### PR TITLE
Add RUSTPYTHONPATH to whats_left.sh to run the script without setting an environment variable

### DIFF
--- a/whats_left.sh
+++ b/whats_left.sh
@@ -15,6 +15,8 @@ h() {
 
 cd "$(dirname "$0")"
 
+export RUSTPYTHONPATH=Lib
+
 (
   cd tests
   # -I means isolate from environment; we don't want any pip packages to be listed


### PR DESCRIPTION
Simply adds RUSTPYTHONPATH to whats_left.sh to avoid setting it explicitly for running the script.

As a newcomer, while I ran the script, I didn't recognize setting RUSTPYTHONPATH for the error below.
So, I think it's good to add RUSTPYTHONPATH for convinence.
```
===== MODULES =====
Traceback (most recent call last):
  File "tests/snippets/whats_left_modules.py", line 8, in <module>
    import os
ModuleNotFoundError: No module named 'os
```