### PR TITLE
Change #[pymethod(property)] to #[pyproperty]

### DIFF
--- a/derive/src/pyclass.rs
+++ b/derive/src/pyclass.rs
@@ -28,6 +28,7 @@ impl ClassItem {
     fn extract_from_syn(attrs: &mut Vec<Attribute>, sig: &MethodSig) -> Option<ClassItem> {
         let mut item = None;
         let mut attr_idx = None;
+        // TODO: better error handling throughout this
         for (i, meta) in attrs
             .iter()
             .filter_map(|attr| attr.parse_meta().ok())
@@ -38,13 +39,15 @@ impl ClassItem {
                 if item.is_some() {
                     panic!("You can only have one #[py*] attribute on an impl item")
                 }
-                let nesteds = meta_to_vec(meta)
-                    .expect("#[pymethod = ...] must be a list, e.g. #[pymethod(...)]");
+                let nesteds = meta_to_vec(meta).expect(
+                    "#[pyproperty = \"...\"] cannot be a name/value, you probably meant \
+                     #[pyproperty(name = \"...\")]",
+                );
                 let mut py_name = None;
                 for meta in nesteds {
                     let meta = match meta {
                         NestedMeta::Meta(meta) => meta,
-                        NestedMeta::Literal(_) => panic!("Expected a meta, found a literal"),
+                        NestedMeta::Literal(_) => continue,
                     };
                     match meta {
                         Meta::NameValue(name_value) => {
@@ -68,14 +71,16 @@ impl ClassItem {
                 if item.is_some() {
                     panic!("You can only have one #[py*] attribute on an impl item")
                 }
-                let nesteds = meta_to_vec(meta)
-                    .expect("#[pyproperty = ...] must be a list, e.g. #[pyproperty(...)]");
+                let nesteds = meta_to_vec(meta).expect(
+                    "#[pyproperty = \"...\"] cannot be a name/value, you probably meant \
+                     #[pyproperty(name = \"...\")]",
+                );
                 let mut setter = false;
                 let mut py_name = None;
                 for meta in nesteds {
                     let meta = match meta {
                         NestedMeta::Meta(meta) => meta,
-                        NestedMeta::Literal(_) => panic!("Expected a meta, found a literal"),
+                        NestedMeta::Literal(_) => continue,
                     };
                     match meta {
                         Meta::NameValue(name_value) => {

--- a/derive/src/pyclass.rs
+++ b/derive/src/pyclass.rs
@@ -102,21 +102,25 @@ impl ClassItem {
                 }
                 let py_name = py_name.unwrap_or_else(|| {
                     let item_ident = sig.ident.to_string();
-                    if item_ident.starts_with("set_") {
-                        let name = &item_ident["set_".len()..];
-                        if name.is_empty() {
-                            panic!(
-                                "A #[pyproperty(setter)] fn with a set_* name have something \
-                                 after \"set_\""
-                            )
+                    if setter {
+                        if item_ident.starts_with("set_") {
+                            let name = &item_ident["set_".len()..];
+                            if name.is_empty() {
+                                panic!(
+                                    "A #[pyproperty(setter)] fn with a set_* name have something \
+                                     after \"set_\""
+                                )
+                            } else {
+                                name.to_string()
+                            }
                         } else {
-                            name.to_string()
-                        }
-                    } else {
-                        panic!(
+                            panic!(
                             "A #[pyproperty(setter)] fn must either have a `name` parameter or a \
                              fn name along the lines of \"set_*\""
                         )
+                        }
+                    } else {
+                        item_ident
                     }
                 });
                 item = Some(ClassItem::Property {
@@ -195,7 +199,7 @@ pub fn impl_pyimpl(attr: AttributeArgs, item: Item) -> TokenStream2 {
         quote! {
             class.set_str_attr(
                 #name,
-                #rp_path::obj::objproperty::PropertyBuilder
+                #rp_path::obj::objproperty::PropertyBuilder::new(ctx)
                     .add_getter(Self::#getter)
                     #add_setter
                     .create(),

--- a/derive/src/pyclass.rs
+++ b/derive/src/pyclass.rs
@@ -1,91 +1,138 @@
 use super::rustpython_path_attr;
-use proc_macro2::{Span, TokenStream as TokenStream2};
+use proc_macro2::TokenStream as TokenStream2;
 use quote::quote;
+use std::collections::HashMap;
 use syn::{Attribute, AttributeArgs, Ident, ImplItem, Item, Lit, Meta, MethodSig, NestedMeta};
 
-enum MethodKind {
+#[derive(PartialEq, Clone, Copy)]
+enum ClassItemKind {
     Method,
-    Property,
+    PropertyGetter,
+    PropertySetter,
 }
 
-impl MethodKind {
-    fn to_ctx_constructor_fn(&self) -> Ident {
-        let f = match self {
-            MethodKind::Method => "new_rustfunc",
-            MethodKind::Property => "new_property",
-        };
-        Ident::new(f, Span::call_site())
+struct ClassItem {
+    item_name: Ident,
+    py_name: String,
+    kind: ClassItemKind,
+}
+
+fn meta_to_vec(meta: Meta) -> Result<Vec<NestedMeta>, Meta> {
+    match meta {
+        Meta::Word(_) => Ok(Vec::new()),
+        Meta::List(list) => Ok(list.nested.into_iter().collect()),
+        Meta::NameValue(_) => Err(meta),
     }
 }
 
-struct Method {
-    fn_name: Ident,
-    py_name: String,
-    kind: MethodKind,
-}
-
-impl Method {
-    fn from_syn(attrs: &mut Vec<Attribute>, sig: &MethodSig) -> Option<Method> {
-        let mut py_name = None;
-        let mut kind = MethodKind::Method;
-        let mut pymethod_to_remove = Vec::new();
-        let metas = attrs
+impl ClassItem {
+    fn extract_from_syn(attrs: &mut Vec<Attribute>, sig: &MethodSig) -> Option<ClassItem> {
+        let mut item = None;
+        let mut attr_idx = None;
+        for (i, meta) in attrs
             .iter()
+            .filter_map(|attr| attr.parse_meta().ok())
             .enumerate()
-            .filter_map(|(i, attr)| {
-                if attr.path.is_ident("pymethod") {
-                    let meta = attr.parse_meta().expect("Invalid attribute");
-                    // remove #[pymethod] because there's no actual proc macro
-                    // implementation for it
-                    pymethod_to_remove.push(i);
-                    match meta {
-                        Meta::List(list) => Some(list),
-                        Meta::Word(_) => None,
-                        Meta::NameValue(_) => panic!(
-                            "#[pymethod = ...] attribute on a method should be a list, like \
-                             #[pymethod(...)]"
-                        ),
-                    }
-                } else {
-                    None
+        {
+            let name = meta.name();
+            if name == "pymethod" {
+                if item.is_some() {
+                    panic!("You can only have one #[py*] attribute on an impl item")
                 }
-            })
-            .flat_map(|attr| attr.nested);
-        for meta in metas {
-            if let NestedMeta::Meta(meta) = meta {
-                match meta {
-                    Meta::NameValue(name_value) => {
-                        if name_value.ident == "name" {
-                            if let Lit::Str(s) = &name_value.lit {
-                                py_name = Some(s.value());
-                            } else {
-                                panic!("#[pymethod(name = ...)] must be a string");
+                let nesteds = meta_to_vec(meta)
+                    .expect("#[pymethod = ...] must be a list, e.g. #[pymethod(...)]");
+                let mut py_name = None;
+                for meta in nesteds {
+                    let meta = match meta {
+                        NestedMeta::Meta(meta) => meta,
+                        NestedMeta::Literal(_) => panic!("Expected a meta, found a literal"),
+                    };
+                    match meta {
+                        Meta::NameValue(name_value) => {
+                            if name_value.ident == "name" {
+                                if let Lit::Str(s) = &name_value.lit {
+                                    py_name = Some(s.value());
+                                } else {
+                                    panic!("#[pymethod(name = ...)] must be a string");
+                                }
                             }
                         }
+                        _ => {}
                     }
-                    Meta::Word(ident) => {
-                        if ident == "property" {
-                            kind = MethodKind::Property
-                        }
-                    }
-                    _ => {}
                 }
+                item = Some(ClassItem {
+                    item_name: sig.ident.clone(),
+                    py_name: py_name.unwrap_or_else(|| sig.ident.to_string()),
+                    kind: ClassItemKind::Method,
+                });
+                attr_idx = Some(i);
+            } else if name == "pyproperty" {
+                if item.is_some() {
+                    panic!("You can only have one #[py*] attribute on an impl item")
+                }
+                let nesteds = meta_to_vec(meta)
+                    .expect("#[pyproperty = ...] must be a list, e.g. #[pyproperty(...)]");
+                let mut setter = false;
+                let mut py_name = None;
+                for meta in nesteds {
+                    let meta = match meta {
+                        NestedMeta::Meta(meta) => meta,
+                        NestedMeta::Literal(_) => panic!("Expected a meta, found a literal"),
+                    };
+                    match meta {
+                        Meta::NameValue(name_value) => {
+                            if name_value.ident == "name" {
+                                if let Lit::Str(s) = &name_value.lit {
+                                    py_name = Some(s.value());
+                                } else {
+                                    panic!("#[pyproperty(name = ...)] must be a string");
+                                }
+                            }
+                        }
+                        Meta::Word(ident) => {
+                            if ident == "setter" {
+                                setter = true;
+                            }
+                        }
+                        _ => {}
+                    }
+                }
+                let kind = if setter {
+                    ClassItemKind::PropertySetter
+                } else {
+                    ClassItemKind::PropertyGetter
+                };
+                let py_name = py_name.unwrap_or_else(|| {
+                    let item_name = sig.ident.to_string();
+                    if item_name.starts_with("set_") {
+                        let name = &item_name["set_".len()..];
+                        if name.is_empty() {
+                            panic!(
+                                "A #[pyproperty(setter)] fn with a set_* name have something \
+                                 after \"set_\""
+                            )
+                        } else {
+                            name.to_string()
+                        }
+                    } else {
+                        panic!(
+                            "A #[pyproperty(setter)] fn must either have a `name` parameter or a \
+                             fn name along the lines of \"set_*\""
+                        )
+                    }
+                });
+                item = Some(ClassItem {
+                    py_name,
+                    item_name: sig.ident.clone(),
+                    kind,
+                });
+                attr_idx = Some(i);
             }
         }
-        // if there are no #[pymethods]s, then it's not a method, so exclude it from
-        // the final result
-        if pymethod_to_remove.is_empty() {
-            return None;
+        if let Some(attr_idx) = attr_idx {
+            attrs.remove(attr_idx);
         }
-        for i in pymethod_to_remove {
-            attrs.remove(i);
-        }
-        let py_name = py_name.unwrap_or_else(|| sig.ident.to_string());
-        Some(Method {
-            fn_name: sig.ident.clone(),
-            py_name,
-            kind,
-        })
+        item
     }
 }
 
@@ -98,30 +145,66 @@ pub fn impl_pyimpl(attr: AttributeArgs, item: Item) -> TokenStream2 {
 
     let rp_path = rustpython_path_attr(&attr);
 
-    let methods = imp
+    let items = imp
         .items
         .iter_mut()
         .filter_map(|item| {
             if let ImplItem::Method(meth) = item {
-                Method::from_syn(&mut meth.attrs, &meth.sig)
+                ClassItem::extract_from_syn(&mut meth.attrs, &meth.sig)
             } else {
                 None
             }
         })
         .collect::<Vec<_>>();
     let ty = &imp.self_ty;
-    let methods = methods.iter().map(
-        |Method {
-             py_name,
-             fn_name,
-             kind,
-         }| {
-            let constructor_fn = kind.to_ctx_constructor_fn();
-            quote! {
-                class.set_str_attr(#py_name, ctx.#constructor_fn(Self::#fn_name));
+    let mut properties: HashMap<&str, (Option<&Ident>, Option<&Ident>)> = HashMap::new();
+    for item in items.iter() {
+        match item.kind {
+            ClassItemKind::PropertyGetter => {
+                let (ref mut getter, _) = properties.entry(&item.py_name).or_default();
+                if getter.is_some() {
+                    panic!("Multiple property getters with name {:?}", &item.py_name)
+                }
+                *getter = Some(&item.item_name);
             }
-        },
-    );
+            ClassItemKind::PropertySetter => {
+                let (_, ref mut setter) = properties.entry(&item.py_name).or_default();
+                if setter.is_some() {
+                    panic!("Multiple property getters with name {:?}", &item.py_name)
+                }
+                *setter = Some(&item.item_name);
+            }
+            ClassItemKind::Method => {}
+        }
+    }
+    let methods = items.iter().filter_map(|item| {
+        if let ClassItemKind::Method = item.kind {
+            let ClassItem {
+                py_name, item_name, ..
+            } = item;
+            Some(quote! {
+                class.set_str_attr(#py_name, ctx.new_rustfunc(Self::#item_name));
+            })
+        } else {
+            None
+        }
+    });
+    let properties = properties.iter().map(|(name, prop)| {
+        let getter = match prop.0 {
+            Some(getter) => getter,
+            None => panic!("Property {:?} is missing a getter", name),
+        };
+        let add_setter = prop.1.map(|setter| quote!(.add_setter(Self::#setter)));
+        quote! {
+            class.set_str_attr(
+                #name,
+                #rp_path::obj::objproperty::PropertyBuilder
+                    .add_getter(Self::#getter)
+                    #add_setter
+                    .create(),
+            );
+        }
+    });
 
     quote! {
         #imp
@@ -131,6 +214,7 @@ pub fn impl_pyimpl(attr: AttributeArgs, item: Item) -> TokenStream2 {
                 class: &#rp_path::obj::objtype::PyClassRef,
             ) {
                 #(#methods)*
+                #(#properties)*
             }
         }
     }

--- a/vm/src/obj/objint.rs
+++ b/vm/src/obj/objint.rs
@@ -17,6 +17,7 @@ use super::objstr::{PyString, PyStringRef};
 use super::objtype;
 use crate::obj::objtype::PyClassRef;
 
+#[pyclass(__inside_vm)]
 #[derive(Debug)]
 pub struct PyInt {
     value: BigInt,
@@ -95,7 +96,9 @@ impl_try_from_object_int!(
     (u64, to_u64),
 );
 
+#[pyimpl(__inside_vm)]
 impl PyInt {
+    #[pymethod(name = "__eq__")]
     fn eq(&self, other: PyObjectRef, vm: &VirtualMachine) -> PyObjectRef {
         if objtype::isinstance(&other, &vm.ctx.int_type()) {
             vm.ctx.new_bool(self.value == *get_value(&other))
@@ -104,6 +107,7 @@ impl PyInt {
         }
     }
 
+    #[pymethod(name = "__ne__")]
     fn ne(&self, other: PyObjectRef, vm: &VirtualMachine) -> PyObjectRef {
         if objtype::isinstance(&other, &vm.ctx.int_type()) {
             vm.ctx.new_bool(self.value != *get_value(&other))
@@ -112,6 +116,7 @@ impl PyInt {
         }
     }
 
+    #[pymethod(name = "__lt__")]
     fn lt(&self, other: PyObjectRef, vm: &VirtualMachine) -> PyObjectRef {
         if objtype::isinstance(&other, &vm.ctx.int_type()) {
             vm.ctx.new_bool(self.value < *get_value(&other))
@@ -120,6 +125,7 @@ impl PyInt {
         }
     }
 
+    #[pymethod(name = "__le__")]
     fn le(&self, other: PyObjectRef, vm: &VirtualMachine) -> PyObjectRef {
         if objtype::isinstance(&other, &vm.ctx.int_type()) {
             vm.ctx.new_bool(self.value <= *get_value(&other))
@@ -128,6 +134,7 @@ impl PyInt {
         }
     }
 
+    #[pymethod(name = "__gt__")]
     fn gt(&self, other: PyObjectRef, vm: &VirtualMachine) -> PyObjectRef {
         if objtype::isinstance(&other, &vm.ctx.int_type()) {
             vm.ctx.new_bool(self.value > *get_value(&other))
@@ -136,6 +143,7 @@ impl PyInt {
         }
     }
 
+    #[pymethod(name = "__ge__")]
     fn ge(&self, other: PyObjectRef, vm: &VirtualMachine) -> PyObjectRef {
         if objtype::isinstance(&other, &vm.ctx.int_type()) {
             vm.ctx.new_bool(self.value >= *get_value(&other))
@@ -144,6 +152,7 @@ impl PyInt {
         }
     }
 
+    #[pymethod(name = "__add__")]
     fn add(&self, other: PyObjectRef, vm: &VirtualMachine) -> PyObjectRef {
         if objtype::isinstance(&other, &vm.ctx.int_type()) {
             vm.ctx.new_int((&self.value) + get_value(&other))
@@ -152,6 +161,7 @@ impl PyInt {
         }
     }
 
+    #[pymethod(name = "__sub__")]
     fn sub(&self, other: PyObjectRef, vm: &VirtualMachine) -> PyObjectRef {
         if objtype::isinstance(&other, &vm.ctx.int_type()) {
             vm.ctx.new_int((&self.value) - get_value(&other))
@@ -160,6 +170,7 @@ impl PyInt {
         }
     }
 
+    #[pymethod(name = "__rsub__")]
     fn rsub(&self, other: PyObjectRef, vm: &VirtualMachine) -> PyObjectRef {
         if objtype::isinstance(&other, &vm.ctx.int_type()) {
             vm.ctx.new_int(get_value(&other) - (&self.value))
@@ -168,6 +179,7 @@ impl PyInt {
         }
     }
 
+    #[pymethod(name = "__mul__")]
     fn mul(&self, other: PyObjectRef, vm: &VirtualMachine) -> PyObjectRef {
         if objtype::isinstance(&other, &vm.ctx.int_type()) {
             vm.ctx.new_int((&self.value) * get_value(&other))
@@ -176,6 +188,7 @@ impl PyInt {
         }
     }
 
+    #[pymethod(name = "__truediv__")]
     fn truediv(&self, other: PyObjectRef, vm: &VirtualMachine) -> PyResult {
         if objtype::isinstance(&other, &vm.ctx.int_type()) {
             div_ints(vm, &self.value, &get_value(&other))
@@ -184,6 +197,7 @@ impl PyInt {
         }
     }
 
+    #[pymethod(name = "__rtruediv__")]
     fn rtruediv(&self, other: PyObjectRef, vm: &VirtualMachine) -> PyResult {
         if objtype::isinstance(&other, &vm.ctx.int_type()) {
             div_ints(vm, &get_value(&other), &self.value)
@@ -192,6 +206,7 @@ impl PyInt {
         }
     }
 
+    #[pymethod(name = "__floordiv__")]
     fn floordiv(&self, other: PyObjectRef, vm: &VirtualMachine) -> PyResult {
         if objtype::isinstance(&other, &vm.ctx.int_type()) {
             let v2 = get_value(&other);
@@ -205,6 +220,7 @@ impl PyInt {
         }
     }
 
+    #[pymethod(name = "__lshift__")]
     fn lshift(&self, other: PyObjectRef, vm: &VirtualMachine) -> PyResult {
         if !objtype::isinstance(&other, &vm.ctx.int_type()) {
             return Ok(vm.ctx.not_implemented());
@@ -224,6 +240,7 @@ impl PyInt {
         }
     }
 
+    #[pymethod(name = "__rshift__")]
     fn rshift(&self, other: PyObjectRef, vm: &VirtualMachine) -> PyResult {
         if !objtype::isinstance(&other, &vm.ctx.int_type()) {
             return Ok(vm.ctx.not_implemented());
@@ -243,6 +260,7 @@ impl PyInt {
         }
     }
 
+    #[pymethod(name = "__xor__")]
     fn xor(&self, other: PyObjectRef, vm: &VirtualMachine) -> PyObjectRef {
         if objtype::isinstance(&other, &vm.ctx.int_type()) {
             vm.ctx.new_int((&self.value) ^ get_value(&other))
@@ -251,6 +269,7 @@ impl PyInt {
         }
     }
 
+    #[pymethod(name = "__rxor__")]
     fn rxor(&self, other: PyObjectRef, vm: &VirtualMachine) -> PyObjectRef {
         if objtype::isinstance(&other, &vm.ctx.int_type()) {
             vm.ctx.new_int(get_value(&other) ^ (&self.value))
@@ -259,6 +278,7 @@ impl PyInt {
         }
     }
 
+    #[pymethod(name = "__or__")]
     fn or(&self, other: PyObjectRef, vm: &VirtualMachine) -> PyObjectRef {
         if objtype::isinstance(&other, &vm.ctx.int_type()) {
             vm.ctx.new_int((&self.value) | get_value(&other))
@@ -267,6 +287,7 @@ impl PyInt {
         }
     }
 
+    #[pymethod(name = "__and__")]
     fn and(&self, other: PyObjectRef, vm: &VirtualMachine) -> PyObjectRef {
         if objtype::isinstance(&other, &vm.ctx.int_type()) {
             let v2 = get_value(&other);
@@ -276,6 +297,7 @@ impl PyInt {
         }
     }
 
+    #[pymethod(name = "__pow__")]
     fn pow(&self, other: PyObjectRef, vm: &VirtualMachine) -> PyObjectRef {
         if objtype::isinstance(&other, &vm.ctx.int_type()) {
             let v2 = get_value(&other).to_u32().unwrap();
@@ -288,6 +310,7 @@ impl PyInt {
         }
     }
 
+    #[pymethod(name = "__mod__")]
     fn mod_(&self, other: PyObjectRef, vm: &VirtualMachine) -> PyResult {
         if objtype::isinstance(&other, &vm.ctx.int_type()) {
             let v2 = get_value(&other);
@@ -301,6 +324,7 @@ impl PyInt {
         }
     }
 
+    #[pymethod(name = "__divmod__")]
     fn divmod(&self, other: PyObjectRef, vm: &VirtualMachine) -> PyResult {
         if objtype::isinstance(&other, &vm.ctx.int_type()) {
             let v2 = get_value(&other);
@@ -317,20 +341,24 @@ impl PyInt {
         }
     }
 
+    #[pymethod(name = "__neg__")]
     fn neg(&self, _vm: &VirtualMachine) -> BigInt {
         -(&self.value)
     }
 
+    #[pymethod(name = "__hash__")]
     fn hash(&self, _vm: &VirtualMachine) -> u64 {
         let mut hasher = std::collections::hash_map::DefaultHasher::new();
         self.value.hash(&mut hasher);
         hasher.finish()
     }
 
+    #[pymethod(name = "__abs__")]
     fn abs(&self, _vm: &VirtualMachine) -> BigInt {
         self.value.abs()
     }
 
+    #[pymethod(name = "__round__")]
     fn round(
         zelf: PyRef<Self>,
         _precision: OptionalArg<PyObjectRef>,
@@ -339,14 +367,17 @@ impl PyInt {
         zelf
     }
 
+    #[pymethod(name = "__int__")]
     fn int(zelf: PyRef<Self>, _vm: &VirtualMachine) -> PyIntRef {
         zelf
     }
 
+    #[pymethod(name = "__pos__")]
     fn pos(zelf: PyRef<Self>, _vm: &VirtualMachine) -> PyIntRef {
         zelf
     }
 
+    #[pymethod(name = "__float__")]
     fn float(&self, vm: &VirtualMachine) -> PyResult<PyFloat> {
         self.value
             .to_f64()
@@ -354,30 +385,37 @@ impl PyInt {
             .ok_or_else(|| vm.new_overflow_error("int too large to convert to float".to_string()))
     }
 
+    #[pymethod(name = "__trunc__")]
     fn trunc(zelf: PyRef<Self>, _vm: &VirtualMachine) -> PyIntRef {
         zelf
     }
 
+    #[pymethod(name = "__floor__")]
     fn floor(zelf: PyRef<Self>, _vm: &VirtualMachine) -> PyIntRef {
         zelf
     }
 
+    #[pymethod(name = "__ceil__")]
     fn ceil(zelf: PyRef<Self>, _vm: &VirtualMachine) -> PyIntRef {
         zelf
     }
 
+    #[pymethod(name = "__index__")]
     fn index(zelf: PyRef<Self>, _vm: &VirtualMachine) -> PyIntRef {
         zelf
     }
 
+    #[pymethod(name = "__invert__")]
     fn invert(&self, _vm: &VirtualMachine) -> BigInt {
         !(&self.value)
     }
 
+    #[pymethod(name = "__repr__")]
     fn repr(&self, _vm: &VirtualMachine) -> String {
         self.value.to_string()
     }
 
+    #[pymethod(name = "__format__")]
     fn format(&self, spec: PyStringRef, vm: &VirtualMachine) -> PyResult<String> {
         let format_spec = FormatSpec::parse(&spec.value);
         match format_spec.format_int(&self.value) {
@@ -386,22 +424,27 @@ impl PyInt {
         }
     }
 
+    #[pymethod(name = "__bool__")]
     fn bool(&self, _vm: &VirtualMachine) -> bool {
         !self.value.is_zero()
     }
 
+    #[pymethod]
     fn bit_length(&self, _vm: &VirtualMachine) -> usize {
         self.value.bits()
     }
 
+    #[pymethod]
     fn conjugate(zelf: PyRef<Self>, _vm: &VirtualMachine) -> PyIntRef {
         zelf
     }
 
+    #[pyproperty]
     fn real(zelf: PyRef<Self>, _vm: &VirtualMachine) -> PyIntRef {
         zelf
     }
 
+    #[pyproperty]
     fn imag(&self, _vm: &VirtualMachine) -> usize {
         0
     }

--- a/vm/src/obj/objint.rs
+++ b/vm/src/obj/objint.rs
@@ -176,6 +176,11 @@ impl PyInt {
         }
     }
 
+    #[pymethod(name = "__radd__")]
+    fn radd(&self, other: PyObjectRef, vm: &VirtualMachine) -> PyObjectRef {
+        self.add(other, vm)
+    }
+
     #[pymethod(name = "__sub__")]
     fn sub(&self, other: PyObjectRef, vm: &VirtualMachine) -> PyObjectRef {
         if objtype::isinstance(&other, &vm.ctx.int_type()) {
@@ -201,6 +206,11 @@ impl PyInt {
         } else {
             vm.ctx.not_implemented()
         }
+    }
+
+    #[pymethod(name = "__rmul__")]
+    fn rmul(&self, other: PyObjectRef, vm: &VirtualMachine) -> PyObjectRef {
+        self.mul(other, vm)
     }
 
     #[pymethod(name = "__truediv__")]


### PR DESCRIPTION
I have come to the conclusion that it is impossible to write clean code for a macro implementation.