### PR TITLE
Proper construction of scope for exec/eval.

### DIFF
--- a/tests/snippets/test_exec.py
+++ b/tests/snippets/test_exec.py
@@ -1,0 +1,12 @@
+exec("def square(x):\n return x * x\n")
+assert 16 == square(4)
+
+d = {}
+exec("def square(x):\n return x * x\n", {}, d)
+assert 16 == d['square'](4)
+
+exec("assert 2 == x", {}, {'x': 2})
+exec("assert 2 == x", {'x': 2}, {})
+exec("assert 4 == x", {'x': 2}, {'x': 4})
+
+exec("assert max(1, 2) == 2", {}, {})

--- a/tests/snippets/test_exec.py
+++ b/tests/snippets/test_exec.py
@@ -10,3 +10,12 @@ exec("assert 2 == x", {'x': 2}, {})
 exec("assert 4 == x", {'x': 2}, {'x': 4})
 
 exec("assert max(1, 2) == 2", {}, {})
+
+exec("max(1, 5, square(5)) == 25", None)
+
+try:
+    exec("", 1)
+except TypeError:
+    pass
+else:
+    raise TypeError("exec should fail unless globals is a dict or None")

--- a/tests/snippets/test_exec.py
+++ b/tests/snippets/test_exec.py
@@ -11,7 +11,28 @@ exec("assert 4 == x", {'x': 2}, {'x': 4})
 
 exec("assert max(1, 2) == 2", {}, {})
 
-exec("max(1, 5, square(5)) == 25", None)
+exec("assert max(1, 5, square(5)) == 25", None)
+
+#
+# These doesn't work yet:
+#
+# Local environment shouldn't replace global environment:
+#
+# exec("assert max(1, 5, square(5)) == 25", None, {})
+#
+# Closures aren't available if local scope is replaced:
+#
+# def g():
+#     seven = "seven"
+#     def f():
+#         try:
+#             exec("seven", None, {})
+#         except NameError:
+#             pass
+#         else:
+#             raise NameError("seven shouldn't be in scope")
+#     f()
+# g()
 
 try:
     exec("", 1)

--- a/vm/src/builtins.rs
+++ b/vm/src/builtins.rs
@@ -190,11 +190,10 @@ fn builtin_eval(vm: &mut VirtualMachine, args: PyFuncArgs) -> PyResult {
         vm,
         args,
         required = [(source, None)],
-        optional = [
-            (globals, Some(vm.ctx.dict_type())),
-            (locals, Some(vm.ctx.dict_type()))
-        ]
+        optional = [(globals, None), (locals, Some(vm.ctx.dict_type()))]
     );
+
+    check_but_allow_none!(vm, globals, vm.ctx.dict_type());
 
     // Determine code object:
     let code_obj = if objtype::isinstance(source, &vm.ctx.code_type()) {
@@ -227,11 +226,10 @@ fn builtin_exec(vm: &mut VirtualMachine, args: PyFuncArgs) -> PyResult {
         vm,
         args,
         required = [(source, None)],
-        optional = [
-            (globals, Some(vm.ctx.dict_type())),
-            (locals, Some(vm.ctx.dict_type()))
-        ]
+        optional = [(globals, None), (locals, Some(vm.ctx.dict_type()))]
     );
+
+    check_but_allow_none!(vm, globals, vm.ctx.dict_type());
 
     // Determine code object:
     let code_obj = if objtype::isinstance(source, &vm.ctx.str_type()) {

--- a/vm/src/frame.rs
+++ b/vm/src/frame.rs
@@ -35,6 +35,12 @@ pub struct Scope {
 }
 pub type ScopeRef = Rc<Scope>;
 
+impl Scope {
+    pub fn new(locals: PyObjectRef, parent: Option<ScopeRef>) -> ScopeRef {
+        Rc::new(Scope { locals, parent })
+    }
+}
+
 #[derive(Clone, Debug)]
 struct Block {
     /// The type of block.

--- a/vm/src/macros.rs
+++ b/vm/src/macros.rs
@@ -36,34 +36,6 @@ macro_rules! type_check {
 }
 
 #[macro_export]
-macro_rules! check_but_allow_none {
-    ( $vm: ident, $arg: ident, $expected_type: expr ) => {
-        let $arg = match $arg {
-            Some(arg) => {
-                if arg.is(&$vm.get_none()) {
-                    None
-                } else {
-                    if $crate::obj::objtype::real_isinstance($vm, arg, &$expected_type)? {
-                        Some(arg)
-                    } else {
-                        let arg_typ = arg.typ();
-                        let actual_type = $vm.to_pystr(&arg_typ)?;
-                        let expected_type_name = $vm.to_pystr(&$expected_type)?;
-                        return Err($vm.new_type_error(format!(
-                            "{} must be a {}, not {}",
-                            stringify!($arg),
-                            expected_type_name,
-                            actual_type
-                        )));
-                    }
-                }
-            }
-            None => None,
-        };
-    };
-}
-
-#[macro_export]
 macro_rules! arg_check {
     ( $vm: ident, $args:ident ) => {
         // Zero-arg case

--- a/vm/src/vm.rs
+++ b/vm/src/vm.rs
@@ -90,6 +90,12 @@ impl VirtualMachine {
         result
     }
 
+    pub fn current_scope(&self) -> &ScopeRef {
+        let current_frame = &self.frames[self.frames.len() - 1];
+        let frame = objframe::get_value(current_frame);
+        &frame.scope
+    }
+
     /// Create a new python string object.
     pub fn new_str(&self, s: String) -> PyObjectRef {
         self.ctx.new_str(s)
@@ -218,7 +224,7 @@ impl VirtualMachine {
         &self.ctx
     }
 
-    pub fn get_builtin_scope(&mut self) -> ScopeRef {
+    pub fn get_builtin_scope(&self) -> ScopeRef {
         let a2 = &*self.builtins;
         match a2.payload {
             PyObjectPayload::Module { ref scope, .. } => scope.clone(),


### PR DESCRIPTION
One case I couldn't handle is that the following is valid in CPython.

```
>>>>> exec("print(x)", None, {'x': 2})
Traceback (most recent call last):
  File <stdin>, line 0, in <module>
TypeError: argument of type <class 'dict'> is required for parameter 2 (globals) (got: <class 'NoneType'>)
```

```arg_check!``` needs to allow None and treat it as if the optional argument wasn't passed. I don't know what other builtins have this behaviour.

