### PR TITLE
Update Dockerfiles

### DIFF
--- a/Dockerfile.bin
+++ b/Dockerfile.bin
@@ -1,4 +1,4 @@
-FROM rust:1.36-slim
+FROM rust:latest as rust
 
 WORKDIR /rustpython
 
@@ -6,4 +6,10 @@ COPY . .
 
 RUN cargo build --release
 
-CMD [ "/rustpython/target/release/rustpython" ]
+FROM debian:stable-slim
+
+COPY --from=rust /rustpython/target/release/rustpython /usr/bin
+COPY --from=rust /rustpython/Lib /usr/lib/rustpython
+ENV RUSTPYTHONPATH /usr/lib/rustpython
+
+ENTRYPOINT [ "rustpython" ]

--- a/Dockerfile.wasm
+++ b/Dockerfile.wasm
@@ -1,23 +1,15 @@
-FROM rust:1.36-slim AS rust
+FROM rust:slim AS rust
 
 WORKDIR /rustpython
 
 USER root
-ENV USER=root
+ENV USER root
 
 
 RUN apt-get update && apt-get install curl libssl-dev pkg-config -y && \
   curl https://rustwasm.github.io/wasm-pack/installer/init.sh -sSf | sh
 
-COPY Cargo.toml Cargo.lock ./
-COPY src src
-COPY vm vm
-COPY derive derive
-COPY parser parser
-COPY bytecode bytecode
-COPY compiler compiler
-COPY wasm/lib wasm/lib
-COPY Lib Lib
+COPY . .
 
 RUN cd wasm/lib/ && wasm-pack build --release
 
@@ -33,14 +25,8 @@ COPY wasm/demo .
 RUN npm install && npm run dist -- --env.noWasmPack --env.rustpythonPkg=rustpython_wasm
 
 
-FROM node:slim
+FROM nginx:alpine
 
-WORKDIR /rustpython-demo
-
-RUN npm i -g serve
-
-COPY --from=node /rustpython-demo/dist .
-
-CMD [ "serve", "-l", "80", "/rustpython-demo" ]
-
-EXPOSE 80
+COPY --from=node /rustpython-demo/dist /usr/share/nginx/html
+# Add the WASM mime type
+RUN echo "types { application/wasm wasm; }" >>/etc/nginx/mime.types

--- a/wasm/lib/Cargo.toml
+++ b/wasm/lib/Cargo.toml
@@ -38,3 +38,6 @@ features = [
     "RequestInit",
     "Response"
 ]
+
+[package.metadata.wasm-pack.profile.release]
+wasm-opt = ["-O1"]


### PR DESCRIPTION
I also lowered the optimization level for `wasm-opt` for `rustpython-wasm` to only `-O1`, as it was taking upwards of 15-20 minutes for `wasm-opt` to run at its default optimization level.