### PR TITLE
bytes.replace: replacing bytes w/ diff len

### DIFF
--- a/tests/snippets/bytes.py
+++ b/tests/snippets/bytes.py
@@ -581,6 +581,9 @@ assert b"123456789123".replace(b"23", b"XX", 1) == b"1XX456789123"
 assert b"123456789123".replace(b"23", b"XX", 0) == b"123456789123"
 assert b"123456789123".replace(b"23", b"XX", -1) == b"1XX4567891XX"
 assert b"123456789123".replace(b"23", b"") == b"14567891"
+assert b"123456789123".replace(b"23", b"X") == b"1X4567891X"
+assert b"rust  python".replace(b" ", b"-") == b"rust--python"
+assert b"rust  python".replace(b"  ", b"-") == b"rust-python"
 
 # title
 assert b"Hello world".title() == b"Hello World"

--- a/vm/src/obj/objbyteinner.rs
+++ b/vm/src/obj/objbyteinner.rs
@@ -1013,8 +1013,8 @@ impl PyByteInner {
         let mut done = 0;
 
         let slice = &self.elements;
-        while index <= slice.len() - old.len() {
-            if done == count {
+        loop {
+            if done == count || index > slice.len() - old.len() {
                 res.extend_from_slice(&slice[index..]);
                 break;
             }


### PR DESCRIPTION
fix the bug on replacing bytes with different length
issue #1560 