### PR TITLE
Dict protocols

### DIFF
--- a/tests/snippets/dict.py
+++ b/tests/snippets/dict.py
@@ -58,11 +58,13 @@ assert x.get("here", "default") == "here"
 assert x.get("not here") == None
 
 class LengthDict(dict):
-    pass
+    def __getitem__(self, k):
+        return len(k)
 
 x = LengthDict()
 assert type(x) == LengthDict
-
+assert x['word'] == 4
+assert x.get('word') is None
 
 # An object that hashes to the same value always, and compares equal if any its values match.
 class Hashable(object):

--- a/tests/snippets/dict.py
+++ b/tests/snippets/dict.py
@@ -66,6 +66,8 @@ assert type(x) == LengthDict
 assert x['word'] == 4
 assert x.get('word') is None
 
+assert 5 == eval("a + word", LengthDict())
+
 # An object that hashes to the same value always, and compares equal if any its values match.
 class Hashable(object):
     def __init__(self, *args):

--- a/tests/snippets/dict.py
+++ b/tests/snippets/dict.py
@@ -57,6 +57,13 @@ assert x.get("not here", "default") == "default"
 assert x.get("here", "default") == "here"
 assert x.get("not here") == None
 
+class LengthDict(dict):
+    pass
+
+x = LengthDict()
+assert type(x) == LengthDict
+
+
 # An object that hashes to the same value always, and compares equal if any its values match.
 class Hashable(object):
     def __init__(self, *args):

--- a/tests/snippets/dict.py
+++ b/tests/snippets/dict.py
@@ -68,6 +68,16 @@ assert x.get('word') is None
 
 assert 5 == eval("a + word", LengthDict())
 
+
+class Squares(dict):
+    def __missing__(self, k):
+        v = k * k
+        self[k] = v
+        return v
+
+x = Squares()
+assert x[-5] == 25
+
 # An object that hashes to the same value always, and compares equal if any its values match.
 class Hashable(object):
     def __init__(self, *args):

--- a/vm/src/builtins.rs
+++ b/vm/src/builtins.rs
@@ -20,7 +20,7 @@ use crate::obj::objtype::{self, PyClassRef};
 use crate::frame::Scope;
 use crate::function::{Args, OptionalArg, PyFuncArgs};
 use crate::pyobject::{
-    DictProtocol, IdProtocol, PyIterable, PyObjectRef, PyResult, PyValue, TryFromObject,
+    IdProtocol, ItemProtocol, PyIterable, PyObjectRef, PyResult, PyValue, TryFromObject,
     TypeProtocol,
 };
 use crate::vm::VirtualMachine;
@@ -804,6 +804,6 @@ pub fn builtin_build_class_(vm: &VirtualMachine, mut args: PyFuncArgs) -> PyResu
         "__call__",
         vec![name_arg, bases, namespace.into_object()],
     )?;
-    cells.set_item("__class__", class.clone(), vm);
+    cells.set_item("__class__", class.clone(), vm)?;
     Ok(class)
 }

--- a/vm/src/dictdatatype.rs
+++ b/vm/src/dictdatatype.rs
@@ -76,16 +76,15 @@ impl Dict {
     }
 
     /// Retrieve a key
-    pub fn get(&self, vm: &VirtualMachine, key: &PyObjectRef) -> PyResult {
+    pub fn get(&self, vm: &VirtualMachine, key: &PyObjectRef) -> PyResult<Option<PyObjectRef>> {
         if let LookupResult::Existing(index) = self.lookup(vm, key)? {
             if let Some(entry) = &self.entries[index] {
-                Ok(entry.value.clone())
+                Ok(Some(entry.value.clone()))
             } else {
                 panic!("Lookup returned invalid index into entries!");
             }
         } else {
-            let key_repr = vm.to_pystr(key)?;
-            Err(vm.new_key_error(format!("Key not found: {}", key_repr)))
+            Ok(None)
         }
     }
 

--- a/vm/src/frame.rs
+++ b/vm/src/frame.rs
@@ -21,8 +21,8 @@ use crate::obj::objstr;
 use crate::obj::objtype;
 use crate::obj::objtype::PyClassRef;
 use crate::pyobject::{
-    DictProtocol, IdProtocol, ItemProtocol, PyContext, PyObjectRef, PyRef, PyResult, PyValue,
-    TryFromObject, TypeProtocol,
+    IdProtocol, ItemProtocol, PyContext, PyObjectRef, PyRef, PyResult, PyValue, TryFromObject,
+    TypeProtocol,
 };
 use crate::vm::VirtualMachine;
 use itertools::Itertools;
@@ -133,12 +133,12 @@ pub trait NameProtocol {
 impl NameProtocol for Scope {
     fn load_name(&self, vm: &VirtualMachine, name: &str) -> Option<PyObjectRef> {
         for dict in self.locals.iter() {
-            if let Some(value) = dict.get_item(name, vm) {
+            if let Some(value) = dict.get_item_option(name, vm).unwrap() {
                 return Some(value);
             }
         }
 
-        if let Some(value) = self.globals.get_item(name, vm) {
+        if let Some(value) = self.globals.get_item_option(name, vm).unwrap() {
             return Some(value);
         }
 
@@ -147,7 +147,7 @@ impl NameProtocol for Scope {
 
     fn load_cell(&self, vm: &VirtualMachine, name: &str) -> Option<PyObjectRef> {
         for dict in self.locals.iter().skip(1) {
-            if let Some(value) = dict.get_item(name, vm) {
+            if let Some(value) = dict.get_item_option(name, vm).unwrap() {
                 return Some(value);
             }
         }
@@ -155,11 +155,11 @@ impl NameProtocol for Scope {
     }
 
     fn store_name(&self, vm: &VirtualMachine, key: &str, value: PyObjectRef) {
-        self.get_locals().set_item(key, value, vm)
+        self.get_locals().set_item(key, value, vm).unwrap();
     }
 
     fn delete_name(&self, vm: &VirtualMachine, key: &str) {
-        self.get_locals().del_item(key, vm)
+        self.get_locals().del_item(key, vm).unwrap();
     }
 }
 
@@ -394,12 +394,12 @@ impl Frame {
                             obj.downcast().expect("Need a dictionary to build a map.");
                         let dict_elements = dict.get_key_value_pairs();
                         for (key, value) in dict_elements.iter() {
-                            map_obj.set_item(key.clone(), value.clone(), vm);
+                            map_obj.set_item(key.clone(), value.clone(), vm).unwrap();
                         }
                     }
                 } else {
                     for (key, value) in self.pop_multiple(2 * size).into_iter().tuples() {
-                        map_obj.set_item(key, value, vm)
+                        map_obj.set_item(key, value, vm).unwrap();
                     }
                 }
 

--- a/vm/src/import.rs
+++ b/vm/src/import.rs
@@ -8,7 +8,7 @@ use std::path::PathBuf;
 use crate::compile;
 use crate::frame::Scope;
 use crate::obj::{objsequence, objstr};
-use crate::pyobject::{DictProtocol, ItemProtocol, PyResult};
+use crate::pyobject::{ItemProtocol, PyResult};
 use crate::util;
 use crate::vm::VirtualMachine;
 
@@ -39,7 +39,7 @@ fn import_uncached_module(vm: &VirtualMachine, current_path: PathBuf, module: &s
     // trace!("Code object: {:?}", code_obj);
 
     let attrs = vm.ctx.new_dict();
-    attrs.set_item("__name__", vm.new_str(module.to_string()), vm);
+    attrs.set_item("__name__", vm.new_str(module.to_string()), vm)?;
     vm.run_code_obj(code_obj, Scope::new(None, attrs.clone()))?;
     Ok(vm.ctx.new_module(module, attrs))
 }

--- a/vm/src/obj/objdict.rs
+++ b/vm/src/obj/objdict.rs
@@ -89,7 +89,7 @@ impl PyDictRef {
         self.entries.borrow().len()
     }
 
-    fn repr(self, vm: &VirtualMachine) -> PyResult {
+    fn repr(self, vm: &VirtualMachine) -> PyResult<String> {
         let s = if let Some(_guard) = ReprGuard::enter(self.as_object()) {
             let mut str_parts = vec![];
             for (key, value) in self.get_key_value_pairs() {
@@ -102,7 +102,7 @@ impl PyDictRef {
         } else {
             "{...}".to_string()
         };
-        Ok(vm.new_str(s))
+        Ok(s)
     }
 
     fn contains(self, key: PyObjectRef, vm: &VirtualMachine) -> PyResult<bool> {

--- a/vm/src/obj/objdict.rs
+++ b/vm/src/obj/objdict.rs
@@ -229,7 +229,7 @@ impl PyDictRef {
 
 impl ItemProtocol for PyDictRef {
     fn get_item<T: IntoPyObject>(&self, key: T, vm: &VirtualMachine) -> PyResult {
-        vm.call_method(self.as_object(), "__getitem__", key.into_pyobject(vm)?)
+        self.as_object().get_item(key, vm)
     }
 
     fn set_item<T: IntoPyObject>(
@@ -238,15 +238,11 @@ impl ItemProtocol for PyDictRef {
         value: PyObjectRef,
         vm: &VirtualMachine,
     ) -> PyResult {
-        vm.call_method(
-            self.as_object(),
-            "__setitem__",
-            vec![key.into_pyobject(vm)?, value],
-        )
+        self.as_object().set_item(key, value, vm)
     }
 
     fn del_item<T: IntoPyObject>(&self, key: T, vm: &VirtualMachine) -> PyResult {
-        vm.call_method(self.as_object(), "__delitem__", key.into_pyobject(vm)?)
+        self.as_object().del_item(key, vm)
     }
 }
 

--- a/vm/src/obj/objdict.rs
+++ b/vm/src/obj/objdict.rs
@@ -109,7 +109,7 @@ impl PyDictRef {
         self.entries.borrow().contains(vm, &key)
     }
 
-    fn delitem(self, key: PyObjectRef, vm: &VirtualMachine) -> PyResult<()> {
+    fn inner_delitem(self, key: PyObjectRef, vm: &VirtualMachine) -> PyResult<()> {
         self.entries.borrow_mut().delete(vm, &key)
     }
 
@@ -173,11 +173,16 @@ impl PyDictRef {
         self.entries.borrow().get_items()
     }
 
-    fn setitem(self, key: PyObjectRef, value: PyObjectRef, vm: &VirtualMachine) -> PyResult<()> {
+    fn inner_setitem(
+        self,
+        key: PyObjectRef,
+        value: PyObjectRef,
+        vm: &VirtualMachine,
+    ) -> PyResult<()> {
         self.entries.borrow_mut().insert(vm, &key, value)
     }
 
-    fn getitem(self, key: PyObjectRef, vm: &VirtualMachine) -> PyResult {
+    fn inner_getitem(self, key: PyObjectRef, vm: &VirtualMachine) -> PyResult {
         match self.entries.borrow().get(vm, &key)? {
             Some(value) => Ok(value),
             None => {
@@ -250,12 +255,12 @@ pub fn init(context: &PyContext) {
         "__bool__" => context.new_rustfunc(PyDictRef::bool),
         "__len__" => context.new_rustfunc(PyDictRef::len),
         "__contains__" => context.new_rustfunc(PyDictRef::contains),
-        "__delitem__" => context.new_rustfunc(PyDictRef::delitem),
-        "__getitem__" => context.new_rustfunc(PyDictRef::getitem),
+        "__delitem__" => context.new_rustfunc(PyDictRef::inner_delitem),
+        "__getitem__" => context.new_rustfunc(PyDictRef::inner_getitem),
         "__iter__" => context.new_rustfunc(PyDictRef::iter),
         "__new__" => context.new_rustfunc(PyDictRef::new),
         "__repr__" => context.new_rustfunc(PyDictRef::repr),
-        "__setitem__" => context.new_rustfunc(PyDictRef::setitem),
+        "__setitem__" => context.new_rustfunc(PyDictRef::inner_setitem),
         "__hash__" => context.new_rustfunc(PyDictRef::hash),
         "clear" => context.new_rustfunc(PyDictRef::clear),
         "values" => context.new_rustfunc(PyDictRef::values),

--- a/vm/src/obj/objsuper.rs
+++ b/vm/src/obj/objsuper.rs
@@ -12,7 +12,7 @@ use crate::obj::objfunction::PyMethod;
 use crate::obj::objstr;
 use crate::obj::objtype::{PyClass, PyClassRef};
 use crate::pyobject::{
-    DictProtocol, PyContext, PyObjectRef, PyRef, PyResult, PyValue, TryFromObject, TypeProtocol,
+    ItemProtocol, PyContext, PyObjectRef, PyRef, PyResult, PyValue, TryFromObject, TypeProtocol,
 };
 use crate::vm::VirtualMachine;
 
@@ -124,7 +124,7 @@ fn super_new(
     } else {
         let frame = vm.current_frame().expect("no current frame for super()");
         if let Some(first_arg) = frame.code.arg_names.get(0) {
-            match vm.get_locals().get_item(first_arg, vm) {
+            match vm.get_locals().get_item_option(first_arg, vm)? {
                 Some(obj) => obj.clone(),
                 _ => {
                     return Err(vm

--- a/vm/src/pyobject.rs
+++ b/vm/src/pyobject.rs
@@ -912,12 +912,6 @@ impl<T> TypeProtocol for PyRef<T> {
     }
 }
 
-pub trait DictProtocol {
-    fn get_item<T: IntoPyObject>(&self, key: T, vm: &VirtualMachine) -> Option<PyObjectRef>;
-    fn set_item<T: IntoPyObject>(&self, key: T, value: PyObjectRef, vm: &VirtualMachine);
-    fn del_item<T: IntoPyObject>(&self, key: T, vm: &VirtualMachine);
-}
-
 pub trait ItemProtocol {
     fn get_item<T: IntoPyObject>(&self, key: T, vm: &VirtualMachine) -> PyResult;
     fn set_item<T: IntoPyObject>(
@@ -927,6 +921,22 @@ pub trait ItemProtocol {
         vm: &VirtualMachine,
     ) -> PyResult;
     fn del_item<T: IntoPyObject>(&self, key: T, vm: &VirtualMachine) -> PyResult;
+    fn get_item_option<T: IntoPyObject>(
+        &self,
+        key: T,
+        vm: &VirtualMachine,
+    ) -> PyResult<Option<PyObjectRef>> {
+        match self.get_item(key, vm) {
+            Ok(value) => Ok(Some(value)),
+            Err(exc) => {
+                if objtype::isinstance(&exc, &vm.ctx.exceptions.key_error) {
+                    Ok(None)
+                } else {
+                    Err(exc)
+                }
+            }
+        }
+    }
 }
 
 impl ItemProtocol for PyObjectRef {

--- a/vm/src/stdlib/json.rs
+++ b/vm/src/stdlib/json.rs
@@ -13,9 +13,7 @@ use crate::obj::{
     objstr::{self, PyString},
     objtype,
 };
-use crate::pyobject::{
-    create_type, DictProtocol, IdProtocol, ItemProtocol, PyObjectRef, PyResult, TypeProtocol,
-};
+use crate::pyobject::{create_type, IdProtocol, ItemProtocol, PyObjectRef, PyResult, TypeProtocol};
 use crate::VirtualMachine;
 use num_traits::cast::ToPrimitive;
 
@@ -178,7 +176,7 @@ impl<'de> Visitor<'de> for PyObjectDeserializer<'de> {
                 Some(PyString { ref value }) => value.clone(),
                 _ => unimplemented!("map keys must be strings"),
             };
-            dict.set_item(&key, value, self.vm);
+            dict.set_item(&key, value, self.vm).unwrap();
         }
         Ok(dict.into_object())
     }

--- a/vm/src/sysmodule.rs
+++ b/vm/src/sysmodule.rs
@@ -3,7 +3,7 @@ use std::{env, mem};
 
 use crate::frame::FrameRef;
 use crate::function::{OptionalArg, PyFuncArgs};
-use crate::pyobject::{DictProtocol, PyContext, PyObjectRef, PyResult, TypeProtocol};
+use crate::pyobject::{ItemProtocol, PyContext, PyObjectRef, PyResult, TypeProtocol};
 use crate::vm::VirtualMachine;
 
 /*
@@ -139,6 +139,6 @@ settrace() -- set the global debug tracing function
       "modules" => modules.clone(),
     });
 
-    modules.set_item("sys", module.clone(), vm);
-    modules.set_item("builtins", builtins.clone(), vm);
+    modules.set_item("sys", module.clone(), vm).unwrap();
+    modules.set_item("builtins", builtins.clone(), vm).unwrap();
 }

--- a/wasm/lib/src/convert.rs
+++ b/wasm/lib/src/convert.rs
@@ -4,7 +4,7 @@ use wasm_bindgen::{closure::Closure, prelude::*, JsCast};
 
 use rustpython_vm::function::PyFuncArgs;
 use rustpython_vm::obj::{objbytes, objint, objsequence, objtype};
-use rustpython_vm::pyobject::{DictProtocol, PyObjectRef, PyResult, PyValue};
+use rustpython_vm::pyobject::{ItemProtocol, PyObjectRef, PyResult, PyValue};
 use rustpython_vm::VirtualMachine;
 
 use crate::browser_module;
@@ -192,7 +192,8 @@ pub fn js_to_py(vm: &VirtualMachine, js_val: JsValue) -> PyObjectRef {
             for pair in object_entries(&Object::from(js_val)) {
                 let (key, val) = pair.expect("iteration over object to not fail");
                 let py_val = js_to_py(vm, val);
-                dict.set_item(&String::from(js_sys::JsString::from(key)), py_val, vm);
+                dict.set_item(&String::from(js_sys::JsString::from(key)), py_val, vm)
+                    .unwrap();
             }
             dict.into_object()
         }


### PR DESCRIPTION
Finally remove DictProtocol, and clean up a bunch of other dict things.

I've come to the conclusion that ```ItemProtocol``` on ```PyDictRef``` must do the same thing as the version on ```PyObjectRef```.

* It's way too surprising if ```dict.get_item``` and ```dict.as_object().get_item``` are different.
* I haven't found any cases where it's correct to bypass the overridden ```__getitem__```, so the only thing left is the performance boost where we know it's a base dictionary because we just created it. In that case it's clearer to call ```inner_getitem``` explicitly. (We should optimise attribute access first though.)