### PR TITLE
Add nicer test names for benchmarks

### DIFF
--- a/benchmarks/test_benchmarks.py
+++ b/benchmarks/test_benchmarks.py
@@ -1,4 +1,5 @@
 
+import os
 import time
 import sys
 
@@ -19,8 +20,11 @@ benchmarks = [
     ['benchmarks/mandelbrot.py'],
 ]
 
-@pytest.mark.parametrize('exe', pythons)
-@pytest.mark.parametrize('args', benchmarks)
+exe_ids = ['cpython', 'rustpython']
+benchmark_ids = [benchmark[0].split('/')[-1] for benchmark in benchmarks]
+
+@pytest.mark.parametrize('exe', pythons, ids=exe_ids)
+@pytest.mark.parametrize('args', benchmarks, ids=benchmark_ids)
 def test_bench(exe, args, benchmark):
     def bench():
         subprocess.run([exe] + args)


### PR DESCRIPTION
Right now ```pytest``` does not show correct name/filename of the bench:
```
test_benchmarks.py::test_bench[args0-/usr/bin/python]
test_benchmarks.py::test_bench[args0-../target/release/rustpython]
test_benchmarks.py::test_bench[args1-/usr/bin/python]
test_benchmarks.py::test_bench[args1-../target/release/rustpython]
```

This PR:
```
test_benchmarks.py::test_bench[nbody.py-cpython]
test_benchmarks.py::test_bench[nbody.py-rustpython]
test_benchmarks.py::test_bench[mandelbrot.py-cpython]
test_benchmarks.py::test_bench[mandelbrot.py-rustpython]
```