### PR TITLE
Simplify error formatting of str.__mod__ method.

### DIFF
--- a/vm/src/obj/objstr.rs
+++ b/vm/src/obj/objstr.rs
@@ -514,7 +514,7 @@ impl PyString {
     fn modulo(&self, values: PyObjectRef, vm: &VirtualMachine) -> PyResult {
         let format_string_text = &self.value;
         let format_string = CFormatString::from_str(format_string_text)
-            .map_err(|err| vm.new_value_error(format!("{}", err)))?;
+            .map_err(|err| vm.new_value_error(err.to_string()))?;
         do_cformat(vm, format_string, values.clone())
     }
 


### PR DESCRIPTION
suggested by @coolreader18 in #1262 