### PR TITLE
Fix Cargo.toml versions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -730,7 +730,7 @@ dependencies = [
 
 [[package]]
 name = "rustpython"
-version = "0.0.1-pre-alpha.1"
+version = "0.0.1"
 dependencies = [
  "clap 2.31.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "env_logger 0.5.10 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -781,7 +781,7 @@ dependencies = [
 
 [[package]]
 name = "rustpython_wasm"
-version = "0.1.0"
+version = "0.1.0-pre-alpha.1"
 dependencies = [
  "cfg-if 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.1.25 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rustpython"
-version = "0.0.1-pre-alpha.1"
+version = "0.0.1"
 authors = ["Windel Bouwman", "Shing Lyu <shing.lyu@gmail.com>"]
 edition = "2018"
 

--- a/wasm/lib/Cargo.toml
+++ b/wasm/lib/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rustpython_wasm"
-version = "0.1.0"
+version = "0.1.0-pre-alpha.1"
 authors = ["Ryan Liddle <ryan@rmliddle.com>"]
 license = "MIT"
 description = "A Python-3 (CPython >= 3.5.0) Interpreter written in Rust, compiled to WASM"


### PR DESCRIPTION
In #602, I meant to change the version of `/wasm/lib/Cargo.toml` but I changed `/Cargo.toml`. This PR fixes that.