### PR TITLE
Make it possible to implement PyValue in stdlib

### DIFF
--- a/vm/src/frame.rs
+++ b/vm/src/frame.rs
@@ -184,7 +184,7 @@ pub struct Frame {
 }
 
 impl PyValue for Frame {
-    fn required_type(ctx: &PyContext) -> PyObjectRef {
+    fn class(ctx: &PyContext) -> PyObjectRef {
         ctx.frame_type()
     }
 }

--- a/vm/src/frame.rs
+++ b/vm/src/frame.rs
@@ -184,8 +184,8 @@ pub struct Frame {
 }
 
 impl PyValue for Frame {
-    fn class(ctx: &PyContext) -> PyObjectRef {
-        ctx.frame_type()
+    fn class(vm: &mut VirtualMachine) -> PyObjectRef {
+        vm.ctx.frame_type()
     }
 }
 

--- a/vm/src/obj/objbool.rs
+++ b/vm/src/obj/objbool.rs
@@ -12,8 +12,8 @@ use super::objtuple::PyTuple;
 use super::objtype;
 
 impl IntoPyObject for bool {
-    fn into_pyobject(self, ctx: &PyContext) -> PyResult {
-        Ok(ctx.new_bool(self))
+    fn into_pyobject(self, vm: &mut VirtualMachine) -> PyResult {
+        Ok(vm.ctx.new_bool(self))
     }
 }
 

--- a/vm/src/obj/objbuiltinfunc.rs
+++ b/vm/src/obj/objbuiltinfunc.rs
@@ -8,7 +8,7 @@ pub struct PyBuiltinFunction {
 }
 
 impl PyValue for PyBuiltinFunction {
-    fn required_type(ctx: &PyContext) -> PyObjectRef {
+    fn class(ctx: &PyContext) -> PyObjectRef {
         ctx.builtin_function_or_method_type()
     }
 }

--- a/vm/src/obj/objbuiltinfunc.rs
+++ b/vm/src/obj/objbuiltinfunc.rs
@@ -1,6 +1,7 @@
 use std::fmt;
 
-use crate::pyobject::{PyContext, PyNativeFunc, PyObjectRef, PyValue};
+use crate::pyobject::{PyNativeFunc, PyObjectRef, PyValue};
+use crate::vm::VirtualMachine;
 
 pub struct PyBuiltinFunction {
     // TODO: shouldn't be public
@@ -8,8 +9,8 @@ pub struct PyBuiltinFunction {
 }
 
 impl PyValue for PyBuiltinFunction {
-    fn class(ctx: &PyContext) -> PyObjectRef {
-        ctx.builtin_function_or_method_type()
+    fn class(vm: &mut VirtualMachine) -> PyObjectRef {
+        vm.ctx.builtin_function_or_method_type()
     }
 }
 

--- a/vm/src/obj/objbytearray.rs
+++ b/vm/src/obj/objbytearray.rs
@@ -29,7 +29,7 @@ impl PyByteArray {
 }
 
 impl PyValue for PyByteArray {
-    fn required_type(ctx: &PyContext) -> PyObjectRef {
+    fn class(ctx: &PyContext) -> PyObjectRef {
         ctx.bytearray_type()
     }
 }

--- a/vm/src/obj/objbytearray.rs
+++ b/vm/src/obj/objbytearray.rs
@@ -29,8 +29,8 @@ impl PyByteArray {
 }
 
 impl PyValue for PyByteArray {
-    fn class(ctx: &PyContext) -> PyObjectRef {
-        ctx.bytearray_type()
+    fn class(vm: &mut VirtualMachine) -> PyObjectRef {
+        vm.ctx.bytearray_type()
     }
 }
 

--- a/vm/src/obj/objbytes.rs
+++ b/vm/src/obj/objbytes.rs
@@ -30,8 +30,8 @@ impl Deref for PyBytes {
 }
 
 impl PyValue for PyBytes {
-    fn class(ctx: &PyContext) -> PyObjectRef {
-        ctx.bytes_type()
+    fn class(vm: &mut VirtualMachine) -> PyObjectRef {
+        vm.ctx.bytes_type()
     }
 }
 

--- a/vm/src/obj/objbytes.rs
+++ b/vm/src/obj/objbytes.rs
@@ -30,7 +30,7 @@ impl Deref for PyBytes {
 }
 
 impl PyValue for PyBytes {
-    fn required_type(ctx: &PyContext) -> PyObjectRef {
+    fn class(ctx: &PyContext) -> PyObjectRef {
         ctx.bytes_type()
     }
 }

--- a/vm/src/obj/objcode.rs
+++ b/vm/src/obj/objcode.rs
@@ -26,8 +26,8 @@ impl fmt::Debug for PyCode {
 }
 
 impl PyValue for PyCode {
-    fn class(ctx: &PyContext) -> PyObjectRef {
-        ctx.code_type()
+    fn class(vm: &mut VirtualMachine) -> PyObjectRef {
+        vm.ctx.code_type()
     }
 }
 

--- a/vm/src/obj/objcode.rs
+++ b/vm/src/obj/objcode.rs
@@ -26,7 +26,7 @@ impl fmt::Debug for PyCode {
 }
 
 impl PyValue for PyCode {
-    fn required_type(ctx: &PyContext) -> PyObjectRef {
+    fn class(ctx: &PyContext) -> PyObjectRef {
         ctx.code_type()
     }
 }

--- a/vm/src/obj/objcomplex.rs
+++ b/vm/src/obj/objcomplex.rs
@@ -14,7 +14,7 @@ pub struct PyComplex {
 }
 
 impl PyValue for PyComplex {
-    fn required_type(ctx: &PyContext) -> PyObjectRef {
+    fn class(ctx: &PyContext) -> PyObjectRef {
         ctx.complex_type()
     }
 }

--- a/vm/src/obj/objcomplex.rs
+++ b/vm/src/obj/objcomplex.rs
@@ -14,8 +14,8 @@ pub struct PyComplex {
 }
 
 impl PyValue for PyComplex {
-    fn class(ctx: &PyContext) -> PyObjectRef {
-        ctx.complex_type()
+    fn class(vm: &mut VirtualMachine) -> PyObjectRef {
+        vm.ctx.complex_type()
     }
 }
 

--- a/vm/src/obj/objdict.rs
+++ b/vm/src/obj/objdict.rs
@@ -30,7 +30,7 @@ impl fmt::Debug for PyDict {
 }
 
 impl PyValue for PyDict {
-    fn required_type(ctx: &PyContext) -> PyObjectRef {
+    fn class(ctx: &PyContext) -> PyObjectRef {
         ctx.dict_type()
     }
 }

--- a/vm/src/obj/objdict.rs
+++ b/vm/src/obj/objdict.rs
@@ -30,8 +30,8 @@ impl fmt::Debug for PyDict {
 }
 
 impl PyValue for PyDict {
-    fn class(ctx: &PyContext) -> PyObjectRef {
-        ctx.dict_type()
+    fn class(vm: &mut VirtualMachine) -> PyObjectRef {
+        vm.ctx.dict_type()
     }
 }
 

--- a/vm/src/obj/objenumerate.rs
+++ b/vm/src/obj/objenumerate.rs
@@ -17,7 +17,7 @@ pub struct PyEnumerate {
 }
 
 impl PyValue for PyEnumerate {
-    fn required_type(ctx: &PyContext) -> PyObjectRef {
+    fn class(ctx: &PyContext) -> PyObjectRef {
         ctx.enumerate_type()
     }
 }

--- a/vm/src/obj/objenumerate.rs
+++ b/vm/src/obj/objenumerate.rs
@@ -17,8 +17,8 @@ pub struct PyEnumerate {
 }
 
 impl PyValue for PyEnumerate {
-    fn class(ctx: &PyContext) -> PyObjectRef {
-        ctx.enumerate_type()
+    fn class(vm: &mut VirtualMachine) -> PyObjectRef {
+        vm.ctx.enumerate_type()
     }
 }
 

--- a/vm/src/obj/objfilter.rs
+++ b/vm/src/obj/objfilter.rs
@@ -13,7 +13,7 @@ pub struct PyFilter {
 }
 
 impl PyValue for PyFilter {
-    fn required_type(ctx: &PyContext) -> PyObjectRef {
+    fn class(ctx: &PyContext) -> PyObjectRef {
         ctx.filter_type()
     }
 }

--- a/vm/src/obj/objfilter.rs
+++ b/vm/src/obj/objfilter.rs
@@ -13,8 +13,8 @@ pub struct PyFilter {
 }
 
 impl PyValue for PyFilter {
-    fn class(ctx: &PyContext) -> PyObjectRef {
-        ctx.filter_type()
+    fn class(vm: &mut VirtualMachine) -> PyObjectRef {
+        vm.ctx.filter_type()
     }
 }
 

--- a/vm/src/obj/objfloat.rs
+++ b/vm/src/obj/objfloat.rs
@@ -16,7 +16,7 @@ pub struct PyFloat {
 }
 
 impl PyValue for PyFloat {
-    fn required_type(ctx: &PyContext) -> PyObjectRef {
+    fn class(ctx: &PyContext) -> PyObjectRef {
         ctx.float_type()
     }
 }

--- a/vm/src/obj/objfloat.rs
+++ b/vm/src/obj/objfloat.rs
@@ -16,14 +16,14 @@ pub struct PyFloat {
 }
 
 impl PyValue for PyFloat {
-    fn class(ctx: &PyContext) -> PyObjectRef {
-        ctx.float_type()
+    fn class(vm: &mut VirtualMachine) -> PyObjectRef {
+        vm.ctx.float_type()
     }
 }
 
 impl IntoPyObject for f64 {
-    fn into_pyobject(self, ctx: &PyContext) -> PyResult {
-        Ok(ctx.new_float(self))
+    fn into_pyobject(self, vm: &mut VirtualMachine) -> PyResult {
+        Ok(vm.ctx.new_float(self))
     }
 }
 

--- a/vm/src/obj/objfunction.rs
+++ b/vm/src/obj/objfunction.rs
@@ -23,7 +23,7 @@ impl PyFunction {
 }
 
 impl PyValue for PyFunction {
-    fn required_type(ctx: &PyContext) -> PyObjectRef {
+    fn class(ctx: &PyContext) -> PyObjectRef {
         ctx.function_type()
     }
 }
@@ -42,7 +42,7 @@ impl PyMethod {
 }
 
 impl PyValue for PyMethod {
-    fn required_type(ctx: &PyContext) -> PyObjectRef {
+    fn class(ctx: &PyContext) -> PyObjectRef {
         ctx.bound_method_type()
     }
 }

--- a/vm/src/obj/objfunction.rs
+++ b/vm/src/obj/objfunction.rs
@@ -23,8 +23,8 @@ impl PyFunction {
 }
 
 impl PyValue for PyFunction {
-    fn class(ctx: &PyContext) -> PyObjectRef {
-        ctx.function_type()
+    fn class(vm: &mut VirtualMachine) -> PyObjectRef {
+        vm.ctx.function_type()
     }
 }
 
@@ -42,8 +42,8 @@ impl PyMethod {
 }
 
 impl PyValue for PyMethod {
-    fn class(ctx: &PyContext) -> PyObjectRef {
-        ctx.bound_method_type()
+    fn class(vm: &mut VirtualMachine) -> PyObjectRef {
+        vm.ctx.bound_method_type()
     }
 }
 

--- a/vm/src/obj/objgenerator.rs
+++ b/vm/src/obj/objgenerator.rs
@@ -14,8 +14,8 @@ pub struct PyGenerator {
 }
 
 impl PyValue for PyGenerator {
-    fn class(ctx: &PyContext) -> PyObjectRef {
-        ctx.generator_type()
+    fn class(vm: &mut VirtualMachine) -> PyObjectRef {
+        vm.ctx.generator_type()
     }
 }
 

--- a/vm/src/obj/objgenerator.rs
+++ b/vm/src/obj/objgenerator.rs
@@ -14,7 +14,7 @@ pub struct PyGenerator {
 }
 
 impl PyValue for PyGenerator {
-    fn required_type(ctx: &PyContext) -> PyObjectRef {
+    fn class(ctx: &PyContext) -> PyObjectRef {
         ctx.generator_type()
     }
 }

--- a/vm/src/obj/objint.rs
+++ b/vm/src/obj/objint.rs
@@ -30,22 +30,22 @@ impl PyInt {
 }
 
 impl IntoPyObject for BigInt {
-    fn into_pyobject(self, ctx: &PyContext) -> PyResult {
-        Ok(ctx.new_int(self))
+    fn into_pyobject(self, vm: &mut VirtualMachine) -> PyResult {
+        Ok(vm.ctx.new_int(self))
     }
 }
 
 impl PyValue for PyInt {
-    fn class(ctx: &PyContext) -> PyObjectRef {
-        ctx.int_type()
+    fn class(vm: &mut VirtualMachine) -> PyObjectRef {
+        vm.ctx.int_type()
     }
 }
 
 macro_rules! impl_into_pyobject_int {
     ($($t:ty)*) => {$(
         impl IntoPyObject for $t {
-            fn into_pyobject(self, ctx: &PyContext) -> PyResult {
-                Ok(ctx.new_int(self))
+            fn into_pyobject(self, vm: &mut VirtualMachine) -> PyResult {
+                Ok(vm.ctx.new_int(self))
             }
         }
     )*};

--- a/vm/src/obj/objint.rs
+++ b/vm/src/obj/objint.rs
@@ -36,7 +36,7 @@ impl IntoPyObject for BigInt {
 }
 
 impl PyValue for PyInt {
-    fn required_type(ctx: &PyContext) -> PyObjectRef {
+    fn class(ctx: &PyContext) -> PyObjectRef {
         ctx.int_type()
     }
 }

--- a/vm/src/obj/objlist.rs
+++ b/vm/src/obj/objlist.rs
@@ -38,8 +38,8 @@ impl From<Vec<PyObjectRef>> for PyList {
 }
 
 impl PyValue for PyList {
-    fn class(ctx: &PyContext) -> PyObjectRef {
-        ctx.list_type()
+    fn class(vm: &mut VirtualMachine) -> PyObjectRef {
+        vm.ctx.list_type()
     }
 }
 

--- a/vm/src/obj/objlist.rs
+++ b/vm/src/obj/objlist.rs
@@ -38,7 +38,7 @@ impl From<Vec<PyObjectRef>> for PyList {
 }
 
 impl PyValue for PyList {
-    fn required_type(ctx: &PyContext) -> PyObjectRef {
+    fn class(ctx: &PyContext) -> PyObjectRef {
         ctx.list_type()
     }
 }

--- a/vm/src/obj/objmap.rs
+++ b/vm/src/obj/objmap.rs
@@ -12,8 +12,8 @@ pub struct PyMap {
 }
 
 impl PyValue for PyMap {
-    fn class(ctx: &PyContext) -> PyObjectRef {
-        ctx.map_type()
+    fn class(vm: &mut VirtualMachine) -> PyObjectRef {
+        vm.ctx.map_type()
     }
 }
 

--- a/vm/src/obj/objmap.rs
+++ b/vm/src/obj/objmap.rs
@@ -12,7 +12,7 @@ pub struct PyMap {
 }
 
 impl PyValue for PyMap {
-    fn required_type(ctx: &PyContext) -> PyObjectRef {
+    fn class(ctx: &PyContext) -> PyObjectRef {
         ctx.map_type()
     }
 }

--- a/vm/src/obj/objmemory.rs
+++ b/vm/src/obj/objmemory.rs
@@ -9,8 +9,8 @@ pub struct PyMemoryView {
 }
 
 impl PyValue for PyMemoryView {
-    fn class(ctx: &PyContext) -> PyObjectRef {
-        ctx.memoryview_type()
+    fn class(vm: &mut VirtualMachine) -> PyObjectRef {
+        vm.ctx.memoryview_type()
     }
 }
 

--- a/vm/src/obj/objmemory.rs
+++ b/vm/src/obj/objmemory.rs
@@ -9,7 +9,7 @@ pub struct PyMemoryView {
 }
 
 impl PyValue for PyMemoryView {
-    fn required_type(ctx: &PyContext) -> PyObjectRef {
+    fn class(ctx: &PyContext) -> PyObjectRef {
         ctx.memoryview_type()
     }
 }

--- a/vm/src/obj/objmodule.rs
+++ b/vm/src/obj/objmodule.rs
@@ -9,7 +9,7 @@ pub struct PyModule {
 pub type PyModuleRef = PyRef<PyModule>;
 
 impl PyValue for PyModule {
-    fn required_type(ctx: &PyContext) -> PyObjectRef {
+    fn class(ctx: &PyContext) -> PyObjectRef {
         ctx.module_type()
     }
 }

--- a/vm/src/obj/objmodule.rs
+++ b/vm/src/obj/objmodule.rs
@@ -9,8 +9,8 @@ pub struct PyModule {
 pub type PyModuleRef = PyRef<PyModule>;
 
 impl PyValue for PyModule {
-    fn class(ctx: &PyContext) -> PyObjectRef {
-        ctx.module_type()
+    fn class(vm: &mut VirtualMachine) -> PyObjectRef {
+        vm.ctx.module_type()
     }
 }
 

--- a/vm/src/obj/objnone.rs
+++ b/vm/src/obj/objnone.rs
@@ -8,24 +8,24 @@ pub struct PyNone;
 pub type PyNoneRef = PyRef<PyNone>;
 
 impl PyValue for PyNone {
-    fn class(ctx: &PyContext) -> PyObjectRef {
-        ctx.none().typ()
+    fn class(vm: &mut VirtualMachine) -> PyObjectRef {
+        vm.ctx.none().typ()
     }
 }
 
 // This allows a built-in function to not return a value, mapping to
 // Python's behavior of returning `None` in this situation.
 impl IntoPyObject for () {
-    fn into_pyobject(self, ctx: &PyContext) -> PyResult {
-        Ok(ctx.none())
+    fn into_pyobject(self, vm: &mut VirtualMachine) -> PyResult {
+        Ok(vm.ctx.none())
     }
 }
 
 impl<T: IntoPyObject> IntoPyObject for Option<T> {
-    fn into_pyobject(self, ctx: &PyContext) -> PyResult {
+    fn into_pyobject(self, vm: &mut VirtualMachine) -> PyResult {
         match self {
-            Some(x) => x.into_pyobject(ctx),
-            None => Ok(ctx.none()),
+            Some(x) => x.into_pyobject(vm),
+            None => Ok(vm.ctx.none()),
         }
     }
 }

--- a/vm/src/obj/objnone.rs
+++ b/vm/src/obj/objnone.rs
@@ -8,7 +8,7 @@ pub struct PyNone;
 pub type PyNoneRef = PyRef<PyNone>;
 
 impl PyValue for PyNone {
-    fn required_type(ctx: &PyContext) -> PyObjectRef {
+    fn class(ctx: &PyContext) -> PyObjectRef {
         ctx.none().typ()
     }
 }

--- a/vm/src/obj/objobject.rs
+++ b/vm/src/obj/objobject.rs
@@ -12,7 +12,7 @@ use crate::vm::VirtualMachine;
 pub struct PyInstance;
 
 impl PyValue for PyInstance {
-    fn required_type(ctx: &PyContext) -> PyObjectRef {
+    fn class(ctx: &PyContext) -> PyObjectRef {
         ctx.object()
     }
 }

--- a/vm/src/obj/objobject.rs
+++ b/vm/src/obj/objobject.rs
@@ -12,8 +12,8 @@ use crate::vm::VirtualMachine;
 pub struct PyInstance;
 
 impl PyValue for PyInstance {
-    fn class(ctx: &PyContext) -> PyObjectRef {
-        ctx.object()
+    fn class(vm: &mut VirtualMachine) -> PyObjectRef {
+        vm.ctx.object()
     }
 }
 

--- a/vm/src/obj/objproperty.rs
+++ b/vm/src/obj/objproperty.rs
@@ -16,8 +16,8 @@ pub struct PyReadOnlyProperty {
 }
 
 impl PyValue for PyReadOnlyProperty {
-    fn class(ctx: &PyContext) -> PyObjectRef {
-        ctx.readonly_property_type()
+    fn class(vm: &mut VirtualMachine) -> PyObjectRef {
+        vm.ctx.readonly_property_type()
     }
 }
 
@@ -38,8 +38,8 @@ pub struct PyProperty {
 }
 
 impl PyValue for PyProperty {
-    fn class(ctx: &PyContext) -> PyObjectRef {
-        ctx.property_type()
+    fn class(vm: &mut VirtualMachine) -> PyObjectRef {
+        vm.ctx.property_type()
     }
 }
 

--- a/vm/src/obj/objproperty.rs
+++ b/vm/src/obj/objproperty.rs
@@ -16,7 +16,7 @@ pub struct PyReadOnlyProperty {
 }
 
 impl PyValue for PyReadOnlyProperty {
-    fn required_type(ctx: &PyContext) -> PyObjectRef {
+    fn class(ctx: &PyContext) -> PyObjectRef {
         ctx.readonly_property_type()
     }
 }
@@ -38,7 +38,7 @@ pub struct PyProperty {
 }
 
 impl PyValue for PyProperty {
-    fn required_type(ctx: &PyContext) -> PyObjectRef {
+    fn class(ctx: &PyContext) -> PyObjectRef {
         ctx.property_type()
     }
 }

--- a/vm/src/obj/objrange.rs
+++ b/vm/src/obj/objrange.rs
@@ -24,8 +24,8 @@ pub struct PyRange {
 }
 
 impl PyValue for PyRange {
-    fn class(ctx: &PyContext) -> PyObjectRef {
-        ctx.range_type()
+    fn class(vm: &mut VirtualMachine) -> PyObjectRef {
+        vm.ctx.range_type()
     }
 }
 

--- a/vm/src/obj/objrange.rs
+++ b/vm/src/obj/objrange.rs
@@ -24,7 +24,7 @@ pub struct PyRange {
 }
 
 impl PyValue for PyRange {
-    fn required_type(ctx: &PyContext) -> PyObjectRef {
+    fn class(ctx: &PyContext) -> PyObjectRef {
         ctx.range_type()
     }
 }

--- a/vm/src/obj/objset.rs
+++ b/vm/src/obj/objset.rs
@@ -30,7 +30,7 @@ impl fmt::Debug for PySet {
 }
 
 impl PyValue for PySet {
-    fn required_type(ctx: &PyContext) -> PyObjectRef {
+    fn class(ctx: &PyContext) -> PyObjectRef {
         ctx.set_type()
     }
 }

--- a/vm/src/obj/objset.rs
+++ b/vm/src/obj/objset.rs
@@ -30,8 +30,8 @@ impl fmt::Debug for PySet {
 }
 
 impl PyValue for PySet {
-    fn class(ctx: &PyContext) -> PyObjectRef {
-        ctx.set_type()
+    fn class(vm: &mut VirtualMachine) -> PyObjectRef {
+        vm.ctx.set_type()
     }
 }
 

--- a/vm/src/obj/objslice.rs
+++ b/vm/src/obj/objslice.rs
@@ -14,8 +14,8 @@ pub struct PySlice {
 }
 
 impl PyValue for PySlice {
-    fn class(ctx: &PyContext) -> PyObjectRef {
-        ctx.slice_type()
+    fn class(vm: &mut VirtualMachine) -> PyObjectRef {
+        vm.ctx.slice_type()
     }
 }
 

--- a/vm/src/obj/objslice.rs
+++ b/vm/src/obj/objslice.rs
@@ -14,7 +14,7 @@ pub struct PySlice {
 }
 
 impl PyValue for PySlice {
-    fn required_type(ctx: &PyContext) -> PyObjectRef {
+    fn class(ctx: &PyContext) -> PyObjectRef {
         ctx.slice_type()
     }
 }

--- a/vm/src/obj/objstr.rs
+++ b/vm/src/obj/objstr.rs
@@ -597,14 +597,14 @@ impl PyStringRef {
 }
 
 impl PyValue for PyString {
-    fn class(ctx: &PyContext) -> PyObjectRef {
-        ctx.str_type()
+    fn class(vm: &mut VirtualMachine) -> PyObjectRef {
+        vm.ctx.str_type()
     }
 }
 
 impl IntoPyObject for String {
-    fn into_pyobject(self, ctx: &PyContext) -> PyResult {
-        Ok(ctx.new_str(self))
+    fn into_pyobject(self, vm: &mut VirtualMachine) -> PyResult {
+        Ok(vm.ctx.new_str(self))
     }
 }
 

--- a/vm/src/obj/objstr.rs
+++ b/vm/src/obj/objstr.rs
@@ -597,7 +597,7 @@ impl PyStringRef {
 }
 
 impl PyValue for PyString {
-    fn required_type(ctx: &PyContext) -> PyObjectRef {
+    fn class(ctx: &PyContext) -> PyObjectRef {
         ctx.str_type()
     }
 }

--- a/vm/src/obj/objtuple.rs
+++ b/vm/src/obj/objtuple.rs
@@ -39,7 +39,7 @@ impl From<Vec<PyObjectRef>> for PyTuple {
 }
 
 impl PyValue for PyTuple {
-    fn required_type(ctx: &PyContext) -> PyObjectRef {
+    fn class(ctx: &PyContext) -> PyObjectRef {
         ctx.tuple_type()
     }
 }

--- a/vm/src/obj/objtuple.rs
+++ b/vm/src/obj/objtuple.rs
@@ -39,8 +39,8 @@ impl From<Vec<PyObjectRef>> for PyTuple {
 }
 
 impl PyValue for PyTuple {
-    fn class(ctx: &PyContext) -> PyObjectRef {
-        ctx.tuple_type()
+    fn class(vm: &mut VirtualMachine) -> PyObjectRef {
+        vm.ctx.tuple_type()
     }
 }
 

--- a/vm/src/obj/objtype.rs
+++ b/vm/src/obj/objtype.rs
@@ -22,8 +22,8 @@ pub struct PyClass {
 pub type PyClassRef = PyRef<PyClass>;
 
 impl PyValue for PyClass {
-    fn class(ctx: &PyContext) -> PyObjectRef {
-        ctx.type_type()
+    fn class(vm: &mut VirtualMachine) -> PyObjectRef {
+        vm.ctx.type_type()
     }
 }
 

--- a/vm/src/obj/objtype.rs
+++ b/vm/src/obj/objtype.rs
@@ -22,7 +22,7 @@ pub struct PyClass {
 pub type PyClassRef = PyRef<PyClass>;
 
 impl PyValue for PyClass {
-    fn required_type(ctx: &PyContext) -> PyObjectRef {
+    fn class(ctx: &PyContext) -> PyObjectRef {
         ctx.type_type()
     }
 }

--- a/vm/src/obj/objweakref.rs
+++ b/vm/src/obj/objweakref.rs
@@ -23,8 +23,8 @@ impl PyWeak {
 }
 
 impl PyValue for PyWeak {
-    fn class(ctx: &PyContext) -> PyObjectRef {
-        ctx.weakref_type()
+    fn class(vm: &mut VirtualMachine) -> PyObjectRef {
+        vm.ctx.weakref_type()
     }
 }
 

--- a/vm/src/obj/objweakref.rs
+++ b/vm/src/obj/objweakref.rs
@@ -23,7 +23,7 @@ impl PyWeak {
 }
 
 impl PyValue for PyWeak {
-    fn required_type(ctx: &PyContext) -> PyObjectRef {
+    fn class(ctx: &PyContext) -> PyObjectRef {
         ctx.weakref_type()
     }
 }

--- a/vm/src/obj/objzip.rs
+++ b/vm/src/obj/objzip.rs
@@ -11,7 +11,7 @@ pub struct PyZip {
 }
 
 impl PyValue for PyZip {
-    fn required_type(ctx: &PyContext) -> PyObjectRef {
+    fn class(ctx: &PyContext) -> PyObjectRef {
         ctx.zip_type()
     }
 }

--- a/vm/src/obj/objzip.rs
+++ b/vm/src/obj/objzip.rs
@@ -11,8 +11,8 @@ pub struct PyZip {
 }
 
 impl PyValue for PyZip {
-    fn class(ctx: &PyContext) -> PyObjectRef {
-        ctx.zip_type()
+    fn class(vm: &mut VirtualMachine) -> PyObjectRef {
+        vm.ctx.zip_type()
     }
 }
 

--- a/vm/src/stdlib/re.rs
+++ b/vm/src/stdlib/re.rs
@@ -17,7 +17,7 @@ use crate::pyobject::{
 use crate::VirtualMachine;
 
 impl PyValue for Regex {
-    fn required_type(_ctx: &PyContext) -> PyObjectRef {
+    fn class(_ctx: &PyContext) -> PyObjectRef {
         // TODO
         unimplemented!()
     }
@@ -111,7 +111,7 @@ struct PyMatch {
 }
 
 impl PyValue for PyMatch {
-    fn required_type(_ctx: &PyContext) -> PyObjectRef {
+    fn class(_ctx: &PyContext) -> PyObjectRef {
         // TODO
         unimplemented!()
     }

--- a/vm/src/stdlib/re.rs
+++ b/vm/src/stdlib/re.rs
@@ -5,21 +5,21 @@
  * system.
  */
 
-// extern crate regex;
-use crate::import;
-use regex::{Match, Regex};
 use std::path::PathBuf;
 
+use regex::{Match, Regex};
+
+use crate::import;
 use crate::obj::objstr;
 use crate::pyobject::{
-    PyContext, PyFuncArgs, PyObject, PyObjectRef, PyResult, PyValue, TypeProtocol,
+    AttributeProtocol, PyContext, PyFuncArgs, PyObject, PyObjectRef, PyResult, PyValue,
+    TypeProtocol,
 };
 use crate::VirtualMachine;
 
 impl PyValue for Regex {
-    fn class(_ctx: &PyContext) -> PyObjectRef {
-        // TODO
-        unimplemented!()
+    fn class(vm: &mut VirtualMachine) -> PyObjectRef {
+        vm.import("re").unwrap().get_attr("Pattern").unwrap()
     }
 }
 
@@ -111,9 +111,8 @@ struct PyMatch {
 }
 
 impl PyValue for PyMatch {
-    fn class(_ctx: &PyContext) -> PyObjectRef {
-        // TODO
-        unimplemented!()
+    fn class(vm: &mut VirtualMachine) -> PyObjectRef {
+        vm.import("re").unwrap().get_attr("Match").unwrap()
     }
 }
 

--- a/vm/src/stdlib/re.rs
+++ b/vm/src/stdlib/re.rs
@@ -112,7 +112,7 @@ struct PyMatch {
 
 impl PyValue for PyMatch {
     fn class(vm: &mut VirtualMachine) -> PyObjectRef {
-        vm.import("re").unwrap().get_attr("Match").unwrap()
+        vm.class("re", "Match")
     }
 }
 

--- a/vm/src/stdlib/socket.rs
+++ b/vm/src/stdlib/socket.rs
@@ -119,7 +119,7 @@ pub struct Socket {
 }
 
 impl PyValue for Socket {
-    fn required_type(_ctx: &PyContext) -> PyObjectRef {
+    fn class(_ctx: &PyContext) -> PyObjectRef {
         // TODO
         unimplemented!()
     }

--- a/vm/src/stdlib/socket.rs
+++ b/vm/src/stdlib/socket.rs
@@ -119,7 +119,7 @@ pub struct Socket {
 }
 
 impl PyValue for Socket {
-    fn class(_ctx: &PyContext) -> PyObjectRef {
+    fn class(_vm: &mut VirtualMachine) -> PyObjectRef {
         // TODO
         unimplemented!()
     }

--- a/vm/src/vm.rs
+++ b/vm/src/vm.rs
@@ -103,6 +103,13 @@ impl VirtualMachine {
         &frame.scope
     }
 
+    pub fn class(&mut self, module: &str, class: &str) -> PyObjectRef {
+        self.import(module)
+            .unwrap_or_else(|_| panic!("unable to import {}", module))
+            .get_attr(class)
+            .unwrap_or_else(|| panic!("module {} has no class {}", module, class))
+    }
+
     /// Create a new python string object.
     pub fn new_str(&self, s: String) -> PyObjectRef {
         self.ctx.new_str(s)

--- a/wasm/lib/src/browser_module.rs
+++ b/wasm/lib/src/browser_module.rs
@@ -158,7 +158,7 @@ pub struct PyPromise {
 }
 
 impl PyValue for PyPromise {
-    fn class(_ctx: &PyContext) -> PyObjectRef {
+    fn class(_vm: &mut VirtualMachine) -> PyObjectRef {
         // TODO
         unimplemented!()
     }

--- a/wasm/lib/src/browser_module.rs
+++ b/wasm/lib/src/browser_module.rs
@@ -158,7 +158,7 @@ pub struct PyPromise {
 }
 
 impl PyValue for PyPromise {
-    fn required_type(_ctx: &PyContext) -> PyObjectRef {
+    fn class(_ctx: &PyContext) -> PyObjectRef {
         // TODO
         unimplemented!()
     }


### PR DESCRIPTION
- Renamed `PyValue::required_type()` to `PyValue::class()` which is clearer
- Make a full `&mut VirtualMachine` available rather than just a `&PyContext`, which is needed for implementing types in stdlib