### PR TITLE
Refactor float, complex cmp/op , str, None

### DIFF
--- a/vm/src/obj/objint.rs
+++ b/vm/src/obj/objint.rs
@@ -120,7 +120,7 @@ fn inner_pow(int1: &BigInt, int2: &BigInt, vm: &VirtualMachine) -> PyResult {
     if int2.is_negative() {
         let v1 = try_float(int1, vm)?;
         let v2 = try_float(int2, vm)?;
-        objfloat::float_pow(v1, v2, vm)
+        objfloat::float_pow(v1, v2, vm).into_pyobject(vm)
     } else {
         Ok(if let Some(v2) = int2.to_u64() {
             vm.ctx.new_int(int1.pow(v2))

--- a/vm/src/obj/objint.rs
+++ b/vm/src/obj/objint.rs
@@ -223,8 +223,8 @@ impl PyInt {
     where
         F: Fn(&BigInt, &BigInt) -> bool,
     {
-        if objtype::isinstance(&other, &vm.ctx.int_type()) {
-            vm.ctx.new_bool(op(&self.value, get_value(&other)))
+        if let Some(other) = other.payload_if_subclass::<PyInt>(vm) {
+            vm.ctx.new_bool(op(&self.value, &other.value))
         } else {
             vm.ctx.not_implemented()
         }
@@ -265,8 +265,8 @@ impl PyInt {
     where
         F: Fn(&BigInt, &BigInt) -> BigInt,
     {
-        if objtype::isinstance(&other, &vm.ctx.int_type()) {
-            vm.ctx.new_int(op(&self.value, get_value(&other)))
+        if let Some(other) = other.payload_if_subclass::<PyInt>(vm) {
+            vm.ctx.new_int(op(&self.value, &other.value))
         } else {
             vm.ctx.not_implemented()
         }
@@ -277,8 +277,8 @@ impl PyInt {
     where
         F: Fn(&BigInt, &BigInt) -> PyResult,
     {
-        if objtype::isinstance(&other, &vm.ctx.int_type()) {
-            op(&self.value, get_value(&other))
+        if let Some(other) = other.payload_if_subclass::<PyInt>(vm) {
+            op(&self.value, &other.value)
         } else {
             Ok(vm.ctx.not_implemented())
         }

--- a/vm/src/obj/objstr.rs
+++ b/vm/src/obj/objstr.rs
@@ -280,39 +280,23 @@ impl PyString {
     }
 
     #[pymethod(name = "__gt__")]
-    fn gt(&self, rhs: PyObjectRef, vm: &VirtualMachine) -> PyResult<bool> {
-        if objtype::isinstance(&rhs, &vm.ctx.str_type()) {
-            Ok(self.value > get_value(&rhs))
-        } else {
-            Err(vm.new_type_error(format!("Cannot compare {} and {}", self, rhs)))
-        }
+    fn gt(&self, other: PyStringRef, _vm: &VirtualMachine) -> bool {
+        self.value > other.value
     }
 
     #[pymethod(name = "__ge__")]
-    fn ge(&self, rhs: PyObjectRef, vm: &VirtualMachine) -> PyResult<bool> {
-        if objtype::isinstance(&rhs, &vm.ctx.str_type()) {
-            Ok(self.value >= get_value(&rhs))
-        } else {
-            Err(vm.new_type_error(format!("Cannot compare {} and {}", self, rhs)))
-        }
+    fn ge(&self, other: PyStringRef, _vm: &VirtualMachine) -> bool {
+        self.value >= other.value
     }
 
     #[pymethod(name = "__lt__")]
-    fn lt(&self, rhs: PyObjectRef, vm: &VirtualMachine) -> PyResult<bool> {
-        if objtype::isinstance(&rhs, &vm.ctx.str_type()) {
-            Ok(self.value < get_value(&rhs))
-        } else {
-            Err(vm.new_type_error(format!("Cannot compare {} and {}", self, rhs)))
-        }
+    fn lt(&self, other: PyStringRef, _vm: &VirtualMachine) -> bool {
+        self.value < other.value
     }
 
     #[pymethod(name = "__le__")]
-    fn le(&self, rhs: PyObjectRef, vm: &VirtualMachine) -> PyResult<bool> {
-        if objtype::isinstance(&rhs, &vm.ctx.str_type()) {
-            Ok(self.value <= get_value(&rhs))
-        } else {
-            Err(vm.new_type_error(format!("Cannot compare {} and {}", self, rhs)))
-        }
+    fn le(&self, other: PyStringRef, _vm: &VirtualMachine) -> bool {
+        self.value <= other.value
     }
 
     #[pymethod(name = "__hash__")]

--- a/vm/src/stdlib/math.rs
+++ b/vm/src/stdlib/math.rs
@@ -225,7 +225,7 @@ fn math_trunc(value: PyObjectRef, vm: &VirtualMachine) -> PyResult {
 fn math_ceil(value: PyObjectRef, vm: &VirtualMachine) -> PyResult {
     if objtype::isinstance(&value, &vm.ctx.float_type()) {
         let v = objfloat::get_value(&value);
-        let v = objfloat::try_to_bigint(v.ceil(), vm)?;
+        let v = objfloat::try_bigint(v.ceil(), vm)?;
         Ok(vm.ctx.new_int(v))
     } else {
         try_magic_method("__ceil__", vm, &value)
@@ -241,7 +241,7 @@ fn math_ceil(value: PyObjectRef, vm: &VirtualMachine) -> PyResult {
 fn math_floor(value: PyObjectRef, vm: &VirtualMachine) -> PyResult {
     if objtype::isinstance(&value, &vm.ctx.float_type()) {
         let v = objfloat::get_value(&value);
-        let v = objfloat::try_to_bigint(v.floor(), vm)?;
+        let v = objfloat::try_bigint(v.floor(), vm)?;
         Ok(vm.ctx.new_int(v))
     } else {
         try_magic_method("__floor__", vm, &value)


### PR DESCRIPTION
- float, complex same as #1641 
- str uses PyStringRef rather than PyObjectRef
- impl PyNoneRef -> impl PyNone