### PR TITLE
Type mro

### DIFF
--- a/tests/snippets/mro.py
+++ b/tests/snippets/mro.py
@@ -18,3 +18,5 @@ class C(A, B):
     pass
 
 assert (C, A, B, X, Y, object) == C.__mro__
+
+assert type.__mro__ == (type, object)

--- a/vm/src/obj/objproperty.rs
+++ b/vm/src/obj/objproperty.rs
@@ -119,7 +119,7 @@ impl<'a, T> PropertyBuilder<'a, T> {
         }
     }
 
-    pub fn add_setter<I, F: IntoPyNativeFunc<(I, T), PyResult>>(self, func: F) -> Self {
+    pub fn add_setter<I, V, F: IntoPyNativeFunc<(I, V), PyResult>>(self, func: F) -> Self {
         let func = self.ctx.new_rustfunc(func);
         Self {
             ctx: self.ctx,

--- a/vm/src/obj/objtype.rs
+++ b/vm/src/obj/objtype.rs
@@ -9,6 +9,7 @@ use crate::vm::VirtualMachine;
 
 use super::objdict;
 use super::objlist::PyList;
+use super::objproperty::PropertyBuilder;
 use super::objstr::{self, PyStringRef};
 use super::objtuple::PyTuple;
 
@@ -64,6 +65,10 @@ impl PyClassRef {
         PyTuple::from(_mro(&self))
     }
 
+    fn set_mro(self, _value: PyObjectRef, vm: &mut VirtualMachine) -> PyResult {
+        Err(vm.new_attribute_error("read-only attribute".to_string()))
+    }
+
     fn dir(self, vm: &mut VirtualMachine) -> PyList {
         let attributes = get_attributes(self);
         let attributes: Vec<PyObjectRef> = attributes
@@ -115,7 +120,11 @@ pub fn init(ctx: &PyContext) {
     extend_class!(&ctx, &ctx.type_type, {
         "__call__" => ctx.new_rustfunc(type_call),
         "__new__" => ctx.new_rustfunc(type_new),
-        "__mro__" => ctx.new_property(PyClassRef::mro),
+        "__mro__" =>
+            PropertyBuilder::new(ctx)
+                .add_getter(PyClassRef::mro)
+                .add_setter(PyClassRef::set_mro)
+                .create(),
         "__repr__" => ctx.new_rustfunc(PyClassRef::repr),
         "__prepare__" => ctx.new_rustfunc(PyClassRef::prepare),
         "__getattribute__" => ctx.new_rustfunc(type_getattribute),


### PR DESCRIPTION
Fix this:

```
>>>>> type.__mro__
Traceback (most recent call last):
  File <stdin>, line 0, in <module>
TypeError: Expected type <class 'type'>, not <class 'NoneType'>
```