### PR TITLE
Unify property like objects

### DIFF
--- a/tests/snippets/class.py
+++ b/tests/snippets/class.py
@@ -16,22 +16,6 @@ assert foo.x == 5
 assert foo.square() == 25
 
 
-class Fubar:
-    def __init__(self):
-        self.x = 100
-
-    @property
-    def foo(self):
-        value = self.x
-        self.x += 1
-        return value
-
-
-f = Fubar()
-assert f.foo == 100
-assert f.foo == 101
-
-
 class Bar:
     """ W00t """
     def __init__(self, x):

--- a/tests/snippets/property.py
+++ b/tests/snippets/property.py
@@ -1,0 +1,32 @@
+from testutils import assertRaises
+
+
+class Fubar:
+    def __init__(self):
+        self.x = 100
+
+    @property
+    def foo(self):
+        value = self.x
+        self.x += 1
+        return value
+
+
+f = Fubar()
+assert f.foo == 100
+assert f.foo == 101
+
+
+null_property = property()
+assert type(null_property) is property
+
+p = property(lambda x: x[0])
+assert p.__get__((2,), tuple) == 2
+# TODO owner parameter is optional
+# assert p.__get__((2,)) == 2
+
+with assertRaises(AttributeError):
+    null_property.__get__((), tuple)
+
+with assertRaises(TypeError):
+    property.__new__(object)

--- a/vm/src/function.rs
+++ b/vm/src/function.rs
@@ -3,6 +3,7 @@ use std::marker::PhantomData;
 use std::ops::Deref;
 
 use crate::obj::objtype;
+use crate::obj::objtype::PyClassRef;
 use crate::pyobject::{
     IntoPyObject, PyContext, PyObject, PyObjectPayload, PyObjectPayload2, PyObjectRef, PyResult,
     TryFromObject, TypeProtocol,
@@ -42,6 +43,25 @@ where
                 T::required_type(ctx),
             ),
             _payload: PhantomData,
+        }
+    }
+
+    pub fn new_with_type(vm: &mut VirtualMachine, payload: T, cls: PyClassRef) -> PyResult<Self> {
+        let required_type = T::required_type(&vm.ctx);
+        if objtype::issubclass(&cls.obj, &required_type) {
+            Ok(PyRef {
+                obj: PyObject::new(
+                    PyObjectPayload::AnyRustValue {
+                        value: Box::new(payload),
+                    },
+                    cls.obj,
+                ),
+                _payload: PhantomData,
+            })
+        } else {
+            let subtype = vm.to_pystr(&cls.obj)?;
+            let basetype = vm.to_pystr(&required_type)?;
+            Err(vm.new_type_error(format!("{} is not a subtype of {}", subtype, basetype)))
         }
     }
 }

--- a/vm/src/obj/objcode.rs
+++ b/vm/src/obj/objcode.rs
@@ -47,7 +47,7 @@ pub fn init(context: &PyContext) {
         ("co_kwonlyargcount", code_co_kwonlyargcount),
         ("co_name", code_co_name),
     ] {
-        context.set_attr(code_type, name, context.new_member_descriptor(f))
+        context.set_attr(code_type, name, context.new_property(f))
     }
 }
 
@@ -83,8 +83,7 @@ fn member_code_obj(vm: &mut VirtualMachine, args: PyFuncArgs) -> PyResult<byteco
         vm,
         args,
         required = [
-            (zelf, Some(vm.ctx.code_type())),
-            (_cls, Some(vm.ctx.type_type()))
+            (zelf, Some(vm.ctx.code_type()))
         ]
     );
     Ok(get_value(zelf))

--- a/vm/src/obj/objcode.rs
+++ b/vm/src/obj/objcode.rs
@@ -79,13 +79,7 @@ fn code_repr(vm: &mut VirtualMachine, args: PyFuncArgs) -> PyResult {
 }
 
 fn member_code_obj(vm: &mut VirtualMachine, args: PyFuncArgs) -> PyResult<bytecode::CodeObject> {
-    arg_check!(
-        vm,
-        args,
-        required = [
-            (zelf, Some(vm.ctx.code_type()))
-        ]
-    );
+    arg_check!(vm, args, required = [(zelf, Some(vm.ctx.code_type()))]);
     Ok(get_value(zelf))
 }
 

--- a/vm/src/obj/objfunction.rs
+++ b/vm/src/obj/objfunction.rs
@@ -10,7 +10,7 @@ pub fn init(context: &PyContext) {
     context.set_attr(
         &function_type,
         "__code__",
-        context.new_member_descriptor(function_code),
+        context.new_property(function_code),
     );
 
     let builtin_function_or_method_type = &context.builtin_function_or_method_type;
@@ -20,24 +20,6 @@ pub fn init(context: &PyContext) {
         context.new_rustfunc(bind_method),
     );
 
-    let member_descriptor_type = &context.member_descriptor_type;
-    context.set_attr(
-        &member_descriptor_type,
-        "__get__",
-        context.new_rustfunc(member_get),
-    );
-
-    let data_descriptor_type = &context.data_descriptor_type;
-    context.set_attr(
-        &data_descriptor_type,
-        "__get__",
-        context.new_rustfunc(data_get),
-    );
-    context.set_attr(
-        &data_descriptor_type,
-        "__set__",
-        context.new_rustfunc(data_set),
-    );
 
     let classmethod_type = &context.classmethod_type;
     context.set_attr(
@@ -82,36 +64,6 @@ fn function_code(vm: &mut VirtualMachine, args: PyFuncArgs) -> PyResult {
     match args.args[0].payload {
         PyObjectPayload::Function { ref code, .. } => Ok(code.clone()),
         _ => Err(vm.new_type_error("no code".to_string())),
-    }
-}
-
-fn member_get(vm: &mut VirtualMachine, mut args: PyFuncArgs) -> PyResult {
-    match args.shift().get_attr("function") {
-        Some(function) => vm.invoke(function, args),
-        None => {
-            let attribute_error = vm.context().exceptions.attribute_error.clone();
-            Err(vm.new_exception(attribute_error, String::from("Attribute Error")))
-        }
-    }
-}
-
-fn data_get(vm: &mut VirtualMachine, mut args: PyFuncArgs) -> PyResult {
-    match args.shift().get_attr("fget") {
-        Some(function) => vm.invoke(function, args),
-        None => {
-            let attribute_error = vm.context().exceptions.attribute_error.clone();
-            Err(vm.new_exception(attribute_error, String::from("Attribute Error")))
-        }
-    }
-}
-
-fn data_set(vm: &mut VirtualMachine, mut args: PyFuncArgs) -> PyResult {
-    match args.shift().get_attr("fset") {
-        Some(function) => vm.invoke(function, args),
-        None => {
-            let attribute_error = vm.context().exceptions.attribute_error.clone();
-            Err(vm.new_exception(attribute_error, String::from("Attribute Error")))
-        }
     }
 }
 

--- a/vm/src/obj/objfunction.rs
+++ b/vm/src/obj/objfunction.rs
@@ -20,7 +20,6 @@ pub fn init(context: &PyContext) {
         context.new_rustfunc(bind_method),
     );
 
-
     let classmethod_type = &context.classmethod_type;
     context.set_attr(
         &classmethod_type,

--- a/vm/src/obj/objobject.rs
+++ b/vm/src/obj/objobject.rs
@@ -1,6 +1,7 @@
 use super::objstr;
 use super::objtype;
 use crate::function::PyRef;
+use crate::obj::objproperty::PropertyBuilder;
 use crate::pyobject::{
     AttributeProtocol, DictProtocol, IdProtocol, PyAttributes, PyContext, PyFuncArgs, PyObject,
     PyObjectPayload, PyObjectRef, PyResult, TypeProtocol,
@@ -8,7 +9,6 @@ use crate::pyobject::{
 use crate::vm::VirtualMachine;
 use std::cell::RefCell;
 use std::collections::HashMap;
-use crate::obj::objproperty::PropertyBuilder;
 
 #[derive(Clone, Debug)]
 pub struct PyInstance;
@@ -174,7 +174,8 @@ pub fn init(context: &PyContext) {
         "__class__",
         PropertyBuilder::new(context)
             .add_getter(object_class)
-            .add_setter(object_class_setter).create(),
+            .add_setter(object_class_setter)
+            .create(),
     );
     context.set_attr(&object, "__eq__", context.new_rustfunc(object_eq));
     context.set_attr(&object, "__ne__", context.new_rustfunc(object_ne));
@@ -183,11 +184,7 @@ pub fn init(context: &PyContext) {
     context.set_attr(&object, "__gt__", context.new_rustfunc(object_gt));
     context.set_attr(&object, "__ge__", context.new_rustfunc(object_ge));
     context.set_attr(&object, "__delattr__", context.new_rustfunc(object_delattr));
-    context.set_attr(
-        &object,
-        "__dict__",
-        context.new_property(object_dict),
-    );
+    context.set_attr(&object, "__dict__", context.new_property(object_dict));
     context.set_attr(&object, "__dir__", context.new_rustfunc(object_dir));
     context.set_attr(&object, "__hash__", context.new_rustfunc(object_hash));
     context.set_attr(&object, "__str__", context.new_rustfunc(object_str));

--- a/vm/src/obj/objproperty.rs
+++ b/vm/src/obj/objproperty.rs
@@ -2,17 +2,20 @@
 
 */
 
-use crate::pyobject::{PyContext, PyFuncArgs, PyObject, PyObjectRef, PyObjectPayload, PyObjectPayload2, PyResult, TypeProtocol};
-use crate::pyobject::IntoPyNativeFunc;
-use crate::VirtualMachine;
 use crate::function::PyRef;
-use std::marker::PhantomData;
+use crate::obj::objstr::PyStringRef;
 use crate::obj::objtype::PyClassRef;
+use crate::pyobject::IntoPyNativeFunc;
+use crate::pyobject::{
+    OptionalArg, PyContext, PyObject, PyObjectPayload, PyObjectPayload2, PyObjectRef, PyResult,
+};
+use crate::VirtualMachine;
+use std::marker::PhantomData;
 
 /// Read-only property, doesn't have __set__ or __delete__
 #[derive(Debug)]
 pub struct PyReadOnlyProperty {
-    getter: PyObjectRef
+    getter: PyObjectRef,
 }
 
 impl PyObjectPayload2 for PyReadOnlyProperty {
@@ -34,7 +37,7 @@ impl PyReadOnlyPropertyRef {
 pub struct PyProperty {
     getter: Option<PyObjectRef>,
     setter: Option<PyObjectRef>,
-    deleter: Option<PyObjectRef>
+    deleter: Option<PyObjectRef>,
 }
 
 impl PyObjectPayload2 for PyProperty {
@@ -46,6 +49,25 @@ impl PyObjectPayload2 for PyProperty {
 pub type PyPropertyRef = PyRef<PyProperty>;
 
 impl PyPropertyRef {
+    fn new_property(
+        cls: PyClassRef,
+        fget: OptionalArg<PyObjectRef>,
+        fset: OptionalArg<PyObjectRef>,
+        fdel: OptionalArg<PyObjectRef>,
+        _doc: OptionalArg<PyStringRef>,
+        vm: &mut VirtualMachine,
+    ) -> PyResult<PyPropertyRef> {
+        Self::new_with_type(
+            vm,
+            PyProperty {
+                getter: fget.into_option(),
+                setter: fset.into_option(),
+                deleter: fdel.into_option(),
+            },
+            cls,
+        )
+    }
+
     fn get(self, obj: PyObjectRef, _owner: PyClassRef, vm: &mut VirtualMachine) -> PyResult {
         if let Some(getter) = self.getter.as_ref() {
             vm.invoke(getter.clone(), obj)
@@ -75,9 +97,8 @@ pub struct PropertyBuilder<'a, T> {
     ctx: &'a PyContext,
     getter: Option<PyObjectRef>,
     setter: Option<PyObjectRef>,
-    _return: PhantomData<T>
+    _return: PhantomData<T>,
 }
-
 
 impl<'a, T> PropertyBuilder<'a, T> {
     pub fn new(ctx: &'a PyContext) -> Self {
@@ -85,27 +106,27 @@ impl<'a, T> PropertyBuilder<'a, T> {
             ctx,
             getter: None,
             setter: None,
-            _return: PhantomData
+            _return: PhantomData,
         }
     }
 
-    pub fn add_getter<I, F:IntoPyNativeFunc<I, T>>(self, func: F) -> Self {
+    pub fn add_getter<I, F: IntoPyNativeFunc<I, T>>(self, func: F) -> Self {
         let func = self.ctx.new_rustfunc(func);
         Self {
             ctx: self.ctx,
             getter: Some(func),
             setter: self.setter,
-            _return: PhantomData
+            _return: PhantomData,
         }
     }
 
-    pub fn add_setter<I, F:IntoPyNativeFunc<(I, T), PyResult>>(self, func: F) -> Self {
+    pub fn add_setter<I, F: IntoPyNativeFunc<(I, T), PyResult>>(self, func: F) -> Self {
         let func = self.ctx.new_rustfunc(func);
         Self {
             ctx: self.ctx,
             getter: self.getter,
             setter: Some(func),
-            _return: PhantomData
+            _return: PhantomData,
         }
     }
 
@@ -114,30 +135,31 @@ impl<'a, T> PropertyBuilder<'a, T> {
             let payload = PyProperty {
                 getter: self.getter.clone(),
                 setter: self.setter.clone(),
-                deleter: None
+                deleter: None,
             };
 
             PyObject::new(
                 PyObjectPayload::AnyRustValue {
-                    value: Box::new(payload)
+                    value: Box::new(payload),
                 },
                 self.ctx.property_type(),
             )
         } else {
             let payload = PyReadOnlyProperty {
-                getter: self.getter.expect("One of add_getter/add_setter must be called when constructing a property")
+                getter: self.getter.expect(
+                    "One of add_getter/add_setter must be called when constructing a property",
+                ),
             };
 
             PyObject::new(
                 PyObjectPayload::AnyRustValue {
-                    value: Box::new(payload)
+                    value: Box::new(payload),
                 },
                 self.ctx.readonly_property_type(),
             )
         }
     }
 }
-
 
 pub fn init(context: &PyContext) {
     extend_class!(context, &context.readonly_property_type, {
@@ -173,20 +195,11 @@ pub fn init(context: &PyContext) {
          del self._x";
 
     extend_class!(context, &context.property_type, {
-        "__new__" => context.new_rustfunc(property_new),
+        "__new__" => context.new_rustfunc(PyPropertyRef::new_property),
         "__doc__" => context.new_str(property_doc.to_string()),
 
         "__get__" => context.new_rustfunc(PyPropertyRef::get),
         "__set__" => context.new_rustfunc(PyPropertyRef::set),
         "__delete__" => context.new_rustfunc(PyPropertyRef::delete),
     });
-}
-
-fn property_new(vm: &mut VirtualMachine, args: PyFuncArgs) -> PyResult {
-    trace!("property.__new__ {:?}", args.args);
-    arg_check!(vm, args, required = [(cls, None), (fget, None)]);
-
-    let py_obj = vm.ctx.new_instance(cls.clone(), None);
-    vm.ctx.set_attr(&py_obj, "fget", fget.clone());
-    Ok(py_obj)
 }

--- a/vm/src/obj/objtype.rs
+++ b/vm/src/obj/objtype.rs
@@ -50,11 +50,7 @@ pub fn init(context: &PyContext) {
 
     context.set_attr(&type_type, "__call__", context.new_rustfunc(type_call));
     context.set_attr(&type_type, "__new__", context.new_rustfunc(type_new));
-    context.set_attr(
-        &type_type,
-        "__mro__",
-        context.new_property(type_mro),
-    );
+    context.set_attr(&type_type, "__mro__", context.new_property(type_mro));
     context.set_attr(&type_type, "__repr__", context.new_rustfunc(type_repr));
     context.set_attr(
         &type_type,
@@ -81,13 +77,7 @@ pub fn init(context: &PyContext) {
 }
 
 fn type_mro(vm: &mut VirtualMachine, args: PyFuncArgs) -> PyResult {
-    arg_check!(
-        vm,
-        args,
-        required = [
-            (cls, Some(vm.ctx.type_type()))
-        ]
-    );
+    arg_check!(vm, args, required = [(cls, Some(vm.ctx.type_type()))]);
     match _mro(cls.clone()) {
         Some(mro) => Ok(vm.context().new_tuple(mro)),
         None => Err(vm.new_type_error("Only classes have an MRO.".to_string())),

--- a/vm/src/obj/objtype.rs
+++ b/vm/src/obj/objtype.rs
@@ -53,7 +53,7 @@ pub fn init(context: &PyContext) {
     context.set_attr(
         &type_type,
         "__mro__",
-        context.new_member_descriptor(type_mro),
+        context.new_property(type_mro),
     );
     context.set_attr(&type_type, "__repr__", context.new_rustfunc(type_repr));
     context.set_attr(
@@ -85,8 +85,7 @@ fn type_mro(vm: &mut VirtualMachine, args: PyFuncArgs) -> PyResult {
         vm,
         args,
         required = [
-            (cls, Some(vm.ctx.type_type())),
-            (_typ, Some(vm.ctx.type_type()))
+            (cls, Some(vm.ctx.type_type()))
         ]
     );
     match _mro(cls.clone()) {

--- a/vm/src/pyobject.rs
+++ b/vm/src/pyobject.rs
@@ -192,7 +192,8 @@ impl PyContext {
             &dict_type,
         );
         let property_type = create_type("property", &type_type, &object_type, &dict_type);
-        let readonly_property_type = create_type("readonly_property", &type_type, &object_type, &dict_type);
+        let readonly_property_type =
+            create_type("readonly_property", &type_type, &object_type, &dict_type);
         let super_type = create_type("super", &type_type, &object_type, &dict_type);
         let generator_type = create_type("generator", &type_type, &object_type, &dict_type);
         let bound_method_type = create_type("method", &type_type, &object_type, &dict_type);
@@ -947,7 +948,6 @@ impl From<PyObjectRef> for PyFuncArgs {
         }
     }
 }
-
 
 impl PyFuncArgs {
     pub fn new(mut args: Vec<PyObjectRef>, kwarg_names: Vec<String>) -> PyFuncArgs {

--- a/vm/src/pyobject.rs
+++ b/vm/src/pyobject.rs
@@ -147,6 +147,7 @@ pub struct PyContext {
     pub function_type: PyObjectRef,
     pub builtin_function_or_method_type: PyObjectRef,
     pub property_type: PyObjectRef,
+    pub readonly_property_type: PyObjectRef,
     pub module_type: PyObjectRef,
     pub bound_method_type: PyObjectRef,
     pub member_descriptor_type: PyObjectRef,
@@ -197,6 +198,7 @@ impl PyContext {
             &dict_type,
         );
         let property_type = create_type("property", &type_type, &object_type, &dict_type);
+        let readonly_property_type = create_type("readonly_property", &type_type, &object_type, &dict_type);
         let super_type = create_type("super", &type_type, &object_type, &dict_type);
         let generator_type = create_type("generator", &type_type, &object_type, &dict_type);
         let bound_method_type = create_type("method", &type_type, &object_type, &dict_type);
@@ -297,6 +299,7 @@ impl PyContext {
             builtin_function_or_method_type,
             super_type,
             property_type,
+            readonly_property_type,
             generator_type,
             module_type,
             bound_method_type,
@@ -446,6 +449,10 @@ impl PyContext {
 
     pub fn property_type(&self) -> PyObjectRef {
         self.property_type.clone()
+    }
+
+    pub fn readonly_property_type(&self) -> PyObjectRef {
+        self.readonly_property_type.clone()
     }
 
     pub fn classmethod_type(&self) -> PyObjectRef {
@@ -961,6 +968,16 @@ impl From<Vec<PyObjectRef>> for PyFuncArgs {
         }
     }
 }
+
+impl From<PyObjectRef> for PyFuncArgs {
+    fn from(arg: PyObjectRef) -> Self {
+        PyFuncArgs {
+            args: vec![arg],
+            kwargs: vec![],
+        }
+    }
+}
+
 
 impl PyFuncArgs {
     pub fn new(mut args: Vec<PyObjectRef>, kwarg_names: Vec<String>) -> PyFuncArgs {

--- a/vm/src/pyobject.rs
+++ b/vm/src/pyobject.rs
@@ -151,8 +151,6 @@ pub struct PyContext {
     pub readonly_property_type: PyObjectRef,
     pub module_type: PyObjectRef,
     pub bound_method_type: PyObjectRef,
-    pub member_descriptor_type: PyObjectRef,
-    pub data_descriptor_type: PyObjectRef,
     pub object: PyObjectRef,
     pub exceptions: exceptions::ExceptionZoo,
 }
@@ -198,10 +196,6 @@ impl PyContext {
         let super_type = create_type("super", &type_type, &object_type, &dict_type);
         let generator_type = create_type("generator", &type_type, &object_type, &dict_type);
         let bound_method_type = create_type("method", &type_type, &object_type, &dict_type);
-        let member_descriptor_type =
-            create_type("member_descriptor", &type_type, &object_type, &dict_type);
-        let data_descriptor_type =
-            create_type("data_descriptor", &type_type, &object_type, &dict_type);
         let str_type = create_type("str", &type_type, &object_type, &dict_type);
         let list_type = create_type("list", &type_type, &object_type, &dict_type);
         let set_type = create_type("set", &type_type, &object_type, &dict_type);
@@ -299,8 +293,6 @@ impl PyContext {
             generator_type,
             module_type,
             bound_method_type,
-            member_descriptor_type,
-            data_descriptor_type,
             type_type,
             exceptions,
         };
@@ -465,12 +457,6 @@ impl PyContext {
 
     pub fn bound_method_type(&self) -> PyObjectRef {
         self.bound_method_type.clone()
-    }
-    pub fn member_descriptor_type(&self) -> PyObjectRef {
-        self.member_descriptor_type.clone()
-    }
-    pub fn data_descriptor_type(&self) -> PyObjectRef {
-        self.data_descriptor_type.clone()
     }
 
     pub fn type_type(&self) -> PyObjectRef {
@@ -640,10 +626,7 @@ impl PyContext {
     where
         F: IntoPyNativeFunc<T, R>,
     {
-        let fget = self.new_rustfunc(f);
-        let py_obj = self.new_instance(self.property_type(), None);
-        self.set_attr(&py_obj, "fget", fget);
-        py_obj
+        PropertyBuilder::new(self).add_getter(f).create()
     }
 
     pub fn new_code_object(&self, code: bytecode::CodeObject) -> PyObjectRef {
@@ -676,31 +659,6 @@ impl PyContext {
             PyObjectPayload::BoundMethod { function, object },
             self.bound_method_type(),
         )
-    }
-
-    pub fn new_member_descriptor<F: 'static + Fn(&mut VirtualMachine, PyFuncArgs) -> PyResult>(
-        &self,
-        function: F,
-    ) -> PyObjectRef {
-        let mut dict = PyAttributes::new();
-        dict.insert("function".to_string(), self.new_rustfunc(function));
-        self.new_instance(self.member_descriptor_type(), Some(dict))
-    }
-
-    pub fn new_data_descriptor<
-        G: IntoPyNativeFunc<(I, PyObjectRef), T>,
-        S: IntoPyNativeFunc<(I, T), PyResult>,
-        T,
-        I,
-    >(
-        &self,
-        getter: G,
-        setter: S,
-    ) -> PyObjectRef {
-        let mut dict = PyAttributes::new();
-        dict.insert("fget".to_string(), self.new_rustfunc(getter));
-        dict.insert("fset".to_string(), self.new_rustfunc(setter));
-        self.new_instance(self.data_descriptor_type(), Some(dict))
     }
 
     pub fn new_instance(&self, class: PyObjectRef, dict: Option<PyAttributes>) -> PyObjectRef {
@@ -1292,6 +1250,7 @@ pub enum OptionalArg<T> {
 }
 
 use self::OptionalArg::*;
+use crate::obj::objproperty::PropertyBuilder;
 
 impl<T> OptionalArg<T> {
     pub fn into_option(self) -> Option<T> {

--- a/vm/src/vm.rs
+++ b/vm/src/vm.rs
@@ -135,7 +135,7 @@ impl VirtualMachine {
     }
 
     pub fn new_attribute_error(&mut self, msg: String) -> PyObjectRef {
-        let type_error = self.ctx.exceptions.arithmetic_error.clone();
+        let type_error = self.ctx.exceptions.attribute_error.clone();
         self.new_exception(type_error, msg)
     }
 

--- a/vm/src/vm.rs
+++ b/vm/src/vm.rs
@@ -132,6 +132,11 @@ impl VirtualMachine {
         self.invoke(exc_type, args).unwrap()
     }
 
+    pub fn new_attribute_error(&mut self, msg: String) -> PyObjectRef {
+        let type_error = self.ctx.exceptions.arithmetic_error.clone();
+        self.new_exception(type_error, msg)
+    }
+
     pub fn new_type_error(&mut self, msg: String) -> PyObjectRef {
         let type_error = self.ctx.exceptions.type_error.clone();
         self.new_exception(type_error, msg)


### PR DESCRIPTION
Followup to #619, migrates property to the newer style and unify property like objects by:

* making data descriptors an actual property, removing the need for an extra class. 
* making any property created from rust, which only has a getter(any use of vm.new_property) a readonly property. This means they can be overridden by the instance dict, hopefully leading to more consistent behavior.
* changes member descriptors to be properties