### PR TITLE
Fix infinite loop when breaking from nested for loop

### DIFF
--- a/tests/snippets/control_flow.py
+++ b/tests/snippets/control_flow.py
@@ -1,0 +1,10 @@
+def foo():
+    sum = 0
+    for i in range(10):
+        sum += i
+        for j in range(10):
+            sum += j
+            break
+    return sum
+
+assert foo() == 45

--- a/vm/src/compile.rs
+++ b/vm/src/compile.rs
@@ -234,11 +234,11 @@ impl Compiler {
                     target: start_label,
                 });
                 self.set_label(else_label);
+                self.emit(Instruction::PopBlock);
                 if let Some(orelse) = orelse {
                     self.compile_statements(orelse)?;
                 }
                 self.set_label(end_label);
-                self.emit(Instruction::PopBlock);
             }
             ast::Statement::With { items, body } => {
                 let end_label = self.new_label();
@@ -267,14 +267,6 @@ impl Compiler {
                 body,
                 orelse,
             } => {
-                // The thing iterated:
-                for i in iter {
-                    self.compile_expression(i)?;
-                }
-
-                // Retrieve iterator
-                self.emit(Instruction::GetIter);
-
                 // Start loop
                 let start_label = self.new_label();
                 let else_label = self.new_label();
@@ -283,6 +275,15 @@ impl Compiler {
                     start: start_label,
                     end: end_label,
                 });
+
+                // The thing iterated:
+                for i in iter {
+                    self.compile_expression(i)?;
+                }
+
+                // Retrieve Iterator
+                self.emit(Instruction::GetIter);
+
                 self.set_label(start_label);
                 self.emit(Instruction::ForIter { target: else_label });
 
@@ -295,11 +296,11 @@ impl Compiler {
                     target: start_label,
                 });
                 self.set_label(else_label);
+                self.emit(Instruction::PopBlock);
                 if let Some(orelse) = orelse {
                     self.compile_statements(orelse)?;
                 }
                 self.set_label(end_label);
-                self.emit(Instruction::PopBlock);
             }
             ast::Statement::Raise { exception, cause } => match exception {
                 Some(value) => {


### PR DESCRIPTION
Fixes #498.

A few different issues were at play here:

1. When a block was popped, values from its execution were left on the stack. The value stack is now truncated to the level it was at prior to entering the block.
2. The for-loop iterator was being pushed to the value stack _before_ entering the loop block.
3. Breaking from loops was actually popping the block twice, first in the `Break` instruction, and then in the `PopBlock` instruction it jumped to. This probably went unnoticed because the `PopBlock` instruction didn't consider it an error when the block stack was empty, so things still worked for top-level loops. 