### PR TITLE
Implement SystemExit

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -681,6 +681,7 @@ dependencies = [
  "clap 2.31.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "env_logger 0.5.10 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "num-traits 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "rustpython_parser 0.0.1",
  "rustpython_vm 0.1.0",
  "rustyline 2.1.0 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,7 @@ rustpython_parser = {path = "parser"}
 rustpython_vm = {path = "vm"}
 rustyline = "2.1.0"
 xdg = "2.2.0"
+num-traits = "0.2.6"
 
 [profile.release]
 opt-level = "s"

--- a/tests/snippets/system_exit.py
+++ b/tests/snippets/system_exit.py
@@ -1,0 +1,10 @@
+try:
+    exit(1)
+except SystemExit as e:
+    assert e.code == 1
+
+
+try:
+    exit()
+except SystemExit as e:
+    assert e.code is None, "Exit code is " + str(e.code)

--- a/vm/src/builtins.rs
+++ b/vm/src/builtins.rs
@@ -719,6 +719,11 @@ fn builtin_zip(vm: &mut VirtualMachine, args: PyFuncArgs) -> PyResult {
     Ok(vm.ctx.new_list(new_items))
 }
 
+fn builtin_exit(vm: &mut VirtualMachine, args: PyFuncArgs) -> PyResult {
+    let system_exit = vm.context().exceptions.system_exit.clone();
+    return Err(vm.new_exception(system_exit,"SystemExit".to_string()));
+}
+
 // builtin___import__
 
 pub fn make_module(ctx: &PyContext) -> PyObjectRef {
@@ -786,6 +791,7 @@ pub fn make_module(ctx: &PyContext) -> PyObjectRef {
     ctx.set_attr(&py_mod, "tuple", ctx.tuple_type());
     ctx.set_attr(&py_mod, "type", ctx.type_type());
     ctx.set_attr(&py_mod, "zip", ctx.new_rustfunc(builtin_zip));
+    ctx.set_attr(&py_mod, "exit", ctx.new_rustfunc(builtin_exit));
 
     // Exceptions:
     ctx.set_attr(
@@ -819,6 +825,7 @@ pub fn make_module(ctx: &PyContext) -> PyObjectRef {
     ctx.set_attr(&py_mod, "ValueError", ctx.exceptions.value_error.clone());
     ctx.set_attr(&py_mod, "IndexError", ctx.exceptions.index_error.clone());
     ctx.set_attr(&py_mod, "ImportError", ctx.exceptions.import_error.clone());
+    ctx.set_attr(&py_mod, "SystemExit", ctx.exceptions.system_exit.clone());
 
     py_mod
 }

--- a/vm/src/builtins.rs
+++ b/vm/src/builtins.rs
@@ -720,8 +720,20 @@ fn builtin_zip(vm: &mut VirtualMachine, args: PyFuncArgs) -> PyResult {
 }
 
 fn builtin_exit(vm: &mut VirtualMachine, args: PyFuncArgs) -> PyResult {
+    arg_check!(
+        vm,
+        args,
+        required = [],
+        optional = [(number, Some(vm.ctx.int_type()))]
+    );
+    let default_exit_code = vm.context().none();
+    let number = number.unwrap_or(&default_exit_code);
     let system_exit = vm.context().exceptions.system_exit.clone();
-    return Err(vm.new_exception(system_exit,"SystemExit".to_string()));
+    let args = PyFuncArgs {
+        args: vec![number.clone()],
+        kwargs: vec![],
+    };
+    return Err(vm.new_exception_with_args(system_exit, args));
 }
 
 // builtin___import__

--- a/vm/src/exceptions.rs
+++ b/vm/src/exceptions.rs
@@ -99,6 +99,7 @@ pub struct ExceptionZoo {
     pub syntax_error: PyObjectRef,
     pub type_error: PyObjectRef,
     pub value_error: PyObjectRef,
+    pub system_exit: PyObjectRef,
 }
 
 impl ExceptionZoo {
@@ -140,6 +141,7 @@ impl ExceptionZoo {
         let file_not_found_error =
             create_type("FileNotFoundError", &type_type, &os_error, &dict_type);
         let permission_error = create_type("PermissionError", &type_type, &os_error, &dict_type);
+        let system_exit = create_type("SystemExit", &type_type, &exception_type.clone(), &dict_type);
 
         ExceptionZoo {
             assertion_error,
@@ -160,6 +162,7 @@ impl ExceptionZoo {
             syntax_error,
             type_error,
             value_error,
+            system_exit,
         }
     }
 }

--- a/vm/src/vm.rs
+++ b/vm/src/vm.rs
@@ -90,7 +90,15 @@ impl VirtualMachine {
             kwargs: vec![],
         };
 
-        // Call function:
+        let exception = self.new_exception_with_args(exc_type, args);
+        exception
+    }
+
+    pub fn new_exception_with_args(
+        &mut self,
+        exc_type: PyObjectRef,
+        args: PyFuncArgs,
+    ) -> PyObjectRef {
         let exception = self.invoke(exc_type, args).unwrap();
         exception
     }


### PR DESCRIPTION
I'm not sure how best to structure this. CPython throws a `SystemExit` when `exit()` (technically `sys.exit()`) is called, and this appears to be caught and handled here: https://github.com/python/cpython/blob/dcfcd146f8e6fc5c2fc16a4c192a0c5f5ca8c53c/Python/pythonrun.c#L650

I'm not sure that the `run_code_obj` is the best place to handle this, as the return value is just a `PyResult`. So callers would need to inspect to see if it's an exception type and check which seems iffy.

We might want a custom enum for unrecoverable 'shutdown-esque' errors, like `SystemExit` or `MemoryError`, so the code calling the VM can handle this appropriately?