### PR TITLE
Add "Ellipsis" for Ellipsis

### DIFF
--- a/tests/snippets/ellipsis.py
+++ b/tests/snippets/ellipsis.py
@@ -3,6 +3,14 @@
 a = ...
 b = ...
 c = type(a)()  # Test singleton behavior
+d = Ellipsis
+e = Ellipsis
 
 assert a is b
 assert b is c
+assert b is d
+assert d is e
+
+assert Ellipsis is ...
+Ellipsis = 2
+assert Ellipsis is not ...

--- a/vm/src/builtins.rs
+++ b/vm/src/builtins.rs
@@ -858,6 +858,7 @@ pub fn make_module(vm: &VirtualMachine, module: PyObjectRef) {
 
         // Constants
         "NotImplemented" => ctx.not_implemented(),
+        "Ellipsis" => vm.ctx.ellipsis.clone(),
 
         // Exceptions:
         "BaseException" => ctx.exceptions.base_exception_type.clone(),


### PR DESCRIPTION
Currently, only "..." works for Ellipsis type.
This PR will fix the RustPython to work correctly on this code.
```python
a = Ellipsis
b = ...
a is b
```