### PR TITLE
Fixed the 'unneeded_field_pattern' clippy warnings

### DIFF
--- a/vm/src/frame.rs
+++ b/vm/src/frame.rs
@@ -522,7 +522,7 @@ impl Frame {
 
             bytecode::Instruction::Break => {
                 let block = self.unwind_loop(vm);
-                if let Block::Loop { start: _, end } = block {
+                if let Block::Loop { end, .. } = block {
                     self.jump(end);
                 }
                 Ok(None)
@@ -533,7 +533,7 @@ impl Frame {
             }
             bytecode::Instruction::Continue => {
                 let block = self.unwind_loop(vm);
-                if let Block::Loop { start, end: _ } = block {
+                if let Block::Loop { start, .. } = block {
                     self.jump(start);
                 } else {
                     assert!(false);
@@ -708,8 +708,7 @@ impl Frame {
                     // TODO: execute finally handler
                 }
                 Some(Block::With {
-                    end: _,
-                    context_manager,
+                    context_manager, ..
                 }) => {
                     match self.with_exit(vm, &context_manager, None) {
                         Ok(..) => {}
@@ -728,13 +727,12 @@ impl Frame {
         loop {
             let block = self.pop_block();
             match block {
-                Some(Block::Loop { start: _, end: __ }) => break block.unwrap(),
+                Some(Block::Loop { .. }) => break block.unwrap(),
                 Some(Block::TryExcept { .. }) => {
                     // TODO: execute finally handler
                 }
                 Some(Block::With {
-                    end: _,
-                    context_manager,
+                    context_manager, ..
                 }) => match self.with_exit(vm, &context_manager, None) {
                     Ok(..) => {}
                     Err(exc) => {

--- a/vm/src/obj/objsequence.rs
+++ b/vm/src/obj/objsequence.rs
@@ -90,13 +90,10 @@ pub fn get_item(
                 Err(vm.new_index_error("cannot fit 'int' into an index-sized integer".to_string()))
             }
         },
-        PyObjectPayload::Slice {
-            start: _,
-            stop: _,
-            step: _,
-        } => Ok(PyObject::new(
+
+        PyObjectPayload::Slice { .. } => Ok(PyObject::new(
             match &(sequence.borrow()).payload {
-                PyObjectPayload::Sequence { elements: _ } => PyObjectPayload::Sequence {
+                PyObjectPayload::Sequence { .. } => PyObjectPayload::Sequence {
                     elements: elements.to_vec().get_slice_items(&subscript),
                 },
                 ref payload => panic!("sequence get_item called for non-sequence: {:?}", payload),

--- a/vm/src/obj/objstr.rs
+++ b/vm/src/obj/objstr.rs
@@ -1030,11 +1030,9 @@ pub fn subscript(vm: &mut VirtualMachine, value: &str, b: PyObjectRef) -> PyResu
         }
     } else {
         match &(*b.borrow()).payload {
-            &PyObjectPayload::Slice {
-                start: _,
-                stop: _,
-                step: _,
-            } => Ok(vm.new_str(value.to_string().get_slice_items(&b).to_string())),
+            &PyObjectPayload::Slice { .. } => {
+                Ok(vm.new_str(value.to_string().get_slice_items(&b).to_string()))
+            }
             _ => panic!(
                 "TypeError: indexing type {:?} with index {:?} is not supported (yet?)",
                 value, b

--- a/vm/src/obj/objtype.rs
+++ b/vm/src/obj/objtype.rs
@@ -89,12 +89,7 @@ pub fn issubclass(typ: &PyObjectRef, cls: &PyObjectRef) -> bool {
 }
 
 pub fn get_type_name(typ: &PyObjectRef) -> String {
-    if let PyObjectPayload::Class {
-        name,
-        dict: _,
-        mro: _,
-    } = &typ.borrow().payload
-    {
+    if let PyObjectPayload::Class { name, .. } = &typ.borrow().payload {
         name.clone()
     } else {
         panic!("Cannot get type_name of non-type type {:?}", typ);
@@ -219,12 +214,7 @@ pub fn get_attributes(obj: &PyObjectRef) -> HashMap<String, PyObjectRef> {
     let mut base_classes = objtype::base_classes(obj);
     base_classes.reverse();
     for bc in base_classes {
-        if let PyObjectPayload::Class {
-            name: _,
-            dict,
-            mro: _,
-        } = &bc.borrow().payload
-        {
+        if let PyObjectPayload::Class { dict, .. } = &bc.borrow().payload {
             let elements = objdict::get_key_value_pairs(dict);
             for (name, value) in elements.iter() {
                 let name = objstr::get_value(name);

--- a/vm/src/pyobject.rs
+++ b/vm/src/pyobject.rs
@@ -436,17 +436,11 @@ impl PyContext {
     }
 
     pub fn new_tuple(&self, elements: Vec<PyObjectRef>) -> PyObjectRef {
-        PyObject::new(
-            PyObjectPayload::Sequence { elements: elements },
-            self.tuple_type(),
-        )
+        PyObject::new(PyObjectPayload::Sequence { elements }, self.tuple_type())
     }
 
     pub fn new_list(&self, elements: Vec<PyObjectRef>) -> PyObjectRef {
-        PyObject::new(
-            PyObjectPayload::Sequence { elements: elements },
-            self.list_type(),
-        )
+        PyObject::new(PyObjectPayload::Sequence { elements }, self.list_type())
     }
 
     pub fn new_set(&self, elements: Vec<PyObjectRef>) -> PyObjectRef {
@@ -469,12 +463,11 @@ impl PyContext {
 
     pub fn new_scope(&self, parent: Option<PyObjectRef>) -> PyObjectRef {
         let locals = self.new_dict();
-        let scope = Scope {
-            locals: locals,
-            parent: parent,
-        };
+
+        let scope = Scope { locals, parent };
+
         PyObject {
-            payload: PyObjectPayload::Scope { scope: scope },
+            payload: PyObjectPayload::Scope { scope },
             typ: None,
         }
         .into_ref()
@@ -553,10 +546,7 @@ impl PyContext {
 
     pub fn new_bound_method(&self, function: PyObjectRef, object: PyObjectRef) -> PyObjectRef {
         PyObject::new(
-            PyObjectPayload::BoundMethod {
-                function: function,
-                object: object,
-            },
+            PyObjectPayload::BoundMethod { function, object },
             self.bound_method_type(),
         )
     }
@@ -581,10 +571,7 @@ impl PyContext {
                 let key = self.new_str(key.to_string());
                 objdict::set_item_in_content(elements, &key, &v);
             }
-            PyObjectPayload::Module {
-                name: _,
-                ref mut dict,
-            } => self.set_item(dict, key, v),
+            PyObjectPayload::Module { ref mut dict, .. } => self.set_item(dict, key, v),
             PyObjectPayload::Scope { ref mut scope } => {
                 self.set_item(&scope.locals, key, v);
             }
@@ -601,13 +588,9 @@ impl PyContext {
 
     pub fn set_attr(&self, obj: &PyObjectRef, attr_name: &str, value: PyObjectRef) {
         match obj.borrow().payload {
-            PyObjectPayload::Module { name: _, ref dict } => self.set_item(dict, attr_name, value),
+            PyObjectPayload::Module { ref dict, .. } => self.set_item(dict, attr_name, value),
             PyObjectPayload::Instance { ref dict } => self.set_item(dict, attr_name, value),
-            PyObjectPayload::Class {
-                name: _,
-                ref dict,
-                mro: _,
-            } => self.set_item(dict, attr_name, value),
+            PyObjectPayload::Class { ref dict, .. } => self.set_item(dict, attr_name, value),
             ref payload => unimplemented!("set_attr unimplemented for: {:?}", payload),
         };
     }
@@ -732,7 +715,7 @@ impl AttributeProtocol for PyObjectRef {
     fn has_attr(&self, attr_name: &str) -> bool {
         let obj = self.borrow();
         match obj.payload {
-            PyObjectPayload::Module { name: _, ref dict } => dict.contains_key(attr_name),
+            PyObjectPayload::Module { ref dict, .. } => dict.contains_key(attr_name),
             PyObjectPayload::Class { ref mro, .. } => {
                 class_has_item(self, attr_name)
                     || mro.into_iter().any(|d| class_has_item(d, attr_name))
@@ -755,7 +738,7 @@ impl DictProtocol for PyObjectRef {
             PyObjectPayload::Dict { ref elements } => {
                 objdict::content_contains_key_str(elements, k)
             }
-            PyObjectPayload::Module { name: _, ref dict } => dict.contains_key(k),
+            PyObjectPayload::Module { ref dict, .. } => dict.contains_key(k),
             PyObjectPayload::Scope { ref scope } => scope.locals.contains_key(k),
             ref payload => unimplemented!("TODO {:?}", payload),
         }
@@ -764,7 +747,7 @@ impl DictProtocol for PyObjectRef {
     fn get_item(&self, k: &str) -> Option<PyObjectRef> {
         match self.borrow().payload {
             PyObjectPayload::Dict { ref elements } => objdict::content_get_key_str(elements, k),
-            PyObjectPayload::Module { name: _, ref dict } => dict.get_item(k),
+            PyObjectPayload::Module { ref dict, .. } => dict.get_item(k),
             PyObjectPayload::Scope { ref scope } => scope.locals.get_item(k),
             _ => panic!("TODO"),
         }
@@ -772,8 +755,8 @@ impl DictProtocol for PyObjectRef {
 
     fn get_key_value_pairs(&self) -> Vec<(PyObjectRef, PyObjectRef)> {
         match self.borrow().payload {
-            PyObjectPayload::Dict { elements: _ } => objdict::get_key_value_pairs(self),
-            PyObjectPayload::Module { name: _, ref dict } => dict.get_key_value_pairs(),
+            PyObjectPayload::Dict { .. } => objdict::get_key_value_pairs(self),
+            PyObjectPayload::Module { ref dict, .. } => dict.get_key_value_pairs(),
             PyObjectPayload::Scope { ref scope } => scope.locals.get_key_value_pairs(),
             _ => panic!("TODO"),
         }
@@ -815,10 +798,7 @@ impl PyFuncArgs {
         for name in kwarg_names.iter().rev() {
             kwargs.push((name.clone(), args.pop().unwrap()));
         }
-        PyFuncArgs {
-            args: args,
-            kwargs: kwargs,
-        }
+        PyFuncArgs { args, kwargs }
     }
 
     pub fn insert(&self, item: PyObjectRef) -> PyFuncArgs {
@@ -948,37 +928,26 @@ impl fmt::Debug for PyObjectPayload {
             PyObjectPayload::Complex { ref value } => write!(f, "complex {}", value),
             PyObjectPayload::Bytes { ref value } => write!(f, "bytes/bytearray {:?}", value),
             PyObjectPayload::MemoryView { ref obj } => write!(f, "bytes/bytearray {:?}", obj),
-            PyObjectPayload::Sequence { elements: _ } => write!(f, "list or tuple"),
-            PyObjectPayload::Dict { elements: _ } => write!(f, "dict"),
-            PyObjectPayload::Set { elements: _ } => write!(f, "set"),
+            PyObjectPayload::Sequence { .. } => write!(f, "list or tuple"),
+            PyObjectPayload::Dict { .. } => write!(f, "dict"),
+            PyObjectPayload::Set { .. } => write!(f, "set"),
             PyObjectPayload::WeakRef { .. } => write!(f, "weakref"),
-            PyObjectPayload::Iterator {
-                position: _,
-                iterated_obj: _,
-            } => write!(f, "iterator"),
-            PyObjectPayload::Slice {
-                start: _,
-                stop: _,
-                step: _,
-            } => write!(f, "slice"),
-            &PyObjectPayload::Range { range: _ } => write!(f, "range"),
-            &PyObjectPayload::Code { ref code } => write!(f, "code: {:?}", code),
-            &PyObjectPayload::Function { .. } => write!(f, "function"),
-            &PyObjectPayload::Generator { .. } => write!(f, "generator"),
-            &PyObjectPayload::BoundMethod {
+            PyObjectPayload::Range { .. } => write!(f, "range"),
+            PyObjectPayload::Iterator { .. } => write!(f, "iterator"),
+            PyObjectPayload::Slice { .. } => write!(f, "slice"),
+            PyObjectPayload::Code { ref code } => write!(f, "code: {:?}", code),
+            PyObjectPayload::Function { .. } => write!(f, "function"),
+            PyObjectPayload::Generator { .. } => write!(f, "generator"),
+            PyObjectPayload::BoundMethod {
                 ref function,
                 ref object,
             } => write!(f, "bound-method: {:?} of {:?}", function, object),
-            PyObjectPayload::Module { name: _, dict: _ } => write!(f, "module"),
-            PyObjectPayload::Scope { scope: _ } => write!(f, "scope"),
+            PyObjectPayload::Module { .. } => write!(f, "module"),
+            PyObjectPayload::Scope { .. } => write!(f, "scope"),
             PyObjectPayload::None => write!(f, "None"),
-            PyObjectPayload::Class {
-                ref name,
-                dict: _,
-                mro: _,
-            } => write!(f, "class {:?}", name),
-            PyObjectPayload::Instance { dict: _ } => write!(f, "instance"),
-            PyObjectPayload::RustFunction { function: _ } => write!(f, "rust function"),
+            PyObjectPayload::Class { ref name, .. } => write!(f, "class {:?}", name),
+            PyObjectPayload::Instance { .. } => write!(f, "instance"),
+            PyObjectPayload::RustFunction { .. } => write!(f, "rust function"),
             PyObjectPayload::Frame { .. } => write!(f, "frame"),
         }
     }
@@ -1035,16 +1004,17 @@ impl PyObject {
             PyObjectPayload::Class {
                 ref name,
                 dict: ref _dict,
-                mro: _,
+                ..
             } => format!("<class '{}'>", name),
-            PyObjectPayload::Instance { dict: _ } => format!("<instance>"),
-            PyObjectPayload::Code { code: _ } => format!("<code>"),
-            PyObjectPayload::Function { .. } => format!("<func>"),
-            PyObjectPayload::Generator { .. } => format!("<generator>"),
-            PyObjectPayload::Frame { .. } => format!("<frame>"),
-            PyObjectPayload::BoundMethod { .. } => format!("<bound-method>"),
-            PyObjectPayload::RustFunction { function: _ } => format!("<rustfunc>"),
-            PyObjectPayload::Module { ref name, dict: _ } => format!("<module '{}'>", name),
+
+            PyObjectPayload::Instance { .. } => "<instance>".to_string(),
+            PyObjectPayload::Code { .. } => "<code>".to_string(),
+            PyObjectPayload::Function { .. } => "<func>".to_string(),
+            PyObjectPayload::Generator { .. } => "<generator>".to_string(),
+            PyObjectPayload::Frame { .. } => "<frame>".to_string(),
+            PyObjectPayload::BoundMethod { .. } => "<bound-method>".to_string(),
+            PyObjectPayload::RustFunction { .. } => "<rustfunc>".to_string(),
+            PyObjectPayload::Module { ref name, .. } => format!("<module '{}'>", name),
             PyObjectPayload::Scope { ref scope } => format!("<scope '{:?}'>", scope),
             PyObjectPayload::Slice {
                 ref start,

--- a/vm/src/stdlib/ast.rs
+++ b/vm/src/stdlib/ast.rs
@@ -64,9 +64,8 @@ fn statement_to_ast(ctx: &PyContext, statement: &ast::LocatedStatement) -> PyObj
         ast::Statement::ClassDef {
             name,
             body,
-            bases: _,
-            keywords: _,
             decorator_list,
+            ..
         } => {
             let node = create_node(ctx, "ClassDef");
 
@@ -249,11 +248,7 @@ fn expressions_to_ast(ctx: &PyContext, expressions: &Vec<ast::Expression>) -> Py
 
 fn expression_to_ast(ctx: &PyContext, expression: &ast::Expression) -> PyObjectRef {
     let node = match &expression {
-        ast::Expression::Call {
-            function,
-            args,
-            keywords: _,
-        } => {
+        ast::Expression::Call { function, args, .. } => {
             let node = create_node(ctx, "Call");
 
             let py_func_ast = expression_to_ast(ctx, function);

--- a/vm/src/vm.rs
+++ b/vm/src/vm.rs
@@ -164,7 +164,7 @@ impl VirtualMachine {
     pub fn get_builtin_scope(&mut self) -> PyObjectRef {
         let a2 = &*self.builtins.borrow();
         match a2.payload {
-            PyObjectPayload::Module { name: _, ref dict } => dict.clone(),
+            PyObjectPayload::Module { ref dict, .. } => dict.clone(),
             _ => {
                 panic!("OMG");
             }
@@ -250,11 +250,7 @@ impl VirtualMachine {
                 ref scope,
                 ref defaults,
             } => self.invoke_python_function(code, scope, defaults, args),
-            PyObjectPayload::Class {
-                name: _,
-                dict: _,
-                mro: _,
-            } => self.call_method_pyargs(&func_ref, "__call__", args),
+            PyObjectPayload::Class { .. } => self.call_method_pyargs(&func_ref, "__call__", args),
             PyObjectPayload::BoundMethod {
                 ref function,
                 ref object,


### PR DESCRIPTION
This replaces all the occurrences of the Struct {field: _} with the Struct { .. }.

Relevant clippy warning: https://rust-lang.github.io/rust-clippy/master/index.html#unneeded_field_pattern

This is a part of the #312 