### PR TITLE
Bool is a subclass of int, so doesn't need a special kind.

### DIFF
--- a/tests/snippets/bools.py
+++ b/tests/snippets/bools.py
@@ -39,3 +39,10 @@ assert ("thing" or 0) == "thing"
 assert (True and True)
 assert not (False and fake)
 assert (True and 5) == 5
+
+# Bools are also ints.
+assert isinstance(True, int)
+assert True + True == 2
+assert False * 7 == 0
+assert True > 0
+assert int(True) == 1

--- a/vm/src/objbool.rs
+++ b/vm/src/objbool.rs
@@ -6,7 +6,6 @@ use super::vm::VirtualMachine;
 
 pub fn boolval(vm: &mut VirtualMachine, obj: PyObjectRef) -> Result<bool, PyObjectRef> {
     let result = match obj.borrow().kind {
-        PyObjectKind::Boolean { value } => value,
         PyObjectKind::Integer { value } => value != 0,
         PyObjectKind::Float { value } => value != 0.0,
         PyObjectKind::List { ref elements } => !elements.is_empty(),
@@ -18,7 +17,7 @@ pub fn boolval(vm: &mut VirtualMachine, obj: PyObjectRef) -> Result<bool, PyObje
             if let Ok(f) = objtype::get_attribute(vm, obj.clone(), &String::from("__bool__")) {
                 match vm.invoke(f, PyFuncArgs::default()) {
                     Ok(result) => match result.borrow().kind {
-                        PyObjectKind::Boolean { value } => value,
+                        PyObjectKind::Integer { value } => value != 0,
                         _ => return Err(vm.new_type_error(String::from("TypeError"))),
                     },
                     Err(err) => return Err(err),
@@ -35,22 +34,6 @@ pub fn init(context: &PyContext) {
     let ref bool_type = context.bool_type;
     bool_type.set_attr("__new__", context.new_rustfunc(bool_new));
     bool_type.set_attr("__str__", context.new_rustfunc(bool_str));
-    bool_type.set_attr("__eq__", context.new_rustfunc(bool_eq));
-}
-
-fn bool_eq(vm: &mut VirtualMachine, args: PyFuncArgs) -> PyResult {
-    arg_check!(
-        vm,
-        args,
-        required = [(zelf, Some(vm.ctx.bool_type())), (other, None)]
-    );
-
-    let result = if objtype::isinstance(other.clone(), vm.ctx.bool_type()) {
-        get_value(zelf) == get_value(other)
-    } else {
-        false
-    };
-    Ok(vm.ctx.new_bool(result))
 }
 
 pub fn not(vm: &mut VirtualMachine, obj: &PyObjectRef) -> PyResult {
@@ -64,8 +47,8 @@ pub fn not(vm: &mut VirtualMachine, obj: &PyObjectRef) -> PyResult {
 
 // Retrieve inner int value:
 pub fn get_value(obj: &PyObjectRef) -> bool {
-    if let PyObjectKind::Boolean { value } = &obj.borrow().kind {
-        *value
+    if let PyObjectKind::Integer { value } = &obj.borrow().kind {
+        *value != 0
     } else {
         panic!("Inner error getting inner boolean");
     }

--- a/vm/src/stdlib/json.rs
+++ b/vm/src/stdlib/json.rs
@@ -45,12 +45,12 @@ impl<'s> serde::Serialize for PyObjectSerializer<'s> {
             };
         if objtype::isinstance(self.pyobject.clone(), self.vm.ctx.str_type()) {
             serializer.serialize_str(&objstr::get_value(&self.pyobject))
-        } else if objtype::isinstance(self.pyobject.clone(), self.vm.ctx.int_type()) {
-            serializer.serialize_i32(objint::get_value(self.pyobject))
         } else if objtype::isinstance(self.pyobject.clone(), self.vm.ctx.float_type()) {
             serializer.serialize_f64(objfloat::get_value(self.pyobject))
         } else if objtype::isinstance(self.pyobject.clone(), self.vm.ctx.bool_type()) {
             serializer.serialize_bool(objbool::get_value(self.pyobject))
+        } else if objtype::isinstance(self.pyobject.clone(), self.vm.ctx.int_type()) {
+            serializer.serialize_i32(objint::get_value(self.pyobject))
         } else if objtype::isinstance(self.pyobject.clone(), self.vm.ctx.list_type()) {
             let elements = objlist::get_elements(self.pyobject);
             serialize_seq_elements(serializer, elements)
@@ -143,7 +143,9 @@ impl<'de> Visitor<'de> for PyObjectKindVisitor {
     where
         E: serde::de::Error,
     {
-        Ok(PyObjectKind::Boolean { value })
+        Ok(PyObjectKind::Integer {
+            value: if value { 1 } else { 0 },
+        })
     }
 
     fn visit_seq<A>(self, mut access: A) -> Result<Self::Value, A::Error>


### PR DESCRIPTION
A surprising edge case of python that I'd forgotten about. Let's us delete some code.