### PR TITLE
Added list.index()

### DIFF
--- a/tests/snippets/list.py
+++ b/tests/snippets/list.py
@@ -11,3 +11,12 @@ assert y == [2, 1, 2, 3, 1, 2, 3]
 
 assert x * 0 == [], "list __mul__ by 0 failed"
 assert x * 2 == [1, 2, 3, 1, 2, 3], "list __mul__ by 2 failed"
+
+assert ['a', 'b', 'c'].index('b') == 1
+assert [5, 6, 7].index(7) == 2
+try:
+    ['a', 'b', 'c'].index('z')
+except ValueError:
+    pass
+else:
+    assert False, "ValueError was not raised"


### PR DESCRIPTION
Currently I use `fmt::Debug` in the `ValueError` message. So it will look like this:

`ValueError: '[PyObj str "x"]' is not in list`,

not like cpython: 

`ValueError: 'x' is not in list`. 

The `fmt::Display` only prints `'str' object`, so it's also not useful. I wonder if that's the expected behavior for our `Display` implementation, or should we print the value instead? If not maybe I need to build another trait for printing the value.

