### PR TITLE
Basic repl based on rustyline

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@
 __pycache__
 **/*.pytest_cache
 .*sw*
+.repl_history.txt

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,3 +11,4 @@ env_logger="0.5.10"
 clap = "2.31.2"
 rustpython_parser = {path = "parser"}
 rustpython_vm = {path = "vm"}
+rustyline = "2.1.0"

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Or use the interactive shell:
 
     $ cargo run
     Welcome to rustpython
-    >>>>> 2+2
+    >>> 2+2
     4
 
 <!-- Or use pip to install extra modules:


### PR DESCRIPTION
Hi. I am not really sure about the dependency politics for this project. Is it to depend on the less possible external dependencies, or is it ok to use something like [https://github.com/kkawakam/rustyline](rustyline)?

If rustyline is ok, then this PR brings a repl history, and navigation. Some further steps would be required to have an awesome repl, but it seems that rustyline natively offers some of them. An awesome repl would probably have:
- syntax highlighting for the code
- syntax highlighting for the tracebacks
- history stored in some XDG repository
- code completion

If that's ok for you, I can create issues for those features.

Also, I do not really know how to test a feature like this. Maybe send some input to the binary, and expect some output?