### PR TITLE
Fixed the 'toplevel_ref_arg' clippy warning

### DIFF
--- a/vm/src/obj/objbool.rs
+++ b/vm/src/obj/objbool.rs
@@ -30,13 +30,13 @@ pub fn boolval(vm: &mut VirtualMachine, obj: PyObjectRef) -> Result<bool, PyObje
 }
 
 pub fn init(context: &PyContext) {
-    let ref bool_type = context.bool_type;
     let bool_doc = "bool(x) -> bool
 
 Returns True when the argument x is true, False otherwise.
 The builtins True and False are the only two instances of the class bool.
 The class bool is a subclass of the class int, and cannot be subclassed.";
 
+    let bool_type = &context.bool_type;
     context.set_attr(&bool_type, "__new__", context.new_rustfunc(bool_new));
     context.set_attr(&bool_type, "__repr__", context.new_rustfunc(bool_repr));
     context.set_attr(&bool_type, "__doc__", context.new_str(bool_doc.to_string()));

--- a/vm/src/obj/objbytearray.rs
+++ b/vm/src/obj/objbytearray.rs
@@ -16,7 +16,7 @@ use num_traits::ToPrimitive;
 
 /// Fill bytearray class methods dictionary.
 pub fn init(context: &PyContext) {
-    let ref bytearray_type = context.bytearray_type;
+    let bytearray_type = &context.bytearray_type;
     context.set_attr(
         &bytearray_type,
         "__eq__",

--- a/vm/src/obj/objbytes.rs
+++ b/vm/src/obj/objbytes.rs
@@ -14,7 +14,7 @@ use std::ops::Deref;
 
 // Fill bytes class methods:
 pub fn init(context: &PyContext) {
-    let ref bytes_type = context.bytes_type;
+    let bytes_type = &context.bytes_type;
     context.set_attr(bytes_type, "__eq__", context.new_rustfunc(bytes_eq));
     context.set_attr(bytes_type, "__hash__", context.new_rustfunc(bytes_hash));
     context.set_attr(bytes_type, "__new__", context.new_rustfunc(bytes_new));

--- a/vm/src/obj/objcode.rs
+++ b/vm/src/obj/objcode.rs
@@ -10,7 +10,7 @@ use super::super::vm::VirtualMachine;
 use super::objtype;
 
 pub fn init(context: &PyContext) {
-    let ref code_type = context.code_type;
+    let code_type = &context.code_type;
     context.set_attr(code_type, "__new__", context.new_rustfunc(code_new));
     context.set_attr(code_type, "__repr__", context.new_rustfunc(code_repr));
 }

--- a/vm/src/obj/objcomplex.rs
+++ b/vm/src/obj/objcomplex.rs
@@ -7,7 +7,7 @@ use super::objtype;
 use num_complex::Complex64;
 
 pub fn init(context: &PyContext) {
-    let ref complex_type = context.complex_type;
+    let complex_type = &context.complex_type;
     context.set_attr(&complex_type, "__add__", context.new_rustfunc(complex_add));
     context.set_attr(&complex_type, "__new__", context.new_rustfunc(complex_new));
     context.set_attr(

--- a/vm/src/obj/objdict.rs
+++ b/vm/src/obj/objdict.rs
@@ -284,7 +284,7 @@ pub fn create_type(type_type: PyObjectRef, object_type: PyObjectRef, dict_type: 
 }
 
 pub fn init(context: &PyContext) {
-    let ref dict_type = context.dict_type;
+    let dict_type = &context.dict_type;
     context.set_attr(&dict_type, "__len__", context.new_rustfunc(dict_len));
     context.set_attr(
         &dict_type,

--- a/vm/src/obj/objfloat.rs
+++ b/vm/src/obj/objfloat.rs
@@ -267,7 +267,7 @@ fn float_pow(vm: &mut VirtualMachine, args: PyFuncArgs) -> PyResult {
 }
 
 pub fn init(context: &PyContext) {
-    let ref float_type = context.float_type;
+    let float_type = &context.float_type;
     context.set_attr(&float_type, "__eq__", context.new_rustfunc(float_eq));
     context.set_attr(&float_type, "__lt__", context.new_rustfunc(float_lt));
     context.set_attr(&float_type, "__le__", context.new_rustfunc(float_le));

--- a/vm/src/obj/objframe.rs
+++ b/vm/src/obj/objframe.rs
@@ -10,7 +10,7 @@ use super::super::vm::VirtualMachine;
 use super::objtype;
 
 pub fn init(context: &PyContext) {
-    let ref frame_type = context.frame_type;
+    let frame_type = &context.frame_type;
     context.set_attr(&frame_type, "__new__", context.new_rustfunc(frame_new));
     context.set_attr(&frame_type, "__repr__", context.new_rustfunc(frame_repr));
     context.set_attr(&frame_type, "f_locals", context.new_property(frame_flocals));

--- a/vm/src/obj/objfunction.rs
+++ b/vm/src/obj/objfunction.rs
@@ -6,17 +6,17 @@ use super::super::vm::VirtualMachine;
 use super::objtype;
 
 pub fn init(context: &PyContext) {
-    let ref function_type = context.function_type;
+    let function_type = &context.function_type;
     context.set_attr(&function_type, "__get__", context.new_rustfunc(bind_method));
 
-    let ref member_descriptor_type = context.member_descriptor_type;
+    let member_descriptor_type = &context.member_descriptor_type;
     context.set_attr(
         &member_descriptor_type,
         "__get__",
         context.new_rustfunc(member_get),
     );
 
-    let ref classmethod_type = context.classmethod_type;
+    let classmethod_type = &context.classmethod_type;
     context.set_attr(
         &classmethod_type,
         "__get__",
@@ -28,7 +28,7 @@ pub fn init(context: &PyContext) {
         context.new_rustfunc(classmethod_new),
     );
 
-    let ref staticmethod_type = context.staticmethod_type;
+    let staticmethod_type = &context.staticmethod_type;
     context.set_attr(
         staticmethod_type,
         "__get__",

--- a/vm/src/obj/objgenerator.rs
+++ b/vm/src/obj/objgenerator.rs
@@ -10,7 +10,7 @@ use super::super::vm::VirtualMachine;
 use super::objtype;
 
 pub fn init(context: &PyContext) {
-    let ref generator_type = context.generator_type;
+    let generator_type = &context.generator_type;
     context.set_attr(
         &generator_type,
         "__iter__",

--- a/vm/src/obj/objint.rs
+++ b/vm/src/obj/objint.rs
@@ -510,7 +510,6 @@ fn int_conjugate(vm: &mut VirtualMachine, args: PyFuncArgs) -> PyResult {
 }
 
 pub fn init(context: &PyContext) {
-    let ref int_type = context.int_type;
     let int_doc = "int(x=0) -> integer
 int(x, base=10) -> integer
 
@@ -525,6 +524,8 @@ by whitespace.  The base defaults to 10.  Valid bases are 0 and 2-36.
 Base 0 means to interpret the base from the string as an integer literal.
 >>> int('0b100', base=0)
 4";
+    let int_type = &context.int_type;
+
     context.set_attr(&int_type, "__eq__", context.new_rustfunc(int_eq));
     context.set_attr(&int_type, "__lt__", context.new_rustfunc(int_lt));
     context.set_attr(&int_type, "__le__", context.new_rustfunc(int_le));

--- a/vm/src/obj/objiter.rs
+++ b/vm/src/obj/objiter.rs
@@ -141,7 +141,7 @@ fn iter_next(vm: &mut VirtualMachine, args: PyFuncArgs) -> PyResult {
 }
 
 pub fn init(context: &PyContext) {
-    let ref iter_type = context.iter_type;
+    let iter_type = &context.iter_type;
     context.set_attr(
         &iter_type,
         "__contains__",

--- a/vm/src/obj/objlist.rs
+++ b/vm/src/obj/objlist.rs
@@ -365,7 +365,7 @@ fn list_pop(vm: &mut VirtualMachine, args: PyFuncArgs) -> PyResult {
 }
 
 pub fn init(context: &PyContext) {
-    let ref list_type = context.list_type;
+    let list_type = &context.list_type;
     context.set_attr(&list_type, "__add__", context.new_rustfunc(list_add));
     context.set_attr(
         &list_type,

--- a/vm/src/obj/objmemory.rs
+++ b/vm/src/obj/objmemory.rs
@@ -17,7 +17,7 @@ pub fn new_memory_view(vm: &mut VirtualMachine, args: PyFuncArgs) -> PyResult {
 }
 
 pub fn init(ctx: &PyContext) {
-    let ref memoryview_type = ctx.memoryview_type;
+    let memoryview_type = &ctx.memoryview_type;
     ctx.set_attr(
         &memoryview_type,
         "__new__",

--- a/vm/src/obj/objobject.rs
+++ b/vm/src/obj/objobject.rs
@@ -86,7 +86,7 @@ fn object_repr(vm: &mut VirtualMachine, args: PyFuncArgs) -> PyResult {
 }
 
 pub fn init(context: &PyContext) {
-    let ref object = context.object;
+    let object = &context.object;
     context.set_attr(&object, "__new__", context.new_rustfunc(new_instance));
     context.set_attr(&object, "__init__", context.new_rustfunc(object_init));
     context.set_attr(&object, "__eq__", context.new_rustfunc(object_eq));

--- a/vm/src/obj/objproperty.rs
+++ b/vm/src/obj/objproperty.rs
@@ -9,7 +9,7 @@ use super::super::vm::VirtualMachine;
 use super::objtype;
 
 pub fn init(context: &PyContext) {
-    let ref property_type = context.property_type;
+    let property_type = &context.property_type;
     context.set_attr(
         &property_type,
         "__get__",

--- a/vm/src/obj/objset.rs
+++ b/vm/src/obj/objset.rs
@@ -151,7 +151,7 @@ fn frozenset_repr(vm: &mut VirtualMachine, args: PyFuncArgs) -> PyResult {
 }
 
 pub fn init(context: &PyContext) {
-    let ref set_type = context.set_type;
+    let set_type = &context.set_type;
     context.set_attr(
         &set_type,
         "__contains__",
@@ -162,7 +162,7 @@ pub fn init(context: &PyContext) {
     context.set_attr(&set_type, "__repr__", context.new_rustfunc(set_repr));
     context.set_attr(&set_type, "add", context.new_rustfunc(set_add));
 
-    let ref frozenset_type = context.frozenset_type;
+    let frozenset_type = &context.frozenset_type;
     context.set_attr(
         &frozenset_type,
         "__contains__",

--- a/vm/src/obj/objstr.rs
+++ b/vm/src/obj/objstr.rs
@@ -16,7 +16,7 @@ extern crate unicode_segmentation;
 use self::unicode_segmentation::UnicodeSegmentation;
 
 pub fn init(context: &PyContext) {
-    let ref str_type = context.str_type;
+    let str_type = &context.str_type;
     context.set_attr(&str_type, "__add__", context.new_rustfunc(str_add));
     context.set_attr(&str_type, "__eq__", context.new_rustfunc(str_eq));
     context.set_attr(

--- a/vm/src/obj/objsuper.rs
+++ b/vm/src/obj/objsuper.rs
@@ -11,7 +11,7 @@ use super::super::vm::VirtualMachine;
 use super::objtype;
 
 pub fn init(context: &PyContext) {
-    let ref super_type = context.super_type;
+    let super_type = &context.super_type;
     context.set_attr(&super_type, "__init__", context.new_rustfunc(super_init));
 }
 

--- a/vm/src/obj/objtuple.rs
+++ b/vm/src/obj/objtuple.rs
@@ -275,7 +275,7 @@ pub fn tuple_contains(vm: &mut VirtualMachine, args: PyFuncArgs) -> PyResult {
 }
 
 pub fn init(context: &PyContext) {
-    let ref tuple_type = context.tuple_type;
+    let tuple_type = &context.tuple_type;
     context.set_attr(&tuple_type, "__add__", context.new_rustfunc(tuple_add));
     context.set_attr(&tuple_type, "__eq__", context.new_rustfunc(tuple_eq));
     context.set_attr(

--- a/vm/src/obj/objtype.rs
+++ b/vm/src/obj/objtype.rs
@@ -22,7 +22,7 @@ pub fn create_type(type_type: PyObjectRef, object_type: PyObjectRef, dict_type: 
 }
 
 pub fn init(context: &PyContext) {
-    let ref type_type = context.type_type;
+    let type_type = &context.type_type;
     context.set_attr(&type_type, "__call__", context.new_rustfunc(type_call));
     context.set_attr(&type_type, "__new__", context.new_rustfunc(type_new));
     context.set_attr(
@@ -263,7 +263,7 @@ fn take_next_base(
     }
 
     if let Some(head) = next {
-        for ref mut item in &mut bases {
+        for item in &mut bases {
             if item[0].get_id() == head.get_id() {
                 item.remove(0);
             }

--- a/vm/src/pyobject.rs
+++ b/vm/src/pyobject.rs
@@ -717,7 +717,7 @@ impl AttributeProtocol for PyObjectRef {
                 if let Some(item) = class_get_item(self, attr_name) {
                     return Some(item);
                 }
-                for ref class in mro {
+                for class in mro {
                     if let Some(item) = class_get_item(class, attr_name) {
                         return Some(item);
                     }


### PR DESCRIPTION
This replaces all the occurrences of the 'let ref var = another_var' with the 'let var = &another_var'

Relevant clippy warning: https://rust-lang.github.io/rust-clippy/master/index.html#toplevel_ref_arg

This is a part of the #312 