### PR TITLE
Optimize BuildMap bytecode emission

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1114,6 +1114,7 @@ version = "0.1.1"
 dependencies = [
  "arrayvec 0.4.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "indexmap 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "itertools 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "num-complex 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "rustpython-bytecode 0.1.1",

--- a/compiler/Cargo.toml
+++ b/compiler/Cargo.toml
@@ -9,6 +9,7 @@ edition = "2018"
 
 [dependencies]
 indexmap = "1.0"
+itertools = "0.8.0"
 rustpython-bytecode = { path = "../bytecode", version = "0.1.1" }
 rustpython-parser = { path = "../parser", version = "0.1.1" }
 num-complex = { version = "0.2", features = ["serde"] }


### PR DESCRIPTION
For codes like `f(a=1, b=2, **c)`, emit less BuildMap bytecodes.

Before: LoadConst a, LoadConst 1, BuildMap 1, LoadConst b, LoadConst 2, BuildMap 1, LoadName c, BuildMapUnpack 3

After: LoadConst a, LoadConst 1, LoadConst b, LoadConst 2, BuildMap 2, LoadName c, BuildMapUnpack 2