### PR TITLE
RustPython changes for #824

### DIFF
--- a/Lib/_collections_abc.py
+++ b/Lib/_collections_abc.py
@@ -52,7 +52,7 @@ dict_keys = type({}.keys())
 dict_values = type({}.values())
 dict_items = type({}.items())
 ## misc ##
-mappingproxy = type(type.__dict__)
+# mappingproxy = type(type.__dict__)
 # generator = type((lambda: (yield))())
 ## coroutine ##
 # async def _coro(): pass
@@ -688,7 +688,7 @@ class Mapping(Collection):
 
     __reversed__ = None
 
-Mapping.register(mappingproxy)
+# Mapping.register(mappingproxy)
 
 
 class MappingView(Sized):

--- a/vm/src/builtins.rs
+++ b/vm/src/builtins.rs
@@ -102,10 +102,8 @@ fn builtin_compile(
         }
     };
 
-    compile::compile(vm, &source, &mode, filename.value.to_string()).map_err(|err| {
-        let syntax_error = vm.context().exceptions.syntax_error.clone();
-        vm.new_exception(syntax_error, err.to_string())
-    })
+    compile::compile(vm, &source, &mode, filename.value.to_string())
+        .map_err(|err| vm.new_syntax_error(&err))
 }
 
 fn builtin_delattr(obj: PyObjectRef, attr: PyStringRef, vm: &VirtualMachine) -> PyResult<()> {
@@ -151,10 +149,8 @@ fn builtin_eval(vm: &VirtualMachine, args: PyFuncArgs) -> PyResult {
         let source = objstr::get_value(source);
         // TODO: fix this newline bug:
         let source = format!("{}\n", source);
-        compile::compile(vm, &source, &mode, "<string>".to_string()).map_err(|err| {
-            let syntax_error = vm.context().exceptions.syntax_error.clone();
-            vm.new_exception(syntax_error, err.to_string())
-        })?
+        compile::compile(vm, &source, &mode, "<string>".to_string())
+            .map_err(|err| vm.new_syntax_error(&err))?
     } else {
         return Err(vm.new_type_error("code argument must be str or code object".to_string()));
     };
@@ -181,10 +177,8 @@ fn builtin_exec(vm: &VirtualMachine, args: PyFuncArgs) -> PyResult {
         let source = objstr::get_value(source);
         // TODO: fix this newline bug:
         let source = format!("{}\n", source);
-        compile::compile(vm, &source, &mode, "<string>".to_string()).map_err(|err| {
-            let syntax_error = vm.context().exceptions.syntax_error.clone();
-            vm.new_exception(syntax_error, err.to_string())
-        })?
+        compile::compile(vm, &source, &mode, "<string>".to_string())
+            .map_err(|err| vm.new_syntax_error(&err))?
     } else if let Ok(code_obj) = PyCodeRef::try_from_object(vm, source.clone()) {
         code_obj
     } else {

--- a/vm/src/eval.rs
+++ b/vm/src/eval.rs
@@ -1,7 +1,5 @@
 extern crate rustpython_parser;
 
-use std::error::Error;
-
 use crate::compile;
 use crate::frame::Scope;
 use crate::pyobject::PyResult;
@@ -13,10 +11,7 @@ pub fn eval(vm: &VirtualMachine, source: &str, scope: Scope, source_path: &str) 
             debug!("Code object: {:?}", bytecode);
             vm.run_code_obj(bytecode, scope)
         }
-        Err(err) => {
-            let syntax_error = vm.context().exceptions.syntax_error.clone();
-            Err(vm.new_exception(syntax_error, err.description().to_string()))
-        }
+        Err(err) => Err(vm.new_syntax_error(&err)),
     }
 }
 

--- a/vm/src/import.rs
+++ b/vm/src/import.rs
@@ -2,7 +2,6 @@
  * Import mechanics
  */
 
-use std::error::Error;
 use std::path::PathBuf;
 
 use crate::compile;
@@ -25,17 +24,14 @@ fn import_uncached_module(vm: &VirtualMachine, current_path: PathBuf, module: &s
     let file_path = find_source(vm, current_path, module)
         .map_err(|e| vm.new_exception(notfound_error.clone(), e))?;
     let source = util::read_file(file_path.as_path())
-        .map_err(|e| vm.new_exception(import_error.clone(), e.description().to_string()))?;
+        .map_err(|e| vm.new_exception(import_error.clone(), format!("{}", e)))?;
     let code_obj = compile::compile(
         vm,
         &source,
         &compile::Mode::Exec,
         file_path.to_str().unwrap().to_string(),
     )
-    .map_err(|err| {
-        let syntax_error = vm.context().exceptions.syntax_error.clone();
-        vm.new_exception(syntax_error, err.description().to_string())
-    })?;
+    .map_err(|err| vm.new_syntax_error(&err))?;
     // trace!("Code object: {:?}", code_obj);
 
     let attrs = vm.ctx.new_dict();
@@ -64,12 +60,13 @@ fn find_source(vm: &VirtualMachine, current_path: PathBuf, name: &str) -> Result
 
     paths.insert(0, current_path);
 
+    let rel_name = name.replace('.', "/");
     let suffixes = [".py", "/__init__.py"];
     let mut file_paths = vec![];
     for path in paths {
         for suffix in suffixes.iter() {
             let mut file_path = path.clone();
-            file_path.push(format!("{}{}", name, suffix));
+            file_path.push(format!("{}{}", rel_name, suffix));
             file_paths.push(file_path);
         }
     }

--- a/vm/src/import.rs
+++ b/vm/src/import.rs
@@ -24,7 +24,7 @@ fn import_uncached_module(vm: &VirtualMachine, current_path: PathBuf, module: &s
     let file_path = find_source(vm, current_path, module)
         .map_err(|e| vm.new_exception(notfound_error.clone(), e))?;
     let source = util::read_file(file_path.as_path())
-        .map_err(|e| vm.new_exception(import_error.clone(), format!("{}", e)))?;
+        .map_err(|e| vm.new_exception(import_error.clone(), e.to_string()))?;
     let code_obj = compile::compile(
         vm,
         &source,

--- a/vm/src/obj/objclassmethod.rs
+++ b/vm/src/obj/objclassmethod.rs
@@ -9,6 +9,8 @@ pub struct PyClassMethod {
 pub type PyClassMethodRef = PyRef<PyClassMethod>;
 
 impl PyValue for PyClassMethod {
+    const HAVE_DICT: bool = true;
+
     fn class(vm: &VirtualMachine) -> PyClassRef {
         vm.ctx.classmethod_type()
     }

--- a/vm/src/obj/objfunction.rs
+++ b/vm/src/obj/objfunction.rs
@@ -1,4 +1,5 @@
 use crate::frame::Scope;
+use crate::function::{Args, KwArgs};
 use crate::obj::objcode::PyCodeRef;
 use crate::obj::objdict::PyDictRef;
 use crate::obj::objtuple::PyTupleRef;
@@ -40,6 +41,10 @@ impl PyValue for PyFunction {
 }
 
 impl PyFunctionRef {
+    fn call(self, args: Args, kwargs: KwArgs, vm: &VirtualMachine) -> PyResult {
+        vm.invoke(self.into_object(), (&args, &kwargs))
+    }
+
     fn code(self, _vm: &VirtualMachine) -> PyCodeRef {
         self.code.clone()
     }
@@ -76,6 +81,7 @@ pub fn init(context: &PyContext) {
     let function_type = &context.function_type;
     extend_class!(context, function_type, {
         "__get__" => context.new_rustfunc(bind_method),
+        "__call__" => context.new_rustfunc(PyFunctionRef::call),
         "__code__" => context.new_property(PyFunctionRef::code),
         "__defaults__" => context.new_property(PyFunctionRef::defaults),
         "__kwdefaults__" => context.new_property(PyFunctionRef::kwdefaults),

--- a/vm/src/obj/objobject.rs
+++ b/vm/src/obj/objobject.rs
@@ -167,7 +167,11 @@ pub fn init(context: &PyContext) {
         "__ge__" => context.new_rustfunc(object_ge),
         "__setattr__" => context.new_rustfunc(object_setattr),
         "__delattr__" => context.new_rustfunc(object_delattr),
-        "__dict__" => context.new_property(object_dict),
+        "__dict__" =>
+        PropertyBuilder::new(context)
+                .add_getter(object_dict)
+                .add_setter(object_dict_setter)
+                .create(),
         "__dir__" => context.new_rustfunc(object_dir),
         "__hash__" => context.new_rustfunc(object_hash),
         "__str__" => context.new_rustfunc(object_str),
@@ -201,6 +205,16 @@ fn object_dict(object: PyObjectRef, vm: &VirtualMachine) -> PyResult<PyDictRef> 
     } else {
         Err(vm.new_type_error("TypeError: no dictionary.".to_string()))
     }
+}
+
+fn object_dict_setter(
+    _instance: PyObjectRef,
+    _value: PyObjectRef,
+    vm: &VirtualMachine,
+) -> PyResult {
+    Err(vm.new_not_implemented_error(
+        "Setting __dict__ attribute on am object isn't yet implemented".to_string(),
+    ))
 }
 
 fn object_getattribute(obj: PyObjectRef, name_str: PyStringRef, vm: &VirtualMachine) -> PyResult {

--- a/vm/src/pyobject.rs
+++ b/vm/src/pyobject.rs
@@ -1191,6 +1191,8 @@ impl PyObject<dyn PyObjectPayload> {
 }
 
 pub trait PyValue: fmt::Debug + Sized + 'static {
+    const HAVE_DICT: bool = false;
+
     fn class(vm: &VirtualMachine) -> PyClassRef;
 
     fn into_ref(self, vm: &VirtualMachine) -> PyRef<Self> {
@@ -1203,7 +1205,7 @@ pub trait PyValue: fmt::Debug + Sized + 'static {
     fn into_ref_with_type(self, vm: &VirtualMachine, cls: PyClassRef) -> PyResult<PyRef<Self>> {
         let class = Self::class(vm);
         if objtype::issubclass(&cls, &class) {
-            let dict = if cls.is(&class) {
+            let dict = if !Self::HAVE_DICT && cls.is(&class) {
                 None
             } else {
                 Some(vm.ctx.new_dict())

--- a/vm/src/stdlib/io.rs
+++ b/vm/src/stdlib/io.rs
@@ -95,6 +95,9 @@ fn io_base_cm_exit(vm: &VirtualMachine, args: PyFuncArgs) -> PyResult {
     Ok(vm.get_none())
 }
 
+// TODO Check if closed, then if so raise ValueError
+fn io_base_flush(_zelf: PyObjectRef, _vm: &VirtualMachine) {}
+
 fn buffered_io_base_init(vm: &VirtualMachine, args: PyFuncArgs) -> PyResult {
     arg_check!(vm, args, required = [(buffered, None), (raw, None)]);
     vm.set_attr(buffered, "raw", raw.clone())?;
@@ -369,7 +372,8 @@ pub fn make_module(vm: &VirtualMachine) -> PyObjectRef {
     //IOBase the abstract base class of the IO Module
     let io_base = py_class!(ctx, "IOBase", ctx.object(), {
         "__enter__" => ctx.new_rustfunc(io_base_cm_enter),
-        "__exit__" => ctx.new_rustfunc(io_base_cm_exit)
+        "__exit__" => ctx.new_rustfunc(io_base_cm_exit),
+        "flush" => ctx.new_rustfunc(io_base_flush)
     });
 
     // IOBase Subclasses

--- a/vm/src/stdlib/mod.rs
+++ b/vm/src/stdlib/mod.rs
@@ -9,6 +9,7 @@ mod random;
 mod re;
 pub mod socket;
 mod string;
+mod thread;
 mod time_module;
 mod tokenize;
 mod types;
@@ -41,6 +42,7 @@ pub fn get_module_inits() -> HashMap<String, StdlibInitFunc> {
     modules.insert("random".to_string(), Box::new(random::make_module));
     modules.insert("string".to_string(), Box::new(string::make_module));
     modules.insert("struct".to_string(), Box::new(pystruct::make_module));
+    modules.insert("_thread".to_string(), Box::new(thread::make_module));
     modules.insert("time".to_string(), Box::new(time_module::make_module));
     modules.insert("tokenize".to_string(), Box::new(tokenize::make_module));
     modules.insert("types".to_string(), Box::new(types::make_module));

--- a/vm/src/stdlib/thread.rs
+++ b/vm/src/stdlib/thread.rs
@@ -1,0 +1,30 @@
+/// Implementation of the _thread module, currently noop implementation as RustPython doesn't yet
+/// support threading
+use super::super::pyobject::PyObjectRef;
+use crate::function::PyFuncArgs;
+use crate::pyobject::PyResult;
+use crate::vm::VirtualMachine;
+
+fn rlock_acquire(vm: &VirtualMachine, _args: PyFuncArgs) -> PyResult {
+    Ok(vm.get_none())
+}
+
+fn rlock_release(_zelf: PyObjectRef, _vm: &VirtualMachine) {}
+
+fn get_ident(_vm: &VirtualMachine) -> u32 {
+    1
+}
+
+pub fn make_module(vm: &VirtualMachine) -> PyObjectRef {
+    let ctx = &vm.ctx;
+
+    let rlock_type = py_class!(ctx, "_thread.RLock", ctx.object(), {
+        "acquire" => ctx.new_rustfunc(rlock_acquire),
+        "release" => ctx.new_rustfunc(rlock_release),
+    });
+
+    py_module!(vm, "_thread", {
+        "RLock" => rlock_type,
+        "get_ident" => ctx.new_rustfunc(get_ident)
+    })
+}

--- a/vm/src/stdlib/types.rs
+++ b/vm/src/stdlib/types.rs
@@ -31,6 +31,7 @@ pub fn make_module(vm: &VirtualMachine) -> PyObjectRef {
     py_module!(vm, "types", {
         "new_class" => ctx.new_rustfunc(types_new_class),
         "FunctionType" => ctx.function_type(),
+        "MethodType" => ctx.bound_method_type(),
         "LambdaType" => ctx.function_type(),
         "CodeType" => ctx.code_type(),
         "FrameType" => ctx.frame_type()

--- a/vm/src/sysmodule.rs
+++ b/vm/src/sysmodule.rs
@@ -3,6 +3,7 @@ use std::{env, mem};
 
 use crate::frame::FrameRef;
 use crate::function::{OptionalArg, PyFuncArgs};
+use crate::obj::objstr::PyStringRef;
 use crate::pyobject::{ItemProtocol, PyContext, PyObjectRef, PyResult, TypeProtocol};
 use crate::vm::VirtualMachine;
 
@@ -37,6 +38,11 @@ fn sys_getsizeof(vm: &VirtualMachine, args: PyFuncArgs) -> PyResult {
     // TODO: implement default optional argument.
     let size = mem::size_of_val(&object);
     Ok(vm.ctx.new_int(size))
+}
+
+// TODO implement string interning, this will be key for performance
+fn sys_intern(value: PyStringRef, _vm: &VirtualMachine) -> PyStringRef {
+    value
 }
 
 pub fn make_module(vm: &VirtualMachine, module: PyObjectRef, builtins: PyObjectRef) {
@@ -130,6 +136,7 @@ settrace() -- set the global debug tracing function
       "argv" => argv(ctx),
       "getrefcount" => ctx.new_rustfunc(sys_getrefcount),
       "getsizeof" => ctx.new_rustfunc(sys_getsizeof),
+      "intern" => ctx.new_rustfunc(sys_intern),
       "maxsize" => ctx.new_int(std::usize::MAX),
       "path" => path,
       "ps1" => ctx.new_str(">>>>> ".to_string()),
@@ -137,6 +144,7 @@ settrace() -- set the global debug tracing function
       "__doc__" => ctx.new_str(sys_doc.to_string()),
       "_getframe" => ctx.new_rustfunc(getframe),
       "modules" => modules.clone(),
+      "warnoptions" => ctx.new_list(vec![]),
     });
 
     modules.set_item("sys", module.clone(), vm).unwrap();

--- a/vm/src/vm.rs
+++ b/vm/src/vm.rs
@@ -234,6 +234,11 @@ impl VirtualMachine {
         self.new_exception(overflow_error, msg)
     }
 
+    pub fn new_syntax_error<T: ToString>(&self, msg: &T) -> PyObjectRef {
+        let syntax_error = self.ctx.exceptions.syntax_error.clone();
+        self.new_exception(syntax_error, msg.to_string())
+    }
+
     pub fn get_none(&self) -> PyObjectRef {
         self.ctx.none()
     }


### PR DESCRIPTION
Split from #824 as requested. These are the changes to RustPython itself to support importing and running unittest.

The changes are:
- Ability to do an absolute import of a non-top-level module. i.e. import unittest.case. This isn't implemented properly but is a hack to get importing of those to happen.
- Add function.__call__
- Add io.IOBase.flush
- Add skeleton _thread module
- Expose types.MethodType
- Add fake sys.intern and sys.warnoptions
- Make classmethod have a dict by default.