### PR TITLE
Fix travis deployment

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -69,6 +69,7 @@ matrix:
       if: branch = release
       env:
         - REGULAR_TEST=false
+        - DEPLOY_TO=doc
     - name: WASM online demo
       language: rust
       rust: nightly
@@ -84,6 +85,7 @@ matrix:
       if: branch = release
       env:
         - REGULAR_TEST=false
+        - DEPLOY_TO=wasm
   allow_failures:
     - rust: nightly
       env: REGULAR_TEST=true
@@ -99,6 +101,7 @@ deploy:
     keep-history: true
     on:
       branch: release
+      condition: $DEPLOY_TO = doc
   - provider: pages
     repo: RustPython/demo
     target-branch: master
@@ -109,3 +112,4 @@ deploy:
     keep-history: true
     on:
       branch: release
+      condition: $DEPLOY_TO = wasm


### PR DESCRIPTION
I'm pretty sure that the problem was it was trying to deploy on every CI instance, but not all the scripts built the wasm demo or the docs. This adds a `DEPLOY_TO` env variable that the deploy section checks through `env.condition: $DEPLOY_TO = x`, the `x` being `wasm` or `demo` as set in the matrix section that builds them.