### PR TITLE
Add IntoPyBool

### DIFF
--- a/vm/src/builtins.rs
+++ b/vm/src/builtins.rs
@@ -10,7 +10,7 @@ use std::str;
 use num_bigint::Sign;
 use num_traits::{Signed, ToPrimitive, Zero};
 
-use crate::obj::objbool::{self, PyBoolLike};
+use crate::obj::objbool::{self, IntoPyBool};
 use crate::obj::objbytes::PyBytesRef;
 use crate::obj::objcode::PyCodeRef;
 use crate::obj::objdict::PyDictRef;
@@ -40,7 +40,7 @@ fn builtin_abs(x: PyObjectRef, vm: &VirtualMachine) -> PyResult {
     vm.invoke(&method, PyFuncArgs::new(vec![], vec![]))
 }
 
-fn builtin_all(iterable: PyIterable<PyBoolLike>, vm: &VirtualMachine) -> PyResult<bool> {
+fn builtin_all(iterable: PyIterable<IntoPyBool>, vm: &VirtualMachine) -> PyResult<bool> {
     for item in iterable.iter(vm)? {
         if !item?.to_bool() {
             return Ok(false);
@@ -49,7 +49,7 @@ fn builtin_all(iterable: PyIterable<PyBoolLike>, vm: &VirtualMachine) -> PyResul
     Ok(true)
 }
 
-fn builtin_any(iterable: PyIterable<PyBoolLike>, vm: &VirtualMachine) -> PyResult<bool> {
+fn builtin_any(iterable: PyIterable<IntoPyBool>, vm: &VirtualMachine) -> PyResult<bool> {
     for item in iterable.iter(vm)? {
         if item?.to_bool() {
             return Ok(true);
@@ -573,8 +573,8 @@ pub struct PrintOptions {
     sep: Option<PyStringRef>,
     #[pyarg(keyword_only, default = "None")]
     end: Option<PyStringRef>,
-    #[pyarg(keyword_only, default = "PyBoolLike::get_false()")]
-    flush: PyBoolLike,
+    #[pyarg(keyword_only, default = "IntoPyBool::get_false()")]
+    flush: IntoPyBool,
     #[pyarg(keyword_only, default = "None")]
     file: Option<PyObjectRef>,
 }

--- a/vm/src/builtins.rs
+++ b/vm/src/builtins.rs
@@ -10,7 +10,7 @@ use std::str;
 use num_bigint::Sign;
 use num_traits::{Signed, ToPrimitive, Zero};
 
-use crate::obj::objbool;
+use crate::obj::objbool::{self, PyBoolLike};
 use crate::obj::objbytes::PyBytesRef;
 use crate::obj::objcode::PyCodeRef;
 use crate::obj::objdict::PyDictRef;
@@ -40,18 +40,18 @@ fn builtin_abs(x: PyObjectRef, vm: &VirtualMachine) -> PyResult {
     vm.invoke(&method, PyFuncArgs::new(vec![], vec![]))
 }
 
-fn builtin_all(iterable: PyIterable<bool>, vm: &VirtualMachine) -> PyResult<bool> {
+fn builtin_all(iterable: PyIterable<PyBoolLike>, vm: &VirtualMachine) -> PyResult<bool> {
     for item in iterable.iter(vm)? {
-        if !item? {
+        if !item?.to_bool() {
             return Ok(false);
         }
     }
     Ok(true)
 }
 
-fn builtin_any(iterable: PyIterable<bool>, vm: &VirtualMachine) -> PyResult<bool> {
+fn builtin_any(iterable: PyIterable<PyBoolLike>, vm: &VirtualMachine) -> PyResult<bool> {
     for item in iterable.iter(vm)? {
-        if item? {
+        if item?.to_bool() {
             return Ok(true);
         }
     }

--- a/vm/src/builtins.rs
+++ b/vm/src/builtins.rs
@@ -573,8 +573,8 @@ pub struct PrintOptions {
     sep: Option<PyStringRef>,
     #[pyarg(keyword_only, default = "None")]
     end: Option<PyStringRef>,
-    #[pyarg(keyword_only, default = "false")]
-    flush: bool,
+    #[pyarg(keyword_only, default = "PyBoolLike::get_false()")]
+    flush: PyBoolLike,
     #[pyarg(keyword_only, default = "None")]
     file: Option<PyObjectRef>,
 }
@@ -654,7 +654,7 @@ pub fn builtin_print(objects: Args, options: PrintOptions, vm: &VirtualMachine) 
         .unwrap();
     printer.write(vm, end)?;
 
-    if options.flush {
+    if options.flush.to_bool() {
         printer.flush(vm)?;
     }
 

--- a/vm/src/builtins.rs
+++ b/vm/src/builtins.rs
@@ -573,7 +573,7 @@ pub struct PrintOptions {
     sep: Option<PyStringRef>,
     #[pyarg(keyword_only, default = "None")]
     end: Option<PyStringRef>,
-    #[pyarg(keyword_only, default = "IntoPyBool::get_false()")]
+    #[pyarg(keyword_only, default = "IntoPyBool::FALSE")]
     flush: IntoPyBool,
     #[pyarg(keyword_only, default = "None")]
     file: Option<PyObjectRef>,

--- a/vm/src/obj/objbool.rs
+++ b/vm/src/obj/objbool.rs
@@ -202,13 +202,8 @@ pub struct IntoPyBool {
 }
 
 impl IntoPyBool {
-    pub fn get_false() -> Self {
-        IntoPyBool { value: false }
-    }
-
-    pub fn get_true() -> Self {
-        IntoPyBool { value: true }
-    }
+    pub const TRUE: IntoPyBool = IntoPyBool { value: true };
+    pub const FALSE: IntoPyBool = IntoPyBool { value: false };
 
     pub fn to_bool(self) -> bool {
         self.value

--- a/vm/src/obj/objbool.rs
+++ b/vm/src/obj/objbool.rs
@@ -202,6 +202,14 @@ pub struct PyBoolLike {
 }
 
 impl PyBoolLike {
+    pub fn get_false() -> Self {
+        PyBoolLike { value: false }
+    }
+
+    pub fn get_true() -> Self {
+        PyBoolLike { value: true }
+    }
+
     pub fn to_bool(self) -> bool {
         self.value
     }

--- a/vm/src/obj/objbool.rs
+++ b/vm/src/obj/objbool.rs
@@ -21,8 +21,7 @@ impl TryFromObject for bool {
         if objtype::isinstance(&obj, &vm.ctx.int_type()) {
             Ok(get_value(&obj))
         } else {
-            let actual_type = vm.to_pystr(&obj.class())?;
-            Err(vm.new_type_error(format!("Expected type bool, not {}", actual_type,)))
+            Err(vm.new_type_error(format!("Expected type bool, not {}", obj.class().name)))
         }
     }
 }

--- a/vm/src/obj/objbool.rs
+++ b/vm/src/obj/objbool.rs
@@ -18,7 +18,12 @@ impl IntoPyObject for bool {
 
 impl TryFromObject for bool {
     fn try_from_object(vm: &VirtualMachine, obj: PyObjectRef) -> PyResult<bool> {
-        boolval(vm, obj)
+        if objtype::isinstance(&obj, &vm.ctx.int_type()) {
+            Ok(get_value(&obj))
+        } else {
+            let actual_type = vm.to_pystr(&obj.class())?;
+            Err(vm.new_type_error(format!("Expected type bool, not {}", actual_type,)))
+        }
     }
 }
 
@@ -95,15 +100,12 @@ pub fn get_value(obj: &PyObjectRef) -> bool {
     !obj.payload::<PyInt>().unwrap().as_bigint().is_zero()
 }
 
-fn bool_repr(vm: &VirtualMachine, args: PyFuncArgs) -> Result<PyObjectRef, PyObjectRef> {
-    arg_check!(vm, args, required = [(obj, Some(vm.ctx.bool_type()))]);
-    let v = get_value(obj);
-    let s = if v {
+fn bool_repr(obj: bool, _vm: &VirtualMachine) -> String {
+    if obj {
         "True".to_string()
     } else {
         "False".to_string()
-    };
-    Ok(vm.new_str(s))
+    }
 }
 
 fn bool_format(
@@ -130,14 +132,12 @@ fn do_bool_or(vm: &VirtualMachine, lhs: &PyObjectRef, rhs: &PyObjectRef) -> PyRe
     }
 }
 
-fn bool_or(vm: &VirtualMachine, args: PyFuncArgs) -> PyResult {
-    arg_check!(vm, args, required = [(lhs, None), (rhs, None)]);
-    do_bool_or(vm, lhs, rhs)
+fn bool_or(lhs: PyObjectRef, rhs: PyObjectRef, vm: &VirtualMachine) -> PyResult {
+    do_bool_or(vm, &lhs, &rhs)
 }
 
-fn bool_ror(vm: &VirtualMachine, args: PyFuncArgs) -> PyResult {
-    arg_check!(vm, args, required = [(rhs, None), (lhs, None)]);
-    do_bool_or(vm, lhs, rhs)
+fn bool_ror(lhs: PyObjectRef, rhs: PyObjectRef, vm: &VirtualMachine) -> PyResult {
+    do_bool_or(vm, &lhs, &rhs)
 }
 
 fn do_bool_and(vm: &VirtualMachine, lhs: &PyObjectRef, rhs: &PyObjectRef) -> PyResult {
@@ -152,14 +152,12 @@ fn do_bool_and(vm: &VirtualMachine, lhs: &PyObjectRef, rhs: &PyObjectRef) -> PyR
     }
 }
 
-fn bool_and(vm: &VirtualMachine, args: PyFuncArgs) -> PyResult {
-    arg_check!(vm, args, required = [(lhs, None), (rhs, None)]);
-    do_bool_and(vm, lhs, rhs)
+fn bool_and(lhs: PyObjectRef, rhs: PyObjectRef, vm: &VirtualMachine) -> PyResult {
+    do_bool_and(vm, &lhs, &rhs)
 }
 
-fn bool_rand(vm: &VirtualMachine, args: PyFuncArgs) -> PyResult {
-    arg_check!(vm, args, required = [(rhs, None), (lhs, None)]);
-    do_bool_and(vm, lhs, rhs)
+fn bool_rand(lhs: PyObjectRef, rhs: PyObjectRef, vm: &VirtualMachine) -> PyResult {
+    do_bool_and(vm, &lhs, &rhs)
 }
 
 fn do_bool_xor(vm: &VirtualMachine, lhs: &PyObjectRef, rhs: &PyObjectRef) -> PyResult {
@@ -174,14 +172,12 @@ fn do_bool_xor(vm: &VirtualMachine, lhs: &PyObjectRef, rhs: &PyObjectRef) -> PyR
     }
 }
 
-fn bool_xor(vm: &VirtualMachine, args: PyFuncArgs) -> PyResult {
-    arg_check!(vm, args, required = [(lhs, None), (rhs, None)]);
-    do_bool_xor(vm, lhs, rhs)
+fn bool_xor(lhs: PyObjectRef, rhs: PyObjectRef, vm: &VirtualMachine) -> PyResult {
+    do_bool_xor(vm, &lhs, &rhs)
 }
 
-fn bool_rxor(vm: &VirtualMachine, args: PyFuncArgs) -> PyResult {
-    arg_check!(vm, args, required = [(rhs, None), (lhs, None)]);
-    do_bool_xor(vm, lhs, rhs)
+fn bool_rxor(lhs: PyObjectRef, rhs: PyObjectRef, vm: &VirtualMachine) -> PyResult {
+    do_bool_xor(vm, &lhs, &rhs)
 }
 
 fn bool_new(vm: &VirtualMachine, args: PyFuncArgs) -> PyResult {
@@ -198,4 +194,23 @@ fn bool_new(vm: &VirtualMachine, args: PyFuncArgs) -> PyResult {
         }
         None => vm.context().new_bool(false),
     })
+}
+
+#[derive(Debug, Copy, Clone, PartialEq)]
+pub struct PyBoolLike {
+    value: bool,
+}
+
+impl PyBoolLike {
+    pub fn to_bool(self) -> bool {
+        self.value
+    }
+}
+
+impl TryFromObject for PyBoolLike {
+    fn try_from_object(vm: &VirtualMachine, obj: PyObjectRef) -> PyResult<Self> {
+        Ok(PyBoolLike {
+            value: boolval(vm, obj)?,
+        })
+    }
 }

--- a/vm/src/obj/objbool.rs
+++ b/vm/src/obj/objbool.rs
@@ -197,17 +197,17 @@ fn bool_new(vm: &VirtualMachine, args: PyFuncArgs) -> PyResult {
 }
 
 #[derive(Debug, Copy, Clone, PartialEq)]
-pub struct PyBoolLike {
+pub struct IntoPyBool {
     value: bool,
 }
 
-impl PyBoolLike {
+impl IntoPyBool {
     pub fn get_false() -> Self {
-        PyBoolLike { value: false }
+        IntoPyBool { value: false }
     }
 
     pub fn get_true() -> Self {
-        PyBoolLike { value: true }
+        IntoPyBool { value: true }
     }
 
     pub fn to_bool(self) -> bool {
@@ -215,9 +215,9 @@ impl PyBoolLike {
     }
 }
 
-impl TryFromObject for PyBoolLike {
+impl TryFromObject for IntoPyBool {
     fn try_from_object(vm: &VirtualMachine, obj: PyObjectRef) -> PyResult<Self> {
-        Ok(PyBoolLike {
+        Ok(IntoPyBool {
             value: boolval(vm, obj)?,
         })
     }


### PR DESCRIPTION
The purpose of the change is to differentiate between function that accept `Boolean` arguments (`True`, `False`) and function that accept "bool like" arguments that can be converted to bool by using `__bool__` or `__len__`. For example the builtin function `all` can get any "bool like" objects in its iterator for example `all([True,[1] ])` while doing `[1,2,3].sort(reverse=[1])` will result in a `TypeError`.

If anyone has a better suggestion then `PyBoolLike` for the struct name I would love that as I could not think of a better name...