### PR TITLE
Set docstring of function as None if not declared

### DIFF
--- a/compiler/src/compile.rs
+++ b/compiler/src/compile.rs
@@ -1015,22 +1015,23 @@ impl<O: OutputStream> Compiler<O> {
     }
 
     fn store_docstring(&mut self, doc_str: Option<String>) {
-        if let Some(doc_string) = doc_str {
-            // Duplicate top of stack (the function or class object)
-            self.emit(Instruction::Duplicate);
+        // Duplicate top of stack (the function or class object)
+        self.emit(Instruction::Duplicate);
 
-            // Doc string value:
-            self.emit(Instruction::LoadConst {
-                value: bytecode::Constant::String {
-                    value: doc_string.to_string(),
+        // Doc string value:
+        self.emit(Instruction::LoadConst {
+            value: match doc_str {
+                Some(doc) => bytecode::Constant::String {
+                    value: doc.to_string(),
                 },
-            });
+                None => bytecode::Constant::None, // set docstring None if not declared
+            },
+        });
 
-            self.emit(Instruction::Rotate { amount: 2 });
-            self.emit(Instruction::StoreAttr {
-                name: "__doc__".to_string(),
-            });
-        }
+        self.emit(Instruction::Rotate { amount: 2 });
+        self.emit(Instruction::StoreAttr {
+            name: "__doc__".to_string(),
+        });
     }
 
     fn compile_while(

--- a/tests/snippets/function.py
+++ b/tests/snippets/function.py
@@ -95,3 +95,8 @@ assert f8() == 10
 
 with assert_raises(SyntaxError):
     exec('print(keyword=10, 20)')
+
+def f9():
+    pass
+
+assert f9.__doc__ == None


### PR DESCRIPTION
In cpython, if there is no docstring declared in function definition,
the `__doc__` attribute of the function is None.
So this implements the behavior.

Fix #1523