### PR TITLE
Implement P3.9 style dict union (PEP584)

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -62,7 +62,7 @@ jobs:
           args: --release --verbose --all
       - uses: actions/setup-python@v1
         with:
-          python-version: 3.8
+          python-version: 3.9
       - name: Install pipenv
         run: |
           python -V
@@ -108,7 +108,7 @@ jobs:
       - uses: actions/checkout@master
       - uses: actions/setup-python@v1
         with:
-          python-version: 3.8
+          python-version: 3.9
       - name: install flake8
         run: python -m pip install flake8
       - name: run lint
@@ -135,7 +135,7 @@ jobs:
           tar -xzf geckodriver-v0.24.0-linux32.tar.gz -C geckodriver
       - uses: actions/setup-python@v1
         with:
-          python-version: 3.8
+          python-version: 3.9
       - name: Install pipenv
         run: |
           python -V

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -62,7 +62,7 @@ jobs:
           args: --release --verbose --all
       - uses: actions/setup-python@v1
         with:
-          python-version: 3.9
+          python-version: 3.8
       - name: Install pipenv
         run: |
           python -V
@@ -108,7 +108,7 @@ jobs:
       - uses: actions/checkout@master
       - uses: actions/setup-python@v1
         with:
-          python-version: 3.9
+          python-version: 3.8
       - name: install flake8
         run: python -m pip install flake8
       - name: run lint
@@ -135,7 +135,7 @@ jobs:
           tar -xzf geckodriver-v0.24.0-linux32.tar.gz -C geckodriver
       - uses: actions/setup-python@v1
         with:
-          python-version: 3.9
+          python-version: 3.8
       - name: Install pipenv
         run: |
           python -V

--- a/parser/src/fstring.rs
+++ b/parser/src/fstring.rs
@@ -73,6 +73,11 @@ impl<'a> FStringParser<'a> {
                             return Err(ExpectedRbrace);
                         }
                     });
+
+                    let peek = self.chars.peek();
+                    if peek != Some(&'}') && peek != Some(&':') {
+                        return Err(ExpectedRbrace);
+                    }
                 }
 
                 // match a python 3.8 self documenting expression
@@ -383,6 +388,7 @@ mod tests {
     #[test]
     fn test_parse_invalid_fstring() {
         assert_eq!(parse_fstring("{5!a"), Err(ExpectedRbrace));
+
         assert_eq!(parse_fstring("{5!a1}"), Err(ExpectedRbrace));
         assert_eq!(parse_fstring("{5!"), Err(ExpectedRbrace));
 

--- a/parser/src/fstring.rs
+++ b/parser/src/fstring.rs
@@ -83,7 +83,6 @@ impl<'a> FStringParser<'a> {
                 // format '{' PYTHON_EXPRESSION '=' FORMAT_SPECIFIER? '}'
                 '=' if self.chars.peek() != Some(&'=') => { // check for delims empty?
                     pred_expression_text = expression.to_string(); // safe expression before = to print it
-                    //  pred_expression_text contains trailing spaces, which are trimmed somewhere later before printing, this needs to be prevented orovercome here
                 }
 
                 ':' if delims.is_empty() => {

--- a/parser/src/fstring.rs
+++ b/parser/src/fstring.rs
@@ -73,10 +73,6 @@ impl<'a> FStringParser<'a> {
                             return Err(ExpectedRbrace);
                         }
                     });
-
-                    if self.chars.peek() != Some(&'}') {
-                        return Err(ExpectedRbrace);
-                    }
                 }
 
                 // match a python 3.8 self documenting expression

--- a/parser/src/fstring.rs
+++ b/parser/src/fstring.rs
@@ -27,7 +27,7 @@ impl<'a> FStringParser<'a> {
         let mut delims = Vec::new();
         let mut conversion = None;
         let mut pred_expression_text = String::new();
-        let mut trailing_seq=String::new();
+        let mut trailing_seq = String::new();
 
         while let Some(ch) = self.chars.next() {
             match ch {
@@ -77,7 +77,8 @@ impl<'a> FStringParser<'a> {
 
                 // match a python 3.8 self documenting expression
                 // format '{' PYTHON_EXPRESSION '=' FORMAT_SPECIFIER? '}'
-                '=' if self.chars.peek() != Some(&'=') => { // check for delims empty?
+                '=' if self.chars.peek() != Some(&'=') => {
+                    // check for delims empty?
                     pred_expression_text = expression.to_string(); // safe expression before = to print it
                 }
 
@@ -161,28 +162,25 @@ impl<'a> FStringParser<'a> {
                             conversion,
                             spec,
                         });
-                    }
-                    else {
-                        return Ok(Joined{
-                                values:vec![
-                                    Constant{
-                                        value:pred_expression_text.to_owned()+"="
-                                    },
-
-                                    Constant {
-                                        value:trailing_seq.to_owned()
-                                    },
-
-                                    FormattedValue {
+                    } else {
+                        return Ok(Joined {
+                            values: vec![
+                                Constant {
+                                    value: pred_expression_text.to_owned() + "=",
+                                },
+                                Constant {
+                                    value: trailing_seq.to_owned(),
+                                },
+                                FormattedValue {
                                     value: Box::new(
                                         parse_expression(expression.trim())
                                             .map_err(|e| InvalidExpression(Box::new(e.error)))?,
                                     ),
                                     conversion,
-                                    spec,},
-                                ]
-                            }
-                        );
+                                    spec,
+                                },
+                            ],
+                        });
                     }
                 }
                 '"' | '\'' => {
@@ -360,24 +358,24 @@ mod tests {
 
     #[test]
     fn test_fstring_parse_selfdocumenting_base() {
-        let src=String::from("{user=}");
-        let parse_ast=parse_fstring(&src);
+        let src = String::from("{user=}");
+        let parse_ast = parse_fstring(&src);
 
         assert!(parse_ast.is_ok());
     }
 
     #[test]
     fn test_fstring_parse_selfdocumenting_base_more() {
-        let src=String::from("mix {user=} with text and {second=}");
-        let parse_ast=parse_fstring(&src);
+        let src = String::from("mix {user=} with text and {second=}");
+        let parse_ast = parse_fstring(&src);
 
         assert!(parse_ast.is_ok());
     }
 
     #[test]
     fn test_fstring_parse_selfdocumenting_format() {
-        let src=String::from("{user=:>10}");
-        let parse_ast=parse_fstring(&src);
+        let src = String::from("{user=:>10}");
+        let parse_ast = parse_fstring(&src);
 
         assert!(parse_ast.is_ok());
     }

--- a/parser/src/fstring.rs
+++ b/parser/src/fstring.rs
@@ -171,10 +171,10 @@ impl<'a> FStringParser<'a> {
                         return Ok(Joined {
                             values: vec![
                                 Constant {
-                                    value: pred_expression_text.to_owned() + "=",
+                                    value: pred_expression_text + "=",
                                 },
                                 Constant {
-                                    value: trailing_seq.to_owned(),
+                                    value: trailing_seq,
                                 },
                                 FormattedValue {
                                     value: Box::new(

--- a/tests/snippets/dict_union.py
+++ b/tests/snippets/dict_union.py
@@ -1,0 +1,47 @@
+
+
+
+def test_dunion_ior0():
+    a={1:2,2:3}
+    b={3:4,5:6}
+    a|=b
+
+    assert a == {1:2,2:3,3:4,5:6}, f"wrong value assigned {a=}"
+    assert b == {3:4,5:6}, f"right hand side modified, {b=}"
+
+def test_dunion_or0():
+    a={1:2,2:3}
+    b={3:4,5:6}
+    c=a|b
+
+    assert a == {1:2,2:3}, f"left hand side of non-assignment operator modified {a=}"
+    assert b == {3:4,5:6}, f"right hand side of non-assignment operator modified, {b=}"
+    assert c == {1:2,2:3, 3:4, 5:6}, f"unexpected result of dict union {c=}"
+
+
+def test_dunion_or1():
+    a={1:2,2:3}
+    b={3:4,5:6}
+    c=a.__or__(b)
+
+    assert a == {1:2,2:3}, f"left hand side of non-assignment operator modified {a=}"
+    assert b == {3:4,5:6}, f"right hand side of non-assignment operator modified, {b=}"
+    assert c == {1:2,2:3, 3:4, 5:6}, f"unexpected result of dict union {c=}"
+
+
+def test_dunion_ror0():
+    a={1:2,2:3}
+    b={3:4,5:6}
+    c=b.__ror__(a)
+
+    assert a == {1:2,2:3}, f"left hand side of non-assignment operator modified {a=}"
+    assert b == {3:4,5:6}, f"right hand side of non-assignment operator modified, {b=}"
+    assert c == {1:2,2:3, 3:4, 5:6}, f"unexpected result of dict union {c=}"
+
+test_dunion_ior0()
+test_dunion_or0()
+test_dunion_or1()
+test_dunion_ror0()
+
+
+

--- a/tests/snippets/dict_union.py
+++ b/tests/snippets/dict_union.py
@@ -1,5 +1,5 @@
 
-
+import testutils
 
 def test_dunion_ior0():
     a={1:2,2:3}
@@ -38,10 +38,46 @@ def test_dunion_ror0():
     assert b == {3:4,5:6}, f"right hand side of non-assignment operator modified, {b=}"
     assert c == {1:2,2:3, 3:4, 5:6}, f"unexpected result of dict union {c=}"
 
-test_dunion_ior0()
-test_dunion_or0()
-test_dunion_or1()
-test_dunion_ror0()
+
+def test_dunion_other_types():
+    def perf_test_or(other_obj):
+        d={1:2}
+        try:
+            d.__or__(other_obj)
+        except:
+            return True
+        return False
+
+    def perf_test_ior(other_obj):
+        d={1:2}
+        try:
+            d.__ior__(other_obj)
+        except:
+            return True
+        return False
+
+    def perf_test_ror(other_obj):
+        d={1:2}
+        try:
+            d.__ror__(other_obj)
+        except:
+            return True
+        return False
+
+    test_fct={'__or__':perf_test_or, '__ror__':perf_test_ror, '__ior__':perf_test_ior}
+    others=['FooBar', 42, [36], set([19]), ['aa'], None]
+    for tfn,tf in test_fct.items():
+        for other in others:
+            assert tf(other), f"Failed: dict {tfn}, accepted {other}"
+
+
+
+
+testutils.skip_if_unsupported(3,9,test_dunion_ior0)
+testutils.skip_if_unsupported(3,9,test_dunion_or0)
+testutils.skip_if_unsupported(3,9,test_dunion_or1)
+testutils.skip_if_unsupported(3,9,test_dunion_ror0)
+testutils.skip_if_unsupported(3,9,test_dunion_other_types)
 
 
 

--- a/tests/snippets/fstrings.py
+++ b/tests/snippets/fstrings.py
@@ -77,9 +77,9 @@ assert f'>{v!a}' == r">'\u262e'"
 assert f'{"42"!s:<5}' == '42   ', '#' + f'{"42"!s:<5}' +'#'
 assert f'{"42"!s:>5}' == '   42', '#' + f'{"42"!s:>5}' +'#'
 
-#assert f'{"42"=!s:5}' == '42=42   ', '#'+ f'{"42"=!s:5}' +'#' # TODO add ' arround string literal in expression # TODO default alingment in cpython is left
-assert f'{"42"=!s:<5}' == '"42"=42   ', '#'+ f'{"42"=!s:<5}' +'#' # TODO add ' arround string literal in expression
-assert f'{"42"=!s:>5}' == '"42"=   42', '#'+ f'{"42"=!s:>5}' +'#' # TODO add ' arround string literal in expression
+#assert f'{"42"=!s:5}' == '"42"=42   ', '#'+ f'{"42"=!s:5}' +'#' # TODO default alingment in cpython is left
+assert f'{"42"=!s:<5}' == '"42"=42   ', '#'+ f'{"42"=!s:<5}' +'#'
+assert f'{"42"=!s:>5}' == '"42"=   42', '#'+ f'{"42"=!s:>5}' +'#'
 
 
 
@@ -95,16 +95,16 @@ x = 'A string'
 self.assertEqual(f'{10=}', '10=10')
 self.assertEqual(f'{x=}', 'x=' + x )#repr(x)) # TODO: add  ' when printing strings
 self.assertEqual(f'{x =}', 'x =' + x )# + repr(x)) # TODO: implement '  handling
-self.assertEqual(f'{x=!s}', 'x=' + str(x)) # TODO : implement format specs properly
+self.assertEqual(f'{x=!s}', 'x=' + str(x))
 # self.assertEqual(f'{x=!r}', 'x=' + x) #repr(x))
 self.assertEqual(f'{x=!a}', 'x=' + ascii(x))
 
 x = 2.71828
 self.assertEqual(f'{x=:.2f}', 'x=' + format(x, '.2f'))
 self.assertEqual(f'{x=:}', 'x=' + format(x, ''))
-#self.assertEqual(f'{x=!r:^20}', 'x=' + format(repr(x), '^20')) #TODO formatspecifier after conversion flsg is currently not supported (also for classical fstrings)
-#self.assertEqual(f'{x=!s:^20}', 'x=' + format(str(x), '^20'))
-#self.assertEqual(f'{x=!a:^20}', 'x=' + format(ascii(x), '^20'))
+self.assertEqual(f'{x=!r:^20}', 'x=' + format(repr(x), '^20')) #TODO formatspecifier after conversion flsg is currently not supported (also for classical fstrings)
+self.assertEqual(f'{x=!s:^20}', 'x=' + format(str(x), '^20'))
+self.assertEqual(f'{x=!a:^20}', 'x=' + format(ascii(x), '^20'))
 
 x = 9
 self.assertEqual(f'{3*x+15=}', '3*x+15=42')
@@ -146,7 +146,7 @@ self.assertEqual(f'X{x=}Y', 'Xx='+x+'Y') # just for the moment
 # self.assertEqual(f'X{x=  }Y', 'Xx=  '+repr(x)+'Y') # TODO '
 # self.assertEqual(f'X{x  =  }Y', 'Xx  =  '+repr(x)+'Y') # TODO '
 
-# TODO remove trim
+
 self.assertEqual(f'X{x  =}Y', 'Xx  ='+x+'Y')
 self.assertEqual(f'X{x=  }Y', 'Xx=  '+x+'Y')
 self.assertEqual(f'X{x  =  }Y', 'Xx  =  '+x+'Y')

--- a/tests/snippets/fstrings.py
+++ b/tests/snippets/fstrings.py
@@ -1,4 +1,20 @@
-#from testutils import assert_raises
+from testutils import assert_raises
+
+#test only makes sense with python 3.8 or higher (or RustPython)
+import sys
+import platform
+if platform.python_implementation() == 'CPython':
+    assert sys.version_info.major == 3, 'Incompatible Python Version, expected CPython 3.8 or later'
+    assert sys.version_info.minor == 8, 'Incompatible Python Version, expected CPython 3.8 or later'
+elif platform.python_implementation == 'RustPython':
+    # ok
+    pass
+else:
+    # other implementation - lets give it a try
+    pass
+
+
+# lets start tersing
 foo = 'bar'
 
 assert f"{''}" == ''
@@ -25,7 +41,7 @@ num=42
 
 f'{num=}' # keep this line as it will fail when using a python 3.7 interpreter 
 
-assert f'{num=}' == 'num=42', 
+assert f'{num=}' == 'num=42'
 assert f'{num=:>10}' == 'num=        42'
 
 

--- a/tests/snippets/fstrings.py
+++ b/tests/snippets/fstrings.py
@@ -114,11 +114,11 @@ self=C()
 
 x = 'A string'
 self.assertEqual(f'{10=}', '10=10')
-self.assertEqual(f'{x=}', 'x=' + x )#repr(x)) # TODO: add  ' when printing strings
-self.assertEqual(f'{x =}', 'x =' + x )# + repr(x)) # TODO: implement '  handling
+# self.assertEqual(f'{x=}', 'x=' + x )#repr(x)) # TODO: add  ' when printing strings
+# self.assertEqual(f'{x =}', 'x =' + x )# + repr(x)) # TODO: implement '  handling
 self.assertEqual(f'{x=!s}', 'x=' + str(x))
-# self.assertEqual(f'{x=!r}', 'x=' + x) #repr(x))
-self.assertEqual(f'{x=!a}', 'x=' + ascii(x))
+# # self.assertEqual(f'{x=!r}', 'x=' + x) #repr(x)) # !r not supported
+# self.assertEqual(f'{x=!a}', 'x=' + ascii(x))
 
 x = 2.71828
 self.assertEqual(f'{x=:.2f}', 'x=' + format(x, '.2f'))
@@ -158,9 +158,9 @@ self.assertEqual(f'{0<=1}', 'True')
 self.assertEqual(f'{0>=1}', 'False')
 
 # Make sure leading and following text works.
-x = 'foo'
+# x = 'foo'
 #self.assertEqual(f'X{x=}Y', 'Xx='+repr(x)+'Y') # TODO ' 
-self.assertEqual(f'X{x=}Y', 'Xx='+x+'Y') # just for the moment
+# self.assertEqual(f'X{x=}Y', 'Xx='+x+'Y') # just for the moment
 
 # Make sure whitespace around the = works.
 # self.assertEqual(f'X{x  =}Y', 'Xx  ='+repr(x)+'Y')  # TODO '
@@ -168,6 +168,6 @@ self.assertEqual(f'X{x=}Y', 'Xx='+x+'Y') # just for the moment
 # self.assertEqual(f'X{x  =  }Y', 'Xx  =  '+repr(x)+'Y') # TODO '
 
 
-self.assertEqual(f'X{x  =}Y', 'Xx  ='+x+'Y')
-self.assertEqual(f'X{x=  }Y', 'Xx=  '+x+'Y')
-self.assertEqual(f'X{x  =  }Y', 'Xx  =  '+x+'Y')
+# self.assertEqual(f'X{x  =}Y', 'Xx  ='+x+'Y')
+# self.assertEqual(f'X{x=  }Y', 'Xx=  '+x+'Y')
+# self.assertEqual(f'X{x  =  }Y', 'Xx  =  '+x+'Y')

--- a/tests/snippets/fstrings.py
+++ b/tests/snippets/fstrings.py
@@ -71,6 +71,16 @@ assert f'>{v!a}' == r">'\u262e'"
 
 
 
+# Test format specifier after conversion flag
+#assert f'{"42"!s:<5}' == '42   ', '#' + f'{"42"!s:5}' +'#' # TODO: default alignment in cpython is left
+
+assert f'{"42"!s:<5}' == '42   ', '#' + f'{"42"!s:5}' +'#'
+assert f'{"42"!s:>5}' == '   42', '#' + f'{"42"!s:5}' +'#'
+
+#assert f'{"42"=!s:5}' == '42=42   ', '#'+ f'{"42"!s:5}' +'#' # TODO add ' arround string literal in expression # TODO default alingment in cpython is left
+assert f'{"42"=!s:<5}' == '42=42   ', '#'+ f'{"42"!s:5}' +'#' # TODO add ' arround string literal in expression
+assert f'{"42"=!s:>5}' == '42=   42', '#'+ f'{"42"!s:5}' +'#' # TODO add ' arround string literal in expression
+
 
 
 ### Tests for fstring selfdocumenting form CPython
@@ -84,17 +94,17 @@ self=C()
 x = 'A string'
 self.assertEqual(f'{10=}', '10=10')
 self.assertEqual(f'{x=}', 'x=' + x )#repr(x)) # TODO: add  ' when printing strings
-#self.assertEqual(f'{x =}', 'x =' + x )# + repr(x)) # TODO: remove trim in impl
-# self.assertEqual(f'{x=!s}', 'x=' + str(x)) # TODO : implement format specs properly
+self.assertEqual(f'{x =}', 'x =' + x )# + repr(x)) # TODO: implement '  handling
+self.assertEqual(f'{x=!s}', 'x=' + str(x)) # TODO : implement format specs properly
 # self.assertEqual(f'{x=!r}', 'x=' + x) #repr(x))
-#self.assertEqual(f'{x=!a}', 'x=' + ascii(x))
+self.assertEqual(f'{x=!a}', 'x=' + ascii(x))
 
 x = 2.71828
 self.assertEqual(f'{x=:.2f}', 'x=' + format(x, '.2f'))
 self.assertEqual(f'{x=:}', 'x=' + format(x, ''))
-# self.assertEqual(f'{x=!r:^20}', 'x=' + format(repr(x), '^20'))
-# self.assertEqual(f'{x=!s:^20}', 'x=' + format(str(x), '^20'))
-# self.assertEqual(f'{x=!a:^20}', 'x=' + format(ascii(x), '^20'))
+#self.assertEqual(f'{x=!r:^20}', 'x=' + format(repr(x), '^20')) #TODO formatspecifier after conversion flsg is currently not supported (also for classical fstrings)
+#self.assertEqual(f'{x=!s:^20}', 'x=' + format(str(x), '^20'))
+#self.assertEqual(f'{x=!a:^20}', 'x=' + format(ascii(x), '^20'))
 
 x = 9
 self.assertEqual(f'{3*x+15=}', '3*x+15=42')

--- a/tests/snippets/fstrings.py
+++ b/tests/snippets/fstrings.py
@@ -74,12 +74,12 @@ assert f'>{v!a}' == r">'\u262e'"
 # Test format specifier after conversion flag
 #assert f'{"42"!s:<5}' == '42   ', '#' + f'{"42"!s:5}' +'#' # TODO: default alignment in cpython is left
 
-assert f'{"42"!s:<5}' == '42   ', '#' + f'{"42"!s:5}' +'#'
-assert f'{"42"!s:>5}' == '   42', '#' + f'{"42"!s:5}' +'#'
+assert f'{"42"!s:<5}' == '42   ', '#' + f'{"42"!s:<5}' +'#'
+assert f'{"42"!s:>5}' == '   42', '#' + f'{"42"!s:>5}' +'#'
 
-#assert f'{"42"=!s:5}' == '42=42   ', '#'+ f'{"42"!s:5}' +'#' # TODO add ' arround string literal in expression # TODO default alingment in cpython is left
-assert f'{"42"=!s:<5}' == '42=42   ', '#'+ f'{"42"!s:5}' +'#' # TODO add ' arround string literal in expression
-assert f'{"42"=!s:>5}' == '42=   42', '#'+ f'{"42"!s:5}' +'#' # TODO add ' arround string literal in expression
+#assert f'{"42"=!s:5}' == '42=42   ', '#'+ f'{"42"=!s:5}' +'#' # TODO add ' arround string literal in expression # TODO default alingment in cpython is left
+assert f'{"42"=!s:<5}' == '"42"=42   ', '#'+ f'{"42"=!s:<5}' +'#' # TODO add ' arround string literal in expression
+assert f'{"42"=!s:>5}' == '"42"=   42', '#'+ f'{"42"=!s:>5}' +'#' # TODO add ' arround string literal in expression
 
 
 

--- a/tests/snippets/fstrings.py
+++ b/tests/snippets/fstrings.py
@@ -17,10 +17,15 @@ assert fr'x={4*10}\n' == 'x=40\\n'
 assert f'{16:0>+#10x}' == '00000+0x10'
 assert f"{{{(lambda x: f'hello, {x}')('world}')}" == '{hello, world}'
 
-assert f'{foo=}' == 'foo=bar'
+
+# base test of self documenting strings
+#assert f'{foo=}' == 'foo=bar' # TODO ' missing
 
 num=42
-assert f'{num=}' == 'num=42'
+
+f'{num=}' # keep this line as it will fail when using a python 3.7 interpreter 
+
+assert f'{num=}' == 'num=42', 
 assert f'{num=:>10}' == 'num=        42'
 
 

--- a/tests/snippets/fstrings.py
+++ b/tests/snippets/fstrings.py
@@ -167,7 +167,6 @@ self.assertEqual(f'{0>=1}', 'False')
 # self.assertEqual(f'X{x=  }Y', 'Xx=  '+repr(x)+'Y') # TODO '
 # self.assertEqual(f'X{x  =  }Y', 'Xx  =  '+repr(x)+'Y') # TODO '
 
-
 # self.assertEqual(f'X{x  =}Y', 'Xx  ='+x+'Y')
 # self.assertEqual(f'X{x=  }Y', 'Xx=  '+x+'Y')
 # self.assertEqual(f'X{x  =  }Y', 'Xx  =  '+x+'Y')

--- a/tests/snippets/testutils.py
+++ b/tests/snippets/testutils.py
@@ -75,7 +75,7 @@ def skip_if_unsupported(req_maj_vers, req_min_vers, test_fct):
     def exec():
         test_fct()
 
-    if platform.python_implementation == 'RustPython':
+    if platform.python_implementation() == 'RustPython':
         exec()
     elif sys.version_info.major>=req_maj_vers and sys.version_info.minor>=req_min_vers:
         exec()
@@ -86,7 +86,7 @@ def fail_if_unsupported(req_maj_vers, req_min_vers, test_fct):
     def exec():
         test_fct()
 
-    if platform.python_implementation == 'RustPython':
+    if platform.python_implementation() == 'RustPython':
         exec()
     elif sys.version_info.major>=req_maj_vers and sys.version_info.minor>=req_min_vers:
         exec()

--- a/tests/snippets/testutils.py
+++ b/tests/snippets/testutils.py
@@ -1,3 +1,6 @@
+import platform
+import sys
+
 def assert_raises(expected, *args, _msg=None, **kw):
     if args:
         f, f_args = args[0], args[1:]
@@ -67,3 +70,26 @@ def assert_isinstance(obj, klass):
 
 def assert_in(a, b):
     _assert_print(lambda: a in b, [a, 'in', b])
+
+def skip_if_unsupported(req_maj_vers, req_min_vers, test_fct):
+    def exec():
+        test_fct()
+
+    if platform.python_implementation == 'RustPython':
+        exec()
+    elif sys.version_info.major>=req_maj_vers and sys.version_info.minor>=req_min_vers:
+        exec()
+    else:
+        print(f'Skipping test as a higher python version is required. Using {platform.python_implementation()} {platform.python_version()}')
+
+def fail_if_unsupported(req_maj_vers, req_min_vers, test_fct):
+    def exec():
+        test_fct()
+
+    if platform.python_implementation == 'RustPython':
+        exec()
+    elif sys.version_info.major>=req_maj_vers and sys.version_info.minor>=req_min_vers:
+        exec()
+    else:
+        assert False, f'Test cannot performed on this python version. {platform.python_implementation()} {paltform.python_version()}'
+

--- a/tests/snippets/testutils.py
+++ b/tests/snippets/testutils.py
@@ -91,5 +91,5 @@ def fail_if_unsupported(req_maj_vers, req_min_vers, test_fct):
     elif sys.version_info.major>=req_maj_vers and sys.version_info.minor>=req_min_vers:
         exec()
     else:
-        assert False, f'Test cannot performed on this python version. {platform.python_implementation()} {paltform.python_version()}'
+        assert False, f'Test cannot performed on this python version. {platform.python_implementation()} {platform.python_version()}'
 

--- a/vm/src/obj/objdict.rs
+++ b/vm/src/obj/objdict.rs
@@ -104,6 +104,91 @@ impl PyDictRef {
         Ok(())
     }
 
+    fn merge_no_arg(
+        dict: &DictContentType,
+        dict_obj: OptionalArg<PyObjectRef>,
+        vm: &VirtualMachine,
+    ) -> PyResult<()> {
+        if let OptionalArg::Present(dict_obj) = dict_obj {
+            let dicted: Result<PyDictRef, _> = dict_obj.clone().downcast();
+            if let Ok(dict_obj) = dicted {
+                for (key, value) in dict_obj {
+                    dict.insert(vm, &key, value)?;
+                }
+            } else if let Some(keys) = vm.get_method(dict_obj.clone(), "keys") {
+                let keys = objiter::get_iter(vm, &vm.invoke(&keys?, vec![])?)?;
+                while let Some(key) = objiter::get_next_object(vm, &keys)? {
+                    let val = dict_obj.get_item(&key, vm)?;
+                    dict.insert(vm, &key, val)?;
+                }
+            } else {
+                let iter = objiter::get_iter(vm, &dict_obj)?;
+                loop {
+                    fn err(vm: &VirtualMachine) -> PyBaseExceptionRef {
+                        vm.new_type_error("Iterator must have exactly two elements".to_owned())
+                    }
+                    let element = match objiter::get_next_object(vm, &iter)? {
+                        Some(obj) => obj,
+                        None => break,
+                    };
+                    let elem_iter = objiter::get_iter(vm, &element)?;
+                    let key = objiter::get_next_object(vm, &elem_iter)?.ok_or_else(|| err(vm))?;
+                    let value = objiter::get_next_object(vm, &elem_iter)?.ok_or_else(|| err(vm))?;
+                    if objiter::get_next_object(vm, &elem_iter)?.is_some() {
+                        return Err(err(vm));
+                    }
+                    dict.insert(vm, &key, value)?;
+                }
+            }
+        }
+
+        Ok(())
+    }
+
+    fn merge_no_arg_dict(
+        dict: &DictContentType,
+        dict_other: PyDictRef,
+        vm: &VirtualMachine,
+    ) -> PyResult<()> {
+        for (key, value) in dict_other {
+            dict.insert(vm, &key, value)?;
+        }
+        // if let OptionalArg::Present(dict_obj) = dict_obj {
+        //     let dicted: Result<PyDictRef, _> = dict_obj.clone().downcast();
+        //     if let Ok(dict_obj) = dicted {
+        //         for (key, value) in dict_obj {
+        //             dict.insert(vm, &key, value)?;
+        //         }
+        //     } else if let Some(keys) = vm.get_method(dict_obj.clone(), "keys") {
+        //         let keys = objiter::get_iter(vm, &vm.invoke(&keys?, vec![])?)?;
+        //         while let Some(key) = objiter::get_next_object(vm, &keys)? {
+        //             let val = dict_obj.get_item(&key, vm)?;
+        //             dict.insert(vm, &key, val)?;
+        //         }
+        //     } else {
+        //         let iter = objiter::get_iter(vm, &dict_obj)?;
+        //         loop {
+        //             fn err(vm: &VirtualMachine) -> PyBaseExceptionRef {
+        //                 vm.new_type_error("Iterator must have exactly two elements".to_owned())
+        //             }
+        //             let element = match objiter::get_next_object(vm, &iter)? {
+        //                 Some(obj) => obj,
+        //                 None => break,
+        //             };
+        //             let elem_iter = objiter::get_iter(vm, &element)?;
+        //             let key = objiter::get_next_object(vm, &elem_iter)?.ok_or_else(|| err(vm))?;
+        //             let value = objiter::get_next_object(vm, &elem_iter)?.ok_or_else(|| err(vm))?;
+        //             if objiter::get_next_object(vm, &elem_iter)?.is_some() {
+        //                 return Err(err(vm));
+        //             }
+        //             dict.insert(vm, &key, value)?;
+        //         }
+        //     }
+        // }
+
+        Ok(())
+    }
+
     #[pyclassmethod]
     fn fromkeys(
         class: PyClassRef,
@@ -319,6 +404,32 @@ impl PyDictRef {
     ) -> PyResult<()> {
         PyDictRef::merge(&self.entries, dict_obj, kwargs, vm)
     }
+
+    #[pymethod(name="__ior__")]
+    fn ior(self, other:PyObjectRef, vm:&VirtualMachine) -> PyResult {
+        PyDictRef::merge_no_arg(&self.entries, OptionalArg::Present(other), vm);
+        Ok(self.into_object())
+    }
+
+    #[pymethod(name="__ror__")]
+    fn ror(self, other:PyObjectRef, vm:&VirtualMachine) -> PyResult<PyDict> {
+        let dicted: Result<PyDictRef, _> = other.clone().downcast();
+        if let Ok(other) = dicted {
+            let other_cp=other.copy();
+            PyDictRef::merge_no_arg_dict(&other_cp.entries, self, vm);
+            return Ok(other_cp);
+        }
+        let err_msg = vm.new_str("__ror__ not implemented for non-dict type".to_owned());
+        Err(vm.new_key_error(err_msg))
+    }
+
+    // #[pymethod(name="__or__")]
+    // fn or(self, other:PyObjectRef, vm:&VirtualMachine) -> PyResult<PyDict> { // PyResult {
+    //     //if type(other)==dict
+    //     let cp=self.copy();
+    //     PyDictRef::merge_no_arg(&cp.entries, OptionalArg::Present(other), vm);
+    //     Ok(cp)
+    // }
 
     #[pymethod]
     fn pop(

--- a/vm/src/obj/objdict.rs
+++ b/vm/src/obj/objdict.rs
@@ -423,13 +423,17 @@ impl PyDictRef {
         Err(vm.new_key_error(err_msg))
     }
 
-    // #[pymethod(name="__or__")]
-    // fn or(self, other:PyObjectRef, vm:&VirtualMachine) -> PyResult<PyDict> { // PyResult {
-    //     //if type(other)==dict
-    //     let cp=self.copy();
-    //     PyDictRef::merge_no_arg(&cp.entries, OptionalArg::Present(other), vm);
-    //     Ok(cp)
-    // }
+    #[pymethod(name="__or__")]
+    fn or(self, other:PyObjectRef, vm:&VirtualMachine) -> PyResult<PyDict> { // PyResult {
+        let dicted: Result<PyDictRef, _> = other.clone().downcast();
+        if let Ok(other) = dicted {
+            let self_cp=self.copy();
+            PyDictRef::merge_no_arg_dict(&self_cp.entries, other, vm);
+            return Ok(self_cp);
+        }
+        let err_msg = vm.new_str("__or__ not implemented for non-dict type".to_owned());
+        Err(vm.new_key_error(err_msg))
+    }
 
     #[pymethod]
     fn pop(

--- a/vm/src/obj/objdict.rs
+++ b/vm/src/obj/objdict.rs
@@ -338,8 +338,7 @@ impl PyDictRef {
             PyDictRef::merge_dict(&self.entries, other, vm)?;
             return Ok(self.into_object());
         }
-        let err_msg = vm.new_str("__ior__ not implemented for non-dict type".to_owned());
-        Err(vm.new_key_error(err_msg))
+        Err(vm.new_type_error("__ior__ not implemented for non-dict type".to_owned()))
     }
 
     #[pymethod(name = "__ror__")]
@@ -350,8 +349,7 @@ impl PyDictRef {
             PyDictRef::merge_dict(&other_cp.entries, self, vm)?;
             return Ok(other_cp);
         }
-        let err_msg = vm.new_str("__ror__ not implemented for non-dict type".to_owned());
-        Err(vm.new_key_error(err_msg))
+        Err(vm.new_type_error("__ror__ not implemented for non-dict type".to_owned()))
     }
 
     #[pymethod(name = "__or__")]
@@ -362,8 +360,7 @@ impl PyDictRef {
             PyDictRef::merge_dict(&self_cp.entries, other, vm)?;
             return Ok(self_cp);
         }
-        let err_msg = vm.new_str("__or__ not implemented for non-dict type".to_owned());
-        Err(vm.new_key_error(err_msg))
+        Err(vm.new_type_error("__or__ not implemented for non-dict type".to_owned()))
     }
 
     #[pymethod]


### PR DESCRIPTION
This PR implements the dict union as defined in PEP 854 in RustPython and tests it. Compability tests with Cpython are skipped when tested with Python 3.8 or below (due to abvious reason - Githib doesnt support python 3.9 so far, changing ci configuration failed).

Now it is possible to write things like:
>>> a = {1:2, 2:3}
>>> b = {3:4, 5:6}
>>> c=a|b
>>> a|=b