### PR TITLE
Change RustPyFunc from a fn pointer to a Fn trait

### DIFF
--- a/vm/src/frame.rs
+++ b/vm/src/frame.rs
@@ -560,7 +560,7 @@ impl Frame {
             bytecode::Instruction::LoadBuildClass => {
                 let rustfunc = PyObject::new(
                     PyObjectKind::RustFunction {
-                        function: builtins::builtin_build_class_,
+                        function: Box::new(builtins::builtin_build_class_),
                     },
                     vm.ctx.type_type(),
                 );

--- a/vm/src/pyobject.rs
+++ b/vm/src/pyobject.rs
@@ -452,9 +452,24 @@ impl PyContext {
         )
     }
 
-    pub fn new_rustfunc(&self, function: RustPyFunc) -> PyObjectRef {
+    pub fn new_rustfunc<F: 'static + Fn(&mut VirtualMachine, PyFuncArgs) -> PyResult>(
+        &self,
+        function: F,
+    ) -> PyObjectRef {
         PyObject::new(
-            PyObjectKind::RustFunction { function: function },
+            PyObjectKind::RustFunction {
+                function: Box::new(function),
+            },
+            self.function_type(),
+        )
+    }
+
+    pub fn new_rustfunc_from_box(
+        &self,
+        function: Box<Fn(&mut VirtualMachine, PyFuncArgs) -> PyResult>,
+    ) -> PyObjectRef {
+        PyObject::new(
+            PyObjectKind::RustFunction { function },
             self.function_type(),
         )
     }
@@ -463,7 +478,10 @@ impl PyContext {
         PyObject::new(PyObjectKind::Frame { frame: frame }, self.frame_type())
     }
 
-    pub fn new_property(&self, function: RustPyFunc) -> PyObjectRef {
+    pub fn new_property<F: 'static + Fn(&mut VirtualMachine, PyFuncArgs) -> PyResult>(
+        &self,
+        function: F,
+    ) -> PyObjectRef {
         let fget = self.new_rustfunc(function);
         let py_obj = PyObject::new(
             PyObjectKind::Instance {
@@ -505,7 +523,10 @@ impl PyContext {
         )
     }
 
-    pub fn new_member_descriptor(&self, function: RustPyFunc) -> PyObjectRef {
+    pub fn new_member_descriptor<F: 'static + Fn(&mut VirtualMachine, PyFuncArgs) -> PyResult>(
+        &self,
+        function: F,
+    ) -> PyObjectRef {
         let dict = self.new_dict();
         self.set_item(&dict, "function", self.new_rustfunc(function));
         self.new_instance(dict, self.member_descriptor_type())
@@ -772,8 +793,6 @@ impl PyFuncArgs {
     }
 }
 
-type RustPyFunc = fn(vm: &mut VirtualMachine, PyFuncArgs) -> PyResult;
-
 /// Rather than determining the type of a python object, this enum is more
 /// a holder for the rust payload of a python object. It is more a carrier
 /// of rust data for a particular python object. Determine the python type
@@ -850,7 +869,7 @@ pub enum PyObjectKind {
         dict: PyObjectRef,
     },
     RustFunction {
-        function: RustPyFunc,
+        function: Box<Fn(&mut VirtualMachine, PyFuncArgs) -> PyResult>,
     },
 }
 

--- a/vm/src/vm.rs
+++ b/vm/src/vm.rs
@@ -239,7 +239,7 @@ impl VirtualMachine {
     pub fn invoke(&mut self, func_ref: PyObjectRef, args: PyFuncArgs) -> PyResult {
         trace!("Invoke: {:?} {:?}", func_ref, args);
         match func_ref.borrow().kind {
-            PyObjectKind::RustFunction { function } => function(self, args),
+            PyObjectKind::RustFunction { ref function } => function(self, args),
             PyObjectKind::Function {
                 ref code,
                 ref scope,


### PR DESCRIPTION
This is a portion of #238, split off into its own PR. This allows for closures to be used as rustfuncs in addition to normal functions.