### PR TITLE
Weakref callback

### DIFF
--- a/tests/snippets/weakrefs.py
+++ b/tests/snippets/weakrefs.py
@@ -1,13 +1,60 @@
+import sys
 from _weakref import ref
 
 
+data_holder = {}
+
+
 class X:
-    pass
+    def __init__(self, param=0):
+        self.param = param
+
+    def __str__(self):
+        return f"param: {self.param}"
 
 
 a = X()
 b = ref(a)
 
+
+def callback(weak_ref):
+    assert weak_ref is c
+    assert b() is None, 'reference to same object is dead'
+    assert c() is None, 'reference is dead'
+    data_holder['first'] = True
+
+
+c = ref(a, callback)
+
+
+def never_callback(_weak_ref):
+    data_holder['never'] = True
+
+
+# weakref should be cleaned up before object, so callback is never called
+ref(a, never_callback)
+
 assert callable(b)
 assert b() is a
+
+assert 'first' not in data_holder
+del a
+assert b() is None
+assert 'first' in data_holder
+assert 'never' not in data_holder
+
+# TODO proper detection of RustPython if sys.implementation.name == 'RustPython':
+if not hasattr(sys, 'implementation'):
+    # implementation detail that the object isn't dropped straight away
+    # this tests that when an object is resurrected it still acts as normal
+    delayed_drop = X(5)
+    delayed_drop_ref = ref(delayed_drop)
+
+    delayed_drop = None
+
+    assert delayed_drop_ref() is not None
+    value = delayed_drop_ref()
+    del delayed_drop  # triggers process_deletes
+
+    assert str(value) == "param: 5"
 

--- a/tests/snippets/weakrefs.py
+++ b/tests/snippets/weakrefs.py
@@ -1,6 +1,7 @@
 import sys
 from _weakref import ref
 
+from testutils import assert_raises
 
 data_holder = {}
 
@@ -58,3 +59,4 @@ if not hasattr(sys, 'implementation'):
 
     assert str(value) == "param: 5"
 
+assert_raises(TypeError, lambda: ref(1), "can't create weak reference to an int")

--- a/vm/src/builtins.rs
+++ b/vm/src/builtins.rs
@@ -16,8 +16,8 @@ use super::obj::objstr;
 use super::obj::objtype;
 
 use super::pyobject::{
-    AttributeProtocol, IdProtocol, PyContext, PyFuncArgs, PyObject, PyObjectPayload, PyObjectRef,
-    PyResult, Scope, TypeProtocol,
+    AttributeProtocol, IdProtocol, PyContext, PyFuncArgs, PyObjectRef,
+    PyResult, TypeProtocol,
 };
 use super::stdlib::io::io_open;
 
@@ -265,17 +265,7 @@ fn make_scope(vm: &mut VirtualMachine, locals: Option<&PyObjectRef>) -> PyObject
     };
 
     // TODO: handle optional globals
-    // Construct new scope:
-    let scope_inner = Scope {
-        locals,
-        parent: None,
-    };
-
-    PyObject {
-        payload: PyObjectPayload::Scope { scope: scope_inner },
-        typ: None,
-    }
-    .into_ref()
+    vm.ctx.new_scope_with_locals(None, locals)
 }
 
 fn builtin_format(vm: &mut VirtualMachine, args: PyFuncArgs) -> PyResult {

--- a/vm/src/builtins.rs
+++ b/vm/src/builtins.rs
@@ -16,8 +16,7 @@ use super::obj::objstr;
 use super::obj::objtype;
 
 use super::pyobject::{
-    AttributeProtocol, IdProtocol, PyContext, PyFuncArgs, PyObjectRef,
-    PyResult, TypeProtocol,
+    AttributeProtocol, IdProtocol, PyContext, PyFuncArgs, PyObjectRef, PyResult, TypeProtocol,
 };
 use super::stdlib::io::io_open;
 

--- a/vm/src/frame.rs
+++ b/vm/src/frame.rs
@@ -844,6 +844,10 @@ impl Frame {
         // Assume here that locals is a dict
         let name = vm.ctx.new_str(name.to_string());
         vm.call_method(&locals, "__delitem__", vec![name])?;
+
+        // process possible delete
+        PyObjectRef::process_deletes(vm);
+
         Ok(None)
     }
 

--- a/vm/src/frame.rs
+++ b/vm/src/frame.rs
@@ -140,6 +140,8 @@ impl Frame {
             }
         };
 
+        PyObjectRef::process_deletes(vm);
+
         vm.current_frame = prev_frame;
         value
     }

--- a/vm/src/obj/mod.rs
+++ b/vm/src/obj/mod.rs
@@ -28,4 +28,5 @@ pub mod objstr;
 pub mod objsuper;
 pub mod objtuple;
 pub mod objtype;
+pub mod objweakref;
 pub mod objzip;

--- a/vm/src/obj/objstr.rs
+++ b/vm/src/obj/objstr.rs
@@ -1,6 +1,6 @@
 use super::super::format::{FormatParseError, FormatPart, FormatString};
 use super::super::pyobject::{
-    PyContext, PyFuncArgs, PyObject, PyObjectPayload, PyObjectRef, PyResult, TypeProtocol,
+    PyContext, PyFuncArgs, PyObjectPayload, PyObjectRef, PyResult, TypeProtocol,
 };
 use super::super::vm::VirtualMachine;
 use super::objint;
@@ -1126,8 +1126,8 @@ pub fn subscript(vm: &mut VirtualMachine, value: &str, b: PyObjectRef) -> PyResu
 
 // help get optional string indices
 fn get_slice(
-    start: Option<&std::rc::Rc<std::cell::RefCell<PyObject>>>,
-    end: Option<&std::rc::Rc<std::cell::RefCell<PyObject>>>,
+    start: Option<&PyObjectRef>,
+    end: Option<&PyObjectRef>,
     len: usize,
 ) -> Result<(usize, usize), String> {
     let start_idx = match start {

--- a/vm/src/obj/objtype.rs
+++ b/vm/src/obj/objtype.rs
@@ -232,7 +232,7 @@ pub fn get_attributes(obj: &PyObjectRef) -> PyAttributes {
     }
 
     // Get instance attributes:
-    if let PyObjectPayload::Instance { dict } = &obj.borrow().payload {
+    if let PyObjectPayload::Instance { dict, .. } = &obj.borrow().payload {
         for (name, value) in dict.borrow().iter() {
             attributes.insert(name.to_string(), value.clone());
         }

--- a/vm/src/obj/objweakref.rs
+++ b/vm/src/obj/objweakref.rs
@@ -37,6 +37,14 @@ fn get_value(obj: &PyObjectRef) -> PyObjectWeakRef {
     }
 }
 
+pub fn clear_weak_ref(obj: &PyObjectRef) {
+    if let PyObjectPayload::WeakRef { ref mut referent, .. } = &mut obj.borrow_mut().payload {
+        referent.clear();
+    } else {
+        panic!("Inner error getting weak ref {:?}", obj);
+    }
+}
+
 pub fn notify_weak_ref(vm: &mut VirtualMachine, obj: &PyObjectRef) -> PyResult {
     if let PyObjectPayload::WeakRef { callback, .. } = &obj.borrow().payload {
         if let Some(callback) = callback {

--- a/vm/src/obj/objweakref.rs
+++ b/vm/src/obj/objweakref.rs
@@ -21,8 +21,15 @@ fn ref_new(vm: &mut VirtualMachine, args: PyFuncArgs) -> PyResult {
         },
         cls.clone(),
     );
-    referent.borrow_mut().add_weakref(&weakref);
-    Ok(weakref)
+    if referent.borrow_mut().add_weakref(&weakref) {
+        Ok(weakref)
+    } else {
+        let referent_repr = vm.to_pystr(&referent.typ())?;
+        Err(vm.new_type_error(format!(
+            "cannot create weak reference to '{}' object",
+            referent_repr
+        )))
+    }
 }
 
 /// Dereference the weakref, and check if we still refer something.

--- a/vm/src/obj/objweakref.rs
+++ b/vm/src/obj/objweakref.rs
@@ -1,0 +1,42 @@
+use super::super::pyobject::{
+    PyContext, PyFuncArgs, PyObject, PyObjectRef, PyObjectWeakRef, PyObjectPayload, PyResult, TypeProtocol,
+};
+use super::super::vm::VirtualMachine;
+use super::objtype; // Required for arg_check! to use isinstance
+
+fn ref_new(vm: &mut VirtualMachine, args: PyFuncArgs) -> PyResult {
+    // TODO: check first argument for subclass of `ref`.
+    arg_check!(vm, args, required = [(cls, Some(vm.ctx.type_type())), (referent, None)],
+        optional = [(callback, None)]);
+    let referent = PyObjectRef::downgrade(referent);
+    Ok(PyObject::new(
+        PyObjectPayload::WeakRef { referent, callback: callback.cloned() },
+        cls.clone(),
+    ))
+}
+
+/// Dereference the weakref, and check if we still refer something.
+fn ref_call(vm: &mut VirtualMachine, args: PyFuncArgs) -> PyResult {
+    arg_check!(vm, args, required = [(zelf, Some(vm.ctx.weakref_type()))]);
+    let referent = get_value(zelf);
+    let py_obj = if let Some(obj) = referent.upgrade() {
+        obj
+    } else {
+        vm.get_none()
+    };
+    Ok(py_obj)
+}
+
+fn get_value(obj: &PyObjectRef) -> PyObjectWeakRef {
+    if let PyObjectPayload::WeakRef { referent, .. } = &obj.borrow().payload {
+        referent.clone()
+    } else {
+        panic!("Inner error getting weak ref {:?}", obj);
+    }
+}
+
+pub fn init(context: &PyContext) {
+    let weakref_type = &context.weakref_type;
+    context.set_attr(weakref_type, "__new__", context.new_rustfunc(ref_new));
+    context.set_attr(weakref_type, "__call__", context.new_rustfunc(ref_call));
+}

--- a/vm/src/pyobject.rs
+++ b/vm/src/pyobject.rs
@@ -28,6 +28,7 @@ use super::obj::objstr;
 use super::obj::objsuper;
 use super::obj::objtuple;
 use super::obj::objtype;
+use super::obj::objweakref;
 use super::obj::objzip;
 use super::vm::VirtualMachine;
 use num_bigint::BigInt;
@@ -177,6 +178,7 @@ pub struct PyContext {
     pub module_type: PyObjectRef,
     pub bound_method_type: PyObjectRef,
     pub member_descriptor_type: PyObjectRef,
+    pub weakref_type: PyObjectRef,
     pub object: PyObjectRef,
     pub exceptions: exceptions::ExceptionZoo,
 }
@@ -229,6 +231,7 @@ impl PyContext {
         );
         let property_type = create_type("property", &type_type, &object_type, &dict_type);
         let super_type = create_type("super", &type_type, &object_type, &dict_type);
+        let weakref_type = create_type("ref", &type_type, &object_type, &dict_type);
         let generator_type = create_type("generator", &type_type, &object_type, &dict_type);
         let bound_method_type = create_type("method", &type_type, &object_type, &dict_type);
         let member_descriptor_type =
@@ -314,6 +317,7 @@ impl PyContext {
             module_type,
             bound_method_type,
             member_descriptor_type,
+            weakref_type,
             type_type,
             exceptions,
         };
@@ -345,6 +349,7 @@ impl PyContext {
         objbool::init(&context);
         objcode::init(&context);
         objframe::init(&context);
+        objweakref::init(&context);
         objnone::init(&context);
         exceptions::init(&context);
         context
@@ -472,6 +477,7 @@ impl PyContext {
     pub fn member_descriptor_type(&self) -> PyObjectRef {
         self.member_descriptor_type.clone()
     }
+    pub fn weakref_type(&self) -> PyObjectRef { self.weakref_type.clone() }
     pub fn type_type(&self) -> PyObjectRef {
         self.type_type.clone()
     }

--- a/vm/src/pyobject.rs
+++ b/vm/src/pyobject.rs
@@ -141,7 +141,10 @@ impl Drop for PyObjectRef {
             // The PyObject is going to be dropped, delete it later when we have access to vm.
             // This will error when the tls is destroyed, thus meaning objects won't actually
             // be properly destroyed.
-            if DELETE_QUEUE.try_with(|q| q.borrow_mut().push_back(self.clone())).is_err() {
+            if DELETE_QUEUE
+                .try_with(|q| q.borrow_mut().push_back(self.clone()))
+                .is_err()
+            {
                 warn!("Object hasn't been cleaned up {:?}.", self);
             }
         }
@@ -798,7 +801,8 @@ impl PyContext {
 pub struct PyObject {
     pub payload: PyObjectPayload,
     pub typ: Option<PyObjectRef>,
-    weak_refs: Vec<PyObjectWeakRef>, // pub dict: HashMap<String, PyObjectRef>, // __dict__ member
+    weak_refs: Vec<PyObjectWeakRef>,
+    // pub dict: HashMap<String, PyObjectRef>, // __dict__ member
 }
 
 pub trait IdProtocol {

--- a/vm/src/pyobject.rs
+++ b/vm/src/pyobject.rs
@@ -141,7 +141,7 @@ impl Drop for PyObjectRef {
             // The PyObject is going to be dropped, delete it later when we have access to vm.
             // This will error when the tls is destroyed, thus meaning objects won't actually
             // be properly destroyed.
-            if let Err(_) = DELETE_QUEUE.try_with(|q| q.borrow_mut().push_back(self.clone())) {
+            if DELETE_QUEUE.try_with(|q| q.borrow_mut().push_back(self.clone())).is_err() {
                 warn!("Object hasn't been cleaned up {:?}.", self);
             }
         }

--- a/vm/src/stdlib/weakref.rs
+++ b/vm/src/stdlib/weakref.rs
@@ -5,9 +5,7 @@
 //! - [rust weak struct](https://doc.rust-lang.org/std/rc/struct.Weak.html)
 //!
 
-use super::super::pyobject::{
-    PyContext, PyObjectRef
-};
+use super::super::pyobject::{PyContext, PyObjectRef};
 
 pub fn mk_module(ctx: &PyContext) -> PyObjectRef {
     let py_mod = ctx.new_module("_weakref", ctx.new_scope(None));
@@ -15,4 +13,3 @@ pub fn mk_module(ctx: &PyContext) -> PyObjectRef {
     ctx.set_attr(&py_mod, "ref", ctx.weakref_type());
     py_mod
 }
-

--- a/vm/src/sysmodule.rs
+++ b/vm/src/sysmodule.rs
@@ -1,6 +1,5 @@
 use obj::objtype;
 use pyobject::{PyContext, PyFuncArgs, PyObjectRef, PyResult, TypeProtocol};
-use std::rc::Rc;
 use std::{env, mem};
 use vm::VirtualMachine;
 
@@ -24,7 +23,7 @@ fn getframe(vm: &mut VirtualMachine, _args: PyFuncArgs) -> PyResult {
 
 fn sys_getrefcount(vm: &mut VirtualMachine, args: PyFuncArgs) -> PyResult {
     arg_check!(vm, args, required = [(object, None)]);
-    let size = Rc::strong_count(&object);
+    let size = PyObjectRef::strong_count(object);
     Ok(vm.ctx.new_int(size))
 }
 


### PR DESCRIPTION
I have made changes to allow weak references to have callbacks, but I have ran into a problem about how to run these callbacks during drop as we have no reference in the virual machine within the drop method.

I see three possible solutions to this:
1. Add PyObjectRef::drop(vm: &mut VirtualMachine, obj: PyObjectRef) which would have be called to drop each reference. There is no way to make the compiler enforce this, so this could lead to plenty of bugs caused by not being dropped correctly.
2. Make it possible to invoke Python code without having to be passed a mutable reference to the virtual machine. This would likely involve making fine locks for the parts of the virtual machine that needs to be locked. This is effectively 'Remove GIL'. 
3. Don't immediately invoke the callbacks/\_\_del\_\_ and do it later:
    - Either when control returns to the core interpreter
    - Or don't use reference counting at all, instead use a mark and sweep GC which can be given the mutable reference to the virtual machine when we want to collect garbage.