### PR TITLE
freeze stdlib in WASM

### DIFF
--- a/wasm/lib/Cargo.toml
+++ b/wasm/lib/Cargo.toml
@@ -10,6 +10,9 @@ edition = "2018"
 [lib]
 crate-type = ["cdylib", "rlib"]
 
+[features]
+freeze-stdlib = ["rustpython-vm/freeze-stdlib"]
+
 [dependencies]
 rustpython-compiler = { path = "../../compiler" }
 rustpython-parser = { path = "../../parser" }

--- a/wasm/lib/Cargo.toml
+++ b/wasm/lib/Cargo.toml
@@ -11,6 +11,7 @@ edition = "2018"
 crate-type = ["cdylib", "rlib"]
 
 [features]
+default = ["freeze-stdlib"]
 freeze-stdlib = ["rustpython-vm/freeze-stdlib"]
 
 [dependencies]


### PR DESCRIPTION
As discussed in #1142. We did not reach a conclusion there if we should make this the default. I can remove the default if we will decide against this.