### PR TITLE
Revert "Make CodeObject.source_path an Option<String>", just add a parameter to import_codeobj

### DIFF
--- a/compiler/src/bytecode.rs
+++ b/compiler/src/bytecode.rs
@@ -21,7 +21,7 @@ pub struct CodeObject {
     pub varargs: Varargs,       // *args or *
     pub kwonlyarg_names: Vec<String>,
     pub varkeywords: Varargs, // **kwargs or **
-    pub source_path: Option<String>,
+    pub source_path: String,
     pub first_line_number: usize,
     pub obj_name: String, // Name of the object that created this code object
     pub is_generator: bool,
@@ -269,7 +269,7 @@ impl CodeObject {
         varargs: Varargs,
         kwonlyarg_names: Vec<String>,
         varkeywords: Varargs,
-        source_path: Option<String>,
+        source_path: String,
         first_line_number: usize,
         obj_name: String,
     ) -> CodeObject {

--- a/compiler/src/compile.rs
+++ b/compiler/src/compile.rs
@@ -23,11 +23,7 @@ struct Compiler {
 }
 
 /// Compile a given sourcecode into a bytecode object.
-pub fn compile(
-    source: &str,
-    mode: &Mode,
-    source_path: Option<String>,
-) -> Result<CodeObject, CompileError> {
+pub fn compile(source: &str, mode: &Mode, source_path: String) -> Result<CodeObject, CompileError> {
     match mode {
         Mode::Exec => {
             let ast = parser::parse_program(source)?;
@@ -46,11 +42,11 @@ pub fn compile(
 
 /// A helper function for the shared code of the different compile functions
 fn with_compiler(
-    source_path: Option<String>,
+    source_path: String,
     f: impl FnOnce(&mut Compiler) -> Result<(), CompileError>,
 ) -> Result<CodeObject, CompileError> {
     let mut compiler = Compiler::new();
-    compiler.source_path = source_path;
+    compiler.source_path = Some(source_path);
     compiler.push_new_code_object("<module>".to_string());
     f(&mut compiler)?;
     let code = compiler.pop_code_object();
@@ -59,10 +55,7 @@ fn with_compiler(
 }
 
 /// Compile a standard Python program to bytecode
-pub fn compile_program(
-    ast: ast::Program,
-    source_path: Option<String>,
-) -> Result<CodeObject, CompileError> {
+pub fn compile_program(ast: ast::Program, source_path: String) -> Result<CodeObject, CompileError> {
     with_compiler(source_path, |compiler| {
         let symbol_table = make_symbol_table(&ast)?;
         compiler.compile_program(&ast, symbol_table)
@@ -72,7 +65,7 @@ pub fn compile_program(
 /// Compile a single Python expression to bytecode
 pub fn compile_statement_eval(
     statement: Vec<ast::LocatedStatement>,
-    source_path: Option<String>,
+    source_path: String,
 ) -> Result<CodeObject, CompileError> {
     with_compiler(source_path, |compiler| {
         let symbol_table = statements_to_symbol_table(&statement)?;
@@ -83,7 +76,7 @@ pub fn compile_statement_eval(
 /// Compile a Python program to bytecode for the context of a REPL
 pub fn compile_program_single(
     ast: ast::Program,
-    source_path: Option<String>,
+    source_path: String,
 ) -> Result<CodeObject, CompileError> {
     with_compiler(source_path, |compiler| {
         let symbol_table = make_symbol_table(&ast)?;
@@ -126,7 +119,7 @@ impl Compiler {
             Varargs::None,
             Vec::new(),
             Varargs::None,
-            self.source_path.clone(),
+            self.source_path.clone().unwrap(),
             line_number,
             obj_name,
         ));
@@ -603,7 +596,7 @@ impl Compiler {
             Varargs::from(&args.vararg),
             args.kwonlyargs.iter().map(|a| a.arg.clone()).collect(),
             Varargs::from(&args.kwarg),
-            self.source_path.clone(),
+            self.source_path.clone().unwrap(),
             line_number,
             name.to_string(),
         ));
@@ -856,7 +849,7 @@ impl Compiler {
             Varargs::None,
             vec![],
             Varargs::None,
-            self.source_path.clone(),
+            self.source_path.clone().unwrap(),
             line_number,
             name.to_string(),
         ));
@@ -1578,7 +1571,7 @@ impl Compiler {
             Varargs::None,
             vec![],
             Varargs::None,
-            self.source_path.clone(),
+            self.source_path.clone().unwrap(),
             line_number,
             name.clone(),
         ));

--- a/derive/src/compile_bytecode.rs
+++ b/derive/src/compile_bytecode.rs
@@ -8,8 +8,8 @@
 //!
 //!     // the mode to compile the code in
 //!     mode = "exec", // or "eval" or "single"
-//!     // the path put into the CodeObject, defaults to `None`
-//!     source_path = "frozen",
+//!     // the path put into the CodeObject, defaults to "frozen"
+//!     module_name = "frozen",
 //! )
 //! ```
 
@@ -35,9 +35,9 @@ struct CompilationSource {
 }
 
 impl CompilationSource {
-    fn compile(self, mode: &compile::Mode, source_path: String) -> Result<CodeObject, Diagnostic> {
+    fn compile(self, mode: &compile::Mode, module_name: String) -> Result<CodeObject, Diagnostic> {
         let compile = |source| {
-            compile::compile(source, mode, source_path).map_err(|err| {
+            compile::compile(source, mode, module_name).map_err(|err| {
                 Diagnostic::spans_error(self.span, format!("Compile error: {}", err))
             })
         };
@@ -69,7 +69,7 @@ struct PyCompileInput {
 
 impl PyCompileInput {
     fn compile(&self) -> Result<CodeObject, Diagnostic> {
-        let mut source_path = None;
+        let mut module_name = None;
         let mut mode = None;
         let mut source: Option<CompilationSource> = None;
 
@@ -97,10 +97,10 @@ impl PyCompileInput {
                             },
                             _ => bail_span!(name_value.lit, "mode must be a string"),
                         })
-                    } else if name_value.ident == "source_path" {
-                        source_path = Some(match &name_value.lit {
+                    } else if name_value.ident == "module_name" {
+                        module_name = Some(match &name_value.lit {
                             Lit::Str(s) => s.value(),
-                            _ => bail_span!(name_value.lit, "source_path must be string"),
+                            _ => bail_span!(name_value.lit, "module_name must be string"),
                         })
                     } else if name_value.ident == "source" {
                         assert_source_empty(&source)?;
@@ -137,7 +137,7 @@ impl PyCompileInput {
             })?
             .compile(
                 &mode.unwrap_or(compile::Mode::Exec),
-                source_path.unwrap_or_else(|| "frozen".to_string()),
+                module_name.unwrap_or_else(|| "frozen".to_string()),
             )
     }
 }

--- a/derive/src/compile_bytecode.rs
+++ b/derive/src/compile_bytecode.rs
@@ -35,11 +35,7 @@ struct CompilationSource {
 }
 
 impl CompilationSource {
-    fn compile(
-        self,
-        mode: &compile::Mode,
-        source_path: Option<String>,
-    ) -> Result<CodeObject, Diagnostic> {
+    fn compile(self, mode: &compile::Mode, source_path: String) -> Result<CodeObject, Diagnostic> {
         let compile = |source| {
             compile::compile(source, mode, source_path).map_err(|err| {
                 Diagnostic::spans_error(self.span, format!("Compile error: {}", err))
@@ -139,7 +135,10 @@ impl PyCompileInput {
                     "Must have either file or source in py_compile_bytecode!()",
                 )
             })?
-            .compile(&mode.unwrap_or(compile::Mode::Exec), source_path)
+            .compile(
+                &mode.unwrap_or(compile::Mode::Exec),
+                source_path.unwrap_or_else(|| "frozen".to_string()),
+            )
     }
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -76,7 +76,7 @@ fn main() {
 
 fn _run_string(vm: &VirtualMachine, source: &str, source_path: String) -> PyResult {
     let code_obj = vm
-        .compile(source, &compile::Mode::Exec, Some(source_path.clone()))
+        .compile(source, &compile::Mode::Exec, source_path.clone())
         .map_err(|err| vm.new_syntax_error(&err))?;
     // trace!("Code object: {:?}", code_obj.borrow());
     let attrs = vm.ctx.new_dict();
@@ -161,7 +161,7 @@ fn test_run_script() {
 }
 
 fn shell_exec(vm: &VirtualMachine, source: &str, scope: Scope) -> Result<(), CompileError> {
-    match vm.compile(source, &compile::Mode::Single, Some("<stdin>".to_string())) {
+    match vm.compile(source, &compile::Mode::Single, "<stdin>".to_string()) {
         Ok(code) => {
             match vm.run_code_obj(code, scope.clone()) {
                 Ok(value) => {

--- a/vm/src/builtins.rs
+++ b/vm/src/builtins.rs
@@ -122,7 +122,7 @@ fn builtin_compile(args: CompileArgs, vm: &VirtualMachine) -> PyResult<PyCodeRef
         }
     };
 
-    vm.compile(&source, &mode, Some(args.filename.value.to_string()))
+    vm.compile(&source, &mode, args.filename.value.to_string())
         .map_err(|err| vm.new_syntax_error(&err))
 }
 
@@ -171,7 +171,7 @@ fn builtin_eval(vm: &VirtualMachine, args: PyFuncArgs) -> PyResult {
         let source = objstr::get_value(source);
         // TODO: fix this newline bug:
         let source = format!("{}\n", source);
-        vm.compile(&source, &mode, Some("<string>".to_string()))
+        vm.compile(&source, &mode, "<string>".to_string())
             .map_err(|err| vm.new_syntax_error(&err))?
     } else {
         return Err(vm.new_type_error("code argument must be str or code object".to_string()));
@@ -199,7 +199,7 @@ fn builtin_exec(vm: &VirtualMachine, args: PyFuncArgs) -> PyResult {
         let source = objstr::get_value(source);
         // TODO: fix this newline bug:
         let source = format!("{}\n", source);
-        vm.compile(&source, &mode, Some("<string>".to_string()))
+        vm.compile(&source, &mode, "<string>".to_string())
             .map_err(|err| vm.new_syntax_error(&err))?
     } else if let Ok(code_obj) = PyCodeRef::try_from_object(vm, source.clone()) {
         code_obj

--- a/vm/src/eval.rs
+++ b/vm/src/eval.rs
@@ -1,15 +1,12 @@
+extern crate rustpython_parser;
+
 use crate::compile;
 use crate::frame::Scope;
 use crate::pyobject::PyResult;
 use crate::vm::VirtualMachine;
 
-pub fn eval(
-    vm: &VirtualMachine,
-    source: &str,
-    scope: Scope,
-    source_path: Option<String>,
-) -> PyResult {
-    match vm.compile(source, &compile::Mode::Eval, source_path) {
+pub fn eval(vm: &VirtualMachine, source: &str, scope: Scope, source_path: &str) -> PyResult {
+    match vm.compile(source, &compile::Mode::Eval, source_path.to_string()) {
         Ok(bytecode) => {
             debug!("Code object: {:?}", bytecode);
             vm.run_code_obj(bytecode, scope)
@@ -28,7 +25,7 @@ mod tests {
         let source = String::from("print('Hello world')\n");
         let mut vm = VirtualMachine::new();
         let vars = vm.new_scope_with_builtins();
-        let _result = eval(&mut vm, &source, vars, Some("<unittest>".to_string()));
+        let _result = eval(&mut vm, &source, vars, "<unittest>");
 
         // TODO: check result?
         //assert_eq!(

--- a/vm/src/frame.rs
+++ b/vm/src/frame.rs
@@ -271,10 +271,7 @@ impl Frame {
     }
 
     pub fn run(&self, vm: &VirtualMachine) -> Result<ExecutionResult, PyObjectRef> {
-        let filename = match self.code.source_path.clone() {
-            Some(s) => vm.ctx.new_str(s),
-            None => vm.get_none(),
-        };
+        let filename = &self.code.source_path.to_string();
 
         // This is the name of the object being run:
         let run_obj_name = &self.code.obj_name.to_string();
@@ -302,7 +299,7 @@ impl Frame {
                         .unwrap();
                     trace!("Adding to traceback: {:?} {:?}", traceback, lineno);
                     let raise_location = vm.ctx.new_tuple(vec![
-                        filename.clone(),
+                        vm.ctx.new_str(filename.clone()),
                         vm.ctx.new_int(lineno.get_row()),
                         vm.ctx.new_str(run_obj_name.clone()),
                     ]);

--- a/vm/src/frozen.rs
+++ b/vm/src/frozen.rs
@@ -5,12 +5,15 @@ pub fn get_module_inits() -> HashMap<String, CodeObject> {
     hashmap! {
         "__hello__".into() => py_compile_bytecode!(
             source = "initialized = True; print(\"Hello world!\")\n",
+            module_name = "__hello__",
         ),
         "_frozen_importlib".into() => py_compile_bytecode!(
             file = "../Lib/importlib/_bootstrap.py",
+            module_name = "_frozen_importlib",
         ),
         "_frozen_importlib_external".into() => py_compile_bytecode!(
             file = "../Lib/importlib/_bootstrap_external.py",
+            module_name = "_frozen_importlib_external",
         ),
     }
 }

--- a/vm/src/import.rs
+++ b/vm/src/import.rs
@@ -25,12 +25,13 @@ pub fn init_importlib(vm: &VirtualMachine) -> PyResult {
 }
 
 pub fn import_frozen(vm: &VirtualMachine, module_name: &str) -> PyResult {
-    vm.frozen
-        .borrow()
-        .get(module_name)
-        .cloned()
-        .ok_or_else(|| vm.new_import_error(format!("Cannot import frozen module {}", module_name)))
-        .and_then(|frozen| import_codeobj(vm, module_name, frozen))
+    if let Some(frozen) = vm.frozen.borrow().get(module_name) {
+        let mut frozen = frozen.clone();
+        frozen.source_path = format!("frozen {}", module_name);
+        import_codeobj(vm, module_name, frozen)
+    } else {
+        Err(vm.new_import_error(format!("Cannot import frozen module {}", module_name)))
+    }
 }
 
 pub fn import_builtin(vm: &VirtualMachine, module_name: &str) -> PyResult {
@@ -68,7 +69,7 @@ pub fn import_module(vm: &VirtualMachine, current_path: PathBuf, module_name: &s
         import_file(
             vm,
             module_name,
-            Some(file_path.to_str().unwrap().to_string()),
+            file_path.to_str().unwrap().to_string(),
             source,
         )
     }
@@ -77,7 +78,7 @@ pub fn import_module(vm: &VirtualMachine, current_path: PathBuf, module_name: &s
 pub fn import_file(
     vm: &VirtualMachine,
     module_name: &str,
-    file_path: Option<String>,
+    file_path: String,
     content: String,
 ) -> PyResult {
     let code_obj = compile::compile(&content, &compile::Mode::Exec, file_path)
@@ -88,8 +89,10 @@ pub fn import_file(
 pub fn import_codeobj(vm: &VirtualMachine, module_name: &str, code_obj: CodeObject) -> PyResult {
     let attrs = vm.ctx.new_dict();
     attrs.set_item("__name__", vm.new_str(module_name.to_string()), vm)?;
-    if let Some(source_path) = &code_obj.source_path {
-        attrs.set_item("__file__", vm.new_str(source_path.to_owned()), vm)?;
+    let file_path = &code_obj.source_path;
+    if !file_path.starts_with("frozen") {
+        // TODO: Should be less hacky, not depend on source_path
+        attrs.set_item("__file__", vm.new_str(file_path.to_owned()), vm)?;
     }
     let module = vm.ctx.new_module(module_name, attrs.clone());
 

--- a/vm/src/import.rs
+++ b/vm/src/import.rs
@@ -25,24 +25,24 @@ pub fn init_importlib(vm: &VirtualMachine) -> PyResult {
 }
 
 pub fn import_frozen(vm: &VirtualMachine, module_name: &str) -> PyResult {
-    if let Some(frozen) = vm.frozen.borrow().get(module_name) {
-        let mut frozen = frozen.clone();
-        frozen.source_path = format!("frozen {}", module_name);
-        import_codeobj(vm, module_name, frozen)
-    } else {
-        Err(vm.new_import_error(format!("Cannot import frozen module {}", module_name)))
-    }
+    vm.frozen
+        .borrow()
+        .get(module_name)
+        .ok_or_else(|| vm.new_import_error(format!("Cannot import frozen module {}", module_name)))
+        .and_then(|frozen| import_codeobj(vm, module_name, frozen.clone(), false))
 }
 
 pub fn import_builtin(vm: &VirtualMachine, module_name: &str) -> PyResult {
-    let sys_modules = vm.get_attribute(vm.sys_module.clone(), "modules").unwrap();
-    if let Some(make_module_func) = vm.stdlib_inits.borrow().get(module_name) {
-        let module = make_module_func(vm);
-        sys_modules.set_item(module_name, module.clone(), vm)?;
-        Ok(module)
-    } else {
-        Err(vm.new_import_error(format!("Cannot import bultin module {}", module_name)))
-    }
+    vm.stdlib_inits
+        .borrow()
+        .get(module_name)
+        .ok_or_else(|| vm.new_import_error(format!("Cannot import bultin module {}", module_name)))
+        .and_then(|make_module_func| {
+            let module = make_module_func(vm);
+            let sys_modules = vm.get_attribute(vm.sys_module.clone(), "modules")?;
+            sys_modules.set_item(module_name, module.clone(), vm)?;
+            Ok(module)
+        })
 }
 
 pub fn import_module(vm: &VirtualMachine, current_path: PathBuf, module_name: &str) -> PyResult {
@@ -57,8 +57,8 @@ pub fn import_module(vm: &VirtualMachine, current_path: PathBuf, module_name: &s
     } else if vm.stdlib_inits.borrow().contains_key(module_name) {
         import_builtin(vm, module_name)
     } else {
-        let notfound_error = vm.context().exceptions.module_not_found_error.clone();
-        let import_error = vm.context().exceptions.import_error.clone();
+        let notfound_error = &vm.ctx.exceptions.module_not_found_error;
+        let import_error = &vm.ctx.exceptions.import_error;
 
         // Time to search for module in any place:
         let file_path = find_source(vm, current_path, module_name)
@@ -83,21 +83,24 @@ pub fn import_file(
 ) -> PyResult {
     let code_obj = compile::compile(&content, &compile::Mode::Exec, file_path)
         .map_err(|err| vm.new_syntax_error(&err))?;
-    import_codeobj(vm, module_name, code_obj)
+    import_codeobj(vm, module_name, code_obj, true)
 }
 
-pub fn import_codeobj(vm: &VirtualMachine, module_name: &str, code_obj: CodeObject) -> PyResult {
+pub fn import_codeobj(
+    vm: &VirtualMachine,
+    module_name: &str,
+    code_obj: CodeObject,
+    set_file_attr: bool,
+) -> PyResult {
     let attrs = vm.ctx.new_dict();
     attrs.set_item("__name__", vm.new_str(module_name.to_string()), vm)?;
-    let file_path = &code_obj.source_path;
-    if !file_path.starts_with("frozen") {
-        // TODO: Should be less hacky, not depend on source_path
-        attrs.set_item("__file__", vm.new_str(file_path.to_owned()), vm)?;
+    if set_file_attr {
+        attrs.set_item("__file__", vm.new_str(code_obj.source_path.to_owned()), vm)?;
     }
     let module = vm.ctx.new_module(module_name, attrs.clone());
 
     // Store module in cache to prevent infinite loop with mutual importing libs:
-    let sys_modules = vm.get_attribute(vm.sys_module.clone(), "modules").unwrap();
+    let sys_modules = vm.get_attribute(vm.sys_module.clone(), "modules")?;
     sys_modules.set_item(module_name, module.clone(), vm)?;
 
     // Execute main code in module:

--- a/vm/src/obj/objcode.rs
+++ b/vm/src/obj/objcode.rs
@@ -54,7 +54,7 @@ impl PyCodeRef {
         self.code.arg_names.len()
     }
 
-    fn co_filename(self, _vm: &VirtualMachine) -> Option<String> {
+    fn co_filename(self, _vm: &VirtualMachine) -> String {
         self.code.source_path.clone()
     }
 

--- a/vm/src/stdlib/imp.rs
+++ b/vm/src/stdlib/imp.rs
@@ -58,8 +58,11 @@ fn imp_get_frozen_object(name: PyStringRef, vm: &VirtualMachine) -> PyResult<PyC
     vm.frozen
         .borrow()
         .get(name.as_str())
-        .cloned()
-        .map(PyCode::new)
+        .map(|frozen| {
+            let mut frozen = frozen.clone();
+            frozen.source_path = format!("frozen {}", name.as_str());
+            PyCode::new(frozen)
+        })
         .ok_or_else(|| {
             vm.new_import_error(format!("No such frozen object named {}", name.as_str()))
         })

--- a/vm/src/vm.rs
+++ b/vm/src/vm.rs
@@ -739,7 +739,7 @@ impl VirtualMachine {
         &self,
         source: &str,
         mode: &compile::Mode,
-        source_path: Option<String>,
+        source_path: String,
     ) -> Result<PyCodeRef, CompileError> {
         compile::compile(source, mode, source_path)
             .map(|codeobj| PyCode::new(codeobj).into_ref(self))

--- a/wasm/lib/src/browser_module.rs
+++ b/wasm/lib/src/browser_module.rs
@@ -373,7 +373,7 @@ fn browser_load_module(module: PyStringRef, path: PyStringRef, vm: &VirtualMachi
                 .expect("that the vm is valid when the promise resolves");
             let vm = &stored_vm.vm;
             let resp_text = text.as_string().unwrap();
-            let res = import_file(vm, module.as_str(), Some("WEB".to_string()), resp_text);
+            let res = import_file(vm, module.as_str(), "WEB".to_string(), resp_text);
             match res {
                 Ok(_) => Ok(JsValue::null()),
                 Err(err) => Err(convert::py_err_to_js_err(vm, &err)),

--- a/wasm/lib/src/vm_class.rs
+++ b/wasm/lib/src/vm_class.rs
@@ -263,7 +263,7 @@ impl WASMVirtualMachine {
                  ref vm, ref scope, ..
              }| {
                 source.push('\n');
-                let code = vm.compile(&source, &mode, Some("<wasm>".to_string()));
+                let code = vm.compile(&source, &mode, "<wasm>".to_string());
                 let code = code.map_err(|err| {
                     let js_err = SyntaxError::new(&format!("Error parsing Python code: {}", err));
                     if let rustpython_vm::error::CompileErrorType::Parse(ref parse_error) =


### PR DESCRIPTION
Reverts RustPython/RustPython#1037. See https://github.com/RustPython/RustPython/pull/1037#issuecomment-504101074