### PR TITLE
Add #![doc(html_logo_url = ...)] to crates

### DIFF
--- a/bytecode/src/lib.rs
+++ b/bytecode/src/lib.rs
@@ -1,1 +1,4 @@
+#![doc(html_logo_url = "https://raw.githubusercontent.com/RustPython/RustPython/master/logo.png")]
+#![doc(html_root_url = "https://docs.rs/rustpython-bytecode/")]
+
 pub mod bytecode;

--- a/compiler/src/lib.rs
+++ b/compiler/src/lib.rs
@@ -1,5 +1,7 @@
 //! Compile a Python AST or source code into bytecode consumable by RustPython or
 //! (eventually) CPython.
+#![doc(html_logo_url = "https://raw.githubusercontent.com/RustPython/RustPython/master/logo.png")]
+#![doc(html_root_url = "https://docs.rs/rustpython-compiler/")]
 
 #[macro_use]
 extern crate log;

--- a/derive/src/lib.rs
+++ b/derive/src/lib.rs
@@ -1,4 +1,6 @@
 #![recursion_limit = "128"]
+#![doc(html_logo_url = "https://raw.githubusercontent.com/RustPython/RustPython/master/logo.png")]
+#![doc(html_root_url = "https://docs.rs/rustpython-derive/")]
 
 extern crate proc_macro;
 

--- a/parser/src/lib.rs
+++ b/parser/src/lib.rs
@@ -1,3 +1,6 @@
+#![doc(html_logo_url = "https://raw.githubusercontent.com/RustPython/RustPython/master/logo.png")]
+#![doc(html_root_url = "https://docs.rs/rustpython-parser/")]
+
 #[macro_use]
 extern crate log;
 use lalrpop_util::lalrpop_mod;

--- a/vm/src/lib.rs
+++ b/vm/src/lib.rs
@@ -11,6 +11,8 @@
     clippy::let_and_return,
     clippy::implicit_hasher
 )]
+#![doc(html_logo_url = "https://raw.githubusercontent.com/RustPython/RustPython/master/logo.png")]
+#![doc(html_root_url = "https://docs.rs/rustpython-vm/")]
 
 #[macro_use]
 extern crate bitflags;


### PR DESCRIPTION
I randomly came across [this crate](https://docs.rs/adapton/0.3.30/adapton/) on docs.rs, and I had no idea that you were able to put logos in rustdoc! I figured we should put our derpy logo there. :smiley: