### PR TITLE
fix error message for __call__ for non-callable objects

### DIFF
--- a/vm/src/vm.rs
+++ b/vm/src/vm.rs
@@ -603,15 +603,13 @@ impl VirtualMachine {
             self.invoke(&function, args.insert(object.clone()))
         } else if let Some(PyBuiltinFunction { ref value }) = func_ref.payload() {
             value(self, args)
+        } else if self.is_callable(&func_ref) {
+            self.call_method(&func_ref, "__call__", args)
         } else {
-            if self.is_callable(&func_ref) {
-                self.call_method(&func_ref, "__call__", args)
-            } else {
-                Err(self.new_type_error(format!(
-                    "'{}' object is not callable",
-                    func_ref.class().name
-                )))
-            }
+            Err(self.new_type_error(format!(
+                "'{}' object is not callable",
+                func_ref.class().name
+            )))
         }
     }
 

--- a/vm/src/vm.rs
+++ b/vm/src/vm.rs
@@ -604,9 +604,14 @@ impl VirtualMachine {
         } else if let Some(PyBuiltinFunction { ref value }) = func_ref.payload() {
             value(self, args)
         } else {
-            // TODO: is it safe to just invoke __call__ otherwise?
-            vm_trace!("invoke __call__ for: {:?}", &func_ref.payload);
-            self.call_method(&func_ref, "__call__", args)
+            if self.is_callable(&func_ref) {
+                self.call_method(&func_ref, "__call__", args)
+            } else {
+                Err(self.new_type_error(format!(
+                    "'{}' object is not callable",
+                    func_ref.class().name
+                )))
+            }
         }
     }
 


### PR DESCRIPTION
closes #1416.

Changed only `vm.rs` file, and the other files were just auto-formatted with `cargo fmt`