### PR TITLE
Use default opt-level for release builds.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,6 +15,3 @@ rustpython_parser = {path = "parser"}
 rustpython_vm = {path = "vm"}
 rustyline = "2.1.0"
 xdg = "2.2.0"
-
-[profile.release]
-opt-level = "s"


### PR DESCRIPTION
This makes the release build noticeably faster (~50% faster on random microbenchmarks) while increasing the binary size slightly (less than 10% on x86).
It's a question to wasm guys on whether it's acceptable (as AFAIK this option was added specifically for wasm). If not, a per-target config would be needed.