### PR TITLE
Add gitpod configuration

### DIFF
--- a/.gitpod.Dockerfile
+++ b/.gitpod.Dockerfile
@@ -1,0 +1,13 @@
+FROM gitpod/workspace-full
+
+USER gitpod
+
+# Update Rust to the latest version
+RUN rm -rf ~/.rustup && ~/.cargo/bin/rustup update stable
+
+# Set up wasm-pack and wasm32-unknown-unknown for rustpython_wasm
+RUN export PATH=$HOME/.cargo/bin:$PATH && \
+    curl https://rustwasm.github.io/wasm-pack/installer/init.sh -sSf | sh && \
+    rustup target add wasm32-unknown-unknown
+
+USER root

--- a/.gitpod.Dockerfile
+++ b/.gitpod.Dockerfile
@@ -3,10 +3,11 @@ FROM gitpod/workspace-full
 USER gitpod
 
 # Update Rust to the latest version
-RUN rm -rf ~/.rustup && ~/.cargo/bin/rustup update stable
-
-# Set up wasm-pack and wasm32-unknown-unknown for rustpython_wasm
-RUN export PATH=$HOME/.cargo/bin:$PATH && \
+RUN rm -rf ~/.rustup && \
+    export PATH=$HOME/.cargo/bin:$PATH && \
+    rustup update stable && \
+    rustup component add rls && \
+    # Set up wasm-pack and wasm32-unknown-unknown for rustpython_wasm
     curl https://rustwasm.github.io/wasm-pack/installer/init.sh -sSf | sh && \
     rustup target add wasm32-unknown-unknown
 

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -1,0 +1,2 @@
+image:
+  file: .gitpod.Dockerfile

--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ A Python-3 (CPython >= 3.5.0) Interpreter written in Rust :snake: :scream:
 [![Crates.io](https://img.shields.io/crates/v/rustpython)](https://crates.io/crates/rustpython)
 [![dependency status](https://deps.rs/crate/rustpython/0.1.1/status.svg)](https://deps.rs/crate/rustpython/0.1.1)
 [![WAPM package](https://wapm.io/package/rustpython/badge.svg?style=flat)](https://wapm.io/package/rustpython)
+[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io#https://github.com/RustPython/RustPython)
 
 ## Usage
 

--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ A Python-3 (CPython >= 3.5.0) Interpreter written in Rust :snake: :scream:
 
 [![Build Status](https://travis-ci.org/RustPython/RustPython.svg?branch=master)](https://travis-ci.org/RustPython/RustPython)
 [![Build Status](https://dev.azure.com/ryan0463/ryan/_apis/build/status/RustPython.RustPython?branchName=master)](https://dev.azure.com/ryan0463/ryan/_build/latest?definitionId=1&branchName=master)
+[![Build Status](https://github.com/RustPython/RustPython/workflows/CI/badge.svg)](https://github.com/RustPython/RustPython/actions?query=workflow%3ACI)
 [![codecov](https://codecov.io/gh/RustPython/RustPython/branch/master/graph/badge.svg)](https://codecov.io/gh/RustPython/RustPython)
 [![License: MIT](https://img.shields.io/badge/License-MIT-green.svg)](https://opensource.org/licenses/MIT)
 [![Contributors](https://img.shields.io/github/contributors/RustPython/RustPython.svg)](https://github.com/RustPython/RustPython/graphs/contributors)
@@ -15,7 +16,7 @@ A Python-3 (CPython >= 3.5.0) Interpreter written in Rust :snake: :scream:
 [![Crates.io](https://img.shields.io/crates/v/rustpython)](https://crates.io/crates/rustpython)
 [![dependency status](https://deps.rs/crate/rustpython/0.1.1/status.svg)](https://deps.rs/crate/rustpython/0.1.1)
 [![WAPM package](https://wapm.io/package/rustpython/badge.svg?style=flat)](https://wapm.io/package/rustpython)
-[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io#https://github.com/RustPython/RustPython)
+[![Open in Gitpod](https://img.shields.io/static/v1?label=Open%20in&message=Gitpod&color=1aa6e4&logo=gitpod)](https://gitpod.io#https://github.com/RustPython/RustPython)
 
 ## Usage
 


### PR DESCRIPTION
Gitpod is a really neat tool that allows you to pop into a build environment for a project to play around with what how it works; I've been using it to develop RustPython while away from my main computer and I figured I'd add explicit support for it to the project.