### PR TITLE
Refactor symbolic strings

### DIFF
--- a/vm/src/builtins.rs
+++ b/vm/src/builtins.rs
@@ -325,7 +325,7 @@ fn builtin_hasattr(vm: &mut VirtualMachine, args: PyFuncArgs) -> PyResult {
 fn builtin_hash(vm: &mut VirtualMachine, args: PyFuncArgs) -> PyResult {
     arg_check!(vm, args, required = [(obj, None)]);
 
-    vm.call_method(obj, "__hash__", vec![])
+    vm.call_method(obj, crate::VM_HASH, vec![])
 }
 
 // builtin_help

--- a/vm/src/compile.rs
+++ b/vm/src/compile.rs
@@ -30,7 +30,7 @@ pub fn compile(
 ) -> Result<PyObjectRef, CompileError> {
     let mut compiler = Compiler::new();
     compiler.source_path = Some(source_path);
-    compiler.push_new_code_object("<module>".to_string());
+    compiler.push_new_code_object(crate::VM_MODULE.to_string());
 
     match mode {
         Mode::Exec => {
@@ -1524,7 +1524,7 @@ mod tests {
     fn compile_exec(source: &str) -> CodeObject {
         let mut compiler = Compiler::new();
         compiler.source_path = Some("source_path".to_string());
-        compiler.push_new_code_object("<module>".to_string());
+        compiler.push_new_code_object(crate::VM_MODULE.to_string());
         let ast = parser::parse_program(&source.to_string()).unwrap();
         compiler.compile_program(&ast).unwrap();
         compiler.pop_code_object()

--- a/vm/src/dictdatatype.rs
+++ b/vm/src/dictdatatype.rs
@@ -170,7 +170,7 @@ enum LookupResult {
 }
 
 fn calc_hash(vm: &mut VirtualMachine, key: &PyObjectRef) -> PyResult<usize> {
-    let hash = vm.call_method(key, "__hash__", vec![])?;
+    let hash = vm.call_method(key, crate::VM_HASH, vec![])?;
     Ok(objint::get_value(&hash).to_usize().unwrap())
 }
 

--- a/vm/src/exceptions.rs
+++ b/vm/src/exceptions.rs
@@ -168,7 +168,7 @@ pub fn init(context: &PyContext) {
     let exception_type = &context.exceptions.exception_type;
     context.set_attr(
         &exception_type,
-        "__str__",
+        crate::VM_STR,
         context.new_rustfunc(exception_str),
     );
 }

--- a/vm/src/lib.rs
+++ b/vm/src/lib.rs
@@ -55,3 +55,4 @@ pub use self::exceptions::print_exception;
 pub use self::vm::VirtualMachine;
 
 pub static VM_REPR: &str = "__repr__";
+pub static VM_MODULE: &str = "<module>";

--- a/vm/src/lib.rs
+++ b/vm/src/lib.rs
@@ -53,3 +53,5 @@ mod vm;
 // pub use self::pyobject::Executor;
 pub use self::exceptions::print_exception;
 pub use self::vm::VirtualMachine;
+
+pub static VM_REPR: &str = "__repr__";

--- a/vm/src/lib.rs
+++ b/vm/src/lib.rs
@@ -56,3 +56,4 @@ pub use self::vm::VirtualMachine;
 
 pub static VM_REPR: &str = "__repr__";
 pub static VM_MODULE: &str = "<module>";
+pub static VM_STR: &str = "__str__";

--- a/vm/src/lib.rs
+++ b/vm/src/lib.rs
@@ -57,3 +57,4 @@ pub use self::vm::VirtualMachine;
 pub static VM_REPR: &str = "__repr__";
 pub static VM_MODULE: &str = "<module>";
 pub static VM_STR: &str = "__str__";
+pub static VM_HASH: &str = "__hash__";

--- a/vm/src/obj/objbool.rs
+++ b/vm/src/obj/objbool.rs
@@ -57,7 +57,7 @@ The class bool is a subclass of the class int, and cannot be subclassed.";
 
     let bool_type = &context.bool_type;
     context.set_attr(&bool_type, "__new__", context.new_rustfunc(bool_new));
-    context.set_attr(&bool_type, "__repr__", context.new_rustfunc(bool_repr));
+    context.set_attr(&bool_type, crate::VM_REPR, context.new_rustfunc(bool_repr));
     context.set_attr(&bool_type, "__doc__", context.new_str(bool_doc.to_string()));
 }
 

--- a/vm/src/obj/objbytearray.rs
+++ b/vm/src/obj/objbytearray.rs
@@ -73,7 +73,7 @@ pub fn init(context: &PyContext) {
     );
     context.set_attr(
         &bytearray_type,
-        "__repr__",
+        crate::VM_REPR,
         context.new_rustfunc(bytearray_repr),
     );
     context.set_attr(

--- a/vm/src/obj/objbytes.rs
+++ b/vm/src/obj/objbytes.rs
@@ -59,7 +59,7 @@ pub fn init(context: &PyContext) {
     context.set_attr(bytes_type, "__ge__", context.new_rustfunc(bytes_ge));
     context.set_attr(bytes_type, "__hash__", context.new_rustfunc(bytes_hash));
     context.set_attr(bytes_type, "__new__", context.new_rustfunc(bytes_new));
-    context.set_attr(bytes_type, "__repr__", context.new_rustfunc(bytes_repr));
+    context.set_attr(bytes_type, crate::VM_REPR, context.new_rustfunc(bytes_repr));
     context.set_attr(bytes_type, "__len__", context.new_rustfunc(bytes_len));
     context.set_attr(bytes_type, "__iter__", context.new_rustfunc(bytes_iter));
     context.set_attr(

--- a/vm/src/obj/objbytes.rs
+++ b/vm/src/obj/objbytes.rs
@@ -57,7 +57,7 @@ pub fn init(context: &PyContext) {
     context.set_attr(bytes_type, "__le__", context.new_rustfunc(bytes_le));
     context.set_attr(bytes_type, "__gt__", context.new_rustfunc(bytes_gt));
     context.set_attr(bytes_type, "__ge__", context.new_rustfunc(bytes_ge));
-    context.set_attr(bytes_type, "__hash__", context.new_rustfunc(bytes_hash));
+    context.set_attr(bytes_type, crate::VM_HASH, context.new_rustfunc(bytes_hash));
     context.set_attr(bytes_type, "__new__", context.new_rustfunc(bytes_new));
     context.set_attr(bytes_type, crate::VM_REPR, context.new_rustfunc(bytes_repr));
     context.set_attr(bytes_type, "__len__", context.new_rustfunc(bytes_len));

--- a/vm/src/obj/objcode.rs
+++ b/vm/src/obj/objcode.rs
@@ -34,7 +34,7 @@ impl PyValue for PyCode {
 pub fn init(context: &PyContext) {
     let code_type = &context.code_type;
     context.set_attr(code_type, "__new__", context.new_rustfunc(code_new));
-    context.set_attr(code_type, "__repr__", context.new_rustfunc(code_repr));
+    context.set_attr(code_type, crate::VM_REPR, context.new_rustfunc(code_repr));
 
     for (name, f) in &[
         (

--- a/vm/src/obj/objcomplex.rs
+++ b/vm/src/obj/objcomplex.rs
@@ -51,7 +51,7 @@ pub fn init(context: &PyContext) {
     );
     context.set_attr(
         &complex_type,
-        "__repr__",
+        crate::VM_REPR,
         context.new_rustfunc(complex_repr),
     );
     context.set_attr(

--- a/vm/src/obj/objdict.rs
+++ b/vm/src/obj/objdict.rs
@@ -390,7 +390,7 @@ pub fn init(context: &PyContext) {
     );
     context.set_attr(&dict_type, "__iter__", context.new_rustfunc(dict_iter));
     context.set_attr(&dict_type, "__new__", context.new_rustfunc(dict_new));
-    context.set_attr(&dict_type, "__repr__", context.new_rustfunc(dict_repr));
+    context.set_attr(&dict_type, crate::VM_REPR, context.new_rustfunc(dict_repr));
     context.set_attr(
         &dict_type,
         "__setitem__",

--- a/vm/src/obj/objellipsis.rs
+++ b/vm/src/obj/objellipsis.rs
@@ -6,7 +6,7 @@ pub fn init(context: &PyContext) {
     context.set_attr(ellipsis_type, "__new__", context.new_rustfunc(ellipsis_new));
     context.set_attr(
         ellipsis_type,
-        "__repr__",
+        crate::VM_REPR,
         context.new_rustfunc(ellipsis_repr),
     );
 }

--- a/vm/src/obj/objfloat.rs
+++ b/vm/src/obj/objfloat.rs
@@ -372,7 +372,7 @@ pub fn init(context: &PyContext) {
     context.set_attr(&float_type, "__pow__", context.new_rustfunc(PyFloatRef::pow));
     context.set_attr(&float_type, "__sub__", context.new_rustfunc(PyFloatRef::sub));
     context.set_attr(&float_type, "__rsub__", context.new_rustfunc(PyFloatRef::rsub));
-    context.set_attr(&float_type, "__repr__", context.new_rustfunc(PyFloatRef::repr));
+    context.set_attr(&float_type, crate::VM_REPR, context.new_rustfunc(PyFloatRef::repr));
     context.set_attr(&float_type, "__doc__", context.new_str(float_doc.to_string()));
     context.set_attr(&float_type, "__truediv__", context.new_rustfunc(PyFloatRef::truediv));
     context.set_attr(&float_type, "__rtruediv__", context.new_rustfunc(PyFloatRef::rtruediv));

--- a/vm/src/obj/objframe.rs
+++ b/vm/src/obj/objframe.rs
@@ -9,7 +9,7 @@ use crate::vm::VirtualMachine;
 pub fn init(context: &PyContext) {
     let frame_type = &context.frame_type;
     context.set_attr(&frame_type, "__new__", context.new_rustfunc(frame_new));
-    context.set_attr(&frame_type, "__repr__", context.new_rustfunc(frame_repr));
+    context.set_attr(&frame_type, crate::VM_REPR, context.new_rustfunc(frame_repr));
     context.set_attr(&frame_type, "f_locals", context.new_property(frame_flocals));
     context.set_attr(&frame_type, "f_code", context.new_property(frame_fcode));
 }

--- a/vm/src/obj/objframe.rs
+++ b/vm/src/obj/objframe.rs
@@ -9,7 +9,11 @@ use crate::vm::VirtualMachine;
 pub fn init(context: &PyContext) {
     let frame_type = &context.frame_type;
     context.set_attr(&frame_type, "__new__", context.new_rustfunc(frame_new));
-    context.set_attr(&frame_type, crate::VM_REPR, context.new_rustfunc(frame_repr));
+    context.set_attr(
+        &frame_type,
+        crate::VM_REPR,
+        context.new_rustfunc(frame_repr),
+    );
     context.set_attr(&frame_type, "f_locals", context.new_property(frame_flocals));
     context.set_attr(&frame_type, "f_code", context.new_property(frame_fcode));
 }

--- a/vm/src/obj/objint.rs
+++ b/vm/src/obj/objint.rs
@@ -505,7 +505,7 @@ Base 0 means to interpret the base from the string as an integer literal.
     context.set_attr(&int_type, "__neg__", context.new_rustfunc(PyIntRef::neg));
     context.set_attr(&int_type, "__pos__", context.new_rustfunc(PyIntRef::pass_value));
     context.set_attr(&int_type, "__pow__", context.new_rustfunc(PyIntRef::pow));
-    context.set_attr(&int_type, "__repr__", context.new_rustfunc(PyIntRef::repr));
+    context.set_attr(&int_type, crate::VM_REPR, context.new_rustfunc(PyIntRef::repr));
     context.set_attr(&int_type, "__sub__", context.new_rustfunc(PyIntRef::sub));
     context.set_attr(&int_type, "__rsub__", context.new_rustfunc(PyIntRef::rsub));
     context.set_attr(&int_type, "__format__", context.new_rustfunc(PyIntRef::format));

--- a/vm/src/obj/objint.rs
+++ b/vm/src/obj/objint.rs
@@ -494,7 +494,7 @@ Base 0 means to interpret the base from the string as an integer literal.
     context.set_attr(&int_type, "__trunc__", context.new_rustfunc(PyIntRef::pass_value));
     context.set_attr(&int_type, "__int__", context.new_rustfunc(PyIntRef::pass_value));
     context.set_attr(&int_type, "__floordiv__", context.new_rustfunc(PyIntRef::floordiv));
-    context.set_attr(&int_type, "__hash__", context.new_rustfunc(PyIntRef::hash));
+    context.set_attr(&int_type, crate::VM_HASH, context.new_rustfunc(PyIntRef::hash));
     context.set_attr(&int_type, "__lshift__", context.new_rustfunc(PyIntRef::lshift));
     context.set_attr(&int_type, "__rshift__", context.new_rustfunc(PyIntRef::rshift));
     context.set_attr(&int_type, "__new__", context.new_rustfunc(int_new));

--- a/vm/src/obj/objlist.rs
+++ b/vm/src/obj/objlist.rs
@@ -430,7 +430,7 @@ pub fn init(context: &PyContext) {
     context.set_attr(&list_type, "__mul__", context.new_rustfunc(PyListRef::mul));
     context.set_attr(&list_type, "__len__", context.new_rustfunc(PyListRef::len));
     context.set_attr(&list_type, "__new__", context.new_rustfunc(list_new));
-    context.set_attr(&list_type, "__repr__", context.new_rustfunc(PyListRef::repr));
+    context.set_attr(&list_type, crate::VM_REPR, context.new_rustfunc(PyListRef::repr));
     context.set_attr(&list_type, "__doc__", context.new_str(list_doc.to_string()));
     context.set_attr(&list_type, "append", context.new_rustfunc(PyListRef::append));
     context.set_attr(&list_type, "clear", context.new_rustfunc(PyListRef::clear));

--- a/vm/src/obj/objnone.rs
+++ b/vm/src/obj/objnone.rs
@@ -52,7 +52,7 @@ fn none_new(vm: &mut VirtualMachine, args: PyFuncArgs) -> PyResult {
 pub fn init(context: &PyContext) {
     extend_class!(context, &context.none.typ(), {
         "__new__" => context.new_rustfunc(none_new),
-        "__repr__" => context.new_rustfunc(PyNoneRef::repr),
+        crate::VM_REPR => context.new_rustfunc(PyNoneRef::repr),
         "__bool__" => context.new_rustfunc(PyNoneRef::bool),
     });
 }

--- a/vm/src/obj/objobject.rs
+++ b/vm/src/obj/objobject.rs
@@ -115,7 +115,7 @@ fn object_delattr(vm: &mut VirtualMachine, args: PyFuncArgs) -> PyResult {
 
 fn object_str(vm: &mut VirtualMachine, args: PyFuncArgs) -> PyResult {
     arg_check!(vm, args, required = [(zelf, Some(vm.ctx.object()))]);
-    vm.call_method(zelf, "__repr__", vec![])
+    vm.call_method(zelf, crate::VM_REPR, vec![])
 }
 
 fn object_repr(vm: &mut VirtualMachine, args: PyFuncArgs) -> PyResult {
@@ -175,7 +175,7 @@ pub fn init(context: &PyContext) {
     context.set_attr(&object, "__dir__", context.new_rustfunc(object_dir));
     context.set_attr(&object, "__hash__", context.new_rustfunc(object_hash));
     context.set_attr(&object, "__str__", context.new_rustfunc(object_str));
-    context.set_attr(&object, "__repr__", context.new_rustfunc(object_repr));
+    context.set_attr(&object, crate::VM_REPR, context.new_rustfunc(object_repr));
     context.set_attr(&object, "__format__", context.new_rustfunc(object_format));
     context.set_attr(
         &object,

--- a/vm/src/obj/objobject.rs
+++ b/vm/src/obj/objobject.rs
@@ -174,7 +174,7 @@ pub fn init(context: &PyContext) {
     context.set_attr(&object, "__dict__", context.new_property(object_dict));
     context.set_attr(&object, "__dir__", context.new_rustfunc(object_dir));
     context.set_attr(&object, "__hash__", context.new_rustfunc(object_hash));
-    context.set_attr(&object, "__str__", context.new_rustfunc(object_str));
+    context.set_attr(&object, crate::VM_STR, context.new_rustfunc(object_str));
     context.set_attr(&object, crate::VM_REPR, context.new_rustfunc(object_repr));
     context.set_attr(&object, "__format__", context.new_rustfunc(object_format));
     context.set_attr(

--- a/vm/src/obj/objobject.rs
+++ b/vm/src/obj/objobject.rs
@@ -173,7 +173,7 @@ pub fn init(context: &PyContext) {
     context.set_attr(&object, "__delattr__", context.new_rustfunc(object_delattr));
     context.set_attr(&object, "__dict__", context.new_property(object_dict));
     context.set_attr(&object, "__dir__", context.new_rustfunc(object_dir));
-    context.set_attr(&object, "__hash__", context.new_rustfunc(object_hash));
+    context.set_attr(&object, crate::VM_HASH, context.new_rustfunc(object_hash));
     context.set_attr(&object, crate::VM_STR, context.new_rustfunc(object_str));
     context.set_attr(&object, crate::VM_REPR, context.new_rustfunc(object_repr));
     context.set_attr(&object, "__format__", context.new_rustfunc(object_format));

--- a/vm/src/obj/objrange.rs
+++ b/vm/src/obj/objrange.rs
@@ -181,7 +181,11 @@ pub fn init(context: &PyContext) {
         "__getitem__",
         context.new_rustfunc(range_getitem),
     );
-    context.set_attr(&range_type, "__repr__", context.new_rustfunc(range_repr));
+    context.set_attr(
+        &range_type,
+        crate::VM_REPR,
+        context.new_rustfunc(range_repr),
+    );
     context.set_attr(&range_type, "__bool__", context.new_rustfunc(range_bool));
     context.set_attr(
         &range_type,

--- a/vm/src/obj/objset.rs
+++ b/vm/src/obj/objset.rs
@@ -604,7 +604,7 @@ pub fn init(context: &PyContext) {
     );
     context.set_attr(&set_type, "__len__", context.new_rustfunc(set_len));
     context.set_attr(&set_type, "__new__", context.new_rustfunc(set_new));
-    context.set_attr(&set_type, "__repr__", context.new_rustfunc(set_repr));
+    context.set_attr(&set_type, crate::VM_REPR, context.new_rustfunc(set_repr));
     context.set_attr(&set_type, "__eq__", context.new_rustfunc(set_eq));
     context.set_attr(&set_type, "__ge__", context.new_rustfunc(set_ge));
     context.set_attr(&set_type, "__gt__", context.new_rustfunc(set_gt));
@@ -684,7 +684,7 @@ pub fn init(context: &PyContext) {
     );
     context.set_attr(
         &frozenset_type,
-        "__repr__",
+        crate::VM_REPR,
         context.new_rustfunc(frozenset_repr),
     );
 }

--- a/vm/src/obj/objset.rs
+++ b/vm/src/obj/objset.rs
@@ -45,7 +45,7 @@ fn perform_action_with_hash(
     item: &PyObjectRef,
     f: &Fn(&mut VirtualMachine, &mut HashMap<u64, PyObjectRef>, u64, &PyObjectRef) -> PyResult,
 ) -> PyResult {
-    let hash: PyObjectRef = vm.call_method(item, "__hash__", vec![])?;
+    let hash: PyObjectRef = vm.call_method(item, crate::VM_HASH, vec![])?;
 
     let hash_value = objint::get_value(&hash);
     let mut hasher = DefaultHasher::new();

--- a/vm/src/obj/objstr.rs
+++ b/vm/src/obj/objstr.rs
@@ -634,7 +634,7 @@ pub fn init(context: &PyContext) {
     context.set_attr(&str_type, "__mul__", context.new_rustfunc(PyStringRef::mul));
     context.set_attr(&str_type, "__new__", context.new_rustfunc(str_new));
     context.set_attr(&str_type, "__str__", context.new_rustfunc(PyStringRef::str));
-    context.set_attr(&str_type, "__repr__", context.new_rustfunc(PyStringRef::repr));
+    context.set_attr(&str_type, crate::VM_REPR, context.new_rustfunc(PyStringRef::repr));
     context.set_attr(&str_type, "format", context.new_rustfunc(str_format));
     context.set_attr(&str_type, "lower", context.new_rustfunc(PyStringRef::lower));
     context.set_attr(&str_type, "casefold", context.new_rustfunc(PyStringRef::casefold));

--- a/vm/src/obj/objstr.rs
+++ b/vm/src/obj/objstr.rs
@@ -633,7 +633,7 @@ pub fn init(context: &PyContext) {
     context.set_attr(&str_type, "__len__", context.new_rustfunc(PyStringRef::len));
     context.set_attr(&str_type, "__mul__", context.new_rustfunc(PyStringRef::mul));
     context.set_attr(&str_type, "__new__", context.new_rustfunc(str_new));
-    context.set_attr(&str_type, "__str__", context.new_rustfunc(PyStringRef::str));
+    context.set_attr(&str_type, crate::VM_STR, context.new_rustfunc(PyStringRef::str));
     context.set_attr(&str_type, crate::VM_REPR, context.new_rustfunc(PyStringRef::repr));
     context.set_attr(&str_type, "format", context.new_rustfunc(str_format));
     context.set_attr(&str_type, "lower", context.new_rustfunc(PyStringRef::lower));

--- a/vm/src/obj/objstr.rs
+++ b/vm/src/obj/objstr.rs
@@ -629,7 +629,7 @@ pub fn init(context: &PyContext) {
     context.set_attr(&str_type, "__ge__", context.new_rustfunc(PyStringRef::ge));
     context.set_attr(&str_type, "__lt__", context.new_rustfunc(PyStringRef::lt));
     context.set_attr(&str_type, "__le__", context.new_rustfunc(PyStringRef::le));
-    context.set_attr(&str_type, "__hash__", context.new_rustfunc(PyStringRef::hash));
+    context.set_attr(&str_type, crate::VM_HASH, context.new_rustfunc(PyStringRef::hash));
     context.set_attr(&str_type, "__len__", context.new_rustfunc(PyStringRef::len));
     context.set_attr(&str_type, "__mul__", context.new_rustfunc(PyStringRef::mul));
     context.set_attr(&str_type, "__new__", context.new_rustfunc(str_new));

--- a/vm/src/obj/objtuple.rs
+++ b/vm/src/obj/objtuple.rs
@@ -126,7 +126,7 @@ impl PyTupleRef {
     fn hash(self, vm: &mut VirtualMachine) -> PyResult<u64> {
         let mut hasher = std::collections::hash_map::DefaultHasher::new();
         for element in self.elements.borrow().iter() {
-            let hash_result = vm.call_method(element, "__hash__", vec![])?;
+            let hash_result = vm.call_method(element, crate::VM_HASH, vec![])?;
             let element_hash = objint::get_value(&hash_result);
             element_hash.hash(&mut hasher);
         }
@@ -236,7 +236,7 @@ If the argument is a tuple, the return value is the same object.";
     context.set_attr(&tuple_type, "__eq__", context.new_rustfunc(PyTupleRef::eq));
     context.set_attr(&tuple_type,"__contains__",context.new_rustfunc(PyTupleRef::contains));
     context.set_attr(&tuple_type,"__getitem__",context.new_rustfunc(PyTupleRef::getitem));
-    context.set_attr(&tuple_type, "__hash__", context.new_rustfunc(PyTupleRef::hash));
+    context.set_attr(&tuple_type, crate::VM_HASH, context.new_rustfunc(PyTupleRef::hash));
     context.set_attr(&tuple_type, "__iter__", context.new_rustfunc(PyTupleRef::iter));
     context.set_attr(&tuple_type, "__len__", context.new_rustfunc(PyTupleRef::len));
     context.set_attr(&tuple_type, "__new__", context.new_rustfunc(tuple_new));

--- a/vm/src/obj/objtuple.rs
+++ b/vm/src/obj/objtuple.rs
@@ -241,7 +241,7 @@ If the argument is a tuple, the return value is the same object.";
     context.set_attr(&tuple_type, "__len__", context.new_rustfunc(PyTupleRef::len));
     context.set_attr(&tuple_type, "__new__", context.new_rustfunc(tuple_new));
     context.set_attr(&tuple_type, "__mul__", context.new_rustfunc(PyTupleRef::mul));
-    context.set_attr(&tuple_type, "__repr__", context.new_rustfunc(PyTupleRef::repr));
+    context.set_attr(&tuple_type, crate::VM_REPR, context.new_rustfunc(PyTupleRef::repr));
     context.set_attr(&tuple_type, "count", context.new_rustfunc(PyTupleRef::count));
     context.set_attr(&tuple_type, "__lt__", context.new_rustfunc(PyTupleRef::lt));
     context.set_attr(&tuple_type, "__le__", context.new_rustfunc(PyTupleRef::le));

--- a/vm/src/obj/objtype.rs
+++ b/vm/src/obj/objtype.rs
@@ -126,7 +126,7 @@ pub fn init(ctx: &PyContext) {
                 .add_getter(PyClassRef::mro)
                 .add_setter(PyClassRef::set_mro)
                 .create(),
-        "__repr__" => ctx.new_rustfunc(PyClassRef::repr),
+        crate::VM_REPR => ctx.new_rustfunc(PyClassRef::repr),
         "__prepare__" => ctx.new_rustfunc(PyClassRef::prepare),
         "__getattribute__" => ctx.new_rustfunc(type_getattribute),
         "__instancecheck__" => ctx.new_rustfunc(PyClassRef::instance_check),

--- a/vm/src/vm.rs
+++ b/vm/src/vm.rs
@@ -229,7 +229,7 @@ impl VirtualMachine {
 
     // Container of the virtual machine state:
     pub fn to_str(&mut self, obj: &PyObjectRef) -> PyResult {
-        self.call_method(&obj, "__str__", vec![])
+        self.call_method(&obj, crate::VM_STR, vec![])
     }
 
     pub fn to_pystr(&mut self, obj: &PyObjectRef) -> Result<String, PyObjectRef> {

--- a/vm/src/vm.rs
+++ b/vm/src/vm.rs
@@ -238,7 +238,7 @@ impl VirtualMachine {
     }
 
     pub fn to_repr(&mut self, obj: &PyObjectRef) -> PyResult {
-        self.call_method(obj, "__repr__", vec![])
+        self.call_method(obj, crate::VM_REPR, vec![])
     }
 
     pub fn import(&mut self, module: &str) -> PyResult {


### PR DESCRIPTION
This PR replaces the occurrences of the symbolic strings like `"__repr__"` with the appropriate static string.

Closes #463 