### PR TITLE
Add support for function argument defaults

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -62,7 +62,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "bitflags"
-version = "1.0.3"
+version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -91,7 +91,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "ansi_term 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "atty 0.2.10 (registry+https://github.com/rust-lang/crates.io-index)",
- "bitflags 1.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "bitflags 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "strsim 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "textwrap 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "unicode-width 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -160,7 +160,7 @@ name = "fuchsia-zircon"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "bitflags 1.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "bitflags 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "fuchsia-zircon-sys 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -466,6 +466,7 @@ dependencies = [
 name = "rustpython_vm"
 version = "0.1.0"
 dependencies = [
+ "bitflags 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "rustpython_parser 0.0.1",
  "serde 1.0.66 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -703,7 +704,7 @@ dependencies = [
 "checksum atty 0.2.10 (registry+https://github.com/rust-lang/crates.io-index)" = "2fc4a1aa4c24c0718a250f0681885c1af91419d242f29eb8f2ab28502d80dbd1"
 "checksum bit-set 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "d9bf6104718e80d7b26a68fdbacff3481cfc05df670821affc7e9cbc1884400c"
 "checksum bit-vec 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)" = "02b4ff8b16e6076c3e14220b39fbc1fabb6737522281a388998046859400895f"
-"checksum bitflags 1.0.3 (registry+https://github.com/rust-lang/crates.io-index)" = "d0c54bb8f454c567f21197eefcdbf5679d0bd99f2ddbe52e84c77061952e6789"
+"checksum bitflags 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)" = "228047a76f468627ca71776ecdebd732a3423081fcf5125585bcd7c49886ce12"
 "checksum block-buffer 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "a076c298b9ecdb530ed9d967e74a6027d6a7478924520acddcddc24c1c8ab3ab"
 "checksum byte-tools 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "560c32574a12a89ecd91f5e742165893f86e3ab98d21f8ea548658eb9eef5f40"
 "checksum cfg-if 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)" = "405216fd8fe65f718daa7102ea808a946b6ce40c742998fbfd3463645552de18"

--- a/parser/src/ast.rs
+++ b/parser/src/ast.rs
@@ -95,12 +95,12 @@ pub enum Statement {
     ClassDef {
         name: String,
         body: Vec<LocatedStatement>,
-        args: Vec<String>,
+        args: Vec<(String, Option<Expression>)>,
         // TODO: docstring: String,
     },
     FunctionDef {
         name: String,
-        args: Vec<String>,
+        args: Vec<(String, Option<Expression>)>,
         // docstring: String,
         body: Vec<LocatedStatement>,
     },
@@ -161,7 +161,7 @@ pub enum Expression {
         name: String,
     },
     Lambda {
-        args: Vec<String>,
+        args: Vec<(String, Option<Expression>)>,
         body: Box<Expression>,
     },
     True,

--- a/parser/src/parser.rs
+++ b/parser/src/parser.rs
@@ -193,7 +193,7 @@ mod tests {
                 location: ast::Location::new(1, 1),
                 node: ast::Statement::Expression {
                     expression: ast::Expression::Lambda {
-                        args: vec![String::from("x"), String::from("y")],
+                        args: vec![(String::from("x"), None), (String::from("y"), None)],
                         body: Box::new(ast::Expression::Binop {
                             a: Box::new(ast::Expression::Identifier {
                                 name: String::from("x"),
@@ -211,25 +211,46 @@ mod tests {
 
     #[test]
     fn test_parse_class() {
-        let source = String::from("class Foo(A, B):\n def __init__(self):\n  pass\n");
+        let source = String::from("class Foo(A, B):\n def __init__(self):\n  pass\n def method_with_default(self, arg='default'):\n  pass\n");
         assert_eq!(
             parse_statement(&source),
             Ok(ast::LocatedStatement {
                 location: ast::Location::new(1, 1),
                 node: ast::Statement::ClassDef {
                     name: String::from("Foo"),
-                    args: vec![String::from("A"), String::from("B")],
-                    body: vec![ast::LocatedStatement {
-                        location: ast::Location::new(2, 2),
-                        node: ast::Statement::FunctionDef {
-                            name: String::from("__init__"),
-                            args: vec![String::from("self")],
-                            body: vec![ast::LocatedStatement {
-                                location: ast::Location::new(3, 3),
-                                node: ast::Statement::Pass,
-                            }],
+                    args: vec![(String::from("A"), None), (String::from("B"), None)],
+                    body: vec![
+                        ast::LocatedStatement {
+                            location: ast::Location::new(2, 2),
+                            node: ast::Statement::FunctionDef {
+                                name: String::from("__init__"),
+                                args: vec![(String::from("self"), None)],
+                                body: vec![ast::LocatedStatement {
+                                    location: ast::Location::new(3, 3),
+                                    node: ast::Statement::Pass,
+                                }],
+                            }
+                        },
+                        ast::LocatedStatement {
+                            location: ast::Location::new(4, 2),
+                            node: ast::Statement::FunctionDef {
+                                name: String::from("method_with_default"),
+                                args: vec![
+                                    (String::from("self"), None),
+                                    (
+                                        String::from("arg"),
+                                        Some(ast::Expression::String {
+                                            value: "default".to_string()
+                                        })
+                                    )
+                                ],
+                                body: vec![ast::LocatedStatement {
+                                    location: ast::Location::new(5, 3),
+                                    node: ast::Statement::Pass,
+                                }],
+                            }
                         }
-                    }],
+                    ],
                 }
             })
         )

--- a/parser/src/python.lalrpop
+++ b/parser/src/python.lalrpop
@@ -315,9 +315,12 @@ Parameters: Vec<(String, Option<ast::Expression>)> = {
 // parameters are (String, None), kwargs are (String, Some(Test)) where Test is
 // the default
 TypedArgsList: Vec<(String, Option<ast::Expression>)> = {
-  <a: Comma<Identifier>> => {
-      a.iter().map(|param| (param.clone(), None)).collect()
-  },
+  <a: Comma<Parameter>> => a
+};
+
+Parameter: (String, Option<ast::Expression>) = {
+    <i:Identifier> => (i.clone(), None),
+    <i:Identifier> "=" <e:Expression> => (i.clone(), Some(e.clone())),
 };
 
 ClassDef: ast::LocatedStatement = {

--- a/parser/src/python.lalrpop
+++ b/parser/src/python.lalrpop
@@ -308,12 +308,16 @@ FuncDef: ast::LocatedStatement = {
   },
 };
 
-Parameters: Vec<String> = {
+Parameters: Vec<(String, Option<ast::Expression>)> = {
   "(" <a: TypedArgsList> ")" => a,
 };
 
-TypedArgsList: Vec<String> = {
-  <a: Comma<Identifier>> => a,
+// parameters are (String, None), kwargs are (String, Some(Test)) where Test is
+// the default
+TypedArgsList: Vec<(String, Option<ast::Expression>)> = {
+  <a: Comma<Identifier>> => {
+      a.iter().map(|param| (param.clone(), None)).collect()
+  },
 };
 
 ClassDef: ast::LocatedStatement = {

--- a/tests/snippets/func_defaults.py
+++ b/tests/snippets/func_defaults.py
@@ -1,0 +1,66 @@
+def no_args():
+    pass
+
+no_args()
+
+try:
+    no_args('one_arg')
+except TypeError:
+    pass
+else:
+    assert False, 'no TypeError raised: 1 arg to no_args'
+
+
+def one_arg(arg):
+    pass
+
+one_arg('one_arg')
+
+try:
+    one_arg()
+except TypeError:
+    pass
+else:
+    assert False, 'no TypeError raised: no args to one_arg'
+
+try:
+    one_arg('one_arg', 'two_arg')
+except TypeError:
+    pass
+else:
+    assert False, 'no TypeError raised: two args to one_arg'
+
+
+def one_default_arg(arg="default"):
+    return arg
+
+assert 'default' == one_default_arg()
+assert 'arg' == one_default_arg('arg')
+
+try:
+    one_default_arg('one_arg', 'two_arg')
+except TypeError:
+    pass
+else:
+    assert False, 'no TypeError raised: two args to one_default_arg'
+
+
+def one_normal_one_default_arg(pos, arg="default"):
+    return pos, arg
+
+assert ('arg', 'default') == one_normal_one_default_arg('arg')
+assert ('arg', 'arg2') == one_normal_one_default_arg('arg', 'arg2')
+
+try:
+    one_normal_one_default_arg()
+except TypeError:
+    pass
+else:
+    assert False, 'no TypeError raised: two args to one_default_arg'
+
+try:
+    one_normal_one_default_arg('one', 'two', 'three')
+except TypeError:
+    pass
+else:
+    assert False, 'no TypeError raised: two args to one_default_arg'

--- a/vm/Cargo.toml
+++ b/vm/Cargo.toml
@@ -4,6 +4,7 @@ version = "0.1.0"
 authors = ["Shing Lyu <shing.lyu@gmail.com>"]
 
 [dependencies]
+bitflags = "1.0.4"
 log = "0.3"
 rustpython_parser = {path = "../parser"}
 serde = "1.0.66"

--- a/vm/src/bytecode.rs
+++ b/vm/src/bytecode.rs
@@ -37,6 +37,12 @@ impl CodeObject {
     }
 }
 
+bitflags! {
+    pub struct FunctionOpArg: u8 {
+        const HAS_DEFAULTS = 0x01;
+    }
+}
+
 pub type Label = usize;
 
 #[derive(Debug, Clone, PartialEq)]
@@ -88,7 +94,9 @@ pub enum Instruction {
     JumpIfFalse {
         target: Label,
     },
-    MakeFunction,
+    MakeFunction {
+        flags: FunctionOpArg,
+    },
     CallFunction {
         count: usize,
     },

--- a/vm/src/compile.rs
+++ b/vm/src/compile.rs
@@ -357,6 +357,12 @@ impl Compiler {
                     names.push(name.clone());
                     if let Some(default) = default {
                         default_elements.push(default.clone());
+                    } else {
+                        if default_elements.len() > 0 {
+                            // Once we have started with defaults, all remaining arguments must
+                            // have defaults
+                            panic!("non-default argument follows default argument: {}", name);
+                        }
                     }
                 }
 

--- a/vm/src/lib.rs
+++ b/vm/src/lib.rs
@@ -1,4 +1,6 @@
 #[macro_use]
+extern crate bitflags;
+#[macro_use]
 extern crate log;
 // extern crate env_logger;
 extern crate serde;

--- a/vm/src/pyobject.rs
+++ b/vm/src/pyobject.rs
@@ -267,11 +267,17 @@ impl PyContext {
         )
     }
 
-    pub fn new_function(&self, code_obj: PyObjectRef, scope: PyObjectRef) -> PyObjectRef {
+    pub fn new_function(
+        &self,
+        code_obj: PyObjectRef,
+        scope: PyObjectRef,
+        defaults: PyObjectRef,
+    ) -> PyObjectRef {
         PyObject::new(
             PyObjectKind::Function {
                 code: code_obj,
                 scope: scope,
+                defaults: defaults,
             },
             self.function_type(),
         )
@@ -566,6 +572,7 @@ pub enum PyObjectKind {
     Function {
         code: PyObjectRef,
         scope: PyObjectRef,
+        defaults: PyObjectRef,
     },
     BoundMethod {
         function: PyObjectRef,
@@ -613,7 +620,7 @@ impl fmt::Debug for PyObjectKind {
             } => write!(f, "slice"),
             &PyObjectKind::NameError { name: _ } => write!(f, "NameError"),
             &PyObjectKind::Code { ref code } => write!(f, "code: {:?}", code),
-            &PyObjectKind::Function { code: _, scope: _ } => write!(f, "function"),
+            &PyObjectKind::Function { .. } => write!(f, "function"),
             &PyObjectKind::BoundMethod {
                 ref function,
                 ref object,
@@ -683,7 +690,7 @@ impl PyObject {
             } => format!("<class '{}'>", name),
             PyObjectKind::Instance { dict: _ } => format!("<instance>"),
             PyObjectKind::Code { code: _ } => format!("<code>"),
-            PyObjectKind::Function { code: _, scope: _ } => format!("<func>"),
+            PyObjectKind::Function { .. } => format!("<func>"),
             PyObjectKind::BoundMethod { .. } => format!("<bound-method>"),
             PyObjectKind::RustFunction { function: _ } => format!("<rustfunc>"),
             PyObjectKind::Module { ref name, dict: _ } => format!("<module '{}'>", name),


### PR DESCRIPTION
This allows defaults to be specified at function definition:

```py
def func(pos, defaulting="default"):
    return pos, defaulting

assert 1, 2 == func(1, 2)
assert 1, "default" == func(1)
```