### PR TITLE
Attributes and dictionaries

### DIFF
--- a/vm/src/builtins.rs
+++ b/vm/src/builtins.rs
@@ -815,9 +815,9 @@ pub fn builtin_build_class_(vm: &VirtualMachine, mut args: PyFuncArgs) -> PyResu
     let prepare = vm.get_attribute(metaclass.clone().into_object(), "__prepare__")?;
     let namespace = vm.invoke(prepare, vec![name_arg.clone(), bases.clone()])?;
 
-    let cells = vm.new_dict();
+    let cells = vm.ctx.new_dict();
 
-    vm.invoke_with_locals(function, cells.clone(), namespace.clone())?;
+    vm.invoke_with_locals(function, cells.clone().into_object(), namespace.clone())?;
     let class = vm.call_method(
         metaclass.as_object(),
         "__call__",

--- a/vm/src/builtins.rs
+++ b/vm/src/builtins.rs
@@ -11,7 +11,6 @@ use num_traits::{Signed, ToPrimitive};
 use crate::compile;
 use crate::import::import_module;
 use crate::obj::objbool;
-use crate::obj::objdict;
 use crate::obj::objint;
 use crate::obj::objiter;
 use crate::obj::objstr::{self, PyStringRef};
@@ -29,14 +28,7 @@ use crate::obj::objcode::PyCodeRef;
 use crate::stdlib::io::io_open;
 
 fn get_locals(vm: &VirtualMachine) -> PyObjectRef {
-    let d = vm.new_dict();
-    // TODO: implement dict_iter_items?
-    let locals = vm.get_locals();
-    let key_value_pairs = objdict::get_key_value_pairs(&locals);
-    for (key, value) in key_value_pairs {
-        objdict::set_item(&d, vm, &key, &value);
-    }
-    d
+    vm.get_locals()
 }
 
 fn dir_locals(vm: &VirtualMachine) -> PyObjectRef {

--- a/vm/src/function.rs
+++ b/vm/src/function.rs
@@ -247,6 +247,15 @@ where
     }
 }
 
+impl<T> IntoIterator for KwArgs<T> {
+    type Item = (String, T);
+    type IntoIter = std::collections::hash_map::IntoIter<String, T>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        self.0.into_iter()
+    }
+}
+
 /// A list of positional argument values.
 ///
 /// A built-in function with a `Args` parameter is analagous to a Python

--- a/vm/src/import.rs
+++ b/vm/src/import.rs
@@ -40,7 +40,7 @@ fn import_uncached_module(vm: &VirtualMachine, current_path: PathBuf, module: &s
 
     let attrs = vm.ctx.new_dict();
     attrs.set_item(&vm.ctx, "__name__", vm.new_str(module.to_string()));
-    vm.run_code_obj(code_obj, Scope::new(None, attrs.clone()))?;
+    vm.run_code_obj(code_obj, Scope::new(None, attrs.clone().into_object()))?;
     Ok(vm.ctx.new_module(module, attrs))
 }
 

--- a/vm/src/obj/objmodule.rs
+++ b/vm/src/obj/objmodule.rs
@@ -1,12 +1,10 @@
-use crate::obj::objstr::PyStringRef;
 use crate::obj::objtype::PyClassRef;
-use crate::pyobject::{DictProtocol, PyContext, PyObjectRef, PyRef, PyResult, PyValue};
+use crate::pyobject::{DictProtocol, PyContext, PyRef, PyResult, PyValue};
 use crate::vm::VirtualMachine;
 
 #[derive(Debug)]
 pub struct PyModule {
     pub name: String,
-    pub dict: PyObjectRef,
 }
 pub type PyModuleRef = PyRef<PyModule>;
 
@@ -18,23 +16,21 @@ impl PyValue for PyModule {
 
 impl PyModuleRef {
     fn dir(self: PyModuleRef, vm: &VirtualMachine) -> PyResult {
-        let keys = self
-            .dict
-            .get_key_value_pairs()
-            .iter()
-            .map(|(k, _v)| k.clone())
-            .collect();
-        Ok(vm.ctx.new_list(keys))
-    }
-
-    fn set_attr(self, attr: PyStringRef, value: PyObjectRef, vm: &VirtualMachine) {
-        self.dict.set_item(&vm.ctx, &attr.value, value)
+        if let Some(dict) = &self.into_object().dict {
+            let keys = dict
+                .get_key_value_pairs()
+                .iter()
+                .map(|(k, _v)| k.clone())
+                .collect();
+            Ok(vm.ctx.new_list(keys))
+        } else {
+            panic!("Modules should definitely have a dict.");
+        }
     }
 }
 
 pub fn init(context: &PyContext) {
     extend_class!(&context, &context.module_type, {
         "__dir__" => context.new_rustfunc(PyModuleRef::dir),
-        "__setattr__" => context.new_rustfunc(PyModuleRef::set_attr)
     });
 }

--- a/vm/src/obj/objproperty.rs
+++ b/vm/src/obj/objproperty.rs
@@ -200,7 +200,7 @@ impl<'a> PropertyBuilder<'a> {
                 deleter: None,
             };
 
-            PyObject::new(payload, self.ctx.property_type())
+            PyObject::new(payload, self.ctx.property_type(), None)
         } else {
             let payload = PyReadOnlyProperty {
                 getter: self.getter.expect(
@@ -208,7 +208,7 @@ impl<'a> PropertyBuilder<'a> {
                 ),
             };
 
-            PyObject::new(payload, self.ctx.readonly_property_type())
+            PyObject::new(payload, self.ctx.readonly_property_type(), None)
         }
     }
 }

--- a/vm/src/obj/objsequence.rs
+++ b/vm/src/obj/objsequence.rs
@@ -164,11 +164,13 @@ pub fn get_item(
             Ok(PyObject::new(
                 PyList::from(elements.to_vec().get_slice_items(vm, &subscript)?),
                 sequence.type_pyref(),
+                None,
             ))
         } else if sequence.payload::<PyTuple>().is_some() {
             Ok(PyObject::new(
                 PyTuple::from(elements.to_vec().get_slice_items(vm, &subscript)?),
                 sequence.type_pyref(),
+                None,
             ))
         } else {
             panic!("sequence get_item called for non-sequence")

--- a/vm/src/obj/objtype.rs
+++ b/vm/src/obj/objtype.rs
@@ -110,8 +110,8 @@ impl PyClassRef {
         format!("<class '{}'>", self.name)
     }
 
-    fn prepare(_name: PyStringRef, _bases: PyObjectRef, vm: &VirtualMachine) -> PyObjectRef {
-        vm.new_dict()
+    fn prepare(_name: PyStringRef, _bases: PyObjectRef, vm: &VirtualMachine) -> PyDictRef {
+        vm.ctx.new_dict()
     }
 
     fn getattribute(self, name_ref: PyStringRef, vm: &VirtualMachine) -> PyResult {

--- a/vm/src/obj/objtype.rs
+++ b/vm/src/obj/objtype.rs
@@ -22,6 +22,7 @@ pub struct PyClass {
     pub name: String,
     pub mro: Vec<PyClassRef>,
     pub subclasses: RefCell<Vec<PyWeak>>,
+    pub attributes: RefCell<PyAttributes>,
 }
 
 impl fmt::Display for PyClass {
@@ -149,6 +150,25 @@ impl PyClassRef {
         }
     }
 
+    fn set_attr(
+        self,
+        attr_name: PyStringRef,
+        value: PyObjectRef,
+        vm: &VirtualMachine,
+    ) -> PyResult<()> {
+        if let Some(attr) = class_get_attr(&self.type_pyref(), &attr_name.value) {
+            if let Some(descriptor) = class_get_attr(&attr.type_pyref(), "__set__") {
+                vm.invoke(descriptor, vec![attr, self.into_object(), value])?;
+                return Ok(());
+            }
+        }
+
+        self.attributes
+            .borrow_mut()
+            .insert(attr_name.to_string(), value);
+        Ok(())
+    }
+
     fn subclasses(self, _vm: &VirtualMachine) -> PyList {
         let mut subclasses = self.subclasses.borrow_mut();
         subclasses.retain(|x| x.upgrade().is_some());
@@ -181,6 +201,7 @@ pub fn init(ctx: &PyContext) {
         "__repr__" => ctx.new_rustfunc(PyClassRef::repr),
         "__prepare__" => ctx.new_rustfunc(PyClassRef::prepare),
         "__getattribute__" => ctx.new_rustfunc(PyClassRef::getattribute),
+        "__setattr__" => ctx.new_rustfunc(PyClassRef::set_attr),
         "__subclasses__" => ctx.new_rustfunc(PyClassRef::subclasses),
         "__getattribute__" => ctx.new_rustfunc(PyClassRef::getattribute),
         "__instancecheck__" => ctx.new_rustfunc(PyClassRef::instance_check),
@@ -260,32 +281,13 @@ pub fn type_call(class: PyClassRef, args: Args, kwargs: KwArgs, vm: &VirtualMach
     Ok(obj)
 }
 
-// Very private helper function for class_get_attr
-fn class_get_attr_in_dict(class: &PyClassRef, attr_name: &str) -> Option<PyObjectRef> {
-    if let Some(ref dict) = class.as_object().dict {
-        dict.borrow().get(attr_name).cloned()
-    } else {
-        panic!("Only classes should be in MRO!");
-    }
-}
-
-// Very private helper function for class_has_attr
-fn class_has_attr_in_dict(class: &PyClassRef, attr_name: &str) -> bool {
-    if let Some(ref dict) = class.as_object().dict {
-        dict.borrow().contains_key(attr_name)
-    } else {
-        panic!("All classes are expected to have dicts!");
-    }
-}
-
 // This is the internal get_attr implementation for fast lookup on a class.
-pub fn class_get_attr(zelf: &PyClassRef, attr_name: &str) -> Option<PyObjectRef> {
-    let mro = &zelf.mro;
-    if let Some(item) = class_get_attr_in_dict(zelf, attr_name) {
+pub fn class_get_attr(class: &PyClassRef, attr_name: &str) -> Option<PyObjectRef> {
+    if let Some(item) = class.attributes.borrow().get(attr_name).cloned() {
         return Some(item);
     }
-    for class in mro {
-        if let Some(item) = class_get_attr_in_dict(class, attr_name) {
+    for class in &class.mro {
+        if let Some(item) = class.attributes.borrow().get(attr_name).cloned() {
             return Some(item);
         }
     }
@@ -293,12 +295,12 @@ pub fn class_get_attr(zelf: &PyClassRef, attr_name: &str) -> Option<PyObjectRef>
 }
 
 // This is the internal has_attr implementation for fast lookup on a class.
-pub fn class_has_attr(zelf: &PyClassRef, attr_name: &str) -> bool {
-    class_has_attr_in_dict(zelf, attr_name)
-        || zelf
+pub fn class_has_attr(class: &PyClassRef, attr_name: &str) -> bool {
+    class.attributes.borrow().contains_key(attr_name)
+        || class
             .mro
             .iter()
-            .any(|d| class_has_attr_in_dict(d, attr_name))
+            .any(|c| c.attributes.borrow().contains_key(attr_name))
 }
 
 pub fn get_attributes(cls: PyClassRef) -> PyAttributes {
@@ -309,10 +311,8 @@ pub fn get_attributes(cls: PyClassRef) -> PyAttributes {
     base_classes.reverse();
 
     for bc in base_classes {
-        if let Some(ref dict) = &bc.as_object().dict {
-            for (name, value) in dict.borrow().iter() {
-                attributes.insert(name.to_string(), value.clone());
-            }
+        for (name, value) in bc.attributes.borrow().iter() {
+            attributes.insert(name.to_string(), value.clone());
         }
     }
 
@@ -374,8 +374,9 @@ pub fn new(
             name: String::from(name),
             mro,
             subclasses: RefCell::new(vec![]),
+            attributes: RefCell::new(dict),
         },
-        dict: Some(RefCell::new(dict)),
+        dict: None,
         typ,
     }
     .into_ref();

--- a/vm/src/pyobject.rs
+++ b/vm/src/pyobject.rs
@@ -24,7 +24,7 @@ use crate::obj::objclassmethod;
 use crate::obj::objcode;
 use crate::obj::objcode::PyCodeRef;
 use crate::obj::objcomplex::{self, PyComplex};
-use crate::obj::objdict::{self, PyDict};
+use crate::obj::objdict::{self, PyDict, PyDictRef};
 use crate::obj::objellipsis;
 use crate::obj::objenumerate;
 use crate::obj::objfilter;
@@ -271,7 +271,7 @@ impl PyContext {
 
         fn create_object<T: PyObjectPayload>(payload: T, cls: &PyClassRef) -> PyRef<T> {
             PyRef {
-                obj: PyObject::new(payload, cls.clone()),
+                obj: PyObject::new(payload, cls.clone(), None),
                 _payload: PhantomData,
             }
         }
@@ -521,32 +521,32 @@ impl PyContext {
         self.object.clone()
     }
 
-    pub fn new_object(&self) -> PyObjectRef {
-        self.new_instance(self.object.clone(), None)
-    }
-
     pub fn new_int<T: Into<BigInt>>(&self, i: T) -> PyObjectRef {
-        PyObject::new(PyInt::new(i), self.int_type())
+        PyObject::new(PyInt::new(i), self.int_type(), None)
     }
 
     pub fn new_float(&self, value: f64) -> PyObjectRef {
-        PyObject::new(PyFloat::from(value), self.float_type())
+        PyObject::new(PyFloat::from(value), self.float_type(), None)
     }
 
     pub fn new_complex(&self, value: Complex64) -> PyObjectRef {
-        PyObject::new(PyComplex::from(value), self.complex_type())
+        PyObject::new(PyComplex::from(value), self.complex_type(), None)
     }
 
     pub fn new_str(&self, s: String) -> PyObjectRef {
-        PyObject::new(objstr::PyString { value: s }, self.str_type())
+        PyObject::new(objstr::PyString { value: s }, self.str_type(), None)
     }
 
     pub fn new_bytes(&self, data: Vec<u8>) -> PyObjectRef {
-        PyObject::new(objbytes::PyBytes::new(data), self.bytes_type())
+        PyObject::new(objbytes::PyBytes::new(data), self.bytes_type(), None)
     }
 
     pub fn new_bytearray(&self, data: Vec<u8>) -> PyObjectRef {
-        PyObject::new(objbytearray::PyByteArray::new(data), self.bytearray_type())
+        PyObject::new(
+            objbytearray::PyByteArray::new(data),
+            self.bytearray_type(),
+            None,
+        )
     }
 
     pub fn new_bool(&self, b: bool) -> PyObjectRef {
@@ -558,21 +558,23 @@ impl PyContext {
     }
 
     pub fn new_tuple(&self, elements: Vec<PyObjectRef>) -> PyObjectRef {
-        PyObject::new(PyTuple::from(elements), self.tuple_type())
+        PyObject::new(PyTuple::from(elements), self.tuple_type(), None)
     }
 
     pub fn new_list(&self, elements: Vec<PyObjectRef>) -> PyObjectRef {
-        PyObject::new(PyList::from(elements), self.list_type())
+        PyObject::new(PyList::from(elements), self.list_type(), None)
     }
 
     pub fn new_set(&self) -> PyObjectRef {
         // Initialized empty, as calling __hash__ is required for adding each object to the set
         // which requires a VM context - this is done in the objset code itself.
-        PyObject::new(PySet::default(), self.set_type())
+        PyObject::new(PySet::default(), self.set_type(), None)
     }
 
-    pub fn new_dict(&self) -> PyObjectRef {
-        PyObject::new(PyDict::default(), self.dict_type())
+    pub fn new_dict(&self) -> PyDictRef {
+        PyObject::new(PyDict::default(), self.dict_type(), None)
+            .downcast()
+            .unwrap()
     }
 
     pub fn new_class(&self, name: &str, base: PyClassRef) -> PyClassRef {
@@ -580,16 +582,16 @@ impl PyContext {
     }
 
     pub fn new_scope(&self) -> Scope {
-        Scope::new(None, self.new_dict())
+        Scope::new(None, self.new_dict().into_object())
     }
 
-    pub fn new_module(&self, name: &str, dict: PyObjectRef) -> PyObjectRef {
+    pub fn new_module(&self, name: &str, dict: PyDictRef) -> PyObjectRef {
         PyObject::new(
             PyModule {
                 name: name.to_string(),
-                dict,
             },
             self.module_type.clone(),
+            Some(dict),
         )
     }
 
@@ -600,6 +602,7 @@ impl PyContext {
         PyObject::new(
             PyBuiltinFunction::new(f.into_func()),
             self.builtin_function_or_method_type(),
+            None,
         )
     }
 
@@ -611,7 +614,7 @@ impl PyContext {
     }
 
     pub fn new_code_object(&self, code: bytecode::CodeObject) -> PyObjectRef {
-        PyObject::new(objcode::PyCode::new(code), self.code_type())
+        PyObject::new(objcode::PyCode::new(code), self.code_type(), None)
     }
 
     pub fn new_function(
@@ -623,18 +626,22 @@ impl PyContext {
         PyObject::new(
             PyFunction::new(code_obj, scope, defaults),
             self.function_type(),
+            Some(self.new_dict()),
         )
     }
 
     pub fn new_bound_method(&self, function: PyObjectRef, object: PyObjectRef) -> PyObjectRef {
-        PyObject::new(PyMethod::new(object, function), self.bound_method_type())
+        PyObject::new(
+            PyMethod::new(object, function),
+            self.bound_method_type(),
+            None,
+        )
     }
 
-    pub fn new_instance(&self, class: PyClassRef, dict: Option<PyAttributes>) -> PyObjectRef {
-        let dict = dict.unwrap_or_default();
+    pub fn new_instance(&self, class: PyClassRef, dict: Option<PyDictRef>) -> PyObjectRef {
         PyObject {
             typ: class,
-            dict: Some(RefCell::new(dict)),
+            dict: dict,
             payload: objobject::PyInstance,
         }
         .into_ref()
@@ -661,11 +668,8 @@ impl PyContext {
             attributes
                 .borrow_mut()
                 .insert(attr_name.to_string(), value.into());
-        } else if let Some(PyModule { ref dict, .. }) = obj.payload::<PyModule>() {
-            dict.set_item(self, attr_name, value.into())
         } else if let Some(ref dict) = obj.dict {
-            dict.borrow_mut()
-                .insert(attr_name.to_string(), value.into());
+            dict.set_item(self, attr_name, value.into());
         } else {
             unimplemented!("set_attr unimplemented for: {:?}", obj);
         };
@@ -707,7 +711,7 @@ where
     T: ?Sized + PyObjectPayload,
 {
     pub typ: PyClassRef,
-    pub dict: Option<RefCell<PyAttributes>>, // __dict__ member
+    pub dict: Option<PyDictRef>, // __dict__ member
     pub payload: T,
 }
 
@@ -917,8 +921,6 @@ impl DictProtocol for PyObjectRef {
     fn get_item(&self, k: &str) -> Option<PyObjectRef> {
         if let Some(dict) = self.payload::<PyDict>() {
             objdict::content_get_key_str(&dict.entries.borrow(), k)
-        } else if let Some(PyModule { ref dict, .. }) = self.payload::<PyModule>() {
-            dict.get_item(k)
         } else {
             panic!("TODO {:?}", k)
         }
@@ -927,8 +929,6 @@ impl DictProtocol for PyObjectRef {
     fn get_key_value_pairs(&self) -> Vec<(PyObjectRef, PyObjectRef)> {
         if self.payload_is::<PyDict>() {
             objdict::get_key_value_pairs(self)
-        } else if let Some(PyModule { ref dict, .. }) = self.payload::<PyModule>() {
-            dict.get_key_value_pairs()
         } else {
             panic!("TODO")
         }
@@ -939,8 +939,6 @@ impl DictProtocol for PyObjectRef {
         if let Some(dict) = self.payload::<PyDict>() {
             let key = ctx.new_str(key.to_string());
             objdict::set_item_in_content(&mut dict.entries.borrow_mut(), &key, &v);
-        } else if let Some(PyModule { ref dict, .. }) = self.payload::<PyModule>() {
-            dict.set_item(ctx, key, v);
         } else {
             panic!("TODO {:?}", self);
         }
@@ -1121,7 +1119,7 @@ where
     T: PyValue + Sized,
 {
     fn into_pyobject(self, vm: &VirtualMachine) -> PyResult {
-        Ok(PyObject::new(self, T::class(vm)))
+        Ok(PyObject::new(self, T::class(vm), None))
     }
 }
 
@@ -1143,19 +1141,10 @@ impl<T> PyObject<T>
 where
     T: Sized + PyObjectPayload,
 {
-    pub fn new(payload: T, typ: PyClassRef) -> PyObjectRef {
+    pub fn new(payload: T, typ: PyClassRef, dict: Option<PyDictRef>) -> PyObjectRef {
         PyObject {
             typ,
-            dict: Some(RefCell::new(PyAttributes::new())),
-            payload,
-        }
-        .into_ref()
-    }
-
-    pub fn new_without_dict(payload: T, typ: PyClassRef) -> PyObjectRef {
-        PyObject {
-            typ,
-            dict: None,
+            dict: dict,
             payload,
         }
         .into_ref()
@@ -1184,7 +1173,7 @@ pub trait PyValue: fmt::Debug + Sized + 'static {
 
     fn into_ref(self, vm: &VirtualMachine) -> PyRef<Self> {
         PyRef {
-            obj: PyObject::new(self, Self::class(vm)),
+            obj: PyObject::new(self, Self::class(vm), None),
             _payload: PhantomData,
         }
     }
@@ -1192,8 +1181,13 @@ pub trait PyValue: fmt::Debug + Sized + 'static {
     fn into_ref_with_type(self, vm: &VirtualMachine, cls: PyClassRef) -> PyResult<PyRef<Self>> {
         let class = Self::class(vm);
         if objtype::issubclass(&cls, &class) {
+            let dict = if cls.is(&class) {
+                None
+            } else {
+                Some(vm.ctx.new_dict())
+            };
             Ok(PyRef {
-                obj: PyObject::new(self, cls),
+                obj: PyObject::new(self, cls, dict),
                 _payload: PhantomData,
             })
         } else {

--- a/vm/src/stdlib/json.rs
+++ b/vm/src/stdlib/json.rs
@@ -177,7 +177,7 @@ impl<'de> Visitor<'de> for PyObjectDeserializer<'de> {
             };
             dict.set_item(&self.vm.ctx, &key, value);
         }
-        Ok(dict)
+        Ok(dict.into_object())
     }
 
     fn visit_unit<E>(self) -> Result<Self::Value, E>

--- a/vm/src/vm.rs
+++ b/vm/src/vm.rs
@@ -141,10 +141,6 @@ impl VirtualMachine {
         self.ctx.new_bool(b)
     }
 
-    pub fn new_dict(&self) -> PyObjectRef {
-        self.ctx.new_dict()
-    }
-
     pub fn new_empty_exception(&self, exc_type: PyClassRef) -> PyResult {
         info!("New exception created: no msg");
         let args = PyFuncArgs::default();
@@ -454,11 +450,11 @@ impl VirtualMachine {
         // Do we support `**kwargs` ?
         let kwargs = match code_object.varkeywords {
             bytecode::Varargs::Named(ref kwargs_name) => {
-                let d = self.new_dict();
+                let d = self.ctx.new_dict().into_object();
                 locals.set_item(&self.ctx, kwargs_name, d.clone());
                 Some(d)
             }
-            bytecode::Varargs::Unnamed => Some(self.new_dict()),
+            bytecode::Varargs::Unnamed => Some(self.ctx.new_dict().into_object()),
             bytecode::Varargs::None => None,
         };
 

--- a/wasm/lib/src/browser_module.rs
+++ b/wasm/lib/src/browser_module.rs
@@ -363,6 +363,7 @@ pub fn make_module(ctx: &PyContext) -> PyObjectRef {
             doc: window().document().expect("Document missing from window"),
         },
         document_class.clone(),
+        None,
     );
 
     let element = py_class!(ctx, "Element", ctx.object(), {

--- a/wasm/lib/src/convert.rs
+++ b/wasm/lib/src/convert.rs
@@ -187,13 +187,13 @@ pub fn js_to_py(vm: &VirtualMachine, js_val: JsValue) -> PyObjectRef {
             u8_array.for_each(&mut |byte, _, _| vec.push(byte));
             vm.ctx.new_bytes(vec)
         } else {
-            let dict = vm.new_dict();
+            let dict = vm.ctx.new_dict();
             for pair in object_entries(&Object::from(js_val)) {
                 let (key, val) = pair.expect("iteration over object to not fail");
                 let py_val = js_to_py(vm, val);
                 dict.set_item(&vm.ctx, &String::from(js_sys::JsString::from(key)), py_val);
             }
-            dict
+            dict.into_object()
         }
     } else if js_val.is_function() {
         let func = js_sys::Function::from(js_val);


### PR DESCRIPTION
Sorry, this is a bit of monster (especially as I had to change most of AST).

This is the controversial change I've been working towards:

After this:

* Instances (including modules) use real dictionaries for their attributes.
* Classes keep their attributes in a hidden PyAttributes.

We should create fewer dictionaries generally.