### PR TITLE
Use primitives directly

### DIFF
--- a/vm/src/obj/objbytearray.rs
+++ b/vm/src/obj/objbytearray.rs
@@ -2,8 +2,6 @@
 use std::cell::{Cell, RefCell};
 use std::convert::TryFrom;
 
-use num_traits::ToPrimitive;
-
 use super::objbyteinner::{
     ByteInnerExpandtabsOptions, ByteInnerFindOptions, ByteInnerNewOptions, ByteInnerPaddingOptions,
     ByteInnerPosition, ByteInnerSplitOptions, ByteInnerSplitlinesOptions,
@@ -506,17 +504,12 @@ impl PyByteArrayRef {
     }
 
     #[pymethod(name = "insert")]
-    fn insert(self, index: PyIntRef, x: PyIntRef, vm: &VirtualMachine) -> PyResult<()> {
+    fn insert(self, mut index: isize, x: PyIntRef, vm: &VirtualMachine) -> PyResult<()> {
         let bytes = &mut self.inner.borrow_mut().elements;
         let len = isize::try_from(bytes.len())
             .map_err(|_e| vm.new_overflow_error("bytearray too big".to_string()))?;
 
         let x = x.as_bigint().byte_or(vm)?;
-
-        let mut index = index
-            .as_bigint()
-            .to_isize()
-            .ok_or_else(|| vm.new_overflow_error("index too big".to_string()))?;
 
         if index >= len {
             bytes.push(x);
@@ -550,17 +543,17 @@ impl PyByteArrayRef {
     }
 
     #[pymethod(name = "__mul__")]
-    fn repeat(self, n: PyIntRef, vm: &VirtualMachine) -> PyResult {
+    fn repeat(self, n: isize, vm: &VirtualMachine) -> PyResult {
         Ok(vm.ctx.new_bytearray(self.inner.borrow().repeat(n, vm)?))
     }
 
     #[pymethod(name = "__rmul__")]
-    fn rmul(self, n: PyIntRef, vm: &VirtualMachine) -> PyResult {
+    fn rmul(self, n: isize, vm: &VirtualMachine) -> PyResult {
         self.repeat(n, vm)
     }
 
     #[pymethod(name = "__imul__")]
-    fn irepeat(self, n: PyIntRef, vm: &VirtualMachine) -> PyResult<()> {
+    fn irepeat(self, n: isize, vm: &VirtualMachine) -> PyResult<()> {
         self.inner.borrow_mut().irepeat(n, vm)
     }
 

--- a/vm/src/obj/objbytearray.rs
+++ b/vm/src/obj/objbytearray.rs
@@ -170,14 +170,14 @@ impl PyByteArrayRef {
     }
 
     #[pymethod(name = "__getitem__")]
-    fn getitem(self, needle: Either<PyIntRef, PySliceRef>, vm: &VirtualMachine) -> PyResult {
+    fn getitem(self, needle: Either<i32, PySliceRef>, vm: &VirtualMachine) -> PyResult {
         self.inner.borrow().getitem(needle, vm)
     }
 
     #[pymethod(name = "__setitem__")]
     fn setitem(
         self,
-        needle: Either<PyIntRef, PySliceRef>,
+        needle: Either<i32, PySliceRef>,
         value: PyObjectRef,
         vm: &VirtualMachine,
     ) -> PyResult {

--- a/vm/src/obj/objbyteinner.rs
+++ b/vm/src/obj/objbyteinner.rs
@@ -1073,15 +1073,11 @@ impl PyByteInner {
         res
     }
 
-    pub fn repeat(&self, n: PyIntRef, vm: &VirtualMachine) -> PyResult<Vec<u8>> {
+    pub fn repeat(&self, n: isize, _vm: &VirtualMachine) -> PyResult<Vec<u8>> {
         if self.elements.is_empty() {
             // We can multiple an empty vector by any integer, even if it doesn't fit in an isize.
             return Ok(vec![]);
         }
-
-        let n = n.as_bigint().to_isize().ok_or_else(|| {
-            vm.new_overflow_error("can't multiply bytes that many times".to_string())
-        })?;
 
         if n <= 0 {
             Ok(vec![])
@@ -1097,15 +1093,11 @@ impl PyByteInner {
         }
     }
 
-    pub fn irepeat(&mut self, n: PyIntRef, vm: &VirtualMachine) -> PyResult<()> {
+    pub fn irepeat(&mut self, n: isize, _vm: &VirtualMachine) -> PyResult<()> {
         if self.elements.is_empty() {
             // We can multiple an empty vector by any integer, even if it doesn't fit in an isize.
             return Ok(());
         }
-
-        let n = n.as_bigint().to_isize().ok_or_else(|| {
-            vm.new_overflow_error("can't multiply bytes that many times".to_string())
-        })?;
 
         if n <= 0 {
             self.elements.clear();

--- a/vm/src/obj/objbyteinner.rs
+++ b/vm/src/obj/objbyteinner.rs
@@ -17,9 +17,7 @@ use super::objstr::{PyString, PyStringRef};
 use super::objtuple::PyTupleRef;
 use crate::function::OptionalArg;
 use crate::pyhash;
-use crate::pyobject::{
-    Either, PyIterable, PyObjectRef, PyRef, PyResult, PyValue, TryFromObject, TypeProtocol,
-};
+use crate::pyobject::{Either, PyIterable, PyObjectRef, PyResult, TryFromObject, TypeProtocol};
 use crate::vm::VirtualMachine;
 
 #[derive(Debug, Default, Clone)]
@@ -45,22 +43,6 @@ impl TryFromObject for PyByteInner {
                 obj.class()
             ))),
         })
-    }
-}
-
-impl<B: PyValue> TryFromObject for Either<PyByteInner, PyRef<B>> {
-    fn try_from_object(vm: &VirtualMachine, obj: PyObjectRef) -> PyResult<Self> {
-        match PyByteInner::try_from_object(vm, obj.clone()) {
-            Ok(a) => Ok(Either::A(a)),
-            Err(_) => match obj.clone().downcast::<B>() {
-                Ok(b) => Ok(Either::B(b)),
-                Err(_) => Err(vm.new_type_error(format!(
-                    "a bytes-like object or {} is required, not {}",
-                    B::class(vm),
-                    obj.class()
-                ))),
-            },
-        }
     }
 }
 

--- a/vm/src/obj/objbyteinner.rs
+++ b/vm/src/obj/objbyteinner.rs
@@ -256,7 +256,7 @@ pub struct ByteInnerSplitOptions {
     #[pyarg(positional_or_keyword, optional = true)]
     sep: OptionalArg<Option<PyByteInner>>,
     #[pyarg(positional_or_keyword, optional = true)]
-    maxsplit: OptionalArg<PyIntRef>,
+    maxsplit: OptionalArg<i32>,
 }
 
 impl ByteInnerSplitOptions {
@@ -267,7 +267,7 @@ impl ByteInnerSplitOptions {
         };
 
         let maxsplit = if let OptionalArg::Present(value) = self.maxsplit {
-            value.as_bigint().to_i32().unwrap()
+            value
         } else {
             -1
         };
@@ -424,10 +424,10 @@ impl PyByteInner {
         }
     }
 
-    pub fn getitem(&self, needle: Either<PyIntRef, PySliceRef>, vm: &VirtualMachine) -> PyResult {
+    pub fn getitem(&self, needle: Either<i32, PySliceRef>, vm: &VirtualMachine) -> PyResult {
         match needle {
             Either::A(int) => {
-                if let Some(idx) = self.elements.get_pos(int.as_bigint().to_i32().unwrap()) {
+                if let Some(idx) = self.elements.get_pos(int) {
                     Ok(vm.new_int(self.elements[idx]))
                 } else {
                     Err(vm.new_index_error("index out of range".to_string()))
@@ -439,8 +439,8 @@ impl PyByteInner {
         }
     }
 
-    fn setindex(&mut self, int: PyIntRef, object: PyObjectRef, vm: &VirtualMachine) -> PyResult {
-        if let Some(idx) = self.elements.get_pos(int.as_bigint().to_i32().unwrap()) {
+    fn setindex(&mut self, int: i32, object: PyObjectRef, vm: &VirtualMachine) -> PyResult {
+        if let Some(idx) = self.elements.get_pos(int) {
             let result = match_class!(match object {
                 i @ PyInt => {
                     if let Some(value) = i.as_bigint().to_u8() {
@@ -493,7 +493,7 @@ impl PyByteInner {
 
     pub fn setitem(
         &mut self,
-        needle: Either<PyIntRef, PySliceRef>,
+        needle: Either<i32, PySliceRef>,
         object: PyObjectRef,
         vm: &VirtualMachine,
     ) -> PyResult {

--- a/vm/src/obj/objbytes.rs
+++ b/vm/src/obj/objbytes.rs
@@ -421,12 +421,12 @@ impl PyBytesRef {
     }
 
     #[pymethod(name = "__mul__")]
-    fn repeat(self, n: PyIntRef, vm: &VirtualMachine) -> PyResult {
+    fn repeat(self, n: isize, vm: &VirtualMachine) -> PyResult {
         Ok(vm.ctx.new_bytes(self.inner.repeat(n, vm)?))
     }
 
     #[pymethod(name = "__rmul__")]
-    fn rmul(self, n: PyIntRef, vm: &VirtualMachine) -> PyResult {
+    fn rmul(self, n: isize, vm: &VirtualMachine) -> PyResult {
         self.repeat(n, vm)
     }
 

--- a/vm/src/obj/objbytes.rs
+++ b/vm/src/obj/objbytes.rs
@@ -168,7 +168,7 @@ impl PyBytesRef {
     }
 
     #[pymethod(name = "__getitem__")]
-    fn getitem(self, needle: Either<PyIntRef, PySliceRef>, vm: &VirtualMachine) -> PyResult {
+    fn getitem(self, needle: Either<i32, PySliceRef>, vm: &VirtualMachine) -> PyResult {
         self.inner.getitem(needle, vm)
     }
 

--- a/vm/src/obj/objstr.rs
+++ b/vm/src/obj/objstr.rs
@@ -1380,9 +1380,7 @@ fn try_update_quantity_from_tuple(
                         Ok(tuple_index)
                     }
                 }
-                None => {
-                    Err(vm.new_type_error("not enough arguments for format string".to_string()))
-                }
+                None => Err(vm.new_type_error("not enough arguments for format string".to_string())),
             }
         }
         _ => Ok(tuple_index),

--- a/vm/src/pyobject.rs
+++ b/vm/src/pyobject.rs
@@ -1134,7 +1134,7 @@ where
     fn try_from_object(vm: &VirtualMachine, obj: PyObjectRef) -> PyResult<Self> {
         A::try_from_object(vm, obj.clone())
             .map(Either::A)
-            .or(B::try_from_object(vm, obj.clone()).map(Either::B))
+            .or_else(|_| B::try_from_object(vm, obj.clone()).map(Either::B))
             .map_err(|_| vm.new_type_error(format!("unexpected type {}", obj.class())))
     }
 }

--- a/vm/src/stdlib/binascii.rs
+++ b/vm/src/stdlib/binascii.rs
@@ -1,10 +1,8 @@
 use crate::function::OptionalArg;
 use crate::obj::objbytes::PyBytesRef;
-use crate::obj::objint::PyIntRef;
 use crate::pyobject::{PyObjectRef, PyResult};
 use crate::vm::VirtualMachine;
 use crc::{crc32, Hasher32};
-use num_traits::ToPrimitive;
 
 fn hex_nibble(n: u8) -> u8 {
     match n {
@@ -55,12 +53,9 @@ fn binascii_unhexlify(hexstr: PyBytesRef, vm: &VirtualMachine) -> PyResult {
     Ok(vm.ctx.new_bytes(unhex))
 }
 
-fn binascii_crc32(data: PyBytesRef, value: OptionalArg<PyIntRef>, vm: &VirtualMachine) -> PyResult {
+fn binascii_crc32(data: PyBytesRef, value: OptionalArg<u32>, vm: &VirtualMachine) -> PyResult {
     let bytes = data.get_value();
-    let crc = match value {
-        OptionalArg::Missing => 0u32,
-        OptionalArg::Present(value) => value.as_bigint().to_u32().unwrap(),
-    };
+    let crc = value.unwrap_or(0u32);
 
     let mut digest = crc32::Digest::new_with_initial(crc32::IEEE, crc);
     digest.write(&bytes);

--- a/vm/src/stdlib/io.rs
+++ b/vm/src/stdlib/io.rs
@@ -9,7 +9,7 @@ use std::io::SeekFrom;
 use num_traits::ToPrimitive;
 
 use super::os;
-use crate::function::{OptionalArg, PyFuncArgs};
+use crate::function::{OptionalArg, OptionalOption, PyFuncArgs};
 use crate::obj::objbytearray::PyByteArray;
 use crate::obj::objbytes;
 use crate::obj::objbytes::PyBytes;
@@ -21,11 +21,8 @@ use crate::pyobject::TypeProtocol;
 use crate::pyobject::{BufferProtocol, Either, PyObjectRef, PyRef, PyResult, PyValue};
 use crate::vm::VirtualMachine;
 
-fn byte_count(bytes: OptionalArg<Option<PyObjectRef>>) -> i64 {
-    match bytes {
-        OptionalArg::Present(Some(ref int)) => objint::get_value(int).to_i64().unwrap(),
-        _ => (-1 as i64),
-    }
+fn byte_count(bytes: OptionalOption<i64>) -> i64 {
+    bytes.flat_option().unwrap_or(-1 as i64)
 }
 
 #[derive(Debug)]
@@ -134,7 +131,7 @@ impl PyStringIORef {
     //Read k bytes from the object and return.
     //If k is undefined || k == -1, then we read all bytes until the end of the file.
     //This also increments the stream position by the value of k
-    fn read(self, bytes: OptionalArg<Option<PyObjectRef>>, vm: &VirtualMachine) -> PyResult {
+    fn read(self, bytes: OptionalOption<i64>, vm: &VirtualMachine) -> PyResult {
         let data = match self.buffer.borrow_mut().read(byte_count(bytes)) {
             Some(value) => value,
             None => Vec::new(),
@@ -193,7 +190,7 @@ impl PyBytesIORef {
     //Takes an integer k (bytes) and returns them from the underlying buffer
     //If k is undefined || k == -1, then we read all bytes until the end of the file.
     //This also increments the stream position by the value of k
-    fn read(self, bytes: OptionalArg<Option<PyObjectRef>>, vm: &VirtualMachine) -> PyResult {
+    fn read(self, bytes: OptionalOption<i64>, vm: &VirtualMachine) -> PyResult {
         match self.buffer.borrow_mut().read(byte_count(bytes)) {
             Some(value) => Ok(vm.ctx.new_bytes(value)),
             None => Err(vm.new_value_error("Error Retrieving Value".to_string())),

--- a/vm/src/stdlib/io.rs
+++ b/vm/src/stdlib/io.rs
@@ -116,9 +116,8 @@ impl PyStringIORef {
     }
 
     //skip to the jth position
-    fn seek(self, offset: PyObjectRef, vm: &VirtualMachine) -> PyResult {
-        let position = objint::get_value(&offset).to_u64().unwrap();
-        match self.buffer.borrow_mut().seek(position) {
+    fn seek(self, offset: u64, vm: &VirtualMachine) -> PyResult {
+        match self.buffer.borrow_mut().seek(offset) {
             Some(value) => Ok(vm.ctx.new_int(value)),
             None => Err(vm.new_value_error("Error Performing Operation".to_string())),
         }
@@ -198,9 +197,8 @@ impl PyBytesIORef {
     }
 
     //skip to the jth position
-    fn seek(self, offset: PyObjectRef, vm: &VirtualMachine) -> PyResult {
-        let position = objint::get_value(&offset).to_u64().unwrap();
-        match self.buffer.borrow_mut().seek(position) {
+    fn seek(self, offset: u64, vm: &VirtualMachine) -> PyResult {
+        match self.buffer.borrow_mut().seek(offset) {
             Some(value) => Ok(vm.ctx.new_int(value)),
             None => Err(vm.new_value_error("Error Performing Operation".to_string())),
         }

--- a/vm/src/stdlib/itertools.rs
+++ b/vm/src/stdlib/itertools.rs
@@ -687,16 +687,10 @@ impl PyItertoolsTee {
     fn new(
         _cls: PyClassRef,
         iterable: PyObjectRef,
-        n: OptionalArg<PyIntRef>,
+        n: OptionalArg<usize>,
         vm: &VirtualMachine,
     ) -> PyResult<PyRef<PyTuple>> {
-        let n = match n {
-            OptionalArg::Present(x) => match x.as_bigint().to_usize() {
-                Some(y) => y,
-                None => return Err(vm.new_overflow_error(String::from("n is too big"))),
-            },
-            OptionalArg::Missing => 2,
-        };
+        let n = n.unwrap_or(2);
 
         let copyable = if objtype::class_has_attr(&iterable.class(), "__copy__") {
             vm.call_method(&iterable, "__copy__", PyFuncArgs::from(vec![]))?

--- a/vm/src/stdlib/os.rs
+++ b/vm/src/stdlib/os.rs
@@ -20,7 +20,6 @@ use nix::errno::Errno;
 use nix::pty::openpty;
 #[cfg(unix)]
 use nix::unistd::{self, Gid, Pid, Uid, Whence};
-use num_traits::cast::ToPrimitive;
 
 use crate::function::{IntoPyNativeFunc, OptionalArg, PyFuncArgs};
 use crate::obj::objbytes::PyBytesRef;
@@ -1008,9 +1007,7 @@ fn os_getegid(vm: &VirtualMachine) -> PyObjectRef {
 }
 
 #[cfg(unix)]
-fn os_getpgid(pid: PyIntRef, vm: &VirtualMachine) -> PyObjectRef {
-    let pid = pid.as_bigint().to_u32().unwrap();
-
+fn os_getpgid(pid: u32, vm: &VirtualMachine) -> PyObjectRef {
     match unistd::getpgid(Some(Pid::from_raw(pid as i32))) {
         Ok(pgid) => vm.new_int(pgid.as_raw()),
         Err(err) => convert_nix_error(vm, err),
@@ -1018,9 +1015,7 @@ fn os_getpgid(pid: PyIntRef, vm: &VirtualMachine) -> PyObjectRef {
 }
 
 #[cfg(all(unix, not(target_os = "redox")))]
-fn os_getsid(pid: PyIntRef, vm: &VirtualMachine) -> PyObjectRef {
-    let pid = pid.as_bigint().to_u32().unwrap();
-
+fn os_getsid(pid: u32, vm: &VirtualMachine) -> PyObjectRef {
     match unistd::getsid(Some(Pid::from_raw(pid as i32))) {
         Ok(sid) => vm.new_int(sid.as_raw()),
         Err(err) => convert_nix_error(vm, err),
@@ -1040,24 +1035,17 @@ fn os_geteuid(vm: &VirtualMachine) -> PyObjectRef {
 }
 
 #[cfg(unix)]
-fn os_setgid(gid: PyIntRef, vm: &VirtualMachine) -> PyResult<()> {
-    let gid = gid.as_bigint().to_u32().unwrap();
-
+fn os_setgid(gid: u32, vm: &VirtualMachine) -> PyResult<()> {
     unistd::setgid(Gid::from_raw(gid)).map_err(|err| convert_nix_error(vm, err))
 }
 
 #[cfg(all(unix, not(target_os = "redox")))]
-fn os_setegid(egid: PyIntRef, vm: &VirtualMachine) -> PyResult<()> {
-    let egid = egid.as_bigint().to_u32().unwrap();
-
+fn os_setegid(egid: u32, vm: &VirtualMachine) -> PyResult<()> {
     unistd::setegid(Gid::from_raw(egid)).map_err(|err| convert_nix_error(vm, err))
 }
 
 #[cfg(unix)]
-fn os_setpgid(pid: PyIntRef, pgid: PyIntRef, vm: &VirtualMachine) -> PyResult<()> {
-    let pid = pid.as_bigint().to_u32().unwrap();
-    let pgid = pgid.as_bigint().to_u32().unwrap();
-
+fn os_setpgid(pid: u32, pgid: u32, vm: &VirtualMachine) -> PyResult<()> {
     unistd::setpgid(Pid::from_raw(pid as i32), Pid::from_raw(pgid as i32))
         .map_err(|err| convert_nix_error(vm, err))
 }
@@ -1070,16 +1058,12 @@ fn os_setsid(vm: &VirtualMachine) -> PyResult<()> {
 }
 
 #[cfg(unix)]
-fn os_setuid(uid: PyIntRef, vm: &VirtualMachine) -> PyResult<()> {
-    let uid = uid.as_bigint().to_u32().unwrap();
-
+fn os_setuid(uid: u32, vm: &VirtualMachine) -> PyResult<()> {
     unistd::setuid(Uid::from_raw(uid)).map_err(|err| convert_nix_error(vm, err))
 }
 
 #[cfg(all(unix, not(target_os = "redox")))]
-fn os_seteuid(euid: PyIntRef, vm: &VirtualMachine) -> PyResult<()> {
-    let euid = euid.as_bigint().to_u32().unwrap();
-
+fn os_seteuid(euid: u32, vm: &VirtualMachine) -> PyResult<()> {
     unistd::seteuid(Uid::from_raw(euid)).map_err(|err| convert_nix_error(vm, err))
 }
 

--- a/vm/src/stdlib/os.rs
+++ b/vm/src/stdlib/os.rs
@@ -334,17 +334,17 @@ fn os_error(message: OptionalArg<PyStringRef>, vm: &VirtualMachine) -> PyResult 
     Err(vm.new_os_error(msg))
 }
 
-fn os_fsync(fd: PyIntRef, vm: &VirtualMachine) -> PyResult<()> {
-    let file = rust_file(fd.as_bigint().to_i64().unwrap());
+fn os_fsync(fd: i64, vm: &VirtualMachine) -> PyResult<()> {
+    let file = rust_file(fd);
     file.sync_all().map_err(|err| convert_io_error(vm, err))?;
     // Avoid closing the fd
     raw_file_number(file);
     Ok(())
 }
 
-fn os_read(fd: PyIntRef, n: PyIntRef, vm: &VirtualMachine) -> PyResult {
-    let mut buffer = vec![0u8; n.as_bigint().to_usize().unwrap()];
-    let mut file = rust_file(fd.as_bigint().to_i64().unwrap());
+fn os_read(fd: i64, n: usize, vm: &VirtualMachine) -> PyResult {
+    let mut buffer = vec![0u8; n];
+    let mut file = rust_file(fd);
     file.read_exact(&mut buffer)
         .map_err(|err| convert_io_error(vm, err))?;
 
@@ -353,8 +353,8 @@ fn os_read(fd: PyIntRef, n: PyIntRef, vm: &VirtualMachine) -> PyResult {
     Ok(vm.ctx.new_bytes(buffer))
 }
 
-fn os_write(fd: PyIntRef, data: PyBytesRef, vm: &VirtualMachine) -> PyResult {
-    let mut file = rust_file(fd.as_bigint().to_i64().unwrap());
+fn os_write(fd: i64, data: PyBytesRef, vm: &VirtualMachine) -> PyResult {
+    let mut file = rust_file(fd);
     let written = file.write(&data).map_err(|err| convert_io_error(vm, err))?;
 
     // Avoid closing the fd

--- a/vm/src/stdlib/re.rs
+++ b/vm/src/stdlib/re.rs
@@ -6,7 +6,7 @@
  */
 use std::fmt;
 
-use num_traits::{Signed, ToPrimitive};
+use num_traits::Signed;
 use regex::bytes::{Captures, Regex, RegexBuilder};
 
 use crate::function::{Args, OptionalArg};
@@ -93,7 +93,7 @@ impl PyValue for PyMatch {
 fn re_match(
     pattern: PyStringRef,
     string: PyStringRef,
-    flags: OptionalArg<PyIntRef>,
+    flags: OptionalArg<usize>,
     vm: &VirtualMachine,
 ) -> PyResult {
     let flags = extract_flags(flags);
@@ -104,7 +104,7 @@ fn re_match(
 fn re_search(
     pattern: PyStringRef,
     string: PyStringRef,
-    flags: OptionalArg<PyIntRef>,
+    flags: OptionalArg<usize>,
     vm: &VirtualMachine,
 ) -> PyResult {
     let flags = extract_flags(flags);
@@ -117,7 +117,7 @@ fn re_sub(
     repl: PyStringRef,
     string: PyStringRef,
     count: OptionalArg<usize>,
-    flags: OptionalArg<PyIntRef>,
+    flags: OptionalArg<usize>,
     vm: &VirtualMachine,
 ) -> PyResult {
     let flags = extract_flags(flags);
@@ -129,7 +129,7 @@ fn re_sub(
 fn re_findall(
     pattern: PyStringRef,
     string: PyStringRef,
-    flags: OptionalArg<PyIntRef>,
+    flags: OptionalArg<usize>,
     vm: &VirtualMachine,
 ) -> PyResult {
     let flags = extract_flags(flags);
@@ -141,7 +141,7 @@ fn re_split(
     pattern: PyStringRef,
     string: PyStringRef,
     maxsplit: OptionalArg<PyIntRef>,
-    flags: OptionalArg<PyIntRef>,
+    flags: OptionalArg<usize>,
     vm: &VirtualMachine,
 ) -> PyResult {
     let flags = extract_flags(flags);
@@ -296,18 +296,16 @@ fn create_match(vm: &VirtualMachine, haystack: PyStringRef, captures: Captures) 
     PyMatch { haystack, captures }.into_ref(vm).into_object()
 }
 
-fn extract_flags(flags: OptionalArg<PyIntRef>) -> PyRegexFlags {
+fn extract_flags(flags: OptionalArg<usize>) -> PyRegexFlags {
     match flags {
-        OptionalArg::Present(flags) => {
-            PyRegexFlags::from_int(flags.as_bigint().to_usize().unwrap())
-        }
+        OptionalArg::Present(flags) => PyRegexFlags::from_int(flags),
         OptionalArg::Missing => Default::default(),
     }
 }
 
 fn re_compile(
     pattern: PyStringRef,
-    flags: OptionalArg<PyIntRef>,
+    flags: OptionalArg<usize>,
     vm: &VirtualMachine,
 ) -> PyResult<PyPattern> {
     let flags = extract_flags(flags);

--- a/vm/src/stdlib/socket.rs
+++ b/vm/src/stdlib/socket.rs
@@ -9,7 +9,6 @@ use byteorder::{BigEndian, ByteOrder};
 use gethostname::gethostname;
 #[cfg(all(unix, not(target_os = "redox")))]
 use nix::unistd::sethostname;
-use num_bigint::Sign;
 use num_traits::ToPrimitive;
 
 use crate::function::PyFuncArgs;
@@ -546,14 +545,7 @@ fn socket_inet_ntoa(packed_ip: PyBytesRef, vm: &VirtualMachine) -> PyResult {
     Ok(vm.new_str(Ipv4Addr::from(ip_num).to_string()))
 }
 
-fn socket_htonl(host: PyIntRef, vm: &VirtualMachine) -> PyResult {
-    if host.as_bigint().sign() == Sign::Minus {
-        return Err(
-            vm.new_overflow_error("can't convert negative value to unsigned int".to_string())
-        );
-    }
-
-    let host = host.as_bigint().to_u32().unwrap();
+fn socket_htonl(host: u32, vm: &VirtualMachine) -> PyResult {
     Ok(vm.new_int(host.to_be()))
 }
 

--- a/vm/src/stdlib/socket.rs
+++ b/vm/src/stdlib/socket.rs
@@ -312,8 +312,8 @@ impl SocketRef {
         Ok(vm.ctx.new_tuple(vec![socket.into_object(), addr_tuple]))
     }
 
-    fn recv(self, bufsize: PyIntRef, vm: &VirtualMachine) -> PyResult {
-        let mut buffer = vec![0u8; bufsize.as_bigint().to_usize().unwrap()];
+    fn recv(self, bufsize: usize, vm: &VirtualMachine) -> PyResult {
+        let mut buffer = vec![0u8; bufsize];
         match self.con.borrow_mut().as_mut() {
             Some(v) => match v.read_exact(&mut buffer) {
                 Ok(_) => (),
@@ -328,8 +328,8 @@ impl SocketRef {
         Ok(vm.ctx.new_bytes(buffer))
     }
 
-    fn recvfrom(self, bufsize: PyIntRef, vm: &VirtualMachine) -> PyResult {
-        let mut buffer = vec![0u8; bufsize.as_bigint().to_usize().unwrap()];
+    fn recvfrom(self, bufsize: usize, vm: &VirtualMachine) -> PyResult {
+        let mut buffer = vec![0u8; bufsize];
         let ret = match self.con.borrow().as_ref() {
             Some(v) => v.recv_from(&mut buffer),
             None => return Err(vm.new_type_error("".to_string())),

--- a/vm/src/stdlib/zlib.rs
+++ b/vm/src/stdlib/zlib.rs
@@ -41,18 +41,10 @@ pub fn make_module(vm: &VirtualMachine) -> PyObjectRef {
 }
 
 /// Compute an Adler-32 checksum of data.
-fn zlib_adler32(
-    data: PyBytesRef,
-    begin_state: OptionalArg<PyIntRef>,
-    vm: &VirtualMachine,
-) -> PyResult {
+fn zlib_adler32(data: PyBytesRef, begin_state: OptionalArg<i32>, vm: &VirtualMachine) -> PyResult {
     let data = data.get_value();
 
-    let begin_state = begin_state
-        .into_option()
-        .as_ref()
-        .map(|v| v.as_bigint().to_i32().unwrap())
-        .unwrap_or(1);
+    let begin_state = begin_state.unwrap_or(1);
 
     let mut hasher = Adler32::from_value(begin_state as u32);
     hasher.update_buffer(data);
@@ -63,18 +55,10 @@ fn zlib_adler32(
 }
 
 /// Compute a CRC-32 checksum of data.
-fn zlib_crc32(
-    data: PyBytesRef,
-    begin_state: OptionalArg<PyIntRef>,
-    vm: &VirtualMachine,
-) -> PyResult {
+fn zlib_crc32(data: PyBytesRef, begin_state: OptionalArg<i32>, vm: &VirtualMachine) -> PyResult {
     let data = data.get_value();
 
-    let begin_state = begin_state
-        .into_option()
-        .as_ref()
-        .map(|v| v.as_bigint().to_i32().unwrap())
-        .unwrap_or(0);
+    let begin_state = begin_state.unwrap_or(0);
 
     let mut hasher = Crc32::new_with_initial(begin_state as u32);
     hasher.update(data);
@@ -85,14 +69,10 @@ fn zlib_crc32(
 }
 
 /// Returns a bytes object containing compressed data.
-fn zlib_compress(data: PyBytesRef, level: OptionalArg<PyIntRef>, vm: &VirtualMachine) -> PyResult {
+fn zlib_compress(data: PyBytesRef, level: OptionalArg<i32>, vm: &VirtualMachine) -> PyResult {
     let input_bytes = data.get_value();
 
-    let level = level
-        .into_option()
-        .as_ref()
-        .map(|v| v.as_bigint().to_i32().unwrap())
-        .unwrap_or(libz::Z_DEFAULT_COMPRESSION);
+    let level = level.unwrap_or(libz::Z_DEFAULT_COMPRESSION);
 
     let compression = match level {
         valid_level @ libz::Z_NO_COMPRESSION..=libz::Z_BEST_COMPRESSION => {


### PR DESCRIPTION
This change is mainly changes of `PyIntRef` to primitives types. I will do other type in a different PR as this became a very large change...