### PR TITLE
File-IO: IO Module and Open Builtin

### DIFF
--- a/tests/snippets/buffered_reader.py
+++ b/tests/snippets/buffered_reader.py
@@ -1,10 +1,10 @@
 from io import BufferedReader, FileIO
 
-fi = FileIO('Cargo.toml')
+fi = FileIO('README.md')
 bb = BufferedReader(fi)
 
 result = bb.read()
 
 assert len(result) <= 8*1024
 assert len(result) >= 0
-
+assert isinstance(result, bytes)

--- a/tests/snippets/buffered_reader.py
+++ b/tests/snippets/buffered_reader.py
@@ -1,0 +1,10 @@
+from io import BufferedReader, FileIO
+
+fi = FileIO('Cargo.toml')
+bb = BufferedReader(fi)
+
+result = bb.read()
+
+assert len(result) <= 8*1024
+assert len(result) >= 0
+

--- a/tests/snippets/builtin_open.py
+++ b/tests/snippets/builtin_open.py
@@ -1,9 +1,0 @@
-c1 = open('README.md').read()
-
-assert isinstance(c1, str)
-assert 0 < len(c1)
-
-c2 = open('README.md', 'rb').read()
-
-assert isinstance(c2, bytes)
-assert 0 < len(c2)

--- a/tests/snippets/builtin_open.py
+++ b/tests/snippets/builtin_open.py
@@ -1,0 +1,9 @@
+c1 = open('README.md').read()
+
+assert isinstance(c1, str)
+assert 0 < len(c1)
+
+c2 = open('README.md', 'rb').read()
+
+assert isinstance(c2, bytes)
+assert 0 < len(c2)

--- a/tests/snippets/os_open.py
+++ b/tests/snippets/os_open.py
@@ -1,4 +1,4 @@
 import os 
 
-assert os.open('README.md') > 0
+assert os.open('README.md', 0) > 0
 

--- a/tests/snippets/os_open.py
+++ b/tests/snippets/os_open.py
@@ -1,0 +1,4 @@
+import os 
+
+assert os.open('README.md') > 0
+

--- a/tests/snippets/os_static.py
+++ b/tests/snippets/os_static.py
@@ -3,6 +3,6 @@ import os
 assert os.O_RDONLY == 0
 assert os.O_WRONLY == 1
 assert os.O_RDWR == 2
-assert os.O_NONBLOCK == 3
+assert os.O_NONBLOCK == 4
 assert os.O_APPEND == 8
 assert os.O_CREAT == 512

--- a/tests/snippets/os_static.py
+++ b/tests/snippets/os_static.py
@@ -3,5 +3,3 @@ import os
 assert os.O_RDONLY == 0
 assert os.O_WRONLY == 1
 assert os.O_RDWR == 2
-assert os.O_APPEND == 8
-assert os.O_CREAT == 512

--- a/tests/snippets/os_static.py
+++ b/tests/snippets/os_static.py
@@ -1,0 +1,8 @@
+import os 
+
+assert os.O_RDONLY == 0
+assert os.O_WRONLY == 1
+assert os.O_RDWR == 2
+assert os.O_NONBLOCK == 3
+assert os.O_APPEND == 8
+assert os.O_CREAT == 512

--- a/tests/snippets/os_static.py
+++ b/tests/snippets/os_static.py
@@ -3,6 +3,5 @@ import os
 assert os.O_RDONLY == 0
 assert os.O_WRONLY == 1
 assert os.O_RDWR == 2
-assert os.O_NONBLOCK == 4
 assert os.O_APPEND == 8
 assert os.O_CREAT == 512

--- a/vm/src/builtins.rs
+++ b/vm/src/builtins.rs
@@ -499,8 +499,6 @@ fn builtin_max(vm: &mut VirtualMachine, args: PyFuncArgs) -> PyResult {
     Ok(x)
 }
 
-// builtin_memoryview
-
 fn builtin_min(vm: &mut VirtualMachine, args: PyFuncArgs) -> PyResult {
     let candidates = if args.args.len() > 1 {
         args.args.clone()
@@ -774,6 +772,7 @@ pub fn make_module(ctx: &PyContext) -> PyObjectRef {
     ctx.set_attr(&py_mod, "locals", ctx.new_rustfunc(builtin_locals));
     ctx.set_attr(&py_mod, "map", ctx.new_rustfunc(builtin_map));
     ctx.set_attr(&py_mod, "max", ctx.new_rustfunc(builtin_max));
+    ctx.set_attr(&py_mod, "memoryview", ctx.memoryview_type());
     ctx.set_attr(&py_mod, "min", ctx.new_rustfunc(builtin_min));
     ctx.set_attr(&py_mod, "object", ctx.object());
     ctx.set_attr(&py_mod, "oct", ctx.new_rustfunc(builtin_oct));

--- a/vm/src/builtins.rs
+++ b/vm/src/builtins.rs
@@ -242,7 +242,8 @@ fn builtin_eval(vm: &mut VirtualMachine, args: PyFuncArgs) -> PyResult {
     let scope = PyObject {
         kind: PyObjectKind::Scope { scope: scope_inner },
         typ: None,
-    }.into_ref();
+    }
+    .into_ref();
 
     // Run the source:
     vm.run_code_obj(code_obj.clone(), scope)
@@ -289,7 +290,8 @@ fn builtin_exec(vm: &mut VirtualMachine, args: PyFuncArgs) -> PyResult {
     let scope = PyObject {
         kind: PyObjectKind::Scope { scope: scope_inner },
         typ: None,
-    }.into_ref();
+    }
+    .into_ref();
 
     // Run the code:
     vm.run_code_obj(code_obj, scope)

--- a/vm/src/builtins.rs
+++ b/vm/src/builtins.rs
@@ -13,10 +13,13 @@ use super::obj::objint;
 use super::obj::objiter;
 use super::obj::objstr;
 use super::obj::objtype;
+
+use super::stdlib::io::io_open;
 use super::pyobject::{
     AttributeProtocol, IdProtocol, PyContext, PyFuncArgs, PyObject, PyObjectKind, PyObjectRef,
-    PyResult, Scope, TypeProtocol,
+    PyResult, Scope, TypeProtocol
 };
+
 use super::vm::VirtualMachine;
 use num_bigint::ToBigInt;
 use num_traits::{Signed, ToPrimitive, Zero};
@@ -585,8 +588,6 @@ fn builtin_oct(vm: &mut VirtualMachine, args: PyFuncArgs) -> PyResult {
     Ok(vm.new_str(s))
 }
 
-// builtin_open
-
 fn builtin_ord(vm: &mut VirtualMachine, args: PyFuncArgs) -> PyResult {
     arg_check!(vm, args, required = [(string, Some(vm.ctx.str_type()))]);
     let string = objstr::get_value(string);
@@ -776,6 +777,7 @@ pub fn make_module(ctx: &PyContext) -> PyObjectRef {
     ctx.set_attr(&py_mod, "min", ctx.new_rustfunc(builtin_min));
     ctx.set_attr(&py_mod, "object", ctx.object());
     ctx.set_attr(&py_mod, "oct", ctx.new_rustfunc(builtin_oct));
+    ctx.set_attr(&py_mod, "open", ctx.new_rustfunc(io_open));
     ctx.set_attr(&py_mod, "ord", ctx.new_rustfunc(builtin_ord));
     ctx.set_attr(&py_mod, "next", ctx.new_rustfunc(builtin_next));
     ctx.set_attr(&py_mod, "pow", ctx.new_rustfunc(builtin_pow));

--- a/vm/src/builtins.rs
+++ b/vm/src/builtins.rs
@@ -14,11 +14,11 @@ use super::obj::objiter;
 use super::obj::objstr;
 use super::obj::objtype;
 
-use super::stdlib::io::io_open;
 use super::pyobject::{
     AttributeProtocol, IdProtocol, PyContext, PyFuncArgs, PyObject, PyObjectKind, PyObjectRef,
-    PyResult, Scope, TypeProtocol
+    PyResult, Scope, TypeProtocol,
 };
+use super::stdlib::io::io_open;
 
 use super::vm::VirtualMachine;
 use num_bigint::ToBigInt;
@@ -242,8 +242,7 @@ fn builtin_eval(vm: &mut VirtualMachine, args: PyFuncArgs) -> PyResult {
     let scope = PyObject {
         kind: PyObjectKind::Scope { scope: scope_inner },
         typ: None,
-    }
-    .into_ref();
+    }.into_ref();
 
     // Run the source:
     vm.run_code_obj(code_obj.clone(), scope)
@@ -290,8 +289,7 @@ fn builtin_exec(vm: &mut VirtualMachine, args: PyFuncArgs) -> PyResult {
     let scope = PyObject {
         kind: PyObjectKind::Scope { scope: scope_inner },
         typ: None,
-    }
-    .into_ref();
+    }.into_ref();
 
     // Run the code:
     vm.run_code_obj(code_obj, scope)

--- a/vm/src/obj/mod.rs
+++ b/vm/src/obj/mod.rs
@@ -13,6 +13,7 @@ pub mod objgenerator;
 pub mod objint;
 pub mod objiter;
 pub mod objlist;
+pub mod objmemory;
 pub mod objobject;
 pub mod objproperty;
 pub mod objsequence;

--- a/vm/src/obj/objbytearray.rs
+++ b/vm/src/obj/objbytearray.rs
@@ -28,6 +28,11 @@ pub fn init(context: &PyContext) {
         "__repr__",
         context.new_rustfunc(bytearray_repr),
     );
+    context.set_attr(
+        &bytearray_type,
+        "__len__",
+        context.new_rustfunc(bytearray_type),
+    );
 }
 
 fn bytearray_new(vm: &mut VirtualMachine, args: PyFuncArgs) -> PyResult {
@@ -60,6 +65,18 @@ fn bytearray_new(vm: &mut VirtualMachine, args: PyFuncArgs) -> PyResult {
         cls.clone(),
     ))
 }
+
+fn bytesarray_len(vm: &mut VirtualMachine, args: PyFuncArgs) -> PyResult {
+    arg_check!(
+        vm,
+        args,
+        required = [(a, Some(vm.ctx.bytearray_type()))]
+    );
+
+    let byte_vec = get_value(a).to_vec();
+    Ok(vm.ctx.new_int(byte_vec.len()))
+}
+
 
 fn bytearray_eq(vm: &mut VirtualMachine, args: PyFuncArgs) -> PyResult {
     arg_check!(

--- a/vm/src/obj/objbytearray.rs
+++ b/vm/src/obj/objbytearray.rs
@@ -7,13 +7,10 @@ use super::super::pyobject::{
 use super::objint;
 
 use super::super::vm::VirtualMachine;
-// use super::objbytes::get_value;
+use super::objbytes::get_value;
 use super::objtype;
 use num_bigint::ToBigInt;
 use num_traits::ToPrimitive;
-
-use std::cell::Ref;
-use std::ops::Deref;
 
 // Binary data support
 
@@ -67,7 +64,7 @@ fn bytearray_new(vm: &mut VirtualMachine, args: PyFuncArgs) -> PyResult {
         vec![]
     };
     Ok(PyObject::new(
-        PyObjectKind::ByteArray { value: value },
+        PyObjectKind::Bytes { value: value },
         cls.clone(),
     ))
 }
@@ -95,15 +92,6 @@ fn bytearray_eq(vm: &mut VirtualMachine, args: PyFuncArgs) -> PyResult {
     Ok(vm.ctx.new_bool(result))
 }
 
-pub fn get_value<'a>(obj: &'a PyObjectRef) -> impl Deref<Target = Vec<u8>> + 'a {
-    Ref::map(obj.borrow(), |py_obj| {
-        if let PyObjectKind::ByteArray { ref value } = py_obj.kind {
-            value
-        } else {
-            panic!("Inner error getting int {:?}", obj);
-        }
-    })
-}
 /*
 fn bytearray_getitem(vm: &mut VirtualMachine, args: PyFuncArgs) -> PyResult {
     arg_check!(

--- a/vm/src/obj/objbytearray.rs
+++ b/vm/src/obj/objbytearray.rs
@@ -3,12 +3,14 @@
 use super::super::pyobject::{
     PyContext, PyFuncArgs, PyObject, PyObjectKind, PyObjectRef, PyResult, TypeProtocol,
 };
+
+use super::objint;
+
 use super::super::vm::VirtualMachine;
 use super::objbytes::get_value;
-use super::objint;
 use super::objtype;
 use num_traits::ToPrimitive;
-use num_bigint::{BigInt, ToBigInt};
+use num_bigint::{ToBigInt};
 
 // Binary data support
 

--- a/vm/src/obj/objbytearray.rs
+++ b/vm/src/obj/objbytearray.rs
@@ -8,6 +8,8 @@ use super::objbytes::get_value;
 use super::objint;
 use super::objtype;
 use num_traits::ToPrimitive;
+use num_bigint::{BigInt, ToBigInt};
+
 // Binary data support
 
 /// Fill bytearray class methods dictionary.
@@ -31,7 +33,7 @@ pub fn init(context: &PyContext) {
     context.set_attr(
         &bytearray_type,
         "__len__",
-        context.new_rustfunc(bytearray_type),
+        context.new_rustfunc(bytesarray_len),
     );
 }
 
@@ -74,7 +76,8 @@ fn bytesarray_len(vm: &mut VirtualMachine, args: PyFuncArgs) -> PyResult {
     );
 
     let byte_vec = get_value(a).to_vec();
-    Ok(vm.ctx.new_int(byte_vec.len()))
+    let value = byte_vec.len().to_bigint();
+    Ok(vm.ctx.new_int(value.unwrap()))
 }
 
 
@@ -112,8 +115,7 @@ fn set_value(obj: &PyObjectRef, value: Vec<u8>) {
 
 fn bytearray_repr(vm: &mut VirtualMachine, args: PyFuncArgs) -> PyResult {
     arg_check!(vm, args, required = [(obj, Some(vm.ctx.bytearray_type()))]);
-    let data = get_value(obj);
-    let data: Vec<String> = data.iter().map(|b| format!("\\x{:02x}", b)).collect();
-    let data = data.join("");
+    let value = get_value(obj);
+    let data = String::from_utf8(value.to_vec()).unwrap();
     Ok(vm.new_str(format!("bytearray(b'{}')", data)))
 }

--- a/vm/src/obj/objbytes.rs
+++ b/vm/src/obj/objbytes.rs
@@ -20,7 +20,6 @@ pub fn init(context: &PyContext) {
     context.set_attr(bytes_type, "__new__", context.new_rustfunc(bytes_new));
     context.set_attr(bytes_type, "__repr__", context.new_rustfunc(bytes_repr));
     context.set_attr(bytes_type, "__len__", context.new_rustfunc(bytes_len));
-
 }
 
 fn bytes_new(vm: &mut VirtualMachine, args: PyFuncArgs) -> PyResult {
@@ -70,17 +69,12 @@ fn bytes_eq(vm: &mut VirtualMachine, args: PyFuncArgs) -> PyResult {
 }
 
 fn bytes_len(vm: &mut VirtualMachine, args: PyFuncArgs) -> PyResult {
-    arg_check!(
-        vm,
-        args,
-        required = [(a, Some(vm.ctx.bytes_type()))]
-    );
+    arg_check!(vm, args, required = [(a, Some(vm.ctx.bytes_type()))]);
 
     let byte_vec = get_value(a).to_vec();
     let value = byte_vec.len().to_bigint();
     Ok(vm.ctx.new_int(value.unwrap()))
 }
-
 
 fn bytes_hash(vm: &mut VirtualMachine, args: PyFuncArgs) -> PyResult {
     arg_check!(vm, args, required = [(zelf, Some(vm.ctx.bytes_type()))]);

--- a/vm/src/obj/objbytes.rs
+++ b/vm/src/obj/objbytes.rs
@@ -9,6 +9,7 @@ use num_traits::ToPrimitive;
 use std::cell::Ref;
 use std::hash::{Hash, Hasher};
 use std::ops::Deref;
+
 // Binary data support
 
 // Fill bytes class methods:
@@ -76,7 +77,8 @@ fn bytes_len(vm: &mut VirtualMachine, args: PyFuncArgs) -> PyResult {
     );
 
     let byte_vec = get_value(a).to_vec();
-    Ok(vm.ctx.new_int(byte_vec.len()))
+    let value = byte_vec.len().to_bigint();
+    Ok(vm.ctx.new_int(value.unwrap()))
 }
 
 

--- a/vm/src/obj/objbytes.rs
+++ b/vm/src/obj/objbytes.rs
@@ -18,6 +18,8 @@ pub fn init(context: &PyContext) {
     context.set_attr(bytes_type, "__hash__", context.new_rustfunc(bytes_hash));
     context.set_attr(bytes_type, "__new__", context.new_rustfunc(bytes_new));
     context.set_attr(bytes_type, "__repr__", context.new_rustfunc(bytes_repr));
+    context.set_attr(bytes_type, "__len__", context.new_rustfunc(bytes_len));
+
 }
 
 fn bytes_new(vm: &mut VirtualMachine, args: PyFuncArgs) -> PyResult {
@@ -66,6 +68,18 @@ fn bytes_eq(vm: &mut VirtualMachine, args: PyFuncArgs) -> PyResult {
     Ok(vm.ctx.new_bool(result))
 }
 
+fn bytes_len(vm: &mut VirtualMachine, args: PyFuncArgs) -> PyResult {
+    arg_check!(
+        vm,
+        args,
+        required = [(a, Some(vm.ctx.bytes_type()))]
+    );
+
+    let byte_vec = get_value(a).to_vec();
+    Ok(vm.ctx.new_int(byte_vec.len()))
+}
+
+
 fn bytes_hash(vm: &mut VirtualMachine, args: PyFuncArgs) -> PyResult {
     arg_check!(vm, args, required = [(zelf, Some(vm.ctx.bytes_type()))]);
     let data = get_value(zelf);
@@ -87,8 +101,7 @@ pub fn get_value<'a>(obj: &'a PyObjectRef) -> impl Deref<Target = Vec<u8>> + 'a 
 
 fn bytes_repr(vm: &mut VirtualMachine, args: PyFuncArgs) -> PyResult {
     arg_check!(vm, args, required = [(obj, Some(vm.ctx.bytes_type()))]);
-    let data = get_value(obj);
-    let data: Vec<String> = data.iter().map(|b| format!("\\x{:02x}", b)).collect();
-    let data = data.join("");
+    let value = get_value(obj);
+    let data = String::from_utf8(value.to_vec()).unwrap();
     Ok(vm.new_str(format!("b'{}'", data)))
 }

--- a/vm/src/obj/objmemory.rs
+++ b/vm/src/obj/objmemory.rs
@@ -1,27 +1,26 @@
-
 use super::objtype;
 
 use super::super::pyobject::{
-    PyContext, PyFuncArgs, PyObject, PyObjectKind, PyObjectRef, PyResult, TypeProtocol
+    PyContext, PyFuncArgs, PyObject, PyObjectKind, PyObjectRef, PyResult, TypeProtocol,
 };
 use super::super::vm::VirtualMachine;
 
-
 pub fn new_memory_view(vm: &mut VirtualMachine, args: PyFuncArgs) -> PyResult {
-    arg_check!(
-        vm,
-        args,
-        required = [(cls, None), (bytes_object, None)]
-    );
+    arg_check!(vm, args, required = [(cls, None), (bytes_object, None)]);
     vm.ctx.set_attr(&cls, "obj", bytes_object.clone());
     Ok(PyObject::new(
-        PyObjectKind::MemoryView { obj: bytes_object.clone() },
-        cls.clone()
+        PyObjectKind::MemoryView {
+            obj: bytes_object.clone(),
+        },
+        cls.clone(),
     ))
-
 }
 
 pub fn init(ctx: &PyContext) {
     let ref memoryview_type = ctx.memoryview_type;
-    ctx.set_attr(&memoryview_type, "__new__", ctx.new_rustfunc(new_memory_view));
+    ctx.set_attr(
+        &memoryview_type,
+        "__new__",
+        ctx.new_rustfunc(new_memory_view),
+    );
 }

--- a/vm/src/obj/objmemory.rs
+++ b/vm/src/obj/objmemory.rs
@@ -1,0 +1,27 @@
+
+use super::objtype;
+
+use super::super::pyobject::{
+    PyContext, PyFuncArgs, PyObject, PyObjectKind, PyObjectRef, PyResult, TypeProtocol
+};
+use super::super::vm::VirtualMachine;
+
+
+pub fn new_memory_view(vm: &mut VirtualMachine, args: PyFuncArgs) -> PyResult {
+    arg_check!(
+        vm,
+        args,
+        required = [(cls, None), (bytes_object, None)]
+    );
+    vm.ctx.set_attr(&cls, "obj", bytes_object.clone());
+    Ok(PyObject::new(
+        PyObjectKind::MemoryView { obj: bytes_object.clone() },
+        cls.clone()
+    ))
+
+}
+
+pub fn init(ctx: &PyContext) {
+    let ref memoryview_type = ctx.memoryview_type;
+    ctx.set_attr(&memoryview_type, "__new__", ctx.new_rustfunc(new_memory_view));
+}

--- a/vm/src/pyobject.rs
+++ b/vm/src/pyobject.rs
@@ -146,8 +146,7 @@ fn _nothing() -> PyObjectRef {
     PyObject {
         kind: PyObjectKind::None,
         typ: None,
-    }
-    .into_ref()
+    }.into_ref()
 }
 
 pub fn create_type(
@@ -220,7 +219,7 @@ impl PyContext {
         );
         let context = PyContext {
             bool_type: bool_type,
-            memoryview_type : memoryview_type,
+            memoryview_type: memoryview_type,
             bytearray_type: bytearray_type,
             bytes_type: bytes_type,
             code_type: code_type,
@@ -412,7 +411,10 @@ impl PyContext {
     }
 
     pub fn new_bytearray(&self, data: Vec<u8>) -> PyObjectRef {
-        PyObject::new(PyObjectKind::Bytes { value: data }, self.bytearray_type())
+        PyObject::new(
+            PyObjectKind::ByteArray { value: data },
+            self.bytearray_type(),
+        )
     }
 
     pub fn new_bool(&self, b: bool) -> PyObjectRef {
@@ -464,8 +466,7 @@ impl PyContext {
         PyObject {
             kind: PyObjectKind::Scope { scope: scope },
             typ: None,
-        }
-        .into_ref()
+        }.into_ref()
     }
 
     pub fn new_module(&self, name: &str, scope: PyObjectRef) -> PyObjectRef {
@@ -745,6 +746,21 @@ impl DictProtocol for PyObjectRef {
     }
 }
 
+pub trait BufferProtocol {
+    fn readonly(&self) -> bool;
+}
+
+impl BufferProtocol for PyObjectRef {
+    fn readonly(&self) -> bool {
+        match self.borrow().kind {
+            PyObjectKind::Bytes { value: _ } => false,
+            PyObjectKind::ByteArray { value: _ } => true,
+            PyObjectKind::MemoryView { obj: _ } => true,
+            _ => panic!("Bytes-Like type expected not {:?}", self),
+        }
+    }
+}
+
 impl fmt::Debug for PyObject {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "[PyObj {:?}]", self.kind)
@@ -826,6 +842,9 @@ pub enum PyObjectKind {
     Bytes {
         value: Vec<u8>,
     },
+    ByteArray {
+        value: Vec<u8>,
+    },
     Sequence {
         elements: Vec<PyObjectRef>,
     },
@@ -845,7 +864,7 @@ pub enum PyObjectKind {
         step: Option<i32>,
     },
     MemoryView {
-        obj : PyObjectRef
+        obj: PyObjectRef,
     },
     Code {
         code: bytecode::CodeObject,
@@ -897,6 +916,7 @@ impl fmt::Debug for PyObjectKind {
             &PyObjectKind::Float { ref value } => write!(f, "float {}", value),
             &PyObjectKind::Complex { ref value } => write!(f, "complex {}", value),
             &PyObjectKind::Bytes { ref value } => write!(f, "bytes/bytearray {:?}", value),
+            &PyObjectKind::ByteArray { ref value } => write!(f, "bytes/bytearray {:?}", value),
             &PyObjectKind::MemoryView { ref obj } => write!(f, "bytes/bytearray {:?}", obj),
             &PyObjectKind::Sequence { elements: _ } => write!(f, "list or tuple"),
             &PyObjectKind::Dict { elements: _ } => write!(f, "dict"),
@@ -939,8 +959,7 @@ impl PyObject {
             kind: kind,
             typ: Some(typ),
             // dict: HashMap::new(),  // dict,
-        }
-        .into_ref()
+        }.into_ref()
     }
 
     /// Deprecated method, please call `vm.to_pystr`
@@ -951,6 +970,7 @@ impl PyObject {
             PyObjectKind::Float { ref value } => format!("{:?}", value),
             PyObjectKind::Complex { ref value } => format!("{:?}", value),
             PyObjectKind::Bytes { ref value } => format!("b'{:?}'", value),
+            PyObjectKind::ByteArray { ref value } => format!("b'{:?}'", value),
             PyObjectKind::MemoryView { ref obj } => format!("b'{:?}'", obj),
             PyObjectKind::Sequence { ref elements } => format!(
                 "(/[{}]/)",

--- a/vm/src/pyobject.rs
+++ b/vm/src/pyobject.rs
@@ -14,6 +14,7 @@ use super::obj::objgenerator;
 use super::obj::objint;
 use super::obj::objiter;
 use super::obj::objlist;
+use super::obj::objmemory;
 use super::obj::objobject;
 use super::obj::objproperty;
 use super::obj::objset;
@@ -114,6 +115,7 @@ pub struct PyContext {
     pub true_value: PyObjectRef,
     pub false_value: PyObjectRef,
     pub list_type: PyObjectRef,
+    pub memoryview_type: PyObjectRef,
     pub none: PyObjectRef,
     pub tuple_type: PyObjectRef,
     pub set_type: PyObjectRef,
@@ -197,6 +199,7 @@ impl PyContext {
         let tuple_type = create_type("tuple", &type_type, &object_type, &dict_type);
         let iter_type = create_type("iter", &type_type, &object_type, &dict_type);
         let bool_type = create_type("bool", &type_type, &int_type, &dict_type);
+        let memoryview_type = create_type("memoryview", &type_type, &object_type, &dict_type);
         let code_type = create_type("code", &type_type, &int_type, &dict_type);
         let exceptions = exceptions::ExceptionZoo::new(&type_type, &object_type, &dict_type);
 
@@ -217,6 +220,7 @@ impl PyContext {
         );
         let context = PyContext {
             bool_type: bool_type,
+            memoryview_type : memoryview_type,
             bytearray_type: bytearray_type,
             bytes_type: bytes_type,
             code_type: code_type,
@@ -261,6 +265,7 @@ impl PyContext {
         objbytes::init(&context);
         objbytearray::init(&context);
         objproperty::init(&context);
+        objmemory::init(&context);
         objstr::init(&context);
         objsuper::init(&context);
         objtuple::init(&context);
@@ -318,6 +323,10 @@ impl PyContext {
 
     pub fn bool_type(&self) -> PyObjectRef {
         self.bool_type.clone()
+    }
+
+    pub fn memoryview_type(&self) -> PyObjectRef {
+        self.memoryview_type.clone()
     }
 
     pub fn tuple_type(&self) -> PyObjectRef {
@@ -831,6 +840,9 @@ pub enum PyObjectKind {
         stop: Option<i32>,
         step: Option<i32>,
     },
+    MemoryView {
+        obj : PyObjectRef
+    },
     Code {
         code: bytecode::CodeObject,
     },
@@ -881,6 +893,7 @@ impl fmt::Debug for PyObjectKind {
             &PyObjectKind::Float { ref value } => write!(f, "float {}", value),
             &PyObjectKind::Complex { ref value } => write!(f, "complex {}", value),
             &PyObjectKind::Bytes { ref value } => write!(f, "bytes/bytearray {:?}", value),
+            &PyObjectKind::MemoryView { ref obj } => write!(f, "bytes/bytearray {:?}", obj),
             &PyObjectKind::Sequence { elements: _ } => write!(f, "list or tuple"),
             &PyObjectKind::Dict { elements: _ } => write!(f, "dict"),
             &PyObjectKind::Set { elements: _ } => write!(f, "set"),
@@ -934,6 +947,7 @@ impl PyObject {
             PyObjectKind::Float { ref value } => format!("{:?}", value),
             PyObjectKind::Complex { ref value } => format!("{:?}", value),
             PyObjectKind::Bytes { ref value } => format!("b'{:?}'", value),
+            PyObjectKind::MemoryView { ref obj } => format!("b'{:?}'", obj),
             PyObjectKind::Sequence { ref elements } => format!(
                 "(/[{}]/)",
                 elements

--- a/vm/src/pyobject.rs
+++ b/vm/src/pyobject.rs
@@ -411,6 +411,10 @@ impl PyContext {
         PyObject::new(PyObjectKind::Bytes { value: data }, self.bytes_type())
     }
 
+    pub fn new_bytearray(&self, data: Vec<u8>) -> PyObjectRef {
+        PyObject::new(PyObjectKind::Bytes { value: data }, self.bytearray_type())
+    }
+
     pub fn new_bool(&self, b: bool) -> PyObjectRef {
         if b {
             self.true_value.clone()

--- a/vm/src/pyobject.rs
+++ b/vm/src/pyobject.rs
@@ -146,7 +146,8 @@ fn _nothing() -> PyObjectRef {
     PyObject {
         kind: PyObjectKind::None,
         typ: None,
-    }.into_ref()
+    }
+    .into_ref()
 }
 
 pub fn create_type(
@@ -466,7 +467,8 @@ impl PyContext {
         PyObject {
             kind: PyObjectKind::Scope { scope: scope },
             typ: None,
-        }.into_ref()
+        }
+        .into_ref()
     }
 
     pub fn new_module(&self, name: &str, scope: PyObjectRef) -> PyObjectRef {
@@ -959,7 +961,8 @@ impl PyObject {
             kind: kind,
             typ: Some(typ),
             // dict: HashMap::new(),  // dict,
-        }.into_ref()
+        }
+        .into_ref()
     }
 
     /// Deprecated method, please call `vm.to_pystr`

--- a/vm/src/stdlib/io.rs
+++ b/vm/src/stdlib/io.rs
@@ -2,9 +2,21 @@
  * I/O core tools.
  */
 
-// use super::super::obj::{objstr, objtype};
-use super::super::pyobject::{PyContext, PyFuncArgs, PyObjectRef, PyResult};
-use super::super::VirtualMachine;
+
+use std::fs::File;
+use std::io::prelude::*;
+use std::io::{BufReader,BufWriter};
+
+use super::super::obj::objstr::get_value;
+
+use super::super::obj::objtype;
+
+use super::super::pyobject::{
+    PyContext, PyFuncArgs, PyObjectKind, PyObjectRef, PyResult, TypeProtocol, AttributeProtocol
+};
+
+use super::super::vm::VirtualMachine;
+
 
 fn string_io_init(vm: &mut VirtualMachine, _args: PyFuncArgs) -> PyResult {
     // arg_check!(vm, args, required = [(s, Some(vm.ctx.str_type()))]);
@@ -29,17 +41,154 @@ fn bytes_io_getvalue(vm: &mut VirtualMachine, args: PyFuncArgs) -> PyResult {
     Ok(vm.get_none())
 }
 
+fn buffered_io_base_init(vm: &mut VirtualMachine, args: PyFuncArgs) -> PyResult {
+    // arg_check!(vm, args);
+
+    // TODO
+    Ok(vm.get_none())
+}
+
+fn file_io_init(vm: &mut VirtualMachine, args: PyFuncArgs) -> PyResult {
+    arg_check!(
+        vm,
+        args,
+        required = [(file_io, None), (name, Some(vm.ctx.str_type()))]
+    );
+
+    vm.ctx.set_attr(&file_io, "name", name.clone());
+    Ok(vm.get_none())
+}
+
+fn file_io_read(vm: &mut VirtualMachine, args: PyFuncArgs) -> PyResult {
+    arg_check!(
+        vm,
+        args,
+        required = [(file_io, None)]
+    );
+    let py_name = file_io.get_attr("name").unwrap();
+    let f = match File::open(get_value(& py_name)) {
+        Ok(v) => Ok(v),
+        Err(v) => Err(vm.new_type_error("Error opening file".to_string())),
+    }; 
+
+    let buffer = match f {
+        Ok(v) =>  Ok(BufReader::new(v)),
+        Err(v) => Err(vm.new_type_error("Error reading from file".to_string()))
+    };
+
+    let mut bytes = vec![];
+    if let Ok(mut buff) = buffer {
+        buff.read_to_end(&mut bytes);
+    }    
+
+    Ok(vm.ctx.new_bytes(bytes))
+}
+
+
+fn file_io_read_into(vm: &mut VirtualMachine, args: PyFuncArgs) -> PyResult {
+    arg_check!(
+        vm,
+        args,
+        required = [(file_io, None), (view, Some(vm.ctx.bytes_type()))]
+    );
+    let py_name = file_io.get_attr("name").unwrap();
+    let f = match File::open(get_value(& py_name)) {
+        Ok(v) => Ok(v),
+        Err(v) => Err(vm.new_type_error("Error opening file".to_string())),
+    }; 
+
+    let buffer = match f {
+        Ok(v) =>  Ok(BufReader::new(v)),
+        Err(v) => Err(vm.new_type_error("Error reading from file".to_string()))
+    };
+
+
+    match view.borrow_mut().kind {
+        PyObjectKind::Bytes { ref mut value } => {
+            if let Ok(mut buff) = buffer {
+                buff.read_to_end(&mut *value);
+            };   
+        },
+        _ => {}
+    };
+
+    Ok(vm.get_none())
+}
+
+fn buffered_reader_read(vm: &mut VirtualMachine, args: PyFuncArgs) -> PyResult {
+    arg_check!(vm, args);
+    // TODO
+    Ok(vm.get_none())
+}
+
+fn io_open(vm: &mut VirtualMachine, args: PyFuncArgs) -> PyResult {
+    arg_check!(
+        vm, 
+        args, 
+        required = [(file, None), (mode, None)]
+    );
+
+
+    Ok(vm.get_none())
+    //mode is optional: 'rt' is the default mode (open from reading text)
+    //To start we construct a FileIO (subclass of RawIOBase)
+    //This is subsequently consumed by a Buffered_class of type depending
+    //operation in the mode. i.e:
+    // updating => PyBufferedRandom
+    // creating || writing || appending => BufferedWriter
+    // reading => BufferedReader
+    // If the mode is binary this Buffered class is returned directly at
+    // this point.
+
+    //If the mode is text this buffer type is consumed on construction of 
+    //a TextIOWrapper which is subsequently returned.
+}
+
+
 pub fn mk_module(ctx: &PyContext) -> PyObjectRef {
     let py_mod = ctx.new_module(&"io".to_string(), ctx.new_scope(None));
-
+    ctx.set_attr(&py_mod, "open", ctx.new_rustfunc(io_open));
+     //IOBase the abstract base class of the IO Module
     let io_base = ctx.new_class("IOBase", ctx.object());
     ctx.set_attr(&py_mod, "IOBase", io_base.clone());
 
+    // IOBase Subclasses
+    let raw_io_base = ctx.new_class("RawIOBase", ctx.object());
+    ctx.set_attr(&py_mod, "RawIOBase", raw_io_base.clone());
+
+    let buffered_io_base = ctx.new_class("BufferedIOBase", io_base.clone());
+    ctx.set_attr(&buffered_io_base, "__init__", ctx.new_rustfunc(buffered_io_base_init));
+    ctx.set_attr(&py_mod, "BufferedIOBase", buffered_io_base.clone());
+
+    let text_io_base = ctx.new_class("TextIOBase", io_base.clone());
+    ctx.set_attr(&py_mod, "TextIOBase", text_io_base.clone());
+
+    // RawBaseIO Subclasses
+    let file_io = ctx.new_class("FileIO", raw_io_base.clone());
+    ctx.set_attr(&file_io, "__init__", ctx.new_rustfunc(file_io_init));
+    ctx.set_attr(&file_io, "name", ctx.str_type());
+    ctx.set_attr(&file_io, "read", ctx.new_rustfunc(file_io_read));
+    ctx.set_attr(&file_io, "read_into", ctx.new_rustfunc(file_io_read_into));
+    ctx.set_attr(&py_mod, "FileIO", file_io.clone());
+
+    // BufferedIOBase Subclasses
+    let buffered_reader = ctx.new_class("BufferedReader", buffered_io_base.clone());
+    ctx.set_attr(&py_mod, "BufferedReader", buffered_reader.clone());
+
+    let buffered_reader = ctx.new_class("BufferedWriter", buffered_io_base.clone());
+    ctx.set_attr(&py_mod, "BufferedWriter", buffered_reader.clone());
+
+    //TextIOBase Subclass
+    let text_io_wrapper = ctx.new_class("TextIOWrapper", ctx.object());
+    ctx.set_attr(&py_mod, "TextIOWrapper", text_io_wrapper.clone());
+
+    // BytesIO: in-memory bytes
     let string_io = ctx.new_class("StringIO", io_base.clone());
     ctx.set_attr(&string_io, "__init__", ctx.new_rustfunc(string_io_init));
     ctx.set_attr(&string_io, "getvalue", ctx.new_rustfunc(string_io_getvalue));
     ctx.set_attr(&py_mod, "StringIO", string_io);
 
+    // StringIO: in-memory text
     let bytes_io = ctx.new_class("BytesIO", io_base.clone());
     ctx.set_attr(&bytes_io, "__init__", ctx.new_rustfunc(bytes_io_init));
     ctx.set_attr(&bytes_io, "getvalue", ctx.new_rustfunc(bytes_io_getvalue));

--- a/vm/src/stdlib/io.rs
+++ b/vm/src/stdlib/io.rs
@@ -243,7 +243,7 @@ fn buffered_writer_write(vm: &mut VirtualMachine, args: PyFuncArgs) -> PyResult 
 
 }
 
-fn io_open(vm: &mut VirtualMachine, args: PyFuncArgs) -> PyResult {
+pub fn io_open(vm: &mut VirtualMachine, args: PyFuncArgs) -> PyResult {
     arg_check!(
         vm, 
         args, 
@@ -259,7 +259,7 @@ fn io_open(vm: &mut VirtualMachine, args: PyFuncArgs) -> PyResult {
     let buffered_reader_class = vm.ctx.get_attr(&module, "BufferedReader").unwrap();
 
     //instantiate raw fileio
-    let file_io = vm.invoke(file_io_class, PyFuncArgs::new(vec![file.clone()], vec![])).unwrap();
+    let file_io = vm.invoke(file_io_class, args.clone()).unwrap();
 
     //This is subsequently consumed by a Buffered_class of type depending
     //operation in the mode. i.e:
@@ -269,7 +269,6 @@ fn io_open(vm: &mut VirtualMachine, args: PyFuncArgs) -> PyResult {
     // creating || writing || appending => BufferedWriter
     let buffered = if rust_mode.contains("w") {
         // vm.new_not_implemented_error("Writes are not yet implemented".to_string());
-        println!("writer class");
         vm.invoke(buffered_writer_class, PyFuncArgs::new(vec![file_io.clone()], vec![]))
     // reading => BufferedReader
     } else {

--- a/vm/src/stdlib/io.rs
+++ b/vm/src/stdlib/io.rs
@@ -89,7 +89,7 @@ fn file_io_read_into(vm: &mut VirtualMachine, args: PyFuncArgs) -> PyResult {
     arg_check!(
         vm,
         args,
-        required = [(file_io, None), (view, Some(vm.ctx.bytes_type()))]
+        required = [(file_io, None), (view, Some(vm.ctx.bytearray_type()))]
     );
     let py_name = file_io.get_attr("name").unwrap();
     let f = match File::open(get_value(& py_name)) {
@@ -117,6 +117,8 @@ fn file_io_read_into(vm: &mut VirtualMachine, args: PyFuncArgs) -> PyResult {
 
 fn buffered_reader_read(vm: &mut VirtualMachine, args: PyFuncArgs) -> PyResult {
     arg_check!(vm, args);
+
+    //simple calls read on the read class!
     // TODO
     Ok(vm.get_none())
 }
@@ -130,6 +132,7 @@ fn io_open(vm: &mut VirtualMachine, args: PyFuncArgs) -> PyResult {
 
 
     Ok(vm.get_none())
+
     //mode is optional: 'rt' is the default mode (open from reading text)
     //To start we construct a FileIO (subclass of RawIOBase)
     //This is subsequently consumed by a Buffered_class of type depending
@@ -139,6 +142,7 @@ fn io_open(vm: &mut VirtualMachine, args: PyFuncArgs) -> PyResult {
     // reading => BufferedReader
     // If the mode is binary this Buffered class is returned directly at
     // this point.
+    //For Buffered class construct "raw" IO class e.g. FileIO and pass this into corresponding field
 
     //If the mode is text this buffer type is consumed on construction of 
     //a TextIOWrapper which is subsequently returned.
@@ -168,7 +172,7 @@ pub fn mk_module(ctx: &PyContext) -> PyObjectRef {
     ctx.set_attr(&file_io, "__init__", ctx.new_rustfunc(file_io_init));
     ctx.set_attr(&file_io, "name", ctx.str_type());
     ctx.set_attr(&file_io, "read", ctx.new_rustfunc(file_io_read));
-    ctx.set_attr(&file_io, "read_into", ctx.new_rustfunc(file_io_read_into));
+    ctx.set_attr(&file_io, "readinto", ctx.new_rustfunc(file_io_read_into));
     ctx.set_attr(&py_mod, "FileIO", file_io.clone());
 
     // BufferedIOBase Subclasses

--- a/vm/src/stdlib/io.rs
+++ b/vm/src/stdlib/io.rs
@@ -88,7 +88,7 @@ fn buffered_reader_read(vm: &mut VirtualMachine, args: PyFuncArgs) -> PyResult {
 
         //Copy bytes from the buffer vector into the results vector
         match buffer.borrow_mut().kind {
-            PyObjectKind::ByteArray { ref mut value } => {
+            PyObjectKind::Bytes { ref mut value } => {
                 result.extend(value.iter().cloned());
             }
             _ => {}
@@ -177,7 +177,7 @@ fn file_io_readinto(vm: &mut VirtualMachine, args: PyFuncArgs) -> PyResult {
     let mut f = handle.take(length);
     match obj.borrow_mut().kind {
         //TODO: Implement for MemoryView
-        PyObjectKind::ByteArray { ref mut value } => {
+        PyObjectKind::Bytes { ref mut value } => {
             value.clear();
             match f.read_to_end(&mut *value) {
                 Ok(_) => {}

--- a/vm/src/stdlib/mod.rs
+++ b/vm/src/stdlib/mod.rs
@@ -10,6 +10,7 @@ mod time_module;
 mod tokenize;
 mod types;
 mod weakref;
+mod os;
 use std::collections::HashMap;
 
 use super::pyobject::{PyContext, PyObjectRef};
@@ -23,6 +24,7 @@ pub fn get_module_inits() -> HashMap<String, StdlibInitFunc> {
     modules.insert("json".to_string(), json::mk_module as StdlibInitFunc);
     modules.insert("keyword".to_string(), keyword::mk_module as StdlibInitFunc);
     modules.insert("math".to_string(), math::mk_module as StdlibInitFunc);
+    modules.insert("os".to_string(), os::mk_module as StdlibInitFunc);
     modules.insert("re".to_string(), re::mk_module as StdlibInitFunc);
     modules.insert("random".to_string(), random::mk_module as StdlibInitFunc);
     modules.insert("struct".to_string(), pystruct::mk_module as StdlibInitFunc);

--- a/vm/src/stdlib/mod.rs
+++ b/vm/src/stdlib/mod.rs
@@ -1,5 +1,5 @@
 mod ast;
-mod io;
+pub mod io;
 mod json;
 mod keyword;
 mod math;

--- a/vm/src/stdlib/mod.rs
+++ b/vm/src/stdlib/mod.rs
@@ -3,6 +3,7 @@ pub mod io;
 mod json;
 mod keyword;
 mod math;
+mod os;
 mod pystruct;
 mod random;
 mod re;
@@ -10,7 +11,6 @@ mod time_module;
 mod tokenize;
 mod types;
 mod weakref;
-mod os;
 use std::collections::HashMap;
 
 use super::pyobject::{PyContext, PyObjectRef};

--- a/vm/src/stdlib/os.rs
+++ b/vm/src/stdlib/os.rs
@@ -1,16 +1,14 @@
 use std::fs::OpenOptions;
 use std::os::unix::io::IntoRawFd;
 
-use num_bigint::{ToBigInt};
+use num_bigint::ToBigInt;
 use num_traits::cast::ToPrimitive;
 
-use super::super::obj::objstr;
 use super::super::obj::objint;
+use super::super::obj::objstr;
 use super::super::obj::objtype;
 
-use super::super::pyobject::{
-    PyContext, PyFuncArgs, PyObjectRef, PyResult, TypeProtocol
-};
+use super::super::pyobject::{PyContext, PyFuncArgs, PyObjectRef, PyResult, TypeProtocol};
 
 use super::super::vm::VirtualMachine;
 
@@ -19,7 +17,7 @@ pub fn os_open(vm: &mut VirtualMachine, args: PyFuncArgs) -> PyResult {
         vm,
         args,
         required = [(name, Some(vm.ctx.str_type()))],
-        optional = [(mode, Some(vm.ctx.int_type()))] 
+        optional = [(mode, Some(vm.ctx.int_type()))]
     );
 
     let mode = if let Some(m) = mode {
@@ -28,15 +26,20 @@ pub fn os_open(vm: &mut VirtualMachine, args: PyFuncArgs) -> PyResult {
         0.to_bigint().unwrap()
     };
 
-    let handle = match mode.to_u16().unwrap() { 
+    let handle = match mode.to_u16().unwrap() {
         0 => OpenOptions::new().read(true).open(objstr::get_value(&name)),
-        1 => OpenOptions::new().write(true).open(objstr::get_value(&name)),
-        512 => OpenOptions::new().write(true).create(true).open(objstr::get_value(&name)),
-        _ => OpenOptions::new().read(true).open(objstr::get_value(&name))
+        1 => OpenOptions::new()
+            .write(true)
+            .open(objstr::get_value(&name)),
+        512 => OpenOptions::new()
+            .write(true)
+            .create(true)
+            .open(objstr::get_value(&name)),
+        _ => OpenOptions::new().read(true).open(objstr::get_value(&name)),
     };
 
     //raw_fd is supported on UNIX only. This will need to be extended
-    //to support windows - i.e. raw file_handles 
+    //to support windows - i.e. raw file_handles
     if let Ok(f) = handle {
         Ok(vm.ctx.new_int(f.into_raw_fd().to_bigint().unwrap()))
     } else {

--- a/vm/src/stdlib/os.rs
+++ b/vm/src/stdlib/os.rs
@@ -16,17 +16,13 @@ pub fn os_open(vm: &mut VirtualMachine, args: PyFuncArgs) -> PyResult {
     arg_check!(
         vm,
         args,
-        required = [(name, Some(vm.ctx.str_type()))],
-        optional = [(mode, Some(vm.ctx.int_type()))]
+        required = [
+            (name, Some(vm.ctx.str_type())),
+            (mode, Some(vm.ctx.int_type()))
+        ]
     );
 
-    let mode = if let Some(m) = mode {
-        objint::get_value(m)
-    } else {
-        0.to_bigint().unwrap()
-    };
-
-    let handle = match mode.to_u16().unwrap() {
+    let handle = match objint::get_value(mode).to_u16().unwrap() {
         0 => OpenOptions::new().read(true).open(objstr::get_value(&name)),
         1 => OpenOptions::new()
             .write(true)
@@ -53,7 +49,7 @@ pub fn mk_module(ctx: &PyContext) -> PyObjectRef {
     ctx.set_attr(&py_mod, "O_RDONLY", ctx.new_int(0.to_bigint().unwrap()));
     ctx.set_attr(&py_mod, "O_WRONLY", ctx.new_int(1.to_bigint().unwrap()));
     ctx.set_attr(&py_mod, "O_RDWR", ctx.new_int(2.to_bigint().unwrap()));
-    ctx.set_attr(&py_mod, "O_NONBLOCK", ctx.new_int(3.to_bigint().unwrap()));
+    ctx.set_attr(&py_mod, "O_NONBLOCK", ctx.new_int(4.to_bigint().unwrap()));
     ctx.set_attr(&py_mod, "O_APPEND", ctx.new_int(8.to_bigint().unwrap()));
     ctx.set_attr(&py_mod, "O_CREAT", ctx.new_int(512.to_bigint().unwrap()));
     py_mod

--- a/vm/src/stdlib/os.rs
+++ b/vm/src/stdlib/os.rs
@@ -51,6 +51,7 @@ pub fn mk_module(ctx: &PyContext) -> PyObjectRef {
     ctx.set_attr(&py_mod, "O_WRONLY", ctx.new_int(1.to_bigint().unwrap()));
     ctx.set_attr(&py_mod, "O_RDWR", ctx.new_int(2.to_bigint().unwrap()));
     ctx.set_attr(&py_mod, "O_NONBLOCK", ctx.new_int(3.to_bigint().unwrap()));
+    ctx.set_attr(&py_mod, "O_APPEND", ctx.new_int(8.to_bigint().unwrap()));
     ctx.set_attr(&py_mod, "O_CREAT", ctx.new_int(512.to_bigint().unwrap()));
     py_mod
 }

--- a/vm/src/stdlib/os.rs
+++ b/vm/src/stdlib/os.rs
@@ -1,0 +1,34 @@
+use std::fs::File;
+use std::os::unix::io::IntoRawFd;
+
+use num_bigint::{BigInt, ToBigInt};
+
+use super::super::obj::objstr;
+use super::super::obj::objint;
+use super::super::obj::objtype;
+
+use super::super::pyobject::{
+    PyContext, PyFuncArgs, PyObjectKind, PyObjectRef, PyResult, TypeProtocol, AttributeProtocol
+};
+
+
+use super::super::vm::VirtualMachine;
+
+
+fn os_open(vm: &mut VirtualMachine, args: PyFuncArgs) -> PyResult {
+    arg_check!(
+        vm,
+        args,
+        required = [(name, Some(vm.ctx.str_type()))]
+    );
+    match File::open(objstr::get_value(&name)) {
+        Ok(v) => Ok(vm.ctx.new_int(v.into_raw_fd().to_bigint().unwrap())),
+        Err(v) => Err(vm.new_type_error("Error opening file".to_string())),
+    }
+}
+
+pub fn mk_module(ctx: &PyContext) -> PyObjectRef {
+    let py_mod = ctx.new_module(&"io".to_string(), ctx.new_scope(None));
+    ctx.set_attr(&py_mod, "open", ctx.new_rustfunc(os_open));
+    py_mod
+}

--- a/vm/src/stdlib/os.rs
+++ b/vm/src/stdlib/os.rs
@@ -15,7 +15,7 @@ use super::super::pyobject::{
 use super::super::vm::VirtualMachine;
 
 
-fn os_open(vm: &mut VirtualMachine, args: PyFuncArgs) -> PyResult {
+pub fn os_open(vm: &mut VirtualMachine, args: PyFuncArgs) -> PyResult {
     arg_check!(
         vm,
         args,

--- a/vm/src/stdlib/os.rs
+++ b/vm/src/stdlib/os.rs
@@ -12,9 +12,7 @@ use super::super::pyobject::{
     PyContext, PyFuncArgs, PyObjectRef, PyResult, TypeProtocol
 };
 
-
 use super::super::vm::VirtualMachine;
-
 
 pub fn os_open(vm: &mut VirtualMachine, args: PyFuncArgs) -> PyResult {
     arg_check!(
@@ -42,7 +40,7 @@ pub fn os_open(vm: &mut VirtualMachine, args: PyFuncArgs) -> PyResult {
     if let Ok(f) = handle {
         Ok(vm.ctx.new_int(f.into_raw_fd().to_bigint().unwrap()))
     } else {
-        Err(vm.get_none())
+        Err(vm.new_value_error("Bad file descriptor".to_string()))
     }
 }
 
@@ -53,6 +51,6 @@ pub fn mk_module(ctx: &PyContext) -> PyObjectRef {
     ctx.set_attr(&py_mod, "O_WRONLY", ctx.new_int(1.to_bigint().unwrap()));
     ctx.set_attr(&py_mod, "O_RDWR", ctx.new_int(2.to_bigint().unwrap()));
     ctx.set_attr(&py_mod, "O_NONBLOCK", ctx.new_int(3.to_bigint().unwrap()));
-
+    ctx.set_attr(&py_mod, "O_CREAT", ctx.new_int(512.to_bigint().unwrap()));
     py_mod
 }


### PR DESCRIPTION
Start on some methods on the io Classes related to File-IO:  FileIO, BufferedReader/Writer and TextIOWrapper Classes and the open builtin.

Follows (approximately) the CPython implementation.

TextIOWrapper - BufferedReader/Writer - FileIO

Where open returns the TextIOWrapper or Buffered Type depending on the mode parameters. 

Some related implementation from the os module, memoryview and minor changes to bytes and byte array types.

[open](https://docs.python.org/3/library/functions.html#open) builtin at this stage only supports first two parameters: file and mode
