### PR TITLE
Implement dict resizing

### DIFF
--- a/vm/src/dictdatatype.rs
+++ b/vm/src/dictdatatype.rs
@@ -37,7 +37,6 @@ impl<T> Default for Dict<T> {
 
 #[derive(Clone)]
 struct DictEntry<T> {
-    hash_index: HashIndex,
     hash: HashValue,
     key: PyObjectRef,
     value: T,
@@ -78,7 +77,6 @@ impl<T: Clone> Dict<T> {
     ) {
         let entry = DictEntry {
             hash: hash_value,
-            hash_index,
             key,
             value,
         };


### PR DESCRIPTION
Dict resizing is working by removing all None entries, and filling up indices map from scratch
Frequency of resizing should be adjusted, I guess. Maybe it'll be useful to trigger it more often, it's hard to say without somewhat realistic benchmark

Addresses: #1531 

Benchmark: 
```python
a = {0: 1}
for i in range(10000):
    del a[0]
    a[0] = 1


```

Results: 
```
$ time ./target/release/rustpython-master test.py

real    0m3,316s
user    0m3,312s
sys     0m0,004s

$ time ./target/release/rustpython test.py

real    0m0,062s
user    0m0,055s
sys     0m0,008s

$ time python3 test.py

real    0m0,023s
user    0m0,015s
sys     0m0,008s

```