### PR TITLE
Add an speedscope output format for profiling 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,4 +10,7 @@ __pycache__
 wasm-pack.log
 .idea/
 tests/snippets/resources
+
 flame-graph.html
+flame.txt
+flamescope.json

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -381,7 +381,7 @@ dependencies = [
 
 [[package]]
 name = "flamescope"
-version = "0.1.0"
+version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "flame 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1006,7 +1006,7 @@ dependencies = [
  "cpython 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "env_logger 0.5.13 (registry+https://github.com/rust-lang/crates.io-index)",
  "flame 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "flamescope 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "flamescope 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "rustpython-compiler 0.1.0",
  "rustpython-parser 0.1.0",
@@ -1980,7 +1980,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum fixedbitset 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)" = "86d4de0081402f5e88cdac65c8dcdcc73118c1a7a465e2a05f0da05843a8ea33"
 "checksum flame 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "1fc2706461e1ee94f55cab2ed2e3d34ae9536cfa830358ef80acff1a3dacab30"
 "checksum flamer 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "f2add1a5e84b1ed7b5d00cdc21789a28e0a8f4e427b677313c773880ba3c4dac"
-"checksum flamescope 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "917f99871e49c0d61d7352737811207113fb34741a440a76087669c05d422857"
+"checksum flamescope 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "6e3e6aee625a28b97be4308bccc2eb5f81d9ec606b3f29e13c0f459ce20dd136"
 "checksum fnv 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)" = "2fad85553e09a6f881f739c29f0b00b0f01357c743266d478b68951ce23285f3"
 "checksum fuchsia-cprng 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "a06f77d526c1a601b7c4cdd98f54b5eaabffc14d5f2f0296febdc7f357c6d3ba"
 "checksum futures 0.1.27 (registry+https://github.com/rust-lang/crates.io-index)" = "a2037ec1c6c1c4f79557762eab1f7eae1f64f6cb418ace90fae88f0942b60139"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -380,6 +380,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "flamescope"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "flame 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "indexmap 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.92 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_json 1.0.39 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "fnv"
 version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -995,6 +1006,7 @@ dependencies = [
  "cpython 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "env_logger 0.5.13 (registry+https://github.com/rust-lang/crates.io-index)",
  "flame 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "flamescope 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "rustpython-compiler 0.1.0",
  "rustpython-parser 0.1.0",
@@ -1968,6 +1980,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum fixedbitset 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)" = "86d4de0081402f5e88cdac65c8dcdcc73118c1a7a465e2a05f0da05843a8ea33"
 "checksum flame 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "1fc2706461e1ee94f55cab2ed2e3d34ae9536cfa830358ef80acff1a3dacab30"
 "checksum flamer 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "f2add1a5e84b1ed7b5d00cdc21789a28e0a8f4e427b677313c773880ba3c4dac"
+"checksum flamescope 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "917f99871e49c0d61d7352737811207113fb34741a440a76087669c05d422857"
 "checksum fnv 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)" = "2fad85553e09a6f881f739c29f0b00b0f01357c743266d478b68951ce23285f3"
 "checksum fuchsia-cprng 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "a06f77d526c1a601b7c4cdd98f54b5eaabffc14d5f2f0296febdc7f357c6d3ba"
 "checksum futures 0.1.27 (registry+https://github.com/rust-lang/crates.io-index)" = "a2037ec1c6c1c4f79557762eab1f7eae1f64f6cb418ace90fae88f0942b60139"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ path = "./benchmarks/bench.rs"
 
 [features]
 default = []
-flame-it = ["rustpython-vm/flame-it", "flame"]
+flame-it = ["rustpython-vm/flame-it", "flame", "flamescope"]
 
 [dependencies]
 log="0.4.1"
@@ -29,6 +29,7 @@ rustyline = "4.1.0"
 xdg = "2.2.0"
 
 flame = { version = "0.2", optional = true }
+flamescope = { version = "0.1", optional = true }
 
 [dev-dependencies.cpython]
 version = "0.2"

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -1,0 +1,56 @@
+# RustPython Development Guide and Tips
+
+## Code organization
+
+- `parser/src`: python lexing, parsing and ast
+- `vm/src`: python virtual machine
+  - `builtins.rs`: Builtin functions
+  - `compile.rs`: the python compiler from ast to bytecode
+  - `obj`: python builtin types
+- `src`: using the other subcrates to bring rustpython to life.
+- `docs`: documentation (work in progress)
+- `py_code_object`: CPython bytecode to rustpython bytecode converter (work in
+  progress)
+- `wasm`: Binary crate and resources for WebAssembly build
+- `tests`: integration test snippets
+
+## Code style
+
+The code style used is the default
+[rustfmt](https://github.com/rust-lang/rustfmt) codestyle. Please format your
+code accordingly. We also use [clippy](https://github.com/rust-lang/rust-clippy)
+to detect rust code issues.
+
+## Testing
+
+To test rustpython, there is a collection of python snippets located in the
+`tests/snippets` directory. To run those tests do the following:
+
+```shell
+$ cd tests
+$ pipenv install
+$ pipenv run pytest -v
+```
+
+There also are some unit tests, you can run those with cargo:
+
+```shell
+$ cargo test --all
+```
+
+## Profiling
+
+To profile rustpython, simply build in release mode with the `flame-it` feature.
+This will generate a file `flamescope.json`, which you can then view at
+https://speedscope.app.
+
+```sh
+$ cargo run --release --features flame-it script.py
+$ cat flamescope.json
+{<json>}
+```
+
+You can also pass the `--output-file` option to choose which file to output to
+(or stdout if you specify `-`), and the `--output-format` option to choose if
+you want to output in the speedscope json format (default), text, or a raw html
+viewer (currently broken).

--- a/README.md
+++ b/README.md
@@ -105,6 +105,23 @@ There also are some unit tests, you can run those with cargo:
 $ cargo test --all
 ```
 
+# Profiling
+
+To profile rustpython, simply build in release mode with the `flame-it` feature.
+This will generate a file `flamescope.json`, which you can then view at
+https://speedscope.app.
+
+```sh
+$ cargo run --release --features flame-it script.py
+$ cat flamescope.json
+{<json>}
+```
+
+You can also pass the `--output-file` option to choose which file to output to
+(or stdout if you specify `-`), and the `--output-format` option to choose if
+you want to output in the speedscope json format (default), text, or a raw html
+viewer (currently broken).
+
 # Using a standard library
 
 As of now the standard library is under construction. You can

--- a/README.md
+++ b/README.md
@@ -59,19 +59,6 @@ Documentation HTML files can then be found in the `target/doc` directory.
 
 If you wish to update the online documentation, push directly to the `release` branch (or ask a maintainer to do so). This will trigger a Travis build that updates the documentation and WebAssembly demo page.
 
-# Code organization
-
-- `parser/src`: python lexing, parsing and ast
-- `vm/src`: python virtual machine
-  - `builtins.rs`: Builtin functions
-  - `compile.rs`: the python compiler from ast to bytecode
-  - `obj`: python builtin types
-- `src`: using the other subcrates to bring rustpython to life.
-- `docs`: documentation (work in progress)
-- `py_code_object`: CPython bytecode to rustpython bytecode converter (work in progress)
-- `wasm`: Binary crate and resources for WebAssembly build
-- `tests`: integration test snippets
-
 # Contributing
 
 Contributions are more than welcome, and in many cases we are happy to guide contributors through PRs or on gitter.
@@ -87,40 +74,6 @@ and easiest way to contribute.
 You can also simply run
 `./whats_left.sh` to assist in finding any
 unimplemented method.
-
-# Testing
-
-To test rustpython, there is a collection of python snippets located in the
-`tests/snippets` directory. To run those tests do the following:
-
-```shell
-$ cd tests
-$ pipenv install
-$ pipenv run pytest -v
-```
-
-There also are some unit tests, you can run those with cargo:
-
-```shell
-$ cargo test --all
-```
-
-# Profiling
-
-To profile rustpython, simply build in release mode with the `flame-it` feature.
-This will generate a file `flamescope.json`, which you can then view at
-https://speedscope.app.
-
-```sh
-$ cargo run --release --features flame-it script.py
-$ cat flamescope.json
-{<json>}
-```
-
-You can also pass the `--output-file` option to choose which file to output to
-(or stdout if you specify `-`), and the `--output-format` option to choose if
-you want to output in the speedscope json format (default), text, or a raw html
-viewer (currently broken).
 
 # Using a standard library
 
@@ -142,11 +95,6 @@ the [ouroboros library](https://github.com/pybee/ouroboros).
 # Compiling to WebAssembly
 
 [See this doc](wasm/README.md)
-
-# Code style
-
-The code style used is the default [rustfmt](https://github.com/rust-lang/rustfmt) codestyle. Please format your code accordingly.
-We also use [clippy](https://github.com/rust-lang/rust-clippy) to detect rust code issues.
 
 # Community
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -29,6 +29,8 @@ fn main() {
 }
 
 fn run() -> Result<(), Box<dyn std::error::Error>> {
+    #[cfg(feature = "flame-it")]
+    let main_guard = flame::start_guard("RustPython main");
     env_logger::init();
     let app = App::new("RustPython")
         .version(crate_version!())
@@ -55,15 +57,25 @@ fn run() -> Result<(), Box<dyn std::error::Error>> {
         )
         .arg(Arg::from_usage("[pyargs] 'args for python'").multiple(true));
     #[cfg(feature = "flame-it")]
-    let app = app.arg(
-        Arg::with_name("profile_output")
-            .long("profile-output")
-            .takes_value(true)
-            .help(
-                "the file to output the profile graph to. present due to being \
-                 built with feature 'flame-it'",
-            ),
-    );
+    let app = app
+        .arg(
+            Arg::with_name("profile_output")
+                .long("profile-output")
+                .takes_value(true)
+                .help(
+                    "the file to output the profiling information to. present due to being \
+                     built with feature 'flame-it'",
+                ),
+        )
+        .arg(
+            Arg::with_name("profile_format")
+                .long("profile-format")
+                .takes_value(true)
+                .help(
+                    "the profile format to output the profiling information in. present due to \
+                     being built with feature 'flame-it'",
+                ),
+        );
     let matches = app.get_matches();
 
     // Construct vm:
@@ -92,13 +104,43 @@ fn run() -> Result<(), Box<dyn std::error::Error>> {
     {
         use std::fs::File;
 
-        let profile_output = matches
-            .value_of_os("profile_output")
-            .unwrap_or_else(|| "flame-graph.html".as_ref());
-        if profile_output == "-" {
-            flame::dump_stdout();
+        main_guard.end();
+
+        enum ProfileFormat {
+            Html,
+            Text,
+            Speedscope,
+        }
+
+        let profile_output = matches.value_of_os("profile_output");
+
+        let profile_format = match matches.value_of("profile_format") {
+            Some("html") => ProfileFormat::Html,
+            Some("text") => ProfileFormat::Text,
+            None if profile_output == Some("-".as_ref()) => ProfileFormat::Text,
+            Some("speedscope") | None => ProfileFormat::Speedscope,
+            Some(other) => {
+                error!("Unknown profile format {}", other);
+                process::exit(1);
+            }
+        };
+
+        let profile_output = profile_output.unwrap_or_else(|| match profile_format {
+            ProfileFormat::Html => "flame-graph.html".as_ref(),
+            ProfileFormat::Text => "flame.txt".as_ref(),
+            ProfileFormat::Speedscope => "flamescope.json".as_ref(),
+        });
+
+        let profile_output: Box<dyn std::io::Write> = if profile_output == "-" {
+            Box::new(std::io::stdout())
         } else {
-            flame::dump_html(&mut File::create(profile_output)?)?;
+            Box::new(File::create(profile_output)?)
+        };
+
+        match profile_format {
+            ProfileFormat::Html => flame::dump_html(profile_output)?,
+            ProfileFormat::Text => flame::dump_text_to_writer(profile_output)?,
+            ProfileFormat::Speedscope => flamescope::dump(profile_output)?,
         }
     }
 

--- a/vm/src/frame.rs
+++ b/vm/src/frame.rs
@@ -271,11 +271,6 @@ impl Frame {
     // #[cfg_attr(feature = "flame-it", flame("Frame"))]
     pub fn run(&self, vm: &VirtualMachine) -> Result<ExecutionResult, PyObjectRef> {
         flame_guard!(format!("Frame::run({})", self.code.obj_name));
-        // flame doesn't include notes in the html graph :(
-        flame_note!(
-            flame::StrCow::from("CodeObj name"),
-            self.code.obj_name.clone().into()
-        );
 
         let filename = &self.code.source_path.to_string();
 
@@ -342,9 +337,10 @@ impl Frame {
 
     /// Execute a single instruction.
     #[allow(clippy::cognitive_complexity)]
-    #[cfg_attr(feature = "flame-it", flame("Frame"))]
     fn execute_instruction(&self, vm: &VirtualMachine) -> FrameResult {
         let instruction = self.fetch_instruction();
+
+        flame_guard!(format!("Frame::execute_instruction({:?})", instruction));
 
         #[cfg(feature = "vm-tracing-logging")]
         {

--- a/vm/src/macros.rs
+++ b/vm/src/macros.rs
@@ -273,14 +273,3 @@ macro_rules! flame_guard {
         let _guard = ::flame::start_guard($name);
     };
 }
-
-macro_rules! flame_note {
-    ($name:expr, $desc:expr$(,)?) => {
-        #[cfg(feature = "flame-it")]
-        ::flame::note($name, ::std::option::Option::Some($desc));
-    };
-    ($name:expr$(,)?) => {
-        #[cfg(feature = "flame-it")]
-        ::flame::note($name, ::std::option::Option::None);
-    };
-}


### PR DESCRIPTION
I added some documentation to `README.md`, but essentially it now by default outputs a `flamescope.json` file, which you can upload to https://speedscope.app to view profiling information in a *much* nicer viewer than the html that flame outputs. I authored the `flamescope` crate, so if there are any problems that come up I can quickly fix them.

[Here's](https://www.speedscope.app/#profileURL=https://gist.githubusercontent.com/coolreader18/4d601fb73b9382a5c217f3ce9efcf849/raw/9b98b5814c110cd32e90fb9c3e73f3a598a0c9da/flamescope.json) a demo of speedscope with a RustPython profiling output.