### PR TITLE
Have AnyRustValue actually format with its own Debug impl

### DIFF
--- a/vm/src/pyobject.rs
+++ b/vm/src/pyobject.rs
@@ -1562,7 +1562,7 @@ impl fmt::Debug for PyObjectPayload {
             PyObjectPayload::Instance { .. } => write!(f, "instance"),
             PyObjectPayload::RustFunction { .. } => write!(f, "rust function"),
             PyObjectPayload::Frame { .. } => write!(f, "frame"),
-            PyObjectPayload::AnyRustValue { .. } => write!(f, "some rust value"),
+            PyObjectPayload::AnyRustValue { value } => value.fmt(f),
         }
     }
 }


### PR DESCRIPTION
Since `PyObjectPayload2` is required to be `Debug`, might as well use that impl for `<PyObjectPayload as Debug>::fmt()`.