### PR TITLE
Use LinkedList in scope locals

### DIFF
--- a/vm/src/scope.rs
+++ b/vm/src/scope.rs
@@ -60,7 +60,7 @@ impl Scope {
     pub fn new_child_scope_with_locals(&self, locals: PyDictRef) -> Scope {
         let mut new_locals = Vec::with_capacity(self.locals.len() + 1);
         new_locals.push(locals);
-        new_locals.append(&mut self.locals.clone());
+        new_locals.extend_from_slice(&self.locals);
         Scope {
             locals: new_locals,
             globals: self.globals.clone(),

--- a/vm/src/scope.rs
+++ b/vm/src/scope.rs
@@ -114,8 +114,7 @@ impl NameProtocol for Scope {
 
     fn store_cell(&self, vm: &VirtualMachine, name: &str, value: PyObjectRef) {
         self.locals
-            .iter()
-            .nth(1)
+            .get(1)
             .expect("no outer scope for non-local")
             .set_item(name, value, vm)
             .unwrap();


### PR DESCRIPTION
I hoped this change will increase the speed a little by accessing the last element without iterating but
from checking the benchmarks this does not have an effect on the speed.
Before:
```
--------------------------------------------------------------------------------------------- benchmark: 4 tests ---------------------------------------------------------------------------------------------
Name (time in ms)                             Min                 Max                Mean             StdDev              Median                IQR            Outliers      OPS            Rounds  Iterations
--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
test_bench[nbody.py-cpython]              27.4479 (1.0)       29.5264 (1.0)       27.7710 (1.0)       0.3353 (1.0)       27.6960 (1.0)       0.2146 (1.0)           1;1  36.0088 (1.0)          36           1
test_bench[mandelbrot.py-cpython]         44.6213 (1.63)      49.8505 (1.69)      46.3056 (1.67)      1.1451 (3.42)      46.1056 (1.66)      1.5482 (7.22)          4;1  21.5957 (0.60)         22           1
test_bench[nbody.py-rustpython]          253.9762 (9.25)     275.2160 (9.32)     259.4745 (9.34)      8.9302 (26.64)    255.2859 (9.22)      7.7041 (35.91)         1;1   3.8539 (0.11)          5           1
test_bench[mandelbrot.py-rustpython]     775.8832 (28.27)    809.1849 (27.41)    786.2342 (28.31)    13.9292 (41.54)    779.6782 (28.15)    17.8695 (83.29)         1;0   1.2719 (0.04)          5           1
--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
```

After:
```
--------------------------------------------------------------------------------------------- benchmark: 4 tests --------------------------------------------------------------------------------------------
Name (time in ms)                             Min                 Max                Mean            StdDev              Median                IQR            Outliers      OPS            Rounds  Iterations
-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
test_bench[nbody.py-cpython]              27.5833 (1.0)       28.7476 (1.0)       27.8824 (1.0)      0.2265 (1.0)       27.8289 (1.0)       0.3121 (1.0)           8;1  35.8649 (1.0)          36           1
test_bench[mandelbrot.py-cpython]         44.8888 (1.63)      47.8632 (1.66)      46.2177 (1.66)     0.8791 (3.88)      45.9631 (1.65)      1.0685 (3.42)          7;0  21.6367 (0.60)         22           1
test_bench[nbody.py-rustpython]          254.4413 (9.22)     257.1632 (8.95)     255.8780 (9.18)     1.1675 (5.16)     256.1233 (9.20)      2.0518 (6.57)          2;0   3.9081 (0.11)          5           1
test_bench[mandelbrot.py-rustpython]     771.7654 (27.98)    795.8604 (27.68)    779.6076 (27.96)    9.8172 (43.35)    777.5865 (27.94)    12.3309 (39.51)         1;0   1.2827 (0.04)          5           1
-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
```