### PR TITLE
Separate BaseException to __init__ and __new__

### DIFF
--- a/tests/snippets/exceptions.py
+++ b/tests/snippets/exceptions.py
@@ -51,3 +51,15 @@ assert exc.name == 'name'
 assert exc.path == 'path'
 assert exc.msg == 'hello'
 assert exc.args == ('hello',)
+
+
+class NewException(Exception):
+
+	def __init__(self, value):
+		self.value = value
+
+
+try:
+	raise NewException("test")
+except NewException as e:
+	assert e.value == "test"

--- a/vm/src/exceptions.rs
+++ b/vm/src/exceptions.rs
@@ -10,11 +10,11 @@ use crate::types::create_type;
 use crate::vm::VirtualMachine;
 use itertools::Itertools;
 use std::cell::{Cell, RefCell};
+use std::fmt;
 use std::fs::File;
 use std::io::{self, BufRead, BufReader, Write};
 
 #[pyclass]
-#[derive(Debug)]
 pub struct PyBaseException {
     traceback: RefCell<Option<PyTracebackRef>>,
     cause: RefCell<Option<PyObjectRef>>,
@@ -22,6 +22,14 @@ pub struct PyBaseException {
     suppress_context: Cell<bool>,
     args: RefCell<PyObjectRef>,
 }
+
+impl fmt::Debug for PyBaseException {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        // TODO: implement more detailed, non-recursive Debug formatter
+        f.write_str("PyBaseException")
+    }
+}
+
 pub type PyBaseExceptionRef = PyRef<PyBaseException>;
 
 impl PyValue for PyBaseException {


### PR DESCRIPTION
In CPython the BaseException initialize `__traceback__`, `__cause__`, `__context__` and `__suppress_context__` in `__new__` and not in `__init__`.
Do you think this attributes should be members of `PyBaseException`? 