### PR TITLE
tests: Removed tests for the __doc__

### DIFF
--- a/tests/snippets/bools.py
+++ b/tests/snippets/bools.py
@@ -40,8 +40,6 @@ assert (True and True)
 assert not (False and fake)
 assert (True and 5) == 5
 
-assert bool.__doc__ == "bool(x) -> bool\n\nReturns True when the argument x is true, False otherwise.\nThe builtins True and False are the only two instances of the class bool.\nThe class bool is a subclass of the class int, and cannot be subclassed."
-
 # Bools are also ints.
 assert isinstance(True, int)
 assert True + True == 2

--- a/tests/snippets/numbers.py
+++ b/tests/snippets/numbers.py
@@ -2,8 +2,6 @@ x = 5
 x.__init__(6)
 assert x == 5
 
-assert int.__doc__ == "int(x=0) -> integer\nint(x, base=10) -> integer\n\nConvert a number or string to an integer, or return 0 if no arguments\nare given.  If x is a number, return x.__int__().  For floating point\nnumbers, this truncates towards zero.\n\nIf x is not a number or if base is given, then x must be a string,\nbytes, or bytearray instance representing an integer literal in the\ngiven base.  The literal can be preceded by '+' or '-' and be surrounded\nby whitespace.  The base defaults to 10.  Valid bases are 0 and 2-36.\nBase 0 means to interpret the base from the string as an integer literal.\n>>> int('0b100', base=0)\n4"
-
 
 class A(int):
     pass

--- a/tests/snippets/tuple.py
+++ b/tests/snippets/tuple.py
@@ -19,5 +19,3 @@ assert x > y, "tuple __gt__ failed"
 
 b = (1,2,3)
 assert b.index(2) == 1
-
-assert b.__doc__ == "tuple() -> empty tuple\ntuple(iterable) -> tuple initialized from iterable's items\n\nIf the argument is a tuple, the return value is the same object."


### PR DESCRIPTION
This PR removes all tests that deal with the `__doc__` as per [this comment](https://github.com/RustPython/RustPython/pull/327#issuecomment-461577440)