### PR TITLE
Add builtin warning classes

### DIFF
--- a/vm/src/builtins.rs
+++ b/vm/src/builtins.rs
@@ -767,6 +767,19 @@ pub fn make_module(vm: &VirtualMachine, module: PyObjectRef) {
         "ZeroDivisionError" => ctx.exceptions.zero_division_error.clone(),
         "KeyError" => ctx.exceptions.key_error.clone(),
         "OSError" => ctx.exceptions.os_error.clone(),
+
+        // Warnings
+        "Warning" => ctx.exceptions.warning.clone(),
+        "BytesWarning" => ctx.exceptions.bytes_warning.clone(),
+        "UnicodeWarning" => ctx.exceptions.unicode_warning.clone(),
+        "DeprecationWarning" => ctx.exceptions.deprecation_warning.clone(),
+        "PendingDeprecationWarning" => ctx.exceptions.pending_deprecation_warning.clone(),
+        "FutureWarning" => ctx.exceptions.future_warning.clone(),
+        "ImportWarning" => ctx.exceptions.import_warning.clone(),
+        "SyntaxWarning" => ctx.exceptions.syntax_warning.clone(),
+        "ResourceWarning" => ctx.exceptions.resource_warning.clone(),
+        "RuntimeWarning" => ctx.exceptions.runtime_warning.clone(),
+        "UserWarning" => ctx.exceptions.user_warning.clone(),
     });
 }
 

--- a/vm/src/exceptions.rs
+++ b/vm/src/exceptions.rs
@@ -103,6 +103,18 @@ pub struct ExceptionZoo {
     pub type_error: PyClassRef,
     pub value_error: PyClassRef,
     pub zero_division_error: PyClassRef,
+
+    pub warning: PyClassRef,
+    pub bytes_warning: PyClassRef,
+    pub unicode_warning: PyClassRef,
+    pub deprecation_warning: PyClassRef,
+    pub pending_deprecation_warning: PyClassRef,
+    pub future_warning: PyClassRef,
+    pub import_warning: PyClassRef,
+    pub syntax_warning: PyClassRef,
+    pub resource_warning: PyClassRef,
+    pub runtime_warning: PyClassRef,
+    pub user_warning: PyClassRef,
 }
 
 impl ExceptionZoo {
@@ -130,6 +142,19 @@ impl ExceptionZoo {
         let file_not_found_error = create_type("FileNotFoundError", &type_type, &os_error);
         let permission_error = create_type("PermissionError", &type_type, &os_error);
 
+        let warning = create_type("Warning", &type_type, &exception_type);
+        let bytes_warning = create_type("BytesWarning", &type_type, &warning);
+        let unicode_warning = create_type("UnicodeWarning", &type_type, &warning);
+        let deprecation_warning = create_type("DeprecationWarning", &type_type, &warning);
+        let pending_deprecation_warning =
+            create_type("PendingDeprecationWarning", &type_type, &warning);
+        let future_warning = create_type("FutureWarning", &type_type, &warning);
+        let import_warning = create_type("ImportWarning", &type_type, &warning);
+        let syntax_warning = create_type("SyntaxWarning", &type_type, &warning);
+        let resource_warning = create_type("ResourceWarning", &type_type, &warning);
+        let runtime_warning = create_type("RuntimeWarning", &type_type, &warning);
+        let user_warning = create_type("UserWarning", &type_type, &warning);
+
         ExceptionZoo {
             arithmetic_error,
             assertion_error,
@@ -152,6 +177,17 @@ impl ExceptionZoo {
             type_error,
             value_error,
             zero_division_error,
+            warning,
+            bytes_warning,
+            unicode_warning,
+            deprecation_warning,
+            pending_deprecation_warning,
+            future_warning,
+            import_warning,
+            syntax_warning,
+            resource_warning,
+            runtime_warning,
+            user_warning,
         }
     }
 }


### PR DESCRIPTION
This is required for importing of the warnings module, which is a dependency of unittest.