### PR TITLE
Defer BigInt::clone() for new_int

### DIFF
--- a/vm/src/obj/objenumerate.rs
+++ b/vm/src/obj/objenumerate.rs
@@ -55,7 +55,7 @@ impl PyEnumerate {
         let next_obj = objiter::call_next(vm, iterator)?;
         let result = vm
             .ctx
-            .new_tuple(vec![vm.ctx.new_int(counter.borrow().clone()), next_obj]);
+            .new_tuple(vec![vm.ctx.new_bigint(&counter.borrow()), next_obj]);
 
         AddAssign::add_assign(&mut counter.borrow_mut() as &mut BigInt, 1);
 

--- a/vm/src/obj/objfloat.rs
+++ b/vm/src/obj/objfloat.rs
@@ -560,8 +560,8 @@ impl PyFloat {
         }
 
         let ratio = Ratio::from_float(value).unwrap();
-        let numer = vm.ctx.new_int(ratio.numer().clone());
-        let denom = vm.ctx.new_int(ratio.denom().clone());
+        let numer = vm.ctx.new_bigint(ratio.numer());
+        let denom = vm.ctx.new_bigint(ratio.denom());
         Ok(vm.ctx.new_tuple(vec![numer, denom]))
     }
 

--- a/vm/src/obj/objint.rs
+++ b/vm/src/obj/objint.rs
@@ -126,8 +126,10 @@ fn inner_pow(int1: &PyInt, int2: &PyInt, vm: &VirtualMachine) -> PyResult {
     } else {
         Ok(if let Some(v2) = int2.value.to_u64() {
             vm.ctx.new_int(int1.value.pow(v2))
-        } else if int1.value.is_one() || int1.value.is_zero() {
-            vm.ctx.new_int(int1.value.clone())
+        } else if int1.value.is_one() {
+            vm.ctx.new_int(1)
+        } else if int1.value.is_zero() {
+            vm.ctx.new_int(0)
         } else if int1.value == BigInt::from(-1) {
             if int2.value.is_odd() {
                 vm.ctx.new_int(-1)
@@ -674,7 +676,7 @@ impl PyInt {
     }
     #[pyproperty]
     fn real(&self, vm: &VirtualMachine) -> PyObjectRef {
-        vm.ctx.new_int(self.value.clone())
+        vm.ctx.new_bigint(&self.value)
     }
 
     #[pyproperty]

--- a/vm/src/pyobject.rs
+++ b/vm/src/pyobject.rs
@@ -384,6 +384,17 @@ impl PyContext {
         PyObject::new(PyInt::new(i), self.int_type(), None)
     }
 
+    #[inline]
+    pub fn new_bigint(&self, i: &BigInt) -> PyObjectRef {
+        if let Some(i) = i.to_i32() {
+            if i >= INT_CACHE_POOL_MIN && i <= INT_CACHE_POOL_MAX {
+                let inner_idx = (i - INT_CACHE_POOL_MIN) as usize;
+                return self.int_cache_pool[inner_idx].clone();
+            }
+        }
+        PyObject::new(PyInt::new(i.clone()), self.int_type(), None)
+    }
+
     pub fn new_float(&self, value: f64) -> PyObjectRef {
         PyObject::new(PyFloat::from(value), self.float_type(), None)
     }
@@ -519,7 +530,7 @@ impl PyContext {
 
     pub fn unwrap_constant(&self, value: &bytecode::Constant) -> PyObjectRef {
         match *value {
-            bytecode::Constant::Integer { ref value } => self.new_int(value.clone()),
+            bytecode::Constant::Integer { ref value } => self.new_bigint(value),
             bytecode::Constant::Float { ref value } => self.new_float(*value),
             bytecode::Constant::Complex { ref value } => self.new_complex(*value),
             bytecode::Constant::String { ref value } => self.new_str(value.clone()),


### PR DESCRIPTION
This change will reduce useless `BigInt::clone()` for a few cases.