### PR TITLE
Socket OSError

### DIFF
--- a/tests/snippets/stdlib_socket.py
+++ b/tests/snippets/stdlib_socket.py
@@ -29,8 +29,16 @@ s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
 with assertRaises(TypeError):
 	s.connect(("127.0.0.1", 8888, 8888))
 
+with assertRaises(OSError):
+	# Lets hope nobody is listening on port 1
+	s.connect(("127.0.0.1", 1))
+
 with assertRaises(TypeError):
 	s.bind(("127.0.0.1", 8888, 8888))
+
+with assertRaises(OSError):
+	# Lets hope nobody run this test on machine with ip 1.2.3.4
+	s.bind(("1.2.3.4", 8888))
 
 with assertRaises(TypeError):
 	s.bind((888, 8888))
@@ -73,6 +81,10 @@ assert recv_a == MESSAGE_A
 assert recv_b == MESSAGE_B
 sock1.close()
 sock3.close()
+
+s = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+with assertRaises(OSError):
+	s.bind(("1.2.3.4", 888))
 
 ### Errors
 with assertRaises(OSError):

--- a/tests/snippets/stdlib_socket.py
+++ b/tests/snippets/stdlib_socket.py
@@ -43,6 +43,13 @@ with assertRaises(OSError):
 with assertRaises(TypeError):
 	s.bind((888, 8888))
 
+s.bind(("127.0.0.1", 0))
+with assertRaises(OSError):
+	s.recv(100)
+
+with assertRaises(OSError):
+	s.send(MESSAGE_A)
+
 s.close()
 
 # UDP
@@ -86,6 +93,11 @@ s = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
 with assertRaises(OSError):
 	s.bind(("1.2.3.4", 888))
 
+s.bind(("127.0.0.1", 0))
+with assertRaises(OSError):
+	s.sendto(MESSAGE_A, ("1.2.3.4", 888))
+
+s.close()
 ### Errors
 with assertRaises(OSError):
 	socket.socket(100, socket.SOCK_STREAM)

--- a/tests/snippets/stdlib_socket.py
+++ b/tests/snippets/stdlib_socket.py
@@ -73,3 +73,7 @@ assert recv_a == MESSAGE_A
 assert recv_b == MESSAGE_B
 sock1.close()
 sock3.close()
+
+### Errors
+with assertRaises(OSError):
+	socket.socket(100, socket.SOCK_STREAM)

--- a/tests/snippets/stdlib_socket.py
+++ b/tests/snippets/stdlib_socket.py
@@ -77,3 +77,6 @@ sock3.close()
 ### Errors
 with assertRaises(OSError):
 	socket.socket(100, socket.SOCK_STREAM)
+
+with assertRaises(OSError):
+	socket.socket(socket.AF_INET, 1000)

--- a/tests/snippets/stdlib_socket.py
+++ b/tests/snippets/stdlib_socket.py
@@ -43,6 +43,8 @@ with assertRaises(OSError):
 with assertRaises(TypeError):
 	s.bind((888, 8888))
 
+s.close()
+s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
 s.bind(("127.0.0.1", 0))
 with assertRaises(OSError):
 	s.recv(100)
@@ -92,10 +94,6 @@ sock3.close()
 s = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
 with assertRaises(OSError):
 	s.bind(("1.2.3.4", 888))
-
-s.bind(("127.0.0.1", 0))
-with assertRaises(OSError):
-	s.sendto(MESSAGE_A, ("1.2.3.4", 888))
 
 s.close()
 ### Errors

--- a/vm/src/builtins.rs
+++ b/vm/src/builtins.rs
@@ -802,6 +802,7 @@ pub fn make_module(ctx: &PyContext) -> PyObjectRef {
         "StopIteration" => ctx.exceptions.stop_iteration.clone(),
         "ZeroDivisionError" => ctx.exceptions.zero_division_error.clone(),
         "KeyError" => ctx.exceptions.key_error.clone(),
+        "OSError" => ctx.exceptions.os_error.clone(),
     });
 
     #[cfg(not(target_arch = "wasm32"))]

--- a/vm/src/stdlib/socket.rs
+++ b/vm/src/stdlib/socket.rs
@@ -24,12 +24,12 @@ enum AddressFamily {
 }
 
 impl AddressFamily {
-    fn from_i32(value: i32) -> AddressFamily {
+    fn from_i32(vm: &mut VirtualMachine, value: i32) -> Result<AddressFamily, PyObjectRef> {
         match value {
-            1 => AddressFamily::Unix,
-            2 => AddressFamily::Inet,
-            3 => AddressFamily::Inet6,
-            _ => panic!("Unknown value: {}", value),
+            1 => Ok(AddressFamily::Unix),
+            2 => Ok(AddressFamily::Inet),
+            3 => Ok(AddressFamily::Inet6),
+            _ => Err(vm.new_os_error(format!("Unknown address family value: {}", value))),
         }
     }
 }
@@ -146,7 +146,8 @@ fn socket_new(vm: &mut VirtualMachine, args: PyFuncArgs) -> PyResult {
         ]
     );
 
-    let address_family = AddressFamily::from_i32(objint::get_value(family_int).to_i32().unwrap());
+    let address_family =
+        AddressFamily::from_i32(vm, objint::get_value(family_int).to_i32().unwrap())?;
     let kind = SocketKind::from_i32(objint::get_value(kind_int).to_i32().unwrap());
 
     let socket = RefCell::new(Socket::new(address_family, kind));

--- a/vm/src/stdlib/socket.rs
+++ b/vm/src/stdlib/socket.rs
@@ -172,21 +172,18 @@ fn socket_connect(vm: &mut VirtualMachine, args: PyFuncArgs) -> PyResult {
     let mut socket = get_socket(zelf);
 
     match socket.socket_kind {
-        SocketKind::Stream => {
-            if let Ok(stream) = TcpStream::connect(address_string) {
+        SocketKind::Stream => match TcpStream::connect(address_string) {
+            Ok(stream) => {
                 socket.con = Some(Connection::TcpStream(stream));
                 Ok(vm.get_none())
-            } else {
-                // TODO: Socket error
-                Err(vm.new_type_error("socket failed".to_string()))
             }
-        }
+            Err(s) => Err(vm.new_os_error(s.to_string())),
+        },
         SocketKind::Dgram => {
             if let Some(Connection::UdpSocket(con)) = &socket.con {
                 match con.connect(address_string) {
                     Ok(_) => Ok(vm.get_none()),
-                    // TODO: Socket error
-                    Err(_) => Err(vm.new_type_error("socket failed".to_string())),
+                    Err(s) => Err(vm.new_os_error(s.to_string())),
                 }
             } else {
                 Err(vm.new_type_error("".to_string()))
@@ -207,24 +204,20 @@ fn socket_bind(vm: &mut VirtualMachine, args: PyFuncArgs) -> PyResult {
     let mut socket = get_socket(zelf);
 
     match socket.socket_kind {
-        SocketKind::Stream => {
-            if let Ok(stream) = TcpListener::bind(address_string) {
+        SocketKind::Stream => match TcpListener::bind(address_string) {
+            Ok(stream) => {
                 socket.con = Some(Connection::TcpListener(stream));
                 Ok(vm.get_none())
-            } else {
-                // TODO: Socket error
-                Err(vm.new_type_error("socket failed".to_string()))
             }
-        }
-        SocketKind::Dgram => {
-            if let Ok(dgram) = UdpSocket::bind(address_string) {
+            Err(s) => Err(vm.new_os_error(s.to_string())),
+        },
+        SocketKind::Dgram => match UdpSocket::bind(address_string) {
+            Ok(dgram) => {
                 socket.con = Some(Connection::UdpSocket(dgram));
                 Ok(vm.get_none())
-            } else {
-                // TODO: Socket error
-                Err(vm.new_type_error("socket failed".to_string()))
             }
-        }
+            Err(s) => Err(vm.new_os_error(s.to_string())),
+        },
     }
 }
 

--- a/vm/src/stdlib/socket.rs
+++ b/vm/src/stdlib/socket.rs
@@ -41,11 +41,11 @@ enum SocketKind {
 }
 
 impl SocketKind {
-    fn from_i32(value: i32) -> SocketKind {
+    fn from_i32(vm: &mut VirtualMachine, value: i32) -> Result<SocketKind, PyObjectRef> {
         match value {
-            1 => SocketKind::Stream,
-            2 => SocketKind::Dgram,
-            _ => panic!("Unknown value: {}", value),
+            1 => Ok(SocketKind::Stream),
+            2 => Ok(SocketKind::Dgram),
+            _ => Err(vm.new_os_error(format!("Unknown socket kind value: {}", value))),
         }
     }
 }
@@ -148,7 +148,7 @@ fn socket_new(vm: &mut VirtualMachine, args: PyFuncArgs) -> PyResult {
 
     let address_family =
         AddressFamily::from_i32(vm, objint::get_value(family_int).to_i32().unwrap())?;
-    let kind = SocketKind::from_i32(objint::get_value(kind_int).to_i32().unwrap());
+    let kind = SocketKind::from_i32(vm, objint::get_value(kind_int).to_i32().unwrap())?;
 
     let socket = RefCell::new(Socket::new(address_family, kind));
 


### PR DESCRIPTION
Change many socket errors to OSError with indicative error message. For example:
```py
>>>>> import socket
>>>>> s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
>>>>> s.connect(("127.0.0.1", 1))
Traceback (most recent call last):
  File <stdin>, line 0, in <module>
OSError: Connection refused (os error 111)
```