### PR TITLE
Make _random work on wasm

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -636,6 +636,7 @@ dependencies = [
  "cfg-if",
  "libc",
  "wasi",
+ "wasm-bindgen",
 ]
 
 [[package]]

--- a/Lib/random.py
+++ b/Lib/random.py
@@ -41,7 +41,13 @@ from warnings import warn as _warn
 from types import MethodType as _MethodType, BuiltinMethodType as _BuiltinMethodType
 from math import log as _log, exp as _exp, pi as _pi, e as _e, ceil as _ceil
 from math import sqrt as _sqrt, acos as _acos, cos as _cos, sin as _sin
-from os import urandom as _urandom
+try:
+    from os import urandom as _urandom
+except ImportError:
+    # On wasm, _random.Random.random() does give a proper random value, but
+    # we don't have the os module
+    def _urandom(*args, **kwargs):
+        raise NotImplementedError("urandom")
 from _collections_abc import Set as _Set, Sequence as _Sequence
 from hashlib import sha512 as _sha512
 import itertools as _itertools

--- a/vm/Cargo.toml
+++ b/vm/Cargo.toml
@@ -30,9 +30,9 @@ num-traits = "0.2.8"
 num-integer = "0.1.41"
 num-rational = "0.2.2"
 num-iter = "0.1.39"
-rand = "0.7"
+rand = { version = "0.7", features = ["wasm-bindgen"] }
 rand_core = "0.5"
-getrandom = "0.1"
+getrandom = { version = "0.1", features = ["wasm-bindgen"] }
 log = "0.4"
 rustpython-derive = {path = "../derive", version = "0.1.1"}
 rustpython-parser = {path = "../parser", optional = true, version = "0.1.1"}


### PR DESCRIPTION
Adds the `wasm-bindgen` feature to rand/getrandom, and makes the `os` module optional for the `random` module.