### PR TITLE
Exception reraise and context

### DIFF
--- a/tests/snippets/try_exceptions.py
+++ b/tests/snippets/try_exceptions.py
@@ -126,18 +126,14 @@ try:
 except ZeroDivisionError as ex:
     assert type(ex.__cause__) == NameError
 
-try:
+with assertRaises(NameError):
     try:
         raise NameError
     except:
         raise
-except NameError:
-    pass
 
-try:
+with assertRaises(RuntimeError):
     raise
-except RuntimeError:
-    pass
 
 context = None
 try:

--- a/tests/snippets/try_exceptions.py
+++ b/tests/snippets/try_exceptions.py
@@ -125,3 +125,15 @@ try:
 except ZeroDivisionError as ex:
     assert type(ex.__cause__) == NameError
 
+try:
+    try:
+        raise NameError
+    except:
+        raise
+except NameError:
+    pass
+
+try:
+    raise
+except RuntimeError:
+    pass

--- a/tests/snippets/try_exceptions.py
+++ b/tests/snippets/try_exceptions.py
@@ -137,3 +137,8 @@ try:
     raise
 except RuntimeError:
     pass
+
+try:
+    raise ZeroDivisionError
+except ZeroDivisionError as ex:
+    assert ex.__context__ == None

--- a/tests/snippets/try_exceptions.py
+++ b/tests/snippets/try_exceptions.py
@@ -161,3 +161,13 @@ try:
 except ZeroDivisionError as ex:
     assert type(ex.__cause__) == NameError
     assert ex.__context__ == None
+
+try:
+    try:
+        raise ZeroDivisionError
+    except ZeroDivisionError as ex:
+        pass
+    finally:
+        raise NameError
+except NameError as ex2:
+    assert ex2.__context__ == None

--- a/tests/snippets/try_exceptions.py
+++ b/tests/snippets/try_exceptions.py
@@ -106,6 +106,7 @@ try:
         raise NameError from ex
 except NameError as ex2:
     assert ex2.__cause__ == cause
+    assert ex2.__context__ == cause
 
 try:
     raise ZeroDivisionError from None
@@ -138,7 +139,25 @@ try:
 except RuntimeError:
     pass
 
+context = None
+try:
+    try:
+        raise ZeroDivisionError
+    except ZeroDivisionError as ex:
+        assert ex.__context__ == None
+        context = ex
+        raise NameError
+except NameError as ex2:
+    assert ex2.__context__ == context
+    assert type(ex2.__context__) == ZeroDivisionError
+
 try:
     raise ZeroDivisionError
 except ZeroDivisionError as ex:
+    assert ex.__context__ == None
+
+try:
+    raise ZeroDivisionError from NameError
+except ZeroDivisionError as ex:
+    assert type(ex.__cause__) == NameError
     assert ex.__context__ == None

--- a/vm/src/bytecode.rs
+++ b/vm/src/bytecode.rs
@@ -135,6 +135,7 @@ pub enum Instruction {
     PopBlock,
     Raise {
         argc: usize,
+        in_exc: bool,
     },
     BuildString {
         size: usize,
@@ -363,7 +364,7 @@ impl Instruction {
             SetupWith { end } => w!(SetupWith, end),
             CleanupWith { end } => w!(CleanupWith, end),
             PopBlock => w!(PopBlock),
-            Raise { argc } => w!(Raise, argc),
+            Raise { argc, in_exc } => w!(Raise, argc, in_exc),
             BuildString { size } => w!(BuildString, size),
             BuildTuple { size, unpack } => w!(BuildTuple, size, unpack),
             BuildList { size, unpack } => w!(BuildList, size, unpack),

--- a/vm/src/compile.rs
+++ b/vm/src/compile.rs
@@ -637,6 +637,8 @@ impl Compiler {
             in_exc: true,
         });
 
+        self.in_exc_handler = was_in_exc_handler;
+
         // We successfully ran the try block:
         // else:
         self.set_label(else_label);
@@ -649,7 +651,6 @@ impl Compiler {
         if let Some(statements) = finalbody {
             self.compile_statements(statements)?;
         }
-        self.in_exc_handler = was_in_exc_handler;
         // unimplemented!();
         Ok(())
     }

--- a/vm/src/compile.rs
+++ b/vm/src/compile.rs
@@ -24,6 +24,7 @@ struct Compiler {
     current_qualified_path: Option<String>,
     in_loop: bool,
     in_function_def: bool,
+    in_exc_handler: bool,
 }
 
 /// Compile a given sourcecode into a bytecode object.
@@ -85,6 +86,7 @@ impl Compiler {
             current_qualified_path: None,
             in_loop: false,
             in_function_def: false,
+            in_exc_handler: false,
         }
     }
 
@@ -325,15 +327,24 @@ impl Compiler {
                     match cause {
                         Some(cause) => {
                             self.compile_expression(cause)?;
-                            self.emit(Instruction::Raise { argc: 2 });
+                            self.emit(Instruction::Raise {
+                                argc: 2,
+                                in_exc: self.in_exc_handler,
+                            });
                         }
                         None => {
-                            self.emit(Instruction::Raise { argc: 1 });
+                            self.emit(Instruction::Raise {
+                                argc: 1,
+                                in_exc: self.in_exc_handler,
+                            });
                         }
                     }
                 }
                 None => {
-                    self.emit(Instruction::Raise { argc: 0 });
+                    self.emit(Instruction::Raise {
+                        argc: 0,
+                        in_exc: self.in_exc_handler,
+                    });
                 }
             },
             ast::Statement::Try {
@@ -378,7 +389,10 @@ impl Compiler {
                         });
                     }
                 }
-                self.emit(Instruction::Raise { argc: 1 });
+                self.emit(Instruction::Raise {
+                    argc: 1,
+                    in_exc: self.in_exc_handler,
+                });
                 self.set_label(end_label);
             }
             ast::Statement::Break => {
@@ -558,6 +572,7 @@ impl Compiler {
         self.emit(Instruction::Jump { target: else_label });
 
         // except handlers:
+        self.in_exc_handler = true;
         self.set_label(handler_label);
         // Exception is on top of stack now
         handler_label = self.new_label();
@@ -586,15 +601,10 @@ impl Compiler {
 
                 // We have a match, store in name (except x as y)
                 if let Some(alias) = &handler.name {
+                    // Duplicate exception for context:
+                    self.emit(Instruction::Duplicate);
                     self.store_name(alias);
-                } else {
-                    // Drop exception from top of stack:
-                    self.emit(Instruction::Pop);
                 }
-            } else {
-                // Catch all!
-                // Drop exception from top of stack:
-                self.emit(Instruction::Pop);
             }
 
             // Handler code:
@@ -611,6 +621,9 @@ impl Compiler {
             target: handler_label,
         });
         self.set_label(handler_label);
+        // Drop exception from top of stack:
+        self.emit(Instruction::Pop);
+        self.in_exc_handler = false;
         // If code flows here, we have an unhandled exception,
         // emit finally code and raise again!
         // Duplicate finally code here:
@@ -619,7 +632,10 @@ impl Compiler {
         if let Some(statements) = finalbody {
             self.compile_statements(statements)?;
         }
-        self.emit(Instruction::Raise { argc: 1 });
+        self.emit(Instruction::Raise {
+            argc: 1,
+            in_exc: false,
+        });
 
         // We successfully ran the try block:
         // else:

--- a/vm/src/exceptions.rs
+++ b/vm/src/exceptions.rs
@@ -20,10 +20,20 @@ fn exception_init(vm: &VirtualMachine, args: PyFuncArgs) -> PyResult {
 
 // print excption chain
 pub fn print_exception(vm: &VirtualMachine, exc: &PyObjectRef) {
+    let mut had_casue = false;
     if let Ok(cause) = vm.get_attribute(exc.clone(), "__cause__") {
         if !vm.get_none().is(&cause) {
+            had_casue = true;
             print_exception(vm, &cause);
             println!("\nThe above exception was the direct cause of the following exception:\n");
+        }
+    }
+    if !had_casue {
+        if let Ok(context) = vm.get_attribute(exc.clone(), "__context__") {
+            if !vm.get_none().is(&context) {
+                print_exception(vm, &context);
+                println!("\nDuring handling of the above exception, another exception occurred:\n");
+            }
         }
     }
     print_exception_inner(vm, exc)

--- a/vm/src/exceptions.rs
+++ b/vm/src/exceptions.rs
@@ -20,15 +20,15 @@ fn exception_init(vm: &VirtualMachine, args: PyFuncArgs) -> PyResult {
 
 // print excption chain
 pub fn print_exception(vm: &VirtualMachine, exc: &PyObjectRef) {
-    let mut had_casue = false;
+    let mut had_cause = false;
     if let Ok(cause) = vm.get_attribute(exc.clone(), "__cause__") {
         if !vm.get_none().is(&cause) {
-            had_casue = true;
+            had_cause = true;
             print_exception(vm, &cause);
             println!("\nThe above exception was the direct cause of the following exception:\n");
         }
     }
-    if !had_casue {
+    if !had_cause {
         if let Ok(context) = vm.get_attribute(exc.clone(), "__context__") {
             if !vm.get_none().is(&context) {
                 print_exception(vm, &context);

--- a/vm/src/frame.rs
+++ b/vm/src/frame.rs
@@ -715,14 +715,20 @@ impl Frame {
                 Ok(None)
             }
 
-            bytecode::Instruction::Raise { argc } => {
+            bytecode::Instruction::Raise { argc, in_exc } => {
+                if argc.clone() == 0 && in_exc.clone() == false {
+                    return Err(vm.new_exception(
+                        vm.ctx.exceptions.runtime_error.clone(),
+                        "No active exception to reraise".to_string(),
+                    ));
+                }
                 let cause = match argc {
                     2 => self.get_exception(vm, true)?,
                     _ => vm.get_none(),
                 };
                 let exception = match argc {
-                    1 | 2 => self.get_exception(vm, false)?,
-                    0 | 3 => panic!("Not implemented!"),
+                    0 | 1 | 2 => self.get_exception(vm, false)?,
+                    3 => panic!("Not implemented!"),
                     _ => panic!("Invalid parameter for RAISE_VARARGS, must be between 0 to 3"),
                 };
                 info!("Exception raised: {:?} with cause: {:?}", exception, cause);


### PR DESCRIPTION
This PR add support for reraise:
```py
>>>>> try:
.....     raise NameError
..... except:
.....     raise
..... 
Traceback (most recent call last):
  File <stdin>, line 4, in <module>
  File <stdin>, line 2, in <module>
NameError: No msg
```

And exception context:
```py
>>>>> try:
.....     raise ZeroDivisionError
..... except ZeroDivisionError as ex:
.....     raise NameError
..... 
Traceback (most recent call last):
  File <stdin>, line 2, in <module>
ZeroDivisionError: No msg

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File <stdin>, line 4, in <module>
NameError: No msg
```