### PR TITLE
Remove RefCell from tuple

### DIFF
--- a/vm/src/exceptions.rs
+++ b/vm/src/exceptions.rs
@@ -44,11 +44,11 @@ pub fn print_exception_inner(vm: &VirtualMachine, exc: &PyObjectRef) {
     if let Ok(tb) = vm.get_attribute(exc.clone(), "__traceback__") {
         println!("Traceback (most recent call last):");
         if objtype::isinstance(&tb, &vm.ctx.list_type()) {
-            let mut elements = objsequence::get_elements(&tb).to_vec();
+            let mut elements = objsequence::get_elements_list(&tb).to_vec();
             elements.reverse();
             for element in elements.iter() {
                 if objtype::isinstance(&element, &vm.ctx.tuple_type()) {
-                    let element = objsequence::get_elements(&element);
+                    let element = objsequence::get_elements_tuple(&element);
                     let filename = if let Ok(x) = vm.to_str(&element[0]) {
                         x.value.clone()
                     } else {

--- a/vm/src/function.rs
+++ b/vm/src/function.rs
@@ -538,7 +538,7 @@ pub fn single_or_tuple_any<T: PyValue, F: Fn(PyRef<T>) -> PyResult<bool>>(
     match_class!(obj,
         obj @ T => predicate(obj),
         tuple @ PyTuple => {
-            for obj in tuple.elements.borrow().iter() {
+            for obj in tuple.elements.iter() {
                 let inner_val = PyRef::<T>::try_from_object(vm, obj.clone())?;
                 if predicate(inner_val)? {
                     return Ok(true);

--- a/vm/src/import.rs
+++ b/vm/src/import.rs
@@ -67,7 +67,7 @@ pub fn import_file(
 
 fn find_source(vm: &VirtualMachine, current_path: PathBuf, name: &str) -> Result<PathBuf, String> {
     let sys_path = vm.get_attribute(vm.sys_module.clone(), "path").unwrap();
-    let mut paths: Vec<PathBuf> = objsequence::get_elements(&sys_path)
+    let mut paths: Vec<PathBuf> = objsequence::get_elements_list(&sys_path)
         .iter()
         .map(|item| PathBuf::from(objstr::get_value(item)))
         .collect();

--- a/vm/src/obj/objbyteinner.rs
+++ b/vm/src/obj/objbyteinner.rs
@@ -686,7 +686,7 @@ impl PyByteInner {
             Either::A(byte) => byte.elements,
             Either::B(tuple) => {
                 let mut flatten = vec![];
-                for v in objsequence::get_elements(tuple.as_object()).to_vec() {
+                for v in objsequence::get_elements_tuple(tuple.as_object()).to_vec() {
                     flatten.extend(PyByteInner::try_from_object(vm, v)?.elements)
                 }
                 flatten

--- a/vm/src/obj/objlist.rs
+++ b/vm/src/obj/objlist.rs
@@ -17,8 +17,8 @@ use super::objbool;
 //use super::objint;
 use super::objiter;
 use super::objsequence::{
-    get_elements, get_elements_cell, get_item, seq_equal, seq_ge, seq_gt, seq_le, seq_lt, seq_mul,
-    SequenceIndex,
+    get_elements_cell, get_elements_list, get_item, seq_equal, seq_ge, seq_gt, seq_le, seq_lt,
+    seq_mul, SequenceIndex,
 };
 use super::objslice::PySliceRef;
 use super::objtype;
@@ -129,7 +129,7 @@ impl PyListRef {
     fn add(self, other: PyObjectRef, vm: &VirtualMachine) -> PyResult {
         if objtype::isinstance(&other, &vm.ctx.list_type()) {
             let e1 = self.elements.borrow();
-            let e2 = get_elements(&other);
+            let e2 = get_elements_list(&other);
             let elements = e1.iter().chain(e2.iter()).cloned().collect();
             Ok(vm.ctx.new_list(elements))
         } else {
@@ -141,7 +141,7 @@ impl PyListRef {
         if objtype::isinstance(&other, &vm.ctx.list_type()) {
             self.elements
                 .borrow_mut()
-                .extend_from_slice(&get_elements(&other));
+                .extend_from_slice(&get_elements_list(&other));
             Ok(self.into_object())
         } else {
             Ok(vm.ctx.not_implemented())
@@ -490,7 +490,7 @@ impl PyListRef {
 
         if objtype::isinstance(&other, &vm.ctx.list_type()) {
             let zelf = self.elements.borrow();
-            let other = get_elements(&other);
+            let other = get_elements_list(&other);
             let res = seq_equal(vm, &zelf, &other)?;
             Ok(vm.new_bool(res))
         } else {
@@ -501,7 +501,7 @@ impl PyListRef {
     fn lt(self, other: PyObjectRef, vm: &VirtualMachine) -> PyResult {
         if objtype::isinstance(&other, &vm.ctx.list_type()) {
             let zelf = self.elements.borrow();
-            let other = get_elements(&other);
+            let other = get_elements_list(&other);
             let res = seq_lt(vm, &zelf, &other)?;
             Ok(vm.new_bool(res))
         } else {
@@ -512,7 +512,7 @@ impl PyListRef {
     fn gt(self, other: PyObjectRef, vm: &VirtualMachine) -> PyResult {
         if objtype::isinstance(&other, &vm.ctx.list_type()) {
             let zelf = self.elements.borrow();
-            let other = get_elements(&other);
+            let other = get_elements_list(&other);
             let res = seq_gt(vm, &zelf, &other)?;
             Ok(vm.new_bool(res))
         } else {
@@ -523,7 +523,7 @@ impl PyListRef {
     fn ge(self, other: PyObjectRef, vm: &VirtualMachine) -> PyResult {
         if objtype::isinstance(&other, &vm.ctx.list_type()) {
             let zelf = self.elements.borrow();
-            let other = get_elements(&other);
+            let other = get_elements_list(&other);
             let res = seq_ge(vm, &zelf, &other)?;
             Ok(vm.new_bool(res))
         } else {
@@ -534,7 +534,7 @@ impl PyListRef {
     fn le(self, other: PyObjectRef, vm: &VirtualMachine) -> PyResult {
         if objtype::isinstance(&other, &vm.ctx.list_type()) {
             let zelf = self.elements.borrow();
-            let other = get_elements(&other);
+            let other = get_elements_list(&other);
             let res = seq_le(vm, &zelf, &other)?;
             Ok(vm.new_bool(res))
         } else {

--- a/vm/src/obj/objsequence.rs
+++ b/vm/src/obj/objsequence.rs
@@ -348,9 +348,6 @@ pub fn get_elements_cell<'a>(obj: &'a PyObjectRef) -> &'a RefCell<Vec<PyObjectRe
     if let Some(list) = obj.payload::<PyList>() {
         return &list.elements;
     }
-    if let Some(tuple) = obj.payload::<PyTuple>() {
-        return &tuple.elements;
-    }
     panic!("Cannot extract elements from non-sequence");
 }
 

--- a/vm/src/obj/objsequence.rs
+++ b/vm/src/obj/objsequence.rs
@@ -351,12 +351,16 @@ pub fn get_elements_cell<'a>(obj: &'a PyObjectRef) -> &'a RefCell<Vec<PyObjectRe
     panic!("Cannot extract elements from non-sequence");
 }
 
-pub fn get_elements<'a>(obj: &'a PyObjectRef) -> impl Deref<Target = Vec<PyObjectRef>> + 'a {
+pub fn get_elements_list<'a>(obj: &'a PyObjectRef) -> impl Deref<Target = Vec<PyObjectRef>> + 'a {
     if let Some(list) = obj.payload::<PyList>() {
         return list.elements.borrow();
     }
+    panic!("Cannot extract elements from non-sequence");
+}
+
+pub fn get_elements_tuple<'a>(obj: &'a PyObjectRef) -> impl Deref<Target = Vec<PyObjectRef>> + 'a {
     if let Some(tuple) = obj.payload::<PyTuple>() {
-        return tuple.elements.borrow();
+        return &tuple.elements;
     }
     panic!("Cannot extract elements from non-sequence");
 }

--- a/vm/src/obj/objsequence.rs
+++ b/vm/src/obj/objsequence.rs
@@ -368,9 +368,6 @@ pub fn get_mut_elements<'a>(obj: &'a PyObjectRef) -> impl DerefMut<Target = Vec<
     if let Some(list) = obj.payload::<PyList>() {
         return list.elements.borrow_mut();
     }
-    if let Some(tuple) = obj.payload::<PyTuple>() {
-        return tuple.elements.borrow_mut();
-    }
     panic!("Cannot extract elements from non-sequence");
 }
 

--- a/vm/src/obj/objtuple.rs
+++ b/vm/src/obj/objtuple.rs
@@ -1,4 +1,4 @@
-use std::cell::{Cell, RefCell};
+use std::cell::Cell;
 use std::fmt;
 
 use crate::function::OptionalArg;
@@ -9,14 +9,13 @@ use crate::vm::{ReprGuard, VirtualMachine};
 use super::objbool;
 use super::objiter;
 use super::objsequence::{
-    get_elements, get_item, seq_equal, seq_ge, seq_gt, seq_le, seq_lt, seq_mul,
+    get_elements_tuple, get_item, seq_equal, seq_ge, seq_gt, seq_le, seq_lt, seq_mul,
 };
 use super::objtype::{self, PyClassRef};
 
 pub struct PyTuple {
     // TODO: shouldn't be public
-    // TODO: tuples are immutable, remove this RefCell
-    pub elements: RefCell<Vec<PyObjectRef>>,
+    pub elements: Vec<PyObjectRef>,
 }
 
 impl fmt::Debug for PyTuple {
@@ -28,9 +27,7 @@ impl fmt::Debug for PyTuple {
 
 impl From<Vec<PyObjectRef>> for PyTuple {
     fn from(elements: Vec<PyObjectRef>) -> Self {
-        PyTuple {
-            elements: RefCell::new(elements),
-        }
+        PyTuple { elements: elements }
     }
 }
 
@@ -45,9 +42,8 @@ pub type PyTupleRef = PyRef<PyTuple>;
 impl PyTupleRef {
     fn lt(self, other: PyObjectRef, vm: &VirtualMachine) -> PyResult {
         if objtype::isinstance(&other, &vm.ctx.tuple_type()) {
-            let zelf = self.elements.borrow();
-            let other = get_elements(&other);
-            let res = seq_lt(vm, &zelf, &other)?;
+            let other = get_elements_tuple(&other);
+            let res = seq_lt(vm, &self.elements, &other)?;
             Ok(vm.new_bool(res))
         } else {
             Ok(vm.ctx.not_implemented())
@@ -56,9 +52,8 @@ impl PyTupleRef {
 
     fn gt(self, other: PyObjectRef, vm: &VirtualMachine) -> PyResult {
         if objtype::isinstance(&other, &vm.ctx.tuple_type()) {
-            let zelf = self.elements.borrow();
-            let other = get_elements(&other);
-            let res = seq_gt(vm, &zelf, &other)?;
+            let other = get_elements_tuple(&other);
+            let res = seq_gt(vm, &self.elements, &other)?;
             Ok(vm.new_bool(res))
         } else {
             Ok(vm.ctx.not_implemented())
@@ -67,9 +62,8 @@ impl PyTupleRef {
 
     fn ge(self, other: PyObjectRef, vm: &VirtualMachine) -> PyResult {
         if objtype::isinstance(&other, &vm.ctx.tuple_type()) {
-            let zelf = self.elements.borrow();
-            let other = get_elements(&other);
-            let res = seq_ge(vm, &zelf, &other)?;
+            let other = get_elements_tuple(&other);
+            let res = seq_ge(vm, &self.elements, &other)?;
             Ok(vm.new_bool(res))
         } else {
             Ok(vm.ctx.not_implemented())
@@ -78,9 +72,8 @@ impl PyTupleRef {
 
     fn le(self, other: PyObjectRef, vm: &VirtualMachine) -> PyResult {
         if objtype::isinstance(&other, &vm.ctx.tuple_type()) {
-            let zelf = self.elements.borrow();
-            let other = get_elements(&other);
-            let res = seq_le(vm, &zelf, &other)?;
+            let other = get_elements_tuple(&other);
+            let res = seq_le(vm, &self.elements, &other)?;
             Ok(vm.new_bool(res))
         } else {
             Ok(vm.ctx.not_implemented())
@@ -89,9 +82,8 @@ impl PyTupleRef {
 
     fn add(self, other: PyObjectRef, vm: &VirtualMachine) -> PyResult {
         if objtype::isinstance(&other, &vm.ctx.tuple_type()) {
-            let e1 = self.elements.borrow();
-            let e2 = get_elements(&other);
-            let elements = e1.iter().chain(e2.iter()).cloned().collect();
+            let e2 = get_elements_tuple(&other);
+            let elements = self.elements.iter().chain(e2.iter()).cloned().collect();
             Ok(vm.ctx.new_tuple(elements))
         } else {
             Ok(vm.ctx.not_implemented())
@@ -99,12 +91,12 @@ impl PyTupleRef {
     }
 
     fn bool(self, _vm: &VirtualMachine) -> bool {
-        !self.elements.borrow().is_empty()
+        !self.elements.is_empty()
     }
 
     fn count(self, needle: PyObjectRef, vm: &VirtualMachine) -> PyResult<usize> {
         let mut count: usize = 0;
-        for element in self.elements.borrow().iter() {
+        for element in self.elements.iter() {
             if element.is(&needle) {
                 count += 1;
             } else {
@@ -119,9 +111,8 @@ impl PyTupleRef {
 
     fn eq(self, other: PyObjectRef, vm: &VirtualMachine) -> PyResult {
         if objtype::isinstance(&other, &vm.ctx.tuple_type()) {
-            let zelf = &self.elements.borrow();
-            let other = get_elements(&other);
-            let res = seq_equal(vm, &zelf, &other)?;
+            let other = get_elements_tuple(&other);
+            let res = seq_equal(vm, &self.elements, &other)?;
             Ok(vm.new_bool(res))
         } else {
             Ok(vm.ctx.not_implemented())
@@ -129,7 +120,7 @@ impl PyTupleRef {
     }
 
     fn hash(self, vm: &VirtualMachine) -> PyResult<pyhash::PyHash> {
-        pyhash::hash_iter(self.elements.borrow().iter(), vm)
+        pyhash::hash_iter(self.elements.iter(), vm)
     }
 
     fn iter(self, _vm: &VirtualMachine) -> PyTupleIterator {
@@ -140,13 +131,13 @@ impl PyTupleRef {
     }
 
     fn len(self, _vm: &VirtualMachine) -> usize {
-        self.elements.borrow().len()
+        self.elements.len()
     }
 
     fn repr(self, vm: &VirtualMachine) -> PyResult<String> {
         let s = if let Some(_guard) = ReprGuard::enter(self.as_object()) {
             let mut str_parts = vec![];
-            for elem in self.elements.borrow().iter() {
+            for elem in self.elements.iter() {
                 let s = vm.to_repr(elem)?;
                 str_parts.push(s.value.clone());
             }
@@ -163,21 +154,16 @@ impl PyTupleRef {
     }
 
     fn mul(self, counter: isize, vm: &VirtualMachine) -> PyObjectRef {
-        let new_elements = seq_mul(&self.elements.borrow(), counter);
+        let new_elements = seq_mul(&self.elements, counter);
         vm.ctx.new_tuple(new_elements)
     }
 
     fn getitem(self, needle: PyObjectRef, vm: &VirtualMachine) -> PyResult {
-        get_item(
-            vm,
-            self.as_object(),
-            &self.elements.borrow(),
-            needle.clone(),
-        )
+        get_item(vm, self.as_object(), &self.elements, needle.clone())
     }
 
     fn index(self, needle: PyObjectRef, vm: &VirtualMachine) -> PyResult<usize> {
-        for (index, element) in self.elements.borrow().iter().enumerate() {
+        for (index, element) in self.elements.iter().enumerate() {
             if element.is(&needle) {
                 return Ok(index);
             }
@@ -190,7 +176,7 @@ impl PyTupleRef {
     }
 
     fn contains(self, needle: PyObjectRef, vm: &VirtualMachine) -> PyResult<bool> {
-        for element in self.elements.borrow().iter() {
+        for element in self.elements.iter() {
             if element.is(&needle) {
                 return Ok(true);
             }
@@ -234,8 +220,8 @@ impl PyValue for PyTupleIterator {
 impl PyTupleIterator {
     #[pymethod(name = "__next__")]
     fn next(&self, vm: &VirtualMachine) -> PyResult {
-        if self.position.get() < self.tuple.elements.borrow().len() {
-            let ret = self.tuple.elements.borrow()[self.position.get()].clone();
+        if self.position.get() < self.tuple.elements.len() {
+            let ret = self.tuple.elements[self.position.get()].clone();
             self.position.set(self.position.get() + 1);
             Ok(ret)
         } else {

--- a/vm/src/stdlib/json.rs
+++ b/vm/src/stdlib/json.rs
@@ -57,10 +57,11 @@ impl<'s> serde::Serialize for PyObjectSerializer<'s> {
             serializer.serialize_i64(v.to_i64().unwrap())
         // Although this may seem nice, it does not give the right result:
         // v.serialize(serializer)
-        } else if objtype::isinstance(self.pyobject, &self.vm.ctx.list_type())
-            || objtype::isinstance(self.pyobject, &self.vm.ctx.tuple_type())
-        {
-            let elements = objsequence::get_elements(self.pyobject);
+        } else if objtype::isinstance(self.pyobject, &self.vm.ctx.list_type()) {
+            let elements = objsequence::get_elements_list(self.pyobject);
+            serialize_seq_elements(serializer, &elements)
+        } else if objtype::isinstance(self.pyobject, &self.vm.ctx.tuple_type()) {
+            let elements = objsequence::get_elements_tuple(self.pyobject);
             serialize_seq_elements(serializer, &elements)
         } else if objtype::isinstance(self.pyobject, &self.vm.ctx.dict_type()) {
             let dict: PyDictRef = self.pyobject.clone().downcast().unwrap();

--- a/vm/src/stdlib/socket.rs
+++ b/vm/src/stdlib/socket.rs
@@ -349,14 +349,14 @@ impl Address {
 impl TryFromObject for Address {
     fn try_from_object(vm: &VirtualMachine, obj: PyObjectRef) -> PyResult<Self> {
         let tuple = PyTupleRef::try_from_object(vm, obj)?;
-        if tuple.elements.borrow().len() != 2 {
+        if tuple.elements.len() != 2 {
             Err(vm.new_type_error("Address tuple should have only 2 values".to_string()))
         } else {
             Ok(Address {
-                host: PyStringRef::try_from_object(vm, tuple.elements.borrow()[0].clone())?
+                host: PyStringRef::try_from_object(vm, tuple.elements[0].clone())?
                     .value
                     .to_string(),
-                port: PyIntRef::try_from_object(vm, tuple.elements.borrow()[1].clone())?
+                port: PyIntRef::try_from_object(vm, tuple.elements[1].clone())?
                     .as_bigint()
                     .to_usize()
                     .unwrap(),

--- a/vm/src/vm.rs
+++ b/vm/src/vm.rs
@@ -527,7 +527,7 @@ impl VirtualMachine {
         // Add missing positional arguments, if we have fewer positional arguments than the
         // function definition calls for
         if nargs < nexpected_args {
-            let num_defaults_available = defaults.as_ref().map_or(0, |d| d.elements.borrow().len());
+            let num_defaults_available = defaults.as_ref().map_or(0, |d| d.elements.len());
 
             // Given the number of defaults available, check all the arguments for which we
             // _don't_ have defaults; if any are missing, raise an exception
@@ -547,7 +547,7 @@ impl VirtualMachine {
                 )));
             }
             if let Some(defaults) = defaults {
-                let defaults = defaults.elements.borrow();
+                let defaults = &defaults.elements;
                 // We have sufficient defaults, so iterate over the corresponding names and use
                 // the default if we don't already have a value
                 for (default_index, i) in (required_args..nexpected_args).enumerate() {
@@ -580,10 +580,10 @@ impl VirtualMachine {
 
     pub fn extract_elements(&self, value: &PyObjectRef) -> PyResult<Vec<PyObjectRef>> {
         // Extract elements from item, if possible:
-        let elements = if objtype::isinstance(value, &self.ctx.tuple_type())
-            || objtype::isinstance(value, &self.ctx.list_type())
-        {
-            objsequence::get_elements(value).to_vec()
+        let elements = if objtype::isinstance(value, &self.ctx.tuple_type()) {
+            objsequence::get_elements_tuple(value).to_vec()
+        } else if objtype::isinstance(value, &self.ctx.list_type()) {
+            objsequence::get_elements_list(value).to_vec()
         } else {
             let iter = objiter::get_iter(self, value)?;
             objiter::get_all(self, &iter)?

--- a/wasm/lib/src/convert.rs
+++ b/wasm/lib/src/convert.rs
@@ -40,10 +40,10 @@ pub fn py_err_to_js_err(vm: &VirtualMachine, py_err: &PyObjectRef) -> JsValue {
     });
     if let Ok(tb) = vm.get_attribute(py_err.clone(), "__traceback__") {
         if objtype::isinstance(&tb, &vm.ctx.list_type()) {
-            let elements = objsequence::get_elements(&tb).to_vec();
+            let elements = objsequence::get_elements_list(&tb).to_vec();
             if let Some(top) = elements.get(0) {
                 if objtype::isinstance(&top, &vm.ctx.tuple_type()) {
-                    let element = objsequence::get_elements(&top);
+                    let element = objsequence::get_elements_list(&top);
 
                     if let Some(lineno) = objint::to_int(vm, &element[1], 10)
                         .ok()


### PR DESCRIPTION
I didn't find any reason to have a shared `get_elements`, mostly since a direct check on `type in (tuple, list)` is done anyways before the call.

Removing the RefCell, the API now won't allow returning both a normal reference and a `Ref`, so if we want to keep this API then some larger change has to be made.