### PR TITLE
support unicode literal

### DIFF
--- a/parser/Cargo.toml
+++ b/parser/Cargo.toml
@@ -17,3 +17,4 @@ num-traits = "0.2"
 unicode-xid = "0.1.0"
 unic-emoji-char = "0.9.0"
 serde = { version = "1.0.66", features = ["derive"] }
+wtf8 = "0.0.3"

--- a/tests/snippets/strings.py
+++ b/tests/snippets/strings.py
@@ -240,3 +240,12 @@ assert " ".isprintable()
 assert "abcdefg".isprintable()
 assert not "abcdefg\n".isprintable()
 assert "ʹ".isprintable()
+
+# test unicode iterals
+assert "\xac" == "¬"
+assert "\u0037" == "7"
+assert "\u0040" == "@"
+assert "\u0041" == "A"
+assert "\u00BE" == "¾"
+assert "\u9487" == "钇"
+assert "\U0001F609" == "😉"


### PR DESCRIPTION
support Unicode literal as same as CPython #1025 
- support Unicode literal `\x` with 2 digits
- support Unicode literal `\u` with 4 digits
- support Unicode literal `\U` with 8 digits