### PR TITLE
Printf-style formatting

### DIFF
--- a/tests/snippets/strings.py
+++ b/tests/snippets/strings.py
@@ -204,6 +204,20 @@ assert "{} {!s} {!r} {!a}".format(f, f, f, f) == 'str(Foo) str(Foo) repr(Foo) re
 assert "{foo} {foo!s} {foo!r} {foo!a}".format(foo=f) == 'str(Foo) str(Foo) repr(Foo) repr(Foo)'
 # assert '{} {!r} {:10} {!r:10} {foo!r:10} {foo!r} {foo}'.format('txt1', 'txt2', 'txt3', 'txt4', 'txt5', foo='bar')
 
+
+# Printf-style String formatting
+assert "%d %d" % (1, 2) == "1 2"
+assert "%*c  " % (3, '❤') == "  ❤  "
+assert "%(first)s %(second)s" % {'second': 'World!', 'first': "Hello,"} == "Hello, World!"
+assert "%(key())s" % {'key()': 'aaa'}
+assert "%s %a %r" % (f, f, f) == "str(Foo) repr(Foo) repr(Foo)"
+assert "repr() shows quotes: %r; str() doesn't: %s" % ("test1", "test2") == "repr() shows quotes: 'test1'; str() doesn't: test2"
+
+assert_raises(TypeError, lambda: "My name is %s and I'm %(age)d years old" % ("Foo", 25), msg="format requires a mapping")
+assert_raises(TypeError, lambda: "My name is %(name)s" % "Foo", msg="format requires a mapping")
+assert_raises(ValueError, lambda: "This %(food}s is great!" % {"food": "cookie"}, msg="incomplete format key")
+assert_raises(ValueError, lambda: "My name is %" % "Foo", msg="incomplete format")
+
 assert 'a' < 'b'
 assert 'a' <= 'b'
 assert 'a' <= 'a'

--- a/vm/src/cformat.rs
+++ b/vm/src/cformat.rs
@@ -4,6 +4,7 @@ use crate::format::get_num_digits;
 use num_bigint::{BigInt, Sign};
 use num_traits::Signed;
 use std::cmp;
+use std::fmt;
 use std::str::FromStr;
 
 #[derive(Debug, PartialEq)]
@@ -23,6 +24,22 @@ type ParsingError = (CFormatErrorType, usize);
 pub struct CFormatError {
     pub typ: CFormatErrorType,
     pub index: usize,
+}
+
+impl fmt::Display for CFormatError {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        use CFormatErrorType::*;
+        match self.typ {
+            UnmatchedKeyParentheses => write!(f, "incomplete format key"),
+            CFormatErrorType::IncompleteFormat => write!(f, "incomplete format"),
+            UnsupportedFormatChar(c) => write!(
+                f,
+                "unsupported format character '{}' ({:#x}) at index {}",
+                c, c as u32, self.index
+            ),
+            _ => write!(f, "unexpected error parsing format string"),
+        }
+    }
 }
 
 #[derive(Debug, PartialEq)]

--- a/vm/src/cformat.rs
+++ b/vm/src/cformat.rs
@@ -100,7 +100,7 @@ impl CFormatSpec {
         fill_char: char,
         num_prefix_chars: Option<usize>,
     ) -> String {
-        let mut num_chars = string.len();
+        let mut num_chars = string.chars().count();
         if let Some(num_prefix_chars) = num_prefix_chars {
             num_chars = num_chars + num_prefix_chars;
         }
@@ -128,8 +128,8 @@ impl CFormatSpec {
         let mut string = string;
         // truncate if needed
         if let Some(CFormatQuantity::Amount(precision)) = self.precision {
-            if string.len() > precision {
-                string.truncate(precision);
+            if string.chars().count() > precision {
+                string = string.chars().take(precision).collect::<String>();
             }
         }
         self.fill_string(string, ' ', None)
@@ -186,7 +186,7 @@ impl CFormatSpec {
             format!(
                 "{}{}",
                 prefix,
-                self.fill_string(magnitude_string, fill_char, Some(prefix.len()))
+                self.fill_string(magnitude_string, fill_char, Some(prefix.chars().count()))
             )
         } else {
             self.fill_string(format!("{}{}", prefix, magnitude_string), ' ', None)
@@ -322,7 +322,7 @@ fn parse_literal(text: &str) -> Result<(CFormatPart, &str, usize), ParsingError>
     Ok((
         CFormatPart::Literal(result_string.to_string()),
         "",
-        text.len(),
+        text.chars().count(),
     ))
 }
 
@@ -635,6 +635,17 @@ mod tests {
                 .unwrap()
                 .format_string("Hello, World!".to_string()),
             "Hell ".to_string()
+        );
+    }
+
+    #[test]
+    fn test_parse_and_format_unicode_string() {
+        assert_eq!(
+            "%.2s"
+                .parse::<CFormatSpec>()
+                .unwrap()
+                .format_string("❤❤❤❤❤❤❤❤".to_string()),
+            "❤❤".to_string()
         );
     }
 

--- a/vm/src/format.rs
+++ b/vm/src/format.rs
@@ -110,7 +110,7 @@ pub struct FormatSpec {
     format_type: Option<FormatType>,
 }
 
-fn get_num_digits(text: &str) -> usize {
+pub fn get_num_digits(text: &str) -> usize {
     for (index, character) in text.char_indices() {
         if !character.is_digit(10) {
             return index;
@@ -151,7 +151,7 @@ fn parse_fill_and_align(text: &str) -> (Option<char>, Option<FormatAlign>, &str)
     }
 }
 
-pub fn parse_number(text: &str) -> (Option<usize>, &str) {
+fn parse_number(text: &str) -> (Option<usize>, &str) {
     let num_digits: usize = get_num_digits(text);
     if num_digits == 0 {
         return (None, text);
@@ -189,7 +189,7 @@ fn parse_zero(text: &str) -> &str {
     }
 }
 
-pub fn parse_precision(text: &str) -> (Option<usize>, &str) {
+fn parse_precision(text: &str) -> (Option<usize>, &str) {
     let mut chars = text.chars();
     match chars.next() {
         Some('.') => {

--- a/vm/src/format.rs
+++ b/vm/src/format.rs
@@ -151,7 +151,7 @@ fn parse_fill_and_align(text: &str) -> (Option<char>, Option<FormatAlign>, &str)
     }
 }
 
-fn parse_number(text: &str) -> (Option<usize>, &str) {
+pub fn parse_number(text: &str) -> (Option<usize>, &str) {
     let num_digits: usize = get_num_digits(text);
     if num_digits == 0 {
         return (None, text);
@@ -189,7 +189,7 @@ fn parse_zero(text: &str) -> &str {
     }
 }
 
-fn parse_precision(text: &str) -> (Option<usize>, &str) {
+pub fn parse_precision(text: &str) -> (Option<usize>, &str) {
     let mut chars = text.chars();
     match chars.next() {
         Some('.') => {

--- a/vm/src/lib.rs
+++ b/vm/src/lib.rs
@@ -13,6 +13,8 @@
 )]
 
 #[macro_use]
+extern crate bitflags;
+#[macro_use]
 extern crate lazy_static;
 extern crate lexical;
 #[macro_use]
@@ -41,6 +43,7 @@ pub use rustpython_derive::py_compile_bytecode;
 pub mod macros;
 
 mod builtins;
+pub mod cformat;
 mod dictdatatype;
 pub mod eval;
 mod exceptions;

--- a/vm/src/obj/objstr.rs
+++ b/vm/src/obj/objstr.rs
@@ -1269,11 +1269,11 @@ fn do_cformat(
 
     // check that all arguments were converted
     if !mapping_required {
-        if !objtuple::get_value(&values_obj)
+        if objtuple::get_value(&values_obj)
             .into_iter()
             .skip(auto_index)
-            .collect::<Vec<PyObjectRef>>()
-            .is_empty()
+            .next()
+            .is_some()
         {
             return Err(vm.new_type_error(
                 "not all arguments converted during string formatting".to_string(),

--- a/vm/src/obj/objtuple.rs
+++ b/vm/src/obj/objtuple.rs
@@ -45,6 +45,10 @@ impl PyTuple {
 
 pub type PyTupleRef = PyRef<PyTuple>;
 
+pub fn get_value(obj: &PyObjectRef) -> Vec<PyObjectRef> {
+    obj.payload::<PyTuple>().unwrap().elements.clone()
+}
+
 impl PyTupleRef {
     fn lt(self, other: PyObjectRef, vm: &VirtualMachine) -> PyResult {
         if objtype::isinstance(&other, &vm.ctx.tuple_type()) {


### PR DESCRIPTION
This is a WIP on `str % tuple` formatting.
Currently on the parser itself is available for reviewing, I will be happy to take your comments and improve it.

Example usage:
```rust
let format_string = match CFormatString::from_str("Hello, My name is %s and I'm %d years old. My favorite hex number is %#08x") {
        Ok(fmt) => fmt,
        Err(_) => { panic!("got an error") }
    };
    println!("{:?}", format_string.format_parts);
```

will output:
```
[(0, Literal("Hello, My name is ")), (18, Spec(CFormatSpec { mapping_key: None, flags: (empty), min_field_width: None, precision: None, format_type: String(Str), format_char: 's' })), (20, Literal(" and I\'m ")), (29, Spec(CFormatSpec { mapping_key: None, flags: (empty), min_field_width: None, precision: None, format_type: Number(Decimal), format_char: 'd' })), (31, Literal(" years old. My favorite hex number is ")), (69, Spec(CFormatSpec { mapping_key: None, flags: ALTERNATE_FORM | ZERO_PAD, min_field_width: Some(8), precision: None, format_type: Number(Hex(Lowercase)), format_char: 'x' }))]

```