### PR TITLE
Allow mutiple types in PyValue

### DIFF
--- a/vm/src/frame.rs
+++ b/vm/src/frame.rs
@@ -185,8 +185,8 @@ pub struct Frame {
 }
 
 impl PyValue for Frame {
-    fn class(vm: &VirtualMachine) -> PyObjectRef {
-        vm.ctx.frame_type()
+    fn class(vm: &VirtualMachine) -> Vec<PyObjectRef> {
+        vec![vm.ctx.frame_type()]
     }
 }
 

--- a/vm/src/obj/objbuiltinfunc.rs
+++ b/vm/src/obj/objbuiltinfunc.rs
@@ -10,8 +10,8 @@ pub struct PyBuiltinFunction {
 }
 
 impl PyValue for PyBuiltinFunction {
-    fn class(vm: &VirtualMachine) -> PyObjectRef {
-        vm.ctx.builtin_function_or_method_type()
+    fn class(vm: &VirtualMachine) -> Vec<PyObjectRef> {
+        vec![vm.ctx.builtin_function_or_method_type()]
     }
 }
 

--- a/vm/src/obj/objbytearray.rs
+++ b/vm/src/obj/objbytearray.rs
@@ -29,8 +29,8 @@ impl PyByteArray {
 }
 
 impl PyValue for PyByteArray {
-    fn class(vm: &VirtualMachine) -> PyObjectRef {
-        vm.ctx.bytearray_type()
+    fn class(vm: &VirtualMachine) -> Vec<PyObjectRef> {
+        vec![vm.ctx.bytearray_type()]
     }
 }
 

--- a/vm/src/obj/objbytes.rs
+++ b/vm/src/obj/objbytes.rs
@@ -34,8 +34,8 @@ impl Deref for PyBytes {
 }
 
 impl PyValue for PyBytes {
-    fn class(vm: &VirtualMachine) -> PyObjectRef {
-        vm.ctx.bytes_type()
+    fn class(vm: &VirtualMachine) -> Vec<PyObjectRef> {
+        vec![vm.ctx.bytes_type()]
     }
 }
 

--- a/vm/src/obj/objclassmethod.rs
+++ b/vm/src/obj/objclassmethod.rs
@@ -9,8 +9,8 @@ pub struct PyClassMethod {
 pub type PyClassMethodRef = PyRef<PyClassMethod>;
 
 impl PyValue for PyClassMethod {
-    fn class(vm: &VirtualMachine) -> PyObjectRef {
-        vm.ctx.classmethod_type()
+    fn class(vm: &VirtualMachine) -> Vec<PyObjectRef> {
+        vec![vm.ctx.classmethod_type()]
     }
 }
 

--- a/vm/src/obj/objcode.rs
+++ b/vm/src/obj/objcode.rs
@@ -26,8 +26,8 @@ impl fmt::Debug for PyCode {
 }
 
 impl PyValue for PyCode {
-    fn class(vm: &VirtualMachine) -> PyObjectRef {
-        vm.ctx.code_type()
+    fn class(vm: &VirtualMachine) -> Vec<PyObjectRef> {
+        vec![vm.ctx.code_type()]
     }
 }
 

--- a/vm/src/obj/objcomplex.rs
+++ b/vm/src/obj/objcomplex.rs
@@ -16,8 +16,8 @@ pub struct PyComplex {
 type PyComplexRef = PyRef<PyComplex>;
 
 impl PyValue for PyComplex {
-    fn class(vm: &VirtualMachine) -> PyObjectRef {
-        vm.ctx.complex_type()
+    fn class(vm: &VirtualMachine) -> Vec<PyObjectRef> {
+        vec![vm.ctx.complex_type()]
     }
 }
 

--- a/vm/src/obj/objdict.rs
+++ b/vm/src/obj/objdict.rs
@@ -30,8 +30,8 @@ impl fmt::Debug for PyDict {
 }
 
 impl PyValue for PyDict {
-    fn class(vm: &VirtualMachine) -> PyObjectRef {
-        vm.ctx.dict_type()
+    fn class(vm: &VirtualMachine) -> Vec<PyObjectRef> {
+        vec![vm.ctx.dict_type()]
     }
 }
 

--- a/vm/src/obj/objenumerate.rs
+++ b/vm/src/obj/objenumerate.rs
@@ -20,8 +20,8 @@ pub struct PyEnumerate {
 type PyEnumerateRef = PyRef<PyEnumerate>;
 
 impl PyValue for PyEnumerate {
-    fn class(vm: &VirtualMachine) -> PyObjectRef {
-        vm.ctx.enumerate_type()
+    fn class(vm: &VirtualMachine) -> Vec<PyObjectRef> {
+        vec![vm.ctx.enumerate_type()]
     }
 }
 

--- a/vm/src/obj/objfilter.rs
+++ b/vm/src/obj/objfilter.rs
@@ -14,8 +14,8 @@ pub struct PyFilter {
 }
 
 impl PyValue for PyFilter {
-    fn class(vm: &VirtualMachine) -> PyObjectRef {
-        vm.ctx.filter_type()
+    fn class(vm: &VirtualMachine) -> Vec<PyObjectRef> {
+        vec![vm.ctx.filter_type()]
     }
 }
 

--- a/vm/src/obj/objfloat.rs
+++ b/vm/src/obj/objfloat.rs
@@ -16,8 +16,8 @@ pub struct PyFloat {
 }
 
 impl PyValue for PyFloat {
-    fn class(vm: &VirtualMachine) -> PyObjectRef {
-        vm.ctx.float_type()
+    fn class(vm: &VirtualMachine) -> Vec<PyObjectRef> {
+        vec![vm.ctx.float_type()]
     }
 }
 

--- a/vm/src/obj/objfunction.rs
+++ b/vm/src/obj/objfunction.rs
@@ -22,8 +22,8 @@ impl PyFunction {
 }
 
 impl PyValue for PyFunction {
-    fn class(vm: &VirtualMachine) -> PyObjectRef {
-        vm.ctx.function_type()
+    fn class(vm: &VirtualMachine) -> Vec<PyObjectRef> {
+        vec![vm.ctx.function_type()]
     }
 }
 
@@ -41,8 +41,8 @@ impl PyMethod {
 }
 
 impl PyValue for PyMethod {
-    fn class(vm: &VirtualMachine) -> PyObjectRef {
-        vm.ctx.bound_method_type()
+    fn class(vm: &VirtualMachine) -> Vec<PyObjectRef> {
+        vec![vm.ctx.bound_method_type()]
     }
 }
 

--- a/vm/src/obj/objgenerator.rs
+++ b/vm/src/obj/objgenerator.rs
@@ -14,8 +14,8 @@ pub struct PyGenerator {
 type PyGeneratorRef = PyRef<PyGenerator>;
 
 impl PyValue for PyGenerator {
-    fn class(vm: &VirtualMachine) -> PyObjectRef {
-        vm.ctx.generator_type()
+    fn class(vm: &VirtualMachine) -> Vec<PyObjectRef> {
+        vec![vm.ctx.generator_type()]
     }
 }
 

--- a/vm/src/obj/objint.rs
+++ b/vm/src/obj/objint.rs
@@ -37,8 +37,8 @@ impl IntoPyObject for BigInt {
 }
 
 impl PyValue for PyInt {
-    fn class(vm: &VirtualMachine) -> PyObjectRef {
-        vm.ctx.int_type()
+    fn class(vm: &VirtualMachine) -> Vec<PyObjectRef> {
+        vec![vm.ctx.int_type()]
     }
 }
 

--- a/vm/src/obj/objlist.rs
+++ b/vm/src/obj/objlist.rs
@@ -40,8 +40,8 @@ impl From<Vec<PyObjectRef>> for PyList {
 }
 
 impl PyValue for PyList {
-    fn class(vm: &VirtualMachine) -> PyObjectRef {
-        vm.ctx.list_type()
+    fn class(vm: &VirtualMachine) -> Vec<PyObjectRef> {
+        vec![vm.ctx.list_type()]
     }
 }
 

--- a/vm/src/obj/objmap.rs
+++ b/vm/src/obj/objmap.rs
@@ -13,8 +13,8 @@ pub struct PyMap {
 type PyMapRef = PyRef<PyMap>;
 
 impl PyValue for PyMap {
-    fn class(vm: &VirtualMachine) -> PyObjectRef {
-        vm.ctx.map_type()
+    fn class(vm: &VirtualMachine) -> Vec<PyObjectRef> {
+        vec![vm.ctx.map_type()]
     }
 }
 

--- a/vm/src/obj/objmemory.rs
+++ b/vm/src/obj/objmemory.rs
@@ -8,8 +8,8 @@ pub struct PyMemoryView {
 }
 
 impl PyValue for PyMemoryView {
-    fn class(vm: &VirtualMachine) -> PyObjectRef {
-        vm.ctx.memoryview_type()
+    fn class(vm: &VirtualMachine) -> Vec<PyObjectRef> {
+        vec![vm.ctx.memoryview_type()]
     }
 }
 

--- a/vm/src/obj/objmodule.rs
+++ b/vm/src/obj/objmodule.rs
@@ -10,8 +10,8 @@ pub struct PyModule {
 pub type PyModuleRef = PyRef<PyModule>;
 
 impl PyValue for PyModule {
-    fn class(vm: &VirtualMachine) -> PyObjectRef {
-        vm.ctx.module_type()
+    fn class(vm: &VirtualMachine) -> Vec<PyObjectRef> {
+        vec![vm.ctx.module_type()]
     }
 }
 

--- a/vm/src/obj/objnone.rs
+++ b/vm/src/obj/objnone.rs
@@ -12,8 +12,8 @@ pub struct PyNone;
 pub type PyNoneRef = PyRef<PyNone>;
 
 impl PyValue for PyNone {
-    fn class(vm: &VirtualMachine) -> PyObjectRef {
-        vm.ctx.none().typ()
+    fn class(vm: &VirtualMachine) -> Vec<PyObjectRef> {
+        vec![vm.ctx.none().typ()]
     }
 }
 

--- a/vm/src/obj/objobject.rs
+++ b/vm/src/obj/objobject.rs
@@ -13,8 +13,8 @@ use crate::vm::VirtualMachine;
 pub struct PyInstance;
 
 impl PyValue for PyInstance {
-    fn class(vm: &VirtualMachine) -> PyObjectRef {
-        vm.ctx.object()
+    fn class(vm: &VirtualMachine) -> Vec<PyObjectRef> {
+        vec![vm.ctx.object()]
     }
 }
 

--- a/vm/src/obj/objproperty.rs
+++ b/vm/src/obj/objproperty.rs
@@ -16,8 +16,8 @@ pub struct PyReadOnlyProperty {
 }
 
 impl PyValue for PyReadOnlyProperty {
-    fn class(vm: &VirtualMachine) -> PyObjectRef {
-        vm.ctx.readonly_property_type()
+    fn class(vm: &VirtualMachine) -> Vec<PyObjectRef> {
+        vec![vm.ctx.readonly_property_type()]
     }
 }
 
@@ -47,8 +47,8 @@ pub struct PyProperty {
 }
 
 impl PyValue for PyProperty {
-    fn class(vm: &VirtualMachine) -> PyObjectRef {
-        vm.ctx.property_type()
+    fn class(vm: &VirtualMachine) -> Vec<PyObjectRef> {
+        vec![vm.ctx.property_type()]
     }
 }
 

--- a/vm/src/obj/objrange.rs
+++ b/vm/src/obj/objrange.rs
@@ -25,8 +25,8 @@ pub struct PyRange {
 }
 
 impl PyValue for PyRange {
-    fn class(vm: &VirtualMachine) -> PyObjectRef {
-        vm.ctx.range_type()
+    fn class(vm: &VirtualMachine) -> Vec<PyObjectRef> {
+        vec![vm.ctx.range_type()]
     }
 }
 

--- a/vm/src/obj/objset.rs
+++ b/vm/src/obj/objset.rs
@@ -32,8 +32,8 @@ impl fmt::Debug for PySet {
 }
 
 impl PyValue for PySet {
-    fn class(vm: &VirtualMachine) -> PyObjectRef {
-        vm.ctx.set_type()
+    fn class(vm: &VirtualMachine) -> Vec<PyObjectRef> {
+        vec![vm.ctx.set_type()]
     }
 }
 

--- a/vm/src/obj/objslice.rs
+++ b/vm/src/obj/objslice.rs
@@ -15,8 +15,8 @@ pub struct PySlice {
 }
 
 impl PyValue for PySlice {
-    fn class(vm: &VirtualMachine) -> PyObjectRef {
-        vm.ctx.slice_type()
+    fn class(vm: &VirtualMachine) -> Vec<PyObjectRef> {
+        vec![vm.ctx.slice_type()]
     }
 }
 

--- a/vm/src/obj/objstaticmethod.rs
+++ b/vm/src/obj/objstaticmethod.rs
@@ -9,8 +9,8 @@ pub struct PyStaticMethod {
 pub type PyStaticMethodRef = PyRef<PyStaticMethod>;
 
 impl PyValue for PyStaticMethod {
-    fn class(vm: &VirtualMachine) -> PyObjectRef {
-        vm.ctx.staticmethod_type()
+    fn class(vm: &VirtualMachine) -> Vec<PyObjectRef> {
+        vec![vm.ctx.staticmethod_type()]
     }
 }
 

--- a/vm/src/obj/objstr.rs
+++ b/vm/src/obj/objstr.rs
@@ -605,8 +605,8 @@ impl PyStringRef {
 }
 
 impl PyValue for PyString {
-    fn class(vm: &VirtualMachine) -> PyObjectRef {
-        vm.ctx.str_type()
+    fn class(vm: &VirtualMachine) -> Vec<PyObjectRef> {
+        vec![vm.ctx.str_type()]
     }
 }
 

--- a/vm/src/obj/objsuper.rs
+++ b/vm/src/obj/objsuper.rs
@@ -21,8 +21,8 @@ pub struct PySuper {
 }
 
 impl PyValue for PySuper {
-    fn class(vm: &VirtualMachine) -> PyObjectRef {
-        vm.ctx.super_type()
+    fn class(vm: &VirtualMachine) -> Vec<PyObjectRef> {
+        vec![vm.ctx.super_type()]
     }
 }
 

--- a/vm/src/obj/objtuple.rs
+++ b/vm/src/obj/objtuple.rs
@@ -38,8 +38,8 @@ impl From<Vec<PyObjectRef>> for PyTuple {
 }
 
 impl PyValue for PyTuple {
-    fn class(vm: &VirtualMachine) -> PyObjectRef {
-        vm.ctx.tuple_type()
+    fn class(vm: &VirtualMachine) -> Vec<PyObjectRef> {
+        vec![vm.ctx.tuple_type()]
     }
 }
 

--- a/vm/src/obj/objtype.rs
+++ b/vm/src/obj/objtype.rs
@@ -30,8 +30,8 @@ impl fmt::Display for PyClass {
 pub type PyClassRef = PyRef<PyClass>;
 
 impl PyValue for PyClass {
-    fn class(vm: &VirtualMachine) -> PyObjectRef {
-        vm.ctx.type_type()
+    fn class(vm: &VirtualMachine) -> Vec<PyObjectRef> {
+        vec![vm.ctx.type_type()]
     }
 }
 

--- a/vm/src/obj/objweakref.rs
+++ b/vm/src/obj/objweakref.rs
@@ -23,8 +23,8 @@ impl PyWeak {
 }
 
 impl PyValue for PyWeak {
-    fn class(vm: &VirtualMachine) -> PyObjectRef {
-        vm.ctx.weakref_type()
+    fn class(vm: &VirtualMachine) -> Vec<PyObjectRef> {
+        vec![vm.ctx.weakref_type()]
     }
 }
 

--- a/vm/src/obj/objzip.rs
+++ b/vm/src/obj/objzip.rs
@@ -10,8 +10,8 @@ pub struct PyZip {
 }
 
 impl PyValue for PyZip {
-    fn class(vm: &VirtualMachine) -> PyObjectRef {
-        vm.ctx.zip_type()
+    fn class(vm: &VirtualMachine) -> Vec<PyObjectRef> {
+        vec![vm.ctx.zip_type()]
     }
 }
 

--- a/vm/src/stdlib/io.rs
+++ b/vm/src/stdlib/io.rs
@@ -42,8 +42,8 @@ struct PyStringIO {
 type PyStringIORef = PyRef<PyStringIO>;
 
 impl PyValue for PyStringIO {
-    fn class(vm: &VirtualMachine) -> PyObjectRef {
-        vm.class("io", "StringIO")
+    fn class(vm: &VirtualMachine) -> Vec<PyObjectRef> {
+        vec![vm.class("io", "StringIO")]
     }
 }
 

--- a/vm/src/stdlib/re.rs
+++ b/vm/src/stdlib/re.rs
@@ -16,8 +16,8 @@ use crate::pyobject::{PyContext, PyObject, PyObjectRef, PyResult, PyValue, TypeP
 use crate::vm::VirtualMachine;
 
 impl PyValue for Regex {
-    fn class(vm: &VirtualMachine) -> PyObjectRef {
-        vm.class("re", "Pattern")
+    fn class(vm: &VirtualMachine) -> Vec<PyObjectRef> {
+        vec![vm.class("re", "Pattern")]
     }
 }
 
@@ -109,8 +109,8 @@ struct PyMatch {
 }
 
 impl PyValue for PyMatch {
-    fn class(vm: &VirtualMachine) -> PyObjectRef {
-        vm.class("re", "Match")
+    fn class(vm: &VirtualMachine) -> Vec<PyObjectRef> {
+        vec![vm.class("re", "Match")]
     }
 }
 

--- a/vm/src/stdlib/socket.rs
+++ b/vm/src/stdlib/socket.rs
@@ -118,7 +118,7 @@ pub struct Socket {
 }
 
 impl PyValue for Socket {
-    fn class(_vm: &VirtualMachine) -> PyObjectRef {
+    fn class(_vm: &VirtualMachine) -> Vec<PyObjectRef> {
         // TODO
         unimplemented!()
     }


### PR DESCRIPTION
As suggested by @adrian17 #715. This will allow the same `PyValue`  to be used for multiple types. For example:

- `set` and `frozenset`
- `bytes` and `bytearray`