### PR TITLE
Make bytecode::Label its own struct

### DIFF
--- a/bytecode/src/bytecode.rs
+++ b/bytecode/src/bytecode.rs
@@ -56,7 +56,14 @@ bitflags! {
     }
 }
 
-pub type Label = usize;
+#[derive(Serialize, Debug, Deserialize, Clone, Copy, PartialEq, Eq, Hash)]
+pub struct Label(usize);
+
+impl Label {
+    pub fn new(label: usize) -> Self {
+        Label(label)
+    }
+}
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 /// An indication where the name must be accessed.
@@ -499,8 +506,8 @@ impl Instruction {
             SetupFinally { handler } => w!(SetupFinally, label_map[handler]),
             EnterFinally => w!(EnterFinally),
             EndFinally => w!(EndFinally),
-            SetupWith { end } => w!(SetupWith, end),
-            CleanupWith { end } => w!(CleanupWith, end),
+            SetupWith { end } => w!(SetupWith, label_map[end]),
+            CleanupWith { end } => w!(CleanupWith, label_map[end]),
             PopBlock => w!(PopBlock),
             Raise { argc } => w!(Raise, argc),
             BuildString { size } => w!(BuildString, size),

--- a/compiler/src/compile.rs
+++ b/compiler/src/compile.rs
@@ -12,7 +12,7 @@ use crate::symboltable::{
     make_symbol_table, statements_to_symbol_table, Symbol, SymbolScope, SymbolTable,
 };
 use num_complex::Complex64;
-use rustpython_bytecode::bytecode::{self, CallType, CodeObject, Instruction, Varargs};
+use rustpython_bytecode::bytecode::{self, CallType, CodeObject, Instruction, Label, Varargs};
 use rustpython_parser::{ast, parser};
 
 type BasicOutputStream = PeepholeOptimizer<CodeObjectStream>;
@@ -133,8 +133,6 @@ impl std::fmt::Display for ModeParseError {
         write!(f, r#"mode should be "exec", "eval", or "single""#)
     }
 }
-
-pub(crate) type Label = usize;
 
 impl<O> Default for Compiler<O>
 where
@@ -2004,7 +2002,7 @@ impl<O: OutputStream> Compiler<O> {
 
     // Generate a new label
     fn new_label(&mut self) -> Label {
-        let l = self.nxt_label;
+        let l = Label::new(self.nxt_label);
         self.nxt_label += 1;
         l
     }
@@ -2093,9 +2091,9 @@ fn compile_conversion_flag(conversion_flag: ast::ConversionFlag) -> bytecode::Co
 mod tests {
     use super::Compiler;
     use crate::symboltable::make_symbol_table;
-    use rustpython_bytecode::bytecode::CodeObject;
     use rustpython_bytecode::bytecode::Constant::*;
     use rustpython_bytecode::bytecode::Instruction::*;
+    use rustpython_bytecode::bytecode::{CodeObject, Label};
     use rustpython_parser::parser;
 
     fn compile_exec(source: &str) -> CodeObject {
@@ -2116,15 +2114,21 @@ mod tests {
                 LoadConst {
                     value: Boolean { value: true }
                 },
-                JumpIfTrue { target: 1 },
+                JumpIfTrue {
+                    target: Label::new(1)
+                },
                 LoadConst {
                     value: Boolean { value: false }
                 },
-                JumpIfTrue { target: 1 },
+                JumpIfTrue {
+                    target: Label::new(1)
+                },
                 LoadConst {
                     value: Boolean { value: false }
                 },
-                JumpIfFalse { target: 0 },
+                JumpIfFalse {
+                    target: Label::new(0)
+                },
                 Pass,
                 LoadConst { value: None },
                 ReturnValue
@@ -2141,15 +2145,21 @@ mod tests {
                 LoadConst {
                     value: Boolean { value: true }
                 },
-                JumpIfFalse { target: 0 },
+                JumpIfFalse {
+                    target: Label::new(0)
+                },
                 LoadConst {
                     value: Boolean { value: false }
                 },
-                JumpIfFalse { target: 0 },
+                JumpIfFalse {
+                    target: Label::new(0)
+                },
                 LoadConst {
                     value: Boolean { value: false }
                 },
-                JumpIfFalse { target: 0 },
+                JumpIfFalse {
+                    target: Label::new(0)
+                },
                 Pass,
                 LoadConst { value: None },
                 ReturnValue
@@ -2166,19 +2176,27 @@ mod tests {
                 LoadConst {
                     value: Boolean { value: true }
                 },
-                JumpIfFalse { target: 2 },
+                JumpIfFalse {
+                    target: Label::new(2)
+                },
                 LoadConst {
                     value: Boolean { value: false }
                 },
-                JumpIfTrue { target: 1 },
+                JumpIfTrue {
+                    target: Label::new(1)
+                },
                 LoadConst {
                     value: Boolean { value: false }
                 },
-                JumpIfFalse { target: 0 },
+                JumpIfFalse {
+                    target: Label::new(0)
+                },
                 LoadConst {
                     value: Boolean { value: true }
                 },
-                JumpIfFalse { target: 0 },
+                JumpIfFalse {
+                    target: Label::new(0)
+                },
                 Pass,
                 LoadConst { value: None },
                 ReturnValue

--- a/compiler/src/output_stream.rs
+++ b/compiler/src/output_stream.rs
@@ -1,5 +1,4 @@
-use crate::compile::Label;
-use rustpython_bytecode::bytecode::{CodeObject, Instruction, Location};
+use rustpython_bytecode::bytecode::{CodeObject, Instruction, Label, Location};
 
 pub trait OutputStream: From<CodeObject> + Into<CodeObject> {
     /// Output an instruction

--- a/compiler/src/peephole.rs
+++ b/compiler/src/peephole.rs
@@ -1,7 +1,6 @@
-use crate::compile::Label;
 use crate::output_stream::OutputStream;
 use arrayvec::ArrayVec;
-use rustpython_bytecode::bytecode::{self, CodeObject, Instruction, Location};
+use rustpython_bytecode::bytecode::{self, CodeObject, Instruction, Label, Location};
 
 const PEEPHOLE_BUFFER_SIZE: usize = 20;
 
@@ -92,7 +91,7 @@ where
         self.push(instruction, loc.into());
         optimize(self);
     }
-    fn set_label(&mut self, label: crate::compile::Label) {
+    fn set_label(&mut self, label: Label) {
         if let Some(instr) = self.buffer.last_mut() {
             instr.1.labels.push(label)
         }


### PR DESCRIPTION
This helps to prevent accidentally using the `Label` type as a usize, as it was previously just a type alias and therefore could be used in any place a usize could, e.g. arithmetic operations. I actually caught a bug while I was making this change; the `fmt_dis` impls for `SetupExcept`, `SetupWith`, and `CleanupWith` printed the label value instead of the label target.