### PR TITLE
Alphebetize exception related code

### DIFF
--- a/vm/src/exceptions.rs
+++ b/vm/src/exceptions.rs
@@ -81,23 +81,23 @@ fn exception_str(vm: &mut VirtualMachine, args: PyFuncArgs) -> PyResult {
 
 #[derive(Debug)]
 pub struct ExceptionZoo {
-    pub base_exception_type: PyObjectRef,
-    pub exception_type: PyObjectRef,
-    pub syntax_error: PyObjectRef,
     pub assertion_error: PyObjectRef,
     pub attribute_error: PyObjectRef,
+    pub base_exception_type: PyObjectRef,
+    pub exception_type: PyObjectRef,
+    pub file_not_found_error: PyObjectRef,
+    pub import_error: PyObjectRef,
     pub index_error: PyObjectRef,
     pub key_error: PyObjectRef,
+    pub module_not_found_error: PyObjectRef,
     pub name_error: PyObjectRef,
-    pub runtime_error: PyObjectRef,
     pub not_implemented_error: PyObjectRef,
+    pub permission_error: PyObjectRef,
+    pub runtime_error: PyObjectRef,
     pub stop_iteration: PyObjectRef,
+    pub syntax_error: PyObjectRef,
     pub type_error: PyObjectRef,
     pub value_error: PyObjectRef,
-    pub import_error: PyObjectRef,
-    pub module_not_found_error: PyObjectRef,
-    pub file_not_found_error: PyObjectRef,
-    pub permission_error: PyObjectRef,
 }
 
 impl ExceptionZoo {
@@ -106,11 +106,16 @@ impl ExceptionZoo {
         object_type: &PyObjectRef,
         dict_type: &PyObjectRef,
     ) -> Self {
+        // Sorted By Hierarchy then alphabetized.
+
         let base_exception_type =
             create_type("BaseException", &type_type, &object_type, &dict_type);
 
         let exception_type = create_type("Exception", &type_type, &base_exception_type, &dict_type);
-        let syntax_error = create_type("SyntaxError", &type_type, &exception_type, &dict_type);
+
+        let runtime_error = create_type("RuntimeError", &type_type, &exception_type, &dict_type);
+        let import_error = create_type("ImportError", &type_type, &exception_type, &dict_type);
+
         let assertion_error =
             create_type("AssertionError", &type_type, &exception_type, &dict_type);
         let attribute_error = create_type(
@@ -119,6 +124,8 @@ impl ExceptionZoo {
             &exception_type.clone(),
             &dict_type,
         );
+        let file_not_found_error =
+            create_type("FileNotFoundError", &type_type, &import_error, &dict_type);
         let index_error = create_type(
             "IndexError",
             &type_type,
@@ -126,43 +133,40 @@ impl ExceptionZoo {
             &dict_type,
         );
         let key_error = create_type("KeyError", &type_type, &exception_type.clone(), &dict_type);
+        let module_not_found_error =
+            create_type("ModuleNotFoundError", &type_type, &import_error, &dict_type);
         let name_error = create_type("NameError", &type_type, &exception_type.clone(), &dict_type);
-        let runtime_error = create_type("RuntimeError", &type_type, &exception_type, &dict_type);
         let not_implemented_error = create_type(
             "NotImplementedError",
             &type_type,
             &runtime_error,
             &dict_type,
         );
-        let stop_iteration = create_type("StopIteration", &type_type, &exception_type, &dict_type);
-        let type_error = create_type("TypeError", &type_type, &exception_type, &dict_type);
-        let value_error = create_type("ValueError", &type_type, &exception_type, &dict_type);
-        let import_error = create_type("ImportError", &type_type, &exception_type, &dict_type);
-        let module_not_found_error =
-            create_type("ModuleNotFoundError", &type_type, &import_error, &dict_type);
-        let file_not_found_error =
-            create_type("FileNotFoundError", &type_type, &import_error, &dict_type);
         let permission_error =
             create_type("PermissionError", &type_type, &import_error, &dict_type);
+        let stop_iteration = create_type("StopIteration", &type_type, &exception_type, &dict_type);
+        let syntax_error = create_type("SyntaxError", &type_type, &exception_type, &dict_type);
+        let type_error = create_type("TypeError", &type_type, &exception_type, &dict_type);
+        let value_error = create_type("ValueError", &type_type, &exception_type, &dict_type);
 
         ExceptionZoo {
+            attribute_error: attribute_error,
+            assertion_error: assertion_error,
             base_exception_type: base_exception_type,
             exception_type: exception_type,
-            syntax_error: syntax_error,
-            assertion_error: assertion_error,
-            attribute_error: attribute_error,
+            file_not_found_error: file_not_found_error,
+            import_error: import_error,
             index_error: index_error,
             key_error: key_error,
+            module_not_found_error: module_not_found_error,
             name_error: name_error,
-            runtime_error: runtime_error,
             not_implemented_error: not_implemented_error,
+            permission_error: permission_error,
+            runtime_error: runtime_error,
             stop_iteration: stop_iteration,
+            syntax_error: syntax_error,
             type_error: type_error,
             value_error: value_error,
-            import_error: import_error,
-            module_not_found_error: module_not_found_error,
-            file_not_found_error: file_not_found_error,
-            permission_error: permission_error,
         }
     }
 }

--- a/vm/src/exceptions.rs
+++ b/vm/src/exceptions.rs
@@ -113,9 +113,6 @@ impl ExceptionZoo {
 
         let exception_type = create_type("Exception", &type_type, &base_exception_type, &dict_type);
 
-        let runtime_error = create_type("RuntimeError", &type_type, &exception_type, &dict_type);
-        let import_error = create_type("ImportError", &type_type, &exception_type, &dict_type);
-
         let assertion_error =
             create_type("AssertionError", &type_type, &exception_type, &dict_type);
         let attribute_error = create_type(
@@ -124,8 +121,7 @@ impl ExceptionZoo {
             &exception_type.clone(),
             &dict_type,
         );
-        let file_not_found_error =
-            create_type("FileNotFoundError", &type_type, &import_error, &dict_type);
+        let import_error = create_type("ImportError", &type_type, &exception_type, &dict_type);
         let index_error = create_type(
             "IndexError",
             &type_type,
@@ -133,9 +129,17 @@ impl ExceptionZoo {
             &dict_type,
         );
         let key_error = create_type("KeyError", &type_type, &exception_type.clone(), &dict_type);
+        let name_error = create_type("NameError", &type_type, &exception_type.clone(), &dict_type);
+        let runtime_error = create_type("RuntimeError", &type_type, &exception_type, &dict_type);
+        let stop_iteration = create_type("StopIteration", &type_type, &exception_type, &dict_type);
+        let syntax_error = create_type("SyntaxError", &type_type, &exception_type, &dict_type);
+        let type_error = create_type("TypeError", &type_type, &exception_type, &dict_type);
+        let value_error = create_type("ValueError", &type_type, &exception_type, &dict_type);
+
+        let file_not_found_error =
+            create_type("FileNotFoundError", &type_type, &import_error, &dict_type);
         let module_not_found_error =
             create_type("ModuleNotFoundError", &type_type, &import_error, &dict_type);
-        let name_error = create_type("NameError", &type_type, &exception_type.clone(), &dict_type);
         let not_implemented_error = create_type(
             "NotImplementedError",
             &type_type,
@@ -144,14 +148,10 @@ impl ExceptionZoo {
         );
         let permission_error =
             create_type("PermissionError", &type_type, &import_error, &dict_type);
-        let stop_iteration = create_type("StopIteration", &type_type, &exception_type, &dict_type);
-        let syntax_error = create_type("SyntaxError", &type_type, &exception_type, &dict_type);
-        let type_error = create_type("TypeError", &type_type, &exception_type, &dict_type);
-        let value_error = create_type("ValueError", &type_type, &exception_type, &dict_type);
 
         ExceptionZoo {
-            attribute_error: attribute_error,
             assertion_error: assertion_error,
+            attribute_error: attribute_error,
             base_exception_type: base_exception_type,
             exception_type: exception_type,
             file_not_found_error: file_not_found_error,


### PR DESCRIPTION
Reordered the Exception Zoo wherever possible.  In the case of the definitions, there is some dependence on their order of initialization, because of sub-classing.  In this case, I sorted first by location in the dependency hierarchy, and secondly by their alphabetic position.

I don't believe this change is easily testable (or needs it beyond, compilation), however please let me know if I can add any useful tests.