### PR TITLE
Define `os_unix_stat_inner` only when required

### DIFF
--- a/vm/src/stdlib/os.rs
+++ b/vm/src/stdlib/os.rs
@@ -357,6 +357,7 @@ impl StatResultRef {
     }
 }
 
+#[cfg(unix)]
 macro_rules! os_unix_stat_inner {
     ( $path:expr, $follow_symlinks:expr, $vm:expr) => {{
         let metadata = match $follow_symlinks.follow_symlinks {


### PR DESCRIPTION
Avoids warn when building on Windows.