### PR TITLE
Don't use proc-macro-hack; use our own slightly-less-hacky hack

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1306,7 +1306,6 @@ name = "rustpython-derive"
 version = "0.1.1"
 dependencies = [
  "maplit 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "proc-macro-hack 0.5.10 (registry+https://github.com/rust-lang/crates.io-index)",
  "proc-macro2 0.4.30 (registry+https://github.com/rust-lang/crates.io-index)",
  "quote 0.6.13 (registry+https://github.com/rust-lang/crates.io-index)",
  "rustpython-bytecode 0.1.1",
@@ -1373,7 +1372,6 @@ dependencies = [
  "num-traits 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "num_cpus 1.10.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "paste 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "proc-macro-hack 0.5.10 (registry+https://github.com/rust-lang/crates.io-index)",
  "pwd 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.7.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand_distr 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,6 @@ name = "bench"
 path = "./benchmarks/bench.rs"
 
 [features]
-default = ["rustpython-vm/use-proc-macro-hack"]
 flame-it = ["rustpython-vm/flame-it", "flame", "flamescope"]
 freeze-stdlib = ["rustpython-vm/freeze-stdlib"]
 

--- a/derive/Cargo.toml
+++ b/derive/Cargo.toml
@@ -10,14 +10,10 @@ edition = "2018"
 [lib]
 proc-macro = true
 
-[features]
-default = ["proc-macro-hack"]
-
 [dependencies]
 syn = { version = "0.15.29", features = ["full"] }
 quote = "0.6.11"
 proc-macro2 = "0.4.27"
 rustpython-compiler = { path = "../compiler", version = "0.1.1" }
 rustpython-bytecode = { path = "../bytecode", version = "0.1.1" }
-proc-macro-hack = { version = "0.5", optional = true }
 maplit = "1.0"

--- a/derive/src/lib.rs
+++ b/derive/src/lib.rs
@@ -53,8 +53,17 @@ pub fn pystruct_sequence(attr: TokenStream, item: TokenStream) -> TokenStream {
     result_to_tokens(pyclass::impl_pystruct_sequence(attr, item))
 }
 
-#[cfg_attr(feature = "proc-macro-hack", proc_macro_hack::proc_macro_hack)]
-#[cfg_attr(not(feature = "proc-macro-hack"), proc_macro)]
+fn result_to_tokens_expr(result: Result<TokenStream2, Diagnostic>) -> TokenStream {
+    result_to_tokens(result.map(|out_expr| {
+        quote::quote! {
+            macro_rules! __proc_macro_call {
+                () => {{ #out_expr }};
+            }
+        }
+    }))
+}
+
+#[proc_macro]
 pub fn py_compile_bytecode(input: TokenStream) -> TokenStream {
-    result_to_tokens(compile_bytecode::impl_py_compile_bytecode(input.into()))
+    result_to_tokens_expr(compile_bytecode::impl_py_compile_bytecode(input.into()))
 }

--- a/vm/Cargo.toml
+++ b/vm/Cargo.toml
@@ -9,10 +9,9 @@ edition = "2018"
 include = ["src/**/*.rs", "Cargo.toml", "build.rs", "Lib/**/*.py"]
 
 [features]
-default = ["rustpython-parser", "rustpython-compiler", "use-proc-macro-hack"]
+default = ["rustpython-parser", "rustpython-compiler"]
 vm-tracing-logging = []
 flame-it = ["flame", "flamer"]
-use-proc-macro-hack = ["proc-macro-hack", "rustpython-derive/proc-macro-hack"]
 freeze-stdlib = []
 
 [dependencies]
@@ -60,7 +59,6 @@ unicode-casing = "0.1"
 unic = "0.9"
 unic-common = "0.9"
 maplit = "1.0"
-proc-macro-hack = { version = "0.5", optional = true }
 bitflags = "1.1"
 libc = "0.2"
 nix = "0.15.0"

--- a/vm/src/lib.rs
+++ b/vm/src/lib.rs
@@ -13,7 +13,6 @@
 )]
 #![doc(html_logo_url = "https://raw.githubusercontent.com/RustPython/RustPython/master/logo.png")]
 #![doc(html_root_url = "https://docs.rs/rustpython-vm/")]
-#![cfg_attr(not(feature = "use-proc-macro-hack"), feature(proc_macro_hygiene))]
 
 #[cfg(feature = "flame-it")]
 #[macro_use]
@@ -37,9 +36,19 @@ extern crate self as rustpython_vm;
 
 pub use rustpython_derive::*;
 
-#[cfg(feature = "use-proc-macro-hack")]
-#[proc_macro_hack::proc_macro_hack]
-pub use rustpython_derive::py_compile_bytecode;
+#[doc(hidden)]
+pub use rustpython_derive::py_compile_bytecode as _py_compile_bytecode;
+
+#[macro_export]
+macro_rules! py_compile_bytecode {
+    ($($arg:tt)*) => {{
+        #[macro_use]
+        mod __m {
+            $crate::_py_compile_bytecode!($($arg)*);
+        }
+        __proc_macro_call!()
+    }};
+}
 
 //extern crate eval; use eval::eval::*;
 // use py_code_object::{Function, NativeType, PyCodeObject};


### PR DESCRIPTION
`proc-macro-hack` is sort of a pain to deal with (based on the nested cargo features that were removed by this), and with Rust 1.40 [function-like macros can generate `macro_rules!`](https://github.com/rust-lang/rust/pull/64035), so this is pretty easy to implement ourselves (`proc-macro-hack` does something with a custom derive on an enum and stringifying and reparsing the input stream).