### PR TITLE
add cargo install instructions to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,14 @@ Or use the interactive shell:
     >>>>> 2+2
     4
 
+You can also install and run RustPython with the following:
+
+    $ cargo install rustpython
+    $ rustpython
+    Welcome to the magnificent Rust Python interpreter
+    >>>>> 
+
+
 ### WASI
 
 You can compile RustPython to a standalone WebAssembly WASI module so it can run anywhere.


### PR DESCRIPTION
The readme has instructions for cloning and testing the repo and for installing with wapm, but it's always nice to have copy-able cargo install instructions