### PR TITLE
Check RUSTPYTHONPATH as well as PYTHONPATH env variables

### DIFF
--- a/vm/src/sysmodule.rs
+++ b/vm/src/sysmodule.rs
@@ -54,15 +54,19 @@ pub fn make_module(vm: &VirtualMachine, module: PyObjectRef, builtins: PyObjectR
         "cache_tag" => ctx.new_str("rustpython-01".to_string()),
     });
 
-    fn get_paths(env_name: &str) -> impl Iterator<Item = std::path::PathBuf> {
-        match env::var_os(env_name) {
-            Some(paths) => env::split_paths(&paths),
+    fn get_paths<'a>(
+        paths: &'a Option<std::ffi::OsString>,
+    ) -> impl Iterator<Item = std::path::PathBuf> + 'a {
+        match paths {
+            Some(paths) => env::split_paths(paths),
             None => env::split_paths(""),
         }
     }
 
-    let path_list = get_paths("RUSTPYTHONPATH")
-        .chain(get_paths("PYTHONPATH"))
+    let rustpy_path = env::var_os("RUSTPYTHONPATH");
+    let py_path = env::var_os("PYTHONPATH");
+    let path_list = get_paths(&rustpy_path)
+        .chain(get_paths(&py_path))
         .map(|path| {
             ctx.new_str(
                 path.to_str()

--- a/vm/src/sysmodule.rs
+++ b/vm/src/sysmodule.rs
@@ -54,27 +54,31 @@ pub fn make_module(vm: &VirtualMachine, module: PyObjectRef, builtins: PyObjectR
         "cache_tag" => ctx.new_str("rustpython-01".to_string()),
     });
 
-    fn get_paths<'a>(
-        paths: &'a Option<std::ffi::OsString>,
-    ) -> impl Iterator<Item = std::path::PathBuf> + 'a {
-        match paths {
-            Some(paths) => env::split_paths(paths),
-            None => env::split_paths(""),
+    let path_list = if cfg!(target_arch = "wasm32") {
+        vec![]
+    } else {
+        fn get_paths<'a>(
+            paths: &'a Option<std::ffi::OsString>,
+        ) -> impl Iterator<Item = std::path::PathBuf> + 'a {
+            match paths {
+                Some(paths) => env::split_paths(paths),
+                None => env::split_paths(""),
+            }
         }
-    }
 
-    let rustpy_path = env::var_os("RUSTPYTHONPATH");
-    let py_path = env::var_os("PYTHONPATH");
-    let path_list = get_paths(&rustpy_path)
-        .chain(get_paths(&py_path))
-        .map(|path| {
-            ctx.new_str(
-                path.to_str()
-                    .expect("PYTHONPATH isn't valid unicode")
-                    .to_string(),
-            )
-        })
-        .collect();
+        let rustpy_path = env::var_os("RUSTPYTHONPATH");
+        let py_path = env::var_os("PYTHONPATH");
+        get_paths(&rustpy_path)
+            .chain(get_paths(&py_path))
+            .map(|path| {
+                ctx.new_str(
+                    path.to_str()
+                        .expect("PYTHONPATH isn't valid unicode")
+                        .to_string(),
+                )
+            })
+            .collect()
+    };
     let path = ctx.new_list(path_list);
 
     let platform = if cfg!(target_os = "linux") {


### PR DESCRIPTION
The motivation for this is so that we could `export RUSTPYTHONPATH=${rustpython_checkout}/Lib` in our dev environments, and then not have to worry about having to do `PYTHONPATH=$PWD/Lib cargo run` or worrying about a permanently set PYTHONPATH with the RustPython `Lib` directory messing something up for python programs. If anyone has come up with a better way of managing this in their dev environment I'd be interested in hearing it.