### PR TITLE
Add bytes.count and bytes.join

### DIFF
--- a/tests/snippets/bytes.py
+++ b/tests/snippets/bytes.py
@@ -158,6 +158,7 @@ with assertRaises(TypeError):
 with assertRaises(TypeError):
     b"b".center(2, b"ba")
 b"kok".center(5, bytearray(b"x"))
+b"kok".center(-5,)
 
 # count
 assert b"azeazerazeazopia".count(b"aze") == 3
@@ -177,6 +178,7 @@ assert b"azeazerazeazopia".count(b"aze", -13, -10) == 1
 assert b"azeazerazeazopia".count(b"aze", 1, 10000) == 2
 with assertRaises(ValueError):
     b"ilj".count(3550)
+assert b"azeazerazeazopia".count(97) == 5
 
 # join
 assert (

--- a/tests/snippets/bytes.py
+++ b/tests/snippets/bytes.py
@@ -158,3 +158,11 @@ with assertRaises(TypeError):
 with assertRaises(TypeError):
     b"b".center(2, b"ba")
 b"kok".center(5, bytearray(b"x"))
+
+# count
+assert b"azeazerazeazopia".count(b"aze") == 3
+assert b"azeazerazeazopia".count(b"az") == 4
+assert b"azeazerazeazopia".count(b"a") == 5
+assert b"123456789".count(b"") == 10
+assert b"azeazerazeazopia".count(bytearray(b"aze")) == 3
+assert b"azeazerazeazopia".count(memoryview(b"aze")) == 3

--- a/tests/snippets/bytes.py
+++ b/tests/snippets/bytes.py
@@ -166,3 +166,14 @@ assert b"azeazerazeazopia".count(b"a") == 5
 assert b"123456789".count(b"") == 10
 assert b"azeazerazeazopia".count(bytearray(b"aze")) == 3
 assert b"azeazerazeazopia".count(memoryview(b"aze")) == 3
+assert b"azeazerazeazopia".count(memoryview(b"aze"),1,9 ) == 1
+assert b"azeazerazeazopia".count(b"aze", None, None) == 3
+assert b"azeazerazeazopia".count(b"aze", 2, None) == 2
+assert b"azeazerazeazopia".count(b"aze", 2) == 2
+assert b"azeazerazeazopia".count(b"aze", None, 7) == 2
+assert b"azeazerazeazopia".count(b"aze", None, 7) == 2
+assert b"azeazerazeazopia".count(b"aze", 2, 7) == 1
+assert b"azeazerazeazopia".count(b"aze", -13, -10) == 1
+assert b"azeazerazeazopia".count(b"aze", 1, 10000) == 2
+with assertRaises(ValueError):
+    b"ilj".count(355)

--- a/tests/snippets/bytes.py
+++ b/tests/snippets/bytes.py
@@ -166,7 +166,7 @@ assert b"azeazerazeazopia".count(b"a") == 5
 assert b"123456789".count(b"") == 10
 assert b"azeazerazeazopia".count(bytearray(b"aze")) == 3
 assert b"azeazerazeazopia".count(memoryview(b"aze")) == 3
-assert b"azeazerazeazopia".count(memoryview(b"aze"),1,9 ) == 1
+assert b"azeazerazeazopia".count(memoryview(b"aze"), 1, 9) == 1
 assert b"azeazerazeazopia".count(b"aze", None, None) == 3
 assert b"azeazerazeazopia".count(b"aze", 2, None) == 2
 assert b"azeazerazeazopia".count(b"aze", 2) == 2
@@ -176,4 +176,12 @@ assert b"azeazerazeazopia".count(b"aze", 2, 7) == 1
 assert b"azeazerazeazopia".count(b"aze", -13, -10) == 1
 assert b"azeazerazeazopia".count(b"aze", 1, 10000) == 2
 with assertRaises(ValueError):
-    b"ilj".count(355)
+    b"ilj".count(3550)
+
+# join
+assert (
+    b"".join((b"jiljl", bytearray(b"kmoomk"), memoryview(b"aaaa")))
+    == b"jiljlkmoomkaaaa"
+)
+with assertRaises(TypeError):
+    b"".join((b"km", "kl"))

--- a/vm/src/obj/objbyteinner.rs
+++ b/vm/src/obj/objbyteinner.rs
@@ -363,12 +363,45 @@ impl PyByteInner {
             .collect::<Vec<u8>>())
     }
 
-    pub fn center(&self, width: &BigInt, fillbyte: u8, _vm: &VirtualMachine) -> Vec<u8> {
-        let width = width.to_usize().unwrap();
+    pub fn center(&self, width_a: PyObjectRef, fillbyte: OptionalArg<PyObjectRef>, vm: &VirtualMachine) -> PyResult<Vec<u8>> {
+        let fillbyte = if let OptionalArg::Present(v) = fillbyte {
+            match try_as_byte(&v) {
+                Some(x) => {
+                    if x.len() == 1 {
+                        x[0]
+                    } else {
+                        return Err(vm.new_type_error(format!(
+                            "center() argument 2 must be a byte string of length 1, not {}",
+                            &v
+                        )));
+                    }
+                }
+                None => {
+                    return Err(vm.new_type_error(format!(
+                        "center() argument 2 must be a byte string of length 1, not {}",
+                        &v
+                    )));
+                }
+            }
+        } else {
+            32 // default is space
+        };
+
+        let width_b  = match_class!(width_a,
+        i @PyInt => i,
+        obj => {return Err(vm.new_type_error(format!("{} cannot be interpreted as an integer", obj)));}
+        );
+
+
+        // <0 = no change
+        let width = if let Some(x) = width_b.as_bigint().to_usize() {
+            x
+        } else {return Ok(self.elements.clone());};
+        
 
         // adjust right et left side
         if width <= self.len() {
-            return self.elements.clone();
+            return Ok(self.elements.clone());
         }
         let diff: usize = width - self.len();
         let mut ln: usize = diff / 2;
@@ -387,16 +420,23 @@ impl PyByteInner {
         res.extend_from_slice(&self.elements[..]);
         res.extend_from_slice(&vec![fillbyte; rn][..]);
 
-        res
+        Ok(res)
     }
 
     pub fn count(
         &self,
-        sub: Vec<u8>,
+        sub: PyObjectRef,
         start: OptionalArg<PyObjectRef>,
         end: OptionalArg<PyObjectRef>,
         vm: &VirtualMachine,
-    ) -> Result<usize, PyObjectRef> {
+    ) -> PyResult<usize> {
+        let sub = match try_as_bytes_like(&sub) {
+            Some(value) => value,
+            None => match_class!(sub,
+                i @ PyInt => 
+                    vec![i.as_bigint().byte_or(vm)?],
+                obj => {return Err(vm.new_type_error(format!("argument should be integer or bytes-like object, not {}", obj)));}),
+        };
         let start = if let OptionalArg::Present(st) = start {
             match_class!(st,
             i @ PyInt => {Some(i.as_bigint().clone())},
@@ -442,7 +482,7 @@ impl PyByteInner {
         let mut refs = vec![];
         for (index, v) in iter.iter(vm)?.enumerate() {
             let v = v?;
-            match is_bytes_like(&v) {
+            match try_as_bytes_like(&v) {
                 None => {
                     return Err(vm.new_type_error(format!(
                         "sequence item {}: expected a bytes-like object, {} found",
@@ -458,7 +498,7 @@ impl PyByteInner {
     }
 }
 
-pub fn is_byte(obj: &PyObjectRef) -> Option<Vec<u8>> {
+pub fn try_as_byte(obj: &PyObjectRef) -> Option<Vec<u8>> {
     match_class!(obj.clone(),
 
     i @ PyBytes => Some(i.get_value().to_vec()),
@@ -466,7 +506,7 @@ pub fn is_byte(obj: &PyObjectRef) -> Option<Vec<u8>> {
     _ => None)
 }
 
-pub fn is_bytes_like(obj: &PyObjectRef) -> Option<Vec<u8>> {
+pub fn try_as_bytes_like(obj: &PyObjectRef) -> Option<Vec<u8>> {
     match_class!(obj.clone(),
 
     i @ PyBytes => Some(i.get_value().to_vec()),
@@ -475,8 +515,8 @@ pub fn is_bytes_like(obj: &PyObjectRef) -> Option<Vec<u8>> {
     _ => None)
 }
 
-pub trait IsByte: ToPrimitive {
-    fn is_byte(&self, vm: &VirtualMachine) -> Result<u8, PyObjectRef> {
+pub trait ByteOr: ToPrimitive {
+    fn byte_or(&self, vm: &VirtualMachine) -> Result<u8, PyObjectRef> {
         match self.to_u8() {
             Some(value) => Ok(value),
             None => Err(vm.new_value_error("byte must be in range(0, 256)".to_string())),
@@ -484,4 +524,4 @@ pub trait IsByte: ToPrimitive {
     }
 }
 
-impl IsByte for BigInt {}
+impl ByteOr for BigInt {}

--- a/vm/src/obj/objbyteinner.rs
+++ b/vm/src/obj/objbyteinner.rs
@@ -20,6 +20,7 @@ use num_traits::ToPrimitive;
 use super::objbytearray::{get_value as get_value_bytearray, PyByteArray};
 use super::objbytes::PyBytes;
 use super::objmemory::PyMemoryView;
+use super::objnone::PyNone;
 
 #[derive(Debug, Default, Clone)]
 pub struct PyByteInner {
@@ -389,21 +390,52 @@ impl PyByteInner {
         res
     }
 
-    pub fn count(&self, sub: Vec<u8>) -> usize {
+    pub fn count(
+        &self,
+        sub: Vec<u8>,
+        start: OptionalArg<PyObjectRef>,
+        end: OptionalArg<PyObjectRef>,
+        vm: &VirtualMachine,
+    ) -> Result<usize, PyObjectRef> {
+        let start = if let OptionalArg::Present(st) = start {
+            match_class!(st,
+            i @ PyInt => {Some(i.as_bigint().clone())},
+            _obj @ PyNone => None,
+            _=> {return Err(vm.new_type_error("slice indices must be integers or None or have an __index__ method".to_string()));}
+            )
+        } else {
+            None
+        };
+        let end = if let OptionalArg::Present(e) = end {
+            match_class!(e,
+            i @ PyInt => {Some(i.as_bigint().clone())},
+            _obj @ PyNone => None,
+            _=> {return Err(vm.new_type_error("slice indices must be integers or None or have an __index__ method".to_string()));}
+            )
+        } else {
+            None
+        };
+
+        let range = self.elements.get_slice_range(&start, &end);
+
         if sub.is_empty() {
-            return self.len() + 1;
+            return Ok(self.len() + 1);
         }
 
         let mut total: usize = 0;
-        for (n, i) in self.elements.iter().enumerate() {
-            if n + sub.len() <= self.len()
-                && *i == sub[0]
-                && &self.elements[n..n + sub.len()] == sub.as_slice()
+        let mut i_start = range.start;
+        let i_end = range.end;
+
+        for i in self.elements.do_slice(range) {
+            if i_start + sub.len() <= i_end
+                && i == sub[0]
+                && &self.elements[i_start..(i_start + sub.len())] == sub.as_slice()
             {
                 total += 1;
             }
+            i_start += 1;
         }
-        total
+        Ok(total)
     }
 }
 
@@ -423,3 +455,14 @@ pub fn is_bytes_like(obj: &PyObjectRef) -> Option<Vec<u8>> {
     k @ PyMemoryView => Some(k.get_obj_value().unwrap()),
     _ => None)
 }
+
+pub trait IsByte: ToPrimitive {
+    fn is_byte(&self, vm: &VirtualMachine) -> Result<u8, PyObjectRef> {
+        match self.to_u8() {
+            Some(value) => Ok(value),
+            None => Err(vm.new_value_error("byte must be in range(0, 256)".to_string())),
+        }
+    }
+}
+
+impl IsByte for BigInt {}

--- a/vm/src/obj/objbyteinner.rs
+++ b/vm/src/obj/objbyteinner.rs
@@ -1,4 +1,4 @@
-use crate::pyobject::PyObjectRef;
+use crate::pyobject::{PyIterable, PyObjectRef};
 use num_bigint::BigInt;
 
 use crate::function::OptionalArg;
@@ -436,6 +436,25 @@ impl PyByteInner {
             i_start += 1;
         }
         Ok(total)
+    }
+
+    pub fn join(&self, iter: PyIterable, vm: &VirtualMachine) -> PyResult {
+        let mut refs = vec![];
+        for (index, v) in iter.iter(vm)?.enumerate() {
+            let v = v?;
+            match is_bytes_like(&v) {
+                None => {
+                    return Err(vm.new_type_error(format!(
+                        "sequence item {}: expected a bytes-like object, {} found",
+                        index,
+                        &v.class().name,
+                    )));
+                }
+                Some(value) => refs.extend(value),
+            }
+        }
+
+        Ok(vm.ctx.new_bytes(refs))
     }
 }
 

--- a/vm/src/obj/objbyteinner.rs
+++ b/vm/src/obj/objbyteinner.rs
@@ -363,7 +363,12 @@ impl PyByteInner {
             .collect::<Vec<u8>>())
     }
 
-    pub fn center(&self, width_a: PyObjectRef, fillbyte: OptionalArg<PyObjectRef>, vm: &VirtualMachine) -> PyResult<Vec<u8>> {
+    pub fn center(
+        &self,
+        width_a: PyObjectRef,
+        fillbyte: OptionalArg<PyObjectRef>,
+        vm: &VirtualMachine,
+    ) -> PyResult<Vec<u8>> {
         let fillbyte = if let OptionalArg::Present(v) = fillbyte {
             match try_as_byte(&v) {
                 Some(x) => {
@@ -387,17 +392,17 @@ impl PyByteInner {
             32 // default is space
         };
 
-        let width_b  = match_class!(width_a,
-        i @PyInt => i,
-        obj => {return Err(vm.new_type_error(format!("{} cannot be interpreted as an integer", obj)));}
+        let width_b = match_class!(width_a,
+            i @PyInt => i,
+            obj => {return Err(vm.new_type_error(format!("{} cannot be interpreted as an integer", obj)));}
         );
-
 
         // <0 = no change
         let width = if let Some(x) = width_b.as_bigint().to_usize() {
             x
-        } else {return Ok(self.elements.clone());};
-        
+        } else {
+            return Ok(self.elements.clone());
+        };
 
         // adjust right et left side
         if width <= self.len() {
@@ -433,8 +438,7 @@ impl PyByteInner {
         let sub = match try_as_bytes_like(&sub) {
             Some(value) => value,
             None => match_class!(sub,
-                i @ PyInt => 
-                    vec![i.as_bigint().byte_or(vm)?],
+                i @ PyInt => vec![i.as_bigint().byte_or(vm)?],
                 obj => {return Err(vm.new_type_error(format!("argument should be integer or bytes-like object, not {}", obj)));}),
         };
         let start = if let OptionalArg::Present(st) = start {

--- a/vm/src/obj/objbyteinner.rs
+++ b/vm/src/obj/objbyteinner.rs
@@ -19,6 +19,7 @@ use num_traits::ToPrimitive;
 
 use super::objbytearray::{get_value as get_value_bytearray, PyByteArray};
 use super::objbytes::PyBytes;
+use super::objmemory::PyMemoryView;
 
 #[derive(Debug, Default, Clone)]
 pub struct PyByteInner {
@@ -387,6 +388,23 @@ impl PyByteInner {
 
         res
     }
+
+    pub fn count(&self, sub: Vec<u8>) -> usize {
+        if sub.is_empty() {
+            return self.len() + 1;
+        }
+
+        let mut total: usize = 0;
+        for (n, i) in self.elements.iter().enumerate() {
+            if n + sub.len() <= self.len()
+                && *i == sub[0]
+                && &self.elements[n..n + sub.len()] == sub.as_slice()
+            {
+                total += 1;
+            }
+        }
+        total
+    }
 }
 
 pub fn is_byte(obj: &PyObjectRef) -> Option<Vec<u8>> {
@@ -394,5 +412,14 @@ pub fn is_byte(obj: &PyObjectRef) -> Option<Vec<u8>> {
 
     i @ PyBytes => Some(i.get_value().to_vec()),
     j @ PyByteArray => Some(get_value_bytearray(&j.as_object()).to_vec()),
+    _ => None)
+}
+
+pub fn is_bytes_like(obj: &PyObjectRef) -> Option<Vec<u8>> {
+    match_class!(obj.clone(),
+
+    i @ PyBytes => Some(i.get_value().to_vec()),
+    j @ PyByteArray => Some(get_value_bytearray(&j.as_object()).to_vec()),
+    k @ PyMemoryView => Some(k.get_obj_value().unwrap()),
     _ => None)
 }

--- a/vm/src/obj/objbytes.rs
+++ b/vm/src/obj/objbytes.rs
@@ -5,13 +5,12 @@ use core::cell::Cell;
 use std::ops::Deref;
 
 use crate::function::OptionalArg;
-use crate::pyobject::{PyClassImpl, PyContext, PyObjectRef, PyRef, PyResult, PyValue};
+use crate::pyobject::{PyClassImpl, PyContext, PyIterable, PyObjectRef, PyRef, PyResult, PyValue};
 
 use super::objbyteinner::{is_byte, is_bytes_like, IsByte, PyByteInner};
 use super::objiter;
 use super::objslice::PySlice;
 use super::objtype::PyClassRef;
-
 /// "bytes(iterable_of_ints) -> bytes\n\
 /// bytes(string, encoding[, errors]) -> bytes\n\
 /// bytes(bytes_or_buffer) -> immutable copy of bytes_or_buffer\n\
@@ -285,6 +284,11 @@ impl PyBytesRef {
                     Ok(vm.new_int(self.inner.count(vec![i.as_bigint().is_byte(vm)?], start, end, vm)?))},
                 obj => {Err(vm.new_type_error(format!("argument should be integer or bytes-like object, not {}", obj)))}),
         }
+    }
+
+    #[pymethod(name = "join")]
+    fn join(self, iter: PyIterable, vm: &VirtualMachine) -> PyResult {
+        self.inner.join(iter, vm)
     }
 }
 

--- a/vm/src/obj/objbytes.rs
+++ b/vm/src/obj/objbytes.rs
@@ -7,7 +7,7 @@ use std::ops::Deref;
 use crate::function::OptionalArg;
 use crate::pyobject::{PyClassImpl, PyContext, PyObjectRef, PyRef, PyResult, PyValue};
 
-use super::objbyteinner::{is_byte, PyByteInner};
+use super::objbyteinner::{is_byte, is_bytes_like, PyByteInner};
 use super::objiter;
 use super::objslice::PySlice;
 use super::objtype::PyClassRef;
@@ -268,6 +268,16 @@ impl PyBytesRef {
         i @PyInt => Ok(vm.ctx.new_bytes(self.inner.center(i.as_bigint(), sym, vm))),
         obj => {Err(vm.new_type_error(format!("{} cannot be interpreted as an integer", obj)))}
         )
+    }
+
+    #[pymethod(name = "count")]
+    fn count(self, width: PyObjectRef, vm: &VirtualMachine) -> PyResult {
+        match is_bytes_like(&width) {
+            Some(value) => Ok(vm.new_int(self.inner.count(value))),
+            None => {
+                Err(vm.new_type_error(format!("a bytes-like object is required, not {}", width)))
+            }
+        }
     }
 }
 

--- a/vm/src/obj/objbytes.rs
+++ b/vm/src/obj/objbytes.rs
@@ -283,7 +283,7 @@ impl PyBytesRef {
             None => match_class!(sub,
                 i @ PyInt => {
                     Ok(vm.new_int(self.inner.count(vec![i.as_bigint().is_byte(vm)?], start, end, vm)?))},
-                obj => {Err(vm.new_type_error(format!("a bytes-like object is required, not {}", obj)))}),
+                obj => {Err(vm.new_type_error(format!("argument should be integer or bytes-like object, not {}", obj)))}),
         }
     }
 }

--- a/vm/src/obj/objmemory.rs
+++ b/vm/src/obj/objmemory.rs
@@ -1,4 +1,4 @@
-use crate::obj::objbyteinner::is_byte;
+use crate::obj::objbyteinner::try_as_byte;
 use crate::obj::objtype::PyClassRef;
 use crate::pyobject::{PyContext, PyObjectRef, PyRef, PyResult, PyValue};
 use crate::vm::VirtualMachine;
@@ -12,7 +12,7 @@ pub struct PyMemoryView {
 
 impl PyMemoryView {
     pub fn get_obj_value(&self) -> Option<Vec<u8>> {
-        is_byte(&self.obj)
+        try_as_byte(&self.obj)
     }
 }
 

--- a/vm/src/obj/objmemory.rs
+++ b/vm/src/obj/objmemory.rs
@@ -1,3 +1,4 @@
+use crate::obj::objbyteinner::is_byte;
 use crate::obj::objtype::PyClassRef;
 use crate::pyobject::{PyContext, PyObjectRef, PyRef, PyResult, PyValue};
 use crate::vm::VirtualMachine;
@@ -7,6 +8,12 @@ pub type PyMemoryViewRef = PyRef<PyMemoryView>;
 #[derive(Debug)]
 pub struct PyMemoryView {
     obj: PyObjectRef,
+}
+
+impl PyMemoryView {
+    pub fn get_obj_value(&self) -> Option<Vec<u8>> {
+        is_byte(&self.obj)
+    }
 }
 
 impl PyValue for PyMemoryView {


### PR DESCRIPTION
-  add bytes.count
- add IsByte trait to BigInt to always return error if not an u8 : If you are ok with this, I could modify some more things to use it.
- add is_bytes_like : reusable function to check for a "python" bytes like object.
TODO : check if slice argument is an object with a  `__index__` method. I don't know how to do it, need some indication.
- add bytes.join