### PR TITLE
[WIP] Convert PyObjectPayload to a dyn trait

### DIFF
--- a/vm/src/obj/objbytes.rs
+++ b/vm/src/obj/objbytes.rs
@@ -45,6 +45,22 @@ pub fn init(context: &PyContext) {
     );
 }
 
+pub struct ObjBytes {
+    value: Vec<u8>,
+}
+
+impl std::fmt::Debug for ObjBytes {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        write!(f, "bytes {:?}", self.value)
+    }
+}
+
+impl PyObjectPayload for ObjBytes {
+    fn payload_kind(&self) -> &str {
+        "bytes"
+    }
+}
+
 fn bytes_new(vm: &mut VirtualMachine, args: PyFuncArgs) -> PyResult {
     arg_check!(
         vm,
@@ -70,7 +86,7 @@ fn bytes_new(vm: &mut VirtualMachine, args: PyFuncArgs) -> PyResult {
         vec![]
     };
 
-    Ok(PyObject::new(PyObjectPayload::Bytes { value }, cls.clone()))
+    Ok(PyObject::new(ObjBytes { value }, cls.clone()))
 }
 
 fn bytes_eq(vm: &mut VirtualMachine, args: PyFuncArgs) -> PyResult {

--- a/vm/src/obj/objcomplex.rs
+++ b/vm/src/obj/objcomplex.rs
@@ -44,6 +44,12 @@ pub fn init(context: &PyContext) {
     );
 }
 
+pub struct ObjComplex {
+    value: Complex64,
+}
+
+impl PyObjectPayload for ObjComplex {}
+
 pub fn get_value(obj: &PyObjectRef) -> Complex64 {
     if let PyObjectPayload::Complex { value } = &obj.borrow().payload {
         *value

--- a/vm/src/obj/objcomplex.rs
+++ b/vm/src/obj/objcomplex.rs
@@ -48,7 +48,17 @@ pub struct ObjComplex {
     value: Complex64,
 }
 
-impl PyObjectPayload for ObjComplex {}
+impl std::fmt::Debug for ObjComplex {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        write!(f, "complex {}", self.value)
+    }
+}
+
+impl PyObjectPayload for ObjComplex {
+    fn payload_kind(&self) -> &str {
+        "complex"
+    }
+}
 
 pub fn get_value(obj: &PyObjectRef) -> Complex64 {
     if let PyObjectPayload::Complex { value } = &obj.borrow().payload {

--- a/vm/src/obj/objfloat.rs
+++ b/vm/src/obj/objfloat.rs
@@ -9,6 +9,12 @@ use crate::vm::VirtualMachine;
 use num_bigint::ToBigInt;
 use num_traits::ToPrimitive;
 
+pub struct ObjFloat {
+    value: f64,
+}
+
+impl PyObjectPayload for ObjFloat {}
+
 fn float_repr(vm: &mut VirtualMachine, args: PyFuncArgs) -> PyResult {
     arg_check!(vm, args, required = [(float, Some(vm.ctx.float_type()))]);
     let v = get_value(float);
@@ -61,8 +67,8 @@ fn float_init(vm: &mut VirtualMachine, args: PyFuncArgs) -> PyResult {
 
 // Retrieve inner float value:
 pub fn get_value(obj: &PyObjectRef) -> f64 {
-    if let PyObjectPayload::Float { value } = &obj.borrow().payload {
-        *value
+    if let Some(objfloat) = &obj.borrow().payload.downcast_ref::<ObjFloat>() {
+        *objfloat.value
     } else {
         panic!("Inner error getting float");
     }
@@ -86,7 +92,7 @@ pub fn make_float(vm: &mut VirtualMachine, obj: &PyObjectRef) -> Result<f64, PyO
 }
 
 fn set_value(obj: &PyObjectRef, value: f64) {
-    obj.borrow_mut().payload = PyObjectPayload::Float { value };
+    *obj.borrow_mut().payload = ObjFloat { value };
 }
 
 fn float_eq(vm: &mut VirtualMachine, args: PyFuncArgs) -> PyResult {

--- a/vm/src/obj/objfloat.rs
+++ b/vm/src/obj/objfloat.rs
@@ -13,7 +13,17 @@ pub struct ObjFloat {
     value: f64,
 }
 
-impl PyObjectPayload for ObjFloat {}
+impl std::fmt::Debug for ObjFloat {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        write!(f, "float {}", self.value)
+    }
+}
+
+impl PyObjectPayload for ObjFloat {
+    fn payload_kind(&self) -> &str {
+        "float"
+    }
+}
 
 fn float_repr(vm: &mut VirtualMachine, args: PyFuncArgs) -> PyResult {
     arg_check!(vm, args, required = [(float, Some(vm.ctx.float_type()))]);

--- a/vm/src/obj/objint.rs
+++ b/vm/src/obj/objint.rs
@@ -3,7 +3,7 @@ use super::objstr;
 use super::objtype;
 use crate::format::FormatSpec;
 use crate::pyobject::{
-    FromPyObjectRef, PyContext, PyFuncArgs, PyObject, PyObjectPayload, PyObjectRef, PyResult,
+    self, FromPyObjectRef, PyContext, PyFuncArgs, PyObject, PyObjectPayload, PyObjectRef, PyResult,
     TypeProtocol,
 };
 use crate::vm::VirtualMachine;
@@ -19,7 +19,17 @@ pub struct ObjInt {
     value: IntType,
 }
 
-impl PyObjectPayload for ObjInt {}
+impl std::fmt::Debug for ObjInt {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        write!(f, "int {}", self.value)
+    }
+}
+
+impl PyObjectPayload for ObjInt {
+    fn payload_kind(&self) -> &str {
+        "int"
+    }
+}
 
 fn int_repr(vm: &mut VirtualMachine, args: PyFuncArgs) -> PyResult {
     arg_check!(vm, args, required = [(int, Some(vm.ctx.int_type()))]);
@@ -81,7 +91,7 @@ pub fn to_int(
 
 // Retrieve inner int value:
 pub fn get_value(obj: &PyObjectRef) -> IntType {
-    if let Some(objint) = &obj.borrow().payload.downcast_ref::<ObjInt>() {
+    if let Some(objint) = pyobject::get_value::<ObjInt>(obj) {
         objint.value.clone()
     } else {
         panic!("Inner error getting int {:?}", obj);

--- a/vm/src/obj/objstr.rs
+++ b/vm/src/obj/objstr.rs
@@ -107,11 +107,15 @@ pub struct ObjString {
     value: String,
 }
 
-impl PyObjectPayload for ObjString {}
-
 impl std::fmt::Debug for ObjString {
     fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
         write!(f, "str {:?}", self.value)
+    }
+}
+
+impl PyObjectPayload for ObjString {
+    fn payload_kind(&self) -> &str {
+        "str"
     }
 }
 

--- a/vm/src/obj/objstr.rs
+++ b/vm/src/obj/objstr.rs
@@ -103,9 +103,21 @@ pub fn init(context: &PyContext) {
     );
 }
 
+pub struct ObjString {
+    value: String,
+}
+
+impl PyObjectPayload for ObjString {}
+
+impl std::fmt::Debug for ObjString {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        write!(f, "str {:?}", self.value)
+    }
+}
+
 pub fn get_value(obj: &PyObjectRef) -> String {
-    if let PyObjectPayload::String { value } = &obj.borrow().payload {
-        value.to_string()
+    if let Some(objstr) = &obj.borrow().payload.downcast_ref::<ObjString>() {
+        objstr.value.to_string()
     } else {
         panic!("Inner error getting str");
     }
@@ -113,8 +125,8 @@ pub fn get_value(obj: &PyObjectRef) -> String {
 
 pub fn borrow_value(obj: &PyObjectRef) -> Ref<str> {
     Ref::map(obj.borrow(), |py_obj| {
-        if let PyObjectPayload::String { value } = &py_obj.payload {
-            value.as_ref()
+        if let Some(objstr) = &py_obj.payload.downcast_ref::<ObjString>() {
+            objstr.value.as_ref()
         } else {
             panic!("Inner error getting str");
         }


### PR DESCRIPTION
This is what I discussed in #535, I've changed so far just a few but here's what a bare-bones obj module would look like:

```rust
pub struct ObjFloat {
    value: f64,
}
fn get_value(obj: &PyObjectRef) -> f64 {
    if let Some(objfloat) = obj.payload.downcast_ref::<ObjFloat>() {
        *objfloat.value
    } else {
        panic!("Inner error getting float")
    }
}
```