### PR TITLE
Use cargo-sweep to manage travis caches

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,9 @@
+before_cache: |
+  if command -v cargo; then
+    ! command -v cargo-sweep && cargo install cargo-sweep
+    cargo sweep -i
+    cargo sweep -t 15
+  fi
 
 matrix:
   fast_finish: true
@@ -56,7 +62,9 @@ matrix:
       cache: pip
       env: JOBCACHE=9
       install: pip install flake8
-      script: flake8 . --count --exclude=./.*,./Lib,./vm/Lib  --select=E9,F63,F7,F82 --show-source --statistics
+      script:
+        flake8 . --count --exclude=./.*,./Lib,./vm/Lib  --select=E9,F63,F7,F82
+        --show-source --statistics
 
     - name: Publish documentation
       language: rust


### PR DESCRIPTION
[`cargo-sweep`](https://github.com/holmgr/cargo-sweep)

The `before_cache` lifetime script now runs this:

```
if command -v cargo; then
  ! command -v cargo-sweep && cargo install cargo-sweep
  cargo sweep -i
  cargo sweep -t 15
fi
```

It first checks that there is rust/cargo installed, as our flake8 script doesn't install the rust toolchain. It then installs cargo-sweep if it isn't already, and removes artifacts from old versions of the rust toolchain and those that are more than 15 days old (by mtime). I'm not sure if that's a good measurement, it might be better if it were longer or shorter.