### PR TITLE
Add os.scandir

### DIFF
--- a/tests/snippets/stdlib_os.py
+++ b/tests/snippets/stdlib_os.py
@@ -85,12 +85,16 @@ with TestWithTempDir() as tmpdir:
 	names = set()
 	paths = set()
 	dirs = set()
+	files = set()
 	for dir_entry in os.scandir(tmpdir):
 		names.add(dir_entry.name)
 		paths.add(dir_entry.path)
 		if dir_entry.is_dir():
 			dirs.add(dir_entry.name)
+		if dir_entry.is_file():
+			files.add(dir_entry.name)
 
 	assert names == set([FILE_NAME, FILE_NAME2, FOLDER])
 	assert paths == set([fname, fname2, folder])
 	assert dirs == set([FOLDER])
+	assert files == set([FILE_NAME, FILE_NAME2])

--- a/tests/snippets/stdlib_os.py
+++ b/tests/snippets/stdlib_os.py
@@ -57,6 +57,7 @@ class TestWithTempDir():
 
 FILE_NAME = "test1"
 FILE_NAME2 = "test2"
+FOLDER = "dir1"
 CONTENT = b"testing"
 CONTENT2 = b"rustpython"
 CONTENT3 = b"BOYA"
@@ -75,15 +76,21 @@ with TestWithTempDir() as tmpdir:
 	assert os.read(fd, len(CONTENT3)) == CONTENT3
 	os.close(fd)
 
-
 	fname2 = tmpdir + os.sep + FILE_NAME2
 	with open(fname2, "wb"):
 		pass
-	files = set()
-	paths = set()
-	for dir_entry in os.scandir(tmpdir):
-		files.add(dir_entry.name)
-		paths.add(dir_entry.path)
+	folder = tmpdir + os.sep + FOLDER
+	os.mkdir(folder)
 
-	assert files == set([FILE_NAME, FILE_NAME2])
-	assert paths == set([fname, fname2])
+	names = set()
+	paths = set()
+	dirs = set()
+	for dir_entry in os.scandir(tmpdir):
+		names.add(dir_entry.name)
+		paths.add(dir_entry.path)
+		if dir_entry.is_dir():
+			dirs.add(dir_entry.name)
+
+	assert names == set([FILE_NAME, FILE_NAME2, FOLDER])
+	assert paths == set([fname, fname2, folder])
+	assert dirs == set([FOLDER])

--- a/tests/snippets/stdlib_os.py
+++ b/tests/snippets/stdlib_os.py
@@ -56,6 +56,7 @@ class TestWithTempDir():
 
 
 FILE_NAME = "test1"
+FILE_NAME2 = "test2"
 CONTENT = b"testing"
 CONTENT2 = b"rustpython"
 CONTENT3 = b"BOYA"
@@ -73,3 +74,16 @@ with TestWithTempDir() as tmpdir:
 	assert os.read(fd, len(CONTENT2)) == CONTENT2
 	assert os.read(fd, len(CONTENT3)) == CONTENT3
 	os.close(fd)
+
+
+	fname2 = tmpdir + os.sep + FILE_NAME2
+	with open(fname2, "wb"):
+		pass
+	files = set()
+	paths = set()
+	for dir_entry in os.scandir(tmpdir):
+		files.add(dir_entry.name)
+		paths.add(dir_entry.path)
+
+	assert files == set([FILE_NAME, FILE_NAME2])
+	assert paths == set([fname, fname2])

--- a/vm/src/stdlib/os.rs
+++ b/vm/src/stdlib/os.rs
@@ -222,6 +222,14 @@ impl DirEntryRef {
             .map_err(|s| vm.new_os_error(s.to_string()))?
             .is_dir())
     }
+
+    fn is_file(self, vm: &VirtualMachine) -> PyResult<bool> {
+        Ok(self
+            .entry
+            .file_type()
+            .map_err(|s| vm.new_os_error(s.to_string()))?
+            .is_file())
+    }
 }
 
 #[derive(Debug)]
@@ -284,6 +292,7 @@ pub fn make_module(vm: &VirtualMachine) -> PyObjectRef {
          "name" => ctx.new_property(DirEntryRef::name),
          "path" => ctx.new_property(DirEntryRef::path),
          "is_dir" => ctx.new_rustfunc(DirEntryRef::is_dir),
+         "is_file" => ctx.new_rustfunc(DirEntryRef::is_file),
     });
 
     py_module!(vm, "_os", {

--- a/vm/src/stdlib/os.rs
+++ b/vm/src/stdlib/os.rs
@@ -210,6 +210,10 @@ impl DirEntryRef {
     fn name(self, _vm: &VirtualMachine) -> String {
         self.entry.file_name().into_string().unwrap()
     }
+
+    fn path(self, _vm: &VirtualMachine) -> String {
+        self.entry.path().to_str().unwrap().to_string()
+    }
 }
 
 #[derive(Debug)]
@@ -269,7 +273,8 @@ pub fn make_module(vm: &VirtualMachine) -> PyObjectRef {
     });
 
     let dir_entry = py_class!(ctx, "DirEntry", ctx.object(), {
-         "name" => ctx.new_rustfunc(DirEntryRef::name),
+         "name" => ctx.new_property(DirEntryRef::name),
+         "path" => ctx.new_property(DirEntryRef::path),
     });
 
     py_module!(vm, "_os", {

--- a/vm/src/stdlib/os.rs
+++ b/vm/src/stdlib/os.rs
@@ -214,6 +214,14 @@ impl DirEntryRef {
     fn path(self, _vm: &VirtualMachine) -> String {
         self.entry.path().to_str().unwrap().to_string()
     }
+
+    fn is_dir(self, vm: &VirtualMachine) -> PyResult<bool> {
+        Ok(self
+            .entry
+            .file_type()
+            .map_err(|s| vm.new_os_error(s.to_string()))?
+            .is_dir())
+    }
 }
 
 #[derive(Debug)]
@@ -275,6 +283,7 @@ pub fn make_module(vm: &VirtualMachine) -> PyObjectRef {
     let dir_entry = py_class!(ctx, "DirEntry", ctx.object(), {
          "name" => ctx.new_property(DirEntryRef::name),
          "path" => ctx.new_property(DirEntryRef::path),
+         "is_dir" => ctx.new_rustfunc(DirEntryRef::is_dir),
     });
 
     py_module!(vm, "_os", {


### PR DESCRIPTION
Currently support `name, path, is_dir, is_file`.
I will add `stat` and `symlink` support in separate PRs. 