### PR TITLE
Use "extractor" pattern for native functions

### DIFF
--- a/vm/src/obj/objbool.rs
+++ b/vm/src/obj/objbool.rs
@@ -1,9 +1,15 @@
 use super::objtype;
 use crate::pyobject::{
-    PyContext, PyFuncArgs, PyObjectPayload, PyObjectRef, PyResult, TypeProtocol,
+    IntoPyObject, PyContext, PyFuncArgs, PyObjectPayload, PyObjectRef, PyResult, TypeProtocol,
 };
 use crate::vm::VirtualMachine;
 use num_traits::Zero;
+
+impl IntoPyObject for bool {
+    fn into_pyobject(self, ctx: &PyContext) -> PyResult {
+        Ok(ctx.new_bool(self))
+    }
+}
 
 pub fn boolval(vm: &mut VirtualMachine, obj: PyObjectRef) -> Result<bool, PyObjectRef> {
     let result = match obj.borrow().payload {

--- a/vm/src/obj/objint.rs
+++ b/vm/src/obj/objint.rs
@@ -3,8 +3,8 @@ use super::objstr;
 use super::objtype;
 use crate::format::FormatSpec;
 use crate::pyobject::{
-    FromPyObjectRef, PyContext, PyFuncArgs, PyObject, PyObjectPayload, PyObjectRef, PyResult,
-    TypeProtocol,
+    FromPyObject, FromPyObjectRef, IntoPyObject, PyContext, PyFuncArgs, PyObject, PyObjectPayload,
+    PyObjectRef, PyResult, TypeProtocol,
 };
 use crate::vm::VirtualMachine;
 use num_bigint::{BigInt, ToBigInt};
@@ -14,6 +14,22 @@ use std::hash::{Hash, Hasher};
 
 // This proxy allows for easy switching between types.
 type IntType = BigInt;
+
+pub type PyInt = BigInt;
+
+impl IntoPyObject for PyInt {
+    fn into_pyobject(self, ctx: &PyContext) -> PyResult {
+        Ok(ctx.new_int(self))
+    }
+}
+
+// TODO: macro to impl for all primitive ints
+
+impl IntoPyObject for usize {
+    fn into_pyobject(self, ctx: &PyContext) -> PyResult {
+        Ok(ctx.new_int(self))
+    }
+}
 
 fn int_repr(vm: &mut VirtualMachine, args: PyFuncArgs) -> PyResult {
     arg_check!(vm, args, required = [(int, Some(vm.ctx.int_type()))]);

--- a/vm/src/obj/objint.rs
+++ b/vm/src/obj/objint.rs
@@ -3,8 +3,8 @@ use super::objstr;
 use super::objtype;
 use crate::format::FormatSpec;
 use crate::pyobject::{
-    FromPyObject, FromPyObjectRef, IntoPyObject, PyContext, PyFuncArgs, PyObject, PyObjectPayload,
-    PyObjectRef, PyResult, TypeProtocol,
+    FromPyObjectRef, IntoPyObject, PyContext, PyFuncArgs, PyObject, PyObjectPayload, PyObjectRef,
+    PyResult, TypeProtocol,
 };
 use crate::vm::VirtualMachine;
 use num_bigint::{BigInt, ToBigInt};

--- a/vm/src/obj/objrange.rs
+++ b/vm/src/obj/objrange.rs
@@ -22,6 +22,10 @@ pub struct RangeType {
 type PyRange = RangeType;
 
 impl FromPyObject for PyRange {
+    fn typ(ctx: &PyContext) -> Option<PyObjectRef> {
+        Some(ctx.range_type())
+    }
+
     fn from_pyobject(obj: PyObjectRef) -> PyResult<Self> {
         Ok(get_value(&obj))
     }

--- a/vm/src/obj/objrange.rs
+++ b/vm/src/obj/objrange.rs
@@ -1,4 +1,4 @@
-use super::objint::{self, PyInt};
+use super::objint;
 use super::objtype;
 use crate::pyobject::{
     FromPyObject, PyContext, PyFuncArgs, PyObject, PyObjectPayload, PyObjectRef, PyResult,

--- a/vm/src/obj/objstr.rs
+++ b/vm/src/obj/objstr.rs
@@ -3,7 +3,8 @@ use super::objsequence::PySliceableSequence;
 use super::objtype;
 use crate::format::{FormatParseError, FormatPart, FormatString};
 use crate::pyobject::{
-    PyContext, PyFuncArgs, PyObject, PyObjectPayload, PyObjectRef, PyResult, TypeProtocol,
+    FromPyObject, PyContext, PyFuncArgs, PyObject, PyObjectPayload, PyObjectRef, PyResult,
+    TypeProtocol,
 };
 use crate::vm::VirtualMachine;
 use num_traits::ToPrimitive;
@@ -16,6 +17,16 @@ extern crate caseless;
 extern crate unicode_segmentation;
 
 use self::unicode_segmentation::UnicodeSegmentation;
+
+impl FromPyObject for String {
+    fn typ(ctx: &PyContext) -> Option<PyObjectRef> {
+        Some(ctx.str_type())
+    }
+
+    fn from_pyobject(obj: PyObjectRef) -> PyResult<Self> {
+        Ok(get_value(&obj))
+    }
+}
 
 pub fn init(context: &PyContext) {
     let str_type = &context.str_type;
@@ -474,15 +485,8 @@ fn str_rstrip(vm: &mut VirtualMachine, args: PyFuncArgs) -> PyResult {
     Ok(vm.ctx.new_str(value))
 }
 
-fn str_endswith(vm: &mut VirtualMachine, args: PyFuncArgs) -> PyResult {
-    arg_check!(
-        vm,
-        args,
-        required = [(s, Some(vm.ctx.str_type())), (pat, Some(vm.ctx.str_type()))]
-    );
-    let value = get_value(&s);
-    let pat = get_value(&pat);
-    Ok(vm.ctx.new_bool(value.ends_with(pat.as_str())))
+fn str_endswith(_vm: &mut VirtualMachine, zelf: String, suffix: String) -> bool {
+    zelf.ends_with(&suffix)
 }
 
 fn str_isidentifier(vm: &mut VirtualMachine, args: PyFuncArgs) -> PyResult {


### PR DESCRIPTION
First off, this is _far_ from being complete, but I wanted to share it early to see if this is a direction we actually want to go in before continuing.

The idea is to apply the ["extractor pattern"](https://actix.rs/#extractors) used by Rust web frameworks such as actix to native/rust python functions, so that the function signature determines things such as type checking, conversions to and from python objects, etc.

For example, a function that adds two ints would currently look like this:
```rus
fn add(vm: &mut VirtualMachine, args: PyFuncArgs) -> PyResult {
    arg_check!(
        vm,
        args,
        required = [(a, Some(vm.ctx.int_type())), (b, Some(vm.ctx.int_type())]
    );
    Ok(vm.ctx.new_int(get_value(a) + get_value(a)))
}
```
This isn't _bad_, but it's a lot for such a simple function, and for more complex functions the boilerplate overwhelms everything else.

The new way would look like this:
```rust
fn add(a: PyInt, b: PyInt) -> PyInt {
    a + b
}
```

Additionally, the old way still works for when you need it, because `PyFuncArgs` impls `FromPyFuncArgs`, `PyResult` impls `IntoPyObject`, etc.

Some other neat consequences:
1. A function could take a `VarArgs<T>` parameter that shifts the rest of the positional args into a `Vec`.
2. `FromPyObject` impls for primitives could raising overflow exceptions so they wouldn't have to be scattered around everywhere as they are now
3. For functions that take a lot of keyword args, one can imagine a `derive(FromFuncArgs)` proc-macro.
