### PR TITLE
Fix range slicing behavior

### DIFF
--- a/tests/snippets/builtin_range.py
+++ b/tests/snippets/builtin_range.py
@@ -35,6 +35,12 @@ assert range(10, 100, 3)[4:1000:5] == range(22, 100, 15)
 assert range(10)[:] == range(10)
 assert range(10, 0, -2)[0:5:2] == range(10, 0, -4)
 assert range(10)[10:11] == range(10,10)
+assert range(0, 10, -1)[::-1] == range(1, 1)
+assert range(0, 10)[::-1] == range(9, -1, -1)
+assert range(0, -10)[::-1] == range(-1, -1, -1)
+assert range(0, -10)[::-1][::-1] == range(0, 0)
+assert_raises(ValueError, lambda: range(0, 10)[::0], _msg='slice step cannot be zero')
+assert_raises(TypeError, lambda: range(0, 10)['a':], _msg='slice indices must be integers or None or have an __index__ method')
 
 # count tests
 assert range(10).count(2) == 1

--- a/vm/src/builtins.rs
+++ b/vm/src/builtins.rs
@@ -380,11 +380,8 @@ fn builtin_max(vm: &VirtualMachine, args: PyFuncArgs) -> PyResult {
 
     if candidates.is_empty() {
         let default = args.get_optional_kwarg("default");
-        if default.is_none() {
-            return Err(vm.new_value_error("max() arg is an empty sequence".to_string()));
-        } else {
-            return Ok(default.unwrap());
-        }
+        return default
+            .ok_or_else(|| vm.new_value_error("max() arg is an empty sequence".to_string()));
     }
 
     let key_func = args.get_optional_kwarg("key");
@@ -429,11 +426,8 @@ fn builtin_min(vm: &VirtualMachine, args: PyFuncArgs) -> PyResult {
 
     if candidates.is_empty() {
         let default = args.get_optional_kwarg("default");
-        if default.is_none() {
-            return Err(vm.new_value_error("min() arg is an empty sequence".to_string()));
-        } else {
-            return Ok(default.unwrap());
-        }
+        return default
+            .ok_or_else(|| vm.new_value_error("min() arg is an empty sequence".to_string()));
     }
 
     let key_func = args.get_optional_kwarg("key");

--- a/vm/src/obj/objbytes.rs
+++ b/vm/src/obj/objbytes.rs
@@ -509,7 +509,7 @@ impl PyBytesRef {
                                     }
                                 }
                                 None => {
-                                    if replacing_char.is_none() {
+                                    if replacing_char.is_some() {
                                         decode_content.push(replacing_char.unwrap())
                                     }
                                 }

--- a/vm/src/obj/objrange.rs
+++ b/vm/src/obj/objrange.rs
@@ -363,7 +363,7 @@ impl PyRange {
                 };
 
                 let new_step = if let Some(int) = slice.step_index(vm)? {
-                    if step.is_zero() {
+                    if int.is_zero() {
                         return Err(vm.new_value_error("slice step cannot be zero".to_string()));
                     } else {
                         PyInt::new(int * self.step.as_bigint()).into_ref(vm)

--- a/vm/src/obj/objrange.rs
+++ b/vm/src/obj/objrange.rs
@@ -354,19 +354,15 @@ impl PyRange {
                         } else {
                             tmp.clone()
                         }
-                    } else {
-                        if slice_start > upper_bound {
-                            upper_bound.clone()
-                        } else {
-                            slice_start.clone()
-                        }
-                    }
-                } else {
-                    if negative_step {
+                    } else if slice_start > upper_bound {
                         upper_bound.clone()
                     } else {
-                        lower_bound.clone()
+                        slice_start.clone()
                     }
+                } else if negative_step {
+                    upper_bound.clone()
+                } else {
+                    lower_bound.clone()
                 };
 
                 let substop = if let Some(slice_stop) = slice.stop_index(vm)? {
@@ -377,19 +373,15 @@ impl PyRange {
                         } else {
                             tmp.clone()
                         }
-                    } else {
-                        if slice_stop > upper_bound {
-                            upper_bound.clone()
-                        } else {
-                            slice_stop.clone()
-                        }
-                    }
-                } else {
-                    if negative_step {
-                        lower_bound.clone()
-                    } else {
+                    } else if slice_stop > upper_bound {
                         upper_bound.clone()
+                    } else {
+                        slice_stop.clone()
                     }
+                } else if negative_step {
+                    lower_bound.clone()
+                } else {
+                    upper_bound.clone()
                 };
 
                 let step = range_step * &substep;

--- a/vm/src/obj/objrange.rs
+++ b/vm/src/obj/objrange.rs
@@ -335,8 +335,16 @@ impl PyRange {
                 };
 
                 let negative_step = substep.is_negative();
-                let lower_bound = if negative_step { -BigInt::one() } else { BigInt::zero() };
-                let upper_bound = if negative_step { &lower_bound + range_length } else { range_length.clone() };
+                let lower_bound = if negative_step {
+                    -BigInt::one()
+                } else {
+                    BigInt::zero()
+                };
+                let upper_bound = if negative_step {
+                    &lower_bound + range_length
+                } else {
+                    range_length.clone()
+                };
 
                 let substart = if let Some(slice_start) = slice.start_index(vm)? {
                     if slice_start.is_negative() {
@@ -354,7 +362,11 @@ impl PyRange {
                         }
                     }
                 } else {
-                    if negative_step { upper_bound.clone() } else { lower_bound.clone() }
+                    if negative_step {
+                        upper_bound.clone()
+                    } else {
+                        lower_bound.clone()
+                    }
                 };
 
                 let substop = if let Some(slice_stop) = slice.stop_index(vm)? {
@@ -373,7 +385,11 @@ impl PyRange {
                         }
                     }
                 } else {
-                    if negative_step { lower_bound.clone() } else { upper_bound.clone() }
+                    if negative_step {
+                        lower_bound.clone()
+                    } else {
+                        upper_bound.clone()
+                    }
                 };
 
                 let step = range_step * &substep;
@@ -388,12 +404,10 @@ impl PyRange {
                 .into_ref(vm)
                 .into_object())
             }
-            RangeIndex::Int(index) => {
-                match self.get(index.as_bigint()) {
-                    Some(value) => Ok(PyInt::new(value).into_ref(vm).into_object()),
-                    None => Err(vm.new_index_error("range object index out of range".to_string()))
-                }
-            }
+            RangeIndex::Int(index) => match self.get(index.as_bigint()) {
+                Some(value) => Ok(PyInt::new(value).into_ref(vm).into_object()),
+                None => Err(vm.new_index_error("range object index out of range".to_string())),
+            },
         }
     }
 

--- a/vm/src/obj/objrange.rs
+++ b/vm/src/obj/objrange.rs
@@ -381,10 +381,9 @@ impl PyRange {
                 .into_object())
             }
             RangeIndex::Int(index) => {
-                if let Some(value) = self.get(index.as_bigint()) {
-                    Ok(PyInt::new(value).into_ref(vm).into_object())
-                } else {
-                    Err(vm.new_index_error("range object index out of range".to_string()))
+                match self.get(index.as_bigint()) {
+                    Some(value) => Ok(PyInt::new(value).into_ref(vm).into_object()),
+                    None => Err(vm.new_index_error("range object index out of range".to_string()))
                 }
             }
         }

--- a/vm/src/obj/objrange.rs
+++ b/vm/src/obj/objrange.rs
@@ -82,15 +82,15 @@ impl PyRange {
             return None;
         }
 
-        let length = if start < stop {
+        let length: BigInt = if start < stop {
             (stop - start - 1) / step + 1
         } else {
             (start - stop - 1) / (-step) + 1
         };
 
-        let index = if index < BigInt::zero() {
-            let new_index = &length + &index;
-            if new_index < BigInt::zero() {
+        let index = if index.is_negative() {
+            let new_index: BigInt = &length + &index;
+            if new_index.is_negative() {
                 return None;
             }
             length + index

--- a/vm/src/obj/objsequence.rs
+++ b/vm/src/obj/objsequence.rs
@@ -465,7 +465,7 @@ pub fn get_mut_elements<'a>(obj: &'a PyObjectRef) -> impl DerefMut<Target = Vec<
     panic!("Cannot extract elements from non-sequence");
 }
 
-//Check if given arg could be used with PySciceableSequance.get_slice_range()
+//Check if given arg could be used with PySliceableSequence.get_slice_range()
 pub fn is_valid_slice_arg(
     arg: OptionalArg<PyObjectRef>,
     vm: &VirtualMachine,


### PR DESCRIPTION
* Adds several new tests to ```tests/snippets/builtin_range.py```
* Fixes 2 bugs in range slicing behavior
* Does some refactoring

This implementation is basically [0] and [1] combined and translated to Rust.  There might be a better way to do it, but I went with just copying the CPython algorithm for the time being, since the way negative steps are handled with slices is counter-intuitive and really tricky.

[0]  https://github.com/python/cpython/blob/530f506ac91338b55cf2be71b1cdf50cb077512f/Objects/rangeobject.c#L297-L334

[1] https://github.com/python/cpython/blob/bed4817d52d7b5a383b1b61269c1337b61acc493/Objects/sliceobject.c#L368-L511

See: https://github.com/RustPython/RustPython/issues/1373