### PR TITLE
refactor bytes

### DIFF
--- a/parser/src/lexer.rs
+++ b/parser/src/lexer.rs
@@ -540,8 +540,12 @@ where
         let end_pos = self.get_pos();
 
         let tok = if is_bytes {
-            Tok::Bytes {
-                value: string_content.as_bytes().to_vec(),
+            if string_content.is_ascii() {
+                Tok::Bytes {
+                    value: string_content.as_bytes().to_vec(),
+                }
+            } else {
+                return Err(LexicalError::StringError);
             }
         } else {
             Tok::String {

--- a/tests/snippets/bytes.py
+++ b/tests/snippets/bytes.py
@@ -7,10 +7,8 @@ assert bytes(range(4))
 assert bytes(3)
 assert b"bla"
 assert bytes("bla", "utf8")
-try:
+with assertRaises(TypeError):
     bytes("bla")
-except TypeError:
-    assert True
 
 
 a = b"abcd"
@@ -48,7 +46,7 @@ hash(a) == hash(b"abcd")
 
 # iter
 [i for i in b"abcd"] == ["a", "b", "c", "d"]
-assert list(bytes(3)) ==  [0,0,0]
+assert list(bytes(3)) == [0, 0, 0]
 
 # add
 assert a + b == b"abcdab"
@@ -62,10 +60,8 @@ assert b"d" in b"abcd"
 assert b"dc" not in b"abcd"
 assert 97 in b"abcd"
 assert 150 not in b"abcd"
-try:
+with assertRaises(ValueError):
     350 in b"abcd"
-except ValueError:
-    pass
 
 
 # getitem
@@ -113,7 +109,7 @@ assert not bytes(b"tuPpEr").isupper()
 assert bytes(b"Is Title Case").istitle()
 assert not bytes(b"is Not title casE").istitle()
 
-# upper lower 
+# upper lower
 l = bytes(b"lower")
 b = bytes(b"UPPER")
 assert l.lower().islower()

--- a/tests/snippets/bytes.py
+++ b/tests/snippets/bytes.py
@@ -14,7 +14,28 @@ except TypeError:
 else:
     assert False
 
-# 
+a = b"abcd"
+b = b"ab"
+c = b"abcd"
+
+#
+# repr
+assert repr(bytes([0, 1, 2])) == repr(b'\x00\x01\x02')
+assert (
+repr(bytes([0, 1, 9, 10, 11, 13, 31, 32, 33, 89, 120, 255])
+== "b'\\x00\\x01\\t\\n\\x0b\\r\\x1f !Yx\\xff'")
+)
+assert repr(b"abcd") == "b'abcd'"
+
+#len
+assert len(bytes("abcdé", "utf8")) == 6
+
+#
+assert a == b"abcd"
+# assert a > b
+# assert a >= b
+# assert b < a
+# assert b <= a
 
 assert b'foobar'.__eq__(2) == NotImplemented
 assert b'foobar'.__ne__(2) == NotImplemented

--- a/tests/snippets/bytes.py
+++ b/tests/snippets/bytes.py
@@ -113,8 +113,9 @@ assert not bytes(b"tuPpEr").isupper()
 assert bytes(b"Is Title Case").istitle()
 assert not bytes(b"is Not title casE").istitle()
 
-# upper lower
+# upper lower hex
 l = bytes(b"lower")
 b = bytes(b"UPPER")
 assert l.lower().islower()
 assert b.upper().isupper()
+assert bytes([0, 1, 9, 23, 90, 234]).hex() == "000109175aea"

--- a/tests/snippets/bytes.py
+++ b/tests/snippets/bytes.py
@@ -32,10 +32,10 @@ assert len(bytes("abcdé", "utf8")) == 6
 
 #
 assert a == b"abcd"
-# assert a > b
-# assert a >= b
-# assert b < a
-# assert b <= a
+assert a > b
+assert a >= b
+assert b < a
+assert b <= a
 
 assert b'foobar'.__eq__(2) == NotImplemented
 assert b'foobar'.__ne__(2) == NotImplemented

--- a/tests/snippets/bytes.py
+++ b/tests/snippets/bytes.py
@@ -11,10 +11,6 @@ try:
     bytes("bla")
 except TypeError:
     assert True
-else:
-    assert False
-
-
 
 
 a = b"abcd"

--- a/tests/snippets/bytes.py
+++ b/tests/snippets/bytes.py
@@ -30,7 +30,7 @@ assert repr(b"abcd") == "b'abcd'"
 #len
 assert len(bytes("abcdé", "utf8")) == 6
 
-#
+#comp
 assert a == b"abcd"
 assert a > b
 assert a >= b
@@ -43,3 +43,9 @@ assert b'foobar'.__gt__(2) == NotImplemented
 assert b'foobar'.__ge__(2) == NotImplemented
 assert b'foobar'.__lt__(2) == NotImplemented
 assert b'foobar'.__le__(2) == NotImplemented
+
+#hash
+hash(a) == hash(b"abcd")
+
+#iter
+[i for i in b"abcd"] == ["a", "b", "c", "d"]

--- a/tests/snippets/bytes.py
+++ b/tests/snippets/bytes.py
@@ -113,9 +113,21 @@ assert not bytes(b"tuPpEr").isupper()
 assert bytes(b"Is Title Case").istitle()
 assert not bytes(b"is Not title casE").istitle()
 
-# upper lower hex
+# upper lower 
 l = bytes(b"lower")
 b = bytes(b"UPPER")
 assert l.lower().islower()
 assert b.upper().isupper()
+
+# hex from hex
 assert bytes([0, 1, 9, 23, 90, 234]).hex() == "000109175aea"
+
+bytes.fromhex("62 6c7a 34350a ") == b"blz45\n"
+try:
+    bytes.fromhex("62 a 21")
+except ValueError as e:
+    str(e) == "non-hexadecimal number found in fromhex() arg at position 4"
+try:
+    bytes.fromhex("6Z2")
+except ValueError as e:
+    str(e) == "non-hexadecimal number found in fromhex() arg at position 1"

--- a/tests/snippets/bytes.py
+++ b/tests/snippets/bytes.py
@@ -66,3 +66,14 @@ try:
     350 in b"abcd"
 except ValueError:
     pass
+
+
+# getitem
+d = b"abcdefghij"
+
+assert d[1] == 98
+assert d[-1] == 106
+assert d[2:6] == b"cdef"
+assert d[-6:] == b"efghij"
+assert d[1:8:2] == b"bdfh"
+assert d[8:1:-2] == b"igec"

--- a/tests/snippets/bytes.py
+++ b/tests/snippets/bytes.py
@@ -1,3 +1,21 @@
+from testutils import assertRaises
+
+# new
+assert bytes([1,2,3])
+assert bytes((1,2,3))
+assert bytes(range(4))
+assert b'bla'
+assert bytes(3)
+assert bytes("bla", "utf8")
+try:
+    bytes("bla")
+except TypeError:
+    assert True
+else:
+    assert False
+
+# 
+
 assert b'foobar'.__eq__(2) == NotImplemented
 assert b'foobar'.__ne__(2) == NotImplemented
 assert b'foobar'.__gt__(2) == NotImplemented

--- a/tests/snippets/bytes.py
+++ b/tests/snippets/bytes.py
@@ -1,10 +1,10 @@
 from testutils import assertRaises
 
 # new
-assert bytes([1,2,3])
-assert bytes((1,2,3))
+assert bytes([1, 2, 3])
+assert bytes((1, 2, 3))
 assert bytes(range(4))
-assert b'bla'
+assert b"bla"
 assert bytes(3)
 assert bytes("bla", "utf8")
 try:
@@ -20,40 +20,39 @@ c = b"abcd"
 
 #
 # repr
-assert repr(bytes([0, 1, 2])) == repr(b'\x00\x01\x02')
-assert (
-repr(bytes([0, 1, 9, 10, 11, 13, 31, 32, 33, 89, 120, 255])
-== "b'\\x00\\x01\\t\\n\\x0b\\r\\x1f !Yx\\xff'")
+assert repr(bytes([0, 1, 2])) == repr(b"\x00\x01\x02")
+assert repr(
+    bytes([0, 1, 9, 10, 11, 13, 31, 32, 33, 89, 120, 255])
+    == "b'\\x00\\x01\\t\\n\\x0b\\r\\x1f !Yx\\xff'"
 )
 assert repr(b"abcd") == "b'abcd'"
 
-#len
+# len
 assert len(bytes("abcdé", "utf8")) == 6
 
-#comp
+# comp
 assert a == b"abcd"
 assert a > b
 assert a >= b
 assert b < a
 assert b <= a
 
-assert b'foobar'.__eq__(2) == NotImplemented
-assert b'foobar'.__ne__(2) == NotImplemented
-assert b'foobar'.__gt__(2) == NotImplemented
-assert b'foobar'.__ge__(2) == NotImplemented
-assert b'foobar'.__lt__(2) == NotImplemented
-assert b'foobar'.__le__(2) == NotImplemented
+assert b"foobar".__eq__(2) == NotImplemented
+assert b"foobar".__ne__(2) == NotImplemented
+assert b"foobar".__gt__(2) == NotImplemented
+assert b"foobar".__ge__(2) == NotImplemented
+assert b"foobar".__lt__(2) == NotImplemented
+assert b"foobar".__le__(2) == NotImplemented
 
-#hash
+# hash
 hash(a) == hash(b"abcd")
 
-#iter
+# iter
 [i for i in b"abcd"] == ["a", "b", "c", "d"]
 
-#add
+# add
 assert a + b == b"abcdab"
 
-#contains
 # contains
 assert b"ab" in b"abcd"
 assert b"cd" in b"abcd"
@@ -61,5 +60,9 @@ assert b"abcd" in b"abcd"
 assert b"a" in b"abcd"
 assert b"d" in b"abcd"
 assert b"dc" not in b"abcd"
-# assert 97 in b"abcd"
-# assert 150 not in b"abcd"
+assert 97 in b"abcd"
+assert 150 not in b"abcd"
+try:
+    350 in b"abcd"
+except ValueError:
+    pass

--- a/tests/snippets/bytes.py
+++ b/tests/snippets/bytes.py
@@ -112,3 +112,9 @@ assert not bytes(b"tuPpEr").isupper()
 
 assert bytes(b"Is Title Case").istitle()
 assert not bytes(b"is Not title casE").istitle()
+
+# upper lower
+l = bytes(b"lower")
+b = bytes(b"UPPER")
+assert l.lower().islower()
+assert b.upper().isupper()

--- a/tests/snippets/bytes.py
+++ b/tests/snippets/bytes.py
@@ -49,3 +49,17 @@ hash(a) == hash(b"abcd")
 
 #iter
 [i for i in b"abcd"] == ["a", "b", "c", "d"]
+
+#add
+assert a + b == b"abcdab"
+
+#contains
+# contains
+assert b"ab" in b"abcd"
+assert b"cd" in b"abcd"
+assert b"abcd" in b"abcd"
+assert b"a" in b"abcd"
+assert b"d" in b"abcd"
+assert b"dc" not in b"abcd"
+# assert 97 in b"abcd"
+# assert 150 not in b"abcd"

--- a/tests/snippets/bytes.py
+++ b/tests/snippets/bytes.py
@@ -4,8 +4,8 @@ from testutils import assertRaises
 assert bytes([1, 2, 3])
 assert bytes((1, 2, 3))
 assert bytes(range(4))
-assert b"bla"
 assert bytes(3)
+assert b"bla"
 assert bytes("bla", "utf8")
 try:
     bytes("bla")
@@ -13,6 +13,9 @@ except TypeError:
     assert True
 else:
     assert False
+
+
+
 
 a = b"abcd"
 b = b"ab"
@@ -49,6 +52,7 @@ hash(a) == hash(b"abcd")
 
 # iter
 [i for i in b"abcd"] == ["a", "b", "c", "d"]
+assert list(bytes(3)) ==  [0,0,0]
 
 # add
 assert a + b == b"abcdab"

--- a/tests/snippets/bytes.py
+++ b/tests/snippets/bytes.py
@@ -77,3 +77,38 @@ assert d[2:6] == b"cdef"
 assert d[-6:] == b"efghij"
 assert d[1:8:2] == b"bdfh"
 assert d[8:1:-2] == b"igec"
+
+
+# is_xx methods
+
+assert bytes(b"1a23").isalnum()
+assert not bytes(b"1%a23").isalnum()
+
+assert bytes(b"abc").isalpha()
+assert not bytes(b"abc1").isalpha()
+
+# travis doesn't like this
+# assert bytes(b'xyz').isascii()
+# assert not bytes([128, 157, 32]).isascii()
+
+assert bytes(b"1234567890").isdigit()
+assert not bytes(b"12ab").isdigit()
+
+l = bytes(b"lower")
+b = bytes(b"UPPER")
+
+assert l.islower()
+assert not l.isupper()
+assert b.isupper()
+assert not bytes(b"Super Friends").islower()
+
+assert bytes(b" \n\t").isspace()
+assert not bytes(b"\td\n").isspace()
+
+assert b.isupper()
+assert not b.islower()
+assert l.islower()
+assert not bytes(b"tuPpEr").isupper()
+
+assert bytes(b"Is Title Case").istitle()
+assert not bytes(b"is Not title casE").istitle()

--- a/vm/src/obj/mod.rs
+++ b/vm/src/obj/mod.rs
@@ -3,6 +3,7 @@
 pub mod objbool;
 pub mod objbuiltinfunc;
 pub mod objbytearray;
+pub mod objbyteinner;
 pub mod objbytes;
 pub mod objclassmethod;
 pub mod objcode;

--- a/vm/src/obj/objbyteinner.rs
+++ b/vm/src/obj/objbyteinner.rs
@@ -1,4 +1,3 @@
-use crate::obj::objtype::PyClassRef;
 use crate::pyobject::PyObjectRef;
 
 use crate::function::OptionalArg;
@@ -93,4 +92,33 @@ impl PyByteInner {
             }
         }
     }
+
+    pub fn repr(&self) -> PyResult<String> {
+        let mut res = String::with_capacity(self.elements.len());
+        for i in self.elements.iter() {
+            match i {
+                0..=8 => res.push_str(&format!("\\x0{}", i)),
+                9 => res.push_str("\\t"),
+                10 => res.push_str("\\n"),
+                13 => res.push_str("\\r"),
+                32..=126 => res.push(*(i) as char),
+                _ => res.push_str(&format!("\\x{:x}", i)),
+            }
+        }
+        Ok(res)
+    }
+
+    pub fn len(&self) -> usize {
+        self.elements.len()
+    }
+
+    pub fn eq(&self, other: &PyByteInner, vm: &VirtualMachine) -> PyResult {
+        if self.elements == other.elements {
+            Ok(vm.new_bool(true))
+        } else {
+            Ok(vm.new_bool(false))
+        }
+    }
 }
+// TODO
+// fix b"é" not allowed should be bytes("é", "utf8")

--- a/vm/src/obj/objbyteinner.rs
+++ b/vm/src/obj/objbyteinner.rs
@@ -314,6 +314,39 @@ impl PyByteInner {
             .collect::<String>();
         Ok(vm.ctx.new_str(bla))
     }
+
+    pub fn fromhex(string: String, vm: &VirtualMachine) -> Result<Vec<u8>, PyObjectRef> {
+        // first check for invalid character
+        for (i, c) in string.char_indices() {
+            if !c.is_digit(16) && !c.is_whitespace() {
+                return Err(vm.new_value_error(format!(
+                    "non-hexadecimal number found in fromhex() arg at position {}",
+                    i
+                )));
+            }
+        }
+
+        // strip white spaces
+        let stripped = string.split_whitespace().collect::<String>();
+
+        // Hex is evaluated on 2 digits
+        if stripped.len() % 2 != 0 {
+            return Err(vm.new_value_error(format!(
+                "non-hexadecimal number found in fromhex() arg at position {}",
+                stripped.len() - 1
+            )));
+        }
+
+        // parse even string
+        Ok(stripped
+            .chars()
+            .collect::<Vec<char>>()
+            .chunks(2)
+            .map(|x| x.to_vec().iter().collect::<String>())
+            .map(|x| u8::from_str_radix(&x, 16))
+            .map(|x| x.unwrap())
+            .collect::<Vec<u8>>())
+    }
 }
 
 // TODO

--- a/vm/src/obj/objbyteinner.rs
+++ b/vm/src/obj/objbyteinner.rs
@@ -119,6 +119,38 @@ impl PyByteInner {
             Ok(vm.new_bool(false))
         }
     }
+
+    pub fn ge(&self, other: &PyByteInner, vm: &VirtualMachine) -> PyResult {
+        if self.elements >= other.elements {
+            Ok(vm.new_bool(true))
+        } else {
+            Ok(vm.new_bool(false))
+        }
+    }
+
+    pub fn le(&self, other: &PyByteInner, vm: &VirtualMachine) -> PyResult {
+        if self.elements <= other.elements {
+            Ok(vm.new_bool(true))
+        } else {
+            Ok(vm.new_bool(false))
+        }
+    }
+
+    pub fn gt(&self, other: &PyByteInner, vm: &VirtualMachine) -> PyResult {
+        if self.elements > other.elements {
+            Ok(vm.new_bool(true))
+        } else {
+            Ok(vm.new_bool(false))
+        }
+    }
+
+    pub fn lt(&self, other: &PyByteInner, vm: &VirtualMachine) -> PyResult {
+        if self.elements < other.elements {
+            Ok(vm.new_bool(true))
+        } else {
+            Ok(vm.new_bool(false))
+        }
+    }
 }
 // TODO
 // fix b"é" not allowed should be bytes("é", "utf8")

--- a/vm/src/obj/objbyteinner.rs
+++ b/vm/src/obj/objbyteinner.rs
@@ -181,11 +181,17 @@ impl PyByteInner {
         Ok(vm.new_bool(false))
     }
 
-    pub fn contains_int(&self, int: &PyInt, vm: &VirtualMachine) -> PyResult {
-        self.elements.contains(int);
-        Ok(vm.new_bool(false))
+    pub fn contains_int(&self, int: &PyInt, vm: &VirtualMachine) -> PyResult<PyObjectRef> {
+        if let Some(int) = int.as_bigint().to_u8() {
+            if self.elements.contains(&int) {
+                Ok(vm.new_bool(true))
+            } else {
+                Ok(vm.new_bool(false))
+            }
+        } else {
+            Err(vm.new_value_error("byte must be in range(0, 256)".to_string()))
+        }
     }
 }
-
 // TODO
 // fix b"é" not allowed should be bytes("é", "utf8")

--- a/vm/src/obj/objbyteinner.rs
+++ b/vm/src/obj/objbyteinner.rs
@@ -297,6 +297,14 @@ impl PyByteInner {
 
         Ok(vm.new_bool(true))
     }
+
+    pub fn lower(&self, _vm: &VirtualMachine) -> Vec<u8> {
+        self.elements.to_ascii_lowercase()
+    }
+
+    pub fn upper(&self, _vm: &VirtualMachine) -> Vec<u8> {
+        self.elements.to_ascii_uppercase()
+    }
 }
 
 // TODO

--- a/vm/src/obj/objbyteinner.rs
+++ b/vm/src/obj/objbyteinner.rs
@@ -61,11 +61,7 @@ impl PyByteInner {
                 match_class!(ival.clone(),
                     i @ PyInt => {
                             let size = objint::get_value(&i.into_object()).to_usize().unwrap();
-                            let mut res: Vec<u8> = Vec::with_capacity(size);
-                            for _ in 0..size {
-                                res.push(0)
-                            }
-                            Ok(res)},
+                            Ok(vec![0; size])},
                     _l @ PyString=> {return Err(vm.new_type_error(format!(
                         "string argument without an encoding"
                     )));},

--- a/vm/src/obj/objbyteinner.rs
+++ b/vm/src/obj/objbyteinner.rs
@@ -1,9 +1,96 @@
+use crate::obj::objtype::PyClassRef;
+use crate::pyobject::PyObjectRef;
+
+use crate::function::OptionalArg;
+
+use crate::vm::VirtualMachine;
+
+use crate::pyobject::{PyResult, TypeProtocol};
+
+use crate::obj::objstr::PyString;
+
+use super::objint;
+use crate::obj::objint::PyInt;
+use num_traits::ToPrimitive;
+
 #[derive(Debug, Default, Clone)]
 pub struct PyByteInner {
     pub elements: Vec<u8>,
 }
+
 impl PyByteInner {
-    pub fn new(data: Vec<u8>) -> Self {
-        PyByteInner { elements: data }
+    pub fn new(
+        val_option: OptionalArg<PyObjectRef>,
+        enc_option: OptionalArg<PyObjectRef>,
+        vm: &VirtualMachine,
+    ) -> PyResult<PyByteInner> {
+        // First handle bytes(string, encoding[, errors])
+        if let OptionalArg::Present(enc) = enc_option {
+            if let OptionalArg::Present(eval) = val_option {
+                if let Ok(input) = eval.downcast::<PyString>() {
+                    if let Ok(encoding) = enc.clone().downcast::<PyString>() {
+                        if encoding.value.to_lowercase() == "utf8".to_string()
+                            || encoding.value.to_lowercase() == "utf-8".to_string()
+                        // TODO: different encoding
+                        {
+                            return Ok(PyByteInner {
+                                elements: input.value.as_bytes().to_vec(),
+                            });
+                        } else {
+                            return Err(
+                                vm.new_value_error(format!("unknown encoding: {}", encoding.value)), //should be lookup error
+                            );
+                        }
+                    } else {
+                        return Err(vm.new_type_error(format!(
+                            "bytes() argument 2 must be str, not {}",
+                            enc.class().name
+                        )));
+                    }
+                } else {
+                    return Err(vm.new_type_error("encoding without a string argument".to_string()));
+                }
+            } else {
+                return Err(vm.new_type_error("encoding without a string argument".to_string()));
+            }
+        // On ly one argument
+        } else {
+            let value = if let OptionalArg::Present(ival) = val_option {
+                match_class!(ival.clone(),
+                    i @ PyInt => {
+                            let size = objint::get_value(&i.into_object()).to_usize().unwrap();
+                            let mut res: Vec<u8> = Vec::with_capacity(size);
+                            for _ in 0..size {
+                                res.push(0)
+                            }
+                            Ok(res)},
+                    _l @ PyString=> {return Err(vm.new_type_error(format!(
+                        "string argument without an encoding"
+                    )));},
+                    obj => {
+                        let elements = vm.extract_elements(&obj).or_else(|_| {return Err(vm.new_type_error(format!(
+                        "cannot convert {} object to bytes", obj.class().name)));});
+
+                        let mut data_bytes = vec![];
+                        for elem in elements.unwrap(){
+                            let v = objint::to_int(vm, &elem, 10)?;
+                            if let Some(i) = v.to_u8() {
+                                data_bytes.push(i);
+                            } else {
+                                return Err(vm.new_value_error("bytes must be in range(0, 256)".to_string()));
+                                }
+
+                            }
+                        Ok(data_bytes)
+                        }
+                )
+            } else {
+                Ok(vec![])
+            };
+            match value {
+                Ok(val) => Ok(PyByteInner { elements: val }),
+                Err(err) => Err(err),
+            }
+        }
     }
 }

--- a/vm/src/obj/objbyteinner.rs
+++ b/vm/src/obj/objbyteinner.rs
@@ -305,6 +305,15 @@ impl PyByteInner {
     pub fn upper(&self, _vm: &VirtualMachine) -> Vec<u8> {
         self.elements.to_ascii_uppercase()
     }
+
+    pub fn hex(&self, vm: &VirtualMachine) -> PyResult {
+        let bla = self
+            .elements
+            .iter()
+            .map(|x| format!("{:02x}", x))
+            .collect::<String>();
+        Ok(vm.ctx.new_str(bla))
+    }
 }
 
 // TODO

--- a/vm/src/obj/objbyteinner.rs
+++ b/vm/src/obj/objbyteinner.rs
@@ -207,6 +207,96 @@ impl PyByteInner {
             .ctx
             .new_bytes(self.elements.get_slice_items(vm, slice).unwrap()))
     }
+
+    pub fn isalnum(&self, vm: &VirtualMachine) -> PyResult {
+        Ok(vm.new_bool(
+            !self.elements.is_empty()
+                && self
+                    .elements
+                    .iter()
+                    .all(|x| char::from(*x).is_alphanumeric()),
+        ))
+    }
+
+    pub fn isalpha(&self, vm: &VirtualMachine) -> PyResult {
+        Ok(vm.new_bool(
+            !self.elements.is_empty()
+                && self.elements.iter().all(|x| char::from(*x).is_alphabetic()),
+        ))
+    }
+
+    pub fn isascii(&self, vm: &VirtualMachine) -> PyResult {
+        Ok(vm.new_bool(
+            !self.elements.is_empty() && self.elements.iter().all(|x| char::from(*x).is_ascii()),
+        ))
+    }
+
+    pub fn isdigit(&self, vm: &VirtualMachine) -> PyResult {
+        Ok(vm.new_bool(
+            !self.elements.is_empty() && self.elements.iter().all(|x| char::from(*x).is_digit(10)),
+        ))
+    }
+
+    pub fn islower(&self, vm: &VirtualMachine) -> PyResult {
+        Ok(vm.new_bool(
+            !self.elements.is_empty()
+                && self
+                    .elements
+                    .iter()
+                    .filter(|x| !char::from(**x).is_whitespace())
+                    .all(|x| char::from(*x).is_lowercase()),
+        ))
+    }
+
+    pub fn isspace(&self, vm: &VirtualMachine) -> PyResult {
+        Ok(vm.new_bool(
+            !self.elements.is_empty()
+                && self.elements.iter().all(|x| char::from(*x).is_whitespace()),
+        ))
+    }
+
+    pub fn isupper(&self, vm: &VirtualMachine) -> PyResult {
+        Ok(vm.new_bool(
+            !self.elements.is_empty()
+                && self
+                    .elements
+                    .iter()
+                    .filter(|x| !char::from(**x).is_whitespace())
+                    .all(|x| char::from(*x).is_uppercase()),
+        ))
+    }
+
+    pub fn istitle(&self, vm: &VirtualMachine) -> PyResult {
+        if self.elements.is_empty() {
+            return Ok(vm.new_bool(false));
+        }
+
+        let mut iter = self.elements.iter().peekable();
+        let mut prev_cased = false;
+
+        while let Some(c) = iter.next() {
+            let current = char::from(*c);
+            let next = if let Some(k) = iter.peek() {
+                char::from(**k)
+            } else if current.is_uppercase() {
+                return Ok(vm.new_bool(!prev_cased));
+            } else {
+                return Ok(vm.new_bool(prev_cased));
+            };
+
+            let is_cased = current.to_uppercase().next().unwrap() != current
+                || current.to_lowercase().next().unwrap() != current;
+            if (is_cased && next.is_uppercase() && !prev_cased)
+                || (!is_cased && next.is_lowercase())
+            {
+                return Ok(vm.new_bool(false));
+            }
+
+            prev_cased = is_cased;
+        }
+
+        Ok(vm.new_bool(true))
+    }
 }
 
 // TODO

--- a/vm/src/obj/objbyteinner.rs
+++ b/vm/src/obj/objbyteinner.rs
@@ -7,6 +7,8 @@ use crate::vm::VirtualMachine;
 use crate::pyobject::{PyResult, TypeProtocol};
 
 use crate::obj::objstr::PyString;
+use std::collections::hash_map::DefaultHasher;
+use std::hash::{Hash, Hasher};
 
 use super::objint;
 use crate::obj::objint::PyInt;
@@ -151,6 +153,13 @@ impl PyByteInner {
             Ok(vm.new_bool(false))
         }
     }
+
+    pub fn hash(&self) -> usize {
+        let mut hasher = DefaultHasher::new();
+        self.elements.hash(&mut hasher);
+        hasher.finish() as usize
+    }
 }
+
 // TODO
 // fix b"é" not allowed should be bytes("é", "utf8")

--- a/vm/src/obj/objbyteinner.rs
+++ b/vm/src/obj/objbyteinner.rs
@@ -159,6 +159,32 @@ impl PyByteInner {
         self.elements.hash(&mut hasher);
         hasher.finish() as usize
     }
+
+    pub fn add(&self, other: &PyByteInner, vm: &VirtualMachine) -> PyResult {
+        let elements: Vec<u8> = self
+            .elements
+            .iter()
+            .chain(other.elements.iter())
+            .cloned()
+            .collect();
+        Ok(vm.ctx.new_bytes(elements))
+    }
+
+    pub fn contains_bytes(&self, other: &PyByteInner, vm: &VirtualMachine) -> PyResult {
+        for (n, i) in self.elements.iter().enumerate() {
+            if n + other.len() <= self.len() && *i == other.elements[0] {
+                if &self.elements[n..n + other.len()] == other.elements.as_slice() {
+                    return Ok(vm.new_bool(true));
+                }
+            }
+        }
+        Ok(vm.new_bool(false))
+    }
+
+    pub fn contains_int(&self, int: &PyInt, vm: &VirtualMachine) -> PyResult {
+        self.elements.contains(int);
+        Ok(vm.new_bool(false))
+    }
 }
 
 // TODO

--- a/vm/src/obj/objbyteinner.rs
+++ b/vm/src/obj/objbyteinner.rs
@@ -1,0 +1,9 @@
+#[derive(Debug, Default, Clone)]
+pub struct PyByteInner {
+    pub elements: Vec<u8>,
+}
+impl PyByteInner {
+    pub fn new(data: Vec<u8>) -> Self {
+        PyByteInner { elements: data }
+    }
+}

--- a/vm/src/obj/objbyteinner.rs
+++ b/vm/src/obj/objbyteinner.rs
@@ -55,7 +55,7 @@ impl PyByteInner {
             } else {
                 return Err(vm.new_type_error("encoding without a string argument".to_string()));
             }
-        // On ly one argument
+        // Only one argument
         } else {
             let value = if let OptionalArg::Present(ival) = val_option {
                 match_class!(ival.clone(),
@@ -161,14 +161,14 @@ impl PyByteInner {
         hasher.finish() as usize
     }
 
-    pub fn add(&self, other: &PyByteInner, vm: &VirtualMachine) -> PyResult {
+    pub fn add(&self, other: &PyByteInner, _vm: &VirtualMachine) -> Vec<u8> {
         let elements: Vec<u8> = self
             .elements
             .iter()
             .chain(other.elements.iter())
             .cloned()
             .collect();
-        Ok(vm.ctx.new_bytes(elements))
+        elements
     }
 
     pub fn contains_bytes(&self, other: &PyByteInner, vm: &VirtualMachine) -> PyResult {

--- a/vm/src/obj/objbyteinner.rs
+++ b/vm/src/obj/objbyteinner.rs
@@ -11,6 +11,7 @@ use std::collections::hash_map::DefaultHasher;
 use std::hash::{Hash, Hasher};
 
 use super::objint;
+use super::objsequence::PySliceableSequence;
 use crate::obj::objint::PyInt;
 use num_traits::ToPrimitive;
 
@@ -189,9 +190,24 @@ impl PyByteInner {
                 Ok(vm.new_bool(false))
             }
         } else {
-            Err(vm.new_value_error("byte must be in range(0, 256)".to_string()))
+            Err(vm.new_value_error("byte mu st be in range(0, 256)".to_string()))
         }
     }
+
+    pub fn getitem_int(&self, int: &PyInt, vm: &VirtualMachine) -> PyResult {
+        if let Some(idx) = self.elements.get_pos(int.as_bigint().to_i32().unwrap()) {
+            Ok(vm.new_int(self.elements[idx]))
+        } else {
+            Err(vm.new_index_error("index out of range".to_string()))
+        }
+    }
+
+    pub fn getitem_slice(&self, slice: &PyObjectRef, vm: &VirtualMachine) -> PyResult {
+        Ok(vm
+            .ctx
+            .new_bytes(self.elements.get_slice_items(vm, slice).unwrap()))
+    }
 }
+
 // TODO
 // fix b"é" not allowed should be bytes("é", "utf8")

--- a/vm/src/obj/objbytes.rs
+++ b/vm/src/obj/objbytes.rs
@@ -106,73 +106,10 @@ impl PyBytesRef {
         enc_option: OptionalArg<PyObjectRef>,
         vm: &VirtualMachine,
     ) -> PyResult<PyBytesRef> {
-        // First handle bytes(string, encoding[, errors])
-        if let OptionalArg::Present(enc) = enc_option {
-            if let OptionalArg::Present(eval) = val_option {
-                if let Ok(input) = eval.downcast::<PyString>() {
-                    if let Ok(encoding) = enc.clone().downcast::<PyString>() {
-                        if encoding.value.to_lowercase() == "utf8".to_string()
-                            || encoding.value.to_lowercase() == "utf-8".to_string()
-                        // TODO: different encoding
-                        {
-                            return PyBytes::new(input.value.as_bytes().to_vec())
-                                .into_ref_with_type(vm, cls.clone());
-                        } else {
-                            return Err(
-                                vm.new_value_error(format!("unknown encoding: {}", encoding.value)), //should be lookup error
-                            );
-                        }
-                    } else {
-                        return Err(vm.new_type_error(format!(
-                            "bytes() argument 2 must be str, not {}",
-                            enc.class().name
-                        )));
-                    }
-                } else {
-                    return Err(vm.new_type_error("encoding without a string argument".to_string()));
-                }
-            } else {
-                return Err(vm.new_type_error("encoding without a string argument".to_string()));
-            }
-        // On ly one argument
-        } else {
-            let value = if let OptionalArg::Present(ival) = val_option {
-                match_class!(ival.clone(),
-                    i @ PyInt => {
-                            let size = objint::get_value(&i.into_object()).to_usize().unwrap();
-                            let mut res: Vec<u8> = Vec::with_capacity(size);
-                            for _ in 0..size {
-                                res.push(0)
-                            }
-                            Ok(res)},
-                    _l @ PyString=> {return Err(vm.new_type_error(format!(
-                        "string argument without an encoding"
-                    )));},
-                    obj => {
-                        let elements = vm.extract_elements(&obj).or_else(|_| {return Err(vm.new_type_error(format!(
-                        "cannot convert {} object to bytes", obj.class().name)));});
-
-                        let mut data_bytes = vec![];
-                        for elem in elements.unwrap(){
-                            let v = objint::to_int(vm, &elem, 10)?;
-                            if let Some(i) = v.to_u8() {
-                                data_bytes.push(i);
-                            } else {
-                                return Err(vm.new_value_error("bytes must be in range(0, 256)".to_string()));
-                                }
-
-                            }
-                        Ok(data_bytes)
-                        }
-                )
-            } else {
-                Ok(vec![])
-            };
-            match value {
-                Ok(val) => PyBytes::new(val).into_ref_with_type(vm, cls.clone()),
-                Err(err) => Err(err),
-            }
+        PyBytes {
+            inner: PyByteInner::new(val_option, enc_option, vm)?,
         }
+        .into_ref_with_type(vm, cls)
     }
 
     #[pymethod(name = "__repr__")]

--- a/vm/src/obj/objbytes.rs
+++ b/vm/src/obj/objbytes.rs
@@ -134,7 +134,7 @@ impl PyBytesRef {
     #[pymethod(name = "__add__")]
     fn add(self, other: PyObjectRef, vm: &VirtualMachine) -> PyResult {
         match_class!(other,
-        bytes @ PyBytes => self.inner.add(&bytes.inner, vm),
+        bytes @ PyBytes => Ok(vm.ctx.new_bytes(self.inner.add(&bytes.inner, vm))),
         _  => Ok(vm.ctx.not_implemented()))
     }
 

--- a/vm/src/obj/objbytes.rs
+++ b/vm/src/obj/objbytes.rs
@@ -1,11 +1,14 @@
 use crate::vm::VirtualMachine;
+use core::cell::Cell;
 use std::ops::Deref;
 
 use crate::function::OptionalArg;
 use crate::pyobject::{PyClassImpl, PyContext, PyObjectRef, PyRef, PyResult, PyValue};
 
 use super::objbyteinner::PyByteInner;
+use super::objiter;
 use super::objtype::PyClassRef;
+
 /// "bytes(iterable_of_ints) -> bytes\n\
 /// bytes(string, encoding[, errors]) -> bytes\n\
 /// bytes(bytes_or_buffer) -> immutable copy of bytes_or_buffer\n\
@@ -44,39 +47,18 @@ impl PyValue for PyBytes {
     }
 }
 
-// Binary data support
-
-// Fill bytes class methods:
-
 pub fn get_value<'a>(obj: &'a PyObjectRef) -> impl Deref<Target = Vec<u8>> + 'a {
     &obj.payload::<PyBytes>().unwrap().inner.elements
 }
 
-// pub fn init(context: &PyContext) {
-//    let bytes_doc =
-pub fn init(ctx: &PyContext) {
-    PyBytesRef::extend_class(ctx, &ctx.bytes_type);
+pub fn init(context: &PyContext) {
+    PyBytesRef::extend_class(context, &context.bytes_type);
+    let bytesiterator_type = &context.bytesiterator_type;
+    extend_class!(context, bytesiterator_type, {
+            "__next__" => context.new_rustfunc(PyBytesIteratorRef::next),
+            "__iter__" => context.new_rustfunc(PyBytesIteratorRef::iter),
+    });
 }
-//extend_class!(context, &context.bytes_type, {
-//"__new__" => context.new_rustfunc(bytes_new),
-/*        "__eq__" => context.new_rustfunc(PyBytesRef::eq),
-"__lt__" => context.new_rustfunc(PyBytesRef::lt),
-"__le__" => context.new_rustfunc(PyBytesRef::le),
-"__gt__" => context.new_rustfunc(PyBytesRef::gt),
-"__ge__" => context.new_rustfunc(PyBytesRef::ge),
-"__hash__" => context.new_rustfunc(PyBytesRef::hash),
-"__repr__" => context.new_rustfunc(PyBytesRef::repr),
-"__len__" => context.new_rustfunc(PyBytesRef::len),
-"__iter__" => context.new_rustfunc(PyBytesRef::iter),
-"__doc__" => context.new_str(bytes_doc.to_string())*/
-// });
-
-/*    let bytesiterator_type = &context.bytesiterator_type;
-extend_class!(context, bytesiterator_type, {
-    "__next__" => context.new_rustfunc(PyBytesIteratorRef::next),
-    "__iter__" => context.new_rustfunc(PyBytesIteratorRef::iter),
-});*/
-//}
 
 #[pyimpl(__inside_vm)]
 impl PyBytesRef {
@@ -134,48 +116,46 @@ impl PyBytesRef {
         bytes @ PyBytes => self.inner.lt(&bytes.inner, vm),
         _  => Ok(vm.ctx.not_implemented()))
     }
+    #[pymethod(name = "__hash__")]
+    fn hash(self, _vm: &VirtualMachine) -> usize {
+        self.inner.hash()
+    }
+
+    #[pymethod(name = "__iter__")]
+    fn iter(self, _vm: &VirtualMachine) -> PyBytesIterator {
+        PyBytesIterator {
+            position: Cell::new(0),
+            bytes: self,
+        }
+    }
 }
 
-//     fn hash(self, _vm: &VirtualMachine) -> u64 {
-//         let mut hasher = DefaultHasher::new();
-//         self.value.hash(&mut hasher);
-//         hasher.finish()
-//     }
+#[derive(Debug)]
+pub struct PyBytesIterator {
+    position: Cell<usize>,
+    bytes: PyBytesRef,
+}
 
-//     fn iter(self, _vm: &VirtualMachine) -> PyBytesIterator {
-//         PyBytesIterator {
-//             position: Cell::new(0),
-//             bytes: self,
-//         }
-//     }
-// }
+impl PyValue for PyBytesIterator {
+    fn class(vm: &VirtualMachine) -> PyClassRef {
+        vm.ctx.bytesiterator_type()
+    }
+}
 
-// #[derive(Debug)]
-// pub struct PyBytesIterator {
-//     position: Cell<usize>,
-//     bytes: PyBytesRef,
-// }
+type PyBytesIteratorRef = PyRef<PyBytesIterator>;
 
-// impl PyValue for PyBytesIterator {
-//     fn class(vm: &VirtualMachine) -> PyClassRef {
-//         vm.ctx.bytesiterator_type()
-//     }
-// }
+impl PyBytesIteratorRef {
+    fn next(self, vm: &VirtualMachine) -> PyResult<u8> {
+        if self.position.get() < self.bytes.inner.len() {
+            let ret = self.bytes[self.position.get()];
+            self.position.set(self.position.get() + 1);
+            Ok(ret)
+        } else {
+            Err(objiter::new_stop_iteration(vm))
+        }
+    }
 
-// type PyBytesIteratorRef = PyRef<PyBytesIterator>;
-
-// impl PyBytesIteratorRef {
-//     fn next(self, vm: &VirtualMachine) -> PyResult<u8> {
-//         if self.position.get() < self.bytes.value.len() {
-//             let ret = self.bytes[self.position.get()];
-//             self.position.set(self.position.get() + 1);
-//             Ok(ret)
-//         } else {
-//             Err(objiter::new_stop_iteration(vm))
-//         }
-//     }
-
-//     fn iter(self, _vm: &VirtualMachine) -> Self {
-//         self
-//     }
-// }
+    fn iter(self, _vm: &VirtualMachine) -> Self {
+        self
+    }
+}

--- a/vm/src/obj/objbytes.rs
+++ b/vm/src/obj/objbytes.rs
@@ -158,33 +158,50 @@ impl PyBytesRef {
     fn isalnum(self, vm: &VirtualMachine) -> PyResult {
         self.inner.isalnum(vm)
     }
+
     #[pymethod(name = "isalpha")]
     fn isalpha(self, vm: &VirtualMachine) -> PyResult {
         self.inner.isalpha(vm)
     }
+
     #[pymethod(name = "isascii")]
     fn isascii(self, vm: &VirtualMachine) -> PyResult {
         self.inner.isascii(vm)
     }
+
     #[pymethod(name = "isdigit")]
     fn isdigit(self, vm: &VirtualMachine) -> PyResult {
         self.inner.isdigit(vm)
     }
+
     #[pymethod(name = "islower")]
     fn islower(self, vm: &VirtualMachine) -> PyResult {
         self.inner.islower(vm)
     }
+
     #[pymethod(name = "isspace")]
     fn isspace(self, vm: &VirtualMachine) -> PyResult {
         self.inner.isspace(vm)
     }
+
     #[pymethod(name = "isupper")]
     fn isupper(self, vm: &VirtualMachine) -> PyResult {
         self.inner.isupper(vm)
     }
+
     #[pymethod(name = "istitle")]
     fn istitle(self, vm: &VirtualMachine) -> PyResult {
         self.inner.istitle(vm)
+    }
+
+    #[pymethod(name = "lower")]
+    fn lower(self, vm: &VirtualMachine) -> PyResult {
+        Ok(vm.ctx.new_bytes(self.inner.lower(vm)))
+    }
+
+    #[pymethod(name = "upper")]
+    fn upper(self, vm: &VirtualMachine) -> PyResult {
+        Ok(vm.ctx.new_bytes(self.inner.upper(vm)))
     }
 }
 

--- a/vm/src/obj/objbytes.rs
+++ b/vm/src/obj/objbytes.rs
@@ -1,3 +1,4 @@
+use crate::obj::objint::PyInt;
 use crate::vm::VirtualMachine;
 use core::cell::Cell;
 use std::ops::Deref;
@@ -143,17 +144,6 @@ impl PyBytesRef {
         bytes @ PyBytes => self.inner.contains_bytes(&bytes.inner, vm),
         int @ PyInt => self.inner.contains_int(&int, vm),
         _  => Ok(vm.ctx.not_implemented()))
-        // if objtype::isinstance(&needle, &vm.ctx.bytes_type()) {
-        //     let result = vec_contains(&self.value, &get_value(&needle));
-        //     vm.ctx.new_bool(result)
-        // } else if objtype::isinstance(&needle, &vm.ctx.int_type()) {
-        //     let result = self
-        //         .value
-        //         .contains(&objint::get_value(&needle).to_u8().unwrap());
-        //     vm.ctx.new_bool(result)
-        // } else {
-        //     vm.new_type_error(format!("Cannot add {:?} and {:?}", self, needle))
-        // }
     }
 }
 

--- a/vm/src/obj/objbytes.rs
+++ b/vm/src/obj/objbytes.rs
@@ -128,6 +128,33 @@ impl PyBytesRef {
             bytes: self,
         }
     }
+
+    #[pymethod(name = "__add__")]
+    fn add(self, other: PyObjectRef, vm: &VirtualMachine) -> PyResult {
+        match_class!(other,
+        bytes @ PyBytes => self.inner.add(&bytes.inner, vm),
+        _  => Ok(vm.ctx.not_implemented()))
+    }
+
+    #[pymethod(name = "__contains__")]
+    fn contains(self, needle: PyObjectRef, vm: &VirtualMachine) -> PyResult {
+        // no new style since objint is not.
+        match_class!(needle,
+        bytes @ PyBytes => self.inner.contains_bytes(&bytes.inner, vm),
+        int @ PyInt => self.inner.contains_int(&int, vm),
+        _  => Ok(vm.ctx.not_implemented()))
+        // if objtype::isinstance(&needle, &vm.ctx.bytes_type()) {
+        //     let result = vec_contains(&self.value, &get_value(&needle));
+        //     vm.ctx.new_bool(result)
+        // } else if objtype::isinstance(&needle, &vm.ctx.int_type()) {
+        //     let result = self
+        //         .value
+        //         .contains(&objint::get_value(&needle).to_u8().unwrap());
+        //     vm.ctx.new_bool(result)
+        // } else {
+        //     vm.new_type_error(format!("Cannot add {:?} and {:?}", self, needle))
+        // }
+    }
 }
 
 #[derive(Debug)]

--- a/vm/src/obj/objbytes.rs
+++ b/vm/src/obj/objbytes.rs
@@ -6,22 +6,37 @@ use std::ops::Deref;
 use num_traits::ToPrimitive;
 
 use crate::function::OptionalArg;
-use crate::pyobject::{PyContext, PyObjectRef, PyRef, PyResult, PyValue};
+use crate::pyobject::{
+    IntoPyObject, PyClassImpl, PyContext, PyObjectRef, PyRef, PyResult, PyValue,
+};
 use crate::vm::VirtualMachine;
 
+use super::objbyteinner::PyByteInner;
 use super::objint;
 use super::objiter;
 use super::objtype::PyClassRef;
 
+/// "bytes(iterable_of_ints) -> bytes\n\
+/// bytes(string, encoding[, errors]) -> bytes\n\
+/// bytes(bytes_or_buffer) -> immutable copy of bytes_or_buffer\n\
+/// bytes(int) -> bytes object of size given by the parameter initialized with null bytes\n\
+/// bytes() -> empty bytes object\n\nConstruct an immutable array of bytes from:\n  \
+/// - an iterable yielding integers in range(256)\n  \
+/// - a text string encoded using the specified encoding\n  \
+/// - any object implementing the buffer API.\n  \
+/// - an integer";
+#[pyclass(name = "bytes", __inside_vm)]
 #[derive(Debug)]
 pub struct PyBytes {
-    value: Vec<u8>,
+    inner: PyByteInner,
 }
 type PyBytesRef = PyRef<PyBytes>;
 
 impl PyBytes {
-    pub fn new(data: Vec<u8>) -> Self {
-        PyBytes { value: data }
+    pub fn new(elements: Vec<u8>) -> Self {
+        PyBytes {
+            inner: PyByteInner { elements },
+        }
     }
 }
 
@@ -29,7 +44,7 @@ impl Deref for PyBytes {
     type Target = [u8];
 
     fn deref(&self) -> &[u8] {
-        &self.value
+        &self.inner.elements
     }
 }
 
@@ -42,62 +57,74 @@ impl PyValue for PyBytes {
 // Binary data support
 
 // Fill bytes class methods:
-pub fn init(context: &PyContext) {
-    let bytes_doc =
-        "bytes(iterable_of_ints) -> bytes\n\
-         bytes(string, encoding[, errors]) -> bytes\n\
-         bytes(bytes_or_buffer) -> immutable copy of bytes_or_buffer\n\
-         bytes(int) -> bytes object of size given by the parameter initialized with null bytes\n\
-         bytes() -> empty bytes object\n\nConstruct an immutable array of bytes from:\n  \
-         - an iterable yielding integers in range(256)\n  \
-         - a text string encoded using the specified encoding\n  \
-         - any object implementing the buffer API.\n  \
-         - an integer";
 
-    extend_class!(context, &context.bytes_type, {
-        "__new__" => context.new_rustfunc(bytes_new),
-        "__eq__" => context.new_rustfunc(PyBytesRef::eq),
-        "__lt__" => context.new_rustfunc(PyBytesRef::lt),
-        "__le__" => context.new_rustfunc(PyBytesRef::le),
-        "__gt__" => context.new_rustfunc(PyBytesRef::gt),
-        "__ge__" => context.new_rustfunc(PyBytesRef::ge),
-        "__hash__" => context.new_rustfunc(PyBytesRef::hash),
-        "__repr__" => context.new_rustfunc(PyBytesRef::repr),
-        "__len__" => context.new_rustfunc(PyBytesRef::len),
-        "__iter__" => context.new_rustfunc(PyBytesRef::iter),
-        "__doc__" => context.new_str(bytes_doc.to_string())
-    });
-
-    let bytesiterator_type = &context.bytesiterator_type;
-    extend_class!(context, bytesiterator_type, {
-        "__next__" => context.new_rustfunc(PyBytesIteratorRef::next),
-        "__iter__" => context.new_rustfunc(PyBytesIteratorRef::iter),
-    });
+pub fn get_value<'a>(obj: &'a PyObjectRef) -> impl Deref<Target = Vec<u8>> + 'a {
+    &obj.payload::<PyBytes>().unwrap().inner.elements
 }
 
-fn bytes_new(
-    cls: PyClassRef,
-    val_option: OptionalArg<PyObjectRef>,
-    vm: &VirtualMachine,
-) -> PyResult<PyBytesRef> {
-    // Create bytes data:
-    let value = if let OptionalArg::Present(ival) = val_option {
-        let elements = vm.extract_elements(&ival)?;
-        let mut data_bytes = vec![];
-        for elem in elements.iter() {
-            let v = objint::to_int(vm, elem, 10)?;
-            data_bytes.push(v.to_u8().unwrap());
-        }
-        data_bytes
-    // return Err(vm.new_type_error("Cannot construct bytes".to_string()));
-    } else {
-        vec![]
-    };
-
-    PyBytes::new(value).into_ref_with_type(vm, cls)
+// pub fn init(context: &PyContext) {
+//    let bytes_doc =
+pub fn init(ctx: &PyContext) {
+    PyBytesRef::extend_class(ctx, &ctx.bytes_type);
 }
+//extend_class!(context, &context.bytes_type, {
+//"__new__" => context.new_rustfunc(bytes_new),
+/*        "__eq__" => context.new_rustfunc(PyBytesRef::eq),
+"__lt__" => context.new_rustfunc(PyBytesRef::lt),
+"__le__" => context.new_rustfunc(PyBytesRef::le),
+"__gt__" => context.new_rustfunc(PyBytesRef::gt),
+"__ge__" => context.new_rustfunc(PyBytesRef::ge),
+"__hash__" => context.new_rustfunc(PyBytesRef::hash),
+"__repr__" => context.new_rustfunc(PyBytesRef::repr),
+"__len__" => context.new_rustfunc(PyBytesRef::len),
+"__iter__" => context.new_rustfunc(PyBytesRef::iter),
+"__doc__" => context.new_str(bytes_doc.to_string())*/
+// });
 
+/*    let bytesiterator_type = &context.bytesiterator_type;
+extend_class!(context, bytesiterator_type, {
+    "__next__" => context.new_rustfunc(PyBytesIteratorRef::next),
+    "__iter__" => context.new_rustfunc(PyBytesIteratorRef::iter),
+});*/
+//}
+#[pyimpl(__inside_vm)]
 impl PyBytesRef {
+    #[pymethod(name = "__new__")]
+    fn bytes_new(
+        cls: PyClassRef,
+        val_option: OptionalArg<PyObjectRef>,
+        vm: &VirtualMachine,
+    ) -> PyResult<PyBytesRef> {
+        // Create bytes data:
+        let value = if let OptionalArg::Present(ival) = val_option {
+            let elements = vm.extract_elements(&ival)?;
+            let mut data_bytes = vec![];
+            for elem in elements.iter() {
+                let v = objint::to_int(vm, elem, 10)?;
+                data_bytes.push(v.to_u8().unwrap());
+            }
+            data_bytes
+        // return Err(vm.new_type_error("Cannot construct bytes".to_string()));
+        } else {
+            vec![]
+        };
+
+        PyBytes::new(value).into_ref_with_type(vm, cls)
+    }
+
+    #[pymethod(name = "__repr__")]
+    fn repr(self, _vm: &VirtualMachine) -> String {
+        // TODO: don't just unwrap
+        let data = self.inner.elements.clone();
+        format!("b'{:?}'", data)
+    }
+
+    #[pymethod(name = "__len__")]
+    fn len(self, _vm: &VirtualMachine) -> usize {
+        self.inner.elements.len()
+    }
+}
+/*
     fn eq(self, other: PyObjectRef, vm: &VirtualMachine) -> PyObjectRef {
         if let Ok(other) = other.downcast::<PyBytes>() {
             vm.ctx.new_bool(self.value == other.value)
@@ -138,9 +165,6 @@ impl PyBytesRef {
         }
     }
 
-    fn len(self, _vm: &VirtualMachine) -> usize {
-        self.value.len()
-    }
 
     fn hash(self, _vm: &VirtualMachine) -> u64 {
         let mut hasher = DefaultHasher::new();
@@ -148,11 +172,6 @@ impl PyBytesRef {
         hasher.finish()
     }
 
-    fn repr(self, _vm: &VirtualMachine) -> String {
-        // TODO: don't just unwrap
-        let data = String::from_utf8(self.value.clone()).unwrap();
-        format!("b'{}'", data)
-    }
 
     fn iter(self, _vm: &VirtualMachine) -> PyBytesIterator {
         PyBytesIterator {
@@ -162,9 +181,7 @@ impl PyBytesRef {
     }
 }
 
-pub fn get_value<'a>(obj: &'a PyObjectRef) -> impl Deref<Target = Vec<u8>> + 'a {
-    &obj.payload::<PyBytes>().unwrap().value
-}
+
 
 #[derive(Debug)]
 pub struct PyBytesIterator {
@@ -194,4 +211,4 @@ impl PyBytesIteratorRef {
     fn iter(self, _vm: &VirtualMachine) -> Self {
         self
     }
-}
+}*/

--- a/vm/src/obj/objbytes.rs
+++ b/vm/src/obj/objbytes.rs
@@ -203,6 +203,11 @@ impl PyBytesRef {
     fn upper(self, vm: &VirtualMachine) -> PyResult {
         Ok(vm.ctx.new_bytes(self.inner.upper(vm)))
     }
+
+    #[pymethod(name = "hex")]
+    fn hex(self, vm: &VirtualMachine) -> PyResult {
+        self.inner.hex(vm)
+    }
 }
 
 #[derive(Debug)]

--- a/vm/src/obj/objbytes.rs
+++ b/vm/src/obj/objbytes.rs
@@ -153,6 +153,39 @@ impl PyBytesRef {
         slice @ PySlice => self.inner.getitem_slice(slice.as_object(), vm),
         obj  => Err(vm.new_type_error(format!("byte indices must be integers or slices, not {}", obj))))
     }
+
+    #[pymethod(name = "isalnum")]
+    fn isalnum(self, vm: &VirtualMachine) -> PyResult {
+        self.inner.isalnum(vm)
+    }
+    #[pymethod(name = "isalpha")]
+    fn isalpha(self, vm: &VirtualMachine) -> PyResult {
+        self.inner.isalpha(vm)
+    }
+    #[pymethod(name = "isascii")]
+    fn isascii(self, vm: &VirtualMachine) -> PyResult {
+        self.inner.isascii(vm)
+    }
+    #[pymethod(name = "isdigit")]
+    fn isdigit(self, vm: &VirtualMachine) -> PyResult {
+        self.inner.isdigit(vm)
+    }
+    #[pymethod(name = "islower")]
+    fn islower(self, vm: &VirtualMachine) -> PyResult {
+        self.inner.islower(vm)
+    }
+    #[pymethod(name = "isspace")]
+    fn isspace(self, vm: &VirtualMachine) -> PyResult {
+        self.inner.isspace(vm)
+    }
+    #[pymethod(name = "isupper")]
+    fn isupper(self, vm: &VirtualMachine) -> PyResult {
+        self.inner.isupper(vm)
+    }
+    #[pymethod(name = "istitle")]
+    fn istitle(self, vm: &VirtualMachine) -> PyResult {
+        self.inner.istitle(vm)
+    }
 }
 
 #[derive(Debug)]


### PR DESCRIPTION
It's the start to refactor bytes and  bytearray like #765 .

- only bytes for now (no bytearray) with new style method
- What to do with byteinner ? change the name ? remove a differet file and put everything in bytes.rs
- tests added
- I struggled with the iterator, I don't know if it can be send to byteinner.rs or not.
- the `__new__` method has been rewritten to deal with more cases, but it's quite horrible to read. interested in ideas to refactor this one. there are many possibilities with various error message so ...
- `b"éùà"` passes now but it shouldn't. I'm not sur where to fix it.
