### PR TITLE
Fix issue #1575 distinguish between 'cased' and 'non-cased' characters

### DIFF
--- a/tests/snippets/strings.py
+++ b/tests/snippets/strings.py
@@ -325,5 +325,12 @@ assert not "a".__ne__("a")
 assert not "".__ne__("")
 assert "".__ne__(1) == NotImplemented
 
+# check non-cased characters
 assert "A_B".isupper()
 assert "a_b".islower()
+assert "A1".isupper()
+assert "1A".isupper()
+assert "a1".islower()
+assert "1a".islower()
+assert "가나다a".islower()
+assert "가나다A".isupper()

--- a/vm/src/obj/objstr.rs
+++ b/vm/src/obj/objstr.rs
@@ -753,6 +753,7 @@ impl PyString {
         }
         cased
     }
+    
     #[pymethod]
     fn isascii(&self, _vm: &VirtualMachine) -> bool {
         !self.value.is_empty() && self.value.chars().all(|c| c.is_ascii())

--- a/vm/src/obj/objstr.rs
+++ b/vm/src/obj/objstr.rs
@@ -10,10 +10,10 @@ use std::str::FromStr;
 use std::string::ToString;
 
 use num_traits::ToPrimitive;
+use unic::ucd::is_cased;
 use unicode_casing::CharExt;
 use unicode_categories::UnicodeCategories;
 use unicode_xid::UnicodeXID;
-use unic::ucd::is_cased;
 
 use super::objbytes::PyBytes;
 use super::objdict::PyDict;
@@ -729,27 +729,25 @@ impl PyString {
     // Return true if all cased characters in the string are uppercase and there is at least one cased character, false otherwise.
     #[pymethod]
     fn isupper(&self, _vm: &VirtualMachine) -> bool {
-        // TODO: assert not " ".isupper(), assert not "_".isupper()
         let mut cased = false;
         for c in self.value.chars() {
-            if is_cased(c) && c.is_uppercase(){
+            if is_cased(c) && c.is_uppercase() {
                 cased = true
-            }
-            else if is_cased(c) && c.is_lowercase(){
+            } else if is_cased(c) && c.is_lowercase() {
                 return false;
             }
         }
         cased
     }
 
+    // Return true if all cased characters in the string are lowercase and there is at least one cased character, false otherwise.
     #[pymethod]
     fn islower(&self, _vm: &VirtualMachine) -> bool {
         let mut cased = false;
         for c in self.value.chars() {
-            if is_cased(c) && c.is_lowercase(){
+            if is_cased(c) && c.is_lowercase() {
                 cased = true
-            }
-            else if is_cased(c) && c.is_uppercase(){
+            } else if is_cased(c) && c.is_uppercase() {
                 return false;
             }
         }

--- a/vm/src/obj/objstr.rs
+++ b/vm/src/obj/objstr.rs
@@ -728,24 +728,35 @@ impl PyString {
     #[pymethod]
     fn isupper(&self, _vm: &VirtualMachine) -> bool {
         // TODO: assert not " ".isupper(), assert not "_".isupper()
-        !self.value.is_empty()
+        if self.value.chars().all(char::is_numeric) {
+            false
+        }
+        else{
+            !self.value.is_empty()
             && self
                 .value
                 .chars()
-                .filter(|x| !x.is_ascii_whitespace() && *x != '_')
+                .filter(|x| !x.is_ascii_whitespace())
+                .filter(|x| !x.is_numeric())
                 .all(char::is_uppercase)
+        }
     }
 
     #[pymethod]
     fn islower(&self, _vm: &VirtualMachine) -> bool {
-        !self.value.is_empty()
+        if self.value.chars().all(char::is_numeric) {
+            false
+        }
+        else{
+            !self.value.is_empty()
             && self
                 .value
                 .chars()
-                .filter(|x| !x.is_ascii_whitespace() && *x != '_')
+                .filter(|x| !x.is_ascii_whitespace())
+                .filter(|x| !x.is_numeric())
                 .all(char::is_lowercase)
+        }
     }
-
     #[pymethod]
     fn isascii(&self, _vm: &VirtualMachine) -> bool {
         !self.value.is_empty() && self.value.chars().all(|c| c.is_ascii())

--- a/vm/src/obj/objstr.rs
+++ b/vm/src/obj/objstr.rs
@@ -753,7 +753,7 @@ impl PyString {
         }
         cased
     }
-    
+
     #[pymethod]
     fn isascii(&self, _vm: &VirtualMachine) -> bool {
         !self.value.is_empty() && self.value.chars().all(|c| c.is_ascii())

--- a/vm/src/obj/objstr.rs
+++ b/vm/src/obj/objstr.rs
@@ -13,6 +13,7 @@ use num_traits::ToPrimitive;
 use unicode_casing::CharExt;
 use unicode_categories::UnicodeCategories;
 use unicode_xid::UnicodeXID;
+use unic::ucd::is_cased;
 
 use super::objbytes::PyBytes;
 use super::objdict::PyDict;
@@ -725,37 +726,34 @@ impl PyString {
         !self.value.is_empty() && self.value.chars().all(|c| c.is_ascii_whitespace())
     }
 
+    // Return true if all cased characters in the string are uppercase and there is at least one cased character, false otherwise.
     #[pymethod]
     fn isupper(&self, _vm: &VirtualMachine) -> bool {
         // TODO: assert not " ".isupper(), assert not "_".isupper()
-        if self.value.chars().all(char::is_numeric) {
-            false
+        let mut cased = false;
+        for c in self.value.chars() {
+            if is_cased(c) && c.is_uppercase(){
+                cased = true
+            }
+            else if is_cased(c) && c.is_lowercase(){
+                return false;
+            }
         }
-        else{
-            !self.value.is_empty()
-            && self
-                .value
-                .chars()
-                .filter(|x| !x.is_ascii_whitespace())
-                .filter(|x| !x.is_numeric())
-                .all(char::is_uppercase)
-        }
+        cased
     }
 
     #[pymethod]
     fn islower(&self, _vm: &VirtualMachine) -> bool {
-        if self.value.chars().all(char::is_numeric) {
-            false
+        let mut cased = false;
+        for c in self.value.chars() {
+            if is_cased(c) && c.is_lowercase(){
+                cased = true
+            }
+            else if is_cased(c) && c.is_uppercase(){
+                return false;
+            }
         }
-        else{
-            !self.value.is_empty()
-            && self
-                .value
-                .chars()
-                .filter(|x| !x.is_ascii_whitespace())
-                .filter(|x| !x.is_numeric())
-                .all(char::is_lowercase)
-        }
+        cased
     }
     #[pymethod]
     fn isascii(&self, _vm: &VirtualMachine) -> bool {


### PR DESCRIPTION
#1575 distinguish between 'cased' and 'non-cased' characters

use unic::ucd::is_cased function to ignore non-cased character