### PR TITLE
[WASM] Catch errors and show it in the standard output textarea

### DIFF
--- a/wasm/app/index.html
+++ b/wasm/app/index.html
@@ -19,7 +19,7 @@
       }
 
       #run-btn {
-        width: 4em;
+        width: 6em;
         height: 2em;
         font-size: 24px;
       }

--- a/wasm/app/index.js
+++ b/wasm/app/index.js
@@ -1,16 +1,26 @@
 import * as rp from "rustpython_wasm";
 
 function runCodeFromTextarea(_) {
+  const consoleElement = document.getElementById('console');
   // Clean the console
-  document.getElementById('console').value = '';
+  consoleElement.value = '';
 
   const code = document.getElementById('code').value;
-  if (!code.endsWith('\n')) { // HACK: if the code doesn't end with newline it crashes.
-    rp.run_code(code + '\n');
-    return;
+  try {
+    if (!code.endsWith('\n')) { // HACK: if the code doesn't end with newline it crashes.
+      rp.run_code(code + '\n');
+      return;
+    }
+
+    rp.run_code(code);
+
+  } catch(e) {
+    consoleElement.value = 'Execution failed. Please check if your Python code has any syntax error.';
+    console.error(e);
   }
-  rp.run_code(code);
+
 }
+
 document.getElementById('run-btn').addEventListener('click', runCodeFromTextarea);
 
 runCodeFromTextarea(); // Run once for demo


### PR DESCRIPTION
This only catches Rust panic. If the code raises a Python exception but the interpreter didn't crash, the error will not show up.
e.g. 
```
x = [1,2,3]
print(x[10]) # IndexError
```
The above code will not be captured. I'll create a followup issue to expose that to JavaScript.