### PR TITLE
Return function attributes in method

### DIFF
--- a/tests/snippets/class.py
+++ b/tests/snippets/class.py
@@ -33,6 +33,10 @@ class Bar:
         assert __class__ is Bar
         return self.x
 
+    def doc_func(self):
+        "doc string"
+        pass
+
     @classmethod
     def fubar(cls, x):
         assert __class__ is cls
@@ -48,6 +52,8 @@ class Bar:
 assert Bar.__doc__ == " W00t "
 
 bar = Bar(42)
+assert bar.get_x.__doc__ == None
+assert bar.doc_func.__doc__ == "doc string"
 
 bar.fubar(2)
 Bar.fubar(2)

--- a/vm/src/obj/objfunction.rs
+++ b/vm/src/obj/objfunction.rs
@@ -1,5 +1,6 @@
 use super::objcode::PyCodeRef;
 use super::objdict::PyDictRef;
+use super::objstr::PyStringRef;
 use super::objtuple::PyTupleRef;
 use super::objtype::PyClassRef;
 use crate::function::PyFuncArgs;
@@ -69,6 +70,10 @@ impl PyMethod {
     pub fn new(object: PyObjectRef, function: PyObjectRef) -> Self {
         PyMethod { object, function }
     }
+
+    fn getattribute(&self, name: PyStringRef, vm: &VirtualMachine) -> PyResult {
+        vm.get_attribute(self.function.clone(), name.clone())
+    }
 }
 
 impl PyValue for PyMethod {
@@ -91,6 +96,11 @@ pub fn init(context: &PyContext) {
     extend_class!(context, builtin_function_or_method_type, {
         "__get__" => context.new_rustfunc(bind_method),
         "__call__" => context.new_rustfunc(PyFunctionRef::call),
+    });
+
+    let method_type = &context.types.bound_method_type;
+    extend_class!(context, method_type, {
+        "__getattribute__" => context.new_rustfunc(PyMethod::getattribute),
     });
 }
 

--- a/vm/src/obj/objtype.rs
+++ b/vm/src/obj/objtype.rs
@@ -321,12 +321,7 @@ fn type_new_slot(metatype: PyClassRef, args: PyFuncArgs, vm: &VirtualMachine) ->
         bases
     };
 
-    let mut attributes = dict.to_attributes();
-
-    // insert __doc__ as None if it is not included in attributes
-    if !attributes.contains_key("__doc__") {
-        attributes.insert("__doc__".to_string(), vm.ctx.none());
-    }
+    let attributes = dict.to_attributes();
 
     let mut winner = metatype.clone();
     for base in &bases {


### PR DESCRIPTION
Currently the method return the attributes of the `PyMethod` object. This changes the attributes of the wrapped function to be returned.
In addition removed the change in #1550 after #1580.