### PR TITLE
Add sys.getfilesystemencoding, sys.getfilesystemencodeerrors

### DIFF
--- a/tests/snippets/sysmod.py
+++ b/tests/snippets/sysmod.py
@@ -10,3 +10,6 @@ assert 'sys' in sys.builtin_module_names
 
 assert isinstance(sys.implementation.name, str)
 assert isinstance(sys.implementation.cache_tag, str)
+
+assert sys.getfilesystemencoding() == 'utf-8'
+assert sys.getfilesystemencodeerrors().startswith('surrogate')

--- a/vm/src/sysmodule.rs
+++ b/vm/src/sysmodule.rs
@@ -40,6 +40,21 @@ fn sys_getsizeof(vm: &VirtualMachine, args: PyFuncArgs) -> PyResult {
     Ok(vm.ctx.new_int(size))
 }
 
+fn sys_getfilesystemencoding(_vm: &VirtualMachine) -> String {
+    // TODO: implmement non-utf-8 mode.
+    "utf-8".to_string()
+}
+
+#[cfg(not(windows))]
+fn sys_getfilesystemencodeerrors(_vm: &VirtualMachine) -> String {
+    "surrogateescape".to_string()
+}
+
+#[cfg(windows)]
+fn sys_getfilesystemencodeerrors(_vm: &VirtualMachine) -> String {
+    "surrogatepass".to_string()
+}
+
 // TODO implement string interning, this will be key for performance
 fn sys_intern(value: PyStringRef, _vm: &VirtualMachine) -> PyStringRef {
     value
@@ -161,6 +176,8 @@ settrace() -- set the global debug tracing function
       "getrefcount" => ctx.new_rustfunc(sys_getrefcount),
       "getsizeof" => ctx.new_rustfunc(sys_getsizeof),
       "implementation" => implementation,
+      "getfilesystemencoding" => ctx.new_rustfunc(sys_getfilesystemencoding),
+      "getfilesystemencodeerrors" => ctx.new_rustfunc(sys_getfilesystemencodeerrors),
       "intern" => ctx.new_rustfunc(sys_intern),
       "maxsize" => ctx.new_int(std::usize::MAX),
       "path" => path,


### PR DESCRIPTION
Related features: `os.fsencode()` `os.fsdecode()` (with this PR + #901)