### PR TITLE
Fix __repr__ return value for -0.0

### DIFF
--- a/tests/snippets/floats.py
+++ b/tests/snippets/floats.py
@@ -198,6 +198,7 @@ assert_raises(ValueError, float('nan').as_integer_ratio)
 
 assert str(1.0) == '1.0'
 assert str(0.0) == '0.0'
+assert str(-0.0) == '-0.0'
 assert str(1.123456789) == '1.123456789'
 
 # Test special case for lexer, float starts with a dot:

--- a/vm/src/obj/objfloat.rs
+++ b/vm/src/obj/objfloat.rs
@@ -411,7 +411,7 @@ impl PyFloat {
     #[pymethod(name = "__repr__")]
     fn repr(&self, vm: &VirtualMachine) -> String {
         if self.is_integer(vm) {
-            format!("{:.1}", self.value)
+            format!("{:.1?}", self.value)
         } else {
             self.value.to_string()
         }


### PR DESCRIPTION
Hi, I just noticed that the behavior of float.__repr __ is different between Python and RustPython. 

Python 3
```
>>> -0.0
-0.0
>>> float(-0.0)
-0.0
```

RustPython 
```
>>> -0.0
0.0
>>> float(-0.0)
0.0
```

On Python 3, __repr __ call on -0.0 returns -0.0, whereas on RustPython, it returns 0.0, without negative sign. I made a simple fix for that.