### PR TITLE
 Convert most objint functions to new args style

### DIFF
--- a/vm/src/builtins.rs
+++ b/vm/src/builtins.rs
@@ -674,7 +674,7 @@ fn builtin_round(vm: &mut VirtualMachine, args: PyFuncArgs) -> PyResult {
     } else {
         // without a parameter, the result type is coerced to int
         let rounded = &vm.call_method(number, "__round__", vec![])?;
-        Ok(vm.ctx.new_int(objint::get_value(rounded)))
+        Ok(vm.ctx.new_int(objint::get_value(rounded).clone()))
     }
 }
 

--- a/vm/src/obj/objenumerate.rs
+++ b/vm/src/obj/objenumerate.rs
@@ -30,7 +30,7 @@ fn enumerate_new(vm: &mut VirtualMachine, args: PyFuncArgs) -> PyResult {
         optional = [(start, Some(vm.ctx.int_type()))]
     );
     let counter = if let Some(x) = start {
-        objint::get_value(x)
+        objint::get_value(x).clone()
     } else {
         BigInt::zero()
     };

--- a/vm/src/obj/objfloat.rs
+++ b/vm/src/obj/objfloat.rs
@@ -45,7 +45,7 @@ impl PyFloatRef {
             let other_int = objint::get_value(&other);
 
             if let (Some(self_int), Some(other_float)) = (value.to_bigint(), other_int.to_f64()) {
-                value == other_float && self_int == other_int
+                value == other_float && self_int == *other_int
             } else {
                 false
             }

--- a/vm/src/obj/objint.rs
+++ b/vm/src/obj/objint.rs
@@ -6,7 +6,7 @@ use num_traits::{Pow, Signed, ToPrimitive, Zero};
 
 use crate::format::FormatSpec;
 use crate::pyobject::{
-    FromPyObjectRef, IntoPyObject, PyContext, PyFuncArgs, PyObject, PyObjectRef, PyRef, PyResult,
+    IntoPyObject, OptionalArg, PyContext, PyFuncArgs, PyObject, PyObjectRef, PyRef, PyResult,
     PyValue, TryFromObject, TypeProtocol,
 };
 use crate::vm::VirtualMachine;
@@ -26,6 +26,7 @@ pub type PyIntRef = PyRef<PyInt>;
 impl PyInt {
     pub fn new<T: ToBigInt>(i: T) -> Self {
         PyInt {
+            // TODO: this .clone()s a BigInt, which is not what we want.
             value: i.to_bigint().unwrap(),
         }
     }
@@ -80,10 +81,293 @@ impl_try_from_object_int!(
     (u64, to_u64),
 );
 
-fn int_repr(vm: &mut VirtualMachine, args: PyFuncArgs) -> PyResult {
-    arg_check!(vm, args, required = [(int, Some(vm.ctx.int_type()))]);
-    let v = get_value(int);
-    Ok(vm.new_str(v.to_string()))
+impl PyIntRef {
+    fn pass_value(self, _vm: &mut VirtualMachine) -> Self {
+        self
+    }
+
+    fn eq(self, other: PyObjectRef, vm: &mut VirtualMachine) -> PyObjectRef {
+        if objtype::isinstance(&other, &vm.ctx.int_type()) {
+            vm.ctx.new_bool(self.value == get_value(&other))
+        } else {
+            vm.ctx.not_implemented()
+        }
+    }
+
+    fn ne(self, other: PyObjectRef, vm: &mut VirtualMachine) -> PyObjectRef {
+        if objtype::isinstance(&other, &vm.ctx.int_type()) {
+            vm.ctx.new_bool(self.value != get_value(&other))
+        } else {
+            vm.ctx.not_implemented()
+        }
+    }
+
+    fn lt(self, other: PyObjectRef, vm: &mut VirtualMachine) -> PyObjectRef {
+        if objtype::isinstance(&other, &vm.ctx.int_type()) {
+            vm.ctx.new_bool(self.value < get_value(&other))
+        } else {
+            vm.ctx.not_implemented()
+        }
+    }
+
+    fn le(self, other: PyObjectRef, vm: &mut VirtualMachine) -> PyObjectRef {
+        if objtype::isinstance(&other, &vm.ctx.int_type()) {
+            vm.ctx.new_bool(self.value <= get_value(&other))
+        } else {
+            vm.ctx.not_implemented()
+        }
+    }
+
+    fn gt(self, other: PyObjectRef, vm: &mut VirtualMachine) -> PyObjectRef {
+        if objtype::isinstance(&other, &vm.ctx.int_type()) {
+            vm.ctx.new_bool(self.value > get_value(&other))
+        } else {
+            vm.ctx.not_implemented()
+        }
+    }
+
+    fn ge(self, other: PyObjectRef, vm: &mut VirtualMachine) -> PyObjectRef {
+        if objtype::isinstance(&other, &vm.ctx.int_type()) {
+            vm.ctx.new_bool(self.value >= get_value(&other))
+        } else {
+            vm.ctx.not_implemented()
+        }
+    }
+
+    fn add(self, other: PyObjectRef, vm: &mut VirtualMachine) -> PyObjectRef {
+        if objtype::isinstance(&other, &vm.ctx.int_type()) {
+            vm.ctx.new_int((&self.value) + get_value(&other))
+        } else {
+            vm.ctx.not_implemented()
+        }
+    }
+
+    fn sub(self, other: PyObjectRef, vm: &mut VirtualMachine) -> PyObjectRef {
+        if objtype::isinstance(&other, &vm.ctx.int_type()) {
+            vm.ctx.new_int((&self.value) - get_value(&other))
+        } else {
+            vm.ctx.not_implemented()
+        }
+    }
+
+    fn rsub(self, other: PyObjectRef, vm: &mut VirtualMachine) -> PyObjectRef {
+        if objtype::isinstance(&other, &vm.ctx.int_type()) {
+            vm.ctx.new_int(get_value(&other) - (&self.value))
+        } else {
+            vm.ctx.not_implemented()
+        }
+    }
+
+    fn mul(self, other: PyObjectRef, vm: &mut VirtualMachine) -> PyObjectRef {
+        if objtype::isinstance(&other, &vm.ctx.int_type()) {
+            vm.ctx.new_int((&self.value) * get_value(&other))
+        } else {
+            vm.ctx.not_implemented()
+        }
+    }
+
+    fn truediv(self, other: PyObjectRef, vm: &mut VirtualMachine) -> PyResult {
+        if objtype::isinstance(&other, &vm.ctx.int_type()) {
+            div_ints(vm, &self.value, &get_value(&other))
+        } else {
+            Ok(vm.ctx.not_implemented())
+        }
+    }
+
+    fn rtruediv(self, other: PyObjectRef, vm: &mut VirtualMachine) -> PyResult {
+        if objtype::isinstance(&other, &vm.ctx.int_type()) {
+            div_ints(vm, &get_value(&other), &self.value)
+        } else {
+            Ok(vm.ctx.not_implemented())
+        }
+    }
+
+    fn floordiv(self, other: PyObjectRef, vm: &mut VirtualMachine) -> PyResult {
+        if objtype::isinstance(&other, &vm.ctx.int_type()) {
+            let v2 = get_value(&other);
+            if v2 != BigInt::zero() {
+                Ok(vm.ctx.new_int((&self.value) / v2))
+            } else {
+                Err(vm.new_zero_division_error("integer floordiv by zero".to_string()))
+            }
+        } else {
+            Ok(vm.ctx.not_implemented())
+        }
+    }
+
+    fn lshift(self, other: PyObjectRef, vm: &mut VirtualMachine) -> PyResult {
+        if !objtype::isinstance(&other, &vm.ctx.int_type()) {
+            return Err(vm.new_type_error(format!(
+                "unsupported operand type(s) for << '{}' and '{}'",
+                objtype::get_type_name(&self.as_object().typ()),
+                objtype::get_type_name(&other.typ())
+            )));
+        }
+
+        if let Some(n_bits) = get_value(&other).to_usize() {
+            return Ok(vm.ctx.new_int((&self.value) << n_bits));
+        }
+
+        // i2 failed `to_usize()` conversion
+        match get_value(&other) {
+            ref v if *v < BigInt::zero() => {
+                Err(vm.new_value_error("negative shift count".to_string()))
+            }
+            ref v if *v > BigInt::from(usize::max_value()) => {
+                Err(vm.new_overflow_error("the number is too large to convert to int".to_string()))
+            }
+            _ => panic!("Failed converting {} to rust usize", get_value(&other)),
+        }
+    }
+
+    fn rshift(self, other: PyObjectRef, vm: &mut VirtualMachine) -> PyResult {
+        if !objtype::isinstance(&other, &vm.ctx.int_type()) {
+            return Err(vm.new_type_error(format!(
+                "unsupported operand type(s) for >> '{}' and '{}'",
+                objtype::get_type_name(&self.as_object().typ()),
+                objtype::get_type_name(&other.typ())
+            )));
+        }
+
+        if let Some(n_bits) = get_value(&other).to_usize() {
+            return Ok(vm.ctx.new_int((&self.value) >> n_bits));
+        }
+
+        // i2 failed `to_usize()` conversion
+        match get_value(&other) {
+            ref v if *v < BigInt::zero() => {
+                Err(vm.new_value_error("negative shift count".to_string()))
+            }
+            ref v if *v > BigInt::from(usize::max_value()) => {
+                Err(vm.new_overflow_error("the number is too large to convert to int".to_string()))
+            }
+            _ => panic!("Failed converting {} to rust usize", get_value(&other)),
+        }
+    }
+
+    fn xor(self, other: PyObjectRef, vm: &mut VirtualMachine) -> PyObjectRef {
+        if objtype::isinstance(&other, &vm.ctx.int_type()) {
+            vm.ctx.new_int((&self.value) ^ get_value(&other))
+        } else {
+            vm.ctx.not_implemented()
+        }
+    }
+
+    fn rxor(self, other: PyObjectRef, vm: &mut VirtualMachine) -> PyObjectRef {
+        if objtype::isinstance(&other, &vm.ctx.int_type()) {
+            vm.ctx.new_int(get_value(&other) ^ (&self.value))
+        } else {
+            vm.ctx.not_implemented()
+        }
+    }
+
+    fn or(self, other: PyObjectRef, vm: &mut VirtualMachine) -> PyObjectRef {
+        if objtype::isinstance(&other, &vm.ctx.int_type()) {
+            vm.ctx.new_int((&self.value) | get_value(&other))
+        } else {
+            vm.ctx.not_implemented()
+        }
+    }
+
+    fn and(self, other: PyObjectRef, vm: &mut VirtualMachine) -> PyObjectRef {
+        if objtype::isinstance(&other, &vm.ctx.int_type()) {
+            let v2 = get_value(&other);
+            vm.ctx.new_int((&self.value) & v2)
+        } else {
+            vm.ctx.not_implemented()
+        }
+    }
+
+    fn pow(self, other: PyObjectRef, vm: &mut VirtualMachine) -> PyObjectRef {
+        if objtype::isinstance(&other, &vm.ctx.int_type()) {
+            let v2 = get_value(&other).to_u32().unwrap();
+            vm.ctx.new_int(self.value.pow(v2))
+        } else if objtype::isinstance(&other, &vm.ctx.float_type()) {
+            let v2 = objfloat::get_value(&other);
+            vm.ctx.new_float((self.value.to_f64().unwrap()).powf(v2))
+        } else {
+            vm.ctx.not_implemented()
+        }
+    }
+
+    fn mod_(self, other: PyObjectRef, vm: &mut VirtualMachine) -> PyResult {
+        if objtype::isinstance(&other, &vm.ctx.int_type()) {
+            let v2 = get_value(&other);
+            if v2 != BigInt::zero() {
+                Ok(vm.ctx.new_int((&self.value) % v2))
+            } else {
+                Err(vm.new_zero_division_error("integer modulo by zero".to_string()))
+            }
+        } else {
+            Ok(vm.ctx.not_implemented())
+        }
+    }
+
+    fn divmod(self, other: PyObjectRef, vm: &mut VirtualMachine) -> PyResult {
+        if objtype::isinstance(&other, &vm.ctx.int_type()) {
+            let v2 = get_value(&other);
+            if v2 != BigInt::zero() {
+                let (r1, r2) = self.value.div_rem(&v2);
+                Ok(vm
+                    .ctx
+                    .new_tuple(vec![vm.ctx.new_int(r1), vm.ctx.new_int(r2)]))
+            } else {
+                Err(vm.new_zero_division_error("integer divmod by zero".to_string()))
+            }
+        } else {
+            Ok(vm.ctx.not_implemented())
+        }
+    }
+
+    fn neg(self, vm: &mut VirtualMachine) -> PyObjectRef {
+        vm.ctx.new_int(-(&self.value))
+    }
+
+    fn hash(self, _vm: &mut VirtualMachine) -> u64 {
+        let mut hasher = std::collections::hash_map::DefaultHasher::new();
+        self.value.hash(&mut hasher);
+        hasher.finish()
+    }
+
+    fn abs(self, vm: &mut VirtualMachine) -> PyObjectRef {
+        vm.ctx.new_int(self.value.abs())
+    }
+
+    fn round(self, _precision: OptionalArg<PyObjectRef>, _vm: &mut VirtualMachine) -> Self {
+        self
+    }
+
+    fn float(self, _vm: &mut VirtualMachine) -> f64 {
+        self.value.to_f64().unwrap()
+    }
+
+    fn invert(self, vm: &mut VirtualMachine) -> PyObjectRef {
+        vm.ctx.new_int(!(&self.value))
+    }
+
+    fn repr(self, _vm: &mut VirtualMachine) -> String {
+        self.value.to_string()
+    }
+
+    fn format(self, spec: PyRef<objstr::PyString>, vm: &mut VirtualMachine) -> PyResult<String> {
+        let format_spec = FormatSpec::parse(&spec.value);
+        match format_spec.format_int(&self.value) {
+            Ok(string) => Ok(string),
+            Err(err) => Err(vm.new_value_error(err.to_string())),
+        }
+    }
+
+    fn bool(self, _vm: &mut VirtualMachine) -> bool {
+        !self.value.is_zero()
+    }
+
+    fn bit_length(self, _vm: &mut VirtualMachine) -> usize {
+        self.value.bits()
+    }
+
+    fn imag(self, _vm: &mut VirtualMachine) -> usize {
+        0
+    }
 }
 
 fn int_new(vm: &mut VirtualMachine, args: PyFuncArgs) -> PyResult {
@@ -141,346 +425,6 @@ pub fn get_value(obj: &PyObjectRef) -> BigInt {
     obj.payload::<PyInt>().unwrap().value.clone()
 }
 
-impl FromPyObjectRef for BigInt {
-    fn from_pyobj(obj: &PyObjectRef) -> BigInt {
-        get_value(obj)
-    }
-}
-
-fn int_bool(vm: &mut VirtualMachine, args: PyFuncArgs) -> PyResult {
-    arg_check!(vm, args, required = [(zelf, Some(vm.ctx.int_type()))]);
-    let result = !BigInt::from_pyobj(zelf).is_zero();
-    Ok(vm.ctx.new_bool(result))
-}
-
-fn int_invert(vm: &mut VirtualMachine, args: PyFuncArgs) -> PyResult {
-    arg_check!(vm, args, required = [(zelf, Some(vm.ctx.int_type()))]);
-
-    let result = !BigInt::from_pyobj(zelf);
-
-    Ok(vm.ctx.new_int(result))
-}
-
-fn int_eq(vm: &mut VirtualMachine, args: PyFuncArgs) -> PyResult {
-    arg_check!(
-        vm,
-        args,
-        required = [(zelf, Some(vm.ctx.int_type())), (other, None)]
-    );
-
-    let zelf = BigInt::from_pyobj(zelf);
-    let result = if objtype::isinstance(other, &vm.ctx.int_type()) {
-        let other = BigInt::from_pyobj(other);
-        zelf == other
-    } else {
-        return Ok(vm.ctx.not_implemented());
-    };
-    Ok(vm.ctx.new_bool(result))
-}
-
-fn int_ne(vm: &mut VirtualMachine, args: PyFuncArgs) -> PyResult {
-    arg_check!(
-        vm,
-        args,
-        required = [(zelf, Some(vm.ctx.int_type())), (other, None)]
-    );
-
-    let zelf = BigInt::from_pyobj(zelf);
-    let result = if objtype::isinstance(other, &vm.ctx.int_type()) {
-        let other = BigInt::from_pyobj(other);
-        zelf != other
-    } else {
-        return Ok(vm.ctx.not_implemented());
-    };
-    Ok(vm.ctx.new_bool(result))
-}
-
-fn int_lt(vm: &mut VirtualMachine, args: PyFuncArgs) -> PyResult {
-    arg_check!(
-        vm,
-        args,
-        required = [(zelf, Some(vm.ctx.int_type())), (other, None)]
-    );
-
-    if !objtype::isinstance(other, &vm.ctx.int_type()) {
-        return Ok(vm.ctx.not_implemented());
-    }
-
-    let zelf = BigInt::from_pyobj(zelf);
-    let other = BigInt::from_pyobj(other);
-    let result = zelf < other;
-    Ok(vm.ctx.new_bool(result))
-}
-
-fn int_le(vm: &mut VirtualMachine, args: PyFuncArgs) -> PyResult {
-    arg_check!(
-        vm,
-        args,
-        required = [(zelf, Some(vm.ctx.int_type())), (other, None)]
-    );
-
-    if !objtype::isinstance(other, &vm.ctx.int_type()) {
-        return Ok(vm.ctx.not_implemented());
-    }
-
-    let zelf = BigInt::from_pyobj(zelf);
-    let other = BigInt::from_pyobj(other);
-    let result = zelf <= other;
-    Ok(vm.ctx.new_bool(result))
-}
-
-fn int_gt(vm: &mut VirtualMachine, args: PyFuncArgs) -> PyResult {
-    arg_check!(
-        vm,
-        args,
-        required = [(zelf, Some(vm.ctx.int_type())), (other, None)]
-    );
-
-    if !objtype::isinstance(other, &vm.ctx.int_type()) {
-        return Ok(vm.ctx.not_implemented());
-    }
-
-    let zelf = BigInt::from_pyobj(zelf);
-    let other = BigInt::from_pyobj(other);
-    let result = zelf > other;
-    Ok(vm.ctx.new_bool(result))
-}
-
-fn int_ge(vm: &mut VirtualMachine, args: PyFuncArgs) -> PyResult {
-    arg_check!(
-        vm,
-        args,
-        required = [(zelf, Some(vm.ctx.int_type())), (other, None)]
-    );
-
-    if !objtype::isinstance(other, &vm.ctx.int_type()) {
-        return Ok(vm.ctx.not_implemented());
-    }
-
-    let zelf = BigInt::from_pyobj(zelf);
-    let other = BigInt::from_pyobj(other);
-    let result = zelf >= other;
-    Ok(vm.ctx.new_bool(result))
-}
-
-fn int_lshift(vm: &mut VirtualMachine, args: PyFuncArgs) -> PyResult {
-    arg_check!(
-        vm,
-        args,
-        required = [(i, Some(vm.ctx.int_type())), (i2, None)]
-    );
-
-    if !objtype::isinstance(i2, &vm.ctx.int_type()) {
-        return Err(vm.new_type_error(format!(
-            "unsupported operand type(s) for << '{}' and '{}'",
-            objtype::get_type_name(&i.typ()),
-            objtype::get_type_name(&i2.typ())
-        )));
-    }
-
-    if let Some(n_bits) = get_value(i2).to_usize() {
-        return Ok(vm.ctx.new_int(get_value(i) << n_bits));
-    }
-
-    // i2 failed `to_usize()` conversion
-    match get_value(i2) {
-        ref v if *v < BigInt::zero() => Err(vm.new_value_error("negative shift count".to_string())),
-        ref v if *v > BigInt::from(usize::max_value()) => {
-            Err(vm.new_overflow_error("the number is too large to convert to int".to_string()))
-        }
-        _ => panic!("Failed converting {} to rust usize", get_value(i2)),
-    }
-}
-
-fn int_rshift(vm: &mut VirtualMachine, args: PyFuncArgs) -> PyResult {
-    arg_check!(
-        vm,
-        args,
-        required = [(i, Some(vm.ctx.int_type())), (i2, None)]
-    );
-
-    if !objtype::isinstance(i2, &vm.ctx.int_type()) {
-        return Err(vm.new_type_error(format!(
-            "unsupported operand type(s) for >> '{}' and '{}'",
-            objtype::get_type_name(&i.typ()),
-            objtype::get_type_name(&i2.typ())
-        )));
-    }
-
-    if let Some(n_bits) = get_value(i2).to_usize() {
-        return Ok(vm.ctx.new_int(get_value(i) >> n_bits));
-    }
-
-    // i2 failed `to_usize()` conversion
-    match get_value(i2) {
-        ref v if *v < BigInt::zero() => Err(vm.new_value_error("negative shift count".to_string())),
-        ref v if *v > BigInt::from(usize::max_value()) => {
-            Err(vm.new_overflow_error("the number is too large to convert to int".to_string()))
-        }
-        _ => panic!("Failed converting {} to rust usize", get_value(i2)),
-    }
-}
-
-fn int_hash(vm: &mut VirtualMachine, args: PyFuncArgs) -> PyResult {
-    arg_check!(vm, args, required = [(zelf, Some(vm.ctx.int_type()))]);
-    let value = BigInt::from_pyobj(zelf);
-    let mut hasher = std::collections::hash_map::DefaultHasher::new();
-    value.hash(&mut hasher);
-    let hash = hasher.finish();
-    Ok(vm.ctx.new_int(hash))
-}
-
-fn int_abs(vm: &mut VirtualMachine, args: PyFuncArgs) -> PyResult {
-    arg_check!(vm, args, required = [(i, Some(vm.ctx.int_type()))]);
-    Ok(vm.ctx.new_int(get_value(i).abs()))
-}
-
-fn int_add(vm: &mut VirtualMachine, args: PyFuncArgs) -> PyResult {
-    arg_check!(
-        vm,
-        args,
-        required = [(zelf, Some(vm.ctx.int_type())), (other, None)]
-    );
-    if objtype::isinstance(other, &vm.ctx.int_type()) {
-        Ok(vm.ctx.new_int(get_value(zelf) + get_value(other)))
-    } else {
-        Ok(vm.ctx.not_implemented())
-    }
-}
-
-fn int_radd(vm: &mut VirtualMachine, args: PyFuncArgs) -> PyResult {
-    int_add(vm, args)
-}
-
-fn int_float(vm: &mut VirtualMachine, args: PyFuncArgs) -> PyResult {
-    arg_check!(vm, args, required = [(i, Some(vm.ctx.int_type()))]);
-    let i = get_value(i);
-    Ok(vm.ctx.new_float(i.to_f64().unwrap()))
-}
-
-fn int_floordiv(vm: &mut VirtualMachine, args: PyFuncArgs) -> PyResult {
-    arg_check!(
-        vm,
-        args,
-        required = [(i, Some(vm.ctx.int_type())), (i2, None)]
-    );
-    if objtype::isinstance(i2, &vm.ctx.int_type()) {
-        let (v1, v2) = (get_value(i), get_value(i2));
-
-        if v2 != BigInt::zero() {
-            Ok(vm.ctx.new_int(v1 / v2))
-        } else {
-            Err(vm.new_zero_division_error("integer floordiv by zero".to_string()))
-        }
-    } else {
-        Ok(vm.ctx.not_implemented())
-    }
-}
-
-fn int_round(vm: &mut VirtualMachine, args: PyFuncArgs) -> PyResult {
-    arg_check!(
-        vm,
-        args,
-        required = [(i, Some(vm.ctx.int_type()))],
-        optional = [(_precision, None)]
-    );
-    Ok(vm.ctx.new_int(get_value(i)))
-}
-
-fn int_pass_value(vm: &mut VirtualMachine, args: PyFuncArgs) -> PyResult {
-    arg_check!(vm, args, required = [(i, Some(vm.ctx.int_type()))]);
-    Ok(vm.ctx.new_int(get_value(i)))
-}
-
-fn int_format(vm: &mut VirtualMachine, args: PyFuncArgs) -> PyResult {
-    arg_check!(
-        vm,
-        args,
-        required = [
-            (i, Some(vm.ctx.int_type())),
-            (format_spec, Some(vm.ctx.str_type()))
-        ]
-    );
-    let string_value = objstr::get_value(format_spec);
-    let format_spec = FormatSpec::parse(&string_value);
-    let int_value = get_value(i);
-    match format_spec.format_int(&int_value) {
-        Ok(string) => Ok(vm.ctx.new_str(string)),
-        Err(err) => Err(vm.new_value_error(err.to_string())),
-    }
-}
-
-fn int_sub(vm: &mut VirtualMachine, args: PyFuncArgs) -> PyResult {
-    arg_check!(
-        vm,
-        args,
-        required = [(zelf, Some(vm.ctx.int_type())), (other, None)]
-    );
-    if objtype::isinstance(other, &vm.ctx.int_type()) {
-        Ok(vm.ctx.new_int(get_value(zelf) - get_value(other)))
-    } else {
-        Ok(vm.ctx.not_implemented())
-    }
-}
-
-fn int_rsub(vm: &mut VirtualMachine, args: PyFuncArgs) -> PyResult {
-    arg_check!(
-        vm,
-        args,
-        required = [(zelf, Some(vm.ctx.int_type())), (other, None)]
-    );
-    if objtype::isinstance(other, &vm.ctx.int_type()) {
-        Ok(vm.ctx.new_int(get_value(other) - get_value(zelf)))
-    } else {
-        Ok(vm.ctx.not_implemented())
-    }
-}
-
-fn int_mul(vm: &mut VirtualMachine, args: PyFuncArgs) -> PyResult {
-    arg_check!(
-        vm,
-        args,
-        required = [(zelf, Some(vm.ctx.int_type())), (other, None)]
-    );
-    if objtype::isinstance(other, &vm.ctx.int_type()) {
-        Ok(vm.ctx.new_int(get_value(zelf) * get_value(other)))
-    } else {
-        Ok(vm.ctx.not_implemented())
-    }
-}
-
-fn int_rmul(vm: &mut VirtualMachine, args: PyFuncArgs) -> PyResult {
-    int_mul(vm, args)
-}
-
-fn int_truediv(vm: &mut VirtualMachine, args: PyFuncArgs) -> PyResult {
-    arg_check!(
-        vm,
-        args,
-        required = [(zelf, Some(vm.ctx.int_type())), (other, None)]
-    );
-
-    if objtype::isinstance(other, &vm.ctx.int_type()) {
-        div_ints(vm, &get_value(zelf), &get_value(other))
-    } else {
-        Ok(vm.ctx.not_implemented())
-    }
-}
-
-fn int_rtruediv(vm: &mut VirtualMachine, args: PyFuncArgs) -> PyResult {
-    arg_check!(
-        vm,
-        args,
-        required = [(zelf, Some(vm.ctx.int_type())), (other, None)]
-    );
-
-    if objtype::isinstance(other, &vm.ctx.int_type()) {
-        div_ints(vm, &get_value(other), &get_value(zelf))
-    } else {
-        Ok(vm.ctx.not_implemented())
-    }
-}
-
 #[inline]
 fn div_ints(vm: &mut VirtualMachine, i1: &BigInt, i2: &BigInt) -> PyResult {
     if i2.is_zero() {
@@ -513,167 +457,7 @@ fn div_ints(vm: &mut VirtualMachine, i1: &BigInt, i2: &BigInt) -> PyResult {
     }
 }
 
-fn int_mod(vm: &mut VirtualMachine, args: PyFuncArgs) -> PyResult {
-    arg_check!(
-        vm,
-        args,
-        required = [(i, Some(vm.ctx.int_type())), (i2, None)]
-    );
-    let v1 = get_value(i);
-    if objtype::isinstance(i2, &vm.ctx.int_type()) {
-        let v2 = get_value(i2);
-
-        if v2 != BigInt::zero() {
-            Ok(vm.ctx.new_int(v1 % get_value(i2)))
-        } else {
-            Err(vm.new_zero_division_error("integer modulo by zero".to_string()))
-        }
-    } else {
-        Ok(vm.ctx.not_implemented())
-    }
-}
-
-fn int_neg(vm: &mut VirtualMachine, args: PyFuncArgs) -> PyResult {
-    arg_check!(vm, args, required = [(i, Some(vm.ctx.int_type()))]);
-    let i = BigInt::from_pyobj(i);
-    Ok(vm.ctx.new_int(-i))
-}
-
-fn int_pos(vm: &mut VirtualMachine, args: PyFuncArgs) -> PyResult {
-    arg_check!(vm, args, required = [(i, Some(vm.ctx.int_type()))]);
-    Ok(i.clone())
-}
-
-fn int_pow(vm: &mut VirtualMachine, args: PyFuncArgs) -> PyResult {
-    arg_check!(
-        vm,
-        args,
-        required = [(i, Some(vm.ctx.int_type())), (i2, None)]
-    );
-    let v1 = get_value(i);
-    if objtype::isinstance(i2, &vm.ctx.int_type()) {
-        let v2 = get_value(i2).to_u32().unwrap();
-        Ok(vm.ctx.new_int(v1.pow(v2)))
-    } else if objtype::isinstance(i2, &vm.ctx.float_type()) {
-        let v2 = objfloat::get_value(i2);
-        Ok(vm.ctx.new_float((v1.to_f64().unwrap()).powf(v2)))
-    } else {
-        Ok(vm.ctx.not_implemented())
-    }
-}
-
-fn int_divmod(vm: &mut VirtualMachine, args: PyFuncArgs) -> PyResult {
-    arg_check!(
-        vm,
-        args,
-        required = [(i, Some(vm.ctx.int_type())), (i2, None)]
-    );
-
-    if objtype::isinstance(i2, &vm.ctx.int_type()) {
-        let v1 = get_value(i);
-        let v2 = get_value(i2);
-
-        if v2 != BigInt::zero() {
-            let (r1, r2) = v1.div_rem(&v2);
-
-            Ok(vm
-                .ctx
-                .new_tuple(vec![vm.ctx.new_int(r1), vm.ctx.new_int(r2)]))
-        } else {
-            Err(vm.new_zero_division_error("integer divmod by zero".to_string()))
-        }
-    } else {
-        Ok(vm.ctx.not_implemented())
-    }
-}
-
-fn int_xor(vm: &mut VirtualMachine, args: PyFuncArgs) -> PyResult {
-    arg_check!(
-        vm,
-        args,
-        required = [(i, Some(vm.ctx.int_type())), (i2, None)]
-    );
-    let v1 = get_value(i);
-    if objtype::isinstance(i2, &vm.ctx.int_type()) {
-        let v2 = get_value(i2);
-        Ok(vm.ctx.new_int(v1 ^ v2))
-    } else {
-        Ok(vm.ctx.not_implemented())
-    }
-}
-
-fn int_rxor(vm: &mut VirtualMachine, args: PyFuncArgs) -> PyResult {
-    arg_check!(
-        vm,
-        args,
-        required = [(i, Some(vm.ctx.int_type())), (i2, None)]
-    );
-
-    if objtype::isinstance(i2, &vm.ctx.int_type()) {
-        let right_val = get_value(i);
-        let left_val = get_value(i2);
-
-        Ok(vm.ctx.new_int(left_val ^ right_val))
-    } else {
-        Ok(vm.ctx.not_implemented())
-    }
-}
-
-fn int_or(vm: &mut VirtualMachine, args: PyFuncArgs) -> PyResult {
-    arg_check!(
-        vm,
-        args,
-        required = [(i, Some(vm.ctx.int_type())), (i2, None)]
-    );
-    let v1 = get_value(i);
-    if objtype::isinstance(i2, &vm.ctx.int_type()) {
-        let v2 = get_value(i2);
-        Ok(vm.ctx.new_int(v1 | v2))
-    } else {
-        Ok(vm.ctx.not_implemented())
-    }
-}
-
-fn int_and(vm: &mut VirtualMachine, args: PyFuncArgs) -> PyResult {
-    arg_check!(
-        vm,
-        args,
-        required = [(i, Some(vm.ctx.int_type())), (i2, None)]
-    );
-    let v1 = get_value(i);
-    if objtype::isinstance(i2, &vm.ctx.int_type()) {
-        let v2 = get_value(i2);
-        Ok(vm.ctx.new_int(v1 & v2))
-    } else {
-        Ok(vm.ctx.not_implemented())
-    }
-}
-
-fn int_bit_length(vm: &mut VirtualMachine, args: PyFuncArgs) -> PyResult {
-    arg_check!(vm, args, required = [(i, Some(vm.ctx.int_type()))]);
-    let v = get_value(i);
-    let bits = v.bits();
-    Ok(vm.ctx.new_int(bits))
-}
-
-fn int_conjugate(vm: &mut VirtualMachine, args: PyFuncArgs) -> PyResult {
-    arg_check!(vm, args, required = [(i, Some(vm.ctx.int_type()))]);
-    let v = get_value(i);
-    Ok(vm.ctx.new_int(v))
-}
-
-fn int_real(vm: &mut VirtualMachine, args: PyFuncArgs) -> PyResult {
-    arg_check!(vm, args, required = [(zelf, Some(vm.ctx.int_type()))]);
-    let value = BigInt::from_pyobj(zelf);
-    Ok(vm.ctx.new_int(value))
-}
-
-fn int_imag(vm: &mut VirtualMachine, args: PyFuncArgs) -> PyResult {
-    arg_check!(vm, args, required = [(_zelf, Some(vm.ctx.int_type()))]);
-    let value = BigInt::from(0);
-    Ok(vm.ctx.new_int(value))
-}
-
+#[rustfmt::skip] // to avoid line splitting
 pub fn init(context: &PyContext) {
     let int_doc = "int(x=0) -> integer
 int(x, base=10) -> integer
@@ -691,61 +475,49 @@ Base 0 means to interpret the base from the string as an integer literal.
 4";
     let int_type = &context.int_type;
 
-    context.set_attr(&int_type, "__eq__", context.new_rustfunc(int_eq));
-    context.set_attr(&int_type, "__ne__", context.new_rustfunc(int_ne));
-    context.set_attr(&int_type, "__lt__", context.new_rustfunc(int_lt));
-    context.set_attr(&int_type, "__le__", context.new_rustfunc(int_le));
-    context.set_attr(&int_type, "__gt__", context.new_rustfunc(int_gt));
-    context.set_attr(&int_type, "__ge__", context.new_rustfunc(int_ge));
-    context.set_attr(&int_type, "__abs__", context.new_rustfunc(int_abs));
-    context.set_attr(&int_type, "__add__", context.new_rustfunc(int_add));
-    context.set_attr(&int_type, "__radd__", context.new_rustfunc(int_radd));
-    context.set_attr(&int_type, "__and__", context.new_rustfunc(int_and));
-    context.set_attr(&int_type, "__divmod__", context.new_rustfunc(int_divmod));
-    context.set_attr(&int_type, "__float__", context.new_rustfunc(int_float));
-    context.set_attr(&int_type, "__round__", context.new_rustfunc(int_round));
-    context.set_attr(&int_type, "__ceil__", context.new_rustfunc(int_pass_value));
-    context.set_attr(&int_type, "__floor__", context.new_rustfunc(int_pass_value));
-    context.set_attr(&int_type, "__index__", context.new_rustfunc(int_pass_value));
-    context.set_attr(&int_type, "__trunc__", context.new_rustfunc(int_pass_value));
-    context.set_attr(&int_type, "__int__", context.new_rustfunc(int_pass_value));
-    context.set_attr(
-        &int_type,
-        "__floordiv__",
-        context.new_rustfunc(int_floordiv),
-    );
-    context.set_attr(&int_type, "__hash__", context.new_rustfunc(int_hash));
-    context.set_attr(&int_type, "__lshift__", context.new_rustfunc(int_lshift));
-    context.set_attr(&int_type, "__rshift__", context.new_rustfunc(int_rshift));
-    context.set_attr(&int_type, "__new__", context.new_rustfunc(int_new));
-    context.set_attr(&int_type, "__mod__", context.new_rustfunc(int_mod));
-    context.set_attr(&int_type, "__mul__", context.new_rustfunc(int_mul));
-    context.set_attr(&int_type, "__rmul__", context.new_rustfunc(int_rmul));
-    context.set_attr(&int_type, "__neg__", context.new_rustfunc(int_neg));
-    context.set_attr(&int_type, "__or__", context.new_rustfunc(int_or));
-    context.set_attr(&int_type, "__pos__", context.new_rustfunc(int_pos));
-    context.set_attr(&int_type, "__pow__", context.new_rustfunc(int_pow));
-    context.set_attr(&int_type, "__repr__", context.new_rustfunc(int_repr));
-    context.set_attr(&int_type, "__sub__", context.new_rustfunc(int_sub));
-    context.set_attr(&int_type, "__rsub__", context.new_rustfunc(int_rsub));
-    context.set_attr(&int_type, "__format__", context.new_rustfunc(int_format));
-    context.set_attr(&int_type, "__truediv__", context.new_rustfunc(int_truediv));
-    context.set_attr(
-        &int_type,
-        "__rtruediv__",
-        context.new_rustfunc(int_rtruediv),
-    );
-    context.set_attr(&int_type, "__xor__", context.new_rustfunc(int_xor));
-    context.set_attr(&int_type, "__rxor__", context.new_rustfunc(int_rxor));
-    context.set_attr(&int_type, "__bool__", context.new_rustfunc(int_bool));
-    context.set_attr(&int_type, "__invert__", context.new_rustfunc(int_invert));
-    context.set_attr(
-        &int_type,
-        "bit_length",
-        context.new_rustfunc(int_bit_length),
-    );
     context.set_attr(&int_type, "__doc__", context.new_str(int_doc.to_string()));
-    context.set_attr(&int_type, "conjugate", context.new_rustfunc(int_conjugate));
-    context.set_attr(&int_type, "real", context.new_property(int_real));
-    context.set_attr(&int_type, "imag", context.new_property(int_imag));
+    context.set_attr(&int_type, "__eq__", context.new_rustfunc(PyIntRef::eq));
+    context.set_attr(&int_type, "__ne__", context.new_rustfunc(PyIntRef::ne));
+    context.set_attr(&int_type, "__lt__", context.new_rustfunc(PyIntRef::lt));
+    context.set_attr(&int_type, "__le__", context.new_rustfunc(PyIntRef::le));
+    context.set_attr(&int_type, "__gt__", context.new_rustfunc(PyIntRef::gt));
+    context.set_attr(&int_type, "__ge__", context.new_rustfunc(PyIntRef::ge));
+    context.set_attr(&int_type, "__abs__", context.new_rustfunc(PyIntRef::abs));
+    context.set_attr(&int_type, "__add__", context.new_rustfunc(PyIntRef::add));
+    context.set_attr(&int_type, "__radd__", context.new_rustfunc(PyIntRef::add));
+    context.set_attr(&int_type, "__and__", context.new_rustfunc(PyIntRef::and));
+    context.set_attr(&int_type, "__divmod__", context.new_rustfunc(PyIntRef::divmod));
+    context.set_attr(&int_type, "__float__", context.new_rustfunc(PyIntRef::float));
+    context.set_attr(&int_type, "__round__", context.new_rustfunc(PyIntRef::round));
+    context.set_attr(&int_type, "__ceil__", context.new_rustfunc(PyIntRef::pass_value));
+    context.set_attr(&int_type, "__floor__", context.new_rustfunc(PyIntRef::pass_value));
+    context.set_attr(&int_type, "__index__", context.new_rustfunc(PyIntRef::pass_value));
+    context.set_attr(&int_type, "__trunc__", context.new_rustfunc(PyIntRef::pass_value));
+    context.set_attr(&int_type, "__int__", context.new_rustfunc(PyIntRef::pass_value));
+    context.set_attr(&int_type, "__floordiv__", context.new_rustfunc(PyIntRef::floordiv));
+    context.set_attr(&int_type, "__hash__", context.new_rustfunc(PyIntRef::hash));
+    context.set_attr(&int_type, "__lshift__", context.new_rustfunc(PyIntRef::lshift));
+    context.set_attr(&int_type, "__rshift__", context.new_rustfunc(PyIntRef::rshift));
+    context.set_attr(&int_type, "__new__", context.new_rustfunc(int_new));
+    context.set_attr(&int_type, "__mod__", context.new_rustfunc(PyIntRef::mod_));
+    context.set_attr(&int_type, "__mul__", context.new_rustfunc(PyIntRef::mul));
+    context.set_attr(&int_type, "__rmul__", context.new_rustfunc(PyIntRef::mul));
+    context.set_attr(&int_type, "__or__", context.new_rustfunc(PyIntRef::or));
+    context.set_attr(&int_type, "__neg__", context.new_rustfunc(PyIntRef::neg));
+    context.set_attr(&int_type, "__pos__", context.new_rustfunc(PyIntRef::pass_value));
+    context.set_attr(&int_type, "__pow__", context.new_rustfunc(PyIntRef::pow));
+    context.set_attr(&int_type, "__repr__", context.new_rustfunc(PyIntRef::repr));
+    context.set_attr(&int_type, "__sub__", context.new_rustfunc(PyIntRef::sub));
+    context.set_attr(&int_type, "__rsub__", context.new_rustfunc(PyIntRef::rsub));
+    context.set_attr(&int_type, "__format__", context.new_rustfunc(PyIntRef::format));
+    context.set_attr(&int_type, "__truediv__", context.new_rustfunc(PyIntRef::truediv));
+    context.set_attr(&int_type, "__rtruediv__", context.new_rustfunc(PyIntRef::rtruediv));
+    context.set_attr(&int_type, "__xor__", context.new_rustfunc(PyIntRef::xor));
+    context.set_attr(&int_type, "__rxor__", context.new_rustfunc(PyIntRef::rxor));
+    context.set_attr(&int_type, "__bool__", context.new_rustfunc(PyIntRef::bool));
+    context.set_attr(&int_type, "__invert__", context.new_rustfunc(PyIntRef::invert));
+    context.set_attr(&int_type, "bit_length", context.new_rustfunc(PyIntRef::bit_length));
+    context.set_attr(&int_type, "conjugate", context.new_rustfunc(PyIntRef::pass_value));
+    context.set_attr(&int_type, "real", context.new_property(PyIntRef::pass_value));
+    context.set_attr(&int_type, "imag", context.new_property(PyIntRef::imag));
 }

--- a/vm/src/obj/objrange.rs
+++ b/vm/src/obj/objrange.rs
@@ -207,19 +207,19 @@ fn range_new(vm: &mut VirtualMachine, args: PyFuncArgs) -> PyResult {
     );
 
     let start = if second.is_some() {
-        objint::get_value(first)
+        objint::get_value(first).clone()
     } else {
         BigInt::zero()
     };
 
     let end = if let Some(pyint) = second {
-        objint::get_value(pyint)
+        objint::get_value(pyint).clone()
     } else {
-        objint::get_value(first)
+        objint::get_value(first).clone()
     };
 
     let step = if let Some(pyint) = step {
-        objint::get_value(pyint)
+        objint::get_value(pyint).clone()
     } else {
         BigInt::one()
     };

--- a/vm/src/obj/objslice.rs
+++ b/vm/src/obj/objslice.rs
@@ -55,9 +55,9 @@ fn slice_new(vm: &mut VirtualMachine, args: PyFuncArgs) -> PyResult {
     }?;
     Ok(PyObject::new(
         PySlice {
-            start: start.map(|x| objint::get_value(x)),
-            stop: stop.map(|x| objint::get_value(x)),
-            step: step.map(|x| objint::get_value(x)),
+            start: start.map(|x| objint::get_value(x).clone()),
+            stop: stop.map(|x| objint::get_value(x).clone()),
+            step: step.map(|x| objint::get_value(x).clone()),
         },
         cls.clone(),
     ))

--- a/vm/src/obj/objtuple.rs
+++ b/vm/src/obj/objtuple.rs
@@ -118,7 +118,8 @@ impl PyTupleRef {
     fn hash(self, vm: &mut VirtualMachine) -> PyResult<u64> {
         let mut hasher = std::collections::hash_map::DefaultHasher::new();
         for element in self.elements.borrow().iter() {
-            let element_hash = objint::get_value(&vm.call_method(element, "__hash__", vec![])?);
+            let hash_result = vm.call_method(element, "__hash__", vec![])?;
+            let element_hash = objint::get_value(&hash_result);
             element_hash.hash(&mut hasher);
         }
         Ok(hasher.finish())

--- a/vm/src/vm.rs
+++ b/vm/src/vm.rs
@@ -861,7 +861,7 @@ mod tests {
         let b = vm.ctx.new_int(12_i32);
         let res = vm._add(a, b).unwrap();
         let value = objint::get_value(&res);
-        assert_eq!(value, 45_i32.to_bigint().unwrap());
+        assert_eq!(*value, 45_i32.to_bigint().unwrap());
     }
 
     #[test]


### PR DESCRIPTION
Things still to do: currently constructing a new PyInt from a BigInt clone()s it, which causes unnecessary allocations.