### PR TITLE
Refactor arg_check macro

### DIFF
--- a/vm/src/macros.rs
+++ b/vm/src/macros.rs
@@ -1,3 +1,35 @@
+// see: https://danielkeep.github.io/tlborm/book/blk-counting.html
+macro_rules! replace_expr {
+    ($_t:tt $sub:expr) => {
+        $sub
+    };
+}
+
+macro_rules! count_tts {
+    ($($tts:tt)*) => {0usize $(+ replace_expr!($tts 1usize))*};
+}
+
+macro_rules! type_check {
+    ($vm:ident, $args:ident, $arg_count:ident, $arg_name:ident, $arg_type:expr) => {
+        // None indicates that we have no type requirement (i.e. we accept any type)
+        if let Some(expected_type) = $arg_type {
+            let arg = &$args.args[$arg_count];
+            if !objtype::isinstance(arg, &expected_type) {
+                let arg_typ = arg.typ();
+                let expected_type_name = $vm.to_pystr(&expected_type)?;
+                let actual_type = $vm.to_pystr(&arg_typ)?;
+                return Err($vm.new_type_error(format!(
+                    "argument of type {} is required for parameter {} ({}) (got: {})",
+                    expected_type_name,
+                    $arg_count + 1,
+                    stringify!($arg_name),
+                    actual_type
+                )));
+            }
+        }
+    };
+}
+
 macro_rules! arg_check {
     ( $vm: ident, $args:ident ) => {
         // Zero-arg case
@@ -10,18 +42,26 @@ macro_rules! arg_check {
         arg_check!($vm, $args, required=[$( ($arg_name, $arg_type) ),*], optional=[]);
     };
     ( $vm: ident, $args:ident, required=[$( ($arg_name:ident, $arg_type:expr) ),*], optional=[$( ($optional_arg_name:ident, $optional_arg_type:expr) ),*] ) => {
-        let mut expected_args: Vec<(usize, &str, Option<PyObjectRef>)> = vec![];
         let mut arg_count = 0;
 
+        let minimum_arg_count = count_tts!($($arg_name)*);
+        let maximum_arg_count = minimum_arg_count + count_tts!($($optional_arg_name)*);
+
+        if $args.args.len() < minimum_arg_count || $args.args.len() > maximum_arg_count {
+            let expected_str = if minimum_arg_count == maximum_arg_count {
+                format!("{}", minimum_arg_count)
+            } else {
+                format!("{}-{}", minimum_arg_count, maximum_arg_count)
+            };
+            return Err($vm.new_type_error(format!(
+                "Expected {} arguments (got: {})",
+                expected_str,
+                $args.args.len()
+            )));
+        };
+
         $(
-            if arg_count >= $args.args.len() {
-                // TODO: Report the number of expected arguments
-                return Err($vm.new_type_error(format!(
-                    "Expected more arguments (got: {})",
-                    $args.args.len()
-                )));
-            }
-            expected_args.push((arg_count, stringify!($arg_name), $arg_type));
+            type_check!($vm, $args, arg_count, $arg_name, $arg_type);
             let $arg_name = &$args.args[arg_count];
             #[allow(unused_assignments)]
             {
@@ -29,11 +69,9 @@ macro_rules! arg_check {
             }
         )*
 
-        let minimum_arg_count = arg_count;
-
         $(
             let $optional_arg_name = if arg_count < $args.args.len() {
-                expected_args.push((arg_count, stringify!($optional_arg_name), $optional_arg_type));
+                type_check!($vm, $args, arg_count, $optional_arg_name, $optional_arg_type);
                 let ret = Some(&$args.args[arg_count]);
                 #[allow(unused_assignments)]
                 {
@@ -44,42 +82,6 @@ macro_rules! arg_check {
                 None
             };
         )*
-
-        if $args.args.len() < minimum_arg_count || $args.args.len() > expected_args.len() {
-            let expected_str = if minimum_arg_count == arg_count {
-                format!("{}", arg_count)
-            } else {
-                format!("{}-{}", minimum_arg_count, arg_count)
-            };
-            return Err($vm.new_type_error(format!(
-                "Expected {} arguments (got: {})",
-                expected_str,
-                $args.args.len()
-            )));
-        };
-
-        for (arg, (arg_position, arg_name, expected_type)) in
-            $args.args.iter().zip(expected_args.iter())
-        {
-            match expected_type {
-                Some(expected_type) => {
-                    if !objtype::isinstance(arg, &expected_type) {
-                        let arg_typ = arg.typ();
-                        let expected_type_name = $vm.to_pystr(expected_type)?;
-                        let actual_type = $vm.to_pystr(&arg_typ)?;
-                        return Err($vm.new_type_error(format!(
-                            "argument of type {} is required for parameter {} ({}) (got: {})",
-                            expected_type_name,
-                            arg_position + 1,
-                            arg_name,
-                            actual_type
-                        )));
-                    }
-                }
-                // None indicates that we have no type requirement (i.e. we accept any type)
-                None => {}
-            }
-        }
     };
 }
 

--- a/vm/src/obj/objbytearray.rs
+++ b/vm/src/obj/objbytearray.rs
@@ -1,7 +1,7 @@
 //! Implementation of the python bytearray object.
 
 use super::super::pyobject::{
-    PyContext, PyFuncArgs, PyObject, PyObjectPayload, PyObjectRef, PyResult, TypeProtocol,
+    PyContext, PyFuncArgs, PyObject, PyObjectPayload, PyResult, TypeProtocol,
 };
 
 use super::objint;

--- a/vm/src/obj/objenumerate.rs
+++ b/vm/src/obj/objenumerate.rs
@@ -1,5 +1,5 @@
 use super::super::pyobject::{
-    PyContext, PyFuncArgs, PyObject, PyObjectPayload, PyObjectRef, PyResult, TypeProtocol,
+    PyContext, PyFuncArgs, PyObject, PyObjectPayload, PyResult, TypeProtocol,
 };
 use super::super::vm::VirtualMachine;
 use super::objint;

--- a/vm/src/obj/objfilter.rs
+++ b/vm/src/obj/objfilter.rs
@@ -1,6 +1,5 @@
 use super::super::pyobject::{
-    IdProtocol, PyContext, PyFuncArgs, PyObject, PyObjectPayload, PyObjectRef, PyResult,
-    TypeProtocol,
+    IdProtocol, PyContext, PyFuncArgs, PyObject, PyObjectPayload, PyResult, TypeProtocol,
 };
 use super::super::vm::VirtualMachine;
 use super::objbool;

--- a/vm/src/obj/objfunction.rs
+++ b/vm/src/obj/objfunction.rs
@@ -1,6 +1,5 @@
 use super::super::pyobject::{
-    AttributeProtocol, IdProtocol, PyContext, PyFuncArgs, PyObjectPayload, PyObjectRef, PyResult,
-    TypeProtocol,
+    AttributeProtocol, IdProtocol, PyContext, PyFuncArgs, PyObjectPayload, PyResult, TypeProtocol,
 };
 use super::super::vm::VirtualMachine;
 use super::objtype;

--- a/vm/src/obj/objmap.rs
+++ b/vm/src/obj/objmap.rs
@@ -1,5 +1,5 @@
 use super::super::pyobject::{
-    PyContext, PyFuncArgs, PyObject, PyObjectPayload, PyObjectRef, PyResult, TypeProtocol,
+    PyContext, PyFuncArgs, PyObject, PyObjectPayload, PyResult, TypeProtocol,
 };
 use super::super::vm::VirtualMachine;
 use super::objiter;

--- a/vm/src/obj/objmemory.rs
+++ b/vm/src/obj/objmemory.rs
@@ -1,7 +1,7 @@
 use super::objtype;
 
 use super::super::pyobject::{
-    PyContext, PyFuncArgs, PyObject, PyObjectPayload, PyObjectRef, PyResult, TypeProtocol,
+    PyContext, PyFuncArgs, PyObject, PyObjectPayload, PyResult, TypeProtocol,
 };
 use super::super::vm::VirtualMachine;
 

--- a/vm/src/obj/objnone.rs
+++ b/vm/src/obj/objnone.rs
@@ -1,4 +1,4 @@
-use super::super::pyobject::{PyContext, PyFuncArgs, PyObjectRef, PyResult, TypeProtocol};
+use super::super::pyobject::{PyContext, PyFuncArgs, PyResult, TypeProtocol};
 use super::super::vm::VirtualMachine;
 use super::objtype;
 

--- a/vm/src/obj/objproperty.rs
+++ b/vm/src/obj/objproperty.rs
@@ -2,7 +2,7 @@
 
 */
 
-use super::super::pyobject::{PyContext, PyFuncArgs, PyObjectRef, PyResult, TypeProtocol};
+use super::super::pyobject::{PyContext, PyFuncArgs, PyResult, TypeProtocol};
 use super::super::vm::VirtualMachine;
 use super::objtype;
 

--- a/vm/src/obj/objsuper.rs
+++ b/vm/src/obj/objsuper.rs
@@ -6,7 +6,7 @@ https://github.com/python/cpython/blob/50b48572d9a90c5bb36e2bef6179548ea927a35a/
 
 */
 
-use super::super::pyobject::{PyContext, PyFuncArgs, PyObjectRef, PyResult, TypeProtocol};
+use super::super::pyobject::{PyContext, PyFuncArgs, PyResult, TypeProtocol};
 use super::super::vm::VirtualMachine;
 use super::objtype;
 

--- a/vm/src/obj/objtuple.rs
+++ b/vm/src/obj/objtuple.rs
@@ -1,5 +1,5 @@
 use super::super::pyobject::{
-    PyContext, PyFuncArgs, PyObject, PyObjectPayload, PyObjectRef, PyResult, TypeProtocol,
+    PyContext, PyFuncArgs, PyObject, PyObjectPayload, PyResult, TypeProtocol,
 };
 use super::super::vm::{ReprGuard, VirtualMachine};
 use super::objbool;

--- a/vm/src/obj/objzip.rs
+++ b/vm/src/obj/objzip.rs
@@ -1,5 +1,5 @@
 use super::super::pyobject::{
-    PyContext, PyFuncArgs, PyObject, PyObjectPayload, PyObjectRef, PyResult, TypeProtocol,
+    PyContext, PyFuncArgs, PyObject, PyObjectPayload, PyResult, TypeProtocol,
 };
 use super::super::vm::VirtualMachine;
 use super::objiter;


### PR DESCRIPTION
This basically unrolls the typechecking loop, moving type checks to assignment time, and moving argument count check to a single check at the beginning of the function. Expected number of args can be deduced by macro magic.
Advantages:
- avoids allocating a vector of expected_args on every function call
- doesn't repeatedly check for argument count
- optimizer-friendly (arguments without type requirements can have the type check branches completely removed)
- functions with 1-2 args generate less code (I checked that the binary size reduced).
- arguably more readable

Disadvantages:
- can generate more code for functions with a lot of args. (this can probably be reduced more by moving the error creation block to a separate function)

Let me know if I missed anything.