### PR TITLE
Output locals mapping in trace logging

### DIFF
--- a/vm/src/frame.rs
+++ b/vm/src/frame.rs
@@ -117,12 +117,12 @@ impl fmt::Debug for Frame {
         let local_str = match self.locals.borrow().kind {
             PyObjectKind::Scope { ref scope } => match scope.locals.borrow().kind {
                 PyObjectKind::Dict { ref elements } => format!(" {:?}", elements),
-                ref unexpected => format!(
+                ref unexpected => panic!(
                     "locals unexpectedly not wrapping a dict! instead: {:?}",
                     unexpected
                 ),
             },
-            ref unexpected => format!("locals unexpectedly not a scope! instead: {:?}", unexpected),
+            ref unexpected => panic!("locals unexpectedly not a scope! instead: {:?}", unexpected),
         };
         write!(
             f,

--- a/vm/src/frame.rs
+++ b/vm/src/frame.rs
@@ -116,7 +116,11 @@ impl fmt::Debug for Frame {
             .join("");
         let local_str = match self.locals.borrow().kind {
             PyObjectKind::Scope { ref scope } => match scope.locals.borrow().kind {
-                PyObjectKind::Dict { ref elements } => format!(" {:?}", elements),
+                PyObjectKind::Dict { ref elements } => elements
+                    .iter()
+                    .map(|elem| format!("\n  {} = {}", elem.0, elem.1.borrow_mut().str()))
+                    .collect::<Vec<_>>()
+                    .join(""),
                 ref unexpected => panic!(
                     "locals unexpectedly not wrapping a dict! instead: {:?}",
                     unexpected

--- a/vm/src/frame.rs
+++ b/vm/src/frame.rs
@@ -114,11 +114,16 @@ impl fmt::Debug for Frame {
             .map(|elem| format!("\n  > {:?}", elem))
             .collect::<Vec<_>>()
             .join("");
-        let local_str = "".to_string(); /* self.locals
-            .iter()
-            .map(|elem| format!("\n  {} = {}", elem.0, elem.1.borrow_mut().str()))
-            .collect::<Vec<_>>()
-            .join(""); */
+        let local_str = match self.locals.borrow().kind {
+            PyObjectKind::Scope { ref scope } => match scope.locals.borrow().kind {
+                PyObjectKind::Dict { ref elements } => format!(" {:?}", elements),
+                ref unexpected => format!(
+                    "locals unexpectedly not wrapping a dict! instead: {:?}",
+                    unexpected
+                ),
+            },
+            ref unexpected => format!("locals unexpectedly not a scope! instead: {:?}", unexpected),
+        };
         write!(
             f,
             "Frame Object {{ \n Stack:{}\n Blocks:{}\n Locals:{}\n}}",


### PR DESCRIPTION
The Locals line in the Frame Object output is now, for example:

Locals: {"num": RefCell { value: [PyObj int 9] }, "f": RefCell { value: [PyObj function] }}

(Note that in cases where the inner values of the PyObjectRefs are unexpected, I simply output to the log and continue; potentially we should panic instead, but I wasn't sure if that was appropriate in a trace log.)