### PR TITLE
Use PyBaseExceptionRef in places where we expect exceptions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -598,7 +598,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "itertools"
-version = "0.8.0"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "either 1.5.3 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -633,7 +633,7 @@ dependencies = [
  "diff 0.1.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "docopt 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "ena 0.13.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "itertools 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "itertools 0.8.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "lalrpop-util 0.17.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "petgraph 0.4.13 (registry+https://github.com/rust-lang/crates.io-index)",
  "regex 1.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1255,7 +1255,7 @@ version = "0.1.1"
 dependencies = [
  "arrayvec 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "indexmap 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "itertools 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "itertools 0.8.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "num-complex 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "rustpython-bytecode 0.1.1",
@@ -1316,7 +1316,7 @@ dependencies = [
  "hex 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "hexf-parse 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "indexmap 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "itertools 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "itertools 0.8.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "lexical 4.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.66 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2226,7 +2226,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum hexf-parse 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "79296f72d53a89096cbc9a88c9547ee8dfe793388674620e2207593d370550ac"
 "checksum humantime 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "df004cfca50ef23c36850aaaa59ad52cc70d0e90243c3c7737a4dd32dc7a3c4f"
 "checksum indexmap 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "a61202fbe46c4a951e9404a720a0180bcf3212c750d735cb5c4ba4dc551299f3"
-"checksum itertools 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)" = "5b8467d9c1cebe26feb08c640139247fac215782d35371ade9a2136ed6085358"
+"checksum itertools 0.8.2 (registry+https://github.com/rust-lang/crates.io-index)" = "f56a2d0bc861f9165be4eb3442afd3c236d8a98afd426f65d92324ae1091a484"
 "checksum itoa 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)" = "501266b7edd0174f8530248f87f99c88fbe60ca4ef3dd486835b8d8d53136f7f"
 "checksum js-sys 0.3.28 (registry+https://github.com/rust-lang/crates.io-index)" = "2cc9a97d7cec30128fd8b28a7c1f9df1c001ceb9b441e2b755e24130a6b43c79"
 "checksum keccak 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "67c21572b4949434e4fc1e1978b99c5f77064153c59d998bf13ecd96fb5ecba7"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1368,8 +1368,6 @@ dependencies = [
  "cfg-if 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.1.29 (registry+https://github.com/rust-lang/crates.io-index)",
  "js-sys 0.3.28 (registry+https://github.com/rust-lang/crates.io-index)",
- "num-bigint 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "num-traits 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "rustpython-compiler 0.1.1",
  "rustpython-parser 0.1.1",
  "rustpython-vm 0.1.1",

--- a/src/main.rs
+++ b/src/main.rs
@@ -7,7 +7,7 @@ extern crate log;
 use clap::{App, AppSettings, Arg, ArgMatches};
 use rustpython_compiler::compile;
 use rustpython_vm::{
-    exceptions::{print_exception, PyBaseExceptionRef},
+    exceptions::print_exception,
     match_class,
     obj::{objint::PyInt, objtype},
     pyobject::{ItemProtocol, PyResult},
@@ -51,7 +51,6 @@ fn main() {
     // See if any exception leaked out:
     if let Err(err) = res {
         if objtype::isinstance(&err, &vm.ctx.exceptions.system_exit) {
-            let err: PyBaseExceptionRef = err.downcast().unwrap();
             let args = err.args();
             match args.elements.len() {
                 0 => return,

--- a/src/main.rs
+++ b/src/main.rs
@@ -7,9 +7,9 @@ extern crate log;
 use clap::{App, AppSettings, Arg, ArgMatches};
 use rustpython_compiler::compile;
 use rustpython_vm::{
+    exceptions::{print_exception, PyBaseExceptionRef},
     match_class,
-    obj::{objint::PyInt, objtuple::PyTuple, objtype},
-    print_exception,
+    obj::{objint::PyInt, objtype},
     pyobject::{ItemProtocol, PyResult},
     scope::Scope,
     util, InitParameter, PySettings, VirtualMachine,
@@ -51,8 +51,8 @@ fn main() {
     // See if any exception leaked out:
     if let Err(err) = res {
         if objtype::isinstance(&err, &vm.ctx.exceptions.system_exit) {
-            let args = vm.get_attribute(err.clone(), "args").unwrap();
-            let args = args.downcast::<PyTuple>().expect("'args' must be a tuple");
+            let err: PyBaseExceptionRef = err.downcast().unwrap();
+            let args = err.args();
             match args.elements.len() {
                 0 => return,
                 1 => match_class!(match args.elements[0].clone() {

--- a/src/shell.rs
+++ b/src/shell.rs
@@ -5,9 +5,9 @@ mod rustyline_helper;
 use rustpython_compiler::{compile, error::CompileError, error::CompileErrorType};
 use rustpython_parser::error::ParseErrorType;
 use rustpython_vm::{
-    exceptions::print_exception,
+    exceptions::{print_exception, PyBaseExceptionRef},
     obj::objtype,
-    pyobject::{ItemProtocol, PyObjectRef, PyResult},
+    pyobject::{ItemProtocol, PyResult},
     scope::Scope,
     VirtualMachine,
 };
@@ -16,7 +16,7 @@ use readline::{Readline, ReadlineResult};
 
 enum ShellExecResult {
     Ok,
-    PyErr(PyObjectRef),
+    PyErr(PyBaseExceptionRef),
     Continue,
 }
 

--- a/src/shell.rs
+++ b/src/shell.rs
@@ -5,8 +5,8 @@ mod rustyline_helper;
 use rustpython_compiler::{compile, error::CompileError, error::CompileErrorType};
 use rustpython_parser::error::ParseErrorType;
 use rustpython_vm::{
+    exceptions::print_exception,
     obj::objtype,
-    print_exception,
     pyobject::{ItemProtocol, PyObjectRef, PyResult},
     scope::Scope,
     VirtualMachine,

--- a/src/shell.rs
+++ b/src/shell.rs
@@ -118,9 +118,8 @@ pub fn run_shell(vm: &VirtualMachine, scope: Scope) -> PyResult<()> {
             ReadlineResult::Interrupt => {
                 continuing = false;
                 full_input.clear();
-                let keyboard_interrupt = vm
-                    .new_empty_exception(vm.ctx.exceptions.keyboard_interrupt.clone())
-                    .unwrap();
+                let keyboard_interrupt =
+                    vm.new_exception_empty(vm.ctx.exceptions.keyboard_interrupt.clone());
                 Err(keyboard_interrupt)
             }
             ReadlineResult::EOF => {

--- a/tests/snippets/try_exceptions.py
+++ b/tests/snippets/try_exceptions.py
@@ -250,7 +250,23 @@ try:
     except ZeroDivisionError as ex:
         raise NameError from ex
 except NameError as ex2:
-    pass
+    assert isinstance(ex2.__cause__, ZeroDivisionError)
+else:
+    assert False, "no raise"
+
+
+try:
+    try:
+        try:
+            raise ZeroDivisionError
+        except ZeroDivisionError as ex:
+            raise NameError from ex
+    except NameError:
+        raise
+except NameError as ex2:
+    assert isinstance(ex2.__cause__, ZeroDivisionError)
+else:
+    assert False, "no raise"
 
 
 # the else clause requires at least one except clause:

--- a/vm/Cargo.toml
+++ b/vm/Cargo.toml
@@ -49,7 +49,7 @@ chrono = { version = "=0.4.9", features = ["wasmbind"] }
 unicode-xid = "0.2.0"
 lazy_static = "^1.0.1"
 lexical = "4"
-itertools = "^0.8.0"
+itertools = "0.8"
 hex = "0.4.0"
 hexf-parse = "0.1.0"
 indexmap = "1.0.2"

--- a/vm/src/builtins.rs
+++ b/vm/src/builtins.rs
@@ -12,6 +12,7 @@ use num_traits::{Signed, ToPrimitive, Zero};
 #[cfg(feature = "rustpython-compiler")]
 use rustpython_compiler::compile;
 
+use crate::exceptions::PyBaseExceptionRef;
 use crate::function::{single_or_tuple_any, Args, KwArgs, OptionalArg, PyFuncArgs};
 use crate::obj::objbool::{self, IntoPyBool};
 use crate::obj::objbyteinner::PyByteInner;
@@ -290,7 +291,7 @@ fn builtin_format(
         })
 }
 
-fn catch_attr_exception<T>(ex: PyObjectRef, default: T, vm: &VirtualMachine) -> PyResult<T> {
+fn catch_attr_exception<T>(ex: PyBaseExceptionRef, default: T, vm: &VirtualMachine) -> PyResult<T> {
     if objtype::isinstance(&ex, &vm.ctx.exceptions.attribute_error) {
         Ok(default)
     } else {

--- a/vm/src/builtins.rs
+++ b/vm/src/builtins.rs
@@ -629,7 +629,7 @@ impl Printer for std::io::StdoutLock<'_> {
 
 pub fn builtin_exit(exit_code_arg: OptionalArg<PyObjectRef>, vm: &VirtualMachine) -> PyResult {
     let code = exit_code_arg.unwrap_or_else(|| vm.new_int(0));
-    Err(vm.new_exception_obj(vm.ctx.exceptions.system_exit.clone(), vec![code])?)
+    Err(vm.new_exception(vm.ctx.exceptions.system_exit.clone(), vec![code]))
 }
 
 pub fn builtin_print(objects: Args, options: PrintOptions, vm: &VirtualMachine) -> PyResult<()> {

--- a/vm/src/frame.rs
+++ b/vm/src/frame.rs
@@ -127,7 +127,7 @@ impl ExecutionResult {
                 } else {
                     vec![value]
                 };
-                Err(vm.new_exception_obj(stop_iteration, args).unwrap())
+                Err(vm.new_exception(stop_iteration, args))
             }
         }
     }
@@ -978,7 +978,7 @@ impl Frame {
             0 => match vm.current_exception() {
                 Some(exc) => exc,
                 None => {
-                    return Err(vm.new_exception(
+                    return Err(vm.new_exception_msg(
                         vm.ctx.exceptions.runtime_error.clone(),
                         "No active exception to reraise".to_string(),
                     ))

--- a/vm/src/frame.rs
+++ b/vm/src/frame.rs
@@ -5,7 +5,7 @@ use indexmap::IndexMap;
 use itertools::Itertools;
 
 use crate::bytecode;
-use crate::exceptions::PyBaseExceptionRef;
+use crate::exceptions::{self, PyBaseExceptionRef};
 use crate::function::{single_or_tuple_any, PyFuncArgs};
 use crate::obj::objbool;
 use crate::obj::objcode::PyCodeRef;
@@ -223,7 +223,7 @@ impl Frame {
                 })
                 .map(ExecutionResult::Yield)
         } else {
-            let exception = vm.normalize_exception(exc_type, exc_val, exc_tb)?;
+            let exception = exceptions::normalize(exc_type, exc_val, exc_tb, vm)?;
             match self.unwind_blocks(vm, UnwindReason::Raising { exception }) {
                 Ok(None) => self.run(vm),
                 Ok(Some(result)) => Ok(result),

--- a/vm/src/function.rs
+++ b/vm/src/function.rs
@@ -4,6 +4,7 @@ use std::ops::RangeInclusive;
 
 use indexmap::IndexMap;
 
+use crate::exceptions::PyBaseExceptionRef;
 use crate::obj::objtuple::PyTuple;
 use crate::obj::objtype::{isinstance, PyClassRef};
 use crate::pyobject::{
@@ -207,11 +208,11 @@ pub enum ArgumentError {
     RequiredKeywordArgument(String),
     /// An exception was raised while binding arguments to the function
     /// parameters.
-    Exception(PyObjectRef),
+    Exception(PyBaseExceptionRef),
 }
 
-impl From<PyObjectRef> for ArgumentError {
-    fn from(ex: PyObjectRef) -> Self {
+impl From<PyBaseExceptionRef> for ArgumentError {
+    fn from(ex: PyBaseExceptionRef) -> Self {
         ArgumentError::Exception(ex)
     }
 }

--- a/vm/src/lib.rs
+++ b/vm/src/lib.rs
@@ -72,7 +72,6 @@ mod version;
 mod vm;
 
 // pub use self::pyobject::Executor;
-pub use self::exceptions::{print_exception, write_exception};
 pub use self::vm::{InitParameter, PySettings, VirtualMachine};
 pub use rustpython_bytecode::*;
 

--- a/vm/src/lib.rs
+++ b/vm/src/lib.rs
@@ -53,7 +53,7 @@ pub mod cformat;
 mod dictdatatype;
 #[cfg(feature = "rustpython-compiler")]
 pub mod eval;
-mod exceptions;
+pub mod exceptions;
 pub mod format;
 mod frame;
 mod frozen;

--- a/vm/src/obj/objcoroutine.rs
+++ b/vm/src/obj/objcoroutine.rs
@@ -1,10 +1,8 @@
 use super::objiter::new_stop_iteration;
-use super::objtype::{isinstance, issubclass, PyClassRef};
+use super::objtype::{isinstance, PyClassRef};
 use crate::frame::{ExecutionResult, FrameRef};
 use crate::function::OptionalArg;
-use crate::pyobject::{
-    PyClassImpl, PyContext, PyObjectRef, PyRef, PyResult, PyValue, TryFromObject,
-};
+use crate::pyobject::{PyClassImpl, PyContext, PyObjectRef, PyRef, PyResult, PyValue};
 use crate::vm::VirtualMachine;
 
 use std::cell::Cell;
@@ -58,30 +56,18 @@ impl PyCoroutine {
     #[pymethod]
     fn throw(
         &self,
-        exc_type: PyClassRef,
+        exc_type: PyObjectRef,
         exc_val: OptionalArg,
         exc_tb: OptionalArg,
         vm: &VirtualMachine,
     ) -> PyResult {
+        let exc_val = exc_val.unwrap_or_else(|| vm.get_none());
+        let exc_tb = exc_tb.unwrap_or_else(|| vm.get_none());
         if self.closed.get() {
-            // TODO: normalize exception
-            return Err(TryFromObject::try_from_object(
-                vm,
-                vm.invoke(exc_type.as_object(), vec![])?,
-            )?);
-        }
-        // TODO what should we do with the other parameters? CPython normalises them with
-        //      PyErr_NormalizeException, do we want to do the same.
-        if !issubclass(&exc_type, &vm.ctx.exceptions.base_exception_type) {
-            return Err(vm.new_type_error("Can't throw non exception".to_string()));
+            return Err(vm.normalize_exception(exc_type, exc_val, exc_tb)?);
         }
         vm.frames.borrow_mut().push(self.frame.clone());
-        let result = self.frame.gen_throw(
-            vm,
-            exc_type,
-            exc_val.unwrap_or(vm.get_none()),
-            exc_tb.unwrap_or(vm.get_none()),
-        );
+        let result = self.frame.gen_throw(vm, exc_type, exc_val, exc_tb);
         self.maybe_close(&result);
         vm.frames.borrow_mut().pop();
         result?.into_result(vm)
@@ -95,7 +81,7 @@ impl PyCoroutine {
         vm.frames.borrow_mut().push(self.frame.clone());
         let result = self.frame.gen_throw(
             vm,
-            vm.ctx.exceptions.generator_exit.clone(),
+            vm.ctx.exceptions.generator_exit.clone().into_object(),
             vm.get_none(),
             vm.get_none(),
         );
@@ -155,7 +141,7 @@ impl PyCoroutineWrapper {
     #[pymethod]
     fn throw(
         &self,
-        exc_type: PyClassRef,
+        exc_type: PyObjectRef,
         exc_val: OptionalArg,
         exc_tb: OptionalArg,
         vm: &VirtualMachine,

--- a/vm/src/obj/objcoroutine.rs
+++ b/vm/src/obj/objcoroutine.rs
@@ -2,7 +2,9 @@ use super::objiter::new_stop_iteration;
 use super::objtype::{isinstance, issubclass, PyClassRef};
 use crate::frame::{ExecutionResult, FrameRef};
 use crate::function::OptionalArg;
-use crate::pyobject::{PyClassImpl, PyContext, PyObjectRef, PyRef, PyResult, PyValue};
+use crate::pyobject::{
+    PyClassImpl, PyContext, PyObjectRef, PyRef, PyResult, PyValue, TryFromObject,
+};
 use crate::vm::VirtualMachine;
 
 use std::cell::Cell;
@@ -62,7 +64,11 @@ impl PyCoroutine {
         vm: &VirtualMachine,
     ) -> PyResult {
         if self.closed.get() {
-            return Err(vm.invoke(exc_type.as_object(), vec![])?);
+            // TODO: normalize exception
+            return Err(TryFromObject::try_from_object(
+                vm,
+                vm.invoke(exc_type.as_object(), vec![])?,
+            )?);
         }
         // TODO what should we do with the other parameters? CPython normalises them with
         //      PyErr_NormalizeException, do we want to do the same.

--- a/vm/src/obj/objcoroutine.rs
+++ b/vm/src/obj/objcoroutine.rs
@@ -89,7 +89,7 @@ impl PyCoroutine {
         vm.frames.borrow_mut().pop();
         self.closed.set(true);
         match result {
-            Ok(ExecutionResult::Yield(_)) => Err(vm.new_exception(
+            Ok(ExecutionResult::Yield(_)) => Err(vm.new_exception_msg(
                 vm.ctx.exceptions.runtime_error.clone(),
                 "generator ignored GeneratorExit".to_string(),
             )),

--- a/vm/src/obj/objcoroutine.rs
+++ b/vm/src/obj/objcoroutine.rs
@@ -1,5 +1,6 @@
 use super::objiter::new_stop_iteration;
 use super::objtype::{isinstance, PyClassRef};
+use crate::exceptions;
 use crate::frame::{ExecutionResult, FrameRef};
 use crate::function::OptionalArg;
 use crate::pyobject::{PyClassImpl, PyContext, PyObjectRef, PyRef, PyResult, PyValue};
@@ -64,7 +65,7 @@ impl PyCoroutine {
         let exc_val = exc_val.unwrap_or_else(|| vm.get_none());
         let exc_tb = exc_tb.unwrap_or_else(|| vm.get_none());
         if self.closed.get() {
-            return Err(vm.normalize_exception(exc_type, exc_val, exc_tb)?);
+            return Err(exceptions::normalize(exc_type, exc_val, exc_tb, vm)?);
         }
         vm.frames.borrow_mut().push(self.frame.clone());
         let result = self.frame.gen_throw(vm, exc_type, exc_val, exc_tb);

--- a/vm/src/obj/objdict.rs
+++ b/vm/src/obj/objdict.rs
@@ -5,6 +5,7 @@ use super::objiter;
 use super::objstr;
 use super::objtype::{self, PyClassRef};
 use crate::dictdatatype::{self, DictKey};
+use crate::exceptions::PyBaseExceptionRef;
 use crate::function::{KwArgs, OptionalArg};
 use crate::pyobject::{
     IdProtocol, IntoPyObject, ItemProtocol, PyAttributes, PyClassImpl, PyContext, PyIterable,
@@ -60,7 +61,7 @@ impl PyDictRef {
         vm: &VirtualMachine,
     ) -> PyResult<()> {
         if let OptionalArg::Present(dict_obj) = dict_obj {
-            let dicted: PyResult<PyDictRef> = dict_obj.clone().downcast();
+            let dicted: Result<PyDictRef, _> = dict_obj.clone().downcast();
             if let Ok(dict_obj) = dicted {
                 for (key, value) in dict_obj {
                     dict.borrow_mut().insert(vm, &key, value)?;
@@ -74,7 +75,7 @@ impl PyDictRef {
             } else {
                 let iter = objiter::get_iter(vm, &dict_obj)?;
                 loop {
-                    fn err(vm: &VirtualMachine) -> PyObjectRef {
+                    fn err(vm: &VirtualMachine) -> PyBaseExceptionRef {
                         vm.new_type_error("Iterator must have exactly two elements".to_string())
                     }
                     let element = match objiter::get_next_object(vm, &iter)? {

--- a/vm/src/obj/objdict.rs
+++ b/vm/src/obj/objdict.rs
@@ -527,7 +527,7 @@ macro_rules! dict_iterator {
                 let mut position = self.position.get();
                 let dict = self.dict.entries.borrow();
                 if dict.has_changed_size(&self.size) {
-                    return Err(vm.new_exception(
+                    return Err(vm.new_exception_msg(
                         vm.ctx.exceptions.runtime_error.clone(),
                         "dictionary changed size during iteration".to_string(),
                     ));

--- a/vm/src/obj/objfloat.rs
+++ b/vm/src/obj/objfloat.rs
@@ -7,6 +7,7 @@ use super::objbytes;
 use super::objint::{self, PyInt, PyIntRef};
 use super::objstr::{PyString, PyStringRef};
 use super::objtype::{self, PyClassRef};
+use crate::exceptions::PyBaseExceptionRef;
 use crate::function::{OptionalArg, OptionalOption};
 use crate::pyhash;
 use crate::pyobject::{
@@ -675,7 +676,7 @@ fn str_to_float(vm: &VirtualMachine, literal: &str) -> PyResult<f64> {
     }
 }
 
-fn invalid_convert(vm: &VirtualMachine, literal: &str) -> PyObjectRef {
+fn invalid_convert(vm: &VirtualMachine, literal: &str) -> PyBaseExceptionRef {
     vm.new_value_error(format!("could not convert string to float: '{}'", literal))
 }
 

--- a/vm/src/obj/objgenerator.rs
+++ b/vm/src/obj/objgenerator.rs
@@ -6,7 +6,9 @@ use super::objiter::new_stop_iteration;
 use super::objtype::{isinstance, issubclass, PyClassRef};
 use crate::frame::{ExecutionResult, FrameRef};
 use crate::function::OptionalArg;
-use crate::pyobject::{PyClassImpl, PyContext, PyObjectRef, PyRef, PyResult, PyValue};
+use crate::pyobject::{
+    PyClassImpl, PyContext, PyObjectRef, PyRef, PyResult, PyValue, TryFromObject,
+};
 use crate::vm::VirtualMachine;
 
 use std::cell::Cell;
@@ -75,7 +77,10 @@ impl PyGenerator {
         vm: &VirtualMachine,
     ) -> PyResult {
         if self.closed.get() {
-            return Err(vm.invoke(exc_type.as_object(), vec![])?);
+            return Err(TryFromObject::try_from_object(
+                vm,
+                vm.invoke(exc_type.as_object(), vec![])?,
+            )?);
         }
         // TODO what should we do with the other parameters? CPython normalises them with
         //      PyErr_NormalizeException, do we want to do the same.

--- a/vm/src/obj/objgenerator.rs
+++ b/vm/src/obj/objgenerator.rs
@@ -4,6 +4,7 @@
 
 use super::objiter::new_stop_iteration;
 use super::objtype::{isinstance, PyClassRef};
+use crate::exceptions;
 use crate::frame::{ExecutionResult, FrameRef};
 use crate::function::OptionalArg;
 use crate::pyobject::{PyClassImpl, PyContext, PyObjectRef, PyRef, PyResult, PyValue};
@@ -77,7 +78,7 @@ impl PyGenerator {
         let exc_val = exc_val.unwrap_or_else(|| vm.get_none());
         let exc_tb = exc_tb.unwrap_or_else(|| vm.get_none());
         if self.closed.get() {
-            return Err(vm.normalize_exception(exc_type, exc_val, exc_tb)?);
+            return Err(exceptions::normalize(exc_type, exc_val, exc_tb, vm)?);
         }
         vm.frames.borrow_mut().push(self.frame.clone());
         let result = self.frame.gen_throw(vm, exc_type, exc_val, exc_tb);

--- a/vm/src/obj/objgenerator.rs
+++ b/vm/src/obj/objgenerator.rs
@@ -102,7 +102,7 @@ impl PyGenerator {
         vm.frames.borrow_mut().pop();
         self.closed.set(true);
         match result {
-            Ok(ExecutionResult::Yield(_)) => Err(vm.new_exception(
+            Ok(ExecutionResult::Yield(_)) => Err(vm.new_exception_msg(
                 vm.ctx.exceptions.runtime_error.clone(),
                 "generator ignored GeneratorExit".to_string(),
             )),

--- a/vm/src/obj/objint.rs
+++ b/vm/src/obj/objint.rs
@@ -12,6 +12,7 @@ use super::objbytes::PyBytes;
 use super::objfloat;
 use super::objstr::{PyString, PyStringRef};
 use super::objtype::{self, PyClassRef};
+use crate::exceptions::PyBaseExceptionRef;
 use crate::format::FormatSpec;
 use crate::function::{OptionalArg, PyFuncArgs};
 use crate::pyhash;
@@ -817,7 +818,7 @@ fn detect_base(literal: &str) -> Option<u32> {
     }
 }
 
-fn invalid_literal(vm: &VirtualMachine, literal: &str, base: &BigInt) -> PyObjectRef {
+fn invalid_literal(vm: &VirtualMachine, literal: &str, base: &BigInt) -> PyBaseExceptionRef {
     vm.new_value_error(format!(
         "invalid literal for int() with base {}: '{}'",
         base, literal

--- a/vm/src/obj/objiter.rs
+++ b/vm/src/obj/objiter.rs
@@ -4,8 +4,8 @@
 
 use std::cell::Cell;
 
-use super::objtuple::PyTuple;
 use super::objtype::{self, PyClassRef};
+use crate::exceptions::PyBaseExceptionRef;
 use crate::pyobject::{
     PyClassImpl, PyContext, PyObjectRef, PyRef, PyResult, PyValue, TryFromObject, TypeProtocol,
 };
@@ -74,8 +74,8 @@ pub fn new_stop_iteration(vm: &VirtualMachine) -> PyObjectRef {
 }
 
 pub fn stop_iter_value(vm: &VirtualMachine, exc: &PyObjectRef) -> PyResult {
-    let args = vm.get_attribute(exc.clone(), "args")?;
-    let args: &PyTuple = args.payload().unwrap();
+    let exc = PyBaseExceptionRef::try_from_object(vm, exc.clone())?;
+    let args = exc.args();
     let val = args
         .elements
         .first()

--- a/vm/src/obj/objiter.rs
+++ b/vm/src/obj/objiter.rs
@@ -68,13 +68,12 @@ pub fn get_all<T: TryFromObject>(vm: &VirtualMachine, iter_obj: &PyObjectRef) ->
     Ok(elements)
 }
 
-pub fn new_stop_iteration(vm: &VirtualMachine) -> PyObjectRef {
+pub fn new_stop_iteration(vm: &VirtualMachine) -> PyBaseExceptionRef {
     let stop_iteration_type = vm.ctx.exceptions.stop_iteration.clone();
     vm.new_empty_exception(stop_iteration_type).unwrap()
 }
 
-pub fn stop_iter_value(vm: &VirtualMachine, exc: &PyObjectRef) -> PyResult {
-    let exc = PyBaseExceptionRef::try_from_object(vm, exc.clone())?;
+pub fn stop_iter_value(vm: &VirtualMachine, exc: &PyBaseExceptionRef) -> PyResult {
     let args = exc.args();
     let val = args
         .elements

--- a/vm/src/obj/objiter.rs
+++ b/vm/src/obj/objiter.rs
@@ -70,7 +70,7 @@ pub fn get_all<T: TryFromObject>(vm: &VirtualMachine, iter_obj: &PyObjectRef) ->
 
 pub fn new_stop_iteration(vm: &VirtualMachine) -> PyBaseExceptionRef {
     let stop_iteration_type = vm.ctx.exceptions.stop_iteration.clone();
-    vm.new_empty_exception(stop_iteration_type).unwrap()
+    vm.new_exception_empty(stop_iteration_type)
 }
 
 pub fn stop_iter_value(vm: &VirtualMachine, exc: &PyBaseExceptionRef) -> PyResult {

--- a/vm/src/obj/objtype.rs
+++ b/vm/src/obj/objtype.rs
@@ -288,7 +288,7 @@ fn _mro(cls: &PyClassRef) -> Vec<PyClassRef> {
 /// Determines if `obj` actually an instance of `cls`, this doesn't call __instancecheck__, so only
 /// use this if `cls` is known to have not overridden the base __instancecheck__ magic method.
 #[cfg_attr(feature = "flame-it", flame("objtype"))]
-pub fn isinstance(obj: &PyObjectRef, cls: &PyClassRef) -> bool {
+pub fn isinstance(obj: &impl TypeProtocol, cls: &PyClassRef) -> bool {
     issubclass(&obj.class(), &cls)
 }
 

--- a/vm/src/obj/objtype.rs
+++ b/vm/src/obj/objtype.rs
@@ -287,8 +287,8 @@ fn _mro(cls: &PyClassRef) -> Vec<PyClassRef> {
 
 /// Determines if `obj` actually an instance of `cls`, this doesn't call __instancecheck__, so only
 /// use this if `cls` is known to have not overridden the base __instancecheck__ magic method.
-#[cfg_attr(feature = "flame-it", flame("objtype"))]
-pub fn isinstance(obj: &impl TypeProtocol, cls: &PyClassRef) -> bool {
+#[inline]
+pub fn isinstance<T: TypeProtocol>(obj: &T, cls: &PyClassRef) -> bool {
     issubclass(&obj.class(), &cls)
 }
 

--- a/vm/src/obj/objweakproxy.rs
+++ b/vm/src/obj/objweakproxy.rs
@@ -41,7 +41,7 @@ impl PyWeakProxy {
     fn getattr(&self, attr_name: PyObjectRef, vm: &VirtualMachine) -> PyResult {
         match self.weak.upgrade() {
             Some(obj) => vm.get_attribute(obj, attr_name),
-            None => Err(vm.new_exception(
+            None => Err(vm.new_exception_msg(
                 vm.ctx.exceptions.reference_error.clone(),
                 "weakly-referenced object no longer exists".to_string(),
             )),
@@ -52,7 +52,7 @@ impl PyWeakProxy {
     fn setattr(&self, attr_name: PyObjectRef, value: PyObjectRef, vm: &VirtualMachine) -> PyResult {
         match self.weak.upgrade() {
             Some(obj) => vm.set_attr(&obj, attr_name, value),
-            None => Err(vm.new_exception(
+            None => Err(vm.new_exception_msg(
                 vm.ctx.exceptions.reference_error.clone(),
                 "weakly-referenced object no longer exists".to_string(),
             )),

--- a/vm/src/pyobject.rs
+++ b/vm/src/pyobject.rs
@@ -13,7 +13,7 @@ use num_traits::{One, ToPrimitive, Zero};
 
 use crate::bytecode;
 use crate::dictdatatype::DictKey;
-use crate::exceptions;
+use crate::exceptions::{self, PyBaseExceptionRef};
 use crate::function::{IntoPyNativeFunc, PyFuncArgs};
 use crate::obj::objbuiltinfunc::PyBuiltinFunction;
 use crate::obj::objbytearray;
@@ -64,7 +64,7 @@ pub type PyObjectRef = Rc<PyObject<dyn PyObjectPayload>>;
 /// Use this type for functions which return a python object or an exception.
 /// Both the python object and the python exception are `PyObjectRef` types
 /// since exceptions are also python objects.
-pub type PyResult<T = PyObjectRef> = Result<T, PyObjectRef>; // A valid value, or an exception
+pub type PyResult<T = PyObjectRef> = Result<T, PyBaseExceptionRef>; // A valid value, or an exception
 
 /// For attributes we do not use a dict, but a hashmap. This is probably
 /// faster, unordered, and only supports strings as keys.
@@ -799,6 +799,12 @@ where
 impl<T> TypeProtocol for PyRef<T> {
     fn class(&self) -> PyClassRef {
         self.obj.typ.clone()
+    }
+}
+
+impl<T: TypeProtocol> TypeProtocol for &'_ T {
+    fn class(&self) -> PyClassRef {
+        (&**self).class()
     }
 }
 

--- a/vm/src/pyobject.rs
+++ b/vm/src/pyobject.rs
@@ -619,7 +619,7 @@ impl<T: PyValue> PyRef<T> {
         if obj.payload_is::<T>() {
             Ok(Self::new_ref_unchecked(obj))
         } else {
-            Err(vm.new_exception(
+            Err(vm.new_exception_msg(
                 vm.ctx.exceptions.runtime_error.clone(),
                 format!("Unexpected payload for type {:?}", obj.class().name),
             ))
@@ -1085,7 +1085,7 @@ pub trait PyValue: fmt::Debug + Sized + 'static {
     fn class(vm: &VirtualMachine) -> PyClassRef;
 
     fn into_ref(self, vm: &VirtualMachine) -> PyRef<Self> {
-        PyRef::new_ref_unchecked(PyObject::new(self, Self::class(vm), None))
+        self.into_ref_with_type_unchecked(Self::class(vm))
     }
 
     fn into_ref_with_type(self, vm: &VirtualMachine, cls: PyClassRef) -> PyResult<PyRef<Self>> {
@@ -1102,6 +1102,10 @@ pub trait PyValue: fmt::Debug + Sized + 'static {
             let basetype = vm.to_pystr(&class.obj)?;
             Err(vm.new_type_error(format!("{} is not a subtype of {}", subtype, basetype)))
         }
+    }
+
+    fn into_ref_with_type_unchecked(self, cls: PyClassRef) -> PyRef<Self> {
+        PyRef::new_ref_unchecked(PyObject::new(self, cls, None))
     }
 }
 

--- a/vm/src/pyobject.rs
+++ b/vm/src/pyobject.rs
@@ -1085,7 +1085,7 @@ pub trait PyValue: fmt::Debug + Sized + 'static {
     fn class(vm: &VirtualMachine) -> PyClassRef;
 
     fn into_ref(self, vm: &VirtualMachine) -> PyRef<Self> {
-        self.into_ref_with_type_unchecked(Self::class(vm))
+        self.into_ref_with_type_unchecked(Self::class(vm), None)
     }
 
     fn into_ref_with_type(self, vm: &VirtualMachine, cls: PyClassRef) -> PyResult<PyRef<Self>> {
@@ -1104,8 +1104,8 @@ pub trait PyValue: fmt::Debug + Sized + 'static {
         }
     }
 
-    fn into_ref_with_type_unchecked(self, cls: PyClassRef) -> PyRef<Self> {
-        PyRef::new_ref_unchecked(PyObject::new(self, cls, None))
+    fn into_ref_with_type_unchecked(self, cls: PyClassRef, dict: Option<PyDictRef>) -> PyRef<Self> {
+        PyRef::new_ref_unchecked(PyObject::new(self, cls, dict))
     }
 }
 

--- a/vm/src/pyobject.rs
+++ b/vm/src/pyobject.rs
@@ -575,9 +575,6 @@ impl PyObject<dyn PyObjectPayload> {
     ///
     /// If the downcast fails, the original ref is returned in as `Err` so
     /// another downcast can be attempted without unnecessary cloning.
-    ///
-    /// Note: The returned `Result` is _not_ a `PyResult`, even though the
-    ///       types are compatible.
     pub fn downcast<T: PyObjectPayload>(self: Rc<Self>) -> Result<PyRef<T>, PyObjectRef> {
         if self.payload_is::<T>() {
             Ok({

--- a/vm/src/stdlib/functools.rs
+++ b/vm/src/stdlib/functools.rs
@@ -26,7 +26,7 @@ fn functools_reduce(
         objiter::call_next(vm, &iterator).map_err(|err| {
             if objtype::isinstance(&err, &vm.ctx.exceptions.stop_iteration) {
                 let exc_type = vm.ctx.exceptions.type_error.clone();
-                vm.new_exception(
+                vm.new_exception_msg(
                     exc_type,
                     "reduce() of empty sequence with no initial value".to_string(),
                 )

--- a/vm/src/stdlib/io.rs
+++ b/vm/src/stdlib/io.rs
@@ -386,7 +386,7 @@ fn io_base_checkclosed(
         let msg = msg
             .flat_option()
             .unwrap_or_else(|| vm.new_str("I/O operation on closed file.".to_string()));
-        Err(vm.new_exception_obj(vm.ctx.exceptions.value_error.clone(), vec![msg])?)
+        Err(vm.new_exception(vm.ctx.exceptions.value_error.clone(), vec![msg]))
     } else {
         Ok(())
     }
@@ -401,7 +401,7 @@ fn io_base_checkreadable(
         let msg = msg
             .flat_option()
             .unwrap_or_else(|| vm.new_str("File or stream is not readable.".to_string()));
-        Err(vm.new_exception_obj(vm.ctx.exceptions.value_error.clone(), vec![msg])?)
+        Err(vm.new_exception(vm.ctx.exceptions.value_error.clone(), vec![msg]))
     } else {
         Ok(())
     }
@@ -416,7 +416,7 @@ fn io_base_checkwritable(
         let msg = msg
             .flat_option()
             .unwrap_or_else(|| vm.new_str("File or stream is not writable.".to_string()));
-        Err(vm.new_exception_obj(vm.ctx.exceptions.value_error.clone(), vec![msg])?)
+        Err(vm.new_exception(vm.ctx.exceptions.value_error.clone(), vec![msg]))
     } else {
         Ok(())
     }
@@ -431,7 +431,7 @@ fn io_base_checkseekable(
         let msg = msg
             .flat_option()
             .unwrap_or_else(|| vm.new_str("File or stream is not seekable.".to_string()));
-        Err(vm.new_exception_obj(vm.ctx.exceptions.value_error.clone(), vec![msg])?)
+        Err(vm.new_exception(vm.ctx.exceptions.value_error.clone(), vec![msg]))
     } else {
         Ok(())
     }

--- a/vm/src/stdlib/json.rs
+++ b/vm/src/stdlib/json.rs
@@ -47,9 +47,9 @@ pub fn json_loads(obj: PyObjectRef, vm: &VirtualMachine) -> PyResult {
         let json_decode_error = vm.get_attribute(module, "JSONDecodeError").unwrap();
         let json_decode_error = json_decode_error.downcast().unwrap();
         let exc = vm.new_exception(json_decode_error, format!("{}", err));
-        vm.set_attr(&exc, "lineno", vm.ctx.new_int(err.line()))
+        vm.set_attr(exc.as_object(), "lineno", vm.ctx.new_int(err.line()))
             .unwrap();
-        vm.set_attr(&exc, "colno", vm.ctx.new_int(err.column()))
+        vm.set_attr(exc.as_object(), "colno", vm.ctx.new_int(err.column()))
             .unwrap();
         exc
     })

--- a/vm/src/stdlib/json.rs
+++ b/vm/src/stdlib/json.rs
@@ -46,7 +46,7 @@ pub fn json_loads(obj: PyObjectRef, vm: &VirtualMachine) -> PyResult {
             .unwrap();
         let json_decode_error = vm.get_attribute(module, "JSONDecodeError").unwrap();
         let json_decode_error = json_decode_error.downcast().unwrap();
-        let exc = vm.new_exception(json_decode_error, format!("{}", err));
+        let exc = vm.new_exception_msg(json_decode_error, format!("{}", err));
         vm.set_attr(exc.as_object(), "lineno", vm.ctx.new_int(err.line()))
             .unwrap();
         vm.set_attr(exc.as_object(), "colno", vm.ctx.new_int(err.column()))

--- a/vm/src/stdlib/os.rs
+++ b/vm/src/stdlib/os.rs
@@ -171,7 +171,7 @@ pub fn convert_io_error(vm: &VirtualMachine, err: io::Error) -> PyBaseExceptionR
             _ => vm.ctx.exceptions.os_error.clone(),
         },
     };
-    let os_error = vm.new_exception(exc_type, err.to_string());
+    let os_error = vm.new_exception_msg(exc_type, err.to_string());
     let errno = match err.raw_os_error() {
         Some(errno) => vm.new_int(errno),
         None => vm.get_none(),
@@ -185,19 +185,19 @@ pub fn convert_nix_error(vm: &VirtualMachine, err: nix::Error) -> PyBaseExceptio
     let nix_error = match err {
         nix::Error::InvalidPath => {
             let exc_type = vm.ctx.exceptions.file_not_found_error.clone();
-            vm.new_exception(exc_type, err.to_string())
+            vm.new_exception_msg(exc_type, err.to_string())
         }
         nix::Error::InvalidUtf8 => {
             let exc_type = vm.ctx.exceptions.unicode_error.clone();
-            vm.new_exception(exc_type, err.to_string())
+            vm.new_exception_msg(exc_type, err.to_string())
         }
         nix::Error::UnsupportedOperation => {
             let exc_type = vm.ctx.exceptions.runtime_error.clone();
-            vm.new_exception(exc_type, err.to_string())
+            vm.new_exception_msg(exc_type, err.to_string())
         }
         nix::Error::Sys(errno) => {
             let exc_type = convert_nix_errno(vm, errno);
-            vm.new_exception(exc_type, err.to_string())
+            vm.new_exception_msg(exc_type, err.to_string())
         }
     };
 

--- a/vm/src/stdlib/random.rs
+++ b/vm/src/stdlib/random.rs
@@ -19,7 +19,7 @@ pub fn make_module(vm: &VirtualMachine) -> PyObjectRef {
 
 fn random_normalvariate(mu: f64, sigma: f64, vm: &VirtualMachine) -> PyResult<f64> {
     let normal = Normal::new(mu, sigma).map_err(|rand_err| {
-        vm.new_exception(
+        vm.new_exception_msg(
             vm.ctx.exceptions.arithmetic_error.clone(),
             format!("invalid normal distribution: {:?}", rand_err),
         )

--- a/vm/src/stdlib/signal.rs
+++ b/vm/src/stdlib/signal.rs
@@ -108,7 +108,7 @@ pub fn check_signals(vm: &VirtualMachine) -> PyResult<()> {
 }
 
 fn default_int_handler(_signum: PyObjectRef, _arg: PyObjectRef, vm: &VirtualMachine) -> PyResult {
-    Err(vm.new_empty_exception(vm.ctx.exceptions.keyboard_interrupt.clone())?)
+    Err(vm.new_exception_empty(vm.ctx.exceptions.keyboard_interrupt.clone()))
 }
 
 pub fn make_module(vm: &VirtualMachine) -> PyObjectRef {

--- a/vm/src/stdlib/socket.rs
+++ b/vm/src/stdlib/socket.rs
@@ -485,7 +485,7 @@ fn socket_getaddrinfo(opts: GAIOptions, vm: &VirtualMachine) -> PyResult {
 
     let addrs = dns_lookup::getaddrinfo(host, port, Some(hints)).map_err(|err| {
         let error_type = vm.class("_socket", "gaierror");
-        vm.new_exception(error_type, io::Error::from(err).to_string())
+        vm.new_exception_msg(error_type, io::Error::from(err).to_string())
     })?;
 
     let list = addrs
@@ -537,7 +537,7 @@ where
         Ok(mut sock_addrs) => {
             if sock_addrs.len() == 0 {
                 let error_type = vm.class("_socket", "gaierror");
-                Err(vm.new_exception(
+                Err(vm.new_exception_msg(
                     error_type,
                     "nodename nor servname provided, or not known".to_string(),
                 ))
@@ -547,7 +547,7 @@ where
         }
         Err(e) => {
             let error_type = vm.class("_socket", "gaierror");
-            Err(vm.new_exception(error_type, e.to_string()))
+            Err(vm.new_exception_msg(error_type, e.to_string()))
         }
     }
 }
@@ -593,7 +593,7 @@ fn invalid_sock() -> Socket {
 fn convert_sock_error(vm: &VirtualMachine, err: io::Error) -> PyBaseExceptionRef {
     if err.kind() == io::ErrorKind::TimedOut {
         let socket_timeout = vm.class("_socket", "timeout");
-        vm.new_exception(socket_timeout, "Timed out".to_string())
+        vm.new_exception_msg(socket_timeout, "Timed out".to_string())
     } else {
         convert_io_error(vm, err)
     }

--- a/vm/src/stdlib/socket.rs
+++ b/vm/src/stdlib/socket.rs
@@ -12,6 +12,7 @@ use socket2::{Domain, Protocol, Socket, Type as SocketType};
 use super::os::convert_io_error;
 #[cfg(unix)]
 use super::os::convert_nix_error;
+use crate::exceptions::PyBaseExceptionRef;
 use crate::function::{OptionalArg, PyFuncArgs};
 use crate::obj::objbytearray::PyByteArrayRef;
 use crate::obj::objbyteinner::PyBytesLike;
@@ -589,7 +590,7 @@ fn invalid_sock() -> Socket {
     }
 }
 
-fn convert_sock_error(vm: &VirtualMachine, err: io::Error) -> PyObjectRef {
+fn convert_sock_error(vm: &VirtualMachine, err: io::Error) -> PyBaseExceptionRef {
     if err.kind() == io::ErrorKind::TimedOut {
         let socket_timeout = vm.class("_socket", "timeout");
         vm.new_exception(socket_timeout, "Timed out".to_string())

--- a/vm/src/stdlib/subprocess.rs
+++ b/vm/src/stdlib/subprocess.rs
@@ -152,7 +152,7 @@ impl PopenRef {
         .map_err(|s| vm.new_os_error(format!("Could not start program: {}", s)))?;
         if timeout.is_none() {
             let timeout_expired = vm.try_class("_subprocess", "TimeoutExpired")?;
-            Err(vm.new_exception(timeout_expired, "Timeout".to_string()))
+            Err(vm.new_exception_msg(timeout_expired, "Timeout".to_string()))
         } else {
             Ok(())
         }

--- a/vm/src/stdlib/symtable.rs
+++ b/vm/src/stdlib/symtable.rs
@@ -110,7 +110,7 @@ impl PySymbolTable {
             }
             .into_ref(vm))
         } else {
-            Err(vm.ctx.new_str(name.to_string()))
+            Err(vm.new_lookup_error(name.to_string()))
         }
     }
 

--- a/vm/src/stdlib/zlib.rs
+++ b/vm/src/stdlib/zlib.rs
@@ -1,3 +1,4 @@
+use crate::exceptions::PyBaseExceptionRef;
 use crate::function::OptionalArg;
 use crate::obj::objbytes::PyBytesRef;
 use crate::pyobject::{ItemProtocol, PyObjectRef, PyResult};
@@ -110,7 +111,7 @@ fn zlib_decompress(
     }
 }
 
-fn zlib_error(message: &str, vm: &VirtualMachine) -> PyObjectRef {
+fn zlib_error(message: &str, vm: &VirtualMachine) -> PyBaseExceptionRef {
     let module = vm
         .get_attribute(vm.sys_module.clone(), "modules")
         .unwrap()

--- a/vm/src/stdlib/zlib.rs
+++ b/vm/src/stdlib/zlib.rs
@@ -121,5 +121,5 @@ fn zlib_error(message: &str, vm: &VirtualMachine) -> PyBaseExceptionRef {
     let zlib_error = vm.get_attribute(module, "error").unwrap();
     let zlib_error = zlib_error.downcast().unwrap();
 
-    vm.new_exception(zlib_error, message.to_string())
+    vm.new_exception_msg(zlib_error, message.to_string())
 }

--- a/vm/src/sysmodule.rs
+++ b/vm/src/sysmodule.rs
@@ -198,7 +198,7 @@ fn sys_git_info(vm: &VirtualMachine) -> PyObjectRef {
 
 fn sys_exit(code: OptionalArg<PyObjectRef>, vm: &VirtualMachine) -> PyResult {
     let code = code.unwrap_or_else(|| vm.new_int(0));
-    Err(vm.new_exception_obj(vm.ctx.exceptions.system_exit.clone(), vec![code])?)
+    Err(vm.new_exception(vm.ctx.exceptions.system_exit.clone(), vec![code]))
 }
 
 pub fn make_module(vm: &VirtualMachine, module: PyObjectRef, builtins: PyObjectRef) {

--- a/vm/src/sysmodule.rs
+++ b/vm/src/sysmodule.rs
@@ -174,15 +174,18 @@ fn sys_intern(value: PyStringRef, _vm: &VirtualMachine) -> PyStringRef {
     value
 }
 
-fn sys_exc_info(vm: &VirtualMachine) -> PyResult {
-    Ok(vm.ctx.new_tuple(match vm.current_exception() {
+fn sys_exc_info(vm: &VirtualMachine) -> PyObjectRef {
+    let exc_info = match vm.current_exception() {
         Some(exception) => vec![
             exception.class().into_object(),
-            exception.clone(),
-            vm.get_none(),
+            exception.clone().into_object(),
+            exception
+                .traceback()
+                .map_or(vm.get_none(), |tb| tb.into_object()),
         ],
         None => vec![vm.get_none(), vm.get_none(), vm.get_none()],
-    }))
+    };
+    vm.ctx.new_tuple(exc_info)
 }
 
 fn sys_git_info(vm: &VirtualMachine) -> PyObjectRef {

--- a/vm/src/vm.rs
+++ b/vm/src/vm.rs
@@ -343,7 +343,8 @@ impl VirtualMachine {
     ) -> PyBaseExceptionRef {
         // TODO: add repr of args into logging?
         vm_trace!("New exception created: {}", exc_type.name);
-        PyBaseException::new(args, self).into_ref_with_type_unchecked(exc_type)
+        PyBaseException::new(args, self)
+            .into_ref_with_type_unchecked(exc_type, Some(self.ctx.new_dict()))
     }
 
     /// Instantiate an exception with no arguments.

--- a/vm/src/vm.rs
+++ b/vm/src/vm.rs
@@ -19,7 +19,7 @@ use rustpython_compiler::{compile, error::CompileError};
 
 use crate::builtins::{self, to_ascii};
 use crate::bytecode;
-use crate::exceptions::PyBaseExceptionRef;
+use crate::exceptions::{PyBaseException, PyBaseExceptionRef};
 use crate::frame::{ExecutionResult, Frame, FrameRef};
 use crate::frozen;
 use crate::function::PyFuncArgs;
@@ -36,12 +36,12 @@ use crate::obj::objiter;
 use crate::obj::objmodule::{self, PyModule};
 use crate::obj::objsequence;
 use crate::obj::objstr::{PyString, PyStringRef};
-use crate::obj::objtuple::PyTupleRef;
+use crate::obj::objtuple::{PyTuple, PyTupleRef};
 use crate::obj::objtype::{self, PyClassRef};
 use crate::pyhash;
 use crate::pyobject::{
-    IdProtocol, ItemProtocol, PyContext, PyObject, PyObjectRef, PyResult, PyValue, TryFromObject,
-    TryIntoRef, TypeProtocol,
+    Either, IdProtocol, ItemProtocol, PyContext, PyObject, PyObjectRef, PyResult, PyValue,
+    TryFromObject, TryIntoRef, TypeProtocol,
 };
 use crate::scope::Scope;
 use crate::stdlib;
@@ -327,6 +327,62 @@ impl VirtualMachine {
     pub fn new_module(&self, name: &str, dict: PyDictRef) -> PyObjectRef {
         objmodule::init_module_dict(self, &dict, self.new_str(name.to_owned()), self.get_none());
         PyObject::new(PyModule {}, self.ctx.types.module_type.clone(), Some(dict))
+    }
+
+    /// Similar to PyErr_NormalizeException in CPython
+    pub fn normalize_exception(
+        &self,
+        exc_type: PyObjectRef,
+        exc_val: PyObjectRef,
+        exc_tb: PyObjectRef,
+    ) -> PyResult<PyBaseExceptionRef> {
+        let args = || {
+            if self.is_none(&exc_val) {
+                vec![]
+            } else {
+                match_class!(match exc_val.clone() {
+                    tup @ PyTuple => tup.elements.clone(),
+                    exc @ PyBaseException => exc.args().elements.clone(),
+                    obj => vec![obj],
+                })
+            }
+        };
+        let exc_type = if let Ok(exc) = PyBaseExceptionRef::try_from_object(self, exc_type.clone())
+        {
+            Either::A(exc)
+        } else if let Ok(cls) = PyClassRef::try_from_object(self, exc_type.clone()) {
+            Either::B(cls)
+        } else {
+            return Err(self.new_type_error(format!(
+                "expected an exception instance or type, got '{}'",
+                exc_type.class().name
+            )));
+        };
+        let exc = if let Ok(exc) = PyBaseExceptionRef::try_from_object(self, exc_val.clone()) {
+            match exc_type {
+                Either::A(_) => {
+                    return Err(self.new_type_error(
+                        "instance exception may not have a separate value".to_string(),
+                    ))
+                }
+                Either::B(cls) => {
+                    if objtype::isinstance(&exc, &cls) {
+                        exc
+                    } else {
+                        self.new_exception_obj(cls, args())?
+                    }
+                }
+            }
+        } else {
+            match exc_type {
+                Either::A(exc) => exc,
+                Either::B(cls) => self.new_exception_obj(cls, args())?,
+            }
+        };
+        if let Some(tb) = TryFromObject::try_from_object(self, exc_tb)? {
+            exc.set_traceback(Some(tb));
+        }
+        Ok(exc)
     }
 
     #[cfg_attr(feature = "flame-it", flame("VirtualMachine"))]

--- a/wasm/lib/Cargo.toml
+++ b/wasm/lib/Cargo.toml
@@ -25,8 +25,6 @@ serde-wasm-bindgen = "0.1"
 serde = "1.0"
 js-sys = "0.3"
 futures = "0.1"
-num-traits = "0.2"
-num-bigint = { version = "0.2.3", features = ["serde"] }
 
 [dependencies.web-sys]
 version = "0.3"

--- a/wasm/lib/src/browser_module.rs
+++ b/wasm/lib/src/browser_module.rs
@@ -1,15 +1,12 @@
 use futures::Future;
 use js_sys::Promise;
-use num_traits::cast::ToPrimitive;
 use wasm_bindgen::prelude::*;
 use wasm_bindgen::JsCast;
 use wasm_bindgen_futures::{future_to_promise, JsFuture};
 
 use rustpython_vm::function::{OptionalArg, PyFuncArgs};
 use rustpython_vm::import::import_file;
-use rustpython_vm::obj::{
-    objdict::PyDictRef, objint::PyIntRef, objstr::PyStringRef, objtype::PyClassRef,
-};
+use rustpython_vm::obj::{objdict::PyDictRef, objstr::PyStringRef, objtype::PyClassRef};
 use rustpython_vm::pyobject::{
     PyCallable, PyClassImpl, PyObject, PyObjectRef, PyRef, PyResult, PyValue,
 };
@@ -148,14 +145,7 @@ fn browser_request_animation_frame(func: PyCallable, vm: &VirtualMachine) -> PyR
     Ok(vm.ctx.new_int(id))
 }
 
-fn browser_cancel_animation_frame(id: PyIntRef, vm: &VirtualMachine) -> PyResult {
-    let id = id.as_bigint().to_i32().ok_or_else(|| {
-        vm.new_exception(
-            vm.ctx.exceptions.value_error.clone(),
-            "Integer too large to convert to i32 for animationFrame id".into(),
-        )
-    })?;
-
+fn browser_cancel_animation_frame(id: i32, vm: &VirtualMachine) -> PyResult {
     window()
         .cancel_animation_frame(id)
         .map_err(|err| convert::js_py_typeerror(vm, err))?;
@@ -308,7 +298,7 @@ impl Element {
     fn set_attr(&self, attr: PyStringRef, value: PyStringRef, vm: &VirtualMachine) -> PyResult<()> {
         self.elem
             .set_attribute(attr.as_str(), value.as_str())
-            .map_err(|err| convert::js_to_py(vm, err))
+            .map_err(|err| convert::js_py_typeerror(vm, err))
     }
 }
 

--- a/wasm/lib/src/convert.rs
+++ b/wasm/lib/src/convert.rs
@@ -57,9 +57,9 @@ pub fn js_err_to_py_err(vm: &VirtualMachine, js_err: &JsValue) -> PyBaseExceptio
                 _ => &vm.ctx.exceptions.exception_type,
             }
             .clone();
-            vm.new_exception(exc_type, err.message().into())
+            vm.new_exception_msg(exc_type, err.message().into())
         }
-        None => vm.new_exception(
+        None => vm.new_exception_msg(
             vm.ctx.exceptions.exception_type.clone(),
             format!("{:?}", js_err),
         ),

--- a/wasm/lib/src/js_module.rs
+++ b/wasm/lib/src/js_module.rs
@@ -1,4 +1,5 @@
 use js_sys::{Array, Object, Reflect};
+use rustpython_vm::exceptions::PyBaseExceptionRef;
 use rustpython_vm::function::Args;
 use rustpython_vm::obj::{objfloat::PyFloatRef, objstr::PyStringRef, objtype::PyClassRef};
 use rustpython_vm::pyobject::{PyClassImpl, PyObjectRef, PyRef, PyResult, PyValue, TryFromObject};
@@ -233,10 +234,14 @@ struct NewObjectOptions {
     prototype: Option<PyJsValueRef>,
 }
 
-fn new_js_error(vm: &VirtualMachine, err: JsValue) -> PyObjectRef {
+fn new_js_error(vm: &VirtualMachine, err: JsValue) -> PyBaseExceptionRef {
     let exc = vm.new_exception(vm.class("_js", "JsError"), format!("{:?}", err));
-    vm.set_attr(&exc, "js_value", PyJsValue::new(err).into_ref(vm))
-        .unwrap();
+    vm.set_attr(
+        exc.as_object(),
+        "js_value",
+        PyJsValue::new(err).into_ref(vm),
+    )
+    .unwrap();
     exc
 }
 

--- a/wasm/lib/src/js_module.rs
+++ b/wasm/lib/src/js_module.rs
@@ -235,7 +235,7 @@ struct NewObjectOptions {
 }
 
 fn new_js_error(vm: &VirtualMachine, err: JsValue) -> PyBaseExceptionRef {
-    let exc = vm.new_exception(vm.class("_js", "JsError"), format!("{:?}", err));
+    let exc = vm.new_exception_msg(vm.class("_js", "JsError"), format!("{:?}", err));
     vm.set_attr(
         exc.as_object(),
         "js_value",

--- a/wasm/lib/src/vm_class.rs
+++ b/wasm/lib/src/vm_class.rs
@@ -232,7 +232,7 @@ impl WASMVirtualMachine {
                             &JsValue::UNDEFINED,
                             &wasm_builtins::format_print_args(vm, args)?.into(),
                         )
-                        .map_err(|err| convert::js_to_py(vm, err))?;
+                        .map_err(|err| convert::js_py_typeerror(vm, err))?;
                         Ok(vm.get_none())
                     })
             } else if stdout.is_null() {


### PR DESCRIPTION
e.g. in `PyResult`, the exception stack, and any function that does an operation on an exception. I also noticed a bug where if the `from` argument to raise was missing, it would still overwrite the `__cause__` on the exception as if it had been raised `from None`.