### PR TITLE
Fix importlib path separators

### DIFF
--- a/vm/Lib/_bootstrap_external.py
+++ b/vm/Lib/_bootstrap_external.py
@@ -1575,22 +1575,21 @@ def _setup(_bootstrap_module):
         setattr(self_module, builtin_name, builtin_module)
 
     # Directly load the os module (needed during bootstrap).
-    os_details = ('_os', ['/']), ('_os', ['\\', '/'])  # XXX Changed to fit RustPython!!!
-    for builtin_os, path_separators in os_details:
-        # Assumption made in _path_join()
-        assert all(len(sep) == 1 for sep in path_separators)
-        path_sep = path_separators[0]
-        if builtin_os in sys.modules:
-            os_module = sys.modules[builtin_os]
-            break
-        else:
-            try:
-                os_module = _bootstrap._builtin_from_name(builtin_os)
-                break
-            except ImportError:
-                continue
+    # XXX Changed to fit RustPython!!!
+    builtin_os = "_os"
+    if builtin_os in sys.modules:
+        os_module = sys.modules[builtin_os]
     else:
-        raise ImportError('importlib requires posix or nt')
+        try:
+            os_module = _bootstrap._builtin_from_name(builtin_os)
+        except ImportError:
+            raise ImportError('importlib requires _os')
+    path_separators = ['\\', '/'] if os_module.name == 'nt' else ['/']
+    
+    # Assumption made in _path_join()
+    assert all(len(sep) == 1 for sep in path_separators)
+    path_sep = path_separators[0]
+
     setattr(self_module, '_os', os_module)
     setattr(self_module, 'path_sep', path_sep)
     setattr(self_module, 'path_separators', ''.join(path_separators))

--- a/vm/src/obj/objstr.rs
+++ b/vm/src/obj/objstr.rs
@@ -346,18 +346,10 @@ impl PyString {
     }
 
     #[pymethod]
-    fn split(
-        &self,
-        pattern: OptionalArg<PyStringRef>,
-        num: OptionalArg<isize>,
-        vm: &VirtualMachine,
-    ) -> PyObjectRef {
+    fn split(&self, args: SplitArgs, vm: &VirtualMachine) -> PyObjectRef {
         let value = &self.value;
-        let pattern = match pattern {
-            OptionalArg::Present(ref s) => Some(s.as_str()),
-            OptionalArg::Missing => None,
-        };
-        let num_splits = num.into_option().unwrap_or(-1);
+        let pattern = args.sep.as_ref().map(|s| s.as_str());
+        let num_splits = args.maxsplit;
         let elements: Vec<_> = match (pattern, num_splits.is_negative()) {
             (Some(pattern), true) => value
                 .split(pattern)
@@ -382,18 +374,10 @@ impl PyString {
     }
 
     #[pymethod]
-    fn rsplit(
-        &self,
-        pattern: OptionalArg<PyStringRef>,
-        num: OptionalArg<isize>,
-        vm: &VirtualMachine,
-    ) -> PyObjectRef {
+    fn rsplit(&self, args: SplitArgs, vm: &VirtualMachine) -> PyObjectRef {
         let value = &self.value;
-        let pattern = match pattern {
-            OptionalArg::Present(ref s) => Some(s.as_str()),
-            OptionalArg::Missing => None,
-        };
-        let num_splits = num.into_option().unwrap_or(-1);
+        let pattern = args.sep.as_ref().map(|s| s.as_str());
+        let num_splits = args.maxsplit;
         let mut elements: Vec<_> = match (pattern, num_splits.is_negative()) {
             (Some(pattern), true) => value
                 .rsplit(pattern)
@@ -1180,6 +1164,14 @@ impl IntoPyObject for &String {
     fn into_pyobject(self, vm: &VirtualMachine) -> PyResult {
         Ok(vm.ctx.new_str(self.clone()))
     }
+}
+
+#[derive(FromArgs)]
+struct SplitArgs {
+    #[pyarg(positional_or_keyword, default = "None")]
+    sep: Option<PyStringRef>,
+    #[pyarg(positional_or_keyword, default = "-1")]
+    maxsplit: isize,
 }
 
 pub fn init(ctx: &PyContext) {


### PR DESCRIPTION
This mainly affects the module type repr on Windows, it would do something like `<module x from 'C:\\...\\RustPython\\Lib/importlib/__init__.py'>`. This fixes that and corrects it to `<module x from 'C:\\...\\RustPython\\Lib\\importlib\\__init__.py'>`, along with in general being more accurate code to what the CPython version was doing in a CPython-accurate environment.