### PR TITLE
Add a cron job to push jsontest data to the website

### DIFF
--- a/.github/workflows/cron-ci.yaml
+++ b/.github/workflows/cron-ci.yaml
@@ -56,3 +56,33 @@ jobs:
         uses: codecov/codecov-action@v1
         with:
           file: ${{ steps.coverage.outputs.report }}
+
+  testdata:
+    name: Collect regression test data
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@master
+      - name: build rustpython
+        uses: actions-rs/cargo@v1
+        with:
+          command: build
+          args: --release --verbose --all
+      - name: collect tests data
+        run: cargo run --release tests/jsontests.py
+        env:
+          RUSTPYTHONPATH: ${{ github.workspace }}/Lib
+      - name: upload tests data to the website
+        env:
+          SSHKEY: ${{ secrets.ACTIONS_TESTS_DATA_DEPLOY_KEY }}
+          GITHUB_ACTOR: ${{ github.actor }}
+        run: |
+          echo "$SSHKEY" >~/github_key
+          chmod 600 ~/github_key
+          export GIT_SSH_COMMAND="ssh -i ~/github_key"
+
+          git clone git@github.com:RustPython/rustpython.github.io.git website
+          cd website
+          cp ../tests/cpython_tests_results.json ./_data/regrtests_results.json
+          git add ./_data/regrtests_results.json
+          git -c user.name="Github Actions" -c user.email="actions@github.com" commit -m "Update regression test results" --author="$GITHUB_ACTOR"
+          git push


### PR DESCRIPTION
As @mireille-raad requested in #1671. Successful run [here](https://github.com/RustPython/RustPython/runs/581687268?check_suite_focus=true).