### PR TITLE
Fix os.unsetenv test for windows

### DIFF
--- a/tests/snippets/stdlib_os.py
+++ b/tests/snippets/stdlib_os.py
@@ -55,7 +55,6 @@ assert ENV_KEY not in os.environ
 assert os.getenv(ENV_KEY) == None
 
 if os.name == "posix":
-	os.environ[ENV_KEY] = ENV_VALUE
+	os.putenv(ENV_KEY, ENV_VALUE)
 	os.unsetenv(ENV_KEY)
-	assert ENV_KEY not in os.environ
 	assert os.getenv(ENV_KEY) == None

--- a/tests/snippets/stdlib_os.py
+++ b/tests/snippets/stdlib_os.py
@@ -51,6 +51,11 @@ os.environ[ENV_KEY] = ENV_VALUE
 assert ENV_KEY in os.environ
 assert os.getenv(ENV_KEY) == ENV_VALUE
 del os.environ[ENV_KEY]
-os.unsetenv(ENV_KEY)
 assert ENV_KEY not in os.environ
 assert os.getenv(ENV_KEY) == None
+
+if os.name == "posix":
+	os.environ[ENV_KEY] = ENV_VALUE
+	os.unsetenv(ENV_KEY)
+	assert ENV_KEY not in os.environ
+	assert os.getenv(ENV_KEY) == None


### PR DESCRIPTION
Should we add a `cfg` to not put `unsetenv` into `os` if on Windows?