### PR TITLE
String performance

### DIFF
--- a/benchmarks/benchmarks/strings.py
+++ b/benchmarks/benchmarks/strings.py
@@ -1,0 +1,4 @@
+long_string = "a" * 50000
+
+for char in long_string:
+    pass

--- a/benchmarks/test_benchmarks.py
+++ b/benchmarks/test_benchmarks.py
@@ -18,6 +18,7 @@ pythons = [
 benchmarks = [
     ['benchmarks/nbody.py'],
     ['benchmarks/mandelbrot.py'],
+    ['benchmarks/strings.py'],
 ]
 
 exe_ids = ['cpython', 'rustpython']

--- a/tests/snippets/strings.py
+++ b/tests/snippets/strings.py
@@ -277,7 +277,7 @@ assert "\u9487" == "钇"
 assert "\U0001F609" == "😉"
 
 # test str iter
-iterable_str = "123456789"
+iterable_str = "12345678😉"
 str_iter = iter(iterable_str)
 
 assert next(str_iter) == "1"
@@ -288,13 +288,13 @@ assert next(str_iter) == "5"
 assert next(str_iter) == "6"
 assert next(str_iter) == "7"
 assert next(str_iter) == "8"
-assert next(str_iter) == "9"
+assert next(str_iter) == "😉"
 assert next(str_iter, None) == None
 assert_raises(StopIteration, next, str_iter)
 
 str_iter_reversed = reversed(iterable_str)
 
-assert next(str_iter_reversed) == "9"
+assert next(str_iter_reversed) == "😉"
 assert next(str_iter_reversed) == "8"
 assert next(str_iter_reversed) == "7"
 assert next(str_iter_reversed) == "6"


### PR DESCRIPTION
I noticed that the string iterator looped over all or parts of the characters twice for each call to `__next__`. Made an attempt to remove both of them and only keep the current byte position, which should change string iteration an O(n) operation instead of O(n²).

### Benchmark results
Master (but with this branch's benchmark test):
```
(rustpython_benchmarks) benchmarks (master) $ (cd .. && cargo build --release) && pytest -k "strings.py"
   <skipped>
------------------------------------------------------------------------------------------------ benchmark: 2 tests -----------------------------------------------------------------------------------------------
Name (time in ms)                            Min                   Max                  Mean             StdDev                Median                IQR            Outliers      OPS            Rounds  Iterations
-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
test_bench[strings.py-cpython]           16.8248 (1.0)         22.7763 (1.0)         18.2347 (1.0)       1.1636 (1.0)         17.8539 (1.0)       0.8779 (1.0)           7;4  54.8405 (1.0)          48           1
test_bench[strings.py-rustpython]     2,393.0537 (142.23)   2,522.6919 (110.76)   2,430.8572 (133.31)   53.6760 (46.13)    2,406.0248 (134.76)   58.7938 (66.97)         1;0   0.4114 (0.01)          5           1
-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------

Legend:
  Outliers: 1 Standard Deviation from Mean; 1.5 IQR (InterQuartile Range) from 1st Quartile and 3rd Quartile.
  OPS: Operations Per Second, computed as 1 / Mean
===================================================================================== 2 passed, 4 deselected in 18.95s =====================================================================================
```

This branch:
```
(rustpython_benchmarks) benchmarks (string-performance) $ (cd .. && cargo build --release) && pytest -k "strings.py"
   <skipped>
----------------------------------------------------------------------------------------- benchmark: 2 tests -----------------------------------------------------------------------------------------
Name (time in ms)                         Min                 Max               Mean            StdDev             Median               IQR            Outliers      OPS            Rounds  Iterations
------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
test_bench[strings.py-cpython]        17.1139 (1.0)       23.0330 (1.0)      18.3834 (1.0)      1.2884 (1.0)      17.9384 (1.0)      1.1421 (1.0)           5;3  54.3969 (1.0)          47           1
test_bench[strings.py-rustpython]     96.9285 (5.66)     102.4910 (4.45)     99.6611 (5.42)     2.0462 (1.59)     99.9837 (5.57)     3.6483 (3.19)          4;0  10.0340 (0.18)          9           1
------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------

Legend:
  Outliers: 1 Standard Deviation from Mean; 1.5 IQR (InterQuartile Range) from 1st Quartile and 3rd Quartile.
  OPS: Operations Per Second, computed as 1 / Mean
===================================================================================== 2 passed, 4 deselected in 3.04s ======================================================================================
```

### Related
The reverse iterator could also use a similar approach, although finding the last character in a string slice seems more difficult than finding the first.

---

I'm new to rust. Is this a decent solution? I looked into using a the chars iterator directly, but I'm not sure if the lifecycle management of that could be matched with the reference counting here in a nice way.