### PR TITLE
Use new style args for int.__new__

### DIFF
--- a/derive/src/lib.rs
+++ b/derive/src/lib.rs
@@ -146,14 +146,19 @@ fn generate_field(field: &Field) -> TokenStream2 {
         quote! {
             .unwrap_or_else(|| #default)
         }
+    } else if attr.optional {
+        quote! {
+            .map(crate::function::OptionalArg::Present)
+            .unwrap_or(crate::function::OptionalArg::Missing)
+        }
     } else {
         let err = match attr.kind {
-            ArgKind::Positional | ArgKind::PositionalKeyword => {
-                quote!(crate::function::ArgumentError::TooFewArgs)
-            }
-            ArgKind::Keyword => quote!(crate::function::ArgumentError::RequiredKeywordArgument(
-                stringify!(#name)
-            )),
+            ArgKind::Positional | ArgKind::PositionalKeyword => quote! {
+                crate::function::ArgumentError::TooFewArgs
+            },
+            ArgKind::Keyword => quote! {
+                crate::function::ArgumentError::RequiredKeywordArgument(tringify!(#name))
+            },
         };
         quote! {
             .ok_or_else(|| #err)?

--- a/derive/src/lib.rs
+++ b/derive/src/lib.rs
@@ -3,9 +3,9 @@ extern crate proc_macro;
 use proc_macro::TokenStream;
 use proc_macro2::TokenStream as TokenStream2;
 use quote::quote;
-use syn::{Data, DeriveInput, Field, Fields};
+use syn::{Attribute, Data, DeriveInput, Expr, Field, Fields, Ident, Lit, Meta, NestedMeta};
 
-#[proc_macro_derive(FromArgs, attributes(positional, keyword))]
+#[proc_macro_derive(FromArgs, attributes(pyarg))]
 pub fn derive_from_args(input: TokenStream) -> TokenStream {
     let ast: DeriveInput = syn::parse(input).unwrap();
 
@@ -13,40 +13,167 @@ pub fn derive_from_args(input: TokenStream) -> TokenStream {
     gen.to_string().parse().unwrap()
 }
 
-enum ArgType {
+enum ArgKind {
     Positional,
     PositionalKeyword,
     Keyword,
 }
 
-fn generate_field(field: &Field) -> TokenStream2 {
-    let arg_type = if let Some(attr) = field.attrs.first() {
-        if attr.path.is_ident("positional") {
-            ArgType::Positional
-        } else if attr.path.is_ident("keyword") {
-            ArgType::Keyword
+impl ArgKind {
+    fn from_ident(ident: &Ident) -> ArgKind {
+        if ident == "positional" {
+            ArgKind::Positional
+        } else if ident == "positional_keyword" {
+            ArgKind::PositionalKeyword
+        } else if ident == "keyword" {
+            ArgKind::Keyword
         } else {
             panic!("Unrecognised attribute")
         }
+    }
+}
+
+struct ArgAttribute {
+    kind: ArgKind,
+    default: Option<Expr>,
+    optional: bool,
+}
+
+impl ArgAttribute {
+    fn from_attribute(attr: &Attribute) -> Option<ArgAttribute> {
+        if !attr.path.is_ident("pyarg") {
+            return None;
+        }
+
+        match attr.parse_meta().unwrap() {
+            Meta::List(list) => {
+                let mut iter = list.nested.iter();
+                let first_arg = iter.next().expect("at least one argument in pyarg list");
+                let kind = match first_arg {
+                    NestedMeta::Meta(Meta::Word(ident)) => ArgKind::from_ident(ident),
+                    _ => panic!("Bad syntax for first pyarg attribute argument"),
+                };
+
+                let mut attribute = ArgAttribute {
+                    kind,
+                    default: None,
+                    optional: false,
+                };
+
+                while let Some(arg) = iter.next() {
+                    attribute.parse_argument(arg);
+                }
+
+                assert!(
+                    attribute.default.is_none() || !attribute.optional,
+                    "Can't set both a default value and optional"
+                );
+
+                Some(attribute)
+            }
+            _ => panic!("Bad syntax for pyarg attribute"),
+        }
+    }
+
+    fn parse_argument(&mut self, arg: &NestedMeta) {
+        match arg {
+            NestedMeta::Meta(Meta::Word(ident)) => {
+                if ident == "default" {
+                    assert!(self.default.is_none(), "Default already set");
+                    let expr = syn::parse_str::<Expr>("Default::default()").unwrap();
+                    self.default = Some(expr);
+                } else if ident == "optional" {
+                    self.optional = true;
+                } else {
+                    panic!("Unrecognised pyarg attribute '{}'", ident);
+                }
+            }
+            NestedMeta::Meta(Meta::NameValue(name_value)) => {
+                if name_value.ident == "default" {
+                    assert!(self.default.is_none(), "Default already set");
+
+                    match name_value.lit {
+                        Lit::Str(ref val) => {
+                            let expr = val
+                                .parse::<Expr>()
+                                .expect("a valid expression for default argument");
+                            self.default = Some(expr);
+                        }
+                        _ => panic!("Expected string value for default argument"),
+                    }
+                } else if name_value.ident == "optional" {
+                    match name_value.lit {
+                        Lit::Bool(ref val) => {
+                            self.optional = val.value;
+                        }
+                        _ => panic!("Expected boolean value for optional argument"),
+                    }
+                } else {
+                    panic!("Unrecognised pyarg attribute '{}'", name_value.ident);
+                }
+            }
+            _ => panic!("Bad syntax for first pyarg attribute argument"),
+        };
+    }
+}
+
+fn generate_field(field: &Field) -> TokenStream2 {
+    let mut pyarg_attrs = field
+        .attrs
+        .iter()
+        .filter_map(ArgAttribute::from_attribute)
+        .collect::<Vec<_>>();
+    let attr = if pyarg_attrs.is_empty() {
+        ArgAttribute {
+            kind: ArgKind::PositionalKeyword,
+            default: None,
+            optional: false,
+        }
+    } else if pyarg_attrs.len() == 1 {
+        pyarg_attrs.remove(0)
     } else {
-        ArgType::PositionalKeyword
+        panic!(
+            "Multiple pyarg attributes on field '{}'",
+            field.ident.as_ref().unwrap()
+        );
     };
 
     let name = &field.ident;
-    match arg_type {
-        ArgType::Positional => {
+    let middle = quote! {
+        .map(|x| crate::pyobject::TryFromObject::try_from_object(vm, x)).transpose()?
+    };
+    let ending = if let Some(default) = attr.default {
+        quote! {
+            .unwrap_or_else(|| #default)
+        }
+    } else {
+        let err = match attr.kind {
+            ArgKind::Positional | ArgKind::PositionalKeyword => {
+                quote!(crate::function::ArgumentError::TooFewArgs)
+            }
+            ArgKind::Keyword => quote!(crate::function::ArgumentError::RequiredKeywordArgument(
+                stringify!(#name)
+            )),
+        };
+        quote! {
+            .ok_or_else(|| #err)?
+        }
+    };
+
+    match attr.kind {
+        ArgKind::Positional => {
             quote! {
-                #name: args.take_positional(vm)?,
+                #name: args.take_positional()#middle#ending,
             }
         }
-        ArgType::PositionalKeyword => {
+        ArgKind::PositionalKeyword => {
             quote! {
-                #name: args.take_positional_keyword(vm, stringify!(#name))?,
+                #name: args.take_positional_keyword(stringify!(#name))#middle#ending,
             }
         }
-        ArgType::Keyword => {
+        ArgKind::Keyword => {
             quote! {
-                #name: args.take_keyword(vm, stringify!(#name))?,
+                #name: args.take_keyword(stringify!(#name))#middle#ending,
             }
         }
     }

--- a/derive/src/lib.rs
+++ b/derive/src/lib.rs
@@ -3,9 +3,9 @@ extern crate proc_macro;
 use proc_macro::TokenStream;
 use proc_macro2::TokenStream as TokenStream2;
 use quote::quote;
-use syn::{Data, DeriveInput, Fields};
+use syn::{Data, DeriveInput, Field, Fields};
 
-#[proc_macro_derive(FromArgs)]
+#[proc_macro_derive(FromArgs, attributes(positional, keyword))]
 pub fn derive_from_args(input: TokenStream) -> TokenStream {
     let ast: DeriveInput = syn::parse(input).unwrap();
 
@@ -13,21 +13,54 @@ pub fn derive_from_args(input: TokenStream) -> TokenStream {
     gen.to_string().parse().unwrap()
 }
 
+enum ArgType {
+    Positional,
+    PositionalKeyword,
+    Keyword,
+}
+
+fn generate_field(field: &Field) -> TokenStream2 {
+    let arg_type = if let Some(attr) = field.attrs.first() {
+        if attr.path.is_ident("positional") {
+            ArgType::Positional
+        } else if attr.path.is_ident("keyword") {
+            ArgType::Keyword
+        } else {
+            panic!("Unrecognised attribute")
+        }
+    } else {
+        ArgType::PositionalKeyword
+    };
+
+    let name = &field.ident;
+    match arg_type {
+        ArgType::Positional => {
+            quote! {
+                #name: args.take_positional(vm)?,
+            }
+        }
+        ArgType::PositionalKeyword => {
+            quote! {
+                #name: args.take_positional_keyword(vm, stringify!(#name))?,
+            }
+        }
+        ArgType::Keyword => {
+            quote! {
+                #name: args.take_keyword(vm, stringify!(#name))?,
+            }
+        }
+    }
+}
+
 fn impl_from_args(input: &DeriveInput) -> TokenStream2 {
     // FIXME: This references types using `crate` instead of `rustpython_vm`
     //        so that it can be used in the latter. How can we support both?
+    //        Can use extern crate self as rustpython_vm; once in stable.
+    //        https://github.com/rust-lang/rust/issues/56409
     let fields = match input.data {
         Data::Struct(ref data) => {
             match data.fields {
-                Fields::Named(ref fields) => fields.named.iter().map(|field| {
-                    let name = &field.ident;
-                    quote! {
-                        #name: crate::pyobject::TryFromObject::try_from_object(
-                            vm,
-                            args.take_keyword(stringify!(#name)).unwrap_or_else(|| vm.ctx.none())
-                        )?,
-                    }
-                }),
+                Fields::Named(ref fields) => fields.named.iter().map(generate_field),
                 Fields::Unnamed(_) | Fields::Unit => unimplemented!(), // TODO: better error message
             }
         }

--- a/derive/src/lib.rs
+++ b/derive/src/lib.rs
@@ -23,11 +23,11 @@ enum ParameterKind {
 
 impl ParameterKind {
     fn from_ident(ident: &Ident) -> ParameterKind {
-        if ident == "positional" {
+        if ident == "positional_only" {
             ParameterKind::PositionalOnly
-        } else if ident == "positional_keyword" {
+        } else if ident == "positional_or_keyword" {
             ParameterKind::PositionalOrKeyword
-        } else if ident == "keyword" {
+        } else if ident == "keyword_only" {
             ParameterKind::KeywordOnly
         } else {
             panic!("Unrecognised attribute")

--- a/tests/snippets/ints.py
+++ b/tests/snippets/ints.py
@@ -1,4 +1,4 @@
-from testutils import assert_raises
+from testutils import assert_raises, assertRaises
 
 # int to int comparisons
 
@@ -58,3 +58,19 @@ assert (2).__mul__(1.0) == NotImplemented
 assert (2).__rmul__(1.0) == NotImplemented
 assert (2).__truediv__(1.0) == NotImplemented
 assert (2).__rtruediv__(1.0) == NotImplemented
+
+
+assert int() == 0
+assert int("101", 2) == 5
+assert int("101", base=2) == 5
+assert int(1) == 1
+
+with assertRaises(TypeError):
+    int(base=2)
+
+with assertRaises(TypeError):
+    int(1, base=2)
+
+with assertRaises(TypeError):
+    # check that first parameter is truly positional only
+    int(val_options=1)

--- a/vm/src/builtins.rs
+++ b/vm/src/builtins.rs
@@ -559,22 +559,14 @@ fn builtin_pow(vm: &VirtualMachine, args: PyFuncArgs) -> PyResult {
     }
 }
 
-// Idea: Should we have a 'default' attribute, so we don't have to use OptionalArg's in this case
-//#[derive(Debug, FromArgs)]
-//pub struct PrintOptions {
-//    #[keyword] #[default(None)] sep: Option<PyStringRef>,
-//    #[keyword] #[default(None)] end: Option<PyStringRef>,
-//    #[keyword] #[default(flush)] flush: bool,
-//}
-
 #[derive(Debug, FromArgs)]
 pub struct PrintOptions {
-    #[keyword]
-    sep: OptionalArg<Option<PyStringRef>>,
-    #[keyword]
-    end: OptionalArg<Option<PyStringRef>>,
-    #[keyword]
-    flush: OptionalArg<bool>,
+    #[pyarg(keyword, default = "None")]
+    sep: Option<PyStringRef>,
+    #[pyarg(keyword, default = "None")]
+    end: Option<PyStringRef>,
+    #[pyarg(keyword, default = "false")]
+    flush: bool,
 }
 
 pub fn builtin_print(objects: Args, options: PrintOptions, vm: &VirtualMachine) -> PyResult<()> {
@@ -584,7 +576,7 @@ pub fn builtin_print(objects: Args, options: PrintOptions, vm: &VirtualMachine) 
     for object in objects {
         if first {
             first = false;
-        } else if let OptionalArg::Present(Some(ref sep)) = options.sep {
+        } else if let Some(ref sep) = options.sep {
             write!(stdout_lock, "{}", sep.value).unwrap();
         } else {
             write!(stdout_lock, " ").unwrap();
@@ -593,13 +585,13 @@ pub fn builtin_print(objects: Args, options: PrintOptions, vm: &VirtualMachine) 
         write!(stdout_lock, "{}", s).unwrap();
     }
 
-    if let OptionalArg::Present(Some(end)) = options.end {
+    if let Some(end) = options.end {
         write!(stdout_lock, "{}", end.value).unwrap();
     } else {
         writeln!(stdout_lock).unwrap();
     }
 
-    if options.flush.into_option().unwrap_or(false) {
+    if options.flush {
         stdout_lock.flush().unwrap();
     }
 

--- a/vm/src/builtins.rs
+++ b/vm/src/builtins.rs
@@ -537,11 +537,11 @@ fn builtin_pow(vm: &VirtualMachine, args: PyFuncArgs) -> PyResult {
 
 #[derive(Debug, FromArgs)]
 pub struct PrintOptions {
-    #[pyarg(keyword, default = "None")]
+    #[pyarg(keyword_only, default = "None")]
     sep: Option<PyStringRef>,
-    #[pyarg(keyword, default = "None")]
+    #[pyarg(keyword_only, default = "None")]
     end: Option<PyStringRef>,
-    #[pyarg(keyword, default = "false")]
+    #[pyarg(keyword_only, default = "false")]
     flush: bool,
 }
 

--- a/vm/src/obj/objint.rs
+++ b/vm/src/obj/objint.rs
@@ -374,9 +374,9 @@ impl PyIntRef {
 
 #[derive(FromArgs)]
 struct IntOptions {
-    #[pyarg(positional, optional = true)]
+    #[pyarg(positional_only, optional = true)]
     val_options: OptionalArg<PyObjectRef>,
-    #[pyarg(positional_keyword, optional = true)]
+    #[pyarg(positional_or_keyword, optional = true)]
     base: OptionalArg<u32>,
 }
 

--- a/vm/src/obj/objint.rs
+++ b/vm/src/obj/objint.rs
@@ -382,8 +382,9 @@ impl PyIntRef {
 
 #[derive(FromArgs)]
 struct IntOptions {
-    #[positional]
+    #[pyarg(positional, optional = true)]
     val_options: OptionalArg<PyObjectRef>,
+    #[pyarg(positional_keyword, optional = true)]
     base: OptionalArg<u32>,
 }
 


### PR DESCRIPTION
To achieve this I anhanced FromArgs derive proc macro to support positional arguments. Positional-only arguments have the #[positional] attribute in front of it's field and while keyword-only arguments have #[keyword] attribute in front of it's field.