### PR TITLE
Remove unnecessary to_string conversions

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -60,7 +60,7 @@ fn main() {
         // Figure out if a script was passed:
         match matches.value_of("script") {
             None => run_shell(&mut vm),
-            Some(filename) => run_script(&mut vm, &filename.to_string()),
+            Some(filename) => run_script(&mut vm, filename),
         }
     };
 
@@ -69,7 +69,7 @@ fn main() {
 }
 
 fn _run_string(vm: &mut VirtualMachine, source: &str, source_path: Option<String>) -> PyResult {
-    let code_obj = compile::compile(vm, &source.to_string(), compile::Mode::Exec, source_path)?;
+    let code_obj = compile::compile(vm, source, compile::Mode::Exec, source_path)?;
     // trace!("Code object: {:?}", code_obj.borrow());
     let builtins = vm.get_builtin_scope();
     let vars = vm.context().new_scope(Some(builtins)); // Keep track of local variables
@@ -114,7 +114,7 @@ fn run_script(vm: &mut VirtualMachine, script_file: &str) -> PyResult {
 }
 
 fn shell_exec(vm: &mut VirtualMachine, source: &str, scope: PyObjectRef) -> bool {
-    match compile::compile(vm, &source.to_string(), compile::Mode::Single, None) {
+    match compile::compile(vm, source, compile::Mode::Single, None) {
         Ok(code) => {
             match vm.run_code_obj(code, scope) {
                 Ok(_value) => {

--- a/vm/src/builtins.rs
+++ b/vm/src/builtins.rs
@@ -405,8 +405,8 @@ fn builtin_iter(vm: &mut VirtualMachine, args: PyFuncArgs) -> PyResult {
 
 fn builtin_len(vm: &mut VirtualMachine, args: PyFuncArgs) -> PyResult {
     arg_check!(vm, args, required = [(obj, None)]);
-    let len_method_name = "__len__".to_string();
-    match vm.get_method(obj.clone(), &len_method_name) {
+    let len_method_name = "__len__";
+    match vm.get_method(obj.clone(), len_method_name) {
         Ok(value) => vm.invoke(value, PyFuncArgs::default()),
         Err(..) => Err(vm.new_type_error(format!(
             "object of type '{}' has no method {:?}",
@@ -616,8 +616,8 @@ fn builtin_pow(vm: &mut VirtualMachine, args: PyFuncArgs) -> PyResult {
         required = [(x, None), (y, None)],
         optional = [(mod_value, Some(vm.ctx.int_type()))]
     );
-    let pow_method_name = "__pow__".to_string();
-    let result = match vm.get_method(x.clone(), &pow_method_name) {
+    let pow_method_name = "__pow__";
+    let result = match vm.get_method(x.clone(), pow_method_name) {
         Ok(attrib) => vm.invoke(attrib, PyFuncArgs::new(vec![y.clone()], vec![])),
         Err(..) => Err(vm.new_type_error("unsupported operand type(s) for pow".to_string())),
     };
@@ -626,11 +626,8 @@ fn builtin_pow(vm: &mut VirtualMachine, args: PyFuncArgs) -> PyResult {
     //order to improve performance
     match mod_value {
         Some(mod_value) => {
-            let mod_method_name = "__mod__".to_string();
-            match vm.get_method(
-                result.expect("result not defined").clone(),
-                &mod_method_name,
-            ) {
+            let mod_method_name = "__mod__";
+            match vm.get_method(result.expect("result not defined").clone(), mod_method_name) {
                 Ok(value) => vm.invoke(value, PyFuncArgs::new(vec![mod_value.clone()], vec![])),
                 Err(..) => {
                     Err(vm.new_type_error("unsupported operand type(s) for mod".to_string()))
@@ -731,8 +728,8 @@ fn builtin_zip(vm: &mut VirtualMachine, args: PyFuncArgs) -> PyResult {
 // builtin___import__
 
 pub fn make_module(ctx: &PyContext) -> PyObjectRef {
-    let mod_name = "__builtins__".to_string();
-    let py_mod = ctx.new_module(&mod_name, ctx.new_scope(None));
+    let mod_name = "__builtins__";
+    let py_mod = ctx.new_module(mod_name, ctx.new_scope(None));
 
     //set __name__ fixes: https://github.com/RustPython/RustPython/issues/146
     ctx.set_attr(&py_mod, "__name__", ctx.new_str(String::from("__main__")));

--- a/vm/src/frame.rs
+++ b/vm/src/frame.rs
@@ -671,7 +671,7 @@ impl Frame {
             None => PathBuf::from("."),
         };
 
-        let obj = import(vm, current_path, &module.to_string(), symbol)?;
+        let obj = import(vm, current_path, module, symbol)?;
 
         // Push module on stack:
         self.push_value(obj);

--- a/vm/src/obj/objstr.rs
+++ b/vm/src/obj/objstr.rs
@@ -352,7 +352,7 @@ fn str_capitalize(vm: &mut VirtualMachine, args: PyFuncArgs) -> PyResult {
     arg_check!(vm, args, required = [(s, Some(vm.ctx.str_type()))]);
     let value = get_value(&s);
     let (first_part, lower_str) = value.split_at(1);
-    let capitalized = format!("{}{}", first_part.to_uppercase().to_string(), lower_str);
+    let capitalized = format!("{}{}", first_part.to_uppercase(), lower_str);
     Ok(vm.ctx.new_str(capitalized))
 }
 

--- a/vm/src/stdlib/ast.rs
+++ b/vm/src/stdlib/ast.rs
@@ -610,24 +610,20 @@ fn ast_parse(vm: &mut VirtualMachine, args: PyFuncArgs) -> PyResult {
 }
 
 pub fn mk_module(ctx: &PyContext) -> PyObjectRef {
-    let ast_mod = ctx.new_module(&"ast".to_string(), ctx.new_scope(None));
+    let ast_mod = ctx.new_module("ast", ctx.new_scope(None));
     ctx.set_attr(&ast_mod, "parse", ctx.new_rustfunc(ast_parse));
     ctx.set_attr(
         &ast_mod,
         "Module",
-        ctx.new_class(&"_ast.Module".to_string(), ctx.object()),
+        ctx.new_class("_ast.Module", ctx.object()),
     );
 
     // TODO: maybe we can use some clever macro to generate this?
     ctx.set_attr(
         &ast_mod,
         "FunctionDef",
-        ctx.new_class(&"_ast.FunctionDef".to_string(), ctx.object()),
+        ctx.new_class("_ast.FunctionDef", ctx.object()),
     );
-    ctx.set_attr(
-        &ast_mod,
-        "Call",
-        ctx.new_class(&"_ast.Call".to_string(), ctx.object()),
-    );
+    ctx.set_attr(&ast_mod, "Call", ctx.new_class("_ast.Call", ctx.object()));
     ast_mod
 }

--- a/vm/src/stdlib/json.rs
+++ b/vm/src/stdlib/json.rs
@@ -232,7 +232,7 @@ fn loads(vm: &mut VirtualMachine, args: PyFuncArgs) -> PyResult {
 }
 
 pub fn mk_module(ctx: &PyContext) -> PyObjectRef {
-    let json_mod = ctx.new_module(&"json".to_string(), ctx.new_scope(None));
+    let json_mod = ctx.new_module("json", ctx.new_scope(None));
     ctx.set_attr(&json_mod, "dumps", ctx.new_rustfunc(dumps));
     ctx.set_attr(&json_mod, "loads", ctx.new_rustfunc(loads));
     // TODO: Make this a proper type with a constructor

--- a/vm/src/stdlib/keyword.rs
+++ b/vm/src/stdlib/keyword.rs
@@ -18,7 +18,7 @@ fn keyword_iskeyword(vm: &mut VirtualMachine, args: PyFuncArgs) -> PyResult {
 }
 
 pub fn mk_module(ctx: &PyContext) -> PyObjectRef {
-    let py_mod = ctx.new_module(&"keyword".to_string(), ctx.new_scope(None));
+    let py_mod = ctx.new_module("keyword", ctx.new_scope(None));
     ctx.set_attr(&py_mod, "iskeyword", ctx.new_rustfunc(keyword_iskeyword));
     let keyword_kwlist = ctx.new_list(
         lexer::get_keywords()

--- a/vm/src/stdlib/re.rs
+++ b/vm/src/stdlib/re.rs
@@ -50,8 +50,8 @@ fn re_search(vm: &mut VirtualMachine, args: PyFuncArgs) -> PyResult {
 }
 
 pub fn mk_module(ctx: &PyContext) -> PyObjectRef {
-    let py_mod = ctx.new_module(&"re".to_string(), ctx.new_scope(None));
-    let match_type = ctx.new_class(&"Match".to_string(), ctx.object());
+    let py_mod = ctx.new_module("re", ctx.new_scope(None));
+    let match_type = ctx.new_class("Match", ctx.object());
     ctx.set_attr(&py_mod, "Match", match_type);
     ctx.set_attr(&py_mod, "match", ctx.new_rustfunc(re_match));
     ctx.set_attr(&py_mod, "search", ctx.new_rustfunc(re_search));

--- a/vm/src/stdlib/string.rs
+++ b/vm/src/stdlib/string.rs
@@ -21,23 +21,15 @@ pub fn mk_module(ctx: &PyContext) -> PyObjectRef {
     */
 
     // Constants:
-    ctx.set_attr(&py_mod, "ascii_letters", ctx.new_str(ascii_letters.clone()));
-    ctx.set_attr(
-        &py_mod,
-        "ascii_lowercase",
-        ctx.new_str(ascii_lowercase.clone()),
-    );
-    ctx.set_attr(
-        &py_mod,
-        "ascii_uppercase",
-        ctx.new_str(ascii_uppercase.clone()),
-    );
-    ctx.set_attr(&py_mod, "digits", ctx.new_str(digits.clone()));
-    ctx.set_attr(&py_mod, "hexdigits", ctx.new_str(hexdigits.clone()));
-    ctx.set_attr(&py_mod, "octdigits", ctx.new_str(octdigits.clone()));
-    // ctx.set_attr(&py_mod, "printable", ctx.new_str(printable.clone()));
-    ctx.set_attr(&py_mod, "punctuation", ctx.new_str(punctuation.clone()));
-    // ctx.set_attr(&py_mod, "whitespace", ctx.new_str(whitespace.clone()));
+    ctx.set_attr(&py_mod, "ascii_letters", ctx.new_str(ascii_letters));
+    ctx.set_attr(&py_mod, "ascii_lowercase", ctx.new_str(ascii_lowercase));
+    ctx.set_attr(&py_mod, "ascii_uppercase", ctx.new_str(ascii_uppercase));
+    ctx.set_attr(&py_mod, "digits", ctx.new_str(digits));
+    ctx.set_attr(&py_mod, "hexdigits", ctx.new_str(hexdigits));
+    ctx.set_attr(&py_mod, "octdigits", ctx.new_str(octdigits));
+    // ctx.set_attr(&py_mod, "printable", ctx.new_str(printable));
+    ctx.set_attr(&py_mod, "punctuation", ctx.new_str(punctuation));
+    // ctx.set_attr(&py_mod, "whitespace", ctx.new_str(whitespace));
 
     py_mod
 }

--- a/vm/src/stdlib/time_module.rs
+++ b/vm/src/stdlib/time_module.rs
@@ -31,7 +31,7 @@ fn time_time(vm: &mut VirtualMachine, args: PyFuncArgs) -> PyResult {
 }
 
 pub fn mk_module(ctx: &PyContext) -> PyObjectRef {
-    let py_mod = ctx.new_module(&"time".to_string(), ctx.new_scope(None));
+    let py_mod = ctx.new_module("time", ctx.new_scope(None));
     ctx.set_attr(&py_mod, "sleep", ctx.new_rustfunc(time_sleep));
     ctx.set_attr(&py_mod, "time", ctx.new_rustfunc(time_time));
     py_mod

--- a/vm/src/stdlib/tokenize.rs
+++ b/vm/src/stdlib/tokenize.rs
@@ -26,7 +26,7 @@ fn tokenize_tokenize(vm: &mut VirtualMachine, args: PyFuncArgs) -> PyResult {
 // TODO: create main function when called with -m
 
 pub fn mk_module(ctx: &PyContext) -> PyObjectRef {
-    let py_mod = ctx.new_module(&"tokenize".to_string(), ctx.new_scope(None));
+    let py_mod = ctx.new_module("tokenize", ctx.new_scope(None));
 
     // Number theory functions:
     ctx.set_item(&py_mod, "tokenize", ctx.new_rustfunc(tokenize_tokenize));

--- a/vm/src/stdlib/types.rs
+++ b/vm/src/stdlib/types.rs
@@ -32,7 +32,7 @@ fn types_new_class(vm: &mut VirtualMachine, args: PyFuncArgs) -> PyResult {
 }
 
 pub fn mk_module(ctx: &PyContext) -> PyObjectRef {
-    let py_mod = ctx.new_module(&"types".to_string(), ctx.new_scope(None));
+    let py_mod = ctx.new_module("types", ctx.new_scope(None));
 
     // Number theory functions:
     ctx.set_attr(&py_mod, "new_class", ctx.new_rustfunc(types_new_class));

--- a/vm/src/stdlib/weakref.rs
+++ b/vm/src/stdlib/weakref.rs
@@ -14,7 +14,7 @@ use super::super::VirtualMachine;
 use std::rc::Rc;
 
 pub fn mk_module(ctx: &PyContext) -> PyObjectRef {
-    let py_mod = ctx.new_module(&"_weakref".to_string(), ctx.new_scope(None));
+    let py_mod = ctx.new_module("_weakref", ctx.new_scope(None));
 
     let py_ref_class = ctx.new_class("ref", ctx.object());
     ctx.set_attr(&py_ref_class, "__new__", ctx.new_rustfunc(ref_new));

--- a/vm/src/sysmodule.rs
+++ b/vm/src/sysmodule.rs
@@ -45,9 +45,9 @@ pub fn mk_module(ctx: &PyContext) -> PyObjectRef {
     };
     let path = ctx.new_list(path_list);
     let modules = ctx.new_dict();
-    let sys_name = "sys".to_string();
+    let sys_name = "sys";
     let sys_mod = ctx.new_module(&sys_name, ctx.new_scope(None));
-    ctx.set_item(&modules, &sys_name, sys_mod.clone());
+    ctx.set_item(&modules, sys_name, sys_mod.clone());
     ctx.set_item(&sys_mod, "modules", modules);
     ctx.set_item(&sys_mod, "argv", argv(ctx));
     ctx.set_item(&sys_mod, "getrefcount", ctx.new_rustfunc(sys_getrefcount));


### PR DESCRIPTION
This'll especially be useful in `main.rs`, which was cloning the entire source of the file it loaded :smiley: 