### PR TITLE
Fixed several clippy warnings

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -195,7 +195,7 @@ fn run_shell(vm: &mut VirtualMachine) -> PyResult {
                 debug!("You entered {:?}", input);
                 if shell_exec(vm, &input, vars.clone()) {
                     // Line was complete.
-                    rl.add_history_entry(input.trim_end().as_ref());
+                    rl.add_history_entry(input.trim_end());
                     input = String::new();
                 } else {
                     loop {
@@ -208,7 +208,7 @@ fn run_shell(vm: &mut VirtualMachine) -> PyResult {
                             Ok(line) => {
                                 if line.len() == 0 {
                                     if shell_exec(vm, &input, vars.clone()) {
-                                        rl.add_history_entry(input.trim_end().as_ref());
+                                        rl.add_history_entry(input.trim_end());
                                         input = String::new();
                                         break;
                                     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -206,7 +206,7 @@ fn run_shell(vm: &mut VirtualMachine) -> PyResult {
                         //};
                         match rl.readline(&ps2) {
                             Ok(line) => {
-                                if line.len() == 0 {
+                                if line.is_empty() {
                                     if shell_exec(vm, &input, vars.clone()) {
                                         rl.add_history_entry(input.trim_end());
                                         input = String::new();

--- a/vm/src/format.rs
+++ b/vm/src/format.rs
@@ -496,8 +496,12 @@ impl FormatString {
             None => Err(FormatParseError::UnmatchedBracket),
         }
     }
+}
 
-    pub fn from_str(text: &str) -> Result<FormatString, FormatParseError> {
+impl FromStr for FormatString {
+    type Err = FormatParseError;
+
+    fn from_str(text: &str) -> Result<Self, Self::Err> {
         let mut cur_text: &str = text;
         let mut parts: Vec<FormatPart> = Vec::new();
         while !cur_text.is_empty() {

--- a/vm/src/frame.rs
+++ b/vm/src/frame.rs
@@ -197,7 +197,7 @@ impl Frame {
             }
             bytecode::Instruction::Rotate { amount } => {
                 // Shuffles top of stack amount down
-                if amount < &2 {
+                if *amount < 2 {
                     panic!("Can only rotate two or more values");
                 }
 

--- a/vm/src/import.rs
+++ b/vm/src/import.rs
@@ -77,7 +77,7 @@ pub fn import(
                 let import_error = vm.context().exceptions.import_error.clone();
                 Err(vm.new_exception(import_error, format!("cannot import name '{}'", symbol)))
             },
-            |obj| Ok(obj),
+            Ok,
         )
     } else {
         Ok(module)

--- a/vm/src/obj/objbytearray.rs
+++ b/vm/src/obj/objbytearray.rs
@@ -214,12 +214,10 @@ fn bytearray_istitle(vm: &mut VirtualMachine, args: PyFuncArgs) -> PyResult {
             let current = char::from(*c);
             let next = if let Some(k) = iter.peek() {
                 char::from(**k)
+            } else if current.is_uppercase() {
+                return Ok(vm.new_bool(!prev_cased));
             } else {
-                if current.is_uppercase() {
-                    return Ok(vm.new_bool(!prev_cased));
-                } else {
-                    return Ok(vm.new_bool(prev_cased));
-                }
+                return Ok(vm.new_bool(prev_cased));
             };
 
             if (is_cased(current) && next.is_uppercase() && !prev_cased)

--- a/vm/src/obj/objcode.rs
+++ b/vm/src/obj/objcode.rs
@@ -14,7 +14,7 @@ pub fn init(context: &PyContext) {
     context.set_attr(code_type, "__new__", context.new_rustfunc(code_new));
     context.set_attr(code_type, "__repr__", context.new_rustfunc(code_repr));
 
-    for (name, f) in vec![
+    for (name, f) in &[
         (
             "co_argcount",
             code_co_argcount as fn(&mut VirtualMachine, PyFuncArgs) -> PyResult,

--- a/vm/src/obj/objmap.rs
+++ b/vm/src/obj/objmap.rs
@@ -14,7 +14,7 @@ fn map_new(vm: &mut VirtualMachine, args: PyFuncArgs) -> PyResult {
         let function = &args.args[1];
         let iterables = &args.args[2..];
         let iterators = iterables
-            .into_iter()
+            .iter()
             .map(|iterable| objiter::get_iter(vm, iterable))
             .collect::<Result<Vec<_>, _>>()?;
         Ok(PyObject::new(

--- a/vm/src/obj/objrange.rs
+++ b/vm/src/obj/objrange.rs
@@ -146,7 +146,7 @@ pub fn get_value(obj: &PyObjectRef) -> RangeType {
 }
 
 pub fn init(context: &PyContext) {
-    let ref range_type = context.range_type;
+    let range_type = &context.range_type;
 
     let range_doc = "range(stop) -> range object\n\
                      range(start, stop[, step]) -> range object\n\n\

--- a/vm/src/obj/objrange.rs
+++ b/vm/src/obj/objrange.rs
@@ -42,8 +42,8 @@ impl RangeType {
     #[inline]
     fn offset(&self, value: &BigInt) -> Option<BigInt> {
         match self.step.sign() {
-            Sign::Plus if value >= &self.start && value < &self.end => Some(value - &self.start),
-            Sign::Minus if value <= &self.start && value > &self.end => Some(&self.start - value),
+            Sign::Plus if *value >= self.start && *value < self.end => Some(value - &self.start),
+            Sign::Minus if *value <= self.start && *value > self.end => Some(&self.start - value),
             _ => None,
         }
     }

--- a/vm/src/obj/objrange.rs
+++ b/vm/src/obj/objrange.rs
@@ -199,7 +199,7 @@ fn range_new(vm: &mut VirtualMachine, args: PyFuncArgs) -> PyResult {
         ]
     );
 
-    let start = if let Some(_) = second {
+    let start = if second.is_some() {
         objint::get_value(first)
     } else {
         BigInt::zero()

--- a/vm/src/obj/objrange.rs
+++ b/vm/src/obj/objrange.rs
@@ -68,9 +68,10 @@ impl RangeType {
 
     #[inline]
     pub fn count(&self, value: &BigInt) -> usize {
-        match self.index_of(value).is_some() {
-            true => 1,
-            false => 0,
+        if self.index_of(value).is_some() {
+            1
+        } else {
+            0
         }
     }
 

--- a/vm/src/obj/objsequence.rs
+++ b/vm/src/obj/objsequence.rs
@@ -15,6 +15,7 @@ pub trait PySliceableSequence {
     fn do_stepped_slice_reverse(&self, range: Range<usize>, step: usize) -> Self;
     fn empty() -> Self;
     fn len(&self) -> usize;
+    fn is_empty(&self) -> bool;
     fn get_pos(&self, p: i32) -> Option<usize> {
         if p < 0 {
             if -p as usize > self.len() {
@@ -126,6 +127,10 @@ impl<T: Clone> PySliceableSequence for Vec<T> {
 
     fn len(&self) -> usize {
         self.len()
+    }
+
+    fn is_empty(&self) -> bool {
+        self.is_empty()
     }
 }
 

--- a/vm/src/obj/objsequence.rs
+++ b/vm/src/obj/objsequence.rs
@@ -293,7 +293,7 @@ pub fn seq_mul(elements: &[PyObjectRef], product: &PyObjectRef) -> Vec<PyObjectR
     let mut new_elements = Vec::with_capacity(new_len);
 
     for _ in 0..counter {
-        new_elements.extend(elements.clone().to_owned());
+        new_elements.extend(elements.to_owned());
     }
 
     new_elements

--- a/vm/src/obj/objset.rs
+++ b/vm/src/obj/objset.rs
@@ -180,48 +180,48 @@ pub fn set_contains(vm: &mut VirtualMachine, args: PyFuncArgs) -> PyResult {
 }
 
 fn set_eq(vm: &mut VirtualMachine, args: PyFuncArgs) -> PyResult {
-    return set_compare_inner(
+    set_compare_inner(
         vm,
         args,
         &|zelf: usize, other: usize| -> bool { zelf != other },
         false,
-    );
+    )
 }
 
 fn set_ge(vm: &mut VirtualMachine, args: PyFuncArgs) -> PyResult {
-    return set_compare_inner(
+    set_compare_inner(
         vm,
         args,
         &|zelf: usize, other: usize| -> bool { zelf < other },
         false,
-    );
+    )
 }
 
 fn set_gt(vm: &mut VirtualMachine, args: PyFuncArgs) -> PyResult {
-    return set_compare_inner(
+    set_compare_inner(
         vm,
         args,
         &|zelf: usize, other: usize| -> bool { zelf <= other },
         false,
-    );
+    )
 }
 
 fn set_le(vm: &mut VirtualMachine, args: PyFuncArgs) -> PyResult {
-    return set_compare_inner(
+    set_compare_inner(
         vm,
         args,
         &|zelf: usize, other: usize| -> bool { zelf < other },
         true,
-    );
+    )
 }
 
 fn set_lt(vm: &mut VirtualMachine, args: PyFuncArgs) -> PyResult {
-    return set_compare_inner(
+    set_compare_inner(
         vm,
         args,
         &|zelf: usize, other: usize| -> bool { zelf <= other },
         true,
-    );
+    )
 }
 
 fn set_compare_inner(

--- a/vm/src/obj/objstr.rs
+++ b/vm/src/obj/objstr.rs
@@ -9,6 +9,7 @@ use super::objtype;
 use num_traits::ToPrimitive;
 use std::hash::{Hash, Hasher};
 use std::ops::Range;
+use std::str::FromStr;
 // rust's builtin to_lowercase isn't sufficient for casefold
 extern crate caseless;
 extern crate unicode_segmentation;

--- a/vm/src/obj/objstr.rs
+++ b/vm/src/obj/objstr.rs
@@ -1070,6 +1070,10 @@ impl PySliceableSequence for String {
     fn len(&self) -> usize {
         to_graphemes(self).len()
     }
+
+    fn is_empty(&self) -> bool {
+        self.is_empty()
+    }
 }
 
 /// Convert a string-able `value` to a vec of graphemes

--- a/vm/src/pyobject.rs
+++ b/vm/src/pyobject.rs
@@ -514,7 +514,7 @@ impl PyContext {
         // Initialized empty, as calling __hash__ is required for adding each object to the set
         // which requires a VM context - this is done in the objset code itself.
         let elements: HashMap<u64, PyObjectRef> = HashMap::new();
-        PyObject::new(PyObjectPayload::Set { elements: elements }, self.set_type())
+        PyObject::new(PyObjectPayload::Set { elements }, self.set_type())
     }
 
     pub fn new_dict(&self) -> PyObjectRef {

--- a/vm/src/stdlib/json.rs
+++ b/vm/src/stdlib/json.rs
@@ -189,10 +189,7 @@ fn json_dumps(vm: &mut VirtualMachine, args: PyFuncArgs) -> PyResult {
     // TODO: Implement non-trivial serialisation case
     arg_check!(vm, args, required = [(obj, None)]);
     let res = {
-        let serializer = PyObjectSerializer {
-            pyobject: obj,
-            vm: vm,
-        };
+        let serializer = PyObjectSerializer { pyobject: obj, vm };
         serde_json::to_string(&serializer)
     };
     let string = res.map_err(|err| vm.new_type_error(format!("{}", err)))?;
@@ -204,7 +201,7 @@ fn json_loads(vm: &mut VirtualMachine, args: PyFuncArgs) -> PyResult {
     // TODO: Implement non-trivial deserialisation case
     arg_check!(vm, args, required = [(string, Some(vm.ctx.str_type()))]);
     let res = {
-        let de = PyObjectDeserializer { vm: vm };
+        let de = PyObjectDeserializer { vm };
         // TODO: Support deserializing string sub-classes
         de.deserialize(&mut serde_json::Deserializer::from_str(&objstr::get_value(
             &string,

--- a/wasm/lib/src/lib.rs
+++ b/wasm/lib/src/lib.rs
@@ -145,7 +145,7 @@ fn eval(vm: &mut VirtualMachine, source: &str, vars: PyObjectRef) -> PyResult {
 /// -   `stdout?`: `(out: string) => void`: A function to replace the native print
 ///     function, by default `console.log`.
 pub fn eval_py(source: &str, options: Option<Object>) -> Result<JsValue, JsValue> {
-    let options = options.unwrap_or_else(|| Object::new());
+    let options = options.unwrap_or_else(Object::new);
     let js_vars = {
         let prop = Reflect::get(&options, &"vars".into())?;
         if prop.is_undefined() {

--- a/wasm/lib/src/lib.rs
+++ b/wasm/lib/src/lib.rs
@@ -199,7 +199,7 @@ pub fn eval_py(source: &str, options: Option<Object>) -> Result<JsValue, JsValue
         vm.ctx.new_rustfunc_from_box(print_fn),
     );
 
-    let mut vars = base_scope(&mut vm);
+    let vars = base_scope(&mut vm);
 
     let injections = vm.new_dict();
 
@@ -217,7 +217,7 @@ pub fn eval_py(source: &str, options: Option<Object>) -> Result<JsValue, JsValue
         }
     }
 
-    vm.ctx.set_item(&mut vars, "js_vars", injections);
+    vm.ctx.set_item(&vars, "js_vars", injections);
 
     eval(&mut vm, source, vars)
         .map(|value| py_to_js(&mut vm, value))


### PR DESCRIPTION
This PR fixed the last batch of the simple clippy warnings.

The remaining warnings deal with the basic types representation and API, which potentially introduces breaking changes, therefore they will be dealt with in the separate PRs