### PR TITLE
Fix int.__pow__

### DIFF
--- a/tests/snippets/ints.py
+++ b/tests/snippets/ints.py
@@ -39,6 +39,7 @@ assert (2).__truediv__(1) == 2.0
 assert (2).__rtruediv__(1) == 0.5
 assert (2).__pow__(3) == 8
 assert (10).__pow__(-1) == 0.1
+assert (2).__rpow__(3) == 9
 
 # real/imag attributes
 assert (1).real == 1
@@ -61,6 +62,7 @@ assert (2).__rmul__(1.0) == NotImplemented
 assert (2).__truediv__(1.0) == NotImplemented
 assert (2).__rtruediv__(1.0) == NotImplemented
 assert (2).__pow__(3.0) == NotImplemented
+assert (2).__rpow__(3.0) == NotImplemented
 
 
 assert int() == 0

--- a/tests/snippets/ints.py
+++ b/tests/snippets/ints.py
@@ -37,6 +37,8 @@ assert (2).__mul__(1) == 2
 assert (2).__rmul__(1) == 2
 assert (2).__truediv__(1) == 2.0
 assert (2).__rtruediv__(1) == 0.5
+assert (2).__pow__(3) == 8
+assert (10).__pow__(-1) == 0.1
 
 # real/imag attributes
 assert (1).real == 1
@@ -58,6 +60,7 @@ assert (2).__mul__(1.0) == NotImplemented
 assert (2).__rmul__(1.0) == NotImplemented
 assert (2).__truediv__(1.0) == NotImplemented
 assert (2).__rtruediv__(1.0) == NotImplemented
+assert (2).__pow__(3.0) == NotImplemented
 
 
 assert int() == 0

--- a/tests/snippets/math_basics.py
+++ b/tests/snippets/math_basics.py
@@ -39,9 +39,14 @@ assert_raises(
     lambda: round(-float('inf')),
     'OverflowError: cannot convert float NaN to integer')
 
+assert pow(0, 0) == 1
 assert pow(2, 2) == 4
 assert pow(1, 2.0) == 1.0
 assert pow(2.0, 1) == 2.0
+assert pow(0, 10**1000) == 0
+assert pow(1, 10**1000) == 1
+assert pow(-1, 10**1000+1) == -1
+assert pow(-1, 10**1000) == 1
 
 assert pow(2, 4, 5) == 1
 assert_raises(

--- a/tests/snippets/math_basics.py
+++ b/tests/snippets/math_basics.py
@@ -42,3 +42,25 @@ assert_raises(
 assert pow(2, 2) == 4
 assert pow(1, 2.0) == 1.0
 assert pow(2.0, 1) == 2.0
+
+assert pow(2, 4, 5) == 1
+assert_raises(
+    TypeError,
+    lambda: pow(2, 4, 5.0),
+    'pow() 3rd argument not allowed unless all arguments are integers')
+assert_raises(
+    TypeError,
+    lambda: pow(2, 4.0, 5),
+    'pow() 3rd argument not allowed unless all arguments are integers')
+assert_raises(
+    TypeError,
+    lambda: pow(2.0, 4, 5),
+    'pow() 3rd argument not allowed unless all arguments are integers')
+assert_raises(
+    ValueError,
+    lambda: pow(2, -1, 5),
+    'pow() 2nd argument cannot be negative when 3rd argument specified')
+assert_raises(
+    ValueError,
+    lambda: pow(2, 2, 0),
+    'pow() 3rd argument cannot be 0')

--- a/tests/snippets/math_basics.py
+++ b/tests/snippets/math_basics.py
@@ -14,7 +14,7 @@ assert a ** 3 == 64
 assert a * 3 == 12
 assert a / 2 == 2
 assert 2 == a / 2
-# assert a % 3 == 1
+assert a % 3 == 1
 assert a - 3 == 1
 assert -a == -4
 assert +a == 4
@@ -38,3 +38,7 @@ assert_raises(
     OverflowError,
     lambda: round(-float('inf')),
     'OverflowError: cannot convert float NaN to integer')
+
+assert pow(2, 2) == 4
+assert pow(1, 2.0) == 1.0
+assert pow(2.0, 1) == 2.0

--- a/vm/src/builtins.rs
+++ b/vm/src/builtins.rs
@@ -529,11 +529,11 @@ fn builtin_pow(vm: &VirtualMachine, args: PyFuncArgs) -> PyResult {
         required = [(x, None), (y, None)],
         optional = [(mod_value, Some(vm.ctx.int_type()))]
     );
-    let pow_method_name = "__pow__";
-    let result = match vm.get_method(x.clone(), pow_method_name) {
-        Ok(attrib) => vm.invoke(attrib, vec![y.clone()]),
-        Err(..) => Err(vm.new_type_error("unsupported operand type(s) for pow".to_string())),
-    };
+
+    let result = vm.call_or_reflection(x.clone(), y.clone(), "__pow__", "__rpow__", |vm, x, y| {
+        Err(vm.new_unsupported_operand_error(x, y, "pow"))
+    });
+
     //Check if the 3rd argument is defined and perform modulus on the result
     //this should be optimized in the future to perform a "power-mod" algorithm in
     //order to improve performance

--- a/vm/src/obj/objint.rs
+++ b/vm/src/obj/objint.rs
@@ -13,7 +13,7 @@ use crate::pyobject::{
 };
 use crate::vm::VirtualMachine;
 
-use super::objfloat::{self, PyFloat};
+use super::objfloat::PyFloat;
 use super::objstr::{PyString, PyStringRef};
 use super::objtype;
 use crate::obj::objtype::PyClassRef;
@@ -327,9 +327,6 @@ impl PyInt {
         if objtype::isinstance(&other, &vm.ctx.int_type()) {
             let v2 = get_value(&other).to_u32().unwrap();
             vm.ctx.new_int(self.value.pow(v2))
-        } else if objtype::isinstance(&other, &vm.ctx.float_type()) {
-            let v2 = objfloat::get_value(&other);
-            vm.ctx.new_float((self.value.to_f64().unwrap()).powf(v2))
         } else {
             vm.ctx.not_implemented()
         }


### PR DESCRIPTION
- Fix `int.__pow__` not to process float 
- Fix `int.__pow__` to process negative exp
- Add `int.__rpow__`
- Fix `__builtins__.pow` to reflect `__rpow__`
- Fix `__builtins__.pow` to perform modpow for 3rd argument and correctly validate arguments
- Add special handling for base -1, 0, 1

~Dependency to #893 to pass tests~