### PR TITLE
Fixed the 'ptr_arg' clippy warnings

### DIFF
--- a/vm/src/compile.rs
+++ b/vm/src/compile.rs
@@ -674,14 +674,14 @@ impl Compiler {
         Ok(flags)
     }
 
-    fn prepare_decorators(&mut self, decorator_list: &Vec<ast::Expression>) -> Result<(), String> {
+    fn prepare_decorators(&mut self, decorator_list: &[ast::Expression]) -> Result<(), String> {
         for decorator in decorator_list {
             self.compile_expression(decorator)?;
         }
         Ok(())
     }
 
-    fn apply_decorators(&mut self, decorator_list: &Vec<ast::Expression>) {
+    fn apply_decorators(&mut self, decorator_list: &[ast::Expression]) {
         // Apply decorators:
         for _ in decorator_list {
             self.emit(Instruction::CallFunction {
@@ -1036,8 +1036,8 @@ impl Compiler {
     fn compile_call(
         &mut self,
         function: &ast::Expression,
-        args: &Vec<ast::Expression>,
-        keywords: &Vec<ast::Keyword>,
+        args: &[ast::Expression],
+        keywords: &[ast::Keyword],
     ) -> Result<(), String> {
         self.compile_expression(function)?;
         let count = args.len() + keywords.len();
@@ -1123,7 +1123,7 @@ impl Compiler {
 
     // Given a vector of expr / star expr generate code which gives either
     // a list of expressions on the stack, or a list of tuples.
-    fn gather_elements(&mut self, elements: &Vec<ast::Expression>) -> Result<bool, String> {
+    fn gather_elements(&mut self, elements: &[ast::Expression]) -> Result<bool, String> {
         // First determine if we have starred elements:
         let has_stars = elements.iter().any(|e| {
             if let ast::Expression::Starred { .. } = e {
@@ -1153,7 +1153,7 @@ impl Compiler {
     fn compile_comprehension(
         &mut self,
         kind: &ast::ComprehensionKind,
-        generators: &Vec<ast::Comprehension>,
+        generators: &[ast::Comprehension],
     ) -> Result<(), String> {
         // We must have at least one generator:
         assert!(generators.len() > 0);

--- a/vm/src/obj/objsequence.rs
+++ b/vm/src/obj/objsequence.rs
@@ -112,8 +112,8 @@ pub fn get_item(
 
 pub fn seq_equal(
     vm: &mut VirtualMachine,
-    zelf: &Vec<PyObjectRef>,
-    other: &Vec<PyObjectRef>,
+    zelf: &[PyObjectRef],
+    other: &[PyObjectRef],
 ) -> Result<bool, PyObjectRef> {
     if zelf.len() == other.len() {
         for (a, b) in Iterator::zip(zelf.iter(), other.iter()) {
@@ -131,8 +131,8 @@ pub fn seq_equal(
 
 pub fn seq_lt(
     vm: &mut VirtualMachine,
-    zelf: &Vec<PyObjectRef>,
-    other: &Vec<PyObjectRef>,
+    zelf: &[PyObjectRef],
+    other: &[PyObjectRef],
 ) -> Result<bool, PyObjectRef> {
     if zelf.len() == other.len() {
         for (a, b) in Iterator::zip(zelf.iter(), other.iter()) {
@@ -171,8 +171,8 @@ pub fn seq_lt(
 
 pub fn seq_gt(
     vm: &mut VirtualMachine,
-    zelf: &Vec<PyObjectRef>,
-    other: &Vec<PyObjectRef>,
+    zelf: &[PyObjectRef],
+    other: &[PyObjectRef],
 ) -> Result<bool, PyObjectRef> {
     if zelf.len() == other.len() {
         for (a, b) in Iterator::zip(zelf.iter(), other.iter()) {
@@ -210,21 +210,21 @@ pub fn seq_gt(
 
 pub fn seq_ge(
     vm: &mut VirtualMachine,
-    zelf: &Vec<PyObjectRef>,
-    other: &Vec<PyObjectRef>,
+    zelf: &[PyObjectRef],
+    other: &[PyObjectRef],
 ) -> Result<bool, PyObjectRef> {
     Ok(seq_gt(vm, zelf, other)? || seq_equal(vm, zelf, other)?)
 }
 
 pub fn seq_le(
     vm: &mut VirtualMachine,
-    zelf: &Vec<PyObjectRef>,
-    other: &Vec<PyObjectRef>,
+    zelf: &[PyObjectRef],
+    other: &[PyObjectRef],
 ) -> Result<bool, PyObjectRef> {
     Ok(seq_lt(vm, zelf, other)? || seq_equal(vm, zelf, other)?)
 }
 
-pub fn seq_mul(elements: &Vec<PyObjectRef>, product: &PyObjectRef) -> Vec<PyObjectRef> {
+pub fn seq_mul(elements: &[PyObjectRef], product: &PyObjectRef) -> Vec<PyObjectRef> {
     let counter = objint::get_value(&product).to_isize().unwrap();
 
     let current_len = elements.len();
@@ -232,7 +232,7 @@ pub fn seq_mul(elements: &Vec<PyObjectRef>, product: &PyObjectRef) -> Vec<PyObje
     let mut new_elements = Vec::with_capacity(new_len);
 
     for _ in 0..counter {
-        new_elements.extend(elements.clone());
+        new_elements.extend(elements.clone().to_owned());
     }
 
     new_elements

--- a/vm/src/obj/objset.rs
+++ b/vm/src/obj/objset.rs
@@ -22,7 +22,7 @@ pub fn get_elements(obj: &PyObjectRef) -> HashMap<usize, PyObjectRef> {
     }
 }
 
-pub fn sequence_to_hashmap(iterable: &Vec<PyObjectRef>) -> HashMap<usize, PyObjectRef> {
+pub fn sequence_to_hashmap(iterable: &[PyObjectRef]) -> HashMap<usize, PyObjectRef> {
     let mut elements = HashMap::new();
     for item in iterable {
         let key = item.get_id();

--- a/vm/src/obj/objstr.rs
+++ b/vm/src/obj/objstr.rs
@@ -238,9 +238,9 @@ fn str_format(vm: &mut VirtualMachine, args: PyFuncArgs) -> PyResult {
 fn call_object_format(
     vm: &mut VirtualMachine,
     argument: PyObjectRef,
-    format_spec: &String,
+    format_spec: &str,
 ) -> PyResult {
-    let returned_type = vm.ctx.new_str(format_spec.clone());
+    let returned_type = vm.ctx.new_str(format_spec.to_string());
     let result = vm.call_method(&argument, "__format__", vec![returned_type])?;
     if !objtype::isinstance(&result, &vm.ctx.str_type()) {
         let result_type = result.typ();

--- a/vm/src/stdlib/ast.rs
+++ b/vm/src/stdlib/ast.rs
@@ -239,7 +239,7 @@ fn statement_to_ast(ctx: &PyContext, statement: &ast::LocatedStatement) -> PyObj
     node
 }
 
-fn expressions_to_ast(ctx: &PyContext, expressions: &Vec<ast::Expression>) -> PyObjectRef {
+fn expressions_to_ast(ctx: &PyContext, expressions: &[ast::Expression]) -> PyObjectRef {
     let mut py_expression_nodes = vec![];
     for expression in expressions {
         py_expression_nodes.push(expression_to_ast(ctx, expression));

--- a/vm/src/stdlib/io.rs
+++ b/vm/src/stdlib/io.rs
@@ -26,7 +26,7 @@ use super::super::pyobject::{
 
 use super::super::vm::VirtualMachine;
 
-fn compute_c_flag(mode: &String) -> u16 {
+fn compute_c_flag(mode: &str) -> u16 {
     match mode.as_ref() {
         "w" => 512,
         "x" => 512,


### PR DESCRIPTION
This replaces all the occurrences of &<dynamic collection><T> with the &[T].

Relevant clippy warning: https://rust-lang.github.io/rust-clippy/master/index.html#ptr_arg

This is a part of the #312