### PR TITLE
Optimize import

### DIFF
--- a/vm/src/import.rs
+++ b/vm/src/import.rs
@@ -88,7 +88,7 @@ pub fn import_codeobj(
 }
 
 // TODO: This function should do nothing on verbose mode.
-pub fn remove_importlib_frames(vm: &VirtualMachine, exc: &PyObjectRef) -> PyObjectRef {
+fn remove_importlib_frames(vm: &VirtualMachine, exc: &PyObjectRef) -> PyObjectRef {
     let always_trim = objtype::isinstance(exc, &vm.ctx.exceptions.import_error);
 
     if let Ok(tb) = vm.get_attribute(exc.clone(), "__traceback__") {
@@ -204,7 +204,8 @@ pub fn import(
                     vm.new_str(abs_name.clone()),
                     vm.import_func.borrow().clone(),
                 ],
-            )?
+            )
+            .map_err(|exc| remove_importlib_frames(vm, &exc))?
         }
     };
 
@@ -227,6 +228,7 @@ pub fn import(
                 handle_fromlist,
                 vec![module, from_list.unwrap(), vm.import_func.borrow().clone()],
             )
+            .map_err(|exc| remove_importlib_frames(vm, &exc))
         } else {
             Ok(module)
         }

--- a/vm/src/vm.rs
+++ b/vm/src/vm.rs
@@ -15,7 +15,6 @@ use crate::bytecode;
 use crate::frame::{ExecutionResult, Frame, FrameRef, Scope};
 use crate::frozen;
 use crate::function::PyFuncArgs;
-use crate::import;
 use crate::obj::objbool;
 use crate::obj::objbuiltinfunc::PyBuiltinFunction;
 use crate::obj::objcode::{PyCode, PyCodeRef};
@@ -337,7 +336,6 @@ impl VirtualMachine {
                 self.ctx.new_int(level),
             ],
         )
-        .map_err(|exc| import::remove_importlib_frames(self, &exc))
     }
 
     /// Determines if `obj` is an instance of `cls`, either directly, indirectly or virtually via


### PR DESCRIPTION
I implemented CPython [PyImport_ImportModuleLevelObject](https://github.com/python/cpython/blob/59ad110d7a7784d53d0b502eebce0346597a6bef/Python/import.c#L1764) trying to improve the import speed. The problem is that it has almost no effect. For the following script:
```py
import time

start = time.time()
import os
print(time.time() - start)
```
I get after the change 0.11813092231750488 and before 0.12146615982055664.
Do you think we should add this change? 