### PR TITLE
Fix compilation of nested boolean operations

### DIFF
--- a/compiler/src/compile.rs
+++ b/compiler/src/compile.rs
@@ -1303,11 +1303,9 @@ impl<O: OutputStream> Compiler<O> {
                             self.emit(Instruction::Pop);
                         }
                         if let Some(false_label) = false_label {
-                            self.emit(Instruction::Duplicate);
                             self.emit(Instruction::JumpIfFalse {
                                 target: false_label,
                             });
-                            self.emit(Instruction::Pop);
                         }
                     }
                 }


### PR DESCRIPTION
I ran into this in `unittest/runner.py`, which has this code:

```py
(run, run != 1 and "s" or "", timeTaken)
```

It was duplicating the False from the `!=` expression but not popping it off the stack, so when BuildTuple was called it included that original False as the first element of the tuple.