### PR TITLE
Make `dict()` work like it does in cpython

### DIFF
--- a/tests/snippets/dict.py
+++ b/tests/snippets/dict.py
@@ -1,0 +1,16 @@
+def dict_eq(d1, d2):
+    return (all(k in d2 and d1[k] == d2[k] for k in d1)
+            and all(k in d1 and d1[k] == d2[k] for k in d2))
+
+
+assert dict_eq(dict(a=2, b=3), {'a': 2, 'b': 3})
+assert dict_eq(dict({'a': 2, 'b': 3}, b=4), {'a': 2, 'b': 4})
+assert dict_eq(dict([('a', 2), ('b', 3)]), {'a': 2, 'b': 3})
+
+a = {'g': 5}
+b = {'a': a, 'd': 9}
+c = dict(b)
+c['d'] = 3
+c['a']['g'] = 2
+assert dict_eq(a, {'g': 2})
+assert dict_eq(b, {'a': a, 'd': 9})

--- a/vm/src/obj/objdict.rs
+++ b/vm/src/obj/objdict.rs
@@ -113,8 +113,12 @@ pub fn content_contains_key_str(elements: &DictContentType, key: &str) -> bool {
 
 // Python dict methods:
 
-fn dict_new(_vm: &mut VirtualMachine, args: PyFuncArgs) -> PyResult {
-    Ok(new(args.args[0].clone()))
+fn dict_new(vm: &mut VirtualMachine, args: PyFuncArgs) -> PyResult {
+    let dict = new(args.args[0].clone());
+    for (needle, value) in args.kwargs {
+        set_item(&dict, &vm.new_str(needle), &value);
+    }
+    Ok(dict)
 }
 
 fn dict_len(vm: &mut VirtualMachine, args: PyFuncArgs) -> PyResult {


### PR DESCRIPTION
e.g.
```py
dict(a=2, b=3) == {'a': 2, 'b': 3}
dict({'a': 2, 'b': 3}, b=4) == {'a': 2, 'b': 4}
dict([('a', 2), ('b', 3)]) == {'a': 2, 'b': 3}
```