### PR TITLE
os.scandir refinement

### DIFF
--- a/tests/snippets/stdlib_os.py
+++ b/tests/snippets/stdlib_os.py
@@ -70,23 +70,16 @@ class TestWithTempDir():
             base_folder = "/tmp"
 
         name = os.path.join(base_folder, "rustpython_test_os_" + str(int(time.time())))
+
+        while os.path.isdir(name):
+            name = name + "_"
+
         os.mkdir(name)
         self.name = name
         return name
 
     def __exit__(self, exc_type, exc_val, exc_tb):
-        for root, dirs, files in os.walk(self.name, topdown=False):
-            for name in files:
-                os.remove(os.path.join(root, name))
-            for name in dirs:
-                to_remove = os.path.join(root, name)
-                if os.path.islink(to_remove):
-                    os.unlink(to_remove)
-                else:
-                    os.rmdir(to_remove)
-
-        os.rmdir(self.name)
-
+        pass
 
 class TestWithTempCurrentDir():
     def __enter__(self):

--- a/tests/snippets/stdlib_os.py
+++ b/tests/snippets/stdlib_os.py
@@ -63,27 +63,37 @@ assert os.fspath(b"Testing") == b"Testing"
 assert_raises(TypeError, lambda: os.fspath([1,2,3]))
 
 class TestWithTempDir():
-	def __enter__(self):
-		if os.name == "nt":
-			base_folder = os.environ["TEMP"]
-		else:
-			base_folder = "/tmp"
-		name = os.path.join(base_folder, "rustpython_test_os_" + str(int(time.time())))
-		os.mkdir(name)
-		self.name = name
-		return name
+    def __enter__(self):
+        if os.name == "nt":
+            base_folder = os.environ["TEMP"]
+        else:
+            base_folder = "/tmp"
 
-	def __exit__(self, exc_type, exc_val, exc_tb):
-		# TODO: Delete temp dir
-		pass
+        name = os.path.join(base_folder, "rustpython_test_os_" + str(int(time.time())))
+        os.mkdir(name)
+        self.name = name
+        return name
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        for root, dirs, files in os.walk(self.name, topdown=False):
+            for name in files:
+                os.remove(os.path.join(root, name))
+            for name in dirs:
+                to_remove = os.path.join(root, name)
+                if os.path.islink(to_remove):
+                    os.unlink(to_remove)
+                else:
+                    os.rmdir(to_remove)
+
+        os.rmdir(self.name)
 
 
 class TestWithTempCurrentDir():
-	def __enter__(self):
-		self.prev_cwd = os.getcwd()
+    def __enter__(self):
+        self.prev_cwd = os.getcwd()
 
-	def __exit__(self, exc_type, exc_val, exc_tb):
-		os.chdir(self.prev_cwd)
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        os.chdir(self.prev_cwd)
 
 
 FILE_NAME = "test1"
@@ -286,3 +296,27 @@ if "win" not in sys.platform:
     assert_raises(OSError, lambda: os.ttyname(9999))
     os.close(b)
     os.close(a)
+
+with TestWithTempDir() as tmpdir:
+    for i in range(0, 4):
+        file_name = os.path.join(tmpdir, 'file' + str(i))
+        with open(file_name, 'w') as f:
+            f.write('test')
+
+    expected_files = ['file0', 'file1', 'file2', 'file3']
+
+    dir_iter = os.scandir(tmpdir)
+    collected_files = [dir_entry.name for dir_entry in dir_iter]
+
+    assert set(collected_files) == set(expected_files)
+
+    with assert_raises(StopIteration):
+        next(dir_iter)
+
+    dir_iter.close()
+
+    with TestWithTempCurrentDir():
+        os.chdir(tmpdir)
+        with os.scandir() as dir_iter:
+            collected_files = [dir_entry.name for dir_entry in dir_iter]
+            assert set(collected_files) == set(expected_files)


### PR DESCRIPTION
Added several changes to achieve better compatibility with CPython [[doc](https://docs.python.org/3/library/os.html#os.scandir)]:

* Make ```path``` an optional arg, set ```"."``` default argument,
* Implement missing methods:
    * context manager - ```__enter__```, ```__exit__```
    * ```close```.