### PR TITLE
Allow skipping of unknown modules in whats_left.sh

### DIFF
--- a/tests/not_impl_gen.py
+++ b/tests/not_impl_gen.py
@@ -60,6 +60,12 @@ def gen_methods(header, footer, output):
     output.write("}\n\n")
     output.write(footer.read())
 
+def get_module_methods(name):
+    try:
+        return set(dir(__import__(name))) if name not in ("this", "antigravity") else None
+    except ModuleNotFoundError:
+        return None
+
 
 def gen_modules(header, footer, output):
     output.write(header.read())
@@ -70,9 +76,7 @@ def gen_modules(header, footer, output):
                 mod.name,
                 # check name b/c modules listed have side effects on import,
                 # e.g. printing something or opening a webpage
-                set(dir(__import__(mod.name)))
-                if mod.name not in ("this", "antigravity")
-                else None,
+                get_module_methods(mod.name)
             ),
             pkgutil.iter_modules(),
         )


### PR DESCRIPTION
I kept getting the following error:
```py
Traceback (most recent call last):
  File "not_impl_gen.py", line 99, in <module>
    output=open(f"snippets/whats_left_{name}.py", "w"),
  File "not_impl_gen.py", line 77, in gen_modules
    pkgutil.iter_modules(),
  File "not_impl_gen.py", line 74, in <lambda>
    if mod.name not in ("this", "antigravity")
  File "/usr/lib/python3.6/turtle.py", line 107, in <module>
    import tkinter as TK
ModuleNotFoundError: No module named 'tkinter'
```