### PR TITLE
big Integers division

### DIFF
--- a/tests/snippets/division_of_big_ints.py
+++ b/tests/snippets/division_of_big_ints.py
@@ -1,0 +1,27 @@
+# 2.456984346552728
+res = 10**500 / (4 * 10**499 + 7 * 10**497 + 3 * 10**494)
+assert 2.456984 <= res <= 2.456985
+
+# 95.23809523809524
+res = 10**3000 / (10**2998 + 5 * 10**2996)
+assert 95.238095 <= res <= 95.238096
+
+assert 10**500 / (2*10**(500-308)) == 5e307
+assert 10**500 / (10**(500-308)) == 1e308
+try:
+    10**500 / (10**(500-309))
+except OverflowError:
+    pass
+else:
+    assert False, 'Expected overflow on too big result'
+
+# a bit more than f64::MAX = 1.7976931348623157e+308_f64
+assert (2 * 10**308) / 2 == 1e308
+
+# when dividing too big int by a float, the operation should fail
+try:
+    (2 * 10**308) / 2.0
+except OverflowError:
+    pass
+else:
+    assert False, 'Expected overflow on division of a big int by a float'

--- a/vm/src/builtins.rs
+++ b/vm/src/builtins.rs
@@ -596,7 +596,7 @@ pub fn builtin_print(vm: &mut VirtualMachine, args: PyFuncArgs) -> PyResult {
             )));
         }
     }
-    let sep_str = sep_arg.as_ref().map(|obj| objstr::get_value_as_ref(obj));
+    let sep_str = sep_arg.as_ref().map(|obj| objstr::borrow_value(obj));
 
     // Handle 'end' kwarg:
     let end_arg = args
@@ -610,7 +610,7 @@ pub fn builtin_print(vm: &mut VirtualMachine, args: PyFuncArgs) -> PyResult {
             )));
         }
     }
-    let end_str = end_arg.as_ref().map(|obj| objstr::get_value_as_ref(obj));
+    let end_str = end_arg.as_ref().map(|obj| objstr::borrow_value(obj));
 
     // Handle 'flush' kwarg:
     let flush = if let Some(flush) = &args.get_optional_kwarg("flush") {
@@ -631,7 +631,7 @@ pub fn builtin_print(vm: &mut VirtualMachine, args: PyFuncArgs) -> PyResult {
             write!(stdout_lock, " ").unwrap();
         }
         let v = vm.to_str(&a)?;
-        let s = objstr::get_value_as_ref(&v);
+        let s = objstr::borrow_value(&v);
         write!(stdout_lock, "{}", s).unwrap();
     }
 

--- a/vm/src/obj/objint.rs
+++ b/vm/src/obj/objint.rs
@@ -441,7 +441,9 @@ fn div_ints(vm: &mut VirtualMachine, i1: &BigInt, i2: &BigInt) -> PyResult {
 
         if let Some(quotient) = quotient.to_f64() {
             let rem_part = loop {
-                if let (Some(rem), Some(divisor)) = (rem.to_f64(), divisor.to_f64()) {
+                if rem.is_zero() {
+                    break 0.0;
+                } else if let (Some(rem), Some(divisor)) = (rem.to_f64(), divisor.to_f64()) {
                     break rem / divisor;
                 } else {
                     // try with smaller numbers

--- a/vm/src/obj/objint.rs
+++ b/vm/src/obj/objint.rs
@@ -438,19 +438,17 @@ fn div_ints(vm: &mut VirtualMachine, i1: &BigInt, i2: &BigInt) -> PyResult {
     } else {
         let (quotient, mut rem) = i1.div_rem(i2);
         let mut divisor = i2.clone();
-        let mut rem_part = 0.0;
 
-        if let Some(mut quotient) = quotient.to_f64() {
-            loop {
+        if let Some(quotient) = quotient.to_f64() {
+            let rem_part = loop {
                 if let (Some(rem), Some(divisor)) = (rem.to_f64(), divisor.to_f64()) {
-                    rem_part += rem / divisor;
-                    break;
+                    break rem / divisor;
                 } else {
                     // try with smaller numbers
                     rem /= 2;
                     divisor /= 2;
                 }
-            }
+            };
 
             Ok(vm.ctx.new_float(quotient + rem_part))
         } else {

--- a/vm/src/obj/objstr.rs
+++ b/vm/src/obj/objstr.rs
@@ -111,7 +111,7 @@ pub fn get_value(obj: &PyObjectRef) -> String {
     }
 }
 
-pub fn get_value_as_ref(obj: &PyObjectRef) -> Ref<str> {
+pub fn borrow_value(obj: &PyObjectRef) -> Ref<str> {
     Ref::map(obj.borrow(), |py_obj| {
         if let PyObjectPayload::String { value } = &py_obj.payload {
             value.as_ref()

--- a/wasm/lib/src/wasm_builtins.rs
+++ b/wasm/lib/src/wasm_builtins.rs
@@ -44,7 +44,7 @@ pub fn format_print_args(vm: &mut VirtualMachine, args: PyFuncArgs) -> Result<St
             )));
         }
     }
-    let sep_str = sep_arg.as_ref().map(|obj| objstr::get_value_as_ref(obj));
+    let sep_str = sep_arg.as_ref().map(|obj| objstr::borrow_value(obj));
 
     // Handle 'end' kwarg:
     let end_arg = args
@@ -58,7 +58,7 @@ pub fn format_print_args(vm: &mut VirtualMachine, args: PyFuncArgs) -> Result<St
             )));
         }
     }
-    let end_str = end_arg.as_ref().map(|obj| objstr::get_value_as_ref(obj));
+    let end_str = end_arg.as_ref().map(|obj| objstr::borrow_value(obj));
 
     // No need to handle 'flush' kwarg, irrelevant when writing to String
 


### PR DESCRIPTION
Fixes #459.

Also I changed the `objstr::get_value_as_ref` function to `objstr::borrow_value`. I think it is a better name for a function extracting ref to the inner value.