### PR TITLE
Modify os window check logic in test code

### DIFF
--- a/tests/snippets/stdlib_os.py
+++ b/tests/snippets/stdlib_os.py
@@ -98,6 +98,7 @@ FOLDER = "dir1"
 CONTENT = b"testing"
 CONTENT2 = b"rustpython"
 CONTENT3 = b"BOYA"
+is_win = sys.platform.startswith("win")
 
 with TestWithTempDir() as tmpdir:
 	fname = os.path.join(tmpdir, FILE_NAME)
@@ -265,7 +266,7 @@ assert isinstance(os.supports_follow_symlinks, set)
 assert isinstance(os.getpid(), int)
 
 # unix
-if "win" not in sys.platform:
+if is_win:
     assert isinstance(os.getegid(), int)
     assert isinstance(os.getgid(), int)
     assert isinstance(os.getsid(os.getpid()), int)
@@ -378,7 +379,7 @@ with TestWithTempDir() as tmpdir:
             assert set(collected_files) == set(expected_files)
 
 # system()
-if "win" not in sys.platform:
+if not is_win:
     assert os.system('ls') == 0
     assert os.system('{') != 0
 

--- a/tests/snippets/stdlib_select.py
+++ b/tests/snippets/stdlib_select.py
@@ -20,7 +20,9 @@ assert_raises(TypeError, select.select, [Almost()], [], [])
 assert_raises(TypeError, select.select, [], [], [], "not a number")
 assert_raises(ValueError, select.select, [], [], [], -1)
 
-if "win" in sys.platform:
+is_win = sys.platform.startswith("win")
+
+if is_win:
     assert_raises(OSError, select.select, [0], [], [])
 
 recvr = socket.socket()
@@ -38,7 +40,7 @@ sendr.send(b"aaaa")
 
 rres, wres, xres = select.select([recvr], [sendr], [])
 
-if "win" not in sys.platform:
+if not is_win:
     assert recvr in rres
 
 assert sendr in wres

--- a/tests/snippets/stdlib_signal.py
+++ b/tests/snippets/stdlib_signal.py
@@ -6,12 +6,13 @@ from testutils import assert_raises
 assert_raises(TypeError, lambda: signal.signal(signal.SIGINT, 2))
 
 signals = []
+is_win = sys.platform.startswith("win")
 
 def handler(signum, frame):
 	signals.append(signum)
 
 
-signal.signal(signal.SIGILL, signal.SIG_IGN);
+signal.signal(signal.SIGILL, signal.SIG_IGN)
 assert signal.getsignal(signal.SIGILL) is signal.SIG_IGN
 
 old_signal = signal.signal(signal.SIGILL, signal.SIG_DFL)
@@ -20,7 +21,7 @@ assert signal.getsignal(signal.SIGILL) is signal.SIG_DFL
 
 
 # unix
-if "win" not in sys.platform:
+if not is_win:
 	signal.signal(signal.SIGALRM, handler)
 	assert signal.getsignal(signal.SIGALRM) is handler
 

--- a/tests/snippets/stdlib_subprocess.py
+++ b/tests/snippets/stdlib_subprocess.py
@@ -28,7 +28,7 @@ assert p.returncode == 0
 p = subprocess.Popen(["echo", "test"], stdout=subprocess.PIPE)
 p.wait()
 
-is_unix = "win" not in sys.platform or "darwin" in sys.platform
+is_unix = not sys.platform.startswith("win")
 
 if is_unix:
 	# unix


### PR DESCRIPTION
current os check logic in test code can't distinguish window and unix.
I solve this problem and make code more clearly