### PR TITLE
Emit a SetupLoop instruction during while loop compilation

### DIFF
--- a/vm/src/compile.rs
+++ b/vm/src/compile.rs
@@ -130,6 +130,11 @@ impl Compiler {
             ast::Statement::While { test, body, orelse } => {
                 let start_label = self.new_label();
                 let end_label = self.new_label();
+                self.emit(Instruction::SetupLoop {
+                    start: start_label,
+                    end: end_label,
+                });
+
                 self.set_label(start_label);
 
                 self.compile_expression(test);


### PR DESCRIPTION
This means that breaks within while loops function correctly (as they have a block that they can reference to work out where to jump to).

This fixes running `tests/snippets/loop.py`:

```
# Before
$ cargo run -- tests/snippets/loop.py && echo worked
    Finished dev [unoptimized + debuginfo] target(s) in 0.07s
     Running `target/debug/rustpython tests/snippets/loop.py`
thread 'main' panicked at 'No block to break / continue', vm/src/vm.rs:146:25
note: Run with `RUST_BACKTRACE=1` for a backtrace.

# After
$ cargo run -- tests/snippets/loop.py && echo worked
    Finished dev [unoptimized + debuginfo] target(s) in 0.07s
     Running `target/debug/rustpython tests/snippets/loop.py`
worked
```