### PR TITLE
Fix the Display impl for PyRef

### DIFF
--- a/vm/src/obj/objlist.rs
+++ b/vm/src/obj/objlist.rs
@@ -245,57 +245,62 @@ impl PyListRef {
         }
     }
 
-    fn eq(self, other: PyObjectRef, vm: &mut VirtualMachine) -> PyResult<bool> {
+    fn eq(self, other: PyObjectRef, vm: &mut VirtualMachine) -> PyResult {
         if self.as_object().is(&other) {
-            return Ok(true);
+            return Ok(vm.new_bool(true));
         }
 
         if objtype::isinstance(&other, &vm.ctx.list_type()) {
             let zelf = self.elements.borrow();
             let other = get_elements(&other);
-            Ok(seq_equal(vm, &zelf, &other)?)
+            let res = seq_equal(vm, &zelf, &other)?;
+            Ok(vm.new_bool(res))
         } else {
-            Ok(false)
-        }
-    }
-
-    fn lt(self, other: PyObjectRef, vm: &mut VirtualMachine) -> PyResult<bool> {
-        if objtype::isinstance(&other, &vm.ctx.list_type()) {
-            let zelf = self.elements.borrow();
-            let other = get_elements(&other);
-            Ok(seq_lt(vm, &zelf, &other)?)
-        } else {
-            Err(vm.new_type_error(format!("Cannot compare {} and {} using '<'", self, other)))
+            Ok(vm.ctx.not_implemented())
         }
     }
 
-    fn gt(self, other: PyObjectRef, vm: &mut VirtualMachine) -> PyResult<bool> {
+    fn lt(self, other: PyObjectRef, vm: &mut VirtualMachine) -> PyResult {
         if objtype::isinstance(&other, &vm.ctx.list_type()) {
             let zelf = self.elements.borrow();
             let other = get_elements(&other);
-            Ok(seq_gt(vm, &zelf, &other)?)
+            let res = seq_lt(vm, &zelf, &other)?;
+            Ok(vm.new_bool(res))
         } else {
-            Err(vm.new_type_error(format!("Cannot compare {} and {} using '>'", self, other)))
+            Ok(vm.ctx.not_implemented())
         }
     }
 
-    fn ge(self, other: PyObjectRef, vm: &mut VirtualMachine) -> PyResult<bool> {
+    fn gt(self, other: PyObjectRef, vm: &mut VirtualMachine) -> PyResult {
         if objtype::isinstance(&other, &vm.ctx.list_type()) {
             let zelf = self.elements.borrow();
             let other = get_elements(&other);
-            Ok(seq_ge(vm, &zelf, &other)?)
+            let res = seq_gt(vm, &zelf, &other)?;
+            Ok(vm.new_bool(res))
         } else {
-            Err(vm.new_type_error(format!("Cannot compare {} and {} using '>='", self, other)))
+            Ok(vm.ctx.not_implemented())
         }
     }
 
-    fn le(self, other: PyObjectRef, vm: &mut VirtualMachine) -> PyResult<bool> {
+    fn ge(self, other: PyObjectRef, vm: &mut VirtualMachine) -> PyResult {
         if objtype::isinstance(&other, &vm.ctx.list_type()) {
             let zelf = self.elements.borrow();
             let other = get_elements(&other);
-            Ok(seq_le(vm, &zelf, &other)?)
+            let res = seq_ge(vm, &zelf, &other)?;
+            Ok(vm.new_bool(res))
         } else {
-            Err(vm.new_type_error(format!("Cannot compare {} and {} using '<='", self, other)))
+            Ok(vm.ctx.not_implemented())
+        }
+    }
+
+    fn le(self, other: PyObjectRef, vm: &mut VirtualMachine) -> PyResult {
+        if objtype::isinstance(&other, &vm.ctx.list_type()) {
+            let zelf = self.elements.borrow();
+            let other = get_elements(&other);
+            let res = seq_le(vm, &zelf, &other)?;
+            Ok(vm.new_bool(res))
+        } else {
+            Ok(vm.ctx.not_implemented())
         }
     }
 }

--- a/vm/src/obj/objstr.rs
+++ b/vm/src/obj/objstr.rs
@@ -1,3 +1,4 @@
+use std::fmt;
 use std::hash::{Hash, Hasher};
 use std::ops::Range;
 use std::str::FromStr;
@@ -25,11 +26,9 @@ pub struct PyString {
     pub value: String,
 }
 
-impl<T: ToString> From<T> for PyString {
-    fn from(t: T) -> PyString {
-        PyString {
-            value: t.to_string(),
-        }
+impl fmt::Display for PyString {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        fmt::Display::fmt(&self.value, f)
     }
 }
 

--- a/vm/src/obj/objtuple.rs
+++ b/vm/src/obj/objtuple.rs
@@ -46,43 +46,47 @@ impl PyValue for PyTuple {
 pub type PyTupleRef = PyRef<PyTuple>;
 
 impl PyTupleRef {
-    fn lt(self, other: PyObjectRef, vm: &mut VirtualMachine) -> PyResult<bool> {
+    fn lt(self, other: PyObjectRef, vm: &mut VirtualMachine) -> PyResult {
         if objtype::isinstance(&other, &vm.ctx.tuple_type()) {
             let zelf = self.elements.borrow();
             let other = get_elements(&other);
-            Ok(seq_lt(vm, &zelf, &other)?)
+            let res = seq_lt(vm, &zelf, &other)?;
+            Ok(vm.new_bool(res))
         } else {
-            Err(vm.new_type_error(format!("Cannot compare {} and {} using '<'", self, other)))
+            Ok(vm.ctx.not_implemented())
         }
     }
 
-    fn gt(self, other: PyObjectRef, vm: &mut VirtualMachine) -> PyResult<bool> {
+    fn gt(self, other: PyObjectRef, vm: &mut VirtualMachine) -> PyResult {
         if objtype::isinstance(&other, &vm.ctx.tuple_type()) {
             let zelf = self.elements.borrow();
             let other = get_elements(&other);
-            Ok(seq_gt(vm, &zelf, &other)?)
+            let res = seq_gt(vm, &zelf, &other)?;
+            Ok(vm.new_bool(res))
         } else {
-            Err(vm.new_type_error(format!("Cannot compare {} and {} using '>'", self, other)))
+            Ok(vm.ctx.not_implemented())
         }
     }
 
-    fn ge(self, other: PyObjectRef, vm: &mut VirtualMachine) -> PyResult<bool> {
+    fn ge(self, other: PyObjectRef, vm: &mut VirtualMachine) -> PyResult {
         if objtype::isinstance(&other, &vm.ctx.tuple_type()) {
             let zelf = self.elements.borrow();
             let other = get_elements(&other);
-            Ok(seq_ge(vm, &zelf, &other)?)
+            let res = seq_ge(vm, &zelf, &other)?;
+            Ok(vm.new_bool(res))
         } else {
-            Err(vm.new_type_error(format!("Cannot compare {} and {} using '>='", self, other)))
+            Ok(vm.ctx.not_implemented())
         }
     }
 
-    fn le(self, other: PyObjectRef, vm: &mut VirtualMachine) -> PyResult<bool> {
+    fn le(self, other: PyObjectRef, vm: &mut VirtualMachine) -> PyResult {
         if objtype::isinstance(&other, &vm.ctx.tuple_type()) {
             let zelf = self.elements.borrow();
             let other = get_elements(&other);
-            Ok(seq_le(vm, &zelf, &other)?)
+            let res = seq_le(vm, &zelf, &other)?;
+            Ok(vm.new_bool(res))
         } else {
-            Err(vm.new_type_error(format!("Cannot compare {} and {} using '<='", self, other)))
+            Ok(vm.ctx.not_implemented())
         }
     }
 
@@ -93,7 +97,7 @@ impl PyTupleRef {
             let elements = e1.iter().chain(e2.iter()).cloned().collect();
             Ok(vm.ctx.new_tuple(elements))
         } else {
-            Err(vm.new_type_error(format!("Cannot add {} and {}", self, other)))
+            Ok(vm.ctx.not_implemented())
         }
     }
 
@@ -112,13 +116,14 @@ impl PyTupleRef {
         Ok(count)
     }
 
-    fn eq(self, other: PyObjectRef, vm: &mut VirtualMachine) -> PyResult<bool> {
+    fn eq(self, other: PyObjectRef, vm: &mut VirtualMachine) -> PyResult {
         if objtype::isinstance(&other, &vm.ctx.tuple_type()) {
             let zelf = &self.elements.borrow();
             let other = get_elements(&other);
-            seq_equal(vm, &zelf, &other)
+            let res = seq_equal(vm, &zelf, &other)?;
+            Ok(vm.new_bool(res))
         } else {
-            Ok(false)
+            Ok(vm.ctx.not_implemented())
         }
     }
 

--- a/vm/src/obj/objtype.rs
+++ b/vm/src/obj/objtype.rs
@@ -1,5 +1,6 @@
 use std::cell::RefCell;
 use std::collections::HashMap;
+use std::fmt;
 
 use crate::function::PyFuncArgs;
 use crate::pyobject::{
@@ -18,6 +19,12 @@ use super::objtuple::PyTuple;
 pub struct PyClass {
     pub name: String,
     pub mro: Vec<PyClassRef>,
+}
+
+impl fmt::Display for PyClass {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        fmt::Display::fmt(&self.name, f)
+    }
 }
 
 pub type PyClassRef = PyRef<PyClass>;

--- a/vm/src/pyobject.rs
+++ b/vm/src/pyobject.rs
@@ -768,9 +768,13 @@ impl<T> IntoPyObject for PyRef<T> {
     }
 }
 
-impl<T> fmt::Display for PyRef<T> {
+impl<T: fmt::Display> fmt::Display for PyRef<T>
+where
+    T: PyValue + fmt::Display,
+{
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        self.obj.fmt(f)
+        let value: &T = self.obj.payload().expect("unexpected payload for type");
+        fmt::Display::fmt(value, f)
     }
 }
 


### PR DESCRIPTION
Previously used the target's `Debug` impl which leads to surprising results.

(Also, to avoid implementing `Display` for `PyTuple` and `PyList`, I corrected the comparison methods on these to return `NotImplemented` instead of formatting and raising their own errors.)