### PR TITLE
[WASM] Add a JsValue class

### DIFF
--- a/derive/src/compile_bytecode.rs
+++ b/derive/src/compile_bytecode.rs
@@ -163,7 +163,7 @@ pub fn impl_py_compile_bytecode(input: TokenStream2) -> Result<TokenStream2, Dia
 
     let output = quote! {
         ({
-            use ::bincode;
+            use ::rustpython_vm::__exports::bincode;
             bincode::deserialize::<::rustpython_vm::bytecode::CodeObject>(#bytes)
                 .expect("Deserializing CodeObject failed")
         })

--- a/derive/src/pyclass.rs
+++ b/derive/src/pyclass.rs
@@ -11,10 +11,6 @@ enum ClassItem {
         item_ident: Ident,
         py_name: String,
     },
-    ClassMethod {
-        item_ident: Ident,
-        py_name: String,
-    },
     Property {
         item_ident: Ident,
         py_name: String,
@@ -53,8 +49,8 @@ impl ClassItem {
                 let nesteds = meta_to_vec(meta).map_err(|meta| {
                     err_span!(
                         meta,
-                        "#[pymethod = \"...\"] cannot be a name/value, you probably meant \
-                         #[pymethod(name = \"...\")]",
+                        "#[pyproperty = \"...\"] cannot be a name/value, you probably meant \
+                         #[pyproperty(name = \"...\")]",
                     )
                 })?;
                 let mut py_name = None;
@@ -80,47 +76,6 @@ impl ClassItem {
                     }
                 }
                 item = Some(ClassItem::Method {
-                    item_ident: sig.ident.clone(),
-                    py_name: py_name.unwrap_or_else(|| sig.ident.to_string()),
-                });
-                attr_idx = Some(i);
-            } else if name == "pyclassmethod" {
-                if item.is_some() {
-                    bail_span!(
-                        sig.ident,
-                        "You can only have one #[py*] attribute on an impl item"
-                    )
-                }
-                let nesteds = meta_to_vec(meta).map_err(|meta| {
-                    err_span!(
-                        meta,
-                        "#[pyclassmethod = \"...\"] cannot be a name/value, you probably meant \
-                         #[pyclassmethod(name = \"...\")]",
-                    )
-                })?;
-                let mut py_name = None;
-                for meta in nesteds {
-                    let meta = match meta {
-                        NestedMeta::Meta(meta) => meta,
-                        NestedMeta::Literal(_) => continue,
-                    };
-                    match meta {
-                        Meta::NameValue(name_value) => {
-                            if name_value.ident == "name" {
-                                if let Lit::Str(s) = &name_value.lit {
-                                    py_name = Some(s.value());
-                                } else {
-                                    bail_span!(
-                                        &sig.ident,
-                                        "#[pyclassmethod(name = ...)] must be a string"
-                                    );
-                                }
-                            }
-                        }
-                        _ => {}
-                    }
-                }
-                item = Some(ClassItem::ClassMethod {
                     item_ident: sig.ident.clone(),
                     py_name: py_name.unwrap_or_else(|| sig.ident.to_string()),
                 });
@@ -255,20 +210,18 @@ pub fn impl_pyimpl(_attr: AttributeArgs, item: Item) -> Result<TokenStream2, Dia
             _ => {}
         }
     }
-    let methods = items.iter().filter_map(|item| match item {
-        ClassItem::Method {
+    let methods = items.iter().filter_map(|item| {
+        if let ClassItem::Method {
             item_ident,
             py_name,
-        } => Some(quote! {
-            class.set_str_attr(#py_name, ctx.new_rustfunc(Self::#item_ident));
-        }),
-        ClassItem::ClassMethod {
-            item_ident,
-            py_name,
-        } => Some(quote! {
-            class.set_str_attr(#py_name, ctx.new_classmethod(Self::#item_ident));
-        }),
-        _ => None,
+        } = item
+        {
+            Some(quote! {
+                class.set_str_attr(#py_name, ctx.new_rustfunc(Self::#item_ident));
+            })
+        } else {
+            None
+        }
     });
     let properties = properties
         .iter()

--- a/vm/src/lib.rs
+++ b/vm/src/lib.rs
@@ -66,3 +66,8 @@ mod vm;
 pub use self::exceptions::print_exception;
 pub use self::vm::VirtualMachine;
 pub use rustpython_compiler::*;
+
+#[doc(hidden)]
+pub mod __exports {
+    pub use bincode;
+}

--- a/vm/src/pyobject.rs
+++ b/vm/src/pyobject.rs
@@ -1379,7 +1379,11 @@ pub trait PyClassImpl: PyClassDef {
     }
 
     fn make_class(ctx: &PyContext) -> PyClassRef {
-        let py_class = ctx.new_class(Self::NAME, ctx.object());
+        Self::make_class_with_base(ctx, ctx.object())
+    }
+
+    fn make_class_with_base(ctx: &PyContext, base: PyClassRef) -> PyClassRef {
+        let py_class = ctx.new_class(Self::NAME, base);
         Self::extend_class(ctx, &py_class);
         py_class
     }

--- a/vm/src/stdlib/mod.rs
+++ b/vm/src/stdlib/mod.rs
@@ -34,6 +34,7 @@ use crate::pyobject::PyObjectRef;
 pub type StdlibInitFunc = Box<dyn Fn(&VirtualMachine) -> PyObjectRef>;
 
 pub fn get_module_inits() -> HashMap<String, StdlibInitFunc> {
+    #[allow(unused_mut)]
     let mut modules = hashmap! {
         "ast".to_string() => Box::new(ast::make_module) as StdlibInitFunc,
         "binascii".to_string() => Box::new(binascii::make_module),

--- a/wasm/lib/src/browser.py
+++ b/wasm/lib/src/browser.py
@@ -1,4 +1,5 @@
 from _browser import *
+
 from _js import JsValue
 from _window import window
 
@@ -10,3 +11,27 @@ def alert(msg):
     if type(msg) != str:
         raise TypeError("msg must be a string")
     _alert.call(JsValue.fromstr(msg))
+
+
+_confirm = window.get_prop("confirm")
+
+
+def confirm(msg):
+    if type(msg) != str:
+        raise TypeError("msg must be a string")
+    return _confirm.call(JsValue.fromstr(msg)).as_bool()
+
+
+_prompt = window.get_prop("prompt")
+
+
+def prompt(msg, default_val=None):
+    if type(msg) != str:
+        raise TypeError("msg must be a string")
+    if default_val is not None and type(default_val) != str:
+        raise TypeError("default_val must be a string")
+
+    return _prompt.call(
+        JsValue.fromstr(arg) for arg in [msg, default_val] if arg
+    ).as_str()
+

--- a/wasm/lib/src/browser.py
+++ b/wasm/lib/src/browser.py
@@ -1,0 +1,12 @@
+from _browser import *
+from _js import JsValue
+from _window import window
+
+
+_alert = window.get_prop("alert")
+
+
+def alert(msg):
+    if type(msg) != str:
+        raise TypeError("msg must be a string")
+    _alert.call(JsValue.fromstr(msg))

--- a/wasm/lib/src/browser.py
+++ b/wasm/lib/src/browser.py
@@ -4,13 +4,16 @@ from _js import JsValue
 from _window import window
 
 
+jsstr = window.new_from_str
+
+
 _alert = window.get_prop("alert")
 
 
 def alert(msg):
     if type(msg) != str:
         raise TypeError("msg must be a string")
-    _alert.call(JsValue.fromstr(msg))
+    _alert.call(jsstr(msg))
 
 
 _confirm = window.get_prop("confirm")
@@ -19,7 +22,7 @@ _confirm = window.get_prop("confirm")
 def confirm(msg):
     if type(msg) != str:
         raise TypeError("msg must be a string")
-    return _confirm.call(JsValue.fromstr(msg)).as_bool()
+    return _confirm.call(jsstr(msg)).as_bool()
 
 
 _prompt = window.get_prop("prompt")
@@ -31,7 +34,4 @@ def prompt(msg, default_val=None):
     if default_val is not None and type(default_val) != str:
         raise TypeError("default_val must be a string")
 
-    return _prompt.call(
-        JsValue.fromstr(arg) for arg in [msg, default_val] if arg
-    ).as_str()
-
+    return _prompt.call(*(jsstr(arg) for arg in [msg, default_val] if arg)).as_str()

--- a/wasm/lib/src/browser_module.rs
+++ b/wasm/lib/src/browser_module.rs
@@ -418,5 +418,9 @@ pub fn make_module(vm: &VirtualMachine) -> PyObjectRef {
 pub fn setup_browser_module(vm: &VirtualMachine) {
     vm.stdlib_inits
         .borrow_mut()
-        .insert("browser".to_string(), Box::new(make_module));
+        .insert("_browser".to_string(), Box::new(make_module));
+    vm.frozen.borrow_mut().insert(
+        "browser".to_string(),
+        py_compile_bytecode!(file = "src/browser.py"),
+    );
 }

--- a/wasm/lib/src/browser_module.rs
+++ b/wasm/lib/src/browser_module.rs
@@ -312,22 +312,6 @@ impl Element {
     }
 }
 
-fn browser_alert(message: PyStringRef, vm: &VirtualMachine) -> PyResult {
-    window()
-        .alert_with_message(message.as_str())
-        .expect("alert() not to fail");
-
-    Ok(vm.get_none())
-}
-
-fn browser_confirm(message: PyStringRef, vm: &VirtualMachine) -> PyResult {
-    let result = window()
-        .confirm_with_message(message.as_str())
-        .expect("confirm() not to fail");
-
-    Ok(vm.new_bool(result))
-}
-
 fn browser_prompt(
     message: PyStringRef,
     default: OptionalArg<PyStringRef>,
@@ -408,9 +392,6 @@ pub fn make_module(vm: &VirtualMachine) -> PyObjectRef {
         "Document" => document_class,
         "document" => document,
         "Element" => element,
-        "alert" => ctx.new_rustfunc(browser_alert),
-        "confirm" => ctx.new_rustfunc(browser_confirm),
-        "prompt" => ctx.new_rustfunc(browser_prompt),
         "load_module" => ctx.new_rustfunc(browser_load_module),
     })
 }

--- a/wasm/lib/src/browser_module.rs
+++ b/wasm/lib/src/browser_module.rs
@@ -312,25 +312,6 @@ impl Element {
     }
 }
 
-fn browser_prompt(
-    message: PyStringRef,
-    default: OptionalArg<PyStringRef>,
-    vm: &VirtualMachine,
-) -> PyResult {
-    let result = if let OptionalArg::Present(default) = default {
-        window().prompt_with_message_and_default(message.as_str(), default.as_str())
-    } else {
-        window().prompt_with_message(message.as_str())
-    };
-
-    let result = match result.expect("prompt() not to fail") {
-        Some(result) => vm.new_str(result),
-        None => vm.get_none(),
-    };
-
-    Ok(result)
-}
-
 fn browser_load_module(module: PyStringRef, path: PyStringRef, vm: &VirtualMachine) -> PyResult {
     let weak_vm = weak_vm(vm);
 

--- a/wasm/lib/src/convert.rs
+++ b/wasm/lib/src/convert.rs
@@ -45,7 +45,7 @@ pub fn py_err_to_js_err(vm: &VirtualMachine, py_err: &PyObjectRef) -> JsValue {
             let elements = objsequence::get_elements_list(&tb).to_vec();
             if let Some(top) = elements.get(0) {
                 if objtype::isinstance(&top, &vm.ctx.tuple_type()) {
-                    let element = objsequence::get_elements_list(&top);
+                    let element = objsequence::get_elements_tuple(&top);
 
                     if let Some(lineno) = objint::to_int(vm, &element[1], 10)
                         .ok()

--- a/wasm/lib/src/js_module.rs
+++ b/wasm/lib/src/js_module.rs
@@ -130,6 +130,11 @@ impl PyJsValue {
     fn as_float(&self, _vm: &VirtualMachine) -> Option<f64> {
         self.value.as_f64()
     }
+    
+    #[pymethod]
+    fn as_bool(&self, _vm: &VirtualMachine) -> Option<bool> {
+        self.value.as_bool()
+    }
 
     #[pymethod]
     /// Checks that `typeof self == "object" && self !== null`. Use instead
@@ -186,6 +191,7 @@ impl PyJsValue {
         } else {
             Reflect::construct(ctor, &js_args)
         };
+
         constructed_result
             .map(PyJsValue::new)
             .map_err(|err| convert::js_to_py(vm, err))

--- a/wasm/lib/src/js_module.rs
+++ b/wasm/lib/src/js_module.rs
@@ -1,0 +1,198 @@
+use crate::convert;
+use js_sys::{Array, Object, Reflect};
+use rustpython_vm::function::Args;
+use rustpython_vm::obj::{objfloat::PyFloatRef, objstr::PyStringRef, objtype::PyClassRef};
+use rustpython_vm::pyobject::{PyClassImpl, PyObjectRef, PyRef, PyResult, PyValue, TryFromObject};
+use rustpython_vm::VirtualMachine;
+use wasm_bindgen::{prelude::*, JsCast};
+
+// I don't know why there is no other option for this
+#[wasm_bindgen(inline_js = "export function type_of(a) { return typeof a; }")]
+extern "C" {
+    #[wasm_bindgen]
+    fn type_of(a: JsValue) -> String;
+}
+
+#[pyclass(name = "JsValue")]
+#[derive(Debug)]
+pub struct PyJsValue {
+    value: JsValue,
+}
+type PyJsValueRef = PyRef<PyJsValue>;
+
+impl PyValue for PyJsValue {
+    fn class(vm: &VirtualMachine) -> PyClassRef {
+        vm.class("_js", "JsValue")
+    }
+}
+
+enum JsProperty {
+    Str(PyStringRef),
+    Js(PyJsValueRef),
+}
+
+impl TryFromObject for JsProperty {
+    fn try_from_object(vm: &VirtualMachine, obj: PyObjectRef) -> PyResult<Self> {
+        PyStringRef::try_from_object(vm, obj.clone())
+            .map(JsProperty::Str)
+            .or_else(|_| PyJsValueRef::try_from_object(vm, obj).map(JsProperty::Js))
+    }
+}
+
+impl JsProperty {
+    fn to_jsvalue(self) -> JsValue {
+        match self {
+            JsProperty::Str(s) => s.as_str().into(),
+            JsProperty::Js(value) => value.value.clone(),
+        }
+    }
+}
+
+#[pyimpl]
+impl PyJsValue {
+    #[inline]
+    pub fn new(value: impl Into<JsValue>) -> PyJsValue {
+        PyJsValue {
+            value: value.into(),
+        }
+    }
+
+    #[pyclassmethod]
+    fn null(cls: PyClassRef, vm: &VirtualMachine) -> PyResult<PyJsValueRef> {
+        PyJsValue::new(JsValue::NULL).into_ref_with_type(vm, cls)
+    }
+
+    #[pyclassmethod]
+    fn undefined(cls: PyClassRef, vm: &VirtualMachine) -> PyResult<PyJsValueRef> {
+        PyJsValue::new(JsValue::UNDEFINED).into_ref_with_type(vm, cls)
+    }
+
+    #[pyclassmethod]
+    fn fromstr(cls: PyClassRef, s: PyStringRef, vm: &VirtualMachine) -> PyResult<PyJsValueRef> {
+        PyJsValue::new(s.as_str()).into_ref_with_type(vm, cls)
+    }
+
+    #[pyclassmethod]
+    fn fromfloat(cls: PyClassRef, n: PyFloatRef, vm: &VirtualMachine) -> PyResult<PyJsValueRef> {
+        PyJsValue::new(n.to_f64()).into_ref_with_type(vm, cls)
+    }
+
+    #[pyclassmethod]
+    fn new_object(
+        cls: PyClassRef,
+        opts: NewObjectOptions,
+        vm: &VirtualMachine,
+    ) -> PyResult<PyJsValueRef> {
+        let value = if let Some(proto) = opts.prototype {
+            if let Some(proto) = proto.value.dyn_ref::<Object>() {
+                Object::create(proto)
+            } else if proto.value.is_null() {
+                Object::create(proto.value.unchecked_ref())
+            } else {
+                return Err(vm.new_value_error(format!("prototype must be an Object or null")));
+            }
+        } else {
+            Object::new()
+        };
+        PyJsValue::new(value).into_ref_with_type(vm, cls)
+    }
+
+    #[pymethod]
+    fn get_prop(&self, name: JsProperty, vm: &VirtualMachine) -> PyResult<PyJsValue> {
+        let name = &name.to_jsvalue();
+        if Reflect::has(&self.value, name).map_err(|err| convert::js_to_py(vm, err))? {
+            Reflect::get(&self.value, name)
+                .map(PyJsValue::new)
+                .map_err(|err| convert::js_to_py(vm, err))
+        } else {
+            Err(vm.new_attribute_error(format!("No attribute {:?} on JS value", name)))
+        }
+    }
+
+    #[pymethod]
+    fn set_prop(
+        &self,
+        name: JsProperty,
+        value: PyJsValueRef,
+        vm: &VirtualMachine,
+    ) -> PyResult<PyJsValue> {
+        Reflect::set(&self.value, &name.to_jsvalue(), &value.value)
+            .map(PyJsValue::new)
+            .map_err(|err| convert::js_to_py(vm, err))
+    }
+
+    #[pymethod]
+    fn as_str(&self, _vm: &VirtualMachine) -> Option<String> {
+        self.value.as_string()
+    }
+
+    #[pymethod]
+    fn as_float(&self, _vm: &VirtualMachine) -> Option<f64> {
+        self.value.as_f64()
+    }
+
+    #[pymethod]
+    /// Checks that `typeof self == "object" && self !== null`. Use instead
+    /// of `value.typeof() == "object"`
+    fn is_object(&self, _vm: &VirtualMachine) -> bool {
+        self.value.is_object()
+    }
+
+    #[pymethod]
+    fn call(
+        &self,
+        args: Args<PyJsValueRef>,
+        opts: CallOptions,
+        vm: &VirtualMachine,
+    ) -> PyResult<PyJsValue> {
+        let func = self
+            .value
+            .dyn_ref::<js_sys::Function>()
+            .ok_or_else(|| vm.new_type_error("JS value is not callable".to_string()))?;
+        let this = opts
+            .this
+            .map(|this| this.value.clone())
+            .unwrap_or(JsValue::UNDEFINED);
+        let js_args = Array::new();
+        for arg in args {
+            js_args.push(&arg.value);
+        }
+        Reflect::apply(func, &this, &js_args)
+            .map(PyJsValue::new)
+            .map_err(|err| convert::js_to_py(vm, err))
+    }
+
+    #[pymethod(name = "typeof")]
+    fn type_of(&self, _vm: &VirtualMachine) -> String {
+        type_of(self.value.clone())
+    }
+
+    #[pymethod(name = "__repr__")]
+    fn repr(&self, _vm: &VirtualMachine) -> String {
+        format!("{:?}", self.value)
+    }
+}
+
+#[derive(FromArgs)]
+struct CallOptions {
+    #[pyarg(keyword_only, default = "None")]
+    this: Option<PyJsValueRef>,
+}
+
+#[derive(FromArgs)]
+struct NewObjectOptions {
+    #[pyarg(keyword_only, default = "None")]
+    prototype: Option<PyJsValueRef>,
+}
+
+pub fn make_module(vm: &VirtualMachine) -> PyObjectRef {
+    py_module!(vm, "_js", {
+      "JsValue" => PyJsValue::make_class(&vm.ctx),
+    })
+}
+
+pub fn setup_js_module(vm: &VirtualMachine) {
+    vm.stdlib_inits
+        .borrow_mut()
+        .insert("_js".to_string(), Box::new(make_module));
+}

--- a/wasm/lib/src/js_module.rs
+++ b/wasm/lib/src/js_module.rs
@@ -70,32 +70,28 @@ impl PyJsValue {
         }
     }
 
-    #[pyclassmethod]
-    fn null(cls: PyClassRef, vm: &VirtualMachine) -> PyResult<PyJsValueRef> {
-        PyJsValue::new(JsValue::NULL).into_ref_with_type(vm, cls)
+    #[pymethod]
+    fn null(&self, _vm: &VirtualMachine) -> PyJsValue {
+        PyJsValue::new(JsValue::NULL)
     }
 
-    #[pyclassmethod]
-    fn undefined(cls: PyClassRef, vm: &VirtualMachine) -> PyResult<PyJsValueRef> {
-        PyJsValue::new(JsValue::UNDEFINED).into_ref_with_type(vm, cls)
+    #[pymethod]
+    fn undefined(&self, _vm: &VirtualMachine) -> PyJsValue {
+        PyJsValue::new(JsValue::UNDEFINED)
     }
 
-    #[pyclassmethod]
-    fn fromstr(cls: PyClassRef, s: PyStringRef, vm: &VirtualMachine) -> PyResult<PyJsValueRef> {
-        PyJsValue::new(s.as_str()).into_ref_with_type(vm, cls)
+    #[pymethod]
+    fn new_from_str(&self, s: PyStringRef, _vm: &VirtualMachine) -> PyJsValue {
+        PyJsValue::new(s.as_str())
     }
 
-    #[pyclassmethod]
-    fn fromfloat(cls: PyClassRef, n: PyFloatRef, vm: &VirtualMachine) -> PyResult<PyJsValueRef> {
-        PyJsValue::new(n.to_f64()).into_ref_with_type(vm, cls)
+    #[pymethod]
+    fn new_from_float(&self, n: PyFloatRef, _vm: &VirtualMachine) -> PyJsValue {
+        PyJsValue::new(n.to_f64())
     }
 
-    #[pyclassmethod]
-    fn new_object(
-        cls: PyClassRef,
-        opts: NewObjectOptions,
-        vm: &VirtualMachine,
-    ) -> PyResult<PyJsValueRef> {
+    #[pymethod]
+    fn new_object(&self, opts: NewObjectOptions, vm: &VirtualMachine) -> PyResult<PyJsValue> {
         let value = if let Some(proto) = opts.prototype {
             if let Some(proto) = proto.value.dyn_ref::<Object>() {
                 Object::create(proto)
@@ -107,7 +103,7 @@ impl PyJsValue {
         } else {
             Object::new()
         };
-        PyJsValue::new(value).into_ref_with_type(vm, cls)
+        Ok(PyJsValue::new(value))
     }
 
     #[pymethod]

--- a/wasm/lib/src/lib.rs
+++ b/wasm/lib/src/lib.rs
@@ -1,5 +1,6 @@
 pub mod browser_module;
 pub mod convert;
+pub mod js_module;
 pub mod vm_class;
 pub mod wasm_builtins;
 

--- a/wasm/lib/src/vm_class.rs
+++ b/wasm/lib/src/vm_class.rs
@@ -8,11 +8,12 @@ use wasm_bindgen::prelude::*;
 use rustpython_vm::compile;
 use rustpython_vm::frame::{NameProtocol, Scope};
 use rustpython_vm::function::PyFuncArgs;
-use rustpython_vm::pyobject::{PyObject, PyObjectPayload, PyObjectRef, PyResult};
+use rustpython_vm::pyobject::{PyObject, PyObjectPayload, PyObjectRef, PyResult, PyValue};
 use rustpython_vm::VirtualMachine;
 
 use crate::browser_module::setup_browser_module;
 use crate::convert;
+use crate::js_module;
 use crate::wasm_builtins;
 
 pub(crate) struct StoredVirtualMachine {
@@ -26,11 +27,24 @@ pub(crate) struct StoredVirtualMachine {
 impl StoredVirtualMachine {
     fn new(id: String, inject_browser_module: bool) -> StoredVirtualMachine {
         let mut vm = VirtualMachine::new();
+        vm.wasm_id = Some(id);
         let scope = vm.new_scope_with_builtins();
+
+        js_module::setup_js_module(&vm);
         if inject_browser_module {
+            vm.stdlib_inits.borrow_mut().insert(
+                "_window".to_string(),
+                Box::new(|vm| {
+                    py_module!(vm, "_window", {
+                        "window" => js_module::PyJsValue::new(wasm_builtins::window()).into_ref(vm),
+                    })
+                }),
+            );
             setup_browser_module(&vm);
         }
-        vm.wasm_id = Some(id);
+
+        *vm.import_func.borrow_mut() = vm.ctx.new_rustfunc(wasm_builtins::builtin_import);
+
         StoredVirtualMachine {
             vm,
             scope: RefCell::new(scope),

--- a/wasm/lib/src/wasm_builtins.rs
+++ b/wasm/lib/src/wasm_builtins.rs
@@ -7,9 +7,13 @@
 use js_sys::{self, Array};
 use web_sys::{self, console};
 
-use rustpython_vm::function::PyFuncArgs;
-use rustpython_vm::obj::{objstr, objtype};
-use rustpython_vm::pyobject::{IdProtocol, PyObjectRef, PyResult, TypeProtocol};
+use rustpython_vm::function::{Args, KwArgs, PyFuncArgs};
+use rustpython_vm::import;
+use rustpython_vm::obj::{
+    objstr::{self, PyStringRef},
+    objtype,
+};
+use rustpython_vm::pyobject::{IdProtocol, ItemProtocol, PyObjectRef, PyResult, TypeProtocol};
 use rustpython_vm::VirtualMachine;
 
 pub(crate) fn window() -> web_sys::Window {
@@ -75,4 +79,30 @@ pub fn builtin_print_console(vm: &VirtualMachine, args: PyFuncArgs) -> PyResult 
     }
     console::log(&arr);
     Ok(vm.get_none())
+}
+
+pub fn builtin_import(
+    module_name: PyStringRef,
+    _args: Args,
+    _kwargs: KwArgs,
+    vm: &VirtualMachine,
+) -> PyResult<PyObjectRef> {
+    let module_name = module_name.as_str();
+
+    let sys_modules = vm.get_attribute(vm.sys_module.clone(), "modules").unwrap();
+
+    // First, see if we already loaded the module:
+    if let Ok(module) = sys_modules.get_item(module_name.to_string(), vm) {
+        Ok(module)
+    } else if vm.frozen.borrow().contains_key(module_name) {
+        import::import_frozen(vm, module_name)
+    } else if vm.stdlib_inits.borrow().contains_key(module_name) {
+        import::import_builtin(vm, module_name)
+    } else {
+        let notfound_error = vm.context().exceptions.module_not_found_error.clone();
+        Err(vm.new_exception(
+            notfound_error,
+            format!("Module {:?} not found", module_name),
+        ))
+    }
 }


### PR DESCRIPTION
Attempt number 2, after #848. Here's the design for this implementation:

- `_js` module - contains the `JsValue` class which wraps a `wasm_bindgen::JsValue` and provides methods like `get_prop()`, `set_prop()`, and `typeof()`.
- `_window` - provides a single export, a `JsValue` wrapping `window`. Can be disabled by the JS code using `rustpython_wasm`.
- `browser` - a (eventually) Python frozen module that imports `window` from `_window` and uses it to provide all the functionality that the `browser` native module does now.
- (eventually) `jslib` - a frozen module that provides a JsProxy similar in functionality to the `JsValue` discussed in #808 among some other things (like a Promise wrapper).

Closes #808.