### PR TITLE
Except block

### DIFF
--- a/tests/snippets/try_exceptions.py
+++ b/tests/snippets/try_exceptions.py
@@ -193,3 +193,16 @@ for _ in [1, 2]:
         raise ArithmeticError()
     except ArithmeticError as e:
         continue
+
+
+def g():
+    try:
+        1/0
+    except ArithmeticError:
+        return 5
+
+try:
+    g()
+    raise NameError
+except NameError as ex:
+    assert ex.__context__ == None

--- a/tests/snippets/try_exceptions.py
+++ b/tests/snippets/try_exceptions.py
@@ -206,3 +206,17 @@ try:
     raise NameError
 except NameError as ex:
     assert ex.__context__ == None
+
+
+def y():
+    try:
+        1/0
+    except ArithmeticError:
+        yield 5
+
+
+try:
+    y()
+    raise NameError
+except NameError as ex:
+    assert ex.__context__ == None

--- a/vm/src/frame.rs
+++ b/vm/src/frame.rs
@@ -862,14 +862,13 @@ impl Frame {
                 Ok(None)
             }
             bytecode::Instruction::PopException {} => {
-                assert!(vm.pop_exception().is_some());
-                let block = self.pop_block();
-                assert!(block.is_some());
-                match block.unwrap().typ {
-                    BlockType::ExceptHandler => (),
-                    _ => assert!(false),
-                };
-                Ok(None)
+                let block = self.pop_block().unwrap(); // this asserts that the block is_some.
+                if let BlockType::ExceptHandler = block.typ {
+                    assert!(vm.pop_exception().is_some());
+                    Ok(None)
+                } else {
+                    panic!("Block type must be ExceptHandler here.")
+                }
             }
         }
     }

--- a/vm/src/frame.rs
+++ b/vm/src/frame.rs
@@ -203,7 +203,7 @@ enum BlockType {
         end: bytecode::Label,
         context_manager: PyObjectRef,
     },
-    ExceptHandler {},
+    ExceptHandler,
 }
 
 pub type FrameRef = PyRef<Frame>;
@@ -866,7 +866,7 @@ impl Frame {
                 let block = self.pop_block();
                 assert!(block.is_some());
                 match block.unwrap().typ {
-                    BlockType::ExceptHandler {} => (),
+                    BlockType::ExceptHandler => (),
                     _ => assert!(false),
                 };
                 Ok(None)
@@ -944,7 +944,7 @@ impl Frame {
                         }
                     }
                 }
-                BlockType::ExceptHandler { .. } => {
+                BlockType::ExceptHandler => {
                     vm.pop_exception();
                 }
             }
@@ -969,7 +969,7 @@ impl Frame {
                         panic!("Exception in with __exit__ {:?}", exc);
                     }
                 },
-                BlockType::ExceptHandler { .. } => {
+                BlockType::ExceptHandler => {
                     vm.pop_exception();
                 }
             }
@@ -1019,7 +1019,7 @@ impl Frame {
                 }
                 BlockType::Loop { .. } => {}
                 // Exception was already poped on Raised.
-                BlockType::ExceptHandler { .. } => {}
+                BlockType::ExceptHandler => {}
             }
         }
         Some(exc)


### PR DESCRIPTION
This solution come to fix the following problem:
```py
def g():
    try:
        1/0
    except ArithmeticError:
        return 5

try:
    g()
    raise NameError
except NameError as ex:
    assert ex.__context__ == None
```
When we exit an except with `return` or `yield` we need to pop the exception from the exception stack.