### PR TITLE
Add checking if value more then 255 in bytearraya

### DIFF
--- a/tests/snippets/bytearray.py
+++ b/tests/snippets/bytearray.py
@@ -33,3 +33,10 @@ assert not bytearray(b'is Not title casE').istitle()
 a = bytearray(b'abcd')
 a.clear()
 assert len(a) == 0
+
+try:
+    bytearray([400])
+except ValueError:
+    pass
+else:
+    assert False

--- a/vm/src/obj/objbytearray.rs
+++ b/vm/src/obj/objbytearray.rs
@@ -119,7 +119,11 @@ fn bytearray_new(vm: &mut VirtualMachine, args: PyFuncArgs) -> PyResult {
         let mut data_bytes = vec![];
         for elem in elements.iter() {
             let v = objint::to_int(vm, elem, 10)?;
-            data_bytes.push(v.to_u8().unwrap());
+            if let Some(i) = v.to_u8() {
+                data_bytes.push(i);
+            } else {
+                return Err(vm.new_value_error("byte must be in range(0, 256)".to_string()));
+            }
         }
         data_bytes
     // return Err(vm.new_type_error("Cannot construct bytes".to_string()));


### PR DESCRIPTION
Fix the issue:

```
>>>>> a = bytearray([400])
thread 'main' panicked at 'called `Option::unwrap()` on a `None` value', src/libcore/option.rs:355:21
```

Python:
```
>>> a = bytearray([400])
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
ValueError: byte must be in range(0, 256)
```