### PR TITLE
PyFloat overflow handling + missing methods

### DIFF
--- a/tests/snippets/floats.py
+++ b/tests/snippets/floats.py
@@ -106,6 +106,8 @@ assert 2.0.__sub__(1.0) == 1.0
 assert 2.0.__rmul__(1.0) == 2.0
 assert 1.0.__truediv__(2.0) == 0.5
 assert 1.0.__rtruediv__(2.0) == 2.0
+assert 2.5.__divmod__(2.0) == (1.0, 0.5)
+assert 2.0.__rdivmod__(2.5) == (1.0, 0.5)
 
 assert 1.0.__add__(1) == 2.0
 assert 1.0.__radd__(1) == 2.0
@@ -120,6 +122,11 @@ assert 2.0.__rmod__(2) == 0.0
 assert_raises(ZeroDivisionError, lambda: 2.0 / 0)
 assert_raises(ZeroDivisionError, lambda: 2.0 // 0)
 assert_raises(ZeroDivisionError, lambda: 2.0 % 0)
+assert_raises(ZeroDivisionError, lambda: divmod(2.0, 0))
+assert_raises(ZeroDivisionError, lambda: 2 / 0.0)
+assert_raises(ZeroDivisionError, lambda: 2 // 0.0)
+assert_raises(ZeroDivisionError, lambda: 2 % 0.0)
+# assert_raises(ZeroDivisionError, lambda: divmod(2, 0.0))
 
 assert 1.2.__int__() == 1
 assert 1.2.__float__() == 1.2

--- a/tests/snippets/floats.py
+++ b/tests/snippets/floats.py
@@ -8,6 +8,7 @@ a = 1.2
 b = 1.3
 c = 1.2
 z = 2
+ov = 10 ** 1000
 
 assert -a == -1.2
 
@@ -37,6 +38,20 @@ assert a / z == 0.6
 assert 6 / a == 5.0
 assert 2.0 % z == 0.0
 assert z % 2.0 == 0.0
+assert_raises(OverflowError, lambda: a + ov)
+assert_raises(OverflowError, lambda: a - ov)
+assert_raises(OverflowError, lambda: a * ov)
+assert_raises(OverflowError, lambda: a / ov)
+assert_raises(OverflowError, lambda: a // ov)
+assert_raises(OverflowError, lambda: a % ov)
+assert_raises(OverflowError, lambda: a ** ov)
+assert_raises(OverflowError, lambda: ov + a)
+assert_raises(OverflowError, lambda: ov - a)
+assert_raises(OverflowError, lambda: ov * a)
+assert_raises(OverflowError, lambda: ov / a)
+assert_raises(OverflowError, lambda: ov // a)
+assert_raises(OverflowError, lambda: ov % a)
+# assert_raises(OverflowError, lambda: ov ** a)
 
 assert a < 5
 assert a <= 5

--- a/tests/snippets/floats.py
+++ b/tests/snippets/floats.py
@@ -113,6 +113,9 @@ assert int(1.2) == 1
 assert float(1.2) == 1.2
 # assert math.trunc(1.2) == 1
 
+assert 1.2 ** 2 == 1.44
+assert_raises(OverflowError, lambda: 1.2 ** (10 ** 1000))
+
 assert (1.7).real == 1.7
 assert (1.3).is_integer() == False
 assert (1.0).is_integer()    == True

--- a/tests/snippets/floats.py
+++ b/tests/snippets/floats.py
@@ -137,6 +137,7 @@ assert float(1.2) == 1.2
 
 assert 1.2 ** 2 == 1.44
 assert_raises(OverflowError, lambda: 1.2 ** (10 ** 1000))
+assert 3 ** 2.0 == 9.0
 
 assert (1.7).real == 1.7
 assert (1.3).is_integer() == False

--- a/vm/src/obj/objfloat.rs
+++ b/vm/src/obj/objfloat.rs
@@ -284,6 +284,14 @@ impl PyFloat {
         )
     }
 
+    #[pymethod(name = "__rpow__")]
+    fn rpow(&self, other: PyObjectRef, vm: &VirtualMachine) -> PyResult {
+        try_float(&other, vm)?.map_or_else(
+            || Ok(vm.ctx.not_implemented()),
+            |other| other.powf(self.value).into_pyobject(vm),
+        )
+    }
+
     #[pymethod(name = "__sub__")]
     fn sub(&self, other: PyObjectRef, vm: &VirtualMachine) -> PyResult {
         try_float(&other, vm)?.map_or_else(

--- a/vm/src/obj/objfloat.rs
+++ b/vm/src/obj/objfloat.rs
@@ -262,16 +262,11 @@ impl PyFloat {
     }
 
     #[pymethod(name = "__pow__")]
-    fn pow(&self, other: PyObjectRef, vm: &VirtualMachine) -> PyObjectRef {
-        let v1 = self.value;
-        if objtype::isinstance(&other, &vm.ctx.float_type()) {
-            vm.ctx.new_float(v1.powf(get_value(&other)))
-        } else if objtype::isinstance(&other, &vm.ctx.int_type()) {
-            let result = v1.powf(objint::get_value(&other).to_f64().unwrap());
-            vm.ctx.new_float(result)
-        } else {
-            vm.ctx.not_implemented()
-        }
+    fn pow(&self, other: PyObjectRef, vm: &VirtualMachine) -> PyResult {
+        try_float(&other, vm)?.map_or_else(
+            || Ok(vm.ctx.not_implemented()),
+            |other| self.value.powf(other).into_pyobject(vm),
+        )
     }
 
     #[pymethod(name = "__sub__")]

--- a/vm/src/obj/objfloat.rs
+++ b/vm/src/obj/objfloat.rs
@@ -41,6 +41,16 @@ impl From<f64> for PyFloat {
     }
 }
 
+fn try_float(value: &PyObjectRef, vm: &VirtualMachine) -> PyResult<Option<f64>> {
+    Ok(if objtype::isinstance(&value, &vm.ctx.float_type()) {
+        Some(get_value(&value))
+    } else if objtype::isinstance(&value, &vm.ctx.int_type()) {
+        Some(objint::get_float_value(&value, vm)?)
+    } else {
+        None
+    })
+}
+
 fn mod_(v1: f64, v2: f64, vm: &VirtualMachine) -> PyResult {
     if v2 != 0.0 {
         Ok(vm.ctx.new_float(v1 % v2))


### PR DESCRIPTION
Added `__rfloordiv__`, `__divmod__`, `__rdivmod__` and `__rpow__`