### PR TITLE
`sys.std{in,out,err}` implemented in the most simple way

### DIFF
--- a/Lib/_sitebuiltins.py
+++ b/Lib/_sitebuiltins.py
@@ -12,8 +12,8 @@ import os
 import sys
 
 sys.stdin = sys.__stdin__ = getattr(sys, '__stdin__', False) or os.fdopen(0, "r")
-sys.stdout = sys.__stdin__ = getattr(sys, '__stdout__', False) or os.fdopen(1, "w")
-sys.stderr = sys.__stdin__ = getattr(sys, '__stderr__', False) or os.fdopen(2, "w")
+sys.stdout = sys.__stdout__ = getattr(sys, '__stdout__', False) or os.fdopen(1, "w")
+sys.stderr = sys.__stderr__ = getattr(sys, '__stderr__', False) or os.fdopen(2, "w")
 
 
 class Quitter(object):

--- a/Lib/_sitebuiltins.py
+++ b/Lib/_sitebuiltins.py
@@ -10,6 +10,11 @@ The objects used by the site module to add custom builtins.
 
 import sys
 
+sys.stdin = getattr(sys, 'stdin', False) or open('/dev/stdin')
+sys.stdout = getattr(sys, 'stdout', False) or open('/dev/stdout', 'w')
+sys.stderr = getattr(sys, 'stderr', False) or open('/dev/stderr', 'w')
+
+
 class Quitter(object):
     def __init__(self, name, eof):
         self.name = name

--- a/Lib/_sitebuiltins.py
+++ b/Lib/_sitebuiltins.py
@@ -8,11 +8,12 @@ The objects used by the site module to add custom builtins.
 # Note this means this module should also avoid keep things alive in its
 # globals.
 
+import os
 import sys
 
-sys.stdin = sys.__stdin__ = getattr(sys, '__stdin__', False) or open('/dev/stdin')
-sys.stdout = sys.__stdin__ = getattr(sys, '__stdout__', False) or open('/dev/stdout', 'w')
-sys.stderr = sys.__stdin__ = getattr(sys, '__stderr__', False) or open('/dev/stderr', 'w')
+sys.stdin = sys.__stdin__ = getattr(sys, '__stdin__', False) or os.fdopen(0, "r")
+sys.stdout = sys.__stdin__ = getattr(sys, '__stdout__', False) or os.fdopen(1, "w")
+sys.stderr = sys.__stdin__ = getattr(sys, '__stderr__', False) or os.fdopen(2, "w")
 
 
 class Quitter(object):

--- a/Lib/_sitebuiltins.py
+++ b/Lib/_sitebuiltins.py
@@ -10,9 +10,9 @@ The objects used by the site module to add custom builtins.
 
 import sys
 
-sys.stdin = getattr(sys, 'stdin', False) or open('/dev/stdin')
-sys.stdout = getattr(sys, 'stdout', False) or open('/dev/stdout', 'w')
-sys.stderr = getattr(sys, 'stderr', False) or open('/dev/stderr', 'w')
+sys.stdin = sys.__stdin__ = getattr(sys, '__stdin__', False) or open('/dev/stdin')
+sys.stdout = sys.__stdin__ = getattr(sys, '__stdout__', False) or open('/dev/stdout', 'w')
+sys.stderr = sys.__stdin__ = getattr(sys, '__stderr__', False) or open('/dev/stderr', 'w')
 
 
 class Quitter(object):


### PR DESCRIPTION
Opens the files on initialization and attaches to `sys.std{in,out,err}`
- It respects what already exists if any
- Otherwise it opens de UNIX standard files

Caveats:
- May be not on the proper place
- Is open to discussion on what codec, or if should be opened as bytes
- Can be also done in Rust side