### PR TITLE
Fixes build on Windows

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -143,20 +143,19 @@ fn shell_exec(vm: &mut VirtualMachine, source: &str, scope: PyObjectRef) -> bool
 }
 
 #[cfg(target_family = "windows")]
-fn get_history_path() -> String {
-    //
-    String::from(".repl_history.txt")
+fn get_history_path() -> PathBuf {
+    //Path buffer
+    PathBuf::from(".repl_history.txt")
 }
 
 #[cfg(target_family = "unix")]
-fn get_history_path() -> String {
+fn get_history_path() -> PathBuf {
     //work around for windows dependent builds. The xdg crate is unix specific
     //so access to the BaseDirectories struct breaks builds on python.
     extern crate xdg;
 
     let xdg_dirs = xdg::BaseDirectories::with_prefix("rustpython").unwrap();
-    let repl_history_path = xdg_dirs.place_cache_file("repl_history.txt").unwrap();
-    repl_history_path.to_str().unwrap()
+    xdg_dirs.place_cache_file("repl_history.txt").unwrap()
 }
 
 fn run_shell(vm: &mut VirtualMachine) -> PyResult {

--- a/src/main.rs
+++ b/src/main.rs
@@ -144,19 +144,19 @@ fn shell_exec(vm: &mut VirtualMachine, source: &str, scope: PyObjectRef) -> bool
 
 #[cfg(target_family = "windows")]
 fn get_history_path() -> String {
-	//
-	String::from(".repl_history.txt")
+    //
+    String::from(".repl_history.txt")
 }
 
 #[cfg(target_family = "unix")]
 fn get_history_path() -> String {
-	//work around for windows dependent builds. The xdg crate is unix specific
-	//so access to the BaseDirectories struct breaks builds on python.
-	extern crate xdg;
+    //work around for windows dependent builds. The xdg crate is unix specific
+    //so access to the BaseDirectories struct breaks builds on python.
+    extern crate xdg;
 
     let xdg_dirs = xdg::BaseDirectories::with_prefix("rustpython").unwrap();
     let repl_history_path = xdg_dirs.place_cache_file("repl_history.txt").unwrap();
-	repl_history_path.to_str().unwrap()
+    repl_history_path.to_str().unwrap()
 }
 
 fn run_shell(vm: &mut VirtualMachine) -> PyResult {
@@ -171,8 +171,8 @@ fn run_shell(vm: &mut VirtualMachine) -> PyResult {
     let mut input = String::new();
     let mut rl = Editor::<()>::new();
 
-	//retrieve a history_path_str dependent to the os
-	let repl_history_path_str = &get_history_path();
+    //retrieve a history_path_str dependent to the os
+    let repl_history_path_str = &get_history_path();
     if rl.load_history(repl_history_path_str).is_err() {
         println!("No previous history.");
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -142,7 +142,7 @@ fn shell_exec(vm: &mut VirtualMachine, source: &str, scope: PyObjectRef) -> bool
     true
 }
 
-#[cfg(target_family = "windows")]
+#[cfg(not(target_family = "unix"))]
 fn get_history_path() -> PathBuf {
     //Path buffer
     PathBuf::from(".repl_history.txt")

--- a/src/main.rs
+++ b/src/main.rs
@@ -7,7 +7,6 @@ extern crate log;
 extern crate rustpython_parser;
 extern crate rustpython_vm;
 extern crate rustyline;
-extern crate xdg;
 
 use clap::{App, Arg};
 use rustpython_parser::parser;
@@ -143,6 +142,23 @@ fn shell_exec(vm: &mut VirtualMachine, source: &str, scope: PyObjectRef) -> bool
     true
 }
 
+#[cfg(target_family = "windows")]
+fn get_history_path() -> String {
+	//
+	String::from(".repl_history.txt")
+}
+
+#[cfg(target_family = "unix")]
+fn get_history_path() -> String {
+	//work around for windows dependent builds. The xdg crate is unix specific
+	//so access to the BaseDirectories struct breaks builds on python.
+	extern crate xdg;
+
+    let xdg_dirs = xdg::BaseDirectories::with_prefix("rustpython").unwrap();
+    let repl_history_path = xdg_dirs.place_cache_file("repl_history.txt").unwrap();
+	repl_history_path.to_str().unwrap()
+}
+
 fn run_shell(vm: &mut VirtualMachine) -> PyResult {
     println!(
         "Welcome to the magnificent Rust Python {} interpreter",
@@ -155,9 +171,8 @@ fn run_shell(vm: &mut VirtualMachine) -> PyResult {
     let mut input = String::new();
     let mut rl = Editor::<()>::new();
 
-    let xdg_dirs = xdg::BaseDirectories::with_prefix("rustpython").unwrap();
-    let repl_history_path = xdg_dirs.place_cache_file("repl_history.txt").unwrap();
-    let repl_history_path_str = repl_history_path.to_str().unwrap();
+	//retrieve a history_path_str dependent to the os
+	let repl_history_path_str = &get_history_path();
     if rl.load_history(repl_history_path_str).is_err() {
         println!("No previous history.");
     }


### PR DESCRIPTION
Issue here was due to xdg struct being unix dependent.

Windows builds appear to now success after this change.

Closes #313 (and #349)