### PR TITLE
Convert print() builtin to new args style

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 /target
+/*/target
 **/*.rs.bk
 **/*.bytecode
 __pycache__

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -262,8 +262,8 @@ name = "failure_derive"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "proc-macro2 0.4.20 (registry+https://github.com/rust-lang/crates.io-index)",
- "quote 0.6.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "proc-macro2 0.4.27 (registry+https://github.com/rust-lang/crates.io-index)",
+ "quote 0.6.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "syn 0.14.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "synstructure 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -575,7 +575,7 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "0.4.20"
+version = "0.4.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "unicode-xid 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -596,10 +596,10 @@ dependencies = [
 
 [[package]]
 name = "quote"
-version = "0.6.3"
+version = "0.6.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "proc-macro2 0.4.20 (registry+https://github.com/rust-lang/crates.io-index)",
+ "proc-macro2 0.4.27 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -742,6 +742,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustpython_derive"
+version = "0.1.0"
+dependencies = [
+ "proc-macro2 0.4.27 (registry+https://github.com/rust-lang/crates.io-index)",
+ "quote 0.6.11 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 0.15.29 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "rustpython_parser"
 version = "0.0.1"
 dependencies = [
@@ -771,6 +780,7 @@ dependencies = [
  "rand 0.5.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "regex 1.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "rustc_version_runtime 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustpython_derive 0.1.0",
  "rustpython_parser 0.0.1",
  "serde 1.0.66 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_derive 1.0.66 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -843,8 +853,8 @@ name = "serde_derive"
 version = "1.0.66"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "proc-macro2 0.4.20 (registry+https://github.com/rust-lang/crates.io-index)",
- "quote 0.6.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "proc-macro2 0.4.27 (registry+https://github.com/rust-lang/crates.io-index)",
+ "quote 0.6.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "syn 0.14.9 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -946,18 +956,18 @@ name = "syn"
 version = "0.14.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "proc-macro2 0.4.20 (registry+https://github.com/rust-lang/crates.io-index)",
- "quote 0.6.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "proc-macro2 0.4.27 (registry+https://github.com/rust-lang/crates.io-index)",
+ "quote 0.6.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "unicode-xid 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "syn"
-version = "0.15.23"
+version = "0.15.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "proc-macro2 0.4.20 (registry+https://github.com/rust-lang/crates.io-index)",
- "quote 0.6.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "proc-macro2 0.4.27 (registry+https://github.com/rust-lang/crates.io-index)",
+ "quote 0.6.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "unicode-xid 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -966,8 +976,8 @@ name = "synstructure"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "proc-macro2 0.4.20 (registry+https://github.com/rust-lang/crates.io-index)",
- "quote 0.6.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "proc-macro2 0.4.27 (registry+https://github.com/rust-lang/crates.io-index)",
+ "quote 0.6.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "syn 0.14.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "unicode-xid 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -1096,9 +1106,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "lazy_static 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "proc-macro2 0.4.20 (registry+https://github.com/rust-lang/crates.io-index)",
- "quote 0.6.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "syn 0.15.23 (registry+https://github.com/rust-lang/crates.io-index)",
+ "proc-macro2 0.4.27 (registry+https://github.com/rust-lang/crates.io-index)",
+ "quote 0.6.11 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 0.15.29 (registry+https://github.com/rust-lang/crates.io-index)",
  "wasm-bindgen-shared 0.2.29 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -1117,7 +1127,7 @@ name = "wasm-bindgen-macro"
 version = "0.2.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "quote 0.6.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "quote 0.6.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "wasm-bindgen-macro-support 0.2.29 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -1126,9 +1136,9 @@ name = "wasm-bindgen-macro-support"
 version = "0.2.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "proc-macro2 0.4.20 (registry+https://github.com/rust-lang/crates.io-index)",
- "quote 0.6.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "syn 0.15.23 (registry+https://github.com/rust-lang/crates.io-index)",
+ "proc-macro2 0.4.27 (registry+https://github.com/rust-lang/crates.io-index)",
+ "quote 0.6.11 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 0.15.29 (registry+https://github.com/rust-lang/crates.io-index)",
  "wasm-bindgen-backend 0.2.29 (registry+https://github.com/rust-lang/crates.io-index)",
  "wasm-bindgen-shared 0.2.29 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -1146,9 +1156,9 @@ dependencies = [
  "failure 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "heck 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "proc-macro2 0.4.20 (registry+https://github.com/rust-lang/crates.io-index)",
- "quote 0.6.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "syn 0.15.23 (registry+https://github.com/rust-lang/crates.io-index)",
+ "proc-macro2 0.4.27 (registry+https://github.com/rust-lang/crates.io-index)",
+ "quote 0.6.11 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 0.15.29 (registry+https://github.com/rust-lang/crates.io-index)",
  "wasm-bindgen-backend 0.2.29 (registry+https://github.com/rust-lang/crates.io-index)",
  "weedle 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -1304,10 +1314,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum phf_shared 0.7.22 (registry+https://github.com/rust-lang/crates.io-index)" = "c2261d544c2bb6aa3b10022b0be371b9c7c64f762ef28c6f5d4f1ef6d97b5930"
 "checksum precomputed-hash 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "925383efa346730478fb4838dbe9137d2a47675ad789c546d150a6e1dd4ab31c"
 "checksum proc-macro2 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)" = "1b06e2f335f48d24442b35a19df506a835fb3547bc3c06ef27340da9acf5cae7"
-"checksum proc-macro2 0.4.20 (registry+https://github.com/rust-lang/crates.io-index)" = "3d7b7eaaa90b4a90a932a9ea6666c95a389e424eff347f0f793979289429feee"
+"checksum proc-macro2 0.4.27 (registry+https://github.com/rust-lang/crates.io-index)" = "4d317f9caece796be1980837fd5cb3dfec5613ebdb04ad0956deea83ce168915"
 "checksum quick-error 1.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "9274b940887ce9addde99c4eee6b5c44cc494b182b97e73dc8ffdcb3397fd3f0"
 "checksum quote 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)" = "9949cfe66888ffe1d53e6ec9d9f3b70714083854be20fd5e271b232a017401e8"
-"checksum quote 0.6.3 (registry+https://github.com/rust-lang/crates.io-index)" = "e44651a0dc4cdd99f71c83b561e221f714912d11af1a4dff0631f923d53af035"
+"checksum quote 0.6.11 (registry+https://github.com/rust-lang/crates.io-index)" = "cdd8e04bd9c52e0342b406469d494fcb033be4bdbe5c606016defbb1681411e1"
 "checksum rand 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)" = "eba5f8cb59cc50ed56be8880a5c7b496bfd9bd26394e176bc67884094145c2c5"
 "checksum rand 0.5.5 (registry+https://github.com/rust-lang/crates.io-index)" = "e464cd887e869cddcae8792a4ee31d23c7edd516700695608f5b98c67ee0131c"
 "checksum rand_core 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "1961a422c4d189dfb50ffa9320bf1f2a9bd54ecb92792fb9477f99a1045f3372"
@@ -1343,7 +1353,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum strsim 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)" = "b4d15c810519a91cf877e7e36e63fe068815c678181439f2f29e2562147c3694"
 "checksum strsim 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "bb4f380125926a99e52bc279241539c018323fab05ad6368b56f93d9369ff550"
 "checksum syn 0.14.9 (registry+https://github.com/rust-lang/crates.io-index)" = "261ae9ecaa397c42b960649561949d69311f08eeaea86a65696e6e46517cf741"
-"checksum syn 0.15.23 (registry+https://github.com/rust-lang/crates.io-index)" = "9545a6a093a3f0bd59adb472700acc08cad3776f860f16a897dfce8c88721cbc"
+"checksum syn 0.15.29 (registry+https://github.com/rust-lang/crates.io-index)" = "1825685f977249735d510a242a6727b46efe914bb67e38d30c071b1b72b1d5c2"
 "checksum synstructure 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)" = "85bb9b7550d063ea184027c9b8c20ac167cd36d3e06b3a40bceb9d746dc1a7b7"
 "checksum term 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)" = "fa63644f74ce96fbeb9b794f66aff2a52d601cbd5e80f4b97123e3899f4570f1"
 "checksum termcolor 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)" = "adc4587ead41bf016f11af03e55a624c06568b5a19db4e90fde573d805074f83"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ authors = ["Windel Bouwman", "Shing Lyu <shing.lyu@gmail.com>"]
 edition = "2018"
 
 [workspace]
-members = [".", "vm", "wasm/lib", "parser"]
+members = [".", "derive", "vm", "wasm/lib", "parser"]
 
 [dependencies]
 log="0.4.1"

--- a/derive/Cargo.toml
+++ b/derive/Cargo.toml
@@ -1,0 +1,13 @@
+[package]
+name = "rustpython_derive"
+version = "0.1.0"
+authors = ["Joey <jmhain@protonmail.com>"]
+edition = "2018"
+
+[lib]
+proc-macro = true
+
+[dependencies]
+syn = "0.15.29"
+quote = "0.6.11"
+proc-macro2 = "0.4.27"

--- a/derive/src/lib.rs
+++ b/derive/src/lib.rs
@@ -1,0 +1,48 @@
+extern crate proc_macro;
+
+use proc_macro::TokenStream;
+use proc_macro2::TokenStream as TokenStream2;
+use quote::quote;
+use syn::{Data, DeriveInput, Fields};
+
+#[proc_macro_derive(FromArgs)]
+pub fn derive_from_args(input: TokenStream) -> TokenStream {
+    let ast: DeriveInput = syn::parse(input).unwrap();
+
+    let gen = impl_from_args(&ast);
+    gen.to_string().parse().unwrap()
+}
+
+fn impl_from_args(input: &DeriveInput) -> TokenStream2 {
+    // FIXME: This references types using `crate` instead of `rustpython_vm`
+    //        so that it can be used in the latter. How can we support both?
+    let fields = match input.data {
+        Data::Struct(ref data) => {
+            match data.fields {
+                Fields::Named(ref fields) => fields.named.iter().map(|field| {
+                    let name = &field.ident;
+                    quote! {
+                        #name: crate::pyobject::TryFromObject::try_from_object(
+                            vm,
+                            args.take_keyword(stringify!(#name)).unwrap_or_else(|| vm.ctx.none())
+                        )?,
+                    }
+                }),
+                Fields::Unnamed(_) | Fields::Unit => unimplemented!(), // TODO: better error message
+            }
+        }
+        Data::Enum(_) | Data::Union(_) => unimplemented!(), // TODO: better error message
+    };
+
+    let name = &input.ident;
+    quote! {
+        impl crate::function::FromArgs for #name {
+            fn from_args(
+                vm: &mut crate::vm::VirtualMachine,
+                args: &mut crate::function::PyFuncArgs
+            ) -> Result<Self, crate::function::ArgumentError> {
+                Ok(#name { #(#fields)* })
+            }
+        }
+    }
+}

--- a/vm/Cargo.toml
+++ b/vm/Cargo.toml
@@ -13,6 +13,7 @@ num-integer = "0.1.39"
 num-rational = "0.2.1"
 rand = "0.5"
 log = "0.3"
+rustpython_derive = {path = "../derive"}
 rustpython_parser = {path = "../parser"}
 serde = "1.0.66"
 serde_derive = "1.0.66"

--- a/vm/src/builtins.rs
+++ b/vm/src/builtins.rs
@@ -18,9 +18,9 @@ use crate::obj::objstr::{self, PyStringRef};
 use crate::obj::objtype;
 
 use crate::frame::Scope;
-use crate::function::{Args, ArgumentError, FromArgs, PyFuncArgs};
+use crate::function::{Args, PyFuncArgs};
 use crate::pyobject::{
-    AttributeProtocol, IdProtocol, PyContext, PyObjectRef, PyResult, TryFromObject, TypeProtocol,
+    AttributeProtocol, IdProtocol, PyContext, PyObjectRef, PyResult, TypeProtocol,
 };
 use crate::vm::VirtualMachine;
 
@@ -582,31 +582,11 @@ fn builtin_pow(vm: &mut VirtualMachine, args: PyFuncArgs) -> PyResult {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, FromArgs)]
 pub struct PrintOptions {
     sep: Option<PyStringRef>,
     end: Option<PyStringRef>,
     flush: bool,
-}
-
-// In the future, this impl will be generated w/ a derive macro.
-impl FromArgs for PrintOptions {
-    fn from_args(vm: &mut VirtualMachine, args: &mut PyFuncArgs) -> Result<Self, ArgumentError> {
-        Ok(PrintOptions {
-            sep: TryFromObject::try_from_object(
-                vm,
-                args.take_keyword("sep").unwrap_or_else(|| vm.ctx.none()),
-            )?,
-            end: TryFromObject::try_from_object(
-                vm,
-                args.take_keyword("end").unwrap_or_else(|| vm.ctx.none()),
-            )?,
-            flush: TryFromObject::try_from_object(
-                vm,
-                args.take_keyword("flush").unwrap_or_else(|| vm.ctx.none()),
-            )?,
-        })
-    }
 }
 
 pub fn builtin_print(

--- a/vm/src/builtins.rs
+++ b/vm/src/builtins.rs
@@ -604,7 +604,7 @@ impl FromArgs for PrintOptions {
         let mut end: Option<PyStringRef> = Some(PyString::from("\n").into_ref(vm));
         let mut flush = false;
 
-        while let Some(arg) = args.next() {
+        for arg in args {
             match arg {
                 PyArg::Keyword(name, value) => match name.as_str() {
                     "sep" => {

--- a/vm/src/builtins.rs
+++ b/vm/src/builtins.rs
@@ -15,14 +15,13 @@ use crate::obj::objbool;
 use crate::obj::objdict;
 use crate::obj::objint;
 use crate::obj::objiter;
-use crate::obj::objstr::{self, PyString, PyStringRef};
+use crate::obj::objstr::{self, PyStringRef};
 use crate::obj::objtype;
 
 use crate::frame::Scope;
 use crate::function::{Args, ArgumentError, FromArgs, PyArg, PyFuncArgs};
 use crate::pyobject::{
-    AttributeProtocol, IdProtocol, PyContext, PyObjectRef, PyResult, PyValue, TryFromObject,
-    TypeProtocol,
+    AttributeProtocol, IdProtocol, PyContext, PyObjectRef, PyResult, TryFromObject, TypeProtocol,
 };
 use crate::vm::VirtualMachine;
 
@@ -600,8 +599,8 @@ impl FromArgs for PrintOptions {
     where
         I: Iterator<Item = PyArg>,
     {
-        let mut sep: Option<PyStringRef> = Some(PyString::from(" ").into_ref(vm));
-        let mut end: Option<PyStringRef> = Some(PyString::from("\n").into_ref(vm));
+        let mut sep: Option<PyStringRef> = None;
+        let mut end: Option<PyStringRef> = None;
         let mut flush = false;
 
         for arg in args {

--- a/vm/src/builtins.rs
+++ b/vm/src/builtins.rs
@@ -2,9 +2,9 @@
 //!
 //! Implements functions listed here: https://docs.python.org/3/library/builtins.html
 
-// use std::ops::Deref;
 use std::char;
 use std::io::{self, Write};
+use std::iter;
 use std::path::PathBuf;
 
 use num_traits::{Signed, ToPrimitive};
@@ -15,13 +15,14 @@ use crate::obj::objbool;
 use crate::obj::objdict;
 use crate::obj::objint;
 use crate::obj::objiter;
-use crate::obj::objstr;
+use crate::obj::objstr::{self, PyString, PyStringRef};
 use crate::obj::objtype;
 
 use crate::frame::Scope;
-use crate::function::PyFuncArgs;
+use crate::function::{Args, ArgumentError, FromArgs, PyArg, PyFuncArgs};
 use crate::pyobject::{
-    AttributeProtocol, IdProtocol, PyContext, PyObjectRef, PyResult, TypeProtocol,
+    AttributeProtocol, IdProtocol, PyContext, PyObjectRef, PyResult, PyValue, TryFromObject,
+    TypeProtocol,
 };
 use crate::vm::VirtualMachine;
 
@@ -583,71 +584,84 @@ fn builtin_pow(vm: &mut VirtualMachine, args: PyFuncArgs) -> PyResult {
     }
 }
 
-pub fn builtin_print(vm: &mut VirtualMachine, args: PyFuncArgs) -> PyResult {
-    trace!("print called with {:?}", args);
+#[derive(Debug)]
+pub struct PrintOptions {
+    sep: Option<PyStringRef>,
+    end: Option<PyStringRef>,
+    flush: bool,
+}
 
-    // Handle 'sep' kwarg:
-    let sep_arg = args
-        .get_optional_kwarg("sep")
-        .filter(|obj| !obj.is(&vm.get_none()));
-    if let Some(ref obj) = sep_arg {
-        if !objtype::isinstance(obj, &vm.ctx.str_type()) {
-            return Err(vm.new_type_error(format!(
-                "sep must be None or a string, not {}",
-                objtype::get_type_name(&obj.typ())
-            )));
+// In the future, this impl will be generated w/ a derive macro.
+impl FromArgs for PrintOptions {
+    fn from_args<I>(
+        vm: &mut VirtualMachine,
+        args: &mut iter::Peekable<I>,
+    ) -> Result<Self, ArgumentError>
+    where
+        I: Iterator<Item = PyArg>,
+    {
+        let mut sep: Option<PyStringRef> = Some(PyString::from(" ").into_ref(vm));
+        let mut end: Option<PyStringRef> = Some(PyString::from("\n").into_ref(vm));
+        let mut flush = false;
+
+        while let Some(arg) = args.next() {
+            match arg {
+                PyArg::Keyword(name, value) => match name.as_str() {
+                    "sep" => {
+                        sep = TryFromObject::try_from_object(vm, value)?;
+                    }
+                    "end" => {
+                        end = TryFromObject::try_from_object(vm, value)?;
+                    }
+                    "flush" => {
+                        flush = TryFromObject::try_from_object(vm, value)?;
+                    }
+                    _ => {
+                        return Err(ArgumentError::InvalidKeywordArgument(name));
+                    }
+                },
+                PyArg::Positional(_) => {
+                    return Err(ArgumentError::TooManyArgs);
+                }
+            }
         }
+
+        Ok(PrintOptions { sep, end, flush })
     }
-    let sep_str = sep_arg.as_ref().map(|obj| objstr::borrow_value(obj));
+}
 
-    // Handle 'end' kwarg:
-    let end_arg = args
-        .get_optional_kwarg("end")
-        .filter(|obj| !obj.is(&vm.get_none()));
-    if let Some(ref obj) = end_arg {
-        if !objtype::isinstance(obj, &vm.ctx.str_type()) {
-            return Err(vm.new_type_error(format!(
-                "end must be None or a string, not {}",
-                objtype::get_type_name(&obj.typ())
-            )));
-        }
-    }
-    let end_str = end_arg.as_ref().map(|obj| objstr::borrow_value(obj));
-
-    // Handle 'flush' kwarg:
-    let flush = if let Some(flush) = &args.get_optional_kwarg("flush") {
-        objbool::boolval(vm, flush.clone()).unwrap()
-    } else {
-        false
-    };
-
+pub fn builtin_print(
+    objects: Args,
+    options: PrintOptions,
+    vm: &mut VirtualMachine,
+) -> PyResult<()> {
     let stdout = io::stdout();
     let mut stdout_lock = stdout.lock();
     let mut first = true;
-    for a in &args.args {
+    for object in objects {
         if first {
             first = false;
-        } else if let Some(ref sep_str) = sep_str {
-            write!(stdout_lock, "{}", sep_str).unwrap();
+        } else if let Some(ref sep) = options.sep {
+            write!(stdout_lock, "{}", sep.value).unwrap();
         } else {
             write!(stdout_lock, " ").unwrap();
         }
-        let v = vm.to_str(&a)?;
+        let v = vm.to_str(&object)?;
         let s = objstr::borrow_value(&v);
         write!(stdout_lock, "{}", s).unwrap();
     }
 
-    if let Some(end_str) = end_str {
-        write!(stdout_lock, "{}", end_str).unwrap();
+    if let Some(end) = options.end {
+        write!(stdout_lock, "{}", end.value).unwrap();
     } else {
         writeln!(stdout_lock).unwrap();
     }
 
-    if flush {
+    if options.flush {
         stdout_lock.flush().unwrap();
     }
 
-    Ok(vm.get_none())
+    Ok(())
 }
 
 fn builtin_repr(vm: &mut VirtualMachine, args: PyFuncArgs) -> PyResult {

--- a/vm/src/function.rs
+++ b/vm/src/function.rs
@@ -192,14 +192,21 @@ pub trait FromArgs: Sized {
     /// Extracts this item from the next argument(s).
     fn from_args(vm: &mut VirtualMachine, args: &mut PyFuncArgs) -> Result<Self, ArgumentError>;
 }
+
 /// A map of keyword arguments to their values.
 ///
 /// A built-in function with a `KwArgs` parameter is analagous to a Python
-/// function with `*kwargs`. All remaining keyword arguments are extracted
+/// function with `**kwargs`. All remaining keyword arguments are extracted
 /// (and hence the function will permit an arbitrary number of them).
 ///
 /// `KwArgs` optionally accepts a generic type parameter to allow type checks
 /// or conversions of each argument.
+///
+/// Note:
+///
+/// KwArgs is only for functions that accept arbitrary keyword arguments. For
+/// functions that accept only *specific* named arguments, a rust struct with
+/// an appropriate FromArgs implementation must be created.
 pub struct KwArgs<T = PyObjectRef>(HashMap<String, T>);
 
 impl<T> FromArgs for KwArgs<T>

--- a/vm/src/function.rs
+++ b/vm/src/function.rs
@@ -106,6 +106,19 @@ impl PyFuncArgs {
         }
     }
 
+    pub fn take_keyword(&mut self, name: &str) -> Option<PyObjectRef> {
+        // TODO: change kwarg representation so this scan isn't necessary
+        if let Some(index) = self
+            .kwargs
+            .iter()
+            .position(|(arg_name, _)| arg_name == name)
+        {
+            Some(self.kwargs.remove(index).1)
+        } else {
+            None
+        }
+    }
+
     pub fn remaining_keyword<'a>(&'a mut self) -> impl Iterator<Item = (String, PyObjectRef)> + 'a {
         self.kwargs.drain(..)
     }

--- a/vm/src/lib.rs
+++ b/vm/src/lib.rs
@@ -25,6 +25,8 @@ extern crate serde_json;
 extern crate statrs;
 
 extern crate rustpython_parser;
+#[macro_use]
+extern crate rustpython_derive;
 
 //extern crate eval; use eval::eval::*;
 // use py_code_object::{Function, NativeType, PyCodeObject};

--- a/vm/src/obj/objbool.rs
+++ b/vm/src/obj/objbool.rs
@@ -1,7 +1,9 @@
 use num_traits::Zero;
 
 use crate::function::PyFuncArgs;
-use crate::pyobject::{IntoPyObject, PyContext, PyObjectRef, PyResult, TypeProtocol};
+use crate::pyobject::{
+    IntoPyObject, PyContext, PyObjectRef, PyResult, TryFromObject, TypeProtocol,
+};
 use crate::vm::VirtualMachine;
 
 use super::objdict::PyDict;
@@ -15,6 +17,12 @@ use super::objtype;
 impl IntoPyObject for bool {
     fn into_pyobject(self, vm: &mut VirtualMachine) -> PyResult {
         Ok(vm.ctx.new_bool(self))
+    }
+}
+
+impl TryFromObject for bool {
+    fn try_from_object(vm: &mut VirtualMachine, obj: PyObjectRef) -> PyResult<bool> {
+        boolval(vm, obj)
     }
 }
 

--- a/vm/src/obj/objstr.rs
+++ b/vm/src/obj/objstr.rs
@@ -1,6 +1,7 @@
 use std::hash::{Hash, Hasher};
 use std::ops::Range;
 use std::str::FromStr;
+use std::string::ToString;
 
 use num_traits::ToPrimitive;
 use unicode_segmentation::UnicodeSegmentation;
@@ -22,6 +23,14 @@ use super::objtype::{self, PyClassRef};
 pub struct PyString {
     // TODO: shouldn't be public
     pub value: String,
+}
+
+impl<T: ToString> From<T> for PyString {
+    fn from(t: T) -> PyString {
+        PyString {
+            value: t.to_string(),
+        }
+    }
 }
 
 pub type PyStringRef = PyRef<PyString>;


### PR DESCRIPTION
Based on #693 to avoid merge conflict.

I decided to convert this because it hits a lot of edge cases and thus helps to validate the model of the new args style.

In addition to converting to the new style, this also fixes a couple bugs:

- `Args` was swallowing the first keyword argument after it finished slurping the remaining positional args.
- `print` was accepting arbitrary / unknown keyword arguments, they are now rejected 

Note:

`KwArgs` is _only_ for functions that accept arbitrary keyword arguments, (i.e. `**kwargs` in python). For functions that accept _specific_ named arguments, a rust struct with an appropriate `FromArgs` implementation must be created. ~~This means some boilerplate right now, but is still cleaner / less error-prone than doing it in the function itself, and will be eliminated in the future with a `#[derive(FromArgs)]` macro.~~ *