### PR TITLE
objtype: Set __doc__ as None if not included 

### DIFF
--- a/tests/snippets/class.py
+++ b/tests/snippets/class.py
@@ -174,6 +174,16 @@ class A:
     assert a == 2
 A.b()
 
+class A:
+    pass
+
+assert A.__doc__ == None
+
+class B:
+    "Docstring"
+
+assert B.__doc__ == "Docstring"
+
 # TODO: uncomment once free vars/cells are working
 # The symboltable sees that b() is referring to a in the nested scope,
 # so it marks it as non local. When it's executed, it walks up the scopes

--- a/vm/src/obj/objtype.rs
+++ b/vm/src/obj/objtype.rs
@@ -321,7 +321,12 @@ fn type_new_slot(metatype: PyClassRef, args: PyFuncArgs, vm: &VirtualMachine) ->
         bases
     };
 
-    let attributes = dict.to_attributes();
+    let mut attributes = dict.to_attributes();
+
+    // insert __doc__ as None if it is not included in attributes
+    if !attributes.contains_key("__doc__") {
+        attributes.insert("__doc__".to_string(), vm.ctx.none());
+    }
 
     let mut winner = metatype.clone();
     for base in &bases {


### PR DESCRIPTION
This set `__doc__` as None if it is not included in attribute
while making new instance of type.
In cpython if there is no docstring in class definition,
`__doc__` attribute will be None. So RustPython should follow it.

Partially solves #1523 

This only fixes class definition.