### PR TITLE
set raises TypeError when unhashable element is passed in creation

### DIFF
--- a/tests/snippets/set.py
+++ b/tests/snippets/set.py
@@ -45,3 +45,17 @@ a = set([1, 2, 3])
 assert len(a) == 3
 a.clear()
 assert len(a) == 0
+
+try:
+	set([[]])
+except TypeError:
+	pass
+else:
+	assert False, "TypeError was not raised"
+
+try:
+	set().add([])
+except TypeError:
+	pass
+else:
+	assert False, "TypeError was not raised"

--- a/vm/src/obj/objset.rs
+++ b/vm/src/obj/objset.rs
@@ -133,7 +133,7 @@ fn set_new(vm: &mut VirtualMachine, args: PyFuncArgs) -> PyResult {
             let mut elements = HashMap::new();
             let iterator = objiter::get_iter(vm, iterable)?;
             while let Ok(v) = vm.call_method(&iterator, "__next__", vec![]) {
-                insert_into_set(vm, &mut elements, &v).unwrap();
+                insert_into_set(vm, &mut elements, &v)?;
             }
             elements
         }


### PR DESCRIPTION
Currently when we do `set([[]])` we will panic:
```
thread 'main' panicked at 'called `Result::unwrap()` on an `Err` value: RefCell { value: [PyObj instance] }', src/libcore/result.rs:1009:5
```
Now we will raise;
```py
TypeError: unhashable type
```