### PR TITLE
Handle MemoryError for list and strings.

### DIFF
--- a/vm/src/obj/objlist.rs
+++ b/vm/src/obj/objlist.rs
@@ -477,7 +477,7 @@ impl PyList {
                 .collect();
             return Ok(vm.ctx.new_list(new_elements));
         }
-        return Err(vm.new_memory_error("".to_owned()));
+        Err(vm.new_memory_error("".to_owned()))
     }
 
     #[pymethod(name = "__rmul__")]
@@ -486,15 +486,15 @@ impl PyList {
     }
 
     #[pymethod(name = "__imul__")]
-    fn imul(zelf: PyRef<Self>, counter: isize) -> PyResult<Self> {
+    fn imul(zelf: PyRef<Self>, counter: isize, vm: &VirtualMachine) -> PyResult<PyRef<Self>> {
         if counter < 0 || zelf.len() * (counter as usize) < MAX_MEMORY_SIZE {
             let new_elements = sequence::seq_mul(&zelf.borrow_sequence(), counter)
                 .cloned()
                 .collect();
             zelf.elements.replace(new_elements);
-            return Ok(*zelf);
+            return Ok(zelf);
         }
-        return Err(vm.new_memory_error("".to_owned()));
+        Err(vm.new_memory_error("".to_owned()))
     }
 
     #[pymethod]

--- a/vm/src/obj/objstr.rs
+++ b/vm/src/obj/objstr.rs
@@ -337,7 +337,7 @@ impl PyString {
                     vm.new_overflow_error("cannot fit 'int' into an index-sized integer".to_owned())
                 });
         }
-        return Err(vm.new_memory_error("".to_owned()));
+        Err(vm.new_memory_error("".to_owned()))
     }
 
     #[pymethod(name = "__rmul__")]

--- a/vm/src/vm.rs
+++ b/vm/src/vm.rs
@@ -73,7 +73,7 @@ pub struct VirtualMachine {
 }
 
 pub const NSIG: usize = 64;
-pub const MAX_MEMORY_SIZE: usize = (std::usize::MAX >> 3)+1;
+pub const MAX_MEMORY_SIZE: usize = (std::usize::MAX >> 3) + 1;
 
 #[derive(Copy, Clone)]
 pub enum InitParameter {

--- a/vm/src/vm.rs
+++ b/vm/src/vm.rs
@@ -73,7 +73,7 @@ pub struct VirtualMachine {
 }
 
 pub const NSIG: usize = 64;
-pub const MAX_MEMORY_SIZE: usize = 0x2000_0000_0000_0000;
+pub const MAX_MEMORY_SIZE: usize = (std::usize::MAX >> 3)+1;
 
 #[derive(Copy, Clone)]
 pub enum InitParameter {

--- a/vm/src/vm.rs
+++ b/vm/src/vm.rs
@@ -73,6 +73,7 @@ pub struct VirtualMachine {
 }
 
 pub const NSIG: usize = 64;
+pub const MAX_MEMORY_SIZE: usize = 0x2000_0000_0000_0000;
 
 #[derive(Copy, Clone)]
 pub enum InitParameter {
@@ -381,6 +382,11 @@ impl VirtualMachine {
     pub fn new_type_error(&self, msg: String) -> PyBaseExceptionRef {
         let type_error = self.ctx.exceptions.type_error.clone();
         self.new_exception_msg(type_error, msg)
+    }
+
+    pub fn new_memory_error(&self, msg: String) -> PyBaseExceptionRef {
+        let memory_error = self.ctx.exceptions.memory_error.clone();
+        self.new_exception_msg(memory_error, msg)
     }
 
     pub fn new_name_error(&self, msg: String) -> PyBaseExceptionRef {


### PR DESCRIPTION
This aims to address #1750 by raising a Memory error for excessively large allocations. It adds a MAX_MEMORY_SIZE const to VM which is then used by objlist.rs and objstr.rs when doing imul or mul operations. 