### PR TITLE
Added WAPM badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ A Python-3 (CPython >= 3.5.0) Interpreter written in Rust :snake: :scream:
 [![docs.rs](https://docs.rs/rustpython/badge.svg)](https://docs.rs/rustpython/)
 [![Crates.io](https://img.shields.io/crates/v/rustpython)](https://crates.io/crates/rustpython)
 [![dependency status](https://deps.rs/crate/rustpython/0.1.1/status.svg)](https://deps.rs/crate/rustpython/0.1.1)
+[![WAPM package](https://wapm.io/package/rustpython/badge.svg?style=flat)](https://wapm.io/package/rustpython)
 
 ## Usage
 


### PR DESCRIPTION
We just created badges for WAPM packages, so projects that are published there can use them.

It will appear in the README like this:
[![WAPM package](https://wapm.io/package/rustpython/badge.svg?style=flat&nocache)](https://wapm.io/package/rustpython)


Hope you find it useful! :)