### PR TITLE
Fix the deploy condition for missing spaces around equals sign

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -101,7 +101,7 @@ deploy:
     keep-history: true
     on:
       branch: release
-      condition: $DEPLOY_DOC=true
+      condition: $DEPLOY_DOC = true
   - provider: pages
     repo: RustPython/demo
     target-branch: master
@@ -112,4 +112,4 @@ deploy:
     keep-history: true
     on:
       branch: release
-      condition: $DEPLOY_DEMO=true
+      condition: $DEPLOY_DEMO = true


### PR DESCRIPTION
I was stupid to forgot to add spaces around the equals signs in the previous PR #250 .

Clearly if you do `$FOO=true`, it is always evaluated as true in bash's `if [[ ... ]]` condition. ([Reference](https://stackoverflow.com/questions/4977367/why-equal-to-operator-does-not-work-if-it-is-not-surrounded-by-space))

I tested in a branch and now it seems to skip the deployment step properly: https://travis-ci.org/RustPython/RustPython/builds/478033185