### PR TITLE
 Include reimplemented methods in whats_left.sh, and skip inherited methods

### DIFF
--- a/tests/not_impl_gen.py
+++ b/tests/not_impl_gen.py
@@ -16,6 +16,18 @@ objects = [
     object,
 ]
 
+
+def attr_is_not_inherited(type_, attr):
+    """
+    returns True if type_'s attr is not inherited from any of its base classes
+    """
+
+    bases = obj.__mro__[1:]
+
+    return getattr(obj, attr) not in (
+        getattr(base, attr, None) for base in bases)
+
+
 header = open("generator/not_impl_header.txt")
 footer = open("generator/not_impl_footer.txt")
 output = open("snippets/whats_left_to_implement.py", "w")
@@ -25,7 +37,11 @@ output.write("expected_methods = {\n")
 
 for obj in objects:
     output.write(f" '{obj.__name__}': ({obj.__name__}, [\n")
-    output.write("\n".join(f"  '{attr}'," for attr in dir(obj)))
+    output.write("\n".join(
+        f"  {attr!r},"
+        for attr in dir(obj)
+        if attr_is_not_inherited(obj, attr)
+    ))
     output.write("\n ])," + ("\n" if objects[-1] == obj else "\n\n"))
 
 output.write("}\n\n")

--- a/tests/not_impl_gen.py
+++ b/tests/not_impl_gen.py
@@ -7,14 +7,13 @@ objects = [
     float,
     frozenset,
     int,
-    iter,
     list,
     memoryview,
     range,
     set,
     str,
     tuple,
-    object
+    object,
 ]
 
 header = open("generator/not_impl_header.txt")


### PR DESCRIPTION
This is so that in e.g. #358 , bool methods that are inherited from int aren't displayed. But methods that have are currently implemented as inherited from int, but should instead be reimplemented with special behavior, are displayed.
