### PR TITLE
Add as_integer_ratio to PyInt

### DIFF
--- a/tests/snippets/ints.py
+++ b/tests/snippets/ints.py
@@ -61,6 +61,12 @@ assert (6).__rmod__(10) == 4
 with assert_raises(ZeroDivisionError):
     (0).__rmod__(10)
 
+# as_integer_ratio
+# TODO uncomment the following tests once #1705 lands (or when the CPython version in test pipeline is upgraded to 3.8)
+# assert (42).as_integer_ratio() == (42, 1)
+# assert (-17).as_integer_ratio() == (-17, 1)
+# assert (0).as_integer_ratio() == (0, 1)
+
 # real/imag attributes
 assert (1).real == 1
 assert (1).imag == 0

--- a/vm/src/obj/objint.rs
+++ b/vm/src/obj/objint.rs
@@ -521,6 +521,14 @@ impl PyInt {
         size_of::<Self>() + ((self.value.bits() + 7) & !7) / 8
     }
 
+    #[pymethod(name = "as_integer_ratio")]
+    fn as_integer_ratio(&self, vm: &VirtualMachine) -> PyResult {
+        Ok(vm.ctx.new_tuple(vec![
+            vm.ctx.new_bigint(&self.value),
+            vm.ctx.new_bigint(&BigInt::one()),
+        ]))
+    }
+
     #[pymethod]
     fn bit_length(&self) -> usize {
         self.value.bits()


### PR DESCRIPTION
This pull request adds support for `as_integer_ratio` to the VM's integer number type, `PyInt`.

## Current behavior on master
```python
>>>>> (10).as_integer_ratio()        
Traceback (most recent call last):                                             
  File "<stdin>", line 1, in <module>
AttributeError: 'int' object has no attribute 'as_integer_ratio'
>>>>> 
```

## Behavior after this pull request
```python
>>>>> (10).as_integer_ratio()
(10, 1)
>>>>> 
```