### PR TITLE
Support frozen modules

### DIFF
--- a/tests/snippets/frozen.py
+++ b/tests/snippets/frozen.py
@@ -1,0 +1,2 @@
+import __hello__
+assert __hello__.initialized == True

--- a/vm/src/frozen.rs
+++ b/vm/src/frozen.rs
@@ -1,0 +1,11 @@
+use std::collections::hash_map::HashMap;
+
+const HELLO: &str = "initialized = True
+print(\"Hello world!\")
+";
+
+pub fn get_module_inits() -> HashMap<String, &'static str> {
+    let mut modules = HashMap::new();
+    modules.insert("__hello__".to_string(), HELLO);
+    modules
+}

--- a/vm/src/import.rs
+++ b/vm/src/import.rs
@@ -18,6 +18,8 @@ pub fn import_module(vm: &VirtualMachine, current_path: PathBuf, module_name: &s
     // First, see if we already loaded the module:
     if let Ok(module) = sys_modules.get_item(module_name.to_string(), vm) {
         Ok(module)
+    } else if let Some(frozen) = vm.frozen.borrow().get(module_name) {
+        import_file(vm, module_name, "frozen".to_string(), frozen.to_string())
     } else if let Some(make_module_func) = vm.stdlib_inits.borrow().get(module_name) {
         let module = make_module_func(vm);
         sys_modules.set_item(module_name, module.clone(), vm)?;

--- a/vm/src/lib.rs
+++ b/vm/src/lib.rs
@@ -45,6 +45,7 @@ pub mod eval;
 mod exceptions;
 pub mod format;
 pub mod frame;
+mod frozen;
 pub mod function;
 pub mod import;
 pub mod obj;

--- a/vm/src/vm.rs
+++ b/vm/src/vm.rs
@@ -16,6 +16,7 @@ use crate::builtins;
 use crate::bytecode;
 use crate::error::CompileError;
 use crate::frame::{ExecutionResult, Frame, FrameRef, Scope};
+use crate::frozen;
 use crate::function::PyFuncArgs;
 use crate::obj::objbool;
 use crate::obj::objbuiltinfunc::PyBuiltinFunction;
@@ -53,6 +54,7 @@ pub struct VirtualMachine {
     pub frames: RefCell<Vec<FrameRef>>,
     pub wasm_id: Option<String>,
     pub exceptions: RefCell<Vec<PyObjectRef>>,
+    pub frozen: RefCell<HashMap<String, &'static str>>,
 }
 
 impl VirtualMachine {
@@ -65,6 +67,7 @@ impl VirtualMachine {
         let sysmod = ctx.new_module("sys", ctx.new_dict());
 
         let stdlib_inits = RefCell::new(stdlib::get_module_inits());
+        let frozen = RefCell::new(frozen::get_module_inits());
         let vm = VirtualMachine {
             builtins: builtins.clone(),
             sys_module: sysmod.clone(),
@@ -73,6 +76,7 @@ impl VirtualMachine {
             frames: RefCell::new(vec![]),
             wasm_id: None,
             exceptions: RefCell::new(vec![]),
+            frozen,
         };
 
         builtins::make_module(&vm, builtins.clone());


### PR DESCRIPTION
As part of #958 we need to be able to import frozen modules. This is not the same as in Cpython as we do not compile the code and marshal it. I think that can wait for a later stage.