### PR TITLE
Add a better injectModule method to WASM

### DIFF
--- a/benchmarks/bench.rs
+++ b/benchmarks/bench.rs
@@ -94,15 +94,14 @@ fn bench_rustpy_nbody(b: &mut test::Bencher) {
 
     let vm = VirtualMachine::default();
 
-    let code = match vm.compile(source, compile::Mode::Single, "<stdin>".to_owned()) {
-        Ok(code) => code,
-        Err(e) => panic!("{:?}", e),
-    };
+    let code = vm
+        .compile(source, compile::Mode::Exec, "<stdin>".to_owned())
+        .unwrap();
 
     b.iter(|| {
         let scope = vm.new_scope_with_builtins();
         let res: PyResult = vm.run_code_obj(code.clone(), scope);
-        assert!(res.is_ok());
+        vm.unwrap_pyresult(res);
     })
 }
 
@@ -113,14 +112,13 @@ fn bench_rustpy_mandelbrot(b: &mut test::Bencher) {
 
     let vm = VirtualMachine::default();
 
-    let code = match vm.compile(source, compile::Mode::Single, "<stdin>".to_owned()) {
-        Ok(code) => code,
-        Err(e) => panic!("{:?}", e),
-    };
+    let code = vm
+        .compile(source, compile::Mode::Exec, "<stdin>".to_owned())
+        .unwrap();
 
     b.iter(|| {
         let scope = vm.new_scope_with_builtins();
         let res: PyResult = vm.run_code_obj(code.clone(), scope);
-        assert!(res.is_ok());
+        vm.unwrap_pyresult(res);
     })
 }

--- a/bytecode/src/bytecode.rs
+++ b/bytecode/src/bytecode.rs
@@ -46,18 +46,18 @@ pub struct CodeObject {
     pub source_path: String,
     pub first_line_number: usize,
     pub obj_name: String, // Name of the object that created this code object
-    pub incognito: bool,
 }
 
 bitflags! {
     #[derive(Serialize, Deserialize)]
-    pub struct CodeFlags: u8 {
+    pub struct CodeFlags: u16 {
         const HAS_DEFAULTS = 0x01;
         const HAS_KW_ONLY_DEFAULTS = 0x02;
         const HAS_ANNOTATIONS = 0x04;
         const NEW_LOCALS = 0x08;
         const IS_GENERATOR = 0x10;
         const IS_COROUTINE = 0x20;
+        const INCOGNITO = 1 << 15;
     }
 }
 
@@ -394,7 +394,6 @@ impl CodeObject {
             source_path,
             first_line_number,
             obj_name,
-            incognito: false,
         }
     }
 
@@ -450,6 +449,10 @@ impl CodeObject {
             }
         }
         Display(self)
+    }
+
+    pub fn incognito(&self) -> bool {
+        self.flags.contains(CodeFlags::INCOGNITO)
     }
 }
 

--- a/bytecode/src/bytecode.rs
+++ b/bytecode/src/bytecode.rs
@@ -46,6 +46,7 @@ pub struct CodeObject {
     pub source_path: String,
     pub first_line_number: usize,
     pub obj_name: String, // Name of the object that created this code object
+    pub incognito: bool,
 }
 
 bitflags! {
@@ -393,6 +394,7 @@ impl CodeObject {
             source_path,
             first_line_number,
             obj_name,
+            incognito: false,
         }
     }
 

--- a/bytecode/src/bytecode.rs
+++ b/bytecode/src/bytecode.rs
@@ -57,7 +57,6 @@ bitflags! {
         const NEW_LOCALS = 0x08;
         const IS_GENERATOR = 0x10;
         const IS_COROUTINE = 0x20;
-        const INCOGNITO = 1 << 15;
     }
 }
 
@@ -449,10 +448,6 @@ impl CodeObject {
             }
         }
         Display(self)
-    }
-
-    pub fn incognito(&self) -> bool {
-        self.flags.contains(CodeFlags::INCOGNITO)
     }
 }
 

--- a/compiler/src/compile.rs
+++ b/compiler/src/compile.rs
@@ -39,17 +39,10 @@ pub struct CompileOpts {
     /// How optimized the bytecode output should be; any optimize > 0 does
     /// not emit assert statements
     pub optimize: u8,
-    /// Whether introspection on defined functions/other items should be allowed;
-    /// e.g. when true, `func.__globals__` throws an error (where func is a function defined
-    /// in an incognito context)
-    pub incognito: bool,
 }
 impl Default for CompileOpts {
     fn default() -> Self {
-        CompileOpts {
-            optimize: 0,
-            incognito: false,
-        }
+        CompileOpts { optimize: 0 }
     }
 }
 
@@ -188,9 +181,7 @@ impl<O: OutputStream> Compiler<O> {
         }
     }
 
-    fn push_output(&mut self, mut code: CodeObject) {
-        code.flags
-            .set(bytecode::CodeFlags::INCOGNITO, self.opts.incognito);
+    fn push_output(&mut self, code: CodeObject) {
         self.output_stack.push(code.into());
     }
 

--- a/compiler/src/compile.rs
+++ b/compiler/src/compile.rs
@@ -189,7 +189,8 @@ impl<O: OutputStream> Compiler<O> {
     }
 
     fn push_output(&mut self, mut code: CodeObject) {
-        code.incognito = self.opts.incognito;
+        code.flags
+            .set(bytecode::CodeFlags::INCOGNITO, self.opts.incognito);
         self.output_stack.push(code.into());
     }
 

--- a/compiler/src/compile.rs
+++ b/compiler/src/compile.rs
@@ -78,15 +78,15 @@ pub fn compile(
     match mode {
         Mode::Exec => {
             let ast = parser::parse_program(source)?;
-            compile_program(ast, source_path.clone(), opts)
+            compile_program(ast, source_path, opts)
         }
         Mode::Eval => {
             let statement = parser::parse_statement(source)?;
-            compile_statement_eval(statement, source_path.clone(), opts)
+            compile_statement_eval(statement, source_path, opts)
         }
         Mode::Single => {
             let ast = parser::parse_program(source)?;
-            compile_program_single(ast, source_path.clone(), opts)
+            compile_program_single(ast, source_path, opts)
         }
     }
 }
@@ -2141,12 +2141,7 @@ impl<O: OutputStream> Compiler<O> {
         features: &[ast::ImportSymbol],
     ) -> Result<(), CompileError> {
         if self.done_with_future_stmts {
-            return Err(CompileError {
-                error: CompileErrorType::InvalidFuturePlacement,
-                location: self.current_source_location.clone(),
-                source_path: self.source_path.clone(),
-                statement: None,
-            });
+            return Err(self.error(CompileErrorType::InvalidFuturePlacement));
         }
         for feature in features {
             match &*feature.symbol {
@@ -2156,12 +2151,7 @@ impl<O: OutputStream> Compiler<O> {
                 // "generator_stop" => {}
                 // "annotations" => {}
                 other => {
-                    return Err(CompileError {
-                        error: CompileErrorType::InvalidFutureFeature(other.to_owned()),
-                        location: self.current_source_location.clone(),
-                        source_path: self.source_path.clone(),
-                        statement: None,
-                    })
+                    return Err(self.error(CompileErrorType::InvalidFutureFeature(other.to_owned())))
                 }
             }
         }

--- a/compiler/src/error.rs
+++ b/compiler/src/error.rs
@@ -58,6 +58,8 @@ pub enum CompileErrorType {
     InvalidAwait,
     AsyncYieldFrom,
     AsyncReturnValue,
+    InvalidFuturePlacement,
+    InvalidFutureFeature(String),
 }
 
 impl CompileError {
@@ -105,6 +107,12 @@ impl fmt::Display for CompileError {
             CompileErrorType::AsyncYieldFrom => "'yield from' inside async function".to_owned(),
             CompileErrorType::AsyncReturnValue => {
                 "'return' with value inside async generator".to_owned()
+            }
+            CompileErrorType::InvalidFuturePlacement => {
+                "from __future__ imports must occur at the beginning of the file".to_owned()
+            }
+            CompileErrorType::InvalidFutureFeature(feat) => {
+                format!("future feature {} is not defined", feat)
             }
         };
 

--- a/derive/src/compile_bytecode.rs
+++ b/derive/src/compile_bytecode.rs
@@ -49,7 +49,7 @@ impl CompilationSource {
         module_name: String,
         origin: F,
     ) -> Result<CodeObject, Diagnostic> {
-        compile::compile(source, mode, module_name, 0).map_err(|err| {
+        compile::compile(source, mode, module_name, Default::default()).map_err(|err| {
             Diagnostic::spans_error(
                 self.span,
                 format!("Python compile error from {}: {}", origin(), err),

--- a/examples/dis.rs
+++ b/examples/dis.rs
@@ -62,9 +62,14 @@ fn main() {
     let optimize = matches.occurrences_of("optimize") as u8;
     let scripts = matches.values_of_os("scripts").unwrap();
 
+    let opts = compile::CompileOpts {
+        optimize,
+        ..Default::default()
+    };
+
     for script in scripts.map(Path::new) {
         if script.exists() && script.is_file() {
-            let res = display_script(script, mode, optimize, expand_codeobjects);
+            let res = display_script(script, mode, opts.clone(), expand_codeobjects);
             if let Err(e) = res {
                 error!("Error while compiling {:?}: {}", script, e);
             }
@@ -77,11 +82,11 @@ fn main() {
 fn display_script(
     path: &Path,
     mode: compile::Mode,
-    optimize: u8,
+    opts: compile::CompileOpts,
     expand_codeobjects: bool,
 ) -> Result<(), Box<dyn Error>> {
     let source = fs::read_to_string(path)?;
-    let code = compile::compile(&source, mode, path.to_string_lossy().into_owned(), optimize)?;
+    let code = compile::compile(&source, mode, path.to_string_lossy().into_owned(), opts)?;
     println!("{}:", path.display());
     if expand_codeobjects {
         println!("{}", code.display_expand_codeobjects());

--- a/tests/snippets/function.py
+++ b/tests/snippets/function.py
@@ -13,6 +13,7 @@ assert foo.__doc__ == "test"
 assert foo.__name__ == "foo"
 assert foo.__qualname__ == "foo"
 assert foo.__module__ == "function"
+assert foo.__globals__ is globals()
 
 def my_func(a,):
     return a+2

--- a/tests/snippets/invalid_syntax.py
+++ b/tests/snippets/invalid_syntax.py
@@ -7,12 +7,9 @@ def valid_func():
 yield 2
 """
 
-try:
+with assert_raises(SyntaxError) as ae:
     compile(src, 'test.py', 'exec')
-except SyntaxError as ex:
-    assert ex.lineno == 5
-else:
-    raise AssertionError("Must throw syntax error")
+assert ae.exception.lineno == 5
 
 src = """
 if True:
@@ -60,3 +57,23 @@ src = """
 
 with assert_raises(SyntaxError):
     compile(src, 'test.py', 'exec')
+
+src = """
+from __future__ import not_a_real_future_feature
+"""
+
+with assert_raises(SyntaxError):
+    compile(src, 'test.py', 'exec')
+
+src = """
+a = 1
+from __future__ import print_function
+"""
+
+with assert_raises(SyntaxError):
+    compile(src, 'test.py', 'exec')
+
+src = """
+from __future__ import print_function
+"""
+compile(src, 'test.py', 'exec')

--- a/vm/src/import.rs
+++ b/vm/src/import.rs
@@ -74,13 +74,8 @@ pub fn import_file(
     file_path: String,
     content: String,
 ) -> PyResult {
-    let code_obj = compile::compile(
-        &content,
-        compile::Mode::Exec,
-        file_path,
-        vm.settings.optimize,
-    )
-    .map_err(|err| vm.new_syntax_error(&err))?;
+    let code_obj = compile::compile(&content, compile::Mode::Exec, file_path, vm.compile_opts())
+        .map_err(|err| vm.new_syntax_error(&err))?;
     import_codeobj(vm, module_name, code_obj, true)
 }
 

--- a/vm/src/obj/objcode.rs
+++ b/vm/src/obj/objcode.rs
@@ -103,7 +103,7 @@ impl PyCodeRef {
     }
 
     #[pyproperty]
-    fn co_flags(self) -> u8 {
+    fn co_flags(self) -> u16 {
         self.code.flags.bits()
     }
 }

--- a/vm/src/obj/objframe.rs
+++ b/vm/src/obj/objframe.rs
@@ -31,7 +31,7 @@ impl FrameRef {
 
     #[pyproperty]
     fn f_globals(self, vm: &VirtualMachine) -> PyResult<PyDictRef> {
-        if self.code.incognito {
+        if self.code.incognito() {
             Err(vm.new_type_error("Can't get f_globals on an incognito frame".to_owned()))
         } else {
             Ok(self.scope.globals.clone())
@@ -40,7 +40,7 @@ impl FrameRef {
 
     #[pyproperty]
     fn f_locals(self, vm: &VirtualMachine) -> PyResult<PyDictRef> {
-        if self.code.incognito {
+        if self.code.incognito() {
             Err(vm.new_type_error("Can't get f_locals on an incognito frame".to_owned()))
         } else {
             Ok(self.scope.get_locals())

--- a/vm/src/obj/objframe.rs
+++ b/vm/src/obj/objframe.rs
@@ -30,21 +30,13 @@ impl FrameRef {
     }
 
     #[pyproperty]
-    fn f_globals(self, vm: &VirtualMachine) -> PyResult<PyDictRef> {
-        if self.code.incognito() {
-            Err(vm.new_type_error("Can't get f_globals on an incognito frame".to_owned()))
-        } else {
-            Ok(self.scope.globals.clone())
-        }
+    fn f_globals(self) -> PyDictRef {
+        self.scope.globals.clone()
     }
 
     #[pyproperty]
-    fn f_locals(self, vm: &VirtualMachine) -> PyResult<PyDictRef> {
-        if self.code.incognito() {
-            Err(vm.new_type_error("Can't get f_locals on an incognito frame".to_owned()))
-        } else {
-            Ok(self.scope.get_locals())
-        }
+    fn f_locals(self) -> PyDictRef {
+        self.scope.get_locals()
     }
 
     #[pyproperty]

--- a/vm/src/obj/objframe.rs
+++ b/vm/src/obj/objframe.rs
@@ -30,13 +30,21 @@ impl FrameRef {
     }
 
     #[pyproperty]
-    fn f_globals(self) -> PyDictRef {
-        self.scope.globals.clone()
+    fn f_globals(self, vm: &VirtualMachine) -> PyResult<PyDictRef> {
+        if self.code.incognito {
+            Err(vm.new_type_error("Can't get f_globals on an incognito frame".to_owned()))
+        } else {
+            Ok(self.scope.globals.clone())
+        }
     }
 
     #[pyproperty]
-    fn f_locals(self) -> PyDictRef {
-        self.scope.get_locals()
+    fn f_locals(self, vm: &VirtualMachine) -> PyResult<PyDictRef> {
+        if self.code.incognito {
+            Err(vm.new_type_error("Can't get f_locals on an incognito frame".to_owned()))
+        } else {
+            Ok(self.scope.get_locals())
+        }
     }
 
     #[pyproperty]

--- a/vm/src/obj/objfunction.rs
+++ b/vm/src/obj/objfunction.rs
@@ -281,7 +281,7 @@ impl PyFunction {
 
     #[pyproperty(magic)]
     fn globals(&self, vm: &VirtualMachine) -> PyResult<PyDictRef> {
-        if self.code.incognito {
+        if self.code.incognito() {
             Err(vm.new_type_error("Can't get __globals__ on an incognito function".to_owned()))
         } else {
             Ok(self.scope.globals.clone())

--- a/vm/src/obj/objfunction.rs
+++ b/vm/src/obj/objfunction.rs
@@ -280,12 +280,8 @@ impl PyFunction {
     }
 
     #[pyproperty(magic)]
-    fn globals(&self, vm: &VirtualMachine) -> PyResult<PyDictRef> {
-        if self.code.incognito() {
-            Err(vm.new_type_error("Can't get __globals__ on an incognito function".to_owned()))
-        } else {
-            Ok(self.scope.globals.clone())
-        }
+    fn globals(&self) -> PyDictRef {
+        self.scope.globals.clone()
     }
 }
 

--- a/vm/src/obj/objfunction.rs
+++ b/vm/src/obj/objfunction.rs
@@ -278,6 +278,15 @@ impl PyFunction {
     fn kwdefaults(&self) -> Option<PyDictRef> {
         self.kw_only_defaults.clone()
     }
+
+    #[pyproperty(magic)]
+    fn globals(&self, vm: &VirtualMachine) -> PyResult<PyDictRef> {
+        if self.code.incognito {
+            Err(vm.new_type_error("Can't get __globals__ on an incognito function".to_owned()))
+        } else {
+            Ok(self.scope.globals.clone())
+        }
+    }
 }
 
 #[pyclass]

--- a/vm/src/vm.rs
+++ b/vm/src/vm.rs
@@ -1009,7 +1009,6 @@ impl VirtualMachine {
     pub fn compile_opts(&self) -> CompileOpts {
         CompileOpts {
             optimize: self.settings.optimize,
-            ..Default::default()
         }
     }
 

--- a/wasm/demo/src/index.js
+++ b/wasm/demo/src/index.js
@@ -127,7 +127,7 @@ async function readPrompts() {
         try {
             terminalVM.execSingle(input);
         } catch (err) {
-            if (err instanceof SyntaxError && err.message.includes('EOF')) {
+            if (err.canContinue) {
                 continuing = true;
                 continue;
             } else if (err instanceof WebAssembly.RuntimeError) {

--- a/wasm/tests/test_demo.py
+++ b/wasm/tests/test_demo.py
@@ -1,8 +1,6 @@
 import time
 import sys
 
-from selenium import webdriver
-from selenium.webdriver.firefox.options import Options
 import pytest
 
 RUN_CODE_TEMPLATE = """

--- a/wasm/tests/test_inject_module.py
+++ b/wasm/tests/test_inject_module.py
@@ -1,5 +1,5 @@
 def test_inject_private(wdriver):
-    assert wdriver.execute_script(
+    wdriver.execute_script(
         """
 const vm = rp.vmStore.init("vm")
 vm.injectModule(
@@ -11,8 +11,17 @@ def get_thing(): return __thing()
 { __thing: () => 1 },
 true
 )
-return vm.execSingle(
-    `import mod; mod.get_thing() == 1 and "__thing" not in dir(mod)`
+vm.execSingle(
+`
+import mod
+assert mod.get_thing() == 1
+assert "__thing" not in dir(mod)
+try:
+    globs = mod.get_thing.__globals__
+except TypeError: pass
+else:
+    assert False, "incognito function.__globals__ didn't error"
+`
 );
         """
     )

--- a/wasm/tests/test_inject_module.py
+++ b/wasm/tests/test_inject_module.py
@@ -1,4 +1,4 @@
-def test_inject_private(wdriver):
+def test_inject_module_basic(wdriver):
     wdriver.execute_script(
         """
 const vm = rp.vmStore.init("vm")
@@ -15,12 +15,6 @@ vm.execSingle(
 `
 import mod
 assert mod.get_thing() == 1
-assert "__thing" not in dir(mod)
-try:
-    globs = mod.get_thing.__globals__
-except TypeError: pass
-else:
-    assert False, "incognito function.__globals__ didn't error"
 `
 );
         """

--- a/wasm/tests/test_inject_module.py
+++ b/wasm/tests/test_inject_module.py
@@ -1,0 +1,19 @@
+def test_inject_private(wdriver):
+    assert wdriver.execute_script(
+        """
+const vm = rp.vmStore.init("vm")
+vm.injectModule(
+"mod",
+`
+__all__ = ['get_thing']
+def get_thing(): return __thing()
+`,
+{ __thing: () => 1 },
+true
+)
+return vm.execSingle(
+    `import mod; mod.get_thing() == 1 and "__thing" not in dir(mod)`
+);
+        """
+    )
+


### PR DESCRIPTION
This allows for strict privacy for WASM modules, which is important in an environment like the browser, where most of the time you're running code on someone else's computer. The idea for this method would be to write a wrapper module around some possibly security-sensitive functions that you pass from js, and then allow arbitrary code to access that module. For [robot rumble](https://github.com/chicode/robot-rumble) (the successor to codingworkshops, the code learning platform), it might be used like:

```js
// vm.injectModule(name, source, imports?, strict_private?)
vm.injectModule(
    "robots",
    `
__all__ = ["export"]
def export(...): runRobot(...)
# robot-rumble "stdlib" source code
`,
    { runRobot: () => { ... } },
    true,
);
// later
vm.exec(userCode);
```

We don't want user code arbitrarily calling the `runRobot` function, so we wrap it in a module that makes sure that it *can't*, and also (ideally) provides a nicer, more pythonic interface. The `strict_private` parameter enables that; it runs the source code provided in one namespace with the JS imports, and copies only the items exported in `__all__` to a new namespace that is injected into `sys.modules`.