### PR TITLE
Add RecursionError

### DIFF
--- a/tests/snippets/sysmod.py
+++ b/tests/snippets/sysmod.py
@@ -1,5 +1,7 @@
 import sys
 
+from testutils import assert_raises
+
 print('python executable:', sys.executable)
 print(sys.argv)
 assert sys.argv[0].endswith('.py')
@@ -60,10 +62,5 @@ def recursive_call(n):
 sys.setrecursionlimit(200)
 assert sys.getrecursionlimit() == 200
 
-exc = None
-try:
+with assert_raises(RecursionError):
     recursive_call(300)
-except RecursionError as exc:
-    pass
-
-assert exc is not None

--- a/tests/snippets/sysmod.py
+++ b/tests/snippets/sysmod.py
@@ -49,3 +49,21 @@ except ZeroDivisionError as exc:
 	exc_info = sys.exc_info()
 	assert exc_info[0] == type(exc) == ZeroDivisionError
 	assert exc_info[1] == exc
+
+
+# Recursion:
+
+def recursive_call(n):
+    if n > 0:
+        recursive_call(n - 1)
+
+sys.setrecursionlimit(200)
+assert sys.getrecursionlimit() == 200
+
+exc = None
+try:
+    recursive_call(300)
+except RecursionError as exc:
+    pass
+
+assert exc is not None

--- a/vm/src/builtins.rs
+++ b/vm/src/builtins.rs
@@ -851,6 +851,7 @@ pub fn make_module(vm: &VirtualMachine, module: PyObjectRef) {
         "ReferenceError" => ctx.exceptions.reference_error.clone(),
         "SyntaxError" =>  ctx.exceptions.syntax_error.clone(),
         "NotImplementedError" => ctx.exceptions.not_implemented_error.clone(),
+        "RecursionError" => ctx.exceptions.recursion_error.clone(),
         "TypeError" => ctx.exceptions.type_error.clone(),
         "ValueError" => ctx.exceptions.value_error.clone(),
         "IndexError" => ctx.exceptions.index_error.clone(),

--- a/vm/src/exceptions.rs
+++ b/vm/src/exceptions.rs
@@ -222,6 +222,7 @@ pub struct ExceptionZoo {
     pub module_not_found_error: PyClassRef,
     pub name_error: PyClassRef,
     pub not_implemented_error: PyClassRef,
+    pub recursion_error: PyClassRef,
     pub os_error: PyClassRef,
     pub overflow_error: PyClassRef,
     pub permission_error: PyClassRef,
@@ -280,6 +281,7 @@ impl ExceptionZoo {
         let zero_division_error = create_type("ZeroDivisionError", &type_type, &arithmetic_error);
         let module_not_found_error = create_type("ModuleNotFoundError", &type_type, &import_error);
         let not_implemented_error = create_type("NotImplementedError", &type_type, &runtime_error);
+        let recursion_error = create_type("RecursionError", &type_type, &runtime_error);
         let file_not_found_error = create_type("FileNotFoundError", &type_type, &os_error);
         let permission_error = create_type("PermissionError", &type_type, &os_error);
         let file_exists_error = create_type("FileExistsError", &type_type, &os_error);
@@ -321,6 +323,7 @@ impl ExceptionZoo {
             module_not_found_error,
             name_error,
             not_implemented_error,
+            recursion_error,
             os_error,
             overflow_error,
             permission_error,

--- a/vm/src/sysmodule.rs
+++ b/vm/src/sysmodule.rs
@@ -148,14 +148,14 @@ fn update_use_tracing(vm: &VirtualMachine) {
 }
 
 fn sys_getrecursionlimit(vm: &VirtualMachine) -> usize {
-    *vm.recursion_limit.borrow()
+    vm.recursion_limit.get()
 }
 
 fn sys_setrecursionlimit(recursion_limit: usize, vm: &VirtualMachine) -> PyResult {
     let recursion_depth = vm.frames.borrow().len();
 
     if recursion_limit > recursion_depth + 1 {
-        vm.recursion_limit.replace(recursion_limit);
+        vm.recursion_limit.set(recursion_limit);
         Ok(vm.ctx.none())
     } else {
         Err(vm.new_recursion_error(format!(

--- a/vm/src/vm.rs
+++ b/vm/src/vm.rs
@@ -4,7 +4,7 @@
 //!   https://github.com/ProgVal/pythonvm-rust/blob/master/src/processor/mod.rs
 //!
 
-use std::cell::{Ref, RefCell};
+use std::cell::{Ref, RefCell, Cell};
 use std::collections::hash_map::HashMap;
 use std::collections::hash_set::HashSet;
 use std::fmt;
@@ -65,7 +65,7 @@ pub struct VirtualMachine {
     pub use_tracing: RefCell<bool>,
     pub signal_handlers: RefCell<[PyObjectRef; NSIG]>,
     pub settings: PySettings,
-    pub recursion_limit: RefCell<usize>,
+    pub recursion_limit: Cell<usize>,
 }
 
 pub const NSIG: usize = 64;
@@ -187,7 +187,7 @@ impl VirtualMachine {
             use_tracing: RefCell::new(false),
             signal_handlers,
             settings,
-            recursion_limit: RefCell::new(512),
+            recursion_limit: Cell::new(512),
         };
 
         objmodule::init_module_dict(
@@ -233,7 +233,7 @@ impl VirtualMachine {
     }
 
     fn check_recursive_call(&self, _where: &str) -> PyResult<()> {
-        if self.frames.borrow().len() > *self.recursion_limit.borrow() {
+        if self.frames.borrow().len() > self.recursion_limit.get() {
             Err(self.new_recursion_error(format!("maximum recursion depth exceeded {}", _where)))
         } else {
             Ok(())

--- a/vm/src/vm.rs
+++ b/vm/src/vm.rs
@@ -4,7 +4,7 @@
 //!   https://github.com/ProgVal/pythonvm-rust/blob/master/src/processor/mod.rs
 //!
 
-use std::cell::{Ref, RefCell, Cell};
+use std::cell::{Cell, Ref, RefCell};
 use std::collections::hash_map::HashMap;
 use std::collections::hash_set::HashSet;
 use std::fmt;


### PR DESCRIPTION
Partial solution of #1374

I made a small change to check recursion depth before push the frame and then raise error instead of run until segmentation fault occurs.

But it seems there is still a problem. RustPython occurs segmentation fault on 700 (debug) ~ 2600 (release) recursive calls while cpython is fine until 15000. This is the reason that I set default limit lower than cpython.

If there is any inappropriate changes, please let me know. Thank you.