### PR TITLE
Purge all UB from init_type_hierarchy

### DIFF
--- a/vm/src/pyobject.rs
+++ b/vm/src/pyobject.rs
@@ -642,7 +642,7 @@ impl<T: PyValue> PyRef<T> {
         }
     }
 
-    fn new_ref_unchecked(obj: PyObjectRef) -> Self {
+    pub(crate) fn new_ref_unchecked(obj: PyObjectRef) -> Self {
         PyRef {
             obj,
             _payload: PhantomData,

--- a/vm/src/types.rs
+++ b/vm/src/types.rs
@@ -245,13 +245,13 @@ macro_rules! partially_init {
         Uninit { $($uninit_field:ident),*$(,)? }$(,)?
     ) => {{
         // check all the fields are there but *don't* actually run it
-        #[allow(deprecated, invalid_value)]
-        {if false {
+        if false {
+            #[allow(invalid_value)]
             let _ = {$ty {
                 $($init_field: $init_value,)*
-                $($uninit_field: ::std::mem::uninitialized(),)*
+                $($uninit_field: ::std::mem::MaybeUninit::uninit().assume_init(),)*
             }};
-        }}
+        }
         let mut m = ::std::mem::MaybeUninit::<$ty>::uninit();
         $(::std::ptr::write(&mut (*m.as_mut_ptr()).$init_field, $init_value);)*
         m


### PR DESCRIPTION
My plan I had in #1411 didn't work out because I failed to account for `PyClassRef` and `Rc<PyObject<PyClass>>` not being the same size due to the former being a trait object, so I went with using raw trait object manipulation.

cc @silmeth