### PR TITLE
Support eval and exec mode in wasm

### DIFF
--- a/wasm/demo/src/main.js
+++ b/wasm/demo/src/main.js
@@ -36,7 +36,7 @@ function runCodeFromTextarea() {
 
     const code = editor.getValue();
     try {
-        rp.pyEval(code, {
+        rp.pyExec(code, {
             stdout: output => {
                 const shouldScroll =
                     consoleElement.scrollHeight - consoleElement.scrollTop ===

--- a/wasm/lib/src/vm_class.rs
+++ b/wasm/lib/src/vm_class.rs
@@ -278,7 +278,7 @@ impl WASMVirtualMachine {
         })?
     }
 
-    fn run(&self, source: &str, mode: compile::Mode) -> Result<JsValue, JsValue> {
+    pub(crate) fn run(&self, source: &str, mode: compile::Mode) -> Result<JsValue, JsValue> {
         self.assert_valid()?;
         self.with_unchecked(
             |StoredVirtualMachine {

--- a/wasm/tests/test_exec_mode.py
+++ b/wasm/tests/test_exec_mode.py
@@ -1,0 +1,46 @@
+import time
+import sys
+
+from selenium import webdriver
+from selenium.webdriver.firefox.options import Options
+import pytest
+
+def print_stack(driver):
+    stack = driver.execute_script(
+        "return window.__RUSTPYTHON_ERROR_MSG + '\\n' + window.__RUSTPYTHON_ERROR_STACK"
+    )
+    print(f"RustPython error stack:\n{stack}", file=sys.stderr)
+
+
+@pytest.fixture(scope="module")
+def driver(request):
+    options = Options()
+    options.add_argument('-headless')
+    driver = webdriver.Firefox(options=options)
+    try:
+        driver.get("http://localhost:8080")
+    except Exception as e:
+        print_stack(driver)
+        raise
+    time.sleep(5)
+    yield driver
+    driver.close()
+
+
+def test_eval_mode(driver):
+    assert driver.execute_script("return window.rp.pyEval('1+1')") == 2
+
+def test_exec_mode(driver):
+    assert driver.execute_script("return window.rp.pyExec('1+1')") is None
+
+def test_exec_single_mode(driver):
+    assert driver.execute_script("return window.rp.pyExecSingle('1+1')") == 2
+    assert driver.execute_script(
+        """
+        var output = [];
+        save_output = function(text) {{
+            output.push(text)
+        }};
+        window.rp.pyExecSingle('1+1\\n2+2',{stdout: save_output});
+        return output;
+        """) == ['2\n', '4\n']


### PR DESCRIPTION
- Expose `pyEval`, `pyExec`, `pyExecSingle` in wasm module

This PR also fix #1612