### PR TITLE
Add the _sre module

### DIFF
--- a/Lib/_sre.py
+++ b/Lib/_sre.py
@@ -1,0 +1,1284 @@
+# NOT_RPYTHON
+"""
+A pure Python reimplementation of the _sre module from CPython 2.4
+Copyright 2005 Nik Haldimann, licensed under the MIT license
+
+This code is based on material licensed under CNRI's Python 1.6 license and
+copyrighted by: Copyright (c) 1997-2001 by Secret Labs AB
+"""
+
+import array, operator, sys
+from sre_constants import ATCODES, OPCODES, CHCODES, MAXREPEAT
+from sre_constants import SRE_INFO_PREFIX, SRE_INFO_LITERAL
+from sre_constants import SRE_FLAG_UNICODE, SRE_FLAG_LOCALE
+
+
+import sys
+
+# Identifying as _sre from Python 2.3 or 2.4
+MAGIC = 20031017
+
+# In _sre.c this is bytesize of the code word type of the C implementation.
+# There it's 2 for normal Python builds and more for wide unicode builds (large
+# enough to hold a 32-bit UCS-4 encoded character). Since here in pure Python
+# we only see re bytecodes as Python longs, we shouldn't have to care about the
+# codesize. But sre_compile will compile some stuff differently depending on the
+# codesize (e.g., charsets).
+if sys.maxunicode == 65535:
+    CODESIZE = 2
+else:
+    CODESIZE = 4
+
+copyright = "_sre.py 2.4c Copyright 2005 by Nik Haldimann"
+
+
+def getcodesize():
+    return CODESIZE
+
+
+def compile(pattern, flags, code, groups=0, groupindex={}, indexgroup=[None]):
+    """Compiles (or rather just converts) a pattern descriptor to a SRE_Pattern
+    object. Actual compilation to opcodes happens in sre_compile."""
+    return SRE_Pattern(pattern, flags, code, groups, groupindex, indexgroup)
+
+def getlower(char_ord, flags):
+    if (char_ord < 128) or (flags & SRE_FLAG_UNICODE) \
+                              or (flags & SRE_FLAG_LOCALE and char_ord < 256):
+        return ord(chr(char_ord).lower())
+    else:
+        return char_ord
+
+
+class SRE_Pattern(object):
+
+    def __init__(self, pattern, flags, code, groups=0, groupindex={}, indexgroup=[None]):
+        self.pattern = pattern
+        self.flags = flags
+        self.groups = groups
+        self.groupindex = groupindex # Maps group names to group indices
+        self._indexgroup = indexgroup # Maps indices to group names
+        self._code = code
+
+    def match(self, string, pos=0, endpos=sys.maxsize):
+        """If zero or more characters at the beginning of string match this
+        regular expression, return a corresponding MatchObject instance. Return
+        None if the string does not match the pattern."""
+        state = _State(string, pos, endpos, self.flags)
+        if state.match(self._code):
+            return SRE_Match(self, state)
+        else:
+            return None
+
+    def search(self, string, pos=0, endpos=sys.maxsize):
+        """Scan through string looking for a location where this regular
+        expression produces a match, and return a corresponding MatchObject
+        instance. Return None if no position in the string matches the
+        pattern."""
+        state = _State(string, pos, endpos, self.flags)
+        if state.search(self._code):
+            return SRE_Match(self, state)
+        else:
+            return None
+
+    def findall(self, string, pos=0, endpos=sys.maxsize):
+        """Return a list of all non-overlapping matches of pattern in string."""
+        matchlist = []
+        state = _State(string, pos, endpos, self.flags)
+        while state.start <= state.end:
+            state.reset()
+            state.string_position = state.start
+            if not state.search(self._code):
+                break
+            match = SRE_Match(self, state)
+            if self.groups == 0 or self.groups == 1:
+                item = match.group(self.groups)
+            else:
+                item = match.groups("")
+            matchlist.append(item)
+            if state.string_position == state.start:
+                state.start += 1
+            else:
+                state.start = state.string_position
+        return matchlist
+
+    def _subx(self, template, string, count=0, subn=False):
+        filter = template
+        if not callable(template) and "\\" in template:
+            # handle non-literal strings ; hand it over to the template compiler
+            import re
+            filter = re._subx(self, template)
+        state = _State(string, 0, sys.maxsize, self.flags)
+        sublist = []
+
+        n = last_pos = 0
+        while not count or n < count:
+            state.reset()
+            state.string_position = state.start
+            if not state.search(self._code):
+                break
+            if last_pos < state.start:
+                sublist.append(string[last_pos:state.start])
+            if not (last_pos == state.start and
+                                last_pos == state.string_position and n > 0):
+                # the above ignores empty matches on latest position
+                if callable(filter):
+                    sublist.append(list(filter(SRE_Match(self, state))))
+                else:
+                    sublist.append(filter)
+                last_pos = state.string_position
+                n += 1
+            if state.string_position == state.start:
+                state.start += 1
+            else:
+                state.start = state.string_position
+
+        if last_pos < state.end:
+            sublist.append(string[last_pos:state.end])
+        item = "".join(sublist)
+        if subn:
+            return item, n
+        else:
+            return item
+
+    def sub(self, repl, string, count=0):
+        """Return the string obtained by replacing the leftmost non-overlapping
+        occurrences of pattern in string by the replacement repl."""
+        return self._subx(repl, string, count, False)
+
+    def subn(self, repl, string, count=0):
+        """Return the tuple (new_string, number_of_subs_made) found by replacing
+        the leftmost non-overlapping occurrences of pattern with the replacement
+        repl."""
+        return self._subx(repl, string, count, True)
+
+    def split(self, string, maxsplit=0):
+        """Split string by the occurrences of pattern."""
+        splitlist = []
+        state = _State(string, 0, sys.maxsize, self.flags)
+        n = 0
+        last = state.start
+        while not maxsplit or n < maxsplit:
+            state.reset()
+            state.string_position = state.start
+            if not state.search(self._code):
+                break
+            if state.start == state.string_position: # zero-width match
+                if last == state.end:                # or end of string
+                    break
+                state.start += 1
+                continue
+            splitlist.append(string[last:state.start])
+            # add groups (if any)
+            if self.groups:
+                match = SRE_Match(self, state)
+                splitlist.extend(list(match.groups(None)))
+            n += 1
+            last = state.start = state.string_position
+        splitlist.append(string[last:state.end])
+        return splitlist
+
+    def finditer(self, string, pos=0, endpos=sys.maxsize):
+        """Return a list of all non-overlapping matches of pattern in string."""
+        scanner = self.scanner(string, pos, endpos)
+        return iter(scanner.search, None)
+
+    def scanner(self, string, start=0, end=sys.maxsize):
+        return SRE_Scanner(self, string, start, end)
+
+    def __copy__(self):
+        raise TypeError("cannot copy this pattern object")
+
+    def __deepcopy__(self):
+        raise TypeError("cannot copy this pattern object")
+
+
+class SRE_Scanner(object):
+    """Undocumented scanner interface of sre."""
+
+    def __init__(self, pattern, string, start, end):
+        self.pattern = pattern
+        self._state = _State(string, start, end, self.pattern.flags)
+
+    def _match_search(self, matcher):
+        state = self._state
+        state.reset()
+        state.string_position = state.start
+        match = None
+        if matcher(self.pattern._code):
+            match = SRE_Match(self.pattern, state)
+        if match is None or state.string_position == state.start:
+            state.start += 1
+        else:
+            state.start = state.string_position
+        return match
+
+    def match(self):
+        return self._match_search(self._state.match)
+
+    def search(self):
+        return self._match_search(self._state.search)
+
+
+class SRE_Match(object):
+
+    def __init__(self, pattern, state):
+        self.re = pattern
+        self.string = state.string
+        self.pos = state.pos
+        self.endpos = state.end
+        self.lastindex = state.lastindex
+        self.regs = self._create_regs(state)
+        if pattern._indexgroup and 0 <= self.lastindex < len(pattern._indexgroup):
+            # The above upper-bound check should not be necessary, as the re
+            # compiler is supposed to always provide an _indexgroup list long
+            # enough. But the re.Scanner class seems to screw up something
+            # there, test_scanner in test_re won't work without upper-bound
+            # checking. XXX investigate this and report bug to CPython.
+            self.lastgroup = pattern._indexgroup[self.lastindex]
+        else:
+            self.lastgroup = None
+
+    def _create_regs(self, state):
+        """Creates a tuple of index pairs representing matched groups."""
+        regs = [(state.start, state.string_position)]
+        for group in range(self.re.groups):
+            mark_index = 2 * group
+            if mark_index + 1 < len(state.marks) \
+                                    and state.marks[mark_index] is not None \
+                                    and state.marks[mark_index + 1] is not None:
+                regs.append((state.marks[mark_index], state.marks[mark_index + 1]))
+            else:
+                regs.append((-1, -1))
+        return tuple(regs)
+
+    def _get_index(self, group):
+        if isinstance(group, int):
+            if group >= 0 and group <= self.re.groups:
+                return group
+        else:
+            if group in self.re.groupindex:
+                return self.re.groupindex[group]
+        raise IndexError("no such group")
+
+    def _get_slice(self, group, default):
+        group_indices = self.regs[group]
+        if group_indices[0] >= 0:
+            return self.string[group_indices[0]:group_indices[1]]
+        else:
+            return default
+
+    def start(self, group=0):
+        """Returns the indices of the start of the substring matched by group;
+        group defaults to zero (meaning the whole matched substring). Returns -1
+        if group exists but did not contribute to the match."""
+        return self.regs[self._get_index(group)][0]
+
+    def end(self, group=0):
+        """Returns the indices of the end of the substring matched by group;
+        group defaults to zero (meaning the whole matched substring). Returns -1
+        if group exists but did not contribute to the match."""
+        return self.regs[self._get_index(group)][1]
+
+    def span(self, group=0):
+        """Returns the 2-tuple (m.start(group), m.end(group))."""
+        return self.start(group), self.end(group)
+
+    def expand(self, template):
+        """Return the string obtained by doing backslash substitution and
+        resolving group references on template."""
+        import sre
+        return sre._expand(self.re, self, template)
+
+    def groups(self, default=None):
+        """Returns a tuple containing all the subgroups of the match. The
+        default argument is used for groups that did not participate in the
+        match (defaults to None)."""
+        groups = []
+        for indices in self.regs[1:]:
+            if indices[0] >= 0:
+                groups.append(self.string[indices[0]:indices[1]])
+            else:
+                groups.append(default)
+        return tuple(groups)
+
+    def groupdict(self, default=None):
+        """Return a dictionary containing all the named subgroups of the match.
+        The default argument is used for groups that did not participate in the
+        match (defaults to None)."""
+        groupdict = {}
+        for key, value in list(self.re.groupindex.items()):
+            groupdict[key] = self._get_slice(value, default)
+        return groupdict
+
+    def group(self, *args):
+        """Returns one or more subgroups of the match. Each argument is either a
+        group index or a group name."""
+        if len(args) == 0:
+            args = (0,)
+        grouplist = []
+        for group in args:
+            grouplist.append(self._get_slice(self._get_index(group), None))
+        if len(grouplist) == 1:
+            return grouplist[0]
+        else:
+            return tuple(grouplist)
+
+    def __copy__():
+        raise TypeError("cannot copy this pattern object")
+
+    def __deepcopy__():
+        raise TypeError("cannot copy this pattern object")
+
+
+class _State(object):
+
+    def __init__(self, string, start, end, flags):
+        self.string = string
+        if start < 0:
+            start = 0
+        if end > len(string):
+            end = len(string)
+        self.start = start
+        self.string_position = self.start
+        self.end = end
+        self.pos = start
+        self.flags = flags
+        self.reset()
+
+    def reset(self):
+        self.marks = []
+        self.lastindex = -1
+        self.marks_stack = []
+        self.context_stack = []
+        self.repeat = None
+
+    def match(self, pattern_codes):
+        # Optimization: Check string length. pattern_codes[3] contains the
+        # minimum length for a string to possibly match.
+        if pattern_codes[0] == OPCODES["info"] and pattern_codes[3]:
+            if self.end - self.string_position < pattern_codes[3]:
+                #_log("reject (got %d chars, need %d)"
+                #         % (self.end - self.string_position, pattern_codes[3]))
+                return False
+
+        dispatcher = _OpcodeDispatcher()
+        self.context_stack.append(_MatchContext(self, pattern_codes))
+        has_matched = None
+        while len(self.context_stack) > 0:
+            context = self.context_stack[-1]
+            has_matched = dispatcher.match(context)
+            if has_matched is not None: # don't pop if context isn't done
+                self.context_stack.pop()
+        return has_matched
+
+    def search(self, pattern_codes):
+        flags = 0
+        if pattern_codes[0] == OPCODES["info"]:
+            # optimization info block
+            # <INFO> <1=skip> <2=flags> <3=min> <4=max> <5=prefix info>
+            if pattern_codes[2] & SRE_INFO_PREFIX and pattern_codes[5] > 1:
+                return self.fast_search(pattern_codes)
+            flags = pattern_codes[2]
+            pattern_codes = pattern_codes[pattern_codes[1] + 1:]
+
+        string_position = self.start
+        if pattern_codes[0] == OPCODES["literal"]:
+            # Special case: Pattern starts with a literal character. This is
+            # used for short prefixes
+            character = pattern_codes[1]
+            while True:
+                while string_position < self.end \
+                        and ord(self.string[string_position]) != character:
+                    string_position += 1
+                if string_position >= self.end:
+                    return False
+                self.start = string_position
+                string_position += 1
+                self.string_position = string_position
+                if flags & SRE_INFO_LITERAL:
+                    return True
+                if self.match(pattern_codes[2:]):
+                    return True
+            return False
+
+        # General case
+        while string_position <= self.end:
+            self.reset()
+            self.start = self.string_position = string_position
+            if self.match(pattern_codes):
+                return True
+            string_position += 1
+        return False
+
+    def fast_search(self, pattern_codes):
+        """Skips forward in a string as fast as possible using information from
+        an optimization info block."""
+        # pattern starts with a known prefix
+        # <5=length> <6=skip> <7=prefix data> <overlap data>
+        flags = pattern_codes[2]
+        prefix_len = pattern_codes[5]
+        prefix_skip = pattern_codes[6] # don't really know what this is good for
+        prefix = pattern_codes[7:7 + prefix_len]
+        overlap = pattern_codes[7 + prefix_len - 1:pattern_codes[1] + 1]
+        pattern_codes = pattern_codes[pattern_codes[1] + 1:]
+        i = 0
+        string_position = self.string_position
+        while string_position < self.end:
+            while True:
+                if ord(self.string[string_position]) != prefix[i]:
+                    if i == 0:
+                        break
+                    else:
+                        i = overlap[i]
+                else:
+                    i += 1
+                    if i == prefix_len:
+                        # found a potential match
+                        self.start = string_position + 1 - prefix_len
+                        self.string_position = string_position + 1 \
+                                                     - prefix_len + prefix_skip
+                        if flags & SRE_INFO_LITERAL:
+                            return True # matched all of pure literal pattern
+                        if self.match(pattern_codes[2 * prefix_skip:]):
+                            return True
+                        i = overlap[i]
+                    break
+            string_position += 1
+        return False
+
+    def set_mark(self, mark_nr, position):
+        if mark_nr & 1:
+            # This id marks the end of a group.
+            self.lastindex = mark_nr // 2 + 1
+        if mark_nr >= len(self.marks):
+            self.marks.extend([None] * (mark_nr - len(self.marks) + 1))
+        self.marks[mark_nr] = position
+
+    def get_marks(self, group_index):
+        marks_index = 2 * group_index
+        if len(self.marks) > marks_index + 1:
+            return self.marks[marks_index], self.marks[marks_index + 1]
+        else:
+            return None, None
+
+    def marks_push(self):
+        self.marks_stack.append((self.marks[:], self.lastindex))
+
+    def marks_pop(self):
+        self.marks, self.lastindex = self.marks_stack.pop()
+
+    def marks_pop_keep(self):
+        self.marks, self.lastindex = self.marks_stack[-1]
+
+    def marks_pop_discard(self):
+        self.marks_stack.pop()
+
+    def lower(self, char_ord):
+        return getlower(char_ord, self.flags)
+
+
+class _MatchContext(object):
+
+    def __init__(self, state, pattern_codes):
+        self.state = state
+        self.pattern_codes = pattern_codes
+        self.string_position = state.string_position
+        self.code_position = 0
+        self.has_matched = None
+
+    def push_new_context(self, pattern_offset):
+        """Creates a new child context of this context and pushes it on the
+        stack. pattern_offset is the offset off the current code position to
+        start interpreting from."""
+        child_context = _MatchContext(self.state,
+            self.pattern_codes[self.code_position + pattern_offset:])
+        self.state.context_stack.append(child_context)
+        return child_context
+
+    def peek_char(self, peek=0):
+        return self.state.string[self.string_position + peek]
+
+    def skip_char(self, skip_count):
+        self.string_position += skip_count
+
+    def remaining_chars(self):
+        return self.state.end - self.string_position
+
+    def peek_code(self, peek=0):
+        return self.pattern_codes[self.code_position + peek]
+
+    def skip_code(self, skip_count):
+        self.code_position += skip_count
+
+    def remaining_codes(self):
+        return len(self.pattern_codes) - self.code_position
+
+    def at_beginning(self):
+        return self.string_position == 0
+
+    def at_end(self):
+        return self.string_position == self.state.end
+
+    def at_linebreak(self):
+        return not self.at_end() and _is_linebreak(self.peek_char())
+
+    def at_boundary(self, word_checker):
+        if self.at_beginning() and self.at_end():
+            return False
+        that = not self.at_beginning() and word_checker(self.peek_char(-1))
+        this = not self.at_end() and word_checker(self.peek_char())
+        return this != that
+
+
+class _RepeatContext(_MatchContext):
+
+    def __init__(self, context):
+        _MatchContext.__init__(self, context.state,
+                            context.pattern_codes[context.code_position:])
+        self.count = -1
+        self.previous = context.state.repeat
+        self.last_position = None
+
+
+class _Dispatcher(object):
+
+    DISPATCH_TABLE = None
+
+    def dispatch(self, code, context):
+        method = self.DISPATCH_TABLE.get(code, self.__class__.unknown)
+        return method(self, context)
+
+    def unknown(self, code, ctx):
+        raise NotImplementedError()
+
+    def build_dispatch_table(cls, code_dict, method_prefix):
+        if cls.DISPATCH_TABLE is not None:
+            return
+        table = {}
+        for key, value in list(code_dict.items()):
+            if hasattr(cls, "%s%s" % (method_prefix, key)):
+                table[value] = getattr(cls, "%s%s" % (method_prefix, key))
+        cls.DISPATCH_TABLE = table
+
+    build_dispatch_table = classmethod(build_dispatch_table)
+
+
+class _OpcodeDispatcher(_Dispatcher):
+
+    def __init__(self):
+        self.executing_contexts = {}
+        self.at_dispatcher = _AtcodeDispatcher()
+        self.ch_dispatcher = _ChcodeDispatcher()
+        self.set_dispatcher = _CharsetDispatcher()
+
+    def match(self, context):
+        """Returns True if the current context matches, False if it doesn't and
+        None if matching is not finished, ie must be resumed after child
+        contexts have been matched."""
+        while context.remaining_codes() > 0 and context.has_matched is None:
+            opcode = context.peek_code()
+            if not self.dispatch(opcode, context):
+                return None
+        if context.has_matched is None:
+            context.has_matched = False
+        return context.has_matched
+
+    def dispatch(self, opcode, context):
+        """Dispatches a context on a given opcode. Returns True if the context
+        is done matching, False if it must be resumed when next encountered."""
+        if id(context) in self.executing_contexts:
+            generator = self.executing_contexts[id(context)]
+            del self.executing_contexts[id(context)]
+            has_finished = next(generator)
+        else:
+            method = self.DISPATCH_TABLE.get(opcode, _OpcodeDispatcher.unknown)
+            has_finished = method(self, context)
+            if hasattr(has_finished, "__next__"): # avoid using the types module
+                generator = has_finished
+                has_finished = next(generator)
+        if not has_finished:
+            self.executing_contexts[id(context)] = generator
+        return has_finished
+
+    def op_success(self, ctx):
+        # end of pattern
+        #self._log(ctx, "SUCCESS")
+        ctx.state.string_position = ctx.string_position
+        ctx.has_matched = True
+        return True
+
+    def op_failure(self, ctx):
+        # immediate failure
+        #self._log(ctx, "FAILURE")
+        ctx.has_matched = False
+        return True
+
+    def general_op_literal(self, ctx, compare, decorate=lambda x: x):
+        if ctx.at_end() or not compare(decorate(ord(ctx.peek_char())),
+                                            decorate(ctx.peek_code(1))):
+            ctx.has_matched = False
+        ctx.skip_code(2)
+        ctx.skip_char(1)
+
+    def op_literal(self, ctx):
+        # match literal string
+        # <LITERAL> <code>
+        #self._log(ctx, "LITERAL", ctx.peek_code(1))
+        self.general_op_literal(ctx, operator.eq)
+        return True
+
+    def op_not_literal(self, ctx):
+        # match anything that is not the given literal character
+        # <NOT_LITERAL> <code>
+        #self._log(ctx, "NOT_LITERAL", ctx.peek_code(1))
+        self.general_op_literal(ctx, operator.ne)
+        return True
+
+    def op_literal_ignore(self, ctx):
+        # match literal regardless of case
+        # <LITERAL_IGNORE> <code>
+        #self._log(ctx, "LITERAL_IGNORE", ctx.peek_code(1))
+        self.general_op_literal(ctx, operator.eq, ctx.state.lower)
+        return True
+
+    def op_not_literal_ignore(self, ctx):
+        # match literal regardless of case
+        # <LITERAL_IGNORE> <code>
+        #self._log(ctx, "LITERAL_IGNORE", ctx.peek_code(1))
+        self.general_op_literal(ctx, operator.ne, ctx.state.lower)
+        return True
+
+    def op_at(self, ctx):
+        # match at given position
+        # <AT> <code>
+        #self._log(ctx, "AT", ctx.peek_code(1))
+        if not self.at_dispatcher.dispatch(ctx.peek_code(1), ctx):
+            ctx.has_matched = False
+            return True
+        ctx.skip_code(2)
+        return True
+
+    def op_category(self, ctx):
+        # match at given category
+        # <CATEGORY> <code>
+        #self._log(ctx, "CATEGORY", ctx.peek_code(1))
+        if ctx.at_end() or not self.ch_dispatcher.dispatch(ctx.peek_code(1), ctx):
+            ctx.has_matched = False
+            return True
+        ctx.skip_code(2)
+        ctx.skip_char(1)
+        return True
+
+    def op_any(self, ctx):
+        # match anything (except a newline)
+        # <ANY>
+        #self._log(ctx, "ANY")
+        if ctx.at_end() or ctx.at_linebreak():
+            ctx.has_matched = False
+            return True
+        ctx.skip_code(1)
+        ctx.skip_char(1)
+        return True
+
+    def op_any_all(self, ctx):
+        # match anything
+        # <ANY_ALL>
+        #self._log(ctx, "ANY_ALL")
+        if ctx.at_end():
+            ctx.has_matched = False
+            return True
+        ctx.skip_code(1)
+        ctx.skip_char(1)
+        return True
+
+    def general_op_in(self, ctx, decorate=lambda x: x):
+        #self._log(ctx, "OP_IN")
+        if ctx.at_end():
+            ctx.has_matched = False
+            return
+        skip = ctx.peek_code(1)
+        ctx.skip_code(2) # set op pointer to the set code
+        if not self.check_charset(ctx, decorate(ord(ctx.peek_char()))):
+            ctx.has_matched = False
+            return
+        ctx.skip_code(skip - 1)
+        ctx.skip_char(1)
+
+    def op_in(self, ctx):
+        # match set member (or non_member)
+        # <IN> <skip> <set>
+        #self._log(ctx, "OP_IN")
+        self.general_op_in(ctx)
+        return True
+
+    def op_in_ignore(self, ctx):
+        # match set member (or non_member), disregarding case of current char
+        # <IN_IGNORE> <skip> <set>
+        #self._log(ctx, "OP_IN_IGNORE")
+        self.general_op_in(ctx, ctx.state.lower)
+        return True
+
+    def op_jump(self, ctx):
+        # jump forward
+        # <JUMP> <offset>
+        #self._log(ctx, "JUMP", ctx.peek_code(1))
+        ctx.skip_code(ctx.peek_code(1) + 1)
+        return True
+
+    # skip info
+    # <INFO> <skip>
+    op_info = op_jump
+
+    def op_mark(self, ctx):
+        # set mark
+        # <MARK> <gid>
+        #self._log(ctx, "OP_MARK", ctx.peek_code(1))
+        ctx.state.set_mark(ctx.peek_code(1), ctx.string_position)
+        ctx.skip_code(2)
+        return True
+
+    def op_branch(self, ctx):
+        # alternation
+        # <BRANCH> <0=skip> code <JUMP> ... <NULL>
+        #self._log(ctx, "BRANCH")
+        ctx.state.marks_push()
+        ctx.skip_code(1)
+        current_branch_length = ctx.peek_code(0)
+        while current_branch_length:
+            # The following tries to shortcut branches starting with a
+            # (unmatched) literal. _sre.c also shortcuts charsets here.
+            if not (ctx.peek_code(1) == OPCODES["literal"] and \
+                    (ctx.at_end() or ctx.peek_code(2) != ord(ctx.peek_char()))):
+                ctx.state.string_position = ctx.string_position
+                child_context = ctx.push_new_context(1)
+                yield False
+                if child_context.has_matched:
+                    ctx.has_matched = True
+                    yield True
+                ctx.state.marks_pop_keep()
+            ctx.skip_code(current_branch_length)
+            current_branch_length = ctx.peek_code(0)
+        ctx.state.marks_pop_discard()
+        ctx.has_matched = False
+        yield True
+
+    def op_repeat_one(self, ctx):
+        # match repeated sequence (maximizing).
+        # this operator only works if the repeated item is exactly one character
+        # wide, and we're not already collecting backtracking points.
+        # <REPEAT_ONE> <skip> <1=min> <2=max> item <SUCCESS> tail
+        mincount = ctx.peek_code(2)
+        maxcount = ctx.peek_code(3)
+        #self._log(ctx, "REPEAT_ONE", mincount, maxcount)
+
+        if ctx.remaining_chars() < mincount:
+            ctx.has_matched = False
+            yield True
+        ctx.state.string_position = ctx.string_position
+        count = self.count_repetitions(ctx, maxcount)
+        ctx.skip_char(count)
+        if count < mincount:
+            ctx.has_matched = False
+            yield True
+        if ctx.peek_code(ctx.peek_code(1) + 1) == OPCODES["success"]:
+            # tail is empty.  we're finished
+            ctx.state.string_position = ctx.string_position
+            ctx.has_matched = True
+            yield True
+
+        ctx.state.marks_push()
+        if ctx.peek_code(ctx.peek_code(1) + 1) == OPCODES["literal"]:
+            # Special case: Tail starts with a literal. Skip positions where
+            # the rest of the pattern cannot possibly match.
+            char = ctx.peek_code(ctx.peek_code(1) + 2)
+            while True:
+                while count >= mincount and \
+                                (ctx.at_end() or ord(ctx.peek_char()) != char):
+                    ctx.skip_char(-1)
+                    count -= 1
+                if count < mincount:
+                    break
+                ctx.state.string_position = ctx.string_position
+                child_context = ctx.push_new_context(ctx.peek_code(1) + 1)
+                yield False
+                if child_context.has_matched:
+                    ctx.has_matched = True
+                    yield True
+                ctx.skip_char(-1)
+                count -= 1
+                ctx.state.marks_pop_keep()
+
+        else:
+            # General case: backtracking
+            while count >= mincount:
+                ctx.state.string_position = ctx.string_position
+                child_context = ctx.push_new_context(ctx.peek_code(1) + 1)
+                yield False
+                if child_context.has_matched:
+                    ctx.has_matched = True
+                    yield True
+                ctx.skip_char(-1)
+                count -= 1
+                ctx.state.marks_pop_keep()
+
+        ctx.state.marks_pop_discard()
+        ctx.has_matched = False
+        yield True
+
+    def op_min_repeat_one(self, ctx):
+        # match repeated sequence (minimizing)
+        # <MIN_REPEAT_ONE> <skip> <1=min> <2=max> item <SUCCESS> tail
+        mincount = ctx.peek_code(2)
+        maxcount = ctx.peek_code(3)
+        #self._log(ctx, "MIN_REPEAT_ONE", mincount, maxcount)
+
+        if ctx.remaining_chars() < mincount:
+            ctx.has_matched = False
+            yield True
+        ctx.state.string_position = ctx.string_position
+        if mincount == 0:
+            count = 0
+        else:
+            count = self.count_repetitions(ctx, mincount)
+            if count < mincount:
+                ctx.has_matched = False
+                yield True
+            ctx.skip_char(count)
+        if ctx.peek_code(ctx.peek_code(1) + 1) == OPCODES["success"]:
+            # tail is empty.  we're finished
+            ctx.state.string_position = ctx.string_position
+            ctx.has_matched = True
+            yield True
+
+        ctx.state.marks_push()
+        while maxcount == MAXREPEAT or count <= maxcount:
+            ctx.state.string_position = ctx.string_position
+            child_context = ctx.push_new_context(ctx.peek_code(1) + 1)
+            yield False
+            if child_context.has_matched:
+                ctx.has_matched = True
+                yield True
+            ctx.state.string_position = ctx.string_position
+            if self.count_repetitions(ctx, 1) == 0:
+                break
+            ctx.skip_char(1)
+            count += 1
+            ctx.state.marks_pop_keep()
+
+        ctx.state.marks_pop_discard()
+        ctx.has_matched = False
+        yield True
+
+    def op_repeat(self, ctx):
+        # create repeat context.  all the hard work is done by the UNTIL
+        # operator (MAX_UNTIL, MIN_UNTIL)
+        # <REPEAT> <skip> <1=min> <2=max> item <UNTIL> tail
+        #self._log(ctx, "REPEAT", ctx.peek_code(2), ctx.peek_code(3))
+        repeat = _RepeatContext(ctx)
+        ctx.state.repeat = repeat
+        ctx.state.string_position = ctx.string_position
+        child_context = ctx.push_new_context(ctx.peek_code(1) + 1)
+        yield False
+        ctx.state.repeat = repeat.previous
+        ctx.has_matched = child_context.has_matched
+        yield True
+
+    def op_max_until(self, ctx):
+        # maximizing repeat
+        # <REPEAT> <skip> <1=min> <2=max> item <MAX_UNTIL> tail
+        repeat = ctx.state.repeat
+        if repeat is None:
+            raise RuntimeError("Internal re error: MAX_UNTIL without REPEAT.")
+        mincount = repeat.peek_code(2)
+        maxcount = repeat.peek_code(3)
+        ctx.state.string_position = ctx.string_position
+        count = repeat.count + 1
+        #self._log(ctx, "MAX_UNTIL", count)
+
+        if count < mincount:
+            # not enough matches
+            repeat.count = count
+            child_context = repeat.push_new_context(4)
+            yield False
+            ctx.has_matched = child_context.has_matched
+            if not ctx.has_matched:
+                repeat.count = count - 1
+                ctx.state.string_position = ctx.string_position
+            yield True
+
+        if (count < maxcount or maxcount == MAXREPEAT) \
+                      and ctx.state.string_position != repeat.last_position:
+            # we may have enough matches, if we can match another item, do so
+            repeat.count = count
+            ctx.state.marks_push()
+            save_last_position = repeat.last_position # zero-width match protection
+            repeat.last_position = ctx.state.string_position
+            child_context = repeat.push_new_context(4)
+            yield False
+            repeat.last_position = save_last_position
+            if child_context.has_matched:
+                ctx.state.marks_pop_discard()
+                ctx.has_matched = True
+                yield True
+            ctx.state.marks_pop()
+            repeat.count = count - 1
+            ctx.state.string_position = ctx.string_position
+
+        # cannot match more repeated items here.  make sure the tail matches
+        ctx.state.repeat = repeat.previous
+        child_context = ctx.push_new_context(1)
+        yield False
+        ctx.has_matched = child_context.has_matched
+        if not ctx.has_matched:
+            ctx.state.repeat = repeat
+            ctx.state.string_position = ctx.string_position
+        yield True
+
+    def op_min_until(self, ctx):
+        # minimizing repeat
+        # <REPEAT> <skip> <1=min> <2=max> item <MIN_UNTIL> tail
+        repeat = ctx.state.repeat
+        if repeat is None:
+            raise RuntimeError("Internal re error: MIN_UNTIL without REPEAT.")
+        mincount = repeat.peek_code(2)
+        maxcount = repeat.peek_code(3)
+        ctx.state.string_position = ctx.string_position
+        count = repeat.count + 1
+        #self._log(ctx, "MIN_UNTIL", count)
+
+        if count < mincount:
+            # not enough matches
+            repeat.count = count
+            child_context = repeat.push_new_context(4)
+            yield False
+            ctx.has_matched = child_context.has_matched
+            if not ctx.has_matched:
+                repeat.count = count - 1
+                ctx.state.string_position = ctx.string_position
+            yield True
+
+        # see if the tail matches
+        ctx.state.marks_push()
+        ctx.state.repeat = repeat.previous
+        child_context = ctx.push_new_context(1)
+        yield False
+        if child_context.has_matched:
+            ctx.has_matched = True
+            yield True
+        ctx.state.repeat = repeat
+        ctx.state.string_position = ctx.string_position
+        ctx.state.marks_pop()
+
+        # match more until tail matches
+        if count >= maxcount and maxcount != MAXREPEAT:
+            ctx.has_matched = False
+            yield True
+        repeat.count = count
+        child_context = repeat.push_new_context(4)
+        yield False
+        ctx.has_matched = child_context.has_matched
+        if not ctx.has_matched:
+            repeat.count = count - 1
+            ctx.state.string_position = ctx.string_position
+        yield True
+
+    def general_op_groupref(self, ctx, decorate=lambda x: x):
+        group_start, group_end = ctx.state.get_marks(ctx.peek_code(1))
+        if group_start is None or group_end is None or group_end < group_start:
+            ctx.has_matched = False
+            return True
+        while group_start < group_end:
+            if ctx.at_end() or decorate(ord(ctx.peek_char())) \
+                                != decorate(ord(ctx.state.string[group_start])):
+                ctx.has_matched = False
+                return True
+            group_start += 1
+            ctx.skip_char(1)
+        ctx.skip_code(2)
+        return True
+
+    def op_groupref(self, ctx):
+        # match backreference
+        # <GROUPREF> <zero-based group index>
+        #self._log(ctx, "GROUPREF", ctx.peek_code(1))
+        return self.general_op_groupref(ctx)
+
+    def op_groupref_ignore(self, ctx):
+        # match backreference case-insensitive
+        # <GROUPREF_IGNORE> <zero-based group index>
+        #self._log(ctx, "GROUPREF_IGNORE", ctx.peek_code(1))
+        return self.general_op_groupref(ctx, ctx.state.lower)
+
+    def op_groupref_exists(self, ctx):
+        # <GROUPREF_EXISTS> <group> <skip> codeyes <JUMP> codeno ...
+        #self._log(ctx, "GROUPREF_EXISTS", ctx.peek_code(1))
+        group_start, group_end = ctx.state.get_marks(ctx.peek_code(1))
+        if group_start is None or group_end is None or group_end < group_start:
+            ctx.skip_code(ctx.peek_code(2) + 1)
+        else:
+            ctx.skip_code(3)
+        return True
+
+    def op_assert(self, ctx):
+        # assert subpattern
+        # <ASSERT> <skip> <back> <pattern>
+        #self._log(ctx, "ASSERT", ctx.peek_code(2))
+        ctx.state.string_position = ctx.string_position - ctx.peek_code(2)
+        if ctx.state.string_position < 0:
+            ctx.has_matched = False
+            yield True
+        child_context = ctx.push_new_context(3)
+        yield False
+        if child_context.has_matched:
+            ctx.skip_code(ctx.peek_code(1) + 1)
+        else:
+            ctx.has_matched = False
+        yield True
+
+    def op_assert_not(self, ctx):
+        # assert not subpattern
+        # <ASSERT_NOT> <skip> <back> <pattern>
+        #self._log(ctx, "ASSERT_NOT", ctx.peek_code(2))
+        ctx.state.string_position = ctx.string_position - ctx.peek_code(2)
+        if ctx.state.string_position >= 0:
+            child_context = ctx.push_new_context(3)
+            yield False
+            if child_context.has_matched:
+                ctx.has_matched = False
+                yield True
+        ctx.skip_code(ctx.peek_code(1) + 1)
+        yield True
+
+    def unknown(self, ctx):
+        #self._log(ctx, "UNKNOWN", ctx.peek_code())
+        raise RuntimeError("Internal re error. Unknown opcode: %s" % ctx.peek_code())
+
+    def check_charset(self, ctx, char):
+        """Checks whether a character matches set of arbitrary length. Assumes
+        the code pointer is at the first member of the set."""
+        self.set_dispatcher.reset(char)
+        save_position = ctx.code_position
+        result = None
+        while result is None:
+            result = self.set_dispatcher.dispatch(ctx.peek_code(), ctx)
+        ctx.code_position = save_position
+        return result
+
+    def count_repetitions(self, ctx, maxcount):
+        """Returns the number of repetitions of a single item, starting from the
+        current string position. The code pointer is expected to point to a
+        REPEAT_ONE operation (with the repeated 4 ahead)."""
+        count = 0
+        real_maxcount = ctx.state.end - ctx.string_position
+        if maxcount < real_maxcount and maxcount != MAXREPEAT:
+            real_maxcount = maxcount
+        # XXX could special case every single character pattern here, as in C.
+        # This is a general solution, a bit hackisch, but works and should be
+        # efficient.
+        code_position = ctx.code_position
+        string_position = ctx.string_position
+        ctx.skip_code(4)
+        reset_position = ctx.code_position
+        while count < real_maxcount:
+            # this works because the single character pattern is followed by
+            # a success opcode
+            ctx.code_position = reset_position
+            self.dispatch(ctx.peek_code(), ctx)
+            if ctx.has_matched is False: # could be None as well
+                break
+            count += 1
+        ctx.has_matched = None
+        ctx.code_position = code_position
+        ctx.string_position = string_position
+        return count
+
+    def _log(self, context, opname, *args):
+        arg_string = ("%s " * len(args)) % args
+        _log("|%s|%s|%s %s" % (context.pattern_codes,
+            context.string_position, opname, arg_string))
+
+_OpcodeDispatcher.build_dispatch_table(OPCODES, "op_")
+
+
+class _CharsetDispatcher(_Dispatcher):
+
+    def __init__(self):
+        self.ch_dispatcher = _ChcodeDispatcher()
+
+    def reset(self, char):
+        self.char = char
+        self.ok = True
+
+    def set_failure(self, ctx):
+        return not self.ok
+    def set_literal(self, ctx):
+        # <LITERAL> <code>
+        if ctx.peek_code(1) == self.char:
+            return self.ok
+        else:
+            ctx.skip_code(2)
+    def set_category(self, ctx):
+        # <CATEGORY> <code>
+        if self.ch_dispatcher.dispatch(ctx.peek_code(1), ctx):
+            return self.ok
+        else:
+            ctx.skip_code(2)
+    def set_charset(self, ctx):
+        # <CHARSET> <bitmap> (16 bits per code word)
+        char_code = self.char
+        ctx.skip_code(1) # point to beginning of bitmap
+        if CODESIZE == 2:
+            if char_code < 256 and ctx.peek_code(char_code >> 4) \
+                                            & (1 << (char_code & 15)):
+                return self.ok
+            ctx.skip_code(16) # skip bitmap
+        else:
+            if char_code < 256 and ctx.peek_code(char_code >> 5) \
+                                            & (1 << (char_code & 31)):
+                return self.ok
+            ctx.skip_code(8) # skip bitmap
+    def set_range(self, ctx):
+        # <RANGE> <lower> <upper>
+        if ctx.peek_code(1) <= self.char <= ctx.peek_code(2):
+            return self.ok
+        ctx.skip_code(3)
+    def set_negate(self, ctx):
+        self.ok = not self.ok
+        ctx.skip_code(1)
+    def set_bigcharset(self, ctx):
+        # <BIGCHARSET> <blockcount> <256 blockindices> <blocks>
+        char_code = self.char
+        count = ctx.peek_code(1)
+        ctx.skip_code(2)
+        if char_code < 65536:
+            block_index = char_code >> 8
+            # NB: there are CODESIZE block indices per bytecode
+            a = array.array("B")
+            a.fromstring(array.array(CODESIZE == 2 and "H" or "I",
+                    [ctx.peek_code(block_index / CODESIZE)]).tostring())
+            block = a[block_index % CODESIZE]
+            ctx.skip_code(256 / CODESIZE) # skip block indices
+            block_value = ctx.peek_code(block * (32 / CODESIZE)
+                    + ((char_code & 255) >> (CODESIZE == 2 and 4 or 5)))
+            if block_value & (1 << (char_code & ((8 * CODESIZE) - 1))):
+                return self.ok
+        else:
+            ctx.skip_code(256 / CODESIZE) # skip block indices
+        ctx.skip_code(count * (32 / CODESIZE)) # skip blocks
+    def unknown(self, ctx):
+        return False
+
+_CharsetDispatcher.build_dispatch_table(OPCODES, "set_")
+
+
+class _AtcodeDispatcher(_Dispatcher):
+
+    def at_beginning(self, ctx):
+        return ctx.at_beginning()
+    at_beginning_string = at_beginning
+    def at_beginning_line(self, ctx):
+        return ctx.at_beginning() or _is_linebreak(ctx.peek_char(-1))
+    def at_end(self, ctx):
+        return (ctx.remaining_chars() == 1 and ctx.at_linebreak()) or ctx.at_end()
+    def at_end_line(self, ctx):
+        return ctx.at_linebreak() or ctx.at_end()
+    def at_end_string(self, ctx):
+        return ctx.at_end()
+    def at_boundary(self, ctx):
+        return ctx.at_boundary(_is_word)
+    def at_non_boundary(self, ctx):
+        return not ctx.at_boundary(_is_word)
+    def at_loc_boundary(self, ctx):
+        return ctx.at_boundary(_is_loc_word)
+    def at_loc_non_boundary(self, ctx):
+        return not ctx.at_boundary(_is_loc_word)
+    def at_uni_boundary(self, ctx):
+        return ctx.at_boundary(_is_uni_word)
+    def at_uni_non_boundary(self, ctx):
+        return not ctx.at_boundary(_is_uni_word)
+    def unknown(self, ctx):
+        return False
+
+_AtcodeDispatcher.build_dispatch_table(ATCODES, "")
+
+
+class _ChcodeDispatcher(_Dispatcher):
+
+    def category_digit(self, ctx):
+        return _is_digit(ctx.peek_char())
+    def category_not_digit(self, ctx):
+        return not _is_digit(ctx.peek_char())
+    def category_space(self, ctx):
+        return _is_space(ctx.peek_char())
+    def category_not_space(self, ctx):
+        return not _is_space(ctx.peek_char())
+    def category_word(self, ctx):
+        return _is_word(ctx.peek_char())
+    def category_not_word(self, ctx):
+        return not _is_word(ctx.peek_char())
+    def category_linebreak(self, ctx):
+        return _is_linebreak(ctx.peek_char())
+    def category_not_linebreak(self, ctx):
+        return not _is_linebreak(ctx.peek_char())
+    def category_loc_word(self, ctx):
+        return _is_loc_word(ctx.peek_char())
+    def category_loc_not_word(self, ctx):
+        return not _is_loc_word(ctx.peek_char())
+    def category_uni_digit(self, ctx):
+        return ctx.peek_char().isdigit()
+    def category_uni_not_digit(self, ctx):
+        return not ctx.peek_char().isdigit()
+    def category_uni_space(self, ctx):
+        return ctx.peek_char().isspace()
+    def category_uni_not_space(self, ctx):
+        return not ctx.peek_char().isspace()
+    def category_uni_word(self, ctx):
+        return _is_uni_word(ctx.peek_char())
+    def category_uni_not_word(self, ctx):
+        return not _is_uni_word(ctx.peek_char())
+    def category_uni_linebreak(self, ctx):
+        return ord(ctx.peek_char()) in _uni_linebreaks
+    def category_uni_not_linebreak(self, ctx):
+        return ord(ctx.peek_char()) not in _uni_linebreaks
+    def unknown(self, ctx):
+        return False
+
+_ChcodeDispatcher.build_dispatch_table(CHCODES, "")
+
+
+_ascii_char_info = [ 0, 0, 0, 0, 0, 0, 0, 0, 0, 2, 6, 2,
+2, 2, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 2, 0, 0,
+0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 25, 25, 25, 25, 25, 25, 25, 25,
+25, 25, 0, 0, 0, 0, 0, 0, 0, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24,
+24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 0, 0,
+0, 0, 16, 0, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24,
+24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 0, 0, 0, 0, 0 ]
+
+def _is_digit(char):
+    code = ord(char)
+    return code < 128 and _ascii_char_info[code] & 1
+
+def _is_space(char):
+    code = ord(char)
+    return code < 128 and _ascii_char_info[code] & 2
+
+def _is_word(char):
+    # NB: non-ASCII chars aren't words according to _sre.c
+    code = ord(char)
+    return code < 128 and _ascii_char_info[code] & 16
+
+def _is_loc_word(char):
+    return (not (ord(char) & ~255) and char.isalnum()) or char == '_'
+
+def _is_uni_word(char):
+    return chr(ord(char)).isalnum() or char == '_'
+
+def _is_linebreak(char):
+    return char == "\n"
+
+# Static list of all unicode codepoints reported by Py_UNICODE_ISLINEBREAK.
+_uni_linebreaks = [10, 13, 28, 29, 30, 133, 8232, 8233]
+
+def _log(message):
+    if 0:
+        print(message)

--- a/Lib/_sre.py
+++ b/Lib/_sre.py
@@ -552,16 +552,16 @@ class _Dispatcher(object):
     def unknown(self, code, ctx):
         raise NotImplementedError()
 
+    @classmethod
     def build_dispatch_table(cls, codes, method_prefix):
         if cls.DISPATCH_TABLE is not None:
             return
         table = {}
         for code in codes:
-            if hasattr(cls, "%s%s" % (method_prefix, code.name)):
-                table[value] = getattr(cls, "%s%s" % (method_prefix, code.name))
+            code_name = code.name.lower()
+            if hasattr(cls, "%s%s" % (method_prefix, code_name)):
+                table[code] = getattr(cls, "%s%s" % (method_prefix, code_name))
         cls.DISPATCH_TABLE = table
-
-    build_dispatch_table = classmethod(build_dispatch_table)
 
 
 class _OpcodeDispatcher(_Dispatcher):

--- a/Lib/argparse.py
+++ b/Lib/argparse.py
@@ -328,18 +328,14 @@ class HelpFormatter(object):
 
                 # break usage into wrappable parts
                 part_regexp = (
-                    r'(\(.*?\)+|\[.*?\]+|\S+)(?:\s|$)'
+                    r'\(.*?\)+(?=\s|$)|'
+                    r'\[.*?\]+(?=\s|$)|'
+                    r'\S+'
                 )
-                # FIXME: use regex below once we're compatible with sre
-                # part_regexp = (
-                #     r'\(.*?\)+(?=\s|$)|'
-                #     r'\[.*?\]+(?=\s|$)|'
-                #     r'\S+'
-                # )
                 opt_usage = format(optionals, groups)
                 pos_usage = format(positionals, groups)
-                opt_parts = list(map(lambda t: t[0], _re.findall(part_regexp, opt_usage)))
-                pos_parts = list(map(lambda t: t[0], _re.findall(part_regexp, pos_usage)))
+                opt_parts = _re.findall(part_regexp, opt_usage)
+                pos_parts = _re.findall(part_regexp, pos_usage)
                 assert ' '.join(opt_parts) == opt_usage
                 assert ' '.join(pos_parts) == pos_usage
 

--- a/Lib/re.py
+++ b/Lib/re.py
@@ -1,0 +1,352 @@
+#
+# Secret Labs' Regular Expression Engine
+#
+# re-compatible interface for the sre matching engine
+#
+# Copyright (c) 1998-2001 by Secret Labs AB.  All rights reserved.
+#
+# This version of the SRE library can be redistributed under CNRI's
+# Python 1.6 license.  For any other use, please contact Secret Labs
+# AB (info@pythonware.com).
+#
+# Portions of this engine have been developed in cooperation with
+# CNRI.  Hewlett-Packard provided funding for 1.6 integration and
+# other compatibility work.
+#
+
+r"""Support for regular expressions (RE).
+
+This module provides regular expression matching operations similar to
+those found in Perl.  It supports both 8-bit and Unicode strings; both
+the pattern and the strings being processed can contain null bytes and
+characters outside the US ASCII range.
+
+Regular expressions can contain both special and ordinary characters.
+Most ordinary characters, like "A", "a", or "0", are the simplest
+regular expressions; they simply match themselves.  You can
+concatenate ordinary characters, so last matches the string 'last'.
+
+The special characters are:
+    "."      Matches any character except a newline.
+    "^"      Matches the start of the string.
+    "$"      Matches the end of the string or just before the newline at
+             the end of the string.
+    "*"      Matches 0 or more (greedy) repetitions of the preceding RE.
+             Greedy means that it will match as many repetitions as possible.
+    "+"      Matches 1 or more (greedy) repetitions of the preceding RE.
+    "?"      Matches 0 or 1 (greedy) of the preceding RE.
+    *?,+?,?? Non-greedy versions of the previous three special characters.
+    {m,n}    Matches from m to n repetitions of the preceding RE.
+    {m,n}?   Non-greedy version of the above.
+    "\\"     Either escapes special characters or signals a special sequence.
+    []       Indicates a set of characters.
+             A "^" as the first character indicates a complementing set.
+    "|"      A|B, creates an RE that will match either A or B.
+    (...)    Matches the RE inside the parentheses.
+             The contents can be retrieved or matched later in the string.
+    (?aiLmsux) Set the A, I, L, M, S, U, or X flag for the RE (see below).
+    (?:...)  Non-grouping version of regular parentheses.
+    (?P<name>...) The substring matched by the group is accessible by name.
+    (?P=name)     Matches the text matched earlier by the group named name.
+    (?#...)  A comment; ignored.
+    (?=...)  Matches if ... matches next, but doesn't consume the string.
+    (?!...)  Matches if ... doesn't match next.
+    (?<=...) Matches if preceded by ... (must be fixed length).
+    (?<!...) Matches if not preceded by ... (must be fixed length).
+    (?(id/name)yes|no) Matches yes pattern if the group with id/name matched,
+                       the (optional) no pattern otherwise.
+
+The special sequences consist of "\\" and a character from the list
+below.  If the ordinary character is not on the list, then the
+resulting RE will match the second character.
+    \number  Matches the contents of the group of the same number.
+    \A       Matches only at the start of the string.
+    \Z       Matches only at the end of the string.
+    \b       Matches the empty string, but only at the start or end of a word.
+    \B       Matches the empty string, but not at the start or end of a word.
+    \d       Matches any decimal digit; equivalent to the set [0-9] in
+             bytes patterns or string patterns with the ASCII flag.
+             In string patterns without the ASCII flag, it will match the whole
+             range of Unicode digits.
+    \D       Matches any non-digit character; equivalent to [^\d].
+    \s       Matches any whitespace character; equivalent to [ \t\n\r\f\v].
+    \S       Matches any non-whitespace character; equiv. to [^ \t\n\r\f\v].
+    \w       Matches any alphanumeric character; equivalent to [a-zA-Z0-9_]
+             in bytes patterns or string patterns with the ASCII flag.
+             In string patterns without the ASCII flag, it will match the
+             range of Unicode alphanumeric characters (letters plus digits
+             plus underscore).
+             With LOCALE, it will match the set [0-9_] plus characters defined
+             as letters for the current locale.
+    \W       Matches the complement of \w.
+    \\       Matches a literal backslash.
+
+This module exports the following functions:
+    match    Match a regular expression pattern to the beginning of a string.
+    search   Search a string for the presence of a pattern.
+    sub      Substitute occurrences of a pattern found in a string.
+    subn     Same as sub, but also return the number of substitutions made.
+    split    Split a string by the occurrences of a pattern.
+    findall  Find all occurrences of a pattern in a string.
+    finditer Return an iterator yielding a match object for each match.
+    compile  Compile a pattern into a RegexObject.
+    purge    Clear the regular expression cache.
+    escape   Backslash all non-alphanumerics in a string.
+
+Some of the functions in this module takes flags as optional parameters:
+    A  ASCII       For string patterns, make \w, \W, \b, \B, \d, \D
+                   match the corresponding ASCII character categories
+                   (rather than the whole Unicode categories, which is the
+                   default).
+                   For bytes patterns, this flag is the only available
+                   behaviour and needn't be specified.
+    I  IGNORECASE  Perform case-insensitive matching.
+    L  LOCALE      Make \w, \W, \b, \B, dependent on the current locale.
+    M  MULTILINE   "^" matches the beginning of lines (after a newline)
+                   as well as the string.
+                   "$" matches the end of lines (before a newline) as well
+                   as the end of the string.
+    S  DOTALL      "." matches any character at all, including the newline.
+    X  VERBOSE     Ignore whitespace and comments for nicer looking RE's.
+    U  UNICODE     For compatibility only. Ignored for string patterns (it
+                   is the default), and forbidden for bytes patterns.
+
+This module also defines an exception 'error'.
+
+"""
+
+import sys
+import sre_compile
+import sre_parse
+
+# public symbols
+__all__ = [ "match", "search", "sub", "subn", "split", "findall",
+    "compile", "purge", "template", "escape", "A", "I", "L", "M", "S", "X",
+    "U", "ASCII", "IGNORECASE", "LOCALE", "MULTILINE", "DOTALL", "VERBOSE",
+    "UNICODE", "error" ]
+
+__version__ = "2.2.1"
+
+# flags
+A = ASCII = sre_compile.SRE_FLAG_ASCII # assume ascii "locale"
+I = IGNORECASE = sre_compile.SRE_FLAG_IGNORECASE # ignore case
+L = LOCALE = sre_compile.SRE_FLAG_LOCALE # assume current 8-bit locale
+U = UNICODE = sre_compile.SRE_FLAG_UNICODE # assume unicode "locale"
+M = MULTILINE = sre_compile.SRE_FLAG_MULTILINE # make anchors look for newline
+S = DOTALL = sre_compile.SRE_FLAG_DOTALL # make dot match newline
+X = VERBOSE = sre_compile.SRE_FLAG_VERBOSE # ignore whitespace and comments
+
+# sre extensions (experimental, don't rely on these)
+T = TEMPLATE = sre_compile.SRE_FLAG_TEMPLATE # disable backtracking
+DEBUG = sre_compile.SRE_FLAG_DEBUG # dump pattern after compilation
+
+# sre exception
+error = sre_compile.error
+
+# --------------------------------------------------------------------
+# public interface
+
+def match(pattern, string, flags=0):
+    """Try to apply the pattern at the start of the string, returning
+    a match object, or None if no match was found."""
+    return _compile(pattern, flags).match(string)
+
+def search(pattern, string, flags=0):
+    """Scan through string looking for a match to the pattern, returning
+    a match object, or None if no match was found."""
+    return _compile(pattern, flags).search(string)
+
+def sub(pattern, repl, string, count=0):
+    """Return the string obtained by replacing the leftmost
+    non-overlapping occurrences of the pattern in string by the
+    replacement repl.  repl can be either a string or a callable;
+    if a string, backslash escapes in it are processed.  If it is
+    a callable, it's passed the match object and must return
+    a replacement string to be used."""
+    return _compile(pattern, 0).sub(repl, string, count)
+
+def subn(pattern, repl, string, count=0):
+    """Return a 2-tuple containing (new_string, number).
+    new_string is the string obtained by replacing the leftmost
+    non-overlapping occurrences of the pattern in the source
+    string by the replacement repl.  number is the number of
+    substitutions that were made. repl can be either a string or a
+    callable; if a string, backslash escapes in it are processed.
+    If it is a callable, it's passed the match object and must
+    return a replacement string to be used."""
+    return _compile(pattern, 0).subn(repl, string, count)
+
+def split(pattern, string, maxsplit=0):
+    """Split the source string by the occurrences of the pattern,
+    returning a list containing the resulting substrings."""
+    return _compile(pattern, 0).split(string, maxsplit)
+
+def findall(pattern, string, flags=0):
+    """Return a list of all non-overlapping matches in the string.
+
+    If one or more groups are present in the pattern, return a
+    list of groups; this will be a list of tuples if the pattern
+    has more than one group.
+
+    Empty matches are included in the result."""
+    return _compile(pattern, flags).findall(string)
+
+if sys.hexversion >= 0x02020000:
+    __all__.append("finditer")
+    def finditer(pattern, string, flags=0):
+        """Return an iterator over all non-overlapping matches in the
+        string.  For each match, the iterator returns a match object.
+
+        Empty matches are included in the result."""
+        return _compile(pattern, flags).finditer(string)
+
+def compile(pattern, flags=0):
+    "Compile a regular expression pattern, returning a pattern object."
+    return _compile(pattern, flags)
+
+def purge():
+    "Clear the regular expression cache"
+    _cache.clear()
+    _cache_repl.clear()
+
+def template(pattern, flags=0):
+    "Compile a template pattern, returning a pattern object"
+    return _compile(pattern, flags|T)
+
+_alphanum_str = frozenset(
+    "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ01234567890")
+_alphanum_bytes = frozenset(
+    b"abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ01234567890")
+
+def escape(pattern):
+    "Escape all non-alphanumeric characters in pattern."
+    if isinstance(pattern, str):
+        alphanum = _alphanum_str
+        s = list(pattern)
+        for i in range(len(pattern)):
+            c = pattern[i]
+            if c not in alphanum:
+                if c == "\000":
+                    s[i] = "\\000"
+                else:
+                    s[i] = "\\" + c
+        return "".join(s)
+    else:
+        alphanum = _alphanum_bytes
+        s = []
+        esc = ord(b"\\")
+        for c in pattern:
+            if c in alphanum:
+                s.append(c)
+            else:
+                if c == 0:
+                    s.extend(b"\\000")
+                else:
+                    s.append(esc)
+                    s.append(c)
+        return bytes(s)
+
+# --------------------------------------------------------------------
+# internals
+
+_cache = {}
+_cache_repl = {}
+
+_pattern_type = type(sre_compile.compile("", 0))
+
+_MAXCACHE = 100
+
+def _compile(*key):
+    # internal: compile pattern
+    cachekey = (type(key[0]),) + key
+    p = _cache.get(cachekey)
+    if p is not None:
+        return p
+    pattern, flags = key
+    if isinstance(pattern, _pattern_type):
+        if flags:
+            raise ValueError(
+                "Cannot process flags argument with a compiled pattern")
+        return pattern
+    if not sre_compile.isstring(pattern):
+        raise TypeError("first argument must be string or compiled pattern")
+    p = sre_compile.compile(pattern, flags)
+    if len(_cache) >= _MAXCACHE:
+        _cache.clear()
+    _cache[cachekey] = p
+    return p
+
+def _compile_repl(*key):
+    # internal: compile replacement pattern
+    p = _cache_repl.get(key)
+    if p is not None:
+        return p
+    repl, pattern = key
+    p = sre_parse.parse_template(repl, pattern)
+    if len(_cache_repl) >= _MAXCACHE:
+        _cache_repl.clear()
+    _cache_repl[key] = p
+    return p
+
+def _expand(pattern, match, template):
+    # internal: match.expand implementation hook
+    template = sre_parse.parse_template(template, pattern)
+    return sre_parse.expand_template(template, match)
+
+def _subx(pattern, template):
+    # internal: pattern.sub/subn implementation helper
+    template = _compile_repl(template, pattern)
+    if not template[0] and len(template[1]) == 1:
+        # literal replacement
+        return template[1][0]
+    def filter(match, template=template):
+        return sre_parse.expand_template(template, match)
+    return filter
+
+# register myself for pickling
+
+import copyreg
+
+def _pickle(p):
+    return _compile, (p.pattern, p.flags)
+
+copyreg.pickle(_pattern_type, _pickle, _compile)
+
+# --------------------------------------------------------------------
+# experimental stuff (see python-dev discussions for details)
+
+class Scanner:
+    def __init__(self, lexicon, flags=0):
+        from sre_constants import BRANCH, SUBPATTERN
+        self.lexicon = lexicon
+        # combine phrases into a compound pattern
+        p = []
+        s = sre_parse.Pattern()
+        s.flags = flags
+        for phrase, action in lexicon:
+            p.append(sre_parse.SubPattern(s, [
+                (SUBPATTERN, (len(p)+1, sre_parse.parse(phrase, flags))),
+                ]))
+        s.groups = len(p)+1
+        p = sre_parse.SubPattern(s, [(BRANCH, (None, p))])
+        self.scanner = sre_compile.compile(p)
+    def scan(self, string):
+        result = []
+        append = result.append
+        match = self.scanner.scanner(string).match
+        i = 0
+        while 1:
+            m = match()
+            if not m:
+                break
+            j = m.end()
+            if i == j:
+                break
+            action = self.lexicon[m.lastindex-1][1]
+            if hasattr(action, "__call__"):
+                self.match = m
+                action = action(self, m.group())
+            if action is not None:
+                append(action)
+            i = j
+        return result, string[i:]

--- a/Lib/re.py
+++ b/Lib/re.py
@@ -191,7 +191,7 @@ def findall(pattern, string, flags=0):
     Empty matches are included in the result."""
     return _compile(pattern, flags).findall(string)
 
-if sys.hexversion >= 0x02020000:
+if True: # XXX RustPython: when sys.hexversion is available, change to (sys.hexversion >= 0x02020000)
     __all__.append("finditer")
     def finditer(pattern, string, flags=0):
         """Return an iterator over all non-overlapping matches in the

--- a/Lib/re.py
+++ b/Lib/re.py
@@ -158,7 +158,10 @@ class RegexFlag(enum.IntFlag):
     TEMPLATE = sre_compile.SRE_FLAG_TEMPLATE # disable backtracking
     T = TEMPLATE
     DEBUG = sre_compile.SRE_FLAG_DEBUG # dump pattern after compilation
-globals().update(RegexFlag.__members__)
+#TODO: globals().update(RegexFlag.__members__) once mappingproxy has __iter__
+for name in ("ASCII","IGNORECASE","LOCALE","UNICODE","MULTILINE","DOTALL",
+             "VERBOSE","A","I","L","U","M","S","X","TEMPLATE","T","DEBUG"):
+    globals()[name] = getattr(RegexFlag, name)
 
 # sre exception
 error = sre_compile.error

--- a/Lib/sre_compile.py
+++ b/Lib/sre_compile.py
@@ -1,0 +1,515 @@
+#
+# Secret Labs' Regular Expression Engine
+#
+# convert template to internal format
+#
+# Copyright (c) 1997-2001 by Secret Labs AB.  All rights reserved.
+#
+# See the sre.py file for information on usage and redistribution.
+#
+
+"""Internal support module for sre"""
+
+import _sre, sys
+import sre_parse
+from sre_constants import *
+
+assert _sre.MAGIC == MAGIC, "SRE module mismatch"
+
+if _sre.CODESIZE == 2:
+    MAXCODE = 65535
+else:
+    MAXCODE = 0xFFFFFFFF
+
+def _identityfunction(x):
+    return x
+
+_LITERAL_CODES = set([LITERAL, NOT_LITERAL])
+_REPEATING_CODES = set([REPEAT, MIN_REPEAT, MAX_REPEAT])
+_SUCCESS_CODES = set([SUCCESS, FAILURE])
+_ASSERT_CODES = set([ASSERT, ASSERT_NOT])
+
+def _compile(code, pattern, flags):
+    # internal: compile a (sub)pattern
+    emit = code.append
+    _len = len
+    LITERAL_CODES = _LITERAL_CODES
+    REPEATING_CODES = _REPEATING_CODES
+    SUCCESS_CODES = _SUCCESS_CODES
+    ASSERT_CODES = _ASSERT_CODES
+    for op, av in pattern:
+        if op in LITERAL_CODES:
+            if flags & SRE_FLAG_IGNORECASE:
+                emit(OPCODES[OP_IGNORE[op]])
+                emit(_sre.getlower(av, flags))
+            else:
+                emit(OPCODES[op])
+                emit(av)
+        elif op is IN:
+            if flags & SRE_FLAG_IGNORECASE:
+                emit(OPCODES[OP_IGNORE[op]])
+                def fixup(literal, flags=flags):
+                    return _sre.getlower(literal, flags)
+            else:
+                emit(OPCODES[op])
+                fixup = _identityfunction
+            skip = _len(code); emit(0)
+            _compile_charset(av, flags, code, fixup)
+            code[skip] = _len(code) - skip
+        elif op is ANY:
+            if flags & SRE_FLAG_DOTALL:
+                emit(OPCODES[ANY_ALL])
+            else:
+                emit(OPCODES[ANY])
+        elif op in REPEATING_CODES:
+            if flags & SRE_FLAG_TEMPLATE:
+                raise error("internal: unsupported template operator")
+                emit(OPCODES[REPEAT])
+                skip = _len(code); emit(0)
+                emit(av[0])
+                emit(av[1])
+                _compile(code, av[2], flags)
+                emit(OPCODES[SUCCESS])
+                code[skip] = _len(code) - skip
+            elif _simple(av) and op is not REPEAT:
+                if op is MAX_REPEAT:
+                    emit(OPCODES[REPEAT_ONE])
+                else:
+                    emit(OPCODES[MIN_REPEAT_ONE])
+                skip = _len(code); emit(0)
+                emit(av[0])
+                emit(av[1])
+                _compile(code, av[2], flags)
+                emit(OPCODES[SUCCESS])
+                code[skip] = _len(code) - skip
+            else:
+                emit(OPCODES[REPEAT])
+                skip = _len(code); emit(0)
+                emit(av[0])
+                emit(av[1])
+                _compile(code, av[2], flags)
+                code[skip] = _len(code) - skip
+                if op is MAX_REPEAT:
+                    emit(OPCODES[MAX_UNTIL])
+                else:
+                    emit(OPCODES[MIN_UNTIL])
+        elif op is SUBPATTERN:
+            if av[0]:
+                emit(OPCODES[MARK])
+                emit((av[0]-1)*2)
+            # _compile_info(code, av[1], flags)
+            _compile(code, av[1], flags)
+            if av[0]:
+                emit(OPCODES[MARK])
+                emit((av[0]-1)*2+1)
+        elif op in SUCCESS_CODES:
+            emit(OPCODES[op])
+        elif op in ASSERT_CODES:
+            emit(OPCODES[op])
+            skip = _len(code); emit(0)
+            if av[0] >= 0:
+                emit(0) # look ahead
+            else:
+                lo, hi = av[1].getwidth()
+                if lo != hi:
+                    raise error("look-behind requires fixed-width pattern")
+                emit(lo) # look behind
+            _compile(code, av[1], flags)
+            emit(OPCODES[SUCCESS])
+            code[skip] = _len(code) - skip
+        elif op is CALL:
+            emit(OPCODES[op])
+            skip = _len(code); emit(0)
+            _compile(code, av, flags)
+            emit(OPCODES[SUCCESS])
+            code[skip] = _len(code) - skip
+        elif op is AT:
+            emit(OPCODES[op])
+            if flags & SRE_FLAG_MULTILINE:
+                av = AT_MULTILINE.get(av, av)
+            if flags & SRE_FLAG_LOCALE:
+                av = AT_LOCALE.get(av, av)
+            elif flags & SRE_FLAG_UNICODE:
+                av = AT_UNICODE.get(av, av)
+            emit(ATCODES[av])
+        elif op is BRANCH:
+            emit(OPCODES[op])
+            tail = []
+            tailappend = tail.append
+            for av in av[1]:
+                skip = _len(code); emit(0)
+                # _compile_info(code, av, flags)
+                _compile(code, av, flags)
+                emit(OPCODES[JUMP])
+                tailappend(_len(code)); emit(0)
+                code[skip] = _len(code) - skip
+            emit(0) # end of branch
+            for tail in tail:
+                code[tail] = _len(code) - tail
+        elif op is CATEGORY:
+            emit(OPCODES[op])
+            if flags & SRE_FLAG_LOCALE:
+                av = CH_LOCALE[av]
+            elif flags & SRE_FLAG_UNICODE:
+                av = CH_UNICODE[av]
+            emit(CHCODES[av])
+        elif op is GROUPREF:
+            if flags & SRE_FLAG_IGNORECASE:
+                emit(OPCODES[OP_IGNORE[op]])
+            else:
+                emit(OPCODES[op])
+            emit(av-1)
+        elif op is GROUPREF_EXISTS:
+            emit(OPCODES[op])
+            emit(av[0]-1)
+            skipyes = _len(code); emit(0)
+            _compile(code, av[1], flags)
+            if av[2]:
+                emit(OPCODES[JUMP])
+                skipno = _len(code); emit(0)
+                code[skipyes] = _len(code) - skipyes + 1
+                _compile(code, av[2], flags)
+                code[skipno] = _len(code) - skipno
+            else:
+                code[skipyes] = _len(code) - skipyes + 1
+        else:
+            raise ValueError("unsupported operand type", op)
+
+def _compile_charset(charset, flags, code, fixup=None):
+    # compile charset subprogram
+    emit = code.append
+    if fixup is None:
+        fixup = _identityfunction
+    for op, av in _optimize_charset(charset, fixup):
+        emit(OPCODES[op])
+        if op is NEGATE:
+            pass
+        elif op is LITERAL:
+            emit(fixup(av))
+        elif op is RANGE:
+            emit(fixup(av[0]))
+            emit(fixup(av[1]))
+        elif op is CHARSET:
+            code.extend(av)
+        elif op is BIGCHARSET:
+            code.extend(av)
+        elif op is CATEGORY:
+            if flags & SRE_FLAG_LOCALE:
+                emit(CHCODES[CH_LOCALE[av]])
+            elif flags & SRE_FLAG_UNICODE:
+                emit(CHCODES[CH_UNICODE[av]])
+            else:
+                emit(CHCODES[av])
+        else:
+            raise error("internal: unsupported set operator")
+    emit(OPCODES[FAILURE])
+
+def _optimize_charset(charset, fixup):
+    # internal: optimize character set
+    out = []
+    outappend = out.append
+    charmap = [0]*256
+    try:
+        for op, av in charset:
+            if op is NEGATE:
+                outappend((op, av))
+            elif op is LITERAL:
+                charmap[fixup(av)] = 1
+            elif op is RANGE:
+                for i in range(fixup(av[0]), fixup(av[1])+1):
+                    charmap[i] = 1
+            elif op is CATEGORY:
+                # XXX: could append to charmap tail
+                return charset # cannot compress
+    except IndexError:
+        # character set contains unicode characters
+        return _optimize_unicode(charset, fixup)
+    # compress character map
+    i = p = n = 0
+    runs = []
+    runsappend = runs.append
+    for c in charmap:
+        if c:
+            if n == 0:
+                p = i
+            n = n + 1
+        elif n:
+            runsappend((p, n))
+            n = 0
+        i = i + 1
+    if n:
+        runsappend((p, n))
+    if len(runs) <= 2:
+        # use literal/range
+        for p, n in runs:
+            if n == 1:
+                outappend((LITERAL, p))
+            else:
+                outappend((RANGE, (p, p+n-1)))
+        if len(out) < len(charset):
+            return out
+    else:
+        # use bitmap
+        data = _mk_bitmap(charmap)
+        outappend((CHARSET, data))
+        return out
+    return charset
+
+def _mk_bitmap(bits):
+    data = []
+    dataappend = data.append
+    if _sre.CODESIZE == 2:
+        start = (1, 0)
+    else:
+        start = (1, 0)
+    m, v = start
+    for c in bits:
+        if c:
+            v = v + m
+        m = m + m
+        if m > MAXCODE:
+            dataappend(v)
+            m, v = start
+    return data
+
+# To represent a big charset, first a bitmap of all characters in the
+# set is constructed. Then, this bitmap is sliced into chunks of 256
+# characters, duplicate chunks are eliminated, and each chunk is
+# given a number. In the compiled expression, the charset is
+# represented by a 16-bit word sequence, consisting of one word for
+# the number of different chunks, a sequence of 256 bytes (128 words)
+# of chunk numbers indexed by their original chunk position, and a
+# sequence of chunks (16 words each).
+
+# Compression is normally good: in a typical charset, large ranges of
+# Unicode will be either completely excluded (e.g. if only cyrillic
+# letters are to be matched), or completely included (e.g. if large
+# subranges of Kanji match). These ranges will be represented by
+# chunks of all one-bits or all zero-bits.
+
+# Matching can be also done efficiently: the more significant byte of
+# the Unicode character is an index into the chunk number, and the
+# less significant byte is a bit index in the chunk (just like the
+# CHARSET matching).
+
+# In UCS-4 mode, the BIGCHARSET opcode still supports only subsets
+# of the basic multilingual plane; an efficient representation
+# for all of UTF-16 has not yet been developed. This means,
+# in particular, that negated charsets cannot be represented as
+# bigcharsets.
+
+def _optimize_unicode(charset, fixup):
+    try:
+        import array
+    except ImportError:
+        return charset
+    charmap = [0]*65536
+    negate = 0
+    try:
+        for op, av in charset:
+            if op is NEGATE:
+                negate = 1
+            elif op is LITERAL:
+                charmap[fixup(av)] = 1
+            elif op is RANGE:
+                for i in range(fixup(av[0]), fixup(av[1])+1):
+                    charmap[i] = 1
+            elif op is CATEGORY:
+                # XXX: could expand category
+                return charset # cannot compress
+    except IndexError:
+        # non-BMP characters
+        return charset
+    if negate:
+        if sys.maxunicode != 65535:
+            # XXX: negation does not work with big charsets
+            return charset
+        for i in range(65536):
+            charmap[i] = not charmap[i]
+    comps = {}
+    mapping = [0]*256
+    block = 0
+    data = []
+    for i in range(256):
+        chunk = tuple(charmap[i*256:(i+1)*256])
+        new = comps.setdefault(chunk, block)
+        mapping[i] = new
+        if new == block:
+            block = block + 1
+            data = data + _mk_bitmap(chunk)
+    header = [block]
+    if _sre.CODESIZE == 2:
+        code = 'H'
+    else:
+        code = 'I'
+    # Convert block indices to byte array of 256 bytes
+    mapping = array.array('b', mapping).tostring()
+    # Convert byte array to word array
+    mapping = array.array(code, mapping)
+    assert mapping.itemsize == _sre.CODESIZE
+    assert len(mapping) * mapping.itemsize == 256
+    header = header + mapping.tolist()
+    data[0:0] = header
+    return [(BIGCHARSET, data)]
+
+def _simple(av):
+    # check if av is a "simple" operator
+    lo, hi = av[2].getwidth()
+    if lo == 0 and hi == MAXREPEAT:
+        raise error("nothing to repeat")
+    return lo == hi == 1 and av[2][0][0] != SUBPATTERN
+
+def _compile_info(code, pattern, flags):
+    # internal: compile an info block.  in the current version,
+    # this contains min/max pattern width, and an optional literal
+    # prefix or a character map
+    lo, hi = pattern.getwidth()
+    if lo == 0:
+        return # not worth it
+    # look for a literal prefix
+    prefix = []
+    prefixappend = prefix.append
+    prefix_skip = 0
+    charset = [] # not used
+    charsetappend = charset.append
+    if not (flags & SRE_FLAG_IGNORECASE):
+        # look for literal prefix
+        for op, av in pattern.data:
+            if op is LITERAL:
+                if len(prefix) == prefix_skip:
+                    prefix_skip = prefix_skip + 1
+                prefixappend(av)
+            elif op is SUBPATTERN and len(av[1]) == 1:
+                op, av = av[1][0]
+                if op is LITERAL:
+                    prefixappend(av)
+                else:
+                    break
+            else:
+                break
+        # if no prefix, look for charset prefix
+        if not prefix and pattern.data:
+            op, av = pattern.data[0]
+            if op is SUBPATTERN and av[1]:
+                op, av = av[1][0]
+                if op is LITERAL:
+                    charsetappend((op, av))
+                elif op is BRANCH:
+                    c = []
+                    cappend = c.append
+                    for p in av[1]:
+                        if not p:
+                            break
+                        op, av = p[0]
+                        if op is LITERAL:
+                            cappend((op, av))
+                        else:
+                            break
+                    else:
+                        charset = c
+            elif op is BRANCH:
+                c = []
+                cappend = c.append
+                for p in av[1]:
+                    if not p:
+                        break
+                    op, av = p[0]
+                    if op is LITERAL:
+                        cappend((op, av))
+                    else:
+                        break
+                else:
+                    charset = c
+            elif op is IN:
+                charset = av
+##     if prefix:
+##         print "*** PREFIX", prefix, prefix_skip
+##     if charset:
+##         print "*** CHARSET", charset
+    # add an info block
+    emit = code.append
+    emit(OPCODES[INFO])
+    skip = len(code); emit(0)
+    # literal flag
+    mask = 0
+    if prefix:
+        mask = SRE_INFO_PREFIX
+        if len(prefix) == prefix_skip == len(pattern.data):
+            mask = mask + SRE_INFO_LITERAL
+    elif charset:
+        mask = mask + SRE_INFO_CHARSET
+    emit(mask)
+    # pattern length
+    if lo < MAXCODE:
+        emit(lo)
+    else:
+        emit(MAXCODE)
+        prefix = prefix[:MAXCODE]
+    if hi < MAXCODE:
+        emit(hi)
+    else:
+        emit(0)
+    # add literal prefix
+    if prefix:
+        emit(len(prefix)) # length
+        emit(prefix_skip) # skip
+        code.extend(prefix)
+        # generate overlap table
+        table = [-1] + ([0]*len(prefix))
+        for i in range(len(prefix)):
+            table[i+1] = table[i]+1
+            while table[i+1] > 0 and prefix[i] != prefix[table[i+1]-1]:
+                table[i+1] = table[table[i+1]-1]+1
+        code.extend(table[1:]) # don't store first entry
+    elif charset:
+        _compile_charset(charset, flags, code)
+    code[skip] = len(code) - skip
+
+def isstring(obj):
+    return isinstance(obj, (str, bytes))
+
+def _code(p, flags):
+
+    flags = p.pattern.flags | flags
+    code = []
+
+    # compile info block
+    _compile_info(code, p, flags)
+
+    # compile the pattern
+    _compile(code, p.data, flags)
+
+    code.append(OPCODES[SUCCESS])
+
+    return code
+
+def compile(p, flags=0):
+    # internal: convert pattern list to internal format
+
+    if isstring(p):
+        pattern = p
+        p = sre_parse.parse(p, flags)
+    else:
+        pattern = None
+
+    code = _code(p, flags)
+
+    # print code
+
+    # XXX: <fl> get rid of this limitation!
+    if p.pattern.groups > 100:
+        raise AssertionError(
+            "sorry, but this version only supports 100 named groups"
+            )
+
+    # map in either direction
+    groupindex = p.pattern.groupdict
+    indexgroup = [None] * p.pattern.groups
+    for k, i in groupindex.items():
+        indexgroup[i] = k
+
+    return _sre.compile(
+        pattern, flags | p.pattern.flags, code,
+        p.pattern.groups-1,
+        groupindex, indexgroup
+        )

--- a/Lib/sre_compile.py
+++ b/Lib/sre_compile.py
@@ -10,24 +10,56 @@
 
 """Internal support module for sre"""
 
-import _sre, sys
+import _sre
 import sre_parse
 from sre_constants import *
 
 assert _sre.MAGIC == MAGIC, "SRE module mismatch"
 
-if _sre.CODESIZE == 2:
-    MAXCODE = 65535
-else:
-    MAXCODE = 0xFFFFFFFF
+_LITERAL_CODES = {LITERAL, NOT_LITERAL}
+_REPEATING_CODES = {REPEAT, MIN_REPEAT, MAX_REPEAT}
+_SUCCESS_CODES = {SUCCESS, FAILURE}
+_ASSERT_CODES = {ASSERT, ASSERT_NOT}
 
-def _identityfunction(x):
-    return x
+# Sets of lowercase characters which have the same uppercase.
+_equivalences = (
+    # LATIN SMALL LETTER I, LATIN SMALL LETTER DOTLESS I
+    (0x69, 0x131), # iı
+    # LATIN SMALL LETTER S, LATIN SMALL LETTER LONG S
+    (0x73, 0x17f), # sſ
+    # MICRO SIGN, GREEK SMALL LETTER MU
+    (0xb5, 0x3bc), # µμ
+    # COMBINING GREEK YPOGEGRAMMENI, GREEK SMALL LETTER IOTA, GREEK PROSGEGRAMMENI
+    (0x345, 0x3b9, 0x1fbe), # \u0345ιι
+    # GREEK SMALL LETTER IOTA WITH DIALYTIKA AND TONOS, GREEK SMALL LETTER IOTA WITH DIALYTIKA AND OXIA
+    (0x390, 0x1fd3), # ΐΐ
+    # GREEK SMALL LETTER UPSILON WITH DIALYTIKA AND TONOS, GREEK SMALL LETTER UPSILON WITH DIALYTIKA AND OXIA
+    (0x3b0, 0x1fe3), # ΰΰ
+    # GREEK SMALL LETTER BETA, GREEK BETA SYMBOL
+    (0x3b2, 0x3d0), # βϐ
+    # GREEK SMALL LETTER EPSILON, GREEK LUNATE EPSILON SYMBOL
+    (0x3b5, 0x3f5), # εϵ
+    # GREEK SMALL LETTER THETA, GREEK THETA SYMBOL
+    (0x3b8, 0x3d1), # θϑ
+    # GREEK SMALL LETTER KAPPA, GREEK KAPPA SYMBOL
+    (0x3ba, 0x3f0), # κϰ
+    # GREEK SMALL LETTER PI, GREEK PI SYMBOL
+    (0x3c0, 0x3d6), # πϖ
+    # GREEK SMALL LETTER RHO, GREEK RHO SYMBOL
+    (0x3c1, 0x3f1), # ρϱ
+    # GREEK SMALL LETTER FINAL SIGMA, GREEK SMALL LETTER SIGMA
+    (0x3c2, 0x3c3), # ςσ
+    # GREEK SMALL LETTER PHI, GREEK PHI SYMBOL
+    (0x3c6, 0x3d5), # φϕ
+    # LATIN SMALL LETTER S WITH DOT ABOVE, LATIN SMALL LETTER LONG S WITH DOT ABOVE
+    (0x1e61, 0x1e9b), # ṡẛ
+    # LATIN SMALL LIGATURE LONG S T, LATIN SMALL LIGATURE ST
+    (0xfb05, 0xfb06), # ﬅﬆ
+)
 
-_LITERAL_CODES = set([LITERAL, NOT_LITERAL])
-_REPEATING_CODES = set([REPEAT, MIN_REPEAT, MAX_REPEAT])
-_SUCCESS_CODES = set([SUCCESS, FAILURE])
-_ASSERT_CODES = set([ASSERT, ASSERT_NOT])
+# Maps the lowercase code to lowercase codes which have the same uppercase.
+_ignorecase_fixes = {i: tuple(j for j in t if i != j)
+                     for t in _equivalences for i in t}
 
 def _compile(code, pattern, flags):
     # internal: compile a (sub)pattern
@@ -37,75 +69,88 @@ def _compile(code, pattern, flags):
     REPEATING_CODES = _REPEATING_CODES
     SUCCESS_CODES = _SUCCESS_CODES
     ASSERT_CODES = _ASSERT_CODES
+    if (flags & SRE_FLAG_IGNORECASE and
+            not (flags & SRE_FLAG_LOCALE) and
+            flags & SRE_FLAG_UNICODE and
+            not (flags & SRE_FLAG_ASCII)):
+        fixes = _ignorecase_fixes
+    else:
+        fixes = None
     for op, av in pattern:
         if op in LITERAL_CODES:
             if flags & SRE_FLAG_IGNORECASE:
-                emit(OPCODES[OP_IGNORE[op]])
-                emit(_sre.getlower(av, flags))
+                lo = _sre.getlower(av, flags)
+                if fixes and lo in fixes:
+                    emit(IN_IGNORE)
+                    skip = _len(code); emit(0)
+                    if op is NOT_LITERAL:
+                        emit(NEGATE)
+                    for k in (lo,) + fixes[lo]:
+                        emit(LITERAL)
+                        emit(k)
+                    emit(FAILURE)
+                    code[skip] = _len(code) - skip
+                else:
+                    emit(OP_IGNORE[op])
+                    emit(lo)
             else:
-                emit(OPCODES[op])
+                emit(op)
                 emit(av)
         elif op is IN:
             if flags & SRE_FLAG_IGNORECASE:
-                emit(OPCODES[OP_IGNORE[op]])
+                emit(OP_IGNORE[op])
                 def fixup(literal, flags=flags):
                     return _sre.getlower(literal, flags)
             else:
-                emit(OPCODES[op])
-                fixup = _identityfunction
+                emit(op)
+                fixup = None
             skip = _len(code); emit(0)
-            _compile_charset(av, flags, code, fixup)
+            _compile_charset(av, flags, code, fixup, fixes)
             code[skip] = _len(code) - skip
         elif op is ANY:
             if flags & SRE_FLAG_DOTALL:
-                emit(OPCODES[ANY_ALL])
+                emit(ANY_ALL)
             else:
-                emit(OPCODES[ANY])
+                emit(ANY)
         elif op in REPEATING_CODES:
             if flags & SRE_FLAG_TEMPLATE:
-                raise error("internal: unsupported template operator")
-                emit(OPCODES[REPEAT])
-                skip = _len(code); emit(0)
-                emit(av[0])
-                emit(av[1])
-                _compile(code, av[2], flags)
-                emit(OPCODES[SUCCESS])
-                code[skip] = _len(code) - skip
+                raise error("internal: unsupported template operator %r" % (op,))
             elif _simple(av) and op is not REPEAT:
                 if op is MAX_REPEAT:
-                    emit(OPCODES[REPEAT_ONE])
+                    emit(REPEAT_ONE)
                 else:
-                    emit(OPCODES[MIN_REPEAT_ONE])
+                    emit(MIN_REPEAT_ONE)
                 skip = _len(code); emit(0)
                 emit(av[0])
                 emit(av[1])
                 _compile(code, av[2], flags)
-                emit(OPCODES[SUCCESS])
+                emit(SUCCESS)
                 code[skip] = _len(code) - skip
             else:
-                emit(OPCODES[REPEAT])
+                emit(REPEAT)
                 skip = _len(code); emit(0)
                 emit(av[0])
                 emit(av[1])
                 _compile(code, av[2], flags)
                 code[skip] = _len(code) - skip
                 if op is MAX_REPEAT:
-                    emit(OPCODES[MAX_UNTIL])
+                    emit(MAX_UNTIL)
                 else:
-                    emit(OPCODES[MIN_UNTIL])
+                    emit(MIN_UNTIL)
         elif op is SUBPATTERN:
-            if av[0]:
-                emit(OPCODES[MARK])
-                emit((av[0]-1)*2)
-            # _compile_info(code, av[1], flags)
-            _compile(code, av[1], flags)
-            if av[0]:
-                emit(OPCODES[MARK])
-                emit((av[0]-1)*2+1)
+            group, add_flags, del_flags, p = av
+            if group:
+                emit(MARK)
+                emit((group-1)*2)
+            # _compile_info(code, p, (flags | add_flags) & ~del_flags)
+            _compile(code, p, (flags | add_flags) & ~del_flags)
+            if group:
+                emit(MARK)
+                emit((group-1)*2+1)
         elif op in SUCCESS_CODES:
-            emit(OPCODES[op])
+            emit(op)
         elif op in ASSERT_CODES:
-            emit(OPCODES[op])
+            emit(op)
             skip = _len(code); emit(0)
             if av[0] >= 0:
                 emit(0) # look ahead
@@ -115,57 +160,57 @@ def _compile(code, pattern, flags):
                     raise error("look-behind requires fixed-width pattern")
                 emit(lo) # look behind
             _compile(code, av[1], flags)
-            emit(OPCODES[SUCCESS])
+            emit(SUCCESS)
             code[skip] = _len(code) - skip
         elif op is CALL:
-            emit(OPCODES[op])
+            emit(op)
             skip = _len(code); emit(0)
             _compile(code, av, flags)
-            emit(OPCODES[SUCCESS])
+            emit(SUCCESS)
             code[skip] = _len(code) - skip
         elif op is AT:
-            emit(OPCODES[op])
+            emit(op)
             if flags & SRE_FLAG_MULTILINE:
                 av = AT_MULTILINE.get(av, av)
             if flags & SRE_FLAG_LOCALE:
                 av = AT_LOCALE.get(av, av)
-            elif flags & SRE_FLAG_UNICODE:
+            elif (flags & SRE_FLAG_UNICODE) and not (flags & SRE_FLAG_ASCII):
                 av = AT_UNICODE.get(av, av)
-            emit(ATCODES[av])
+            emit(av)
         elif op is BRANCH:
-            emit(OPCODES[op])
+            emit(op)
             tail = []
             tailappend = tail.append
             for av in av[1]:
                 skip = _len(code); emit(0)
                 # _compile_info(code, av, flags)
                 _compile(code, av, flags)
-                emit(OPCODES[JUMP])
+                emit(JUMP)
                 tailappend(_len(code)); emit(0)
                 code[skip] = _len(code) - skip
-            emit(0) # end of branch
+            emit(FAILURE) # end of branch
             for tail in tail:
                 code[tail] = _len(code) - tail
         elif op is CATEGORY:
-            emit(OPCODES[op])
+            emit(op)
             if flags & SRE_FLAG_LOCALE:
                 av = CH_LOCALE[av]
-            elif flags & SRE_FLAG_UNICODE:
+            elif (flags & SRE_FLAG_UNICODE) and not (flags & SRE_FLAG_ASCII):
                 av = CH_UNICODE[av]
-            emit(CHCODES[av])
+            emit(av)
         elif op is GROUPREF:
             if flags & SRE_FLAG_IGNORECASE:
-                emit(OPCODES[OP_IGNORE[op]])
+                emit(OP_IGNORE[op])
             else:
-                emit(OPCODES[op])
+                emit(op)
             emit(av-1)
         elif op is GROUPREF_EXISTS:
-            emit(OPCODES[op])
+            emit(op)
             emit(av[0]-1)
             skipyes = _len(code); emit(0)
             _compile(code, av[1], flags)
             if av[2]:
-                emit(OPCODES[JUMP])
+                emit(JUMP)
                 skipno = _len(code); emit(0)
                 code[skipyes] = _len(code) - skipyes + 1
                 _compile(code, av[2], flags)
@@ -173,225 +218,235 @@ def _compile(code, pattern, flags):
             else:
                 code[skipyes] = _len(code) - skipyes + 1
         else:
-            raise ValueError("unsupported operand type", op)
+            raise error("internal: unsupported operand type %r" % (op,))
 
-def _compile_charset(charset, flags, code, fixup=None):
+def _compile_charset(charset, flags, code, fixup=None, fixes=None):
     # compile charset subprogram
     emit = code.append
-    if fixup is None:
-        fixup = _identityfunction
-    for op, av in _optimize_charset(charset, fixup):
-        emit(OPCODES[op])
+    for op, av in _optimize_charset(charset, fixup, fixes):
+        emit(op)
         if op is NEGATE:
             pass
         elif op is LITERAL:
-            emit(fixup(av))
-        elif op is RANGE:
-            emit(fixup(av[0]))
-            emit(fixup(av[1]))
+            emit(av)
+        elif op is RANGE or op is RANGE_IGNORE:
+            emit(av[0])
+            emit(av[1])
         elif op is CHARSET:
             code.extend(av)
         elif op is BIGCHARSET:
             code.extend(av)
         elif op is CATEGORY:
             if flags & SRE_FLAG_LOCALE:
-                emit(CHCODES[CH_LOCALE[av]])
-            elif flags & SRE_FLAG_UNICODE:
-                emit(CHCODES[CH_UNICODE[av]])
+                emit(CH_LOCALE[av])
+            elif (flags & SRE_FLAG_UNICODE) and not (flags & SRE_FLAG_ASCII):
+                emit(CH_UNICODE[av])
             else:
-                emit(CHCODES[av])
+                emit(av)
         else:
-            raise error("internal: unsupported set operator")
-    emit(OPCODES[FAILURE])
+            raise error("internal: unsupported set operator %r" % (op,))
+    emit(FAILURE)
 
-def _optimize_charset(charset, fixup):
+def _optimize_charset(charset, fixup, fixes):
     # internal: optimize character set
     out = []
-    outappend = out.append
-    charmap = [0]*256
-    try:
-        for op, av in charset:
-            if op is NEGATE:
-                outappend((op, av))
-            elif op is LITERAL:
-                charmap[fixup(av)] = 1
-            elif op is RANGE:
-                for i in range(fixup(av[0]), fixup(av[1])+1):
-                    charmap[i] = 1
-            elif op is CATEGORY:
-                # XXX: could append to charmap tail
-                return charset # cannot compress
-    except IndexError:
-        # character set contains unicode characters
-        return _optimize_unicode(charset, fixup)
+    tail = []
+    charmap = bytearray(256)
+    for op, av in charset:
+        while True:
+            try:
+                if op is LITERAL:
+                    if fixup:
+                        lo = fixup(av)
+                        charmap[lo] = 1
+                        if fixes and lo in fixes:
+                            for k in fixes[lo]:
+                                charmap[k] = 1
+                    else:
+                        charmap[av] = 1
+                elif op is RANGE:
+                    r = range(av[0], av[1]+1)
+                    if fixup:
+                        r = map(fixup, r)
+                    if fixup and fixes:
+                        for i in r:
+                            charmap[i] = 1
+                            if i in fixes:
+                                for k in fixes[i]:
+                                    charmap[k] = 1
+                    else:
+                        for i in r:
+                            charmap[i] = 1
+                elif op is NEGATE:
+                    out.append((op, av))
+                else:
+                    tail.append((op, av))
+            except IndexError:
+                if len(charmap) == 256:
+                    # character set contains non-UCS1 character codes
+                    charmap += b'\0' * 0xff00
+                    continue
+                # Character set contains non-BMP character codes.
+                # There are only two ranges of cased non-BMP characters:
+                # 10400-1044F (Deseret) and 118A0-118DF (Warang Citi),
+                # and for both ranges RANGE_IGNORE works.
+                if fixup and op is RANGE:
+                    op = RANGE_IGNORE
+                tail.append((op, av))
+            break
+
     # compress character map
-    i = p = n = 0
     runs = []
-    runsappend = runs.append
-    for c in charmap:
-        if c:
-            if n == 0:
-                p = i
-            n = n + 1
-        elif n:
-            runsappend((p, n))
-            n = 0
-        i = i + 1
-    if n:
-        runsappend((p, n))
-    if len(runs) <= 2:
+    q = 0
+    while True:
+        p = charmap.find(1, q)
+        if p < 0:
+            break
+        if len(runs) >= 2:
+            runs = None
+            break
+        q = charmap.find(0, p)
+        if q < 0:
+            runs.append((p, len(charmap)))
+            break
+        runs.append((p, q))
+    if runs is not None:
         # use literal/range
-        for p, n in runs:
-            if n == 1:
-                outappend((LITERAL, p))
+        for p, q in runs:
+            if q - p == 1:
+                out.append((LITERAL, p))
             else:
-                outappend((RANGE, (p, p+n-1)))
-        if len(out) < len(charset):
+                out.append((RANGE, (p, q - 1)))
+        out += tail
+        # if the case was changed or new representation is more compact
+        if fixup or len(out) < len(charset):
             return out
-    else:
-        # use bitmap
+        # else original character set is good enough
+        return charset
+
+    # use bitmap
+    if len(charmap) == 256:
         data = _mk_bitmap(charmap)
-        outappend((CHARSET, data))
+        out.append((CHARSET, data))
+        out += tail
         return out
-    return charset
 
-def _mk_bitmap(bits):
-    data = []
-    dataappend = data.append
-    if _sre.CODESIZE == 2:
-        start = (1, 0)
-    else:
-        start = (1, 0)
-    m, v = start
-    for c in bits:
-        if c:
-            v = v + m
-        m = m + m
-        if m > MAXCODE:
-            dataappend(v)
-            m, v = start
-    return data
+    # To represent a big charset, first a bitmap of all characters in the
+    # set is constructed. Then, this bitmap is sliced into chunks of 256
+    # characters, duplicate chunks are eliminated, and each chunk is
+    # given a number. In the compiled expression, the charset is
+    # represented by a 32-bit word sequence, consisting of one word for
+    # the number of different chunks, a sequence of 256 bytes (64 words)
+    # of chunk numbers indexed by their original chunk position, and a
+    # sequence of 256-bit chunks (8 words each).
 
-# To represent a big charset, first a bitmap of all characters in the
-# set is constructed. Then, this bitmap is sliced into chunks of 256
-# characters, duplicate chunks are eliminated, and each chunk is
-# given a number. In the compiled expression, the charset is
-# represented by a 16-bit word sequence, consisting of one word for
-# the number of different chunks, a sequence of 256 bytes (128 words)
-# of chunk numbers indexed by their original chunk position, and a
-# sequence of chunks (16 words each).
+    # Compression is normally good: in a typical charset, large ranges of
+    # Unicode will be either completely excluded (e.g. if only cyrillic
+    # letters are to be matched), or completely included (e.g. if large
+    # subranges of Kanji match). These ranges will be represented by
+    # chunks of all one-bits or all zero-bits.
 
-# Compression is normally good: in a typical charset, large ranges of
-# Unicode will be either completely excluded (e.g. if only cyrillic
-# letters are to be matched), or completely included (e.g. if large
-# subranges of Kanji match). These ranges will be represented by
-# chunks of all one-bits or all zero-bits.
+    # Matching can be also done efficiently: the more significant byte of
+    # the Unicode character is an index into the chunk number, and the
+    # less significant byte is a bit index in the chunk (just like the
+    # CHARSET matching).
 
-# Matching can be also done efficiently: the more significant byte of
-# the Unicode character is an index into the chunk number, and the
-# less significant byte is a bit index in the chunk (just like the
-# CHARSET matching).
-
-# In UCS-4 mode, the BIGCHARSET opcode still supports only subsets
-# of the basic multilingual plane; an efficient representation
-# for all of UTF-16 has not yet been developed. This means,
-# in particular, that negated charsets cannot be represented as
-# bigcharsets.
-
-def _optimize_unicode(charset, fixup):
-    try:
-        import array
-    except ImportError:
-        return charset
-    charmap = [0]*65536
-    negate = 0
-    try:
-        for op, av in charset:
-            if op is NEGATE:
-                negate = 1
-            elif op is LITERAL:
-                charmap[fixup(av)] = 1
-            elif op is RANGE:
-                for i in range(fixup(av[0]), fixup(av[1])+1):
-                    charmap[i] = 1
-            elif op is CATEGORY:
-                # XXX: could expand category
-                return charset # cannot compress
-    except IndexError:
-        # non-BMP characters
-        return charset
-    if negate:
-        if sys.maxunicode != 65535:
-            # XXX: negation does not work with big charsets
-            return charset
-        for i in range(65536):
-            charmap[i] = not charmap[i]
+    charmap = bytes(charmap) # should be hashable
     comps = {}
-    mapping = [0]*256
+    mapping = bytearray(256)
     block = 0
-    data = []
-    for i in range(256):
-        chunk = tuple(charmap[i*256:(i+1)*256])
-        new = comps.setdefault(chunk, block)
-        mapping[i] = new
-        if new == block:
-            block = block + 1
-            data = data + _mk_bitmap(chunk)
-    header = [block]
-    if _sre.CODESIZE == 2:
-        code = 'H'
-    else:
-        code = 'I'
-    # Convert block indices to byte array of 256 bytes
-    mapping = array.array('b', mapping).tostring()
-    # Convert byte array to word array
-    mapping = array.array(code, mapping)
-    assert mapping.itemsize == _sre.CODESIZE
-    assert len(mapping) * mapping.itemsize == 256
-    header = header + mapping.tolist()
-    data[0:0] = header
-    return [(BIGCHARSET, data)]
+    data = bytearray()
+    for i in range(0, 65536, 256):
+        chunk = charmap[i: i + 256]
+        if chunk in comps:
+            mapping[i // 256] = comps[chunk]
+        else:
+            mapping[i // 256] = comps[chunk] = block
+            block += 1
+            data += chunk
+    data = _mk_bitmap(data)
+    data[0:0] = [block] + _bytes_to_codes(mapping)
+    out.append((BIGCHARSET, data))
+    out += tail
+    return out
+
+_CODEBITS = _sre.CODESIZE * 8
+MAXCODE = (1 << _CODEBITS) - 1
+_BITS_TRANS = b'0' + b'1' * 255
+def _mk_bitmap(bits, _CODEBITS=_CODEBITS, _int=int):
+    s = bits.translate(_BITS_TRANS)[::-1]
+    return [_int(s[i - _CODEBITS: i], 2)
+            for i in range(len(s), 0, -_CODEBITS)]
+
+def _bytes_to_codes(b):
+    # Convert block indices to word array
+    a = memoryview(b).cast('I')
+    assert a.itemsize == _sre.CODESIZE
+    assert len(a) * a.itemsize == len(b)
+    return a.tolist()
 
 def _simple(av):
     # check if av is a "simple" operator
     lo, hi = av[2].getwidth()
-    if lo == 0 and hi == MAXREPEAT:
-        raise error("nothing to repeat")
     return lo == hi == 1 and av[2][0][0] != SUBPATTERN
 
-def _compile_info(code, pattern, flags):
-    # internal: compile an info block.  in the current version,
-    # this contains min/max pattern width, and an optional literal
-    # prefix or a character map
-    lo, hi = pattern.getwidth()
-    if lo == 0:
-        return # not worth it
-    # look for a literal prefix
+def _generate_overlap_table(prefix):
+    """
+    Generate an overlap table for the following prefix.
+    An overlap table is a table of the same size as the prefix which
+    informs about the potential self-overlap for each index in the prefix:
+    - if overlap[i] == 0, prefix[i:] can't overlap prefix[0:...]
+    - if overlap[i] == k with 0 < k <= i, prefix[i-k+1:i+1] overlaps with
+      prefix[0:k]
+    """
+    table = [0] * len(prefix)
+    for i in range(1, len(prefix)):
+        idx = table[i - 1]
+        while prefix[i] != prefix[idx]:
+            if idx == 0:
+                table[i] = 0
+                break
+            idx = table[idx - 1]
+        else:
+            table[i] = idx + 1
+    return table
+
+def _get_literal_prefix(pattern):
+    # look for literal prefix
     prefix = []
     prefixappend = prefix.append
-    prefix_skip = 0
+    prefix_skip = None
+    for op, av in pattern.data:
+        if op is LITERAL:
+            prefixappend(av)
+        elif op is SUBPATTERN:
+            group, add_flags, del_flags, p = av
+            if add_flags & SRE_FLAG_IGNORECASE:
+                break
+            prefix1, prefix_skip1, got_all = _get_literal_prefix(p)
+            if prefix_skip is None:
+                if group is not None:
+                    prefix_skip = len(prefix)
+                elif prefix_skip1 is not None:
+                    prefix_skip = len(prefix) + prefix_skip1
+            prefix.extend(prefix1)
+            if not got_all:
+                break
+        else:
+            break
+    else:
+        return prefix, prefix_skip, True
+    return prefix, prefix_skip, False
+
+def _get_charset_prefix(pattern):
     charset = [] # not used
     charsetappend = charset.append
-    if not (flags & SRE_FLAG_IGNORECASE):
-        # look for literal prefix
-        for op, av in pattern.data:
-            if op is LITERAL:
-                if len(prefix) == prefix_skip:
-                    prefix_skip = prefix_skip + 1
-                prefixappend(av)
-            elif op is SUBPATTERN and len(av[1]) == 1:
-                op, av = av[1][0]
-                if op is LITERAL:
-                    prefixappend(av)
-                else:
-                    break
-            else:
-                break
-        # if no prefix, look for charset prefix
-        if not prefix and pattern.data:
-            op, av = pattern.data[0]
-            if op is SUBPATTERN and av[1]:
-                op, av = av[1][0]
+    if pattern.data:
+        op, av = pattern.data[0]
+        if op is SUBPATTERN:
+            group, add_flags, del_flags, p = av
+            if p and not (add_flags & SRE_FLAG_IGNORECASE):
+                op, av = p[0]
                 if op is LITERAL:
                     charsetappend((op, av))
                 elif op is BRANCH:
@@ -407,37 +462,59 @@ def _compile_info(code, pattern, flags):
                             break
                     else:
                         charset = c
-            elif op is BRANCH:
-                c = []
-                cappend = c.append
-                for p in av[1]:
-                    if not p:
-                        break
-                    op, av = p[0]
-                    if op is LITERAL:
-                        cappend((op, av))
-                    else:
-                        break
+        elif op is BRANCH:
+            c = []
+            cappend = c.append
+            for p in av[1]:
+                if not p:
+                    break
+                op, av = p[0]
+                if op is LITERAL:
+                    cappend((op, av))
                 else:
-                    charset = c
-            elif op is IN:
-                charset = av
+                    break
+            else:
+                charset = c
+        elif op is IN:
+            charset = av
+    return charset
+
+def _compile_info(code, pattern, flags):
+    # internal: compile an info block.  in the current version,
+    # this contains min/max pattern width, and an optional literal
+    # prefix or a character map
+    lo, hi = pattern.getwidth()
+    if hi > MAXCODE:
+        hi = MAXCODE
+    if lo == 0:
+        code.extend([INFO, 4, 0, lo, hi])
+        return
+    # look for a literal prefix
+    prefix = []
+    prefix_skip = 0
+    charset = [] # not used
+    if not (flags & SRE_FLAG_IGNORECASE):
+        # look for literal prefix
+        prefix, prefix_skip, got_all = _get_literal_prefix(pattern)
+        # if no prefix, look for charset prefix
+        if not prefix:
+            charset = _get_charset_prefix(pattern)
 ##     if prefix:
-##         print "*** PREFIX", prefix, prefix_skip
+##         print("*** PREFIX", prefix, prefix_skip)
 ##     if charset:
-##         print "*** CHARSET", charset
+##         print("*** CHARSET", charset)
     # add an info block
     emit = code.append
-    emit(OPCODES[INFO])
+    emit(INFO)
     skip = len(code); emit(0)
     # literal flag
     mask = 0
     if prefix:
         mask = SRE_INFO_PREFIX
-        if len(prefix) == prefix_skip == len(pattern.data):
-            mask = mask + SRE_INFO_LITERAL
+        if prefix_skip is None and got_all:
+            mask = mask | SRE_INFO_LITERAL
     elif charset:
-        mask = mask + SRE_INFO_CHARSET
+        mask = mask | SRE_INFO_CHARSET
     emit(mask)
     # pattern length
     if lo < MAXCODE:
@@ -445,22 +522,16 @@ def _compile_info(code, pattern, flags):
     else:
         emit(MAXCODE)
         prefix = prefix[:MAXCODE]
-    if hi < MAXCODE:
-        emit(hi)
-    else:
-        emit(0)
+    emit(min(hi, MAXCODE))
     # add literal prefix
     if prefix:
         emit(len(prefix)) # length
+        if prefix_skip is None:
+            prefix_skip =  len(prefix)
         emit(prefix_skip) # skip
         code.extend(prefix)
         # generate overlap table
-        table = [-1] + ([0]*len(prefix))
-        for i in range(len(prefix)):
-            table[i+1] = table[i]+1
-            while table[i+1] > 0 and prefix[i] != prefix[table[i+1]-1]:
-                table[i+1] = table[table[i+1]-1]+1
-        code.extend(table[1:]) # don't store first entry
+        code.extend(_generate_overlap_table(prefix))
     elif charset:
         _compile_charset(charset, flags, code)
     code[skip] = len(code) - skip
@@ -479,7 +550,7 @@ def _code(p, flags):
     # compile the pattern
     _compile(code, p.data, flags)
 
-    code.append(OPCODES[SUCCESS])
+    code.append(SUCCESS)
 
     return code
 
@@ -494,13 +565,7 @@ def compile(p, flags=0):
 
     code = _code(p, flags)
 
-    # print code
-
-    # XXX: <fl> get rid of this limitation!
-    if p.pattern.groups > 100:
-        raise AssertionError(
-            "sorry, but this version only supports 100 named groups"
-            )
+    # print(code)
 
     # map in either direction
     groupindex = p.pattern.groupdict

--- a/Lib/sre_compile.py
+++ b/Lib/sre_compile.py
@@ -380,7 +380,9 @@ def _mk_bitmap(bits, _CODEBITS=_CODEBITS, _int=int):
 
 def _bytes_to_codes(b):
     # Convert block indices to word array
-    a = memoryview(b).cast('I')
+    import array
+    a = array.array('I')
+    a.frombytes(bytes(b))
     assert a.itemsize == _sre.CODESIZE
     assert len(a) * a.itemsize == len(b)
     return a.tolist()

--- a/Lib/sre_constants.py
+++ b/Lib/sre_constants.py
@@ -1,0 +1,262 @@
+#
+# Secret Labs' Regular Expression Engine
+#
+# various symbols used by the regular expression engine.
+# run this script to update the _sre include files!
+#
+# Copyright (c) 1998-2001 by Secret Labs AB.  All rights reserved.
+#
+# See the sre.py file for information on usage and redistribution.
+#
+
+"""Internal support module for sre"""
+
+# update when constants are added or removed
+
+MAGIC = 20031017
+
+# max code word in this release
+
+MAXREPEAT = 65535
+
+# SRE standard exception (access as sre.error)
+# should this really be here?
+
+class error(Exception):
+    pass
+
+# operators
+
+FAILURE = "failure"
+SUCCESS = "success"
+
+ANY = "any"
+ANY_ALL = "any_all"
+ASSERT = "assert"
+ASSERT_NOT = "assert_not"
+AT = "at"
+BIGCHARSET = "bigcharset"
+BRANCH = "branch"
+CALL = "call"
+CATEGORY = "category"
+CHARSET = "charset"
+GROUPREF = "groupref"
+GROUPREF_IGNORE = "groupref_ignore"
+GROUPREF_EXISTS = "groupref_exists"
+IN = "in"
+IN_IGNORE = "in_ignore"
+INFO = "info"
+JUMP = "jump"
+LITERAL = "literal"
+LITERAL_IGNORE = "literal_ignore"
+MARK = "mark"
+MAX_REPEAT = "max_repeat"
+MAX_UNTIL = "max_until"
+MIN_REPEAT = "min_repeat"
+MIN_UNTIL = "min_until"
+NEGATE = "negate"
+NOT_LITERAL = "not_literal"
+NOT_LITERAL_IGNORE = "not_literal_ignore"
+RANGE = "range"
+REPEAT = "repeat"
+REPEAT_ONE = "repeat_one"
+SUBPATTERN = "subpattern"
+MIN_REPEAT_ONE = "min_repeat_one"
+
+# positions
+AT_BEGINNING = "at_beginning"
+AT_BEGINNING_LINE = "at_beginning_line"
+AT_BEGINNING_STRING = "at_beginning_string"
+AT_BOUNDARY = "at_boundary"
+AT_NON_BOUNDARY = "at_non_boundary"
+AT_END = "at_end"
+AT_END_LINE = "at_end_line"
+AT_END_STRING = "at_end_string"
+AT_LOC_BOUNDARY = "at_loc_boundary"
+AT_LOC_NON_BOUNDARY = "at_loc_non_boundary"
+AT_UNI_BOUNDARY = "at_uni_boundary"
+AT_UNI_NON_BOUNDARY = "at_uni_non_boundary"
+
+# categories
+CATEGORY_DIGIT = "category_digit"
+CATEGORY_NOT_DIGIT = "category_not_digit"
+CATEGORY_SPACE = "category_space"
+CATEGORY_NOT_SPACE = "category_not_space"
+CATEGORY_WORD = "category_word"
+CATEGORY_NOT_WORD = "category_not_word"
+CATEGORY_LINEBREAK = "category_linebreak"
+CATEGORY_NOT_LINEBREAK = "category_not_linebreak"
+CATEGORY_LOC_WORD = "category_loc_word"
+CATEGORY_LOC_NOT_WORD = "category_loc_not_word"
+CATEGORY_UNI_DIGIT = "category_uni_digit"
+CATEGORY_UNI_NOT_DIGIT = "category_uni_not_digit"
+CATEGORY_UNI_SPACE = "category_uni_space"
+CATEGORY_UNI_NOT_SPACE = "category_uni_not_space"
+CATEGORY_UNI_WORD = "category_uni_word"
+CATEGORY_UNI_NOT_WORD = "category_uni_not_word"
+CATEGORY_UNI_LINEBREAK = "category_uni_linebreak"
+CATEGORY_UNI_NOT_LINEBREAK = "category_uni_not_linebreak"
+
+OPCODES = [
+
+    # failure=0 success=1 (just because it looks better that way :-)
+    FAILURE, SUCCESS,
+
+    ANY, ANY_ALL,
+    ASSERT, ASSERT_NOT,
+    AT,
+    BRANCH,
+    CALL,
+    CATEGORY,
+    CHARSET, BIGCHARSET,
+    GROUPREF, GROUPREF_EXISTS, GROUPREF_IGNORE,
+    IN, IN_IGNORE,
+    INFO,
+    JUMP,
+    LITERAL, LITERAL_IGNORE,
+    MARK,
+    MAX_UNTIL,
+    MIN_UNTIL,
+    NOT_LITERAL, NOT_LITERAL_IGNORE,
+    NEGATE,
+    RANGE,
+    REPEAT,
+    REPEAT_ONE,
+    SUBPATTERN,
+    MIN_REPEAT_ONE
+
+]
+
+ATCODES = [
+    AT_BEGINNING, AT_BEGINNING_LINE, AT_BEGINNING_STRING, AT_BOUNDARY,
+    AT_NON_BOUNDARY, AT_END, AT_END_LINE, AT_END_STRING,
+    AT_LOC_BOUNDARY, AT_LOC_NON_BOUNDARY, AT_UNI_BOUNDARY,
+    AT_UNI_NON_BOUNDARY
+]
+
+CHCODES = [
+    CATEGORY_DIGIT, CATEGORY_NOT_DIGIT, CATEGORY_SPACE,
+    CATEGORY_NOT_SPACE, CATEGORY_WORD, CATEGORY_NOT_WORD,
+    CATEGORY_LINEBREAK, CATEGORY_NOT_LINEBREAK, CATEGORY_LOC_WORD,
+    CATEGORY_LOC_NOT_WORD, CATEGORY_UNI_DIGIT, CATEGORY_UNI_NOT_DIGIT,
+    CATEGORY_UNI_SPACE, CATEGORY_UNI_NOT_SPACE, CATEGORY_UNI_WORD,
+    CATEGORY_UNI_NOT_WORD, CATEGORY_UNI_LINEBREAK,
+    CATEGORY_UNI_NOT_LINEBREAK
+]
+
+def makedict(list):
+    d = {}
+    i = 0
+    for item in list:
+        d[item] = i
+        i = i + 1
+    return d
+
+OPCODES = makedict(OPCODES)
+ATCODES = makedict(ATCODES)
+CHCODES = makedict(CHCODES)
+
+# replacement operations for "ignore case" mode
+OP_IGNORE = {
+    GROUPREF: GROUPREF_IGNORE,
+    IN: IN_IGNORE,
+    LITERAL: LITERAL_IGNORE,
+    NOT_LITERAL: NOT_LITERAL_IGNORE
+}
+
+AT_MULTILINE = {
+    AT_BEGINNING: AT_BEGINNING_LINE,
+    AT_END: AT_END_LINE
+}
+
+AT_LOCALE = {
+    AT_BOUNDARY: AT_LOC_BOUNDARY,
+    AT_NON_BOUNDARY: AT_LOC_NON_BOUNDARY
+}
+
+AT_UNICODE = {
+    AT_BOUNDARY: AT_UNI_BOUNDARY,
+    AT_NON_BOUNDARY: AT_UNI_NON_BOUNDARY
+}
+
+CH_LOCALE = {
+    CATEGORY_DIGIT: CATEGORY_DIGIT,
+    CATEGORY_NOT_DIGIT: CATEGORY_NOT_DIGIT,
+    CATEGORY_SPACE: CATEGORY_SPACE,
+    CATEGORY_NOT_SPACE: CATEGORY_NOT_SPACE,
+    CATEGORY_WORD: CATEGORY_LOC_WORD,
+    CATEGORY_NOT_WORD: CATEGORY_LOC_NOT_WORD,
+    CATEGORY_LINEBREAK: CATEGORY_LINEBREAK,
+    CATEGORY_NOT_LINEBREAK: CATEGORY_NOT_LINEBREAK
+}
+
+CH_UNICODE = {
+    CATEGORY_DIGIT: CATEGORY_UNI_DIGIT,
+    CATEGORY_NOT_DIGIT: CATEGORY_UNI_NOT_DIGIT,
+    CATEGORY_SPACE: CATEGORY_UNI_SPACE,
+    CATEGORY_NOT_SPACE: CATEGORY_UNI_NOT_SPACE,
+    CATEGORY_WORD: CATEGORY_UNI_WORD,
+    CATEGORY_NOT_WORD: CATEGORY_UNI_NOT_WORD,
+    CATEGORY_LINEBREAK: CATEGORY_UNI_LINEBREAK,
+    CATEGORY_NOT_LINEBREAK: CATEGORY_UNI_NOT_LINEBREAK
+}
+
+# flags
+SRE_FLAG_TEMPLATE = 1 # template mode (disable backtracking)
+SRE_FLAG_IGNORECASE = 2 # case insensitive
+SRE_FLAG_LOCALE = 4 # honour system locale
+SRE_FLAG_MULTILINE = 8 # treat target as multiline string
+SRE_FLAG_DOTALL = 16 # treat target as a single string
+SRE_FLAG_UNICODE = 32 # use unicode "locale"
+SRE_FLAG_VERBOSE = 64 # ignore whitespace and comments
+SRE_FLAG_DEBUG = 128 # debugging
+SRE_FLAG_ASCII = 256 # use ascii "locale"
+
+# flags for INFO primitive
+SRE_INFO_PREFIX = 1 # has prefix
+SRE_INFO_LITERAL = 2 # entire pattern is literal (given by prefix)
+SRE_INFO_CHARSET = 4 # pattern starts with character from given set
+
+if __name__ == "__main__":
+    def dump(f, d, prefix):
+        items = d.items()
+        items.sort(key=lambda a: a[1])
+        for k, v in items:
+            f.write("#define %s_%s %s\n" % (prefix, k.upper(), v))
+    f = open("sre_constants.h", "w")
+    f.write("""\
+/*
+ * Secret Labs' Regular Expression Engine
+ *
+ * regular expression matching engine
+ *
+ * NOTE: This file is generated by sre_constants.py.  If you need
+ * to change anything in here, edit sre_constants.py and run it.
+ *
+ * Copyright (c) 1997-2001 by Secret Labs AB.  All rights reserved.
+ *
+ * See the _sre.c file for information on usage and redistribution.
+ */
+
+""")
+
+    f.write("#define SRE_MAGIC %d\n" % MAGIC)
+
+    dump(f, OPCODES, "SRE_OP")
+    dump(f, ATCODES, "SRE")
+    dump(f, CHCODES, "SRE")
+
+    f.write("#define SRE_FLAG_TEMPLATE %d\n" % SRE_FLAG_TEMPLATE)
+    f.write("#define SRE_FLAG_IGNORECASE %d\n" % SRE_FLAG_IGNORECASE)
+    f.write("#define SRE_FLAG_LOCALE %d\n" % SRE_FLAG_LOCALE)
+    f.write("#define SRE_FLAG_MULTILINE %d\n" % SRE_FLAG_MULTILINE)
+    f.write("#define SRE_FLAG_DOTALL %d\n" % SRE_FLAG_DOTALL)
+    f.write("#define SRE_FLAG_UNICODE %d\n" % SRE_FLAG_UNICODE)
+    f.write("#define SRE_FLAG_VERBOSE %d\n" % SRE_FLAG_VERBOSE)
+
+    f.write("#define SRE_INFO_PREFIX %d\n" % SRE_INFO_PREFIX)
+    f.write("#define SRE_INFO_LITERAL %d\n" % SRE_INFO_LITERAL)
+    f.write("#define SRE_INFO_CHARSET %d\n" % SRE_INFO_CHARSET)
+
+    f.close()
+    print("done")

--- a/Lib/sre_constants.py
+++ b/Lib/sre_constants.py
@@ -13,155 +13,115 @@
 
 # update when constants are added or removed
 
-MAGIC = 20031017
+MAGIC = 20140917
 
-# max code word in this release
-
-MAXREPEAT = 65535
+from _sre import MAXREPEAT, MAXGROUPS
 
 # SRE standard exception (access as sre.error)
 # should this really be here?
 
 class error(Exception):
-    pass
+    def __init__(self, msg, pattern=None, pos=None):
+        self.msg = msg
+        self.pattern = pattern
+        self.pos = pos
+        if pattern is not None and pos is not None:
+            msg = '%s at position %d' % (msg, pos)
+            if isinstance(pattern, str):
+                newline = '\n'
+            else:
+                newline = b'\n'
+            self.lineno = pattern.count(newline, 0, pos) + 1
+            self.colno = pos - pattern.rfind(newline, 0, pos)
+            if newline in pattern:
+                msg = '%s (line %d, column %d)' % (msg, self.lineno, self.colno)
+        else:
+            self.lineno = self.colno = None
+        super().__init__(msg)
+
+
+class _NamedIntConstant(int):
+    def __new__(cls, value, name):
+        self = super(_NamedIntConstant, cls).__new__(cls, value)
+        self.name = name
+        return self
+
+    def __str__(self):
+        return self.name
+
+    __repr__ = __str__
+
+MAXREPEAT = _NamedIntConstant(MAXREPEAT, 'MAXREPEAT')
+
+def _makecodes(names):
+    names = names.strip().split()
+    items = [_NamedIntConstant(i, name) for i, name in enumerate(names)]
+    globals().update({item.name: item for item in items})
+    return items
 
 # operators
+# failure=0 success=1 (just because it looks better that way :-)
+OPCODES = _makecodes("""
+    FAILURE SUCCESS
 
-FAILURE = "failure"
-SUCCESS = "success"
+    ANY ANY_ALL
+    ASSERT ASSERT_NOT
+    AT
+    BRANCH
+    CALL
+    CATEGORY
+    CHARSET BIGCHARSET
+    GROUPREF GROUPREF_EXISTS GROUPREF_IGNORE
+    IN IN_IGNORE
+    INFO
+    JUMP
+    LITERAL LITERAL_IGNORE
+    MARK
+    MAX_UNTIL
+    MIN_UNTIL
+    NOT_LITERAL NOT_LITERAL_IGNORE
+    NEGATE
+    RANGE
+    REPEAT
+    REPEAT_ONE
+    SUBPATTERN
+    MIN_REPEAT_ONE
+    RANGE_IGNORE
 
-ANY = "any"
-ANY_ALL = "any_all"
-ASSERT = "assert"
-ASSERT_NOT = "assert_not"
-AT = "at"
-BIGCHARSET = "bigcharset"
-BRANCH = "branch"
-CALL = "call"
-CATEGORY = "category"
-CHARSET = "charset"
-GROUPREF = "groupref"
-GROUPREF_IGNORE = "groupref_ignore"
-GROUPREF_EXISTS = "groupref_exists"
-IN = "in"
-IN_IGNORE = "in_ignore"
-INFO = "info"
-JUMP = "jump"
-LITERAL = "literal"
-LITERAL_IGNORE = "literal_ignore"
-MARK = "mark"
-MAX_REPEAT = "max_repeat"
-MAX_UNTIL = "max_until"
-MIN_REPEAT = "min_repeat"
-MIN_UNTIL = "min_until"
-NEGATE = "negate"
-NOT_LITERAL = "not_literal"
-NOT_LITERAL_IGNORE = "not_literal_ignore"
-RANGE = "range"
-REPEAT = "repeat"
-REPEAT_ONE = "repeat_one"
-SUBPATTERN = "subpattern"
-MIN_REPEAT_ONE = "min_repeat_one"
+    MIN_REPEAT MAX_REPEAT
+""")
+del OPCODES[-2:] # remove MIN_REPEAT and MAX_REPEAT
 
 # positions
-AT_BEGINNING = "at_beginning"
-AT_BEGINNING_LINE = "at_beginning_line"
-AT_BEGINNING_STRING = "at_beginning_string"
-AT_BOUNDARY = "at_boundary"
-AT_NON_BOUNDARY = "at_non_boundary"
-AT_END = "at_end"
-AT_END_LINE = "at_end_line"
-AT_END_STRING = "at_end_string"
-AT_LOC_BOUNDARY = "at_loc_boundary"
-AT_LOC_NON_BOUNDARY = "at_loc_non_boundary"
-AT_UNI_BOUNDARY = "at_uni_boundary"
-AT_UNI_NON_BOUNDARY = "at_uni_non_boundary"
+ATCODES = _makecodes("""
+    AT_BEGINNING AT_BEGINNING_LINE AT_BEGINNING_STRING
+    AT_BOUNDARY AT_NON_BOUNDARY
+    AT_END AT_END_LINE AT_END_STRING
+    AT_LOC_BOUNDARY AT_LOC_NON_BOUNDARY
+    AT_UNI_BOUNDARY AT_UNI_NON_BOUNDARY
+""")
 
 # categories
-CATEGORY_DIGIT = "category_digit"
-CATEGORY_NOT_DIGIT = "category_not_digit"
-CATEGORY_SPACE = "category_space"
-CATEGORY_NOT_SPACE = "category_not_space"
-CATEGORY_WORD = "category_word"
-CATEGORY_NOT_WORD = "category_not_word"
-CATEGORY_LINEBREAK = "category_linebreak"
-CATEGORY_NOT_LINEBREAK = "category_not_linebreak"
-CATEGORY_LOC_WORD = "category_loc_word"
-CATEGORY_LOC_NOT_WORD = "category_loc_not_word"
-CATEGORY_UNI_DIGIT = "category_uni_digit"
-CATEGORY_UNI_NOT_DIGIT = "category_uni_not_digit"
-CATEGORY_UNI_SPACE = "category_uni_space"
-CATEGORY_UNI_NOT_SPACE = "category_uni_not_space"
-CATEGORY_UNI_WORD = "category_uni_word"
-CATEGORY_UNI_NOT_WORD = "category_uni_not_word"
-CATEGORY_UNI_LINEBREAK = "category_uni_linebreak"
-CATEGORY_UNI_NOT_LINEBREAK = "category_uni_not_linebreak"
+CHCODES = _makecodes("""
+    CATEGORY_DIGIT CATEGORY_NOT_DIGIT
+    CATEGORY_SPACE CATEGORY_NOT_SPACE
+    CATEGORY_WORD CATEGORY_NOT_WORD
+    CATEGORY_LINEBREAK CATEGORY_NOT_LINEBREAK
+    CATEGORY_LOC_WORD CATEGORY_LOC_NOT_WORD
+    CATEGORY_UNI_DIGIT CATEGORY_UNI_NOT_DIGIT
+    CATEGORY_UNI_SPACE CATEGORY_UNI_NOT_SPACE
+    CATEGORY_UNI_WORD CATEGORY_UNI_NOT_WORD
+    CATEGORY_UNI_LINEBREAK CATEGORY_UNI_NOT_LINEBREAK
+""")
 
-OPCODES = [
-
-    # failure=0 success=1 (just because it looks better that way :-)
-    FAILURE, SUCCESS,
-
-    ANY, ANY_ALL,
-    ASSERT, ASSERT_NOT,
-    AT,
-    BRANCH,
-    CALL,
-    CATEGORY,
-    CHARSET, BIGCHARSET,
-    GROUPREF, GROUPREF_EXISTS, GROUPREF_IGNORE,
-    IN, IN_IGNORE,
-    INFO,
-    JUMP,
-    LITERAL, LITERAL_IGNORE,
-    MARK,
-    MAX_UNTIL,
-    MIN_UNTIL,
-    NOT_LITERAL, NOT_LITERAL_IGNORE,
-    NEGATE,
-    RANGE,
-    REPEAT,
-    REPEAT_ONE,
-    SUBPATTERN,
-    MIN_REPEAT_ONE
-
-]
-
-ATCODES = [
-    AT_BEGINNING, AT_BEGINNING_LINE, AT_BEGINNING_STRING, AT_BOUNDARY,
-    AT_NON_BOUNDARY, AT_END, AT_END_LINE, AT_END_STRING,
-    AT_LOC_BOUNDARY, AT_LOC_NON_BOUNDARY, AT_UNI_BOUNDARY,
-    AT_UNI_NON_BOUNDARY
-]
-
-CHCODES = [
-    CATEGORY_DIGIT, CATEGORY_NOT_DIGIT, CATEGORY_SPACE,
-    CATEGORY_NOT_SPACE, CATEGORY_WORD, CATEGORY_NOT_WORD,
-    CATEGORY_LINEBREAK, CATEGORY_NOT_LINEBREAK, CATEGORY_LOC_WORD,
-    CATEGORY_LOC_NOT_WORD, CATEGORY_UNI_DIGIT, CATEGORY_UNI_NOT_DIGIT,
-    CATEGORY_UNI_SPACE, CATEGORY_UNI_NOT_SPACE, CATEGORY_UNI_WORD,
-    CATEGORY_UNI_NOT_WORD, CATEGORY_UNI_LINEBREAK,
-    CATEGORY_UNI_NOT_LINEBREAK
-]
-
-def makedict(list):
-    d = {}
-    i = 0
-    for item in list:
-        d[item] = i
-        i = i + 1
-    return d
-
-OPCODES = makedict(OPCODES)
-ATCODES = makedict(ATCODES)
-CHCODES = makedict(CHCODES)
 
 # replacement operations for "ignore case" mode
 OP_IGNORE = {
     GROUPREF: GROUPREF_IGNORE,
     IN: IN_IGNORE,
     LITERAL: LITERAL_IGNORE,
-    NOT_LITERAL: NOT_LITERAL_IGNORE
+    NOT_LITERAL: NOT_LITERAL_IGNORE,
+    RANGE: RANGE_IGNORE,
 }
 
 AT_MULTILINE = {
@@ -219,12 +179,11 @@ SRE_INFO_CHARSET = 4 # pattern starts with character from given set
 
 if __name__ == "__main__":
     def dump(f, d, prefix):
-        items = d.items()
-        items.sort(key=lambda a: a[1])
-        for k, v in items:
-            f.write("#define %s_%s %s\n" % (prefix, k.upper(), v))
-    f = open("sre_constants.h", "w")
-    f.write("""\
+        items = sorted(d)
+        for item in items:
+            f.write("#define %s_%s %d\n" % (prefix, item, item))
+    with open("sre_constants.h", "w") as f:
+        f.write("""\
 /*
  * Secret Labs' Regular Expression Engine
  *
@@ -240,23 +199,24 @@ if __name__ == "__main__":
 
 """)
 
-    f.write("#define SRE_MAGIC %d\n" % MAGIC)
+        f.write("#define SRE_MAGIC %d\n" % MAGIC)
 
-    dump(f, OPCODES, "SRE_OP")
-    dump(f, ATCODES, "SRE")
-    dump(f, CHCODES, "SRE")
+        dump(f, OPCODES, "SRE_OP")
+        dump(f, ATCODES, "SRE")
+        dump(f, CHCODES, "SRE")
 
-    f.write("#define SRE_FLAG_TEMPLATE %d\n" % SRE_FLAG_TEMPLATE)
-    f.write("#define SRE_FLAG_IGNORECASE %d\n" % SRE_FLAG_IGNORECASE)
-    f.write("#define SRE_FLAG_LOCALE %d\n" % SRE_FLAG_LOCALE)
-    f.write("#define SRE_FLAG_MULTILINE %d\n" % SRE_FLAG_MULTILINE)
-    f.write("#define SRE_FLAG_DOTALL %d\n" % SRE_FLAG_DOTALL)
-    f.write("#define SRE_FLAG_UNICODE %d\n" % SRE_FLAG_UNICODE)
-    f.write("#define SRE_FLAG_VERBOSE %d\n" % SRE_FLAG_VERBOSE)
+        f.write("#define SRE_FLAG_TEMPLATE %d\n" % SRE_FLAG_TEMPLATE)
+        f.write("#define SRE_FLAG_IGNORECASE %d\n" % SRE_FLAG_IGNORECASE)
+        f.write("#define SRE_FLAG_LOCALE %d\n" % SRE_FLAG_LOCALE)
+        f.write("#define SRE_FLAG_MULTILINE %d\n" % SRE_FLAG_MULTILINE)
+        f.write("#define SRE_FLAG_DOTALL %d\n" % SRE_FLAG_DOTALL)
+        f.write("#define SRE_FLAG_UNICODE %d\n" % SRE_FLAG_UNICODE)
+        f.write("#define SRE_FLAG_VERBOSE %d\n" % SRE_FLAG_VERBOSE)
+        f.write("#define SRE_FLAG_DEBUG %d\n" % SRE_FLAG_DEBUG)
+        f.write("#define SRE_FLAG_ASCII %d\n" % SRE_FLAG_ASCII)
 
-    f.write("#define SRE_INFO_PREFIX %d\n" % SRE_INFO_PREFIX)
-    f.write("#define SRE_INFO_LITERAL %d\n" % SRE_INFO_LITERAL)
-    f.write("#define SRE_INFO_CHARSET %d\n" % SRE_INFO_CHARSET)
+        f.write("#define SRE_INFO_PREFIX %d\n" % SRE_INFO_PREFIX)
+        f.write("#define SRE_INFO_LITERAL %d\n" % SRE_INFO_LITERAL)
+        f.write("#define SRE_INFO_CHARSET %d\n" % SRE_INFO_CHARSET)
 
-    f.close()
     print("done")

--- a/Lib/sre_constants.py
+++ b/Lib/sre_constants.py
@@ -15,7 +15,8 @@
 
 MAGIC = 20140917
 
-from _sre import MAXREPEAT, MAXGROUPS
+MAXGROUPS = 2 ** 31 - 1
+MAXREPEAT = 2 ** 32 - 1
 
 # SRE standard exception (access as sre.error)
 # should this really be here?

--- a/Lib/sre_parse.py
+++ b/Lib/sre_parse.py
@@ -1,0 +1,810 @@
+#
+# Secret Labs' Regular Expression Engine
+#
+# convert re-style regular expression to sre pattern
+#
+# Copyright (c) 1998-2001 by Secret Labs AB.  All rights reserved.
+#
+# See the sre.py file for information on usage and redistribution.
+#
+
+"""Internal support module for sre"""
+
+# XXX: show string offset and offending character for all errors
+
+import sys
+
+from sre_constants import *
+
+SPECIAL_CHARS = ".\\[{()*+?^$|"
+REPEAT_CHARS = "*+?{"
+
+DIGITS = set("0123456789")
+
+OCTDIGITS = set("01234567")
+HEXDIGITS = set("0123456789abcdefABCDEF")
+
+WHITESPACE = set(" \t\n\r\v\f")
+
+ESCAPES = {
+    r"\a": (LITERAL, ord("\a")),
+    r"\b": (LITERAL, ord("\b")),
+    r"\f": (LITERAL, ord("\f")),
+    r"\n": (LITERAL, ord("\n")),
+    r"\r": (LITERAL, ord("\r")),
+    r"\t": (LITERAL, ord("\t")),
+    r"\v": (LITERAL, ord("\v")),
+    r"\\": (LITERAL, ord("\\"))
+}
+
+CATEGORIES = {
+    r"\A": (AT, AT_BEGINNING_STRING), # start of string
+    r"\b": (AT, AT_BOUNDARY),
+    r"\B": (AT, AT_NON_BOUNDARY),
+    r"\d": (IN, [(CATEGORY, CATEGORY_DIGIT)]),
+    r"\D": (IN, [(CATEGORY, CATEGORY_NOT_DIGIT)]),
+    r"\s": (IN, [(CATEGORY, CATEGORY_SPACE)]),
+    r"\S": (IN, [(CATEGORY, CATEGORY_NOT_SPACE)]),
+    r"\w": (IN, [(CATEGORY, CATEGORY_WORD)]),
+    r"\W": (IN, [(CATEGORY, CATEGORY_NOT_WORD)]),
+    r"\Z": (AT, AT_END_STRING), # end of string
+}
+
+FLAGS = {
+    # standard flags
+    "i": SRE_FLAG_IGNORECASE,
+    "L": SRE_FLAG_LOCALE,
+    "m": SRE_FLAG_MULTILINE,
+    "s": SRE_FLAG_DOTALL,
+    "x": SRE_FLAG_VERBOSE,
+    # extensions
+    "a": SRE_FLAG_ASCII,
+    "t": SRE_FLAG_TEMPLATE,
+    "u": SRE_FLAG_UNICODE,
+}
+
+class Pattern:
+    # master pattern object.  keeps track of global attributes
+    def __init__(self):
+        self.flags = 0
+        self.open = []
+        self.groups = 1
+        self.groupdict = {}
+    def opengroup(self, name=None):
+        gid = self.groups
+        self.groups = gid + 1
+        if name is not None:
+            ogid = self.groupdict.get(name, None)
+            if ogid is not None:
+                raise error("redefinition of group name %s as group %d; "
+                            "was group %d" % (repr(name), gid,  ogid))
+            self.groupdict[name] = gid
+        self.open.append(gid)
+        return gid
+    def closegroup(self, gid):
+        self.open.remove(gid)
+    def checkgroup(self, gid):
+        return gid < self.groups and gid not in self.open
+
+class SubPattern:
+    # a subpattern, in intermediate form
+    def __init__(self, pattern, data=None):
+        self.pattern = pattern
+        if data is None:
+            data = []
+        self.data = data
+        self.width = None
+    def dump(self, level=0):
+        nl = 1
+        seqtypes = (tuple, list)
+        for op, av in self.data:
+            print(level*"  " + op, end=' '); nl = 0
+            if op == "in":
+                # member sublanguage
+                print(); nl = 1
+                for op, a in av:
+                    print((level+1)*"  " + op, a)
+            elif op == "branch":
+                print(); nl = 1
+                i = 0
+                for a in av[1]:
+                    if i > 0:
+                        print(level*"  " + "or")
+                    a.dump(level+1); nl = 1
+                    i = i + 1
+            elif isinstance(av, seqtypes):
+                for a in av:
+                    if isinstance(a, SubPattern):
+                        if not nl: print()
+                        a.dump(level+1); nl = 1
+                    else:
+                        print(a, end=' ') ; nl = 0
+            else:
+                print(av, end=' ') ; nl = 0
+            if not nl: print()
+    def __repr__(self):
+        return repr(self.data)
+    def __len__(self):
+        return len(self.data)
+    def __delitem__(self, index):
+        del self.data[index]
+    def __getitem__(self, index):
+        if isinstance(index, slice):
+            return SubPattern(self.pattern, self.data[index])
+        return self.data[index]
+    def __setitem__(self, index, code):
+        self.data[index] = code
+    def insert(self, index, code):
+        self.data.insert(index, code)
+    def append(self, code):
+        self.data.append(code)
+    def getwidth(self):
+        # determine the width (min, max) for this subpattern
+        if self.width:
+            return self.width
+        lo = hi = 0
+        UNITCODES = (ANY, RANGE, IN, LITERAL, NOT_LITERAL, CATEGORY)
+        REPEATCODES = (MIN_REPEAT, MAX_REPEAT)
+        for op, av in self.data:
+            if op is BRANCH:
+                i = sys.maxsize
+                j = 0
+                for av in av[1]:
+                    l, h = av.getwidth()
+                    i = min(i, l)
+                    j = max(j, h)
+                lo = lo + i
+                hi = hi + j
+            elif op is CALL:
+                i, j = av.getwidth()
+                lo = lo + i
+                hi = hi + j
+            elif op is SUBPATTERN:
+                i, j = av[1].getwidth()
+                lo = lo + i
+                hi = hi + j
+            elif op in REPEATCODES:
+                i, j = av[2].getwidth()
+                lo = lo + int(i) * av[0]
+                hi = hi + int(j) * av[1]
+            elif op in UNITCODES:
+                lo = lo + 1
+                hi = hi + 1
+            elif op == SUCCESS:
+                break
+        self.width = int(min(lo, sys.maxsize)), int(min(hi, sys.maxsize))
+        return self.width
+
+class Tokenizer:
+    def __init__(self, string):
+        self.string = string
+        self.index = 0
+        self.__next()
+    def __next(self):
+        if self.index >= len(self.string):
+            self.next = None
+            return
+        char = self.string[self.index:self.index+1]
+        # Special case for the str8, since indexing returns a integer
+        # XXX This is only needed for test_bug_926075 in test_re.py
+        if char and isinstance(char, bytes):
+            char = chr(char[0])
+        if char == "\\":
+            try:
+                c = self.string[self.index + 1]
+            except IndexError:
+                raise error("bogus escape (end of line)")
+            if isinstance(self.string, bytes):
+                c = chr(c)
+            char = char + c
+        self.index = self.index + len(char)
+        self.next = char
+    def match(self, char, skip=1):
+        if char == self.next:
+            if skip:
+                self.__next()
+            return 1
+        return 0
+    def get(self):
+        this = self.next
+        self.__next()
+        return this
+    def tell(self):
+        return self.index, self.next
+    def seek(self, index):
+        self.index, self.next = index
+
+def isident(char):
+    return "a" <= char <= "z" or "A" <= char <= "Z" or char == "_"
+
+def isdigit(char):
+    return "0" <= char <= "9"
+
+def isname(name):
+    # check that group name is a valid string
+    if not isident(name[0]):
+        return False
+    for char in name[1:]:
+        if not isident(char) and not isdigit(char):
+            return False
+    return True
+
+def _class_escape(source, escape):
+    # handle escape code inside character class
+    code = ESCAPES.get(escape)
+    if code:
+        return code
+    code = CATEGORIES.get(escape)
+    if code:
+        return code
+    try:
+        c = escape[1:2]
+        if c == "x":
+            # hexadecimal escape (exactly two digits)
+            while source.next in HEXDIGITS and len(escape) < 4:
+                escape = escape + source.get()
+            escape = escape[2:]
+            if len(escape) != 2:
+                raise error("bogus escape: %s" % repr("\\" + escape))
+            return LITERAL, int(escape, 16) & 0xff
+        elif c in OCTDIGITS:
+            # octal escape (up to three digits)
+            while source.next in OCTDIGITS and len(escape) < 4:
+                escape = escape + source.get()
+            escape = escape[1:]
+            return LITERAL, int(escape, 8) & 0xff
+        elif c in DIGITS:
+            raise error("bogus escape: %s" % repr(escape))
+        if len(escape) == 2:
+            return LITERAL, ord(escape[1])
+    except ValueError:
+        pass
+    raise error("bogus escape: %s" % repr(escape))
+
+def _escape(source, escape, state):
+    # handle escape code in expression
+    code = CATEGORIES.get(escape)
+    if code:
+        return code
+    code = ESCAPES.get(escape)
+    if code:
+        return code
+    try:
+        c = escape[1:2]
+        if c == "x":
+            # hexadecimal escape
+            while source.next in HEXDIGITS and len(escape) < 4:
+                escape = escape + source.get()
+            if len(escape) != 4:
+                raise ValueError
+            return LITERAL, int(escape[2:], 16) & 0xff
+        elif c == "0":
+            # octal escape
+            while source.next in OCTDIGITS and len(escape) < 4:
+                escape = escape + source.get()
+            return LITERAL, int(escape[1:], 8) & 0xff
+        elif c in DIGITS:
+            # octal escape *or* decimal group reference (sigh)
+            if source.next in DIGITS:
+                escape = escape + source.get()
+                if (escape[1] in OCTDIGITS and escape[2] in OCTDIGITS and
+                    source.next in OCTDIGITS):
+                    # got three octal digits; this is an octal escape
+                    escape = escape + source.get()
+                    return LITERAL, int(escape[1:], 8) & 0xff
+            # not an octal escape, so this is a group reference
+            group = int(escape[1:])
+            if group < state.groups:
+                if not state.checkgroup(group):
+                    raise error("cannot refer to open group")
+                return GROUPREF, group
+            raise ValueError
+        if len(escape) == 2:
+            return LITERAL, ord(escape[1])
+    except ValueError:
+        pass
+    raise error("bogus escape: %s" % repr(escape))
+
+def _parse_sub(source, state, nested=1):
+    # parse an alternation: a|b|c
+
+    items = []
+    itemsappend = items.append
+    sourcematch = source.match
+    while 1:
+        itemsappend(_parse(source, state))
+        if sourcematch("|"):
+            continue
+        if not nested:
+            break
+        if not source.next or sourcematch(")", 0):
+            break
+        else:
+            raise error("pattern not properly closed")
+
+    if len(items) == 1:
+        return items[0]
+
+    subpattern = SubPattern(state)
+    subpatternappend = subpattern.append
+
+    # check if all items share a common prefix
+    while 1:
+        prefix = None
+        for item in items:
+            if not item:
+                break
+            if prefix is None:
+                prefix = item[0]
+            elif item[0] != prefix:
+                break
+        else:
+            # all subitems start with a common "prefix".
+            # move it out of the branch
+            for item in items:
+                del item[0]
+            subpatternappend(prefix)
+            continue # check next one
+        break
+
+    # check if the branch can be replaced by a character set
+    for item in items:
+        if len(item) != 1 or item[0][0] != LITERAL:
+            break
+    else:
+        # we can store this as a character set instead of a
+        # branch (the compiler may optimize this even more)
+        set = []
+        setappend = set.append
+        for item in items:
+            setappend(item[0])
+        subpatternappend((IN, set))
+        return subpattern
+
+    subpattern.append((BRANCH, (None, items)))
+    return subpattern
+
+def _parse_sub_cond(source, state, condgroup):
+    item_yes = _parse(source, state)
+    if source.match("|"):
+        item_no = _parse(source, state)
+        if source.match("|"):
+            raise error("conditional backref with more than two branches")
+    else:
+        item_no = None
+    if source.next and not source.match(")", 0):
+        raise error("pattern not properly closed")
+    subpattern = SubPattern(state)
+    subpattern.append((GROUPREF_EXISTS, (condgroup, item_yes, item_no)))
+    return subpattern
+
+_PATTERNENDERS = set("|)")
+_ASSERTCHARS = set("=!<")
+_LOOKBEHINDASSERTCHARS = set("=!")
+_REPEATCODES = set([MIN_REPEAT, MAX_REPEAT])
+
+def _parse(source, state):
+    # parse a simple pattern
+    subpattern = SubPattern(state)
+
+    # precompute constants into local variables
+    subpatternappend = subpattern.append
+    sourceget = source.get
+    sourcematch = source.match
+    _len = len
+    PATTERNENDERS = _PATTERNENDERS
+    ASSERTCHARS = _ASSERTCHARS
+    LOOKBEHINDASSERTCHARS = _LOOKBEHINDASSERTCHARS
+    REPEATCODES = _REPEATCODES
+
+    while 1:
+
+        if source.next in PATTERNENDERS:
+            break # end of subpattern
+        this = sourceget()
+        if this is None:
+            break # end of pattern
+
+        if state.flags & SRE_FLAG_VERBOSE:
+            # skip whitespace and comments
+            if this in WHITESPACE:
+                continue
+            if this == "#":
+                while 1:
+                    this = sourceget()
+                    if this in (None, "\n"):
+                        break
+                continue
+
+        if this and this[0] not in SPECIAL_CHARS:
+            subpatternappend((LITERAL, ord(this)))
+
+        elif this == "[":
+            # character set
+            set = []
+            setappend = set.append
+##          if sourcematch(":"):
+##              pass # handle character classes
+            if sourcematch("^"):
+                setappend((NEGATE, None))
+            # check remaining characters
+            start = set[:]
+            while 1:
+                this = sourceget()
+                if this == "]" and set != start:
+                    break
+                elif this and this[0] == "\\":
+                    code1 = _class_escape(source, this)
+                elif this:
+                    code1 = LITERAL, ord(this)
+                else:
+                    raise error("unexpected end of regular expression")
+                if sourcematch("-"):
+                    # potential range
+                    this = sourceget()
+                    if this == "]":
+                        if code1[0] is IN:
+                            code1 = code1[1][0]
+                        setappend(code1)
+                        setappend((LITERAL, ord("-")))
+                        break
+                    elif this:
+                        if this[0] == "\\":
+                            code2 = _class_escape(source, this)
+                        else:
+                            code2 = LITERAL, ord(this)
+                        if code1[0] != LITERAL or code2[0] != LITERAL:
+                            raise error("bad character range")
+                        lo = code1[1]
+                        hi = code2[1]
+                        if hi < lo:
+                            raise error("bad character range")
+                        setappend((RANGE, (lo, hi)))
+                    else:
+                        raise error("unexpected end of regular expression")
+                else:
+                    if code1[0] is IN:
+                        code1 = code1[1][0]
+                    setappend(code1)
+
+            # XXX: <fl> should move set optimization to compiler!
+            if _len(set)==1 and set[0][0] is LITERAL:
+                subpatternappend(set[0]) # optimization
+            elif _len(set)==2 and set[0][0] is NEGATE and set[1][0] is LITERAL:
+                subpatternappend((NOT_LITERAL, set[1][1])) # optimization
+            else:
+                # XXX: <fl> should add charmap optimization here
+                subpatternappend((IN, set))
+
+        elif this and this[0] in REPEAT_CHARS:
+            # repeat previous item
+            if this == "?":
+                min, max = 0, 1
+            elif this == "*":
+                min, max = 0, MAXREPEAT
+
+            elif this == "+":
+                min, max = 1, MAXREPEAT
+            elif this == "{":
+                if source.next == "}":
+                    subpatternappend((LITERAL, ord(this)))
+                    continue
+                here = source.tell()
+                min, max = 0, MAXREPEAT
+                lo = hi = ""
+                while source.next in DIGITS:
+                    lo = lo + source.get()
+                if sourcematch(","):
+                    while source.next in DIGITS:
+                        hi = hi + sourceget()
+                else:
+                    hi = lo
+                if not sourcematch("}"):
+                    subpatternappend((LITERAL, ord(this)))
+                    source.seek(here)
+                    continue
+                if lo:
+                    min = int(lo)
+                if hi:
+                    max = int(hi)
+                if max < min:
+                    raise error("bad repeat interval")
+            else:
+                raise error("not supported")
+            # figure out which item to repeat
+            if subpattern:
+                item = subpattern[-1:]
+            else:
+                item = None
+            if not item or (_len(item) == 1 and item[0][0] == AT):
+                raise error("nothing to repeat")
+            if item[0][0] in REPEATCODES:
+                raise error("multiple repeat")
+            if sourcematch("?"):
+                subpattern[-1] = (MIN_REPEAT, (min, max, item))
+            else:
+                subpattern[-1] = (MAX_REPEAT, (min, max, item))
+
+        elif this == ".":
+            subpatternappend((ANY, None))
+
+        elif this == "(":
+            group = 1
+            name = None
+            condgroup = None
+            if sourcematch("?"):
+                group = 0
+                # options
+                if sourcematch("P"):
+                    # python extensions
+                    if sourcematch("<"):
+                        # named group: skip forward to end of name
+                        name = ""
+                        while 1:
+                            char = sourceget()
+                            if char is None:
+                                raise error("unterminated name")
+                            if char == ">":
+                                break
+                            name = name + char
+                        group = 1
+                        if not isname(name):
+                            raise error("bad character in group name")
+                    elif sourcematch("="):
+                        # named backreference
+                        name = ""
+                        while 1:
+                            char = sourceget()
+                            if char is None:
+                                raise error("unterminated name")
+                            if char == ")":
+                                break
+                            name = name + char
+                        if not isname(name):
+                            raise error("bad character in group name")
+                        gid = state.groupdict.get(name)
+                        if gid is None:
+                            raise error("unknown group name")
+                        subpatternappend((GROUPREF, gid))
+                        continue
+                    else:
+                        char = sourceget()
+                        if char is None:
+                            raise error("unexpected end of pattern")
+                        raise error("unknown specifier: ?P%s" % char)
+                elif sourcematch(":"):
+                    # non-capturing group
+                    group = 2
+                elif sourcematch("#"):
+                    # comment
+                    while 1:
+                        if source.next is None or source.next == ")":
+                            break
+                        sourceget()
+                    if not sourcematch(")"):
+                        raise error("unbalanced parenthesis")
+                    continue
+                elif source.next in ASSERTCHARS:
+                    # lookahead assertions
+                    char = sourceget()
+                    dir = 1
+                    if char == "<":
+                        if source.next not in LOOKBEHINDASSERTCHARS:
+                            raise error("syntax error")
+                        dir = -1 # lookbehind
+                        char = sourceget()
+                    p = _parse_sub(source, state)
+                    if not sourcematch(")"):
+                        raise error("unbalanced parenthesis")
+                    if char == "=":
+                        subpatternappend((ASSERT, (dir, p)))
+                    else:
+                        subpatternappend((ASSERT_NOT, (dir, p)))
+                    continue
+                elif sourcematch("("):
+                    # conditional backreference group
+                    condname = ""
+                    while 1:
+                        char = sourceget()
+                        if char is None:
+                            raise error("unterminated name")
+                        if char == ")":
+                            break
+                        condname = condname + char
+                    group = 2
+                    if isname(condname):
+                        condgroup = state.groupdict.get(condname)
+                        if condgroup is None:
+                            raise error("unknown group name")
+                    else:
+                        try:
+                            condgroup = int(condname)
+                        except ValueError:
+                            raise error("bad character in group name")
+                else:
+                    # flags
+                    if not source.next in FLAGS:
+                        raise error("unexpected end of pattern")
+                    while source.next in FLAGS:
+                        state.flags = state.flags | FLAGS[sourceget()]
+            if group:
+                # parse group contents
+                if group == 2:
+                    # anonymous group
+                    group = None
+                else:
+                    group = state.opengroup(name)
+                if condgroup:
+                    p = _parse_sub_cond(source, state, condgroup)
+                else:
+                    p = _parse_sub(source, state)
+                if not sourcematch(")"):
+                    raise error("unbalanced parenthesis")
+                if group is not None:
+                    state.closegroup(group)
+                subpatternappend((SUBPATTERN, (group, p)))
+            else:
+                while 1:
+                    char = sourceget()
+                    if char is None:
+                        raise error("unexpected end of pattern")
+                    if char == ")":
+                        break
+                    raise error("unknown extension")
+
+        elif this == "^":
+            subpatternappend((AT, AT_BEGINNING))
+
+        elif this == "$":
+            subpattern.append((AT, AT_END))
+
+        elif this and this[0] == "\\":
+            code = _escape(source, this, state)
+            subpatternappend(code)
+
+        else:
+            raise error("parser error")
+
+    return subpattern
+
+def fix_flags(src, flags):
+    # Check and fix flags according to the type of pattern (str or bytes)
+    if isinstance(src, str):
+        if not flags & SRE_FLAG_ASCII:
+            flags |= SRE_FLAG_UNICODE
+        elif flags & SRE_FLAG_UNICODE:
+            raise ValueError("ASCII and UNICODE flags are incompatible")
+    else:
+        if flags & SRE_FLAG_UNICODE:
+            raise ValueError("can't use UNICODE flag with a bytes pattern")
+    return flags
+
+def parse(str, flags=0, pattern=None):
+    # parse 're' pattern into list of (opcode, argument) tuples
+
+    source = Tokenizer(str)
+
+    if pattern is None:
+        pattern = Pattern()
+    pattern.flags = flags
+    pattern.str = str
+
+    p = _parse_sub(source, pattern, 0)
+    p.pattern.flags = fix_flags(str, p.pattern.flags)
+
+    tail = source.get()
+    if tail == ")":
+        raise error("unbalanced parenthesis")
+    elif tail:
+        raise error("bogus characters at end of regular expression")
+
+    if flags & SRE_FLAG_DEBUG:
+        p.dump()
+
+    if not (flags & SRE_FLAG_VERBOSE) and p.pattern.flags & SRE_FLAG_VERBOSE:
+        # the VERBOSE flag was switched on inside the pattern.  to be
+        # on the safe side, we'll parse the whole thing again...
+        return parse(str, p.pattern.flags)
+
+    return p
+
+def parse_template(source, pattern):
+    # parse 're' replacement string into list of literals and
+    # group references
+    s = Tokenizer(source)
+    sget = s.get
+    p = []
+    a = p.append
+    def literal(literal, p=p, pappend=a):
+        if p and p[-1][0] is LITERAL:
+            p[-1] = LITERAL, p[-1][1] + literal
+        else:
+            pappend((LITERAL, literal))
+    sep = source[:0]
+    if isinstance(sep, str):
+        makechar = chr
+    else:
+        makechar = chr
+    while 1:
+        this = sget()
+        if this is None:
+            break # end of replacement string
+        if this and this[0] == "\\":
+            # group
+            c = this[1:2]
+            if c == "g":
+                name = ""
+                if s.match("<"):
+                    while 1:
+                        char = sget()
+                        if char is None:
+                            raise error("unterminated group name")
+                        if char == ">":
+                            break
+                        name = name + char
+                if not name:
+                    raise error("bad group name")
+                try:
+                    index = int(name)
+                    if index < 0:
+                        raise error("negative group number")
+                except ValueError:
+                    if not isname(name):
+                        raise error("bad character in group name")
+                    try:
+                        index = pattern.groupindex[name]
+                    except KeyError:
+                        raise IndexError("unknown group name")
+                a((MARK, index))
+            elif c == "0":
+                if s.next in OCTDIGITS:
+                    this = this + sget()
+                    if s.next in OCTDIGITS:
+                        this = this + sget()
+                literal(makechar(int(this[1:], 8) & 0xff))
+            elif c in DIGITS:
+                isoctal = False
+                if s.next in DIGITS:
+                    this = this + sget()
+                    if (c in OCTDIGITS and this[2] in OCTDIGITS and
+                        s.next in OCTDIGITS):
+                        this = this + sget()
+                        isoctal = True
+                        literal(makechar(int(this[1:], 8) & 0xff))
+                if not isoctal:
+                    a((MARK, int(this[1:])))
+            else:
+                try:
+                    this = makechar(ESCAPES[this][1])
+                except KeyError:
+                    pass
+                literal(this)
+        else:
+            literal(this)
+    # convert template to groups and literals lists
+    i = 0
+    groups = []
+    groupsappend = groups.append
+    literals = [None] * len(p)
+    for c, s in p:
+        if c is MARK:
+            groupsappend((i, s))
+            # literal[i] is already None
+        else:
+            literals[i] = s
+        i = i + 1
+    return groups, literals
+
+def expand_template(template, match):
+    g = match.group
+    sep = match.string[:0]
+    groups, literals = template
+    literals = literals[:]
+    try:
+        for index, group in groups:
+            literals[index] = s = g(group)
+            if s is None:
+                raise error("unmatched group")
+    except IndexError:
+        raise error("invalid group reference")
+    return sep.join(literals)

--- a/Lib/sre_parse.py
+++ b/Lib/sre_parse.py
@@ -12,19 +12,21 @@
 
 # XXX: show string offset and offending character for all errors
 
-import sys
-
 from sre_constants import *
 
 SPECIAL_CHARS = ".\\[{()*+?^$|"
 REPEAT_CHARS = "*+?{"
 
-DIGITS = set("0123456789")
+DIGITS = frozenset("0123456789")
 
-OCTDIGITS = set("01234567")
-HEXDIGITS = set("0123456789abcdefABCDEF")
+OCTDIGITS = frozenset("01234567")
+HEXDIGITS = frozenset("0123456789abcdefABCDEF")
+ASCIILETTERS = frozenset("abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ")
 
-WHITESPACE = set(" \t\n\r\v\f")
+WHITESPACE = frozenset(" \t\n\r\v\f")
+
+_REPEATCODES = frozenset({MIN_REPEAT, MAX_REPEAT})
+_UNITCODES = frozenset({ANY, RANGE, IN, LITERAL, NOT_LITERAL, CATEGORY})
 
 ESCAPES = {
     r"\a": (LITERAL, ord("\a")),
@@ -63,28 +65,46 @@ FLAGS = {
     "u": SRE_FLAG_UNICODE,
 }
 
+GLOBAL_FLAGS = (SRE_FLAG_ASCII | SRE_FLAG_LOCALE | SRE_FLAG_UNICODE |
+                SRE_FLAG_DEBUG | SRE_FLAG_TEMPLATE)
+
+class Verbose(Exception):
+    pass
+
 class Pattern:
     # master pattern object.  keeps track of global attributes
     def __init__(self):
         self.flags = 0
-        self.open = []
-        self.groups = 1
         self.groupdict = {}
+        self.groupwidths = [None]  # group 0
+        self.lookbehindgroups = None
+    @property
+    def groups(self):
+        return len(self.groupwidths)
     def opengroup(self, name=None):
         gid = self.groups
-        self.groups = gid + 1
+        self.groupwidths.append(None)
+        if self.groups > MAXGROUPS:
+            raise error("too many groups")
         if name is not None:
             ogid = self.groupdict.get(name, None)
             if ogid is not None:
-                raise error("redefinition of group name %s as group %d; "
-                            "was group %d" % (repr(name), gid,  ogid))
+                raise error("redefinition of group name %r as group %d; "
+                            "was group %d" % (name, gid,  ogid))
             self.groupdict[name] = gid
-        self.open.append(gid)
         return gid
-    def closegroup(self, gid):
-        self.open.remove(gid)
+    def closegroup(self, gid, p):
+        self.groupwidths[gid] = p.getwidth()
     def checkgroup(self, gid):
-        return gid < self.groups and gid not in self.open
+        return gid < self.groups and self.groupwidths[gid] is not None
+
+    def checklookbehindgroup(self, gid, source):
+        if self.lookbehindgroups is not None:
+            if not self.checkgroup(gid):
+                raise source.error('cannot refer to an open group')
+            if gid >= self.lookbehindgroups:
+                raise source.error('cannot refer to group defined in the same '
+                                   'lookbehind subpattern')
 
 class SubPattern:
     # a subpattern, in intermediate form
@@ -95,33 +115,45 @@ class SubPattern:
         self.data = data
         self.width = None
     def dump(self, level=0):
-        nl = 1
+        nl = True
         seqtypes = (tuple, list)
         for op, av in self.data:
-            print(level*"  " + op, end=' '); nl = 0
-            if op == "in":
+            print(level*"  " + str(op), end='')
+            if op is IN:
                 # member sublanguage
-                print(); nl = 1
+                print()
                 for op, a in av:
-                    print((level+1)*"  " + op, a)
-            elif op == "branch":
-                print(); nl = 1
-                i = 0
-                for a in av[1]:
-                    if i > 0:
-                        print(level*"  " + "or")
-                    a.dump(level+1); nl = 1
-                    i = i + 1
+                    print((level+1)*"  " + str(op), a)
+            elif op is BRANCH:
+                print()
+                for i, a in enumerate(av[1]):
+                    if i:
+                        print(level*"  " + "OR")
+                    a.dump(level+1)
+            elif op is GROUPREF_EXISTS:
+                condgroup, item_yes, item_no = av
+                print('', condgroup)
+                item_yes.dump(level+1)
+                if item_no:
+                    print(level*"  " + "ELSE")
+                    item_no.dump(level+1)
             elif isinstance(av, seqtypes):
+                nl = False
                 for a in av:
                     if isinstance(a, SubPattern):
-                        if not nl: print()
-                        a.dump(level+1); nl = 1
+                        if not nl:
+                            print()
+                        a.dump(level+1)
+                        nl = True
                     else:
-                        print(a, end=' ') ; nl = 0
+                        if not nl:
+                            print(' ', end='')
+                        print(a, end='')
+                        nl = False
+                if not nl:
+                    print()
             else:
-                print(av, end=' ') ; nl = 0
-            if not nl: print()
+                print('', av)
     def __repr__(self):
         return repr(self.data)
     def __len__(self):
@@ -140,14 +172,12 @@ class SubPattern:
         self.data.append(code)
     def getwidth(self):
         # determine the width (min, max) for this subpattern
-        if self.width:
+        if self.width is not None:
             return self.width
         lo = hi = 0
-        UNITCODES = (ANY, RANGE, IN, LITERAL, NOT_LITERAL, CATEGORY)
-        REPEATCODES = (MIN_REPEAT, MAX_REPEAT)
         for op, av in self.data:
             if op is BRANCH:
-                i = sys.maxsize
+                i = MAXREPEAT - 1
                 j = 0
                 for av in av[1]:
                     l, h = av.getwidth()
@@ -160,74 +190,106 @@ class SubPattern:
                 lo = lo + i
                 hi = hi + j
             elif op is SUBPATTERN:
-                i, j = av[1].getwidth()
+                i, j = av[-1].getwidth()
                 lo = lo + i
                 hi = hi + j
-            elif op in REPEATCODES:
+            elif op in _REPEATCODES:
                 i, j = av[2].getwidth()
-                lo = lo + int(i) * av[0]
-                hi = hi + int(j) * av[1]
-            elif op in UNITCODES:
+                lo = lo + i * av[0]
+                hi = hi + j * av[1]
+            elif op in _UNITCODES:
                 lo = lo + 1
                 hi = hi + 1
-            elif op == SUCCESS:
+            elif op is GROUPREF:
+                i, j = self.pattern.groupwidths[av]
+                lo = lo + i
+                hi = hi + j
+            elif op is GROUPREF_EXISTS:
+                i, j = av[1].getwidth()
+                if av[2] is not None:
+                    l, h = av[2].getwidth()
+                    i = min(i, l)
+                    j = max(j, h)
+                else:
+                    i = 0
+                lo = lo + i
+                hi = hi + j
+            elif op is SUCCESS:
                 break
-        self.width = int(min(lo, sys.maxsize)), int(min(hi, sys.maxsize))
+        self.width = min(lo, MAXREPEAT - 1), min(hi, MAXREPEAT)
         return self.width
 
 class Tokenizer:
     def __init__(self, string):
+        self.istext = isinstance(string, str)
         self.string = string
+        if not self.istext:
+            string = str(string, 'latin1')
+        self.decoded_string = string
         self.index = 0
+        self.next = None
         self.__next()
     def __next(self):
-        if self.index >= len(self.string):
+        index = self.index
+        try:
+            char = self.decoded_string[index]
+        except IndexError:
             self.next = None
             return
-        char = self.string[self.index:self.index+1]
-        # Special case for the str8, since indexing returns a integer
-        # XXX This is only needed for test_bug_926075 in test_re.py
-        if char and isinstance(char, bytes):
-            char = chr(char[0])
         if char == "\\":
+            index += 1
             try:
-                c = self.string[self.index + 1]
+                char += self.decoded_string[index]
             except IndexError:
-                raise error("bogus escape (end of line)")
-            if isinstance(self.string, bytes):
-                c = chr(c)
-            char = char + c
-        self.index = self.index + len(char)
+                raise error("bad escape (end of pattern)",
+                            self.string, len(self.string) - 1) from None
+        self.index = index + 1
         self.next = char
-    def match(self, char, skip=1):
+    def match(self, char):
         if char == self.next:
-            if skip:
-                self.__next()
-            return 1
-        return 0
+            self.__next()
+            return True
+        return False
     def get(self):
         this = self.next
         self.__next()
         return this
+    def getwhile(self, n, charset):
+        result = ''
+        for _ in range(n):
+            c = self.next
+            if c not in charset:
+                break
+            result += c
+            self.__next()
+        return result
+    def getuntil(self, terminator):
+        result = ''
+        while True:
+            c = self.next
+            self.__next()
+            if c is None:
+                if not result:
+                    raise self.error("missing group name")
+                raise self.error("missing %s, unterminated name" % terminator,
+                                 len(result))
+            if c == terminator:
+                if not result:
+                    raise self.error("missing group name", 1)
+                break
+            result += c
+        return result
+    @property
+    def pos(self):
+        return self.index - len(self.next or '')
     def tell(self):
-        return self.index, self.next
+        return self.index - len(self.next or '')
     def seek(self, index):
-        self.index, self.next = index
+        self.index = index
+        self.__next()
 
-def isident(char):
-    return "a" <= char <= "z" or "A" <= char <= "Z" or char == "_"
-
-def isdigit(char):
-    return "0" <= char <= "9"
-
-def isname(name):
-    # check that group name is a valid string
-    if not isident(name[0]):
-        return False
-    for char in name[1:]:
-        if not isident(char) and not isdigit(char):
-            return False
-    return True
+    def error(self, msg, offset=0):
+        return error(msg, self.string, self.tell() - offset)
 
 def _class_escape(source, escape):
     # handle escape code inside character class
@@ -235,31 +297,47 @@ def _class_escape(source, escape):
     if code:
         return code
     code = CATEGORIES.get(escape)
-    if code:
+    if code and code[0] is IN:
         return code
     try:
         c = escape[1:2]
         if c == "x":
             # hexadecimal escape (exactly two digits)
-            while source.next in HEXDIGITS and len(escape) < 4:
-                escape = escape + source.get()
-            escape = escape[2:]
-            if len(escape) != 2:
-                raise error("bogus escape: %s" % repr("\\" + escape))
-            return LITERAL, int(escape, 16) & 0xff
+            escape += source.getwhile(2, HEXDIGITS)
+            if len(escape) != 4:
+                raise source.error("incomplete escape %s" % escape, len(escape))
+            return LITERAL, int(escape[2:], 16)
+        elif c == "u" and source.istext:
+            # unicode escape (exactly four digits)
+            escape += source.getwhile(4, HEXDIGITS)
+            if len(escape) != 6:
+                raise source.error("incomplete escape %s" % escape, len(escape))
+            return LITERAL, int(escape[2:], 16)
+        elif c == "U" and source.istext:
+            # unicode escape (exactly eight digits)
+            escape += source.getwhile(8, HEXDIGITS)
+            if len(escape) != 10:
+                raise source.error("incomplete escape %s" % escape, len(escape))
+            c = int(escape[2:], 16)
+            chr(c) # raise ValueError for invalid code
+            return LITERAL, c
         elif c in OCTDIGITS:
             # octal escape (up to three digits)
-            while source.next in OCTDIGITS and len(escape) < 4:
-                escape = escape + source.get()
-            escape = escape[1:]
-            return LITERAL, int(escape, 8) & 0xff
+            escape += source.getwhile(2, OCTDIGITS)
+            c = int(escape[1:], 8)
+            if c > 0o377:
+                raise source.error('octal escape value %s outside of '
+                                   'range 0-0o377' % escape, len(escape))
+            return LITERAL, c
         elif c in DIGITS:
-            raise error("bogus escape: %s" % repr(escape))
+            raise ValueError
         if len(escape) == 2:
+            if c in ASCIILETTERS:
+                raise source.error('bad escape %s' % escape, len(escape))
             return LITERAL, ord(escape[1])
     except ValueError:
         pass
-    raise error("bogus escape: %s" % repr(escape))
+    raise source.error("bad escape %s" % escape, len(escape))
 
 def _escape(source, escape, state):
     # handle escape code in expression
@@ -273,54 +351,70 @@ def _escape(source, escape, state):
         c = escape[1:2]
         if c == "x":
             # hexadecimal escape
-            while source.next in HEXDIGITS and len(escape) < 4:
-                escape = escape + source.get()
+            escape += source.getwhile(2, HEXDIGITS)
             if len(escape) != 4:
-                raise ValueError
-            return LITERAL, int(escape[2:], 16) & 0xff
+                raise source.error("incomplete escape %s" % escape, len(escape))
+            return LITERAL, int(escape[2:], 16)
+        elif c == "u" and source.istext:
+            # unicode escape (exactly four digits)
+            escape += source.getwhile(4, HEXDIGITS)
+            if len(escape) != 6:
+                raise source.error("incomplete escape %s" % escape, len(escape))
+            return LITERAL, int(escape[2:], 16)
+        elif c == "U" and source.istext:
+            # unicode escape (exactly eight digits)
+            escape += source.getwhile(8, HEXDIGITS)
+            if len(escape) != 10:
+                raise source.error("incomplete escape %s" % escape, len(escape))
+            c = int(escape[2:], 16)
+            chr(c) # raise ValueError for invalid code
+            return LITERAL, c
         elif c == "0":
             # octal escape
-            while source.next in OCTDIGITS and len(escape) < 4:
-                escape = escape + source.get()
-            return LITERAL, int(escape[1:], 8) & 0xff
+            escape += source.getwhile(2, OCTDIGITS)
+            return LITERAL, int(escape[1:], 8)
         elif c in DIGITS:
             # octal escape *or* decimal group reference (sigh)
             if source.next in DIGITS:
-                escape = escape + source.get()
+                escape += source.get()
                 if (escape[1] in OCTDIGITS and escape[2] in OCTDIGITS and
                     source.next in OCTDIGITS):
                     # got three octal digits; this is an octal escape
-                    escape = escape + source.get()
-                    return LITERAL, int(escape[1:], 8) & 0xff
+                    escape += source.get()
+                    c = int(escape[1:], 8)
+                    if c > 0o377:
+                        raise source.error('octal escape value %s outside of '
+                                           'range 0-0o377' % escape,
+                                           len(escape))
+                    return LITERAL, c
             # not an octal escape, so this is a group reference
             group = int(escape[1:])
             if group < state.groups:
                 if not state.checkgroup(group):
-                    raise error("cannot refer to open group")
+                    raise source.error("cannot refer to an open group",
+                                       len(escape))
+                state.checklookbehindgroup(group, source)
                 return GROUPREF, group
-            raise ValueError
+            raise source.error("invalid group reference %d" % group, len(escape) - 1)
         if len(escape) == 2:
+            if c in ASCIILETTERS:
+                raise source.error("bad escape %s" % escape, len(escape))
             return LITERAL, ord(escape[1])
     except ValueError:
         pass
-    raise error("bogus escape: %s" % repr(escape))
+    raise source.error("bad escape %s" % escape, len(escape))
 
-def _parse_sub(source, state, nested=1):
+def _parse_sub(source, state, verbose, nested=True):
     # parse an alternation: a|b|c
 
     items = []
     itemsappend = items.append
     sourcematch = source.match
-    while 1:
-        itemsappend(_parse(source, state))
-        if sourcematch("|"):
-            continue
-        if not nested:
+    start = source.tell()
+    while True:
+        itemsappend(_parse(source, state, verbose))
+        if not sourcematch("|"):
             break
-        if not source.next or sourcematch(")", 0):
-            break
-        else:
-            raise error("pattern not properly closed")
 
     if len(items) == 1:
         return items[0]
@@ -329,7 +423,7 @@ def _parse_sub(source, state, nested=1):
     subpatternappend = subpattern.append
 
     # check if all items share a common prefix
-    while 1:
+    while True:
         prefix = None
         for item in items:
             if not item:
@@ -349,41 +443,30 @@ def _parse_sub(source, state, nested=1):
 
     # check if the branch can be replaced by a character set
     for item in items:
-        if len(item) != 1 or item[0][0] != LITERAL:
+        if len(item) != 1 or item[0][0] is not LITERAL:
             break
     else:
         # we can store this as a character set instead of a
         # branch (the compiler may optimize this even more)
-        set = []
-        setappend = set.append
-        for item in items:
-            setappend(item[0])
-        subpatternappend((IN, set))
+        subpatternappend((IN, [item[0] for item in items]))
         return subpattern
 
     subpattern.append((BRANCH, (None, items)))
     return subpattern
 
-def _parse_sub_cond(source, state, condgroup):
-    item_yes = _parse(source, state)
+def _parse_sub_cond(source, state, condgroup, verbose):
+    item_yes = _parse(source, state, verbose)
     if source.match("|"):
-        item_no = _parse(source, state)
-        if source.match("|"):
-            raise error("conditional backref with more than two branches")
+        item_no = _parse(source, state, verbose)
+        if source.next == "|":
+            raise source.error("conditional backref with more than two branches")
     else:
         item_no = None
-    if source.next and not source.match(")", 0):
-        raise error("pattern not properly closed")
     subpattern = SubPattern(state)
     subpattern.append((GROUPREF_EXISTS, (condgroup, item_yes, item_no)))
     return subpattern
 
-_PATTERNENDERS = set("|)")
-_ASSERTCHARS = set("=!<")
-_LOOKBEHINDASSERTCHARS = set("=!")
-_REPEATCODES = set([MIN_REPEAT, MAX_REPEAT])
-
-def _parse(source, state):
+def _parse(source, state, verbose):
     # parse a simple pattern
     subpattern = SubPattern(state)
 
@@ -392,34 +475,37 @@ def _parse(source, state):
     sourceget = source.get
     sourcematch = source.match
     _len = len
-    PATTERNENDERS = _PATTERNENDERS
-    ASSERTCHARS = _ASSERTCHARS
-    LOOKBEHINDASSERTCHARS = _LOOKBEHINDASSERTCHARS
-    REPEATCODES = _REPEATCODES
+    _ord = ord
 
-    while 1:
+    while True:
 
-        if source.next in PATTERNENDERS:
-            break # end of subpattern
-        this = sourceget()
+        this = source.next
         if this is None:
             break # end of pattern
+        if this in "|)":
+            break # end of subpattern
+        sourceget()
 
-        if state.flags & SRE_FLAG_VERBOSE:
+        if verbose:
             # skip whitespace and comments
             if this in WHITESPACE:
                 continue
             if this == "#":
-                while 1:
+                while True:
                     this = sourceget()
-                    if this in (None, "\n"):
+                    if this is None or this == "\n":
                         break
                 continue
 
-        if this and this[0] not in SPECIAL_CHARS:
-            subpatternappend((LITERAL, ord(this)))
+        if this[0] == "\\":
+            code = _escape(source, this, state)
+            subpatternappend(code)
+
+        elif this not in SPECIAL_CHARS:
+            subpatternappend((LITERAL, _ord(this)))
 
         elif this == "[":
+            here = source.tell() - 1
             # character set
             set = []
             setappend = set.append
@@ -429,39 +515,42 @@ def _parse(source, state):
                 setappend((NEGATE, None))
             # check remaining characters
             start = set[:]
-            while 1:
+            while True:
                 this = sourceget()
+                if this is None:
+                    raise source.error("unterminated character set",
+                                       source.tell() - here)
                 if this == "]" and set != start:
                     break
-                elif this and this[0] == "\\":
+                elif this[0] == "\\":
                     code1 = _class_escape(source, this)
-                elif this:
-                    code1 = LITERAL, ord(this)
                 else:
-                    raise error("unexpected end of regular expression")
+                    code1 = LITERAL, _ord(this)
                 if sourcematch("-"):
                     # potential range
-                    this = sourceget()
-                    if this == "]":
+                    that = sourceget()
+                    if that is None:
+                        raise source.error("unterminated character set",
+                                           source.tell() - here)
+                    if that == "]":
                         if code1[0] is IN:
                             code1 = code1[1][0]
                         setappend(code1)
-                        setappend((LITERAL, ord("-")))
+                        setappend((LITERAL, _ord("-")))
                         break
-                    elif this:
-                        if this[0] == "\\":
-                            code2 = _class_escape(source, this)
-                        else:
-                            code2 = LITERAL, ord(this)
-                        if code1[0] != LITERAL or code2[0] != LITERAL:
-                            raise error("bad character range")
-                        lo = code1[1]
-                        hi = code2[1]
-                        if hi < lo:
-                            raise error("bad character range")
-                        setappend((RANGE, (lo, hi)))
+                    if that[0] == "\\":
+                        code2 = _class_escape(source, that)
                     else:
-                        raise error("unexpected end of regular expression")
+                        code2 = LITERAL, _ord(that)
+                    if code1[0] != LITERAL or code2[0] != LITERAL:
+                        msg = "bad character range %s-%s" % (this, that)
+                        raise source.error(msg, len(this) + 1 + len(that))
+                    lo = code1[1]
+                    hi = code2[1]
+                    if hi < lo:
+                        msg = "bad character range %s-%s" % (this, that)
+                        raise source.error(msg, len(this) + 1 + len(that))
+                    setappend((RANGE, (lo, hi)))
                 else:
                     if code1[0] is IN:
                         code1 = code1[1][0]
@@ -476,8 +565,9 @@ def _parse(source, state):
                 # XXX: <fl> should add charmap optimization here
                 subpatternappend((IN, set))
 
-        elif this and this[0] in REPEAT_CHARS:
+        elif this in REPEAT_CHARS:
             # repeat previous item
+            here = source.tell()
             if this == "?":
                 min, max = 0, 1
             elif this == "*":
@@ -487,39 +577,45 @@ def _parse(source, state):
                 min, max = 1, MAXREPEAT
             elif this == "{":
                 if source.next == "}":
-                    subpatternappend((LITERAL, ord(this)))
+                    subpatternappend((LITERAL, _ord(this)))
                     continue
-                here = source.tell()
                 min, max = 0, MAXREPEAT
                 lo = hi = ""
                 while source.next in DIGITS:
-                    lo = lo + source.get()
+                    lo += sourceget()
                 if sourcematch(","):
                     while source.next in DIGITS:
-                        hi = hi + sourceget()
+                        hi += sourceget()
                 else:
                     hi = lo
                 if not sourcematch("}"):
-                    subpatternappend((LITERAL, ord(this)))
+                    subpatternappend((LITERAL, _ord(this)))
                     source.seek(here)
                     continue
                 if lo:
                     min = int(lo)
+                    if min >= MAXREPEAT:
+                        raise OverflowError("the repetition number is too large")
                 if hi:
                     max = int(hi)
-                if max < min:
-                    raise error("bad repeat interval")
+                    if max >= MAXREPEAT:
+                        raise OverflowError("the repetition number is too large")
+                    if max < min:
+                        raise source.error("min repeat greater than max repeat",
+                                           source.tell() - here)
             else:
-                raise error("not supported")
+                raise AssertionError("unsupported quantifier %r" % (char,))
             # figure out which item to repeat
             if subpattern:
                 item = subpattern[-1:]
             else:
                 item = None
-            if not item or (_len(item) == 1 and item[0][0] == AT):
-                raise error("nothing to repeat")
-            if item[0][0] in REPEATCODES:
-                raise error("multiple repeat")
+            if not item or (_len(item) == 1 and item[0][0] is AT):
+                raise source.error("nothing to repeat",
+                                   source.tell() - here + len(this))
+            if item[0][0] in _REPEATCODES:
+                raise source.error("multiple repeat",
+                                   source.tell() - here + len(this))
             if sourcematch("?"):
                 subpattern[-1] = (MIN_REPEAT, (min, max, item))
             else:
@@ -529,128 +625,148 @@ def _parse(source, state):
             subpatternappend((ANY, None))
 
         elif this == "(":
-            group = 1
+            start = source.tell() - 1
+            group = True
             name = None
             condgroup = None
+            add_flags = 0
+            del_flags = 0
             if sourcematch("?"):
-                group = 0
                 # options
-                if sourcematch("P"):
+                char = sourceget()
+                if char is None:
+                    raise source.error("unexpected end of pattern")
+                if char == "P":
                     # python extensions
                     if sourcematch("<"):
                         # named group: skip forward to end of name
-                        name = ""
-                        while 1:
-                            char = sourceget()
-                            if char is None:
-                                raise error("unterminated name")
-                            if char == ">":
-                                break
-                            name = name + char
-                        group = 1
-                        if not isname(name):
-                            raise error("bad character in group name")
+                        name = source.getuntil(">")
+                        if not name.isidentifier():
+                            msg = "bad character in group name %r" % name
+                            raise source.error(msg, len(name) + 1)
                     elif sourcematch("="):
                         # named backreference
-                        name = ""
-                        while 1:
-                            char = sourceget()
-                            if char is None:
-                                raise error("unterminated name")
-                            if char == ")":
-                                break
-                            name = name + char
-                        if not isname(name):
-                            raise error("bad character in group name")
+                        name = source.getuntil(")")
+                        if not name.isidentifier():
+                            msg = "bad character in group name %r" % name
+                            raise source.error(msg, len(name) + 1)
                         gid = state.groupdict.get(name)
                         if gid is None:
-                            raise error("unknown group name")
+                            msg = "unknown group name %r" % name
+                            raise source.error(msg, len(name) + 1)
+                        if not state.checkgroup(gid):
+                            raise source.error("cannot refer to an open group",
+                                               len(name) + 1)
+                        state.checklookbehindgroup(gid, source)
                         subpatternappend((GROUPREF, gid))
                         continue
                     else:
                         char = sourceget()
                         if char is None:
-                            raise error("unexpected end of pattern")
-                        raise error("unknown specifier: ?P%s" % char)
-                elif sourcematch(":"):
+                            raise source.error("unexpected end of pattern")
+                        raise source.error("unknown extension ?P" + char,
+                                           len(char) + 2)
+                elif char == ":":
                     # non-capturing group
-                    group = 2
-                elif sourcematch("#"):
+                    group = None
+                elif char == "#":
                     # comment
-                    while 1:
-                        if source.next is None or source.next == ")":
+                    while True:
+                        if source.next is None:
+                            raise source.error("missing ), unterminated comment",
+                                               source.tell() - start)
+                        if sourceget() == ")":
                             break
-                        sourceget()
-                    if not sourcematch(")"):
-                        raise error("unbalanced parenthesis")
                     continue
-                elif source.next in ASSERTCHARS:
+                elif char in "=!<":
                     # lookahead assertions
-                    char = sourceget()
                     dir = 1
                     if char == "<":
-                        if source.next not in LOOKBEHINDASSERTCHARS:
-                            raise error("syntax error")
-                        dir = -1 # lookbehind
                         char = sourceget()
-                    p = _parse_sub(source, state)
+                        if char is None:
+                            raise source.error("unexpected end of pattern")
+                        if char not in "=!":
+                            raise source.error("unknown extension ?<" + char,
+                                               len(char) + 2)
+                        dir = -1 # lookbehind
+                        lookbehindgroups = state.lookbehindgroups
+                        if lookbehindgroups is None:
+                            state.lookbehindgroups = state.groups
+                    p = _parse_sub(source, state, verbose)
+                    if dir < 0:
+                        if lookbehindgroups is None:
+                            state.lookbehindgroups = None
                     if not sourcematch(")"):
-                        raise error("unbalanced parenthesis")
+                        raise source.error("missing ), unterminated subpattern",
+                                           source.tell() - start)
                     if char == "=":
                         subpatternappend((ASSERT, (dir, p)))
                     else:
                         subpatternappend((ASSERT_NOT, (dir, p)))
                     continue
-                elif sourcematch("("):
+                elif char == "(":
                     # conditional backreference group
-                    condname = ""
-                    while 1:
-                        char = sourceget()
-                        if char is None:
-                            raise error("unterminated name")
-                        if char == ")":
-                            break
-                        condname = condname + char
-                    group = 2
-                    if isname(condname):
+                    condname = source.getuntil(")")
+                    group = None
+                    if condname.isidentifier():
                         condgroup = state.groupdict.get(condname)
                         if condgroup is None:
-                            raise error("unknown group name")
+                            msg = "unknown group name %r" % condname
+                            raise source.error(msg, len(condname) + 1)
                     else:
                         try:
                             condgroup = int(condname)
+                            if condgroup < 0:
+                                raise ValueError
                         except ValueError:
-                            raise error("bad character in group name")
-                else:
+                            msg = "bad character in group name %r" % condname
+                            raise source.error(msg, len(condname) + 1) from None
+                        if not condgroup:
+                            raise source.error("bad group number",
+                                               len(condname) + 1)
+                        if condgroup >= MAXGROUPS:
+                            msg = "invalid group reference %d" % condgroup
+                            raise source.error(msg, len(condname) + 1)
+                    state.checklookbehindgroup(condgroup, source)
+                elif char in FLAGS or char == "-":
                     # flags
-                    if not source.next in FLAGS:
-                        raise error("unexpected end of pattern")
-                    while source.next in FLAGS:
-                        state.flags = state.flags | FLAGS[sourceget()]
-            if group:
-                # parse group contents
-                if group == 2:
-                    # anonymous group
+                    pos = source.pos
+                    flags = _parse_flags(source, state, char)
+                    if flags is None:  # global flags
+                        if pos != 3:  # "(?x"
+                            import warnings
+                            warnings.warn(
+                                'Flags not at the start of the expression %s%s' % (
+                                    source.string[:20],  # truncate long regexes
+                                    ' (truncated)' if len(source.string) > 20 else '',
+                                ),
+                                DeprecationWarning, stacklevel=7
+                            )
+                        continue
+                    add_flags, del_flags = flags
                     group = None
                 else:
+                    raise source.error("unknown extension ?" + char,
+                                       len(char) + 1)
+
+            # parse group contents
+            if group is not None:
+                try:
                     group = state.opengroup(name)
-                if condgroup:
-                    p = _parse_sub_cond(source, state, condgroup)
-                else:
-                    p = _parse_sub(source, state)
-                if not sourcematch(")"):
-                    raise error("unbalanced parenthesis")
-                if group is not None:
-                    state.closegroup(group)
-                subpatternappend((SUBPATTERN, (group, p)))
+                except error as err:
+                    raise source.error(err.msg, len(name) + 1) from None
+            if condgroup:
+                p = _parse_sub_cond(source, state, condgroup, verbose)
             else:
-                while 1:
-                    char = sourceget()
-                    if char is None:
-                        raise error("unexpected end of pattern")
-                    if char == ")":
-                        break
-                    raise error("unknown extension")
+                sub_verbose = ((verbose or (add_flags & SRE_FLAG_VERBOSE)) and
+                               not (del_flags & SRE_FLAG_VERBOSE))
+                p = _parse_sub(source, state, sub_verbose)
+            if not source.match(")"):
+                raise source.error("missing ), unterminated subpattern",
+                                   source.tell() - start)
+            if group is not None:
+                state.closegroup(group, p)
+            subpatternappend((SUBPATTERN, (group, add_flags, del_flags, p)))
 
         elif this == "^":
             subpatternappend((AT, AT_BEGINNING))
@@ -658,25 +774,72 @@ def _parse(source, state):
         elif this == "$":
             subpattern.append((AT, AT_END))
 
-        elif this and this[0] == "\\":
-            code = _escape(source, this, state)
-            subpatternappend(code)
-
         else:
-            raise error("parser error")
+            raise AssertionError("unsupported special character %r" % (char,))
 
     return subpattern
+
+def _parse_flags(source, state, char):
+    sourceget = source.get
+    add_flags = 0
+    del_flags = 0
+    if char != "-":
+        while True:
+            add_flags |= FLAGS[char]
+            char = sourceget()
+            if char is None:
+                raise source.error("missing -, : or )")
+            if char in ")-:":
+                break
+            if char not in FLAGS:
+                msg = "unknown flag" if char.isalpha() else "missing -, : or )"
+                raise source.error(msg, len(char))
+    if char == ")":
+        if ((add_flags & SRE_FLAG_VERBOSE) and
+            not (state.flags & SRE_FLAG_VERBOSE)):
+            raise Verbose
+        state.flags |= add_flags
+        return None
+    if add_flags & GLOBAL_FLAGS:
+        raise source.error("bad inline flags: cannot turn on global flag", 1)
+    if char == "-":
+        char = sourceget()
+        if char is None:
+            raise source.error("missing flag")
+        if char not in FLAGS:
+            msg = "unknown flag" if char.isalpha() else "missing flag"
+            raise source.error(msg, len(char))
+        while True:
+            del_flags |= FLAGS[char]
+            char = sourceget()
+            if char is None:
+                raise source.error("missing :")
+            if char == ":":
+                break
+            if char not in FLAGS:
+                msg = "unknown flag" if char.isalpha() else "missing :"
+                raise source.error(msg, len(char))
+    assert char == ":"
+    if del_flags & GLOBAL_FLAGS:
+        raise source.error("bad inline flags: cannot turn off global flag", 1)
+    if add_flags & del_flags:
+        raise source.error("bad inline flags: flag turned on and off", 1)
+    return add_flags, del_flags
 
 def fix_flags(src, flags):
     # Check and fix flags according to the type of pattern (str or bytes)
     if isinstance(src, str):
+        if flags & SRE_FLAG_LOCALE:
+            raise ValueError("cannot use LOCALE flag with a str pattern")
         if not flags & SRE_FLAG_ASCII:
             flags |= SRE_FLAG_UNICODE
         elif flags & SRE_FLAG_UNICODE:
             raise ValueError("ASCII and UNICODE flags are incompatible")
     else:
         if flags & SRE_FLAG_UNICODE:
-            raise ValueError("can't use UNICODE flag with a bytes pattern")
+            raise ValueError("cannot use UNICODE flag with a bytes pattern")
+        if flags & SRE_FLAG_LOCALE and flags & SRE_FLAG_ASCII:
+            raise ValueError("ASCII and LOCALE flags are incompatible")
     return flags
 
 def parse(str, flags=0, pattern=None):
@@ -689,22 +852,25 @@ def parse(str, flags=0, pattern=None):
     pattern.flags = flags
     pattern.str = str
 
-    p = _parse_sub(source, pattern, 0)
+    try:
+        p = _parse_sub(source, pattern, flags & SRE_FLAG_VERBOSE, False)
+    except Verbose:
+        # the VERBOSE flag was switched on inside the pattern.  to be
+        # on the safe side, we'll parse the whole thing again...
+        pattern = Pattern()
+        pattern.flags = flags | SRE_FLAG_VERBOSE
+        pattern.str = str
+        source.seek(0)
+        p = _parse_sub(source, pattern, True, False)
+
     p.pattern.flags = fix_flags(str, p.pattern.flags)
 
-    tail = source.get()
-    if tail == ")":
-        raise error("unbalanced parenthesis")
-    elif tail:
-        raise error("bogus characters at end of regular expression")
+    if source.next is not None:
+        assert source.next == ")"
+        raise source.error("unbalanced parenthesis")
 
     if flags & SRE_FLAG_DEBUG:
         p.dump()
-
-    if not (flags & SRE_FLAG_VERBOSE) and p.pattern.flags & SRE_FLAG_VERBOSE:
-        # the VERBOSE flag was switched on inside the pattern.  to be
-        # on the safe side, we'll parse the whole thing again...
-        return parse(str, p.pattern.flags)
 
     return p
 
@@ -713,98 +879,96 @@ def parse_template(source, pattern):
     # group references
     s = Tokenizer(source)
     sget = s.get
-    p = []
-    a = p.append
-    def literal(literal, p=p, pappend=a):
-        if p and p[-1][0] is LITERAL:
-            p[-1] = LITERAL, p[-1][1] + literal
-        else:
-            pappend((LITERAL, literal))
-    sep = source[:0]
-    if isinstance(sep, str):
-        makechar = chr
-    else:
-        makechar = chr
-    while 1:
+    groups = []
+    literals = []
+    literal = []
+    lappend = literal.append
+    def addgroup(index, pos):
+        if index > pattern.groups:
+            raise s.error("invalid group reference %d" % index, pos)
+        if literal:
+            literals.append(''.join(literal))
+            del literal[:]
+        groups.append((len(literals), index))
+        literals.append(None)
+    groupindex = pattern.groupindex
+    while True:
         this = sget()
         if this is None:
             break # end of replacement string
-        if this and this[0] == "\\":
+        if this[0] == "\\":
             # group
-            c = this[1:2]
+            c = this[1]
             if c == "g":
                 name = ""
-                if s.match("<"):
-                    while 1:
-                        char = sget()
-                        if char is None:
-                            raise error("unterminated group name")
-                        if char == ">":
-                            break
-                        name = name + char
-                if not name:
-                    raise error("bad group name")
-                try:
-                    index = int(name)
-                    if index < 0:
-                        raise error("negative group number")
-                except ValueError:
-                    if not isname(name):
-                        raise error("bad character in group name")
+                if not s.match("<"):
+                    raise s.error("missing <")
+                name = s.getuntil(">")
+                if name.isidentifier():
                     try:
-                        index = pattern.groupindex[name]
+                        index = groupindex[name]
                     except KeyError:
-                        raise IndexError("unknown group name")
-                a((MARK, index))
+                        raise IndexError("unknown group name %r" % name)
+                else:
+                    try:
+                        index = int(name)
+                        if index < 0:
+                            raise ValueError
+                    except ValueError:
+                        raise s.error("bad character in group name %r" % name,
+                                      len(name) + 1) from None
+                    if index >= MAXGROUPS:
+                        raise s.error("invalid group reference %d" % index,
+                                      len(name) + 1)
+                addgroup(index, len(name) + 1)
             elif c == "0":
                 if s.next in OCTDIGITS:
-                    this = this + sget()
+                    this += sget()
                     if s.next in OCTDIGITS:
-                        this = this + sget()
-                literal(makechar(int(this[1:], 8) & 0xff))
+                        this += sget()
+                lappend(chr(int(this[1:], 8) & 0xff))
             elif c in DIGITS:
                 isoctal = False
                 if s.next in DIGITS:
-                    this = this + sget()
+                    this += sget()
                     if (c in OCTDIGITS and this[2] in OCTDIGITS and
                         s.next in OCTDIGITS):
-                        this = this + sget()
+                        this += sget()
                         isoctal = True
-                        literal(makechar(int(this[1:], 8) & 0xff))
+                        c = int(this[1:], 8)
+                        if c > 0o377:
+                            raise s.error('octal escape value %s outside of '
+                                          'range 0-0o377' % this, len(this))
+                        lappend(chr(c))
                 if not isoctal:
-                    a((MARK, int(this[1:])))
+                    addgroup(int(this[1:]), len(this) - 1)
             else:
                 try:
-                    this = makechar(ESCAPES[this][1])
+                    this = chr(ESCAPES[this][1])
                 except KeyError:
-                    pass
-                literal(this)
+                    if c in ASCIILETTERS:
+                        import warnings
+                        warnings.warn('bad escape %s' % this,
+                                      DeprecationWarning, stacklevel=4)
+                lappend(this)
         else:
-            literal(this)
-    # convert template to groups and literals lists
-    i = 0
-    groups = []
-    groupsappend = groups.append
-    literals = [None] * len(p)
-    for c, s in p:
-        if c is MARK:
-            groupsappend((i, s))
-            # literal[i] is already None
-        else:
-            literals[i] = s
-        i = i + 1
+            lappend(this)
+    if literal:
+        literals.append(''.join(literal))
+    if not isinstance(source, str):
+        # The tokenizer implicitly decodes bytes objects as latin-1, we must
+        # therefore re-encode the final representation.
+        literals = [None if s is None else s.encode('latin-1') for s in literals]
     return groups, literals
 
 def expand_template(template, match):
     g = match.group
-    sep = match.string[:0]
+    empty = match.string[:0]
     groups, literals = template
     literals = literals[:]
     try:
         for index, group in groups:
-            literals[index] = s = g(group)
-            if s is None:
-                raise error("unmatched group")
+            literals[index] = g(group) or empty
     except IndexError:
-        raise error("invalid group reference")
-    return sep.join(literals)
+        raise error("invalid group reference %d" % index)
+    return empty.join(literals)

--- a/Lib/textwrap.py
+++ b/Lib/textwrap.py
@@ -113,7 +113,7 @@ class TextWrapper:
     sentence_end_re = re.compile(r'[a-z]'             # lowercase letter
                                  r'[\.!\?]'          # sentence-ending punct.
                                  r'["\']?'           # optional end-of-quote
-                                 r'\z')               # end of chunk
+                                 r'\Z')               # end of chunk
 
     def __init__(self,
                  width=70,

--- a/vm/src/obj/objnamespace.rs
+++ b/vm/src/obj/objnamespace.rs
@@ -11,6 +11,7 @@ use crate::vm::VirtualMachine;
 pub struct PyNamespace;
 
 impl PyValue for PyNamespace {
+    const HAVE_DICT: bool = true;
     fn class(vm: &VirtualMachine) -> PyClassRef {
         vm.ctx.namespace_type()
     }
@@ -18,12 +19,13 @@ impl PyValue for PyNamespace {
 
 #[pyimpl]
 impl PyNamespace {
-    #[pymethod(name = "__init__")]
-    fn init(zelf: PyRef<Self>, kwargs: KwArgs, vm: &VirtualMachine) -> PyResult<()> {
+    #[pyslot(new)]
+    fn tp_new(cls: PyClassRef, kwargs: KwArgs, vm: &VirtualMachine) -> PyResult<PyRef<Self>> {
+        let zelf = PyNamespace.into_ref_with_type(vm, cls)?;
         for (name, value) in kwargs.into_iter() {
             vm.set_attr(zelf.as_object(), name, value)?;
         }
-        Ok(())
+        Ok(zelf)
     }
 }
 

--- a/vm/src/stdlib/array.rs
+++ b/vm/src/stdlib/array.rs
@@ -165,10 +165,10 @@ def_array_enum!(
     // TODO: support unicode char
     (SignedShort, i16, 'h'),
     (UnsignedShort, u16, 'H'),
-    (SignedInt, i16, 'i'),
-    (UnsignedInt, u16, 'I'),
-    (SignedLong, i32, 'l'),
-    (UnsignedLong, u32, 'L'),
+    (SignedInt, i32, 'i'),
+    (UnsignedInt, u32, 'I'),
+    (SignedLong, i64, 'l'),
+    (UnsignedLong, u64, 'L'),
     (SignedLongLong, i64, 'q'),
     (UnsignedLongLong, u64, 'Q'),
     (Float, f32, 'f'),
@@ -306,6 +306,16 @@ impl PyArray {
     }
 
     #[pymethod]
+    fn tolist(&self, vm: &VirtualMachine) -> PyResult {
+        let array = self.array.borrow();
+        let mut v = Vec::with_capacity(array.len());
+        for obj in array.iter(vm) {
+            v.push(obj?);
+        }
+        Ok(vm.ctx.new_list(v))
+    }
+
+    #[pymethod]
     fn reverse(&self, _vm: &VirtualMachine) {
         self.array.borrow_mut().reverse()
     }
@@ -336,6 +346,11 @@ impl PyArray {
             }
             Ok(vm.new_bool(true))
         }
+    }
+
+    #[pymethod(name = "__len__")]
+    fn len(&self, _vm: &VirtualMachine) -> usize {
+        self.array.borrow().len()
     }
 
     #[pymethod(name = "__iter__")]

--- a/vm/src/stdlib/mod.rs
+++ b/vm/src/stdlib/mod.rs
@@ -68,7 +68,7 @@ pub fn get_module_inits() -> HashMap<String, StdlibInitFunc> {
         "marshal".to_string() => Box::new(marshal::make_module),
         "math".to_string() => Box::new(math::make_module),
         "platform".to_string() => Box::new(platform::make_module),
-        "re".to_string() => Box::new(re::make_module),
+        "regex_crate".to_string() => Box::new(re::make_module),
         "random".to_string() => Box::new(random::make_module),
         "_string".to_string() => Box::new(string::make_module),
         "struct".to_string() => Box::new(pystruct::make_module),

--- a/vm/src/stdlib/re.rs
+++ b/vm/src/stdlib/re.rs
@@ -455,7 +455,7 @@ pub fn make_module(vm: &VirtualMachine) -> PyObjectRef {
     let match_type = PyMatch::make_class(ctx);
     let pattern_type = PyPattern::make_class(ctx);
 
-    py_module!(vm, "re", {
+    py_module!(vm, "regex_crate", {
         "compile" => ctx.new_rustfunc(re_compile),
         "escape" => ctx.new_rustfunc(re_escape),
         "purge" => ctx.new_rustfunc(re_purge),


### PR DESCRIPTION
So it turns out that [`_sre.py`](https://github.com/nikhaldi/_sre.py) actually is fairly compatible with Python 3's `re`. The `re` and `sre_*` python modules are taken from Python 3.0, but I may be able to use the Python 3.6 ones, I haven't tried yet. I kept the Rust `re` module, but I renamed it to `regex_crate`; I'm not sure if that's a good name or what we should do with it in general.