### PR TITLE
Ignore deprecated module warning in a test script

### DIFF
--- a/tests/not_impl_gen.py
+++ b/tests/not_impl_gen.py
@@ -5,6 +5,7 @@
 import pkgutil
 import os
 import sys
+import warnings
 
 sys.path = list(
     filter(
@@ -61,10 +62,13 @@ def gen_methods(header, footer, output):
     output.write(footer.read())
 
 def get_module_methods(name):
-    try:
-        return set(dir(__import__(name))) if name not in ("this", "antigravity") else None
-    except ModuleNotFoundError:
-        return None
+    with warnings.catch_warnings():
+        # ignore warnings caused by importing deprecated modules
+        warnings.filterwarnings("ignore", category=DeprecationWarning)
+        try:
+            return set(dir(__import__(name))) if name not in ("this", "antigravity") else None
+        except ModuleNotFoundError:
+            return None
 
 
 def gen_modules(header, footer, output):


### PR DESCRIPTION
When executing `./whats_left.sh`,
you may see several warning messages at beginning as follows
```
not_impl_gen.py:69: DeprecationWarning: the formatter module is deprecated
  return set(dir(__import__(name))) if name not in ("this", "antigravity") else None
not_impl_gen.py:69: DeprecationWarning: the imp module is deprecated in favour of importlib; see the module's documentation for alternative uses
  return set(dir(__import__(name))) if name not in ("this", "antigravity") else None
not_impl_gen.py:69: DeprecationWarning: the macpath module is deprecated in 3.7 and will be removed in 3.8
  return set(dir(__import__(name))) if name not in ("this", "antigravity") else None
```

This fix will stop showing those messages