### PR TITLE
Import all from_list in one call

### DIFF
--- a/compiler/src/bytecode.rs
+++ b/compiler/src/bytecode.rs
@@ -50,7 +50,7 @@ pub enum NameScope {
 pub enum Instruction {
     Import {
         name: String,
-        symbol: Option<String>,
+        symbols: Vec<String>,
     },
     ImportStar {
         name: String,
@@ -330,7 +330,7 @@ impl Instruction {
         }
 
         match self {
-            Import { name, symbol } => w!(Import, name, format!("{:?}", symbol)),
+            Import { name, symbols } => w!(Import, name, format!("{:?}", symbols)),
             ImportStar { name } => w!(ImportStar, name),
             LoadName { name, scope } => w!(LoadName, name, format!("{:?}", scope)),
             StoreName { name, scope } => w!(StoreName, name, format!("{:?}", scope)),

--- a/compiler/src/symboltable.rs
+++ b/compiler/src/symboltable.rs
@@ -300,14 +300,22 @@ impl SymbolTableBuilder {
                 for part in import_parts {
                     if let Some(alias) = &part.alias {
                         // `import mymodule as myalias`
-                        // `from mymodule import myimportname as myalias`
                         self.register_name(alias, SymbolRole::Assigned)?;
-                    } else if let Some(symbol) = &part.symbol {
-                        // `from mymodule import myimport`
-                        self.register_name(symbol, SymbolRole::Assigned)?;
                     } else {
-                        // `import module`
-                        self.register_name(&part.module, SymbolRole::Assigned)?;
+                        if part.symbols.is_empty() {
+                            // `import module`
+                            self.register_name(&part.module, SymbolRole::Assigned)?;
+                        } else {
+                            // `from mymodule import myimport`
+                            for symbol in &part.symbols {
+                                if let Some(alias) = &symbol.alias {
+                                    // `from mymodule import myimportname as myalias`
+                                    self.register_name(alias, SymbolRole::Assigned)?;
+                                } else {
+                                    self.register_name(&symbol.symbol, SymbolRole::Assigned)?;
+                                }
+                            }
+                        }
                     }
                 }
             }

--- a/parser/src/ast.rs
+++ b/parser/src/ast.rs
@@ -28,11 +28,16 @@ pub struct Program {
 }
 
 #[derive(Debug, PartialEq)]
+pub struct ImportSymbol {
+    pub symbol: String,
+    pub alias: Option<String>,
+}
+
+#[derive(Debug, PartialEq)]
 pub struct SingleImport {
     pub module: String,
-    // (symbol name in module, name it should be assigned locally)
-    pub symbol: Option<String>,
     pub alias: Option<String>,
+    pub symbols: Vec<ImportSymbol>,
 }
 
 #[derive(Debug, PartialEq)]

--- a/parser/src/python.lalrpop
+++ b/parser/src/python.lalrpop
@@ -206,7 +206,7 @@ ImportStatement: ast::LocatedStatement = {
             .map(|(n, a)|
                 ast::SingleImport {
                     module: n.to_string(),
-                    symbol: None,
+                    symbols: vec![],
                     alias: a.clone()
                 })
             .collect()
@@ -217,15 +217,18 @@ ImportStatement: ast::LocatedStatement = {
     ast::LocatedStatement {
       location: loc,
       node: ast::Statement::Import {
-        import_parts: i
-            .iter()
-            .map(|(i, a)|
-                ast::SingleImport {
-                    module: n.to_string(),
-                    symbol: Some(i.to_string()),
-                    alias: a.clone()
-                })
-            .collect()
+        import_parts: vec![
+            ast::SingleImport {
+                module: n.to_string(),
+                symbols: i.iter()
+                    .map(|(i, a)|
+                        ast::ImportSymbol {
+                            symbol: i.to_string(),
+                            alias: a.clone(),
+                        })
+                    .collect(),
+                alias: None
+        }]
       },
     }
   },

--- a/vm/src/frame.rs
+++ b/vm/src/frame.rs
@@ -357,8 +357,8 @@ impl Frame {
             }
             bytecode::Instruction::Import {
                 ref name,
-                ref symbol,
-            } => self.import(vm, name, symbol),
+                ref symbols,
+            } => self.import(vm, name, symbols),
             bytecode::Instruction::ImportStar { ref name } => self.import_star(vm, name),
             bytecode::Instruction::LoadName {
                 ref name,
@@ -907,25 +907,23 @@ impl Frame {
         }
     }
 
-    fn import(&self, vm: &VirtualMachine, module: &str, symbol: &Option<String>) -> FrameResult {
-        let from_list = match symbol {
-            Some(symbol) => vm.ctx.new_tuple(vec![vm.ctx.new_str(symbol.to_string())]),
-            None => vm.ctx.new_tuple(vec![]),
-        };
-        let module = vm.import(module, &from_list)?;
+    fn import(&self, vm: &VirtualMachine, module: &str, symbols: &Vec<String>) -> FrameResult {
+        let mut from_list = vec![];
+        for symbol in symbols {
+            from_list.push(vm.ctx.new_str(symbol.to_string()));
+        }
+        let module = vm.import(module, &vm.ctx.new_tuple(from_list))?;
 
-        // If we're importing a symbol, look it up and use it, otherwise construct a module and return
-        // that
-        let obj = match symbol {
-            Some(symbol) => vm.get_attribute(module, symbol.as_str()).map_err(|_| {
-                let import_error = vm.context().exceptions.import_error.clone();
-                vm.new_exception(import_error, format!("cannot import name '{}'", symbol))
-            }),
-            None => Ok(module),
-        };
-
-        // Push module on stack:
-        self.push_value(obj?);
+        if symbols.is_empty() {
+            self.push_value(module);
+        } else {
+            for symbol in symbols {
+                let obj = vm
+                    .get_attribute(module.clone(), symbol.as_str())
+                    .map_err(|_| vm.new_import_error(format!("cannot import name '{}'", symbol)));
+                self.push_value(obj?);
+            }
+        }
         Ok(None)
     }
 

--- a/vm/src/frame.rs
+++ b/vm/src/frame.rs
@@ -908,10 +908,10 @@ impl Frame {
     }
 
     fn import(&self, vm: &VirtualMachine, module: &str, symbols: &Vec<String>) -> FrameResult {
-        let mut from_list = vec![];
-        for symbol in symbols {
-            from_list.push(vm.ctx.new_str(symbol.to_string()));
-        }
+        let from_list = symbols
+            .iter()
+            .map(|symbol| vm.ctx.new_str(symbol.to_string()))
+            .collect();
         let module = vm.import(module, &vm.ctx.new_tuple(from_list))?;
 
         if symbols.is_empty() {


### PR DESCRIPTION
Currently when doing `from module import a,b,c,d,e` we would call `vm.import` one time for each symbol. This change the parser so we will call `vm.import` once for all symbols.