### PR TITLE
Travis CI: Matrix -> jobs and Python 3.6 to 3.8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ before_cache:
     fi
   - rm -rf ~/.cargo/registry/src
 
-matrix:
+jobs:
   fast_finish: true
   include:
     - name: Run Rust tests(linux)
@@ -42,7 +42,7 @@ matrix:
     # installing rust ourselves is a lot easier than installing Python)
     - name: Python test snippets
       language: python
-      python: 3.6
+      python: 3.8
       cache:
         - pip
         - cargo
@@ -76,7 +76,7 @@ matrix:
 
     - name: Lint Python code with flake8
       language: python
-      python: 3.6
+      python: 3.8
       cache: pip
       env: JOBCACHE=9
       install: pip install flake8
@@ -134,7 +134,7 @@ matrix:
 
     - name: Code Coverage
       language: python
-      python: 3.6
+      python: 3.8
       cache:
         - pip
         - cargo
@@ -149,7 +149,7 @@ matrix:
 
     - name: Test WASM
       language: python
-      python: 3.6
+      python: 3.8
       cache:
         - pip
         - cargo

--- a/.travis.yml
+++ b/.travis.yml
@@ -149,7 +149,7 @@ jobs:
 
     - name: Test WASM
       language: python
-      python: 3.8
+      python: 3.6
       cache:
         - pip
         - cargo

--- a/tests/Pipfile
+++ b/tests/Pipfile
@@ -10,4 +10,4 @@ pytest = "*"
 [dev-packages]
 
 [requires]
-python_version = "3.6"
+python_version = "3.8"

--- a/tests/Pipfile
+++ b/tests/Pipfile
@@ -10,4 +10,3 @@ pytest = "*"
 [dev-packages]
 
 [requires]
-python_version = "3.8"

--- a/tests/snippets/math_basics.py
+++ b/tests/snippets/math_basics.py
@@ -49,7 +49,11 @@ assert pow(2, 4, 5) == 1
 assert_raises(TypeError, pow, 2, 4, 5.0)
 assert_raises(TypeError, pow, 2, 4.0, 5)
 assert_raises(TypeError, pow, 2.0, 4, 5)
-assert_raises(ValueError, pow, 2, -1, 5)
+from sys import version_info
+if version_info < (3, 8):
+  assert_raises(ValueError, pow, 2, -1, 5)
+else:  # https://docs.python.org/3/whatsnew/3.8.html#other-language-changes
+  assert pow(2, -1, 5) == 3 
 assert_raises(ValueError, pow, 2, 2, 0)
 
 # bitwise


### PR DESCRIPTION
https://docs.python.org/3/whatsnew/3.8.html#other-language-changes
> For integers, the three-argument form of the pow() function now permits the exponent to be negative in the case where the base is relatively prime to the modulus. It then computes a modular inverse to the base when the exponent is -1, and a suitable power of that inverse for other negative exponents.