### PR TITLE
Convert all &mut VirtualMachine to &VirtualMachine

### DIFF
--- a/derive/src/lib.rs
+++ b/derive/src/lib.rs
@@ -38,7 +38,7 @@ fn impl_from_args(input: &DeriveInput) -> TokenStream2 {
     quote! {
         impl crate::function::FromArgs for #name {
             fn from_args(
-                vm: &mut crate::vm::VirtualMachine,
+                vm: &crate::vm::VirtualMachine,
                 args: &mut crate::function::PyFuncArgs
             ) -> Result<Self, crate::function::ArgumentError> {
                 Ok(#name { #(#fields)* })

--- a/src/main.rs
+++ b/src/main.rs
@@ -51,26 +51,26 @@ fn main() {
         .get_matches();
 
     // Construct vm:
-    let mut vm = VirtualMachine::new();
+    let vm = VirtualMachine::new();
 
     // Figure out if a -c option was given:
     let result = if let Some(command) = matches.value_of("c") {
-        run_command(&mut vm, command.to_string())
+        run_command(&vm, command.to_string())
     } else if let Some(module) = matches.value_of("m") {
-        run_module(&mut vm, module)
+        run_module(&vm, module)
     } else {
         // Figure out if a script was passed:
         match matches.value_of("script") {
-            None => run_shell(&mut vm),
-            Some(filename) => run_script(&mut vm, filename),
+            None => run_shell(&vm),
+            Some(filename) => run_script(&vm, filename),
         }
     };
 
     // See if any exception leaked out:
-    handle_exception(&mut vm, result);
+    handle_exception(&vm, result);
 }
 
-fn _run_string(vm: &mut VirtualMachine, source: &str, source_path: String) -> PyResult {
+fn _run_string(vm: &VirtualMachine, source: &str, source_path: String) -> PyResult {
     let code_obj = compile::compile(
         source,
         &compile::Mode::Exec,
@@ -86,14 +86,14 @@ fn _run_string(vm: &mut VirtualMachine, source: &str, source_path: String) -> Py
     vm.run_code_obj(code_obj, vars)
 }
 
-fn handle_exception(vm: &mut VirtualMachine, result: PyResult) {
+fn handle_exception(vm: &VirtualMachine, result: PyResult) {
     if let Err(err) = result {
         print_exception(vm, &err);
         std::process::exit(1);
     }
 }
 
-fn run_command(vm: &mut VirtualMachine, mut source: String) -> PyResult {
+fn run_command(vm: &VirtualMachine, mut source: String) -> PyResult {
     debug!("Running command {}", source);
 
     // This works around https://github.com/RustPython/RustPython/issues/17
@@ -101,13 +101,13 @@ fn run_command(vm: &mut VirtualMachine, mut source: String) -> PyResult {
     _run_string(vm, &source, "<stdin>".to_string())
 }
 
-fn run_module(vm: &mut VirtualMachine, module: &str) -> PyResult {
+fn run_module(vm: &VirtualMachine, module: &str) -> PyResult {
     debug!("Running module {}", module);
     let current_path = PathBuf::from(".");
     import::import_module(vm, current_path, module)
 }
 
-fn run_script(vm: &mut VirtualMachine, script_file: &str) -> PyResult {
+fn run_script(vm: &VirtualMachine, script_file: &str) -> PyResult {
     debug!("Running file {}", script_file);
     // Parse an ast from it:
     let file_path = Path::new(script_file);
@@ -120,7 +120,7 @@ fn run_script(vm: &mut VirtualMachine, script_file: &str) -> PyResult {
     }
 }
 
-fn shell_exec(vm: &mut VirtualMachine, source: &str, scope: Scope) -> Result<(), CompileError> {
+fn shell_exec(vm: &VirtualMachine, source: &str, scope: Scope) -> Result<(), CompileError> {
     match compile::compile(
         source,
         &compile::Mode::Single,
@@ -159,7 +159,7 @@ fn get_history_path() -> PathBuf {
     xdg_dirs.place_cache_file("repl_history.txt").unwrap()
 }
 
-fn run_shell(vm: &mut VirtualMachine) -> PyResult {
+fn run_shell(vm: &VirtualMachine) -> PyResult {
     println!(
         "Welcome to the magnificent Rust Python {} interpreter",
         crate_version!()

--- a/vm/src/dictdatatype.rs
+++ b/vm/src/dictdatatype.rs
@@ -33,7 +33,7 @@ impl Dict {
     /// Store a key
     pub fn insert(
         &mut self,
-        vm: &mut VirtualMachine,
+        vm: &VirtualMachine,
         key: &PyObjectRef,
         value: PyObjectRef,
     ) -> PyResult<()> {
@@ -66,7 +66,7 @@ impl Dict {
         }
     }
 
-    pub fn contains(&self, vm: &mut VirtualMachine, key: &PyObjectRef) -> PyResult<bool> {
+    pub fn contains(&self, vm: &VirtualMachine, key: &PyObjectRef) -> PyResult<bool> {
         if let LookupResult::Existing(_index) = self.lookup(vm, key)? {
             Ok(true)
         } else {
@@ -75,7 +75,7 @@ impl Dict {
     }
 
     /// Retrieve a key
-    pub fn get(&self, vm: &mut VirtualMachine, key: &PyObjectRef) -> PyResult {
+    pub fn get(&self, vm: &VirtualMachine, key: &PyObjectRef) -> PyResult {
         if let LookupResult::Existing(index) = self.lookup(vm, key)? {
             if let Some(entry) = &self.entries[index] {
                 Ok(entry.value.clone())
@@ -89,7 +89,7 @@ impl Dict {
     }
 
     /// Delete a key
-    pub fn delete(&mut self, vm: &mut VirtualMachine, key: &PyObjectRef) -> PyResult<()> {
+    pub fn delete(&mut self, vm: &VirtualMachine, key: &PyObjectRef) -> PyResult<()> {
         if let LookupResult::Existing(index) = self.lookup(vm, key)? {
             self.entries[index] = None;
             self.size -= 1;
@@ -118,7 +118,7 @@ impl Dict {
     }
 
     /// Lookup the index for the given key.
-    fn lookup(&self, vm: &mut VirtualMachine, key: &PyObjectRef) -> PyResult<LookupResult> {
+    fn lookup(&self, vm: &VirtualMachine, key: &PyObjectRef) -> PyResult<LookupResult> {
         let hash_value = calc_hash(vm, key)?;
         let perturb = hash_value;
         let mut hash_index: usize = hash_value;
@@ -169,14 +169,14 @@ enum LookupResult {
     Existing(usize), // Existing record, index into entries
 }
 
-fn calc_hash(vm: &mut VirtualMachine, key: &PyObjectRef) -> PyResult<usize> {
+fn calc_hash(vm: &VirtualMachine, key: &PyObjectRef) -> PyResult<usize> {
     let hash = vm.call_method(key, "__hash__", vec![])?;
     Ok(objint::get_value(&hash).to_usize().unwrap())
 }
 
 /// Invoke __eq__ on two keys
 fn do_eq(
-    vm: &mut VirtualMachine,
+    vm: &VirtualMachine,
     key1: &PyObjectRef,
     key2: &PyObjectRef,
 ) -> Result<bool, PyObjectRef> {

--- a/vm/src/eval.rs
+++ b/vm/src/eval.rs
@@ -7,7 +7,7 @@ use crate::frame::Scope;
 use crate::pyobject::PyResult;
 use crate::vm::VirtualMachine;
 
-pub fn eval(vm: &mut VirtualMachine, source: &str, scope: Scope, source_path: &str) -> PyResult {
+pub fn eval(vm: &VirtualMachine, source: &str, scope: Scope, source_path: &str) -> PyResult {
     match compile::compile(
         source,
         &compile::Mode::Eval,

--- a/vm/src/exceptions.rs
+++ b/vm/src/exceptions.rs
@@ -4,7 +4,7 @@ use crate::obj::objtype;
 use crate::pyobject::{create_type, PyContext, PyObjectRef, PyResult, TypeProtocol};
 use crate::vm::VirtualMachine;
 
-fn exception_init(vm: &mut VirtualMachine, args: PyFuncArgs) -> PyResult {
+fn exception_init(vm: &VirtualMachine, args: PyFuncArgs) -> PyResult {
     let zelf = args.args[0].clone();
     let msg = if args.args.len() > 1 {
         args.args[1].clone()
@@ -18,7 +18,7 @@ fn exception_init(vm: &mut VirtualMachine, args: PyFuncArgs) -> PyResult {
 }
 
 // Print exception including traceback:
-pub fn print_exception(vm: &mut VirtualMachine, exc: &PyObjectRef) {
+pub fn print_exception(vm: &VirtualMachine, exc: &PyObjectRef) {
     if let Ok(tb) = vm.get_attribute(exc.clone(), "__traceback__") {
         println!("Traceback (most recent call last):");
         if objtype::isinstance(&tb, &vm.ctx.list_type()) {
@@ -61,7 +61,7 @@ pub fn print_exception(vm: &mut VirtualMachine, exc: &PyObjectRef) {
     }
 }
 
-fn exception_str(vm: &mut VirtualMachine, args: PyFuncArgs) -> PyResult {
+fn exception_str(vm: &VirtualMachine, args: PyFuncArgs) -> PyResult {
     arg_check!(
         vm,
         args,

--- a/vm/src/frame.rs
+++ b/vm/src/frame.rs
@@ -185,7 +185,7 @@ pub struct Frame {
 }
 
 impl PyValue for Frame {
-    fn class(vm: &mut VirtualMachine) -> PyObjectRef {
+    fn class(vm: &VirtualMachine) -> PyObjectRef {
         vm.ctx.frame_type()
     }
 }
@@ -223,7 +223,7 @@ impl Frame {
         }
     }
 
-    pub fn run(&self, vm: &mut VirtualMachine) -> Result<ExecutionResult, PyObjectRef> {
+    pub fn run(&self, vm: &VirtualMachine) -> Result<ExecutionResult, PyObjectRef> {
         let filename = &self.code.source_path.to_string();
 
         // This is the name of the object being run:
@@ -276,7 +276,7 @@ impl Frame {
     }
 
     // Execute a single instruction:
-    fn execute_instruction(&self, vm: &mut VirtualMachine) -> FrameResult {
+    fn execute_instruction(&self, vm: &VirtualMachine) -> FrameResult {
         let instruction = self.fetch_instruction();
         {
             trace!("=======");
@@ -780,7 +780,7 @@ impl Frame {
 
     fn get_elements(
         &self,
-        vm: &mut VirtualMachine,
+        vm: &VirtualMachine,
         size: usize,
         unpack: bool,
     ) -> Result<Vec<PyObjectRef>, PyObjectRef> {
@@ -799,12 +799,7 @@ impl Frame {
         }
     }
 
-    fn import(
-        &self,
-        vm: &mut VirtualMachine,
-        module: &str,
-        symbol: &Option<String>,
-    ) -> FrameResult {
+    fn import(&self, vm: &VirtualMachine, module: &str, symbol: &Option<String>) -> FrameResult {
         let module = vm.import(module)?;
 
         // If we're importing a symbol, look it up and use it, otherwise construct a module and return
@@ -825,7 +820,7 @@ impl Frame {
         Ok(None)
     }
 
-    fn import_star(&self, vm: &mut VirtualMachine, module: &str) -> FrameResult {
+    fn import_star(&self, vm: &VirtualMachine, module: &str) -> FrameResult {
         let module = vm.import(module)?;
 
         // Grab all the names from the module and put them in the context
@@ -836,7 +831,7 @@ impl Frame {
     }
 
     // Unwind all blocks:
-    fn unwind_blocks(&self, vm: &mut VirtualMachine) -> Option<PyObjectRef> {
+    fn unwind_blocks(&self, vm: &VirtualMachine) -> Option<PyObjectRef> {
         while let Some(block) = self.pop_block() {
             match block.typ {
                 BlockType::Loop { .. } => {}
@@ -860,7 +855,7 @@ impl Frame {
         None
     }
 
-    fn unwind_loop(&self, vm: &mut VirtualMachine) -> Block {
+    fn unwind_loop(&self, vm: &VirtualMachine) -> Block {
         loop {
             let block = self.current_block().expect("not in a loop");
             match block.typ {
@@ -882,7 +877,7 @@ impl Frame {
         }
     }
 
-    fn unwind_exception(&self, vm: &mut VirtualMachine, exc: PyObjectRef) -> Option<PyObjectRef> {
+    fn unwind_exception(&self, vm: &VirtualMachine, exc: PyObjectRef) -> Option<PyObjectRef> {
         // unwind block stack on exception and find any handlers:
         while let Some(block) = self.pop_block() {
             match block.typ {
@@ -927,7 +922,7 @@ impl Frame {
 
     fn with_exit(
         &self,
-        vm: &mut VirtualMachine,
+        vm: &VirtualMachine,
         context_manager: &PyObjectRef,
         exc: Option<PyObjectRef>,
     ) -> PyResult {
@@ -950,18 +945,18 @@ impl Frame {
         vm.call_method(context_manager, "__exit__", args)
     }
 
-    fn store_name(&self, vm: &mut VirtualMachine, name: &str) -> FrameResult {
+    fn store_name(&self, vm: &VirtualMachine, name: &str) -> FrameResult {
         let obj = self.pop_value();
         self.scope.store_name(&vm, name, obj);
         Ok(None)
     }
 
-    fn delete_name(&self, vm: &mut VirtualMachine, name: &str) -> FrameResult {
+    fn delete_name(&self, vm: &VirtualMachine, name: &str) -> FrameResult {
         self.scope.delete_name(vm, name);
         Ok(None)
     }
 
-    fn load_name(&self, vm: &mut VirtualMachine, name: &str) -> FrameResult {
+    fn load_name(&self, vm: &VirtualMachine, name: &str) -> FrameResult {
         match self.scope.load_name(&vm, name) {
             Some(value) => {
                 self.push_value(value);
@@ -976,11 +971,11 @@ impl Frame {
         }
     }
 
-    fn subscript(&self, vm: &mut VirtualMachine, a: PyObjectRef, b: PyObjectRef) -> PyResult {
+    fn subscript(&self, vm: &VirtualMachine, a: PyObjectRef, b: PyObjectRef) -> PyResult {
         vm.call_method(&a, "__getitem__", vec![b])
     }
 
-    fn execute_store_subscript(&self, vm: &mut VirtualMachine) -> FrameResult {
+    fn execute_store_subscript(&self, vm: &VirtualMachine) -> FrameResult {
         let idx = self.pop_value();
         let obj = self.pop_value();
         let value = self.pop_value();
@@ -988,7 +983,7 @@ impl Frame {
         Ok(None)
     }
 
-    fn execute_delete_subscript(&self, vm: &mut VirtualMachine) -> FrameResult {
+    fn execute_delete_subscript(&self, vm: &VirtualMachine) -> FrameResult {
         let idx = self.pop_value();
         let obj = self.pop_value();
         vm.call_method(&obj, "__delitem__", vec![idx])?;
@@ -1003,7 +998,7 @@ impl Frame {
 
     fn execute_binop(
         &self,
-        vm: &mut VirtualMachine,
+        vm: &VirtualMachine,
         op: &bytecode::BinaryOperator,
         inplace: bool,
     ) -> FrameResult {
@@ -1045,7 +1040,7 @@ impl Frame {
         Ok(None)
     }
 
-    fn execute_unop(&self, vm: &mut VirtualMachine, op: &bytecode::UnaryOperator) -> FrameResult {
+    fn execute_unop(&self, vm: &VirtualMachine, op: &bytecode::UnaryOperator) -> FrameResult {
         let a = self.pop_value();
         let value = match *op {
             bytecode::UnaryOperator::Minus => vm.call_method(&a, "__neg__", vec![])?,
@@ -1067,7 +1062,7 @@ impl Frame {
     // https://docs.python.org/3/reference/expressions.html#membership-test-operations
     fn _membership(
         &self,
-        vm: &mut VirtualMachine,
+        vm: &VirtualMachine,
         needle: PyObjectRef,
         haystack: &PyObjectRef,
     ) -> PyResult {
@@ -1076,7 +1071,7 @@ impl Frame {
         // not implemented.
     }
 
-    fn _in(&self, vm: &mut VirtualMachine, needle: PyObjectRef, haystack: PyObjectRef) -> PyResult {
+    fn _in(&self, vm: &VirtualMachine, needle: PyObjectRef, haystack: PyObjectRef) -> PyResult {
         match self._membership(vm, needle, &haystack) {
             Ok(found) => Ok(found),
             Err(_) => Err(vm.new_type_error(format!(
@@ -1086,12 +1081,7 @@ impl Frame {
         }
     }
 
-    fn _not_in(
-        &self,
-        vm: &mut VirtualMachine,
-        needle: PyObjectRef,
-        haystack: PyObjectRef,
-    ) -> PyResult {
+    fn _not_in(&self, vm: &VirtualMachine, needle: PyObjectRef, haystack: PyObjectRef) -> PyResult {
         match self._membership(vm, needle, &haystack) {
             Ok(found) => Ok(vm.ctx.new_bool(!objbool::get_value(&found))),
             Err(_) => Err(vm.new_type_error(format!(
@@ -1114,7 +1104,7 @@ impl Frame {
 
     fn execute_compare(
         &self,
-        vm: &mut VirtualMachine,
+        vm: &VirtualMachine,
         op: &bytecode::ComparisonOperator,
     ) -> FrameResult {
         let b = self.pop_value();
@@ -1136,21 +1126,21 @@ impl Frame {
         Ok(None)
     }
 
-    fn load_attr(&self, vm: &mut VirtualMachine, attr_name: &str) -> FrameResult {
+    fn load_attr(&self, vm: &VirtualMachine, attr_name: &str) -> FrameResult {
         let parent = self.pop_value();
         let obj = vm.get_attribute(parent, attr_name)?;
         self.push_value(obj);
         Ok(None)
     }
 
-    fn store_attr(&self, vm: &mut VirtualMachine, attr_name: &str) -> FrameResult {
+    fn store_attr(&self, vm: &VirtualMachine, attr_name: &str) -> FrameResult {
         let parent = self.pop_value();
         let value = self.pop_value();
         vm.set_attr(&parent, vm.new_str(attr_name.to_string()), value)?;
         Ok(None)
     }
 
-    fn delete_attr(&self, vm: &mut VirtualMachine, attr_name: &str) -> FrameResult {
+    fn delete_attr(&self, vm: &VirtualMachine, attr_name: &str) -> FrameResult {
         let parent = self.pop_value();
         let name = vm.ctx.new_str(attr_name.to_string());
         vm.del_attr(&parent, name)?;

--- a/vm/src/import.rs
+++ b/vm/src/import.rs
@@ -56,7 +56,7 @@ pub fn import_module(vm: &VirtualMachine, current_path: PathBuf, module_name: &s
 }
 
 fn find_source(
-    vm: &mut VirtualMachine,
+    vm: &VirtualMachine,
     current_path: PathBuf,
     name: &str,
 ) -> Result<PathBuf, String> {

--- a/vm/src/import.rs
+++ b/vm/src/import.rs
@@ -12,13 +12,9 @@ use crate::pyobject::{AttributeProtocol, DictProtocol, PyResult};
 use crate::util;
 use crate::vm::VirtualMachine;
 
-fn import_uncached_module(
-    vm: &mut VirtualMachine,
-    current_path: PathBuf,
-    module: &str,
-) -> PyResult {
+fn import_uncached_module(vm: &VirtualMachine, current_path: PathBuf, module: &str) -> PyResult {
     // Check for Rust-native modules
-    if let Some(module) = vm.stdlib_inits.get(module) {
+    if let Some(module) = vm.stdlib_inits.borrow().get(module) {
         return Ok(module(&vm.ctx).clone());
     }
 
@@ -48,11 +44,7 @@ fn import_uncached_module(
     Ok(vm.ctx.new_module(module, attrs))
 }
 
-pub fn import_module(
-    vm: &mut VirtualMachine,
-    current_path: PathBuf,
-    module_name: &str,
-) -> PyResult {
+pub fn import_module(vm: &VirtualMachine, current_path: PathBuf, module_name: &str) -> PyResult {
     // First, see if we already loaded the module:
     let sys_modules = vm.sys_module.get_attr("modules").unwrap();
     if let Some(module) = sys_modules.get_item(module_name) {

--- a/vm/src/obj/objbool.rs
+++ b/vm/src/obj/objbool.rs
@@ -15,18 +15,18 @@ use super::objtuple::PyTuple;
 use super::objtype;
 
 impl IntoPyObject for bool {
-    fn into_pyobject(self, vm: &mut VirtualMachine) -> PyResult {
+    fn into_pyobject(self, vm: &VirtualMachine) -> PyResult {
         Ok(vm.ctx.new_bool(self))
     }
 }
 
 impl TryFromObject for bool {
-    fn try_from_object(vm: &mut VirtualMachine, obj: PyObjectRef) -> PyResult<bool> {
+    fn try_from_object(vm: &VirtualMachine, obj: PyObjectRef) -> PyResult<bool> {
         boolval(vm, obj)
     }
 }
 
-pub fn boolval(vm: &mut VirtualMachine, obj: PyObjectRef) -> PyResult<bool> {
+pub fn boolval(vm: &VirtualMachine, obj: PyObjectRef) -> PyResult<bool> {
     if let Some(s) = obj.payload::<PyString>() {
         return Ok(!s.value.is_empty());
     }
@@ -70,7 +70,7 @@ The class bool is a subclass of the class int, and cannot be subclassed.";
     context.set_attr(&bool_type, "__doc__", context.new_str(bool_doc.to_string()));
 }
 
-pub fn not(vm: &mut VirtualMachine, obj: &PyObjectRef) -> PyResult {
+pub fn not(vm: &VirtualMachine, obj: &PyObjectRef) -> PyResult {
     if objtype::isinstance(obj, &vm.ctx.bool_type()) {
         let value = get_value(obj);
         Ok(vm.ctx.new_bool(!value))
@@ -84,7 +84,7 @@ pub fn get_value(obj: &PyObjectRef) -> bool {
     !obj.payload::<PyInt>().unwrap().value.is_zero()
 }
 
-fn bool_repr(vm: &mut VirtualMachine, args: PyFuncArgs) -> Result<PyObjectRef, PyObjectRef> {
+fn bool_repr(vm: &VirtualMachine, args: PyFuncArgs) -> Result<PyObjectRef, PyObjectRef> {
     arg_check!(vm, args, required = [(obj, Some(vm.ctx.bool_type()))]);
     let v = get_value(obj);
     let s = if v {
@@ -95,7 +95,7 @@ fn bool_repr(vm: &mut VirtualMachine, args: PyFuncArgs) -> Result<PyObjectRef, P
     Ok(vm.new_str(s))
 }
 
-fn bool_new(vm: &mut VirtualMachine, args: PyFuncArgs) -> PyResult {
+fn bool_new(vm: &VirtualMachine, args: PyFuncArgs) -> PyResult {
     arg_check!(
         vm,
         args,

--- a/vm/src/obj/objbuiltinfunc.rs
+++ b/vm/src/obj/objbuiltinfunc.rs
@@ -10,7 +10,7 @@ pub struct PyBuiltinFunction {
 }
 
 impl PyValue for PyBuiltinFunction {
-    fn class(vm: &mut VirtualMachine) -> PyObjectRef {
+    fn class(vm: &VirtualMachine) -> PyObjectRef {
         vm.ctx.builtin_function_or_method_type()
     }
 }

--- a/vm/src/obj/objbytearray.rs
+++ b/vm/src/obj/objbytearray.rs
@@ -29,7 +29,7 @@ impl PyByteArray {
 }
 
 impl PyValue for PyByteArray {
-    fn class(vm: &mut VirtualMachine) -> PyObjectRef {
+    fn class(vm: &VirtualMachine) -> PyObjectRef {
         vm.ctx.bytearray_type()
     }
 }
@@ -147,7 +147,7 @@ pub fn init(context: &PyContext) {
 fn bytearray_new(
     cls: PyClassRef,
     val_option: OptionalArg<PyObjectRef>,
-    vm: &mut VirtualMachine,
+    vm: &VirtualMachine,
 ) -> PyResult<PyByteArrayRef> {
     // Create bytes data:
     let value = if let OptionalArg::Present(ival) = val_option {
@@ -169,14 +169,14 @@ fn bytearray_new(
     PyByteArray::new(value).into_ref_with_type(vm, cls.clone())
 }
 
-fn bytesarray_len(vm: &mut VirtualMachine, args: PyFuncArgs) -> PyResult {
+fn bytesarray_len(vm: &VirtualMachine, args: PyFuncArgs) -> PyResult {
     arg_check!(vm, args, required = [(a, Some(vm.ctx.bytearray_type()))]);
 
     let byte_vec = get_value(a).to_vec();
     Ok(vm.ctx.new_int(byte_vec.len()))
 }
 
-fn bytearray_eq(vm: &mut VirtualMachine, args: PyFuncArgs) -> PyResult {
+fn bytearray_eq(vm: &VirtualMachine, args: PyFuncArgs) -> PyResult {
     arg_check!(
         vm,
         args,
@@ -191,31 +191,31 @@ fn bytearray_eq(vm: &mut VirtualMachine, args: PyFuncArgs) -> PyResult {
     Ok(vm.ctx.new_bool(result))
 }
 
-fn bytearray_isalnum(vm: &mut VirtualMachine, args: PyFuncArgs) -> PyResult {
+fn bytearray_isalnum(vm: &VirtualMachine, args: PyFuncArgs) -> PyResult {
     arg_check!(vm, args, required = [(zelf, Some(vm.ctx.bytearray_type()))]);
     let bytes = get_value(zelf);
     Ok(vm.new_bool(!bytes.is_empty() && bytes.iter().all(|x| char::from(*x).is_alphanumeric())))
 }
 
-fn bytearray_isalpha(vm: &mut VirtualMachine, args: PyFuncArgs) -> PyResult {
+fn bytearray_isalpha(vm: &VirtualMachine, args: PyFuncArgs) -> PyResult {
     arg_check!(vm, args, required = [(zelf, Some(vm.ctx.bytearray_type()))]);
     let bytes = get_value(zelf);
     Ok(vm.new_bool(!bytes.is_empty() && bytes.iter().all(|x| char::from(*x).is_alphabetic())))
 }
 
-fn bytearray_isascii(vm: &mut VirtualMachine, args: PyFuncArgs) -> PyResult {
+fn bytearray_isascii(vm: &VirtualMachine, args: PyFuncArgs) -> PyResult {
     arg_check!(vm, args, required = [(zelf, Some(vm.ctx.bytearray_type()))]);
     let bytes = get_value(zelf);
     Ok(vm.new_bool(!bytes.is_empty() && bytes.iter().all(|x| char::from(*x).is_ascii())))
 }
 
-fn bytearray_isdigit(vm: &mut VirtualMachine, args: PyFuncArgs) -> PyResult {
+fn bytearray_isdigit(vm: &VirtualMachine, args: PyFuncArgs) -> PyResult {
     arg_check!(vm, args, required = [(zelf, Some(vm.ctx.bytearray_type()))]);
     let bytes = get_value(zelf);
     Ok(vm.new_bool(!bytes.is_empty() && bytes.iter().all(|x| char::from(*x).is_digit(10))))
 }
 
-fn bytearray_islower(vm: &mut VirtualMachine, args: PyFuncArgs) -> PyResult {
+fn bytearray_islower(vm: &VirtualMachine, args: PyFuncArgs) -> PyResult {
     arg_check!(vm, args, required = [(zelf, Some(vm.ctx.bytearray_type()))]);
     let bytes = get_value(zelf);
     Ok(vm.new_bool(
@@ -227,13 +227,13 @@ fn bytearray_islower(vm: &mut VirtualMachine, args: PyFuncArgs) -> PyResult {
     ))
 }
 
-fn bytearray_isspace(vm: &mut VirtualMachine, args: PyFuncArgs) -> PyResult {
+fn bytearray_isspace(vm: &VirtualMachine, args: PyFuncArgs) -> PyResult {
     arg_check!(vm, args, required = [(zelf, Some(vm.ctx.bytearray_type()))]);
     let bytes = get_value(zelf);
     Ok(vm.new_bool(!bytes.is_empty() && bytes.iter().all(|x| char::from(*x).is_whitespace())))
 }
 
-fn bytearray_isupper(vm: &mut VirtualMachine, args: PyFuncArgs) -> PyResult {
+fn bytearray_isupper(vm: &VirtualMachine, args: PyFuncArgs) -> PyResult {
     arg_check!(vm, args, required = [(zelf, Some(vm.ctx.bytearray_type()))]);
     let bytes = get_value(zelf);
     Ok(vm.new_bool(
@@ -245,7 +245,7 @@ fn bytearray_isupper(vm: &mut VirtualMachine, args: PyFuncArgs) -> PyResult {
     ))
 }
 
-fn bytearray_istitle(vm: &mut VirtualMachine, args: PyFuncArgs) -> PyResult {
+fn bytearray_istitle(vm: &VirtualMachine, args: PyFuncArgs) -> PyResult {
     arg_check!(vm, args, required = [(zelf, Some(vm.ctx.bytearray_type()))]);
     let bytes = get_value(zelf);
 
@@ -284,7 +284,7 @@ fn is_cased(c: char) -> bool {
 }
 
 /*
-fn bytearray_getitem(vm: &mut VirtualMachine, args: PyFuncArgs) -> PyResult {
+fn bytearray_getitem(vm: &VirtualMachine, args: PyFuncArgs) -> PyResult {
     arg_check!(
         vm,
         args,
@@ -308,7 +308,7 @@ fn bytearray_to_hex(bytearray: &[u8]) -> String {
     })
 }
 
-fn bytearray_repr(vm: &mut VirtualMachine, args: PyFuncArgs) -> PyResult {
+fn bytearray_repr(vm: &VirtualMachine, args: PyFuncArgs) -> PyResult {
     arg_check!(vm, args, required = [(obj, Some(vm.ctx.bytearray_type()))]);
     let value = get_value(obj);
     let data =
@@ -316,13 +316,13 @@ fn bytearray_repr(vm: &mut VirtualMachine, args: PyFuncArgs) -> PyResult {
     Ok(vm.new_str(format!("bytearray(b'{}')", data)))
 }
 
-fn bytearray_clear(vm: &mut VirtualMachine, args: PyFuncArgs) -> PyResult {
+fn bytearray_clear(vm: &VirtualMachine, args: PyFuncArgs) -> PyResult {
     arg_check!(vm, args, required = [(zelf, Some(vm.ctx.bytearray_type()))]);
     get_mut_value(zelf).clear();
     Ok(vm.get_none())
 }
 
-fn bytearray_pop(vm: &mut VirtualMachine, args: PyFuncArgs) -> PyResult {
+fn bytearray_pop(vm: &VirtualMachine, args: PyFuncArgs) -> PyResult {
     arg_check!(vm, args, required = [(obj, Some(vm.ctx.bytearray_type()))]);
     let mut value = get_mut_value(obj);
 
@@ -333,13 +333,13 @@ fn bytearray_pop(vm: &mut VirtualMachine, args: PyFuncArgs) -> PyResult {
     }
 }
 
-fn bytearray_lower(vm: &mut VirtualMachine, args: PyFuncArgs) -> PyResult {
+fn bytearray_lower(vm: &VirtualMachine, args: PyFuncArgs) -> PyResult {
     arg_check!(vm, args, required = [(obj, Some(vm.ctx.bytearray_type()))]);
     let value = get_value(obj).to_vec().to_ascii_lowercase();
     Ok(vm.ctx.new_bytearray(value))
 }
 
-fn bytearray_upper(vm: &mut VirtualMachine, args: PyFuncArgs) -> PyResult {
+fn bytearray_upper(vm: &VirtualMachine, args: PyFuncArgs) -> PyResult {
     arg_check!(vm, args, required = [(obj, Some(vm.ctx.bytearray_type()))]);
     let value = get_value(obj).to_vec().to_ascii_uppercase();
     Ok(vm.ctx.new_bytearray(value))

--- a/vm/src/obj/objbytes.rs
+++ b/vm/src/obj/objbytes.rs
@@ -34,7 +34,7 @@ impl Deref for PyBytes {
 }
 
 impl PyValue for PyBytes {
-    fn class(vm: &mut VirtualMachine) -> PyObjectRef {
+    fn class(vm: &VirtualMachine) -> PyObjectRef {
         vm.ctx.bytes_type()
     }
 }
@@ -76,7 +76,7 @@ pub fn init(context: &PyContext) {
 fn bytes_new(
     cls: PyClassRef,
     val_option: OptionalArg<PyObjectRef>,
-    vm: &mut VirtualMachine,
+    vm: &VirtualMachine,
 ) -> PyResult<PyBytesRef> {
     // Create bytes data:
     let value = if let OptionalArg::Present(ival) = val_option {
@@ -95,7 +95,7 @@ fn bytes_new(
     PyBytes::new(value).into_ref_with_type(vm, cls)
 }
 
-fn bytes_eq(vm: &mut VirtualMachine, args: PyFuncArgs) -> PyResult {
+fn bytes_eq(vm: &VirtualMachine, args: PyFuncArgs) -> PyResult {
     arg_check!(
         vm,
         args,
@@ -110,7 +110,7 @@ fn bytes_eq(vm: &mut VirtualMachine, args: PyFuncArgs) -> PyResult {
     Ok(vm.ctx.new_bool(result))
 }
 
-fn bytes_ge(vm: &mut VirtualMachine, args: PyFuncArgs) -> PyResult {
+fn bytes_ge(vm: &VirtualMachine, args: PyFuncArgs) -> PyResult {
     arg_check!(
         vm,
         args,
@@ -125,7 +125,7 @@ fn bytes_ge(vm: &mut VirtualMachine, args: PyFuncArgs) -> PyResult {
     Ok(vm.ctx.new_bool(result))
 }
 
-fn bytes_gt(vm: &mut VirtualMachine, args: PyFuncArgs) -> PyResult {
+fn bytes_gt(vm: &VirtualMachine, args: PyFuncArgs) -> PyResult {
     arg_check!(
         vm,
         args,
@@ -140,7 +140,7 @@ fn bytes_gt(vm: &mut VirtualMachine, args: PyFuncArgs) -> PyResult {
     Ok(vm.ctx.new_bool(result))
 }
 
-fn bytes_le(vm: &mut VirtualMachine, args: PyFuncArgs) -> PyResult {
+fn bytes_le(vm: &VirtualMachine, args: PyFuncArgs) -> PyResult {
     arg_check!(
         vm,
         args,
@@ -155,7 +155,7 @@ fn bytes_le(vm: &mut VirtualMachine, args: PyFuncArgs) -> PyResult {
     Ok(vm.ctx.new_bool(result))
 }
 
-fn bytes_lt(vm: &mut VirtualMachine, args: PyFuncArgs) -> PyResult {
+fn bytes_lt(vm: &VirtualMachine, args: PyFuncArgs) -> PyResult {
     arg_check!(
         vm,
         args,
@@ -170,14 +170,14 @@ fn bytes_lt(vm: &mut VirtualMachine, args: PyFuncArgs) -> PyResult {
     Ok(vm.ctx.new_bool(result))
 }
 
-fn bytes_len(vm: &mut VirtualMachine, args: PyFuncArgs) -> PyResult {
+fn bytes_len(vm: &VirtualMachine, args: PyFuncArgs) -> PyResult {
     arg_check!(vm, args, required = [(a, Some(vm.ctx.bytes_type()))]);
 
     let byte_vec = get_value(a).to_vec();
     Ok(vm.ctx.new_int(byte_vec.len()))
 }
 
-fn bytes_hash(vm: &mut VirtualMachine, args: PyFuncArgs) -> PyResult {
+fn bytes_hash(vm: &VirtualMachine, args: PyFuncArgs) -> PyResult {
     arg_check!(vm, args, required = [(zelf, Some(vm.ctx.bytes_type()))]);
     let data = get_value(zelf);
     let mut hasher = std::collections::hash_map::DefaultHasher::new();
@@ -190,14 +190,14 @@ pub fn get_value<'a>(obj: &'a PyObjectRef) -> impl Deref<Target = Vec<u8>> + 'a 
     &obj.payload::<PyBytes>().unwrap().value
 }
 
-fn bytes_repr(vm: &mut VirtualMachine, args: PyFuncArgs) -> PyResult {
+fn bytes_repr(vm: &VirtualMachine, args: PyFuncArgs) -> PyResult {
     arg_check!(vm, args, required = [(obj, Some(vm.ctx.bytes_type()))]);
     let value = get_value(obj);
     let data = String::from_utf8(value.to_vec()).unwrap();
     Ok(vm.new_str(format!("b'{}'", data)))
 }
 
-fn bytes_iter(obj: PyBytesRef, _vm: &mut VirtualMachine) -> PyIteratorValue {
+fn bytes_iter(obj: PyBytesRef, _vm: &VirtualMachine) -> PyIteratorValue {
     PyIteratorValue {
         position: Cell::new(0),
         iterated_obj: obj.into_object(),

--- a/vm/src/obj/objclassmethod.rs
+++ b/vm/src/obj/objclassmethod.rs
@@ -10,7 +10,7 @@ pub fn init(context: &PyContext) {
     });
 }
 
-fn classmethod_get(vm: &mut VirtualMachine, args: PyFuncArgs) -> PyResult {
+fn classmethod_get(vm: &VirtualMachine, args: PyFuncArgs) -> PyResult {
     trace!("classmethod.__get__ {:?}", args.args);
     arg_check!(
         vm,
@@ -33,7 +33,7 @@ fn classmethod_get(vm: &mut VirtualMachine, args: PyFuncArgs) -> PyResult {
     }
 }
 
-fn classmethod_new(vm: &mut VirtualMachine, args: PyFuncArgs) -> PyResult {
+fn classmethod_new(vm: &VirtualMachine, args: PyFuncArgs) -> PyResult {
     trace!("classmethod.__new__ {:?}", args.args);
     arg_check!(vm, args, required = [(cls, None), (callable, None)]);
 

--- a/vm/src/obj/objclassmethod.rs
+++ b/vm/src/obj/objclassmethod.rs
@@ -9,7 +9,7 @@ pub struct PyClassMethod {
 pub type PyClassMethodRef = PyRef<PyClassMethod>;
 
 impl PyValue for PyClassMethod {
-    fn class(vm: &mut VirtualMachine) -> PyObjectRef {
+    fn class(vm: &VirtualMachine) -> PyObjectRef {
         vm.ctx.classmethod_type()
     }
 }

--- a/vm/src/obj/objcode.rs
+++ b/vm/src/obj/objcode.rs
@@ -26,7 +26,7 @@ impl fmt::Debug for PyCode {
 }
 
 impl PyValue for PyCode {
-    fn class(vm: &mut VirtualMachine) -> PyObjectRef {
+    fn class(vm: &VirtualMachine) -> PyObjectRef {
         vm.ctx.code_type()
     }
 }
@@ -39,7 +39,7 @@ pub fn init(context: &PyContext) {
     for (name, f) in &[
         (
             "co_argcount",
-            code_co_argcount as fn(&mut VirtualMachine, PyFuncArgs) -> PyResult,
+            code_co_argcount as fn(&VirtualMachine, PyFuncArgs) -> PyResult,
         ),
         ("co_consts", code_co_consts),
         ("co_filename", code_co_filename),
@@ -59,12 +59,12 @@ pub fn get_value(obj: &PyObjectRef) -> bytecode::CodeObject {
     }
 }
 
-fn code_new(vm: &mut VirtualMachine, args: PyFuncArgs) -> PyResult {
+fn code_new(vm: &VirtualMachine, args: PyFuncArgs) -> PyResult {
     arg_check!(vm, args, required = [(_cls, None)]);
     Err(vm.new_type_error("Cannot directly create code object".to_string()))
 }
 
-fn code_repr(vm: &mut VirtualMachine, args: PyFuncArgs) -> PyResult {
+fn code_repr(vm: &VirtualMachine, args: PyFuncArgs) -> PyResult {
     arg_check!(vm, args, required = [(o, Some(vm.ctx.code_type()))]);
 
     let code = get_value(o);
@@ -78,33 +78,33 @@ fn code_repr(vm: &mut VirtualMachine, args: PyFuncArgs) -> PyResult {
     Ok(vm.new_str(repr))
 }
 
-fn member_code_obj(vm: &mut VirtualMachine, args: PyFuncArgs) -> PyResult<bytecode::CodeObject> {
+fn member_code_obj(vm: &VirtualMachine, args: PyFuncArgs) -> PyResult<bytecode::CodeObject> {
     arg_check!(vm, args, required = [(zelf, Some(vm.ctx.code_type()))]);
     Ok(get_value(zelf))
 }
 
-fn code_co_argcount(vm: &mut VirtualMachine, args: PyFuncArgs) -> PyResult {
+fn code_co_argcount(vm: &VirtualMachine, args: PyFuncArgs) -> PyResult {
     let code_obj = member_code_obj(vm, args)?;
     Ok(vm.ctx.new_int(code_obj.arg_names.len()))
 }
 
-fn code_co_filename(vm: &mut VirtualMachine, args: PyFuncArgs) -> PyResult {
+fn code_co_filename(vm: &VirtualMachine, args: PyFuncArgs) -> PyResult {
     let code_obj = member_code_obj(vm, args)?;
     let source_path = code_obj.source_path;
     Ok(vm.new_str(source_path))
 }
 
-fn code_co_firstlineno(vm: &mut VirtualMachine, args: PyFuncArgs) -> PyResult {
+fn code_co_firstlineno(vm: &VirtualMachine, args: PyFuncArgs) -> PyResult {
     let code_obj = member_code_obj(vm, args)?;
     Ok(vm.ctx.new_int(code_obj.first_line_number))
 }
 
-fn code_co_kwonlyargcount(vm: &mut VirtualMachine, args: PyFuncArgs) -> PyResult {
+fn code_co_kwonlyargcount(vm: &VirtualMachine, args: PyFuncArgs) -> PyResult {
     let code_obj = member_code_obj(vm, args)?;
     Ok(vm.ctx.new_int(code_obj.kwonlyarg_names.len()))
 }
 
-fn code_co_consts(vm: &mut VirtualMachine, args: PyFuncArgs) -> PyResult {
+fn code_co_consts(vm: &VirtualMachine, args: PyFuncArgs) -> PyResult {
     let code_obj = member_code_obj(vm, args)?;
     let consts = code_obj
         .get_constants()
@@ -113,7 +113,7 @@ fn code_co_consts(vm: &mut VirtualMachine, args: PyFuncArgs) -> PyResult {
     Ok(vm.ctx.new_tuple(consts))
 }
 
-fn code_co_name(vm: &mut VirtualMachine, args: PyFuncArgs) -> PyResult {
+fn code_co_name(vm: &VirtualMachine, args: PyFuncArgs) -> PyResult {
     let code_obj = member_code_obj(vm, args)?;
     Ok(vm.new_str(code_obj.obj_name))
 }

--- a/vm/src/obj/objcomplex.rs
+++ b/vm/src/obj/objcomplex.rs
@@ -16,7 +16,7 @@ pub struct PyComplex {
 type PyComplexRef = PyRef<PyComplex>;
 
 impl PyValue for PyComplex {
-    fn class(vm: &mut VirtualMachine) -> PyObjectRef {
+    fn class(vm: &VirtualMachine) -> PyObjectRef {
         vm.ctx.complex_type()
     }
 }
@@ -71,7 +71,7 @@ fn complex_new(
     cls: PyClassRef,
     real: OptionalArg<PyObjectRef>,
     imag: OptionalArg<PyObjectRef>,
-    vm: &mut VirtualMachine,
+    vm: &VirtualMachine,
 ) -> PyResult<PyComplexRef> {
     let real = match real {
         OptionalArg::Missing => 0.0,
@@ -87,26 +87,26 @@ fn complex_new(
     PyComplex { value }.into_ref_with_type(vm, cls)
 }
 
-fn complex_real(vm: &mut VirtualMachine, args: PyFuncArgs) -> PyResult {
+fn complex_real(vm: &VirtualMachine, args: PyFuncArgs) -> PyResult {
     arg_check!(vm, args, required = [(zelf, Some(vm.ctx.complex_type()))]);
     let Complex64 { re, .. } = get_value(zelf);
     Ok(vm.ctx.new_float(re))
 }
 
-fn complex_imag(vm: &mut VirtualMachine, args: PyFuncArgs) -> PyResult {
+fn complex_imag(vm: &VirtualMachine, args: PyFuncArgs) -> PyResult {
     arg_check!(vm, args, required = [(zelf, Some(vm.ctx.complex_type()))]);
     let Complex64 { im, .. } = get_value(zelf);
     Ok(vm.ctx.new_float(im))
 }
 
-fn complex_abs(vm: &mut VirtualMachine, args: PyFuncArgs) -> PyResult {
+fn complex_abs(vm: &VirtualMachine, args: PyFuncArgs) -> PyResult {
     arg_check!(vm, args, required = [(zelf, Some(vm.ctx.complex_type()))]);
 
     let Complex64 { re, im } = get_value(zelf);
     Ok(vm.ctx.new_float(re.hypot(im)))
 }
 
-fn complex_add(vm: &mut VirtualMachine, args: PyFuncArgs) -> PyResult {
+fn complex_add(vm: &VirtualMachine, args: PyFuncArgs) -> PyResult {
     arg_check!(
         vm,
         args,
@@ -126,7 +126,7 @@ fn complex_add(vm: &mut VirtualMachine, args: PyFuncArgs) -> PyResult {
     }
 }
 
-fn complex_radd(vm: &mut VirtualMachine, args: PyFuncArgs) -> PyResult {
+fn complex_radd(vm: &VirtualMachine, args: PyFuncArgs) -> PyResult {
     arg_check!(
         vm,
         args,
@@ -145,14 +145,14 @@ fn complex_radd(vm: &mut VirtualMachine, args: PyFuncArgs) -> PyResult {
     }
 }
 
-fn complex_conjugate(vm: &mut VirtualMachine, args: PyFuncArgs) -> PyResult {
+fn complex_conjugate(vm: &VirtualMachine, args: PyFuncArgs) -> PyResult {
     arg_check!(vm, args, required = [(i, Some(vm.ctx.complex_type()))]);
 
     let v1 = get_value(i);
     Ok(vm.ctx.new_complex(v1.conj()))
 }
 
-fn complex_eq(vm: &mut VirtualMachine, args: PyFuncArgs) -> PyResult {
+fn complex_eq(vm: &VirtualMachine, args: PyFuncArgs) -> PyResult {
     arg_check!(
         vm,
         args,
@@ -177,12 +177,12 @@ fn complex_eq(vm: &mut VirtualMachine, args: PyFuncArgs) -> PyResult {
     Ok(vm.ctx.new_bool(result))
 }
 
-fn complex_neg(vm: &mut VirtualMachine, args: PyFuncArgs) -> PyResult {
+fn complex_neg(vm: &VirtualMachine, args: PyFuncArgs) -> PyResult {
     arg_check!(vm, args, required = [(zelf, Some(vm.ctx.complex_type()))]);
     Ok(vm.ctx.new_complex(-get_value(zelf)))
 }
 
-fn complex_repr(vm: &mut VirtualMachine, args: PyFuncArgs) -> PyResult {
+fn complex_repr(vm: &VirtualMachine, args: PyFuncArgs) -> PyResult {
     arg_check!(vm, args, required = [(obj, Some(vm.ctx.complex_type()))]);
     let v = get_value(obj);
     let repr = if v.re == 0. {

--- a/vm/src/obj/objdict.rs
+++ b/vm/src/obj/objdict.rs
@@ -30,7 +30,7 @@ impl fmt::Debug for PyDict {
 }
 
 impl PyValue for PyDict {
-    fn class(vm: &mut VirtualMachine) -> PyObjectRef {
+    fn class(vm: &VirtualMachine) -> PyObjectRef {
         vm.ctx.dict_type()
     }
 }
@@ -45,7 +45,7 @@ pub fn get_mut_elements<'a>(obj: &'a PyObjectRef) -> impl DerefMut<Target = Dict
 
 pub fn set_item(
     dict: &PyObjectRef,
-    _vm: &mut VirtualMachine,
+    _vm: &VirtualMachine,
     needle: &PyObjectRef,
     value: &PyObjectRef,
 ) {
@@ -123,7 +123,7 @@ pub fn py_dict_to_attributes(dict: &PyObjectRef) -> PyAttributes {
     attrs
 }
 
-pub fn attributes_to_py_dict(vm: &mut VirtualMachine, attributes: PyAttributes) -> PyResult {
+pub fn attributes_to_py_dict(vm: &VirtualMachine, attributes: PyAttributes) -> PyResult {
     let dict = vm.ctx.new_dict();
     for (key, value) in attributes {
         let key = vm.ctx.new_str(key);
@@ -133,7 +133,7 @@ pub fn attributes_to_py_dict(vm: &mut VirtualMachine, attributes: PyAttributes) 
 }
 
 // Python dict methods:
-fn dict_new(vm: &mut VirtualMachine, args: PyFuncArgs) -> PyResult {
+fn dict_new(vm: &VirtualMachine, args: PyFuncArgs) -> PyResult {
     arg_check!(
         vm,
         args,
@@ -149,7 +149,7 @@ fn dict_new(vm: &mut VirtualMachine, args: PyFuncArgs) -> PyResult {
         } else {
             let iter = objiter::get_iter(vm, dict_obj)?;
             loop {
-                fn err(vm: &mut VirtualMachine) -> PyObjectRef {
+                fn err(vm: &VirtualMachine) -> PyObjectRef {
                     vm.new_type_error("Iterator must have exactly two elements".to_string())
                 }
                 let element = match objiter::get_next_object(vm, &iter)? {
@@ -174,11 +174,11 @@ fn dict_new(vm: &mut VirtualMachine, args: PyFuncArgs) -> PyResult {
 }
 
 impl PyDictRef {
-    fn len(self, _vm: &mut VirtualMachine) -> usize {
+    fn len(self, _vm: &VirtualMachine) -> usize {
         self.entries.borrow().len()
     }
 
-    fn repr(self, vm: &mut VirtualMachine) -> PyResult {
+    fn repr(self, vm: &VirtualMachine) -> PyResult {
         let s = if let Some(_guard) = ReprGuard::enter(self.as_object()) {
             let elements = get_key_value_pairs(self.as_object());
             let mut str_parts = vec![];
@@ -195,11 +195,11 @@ impl PyDictRef {
         Ok(vm.new_str(s))
     }
 
-    fn contains(self, key: PyStringRef, _vm: &mut VirtualMachine) -> bool {
+    fn contains(self, key: PyStringRef, _vm: &VirtualMachine) -> bool {
         self.entries.borrow().contains_key(&key.value)
     }
 
-    fn delitem(self, key: PyStringRef, vm: &mut VirtualMachine) -> PyResult<()> {
+    fn delitem(self, key: PyStringRef, vm: &VirtualMachine) -> PyResult<()> {
         let key = &key.value;
         // Delete the item:
         let mut elements = self.entries.borrow_mut();
@@ -209,12 +209,12 @@ impl PyDictRef {
         }
     }
 
-    fn clear(self, _vm: &mut VirtualMachine) {
+    fn clear(self, _vm: &VirtualMachine) {
         self.entries.borrow_mut().clear()
     }
 
     /// When iterating over a dictionary, we iterate over the keys of it.
-    fn iter(self, vm: &mut VirtualMachine) -> PyIteratorValue {
+    fn iter(self, vm: &VirtualMachine) -> PyIteratorValue {
         let keys = self
             .entries
             .borrow()
@@ -229,7 +229,7 @@ impl PyDictRef {
         }
     }
 
-    fn values(self, vm: &mut VirtualMachine) -> PyIteratorValue {
+    fn values(self, vm: &VirtualMachine) -> PyIteratorValue {
         let values = self
             .entries
             .borrow()
@@ -244,7 +244,7 @@ impl PyDictRef {
         }
     }
 
-    fn items(self, vm: &mut VirtualMachine) -> PyIteratorValue {
+    fn items(self, vm: &VirtualMachine) -> PyIteratorValue {
         let items = self
             .entries
             .borrow()
@@ -259,12 +259,12 @@ impl PyDictRef {
         }
     }
 
-    fn setitem(self, needle: PyObjectRef, value: PyObjectRef, _vm: &mut VirtualMachine) {
+    fn setitem(self, needle: PyObjectRef, value: PyObjectRef, _vm: &VirtualMachine) {
         let mut elements = self.entries.borrow_mut();
         set_item_in_content(&mut elements, &needle, &value)
     }
 
-    fn getitem(self, key: PyStringRef, vm: &mut VirtualMachine) -> PyResult {
+    fn getitem(self, key: PyStringRef, vm: &VirtualMachine) -> PyResult {
         let key = &key.value;
 
         // What we are looking for:
@@ -280,7 +280,7 @@ impl PyDictRef {
         self,
         key: PyStringRef,
         default: OptionalArg<PyObjectRef>,
-        vm: &mut VirtualMachine,
+        vm: &VirtualMachine,
     ) -> PyObjectRef {
         // What we are looking for:
         let key = &key.value;

--- a/vm/src/obj/objellipsis.rs
+++ b/vm/src/obj/objellipsis.rs
@@ -12,12 +12,12 @@ pub fn init(context: &PyContext) {
     );
 }
 
-fn ellipsis_new(vm: &mut VirtualMachine, args: PyFuncArgs) -> PyResult {
+fn ellipsis_new(vm: &VirtualMachine, args: PyFuncArgs) -> PyResult {
     arg_check!(vm, args, required = [(_cls, None)]);
     Ok(vm.ctx.ellipsis())
 }
 
-fn ellipsis_repr(vm: &mut VirtualMachine, args: PyFuncArgs) -> PyResult {
+fn ellipsis_repr(vm: &VirtualMachine, args: PyFuncArgs) -> PyResult {
     arg_check!(vm, args, required = [(_cls, None)]);
     Ok(vm.new_str("Ellipsis".to_string()))
 }

--- a/vm/src/obj/objenumerate.rs
+++ b/vm/src/obj/objenumerate.rs
@@ -20,7 +20,7 @@ pub struct PyEnumerate {
 type PyEnumerateRef = PyRef<PyEnumerate>;
 
 impl PyValue for PyEnumerate {
-    fn class(vm: &mut VirtualMachine) -> PyObjectRef {
+    fn class(vm: &VirtualMachine) -> PyObjectRef {
         vm.ctx.enumerate_type()
     }
 }
@@ -29,7 +29,7 @@ fn enumerate_new(
     cls: PyClassRef,
     iterable: PyObjectRef,
     start: OptionalArg<PyIntRef>,
-    vm: &mut VirtualMachine,
+    vm: &VirtualMachine,
 ) -> PyResult<PyEnumerateRef> {
     let counter = match start {
         OptionalArg::Present(start) => start.value.clone(),
@@ -44,7 +44,7 @@ fn enumerate_new(
     .into_ref_with_type(vm, cls)
 }
 
-fn enumerate_next(vm: &mut VirtualMachine, args: PyFuncArgs) -> PyResult {
+fn enumerate_next(vm: &VirtualMachine, args: PyFuncArgs) -> PyResult {
     arg_check!(
         vm,
         args,

--- a/vm/src/obj/objfilter.rs
+++ b/vm/src/obj/objfilter.rs
@@ -14,12 +14,12 @@ pub struct PyFilter {
 }
 
 impl PyValue for PyFilter {
-    fn class(vm: &mut VirtualMachine) -> PyObjectRef {
+    fn class(vm: &VirtualMachine) -> PyObjectRef {
         vm.ctx.filter_type()
     }
 }
 
-fn filter_new(vm: &mut VirtualMachine, args: PyFuncArgs) -> PyResult {
+fn filter_new(vm: &VirtualMachine, args: PyFuncArgs) -> PyResult {
     arg_check!(
         vm,
         args,
@@ -35,7 +35,7 @@ fn filter_new(vm: &mut VirtualMachine, args: PyFuncArgs) -> PyResult {
     ))
 }
 
-fn filter_next(vm: &mut VirtualMachine, args: PyFuncArgs) -> PyResult {
+fn filter_next(vm: &VirtualMachine, args: PyFuncArgs) -> PyResult {
     arg_check!(vm, args, required = [(filter, Some(vm.ctx.filter_type()))]);
 
     if let Some(PyFilter {

--- a/vm/src/obj/objfloat.rs
+++ b/vm/src/obj/objfloat.rs
@@ -16,13 +16,13 @@ pub struct PyFloat {
 }
 
 impl PyValue for PyFloat {
-    fn class(vm: &mut VirtualMachine) -> PyObjectRef {
+    fn class(vm: &VirtualMachine) -> PyObjectRef {
         vm.ctx.float_type()
     }
 }
 
 impl IntoPyObject for f64 {
-    fn into_pyobject(self, vm: &mut VirtualMachine) -> PyResult {
+    fn into_pyobject(self, vm: &VirtualMachine) -> PyResult {
         Ok(vm.ctx.new_float(self))
     }
 }
@@ -36,7 +36,7 @@ impl From<f64> for PyFloat {
 pub type PyFloatRef = PyRef<PyFloat>;
 
 impl PyFloatRef {
-    fn eq(self, other: PyObjectRef, vm: &mut VirtualMachine) -> PyObjectRef {
+    fn eq(self, other: PyObjectRef, vm: &VirtualMachine) -> PyObjectRef {
         let value = self.value;
         let result = if objtype::isinstance(&other, &vm.ctx.float_type()) {
             let other = get_value(&other);
@@ -55,7 +55,7 @@ impl PyFloatRef {
         vm.ctx.new_bool(result)
     }
 
-    fn lt(self, i2: PyObjectRef, vm: &mut VirtualMachine) -> PyObjectRef {
+    fn lt(self, i2: PyObjectRef, vm: &VirtualMachine) -> PyObjectRef {
         let v1 = self.value;
         if objtype::isinstance(&i2, &vm.ctx.float_type()) {
             vm.ctx.new_bool(v1 < get_value(&i2))
@@ -67,7 +67,7 @@ impl PyFloatRef {
         }
     }
 
-    fn le(self, i2: PyObjectRef, vm: &mut VirtualMachine) -> PyObjectRef {
+    fn le(self, i2: PyObjectRef, vm: &VirtualMachine) -> PyObjectRef {
         let v1 = self.value;
         if objtype::isinstance(&i2, &vm.ctx.float_type()) {
             vm.ctx.new_bool(v1 <= get_value(&i2))
@@ -79,7 +79,7 @@ impl PyFloatRef {
         }
     }
 
-    fn gt(self, i2: PyObjectRef, vm: &mut VirtualMachine) -> PyObjectRef {
+    fn gt(self, i2: PyObjectRef, vm: &VirtualMachine) -> PyObjectRef {
         let v1 = self.value;
         if objtype::isinstance(&i2, &vm.ctx.float_type()) {
             vm.ctx.new_bool(v1 > get_value(&i2))
@@ -91,7 +91,7 @@ impl PyFloatRef {
         }
     }
 
-    fn ge(self, i2: PyObjectRef, vm: &mut VirtualMachine) -> PyObjectRef {
+    fn ge(self, i2: PyObjectRef, vm: &VirtualMachine) -> PyObjectRef {
         let v1 = self.value;
         if objtype::isinstance(&i2, &vm.ctx.float_type()) {
             vm.ctx.new_bool(v1 >= get_value(&i2))
@@ -103,11 +103,11 @@ impl PyFloatRef {
         }
     }
 
-    fn abs(self, _vm: &mut VirtualMachine) -> f64 {
+    fn abs(self, _vm: &VirtualMachine) -> f64 {
         self.value.abs()
     }
 
-    fn add(self, other: PyObjectRef, vm: &mut VirtualMachine) -> PyObjectRef {
+    fn add(self, other: PyObjectRef, vm: &VirtualMachine) -> PyObjectRef {
         let v1 = self.value;
         if objtype::isinstance(&other, &vm.ctx.float_type()) {
             vm.ctx.new_float(v1 + get_value(&other))
@@ -119,7 +119,7 @@ impl PyFloatRef {
         }
     }
 
-    fn divmod(self, other: PyObjectRef, vm: &mut VirtualMachine) -> PyResult {
+    fn divmod(self, other: PyObjectRef, vm: &VirtualMachine) -> PyResult {
         if objtype::isinstance(&other, &vm.ctx.float_type())
             || objtype::isinstance(&other, &vm.ctx.int_type())
         {
@@ -131,7 +131,7 @@ impl PyFloatRef {
         }
     }
 
-    fn floordiv(self, other: PyObjectRef, vm: &mut VirtualMachine) -> PyResult {
+    fn floordiv(self, other: PyObjectRef, vm: &VirtualMachine) -> PyResult {
         let v1 = self.value;
         let v2 = if objtype::isinstance(&other, &vm.ctx.float_type) {
             get_value(&other)
@@ -150,7 +150,7 @@ impl PyFloatRef {
         }
     }
 
-    fn new_float(cls: PyObjectRef, arg: PyObjectRef, vm: &mut VirtualMachine) -> PyResult {
+    fn new_float(cls: PyObjectRef, arg: PyObjectRef, vm: &VirtualMachine) -> PyResult {
         let value = if objtype::isinstance(&arg, &vm.ctx.float_type()) {
             get_value(&arg)
         } else if objtype::isinstance(&arg, &vm.ctx.int_type()) {
@@ -191,7 +191,7 @@ impl PyFloatRef {
         Ok(PyObject::new(PyFloat { value }, cls.clone()))
     }
 
-    fn mod_(self, other: PyObjectRef, vm: &mut VirtualMachine) -> PyResult {
+    fn mod_(self, other: PyObjectRef, vm: &VirtualMachine) -> PyResult {
         let v1 = self.value;
         let v2 = if objtype::isinstance(&other, &vm.ctx.float_type) {
             get_value(&other)
@@ -210,11 +210,11 @@ impl PyFloatRef {
         }
     }
 
-    fn neg(self, _vm: &mut VirtualMachine) -> f64 {
+    fn neg(self, _vm: &VirtualMachine) -> f64 {
         -self.value
     }
 
-    fn pow(self, other: PyObjectRef, vm: &mut VirtualMachine) -> PyObjectRef {
+    fn pow(self, other: PyObjectRef, vm: &VirtualMachine) -> PyObjectRef {
         let v1 = self.value;
         if objtype::isinstance(&other, &vm.ctx.float_type()) {
             vm.ctx.new_float(v1.powf(get_value(&other)))
@@ -226,7 +226,7 @@ impl PyFloatRef {
         }
     }
 
-    fn sub(self, other: PyObjectRef, vm: &mut VirtualMachine) -> PyResult {
+    fn sub(self, other: PyObjectRef, vm: &VirtualMachine) -> PyResult {
         let v1 = self.value;
         if objtype::isinstance(&other, &vm.ctx.float_type()) {
             Ok(vm.ctx.new_float(v1 - get_value(&other)))
@@ -239,7 +239,7 @@ impl PyFloatRef {
         }
     }
 
-    fn rsub(self, other: PyObjectRef, vm: &mut VirtualMachine) -> PyResult {
+    fn rsub(self, other: PyObjectRef, vm: &VirtualMachine) -> PyResult {
         let v1 = self.value;
         if objtype::isinstance(&other, &vm.ctx.float_type()) {
             Ok(vm.ctx.new_float(get_value(&other) - v1))
@@ -252,11 +252,11 @@ impl PyFloatRef {
         }
     }
 
-    fn repr(self, _vm: &mut VirtualMachine) -> String {
+    fn repr(self, _vm: &VirtualMachine) -> String {
         self.value.to_string()
     }
 
-    fn truediv(self, other: PyObjectRef, vm: &mut VirtualMachine) -> PyResult {
+    fn truediv(self, other: PyObjectRef, vm: &VirtualMachine) -> PyResult {
         let v1 = self.value;
         let v2 = if objtype::isinstance(&other, &vm.ctx.float_type) {
             get_value(&other)
@@ -275,7 +275,7 @@ impl PyFloatRef {
         }
     }
 
-    fn rtruediv(self, other: PyObjectRef, vm: &mut VirtualMachine) -> PyResult {
+    fn rtruediv(self, other: PyObjectRef, vm: &VirtualMachine) -> PyResult {
         let v1 = self.value;
         let v2 = if objtype::isinstance(&other, &vm.ctx.float_type) {
             get_value(&other)
@@ -294,7 +294,7 @@ impl PyFloatRef {
         }
     }
 
-    fn mul(self, other: PyObjectRef, vm: &mut VirtualMachine) -> PyResult {
+    fn mul(self, other: PyObjectRef, vm: &VirtualMachine) -> PyResult {
         let v1 = self.value;
         if objtype::isinstance(&other, &vm.ctx.float_type) {
             Ok(vm.ctx.new_float(v1 * get_value(&other)))
@@ -307,16 +307,16 @@ impl PyFloatRef {
         }
     }
 
-    fn is_integer(self, _vm: &mut VirtualMachine) -> bool {
+    fn is_integer(self, _vm: &VirtualMachine) -> bool {
         let v = self.value;
         (v - v.round()).abs() < std::f64::EPSILON
     }
 
-    fn real(self, _vm: &mut VirtualMachine) -> Self {
+    fn real(self, _vm: &VirtualMachine) -> Self {
         self
     }
 
-    fn as_integer_ratio(self, vm: &mut VirtualMachine) -> PyResult {
+    fn as_integer_ratio(self, vm: &VirtualMachine) -> PyResult {
         let value = self.value;
         if value.is_infinite() {
             return Err(
@@ -339,7 +339,7 @@ pub fn get_value(obj: &PyObjectRef) -> f64 {
     obj.payload::<PyFloat>().unwrap().value
 }
 
-pub fn make_float(vm: &mut VirtualMachine, obj: &PyObjectRef) -> PyResult<f64> {
+pub fn make_float(vm: &VirtualMachine, obj: &PyObjectRef) -> PyResult<f64> {
     if objtype::isinstance(obj, &vm.ctx.float_type()) {
         Ok(get_value(obj))
     } else if let Ok(method) = vm.get_method(obj.clone(), "__float__") {

--- a/vm/src/obj/objframe.rs
+++ b/vm/src/obj/objframe.rs
@@ -15,24 +15,24 @@ pub fn init(context: &PyContext) {
     context.set_attr(&frame_type, "f_code", context.new_property(frame_fcode));
 }
 
-fn frame_new(vm: &mut VirtualMachine, args: PyFuncArgs) -> PyResult {
+fn frame_new(vm: &VirtualMachine, args: PyFuncArgs) -> PyResult {
     arg_check!(vm, args, required = [(_cls, None)]);
     Err(vm.new_type_error("Cannot directly create frame object".to_string()))
 }
 
-fn frame_repr(vm: &mut VirtualMachine, args: PyFuncArgs) -> PyResult {
+fn frame_repr(vm: &VirtualMachine, args: PyFuncArgs) -> PyResult {
     arg_check!(vm, args, required = [(_frame, Some(vm.ctx.frame_type()))]);
     let repr = "<frame object at .. >".to_string();
     Ok(vm.new_str(repr))
 }
 
-fn frame_flocals(vm: &mut VirtualMachine, args: PyFuncArgs) -> PyResult {
+fn frame_flocals(vm: &VirtualMachine, args: PyFuncArgs) -> PyResult {
     arg_check!(vm, args, required = [(frame, Some(vm.ctx.frame_type()))]);
     let frame = get_value(frame);
     Ok(frame.scope.get_locals().clone())
 }
 
-fn frame_fcode(vm: &mut VirtualMachine, args: PyFuncArgs) -> PyResult {
+fn frame_fcode(vm: &VirtualMachine, args: PyFuncArgs) -> PyResult {
     arg_check!(vm, args, required = [(frame, Some(vm.ctx.frame_type()))]);
     Ok(vm.ctx.new_code_object(get_value(frame).code.clone()))
 }

--- a/vm/src/obj/objfunction.rs
+++ b/vm/src/obj/objfunction.rs
@@ -22,7 +22,7 @@ impl PyFunction {
 }
 
 impl PyValue for PyFunction {
-    fn class(vm: &mut VirtualMachine) -> PyObjectRef {
+    fn class(vm: &VirtualMachine) -> PyObjectRef {
         vm.ctx.function_type()
     }
 }
@@ -41,7 +41,7 @@ impl PyMethod {
 }
 
 impl PyValue for PyMethod {
-    fn class(vm: &mut VirtualMachine) -> PyObjectRef {
+    fn class(vm: &VirtualMachine) -> PyObjectRef {
         vm.ctx.bound_method_type()
     }
 }
@@ -59,7 +59,7 @@ pub fn init(context: &PyContext) {
     });
 }
 
-fn bind_method(vm: &mut VirtualMachine, args: PyFuncArgs) -> PyResult {
+fn bind_method(vm: &VirtualMachine, args: PyFuncArgs) -> PyResult {
     arg_check!(
         vm,
         args,
@@ -73,7 +73,7 @@ fn bind_method(vm: &mut VirtualMachine, args: PyFuncArgs) -> PyResult {
     }
 }
 
-fn function_code(vm: &mut VirtualMachine, args: PyFuncArgs) -> PyResult {
+fn function_code(vm: &VirtualMachine, args: PyFuncArgs) -> PyResult {
     match args.args[0].payload() {
         Some(PyFunction { ref code, .. }) => Ok(code.clone()),
         None => Err(vm.new_type_error("no code".to_string())),

--- a/vm/src/obj/objgenerator.rs
+++ b/vm/src/obj/objgenerator.rs
@@ -14,7 +14,7 @@ pub struct PyGenerator {
 type PyGeneratorRef = PyRef<PyGenerator>;
 
 impl PyValue for PyGenerator {
-    fn class(vm: &mut VirtualMachine) -> PyObjectRef {
+    fn class(vm: &VirtualMachine) -> PyObjectRef {
         vm.ctx.generator_type()
     }
 }
@@ -38,22 +38,22 @@ pub fn init(context: &PyContext) {
     );
 }
 
-pub fn new_generator(frame: PyObjectRef, vm: &mut VirtualMachine) -> PyGeneratorRef {
+pub fn new_generator(frame: PyObjectRef, vm: &VirtualMachine) -> PyGeneratorRef {
     PyGenerator { frame }.into_ref(vm)
 }
 
-fn generator_iter(vm: &mut VirtualMachine, args: PyFuncArgs) -> PyResult {
+fn generator_iter(vm: &VirtualMachine, args: PyFuncArgs) -> PyResult {
     arg_check!(vm, args, required = [(o, Some(vm.ctx.generator_type()))]);
     Ok(o.clone())
 }
 
-fn generator_next(vm: &mut VirtualMachine, args: PyFuncArgs) -> PyResult {
+fn generator_next(vm: &VirtualMachine, args: PyFuncArgs) -> PyResult {
     arg_check!(vm, args, required = [(o, Some(vm.ctx.generator_type()))]);
     let value = vm.get_none();
     send(vm, o, &value)
 }
 
-fn generator_send(vm: &mut VirtualMachine, args: PyFuncArgs) -> PyResult {
+fn generator_send(vm: &VirtualMachine, args: PyFuncArgs) -> PyResult {
     arg_check!(
         vm,
         args,
@@ -62,7 +62,7 @@ fn generator_send(vm: &mut VirtualMachine, args: PyFuncArgs) -> PyResult {
     send(vm, o, value)
 }
 
-fn send(vm: &mut VirtualMachine, gen: &PyObjectRef, value: &PyObjectRef) -> PyResult {
+fn send(vm: &VirtualMachine, gen: &PyObjectRef, value: &PyObjectRef) -> PyResult {
     if let Some(PyGenerator { ref frame }) = gen.payload() {
         if let Some(frame) = frame.payload::<Frame>() {
             frame.push_value(value.clone());

--- a/vm/src/obj/objint.rs
+++ b/vm/src/obj/objint.rs
@@ -31,13 +31,13 @@ impl PyInt {
 }
 
 impl IntoPyObject for BigInt {
-    fn into_pyobject(self, vm: &mut VirtualMachine) -> PyResult {
+    fn into_pyobject(self, vm: &VirtualMachine) -> PyResult {
         Ok(vm.ctx.new_int(self))
     }
 }
 
 impl PyValue for PyInt {
-    fn class(vm: &mut VirtualMachine) -> PyObjectRef {
+    fn class(vm: &VirtualMachine) -> PyObjectRef {
         vm.ctx.int_type()
     }
 }
@@ -45,7 +45,7 @@ impl PyValue for PyInt {
 macro_rules! impl_into_pyobject_int {
     ($($t:ty)*) => {$(
         impl IntoPyObject for $t {
-            fn into_pyobject(self, vm: &mut VirtualMachine) -> PyResult {
+            fn into_pyobject(self, vm: &VirtualMachine) -> PyResult {
                 Ok(vm.ctx.new_int(self))
             }
         }
@@ -57,7 +57,7 @@ impl_into_pyobject_int!(isize i8 i16 i32 i64 usize u8 u16 u32 u64) ;
 macro_rules! impl_try_from_object_int {
     ($(($t:ty, $to_prim:ident),)*) => {$(
         impl TryFromObject for $t {
-            fn try_from_object(vm: &mut VirtualMachine, obj: PyObjectRef) -> PyResult<Self> {
+            fn try_from_object(vm: &VirtualMachine, obj: PyObjectRef) -> PyResult<Self> {
                 match PyRef::<PyInt>::try_from_object(vm, obj)?.value.$to_prim() {
                     Some(value) => Ok(value),
                     None => Err(
@@ -86,11 +86,11 @@ impl_try_from_object_int!(
 );
 
 impl PyIntRef {
-    fn pass_value(self, _vm: &mut VirtualMachine) -> Self {
+    fn pass_value(self, _vm: &VirtualMachine) -> Self {
         self
     }
 
-    fn eq(self, other: PyObjectRef, vm: &mut VirtualMachine) -> PyObjectRef {
+    fn eq(self, other: PyObjectRef, vm: &VirtualMachine) -> PyObjectRef {
         if objtype::isinstance(&other, &vm.ctx.int_type()) {
             vm.ctx.new_bool(self.value == *get_value(&other))
         } else {
@@ -98,7 +98,7 @@ impl PyIntRef {
         }
     }
 
-    fn ne(self, other: PyObjectRef, vm: &mut VirtualMachine) -> PyObjectRef {
+    fn ne(self, other: PyObjectRef, vm: &VirtualMachine) -> PyObjectRef {
         if objtype::isinstance(&other, &vm.ctx.int_type()) {
             vm.ctx.new_bool(self.value != *get_value(&other))
         } else {
@@ -106,7 +106,7 @@ impl PyIntRef {
         }
     }
 
-    fn lt(self, other: PyObjectRef, vm: &mut VirtualMachine) -> PyObjectRef {
+    fn lt(self, other: PyObjectRef, vm: &VirtualMachine) -> PyObjectRef {
         if objtype::isinstance(&other, &vm.ctx.int_type()) {
             vm.ctx.new_bool(self.value < *get_value(&other))
         } else {
@@ -114,7 +114,7 @@ impl PyIntRef {
         }
     }
 
-    fn le(self, other: PyObjectRef, vm: &mut VirtualMachine) -> PyObjectRef {
+    fn le(self, other: PyObjectRef, vm: &VirtualMachine) -> PyObjectRef {
         if objtype::isinstance(&other, &vm.ctx.int_type()) {
             vm.ctx.new_bool(self.value <= *get_value(&other))
         } else {
@@ -122,7 +122,7 @@ impl PyIntRef {
         }
     }
 
-    fn gt(self, other: PyObjectRef, vm: &mut VirtualMachine) -> PyObjectRef {
+    fn gt(self, other: PyObjectRef, vm: &VirtualMachine) -> PyObjectRef {
         if objtype::isinstance(&other, &vm.ctx.int_type()) {
             vm.ctx.new_bool(self.value > *get_value(&other))
         } else {
@@ -130,7 +130,7 @@ impl PyIntRef {
         }
     }
 
-    fn ge(self, other: PyObjectRef, vm: &mut VirtualMachine) -> PyObjectRef {
+    fn ge(self, other: PyObjectRef, vm: &VirtualMachine) -> PyObjectRef {
         if objtype::isinstance(&other, &vm.ctx.int_type()) {
             vm.ctx.new_bool(self.value >= *get_value(&other))
         } else {
@@ -138,7 +138,7 @@ impl PyIntRef {
         }
     }
 
-    fn add(self, other: PyObjectRef, vm: &mut VirtualMachine) -> PyObjectRef {
+    fn add(self, other: PyObjectRef, vm: &VirtualMachine) -> PyObjectRef {
         if objtype::isinstance(&other, &vm.ctx.int_type()) {
             vm.ctx.new_int((&self.value) + get_value(&other))
         } else {
@@ -146,7 +146,7 @@ impl PyIntRef {
         }
     }
 
-    fn sub(self, other: PyObjectRef, vm: &mut VirtualMachine) -> PyObjectRef {
+    fn sub(self, other: PyObjectRef, vm: &VirtualMachine) -> PyObjectRef {
         if objtype::isinstance(&other, &vm.ctx.int_type()) {
             vm.ctx.new_int((&self.value) - get_value(&other))
         } else {
@@ -154,7 +154,7 @@ impl PyIntRef {
         }
     }
 
-    fn rsub(self, other: PyObjectRef, vm: &mut VirtualMachine) -> PyObjectRef {
+    fn rsub(self, other: PyObjectRef, vm: &VirtualMachine) -> PyObjectRef {
         if objtype::isinstance(&other, &vm.ctx.int_type()) {
             vm.ctx.new_int(get_value(&other) - (&self.value))
         } else {
@@ -162,7 +162,7 @@ impl PyIntRef {
         }
     }
 
-    fn mul(self, other: PyObjectRef, vm: &mut VirtualMachine) -> PyObjectRef {
+    fn mul(self, other: PyObjectRef, vm: &VirtualMachine) -> PyObjectRef {
         if objtype::isinstance(&other, &vm.ctx.int_type()) {
             vm.ctx.new_int((&self.value) * get_value(&other))
         } else {
@@ -170,7 +170,7 @@ impl PyIntRef {
         }
     }
 
-    fn truediv(self, other: PyObjectRef, vm: &mut VirtualMachine) -> PyResult {
+    fn truediv(self, other: PyObjectRef, vm: &VirtualMachine) -> PyResult {
         if objtype::isinstance(&other, &vm.ctx.int_type()) {
             div_ints(vm, &self.value, &get_value(&other))
         } else {
@@ -178,7 +178,7 @@ impl PyIntRef {
         }
     }
 
-    fn rtruediv(self, other: PyObjectRef, vm: &mut VirtualMachine) -> PyResult {
+    fn rtruediv(self, other: PyObjectRef, vm: &VirtualMachine) -> PyResult {
         if objtype::isinstance(&other, &vm.ctx.int_type()) {
             div_ints(vm, &get_value(&other), &self.value)
         } else {
@@ -186,7 +186,7 @@ impl PyIntRef {
         }
     }
 
-    fn floordiv(self, other: PyObjectRef, vm: &mut VirtualMachine) -> PyResult {
+    fn floordiv(self, other: PyObjectRef, vm: &VirtualMachine) -> PyResult {
         if objtype::isinstance(&other, &vm.ctx.int_type()) {
             let v2 = get_value(&other);
             if *v2 != BigInt::zero() {
@@ -199,7 +199,7 @@ impl PyIntRef {
         }
     }
 
-    fn lshift(self, other: PyObjectRef, vm: &mut VirtualMachine) -> PyResult {
+    fn lshift(self, other: PyObjectRef, vm: &VirtualMachine) -> PyResult {
         if !objtype::isinstance(&other, &vm.ctx.int_type()) {
             return Err(vm.new_type_error(format!(
                 "unsupported operand type(s) for << '{}' and '{}'",
@@ -222,7 +222,7 @@ impl PyIntRef {
         }
     }
 
-    fn rshift(self, other: PyObjectRef, vm: &mut VirtualMachine) -> PyResult {
+    fn rshift(self, other: PyObjectRef, vm: &VirtualMachine) -> PyResult {
         if !objtype::isinstance(&other, &vm.ctx.int_type()) {
             return Err(vm.new_type_error(format!(
                 "unsupported operand type(s) for >> '{}' and '{}'",
@@ -245,7 +245,7 @@ impl PyIntRef {
         }
     }
 
-    fn xor(self, other: PyObjectRef, vm: &mut VirtualMachine) -> PyObjectRef {
+    fn xor(self, other: PyObjectRef, vm: &VirtualMachine) -> PyObjectRef {
         if objtype::isinstance(&other, &vm.ctx.int_type()) {
             vm.ctx.new_int((&self.value) ^ get_value(&other))
         } else {
@@ -253,7 +253,7 @@ impl PyIntRef {
         }
     }
 
-    fn rxor(self, other: PyObjectRef, vm: &mut VirtualMachine) -> PyObjectRef {
+    fn rxor(self, other: PyObjectRef, vm: &VirtualMachine) -> PyObjectRef {
         if objtype::isinstance(&other, &vm.ctx.int_type()) {
             vm.ctx.new_int(get_value(&other) ^ (&self.value))
         } else {
@@ -261,7 +261,7 @@ impl PyIntRef {
         }
     }
 
-    fn or(self, other: PyObjectRef, vm: &mut VirtualMachine) -> PyObjectRef {
+    fn or(self, other: PyObjectRef, vm: &VirtualMachine) -> PyObjectRef {
         if objtype::isinstance(&other, &vm.ctx.int_type()) {
             vm.ctx.new_int((&self.value) | get_value(&other))
         } else {
@@ -269,7 +269,7 @@ impl PyIntRef {
         }
     }
 
-    fn and(self, other: PyObjectRef, vm: &mut VirtualMachine) -> PyObjectRef {
+    fn and(self, other: PyObjectRef, vm: &VirtualMachine) -> PyObjectRef {
         if objtype::isinstance(&other, &vm.ctx.int_type()) {
             let v2 = get_value(&other);
             vm.ctx.new_int((&self.value) & v2)
@@ -278,7 +278,7 @@ impl PyIntRef {
         }
     }
 
-    fn pow(self, other: PyObjectRef, vm: &mut VirtualMachine) -> PyObjectRef {
+    fn pow(self, other: PyObjectRef, vm: &VirtualMachine) -> PyObjectRef {
         if objtype::isinstance(&other, &vm.ctx.int_type()) {
             let v2 = get_value(&other).to_u32().unwrap();
             vm.ctx.new_int(self.value.pow(v2))
@@ -290,7 +290,7 @@ impl PyIntRef {
         }
     }
 
-    fn mod_(self, other: PyObjectRef, vm: &mut VirtualMachine) -> PyResult {
+    fn mod_(self, other: PyObjectRef, vm: &VirtualMachine) -> PyResult {
         if objtype::isinstance(&other, &vm.ctx.int_type()) {
             let v2 = get_value(&other);
             if *v2 != BigInt::zero() {
@@ -303,7 +303,7 @@ impl PyIntRef {
         }
     }
 
-    fn divmod(self, other: PyObjectRef, vm: &mut VirtualMachine) -> PyResult {
+    fn divmod(self, other: PyObjectRef, vm: &VirtualMachine) -> PyResult {
         if objtype::isinstance(&other, &vm.ctx.int_type()) {
             let v2 = get_value(&other);
             if *v2 != BigInt::zero() {
@@ -319,37 +319,37 @@ impl PyIntRef {
         }
     }
 
-    fn neg(self, _vm: &mut VirtualMachine) -> BigInt {
+    fn neg(self, _vm: &VirtualMachine) -> BigInt {
         -(&self.value)
     }
 
-    fn hash(self, _vm: &mut VirtualMachine) -> u64 {
+    fn hash(self, _vm: &VirtualMachine) -> u64 {
         let mut hasher = std::collections::hash_map::DefaultHasher::new();
         self.value.hash(&mut hasher);
         hasher.finish()
     }
 
-    fn abs(self, _vm: &mut VirtualMachine) -> BigInt {
+    fn abs(self, _vm: &VirtualMachine) -> BigInt {
         self.value.abs()
     }
 
-    fn round(self, _precision: OptionalArg<PyObjectRef>, _vm: &mut VirtualMachine) -> Self {
+    fn round(self, _precision: OptionalArg<PyObjectRef>, _vm: &VirtualMachine) -> Self {
         self
     }
 
-    fn float(self, _vm: &mut VirtualMachine) -> f64 {
+    fn float(self, _vm: &VirtualMachine) -> f64 {
         self.value.to_f64().unwrap()
     }
 
-    fn invert(self, _vm: &mut VirtualMachine) -> BigInt {
+    fn invert(self, _vm: &VirtualMachine) -> BigInt {
         !(&self.value)
     }
 
-    fn repr(self, _vm: &mut VirtualMachine) -> String {
+    fn repr(self, _vm: &VirtualMachine) -> String {
         self.value.to_string()
     }
 
-    fn format(self, spec: PyRef<objstr::PyString>, vm: &mut VirtualMachine) -> PyResult<String> {
+    fn format(self, spec: PyRef<objstr::PyString>, vm: &VirtualMachine) -> PyResult<String> {
         let format_spec = FormatSpec::parse(&spec.value);
         match format_spec.format_int(&self.value) {
             Ok(string) => Ok(string),
@@ -357,20 +357,20 @@ impl PyIntRef {
         }
     }
 
-    fn bool(self, _vm: &mut VirtualMachine) -> bool {
+    fn bool(self, _vm: &VirtualMachine) -> bool {
         !self.value.is_zero()
     }
 
-    fn bit_length(self, _vm: &mut VirtualMachine) -> usize {
+    fn bit_length(self, _vm: &VirtualMachine) -> usize {
         self.value.bits()
     }
 
-    fn imag(self, _vm: &mut VirtualMachine) -> usize {
+    fn imag(self, _vm: &VirtualMachine) -> usize {
         0
     }
 }
 
-fn int_new(vm: &mut VirtualMachine, args: PyFuncArgs) -> PyResult {
+fn int_new(vm: &VirtualMachine, args: PyFuncArgs) -> PyResult {
     arg_check!(
         vm,
         args,
@@ -393,7 +393,7 @@ fn int_new(vm: &mut VirtualMachine, args: PyFuncArgs) -> PyResult {
 }
 
 // Casting function:
-pub fn to_int(vm: &mut VirtualMachine, obj: &PyObjectRef, base: u32) -> PyResult<BigInt> {
+pub fn to_int(vm: &VirtualMachine, obj: &PyObjectRef, base: u32) -> PyResult<BigInt> {
     let val = if objtype::isinstance(obj, &vm.ctx.int_type()) {
         get_value(obj).clone()
     } else if objtype::isinstance(obj, &vm.ctx.float_type()) {
@@ -426,7 +426,7 @@ pub fn get_value(obj: &PyObjectRef) -> &BigInt {
 }
 
 #[inline]
-fn div_ints(vm: &mut VirtualMachine, i1: &BigInt, i2: &BigInt) -> PyResult {
+fn div_ints(vm: &VirtualMachine, i1: &BigInt, i2: &BigInt) -> PyResult {
     if i2.is_zero() {
         return Err(vm.new_zero_division_error("integer division by zero".to_string()));
     }

--- a/vm/src/obj/objmap.rs
+++ b/vm/src/obj/objmap.rs
@@ -13,7 +13,7 @@ pub struct PyMap {
 type PyMapRef = PyRef<PyMap>;
 
 impl PyValue for PyMap {
-    fn class(vm: &mut VirtualMachine) -> PyObjectRef {
+    fn class(vm: &VirtualMachine) -> PyObjectRef {
         vm.ctx.map_type()
     }
 }
@@ -22,7 +22,7 @@ fn map_new(
     cls: PyClassRef,
     function: PyObjectRef,
     iterables: Args,
-    vm: &mut VirtualMachine,
+    vm: &VirtualMachine,
 ) -> PyResult<PyMapRef> {
     let iterators = iterables
         .into_iter()
@@ -35,7 +35,7 @@ fn map_new(
     .into_ref_with_type(vm, cls.clone())
 }
 
-fn map_next(vm: &mut VirtualMachine, args: PyFuncArgs) -> PyResult {
+fn map_next(vm: &VirtualMachine, args: PyFuncArgs) -> PyResult {
     arg_check!(vm, args, required = [(map, Some(vm.ctx.map_type()))]);
 
     if let Some(PyMap {

--- a/vm/src/obj/objmemory.rs
+++ b/vm/src/obj/objmemory.rs
@@ -8,12 +8,12 @@ pub struct PyMemoryView {
 }
 
 impl PyValue for PyMemoryView {
-    fn class(vm: &mut VirtualMachine) -> PyObjectRef {
+    fn class(vm: &VirtualMachine) -> PyObjectRef {
         vm.ctx.memoryview_type()
     }
 }
 
-pub fn new_memory_view(vm: &mut VirtualMachine, args: PyFuncArgs) -> PyResult {
+pub fn new_memory_view(vm: &VirtualMachine, args: PyFuncArgs) -> PyResult {
     arg_check!(vm, args, required = [(cls, None), (bytes_object, None)]);
     vm.ctx.set_attr(&cls, "obj", bytes_object.clone());
     Ok(PyObject::new(

--- a/vm/src/obj/objmodule.rs
+++ b/vm/src/obj/objmodule.rs
@@ -10,13 +10,13 @@ pub struct PyModule {
 pub type PyModuleRef = PyRef<PyModule>;
 
 impl PyValue for PyModule {
-    fn class(vm: &mut VirtualMachine) -> PyObjectRef {
+    fn class(vm: &VirtualMachine) -> PyObjectRef {
         vm.ctx.module_type()
     }
 }
 
 impl PyModuleRef {
-    fn dir(self: PyModuleRef, vm: &mut VirtualMachine) -> PyResult {
+    fn dir(self: PyModuleRef, vm: &VirtualMachine) -> PyResult {
         let keys = self
             .dict
             .get_key_value_pairs()
@@ -26,7 +26,7 @@ impl PyModuleRef {
         Ok(vm.ctx.new_list(keys))
     }
 
-    fn set_attr(self, attr: PyStringRef, value: PyObjectRef, vm: &mut VirtualMachine) {
+    fn set_attr(self, attr: PyStringRef, value: PyObjectRef, vm: &VirtualMachine) {
         self.dict.set_item(&vm.ctx, &attr.value, value)
     }
 }

--- a/vm/src/obj/objnone.rs
+++ b/vm/src/obj/objnone.rs
@@ -12,7 +12,7 @@ pub struct PyNone;
 pub type PyNoneRef = PyRef<PyNone>;
 
 impl PyValue for PyNone {
-    fn class(vm: &mut VirtualMachine) -> PyObjectRef {
+    fn class(vm: &VirtualMachine) -> PyObjectRef {
         vm.ctx.none().typ()
     }
 }
@@ -20,13 +20,13 @@ impl PyValue for PyNone {
 // This allows a built-in function to not return a value, mapping to
 // Python's behavior of returning `None` in this situation.
 impl IntoPyObject for () {
-    fn into_pyobject(self, vm: &mut VirtualMachine) -> PyResult {
+    fn into_pyobject(self, vm: &VirtualMachine) -> PyResult {
         Ok(vm.ctx.none())
     }
 }
 
 impl<T: IntoPyObject> IntoPyObject for Option<T> {
-    fn into_pyobject(self, vm: &mut VirtualMachine) -> PyResult {
+    fn into_pyobject(self, vm: &VirtualMachine) -> PyResult {
         match self {
             Some(x) => x.into_pyobject(vm),
             None => Ok(vm.ctx.none()),
@@ -35,15 +35,15 @@ impl<T: IntoPyObject> IntoPyObject for Option<T> {
 }
 
 impl PyNoneRef {
-    fn repr(self, _vm: &mut VirtualMachine) -> PyResult<String> {
+    fn repr(self, _vm: &VirtualMachine) -> PyResult<String> {
         Ok("None".to_string())
     }
 
-    fn bool(self, _vm: &mut VirtualMachine) -> PyResult<bool> {
+    fn bool(self, _vm: &VirtualMachine) -> PyResult<bool> {
         Ok(false)
     }
 
-    fn get_attribute(self, name: PyStringRef, vm: &mut VirtualMachine) -> PyResult {
+    fn get_attribute(self, name: PyStringRef, vm: &VirtualMachine) -> PyResult {
         trace!("None.__getattribute__({:?}, {:?})", self, name);
         let cls = self.typ().into_object();
 
@@ -60,7 +60,7 @@ impl PyNoneRef {
             get_func: PyObjectRef,
             obj: PyObjectRef,
             cls: PyObjectRef,
-            vm: &mut VirtualMachine,
+            vm: &VirtualMachine,
         ) -> PyResult {
             if let Ok(property) = PyPropertyRef::try_from_object(vm, descriptor.clone()) {
                 property.instance_binding_get(obj, vm)
@@ -95,7 +95,7 @@ impl PyNoneRef {
     }
 }
 
-fn none_new(vm: &mut VirtualMachine, args: PyFuncArgs) -> PyResult {
+fn none_new(vm: &VirtualMachine, args: PyFuncArgs) -> PyResult {
     arg_check!(
         vm,
         args,

--- a/vm/src/obj/objproperty.rs
+++ b/vm/src/obj/objproperty.rs
@@ -16,7 +16,7 @@ pub struct PyReadOnlyProperty {
 }
 
 impl PyValue for PyReadOnlyProperty {
-    fn class(vm: &mut VirtualMachine) -> PyObjectRef {
+    fn class(vm: &VirtualMachine) -> PyObjectRef {
         vm.ctx.readonly_property_type()
     }
 }
@@ -28,7 +28,7 @@ impl PyReadOnlyPropertyRef {
         self,
         obj: PyObjectRef,
         _owner: OptionalArg<PyClassRef>,
-        vm: &mut VirtualMachine,
+        vm: &VirtualMachine,
     ) -> PyResult {
         if obj.is(&vm.ctx.none) {
             Ok(self.into_object())
@@ -47,7 +47,7 @@ pub struct PyProperty {
 }
 
 impl PyValue for PyProperty {
-    fn class(vm: &mut VirtualMachine) -> PyObjectRef {
+    fn class(vm: &VirtualMachine) -> PyObjectRef {
         vm.ctx.property_type()
     }
 }
@@ -61,7 +61,7 @@ impl PyPropertyRef {
         fset: OptionalArg<PyObjectRef>,
         fdel: OptionalArg<PyObjectRef>,
         _doc: OptionalArg<PyStringRef>,
-        vm: &mut VirtualMachine,
+        vm: &VirtualMachine,
     ) -> PyResult<PyPropertyRef> {
         PyProperty {
             getter: fget.into_option(),
@@ -74,11 +74,7 @@ impl PyPropertyRef {
     // Descriptor methods
 
     // specialised version that doesn't check for None
-    pub(crate) fn instance_binding_get(
-        self,
-        obj: PyObjectRef,
-        vm: &mut VirtualMachine,
-    ) -> PyResult {
+    pub(crate) fn instance_binding_get(self, obj: PyObjectRef, vm: &VirtualMachine) -> PyResult {
         if let Some(getter) = self.getter.as_ref() {
             vm.invoke(getter.clone(), obj)
         } else {
@@ -90,7 +86,7 @@ impl PyPropertyRef {
         self,
         obj: PyObjectRef,
         _owner: OptionalArg<PyClassRef>,
-        vm: &mut VirtualMachine,
+        vm: &VirtualMachine,
     ) -> PyResult {
         if let Some(getter) = self.getter.as_ref() {
             if obj.is(&vm.ctx.none) {
@@ -103,7 +99,7 @@ impl PyPropertyRef {
         }
     }
 
-    fn set(self, obj: PyObjectRef, value: PyObjectRef, vm: &mut VirtualMachine) -> PyResult {
+    fn set(self, obj: PyObjectRef, value: PyObjectRef, vm: &VirtualMachine) -> PyResult {
         if let Some(setter) = self.setter.as_ref() {
             vm.invoke(setter.clone(), vec![obj, value])
         } else {
@@ -111,7 +107,7 @@ impl PyPropertyRef {
         }
     }
 
-    fn delete(self, obj: PyObjectRef, vm: &mut VirtualMachine) -> PyResult {
+    fn delete(self, obj: PyObjectRef, vm: &VirtualMachine) -> PyResult {
         if let Some(deleter) = self.deleter.as_ref() {
             vm.invoke(deleter.clone(), obj)
         } else {
@@ -121,21 +117,21 @@ impl PyPropertyRef {
 
     // Access functions
 
-    fn fget(self, _vm: &mut VirtualMachine) -> Option<PyObjectRef> {
+    fn fget(self, _vm: &VirtualMachine) -> Option<PyObjectRef> {
         self.getter.clone()
     }
 
-    fn fset(self, _vm: &mut VirtualMachine) -> Option<PyObjectRef> {
+    fn fset(self, _vm: &VirtualMachine) -> Option<PyObjectRef> {
         self.setter.clone()
     }
 
-    fn fdel(self, _vm: &mut VirtualMachine) -> Option<PyObjectRef> {
+    fn fdel(self, _vm: &VirtualMachine) -> Option<PyObjectRef> {
         self.deleter.clone()
     }
 
     // Python builder functions
 
-    fn getter(self, getter: Option<PyObjectRef>, vm: &mut VirtualMachine) -> PyResult<Self> {
+    fn getter(self, getter: Option<PyObjectRef>, vm: &VirtualMachine) -> PyResult<Self> {
         PyProperty {
             getter: getter.or_else(|| self.getter.clone()),
             setter: self.setter.clone(),
@@ -144,7 +140,7 @@ impl PyPropertyRef {
         .into_ref_with_type(vm, self.typ())
     }
 
-    fn setter(self, setter: Option<PyObjectRef>, vm: &mut VirtualMachine) -> PyResult<Self> {
+    fn setter(self, setter: Option<PyObjectRef>, vm: &VirtualMachine) -> PyResult<Self> {
         PyProperty {
             getter: self.getter.clone(),
             setter: setter.or_else(|| self.setter.clone()),
@@ -153,7 +149,7 @@ impl PyPropertyRef {
         .into_ref_with_type(vm, self.typ())
     }
 
-    fn deleter(self, deleter: Option<PyObjectRef>, vm: &mut VirtualMachine) -> PyResult<Self> {
+    fn deleter(self, deleter: Option<PyObjectRef>, vm: &VirtualMachine) -> PyResult<Self> {
         PyProperty {
             getter: self.getter.clone(),
             setter: self.setter.clone(),

--- a/vm/src/obj/objrange.rs
+++ b/vm/src/obj/objrange.rs
@@ -25,7 +25,7 @@ pub struct PyRange {
 }
 
 impl PyValue for PyRange {
-    fn class(vm: &mut VirtualMachine) -> PyObjectRef {
+    fn class(vm: &VirtualMachine) -> PyObjectRef {
         vm.ctx.range_type()
     }
 }
@@ -196,7 +196,7 @@ pub fn init(context: &PyContext) {
     context.set_attr(&range_type, "step", context.new_property(range_step));
 }
 
-fn range_new(vm: &mut VirtualMachine, args: PyFuncArgs) -> PyResult {
+fn range_new(vm: &VirtualMachine, args: PyFuncArgs) -> PyResult {
     arg_check!(
         vm,
         args,
@@ -232,7 +232,7 @@ fn range_new(vm: &mut VirtualMachine, args: PyFuncArgs) -> PyResult {
     }
 }
 
-fn range_iter(vm: &mut VirtualMachine, args: PyFuncArgs) -> PyResult {
+fn range_iter(vm: &VirtualMachine, args: PyFuncArgs) -> PyResult {
     arg_check!(vm, args, required = [(range, Some(vm.ctx.range_type()))]);
 
     Ok(PyObject::new(
@@ -244,7 +244,7 @@ fn range_iter(vm: &mut VirtualMachine, args: PyFuncArgs) -> PyResult {
     ))
 }
 
-fn range_reversed(vm: &mut VirtualMachine, args: PyFuncArgs) -> PyResult {
+fn range_reversed(vm: &VirtualMachine, args: PyFuncArgs) -> PyResult {
     arg_check!(vm, args, required = [(zelf, Some(vm.ctx.range_type()))]);
 
     let range = get_value(zelf).reversed();
@@ -258,7 +258,7 @@ fn range_reversed(vm: &mut VirtualMachine, args: PyFuncArgs) -> PyResult {
     ))
 }
 
-fn range_len(vm: &mut VirtualMachine, args: PyFuncArgs) -> PyResult {
+fn range_len(vm: &VirtualMachine, args: PyFuncArgs) -> PyResult {
     arg_check!(vm, args, required = [(zelf, Some(vm.ctx.range_type()))]);
 
     if let Some(len) = get_value(zelf).try_len() {
@@ -268,7 +268,7 @@ fn range_len(vm: &mut VirtualMachine, args: PyFuncArgs) -> PyResult {
     }
 }
 
-fn range_getitem(vm: &mut VirtualMachine, args: PyFuncArgs) -> PyResult {
+fn range_getitem(vm: &VirtualMachine, args: PyFuncArgs) -> PyResult {
     arg_check!(
         vm,
         args,
@@ -328,7 +328,7 @@ fn range_getitem(vm: &mut VirtualMachine, args: PyFuncArgs) -> PyResult {
     }
 }
 
-fn range_repr(vm: &mut VirtualMachine, args: PyFuncArgs) -> PyResult {
+fn range_repr(vm: &VirtualMachine, args: PyFuncArgs) -> PyResult {
     arg_check!(vm, args, required = [(zelf, Some(vm.ctx.range_type()))]);
 
     let repr = get_value(zelf).repr();
@@ -336,7 +336,7 @@ fn range_repr(vm: &mut VirtualMachine, args: PyFuncArgs) -> PyResult {
     Ok(vm.ctx.new_str(repr))
 }
 
-fn range_bool(vm: &mut VirtualMachine, args: PyFuncArgs) -> PyResult {
+fn range_bool(vm: &VirtualMachine, args: PyFuncArgs) -> PyResult {
     arg_check!(vm, args, required = [(zelf, Some(vm.ctx.range_type()))]);
 
     let len = get_value(zelf).len();
@@ -344,7 +344,7 @@ fn range_bool(vm: &mut VirtualMachine, args: PyFuncArgs) -> PyResult {
     Ok(vm.ctx.new_bool(len > 0))
 }
 
-fn range_contains(vm: &mut VirtualMachine, args: PyFuncArgs) -> PyResult {
+fn range_contains(vm: &VirtualMachine, args: PyFuncArgs) -> PyResult {
     arg_check!(
         vm,
         args,
@@ -362,7 +362,7 @@ fn range_contains(vm: &mut VirtualMachine, args: PyFuncArgs) -> PyResult {
     Ok(vm.ctx.new_bool(result))
 }
 
-fn range_index(vm: &mut VirtualMachine, args: PyFuncArgs) -> PyResult {
+fn range_index(vm: &VirtualMachine, args: PyFuncArgs) -> PyResult {
     arg_check!(
         vm,
         args,
@@ -383,7 +383,7 @@ fn range_index(vm: &mut VirtualMachine, args: PyFuncArgs) -> PyResult {
     }
 }
 
-fn range_count(vm: &mut VirtualMachine, args: PyFuncArgs) -> PyResult {
+fn range_count(vm: &VirtualMachine, args: PyFuncArgs) -> PyResult {
     arg_check!(
         vm,
         args,
@@ -399,17 +399,17 @@ fn range_count(vm: &mut VirtualMachine, args: PyFuncArgs) -> PyResult {
     }
 }
 
-fn range_start(vm: &mut VirtualMachine, args: PyFuncArgs) -> PyResult {
+fn range_start(vm: &VirtualMachine, args: PyFuncArgs) -> PyResult {
     arg_check!(vm, args, required = [(zelf, Some(vm.ctx.range_type()))]);
     Ok(vm.ctx.new_int(get_value(zelf).start))
 }
 
-fn range_stop(vm: &mut VirtualMachine, args: PyFuncArgs) -> PyResult {
+fn range_stop(vm: &VirtualMachine, args: PyFuncArgs) -> PyResult {
     arg_check!(vm, args, required = [(zelf, Some(vm.ctx.range_type()))]);
     Ok(vm.ctx.new_int(get_value(zelf).end))
 }
 
-fn range_step(vm: &mut VirtualMachine, args: PyFuncArgs) -> PyResult {
+fn range_step(vm: &VirtualMachine, args: PyFuncArgs) -> PyResult {
     arg_check!(vm, args, required = [(zelf, Some(vm.ctx.range_type()))]);
     Ok(vm.ctx.new_int(get_value(zelf).step))
 }

--- a/vm/src/obj/objsequence.rs
+++ b/vm/src/obj/objsequence.rs
@@ -61,11 +61,7 @@ pub trait PySliceableSequence {
         start..stop
     }
 
-    fn get_slice_items(
-        &self,
-        vm: &mut VirtualMachine,
-        slice: &PyObjectRef,
-    ) -> Result<Self, PyObjectRef>
+    fn get_slice_items(&self, vm: &VirtualMachine, slice: &PyObjectRef) -> Result<Self, PyObjectRef>
     where
         Self: Sized,
     {
@@ -142,7 +138,7 @@ impl<T: Clone> PySliceableSequence for Vec<T> {
 }
 
 pub fn get_item(
-    vm: &mut VirtualMachine,
+    vm: &VirtualMachine,
     sequence: &PyObjectRef,
     elements: &[PyObjectRef],
     subscript: PyObjectRef,
@@ -186,7 +182,7 @@ pub fn get_item(
 }
 
 pub fn seq_equal(
-    vm: &mut VirtualMachine,
+    vm: &VirtualMachine,
     zelf: &[PyObjectRef],
     other: &[PyObjectRef],
 ) -> Result<bool, PyObjectRef> {
@@ -207,7 +203,7 @@ pub fn seq_equal(
 }
 
 pub fn seq_lt(
-    vm: &mut VirtualMachine,
+    vm: &VirtualMachine,
     zelf: &[PyObjectRef],
     other: &[PyObjectRef],
 ) -> Result<bool, PyObjectRef> {
@@ -247,7 +243,7 @@ pub fn seq_lt(
 }
 
 pub fn seq_gt(
-    vm: &mut VirtualMachine,
+    vm: &VirtualMachine,
     zelf: &[PyObjectRef],
     other: &[PyObjectRef],
 ) -> Result<bool, PyObjectRef> {
@@ -286,7 +282,7 @@ pub fn seq_gt(
 }
 
 pub fn seq_ge(
-    vm: &mut VirtualMachine,
+    vm: &VirtualMachine,
     zelf: &[PyObjectRef],
     other: &[PyObjectRef],
 ) -> Result<bool, PyObjectRef> {
@@ -294,7 +290,7 @@ pub fn seq_ge(
 }
 
 pub fn seq_le(
-    vm: &mut VirtualMachine,
+    vm: &VirtualMachine,
     zelf: &[PyObjectRef],
     other: &[PyObjectRef],
 ) -> Result<bool, PyObjectRef> {

--- a/vm/src/obj/objset.rs
+++ b/vm/src/obj/objset.rs
@@ -32,7 +32,7 @@ impl fmt::Debug for PySet {
 }
 
 impl PyValue for PySet {
-    fn class(vm: &mut VirtualMachine) -> PyObjectRef {
+    fn class(vm: &VirtualMachine) -> PyObjectRef {
         vm.ctx.set_type()
     }
 }
@@ -42,10 +42,10 @@ pub fn get_elements(obj: &PyObjectRef) -> HashMap<u64, PyObjectRef> {
 }
 
 fn perform_action_with_hash(
-    vm: &mut VirtualMachine,
+    vm: &VirtualMachine,
     elements: &mut HashMap<u64, PyObjectRef>,
     item: &PyObjectRef,
-    f: &Fn(&mut VirtualMachine, &mut HashMap<u64, PyObjectRef>, u64, &PyObjectRef) -> PyResult,
+    f: &Fn(&VirtualMachine, &mut HashMap<u64, PyObjectRef>, u64, &PyObjectRef) -> PyResult,
 ) -> PyResult {
     let hash: PyObjectRef = vm.call_method(item, "__hash__", vec![])?;
 
@@ -57,12 +57,12 @@ fn perform_action_with_hash(
 }
 
 fn insert_into_set(
-    vm: &mut VirtualMachine,
+    vm: &VirtualMachine,
     elements: &mut HashMap<u64, PyObjectRef>,
     item: &PyObjectRef,
 ) -> PyResult {
     fn insert(
-        vm: &mut VirtualMachine,
+        vm: &VirtualMachine,
         elements: &mut HashMap<u64, PyObjectRef>,
         key: u64,
         value: &PyObjectRef,
@@ -73,7 +73,7 @@ fn insert_into_set(
     perform_action_with_hash(vm, elements, item, &insert)
 }
 
-fn set_add(vm: &mut VirtualMachine, args: PyFuncArgs) -> PyResult {
+fn set_add(vm: &VirtualMachine, args: PyFuncArgs) -> PyResult {
     trace!("set.add called with: {:?}", args);
     arg_check!(
         vm,
@@ -86,7 +86,7 @@ fn set_add(vm: &mut VirtualMachine, args: PyFuncArgs) -> PyResult {
     }
 }
 
-fn set_remove(vm: &mut VirtualMachine, args: PyFuncArgs) -> PyResult {
+fn set_remove(vm: &VirtualMachine, args: PyFuncArgs) -> PyResult {
     trace!("set.remove called with: {:?}", args);
     arg_check!(
         vm,
@@ -96,7 +96,7 @@ fn set_remove(vm: &mut VirtualMachine, args: PyFuncArgs) -> PyResult {
     match s.payload::<PySet>() {
         Some(set) => {
             fn remove(
-                vm: &mut VirtualMachine,
+                vm: &VirtualMachine,
                 elements: &mut HashMap<u64, PyObjectRef>,
                 key: u64,
                 value: &PyObjectRef,
@@ -115,7 +115,7 @@ fn set_remove(vm: &mut VirtualMachine, args: PyFuncArgs) -> PyResult {
     }
 }
 
-fn set_discard(vm: &mut VirtualMachine, args: PyFuncArgs) -> PyResult {
+fn set_discard(vm: &VirtualMachine, args: PyFuncArgs) -> PyResult {
     trace!("set.discard called with: {:?}", args);
     arg_check!(
         vm,
@@ -125,7 +125,7 @@ fn set_discard(vm: &mut VirtualMachine, args: PyFuncArgs) -> PyResult {
     match s.payload::<PySet>() {
         Some(set) => {
             fn discard(
-                vm: &mut VirtualMachine,
+                vm: &VirtualMachine,
                 elements: &mut HashMap<u64, PyObjectRef>,
                 key: u64,
                 _value: &PyObjectRef,
@@ -139,7 +139,7 @@ fn set_discard(vm: &mut VirtualMachine, args: PyFuncArgs) -> PyResult {
     }
 }
 
-fn set_clear(vm: &mut VirtualMachine, args: PyFuncArgs) -> PyResult {
+fn set_clear(vm: &VirtualMachine, args: PyFuncArgs) -> PyResult {
     trace!("set.clear called");
     arg_check!(vm, args, required = [(s, Some(vm.ctx.set_type()))]);
     match s.payload::<PySet>() {
@@ -155,7 +155,7 @@ fn set_clear(vm: &mut VirtualMachine, args: PyFuncArgs) -> PyResult {
 fn set_new(
     cls: PyClassRef,
     iterable: OptionalArg<PyObjectRef>,
-    vm: &mut VirtualMachine,
+    vm: &VirtualMachine,
 ) -> PyResult<PySetRef> {
     if !objtype::issubclass(cls.as_object(), &vm.ctx.set_type()) {
         return Err(vm.new_type_error(format!("{} is not a subtype of set", cls)));
@@ -179,14 +179,14 @@ fn set_new(
     .into_ref_with_type(vm, cls)
 }
 
-fn set_len(vm: &mut VirtualMachine, args: PyFuncArgs) -> PyResult {
+fn set_len(vm: &VirtualMachine, args: PyFuncArgs) -> PyResult {
     trace!("set.len called with: {:?}", args);
     arg_check!(vm, args, required = [(s, Some(vm.ctx.set_type()))]);
     let elements = get_elements(s);
     Ok(vm.context().new_int(elements.len()))
 }
 
-fn set_copy(obj: PySetRef, _vm: &mut VirtualMachine) -> PySet {
+fn set_copy(obj: PySetRef, _vm: &VirtualMachine) -> PySet {
     trace!("set.copy called with: {:?}", obj);
     let elements = obj.elements.borrow().clone();
     PySet {
@@ -194,7 +194,7 @@ fn set_copy(obj: PySetRef, _vm: &mut VirtualMachine) -> PySet {
     }
 }
 
-fn set_repr(vm: &mut VirtualMachine, args: PyFuncArgs) -> PyResult {
+fn set_repr(vm: &VirtualMachine, args: PyFuncArgs) -> PyResult {
     arg_check!(vm, args, required = [(o, Some(vm.ctx.set_type()))]);
 
     let elements = get_elements(o);
@@ -214,7 +214,7 @@ fn set_repr(vm: &mut VirtualMachine, args: PyFuncArgs) -> PyResult {
     Ok(vm.new_str(s))
 }
 
-pub fn set_contains(vm: &mut VirtualMachine, args: PyFuncArgs) -> PyResult {
+pub fn set_contains(vm: &VirtualMachine, args: PyFuncArgs) -> PyResult {
     arg_check!(
         vm,
         args,
@@ -234,7 +234,7 @@ pub fn set_contains(vm: &mut VirtualMachine, args: PyFuncArgs) -> PyResult {
     Ok(vm.new_bool(false))
 }
 
-fn set_eq(vm: &mut VirtualMachine, args: PyFuncArgs) -> PyResult {
+fn set_eq(vm: &VirtualMachine, args: PyFuncArgs) -> PyResult {
     set_compare_inner(
         vm,
         args,
@@ -243,7 +243,7 @@ fn set_eq(vm: &mut VirtualMachine, args: PyFuncArgs) -> PyResult {
     )
 }
 
-fn set_ge(vm: &mut VirtualMachine, args: PyFuncArgs) -> PyResult {
+fn set_ge(vm: &VirtualMachine, args: PyFuncArgs) -> PyResult {
     set_compare_inner(
         vm,
         args,
@@ -252,7 +252,7 @@ fn set_ge(vm: &mut VirtualMachine, args: PyFuncArgs) -> PyResult {
     )
 }
 
-fn set_gt(vm: &mut VirtualMachine, args: PyFuncArgs) -> PyResult {
+fn set_gt(vm: &VirtualMachine, args: PyFuncArgs) -> PyResult {
     set_compare_inner(
         vm,
         args,
@@ -261,7 +261,7 @@ fn set_gt(vm: &mut VirtualMachine, args: PyFuncArgs) -> PyResult {
     )
 }
 
-fn set_le(vm: &mut VirtualMachine, args: PyFuncArgs) -> PyResult {
+fn set_le(vm: &VirtualMachine, args: PyFuncArgs) -> PyResult {
     set_compare_inner(
         vm,
         args,
@@ -270,7 +270,7 @@ fn set_le(vm: &mut VirtualMachine, args: PyFuncArgs) -> PyResult {
     )
 }
 
-fn set_lt(vm: &mut VirtualMachine, args: PyFuncArgs) -> PyResult {
+fn set_lt(vm: &VirtualMachine, args: PyFuncArgs) -> PyResult {
     set_compare_inner(
         vm,
         args,
@@ -280,7 +280,7 @@ fn set_lt(vm: &mut VirtualMachine, args: PyFuncArgs) -> PyResult {
 }
 
 fn set_compare_inner(
-    vm: &mut VirtualMachine,
+    vm: &VirtualMachine,
     args: PyFuncArgs,
     size_func: &Fn(usize, usize) -> bool,
     swap: bool,
@@ -327,7 +327,7 @@ fn set_compare_inner(
     Ok(vm.new_bool(true))
 }
 
-fn set_union(zelf: PySetRef, other: PySetRef, _vm: &mut VirtualMachine) -> PySet {
+fn set_union(zelf: PySetRef, other: PySetRef, _vm: &VirtualMachine) -> PySet {
     let mut elements = zelf.elements.borrow().clone();
     elements.extend(other.elements.borrow().clone());
 
@@ -336,18 +336,18 @@ fn set_union(zelf: PySetRef, other: PySetRef, _vm: &mut VirtualMachine) -> PySet
     }
 }
 
-fn set_intersection(zelf: PySetRef, other: PySetRef, vm: &mut VirtualMachine) -> PyResult<PySet> {
+fn set_intersection(zelf: PySetRef, other: PySetRef, vm: &VirtualMachine) -> PyResult<PySet> {
     set_combine_inner(zelf, other, vm, SetCombineOperation::Intersection)
 }
 
-fn set_difference(zelf: PySetRef, other: PySetRef, vm: &mut VirtualMachine) -> PyResult<PySet> {
+fn set_difference(zelf: PySetRef, other: PySetRef, vm: &VirtualMachine) -> PyResult<PySet> {
     set_combine_inner(zelf, other, vm, SetCombineOperation::Difference)
 }
 
 fn set_symmetric_difference(
     zelf: PySetRef,
     other: PySetRef,
-    vm: &mut VirtualMachine,
+    vm: &VirtualMachine,
 ) -> PyResult<PySet> {
     let mut elements = HashMap::new();
 
@@ -378,7 +378,7 @@ enum SetCombineOperation {
 fn set_combine_inner(
     zelf: PySetRef,
     other: PySetRef,
-    vm: &mut VirtualMachine,
+    vm: &VirtualMachine,
     op: SetCombineOperation,
 ) -> PyResult<PySet> {
     let mut elements = HashMap::new();
@@ -399,7 +399,7 @@ fn set_combine_inner(
     })
 }
 
-fn set_pop(vm: &mut VirtualMachine, args: PyFuncArgs) -> PyResult {
+fn set_pop(vm: &VirtualMachine, args: PyFuncArgs) -> PyResult {
     arg_check!(vm, args, required = [(s, Some(vm.ctx.set_type()))]);
 
     match s.payload::<PySet>() {
@@ -414,12 +414,12 @@ fn set_pop(vm: &mut VirtualMachine, args: PyFuncArgs) -> PyResult {
     }
 }
 
-fn set_update(vm: &mut VirtualMachine, args: PyFuncArgs) -> PyResult {
+fn set_update(vm: &VirtualMachine, args: PyFuncArgs) -> PyResult {
     set_ior(vm, args)?;
     Ok(vm.get_none())
 }
 
-fn set_ior(vm: &mut VirtualMachine, args: PyFuncArgs) -> PyResult {
+fn set_ior(vm: &VirtualMachine, args: PyFuncArgs) -> PyResult {
     arg_check!(
         vm,
         args,
@@ -438,26 +438,26 @@ fn set_ior(vm: &mut VirtualMachine, args: PyFuncArgs) -> PyResult {
     Ok(zelf.clone())
 }
 
-fn set_intersection_update(vm: &mut VirtualMachine, args: PyFuncArgs) -> PyResult {
+fn set_intersection_update(vm: &VirtualMachine, args: PyFuncArgs) -> PyResult {
     set_combine_update_inner(vm, args, SetCombineOperation::Intersection)?;
     Ok(vm.get_none())
 }
 
-fn set_iand(vm: &mut VirtualMachine, args: PyFuncArgs) -> PyResult {
+fn set_iand(vm: &VirtualMachine, args: PyFuncArgs) -> PyResult {
     set_combine_update_inner(vm, args, SetCombineOperation::Intersection)
 }
 
-fn set_difference_update(vm: &mut VirtualMachine, args: PyFuncArgs) -> PyResult {
+fn set_difference_update(vm: &VirtualMachine, args: PyFuncArgs) -> PyResult {
     set_combine_update_inner(vm, args, SetCombineOperation::Difference)?;
     Ok(vm.get_none())
 }
 
-fn set_isub(vm: &mut VirtualMachine, args: PyFuncArgs) -> PyResult {
+fn set_isub(vm: &VirtualMachine, args: PyFuncArgs) -> PyResult {
     set_combine_update_inner(vm, args, SetCombineOperation::Difference)
 }
 
 fn set_combine_update_inner(
-    vm: &mut VirtualMachine,
+    vm: &VirtualMachine,
     args: PyFuncArgs,
     op: SetCombineOperation,
 ) -> PyResult {
@@ -486,12 +486,12 @@ fn set_combine_update_inner(
     Ok(zelf.clone())
 }
 
-fn set_symmetric_difference_update(vm: &mut VirtualMachine, args: PyFuncArgs) -> PyResult {
+fn set_symmetric_difference_update(vm: &VirtualMachine, args: PyFuncArgs) -> PyResult {
     set_ixor(vm, args)?;
     Ok(vm.get_none())
 }
 
-fn set_ixor(vm: &mut VirtualMachine, args: PyFuncArgs) -> PyResult {
+fn set_ixor(vm: &VirtualMachine, args: PyFuncArgs) -> PyResult {
     arg_check!(
         vm,
         args,
@@ -518,7 +518,7 @@ fn set_ixor(vm: &mut VirtualMachine, args: PyFuncArgs) -> PyResult {
     Ok(zelf.clone())
 }
 
-fn set_iter(zelf: PySetRef, vm: &mut VirtualMachine) -> PyIteratorValue {
+fn set_iter(zelf: PySetRef, vm: &VirtualMachine) -> PyIteratorValue {
     let items = zelf.elements.borrow().values().cloned().collect();
     let set_list = vm.ctx.new_list(items);
     PyIteratorValue {
@@ -527,7 +527,7 @@ fn set_iter(zelf: PySetRef, vm: &mut VirtualMachine) -> PyIteratorValue {
     }
 }
 
-fn frozenset_repr(vm: &mut VirtualMachine, args: PyFuncArgs) -> PyResult {
+fn frozenset_repr(vm: &VirtualMachine, args: PyFuncArgs) -> PyResult {
     arg_check!(vm, args, required = [(o, Some(vm.ctx.frozenset_type()))]);
 
     let elements = get_elements(o);

--- a/vm/src/obj/objslice.rs
+++ b/vm/src/obj/objslice.rs
@@ -15,12 +15,12 @@ pub struct PySlice {
 }
 
 impl PyValue for PySlice {
-    fn class(vm: &mut VirtualMachine) -> PyObjectRef {
+    fn class(vm: &VirtualMachine) -> PyObjectRef {
         vm.ctx.slice_type()
     }
 }
 
-fn slice_new(vm: &mut VirtualMachine, args: PyFuncArgs) -> PyResult {
+fn slice_new(vm: &VirtualMachine, args: PyFuncArgs) -> PyResult {
     no_kwargs!(vm, args);
     let (cls, start, stop, step): (
         &PyObjectRef,
@@ -64,7 +64,7 @@ fn slice_new(vm: &mut VirtualMachine, args: PyFuncArgs) -> PyResult {
     ))
 }
 
-fn get_property_value(vm: &mut VirtualMachine, value: &Option<BigInt>) -> PyResult {
+fn get_property_value(vm: &VirtualMachine, value: &Option<BigInt>) -> PyResult {
     if let Some(value) = value {
         Ok(vm.ctx.new_int(value.clone()))
     } else {
@@ -72,7 +72,7 @@ fn get_property_value(vm: &mut VirtualMachine, value: &Option<BigInt>) -> PyResu
     }
 }
 
-fn slice_start(vm: &mut VirtualMachine, args: PyFuncArgs) -> PyResult {
+fn slice_start(vm: &VirtualMachine, args: PyFuncArgs) -> PyResult {
     arg_check!(vm, args, required = [(slice, Some(vm.ctx.slice_type()))]);
     if let Some(PySlice { start, .. }) = &slice.payload() {
         get_property_value(vm, start)
@@ -81,7 +81,7 @@ fn slice_start(vm: &mut VirtualMachine, args: PyFuncArgs) -> PyResult {
     }
 }
 
-fn slice_stop(vm: &mut VirtualMachine, args: PyFuncArgs) -> PyResult {
+fn slice_stop(vm: &VirtualMachine, args: PyFuncArgs) -> PyResult {
     arg_check!(vm, args, required = [(slice, Some(vm.ctx.slice_type()))]);
     if let Some(PySlice { stop, .. }) = &slice.payload() {
         get_property_value(vm, stop)
@@ -90,7 +90,7 @@ fn slice_stop(vm: &mut VirtualMachine, args: PyFuncArgs) -> PyResult {
     }
 }
 
-fn slice_step(vm: &mut VirtualMachine, args: PyFuncArgs) -> PyResult {
+fn slice_step(vm: &VirtualMachine, args: PyFuncArgs) -> PyResult {
     arg_check!(vm, args, required = [(slice, Some(vm.ctx.slice_type()))]);
     if let Some(PySlice { step, .. }) = &slice.payload() {
         get_property_value(vm, step)

--- a/vm/src/obj/objstaticmethod.rs
+++ b/vm/src/obj/objstaticmethod.rs
@@ -11,7 +11,7 @@ pub fn init(context: &PyContext) {
 }
 
 // `staticmethod` methods.
-fn staticmethod_get(vm: &mut VirtualMachine, args: PyFuncArgs) -> PyResult {
+fn staticmethod_get(vm: &VirtualMachine, args: PyFuncArgs) -> PyResult {
     trace!("staticmethod.__get__ {:?}", args.args);
     arg_check!(
         vm,
@@ -30,7 +30,7 @@ fn staticmethod_get(vm: &mut VirtualMachine, args: PyFuncArgs) -> PyResult {
     }
 }
 
-fn staticmethod_new(vm: &mut VirtualMachine, args: PyFuncArgs) -> PyResult {
+fn staticmethod_new(vm: &VirtualMachine, args: PyFuncArgs) -> PyResult {
     trace!("staticmethod.__new__ {:?}", args.args);
     arg_check!(vm, args, required = [(cls, None), (callable, None)]);
 

--- a/vm/src/obj/objstr.rs
+++ b/vm/src/obj/objstr.rs
@@ -34,13 +34,13 @@ impl fmt::Display for PyString {
 }
 
 impl TryIntoRef<PyString> for String {
-    fn try_into_ref(self, vm: &mut VirtualMachine) -> PyResult<PyRef<PyString>> {
+    fn try_into_ref(self, vm: &VirtualMachine) -> PyResult<PyRef<PyString>> {
         Ok(PyString { value: self }.into_ref(vm))
     }
 }
 
 impl TryIntoRef<PyString> for &str {
-    fn try_into_ref(self, vm: &mut VirtualMachine) -> PyResult<PyRef<PyString>> {
+    fn try_into_ref(self, vm: &VirtualMachine) -> PyResult<PyRef<PyString>> {
         Ok(PyString {
             value: self.to_string(),
         }
@@ -49,7 +49,7 @@ impl TryIntoRef<PyString> for &str {
 }
 
 impl PyStringRef {
-    fn add(self, rhs: PyObjectRef, vm: &mut VirtualMachine) -> PyResult<String> {
+    fn add(self, rhs: PyObjectRef, vm: &VirtualMachine) -> PyResult<String> {
         if objtype::isinstance(&rhs, &vm.ctx.str_type()) {
             Ok(format!("{}{}", self.value, get_value(&rhs)))
         } else {
@@ -57,7 +57,7 @@ impl PyStringRef {
         }
     }
 
-    fn eq(self, rhs: PyObjectRef, vm: &mut VirtualMachine) -> bool {
+    fn eq(self, rhs: PyObjectRef, vm: &VirtualMachine) -> bool {
         if objtype::isinstance(&rhs, &vm.ctx.str_type()) {
             self.value == get_value(&rhs)
         } else {
@@ -65,15 +65,15 @@ impl PyStringRef {
         }
     }
 
-    fn contains(self, needle: PyStringRef, _vm: &mut VirtualMachine) -> bool {
+    fn contains(self, needle: PyStringRef, _vm: &VirtualMachine) -> bool {
         self.value.contains(&needle.value)
     }
 
-    fn getitem(self, needle: PyObjectRef, vm: &mut VirtualMachine) -> PyResult {
+    fn getitem(self, needle: PyObjectRef, vm: &VirtualMachine) -> PyResult {
         subscript(vm, &self.value, needle)
     }
 
-    fn gt(self, rhs: PyObjectRef, vm: &mut VirtualMachine) -> PyResult<bool> {
+    fn gt(self, rhs: PyObjectRef, vm: &VirtualMachine) -> PyResult<bool> {
         if objtype::isinstance(&rhs, &vm.ctx.str_type()) {
             Ok(self.value > get_value(&rhs))
         } else {
@@ -81,7 +81,7 @@ impl PyStringRef {
         }
     }
 
-    fn ge(self, rhs: PyObjectRef, vm: &mut VirtualMachine) -> PyResult<bool> {
+    fn ge(self, rhs: PyObjectRef, vm: &VirtualMachine) -> PyResult<bool> {
         if objtype::isinstance(&rhs, &vm.ctx.str_type()) {
             Ok(self.value >= get_value(&rhs))
         } else {
@@ -89,7 +89,7 @@ impl PyStringRef {
         }
     }
 
-    fn lt(self, rhs: PyObjectRef, vm: &mut VirtualMachine) -> PyResult<bool> {
+    fn lt(self, rhs: PyObjectRef, vm: &VirtualMachine) -> PyResult<bool> {
         if objtype::isinstance(&rhs, &vm.ctx.str_type()) {
             Ok(self.value < get_value(&rhs))
         } else {
@@ -97,7 +97,7 @@ impl PyStringRef {
         }
     }
 
-    fn le(self, rhs: PyObjectRef, vm: &mut VirtualMachine) -> PyResult<bool> {
+    fn le(self, rhs: PyObjectRef, vm: &VirtualMachine) -> PyResult<bool> {
         if objtype::isinstance(&rhs, &vm.ctx.str_type()) {
             Ok(self.value <= get_value(&rhs))
         } else {
@@ -105,17 +105,17 @@ impl PyStringRef {
         }
     }
 
-    fn hash(self, _vm: &mut VirtualMachine) -> usize {
+    fn hash(self, _vm: &VirtualMachine) -> usize {
         let mut hasher = std::collections::hash_map::DefaultHasher::new();
         self.value.hash(&mut hasher);
         hasher.finish() as usize
     }
 
-    fn len(self, _vm: &mut VirtualMachine) -> usize {
+    fn len(self, _vm: &VirtualMachine) -> usize {
         self.value.chars().count()
     }
 
-    fn mul(self, val: PyObjectRef, vm: &mut VirtualMachine) -> PyResult<String> {
+    fn mul(self, val: PyObjectRef, vm: &VirtualMachine) -> PyResult<String> {
         if objtype::isinstance(&val, &vm.ctx.int_type()) {
             let value = &self.value;
             let multiplier = objint::get_value(&val).to_i32().unwrap();
@@ -129,11 +129,11 @@ impl PyStringRef {
         }
     }
 
-    fn str(self, _vm: &mut VirtualMachine) -> PyStringRef {
+    fn str(self, _vm: &VirtualMachine) -> PyStringRef {
         self
     }
 
-    fn repr(self, _vm: &mut VirtualMachine) -> String {
+    fn repr(self, _vm: &VirtualMachine) -> String {
         let value = &self.value;
         let quote_char = if count_char(value, '\'') > count_char(value, '"') {
             '"'
@@ -163,20 +163,20 @@ impl PyStringRef {
         formatted
     }
 
-    fn lower(self, _vm: &mut VirtualMachine) -> String {
+    fn lower(self, _vm: &VirtualMachine) -> String {
         self.value.to_lowercase()
     }
 
     // casefold is much more aggressive than lower
-    fn casefold(self, _vm: &mut VirtualMachine) -> String {
+    fn casefold(self, _vm: &VirtualMachine) -> String {
         caseless::default_case_fold_str(&self.value)
     }
 
-    fn upper(self, _vm: &mut VirtualMachine) -> String {
+    fn upper(self, _vm: &VirtualMachine) -> String {
         self.value.to_uppercase()
     }
 
-    fn capitalize(self, _vm: &mut VirtualMachine) -> String {
+    fn capitalize(self, _vm: &VirtualMachine) -> String {
         let (first_part, lower_str) = self.value.split_at(1);
         format!("{}{}", first_part.to_uppercase(), lower_str)
     }
@@ -185,7 +185,7 @@ impl PyStringRef {
         self,
         pattern: OptionalArg<Self>,
         num: OptionalArg<usize>,
-        vm: &mut VirtualMachine,
+        vm: &VirtualMachine,
     ) -> PyObjectRef {
         let value = &self.value;
         let pattern = match pattern {
@@ -206,7 +206,7 @@ impl PyStringRef {
         self,
         pattern: OptionalArg<Self>,
         num: OptionalArg<usize>,
-        vm: &mut VirtualMachine,
+        vm: &VirtualMachine,
     ) -> PyObjectRef {
         let value = &self.value;
         let pattern = match pattern {
@@ -223,15 +223,15 @@ impl PyStringRef {
         vm.ctx.new_list(elements)
     }
 
-    fn strip(self, _vm: &mut VirtualMachine) -> String {
+    fn strip(self, _vm: &VirtualMachine) -> String {
         self.value.trim().to_string()
     }
 
-    fn lstrip(self, _vm: &mut VirtualMachine) -> String {
+    fn lstrip(self, _vm: &VirtualMachine) -> String {
         self.value.trim_start().to_string()
     }
 
-    fn rstrip(self, _vm: &mut VirtualMachine) -> String {
+    fn rstrip(self, _vm: &VirtualMachine) -> String {
         self.value.trim_end().to_string()
     }
 
@@ -240,7 +240,7 @@ impl PyStringRef {
         suffix: PyStringRef,
         start: OptionalArg<isize>,
         end: OptionalArg<isize>,
-        _vm: &mut VirtualMachine,
+        _vm: &VirtualMachine,
     ) -> bool {
         if let Some((start, end)) = adjust_indices(start, end, self.value.len()) {
             self.value[start..end].ends_with(&suffix.value)
@@ -254,7 +254,7 @@ impl PyStringRef {
         prefix: PyStringRef,
         start: OptionalArg<isize>,
         end: OptionalArg<isize>,
-        _vm: &mut VirtualMachine,
+        _vm: &VirtualMachine,
     ) -> bool {
         if let Some((start, end)) = adjust_indices(start, end, self.value.len()) {
             self.value[start..end].starts_with(&prefix.value)
@@ -263,15 +263,15 @@ impl PyStringRef {
         }
     }
 
-    fn isalnum(self, _vm: &mut VirtualMachine) -> bool {
+    fn isalnum(self, _vm: &VirtualMachine) -> bool {
         !self.value.is_empty() && self.value.chars().all(char::is_alphanumeric)
     }
 
-    fn isnumeric(self, _vm: &mut VirtualMachine) -> bool {
+    fn isnumeric(self, _vm: &VirtualMachine) -> bool {
         !self.value.is_empty() && self.value.chars().all(char::is_numeric)
     }
 
-    fn isdigit(self, _vm: &mut VirtualMachine) -> bool {
+    fn isdigit(self, _vm: &VirtualMachine) -> bool {
         // python's isdigit also checks if exponents are digits, these are the unicodes for exponents
         let valid_unicodes: [u16; 10] = [
             0x2070, 0x00B9, 0x00B2, 0x00B3, 0x2074, 0x2075, 0x2076, 0x2077, 0x2078, 0x2079,
@@ -287,7 +287,7 @@ impl PyStringRef {
         }
     }
 
-    fn isdecimal(self, _vm: &mut VirtualMachine) -> bool {
+    fn isdecimal(self, _vm: &VirtualMachine) -> bool {
         if self.value.is_empty() {
             false
         } else {
@@ -295,11 +295,11 @@ impl PyStringRef {
         }
     }
 
-    fn title(self, _vm: &mut VirtualMachine) -> String {
+    fn title(self, _vm: &VirtualMachine) -> String {
         make_title(&self.value)
     }
 
-    fn swapcase(self, _vm: &mut VirtualMachine) -> String {
+    fn swapcase(self, _vm: &VirtualMachine) -> String {
         let mut swapped_str = String::with_capacity(self.value.len());
         for c in self.value.chars() {
             // to_uppercase returns an iterator, to_ascii_uppercase returns the char
@@ -314,7 +314,7 @@ impl PyStringRef {
         swapped_str
     }
 
-    fn isalpha(self, _vm: &mut VirtualMachine) -> bool {
+    fn isalpha(self, _vm: &VirtualMachine) -> bool {
         !self.value.is_empty() && self.value.chars().all(char::is_alphanumeric)
     }
 
@@ -323,7 +323,7 @@ impl PyStringRef {
         old: Self,
         new: Self,
         num: OptionalArg<usize>,
-        _vm: &mut VirtualMachine,
+        _vm: &VirtualMachine,
     ) -> String {
         match num.into_option() {
             Some(num) => self.value.replacen(&old.value, &new.value, num),
@@ -333,11 +333,11 @@ impl PyStringRef {
 
     // cpython's isspace ignores whitespace, including \t and \n, etc, unless the whole string is empty
     // which is why isspace is using is_ascii_whitespace. Same for isupper & islower
-    fn isspace(self, _vm: &mut VirtualMachine) -> bool {
+    fn isspace(self, _vm: &VirtualMachine) -> bool {
         !self.value.is_empty() && self.value.chars().all(|c| c.is_ascii_whitespace())
     }
 
-    fn isupper(self, _vm: &mut VirtualMachine) -> bool {
+    fn isupper(self, _vm: &VirtualMachine) -> bool {
         !self.value.is_empty()
             && self
                 .value
@@ -346,7 +346,7 @@ impl PyStringRef {
                 .all(char::is_uppercase)
     }
 
-    fn islower(self, _vm: &mut VirtualMachine) -> bool {
+    fn islower(self, _vm: &VirtualMachine) -> bool {
         !self.value.is_empty()
             && self
                 .value
@@ -355,12 +355,12 @@ impl PyStringRef {
                 .all(char::is_lowercase)
     }
 
-    fn isascii(self, _vm: &mut VirtualMachine) -> bool {
+    fn isascii(self, _vm: &VirtualMachine) -> bool {
         !self.value.is_empty() && self.value.chars().all(|c| c.is_ascii())
     }
 
     // doesn't implement keep new line delimiter just yet
-    fn splitlines(self, vm: &mut VirtualMachine) -> PyObjectRef {
+    fn splitlines(self, vm: &VirtualMachine) -> PyObjectRef {
         let elements = self
             .value
             .split('\n')
@@ -369,7 +369,7 @@ impl PyStringRef {
         vm.ctx.new_list(elements)
     }
 
-    fn join(self, iterable: PyIterable<PyStringRef>, vm: &mut VirtualMachine) -> PyResult<String> {
+    fn join(self, iterable: PyIterable<PyStringRef>, vm: &VirtualMachine) -> PyResult<String> {
         let mut joined = String::new();
 
         for (idx, elem) in iterable.iter(vm)?.enumerate() {
@@ -388,7 +388,7 @@ impl PyStringRef {
         sub: Self,
         start: OptionalArg<isize>,
         end: OptionalArg<isize>,
-        _vm: &mut VirtualMachine,
+        _vm: &VirtualMachine,
     ) -> isize {
         let value = &self.value;
         if let Some((start, end)) = adjust_indices(start, end, value.len()) {
@@ -406,7 +406,7 @@ impl PyStringRef {
         sub: Self,
         start: OptionalArg<isize>,
         end: OptionalArg<isize>,
-        _vm: &mut VirtualMachine,
+        _vm: &VirtualMachine,
     ) -> isize {
         let value = &self.value;
         if let Some((start, end)) = adjust_indices(start, end, value.len()) {
@@ -424,7 +424,7 @@ impl PyStringRef {
         sub: Self,
         start: OptionalArg<isize>,
         end: OptionalArg<isize>,
-        vm: &mut VirtualMachine,
+        vm: &VirtualMachine,
     ) -> PyResult<usize> {
         let value = &self.value;
         if let Some((start, end)) = adjust_indices(start, end, value.len()) {
@@ -442,7 +442,7 @@ impl PyStringRef {
         sub: Self,
         start: OptionalArg<isize>,
         end: OptionalArg<isize>,
-        vm: &mut VirtualMachine,
+        vm: &VirtualMachine,
     ) -> PyResult<usize> {
         let value = &self.value;
         if let Some((start, end)) = adjust_indices(start, end, value.len()) {
@@ -455,7 +455,7 @@ impl PyStringRef {
         }
     }
 
-    fn partition(self, sub: PyStringRef, vm: &mut VirtualMachine) -> PyObjectRef {
+    fn partition(self, sub: PyStringRef, vm: &VirtualMachine) -> PyObjectRef {
         let value = &self.value;
         let sub = &sub.value;
         let mut new_tup = Vec::new();
@@ -473,7 +473,7 @@ impl PyStringRef {
         vm.ctx.new_tuple(new_tup)
     }
 
-    fn rpartition(self, sub: PyStringRef, vm: &mut VirtualMachine) -> PyObjectRef {
+    fn rpartition(self, sub: PyStringRef, vm: &VirtualMachine) -> PyObjectRef {
         let value = &self.value;
         let sub = &sub.value;
         let mut new_tup = Vec::new();
@@ -492,7 +492,7 @@ impl PyStringRef {
         vm.ctx.new_tuple(new_tup)
     }
 
-    fn istitle(self, _vm: &mut VirtualMachine) -> bool {
+    fn istitle(self, _vm: &VirtualMachine) -> bool {
         if self.value.is_empty() {
             false
         } else {
@@ -505,7 +505,7 @@ impl PyStringRef {
         sub: Self,
         start: OptionalArg<isize>,
         end: OptionalArg<isize>,
-        _vm: &mut VirtualMachine,
+        _vm: &VirtualMachine,
     ) -> usize {
         let value = &self.value;
         if let Some((start, end)) = adjust_indices(start, end, value.len()) {
@@ -515,7 +515,7 @@ impl PyStringRef {
         }
     }
 
-    fn zfill(self, len: usize, _vm: &mut VirtualMachine) -> String {
+    fn zfill(self, len: usize, _vm: &VirtualMachine) -> String {
         let value = &self.value;
         if len <= value.len() {
             value.to_string()
@@ -524,7 +524,7 @@ impl PyStringRef {
         }
     }
 
-    fn get_fill_char<'a>(rep: &'a OptionalArg<Self>, vm: &mut VirtualMachine) -> PyResult<&'a str> {
+    fn get_fill_char<'a>(rep: &'a OptionalArg<Self>, vm: &VirtualMachine) -> PyResult<&'a str> {
         let rep_str = match rep {
             OptionalArg::Present(ref st) => &st.value,
             OptionalArg::Missing => " ",
@@ -538,34 +538,19 @@ impl PyStringRef {
         }
     }
 
-    fn ljust(
-        self,
-        len: usize,
-        rep: OptionalArg<Self>,
-        vm: &mut VirtualMachine,
-    ) -> PyResult<String> {
+    fn ljust(self, len: usize, rep: OptionalArg<Self>, vm: &VirtualMachine) -> PyResult<String> {
         let value = &self.value;
         let rep_char = PyStringRef::get_fill_char(&rep, vm)?;
         Ok(format!("{}{}", value, rep_char.repeat(len)))
     }
 
-    fn rjust(
-        self,
-        len: usize,
-        rep: OptionalArg<Self>,
-        vm: &mut VirtualMachine,
-    ) -> PyResult<String> {
+    fn rjust(self, len: usize, rep: OptionalArg<Self>, vm: &VirtualMachine) -> PyResult<String> {
         let value = &self.value;
         let rep_char = PyStringRef::get_fill_char(&rep, vm)?;
         Ok(format!("{}{}", rep_char.repeat(len), value))
     }
 
-    fn center(
-        self,
-        len: usize,
-        rep: OptionalArg<Self>,
-        vm: &mut VirtualMachine,
-    ) -> PyResult<String> {
+    fn center(self, len: usize, rep: OptionalArg<Self>, vm: &VirtualMachine) -> PyResult<String> {
         let value = &self.value;
         let rep_char = PyStringRef::get_fill_char(&rep, vm)?;
         let left_buff: usize = (len - value.len()) / 2;
@@ -578,7 +563,7 @@ impl PyStringRef {
         ))
     }
 
-    fn expandtabs(self, tab_stop: OptionalArg<usize>, _vm: &mut VirtualMachine) -> String {
+    fn expandtabs(self, tab_stop: OptionalArg<usize>, _vm: &VirtualMachine) -> String {
         let tab_stop = tab_stop.into_option().unwrap_or(8 as usize);
         let mut expanded_str = String::new();
         let mut tab_size = tab_stop;
@@ -601,7 +586,7 @@ impl PyStringRef {
         expanded_str
     }
 
-    fn isidentifier(self, _vm: &mut VirtualMachine) -> bool {
+    fn isidentifier(self, _vm: &VirtualMachine) -> bool {
         let value = &self.value;
         // a string is not an identifier if it has whitespace or starts with a number
         if !value.chars().any(|c| c.is_ascii_whitespace())
@@ -620,13 +605,13 @@ impl PyStringRef {
 }
 
 impl PyValue for PyString {
-    fn class(vm: &mut VirtualMachine) -> PyObjectRef {
+    fn class(vm: &VirtualMachine) -> PyObjectRef {
         vm.ctx.str_type()
     }
 }
 
 impl IntoPyObject for String {
-    fn into_pyobject(self, vm: &mut VirtualMachine) -> PyResult {
+    fn into_pyobject(self, vm: &VirtualMachine) -> PyResult {
         Ok(vm.ctx.new_str(self))
     }
 }
@@ -713,7 +698,7 @@ fn count_char(s: &str, c: char) -> usize {
     s.chars().filter(|x| *x == c).count()
 }
 
-fn str_format(vm: &mut VirtualMachine, args: PyFuncArgs) -> PyResult {
+fn str_format(vm: &VirtualMachine, args: PyFuncArgs) -> PyResult {
     if args.args.is_empty() {
         return Err(
             vm.new_type_error("descriptor 'format' of 'str' object needs an argument".to_string())
@@ -741,11 +726,7 @@ fn str_format(vm: &mut VirtualMachine, args: PyFuncArgs) -> PyResult {
     }
 }
 
-fn call_object_format(
-    vm: &mut VirtualMachine,
-    argument: PyObjectRef,
-    format_spec: &str,
-) -> PyResult {
+fn call_object_format(vm: &VirtualMachine, argument: PyObjectRef, format_spec: &str) -> PyResult {
     let returned_type = vm.ctx.new_str(format_spec.to_string());
     let result = vm.call_method(&argument, "__format__", vec![returned_type])?;
     if !objtype::isinstance(&result, &vm.ctx.str_type()) {
@@ -757,7 +738,7 @@ fn call_object_format(
 }
 
 fn perform_format(
-    vm: &mut VirtualMachine,
+    vm: &VirtualMachine,
     format_string: &FormatString,
     arguments: &PyFuncArgs,
 ) -> PyResult {
@@ -814,7 +795,7 @@ fn perform_format(
 fn str_new(
     cls: PyClassRef,
     object: OptionalArg<PyObjectRef>,
-    vm: &mut VirtualMachine,
+    vm: &VirtualMachine,
 ) -> PyResult<PyStringRef> {
     let string = match object {
         OptionalArg::Present(ref input) => vm.to_str(input)?.into_object(),
@@ -890,7 +871,7 @@ fn to_graphemes<S: AsRef<str>>(value: S) -> Vec<String> {
         .collect()
 }
 
-pub fn subscript(vm: &mut VirtualMachine, value: &str, b: PyObjectRef) -> PyResult {
+pub fn subscript(vm: &VirtualMachine, value: &str, b: PyObjectRef) -> PyResult {
     if objtype::isinstance(&b, &vm.ctx.int_type()) {
         match objint::get_value(&b).to_i32() {
             Some(pos) => {

--- a/vm/src/obj/objsuper.rs
+++ b/vm/src/obj/objsuper.rs
@@ -21,7 +21,7 @@ pub struct PySuper {
 }
 
 impl PyValue for PySuper {
-    fn class(vm: &mut VirtualMachine) -> PyObjectRef {
+    fn class(vm: &VirtualMachine) -> PyObjectRef {
         vm.ctx.super_type()
     }
 }
@@ -56,7 +56,7 @@ pub fn init(context: &PyContext) {
     );
 }
 
-fn super_getattribute(vm: &mut VirtualMachine, args: PyFuncArgs) -> PyResult {
+fn super_getattribute(vm: &VirtualMachine, args: PyFuncArgs) -> PyResult {
     arg_check!(
         vm,
         args,
@@ -81,7 +81,7 @@ fn super_getattribute(vm: &mut VirtualMachine, args: PyFuncArgs) -> PyResult {
     }
 }
 
-fn super_new(vm: &mut VirtualMachine, args: PyFuncArgs) -> PyResult {
+fn super_new(vm: &VirtualMachine, args: PyFuncArgs) -> PyResult {
     trace!("super.__new__ {:?}", args.args);
     arg_check!(
         vm,

--- a/vm/src/obj/objtuple.rs
+++ b/vm/src/obj/objtuple.rs
@@ -38,7 +38,7 @@ impl From<Vec<PyObjectRef>> for PyTuple {
 }
 
 impl PyValue for PyTuple {
-    fn class(vm: &mut VirtualMachine) -> PyObjectRef {
+    fn class(vm: &VirtualMachine) -> PyObjectRef {
         vm.ctx.tuple_type()
     }
 }
@@ -46,7 +46,7 @@ impl PyValue for PyTuple {
 pub type PyTupleRef = PyRef<PyTuple>;
 
 impl PyTupleRef {
-    fn lt(self, other: PyObjectRef, vm: &mut VirtualMachine) -> PyResult {
+    fn lt(self, other: PyObjectRef, vm: &VirtualMachine) -> PyResult {
         if objtype::isinstance(&other, &vm.ctx.tuple_type()) {
             let zelf = self.elements.borrow();
             let other = get_elements(&other);
@@ -57,7 +57,7 @@ impl PyTupleRef {
         }
     }
 
-    fn gt(self, other: PyObjectRef, vm: &mut VirtualMachine) -> PyResult {
+    fn gt(self, other: PyObjectRef, vm: &VirtualMachine) -> PyResult {
         if objtype::isinstance(&other, &vm.ctx.tuple_type()) {
             let zelf = self.elements.borrow();
             let other = get_elements(&other);
@@ -68,7 +68,7 @@ impl PyTupleRef {
         }
     }
 
-    fn ge(self, other: PyObjectRef, vm: &mut VirtualMachine) -> PyResult {
+    fn ge(self, other: PyObjectRef, vm: &VirtualMachine) -> PyResult {
         if objtype::isinstance(&other, &vm.ctx.tuple_type()) {
             let zelf = self.elements.borrow();
             let other = get_elements(&other);
@@ -79,7 +79,7 @@ impl PyTupleRef {
         }
     }
 
-    fn le(self, other: PyObjectRef, vm: &mut VirtualMachine) -> PyResult {
+    fn le(self, other: PyObjectRef, vm: &VirtualMachine) -> PyResult {
         if objtype::isinstance(&other, &vm.ctx.tuple_type()) {
             let zelf = self.elements.borrow();
             let other = get_elements(&other);
@@ -90,7 +90,7 @@ impl PyTupleRef {
         }
     }
 
-    fn add(self, other: PyObjectRef, vm: &mut VirtualMachine) -> PyResult {
+    fn add(self, other: PyObjectRef, vm: &VirtualMachine) -> PyResult {
         if objtype::isinstance(&other, &vm.ctx.tuple_type()) {
             let e1 = self.elements.borrow();
             let e2 = get_elements(&other);
@@ -101,7 +101,7 @@ impl PyTupleRef {
         }
     }
 
-    fn count(self, needle: PyObjectRef, vm: &mut VirtualMachine) -> PyResult<usize> {
+    fn count(self, needle: PyObjectRef, vm: &VirtualMachine) -> PyResult<usize> {
         let mut count: usize = 0;
         for element in self.elements.borrow().iter() {
             if element.is(&needle) {
@@ -116,7 +116,7 @@ impl PyTupleRef {
         Ok(count)
     }
 
-    fn eq(self, other: PyObjectRef, vm: &mut VirtualMachine) -> PyResult {
+    fn eq(self, other: PyObjectRef, vm: &VirtualMachine) -> PyResult {
         if objtype::isinstance(&other, &vm.ctx.tuple_type()) {
             let zelf = &self.elements.borrow();
             let other = get_elements(&other);
@@ -127,7 +127,7 @@ impl PyTupleRef {
         }
     }
 
-    fn hash(self, vm: &mut VirtualMachine) -> PyResult<u64> {
+    fn hash(self, vm: &VirtualMachine) -> PyResult<u64> {
         let mut hasher = std::collections::hash_map::DefaultHasher::new();
         for element in self.elements.borrow().iter() {
             let hash_result = vm.call_method(element, "__hash__", vec![])?;
@@ -137,18 +137,18 @@ impl PyTupleRef {
         Ok(hasher.finish())
     }
 
-    fn iter(self, _vm: &mut VirtualMachine) -> PyIteratorValue {
+    fn iter(self, _vm: &VirtualMachine) -> PyIteratorValue {
         PyIteratorValue {
             position: Cell::new(0),
             iterated_obj: self.into_object(),
         }
     }
 
-    fn len(self, _vm: &mut VirtualMachine) -> usize {
+    fn len(self, _vm: &VirtualMachine) -> usize {
         self.elements.borrow().len()
     }
 
-    fn repr(self, vm: &mut VirtualMachine) -> PyResult<String> {
+    fn repr(self, vm: &VirtualMachine) -> PyResult<String> {
         let s = if let Some(_guard) = ReprGuard::enter(self.as_object()) {
             let mut str_parts = vec![];
             for elem in self.elements.borrow().iter() {
@@ -167,12 +167,12 @@ impl PyTupleRef {
         Ok(s)
     }
 
-    fn mul(self, counter: isize, vm: &mut VirtualMachine) -> PyObjectRef {
+    fn mul(self, counter: isize, vm: &VirtualMachine) -> PyObjectRef {
         let new_elements = seq_mul(&self.elements.borrow(), counter);
         vm.ctx.new_tuple(new_elements)
     }
 
-    fn getitem(self, needle: PyObjectRef, vm: &mut VirtualMachine) -> PyResult {
+    fn getitem(self, needle: PyObjectRef, vm: &VirtualMachine) -> PyResult {
         get_item(
             vm,
             self.as_object(),
@@ -181,7 +181,7 @@ impl PyTupleRef {
         )
     }
 
-    fn index(self, needle: PyObjectRef, vm: &mut VirtualMachine) -> PyResult<usize> {
+    fn index(self, needle: PyObjectRef, vm: &VirtualMachine) -> PyResult<usize> {
         for (index, element) in self.elements.borrow().iter().enumerate() {
             if element.is(&needle) {
                 return Ok(index);
@@ -194,7 +194,7 @@ impl PyTupleRef {
         Err(vm.new_value_error("tuple.index(x): x not in tuple".to_string()))
     }
 
-    fn contains(self, needle: PyObjectRef, vm: &mut VirtualMachine) -> PyResult<bool> {
+    fn contains(self, needle: PyObjectRef, vm: &VirtualMachine) -> PyResult<bool> {
         for element in self.elements.borrow().iter() {
             if element.is(&needle) {
                 return Ok(true);
@@ -211,7 +211,7 @@ impl PyTupleRef {
 fn tuple_new(
     cls: PyClassRef,
     iterable: OptionalArg<PyObjectRef>,
-    vm: &mut VirtualMachine,
+    vm: &VirtualMachine,
 ) -> PyResult<PyTupleRef> {
     if !objtype::issubclass(cls.as_object(), &vm.ctx.tuple_type()) {
         return Err(vm.new_type_error(format!("{} is not a subtype of tuple", cls)));

--- a/vm/src/obj/objtype.rs
+++ b/vm/src/obj/objtype.rs
@@ -30,7 +30,7 @@ impl fmt::Display for PyClass {
 pub type PyClassRef = PyRef<PyClass>;
 
 impl PyValue for PyClass {
-    fn class(vm: &mut VirtualMachine) -> PyObjectRef {
+    fn class(vm: &VirtualMachine) -> PyObjectRef {
         vm.ctx.type_type()
     }
 }
@@ -81,17 +81,17 @@ impl PyClassRef {
         }
     }
 
-    fn mro(self, _vm: &mut VirtualMachine) -> PyTuple {
+    fn mro(self, _vm: &VirtualMachine) -> PyTuple {
         let elements: Vec<PyObjectRef> =
             _mro(&self).iter().map(|x| x.as_object().clone()).collect();
         PyTuple::from(elements)
     }
 
-    fn set_mro(self, _value: PyObjectRef, vm: &mut VirtualMachine) -> PyResult {
+    fn set_mro(self, _value: PyObjectRef, vm: &VirtualMachine) -> PyResult {
         Err(vm.new_attribute_error("read-only attribute".to_string()))
     }
 
-    fn dir(self, vm: &mut VirtualMachine) -> PyList {
+    fn dir(self, vm: &VirtualMachine) -> PyList {
         let attributes = get_attributes(self);
         let attributes: Vec<PyObjectRef> = attributes
             .keys()
@@ -100,19 +100,19 @@ impl PyClassRef {
         PyList::from(attributes)
     }
 
-    fn instance_check(self, obj: PyObjectRef, _vm: &mut VirtualMachine) -> bool {
+    fn instance_check(self, obj: PyObjectRef, _vm: &VirtualMachine) -> bool {
         isinstance(&obj, self.as_object())
     }
 
-    fn subclass_check(self, subclass: PyObjectRef, _vm: &mut VirtualMachine) -> bool {
+    fn subclass_check(self, subclass: PyObjectRef, _vm: &VirtualMachine) -> bool {
         issubclass(&subclass, self.as_object())
     }
 
-    fn repr(self, _vm: &mut VirtualMachine) -> String {
+    fn repr(self, _vm: &VirtualMachine) -> String {
         format!("<class '{}'>", self.name)
     }
 
-    fn prepare(_name: PyStringRef, _bases: PyObjectRef, vm: &mut VirtualMachine) -> PyObjectRef {
+    fn prepare(_name: PyStringRef, _bases: PyObjectRef, vm: &VirtualMachine) -> PyObjectRef {
         vm.new_dict()
     }
 }
@@ -170,7 +170,7 @@ pub fn get_type_name(typ: &PyObjectRef) -> String {
     }
 }
 
-pub fn type_new(vm: &mut VirtualMachine, args: PyFuncArgs) -> PyResult {
+pub fn type_new(vm: &VirtualMachine, args: PyFuncArgs) -> PyResult {
     debug!("type.__new__ {:?}", args);
     if args.args.len() == 2 {
         arg_check!(
@@ -197,7 +197,7 @@ pub fn type_new(vm: &mut VirtualMachine, args: PyFuncArgs) -> PyResult {
 }
 
 pub fn type_new_class(
-    vm: &mut VirtualMachine,
+    vm: &VirtualMachine,
     typ: &PyObjectRef,
     name: &PyObjectRef,
     bases: &PyObjectRef,
@@ -218,7 +218,7 @@ pub fn type_new_class(
     )
 }
 
-pub fn type_call(vm: &mut VirtualMachine, mut args: PyFuncArgs) -> PyResult {
+pub fn type_call(vm: &VirtualMachine, mut args: PyFuncArgs) -> PyResult {
     debug!("type_call: {:?}", args);
     let cls = args.shift();
     let new = cls.get_attr("__new__").unwrap();
@@ -234,7 +234,7 @@ pub fn type_call(vm: &mut VirtualMachine, mut args: PyFuncArgs) -> PyResult {
     Ok(obj)
 }
 
-pub fn type_getattribute(vm: &mut VirtualMachine, args: PyFuncArgs) -> PyResult {
+pub fn type_getattribute(vm: &VirtualMachine, args: PyFuncArgs) -> PyResult {
     arg_check!(
         vm,
         args,

--- a/vm/src/obj/objweakref.rs
+++ b/vm/src/obj/objweakref.rs
@@ -23,7 +23,7 @@ impl PyWeak {
 }
 
 impl PyValue for PyWeak {
-    fn class(vm: &mut VirtualMachine) -> PyObjectRef {
+    fn class(vm: &VirtualMachine) -> PyObjectRef {
         vm.ctx.weakref_type()
     }
 }
@@ -32,11 +32,11 @@ pub type PyWeakRef = PyRef<PyWeak>;
 
 impl PyWeakRef {
     // TODO callbacks
-    fn create(cls: PyClassRef, referent: PyObjectRef, vm: &mut VirtualMachine) -> PyResult<Self> {
+    fn create(cls: PyClassRef, referent: PyObjectRef, vm: &VirtualMachine) -> PyResult<Self> {
         PyWeak::downgrade(referent).into_ref_with_type(vm, cls)
     }
 
-    fn call(self, vm: &mut VirtualMachine) -> PyObjectRef {
+    fn call(self, vm: &VirtualMachine) -> PyObjectRef {
         self.referent.upgrade().unwrap_or_else(|| vm.get_none())
     }
 }

--- a/vm/src/obj/objzip.rs
+++ b/vm/src/obj/objzip.rs
@@ -10,12 +10,12 @@ pub struct PyZip {
 }
 
 impl PyValue for PyZip {
-    fn class(vm: &mut VirtualMachine) -> PyObjectRef {
+    fn class(vm: &VirtualMachine) -> PyObjectRef {
         vm.ctx.zip_type()
     }
 }
 
-fn zip_new(vm: &mut VirtualMachine, args: PyFuncArgs) -> PyResult {
+fn zip_new(vm: &VirtualMachine, args: PyFuncArgs) -> PyResult {
     no_kwargs!(vm, args);
     let cls = &args.args[0];
     let iterables = &args.args[1..];
@@ -26,7 +26,7 @@ fn zip_new(vm: &mut VirtualMachine, args: PyFuncArgs) -> PyResult {
     Ok(PyObject::new(PyZip { iterators }, cls.clone()))
 }
 
-fn zip_next(vm: &mut VirtualMachine, args: PyFuncArgs) -> PyResult {
+fn zip_next(vm: &VirtualMachine, args: PyFuncArgs) -> PyResult {
     arg_check!(vm, args, required = [(zip, Some(vm.ctx.zip_type()))]);
 
     if let Some(PyZip { ref iterators }) = zip.payload() {

--- a/vm/src/pyobject.rs
+++ b/vm/src/pyobject.rs
@@ -165,7 +165,7 @@ pub fn create_type(name: &str, type_type: &PyObjectRef, base: &PyObjectRef) -> P
 pub struct PyNotImplemented;
 
 impl PyValue for PyNotImplemented {
-    fn class(vm: &mut VirtualMachine) -> PyObjectRef {
+    fn class(vm: &VirtualMachine) -> PyObjectRef {
         vm.ctx.not_implemented().typ()
     }
 }
@@ -174,7 +174,7 @@ impl PyValue for PyNotImplemented {
 pub struct PyEllipsis;
 
 impl PyValue for PyEllipsis {
-    fn class(vm: &mut VirtualMachine) -> PyObjectRef {
+    fn class(vm: &VirtualMachine) -> PyObjectRef {
         vm.ctx.ellipsis_type.clone()
     }
 }
@@ -660,7 +660,7 @@ impl PyContext {
         };
     }
 
-    pub fn unwrap_constant(&mut self, value: &bytecode::Constant) -> PyObjectRef {
+    pub fn unwrap_constant(&self, value: &bytecode::Constant) -> PyObjectRef {
         match *value {
             bytecode::Constant::Integer { ref value } => self.new_int(value.clone()),
             bytecode::Constant::Float { ref value } => self.new_float(*value),
@@ -744,7 +744,7 @@ impl<T> TryFromObject for PyRef<T>
 where
     T: PyValue,
 {
-    fn try_from_object(vm: &mut VirtualMachine, obj: PyObjectRef) -> PyResult<Self> {
+    fn try_from_object(vm: &VirtualMachine, obj: PyObjectRef) -> PyResult<Self> {
         if objtype::isinstance(&obj, &T::class(vm)) {
             Ok(PyRef {
                 obj,
@@ -763,7 +763,7 @@ where
 }
 
 impl<T> IntoPyObject for PyRef<T> {
-    fn into_pyobject(self, _vm: &mut VirtualMachine) -> PyResult {
+    fn into_pyobject(self, _vm: &VirtualMachine) -> PyResult {
         Ok(self.obj)
     }
 }
@@ -976,7 +976,7 @@ impl<T> PyIterable<T> {
     ///
     /// This operation may fail if an exception is raised while invoking the
     /// `__iter__` method of the iterable object.
-    pub fn iter<'a>(&self, vm: &'a mut VirtualMachine) -> PyResult<PyIterator<'a, T>> {
+    pub fn iter<'a>(&self, vm: &'a VirtualMachine) -> PyResult<PyIterator<'a, T>> {
         let iter_obj = vm.invoke(
             self.method.clone(),
             PyFuncArgs {
@@ -994,7 +994,7 @@ impl<T> PyIterable<T> {
 }
 
 pub struct PyIterator<'a, T> {
-    vm: &'a mut VirtualMachine,
+    vm: &'a VirtualMachine,
     obj: PyObjectRef,
     _item: std::marker::PhantomData<T>,
 }
@@ -1024,7 +1024,7 @@ impl<T> TryFromObject for PyIterable<T>
 where
     T: TryFromObject,
 {
-    fn try_from_object(vm: &mut VirtualMachine, obj: PyObjectRef) -> PyResult<Self> {
+    fn try_from_object(vm: &VirtualMachine, obj: PyObjectRef) -> PyResult<Self> {
         Ok(PyIterable {
             method: vm.get_method(obj, "__iter__")?,
             _item: std::marker::PhantomData,
@@ -1033,13 +1033,13 @@ where
 }
 
 impl TryFromObject for PyObjectRef {
-    fn try_from_object(_vm: &mut VirtualMachine, obj: PyObjectRef) -> PyResult<Self> {
+    fn try_from_object(_vm: &VirtualMachine, obj: PyObjectRef) -> PyResult<Self> {
         Ok(obj)
     }
 }
 
 impl<T: TryFromObject> TryFromObject for Option<T> {
-    fn try_from_object(vm: &mut VirtualMachine, obj: PyObjectRef) -> PyResult<Self> {
+    fn try_from_object(vm: &VirtualMachine, obj: PyObjectRef) -> PyResult<Self> {
         if vm.get_none().is(&obj) {
             Ok(None)
         } else {
@@ -1051,11 +1051,11 @@ impl<T: TryFromObject> TryFromObject for Option<T> {
 /// Allows coercion of a types into PyRefs, so that we can write functions that can take
 /// refs, pyobject refs or basic types.
 pub trait TryIntoRef<T> {
-    fn try_into_ref(self, vm: &mut VirtualMachine) -> PyResult<PyRef<T>>;
+    fn try_into_ref(self, vm: &VirtualMachine) -> PyResult<PyRef<T>>;
 }
 
 impl<T> TryIntoRef<T> for PyRef<T> {
-    fn try_into_ref(self, _vm: &mut VirtualMachine) -> PyResult<PyRef<T>> {
+    fn try_into_ref(self, _vm: &VirtualMachine) -> PyResult<PyRef<T>> {
         Ok(self)
     }
 }
@@ -1064,7 +1064,7 @@ impl<T> TryIntoRef<T> for PyObjectRef
 where
     T: PyValue,
 {
-    fn try_into_ref(self, vm: &mut VirtualMachine) -> PyResult<PyRef<T>> {
+    fn try_into_ref(self, vm: &VirtualMachine) -> PyResult<PyRef<T>> {
         TryFromObject::try_from_object(vm, self)
     }
 }
@@ -1075,7 +1075,7 @@ where
 /// so can be accepted as a argument to a built-in function.
 pub trait TryFromObject: Sized {
     /// Attempt to convert a Python object to a value of this type.
-    fn try_from_object(vm: &mut VirtualMachine, obj: PyObjectRef) -> PyResult<Self>;
+    fn try_from_object(vm: &VirtualMachine, obj: PyObjectRef) -> PyResult<Self>;
 }
 
 /// Implemented by any type that can be returned from a built-in Python function.
@@ -1084,11 +1084,11 @@ pub trait TryFromObject: Sized {
 /// and should be implemented by many primitive Rust types, allowing a built-in
 /// function to simply return a `bool` or a `usize` for example.
 pub trait IntoPyObject {
-    fn into_pyobject(self, vm: &mut VirtualMachine) -> PyResult;
+    fn into_pyobject(self, vm: &VirtualMachine) -> PyResult;
 }
 
 impl IntoPyObject for PyObjectRef {
-    fn into_pyobject(self, _vm: &mut VirtualMachine) -> PyResult {
+    fn into_pyobject(self, _vm: &VirtualMachine) -> PyResult {
         Ok(self)
     }
 }
@@ -1097,7 +1097,7 @@ impl<T> IntoPyObject for PyResult<T>
 where
     T: IntoPyObject,
 {
-    fn into_pyobject(self, vm: &mut VirtualMachine) -> PyResult {
+    fn into_pyobject(self, vm: &VirtualMachine) -> PyResult {
         self.and_then(|res| T::into_pyobject(res, vm))
     }
 }
@@ -1108,7 +1108,7 @@ impl<T> IntoPyObject for T
 where
     T: PyValue + Sized,
 {
-    fn into_pyobject(self, vm: &mut VirtualMachine) -> PyResult {
+    fn into_pyobject(self, vm: &VirtualMachine) -> PyResult {
         Ok(PyObject::new(self, T::class(vm)))
     }
 }
@@ -1122,7 +1122,7 @@ pub struct PyIteratorValue {
 }
 
 impl PyValue for PyIteratorValue {
-    fn class(vm: &mut VirtualMachine) -> PyObjectRef {
+    fn class(vm: &VirtualMachine) -> PyObjectRef {
         vm.ctx.iter_type()
     }
 }
@@ -1163,16 +1163,16 @@ impl PyObject {
 }
 
 pub trait PyValue: fmt::Debug + Sized + 'static {
-    fn class(vm: &mut VirtualMachine) -> PyObjectRef;
+    fn class(vm: &VirtualMachine) -> PyObjectRef;
 
-    fn into_ref(self, vm: &mut VirtualMachine) -> PyRef<Self> {
+    fn into_ref(self, vm: &VirtualMachine) -> PyRef<Self> {
         PyRef {
             obj: PyObject::new(self, Self::class(vm)),
             _payload: PhantomData,
         }
     }
 
-    fn into_ref_with_type(self, vm: &mut VirtualMachine, cls: PyClassRef) -> PyResult<PyRef<Self>> {
+    fn into_ref_with_type(self, vm: &VirtualMachine, cls: PyClassRef) -> PyResult<PyRef<Self>> {
         let class = Self::class(vm);
         if objtype::issubclass(&cls.obj, &class) {
             Ok(PyRef {

--- a/vm/src/stdlib/ast.rs
+++ b/vm/src/stdlib/ast.rs
@@ -612,7 +612,7 @@ fn string_to_ast(ctx: &PyContext, string: &ast::StringGroup) -> PyObjectRef {
     }
 }
 
-fn ast_parse(vm: &mut VirtualMachine, args: PyFuncArgs) -> PyResult {
+fn ast_parse(vm: &VirtualMachine, args: PyFuncArgs) -> PyResult {
     arg_check!(vm, args, required = [(source, Some(vm.ctx.str_type()))]);
 
     let source_string = objstr::get_value(source);

--- a/vm/src/stdlib/dis.rs
+++ b/vm/src/stdlib/dis.rs
@@ -3,7 +3,7 @@ use crate::obj::objcode;
 use crate::pyobject::{PyContext, PyObjectRef, PyResult, TypeProtocol};
 use crate::vm::VirtualMachine;
 
-fn dis_dis(vm: &mut VirtualMachine, args: PyFuncArgs) -> PyResult {
+fn dis_dis(vm: &VirtualMachine, args: PyFuncArgs) -> PyResult {
     arg_check!(vm, args, required = [(obj, None)]);
 
     // Method or function:
@@ -14,7 +14,7 @@ fn dis_dis(vm: &mut VirtualMachine, args: PyFuncArgs) -> PyResult {
     dis_disassemble(vm, PyFuncArgs::new(vec![obj.clone()], vec![]))
 }
 
-fn dis_disassemble(vm: &mut VirtualMachine, args: PyFuncArgs) -> PyResult {
+fn dis_disassemble(vm: &VirtualMachine, args: PyFuncArgs) -> PyResult {
     arg_check!(vm, args, required = [(co, Some(vm.ctx.code_type()))]);
 
     let code = objcode::get_value(co);

--- a/vm/src/stdlib/io.rs
+++ b/vm/src/stdlib/io.rs
@@ -43,23 +43,23 @@ struct PyStringIO {
 type PyStringIORef = PyRef<PyStringIO>;
 
 impl PyValue for PyStringIO {
-    fn class(vm: &mut VirtualMachine) -> PyObjectRef {
+    fn class(vm: &VirtualMachine) -> PyObjectRef {
         vm.class("io", "StringIO")
     }
 }
 
 impl PyStringIORef {
-    fn write(self, data: objstr::PyStringRef, _vm: &mut VirtualMachine) {
+    fn write(self, data: objstr::PyStringRef, _vm: &VirtualMachine) {
         let data = data.value.clone();
         self.data.borrow_mut().push_str(&data);
     }
 
-    fn getvalue(self, _vm: &mut VirtualMachine) -> String {
+    fn getvalue(self, _vm: &VirtualMachine) -> String {
         self.data.borrow().clone()
     }
 }
 
-fn string_io_new(vm: &mut VirtualMachine, args: PyFuncArgs) -> PyResult {
+fn string_io_new(vm: &VirtualMachine, args: PyFuncArgs) -> PyResult {
     arg_check!(vm, args, required = [(cls, None)]);
 
     Ok(PyObject::new(
@@ -70,23 +70,23 @@ fn string_io_new(vm: &mut VirtualMachine, args: PyFuncArgs) -> PyResult {
     ))
 }
 
-fn bytes_io_init(vm: &mut VirtualMachine, _args: PyFuncArgs) -> PyResult {
+fn bytes_io_init(vm: &VirtualMachine, _args: PyFuncArgs) -> PyResult {
     // TODO
     Ok(vm.get_none())
 }
 
-fn bytes_io_getvalue(vm: &mut VirtualMachine, args: PyFuncArgs) -> PyResult {
+fn bytes_io_getvalue(vm: &VirtualMachine, args: PyFuncArgs) -> PyResult {
     arg_check!(vm, args);
     // TODO
     Ok(vm.get_none())
 }
 
-fn io_base_cm_enter(vm: &mut VirtualMachine, args: PyFuncArgs) -> PyResult {
+fn io_base_cm_enter(vm: &VirtualMachine, args: PyFuncArgs) -> PyResult {
     arg_check!(vm, args, required = [(instance, None)]);
     Ok(instance.clone())
 }
 
-fn io_base_cm_exit(vm: &mut VirtualMachine, args: PyFuncArgs) -> PyResult {
+fn io_base_cm_exit(vm: &VirtualMachine, args: PyFuncArgs) -> PyResult {
     arg_check!(
         vm,
         args,
@@ -101,13 +101,13 @@ fn io_base_cm_exit(vm: &mut VirtualMachine, args: PyFuncArgs) -> PyResult {
     Ok(vm.get_none())
 }
 
-fn buffered_io_base_init(vm: &mut VirtualMachine, args: PyFuncArgs) -> PyResult {
+fn buffered_io_base_init(vm: &VirtualMachine, args: PyFuncArgs) -> PyResult {
     arg_check!(vm, args, required = [(buffered, None), (raw, None)]);
     vm.ctx.set_attr(&buffered, "raw", raw.clone());
     Ok(vm.get_none())
 }
 
-fn buffered_reader_read(vm: &mut VirtualMachine, args: PyFuncArgs) -> PyResult {
+fn buffered_reader_read(vm: &VirtualMachine, args: PyFuncArgs) -> PyResult {
     arg_check!(vm, args, required = [(buffered, None)]);
     let buff_size = 8 * 1024;
     let buffer = vm.ctx.new_bytearray(vec![0; buff_size]);
@@ -137,7 +137,7 @@ fn buffered_reader_read(vm: &mut VirtualMachine, args: PyFuncArgs) -> PyResult {
     Ok(vm.ctx.new_bytes(result))
 }
 
-fn file_io_init(vm: &mut VirtualMachine, args: PyFuncArgs) -> PyResult {
+fn file_io_init(vm: &VirtualMachine, args: PyFuncArgs) -> PyResult {
     arg_check!(
         vm,
         args,
@@ -163,7 +163,7 @@ fn file_io_init(vm: &mut VirtualMachine, args: PyFuncArgs) -> PyResult {
     }
 }
 
-fn file_io_read(vm: &mut VirtualMachine, args: PyFuncArgs) -> PyResult {
+fn file_io_read(vm: &VirtualMachine, args: PyFuncArgs) -> PyResult {
     arg_check!(vm, args, required = [(file_io, None)]);
     let py_name = file_io.get_attr("name").unwrap();
     let f = match File::open(objstr::get_value(&py_name)) {
@@ -187,7 +187,7 @@ fn file_io_read(vm: &mut VirtualMachine, args: PyFuncArgs) -> PyResult {
     Ok(vm.ctx.new_bytes(bytes))
 }
 
-fn file_io_readinto(vm: &mut VirtualMachine, args: PyFuncArgs) -> PyResult {
+fn file_io_readinto(vm: &VirtualMachine, args: PyFuncArgs) -> PyResult {
     arg_check!(vm, args, required = [(file_io, None), (obj, None)]);
 
     if !obj.readonly() {
@@ -223,7 +223,7 @@ fn file_io_readinto(vm: &mut VirtualMachine, args: PyFuncArgs) -> PyResult {
     Ok(vm.get_none())
 }
 
-fn file_io_write(vm: &mut VirtualMachine, args: PyFuncArgs) -> PyResult {
+fn file_io_write(vm: &VirtualMachine, args: PyFuncArgs) -> PyResult {
     arg_check!(
         vm,
         args,
@@ -257,7 +257,7 @@ fn file_io_write(vm: &mut VirtualMachine, args: PyFuncArgs) -> PyResult {
     }
 }
 
-fn buffered_writer_write(vm: &mut VirtualMachine, args: PyFuncArgs) -> PyResult {
+fn buffered_writer_write(vm: &VirtualMachine, args: PyFuncArgs) -> PyResult {
     arg_check!(
         vm,
         args,
@@ -270,7 +270,7 @@ fn buffered_writer_write(vm: &mut VirtualMachine, args: PyFuncArgs) -> PyResult 
     vm.call_method(&raw, "write", vec![obj.clone()])
 }
 
-fn text_io_wrapper_init(vm: &mut VirtualMachine, args: PyFuncArgs) -> PyResult {
+fn text_io_wrapper_init(vm: &VirtualMachine, args: PyFuncArgs) -> PyResult {
     arg_check!(
         vm,
         args,
@@ -281,7 +281,7 @@ fn text_io_wrapper_init(vm: &mut VirtualMachine, args: PyFuncArgs) -> PyResult {
     Ok(vm.get_none())
 }
 
-fn text_io_base_read(vm: &mut VirtualMachine, args: PyFuncArgs) -> PyResult {
+fn text_io_base_read(vm: &VirtualMachine, args: PyFuncArgs) -> PyResult {
     arg_check!(vm, args, required = [(text_io_base, None)]);
 
     let raw = vm.ctx.get_attr(&text_io_base, "buffer").unwrap();
@@ -297,7 +297,7 @@ fn text_io_base_read(vm: &mut VirtualMachine, args: PyFuncArgs) -> PyResult {
     }
 }
 
-pub fn io_open(vm: &mut VirtualMachine, args: PyFuncArgs) -> PyResult {
+pub fn io_open(vm: &VirtualMachine, args: PyFuncArgs) -> PyResult {
     arg_check!(
         vm,
         args,

--- a/vm/src/stdlib/json.rs
+++ b/vm/src/stdlib/json.rs
@@ -188,12 +188,12 @@ impl<'de> Visitor<'de> for PyObjectDeserializer<'de> {
     }
 }
 
-pub fn ser_pyobject(vm: &mut VirtualMachine, obj: &PyObjectRef) -> PyResult<String> {
+pub fn ser_pyobject(vm: &VirtualMachine, obj: &PyObjectRef) -> PyResult<String> {
     let serializer = PyObjectSerializer { pyobject: obj, vm };
     serde_json::to_string(&serializer).map_err(|err| vm.new_type_error(err.to_string()))
 }
 
-pub fn de_pyobject(vm: &mut VirtualMachine, s: &str) -> PyResult {
+pub fn de_pyobject(vm: &VirtualMachine, s: &str) -> PyResult {
     let de = PyObjectDeserializer { vm };
     // TODO: Support deserializing string sub-classes
     de.deserialize(&mut serde_json::Deserializer::from_str(s))
@@ -214,7 +214,7 @@ pub fn de_pyobject(vm: &mut VirtualMachine, s: &str) -> PyResult {
 }
 
 /// Implement json.dumps
-fn json_dumps(vm: &mut VirtualMachine, args: PyFuncArgs) -> PyResult {
+fn json_dumps(vm: &VirtualMachine, args: PyFuncArgs) -> PyResult {
     // TODO: Implement non-trivial serialisation case
     arg_check!(vm, args, required = [(obj, None)]);
     let string = ser_pyobject(vm, obj)?;
@@ -222,7 +222,7 @@ fn json_dumps(vm: &mut VirtualMachine, args: PyFuncArgs) -> PyResult {
 }
 
 /// Implement json.loads
-fn json_loads(vm: &mut VirtualMachine, args: PyFuncArgs) -> PyResult {
+fn json_loads(vm: &VirtualMachine, args: PyFuncArgs) -> PyResult {
     // TODO: Implement non-trivial deserialization case
     arg_check!(vm, args, required = [(string, Some(vm.ctx.str_type()))]);
 

--- a/vm/src/stdlib/keyword.rs
+++ b/vm/src/stdlib/keyword.rs
@@ -9,7 +9,7 @@ use crate::obj::objstr;
 use crate::pyobject::{PyContext, PyObjectRef, PyResult, TypeProtocol};
 use crate::vm::VirtualMachine;
 
-fn keyword_iskeyword(vm: &mut VirtualMachine, args: PyFuncArgs) -> PyResult {
+fn keyword_iskeyword(vm: &VirtualMachine, args: PyFuncArgs) -> PyResult {
     arg_check!(vm, args, required = [(s, Some(vm.ctx.str_type()))]);
     let s = objstr::get_value(s);
     let keywords = lexer::get_keywords();

--- a/vm/src/stdlib/math.rs
+++ b/vm/src/stdlib/math.rs
@@ -14,7 +14,7 @@ use crate::vm::VirtualMachine;
 // Helper macro:
 macro_rules! make_math_func {
     ( $fname:ident, $fun:ident ) => {
-        fn $fname(vm: &mut VirtualMachine, args: PyFuncArgs) -> PyResult {
+        fn $fname(vm: &VirtualMachine, args: PyFuncArgs) -> PyResult {
             arg_check!(vm, args, required = [(value, None)]);
             let value = objfloat::make_float(vm, value)?;
             let value = value.$fun();
@@ -27,19 +27,19 @@ macro_rules! make_math_func {
 // Number theory functions:
 make_math_func!(math_fabs, abs);
 
-fn math_isfinite(vm: &mut VirtualMachine, args: PyFuncArgs) -> PyResult {
+fn math_isfinite(vm: &VirtualMachine, args: PyFuncArgs) -> PyResult {
     arg_check!(vm, args, required = [(value, None)]);
     let value = objfloat::make_float(vm, value)?.is_finite();
     Ok(vm.ctx.new_bool(value))
 }
 
-fn math_isinf(vm: &mut VirtualMachine, args: PyFuncArgs) -> PyResult {
+fn math_isinf(vm: &VirtualMachine, args: PyFuncArgs) -> PyResult {
     arg_check!(vm, args, required = [(value, None)]);
     let value = objfloat::make_float(vm, value)?.is_infinite();
     Ok(vm.ctx.new_bool(value))
 }
 
-fn math_isnan(vm: &mut VirtualMachine, args: PyFuncArgs) -> PyResult {
+fn math_isnan(vm: &VirtualMachine, args: PyFuncArgs) -> PyResult {
     arg_check!(vm, args, required = [(value, None)]);
     let value = objfloat::make_float(vm, value)?.is_nan();
     Ok(vm.ctx.new_bool(value))
@@ -49,7 +49,7 @@ fn math_isnan(vm: &mut VirtualMachine, args: PyFuncArgs) -> PyResult {
 make_math_func!(math_exp, exp);
 make_math_func!(math_expm1, exp_m1);
 
-fn math_log(vm: &mut VirtualMachine, args: PyFuncArgs) -> PyResult {
+fn math_log(vm: &VirtualMachine, args: PyFuncArgs) -> PyResult {
     arg_check!(vm, args, required = [(x, None)], optional = [(base, None)]);
     let x = objfloat::make_float(vm, x)?;
     match base {
@@ -61,7 +61,7 @@ fn math_log(vm: &mut VirtualMachine, args: PyFuncArgs) -> PyResult {
     }
 }
 
-fn math_log1p(vm: &mut VirtualMachine, args: PyFuncArgs) -> PyResult {
+fn math_log1p(vm: &VirtualMachine, args: PyFuncArgs) -> PyResult {
     arg_check!(vm, args, required = [(x, None)]);
     let x = objfloat::make_float(vm, x)?;
     Ok(vm.ctx.new_float((x + 1.0).ln()))
@@ -70,7 +70,7 @@ fn math_log1p(vm: &mut VirtualMachine, args: PyFuncArgs) -> PyResult {
 make_math_func!(math_log2, log2);
 make_math_func!(math_log10, log10);
 
-fn math_pow(vm: &mut VirtualMachine, args: PyFuncArgs) -> PyResult {
+fn math_pow(vm: &VirtualMachine, args: PyFuncArgs) -> PyResult {
     arg_check!(vm, args, required = [(x, None), (y, None)]);
     let x = objfloat::make_float(vm, x)?;
     let y = objfloat::make_float(vm, y)?;
@@ -84,7 +84,7 @@ make_math_func!(math_acos, acos);
 make_math_func!(math_asin, asin);
 make_math_func!(math_atan, atan);
 
-fn math_atan2(vm: &mut VirtualMachine, args: PyFuncArgs) -> PyResult {
+fn math_atan2(vm: &VirtualMachine, args: PyFuncArgs) -> PyResult {
     arg_check!(vm, args, required = [(y, None), (x, None)]);
     let y = objfloat::make_float(vm, y)?;
     let x = objfloat::make_float(vm, x)?;
@@ -93,7 +93,7 @@ fn math_atan2(vm: &mut VirtualMachine, args: PyFuncArgs) -> PyResult {
 
 make_math_func!(math_cos, cos);
 
-fn math_hypot(vm: &mut VirtualMachine, args: PyFuncArgs) -> PyResult {
+fn math_hypot(vm: &VirtualMachine, args: PyFuncArgs) -> PyResult {
     arg_check!(vm, args, required = [(x, None), (y, None)]);
     let x = objfloat::make_float(vm, x)?;
     let y = objfloat::make_float(vm, y)?;
@@ -103,13 +103,13 @@ fn math_hypot(vm: &mut VirtualMachine, args: PyFuncArgs) -> PyResult {
 make_math_func!(math_sin, sin);
 make_math_func!(math_tan, tan);
 
-fn math_degrees(vm: &mut VirtualMachine, args: PyFuncArgs) -> PyResult {
+fn math_degrees(vm: &VirtualMachine, args: PyFuncArgs) -> PyResult {
     arg_check!(vm, args, required = [(value, None)]);
     let x = objfloat::make_float(vm, value)?;
     Ok(vm.ctx.new_float(x * (180.0 / std::f64::consts::PI)))
 }
 
-fn math_radians(vm: &mut VirtualMachine, args: PyFuncArgs) -> PyResult {
+fn math_radians(vm: &VirtualMachine, args: PyFuncArgs) -> PyResult {
     arg_check!(vm, args, required = [(value, None)]);
     let x = objfloat::make_float(vm, value)?;
     Ok(vm.ctx.new_float(x * (std::f64::consts::PI / 180.0)))
@@ -124,7 +124,7 @@ make_math_func!(math_sinh, sinh);
 make_math_func!(math_tanh, tanh);
 
 // Special functions:
-fn math_erf(vm: &mut VirtualMachine, args: PyFuncArgs) -> PyResult {
+fn math_erf(vm: &VirtualMachine, args: PyFuncArgs) -> PyResult {
     arg_check!(vm, args, required = [(value, None)]);
     let x = objfloat::make_float(vm, value)?;
 
@@ -135,7 +135,7 @@ fn math_erf(vm: &mut VirtualMachine, args: PyFuncArgs) -> PyResult {
     }
 }
 
-fn math_erfc(vm: &mut VirtualMachine, args: PyFuncArgs) -> PyResult {
+fn math_erfc(vm: &VirtualMachine, args: PyFuncArgs) -> PyResult {
     arg_check!(vm, args, required = [(value, None)]);
     let x = objfloat::make_float(vm, value)?;
 
@@ -146,7 +146,7 @@ fn math_erfc(vm: &mut VirtualMachine, args: PyFuncArgs) -> PyResult {
     }
 }
 
-fn math_gamma(vm: &mut VirtualMachine, args: PyFuncArgs) -> PyResult {
+fn math_gamma(vm: &VirtualMachine, args: PyFuncArgs) -> PyResult {
     arg_check!(vm, args, required = [(value, None)]);
     let x = objfloat::make_float(vm, value)?;
 
@@ -159,7 +159,7 @@ fn math_gamma(vm: &mut VirtualMachine, args: PyFuncArgs) -> PyResult {
     }
 }
 
-fn math_lgamma(vm: &mut VirtualMachine, args: PyFuncArgs) -> PyResult {
+fn math_lgamma(vm: &VirtualMachine, args: PyFuncArgs) -> PyResult {
     arg_check!(vm, args, required = [(value, None)]);
     let x = objfloat::make_float(vm, value)?;
 

--- a/vm/src/stdlib/os.rs
+++ b/vm/src/stdlib/os.rs
@@ -50,7 +50,7 @@ pub fn raw_file_number(handle: File) -> i64 {
     unimplemented!();
 }
 
-pub fn os_close(vm: &mut VirtualMachine, args: PyFuncArgs) -> PyResult {
+pub fn os_close(vm: &VirtualMachine, args: PyFuncArgs) -> PyResult {
     arg_check!(vm, args, required = [(fileno, Some(vm.ctx.int_type()))]);
 
     let raw_fileno = objint::get_value(&fileno);
@@ -63,7 +63,7 @@ pub fn os_close(vm: &mut VirtualMachine, args: PyFuncArgs) -> PyResult {
     Ok(vm.get_none())
 }
 
-pub fn os_open(vm: &mut VirtualMachine, args: PyFuncArgs) -> PyResult {
+pub fn os_open(vm: &VirtualMachine, args: PyFuncArgs) -> PyResult {
     arg_check!(
         vm,
         args,
@@ -96,7 +96,7 @@ pub fn os_open(vm: &mut VirtualMachine, args: PyFuncArgs) -> PyResult {
     Ok(vm.ctx.new_int(raw_file_number(handle)))
 }
 
-fn os_error(vm: &mut VirtualMachine, args: PyFuncArgs) -> PyResult {
+fn os_error(vm: &VirtualMachine, args: PyFuncArgs) -> PyResult {
     arg_check!(
         vm,
         args,

--- a/vm/src/stdlib/platform.rs
+++ b/vm/src/stdlib/platform.rs
@@ -10,18 +10,18 @@ pub fn make_module(ctx: &PyContext) -> PyObjectRef {
     })
 }
 
-fn platform_python_implementation(vm: &mut VirtualMachine, args: PyFuncArgs) -> PyResult {
+fn platform_python_implementation(vm: &VirtualMachine, args: PyFuncArgs) -> PyResult {
     arg_check!(vm, args);
     Ok(vm.new_str("RustPython".to_string()))
 }
 
-fn platform_python_version(vm: &mut VirtualMachine, args: PyFuncArgs) -> PyResult {
+fn platform_python_version(vm: &VirtualMachine, args: PyFuncArgs) -> PyResult {
     arg_check!(vm, args);
     // TODO: fetch version from somewhere.
     Ok(vm.new_str("4.0.0".to_string()))
 }
 
-fn platform_python_compiler(vm: &mut VirtualMachine, args: PyFuncArgs) -> PyResult {
+fn platform_python_compiler(vm: &VirtualMachine, args: PyFuncArgs) -> PyResult {
     arg_check!(vm, args);
     let version = rustc_version_runtime::version_meta();
     Ok(vm.new_str(format!("rustc {}", version.semver)))

--- a/vm/src/stdlib/pystruct.rs
+++ b/vm/src/stdlib/pystruct.rs
@@ -43,23 +43,23 @@ fn parse_format_string(fmt: String) -> Vec<FormatCode> {
     codes
 }
 
-fn get_int(vm: &mut VirtualMachine, arg: &PyObjectRef) -> PyResult<BigInt> {
+fn get_int(vm: &VirtualMachine, arg: &PyObjectRef) -> PyResult<BigInt> {
     objint::to_int(vm, arg, 10)
 }
 
-fn pack_i8(vm: &mut VirtualMachine, arg: &PyObjectRef, data: &mut Write) -> PyResult<()> {
+fn pack_i8(vm: &VirtualMachine, arg: &PyObjectRef, data: &mut Write) -> PyResult<()> {
     let v = get_int(vm, arg)?.to_i8().unwrap();
     data.write_i8(v).unwrap();
     Ok(())
 }
 
-fn pack_u8(vm: &mut VirtualMachine, arg: &PyObjectRef, data: &mut Write) -> PyResult<()> {
+fn pack_u8(vm: &VirtualMachine, arg: &PyObjectRef, data: &mut Write) -> PyResult<()> {
     let v = get_int(vm, arg)?.to_u8().unwrap();
     data.write_u8(v).unwrap();
     Ok(())
 }
 
-fn pack_bool(vm: &mut VirtualMachine, arg: &PyObjectRef, data: &mut Write) -> PyResult<()> {
+fn pack_bool(vm: &VirtualMachine, arg: &PyObjectRef, data: &mut Write) -> PyResult<()> {
     if objtype::isinstance(&arg, &vm.ctx.bool_type()) {
         let v = if objbool::get_value(arg) { 1 } else { 0 };
         data.write_u8(v).unwrap();
@@ -69,43 +69,43 @@ fn pack_bool(vm: &mut VirtualMachine, arg: &PyObjectRef, data: &mut Write) -> Py
     }
 }
 
-fn pack_i16(vm: &mut VirtualMachine, arg: &PyObjectRef, data: &mut Write) -> PyResult<()> {
+fn pack_i16(vm: &VirtualMachine, arg: &PyObjectRef, data: &mut Write) -> PyResult<()> {
     let v = get_int(vm, arg)?.to_i16().unwrap();
     data.write_i16::<LittleEndian>(v).unwrap();
     Ok(())
 }
 
-fn pack_u16(vm: &mut VirtualMachine, arg: &PyObjectRef, data: &mut Write) -> PyResult<()> {
+fn pack_u16(vm: &VirtualMachine, arg: &PyObjectRef, data: &mut Write) -> PyResult<()> {
     let v = get_int(vm, arg)?.to_u16().unwrap();
     data.write_u16::<LittleEndian>(v).unwrap();
     Ok(())
 }
 
-fn pack_i32(vm: &mut VirtualMachine, arg: &PyObjectRef, data: &mut Write) -> PyResult<()> {
+fn pack_i32(vm: &VirtualMachine, arg: &PyObjectRef, data: &mut Write) -> PyResult<()> {
     let v = get_int(vm, arg)?.to_i32().unwrap();
     data.write_i32::<LittleEndian>(v).unwrap();
     Ok(())
 }
 
-fn pack_u32(vm: &mut VirtualMachine, arg: &PyObjectRef, data: &mut Write) -> PyResult<()> {
+fn pack_u32(vm: &VirtualMachine, arg: &PyObjectRef, data: &mut Write) -> PyResult<()> {
     let v = get_int(vm, arg)?.to_u32().unwrap();
     data.write_u32::<LittleEndian>(v).unwrap();
     Ok(())
 }
 
-fn pack_i64(vm: &mut VirtualMachine, arg: &PyObjectRef, data: &mut Write) -> PyResult<()> {
+fn pack_i64(vm: &VirtualMachine, arg: &PyObjectRef, data: &mut Write) -> PyResult<()> {
     let v = get_int(vm, arg)?.to_i64().unwrap();
     data.write_i64::<LittleEndian>(v).unwrap();
     Ok(())
 }
 
-fn pack_u64(vm: &mut VirtualMachine, arg: &PyObjectRef, data: &mut Write) -> PyResult<()> {
+fn pack_u64(vm: &VirtualMachine, arg: &PyObjectRef, data: &mut Write) -> PyResult<()> {
     let v = get_int(vm, arg)?.to_u64().unwrap();
     data.write_u64::<LittleEndian>(v).unwrap();
     Ok(())
 }
 
-fn pack_f32(vm: &mut VirtualMachine, arg: &PyObjectRef, data: &mut Write) -> PyResult<()> {
+fn pack_f32(vm: &VirtualMachine, arg: &PyObjectRef, data: &mut Write) -> PyResult<()> {
     if objtype::isinstance(&arg, &vm.ctx.float_type()) {
         let v = objfloat::get_value(arg) as f32;
         data.write_f32::<LittleEndian>(v).unwrap();
@@ -115,7 +115,7 @@ fn pack_f32(vm: &mut VirtualMachine, arg: &PyObjectRef, data: &mut Write) -> PyR
     }
 }
 
-fn pack_f64(vm: &mut VirtualMachine, arg: &PyObjectRef, data: &mut Write) -> PyResult<()> {
+fn pack_f64(vm: &VirtualMachine, arg: &PyObjectRef, data: &mut Write) -> PyResult<()> {
     if objtype::isinstance(&arg, &vm.ctx.float_type()) {
         let v = objfloat::get_value(arg) as f64;
         data.write_f64::<LittleEndian>(v).unwrap();
@@ -125,7 +125,7 @@ fn pack_f64(vm: &mut VirtualMachine, arg: &PyObjectRef, data: &mut Write) -> PyR
     }
 }
 
-fn struct_pack(vm: &mut VirtualMachine, args: PyFuncArgs) -> PyResult {
+fn struct_pack(vm: &VirtualMachine, args: PyFuncArgs) -> PyResult {
     if args.args.is_empty() {
         Err(vm.new_type_error(format!(
             "Expected at least 1 argument (got: {})",
@@ -178,84 +178,84 @@ fn struct_pack(vm: &mut VirtualMachine, args: PyFuncArgs) -> PyResult {
     }
 }
 
-fn unpack_i8(vm: &mut VirtualMachine, rdr: &mut Read) -> PyResult {
+fn unpack_i8(vm: &VirtualMachine, rdr: &mut Read) -> PyResult {
     match rdr.read_i8() {
         Err(err) => panic!("Error in reading {:?}", err),
         Ok(v) => Ok(vm.ctx.new_int(v)),
     }
 }
 
-fn unpack_u8(vm: &mut VirtualMachine, rdr: &mut Read) -> PyResult {
+fn unpack_u8(vm: &VirtualMachine, rdr: &mut Read) -> PyResult {
     match rdr.read_u8() {
         Err(err) => panic!("Error in reading {:?}", err),
         Ok(v) => Ok(vm.ctx.new_int(v)),
     }
 }
 
-fn unpack_bool(vm: &mut VirtualMachine, rdr: &mut Read) -> PyResult {
+fn unpack_bool(vm: &VirtualMachine, rdr: &mut Read) -> PyResult {
     match rdr.read_u8() {
         Err(err) => panic!("Error in reading {:?}", err),
         Ok(v) => Ok(vm.ctx.new_bool(v > 0)),
     }
 }
 
-fn unpack_i16(vm: &mut VirtualMachine, rdr: &mut Read) -> PyResult {
+fn unpack_i16(vm: &VirtualMachine, rdr: &mut Read) -> PyResult {
     match rdr.read_i16::<LittleEndian>() {
         Err(err) => panic!("Error in reading {:?}", err),
         Ok(v) => Ok(vm.ctx.new_int(v)),
     }
 }
 
-fn unpack_u16(vm: &mut VirtualMachine, rdr: &mut Read) -> PyResult {
+fn unpack_u16(vm: &VirtualMachine, rdr: &mut Read) -> PyResult {
     match rdr.read_u16::<LittleEndian>() {
         Err(err) => panic!("Error in reading {:?}", err),
         Ok(v) => Ok(vm.ctx.new_int(v)),
     }
 }
 
-fn unpack_i32(vm: &mut VirtualMachine, rdr: &mut Read) -> PyResult {
+fn unpack_i32(vm: &VirtualMachine, rdr: &mut Read) -> PyResult {
     match rdr.read_i32::<LittleEndian>() {
         Err(err) => panic!("Error in reading {:?}", err),
         Ok(v) => Ok(vm.ctx.new_int(v)),
     }
 }
 
-fn unpack_u32(vm: &mut VirtualMachine, rdr: &mut Read) -> PyResult {
+fn unpack_u32(vm: &VirtualMachine, rdr: &mut Read) -> PyResult {
     match rdr.read_u32::<LittleEndian>() {
         Err(err) => panic!("Error in reading {:?}", err),
         Ok(v) => Ok(vm.ctx.new_int(v)),
     }
 }
 
-fn unpack_i64(vm: &mut VirtualMachine, rdr: &mut Read) -> PyResult {
+fn unpack_i64(vm: &VirtualMachine, rdr: &mut Read) -> PyResult {
     match rdr.read_i64::<LittleEndian>() {
         Err(err) => panic!("Error in reading {:?}", err),
         Ok(v) => Ok(vm.ctx.new_int(v)),
     }
 }
 
-fn unpack_u64(vm: &mut VirtualMachine, rdr: &mut Read) -> PyResult {
+fn unpack_u64(vm: &VirtualMachine, rdr: &mut Read) -> PyResult {
     match rdr.read_u64::<LittleEndian>() {
         Err(err) => panic!("Error in reading {:?}", err),
         Ok(v) => Ok(vm.ctx.new_int(v)),
     }
 }
 
-fn unpack_f32(vm: &mut VirtualMachine, rdr: &mut Read) -> PyResult {
+fn unpack_f32(vm: &VirtualMachine, rdr: &mut Read) -> PyResult {
     match rdr.read_f32::<LittleEndian>() {
         Err(err) => panic!("Error in reading {:?}", err),
         Ok(v) => Ok(vm.ctx.new_float(f64::from(v))),
     }
 }
 
-fn unpack_f64(vm: &mut VirtualMachine, rdr: &mut Read) -> PyResult {
+fn unpack_f64(vm: &VirtualMachine, rdr: &mut Read) -> PyResult {
     match rdr.read_f64::<LittleEndian>() {
         Err(err) => panic!("Error in reading {:?}", err),
         Ok(v) => Ok(vm.ctx.new_float(v)),
     }
 }
 
-fn struct_unpack(vm: &mut VirtualMachine, args: PyFuncArgs) -> PyResult {
+fn struct_unpack(vm: &VirtualMachine, args: PyFuncArgs) -> PyResult {
     arg_check!(
         vm,
         args,

--- a/vm/src/stdlib/random.rs
+++ b/vm/src/stdlib/random.rs
@@ -16,12 +16,12 @@ pub fn make_module(ctx: &PyContext) -> PyObjectRef {
     })
 }
 
-fn random_gauss(vm: &mut VirtualMachine, args: PyFuncArgs) -> PyResult {
+fn random_gauss(vm: &VirtualMachine, args: PyFuncArgs) -> PyResult {
     // TODO: is this the same?
     random_normalvariate(vm, args)
 }
 
-fn random_normalvariate(vm: &mut VirtualMachine, args: PyFuncArgs) -> PyResult {
+fn random_normalvariate(vm: &VirtualMachine, args: PyFuncArgs) -> PyResult {
     arg_check!(
         vm,
         args,
@@ -38,7 +38,7 @@ fn random_normalvariate(vm: &mut VirtualMachine, args: PyFuncArgs) -> PyResult {
     Ok(py_value)
 }
 
-fn random_random(vm: &mut VirtualMachine, args: PyFuncArgs) -> PyResult {
+fn random_random(vm: &VirtualMachine, args: PyFuncArgs) -> PyResult {
     arg_check!(vm, args);
     let value = rand::random::<f64>();
     let py_value = vm.ctx.new_float(value);
@@ -47,7 +47,7 @@ fn random_random(vm: &mut VirtualMachine, args: PyFuncArgs) -> PyResult {
 
 /*
  * TODO: enable this function:
-fn random_weibullvariate(vm: &mut VirtualMachine, args: PyFuncArgs) -> PyResult {
+fn random_weibullvariate(vm: &VirtualMachine, args: PyFuncArgs) -> PyResult {
     arg_check!(vm, args, required = [(alpha, Some(vm.ctx.float_type())), (beta, Some(vm.ctx.float_type()))]);
     let alpha = objfloat::get_value(alpha);
     let beta = objfloat::get_value(beta);

--- a/vm/src/stdlib/re.rs
+++ b/vm/src/stdlib/re.rs
@@ -18,7 +18,7 @@ use crate::pyobject::{
 use crate::vm::VirtualMachine;
 
 impl PyValue for Regex {
-    fn class(vm: &mut VirtualMachine) -> PyObjectRef {
+    fn class(vm: &VirtualMachine) -> PyObjectRef {
         vm.import("re").unwrap().get_attr("Pattern").unwrap()
     }
 }
@@ -47,7 +47,7 @@ pub fn make_module(ctx: &PyContext) -> PyObjectRef {
 /// Implement re.match
 /// See also:
 /// https://docs.python.org/3/library/re.html#re.match
-fn re_match(vm: &mut VirtualMachine, args: PyFuncArgs) -> PyResult {
+fn re_match(vm: &VirtualMachine, args: PyFuncArgs) -> PyResult {
     arg_check!(
         vm,
         args,
@@ -65,7 +65,7 @@ fn re_match(vm: &mut VirtualMachine, args: PyFuncArgs) -> PyResult {
 /// Implement re.search
 /// See also:
 /// https://docs.python.org/3/library/re.html#re.search
-fn re_search(vm: &mut VirtualMachine, args: PyFuncArgs) -> PyResult {
+fn re_search(vm: &VirtualMachine, args: PyFuncArgs) -> PyResult {
     arg_check!(
         vm,
         args,
@@ -82,19 +82,19 @@ fn re_search(vm: &mut VirtualMachine, args: PyFuncArgs) -> PyResult {
     do_search(vm, &regex, search_text)
 }
 
-fn do_match(vm: &mut VirtualMachine, regex: &Regex, search_text: String) -> PyResult {
+fn do_match(vm: &VirtualMachine, regex: &Regex, search_text: String) -> PyResult {
     // TODO: implement match!
     do_search(vm, regex, search_text)
 }
 
-fn do_search(vm: &mut VirtualMachine, regex: &Regex, search_text: String) -> PyResult {
+fn do_search(vm: &VirtualMachine, regex: &Regex, search_text: String) -> PyResult {
     match regex.find(&search_text) {
         None => Ok(vm.get_none()),
         Some(result) => create_match(vm, &result),
     }
 }
 
-fn make_regex(vm: &mut VirtualMachine, pattern: &PyObjectRef) -> PyResult<Regex> {
+fn make_regex(vm: &VirtualMachine, pattern: &PyObjectRef) -> PyResult<Regex> {
     let pattern_str = objstr::get_value(pattern);
 
     match Regex::new(&pattern_str) {
@@ -111,13 +111,13 @@ struct PyMatch {
 }
 
 impl PyValue for PyMatch {
-    fn class(vm: &mut VirtualMachine) -> PyObjectRef {
+    fn class(vm: &VirtualMachine) -> PyObjectRef {
         vm.class("re", "Match")
     }
 }
 
 /// Take a found regular expression and convert it to proper match object.
-fn create_match(vm: &mut VirtualMachine, match_value: &Match) -> PyResult {
+fn create_match(vm: &VirtualMachine, match_value: &Match) -> PyResult {
     // Return match object:
     // TODO: implement match object
     // TODO: how to refer to match object defined in this
@@ -138,7 +138,7 @@ fn create_match(vm: &mut VirtualMachine, match_value: &Match) -> PyResult {
 /// Compile a regular expression into a Pattern object.
 /// See also:
 /// https://docs.python.org/3/library/re.html#re.compile
-fn re_compile(vm: &mut VirtualMachine, args: PyFuncArgs) -> PyResult {
+fn re_compile(vm: &VirtualMachine, args: PyFuncArgs) -> PyResult {
     arg_check!(
         vm,
         args,
@@ -153,7 +153,7 @@ fn re_compile(vm: &mut VirtualMachine, args: PyFuncArgs) -> PyResult {
     Ok(PyObject::new(regex, pattern_class.clone()))
 }
 
-fn pattern_match(vm: &mut VirtualMachine, args: PyFuncArgs) -> PyResult {
+fn pattern_match(vm: &VirtualMachine, args: PyFuncArgs) -> PyResult {
     arg_check!(
         vm,
         args,
@@ -165,7 +165,7 @@ fn pattern_match(vm: &mut VirtualMachine, args: PyFuncArgs) -> PyResult {
     do_match(vm, &regex, search_text)
 }
 
-fn pattern_search(vm: &mut VirtualMachine, args: PyFuncArgs) -> PyResult {
+fn pattern_search(vm: &VirtualMachine, args: PyFuncArgs) -> PyResult {
     arg_check!(
         vm,
         args,
@@ -179,14 +179,14 @@ fn pattern_search(vm: &mut VirtualMachine, args: PyFuncArgs) -> PyResult {
 
 /// Returns start of match
 /// see: https://docs.python.org/3/library/re.html#re.Match.start
-fn match_start(vm: &mut VirtualMachine, args: PyFuncArgs) -> PyResult {
+fn match_start(vm: &VirtualMachine, args: PyFuncArgs) -> PyResult {
     arg_check!(vm, args, required = [(zelf, None)]);
     // TODO: implement groups
     let m = get_match(zelf);
     Ok(vm.new_int(m.start))
 }
 
-fn match_end(vm: &mut VirtualMachine, args: PyFuncArgs) -> PyResult {
+fn match_end(vm: &VirtualMachine, args: PyFuncArgs) -> PyResult {
     arg_check!(vm, args, required = [(zelf, None)]);
     // TODO: implement groups
     let m = get_match(zelf);

--- a/vm/src/stdlib/socket.rs
+++ b/vm/src/stdlib/socket.rs
@@ -23,7 +23,7 @@ enum AddressFamily {
 }
 
 impl AddressFamily {
-    fn from_i32(vm: &mut VirtualMachine, value: i32) -> Result<AddressFamily, PyObjectRef> {
+    fn from_i32(vm: &VirtualMachine, value: i32) -> Result<AddressFamily, PyObjectRef> {
         match value {
             1 => Ok(AddressFamily::Unix),
             2 => Ok(AddressFamily::Inet),
@@ -40,7 +40,7 @@ enum SocketKind {
 }
 
 impl SocketKind {
-    fn from_i32(vm: &mut VirtualMachine, value: i32) -> Result<SocketKind, PyObjectRef> {
+    fn from_i32(vm: &VirtualMachine, value: i32) -> Result<SocketKind, PyObjectRef> {
         match value {
             1 => Ok(SocketKind::Stream),
             2 => Ok(SocketKind::Dgram),
@@ -118,7 +118,7 @@ pub struct Socket {
 }
 
 impl PyValue for Socket {
-    fn class(_vm: &mut VirtualMachine) -> PyObjectRef {
+    fn class(_vm: &VirtualMachine) -> PyObjectRef {
         // TODO
         unimplemented!()
     }
@@ -138,7 +138,7 @@ fn get_socket<'a>(obj: &'a PyObjectRef) -> impl Deref<Target = Socket> + 'a {
     obj.payload::<Socket>().unwrap()
 }
 
-fn socket_new(vm: &mut VirtualMachine, args: PyFuncArgs) -> PyResult {
+fn socket_new(vm: &VirtualMachine, args: PyFuncArgs) -> PyResult {
     arg_check!(
         vm,
         args,
@@ -159,7 +159,7 @@ fn socket_new(vm: &mut VirtualMachine, args: PyFuncArgs) -> PyResult {
     ))
 }
 
-fn socket_connect(vm: &mut VirtualMachine, args: PyFuncArgs) -> PyResult {
+fn socket_connect(vm: &VirtualMachine, args: PyFuncArgs) -> PyResult {
     arg_check!(
         vm,
         args,
@@ -194,7 +194,7 @@ fn socket_connect(vm: &mut VirtualMachine, args: PyFuncArgs) -> PyResult {
     }
 }
 
-fn socket_bind(vm: &mut VirtualMachine, args: PyFuncArgs) -> PyResult {
+fn socket_bind(vm: &VirtualMachine, args: PyFuncArgs) -> PyResult {
     arg_check!(
         vm,
         args,
@@ -229,10 +229,7 @@ fn socket_bind(vm: &mut VirtualMachine, args: PyFuncArgs) -> PyResult {
     }
 }
 
-fn get_address_string(
-    vm: &mut VirtualMachine,
-    address: &PyObjectRef,
-) -> Result<String, PyObjectRef> {
+fn get_address_string(vm: &VirtualMachine, address: &PyObjectRef) -> Result<String, PyObjectRef> {
     let args = PyFuncArgs {
         args: get_elements(address).to_vec(),
         kwargs: vec![],
@@ -253,7 +250,7 @@ fn get_address_string(
     ))
 }
 
-fn socket_listen(vm: &mut VirtualMachine, args: PyFuncArgs) -> PyResult {
+fn socket_listen(vm: &VirtualMachine, args: PyFuncArgs) -> PyResult {
     arg_check!(
         vm,
         args,
@@ -262,7 +259,7 @@ fn socket_listen(vm: &mut VirtualMachine, args: PyFuncArgs) -> PyResult {
     Ok(vm.get_none())
 }
 
-fn socket_accept(vm: &mut VirtualMachine, args: PyFuncArgs) -> PyResult {
+fn socket_accept(vm: &VirtualMachine, args: PyFuncArgs) -> PyResult {
     arg_check!(vm, args, required = [(zelf, None)]);
 
     let socket = get_socket(zelf);
@@ -290,7 +287,7 @@ fn socket_accept(vm: &mut VirtualMachine, args: PyFuncArgs) -> PyResult {
     Ok(vm.ctx.new_tuple(vec![sock_obj, addr_tuple]))
 }
 
-fn socket_recv(vm: &mut VirtualMachine, args: PyFuncArgs) -> PyResult {
+fn socket_recv(vm: &VirtualMachine, args: PyFuncArgs) -> PyResult {
     arg_check!(
         vm,
         args,
@@ -309,7 +306,7 @@ fn socket_recv(vm: &mut VirtualMachine, args: PyFuncArgs) -> PyResult {
     Ok(vm.ctx.new_bytes(buffer))
 }
 
-fn socket_recvfrom(vm: &mut VirtualMachine, args: PyFuncArgs) -> PyResult {
+fn socket_recvfrom(vm: &VirtualMachine, args: PyFuncArgs) -> PyResult {
     arg_check!(
         vm,
         args,
@@ -334,7 +331,7 @@ fn socket_recvfrom(vm: &mut VirtualMachine, args: PyFuncArgs) -> PyResult {
     Ok(vm.ctx.new_tuple(vec![vm.ctx.new_bytes(buffer), addr_tuple]))
 }
 
-fn socket_send(vm: &mut VirtualMachine, args: PyFuncArgs) -> PyResult {
+fn socket_send(vm: &VirtualMachine, args: PyFuncArgs) -> PyResult {
     arg_check!(
         vm,
         args,
@@ -352,7 +349,7 @@ fn socket_send(vm: &mut VirtualMachine, args: PyFuncArgs) -> PyResult {
     Ok(vm.get_none())
 }
 
-fn socket_sendto(vm: &mut VirtualMachine, args: PyFuncArgs) -> PyResult {
+fn socket_sendto(vm: &VirtualMachine, args: PyFuncArgs) -> PyResult {
     arg_check!(
         vm,
         args,
@@ -393,7 +390,7 @@ fn socket_sendto(vm: &mut VirtualMachine, args: PyFuncArgs) -> PyResult {
     }
 }
 
-fn socket_close(vm: &mut VirtualMachine, args: PyFuncArgs) -> PyResult {
+fn socket_close(vm: &VirtualMachine, args: PyFuncArgs) -> PyResult {
     arg_check!(vm, args, required = [(zelf, None)]);
 
     let socket = get_socket(zelf);
@@ -401,7 +398,7 @@ fn socket_close(vm: &mut VirtualMachine, args: PyFuncArgs) -> PyResult {
     Ok(vm.get_none())
 }
 
-fn socket_getsockname(vm: &mut VirtualMachine, args: PyFuncArgs) -> PyResult {
+fn socket_getsockname(vm: &VirtualMachine, args: PyFuncArgs) -> PyResult {
     arg_check!(vm, args, required = [(zelf, None)]);
     let socket = get_socket(zelf);
 
@@ -416,7 +413,7 @@ fn socket_getsockname(vm: &mut VirtualMachine, args: PyFuncArgs) -> PyResult {
     }
 }
 
-fn get_addr_tuple(vm: &mut VirtualMachine, addr: SocketAddr) -> PyResult {
+fn get_addr_tuple(vm: &VirtualMachine, addr: SocketAddr) -> PyResult {
     let port = vm.ctx.new_int(addr.port());
     let ip = vm.ctx.new_str(addr.ip().to_string());
 

--- a/vm/src/stdlib/time_module.rs
+++ b/vm/src/stdlib/time_module.rs
@@ -8,7 +8,7 @@ use crate::obj::objfloat;
 use crate::pyobject::{PyContext, PyObjectRef, PyResult, TypeProtocol};
 use crate::vm::VirtualMachine;
 
-fn time_sleep(vm: &mut VirtualMachine, args: PyFuncArgs) -> PyResult {
+fn time_sleep(vm: &VirtualMachine, args: PyFuncArgs) -> PyResult {
     arg_check!(vm, args, required = [(seconds, Some(vm.ctx.float_type()))]);
     let seconds = objfloat::get_value(seconds);
     let secs: u64 = seconds.trunc() as u64;
@@ -22,7 +22,7 @@ fn duration_to_f64(d: Duration) -> f64 {
     (d.as_secs() as f64) + (f64::from(d.subsec_nanos()) / 1e9)
 }
 
-fn time_time(vm: &mut VirtualMachine, args: PyFuncArgs) -> PyResult {
+fn time_time(vm: &VirtualMachine, args: PyFuncArgs) -> PyResult {
     arg_check!(vm, args);
     let x = match SystemTime::now().duration_since(UNIX_EPOCH) {
         Ok(v) => duration_to_f64(v),

--- a/vm/src/stdlib/tokenize.rs
+++ b/vm/src/stdlib/tokenize.rs
@@ -11,7 +11,7 @@ use crate::obj::objstr;
 use crate::pyobject::{PyContext, PyObjectRef, PyResult, TypeProtocol};
 use crate::vm::VirtualMachine;
 
-fn tokenize_tokenize(vm: &mut VirtualMachine, args: PyFuncArgs) -> PyResult {
+fn tokenize_tokenize(vm: &VirtualMachine, args: PyFuncArgs) -> PyResult {
     arg_check!(vm, args, required = [(readline, Some(vm.ctx.str_type()))]);
     let source = objstr::get_value(readline);
 

--- a/vm/src/stdlib/types.rs
+++ b/vm/src/stdlib/types.rs
@@ -7,7 +7,7 @@ use crate::obj::objtype;
 use crate::pyobject::{PyContext, PyObjectRef, PyResult, TypeProtocol};
 use crate::VirtualMachine;
 
-fn types_new_class(vm: &mut VirtualMachine, args: PyFuncArgs) -> PyResult {
+fn types_new_class(vm: &VirtualMachine, args: PyFuncArgs) -> PyResult {
     arg_check!(
         vm,
         args,

--- a/vm/src/sysmodule.rs
+++ b/vm/src/sysmodule.rs
@@ -18,7 +18,7 @@ fn argv(ctx: &PyContext) -> PyObjectRef {
     ctx.new_list(argv)
 }
 
-fn frame_idx(vm: &mut VirtualMachine, offset: Option<&PyObjectRef>) -> Result<usize, PyObjectRef> {
+fn frame_idx(vm: &VirtualMachine, offset: Option<&PyObjectRef>) -> Result<usize, PyObjectRef> {
     if let Some(int) = offset {
         if let Some(offset) = objint::get_value(&int).to_usize() {
             if offset > vm.frames.borrow().len() - 1 {
@@ -30,7 +30,7 @@ fn frame_idx(vm: &mut VirtualMachine, offset: Option<&PyObjectRef>) -> Result<us
     Ok(0)
 }
 
-fn getframe(vm: &mut VirtualMachine, args: PyFuncArgs) -> PyResult {
+fn getframe(vm: &VirtualMachine, args: PyFuncArgs) -> PyResult {
     arg_check!(
         vm,
         args,
@@ -44,13 +44,13 @@ fn getframe(vm: &mut VirtualMachine, args: PyFuncArgs) -> PyResult {
     Ok(frame.clone())
 }
 
-fn sys_getrefcount(vm: &mut VirtualMachine, args: PyFuncArgs) -> PyResult {
+fn sys_getrefcount(vm: &VirtualMachine, args: PyFuncArgs) -> PyResult {
     arg_check!(vm, args, required = [(object, None)]);
     let size = Rc::strong_count(&object);
     Ok(vm.ctx.new_int(size))
 }
 
-fn sys_getsizeof(vm: &mut VirtualMachine, args: PyFuncArgs) -> PyResult {
+fn sys_getsizeof(vm: &VirtualMachine, args: PyFuncArgs) -> PyResult {
     arg_check!(vm, args, required = [(object, None)]);
     // TODO: implement default optional argument.
     let size = mem::size_of_val(&object);

--- a/wasm/lib/src/vm_class.rs
+++ b/wasm/lib/src/vm_class.rs
@@ -32,7 +32,7 @@ impl StoredVirtualMachine {
         let mut vm = VirtualMachine::new();
         let scope = vm.ctx.new_scope();
         if inject_browser_module {
-            setup_browser_module(&mut vm);
+            setup_browser_module(&vm);
         }
         vm.wasm_id = Some(id);
         StoredVirtualMachine {

--- a/wasm/lib/src/wasm_builtins.rs
+++ b/wasm/lib/src/wasm_builtins.rs
@@ -16,7 +16,7 @@ pub(crate) fn window() -> web_sys::Window {
     web_sys::window().expect("Window to be available")
 }
 
-pub fn format_print_args(vm: &mut VirtualMachine, args: PyFuncArgs) -> Result<String, PyObjectRef> {
+pub fn format_print_args(vm: &VirtualMachine, args: PyFuncArgs) -> Result<String, PyObjectRef> {
     // Handle 'sep' kwarg:
     let sep_arg = args
         .get_optional_kwarg("sep")
@@ -68,7 +68,7 @@ pub fn format_print_args(vm: &mut VirtualMachine, args: PyFuncArgs) -> Result<St
     Ok(output)
 }
 
-pub fn builtin_print_console(vm: &mut VirtualMachine, args: PyFuncArgs) -> PyResult {
+pub fn builtin_print_console(vm: &VirtualMachine, args: PyFuncArgs) -> PyResult {
     let arr = Array::new();
     for arg in args.args {
         arr.push(&vm.to_pystr(&arg)?.into());


### PR DESCRIPTION
Resolves #713.

I did some fiddling in WASM cause I realized we didn't need whatever the heck I had done with `AccessibleVMPtr`, but otherwise it's just a regex `&mut VirtualMachine` -> `&VirtualMachine`.