### PR TITLE
Update isclose module of math

### DIFF
--- a/tests/snippets/stdlib_math.py
+++ b/tests/snippets/stdlib_math.py
@@ -34,37 +34,6 @@ assert math.trunc(2.2) == 2
 assert math.ceil(3.3) == 4
 assert math.floor(4.4) == 4
 
-assert math.copysign(1, 42) == 1.0
-assert math.copysign(0., 42) == 0.0
-assert math.copysign(1., -42) == -1.0
-assert math.copysign(3, 0.) == 3.0
-assert math.copysign(4., -0.) == -4.0
-assert_raises(TypeError, math.copysign)
-# copysign should let us distinguish signs of zeros
-assert math.copysign(1., 0.) == 1.
-assert math.copysign(1., -0.) == -1.
-assert math.copysign(INF, 0.) == INF
-assert math.copysign(INF, -0.) == NINF
-assert math.copysign(NINF, 0.) == INF
-assert math.copysign(NINF, -0.) == NINF
-# and of infinities
-assert math.copysign(1., INF) == 1.
-assert math.copysign(1., NINF) == -1.
-assert math.copysign(INF, INF) == INF
-assert math.copysign(INF, NINF) == NINF
-assert math.copysign(NINF, INF) == INF
-assert math.copysign(NINF, NINF) == NINF
-assert math.isnan(math.copysign(NAN, 1.))
-assert math.isnan(math.copysign(NAN, INF))
-assert math.isnan(math.copysign(NAN, NINF))
-assert math.isnan(math.copysign(NAN, NAN))
-# copysign(INF, NAN) may be INF or it may be NINF, since
-# we don't know whether the sign bit of NAN is set on any
-# given platform.
-assert math.isinf(math.copysign(INF, NAN))
-# similarly, copysign(2., NAN) could be 2. or -2.
-assert abs(math.copysign(2., NAN)) == 2.
-
 class A(object):
     def __trunc__(self):
         return 2
@@ -113,6 +82,125 @@ with assert_raises(TypeError):
     math.ceil(object())
 with assert_raises(TypeError):
     math.floor(object())
+
+isclose = math.isclose
+
+def assertIsClose(a, b, *args, **kwargs):
+    assert isclose(a, b, *args, **kwargs) == True, "%s and %s should be close!" % (a, b)
+
+def assertIsNotClose(a, b, *args, **kwargs):
+    assert isclose(a, b, *args, **kwargs) == False, "%s and %s should not be close!" % (a, b)
+
+def assertAllClose(examples, *args, **kwargs):
+    for a, b in examples:
+        assertIsClose(a, b, *args, **kwargs)
+
+def assertAllNotClose(examples, *args, **kwargs):
+    for a, b in examples:
+        assertIsNotClose(a, b, *args, **kwargs)
+
+# test_negative_tolerances: ValueError should be raised if either tolerance is less than zero
+assert_raises(ValueError, lambda: isclose(1, 1, rel_tol=-1e-100))
+assert_raises(ValueError, lambda: isclose(1, 1, rel_tol=1e-100, abs_tol=-1e10))
+
+# test_identical: identical values must test as close
+identical_examples = [(2.0, 2.0),
+                        (0.1e200, 0.1e200),
+                        (1.123e-300, 1.123e-300),
+                        (12345, 12345.0),
+                        (0.0, -0.0),
+                        (345678, 345678)]
+assertAllClose(identical_examples, rel_tol=0.0, abs_tol=0.0)
+
+# test_eight_decimal_places: examples that are close to 1e-8, but not 1e-9
+eight_decimal_places_examples = [(1e8, 1e8 + 1),
+                                 (-1e-8, -1.000000009e-8),
+                                 (1.12345678, 1.12345679)]
+assertAllClose(eight_decimal_places_examples, rel_tol=1e-08)
+assertAllNotClose(eight_decimal_places_examples, rel_tol=1e-09)
+
+# test_near_zero: values close to zero
+near_zero_examples = [(1e-9, 0.0),
+                      (-1e-9, 0.0),
+                      (-1e-150, 0.0)]
+# these should not be close to any rel_tol
+assertAllNotClose(near_zero_examples, rel_tol=0.9)
+# these should be close to abs_tol=1e-8
+assertAllClose(near_zero_examples, abs_tol=1e-8)
+
+# test_identical_infinite: these are close regardless of tolerance -- i.e. they are equal
+assertIsClose(INF, INF)
+assertIsClose(INF, INF, abs_tol=0.0)
+assertIsClose(NINF, NINF)
+assertIsClose(NINF, NINF, abs_tol=0.0)
+
+# test_inf_ninf_nan(self): these should never be close (following IEEE 754 rules for equality)
+not_close_examples = [(NAN, NAN),
+                      (NAN, 1e-100),
+                      (1e-100, NAN),
+                      (INF, NAN),
+                      (NAN, INF),
+                      (INF, NINF),
+                      (INF, 1.0),
+                      (1.0, INF),
+                      (INF, 1e308),
+                      (1e308, INF)]
+# use largest reasonable tolerance
+assertAllNotClose(not_close_examples, abs_tol=0.999999999999999)
+
+# test_zero_tolerance: test with zero tolerance
+zero_tolerance_close_examples = [(1.0, 1.0),
+                                 (-3.4, -3.4),
+                                 (-1e-300, -1e-300)]
+assertAllClose(zero_tolerance_close_examples, rel_tol=0.0)
+zero_tolerance_not_close_examples = [(1.0, 1.000000000000001),
+                                     (0.99999999999999, 1.0),
+                                     (1.0e200, .999999999999999e200)]
+assertAllNotClose(zero_tolerance_not_close_examples, rel_tol=0.0)
+
+# test_asymmetry: test the asymmetry example from PEP 485
+assertAllClose([(9, 10), (10, 9)], rel_tol=0.1)
+
+# test_integers: test with integer values
+integer_examples = [(100000001, 100000000),
+                    (123456789, 123456788)]
+
+assertAllClose(integer_examples, rel_tol=1e-8)
+assertAllNotClose(integer_examples, rel_tol=1e-9)
+
+# test_decimals: test with Decimal values
+# test_fractions: test with Fraction values
+
+assert math.copysign(1, 42) == 1.0
+assert math.copysign(0., 42) == 0.0
+assert math.copysign(1., -42) == -1.0
+assert math.copysign(3, 0.) == 3.0
+assert math.copysign(4., -0.) == -4.0
+assert_raises(TypeError, math.copysign)
+# copysign should let us distinguish signs of zeros
+assert math.copysign(1., 0.) == 1.
+assert math.copysign(1., -0.) == -1.
+assert math.copysign(INF, 0.) == INF
+assert math.copysign(INF, -0.) == NINF
+assert math.copysign(NINF, 0.) == INF
+assert math.copysign(NINF, -0.) == NINF
+# and of infinities
+assert math.copysign(1., INF) == 1.
+assert math.copysign(1., NINF) == -1.
+assert math.copysign(INF, INF) == INF
+assert math.copysign(INF, NINF) == NINF
+assert math.copysign(NINF, INF) == INF
+assert math.copysign(NINF, NINF) == NINF
+assert math.isnan(math.copysign(NAN, 1.))
+assert math.isnan(math.copysign(NAN, INF))
+assert math.isnan(math.copysign(NAN, NINF))
+assert math.isnan(math.copysign(NAN, NAN))
+# copysign(INF, NAN) may be INF or it may be NINF, since
+# we don't know whether the sign bit of NAN is set on any
+# given platform.
+assert math.isinf(math.copysign(INF, NAN))
+# similarly, copysign(2., NAN) could be 2. or -2.
+assert abs(math.copysign(2., NAN)) == 2.
 
 assert str(math.frexp(0.0)) == str((+0.0, 0))
 assert str(math.frexp(-0.0)) == str((-0.0, 0))

--- a/vm/src/stdlib/math.rs
+++ b/vm/src/stdlib/math.rs
@@ -52,7 +52,7 @@ struct IsCloseArgs {
     abs_tol: OptionalArg<IntoPyFloat>,
 }
 
-#[deny(clippy::float_cmp)]
+#[allow(clippy::float_cmp)]
 fn math_isclose(args: IsCloseArgs, vm: &VirtualMachine) -> PyResult<bool> {
     let a = args.a.to_f64();
     let b = args.b.to_f64();

--- a/vm/src/stdlib/math.rs
+++ b/vm/src/stdlib/math.rs
@@ -40,6 +40,61 @@ make_math_func_bool!(math_isfinite, is_finite);
 make_math_func_bool!(math_isinf, is_infinite);
 make_math_func_bool!(math_isnan, is_nan);
 
+#[derive(FromArgs)]
+struct IsCloseArgs {
+    #[pyarg(positional_only, optional = false)]
+    a: IntoPyFloat,
+    #[pyarg(positional_only, optional = false)]
+    b: IntoPyFloat,
+    #[pyarg(keyword_only, optional = true)]
+    rel_tol: OptionalArg<IntoPyFloat>,
+    #[pyarg(keyword_only, optional = true)]
+    abs_tol: OptionalArg<IntoPyFloat>,
+}
+
+fn math_isclose(
+    args: IsCloseArgs,
+    vm: &VirtualMachine,
+) -> PyResult<bool> {
+    let a = args.a.to_f64();
+    let b = args.b.to_f64();
+    let rel_tol = match args.rel_tol {
+        OptionalArg::Missing => 1e-09,
+        OptionalArg::Present(ref value) => value.to_f64(),
+    };
+
+    let abs_tol = match args.abs_tol {
+        OptionalArg::Missing => 0.0,
+        OptionalArg::Present(ref value) => value.to_f64(),
+    };
+
+    if rel_tol < 0.0 || abs_tol < 0.0 {
+        return Err(vm.new_value_error("tolerances must be non-negative".to_string()));
+    }
+
+    if a == b {
+        /* short circuit exact equality -- needed to catch two infinities of
+           the same sign. And perhaps speeds things up a bit sometimes.
+        */
+        return Ok(true);
+    }
+
+    /* This catches the case of two infinities of opposite sign, or
+       one infinity and one finite number. Two infinities of opposite
+       sign would otherwise have an infinite relative tolerance.
+       Two infinities of the same sign are caught by the equality check
+       above.
+    */
+
+    if a.is_infinite() || b.is_infinite() {
+        return Ok(false);
+    }
+
+    let diff = (b - a).abs();
+
+    Ok((diff <= (rel_tol * b).abs()) || (diff <= (rel_tol * a).abs()) || (diff <= abs_tol))
+}
+
 fn math_copysign(a: IntoPyFloat, b: IntoPyFloat, _vm: &VirtualMachine) -> f64 {
     let a = a.to_f64();
     let b = b.to_f64();
@@ -223,6 +278,7 @@ pub fn make_module(vm: &VirtualMachine) -> PyObjectRef {
         "isfinite" => ctx.new_rustfunc(math_isfinite),
         "isinf" => ctx.new_rustfunc(math_isinf),
         "isnan" => ctx.new_rustfunc(math_isnan),
+        "isclose" => ctx.new_rustfunc(math_isclose),
         "copysign" => ctx.new_rustfunc(math_copysign),
 
         // Power and logarithmic functions:

--- a/vm/src/stdlib/math.rs
+++ b/vm/src/stdlib/math.rs
@@ -52,10 +52,8 @@ struct IsCloseArgs {
     abs_tol: OptionalArg<IntoPyFloat>,
 }
 
-fn math_isclose(
-    args: IsCloseArgs,
-    vm: &VirtualMachine,
-) -> PyResult<bool> {
+#[deny(clippy::float_cmp)]
+fn math_isclose(args: IsCloseArgs, vm: &VirtualMachine) -> PyResult<bool> {
     let a = args.a.to_f64();
     let b = args.b.to_f64();
     let rel_tol = match args.rel_tol {


### PR DESCRIPTION
- Implement `math.isclose()` function with test case
  - Add `IsCloseArgs` struct for `keyword_only` arguments: `rel_tol`, `abs_tol`
- Change order of test case on `math_module.py` for readability