### PR TITLE
README: Clarified the 'Testing' section

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,8 +82,7 @@ To test rustpython, there is a collection of python snippets located in the
 ```shell
 $ cd tests
 $ pipenv install
-$ pipenv shell
-$ pytest -v
+$ pipenv run pytest -v
 ```
 
 There also are some unittests, you can run those will cargo:


### PR DESCRIPTION
Added the `pipenv install` command to the `Testing` section, since using just `pipenv shell` will not install the dependencies from the Pipfile.

Also replaced two `pipenv shell` and `pytest -v` commands with the single `pipenv run pytest -v` command, so it would be easier to run tests, without exiting the shell afterwards.