### PR TITLE
Change sys.implementation.name to only has lowercase

### DIFF
--- a/vm/src/sysmodule.rs
+++ b/vm/src/sysmodule.rs
@@ -200,7 +200,7 @@ pub fn make_module(vm: &VirtualMachine, module: PyObjectRef, builtins: PyObjectR
 
     // TODO Add crate version to this namespace
     let implementation = py_namespace!(vm, {
-        "name" => ctx.new_str("RustPython".to_string()),
+        "name" => ctx.new_str("rustpython".to_string()),
         "cache_tag" => ctx.new_str("rustpython-01".to_string()),
     });
 


### PR DESCRIPTION
Check https://docs.python.org/3/library/sys.html#sys.implementation

> name is the implementation’s identifier, e.g. 'cpython'. The actual string is defined by the Python implementation, but it is guaranteed to be lower case.

