### PR TITLE
Fix int to float comparison

### DIFF
--- a/tests/snippets/ints.py
+++ b/tests/snippets/ints.py
@@ -1,8 +1,22 @@
+# int to int comparisons
+
+assert 1 == 1
+assert not 1 != 1
+
+assert (1).__eq__(1)
+assert not (1).__ne__(1)
+
+# int to float comparisons
+
+assert 1 == 1.0
+assert not 1 != 1.0
 assert not 1 > 1.0
 assert not 1 < 1.0
 assert 1 >= 1.0
 assert 1 <= 1.0
 
+assert (1).__eq__(1.0) == NotImplemented
+assert (1).__ne__(1.0) == NotImplemented
 assert (1).__gt__(1.0) == NotImplemented
 assert (1).__ge__(1.0) == NotImplemented
 assert (1).__lt__(1.0) == NotImplemented

--- a/tests/snippets/ints.py
+++ b/tests/snippets/ints.py
@@ -1,0 +1,9 @@
+assert not 1 > 1.0
+assert not 1 < 1.0
+assert 1 >= 1.0
+assert 1 <= 1.0
+
+assert (1).__gt__(1.0) == NotImplemented
+assert (1).__ge__(1.0) == NotImplemented
+assert (1).__lt__(1.0) == NotImplemented
+assert (1).__le__(1.0) == NotImplemented

--- a/vm/src/obj/objint.rs
+++ b/vm/src/obj/objint.rs
@@ -134,11 +134,13 @@ fn int_lt(vm: &mut VirtualMachine, args: PyFuncArgs) -> PyResult {
     arg_check!(
         vm,
         args,
-        required = [
-            (zelf, Some(vm.ctx.int_type())),
-            (other, Some(vm.ctx.int_type()))
-        ]
+        required = [(zelf, Some(vm.ctx.int_type())), (other, None)]
     );
+
+    if !objtype::isinstance(other, &vm.ctx.int_type()) {
+        return Ok(vm.ctx.not_implemented());
+    }
+
     let zelf = BigInt::from_pyobj(zelf);
     let other = BigInt::from_pyobj(other);
     let result = zelf < other;
@@ -149,11 +151,13 @@ fn int_le(vm: &mut VirtualMachine, args: PyFuncArgs) -> PyResult {
     arg_check!(
         vm,
         args,
-        required = [
-            (zelf, Some(vm.ctx.int_type())),
-            (other, Some(vm.ctx.int_type()))
-        ]
+        required = [(zelf, Some(vm.ctx.int_type())), (other, None)]
     );
+
+    if !objtype::isinstance(other, &vm.ctx.int_type()) {
+        return Ok(vm.ctx.not_implemented());
+    }
+
     let zelf = BigInt::from_pyobj(zelf);
     let other = BigInt::from_pyobj(other);
     let result = zelf <= other;
@@ -164,11 +168,13 @@ fn int_gt(vm: &mut VirtualMachine, args: PyFuncArgs) -> PyResult {
     arg_check!(
         vm,
         args,
-        required = [
-            (zelf, Some(vm.ctx.int_type())),
-            (other, Some(vm.ctx.int_type()))
-        ]
+        required = [(zelf, Some(vm.ctx.int_type())), (other, None)]
     );
+
+    if !objtype::isinstance(other, &vm.ctx.int_type()) {
+        return Ok(vm.ctx.not_implemented());
+    }
+
     let zelf = BigInt::from_pyobj(zelf);
     let other = BigInt::from_pyobj(other);
     let result = zelf > other;
@@ -179,11 +185,13 @@ fn int_ge(vm: &mut VirtualMachine, args: PyFuncArgs) -> PyResult {
     arg_check!(
         vm,
         args,
-        required = [
-            (zelf, Some(vm.ctx.int_type())),
-            (other, Some(vm.ctx.int_type()))
-        ]
+        required = [(zelf, Some(vm.ctx.int_type())), (other, None)]
     );
+
+    if !objtype::isinstance(other, &vm.ctx.int_type()) {
+        return Ok(vm.ctx.not_implemented());
+    }
+
     let zelf = BigInt::from_pyobj(zelf);
     let other = BigInt::from_pyobj(other);
     let result = zelf >= other;

--- a/vm/src/obj/objint.rs
+++ b/vm/src/obj/objint.rs
@@ -116,14 +116,23 @@ fn int_eq(vm: &mut VirtualMachine, args: PyFuncArgs) -> PyResult {
     let result = if objtype::isinstance(other, &vm.ctx.int_type()) {
         let other = BigInt::from_pyobj(other);
         zelf == other
-    } else if objtype::isinstance(other, &vm.ctx.float_type()) {
-        let other_float = objfloat::get_value(other);
+    } else {
+        return Ok(vm.ctx.not_implemented());
+    };
+    Ok(vm.ctx.new_bool(result))
+}
 
-        if let (Some(zelf_float), Some(other_int)) = (zelf.to_f64(), other_float.to_bigint()) {
-            zelf_float == other_float && zelf == other_int
-        } else {
-            false
-        }
+fn int_ne(vm: &mut VirtualMachine, args: PyFuncArgs) -> PyResult {
+    arg_check!(
+        vm,
+        args,
+        required = [(zelf, Some(vm.ctx.int_type())), (other, None)]
+    );
+
+    let zelf = BigInt::from_pyobj(zelf);
+    let result = if objtype::isinstance(other, &vm.ctx.int_type()) {
+        let other = BigInt::from_pyobj(other);
+        zelf != other
     } else {
         return Ok(vm.ctx.not_implemented());
     };
@@ -578,6 +587,7 @@ Base 0 means to interpret the base from the string as an integer literal.
     let int_type = &context.int_type;
 
     context.set_attr(&int_type, "__eq__", context.new_rustfunc(int_eq));
+    context.set_attr(&int_type, "__ne__", context.new_rustfunc(int_ne));
     context.set_attr(&int_type, "__lt__", context.new_rustfunc(int_lt));
     context.set_attr(&int_type, "__le__", context.new_rustfunc(int_le));
     context.set_attr(&int_type, "__gt__", context.new_rustfunc(int_gt));


### PR DESCRIPTION
Int to float comparisons (where int is left operand) currently raise `TypeError`.
```
>>>>> 1 > 1.0
Traceback (most recent call last):
  File <stdin>, line 0, in <module>
TypeError: argument of type <class 'int'> is required for parameter 2 (other) (got: <class 'float'>)
```

This updates int comparison methods to return `NotImplemented` for non-ints.
