### PR TITLE
Add os.system

### DIFF
--- a/tests/snippets/stdlib_os.py
+++ b/tests/snippets/stdlib_os.py
@@ -313,3 +313,18 @@ with TestWithTempDir() as tmpdir:
         with os.scandir() as dir_iter:
             collected_files = [dir_entry.name for dir_entry in dir_iter]
             assert set(collected_files) == set(expected_files)
+
+# system()
+if "win" not in sys.platform:
+    assert os.system('ls') == 0
+    assert os.system('{') != 0
+
+    for arg in [None, 1, 1.0, TabError]:
+        try:
+            os.system(arg)
+        except TypeError:
+            pass
+        else:
+            raise AssertionError(f'os.system failed to raise TypeError with arg {arg}')
+
+

--- a/vm/src/stdlib/os.rs
+++ b/vm/src/stdlib/os.rs
@@ -943,6 +943,17 @@ fn os_chdir(path: PyStringRef, vm: &VirtualMachine) -> PyResult<()> {
 }
 
 #[cfg(unix)]
+fn os_system(command: PyStringRef, vm: &VirtualMachine) -> PyResult<i32> {
+    use libc::system;
+    use std::ffi::CString;
+
+    let rstr = command.as_str();
+    let cstr = CString::new(rstr).unwrap();
+    let x = unsafe { system(cstr.as_ptr()) };
+    Ok(x)
+}
+
+#[cfg(unix)]
 fn os_chmod(
     path: PyStringRef,
     dir_fd: DirFd,
@@ -1292,6 +1303,7 @@ pub fn make_module(vm: &VirtualMachine) -> PyObjectRef {
 fn extend_module_platform_specific(vm: &VirtualMachine, module: PyObjectRef) -> PyObjectRef {
     let ctx = &vm.ctx;
     extend_module!(vm, module, {
+        "system" => ctx.new_rustfunc(os_system),
         "getppid" => ctx.new_rustfunc(os_getppid),
         "getgid" => ctx.new_rustfunc(os_getgid),
         "getegid" => ctx.new_rustfunc(os_getegid),

--- a/vm/src/stdlib/os.rs
+++ b/vm/src/stdlib/os.rs
@@ -943,7 +943,7 @@ fn os_chdir(path: PyStringRef, vm: &VirtualMachine) -> PyResult<()> {
 }
 
 #[cfg(unix)]
-fn os_system(command: PyStringRef, vm: &VirtualMachine) -> PyResult<i32> {
+fn os_system(command: PyStringRef, _vm: &VirtualMachine) -> PyResult<i32> {
     use libc::system;
     use std::ffi::CString;
 

--- a/vm/src/stdlib/os.rs
+++ b/vm/src/stdlib/os.rs
@@ -1303,7 +1303,8 @@ pub fn make_module(vm: &VirtualMachine) -> PyObjectRef {
 fn extend_module_platform_specific(vm: &VirtualMachine, module: PyObjectRef) -> PyObjectRef {
     let ctx = &vm.ctx;
     extend_module!(vm, module, {
-        "system" => ctx.new_rustfunc(os_system),
+        "access" => ctx.new_rustfunc(os_access),
+        "chmod" => ctx.new_rustfunc(os_chmod),
         "getppid" => ctx.new_rustfunc(os_getppid),
         "getgid" => ctx.new_rustfunc(os_getgid),
         "getegid" => ctx.new_rustfunc(os_getegid),
@@ -1313,16 +1314,8 @@ fn extend_module_platform_specific(vm: &VirtualMachine, module: PyObjectRef) -> 
         "setgid" => ctx.new_rustfunc(os_setgid),
         "setpgid" => ctx.new_rustfunc(os_setpgid),
         "setuid" => ctx.new_rustfunc(os_setuid),
-        "access" => ctx.new_rustfunc(os_access),
-        "O_DSYNC" => ctx.new_int(libc::O_DSYNC),
-        "O_NDELAY" => ctx.new_int(libc::O_NDELAY),
-        "O_NOCTTY" => ctx.new_int(libc::O_NOCTTY),
-        "O_CLOEXEC" => ctx.new_int(libc::O_CLOEXEC),
-        "chmod" => ctx.new_rustfunc(os_chmod),
+        "system" => ctx.new_rustfunc(os_system),
         "ttyname" => ctx.new_rustfunc(os_ttyname),
-        "SEEK_SET" => ctx.new_int(Whence::SeekSet as i8),
-        "SEEK_CUR" => ctx.new_int(Whence::SeekCur as i8),
-        "SEEK_END" => ctx.new_int(Whence::SeekEnd as i8),
         "EX_OK" => ctx.new_int(exitcode::OK as i8),
         "EX_USAGE" => ctx.new_int(exitcode::USAGE as i8),
         "EX_DATAERR" => ctx.new_int(exitcode::DATAERR as i8),
@@ -1339,6 +1332,13 @@ fn extend_module_platform_specific(vm: &VirtualMachine, module: PyObjectRef) -> 
         "EX_PROTOCOL" => ctx.new_int(exitcode::PROTOCOL as i8),
         "EX_NOPERM" => ctx.new_int(exitcode::NOPERM as i8),
         "EX_CONFIG" => ctx.new_int(exitcode::CONFIG as i8),
+        "O_DSYNC" => ctx.new_int(libc::O_DSYNC),
+        "O_NDELAY" => ctx.new_int(libc::O_NDELAY),
+        "O_NOCTTY" => ctx.new_int(libc::O_NOCTTY),
+        "O_CLOEXEC" => ctx.new_int(libc::O_CLOEXEC),
+        "SEEK_SET" => ctx.new_int(Whence::SeekSet as i8),
+        "SEEK_CUR" => ctx.new_int(Whence::SeekCur as i8),
+        "SEEK_END" => ctx.new_int(Whence::SeekEnd as i8),
     });
 
     #[cfg(not(target_os = "redox"))]


### PR DESCRIPTION
* Add `os_system` and accompanying Python attribute `os.system` to `os.rs`
* Tested/ working on *Nix (MacOS) only.  Not tested on Windows. 
* Accepts Python `str` argument, but not `bytes or os.PathLike object`