### PR TITLE
Improve behavior wrt errors during import

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -126,14 +126,16 @@ fn read_until_empty_line(input: &mut String) -> Result<i32, std::io::Error> {
         io::stdout().flush().expect("Could not flush stdout");
         let mut line = String::new();
         match io::stdin().read_line(&mut line) {
-            Ok(0) => {
-                return Ok(0);
-            }
-            Ok(1) => {
-                return Ok(1);
-            }
             Ok(_) => {
-                input.push_str(&line);
+                line = line
+                    .trim_right_matches(|c| c == '\r' || c == '\n')
+                    .to_string();
+                if line.len() == 0 {
+                    return Ok(0); // DOne
+                } else {
+                    input.push_str(&line);
+                    input.push_str("\n");
+                }
             }
             Err(msg) => {
                 return Err(msg);
@@ -167,9 +169,6 @@ fn run_shell() {
                     input = String::new();
                 } else {
                     match read_until_empty_line(&mut input) {
-                        Ok(0) => {
-                            break;
-                        }
                         Ok(_) => {
                             shell_exec(&mut vm, &input, vars.clone());
                         }

--- a/vm/src/builtins.rs
+++ b/vm/src/builtins.rs
@@ -110,10 +110,7 @@ fn builtin_compile(vm: &mut VirtualMachine, args: PyFuncArgs) -> PyResult {
     let mode = compile::Mode::Eval;
     let source = source.borrow().str();
 
-    match compile::compile(vm, &source, mode, None) {
-        Ok(value) => Ok(value),
-        Err(msg) => Err(vm.new_type_error(msg)),
-    }
+    compile::compile(vm, &source, mode, None)
 }
 
 // builtin_complex

--- a/vm/src/eval.rs
+++ b/vm/src/eval.rs
@@ -10,9 +10,7 @@ pub fn eval(vm: &mut VirtualMachine, source: &str, scope: PyObjectRef) -> PyResu
             debug!("Code object: {:?}", bytecode);
             vm.run_code_obj(bytecode, scope)
         }
-        Err(msg) => {
-            panic!("Parsing went horribly wrong: {}", msg);
-        }
+        Err(err) => Err(err),
     }
 }
 

--- a/vm/src/exceptions.rs
+++ b/vm/src/exceptions.rs
@@ -15,7 +15,7 @@ fn exception_init(vm: &mut VirtualMachine, args: PyFuncArgs) -> PyResult {
         vm.new_str("No msg".to_string())
     };
     let traceback = vm.ctx.new_list(Vec::new());
-    zelf.set_attr("__msg__", msg);
+    zelf.set_attr("msg", msg);
     zelf.set_attr("__traceback__", traceback);
     Ok(vm.get_none())
 }
@@ -71,7 +71,7 @@ fn exception_str(vm: &mut VirtualMachine, args: PyFuncArgs) -> PyResult {
         required = [(exc, Some(vm.ctx.exceptions.exception_type.clone()))]
     );
     let type_name = objtype::get_type_name(&exc.typ());
-    let msg = if let Some(m) = exc.get_attr("__msg__") {
+    let msg = if let Some(m) = exc.get_attr("msg") {
         objstr::get_value(&m)
     } else {
         panic!("Error message must be set");
@@ -84,6 +84,7 @@ fn exception_str(vm: &mut VirtualMachine, args: PyFuncArgs) -> PyResult {
 pub struct ExceptionZoo {
     pub base_exception_type: PyObjectRef,
     pub exception_type: PyObjectRef,
+    pub syntax_error: PyObjectRef,
     pub assertion_error: PyObjectRef,
     pub attribute_error: PyObjectRef,
     pub name_error: PyObjectRef,
@@ -92,6 +93,8 @@ pub struct ExceptionZoo {
     pub stop_iteration: PyObjectRef,
     pub type_error: PyObjectRef,
     pub value_error: PyObjectRef,
+    pub import_error: PyObjectRef,
+    pub module_not_found_error: PyObjectRef,
 }
 
 impl ExceptionZoo {
@@ -107,6 +110,12 @@ impl ExceptionZoo {
             &String::from("Exception"),
             &type_type,
             &base_exception_type,
+            &dict_type,
+        );
+        let syntax_error = create_type(
+            &String::from("SyntaxError"),
+            &type_type,
+            &exception_type,
             &dict_type,
         );
         let assertion_error = create_type(
@@ -157,10 +166,23 @@ impl ExceptionZoo {
             &exception_type,
             &dict_type,
         );
+        let import_error = create_type(
+            &String::from("ImportError"),
+            &type_type,
+            &exception_type,
+            &dict_type,
+        );
+        let module_not_found_error = create_type(
+            &String::from("ModuleNotFoundError"),
+            &type_type,
+            &import_error,
+            &dict_type,
+        );
 
         ExceptionZoo {
             base_exception_type: base_exception_type,
             exception_type: exception_type,
+            syntax_error: syntax_error,
             assertion_error: assertion_error,
             attribute_error: attribute_error,
             name_error: name_error,
@@ -169,6 +191,8 @@ impl ExceptionZoo {
             stop_iteration: stop_iteration,
             type_error: type_error,
             value_error: value_error,
+            import_error: import_error,
+            module_not_found_error: module_not_found_error,
         }
     }
 }

--- a/vm/src/lib.rs
+++ b/vm/src/lib.rs
@@ -20,7 +20,7 @@ pub mod eval;
 mod exceptions;
 mod frame;
 mod import;
-mod obj;
+pub mod obj;
 pub mod pyobject;
 pub mod stdlib;
 mod sysmodule;


### PR DESCRIPTION
* Raises `ModuleNotFoundError` when the module is not found.
* Raises `ImportError` when the module cannot be read. Rare case. Probably what CPython does.
* Raises `SyntaxError` when the file cannot be compiled.
* Raises whatever error when an exception is raised during executing the module's code.
* Fix multiline comments on Windows (was a `\r\n` thing).
* Keep collecting lines when an empty line is pressed but the code is still incomplete.
* Implemented using `sys.ps`, but stopped because modules dont have attributes yet.