### PR TITLE
[WASM] Fix snippet selector's default selection

### DIFF
--- a/wasm/demo/src/index.ejs
+++ b/wasm/demo/src/index.ejs
@@ -20,7 +20,7 @@
             <select id="snippets">
                 <% for (const name of snippets) { %>
                     <option
-                        <% if (name == defaultSnippetName) %> selected
+                        <% if (name == defaultSnippetName) { %> selected <% } %>
                     ><%= name %></option>
                 <% } %>
             </select>


### PR DESCRIPTION
Right now, on https://rustpython.github.io/demo, all of the `option`s have the `selected` attribute, so it goes with the last one, `mandelbrot`, which takes a long time to run and freezes the page. I'd recommend merging this to `release` so that that issue gets fixed in "production" ASAP.

Edit: it actually does run `fibonacci` first, but shows `mandelbrot` as selected, since the default snippet in the textarea is separate from the `select`, but it's still an issue.