### PR TITLE
Make PyObject.typ a Rc<PyObject<PyClass>>

### DIFF
--- a/vm/src/obj/objmemory.rs
+++ b/vm/src/obj/objmemory.rs
@@ -1,8 +1,8 @@
-use std::borrow::Borrow;
-
 use super::objbyteinner::try_as_byte;
 use super::objtype::{issubclass, PyClassRef};
-use crate::pyobject::{PyClassImpl, PyContext, PyObjectRef, PyRef, PyResult, PyValue};
+use crate::pyobject::{
+    PyClassImpl, PyContext, PyObjectRef, PyRef, PyResult, PyValue, TypeProtocol,
+};
 use crate::stdlib::array::PyArray;
 use crate::vm::VirtualMachine;
 
@@ -26,12 +26,12 @@ impl PyMemoryView {
         bytes_object: PyObjectRef,
         vm: &VirtualMachine,
     ) -> PyResult<PyMemoryViewRef> {
-        let object_type = bytes_object.typ.borrow();
+        let object_type = bytes_object.class();
 
-        if issubclass(object_type, &vm.ctx.types.memoryview_type)
-            || issubclass(object_type, &vm.ctx.types.bytes_type)
-            || issubclass(object_type, &vm.ctx.types.bytearray_type)
-            || issubclass(object_type, &PyArray::class(vm))
+        if issubclass(&object_type, &vm.ctx.types.memoryview_type)
+            || issubclass(&object_type, &vm.ctx.types.bytes_type)
+            || issubclass(&object_type, &vm.ctx.types.bytearray_type)
+            || issubclass(&object_type, &PyArray::class(vm))
         {
             PyMemoryView {
                 obj_ref: bytes_object.clone(),

--- a/vm/src/obj/objtype.rs
+++ b/vm/src/obj/objtype.rs
@@ -526,7 +526,7 @@ pub fn new(
             slots: RefCell::default(),
         },
         dict: None,
-        typ,
+        typ: typ.into_generic_pyobj(),
     }
     .into_ref();
 

--- a/vm/src/obj/objtype.rs
+++ b/vm/src/obj/objtype.rs
@@ -526,7 +526,7 @@ pub fn new(
             slots: RefCell::default(),
         },
         dict: None,
-        typ: typ.into_generic_pyobj(),
+        typ: typ.into_typed_pyobj(),
     }
     .into_ref();
 

--- a/vm/src/pyobject.rs
+++ b/vm/src/pyobject.rs
@@ -649,7 +649,7 @@ impl PyObject<dyn PyObjectPayload> {
         }
     }
 
-    /// Dowcast this PyObjectRef to an `Rc<PyObject<T>>`. The [`downcast`](#method.downcast) method
+    /// Downcast this PyObjectRef to an `Rc<PyObject<T>>`. The [`downcast`](#method.downcast) method
     /// is generally preferred, as the `PyRef<T>` it returns implements `Deref<Target=T>`, and
     /// therefore can be used similarly to an `&T`.
     pub fn downcast_generic<T: PyObjectPayload>(

--- a/vm/src/pyobject.rs
+++ b/vm/src/pyobject.rs
@@ -571,7 +571,7 @@ impl PyContext {
 
     pub fn new_base_object(&self, class: PyClassRef, dict: Option<PyDictRef>) -> PyObjectRef {
         PyObject {
-            typ: class.into_generic_pyobj(),
+            typ: class.into_typed_pyobj(),
             dict: dict.map(RefCell::new),
             payload: objobject::PyBaseObject,
         }
@@ -722,7 +722,7 @@ impl<T: PyValue> PyRef<T> {
         self.obj.class()
     }
 
-    pub fn into_generic_pyobj(self) -> Rc<PyObject<T>> {
+    pub fn into_typed_pyobj(self) -> Rc<PyObject<T>> {
         self.into_object().downcast_generic().unwrap()
     }
 }
@@ -1123,7 +1123,7 @@ where
     #[allow(clippy::new_ret_no_self)]
     pub fn new(payload: T, typ: PyClassRef, dict: Option<PyDictRef>) -> PyObjectRef {
         PyObject {
-            typ: typ.into_generic_pyobj(),
+            typ: typ.into_typed_pyobj(),
             dict: dict.map(RefCell::new),
             payload,
         }

--- a/vm/src/types.rs
+++ b/vm/src/types.rs
@@ -38,9 +38,9 @@ use crate::obj::objtype::{self, PyClass, PyClassRef};
 use crate::obj::objweakproxy;
 use crate::obj::objweakref;
 use crate::obj::objzip;
-use crate::pyobject::{PyAttributes, PyContext, PyObject, PyObjectPayload};
+use crate::pyobject::{PyAttributes, PyContext, PyObject};
 use std::cell::RefCell;
-use std::mem::{self, MaybeUninit};
+use std::mem::MaybeUninit;
 use std::ptr;
 use std::rc::Rc;
 
@@ -312,41 +312,14 @@ fn init_type_hierarchy() -> (PyClassRef, PyClassRef) {
         let type_type_ptr =
             Rc::into_raw(type_type.clone()) as *mut MaybeUninit<PyClassObj> as *mut PyClassObj;
 
-        // same as std::raw::TraitObject (which is unstable, but accurate)
-        #[repr(C)]
-        struct TraitObject {
-            data: *mut (),
-            vtable: *mut (),
-        }
-
-        let pyclass_vptr = {
-            // dummy PyClass
-            let cls = PyClass {
-                name: Default::default(),
-                bases: Default::default(),
-                mro: Default::default(),
-                subclasses: Default::default(),
-                attributes: Default::default(),
-                slots: Default::default(),
-            };
-            // so that we can get the vtable ptr of PyClass for PyObjectPayload
-            mem::transmute::<_, TraitObject>(&cls as &dyn PyObjectPayload).vtable
-        };
-
-        let write_typ_ptr = |ptr: *mut PyClassObj, type_type: UninitRef<PyClassObj>| {
-            // turn type_type into a trait object, using the vtable for PyClass we got earlier
-            let type_type = mem::transmute(TraitObject {
-                data: mem::transmute(type_type),
-                vtable: pyclass_vptr,
-            });
-            ptr::write(
-                &mut (*ptr).typ as *mut PyClassRef as *mut MaybeUninit<PyClassRef>,
-                type_type,
-            );
-        };
-
-        write_typ_ptr(object_type_ptr, type_type.clone());
-        write_typ_ptr(type_type_ptr, type_type);
+        ptr::write(
+            &mut (*object_type_ptr).typ as *mut Rc<PyClassObj> as *mut UninitRef<PyClassObj>,
+            type_type.clone(),
+        );
+        ptr::write(
+            &mut (*type_type_ptr).typ as *mut Rc<PyClassObj> as *mut UninitRef<PyClassObj>,
+            type_type,
+        );
 
         let type_type = PyClassRef::new_ref_unchecked(Rc::from_raw(type_type_ptr));
         let object_type = PyClassRef::new_ref_unchecked(Rc::from_raw(object_type_ptr));


### PR DESCRIPTION
The main motivator for this is to make the type hierarchy creation simpler and less error prone; this removes the trait object hack, including a few questionable transmutes.