### PR TITLE
Have wasm/demo's "test" npm script build the demo in release mode

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -124,6 +124,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@master
+      - name: Cache cargo dependencies
+        uses: actions/cache@v1
+        with:
+          key: ${{ runner.os }}-wasm-${{ hashFiles('**/Cargo.lock') }}
+          path: target
+          restore-keys: |
+            ${{ runner.os }}-wasm-
       - name: install wasm-pack
         run: curl https://rustwasm.github.io/wasm-pack/installer/init.sh -sSf | sh
       - name: install geckodriver

--- a/wasm/demo/package.json
+++ b/wasm/demo/package.json
@@ -24,7 +24,7 @@
         "dev": "webpack-dev-server -d",
         "build": "webpack",
         "dist": "webpack --mode production",
-        "test": "webpack && cd ../tests && pipenv run pytest"
+        "test": "webpack --mode production && cd ../tests && pipenv run pytest"
     },
     "repository": {
         "type": "git",


### PR DESCRIPTION
This should speed up WASM testing, as Rust actually compiles to wasm fairly quickly (and I think the time it takes to run the wasm tests is mostly rustpython_wasm setting itself up), and it will also fix the horrible performance issue that's on the demo page right now, as we've got a (38 MB!) debug build running in production.