### PR TITLE
Add name, path, msg attributes to ImportError

### DIFF
--- a/tests/snippets/exceptions.py
+++ b/tests/snippets/exceptions.py
@@ -1,3 +1,4 @@
+# KeyError
 empty_exc = KeyError()
 assert str(empty_exc) == ''
 assert repr(empty_exc) == 'KeyError()'
@@ -23,3 +24,22 @@ class A:
 exc = KeyError(A())
 assert str(exc) == 'repr'
 assert repr(exc) == 'KeyError(repr,)'
+
+# ImportError / ModuleNotFoundError
+exc = ImportError()
+assert exc.name is None
+assert exc.path is None
+assert exc.msg is None
+assert exc.args == ()
+
+exc = ImportError('hello')
+assert exc.name is None
+assert exc.path is None
+assert exc.msg == 'hello'
+assert exc.args == ('hello',)
+
+exc = ImportError('hello', name='name', path='path')
+assert exc.name == 'name'
+assert exc.path == 'path'
+assert exc.msg == 'hello'
+assert exc.args == ('hello',)

--- a/tests/snippets/import.py
+++ b/tests/snippets/import.py
@@ -25,6 +25,11 @@ try:
 except ImportError:
     pass
 
+try:
+    import mymodule
+except ModuleNotFoundError as exc:
+    assert exc.name == 'mymodule'
+
 
 test = __import__("import_target")
 assert test.X == import_target.X

--- a/vm/src/exceptions.rs
+++ b/vm/src/exceptions.rs
@@ -312,6 +312,35 @@ impl ExceptionZoo {
     }
 }
 
+fn import_error_init(vm: &VirtualMachine, args: PyFuncArgs) -> PyResult {
+    // TODO: call super().__init__(*args) instead
+    exception_init(vm, args.clone())?;
+
+    let exc_self = args.args[0].clone();
+    vm.set_attr(
+        &exc_self,
+        "name",
+        args.kwargs
+            .get("name")
+            .cloned()
+            .unwrap_or_else(|| vm.get_none()),
+    )?;
+    vm.set_attr(
+        &exc_self,
+        "path",
+        args.kwargs
+            .get("path")
+            .cloned()
+            .unwrap_or_else(|| vm.get_none()),
+    )?;
+    vm.set_attr(
+        &exc_self,
+        "msg",
+        args.args.get(1).cloned().unwrap_or_else(|| vm.get_none()),
+    )?;
+    Ok(vm.get_none())
+}
+
 pub fn init(context: &PyContext) {
     let base_exception_type = &context.exceptions.base_exception_type;
     extend_class!(context, base_exception_type, {
@@ -322,5 +351,10 @@ pub fn init(context: &PyContext) {
     extend_class!(context, exception_type, {
         "__str__" => context.new_rustfunc(exception_str),
         "__repr__" => context.new_rustfunc(exception_repr),
+    });
+
+    let import_error_type = &context.exceptions.import_error;
+    extend_class!(context, import_error_type, {
+        "__init__" => context.new_rustfunc(import_error_init)
     });
 }


### PR DESCRIPTION
`importlib` sets those attributes in some places. 

```
cargo run -- -c "from collections import unknown"
```
for relevant failure on the current master. 