### PR TITLE
Remove inner Box from PyObject

### DIFF
--- a/vm/src/obj/objtype.rs
+++ b/vm/src/obj/objtype.rs
@@ -330,10 +330,10 @@ pub fn new(
     let mros = bases.into_iter().map(|x| _mro(&x)).collect();
     let mro = linearise_mro(mros).unwrap();
     Ok(PyObject {
-        payload: Box::new(PyClass {
+        payload: PyClass {
             name: String::from(name),
             mro,
-        }),
+        },
         dict: Some(RefCell::new(dict)),
         typ,
     }

--- a/vm/src/obj/objweakref.rs
+++ b/vm/src/obj/objweakref.rs
@@ -7,7 +7,7 @@ use std::rc::{Rc, Weak};
 
 #[derive(Debug)]
 pub struct PyWeak {
-    referent: Weak<PyObject>,
+    referent: Weak<PyObject<dyn std::any::Any>>,
 }
 
 impl PyWeak {

--- a/vm/src/pyobject.rs
+++ b/vm/src/pyobject.rs
@@ -782,8 +782,8 @@ impl<T> IntoPyObject for PyRef<T> {
 }
 
 impl<T: ?Sized> fmt::Display for PyRef<T> {
-    fn fmt(&self, _f: &mut fmt::Formatter) -> fmt::Result {
-        Ok(()) // TODO
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        self.obj.fmt(f)
     }
 }
 
@@ -965,9 +965,9 @@ impl BufferProtocol for PyObjectRef {
     }
 }
 
-impl<T: ?Sized> fmt::Debug for PyObject<T> {
-    fn fmt(&self, _f: &mut fmt::Formatter) -> fmt::Result {
-        Ok(()) // TODO
+impl<T: ?Sized + fmt::Debug> fmt::Debug for PyObject<T> {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "[PyObj {:?}]", &self.payload)
     }
 }
 

--- a/vm/src/vm.rs
+++ b/vm/src/vm.rs
@@ -323,7 +323,7 @@ impl VirtualMachine {
         }
 
         // TODO: is it safe to just invoke __call__ otherwise?
-        trace!("invoke __call__ for: {:?}", func_ref.payload);
+        //trace!("invoke __call__ for: {:?}", func_ref.payload);
         self.call_method(&func_ref, "__call__", args)
     }
 
@@ -547,7 +547,7 @@ impl VirtualMachine {
         let cls = obj.typ();
         match cls.get_attr(method_name) {
             Some(method) => self.call_get_descriptor(method, obj.clone()),
-            None => Err(self.new_type_error(format!("{} has no method {:?}", obj, method_name))),
+            None => Err(self.new_type_error(format!("{} has no method {:?}", &obj, method_name))),
         }
     }
 

--- a/vm/src/vm.rs
+++ b/vm/src/vm.rs
@@ -323,7 +323,7 @@ impl VirtualMachine {
         }
 
         // TODO: is it safe to just invoke __call__ otherwise?
-        //trace!("invoke __call__ for: {:?}", func_ref.payload);
+        trace!("invoke __call__ for: {:?}", &func_ref.payload);
         self.call_method(&func_ref, "__call__", args)
     }
 


### PR DESCRIPTION
(WIP: will need to incorporate changes from #670 and fixup `Debug` / `Display` impls)

This removes the `Box` inside `PyObject`, so that a `PyRef` / `PyObjectRef` only needs to follow a single pointer (just like cpython). 