### PR TITLE
Add .conjugate() method to int type

### DIFF
--- a/tests/snippets/basic_types.py
+++ b/tests/snippets/basic_types.py
@@ -45,6 +45,8 @@ a = complex(2, 4)
 assert type(a) is complex
 assert type(a + a) is complex
 
+a = 1
+assert a.conjugate() == a
 
 a = 12345
 

--- a/tests/snippets/bools.py
+++ b/tests/snippets/bools.py
@@ -46,3 +46,4 @@ assert True + True == 2
 assert False * 7 == 0
 assert True > 0
 assert int(True) == 1
+#assert True.conjugate() == 1

--- a/tests/snippets/bools.py
+++ b/tests/snippets/bools.py
@@ -46,4 +46,5 @@ assert True + True == 2
 assert False * 7 == 0
 assert True > 0
 assert int(True) == 1
-#assert True.conjugate() == 1
+assert True.conjugate() == 1
+assert isinstance(True.conjugate(), int)

--- a/vm/src/obj/objint.rs
+++ b/vm/src/obj/objint.rs
@@ -489,6 +489,11 @@ fn int_bit_length(vm: &mut VirtualMachine, args: PyFuncArgs) -> PyResult {
     Ok(vm.ctx.new_int(bits.to_bigint().unwrap()))
 }
 
+fn int_conjugate(vm: &mut VirtualMachine, args: PyFuncArgs) -> PyResult {
+    arg_check!(vm, args, required = [(i, Some(vm.ctx.int_type()))]);
+    Ok(i.clone())
+}
+
 pub fn init(context: &PyContext) {
     let ref int_type = context.int_type;
     context.set_attr(&int_type, "__eq__", context.new_rustfunc(int_eq));
@@ -526,4 +531,5 @@ pub fn init(context: &PyContext) {
         "bit_length",
         context.new_rustfunc(int_bit_length),
     );
+    context.set_attr(&int_type, "conjugate", context.new_rustfunc(int_conjugate));
 }

--- a/vm/src/obj/objint.rs
+++ b/vm/src/obj/objint.rs
@@ -491,7 +491,8 @@ fn int_bit_length(vm: &mut VirtualMachine, args: PyFuncArgs) -> PyResult {
 
 fn int_conjugate(vm: &mut VirtualMachine, args: PyFuncArgs) -> PyResult {
     arg_check!(vm, args, required = [(i, Some(vm.ctx.int_type()))]);
-    Ok(i.clone())
+    let v = get_value(i);
+    Ok(vm.ctx.new_int(v))
 }
 
 pub fn init(context: &PyContext) {


### PR DESCRIPTION
The new method, `int.conjugate()`, just returns a clone of the `int`.

However, this method is _also_ used by the `bool` type and in that case returning a clone doesn't match CPython.

CPython does:

```Python
>>> type(True.conjugate())
<class 'int'>
```

A couple options (open to others!):

- Implement `bool.conjugate()` independently
- Cast the return type to `int` in `int.conjugate()`

Happy to implement that to, but would love some feedback.