### PR TITLE
Fix a bunch of clippy lints

### DIFF
--- a/parser/src/fstring.rs
+++ b/parser/src/fstring.rs
@@ -121,7 +121,7 @@ impl<'a> FStringParser<'a> {
             }
         }
 
-        return Err(UnclosedLbrace);
+        Err(UnclosedLbrace)
     }
 
     fn parse(mut self) -> Result<StringGroup, FStringError> {

--- a/vm/src/bytecode.rs
+++ b/vm/src/bytecode.rs
@@ -269,7 +269,7 @@ impl CodeObject {
         }
     }
 
-    pub fn get_constants<'a>(&'a self) -> impl Iterator<Item = &'a Constant> {
+    pub fn get_constants(&self) -> impl Iterator<Item = &Constant> {
         self.instructions.iter().filter_map(|x| {
             if let Instruction::LoadConst { value } = x {
                 Some(value)
@@ -362,10 +362,7 @@ impl Instruction {
             UnpackSequence { size } => w!(UnpackSequence, size),
             UnpackEx { before, after } => w!(UnpackEx, before, after),
             Unpack => w!(Unpack),
-            FormatValue {
-                conversion: _,
-                spec,
-            } => w!(FormatValue, spec), // TODO: write conversion
+            FormatValue { spec, .. } => w!(FormatValue, spec), // TODO: write conversion
         }
     }
 }

--- a/vm/src/compile.rs
+++ b/vm/src/compile.rs
@@ -48,10 +48,7 @@ pub fn compile(
 
     let code = compiler.pop_code_object();
     trace!("Compilation completed: {:?}", code);
-    Ok(PyObject::new(
-        PyObjectPayload::Code { code: code },
-        code_type,
-    ))
+    Ok(PyObject::new(PyObjectPayload::Code { code }, code_type))
 }
 
 pub enum Mode {

--- a/vm/src/frame.rs
+++ b/vm/src/frame.rs
@@ -94,7 +94,7 @@ impl Frame {
         let run_obj_name = &self.code.obj_name.to_string();
 
         // Execute until return or exception:
-        let value = loop {
+        loop {
             let lineno = self.get_lineno();
             let result = self.execute_instruction(vm);
             match result {
@@ -136,9 +136,7 @@ impl Frame {
                     }
                 }
             }
-        };
-
-        value
+        }
     }
 
     pub fn fetch_instruction(&self) -> &bytecode::Instruction {

--- a/vm/src/import.rs
+++ b/vm/src/import.rs
@@ -105,7 +105,7 @@ fn find_source(vm: &VirtualMachine, current_path: PathBuf, name: &str) -> Result
         }
     }
 
-    match file_paths.iter().filter(|p| p.exists()).next() {
+    match file_paths.iter().find(|p| p.exists()) {
         Some(path) => Ok(path.to_path_buf()),
         None => Err(format!("No module named '{}'", name)),
     }

--- a/vm/src/lib.rs
+++ b/vm/src/lib.rs
@@ -5,6 +5,9 @@
 //! - Import mechanics
 //! - Base objects
 
+// for methods like vm.to_str(), not the typical use of 'to' as a method prefix
+#![allow(clippy::wrong_self_convention)]
+
 #[macro_use]
 extern crate bitflags;
 #[macro_use]

--- a/vm/src/obj/objbool.rs
+++ b/vm/src/obj/objbool.rs
@@ -22,12 +22,10 @@ pub fn boolval(vm: &mut VirtualMachine, obj: PyObjectRef) -> Result<bool, PyObje
         _ => {
             if let Ok(f) = vm.get_method(obj.clone(), "__bool__") {
                 let bool_res = vm.invoke(f, PyFuncArgs::default())?;
-                let v = match bool_res.payload {
+                match bool_res.payload {
                     PyObjectPayload::Integer { ref value } => !value.is_zero(),
                     _ => return Err(vm.new_type_error(String::from("TypeError"))),
-                };
-
-                v
+                }
             } else {
                 true
             }

--- a/vm/src/obj/objcomplex.rs
+++ b/vm/src/obj/objcomplex.rs
@@ -84,13 +84,13 @@ fn complex_new(vm: &mut VirtualMachine, args: PyFuncArgs) -> PyResult {
 
 fn complex_real(vm: &mut VirtualMachine, args: PyFuncArgs) -> PyResult {
     arg_check!(vm, args, required = [(zelf, Some(vm.ctx.complex_type()))]);
-    let Complex64 { re, im: _ } = get_value(zelf);
+    let Complex64 { re, .. } = get_value(zelf);
     Ok(vm.ctx.new_float(re))
 }
 
 fn complex_imag(vm: &mut VirtualMachine, args: PyFuncArgs) -> PyResult {
     arg_check!(vm, args, required = [(zelf, Some(vm.ctx.complex_type()))]);
-    let Complex64 { re: _, im } = get_value(zelf);
+    let Complex64 { im, .. } = get_value(zelf);
     Ok(vm.ctx.new_float(im))
 }
 

--- a/vm/src/obj/objfloat.rs
+++ b/vm/src/obj/objfloat.rs
@@ -417,7 +417,7 @@ fn float_real(vm: &mut VirtualMachine, args: PyFuncArgs) -> PyResult {
 fn float_is_integer(vm: &mut VirtualMachine, args: PyFuncArgs) -> PyResult {
     arg_check!(vm, args, required = [(i, Some(vm.ctx.float_type()))]);
     let v = get_value(i);
-    let result = v == v.round();
+    let result = (v - v.round()).abs() < std::f64::EPSILON;
     Ok(vm.ctx.new_bool(result))
 }
 

--- a/vm/src/obj/objgenerator.rs
+++ b/vm/src/obj/objgenerator.rs
@@ -29,7 +29,7 @@ pub fn init(context: &PyContext) {
 
 pub fn new_generator(vm: &mut VirtualMachine, frame: PyObjectRef) -> PyResult {
     Ok(PyObject::new(
-        PyObjectPayload::Generator { frame: frame },
+        PyObjectPayload::Generator { frame },
         vm.ctx.generator_type.clone(),
     ))
 }

--- a/vm/src/obj/objset.rs
+++ b/vm/src/obj/objset.rs
@@ -547,7 +547,7 @@ fn set_ixor(vm: &mut VirtualMachine, args: PyFuncArgs) -> PyResult {
 fn set_iter(vm: &mut VirtualMachine, args: PyFuncArgs) -> PyResult {
     arg_check!(vm, args, required = [(zelf, Some(vm.ctx.set_type()))]);
 
-    let items = get_elements(zelf).values().map(|x| x.clone()).collect();
+    let items = get_elements(zelf).values().cloned().collect();
     let set_list = vm.ctx.new_list(items);
     let iter_obj = PyObject::new(
         PyObjectPayload::Iterator {

--- a/vm/src/obj/objstr.rs
+++ b/vm/src/obj/objstr.rs
@@ -518,7 +518,7 @@ fn str_isupper(vm: &mut VirtualMachine, args: PyFuncArgs) -> PyResult {
             && value
                 .chars()
                 .filter(|x| !x.is_ascii_whitespace())
-                .all(|c| c.is_uppercase()),
+                .all(char::is_uppercase),
     ))
 }
 
@@ -530,7 +530,7 @@ fn str_islower(vm: &mut VirtualMachine, args: PyFuncArgs) -> PyResult {
             && value
                 .chars()
                 .filter(|x| !x.is_ascii_whitespace())
-                .all(|c| c.is_lowercase()),
+                .all(char::is_lowercase),
     ))
 }
 
@@ -895,7 +895,7 @@ fn str_isalnum(vm: &mut VirtualMachine, args: PyFuncArgs) -> PyResult {
     let value = get_value(&s);
     Ok(vm
         .ctx
-        .new_bool(!value.is_empty() && value.chars().all(|c| c.is_alphanumeric())))
+        .new_bool(!value.is_empty() && value.chars().all(char::is_alphanumeric)))
 }
 
 fn str_isascii(vm: &mut VirtualMachine, args: PyFuncArgs) -> PyResult {
@@ -959,7 +959,7 @@ fn str_isnumeric(vm: &mut VirtualMachine, args: PyFuncArgs) -> PyResult {
     let value = get_value(&s);
     Ok(vm
         .ctx
-        .new_bool(!value.is_empty() && value.chars().all(|c| c.is_numeric())))
+        .new_bool(!value.is_empty() && value.chars().all(char::is_numeric)))
 }
 
 fn str_isalpha(vm: &mut VirtualMachine, args: PyFuncArgs) -> PyResult {
@@ -967,7 +967,7 @@ fn str_isalpha(vm: &mut VirtualMachine, args: PyFuncArgs) -> PyResult {
     let value = get_value(&s);
     Ok(vm
         .ctx
-        .new_bool(!value.is_empty() && value.chars().all(|c| c.is_alphanumeric())))
+        .new_bool(!value.is_empty() && value.chars().all(char::is_alphanumeric)))
 }
 
 fn str_isdigit(vm: &mut VirtualMachine, args: PyFuncArgs) -> PyResult {

--- a/vm/src/obj/objtype.rs
+++ b/vm/src/obj/objtype.rs
@@ -343,7 +343,7 @@ fn linearise_mro(mut bases: Vec<Vec<PyObjectRef>>) -> Option<Vec<PyObjectRef>> {
     debug!("Linearising MRO: {:?}", bases);
     let mut result = vec![];
     loop {
-        if (&bases).iter().all(|x| x.is_empty()) {
+        if (&bases).iter().all(Vec::is_empty) {
             break;
         }
         match take_next_base(bases) {

--- a/vm/src/pyobject.rs
+++ b/vm/src/pyobject.rs
@@ -712,6 +712,12 @@ impl PyContext {
     }
 }
 
+impl Default for PyContext {
+    fn default() -> Self {
+        PyContext::new()
+    }
+}
+
 /// This is an actual python object. It consists of a `typ` which is the
 /// python class, and carries some rust payload optionally. This rust
 /// payload can be a rust float or rust int in case of float and int objects.
@@ -1091,7 +1097,7 @@ macro_rules! tuple_py_native_func_factory {
                 let signature = Signature::new(parameters);
 
                 Box::new(move |vm, mut args| {
-                    signature.check(vm, &mut args)?;
+                    signature.check(vm, &args)?;
 
                     (self)(vm, $($T::from_py_func_args(&mut args)?,)+)
                         .into_pyobject(&vm.ctx)

--- a/vm/src/stdlib/socket.rs
+++ b/vm/src/stdlib/socket.rs
@@ -17,17 +17,17 @@ use num_traits::ToPrimitive;
 
 #[derive(Copy, Clone)]
 enum AddressFamily {
-    AfUnix = 1,
-    AfInet = 2,
-    AfInet6 = 3,
+    Unix = 1,
+    Inet = 2,
+    Inet6 = 3,
 }
 
 impl AddressFamily {
     fn from_i32(value: i32) -> AddressFamily {
         match value {
-            1 => AddressFamily::AfUnix,
-            2 => AddressFamily::AfInet,
-            3 => AddressFamily::AfInet6,
+            1 => AddressFamily::Unix,
+            2 => AddressFamily::Inet,
+            3 => AddressFamily::Inet6,
             _ => panic!("Unknown value: {}", value),
         }
     }
@@ -35,15 +35,15 @@ impl AddressFamily {
 
 #[derive(Copy, Clone)]
 enum SocketKind {
-    SockStream = 1,
-    SockDgram = 2,
+    Stream = 1,
+    Dgram = 2,
 }
 
 impl SocketKind {
     fn from_i32(value: i32) -> SocketKind {
         match value {
-            1 => SocketKind::SockStream,
-            2 => SocketKind::SockDgram,
+            1 => SocketKind::Stream,
+            2 => SocketKind::Dgram,
             _ => panic!("Unknown value: {}", value),
         }
     }
@@ -102,7 +102,7 @@ impl Socket {
     fn new(address_family: AddressFamily, socket_kind: SocketKind) -> Socket {
         Socket {
             address_family,
-            socket_kind: socket_kind,
+            socket_kind,
             con: None,
         }
     }
@@ -286,8 +286,8 @@ fn socket_close(vm: &mut VirtualMachine, args: PyFuncArgs) -> PyResult {
         PyObjectPayload::Socket { ref socket } => {
             let mut socket = socket.borrow_mut();
             match socket.address_family {
-                AddressFamily::AfInet => match socket.socket_kind {
-                    SocketKind::SockStream => {
+                AddressFamily::Inet => match socket.socket_kind {
+                    SocketKind::Stream => {
                         socket.con = None;
                         Ok(vm.get_none())
                     }
@@ -320,7 +320,7 @@ fn socket_getsockname(vm: &mut VirtualMachine, args: PyFuncArgs) -> PyResult {
                         vm.ctx.tuple_type(),
                     ))
                 }
-                _ => return Err(vm.new_type_error("".to_string())),
+                _ => Err(vm.new_type_error("".to_string())),
             }
         }
         _ => Err(vm.new_type_error("".to_string())),
@@ -330,16 +330,12 @@ fn socket_getsockname(vm: &mut VirtualMachine, args: PyFuncArgs) -> PyResult {
 pub fn mk_module(ctx: &PyContext) -> PyObjectRef {
     let py_mod = ctx.new_module(&"socket".to_string(), ctx.new_scope(None));
 
-    ctx.set_attr(
-        &py_mod,
-        "AF_INET",
-        ctx.new_int(AddressFamily::AfInet as i32),
-    );
+    ctx.set_attr(&py_mod, "AF_INET", ctx.new_int(AddressFamily::Inet as i32));
 
     ctx.set_attr(
         &py_mod,
         "SOCK_STREAM",
-        ctx.new_int(SocketKind::SockStream as i32),
+        ctx.new_int(SocketKind::Stream as i32),
     );
 
     let socket = {

--- a/vm/src/sysmodule.rs
+++ b/vm/src/sysmodule.rs
@@ -24,7 +24,7 @@ fn frame_idx(vm: &mut VirtualMachine, offset: Option<&PyObjectRef>) -> Result<us
             return Ok(offset);
         }
     }
-    return Ok(0);
+    Ok(0)
 }
 
 fn getframe(vm: &mut VirtualMachine, args: PyFuncArgs) -> PyResult {

--- a/vm/src/vm.rs
+++ b/vm/src/vm.rs
@@ -804,6 +804,12 @@ impl VirtualMachine {
     }
 }
 
+impl Default for VirtualMachine {
+    fn default() -> Self {
+        VirtualMachine::new()
+    }
+}
+
 lazy_static! {
     static ref REPR_GUARDS: Mutex<HashSet<usize>> = { Mutex::new(HashSet::new()) };
 }

--- a/wasm/lib/src/browser_module.rs
+++ b/wasm/lib/src/browser_module.rs
@@ -95,7 +95,7 @@ fn browser_fetch(vm: &mut VirtualMachine, args: PyFuncArgs) -> PyResult {
         })
         .and_then(JsFuture::from);
 
-    Ok(PyPromise::new(promise_type, future_to_promise(future)))
+    Ok(PyPromise::new_obj(promise_type, future_to_promise(future)))
 }
 
 fn browser_request_animation_frame(vm: &mut VirtualMachine, args: PyFuncArgs) -> PyResult {
@@ -159,7 +159,7 @@ pub struct PyPromise {
 }
 
 impl PyPromise {
-    pub fn new(promise_type: PyObjectRef, value: Promise) -> PyObjectRef {
+    pub fn new_obj(promise_type: PyObjectRef, value: Promise) -> PyObjectRef {
         PyObject::new(
             PyObjectPayload::AnyRustValue {
                 value: Box::new(PyPromise { value }),
@@ -230,7 +230,7 @@ fn promise_then(vm: &mut VirtualMachine, args: PyFuncArgs) -> PyResult {
 
     let ret_promise = future_to_promise(ret_future);
 
-    Ok(PyPromise::new(promise_type, ret_promise))
+    Ok(PyPromise::new_obj(promise_type, ret_promise))
 }
 
 fn promise_catch(vm: &mut VirtualMachine, args: PyFuncArgs) -> PyResult {
@@ -265,7 +265,7 @@ fn promise_catch(vm: &mut VirtualMachine, args: PyFuncArgs) -> PyResult {
 
     let ret_promise = future_to_promise(ret_future);
 
-    Ok(PyPromise::new(promise_type, ret_promise))
+    Ok(PyPromise::new_obj(promise_type, ret_promise))
 }
 
 fn browser_alert(vm: &mut VirtualMachine, args: PyFuncArgs) -> PyResult {

--- a/wasm/lib/src/convert.rs
+++ b/wasm/lib/src/convert.rs
@@ -118,7 +118,7 @@ pub fn js_to_py(vm: &mut VirtualMachine, js_val: JsValue) -> PyObjectRef {
         if let Some(promise) = js_val.dyn_ref::<Promise>() {
             // the browser module might not be injected
             if let Ok(promise_type) = browser_module::import_promise_type(vm) {
-                return browser_module::PyPromise::new(promise_type, promise.clone());
+                return browser_module::PyPromise::new_obj(promise_type, promise.clone());
             }
         }
         if Array::is_array(&js_val) {

--- a/wasm/lib/src/lib.rs
+++ b/wasm/lib/src/lib.rs
@@ -34,7 +34,7 @@ fn panic_hook(info: &panic::PanicInfo) {
         Ok(stack) => stack,
         Err(_) => return,
     };
-    let _ = Reflect::set(&window, &"__RUSTPYTHON_ERROR_STACK".into(), &stack.into());
+    let _ = Reflect::set(&window, &"__RUSTPYTHON_ERROR_STACK".into(), &stack);
 }
 
 #[wasm_bindgen(start)]


### PR DESCRIPTION
I'm planning on working on more, but there are some that I'm not sure about:

```
warning: large size difference between variants
    --> vm/src/pyobject.rs:1251:5
     |
1251 | /     Frame {
1252 | |         frame: Frame,
1253 | |     },
     | |_____^
     |
     = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#large_enum_variant
help: consider boxing the large fields to reduce the total size of the enum
     |
1252 |         frame: Box<Frame>,
     |                ^^^^^^^^^^
```
There are a few of ^these, and I don't know what the tradeoff would be between size/box performance. I'll probably do it, it'll just take a lot of refactoring.

```
warning: the function has a cyclomatic complexity of 33
   --> vm/src/compile.rs:150:5
    |
150 | /     fn compile_statement(&mut self, statement: &ast::LocatedStatement) -> Result<(), CompileError> {
151 | |         trace!("Compiling {:?}", statement);
152 | |         self.set_source_location(&statement.location);
153 | |
...   |
671 | |         Ok(())
672 | |     }
    | |_____^
    |
    = note: #[warn(clippy::cyclomatic_complexity)] on by default
    = help: you could split it up into multiple smaller functions
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#cyclomatic_complexity
```
Also 2 of ^these; basically just saying that the function is 500 LOC and you should probably split it up. I might tackle this one too, it'll just take some time.

```
warning: consider using `Option<T>` instead of `Option<Option<T>>` or a custom enum if you need to distinguish all 3 cases
  --> vm/src/bytecode.rs:22:18
   |
22 |     pub varargs: Option<Option<String>>, // *args or *
   |                  ^^^^^^^^^^^^^^^^^^^^^^
   |
   = note: #[warn(clippy::option_option)] on by default
   = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#option_option
```
For this and `varkwargs`, are the three states: No varargs, varargs without a variable to bind to, and varargs with a variable to bind to? I'm not really familiar with the rustpython bytecode.


