### PR TITLE
[WASM] Add PyDocument and PyElement classes to browser

### DIFF
--- a/vm/src/builtins.rs
+++ b/vm/src/builtins.rs
@@ -700,9 +700,14 @@ fn builtin_import(vm: &VirtualMachine, args: PyFuncArgs) -> PyResult {
         ]
     );
     let current_path = {
-        let mut source_pathbuf = PathBuf::from(&vm.current_frame().code.source_path);
-        source_pathbuf.pop();
-        source_pathbuf
+        match vm.current_frame() {
+            Some(frame) => {
+                let mut source_pathbuf = PathBuf::from(&frame.code.source_path);
+                source_pathbuf.pop();
+                source_pathbuf
+            }
+            None => PathBuf::new(),
+        }
     };
 
     import_module(vm, current_path, &objstr::get_value(name))

--- a/vm/src/function.rs
+++ b/vm/src/function.rs
@@ -304,6 +304,7 @@ pub enum OptionalArg<T> {
 }
 
 impl<T> OptionalArg<T> {
+    #[inline]
     pub fn into_option(self) -> Option<T> {
         match self {
             Present(value) => Some(value),

--- a/vm/src/obj/objsuper.rs
+++ b/vm/src/obj/objsuper.rs
@@ -129,13 +129,15 @@ fn super_new(vm: &VirtualMachine, args: PyFuncArgs) -> PyResult {
     let py_obj = if let Some(obj) = py_obj {
         obj.clone()
     } else {
-        let frame = vm.current_frame();
+        let frame = vm.current_frame().expect("no current frame for super()");
         if let Some(first_arg) = frame.code.arg_names.get(0) {
             match vm.get_locals().get_item(first_arg) {
                 Some(obj) => obj.clone(),
                 _ => {
-                    return Err(vm
-                        .new_type_error(format!("super arguement {} was not supplied", first_arg)));
+                    return Err(vm.new_type_error(format!(
+                        "super arguement {} was not supplied",
+                        first_arg
+                    )));
                 }
             }
         } else {

--- a/vm/src/obj/objsuper.rs
+++ b/vm/src/obj/objsuper.rs
@@ -123,10 +123,8 @@ fn super_new(
             match vm.get_locals().get_item(first_arg) {
                 Some(obj) => obj.clone(),
                 _ => {
-                    return Err(vm.new_type_error(format!(
-                        "super arguement {} was not supplied",
-                        first_arg
-                    )));
+                    return Err(vm
+                        .new_type_error(format!("super argument {} was not supplied", first_arg)));
                 }
             }
         } else {

--- a/vm/src/obj/objsuper.rs
+++ b/vm/src/obj/objsuper.rs
@@ -128,9 +128,8 @@ fn super_new(
             match vm.get_locals().get_item(first_arg) {
                 Some(obj) => obj.clone(),
                 _ => {
-                    return Err(
-                        vm.new_type_error(format!("super arguement {} was not supplied", first_arg))
-                    );
+                    return Err(vm
+                        .new_type_error(format!("super arguement {} was not supplied", first_arg)));
                 }
             }
         } else {

--- a/vm/src/obj/objsuper.rs
+++ b/vm/src/obj/objsuper.rs
@@ -128,8 +128,9 @@ fn super_new(
             match vm.get_locals().get_item(first_arg) {
                 Some(obj) => obj.clone(),
                 _ => {
-                    return Err(vm
-                        .new_type_error(format!("super argument {} was not supplied", first_arg)));
+                    return Err(
+                        vm.new_type_error(format!("super arguement {} was not supplied", first_arg))
+                    );
                 }
             }
         } else {

--- a/vm/src/vm.rs
+++ b/vm/src/vm.rs
@@ -111,7 +111,10 @@ impl VirtualMachine {
     }
 
     pub fn try_class(&self, module: &str, class: &str) -> PyResult<PyClassRef> {
-        let class = self.get_attribute(self.import(module)?, class)?.downcast().expect("not a class");
+        let class = self
+            .get_attribute(self.import(module)?, class)?
+            .downcast()
+            .expect("not a class");
         Ok(class)
     }
 
@@ -122,7 +125,7 @@ impl VirtualMachine {
         let class = self
             .get_attribute(module.clone(), class)
             .unwrap_or_else(|_| panic!("module {} has no class {}", module, class));
-        class.downcast().expect("not a class");
+        class.downcast().expect("not a class")
     }
 
     /// Create a new python string object.

--- a/wasm/lib/src/convert.rs
+++ b/wasm/lib/src/convert.rs
@@ -114,7 +114,7 @@ pub fn py_to_js(vm: &VirtualMachine, py_obj: PyObjectRef) -> JsValue {
         }
     }
     // the browser module might not be injected
-    if let Ok(promise_type) = browser_module::import_promise_type(vm) {
+    if let Ok(promise_type) = vm.try_class("browser", "Promise") {
         if objtype::isinstance(&py_obj, &promise_type) {
             return browser_module::get_promise_value(&py_obj).into();
         }
@@ -158,7 +158,7 @@ pub fn js_to_py(vm: &VirtualMachine, js_val: JsValue) -> PyObjectRef {
     if js_val.is_object() {
         if let Some(promise) = js_val.dyn_ref::<Promise>() {
             // the browser module might not be injected
-            if let Ok(promise_type) = browser_module::import_promise_type(vm) {
+            if let Ok(promise_type) = vm.try_class("browser", "Promise") {
                 return browser_module::PyPromise::new_obj(promise_type, promise.clone());
             }
         }

--- a/wasm/lib/src/vm_class.rs
+++ b/wasm/lib/src/vm_class.rs
@@ -49,7 +49,6 @@ impl StoredVirtualMachine {
 thread_local! {
     static STORED_VMS: RefCell<HashMap<String, Rc<StoredVirtualMachine>>> =
         RefCell::default();
-    static ACTIVE_VMS: RefCell<HashMap<String, *const VirtualMachine>> = RefCell::default();
 }
 
 #[wasm_bindgen(js_name = vmStore)]


### PR DESCRIPTION
I was going to do `.on` for events, but I realized that it would require (a) a different class for every single possible Event subclass, or (b) a `PyJsValue` class with `__getattr__`, which I'm going to do but in a separate PR.

I also fixed that issue from before with importing the `json` module - `builtins.__import__` tried to get the current frame, and if there wasn't anything on the stack it just failed because `vm.current_frame()` used `frames[idx]` which panics instead of `.get(idx)` which returns a result in the case of an invalid index.