### PR TITLE
Convert range to new args style

### DIFF
--- a/tests/snippets/builtin_range.py
+++ b/tests/snippets/builtin_range.py
@@ -50,3 +50,7 @@ assert 'foo' not in range(10)
 assert list(reversed(range(5))) == [4, 3, 2, 1, 0]
 assert list(reversed(range(5, 0, -1))) == [1, 2, 3, 4, 5]
 assert list(reversed(range(1,10,5))) == [6, 1]
+
+# range retains the original int refs
+i = 2**64
+assert range(i).stop is i

--- a/vm/src/frame.rs
+++ b/vm/src/frame.rs
@@ -413,7 +413,7 @@ impl Frame {
                         if x.is(&vm.ctx.none()) {
                             None
                         } else if let Some(i) = x.payload::<PyInt>() {
-                            Some(i.value.clone())
+                            Some(i.as_bigint().clone())
                         } else {
                             panic!("Expect Int or None as BUILD_SLICE arguments")
                         }

--- a/vm/src/obj/objbool.rs
+++ b/vm/src/obj/objbool.rs
@@ -25,7 +25,7 @@ pub fn boolval(vm: &VirtualMachine, obj: PyObjectRef) -> PyResult<bool> {
     Ok(if let Ok(f) = vm.get_method(obj.clone(), "__bool__") {
         let bool_res = vm.invoke(f, PyFuncArgs::default())?;
         match bool_res.payload::<PyInt>() {
-            Some(i) => !i.value.is_zero(),
+            Some(i) => !i.as_bigint().is_zero(),
             None => return Err(vm.new_type_error(String::from("TypeError"))),
         }
     } else {
@@ -59,7 +59,7 @@ pub fn not(vm: &VirtualMachine, obj: &PyObjectRef) -> PyResult {
 
 // Retrieve inner int value:
 pub fn get_value(obj: &PyObjectRef) -> bool {
-    !obj.payload::<PyInt>().unwrap().value.is_zero()
+    !obj.payload::<PyInt>().unwrap().as_bigint().is_zero()
 }
 
 fn bool_repr(vm: &VirtualMachine, args: PyFuncArgs) -> Result<PyObjectRef, PyObjectRef> {

--- a/vm/src/obj/objenumerate.rs
+++ b/vm/src/obj/objenumerate.rs
@@ -32,7 +32,7 @@ fn enumerate_new(
     vm: &VirtualMachine,
 ) -> PyResult<PyEnumerateRef> {
     let counter = match start {
-        OptionalArg::Present(start) => start.value.clone(),
+        OptionalArg::Present(start) => start.as_bigint().clone(),
         OptionalArg::Missing => BigInt::zero(),
     };
 

--- a/vm/src/obj/objint.rs
+++ b/vm/src/obj/objint.rs
@@ -1,3 +1,4 @@
+use std::fmt;
 use std::hash::{Hash, Hasher};
 
 use num_bigint::{BigInt, ToBigInt};
@@ -20,6 +21,12 @@ use crate::obj::objtype::PyClassRef;
 pub struct PyInt {
     // TODO: shouldn't be public
     pub value: BigInt,
+}
+
+impl fmt::Display for PyInt {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        BigInt::fmt(&self.value, f)
+    }
 }
 
 pub type PyIntRef = PyRef<PyInt>;

--- a/vm/src/obj/objint.rs
+++ b/vm/src/obj/objint.rs
@@ -19,8 +19,7 @@ use crate::obj::objtype::PyClassRef;
 
 #[derive(Debug)]
 pub struct PyInt {
-    // TODO: shouldn't be public
-    pub value: BigInt,
+    value: BigInt,
 }
 
 impl fmt::Display for PyInt {

--- a/vm/src/obj/objint.rs
+++ b/vm/src/obj/objint.rs
@@ -35,6 +35,10 @@ impl PyInt {
     pub fn new<T: Into<BigInt>>(i: T) -> Self {
         PyInt { value: i.into() }
     }
+
+    pub fn as_bigint(&self) -> &BigInt {
+        &self.value
+    }
 }
 
 impl IntoPyObject for BigInt {

--- a/vm/src/obj/objrange.rs
+++ b/vm/src/obj/objrange.rs
@@ -222,7 +222,7 @@ impl PyRangeRef {
 
     fn contains(self, needle: PyObjectRef, _vm: &VirtualMachine) -> bool {
         if let Ok(int) = needle.downcast::<PyInt>() {
-            match self.offset(&int.value) {
+            match self.offset(int.as_bigint()) {
                 Some(ref offset) => offset.is_multiple_of(self.step.as_bigint()),
                 None => false,
             }
@@ -233,7 +233,7 @@ impl PyRangeRef {
 
     fn index(self, needle: PyObjectRef, vm: &VirtualMachine) -> PyResult<PyInt> {
         if let Ok(int) = needle.downcast::<PyInt>() {
-            match self.index_of(&int.value) {
+            match self.index_of(int.as_bigint()) {
                 Some(idx) => Ok(PyInt::new(idx)),
                 None => Err(vm.new_value_error(format!("{} is not in range", int))),
             }
@@ -244,7 +244,7 @@ impl PyRangeRef {
 
     fn count(self, item: PyObjectRef, _vm: &VirtualMachine) -> PyInt {
         if let Ok(int) = item.downcast::<PyInt>() {
-            if self.index_of(&int.value).is_some() {
+            if self.index_of(int.as_bigint()).is_some() {
                 PyInt::new(1)
             } else {
                 PyInt::new(0)
@@ -257,7 +257,7 @@ impl PyRangeRef {
     fn getitem(self, subscript: Either<PyIntRef, PySliceRef>, vm: &VirtualMachine) -> PyResult {
         match subscript {
             Either::A(index) => {
-                if let Some(value) = self.get(index.value.clone()) {
+                if let Some(value) = self.get(index.as_bigint()) {
                     Ok(PyInt::new(value).into_ref(vm).into_object())
                 } else {
                     Err(vm.new_index_error("range object index out of range".to_string()))

--- a/vm/src/obj/objsequence.rs
+++ b/vm/src/obj/objsequence.rs
@@ -144,7 +144,7 @@ pub fn get_item(
     subscript: PyObjectRef,
 ) -> PyResult {
     if let Some(i) = subscript.payload::<PyInt>() {
-        return match i.value.to_i32() {
+        return match i.as_bigint().to_i32() {
             Some(value) => {
                 if let Some(pos_index) = elements.to_vec().get_pos(value) {
                     let obj = elements[pos_index].clone();


### PR DESCRIPTION
- Converts range to new args style
- Changes representation to hold `PyIntRef`s instead of `BigInt`s
- Removes a _lot_ of unnecessary cloning
- Introduces `as_bigint()` to `PyInt` and makes the latter's value field private