### PR TITLE
Split rust test and snippets in github actions

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -7,7 +7,25 @@ name: CI
 
 jobs:
   rust_tests:
-    name: Run tests
+    name: Run rust tests
+    runs-on:  ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [macos-latest, ubuntu-latest, windows-latest]
+      fail-fast: false
+    steps:
+      - uses: actions/checkout@master
+      - name: Convert symlinks to hardlink (windows only)
+        run: powershell.exe scripts/symlinks-to-hardlinks.ps1
+        if: matrix.os == 'windows-latest'
+      - name: run rust tests
+        uses: actions-rs/cargo@v1
+        with:
+          command: test
+          args: --verbose --all
+
+  snippets:
+    name: Run snippets tests
     runs-on:  ${{ matrix.os }}
     strategy:
       matrix:
@@ -22,12 +40,7 @@ jobs:
         uses: actions-rs/cargo@v1
         with:
           command: build
-          args: --verbose --all
-      - name: run rust tests
-        uses: actions-rs/cargo@v1
-        with:
-          command: test
-          args: --verbose --all
+          args: --release --verbose --all
       - uses: actions/setup-python@v1
         with:
           python-version: 3.6


### PR DESCRIPTION
This will decrease the CI time from ~25 min to ~18 min. The github actions [quotas](https://help.github.com/en/actions/automating-your-workflow-with-github-actions/about-github-actions#usage-limits) are 20 concurrent builds (5 macOS) so I think this should be OK.