### PR TITLE
float.{__lt__, __le__, __ge__, __gt__} fix comparing with non float type

### DIFF
--- a/tests/snippets/floats.py
+++ b/tests/snippets/floats.py
@@ -18,3 +18,24 @@ assert not a >= b
 assert a + b == 2.5
 assert a - c == 0
 assert a / c == 1
+
+assert a < 5
+assert a <= 5
+try:
+    assert a < 'a'
+except TypeError:
+    pass
+try:
+    assert a <= 'a'
+except TypeError:
+    pass
+assert a > 1
+assert a >= 1
+try:
+    assert a > 'a'
+except TypeError:
+    pass
+try:
+    assert a >= 'a'
+except TypeError:
+    pass

--- a/vm/src/obj/objfloat.rs
+++ b/vm/src/obj/objfloat.rs
@@ -83,60 +83,68 @@ fn float_lt(vm: &mut VirtualMachine, args: PyFuncArgs) -> PyResult {
     arg_check!(
         vm,
         args,
-        required = [
-            (zelf, Some(vm.ctx.float_type())),
-            (other, Some(vm.ctx.float_type()))
-        ]
+        required = [(i, Some(vm.ctx.float_type())), (i2, None)]
     );
-    let zelf = get_value(zelf);
-    let other = get_value(other);
-    let result = zelf < other;
-    Ok(vm.ctx.new_bool(result))
+
+    let v1 = get_value(i);
+    if objtype::isinstance(i2, &vm.ctx.float_type()) {
+        Ok(vm.ctx.new_bool(v1 < get_value(i2)))
+    } else if objtype::isinstance(i2, &vm.ctx.int_type()) {
+        Ok(vm.ctx.new_bool(v1 < objint::get_value(i2).to_f64().unwrap()))
+    } else {
+        Err(vm.new_type_error(format!("Cannot compare {} and {}", i.borrow(), i2.borrow())))
+    }
 }
 
 fn float_le(vm: &mut VirtualMachine, args: PyFuncArgs) -> PyResult {
     arg_check!(
         vm,
         args,
-        required = [
-            (zelf, Some(vm.ctx.float_type())),
-            (other, Some(vm.ctx.float_type()))
-        ]
+        required = [(i, Some(vm.ctx.float_type())), (i2, None)]
     );
-    let zelf = get_value(zelf);
-    let other = get_value(other);
-    let result = zelf <= other;
-    Ok(vm.ctx.new_bool(result))
+
+    let v1 = get_value(i);
+    if objtype::isinstance(i2, &vm.ctx.float_type()) {
+        Ok(vm.ctx.new_bool(v1 <= get_value(i2)))
+    } else if objtype::isinstance(i2, &vm.ctx.int_type()) {
+        Ok(vm.ctx.new_bool(v1 <= objint::get_value(i2).to_f64().unwrap()))
+    } else {
+        Err(vm.new_type_error(format!("Cannot compare {} and {}", i.borrow(), i2.borrow())))
+    }
 }
 
 fn float_gt(vm: &mut VirtualMachine, args: PyFuncArgs) -> PyResult {
     arg_check!(
         vm,
         args,
-        required = [
-            (zelf, Some(vm.ctx.float_type())),
-            (other, Some(vm.ctx.float_type()))
-        ]
+        required = [(i, Some(vm.ctx.float_type())), (i2, None)]
     );
-    let zelf = get_value(zelf);
-    let other = get_value(other);
-    let result = zelf > other;
-    Ok(vm.ctx.new_bool(result))
+
+    let v1 = get_value(i);
+    if objtype::isinstance(i2, &vm.ctx.float_type()) {
+        Ok(vm.ctx.new_bool(v1 > get_value(i2)))
+    } else if objtype::isinstance(i2, &vm.ctx.int_type()) {
+        Ok(vm.ctx.new_bool(v1 > objint::get_value(i2).to_f64().unwrap()))
+    } else {
+        Err(vm.new_type_error(format!("Cannot compare {} and {}", i.borrow(), i2.borrow())))
+    }
 }
 
 fn float_ge(vm: &mut VirtualMachine, args: PyFuncArgs) -> PyResult {
     arg_check!(
         vm,
         args,
-        required = [
-            (zelf, Some(vm.ctx.float_type())),
-            (other, Some(vm.ctx.float_type()))
-        ]
+        required = [(i, Some(vm.ctx.float_type())), (i2, None)]
     );
-    let zelf = get_value(zelf);
-    let other = get_value(other);
-    let result = zelf >= other;
-    Ok(vm.ctx.new_bool(result))
+
+    let v1 = get_value(i);
+    if objtype::isinstance(i2, &vm.ctx.float_type()) {
+        Ok(vm.ctx.new_bool(v1 >= get_value(i2)))
+    } else if objtype::isinstance(i2, &vm.ctx.int_type()) {
+        Ok(vm.ctx.new_bool(v1 >= objint::get_value(i2).to_f64().unwrap()))
+    } else {
+        Err(vm.new_type_error(format!("Cannot compare {} and {}", i.borrow(), i2.borrow())))
+    }
 }
 
 fn float_abs(vm: &mut VirtualMachine, args: PyFuncArgs) -> PyResult {

--- a/vm/src/obj/objfloat.rs
+++ b/vm/src/obj/objfloat.rs
@@ -90,7 +90,9 @@ fn float_lt(vm: &mut VirtualMachine, args: PyFuncArgs) -> PyResult {
     if objtype::isinstance(i2, &vm.ctx.float_type()) {
         Ok(vm.ctx.new_bool(v1 < get_value(i2)))
     } else if objtype::isinstance(i2, &vm.ctx.int_type()) {
-        Ok(vm.ctx.new_bool(v1 < objint::get_value(i2).to_f64().unwrap()))
+        Ok(vm
+            .ctx
+            .new_bool(v1 < objint::get_value(i2).to_f64().unwrap()))
     } else {
         Err(vm.new_type_error(format!("Cannot compare {} and {}", i.borrow(), i2.borrow())))
     }
@@ -107,7 +109,9 @@ fn float_le(vm: &mut VirtualMachine, args: PyFuncArgs) -> PyResult {
     if objtype::isinstance(i2, &vm.ctx.float_type()) {
         Ok(vm.ctx.new_bool(v1 <= get_value(i2)))
     } else if objtype::isinstance(i2, &vm.ctx.int_type()) {
-        Ok(vm.ctx.new_bool(v1 <= objint::get_value(i2).to_f64().unwrap()))
+        Ok(vm
+            .ctx
+            .new_bool(v1 <= objint::get_value(i2).to_f64().unwrap()))
     } else {
         Err(vm.new_type_error(format!("Cannot compare {} and {}", i.borrow(), i2.borrow())))
     }
@@ -124,7 +128,9 @@ fn float_gt(vm: &mut VirtualMachine, args: PyFuncArgs) -> PyResult {
     if objtype::isinstance(i2, &vm.ctx.float_type()) {
         Ok(vm.ctx.new_bool(v1 > get_value(i2)))
     } else if objtype::isinstance(i2, &vm.ctx.int_type()) {
-        Ok(vm.ctx.new_bool(v1 > objint::get_value(i2).to_f64().unwrap()))
+        Ok(vm
+            .ctx
+            .new_bool(v1 > objint::get_value(i2).to_f64().unwrap()))
     } else {
         Err(vm.new_type_error(format!("Cannot compare {} and {}", i.borrow(), i2.borrow())))
     }
@@ -141,7 +147,9 @@ fn float_ge(vm: &mut VirtualMachine, args: PyFuncArgs) -> PyResult {
     if objtype::isinstance(i2, &vm.ctx.float_type()) {
         Ok(vm.ctx.new_bool(v1 >= get_value(i2)))
     } else if objtype::isinstance(i2, &vm.ctx.int_type()) {
-        Ok(vm.ctx.new_bool(v1 >= objint::get_value(i2).to_f64().unwrap()))
+        Ok(vm
+            .ctx
+            .new_bool(v1 >= objint::get_value(i2).to_f64().unwrap()))
     } else {
         Err(vm.new_type_error(format!("Cannot compare {} and {}", i.borrow(), i2.borrow())))
     }


### PR DESCRIPTION
Fix the comaring with non float types:

```
1.0 < 1
1.0 <= 1
1.0 > 1
1.0 >= 1
```

Rais 
```
Traceback (most recent call last):
  File <stdin>, line 0, in <module>
TypeError: argument of type <class 'float'> is required for parameter 2 (other) (got: <class 'int'>)
```