### PR TITLE
Fix #1394 Memoryview hash problem

### DIFF
--- a/tests/snippets/memoryview.py
+++ b/tests/snippets/memoryview.py
@@ -4,3 +4,5 @@ a = memoryview(obj)
 assert a.obj == obj
 
 assert a[2:3] == b"c"
+
+assert hash(obj) == hash(a)

--- a/vm/src/obj/objmemory.rs
+++ b/vm/src/obj/objmemory.rs
@@ -34,6 +34,11 @@ impl PyMemoryView {
         self.obj_ref.clone()
     }
 
+    #[pymethod(name = "__hash__")]
+    fn hash(&self, vm: &VirtualMachine) -> PyResult {
+        vm.call_method(&self.obj_ref, "__hash__", vec![])
+    }
+
     #[pymethod(name = "__getitem__")]
     fn getitem(&self, needle: PyObjectRef, vm: &VirtualMachine) -> PyResult {
         vm.call_method(&self.obj_ref, "__getitem__", vec![needle])


### PR DESCRIPTION
#1394

Hash value of memoryview should be hash value of the wrapped object.
```python3
hash(memoryview(b'abcdef')) == hash(b'abcdef')
```

And currently ```memoryview.__hash__()``` returns hash value of itself as below.
https://github.com/RustPython/RustPython/blob/162ff58f1667328da3777a33981c80d363f1df26/vm/src/obj/objobject.rs#L59-L61

So I made it to call ```__hash__()``` of ```obj_ref```.