### PR TITLE
Prefer pyvalue into ref

### DIFF
--- a/vm/src/frame.rs
+++ b/vm/src/frame.rs
@@ -409,7 +409,7 @@ impl Frame {
                 let stop = out[1].take();
                 let step = if out.len() == 3 { out[2].take() } else { None };
 
-                let obj = PySlice { start, stop, step }.into_ref(&vm.ctx);
+                let obj = PySlice { start, stop, step }.into_ref(vm);
                 self.push_value(obj.into_object());
                 Ok(None)
             }
@@ -699,8 +699,8 @@ impl Frame {
                 Ok(None)
             }
             bytecode::Instruction::LoadBuildClass => {
-                let rustfunc = PyBuiltinFunction::new(Box::new(builtins::builtin_build_class_))
-                    .into_ref(&vm.ctx);
+                let rustfunc =
+                    PyBuiltinFunction::new(Box::new(builtins::builtin_build_class_)).into_ref(vm);
                 self.push_value(rustfunc.into_object());
                 Ok(None)
             }

--- a/vm/src/frame.rs
+++ b/vm/src/frame.rs
@@ -20,8 +20,8 @@ use crate::obj::objslice::PySlice;
 use crate::obj::objstr;
 use crate::obj::objtype;
 use crate::pyobject::{
-    AttributeProtocol, DictProtocol, IdProtocol, PyContext, PyFuncArgs, PyObject, PyObjectRef,
-    PyResult, PyValue, TryFromObject, TypeProtocol,
+    AttributeProtocol, DictProtocol, IdProtocol, PyContext, PyFuncArgs, PyObjectRef, PyResult,
+    PyValue, TryFromObject, TypeProtocol,
 };
 use crate::vm::VirtualMachine;
 
@@ -409,8 +409,8 @@ impl Frame {
                 let stop = out[1].take();
                 let step = if out.len() == 3 { out[2].take() } else { None };
 
-                let obj = PyObject::new(PySlice { start, stop, step }, vm.ctx.slice_type());
-                self.push_value(obj);
+                let obj = PySlice { start, stop, step }.into_ref(&vm.ctx);
+                self.push_value(obj.into_object());
                 Ok(None)
             }
             bytecode::Instruction::ListAppend { i } => {
@@ -702,11 +702,9 @@ impl Frame {
                 Ok(None)
             }
             bytecode::Instruction::LoadBuildClass => {
-                let rustfunc = PyObject::new(
-                    PyBuiltinFunction::new(Box::new(builtins::builtin_build_class_)),
-                    vm.ctx.type_type(),
-                );
-                self.push_value(rustfunc);
+                let rustfunc = PyBuiltinFunction::new(Box::new(builtins::builtin_build_class_))
+                    .into_ref(&vm.ctx);
+                self.push_value(rustfunc.into_object());
                 Ok(None)
             }
             bytecode::Instruction::UnpackSequence { size } => {

--- a/vm/src/obj/objbytearray.rs
+++ b/vm/src/obj/objbytearray.rs
@@ -5,12 +5,12 @@ use std::fmt::Write;
 use std::ops::{Deref, DerefMut};
 
 use crate::pyobject::{
-    PyContext, PyFuncArgs, PyObject, PyObjectRef, PyResult, PyValue, TypeProtocol,
+    OptionalArg, PyContext, PyFuncArgs, PyObjectRef, PyRef, PyResult, PyValue, TypeProtocol,
 };
 
 use super::objint;
 
-use super::objtype;
+use super::objtype::{self, PyClassRef};
 use crate::vm::VirtualMachine;
 use num_traits::ToPrimitive;
 
@@ -19,6 +19,7 @@ pub struct PyByteArray {
     // TODO: shouldn't be public
     pub value: RefCell<Vec<u8>>,
 }
+type PyByteArrayRef = PyRef<PyByteArray>;
 
 impl PyByteArray {
     pub fn new(data: Vec<u8>) -> Self {
@@ -144,20 +145,14 @@ pub fn init(context: &PyContext) {
     );
 }
 
-fn bytearray_new(vm: &mut VirtualMachine, args: PyFuncArgs) -> PyResult {
-    arg_check!(
-        vm,
-        args,
-        required = [(cls, None)],
-        optional = [(val_option, None)]
-    );
-    if !objtype::issubclass(cls, &vm.ctx.bytearray_type()) {
-        return Err(vm.new_type_error(format!("{:?} is not a subtype of bytearray", cls)));
-    }
-
+fn bytearray_new(
+    cls: PyClassRef,
+    val_option: OptionalArg<PyObjectRef>,
+    vm: &mut VirtualMachine,
+) -> PyResult<PyByteArrayRef> {
     // Create bytes data:
-    let value = if let Some(ival) = val_option {
-        let elements = vm.extract_elements(ival)?;
+    let value = if let OptionalArg::Present(ival) = val_option {
+        let elements = vm.extract_elements(&ival)?;
         let mut data_bytes = vec![];
         for elem in elements.iter() {
             let v = objint::to_int(vm, elem, 10)?;
@@ -172,7 +167,7 @@ fn bytearray_new(vm: &mut VirtualMachine, args: PyFuncArgs) -> PyResult {
     } else {
         vec![]
     };
-    Ok(PyObject::new(PyByteArray::new(value), cls.clone()))
+    PyByteArray::new(value).into_ref_with_type(vm, cls.clone())
 }
 
 fn bytesarray_len(vm: &mut VirtualMachine, args: PyFuncArgs) -> PyResult {

--- a/vm/src/obj/objcomplex.rs
+++ b/vm/src/obj/objcomplex.rs
@@ -1,8 +1,8 @@
 use super::objfloat;
 use super::objint;
-use super::objtype;
+use super::objtype::{self, PyClassRef};
 use crate::pyobject::{
-    PyContext, PyFuncArgs, PyObject, PyObjectRef, PyResult, PyValue, TypeProtocol,
+    OptionalArg, PyContext, PyFuncArgs, PyObjectRef, PyRef, PyResult, PyValue, TypeProtocol,
 };
 use crate::vm::VirtualMachine;
 use num_complex::Complex64;
@@ -12,6 +12,7 @@ use num_traits::ToPrimitive;
 pub struct PyComplex {
     value: Complex64,
 }
+type PyComplexRef = PyRef<PyComplex>;
 
 impl PyValue for PyComplex {
     fn required_type(ctx: &PyContext) -> PyObjectRef {
@@ -65,31 +66,24 @@ pub fn get_value(obj: &PyObjectRef) -> Complex64 {
     obj.payload::<PyComplex>().unwrap().value
 }
 
-fn complex_new(vm: &mut VirtualMachine, args: PyFuncArgs) -> PyResult {
-    arg_check!(
-        vm,
-        args,
-        required = [(cls, None)],
-        optional = [(real, None), (imag, None)]
-    );
-
-    if !objtype::issubclass(cls, &vm.ctx.complex_type()) {
-        return Err(vm.new_type_error(format!("{:?} is not a subtype of complex", cls)));
-    }
-
+fn complex_new(
+    cls: PyClassRef,
+    real: OptionalArg<PyObjectRef>,
+    imag: OptionalArg<PyObjectRef>,
+    vm: &mut VirtualMachine,
+) -> PyResult<PyComplexRef> {
     let real = match real {
-        None => 0.0,
-        Some(value) => objfloat::make_float(vm, value)?,
+        OptionalArg::Missing => 0.0,
+        OptionalArg::Present(ref value) => objfloat::make_float(vm, value)?,
     };
 
     let imag = match imag {
-        None => 0.0,
-        Some(value) => objfloat::make_float(vm, value)?,
+        OptionalArg::Missing => 0.0,
+        OptionalArg::Present(ref value) => objfloat::make_float(vm, value)?,
     };
 
     let value = Complex64::new(real, imag);
-
-    Ok(PyObject::new(PyComplex { value }, cls.clone()))
+    PyComplex { value }.into_ref_with_type(vm, cls)
 }
 
 fn complex_real(vm: &mut VirtualMachine, args: PyFuncArgs) -> PyResult {

--- a/vm/src/obj/objproperty.rs
+++ b/vm/src/obj/objproperty.rs
@@ -54,15 +54,12 @@ impl PyPropertyRef {
         _doc: OptionalArg<PyStringRef>,
         vm: &mut VirtualMachine,
     ) -> PyResult<PyPropertyRef> {
-        Self::new_with_type(
-            vm,
-            PyProperty {
-                getter: fget.into_option(),
-                setter: fset.into_option(),
-                deleter: fdel.into_option(),
-            },
-            cls,
-        )
+        PyProperty {
+            getter: fget.into_option(),
+            setter: fset.into_option(),
+            deleter: fdel.into_option(),
+        }
+        .into_ref_with_type(vm, cls)
     }
 
     // Descriptor methods
@@ -108,39 +105,30 @@ impl PyPropertyRef {
     // Python builder functions
 
     fn getter(self, getter: Option<PyObjectRef>, vm: &mut VirtualMachine) -> PyResult<Self> {
-        Self::new_with_type(
-            vm,
-            PyProperty {
-                getter: getter.or_else(|| self.getter.clone()),
-                setter: self.setter.clone(),
-                deleter: self.deleter.clone(),
-            },
-            self.typ(),
-        )
+        PyProperty {
+            getter: getter.or_else(|| self.getter.clone()),
+            setter: self.setter.clone(),
+            deleter: self.deleter.clone(),
+        }
+        .into_ref_with_type(vm, self.typ())
     }
 
     fn setter(self, setter: Option<PyObjectRef>, vm: &mut VirtualMachine) -> PyResult<Self> {
-        Self::new_with_type(
-            vm,
-            PyProperty {
-                getter: self.getter.clone(),
-                setter: setter.or_else(|| self.setter.clone()),
-                deleter: self.deleter.clone(),
-            },
-            self.typ(),
-        )
+        PyProperty {
+            getter: self.getter.clone(),
+            setter: setter.or_else(|| self.setter.clone()),
+            deleter: self.deleter.clone(),
+        }
+        .into_ref_with_type(vm, self.typ())
     }
 
     fn deleter(self, deleter: Option<PyObjectRef>, vm: &mut VirtualMachine) -> PyResult<Self> {
-        Self::new_with_type(
-            vm,
-            PyProperty {
-                getter: self.getter.clone(),
-                setter: self.setter.clone(),
-                deleter: deleter.or_else(|| self.deleter.clone()),
-            },
-            self.typ(),
-        )
+        PyProperty {
+            getter: self.getter.clone(),
+            setter: self.setter.clone(),
+            deleter: deleter.or_else(|| self.deleter.clone()),
+        }
+        .into_ref_with_type(vm, self.typ())
     }
 }
 

--- a/vm/src/obj/objstr.rs
+++ b/vm/src/obj/objstr.rs
@@ -801,7 +801,7 @@ fn str_new(
         TryFromObject::try_from_object(vm, string)
     } else {
         let payload = string.payload::<PyString>().unwrap();
-        PyRef::new_with_type(vm, payload.clone(), cls)
+        payload.clone().into_ref_with_type(vm, cls)
     }
 }
 

--- a/vm/src/obj/objweakref.rs
+++ b/vm/src/obj/objweakref.rs
@@ -33,7 +33,7 @@ pub type PyWeakRef = PyRef<PyWeak>;
 impl PyWeakRef {
     // TODO callbacks
     fn create(cls: PyClassRef, referent: PyObjectRef, vm: &mut VirtualMachine) -> PyResult<Self> {
-        Self::new_with_type(vm, PyWeak::downgrade(referent), cls)
+        PyWeak::downgrade(referent).into_ref_with_type(vm, cls)
     }
 
     fn call(self, vm: &mut VirtualMachine) -> PyObjectRef {

--- a/vm/src/pyobject.rs
+++ b/vm/src/pyobject.rs
@@ -713,27 +713,6 @@ pub struct PyRef<T> {
 }
 
 impl<T: PyValue> PyRef<T> {
-    pub fn new(ctx: &PyContext, payload: T) -> Self {
-        PyRef {
-            obj: PyObject::new(payload, T::required_type(ctx)),
-            _payload: PhantomData,
-        }
-    }
-
-    pub fn new_with_type(vm: &mut VirtualMachine, payload: T, cls: PyClassRef) -> PyResult<Self> {
-        let required_type = T::required_type(&vm.ctx);
-        if objtype::issubclass(&cls.obj, &required_type) {
-            Ok(PyRef {
-                obj: PyObject::new(payload, cls.obj),
-                _payload: PhantomData,
-            })
-        } else {
-            let subtype = vm.to_pystr(&cls.obj)?;
-            let basetype = vm.to_pystr(&required_type)?;
-            Err(vm.new_type_error(format!("{} is not a subtype of {}", subtype, basetype)))
-        }
-    }
-
     pub fn as_object(&self) -> &PyObjectRef {
         &self.obj
     }


### PR DESCRIPTION
Various refactors to avoid direct use of PyObject and put things through the into_ref interface.