### PR TITLE
Add htons, ntohl, and ntohs to socket.rs

### DIFF
--- a/vm/src/stdlib/socket.rs
+++ b/vm/src/stdlib/socket.rs
@@ -449,6 +449,28 @@ fn socket_htonl(host: u32, vm: &VirtualMachine) -> PyResult {
     Ok(vm.new_int(host.to_be()))
 }
 
+fn socket_htons(host: u16, vm: &VirtualMachine) -> PyResult {
+    Ok(vm.new_int(host.to_be()))
+}
+
+fn socket_ntohl(network: u32, vm: &VirtualMachine) -> PyResult {
+    if cfg!(target_endian = "big") {
+        Ok(vm.new_int(network))
+    }
+    else {
+        Ok(vm.new_int(network.to_le()))
+    }
+}
+
+fn socket_ntohs(network: u16, vm: &VirtualMachine) -> PyResult {
+    if cfg!(target_endian = "big") {
+        Ok(vm.new_int(network))
+    }
+    else {
+        Ok(vm.new_int(network.to_le()))
+    }
+}
+
 #[derive(FromArgs)]
 struct GAIOptions {
     #[pyarg(positional_only)]
@@ -636,6 +658,9 @@ pub fn make_module(vm: &VirtualMachine) -> PyObjectRef {
         "inet_ntoa" => ctx.new_rustfunc(socket_inet_ntoa),
         "gethostname" => ctx.new_rustfunc(socket_gethostname),
         "htonl" => ctx.new_rustfunc(socket_htonl),
+        "htons" => ctx.new_rustfunc(socket_htons),
+        "ntohl" => ctx.new_rustfunc(socket_ntohl),
+        "ntohs" => ctx.new_rustfunc(socket_ntohs),
         "getdefaulttimeout" => ctx.new_rustfunc(|vm: &VirtualMachine| vm.get_none()),
         "getaddrinfo" => ctx.new_rustfunc(socket_getaddrinfo),
         "gethostbyaddr" => ctx.new_rustfunc(socket_gethostbyaddr),

--- a/vm/src/stdlib/socket.rs
+++ b/vm/src/stdlib/socket.rs
@@ -450,7 +450,7 @@ fn socket_hton<U: num_traits::int::PrimInt>(host: U, _vm: &VirtualMachine) -> U 
 }
 
 fn socket_ntoh<U: num_traits::int::PrimInt>(network: U, _vm: &VirtualMachine) -> U {
-   U::from_be(network) 
+    U::from_be(network)
 }
 
 #[derive(FromArgs)]

--- a/vm/src/stdlib/socket.rs
+++ b/vm/src/stdlib/socket.rs
@@ -445,12 +445,12 @@ fn socket_inet_ntoa(packed_ip: PyBytesRef, vm: &VirtualMachine) -> PyResult {
     Ok(vm.new_str(Ipv4Addr::from(ip_num).to_string()))
 }
 
-fn socket_hton<U: num_traits::PrimInt>(host: U, _vm: &VirtualMachine) -> U {
-    host.to_be()
+fn socket_hton<U: num_traits::int::PrimInt>(host: U, _vm: &VirtualMachine) -> U {
+    U::to_be(host)
 }
 
-fn socket_ntoh<U: num_traits::PrimInt>(network: U, _vm: &VirtualMachine) -> U {
-   network.from_be() 
+fn socket_ntoh<U: num_traits::int::PrimInt>(network: U, _vm: &VirtualMachine) -> U {
+   U::from_be(network) 
 }
 
 #[derive(FromArgs)]

--- a/vm/src/stdlib/socket.rs
+++ b/vm/src/stdlib/socket.rs
@@ -445,30 +445,12 @@ fn socket_inet_ntoa(packed_ip: PyBytesRef, vm: &VirtualMachine) -> PyResult {
     Ok(vm.new_str(Ipv4Addr::from(ip_num).to_string()))
 }
 
-fn socket_htonl(host: u32, vm: &VirtualMachine) -> PyResult {
-    Ok(vm.new_int(host.to_be()))
+fn socket_hton<U: num_traits::PrimInt>(host: U, _vm: &VirtualMachine) -> U {
+    host.to_be()
 }
 
-fn socket_htons(host: u16, vm: &VirtualMachine) -> PyResult {
-    Ok(vm.new_int(host.to_be()))
-}
-
-fn socket_ntohl(network: u32, vm: &VirtualMachine) -> PyResult {
-    if cfg!(target_endian = "big") {
-        Ok(vm.new_int(network))
-    }
-    else {
-        Ok(vm.new_int(network.to_le()))
-    }
-}
-
-fn socket_ntohs(network: u16, vm: &VirtualMachine) -> PyResult {
-    if cfg!(target_endian = "big") {
-        Ok(vm.new_int(network))
-    }
-    else {
-        Ok(vm.new_int(network.to_le()))
-    }
+fn socket_ntoh<U: num_traits::PrimInt>(network: U, _vm: &VirtualMachine) -> U {
+   network.from_be() 
 }
 
 #[derive(FromArgs)]
@@ -657,10 +639,10 @@ pub fn make_module(vm: &VirtualMachine) -> PyObjectRef {
         "inet_aton" => ctx.new_rustfunc(socket_inet_aton),
         "inet_ntoa" => ctx.new_rustfunc(socket_inet_ntoa),
         "gethostname" => ctx.new_rustfunc(socket_gethostname),
-        "htonl" => ctx.new_rustfunc(socket_htonl),
-        "htons" => ctx.new_rustfunc(socket_htons),
-        "ntohl" => ctx.new_rustfunc(socket_ntohl),
-        "ntohs" => ctx.new_rustfunc(socket_ntohs),
+        "htonl" => ctx.new_rustfunc(socket_hton::<u32>),
+        "htons" => ctx.new_rustfunc(socket_hton::<u16>),
+        "ntohl" => ctx.new_rustfunc(socket_ntoh::<u32>),
+        "ntohs" => ctx.new_rustfunc(socket_ntoh::<u16>),
         "getdefaulttimeout" => ctx.new_rustfunc(|vm: &VirtualMachine| vm.get_none()),
         "getaddrinfo" => ctx.new_rustfunc(socket_getaddrinfo),
         "gethostbyaddr" => ctx.new_rustfunc(socket_gethostbyaddr),


### PR DESCRIPTION
For #1176.  Just added each of those functions to `vm/src/stdlib/socket.rs`, mostly by cheating off of the `htonl` implementation.