### PR TITLE
Fixed the 'needless_return' clippy warnings

### DIFF
--- a/vm/src/obj/objint.rs
+++ b/vm/src/obj/objint.rs
@@ -205,9 +205,7 @@ fn int_lshift(vm: &mut VirtualMachine, args: PyFuncArgs) -> PyResult {
 
     // i2 failed `to_usize()` conversion
     match get_value(i2) {
-        ref v if *v < BigInt::zero() => {
-            return Err(vm.new_value_error("negative shift count".to_string()));
-        }
+        ref v if *v < BigInt::zero() => Err(vm.new_value_error("negative shift count".to_string())),
         ref v if *v > BigInt::from(usize::max_value()) => {
             // TODO: raise OverflowError
             panic!("Failed converting {} to rust usize", get_value(i2));
@@ -237,9 +235,7 @@ fn int_rshift(vm: &mut VirtualMachine, args: PyFuncArgs) -> PyResult {
 
     // i2 failed `to_usize()` conversion
     match get_value(i2) {
-        ref v if *v < BigInt::zero() => {
-            return Err(vm.new_value_error("negative shift count".to_string()));
-        }
+        ref v if *v < BigInt::zero() => Err(vm.new_value_error("negative shift count".to_string())),
         ref v if *v > BigInt::from(usize::max_value()) => {
             // TODO: raise OverflowError
             panic!("Failed converting {} to rust usize", get_value(i2));

--- a/vm/src/obj/objstr.rs
+++ b/vm/src/obj/objstr.rs
@@ -1081,5 +1081,5 @@ fn make_title(s: &str) -> String {
             capitalize_char = true;
         }
     }
-    return titled_str;
+    titled_str
 }

--- a/vm/src/pyobject.rs
+++ b/vm/src/pyobject.rs
@@ -827,7 +827,7 @@ impl PyFuncArgs {
             kwargs: self.kwargs.clone(),
         };
         args.args.insert(0, item);
-        return args;
+        args
     }
 
     pub fn shift(&mut self) -> PyObjectRef {


### PR DESCRIPTION
This replaces all the occurrences of the 'return var;' at the end of the functions with the 'var'.

Relevant clippy warning: https://rust-lang.github.io/rust-clippy/master/index.html#needless_return

This is a part of the #312 