### PR TITLE
Use specific PyRef where possible - code object/type_new_class

### DIFF
--- a/vm/src/frame.rs
+++ b/vm/src/frame.rs
@@ -11,7 +11,7 @@ use crate::bytecode;
 use crate::function::PyFuncArgs;
 use crate::obj::objbool;
 use crate::obj::objbuiltinfunc::PyBuiltinFunction;
-use crate::obj::objcode;
+use crate::obj::objcode::PyCodeRef;
 use crate::obj::objdict;
 use crate::obj::objdict::PyDict;
 use crate::obj::objint::PyInt;
@@ -22,7 +22,7 @@ use crate::obj::objstr;
 use crate::obj::objtype;
 use crate::obj::objtype::PyClassRef;
 use crate::pyobject::{
-    DictProtocol, IdProtocol, PyContext, PyObjectRef, PyResult, PyValue, TryFromObject,
+    DictProtocol, IdProtocol, PyContext, PyObjectRef, PyRef, PyResult, PyValue, TryFromObject,
     TypeProtocol,
 };
 use crate::vm::VirtualMachine;
@@ -186,6 +186,8 @@ enum BlockType {
     },
 }
 
+pub type FrameRef = PyRef<Frame>;
+
 pub struct Frame {
     pub code: bytecode::CodeObject,
     // We need 1 stack per frame
@@ -211,7 +213,7 @@ pub enum ExecutionResult {
 pub type FrameResult = Result<Option<ExecutionResult>, PyObjectRef>;
 
 impl Frame {
-    pub fn new(code: PyObjectRef, scope: Scope) -> Frame {
+    pub fn new(code: PyCodeRef, scope: Scope) -> Frame {
         //populate the globals and locals
         //TODO: This is wrong, check https://github.com/nedbat/byterun/blob/31e6c4a8212c35b5157919abff43a7daa0f377c6/byterun/pyvm2.py#L95
         /*
@@ -224,7 +226,7 @@ impl Frame {
         // locals.extend(callargs);
 
         Frame {
-            code: objcode::get_value(&code),
+            code: code.code.clone(),
             stack: RefCell::new(vec![]),
             blocks: RefCell::new(vec![]),
             // save the callargs as locals
@@ -562,7 +564,7 @@ impl Frame {
             }
             bytecode::Instruction::MakeFunction { flags } => {
                 let _qualified_name = self.pop_value();
-                let code_obj = self.pop_value();
+                let code_obj = PyCodeRef::try_from_object(vm, self.pop_value())?;
 
                 let annotations = if flags.contains(bytecode::FunctionOpArg::HAS_ANNOTATIONS) {
                     self.pop_value()

--- a/vm/src/frame.rs
+++ b/vm/src/frame.rs
@@ -564,7 +564,10 @@ impl Frame {
             }
             bytecode::Instruction::MakeFunction { flags } => {
                 let _qualified_name = self.pop_value();
-                let code_obj = PyCodeRef::try_from_object(vm, self.pop_value())?;
+                let code_obj = self
+                    .pop_value()
+                    .downcast()
+                    .expect("Second to top value on the stack must be a code object");
 
                 let annotations = if flags.contains(bytecode::FunctionOpArg::HAS_ANNOTATIONS) {
                     self.pop_value()

--- a/vm/src/obj/objcode.rs
+++ b/vm/src/obj/objcode.rs
@@ -5,9 +5,8 @@
 use std::fmt;
 
 use crate::bytecode;
-use crate::function::PyFuncArgs;
 use crate::obj::objtype::PyClassRef;
-use crate::pyobject::{IdProtocol, PyContext, PyObjectRef, PyRef, PyResult, PyValue, TypeProtocol};
+use crate::pyobject::{IdProtocol, PyContext, PyObjectRef, PyRef, PyResult, PyValue};
 use crate::vm::VirtualMachine;
 
 pub type PyCodeRef = PyRef<PyCode>;
@@ -34,62 +33,63 @@ impl PyValue for PyCode {
     }
 }
 
+impl PyCodeRef {
+    fn new(_cls: PyClassRef, vm: &VirtualMachine) -> PyResult {
+        Err(vm.new_type_error("Cannot directly create code object".to_string()))
+    }
+
+    fn repr(self, _vm: &VirtualMachine) -> String {
+        let code = &self.code;
+        format!(
+            "<code object {} at 0x{:x} file {:?}, line {}>",
+            code.obj_name,
+            self.get_id(),
+            code.source_path,
+            code.first_line_number
+        )
+    }
+
+    fn co_argcount(self, _vm: &VirtualMachine) -> usize {
+        self.code.arg_names.len()
+    }
+
+    fn co_filename(self, _vm: &VirtualMachine) -> String {
+        self.code.source_path.clone()
+    }
+
+    fn co_firstlineno(self, _vm: &VirtualMachine) -> usize {
+        self.code.first_line_number
+    }
+
+    fn co_kwonlyargcount(self, _vm: &VirtualMachine) -> usize {
+        self.code.kwonlyarg_names.len()
+    }
+
+    fn co_consts(self, vm: &VirtualMachine) -> PyObjectRef {
+        let consts = self
+            .code
+            .get_constants()
+            .map(|x| vm.ctx.unwrap_constant(x))
+            .collect();
+        vm.ctx.new_tuple(consts)
+    }
+
+    fn co_name(self, _vm: &VirtualMachine) -> String {
+        self.code.obj_name.clone()
+    }
+}
+
 pub fn init(context: &PyContext) {
     let code_type = context.code_type.as_object();
     extend_class!(context, code_type, {
-        "__new__" => context.new_rustfunc(code_new),
-        "__repr__" => context.new_rustfunc(code_repr),
+        "__new__" => context.new_rustfunc(PyCodeRef::new),
+        "__repr__" => context.new_rustfunc(PyCodeRef::repr),
 
-        "co_argcount" => context.new_property(code_co_argcount),
-        "co_consts" => context.new_property(code_co_consts),
-        "co_filename" => context.new_property(code_co_filename),
-        "co_firstlineno" => context.new_property(code_co_firstlineno),
-        "co_kwonlyargcount" => context.new_property(code_co_kwonlyargcount),
-        "co_name" => context.new_property(code_co_name),
+        "co_argcount" => context.new_property(PyCodeRef::co_argcount),
+        "co_consts" => context.new_property(PyCodeRef::co_consts),
+        "co_filename" => context.new_property(PyCodeRef::co_filename),
+        "co_firstlineno" => context.new_property(PyCodeRef::co_firstlineno),
+        "co_kwonlyargcount" => context.new_property(PyCodeRef::co_kwonlyargcount),
+        "co_name" => context.new_property(PyCodeRef::co_name),
     });
-}
-
-fn code_new(vm: &VirtualMachine, args: PyFuncArgs) -> PyResult {
-    arg_check!(vm, args, required = [(_cls, None)]);
-    Err(vm.new_type_error("Cannot directly create code object".to_string()))
-}
-
-fn code_repr(o: PyCodeRef, _vm: &VirtualMachine) -> String {
-    let code = &o.code;
-    format!(
-        "<code object {} at 0x{:x} file {:?}, line {}>",
-        code.obj_name,
-        o.get_id(),
-        code.source_path,
-        code.first_line_number
-    )
-}
-
-fn code_co_argcount(code: PyCodeRef, _vm: &VirtualMachine) -> usize {
-    code.code.arg_names.len()
-}
-
-fn code_co_filename(code: PyCodeRef, _vm: &VirtualMachine) -> String {
-    code.code.source_path.clone()
-}
-
-fn code_co_firstlineno(code: PyCodeRef, _vm: &VirtualMachine) -> usize {
-    code.code.first_line_number
-}
-
-fn code_co_kwonlyargcount(code: PyCodeRef, _vm: &VirtualMachine) -> usize {
-    code.code.kwonlyarg_names.len()
-}
-
-fn code_co_consts(code: PyCodeRef, vm: &VirtualMachine) -> PyObjectRef {
-    let consts = code
-        .code
-        .get_constants()
-        .map(|x| vm.ctx.unwrap_constant(x))
-        .collect();
-    vm.ctx.new_tuple(consts)
-}
-
-fn code_co_name(code: PyCodeRef, _vm: &VirtualMachine) -> String {
-    code.code.obj_name.clone()
 }

--- a/vm/src/obj/objgenerator.rs
+++ b/vm/src/obj/objgenerator.rs
@@ -2,17 +2,17 @@
  * The mythical generator.
  */
 
-use crate::frame::{ExecutionResult, Frame};
-use crate::function::PyFuncArgs;
+use crate::frame::{ExecutionResult, FrameRef};
 use crate::obj::objtype::PyClassRef;
-use crate::pyobject::{PyContext, PyObjectRef, PyRef, PyResult, PyValue, TypeProtocol};
+use crate::pyobject::{PyContext, PyObjectRef, PyRef, PyResult, PyValue};
 use crate::vm::VirtualMachine;
+
+pub type PyGeneratorRef = PyRef<PyGenerator>;
 
 #[derive(Debug)]
 pub struct PyGenerator {
-    frame: PyObjectRef,
+    frame: FrameRef,
 }
-type PyGeneratorRef = PyRef<PyGenerator>;
 
 impl PyValue for PyGenerator {
     fn class(vm: &VirtualMachine) -> PyClassRef {
@@ -20,48 +20,23 @@ impl PyValue for PyGenerator {
     }
 }
 
-pub fn init(context: &PyContext) {
-    let generator_type = &context.generator_type;
-    extend_class!(context, generator_type, {
-        "__iter__" => context.new_rustfunc(generator_iter),
-        "__next__" => context.new_rustfunc(generator_next),
-        "send" => context.new_rustfunc(generator_send)
-    });
-}
+impl PyGeneratorRef {
+    pub fn new(frame: FrameRef, vm: &VirtualMachine) -> PyGeneratorRef {
+        PyGenerator { frame }.into_ref(vm)
+    }
 
-pub fn new_generator(frame: PyObjectRef, vm: &VirtualMachine) -> PyGeneratorRef {
-    PyGenerator { frame }.into_ref(vm)
-}
+    fn iter(self, _vm: &VirtualMachine) -> PyGeneratorRef {
+        self
+    }
 
-fn generator_iter(vm: &VirtualMachine, args: PyFuncArgs) -> PyResult {
-    arg_check!(vm, args, required = [(o, Some(vm.ctx.generator_type()))]);
-    Ok(o.clone())
-}
+    fn next(self, vm: &VirtualMachine) -> PyResult {
+        self.send(vm.get_none(), vm)
+    }
 
-fn generator_next(vm: &VirtualMachine, args: PyFuncArgs) -> PyResult {
-    arg_check!(vm, args, required = [(o, Some(vm.ctx.generator_type()))]);
-    let value = vm.get_none();
-    send(vm, o, &value)
-}
+    fn send(self, value: PyObjectRef, vm: &VirtualMachine) -> PyResult {
+        self.frame.push_value(value.clone());
 
-fn generator_send(vm: &VirtualMachine, args: PyFuncArgs) -> PyResult {
-    arg_check!(
-        vm,
-        args,
-        required = [(o, Some(vm.ctx.generator_type())), (value, None)]
-    );
-    send(vm, o, value)
-}
-
-fn send(vm: &VirtualMachine, gen: &PyObjectRef, value: &PyObjectRef) -> PyResult {
-    if let Some(PyGenerator { ref frame }) = gen.payload() {
-        if let Some(frame) = frame.payload::<Frame>() {
-            frame.push_value(value.clone());
-        } else {
-            panic!("Generator frame isn't a frame.");
-        }
-
-        match vm.run_frame(frame.clone())? {
+        match vm.run_frame(self.frame.clone())? {
             ExecutionResult::Yield(value) => Ok(value),
             ExecutionResult::Return(_value) => {
                 // Stop iteration!
@@ -69,7 +44,14 @@ fn send(vm: &VirtualMachine, gen: &PyObjectRef, value: &PyObjectRef) -> PyResult
                 Err(vm.new_exception(stop_iteration, "End of generator".to_string()))
             }
         }
-    } else {
-        panic!("Cannot extract frame from non-generator");
     }
+}
+
+pub fn init(context: &PyContext) {
+    let generator_type = &context.generator_type;
+    extend_class!(context, generator_type, {
+        "__iter__" => context.new_rustfunc(PyGeneratorRef::iter),
+        "__next__" => context.new_rustfunc(PyGeneratorRef::next),
+        "send" => context.new_rustfunc(PyGeneratorRef::send)
+    });
 }

--- a/vm/src/pyobject.rs
+++ b/vm/src/pyobject.rs
@@ -14,7 +14,7 @@ use num_traits::{One, Zero};
 
 use crate::bytecode;
 use crate::exceptions;
-use crate::frame::{Frame, Scope};
+use crate::frame::Scope;
 use crate::function::{IntoPyNativeFunc, PyFuncArgs};
 use crate::obj::objbool;
 use crate::obj::objbuiltinfunc::PyBuiltinFunction;
@@ -22,6 +22,7 @@ use crate::obj::objbytearray;
 use crate::obj::objbytes;
 use crate::obj::objclassmethod;
 use crate::obj::objcode;
+use crate::obj::objcode::PyCodeRef;
 use crate::obj::objcomplex::{self, PyComplex};
 use crate::obj::objdict::{self, PyDict};
 use crate::obj::objellipsis;
@@ -591,10 +592,6 @@ impl PyContext {
         )
     }
 
-    pub fn new_frame(&self, code: PyObjectRef, scope: Scope) -> PyObjectRef {
-        PyObject::new(Frame::new(code, scope), self.frame_type())
-    }
-
     pub fn new_property<F, I, V>(&self, f: F) -> PyObjectRef
     where
         F: IntoPyNativeFunc<I, V>,
@@ -608,7 +605,7 @@ impl PyContext {
 
     pub fn new_function(
         &self,
-        code_obj: PyObjectRef,
+        code_obj: PyCodeRef,
         scope: Scope,
         defaults: PyObjectRef,
     ) -> PyObjectRef {

--- a/vm/src/stdlib/dis.rs
+++ b/vm/src/stdlib/dis.rs
@@ -1,23 +1,18 @@
-use crate::function::PyFuncArgs;
-use crate::obj::objcode;
-use crate::pyobject::{PyContext, PyObjectRef, PyResult, TypeProtocol};
+use crate::obj::objcode::PyCodeRef;
+use crate::pyobject::{PyContext, PyObjectRef, PyResult, TryFromObject};
 use crate::vm::VirtualMachine;
 
-fn dis_dis(vm: &VirtualMachine, args: PyFuncArgs) -> PyResult {
-    arg_check!(vm, args, required = [(obj, None)]);
-
+fn dis_dis(obj: PyObjectRef, vm: &VirtualMachine) -> PyResult {
     // Method or function:
     if let Ok(co) = vm.get_attribute(obj.clone(), "__code__") {
-        return dis_disassemble(vm, PyFuncArgs::new(vec![co], vec![]));
+        return dis_disassemble(co, vm);
     }
 
-    dis_disassemble(vm, PyFuncArgs::new(vec![obj.clone()], vec![]))
+    dis_disassemble(obj, vm)
 }
 
-fn dis_disassemble(vm: &VirtualMachine, args: PyFuncArgs) -> PyResult {
-    arg_check!(vm, args, required = [(co, Some(vm.ctx.code_type()))]);
-
-    let code = objcode::get_value(co);
+fn dis_disassemble(co: PyObjectRef, vm: &VirtualMachine) -> PyResult {
+    let code = &PyCodeRef::try_from_object(vm, co)?.code;
     print!("{}", code);
     Ok(vm.get_none())
 }

--- a/vm/src/stdlib/json.rs
+++ b/vm/src/stdlib/json.rs
@@ -184,7 +184,7 @@ impl<'de> Visitor<'de> for PyObjectDeserializer<'de> {
     where
         E: serde::de::Error,
     {
-        Ok(self.vm.ctx.none.clone().into_object())
+        Ok(self.vm.get_none())
     }
 }
 


### PR DESCRIPTION
Following on from my previous PRs, this removes unnecessary uses of `PyObjectRef` in `type_new_class` function and in the areas around the code/frame object.