### PR TITLE
Implement getters for PyContext types

### DIFF
--- a/vm/src/builtins.rs
+++ b/vm/src/builtins.rs
@@ -72,7 +72,7 @@ fn builtin_any(vm: &mut VirtualMachine, args: PyFuncArgs) -> PyResult {
 // builtin_callable
 
 fn builtin_chr(vm: &mut VirtualMachine, args: PyFuncArgs) -> PyResult {
-    arg_check!(vm, args, required = [(i, Some(vm.ctx.int_type.clone()))]);
+    arg_check!(vm, args, required = [(i, Some(vm.ctx.int_type()))]);
 
     let code_point_obj = i.borrow();
 
@@ -127,8 +127,8 @@ fn builtin_eval(vm: &mut VirtualMachine, args: PyFuncArgs) -> PyResult {
         args,
         required = [
             (source, None), // TODO: Use more specific type
-            (_globals, Some(vm.ctx.dict_type.clone())),
-            (locals, Some(vm.ctx.dict_type.clone()))
+            (_globals, Some(vm.ctx.dict_type())),
+            (locals, Some(vm.ctx.dict_type()))
         ]
     );
     // TODO: handle optional global and locals
@@ -159,7 +159,7 @@ fn builtin_getattr(vm: &mut VirtualMachine, args: PyFuncArgs) -> PyResult {
     arg_check!(
         vm,
         args,
-        required = [(obj, None), (attr, Some(vm.ctx.str_type.clone()))]
+        required = [(obj, None), (attr, Some(vm.ctx.str_type()))]
     );
     if let PyObjectKind::String { ref value } = attr.borrow().kind {
         vm.get_attribute(obj.clone(), value)
@@ -174,7 +174,7 @@ fn builtin_hasattr(vm: &mut VirtualMachine, args: PyFuncArgs) -> PyResult {
     arg_check!(
         vm,
         args,
-        required = [(obj, None), (attr, Some(vm.ctx.str_type.clone()))]
+        required = [(obj, None), (attr, Some(vm.ctx.str_type()))]
     );
     if let PyObjectKind::String { ref value } = attr.borrow().kind {
         let has_attr = match vm.get_attribute(obj.clone(), value) {
@@ -272,11 +272,7 @@ pub fn builtin_print(vm: &mut VirtualMachine, args: PyFuncArgs) -> PyResult {
 // builtin_property
 
 fn builtin_range(vm: &mut VirtualMachine, args: PyFuncArgs) -> PyResult {
-    arg_check!(
-        vm,
-        args,
-        required = [(range, Some(vm.ctx.int_type.clone()))]
-    );
+    arg_check!(vm, args, required = [(range, Some(vm.ctx.int_type()))]);
     match range.borrow().kind {
         PyObjectKind::Integer { ref value } => {
             let range_elements: Vec<PyObjectRef> =
@@ -296,11 +292,7 @@ fn builtin_setattr(vm: &mut VirtualMachine, args: PyFuncArgs) -> PyResult {
     arg_check!(
         vm,
         args,
-        required = [
-            (obj, None),
-            (attr, Some(vm.ctx.str_type.clone())),
-            (value, None)
-        ]
+        required = [(obj, None), (attr, Some(vm.ctx.str_type())), (value, None)]
     );
     if let PyObjectKind::String { value: ref name } = attr.borrow().kind {
         obj.clone().set_attr(name, value.clone());
@@ -325,17 +317,17 @@ pub fn make_module(ctx: &PyContext) -> PyObjectRef {
     let mut dict = HashMap::new();
     dict.insert(String::from("all"), ctx.new_rustfunc(builtin_all));
     dict.insert(String::from("any"), ctx.new_rustfunc(builtin_any));
-    dict.insert(String::from("bool"), ctx.bool_type.clone());
+    dict.insert(String::from("bool"), ctx.bool_type());
     dict.insert(String::from("chr"), ctx.new_rustfunc(builtin_chr));
     dict.insert(String::from("compile"), ctx.new_rustfunc(builtin_compile));
-    dict.insert(String::from("dict"), ctx.dict_type.clone());
+    dict.insert(String::from("dict"), ctx.dict_type());
     dict.insert(String::from("dir"), ctx.new_rustfunc(builtin_dir));
     dict.insert(String::from("eval"), ctx.new_rustfunc(builtin_eval));
-    dict.insert(String::from("float"), ctx.float_type.clone());
+    dict.insert(String::from("float"), ctx.float_type());
     dict.insert(String::from("getattr"), ctx.new_rustfunc(builtin_getattr));
     dict.insert(String::from("hasattr"), ctx.new_rustfunc(builtin_hasattr));
     dict.insert(String::from("id"), ctx.new_rustfunc(builtin_id));
-    dict.insert(String::from("int"), ctx.int_type.clone());
+    dict.insert(String::from("int"), ctx.int_type());
     dict.insert(
         String::from("isinstance"),
         ctx.new_rustfunc(builtin_isinstance),
@@ -345,15 +337,15 @@ pub fn make_module(ctx: &PyContext) -> PyObjectRef {
         ctx.new_rustfunc(builtin_issubclass),
     );
     dict.insert(String::from("len"), ctx.new_rustfunc(builtin_len));
-    dict.insert(String::from("list"), ctx.list_type.clone());
+    dict.insert(String::from("list"), ctx.list_type());
     dict.insert(String::from("locals"), ctx.new_rustfunc(builtin_locals));
     dict.insert(String::from("print"), ctx.new_rustfunc(builtin_print));
     dict.insert(String::from("range"), ctx.new_rustfunc(builtin_range));
     dict.insert(String::from("setattr"), ctx.new_rustfunc(builtin_setattr));
-    dict.insert(String::from("str"), ctx.str_type.clone()); // new_rustfunc(builtin_str));
-    dict.insert(String::from("tuple"), ctx.tuple_type.clone());
-    dict.insert(String::from("type"), ctx.type_type.clone());
-    dict.insert(String::from("object"), ctx.object.clone());
+    dict.insert(String::from("str"), ctx.str_type()); // new_rustfunc(builtin_str));
+    dict.insert(String::from("tuple"), ctx.tuple_type());
+    dict.insert(String::from("type"), ctx.type_type());
+    dict.insert(String::from("object"), ctx.object());
 
     // Exceptions:
     dict.insert(
@@ -387,7 +379,7 @@ pub fn make_module(ctx: &PyContext) -> PyObjectRef {
         ctx.exceptions.value_error.clone(),
     );
 
-    let d2 = PyObject::new(PyObjectKind::Dict { elements: dict }, ctx.type_type.clone());
+    let d2 = PyObject::new(PyObjectKind::Dict { elements: dict }, ctx.type_type());
     let scope = PyObject::new(
         PyObjectKind::Scope {
             scope: Scope {
@@ -395,14 +387,14 @@ pub fn make_module(ctx: &PyContext) -> PyObjectRef {
                 parent: None,
             },
         },
-        ctx.type_type.clone(),
+        ctx.type_type(),
     );
     let obj = PyObject::new(
         PyObjectKind::Module {
             name: "__builtins__".to_string(),
             dict: scope,
         },
-        ctx.type_type.clone(),
+        ctx.type_type(),
     );
     obj
 }
@@ -416,7 +408,7 @@ pub fn builtin_build_class_(vm: &mut VirtualMachine, mut args: PyFuncArgs) -> Py
         _ => panic!("Class name must by a string!"),
     };
     let mut bases = args.args.clone();
-    bases.push(vm.context().object.clone());
+    bases.push(vm.context().object());
     let metaclass = vm.get_type();
     let namespace = vm.new_dict();
     &vm.invoke(

--- a/vm/src/objbool.rs
+++ b/vm/src/objbool.rs
@@ -40,7 +40,7 @@ fn bool_new(vm: &mut VirtualMachine, args: PyFuncArgs) -> PyResult {
     arg_check!(
         vm,
         args,
-        required = [(_zelf, Some(vm.ctx.type_type.clone()))],
+        required = [(_zelf, Some(vm.ctx.type_type()))],
         optional = [(val, None)]
     );
     Ok(match val {

--- a/vm/src/objfloat.rs
+++ b/vm/src/objfloat.rs
@@ -5,11 +5,7 @@ use super::pyobject::{
 use super::vm::VirtualMachine;
 
 fn str(vm: &mut VirtualMachine, args: PyFuncArgs) -> Result<PyObjectRef, PyObjectRef> {
-    arg_check!(
-        vm,
-        args,
-        required = [(float, Some(vm.ctx.float_type.clone()))]
-    );
+    arg_check!(vm, args, required = [(float, Some(vm.ctx.float_type()))]);
     let v = get_value(float.clone());
     Ok(vm.new_str(v.to_string()))
 }

--- a/vm/src/objint.rs
+++ b/vm/src/objint.rs
@@ -5,7 +5,7 @@ use super::pyobject::{
 use super::vm::VirtualMachine;
 
 fn str(vm: &mut VirtualMachine, args: PyFuncArgs) -> Result<PyObjectRef, PyObjectRef> {
-    arg_check!(vm, args, required = [(int, Some(vm.ctx.int_type.clone()))]);
+    arg_check!(vm, args, required = [(int, Some(vm.ctx.int_type()))]);
     let v = get_value(int.clone());
     Ok(vm.new_str(v.to_string()))
 }

--- a/vm/src/objlist.rs
+++ b/vm/src/objlist.rs
@@ -30,7 +30,7 @@ pub fn append(vm: &mut VirtualMachine, args: PyFuncArgs) -> PyResult {
     arg_check!(
         vm,
         args,
-        required = [(list, Some(vm.ctx.list_type.clone())), (x, None)]
+        required = [(list, Some(vm.ctx.list_type())), (x, None)]
     );
     let mut list_obj = list.borrow_mut();
     if let PyObjectKind::List { ref mut elements } = list_obj.kind {
@@ -43,11 +43,7 @@ pub fn append(vm: &mut VirtualMachine, args: PyFuncArgs) -> PyResult {
 
 fn clear(vm: &mut VirtualMachine, args: PyFuncArgs) -> PyResult {
     trace!("list.clear called with: {:?}", args);
-    arg_check!(
-        vm,
-        args,
-        required = [(list, Some(vm.ctx.list_type.clone()))]
-    );
+    arg_check!(vm, args, required = [(list, Some(vm.ctx.list_type()))]);
     let mut list_obj = list.borrow_mut();
     if let PyObjectKind::List { ref mut elements } = list_obj.kind {
         elements.clear();
@@ -59,11 +55,7 @@ fn clear(vm: &mut VirtualMachine, args: PyFuncArgs) -> PyResult {
 
 fn len(vm: &mut VirtualMachine, args: PyFuncArgs) -> PyResult {
     trace!("list.len called with: {:?}", args);
-    arg_check!(
-        vm,
-        args,
-        required = [(list, Some(vm.ctx.list_type.clone()))]
-    );
+    arg_check!(vm, args, required = [(list, Some(vm.ctx.list_type()))]);
     let list_obj = list.borrow();
     if let PyObjectKind::List { ref elements } = list_obj.kind {
         Ok(vm.context().new_int(elements.len() as i32))
@@ -74,11 +66,7 @@ fn len(vm: &mut VirtualMachine, args: PyFuncArgs) -> PyResult {
 
 fn reverse(vm: &mut VirtualMachine, args: PyFuncArgs) -> PyResult {
     trace!("list.reverse called with: {:?}", args);
-    arg_check!(
-        vm,
-        args,
-        required = [(list, Some(vm.ctx.list_type.clone()))]
-    );
+    arg_check!(vm, args, required = [(list, Some(vm.ctx.list_type()))]);
     let mut list_obj = list.borrow_mut();
     if let PyObjectKind::List { ref mut elements } = list_obj.kind {
         elements.reverse();

--- a/vm/src/objtype.rs
+++ b/vm/src/objtype.rs
@@ -62,7 +62,7 @@ pub fn type_new(vm: &mut VirtualMachine, args: PyFuncArgs) -> PyResult {
         let typ = args.args[0].clone();
         let name = args.args[1].to_str().unwrap();
         let mut bases = args.args[2].to_vec().unwrap();
-        bases.push(vm.context().object.clone());
+        bases.push(vm.context().object());
         let dict = args.args[3].clone();
         new(typ, &name, bases, dict)
     } else {

--- a/vm/src/pyobject.rs
+++ b/vm/src/pyobject.rs
@@ -155,34 +155,74 @@ impl PyContext {
         context
     }
 
+    pub fn int_type(&self) -> PyObjectRef {
+        self.int_type.clone()
+    }
+
+    pub fn float_type(&self) -> PyObjectRef {
+        self.float_type.clone()
+    }
+
+    pub fn list_type(&self) -> PyObjectRef {
+        self.list_type.clone()
+    }
+    pub fn bool_type(&self) -> PyObjectRef {
+        self.bool_type.clone()
+    }
+    pub fn tuple_type(&self) -> PyObjectRef {
+        self.tuple_type.clone()
+    }
+    pub fn dict_type(&self) -> PyObjectRef {
+        self.dict_type.clone()
+    }
+    pub fn str_type(&self) -> PyObjectRef {
+        self.str_type.clone()
+    }
+    pub fn function_type(&self) -> PyObjectRef {
+        self.function_type.clone()
+    }
+    pub fn bound_method_type(&self) -> PyObjectRef {
+        self.bound_method_type.clone()
+    }
+    pub fn member_descriptor_type(&self) -> PyObjectRef {
+        self.member_descriptor_type.clone()
+    }
+    pub fn type_type(&self) -> PyObjectRef {
+        self.type_type.clone()
+    }
+
+    pub fn none(&self) -> PyObjectRef {
+        self.none.clone()
+    }
+    pub fn object(&self) -> PyObjectRef {
+        self.object.clone()
+    }
+
     pub fn new_int(&self, i: i32) -> PyObjectRef {
-        PyObject::new(PyObjectKind::Integer { value: i }, self.int_type.clone())
+        PyObject::new(PyObjectKind::Integer { value: i }, self.int_type())
     }
 
     pub fn new_float(&self, i: f64) -> PyObjectRef {
-        PyObject::new(PyObjectKind::Float { value: i }, self.float_type.clone())
+        PyObject::new(PyObjectKind::Float { value: i }, self.float_type())
     }
 
     pub fn new_str(&self, s: String) -> PyObjectRef {
-        PyObject::new(PyObjectKind::String { value: s }, self.str_type.clone())
+        PyObject::new(PyObjectKind::String { value: s }, self.str_type())
     }
 
     pub fn new_bool(&self, b: bool) -> PyObjectRef {
-        PyObject::new(PyObjectKind::Boolean { value: b }, self.bool_type.clone())
+        PyObject::new(PyObjectKind::Boolean { value: b }, self.bool_type())
     }
 
     pub fn new_tuple(&self, elements: Vec<PyObjectRef>) -> PyObjectRef {
         PyObject::new(
             PyObjectKind::Tuple { elements: elements },
-            self.tuple_type.clone(),
+            self.tuple_type(),
         )
     }
 
     pub fn new_list(&self, elements: Vec<PyObjectRef>) -> PyObjectRef {
-        PyObject::new(
-            PyObjectKind::List { elements: elements },
-            self.list_type.clone(),
-        )
+        PyObject::new(PyObjectKind::List { elements: elements }, self.list_type())
     }
 
     pub fn new_dict(&self) -> PyObjectRef {
@@ -190,12 +230,12 @@ impl PyContext {
             PyObjectKind::Dict {
                 elements: HashMap::new(),
             },
-            self.dict_type.clone(),
+            self.dict_type(),
         )
     }
 
     pub fn new_class(&self, name: &String, base: PyObjectRef) -> PyObjectRef {
-        objtype::new(self.type_type.clone(), name, vec![base], self.new_dict()).unwrap()
+        objtype::new(self.type_type(), name, vec![base], self.new_dict()).unwrap()
     }
 
     pub fn new_scope(&self, parent: Option<PyObjectRef>) -> PyObjectRef {
@@ -216,14 +256,14 @@ impl PyContext {
                 name: name.clone(),
                 dict: scope.clone(),
             },
-            self.type_type.clone(),
+            self.type_type(),
         )
     }
 
     pub fn new_rustfunc(&self, function: RustPyFunc) -> PyObjectRef {
         PyObject::new(
             PyObjectKind::RustFunction { function: function },
-            self.function_type.clone(),
+            self.function_type(),
         )
     }
 
@@ -233,7 +273,7 @@ impl PyContext {
                 code: code_obj,
                 scope: scope,
             },
-            self.function_type.clone(),
+            self.function_type(),
         )
     }
 
@@ -243,14 +283,14 @@ impl PyContext {
                 function: function,
                 object: object,
             },
-            self.bound_method_type.clone(),
+            self.bound_method_type(),
         )
     }
 
     pub fn new_member_descriptor(&self, function: RustPyFunc) -> PyObjectRef {
         let dict = self.new_dict();
         dict.set_item(&String::from("function"), self.new_rustfunc(function));
-        self.new_instance(dict, self.member_descriptor_type.clone())
+        self.new_instance(dict, self.member_descriptor_type())
     }
 
     pub fn new_instance(&self, dict: PyObjectRef, class: PyObjectRef) -> PyObjectRef {

--- a/vm/src/stdlib/json.rs
+++ b/vm/src/stdlib/json.rs
@@ -178,11 +178,7 @@ fn dumps(vm: &mut VirtualMachine, args: PyFuncArgs) -> PyResult {
 
 fn loads(vm: &mut VirtualMachine, args: PyFuncArgs) -> PyResult {
     // TODO: Implement non-trivial deserialisation case
-    arg_check!(
-        vm,
-        args,
-        required = [(string, Some(vm.ctx.str_type.clone()))]
-    );
+    arg_check!(vm, args, required = [(string, Some(vm.ctx.str_type()))]);
     // TODO: Raise an exception for deserialisation errors
     let kind: PyObjectKind = match string.borrow().kind {
         PyObjectKind::String { ref value } => serde_json::from_str(&value).unwrap(),

--- a/vm/src/vm.rs
+++ b/vm/src/vm.rs
@@ -77,7 +77,7 @@ impl VirtualMachine {
     }
 
     pub fn get_none(&self) -> PyObjectRef {
-        self.ctx.none.clone()
+        self.ctx.none()
     }
 
     pub fn new_bound_method(&self, function: PyObjectRef, object: PyObjectRef) -> PyObjectRef {
@@ -85,11 +85,11 @@ impl VirtualMachine {
     }
 
     pub fn get_type(&self) -> PyObjectRef {
-        self.ctx.type_type.clone()
+        self.ctx.type_type()
     }
 
     pub fn get_object(&self) -> PyObjectRef {
-        self.ctx.object.clone()
+        self.ctx.object()
     }
 
     pub fn get_locals(&self) -> PyObjectRef {
@@ -598,7 +598,7 @@ impl VirtualMachine {
                     &bytecode::Constant::Code { ref code } => {
                         PyObject::new(PyObjectKind::Code { code: code.clone() }, self.get_type())
                     }
-                    &bytecode::Constant::None => self.ctx.none.clone(),
+                    &bytecode::Constant::None => self.ctx.none(),
                 };
                 self.push_value(obj);
                 None
@@ -699,7 +699,7 @@ impl VirtualMachine {
 
                 let obj = PyObject::new(
                     PyObjectKind::Slice { start, stop, step },
-                    self.ctx.type_type.clone(),
+                    self.ctx.type_type(),
                 );
                 self.push_value(obj);
                 None
@@ -735,7 +735,7 @@ impl VirtualMachine {
                         position: 0,
                         iterated_obj: iterated_obj,
                     },
-                    self.ctx.type_type.clone(),
+                    self.ctx.type_type(),
                 );
                 self.push_value(iter_obj);
                 None
@@ -894,7 +894,7 @@ impl VirtualMachine {
                     PyObjectKind::RustFunction {
                         function: builtins::builtin_build_class_,
                     },
-                    self.ctx.type_type.clone(),
+                    self.ctx.type_type(),
                 );
                 self.push_value(rustfunc);
                 None


### PR DESCRIPTION
Currently, all users of the *_type attributes on PyContext have to
immediately clone the pointer before they can use it; this pushes that
cloning in to getters to reduce the clone-clutter across the codebase.