### PR TITLE
Set default stdout of wasm to `console.log`

### DIFF
--- a/wasm/lib/README.md
+++ b/wasm/lib/README.md
@@ -33,8 +33,9 @@ pyEval(code, options?);
 -   `vars?`: `{ [key: string]: any }`: Variables passed to the VM that can be
     accessed in Python with the variable `js_vars`. Functions do work, and
     receive the Python kwargs as the `this` argument.
--   `stdout?`: `(out: string) => void`: A function to replace the native print
-    function, by default `console.log`.
+-   `stdout?`: `"console" | ((out: string) => void) | null`: A function to replace the
+    native print function, and it will be `console.log` when giving `undefined`
+    or "console", and it will be a dumb function when giving null.
 
 ## License
 

--- a/wasm/lib/src/vm_class.rs
+++ b/wasm/lib/src/vm_class.rs
@@ -230,11 +230,13 @@ impl WASMVirtualMachine {
                         .map_err(|err| convert::js_to_py(vm, err))?;
                         Ok(vm.get_none())
                     })
-            } else if stdout.is_undefined() || stdout.is_null() {
+            } else if stdout.is_null() {
                 fn noop(vm: &VirtualMachine, _args: PyFuncArgs) -> PyResult {
                     Ok(vm.get_none())
                 }
                 vm.ctx.new_rustfunc(noop)
+            } else if stdout.is_undefined() {
+                vm.ctx.new_rustfunc(wasm_builtins::builtin_print_console)
             } else {
                 return Err(error());
             };


### PR DESCRIPTION
Fix issue #1610 

The print function of wasm will be
- `console.log` by default or when giving undefined or "console"
- a dumb function when giving `null`
- the function when giving a function