### PR TITLE
Fix spelling

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ You can build the WebAssembly WASI file with:
 cargo build --release --target wasm32-wasi --features="freeze-stdlib"
 ```
 
-> Note: we use the `freeze-stdlib` to include the standard libarary inside the binary.
+> Note: we use the `freeze-stdlib` to include the standard library inside the binary.
 
 ## Disclaimer
 


### PR DESCRIPTION
Change "libarary" to "library".