### PR TITLE
Fix int type casting error with negative base value

### DIFF
--- a/tests/snippets/ints.py
+++ b/tests/snippets/ints.py
@@ -167,6 +167,15 @@ with assert_raises(ValueError):
 with assert_raises(ValueError):
     int(' 1 ', base=37)
 
+with assert_raises(ValueError):
+    int(' 1 ', base=-1)
+
+with assert_raises(ValueError):
+    int(' 1 ', base=1000000000000000)
+
+with assert_raises(ValueError):
+    int(' 1 ', base=-1000000000000000)
+
 with assert_raises(TypeError):
     int(base=2)
 

--- a/vm/src/obj/objbyteinner.rs
+++ b/vm/src/obj/objbyteinner.rs
@@ -135,7 +135,7 @@ impl ByteInnerNewOptions {
 
                         let mut data_bytes = vec![];
                         for elem in elements.unwrap() {
-                            let v = objint::to_int(vm, &elem, 10)?;
+                            let v = objint::to_int(vm, &elem, &BigInt::from(10))?;
                             if let Some(i) = v.to_u8() {
                                 data_bytes.push(i);
                             } else {

--- a/vm/src/stdlib/pystruct.rs
+++ b/vm/src/stdlib/pystruct.rs
@@ -105,7 +105,7 @@ where
 }
 
 fn get_int(vm: &VirtualMachine, arg: &PyObjectRef) -> PyResult<BigInt> {
-    objint::to_int(vm, arg, 10)
+    objint::to_int(vm, arg, &BigInt::from(10))
 }
 
 fn pack_i8(vm: &VirtualMachine, arg: &PyObjectRef, data: &mut dyn Write) -> PyResult<()> {

--- a/wasm/lib/Cargo.toml
+++ b/wasm/lib/Cargo.toml
@@ -26,6 +26,7 @@ serde = "1.0"
 js-sys = "0.3"
 futures = "0.1"
 num-traits = "0.2"
+num-bigint = { version = "0.2.3", features = ["serde"] }
 
 [dependencies.web-sys]
 version = "0.3"

--- a/wasm/lib/src/convert.rs
+++ b/wasm/lib/src/convert.rs
@@ -9,6 +9,8 @@ use rustpython_vm::py_serde;
 use rustpython_vm::pyobject::{ItemProtocol, PyObjectRef, PyResult, PyValue};
 use rustpython_vm::VirtualMachine;
 
+use num_bigint::BigInt;
+
 use crate::browser_module;
 use crate::vm_class::{stored_vm_from_wasm, WASMVirtualMachine};
 
@@ -43,7 +45,7 @@ pub fn py_err_to_js_err(vm: &VirtualMachine, py_err: &PyObjectRef) -> JsValue {
                 if objtype::isinstance(&top, &vm.ctx.tuple_type()) {
                     let element = objsequence::get_elements_tuple(&top);
 
-                    if let Some(lineno) = objint::to_int(vm, &element[1], 10)
+                    if let Some(lineno) = objint::to_int(vm, &element[1], &BigInt::from(10))
                         .ok()
                         .and_then(|lineno| lineno.to_u32())
                     {


### PR DESCRIPTION
Change base type from u32 to i32

After result
```
>>>>> print(int(' 1 ', base=-1))
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
ValueError: int() base must be >= 2 and <= 36, or 0

```

Fixed: #1405