### PR TITLE
Add vm features as alternative to platform checks.

### DIFF
--- a/vm/Cargo.toml
+++ b/vm/Cargo.toml
@@ -4,6 +4,15 @@ version = "0.1.0"
 authors = ["Shing Lyu <shing.lyu@gmail.com>"]
 edition = "2018"
 
+[features]
+
+# Default feature set, include full options.
+# To build without io, or compiler, de-deselect those features.
+default = ["py_compiler", "py_io"]
+
+py_compiler = ["rustpython_parser"]
+py_io = []
+
 [dependencies]
 bitflags = "1.0.4"
 num-complex = "0.2"
@@ -12,7 +21,7 @@ num-traits = "0.2"
 num-integer = "0.1.39"
 rand = "0.5"
 log = "0.3"
-rustpython_parser = {path = "../parser"}
+rustpython_parser = {path = "../parser", optional = true}
 serde = "1.0.66"
 serde_derive = "1.0.66"
 serde_json = "1.0.26"

--- a/wasm/lib/Cargo.toml
+++ b/wasm/lib/Cargo.toml
@@ -12,13 +12,18 @@ crate-type = ["cdylib", "rlib"]
 
 [dependencies]
 rustpython_parser = { path = "../../parser" }
-rustpython_vm = { path = "../../vm" }
 cfg-if = "0.1.2"
 wasm-bindgen = "0.2"
 wasm-bindgen-futures = "0.3"
 js-sys = "0.3"
 futures = "0.1"
 console_error_panic_hook = "0.1"
+
+[dependencies.rustpython_vm]
+path = "../../vm"
+features = [
+    "py_compiler"
+]
 
 [dependencies.web-sys]
 version = "0.3"


### PR DESCRIPTION
Idea is to use cargo features to disable for example io when that does not work on the wasm target for example.

This pull request only introduces the idea, the features still need to be used in the code.