### PR TITLE
Initial support for f-strings (i.e. strings with interpolated expressions)

### DIFF
--- a/parser/src/ast.rs
+++ b/parser/src/ast.rs
@@ -197,7 +197,7 @@ pub enum Expression {
         elements: Vec<Expression>,
     },
     String {
-        value: String,
+        value: StringGroup,
     },
     Bytes {
         value: Vec<u8>,
@@ -311,4 +311,11 @@ pub enum Number {
     Integer { value: BigInt },
     Float { value: f64 },
     Complex { real: f64, imag: f64 },
+}
+
+#[derive(Debug, PartialEq)]
+pub enum StringGroup {
+    Constant { value: String },
+    FormattedValue { value: Box<Expression> },
+    Joined { values: Vec<StringGroup> },
 }

--- a/parser/src/lexer.rs
+++ b/parser/src/lexer.rs
@@ -274,7 +274,6 @@ where
         let mut saw_f = false;
         loop {
             // Detect r"", f"", b"" and u""
-            // TODO: handle f-strings
             if !(saw_b || saw_u || saw_f) && (self.chr0 == Some('b') || self.chr0 == Some('B')) {
                 saw_b = true;
             } else if !(saw_b || saw_r || saw_u || saw_f)
@@ -442,7 +441,7 @@ where
         is_bytes: bool,
         is_raw: bool,
         _is_unicode: bool,
-        _is_fstring: bool,
+        is_fstring: bool,
     ) -> Spanned<Tok> {
         let quote_char = self.next_char().unwrap();
         let mut string_content = String::new();
@@ -533,6 +532,7 @@ where
         } else {
             Tok::String {
                 value: string_content,
+                is_fstring,
             }
         };
 

--- a/parser/src/lexer.rs
+++ b/parser/src/lexer.rs
@@ -1108,9 +1108,11 @@ mod tests {
             vec![
                 Tok::String {
                     value: "\\\\".to_string(),
+                    is_fstring: false,
                 },
                 Tok::String {
                     value: "\\".to_string(),
+                    is_fstring: false,
                 }
             ]
         );
@@ -1402,21 +1404,27 @@ mod tests {
             vec![
                 Tok::String {
                     value: String::from("double"),
+                    is_fstring: false,
                 },
                 Tok::String {
                     value: String::from("single"),
+                    is_fstring: false,
                 },
                 Tok::String {
                     value: String::from("can't"),
+                    is_fstring: false,
                 },
                 Tok::String {
                     value: String::from("\\\""),
+                    is_fstring: false,
                 },
                 Tok::String {
                     value: String::from("\t\r\n"),
+                    is_fstring: false,
                 },
                 Tok::String {
                     value: String::from("\\g"),
+                    is_fstring: false,
                 },
             ]
         );
@@ -1434,6 +1442,7 @@ mod tests {
                     vec![
                         Tok::String {
                             value: String::from("abcdef"),
+                            is_fstring: false,
                         },
                     ]
                 )

--- a/parser/src/parser.rs
+++ b/parser/src/parser.rs
@@ -102,7 +102,7 @@ pub enum FStringError {
 }
 
 impl From<FStringError> for ParseError<lexer::Location, token::Tok, lexer::LexicalError> {
-    fn from(err: FStringError) -> Self {
+    fn from(_err: FStringError) -> Self {
         // TODO: we should have our own top-level ParseError to properly propagate f-string (and
         // other) syntax errors
         ParseError::User {
@@ -126,12 +126,12 @@ pub fn parse_fstring(source: &str) -> Result<ast::StringGroup, FStringError> {
                 escaped = false;
             }
             '{' => {
-                if let Some((_, '{')) = chars.peek() {
-                    escaped = true;
-                    continue;
-                }
-
                 if depth == 0 {
+                    if let Some((_, '{')) = chars.peek() {
+                        escaped = true;
+                        continue;
+                    }
+
                     values.push(ast::StringGroup::Constant {
                         value: mem::replace(&mut content, String::new()),
                     });
@@ -141,12 +141,12 @@ pub fn parse_fstring(source: &str) -> Result<ast::StringGroup, FStringError> {
                 depth += 1;
             }
             '}' => {
-                if let Some((_, '}')) = chars.peek() {
-                    escaped = true;
-                    continue;
-                }
-
                 if depth == 0 {
+                    if let Some((_, '}')) = chars.peek() {
+                        escaped = true;
+                        continue;
+                    }
+
                     return Err(FStringError::UnopenedRbrace);
                 }
 

--- a/parser/src/parser.rs
+++ b/parser/src/parser.rs
@@ -188,7 +188,9 @@ mod tests {
                                 name: String::from("print"),
                             }),
                             args: vec![ast::Expression::String {
-                                value: String::from("Hello world"),
+                                value: ast::StringGroup::Constant {
+                                    value: String::from("Hello world")
+                                }
                             }],
                             keywords: vec![],
                         },
@@ -214,7 +216,9 @@ mod tests {
                             }),
                             args: vec![
                                 ast::Expression::String {
-                                    value: String::from("Hello world"),
+                                    value: ast::StringGroup::Constant {
+                                        value: String::from("Hello world"),
+                                    }
                                 },
                                 ast::Expression::Number {
                                     value: ast::Number::Integer {
@@ -245,7 +249,9 @@ mod tests {
                                 name: String::from("my_func"),
                             }),
                             args: vec![ast::Expression::String {
-                                value: String::from("positional"),
+                                value: ast::StringGroup::Constant {
+                                    value: String::from("positional"),
+                                }
                             }],
                             keywords: vec![ast::Keyword {
                                 name: Some("keyword".to_string()),
@@ -440,7 +446,9 @@ mod tests {
                                     vararg: None,
                                     kwarg: None,
                                     defaults: vec![ast::Expression::String {
-                                        value: "default".to_string()
+                                        value: ast::StringGroup::Constant {
+                                            value: "default".to_string()
+                                        }
                                     }],
                                     kw_defaults: vec![],
                                 },

--- a/parser/src/python.lalrpop
+++ b/parser/src/python.lalrpop
@@ -1017,7 +1017,7 @@ Bytes: Vec<u8> = {
     <s:bytes+> => {
         s.into_iter().flatten().collect::<Vec<u8>>()
     },
-}
+};
 
 Identifier: String = <s:name> => s;
 

--- a/parser/src/python.lalrpop
+++ b/parser/src/python.lalrpop
@@ -6,6 +6,7 @@
 
 use super::ast;
 use super::lexer;
+use super::parser;
 use std::iter::FromIterator;
 use num_bigint::BigInt;
 
@@ -789,7 +790,8 @@ SliceOp: ast::Expression = {
 }
 
 Atom: ast::Expression = {
-    StringConstant,
+    <s:StringGroup> => ast::Expression::String { value: s },
+    <b:Bytes> => ast::Expression::Bytes { value: b },
     <n:Number> => ast::Expression::Number { value: n },
     <i:Identifier> => ast::Expression::Identifier { name: i },
     "[" <e:TestListComp?> "]" => {
@@ -992,16 +994,30 @@ Number: ast::Number = {
     <s:complex> => { ast::Number::Complex { real: s.0, imag: s.1 } },
 };
 
-StringConstant: ast::Expression = {
-    <s:string+> => {
-        let glued = s.join("");
-        ast::Expression::String { value: glued }
-    },
-    <s:bytes+> => {
-        let glued = s.into_iter().flatten().collect::<Vec<u8>>();
-        ast::Expression::Bytes { value: glued }
+StringGroup: ast::StringGroup = {
+    <s:string+> =>? {
+        let mut values = vec![];
+        for (value, is_fstring) in s {
+            values.push(if is_fstring {
+                parser::parse_fstring(&value)?
+            } else {
+                ast::StringGroup::Constant { value }
+            })
+        }
+
+        Ok(if values.len() > 1 {
+            ast::StringGroup::Joined { values }
+        } else {
+            values.into_iter().next().unwrap()
+        })
     },
 };
+
+Bytes: Vec<u8> = {
+    <s:bytes+> => {
+        s.into_iter().flatten().collect::<Vec<u8>>()
+    },
+}
 
 Identifier: String = <s:name> => s;
 
@@ -1096,7 +1112,7 @@ extern {
         int => lexer::Tok::Int { value: <BigInt> },
         float => lexer::Tok::Float { value: <f64> },
         complex => lexer::Tok::Complex { real: <f64>, imag: <f64> },
-        string => lexer::Tok::String { value: <String> },
+        string => lexer::Tok::String { value: <String>, is_fstring: <bool> },
         bytes => lexer::Tok::Bytes { value: <Vec<u8>> },
         name => lexer::Tok::Name { name: <String> },
         "\n" => lexer::Tok::Newline,

--- a/parser/src/token.rs
+++ b/parser/src/token.rs
@@ -9,7 +9,7 @@ pub enum Tok {
     Int { value: BigInt },
     Float { value: f64 },
     Complex { real: f64, imag: f64 },
-    String { value: String },
+    String { value: String, is_fstring: bool },
     Bytes { value: Vec<u8> },
     Newline,
     Indent,

--- a/tests/snippets/fstrings.py
+++ b/tests/snippets/fstrings.py
@@ -7,3 +7,4 @@ assert f"{foo}foo" == 'barfoo'
 assert f"foo{foo}foo" == 'foobarfoo'
 assert f"{{foo}}" == '{foo}'
 assert f"{ {foo} }" == "{'bar'}"
+assert f"{f'{{}}'}" == '{}' # don't include escaped braces in nested f-strings

--- a/tests/snippets/fstrings.py
+++ b/tests/snippets/fstrings.py
@@ -1,0 +1,9 @@
+foo = 'bar'
+
+assert f"{''}" == ''
+assert f"{f'{foo}'}" == 'bar'
+assert f"foo{foo}" == 'foobar'
+assert f"{foo}foo" == 'barfoo'
+assert f"foo{foo}foo" == 'foobarfoo'
+assert f"{{foo}}" == '{foo}'
+assert f"{ {foo} }" == "{'bar'}"

--- a/vm/src/bytecode.rs
+++ b/vm/src/bytecode.rs
@@ -125,6 +125,9 @@ pub enum Instruction {
     Raise {
         argc: usize,
     },
+    BuildString {
+        size: usize,
+    },
     BuildTuple {
         size: usize,
         unpack: bool,
@@ -164,6 +167,7 @@ pub enum Instruction {
         after: usize,
     },
     Unpack,
+    FormatValue,
 }
 
 #[derive(Debug, Clone, PartialEq)]

--- a/vm/src/frame.rs
+++ b/vm/src/frame.rs
@@ -218,6 +218,16 @@ impl Frame {
                 }
                 Ok(None)
             }
+            bytecode::Instruction::BuildString { size } => {
+                let s = self
+                    .pop_multiple(*size)
+                    .into_iter()
+                    .map(|pyobj| objstr::get_value(&pyobj))
+                    .collect::<String>();
+                let str_obj = vm.ctx.new_str(s);
+                self.push_value(str_obj);
+                Ok(None)
+            }
             bytecode::Instruction::BuildList { size, unpack } => {
                 let elements = self.get_elements(vm, *size, *unpack)?;
                 let list_obj = vm.ctx.new_list(elements);
@@ -628,6 +638,12 @@ impl Frame {
                 for element in elements.into_iter().rev() {
                     self.push_value(element);
                 }
+                Ok(None)
+            }
+            bytecode::Instruction::FormatValue => {
+                let value = self.pop_value();
+                let formatted = vm.to_pystr(&value)?;
+                self.push_value(vm.new_str(formatted));
                 Ok(None)
             }
         }


### PR DESCRIPTION
This adds initial support for f-strings. String interpolation is tricky because it is essentially embedding a mini-language inside of the main one, with its own set of rules. There are two approaches to dealing with this that I know of: modal lexers and invoking the parser recursively. I tried both, and the latter worked out a lot better (although not without some weirdness).

Things that work:

- f-strings inside f-strings
- sets inside f-strings
- escaping with {{ and }}
- graceful handling of syntax errors inside f-string (thanks to the undocumented but extremely useful lalrpop fallible rules feature, i.e. `=>?`)

Things missing:
- format specs (e.g. `f"{1/3:.2}"`)
- reporting the specific syntax error (#464 should help with this)
- probably more that I didn't think of