### PR TITLE
Fix #1003 Construct memoryview from bytes-like obejcts

### DIFF
--- a/tests/snippets/memoryview.py
+++ b/tests/snippets/memoryview.py
@@ -1,3 +1,6 @@
+import array
+
+from testutils import assert_raises
 
 obj = b"abcde"
 a = memoryview(obj)
@@ -6,3 +9,23 @@ assert a.obj == obj
 assert a[2:3] == b"c"
 
 assert hash(obj) == hash(a)
+
+class A(array.array):
+    ...
+
+class B(bytes):
+    ...
+
+class C():
+    ...
+
+memoryview(bytearray('abcde', encoding='utf-8'))
+memoryview(array.array('i', [1, 2, 3]))
+memoryview(A('b', [0]))
+memoryview(B('abcde', encoding='utf-8'))
+
+assert_raises(TypeError, lambda: memoryview([1, 2, 3]))
+assert_raises(TypeError, lambda: memoryview((1, 2, 3)))
+assert_raises(TypeError, lambda: memoryview({}))
+assert_raises(TypeError, lambda: memoryview('string'))
+assert_raises(TypeError, lambda: memoryview(C()))

--- a/vm/src/stdlib/mod.rs
+++ b/vm/src/stdlib/mod.rs
@@ -1,4 +1,4 @@
-mod array;
+pub mod array;
 #[cfg(feature = "rustpython-parser")]
 mod ast;
 mod binascii;


### PR DESCRIPTION
#1003 

Now memoryview object can only be constructed from (memoryview|bytes|bytearray|array.array) and its subclasses.

Am I missing any bytes-like objects that should be able to construct memoryview?