### PR TITLE
[WIP] Add int __sizeof__ implementation

### DIFF
--- a/vm/src/obj/objint.rs
+++ b/vm/src/obj/objint.rs
@@ -506,7 +506,7 @@ impl PyInt {
         let capacity = unsafe {
             // Grab a reference to the underlying vector. This relies on the compiler always placing
             // the BigUInt and its data vector directly at the start of their containing structs.
-            let data = & *(&self.value as *const BigInt as *const Vec<u8>);
+            let data = &*(&self.value as *const BigInt as *const Vec<u32>);
             data.capacity()
         };
 

--- a/vm/src/obj/objint.rs
+++ b/vm/src/obj/objint.rs
@@ -499,6 +499,21 @@ impl PyInt {
         !self.value.is_zero()
     }
 
+    #[pymethod(name = "__sizeof__")]
+    fn sizeof(&self, _vm: &VirtualMachine) -> usize {
+        // We would like to get self.value.data.data.capacity(), however, this is private so we
+        // need to use a hack instead
+        let capacity = unsafe {
+            // Grab a reference to the underlying vector. This relies on the compiler always placing
+            // the BigUInt and its data vector directly at the start of their containing structs.
+            let data = & *(&self.value as *const BigInt as *const Vec<u8>);
+            data.capacity()
+        };
+
+        // We would like to do std::mem::size_of::<BigDigit>(), but of course BigDigit is private.
+        std::mem::size_of::<Self>() + capacity * std::mem::size_of::<u32>()
+    }
+
     #[pymethod]
     fn bit_length(&self, _vm: &VirtualMachine) -> usize {
         self.value.bits()


### PR DESCRIPTION
Leaving this here in hopes that someone will tell me there's actually a really easy way of doing this!

On my system (x86_64 ubuntu 18) I've determined that the compiler lays out the BigInt structs like this:
```
offset item
-------------
0:    BigUInt
   0:    Vec
      0:    RawVec
         0:   Unique<T>
         8:   usize (capacity)
      15:   usize (len)
23:   Sign
```

So I can simply cast the `&BigInt` to a  `&Vec` and get the capacity from it.

TODO: Test snippets