### PR TITLE
Added real/imag attributes to int type.

### DIFF
--- a/tests/snippets/ints.py
+++ b/tests/snippets/ints.py
@@ -32,6 +32,11 @@ assert (2).__rmul__(1) == 2
 assert (2).__truediv__(1) == 2.0
 assert (2).__rtruediv__(1) == 0.5
 
+# real/imag attributes
+assert (1).real == 1
+assert (1).imag == 0
+
+
 assert (1).__eq__(1.0) == NotImplemented
 assert (1).__ne__(1.0) == NotImplemented
 assert (1).__gt__(1.0) == NotImplemented

--- a/vm/src/obj/objint.rs
+++ b/vm/src/obj/objint.rs
@@ -608,6 +608,18 @@ fn int_conjugate(vm: &mut VirtualMachine, args: PyFuncArgs) -> PyResult {
     Ok(vm.ctx.new_int(v))
 }
 
+fn int_real(vm: &mut VirtualMachine, args: PyFuncArgs) -> PyResult {
+    arg_check!(vm, args, required = [(zelf, Some(vm.ctx.int_type()))]);
+    let value = BigInt::from_pyobj(zelf);
+    Ok(vm.ctx.new_int(value))
+}
+
+fn int_imag(vm: &mut VirtualMachine, args: PyFuncArgs) -> PyResult {
+    arg_check!(vm, args, required = [(zelf, Some(vm.ctx.int_type()))]);
+    let value = BigInt::from(0);
+    Ok(vm.ctx.new_int(value))
+}
+
 pub fn init(context: &PyContext) {
     let int_doc = "int(x=0) -> integer
 int(x, base=10) -> integer
@@ -680,4 +692,6 @@ Base 0 means to interpret the base from the string as an integer literal.
     );
     context.set_attr(&int_type, "__doc__", context.new_str(int_doc.to_string()));
     context.set_attr(&int_type, "conjugate", context.new_rustfunc(int_conjugate));
+    context.set_attr(&int_type, "real", context.new_property(int_real));
+    context.set_attr(&int_type, "imag", context.new_property(int_imag));
 }


### PR DESCRIPTION
This PR adds a behavior that apparently exists in Python3
```
>>> a = 1
>>> a.imag
0
>>> a.real
1
>>> 
```
