### PR TITLE
Add __class__ cell to method scopes.

### DIFF
--- a/tests/snippets/class.py
+++ b/tests/snippets/class.py
@@ -22,15 +22,18 @@ class Bar:
         self.x = x
 
     def get_x(self):
+        assert __class__ is Bar
         return self.x
 
     @classmethod
     def fubar(cls, x):
+        assert __class__ is cls
         assert cls is Bar
         assert x == 2
 
     @staticmethod
     def kungfu(x):
+        assert __class__ is Bar
         assert x == 3
 
 

--- a/vm/src/vm.rs
+++ b/vm/src/vm.rs
@@ -359,14 +359,21 @@ impl VirtualMachine {
         }
     }
 
-    pub fn invoke_with_locals(&mut self, function: PyObjectRef, locals: PyObjectRef) -> PyResult {
+    pub fn invoke_with_locals(
+        &mut self,
+        function: PyObjectRef,
+        cells: PyObjectRef,
+        locals: PyObjectRef,
+    ) -> PyResult {
         if let Some(PyFunction {
             code,
             scope,
             defaults: _,
         }) = &function.payload()
         {
-            let scope = scope.child_scope_with_locals(locals);
+            let scope = scope
+                .child_scope_with_locals(cells)
+                .child_scope_with_locals(locals);
             let frame = self.ctx.new_frame(code.clone(), scope);
             return self.run_frame_full(frame);
         }


### PR DESCRIPTION
This is a basic implementation that I think should be good enough for ```__super__``` to work.

This should be passed through to the metaclass to allow some more advanced trickery, but I think this is good enough. There's a more optimal implementation than a whole dictionary just for this, which we can sort when we come to optimise local variables.