### PR TITLE
Un-mut some Frame/VirtualMachine methods

### DIFF
--- a/vm/src/frame.rs
+++ b/vm/src/frame.rs
@@ -75,7 +75,7 @@ impl Frame {
         self.blocks.pop()
     }
 
-    pub fn last_block(&mut self) -> &Block {
+    pub fn last_block(&self) -> &Block {
         self.blocks.last().unwrap()
     }
 
@@ -96,7 +96,7 @@ impl Frame {
         objs
     }
 
-    pub fn last_value(&mut self) -> PyObjectRef {
+    pub fn last_value(&self) -> PyObjectRef {
         self.stack.last().unwrap().clone()
     }
 }

--- a/vm/src/vm.rs
+++ b/vm/src/vm.rs
@@ -151,8 +151,8 @@ impl VirtualMachine {
         self.current_frame_mut().pop_block()
     }
 
-    fn last_block(&mut self) -> &Block {
-        self.current_frame_mut().last_block()
+    fn last_block(&self) -> &Block {
+        self.current_frame().last_block()
     }
 
     fn unwind_loop(&mut self) -> Block {
@@ -195,8 +195,8 @@ impl VirtualMachine {
         self.current_frame_mut().pop_multiple(count)
     }
 
-    fn last_value(&mut self) -> PyObjectRef {
-        self.current_frame_mut().last_value()
+    fn last_value(&self) -> PyObjectRef {
+        self.current_frame().last_value()
     }
 
     fn store_name(&mut self, name: &String) -> Option<PyResult> {


### PR DESCRIPTION
They don't actually require mutable references.