### PR TITLE
Implement Repr

### DIFF
--- a/tests/snippets/strings.py
+++ b/tests/snippets/strings.py
@@ -15,3 +15,5 @@ assert str(1) == "1"
 assert str(2.1) == "2.1"
 assert str() == ""
 assert str("abc") == "abc"
+
+assert str(["a", "b", "can't"]) == "['a', 'b', 'can\\'t']"

--- a/tests/snippets/strings.py
+++ b/tests/snippets/strings.py
@@ -16,4 +16,9 @@ assert str(2.1) == "2.1"
 assert str() == ""
 assert str("abc") == "abc"
 
-assert str(["a", "b", "can't"]) == "['a', 'b', 'can\\'t']"
+assert repr("a") == "'a'"
+assert repr("can't") == '"can\'t"'
+assert repr('"won\'t"') == "'\"won\\'t\"'"
+assert repr('\n\t') == "'\\n\\t'"
+
+assert str(["a", "b", "can't"]) == "['a', 'b', \"can't\"]"

--- a/vm/src/builtins.rs
+++ b/vm/src/builtins.rs
@@ -288,6 +288,10 @@ fn builtin_range(vm: &mut VirtualMachine, args: PyFuncArgs) -> PyResult {
 }
 
 // builtin_repr
+fn builtin_repr(vm: &mut VirtualMachine, args: PyFuncArgs) -> PyResult {
+    arg_check!(vm, args, required = [(obj, None)]);
+    vm.to_repr(obj.clone())
+}
 // builtin_reversed
 // builtin_round
 // builtin_set
@@ -346,6 +350,7 @@ pub fn make_module(ctx: &PyContext) -> PyObjectRef {
     dict.insert(String::from("locals"), ctx.new_rustfunc(builtin_locals));
     dict.insert(String::from("print"), ctx.new_rustfunc(builtin_print));
     dict.insert(String::from("range"), ctx.new_rustfunc(builtin_range));
+    dict.insert(String::from("repr"), ctx.new_rustfunc(builtin_repr));
     dict.insert(String::from("setattr"), ctx.new_rustfunc(builtin_setattr));
     dict.insert(String::from("str"), ctx.str_type()); // new_rustfunc(builtin_str));
     dict.insert(String::from("tuple"), ctx.tuple_type());

--- a/vm/src/obj/objbytes.rs
+++ b/vm/src/obj/objbytes.rs
@@ -11,7 +11,7 @@ use super::objtype;
 pub fn init(context: &PyContext) {
     let ref bytes_type = context.bytes_type;
     bytes_type.set_attr("__init__", context.new_rustfunc(bytes_init));
-    bytes_type.set_attr("__str__", context.new_rustfunc(bytes_str));
+    bytes_type.set_attr("__repr__", context.new_rustfunc(bytes_repr));
 }
 
 // __init__ (store value into objectkind)
@@ -50,7 +50,7 @@ fn set_value(obj: &PyObjectRef, value: Vec<u8>) {
     obj.borrow_mut().kind = PyObjectKind::Bytes { value };
 }
 
-fn bytes_str(vm: &mut VirtualMachine, args: PyFuncArgs) -> PyResult {
+fn bytes_repr(vm: &mut VirtualMachine, args: PyFuncArgs) -> PyResult {
     arg_check!(vm, args, required = [(obj, Some(vm.ctx.bytes_type()))]);
     let data = get_value(obj);
     let data: Vec<String> = data.into_iter().map(|b| format!("\\x{:02x}", b)).collect();

--- a/vm/src/obj/objdict.rs
+++ b/vm/src/obj/objdict.rs
@@ -44,7 +44,7 @@ fn dict_len(vm: &mut VirtualMachine, args: PyFuncArgs) -> PyResult {
     Ok(vm.ctx.new_int(elements.len() as i32))
 }
 
-fn dict_str(vm: &mut VirtualMachine, args: PyFuncArgs) -> PyResult {
+fn dict_repr(vm: &mut VirtualMachine, args: PyFuncArgs) -> PyResult {
     arg_check!(vm, args, required = [(o, Some(vm.ctx.dict_type()))]);
 
     let elements = get_elements(o);
@@ -76,5 +76,5 @@ pub fn init(context: &PyContext) {
     let ref dict_type = context.dict_type;
     dict_type.set_attr("__len__", context.new_rustfunc(dict_len));
     dict_type.set_attr("__new__", context.new_rustfunc(dict_new));
-    dict_type.set_attr("__str__", context.new_rustfunc(dict_str));
+    dict_type.set_attr("__repr__", context.new_rustfunc(dict_repr));
 }

--- a/vm/src/obj/objdict.rs
+++ b/vm/src/obj/objdict.rs
@@ -50,7 +50,7 @@ fn dict_repr(vm: &mut VirtualMachine, args: PyFuncArgs) -> PyResult {
     let elements = get_elements(o);
     let mut str_parts = vec![];
     for elem in elements {
-        match vm.to_str(elem.1) {
+        match vm.to_repr(elem.1) {
             Ok(s) => {
                 let value_str = objstr::get_value(&s);
                 str_parts.push(format!("{}: {}", elem.0, value_str));

--- a/vm/src/obj/objfloat.rs
+++ b/vm/src/obj/objfloat.rs
@@ -5,7 +5,7 @@ use super::super::vm::VirtualMachine;
 use super::objint;
 use super::objtype;
 
-fn str(vm: &mut VirtualMachine, args: PyFuncArgs) -> Result<PyObjectRef, PyObjectRef> {
+fn float_repr(vm: &mut VirtualMachine, args: PyFuncArgs) -> Result<PyObjectRef, PyObjectRef> {
     arg_check!(vm, args, required = [(float, Some(vm.ctx.float_type()))]);
     let v = get_value(float);
     Ok(vm.new_str(v.to_string()))
@@ -120,7 +120,6 @@ pub fn init(context: &PyContext) {
     float_type.set_attr("__add__", context.new_rustfunc(float_add));
     float_type.set_attr("__init__", context.new_rustfunc(float_init));
     float_type.set_attr("__pow__", context.new_rustfunc(float_pow));
-    float_type.set_attr("__str__", context.new_rustfunc(str));
     float_type.set_attr("__sub__", context.new_rustfunc(float_sub));
-    float_type.set_attr("__repr__", context.new_rustfunc(str));
+    float_type.set_attr("__repr__", context.new_rustfunc(float_repr));
 }

--- a/vm/src/obj/objint.rs
+++ b/vm/src/obj/objint.rs
@@ -6,7 +6,7 @@ use super::super::vm::VirtualMachine;
 use super::objfloat;
 use super::objtype;
 
-fn str(vm: &mut VirtualMachine, args: PyFuncArgs) -> PyResult {
+fn int_repr(vm: &mut VirtualMachine, args: PyFuncArgs) -> PyResult {
     arg_check!(vm, args, required = [(int, Some(vm.ctx.int_type()))]);
     let v = get_value(int);
     Ok(vm.new_str(v.to_string()))
@@ -219,8 +219,7 @@ pub fn init(context: &PyContext) {
     int_type.set_attr("__mul__", context.new_rustfunc(int_mul));
     int_type.set_attr("__or__", context.new_rustfunc(int_or));
     int_type.set_attr("__pow__", context.new_rustfunc(int_pow));
-    int_type.set_attr("__repr__", context.new_rustfunc(str));
-    int_type.set_attr("__str__", context.new_rustfunc(str));
+    int_type.set_attr("__repr__", context.new_rustfunc(int_repr));
     int_type.set_attr("__sub__", context.new_rustfunc(int_sub));
     int_type.set_attr("__truediv__", context.new_rustfunc(int_truediv));
     int_type.set_attr("__xor__", context.new_rustfunc(int_xor));

--- a/vm/src/obj/objlist.rs
+++ b/vm/src/obj/objlist.rs
@@ -68,7 +68,7 @@ fn list_add(vm: &mut VirtualMachine, args: PyFuncArgs) -> PyResult {
     }
 }
 
-fn list_str(vm: &mut VirtualMachine, args: PyFuncArgs) -> PyResult {
+fn list_repr(vm: &mut VirtualMachine, args: PyFuncArgs) -> PyResult {
     arg_check!(vm, args, required = [(o, Some(vm.ctx.list_type()))]);
 
     let elements = get_elements(o);
@@ -136,7 +136,7 @@ pub fn init(context: &PyContext) {
     list_type.set_attr("__eq__", context.new_rustfunc(list_eq));
     list_type.set_attr("__add__", context.new_rustfunc(list_add));
     list_type.set_attr("__len__", context.new_rustfunc(list_len));
-    list_type.set_attr("__str__", context.new_rustfunc(list_str));
+    list_type.set_attr("__repr__", context.new_rustfunc(list_repr));
     list_type.set_attr("append", context.new_rustfunc(append));
     list_type.set_attr("clear", context.new_rustfunc(clear));
     list_type.set_attr("reverse", context.new_rustfunc(reverse));

--- a/vm/src/obj/objlist.rs
+++ b/vm/src/obj/objlist.rs
@@ -74,7 +74,7 @@ fn list_repr(vm: &mut VirtualMachine, args: PyFuncArgs) -> PyResult {
     let elements = get_elements(o);
     let mut str_parts = vec![];
     for elem in elements {
-        match vm.to_str(elem) {
+        match vm.to_repr(elem) {
             Ok(s) => str_parts.push(objstr::get_value(&s)),
             Err(err) => return Err(err),
         }

--- a/vm/src/obj/objobject.rs
+++ b/vm/src/obj/objobject.rs
@@ -50,6 +50,11 @@ fn object_ne(vm: &mut VirtualMachine, args: PyFuncArgs) -> PyResult {
 }
 
 fn object_str(vm: &mut VirtualMachine, args: PyFuncArgs) -> PyResult {
+    arg_check!(vm, args, required = [(zelf, Some(vm.ctx.object()))]);
+    vm.call_method(zelf.clone(), "__repr__", vec![])
+}
+
+fn object_repr(vm: &mut VirtualMachine, args: PyFuncArgs) -> PyResult {
     arg_check!(vm, args, required = [(obj, Some(vm.ctx.object()))]);
     let type_name = objtype::get_type_name(&obj.typ());
     let address = obj.get_id();
@@ -64,6 +69,7 @@ pub fn init(context: &PyContext) {
     object.set_attr("__ne__", context.new_rustfunc(object_ne));
     object.set_attr("__dict__", context.new_member_descriptor(object_dict));
     object.set_attr("__str__", context.new_rustfunc(object_str));
+    object.set_attr("__repr__", context.new_rustfunc(object_repr));
 }
 
 fn object_init(vm: &mut VirtualMachine, _args: PyFuncArgs) -> PyResult {

--- a/vm/src/obj/objstr.rs
+++ b/vm/src/obj/objstr.rs
@@ -14,6 +14,7 @@ pub fn init(context: &PyContext) {
     str_type.set_attr("__mul__", context.new_rustfunc(str_mul));
     str_type.set_attr("__new__", context.new_rustfunc(str_new));
     str_type.set_attr("__str__", context.new_rustfunc(str_str));
+    str_type.set_attr("__repr__", context.new_rustfunc(str_repr));
 }
 
 pub fn get_value(obj: &PyObjectRef) -> String {
@@ -42,6 +43,25 @@ fn str_eq(vm: &mut VirtualMachine, args: PyFuncArgs) -> PyResult {
 fn str_str(vm: &mut VirtualMachine, args: PyFuncArgs) -> PyResult {
     arg_check!(vm, args, required = [(s, Some(vm.ctx.str_type()))]);
     Ok(s.clone())
+}
+
+fn str_repr(vm: &mut VirtualMachine, args: PyFuncArgs) -> PyResult {
+    arg_check!(vm, args, required = [(s, Some(vm.ctx.str_type()))]);
+    let value = get_value(s);
+    let mut formatted = String::from("'");
+    for c in value.chars() {
+        match c {
+            '\'' | '\\' => {
+                formatted.push('\\');
+                formatted.push(c);
+            }
+            _ => {
+                formatted.push(c);
+            }
+        }
+    }
+    formatted.push('\'');
+    Ok(vm.ctx.new_str(formatted))
 }
 
 fn str_add(vm: &mut VirtualMachine, args: PyFuncArgs) -> PyResult {

--- a/vm/src/obj/objstr.rs
+++ b/vm/src/obj/objstr.rs
@@ -45,22 +45,38 @@ fn str_str(vm: &mut VirtualMachine, args: PyFuncArgs) -> PyResult {
     Ok(s.clone())
 }
 
+fn count_char(s: &str, c: char) -> usize {
+    s.chars().filter(|x| *x == c).count()
+}
+
 fn str_repr(vm: &mut VirtualMachine, args: PyFuncArgs) -> PyResult {
     arg_check!(vm, args, required = [(s, Some(vm.ctx.str_type()))]);
     let value = get_value(s);
-    let mut formatted = String::from("'");
+    let quote_char = if count_char(&value, '\'') > count_char(&value, '"') {
+        '"'
+    } else {
+        '\''
+    };
+    let mut formatted = String::new();
+    formatted.push(quote_char);
     for c in value.chars() {
-        match c {
-            '\'' | '\\' => {
-                formatted.push('\\');
-                formatted.push(c);
-            }
-            _ => {
-                formatted.push(c);
-            }
+        if c == quote_char || c == '\\' {
+            formatted.push('\\');
+            formatted.push(c);
+        } else if c == '\n' {
+            formatted.push('\\');
+            formatted.push('n');
+        } else if c == '\t' {
+            formatted.push('\\');
+            formatted.push('t');
+        } else if c == '\r' {
+            formatted.push('\\');
+            formatted.push('r');
+        } else {
+            formatted.push(c);
         }
     }
-    formatted.push('\'');
+    formatted.push(quote_char);
     Ok(vm.ctx.new_str(formatted))
 }
 

--- a/vm/src/obj/objtuple.rs
+++ b/vm/src/obj/objtuple.rs
@@ -36,7 +36,7 @@ fn tuple_repr(vm: &mut VirtualMachine, args: PyFuncArgs) -> PyResult {
 
     let mut str_parts = vec![];
     for elem in elements {
-        match vm.to_str(elem) {
+        match vm.to_repr(elem) {
             Ok(s) => str_parts.push(objstr::get_value(&s)),
             Err(err) => return Err(err),
         }

--- a/vm/src/obj/objtuple.rs
+++ b/vm/src/obj/objtuple.rs
@@ -29,7 +29,7 @@ fn tuple_len(vm: &mut VirtualMachine, args: PyFuncArgs) -> PyResult {
     Ok(vm.context().new_int(elements.len() as i32))
 }
 
-fn tuple_str(vm: &mut VirtualMachine, args: PyFuncArgs) -> PyResult {
+fn tuple_repr(vm: &mut VirtualMachine, args: PyFuncArgs) -> PyResult {
     arg_check!(vm, args, required = [(zelf, Some(vm.ctx.tuple_type()))]);
 
     let elements = get_elements(zelf);
@@ -62,5 +62,5 @@ pub fn init(context: &PyContext) {
     let ref tuple_type = context.tuple_type;
     tuple_type.set_attr("__eq__", context.new_rustfunc(tuple_eq));
     tuple_type.set_attr("__len__", context.new_rustfunc(tuple_len));
-    tuple_type.set_attr("__str__", context.new_rustfunc(tuple_str));
+    tuple_type.set_attr("__repr__", context.new_rustfunc(tuple_repr));
 }

--- a/vm/src/obj/objtype.rs
+++ b/vm/src/obj/objtype.rs
@@ -25,7 +25,7 @@ pub fn init(context: &PyContext) {
     type_type.set_attr("__new__", context.new_rustfunc(type_new));
     type_type.set_attr("__mro__", context.new_member_descriptor(type_mro));
     type_type.set_attr("__class__", context.new_member_descriptor(type_new));
-    type_type.set_attr("__str__", context.new_rustfunc(type_str));
+    type_type.set_attr("__repr__", context.new_rustfunc(type_repr));
 }
 
 fn type_mro(vm: &mut VirtualMachine, args: PyFuncArgs) -> PyResult {
@@ -221,7 +221,7 @@ pub fn new(typ: PyObjectRef, name: &str, bases: Vec<PyObjectRef>, dict: PyObject
     ))
 }
 
-fn type_str(vm: &mut VirtualMachine, args: PyFuncArgs) -> PyResult {
+fn type_repr(vm: &mut VirtualMachine, args: PyFuncArgs) -> PyResult {
     arg_check!(vm, args, required = [(obj, Some(vm.ctx.type_type()))]);
     let type_name = get_type_name(&obj);
     Ok(vm.new_str(format!("<class '{}'>", type_name)))

--- a/vm/src/objbool.rs
+++ b/vm/src/objbool.rs
@@ -34,7 +34,7 @@ pub fn boolval(vm: &mut VirtualMachine, obj: PyObjectRef) -> Result<bool, PyObje
 pub fn init(context: &PyContext) {
     let ref bool_type = context.bool_type;
     bool_type.set_attr("__new__", context.new_rustfunc(bool_new));
-    bool_type.set_attr("__str__", context.new_rustfunc(bool_str));
+    bool_type.set_attr("__repr__", context.new_rustfunc(bool_repr));
     bool_type.set_attr("__eq__", context.new_rustfunc(bool_eq));
 }
 
@@ -71,7 +71,7 @@ pub fn get_value(obj: &PyObjectRef) -> bool {
     }
 }
 
-fn bool_str(vm: &mut VirtualMachine, args: PyFuncArgs) -> Result<PyObjectRef, PyObjectRef> {
+fn bool_repr(vm: &mut VirtualMachine, args: PyFuncArgs) -> Result<PyObjectRef, PyObjectRef> {
     arg_check!(vm, args, required = [(obj, Some(vm.ctx.bool_type()))]);
     let v = get_value(obj);
     let s = if v {

--- a/vm/src/vm.rs
+++ b/vm/src/vm.rs
@@ -1007,10 +1007,11 @@ impl VirtualMachine {
                 match expr.borrow().kind {
                     PyObjectKind::None => (),
                     _ => {
+                        let repr = self.to_repr(expr.clone()).unwrap();
                         builtins::builtin_print(
                             self,
                             PyFuncArgs {
-                                args: vec![expr.clone()],
+                                args: vec![repr],
                                 kwargs: vec![],
                             },
                         ).unwrap();

--- a/vm/src/vm.rs
+++ b/vm/src/vm.rs
@@ -142,6 +142,10 @@ impl VirtualMachine {
         self.call_method(obj, "__str__", vec![])
     }
 
+    pub fn to_repr(&mut self, obj: PyObjectRef) -> PyResult {
+        self.call_method(obj, "__repr__", vec![])
+    }
+
     pub fn current_frame(&self) -> &Frame {
         self.frames.last().unwrap()
     }


### PR DESCRIPTION
Fixes issue #79 .

```
Welcome to the magnificent Rust Python 0.0.1 interpreter
>>>>> ["a", "b", "can't"]
['a', 'b', 'can\'t'] 
```