### PR TITLE
Add .cache/ to tests/.gitignore

### DIFF
--- a/tests/.gitignore
+++ b/tests/.gitignore
@@ -1,1 +1,2 @@
 snippets/whats_left_*.py
+.cache/


### PR DESCRIPTION
When execute `pytest` local, sometimes generate .cache folder to tests folder.
Add .cache/ to tests/.gitignore prevent wrong commit.