### PR TITLE
Increase performance for get_item_option.

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -441,10 +441,10 @@ fn shell_exec(vm: &VirtualMachine, source: &str, scope: Scope) -> Result<(), Com
                 Ok(value) => {
                     // Save non-None values as "_"
 
-                    use rustpython_vm::pyobject::{IdProtocol, IntoPyObject};
+                    use rustpython_vm::pyobject::IdProtocol;
 
                     if !value.is(&vm.get_none()) {
-                        let key = objstr::PyString::from("_").into_pyobject(vm);
+                        let key = "_";
                         scope.globals.set_item(key, value, vm).unwrap();
                     }
                 }

--- a/vm/src/frame.rs
+++ b/vm/src/frame.rs
@@ -1017,7 +1017,7 @@ impl Frame {
         let module = self
             .scope
             .globals
-            .get_item_option("__name__", vm)?
+            .get_item_option(&"__name__".to_string(), vm)?
             .unwrap_or_else(|| vm.get_none());
         vm.set_attr(&func_obj, "__module__", module)?;
         vm.set_attr(&func_obj, "__annotations__", annotations)?;

--- a/vm/src/frame.rs
+++ b/vm/src/frame.rs
@@ -285,12 +285,12 @@ impl Frame {
                         let dict: PyDictRef =
                             obj.downcast().expect("Need a dictionary to build a map.");
                         for (key, value) in dict {
-                            map_obj.set_item(key, value, vm).unwrap();
+                            map_obj.set_item(&key, value, vm).unwrap();
                         }
                     }
                 } else {
                     for (key, value) in self.pop_multiple(2 * size).into_iter().tuples() {
-                        map_obj.set_item(key, value, vm).unwrap();
+                        map_obj.set_item(&key, value, vm).unwrap();
                     }
                 }
 
@@ -946,14 +946,14 @@ impl Frame {
         let idx = self.pop_value();
         let obj = self.pop_value();
         let value = self.pop_value();
-        obj.set_item(idx, value, vm)?;
+        obj.set_item(&idx, value, vm)?;
         Ok(None)
     }
 
     fn execute_delete_subscript(&self, vm: &VirtualMachine) -> FrameResult {
         let idx = self.pop_value();
         let obj = self.pop_value();
-        obj.del_item(idx, vm)?;
+        obj.del_item(&idx, vm)?;
         Ok(None)
     }
 
@@ -1017,7 +1017,7 @@ impl Frame {
         let module = self
             .scope
             .globals
-            .get_item_option(&"__name__".to_string(), vm)?
+            .get_item_option("__name__", vm)?
             .unwrap_or_else(|| vm.get_none());
         vm.set_attr(&func_obj, "__module__", module)?;
         vm.set_attr(&func_obj, "__annotations__", annotations)?;
@@ -1062,7 +1062,7 @@ impl Frame {
                 bytecode::BinaryOperator::Divide => vm._truediv(a_ref, b_ref),
                 bytecode::BinaryOperator::FloorDivide => vm._floordiv(a_ref, b_ref),
                 // TODO: Subscript should probably have its own op
-                bytecode::BinaryOperator::Subscript => a_ref.get_item(b_ref, vm),
+                bytecode::BinaryOperator::Subscript => a_ref.get_item(&b_ref, vm),
                 bytecode::BinaryOperator::Modulo => vm._mod(a_ref, b_ref),
                 bytecode::BinaryOperator::Lshift => vm._lshift(a_ref, b_ref),
                 bytecode::BinaryOperator::Rshift => vm._rshift(a_ref, b_ref),

--- a/vm/src/obj/objdict.rs
+++ b/vm/src/obj/objdict.rs
@@ -200,7 +200,18 @@ impl PyDictRef {
         value: PyObjectRef,
         vm: &VirtualMachine,
     ) -> PyResult<()> {
-        self.entries.borrow_mut().insert(vm, &key, value)
+        self.inner_setitem_fast(&key, value, vm)
+    }
+
+    /// Set item variant which can be called with multiple
+    /// key types, such as str to name a notable one.
+    fn inner_setitem_fast<K: DictKey + IntoPyObject + Copy>(
+        &self,
+        key: K,
+        value: PyObjectRef,
+        vm: &VirtualMachine,
+    ) -> PyResult<()> {
+        self.entries.borrow_mut().insert(vm, key, value)
     }
 
     #[cfg_attr(feature = "flame-it", flame("PyDictRef"))]
@@ -213,9 +224,9 @@ impl PyDictRef {
     }
 
     /// Return an optional inner item, or an error (can be key error as well)
-    fn inner_getitem_option<K: DictKey + IntoPyObject + Clone>(
+    fn inner_getitem_option<K: DictKey + IntoPyObject + Copy>(
         &self,
-        key: &K,
+        key: K,
         vm: &VirtualMachine,
     ) -> PyResult<Option<PyObjectRef>> {
         if let Some(value) = self.entries.borrow().get(vm, key)? {
@@ -224,9 +235,7 @@ impl PyDictRef {
 
         if let Some(method_or_err) = vm.get_method(self.clone().into_object(), "__missing__") {
             let method = method_or_err?;
-            Ok(Some(
-                vm.invoke(&method, vec![key.clone().into_pyobject(vm)?])?,
-            ))
+            Ok(Some(vm.invoke(&method, vec![key.into_pyobject(vm)?])?))
         } else {
             Ok(None)
         }
@@ -340,9 +349,9 @@ impl PyDictRef {
     /// python value, or None.
     /// Note that we can pass any type which implements the DictKey
     /// trait. Notable examples are String and PyObjectRef.
-    pub fn get_item_option<T: IntoPyObject + DictKey + Clone>(
+    pub fn get_item_option<T: IntoPyObject + DictKey + Copy>(
         &self,
-        key: &T,
+        key: T,
         vm: &VirtualMachine,
     ) -> PyResult<Option<PyObjectRef>> {
         // Test if this object is a true dict, or mabye a subclass?
@@ -365,7 +374,7 @@ impl PyDictRef {
         } else {
             // Fall back to full get_item with KeyError checking
 
-            match self.get_item(key.clone().into_pyobject(vm)?, vm) {
+            match self.get_item(key, vm) {
                 Ok(value) => Ok(Some(value)),
                 Err(exc) => {
                     if objtype::isinstance(&exc, &vm.ctx.exceptions.key_error) {
@@ -380,20 +389,26 @@ impl PyDictRef {
 }
 
 impl ItemProtocol for PyDictRef {
-    fn get_item<T: IntoPyObject>(&self, key: T, vm: &VirtualMachine) -> PyResult {
+    fn get_item<T: IntoPyObject + DictKey + Copy>(&self, key: T, vm: &VirtualMachine) -> PyResult {
         self.as_object().get_item(key, vm)
     }
 
-    fn set_item<T: IntoPyObject>(
+    fn set_item<T: IntoPyObject + DictKey + Copy>(
         &self,
         key: T,
         value: PyObjectRef,
         vm: &VirtualMachine,
     ) -> PyResult {
-        self.as_object().set_item(key, value, vm)
+        if self.typ().is(&vm.ctx.dict_type()) {
+            self.inner_setitem_fast(key, value, vm)
+                .map(|_| vm.ctx.none())
+        } else {
+            // Fall back to slow path if we are in a dict subclass:
+            self.as_object().set_item(key, value, vm)
+        }
     }
 
-    fn del_item<T: IntoPyObject>(&self, key: T, vm: &VirtualMachine) -> PyResult {
+    fn del_item<T: IntoPyObject + DictKey + Copy>(&self, key: T, vm: &VirtualMachine) -> PyResult {
         self.as_object().del_item(key, vm)
     }
 }

--- a/vm/src/obj/objdict.rs
+++ b/vm/src/obj/objdict.rs
@@ -12,7 +12,7 @@ use super::objbool;
 use super::objiter;
 use super::objstr;
 use super::objtype;
-use crate::dictdatatype;
+use crate::dictdatatype::{self, DictKey};
 use crate::obj::objtype::PyClassRef;
 use crate::pyobject::PyClassImpl;
 
@@ -205,14 +205,31 @@ impl PyDictRef {
 
     #[cfg_attr(feature = "flame-it", flame("PyDictRef"))]
     fn inner_getitem(self, key: PyObjectRef, vm: &VirtualMachine) -> PyResult {
-        if let Some(value) = self.entries.borrow().get(vm, &key)? {
-            return Ok(value);
+        if let Some(value) = self.inner_getitem_option(&key, vm)? {
+            Ok(value)
+        } else {
+            Err(vm.new_key_error(key.clone()))
         }
+    }
+
+    /// Return an optional inner item, or an error (can be key error as well)
+    fn inner_getitem_option<K: DictKey + IntoPyObject + Clone>(
+        &self,
+        key: &K,
+        vm: &VirtualMachine,
+    ) -> PyResult<Option<PyObjectRef>> {
+        if let Some(value) = self.entries.borrow().get(vm, key)? {
+            return Ok(Some(value));
+        }
+
         if let Some(method_or_err) = vm.get_method(self.clone().into_object(), "__missing__") {
             let method = method_or_err?;
-            return vm.invoke(&method, vec![key]);
+            Ok(Some(
+                vm.invoke(&method, vec![key.clone().into_pyobject(vm)?])?,
+            ))
+        } else {
+            Ok(None)
         }
-        Err(vm.new_key_error(key.clone()))
     }
 
     fn get(
@@ -318,18 +335,44 @@ impl PyDictRef {
         self.entries.borrow().size()
     }
 
-    pub fn get_item_option<T: IntoPyObject>(
+    /// This function can be used to get an item without raising the
+    /// KeyError, so we can simply check upon the result being Some
+    /// python value, or None.
+    /// Note that we can pass any type which implements the DictKey
+    /// trait. Notable examples are String and PyObjectRef.
+    pub fn get_item_option<T: IntoPyObject + DictKey + Clone>(
         &self,
-        key: T,
+        key: &T,
         vm: &VirtualMachine,
     ) -> PyResult<Option<PyObjectRef>> {
-        match self.get_item(key, vm) {
-            Ok(value) => Ok(Some(value)),
-            Err(exc) => {
-                if objtype::isinstance(&exc, &vm.ctx.exceptions.key_error) {
-                    Ok(None)
-                } else {
-                    Err(exc)
+        // Test if this object is a true dict, or mabye a subclass?
+        // If it is a dict, we can directly invoke inner_get_item_option,
+        // and prevent the creation of the KeyError exception.
+        // Also note, that we prevent the creation of a full PyString object
+        // if we lookup local names (which happens all of the time).
+        if self.typ().is(&vm.ctx.dict_type()) {
+            // We can take the short path here!
+            match self.inner_getitem_option(key, vm) {
+                Err(exc) => {
+                    if objtype::isinstance(&exc, &vm.ctx.exceptions.key_error) {
+                        Ok(None)
+                    } else {
+                        Err(exc)
+                    }
+                }
+                Ok(x) => Ok(x),
+            }
+        } else {
+            // Fall back to full get_item with KeyError checking
+
+            match self.get_item(key.clone().into_pyobject(vm)?, vm) {
+                Ok(value) => Ok(Some(value)),
+                Err(exc) => {
+                    if objtype::isinstance(&exc, &vm.ctx.exceptions.key_error) {
+                        Ok(None)
+                    } else {
+                        Err(exc)
+                    }
                 }
             }
         }

--- a/vm/src/obj/objobject.rs
+++ b/vm/src/obj/objobject.rs
@@ -78,7 +78,7 @@ fn object_setattr(
     }
 
     if let Some(ref dict) = obj.clone().dict {
-        dict.set_item(attr_name, value, vm)?;
+        dict.set_item(&attr_name.value, value, vm)?;
         Ok(())
     } else {
         Err(vm.new_attribute_error(format!(
@@ -99,7 +99,7 @@ fn object_delattr(obj: PyObjectRef, attr_name: PyStringRef, vm: &VirtualMachine)
     }
 
     if let Some(ref dict) = obj.dict {
-        dict.del_item(attr_name, vm)?;
+        dict.del_item(&attr_name.value, vm)?;
         Ok(())
     } else {
         Err(vm.new_attribute_error(format!(

--- a/vm/src/obj/objstr.rs
+++ b/vm/src/obj/objstr.rs
@@ -996,7 +996,7 @@ impl PyString {
 
         let mut translated = String::new();
         for c in self.value.chars() {
-            match table.get_item(c as u32, vm) {
+            match table.get_item(&(c as u32).into_pyobject(vm)?, vm) {
                 Ok(value) => {
                     if let Some(text) = value.payload::<PyString>() {
                         translated.push_str(&text.value);
@@ -1036,11 +1036,11 @@ impl PyString {
                 Ok(from_str) => {
                     if to_str.len(vm) == from_str.len(vm) {
                         for (c1, c2) in from_str.value.chars().zip(to_str.value.chars()) {
-                            new_dict.set_item(c1 as u32, vm.new_int(c2 as u32), vm)?;
+                            new_dict.set_item(&vm.new_int(c1 as u32), vm.new_int(c2 as u32), vm)?;
                         }
                         if let OptionalArg::Present(none_str) = none_str {
                             for c in none_str.value.chars() {
-                                new_dict.set_item(c as u32, vm.get_none(), vm)?;
+                                new_dict.set_item(&vm.new_int(c as u32), vm.get_none(), vm)?;
                             }
                         }
                         new_dict.into_pyobject(vm)
@@ -1061,11 +1061,15 @@ impl PyString {
                 Ok(dict) => {
                     for (key, val) in dict {
                         if let Some(num) = key.payload::<PyInt>() {
-                            new_dict.set_item(num.as_bigint().to_i32(), val, vm)?;
+                            new_dict.set_item(
+                                &num.as_bigint().to_i32().into_pyobject(vm)?,
+                                val,
+                                vm,
+                            )?;
                         } else if let Some(string) = key.payload::<PyString>() {
                             if string.len(vm) == 1 {
                                 let num_value = string.value.chars().next().unwrap() as u32;
-                                new_dict.set_item(num_value, val, vm)?;
+                                new_dict.set_item(&num_value.into_pyobject(vm)?, val, vm)?;
                             } else {
                                 return Err(vm.new_value_error(
                                     "string keys in translate table must be of length 1".to_owned(),

--- a/vm/src/py_serde.rs
+++ b/vm/src/py_serde.rs
@@ -211,7 +211,7 @@ impl<'de> Visitor<'de> for PyObjectDeserializer<'de> {
         // Although JSON keys must be strings, implementation accepts any keys
         // and can be reused by other deserializers without such limit
         while let Some((key_obj, value)) = access.next_entry_seed(self.clone(), self.clone())? {
-            dict.set_item(key_obj, value, self.vm).unwrap();
+            dict.set_item(&key_obj, value, self.vm).unwrap();
         }
         Ok(dict.into_object())
     }

--- a/vm/src/pyobject.rs
+++ b/vm/src/pyobject.rs
@@ -11,6 +11,7 @@ use num_complex::Complex64;
 use num_traits::{One, Zero};
 
 use crate::bytecode;
+use crate::dictdatatype::DictKey;
 use crate::exceptions;
 use crate::function::{IntoPyNativeFunc, PyFuncArgs};
 use crate::obj::objbuiltinfunc::PyBuiltinFunction;
@@ -764,15 +765,17 @@ impl<T> TypeProtocol for PyRef<T> {
     }
 }
 
+/// The python item protocol. Mostly applies to dictionaries.
+/// Allows getting, setting and deletion of keys-value pairs.
 pub trait ItemProtocol {
-    fn get_item<T: IntoPyObject>(&self, key: T, vm: &VirtualMachine) -> PyResult;
-    fn set_item<T: IntoPyObject>(
+    fn get_item<T: IntoPyObject + DictKey + Copy>(&self, key: T, vm: &VirtualMachine) -> PyResult;
+    fn set_item<T: IntoPyObject + DictKey + Copy>(
         &self,
         key: T,
         value: PyObjectRef,
         vm: &VirtualMachine,
     ) -> PyResult;
-    fn del_item<T: IntoPyObject>(&self, key: T, vm: &VirtualMachine) -> PyResult;
+    fn del_item<T: IntoPyObject + DictKey + Copy>(&self, key: T, vm: &VirtualMachine) -> PyResult;
 }
 
 impl ItemProtocol for PyObjectRef {
@@ -962,6 +965,12 @@ pub trait IntoPyObject {
 impl IntoPyObject for PyObjectRef {
     fn into_pyobject(self, _vm: &VirtualMachine) -> PyResult {
         Ok(self)
+    }
+}
+
+impl IntoPyObject for &PyObjectRef {
+    fn into_pyobject(self, _vm: &VirtualMachine) -> PyResult {
+        Ok(self.clone())
     }
 }
 

--- a/vm/src/scope.rs
+++ b/vm/src/scope.rs
@@ -133,12 +133,12 @@ impl NameProtocol for Scope {
     #[cfg_attr(feature = "flame-it", flame("Scope"))]
     fn load_name(&self, vm: &VirtualMachine, name: &str) -> Option<PyObjectRef> {
         for dict in self.locals.iter() {
-            if let Some(value) = dict.get_item_option(&name.to_string(), vm).unwrap() {
+            if let Some(value) = dict.get_item_option(name, vm).unwrap() {
                 return Some(value);
             }
         }
 
-        if let Some(value) = self.globals.get_item_option(&name.to_string(), vm).unwrap() {
+        if let Some(value) = self.globals.get_item_option(name, vm).unwrap() {
             return Some(value);
         }
 
@@ -148,7 +148,7 @@ impl NameProtocol for Scope {
     #[cfg_attr(feature = "flame-it", flame("Scope"))]
     fn load_cell(&self, vm: &VirtualMachine, name: &str) -> Option<PyObjectRef> {
         for dict in self.locals.iter().skip(1) {
-            if let Some(value) = dict.get_item_option(&name.to_string(), vm).unwrap() {
+            if let Some(value) = dict.get_item_option(name, vm).unwrap() {
                 return Some(value);
             }
         }
@@ -174,7 +174,7 @@ impl NameProtocol for Scope {
 
     #[cfg_attr(feature = "flame-it", flame("Scope"))]
     fn load_global(&self, vm: &VirtualMachine, name: &str) -> Option<PyObjectRef> {
-        self.globals.get_item_option(&name.to_string(), vm).unwrap()
+        self.globals.get_item_option(name, vm).unwrap()
     }
 
     fn store_global(&self, vm: &VirtualMachine, name: &str, value: PyObjectRef) {

--- a/vm/src/scope.rs
+++ b/vm/src/scope.rs
@@ -133,12 +133,12 @@ impl NameProtocol for Scope {
     #[cfg_attr(feature = "flame-it", flame("Scope"))]
     fn load_name(&self, vm: &VirtualMachine, name: &str) -> Option<PyObjectRef> {
         for dict in self.locals.iter() {
-            if let Some(value) = dict.get_item_option(name, vm).unwrap() {
+            if let Some(value) = dict.get_item_option(&name.to_string(), vm).unwrap() {
                 return Some(value);
             }
         }
 
-        if let Some(value) = self.globals.get_item_option(name, vm).unwrap() {
+        if let Some(value) = self.globals.get_item_option(&name.to_string(), vm).unwrap() {
             return Some(value);
         }
 
@@ -148,7 +148,7 @@ impl NameProtocol for Scope {
     #[cfg_attr(feature = "flame-it", flame("Scope"))]
     fn load_cell(&self, vm: &VirtualMachine, name: &str) -> Option<PyObjectRef> {
         for dict in self.locals.iter().skip(1) {
-            if let Some(value) = dict.get_item_option(name, vm).unwrap() {
+            if let Some(value) = dict.get_item_option(&name.to_string(), vm).unwrap() {
                 return Some(value);
             }
         }
@@ -174,7 +174,7 @@ impl NameProtocol for Scope {
 
     #[cfg_attr(feature = "flame-it", flame("Scope"))]
     fn load_global(&self, vm: &VirtualMachine, name: &str) -> Option<PyObjectRef> {
-        self.globals.get_item_option(name, vm).unwrap()
+        self.globals.get_item_option(&name.to_string(), vm).unwrap()
     }
 
     fn store_global(&self, vm: &VirtualMachine, name: &str, value: PyObjectRef) {

--- a/vm/src/stdlib/errno.rs
+++ b/vm/src/stdlib/errno.rs
@@ -9,7 +9,7 @@ pub fn make_module(vm: &VirtualMachine) -> PyObjectRef {
     for (name, code) in ERROR_CODES {
         let name = vm.new_str((*name).to_owned());
         let code = vm.ctx.new_int(*code);
-        errorcode.set_item(code.clone(), name.clone(), vm).unwrap();
+        errorcode.set_item(&code, name.clone(), vm).unwrap();
         vm.set_attr(&module, name, code).unwrap();
     }
     module

--- a/vm/src/vm.rs
+++ b/vm/src/vm.rs
@@ -936,7 +936,7 @@ impl VirtualMachine {
         }
 
         let attr = if let Some(ref dict) = obj.dict {
-            dict.get_item_option(name_str.clone(), self)?
+            dict.get_item_option(&name_str.value, self)?
         } else {
             None
         };

--- a/vm/src/vm.rs
+++ b/vm/src/vm.rs
@@ -452,14 +452,13 @@ impl VirtualMachine {
             || level != 0
             || objbool::boolval(self, from_list.clone()).unwrap_or(true);
 
-        let module = self.new_str(module.to_owned());
-
         let cached_module = if weird {
             None
         } else {
             let sys_modules = self.get_attribute(self.sys_module.clone(), "modules")?;
-            sys_modules.get_item(module.clone(), self).ok()
+            sys_modules.get_item(module, self).ok()
         };
+
         match cached_module {
             Some(module) => Ok(module),
             None => {
@@ -478,7 +477,7 @@ impl VirtualMachine {
                 self.invoke(
                     &import_func,
                     vec![
-                        module,
+                        self.new_str(module.to_owned()),
                         globals,
                         locals,
                         from_list.clone(),


### PR DESCRIPTION
I finally got some idea that works in short circuiting the get_item_option for the case of strings. For example, this happens with the load_name opcode.

Idea is to short circuit the get_item logic and prevent several things from happening:
- Creation of the `KeyError`. Simply check for `None` or `Some`.
- Creation of a PyString when we lookup values by `str`.