### PR TITLE
Alternative operator implementation based on typ instead of kind

### DIFF
--- a/tests/snippets/basic_types.py
+++ b/tests/snippets/basic_types.py
@@ -4,13 +4,20 @@ print(None)
 # print(True) # LOAD_NAME???
 print(1)
 # print(1L) # Long
-# print(1.1)
+print(1.1)
 # ComplexType
 print("abc")
 # print(u"abc")
 # Structural below
-# print((1, 2)) # Tuple can be any length, but fixed after declared
-# x = (1,2)
-# print(x[0]) # Tuple can be any length, but fixed after declared
-# print([1, 2, 3])
+print((1, 2)) # Tuple can be any length, but fixed after declared
+x = (1,2)
+print(x[0]) # Tuple can be any length, but fixed after declared
+print([1, 2, 3])
 # print({"first":1,"second":2})
+
+
+assert type(1 - 2) is int
+assert type(2 / 3) is float
+x = 1
+assert type(x) is int
+assert type(x - 1) is int

--- a/vm/src/objbool.rs
+++ b/vm/src/objbool.rs
@@ -34,6 +34,27 @@ pub fn boolval(vm: &mut VirtualMachine, obj: PyObjectRef) -> Result<bool, PyObje
 pub fn init(context: &PyContext) {
     let ref bool_type = context.bool_type;
     bool_type.set_attr("__new__", context.new_rustfunc(bool_new));
+    bool_type.set_attr("__str__", context.new_rustfunc(bool_str));
+}
+
+// Retrieve inner int value:
+pub fn get_value(obj: &PyObjectRef) -> bool {
+    if let PyObjectKind::Boolean { value } = &obj.borrow().kind {
+        *value
+    } else {
+        panic!("Inner error getting inner boolean");
+    }
+}
+
+fn bool_str(vm: &mut VirtualMachine, args: PyFuncArgs) -> Result<PyObjectRef, PyObjectRef> {
+    arg_check!(vm, args, required = [(obj, Some(vm.ctx.bool_type()))]);
+    let v = get_value(obj);
+    let s = if v {
+        "True".to_string()
+    } else {
+        "True".to_string()
+    };
+    Ok(vm.new_str(s))
 }
 
 fn bool_new(vm: &mut VirtualMachine, args: PyFuncArgs) -> PyResult {

--- a/vm/src/objfloat.rs
+++ b/vm/src/objfloat.rs
@@ -1,6 +1,7 @@
+use super::objint;
 use super::objtype;
 use super::pyobject::{
-    AttributeProtocol, PyContext, PyFuncArgs, PyObjectKind, PyObjectRef, TypeProtocol,
+    AttributeProtocol, PyContext, PyFuncArgs, PyObjectKind, PyObjectRef, PyResult, TypeProtocol,
 };
 use super::vm::VirtualMachine;
 
@@ -19,8 +20,50 @@ pub fn get_value(obj: PyObjectRef) -> f64 {
     }
 }
 
+fn float_add(vm: &mut VirtualMachine, args: PyFuncArgs) -> PyResult {
+    arg_check!(
+        vm,
+        args,
+        required = [(i, Some(vm.ctx.float_type())), (i2, None)]
+    );
+
+    if objtype::isinstance(i2.clone(), vm.ctx.float_type()) {
+        Ok(vm
+            .ctx
+            .new_float(get_value(i.clone()) + get_value(i2.clone())))
+    } else if objtype::isinstance(i2.clone(), vm.ctx.int_type()) {
+        Ok(vm
+            .ctx
+            .new_float(get_value(i.clone()) + objint::get_value(i2.clone()) as f64))
+    } else {
+        Err(vm.new_type_error(format!("Cannot add {:?} and {:?}", i, i2)))
+    }
+}
+
+fn float_sub(vm: &mut VirtualMachine, args: PyFuncArgs) -> PyResult {
+    arg_check!(
+        vm,
+        args,
+        required = [(i, Some(vm.ctx.float_type())), (i2, None)]
+    );
+
+    if objtype::isinstance(i2.clone(), vm.ctx.float_type()) {
+        Ok(vm
+            .ctx
+            .new_float(get_value(i.clone()) - get_value(i2.clone())))
+    } else if objtype::isinstance(i2.clone(), vm.ctx.int_type()) {
+        Ok(vm
+            .ctx
+            .new_float(get_value(i.clone()) - objint::get_value(i2.clone()) as f64))
+    } else {
+        Err(vm.new_type_error(format!("Cannot add {:?} and {:?}", i, i2)))
+    }
+}
+
 pub fn init(context: &PyContext) {
     let ref float_type = context.float_type;
+    float_type.set_attr("__add__", context.new_rustfunc(float_add));
     float_type.set_attr("__str__", context.new_rustfunc(str));
+    float_type.set_attr("__sub__", context.new_rustfunc(float_sub));
     float_type.set_attr("__repr__", context.new_rustfunc(str));
 }

--- a/vm/src/objfloat.rs
+++ b/vm/src/objfloat.rs
@@ -27,14 +27,11 @@ fn float_add(vm: &mut VirtualMachine, args: PyFuncArgs) -> PyResult {
         required = [(i, Some(vm.ctx.float_type())), (i2, None)]
     );
 
+    let v1 = get_value(i.clone());
     if objtype::isinstance(i2.clone(), vm.ctx.float_type()) {
-        Ok(vm
-            .ctx
-            .new_float(get_value(i.clone()) + get_value(i2.clone())))
+        Ok(vm.ctx.new_float(v1 + get_value(i2.clone())))
     } else if objtype::isinstance(i2.clone(), vm.ctx.int_type()) {
-        Ok(vm
-            .ctx
-            .new_float(get_value(i.clone()) + objint::get_value(i2.clone()) as f64))
+        Ok(vm.ctx.new_float(v1 + objint::get_value(i2.clone()) as f64))
     } else {
         Err(vm.new_type_error(format!("Cannot add {:?} and {:?}", i, i2)))
     }
@@ -47,14 +44,30 @@ fn float_sub(vm: &mut VirtualMachine, args: PyFuncArgs) -> PyResult {
         required = [(i, Some(vm.ctx.float_type())), (i2, None)]
     );
 
+    let v1 = get_value(i.clone());
     if objtype::isinstance(i2.clone(), vm.ctx.float_type()) {
-        Ok(vm
-            .ctx
-            .new_float(get_value(i.clone()) - get_value(i2.clone())))
+        Ok(vm.ctx.new_float(v1 - get_value(i2.clone())))
     } else if objtype::isinstance(i2.clone(), vm.ctx.int_type()) {
-        Ok(vm
-            .ctx
-            .new_float(get_value(i.clone()) - objint::get_value(i2.clone()) as f64))
+        Ok(vm.ctx.new_float(v1 - objint::get_value(i2.clone()) as f64))
+    } else {
+        Err(vm.new_type_error(format!("Cannot add {:?} and {:?}", i, i2)))
+    }
+}
+
+fn float_pow(vm: &mut VirtualMachine, args: PyFuncArgs) -> PyResult {
+    arg_check!(
+        vm,
+        args,
+        required = [(i, Some(vm.ctx.float_type())), (i2, None)]
+    );
+
+    let v1 = get_value(i.clone());
+    if objtype::isinstance(i2.clone(), vm.ctx.float_type()) {
+        let result = v1.powf(get_value(i2.clone()));
+        Ok(vm.ctx.new_float(result))
+    } else if objtype::isinstance(i2.clone(), vm.ctx.int_type()) {
+        let result = v1.powf(objint::get_value(i2.clone()) as f64);
+        Ok(vm.ctx.new_float(result))
     } else {
         Err(vm.new_type_error(format!("Cannot add {:?} and {:?}", i, i2)))
     }
@@ -63,6 +76,7 @@ fn float_sub(vm: &mut VirtualMachine, args: PyFuncArgs) -> PyResult {
 pub fn init(context: &PyContext) {
     let ref float_type = context.float_type;
     float_type.set_attr("__add__", context.new_rustfunc(float_add));
+    float_type.set_attr("__pow__", context.new_rustfunc(float_pow));
     float_type.set_attr("__str__", context.new_rustfunc(str));
     float_type.set_attr("__sub__", context.new_rustfunc(float_sub));
     float_type.set_attr("__repr__", context.new_rustfunc(str));

--- a/vm/src/objfloat.rs
+++ b/vm/src/objfloat.rs
@@ -11,7 +11,7 @@ fn str(vm: &mut VirtualMachine, args: PyFuncArgs) -> Result<PyObjectRef, PyObjec
 }
 
 // Retrieve inner float value:
-fn get_value(obj: PyObjectRef) -> f64 {
+pub fn get_value(obj: PyObjectRef) -> f64 {
     if let PyObjectKind::Float { value } = &obj.borrow().kind {
         *value
     } else {

--- a/vm/src/objint.rs
+++ b/vm/src/objint.rs
@@ -1,6 +1,7 @@
+use super::objfloat;
 use super::objtype;
 use super::pyobject::{
-    AttributeProtocol, PyContext, PyFuncArgs, PyObjectKind, PyObjectRef, TypeProtocol,
+    AttributeProtocol, PyContext, PyFuncArgs, PyObjectKind, PyObjectRef, PyResult, TypeProtocol,
 };
 use super::vm::VirtualMachine;
 
@@ -19,8 +20,70 @@ fn get_value(obj: PyObjectRef) -> i32 {
     }
 }
 
+fn int_add(vm: &mut VirtualMachine, args: PyFuncArgs) -> PyResult {
+    arg_check!(
+        vm,
+        args,
+        required = [(i, Some(vm.ctx.int_type())), (i2, None)]
+    );
+    if objtype::isinstance(i2.clone(), vm.ctx.int_type()) {
+        Ok(vm.ctx.new_int(get_value(i.clone()) + get_value(i2.clone())))
+    } else {
+        Err(vm.new_type_error(format!("Cannot add {:?} and {:?}", i, i2)))
+    }
+}
+
+fn int_sub(vm: &mut VirtualMachine, args: PyFuncArgs) -> PyResult {
+    arg_check!(
+        vm,
+        args,
+        required = [(i, Some(vm.ctx.int_type())), (i2, None)]
+    );
+    if objtype::isinstance(i2.clone(), vm.ctx.int_type()) {
+        Ok(vm.ctx.new_int(get_value(i.clone()) - get_value(i2.clone())))
+    } else {
+        Err(vm.new_type_error(format!("Cannot substract {:?} and {:?}", i, i2)))
+    }
+}
+
+fn int_mul(vm: &mut VirtualMachine, args: PyFuncArgs) -> PyResult {
+    arg_check!(
+        vm,
+        args,
+        required = [(i, Some(vm.ctx.int_type())), (i2, None)]
+    );
+    if objtype::isinstance(i2.clone(), vm.ctx.int_type()) {
+        Ok(vm.ctx.new_int(get_value(i.clone()) * get_value(i2.clone())))
+    } else {
+        Err(vm.new_type_error(format!("Cannot multiply {:?} and {:?}", i, i2)))
+    }
+}
+
+fn int_truediv(vm: &mut VirtualMachine, args: PyFuncArgs) -> PyResult {
+    arg_check!(
+        vm,
+        args,
+        required = [(i, Some(vm.ctx.int_type())), (i2, None)]
+    );
+    if objtype::isinstance(i2.clone(), vm.ctx.int_type()) {
+        Ok(vm
+            .ctx
+            .new_float(get_value(i.clone()) as f64 / get_value(i2.clone()) as f64))
+    } else if objtype::isinstance(i2.clone(), vm.ctx.float_type()) {
+        Ok(vm
+            .ctx
+            .new_float(get_value(i.clone()) as f64 / objfloat::get_value(i2.clone())))
+    } else {
+        Err(vm.new_type_error(format!("Cannot multiply {:?} and {:?}", i, i2)))
+    }
+}
+
 pub fn init(context: &PyContext) {
     let ref int_type = context.int_type;
-    int_type.set_attr("__str__", context.new_rustfunc(str));
+    int_type.set_attr("__add__", context.new_rustfunc(int_add));
+    int_type.set_attr("__mul__", context.new_rustfunc(int_mul));
     int_type.set_attr("__repr__", context.new_rustfunc(str));
+    int_type.set_attr("__str__", context.new_rustfunc(str));
+    int_type.set_attr("__sub__", context.new_rustfunc(int_sub));
+    int_type.set_attr("__truediv__", context.new_rustfunc(int_truediv));
 }

--- a/vm/src/objint.rs
+++ b/vm/src/objint.rs
@@ -95,11 +95,30 @@ fn int_mod(vm: &mut VirtualMachine, args: PyFuncArgs) -> PyResult {
     }
 }
 
+fn int_pow(vm: &mut VirtualMachine, args: PyFuncArgs) -> PyResult {
+    arg_check!(
+        vm,
+        args,
+        required = [(i, Some(vm.ctx.int_type())), (i2, None)]
+    );
+    let v1 = get_value(i.clone());
+    if objtype::isinstance(i2.clone(), vm.ctx.int_type()) {
+        let v2 = get_value(i2.clone());
+        Ok(vm.ctx.new_int(v1.pow(v2 as u32)))
+    } else if objtype::isinstance(i2.clone(), vm.ctx.float_type()) {
+        let v2 = objfloat::get_value(i2.clone());
+        Ok(vm.ctx.new_float((v1 as f64).powf(v2)))
+    } else {
+        Err(vm.new_type_error(format!("Cannot modulo {:?} and {:?}", i, i2)))
+    }
+}
+
 pub fn init(context: &PyContext) {
     let ref int_type = context.int_type;
     int_type.set_attr("__add__", context.new_rustfunc(int_add));
     int_type.set_attr("__mod__", context.new_rustfunc(int_mod));
     int_type.set_attr("__mul__", context.new_rustfunc(int_mul));
+    int_type.set_attr("__pow__", context.new_rustfunc(int_pow));
     int_type.set_attr("__repr__", context.new_rustfunc(str));
     int_type.set_attr("__str__", context.new_rustfunc(str));
     int_type.set_attr("__sub__", context.new_rustfunc(int_sub));

--- a/vm/src/objint.rs
+++ b/vm/src/objint.rs
@@ -12,7 +12,7 @@ fn str(vm: &mut VirtualMachine, args: PyFuncArgs) -> Result<PyObjectRef, PyObjec
 }
 
 // Retrieve inner int value:
-fn get_value(obj: PyObjectRef) -> i32 {
+pub fn get_value(obj: PyObjectRef) -> i32 {
     if let PyObjectKind::Integer { value } = &obj.borrow().kind {
         *value
     } else {
@@ -28,6 +28,10 @@ fn int_add(vm: &mut VirtualMachine, args: PyFuncArgs) -> PyResult {
     );
     if objtype::isinstance(i2.clone(), vm.ctx.int_type()) {
         Ok(vm.ctx.new_int(get_value(i.clone()) + get_value(i2.clone())))
+    } else if objtype::isinstance(i2.clone(), vm.ctx.float_type()) {
+        Ok(vm
+            .ctx
+            .new_float(get_value(i.clone()) as f64 + objfloat::get_value(i2.clone())))
     } else {
         Err(vm.new_type_error(format!("Cannot add {:?} and {:?}", i, i2)))
     }
@@ -78,9 +82,23 @@ fn int_truediv(vm: &mut VirtualMachine, args: PyFuncArgs) -> PyResult {
     }
 }
 
+fn int_mod(vm: &mut VirtualMachine, args: PyFuncArgs) -> PyResult {
+    arg_check!(
+        vm,
+        args,
+        required = [(i, Some(vm.ctx.int_type())), (i2, None)]
+    );
+    if objtype::isinstance(i2.clone(), vm.ctx.int_type()) {
+        Ok(vm.ctx.new_int(get_value(i.clone()) % get_value(i2.clone())))
+    } else {
+        Err(vm.new_type_error(format!("Cannot modulo {:?} and {:?}", i, i2)))
+    }
+}
+
 pub fn init(context: &PyContext) {
     let ref int_type = context.int_type;
     int_type.set_attr("__add__", context.new_rustfunc(int_add));
+    int_type.set_attr("__mod__", context.new_rustfunc(int_mod));
     int_type.set_attr("__mul__", context.new_rustfunc(int_mul));
     int_type.set_attr("__repr__", context.new_rustfunc(str));
     int_type.set_attr("__str__", context.new_rustfunc(str));

--- a/vm/src/objlist.rs
+++ b/vm/src/objlist.rs
@@ -25,6 +25,31 @@ pub fn set_item(
     }
 }
 
+fn get_elements(obj: PyObjectRef) -> Vec<PyObjectRef> {
+    if let PyObjectKind::List { elements } = &obj.borrow().kind {
+        elements.to_vec()
+    } else {
+        panic!("Cannot extract list elements from non-list");
+    }
+}
+
+fn list_add(vm: &mut VirtualMachine, args: PyFuncArgs) -> PyResult {
+    arg_check!(
+        vm,
+        args,
+        required = [(o, Some(vm.ctx.list_type())), (o2, None)]
+    );
+
+    if objtype::isinstance(o2.clone(), vm.ctx.list_type()) {
+        let e1 = get_elements(o.clone());
+        let e2 = get_elements(o2.clone());
+        let elements = e1.iter().chain(e2.iter()).map(|e| e.clone()).collect();
+        Ok(vm.ctx.new_list(elements))
+    } else {
+        Err(vm.new_type_error(format!("Cannot add {:?} and {:?}", o, o2)))
+    }
+}
+
 pub fn append(vm: &mut VirtualMachine, args: PyFuncArgs) -> PyResult {
     trace!("list.append called with: {:?}", args);
     arg_check!(
@@ -78,6 +103,7 @@ fn reverse(vm: &mut VirtualMachine, args: PyFuncArgs) -> PyResult {
 
 pub fn init(context: &PyContext) {
     let ref list_type = context.list_type;
+    list_type.set_attr("__add__", context.new_rustfunc(list_add));
     list_type.set_attr("__len__", context.new_rustfunc(len));
     list_type.set_attr("append", context.new_rustfunc(append));
     list_type.set_attr("clear", context.new_rustfunc(clear));

--- a/vm/src/objlist.rs
+++ b/vm/src/objlist.rs
@@ -50,6 +50,28 @@ fn list_add(vm: &mut VirtualMachine, args: PyFuncArgs) -> PyResult {
     }
 }
 
+/*
+ * TODO:
+fn list_str(vm: &mut VirtualMachine, args: PyFuncArgs) -> PyResult {
+    arg_check!(
+        vm,
+        args,
+        required = [(o, Some(vm.ctx.list_type()))]
+    );
+
+    let 
+    PyObjectKind::List { ref elements } => format!(
+        "[{}]",
+        elements
+            .iter()
+            .map(|elem| elem.borrow().str())
+            .collect::<Vec<_>>()
+            .join(", ")
+    ),
+    }
+}
+*/
+
 pub fn append(vm: &mut VirtualMachine, args: PyFuncArgs) -> PyResult {
     trace!("list.append called with: {:?}", args);
     arg_check!(
@@ -105,6 +127,7 @@ pub fn init(context: &PyContext) {
     let ref list_type = context.list_type;
     list_type.set_attr("__add__", context.new_rustfunc(list_add));
     list_type.set_attr("__len__", context.new_rustfunc(len));
+    // list_type.set_attr("__str__", context.new_rustfunc(list_str));
     list_type.set_attr("append", context.new_rustfunc(append));
     list_type.set_attr("clear", context.new_rustfunc(clear));
     list_type.set_attr("reverse", context.new_rustfunc(reverse));

--- a/vm/src/objstr.rs
+++ b/vm/src/objstr.rs
@@ -72,8 +72,8 @@ fn str_new(vm: &mut VirtualMachine, args: PyFuncArgs) -> PyResult {
     if args.args.len() > 2 {
         panic!("str expects exactly one parameter");
     };
-    let s = args.args[1].borrow().str();
-    Ok(vm.new_str(s))
+
+    vm.to_str(args.args[1].clone())
 }
 
 impl PySliceableSequence for String {

--- a/vm/src/objstr.rs
+++ b/vm/src/objstr.rs
@@ -1,3 +1,4 @@
+use super::objint;
 use super::objsequence::PySliceableSequence;
 use super::objtype;
 use super::pyobject::{
@@ -7,12 +8,13 @@ use super::vm::VirtualMachine;
 
 pub fn init(context: &PyContext) {
     let ref str_type = context.str_type;
+    str_type.set_attr("__add__", context.new_rustfunc(str_add));
+    str_type.set_attr("__mul__", context.new_rustfunc(str_mul));
     str_type.set_attr("__new__", context.new_rustfunc(str_new));
     str_type.set_attr("__str__", context.new_rustfunc(str_str));
-    str_type.set_attr("__add__", context.new_rustfunc(str_add));
 }
 
-fn get_value(obj: PyObjectRef) -> String {
+pub fn get_value(obj: PyObjectRef) -> String {
     if let PyObjectKind::String { value } = &obj.borrow().kind {
         value.to_string()
     } else {
@@ -37,6 +39,25 @@ fn str_add(vm: &mut VirtualMachine, args: PyFuncArgs) -> PyResult {
             .new_str(format!("{}{}", get_value(s.clone()), get_value(s2.clone()))))
     } else {
         Err(vm.new_type_error(format!("Cannot add {:?} and {:?}", s, s2)))
+    }
+}
+
+fn str_mul(vm: &mut VirtualMachine, args: PyFuncArgs) -> PyResult {
+    arg_check!(
+        vm,
+        args,
+        required = [(s, Some(vm.ctx.str_type())), (s2, None)]
+    );
+    if objtype::isinstance(s2.clone(), vm.ctx.int_type()) {
+        let value1 = get_value(s.clone());
+        let value2 = objint::get_value(s2.clone());
+        let mut result = String::new();
+        for _x in 0..value2 {
+            result.push_str(value1.as_str());
+        }
+        Ok(vm.ctx.new_str(result))
+    } else {
+        Err(vm.new_type_error(format!("Cannot multiply {:?} and {:?}", s, s2)))
     }
 }
 

--- a/vm/src/pyobject.rs
+++ b/vm/src/pyobject.rs
@@ -555,10 +555,6 @@ pub enum PyObjectKind {
         stop: Option<i32>,
         step: Option<i32>,
     },
-    NameError {
-        // TODO: improve python object and type system
-        name: String,
-    },
     Code {
         code: bytecode::CodeObject,
     },
@@ -610,7 +606,6 @@ impl fmt::Debug for PyObjectKind {
                 stop: _,
                 step: _,
             } => write!(f, "slice"),
-            &PyObjectKind::NameError { name: _ } => write!(f, "NameError"),
             &PyObjectKind::Code { ref code } => write!(f, "code: {:?}", code),
             &PyObjectKind::Function { code: _, scope: _ } => write!(f, "function"),
             &PyObjectKind::BoundMethod {
@@ -687,7 +682,6 @@ impl PyObject {
             PyObjectKind::RustFunction { function: _ } => format!("<rustfunc>"),
             PyObjectKind::Module { ref name, dict: _ } => format!("<module '{}'>", name),
             PyObjectKind::Scope { ref scope } => format!("<scope '{:?}'>", scope),
-            PyObjectKind::NameError { ref name } => format!("NameError: {:?}", name),
             PyObjectKind::Slice {
                 ref start,
                 ref stop,

--- a/vm/src/pyobject.rs
+++ b/vm/src/pyobject.rs
@@ -14,7 +14,6 @@ use std::cell::RefCell;
 use std::cmp::Ordering;
 use std::collections::HashMap;
 use std::fmt;
-use std::ops::{Add, Mul, Rem, Sub};
 use std::rc::Rc;
 
 /* Python objects and references.
@@ -740,126 +739,6 @@ impl PyObject {
     }
 }
 
-impl<'a> Add<&'a PyObject> for &'a PyObject {
-    type Output = PyObjectKind;
-
-    fn add(self, rhs: &'a PyObject) -> Self::Output {
-        match self.kind {
-            PyObjectKind::Integer { value: ref value1 } => match &rhs.kind {
-                PyObjectKind::Integer { value: ref value2 } => PyObjectKind::Integer {
-                    value: value1 + value2,
-                },
-                PyObjectKind::Float { value: ref value2 } => PyObjectKind::Float {
-                    value: (*value1 as f64) + value2,
-                },
-                _ => {
-                    panic!("NOT IMPL");
-                }
-            },
-            PyObjectKind::Float { value: ref value1 } => match &rhs.kind {
-                PyObjectKind::Float { value: ref value2 } => PyObjectKind::Float {
-                    value: value1 + value2,
-                },
-                PyObjectKind::Integer { value: ref value2 } => PyObjectKind::Float {
-                    value: value1 + (*value2 as f64),
-                },
-                _ => {
-                    panic!("NOT IMPL");
-                }
-            },
-            PyObjectKind::String { value: ref value1 } => match rhs.kind {
-                PyObjectKind::String { value: ref value2 } => PyObjectKind::String {
-                    value: format!("{}{}", value1, value2),
-                },
-                _ => {
-                    panic!("NOT IMPL");
-                }
-            },
-            PyObjectKind::List { elements: ref e1 } => match rhs.kind {
-                PyObjectKind::List { elements: ref e2 } => PyObjectKind::List {
-                    elements: e1.iter().chain(e2.iter()).map(|e| e.clone()).collect(),
-                },
-                _ => {
-                    panic!("NOT IMPL");
-                }
-            },
-            _ => {
-                // TODO: Lookup __add__ method in dictionary?
-                panic!("NOT IMPL");
-            }
-        }
-    }
-}
-
-impl<'a> Sub<&'a PyObject> for &'a PyObject {
-    type Output = PyObjectKind;
-
-    fn sub(self, rhs: &'a PyObject) -> Self::Output {
-        match self.kind {
-            PyObjectKind::Integer { value: value1 } => match rhs.kind {
-                PyObjectKind::Integer { value: value2 } => PyObjectKind::Integer {
-                    value: value1 - value2,
-                },
-                _ => {
-                    panic!("NOT IMPL");
-                }
-            },
-            _ => {
-                panic!("NOT IMPL");
-            }
-        }
-    }
-}
-
-impl<'a> Mul<&'a PyObject> for &'a PyObject {
-    type Output = PyObjectKind;
-
-    fn mul(self, rhs: &'a PyObject) -> Self::Output {
-        match self.kind {
-            PyObjectKind::Integer { value: value1 } => match rhs.kind {
-                PyObjectKind::Integer { value: value2 } => PyObjectKind::Integer {
-                    value: value1 * value2,
-                },
-                _ => {
-                    panic!("NOT IMPL");
-                }
-            },
-            PyObjectKind::String { value: ref value1 } => match rhs.kind {
-                PyObjectKind::Integer { value: value2 } => {
-                    let mut result = String::new();
-                    for _x in 0..value2 {
-                        result.push_str(value1.as_str());
-                    }
-                    PyObjectKind::String { value: result }
-                }
-                _ => {
-                    panic!("NOT IMPL");
-                }
-            },
-            _ => {
-                panic!("NOT IMPL");
-            }
-        }
-    }
-}
-
-impl<'a> Rem<&'a PyObject> for &'a PyObject {
-    type Output = PyObjectKind;
-
-    fn rem(self, rhs: &'a PyObject) -> Self::Output {
-        match (&self.kind, &rhs.kind) {
-            (PyObjectKind::Integer { value: value1 }, PyObjectKind::Integer { value: value2 }) => {
-                PyObjectKind::Integer {
-                    value: value1 % value2,
-                }
-            }
-            (kind1, kind2) => {
-                unimplemented!("% not implemented for kinds: {:?} {:?}", kind1, kind2);
-            }
-        }
-    }
-}
-
 // impl<'a> PartialEq<&'a PyObject> for &'a PyObject {
 impl PartialEq for PyObject {
     fn eq(&self, other: &PyObject) -> bool {
@@ -924,33 +803,7 @@ impl Ord for PyObject {
 
 #[cfg(test)]
 mod tests {
-    use super::{PyContext, PyObjectKind};
-
-    #[test]
-    fn test_add_py_integers() {
-        let ctx = PyContext::new();
-        let a = ctx.new_int(33);
-        let b = ctx.new_int(12);
-        let c = &*a.borrow() + &*b.borrow();
-        match c {
-            PyObjectKind::Integer { value } => assert_eq!(value, 45),
-            _ => assert!(false),
-        }
-    }
-
-    #[test]
-    fn test_multiply_str() {
-        let ctx = PyContext::new();
-        let a = ctx.new_str(String::from("Hello "));
-        let b = ctx.new_int(4);
-        let c = &*a.borrow() * &*b.borrow();
-        match c {
-            PyObjectKind::String { value } => {
-                assert_eq!(value, String::from("Hello Hello Hello Hello "))
-            }
-            _ => assert!(false),
-        }
-    }
+    use super::PyContext;
 
     #[test]
     fn test_type_type() {

--- a/vm/src/pyobject.rs
+++ b/vm/src/pyobject.rs
@@ -14,7 +14,7 @@ use std::cell::RefCell;
 use std::cmp::Ordering;
 use std::collections::HashMap;
 use std::fmt;
-use std::ops::{Add, Div, Mul, Rem, Sub};
+use std::ops::{Add, Mul, Rem, Sub};
 use std::rc::Rc;
 
 /* Python objects and references.
@@ -836,23 +836,6 @@ impl<'a> Mul<&'a PyObject> for &'a PyObject {
                     panic!("NOT IMPL");
                 }
             },
-            _ => {
-                panic!("NOT IMPL");
-            }
-        }
-    }
-}
-
-impl<'a> Div<&'a PyObject> for &'a PyObject {
-    type Output = PyObjectKind;
-
-    fn div(self, rhs: &'a PyObject) -> Self::Output {
-        match (&self.kind, &rhs.kind) {
-            (PyObjectKind::Integer { value: value1 }, PyObjectKind::Integer { value: value2 }) => {
-                PyObjectKind::Float {
-                    value: *value1 as f64 / *value2 as f64,
-                }
-            }
             _ => {
                 panic!("NOT IMPL");
             }

--- a/vm/src/vm.rs
+++ b/vm/src/vm.rs
@@ -341,9 +341,12 @@ impl VirtualMachine {
     }
 
     fn _div(&mut self, a: PyObjectRef, b: PyObjectRef) -> PyResult {
-        let b2 = &*b.borrow();
-        let a2 = &*a.borrow();
-        Ok(PyObject::new(a2 / b2, self.get_type()))
+        let func = match self.get_attribute(a.clone(), &"__truediv__".to_string()) {
+            Ok(v) => v,
+            Err(err) => return Err(err),
+        };
+        let args = PyFuncArgs { args: vec![b] };
+        self.invoke(func, args)
     }
 
     fn _pow(&mut self, a: PyObjectRef, b: PyObjectRef) -> PyResult {

--- a/vm/src/vm.rs
+++ b/vm/src/vm.rs
@@ -130,8 +130,8 @@ impl VirtualMachine {
     }
 
     // Container of the virtual machine state:
-    pub fn to_str(&mut self, obj: PyObjectRef) -> String {
-        obj.borrow().str()
+    pub fn to_str(&mut self, obj: PyObjectRef) -> PyResult {
+        self.call_method(obj, "__str__".to_string(), vec![])
     }
 
     pub fn current_frame(&self) -> &Frame {
@@ -349,24 +349,7 @@ impl VirtualMachine {
     }
 
     fn _pow(&mut self, a: PyObjectRef, b: PyObjectRef) -> PyResult {
-        let b2 = &*b.borrow();
-        let a2 = &*a.borrow();
-        match (&a2.kind, &b2.kind) {
-            (
-                &PyObjectKind::Integer { value: ref v1 },
-                &PyObjectKind::Integer { value: ref v2 },
-            ) => Ok(self.ctx.new_int(v1.pow(*v2 as u32))),
-            (&PyObjectKind::Float { value: ref v1 }, &PyObjectKind::Integer { value: ref v2 }) => {
-                Ok(self.ctx.new_float(v1.powf(*v2 as f64)))
-            }
-            (&PyObjectKind::Integer { value: ref v1 }, &PyObjectKind::Float { value: ref v2 }) => {
-                Ok(self.ctx.new_float((*v1 as f64).powf(*v2)))
-            }
-            (&PyObjectKind::Float { value: ref v1 }, &PyObjectKind::Float { value: ref v2 }) => {
-                Ok(self.ctx.new_float(v1.powf(*v2)))
-            }
-            _ => panic!("Not impl"),
-        }
+        self.call_method(a, "__pow__".to_string(), vec![b])
     }
 
     fn _modulo(&mut self, a: PyObjectRef, b: PyObjectRef) -> PyResult {


### PR DESCRIPTION
In this pull request I implemented an example of the direction we should take. Please comment your ideas. The idea is to use isinstance more and more to test for certain types, and no longer test on PyObjectKind. Also this adds the methods `__add__` and friends to the builtin types.