### PR TITLE
EOF after `\\` raise EOF Error

### DIFF
--- a/parser/src/error.rs
+++ b/parser/src/error.rs
@@ -28,6 +28,7 @@ pub enum LexicalErrorType {
     UnrecognizedToken { tok: char },
     FStringError(FStringErrorType),
     LineContinuationError,
+    EOF,
     OtherError(String),
 }
 
@@ -59,6 +60,7 @@ impl fmt::Display for LexicalErrorType {
             LexicalErrorType::LineContinuationError => {
                 write!(f, "unexpected character after line continuation character")
             }
+            LexicalErrorType::EOF => write!(f, "unexpected EOF while parsing"),
             LexicalErrorType::OtherError(msg) => write!(f, "{}", msg),
         }
     }

--- a/parser/src/lexer.rs
+++ b/parser/src/lexer.rs
@@ -1191,6 +1191,13 @@ where
                         location: self.get_pos(),
                     });
                 }
+
+                if self.chr0.is_none() {
+                    return Err(LexicalError {
+                        error: LexicalErrorType::EOF,
+                        location: self.get_pos(),
+                    });
+                }
             }
 
             _ => {

--- a/src/shell.rs
+++ b/src/shell.rs
@@ -1,7 +1,7 @@
 mod helper;
 
 use rustpython_compiler::{compile, error::CompileError, error::CompileErrorType};
-use rustpython_parser::error::ParseErrorType;
+use rustpython_parser::error::{LexicalErrorType, ParseErrorType};
 use rustpython_vm::readline::{Readline, ReadlineResult};
 use rustpython_vm::{
     exceptions::{print_exception, PyBaseExceptionRef},
@@ -23,6 +23,10 @@ fn shell_exec(vm: &VirtualMachine, source: &str, scope: Scope) -> ShellExecResul
             Ok(_val) => ShellExecResult::Ok,
             Err(err) => ShellExecResult::PyErr(err),
         },
+        Err(CompileError {
+            error: CompileErrorType::Parse(ParseErrorType::Lexical(LexicalErrorType::EOF)),
+            ..
+        }) => ShellExecResult::Continue,
         Err(CompileError {
             error: CompileErrorType::Parse(ParseErrorType::EOF),
             ..


### PR DESCRIPTION
Return EOF Error to get the next line after` \\ `in the shell.

Closes #1928