### PR TITLE
Rework json.dumps to support subclasses

### DIFF
--- a/tests/snippets/json_snippet.py
+++ b/tests/snippets/json_snippet.py
@@ -42,3 +42,17 @@ assert False == json.loads('false')
 assert [] == json.loads('[]')
 assert ['a'] == json.loads('["a"]')
 assert [['a'], 'b'] == json.loads('[["a"], "b"]')
+
+class String(str): pass
+
+assert '"string"' == json.dumps(String("string"))
+
+# TODO: Uncomment and test once int/float construction is supported
+# class Int(int): pass
+# class Float(float): pass
+
+# TODO: Uncomment and test once sequence/dict subclasses are supported by
+# json.dumps
+# class List(list): pass
+# class Tuple(tuple): pass
+# class Dict(dict): pass

--- a/tests/snippets/json_snippet.py
+++ b/tests/snippets/json_snippet.py
@@ -11,6 +11,7 @@ assert "1" == json.dumps(1)
 assert "1.0" == json.dumps(1.0)
 assert "true" == json.dumps(True)
 assert "false" == json.dumps(False)
+assert 'null' == json.dumps(None)
 
 assert '[]' == json.dumps([])
 assert '[1]' == json.dumps([1])

--- a/tests/snippets/json_snippet.py
+++ b/tests/snippets/json_snippet.py
@@ -17,6 +17,12 @@ assert '[1]' == json.dumps([1])
 assert '[[1]]' == json.dumps([[1]])
 round_trip_test([1, "string", 1.0, True])
 
+assert '[]' == json.dumps(())
+assert '[1]' == json.dumps((1,))
+assert '[[1]]' == json.dumps(((1,),))
+# tuples don't round-trip through json
+assert [1, "string", 1.0, True] == json.loads(json.dumps((1, "string", 1.0, True)))
+
 assert '{}' == json.dumps({})
 # TODO: uncomment once dict comparison is implemented
 # round_trip_test({'a': 'b'})

--- a/vm/src/objdict.rs
+++ b/vm/src/objdict.rs
@@ -26,7 +26,7 @@ pub fn new(dict_type: PyObjectRef) -> PyObjectRef {
     )
 }
 
-fn get_elements(obj: &PyObjectRef) -> HashMap<String, PyObjectRef> {
+pub fn get_elements(obj: &PyObjectRef) -> HashMap<String, PyObjectRef> {
     if let PyObjectKind::Dict { elements } = &obj.borrow().kind {
         elements.clone()
     } else {

--- a/vm/src/objlist.rs
+++ b/vm/src/objlist.rs
@@ -26,7 +26,7 @@ pub fn set_item(
     }
 }
 
-fn get_elements(obj: PyObjectRef) -> Vec<PyObjectRef> {
+pub fn get_elements(obj: PyObjectRef) -> Vec<PyObjectRef> {
     if let PyObjectKind::List { elements } = &obj.borrow().kind {
         elements.to_vec()
     } else {

--- a/vm/src/objsequence.rs
+++ b/vm/src/objsequence.rs
@@ -98,3 +98,11 @@ pub fn get_item(
         ))),
     }
 }
+
+pub fn get_elements(obj: PyObjectRef) -> Vec<PyObjectRef> {
+    if let PyObjectKind::Tuple { elements } = &obj.borrow().kind {
+        elements.to_vec()
+    } else {
+        panic!("Cannot extract list elements from non-list");
+    }
+}


### PR DESCRIPTION
We can currently only construct instances of string subclasses, so
that's the only code path that is actually tested.

Fixes #91.