### PR TITLE
Fixed the 'wrong_self_convention' clippy warning

### DIFF
--- a/vm/src/builtins.rs
+++ b/vm/src/builtins.rs
@@ -618,7 +618,7 @@ pub fn builtin_print(vm: &mut VirtualMachine, args: PyFuncArgs) -> PyResult {
         } else {
             write!(stdout_lock, " ").unwrap();
         }
-        let v = vm.to_str(&a)?;
+        let v = vm.as_str(&a)?;
         let s = objstr::borrow_value(&v);
         write!(stdout_lock, "{}", s).unwrap();
     }
@@ -638,7 +638,7 @@ pub fn builtin_print(vm: &mut VirtualMachine, args: PyFuncArgs) -> PyResult {
 
 fn builtin_repr(vm: &mut VirtualMachine, args: PyFuncArgs) -> PyResult {
     arg_check!(vm, args, required = [(obj, None)]);
-    vm.to_repr(obj)
+    vm.as_repr(obj)
 }
 
 fn builtin_reversed(vm: &mut VirtualMachine, args: PyFuncArgs) -> PyResult {

--- a/vm/src/dictdatatype.rs
+++ b/vm/src/dictdatatype.rs
@@ -87,7 +87,7 @@ impl Dict {
                 panic!("Lookup returned invalid index into entries!");
             }
         } else {
-            let key_repr = vm.to_pystr(key)?;
+            let key_repr = vm.as_pystr(key)?;
             Err(vm.new_value_error(format!("Key not found: {}", key_repr)))
         }
     }
@@ -103,7 +103,7 @@ impl Dict {
             self.size -= 1;
             Ok(())
         } else {
-            let key_repr = vm.to_pystr(key)?;
+            let key_repr = vm.as_pystr(key)?;
             Err(vm.new_value_error(format!("Key not found: {}", key_repr)))
         }
     }

--- a/vm/src/exceptions.rs
+++ b/vm/src/exceptions.rs
@@ -29,19 +29,19 @@ pub fn print_exception(vm: &mut VirtualMachine, exc: &PyObjectRef) {
             for element in elements.iter() {
                 if objtype::isinstance(&element, &vm.ctx.tuple_type()) {
                     let element = objsequence::get_elements(&element);
-                    let filename = if let Ok(x) = vm.to_str(&element[0]) {
+                    let filename = if let Ok(x) = vm.as_str(&element[0]) {
                         objstr::get_value(&x)
                     } else {
                         "<error>".to_string()
                     };
 
-                    let lineno = if let Ok(x) = vm.to_str(&element[1]) {
+                    let lineno = if let Ok(x) = vm.as_str(&element[1]) {
                         objstr::get_value(&x)
                     } else {
                         "<error>".to_string()
                     };
 
-                    let obj_name = if let Ok(x) = vm.to_str(&element[2]) {
+                    let obj_name = if let Ok(x) = vm.as_str(&element[2]) {
                         objstr::get_value(&x)
                     } else {
                         "<error>".to_string()
@@ -57,7 +57,7 @@ pub fn print_exception(vm: &mut VirtualMachine, exc: &PyObjectRef) {
         println!("No traceback set on exception");
     }
 
-    match vm.to_str(exc) {
+    match vm.as_str(exc) {
         Ok(txt) => println!("{}", objstr::get_value(&txt)),
         Err(err) => println!("Error during error {:?}", err),
     }
@@ -71,7 +71,7 @@ fn exception_str(vm: &mut VirtualMachine, args: PyFuncArgs) -> PyResult {
     );
     let type_name = objtype::get_type_name(&exc.typ());
     let msg = if let Some(m) = exc.get_attr("msg") {
-        match vm.to_pystr(&m) {
+        match vm.as_pystr(&m) {
             Ok(msg) => msg,
             _ => "<exception str() failed>".to_string(),
         }

--- a/vm/src/frame.rs
+++ b/vm/src/frame.rs
@@ -555,7 +555,7 @@ impl Frame {
                 match expr.borrow().payload {
                     PyObjectPayload::None => (),
                     _ => {
-                        let repr = vm.to_repr(&expr)?;
+                        let repr = vm.as_repr(&expr)?;
                         builtins::builtin_print(
                             vm,
                             PyFuncArgs {

--- a/vm/src/macros.rs
+++ b/vm/src/macros.rs
@@ -16,8 +16,8 @@ macro_rules! type_check {
             let arg = &$args.args[$arg_count];
             if !objtype::isinstance(arg, &expected_type) {
                 let arg_typ = arg.typ();
-                let expected_type_name = $vm.to_pystr(&expected_type)?;
-                let actual_type = $vm.to_pystr(&arg_typ)?;
+                let expected_type_name = $vm.as_pystr(&expected_type)?;
+                let actual_type = $vm.as_pystr(&arg_typ)?;
                 return Err($vm.new_type_error(format!(
                     "argument of type {} is required for parameter {} ({}) (got: {})",
                     expected_type_name,

--- a/vm/src/obj/objdict.rs
+++ b/vm/src/obj/objdict.rs
@@ -189,8 +189,8 @@ fn dict_repr(vm: &mut VirtualMachine, args: PyFuncArgs) -> PyResult {
         let elements = get_key_value_pairs(dict_obj);
         let mut str_parts = vec![];
         for (key, value) in elements {
-            let key_repr = vm.to_repr(&key)?;
-            let value_repr = vm.to_repr(&value)?;
+            let key_repr = vm.as_repr(&key)?;
+            let value_repr = vm.as_repr(&value)?;
             let key_str = objstr::get_value(&key_repr);
             let value_str = objstr::get_value(&value_repr);
             str_parts.push(format!("{}: {}", key_str, value_str));

--- a/vm/src/obj/objfloat.rs
+++ b/vm/src/obj/objfloat.rs
@@ -35,7 +35,7 @@ fn float_init(vm: &mut VirtualMachine, args: PyFuncArgs) -> PyResult {
         match lexical::try_parse(objstr::get_value(arg)) {
             Ok(f) => f,
             Err(_) => {
-                let arg_repr = vm.to_pystr(arg)?;
+                let arg_repr = vm.as_pystr(arg)?;
                 return Err(
                     vm.new_value_error(format!("could not convert string to float: {}", arg_repr))
                 );
@@ -45,7 +45,7 @@ fn float_init(vm: &mut VirtualMachine, args: PyFuncArgs) -> PyResult {
         match lexical::try_parse(objbytes::get_value(arg).as_slice()) {
             Ok(f) => f,
             Err(_) => {
-                let arg_repr = vm.to_pystr(arg)?;
+                let arg_repr = vm.as_pystr(arg)?;
                 return Err(
                     vm.new_value_error(format!("could not convert string to float: {}", arg_repr))
                 );

--- a/vm/src/obj/objlist.rs
+++ b/vm/src/obj/objlist.rs
@@ -203,7 +203,7 @@ fn list_repr(vm: &mut VirtualMachine, args: PyFuncArgs) -> PyResult {
         let elements = get_elements(o);
         let mut str_parts = vec![];
         for elem in elements.iter() {
-            let s = vm.to_repr(elem)?;
+            let s = vm.as_repr(elem)?;
             str_parts.push(objstr::get_value(&s));
         }
         format!("[{}]", str_parts.join(", "))
@@ -282,7 +282,7 @@ fn list_index(vm: &mut VirtualMachine, args: PyFuncArgs) -> PyResult {
             return Ok(vm.context().new_int(index));
         }
     }
-    let needle_str = objstr::get_value(&vm.to_str(needle).unwrap());
+    let needle_str = objstr::get_value(&vm.as_str(needle).unwrap());
     Err(vm.new_value_error(format!("'{}' is not in list", needle_str)))
 }
 
@@ -445,7 +445,7 @@ fn list_remove(vm: &mut VirtualMachine, args: PyFuncArgs) -> PyResult {
         elements.remove(index);
         Ok(vm.get_none())
     } else {
-        let needle_str = objstr::get_value(&vm.to_str(needle)?);
+        let needle_str = objstr::get_value(&vm.as_str(needle)?);
         Err(vm.new_value_error(format!("'{}' is not in list", needle_str)))
     }
 }

--- a/vm/src/obj/objobject.rs
+++ b/vm/src/obj/objobject.rs
@@ -133,7 +133,7 @@ fn object_format(vm: &mut VirtualMachine, args: PyFuncArgs) -> PyResult {
         ]
     );
     if objstr::get_value(format_spec).is_empty() {
-        vm.to_str(obj)
+        vm.as_str(obj)
     } else {
         Err(vm.new_type_error("unsupported format string passed to object.__format__".to_string()))
     }

--- a/vm/src/obj/objset.rs
+++ b/vm/src/obj/objset.rs
@@ -187,7 +187,7 @@ fn set_repr(vm: &mut VirtualMachine, args: PyFuncArgs) -> PyResult {
     } else if let Some(_guard) = ReprGuard::enter(o) {
         let mut str_parts = vec![];
         for elem in elements.values() {
-            let part = vm.to_repr(elem)?;
+            let part = vm.as_repr(elem)?;
             str_parts.push(objstr::get_value(&part));
         }
 
@@ -417,7 +417,7 @@ fn frozenset_repr(vm: &mut VirtualMachine, args: PyFuncArgs) -> PyResult {
     } else {
         let mut str_parts = vec![];
         for elem in elements.values() {
-            let part = vm.to_repr(elem)?;
+            let part = vm.as_repr(elem)?;
             str_parts.push(objstr::get_value(&part));
         }
 

--- a/vm/src/obj/objstr.rs
+++ b/vm/src/obj/objstr.rs
@@ -261,7 +261,7 @@ fn str_format(vm: &mut VirtualMachine, args: PyFuncArgs) -> PyResult {
     let zelf = &args.args[0];
     if !objtype::isinstance(&zelf, &vm.ctx.str_type()) {
         let zelf_typ = zelf.typ();
-        let actual_type = vm.to_pystr(&zelf_typ)?;
+        let actual_type = vm.as_pystr(&zelf_typ)?;
         return Err(vm.new_type_error(format!(
             "descriptor 'format' requires a 'str' object but received a '{}'",
             actual_type
@@ -288,7 +288,7 @@ fn call_object_format(
     let result = vm.call_method(&argument, "__format__", vec![returned_type])?;
     if !objtype::isinstance(&result, &vm.ctx.str_type()) {
         let result_type = result.typ();
-        let actual_type = vm.to_pystr(&result_type)?;
+        let actual_type = vm.as_pystr(&result_type)?;
         return Err(vm.new_type_error(format!("__format__ must return a str, not {}", actual_type)));
     }
     Ok(result)
@@ -1030,7 +1030,7 @@ fn str_new(vm: &mut VirtualMachine, args: PyFuncArgs) -> PyResult {
         panic!("str expects exactly one parameter");
     };
 
-    vm.to_str(&args.args[1])
+    vm.as_str(&args.args[1])
 }
 
 impl PySliceableSequence for String {

--- a/vm/src/obj/objtuple.rs
+++ b/vm/src/obj/objtuple.rs
@@ -218,7 +218,7 @@ fn tuple_repr(vm: &mut VirtualMachine, args: PyFuncArgs) -> PyResult {
 
         let mut str_parts = vec![];
         for elem in elements.iter() {
-            let s = vm.to_repr(elem)?;
+            let s = vm.as_repr(elem)?;
             str_parts.push(objstr::get_value(&s));
         }
 

--- a/vm/src/vm.rs
+++ b/vm/src/vm.rs
@@ -198,16 +198,16 @@ impl VirtualMachine {
     }
 
     // Container of the virtual machine state:
-    pub fn to_str(&mut self, obj: &PyObjectRef) -> PyResult {
+    pub fn as_str(&mut self, obj: &PyObjectRef) -> PyResult {
         self.call_method(&obj, "__str__", vec![])
     }
 
-    pub fn to_pystr(&mut self, obj: &PyObjectRef) -> Result<String, PyObjectRef> {
-        let py_str_obj = self.to_str(obj)?;
+    pub fn as_pystr(&mut self, obj: &PyObjectRef) -> Result<String, PyObjectRef> {
+        let py_str_obj = self.as_str(obj)?;
         Ok(objstr::get_value(&py_str_obj))
     }
 
-    pub fn to_repr(&mut self, obj: &PyObjectRef) -> PyResult {
+    pub fn as_repr(&mut self, obj: &PyObjectRef) -> PyResult {
         self.call_method(obj, "__repr__", vec![])
     }
 

--- a/wasm/lib/src/lib.rs
+++ b/wasm/lib/src/lib.rs
@@ -17,7 +17,7 @@ use wasm_bindgen::{prelude::*, JsCast};
 const TS_CMT_START: &'static str = "/*";
 
 fn py_str_err(vm: &mut VirtualMachine, py_err: &PyObjectRef) -> String {
-    vm.to_pystr(&py_err)
+    vm.as_pystr(&py_err)
         .unwrap_or_else(|_| "Error, and error getting error message".into())
 }
 
@@ -31,7 +31,7 @@ fn py_to_js(vm: &mut VirtualMachine, py_obj: PyObjectRef) -> JsValue {
     .expect("Couldn't get json.dumps function");
     match vm.invoke(dumps, pyobject::PyFuncArgs::new(vec![py_obj], vec![])) {
         Ok(value) => {
-            let json = vm.to_pystr(&value).unwrap();
+            let json = vm.as_pystr(&value).unwrap();
             js_sys::JSON::parse(&json).unwrap_or(JsValue::UNDEFINED)
         }
         Err(_) => JsValue::UNDEFINED,

--- a/wasm/lib/src/wasm_builtins.rs
+++ b/wasm/lib/src/wasm_builtins.rs
@@ -72,7 +72,7 @@ pub fn format_print_args(vm: &mut VirtualMachine, args: PyFuncArgs) -> Result<St
         } else {
             output.push(' ');
         }
-        output.push_str(&vm.to_pystr(&a)?);
+        output.push_str(&vm.as_pystr(&a)?);
     }
 
     if let Some(end_str) = end_str {
@@ -92,7 +92,7 @@ pub fn builtin_print_html(vm: &mut VirtualMachine, args: PyFuncArgs, selector: &
 pub fn builtin_print_console(vm: &mut VirtualMachine, args: PyFuncArgs) -> PyResult {
     let arr = Array::new();
     for arg in args.args {
-        arr.push(&vm.to_pystr(&arg)?.into());
+        arr.push(&vm.as_pystr(&arg)?.into());
     }
     console::log(&arr);
     Ok(vm.get_none())


### PR DESCRIPTION
This breaks the API of the vm struct all over the code base,
but becomes more consistent with the Rust naming convention,
therefore it will be easier to reason about the code in the future.

Relevant clippy warning: https://rust-lang.github.io/rust-clippy/master/index.html#wrong_self_convention