### PR TITLE
print_exception can print to places that aren't stdout

### DIFF
--- a/vm/src/lib.rs
+++ b/vm/src/lib.rs
@@ -73,7 +73,7 @@ mod version;
 mod vm;
 
 // pub use self::pyobject::Executor;
-pub use self::exceptions::print_exception;
+pub use self::exceptions::{print_exception, write_exception};
 pub use self::vm::{PySettings, VirtualMachine};
 pub use rustpython_bytecode::*;
 


### PR DESCRIPTION
This should allow me to .. show users errors.

I've left `print_exception` ignoring the error, as this is what `println!` does. I'd be happy for it to return the error.