### PR TITLE
Use XDG paths to store Python history

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -684,6 +684,7 @@ dependencies = [
  "rustpython_parser 0.0.1",
  "rustpython_vm 0.1.0",
  "rustyline 2.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "xdg 2.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1128,6 +1129,11 @@ dependencies = [
  "winapi-util 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
+[[package]]
+name = "xdg"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
 [metadata]
 "checksum aho-corasick 0.6.4 (registry+https://github.com/rust-lang/crates.io-index)" = "d6531d44de723825aa81398a6415283229725a00fa30713812ab9323faa82fc4"
 "checksum ansi_term 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ee49baf6cb617b853aa8d93bf420db2383fab46d314482ca2803b40d5fde979b"
@@ -1263,3 +1269,4 @@ dependencies = [
 "checksum winapi-x86_64-pc-windows-gnu 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 "checksum wincolor 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)" = "eeb06499a3a4d44302791052df005d5232b927ed1a9658146d842165c4de7767"
 "checksum wincolor 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "561ed901ae465d6185fa7864d63fbd5720d0ef718366c9a4dc83cf6170d7e9ba"
+"checksum xdg 2.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "d089681aa106a86fade1b0128fb5daf07d5867a509ab036d99988dec80429a57"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,7 @@ clap = "2.31.2"
 rustpython_parser = {path = "parser"}
 rustpython_vm = {path = "vm"}
 rustyline = "2.1.0"
+xdg = "2.2.0"
 
 [profile.release]
 opt-level = "s"

--- a/src/main.rs
+++ b/src/main.rs
@@ -7,6 +7,7 @@ extern crate log;
 extern crate rustpython_parser;
 extern crate rustpython_vm;
 extern crate rustyline;
+extern crate xdg;
 
 use clap::{App, Arg};
 use rustpython_parser::parser;
@@ -154,9 +155,10 @@ fn run_shell(vm: &mut VirtualMachine) -> PyResult {
     let mut input = String::new();
     let mut rl = Editor::<()>::new();
 
-    // TODO: Store the history in a proper XDG directory
-    let repl_history_path = ".repl_history.txt";
-    if rl.load_history(repl_history_path).is_err() {
+    let xdg_dirs = xdg::BaseDirectories::with_prefix("rustpython").unwrap();
+    let repl_history_path = xdg_dirs.place_cache_file("repl_history.txt").unwrap();
+    let repl_history_path_str = repl_history_path.to_str().unwrap();
+    if rl.load_history(repl_history_path_str).is_err() {
         println!("No previous history.");
     }
 
@@ -220,7 +222,7 @@ fn run_shell(vm: &mut VirtualMachine) -> PyResult {
             }
         };
     }
-    rl.save_history(repl_history_path).unwrap();
+    rl.save_history(repl_history_path_str).unwrap();
 
     Ok(vm.get_none())
 }


### PR DESCRIPTION
Awesome talk at FOSDEM! This is my first rust PR so please let me know what could be improved.

I've used the [xdg crate](https://docs.rs/xdg/2.2.0/xdg/struct.BaseDirectories.html) to find the appropriate place to save the readline history file. I'm not sure if we care about Window support here?

Also, it seems that crate does not accept a Path struct but only a string, so I had to unwrap it into a string. Seems like that should be added to xdg at some point.