### PR TITLE
Change sys.version* attributes to return the Python version

### DIFF
--- a/derive/src/pyclass.rs
+++ b/derive/src/pyclass.rs
@@ -454,7 +454,7 @@ pub fn impl_pystruct_sequence(attr: AttributeArgs, item: Item) -> Result<TokenSt
         #struc
         #class_def
         impl #ty {
-            fn into_struct_sequence(&self,
+            pub fn into_struct_sequence(&self,
                 vm: &::rustpython_vm::vm::VirtualMachine,
                 cls: ::rustpython_vm::obj::objtype::PyClassRef,
             ) -> ::rustpython_vm::pyobject::PyResult<::rustpython_vm::obj::objtuple::PyTupleRef> {

--- a/vm/src/sysmodule.rs
+++ b/vm/src/sysmodule.rs
@@ -177,16 +177,6 @@ fn sys_exit(code: OptionalArg<i32>, _vm: &VirtualMachine) -> PyResult<()> {
     std::process::exit(code)
 }
 
-#[pystruct_sequence(name = "version_info")]
-#[derive(Default, Debug)]
-struct VersionInfo {
-    major: usize,
-    minor: usize,
-    micro: usize,
-    releaselevel: String,
-    serial: usize,
-}
-
 pub fn make_module(vm: &VirtualMachine, module: PyObjectRef, builtins: PyObjectRef) {
     let ctx = &vm.ctx;
 
@@ -195,16 +185,10 @@ pub fn make_module(vm: &VirtualMachine, module: PyObjectRef, builtins: PyObjectR
         .into_struct_sequence(vm, flags_type)
         .unwrap();
 
-    let version_info_type = VersionInfo::make_class(ctx);
-    let version_info = VersionInfo {
-        major: env!("CARGO_PKG_VERSION_MAJOR").parse().unwrap(),
-        minor: env!("CARGO_PKG_VERSION_MINOR").parse().unwrap(),
-        micro: env!("CARGO_PKG_VERSION_PATCH").parse().unwrap(),
-        releaselevel: "alpha".to_owned(),
-        serial: 0,
-    }
-    .into_struct_sequence(vm, version_info_type)
-    .unwrap();
+    let version_info_type = version::VersionInfo::make_class(ctx);
+    let version_info = version::get_version_info()
+        .into_struct_sequence(vm, version_info_type)
+        .unwrap();
 
     // TODO Add crate version to this namespace
     let implementation = py_namespace!(vm, {

--- a/vm/src/version.rs
+++ b/vm/src/version.rs
@@ -1,6 +1,22 @@
 /* Several function to retrieve version information.
  */
 
+const MAJOR: usize = 3;
+const MINOR: usize = 5;
+const MICRO: usize = 0;
+const RELEASELEVEL: &str = "alpha";
+const SERIAL: usize = 0;
+
+#[pystruct_sequence(name = "version_info")]
+#[derive(Default, Debug)]
+pub struct VersionInfo {
+    major: usize,
+    minor: usize,
+    micro: usize,
+    releaselevel: &'static str,
+    serial: usize,
+}
+
 pub fn get_version() -> String {
     format!(
         "{} {:?} {}",
@@ -10,14 +26,18 @@ pub fn get_version() -> String {
     )
 }
 
+pub fn get_version_info() -> VersionInfo {
+    VersionInfo {
+        major: MAJOR,
+        minor: MINOR,
+        micro: MICRO,
+        releaselevel: RELEASELEVEL,
+        serial: SERIAL,
+    }
+}
+
 pub fn get_version_number() -> String {
-    format!(
-        "{}.{}.{}{}",
-        env!("CARGO_PKG_VERSION_MAJOR"),
-        env!("CARGO_PKG_VERSION_MINOR"),
-        env!("CARGO_PKG_VERSION_PATCH"),
-        option_env!("CARGO_PKG_VERSION_PRE").unwrap_or("")
-    )
+    format!("{}.{}.{}{}", MAJOR, MINOR, MICRO, RELEASELEVEL)
 }
 
 pub fn get_compiler() -> String {


### PR DESCRIPTION
Return the version of Python that we attempt to be compatible with, not
the version numbers of the RustPython interpreter itself.

closes #1396