### PR TITLE
Fixed the 'len_zero' clippy warnings

### DIFF
--- a/vm/src/builtins.rs
+++ b/vm/src/builtins.rs
@@ -465,7 +465,7 @@ fn builtin_max(vm: &mut VirtualMachine, args: PyFuncArgs) -> PyResult {
         return Err(vm.new_type_error("Expected 1 or more arguments".to_string()));
     };
 
-    if candidates.len() == 0 {
+    if candidates.is_empty() {
         let default = args.get_optional_kwarg("default");
         if default.is_none() {
             return Err(vm.new_value_error("max() arg is an empty sequence".to_string()));
@@ -516,7 +516,7 @@ fn builtin_min(vm: &mut VirtualMachine, args: PyFuncArgs) -> PyResult {
         return Err(vm.new_type_error("Expected 1 or more arguments".to_string()));
     };
 
-    if candidates.len() == 0 {
+    if candidates.is_empty() {
         let default = args.get_optional_kwarg("default");
         if default.is_none() {
             return Err(vm.new_value_error("min() arg is an empty sequence".to_string()));

--- a/vm/src/compile.rs
+++ b/vm/src/compile.rs
@@ -1156,7 +1156,7 @@ impl Compiler {
         generators: &Vec<ast::Comprehension>,
     ) -> Result<(), String> {
         // We must have at least one generator:
-        assert!(generators.len() > 0);
+        assert!(!generators.is_empty());
 
         let name = match kind {
             ast::ComprehensionKind::GeneratorExpression { .. } => "<genexpr>",
@@ -1201,8 +1201,7 @@ impl Compiler {
 
         let mut loop_labels = vec![];
         for generator in generators {
-            let first = loop_labels.len() == 0;
-            if first {
+            if loop_labels.is_empty() {
                 // Load iterator onto stack (passed as first argument):
                 self.emit(Instruction::LoadName {
                     name: String::from(".0"),

--- a/vm/src/format.rs
+++ b/vm/src/format.rs
@@ -87,7 +87,7 @@ fn parse_align(text: &str) -> (Option<FormatAlign>, &str) {
 
 fn parse_fill_and_align(text: &str) -> (Option<char>, Option<FormatAlign>, &str) {
     let char_indices: Vec<(usize, char)> = text.char_indices().take(3).collect();
-    if char_indices.len() == 0 {
+    if char_indices.is_empty() {
         (None, None, text)
     } else if char_indices.len() == 1 {
         let (maybe_align, remaining) = parse_align(text);
@@ -438,14 +438,14 @@ impl FormatString {
     fn parse_literal(text: &str) -> Result<(FormatPart, &str), FormatParseError> {
         let mut cur_text = text;
         let mut result_string = String::new();
-        while cur_text.len() > 0 {
+        while !cur_text.is_empty() {
             match FormatString::parse_literal_single(cur_text) {
                 Ok((next_char, remaining)) => {
                     result_string.push(next_char);
                     cur_text = remaining;
                 }
                 Err(err) => {
-                    if result_string.len() > 0 {
+                    if !result_string.is_empty() {
                         return Ok((FormatPart::Literal(result_string.to_string()), cur_text));
                     } else {
                         return Err(err);
@@ -467,7 +467,7 @@ impl FormatString {
             String::new()
         };
 
-        if arg_part.len() == 0 {
+        if arg_part.is_empty() {
             return Ok(FormatPart::AutoSpec(format_spec));
         }
 
@@ -500,7 +500,7 @@ impl FormatString {
     pub fn from_str(text: &str) -> Result<FormatString, FormatParseError> {
         let mut cur_text: &str = text;
         let mut parts: Vec<FormatPart> = Vec::new();
-        while cur_text.len() > 0 {
+        while !cur_text.is_empty() {
             // Try to parse both literals and bracketed format parts util we
             // run out of text
             cur_text = FormatString::parse_literal(cur_text)

--- a/vm/src/obj/objset.rs
+++ b/vm/src/obj/objset.rs
@@ -98,7 +98,7 @@ fn set_repr(vm: &mut VirtualMachine, args: PyFuncArgs) -> PyResult {
     arg_check!(vm, args, required = [(o, Some(vm.ctx.set_type()))]);
 
     let elements = get_elements(o);
-    let s = if elements.len() == 0 {
+    let s = if elements.is_empty() {
         "set()".to_string()
     } else {
         let mut str_parts = vec![];
@@ -136,7 +136,7 @@ fn frozenset_repr(vm: &mut VirtualMachine, args: PyFuncArgs) -> PyResult {
     arg_check!(vm, args, required = [(o, Some(vm.ctx.frozenset_type()))]);
 
     let elements = get_elements(o);
-    let s = if elements.len() == 0 {
+    let s = if elements.is_empty() {
         "frozenset()".to_string()
     } else {
         let mut str_parts = vec![];

--- a/vm/src/obj/objstr.rs
+++ b/vm/src/obj/objstr.rs
@@ -208,7 +208,7 @@ fn str_add(vm: &mut VirtualMachine, args: PyFuncArgs) -> PyResult {
 }
 
 fn str_format(vm: &mut VirtualMachine, args: PyFuncArgs) -> PyResult {
-    if args.args.len() == 0 {
+    if args.args.is_empty() {
         return Err(
             vm.new_type_error("descriptor 'format' of 'str' object needs an argument".to_string())
         );

--- a/vm/src/stdlib/io.rs
+++ b/vm/src/stdlib/io.rs
@@ -295,7 +295,7 @@ pub fn io_open(vm: &mut VirtualMachine, args: PyFuncArgs) -> PyResult {
         .filter(|a| raw_modes.contains(&a.to_string()))
         .collect();
 
-    if modes.len() == 0 || modes.len() > 1 {
+    if modes.is_empty() || modes.len() > 1 {
         return Err(vm.new_value_error("Invalid Mode".to_string()));
     }
 

--- a/vm/src/stdlib/pystruct.rs
+++ b/vm/src/stdlib/pystruct.rs
@@ -169,7 +169,7 @@ fn pack_f64(
 }
 
 fn struct_pack(vm: &mut VirtualMachine, args: PyFuncArgs) -> PyResult {
-    if args.args.len() < 1 {
+    if args.args.is_empty() {
         Err(vm.new_type_error(format!(
             "Expected at least 1 argument (got: {})",
             args.args.len()


### PR DESCRIPTION
This replaces all the occurrences of the <collection>.len() == 0
with the <collection>.is_empty() and the occurrences of the
<collection>.len() > 0 with the !<collection>.is_empty()

Relevant clippy warning: https://rust-lang.github.io/rust-clippy/master/index.html#len_zero

This is a part of the #312