### PR TITLE
Add empty _imp._fix_co_filename

### DIFF
--- a/vm/src/stdlib/imp.rs
+++ b/vm/src/stdlib/imp.rs
@@ -77,6 +77,10 @@ fn imp_is_frozen_package(_name: PyStringRef, _vm: &VirtualMachine) -> bool {
     false
 }
 
+fn imp_fix_co_filename(_code: PyObjectRef, _path: PyStringRef, _vm: &VirtualMachine) {
+    // TODO:
+}
+
 pub fn make_module(vm: &VirtualMachine) -> PyObjectRef {
     let ctx = &vm.ctx;
     let module = py_module!(vm, "_imp", {
@@ -91,6 +95,7 @@ pub fn make_module(vm: &VirtualMachine) -> PyObjectRef {
         "get_frozen_object" => ctx.new_rustfunc(imp_get_frozen_object),
         "init_frozen" => ctx.new_rustfunc(imp_init_frozen),
         "is_frozen_package" => ctx.new_rustfunc(imp_is_frozen_package),
+        "_fix_co_filename" => ctx.new_rustfunc(imp_fix_co_filename),
     });
 
     module


### PR DESCRIPTION
This PR and #1067 are the last things needed for supporting `.pyc` files. You can now change `sys.dont_write_bytecode` to false.
This improve the import time significantly. for example:
```py
import time

start = time.time()
import os
print(time.time() - start)
```
without `__pycahce__`: 0.272 [sec]
with `__pycache__`: 0.114 [sec]
*in release