### PR TITLE
Do not pollute stack when if-expression condition evaluated to False

### DIFF
--- a/compiler/src/compile.rs
+++ b/compiler/src/compile.rs
@@ -1426,11 +1426,15 @@ impl Compiler {
             ast::Expression::IfExpression { test, body, orelse } => {
                 let no_label = self.new_label();
                 let end_label = self.new_label();
-                self.compile_test(test, None, Some(no_label), EvalContext::Expression)?;
+                self.compile_test(test, None, None, EvalContext::Expression)?;
+                self.emit(Instruction::JumpIfFalse { target: no_label });
+                // True case
                 self.compile_expression(body)?;
                 self.emit(Instruction::Jump { target: end_label });
+                // False case
                 self.set_label(no_label);
                 self.compile_expression(orelse)?;
+                // End
                 self.set_label(end_label);
             }
         }

--- a/tests/snippets/if_expressions.py
+++ b/tests/snippets/if_expressions.py
@@ -1,0 +1,26 @@
+def ret(expression):
+    return expression
+
+
+assert ret("0" if True else "1") == "0"
+assert ret("0" if False else "1") == "1"
+
+assert ret("0" if False else ("1" if True else "2")) == "1"
+assert ret("0" if False else ("1" if False else "2")) == "2"
+
+assert ret(("0" if True else "1") if True else "2") == "0"
+assert ret(("0" if False else "1") if True else "2") == "1"
+
+a = True
+b = False
+assert ret("0" if a or b else "1") == "0"
+assert ret("0" if a and b else "1") == "1"
+
+
+def func1():
+    return 0
+
+def func2():
+    return 20
+
+assert ret(func1() or func2()) == 20


### PR DESCRIPTION
Otherwise provided test snippet fails with `Unsupported method __call__` because vm tries to make a `__call__`on the value returned from expression. 