### PR TITLE
Remove FromPyObjectRef, replace with downcast

### DIFF
--- a/vm/src/obj/objint.rs
+++ b/vm/src/obj/objint.rs
@@ -7,8 +7,7 @@ use num_traits::{Pow, Signed, ToPrimitive, Zero};
 use crate::format::FormatSpec;
 use crate::function::{OptionalArg, PyFuncArgs};
 use crate::pyobject::{
-    FromPyObjectRef, IntoPyObject, PyContext, PyObjectRef, PyRef, PyResult, PyValue, TryFromObject,
-    TypeProtocol,
+    IntoPyObject, PyContext, PyObjectRef, PyRef, PyResult, PyValue, TryFromObject, TypeProtocol,
 };
 use crate::vm::VirtualMachine;
 
@@ -388,7 +387,7 @@ fn int_new(vm: &VirtualMachine, args: PyFuncArgs) -> PyResult {
         None => Zero::zero(),
     };
     Ok(PyInt::new(val)
-        .into_ref_with_type(vm, PyClassRef::from_pyobj(cls))?
+        .into_ref_with_type(vm, cls.clone().downcast().unwrap())?
         .into_object())
 }
 

--- a/vm/src/obj/objtype.rs
+++ b/vm/src/obj/objtype.rs
@@ -4,8 +4,8 @@ use std::fmt;
 
 use crate::function::{Args, KwArgs, PyFuncArgs};
 use crate::pyobject::{
-    FromPyObjectRef, IdProtocol, PyAttributes, PyContext, PyObject, PyObjectRef, PyRef, PyResult,
-    PyValue, TypeProtocol,
+    IdProtocol, PyAttributes, PyContext, PyObject, PyObjectRef, PyRef, PyResult, PyValue,
+    TypeProtocol,
 };
 use crate::vm::VirtualMachine;
 
@@ -236,7 +236,7 @@ pub fn type_new_class(
     let mut bases: Vec<PyClassRef> = vm
         .extract_elements(bases)?
         .iter()
-        .map(|x| FromPyObjectRef::from_pyobj(x))
+        .map(|x| x.clone().downcast().unwrap())
         .collect();
     bases.push(vm.ctx.object());
     let name = objstr::get_value(name);

--- a/vm/src/obj/objtype.rs
+++ b/vm/src/obj/objtype.rs
@@ -385,7 +385,6 @@ pub fn new(
 
 #[cfg(test)]
 mod tests {
-    use super::FromPyObjectRef;
     use super::{linearise_mro, new};
     use super::{HashMap, IdProtocol, PyClassRef, PyContext};
 
@@ -417,8 +416,8 @@ mod tests {
         )
         .unwrap();
 
-        let a: PyClassRef = FromPyObjectRef::from_pyobj(&a);
-        let b: PyClassRef = FromPyObjectRef::from_pyobj(&b);
+        let a: PyClassRef = a.downcast().unwrap();
+        let b: PyClassRef = b.downcast().unwrap();
 
         assert_eq!(
             map_ids(linearise_mro(vec![

--- a/vm/src/stdlib/json.rs
+++ b/vm/src/stdlib/json.rs
@@ -6,15 +6,13 @@ use serde::ser::{SerializeMap, SerializeSeq};
 use serde_json;
 
 use crate::function::PyFuncArgs;
-use crate::obj::objtype::PyClassRef;
 use crate::obj::{
     objbool, objdict, objfloat, objint, objsequence,
     objstr::{self, PyString},
     objtype,
 };
 use crate::pyobject::{
-    create_type, DictProtocol, FromPyObjectRef, IdProtocol, PyContext, PyObjectRef, PyResult,
-    TypeProtocol,
+    create_type, DictProtocol, IdProtocol, PyContext, PyObjectRef, PyResult, TypeProtocol,
 };
 use crate::VirtualMachine;
 use num_traits::cast::ToPrimitive;
@@ -208,7 +206,7 @@ pub fn de_pyobject(vm: &VirtualMachine, s: &str) -> PyResult {
                 .unwrap()
                 .get_item("JSONDecodeError")
                 .unwrap();
-            let json_decode_error = PyClassRef::from_pyobj(&json_decode_error);
+            let json_decode_error = json_decode_error.downcast().unwrap();
             let exc = vm.new_exception(json_decode_error, format!("{}", err));
             vm.ctx.set_attr(&exc, "lineno", vm.ctx.new_int(err.line()));
             vm.ctx.set_attr(&exc, "colno", vm.ctx.new_int(err.column()));

--- a/vm/src/vm.rs
+++ b/vm/src/vm.rs
@@ -30,8 +30,8 @@ use crate::obj::objtuple::PyTuple;
 use crate::obj::objtype;
 use crate::obj::objtype::PyClassRef;
 use crate::pyobject::{
-    DictProtocol, FromPyObjectRef, IdProtocol, PyContext, PyObjectRef, PyResult, TryFromObject,
-    TryIntoRef, TypeProtocol,
+    DictProtocol, IdProtocol, PyContext, PyObjectRef, PyResult, TryFromObject, TryIntoRef,
+    TypeProtocol,
 };
 use crate::stdlib;
 use crate::sysmodule;
@@ -112,7 +112,7 @@ impl VirtualMachine {
         let class = self
             .get_attribute(module.clone(), class)
             .unwrap_or_else(|_| panic!("module {} has no class {}", module, class));
-        PyClassRef::from_pyobj(&class)
+        class.downcast().unwrap()
     }
 
     /// Create a new python string object.


### PR DESCRIPTION
This is the first in a series of PRs that prepare for the merging of `PyRef` and `PyObjectRef` (so that the latter is an alias for `PyRef<dyn PyObjectPayload>` and the payload type of a `PyRef` is statically guaranteed).

This removes the obsolete `FromPyObjectRef` trait and replaces it with a `downcast` method (that will eventually be moved to `PyRef` and have a very different implementation).