### PR TITLE
Add os.{mkdir, mkdirs, rmdir, listdir}

### DIFF
--- a/vm/src/stdlib/os.rs
+++ b/vm/src/stdlib/os.rs
@@ -169,6 +169,15 @@ fn os_mkdirs(path: PyStringRef, vm: &VirtualMachine) -> PyResult {
     Ok(vm.get_none())
 }
 
+fn os_rmdir(path: PyStringRef, vm: &VirtualMachine) -> PyResult {
+    match fs::remove_dir(&path.value) {
+        Ok(_) => (),
+        Err(s) => return Err(vm.new_os_error(s.to_string())),
+    }
+
+    Ok(vm.get_none())
+}
+
 pub fn make_module(vm: &VirtualMachine) -> PyObjectRef {
     let ctx = &vm.ctx;
 
@@ -188,6 +197,7 @@ pub fn make_module(vm: &VirtualMachine) -> PyObjectRef {
         "unlink" => ctx.new_rustfunc(os_remove),
         "mkdir" => ctx.new_rustfunc(os_mkdir),
         "mkdirs" => ctx.new_rustfunc(os_mkdirs),
+        "rmdir" => ctx.new_rustfunc(os_rmdir),
         "name" => ctx.new_str(os_name),
         "O_RDONLY" => ctx.new_int(0),
         "O_WRONLY" => ctx.new_int(1),

--- a/vm/src/stdlib/os.rs
+++ b/vm/src/stdlib/os.rs
@@ -160,6 +160,15 @@ fn os_mkdir(path: PyStringRef, vm: &VirtualMachine) -> PyResult {
     Ok(vm.get_none())
 }
 
+fn os_mkdirs(path: PyStringRef, vm: &VirtualMachine) -> PyResult {
+    match fs::create_dir_all(&path.value) {
+        Ok(_) => (),
+        Err(s) => return Err(vm.new_os_error(s.to_string())),
+    }
+
+    Ok(vm.get_none())
+}
+
 pub fn make_module(vm: &VirtualMachine) -> PyObjectRef {
     let ctx = &vm.ctx;
 
@@ -178,6 +187,7 @@ pub fn make_module(vm: &VirtualMachine) -> PyObjectRef {
         "remove" => ctx.new_rustfunc(os_remove),
         "unlink" => ctx.new_rustfunc(os_remove),
         "mkdir" => ctx.new_rustfunc(os_mkdir),
+        "mkdirs" => ctx.new_rustfunc(os_mkdirs),
         "name" => ctx.new_str(os_name),
         "O_RDONLY" => ctx.new_int(0),
         "O_WRONLY" => ctx.new_int(1),

--- a/vm/src/stdlib/os.rs
+++ b/vm/src/stdlib/os.rs
@@ -142,40 +142,20 @@ fn os_write(fd: PyIntRef, data: PyBytesRef, vm: &VirtualMachine) -> PyResult {
     Ok(vm.ctx.new_int(written))
 }
 
-fn os_remove(path: PyStringRef, vm: &VirtualMachine) -> PyResult {
-    match fs::remove_file(&path.value) {
-        Ok(_) => (),
-        Err(s) => return Err(vm.new_os_error(s.to_string())),
-    }
-
-    Ok(vm.get_none())
+fn os_remove(path: PyStringRef, vm: &VirtualMachine) -> PyResult<()> {
+    fs::remove_file(&path.value).map_err(|s| vm.new_os_error(s.to_string()))
 }
 
-fn os_mkdir(path: PyStringRef, vm: &VirtualMachine) -> PyResult {
-    match fs::create_dir(&path.value) {
-        Ok(_) => (),
-        Err(s) => return Err(vm.new_os_error(s.to_string())),
-    }
-
-    Ok(vm.get_none())
+fn os_mkdir(path: PyStringRef, vm: &VirtualMachine) -> PyResult<()> {
+    fs::create_dir(&path.value).map_err(|s| vm.new_os_error(s.to_string()))
 }
 
-fn os_mkdirs(path: PyStringRef, vm: &VirtualMachine) -> PyResult {
-    match fs::create_dir_all(&path.value) {
-        Ok(_) => (),
-        Err(s) => return Err(vm.new_os_error(s.to_string())),
-    }
-
-    Ok(vm.get_none())
+fn os_mkdirs(path: PyStringRef, vm: &VirtualMachine) -> PyResult<()> {
+    fs::create_dir_all(&path.value).map_err(|s| vm.new_os_error(s.to_string()))
 }
 
-fn os_rmdir(path: PyStringRef, vm: &VirtualMachine) -> PyResult {
-    match fs::remove_dir(&path.value) {
-        Ok(_) => (),
-        Err(s) => return Err(vm.new_os_error(s.to_string())),
-    }
-
-    Ok(vm.get_none())
+fn os_rmdir(path: PyStringRef, vm: &VirtualMachine) -> PyResult<()> {
+    fs::remove_dir(&path.value).map_err(|s| vm.new_os_error(s.to_string()))
 }
 
 fn os_listdir(path: PyStringRef, vm: &VirtualMachine) -> PyResult {

--- a/vm/src/stdlib/os.rs
+++ b/vm/src/stdlib/os.rs
@@ -151,6 +151,15 @@ fn os_remove(path: PyStringRef, vm: &VirtualMachine) -> PyResult {
     Ok(vm.get_none())
 }
 
+fn os_mkdir(path: PyStringRef, vm: &VirtualMachine) -> PyResult {
+    match fs::create_dir(&path.value) {
+        Ok(_) => (),
+        Err(s) => return Err(vm.new_os_error(s.to_string())),
+    }
+
+    Ok(vm.get_none())
+}
+
 pub fn make_module(vm: &VirtualMachine) -> PyObjectRef {
     let ctx = &vm.ctx;
 
@@ -168,6 +177,7 @@ pub fn make_module(vm: &VirtualMachine) -> PyObjectRef {
         "write" => ctx.new_rustfunc(os_write),
         "remove" => ctx.new_rustfunc(os_remove),
         "unlink" => ctx.new_rustfunc(os_remove),
+        "mkdir" => ctx.new_rustfunc(os_mkdir),
         "name" => ctx.new_str(os_name),
         "O_RDONLY" => ctx.new_int(0),
         "O_WRONLY" => ctx.new_int(1),


### PR DESCRIPTION
Currently I did not added tests. I want to move all the files tests to a system temp directory. I will need to add the following in order to do that:

- Add `os.getenv` to get windows `%TEMP%`
- Add `os.sep` for correct path building in windows and linux.

I will these two features and then add to `testutils` a context manager of temp folder and move the tests to use that folder.