### PR TITLE
Fallback exit code to 0 in case of overflow

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -57,7 +57,7 @@ fn main() {
                 1 => match_class!(match args.as_slice()[0].clone() {
                     i @ PyInt => {
                         use num_traits::cast::ToPrimitive;
-                        process::exit(i.as_bigint().to_i32().unwrap());
+                        process::exit(i.as_bigint().to_i32().unwrap_or(0));
                     }
                     arg => {
                         if vm.is_none(&arg) {


### PR DESCRIPTION
Fixes #1742 

This PR changes the exit code to 0 if it overflows by replacing an `unwrap()` call with `unwrap_or(0)`. Let me know what you think @coolreader18!