### PR TITLE
Allow float() to be called without an argument

### DIFF
--- a/tests/snippets/floats.py
+++ b/tests/snippets/floats.py
@@ -86,6 +86,8 @@ assert math.isinf(float('Inf'))
 assert math.isinf(float('+Inf'))
 assert math.isinf(float('-Inf'))
 
+assert float() == 0
+
 assert float('+Inf') > 0
 assert float('-Inf') < 0
 


### PR DESCRIPTION
Copy the same pattern used by int()

closes #1421