### PR TITLE
Remove outer RefCell from PyObjectRef

### DIFF
--- a/vm/src/builtins.rs
+++ b/vm/src/builtins.rs
@@ -3,6 +3,7 @@
 //! Implements functions listed here: https://docs.python.org/3/library/builtins.html
 
 // use std::ops::Deref;
+use std::cell::RefCell;
 use std::char;
 use std::io::{self, Write};
 
@@ -273,7 +274,9 @@ fn make_scope(vm: &mut VirtualMachine, locals: Option<&PyObjectRef>) -> PyObject
     };
 
     PyObject {
-        payload: PyObjectPayload::Scope { scope: scope_inner },
+        payload: PyObjectPayload::Scope {
+            scope: RefCell::new(scope_inner),
+        },
         typ: None,
     }
     .into_ref()

--- a/vm/src/frame.rs
+++ b/vm/src/frame.rs
@@ -593,7 +593,7 @@ impl Frame {
                 let locals = self.pop_value();
                 match self.locals.payload {
                     PyObjectPayload::Scope { ref scope } => {
-                        //scope.locals = locals; // FIXME
+                        (*scope.borrow_mut()).locals = locals;
                     }
                     _ => panic!("We really expect our scope to be a scope!"),
                 }
@@ -855,7 +855,7 @@ impl Frame {
 
     fn delete_name(&mut self, vm: &mut VirtualMachine, name: &str) -> FrameResult {
         let locals = match self.locals.payload {
-            PyObjectPayload::Scope { ref scope } => scope.locals.clone(),
+            PyObjectPayload::Scope { ref scope } => scope.borrow().locals.clone(),
             _ => panic!("We really expect our scope to be a scope!"),
         };
 
@@ -1137,7 +1137,7 @@ impl fmt::Debug for Frame {
             .collect::<Vec<_>>()
             .join("");
         let local_str = match self.locals.payload {
-            PyObjectPayload::Scope { ref scope } => match scope.locals.payload {
+            PyObjectPayload::Scope { ref scope } => match scope.borrow().locals.payload {
                 PyObjectPayload::Dict { ref elements } => {
                     objdict::get_key_value_pairs_from_content(&elements.borrow())
                         .iter()

--- a/vm/src/frame.rs
+++ b/vm/src/frame.rs
@@ -281,7 +281,7 @@ impl Frame {
 
                 let mut out: Vec<Option<BigInt>> = elements
                     .into_iter()
-                    .map(|x| match x.borrow().payload {
+                    .map(|x| match x.payload {
                         PyObjectPayload::Integer { ref value } => Some(value.clone()),
                         PyObjectPayload::None => None,
                         _ => panic!("Expect Int or None as BUILD_SLICE arguments, got {:?}", x),
@@ -531,7 +531,7 @@ impl Frame {
                 } else {
                     let msg = format!(
                         "Can only raise BaseException derived types, not {}",
-                        exception.borrow()
+                        exception
                     );
                     let type_error_type = vm.ctx.exceptions.type_error.clone();
                     let type_error = vm.new_exception(type_error_type, msg);
@@ -564,7 +564,7 @@ impl Frame {
             }
             bytecode::Instruction::PrintExpr => {
                 let expr = self.pop_value();
-                match expr.borrow().payload {
+                match expr.payload {
                     PyObjectPayload::None => (),
                     _ => {
                         let repr = vm.to_repr(&expr)?;
@@ -591,9 +591,9 @@ impl Frame {
             }
             bytecode::Instruction::StoreLocals => {
                 let locals = self.pop_value();
-                match self.locals.borrow_mut().payload {
-                    PyObjectPayload::Scope { ref mut scope } => {
-                        scope.locals = locals;
+                match self.locals.payload {
+                    PyObjectPayload::Scope { ref scope } => {
+                        //scope.locals = locals; // FIXME
                     }
                     _ => panic!("We really expect our scope to be a scope!"),
                 }
@@ -854,7 +854,7 @@ impl Frame {
     }
 
     fn delete_name(&mut self, vm: &mut VirtualMachine, name: &str) -> FrameResult {
-        let locals = match self.locals.borrow().payload {
+        let locals = match self.locals.payload {
             PyObjectPayload::Scope { ref scope } => scope.locals.clone(),
             _ => panic!("We really expect our scope to be a scope!"),
         };
@@ -1127,7 +1127,7 @@ impl fmt::Debug for Frame {
         let stack_str = self
             .stack
             .iter()
-            .map(|elem| format!("\n  > {:?}", elem.borrow()))
+            .map(|elem| format!("\n  > {:?}", elem))
             .collect::<Vec<_>>()
             .join("");
         let block_str = self
@@ -1136,12 +1136,12 @@ impl fmt::Debug for Frame {
             .map(|elem| format!("\n  > {:?}", elem))
             .collect::<Vec<_>>()
             .join("");
-        let local_str = match self.locals.borrow().payload {
-            PyObjectPayload::Scope { ref scope } => match scope.locals.borrow().payload {
+        let local_str = match self.locals.payload {
+            PyObjectPayload::Scope { ref scope } => match scope.locals.payload {
                 PyObjectPayload::Dict { ref elements } => {
-                    objdict::get_key_value_pairs_from_content(elements)
+                    objdict::get_key_value_pairs_from_content(&elements.borrow())
                         .iter()
-                        .map(|elem| format!("\n  {:?} = {:?}", elem.0.borrow(), elem.1.borrow()))
+                        .map(|elem| format!("\n  {:?} = {:?}", elem.0, elem.1))
                         .collect::<Vec<_>>()
                         .join("")
                 }

--- a/vm/src/obj/objbool.rs
+++ b/vm/src/obj/objbool.rs
@@ -12,17 +12,17 @@ impl IntoPyObject for bool {
 }
 
 pub fn boolval(vm: &mut VirtualMachine, obj: PyObjectRef) -> Result<bool, PyObjectRef> {
-    let result = match obj.borrow().payload {
+    let result = match obj.payload {
         PyObjectPayload::Integer { ref value } => !value.is_zero(),
         PyObjectPayload::Float { value } => value != 0.0,
-        PyObjectPayload::Sequence { ref elements } => !elements.is_empty(),
-        PyObjectPayload::Dict { ref elements } => !elements.is_empty(),
+        PyObjectPayload::Sequence { ref elements } => !elements.borrow().is_empty(),
+        PyObjectPayload::Dict { ref elements } => !elements.borrow().is_empty(),
         PyObjectPayload::String { ref value } => !value.is_empty(),
         PyObjectPayload::None { .. } => false,
         _ => {
             if let Ok(f) = vm.get_method(obj.clone(), "__bool__") {
                 let bool_res = vm.invoke(f, PyFuncArgs::default())?;
-                let v = match bool_res.borrow().payload {
+                let v = match bool_res.payload {
                     PyObjectPayload::Integer { ref value } => !value.is_zero(),
                     _ => return Err(vm.new_type_error(String::from("TypeError"))),
                 };
@@ -60,7 +60,7 @@ pub fn not(vm: &mut VirtualMachine, obj: &PyObjectRef) -> PyResult {
 
 // Retrieve inner int value:
 pub fn get_value(obj: &PyObjectRef) -> bool {
-    if let PyObjectPayload::Integer { value } = &obj.borrow().payload {
+    if let PyObjectPayload::Integer { value } = &obj.payload {
         !value.is_zero()
     } else {
         panic!("Inner error getting inner boolean");

--- a/vm/src/obj/objbytes.rs
+++ b/vm/src/obj/objbytes.rs
@@ -1,4 +1,4 @@
-use std::cell::RefCell;
+use std::cell::{Cell, RefCell};
 use std::hash::{Hash, Hasher};
 use std::ops::Deref;
 use std::ops::DerefMut;
@@ -197,7 +197,7 @@ fn bytes_iter(vm: &mut VirtualMachine, args: PyFuncArgs) -> PyResult {
 
     let iter_obj = PyObject::new(
         PyObjectPayload::Iterator {
-            position: 0,
+            position: Cell::new(0),
             iterated_obj: obj.clone(),
         },
         vm.ctx.iter_type(),

--- a/vm/src/obj/objbytes.rs
+++ b/vm/src/obj/objbytes.rs
@@ -1,3 +1,8 @@
+use std::cell::RefCell;
+use std::hash::{Hash, Hasher};
+use std::ops::Deref;
+use std::ops::DerefMut;
+
 use super::objint;
 use super::objtype;
 use crate::pyobject::{
@@ -5,11 +10,6 @@ use crate::pyobject::{
 };
 use crate::vm::VirtualMachine;
 use num_traits::ToPrimitive;
-use std::cell::Ref;
-use std::cell::RefMut;
-use std::hash::{Hash, Hasher};
-use std::ops::Deref;
-use std::ops::DerefMut;
 
 // Binary data support
 
@@ -70,7 +70,12 @@ fn bytes_new(vm: &mut VirtualMachine, args: PyFuncArgs) -> PyResult {
         vec![]
     };
 
-    Ok(PyObject::new(PyObjectPayload::Bytes { value }, cls.clone()))
+    Ok(PyObject::new(
+        PyObjectPayload::Bytes {
+            value: RefCell::new(value),
+        },
+        cls.clone(),
+    ))
 }
 
 fn bytes_eq(vm: &mut VirtualMachine, args: PyFuncArgs) -> PyResult {
@@ -98,11 +103,7 @@ fn bytes_ge(vm: &mut VirtualMachine, args: PyFuncArgs) -> PyResult {
     let result = if objtype::isinstance(b, &vm.ctx.bytes_type()) {
         get_value(a).to_vec() >= get_value(b).to_vec()
     } else {
-        return Err(vm.new_type_error(format!(
-            "Cannot compare {} and {} using '>'",
-            a.borrow(),
-            b.borrow()
-        )));
+        return Err(vm.new_type_error(format!("Cannot compare {} and {} using '>'", a, b)));
     };
     Ok(vm.ctx.new_bool(result))
 }
@@ -117,11 +118,7 @@ fn bytes_gt(vm: &mut VirtualMachine, args: PyFuncArgs) -> PyResult {
     let result = if objtype::isinstance(b, &vm.ctx.bytes_type()) {
         get_value(a).to_vec() > get_value(b).to_vec()
     } else {
-        return Err(vm.new_type_error(format!(
-            "Cannot compare {} and {} using '>='",
-            a.borrow(),
-            b.borrow()
-        )));
+        return Err(vm.new_type_error(format!("Cannot compare {} and {} using '>='", a, b)));
     };
     Ok(vm.ctx.new_bool(result))
 }
@@ -136,11 +133,7 @@ fn bytes_le(vm: &mut VirtualMachine, args: PyFuncArgs) -> PyResult {
     let result = if objtype::isinstance(b, &vm.ctx.bytes_type()) {
         get_value(a).to_vec() <= get_value(b).to_vec()
     } else {
-        return Err(vm.new_type_error(format!(
-            "Cannot compare {} and {} using '<'",
-            a.borrow(),
-            b.borrow()
-        )));
+        return Err(vm.new_type_error(format!("Cannot compare {} and {} using '<'", a, b)));
     };
     Ok(vm.ctx.new_bool(result))
 }
@@ -155,11 +148,7 @@ fn bytes_lt(vm: &mut VirtualMachine, args: PyFuncArgs) -> PyResult {
     let result = if objtype::isinstance(b, &vm.ctx.bytes_type()) {
         get_value(a).to_vec() < get_value(b).to_vec()
     } else {
-        return Err(vm.new_type_error(format!(
-            "Cannot compare {} and {} using '<='",
-            a.borrow(),
-            b.borrow()
-        )));
+        return Err(vm.new_type_error(format!("Cannot compare {} and {} using '<='", a, b)));
     };
     Ok(vm.ctx.new_bool(result))
 }
@@ -181,23 +170,19 @@ fn bytes_hash(vm: &mut VirtualMachine, args: PyFuncArgs) -> PyResult {
 }
 
 pub fn get_value<'a>(obj: &'a PyObjectRef) -> impl Deref<Target = Vec<u8>> + 'a {
-    Ref::map(obj.borrow(), |py_obj| {
-        if let PyObjectPayload::Bytes { ref value } = py_obj.payload {
-            value
-        } else {
-            panic!("Inner error getting bytearray {:?}", obj);
-        }
-    })
+    if let PyObjectPayload::Bytes { ref value } = obj.payload {
+        value.borrow()
+    } else {
+        panic!("Inner error getting bytearray {:?}", obj);
+    }
 }
 
 pub fn get_mut_value<'a>(obj: &'a PyObjectRef) -> impl DerefMut<Target = Vec<u8>> + 'a {
-    RefMut::map(obj.borrow_mut(), |py_obj| {
-        if let PyObjectPayload::Bytes { ref mut value } = py_obj.payload {
-            value
-        } else {
-            panic!("Inner error getting bytearray {:?}", obj);
-        }
-    })
+    if let PyObjectPayload::Bytes { ref value } = obj.payload {
+        value.borrow_mut()
+    } else {
+        panic!("Inner error getting bytearray {:?}", obj);
+    }
 }
 
 fn bytes_repr(vm: &mut VirtualMachine, args: PyFuncArgs) -> PyResult {

--- a/vm/src/obj/objcode.rs
+++ b/vm/src/obj/objcode.rs
@@ -29,7 +29,7 @@ pub fn init(context: &PyContext) {
 }
 
 pub fn get_value(obj: &PyObjectRef) -> bytecode::CodeObject {
-    if let PyObjectPayload::Code { code } = &obj.borrow().payload {
+    if let PyObjectPayload::Code { code } = &obj.payload {
         code.clone()
     } else {
         panic!("Inner error getting code {:?}", obj)

--- a/vm/src/obj/objcomplex.rs
+++ b/vm/src/obj/objcomplex.rs
@@ -45,7 +45,7 @@ pub fn init(context: &PyContext) {
 }
 
 pub fn get_value(obj: &PyObjectRef) -> Complex64 {
-    if let PyObjectPayload::Complex { value } = &obj.borrow().payload {
+    if let PyObjectPayload::Complex { value } = &obj.payload {
         *value
     } else {
         panic!("Inner error getting complex");
@@ -117,7 +117,7 @@ fn complex_add(vm: &mut VirtualMachine, args: PyFuncArgs) -> PyResult {
             v1.im,
         )))
     } else {
-        Err(vm.new_type_error(format!("Cannot add {} and {}", i.borrow(), i2.borrow())))
+        Err(vm.new_type_error(format!("Cannot add {} and {}", i, i2)))
     }
 }
 
@@ -136,7 +136,7 @@ fn complex_radd(vm: &mut VirtualMachine, args: PyFuncArgs) -> PyResult {
             v1.im,
         )))
     } else {
-        Err(vm.new_type_error(format!("Cannot add {} and {}", i.borrow(), i2.borrow())))
+        Err(vm.new_type_error(format!("Cannot add {} and {}", i, i2)))
     }
 }
 

--- a/vm/src/obj/objdict.rs
+++ b/vm/src/obj/objdict.rs
@@ -1,3 +1,7 @@
+use std::cell::{Cell, RefCell};
+use std::collections::HashMap;
+use std::ops::{Deref, DerefMut};
+
 use super::objiter;
 use super::objstr;
 use super::objtype;
@@ -6,9 +10,6 @@ use crate::pyobject::{
     TypeProtocol,
 };
 use crate::vm::{ReprGuard, VirtualMachine};
-use std::cell::RefCell;
-use std::collections::HashMap;
-use std::ops::{Deref, DerefMut};
 
 // This typedef abstracts the actual dict type used.
 // pub type DictContentType = HashMap<usize, Vec<(PyObjectRef, PyObjectRef)>>;
@@ -258,7 +259,7 @@ fn dict_iter(vm: &mut VirtualMachine, args: PyFuncArgs) -> PyResult {
 
     let iter_obj = PyObject::new(
         PyObjectPayload::Iterator {
-            position: 0,
+            position: Cell::new(0),
             iterated_obj: key_list,
         },
         vm.ctx.iter_type(),

--- a/vm/src/obj/objfilter.rs
+++ b/vm/src/obj/objfilter.rs
@@ -25,9 +25,9 @@ fn filter_next(vm: &mut VirtualMachine, args: PyFuncArgs) -> PyResult {
     arg_check!(vm, args, required = [(filter, Some(vm.ctx.filter_type()))]);
 
     if let PyObjectPayload::FilterIterator {
-        ref mut predicate,
-        ref mut iterator,
-    } = filter.borrow_mut().payload
+        ref predicate,
+        ref iterator,
+    } = filter.payload
     {
         loop {
             let next_obj = objiter::call_next(vm, iterator)?;

--- a/vm/src/obj/objfloat.rs
+++ b/vm/src/obj/objfloat.rs
@@ -61,7 +61,7 @@ fn float_init(vm: &mut VirtualMachine, args: PyFuncArgs) -> PyResult {
 
 // Retrieve inner float value:
 pub fn get_value(obj: &PyObjectRef) -> f64 {
-    if let PyObjectPayload::Float { value } = &obj.borrow().payload {
+    if let PyObjectPayload::Float { value } = &obj.payload {
         *value
     } else {
         panic!("Inner error getting float");
@@ -81,12 +81,12 @@ pub fn make_float(vm: &mut VirtualMachine, obj: &PyObjectRef) -> Result<f64, PyO
         )?;
         Ok(get_value(&res))
     } else {
-        Err(vm.new_type_error(format!("Cannot cast {} to float", obj.borrow())))
+        Err(vm.new_type_error(format!("Cannot cast {} to float", obj)))
     }
 }
 
 fn set_value(obj: &PyObjectRef, value: f64) {
-    obj.borrow_mut().payload = PyObjectPayload::Float { value };
+    //obj.payload = PyObjectPayload::Float { value }; // FIXME
 }
 
 fn float_eq(vm: &mut VirtualMachine, args: PyFuncArgs) -> PyResult {

--- a/vm/src/obj/objframe.rs
+++ b/vm/src/obj/objframe.rs
@@ -33,7 +33,7 @@ fn frame_flocals(vm: &mut VirtualMachine, args: PyFuncArgs) -> PyResult {
     let py_scope = frame.locals.clone();
 
     if let PyObjectPayload::Scope { scope } = &py_scope.payload {
-        Ok(scope.locals.clone())
+        Ok(scope.borrow().locals.clone())
     } else {
         panic!("The scope isn't a scope!");
     }

--- a/vm/src/obj/objframe.rs
+++ b/vm/src/obj/objframe.rs
@@ -31,7 +31,6 @@ fn frame_flocals(vm: &mut VirtualMachine, args: PyFuncArgs) -> PyResult {
     arg_check!(vm, args, required = [(frame, Some(vm.ctx.frame_type()))]);
     let frame = get_value(frame);
     let py_scope = frame.locals.clone();
-    let py_scope = py_scope.borrow();
 
     if let PyObjectPayload::Scope { scope } = &py_scope.payload {
         Ok(scope.locals.clone())
@@ -46,7 +45,7 @@ fn frame_fcode(vm: &mut VirtualMachine, args: PyFuncArgs) -> PyResult {
 }
 
 pub fn get_value(obj: &PyObjectRef) -> Frame {
-    if let PyObjectPayload::Frame { frame } = &obj.borrow().payload {
+    if let PyObjectPayload::Frame { frame } = &obj.payload {
         frame.clone()
     } else {
         panic!("Inner error getting int {:?}", obj);

--- a/vm/src/obj/objfunction.rs
+++ b/vm/src/obj/objfunction.rs
@@ -67,7 +67,7 @@ fn bind_method(vm: &mut VirtualMachine, args: PyFuncArgs) -> PyResult {
 }
 
 fn function_code(vm: &mut VirtualMachine, args: PyFuncArgs) -> PyResult {
-    match args.args[0].borrow().payload {
+    match args.args[0].payload {
         PyObjectPayload::Function { ref code, .. } => Ok(code.clone()),
         _ => Err(vm.new_type_error("no code".to_string())),
     }

--- a/vm/src/obj/objgenerator.rs
+++ b/vm/src/obj/objgenerator.rs
@@ -56,16 +56,17 @@ fn generator_send(vm: &mut VirtualMachine, args: PyFuncArgs) -> PyResult {
 }
 
 fn send(vm: &mut VirtualMachine, gen: &PyObjectRef, value: &PyObjectRef) -> PyResult {
-    if let PyObjectPayload::Generator { ref mut frame } = gen.borrow_mut().payload {
-        frame.push_value(value.clone());
-        match frame.run_frame(vm)? {
-            ExecutionResult::Yield(value) => Ok(value),
-            ExecutionResult::Return(_value) => {
-                // Stop iteration!
-                let stop_iteration = vm.ctx.exceptions.stop_iteration.clone();
-                Err(vm.new_exception(stop_iteration, "End of generator".to_string()))
-            }
-        }
+    if let PyObjectPayload::Generator { ref frame } = gen.payload {
+        //frame.push_value(value.clone());
+        //match frame.run_frame(vm)? {
+        //    ExecutionResult::Yield(value) => Ok(value),
+        //    ExecutionResult::Return(_value) => {
+        //        // Stop iteration!
+        //        let stop_iteration = vm.ctx.exceptions.stop_iteration.clone();
+        //        Err(vm.new_exception(stop_iteration, "End of generator".to_string()))
+        //    }
+        //}
+        unimplemented!("FIXME")
     } else {
         panic!("Cannot extract frame from non-generator");
     }

--- a/vm/src/obj/objint.rs
+++ b/vm/src/obj/objint.rs
@@ -94,7 +94,7 @@ pub fn to_int(
 
 // Retrieve inner int value:
 pub fn get_value(obj: &PyObjectRef) -> IntType {
-    if let PyObjectPayload::Integer { value } = &obj.borrow().payload {
+    if let PyObjectPayload::Integer { value } = &obj.payload {
         value.clone()
     } else {
         panic!("Inner error getting int {:?}", obj);

--- a/vm/src/obj/objiter.rs
+++ b/vm/src/obj/objiter.rs
@@ -134,9 +134,9 @@ fn iter_next(vm: &mut VirtualMachine, args: PyFuncArgs) -> PyResult {
     {
         match iterated_obj_ref.payload {
             PyObjectPayload::Sequence { ref elements } => {
-                if *position < elements.borrow().len() {
-                    let obj_ref = elements.borrow()[*position].clone();
-                    //*position += 1; // FIXME
+                if position.get() < elements.borrow().len() {
+                    let obj_ref = elements.borrow()[position.get()].clone();
+                    position.set(position.get() + 1);
                     Ok(obj_ref)
                 } else {
                     Err(new_stop_iteration(vm))
@@ -144,8 +144,8 @@ fn iter_next(vm: &mut VirtualMachine, args: PyFuncArgs) -> PyResult {
             }
 
             PyObjectPayload::Range { ref range } => {
-                if let Some(int) = range.get(*position) {
-                    //*position += 1; // FIXME
+                if let Some(int) = range.get(position.get()) {
+                    position.set(position.get() + 1);
                     Ok(vm.ctx.new_int(int))
                 } else {
                     Err(new_stop_iteration(vm))
@@ -153,9 +153,9 @@ fn iter_next(vm: &mut VirtualMachine, args: PyFuncArgs) -> PyResult {
             }
 
             PyObjectPayload::Bytes { ref value } => {
-                if *position < value.borrow().len() {
-                    let obj_ref = vm.ctx.new_int(value.borrow()[*position]);
-                    // *position += 1; // FIXME
+                if position.get() < value.borrow().len() {
+                    let obj_ref = vm.ctx.new_int(value.borrow()[position.get()]);
+                    position.set(position.get() + 1);
                     Ok(obj_ref)
                 } else {
                     Err(new_stop_iteration(vm))

--- a/vm/src/obj/objiter.rs
+++ b/vm/src/obj/objiter.rs
@@ -128,16 +128,15 @@ fn iter_next(vm: &mut VirtualMachine, args: PyFuncArgs) -> PyResult {
     arg_check!(vm, args, required = [(iter, Some(vm.ctx.iter_type()))]);
 
     if let PyObjectPayload::Iterator {
-        ref mut position,
-        iterated_obj: ref mut iterated_obj_ref,
-    } = iter.borrow_mut().payload
+        ref position,
+        iterated_obj: ref iterated_obj_ref,
+    } = iter.payload
     {
-        let iterated_obj = iterated_obj_ref.borrow_mut();
-        match iterated_obj.payload {
+        match iterated_obj_ref.payload {
             PyObjectPayload::Sequence { ref elements } => {
-                if *position < elements.len() {
-                    let obj_ref = elements[*position].clone();
-                    *position += 1;
+                if *position < elements.borrow().len() {
+                    let obj_ref = elements.borrow()[*position].clone();
+                    //*position += 1; // FIXME
                     Ok(obj_ref)
                 } else {
                     Err(new_stop_iteration(vm))
@@ -146,7 +145,7 @@ fn iter_next(vm: &mut VirtualMachine, args: PyFuncArgs) -> PyResult {
 
             PyObjectPayload::Range { ref range } => {
                 if let Some(int) = range.get(*position) {
-                    *position += 1;
+                    //*position += 1; // FIXME
                     Ok(vm.ctx.new_int(int))
                 } else {
                     Err(new_stop_iteration(vm))
@@ -154,9 +153,9 @@ fn iter_next(vm: &mut VirtualMachine, args: PyFuncArgs) -> PyResult {
             }
 
             PyObjectPayload::Bytes { ref value } => {
-                if *position < value.len() {
-                    let obj_ref = vm.ctx.new_int(value[*position]);
-                    *position += 1;
+                if *position < value.borrow().len() {
+                    let obj_ref = vm.ctx.new_int(value.borrow()[*position]);
+                    // *position += 1; // FIXME
                     Ok(obj_ref)
                 } else {
                     Err(new_stop_iteration(vm))

--- a/vm/src/obj/objlist.rs
+++ b/vm/src/obj/objlist.rs
@@ -1,4 +1,4 @@
-use std::cell::RefCell;
+use std::cell::{Cell, RefCell};
 
 use super::objbool;
 use super::objint;
@@ -381,7 +381,7 @@ fn list_iter(vm: &mut VirtualMachine, args: PyFuncArgs) -> PyResult {
 
     let iter_obj = PyObject::new(
         PyObjectPayload::Iterator {
-            position: 0,
+            position: Cell::new(0),
             iterated_obj: list.clone(),
         },
         vm.ctx.iter_type(),

--- a/vm/src/obj/objlist.rs
+++ b/vm/src/obj/objlist.rs
@@ -1,3 +1,5 @@
+use std::cell::RefCell;
+
 use super::objbool;
 use super::objint;
 use super::objsequence::{
@@ -55,7 +57,9 @@ fn list_new(vm: &mut VirtualMachine, args: PyFuncArgs) -> PyResult {
     };
 
     Ok(PyObject::new(
-        PyObjectPayload::Sequence { elements },
+        PyObjectPayload::Sequence {
+            elements: RefCell::new(elements),
+        },
         cls.clone(),
     ))
 }
@@ -93,11 +97,7 @@ fn list_lt(vm: &mut VirtualMachine, args: PyFuncArgs) -> PyResult {
         let other = get_elements(other);
         seq_lt(vm, &zelf, &other)?
     } else {
-        return Err(vm.new_type_error(format!(
-            "Cannot compare {} and {} using '<'",
-            zelf.borrow(),
-            other.borrow()
-        )));
+        return Err(vm.new_type_error(format!("Cannot compare {} and {} using '<'", zelf, other)));
     };
 
     Ok(vm.ctx.new_bool(result))
@@ -115,11 +115,7 @@ fn list_gt(vm: &mut VirtualMachine, args: PyFuncArgs) -> PyResult {
         let other = get_elements(other);
         seq_gt(vm, &zelf, &other)?
     } else {
-        return Err(vm.new_type_error(format!(
-            "Cannot compare {} and {} using '>'",
-            zelf.borrow(),
-            other.borrow()
-        )));
+        return Err(vm.new_type_error(format!("Cannot compare {} and {} using '>'", zelf, other)));
     };
 
     Ok(vm.ctx.new_bool(result))
@@ -137,11 +133,7 @@ fn list_ge(vm: &mut VirtualMachine, args: PyFuncArgs) -> PyResult {
         let other = get_elements(other);
         seq_ge(vm, &zelf, &other)?
     } else {
-        return Err(vm.new_type_error(format!(
-            "Cannot compare {} and {} using '>='",
-            zelf.borrow(),
-            other.borrow()
-        )));
+        return Err(vm.new_type_error(format!("Cannot compare {} and {} using '>='", zelf, other)));
     };
 
     Ok(vm.ctx.new_bool(result))
@@ -159,11 +151,7 @@ fn list_le(vm: &mut VirtualMachine, args: PyFuncArgs) -> PyResult {
         let other = get_elements(other);
         seq_le(vm, &zelf, &other)?
     } else {
-        return Err(vm.new_type_error(format!(
-            "Cannot compare {} and {} using '<='",
-            zelf.borrow(),
-            other.borrow()
-        )));
+        return Err(vm.new_type_error(format!("Cannot compare {} and {} using '<='", zelf, other)));
     };
 
     Ok(vm.ctx.new_bool(result))
@@ -182,7 +170,7 @@ fn list_add(vm: &mut VirtualMachine, args: PyFuncArgs) -> PyResult {
         let elements = e1.iter().chain(e2.iter()).cloned().collect();
         Ok(vm.ctx.new_list(elements))
     } else {
-        Err(vm.new_type_error(format!("Cannot add {} and {}", o.borrow(), o2.borrow())))
+        Err(vm.new_type_error(format!("Cannot add {} and {}", o, o2)))
     }
 }
 

--- a/vm/src/obj/objmap.rs
+++ b/vm/src/obj/objmap.rs
@@ -28,9 +28,9 @@ fn map_next(vm: &mut VirtualMachine, args: PyFuncArgs) -> PyResult {
     arg_check!(vm, args, required = [(map, Some(vm.ctx.map_type()))]);
 
     if let PyObjectPayload::MapIterator {
-        ref mut mapper,
-        ref mut iterators,
-    } = map.borrow_mut().payload
+        ref mapper,
+        ref iterators,
+    } = map.payload
     {
         let next_objs = iterators
             .iter()

--- a/vm/src/obj/objrange.rs
+++ b/vm/src/obj/objrange.rs
@@ -151,7 +151,7 @@ impl RangeType {
 }
 
 pub fn get_value(obj: &PyObjectRef) -> RangeType {
-    if let PyObjectPayload::Range { range } = &obj.borrow().payload {
+    if let PyObjectPayload::Range { range } = &obj.payload {
         range.clone()
     } else {
         panic!("Inner error getting range {:?}", obj);
@@ -287,7 +287,7 @@ fn range_getitem(vm: &mut VirtualMachine, args: PyFuncArgs) -> PyResult {
 
     let range = get_value(zelf);
 
-    match subscript.borrow().payload {
+    match subscript.payload {
         PyObjectPayload::Integer { ref value } => {
             if let Some(int) = range.get(value) {
                 Ok(vm.ctx.new_int(int))

--- a/vm/src/obj/objrange.rs
+++ b/vm/src/obj/objrange.rs
@@ -1,3 +1,6 @@
+use std::cell::Cell;
+use std::ops::Mul;
+
 use super::objint;
 use super::objtype;
 use crate::pyobject::{
@@ -8,7 +11,6 @@ use crate::vm::VirtualMachine;
 use num_bigint::{BigInt, Sign};
 use num_integer::Integer;
 use num_traits::{One, Signed, ToPrimitive, Zero};
-use std::ops::Mul;
 
 #[derive(Debug, Clone)]
 pub struct RangeType {
@@ -247,7 +249,7 @@ fn range_iter(vm: &mut VirtualMachine, args: PyFuncArgs) -> PyResult {
 
     Ok(PyObject::new(
         PyObjectPayload::Iterator {
-            position: 0,
+            position: Cell::new(0),
             iterated_obj: range.clone(),
         },
         vm.ctx.iter_type(),
@@ -261,7 +263,7 @@ fn range_reversed(vm: &mut VirtualMachine, args: PyFuncArgs) -> PyResult {
 
     Ok(PyObject::new(
         PyObjectPayload::Iterator {
-            position: 0,
+            position: Cell::new(0),
             iterated_obj: PyObject::new(PyObjectPayload::Range { range }, vm.ctx.range_type()),
         },
         vm.ctx.iter_type(),

--- a/vm/src/obj/objsequence.rs
+++ b/vm/src/obj/objsequence.rs
@@ -1,12 +1,13 @@
+use std::cell::RefCell;
+use std::marker::Sized;
+use std::ops::{Deref, DerefMut, Range};
+
 use super::objbool;
 use super::objint;
 use crate::pyobject::{IdProtocol, PyObject, PyObjectPayload, PyObjectRef, PyResult, TypeProtocol};
 use crate::vm::VirtualMachine;
 use num_bigint::BigInt;
 use num_traits::{One, Signed, ToPrimitive, Zero};
-use std::cell::{Ref, RefMut};
-use std::marker::Sized;
-use std::ops::{Deref, DerefMut, Range};
 
 pub trait PySliceableSequence {
     fn do_slice(&self, range: Range<usize>) -> Self;
@@ -64,7 +65,7 @@ pub trait PySliceableSequence {
         Self: Sized,
     {
         // TODO: we could potentially avoid this copy and use slice
-        match &(slice.borrow()).payload {
+        match &slice.payload {
             PyObjectPayload::Slice { start, stop, step } => {
                 let step = step.clone().unwrap_or_else(BigInt::one);
                 if step.is_zero() {
@@ -140,7 +141,7 @@ pub fn get_item(
     elements: &[PyObjectRef],
     subscript: PyObjectRef,
 ) -> PyResult {
-    match &(subscript.borrow()).payload {
+    match &subscript.payload {
         PyObjectPayload::Integer { value } => match value.to_i32() {
             Some(value) => {
                 if let Some(pos_index) = elements.to_vec().get_pos(value) {
@@ -156,9 +157,9 @@ pub fn get_item(
         },
 
         PyObjectPayload::Slice { .. } => Ok(PyObject::new(
-            match &(sequence.borrow()).payload {
+            match &sequence.payload {
                 PyObjectPayload::Sequence { .. } => PyObjectPayload::Sequence {
-                    elements: elements.to_vec().get_slice_items(vm, &subscript)?,
+                    elements: RefCell::new(elements.to_vec().get_slice_items(vm, &subscript)?),
                 },
                 ref payload => panic!("sequence get_item called for non-sequence: {:?}", payload),
             },
@@ -302,23 +303,19 @@ pub fn seq_mul(elements: &[PyObjectRef], product: &PyObjectRef) -> Vec<PyObjectR
 }
 
 pub fn get_elements<'a>(obj: &'a PyObjectRef) -> impl Deref<Target = Vec<PyObjectRef>> + 'a {
-    Ref::map(obj.borrow(), |x| {
-        if let PyObjectPayload::Sequence { ref elements } = x.payload {
-            elements
-        } else {
-            panic!("Cannot extract elements from non-sequence");
-        }
-    })
+    if let PyObjectPayload::Sequence { ref elements } = obj.payload {
+        elements.borrow()
+    } else {
+        panic!("Cannot extract elements from non-sequence");
+    }
 }
 
 pub fn get_mut_elements<'a>(obj: &'a PyObjectRef) -> impl DerefMut<Target = Vec<PyObjectRef>> + 'a {
-    RefMut::map(obj.borrow_mut(), |x| {
-        if let PyObjectPayload::Sequence { ref mut elements } = x.payload {
-            elements
-        } else {
-            panic!("Cannot extract list elements from non-sequence");
-            // TODO: raise proper error?
-            // Err(vm.new_type_error("list.append is called with no list".to_string()))
-        }
-    })
+    if let PyObjectPayload::Sequence { ref elements } = obj.payload {
+        elements.borrow_mut()
+    } else {
+        panic!("Cannot extract list elements from non-sequence");
+        // TODO: raise proper error?
+        // Err(vm.new_type_error("list.append is called with no list".to_string()))
+    }
 }

--- a/vm/src/obj/objset.rs
+++ b/vm/src/obj/objset.rs
@@ -2,7 +2,7 @@
  * Builtin set type with a sequence of unique items.
  */
 
-use std::cell::RefCell;
+use std::cell::{Cell, RefCell};
 use std::collections::hash_map::DefaultHasher;
 use std::collections::HashMap;
 use std::hash::{Hash, Hasher};
@@ -547,7 +547,7 @@ fn set_iter(vm: &mut VirtualMachine, args: PyFuncArgs) -> PyResult {
     let set_list = vm.ctx.new_list(items);
     let iter_obj = PyObject::new(
         PyObjectPayload::Iterator {
-            position: 0,
+            position: Cell::new(0),
             iterated_obj: set_list,
         },
         vm.ctx.iter_type(),

--- a/vm/src/obj/objset.rs
+++ b/vm/src/obj/objset.rs
@@ -2,6 +2,11 @@
  * Builtin set type with a sequence of unique items.
  */
 
+use std::cell::RefCell;
+use std::collections::hash_map::DefaultHasher;
+use std::collections::HashMap;
+use std::hash::{Hash, Hasher};
+
 use super::objbool;
 use super::objint;
 use super::objiter;
@@ -11,13 +16,10 @@ use crate::pyobject::{
     PyContext, PyFuncArgs, PyObject, PyObjectPayload, PyObjectRef, PyResult, TypeProtocol,
 };
 use crate::vm::{ReprGuard, VirtualMachine};
-use std::collections::hash_map::DefaultHasher;
-use std::collections::HashMap;
-use std::hash::{Hash, Hasher};
 
 pub fn get_elements(obj: &PyObjectRef) -> HashMap<u64, PyObjectRef> {
-    if let PyObjectPayload::Set { elements } = &obj.borrow().payload {
-        elements.clone()
+    if let PyObjectPayload::Set { elements } = &obj.payload {
+        elements.borrow().clone()
     } else {
         panic!("Cannot extract set elements from non-set");
     }
@@ -62,10 +64,10 @@ fn set_add(vm: &mut VirtualMachine, args: PyFuncArgs) -> PyResult {
         args,
         required = [(s, Some(vm.ctx.set_type())), (item, None)]
     );
-    let mut mut_obj = s.borrow_mut();
-
-    match mut_obj.payload {
-        PyObjectPayload::Set { ref mut elements } => insert_into_set(vm, elements, item),
+    match s.payload {
+        PyObjectPayload::Set { ref elements } => {
+            insert_into_set(vm, &mut elements.borrow_mut(), item)
+        }
         _ => Err(vm.new_type_error("set.add is called with no item".to_string())),
     }
 }
@@ -77,10 +79,8 @@ fn set_remove(vm: &mut VirtualMachine, args: PyFuncArgs) -> PyResult {
         args,
         required = [(s, Some(vm.ctx.set_type())), (item, None)]
     );
-    let mut mut_obj = s.borrow_mut();
-
-    match mut_obj.payload {
-        PyObjectPayload::Set { ref mut elements } => {
+    match s.payload {
+        PyObjectPayload::Set { ref elements } => {
             fn remove(
                 vm: &mut VirtualMachine,
                 elements: &mut HashMap<u64, PyObjectRef>,
@@ -89,13 +89,13 @@ fn set_remove(vm: &mut VirtualMachine, args: PyFuncArgs) -> PyResult {
             ) -> PyResult {
                 match elements.remove(&key) {
                     None => {
-                        let item_str = format!("{:?}", value.borrow());
+                        let item_str = format!("{:?}", value);
                         Err(vm.new_key_error(item_str))
                     }
                     Some(_) => Ok(vm.get_none()),
                 }
             }
-            perform_action_with_hash(vm, elements, item, &remove)
+            perform_action_with_hash(vm, &mut elements.borrow_mut(), item, &remove)
         }
         _ => Err(vm.new_type_error("set.remove is called with no item".to_string())),
     }
@@ -108,10 +108,8 @@ fn set_discard(vm: &mut VirtualMachine, args: PyFuncArgs) -> PyResult {
         args,
         required = [(s, Some(vm.ctx.set_type())), (item, None)]
     );
-    let mut mut_obj = s.borrow_mut();
-
-    match mut_obj.payload {
-        PyObjectPayload::Set { ref mut elements } => {
+    match s.payload {
+        PyObjectPayload::Set { ref elements } => {
             fn discard(
                 vm: &mut VirtualMachine,
                 elements: &mut HashMap<u64, PyObjectRef>,
@@ -121,7 +119,7 @@ fn set_discard(vm: &mut VirtualMachine, args: PyFuncArgs) -> PyResult {
                 elements.remove(&key);
                 Ok(vm.get_none())
             }
-            perform_action_with_hash(vm, elements, item, &discard)
+            perform_action_with_hash(vm, &mut elements.borrow_mut(), item, &discard)
         }
         _ => Err(vm.new_type_error("set.discard is called with no item".to_string())),
     }
@@ -130,10 +128,9 @@ fn set_discard(vm: &mut VirtualMachine, args: PyFuncArgs) -> PyResult {
 fn set_clear(vm: &mut VirtualMachine, args: PyFuncArgs) -> PyResult {
     trace!("set.clear called");
     arg_check!(vm, args, required = [(s, Some(vm.ctx.set_type()))]);
-    let mut mut_obj = s.borrow_mut();
-    match mut_obj.payload {
-        PyObjectPayload::Set { ref mut elements } => {
-            elements.clear();
+    match s.payload {
+        PyObjectPayload::Set { ref elements } => {
+            elements.borrow_mut().clear();
             Ok(vm.get_none())
         }
         _ => Err(vm.new_type_error("".to_string())),
@@ -150,7 +147,7 @@ fn set_new(vm: &mut VirtualMachine, args: PyFuncArgs) -> PyResult {
     );
 
     if !objtype::issubclass(cls, &vm.ctx.set_type()) {
-        return Err(vm.new_type_error(format!("{} is not a subtype of set", cls.borrow())));
+        return Err(vm.new_type_error(format!("{} is not a subtype of set", cls)));
     }
 
     let elements: HashMap<u64, PyObjectRef> = match iterable {
@@ -166,7 +163,9 @@ fn set_new(vm: &mut VirtualMachine, args: PyFuncArgs) -> PyResult {
     };
 
     Ok(PyObject::new(
-        PyObjectPayload::Set { elements },
+        PyObjectPayload::Set {
+            elements: RefCell::new(elements),
+        },
         cls.clone(),
     ))
 }
@@ -183,7 +182,9 @@ fn set_copy(vm: &mut VirtualMachine, args: PyFuncArgs) -> PyResult {
     arg_check!(vm, args, required = [(s, Some(vm.ctx.set_type()))]);
     let elements = get_elements(s);
     Ok(PyObject::new(
-        PyObjectPayload::Set { elements },
+        PyObjectPayload::Set {
+            elements: RefCell::new(elements),
+        },
         vm.ctx.set_type(),
     ))
 }
@@ -335,7 +336,9 @@ fn set_union(vm: &mut VirtualMachine, args: PyFuncArgs) -> PyResult {
     elements.extend(get_elements(other).clone());
 
     Ok(PyObject::new(
-        PyObjectPayload::Set { elements },
+        PyObjectPayload::Set {
+            elements: RefCell::new(elements),
+        },
         vm.ctx.set_type(),
     ))
 }
@@ -375,7 +378,9 @@ fn set_symmetric_difference(vm: &mut VirtualMachine, args: PyFuncArgs) -> PyResu
     }
 
     Ok(PyObject::new(
-        PyObjectPayload::Set { elements },
+        PyObjectPayload::Set {
+            elements: RefCell::new(elements),
+        },
         vm.ctx.set_type(),
     ))
 }
@@ -413,7 +418,9 @@ fn set_combine_inner(
     }
 
     Ok(PyObject::new(
-        PyObjectPayload::Set { elements },
+        PyObjectPayload::Set {
+            elements: RefCell::new(elements),
+        },
         vm.ctx.set_type(),
     ))
 }
@@ -421,11 +428,9 @@ fn set_combine_inner(
 fn set_pop(vm: &mut VirtualMachine, args: PyFuncArgs) -> PyResult {
     arg_check!(vm, args, required = [(s, Some(vm.ctx.set_type()))]);
 
-    let mut mut_obj = s.borrow_mut();
-
-    match mut_obj.payload {
-        PyObjectPayload::Set { ref mut elements } => match elements.clone().keys().next() {
-            Some(key) => Ok(elements.remove(key).unwrap()),
+    match s.payload {
+        PyObjectPayload::Set { ref elements } => match elements.borrow().clone().keys().next() {
+            Some(key) => Ok(elements.borrow_mut().remove(key).unwrap()),
             None => Err(vm.new_key_error("pop from an empty set".to_string())),
         },
         _ => Err(vm.new_type_error("".to_string())),
@@ -444,13 +449,11 @@ fn set_ior(vm: &mut VirtualMachine, args: PyFuncArgs) -> PyResult {
         required = [(zelf, Some(vm.ctx.set_type())), (iterable, None)]
     );
 
-    let mut mut_obj = zelf.borrow_mut();
-
-    match mut_obj.payload {
-        PyObjectPayload::Set { ref mut elements } => {
+    match zelf.payload {
+        PyObjectPayload::Set { ref elements } => {
             let iterator = objiter::get_iter(vm, iterable)?;
             while let Ok(v) = vm.call_method(&iterator, "__next__", vec![]) {
-                insert_into_set(vm, elements, &v)?;
+                insert_into_set(vm, &mut elements.borrow_mut(), &v)?;
             }
         }
         _ => return Err(vm.new_type_error("set.update is called with no other".to_string())),
@@ -487,18 +490,16 @@ fn set_combine_update_inner(
         required = [(zelf, Some(vm.ctx.set_type())), (iterable, None)]
     );
 
-    let mut mut_obj = zelf.borrow_mut();
-
-    match mut_obj.payload {
-        PyObjectPayload::Set { ref mut elements } => {
-            for element in elements.clone().iter() {
+    match zelf.payload {
+        PyObjectPayload::Set { ref elements } => {
+            for element in elements.borrow().clone().iter() {
                 let value = vm.call_method(iterable, "__contains__", vec![element.1.clone()])?;
                 let should_remove = match op {
                     SetCombineOperation::Intersection => !objbool::get_value(&value),
                     SetCombineOperation::Difference => objbool::get_value(&value),
                 };
                 if should_remove {
-                    elements.remove(&element.0.clone());
+                    elements.borrow_mut().remove(&element.0.clone());
                 }
             }
         }
@@ -519,19 +520,17 @@ fn set_ixor(vm: &mut VirtualMachine, args: PyFuncArgs) -> PyResult {
         required = [(zelf, Some(vm.ctx.set_type())), (iterable, None)]
     );
 
-    let mut mut_obj = zelf.borrow_mut();
-
-    match mut_obj.payload {
-        PyObjectPayload::Set { ref mut elements } => {
-            let elements_original = elements.clone();
+    match zelf.payload {
+        PyObjectPayload::Set { ref elements } => {
+            let elements_original = elements.borrow().clone();
             let iterator = objiter::get_iter(vm, iterable)?;
             while let Ok(v) = vm.call_method(&iterator, "__next__", vec![]) {
-                insert_into_set(vm, elements, &v)?;
+                insert_into_set(vm, &mut elements.borrow_mut(), &v)?;
             }
             for element in elements_original.iter() {
                 let value = vm.call_method(iterable, "__contains__", vec![element.1.clone()])?;
                 if objbool::get_value(&value) {
-                    elements.remove(&element.0.clone());
+                    elements.borrow_mut().remove(&element.0.clone());
                 }
             }
         }

--- a/vm/src/obj/objslice.rs
+++ b/vm/src/obj/objslice.rs
@@ -59,7 +59,7 @@ fn get_property_value(vm: &mut VirtualMachine, value: &Option<BigInt>) -> PyResu
 
 fn slice_start(vm: &mut VirtualMachine, args: PyFuncArgs) -> PyResult {
     arg_check!(vm, args, required = [(slice, Some(vm.ctx.slice_type()))]);
-    if let PyObjectPayload::Slice { start, .. } = &slice.borrow().payload {
+    if let PyObjectPayload::Slice { start, .. } = &slice.payload {
         get_property_value(vm, start)
     } else {
         panic!("Slice has incorrect payload.");
@@ -68,7 +68,7 @@ fn slice_start(vm: &mut VirtualMachine, args: PyFuncArgs) -> PyResult {
 
 fn slice_stop(vm: &mut VirtualMachine, args: PyFuncArgs) -> PyResult {
     arg_check!(vm, args, required = [(slice, Some(vm.ctx.slice_type()))]);
-    if let PyObjectPayload::Slice { stop, .. } = &slice.borrow().payload {
+    if let PyObjectPayload::Slice { stop, .. } = &slice.payload {
         get_property_value(vm, stop)
     } else {
         panic!("Slice has incorrect payload.");
@@ -77,7 +77,7 @@ fn slice_stop(vm: &mut VirtualMachine, args: PyFuncArgs) -> PyResult {
 
 fn slice_step(vm: &mut VirtualMachine, args: PyFuncArgs) -> PyResult {
     arg_check!(vm, args, required = [(slice, Some(vm.ctx.slice_type()))]);
-    if let PyObjectPayload::Slice { step, .. } = &slice.borrow().payload {
+    if let PyObjectPayload::Slice { step, .. } = &slice.payload {
         get_property_value(vm, step)
     } else {
         panic!("Slice has incorrect payload.");

--- a/vm/src/obj/objstr.rs
+++ b/vm/src/obj/objstr.rs
@@ -3,12 +3,10 @@ use super::objsequence::PySliceableSequence;
 use super::objtype;
 use crate::format::{FormatParseError, FormatPart, FormatString};
 use crate::pyobject::{
-    FromPyObject, PyContext, PyFuncArgs, PyObject, PyObjectPayload, PyObjectRef, PyResult,
-    TypeProtocol,
+    FromPyObject, PyContext, PyFuncArgs, PyObjectPayload, PyObjectRef, PyResult, TypeProtocol,
 };
 use crate::vm::VirtualMachine;
 use num_traits::ToPrimitive;
-use std::cell::Ref;
 use std::hash::{Hash, Hasher};
 use std::ops::Range;
 use std::str::FromStr;
@@ -115,21 +113,19 @@ pub fn init(context: &PyContext) {
 }
 
 pub fn get_value(obj: &PyObjectRef) -> String {
-    if let PyObjectPayload::String { value } = &obj.borrow().payload {
+    if let PyObjectPayload::String { value } = &obj.payload {
         value.to_string()
     } else {
         panic!("Inner error getting str");
     }
 }
 
-pub fn borrow_value(obj: &PyObjectRef) -> Ref<str> {
-    Ref::map(obj.borrow(), |py_obj| {
-        if let PyObjectPayload::String { value } = &py_obj.payload {
-            value.as_ref()
-        } else {
-            panic!("Inner error getting str");
-        }
-    })
+pub fn borrow_value(obj: &PyObjectRef) -> &str {
+    if let PyObjectPayload::String { value } = &obj.payload {
+        value.as_str()
+    } else {
+        panic!("Inner error getting str");
+    }
 }
 
 fn str_eq(vm: &mut VirtualMachine, args: PyFuncArgs) -> PyResult {
@@ -158,7 +154,7 @@ fn str_gt(vm: &mut VirtualMachine, args: PyFuncArgs) -> PyResult {
     if objtype::isinstance(i2, &vm.ctx.str_type()) {
         Ok(vm.ctx.new_bool(v1 > get_value(i2)))
     } else {
-        Err(vm.new_type_error(format!("Cannot compare {} and {}", i.borrow(), i2.borrow())))
+        Err(vm.new_type_error(format!("Cannot compare {} and {}", i, i2)))
     }
 }
 
@@ -173,7 +169,7 @@ fn str_ge(vm: &mut VirtualMachine, args: PyFuncArgs) -> PyResult {
     if objtype::isinstance(i2, &vm.ctx.str_type()) {
         Ok(vm.ctx.new_bool(v1 >= get_value(i2)))
     } else {
-        Err(vm.new_type_error(format!("Cannot compare {} and {}", i.borrow(), i2.borrow())))
+        Err(vm.new_type_error(format!("Cannot compare {} and {}", i, i2)))
     }
 }
 
@@ -188,7 +184,7 @@ fn str_lt(vm: &mut VirtualMachine, args: PyFuncArgs) -> PyResult {
     if objtype::isinstance(i2, &vm.ctx.str_type()) {
         Ok(vm.ctx.new_bool(v1 < get_value(i2)))
     } else {
-        Err(vm.new_type_error(format!("Cannot compare {} and {}", i.borrow(), i2.borrow())))
+        Err(vm.new_type_error(format!("Cannot compare {} and {}", i, i2)))
     }
 }
 
@@ -203,7 +199,7 @@ fn str_le(vm: &mut VirtualMachine, args: PyFuncArgs) -> PyResult {
     if objtype::isinstance(i2, &vm.ctx.str_type()) {
         Ok(vm.ctx.new_bool(v1 <= get_value(i2)))
     } else {
-        Err(vm.new_type_error(format!("Cannot compare {} and {}", i.borrow(), i2.borrow())))
+        Err(vm.new_type_error(format!("Cannot compare {} and {}", i, i2)))
     }
 }
 
@@ -258,7 +254,7 @@ fn str_add(vm: &mut VirtualMachine, args: PyFuncArgs) -> PyResult {
             .ctx
             .new_str(format!("{}{}", get_value(&s), get_value(&s2))))
     } else {
-        Err(vm.new_type_error(format!("Cannot add {} and {}", s.borrow(), s2.borrow())))
+        Err(vm.new_type_error(format!("Cannot add {} and {}", s, s2)))
     }
 }
 
@@ -387,11 +383,7 @@ fn str_mul(vm: &mut VirtualMachine, args: PyFuncArgs) -> PyResult {
         }
         Ok(vm.ctx.new_str(result))
     } else {
-        Err(vm.new_type_error(format!(
-            "Cannot multiply {} and {}",
-            s.borrow(),
-            s2.borrow()
-        )))
+        Err(vm.new_type_error(format!("Cannot multiply {} and {}", s, s2)))
     }
 }
 
@@ -1115,7 +1107,7 @@ pub fn subscript(vm: &mut VirtualMachine, value: &str, b: PyObjectRef) -> PyResu
             }
         }
     } else {
-        match (*b.borrow()).payload {
+        match b.payload {
             PyObjectPayload::Slice { .. } => {
                 let string = value.to_string().get_slice_items(vm, &b)?;
                 Ok(vm.new_str(string))
@@ -1130,8 +1122,8 @@ pub fn subscript(vm: &mut VirtualMachine, value: &str, b: PyObjectRef) -> PyResu
 
 // help get optional string indices
 fn get_slice(
-    start: Option<&std::rc::Rc<std::cell::RefCell<PyObject>>>,
-    end: Option<&std::rc::Rc<std::cell::RefCell<PyObject>>>,
+    start: Option<&PyObjectRef>,
+    end: Option<&PyObjectRef>,
     len: usize,
 ) -> Result<(usize, usize), String> {
     let start_idx = match start {

--- a/vm/src/obj/objtuple.rs
+++ b/vm/src/obj/objtuple.rs
@@ -1,3 +1,6 @@
+use std::cell::RefCell;
+use std::hash::{Hash, Hasher};
+
 use super::objbool;
 use super::objint;
 use super::objsequence::{
@@ -7,7 +10,6 @@ use super::objstr;
 use super::objtype;
 use crate::pyobject::{PyContext, PyFuncArgs, PyObject, PyObjectPayload, PyResult, TypeProtocol};
 use crate::vm::{ReprGuard, VirtualMachine};
-use std::hash::{Hash, Hasher};
 
 fn tuple_lt(vm: &mut VirtualMachine, args: PyFuncArgs) -> PyResult {
     arg_check!(
@@ -21,11 +23,7 @@ fn tuple_lt(vm: &mut VirtualMachine, args: PyFuncArgs) -> PyResult {
         let other = get_elements(other);
         seq_lt(vm, &zelf, &other)?
     } else {
-        return Err(vm.new_type_error(format!(
-            "Cannot compare {} and {} using '<'",
-            zelf.borrow(),
-            other.borrow()
-        )));
+        return Err(vm.new_type_error(format!("Cannot compare {} and {} using '<'", zelf, other)));
     };
 
     Ok(vm.ctx.new_bool(result))
@@ -43,11 +41,7 @@ fn tuple_gt(vm: &mut VirtualMachine, args: PyFuncArgs) -> PyResult {
         let other = get_elements(other);
         seq_gt(vm, &zelf, &other)?
     } else {
-        return Err(vm.new_type_error(format!(
-            "Cannot compare {} and {} using '>'",
-            zelf.borrow(),
-            other.borrow()
-        )));
+        return Err(vm.new_type_error(format!("Cannot compare {} and {} using '>'", zelf, other)));
     };
 
     Ok(vm.ctx.new_bool(result))
@@ -65,11 +59,7 @@ fn tuple_ge(vm: &mut VirtualMachine, args: PyFuncArgs) -> PyResult {
         let other = get_elements(other);
         seq_ge(vm, &zelf, &other)?
     } else {
-        return Err(vm.new_type_error(format!(
-            "Cannot compare {} and {} using '>='",
-            zelf.borrow(),
-            other.borrow()
-        )));
+        return Err(vm.new_type_error(format!("Cannot compare {} and {} using '>='", zelf, other)));
     };
 
     Ok(vm.ctx.new_bool(result))
@@ -87,11 +77,7 @@ fn tuple_le(vm: &mut VirtualMachine, args: PyFuncArgs) -> PyResult {
         let other = get_elements(other);
         seq_le(vm, &zelf, &other)?
     } else {
-        return Err(vm.new_type_error(format!(
-            "Cannot compare {} and {} using '<='",
-            zelf.borrow(),
-            other.borrow()
-        )));
+        return Err(vm.new_type_error(format!("Cannot compare {} and {} using '<='", zelf, other)));
     };
 
     Ok(vm.ctx.new_bool(result))
@@ -110,11 +96,7 @@ fn tuple_add(vm: &mut VirtualMachine, args: PyFuncArgs) -> PyResult {
         let elements = e1.iter().chain(e2.iter()).cloned().collect();
         Ok(vm.ctx.new_tuple(elements))
     } else {
-        Err(vm.new_type_error(format!(
-            "Cannot add {} and {}",
-            zelf.borrow(),
-            other.borrow()
-        )))
+        Err(vm.new_type_error(format!("Cannot add {} and {}", zelf, other)))
     }
 }
 
@@ -193,7 +175,7 @@ fn tuple_new(vm: &mut VirtualMachine, args: PyFuncArgs) -> PyResult {
     );
 
     if !objtype::issubclass(cls, &vm.ctx.tuple_type()) {
-        return Err(vm.new_type_error(format!("{} is not a subtype of tuple", cls.borrow())));
+        return Err(vm.new_type_error(format!("{} is not a subtype of tuple", cls)));
     }
 
     let elements = if let Some(iterable) = iterable {
@@ -203,7 +185,9 @@ fn tuple_new(vm: &mut VirtualMachine, args: PyFuncArgs) -> PyResult {
     };
 
     Ok(PyObject::new(
-        PyObjectPayload::Sequence { elements },
+        PyObjectPayload::Sequence {
+            elements: RefCell::new(elements),
+        },
         cls.clone(),
     ))
 }

--- a/vm/src/obj/objtuple.rs
+++ b/vm/src/obj/objtuple.rs
@@ -1,4 +1,4 @@
-use std::cell::RefCell;
+use std::cell::{Cell, RefCell};
 use std::hash::{Hash, Hasher};
 
 use super::objbool;
@@ -151,7 +151,7 @@ fn tuple_iter(vm: &mut VirtualMachine, args: PyFuncArgs) -> PyResult {
 
     let iter_obj = PyObject::new(
         PyObjectPayload::Iterator {
-            position: 0,
+            position: Cell::new(0),
             iterated_obj: tuple.clone(),
         },
         vm.ctx.iter_type(),

--- a/vm/src/obj/objzip.rs
+++ b/vm/src/obj/objzip.rs
@@ -19,7 +19,7 @@ fn zip_new(vm: &mut VirtualMachine, args: PyFuncArgs) -> PyResult {
 fn zip_next(vm: &mut VirtualMachine, args: PyFuncArgs) -> PyResult {
     arg_check!(vm, args, required = [(zip, Some(vm.ctx.zip_type()))]);
 
-    if let PyObjectPayload::ZipIterator { ref mut iterators } = zip.borrow_mut().payload {
+    if let PyObjectPayload::ZipIterator { ref iterators } = zip.payload {
         if iterators.is_empty() {
             Err(objiter::new_stop_iteration(vm))
         } else {

--- a/vm/src/pyobject.rs
+++ b/vm/src/pyobject.rs
@@ -35,7 +35,7 @@ use num_bigint::BigInt;
 use num_bigint::ToBigInt;
 use num_complex::Complex64;
 use num_traits::{One, Zero};
-use std::cell::RefCell;
+use std::cell::{Cell, RefCell};
 use std::collections::HashMap;
 use std::fmt;
 use std::rc::{Rc, Weak};
@@ -1186,7 +1186,7 @@ pub enum PyObjectPayload {
         elements: RefCell<HashMap<u64, PyObjectRef>>,
     },
     Iterator {
-        position: usize,
+        position: Cell<usize>,
         iterated_obj: PyObjectRef,
     },
     EnumerateIterator {

--- a/vm/src/pyobject.rs
+++ b/vm/src/pyobject.rs
@@ -1227,7 +1227,7 @@ pub enum PyObjectPayload {
         defaults: PyObjectRef,
     },
     Generator {
-        frame: Frame,
+        frame: RefCell<Frame>,
     },
     BoundMethod {
         function: PyObjectRef,

--- a/vm/src/stdlib/json.rs
+++ b/vm/src/stdlib/json.rs
@@ -65,7 +65,7 @@ impl<'s> serde::Serialize for PyObjectSerializer<'s> {
                 map.serialize_entry(&key, &self.clone_with_object(&e.1))?;
             }
             map.end()
-        } else if let PyObjectPayload::None = self.pyobject.borrow().payload {
+        } else if let PyObjectPayload::None = self.pyobject.payload {
             serializer.serialize_none()
         } else {
             Err(serde::ser::Error::custom(format!(
@@ -167,7 +167,7 @@ impl<'de> Visitor<'de> for PyObjectDeserializer<'de> {
         // than wrapping the given object up and then unwrapping it to determine whether or
         // not it is a string
         while let Some((key_obj, value)) = access.next_entry_seed(self.clone(), self.clone())? {
-            let key = match key_obj.borrow().payload {
+            let key = match key_obj.payload {
                 PyObjectPayload::String { ref value } => value.clone(),
                 _ => unimplemented!("map keys must be strings"),
             };

--- a/vm/src/stdlib/socket.rs
+++ b/vm/src/stdlib/socket.rs
@@ -255,16 +255,19 @@ fn socket_send(vm: &mut VirtualMachine, args: PyFuncArgs) -> PyResult {
 fn socket_close(vm: &mut VirtualMachine, args: PyFuncArgs) -> PyResult {
     arg_check!(vm, args, required = [(zelf, None)]);
     match zelf.payload {
-        PyObjectPayload::Socket { ref socket } => match socket.borrow().address_family {
-            AddressFamily::AfInet => match socket.borrow().sk {
-                SocketKind::SockStream => {
-                    socket.borrow_mut().con = None;
-                    Ok(vm.get_none())
-                }
+        PyObjectPayload::Socket { ref socket } => {
+            let mut socket = socket.borrow_mut();
+            match socket.address_family {
+                AddressFamily::AfInet => match socket.sk {
+                    SocketKind::SockStream => {
+                        socket.con = None;
+                        Ok(vm.get_none())
+                    }
+                    _ => Err(vm.new_type_error("".to_string())),
+                },
                 _ => Err(vm.new_type_error("".to_string())),
-            },
-            _ => Err(vm.new_type_error("".to_string())),
-        },
+            }
+        }
         _ => Err(vm.new_type_error("".to_string())),
     }
 }

--- a/vm/src/stdlib/weakref.rs
+++ b/vm/src/stdlib/weakref.rs
@@ -46,7 +46,7 @@ fn ref_call(vm: &mut VirtualMachine, args: PyFuncArgs) -> PyResult {
 }
 
 fn get_value(obj: &PyObjectRef) -> PyObjectWeakRef {
-    if let PyObjectPayload::WeakRef { referent } = &obj.borrow().payload {
+    if let PyObjectPayload::WeakRef { referent } = &obj.payload {
         referent.clone()
     } else {
         panic!("Inner error getting weak ref {:?}", obj);

--- a/vm/src/sysmodule.rs
+++ b/vm/src/sysmodule.rs
@@ -30,7 +30,7 @@ fn sys_getrefcount(vm: &mut VirtualMachine, args: PyFuncArgs) -> PyResult {
 fn sys_getsizeof(vm: &mut VirtualMachine, args: PyFuncArgs) -> PyResult {
     arg_check!(vm, args, required = [(object, None)]);
     // TODO: implement default optional argument.
-    let size = mem::size_of_val(&object.borrow());
+    let size = mem::size_of_val(&object);
     Ok(vm.ctx.new_int(size))
 }
 

--- a/vm/src/vm.rs
+++ b/vm/src/vm.rs
@@ -190,7 +190,7 @@ impl VirtualMachine {
     }
 
     pub fn get_builtin_scope(&mut self) -> PyObjectRef {
-        let a2 = &*self.builtins.borrow();
+        let a2 = &*self.builtins;
         match a2.payload {
             PyObjectPayload::Module { ref dict, .. } => dict.clone(),
             _ => {
@@ -271,7 +271,7 @@ impl VirtualMachine {
 
     pub fn invoke(&mut self, func_ref: PyObjectRef, args: PyFuncArgs) -> PyResult {
         trace!("Invoke: {:?} {:?}", func_ref, args);
-        match func_ref.borrow().payload {
+        match func_ref.payload {
             PyObjectPayload::RustFunction { ref function } => function(self, args),
             PyObjectPayload::Function {
                 ref code,
@@ -406,8 +406,8 @@ impl VirtualMachine {
         // Add missing positional arguments, if we have fewer positional arguments than the
         // function definition calls for
         if nargs < nexpected_args {
-            let available_defaults = match defaults.borrow().payload {
-                PyObjectPayload::Sequence { ref elements } => elements.clone(),
+            let available_defaults = match defaults.payload {
+                PyObjectPayload::Sequence { ref elements } => elements.borrow().clone(),
                 PyObjectPayload::None => vec![],
                 _ => panic!("function defaults not tuple or None"),
             };
@@ -493,11 +493,7 @@ impl VirtualMachine {
         let cls = obj.typ();
         match cls.get_attr(method_name) {
             Some(method) => self.call_get_descriptor(method, obj.clone()),
-            None => Err(self.new_type_error(format!(
-                "{} has no method {:?}",
-                obj.borrow(),
-                method_name
-            ))),
+            None => Err(self.new_type_error(format!("{} has no method {:?}", obj, method_name))),
         }
     }
 

--- a/wasm/lib/src/vm_class.rs
+++ b/wasm/lib/src/vm_class.rs
@@ -4,7 +4,7 @@ use crate::wasm_builtins;
 use js_sys::{SyntaxError, TypeError};
 use rustpython_vm::{
     compile,
-    pyobject::{PyFuncArgs, PyObjectRef, PyRef, PyResult},
+    pyobject::{PyFuncArgs, PyObjectRef, PyResult},
     VirtualMachine,
 };
 use std::cell::RefCell;
@@ -34,8 +34,8 @@ impl StoredVirtualMachine {
 // gets compiled down to a normal-ish static varible, like Atomic* types:
 // https://rustwasm.github.io/2018/10/24/multithreading-rust-and-wasm.html#atomic-instructions
 thread_local! {
-    static STORED_VMS: PyRef<HashMap<String, PyRef<StoredVirtualMachine>>> = Rc::default();
-    static ACTIVE_VMS: PyRef<HashMap<String, *mut VirtualMachine>> = Rc::default();
+    static STORED_VMS: Rc<RefCell<HashMap<String, Rc<RefCell<StoredVirtualMachine>>>>> = Rc::default();
+    static ACTIVE_VMS: Rc<RefCell<HashMap<String, *mut VirtualMachine>>> = Rc::default();
 }
 
 #[wasm_bindgen(js_name = vmStore)]


### PR DESCRIPTION
The outer `RefCell` in `PyObjectRef` poses a number of issues.

- It's a layer of indirection all accesses must go through, even if they don't need mutability.
- When we eventually support threading, we'll want to pick the best locks / concurrent data-structures for each object.
- Removing it is needed to create an ergonomic api for defining python functions in rust.

Essentially, this is the next step towards support creating python functions in rust like this:

```rust
struct PyList {
    elements: RefCell<Vec<PyObjectRef>>,
}

impl PyList {
    fn iadd(self: PyRef<Self>, other: PyIterable) -> PyRef<Self> {
        self.elements.borrow_mut().extend(other);
        self
    }
}
```

With the outer `RefCell`, implementing `Deref` for `PyRef` is not possible.