### PR TITLE
Improve  float.fromhex module of objfloat

### DIFF
--- a/tests/snippets/floats.py
+++ b/tests/snippets/floats.py
@@ -236,6 +236,13 @@ a = 3.1__4
 with assert_raises(SyntaxError):
     exec(src)
 
+assert float.fromhex('0.0') == 0.0
+assert float.fromhex('-0.0') == 0.0
+assert float.fromhex('0x0p0') == 0.0
+assert float.fromhex('-0x0p0') == 0.0
+assert float.fromhex('0x0.p0') == 0.0
+assert float.fromhex('-0x0.p0') == 0.0
+assert float.fromhex('-0x0.0p+0') == -0.0
 assert float.fromhex('0x0.0p+0') == 0.0
 assert float.fromhex('-0x0.0p+0') == -0.0
 assert float.fromhex('0x1.000000p+0') == 1.0

--- a/tests/snippets/floats.py
+++ b/tests/snippets/floats.py
@@ -242,7 +242,6 @@ assert float.fromhex('0x0p0') == 0.0
 assert float.fromhex('-0x0p0') == 0.0
 assert float.fromhex('0x0.p0') == 0.0
 assert float.fromhex('-0x0.p0') == 0.0
-assert float.fromhex('-0x0.0p+0') == -0.0
 assert float.fromhex('0x0.0p+0') == 0.0
 assert float.fromhex('-0x0.0p+0') == -0.0
 assert float.fromhex('0x1.000000p+0') == 1.0

--- a/tests/snippets/floats.py
+++ b/tests/snippets/floats.py
@@ -239,6 +239,8 @@ with assert_raises(SyntaxError):
 assert float.fromhex('0.0') == 0.0
 assert float.fromhex('-0.0') == 0.0
 assert float.fromhex('0x0p0') == 0.0
+assert float.fromhex('0x010p0') == 16.0
+assert float.fromhex('0x0.10p3') == 0.5
 assert float.fromhex('-0x0p0') == 0.0
 assert float.fromhex('0x0.p0') == 0.0
 assert float.fromhex('-0x0.p0') == 0.0
@@ -248,6 +250,7 @@ assert float.fromhex('0x1.000000p+0') == 1.0
 assert float.fromhex('-0x1.800000p+0') == -1.5
 assert float.fromhex('inf') == float('inf')
 assert math.isnan(float.fromhex('nan'))
+assert_raises(ValueError, lambda: float.fromhex('error'))
 
 assert (0.0).hex() == '0x0.0p+0'
 assert (-0.0).hex() == '-0x0.0p+0'

--- a/vm/src/obj/objfloat.rs
+++ b/vm/src/obj/objfloat.rs
@@ -587,6 +587,8 @@ impl PyFloat {
                                 hex.push(ch);
                             }
                         }
+                    } else {
+                        hex = value.to_string();
                     }
                     hexf_parse::parse_hexf64(hex.as_str(), false).map_err(|_| {
                         vm.new_value_error("invalid hexadecimal floating-point string".to_string())

--- a/vm/src/obj/objfloat.rs
+++ b/vm/src/obj/objfloat.rs
@@ -585,7 +585,8 @@ impl PyFloat {
                             hex += &ch.to_string();
                         }
                     }
-                    Ok(hexf_parse::parse_hexf64(&hex, false).unwrap())
+                    Ok(hexf_parse::parse_hexf64(&hex, false)
+                        .expect("invalid hexadecimal floating-point string"))
                 } else {
                     let res = match value.parse::<f64>() {
                         Ok(float_num) => Ok(float_num),

--- a/vm/src/obj/objfloat.rs
+++ b/vm/src/obj/objfloat.rs
@@ -575,7 +575,27 @@ impl PyFloat {
             "nan" => Ok(std::f64::NAN),
             "inf" => Ok(std::f64::INFINITY),
             "-inf" => Ok(std::f64::NEG_INFINITY),
-            _ => Err(vm.new_value_error("invalid hexadecimal floating-point string".to_string())),
+            value => {
+                if value.contains("0x") {
+                    let mut hex = "".to_string();
+                    for ch in value.chars() {
+                        if ch == 'p' {
+                            hex += ".p";
+                        } else {
+                            hex += &ch.to_string();
+                        }
+                    }
+                    Ok(hexf_parse::parse_hexf64(&hex, false).unwrap())
+                } else {
+                    let res = match value.parse::<f64>() {
+                        Ok(float_num) => Ok(float_num),
+                        _e => Err(vm.new_value_error(
+                            "invalid hexadecimal floating-point string".to_string(),
+                        )),
+                    };
+                    res
+                }
+            }
         })
     }
 

--- a/vm/src/obj/objfloat.rs
+++ b/vm/src/obj/objfloat.rs
@@ -571,35 +571,28 @@ impl PyFloat {
 
     #[pymethod]
     fn fromhex(repr: PyStringRef, vm: &VirtualMachine) -> PyResult<f64> {
-        hexf_parse::parse_hexf64(repr.as_str(), false).or_else(|_| match repr.as_str() {
-            "nan" => Ok(std::f64::NAN),
-            "inf" => Ok(std::f64::INFINITY),
-            "-inf" => Ok(std::f64::NEG_INFINITY),
-            value => {
-                let err_msg = "invalid hexadecimal floating-point string";
-                let res = if value.contains("0x") {
-                    let mut hex = "".to_string();
-                    for ch in value.chars() {
-                        if ch == 'p' {
-                            hex += ".p";
-                        } else {
-                            hex += &ch.to_string();
+        hexf_parse::parse_hexf64(repr.as_str(), false)
+            .or_else(|_| repr.as_str().parse::<f64>())
+            .or_else(|_| match repr.as_str() {
+                "nan" => Ok(std::f64::NAN),
+                "inf" => Ok(std::f64::INFINITY),
+                "-inf" => Ok(std::f64::NEG_INFINITY),
+                value => {
+                    let mut hex = String::new();
+                    if value.contains("0x") {
+                        for ch in value.chars() {
+                            if ch == 'p' {
+                                hex.push_str(".p");
+                            } else {
+                                hex.push(ch);
+                            }
                         }
                     }
-
-                    match hexf_parse::parse_hexf64(&hex, false) {
-                        Ok(f) => Ok(f),
-                        _e => Err(vm.new_value_error(err_msg.to_string())),
-                    }
-                } else {
-                    match value.parse::<f64>() {
-                        Ok(f) => Ok(f),
-                        _e => Err(vm.new_value_error(err_msg.to_string())),
-                    }
-                };
-                res
-            }
-        })
+                    hexf_parse::parse_hexf64(hex.as_str(), false).map_err(|_| {
+                        vm.new_value_error("invalid hexadecimal floating-point string".to_string())
+                    })
+                }
+            })
     }
 
     #[pymethod]


### PR DESCRIPTION
- Python `float.fromhex` can handle string of float and hex without `.`
  - For example `0.0`, `-0.0`, `0x0p0`, `-0x0p0`
- Add test case mantioned