### PR TITLE
Use vendored version of openssl

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1083,6 +1083,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "openssl-src"
+version = "111.7.0+1.1.1e"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6fde5a8c01ef8aa31ff8d0aaf9bae248581ed8840fca0b66e51cc9f294a8cb2c"
+dependencies = [
+ "cc",
+]
+
+[[package]]
 name = "openssl-sys"
 version = "0.9.54"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1091,6 +1100,7 @@ dependencies = [
  "autocfg 1.0.0",
  "cc",
  "libc",
+ "openssl-src",
  "pkg-config",
  "vcpkg",
 ]

--- a/vm/Cargo.toml
+++ b/vm/Cargo.toml
@@ -92,7 +92,7 @@ subprocess = "0.2.2"
 num_cpus = "1"
 socket2 = { version = "0.3", features = ["unix"] }
 rustyline = "6.0"
-openssl = "0.10"
+openssl = { version = "0.10", features = ["vendored"] }
 openssl-sys = "0.9"
 
 [target.'cfg(not(any(target_arch = "wasm32", target_os = "redox")))'.dependencies]


### PR DESCRIPTION
As discussed in #1823. I would suggest revisiting this once our testing matrix is larger.