### PR TITLE
Don't double-count newlines in comments

### DIFF
--- a/parser/src/lexer.rs
+++ b/parser/src/lexer.rs
@@ -140,11 +140,9 @@ impl<'input> Lexer<'input> {
             self.next_char();
             match self.chr0 {
                 Some('\n') => {
-                    self.new_line();
                     return;
                 }
                 Some('\r') => {
-                    self.new_line();
                     return;
                 }
                 Some(_) => {}


### PR DESCRIPTION
lex_comment doesn't consume the newlines, (correctly) leaving them to
the regular newline parsing.  As such, it shouldn't call self.new_line,
or we end up double-counting lines.