### PR TITLE
Enable Zero-padding with Format Strings

### DIFF
--- a/tests/snippets/builtin_format.py
+++ b/tests/snippets/builtin_format.py
@@ -12,3 +12,9 @@ class BadFormat:
     def __format__(self, spec):
         return 42
 assert_raises(TypeError, format, BadFormat())
+
+def test_zero_padding():
+    i = 1
+    assert f'{i:04d}' == '0001'
+
+test_zero_padding()

--- a/vm/src/obj/objstr.rs
+++ b/vm/src/obj/objstr.rs
@@ -1326,9 +1326,7 @@ fn try_update_quantity_from_tuple(
                         Ok(tuple_index)
                     }
                 }
-                None => {
-                    Err(vm.new_type_error("not enough arguments for format string".to_string()))
-                }
+                None => Err(vm.new_type_error("not enough arguments for format string".to_string())),
             }
         }
         _ => Ok(tuple_index),

--- a/vm/src/stdlib/ast.rs
+++ b/vm/src/stdlib/ast.rs
@@ -620,12 +620,8 @@ fn comprehension_to_ast(
 
 fn string_to_ast(vm: &VirtualMachine, string: &ast::StringGroup) -> PyResult<AstNodeRef> {
     let string = match string {
-        ast::StringGroup::Constant { value } => {
-            node!(vm, Str, { s => vm.ctx.new_str(value.clone()) })
-        }
-        ast::StringGroup::FormattedValue { value, .. } => {
-            node!(vm, FormattedValue, { value => expression_to_ast(vm, value)? })
-        }
+        ast::StringGroup::Constant { value } => node!(vm, Str, { s => vm.ctx.new_str(value.clone()) }),
+        ast::StringGroup::FormattedValue { value, .. } => node!(vm, FormattedValue, { value => expression_to_ast(vm, value)? }),
         ast::StringGroup::Joined { values } => {
             let py_values = map_ast(string_to_ast, vm, &values)?;
             node!(vm, JoinedStr, { values => py_values })

--- a/vm/src/stdlib/unicodedata.rs
+++ b/vm/src/stdlib/unicodedata.rs
@@ -54,9 +54,7 @@ fn name(
     } else {
         match default {
             OptionalArg::Present(obj) => Ok(obj),
-            OptionalArg::Missing => {
-                Err(vm.new_value_error("character name not found!".to_string()))
-            }
+            OptionalArg::Missing => Err(vm.new_value_error("character name not found!".to_string())),
         }
     }
 }

--- a/wasm/lib/src/browser_module.rs
+++ b/wasm/lib/src/browser_module.rs
@@ -137,7 +137,7 @@ fn browser_request_animation_frame(func: PyCallable, vm: &VirtualMachine) -> PyR
 
         let closure = f.borrow_mut().take();
         drop(closure);
-    }) as Box<Fn(f64)>));
+    }) as Box<dyn Fn(f64)>));
 
     let id = window()
         .request_animation_frame(&js_sys::Function::from(


### PR DESCRIPTION
Hi! This patch is an attempt to fix #1379 

References
* https://www.python.org/dev/peps/pep-3101/
* https://github.com/python/cpython/blob/v3.7.4/Python/formatter_unicode.c#L219-L225