### PR TITLE
objstr: Refactored the 'mul' method

### DIFF
--- a/tests/snippets/strings.py
+++ b/tests/snippets/strings.py
@@ -37,6 +37,8 @@ assert 3 * "xy" == "xyxyxy"
 assert 0 * "x" == ""
 assert -1 * "x" == ""
 
+assert_raises(OverflowError, lambda: 'xy' * 234234234234234234234234234234)
+
 a = 'Hallo'
 assert a.lower() == 'hallo'
 assert a.upper() == 'HALLO'

--- a/vm/src/obj/objstr.rs
+++ b/vm/src/obj/objstr.rs
@@ -183,22 +183,16 @@ impl PyString {
 
     #[pymethod(name = "__mul__")]
     fn mul(&self, val: PyObjectRef, vm: &VirtualMachine) -> PyResult<String> {
-        if objtype::isinstance(&val, &vm.ctx.int_type()) {
-            let value = &self.value;
-            let multiplier = objint::get_value(&val).to_i32().unwrap();
-            let capacity = if multiplier > 0 {
-                multiplier.to_usize().unwrap() * value.len()
-            } else {
-                0
-            };
-            let mut result = String::with_capacity(capacity);
-            for _x in 0..multiplier {
-                result.push_str(value.as_str());
-            }
-            Ok(result)
-        } else {
-            Err(vm.new_type_error(format!("Cannot multiply {} and {}", self, val)))
+        if !objtype::isinstance(&val, &vm.ctx.int_type()) {
+            return Err(vm.new_type_error(format!("Cannot multiply {} and {}", self, val)));
         }
+        let value = &self.value;
+        let multiplier = objint::get_value(&val)
+            .to_i32()
+            .map(|multiplier| if multiplier < 0 { 0 } else { multiplier })
+            .and_then(|multiplier| multiplier.to_usize())
+            .unwrap_or(0);
+        Ok(value.repeat(multiplier))
     }
 
     #[pymethod(name = "__rmul__")]

--- a/vm/src/obj/objstr.rs
+++ b/vm/src/obj/objstr.rs
@@ -186,13 +186,14 @@ impl PyString {
         if !objtype::isinstance(&val, &vm.ctx.int_type()) {
             return Err(vm.new_type_error(format!("Cannot multiply {} and {}", self, val)));
         }
-        let value = &self.value;
-        let multiplier = objint::get_value(&val)
-            .to_i32()
+        objint::get_value(&val)
+            .to_isize()
             .map(|multiplier| multiplier.max(0))
             .and_then(|multiplier| multiplier.to_usize())
-            .unwrap_or(0);
-        Ok(value.repeat(multiplier))
+            .map(|multiplier| self.value.repeat(multiplier))
+            .ok_or_else(|| {
+                vm.new_overflow_error("cannot fit 'int' into an index-sized integer".to_string())
+            })
     }
 
     #[pymethod(name = "__rmul__")]

--- a/vm/src/obj/objstr.rs
+++ b/vm/src/obj/objstr.rs
@@ -189,7 +189,7 @@ impl PyString {
         let value = &self.value;
         let multiplier = objint::get_value(&val)
             .to_i32()
-            .map(|multiplier| if multiplier < 0 { 0 } else { multiplier })
+            .map(|multiplier| multiplier.max(0))
             .and_then(|multiplier| multiplier.to_usize())
             .unwrap_or(0);
         Ok(value.repeat(multiplier))


### PR DESCRIPTION
- Used `str::repeat` instead of manually building the result string
- Rewritten the int type check to return error at the beginning of the
method
- Replaced the `unwrap` calls with the single `unwrap_or`