### PR TITLE
Travis CI: Lint Python code with flake8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -53,8 +53,8 @@ matrix:
     - name: Lint Python code with flake8
       language: python
       python: 3.6
-      cache:
-        - pip
+      cache: pip
+      env: JOBCACHE=9
       install: pip install flake8
       script: flake8 . --count --exclude=./.*,./Lib,./vm/Lib  --select=E9,F63,F7,F82 --show-source --statistics
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@
 matrix:
   fast_finish: true
   include:
-    - name: Run rust tests
+    - name: Run Rust tests
       language: rust
       rust: stable
       cache: cargo
@@ -16,7 +16,7 @@ matrix:
 
     # To test the snippets, we use Travis' Python environment (because
     # installing rust ourselves is a lot easier than installing Python)
-    - name: python test snippets
+    - name: Python test snippets
       language: python
       python: 3.6
       cache:
@@ -28,7 +28,7 @@ matrix:
         - CODE_COVERAGE=false
       script: tests/.travis-runner.sh
 
-    - name: Check rust code style with rustfmt
+    - name: Check Rust code style with rustfmt
       language: rust
       rust: stable
       cache: cargo
@@ -39,7 +39,7 @@ matrix:
       env:
         - JOBCACHE=3
 
-    - name: Lint code with clippy
+    - name: Lint Rust code with clippy
       language: rust
       rust: stable
       cache: cargo
@@ -50,7 +50,15 @@ matrix:
       env:
         - JOBCACHE=8
 
-    - name: publish documentation
+    - name: Lint Python code with flake8
+      language: python
+      python: 3.6
+      cache:
+        - pip
+      install: pip install flake8
+      script: flake8 . --count --exclude=./.*,./Lib,./vm/Lib  --select=E9,F63,F7,F82 --show-source --statistics
+
+    - name: Publish documentation
       language: rust
       rust: stable
       cache: cargo
@@ -109,7 +117,7 @@ matrix:
         - TRAVIS_RUST_VERSION=nightly
         - CODE_COVERAGE=true
 
-    - name: test WASM
+    - name: Test WASM
       language: python
       python: 3.6
       cache:

--- a/tests/snippets/bools.py
+++ b/tests/snippets/bools.py
@@ -34,13 +34,13 @@ class Falsey:
 
 assert not Falsey()
 
-assert (True or fake)
+assert (True or fake)  # noqa: F821
 assert (False or True)
 assert not (False or False)
 assert ("thing" or 0) == "thing"
 
 assert (True and True)
-assert not (False and fake)
+assert not (False and fake)  # noqa: F821
 assert (True and 5) == 5
 
 # Bools are also ints.

--- a/tests/snippets/builtins_module.py
+++ b/tests/snippets/builtins_module.py
@@ -6,7 +6,7 @@ with assertRaises(AttributeError):
     __builtins__.__builtins__
 
 __builtins__.x = 'new'
-assert x == 'new'
+assert x == 'new'  # noqa: F821
 
 exec('assert "__builtins__" in globals()', dict())
 exec('assert __builtins__ == 7', {'__builtins__': 7})
@@ -23,6 +23,6 @@ assert namespace['__builtins__'] == __builtins__.__dict__
 # __builtins__ is deletable but names are alive
 del __builtins__
 with assertRaises(NameError):
-    __builtins__
+    __builtins__  # noqa: F821
 
 assert print

--- a/tests/snippets/delete.py
+++ b/tests/snippets/delete.py
@@ -14,8 +14,8 @@ assert not hasattr(foo, 'bar')
 x = 1
 y = 2
 del (x, y)
-assert_raises(NameError, lambda: x)
-assert_raises(NameError, lambda: y)
+assert_raises(NameError, lambda: x)  # noqa: F821
+assert_raises(NameError, lambda: y)  # noqa: F821
 
 with assertRaises(NameError):
-    del y
+    del y  # noqa: F821

--- a/tests/snippets/dismod.py
+++ b/tests/snippets/dismod.py
@@ -10,7 +10,7 @@ dis.dis(compile("f(x=1, y=2)", "", "eval"))
 print("\n")
 
 def f():
-    with g():
+    with g():  # noqa: F821
         try:
             for a in {1: 4, 2: 5}:
                 yield [True and False or True, []]
@@ -21,7 +21,7 @@ dis.dis(f)
 
 class A(object):
     def f():
-        x += 1
+        x += 1  # noqa: F821
         pass
     def g():
         for i in range(5):

--- a/tests/snippets/test_exec.py
+++ b/tests/snippets/test_exec.py
@@ -1,5 +1,5 @@
 exec("def square(x):\n return x * x\n")
-assert 16 == square(4)
+assert 16 == square(4)  # noqa: F821
 
 d = {}
 exec("def square(x):\n return x * x\n", {}, d)
@@ -39,8 +39,8 @@ else:
 g = globals()
 g['x'] = 2
 exec('x += 2')
-assert x == 4
-assert g['x'] == x
+assert x == 4  # noqa: F821
+assert g['x'] == x  # noqa: F821
 
 exec("del x")
 assert 'x' not in g

--- a/tests/snippets/try_exceptions.py
+++ b/tests/snippets/try_exceptions.py
@@ -15,7 +15,7 @@ except ZeroDivisionError as ex:
 
 class E(Exception):
     def __init__(self):
-        asdf
+        asdf  # noqa: F821
 
 try:
     raise E


### PR DESCRIPTION
These tests focus on Python syntax errors and undefined names.

Also capitalize first words and brand names.

$ __flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics__

On the test selection, this PR does not focus on "_style violations_" (the majority of [flake8 error codes](https://lintlyci.github.io/Flake8Rules) that [__python/black__](https://github.com/python/black) can autocorrect).  Instead these tests focus on runtime safety and correctness:
* E9 tests are about Python syntax errors usually raised because flake8 can not build an Abstract Syntax Tree (AST).  Often these issues are a sign of unused code or code that has not been ported to Python 3.  These would be compile-time errors in a compiled language but in a dynamic language like Python they result in the script halting/crashing on the user.
* F63 tests are usually about the confusion between identity and equality in Python.  Use ==/!= to compare str, bytes, and int literals is the classic case.  These are areas where __a == b__ is True but __a is b__ is False (or vice versa).
* F7 tests are logic errors or syntax errors in type hints
* F82 tests are almost always _undefined names_ which are usually a sign of a typo, missing imports, or code that has not been ported to Python 3.  These also would be compile-time errors in a compiled language but in Python a __NameError__ is raised which will halt/crash the script on the user.

This PR adds the __# noqa: F821__ linter directive on lines where our tests create variables in a nonstandard way or where we are actually testing for undefined or deleted variables.