### PR TITLE
Fix TestWithTempDir test to pass on Mac

### DIFF
--- a/tests/snippets/stdlib_os.py
+++ b/tests/snippets/stdlib_os.py
@@ -244,7 +244,7 @@ with TestWithTempDir() as tmpdir:
 
 	with TestWithTempCurrentDir():
 		os.chdir(tmpdir)
-		assert os.getcwd() == tmpdir
+		assert os.getcwd() == os.path.realpath(tmpdir)
 		os.path.exists(FILE_NAME)
 
 # supports


### PR DESCRIPTION
Fix TestWithTempDir test that comapre `os.getcwd()` and `tmpdir`.
`os.getcwd()` returns the result of resolving the symbolic link. But `tmpdir`
absolute path. Testing fails on Mac because the `/tmp` directory is a symbolic
link. Comparing the results of resolving `tmpdir` will pass the test. But
RustPython does not implement `os.lstat`, so it does not pass, but in CPython The
test passes.