### PR TITLE
Allow to skip VM param for IntoPyNativeFunc functions

### DIFF
--- a/vm/src/exceptions.rs
+++ b/vm/src/exceptions.rs
@@ -83,7 +83,7 @@ impl PyBaseException {
     }
 
     #[pyproperty(name = "__traceback__", setter)]
-    fn setter_traceback(&self, traceback: Option<PyTracebackRef>, _vm: &VirtualMachine) {
+    pub fn set_traceback(&self, traceback: Option<PyTracebackRef>) {
         self.traceback.replace(traceback);
     }
 
@@ -153,9 +153,6 @@ impl PyBaseException {
 
     pub fn traceback(&self) -> Option<PyTracebackRef> {
         self.traceback.borrow().clone()
-    }
-    pub fn set_traceback(&self, tb: Option<PyTracebackRef>) {
-        self.traceback.replace(tb);
     }
 
     pub fn cause(&self) -> Option<PyBaseExceptionRef> {

--- a/vm/src/obj/objproperty.rs
+++ b/vm/src/obj/objproperty.rs
@@ -265,7 +265,7 @@ impl<'a> PropertyBuilder<'a> {
         }
     }
 
-    pub fn add_getter<I, V, F: IntoPyNativeFunc<I, V>>(self, func: F) -> Self {
+    pub fn add_getter<I, V, VM, F: IntoPyNativeFunc<I, V, VM>>(self, func: F) -> Self {
         let func = self.ctx.new_rustfunc(func);
         Self {
             ctx: self.ctx,
@@ -274,7 +274,7 @@ impl<'a> PropertyBuilder<'a> {
         }
     }
 
-    pub fn add_setter<I, V, F: IntoPyNativeFunc<(I, V), impl PropertySetterResult>>(
+    pub fn add_setter<I, V, VM, F: IntoPyNativeFunc<(I, V), impl PropertySetterResult, VM>>(
         self,
         func: F,
     ) -> Self {

--- a/vm/src/pyobject.rs
+++ b/vm/src/pyobject.rs
@@ -460,9 +460,9 @@ impl PyContext {
         PyObject::new(PyNamespace, self.namespace_type(), Some(self.new_dict()))
     }
 
-    pub fn new_rustfunc<F, T, R>(&self, f: F) -> PyObjectRef
+    pub fn new_rustfunc<F, T, R, VM>(&self, f: F) -> PyObjectRef
     where
-        F: IntoPyNativeFunc<T, R>,
+        F: IntoPyNativeFunc<T, R, VM>,
     {
         PyObject::new(
             PyBuiltinFunction::new(f.into_func()),
@@ -471,9 +471,9 @@ impl PyContext {
         )
     }
 
-    pub fn new_classmethod<F, T, R>(&self, f: F) -> PyObjectRef
+    pub fn new_classmethod<F, T, R, VM>(&self, f: F) -> PyObjectRef
     where
-        F: IntoPyNativeFunc<T, R>,
+        F: IntoPyNativeFunc<T, R, VM>,
     {
         PyObject::new(
             PyClassMethod {
@@ -484,9 +484,9 @@ impl PyContext {
         )
     }
 
-    pub fn new_property<F, I, V>(&self, f: F) -> PyObjectRef
+    pub fn new_property<F, I, V, VM>(&self, f: F) -> PyObjectRef
     where
-        F: IntoPyNativeFunc<I, V>,
+        F: IntoPyNativeFunc<I, V, VM>,
     {
         PropertyBuilder::new(self).add_getter(f).create()
     }

--- a/vm/src/stdlib/os.rs
+++ b/vm/src/stdlib/os.rs
@@ -1247,7 +1247,7 @@ pub fn make_module(vm: &VirtualMachine) -> PyObjectRef {
         follow_symlinks: Option<bool>,
     };
     impl<'a> SupportFunc<'a> {
-        fn new<F, T, R>(
+        fn new<F, T, R, VM>(
             vm: &VirtualMachine,
             name: &'a str,
             func: F,
@@ -1256,7 +1256,7 @@ pub fn make_module(vm: &VirtualMachine) -> PyObjectRef {
             follow_symlinks: Option<bool>,
         ) -> Self
         where
-            F: IntoPyNativeFunc<T, R>,
+            F: IntoPyNativeFunc<T, R, VM>,
         {
             let func_obj = vm.ctx.new_rustfunc(func);
             Self {


### PR DESCRIPTION
Suggestion from #1644

Not sure this is what we want - because I thought VM param is designated constraint not to confuse plain functions with python functions until now.
