### PR TITLE
Allow compiling VM for wasm32-unknown-unknown

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -134,13 +134,13 @@ fn shell_exec(vm: &mut VirtualMachine, source: &str, scope: PyObjectRef) -> bool
     true
 }
 
-#[cfg(not(target_family = "unix"))]
+#[cfg(not(unix))]
 fn get_history_path() -> PathBuf {
     //Path buffer
     PathBuf::from(".repl_history.txt")
 }
 
-#[cfg(target_family = "unix")]
+#[cfg(unix)]
 fn get_history_path() -> PathBuf {
     //work around for windows dependent builds. The xdg crate is unix specific
     //so access to the BaseDirectories struct breaks builds on python.

--- a/vm/src/stdlib/os.rs
+++ b/vm/src/stdlib/os.rs
@@ -16,34 +16,44 @@ use super::super::obj::objtype;
 use super::super::pyobject::{PyContext, PyFuncArgs, PyObjectRef, PyResult, TypeProtocol};
 use super::super::vm::VirtualMachine;
 
-#[cfg(target_family = "unix")]
+#[cfg(unix)]
 pub fn raw_file_number(handle: File) -> i64 {
     use std::os::unix::io::IntoRawFd;
 
     i64::from(handle.into_raw_fd())
 }
 
-#[cfg(target_family = "unix")]
+#[cfg(unix)]
 pub fn rust_file(raw_fileno: i64) -> File {
     use std::os::unix::io::FromRawFd;
 
     unsafe { File::from_raw_fd(raw_fileno as i32) }
 }
 
-#[cfg(target_family = "windows")]
+#[cfg(windows)]
 pub fn raw_file_number(handle: File) -> i64 {
     use std::os::windows::io::IntoRawHandle;
 
     handle.into_raw_handle() as i64
 }
 
-#[cfg(target_family = "windows")]
+#[cfg(windows)]
 pub fn rust_file(raw_fileno: i64) -> File {
     use std::ffi::c_void;
     use std::os::windows::io::FromRawHandle;
 
     //This seems to work as expected but further testing is required.
     unsafe { File::from_raw_handle(raw_fileno as *mut c_void) }
+}
+
+#[cfg(all(not(unix), not(windows)))]
+pub fn rust_file(raw_fileno: i64) -> File {
+    unimplemented!();
+}
+
+#[cfg(all(not(unix), not(windows)))]
+pub fn raw_file_number(handle: File) -> i64 {
+    unimplemented!();
 }
 
 pub fn os_close(vm: &mut VirtualMachine, args: PyFuncArgs) -> PyResult {


### PR DESCRIPTION
This PR hides the file io behind `cfg` attributes so that RustPython can compile to a `std` without file descriptors.