### PR TITLE
Fix the ValueError for whitespace in float()

### DIFF
--- a/vm/src/obj/objfloat.rs
+++ b/vm/src/obj/objfloat.rs
@@ -323,7 +323,7 @@ impl PyFloat {
         } else if objtype::isinstance(&arg, &vm.ctx.int_type()) {
             objint::get_float_value(&arg, vm)?
         } else if objtype::isinstance(&arg, &vm.ctx.str_type()) {
-            match lexical::try_parse(objstr::get_value(&arg)) {
+            match lexical::try_parse(objstr::get_value(&arg).trim()) {
                 Ok(f) => f,
                 Err(_) => {
                     let arg_repr = vm.to_pystr(&arg)?;


### PR DESCRIPTION
Ignore whitespace

### Before
```
>>>>> float('   -12345\n')
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
ValueError: could not convert string to float: '   -12345
'
```
### After
```
>>>>> float('   -12345\n')
-12345.0
```

Fixed: #1391 