### PR TITLE
Cleanup get_method() error handling

### DIFF
--- a/vm/src/builtins.rs
+++ b/vm/src/builtins.rs
@@ -31,11 +31,9 @@ use crate::vm::VirtualMachine;
 use crate::stdlib::io::io_open;
 
 fn builtin_abs(x: PyObjectRef, vm: &VirtualMachine) -> PyResult {
-    let method = vm.get_method_or_type_error(
-        x.clone(),
-        "__abs__",
-        format!("bad operand type for abs(): '{}'", x.class().name),
-    )?;
+    let method = vm.get_method_or_type_error(x.clone(), "__abs__", || {
+        format!("bad operand type for abs(): '{}'", x.class().name)
+    })?;
     vm.invoke(method, PyFuncArgs::new(vec![], vec![]))
 }
 
@@ -369,11 +367,9 @@ fn builtin_iter(vm: &VirtualMachine, args: PyFuncArgs) -> PyResult {
 
 fn builtin_len(vm: &VirtualMachine, args: PyFuncArgs) -> PyResult {
     arg_check!(vm, args, required = [(obj, None)]);
-    let method = vm.get_method_or_type_error(
-        obj.clone(),
-        "__len__",
-        format!("object of type '{}' has no len()", obj.class().name),
-    )?;
+    let method = vm.get_method_or_type_error(obj.clone(), "__len__", || {
+        format!("object of type '{}' has no len()", obj.class().name)
+    })?;
     vm.invoke(method, PyFuncArgs::default())
 }
 
@@ -671,11 +667,9 @@ fn builtin_reversed(vm: &VirtualMachine, args: PyFuncArgs) -> PyResult {
     arg_check!(vm, args, required = [(obj, None)]);
 
     // TODO: fallback to using __len__ and __getitem__, if object supports sequence protocol
-    let method = vm.get_method_or_type_error(
-        obj.clone(),
-        "__reversed__",
-        format!("argument to reversed() must be a sequence"),
-    )?;
+    let method = vm.get_method_or_type_error(obj.clone(), "__reversed__", || {
+        format!("argument to reversed() must be a sequence")
+    })?;
     vm.invoke(method, PyFuncArgs::default())
 }
 

--- a/vm/src/obj/objdict.rs
+++ b/vm/src/obj/objdict.rs
@@ -206,11 +206,10 @@ impl PyDictRef {
         if let Some(value) = self.entries.borrow().get(vm, &key)? {
             return Ok(value);
         }
-
-        if let Ok(method) = vm.get_method(self.clone().into_object(), "__missing__") {
+        if let Some(method_or_err) = vm.get_method(self.clone().into_object(), "__missing__") {
+            let method = method_or_err?;
             return vm.invoke(method, vec![key]);
         }
-
         Err(vm.new_key_error(format!("Key not found: {}", vm.to_pystr(&key)?)))
     }
 

--- a/vm/src/obj/objfloat.rs
+++ b/vm/src/obj/objfloat.rs
@@ -557,14 +557,12 @@ pub fn make_float(vm: &VirtualMachine, obj: &PyObjectRef) -> PyResult<f64> {
     if objtype::isinstance(obj, &vm.ctx.float_type()) {
         Ok(get_value(obj))
     } else {
-        let method = vm.get_method_or_type_error(
-            obj.clone(),
-            "__float__",
+        let method = vm.get_method_or_type_error(obj.clone(), "__float__", || {
             format!(
                 "float() argument must be a string or a number, not '{}'",
                 obj.class().name
-            ),
-        )?;
+            )
+        })?;
         let result = vm.invoke(method, vec![])?;
         Ok(get_value(&result))
     }

--- a/vm/src/obj/objfloat.rs
+++ b/vm/src/obj/objfloat.rs
@@ -262,7 +262,7 @@ impl PyFloat {
                 Err(_) => {
                     let arg_repr = vm.to_pystr(&arg)?;
                     return Err(vm.new_value_error(format!(
-                        "could not convert string to float: {}",
+                        "could not convert string to float: '{}'",
                         arg_repr
                     )));
                 }
@@ -273,7 +273,7 @@ impl PyFloat {
                 Err(_) => {
                     let arg_repr = vm.to_pystr(&arg)?;
                     return Err(vm.new_value_error(format!(
-                        "could not convert string to float: {}",
+                        "could not convert string to float: '{}'",
                         arg_repr
                     )));
                 }
@@ -556,11 +556,17 @@ pub fn get_value(obj: &PyObjectRef) -> f64 {
 pub fn make_float(vm: &VirtualMachine, obj: &PyObjectRef) -> PyResult<f64> {
     if objtype::isinstance(obj, &vm.ctx.float_type()) {
         Ok(get_value(obj))
-    } else if let Ok(method) = vm.get_method(obj.clone(), "__float__") {
-        let res = vm.invoke(method, vec![])?;
-        Ok(get_value(&res))
     } else {
-        Err(vm.new_type_error(format!("Cannot cast {} to float", obj)))
+        let method = vm.get_method_or_type_error(
+            obj.clone(),
+            "__float__",
+            format!(
+                "float() argument must be a string or a number, not '{}'",
+                obj.class().name
+            ),
+        )?;
+        let result = vm.invoke(method, vec![])?;
+        Ok(get_value(&result))
     }
 }
 

--- a/vm/src/obj/objint.rs
+++ b/vm/src/obj/objint.rs
@@ -657,12 +657,9 @@ pub fn to_int(vm: &VirtualMachine, obj: &PyObjectRef, base: u32) -> PyResult<Big
                 )))
         },
         obj => {
-            let method = vm.get_method_or_type_error(
-                    obj.clone(),
-                    "__int__",
-                    format!("int() argument must be a string or a number, not '{}'",
-                            obj.class().name)
-            )?;
+            let method = vm.get_method_or_type_error(obj.clone(), "__int__", || {
+                format!("int() argument must be a string or a number, not '{}'", obj.class().name)
+            })?;
             let result = vm.invoke(method, PyFuncArgs::default())?;
             match result.payload::<PyInt>() {
                 Some(int_obj) => Ok(int_obj.as_bigint().clone()),

--- a/vm/src/obj/objint.rs
+++ b/vm/src/obj/objint.rs
@@ -657,18 +657,17 @@ pub fn to_int(vm: &VirtualMachine, obj: &PyObjectRef, base: u32) -> PyResult<Big
                 )))
         },
         obj => {
-            if let Ok(f) = vm.get_method(obj.clone(), "__int__") {
-                let int_res = vm.invoke(f, PyFuncArgs::default())?;
-                match int_res.payload::<PyInt>() {
-                    Some(i) => Ok(i.as_bigint().clone()),
-                    None => Err(vm.new_type_error(format!(
-                        "TypeError: __int__ returned non-int (type '{}')", int_res.class().name))),
-                }
-            } else {
-                Err(vm.new_type_error(format!(
-                    "int() argument must be a string or a number, not '{}'",
-                    obj.class().name
-                )))
+            let method = vm.get_method_or_type_error(
+                    obj.clone(),
+                    "__int__",
+                    format!("int() argument must be a string or a number, not '{}'",
+                            obj.class().name)
+            )?;
+            let result = vm.invoke(method, PyFuncArgs::default())?;
+            match result.payload::<PyInt>() {
+                Some(int_obj) => Ok(int_obj.as_bigint().clone()),
+                None => Err(vm.new_type_error(format!(
+                    "TypeError: __int__ returned non-int (type '{}')", result.class().name))),
             }
         }
     )

--- a/vm/src/obj/objiter.rs
+++ b/vm/src/obj/objiter.rs
@@ -18,18 +18,20 @@ use super::objtype::PyClassRef;
  * function 'iter' is called.
  */
 pub fn get_iter(vm: &VirtualMachine, iter_target: &PyObjectRef) -> PyResult {
-    if let Ok(method) = vm.get_method(iter_target.clone(), "__iter__") {
+    if let Some(method_or_err) = vm.get_method(iter_target.clone(), "__iter__") {
+        let method = method_or_err?;
         vm.invoke(method, vec![])
-    } else if vm.get_method(iter_target.clone(), "__getitem__").is_ok() {
-        Ok(PySequenceIterator {
+    } else {
+        vm.get_method_or_type_error(
+            iter_target.clone(),
+            "__getitem__",
+            format!("Cannot iterate over {}", iter_target.class().name),
+        )?;
+        let obj_iterator = PySequenceIterator {
             position: Cell::new(0),
             obj: iter_target.clone(),
-        }
-        .into_ref(vm)
-        .into_object())
-    } else {
-        let message = format!("Cannot iterate over {}", iter_target.class().name);
-        return Err(vm.new_type_error(message));
+        };
+        Ok(obj_iterator.into_ref(vm).into_object())
     }
 }
 

--- a/vm/src/obj/objiter.rs
+++ b/vm/src/obj/objiter.rs
@@ -22,11 +22,9 @@ pub fn get_iter(vm: &VirtualMachine, iter_target: &PyObjectRef) -> PyResult {
         let method = method_or_err?;
         vm.invoke(method, vec![])
     } else {
-        vm.get_method_or_type_error(
-            iter_target.clone(),
-            "__getitem__",
-            format!("Cannot iterate over {}", iter_target.class().name),
-        )?;
+        vm.get_method_or_type_error(iter_target.clone(), "__getitem__", || {
+            format!("Cannot iterate over {}", iter_target.class().name)
+        })?;
         let obj_iterator = PySequenceIterator {
             position: Cell::new(0),
             obj: iter_target.clone(),

--- a/vm/src/obj/objstr.rs
+++ b/vm/src/obj/objstr.rs
@@ -869,11 +869,9 @@ impl PyString {
     // https://docs.python.org/3/library/stdtypes.html#str.translate
     #[pymethod]
     fn translate(&self, table: PyObjectRef, vm: &VirtualMachine) -> PyResult<String> {
-        vm.get_method_or_type_error(
-            table.clone(),
-            "__getitem__",
-            format!("'{}' object is not subscriptable", table.class().name),
-        )?;
+        vm.get_method_or_type_error(table.clone(), "__getitem__", || {
+            format!("'{}' object is not subscriptable", table.class().name)
+        })?;
 
         let mut translated = String::new();
         for c in self.value.chars() {

--- a/vm/src/obj/objstr.rs
+++ b/vm/src/obj/objstr.rs
@@ -869,9 +869,13 @@ impl PyString {
     // https://docs.python.org/3/library/stdtypes.html#str.translate
     #[pymethod]
     fn translate(&self, table: PyObjectRef, vm: &VirtualMachine) -> PyResult<String> {
+        vm.get_method_or_type_error(
+            table.clone(),
+            "__getitem__",
+            format!("'{}' object is not subscriptable", table.class().name),
+        )?;
+
         let mut translated = String::new();
-        // It throws a type error if it is not subscribtable
-        vm.get_method(table.clone(), "__getitem__")?;
         for c in self.value.chars() {
             match table.get_item(c as u32, vm) {
                 Ok(value) => {

--- a/vm/src/obj/objtype.rs
+++ b/vm/src/obj/objtype.rs
@@ -270,8 +270,9 @@ pub fn type_call(class: PyClassRef, args: Args, kwargs: KwArgs, vm: &VirtualMach
     let new_wrapped = vm.call_get_descriptor(new, class.into_object())?;
     let obj = vm.invoke(new_wrapped, (&args, &kwargs))?;
 
-    if let Ok(init) = vm.get_method(obj.clone(), "__init__") {
-        let res = vm.invoke(init, (&args, &kwargs))?;
+    if let Some(init_method_or_err) = vm.get_method(obj.clone(), "__init__") {
+        let init_method = init_method_or_err?;
+        let res = vm.invoke(init_method, (&args, &kwargs))?;
         if !res.is(&vm.get_none()) {
             return Err(vm.new_type_error("__init__ must return None".to_string()));
         }

--- a/vm/src/pyobject.rs
+++ b/vm/src/pyobject.rs
@@ -1141,11 +1141,9 @@ where
                 _item: std::marker::PhantomData,
             })
         } else {
-            vm.get_method_or_type_error(
-                obj.clone(),
-                "__getitem__",
-                format!("'{}' object is not iterable", obj.class().name),
-            )?;
+            vm.get_method_or_type_error(obj.clone(), "__getitem__", || {
+                format!("'{}' object is not iterable", obj.class().name)
+            })?;
             Self::try_from_object(
                 vm,
                 objiter::PySequenceIterator {

--- a/vm/src/stdlib/math.rs
+++ b/vm/src/stdlib/math.rs
@@ -173,15 +173,16 @@ fn math_lgamma(vm: &VirtualMachine, args: PyFuncArgs) -> PyResult {
 }
 
 fn try_magic_method(func_name: &str, vm: &VirtualMachine, value: &PyObjectRef) -> PyResult {
-    if let Ok(method) = vm.get_method(value.clone(), func_name) {
-        vm.invoke(method, vec![])
-    } else {
-        Err(vm.new_type_error(format!(
-            "TypeError: type {} doesn't define {} method",
+    let method = vm.get_method_or_type_error(
+        value.clone(),
+        func_name,
+        format!(
+            "type '{}' doesn't define '{}' method",
             value.class().name,
             func_name,
-        )))
-    }
+        ),
+    )?;
+    vm.invoke(method, vec![])
 }
 
 fn math_trunc(vm: &VirtualMachine, args: PyFuncArgs) -> PyResult {

--- a/vm/src/stdlib/math.rs
+++ b/vm/src/stdlib/math.rs
@@ -173,15 +173,13 @@ fn math_lgamma(vm: &VirtualMachine, args: PyFuncArgs) -> PyResult {
 }
 
 fn try_magic_method(func_name: &str, vm: &VirtualMachine, value: &PyObjectRef) -> PyResult {
-    let method = vm.get_method_or_type_error(
-        value.clone(),
-        func_name,
+    let method = vm.get_method_or_type_error(value.clone(), func_name, || {
         format!(
             "type '{}' doesn't define '{}' method",
             value.class().name,
             func_name,
-        ),
-    )?;
+        )
+    })?;
     vm.invoke(method, vec![])
 }
 

--- a/vm/src/vm.rs
+++ b/vm/src/vm.rs
@@ -166,7 +166,7 @@ impl VirtualMachine {
     }
 
     pub fn new_empty_exception(&self, exc_type: PyClassRef) -> PyResult {
-        info!("New exception created: no msg");
+        info!("New exception created: {}", exc_type.name);
         let args = PyFuncArgs::default();
         self.invoke(exc_type.into_object(), args)
     }
@@ -175,7 +175,7 @@ impl VirtualMachine {
     pub fn new_exception(&self, exc_type: PyClassRef, msg: String) -> PyObjectRef {
         // TODO: exc_type may be user-defined exception, so we should return PyResult
         // TODO: maybe there is a clearer way to create an instance:
-        info!("New exception created: {}", msg);
+        info!("New exception created: {}('{}')", exc_type.name, msg);
         let pymsg = self.new_str(msg);
         let args: Vec<PyObjectRef> = vec![pymsg];
         self.invoke(exc_type.into_object(), args).unwrap()

--- a/vm/src/vm.rs
+++ b/vm/src/vm.rs
@@ -624,16 +624,19 @@ impl VirtualMachine {
 
     // get_method should be used for internal access to magic methods (by-passing
     // the full getattribute look-up.
-    pub fn get_method_or_type_error(
+    pub fn get_method_or_type_error<F>(
         &self,
         obj: PyObjectRef,
         method_name: &str,
-        err_msg: String,
-    ) -> PyResult {
+        err_msg: F,
+    ) -> PyResult
+    where
+        F: FnOnce() -> String,
+    {
         let cls = obj.class();
         match objtype::class_get_attr(&cls, method_name) {
             Some(method) => self.call_get_descriptor(method, obj.clone()),
-            None => Err(self.new_type_error(err_msg)),
+            None => Err(self.new_type_error(err_msg())),
         }
     }
 


### PR DESCRIPTION
1. Make raising `TypeError` from `get_method()` more explicit by splitting it into two methods: one that raises `TypeError` if there's no method, and one that's not (for some cases, like `__missing__` method for dict). 

2. If it's acceptable for method to be absent (`__missing__`, `__iter__` for iterators and others), do not raise `TypeError`. 
(note that if `__get__` descriptor raises an exception, it still gets propagates as before)

3. Make error messages more consistent with CPython. 

4. Add `exc_type` to `info!` exception logging. 