### PR TITLE
PyObject::payload_if_subclass to reduce common pattern

### DIFF
--- a/vm/src/obj/objbool.rs
+++ b/vm/src/obj/objbool.rs
@@ -7,7 +7,7 @@ use crate::pyobject::{
 };
 use crate::vm::VirtualMachine;
 
-use super::objint::{self, PyInt};
+use super::objint::PyInt;
 use super::objstr::PyStringRef;
 use super::objtype;
 
@@ -111,7 +111,11 @@ pub fn not(vm: &VirtualMachine, obj: &PyObjectRef) -> PyResult<bool> {
 
 // Retrieve inner int value:
 pub fn get_value(obj: &PyObjectRef) -> bool {
-    !objint::get_py_int(obj).as_bigint().is_zero()
+    !obj.payload::<PyInt>().unwrap().as_bigint().is_zero()
+}
+
+pub fn get_py_int(obj: &PyObjectRef) -> &PyInt {
+    &obj.payload::<PyInt>().unwrap()
 }
 
 fn bool_repr(obj: bool, _vm: &VirtualMachine) -> String {
@@ -142,7 +146,7 @@ fn bool_or(lhs: PyObjectRef, rhs: PyObjectRef, vm: &VirtualMachine) -> PyResult 
         let rhs = get_value(&rhs);
         (lhs || rhs).into_pyobject(vm)
     } else {
-        Ok(objint::get_py_int(&lhs).or(rhs.clone(), vm))
+        Ok(get_py_int(&lhs).or(rhs.clone(), vm))
     }
 }
 
@@ -154,7 +158,7 @@ fn bool_and(lhs: PyObjectRef, rhs: PyObjectRef, vm: &VirtualMachine) -> PyResult
         let rhs = get_value(&rhs);
         (lhs && rhs).into_pyobject(vm)
     } else {
-        Ok(objint::get_py_int(&lhs).and(rhs.clone(), vm))
+        Ok(get_py_int(&lhs).and(rhs.clone(), vm))
     }
 }
 
@@ -166,7 +170,7 @@ fn bool_xor(lhs: PyObjectRef, rhs: PyObjectRef, vm: &VirtualMachine) -> PyResult
         let rhs = get_value(&rhs);
         (lhs ^ rhs).into_pyobject(vm)
     } else {
-        Ok(objint::get_py_int(&lhs).xor(rhs.clone(), vm))
+        Ok(get_py_int(&lhs).xor(rhs.clone(), vm))
     }
 }
 

--- a/vm/src/pyobject.rs
+++ b/vm/src/pyobject.rs
@@ -1062,6 +1062,18 @@ impl PyObject<dyn PyObjectPayload> {
     pub fn payload_is<T: PyObjectPayload>(&self) -> bool {
         self.payload.as_any().is::<T>()
     }
+
+    #[inline]
+    pub fn payload_if_subclass<T: PyObjectPayload + PyValue>(
+        &self,
+        vm: &VirtualMachine,
+    ) -> Option<&T> {
+        if objtype::issubclass(&self.class(), &T::class(vm)) {
+            self.payload()
+        } else {
+            None
+        }
+    }
 }
 
 pub trait PyValue: fmt::Debug + Sized + 'static {

--- a/vm/src/vm.rs
+++ b/vm/src/vm.rs
@@ -30,7 +30,7 @@ use crate::obj::objcoroutine::PyCoroutine;
 use crate::obj::objdict::PyDictRef;
 use crate::obj::objfunction::{PyFunction, PyMethod};
 use crate::obj::objgenerator::PyGenerator;
-use crate::obj::objint;
+use crate::obj::objint::PyInt;
 use crate::obj::objiter;
 use crate::obj::objmodule::{self, PyModule};
 use crate::obj::objsequence;
@@ -1326,8 +1326,8 @@ impl VirtualMachine {
 
     pub fn _hash(&self, obj: &PyObjectRef) -> PyResult<pyhash::PyHash> {
         let hash_obj = self.call_method(obj, "__hash__", vec![])?;
-        if objtype::isinstance(&hash_obj, &self.ctx.int_type()) {
-            Ok(objint::get_py_int(&hash_obj).hash(self))
+        if let Some(hash_value) = hash_obj.payload_if_subclass::<PyInt>(self) {
+            Ok(hash_value.hash(self))
         } else {
             Err(self.new_type_error("__hash__ method should return an integer".to_string()))
         }


### PR DESCRIPTION
FIrst 2 commits are included in other PR (#1626). So please check only the last commit.

We use this common pattern a lot:
```rust
        if objtype::isinstance(&obj, &vm.ctx.T_type()) {
             let v = obj.payload::<T>().unwrap();
             ...
        } 
```

By adding a new method `PyObject::payload_if_subclass`, this pattern is reduced to
```rust
    if let Some(v) = obj.payload_if_subclass::<T>(vm) {
         ...
    }
```