### PR TITLE
fix line continuation parsing

### DIFF
--- a/parser/src/error.rs
+++ b/parser/src/error.rs
@@ -27,6 +27,7 @@ pub enum LexicalErrorType {
     DuplicateKeywordArgumentError,
     UnrecognizedToken { tok: char },
     FStringError(FStringErrorType),
+    LineContinuationError,
     OtherError(String),
 }
 
@@ -54,6 +55,9 @@ impl fmt::Display for LexicalErrorType {
             }
             LexicalErrorType::UnrecognizedToken { tok } => {
                 write!(f, "Got unexpected token {}", tok)
+            }
+            LexicalErrorType::LineContinuationError => {
+                write!(f, "unexpected character after line continuation character")
             }
             LexicalErrorType::OtherError(msg) => write!(f, "{}", msg),
         }

--- a/tests/snippets/funky_syntax.py
+++ b/tests/snippets/funky_syntax.py
@@ -1,3 +1,4 @@
+import traceback
 
 a = 2
 b = 2 + 4 if a < 5 else 'boe'
@@ -12,3 +13,10 @@ e = lambda x: 1 if x else 0
 assert e(True) == 1
 assert e(False) == 0
 
+try:
+	a = "aaaa" + \
+		"bbbb"
+	1/0
+except ZeroDivisionError as ex:
+	tb = traceback.extract_tb(ex.__traceback__)
+	assert tb[0].lineno == 19

--- a/tests/snippets/invalid_syntax.py
+++ b/tests/snippets/invalid_syntax.py
@@ -51,3 +51,12 @@ with assert_raises(TabError):
 
 with assert_raises(SyntaxError):
     compile('0xX', 'test.py', 'exec')
+
+
+src = """
+"aaaa" \a
+"bbbb"
+"""
+
+with assert_raises(SyntaxError):
+    compile(src, 'test.py', 'exec')


### PR DESCRIPTION
Currently when we had a line continuation all lines numbers after were shifted by one. For example:
```py
a = "aaaa" + \
		"bbbb"
1/0
```
Would say the exception was in line 2 instead of 3.