### PR TITLE
[WIP] Implement object __setattr__

### DIFF
--- a/vm/src/frame.rs
+++ b/vm/src/frame.rs
@@ -1015,7 +1015,8 @@ impl Frame {
     fn store_attr(&mut self, vm: &mut VirtualMachine, attr_name: &str) -> FrameResult {
         let parent = self.pop_value();
         let value = self.pop_value();
-        vm.ctx.set_attr(&parent, attr_name, value);
+        let name = vm.ctx.new_str(attr_name.to_string());
+        vm.set_attr(&parent, name, value)?;
         Ok(None)
     }
 

--- a/vm/src/obj/objobject.rs
+++ b/vm/src/obj/objobject.rs
@@ -166,6 +166,7 @@ pub fn init(context: &PyContext) {
         "__getattribute__",
         context.new_rustfunc(object_getattribute),
     );
+    context.set_attr(&object, "__setattr__", context.new_rustfunc(object_setattr));
     context.set_attr(&object, "__doc__", context.new_str(object_doc.to_string()));
 }
 
@@ -233,4 +234,20 @@ fn object_getattribute(vm: &mut VirtualMachine, args: PyFuncArgs) -> PyResult {
             format!("{} has no attribute '{}'", obj.borrow(), name),
         ))
     }
+}
+
+fn object_setattr(vm: &mut VirtualMachine, args: PyFuncArgs) -> PyResult {
+    arg_check!(
+        vm,
+        args,
+        required = [
+            (zelf, Some(vm.ctx.object())),
+            (name_str, Some(vm.ctx.str_type())),
+            (value, None)
+        ]
+    );
+    trace!("object.__setattr__({:?}, {:?}, {:?})", zelf, name_str, value);
+    let attr_name = objstr::get_value(&name_str);
+    vm.ctx.set_attr(&zelf, &attr_name, value.clone());
+    Ok(vm.get_none())
 }

--- a/vm/src/vm.rs
+++ b/vm/src/vm.rs
@@ -481,6 +481,10 @@ impl VirtualMachine {
         self.call_method(&obj, "__getattribute__", vec![attr_name])
     }
 
+    pub fn set_attr(&mut self, obj: &PyObjectRef, attr_name: PyObjectRef, attr_value: PyObjectRef) -> PyResult {
+        self.call_method(&obj, "__setattr__", vec![attr_name, attr_value])
+    }
+
     pub fn del_attr(&mut self, obj: &PyObjectRef, attr_name: PyObjectRef) -> PyResult {
         self.call_method(&obj, "__delattr__", vec![attr_name])
     }


### PR DESCRIPTION
This PR makes `__setattr__` parallel to `__getattr__` by delegating to the object (via the VM) instead of `set_attr` on the context directly.