### PR TITLE
stdlib.io: Implement seekable()

### DIFF
--- a/tests/snippets/stdlib_io.py
+++ b/tests/snippets/stdlib_io.py
@@ -1,8 +1,10 @@
-from io import BufferedReader, FileIO
+from io import BufferedReader, FileIO, StringIO, BytesIO
 import os
 
 fi = FileIO('README.md')
+assert fi.seekable()
 bb = BufferedReader(fi)
+assert bb.seekable()
 
 result = bb.read()
 


### PR DESCRIPTION
Seekable API is not yet implemented.
Apparently, this PR is not a perfect implementation of seekable but we can fill the rest of implementation in the future.

