### PR TITLE
Fix Github language statistics to make this a Rust project again

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+Lib/* linguist-vendored


### PR DESCRIPTION
Right now, the language statistics for the repository say that it's ~75% Python, despite that being mostly the stdlib (which we didn't really write). This adds a git attribute to mark the `Lib` directory as ["vendored"](https://github.com/github/linguist#vendored-code), so it doesn't count towards the repository statistics.