### PR TITLE
Backwards compitability for python 3.5 to run tests.

### DIFF
--- a/tests/snippets/testutils.py
+++ b/tests/snippets/testutils.py
@@ -16,5 +16,5 @@ def assert_raises(exc_type, expr, msg=None):
     else:
         failmsg = '{!s} was not raised'.format(exc_type.__name__)
         if msg is not None:
-            failmsg += ': {!s}'.formt(msg)
+            failmsg += ': {!s}'.format(msg)
         assert False, failmsg

--- a/tests/snippets/testutils.py
+++ b/tests/snippets/testutils.py
@@ -14,7 +14,7 @@ def assert_raises(exc_type, expr, msg=None):
     except exc_type:
         pass
     else:
-        failmsg = f'{exc_type.__name__} was not raised'
+        failmsg = '%s was not raised' % exc_type.__name__
         if msg is not None:
-            failmsg += f': {msg}'
+            failmsg += ': %s' % msg
         assert False, failmsg

--- a/tests/snippets/testutils.py
+++ b/tests/snippets/testutils.py
@@ -14,7 +14,7 @@ def assert_raises(exc_type, expr, msg=None):
     except exc_type:
         pass
     else:
-        failmsg = '%s was not raised' % exc_type.__name__
+        failmsg = '{!s} was not raised'.format(exc_type.__name__)
         if msg is not None:
-            failmsg += ': %s' % msg
+            failmsg += ': {!s}'.formt(msg)
         assert False, failmsg


### PR DESCRIPTION
Changed syntax in testutils.py that is introduced in 3.6 to a backwards compatible version