### PR TITLE
Provide caret diagnostics for SyntaxError

### DIFF
--- a/compiler/src/compile.rs
+++ b/compiler/src/compile.rs
@@ -255,6 +255,7 @@ impl<O: OutputStream> Compiler<O> {
                 self.compile_expression(expression)?;
             } else {
                 return Err(CompileError {
+                    statement: None,
                     error: CompileErrorType::ExpectExpr,
                     location: statement.location.clone(),
                 });
@@ -533,6 +534,7 @@ impl<O: OutputStream> Compiler<O> {
             Break => {
                 if !self.ctx.in_loop {
                     return Err(CompileError {
+                        statement: None,
                         error: CompileErrorType::InvalidBreak,
                         location: statement.location.clone(),
                     });
@@ -542,6 +544,7 @@ impl<O: OutputStream> Compiler<O> {
             Continue => {
                 if !self.ctx.in_loop {
                     return Err(CompileError {
+                        statement: None,
                         error: CompileErrorType::InvalidContinue,
                         location: statement.location.clone(),
                     });
@@ -551,6 +554,7 @@ impl<O: OutputStream> Compiler<O> {
             Return { value } => {
                 if !self.ctx.in_func() {
                     return Err(CompileError {
+                        statement: None,
                         error: CompileErrorType::InvalidReturn,
                         location: statement.location.clone(),
                     });
@@ -628,6 +632,7 @@ impl<O: OutputStream> Compiler<O> {
             }
             _ => {
                 return Err(CompileError {
+                    statement: None,
                     error: CompileErrorType::Delete(expression.name()),
                     location: self.current_source_location.clone(),
                 });
@@ -1331,6 +1336,7 @@ impl<O: OutputStream> Compiler<O> {
                     if let ast::ExpressionType::Starred { .. } = &element.node {
                         if seen_star {
                             return Err(CompileError {
+                                statement: None,
                                 error: CompileErrorType::StarArgs,
                                 location: self.current_source_location.clone(),
                             });
@@ -1360,6 +1366,7 @@ impl<O: OutputStream> Compiler<O> {
             }
             _ => {
                 return Err(CompileError {
+                    statement: None,
                     error: CompileErrorType::Assign(target.name()),
                     location: self.current_source_location.clone(),
                 });
@@ -1644,6 +1651,7 @@ impl<O: OutputStream> Compiler<O> {
             Yield { value } => {
                 if !self.ctx.in_func() {
                     return Err(CompileError {
+                        statement: Option::None,
                         error: CompileErrorType::InvalidYield,
                         location: self.current_source_location.clone(),
                     });
@@ -1738,6 +1746,7 @@ impl<O: OutputStream> Compiler<O> {
             }
             Starred { .. } => {
                 return Err(CompileError {
+                    statement: Option::None,
                     error: CompileErrorType::SyntaxError(std::string::String::from(
                         "Invalid starred expression",
                     )),

--- a/compiler/src/symboltable.rs
+++ b/compiler/src/symboltable.rs
@@ -142,6 +142,7 @@ pub struct SymbolTableError {
 impl From<SymbolTableError> for CompileError {
     fn from(error: SymbolTableError) -> Self {
         CompileError {
+            statement: None,
             error: CompileErrorType::SyntaxError(error.error),
             location: error.location,
         }

--- a/parser/src/location.rs
+++ b/parser/src/location.rs
@@ -16,6 +16,17 @@ impl fmt::Display for Location {
 }
 
 impl Location {
+    pub fn visualize(&self, desc: &str) -> String {
+        format!(
+            "{}↑\n{}{}",
+            " ".repeat(self.column - 1),
+            " ".repeat(self.column - 1),
+            desc
+        )
+    }
+}
+
+impl Location {
     pub fn new(row: usize, column: usize) -> Self {
         Location { row, column }
     }

--- a/vm/src/vm.rs
+++ b/vm/src/vm.rs
@@ -1007,6 +1007,10 @@ impl VirtualMachine {
     ) -> Result<PyCodeRef, CompileError> {
         compile::compile(source, mode, source_path, self.settings.optimize)
             .map(|codeobj| PyCode::new(codeobj).into_ref(self))
+            .map_err(|mut compile_error| {
+                compile_error.update_statement_info(source.trim_end().to_string());
+                compile_error
+            })
     }
 
     pub fn _sub(&self, a: PyObjectRef, b: PyObjectRef) -> PyResult {


### PR DESCRIPTION
visualize syntax error with caret diagnostics, when the statement is provided

Fix issue #1513 

The result will show as following.
```
Welcome to the magnificent Rust Python 0.1.1 interpreter 😱 🖖
>>>>> a ! b
SyntaxError:
a ! b
  ↑
  Got unexpected token !
>>>>>
```

I am not sure how to implement the test for the python error message if someone knows about this, please kindly tell me, thanks. 