### PR TITLE
Fix most of clippy warnings

### DIFF
--- a/parser/src/ast.rs
+++ b/parser/src/ast.rs
@@ -44,6 +44,7 @@ pub struct Located<T> {
 pub type LocatedStatement = Located<Statement>;
 
 /// Abstract syntax tree nodes for python statements.
+#[allow(clippy::large_enum_variant)]
 #[derive(Debug, PartialEq)]
 pub enum Statement {
     Break,

--- a/vm/src/builtins.rs
+++ b/vm/src/builtins.rs
@@ -612,13 +612,12 @@ impl Printer for std::io::StdoutLock<'_> {
     }
 }
 
-pub fn builtin_exit(object: OptionalArg<PyObjectRef>, vm: &VirtualMachine) -> PyResult<()> {
-    match object {
-        OptionalArg::Present(object) => match i32::try_from_object(&vm, object.clone()) {
+pub fn builtin_exit(exit_code_arg: OptionalArg<PyObjectRef>, vm: &VirtualMachine) -> PyResult<()> {
+    if let OptionalArg::Present(exit_code_obj) = exit_code_arg {
+        match i32::try_from_object(&vm, exit_code_obj.clone()) {
             Ok(code) => std::process::exit(code),
-            _ => println!("{}", vm.to_str(&object)?.as_str()),
-        },
-        _ => {}
+            _ => println!("{}", vm.to_str(&exit_code_obj)?.as_str()),
+        }
     }
     std::process::exit(0);
 }

--- a/vm/src/dictdatatype.rs
+++ b/vm/src/dictdatatype.rs
@@ -193,7 +193,7 @@ impl<T: Clone> Dict<T> {
         Box::new(
             self.entries
                 .iter()
-                .filter_map(|v| v.as_ref().map_or(None, |v| Some(v.key.clone()))),
+                .filter_map(|v| v.as_ref().and_then(|v| Some(v.key.clone()))),
         )
     }
 

--- a/vm/src/frame.rs
+++ b/vm/src/frame.rs
@@ -173,8 +173,7 @@ impl NameProtocol for Scope {
     fn store_cell(&self, vm: &VirtualMachine, name: &str, value: PyObjectRef) {
         self.locals
             .iter()
-            .skip(1)
-            .next()
+            .nth(1)
             .expect("no outer scope for non-local")
             .set_item(name, value, vm)
             .unwrap();

--- a/vm/src/obj/objbytearray.rs
+++ b/vm/src/obj/objbytearray.rs
@@ -340,7 +340,7 @@ impl PyByteArrayRef {
         let pos = bytes
             .iter()
             .position(|b| *b == x)
-            .ok_or(vm.new_value_error("value not found in bytearray".to_string()))?;
+            .ok_or_else(|| vm.new_value_error("value not found in bytearray".to_string()))?;
 
         bytes.remove(pos);
 

--- a/vm/src/obj/objcode.rs
+++ b/vm/src/obj/objcode.rs
@@ -34,6 +34,7 @@ impl PyValue for PyCode {
 }
 
 impl PyCodeRef {
+    #[allow(clippy::new_ret_no_self)]
     fn new(_cls: PyClassRef, vm: &VirtualMachine) -> PyResult {
         Err(vm.new_type_error("Cannot directly create code object".to_string()))
     }

--- a/vm/src/obj/objcomplex.rs
+++ b/vm/src/obj/objcomplex.rs
@@ -126,12 +126,12 @@ impl PyComplex {
 
     #[pymethod(name = "__float__")]
     fn float(&self, vm: &VirtualMachine) -> PyResult {
-        return Err(vm.new_type_error(String::from("Can't convert complex to float")));
+        Err(vm.new_type_error(String::from("Can't convert complex to float")))
     }
 
     #[pymethod(name = "__int__")]
     fn int(&self, vm: &VirtualMachine) -> PyResult {
-        return Err(vm.new_type_error(String::from("Can't convert complex to int")));
+        Err(vm.new_type_error(String::from("Can't convert complex to int")))
     }
 
     #[pymethod(name = "__mul__")]

--- a/vm/src/obj/objfloat.rs
+++ b/vm/src/obj/objfloat.rs
@@ -541,7 +541,7 @@ pub fn ufrexp(value: f64) -> (f64, i32) {
     } else {
         let bits = value.to_bits();
         let exponent: i32 = ((bits >> 52) & 0x7ff) as i32 - 1022;
-        let mantissa_bits = bits & (0x000fffffffffffff) | (1022 << 52);
+        let mantissa_bits = bits & (0x000f_ffff_ffff_ffff) | (1022 << 52);
         (f64::from_bits(mantissa_bits), exponent)
     }
 }

--- a/vm/src/obj/objframe.rs
+++ b/vm/src/obj/objframe.rs
@@ -18,6 +18,7 @@ pub fn init(context: &PyContext) {
 }
 
 impl FrameRef {
+    #[allow(clippy::new_ret_no_self)]
     fn new(_class: FrameRef, vm: &VirtualMachine) -> PyResult {
         Err(vm.new_type_error("Cannot directly create frame object".to_string()))
     }

--- a/vm/src/obj/objint.rs
+++ b/vm/src/obj/objint.rs
@@ -112,8 +112,9 @@ impl_try_from_object_int!(
     (u64, to_u64),
 );
 
+#[allow(clippy::collapsible_if)]
 fn inner_pow(int1: &PyInt, int2: &PyInt, vm: &VirtualMachine) -> PyResult {
-    Ok(if int2.value.is_negative() {
+    let result = if int2.value.is_negative() {
         let v1 = int1.float(vm)?;
         let v2 = int2.float(vm)?;
         vm.ctx.new_float(v1.pow(v2))
@@ -133,7 +134,8 @@ fn inner_pow(int1: &PyInt, int2: &PyInt, vm: &VirtualMachine) -> PyResult {
             // practically, exp over u64 is not possible to calculate anyway
             vm.ctx.not_implemented()
         }
-    })
+    };
+    Ok(result)
 }
 
 #[pyimpl]
@@ -494,6 +496,7 @@ impl PyInt {
     }
 
     #[pymethod]
+    #[allow(clippy::match_bool)]
     fn from_bytes(
         bytes: PyByteInner,
         byteorder: PyStringRef,
@@ -529,6 +532,7 @@ impl PyInt {
         Ok(x)
     }
     #[pymethod]
+    #[allow(clippy::match_bool)]
     fn to_bytes(
         &self,
         length: PyIntRef,
@@ -547,7 +551,7 @@ impl PyInt {
                 );
             }
         }
-        if value.sign() == Sign::Minus && signed == false {
+        if value.sign() == Sign::Minus && !signed {
             return Err(vm.new_overflow_error("can't convert negative int to unsigned".to_string()));
         }
         let byte_len;

--- a/vm/src/obj/objtuple.rs
+++ b/vm/src/obj/objtuple.rs
@@ -27,7 +27,7 @@ impl fmt::Debug for PyTuple {
 
 impl From<Vec<PyObjectRef>> for PyTuple {
     fn from(elements: Vec<PyObjectRef>) -> Self {
-        PyTuple { elements: elements }
+        PyTuple { elements }
     }
 }
 

--- a/vm/src/pyhash.rs
+++ b/vm/src/pyhash.rs
@@ -9,11 +9,11 @@ pub type PyHash = i64;
 pub type PyUHash = u64;
 
 /// Prime multiplier used in string and various other hashes.
-pub const MULTIPLIER: PyHash = 1000003; // 0xf4243
+pub const MULTIPLIER: PyHash = 1_000_003; // 0xf4243
 /// Numeric hashes are based on reduction modulo the prime 2**_BITS - 1
 pub const BITS: usize = 61;
 pub const MODULUS: PyUHash = (1 << BITS) - 1;
-pub const INF: PyHash = 314159;
+pub const INF: PyHash = 314_159;
 pub const NAN: PyHash = 0;
 pub const IMAG: PyHash = MULTIPLIER;
 
@@ -42,7 +42,7 @@ pub fn hash_float(value: f64) -> PyHash {
     let mut x: PyUHash = 0;
     while m != 0.0 {
         x = ((x << 28) & MODULUS) | x >> (BITS - 28);
-        m *= 268435456.0; // 2**28
+        m *= 268_435_456.0; // 2**28
         e -= 28;
         let y = m as PyUHash; // pull out integer part
         m -= y as f64;

--- a/vm/src/pyobject.rs
+++ b/vm/src/pyobject.rs
@@ -1238,6 +1238,7 @@ impl<T> PyObject<T>
 where
     T: Sized + PyObjectPayload,
 {
+    #[allow(clippy::new_ret_no_self)]
     pub fn new(payload: T, typ: PyClassRef, dict: Option<PyDictRef>) -> PyObjectRef {
         PyObject { typ, dict, payload }.into_ref()
     }

--- a/vm/src/stdlib/ast.rs
+++ b/vm/src/stdlib/ast.rs
@@ -457,7 +457,7 @@ fn parameter_to_ast(vm: &VirtualMachine, parameter: &ast::Parameter) -> PyResult
 fn map_ast<T>(
     f: fn(vm: &VirtualMachine, &T) -> PyResult<AstNodeRef>,
     vm: &VirtualMachine,
-    items: &Vec<T>,
+    items: &[T],
 ) -> PyResult<PyObjectRef> {
     let list: PyResult<Vec<PyObjectRef>> =
         items.iter().map(|x| Ok(f(vm, x)?.into_object())).collect();

--- a/vm/src/stdlib/itertools.rs
+++ b/vm/src/stdlib/itertools.rs
@@ -31,6 +31,7 @@ impl PyValue for PyItertoolsChain {
 #[pyimpl]
 impl PyItertoolsChain {
     #[pymethod(name = "__new__")]
+    #[allow(clippy::new_ret_no_self)]
     fn new(_cls: PyClassRef, args: PyFuncArgs, vm: &VirtualMachine) -> PyResult {
         Ok(PyItertoolsChain {
             iterables: args.args,
@@ -88,6 +89,7 @@ impl PyValue for PyItertoolsCount {
 #[pyimpl]
 impl PyItertoolsCount {
     #[pymethod(name = "__new__")]
+    #[allow(clippy::new_ret_no_self)]
     fn new(
         _cls: PyClassRef,
         start: OptionalArg<PyIntRef>,
@@ -105,7 +107,7 @@ impl PyItertoolsCount {
 
         Ok(PyItertoolsCount {
             cur: RefCell::new(start),
-            step: step,
+            step,
         }
         .into_ref(vm)
         .into_object())
@@ -140,6 +142,7 @@ impl PyValue for PyItertoolsRepeat {
 #[pyimpl]
 impl PyItertoolsRepeat {
     #[pymethod(name = "__new__")]
+    #[allow(clippy::new_ret_no_self)]
     fn new(
         _cls: PyClassRef,
         object: PyObjectRef,
@@ -153,7 +156,7 @@ impl PyItertoolsRepeat {
 
         Ok(PyItertoolsRepeat {
             object: object.clone(),
-            times: times,
+            times,
         }
         .into_ref(vm)
         .into_object())
@@ -198,6 +201,7 @@ impl PyValue for PyItertoolsStarmap {
 #[pyimpl]
 impl PyItertoolsStarmap {
     #[pymethod(name = "__new__")]
+    #[allow(clippy::new_ret_no_self)]
     fn new(
         _cls: PyClassRef,
         function: PyObjectRef,
@@ -206,12 +210,9 @@ impl PyItertoolsStarmap {
     ) -> PyResult {
         let iter = get_iter(vm, &iterable)?;
 
-        Ok(PyItertoolsStarmap {
-            function: function,
-            iter: iter,
-        }
-        .into_ref(vm)
-        .into_object())
+        Ok(PyItertoolsStarmap { function, iter }
+            .into_ref(vm)
+            .into_object())
     }
 
     #[pymethod(name = "__next__")]
@@ -244,6 +245,7 @@ impl PyValue for PyItertoolsTakewhile {
 #[pyimpl]
 impl PyItertoolsTakewhile {
     #[pymethod(name = "__new__")]
+    #[allow(clippy::new_ret_no_self)]
     fn new(
         _cls: PyClassRef,
         predicate: PyObjectRef,
@@ -253,7 +255,7 @@ impl PyItertoolsTakewhile {
         let iter = get_iter(vm, &iterable)?;
 
         Ok(PyItertoolsTakewhile {
-            predicate: predicate,
+            predicate,
             iterable: iter,
             stop_flag: RefCell::new(false),
         }
@@ -314,6 +316,7 @@ fn pyobject_to_opt_usize(obj: PyObjectRef, vm: &VirtualMachine) -> Option<usize>
 #[pyimpl]
 impl PyItertoolsIslice {
     #[pymethod(name = "__new__")]
+    #[allow(clippy::new_ret_no_self)]
     fn new(_cls: PyClassRef, args: PyFuncArgs, vm: &VirtualMachine) -> PyResult {
         let (iter, start, stop, step) = match args.args.len() {
             0 | 1 => {
@@ -377,8 +380,8 @@ impl PyItertoolsIslice {
             iterable: iter,
             cur: RefCell::new(0),
             next: RefCell::new(start),
-            stop: stop,
-            step: step,
+            stop,
+            step,
         }
         .into_ref(vm)
         .into_object())

--- a/vm/src/stdlib/os.rs
+++ b/vm/src/stdlib/os.rs
@@ -259,6 +259,7 @@ impl DirEntryRef {
         self.entry.path().to_str().unwrap().to_string()
     }
 
+    #[allow(clippy::match_bool)]
     fn perform_on_metadata(
         self,
         follow_symlinks: FollowSymlinks,
@@ -434,6 +435,7 @@ fn to_seconds_from_nanos(secs: i64, nanos: i64) -> f64 {
 #[cfg(unix)]
 macro_rules! os_unix_stat_inner {
     ( $path:expr, $follow_symlinks:expr, $vm:expr ) => {{
+        #[allow(clippy::match_bool)]
         fn get_stats(path: &str, follow_symlinks: bool) -> io::Result<StatResult> {
             let meta = match follow_symlinks {
                 true => fs::metadata(path)?,
@@ -685,12 +687,13 @@ pub fn make_module(vm: &VirtualMachine) -> PyObjectRef {
         where
             F: IntoPyNativeFunc<T, R>,
         {
+            let func_obj = vm.ctx.new_rustfunc(func);
             Self {
-                name: name,
-                func_obj: vm.ctx.new_rustfunc(func),
-                fd: fd,
-                dir_fd: dir_fd,
-                follow_symlinks: follow_symlinks,
+                name,
+                func_obj,
+                fd,
+                dir_fd,
+                follow_symlinks,
             }
         }
     }

--- a/vm/src/stdlib/socket.rs
+++ b/vm/src/stdlib/socket.rs
@@ -218,7 +218,7 @@ impl SocketRef {
         }
     }
 
-    fn listen(self, _num: PyIntRef, _vm: &VirtualMachine) -> () {}
+    fn listen(self, _num: PyIntRef, _vm: &VirtualMachine) {}
 
     fn accept(self, vm: &VirtualMachine) -> PyResult {
         let ret = match self.con.borrow_mut().as_mut() {
@@ -310,7 +310,7 @@ impl SocketRef {
         }
     }
 
-    fn close(self, _vm: &VirtualMachine) -> () {
+    fn close(self, _vm: &VirtualMachine) {
         self.con.borrow_mut().take();
     }
 

--- a/vm/src/vm.rs
+++ b/vm/src/vm.rs
@@ -951,7 +951,7 @@ impl VirtualMachine {
         }
     }
 
-    pub fn push_exception(&self, exc: PyObjectRef) -> () {
+    pub fn push_exception(&self, exc: PyObjectRef) {
         self.exceptions.borrow_mut().push(exc)
     }
 


### PR DESCRIPTION
`identity_conversion` warnings are false-positives https://github.com/rust-lang/rust-clippy/issues/4133, should disappear in 1.36. 

I'm not sure what to do with others, lots of them are for the `PyFloat` object methods which uses macros, so I'm not positive about `&self` -> `self` change suggested by the lint. 