### PR TITLE
Interpreter improvements

### DIFF
--- a/parser/src/parser.rs
+++ b/parser/src/parser.rs
@@ -69,6 +69,18 @@ mod tests {
     use super::parse_statement;
 
     #[test]
+    fn test_parse_empty() {
+        let parse_ast = parse_program(&String::from("\n"));
+
+        assert_eq!(
+            parse_ast,
+            Ok(ast::Program {
+                statements: vec![]
+            })
+        )
+    }
+
+    #[test]
     fn test_parse_print_hello() {
         let source = String::from("print('Hello world')\n");
         let parse_ast = parse_program(&source).unwrap();

--- a/parser/src/parser.rs
+++ b/parser/src/parser.rs
@@ -1,3 +1,5 @@
+extern crate lalrpop_util;
+
 use std::error::Error;
 use std::fs::File;
 use std::io::Read;
@@ -41,6 +43,8 @@ pub fn parse(filename: &Path) -> Result<ast::Program, String> {
 pub fn parse_program(source: &String) -> Result<ast::Program, String> {
     let lxr = lexer::Lexer::new(&source);
     match python::ProgramParser::new().parse(lxr) {
+        Err(lalrpop_util::ParseError::UnrecognizedToken{token: None, expected: _}) =>
+            Err(String::from("Unexpected end of input.")),
         Err(why) => Err(String::from(format!("{:?}", why))),
         Ok(p) => Ok(p),
     }

--- a/vm/src/bytecode.rs
+++ b/vm/src/bytecode.rs
@@ -63,6 +63,7 @@ pub enum Instruction {
     BuildList { size: usize },
     BuildMap { size: usize },
     BuildSlice { size: usize },
+    PrintExpr,
 }
 
 #[derive(Debug, Clone)]

--- a/vm/src/vm.rs
+++ b/vm/src/vm.rs
@@ -736,6 +736,17 @@ impl VirtualMachine {
                 }
                 None
             }
+            bytecode::Instruction::PrintExpr => {
+                let expr = self.pop_value();
+                match expr.borrow().kind {
+                    PyObjectKind::None =>
+                        (),
+                    _ => {
+                        builtins::builtin_print(self, PyFuncArgs { args: vec![expr.clone()] });
+                    }
+                }
+                None
+            }
             _ => panic!("NOT IMPL {:?}", instruction),
         }
     }


### PR DESCRIPTION
The interpreter should interate a list of expressions and/or statements,
and print the results of any expressions that do not return none.

Eval should fail (should eventually be Syntax Error) if it gets a
statement.

Still need to implement continuation lines.

```is_none``` doesn't belong in main, but I'm not sure where to put it (or if there's a better implementation). The ```is``` method on vm is private and wouldn't work anyway because None isn't a singleton yet.