### PR TITLE
Use compile::Mode::Single for the demo terminal

### DIFF
--- a/vm/src/frame.rs
+++ b/vm/src/frame.rs
@@ -687,13 +687,10 @@ impl Frame {
                 let expr = self.pop_value();
                 if !expr.is(&vm.get_none()) {
                     let repr = vm.to_repr(&expr)?;
-                    builtins::builtin_print(
-                        vm,
-                        PyFuncArgs {
-                            args: vec![repr],
-                            kwargs: vec![],
-                        },
-                    )?;
+                    // TODO: implement sys.displayhook
+                    if let Some(print) = vm.ctx.get_attr(&vm.builtins, "print") {
+                        vm.invoke(print, vec![repr])?;
+                    }
                 }
                 Ok(None)
             }

--- a/wasm/demo/src/main.js
+++ b/wasm/demo/src/main.js
@@ -74,57 +74,58 @@ snippets.addEventListener('change', updateSnippet);
 // option selected for the `select`, but the textarea won't be updated)
 updateSnippet();
 
-const prompt = ">>>>> ";
+const prompt = '>>>>> ';
 
 const term = new Terminal();
 term.open(document.getElementById('terminal'));
 term.write(prompt);
 
 function removeNonAscii(str) {
-    if ((str===null) || (str===''))
-        return false;
-    else
-        str = str.toString();
+    if (str === null || str === '') return false;
+    else str = str.toString();
 
     return str.replace(/[^\x20-\x7E]/g, '');
 }
 
 function printToConsole(data) {
-    term.write(removeNonAscii(data) + "\r\n");
+    term.write(removeNonAscii(data) + '\r\n');
 }
 
-const terminalVM = rp.vmStore.init("term_vm");
+const terminalVM = rp.vmStore.init('term_vm');
 terminalVM.setStdout(printToConsole);
 
-var input = "";
-term.on("data", (data) => {
-  const code = data.charCodeAt(0);
-  if (code == 13) { // CR
-    if (input[input.length - 1] == ':') {
-        input += data
-        term.write("\r\n.....");
-    } else {
-        term.write("\r\n");
-        try {
-            terminalVM.exec(input);
-        } catch (err) {
-            if (err instanceof WebAssembly.RuntimeError) {
-                err = window.__RUSTPYTHON_ERROR || err;
+var input = '';
+term.on('data', data => {
+    const code = data.charCodeAt(0);
+    if (code == 13) {
+        // CR
+        if (input[input.length - 1] == ':') {
+            input += data;
+            term.write('\r\n.....');
+        } else {
+            term.write('\r\n');
+            try {
+                terminalVM.execSingle(input);
+            } catch (err) {
+                if (err instanceof WebAssembly.RuntimeError) {
+                    err = window.__RUSTPYTHON_ERROR || err;
+                }
+                printToConsole(err);
             }
-            printToConsole(err);
+            term.write(prompt);
+            input = '';
         }
-        term.write(prompt);
-        input = "";
+    } else if (code == 127) {
+        if (input.length > 0) {
+            term.write('\b \b');
+            input = input.slice(0, -1);
+        }
+    } else if (code < 32 || code == 127) {
+        // Control
+        return;
+    } else {
+        // Visible
+        term.write(data);
+        input += data;
     }
-  } else if (code == 127) {
-    if (input.length > 0) {
-        term.write("\b \b");
-        input = input.slice(0, -1);
-    }
-  } else if (code < 32 || code == 127) { // Control
-    return;
-  } else { // Visible
-    term.write(data);
-    input += data;
-  }
 });

--- a/wasm/lib/src/vm_class.rs
+++ b/wasm/lib/src/vm_class.rs
@@ -288,10 +288,9 @@ impl WASMVirtualMachine {
                 } else if stdout.is_undefined() || stdout.is_null() {
                     Box::new(wasm_builtins::builtin_print_console)
                 } else {
-                    return Err(TypeError::new(
-                        "stdout must be null, a function or a css selector",
-                    )
-                    .into());
+                    return Err(
+                        TypeError::new("stdout must be null, a function or a css selector").into()
+                    );
                 };
             let rustfunc = vm.ctx.new_rustfunc(print_fn);
             vm.ctx.set_attr(&vm.builtins, "print", rustfunc);

--- a/wasm/lib/src/vm_class.rs
+++ b/wasm/lib/src/vm_class.rs
@@ -289,7 +289,7 @@ impl WASMVirtualMachine {
                     Box::new(wasm_builtins::builtin_print_console)
                 } else {
                     return Err(
-                        TypeError::new("stdout must be null, a function or a css selector").into()
+                        TypeError::new("stdout must be null, a function or a css selector").into(),
                     );
                 };
             let rustfunc = vm.ctx.new_rustfunc(print_fn);


### PR DESCRIPTION
Eventually we should use [`sys.displayhook`](https://docs.python.org/3/library/sys.html#sys.displayhook), but this is fine for now.