### PR TITLE
Store Rust stdlib modules on VirtualMachine and lazily-load them

### DIFF
--- a/vm/src/import.rs
+++ b/vm/src/import.rs
@@ -11,7 +11,6 @@ use std::path::PathBuf;
 use self::rustpython_parser::parser;
 use super::compile;
 use super::pyobject::{DictProtocol, PyObject, PyObjectKind, PyResult};
-use super::stdlib;
 use super::vm::VirtualMachine;
 
 fn import_module(vm: &mut VirtualMachine, module: &String) -> PyResult {
@@ -22,7 +21,7 @@ fn import_module(vm: &mut VirtualMachine, module: &String) -> PyResult {
     }
 
     // Check for Rust-native modules
-    if let Some(module) = stdlib::get_modules(vm).get(module) {
+    if let Some(module) = vm.stdlib_modules.get(module) {
         return Ok(module.clone());
     }
 

--- a/vm/src/import.rs
+++ b/vm/src/import.rs
@@ -21,8 +21,8 @@ fn import_module(vm: &mut VirtualMachine, module: &String) -> PyResult {
     }
 
     // Check for Rust-native modules
-    if let Some(module) = vm.stdlib_modules.get(module) {
-        return Ok(module.clone());
+    if let Some(module) = vm.stdlib_inits.get(module) {
+        return Ok(module(&vm.ctx).clone());
     }
 
     // TODO: introduce import error:

--- a/vm/src/stdlib/mod.rs
+++ b/vm/src/stdlib/mod.rs
@@ -3,8 +3,10 @@ use std::collections::HashMap;
 
 use super::pyobject::{PyContext, PyObjectRef};
 
-pub fn get_modules(ctx: &PyContext) -> HashMap<String, PyObjectRef> {
+pub type StdlibInitFunc = fn(&PyContext) -> PyObjectRef;
+
+pub fn get_module_inits() -> HashMap<String, StdlibInitFunc> {
     let mut modules = HashMap::new();
-    modules.insert("json".to_string(), json::mk_module(ctx));
+    modules.insert("json".to_string(), json::mk_module as StdlibInitFunc);
     modules
 }

--- a/vm/src/stdlib/mod.rs
+++ b/vm/src/stdlib/mod.rs
@@ -1,11 +1,10 @@
 mod json;
 use std::collections::HashMap;
 
-use super::pyobject::PyObjectRef;
-use super::vm::VirtualMachine;
+use super::pyobject::{PyContext, PyObjectRef};
 
-pub fn get_modules(vm: &VirtualMachine) -> HashMap<String, PyObjectRef> {
+pub fn get_modules(ctx: &PyContext) -> HashMap<String, PyObjectRef> {
     let mut modules = HashMap::new();
-    modules.insert("json".to_string(), json::mk_module(vm.context()));
+    modules.insert("json".to_string(), json::mk_module(ctx));
     modules
 }

--- a/vm/src/vm.rs
+++ b/vm/src/vm.rs
@@ -24,6 +24,7 @@ use super::pyobject::{
     AttributeProtocol, DictProtocol, IdProtocol, ParentProtocol, PyContext, PyFuncArgs, PyObject,
     PyObjectKind, PyObjectRef, PyResult,
 };
+use super::stdlib;
 use super::sysmodule;
 
 // use objects::objects;
@@ -34,6 +35,7 @@ pub struct VirtualMachine {
     frames: Vec<Frame>,
     builtins: PyObjectRef,
     pub sys_module: PyObjectRef,
+    pub stdlib_modules: HashMap<String, PyObjectRef>,
     pub ctx: PyContext,
 }
 
@@ -111,10 +113,12 @@ impl VirtualMachine {
         let ctx = PyContext::new();
         let builtins = builtins::make_module(&ctx);
         let sysmod = sysmodule::mk_module(&ctx);
+        let stdlib_modules = stdlib::get_modules(&ctx);
         VirtualMachine {
             frames: vec![],
             builtins: builtins,
             sys_module: sysmod,
+            stdlib_modules,
             ctx: ctx,
         }
     }

--- a/vm/src/vm.rs
+++ b/vm/src/vm.rs
@@ -35,7 +35,7 @@ pub struct VirtualMachine {
     frames: Vec<Frame>,
     builtins: PyObjectRef,
     pub sys_module: PyObjectRef,
-    pub stdlib_modules: HashMap<String, PyObjectRef>,
+    pub stdlib_inits: HashMap<String, stdlib::StdlibInitFunc>,
     pub ctx: PyContext,
 }
 
@@ -113,12 +113,12 @@ impl VirtualMachine {
         let ctx = PyContext::new();
         let builtins = builtins::make_module(&ctx);
         let sysmod = sysmodule::mk_module(&ctx);
-        let stdlib_modules = stdlib::get_modules(&ctx);
+        let stdlib_inits = stdlib::get_module_inits();
         VirtualMachine {
             frames: vec![],
             builtins: builtins,
             sys_module: sysmod,
-            stdlib_modules,
+            stdlib_inits,
             ctx: ctx,
         }
     }


### PR DESCRIPTION
This means we only have to load the modules once at startup.

Fixes #90.