### PR TITLE
Take only numbers after `.`

### DIFF
--- a/parser/src/lexer.rs
+++ b/parser/src/lexer.rs
@@ -357,6 +357,12 @@ where
         if self.chr0 == Some('.') || self.at_exponent() {
             // Take '.':
             if self.chr0 == Some('.') {
+                if self.chr1 == Some('_') {
+                    return Err(LexicalError {
+                        error: LexicalErrorType::OtherError("Invalid Syntax".to_string()),
+                        location: self.get_pos(),
+                    });
+                }
                 value_text.push(self.next_char().unwrap());
                 value_text.push_str(&self.radix_run(10));
             }
@@ -416,6 +422,7 @@ where
     /// like this: '1_2_3_4' == '1234'
     fn radix_run(&mut self, radix: u32) -> String {
         let mut value_text = String::new();
+
         loop {
             if let Some(c) = self.take_number(radix) {
                 value_text.push(c);

--- a/tests/snippets/floats.py
+++ b/tests/snippets/floats.py
@@ -206,6 +206,26 @@ assert str(1.123456789) == '1.123456789'
 # Test special case for lexer, float starts with a dot:
 a = .5
 assert a == 0.5
+assert 3.14 == float('3.14')
+src = """
+a = 3._14
+"""
+
+with assert_raises(SyntaxError):
+    exec(src)
+src = """
+a = 3.__14
+"""
+
+with assert_raises(SyntaxError):
+    exec(src)
+
+src = """
+a = 3.1__4
+"""
+
+with assert_raises(SyntaxError):
+    exec(src)
 
 assert float.fromhex('0x0.0p+0') == 0.0
 assert float.fromhex('-0x0.0p+0') == -0.0


### PR DESCRIPTION
Take only numbers not `_` after `.`

Fixes #1498