### PR TITLE
Add os.stat

### DIFF
--- a/tests/snippets/stdlib_os.py
+++ b/tests/snippets/stdlib_os.py
@@ -104,3 +104,6 @@ with TestWithTempDir() as tmpdir:
 	print(stat_res.st_mode)
 	print(stat_res.st_ino)
 	print(stat_res.st_dev)
+	print(stat_res.st_nlink)
+	print(stat_res.st_uid)
+	print(stat_res.st_gid)

--- a/tests/snippets/stdlib_os.py
+++ b/tests/snippets/stdlib_os.py
@@ -101,3 +101,6 @@ with TestWithTempDir() as tmpdir:
 
 	# Stat
 	stat_res = os.stat(fname)
+	print(stat_res.st_mode)
+	print(stat_res.st_ino)
+	print(stat_res.st_dev)

--- a/tests/snippets/stdlib_os.py
+++ b/tests/snippets/stdlib_os.py
@@ -107,3 +107,5 @@ with TestWithTempDir() as tmpdir:
 	print(stat_res.st_nlink)
 	print(stat_res.st_uid)
 	print(stat_res.st_gid)
+	print(stat_res.st_size)
+	assert stat_res.st_size == len(CONTENT2) + len(CONTENT3)

--- a/tests/snippets/stdlib_os.py
+++ b/tests/snippets/stdlib_os.py
@@ -98,3 +98,6 @@ with TestWithTempDir() as tmpdir:
 	assert paths == set([fname, fname2, folder])
 	assert dirs == set([FOLDER])
 	assert files == set([FILE_NAME, FILE_NAME2])
+
+	# Stat
+	stat_res = os.stat(fname)

--- a/vm/src/stdlib/os.rs
+++ b/vm/src/stdlib/os.rs
@@ -277,6 +277,9 @@ struct StatResult {
     st_mode: u32,
     st_ino: u64,
     st_dev: u64,
+    st_nlink: u64,
+    st_uid: u32,
+    st_gid: u32,
 }
 
 impl PyValue for StatResult {
@@ -299,6 +302,18 @@ impl StatResultRef {
     fn st_dev(self, _vm: &VirtualMachine) -> u64 {
         self.st_dev
     }
+
+    fn st_nlink(self, _vm: &VirtualMachine) -> u64 {
+        self.st_nlink
+    }
+
+    fn st_uid(self, _vm: &VirtualMachine) -> u32 {
+        self.st_uid
+    }
+
+    fn st_gid(self, _vm: &VirtualMachine) -> u32 {
+        self.st_gid
+    }
 }
 
 #[cfg(unix)]
@@ -309,6 +324,9 @@ fn os_stat(path: PyStringRef, vm: &VirtualMachine) -> PyResult {
             st_mode: meta.st_mode(),
             st_ino: meta.st_ino(),
             st_dev: meta.st_dev(),
+            st_nlink: meta.st_nlink(),
+            st_uid: meta.st_uid(),
+            st_gid: meta.st_gid(),
         }
         .into_ref(vm)
         .into_object()),
@@ -322,8 +340,11 @@ fn os_stat(path: PyStringRef, vm: &VirtualMachine) -> PyResult {
     match fs::metadata(&path.value) {
         Ok(meta) => Ok(StatResult {
             st_mode: meta.file_attributes(),
-            st_ino: 0, // TODO: Not implemented in std::os::windows::fs::MetadataExt.
-            st_dev: 0, // TODO: Not implemented in std::os::windows::fs::MetadataExt.
+            st_ino: 0,   // TODO: Not implemented in std::os::windows::fs::MetadataExt.
+            st_dev: 0,   // TODO: Not implemented in std::os::windows::fs::MetadataExt.
+            st_nlink: 0, // TODO: Not implemented in std::os::windows::fs::MetadataExt.
+            st_uid: 0,   // 0 on windows
+            st_gid: 0,   // 0 on windows
         }
         .into_ref(vm)
         .into_object()),
@@ -363,6 +384,9 @@ pub fn make_module(vm: &VirtualMachine) -> PyObjectRef {
          "st_mode" => ctx.new_property(StatResultRef::st_mode),
          "st_ino" => ctx.new_property(StatResultRef::st_ino),
          "st_dev" => ctx.new_property(StatResultRef::st_dev),
+         "st_nlink" => ctx.new_property(StatResultRef::st_nlink),
+         "st_uid" => ctx.new_property(StatResultRef::st_uid),
+         "st_gid" => ctx.new_property(StatResultRef::st_gid),
     });
 
     py_module!(vm, "_os", {

--- a/vm/src/stdlib/os.rs
+++ b/vm/src/stdlib/os.rs
@@ -280,6 +280,7 @@ struct StatResult {
     st_nlink: u64,
     st_uid: u32,
     st_gid: u32,
+    st_size: u64,
 }
 
 impl PyValue for StatResult {
@@ -314,6 +315,10 @@ impl StatResultRef {
     fn st_gid(self, _vm: &VirtualMachine) -> u32 {
         self.st_gid
     }
+
+    fn st_size(self, _vm: &VirtualMachine) -> u64 {
+        self.st_size
+    }
 }
 
 #[cfg(unix)]
@@ -327,6 +332,7 @@ fn os_stat(path: PyStringRef, vm: &VirtualMachine) -> PyResult {
             st_nlink: meta.st_nlink(),
             st_uid: meta.st_uid(),
             st_gid: meta.st_gid(),
+            st_size: meta.st_size(),
         }
         .into_ref(vm)
         .into_object()),
@@ -345,6 +351,7 @@ fn os_stat(path: PyStringRef, vm: &VirtualMachine) -> PyResult {
             st_nlink: 0, // TODO: Not implemented in std::os::windows::fs::MetadataExt.
             st_uid: 0,   // 0 on windows
             st_gid: 0,   // 0 on windows
+            st_size: meta.file_size(),
         }
         .into_ref(vm)
         .into_object()),
@@ -387,6 +394,7 @@ pub fn make_module(vm: &VirtualMachine) -> PyObjectRef {
          "st_nlink" => ctx.new_property(StatResultRef::st_nlink),
          "st_uid" => ctx.new_property(StatResultRef::st_uid),
          "st_gid" => ctx.new_property(StatResultRef::st_gid),
+         "st_size" => ctx.new_property(StatResultRef::st_size),
     });
 
     py_module!(vm, "_os", {


### PR DESCRIPTION
This is only a limited part of `os.stat`. The windows implementation is missing `st_ino`, `st_dev` and `st_nlink` as they are not yet implemented in `std::os::windows::fs::MetadataExt`.
I have tested the results against Cpython on my machine but I am not sure how to test it in the CI. The windows code is not tested yet so I will let the CI test it.