### PR TITLE
Fix comparison operator

### DIFF
--- a/Lib/test/test_compare.py
+++ b/Lib/test/test_compare.py
@@ -70,8 +70,6 @@ class ComparisonTest(unittest.TestCase):
         Left() != Right()
         self.assertSequenceEqual(calls, ['Left.__eq__', 'Right.__ne__'])
 
-    # TODO: RUSTPYTHON
-    @unittest.expectedFailure
     def test_ne_low_priority(self):
         """object.__ne__() should not invoke reflected __eq__()"""
         calls = []


### PR DESCRIPTION
This PR solves `test_ne_low_priority` by implementing `PyObject_RichCompare` to `vm._cmp`.