### PR TITLE
Remove Option from PyObject.typ; Refactor type hierarchy initialization.

### DIFF
--- a/vm/src/exceptions.rs
+++ b/vm/src/exceptions.rs
@@ -108,56 +108,29 @@ pub struct ExceptionZoo {
 }
 
 impl ExceptionZoo {
-    pub fn new(
-        type_type: &PyObjectRef,
-        object_type: &PyObjectRef,
-        dict_type: &PyObjectRef,
-    ) -> Self {
+    pub fn new(type_type: &PyObjectRef, object_type: &PyObjectRef) -> Self {
         // Sorted By Hierarchy then alphabetized.
-        let base_exception_type =
-            create_type("BaseException", &type_type, &object_type, &dict_type);
-
-        let exception_type = create_type("Exception", &type_type, &base_exception_type, &dict_type);
-
-        let arithmetic_error =
-            create_type("ArithmeticError", &type_type, &exception_type, &dict_type);
-        let assertion_error =
-            create_type("AssertionError", &type_type, &exception_type, &dict_type);
-        let attribute_error =
-            create_type("AttributeError", &type_type, &exception_type, &dict_type);
-        let import_error = create_type("ImportError", &type_type, &exception_type, &dict_type);
-        let index_error = create_type("IndexError", &type_type, &exception_type, &dict_type);
-        let key_error = create_type("KeyError", &type_type, &exception_type, &dict_type);
-        let name_error = create_type("NameError", &type_type, &exception_type, &dict_type);
-        let os_error = create_type("OSError", &type_type, &exception_type, &dict_type);
-        let runtime_error = create_type("RuntimeError", &type_type, &exception_type, &dict_type);
-        let stop_iteration = create_type("StopIteration", &type_type, &exception_type, &dict_type);
-        let syntax_error = create_type("SyntaxError", &type_type, &exception_type, &dict_type);
-        let type_error = create_type("TypeError", &type_type, &exception_type, &dict_type);
-        let value_error = create_type("ValueError", &type_type, &exception_type, &dict_type);
-
-        let overflow_error =
-            create_type("OverflowError", &type_type, &arithmetic_error, &dict_type);
-        let zero_division_error = create_type(
-            "ZeroDivisionError",
-            &type_type,
-            &arithmetic_error,
-            &dict_type,
-        );
-
-        let module_not_found_error =
-            create_type("ModuleNotFoundError", &type_type, &import_error, &dict_type);
-
-        let not_implemented_error = create_type(
-            "NotImplementedError",
-            &type_type,
-            &runtime_error,
-            &dict_type,
-        );
-
-        let file_not_found_error =
-            create_type("FileNotFoundError", &type_type, &os_error, &dict_type);
-        let permission_error = create_type("PermissionError", &type_type, &os_error, &dict_type);
+        let base_exception_type = create_type("BaseException", &type_type, &object_type);
+        let exception_type = create_type("Exception", &type_type, &base_exception_type);
+        let arithmetic_error = create_type("ArithmeticError", &type_type, &exception_type);
+        let assertion_error = create_type("AssertionError", &type_type, &exception_type);
+        let attribute_error = create_type("AttributeError", &type_type, &exception_type);
+        let import_error = create_type("ImportError", &type_type, &exception_type);
+        let index_error = create_type("IndexError", &type_type, &exception_type);
+        let key_error = create_type("KeyError", &type_type, &exception_type);
+        let name_error = create_type("NameError", &type_type, &exception_type);
+        let os_error = create_type("OSError", &type_type, &exception_type);
+        let runtime_error = create_type("RuntimeError", &type_type, &exception_type);
+        let stop_iteration = create_type("StopIteration", &type_type, &exception_type);
+        let syntax_error = create_type("SyntaxError", &type_type, &exception_type);
+        let type_error = create_type("TypeError", &type_type, &exception_type);
+        let value_error = create_type("ValueError", &type_type, &exception_type);
+        let overflow_error = create_type("OverflowError", &type_type, &arithmetic_error);
+        let zero_division_error = create_type("ZeroDivisionError", &type_type, &arithmetic_error);
+        let module_not_found_error = create_type("ModuleNotFoundError", &type_type, &import_error);
+        let not_implemented_error = create_type("NotImplementedError", &type_type, &runtime_error);
+        let file_not_found_error = create_type("FileNotFoundError", &type_type, &os_error);
+        let permission_error = create_type("PermissionError", &type_type, &os_error);
 
         ExceptionZoo {
             arithmetic_error,

--- a/vm/src/obj/objdict.rs
+++ b/vm/src/obj/objdict.rs
@@ -3,8 +3,8 @@ use std::collections::HashMap;
 use std::ops::{Deref, DerefMut};
 
 use crate::pyobject::{
-    FromPyObjectRef, PyAttributes, PyContext, PyFuncArgs, PyIteratorValue, PyObject, PyObjectRef,
-    PyRef, PyResult, PyValue, TypeProtocol,
+    PyAttributes, PyContext, PyFuncArgs, PyIteratorValue, PyObject, PyObjectRef, PyRef, PyResult,
+    PyValue, TypeProtocol,
 };
 use crate::vm::{ReprGuard, VirtualMachine};
 
@@ -359,20 +359,6 @@ fn dict_get(vm: &mut VirtualMachine, args: PyFuncArgs) -> PyResult {
         Ok(value.clone())
     } else {
         Ok(vm.get_none())
-    }
-}
-
-pub fn create_type(type_type: PyObjectRef, object_type: PyObjectRef, dict_type: PyObjectRef) {
-    let object_type = FromPyObjectRef::from_pyobj(&object_type);
-    // this is not ideal
-    let ptr = PyObjectRef::into_raw(dict_type.clone()) as *mut PyObject;
-    unsafe {
-        (*ptr).payload = Box::new(objtype::PyClass {
-            name: String::from("dict"),
-            mro: vec![object_type],
-        });
-        (*ptr).dict = Some(RefCell::new(HashMap::new()));
-        (*ptr).typ = Some(type_type.clone());
     }
 }
 

--- a/vm/src/obj/objobject.rs
+++ b/vm/src/obj/objobject.rs
@@ -3,12 +3,10 @@ use super::objstr;
 use super::objtype;
 use crate::obj::objproperty::PropertyBuilder;
 use crate::pyobject::{
-    AttributeProtocol, DictProtocol, IdProtocol, PyAttributes, PyContext, PyFuncArgs, PyObject,
-    PyObjectRef, PyRef, PyResult, TypeProtocol,
+    AttributeProtocol, DictProtocol, IdProtocol, PyAttributes, PyContext, PyFuncArgs, PyObjectRef,
+    PyRef, PyResult, TypeProtocol,
 };
 use crate::vm::VirtualMachine;
-use std::cell::RefCell;
-use std::collections::HashMap;
 
 #[derive(Clone, Debug)]
 pub struct PyInstance;
@@ -20,19 +18,6 @@ pub fn new_instance(vm: &mut VirtualMachine, mut args: PyFuncArgs) -> PyResult {
     let type_ref = args.shift();
     let obj = vm.ctx.new_instance(type_ref.clone(), None);
     Ok(obj)
-}
-
-pub fn create_object(type_type: PyObjectRef, object_type: PyObjectRef, _dict_type: PyObjectRef) {
-    // this is not ideal
-    let ptr = PyObjectRef::into_raw(object_type.clone()) as *mut PyObject;
-    unsafe {
-        (*ptr).payload = Box::new(objtype::PyClass {
-            name: String::from("object"),
-            mro: vec![],
-        });
-        (*ptr).dict = Some(RefCell::new(HashMap::new()));
-        (*ptr).typ = Some(type_type.clone());
-    }
 }
 
 fn object_eq(vm: &mut VirtualMachine, args: PyFuncArgs) -> PyResult {

--- a/vm/src/obj/objtype.rs
+++ b/vm/src/obj/objtype.rs
@@ -108,20 +108,6 @@ impl PyClassRef {
  * The magical type type
  */
 
-pub fn create_type(type_type: PyObjectRef, object_type: PyObjectRef, _dict_type: PyObjectRef) {
-    let object_type = FromPyObjectRef::from_pyobj(&object_type);
-    // this is not ideal
-    let ptr = PyObjectRef::into_raw(type_type.clone()) as *mut PyObject;
-    unsafe {
-        (*ptr).payload = Box::new(PyClass {
-            name: String::from("type"),
-            mro: vec![object_type],
-        });
-        (*ptr).dict = Some(RefCell::new(PyAttributes::new()));
-        (*ptr).typ = Some(type_type);
-    }
-}
-
 pub fn init(ctx: &PyContext) {
     let type_doc = "type(object_or_name, bases, dict)\n\
                     type(object) -> the object's type\n\
@@ -349,7 +335,7 @@ pub fn new(
             mro,
         }),
         dict: Some(RefCell::new(dict)),
-        typ: Some(typ),
+        typ,
     }
     .into_ref())
 }

--- a/vm/src/stdlib/json.rs
+++ b/vm/src/stdlib/json.rs
@@ -234,7 +234,6 @@ pub fn make_module(ctx: &PyContext) -> PyObjectRef {
         "JSONDecodeError",
         &ctx.type_type,
         &ctx.exceptions.exception_type,
-        &ctx.dict_type,
     );
 
     py_module!(ctx, "json", {


### PR DESCRIPTION
Also drops Default for PyObject.