### PR TITLE
Add AnyRustValue payload variant

### DIFF
--- a/vm/src/pyobject.rs
+++ b/vm/src/pyobject.rs
@@ -1287,6 +1287,7 @@ impl fmt::Debug for PyObjectPayload {
             PyObjectPayload::RustFunction { .. } => write!(f, "rust function"),
             PyObjectPayload::Frame { .. } => write!(f, "frame"),
             PyObjectPayload::Socket { .. } => write!(f, "socket"),
+            PyObjectPayload::AnyRustValue { .. } => write!(f, "some rust value"),
         }
     }
 }

--- a/vm/src/pyobject.rs
+++ b/vm/src/pyobject.rs
@@ -1246,6 +1246,9 @@ pub enum PyObjectPayload {
     Socket {
         socket: Socket,
     },
+    AnyRustValue {
+        value: Box<dyn std::any::Any>,
+    },
 }
 
 impl fmt::Debug for PyObjectPayload {


### PR DESCRIPTION
Sort of what I was talking about in #535 and #536, just not as drastic of a change. This would allow outside crates to store whatever data they'd like in a PyObject, e.g. a `js_sys::Promise` as I talked about in the issue, or if someone was embedding RustPython in their program they could wrap their structs using this.