### PR TITLE
Make ast::Location implement Copy

### DIFF
--- a/bytecode/src/bytecode.rs
+++ b/bytecode/src/bytecode.rs
@@ -9,7 +9,7 @@ use std::collections::{HashMap, HashSet};
 use std::fmt;
 
 /// Sourcode location.
-#[derive(Clone, Debug, Default, PartialEq, Serialize, Deserialize)]
+#[derive(Clone, Copy, Debug, Default, PartialEq, Serialize, Deserialize)]
 pub struct Location {
     row: usize,
     column: usize,

--- a/compiler/src/compile.rs
+++ b/compiler/src/compile.rs
@@ -262,7 +262,7 @@ impl<O: OutputStream> Compiler<O> {
                 return Err(CompileError {
                     statement: None,
                     error: CompileErrorType::ExpectExpr,
-                    location: statement.location.clone(),
+                    location: statement.location,
                     source_path: None,
                 });
             }
@@ -306,7 +306,7 @@ impl<O: OutputStream> Compiler<O> {
 
     fn compile_statement(&mut self, statement: &ast::Statement) -> Result<(), CompileError> {
         trace!("Compiling {:?}", statement);
-        self.set_source_location(&statement.location);
+        self.set_source_location(statement.location);
         use ast::StatementType::*;
 
         match &statement.node {
@@ -542,7 +542,7 @@ impl<O: OutputStream> Compiler<O> {
                     return Err(CompileError {
                         statement: None,
                         error: CompileErrorType::InvalidBreak,
-                        location: statement.location.clone(),
+                        location: statement.location,
                         source_path: None,
                     });
                 }
@@ -553,7 +553,7 @@ impl<O: OutputStream> Compiler<O> {
                     return Err(CompileError {
                         statement: None,
                         error: CompileErrorType::InvalidContinue,
-                        location: statement.location.clone(),
+                        location: statement.location,
                         source_path: None,
                     });
                 }
@@ -564,7 +564,7 @@ impl<O: OutputStream> Compiler<O> {
                     return Err(CompileError {
                         statement: None,
                         error: CompileErrorType::InvalidReturn,
-                        location: statement.location.clone(),
+                        location: statement.location,
                         source_path: None,
                     });
                 }
@@ -643,7 +643,7 @@ impl<O: OutputStream> Compiler<O> {
                 return Err(CompileError {
                     statement: None,
                     error: CompileErrorType::Delete(expression.name()),
-                    location: self.current_source_location.clone(),
+                    location: self.current_source_location,
                     source_path: None,
                 });
             }
@@ -1348,7 +1348,7 @@ impl<O: OutputStream> Compiler<O> {
                             return Err(CompileError {
                                 statement: None,
                                 error: CompileErrorType::StarArgs,
-                                location: self.current_source_location.clone(),
+                                location: self.current_source_location,
                                 source_path: None,
                             });
                         } else {
@@ -1379,7 +1379,7 @@ impl<O: OutputStream> Compiler<O> {
                 return Err(CompileError {
                     statement: None,
                     error: CompileErrorType::Assign(target.name()),
-                    location: self.current_source_location.clone(),
+                    location: self.current_source_location,
                     source_path: None,
                 });
             }
@@ -1570,7 +1570,7 @@ impl<O: OutputStream> Compiler<O> {
 
     fn compile_expression(&mut self, expression: &ast::Expression) -> Result<(), CompileError> {
         trace!("Compiling {:?}", expression);
-        self.set_source_location(&expression.location);
+        self.set_source_location(expression.location);
 
         use ast::ExpressionType::*;
         match &expression.node {
@@ -1665,7 +1665,7 @@ impl<O: OutputStream> Compiler<O> {
                     return Err(CompileError {
                         statement: Option::None,
                         error: CompileErrorType::InvalidYield,
-                        location: self.current_source_location.clone(),
+                        location: self.current_source_location,
                         source_path: Option::None,
                     });
                 }
@@ -1763,7 +1763,7 @@ impl<O: OutputStream> Compiler<O> {
                     error: CompileErrorType::SyntaxError(std::string::String::from(
                         "Invalid starred expression",
                     )),
-                    location: self.current_source_location.clone(),
+                    location: self.current_source_location,
                     source_path: Option::None,
                 });
             }
@@ -2182,8 +2182,8 @@ impl<O: OutputStream> Compiler<O> {
         self.current_output().set_label(label)
     }
 
-    fn set_source_location(&mut self, location: &ast::Location) {
-        self.current_source_location = location.clone();
+    fn set_source_location(&mut self, location: ast::Location) {
+        self.current_source_location = location;
     }
 
     fn get_source_line_number(&mut self) -> usize {

--- a/compiler/src/peephole.rs
+++ b/compiler/src/peephole.rs
@@ -15,7 +15,7 @@ impl From<Vec<InstructionMetadata>> for InstructionMetadata {
     fn from(metas: Vec<Self>) -> Self {
         debug_assert!(!metas.is_empty(), "`metas` must not be empty");
         InstructionMetadata {
-            loc: metas[0].loc.clone(),
+            loc: metas[0].loc,
             labels: metas
                 .into_iter()
                 .flat_map(|meta| meta.labels.into_iter())

--- a/parser/src/error.rs
+++ b/parser/src/error.rs
@@ -193,7 +193,7 @@ impl fmt::Display for ParseErrorType {
             ParseErrorType::UnrecognizedToken(ref tok, ref expected) => {
                 if *tok == Tok::Indent {
                     write!(f, "unexpected indent")
-                } else if expected.clone() == Some("Indent".to_owned()) {
+                } else if expected.as_deref() == Some("Indent") {
                     write!(f, "expected an indented block")
                 } else {
                     write!(f, "Got unexpected token {}", tok)

--- a/parser/src/function.rs
+++ b/parser/src/function.rs
@@ -22,7 +22,7 @@ pub fn parse_params(
                 // have defaults
                 return Err(LexicalError {
                     error: LexicalErrorType::DefaultArgumentError,
-                    location: name.location.clone(),
+                    location: name.location,
                 });
             }
         }

--- a/parser/src/lexer.rs
+++ b/parser/src/lexer.rs
@@ -285,7 +285,7 @@ where
         let end_pos = self.get_pos();
         let value = BigInt::from_str_radix(&value_text, radix).map_err(|e| LexicalError {
             error: LexicalErrorType::OtherError(format!("{:?}", e)),
-            location: start_pos.clone(),
+            location: start_pos,
         })?;
         Ok((start_pos, Tok::Int { value }, end_pos))
     }
@@ -711,9 +711,8 @@ where
                 Ordering::Greater => {
                     // New indentation level:
                     self.indentation_stack.push(indentation_level);
-                    let tok_start = self.get_pos();
-                    let tok_end = tok_start.clone();
-                    self.emit((tok_start, Tok::Indent, tok_end));
+                    let tok_pos = self.get_pos();
+                    self.emit((tok_pos, Tok::Indent, tok_pos));
                 }
                 Ordering::Less => {
                     // One or more dedentations
@@ -726,9 +725,8 @@ where
                         match ordering {
                             Ordering::Less => {
                                 self.indentation_stack.pop();
-                                let tok_start = self.get_pos();
-                                let tok_end = tok_start.clone();
-                                self.emit((tok_start, Tok::Dedent, tok_end));
+                                let tok_pos = self.get_pos();
+                                self.emit((tok_pos, Tok::Dedent, tok_pos));
                             }
                             Ordering::Equal => {
                                 // We arrived at proper level of indentation.
@@ -786,16 +784,16 @@ where
             // Next, insert a trailing newline, if required.
             if !self.at_begin_of_line {
                 self.at_begin_of_line = true;
-                self.emit((tok_pos.clone(), Tok::Newline, tok_pos.clone()));
+                self.emit((tok_pos, Tok::Newline, tok_pos));
             }
 
             // Next, flush the indentation stack to zero.
             while self.indentation_stack.len() > 1 {
                 self.indentation_stack.pop();
-                self.emit((tok_pos.clone(), Tok::Dedent, tok_pos.clone()));
+                self.emit((tok_pos, Tok::Dedent, tok_pos));
             }
 
-            self.emit((tok_pos.clone(), Tok::EndOfFile, tok_pos));
+            self.emit((tok_pos, Tok::EndOfFile, tok_pos));
         }
 
         Ok(())
@@ -1194,7 +1192,7 @@ where
 
     /// Helper function to retrieve the current position.
     fn get_pos(&self) -> Location {
-        self.location.clone()
+        self.location
     }
 
     /// Helper function to emit a lexed token to the queue of tokens.

--- a/parser/src/location.rs
+++ b/parser/src/location.rs
@@ -3,7 +3,7 @@
 use std::fmt;
 
 /// A location somewhere in the sourcecode.
-#[derive(Clone, Debug, Default, PartialEq)]
+#[derive(Clone, Copy, Debug, Default, PartialEq)]
 pub struct Location {
     row: usize,
     column: usize,

--- a/parser/src/parser.rs
+++ b/parser/src/parser.rs
@@ -138,7 +138,7 @@ mod tests {
 
     fn as_statement(expr: ast::Expression) -> ast::Statement {
         ast::Statement {
-            location: expr.location.clone(),
+            location: expr.location,
             node: ast::StatementType::Expression { expression: expr },
         }
     }

--- a/parser/src/python.lalrpop
+++ b/parser/src/python.lalrpop
@@ -874,9 +874,9 @@ SubscriptList: ast::Expression = {
 Subscript: ast::Expression = {
     Test,
     <e1:Test?> <location:@L> ":" <e2:Test?> <e3:SliceOp?>  => {
-        let s1 = e1.unwrap_or(ast::Expression { location: location.clone(), node: ast::ExpressionType::None });
-        let s2 = e2.unwrap_or(ast::Expression { location: location.clone(), node: ast::ExpressionType::None });
-        let s3 = e3.unwrap_or(ast::Expression { location: location.clone(), node: ast::ExpressionType::None });
+        let s1 = e1.unwrap_or(ast::Expression { location, node: ast::ExpressionType::None });
+        let s2 = e2.unwrap_or(ast::Expression { location, node: ast::ExpressionType::None });
+        let s3 = e3.unwrap_or(ast::Expression { location, node: ast::ExpressionType::None });
         ast::Expression {
             location,
             node: ast::ExpressionType::Slice { elements: vec![s1, s2, s3] }
@@ -1061,7 +1061,7 @@ FunctionArgument: (Option<Option<String>>, ast::Expression) = {
     <e:Test> <c:CompFor?> => {
         let expr = match c {
             Some(c) => ast::Expression {
-                location: e.location.clone(),
+                location: e.location,
                 node: ast::ExpressionType::Comprehension {
                     kind: Box::new(ast::ComprehensionKind::GeneratorExpression { element: e }),
                     generators: c,
@@ -1071,7 +1071,7 @@ FunctionArgument: (Option<Option<String>>, ast::Expression) = {
         };
         (None, expr)
     },
-    <i:Identifier> "=" <e:Test> => (Some(Some(i.clone())), e),
+    <i:Identifier> "=" <e:Test> => (Some(Some(i)), e),
     <location:@L> "*" <e:Test> => (None, ast::Expression { location, node: ast::ExpressionType::Starred { value: Box::new(e) } }),
     "**" <e:Test> => (Some(None), e),
 };
@@ -1105,7 +1105,7 @@ StringGroup: ast::StringGroup = {
         let mut values = vec![];
         for (value, is_fstring) in s {
             values.push(if is_fstring {
-                parse_located_fstring(&value, loc.clone())?
+                parse_located_fstring(&value, loc)?
             } else {
                 ast::StringGroup::Constant { value }
             })

--- a/vm/src/frame.rs
+++ b/vm/src/frame.rs
@@ -1348,7 +1348,7 @@ impl Frame {
     }
 
     pub fn get_lineno(&self) -> bytecode::Location {
-        self.code.locations[self.lasti.get()].clone()
+        self.code.locations[self.lasti.get()]
     }
 
     fn push_block(&self, typ: BlockType) {


### PR DESCRIPTION
It's only 2 `usize`s and it gets passed around a lot, the `clone()`ing just makes the code more verbose.