### PR TITLE
Dir  

### DIFF
--- a/tests/snippets/builtin_dir.py
+++ b/tests/snippets/builtin_dir.py
@@ -5,7 +5,18 @@ class A:
 
 a = A()
 
-assert "test" in dir(a)
+assert "test" in dir(a), "test not in a"
+assert "test" in dir(A), "test not in A"
+
+class B(A):
+	def __dir__(self):
+		return ('q', 'h')
+
+# Gets sorted and turned into a list
+assert ['h', 'q'] == dir(B())
+
+# This calls type.__dir__ so isn't changed (but inheritance works)!
+assert 'test' in dir(A)
 
 import socket
 

--- a/vm/src/obj/mod.rs
+++ b/vm/src/obj/mod.rs
@@ -18,6 +18,7 @@ pub mod objiter;
 pub mod objlist;
 pub mod objmap;
 pub mod objmemory;
+pub mod objmodule;
 pub mod objnone;
 pub mod objobject;
 pub mod objproperty;

--- a/vm/src/obj/objmodule.rs
+++ b/vm/src/obj/objmodule.rs
@@ -1,0 +1,30 @@
+use crate::frame::ScopeRef;
+use crate::pyobject::{
+    DictProtocol, PyContext, PyFuncArgs, PyObjectPayload, PyObjectRef, PyResult, TypeProtocol,
+};
+use crate::vm::VirtualMachine;
+
+fn module_dir(vm: &mut VirtualMachine, args: PyFuncArgs) -> PyResult {
+    arg_check!(vm, args, required = [(obj, Some(vm.ctx.module_type()))]);
+    let scope = get_scope(obj);
+    let keys = scope
+        .locals
+        .get_key_value_pairs()
+        .iter()
+        .map(|(k, _v)| k.clone())
+        .collect();
+    Ok(vm.ctx.new_list(keys))
+}
+
+pub fn init(context: &PyContext) {
+    let module_type = &context.module_type;
+    context.set_attr(&module_type, "__dir__", context.new_rustfunc(module_dir));
+}
+
+fn get_scope(obj: &PyObjectRef) -> &ScopeRef {
+    if let PyObjectPayload::Module { ref scope, .. } = &obj.payload {
+        &scope
+    } else {
+        panic!("Can't get scope from non-module.")
+    }
+}

--- a/vm/src/obj/objtype.rs
+++ b/vm/src/obj/objtype.rs
@@ -95,10 +95,6 @@ fn _mro(cls: PyObjectRef) -> Option<Vec<PyObjectRef>> {
     }
 }
 
-pub fn base_classes(obj: &PyObjectRef) -> Vec<PyObjectRef> {
-    _mro(obj.typ()).unwrap()
-}
-
 /// Determines if `obj` actually an instance of `cls`, this doesn't call __instancecheck__, so only
 /// use this if `cls` is known to have not overridden the base __instancecheck__ magic method.
 pub fn isinstance(obj: &PyObjectRef, cls: &PyObjectRef) -> bool {

--- a/vm/src/pyobject.rs
+++ b/vm/src/pyobject.rs
@@ -31,6 +31,7 @@ use crate::obj::objiter;
 use crate::obj::objlist;
 use crate::obj::objmap;
 use crate::obj::objmemory;
+use crate::obj::objmodule;
 use crate::obj::objnone;
 use crate::obj::objobject;
 use crate::obj::objproperty;
@@ -317,6 +318,7 @@ impl PyContext {
         objcode::init(&context);
         objframe::init(&context);
         objnone::init(&context);
+        objmodule::init(&context);
         exceptions::init(&context);
         context
     }
@@ -355,6 +357,10 @@ impl PyContext {
 
     pub fn list_type(&self) -> PyObjectRef {
         self.list_type.clone()
+    }
+
+    pub fn module_type(&self) -> PyObjectRef {
+        self.module_type.clone()
     }
 
     pub fn set_type(&self) -> PyObjectRef {


### PR DESCRIPTION
Making dir correct:

dir on type: list attributes of type (including parents)
dir on instance: list attributes of instance, type, and parents.
dir on module: list names in module (and nothing else).

Implemented via __dir__ so it can be customised, and each obj* only inspects its own payload.