### PR TITLE
Clean up the REPL and CodeFlags

### DIFF
--- a/bytecode/src/bytecode.rs
+++ b/bytecode/src/bytecode.rs
@@ -353,6 +353,7 @@ pub enum BlockType {
 */
 
 impl CodeObject {
+    #[allow(clippy::too_many_arguments)]
     pub fn new(
         flags: CodeFlags,
         arg_names: Vec<String>,

--- a/bytecode/src/bytecode.rs
+++ b/bytecode/src/bytecode.rs
@@ -37,6 +37,7 @@ pub struct CodeObject {
     /// Jump targets.
     pub label_map: HashMap<Label, usize>,
     pub locations: Vec<Location>,
+    pub flags: CodeFlags,
     pub arg_names: Vec<String>, // Names of positional arguments
     pub varargs: Varargs,       // *args or *
     pub kwonlyarg_names: Vec<String>,
@@ -44,20 +45,20 @@ pub struct CodeObject {
     pub source_path: String,
     pub first_line_number: usize,
     pub obj_name: String, // Name of the object that created this code object
-    pub is_generator: bool,
 }
 
 bitflags! {
     #[derive(Serialize, Deserialize)]
-    pub struct FunctionOpArg: u8 {
+    pub struct CodeFlags: u8 {
         const HAS_DEFAULTS = 0x01;
         const HAS_KW_ONLY_DEFAULTS = 0x02;
         const HAS_ANNOTATIONS = 0x04;
         const NEW_LOCALS = 0x08;
+        const IS_GENERATOR = 0x10;
     }
 }
 
-impl Default for FunctionOpArg {
+impl Default for CodeFlags {
     fn default() -> Self {
         Self::NEW_LOCALS
     }
@@ -176,9 +177,7 @@ pub enum Instruction {
     JumpIfFalseOrPop {
         target: Label,
     },
-    MakeFunction {
-        flags: FunctionOpArg,
-    },
+    MakeFunction,
     CallFunction {
         typ: CallType,
     },
@@ -355,6 +354,7 @@ pub enum BlockType {
 
 impl CodeObject {
     pub fn new(
+        flags: CodeFlags,
         arg_names: Vec<String>,
         varargs: Varargs,
         kwonlyarg_names: Vec<String>,
@@ -367,6 +367,7 @@ impl CodeObject {
             instructions: Vec::new(),
             label_map: HashMap::new(),
             locations: Vec::new(),
+            flags,
             arg_names,
             varargs,
             kwonlyarg_names,
@@ -374,7 +375,6 @@ impl CodeObject {
             source_path,
             first_line_number,
             obj_name,
-            is_generator: false,
         }
     }
 
@@ -513,7 +513,7 @@ impl Instruction {
             JumpIfFalse { target } => w!(JumpIfFalse, label_map[target]),
             JumpIfTrueOrPop { target } => w!(JumpIfTrueOrPop, label_map[target]),
             JumpIfFalseOrPop { target } => w!(JumpIfFalseOrPop, label_map[target]),
-            MakeFunction { flags } => w!(MakeFunction, format!("{:?}", flags)),
+            MakeFunction => w!(MakeFunction),
             CallFunction { typ } => w!(CallFunction, format!("{:?}", typ)),
             ForIter { target } => w!(ForIter, label_map[target]),
             ReturnValue => w!(ReturnValue),

--- a/compiler/src/compile.rs
+++ b/compiler/src/compile.rs
@@ -137,6 +137,7 @@ impl<O: OutputStream> Compiler<O> {
     fn push_new_code_object(&mut self, obj_name: String) {
         let line_number = self.get_source_line_number();
         self.push_output(CodeObject::new(
+            Default::default(),
             Vec::new(),
             Varargs::None,
             Vec::new(),
@@ -595,11 +596,7 @@ impl<O: OutputStream> Compiler<O> {
         Ok(())
     }
 
-    fn enter_function(
-        &mut self,
-        name: &str,
-        args: &ast::Parameters,
-    ) -> Result<bytecode::FunctionOpArg, CompileError> {
+    fn enter_function(&mut self, name: &str, args: &ast::Parameters) -> Result<(), CompileError> {
         let have_defaults = !args.defaults.is_empty();
         if have_defaults {
             // Construct a tuple:
@@ -633,8 +630,17 @@ impl<O: OutputStream> Compiler<O> {
             });
         }
 
+        let mut flags = bytecode::CodeFlags::default();
+        if have_defaults {
+            flags |= bytecode::CodeFlags::HAS_DEFAULTS;
+        }
+        if num_kw_only_defaults > 0 {
+            flags |= bytecode::CodeFlags::HAS_KW_ONLY_DEFAULTS;
+        }
+
         let line_number = self.get_source_line_number();
         self.push_output(CodeObject::new(
+            flags,
             args.args.iter().map(|a| a.arg.clone()).collect(),
             compile_varargs(&args.vararg),
             args.kwonlyargs.iter().map(|a| a.arg.clone()).collect(),
@@ -645,15 +651,7 @@ impl<O: OutputStream> Compiler<O> {
         ));
         self.enter_scope();
 
-        let mut flags = bytecode::FunctionOpArg::default();
-        if have_defaults {
-            flags |= bytecode::FunctionOpArg::HAS_DEFAULTS;
-        }
-        if num_kw_only_defaults > 0 {
-            flags |= bytecode::FunctionOpArg::HAS_KW_ONLY_DEFAULTS;
-        }
-
-        Ok(flags)
+        Ok(())
     }
 
     fn prepare_decorators(
@@ -813,7 +811,7 @@ impl<O: OutputStream> Compiler<O> {
 
         self.prepare_decorators(decorator_list)?;
 
-        let mut flags = self.enter_function(name, args)?;
+        self.enter_function(name, args)?;
 
         let (body, doc_str) = get_doc(body);
 
@@ -832,7 +830,7 @@ impl<O: OutputStream> Compiler<O> {
             }
         }
 
-        let code = self.pop_code_object();
+        let mut code = self.pop_code_object();
         self.leave_scope();
 
         // Prepare type annotations:
@@ -864,7 +862,7 @@ impl<O: OutputStream> Compiler<O> {
         }
 
         if num_annotations > 0 {
-            flags |= bytecode::FunctionOpArg::HAS_ANNOTATIONS;
+            code.flags |= bytecode::CodeFlags::HAS_ANNOTATIONS;
             self.emit(Instruction::BuildMap {
                 size: num_annotations,
                 unpack: false,
@@ -884,7 +882,7 @@ impl<O: OutputStream> Compiler<O> {
         });
 
         // Turn code object into function object:
-        self.emit(Instruction::MakeFunction { flags });
+        self.emit(Instruction::MakeFunction);
         self.store_docstring(doc_str);
         self.apply_decorators(decorator_list);
 
@@ -915,6 +913,7 @@ impl<O: OutputStream> Compiler<O> {
         self.emit(Instruction::LoadBuildClass);
         let line_number = self.get_source_line_number();
         self.push_output(CodeObject::new(
+            Default::default(),
             vec![],
             Varargs::None,
             vec![],
@@ -950,7 +949,8 @@ impl<O: OutputStream> Compiler<O> {
         });
         self.emit(Instruction::ReturnValue);
 
-        let code = self.pop_code_object();
+        let mut code = self.pop_code_object();
+        code.flags &= !bytecode::CodeFlags::NEW_LOCALS;
         self.leave_scope();
 
         self.emit(Instruction::LoadConst {
@@ -965,9 +965,7 @@ impl<O: OutputStream> Compiler<O> {
         });
 
         // Turn code object into function object:
-        self.emit(Instruction::MakeFunction {
-            flags: bytecode::FunctionOpArg::default() & !bytecode::FunctionOpArg::NEW_LOCALS,
-        });
+        self.emit(Instruction::MakeFunction);
 
         self.emit(Instruction::LoadConst {
             value: bytecode::Constant::String {
@@ -1615,7 +1613,7 @@ impl<O: OutputStream> Compiler<O> {
             Lambda { args, body } => {
                 let name = "<lambda>".to_string();
                 // no need to worry about the self.loop_depth because there are no loops in lambda expressions
-                let flags = self.enter_function(&name, args)?;
+                self.enter_function(&name, args)?;
                 self.compile_expression(body)?;
                 self.emit(Instruction::ReturnValue);
                 let code = self.pop_code_object();
@@ -1629,7 +1627,7 @@ impl<O: OutputStream> Compiler<O> {
                     value: bytecode::Constant::String { value: name },
                 });
                 // Turn code object into function object:
-                self.emit(Instruction::MakeFunction { flags });
+                self.emit(Instruction::MakeFunction);
             }
             Comprehension { kind, generators } => {
                 self.compile_comprehension(kind, generators)?;
@@ -1810,6 +1808,7 @@ impl<O: OutputStream> Compiler<O> {
         let line_number = self.get_source_line_number();
         // Create magnificent function <listcomp>:
         self.push_output(CodeObject::new(
+            Default::default(),
             vec![".0".to_string()],
             Varargs::None,
             vec![],
@@ -1945,9 +1944,7 @@ impl<O: OutputStream> Compiler<O> {
         });
 
         // Turn code object into function object:
-        self.emit(Instruction::MakeFunction {
-            flags: bytecode::FunctionOpArg::default(),
-        });
+        self.emit(Instruction::MakeFunction);
 
         // Evaluate iterated item:
         self.compile_expression(&generators[0].iter)?;

--- a/compiler/src/output_stream.rs
+++ b/compiler/src/output_stream.rs
@@ -1,4 +1,4 @@
-use rustpython_bytecode::bytecode::{CodeObject, Instruction, Label, Location};
+use rustpython_bytecode::bytecode::{CodeFlags, CodeObject, Instruction, Label, Location};
 
 pub trait OutputStream: From<CodeObject> + Into<CodeObject> {
     /// Output an instruction
@@ -34,6 +34,6 @@ impl OutputStream for CodeObjectStream {
         self.code.label_map.insert(label, position);
     }
     fn mark_generator(&mut self) {
-        self.code.is_generator = true;
+        self.code.flags |= CodeFlags::IS_GENERATOR;
     }
 }

--- a/src/shell.rs
+++ b/src/shell.rs
@@ -1,3 +1,4 @@
+mod readline;
 #[cfg(not(target_os = "wasi"))]
 mod rustyline_helper;
 
@@ -10,11 +11,8 @@ use rustpython_vm::{
     scope::Scope,
     VirtualMachine,
 };
-#[cfg(not(target_os = "wasi"))]
-use rustyline_helper::ShellHelper;
 
-use std::io;
-use std::path::Path;
+use readline::{Readline, ReadlineResult};
 
 enum ShellExecResult {
     Ok,
@@ -44,110 +42,6 @@ fn shell_exec(vm: &VirtualMachine, source: &str, scope: Scope) -> ShellExecResul
         Err(err) => ShellExecResult::PyErr(vm.new_syntax_error(&err)),
     }
 }
-
-enum ReadlineResult {
-    Line(String),
-    EOF,
-    Interrupt,
-    IO(std::io::Error),
-    EncodingError,
-    Other(Box<dyn std::error::Error>),
-}
-
-#[allow(unused)]
-struct BasicReadline;
-
-#[allow(unused)]
-impl BasicReadline {
-    fn new(_vm: &VirtualMachine, _scope: Scope) -> Self {
-        BasicReadline
-    }
-
-    fn load_history(&mut self, _path: &Path) -> io::Result<()> {
-        Ok(())
-    }
-
-    fn save_history(&mut self, _path: &Path) -> io::Result<()> {
-        Ok(())
-    }
-
-    fn add_history_entry(&mut self, _entry: &str) {}
-
-    fn readline(&mut self, prompt: &str) -> ReadlineResult {
-        use std::io::prelude::*;
-        print!("{}", prompt);
-        if let Err(e) = io::stdout().flush() {
-            return ReadlineResult::IO(e);
-        }
-
-        match io::stdin().lock().lines().next() {
-            Some(Ok(line)) => ReadlineResult::Line(line),
-            None => ReadlineResult::EOF,
-            Some(Err(e)) => match e.kind() {
-                io::ErrorKind::Interrupted => ReadlineResult::Interrupt,
-                io::ErrorKind::InvalidData => ReadlineResult::EncodingError,
-                _ => ReadlineResult::IO(e),
-            },
-        }
-    }
-}
-
-#[cfg(target_os = "wasi")]
-type Readline = BasicReadline;
-
-#[cfg(not(target_os = "wasi"))]
-struct RustylineReadline<'vm> {
-    repl: rustyline::Editor<ShellHelper<'vm>>,
-}
-#[cfg(not(target_os = "wasi"))]
-impl<'vm> RustylineReadline<'vm> {
-    fn new(vm: &'vm VirtualMachine, scope: Scope) -> Self {
-        use rustyline::{CompletionType, Config, Editor};
-        let mut repl = Editor::with_config(
-            Config::builder()
-                .completion_type(CompletionType::List)
-                .tab_stop(4)
-                .build(),
-        );
-        repl.set_helper(Some(ShellHelper::new(vm, scope)));
-        RustylineReadline { repl }
-    }
-
-    fn load_history(&mut self, path: &Path) -> rustyline::Result<()> {
-        self.repl.load_history(path)
-    }
-
-    fn save_history(&mut self, path: &Path) -> rustyline::Result<()> {
-        if !path.exists() {
-            if let Some(parent) = path.parent() {
-                std::fs::create_dir_all(parent)?;
-            }
-        }
-        self.repl.save_history(path)
-    }
-
-    fn add_history_entry(&mut self, entry: &str) {
-        self.repl.add_history_entry(entry);
-    }
-
-    fn readline(&mut self, prompt: &str) -> ReadlineResult {
-        use rustyline::error::ReadlineError;
-        match self.repl.readline(prompt) {
-            Ok(line) => ReadlineResult::Line(line),
-            Err(ReadlineError::Interrupted) => ReadlineResult::Interrupt,
-            Err(ReadlineError::Eof) => ReadlineResult::EOF,
-            Err(ReadlineError::Io(e)) => ReadlineResult::IO(e),
-            #[cfg(unix)]
-            Err(ReadlineError::Utf8Error) => ReadlineResult::EncodingError,
-            #[cfg(windows)]
-            Err(ReadlineError::Decode(_)) => ReadlineResult::EncodingError,
-            Err(e) => ReadlineResult::Other(e.into()),
-        }
-    }
-}
-
-#[cfg(not(target_os = "wasi"))]
-type Readline<'a> = RustylineReadline<'a>;
 
 pub fn run_shell(vm: &VirtualMachine, scope: Scope) -> PyResult<()> {
     println!(
@@ -187,7 +81,7 @@ pub fn run_shell(vm: &VirtualMachine, scope: Scope) -> PyResult<()> {
             ReadlineResult::Line(line) => {
                 debug!("You entered {:?}", line);
 
-                repl.add_history_entry(line.trim_end());
+                repl.add_history_entry(line.trim_end()).unwrap();
 
                 let stop_continuing = line.is_empty();
 

--- a/src/shell/readline.rs
+++ b/src/shell/readline.rs
@@ -1,0 +1,153 @@
+use std::io;
+use std::path::Path;
+
+use rustpython_vm::{scope::Scope, VirtualMachine};
+
+type OtherError = Box<dyn std::error::Error>;
+type OtherResult<T> = Result<T, OtherError>;
+
+pub enum ReadlineResult {
+    Line(String),
+    EOF,
+    Interrupt,
+    IO(std::io::Error),
+    EncodingError,
+    Other(OtherError),
+}
+
+#[allow(unused)]
+mod basic_readline {
+    use super::*;
+
+    pub struct BasicReadline<'vm> {
+        vm: &'vm VirtualMachine,
+    }
+
+    impl<'vm> BasicReadline<'vm> {
+        pub fn new(vm: &'vm VirtualMachine, _scope: Scope) -> Self {
+            BasicReadline { vm }
+        }
+
+        pub fn load_history(&mut self, _path: &Path) -> OtherResult<()> {
+            Ok(())
+        }
+
+        pub fn save_history(&mut self, _path: &Path) -> OtherResult<()> {
+            Ok(())
+        }
+
+        pub fn add_history_entry(&mut self, _entry: &str) -> OtherResult<()> {
+            Ok(())
+        }
+
+        pub fn readline(&mut self, prompt: &str) -> ReadlineResult {
+            use std::io::prelude::*;
+            print!("{}", prompt);
+            if let Err(e) = io::stdout().flush() {
+                return ReadlineResult::IO(e);
+            }
+
+            match io::stdin().lock().lines().next() {
+                Some(Ok(line)) => ReadlineResult::Line(line),
+                None => ReadlineResult::EOF,
+                Some(Err(e)) => match e.kind() {
+                    io::ErrorKind::Interrupted => ReadlineResult::Interrupt,
+                    io::ErrorKind::InvalidData => ReadlineResult::EncodingError,
+                    _ => ReadlineResult::IO(e),
+                },
+            }
+        }
+    }
+}
+
+#[cfg(not(target_os = "wasi"))]
+mod rustyline_readline {
+    use super::{super::rustyline_helper::ShellHelper, *};
+
+    pub struct RustylineReadline<'vm> {
+        repl: rustyline::Editor<ShellHelper<'vm>>,
+    }
+
+    impl<'vm> RustylineReadline<'vm> {
+        pub fn new(vm: &'vm VirtualMachine, scope: Scope) -> Self {
+            use rustyline::{At, Cmd, CompletionType, Config, Editor, KeyPress, Movement, Word};
+            let mut repl = Editor::with_config(
+                Config::builder()
+                    .completion_type(CompletionType::List)
+                    .tab_stop(8)
+                    .build(),
+            );
+            repl.bind_sequence(
+                KeyPress::ControlLeft,
+                Cmd::Move(Movement::BackwardWord(1, Word::Vi)),
+            );
+            repl.bind_sequence(
+                KeyPress::ControlRight,
+                Cmd::Move(Movement::ForwardWord(1, At::AfterEnd, Word::Vi)),
+            );
+            repl.set_helper(Some(ShellHelper::new(vm, scope)));
+            RustylineReadline { repl }
+        }
+
+        pub fn load_history(&mut self, path: &Path) -> OtherResult<()> {
+            self.repl.load_history(path)?;
+            Ok(())
+        }
+
+        pub fn save_history(&mut self, path: &Path) -> OtherResult<()> {
+            if !path.exists() {
+                if let Some(parent) = path.parent() {
+                    std::fs::create_dir_all(parent)?;
+                }
+            }
+            self.repl.save_history(path)?;
+            Ok(())
+        }
+
+        pub fn add_history_entry(&mut self, entry: &str) -> OtherResult<()> {
+            self.repl.add_history_entry(entry);
+            Ok(())
+        }
+
+        pub fn readline(&mut self, prompt: &str) -> ReadlineResult {
+            use rustyline::error::ReadlineError;
+            match self.repl.readline(prompt) {
+                Ok(line) => ReadlineResult::Line(line),
+                Err(ReadlineError::Interrupted) => ReadlineResult::Interrupt,
+                Err(ReadlineError::Eof) => ReadlineResult::EOF,
+                Err(ReadlineError::Io(e)) => ReadlineResult::IO(e),
+                #[cfg(unix)]
+                Err(ReadlineError::Utf8Error) => ReadlineResult::EncodingError,
+                #[cfg(windows)]
+                Err(ReadlineError::Decode(_)) => ReadlineResult::EncodingError,
+                Err(e) => ReadlineResult::Other(e.into()),
+            }
+        }
+    }
+}
+
+#[cfg(target_os = "wasi")]
+type ReadlineInner<'vm> = basic_readline::BasicReadline<'vm>;
+
+#[cfg(not(target_os = "wasi"))]
+type ReadlineInner<'vm> = rustyline_readline::RustylineReadline<'vm>;
+
+pub struct Readline<'vm>(ReadlineInner<'vm>);
+
+impl<'vm> Readline<'vm> {
+    pub fn new(vm: &'vm VirtualMachine, scope: Scope) -> Self {
+        Readline(ReadlineInner::new(vm, scope))
+    }
+    pub fn load_history(&mut self, path: &Path) -> OtherResult<()> {
+        self.0.load_history(path)
+    }
+    pub fn save_history(&mut self, path: &Path) -> OtherResult<()> {
+        self.0.save_history(path)
+    }
+    pub fn add_history_entry(&mut self, entry: &str) -> OtherResult<()> {
+        self.0.add_history_entry(entry)
+    }
+    pub fn readline(&mut self, prompt: &str) -> ReadlineResult {
+        self.0.readline(prompt)
+    }
+}

--- a/src/shell/rustyline_helper.rs
+++ b/src/shell/rustyline_helper.rs
@@ -152,14 +152,11 @@ impl Completer for ShellHelper<'_> {
         pos: usize,
         _ctx: &Context,
     ) -> rustyline::Result<(usize, Vec<String>)> {
-        if pos != line.len() {
-            return Ok((0, vec![]));
-        }
         Ok(self
-            .complete_opt(line)
+            .complete_opt(&line[0..pos])
             // as far as I can tell, there's no better way to do both completion
             // and indentation (or even just indentation)
-            .unwrap_or_else(|| (line.len(), vec!["    ".to_string()])))
+            .unwrap_or_else(|| (line.len(), vec!["\t".to_string()])))
     }
 }
 

--- a/vm/src/obj/objcode.rs
+++ b/vm/src/obj/objcode.rs
@@ -3,6 +3,7 @@
 */
 
 use std::fmt;
+use std::ops::Deref;
 
 use super::objtype::PyClassRef;
 use crate::bytecode;
@@ -13,6 +14,13 @@ pub type PyCodeRef = PyRef<PyCode>;
 
 pub struct PyCode {
     pub code: bytecode::CodeObject,
+}
+
+impl Deref for PyCode {
+    type Target = bytecode::CodeObject;
+    fn deref(&self) -> &Self::Target {
+        &self.code
+    }
 }
 
 impl PyCode {

--- a/vm/src/obj/objframe.rs
+++ b/vm/src/obj/objframe.rs
@@ -5,48 +5,47 @@
 use super::objcode::PyCodeRef;
 use super::objdict::PyDictRef;
 use crate::frame::FrameRef;
-use crate::pyobject::{PyContext, PyObjectRef, PyResult};
+use crate::pyobject::{PyClassImpl, PyContext, PyObjectRef, PyResult};
 use crate::vm::VirtualMachine;
 
 pub fn init(context: &PyContext) {
-    extend_class!(context, &context.types.frame_type, {
-        (slot new) => FrameRef::new,
-        "__repr__" => context.new_rustfunc(FrameRef::repr),
-        "f_locals" => context.new_property(FrameRef::flocals),
-        "f_globals" => context.new_property(FrameRef::f_globals),
-        "f_code" => context.new_property(FrameRef::fcode),
-        "f_back" => context.new_property(FrameRef::f_back),
-        "f_lasti" => context.new_property(FrameRef::f_lasti),
-    });
+    FrameRef::extend_class(context, &context.types.frame_type);
 }
 
+#[pyimpl]
 impl FrameRef {
-    #[allow(clippy::new_ret_no_self)]
-    fn new(_class: FrameRef, vm: &VirtualMachine) -> PyResult {
+    #[pyslot(new)]
+    fn tp_new(_cls: FrameRef, vm: &VirtualMachine) -> PyResult<Self> {
         Err(vm.new_type_error("Cannot directly create frame object".to_string()))
     }
 
+    #[pymethod(name = "__repr__")]
     fn repr(self, _vm: &VirtualMachine) -> String {
         "<frame object at .. >".to_string()
     }
 
+    #[pyproperty]
     fn f_globals(self, _vm: &VirtualMachine) -> PyDictRef {
         self.scope.globals.clone()
     }
 
-    fn flocals(self, _vm: &VirtualMachine) -> PyDictRef {
+    #[pyproperty]
+    fn f_locals(self, _vm: &VirtualMachine) -> PyDictRef {
         self.scope.get_locals()
     }
 
-    fn fcode(self, vm: &VirtualMachine) -> PyCodeRef {
-        vm.ctx.new_code_object(self.code.clone())
+    #[pyproperty]
+    fn f_code(self, _vm: &VirtualMachine) -> PyCodeRef {
+        self.code.clone()
     }
 
+    #[pyproperty]
     fn f_back(self, vm: &VirtualMachine) -> PyObjectRef {
         // TODO: how to retrieve the upper stack frame??
         vm.ctx.none()
     }
 
+    #[pyproperty]
     fn f_lasti(self, vm: &VirtualMachine) -> PyObjectRef {
         vm.ctx.new_int(*self.lasti.borrow())
     }

--- a/vm/src/obj/objfunction.rs
+++ b/vm/src/obj/objfunction.rs
@@ -16,7 +16,6 @@ pub struct PyFunction {
     pub scope: Scope,
     pub defaults: Option<PyTupleRef>,
     pub kw_only_defaults: Option<PyDictRef>,
-    pub new_locals: bool,
 }
 
 impl PyFunction {
@@ -25,14 +24,12 @@ impl PyFunction {
         scope: Scope,
         defaults: Option<PyTupleRef>,
         kw_only_defaults: Option<PyDictRef>,
-        new_locals: bool,
     ) -> Self {
         PyFunction {
             code,
             scope,
             defaults,
             kw_only_defaults,
-            new_locals,
         }
     }
 }

--- a/vm/src/pyobject.rs
+++ b/vm/src/pyobject.rs
@@ -503,10 +503,9 @@ impl PyContext {
         scope: Scope,
         defaults: Option<PyTupleRef>,
         kw_only_defaults: Option<PyDictRef>,
-        new_locals: bool,
     ) -> PyObjectRef {
         PyObject::new(
-            PyFunction::new(code_obj, scope, defaults, kw_only_defaults, new_locals),
+            PyFunction::new(code_obj, scope, defaults, kw_only_defaults),
             self.function_type(),
             Some(self.new_dict()),
         )

--- a/vm/src/vm.rs
+++ b/vm/src/vm.rs
@@ -668,14 +668,14 @@ impl VirtualMachine {
     ) -> PyResult {
         let code = &func.code;
 
-        let scope = if func.new_locals {
+        let scope = if func.code.flags.contains(bytecode::CodeFlags::NEW_LOCALS) {
             scope.new_child_scope(&self.ctx)
         } else {
             scope.clone()
         };
 
         self.fill_locals_from_args(
-            &code.code,
+            &code,
             &scope.get_locals(),
             func_args,
             &func.defaults,
@@ -686,7 +686,7 @@ impl VirtualMachine {
         let frame = Frame::new(code.clone(), scope).into_ref(self);
 
         // If we have a generator, create a new generator
-        if code.code.is_generator {
+        if code.flags.contains(bytecode::CodeFlags::IS_GENERATOR) {
             Ok(PyGenerator::new(frame, self).into_object())
         } else {
             self.run_frame_full(frame)


### PR DESCRIPTION
I changed `FunctionOpArg` to `CodeFlags`, which is basically the same but is stored inside `CodeObject`. This also means that we don't have to have `enter_function` return the flags for `MakeFunction`; it can just apply them to the `CodeObject` it pushes onto the stack.