### PR TITLE
Fix exit()

### DIFF
--- a/tests/snippets/exit.py
+++ b/tests/snippets/exit.py
@@ -1,0 +1,4 @@
+from testutils import assert_raises
+
+with assert_raises(SystemExit):
+    exit()

--- a/vm/src/builtins.rs
+++ b/vm/src/builtins.rs
@@ -889,6 +889,7 @@ pub fn make_module(vm: &VirtualMachine, module: PyObjectRef) {
         "UserWarning" => ctx.exceptions.user_warning.clone(),
 
         "KeyboardInterrupt" => ctx.exceptions.keyboard_interrupt.clone(),
+        "SystemExit" => ctx.exceptions.system_exit.clone(),
     });
 }
 

--- a/vm/src/exceptions.rs
+++ b/vm/src/exceptions.rs
@@ -252,6 +252,7 @@ pub struct ExceptionZoo {
     pub user_warning: PyClassRef,
 
     pub keyboard_interrupt: PyClassRef,
+    pub system_exit: PyClassRef,
 }
 
 impl ExceptionZoo {
@@ -303,6 +304,7 @@ impl ExceptionZoo {
         let user_warning = create_type("UserWarning", &type_type, &warning);
 
         let keyboard_interrupt = create_type("KeyboardInterrupt", &type_type, &base_exception_type);
+        let system_exit = create_type("SystemExit", &type_type, &base_exception_type);
 
         ExceptionZoo {
             arithmetic_error,
@@ -347,6 +349,7 @@ impl ExceptionZoo {
             reference_error,
             user_warning,
             keyboard_interrupt,
+            system_exit,
         }
     }
 }


### PR DESCRIPTION
After #1343, RustPython could not provide builtin exit() properly.