### PR TITLE
Fix decorator on functions with defaults

### DIFF
--- a/tests/snippets/decorators.py
+++ b/tests/snippets/decorators.py
@@ -15,6 +15,16 @@ c = add(10, 3)
 assert c == 14
 
 
+@logged
+def add3(a, b, c=2):
+    return a + b + c
+
+
+d = add3(12, 5)
+
+assert d == 20
+
+
 def f(func): return lambda: 42
 class A: pass
 a = A()

--- a/vm/src/compile.rs
+++ b/vm/src/compile.rs
@@ -585,6 +585,9 @@ impl Compiler {
         let was_in_function_def = self.in_function_def;
         self.in_loop = false;
         self.in_function_def = true;
+
+        self.prepare_decorators(decorator_list)?;
+
         let mut flags = self.enter_function(name, args)?;
 
         let (new_body, doc_str) = get_doc(body);
@@ -597,8 +600,6 @@ impl Compiler {
         });
         self.emit(Instruction::ReturnValue);
         let code = self.pop_code_object();
-
-        self.prepare_decorators(decorator_list)?;
 
         // Prepare type annotations:
         let mut num_annotations = 0;


### PR DESCRIPTION
Previously, the defaults and decorator function was around the wrong way on the stack, so it tried to call the defaults as if they were the decorator. 