### PR TITLE
Remove importlib frames from traceback

### DIFF
--- a/vm/src/import.rs
+++ b/vm/src/import.rs
@@ -83,6 +83,7 @@ pub fn import_codeobj(
     Ok(module)
 }
 
+// TODO: This function should do nothing on verbose mode.
 pub fn remove_importlib_frames(vm: &VirtualMachine, exc: &PyObjectRef) -> PyObjectRef {
     let always_trim = objtype::isinstance(exc, &vm.ctx.exceptions.import_error);
 


### PR DESCRIPTION
Previously the traceback was:
```py
Traceback (most recent call last):
  File "/tmp/a.py", line 3, in <module>
    import b
  File "_frozen_importlib", line 1093, in __import__
  File "_frozen_importlib", line 1014, in _gcd_import
  File "_frozen_importlib", line 991, in _find_and_load
  File "_frozen_importlib", line 975, in _find_and_load_unlocked
  File "_frozen_importlib", line 686, in _load_unlocked
  File "_frozen_importlib", line 677, in _load_unlocked
  File "_frozen_importlib", line 671, in _load_unlocked
  File "_frozen_importlib_external", line 778, in exec_module
  File "_frozen_importlib", line 219, in _call_with_frames_removed
  File "/tmp/b.py", line 1, in <module>
    1/0
ZeroDivisionError: 'integer division by zero'
```
Now it is:
```py
Traceback (most recent call last):
  File "/tmp/a.py", line 3, in <module>
    import b
  File "/tmp/b.py", line 1, in <module>
    1/0
ZeroDivisionError: 'integer division by zero'
```