### PR TITLE
Implement stepped slicing for tuples

### DIFF
--- a/tests/snippets/3.1.3.2.py
+++ b/tests/snippets/3.1.3.2.py
@@ -8,3 +8,14 @@ assert squares == squares[:]
 assert [1, 9, 25] == squares[::2]
 assert [4, 16] == squares[1::2]
 assert [4] == squares[1:2:2]
+
+squares_tuple = (1, 4, 9, 16, 25)
+
+assert 1 == squares_tuple[0]
+assert 25 == squares_tuple[-1]
+assert (9, 16, 25) == squares_tuple[-3:]
+assert squares_tuple == squares_tuple[:]
+
+assert (1, 9, 25) == squares_tuple[::2]
+assert (4, 16) == squares_tuple[1::2]
+assert (4,) == squares_tuple[1:2:2]

--- a/vm/src/lib.rs
+++ b/vm/src/lib.rs
@@ -14,6 +14,7 @@ mod import;
 mod objdict;
 mod objint;
 mod objlist;
+mod objsequence;
 mod objstr;
 mod objtuple;
 mod objtype;

--- a/vm/src/objlist.rs
+++ b/vm/src/objlist.rs
@@ -9,7 +9,7 @@ fn get_pos(l: &Vec<PyObjectRef>, p: i32) -> usize {
     }
 }
 
-fn get_slice_items(l: &Vec<PyObjectRef>, slice: &PyObjectRef) -> Vec<PyObjectRef> {
+pub fn get_slice_items(l: &Vec<PyObjectRef>, slice: &PyObjectRef) -> Vec<PyObjectRef> {
     // TODO: we could potentially avoid this copy and use slice
     match &(slice.borrow()).kind {
         PyObjectKind::Slice { start, stop, step } => {

--- a/vm/src/objlist.rs
+++ b/vm/src/objlist.rs
@@ -1,48 +1,10 @@
 use super::pyobject::{PyObject, PyObjectKind, PyObjectRef, PyResult};
 use super::vm::VirtualMachine;
 
-pub fn get_pos(l: &Vec<PyObjectRef>, p: i32) -> usize {
-    if p < 0 {
-        l.len() - ((-p) as usize)
-    } else {
-        p as usize
-    }
-}
-
-pub fn get_slice_items(l: &Vec<PyObjectRef>, slice: &PyObjectRef) -> Vec<PyObjectRef> {
-    // TODO: we could potentially avoid this copy and use slice
-    match &(slice.borrow()).kind {
-        PyObjectKind::Slice { start, stop, step } => {
-            let start = match start {
-                &Some(start) => get_pos(l, start),
-                &None => 0,
-            };
-            let stop = match stop {
-                &Some(stop) => get_pos(l, stop),
-                &None => l.len() as usize,
-            };
-            match step {
-                &None | &Some(1) => l[start..stop].to_vec(),
-                &Some(num) => {
-                    if num < 0 {
-                        unimplemented!("negative step indexing not yet supported")
-                    };
-                    l[start..stop]
-                        .iter()
-                        .step_by(num as usize)
-                        .cloned()
-                        .collect()
-                }
-            }
-        }
-        kind => panic!("get_slice_items called with non-slice: {:?}", kind),
-    }
-}
-
 pub fn get_item(vm: &mut VirtualMachine, l: &Vec<PyObjectRef>, b: PyObjectRef) -> PyResult {
     match &(b.borrow()).kind {
         PyObjectKind::Integer { value } => {
-            let pos_index = get_pos(l, *value);
+            let pos_index = super::objsequence::get_pos(l, *value);
             if pos_index < l.len() {
                 let obj = l[pos_index].clone();
                 Ok(obj)
@@ -56,7 +18,7 @@ pub fn get_item(vm: &mut VirtualMachine, l: &Vec<PyObjectRef>, b: PyObjectRef) -
             step: _,
         } => Ok(PyObject::new(
             PyObjectKind::List {
-                elements: get_slice_items(l, &b),
+                elements: super::objsequence::get_slice_items(l, &b),
             },
             vm.get_type(),
         )),
@@ -76,7 +38,7 @@ pub fn set_item(
 ) -> PyResult {
     match &(idx.borrow()).kind {
         PyObjectKind::Integer { value } => {
-            let pos_index = get_pos(l, *value);
+            let pos_index = super::objsequence::get_pos(l, *value);
             l[pos_index] = obj;
             Ok(vm.get_none())
         }

--- a/vm/src/objlist.rs
+++ b/vm/src/objlist.rs
@@ -1,7 +1,7 @@
 use super::pyobject::{PyObject, PyObjectKind, PyObjectRef, PyResult};
 use super::vm::VirtualMachine;
 
-fn get_pos(l: &Vec<PyObjectRef>, p: i32) -> usize {
+pub fn get_pos(l: &Vec<PyObjectRef>, p: i32) -> usize {
     if p < 0 {
         l.len() - ((-p) as usize)
     } else {

--- a/vm/src/objlist.rs
+++ b/vm/src/objlist.rs
@@ -9,6 +9,36 @@ fn get_pos(l: &Vec<PyObjectRef>, p: i32) -> usize {
     }
 }
 
+fn get_slice_items(l: &Vec<PyObjectRef>, slice: &PyObjectRef) -> Vec<PyObjectRef> {
+    // TODO: we could potentially avoid this copy and use slice
+    match &(slice.borrow()).kind {
+        PyObjectKind::Slice { start, stop, step } => {
+            let start = match start {
+                &Some(start) => get_pos(l, start),
+                &None => 0,
+            };
+            let stop = match stop {
+                &Some(stop) => get_pos(l, stop),
+                &None => l.len() as usize,
+            };
+            match step {
+                &None | &Some(1) => l[start..stop].to_vec(),
+                &Some(num) => {
+                    if num < 0 {
+                        unimplemented!("negative step indexing not yet supported")
+                    };
+                    l[start..stop]
+                        .iter()
+                        .step_by(num as usize)
+                        .cloned()
+                        .collect()
+                }
+            }
+        }
+        kind => panic!("get_slice_items called with non-slice: {:?}", kind),
+    }
+}
+
 pub fn get_item(vm: &mut VirtualMachine, l: &Vec<PyObjectRef>, b: PyObjectRef) -> PyResult {
     match &(b.borrow()).kind {
         PyObjectKind::Integer { value } => {
@@ -20,35 +50,16 @@ pub fn get_item(vm: &mut VirtualMachine, l: &Vec<PyObjectRef>, b: PyObjectRef) -
                 Err(vm.new_exception("Index out of bounds!".to_string()))
             }
         }
-        PyObjectKind::Slice { start, stop, step } => {
-            let start = match start {
-                &Some(start) => get_pos(l, start),
-                &None => 0,
-            };
-            let stop = match stop {
-                &Some(stop) => get_pos(l, stop),
-                &None => l.len() as usize,
-            };
-            // TODO: we could potentially avoid this copy and use slice
-            Ok(PyObject::new(
-                PyObjectKind::List {
-                    elements: match step {
-                        &None | &Some(1) => l[start..stop].to_vec(),
-                        &Some(num) => {
-                            if num < 0 {
-                                unimplemented!("negative step indexing not yet supported")
-                            };
-                            l[start..stop]
-                                .iter()
-                                .step_by(num as usize)
-                                .cloned()
-                                .collect()
-                        }
-                    },
-                },
-                vm.get_type(),
-            ))
-        }
+        PyObjectKind::Slice {
+            start: _,
+            stop: _,
+            step: _,
+        } => Ok(PyObject::new(
+            PyObjectKind::List {
+                elements: get_slice_items(l, &b),
+            },
+            vm.get_type(),
+        )),
         _ => Err(vm.new_exception(format!(
             "TypeError: indexing type {:?} with index {:?} is not supported (yet?)",
             l, b

--- a/vm/src/objsequence.rs
+++ b/vm/src/objsequence.rs
@@ -1,0 +1,39 @@
+use super::pyobject::{PyObject, PyObjectKind, PyObjectRef, PyResult};
+
+pub fn get_pos(l: &Vec<PyObjectRef>, p: i32) -> usize {
+    if p < 0 {
+        l.len() - ((-p) as usize)
+    } else {
+        p as usize
+    }
+}
+
+pub fn get_slice_items(l: &Vec<PyObjectRef>, slice: &PyObjectRef) -> Vec<PyObjectRef> {
+    // TODO: we could potentially avoid this copy and use slice
+    match &(slice.borrow()).kind {
+        PyObjectKind::Slice { start, stop, step } => {
+            let start = match start {
+                &Some(start) => get_pos(l, start),
+                &None => 0,
+            };
+            let stop = match stop {
+                &Some(stop) => get_pos(l, stop),
+                &None => l.len() as usize,
+            };
+            match step {
+                &None | &Some(1) => l[start..stop].to_vec(),
+                &Some(num) => {
+                    if num < 0 {
+                        unimplemented!("negative step indexing not yet supported")
+                    };
+                    l[start..stop]
+                        .iter()
+                        .step_by(num as usize)
+                        .cloned()
+                        .collect()
+                }
+            }
+        }
+        kind => panic!("get_slice_items called with non-slice: {:?}", kind),
+    }
+}

--- a/vm/src/objtuple.rs
+++ b/vm/src/objtuple.rs
@@ -4,7 +4,7 @@ use super::vm::VirtualMachine;
 pub fn get_item(vm: &mut VirtualMachine, l: &Vec<PyObjectRef>, b: PyObjectRef) -> PyResult {
     match &(b.borrow()).kind {
         PyObjectKind::Integer { value } => {
-            let pos_index = super::objlist::get_pos(l, *value);
+            let pos_index = super::objsequence::get_pos(l, *value);
             if pos_index < l.len() {
                 let obj = l[pos_index].clone();
                 Ok(obj)
@@ -18,7 +18,7 @@ pub fn get_item(vm: &mut VirtualMachine, l: &Vec<PyObjectRef>, b: PyObjectRef) -
             step: _,
         } => Ok(PyObject::new(
             PyObjectKind::Tuple {
-                elements: super::objlist::get_slice_items(l, &b),
+                elements: super::objsequence::get_slice_items(l, &b),
             },
             vm.get_type(),
         )),

--- a/vm/src/objtuple.rs
+++ b/vm/src/objtuple.rs
@@ -20,29 +20,16 @@ pub fn get_item(vm: &mut VirtualMachine, l: &Vec<PyObjectRef>, b: PyObjectRef) -
                 Err(vm.new_exception("Index out of bounds!".to_string()))
             }
         }
-        PyObjectKind::Slice { start, stop, step } => {
-            let start = match start {
-                &Some(start) => get_pos(l, start),
-                &None => 0,
-            };
-            let stop = match stop {
-                &Some(stop) => get_pos(l, stop),
-                &None => l.len() as usize,
-            };
-            let step = match step {
-                //Some(step) => step as usize,
-                &None => 1 as usize,
-                _ => unimplemented!("stepped slicing not supported for type {:?}", l),
-            };
-            // TODO: we could potentially avoid this copy and use slice
-            let obj = PyObject::new(
-                PyObjectKind::Tuple {
-                    elements: l[start..stop].to_vec(),
-                },
-                vm.get_type(),
-            );
-            Ok(obj)
-        }
+        PyObjectKind::Slice {
+            start: _,
+            stop: _,
+            step: _,
+        } => Ok(PyObject::new(
+            PyObjectKind::Tuple {
+                elements: super::objlist::get_slice_items(l, &b),
+            },
+            vm.get_type(),
+        )),
         _ => Err(vm.new_exception(format!(
             "TypeError: indexing type {:?} with index {:?} is not supported (yet?)",
             l, b

--- a/vm/src/objtuple.rs
+++ b/vm/src/objtuple.rs
@@ -1,18 +1,10 @@
 use super::pyobject::{PyObject, PyObjectKind, PyObjectRef, PyResult};
 use super::vm::VirtualMachine;
 
-fn get_pos(l: &Vec<PyObjectRef>, p: i32) -> usize {
-    if p < 0 {
-        l.len() - ((-p) as usize)
-    } else {
-        p as usize
-    }
-}
-
 pub fn get_item(vm: &mut VirtualMachine, l: &Vec<PyObjectRef>, b: PyObjectRef) -> PyResult {
     match &(b.borrow()).kind {
         PyObjectKind::Integer { value } => {
-            let pos_index = get_pos(l, *value);
+            let pos_index = super::objlist::get_pos(l, *value);
             if pos_index < l.len() {
                 let obj = l[pos_index].clone();
                 Ok(obj)


### PR DESCRIPTION
This moves the list slicing logic in to a separate function, and calls that function from the tuple code. The one thing I'm unsure about is whether `objlist.rs` is the appropriate place for this (though I'm not sure where would be better; suggestions welcome!).