### PR TITLE
use getgroups(2) for apple macos.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,8 +12,22 @@ before_cache:
 matrix:
   fast_finish: true
   include:
-    - name: Run Rust tests
+    - name: Run Rust tests(linux)
       language: rust
+      os: linux
+      rust: stable
+      cache: cargo
+      script:
+        - cargo build --verbose --all
+        - cargo test --verbose --all
+      env:
+        # Prevention of cache corruption.
+        # See: https://docs.travis-ci.com/user/caching/#caches-and-build-matrices
+        - JOBCACHE=1
+
+    - name: Run Rust tests(osx)
+      language: rust
+      os: osx
       rust: stable
       cache: cargo
       script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -36,7 +36,7 @@ matrix:
       env:
         # Prevention of cache corruption.
         # See: https://docs.travis-ci.com/user/caching/#caches-and-build-matrices
-        - JOBCACHE=1
+        - JOBCACHE=11
 
     # To test the snippets, we use Travis' Python environment (because
     # installing rust ourselves is a lot easier than installing Python)


### PR DESCRIPTION
- nix-rust/nix mentioned that this feature should be implemented
based on opendirectoryd. However, CPython implemented it based on getgroups(2)
for apple macOS.
So I ported the code from nix-rust/nix and it works well.

- Add apple macOS tests for travis CI.

ref0: https://github.com/nix-rust/nix/blob/500036a206188dc8f57bf95a7c61616db417038e/src/unistd.rs#L1320
ref1: https://github.com/python/cpython/blob/c4cacc8c5eab50db8da3140353596f38a01115ca/Modules/posixmodule.c#L6852

fix: #1295 