### PR TITLE
Make macros comply fully with Rust 2018

### DIFF
--- a/vm/src/macros.rs
+++ b/vm/src/macros.rs
@@ -9,7 +9,7 @@ macro_rules! replace_expr {
 
 #[macro_export]
 macro_rules! count_tts {
-    ($($tts:tt)*) => {0usize $(+ replace_expr!($tts 1usize))*};
+    ($($tts:tt)*) => {0usize $(+ $crate::replace_expr!($tts 1usize))*};
 }
 
 #[macro_export]
@@ -45,14 +45,14 @@ macro_rules! arg_check {
         }
     };
     ( $vm: ident, $args:ident, required=[$( ($arg_name:ident, $arg_type:expr) ),*] ) => {
-        arg_check!($vm, $args, required=[$( ($arg_name, $arg_type) ),*], optional=[]);
+        $crate::arg_check!($vm, $args, required=[$( ($arg_name, $arg_type) ),*], optional=[]);
     };
     ( $vm: ident, $args:ident, required=[$( ($arg_name:ident, $arg_type:expr) ),*], optional=[$( ($optional_arg_name:ident, $optional_arg_type:expr) ),*] ) => {
         let mut arg_count = 0;
 
         // use macro magic to compile-time count number of required and optional arguments
-        let minimum_arg_count = count_tts!($($arg_name)*);
-        let maximum_arg_count = minimum_arg_count + count_tts!($($optional_arg_name)*);
+        let minimum_arg_count = $crate::count_tts!($($arg_name)*);
+        let maximum_arg_count = minimum_arg_count + $crate::count_tts!($($optional_arg_name)*);
 
         // verify that the number of given arguments is right
         if $args.args.len() < minimum_arg_count || $args.args.len() > maximum_arg_count {
@@ -72,7 +72,7 @@ macro_rules! arg_check {
         //  check if the type matches. If not, return with error
         //  assign the arg to a variable
         $(
-            type_check!($vm, $args, arg_count, $arg_name, $arg_type);
+            $crate::type_check!($vm, $args, arg_count, $arg_name, $arg_type);
             let $arg_name = &$args.args[arg_count];
             #[allow(unused_assignments)]
             {
@@ -85,7 +85,7 @@ macro_rules! arg_check {
         //  assign the arg to a variable
         $(
             let $optional_arg_name = if arg_count < $args.args.len() {
-                type_check!($vm, $args, arg_count, $optional_arg_name, $optional_arg_type);
+                $crate::type_check!($vm, $args, arg_count, $optional_arg_name, $optional_arg_type);
                 let ret = Some(&$args.args[arg_count]);
                 #[allow(unused_assignments)]
                 {
@@ -226,7 +226,7 @@ macro_rules! match_class {
     ($obj:expr, $binding:ident @ $class:ty => $expr:expr, $($rest:tt)*) => {
         match $obj.downcast::<$class>() {
             Ok($binding) => $expr,
-            Err(_obj) => match_class!(_obj, $($rest)*),
+            Err(_obj) => $crate::match_class!(_obj, $($rest)*),
         }
     };
 
@@ -236,7 +236,7 @@ macro_rules! match_class {
         if $obj.payload_is::<$class>() {
             $expr
         } else {
-            match_class!($obj, $($rest)*)
+            $crate::match_class!($obj, $($rest)*)
         }
     };
 }

--- a/vm/src/macros.rs
+++ b/vm/src/macros.rs
@@ -20,6 +20,8 @@ macro_rules! type_check {
             let arg = &$args.args[$arg_count];
 
             if !$crate::obj::objtype::isinstance(arg, &expected_type) {
+                use $crate::pyobject::TypeProtocol;
+
                 let arg_typ = arg.class();
                 let expected_type_name = $vm.to_pystr(&expected_type)?;
                 let actual_type = $vm.to_pystr(&arg_typ)?;

--- a/vm/src/obj/objbool.rs
+++ b/vm/src/obj/objbool.rs
@@ -1,9 +1,7 @@
 use num_traits::Zero;
 
 use crate::function::PyFuncArgs;
-use crate::pyobject::{
-    IntoPyObject, PyContext, PyObjectRef, PyResult, TryFromObject, TypeProtocol,
-};
+use crate::pyobject::{IntoPyObject, PyContext, PyObjectRef, PyResult, TryFromObject};
 use crate::vm::VirtualMachine;
 
 use super::objint::PyInt;

--- a/vm/src/obj/objellipsis.rs
+++ b/vm/src/obj/objellipsis.rs
@@ -1,5 +1,5 @@
 use crate::function::PyFuncArgs;
-use crate::pyobject::{PyContext, PyResult, TypeProtocol};
+use crate::pyobject::{PyContext, PyResult};
 use crate::vm::VirtualMachine;
 
 pub fn init(context: &PyContext) {

--- a/vm/src/obj/objlist.rs
+++ b/vm/src/obj/objlist.rs
@@ -9,7 +9,6 @@ use num_traits::{One, Signed, ToPrimitive, Zero};
 use crate::function::{OptionalArg, PyFuncArgs};
 use crate::pyobject::{
     IdProtocol, PyContext, PyIterable, PyObjectRef, PyRef, PyResult, PyValue, TryFromObject,
-    TypeProtocol,
 };
 use crate::vm::{ReprGuard, VirtualMachine};
 

--- a/vm/src/obj/objslice.rs
+++ b/vm/src/obj/objslice.rs
@@ -1,7 +1,7 @@
 use num_bigint::BigInt;
 
 use crate::function::PyFuncArgs;
-use crate::pyobject::{PyContext, PyObjectRef, PyRef, PyResult, PyValue, TypeProtocol};
+use crate::pyobject::{PyContext, PyObjectRef, PyRef, PyResult, PyValue};
 use crate::vm::VirtualMachine;
 
 use super::objint;

--- a/vm/src/stdlib/io.rs
+++ b/vm/src/stdlib/io.rs
@@ -20,7 +20,7 @@ use crate::obj::objbytes;
 use crate::obj::objint;
 use crate::obj::objstr;
 use crate::obj::objtype::PyClassRef;
-use crate::pyobject::{BufferProtocol, PyObjectRef, PyRef, PyResult, PyValue, TypeProtocol};
+use crate::pyobject::{BufferProtocol, PyObjectRef, PyRef, PyResult, PyValue};
 use crate::vm::VirtualMachine;
 
 fn compute_c_flag(mode: &str) -> u16 {

--- a/vm/src/stdlib/keyword.rs
+++ b/vm/src/stdlib/keyword.rs
@@ -6,7 +6,7 @@ use rustpython_parser::lexer;
 
 use crate::function::PyFuncArgs;
 use crate::obj::objstr;
-use crate::pyobject::{PyObjectRef, PyResult, TypeProtocol};
+use crate::pyobject::{PyObjectRef, PyResult};
 use crate::vm::VirtualMachine;
 
 fn keyword_iskeyword(vm: &VirtualMachine, args: PyFuncArgs) -> PyResult {

--- a/vm/src/stdlib/math.rs
+++ b/vm/src/stdlib/math.rs
@@ -8,7 +8,7 @@ use statrs::function::gamma::{gamma, ln_gamma};
 
 use crate::function::PyFuncArgs;
 use crate::obj::objfloat;
-use crate::pyobject::{PyObjectRef, PyResult, TypeProtocol};
+use crate::pyobject::{PyObjectRef, PyResult};
 use crate::vm::VirtualMachine;
 
 // Helper macro:

--- a/vm/src/stdlib/os.rs
+++ b/vm/src/stdlib/os.rs
@@ -12,7 +12,7 @@ use crate::obj::objint;
 use crate::obj::objint::PyIntRef;
 use crate::obj::objstr;
 use crate::obj::objstr::PyStringRef;
-use crate::pyobject::{ItemProtocol, PyObjectRef, PyResult, TypeProtocol};
+use crate::pyobject::{ItemProtocol, PyObjectRef, PyResult};
 use crate::vm::VirtualMachine;
 
 #[cfg(unix)]

--- a/vm/src/stdlib/pystruct.rs
+++ b/vm/src/stdlib/pystruct.rs
@@ -15,7 +15,7 @@ use num_traits::ToPrimitive;
 
 use crate::function::PyFuncArgs;
 use crate::obj::{objbool, objbytes, objfloat, objint, objstr, objtype};
-use crate::pyobject::{PyObjectRef, PyResult, TypeProtocol};
+use crate::pyobject::{PyObjectRef, PyResult};
 use crate::VirtualMachine;
 
 #[derive(Debug)]

--- a/vm/src/stdlib/random.rs
+++ b/vm/src/stdlib/random.rs
@@ -4,7 +4,7 @@ use rand::distributions::{Distribution, Normal};
 
 use crate::function::PyFuncArgs;
 use crate::obj::objfloat;
-use crate::pyobject::{PyObjectRef, PyResult, TypeProtocol};
+use crate::pyobject::{PyObjectRef, PyResult};
 use crate::vm::VirtualMachine;
 
 pub fn make_module(vm: &VirtualMachine) -> PyObjectRef {

--- a/vm/src/stdlib/socket.rs
+++ b/vm/src/stdlib/socket.rs
@@ -10,7 +10,7 @@ use crate::obj::objbytes;
 use crate::obj::objint;
 use crate::obj::objsequence::get_elements;
 use crate::obj::objstr;
-use crate::pyobject::{PyObjectRef, PyRef, PyResult, PyValue, TryFromObject, TypeProtocol};
+use crate::pyobject::{PyObjectRef, PyRef, PyResult, PyValue, TryFromObject};
 use crate::vm::VirtualMachine;
 
 use crate::obj::objtype::PyClassRef;

--- a/vm/src/stdlib/time_module.rs
+++ b/vm/src/stdlib/time_module.rs
@@ -5,7 +5,7 @@ use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
 use crate::function::PyFuncArgs;
 use crate::obj::objfloat;
-use crate::pyobject::{PyObjectRef, PyResult, TypeProtocol};
+use crate::pyobject::{PyObjectRef, PyResult};
 use crate::vm::VirtualMachine;
 
 fn time_sleep(vm: &VirtualMachine, args: PyFuncArgs) -> PyResult {

--- a/vm/src/stdlib/tokenize.rs
+++ b/vm/src/stdlib/tokenize.rs
@@ -8,7 +8,7 @@ use rustpython_parser::lexer;
 
 use crate::function::PyFuncArgs;
 use crate::obj::objstr;
-use crate::pyobject::{PyObjectRef, PyResult, TypeProtocol};
+use crate::pyobject::{PyObjectRef, PyResult};
 use crate::vm::VirtualMachine;
 
 fn tokenize_tokenize(vm: &VirtualMachine, args: PyFuncArgs) -> PyResult {

--- a/vm/src/sysmodule.rs
+++ b/vm/src/sysmodule.rs
@@ -4,7 +4,7 @@ use std::{env, mem};
 use crate::frame::FrameRef;
 use crate::function::{OptionalArg, PyFuncArgs};
 use crate::obj::objstr::PyStringRef;
-use crate::pyobject::{ItemProtocol, PyContext, PyObjectRef, PyResult, TypeProtocol};
+use crate::pyobject::{ItemProtocol, PyContext, PyObjectRef, PyResult};
 use crate::vm::VirtualMachine;
 
 /*


### PR DESCRIPTION
These changes make it possible to successfully call the exported macros from outside the `rustpython_vm` crate.