### PR TITLE
Implement __init_subclass__

### DIFF
--- a/vm/src/function.rs
+++ b/vm/src/function.rs
@@ -290,6 +290,9 @@ impl<T> Args<T> {
     pub fn into_vec(self) -> Vec<T> {
         self.0
     }
+    pub fn new(args: Vec<T>) -> Self {
+        Self(args)
+    }
 }
 
 impl<T: PyValue> Args<PyRef<T>> {


### PR DESCRIPTION
This pull request implements a portion of the [PEP 487](https://www.python.org/dev/peps/pep-0487/) this pep also defines  `__set_name__` dunder method but it is not implemented in this pr.

`__init_subclass__` method allows a superclass to initialize al subclasses it takes the subclass and any number of arguments