### PR TITLE
Fix f-string edge case and add more tests

### DIFF
--- a/tests/snippets/fstrings.py
+++ b/tests/snippets/fstrings.py
@@ -8,3 +8,6 @@ assert f"foo{foo}foo" == 'foobarfoo'
 assert f"{{foo}}" == '{foo}'
 assert f"{ {foo} }" == "{'bar'}"
 assert f"{f'{{}}'}" == '{}' # don't include escaped braces in nested f-strings
+assert f'{f"{{"}' == '{'
+assert f'{f"}}"}' == '}'
+assert f'{foo}' f"{foo}" 'foo' == 'barbarfoo'


### PR DESCRIPTION
- Fixes edge case where nested fstring contained escaped unmatched parenthesis
- Avoids generating empty string ast nodes
- Several more tests