### PR TITLE
Py object dict

### DIFF
--- a/vm/src/obj/objdict.rs
+++ b/vm/src/obj/objdict.rs
@@ -342,9 +342,9 @@ pub fn create_type(type_type: PyObjectRef, object_type: PyObjectRef, dict_type: 
     unsafe {
         (*ptr).payload = PyObjectPayload::Class {
             name: String::from("dict"),
-            dict: RefCell::new(HashMap::new()),
             mro: vec![object_type],
         };
+        (*ptr).dict = Some(RefCell::new(HashMap::new()));
         (*ptr).typ = Some(type_type.clone());
     }
 }

--- a/vm/src/obj/objobject.rs
+++ b/vm/src/obj/objobject.rs
@@ -1,5 +1,6 @@
 use super::objstr;
 use super::objtype;
+use crate::function::PyRef;
 use crate::pyobject::{
     AttributeProtocol, DictProtocol, IdProtocol, PyAttributes, PyContext, PyFuncArgs, PyObject,
     PyObjectPayload, PyObjectRef, PyResult, TypeProtocol,
@@ -7,6 +8,10 @@ use crate::pyobject::{
 use crate::vm::VirtualMachine;
 use std::cell::RefCell;
 use std::collections::HashMap;
+
+#[derive(Clone, Debug)]
+pub struct PyInstance;
+pub type PyInstanceRef = PyRef<PyInstance>;
 
 pub fn new_instance(vm: &mut VirtualMachine, mut args: PyFuncArgs) -> PyResult {
     // more or less __new__ operator

--- a/vm/src/pyobject.rs
+++ b/vm/src/pyobject.rs
@@ -674,7 +674,7 @@ impl PyContext {
         };
         PyObject {
             payload: PyObjectPayload::AnyRustValue {
-                value: Box::new(()),
+                value: Box::new(objobject::PyInstance),
             },
             typ: Some(class),
             dict: Some(RefCell::new(dict)),

--- a/vm/src/pyobject.rs
+++ b/vm/src/pyobject.rs
@@ -155,13 +155,8 @@ pub struct PyContext {
 }
 
 fn _nothing() -> PyObjectRef {
-    PyObject {
-        payload: PyObjectPayload::AnyRustValue {
-            value: Box::new(()),
-        },
-        typ: None,
-    }
-    .into_ref()
+    let obj: PyObject = Default::default();
+    obj.into_ref()
 }
 
 pub fn create_type(
@@ -745,10 +740,11 @@ impl Default for PyContext {
 /// This is an actual python object. It consists of a `typ` which is the
 /// python class, and carries some rust payload optionally. This rust
 /// payload can be a rust float or rust int in case of float and int objects.
+#[derive(Default)]
 pub struct PyObject {
     pub payload: PyObjectPayload,
     pub typ: Option<PyObjectRef>,
-    // pub dict: HashMap<String, PyObjectRef>, // __dict__ member
+    pub dict: Option<HashMap<String, PyObjectRef>>, // __dict__ member
 }
 
 pub trait IdProtocol {
@@ -1538,6 +1534,14 @@ pub enum PyObjectPayload {
     },
 }
 
+impl Default for PyObjectPayload {
+    fn default() -> Self {
+        PyObjectPayload::AnyRustValue {
+            value: Box::new(()),
+        }
+    }
+}
+
 impl fmt::Debug for PyObjectPayload {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match self {
@@ -1568,14 +1572,11 @@ impl fmt::Debug for PyObjectPayload {
 }
 
 impl PyObject {
-    pub fn new(
-        payload: PyObjectPayload,
-        /* dict: PyObjectRef,*/ typ: PyObjectRef,
-    ) -> PyObjectRef {
+    pub fn new(payload: PyObjectPayload, typ: PyObjectRef) -> PyObjectRef {
         PyObject {
             payload,
             typ: Some(typ),
-            // dict: HashMap::new(),  // dict,
+            dict: None,
         }
         .into_ref()
     }

--- a/vm/src/vm.rs
+++ b/vm/src/vm.rs
@@ -303,7 +303,6 @@ impl VirtualMachine {
                 ref function,
                 ref object,
             } => self.invoke(function.clone(), args.insert(object.clone())),
-            PyObjectPayload::Instance { .. } => self.call_method(&func_ref, "__call__", args),
             ref payload => {
                 // TODO: is it safe to just invoke __call__ otherwise?
                 trace!("invoke __call__ for: {:?}", payload);


### PR DESCRIPTION
Move attribute dict out to PyObject. This doesn't give us anything yet, but is necessary for subclasses of basic types.