### PR TITLE
Revert "Fix argument keyword error in int/float/bool.__new__"

### DIFF
--- a/tests/snippets/bools.py
+++ b/tests/snippets/bools.py
@@ -16,8 +16,6 @@ assert not None
 
 assert bool() == False
 assert bool(1) == True
-assert bool(x=True) == True
-assert bool(x=False) == False
 assert bool({}) == False
 
 assert bool(NotImplemented) == True

--- a/tests/snippets/floats.py
+++ b/tests/snippets/floats.py
@@ -150,8 +150,6 @@ assert 1.2.__float__() == 1.2
 assert 1.2.__trunc__() == 1
 assert int(1.2) == 1
 assert float(1.2) == 1.2
-assert float(x=1.2) == 1.2
-assert float(x='1.2') == 1.2
 assert math.trunc(1.2) == 1
 assert_raises(OverflowError, float('inf').__trunc__)
 assert_raises(ValueError, float('nan').__trunc__)

--- a/tests/snippets/ints.py
+++ b/tests/snippets/ints.py
@@ -151,10 +151,6 @@ assert int('1 ') == 1
 assert int(' 1 ') == 1
 assert int('10', base=0) == 10
 
-assert int(x=10) == 10
-assert int(x='10') == 10
-assert int(x='10', base=0) == 10
-
 # type byte, signed, implied base
 assert int(b'     -0XFF ', base=0) == -255
 

--- a/vm/src/obj/objbool.rs
+++ b/vm/src/obj/objbool.rs
@@ -1,7 +1,7 @@
 use num_bigint::Sign;
 use num_traits::Zero;
 
-use crate::function::{OptionalArg, PyFuncArgs};
+use crate::function::PyFuncArgs;
 use crate::pyobject::{
     IntoPyObject, PyContext, PyObjectRef, PyResult, TryFromObject, TypeProtocol,
 };
@@ -188,16 +188,19 @@ fn bool_rxor(lhs: PyObjectRef, rhs: PyObjectRef, vm: &VirtualMachine) -> PyResul
     do_bool_xor(vm, &lhs, &rhs)
 }
 
-#[derive(FromArgs)]
-struct BoolArgs {
-    #[pyarg(positional_or_keyword, optional = true)]
-    x: OptionalArg<PyObjectRef>,
-}
-
-fn bool_new(_cls: objtype::PyClassRef, args: BoolArgs, vm: &VirtualMachine) -> PyResult {
-    Ok(match args.x {
-        OptionalArg::Present(x) => vm.new_bool(boolval(vm, x.clone())?),
-        OptionalArg::Missing => vm.context().new_bool(false),
+fn bool_new(vm: &VirtualMachine, args: PyFuncArgs) -> PyResult {
+    arg_check!(
+        vm,
+        args,
+        required = [(_zelf, Some(vm.ctx.type_type()))],
+        optional = [(val, None)]
+    );
+    Ok(match val {
+        Some(val) => {
+            let bv = boolval(vm, val.clone())?;
+            vm.new_bool(bv)
+        }
+        None => vm.context().new_bool(false),
     })
 }
 

--- a/vm/src/obj/objfloat.rs
+++ b/vm/src/obj/objfloat.rs
@@ -154,18 +154,16 @@ fn inner_gt_int(value: f64, other_int: &BigInt) -> bool {
     }
 }
 
-#[derive(FromArgs)]
-struct FloatArgs {
-    #[pyarg(positional_or_keyword, optional = true)]
-    x: OptionalArg<PyObjectRef>,
-}
-
 #[pyimpl]
 #[allow(clippy::trivially_copy_pass_by_ref)]
 impl PyFloat {
     #[pyslot(new)]
-    fn tp_new(cls: PyClassRef, arg: FloatArgs, vm: &VirtualMachine) -> PyResult<PyFloatRef> {
-        let float_val = match arg.x {
+    fn tp_new(
+        cls: PyClassRef,
+        arg: OptionalArg<PyObjectRef>,
+        vm: &VirtualMachine,
+    ) -> PyResult<PyFloatRef> {
+        let float_val = match arg {
             OptionalArg::Present(val) => to_float(vm, &val),
             OptionalArg::Missing => Ok(0f64),
         };

--- a/vm/src/obj/objint.rs
+++ b/vm/src/obj/objint.rs
@@ -690,15 +690,15 @@ impl PyInt {
 
 #[derive(FromArgs)]
 struct IntOptions {
-    #[pyarg(positional_or_keyword, optional = true)]
-    x: OptionalArg<PyObjectRef>,
+    #[pyarg(positional_only, optional = true)]
+    val_options: OptionalArg<PyObjectRef>,
     #[pyarg(positional_or_keyword, optional = true)]
     base: OptionalArg<PyIntRef>,
 }
 
 impl IntOptions {
     fn get_int_value(self, vm: &VirtualMachine) -> PyResult<BigInt> {
-        if let OptionalArg::Present(val) = self.x {
+        if let OptionalArg::Present(val) = self.val_options {
             let base = if let OptionalArg::Present(base) = self.base {
                 if !(objtype::isinstance(&val, &vm.ctx.str_type())
                     || objtype::isinstance(&val, &vm.ctx.bytes_type()))


### PR DESCRIPTION
Reverts RustPython/RustPython#1444. Apparently `int(x=...)` [is a bug in and of itself](https://github.com/RustPython/RustPython/issues/1440#issuecomment-537757189) which was fixed in CPython 3.7.