### PR TITLE
Range cleanups

### DIFF
--- a/vm/src/function.rs
+++ b/vm/src/function.rs
@@ -143,7 +143,7 @@ impl PyFuncArgs {
     ///
     /// If the given `FromArgs` includes any conversions, exceptions raised
     /// during the conversion will halt the binding and return the error.
-    fn bind<T: FromArgs>(mut self, vm: &VirtualMachine) -> PyResult<T> {
+    pub fn bind<T: FromArgs>(mut self, vm: &VirtualMachine) -> PyResult<T> {
         let given_args = self.args.len();
         let bound = match T::from_args(vm, &mut self) {
             Ok(args) => args,


### PR DESCRIPTION
- renames `end` field of `PyRange` to `stop` to match python
- removes usages of deprecated `PyObject::new`
- cleans up convoluted range constructor by introducing a simple technique for function overloading