### PR TITLE
Fix global declaration error in the function

### DIFF
--- a/compiler/src/symboltable.rs
+++ b/compiler/src/symboltable.rs
@@ -746,10 +746,15 @@ impl SymbolTableBuilder {
             // Role already set..
             match role {
                 SymbolUsage::Global => {
-                    return Err(SymbolTableError {
-                        error: format!("name '{}' is used prior to global declaration", name),
-                        location,
-                    })
+                    let symbol = table.symbols.get(name).unwrap();
+                    if let SymbolScope::Global = symbol.scope {
+                        // Ok
+                    } else {
+                        return Err(SymbolTableError {
+                            error: format!("name '{}' is used prior to global declaration", name),
+                            location,
+                        });
+                    }
                 }
                 SymbolUsage::Nonlocal => {
                     return Err(SymbolTableError {
@@ -806,6 +811,8 @@ impl SymbolTableBuilder {
             SymbolUsage::Global => {
                 if let SymbolScope::Unknown = symbol.scope {
                     symbol.scope = SymbolScope::Global;
+                } else if let SymbolScope::Global = symbol.scope {
+                    // Global scope can be set to global
                 } else {
                     return Err(SymbolTableError {
                         error: format!("Symbol {} scope cannot be set to global, since its scope was already determined otherwise.", name),

--- a/tests/snippets/global_nonlocal.py
+++ b/tests/snippets/global_nonlocal.py
@@ -27,6 +27,14 @@ def x():
 res = x()
 assert res == 3, str(res)
 
+def x():
+    global a
+    global a # a here shouldn't generate SyntaxError
+    a = 3
+
+x()
+assert a == 3
+
 # Invalid syntax:
 src = """
 b = 2
@@ -44,7 +52,6 @@ nonlocal c
 with assert_raises(SyntaxError):
     exec(src)
 
-
 # Invalid syntax:
 src = """
 def f():
@@ -60,6 +67,15 @@ with assert_raises(SyntaxError):
 src = """
 def a():
     nonlocal a
+"""
+
+with assert_raises(SyntaxError):
+    exec(src)
+
+src = """
+def f():
+    print(a)
+    global a
 """
 
 with assert_raises(SyntaxError):


### PR DESCRIPTION
Fix Global symbol to prevent syntax error
when global declaration for same variable in function.

Fixes #1353