### PR TITLE
Return SyntaxError on Invalid Star Expression

### DIFF
--- a/compiler/src/compile.rs
+++ b/compiler/src/compile.rs
@@ -1616,10 +1616,12 @@ impl<O: OutputStream> Compiler<O> {
             Comprehension { kind, generators } => {
                 self.compile_comprehension(kind, generators)?;
             }
-            Starred { value } => {
-                self.compile_expression(value)?;
-                self.emit(Instruction::Unpack);
-                panic!("We should not just unpack a starred args, since the size is unknown.");
+            Starred { .. } => {
+                use std::string::String;
+                return Err(CompileError {
+                    error: CompileErrorType::SyntaxError(String::from("Invalid starred expression")),
+                    location: self.current_source_location.clone(),
+                });
             }
             IfExpression { test, body, orelse } => {
                 let no_label = self.new_label();


### PR DESCRIPTION
Hi, I was trying out the exciting RustPython and found out it panics on invalid star expressions such as:
```
a = (*1)
```

I simply replaced `panic!()` with returning a SyntaxError, since my observation was that valid starred expressions (used inside List/Tuple/Set displays, or used with function calls) are handled correctly (via the function [gather_elements()](https://github.com/RustPython/RustPython/blob/a65bb73a8033077201399904b87b18fa67aed8f8/compiler/src/compile.rs#L1731)), and `panic!()` is called only when compiling invalid starred expressions.

Please review, thanks!