### PR TITLE
Improve test coverage of os.open/open

### DIFF
--- a/tests/snippets/builtin_open.py
+++ b/tests/snippets/builtin_open.py
@@ -1,0 +1,8 @@
+fd = open('README.md')
+assert 'RustPython' in fd.read()
+
+try:
+    open('DoesNotExist')
+    assert False
+except FileNotFoundError:
+    pass

--- a/tests/snippets/os_open.py
+++ b/tests/snippets/os_open.py
@@ -2,3 +2,9 @@ import os
 
 assert os.open('README.md', 0) > 0
 
+
+try:
+    os.open('DOES_NOT_EXIST', 0)
+    assert False
+except FileNotFoundError:
+    pass

--- a/vm/src/builtins.rs
+++ b/vm/src/builtins.rs
@@ -769,6 +769,11 @@ pub fn make_module(ctx: &PyContext) -> PyObjectRef {
     ctx.set_attr(&py_mod, "ImportError", ctx.exceptions.import_error.clone());
     ctx.set_attr(
         &py_mod,
+        "FileNotFoundError",
+        ctx.exceptions.file_not_found_error.clone(),
+    );
+    ctx.set_attr(
+        &py_mod,
         "StopIteration",
         ctx.exceptions.stop_iteration.clone(),
     );


### PR DESCRIPTION
Currently we panic if we pass a file path that does not exist to `open()`. This seems to be because we assume `os::os_open` doesn't fail and just blindly unwrap it.

I've added a few tests and I've made it bubble up the `ValueError` that `os::os_open` throws. I also removed the `HashSet` as this seemed redundant for only 4 elements.