### PR TITLE
Delay from_list tuple create in import

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -317,7 +317,7 @@ fn run_rustpython(vm: &VirtualMachine, matches: &ArgMatches) -> PyResult<()> {
     vm.get_attribute(vm.sys_module.clone(), "modules")?
         .set_item("__main__", main_module, vm)?;
 
-    let site_result = vm.import("site", &vm.ctx.new_tuple(vec![]), 0);
+    let site_result = vm.import("site", &[], 0);
 
     if site_result.is_err() {
         warn!(
@@ -366,7 +366,7 @@ fn run_command(vm: &VirtualMachine, scope: Scope, source: String) -> PyResult<()
 
 fn run_module(vm: &VirtualMachine, module: &str) -> PyResult<()> {
     debug!("Running module {}", module);
-    let runpy = vm.import("runpy", &vm.ctx.new_tuple(vec![]), 0)?;
+    let runpy = vm.import("runpy", &[], 0)?;
     let run_module_as_main = vm.get_attribute(runpy, "_run_module_as_main")?;
     vm.invoke(&run_module_as_main, vec![vm.new_str(module.to_owned())])?;
     Ok(())

--- a/vm/src/frame.rs
+++ b/vm/src/frame.rs
@@ -539,11 +539,7 @@ impl Frame {
         level: usize,
     ) -> FrameResult {
         let module = module.clone().unwrap_or_default();
-        let from_list = symbols
-            .iter()
-            .map(|symbol| vm.ctx.new_str(symbol.to_string()))
-            .collect();
-        let module = vm.import(&module, &vm.ctx.new_tuple(from_list), level)?;
+        let module = vm.import(&module, symbols, level)?;
 
         self.push_value(module);
         Ok(None)

--- a/vm/src/import.rs
+++ b/vm/src/import.rs
@@ -26,8 +26,7 @@ pub fn init_importlib(vm: &VirtualMachine, external: bool) -> PyResult {
             vm.get_attribute(importlib.clone(), "_install_external_importers")?;
         vm.invoke(&install_external, vec![])?;
         // Set pyc magic number to commit hash. Should be changed when bytecode will be more stable.
-        let importlib_external =
-            vm.import("_frozen_importlib_external", &vm.ctx.new_tuple(vec![]), 0)?;
+        let importlib_external = vm.import("_frozen_importlib_external", &[], 0)?;
         let mut magic = get_git_revision().into_bytes();
         magic.truncate(4);
         if magic.len() != 4 {

--- a/vm/src/obj/objmodule.rs
+++ b/vm/src/obj/objmodule.rs
@@ -74,7 +74,7 @@ impl PyModuleRef {
     }
 
     fn repr(self, vm: &VirtualMachine) -> PyResult {
-        let importlib = vm.import("_frozen_importlib", &vm.ctx.new_tuple(vec![]), 0)?;
+        let importlib = vm.import("_frozen_importlib", &[], 0)?;
         let module_repr = vm.get_attribute(importlib, "_module_repr")?;
         vm.invoke(&module_repr, vec![self.into_object()])
     }

--- a/vm/src/stdlib/io.rs
+++ b/vm/src/stdlib/io.rs
@@ -648,7 +648,7 @@ pub fn io_open(vm: &VirtualMachine, args: PyFuncArgs) -> PyResult {
         }
     };
 
-    let io_module = vm.import("_io", &vm.ctx.new_tuple(vec![]), 0)?;
+    let io_module = vm.import("_io", &[], 0)?;
 
     // Construct a FileIO (subclass of RawIOBase)
     // This is subsequently consumed by a Buffered Class.


### PR DESCRIPTION
This change decreases the time when importing a module which is already in `sys.modules`. If you will run the following script:
```py
import time
start = time.time()
import io
mid = time.time()
import io
end = time.time()
print(mid - start)
print(end - mid)
```
Before the change you will get:
```
0.0029745101928710938
0.00000667572021484375
```
After the change:
```
0.002993345260620117
0.000006198883056640625
```

```
```