### PR TITLE
Move weakref object type to obj module

### DIFF
--- a/vm/src/obj/mod.rs
+++ b/vm/src/obj/mod.rs
@@ -31,4 +31,5 @@ pub mod objstr;
 pub mod objsuper;
 pub mod objtuple;
 pub mod objtype;
+pub mod objweakref;
 pub mod objzip;

--- a/vm/src/obj/objweakref.rs
+++ b/vm/src/obj/objweakref.rs
@@ -1,0 +1,50 @@
+use crate::function::PyRef;
+use crate::obj::objtype::PyClassRef;
+use crate::pyobject::PyObjectPayload2;
+use crate::pyobject::{PyContext, PyObject, PyObjectRef, PyResult};
+use crate::vm::VirtualMachine;
+
+use std::rc::{Rc, Weak};
+
+#[derive(Debug)]
+pub struct PyWeak {
+    referent: Weak<PyObject>,
+}
+
+impl PyWeak {
+    pub fn downgrade(obj: PyObjectRef) -> PyWeak {
+        PyWeak {
+            referent: Rc::downgrade(&obj),
+        }
+    }
+
+    pub fn upgrade(&self) -> Option<PyObjectRef> {
+        self.referent.upgrade()
+    }
+}
+
+impl PyObjectPayload2 for PyWeak {
+    fn required_type(ctx: &PyContext) -> PyObjectRef {
+        ctx.weakref_type()
+    }
+}
+
+pub type PyWeakRef = PyRef<PyWeak>;
+
+impl PyWeakRef {
+    // TODO callbacks
+    fn create(cls: PyClassRef, referent: PyObjectRef, vm: &mut VirtualMachine) -> PyResult<Self> {
+        Self::new_with_type(vm, PyWeak::downgrade(referent), cls)
+    }
+
+    fn call(self, vm: &mut VirtualMachine) -> PyObjectRef {
+        self.referent.upgrade().unwrap_or_else(|| vm.get_none())
+    }
+}
+
+pub fn init(context: &PyContext) {
+    extend_class!(context, &context.weakref_type, {
+        "__new__" => context.new_rustfunc(PyWeakRef::create),
+        "__call__" => context.new_rustfunc(PyWeakRef::call)
+    });
+}

--- a/vm/src/pyobject.rs
+++ b/vm/src/pyobject.rs
@@ -1537,11 +1537,8 @@ impl PyObject {
     }
 
     pub fn payload<T: PyObjectPayload2>(&self) -> Option<&T> {
-        if let PyObjectPayload::AnyRustValue { ref value } = self.payload {
-            value.downcast_ref()
-        } else {
-            None
-        }
+        let PyObjectPayload::AnyRustValue { ref value } = self.payload;
+        value.downcast_ref()
     }
 }
 

--- a/vm/src/stdlib/re.rs
+++ b/vm/src/stdlib/re.rs
@@ -191,20 +191,19 @@ fn match_end(vm: &mut VirtualMachine, args: PyFuncArgs) -> PyResult {
 
 /// Retrieve inner rust regex from python object:
 fn get_regex<'a>(obj: &'a PyObjectRef) -> &'a Regex {
-    if let PyObjectPayload::AnyRustValue { ref value } = obj.payload {
-        if let Some(regex) = value.downcast_ref::<Regex>() {
-            return regex;
-        }
+    // TODO: Regex shouldn't be stored in payload directly, create newtype wrapper
+    let PyObjectPayload::AnyRustValue { ref value } = obj.payload;
+    if let Some(regex) = value.downcast_ref::<Regex>() {
+        return regex;
     }
     panic!("Inner error getting regex {:?}", obj);
 }
 
 /// Retrieve inner rust match from python object:
 fn get_match<'a>(obj: &'a PyObjectRef) -> &'a PyMatch {
-    if let PyObjectPayload::AnyRustValue { ref value } = obj.payload {
-        if let Some(value) = value.downcast_ref::<PyMatch>() {
-            return value;
-        }
+    let PyObjectPayload::AnyRustValue { ref value } = obj.payload;
+    if let Some(value) = value.downcast_ref::<PyMatch>() {
+        return value;
     }
     panic!("Inner error getting match {:?}", obj);
 }

--- a/vm/src/stdlib/socket.rs
+++ b/vm/src/stdlib/socket.rs
@@ -127,10 +127,9 @@ impl Socket {
 }
 
 fn get_socket<'a>(obj: &'a PyObjectRef) -> impl DerefMut<Target = Socket> + 'a {
-    if let PyObjectPayload::AnyRustValue { ref value } = obj.payload {
-        if let Some(socket) = value.downcast_ref::<RefCell<Socket>>() {
-            return socket.borrow_mut();
-        }
+    let PyObjectPayload::AnyRustValue { ref value } = obj.payload;
+    if let Some(socket) = value.downcast_ref::<RefCell<Socket>>() {
+        return socket.borrow_mut();
     }
     panic!("Inner error getting socket {:?}", obj);
 }

--- a/vm/src/stdlib/weakref.rs
+++ b/vm/src/stdlib/weakref.rs
@@ -5,51 +5,10 @@
 //! - [rust weak struct](https://doc.rust-lang.org/std/rc/struct.Weak.html)
 //!
 
-use crate::pyobject::{
-    PyContext, PyFuncArgs, PyObject, PyObjectPayload, PyObjectRef, PyObjectWeakRef, PyResult,
-    TypeProtocol,
-};
-use crate::VirtualMachine;
-use std::rc::Rc;
+use super::super::pyobject::{PyContext, PyObjectRef};
 
 pub fn mk_module(ctx: &PyContext) -> PyObjectRef {
-    let py_ref_class = py_class!(ctx, "ref", ctx.object(), {
-        "__new__" => ctx.new_rustfunc(ref_new),
-        "__call__" => ctx.new_rustfunc(ref_call)
-    });
-
     py_module!(ctx, "_weakref", {
-        "ref" => py_ref_class
+        "ref" => ctx.weakref_type()
     })
-}
-
-fn ref_new(vm: &mut VirtualMachine, args: PyFuncArgs) -> PyResult {
-    // TODO: check first argument for subclass of `ref`.
-    arg_check!(vm, args, required = [(cls, None), (referent, None)]);
-    let referent = Rc::downgrade(referent);
-    Ok(PyObject::new(
-        PyObjectPayload::WeakRef { referent },
-        cls.clone(),
-    ))
-}
-
-/// Dereference the weakref, and check if we still refer something.
-fn ref_call(vm: &mut VirtualMachine, args: PyFuncArgs) -> PyResult {
-    // TODO: check first argument for subclass of `ref`.
-    arg_check!(vm, args, required = [(cls, None)]);
-    let referent = get_value(cls);
-    let py_obj = if let Some(obj) = referent.upgrade() {
-        obj
-    } else {
-        vm.get_none()
-    };
-    Ok(py_obj)
-}
-
-fn get_value(obj: &PyObjectRef) -> PyObjectWeakRef {
-    if let PyObjectPayload::WeakRef { referent } = &obj.payload {
-        referent.clone()
-    } else {
-        panic!("Inner error getting weak ref {:?}", obj);
-    }
 }


### PR DESCRIPTION
Promote weakref to be a core type by moving it out of its stdlib module and into the obj module. This is required to implement weakref callbacks, which I will redo in a followup PR. This was originally implemented as part of the outdated #488 PR.
 
Also, I have migrated the weakref type to use the 'any' payload and new style functions.

I built this on top of #635, so I could use PyRef::new_with_type.