### PR TITLE
Use the number of characters instead of bytes for str.__len__

### DIFF
--- a/tests/snippets/strings.py
+++ b/tests/snippets/strings.py
@@ -8,9 +8,9 @@ assert "\n" == """
 """
 
 assert len(""" " \" """) == 5
-assert len("\u00E9") == 1
-assert len("\u0065\u0301") == 2
-assert len("\u3042") == 1
+assert len("é") == 1
+assert len("é") == 2
+assert len("あ") == 1
 
 assert type("") is str
 assert type(b"") is bytes

--- a/tests/snippets/strings.py
+++ b/tests/snippets/strings.py
@@ -8,6 +8,9 @@ assert "\n" == """
 """
 
 assert len(""" " \" """) == 5
+assert len("\u00E9") == 1
+assert len("\u0065\u0301") == 2
+assert len("\u3042") == 1
 
 assert type("") is str
 assert type(b"") is bytes

--- a/vm/src/obj/objstr.rs
+++ b/vm/src/obj/objstr.rs
@@ -314,7 +314,7 @@ fn str_hash(vm: &mut VirtualMachine, args: PyFuncArgs) -> PyResult {
 fn str_len(vm: &mut VirtualMachine, args: PyFuncArgs) -> PyResult {
     arg_check!(vm, args, required = [(s, Some(vm.ctx.str_type()))]);
     let sv = get_value(s);
-    Ok(vm.ctx.new_int(sv.len().to_bigint().unwrap()))
+    Ok(vm.ctx.new_int(sv.chars().count().to_bigint().unwrap()))
 }
 
 fn str_mul(vm: &mut VirtualMachine, args: PyFuncArgs) -> PyResult {


### PR DESCRIPTION
Hi!
I've found current `str.__len__` returns the number of bytes instead of the number of characters as follows.

```
$ python3
>>> len("あ")
1

$ cargo run
>>>>> len("あ")
3
```

I've changed `str.__len__`  and added a few tests to cover this case.