### PR TITLE
Compile error message cleanup

### DIFF
--- a/parser/src/ast.rs
+++ b/parser/src/ast.rs
@@ -219,6 +219,50 @@ pub enum Expression {
     None,
 }
 
+impl Expression {
+    /// Returns a short name for the node suitable for use in error messages.
+    pub fn name(&self) -> &'static str {
+        use self::Expression::*;
+        use self::StringGroup::*;
+
+        match self {
+            BoolOp { .. } | Binop { .. } | Unop { .. } => "operator",
+            Subscript { .. } => "subscript",
+            Yield { .. } | YieldFrom { .. } => "yield expression",
+            Compare { .. } => "comparison",
+            Attribute { .. } => "attribute",
+            Call { .. } => "function call",
+            Number { .. }
+            | String {
+                value: Constant { .. },
+            }
+            | Bytes { .. } => "literal",
+            List { .. } => "list",
+            Tuple { .. } => "tuple",
+            Dict { .. } => "dict display",
+            Set { .. } => "set display",
+            Comprehension { kind, .. } => match **kind {
+                ComprehensionKind::List { .. } => "list comprehension",
+                ComprehensionKind::Dict { .. } => "dict comprehension",
+                ComprehensionKind::Set { .. } => "set comprehension",
+                ComprehensionKind::GeneratorExpression { .. } => "generator expression",
+            },
+            Starred { .. } => "starred",
+            Slice { .. } => "slice",
+            String {
+                value: Joined { .. },
+            }
+            | String {
+                value: FormattedValue { .. },
+            } => "f-string expression",
+            Identifier { .. } => "named expression",
+            Lambda { .. } => "lambda",
+            IfExpression { .. } => "conditional expression",
+            True | False | None => "keyword",
+        }
+    }
+}
+
 /*
  * In cpython this is called arguments, but we choose parameters to
  * distinguish between function parameters and actual call arguments.

--- a/vm/src/compile.rs
+++ b/vm/src/compile.rs
@@ -573,13 +573,13 @@ impl Compiler {
             }
             ast::Statement::Break => {
                 if !self.in_loop {
-                    return Err(CompileError::SyntaxErr(String::from("break")));
+                    return Err(CompileError::InvalidBreak);
                 }
                 self.emit(Instruction::Break);
             }
             ast::Statement::Continue => {
                 if !self.in_loop {
-                    return Err(CompileError::SyntaxErr(String::from("continue")));
+                    return Err(CompileError::InvalidContinue);
                 }
                 self.emit(Instruction::Continue);
             }
@@ -646,7 +646,7 @@ impl Compiler {
                             self.emit(Instruction::DeleteSubscript);
                         }
                         _ => {
-                            return Err(CompileError::Delete);
+                            return Err(CompileError::Delete(target.name()));
                         }
                     }
                 }
@@ -766,7 +766,7 @@ impl Compiler {
                 }
             }
             _ => {
-                return Err(CompileError::Assign(format!("{:?}", target)));
+                return Err(CompileError::Assign(target.name()));
             }
         }
 

--- a/vm/src/error.rs
+++ b/vm/src/error.rs
@@ -5,29 +5,32 @@ use std::fmt;
 
 #[derive(Debug)]
 pub enum CompileError {
-    // Invalid assignment, cannot store value in target.
-    Assign(String),
-    // Invalid delete
-    Delete,
-    // Expected an expression got a statement
+    /// Invalid assignment, cannot store value in target.
+    Assign(&'static str),
+    /// Invalid delete
+    Delete(&'static str),
+    /// Expected an expression got a statement
     ExpectExpr,
-    // Parser error
+    /// Parser error
     Parse(ParseError),
-    // Multiple `*` detected
+    /// Multiple `*` detected
     StarArgs,
-    // Catches errors undetectable by the parser
-    SyntaxErr(String),
+    /// Break statement outside of loop.
+    InvalidBreak,
+    /// Continue statement outside of loop.
+    InvalidContinue,
 }
 
 impl fmt::Display for CompileError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match self {
-            CompileError::Assign(expr) => write!(f, "Invalid assignment: {}", expr),
-            CompileError::Delete => write!(f, "Invalid delete statement"),
+            CompileError::Assign(target) => write!(f, "can't assign to {}", target),
+            CompileError::Delete(target) => write!(f, "can't delete {}", target),
             CompileError::ExpectExpr => write!(f, "Expecting expression, got statement"),
-            CompileError::Parse(err) => err.fmt(f),
+            CompileError::Parse(err) => write!(f, "{}", err),
             CompileError::StarArgs => write!(f, "Two starred expressions in assignment"),
-            CompileError::SyntaxErr(expr) => write!(f, "Syntax Error: '{}' ouside loop", expr),
+            CompileError::InvalidBreak => write!(f, "break outside loop"),
+            CompileError::InvalidContinue => write!(f, "continue outside loop"),
         }
     }
 }


### PR DESCRIPTION
- Match cpython error messages for invalid assign and delete statements, rather than printing the `Debug` representation of the target node
- Replace redundant `SyntaxErr` variant with `InvalidBreak` and `InvalidContinue`