### PR TITLE
Add floats.{__truediv__, __mul__}

### DIFF
--- a/tests/snippets/floats.py
+++ b/tests/snippets/floats.py
@@ -15,3 +15,6 @@ assert b >= a
 assert c >= a
 assert not a >= b
 
+assert a + b == 2.5
+assert a - c == 0
+assert a / c == 1

--- a/vm/src/obj/objfloat.rs
+++ b/vm/src/obj/objfloat.rs
@@ -274,9 +274,7 @@ fn float_truediv(vm: &mut VirtualMachine, args: PyFuncArgs) -> PyResult {
     );
     let v1 = get_value(i);
     if objtype::isinstance(i2, &vm.ctx.float_type) {
-        Ok(vm
-            .ctx
-            .new_float(v1 / get_value(i2)))
+        Ok(vm.ctx.new_float(v1 / get_value(i2)))
     } else if objtype::isinstance(i2, &vm.ctx.int_type) {
         Ok(vm
             .ctx
@@ -294,15 +292,13 @@ fn float_mul(vm: &mut VirtualMachine, args: PyFuncArgs) -> PyResult {
     );
     let v1 = get_value(i);
     if objtype::isinstance(i2, &vm.ctx.float_type) {
-        Ok(vm
-            .ctx
-            .new_float(v1 * get_value(i2)))
+        Ok(vm.ctx.new_float(v1 * get_value(i2)))
     } else if objtype::isinstance(i2, &vm.ctx.int_type) {
         Ok(vm
             .ctx
             .new_float(v1 * objint::get_value(i2).to_f64().unwrap()))
     } else {
-        Err(vm.new_type_error(format!("Cannot divide {} and {}", i.borrow(), i2.borrow())))
+        Err(vm.new_type_error(format!("Cannot multiply {} and {}", i.borrow(), i2.borrow())))
     }
 }
 
@@ -339,6 +335,10 @@ pub fn init(context: &PyContext) {
         "__doc__",
         context.new_str(float_doc.to_string()),
     );
-    context.set_attr(&float_type, "__truediv__", context.new_rustfunc(float_truediv));
+    context.set_attr(
+        &float_type,
+        "__truediv__",
+        context.new_rustfunc(float_truediv),
+    );
     context.set_attr(&float_type, "__mul__", context.new_rustfunc(float_mul));
 }

--- a/vm/src/obj/objfloat.rs
+++ b/vm/src/obj/objfloat.rs
@@ -266,6 +266,46 @@ fn float_pow(vm: &mut VirtualMachine, args: PyFuncArgs) -> PyResult {
     }
 }
 
+fn float_truediv(vm: &mut VirtualMachine, args: PyFuncArgs) -> PyResult {
+    arg_check!(
+        vm,
+        args,
+        required = [(i, Some(vm.ctx.float_type())), (i2, None)]
+    );
+    let v1 = get_value(i);
+    if objtype::isinstance(i2, &vm.ctx.float_type) {
+        Ok(vm
+            .ctx
+            .new_float(v1 / get_value(i2)))
+    } else if objtype::isinstance(i2, &vm.ctx.int_type) {
+        Ok(vm
+            .ctx
+            .new_float(v1 / objint::get_value(i2).to_f64().unwrap()))
+    } else {
+        Err(vm.new_type_error(format!("Cannot divide {} and {}", i.borrow(), i2.borrow())))
+    }
+}
+
+fn float_mul(vm: &mut VirtualMachine, args: PyFuncArgs) -> PyResult {
+    arg_check!(
+        vm,
+        args,
+        required = [(i, Some(vm.ctx.float_type())), (i2, None)]
+    );
+    let v1 = get_value(i);
+    if objtype::isinstance(i2, &vm.ctx.float_type) {
+        Ok(vm
+            .ctx
+            .new_float(v1 * get_value(i2)))
+    } else if objtype::isinstance(i2, &vm.ctx.int_type) {
+        Ok(vm
+            .ctx
+            .new_float(v1 * objint::get_value(i2).to_f64().unwrap()))
+    } else {
+        Err(vm.new_type_error(format!("Cannot divide {} and {}", i.borrow(), i2.borrow())))
+    }
+}
+
 pub fn init(context: &PyContext) {
     let float_type = &context.float_type;
 
@@ -299,4 +339,6 @@ pub fn init(context: &PyContext) {
         "__doc__",
         context.new_str(float_doc.to_string()),
     );
+    context.set_attr(&float_type, "__truediv__", context.new_rustfunc(float_truediv));
+    context.set_attr(&float_type, "__mul__", context.new_rustfunc(float_mul));
 }

--- a/vm/src/obj/objfloat.rs
+++ b/vm/src/obj/objfloat.rs
@@ -298,7 +298,11 @@ fn float_mul(vm: &mut VirtualMachine, args: PyFuncArgs) -> PyResult {
             .ctx
             .new_float(v1 * objint::get_value(i2).to_f64().unwrap()))
     } else {
-        Err(vm.new_type_error(format!("Cannot multiply {} and {}", i.borrow(), i2.borrow())))
+        Err(vm.new_type_error(format!(
+            "Cannot multiply {} and {}",
+            i.borrow(),
+            i2.borrow()
+        )))
     }
 }
 


### PR DESCRIPTION
According to #352

I added tu methods to `floats` the `__truediv__` and `__mul__`. And also I change a little bit, and with this changes you can run the code below. But it's works really slow.

```python
#!/usr/bin/env python3
# coding: utf-8

w = 50.0
h = 50.0

y = 0.0
while y < h:
	x = 0.0
	s = ''
	while x < w:
		Zr, Zi, Tr, Ti = 0.0, 0.0, 0.0, 0.0
		Cr = 2*x/w - 1.5
		Ci = 2*y/h - 1.0

		i = 0
		while i < 50 and Tr+Ti <= 4.0:
			Zi = 2*Zr*Zi + Ci
			Zr = Tr - Ti + Cr
			Tr = Zr * Zr
			Ti = Zi * Zi
			i = i+1

		if Tr+Ti <= 4.0:
			s += '*'
		else:
			s += '.'
		x = x+1
	print(s)
	y = y+1
```