### PR TITLE
Push website to the master branch to simplify website development

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -69,6 +69,7 @@ matrix:
 deploy:
   provider: pages
   repo: RustPython/website
+  target-branch: master
   local-dir: target/doc
   skip-cleanup: true
   github-token: $WEBSITE_GITHUB_TOKEN  # Set in the settings page of your repository, as a secure variable


### PR DESCRIPTION
Once this is merged, let's change the "Source" in the RustPython/website repo from gh-pages to master branch