### PR TITLE
[WASM] Add requestAnimationFrame to browser module

### DIFF
--- a/wasm/demo/snippets/mandelbrot.py
+++ b/wasm/demo/snippets/mandelbrot.py
@@ -35,4 +35,4 @@ def mandel(_time_elapsed=None):
     _y['y'] += 1
     request_animation_frame(mandel)
 
-mandel()
+request_animation_frame(mandel)

--- a/wasm/demo/snippets/mandelbrot.py
+++ b/wasm/demo/snippets/mandelbrot.py
@@ -3,6 +3,7 @@ from browser import request_animation_frame
 w = 50.0
 h = 50.0
 
+# to make up for the lack of `global`
 _y = {'y': 0.0}
 
 def mandel(_time_elapsed=None):

--- a/wasm/demo/snippets/mandelbrot.py
+++ b/wasm/demo/snippets/mandelbrot.py
@@ -1,11 +1,14 @@
-# NOTE: will take a while, up to around a minute, to run.
-# Expect this page to freeze.
+from browser import request_animation_frame
 
 w = 50.0
 h = 50.0
 
-y = 0.0
-while y < h:
+_y = {'y': 0.0}
+
+def mandel(_time_elapsed=None):
+    y = _y['y']
+    if y >= h:
+        return
     x = 0.0
     while x < w:
         Zr, Zi, Tr, Ti = 0.0, 0.0, 0.0, 0.0
@@ -18,14 +21,17 @@ while y < h:
             Zr = Tr - Ti + Cr
             Tr = Zr * Zr
             Ti = Zi * Zi
-            i = i + 1
+            i += 1
 
         if Tr + Ti <= 4:
             print('*', end='')
         else:
             print('·', end='')
 
-        x = x + 1
+        x += 1
 
     print()
-    y = y + 1
+    _y['y'] += 1
+    request_animation_frame(mandel)
+
+mandel()


### PR DESCRIPTION
I also modified `mandelbrot.py` to use request_animation_frame as I discussed in [#528](https://github.com/RustPython/RustPython/pull/528#issuecomment-466670440).