### PR TITLE
Fix a bunch of clippy lints (again)

### DIFF
--- a/parser/src/ast.rs
+++ b/parser/src/ast.rs
@@ -274,8 +274,8 @@ impl Expression {
 pub struct Parameters {
     pub args: Vec<Parameter>,
     pub kwonlyargs: Vec<Parameter>,
-    pub vararg: Option<Option<Parameter>>, // Optionally we handle optionally named '*args' or '*'
-    pub kwarg: Option<Option<Parameter>>,
+    pub vararg: Varargs, // Optionally we handle optionally named '*args' or '*'
+    pub kwarg: Varargs,
     pub defaults: Vec<Expression>,
     pub kw_defaults: Vec<Option<Expression>>,
 }
@@ -390,4 +390,29 @@ pub enum StringGroup {
     Joined {
         values: Vec<StringGroup>,
     },
+}
+
+#[derive(Debug, PartialEq)]
+pub enum Varargs {
+    None,
+    NoCapture,
+    Capture(Parameter),
+}
+
+impl Default for Varargs {
+    fn default() -> Varargs {
+        Varargs::None
+    }
+}
+
+impl From<Option<Option<Parameter>>> for Varargs {
+    fn from(opt: Option<Option<Parameter>>) -> Varargs {
+        match opt {
+            Some(inner_opt) => match inner_opt {
+                Some(param) => Varargs::Capture(param),
+                None => Varargs::NoCapture,
+            },
+            None => Varargs::None,
+        }
+    }
 }

--- a/parser/src/ast.rs
+++ b/parser/src/ast.rs
@@ -395,8 +395,8 @@ pub enum StringGroup {
 #[derive(Debug, PartialEq)]
 pub enum Varargs {
     None,
-    NoCapture,
-    Capture(Parameter),
+    Unnamed,
+    Named(Parameter),
 }
 
 impl Default for Varargs {
@@ -409,8 +409,8 @@ impl From<Option<Option<Parameter>>> for Varargs {
     fn from(opt: Option<Option<Parameter>>) -> Varargs {
         match opt {
             Some(inner_opt) => match inner_opt {
-                Some(param) => Varargs::Capture(param),
-                None => Varargs::NoCapture,
+                Some(param) => Varargs::Named(param),
+                None => Varargs::Unnamed,
             },
             None => Varargs::None,
         }

--- a/parser/src/parser.rs
+++ b/parser/src/parser.rs
@@ -255,8 +255,8 @@ mod tests {
                                 }
                             ],
                             kwonlyargs: vec![],
-                            vararg: None,
-                            kwarg: None,
+                            vararg: ast::Varargs::None,
+                            kwarg: ast::Varargs::None,
                             defaults: vec![],
                             kw_defaults: vec![],
                         },
@@ -344,8 +344,8 @@ mod tests {
                                         annotation: None,
                                     }],
                                     kwonlyargs: vec![],
-                                    vararg: None,
-                                    kwarg: None,
+                                    vararg: ast::Varargs::None,
+                                    kwarg: ast::Varargs::None,
                                     defaults: vec![],
                                     kw_defaults: vec![],
                                 },
@@ -373,8 +373,8 @@ mod tests {
                                         }
                                     ],
                                     kwonlyargs: vec![],
-                                    vararg: None,
-                                    kwarg: None,
+                                    vararg: ast::Varargs::None,
+                                    kwarg: ast::Varargs::None,
                                     defaults: vec![ast::Expression::String {
                                         value: ast::StringGroup::Constant {
                                             value: "default".to_string()

--- a/parser/src/python.lalrpop
+++ b/parser/src/python.lalrpop
@@ -486,8 +486,8 @@ TypedArgsList<ArgType>: ast::Parameters = {
         ast::Parameters {
             args: names,
             kwonlyargs: kwonlyargs,
-            vararg: vararg,
-            kwarg: kwarg,
+            vararg: vararg.into(),
+            kwarg: kwarg.into(),
             defaults: default_elements,
             kw_defaults: kw_defaults,
         }
@@ -504,8 +504,8 @@ TypedArgsList<ArgType>: ast::Parameters = {
         ast::Parameters {
             args: names,
             kwonlyargs: kwonlyargs,
-            vararg: vararg,
-            kwarg: kwarg,
+            vararg: vararg.into(),
+            kwarg: kwarg.into(),
             defaults: default_elements,
             kw_defaults: kw_defaults,
         }
@@ -515,8 +515,8 @@ TypedArgsList<ArgType>: ast::Parameters = {
         ast::Parameters {
             args: vec![],
             kwonlyargs: kwonlyargs,
-            vararg: vararg,
-            kwarg: kwarg,
+            vararg: vararg.into(),
+            kwarg: kwarg.into(),
             defaults: vec![],
             kw_defaults: kw_defaults,
         }
@@ -525,8 +525,8 @@ TypedArgsList<ArgType>: ast::Parameters = {
         ast::Parameters {
             args: vec![],
             kwonlyargs: vec![],
-            vararg: None,
-            kwarg: Some(kw),
+            vararg: ast::Varargs::None,
+            kwarg: Some(kw).into(),
             defaults: vec![],
             kw_defaults: vec![],
         }

--- a/src/main.rs
+++ b/src/main.rs
@@ -186,7 +186,7 @@ fn run_shell(vm: &mut VirtualMachine) -> PyResult {
                 debug!("You entered {:?}", line);
                 input.push_str(&line);
                 input.push_str("\n");
-                repl.add_history_entry(line.trim_end().as_ref());
+                repl.add_history_entry(line.trim_end());
 
                 match shell_exec(vm, &input, vars.clone()) {
                     Err(CompileError::Parse(ParseError::EOF(_))) => {

--- a/vm/src/bytecode.rs
+++ b/vm/src/bytecode.rs
@@ -18,10 +18,10 @@ pub struct CodeObject {
     pub instructions: Vec<Instruction>,
     pub label_map: HashMap<Label, usize>,
     pub locations: Vec<ast::Location>,
-    pub arg_names: Vec<String>,          // Names of positional arguments
-    pub varargs: Option<Option<String>>, // *args or *
+    pub arg_names: Vec<String>, // Names of positional arguments
+    pub varargs: Varargs,       // *args or *
     pub kwonlyarg_names: Vec<String>,
-    pub varkeywords: Option<Option<String>>, // **kwargs or **
+    pub varkeywords: Varargs, // **kwargs or **
     pub source_path: String,
     pub first_line_number: usize,
     pub obj_name: String, // Name of the object that created this code object
@@ -237,6 +237,13 @@ pub enum UnaryOperator {
     Plus,
 }
 
+#[derive(Debug, Clone, PartialEq)]
+pub enum Varargs {
+    None,
+    NoCapture,
+    Capture(String),
+}
+
 /*
 Maintain a stack of blocks on the VM.
 pub enum BlockType {
@@ -248,9 +255,9 @@ pub enum BlockType {
 impl CodeObject {
     pub fn new(
         arg_names: Vec<String>,
-        varargs: Option<Option<String>>,
+        varargs: Varargs,
         kwonlyarg_names: Vec<String>,
-        varkeywords: Option<Option<String>>,
+        varkeywords: Varargs,
         source_path: String,
         first_line_number: usize,
         obj_name: String,
@@ -399,5 +406,25 @@ impl fmt::Debug for CodeObject {
             "<code object {} at ??? file {:?}, line {}>",
             self.obj_name, self.source_path, self.first_line_number
         )
+    }
+}
+
+impl From<ast::Varargs> for Varargs {
+    fn from(varargs: ast::Varargs) -> Varargs {
+        match varargs {
+            ast::Varargs::None => Varargs::None,
+            ast::Varargs::NoCapture => Varargs::NoCapture,
+            ast::Varargs::Capture(param) => Varargs::Capture(param.arg),
+        }
+    }
+}
+
+impl Varargs {
+    pub fn from_ast_vararg_ref(varargs: &ast::Varargs) -> Varargs {
+        match varargs {
+            ast::Varargs::None => Varargs::None,
+            ast::Varargs::NoCapture => Varargs::NoCapture,
+            ast::Varargs::Capture(ref param) => Varargs::Capture(param.arg.clone()),
+        }
     }
 }

--- a/vm/src/bytecode.rs
+++ b/vm/src/bytecode.rs
@@ -240,8 +240,8 @@ pub enum UnaryOperator {
 #[derive(Debug, Clone, PartialEq)]
 pub enum Varargs {
     None,
-    NoCapture,
-    Capture(String),
+    Unnamed,
+    Named(String),
 }
 
 /*
@@ -413,8 +413,8 @@ impl From<ast::Varargs> for Varargs {
     fn from(varargs: ast::Varargs) -> Varargs {
         match varargs {
             ast::Varargs::None => Varargs::None,
-            ast::Varargs::NoCapture => Varargs::NoCapture,
-            ast::Varargs::Capture(param) => Varargs::Capture(param.arg),
+            ast::Varargs::Unnamed => Varargs::Unnamed,
+            ast::Varargs::Named(param) => Varargs::Named(param.arg),
         }
     }
 }
@@ -423,8 +423,8 @@ impl<'a> From<&'a ast::Varargs> for Varargs {
     fn from(varargs: &'a ast::Varargs) -> Varargs {
         match varargs {
             ast::Varargs::None => Varargs::None,
-            ast::Varargs::NoCapture => Varargs::NoCapture,
-            ast::Varargs::Capture(ref param) => Varargs::Capture(param.arg.clone()),
+            ast::Varargs::Unnamed => Varargs::Unnamed,
+            ast::Varargs::Named(ref param) => Varargs::Named(param.arg.clone()),
         }
     }
 }

--- a/vm/src/bytecode.rs
+++ b/vm/src/bytecode.rs
@@ -419,8 +419,8 @@ impl From<ast::Varargs> for Varargs {
     }
 }
 
-impl Varargs {
-    pub fn from_ast_vararg_ref(varargs: &ast::Varargs) -> Varargs {
+impl<'a> From<&'a ast::Varargs> for Varargs {
+    fn from(varargs: &'a ast::Varargs) -> Varargs {
         match varargs {
             ast::Varargs::None => Varargs::None,
             ast::Varargs::NoCapture => Varargs::NoCapture,

--- a/vm/src/compile.rs
+++ b/vm/src/compile.rs
@@ -445,9 +445,9 @@ impl Compiler {
         let line_number = self.get_source_line_number();
         self.code_object_stack.push(CodeObject::new(
             args.args.iter().map(|a| a.arg.clone()).collect(),
-            Varargs::from_ast_vararg_ref(&args.vararg),
+            Varargs::from(&args.vararg),
             args.kwonlyargs.iter().map(|a| a.arg.clone()).collect(),
-            Varargs::from_ast_vararg_ref(&args.kwarg),
+            Varargs::from(&args.kwarg),
             self.source_path.clone().unwrap(),
             line_number,
             name.to_string(),

--- a/vm/src/compile.rs
+++ b/vm/src/compile.rs
@@ -5,7 +5,7 @@
 //!   https://github.com/python/cpython/blob/master/Python/compile.c
 //!   https://github.com/micropython/micropython/blob/master/py/compile.c
 
-use crate::bytecode::{self, CallType, CodeObject, Instruction};
+use crate::bytecode::{self, CallType, CodeObject, Instruction, Varargs};
 use crate::error::CompileError;
 use crate::obj::objcode;
 use crate::pyobject::{PyObject, PyObjectRef};
@@ -82,9 +82,9 @@ impl Compiler {
         let line_number = self.get_source_line_number();
         self.code_object_stack.push(CodeObject::new(
             Vec::new(),
-            None,
+            Varargs::None,
             Vec::new(),
-            None,
+            Varargs::None,
             self.source_path.clone().unwrap(),
             line_number,
             obj_name,
@@ -445,13 +445,9 @@ impl Compiler {
         let line_number = self.get_source_line_number();
         self.code_object_stack.push(CodeObject::new(
             args.args.iter().map(|a| a.arg.clone()).collect(),
-            args.vararg
-                .as_ref()
-                .map(|x| x.as_ref().map(|a| a.arg.clone())),
+            Varargs::from_ast_vararg_ref(&args.vararg),
             args.kwonlyargs.iter().map(|a| a.arg.clone()).collect(),
-            args.kwarg
-                .as_ref()
-                .map(|x| x.as_ref().map(|a| a.arg.clone())),
+            Varargs::from_ast_vararg_ref(&args.kwarg),
             self.source_path.clone().unwrap(),
             line_number,
             name.to_string(),
@@ -684,9 +680,9 @@ impl Compiler {
         let line_number = self.get_source_line_number();
         self.code_object_stack.push(CodeObject::new(
             vec![],
-            None,
+            Varargs::None,
             vec![],
-            None,
+            Varargs::None,
             self.source_path.clone().unwrap(),
             line_number,
             name.to_string(),
@@ -1297,9 +1293,9 @@ impl Compiler {
         // Create magnificent function <listcomp>:
         self.code_object_stack.push(CodeObject::new(
             vec![".0".to_string()],
-            None,
+            Varargs::None,
             vec![],
-            None,
+            Varargs::None,
             self.source_path.clone().unwrap(),
             line_number,
             name.clone(),

--- a/vm/src/function.rs
+++ b/vm/src/function.rs
@@ -20,7 +20,7 @@ pub struct PyFuncArgs {
 impl From<Vec<PyObjectRef>> for PyFuncArgs {
     fn from(args: Vec<PyObjectRef>) -> Self {
         PyFuncArgs {
-            args: args,
+            args,
             kwargs: vec![],
         }
     }

--- a/vm/src/lib.rs
+++ b/vm/src/lib.rs
@@ -6,7 +6,11 @@
 //! - Base objects
 
 // for methods like vm.to_str(), not the typical use of 'to' as a method prefix
-#![allow(clippy::wrong_self_convention, clippy::let_and_return)]
+#![allow(
+    clippy::wrong_self_convention,
+    clippy::let_and_return,
+    clippy::implicit_hasher
+)]
 
 #[macro_use]
 extern crate bitflags;

--- a/vm/src/lib.rs
+++ b/vm/src/lib.rs
@@ -6,7 +6,7 @@
 //! - Base objects
 
 // for methods like vm.to_str(), not the typical use of 'to' as a method prefix
-#![allow(clippy::wrong_self_convention)]
+#![allow(clippy::wrong_self_convention, clippy::let_and_return)]
 
 #[macro_use]
 extern crate bitflags;

--- a/vm/src/macros.rs
+++ b/vm/src/macros.rs
@@ -117,10 +117,10 @@ macro_rules! py_module {
     ( $ctx:expr, $module_name:expr, { $($name:expr => $value:expr),* $(,)* }) => {
         {
             let py_mod = $ctx.new_module($module_name, $ctx.new_dict());
-        $(
-            $ctx.set_attr(&py_mod, $name, $value);
-        )*
-        py_mod
+            $(
+                $ctx.set_attr(&py_mod, $name, $value);
+            )*
+            py_mod
         }
     }
 }

--- a/vm/src/obj/objlist.rs
+++ b/vm/src/obj/objlist.rs
@@ -203,7 +203,7 @@ impl PyListRef {
                 return Ok(index);
             }
         }
-        let needle_str = vm.to_pystr(&needle)?;
+        let needle_str = &vm.to_str(&needle)?.value;
         Err(vm.new_value_error(format!("'{}' is not in list", needle_str)))
     }
 
@@ -240,7 +240,7 @@ impl PyListRef {
             self.elements.borrow_mut().remove(index);
             Ok(())
         } else {
-            let needle_str = vm.to_pystr(&needle)?;
+            let needle_str = &vm.to_str(&needle)?.value;
             Err(vm.new_value_error(format!("'{}' is not in list", needle_str)))
         }
     }

--- a/vm/src/obj/objlist.rs
+++ b/vm/src/obj/objlist.rs
@@ -206,7 +206,7 @@ impl PyListRef {
                 return Ok(index);
             }
         }
-        let ref needle_str = vm.to_str(&needle)?.value;
+        let needle_str = vm.to_pystr(&needle)?;
         Err(vm.new_value_error(format!("'{}' is not in list", needle_str)))
     }
 
@@ -243,7 +243,7 @@ impl PyListRef {
             self.elements.borrow_mut().remove(index);
             Ok(())
         } else {
-            let ref needle_str = vm.to_str(&needle)?.value;
+            let needle_str = vm.to_pystr(&needle)?;
             Err(vm.new_value_error(format!("'{}' is not in list", needle_str)))
         }
     }

--- a/vm/src/obj/objsequence.rs
+++ b/vm/src/obj/objsequence.rs
@@ -78,6 +78,7 @@ pub trait PySliceableSequence {
                 } else if step.is_positive() {
                     let range = self.get_slice_range(start, stop);
                     if range.start < range.end {
+                        #[allow(clippy::range_plus_one)]
                         match step.to_i32() {
                             Some(1) => Ok(self.do_slice(range)),
                             Some(num) => Ok(self.do_stepped_slice(range, num as usize)),

--- a/vm/src/obj/objtype.rs
+++ b/vm/src/obj/objtype.rs
@@ -331,7 +331,6 @@ fn linearise_mro(mut bases: Vec<Vec<PyClassRef>>) -> Option<Vec<PyClassRef>> {
     Some(result)
 }
 
-#[allow(clippy::implicit_hasher)]
 pub fn new(
     typ: PyObjectRef,
     name: &str,

--- a/vm/src/obj/objtype.rs
+++ b/vm/src/obj/objtype.rs
@@ -151,7 +151,7 @@ pub fn isinstance(obj: &PyObjectRef, cls: &PyObjectRef) -> bool {
 /// so only use this if `cls` is known to have not overridden the base __subclasscheck__ magic
 /// method.
 pub fn issubclass(subclass: &PyObjectRef, cls: &PyObjectRef) -> bool {
-    let ref mro = subclass.payload::<PyClass>().unwrap().mro;
+    let mro = &subclass.payload::<PyClass>().unwrap().mro;
     subclass.is(cls) || mro.iter().any(|c| c.is(cls))
 }
 
@@ -331,6 +331,7 @@ fn linearise_mro(mut bases: Vec<Vec<PyClassRef>>) -> Option<Vec<PyClassRef>> {
     Some(result)
 }
 
+#[allow(clippy::implicit_hasher)]
 pub fn new(
     typ: PyObjectRef,
     name: &str,

--- a/vm/src/pyobject.rs
+++ b/vm/src/pyobject.rs
@@ -908,7 +908,7 @@ impl DictProtocol for PyObjectRef {
     }
 
     fn get_key_value_pairs(&self) -> Vec<(PyObjectRef, PyObjectRef)> {
-        if self.object_is::<PyDict>() {
+        if self.payload_is::<PyDict>() {
             objdict::get_key_value_pairs(self)
         } else if let Some(PyModule { ref dict, .. }) = self.payload::<PyModule>() {
             dict.get_key_value_pairs()
@@ -1123,7 +1123,7 @@ impl PyObject {
     }
 
     #[inline]
-    pub fn object_is<T: PyObjectPayload>(&self) -> bool {
+    pub fn payload_is<T: PyObjectPayload>(&self) -> bool {
         self.payload.as_any().is::<T>()
     }
 }
@@ -1166,7 +1166,7 @@ impl<T: PyValue + 'static> PyObjectPayload for T {
 
 impl FromPyObjectRef for PyRef<PyClass> {
     fn from_pyobj(obj: &PyObjectRef) -> Self {
-        if obj.object_is::<PyClass>() {
+        if obj.payload_is::<PyClass>() {
             PyRef {
                 obj: obj.clone(),
                 _payload: PhantomData,

--- a/vm/src/pyobject.rs
+++ b/vm/src/pyobject.rs
@@ -908,7 +908,7 @@ impl DictProtocol for PyObjectRef {
     }
 
     fn get_key_value_pairs(&self) -> Vec<(PyObjectRef, PyObjectRef)> {
-        if self.payload_is::<PyDict>() {
+        if self.object_is::<PyDict>() {
             objdict::get_key_value_pairs(self)
         } else if let Some(PyModule { ref dict, .. }) = self.payload::<PyModule>() {
             dict.get_key_value_pairs()
@@ -1123,7 +1123,7 @@ impl PyObject {
     }
 
     #[inline]
-    pub fn payload_is<T: PyObjectPayload>(&self) -> bool {
+    pub fn object_is<T: PyObjectPayload>(&self) -> bool {
         self.payload.as_any().is::<T>()
     }
 }
@@ -1166,7 +1166,7 @@ impl<T: PyValue + 'static> PyObjectPayload for T {
 
 impl FromPyObjectRef for PyRef<PyClass> {
     fn from_pyobj(obj: &PyObjectRef) -> Self {
-        if obj.payload_is::<PyClass>() {
+        if obj.object_is::<PyClass>() {
             PyRef {
                 obj: obj.clone(),
                 _payload: PhantomData,

--- a/vm/src/pyobject.rs
+++ b/vm/src/pyobject.rs
@@ -908,7 +908,7 @@ impl DictProtocol for PyObjectRef {
     }
 
     fn get_key_value_pairs(&self) -> Vec<(PyObjectRef, PyObjectRef)> {
-        if let Some(_) = self.payload::<PyDict>() {
+        if self.payload_is::<PyDict>() {
             objdict::get_key_value_pairs(self)
         } else if let Some(PyModule { ref dict, .. }) = self.payload::<PyModule>() {
             dict.get_key_value_pairs()
@@ -1039,7 +1039,7 @@ impl<T: TryFromObject> TryFromObject for Option<T> {
         if vm.get_none().is(&obj) {
             Ok(None)
         } else {
-            T::try_from_object(vm, obj).map(|x| Some(x))
+            T::try_from_object(vm, obj).map(Some)
         }
     }
 }
@@ -1118,8 +1118,13 @@ impl PyObject {
     }
 
     #[inline]
-    pub fn payload<T: PyValue>(&self) -> Option<&T> {
+    pub fn payload<T: PyObjectPayload>(&self) -> Option<&T> {
         self.payload.as_any().downcast_ref()
+    }
+
+    #[inline]
+    pub fn payload_is<T: PyObjectPayload>(&self) -> bool {
+        self.payload.as_any().is::<T>()
     }
 }
 
@@ -1161,7 +1166,7 @@ impl<T: PyValue + 'static> PyObjectPayload for T {
 
 impl FromPyObjectRef for PyRef<PyClass> {
     fn from_pyobj(obj: &PyObjectRef) -> Self {
-        if let Some(_) = obj.payload::<PyClass>() {
+        if obj.payload_is::<PyClass>() {
             PyRef {
                 obj: obj.clone(),
                 _payload: PhantomData,

--- a/vm/src/stdlib/re.rs
+++ b/vm/src/stdlib/re.rs
@@ -194,7 +194,7 @@ fn match_end(vm: &mut VirtualMachine, args: PyFuncArgs) -> PyResult {
 }
 
 /// Retrieve inner rust regex from python object:
-fn get_regex<'a>(obj: &'a PyObjectRef) -> &'a Regex {
+fn get_regex(obj: &PyObjectRef) -> &Regex {
     // TODO: Regex shouldn't be stored in payload directly, create newtype wrapper
     if let Some(regex) = obj.payload::<Regex>() {
         return regex;
@@ -203,7 +203,7 @@ fn get_regex<'a>(obj: &'a PyObjectRef) -> &'a Regex {
 }
 
 /// Retrieve inner rust match from python object:
-fn get_match<'a>(obj: &'a PyObjectRef) -> &'a PyMatch {
+fn get_match(obj: &PyObjectRef) -> &PyMatch {
     if let Some(value) = obj.payload::<PyMatch>() {
         return value;
     }

--- a/vm/src/stdlib/types.rs
+++ b/vm/src/stdlib/types.rs
@@ -15,13 +15,12 @@ fn types_new_class(vm: &mut VirtualMachine, args: PyFuncArgs) -> PyResult {
         optional = [(bases, None), (_kwds, None), (_exec_body, None)]
     );
 
-    let ref type_type = vm.ctx.type_type();
     let bases: PyObjectRef = match bases {
         Some(bases) => bases.clone(),
         None => vm.ctx.new_tuple(vec![]),
     };
     let dict = vm.ctx.new_dict();
-    objtype::type_new_class(vm, &type_type, name, &bases, &dict)
+    objtype::type_new_class(vm, &vm.ctx.type_type(), name, &bases, &dict)
 }
 
 pub fn make_module(ctx: &PyContext) -> PyObjectRef {

--- a/vm/src/vm.rs
+++ b/vm/src/vm.rs
@@ -402,7 +402,7 @@ impl VirtualMachine {
 
         // Pack other positional arguments in to *args:
         match code_object.varargs {
-            bytecode::Varargs::Capture(ref vararg_name) => {
+            bytecode::Varargs::Named(ref vararg_name) => {
                 let mut last_args = vec![];
                 for i in n..nargs {
                     let arg = &args.args[i];
@@ -412,7 +412,7 @@ impl VirtualMachine {
 
                 locals.set_item(&self.ctx, vararg_name, vararg_value);
             }
-            bytecode::Varargs::NoCapture => {
+            bytecode::Varargs::Unnamed => {
                 // just ignore the rest of the args
             }
             bytecode::Varargs::None => {
@@ -428,12 +428,12 @@ impl VirtualMachine {
 
         // Do we support `**kwargs` ?
         let kwargs = match code_object.varkeywords {
-            bytecode::Varargs::Capture(ref kwargs_name) => {
+            bytecode::Varargs::Named(ref kwargs_name) => {
                 let d = self.new_dict();
                 locals.set_item(&self.ctx, kwargs_name, d.clone());
                 Some(d)
             }
-            bytecode::Varargs::NoCapture => Some(self.new_dict()),
+            bytecode::Varargs::Unnamed => Some(self.new_dict()),
             bytecode::Varargs::None => None,
         };
 

--- a/vm/src/vm.rs
+++ b/vm/src/vm.rs
@@ -360,12 +360,7 @@ impl VirtualMachine {
     }
 
     pub fn invoke_with_locals(&mut self, function: PyObjectRef, locals: PyObjectRef) -> PyResult {
-        if let Some(PyFunction {
-            code,
-            scope,
-            defaults: _,
-        }) = &function.payload()
-        {
+        if let Some(PyFunction { code, scope, .. }) = &function.payload() {
             let scope = scope.child_scope_with_locals(locals);
             let frame = self.ctx.new_frame(code.clone(), scope);
             return self.run_frame_full(frame);

--- a/vm/src/vm.rs
+++ b/vm/src/vm.rs
@@ -401,40 +401,40 @@ impl VirtualMachine {
         }
 
         // Pack other positional arguments in to *args:
-        if let Some(vararg) = &code_object.varargs {
-            let mut last_args = vec![];
-            for i in n..nargs {
-                let arg = &args.args[i];
-                last_args.push(arg.clone());
-            }
-            let vararg_value = self.ctx.new_tuple(last_args);
+        match code_object.varargs {
+            bytecode::Varargs::Capture(ref vararg_name) => {
+                let mut last_args = vec![];
+                for i in n..nargs {
+                    let arg = &args.args[i];
+                    last_args.push(arg.clone());
+                }
+                let vararg_value = self.ctx.new_tuple(last_args);
 
-            // If we have a name (not '*' only) then store it:
-            if let Some(vararg_name) = vararg {
                 locals.set_item(&self.ctx, vararg_name, vararg_value);
             }
-        } else {
-            // Check the number of positional arguments
-            if nargs > nexpected_args {
-                return Err(self.new_type_error(format!(
-                    "Expected {} arguments (got: {})",
-                    nexpected_args, nargs
-                )));
+            bytecode::Varargs::NoCapture => {
+                // just ignore the rest of the args
+            }
+            bytecode::Varargs::None => {
+                // Check the number of positional arguments
+                if nargs > nexpected_args {
+                    return Err(self.new_type_error(format!(
+                        "Expected {} arguments (got: {})",
+                        nexpected_args, nargs
+                    )));
+                }
             }
         }
 
         // Do we support `**kwargs` ?
-        let kwargs = if let Some(kwargs) = &code_object.varkeywords {
-            let d = self.new_dict();
-
-            // Store when we have a name:
-            if let Some(kwargs_name) = kwargs {
-                locals.set_item(&self.ctx, &kwargs_name, d.clone());
+        let kwargs = match code_object.varkeywords {
+            bytecode::Varargs::Capture(ref kwargs_name) => {
+                let d = self.new_dict();
+                locals.set_item(&self.ctx, kwargs_name, d.clone());
+                Some(d)
             }
-
-            Some(d)
-        } else {
-            None
+            bytecode::Varargs::NoCapture => Some(self.new_dict()),
+            bytecode::Varargs::None => None,
         };
 
         // Handle keyword arguments

--- a/wasm/lib/src/browser_module.rs
+++ b/wasm/lib/src/browser_module.rs
@@ -75,8 +75,8 @@ fn browser_fetch(vm: &mut VirtualMachine, args: PyFuncArgs) -> PyResult {
     if let Some(headers) = headers {
         let h = request.headers();
         for (key, value) in rustpython_vm::obj::objdict::get_key_value_pairs(&headers) {
-            let ref key = vm.to_str(&key)?.value;
-            let ref value = vm.to_str(&value)?.value;
+            let key = &vm.to_str(&key)?.value;
+            let value = &vm.to_str(&value)?.value;
             h.set(key, value)
                 .map_err(|err| convert::js_py_typeerror(vm, err))?;
         }
@@ -163,9 +163,8 @@ pub struct PyPromise {
 }
 
 impl PyValue for PyPromise {
-    fn class(_vm: &mut VirtualMachine) -> PyObjectRef {
-        // TODO
-        unimplemented!()
+    fn class(vm: &mut VirtualMachine) -> PyObjectRef {
+        vm.class(BROWSER_NAME, "Promise")
     }
 }
 
@@ -183,7 +182,7 @@ pub fn get_promise_value(obj: &PyObjectRef) -> Promise {
 }
 
 pub fn import_promise_type(vm: &mut VirtualMachine) -> PyResult {
-    match import_module(vm, PathBuf::default(), BROWSER_NAME)?.get_attr("Promise".into()) {
+    match import_module(vm, PathBuf::default(), BROWSER_NAME)?.get_attr("Promise") {
         Some(promise) => Ok(promise),
         None => Err(vm.new_not_implemented_error("No Promise".to_string())),
     }

--- a/wasm/lib/src/convert.rs
+++ b/wasm/lib/src/convert.rs
@@ -129,10 +129,7 @@ pub fn py_to_js(vm: &mut VirtualMachine, py_obj: PyObjectRef) -> JsValue {
         }
         arr.into()
     } else {
-        let dumps = rustpython_vm::import::import_module(vm, std::path::PathBuf::default(), "json")
-            .expect("Couldn't get json module")
-            .get_attr("dumps".into())
-            .expect("Couldn't get json dumps");
+        let dumps = vm.class("json", "dumps");
         match vm.invoke(dumps, PyFuncArgs::new(vec![py_obj], vec![])) {
             Ok(value) => {
                 let json = vm.to_pystr(&value).unwrap();
@@ -156,7 +153,7 @@ pub fn object_entries(obj: &Object) -> impl Iterator<Item = Result<(JsValue, JsV
 pub fn pyresult_to_jsresult(vm: &mut VirtualMachine, result: PyResult) -> Result<JsValue, JsValue> {
     result
         .map(|value| py_to_js(vm, value))
-        .map_err(|err| py_err_to_js_err(vm, &err).into())
+        .map_err(|err| py_err_to_js_err(vm, &err))
 }
 
 pub fn js_to_py(vm: &mut VirtualMachine, js_val: JsValue) -> PyObjectRef {
@@ -229,11 +226,7 @@ pub fn js_to_py(vm: &mut VirtualMachine, js_val: JsValue) -> PyObjectRef {
         // Because `JSON.stringify(undefined)` returns undefined
         vm.get_none()
     } else {
-        let loads = rustpython_vm::import::import_module(vm, std::path::PathBuf::default(), "json")
-            .expect("Couldn't get json module")
-            .get_attr("loads".into())
-            .expect("Couldn't get json dumps");
-
+        let loads = vm.class("json", "dumps");
         let json = match js_sys::JSON::stringify(&js_val) {
             Ok(json) => String::from(json),
             Err(_) => return vm.get_none(),

--- a/wasm/lib/src/vm_class.rs
+++ b/wasm/lib/src/vm_class.rs
@@ -3,7 +3,7 @@ use std::collections::HashMap;
 use std::rc::{Rc, Weak};
 
 use js_sys::{Object, Reflect, SyntaxError, TypeError};
-use wasm_bindgen::{prelude::*, JsCast};
+use wasm_bindgen::prelude::*;
 
 use rustpython_vm::compile;
 use rustpython_vm::frame::{NameProtocol, Scope};


### PR DESCRIPTION
The biggest change in this is that I changed the representation of varargs in the bytecode and AST from `Option<Option<_>>` to its own enum in commit ab53883. I sorta jury-rigged it into the lalrpop file because I'm not too familiar with how it functions, so feel free to give critique for that.