### PR TITLE
Feature: str.format accepting !r, !s and !a

### DIFF
--- a/tests/snippets/strings.py
+++ b/tests/snippets/strings.py
@@ -182,13 +182,27 @@ assert not '😂'.isidentifier()
 assert not '123'.isidentifier()
 
 # String Formatting
-assert "{} {}".format(1,2) == "1 2"
-assert "{0} {1}".format(2,3) == "2 3"
+assert "{} {}".format(1, 2) == "1 2"
+assert "{0} {1}".format(2, 3) == "2 3"
 assert "--{:s>4}--".format(1) == "--sss1--"
 assert "{keyword} {0}".format(1, keyword=2) == "2 1"
 assert "repr() shows quotes: {!r}; str() doesn't: {!s}".format(
     'test1', 'test2'
 ) == "repr() shows quotes: 'test1'; str() doesn't: test2", 'Output: {!r}, {!s}'.format('test1', 'test2')
+
+
+class Foo:
+    def __str__(self):
+        return 'str(Foo)'
+
+    def __repr__(self):
+        return 'repr(Foo)'
+
+
+f = Foo()
+assert "{} {!s} {!r} {!a}".format(f, f, f, f) == 'str(Foo) str(Foo) repr(Foo) repr(Foo)'
+assert "{foo} {foo!s} {foo!r} {foo!a}".format(foo=f) == 'str(Foo) str(Foo) repr(Foo) repr(Foo)'
+# assert '{} {!r} {:10} {!r:10} {foo!r:10} {foo!r} {foo}'.format('txt1', 'txt2', 'txt3', 'txt4', 'txt5', foo='bar')
 
 assert 'a' < 'b'
 assert 'a' <= 'b'

--- a/tests/snippets/strings.py
+++ b/tests/snippets/strings.py
@@ -186,6 +186,9 @@ assert "{} {}".format(1,2) == "1 2"
 assert "{0} {1}".format(2,3) == "2 3"
 assert "--{:s>4}--".format(1) == "--sss1--"
 assert "{keyword} {0}".format(1, keyword=2) == "2 1"
+assert "repr() shows quotes: {!r}; str() doesn't: {!s}".format(
+    'test1', 'test2'
+) == "repr() shows quotes: 'test1'; str() doesn't: test2", 'Output: {!r}, {!s}'.format('test1', 'test2')
 
 assert 'a' < 'b'
 assert 'a' <= 'b'

--- a/vm/src/format.rs
+++ b/vm/src/format.rs
@@ -467,6 +467,17 @@ impl FormatString {
             String::new()
         };
 
+        // On parts[0] can still be the preconversor (!r, !s, !a)
+        let parts: Vec<&str> = arg_part .splitn(2, '!').collect();
+        // before the bang is a keyword or arg index, after the comma is maybe a conversor spec.
+        let arg_part = parts[0];
+
+        let preconversor_spec = if parts.len() > 1 {
+            parts[1].to_string()
+        } else {
+            String::new()
+        };
+
         if arg_part.is_empty() {
             return Ok(FormatPart::AutoSpec(format_spec));
         }

--- a/vm/src/format.rs
+++ b/vm/src/format.rs
@@ -613,6 +613,7 @@ mod tests {
     #[test]
     fn test_width_only() {
         let expected = FormatSpec {
+            preconversor: None,
             fill: None,
             align: None,
             sign: None,
@@ -628,6 +629,7 @@ mod tests {
     #[test]
     fn test_fill_and_width() {
         let expected = FormatSpec {
+            preconversor: None,
             fill: Some('<'),
             align: Some(FormatAlign::Right),
             sign: None,
@@ -643,6 +645,7 @@ mod tests {
     #[test]
     fn test_all() {
         let expected = FormatSpec {
+            preconversor: None,
             fill: Some('<'),
             align: Some(FormatAlign::Right),
             sign: Some(FormatSign::Minus),


### PR DESCRIPTION
From: https://gitter.im/rustpython/Lobby?at=5cfa898ebf4cbd167c484cf0

As the Python docs, when a `{!r}` occur, it runs `__repr__` over the argument before applying the `:` rules. The current implementation of `{!a}` is not correct, as simple acts as `!r`.