### PR TITLE
Unit payload

### DIFF
--- a/tests/snippets/bools.py
+++ b/tests/snippets/bools.py
@@ -16,6 +16,9 @@ assert bool() == False
 assert bool(1) == True
 assert bool({}) == False
 
+assert bool(NotImplemented) == True
+assert bool(...) == True
+
 if not 1:
     raise BaseException
 

--- a/vm/src/obj/objbool.rs
+++ b/vm/src/obj/objbool.rs
@@ -14,7 +14,7 @@ impl IntoPyObject for bool {
     }
 }
 
-pub fn boolval(vm: &mut VirtualMachine, obj: PyObjectRef) -> Result<bool, PyObjectRef> {
+pub fn boolval(vm: &mut VirtualMachine, obj: PyObjectRef) -> PyResult<bool> {
     if let Some(s) = obj.payload::<PyString>() {
         return Ok(!s.value.is_empty());
     }
@@ -27,7 +27,6 @@ pub fn boolval(vm: &mut VirtualMachine, obj: PyObjectRef) -> Result<bool, PyObje
     let result = match obj.payload {
         PyObjectPayload::Integer { ref value } => !value.is_zero(),
         PyObjectPayload::Sequence { ref elements } => !elements.borrow().is_empty(),
-        PyObjectPayload::None { .. } => false,
         _ => {
             if let Ok(f) = vm.get_method(obj.clone(), "__bool__") {
                 let bool_res = vm.invoke(f, PyFuncArgs::default())?;

--- a/vm/src/obj/objnone.rs
+++ b/vm/src/obj/objnone.rs
@@ -5,6 +5,7 @@ pub fn init(context: &PyContext) {
     let none_type = &context.none.typ();
     context.set_attr(&none_type, "__new__", context.new_rustfunc(none_new));
     context.set_attr(&none_type, "__repr__", context.new_rustfunc(none_repr));
+    context.set_attr(&none_type, "__bool__", context.new_rustfunc(none_bool));
 }
 
 fn none_new(vm: &mut VirtualMachine, args: PyFuncArgs) -> PyResult {
@@ -19,4 +20,9 @@ fn none_new(vm: &mut VirtualMachine, args: PyFuncArgs) -> PyResult {
 fn none_repr(vm: &mut VirtualMachine, args: PyFuncArgs) -> PyResult {
     arg_check!(vm, args, required = [(_zelf, Some(vm.ctx.none().typ()))]);
     Ok(vm.ctx.new_str("None".to_string()))
+}
+
+fn none_bool(vm: &mut VirtualMachine, args: PyFuncArgs) -> PyResult {
+    arg_check!(vm, args, required = [(_zelf, Some(vm.ctx.none().typ()))]);
+    Ok(vm.ctx.new_bool(false))
 }

--- a/vm/src/pyobject.rs
+++ b/vm/src/pyobject.rs
@@ -155,7 +155,9 @@ pub struct PyContext {
 
 fn _nothing() -> PyObjectRef {
     PyObject {
-        payload: PyObjectPayload::NoPayload,
+        payload: PyObjectPayload::AnyRustValue {
+            value: Box::new(()),
+        },
         typ: None,
     }
     .into_ref()
@@ -223,14 +225,23 @@ impl PyContext {
         let exceptions = exceptions::ExceptionZoo::new(&type_type, &object_type, &dict_type);
 
         let none = PyObject::new(
-            PyObjectPayload::NoPayload,
+            PyObjectPayload::AnyRustValue {
+                value: Box::new(()),
+            },
             create_type("NoneType", &type_type, &object_type, &dict_type),
         );
 
-        let ellipsis = PyObject::new(PyObjectPayload::NoPayload, ellipsis_type.clone());
+        let ellipsis = PyObject::new(
+            PyObjectPayload::AnyRustValue {
+                value: Box::new(()),
+            },
+            ellipsis_type.clone(),
+        );
 
         let not_implemented = PyObject::new(
-            PyObjectPayload::NoPayload,
+            PyObjectPayload::AnyRustValue {
+                value: Box::new(()),
+            },
             create_type("NotImplementedType", &type_type, &object_type, &dict_type),
         );
 
@@ -1484,7 +1495,6 @@ pub enum PyObjectPayload {
         name: String,
         scope: ScopeRef,
     },
-    NoPayload,
     Class {
         name: String,
         dict: RefCell<PyAttributes>,
@@ -1525,7 +1535,6 @@ impl fmt::Debug for PyObjectPayload {
                 ref object,
             } => write!(f, "bound-method: {:?} of {:?}", function, object),
             PyObjectPayload::Module { .. } => write!(f, "module"),
-            PyObjectPayload::NoPayload => write!(f, "NoPayload"),
             PyObjectPayload::Class { ref name, .. } => write!(f, "class {:?}", name),
             PyObjectPayload::Instance { .. } => write!(f, "instance"),
             PyObjectPayload::RustFunction { .. } => write!(f, "rust function"),

--- a/vm/src/pyobject.rs
+++ b/vm/src/pyobject.rs
@@ -155,7 +155,7 @@ pub struct PyContext {
 
 fn _nothing() -> PyObjectRef {
     PyObject {
-        payload: PyObjectPayload::None,
+        payload: PyObjectPayload::NoPayload,
         typ: None,
     }
     .into_ref()
@@ -223,14 +223,14 @@ impl PyContext {
         let exceptions = exceptions::ExceptionZoo::new(&type_type, &object_type, &dict_type);
 
         let none = PyObject::new(
-            PyObjectPayload::None,
+            PyObjectPayload::NoPayload,
             create_type("NoneType", &type_type, &object_type, &dict_type),
         );
 
-        let ellipsis = PyObject::new(PyObjectPayload::None, ellipsis_type.clone());
+        let ellipsis = PyObject::new(PyObjectPayload::NoPayload, ellipsis_type.clone());
 
         let not_implemented = PyObject::new(
-            PyObjectPayload::NotImplemented,
+            PyObjectPayload::NoPayload,
             create_type("NotImplementedType", &type_type, &object_type, &dict_type),
         );
 
@@ -1484,8 +1484,7 @@ pub enum PyObjectPayload {
         name: String,
         scope: ScopeRef,
     },
-    None,
-    NotImplemented,
+    NoPayload,
     Class {
         name: String,
         dict: RefCell<PyAttributes>,
@@ -1526,8 +1525,7 @@ impl fmt::Debug for PyObjectPayload {
                 ref object,
             } => write!(f, "bound-method: {:?} of {:?}", function, object),
             PyObjectPayload::Module { .. } => write!(f, "module"),
-            PyObjectPayload::None => write!(f, "None"),
-            PyObjectPayload::NotImplemented => write!(f, "NotImplemented"),
+            PyObjectPayload::NoPayload => write!(f, "NoPayload"),
             PyObjectPayload::Class { ref name, .. } => write!(f, "class {:?}", name),
             PyObjectPayload::Instance { .. } => write!(f, "instance"),
             PyObjectPayload::RustFunction { .. } => write!(f, "rust function"),

--- a/vm/src/stdlib/json.rs
+++ b/vm/src/stdlib/json.rs
@@ -11,7 +11,7 @@ use crate::obj::{
     objtype,
 };
 use crate::pyobject::{
-    create_type, DictProtocol, PyContext, PyFuncArgs, PyObjectPayload, PyObjectRef, PyResult,
+    create_type, DictProtocol, IdProtocol, PyContext, PyFuncArgs, PyObjectRef, PyResult,
     TypeProtocol,
 };
 use crate::VirtualMachine;
@@ -69,7 +69,7 @@ impl<'s> serde::Serialize for PyObjectSerializer<'s> {
                 map.serialize_entry(&key, &self.clone_with_object(&e.1))?;
             }
             map.end()
-        } else if let PyObjectPayload::None = self.pyobject.payload {
+        } else if self.pyobject.is(&self.vm.get_none()) {
             serializer.serialize_none()
         } else {
             Err(serde::ser::Error::custom(format!(

--- a/vm/src/vm.rs
+++ b/vm/src/vm.rs
@@ -473,10 +473,12 @@ impl VirtualMachine {
         // Add missing positional arguments, if we have fewer positional arguments than the
         // function definition calls for
         if nargs < nexpected_args {
-            let available_defaults = match defaults.payload {
-                PyObjectPayload::Sequence { ref elements } => elements.borrow().clone(),
-                PyObjectPayload::None => vec![],
-                _ => panic!("function defaults not tuple or None"),
+            let available_defaults = if defaults.is(&self.get_none()) {
+                vec![]
+            } else if let PyObjectPayload::Sequence { ref elements } = defaults.payload {
+                elements.borrow().clone()
+            } else {
+                panic!("function defaults not tuple or None");
             };
 
             // Given the number of defaults available, check all the arguments for which we


### PR DESCRIPTION
This cleans up all of the attempts to identify None based on its payload.

I went through a few iterations here:

1. PyUnit - wasn't what I wanted. Py* is for converting the payload to/from rust, and you never want to do this when there isn't a payload.
2. AnyRustValue { value: Box::new(()) } - seems silly to box up unit. (I guess eventually PyObjectPayload becomes simply ```Option<Box<dyn std::any::Any>>```?)
3. NoPayload - could be called None but we already had bugs due to payload None and python None being different it seems better to be explicit.