### PR TITLE
locals() return copy of locals dictionary

### DIFF
--- a/tests/snippets/global_nonlocal.py
+++ b/tests/snippets/global_nonlocal.py
@@ -85,3 +85,27 @@ with assert_raises(SyntaxError):
 #     nonlocal c
 #     c = 2
 
+def a():
+    x = 0
+    locals()['x'] = 3
+    assert x == 0
+
+a()
+
+def a():
+    x = 0
+    del locals()['x']
+    assert x == 0
+
+a()
+
+def a():
+    x = 0
+    b = locals()
+    assert b['x'] == 0
+
+    del b['x']
+    b = locals()
+    assert b['x'] == 0
+
+a()

--- a/vm/src/builtins.rs
+++ b/vm/src/builtins.rs
@@ -366,7 +366,8 @@ fn builtin_len(obj: PyObjectRef, vm: &VirtualMachine) -> PyResult {
 }
 
 fn builtin_locals(vm: &VirtualMachine) -> PyDictRef {
-    vm.get_locals()
+    let locals = vm.get_locals();
+    locals.copy(vm).into_ref(vm)
 }
 
 fn builtin_max(vm: &VirtualMachine, args: PyFuncArgs) -> PyResult {

--- a/vm/src/obj/objdict.rs
+++ b/vm/src/obj/objdict.rs
@@ -279,7 +279,7 @@ impl PyDictRef {
         }
     }
 
-    fn copy(self, _vm: &VirtualMachine) -> PyDict {
+    pub fn copy(self, _vm: &VirtualMachine) -> PyDict {
         PyDict {
             entries: self.entries.clone(),
         }


### PR DESCRIPTION
Return copy of locals so that local variables
does not change even if locals() values is changed

Fixes #1356