### PR TITLE
Implement delattr for type object

### DIFF
--- a/tests/snippets/attr.py
+++ b/tests/snippets/attr.py
@@ -4,11 +4,20 @@ from testutils import assert_raises
 class A:
     pass
 
+class B:
+    x = 50
 
 a = A()
 a.b = 10
 assert hasattr(a, 'b')
 assert a.b == 10
+
+assert B.x == 50
+
+# test delete class attribute with del keyword
+del B.x
+with assert_raises(AttributeError):
+    _ = B.x
 
 # test override attribute
 setattr(a, 'b', 12)


### PR DESCRIPTION
Implement delattr for type object

### Before
```
>>>>> class C:
.....   x = 10
..... 
>>>>> del C.x
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
AttributeError: 'type' object has no attribute 'x'
>>>>> C.x
10
```

### After
```
>>>>> class C:
.....   x = 10
.....
>>>>> del C.x
>>>>> C.x
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
AttributeError: C has no attribute 'x'
```

Fixed: #1404