### PR TITLE
Change set to use hash and add set.{union,intersection,difference,symmetric_difference}

### DIFF
--- a/tests/snippets/set.py
+++ b/tests/snippets/set.py
@@ -37,3 +37,9 @@ assert not set([1,3]).issubset(set([1,2]))
 assert set([1,2]) < set([1,2,3])
 assert not set([1,2]) < set([1,2])
 assert not set([1,3]) < set([1,2])
+
+assert set([1,2,3]).union(set([4,5])) == set([1,2,3,4,5])
+assert set([1,2,3]).union(set([1,2,3,4,5])) == set([1,2,3,4,5])
+
+assert set([1,2,3]) | set([4,5]) == set([1,2,3,4,5])
+assert set([1,2,3]) | set([1,2,3,4,5]) == set([1,2,3,4,5])

--- a/tests/snippets/set.py
+++ b/tests/snippets/set.py
@@ -55,3 +55,9 @@ assert set([1,2,3]).difference(set([5,6])) == set([1,2,3])
 
 assert set([1,2,3]) - set([4,5]) == set([1,2,3])
 assert set([1,2,3]) - set([1,2,3,4,5]) == set([])
+
+assert set([1,2,3]).symmetric_difference(set([1,2])) == set([3])
+assert set([1,2,3]).symmetric_difference(set([5,6])) == set([1,2,3,5,6])
+
+assert set([1,2,3]) ^ set([4,5]) == set([1,2,3,4,5])
+assert set([1,2,3]) ^ set([1,2,3,4,5]) == set([4,5])

--- a/tests/snippets/set.py
+++ b/tests/snippets/set.py
@@ -43,3 +43,9 @@ assert set([1,2,3]).union(set([1,2,3,4,5])) == set([1,2,3,4,5])
 
 assert set([1,2,3]) | set([4,5]) == set([1,2,3,4,5])
 assert set([1,2,3]) | set([1,2,3,4,5]) == set([1,2,3,4,5])
+
+assert set([1,2,3]).intersection(set([1,2])) == set([1,2])
+assert set([1,2,3]).intersection(set([5,6])) == set([])
+
+assert set([1,2,3]) & set([4,5]) == set([])
+assert set([1,2,3]) & set([1,2,3,4,5]) == set([1,2,3])

--- a/tests/snippets/set.py
+++ b/tests/snippets/set.py
@@ -1,3 +1,16 @@
+assert set([1,2,2,3]) == set([1,2,3])
+
+assert len(set([1,2,3])) == 3
+assert len(set([1,2,2,3])) == 3
+
+try:
+	set([[]])
+except TypeError:
+    pass
+else:
+    assert False, "TypeError was not raised"
+
+
 assert set([1,2]) == set([1,2])
 assert not set([1,2,3]) == set([1,2])
 

--- a/tests/snippets/set.py
+++ b/tests/snippets/set.py
@@ -49,3 +49,9 @@ assert set([1,2,3]).intersection(set([5,6])) == set([])
 
 assert set([1,2,3]) & set([4,5]) == set([])
 assert set([1,2,3]) & set([1,2,3,4,5]) == set([1,2,3])
+
+assert set([1,2,3]).difference(set([1,2])) == set([3])
+assert set([1,2,3]).difference(set([5,6])) == set([1,2,3])
+
+assert set([1,2,3]) - set([4,5]) == set([1,2,3])
+assert set([1,2,3]) - set([1,2,3,4,5]) == set([])

--- a/vm/src/obj/objset.rs
+++ b/vm/src/obj/objset.rs
@@ -219,6 +219,25 @@ fn set_compare_inner(
     Ok(vm.new_bool(true))
 }
 
+fn set_union(vm: &mut VirtualMachine, args: PyFuncArgs) -> PyResult {
+    arg_check!(
+        vm,
+        args,
+        required = [
+            (zelf, Some(vm.ctx.set_type())),
+            (other, Some(vm.ctx.set_type()))
+        ]
+    );
+
+    let mut elements = get_elements(zelf).clone();
+    elements.extend(get_elements(other).clone());
+
+    Ok(PyObject::new(
+        PyObjectPayload::Set { elements },
+        vm.ctx.set_type(),
+    ))
+}
+
 fn frozenset_repr(vm: &mut VirtualMachine, args: PyFuncArgs) -> PyResult {
     arg_check!(vm, args, required = [(o, Some(vm.ctx.frozenset_type()))]);
 
@@ -259,6 +278,8 @@ pub fn init(context: &PyContext) {
     context.set_attr(&set_type, "__lt__", context.new_rustfunc(set_lt));
     context.set_attr(&set_type, "issubset", context.new_rustfunc(set_le));
     context.set_attr(&set_type, "issuperset", context.new_rustfunc(set_ge));
+    context.set_attr(&set_type, "union", context.new_rustfunc(set_union));
+    context.set_attr(&set_type, "__or__", context.new_rustfunc(set_union));
     context.set_attr(&set_type, "__doc__", context.new_str(set_doc.to_string()));
     context.set_attr(&set_type, "add", context.new_rustfunc(set_add));
 

--- a/vm/src/obj/objset.rs
+++ b/vm/src/obj/objset.rs
@@ -239,6 +239,23 @@ fn set_union(vm: &mut VirtualMachine, args: PyFuncArgs) -> PyResult {
 }
 
 fn set_intersection(vm: &mut VirtualMachine, args: PyFuncArgs) -> PyResult {
+    set_combine_inner(vm, args, SetCombineOperation::Intersection)
+}
+
+fn set_difference(vm: &mut VirtualMachine, args: PyFuncArgs) -> PyResult {
+    set_combine_inner(vm, args, SetCombineOperation::Difference)
+}
+
+enum SetCombineOperation {
+    Intersection,
+    Difference,
+}
+
+fn set_combine_inner(
+    vm: &mut VirtualMachine,
+    args: PyFuncArgs,
+    op: SetCombineOperation,
+) -> PyResult {
     arg_check!(
         vm,
         args,
@@ -252,7 +269,11 @@ fn set_intersection(vm: &mut VirtualMachine, args: PyFuncArgs) -> PyResult {
 
     for element in get_elements(zelf).iter() {
         let value = vm.call_method(other, "__contains__", vec![element.1.clone()])?;
-        if objbool::get_value(&value) {
+        let should_add = match op {
+            SetCombineOperation::Intersection => objbool::get_value(&value),
+            SetCombineOperation::Difference => !objbool::get_value(&value),
+        };
+        if should_add {
             elements.insert(element.0.clone(), element.1.clone());
         }
     }
@@ -311,6 +332,12 @@ pub fn init(context: &PyContext) {
         context.new_rustfunc(set_intersection),
     );
     context.set_attr(&set_type, "__and__", context.new_rustfunc(set_intersection));
+    context.set_attr(
+        &set_type,
+        "difference",
+        context.new_rustfunc(set_difference),
+    );
+    context.set_attr(&set_type, "__sub__", context.new_rustfunc(set_difference));
     context.set_attr(&set_type, "__doc__", context.new_str(set_doc.to_string()));
     context.set_attr(&set_type, "add", context.new_rustfunc(set_add));
 

--- a/vm/src/obj/objset.rs
+++ b/vm/src/obj/objset.rs
@@ -238,6 +238,31 @@ fn set_union(vm: &mut VirtualMachine, args: PyFuncArgs) -> PyResult {
     ))
 }
 
+fn set_intersection(vm: &mut VirtualMachine, args: PyFuncArgs) -> PyResult {
+    arg_check!(
+        vm,
+        args,
+        required = [
+            (zelf, Some(vm.ctx.set_type())),
+            (other, Some(vm.ctx.set_type()))
+        ]
+    );
+
+    let mut elements = HashMap::new();
+
+    for element in get_elements(zelf).iter() {
+        let value = vm.call_method(other, "__contains__", vec![element.1.clone()])?;
+        if objbool::get_value(&value) {
+            elements.insert(element.0.clone(), element.1.clone());
+        }
+    }
+
+    Ok(PyObject::new(
+        PyObjectPayload::Set { elements },
+        vm.ctx.set_type(),
+    ))
+}
+
 fn frozenset_repr(vm: &mut VirtualMachine, args: PyFuncArgs) -> PyResult {
     arg_check!(vm, args, required = [(o, Some(vm.ctx.frozenset_type()))]);
 
@@ -280,6 +305,12 @@ pub fn init(context: &PyContext) {
     context.set_attr(&set_type, "issuperset", context.new_rustfunc(set_ge));
     context.set_attr(&set_type, "union", context.new_rustfunc(set_union));
     context.set_attr(&set_type, "__or__", context.new_rustfunc(set_union));
+    context.set_attr(
+        &set_type,
+        "intersection",
+        context.new_rustfunc(set_intersection),
+    );
+    context.set_attr(&set_type, "__and__", context.new_rustfunc(set_intersection));
     context.set_attr(&set_type, "__doc__", context.new_str(set_doc.to_string()));
     context.set_attr(&set_type, "add", context.new_rustfunc(set_add));
 


### PR DESCRIPTION
I changed set key in the hashmap to be the element `__hash__` method. Previously the key was the element pointer in memory which allowed sets with duplicate elements.

In addition added set.{union,intersection,difference,symmetric_difference}