### PR TITLE
Improve float.fromhex module representation case

### DIFF
--- a/tests/snippets/floats.py
+++ b/tests/snippets/floats.py
@@ -441,12 +441,8 @@ assert float('inf').hex() == 'inf'
 assert float('-inf').hex() == '-inf'
 assert float('nan').hex() == 'nan'
 
-#for _ in range(10000):
-#    f = random.random() * random.randint(0, 0x10000000000000000)
-#    assert f == fromHex(f.hex())
-
 # Test float exponent:
-assert 1 if 1 else 0 == 1
+assert 1 if 1else 0 == 1
 
 a = 3.
 assert a.__eq__(3) is True


### PR DESCRIPTION
- Refactoring previous PR #1552
  - Embrace hexadecimal without `0x`, `.`, `p`
  - Embrace variety of `nan`, `inf` case
  - Enhance test case based on cpython
- TODO: Still fromhex can't catch overflow error and accept closest to `min`, `max`, `0`, `1` case isn't handled