### PR TITLE
Disable the pwd module on android

### DIFF
--- a/vm/Cargo.toml
+++ b/vm/Cargo.toml
@@ -38,5 +38,5 @@ bincode = "1.1.4"
 git = "https://github.com/OddCoincidence/unicode-casing"
 rev = "90d6d1f02b9cc04ffb55a5f1c3fa1455a84231fb"
 
-[target.'cfg(unix)'.dependencies]
+[target.'cfg(all(unix, not(target_os = "android")))'.dependencies]
 pwd = "1"

--- a/vm/src/stdlib/mod.rs
+++ b/vm/src/stdlib/mod.rs
@@ -26,7 +26,7 @@ use crate::vm::VirtualMachine;
 pub mod io;
 #[cfg(not(target_arch = "wasm32"))]
 mod os;
-#[cfg(unix)]
+#[cfg(all(unix, not(target_os = "android")))]
 mod pwd;
 
 use crate::pyobject::PyObjectRef;
@@ -67,7 +67,7 @@ pub fn get_module_inits() -> HashMap<String, StdlibInitFunc> {
     }
 
     // Unix-only
-    #[cfg(unix)]
+    #[cfg(all(unix, not(target_os = "android")))]
     {
         modules.insert("pwd".to_string(), Box::new(pwd::make_module));
     }


### PR DESCRIPTION
It was causing a build error due to some `libc` functions that aren't available on android.