### PR TITLE
Update f-string errors, handle != in f-string.

### DIFF
--- a/parser/src/error.rs
+++ b/parser/src/error.rs
@@ -81,6 +81,7 @@ pub struct FStringError {
 pub enum FStringErrorType {
     UnclosedLbrace,
     UnopenedRbrace,
+    ExpectedRbrace,
     InvalidExpression(Box<ParseErrorType>),
     InvalidConversionFlag,
     EmptyExpression,
@@ -91,8 +92,9 @@ pub enum FStringErrorType {
 impl fmt::Display for FStringErrorType {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match self {
-            FStringErrorType::UnclosedLbrace => write!(f, "Unclosed '('"),
-            FStringErrorType::UnopenedRbrace => write!(f, "Unopened ')'"),
+            FStringErrorType::UnclosedLbrace => write!(f, "Unclosed '{{'"),
+            FStringErrorType::UnopenedRbrace => write!(f, "Unopened '}}'"),
+            FStringErrorType::ExpectedRbrace => write!(f, "Expected '}}' after conversion flag."),
             FStringErrorType::InvalidExpression(error) => {
                 write!(f, "Invalid expression: {}", error)
             }

--- a/parser/src/fstring.rs
+++ b/parser/src/fstring.rs
@@ -29,39 +29,25 @@ impl<'a> FStringParser<'a> {
 
         while let Some(ch) = self.chars.next() {
             match ch {
-                '!' if delims.is_empty() => {
-                    let x = self.chars.next();
-                    if let Some('=') = x {
-                        expression.push(ch);
-                        expression.push('=');
-                    } else {
-                        if expression.is_empty() {
-                            return Err(EmptyExpression);
-                        }
+                '!' if delims.is_empty() && self.chars.peek() != Some(&'=') => {
+                    if expression.trim().is_empty() {
+                        return Err(EmptyExpression);
+                    }
 
-                        conversion = Some(match x {
-                            Some('s') => ConversionFlag::Str,
-                            Some('a') => ConversionFlag::Ascii,
-                            Some('r') => ConversionFlag::Repr,
-                            Some(_) => {
-                                return Err(InvalidConversionFlag);
-                            }
-                            None => {
-                                break;
-                            }
-                        });
-
-                        match self.chars.peek() {
-                            Some('}') => {
-                                continue;
-                            }
-                            Some(_) => {
-                                return Err(ExpectedRbrace);
-                            }
-                            None => {
-                                break;
-                            }
+                    conversion = Some(match self.chars.next() {
+                        Some('s') => ConversionFlag::Str,
+                        Some('a') => ConversionFlag::Ascii,
+                        Some('r') => ConversionFlag::Repr,
+                        Some(_) => {
+                            return Err(InvalidConversionFlag);
                         }
+                        None => {
+                            return Err(ExpectedRbrace);
+                        }
+                    });
+
+                    if self.chars.peek() != Some(&'}') {
+                        return Err(ExpectedRbrace);
                     }
                 }
                 ':' if delims.is_empty() => {
@@ -314,16 +300,23 @@ mod tests {
 
     #[test]
     fn test_parse_invalid_fstring() {
-        assert_eq!(parse_fstring("{"), Err(UnclosedLbrace));
-        assert_eq!(parse_fstring("}"), Err(UnopenedRbrace));
-        assert_eq!(parse_fstring("{5!a"), Err(UnclosedLbrace));
+        assert_eq!(parse_fstring("{5!a"), Err(ExpectedRbrace));
         assert_eq!(parse_fstring("{5!a1}"), Err(ExpectedRbrace));
+        assert_eq!(parse_fstring("{5!"), Err(ExpectedRbrace));
+
         assert_eq!(parse_fstring("abc{!a 'cat'}"), Err(EmptyExpression));
-        assert_eq!(parse_fstring("{!x}"), Err(EmptyExpression));
+        assert_eq!(parse_fstring("{!a"), Err(EmptyExpression));
+        assert_eq!(parse_fstring("{ !a}"), Err(EmptyExpression));
+
+        assert_eq!(parse_fstring("{5!}"), Err(InvalidConversionFlag));
+        assert_eq!(parse_fstring("{5!x}"), Err(InvalidConversionFlag));
 
         assert_eq!(parse_fstring("{a:{a:{b}}"), Err(ExpressionNestedTooDeeply));
+
         assert_eq!(parse_fstring("{a:b}}"), Err(UnopenedRbrace));
+        assert_eq!(parse_fstring("}"), Err(UnopenedRbrace));
         assert_eq!(parse_fstring("{a:{b}"), Err(UnclosedLbrace));
+        assert_eq!(parse_fstring("{"), Err(UnclosedLbrace));
 
         // TODO: check for InvalidExpression enum?
         assert!(parse_fstring("{class}").is_err());
@@ -333,6 +326,6 @@ mod tests {
     fn test_parse_fstring_not_equals() {
         let source = String::from("{1 != 2}");
         let parse_ast = parse_fstring(&source);
-        assert_ne!(parse_ast, Err(InvalidConversionFlag));
+        assert!(parse_ast.is_ok());
     }
 }


### PR DESCRIPTION
Reopened the pull request due to unusual git behaviour. 

This pull request addresses #1770.

It correctly handles != inside of f strings, as well as f"{!a}" not returning an EmptyExpression error.

This also adds an error for conversion flags not being followed by brace characters, which would otherwise be a token error, unlike the Python implementation.

It also changes the print out for UnopenedRbrace / UnclosedLbrace to correctly print braces instead of brackets.

I've also included tests for expected brace characters and not equals operations inside of braces, as well as the expected EmptyExpression errors for f"{!a}".

