### PR TITLE
Limit the deployment only to the specific build job

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -69,6 +69,7 @@ matrix:
       if: branch = release
       env:
         - REGULAR_TEST=false
+        - DEPLOY_DOC=true
     - name: WASM online demo
       language: rust
       rust: nightly
@@ -84,6 +85,7 @@ matrix:
       if: branch = release
       env:
         - REGULAR_TEST=false
+        - DEPLOY_DEMO=true
   allow_failures:
     - rust: nightly
       env: REGULAR_TEST=true
@@ -99,6 +101,7 @@ deploy:
     keep-history: true
     on:
       branch: release
+      condition: $DEPLOY_DOC=true
   - provider: pages
     repo: RustPython/demo
     target-branch: master
@@ -109,3 +112,4 @@ deploy:
     keep-history: true
     on:
       branch: release
+      condition: $DEPLOY_DEMO=true


### PR DESCRIPTION
Now if you push to the `release` branch, the deployment will run on every test suite. So all of them fails. We only want `publish documentation` to deploy to `RustPython/docs` and `WASM online demo` to release to `RustPython/demo`. 

I can't seem to find a way to put the deployment as a post-build step for just one test suite, so I use this ugly environment variable to limit that. 

Also here is a sample of a failed build: https://travis-ci.org/RustPython/RustPython/builds/476271838