### PR TITLE
Remove the `Rc`s around the WASM global HashMaps

### DIFF
--- a/wasm/lib/src/convert.rs
+++ b/wasm/lib/src/convert.rs
@@ -47,7 +47,7 @@ pub fn py_err_to_js_err(vm: &mut VirtualMachine, py_err: &PyObjectRef) -> JsValu
                         .ok()
                         .and_then(|lineno| lineno.to_u32())
                     {
-                        Reflect::set(&js_err, &"row".into(), &lineno.into());
+                        let _ = Reflect::set(&js_err, &"row".into(), &lineno.into());
                     }
                 }
             }

--- a/wasm/lib/src/vm_class.rs
+++ b/wasm/lib/src/vm_class.rs
@@ -41,12 +41,13 @@ impl StoredVirtualMachine {
     }
 }
 
-// It's fine that it's thread local, since WASM doesn't even have threads yet. thread_local! probably
-// gets compiled down to a normal-ish static varible, like Atomic* types:
+// It's fine that it's thread local, since WASM doesn't even have threads yet. thread_local!
+// probably gets compiled down to a normal-ish static varible, like Atomic* types do:
 // https://rustwasm.github.io/2018/10/24/multithreading-rust-and-wasm.html#atomic-instructions
 thread_local! {
-    static STORED_VMS: Rc<RefCell<HashMap<String, Rc<RefCell<StoredVirtualMachine>>>>> = Rc::default();
-    static ACTIVE_VMS: Rc<RefCell<HashMap<String, *mut VirtualMachine>>> = Rc::default();
+    static STORED_VMS: RefCell<HashMap<String, Rc<RefCell<StoredVirtualMachine>>>> =
+        RefCell::default();
+    static ACTIVE_VMS: RefCell<HashMap<String, *mut VirtualMachine>> = RefCell::default();
 }
 
 #[wasm_bindgen(js_name = vmStore)]


### PR DESCRIPTION
They weren't necessary at all, I don't know why I added them.