### PR TITLE
Fix sub-crate compilation

### DIFF
--- a/derive/src/pyclass.rs
+++ b/derive/src/pyclass.rs
@@ -16,11 +16,11 @@ enum ClassItem {
     },
 }
 
-fn meta_to_vec(meta: Meta) -> Result<Vec<NestedMeta>, Meta> {
+fn meta_to_vec(meta: Meta) -> Option<Vec<NestedMeta>> {
     match meta {
-        Meta::Word(_) => Ok(Vec::new()),
-        Meta::List(list) => Ok(list.nested.into_iter().collect()),
-        Meta::NameValue(_) => Err(meta),
+        Meta::Word(_) => Some(Vec::new()),
+        Meta::List(list) => Some(list.nested.into_iter().collect()),
+        Meta::NameValue(_) => None,
     }
 }
 


### PR DESCRIPTION
Building from anything but the root crate currently fails with:

```
error[E0599]: no method named `expect` found for type `std::result::Result<std::vec::Vec<syn::attr::NestedMeta>, syn::attr::Meta>` in the current scope
  --> derive/src/pyclass.rs:42:49
   |
42 |                 let nesteds = meta_to_vec(meta).expect(
   |                                                 ^^^^^^
   |
   = note: the method `expect` exists but the following trait bounds were not satisfied:
           `syn::attr::Meta : std::fmt::Debug`

error[E0599]: no method named `expect` found for type `std::result::Result<std::vec::Vec<syn::attr::NestedMeta>, syn::attr::Meta>` in the current scope
  --> derive/src/pyclass.rs:74:49
   |
74 |                 let nesteds = meta_to_vec(meta).expect(
   |                                                 ^^^^^^
   |
   = note: the method `expect` exists but the following trait bounds were not satisfied:
           `syn::attr::Meta : std::fmt::Debug`

error: aborting due to 2 previous errors

For more information about this error, try `rustc --explain E0599`.
```

(Not sure why building from the root had no problem with this)