### PR TITLE
Add constants to os module

### DIFF
--- a/Lib/os.py
+++ b/Lib/os.py
@@ -1,9 +1,19 @@
 from _os import *
 
+curdir = '.'
+pardir = '..'
+extsep = '.'
+
 if name == 'nt':
     sep = '\\'
+    linesep = '\r\n'
+    altsep = '/'
+    pathsep = ';'
 else:
     sep = '/'
+    linesep = '\n'
+    altsep = None
+    pathsep = ':'
 
 # Change environ to automatically call putenv(), unsetenv if they exist.
 from _collections_abc import MutableMapping

--- a/tests/snippets/stdlib_os.py
+++ b/tests/snippets/stdlib_os.py
@@ -33,11 +33,20 @@ if os.name == "posix":
 	os.unsetenv(ENV_KEY)
 	assert os.getenv(ENV_KEY) == None
 
+assert os.curdir == "."
+assert os.pardir == ".."
+assert os.extsep == "."
 
 if os.name == "nt":
 	assert os.sep == "\\"
+	assert os.linesep == "\r\n"
+	assert os.altsep == "/"
+	assert os.pathsep == ";"
 else:
 	assert os.sep == "/"
+	assert os.linesep == "\n"
+	assert os.altsep == None
+	assert os.pathsep == ":"
 
 class TestWithTempDir():
 	def __enter__(self):


### PR DESCRIPTION
Add some missing contants:
- `os.curdir`
- `os.pardir`
- `os.extsep`
- `os.linesep`
- `os.altsep`
- `os.pathsep`