### PR TITLE
Move some vm fields to an Arc-wrapped struct

### DIFF
--- a/vm/src/builtins.rs
+++ b/vm/src/builtins.rs
@@ -761,7 +761,7 @@ pub fn make_module(vm: &VirtualMachine, module: PyObjectRef) {
         });
     }
 
-    let debug_mode: bool = vm.settings.optimize == 0;
+    let debug_mode: bool = vm.state.settings.optimize == 0;
     extend_module!(vm, module, {
         "__debug__" => ctx.new_bool(debug_mode),
         //set __name__ fixes: https://github.com/RustPython/RustPython/issues/146

--- a/vm/src/builtins.rs
+++ b/vm/src/builtins.rs
@@ -736,7 +736,7 @@ fn builtin_sum(iterable: PyIterable, start: OptionalArg, vm: &VirtualMachine) ->
 
 // Should be renamed to builtin___import__?
 fn builtin_import(vm: &VirtualMachine, args: PyFuncArgs) -> PyResult {
-    vm.invoke(&vm.import_func.borrow(), args)
+    vm.invoke(&vm.import_func, args)
 }
 
 fn builtin_vars(obj: OptionalArg, vm: &VirtualMachine) -> PyResult {

--- a/vm/src/stdlib/imp.rs
+++ b/vm/src/stdlib/imp.rs
@@ -26,11 +26,11 @@ fn imp_lock_held(_vm: &VirtualMachine) -> PyResult<()> {
 }
 
 fn imp_is_builtin(name: PyStringRef, vm: &VirtualMachine) -> bool {
-    vm.stdlib_inits.borrow().contains_key(name.as_str())
+    vm.state.stdlib_inits.contains_key(name.as_str())
 }
 
 fn imp_is_frozen(name: PyStringRef, vm: &VirtualMachine) -> bool {
-    vm.frozen.borrow().contains_key(name.as_str())
+    vm.state.frozen.contains_key(name.as_str())
 }
 
 fn imp_create_builtin(spec: PyObjectRef, vm: &VirtualMachine) -> PyResult {
@@ -40,7 +40,7 @@ fn imp_create_builtin(spec: PyObjectRef, vm: &VirtualMachine) -> PyResult {
 
     if let Ok(module) = sys_modules.get_item(name, vm) {
         Ok(module)
-    } else if let Some(make_module_func) = vm.stdlib_inits.borrow().get(name) {
+    } else if let Some(make_module_func) = vm.state.stdlib_inits.get(name) {
         Ok(make_module_func(vm))
     } else {
         Ok(vm.get_none())
@@ -53,8 +53,8 @@ fn imp_exec_builtin(_mod: PyModuleRef) -> i32 {
 }
 
 fn imp_get_frozen_object(name: PyStringRef, vm: &VirtualMachine) -> PyResult<PyCode> {
-    vm.frozen
-        .borrow()
+    vm.state
+        .frozen
         .get(name.as_str())
         .map(|frozen| {
             let mut frozen = frozen.code.clone();
@@ -71,8 +71,8 @@ fn imp_init_frozen(name: PyStringRef, vm: &VirtualMachine) -> PyResult {
 }
 
 fn imp_is_frozen_package(name: PyStringRef, vm: &VirtualMachine) -> PyResult<bool> {
-    vm.frozen
-        .borrow()
+    vm.state
+        .frozen
         .get(name.as_str())
         .map(|frozen| frozen.package)
         .ok_or_else(|| {

--- a/vm/src/stdlib/signal.rs
+++ b/vm/src/stdlib/signal.rs
@@ -38,6 +38,10 @@ fn assert_in_range(signum: i32, vm: &VirtualMachine) -> PyResult<()> {
 
 fn signal(signalnum: i32, handler: PyObjectRef, vm: &VirtualMachine) -> PyResult {
     assert_in_range(signalnum, vm)?;
+    let signal_handlers = vm
+        .signal_handlers
+        .as_ref()
+        .ok_or_else(|| vm.new_value_error("signal only works in main thread".to_owned()))?;
 
     let sig_handler = match usize::try_from_object(vm, handler.clone()).ok() {
         Some(SIG_DFL) => SIG_DFL,
@@ -68,7 +72,7 @@ fn signal(signalnum: i32, handler: PyObjectRef, vm: &VirtualMachine) -> PyResult
 
     let mut old_handler = handler;
     std::mem::swap(
-        &mut vm.signal_handlers.borrow_mut()[signalnum as usize],
+        &mut signal_handlers.borrow_mut()[signalnum as usize],
         &mut old_handler,
     );
     Ok(old_handler)
@@ -76,7 +80,11 @@ fn signal(signalnum: i32, handler: PyObjectRef, vm: &VirtualMachine) -> PyResult
 
 fn getsignal(signalnum: i32, vm: &VirtualMachine) -> PyResult {
     assert_in_range(signalnum, vm)?;
-    Ok(vm.signal_handlers.borrow()[signalnum as usize].clone())
+    let signal_handlers = vm
+        .signal_handlers
+        .as_ref()
+        .ok_or_else(|| vm.new_value_error("getsignal only works in main thread".to_owned()))?;
+    Ok(signal_handlers.borrow()[signalnum as usize].clone())
 }
 
 #[cfg(unix)]
@@ -91,13 +99,18 @@ fn alarm(time: u32) -> u32 {
 
 #[cfg_attr(feature = "flame-it", flame)]
 pub fn check_signals(vm: &VirtualMachine) -> PyResult<()> {
+    let signal_handlers = match vm.signal_handlers {
+        Some(ref h) => h.borrow(),
+        None => return Ok(()),
+    };
+
     if !ANY_TRIGGERED.swap(false, Ordering::Relaxed) {
         return Ok(());
     }
     for (signum, trigger) in TRIGGERS.iter().enumerate().skip(1) {
         let triggerd = trigger.swap(false, Ordering::Relaxed);
         if triggerd {
-            let handler = &vm.signal_handlers.borrow()[signum];
+            let handler = &signal_handlers[signum];
             if vm.is_callable(handler) {
                 vm.invoke(handler, vec![vm.new_int(signum), vm.get_none()])?;
             }
@@ -145,7 +158,7 @@ pub fn make_module(vm: &VirtualMachine) -> PyObjectRef {
         } else {
             vm.get_none()
         };
-        vm.signal_handlers.borrow_mut()[signum] = py_handler;
+        vm.signal_handlers.as_ref().unwrap().borrow_mut()[signum] = py_handler;
     }
 
     signal(libc::SIGINT, int_handler, vm).expect("Failed to set sigint handler");

--- a/vm/src/sysmodule.rs
+++ b/vm/src/sysmodule.rs
@@ -154,14 +154,14 @@ fn update_use_tracing(vm: &VirtualMachine) {
 }
 
 fn sys_getrecursionlimit(vm: &VirtualMachine) -> usize {
-    vm.recursion_limit.get()
+    vm.state.recursion_limit.load()
 }
 
 fn sys_setrecursionlimit(recursion_limit: usize, vm: &VirtualMachine) -> PyResult {
     let recursion_depth = vm.frames.borrow().len();
 
     if recursion_limit > recursion_depth + 1 {
-        vm.recursion_limit.set(recursion_limit);
+        vm.state.recursion_limit.store(recursion_limit);
         Ok(vm.ctx.none())
     } else {
         Err(vm.new_recursion_error(format!(
@@ -348,7 +348,7 @@ setprofile() -- set the global profiling function
 setrecursionlimit() -- set the max recursion depth for the interpreter
 settrace() -- set the global debug tracing function
 ";
-    let mut module_names: Vec<String> = vm.stdlib_inits.borrow().keys().cloned().collect();
+    let mut module_names: Vec<String> = vm.state.stdlib_inits.keys().cloned().collect();
     module_names.push("sys".to_owned());
     module_names.push("builtins".to_owned());
     module_names.sort();

--- a/vm/src/sysmodule.rs
+++ b/vm/src/sysmodule.rs
@@ -155,14 +155,14 @@ fn update_use_tracing(vm: &VirtualMachine) {
 }
 
 fn sys_getrecursionlimit(vm: &VirtualMachine) -> usize {
-    vm.state.recursion_limit.load()
+    vm.recursion_limit.get()
 }
 
 fn sys_setrecursionlimit(recursion_limit: usize, vm: &VirtualMachine) -> PyResult {
     let recursion_depth = vm.frames.borrow().len();
 
     if recursion_limit > recursion_depth + 1 {
-        vm.state.recursion_limit.store(recursion_limit);
+        vm.recursion_limit.set(recursion_limit);
         Ok(vm.ctx.none())
     } else {
         Err(vm.new_recursion_error(format!(

--- a/vm/src/sysmodule.rs
+++ b/vm/src/sysmodule.rs
@@ -18,7 +18,8 @@ use crate::vm::{PySettings, VirtualMachine};
 
 fn argv(vm: &VirtualMachine) -> PyObjectRef {
     vm.ctx.new_list(
-        vm.settings
+        vm.state
+            .settings
             .argv
             .iter()
             .map(|arg| vm.new_str(arg.to_owned()))
@@ -150,7 +151,7 @@ fn update_use_tracing(vm: &VirtualMachine) {
     let trace_is_none = vm.is_none(&vm.trace_func.borrow());
     let profile_is_none = vm.is_none(&vm.profile_func.borrow());
     let tracing = !(trace_is_none && profile_is_none);
-    vm.use_tracing.replace(tracing);
+    vm.use_tracing.set(tracing);
 }
 
 fn sys_getrecursionlimit(vm: &VirtualMachine) -> usize {
@@ -225,7 +226,7 @@ pub fn make_module(vm: &VirtualMachine, module: PyObjectRef, builtins: PyObjectR
     let ctx = &vm.ctx;
 
     let flags_type = SysFlags::make_class(ctx);
-    let flags = SysFlags::from_settings(&vm.settings)
+    let flags = SysFlags::from_settings(&vm.state.settings)
         .into_struct_sequence(vm, flags_type)
         .unwrap();
 
@@ -246,7 +247,8 @@ pub fn make_module(vm: &VirtualMachine, module: PyObjectRef, builtins: PyObjectR
     });
 
     let path = ctx.new_list(
-        vm.settings
+        vm.state
+            .settings
             .path_list
             .iter()
             .map(|path| ctx.new_str(path.clone()))
@@ -399,7 +401,7 @@ settrace() -- set the global debug tracing function
       "path_hooks" => ctx.new_list(vec![]),
       "path_importer_cache" => ctx.new_dict(),
       "pycache_prefix" => vm.get_none(),
-      "dont_write_bytecode" => vm.new_bool(vm.settings.dont_write_bytecode),
+      "dont_write_bytecode" => vm.new_bool(vm.state.settings.dont_write_bytecode),
       "setprofile" => ctx.new_function(sys_setprofile),
       "setrecursionlimit" => ctx.new_function(sys_setrecursionlimit),
       "settrace" => ctx.new_function(sys_settrace),

--- a/wasm/lib/src/browser_module.rs
+++ b/wasm/lib/src/browser_module.rs
@@ -1,5 +1,6 @@
 use futures::Future;
 use js_sys::Promise;
+use std::sync::Arc;
 use wasm_bindgen::prelude::*;
 use wasm_bindgen::JsCast;
 use wasm_bindgen_futures::{future_to_promise, JsFuture};
@@ -367,11 +368,12 @@ pub fn make_module(vm: &VirtualMachine) -> PyObjectRef {
     })
 }
 
-pub fn setup_browser_module(vm: &VirtualMachine) {
-    vm.stdlib_inits
-        .borrow_mut()
+pub fn setup_browser_module(vm: &mut VirtualMachine) {
+    let state = Arc::get_mut(&mut vm.state).unwrap();
+    state
+        .stdlib_inits
         .insert("_browser".to_owned(), Box::new(make_module));
-    vm.frozen.borrow_mut().extend(py_compile_bytecode!(
+    state.frozen.extend(py_compile_bytecode!(
         file = "src/browser.py",
         module_name = "browser",
     ));

--- a/wasm/lib/src/js_module.rs
+++ b/wasm/lib/src/js_module.rs
@@ -5,6 +5,7 @@ use rustpython_vm::obj::{objfloat::PyFloatRef, objstr::PyStringRef, objtype::PyC
 use rustpython_vm::pyobject::{PyClassImpl, PyObjectRef, PyRef, PyResult, PyValue, TryFromObject};
 use rustpython_vm::types::create_type;
 use rustpython_vm::VirtualMachine;
+use std::sync::Arc;
 use wasm_bindgen::{prelude::*, JsCast};
 
 #[wasm_bindgen(inline_js = "
@@ -253,8 +254,9 @@ pub fn make_module(vm: &VirtualMachine) -> PyObjectRef {
     })
 }
 
-pub fn setup_js_module(vm: &VirtualMachine) {
-    vm.stdlib_inits
-        .borrow_mut()
+pub fn setup_js_module(vm: &mut VirtualMachine) {
+    let state = Arc::get_mut(&mut vm.state).unwrap();
+    state
+        .stdlib_inits
         .insert("_js".to_owned(), Box::new(make_module));
 }


### PR DESCRIPTION
In preparation for threading; we want to keep some properties of the vm consistent across threads, so I'm moving the ones that should be into an `Arc`.