### PR TITLE
nonlocal generate syntax error

### DIFF
--- a/compiler/src/symboltable.rs
+++ b/compiler/src/symboltable.rs
@@ -211,7 +211,8 @@ impl<'a> SymbolTableAnalyzer<'a> {
                 // symbol.table.borrow().parent.clone();
 
                 if let Some((symbols, _)) = parent_symbol_table {
-                    if !symbols.contains_key(&symbol.name) {
+                    let scope_depth = self.tables.len();
+                    if !symbols.contains_key(&symbol.name) || scope_depth < 2 {
                         return Err(SymbolTableError {
                             error: format!("no binding for nonlocal '{}' found", symbol.name),
                             location: Default::default(),

--- a/tests/snippets/global_nonlocal.py
+++ b/tests/snippets/global_nonlocal.py
@@ -56,6 +56,14 @@ c = 2
 with assertRaises(SyntaxError):
     exec(src)
 
+# Invalid syntax:
+src = """
+def a():
+    nonlocal a
+"""
+
+with assertRaises(SyntaxError):
+    exec(src)
 
 # class X:
 #     nonlocal c


### PR DESCRIPTION
If the scope depth is less than 2,
a syntax error occurs in nonlocal.