### PR TITLE
test.not_impl_gen ignore py module w/ import error

### DIFF
--- a/tests/not_impl_gen.py
+++ b/tests/not_impl_gen.py
@@ -69,6 +69,8 @@ def get_module_methods(name):
             return set(dir(__import__(name))) if name not in ("this", "antigravity") else None
         except ModuleNotFoundError:
             return None
+        except Exception as e:
+            print("!!! {} skipped because {}: {}".format(name, type(e).__name__, str(e)))
 
 
 def gen_modules(header, footer, output):


### PR DESCRIPTION
Ignore python module which cannot be imported and print error message thereof

I am not sure the reason, but I have a problem with import `pyopenvdb`.

This does not really matter to block `whats_left.sh`, so I propose to ignore error and print error message as following.
```
!!! pyopenvdb skipped because ImportError: /usr/lib64/libjemalloc.so.2: cannot allocate memory in static TLS block
```
