### PR TITLE
Add a macro for builtins argument checking

### DIFF
--- a/vm/src/vm.rs
+++ b/vm/src/vm.rs
@@ -31,7 +31,7 @@ pub struct VirtualMachine {
     frames: Vec<Frame>,
     builtins: PyObjectRef,
     pub sys_module: PyObjectRef,
-    ctx: PyContext,
+    pub ctx: PyContext,
 }
 
 impl VirtualMachine {

--- a/vm/src/vm.rs
+++ b/vm/src/vm.rs
@@ -295,7 +295,11 @@ impl VirtualMachine {
     fn _sub(&mut self, a: PyObjectRef, b: PyObjectRef) -> PyResult {
         let b2 = &*b.borrow();
         let a2 = &*a.borrow();
-        Ok(PyObject::new(a2 - b2, self.get_type()))
+        // TODO: Fix this correctly, and for all arithmetic operations
+        Ok(PyObject::new(
+            a2 - b2,
+            a2.typ.clone().unwrap_or(self.get_type()),
+        ))
     }
 
     fn _add(&mut self, a: PyObjectRef, b: PyObjectRef) -> PyResult {


### PR DESCRIPTION
This adds a macro which can be called by rust functions to check that the arguments they have been given are of the correct type. (It also decomposes the args.args elements in to the identifiers that are passed in, removing another bit of boilerplate.)

We're using `char`s to indicate the expected type here because enum variants can't easily be referred to and/or compared.

This was inspired by CPython's Argument Clinic. I attempted to go all the way and unwrap the internal types of kinds (i.e. i32, Vec<...> etc.) but the type-checker defeated me. Rust macros also can't write/rewrite function signatures, which is another way in which this differs from Argument Clinic.