### PR TITLE
Add exception cause

### DIFF
--- a/tests/snippets/try_exceptions.py
+++ b/tests/snippets/try_exceptions.py
@@ -95,3 +95,35 @@ except TypeError as ex:
     l.append(3)
     print('boom', type(ex))
 assert l == [1, 3]
+
+cause = None
+try:
+    try:
+        raise ZeroDivisionError
+    except ZeroDivisionError as ex:
+        assert ex.__cause__ == None
+        cause = ex
+        raise NameError from ex
+except NameError as ex2:
+    assert ex2.__cause__ == cause
+
+try:
+    raise ZeroDivisionError from None
+except ZeroDivisionError as ex:
+    assert ex.__cause__ == None
+
+try:
+    raise ZeroDivisionError
+except ZeroDivisionError as ex:
+    assert ex.__cause__ == None
+
+try:
+    raise ZeroDivisionError from 5
+except TypeError:
+    pass
+
+try:
+    raise ZeroDivisionError from NameError
+except ZeroDivisionError as ex:
+    assert type(ex.__cause__) == NameError
+

--- a/tests/snippets/try_exceptions.py
+++ b/tests/snippets/try_exceptions.py
@@ -1,4 +1,4 @@
-
+from testutils import assertRaises
 
 try:
     raise BaseException()
@@ -117,10 +117,8 @@ try:
 except ZeroDivisionError as ex:
     assert ex.__cause__ == None
 
-try:
+with assertRaises(TypeError):
     raise ZeroDivisionError from 5
-except TypeError:
-    pass
 
 try:
     raise ZeroDivisionError from NameError

--- a/vm/src/frame.rs
+++ b/vm/src/frame.rs
@@ -1207,9 +1207,7 @@ impl Frame {
                     "Can only raise BaseException derived types, not {}",
                     exception
                 );
-                let type_error_type = vm.ctx.exceptions.type_error.clone();
-                let type_error = vm.new_exception(type_error_type, msg);
-                Err(type_error)
+                Err(vm.new_type_error(msg))
             }
         } else {
             Err(vm.new_type_error("exceptions must derive from BaseException".to_string()))

--- a/vm/src/frame.rs
+++ b/vm/src/frame.rs
@@ -686,6 +686,7 @@ impl Frame {
                     0 | 3 => panic!("Not implemented!"),
                     _ => panic!("Invalid parameter for RAISE_VARARGS, must be between 0 to 3"),
                 };
+                info!("Exception raised: {:?} with cause: {:?}", exception, cause);
                 vm.set_attr(&exception, vm.new_str("__cause__".to_string()), cause)?;
                 Err(exception)
             }


### PR DESCRIPTION
You can now do:
```py
try:
    raise ZeroDivisionError
except ZeroDivisionError as ex:
    raise NameError from ex
```
and the output is:
```py
Traceback (most recent call last):
  File tests/snippets/try_exceptions.py, line 131, in <module>
ZeroDivisionError: No msg

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File tests/snippets/try_exceptions.py, line 133, in <module>
NameError: No msg
```