### PR TITLE
Fix __class__

### DIFF
--- a/tests/snippets/types_snippet.py
+++ b/tests/snippets/types_snippet.py
@@ -15,5 +15,14 @@ assert type(inst) is cls
 assert type(cls) is metaclass
 assert type(metaclass) is type
 
+assert issubclass(metaclass, type)
+assert isinstance(cls, type)
+
+assert inst.__class__ is cls
+assert cls.__class__ is metaclass
+assert metaclass.__class__ is type
+assert type.__class__ is type
+assert None.__class__ is type(None)
+
 assert isinstance(type, type)
 assert issubclass(type, type)

--- a/vm/src/obj/objfunction.rs
+++ b/vm/src/obj/objfunction.rs
@@ -27,6 +27,18 @@ pub fn init(context: &PyContext) {
         context.new_rustfunc(member_get),
     );
 
+    let data_descriptor_type = &context.data_descriptor_type;
+    context.set_attr(
+        &data_descriptor_type,
+        "__get__",
+        context.new_rustfunc(data_get),
+    );
+    context.set_attr(
+        &data_descriptor_type,
+        "__set__",
+        context.new_rustfunc(data_set),
+    );
+
     let classmethod_type = &context.classmethod_type;
     context.set_attr(
         &classmethod_type,
@@ -77,6 +89,28 @@ fn member_get(vm: &mut VirtualMachine, mut args: PyFuncArgs) -> PyResult {
     match args.shift().get_attr("function") {
         Some(function) => vm.invoke(function, args),
         None => {
+            let attribute_error = vm.context().exceptions.attribute_error.clone();
+            Err(vm.new_exception(attribute_error, String::from("Attribute Error")))
+        }
+    }
+}
+
+fn data_get(vm: &mut VirtualMachine, mut args: PyFuncArgs) -> PyResult {
+    match args.shift().get_attr("fget") {
+        Some(function) => vm.invoke(function, args),
+        None => {
+            println!("A");
+            let attribute_error = vm.context().exceptions.attribute_error.clone();
+            Err(vm.new_exception(attribute_error, String::from("Attribute Error")))
+        }
+    }
+}
+
+fn data_set(vm: &mut VirtualMachine, mut args: PyFuncArgs) -> PyResult {
+    match args.shift().get_attr("fset") {
+        Some(function) => vm.invoke(function, args),
+        None => {
+            println!("B");
             let attribute_error = vm.context().exceptions.attribute_error.clone();
             Err(vm.new_exception(attribute_error, String::from("Attribute Error")))
         }

--- a/vm/src/obj/objfunction.rs
+++ b/vm/src/obj/objfunction.rs
@@ -99,7 +99,6 @@ fn data_get(vm: &mut VirtualMachine, mut args: PyFuncArgs) -> PyResult {
     match args.shift().get_attr("fget") {
         Some(function) => vm.invoke(function, args),
         None => {
-            println!("A");
             let attribute_error = vm.context().exceptions.attribute_error.clone();
             Err(vm.new_exception(attribute_error, String::from("Attribute Error")))
         }
@@ -110,7 +109,6 @@ fn data_set(vm: &mut VirtualMachine, mut args: PyFuncArgs) -> PyResult {
     match args.shift().get_attr("fset") {
         Some(function) => vm.invoke(function, args),
         None => {
-            println!("B");
             let attribute_error = vm.context().exceptions.attribute_error.clone();
             Err(vm.new_exception(attribute_error, String::from("Attribute Error")))
         }

--- a/vm/src/obj/objobject.rs
+++ b/vm/src/obj/objobject.rs
@@ -195,6 +195,7 @@ fn object_init(vm: &mut VirtualMachine, _args: PyFuncArgs) -> PyResult {
     Ok(vm.ctx.none())
 }
 
+// TODO Use PyClassRef for owner to enforce type
 fn object_class(_obj: PyObjectRef, owner: PyObjectRef, _vm: &mut VirtualMachine) -> PyObjectRef {
     owner
 }

--- a/vm/src/obj/objobject.rs
+++ b/vm/src/obj/objobject.rs
@@ -195,17 +195,15 @@ fn object_init(vm: &mut VirtualMachine, _args: PyFuncArgs) -> PyResult {
     Ok(vm.ctx.none())
 }
 
-fn object_class(vm: &mut VirtualMachine, args: PyFuncArgs) -> PyResult {
-    arg_check!(
-        vm,
-        args,
-        required = [(_obj, None), (owner, Some(vm.ctx.type_type()))]
-    );
-    Ok(owner.clone())
+fn object_class(_obj: PyObjectRef, owner: PyObjectRef, _vm: &mut VirtualMachine) -> PyObjectRef {
+    owner
 }
 
-fn object_class_setter(vm: &mut VirtualMachine, args: PyFuncArgs) -> PyResult {
-    arg_check!(vm, args, required = [(instance, None), (_value, None)]);
+fn object_class_setter(
+    instance: PyObjectRef,
+    _value: PyObjectRef,
+    vm: &mut VirtualMachine,
+) -> PyResult {
     let type_repr = vm.to_pystr(&instance.typ())?;
     Err(vm.new_type_error(format!("can't change class of type '{}'", type_repr)))
 }

--- a/vm/src/obj/objobject.rs
+++ b/vm/src/obj/objobject.rs
@@ -161,6 +161,11 @@ pub fn init(context: &PyContext) {
 
     context.set_attr(&object, "__new__", context.new_rustfunc(new_instance));
     context.set_attr(&object, "__init__", context.new_rustfunc(object_init));
+    context.set_attr(
+        &object,
+        "__class__",
+        context.new_data_descriptor(object_class, object_class_setter),
+    );
     context.set_attr(&object, "__eq__", context.new_rustfunc(object_eq));
     context.set_attr(&object, "__ne__", context.new_rustfunc(object_ne));
     context.set_attr(&object, "__lt__", context.new_rustfunc(object_lt));
@@ -188,6 +193,21 @@ pub fn init(context: &PyContext) {
 
 fn object_init(vm: &mut VirtualMachine, _args: PyFuncArgs) -> PyResult {
     Ok(vm.ctx.none())
+}
+
+fn object_class(vm: &mut VirtualMachine, args: PyFuncArgs) -> PyResult {
+    arg_check!(
+        vm,
+        args,
+        required = [(_obj, None), (owner, Some(vm.ctx.type_type()))]
+    );
+    Ok(owner.clone())
+}
+
+fn object_class_setter(vm: &mut VirtualMachine, args: PyFuncArgs) -> PyResult {
+    arg_check!(vm, args, required = [(instance, None), (_value, None)]);
+    let type_repr = vm.to_pystr(&instance.typ())?;
+    Err(vm.new_type_error(format!("can't change class of type '{}'", type_repr)))
 }
 
 fn object_dict(vm: &mut VirtualMachine, args: PyFuncArgs) -> PyResult {

--- a/vm/src/obj/objtype.rs
+++ b/vm/src/obj/objtype.rs
@@ -39,11 +39,6 @@ pub fn init(context: &PyContext) {
         "__mro__",
         context.new_member_descriptor(type_mro),
     );
-    context.set_attr(
-        &type_type,
-        "__class__",
-        context.new_member_descriptor(type_new),
-    );
     context.set_attr(&type_type, "__repr__", context.new_rustfunc(type_repr));
     context.set_attr(
         &type_type,

--- a/vm/src/pyobject.rs
+++ b/vm/src/pyobject.rs
@@ -667,8 +667,10 @@ impl PyContext {
     }
 
     pub fn new_data_descriptor<
-        G: 'static + Fn(&mut VirtualMachine, PyFuncArgs) -> PyResult,
-        S: 'static + Fn(&mut VirtualMachine, PyFuncArgs) -> PyResult,
+        G: IntoPyNativeFunc<(I, PyObjectRef), T>,
+        S: IntoPyNativeFunc<(I, T), PyResult>,
+        T,
+        I,
     >(
         &self,
         getter: G,


### PR DESCRIPTION
Fixes #583

Moves the \_\_class\_\_ property to object, so lookup of it works properly, this matches CPython. Also to make lookup work the property has to have a \_\_set\_\_ method, at this point it always raises an exception.