### PR TITLE
Add sys.platform

### DIFF
--- a/Lib/posixpath.py
+++ b/Lib/posixpath.py
@@ -444,7 +444,7 @@ def _joinrealpath(path, rest, seen):
     return path, True
 
 
-supports_unicode_filenames = (hasattr(sys, "platform") and sys.platform == 'darwin')
+supports_unicode_filenames = (sys.platform == 'darwin')
 
 def relpath(path, start=None):
     """Return a relative version of a path"""

--- a/tests/snippets/sysmod.py
+++ b/tests/snippets/sysmod.py
@@ -2,3 +2,5 @@ import sys
 
 print(sys.argv)
 assert sys.argv[0].endswith('.py')
+
+assert sys.platform == "linux" or sys.platform == "darwin" or sys.platform == "win32" or sys.platform == "unknown"

--- a/vm/src/sysmodule.rs
+++ b/vm/src/sysmodule.rs
@@ -62,6 +62,19 @@ pub fn make_module(vm: &VirtualMachine, module: PyObjectRef, builtins: PyObjectR
     };
     let path = ctx.new_list(path_list);
 
+    let platform = if cfg!(target_os = "linux") {
+        "linux".to_string()
+    } else if cfg!(target_os = "macos") {
+        "darwin".to_string()
+    } else if cfg!(target_os = "windows") {
+        "win32".to_string()
+    } else if cfg!(target_os = "android") {
+        // Linux as well. see https://bugs.python.org/issue32637
+        "linux".to_string()
+    } else {
+        "unknown".to_string()
+    };
+
     let sys_doc = "This module provides access to some objects used or maintained by the
 interpreter and to functions that interact strongly with the interpreter.
 
@@ -145,6 +158,7 @@ settrace() -- set the global debug tracing function
       "_getframe" => ctx.new_rustfunc(getframe),
       "modules" => modules.clone(),
       "warnoptions" => ctx.new_list(vec![]),
+      "platform" => ctx.new_str(platform),
     });
 
     modules.set_item("sys", module.clone(), vm).unwrap();


### PR DESCRIPTION
For #958.
Currently support:

- linux
- windows
- android
- macos
