### PR TITLE
Implement int.__rmod__

### DIFF
--- a/tests/snippets/ints.py
+++ b/tests/snippets/ints.py
@@ -40,6 +40,14 @@ assert (2).__rtruediv__(1) == 0.5
 assert (2).__pow__(3) == 8
 assert (10).__pow__(-1) == 0.1
 assert (2).__rpow__(3) == 9
+assert (10).__mod__(5) == 0
+assert (10).__mod__(6) == 4
+with assertRaises(ZeroDivisionError):
+    (10).__mod__(0)
+assert (5).__rmod__(10) == 0
+assert (6).__rmod__(10) == 4
+with assertRaises(ZeroDivisionError):
+    (0).__rmod__(10)
 
 # real/imag attributes
 assert (1).real == 1
@@ -63,6 +71,8 @@ assert (2).__truediv__(1.0) == NotImplemented
 assert (2).__rtruediv__(1.0) == NotImplemented
 assert (2).__pow__(3.0) == NotImplemented
 assert (2).__rpow__(3.0) == NotImplemented
+assert (2).__mod__(3.0) == NotImplemented
+assert (2).__rmod__(3.0) == NotImplemented
 
 assert 10 // 4 == 2
 assert -10 // 4 == -3

--- a/vm/src/obj/objint.rs
+++ b/vm/src/obj/objint.rs
@@ -145,7 +145,7 @@ fn inner_mod(int1: &PyInt, int2: &PyInt, vm: &VirtualMachine) -> PyResult {
         Err(vm.new_zero_division_error("integer modulo by zero".to_string()))
     }
 }
- 
+
 #[pyimpl]
 impl PyInt {
     #[pymethod(name = "__eq__")]

--- a/vm/src/obj/objint.rs
+++ b/vm/src/obj/objint.rs
@@ -385,7 +385,7 @@ impl PyInt {
     }
 
     #[pymethod(name = "__rmod__")]
-    fn rmod_(&self, other: PyObjectRef, vm: &VirtualMachine) -> PyResult {
+    fn rmod(&self, other: PyObjectRef, vm: &VirtualMachine) -> PyResult {
         if objtype::isinstance(&other, &vm.ctx.int_type()) {
             let other = other.payload::<PyInt>().unwrap();
             inner_mod(&other, self, vm)

--- a/vm/src/obj/objint.rs
+++ b/vm/src/obj/objint.rs
@@ -138,6 +138,14 @@ fn inner_pow(int1: &PyInt, int2: &PyInt, vm: &VirtualMachine) -> PyResult {
     Ok(result)
 }
 
+fn inner_mod(int1: &PyInt, int2: &PyInt, vm: &VirtualMachine) -> PyResult {
+    if int2.value != BigInt::zero() {
+        Ok(vm.ctx.new_int(&int1.value % &int2.value))
+    } else {
+        Err(vm.new_zero_division_error("integer modulo by zero".to_string()))
+    }
+}
+ 
 #[pyimpl]
 impl PyInt {
     #[pymethod(name = "__eq__")]
@@ -369,12 +377,18 @@ impl PyInt {
     #[pymethod(name = "__mod__")]
     fn mod_(&self, other: PyObjectRef, vm: &VirtualMachine) -> PyResult {
         if objtype::isinstance(&other, &vm.ctx.int_type()) {
-            let v2 = get_value(&other);
-            if *v2 != BigInt::zero() {
-                Ok(vm.ctx.new_int((&self.value) % v2))
-            } else {
-                Err(vm.new_zero_division_error("integer modulo by zero".to_string()))
-            }
+            let other = other.payload::<PyInt>().unwrap();
+            inner_mod(self, &other, vm)
+        } else {
+            Ok(vm.ctx.not_implemented())
+        }
+    }
+
+    #[pymethod(name = "__rmod__")]
+    fn rmod_(&self, other: PyObjectRef, vm: &VirtualMachine) -> PyResult {
+        if objtype::isinstance(&other, &vm.ctx.int_type()) {
+            let other = other.payload::<PyInt>().unwrap();
+            inner_mod(&other, self, vm)
         } else {
             Ok(vm.ctx.not_implemented())
         }


### PR DESCRIPTION
Extracted `inner_mod` function and used in `int.__mod__` and `int.__rmod__`
and also added test snippets of `int.__mod__` and `int.__rmod__`.