### PR TITLE
Fix memoryview.obj misimplementation.

### DIFF
--- a/vm/src/obj/objmemory.rs
+++ b/vm/src/obj/objmemory.rs
@@ -1,18 +1,37 @@
 use crate::obj::objbyteinner::try_as_byte;
 use crate::obj::objtype::PyClassRef;
-use crate::pyobject::{PyContext, PyObjectRef, PyRef, PyResult, PyValue};
+use crate::pyobject::{PyClassImpl, PyContext, PyObjectRef, PyRef, PyResult, PyValue};
 use crate::vm::VirtualMachine;
+
+#[pyclass(name = "memoryview")]
+#[derive(Debug)]
+pub struct PyMemoryView {
+    obj_ref: PyObjectRef,
+}
 
 pub type PyMemoryViewRef = PyRef<PyMemoryView>;
 
-#[derive(Debug)]
-pub struct PyMemoryView {
-    obj: PyObjectRef,
-}
-
+#[pyimpl]
 impl PyMemoryView {
     pub fn get_obj_value(&self) -> Option<Vec<u8>> {
-        try_as_byte(&self.obj)
+        try_as_byte(&self.obj_ref)
+    }
+
+    #[pymethod(name = "__new__")]
+    fn new(
+        cls: PyClassRef,
+        bytes_object: PyObjectRef,
+        vm: &VirtualMachine,
+    ) -> PyResult<PyMemoryViewRef> {
+        PyMemoryView {
+            obj_ref: bytes_object.clone(),
+        }
+        .into_ref_with_type(vm, cls)
+    }
+
+    #[pyproperty]
+    fn obj(&self, __vm: &VirtualMachine) -> PyObjectRef {
+        self.obj_ref.clone()
     }
 }
 
@@ -22,18 +41,6 @@ impl PyValue for PyMemoryView {
     }
 }
 
-pub fn new_memory_view(
-    cls: PyClassRef,
-    bytes_object: PyObjectRef,
-    vm: &VirtualMachine,
-) -> PyResult<PyMemoryViewRef> {
-    vm.set_attr(cls.as_object(), "obj", bytes_object.clone())?;
-    PyMemoryView { obj: bytes_object }.into_ref_with_type(vm, cls)
-}
-
 pub fn init(ctx: &PyContext) {
-    let memoryview_type = &ctx.memoryview_type;
-    extend_class!(ctx, memoryview_type, {
-        "__new__" => ctx.new_rustfunc(new_memory_view)
-    });
+    PyMemoryView::extend_class(ctx, &ctx.memoryview_type)
 }


### PR DESCRIPTION
The memoryview skeleton did not correctly assign the "obj" attribute;
The "obj" attribute was assigned to the memoryview class and not the memryview object,
leading to a funny bug that can be reproduced as follows:

```python

m1 = memoryview(b'1234')
m2 = memoryview(b'abcd')

print(m1.obj)
```

the result would be the value inside `m2` instead that of `m1`