### PR TITLE
Add an optional data parameter for predefined constructors of hashlib

### DIFF
--- a/tests/snippets/stdlib_hashlib.py
+++ b/tests/snippets/stdlib_hashlib.py
@@ -4,26 +4,32 @@ import hashlib
 # print(hashlib.md5)
 h = hashlib.md5()
 h.update(b'a')
-assert h.name == 'md5'
+g = hashlib.md5(b'a')
+assert h.name == g.name == 'md5'
 print(h.hexdigest())
+print(g.hexdigest())
 
-assert h.hexdigest() == '0cc175b9c0f1b6a831c399e269772661'
-assert h.digest_size == 16
+assert h.hexdigest() == g.hexdigest() == '0cc175b9c0f1b6a831c399e269772661'
+assert h.digest_size == g.digest_size == 16
 
 h = hashlib.sha256()
 h.update(b'a')
-assert h.name == 'sha256'
-assert h.digest_size == 32
+g = hashlib.sha256(b'a')
+assert h.name == g.name == 'sha256'
+assert h.digest_size == g.digest_size == 32
 print(h.hexdigest())
+print(g.hexdigest())
 
-assert h.hexdigest() == 'ca978112ca1bbdcafac231b39a23dc4da786eff8147c4e72b9807785afee48bb'
+assert h.hexdigest() == g.hexdigest() == 'ca978112ca1bbdcafac231b39a23dc4da786eff8147c4e72b9807785afee48bb'
 
 h = hashlib.sha512()
-assert h.name == 'sha512'
+g = hashlib.sha512(b'a')
+assert h.name == g.name == 'sha512'
 h.update(b'a')
 print(h.hexdigest())
+print(g.hexdigest())
 
-assert h.hexdigest() == '1f40fc92da241694750979ee6cf582f2d5d7d28e18335de05abc54d0560e0f5302860c652bf08d560252aa5e74210546f369fbbbce8c12cfc7957b2652fe9a75'
+assert h.hexdigest() == g.hexdigest() == '1f40fc92da241694750979ee6cf582f2d5d7d28e18335de05abc54d0560e0f5302860c652bf08d560252aa5e74210546f369fbbbce8c12cfc7957b2652fe9a75'
 
 h = hashlib.new("blake2s", b"fubar")
 print(h.hexdigest())

--- a/vm/src/stdlib/hashlib.rs
+++ b/vm/src/stdlib/hashlib.rs
@@ -105,104 +105,56 @@ fn hashlib_new(
     }
 }
 
-fn md5(data: OptionalArg<PyBytesRef>, vm: &VirtualMachine) -> PyResult<PyHasher> {
-    let hasher = PyHasher::new("md5", HashWrapper::md5());
-
+fn init(
+    hasher: PyHasher,
+    data: OptionalArg<PyBytesRef>,
+    vm: &VirtualMachine,
+) -> PyResult<PyHasher> {
     if let OptionalArg::Present(data) = data {
         hasher.update(data, vm)?;
     }
 
     Ok(hasher)
+}
+
+fn md5(data: OptionalArg<PyBytesRef>, vm: &VirtualMachine) -> PyResult<PyHasher> {
+    init(PyHasher::new("md5", HashWrapper::md5()), data, vm)
 }
 
 fn sha1(data: OptionalArg<PyBytesRef>, vm: &VirtualMachine) -> PyResult<PyHasher> {
-    let hasher = PyHasher::new("sha1", HashWrapper::sha1());
-
-    if let OptionalArg::Present(data) = data {
-        hasher.update(data, vm)?;
-    }
-
-    Ok(hasher)
+    init(PyHasher::new("sha1", HashWrapper::sha1()), data, vm)
 }
 
 fn sha224(data: OptionalArg<PyBytesRef>, vm: &VirtualMachine) -> PyResult<PyHasher> {
-    let hasher = PyHasher::new("sha224", HashWrapper::sha224());
-
-    if let OptionalArg::Present(data) = data {
-        hasher.update(data, vm)?;
-    }
-
-    Ok(hasher)
+    init(PyHasher::new("sha224", HashWrapper::sha224()), data, vm)
 }
 
 fn sha256(data: OptionalArg<PyBytesRef>, vm: &VirtualMachine) -> PyResult<PyHasher> {
-    let hasher = PyHasher::new("sha256", HashWrapper::sha256());
-
-    if let OptionalArg::Present(data) = data {
-        hasher.update(data, vm)?;
-    }
-
-    Ok(hasher)
+    init(PyHasher::new("sha256", HashWrapper::sha256()), data, vm)
 }
 
 fn sha384(data: OptionalArg<PyBytesRef>, vm: &VirtualMachine) -> PyResult<PyHasher> {
-    let hasher = PyHasher::new("sha384", HashWrapper::sha384());
-
-    if let OptionalArg::Present(data) = data {
-        hasher.update(data, vm)?;
-    }
-
-    Ok(hasher)
+    init(PyHasher::new("sha384", HashWrapper::sha384()), data, vm)
 }
 
 fn sha512(data: OptionalArg<PyBytesRef>, vm: &VirtualMachine) -> PyResult<PyHasher> {
-    let hasher = PyHasher::new("sha512", HashWrapper::sha512());
-
-    if let OptionalArg::Present(data) = data {
-        hasher.update(data, vm)?;
-    }
-
-    Ok(hasher)
+    init(PyHasher::new("sha512", HashWrapper::sha512()), data, vm)
 }
 
 fn sha3_224(data: OptionalArg<PyBytesRef>, vm: &VirtualMachine) -> PyResult<PyHasher> {
-    let hasher = PyHasher::new("sha3_224", HashWrapper::sha3_224());
-
-    if let OptionalArg::Present(data) = data {
-        hasher.update(data, vm)?;
-    }
-
-    Ok(hasher)
+    init(PyHasher::new("sha3_224", HashWrapper::sha3_224()), data, vm)
 }
 
 fn sha3_256(data: OptionalArg<PyBytesRef>, vm: &VirtualMachine) -> PyResult<PyHasher> {
-    let hasher = PyHasher::new("sha3_256", HashWrapper::sha3_256());
-
-    if let OptionalArg::Present(data) = data {
-        hasher.update(data, vm)?;
-    }
-
-    Ok(hasher)
+    init(PyHasher::new("sha3_256", HashWrapper::sha3_256()), data, vm)
 }
 
 fn sha3_384(data: OptionalArg<PyBytesRef>, vm: &VirtualMachine) -> PyResult<PyHasher> {
-    let hasher = PyHasher::new("sha3_384", HashWrapper::sha3_384());
-
-    if let OptionalArg::Present(data) = data {
-        hasher.update(data, vm)?;
-    }
-
-    Ok(hasher)
+    init(PyHasher::new("sha3_384", HashWrapper::sha3_384()), data, vm)
 }
 
 fn sha3_512(data: OptionalArg<PyBytesRef>, vm: &VirtualMachine) -> PyResult<PyHasher> {
-    let hasher = PyHasher::new("sha3_512", HashWrapper::sha3_512());
-
-    if let OptionalArg::Present(data) = data {
-        hasher.update(data, vm)?;
-    }
-
-    Ok(hasher)
+    init(PyHasher::new("sha3_512", HashWrapper::sha3_512()), data, vm)
 }
 
 fn shake128(_data: OptionalArg<PyBytesRef>, vm: &VirtualMachine) -> PyResult<PyHasher> {
@@ -215,24 +167,12 @@ fn shake256(_data: OptionalArg<PyBytesRef>, vm: &VirtualMachine) -> PyResult<PyH
 
 fn blake2b(data: OptionalArg<PyBytesRef>, vm: &VirtualMachine) -> PyResult<PyHasher> {
     // TODO: handle parameters
-    let hasher = PyHasher::new("blake2b", HashWrapper::blake2b());
-
-    if let OptionalArg::Present(data) = data {
-        hasher.update(data, vm)?;
-    }
-
-    Ok(hasher)
+    init(PyHasher::new("blake2b", HashWrapper::blake2b()), data, vm)
 }
 
 fn blake2s(data: OptionalArg<PyBytesRef>, vm: &VirtualMachine) -> PyResult<PyHasher> {
     // TODO: handle parameters
-    let hasher = PyHasher::new("blake2s", HashWrapper::blake2s());
-
-    if let OptionalArg::Present(data) = data {
-        hasher.update(data, vm)?;
-    }
-
-    Ok(hasher)
+    init(PyHasher::new("blake2s", HashWrapper::blake2s()), data, vm)
 }
 
 pub fn make_module(vm: &VirtualMachine) -> PyObjectRef {

--- a/vm/src/stdlib/hashlib.rs
+++ b/vm/src/stdlib/hashlib.rs
@@ -86,23 +86,27 @@ fn hashlib_new(
     data: OptionalArg<PyBytesRef>,
     vm: &VirtualMachine,
 ) -> PyResult<PyHasher> {
-    let hasher = match name.as_str() {
-        "md5" => Ok(PyHasher::new("md5", HashWrapper::md5())),
-        "sha1" => Ok(PyHasher::new("sha1", HashWrapper::sha1())),
-        "sha224" => Ok(PyHasher::new("sha224", HashWrapper::sha224())),
-        "sha256" => Ok(PyHasher::new("sha256", HashWrapper::sha256())),
-        "sha384" => Ok(PyHasher::new("sha384", HashWrapper::sha384())),
-        "sha512" => Ok(PyHasher::new("sha512", HashWrapper::sha512())),
-        "sha3_224" => Ok(PyHasher::new("sha3_224", HashWrapper::sha3_224())),
-        "sha3_256" => Ok(PyHasher::new("sha3_256", HashWrapper::sha3_256())),
-        "sha3_384" => Ok(PyHasher::new("sha3_384", HashWrapper::sha3_384())),
-        "sha3_512" => Ok(PyHasher::new("sha3_512", HashWrapper::sha3_512())),
-        // TODO: "shake128" => Ok(PyHasher::new("shake128", HashWrapper::shake128())),
-        // TODO: "shake256" => Ok(PyHasher::new("shake256", HashWrapper::shake256())),
-        "blake2b" => Ok(PyHasher::new("blake2b", HashWrapper::blake2b())),
-        "blake2s" => Ok(PyHasher::new("blake2s", HashWrapper::blake2s())),
+    match name.as_str() {
+        "md5" => md5(data, vm),
+        "sha1" => sha1(data, vm),
+        "sha224" => sha224(data, vm),
+        "sha256" => sha256(data, vm),
+        "sha384" => sha384(data, vm),
+        "sha512" => sha512(data, vm),
+        "sha3_224" => sha3_224(data, vm),
+        "sha3_256" => sha3_256(data, vm),
+        "sha3_384" => sha3_384(data, vm),
+        "sha3_512" => sha3_512(data, vm),
+        // TODO: "shake128" => shake128(data, vm),
+        // TODO: "shake256" => shake256(data, vm),
+        "blake2b" => blake2b(data, vm),
+        "blake2s" => blake2s(data, vm),
         other => Err(vm.new_value_error(format!("Unknown hashing algorithm: {}", other))),
-    }?;
+    }
+}
+
+fn md5(data: OptionalArg<PyBytesRef>, vm: &VirtualMachine) -> PyResult<PyHasher> {
+    let hasher = PyHasher::new("md5", HashWrapper::md5());
 
     if let OptionalArg::Present(data) = data {
         hasher.update(data, vm)?;
@@ -111,64 +115,124 @@ fn hashlib_new(
     Ok(hasher)
 }
 
-fn md5(_vm: &VirtualMachine) -> PyResult<PyHasher> {
-    Ok(PyHasher::new("md5", HashWrapper::md5()))
+fn sha1(data: OptionalArg<PyBytesRef>, vm: &VirtualMachine) -> PyResult<PyHasher> {
+    let hasher = PyHasher::new("sha1", HashWrapper::sha1());
+
+    if let OptionalArg::Present(data) = data {
+        hasher.update(data, vm)?;
+    }
+
+    Ok(hasher)
 }
 
-fn sha1(_vm: &VirtualMachine) -> PyResult<PyHasher> {
-    Ok(PyHasher::new("sha1", HashWrapper::sha1()))
+fn sha224(data: OptionalArg<PyBytesRef>, vm: &VirtualMachine) -> PyResult<PyHasher> {
+    let hasher = PyHasher::new("sha224", HashWrapper::sha224());
+
+    if let OptionalArg::Present(data) = data {
+        hasher.update(data, vm)?;
+    }
+
+    Ok(hasher)
 }
 
-fn sha224(_vm: &VirtualMachine) -> PyResult<PyHasher> {
-    Ok(PyHasher::new("sha224", HashWrapper::sha224()))
+fn sha256(data: OptionalArg<PyBytesRef>, vm: &VirtualMachine) -> PyResult<PyHasher> {
+    let hasher = PyHasher::new("sha256", HashWrapper::sha256());
+
+    if let OptionalArg::Present(data) = data {
+        hasher.update(data, vm)?;
+    }
+
+    Ok(hasher)
 }
 
-fn sha256(_vm: &VirtualMachine) -> PyResult<PyHasher> {
-    Ok(PyHasher::new("sha256", HashWrapper::sha256()))
+fn sha384(data: OptionalArg<PyBytesRef>, vm: &VirtualMachine) -> PyResult<PyHasher> {
+    let hasher = PyHasher::new("sha384", HashWrapper::sha384());
+
+    if let OptionalArg::Present(data) = data {
+        hasher.update(data, vm)?;
+    }
+
+    Ok(hasher)
 }
 
-fn sha384(_vm: &VirtualMachine) -> PyResult<PyHasher> {
-    Ok(PyHasher::new("sha384", HashWrapper::sha384()))
+fn sha512(data: OptionalArg<PyBytesRef>, vm: &VirtualMachine) -> PyResult<PyHasher> {
+    let hasher = PyHasher::new("sha512", HashWrapper::sha512());
+
+    if let OptionalArg::Present(data) = data {
+        hasher.update(data, vm)?;
+    }
+
+    Ok(hasher)
 }
 
-fn sha512(_vm: &VirtualMachine) -> PyResult<PyHasher> {
-    Ok(PyHasher::new("sha512", HashWrapper::sha512()))
+fn sha3_224(data: OptionalArg<PyBytesRef>, vm: &VirtualMachine) -> PyResult<PyHasher> {
+    let hasher = PyHasher::new("sha3_224", HashWrapper::sha3_224());
+
+    if let OptionalArg::Present(data) = data {
+        hasher.update(data, vm)?;
+    }
+
+    Ok(hasher)
 }
 
-fn sha3_224(_vm: &VirtualMachine) -> PyResult<PyHasher> {
-    Ok(PyHasher::new("sha3_224", HashWrapper::sha3_224()))
+fn sha3_256(data: OptionalArg<PyBytesRef>, vm: &VirtualMachine) -> PyResult<PyHasher> {
+    let hasher = PyHasher::new("sha3_256", HashWrapper::sha3_256());
+
+    if let OptionalArg::Present(data) = data {
+        hasher.update(data, vm)?;
+    }
+
+    Ok(hasher)
 }
 
-fn sha3_256(_vm: &VirtualMachine) -> PyResult<PyHasher> {
-    Ok(PyHasher::new("sha3_256", HashWrapper::sha3_256()))
+fn sha3_384(data: OptionalArg<PyBytesRef>, vm: &VirtualMachine) -> PyResult<PyHasher> {
+    let hasher = PyHasher::new("sha3_384", HashWrapper::sha3_384());
+
+    if let OptionalArg::Present(data) = data {
+        hasher.update(data, vm)?;
+    }
+
+    Ok(hasher)
 }
 
-fn sha3_384(_vm: &VirtualMachine) -> PyResult<PyHasher> {
-    Ok(PyHasher::new("sha3_384", HashWrapper::sha3_384()))
+fn sha3_512(data: OptionalArg<PyBytesRef>, vm: &VirtualMachine) -> PyResult<PyHasher> {
+    let hasher = PyHasher::new("sha3_512", HashWrapper::sha3_512());
+
+    if let OptionalArg::Present(data) = data {
+        hasher.update(data, vm)?;
+    }
+
+    Ok(hasher)
 }
 
-fn sha3_512(_vm: &VirtualMachine) -> PyResult<PyHasher> {
-    Ok(PyHasher::new("sha3_512", HashWrapper::sha3_512()))
-}
-
-fn shake128(vm: &VirtualMachine) -> PyResult<PyHasher> {
+fn shake128(_data: OptionalArg<PyBytesRef>, vm: &VirtualMachine) -> PyResult<PyHasher> {
     Err(vm.new_not_implemented_error("shake256".to_string()))
-    // Ok(PyHasher::new("shake128", HashWrapper::shake128()))
 }
 
-fn shake256(vm: &VirtualMachine) -> PyResult<PyHasher> {
+fn shake256(_data: OptionalArg<PyBytesRef>, vm: &VirtualMachine) -> PyResult<PyHasher> {
     Err(vm.new_not_implemented_error("shake256".to_string()))
-    // TODO: Ok(PyHasher::new("shake256", HashWrapper::shake256()))
 }
 
-fn blake2b(_vm: &VirtualMachine) -> PyResult<PyHasher> {
+fn blake2b(data: OptionalArg<PyBytesRef>, vm: &VirtualMachine) -> PyResult<PyHasher> {
     // TODO: handle parameters
-    Ok(PyHasher::new("blake2b", HashWrapper::blake2b()))
+    let hasher = PyHasher::new("blake2b", HashWrapper::blake2b());
+
+    if let OptionalArg::Present(data) = data {
+        hasher.update(data, vm)?;
+    }
+
+    Ok(hasher)
 }
 
-fn blake2s(_vm: &VirtualMachine) -> PyResult<PyHasher> {
+fn blake2s(data: OptionalArg<PyBytesRef>, vm: &VirtualMachine) -> PyResult<PyHasher> {
     // TODO: handle parameters
-    Ok(PyHasher::new("blake2s", HashWrapper::blake2s()))
+    let hasher = PyHasher::new("blake2s", HashWrapper::blake2s());
+
+    if let OptionalArg::Present(data) = data {
+        hasher.update(data, vm)?;
+    }
+
+    Ok(hasher)
 }
 
 pub fn make_module(vm: &VirtualMachine) -> PyObjectRef {


### PR DESCRIPTION
Example case in [the documentation][1]:

```py
>>> hashlib.sha224(b"Nobody inspects the spammish repetition").hexdigest()
'a4337bc45a8fc544c03f52dc550cd6e1e87021bc896588bd79e901e2'
```


[1]: https://docs.python.org/3.6/library/hashlib.html#hash-algorithms