### PR TITLE
Fix dir bug - not including object attributes correctly.

### DIFF
--- a/tests/snippets/builtin_dir.py
+++ b/tests/snippets/builtin_dir.py
@@ -8,6 +8,9 @@ a = A()
 assert "test" in dir(a), "test not in a"
 assert "test" in dir(A), "test not in A"
 
+a.x = 3
+assert "x" in dir(a), "x not in a"
+
 class B(A):
 	def __dir__(self):
 		return ('q', 'h')

--- a/vm/src/obj/objdict.rs
+++ b/vm/src/obj/objdict.rs
@@ -239,6 +239,19 @@ impl PyDictRef {
         attrs
     }
 
+    pub fn from_attributes(attrs: PyAttributes, vm: &VirtualMachine) -> PyResult<Self> {
+        let dict = DictContentType::default();
+        let entries = RefCell::new(dict);
+
+        for (key, value) in attrs {
+            entries
+                .borrow_mut()
+                .insert(vm, &vm.ctx.new_str(key), value)?;
+        }
+
+        Ok(PyDict { entries }.into_ref(vm))
+    }
+
     fn hash(self, vm: &VirtualMachine) -> PyResult {
         Err(vm.new_type_error("unhashable type".to_string()))
     }


### PR DESCRIPTION
On master:

```
>>>>> dir(lambda: 1)
["'str' object", ...
```

This was introduced when we got non-string dictionary keys. We now fail in a slightly different way than CPython but it's a an obscure enough edge case that I don't think it matters:

```
>>> a.__dict__[9] = 2
>>> dir(a)
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
TypeError: '<' not supported between instances of 'str' and 'int'
```

vs

```
>>>>> a.__dict__[9] = 2
>>>>> dir(a)
Traceback (most recent call last):
  File <stdin>, line 0, in <module>
TypeError: Attribute is not a string: "9"
```