### PR TITLE
Improve test check for windows platform

### DIFF
--- a/tests/snippets/stdlib_select.py
+++ b/tests/snippets/stdlib_select.py
@@ -20,7 +20,7 @@ assert_raises(TypeError, select.select, [Almost()], [], [])
 assert_raises(TypeError, select.select, [], [], [], "not a number")
 assert_raises(ValueError, select.select, [], [], [], -1)
 
-if "win" in sys.platform:
+if sys.platform in ["win32", "cygwin"]:
     assert_raises(OSError, select.select, [0], [], [])
 
 recvr = socket.socket()


### PR DESCRIPTION
`'win' in sys.platform` returns true on MacOS, since it's platform string is [`"darwin"`](https://docs.python.org/3/library/sys.html#sys.platform). This was likely not intended, since the check seems to be testing for a windows platform, and was the only test error on a clean master build for me.