### PR TITLE
add overflow errors for int shifts.

### DIFF
--- a/tests/snippets/ints.py
+++ b/tests/snippets/ints.py
@@ -1,3 +1,5 @@
+from testutils import assert_raises
+
 # int to int comparisons
 
 assert 1 == 1
@@ -36,6 +38,7 @@ assert (2).__rtruediv__(1) == 0.5
 assert (1).real == 1
 assert (1).imag == 0
 
+assert_raises(OverflowError, lambda: 1 << 10 ** 100000)
 
 assert (1).__eq__(1.0) == NotImplemented
 assert (1).__ne__(1.0) == NotImplemented

--- a/vm/src/obj/objint.rs
+++ b/vm/src/obj/objint.rs
@@ -246,7 +246,7 @@ fn int_lshift(vm: &mut VirtualMachine, args: PyFuncArgs) -> PyResult {
     match get_value(i2) {
         ref v if *v < BigInt::zero() => Err(vm.new_value_error("negative shift count".to_string())),
         ref v if *v > BigInt::from(usize::max_value()) => {
-            Err(vm.new_overflow_error("the number is too large to convert to float".to_string()))
+            Err(vm.new_overflow_error("the number is too large to convert to int".to_string()))
         }
         _ => panic!("Failed converting {} to rust usize", get_value(i2)),
     }
@@ -275,7 +275,7 @@ fn int_rshift(vm: &mut VirtualMachine, args: PyFuncArgs) -> PyResult {
     match get_value(i2) {
         ref v if *v < BigInt::zero() => Err(vm.new_value_error("negative shift count".to_string())),
         ref v if *v > BigInt::from(usize::max_value()) => {
-            Err(vm.new_overflow_error("the number is too large to convert to float".to_string()))
+            Err(vm.new_overflow_error("the number is too large to convert to int".to_string()))
         }
         _ => panic!("Failed converting {} to rust usize", get_value(i2)),
     }

--- a/vm/src/obj/objint.rs
+++ b/vm/src/obj/objint.rs
@@ -246,8 +246,7 @@ fn int_lshift(vm: &mut VirtualMachine, args: PyFuncArgs) -> PyResult {
     match get_value(i2) {
         ref v if *v < BigInt::zero() => Err(vm.new_value_error("negative shift count".to_string())),
         ref v if *v > BigInt::from(usize::max_value()) => {
-            // TODO: raise OverflowError
-            panic!("Failed converting {} to rust usize", get_value(i2));
+            Err(vm.new_overflow_error("the number is too large to convert to float".to_string()))
         }
         _ => panic!("Failed converting {} to rust usize", get_value(i2)),
     }
@@ -276,8 +275,7 @@ fn int_rshift(vm: &mut VirtualMachine, args: PyFuncArgs) -> PyResult {
     match get_value(i2) {
         ref v if *v < BigInt::zero() => Err(vm.new_value_error("negative shift count".to_string())),
         ref v if *v > BigInt::from(usize::max_value()) => {
-            // TODO: raise OverflowError
-            panic!("Failed converting {} to rust usize", get_value(i2));
+            Err(vm.new_overflow_error("the number is too large to convert to float".to_string()))
         }
         _ => panic!("Failed converting {} to rust usize", get_value(i2)),
     }


### PR DESCRIPTION
fix for https://github.com/RustPython/RustPython/issues/556