### PR TITLE
update rust version in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ A Python-3 (CPython >= 3.5.0) Interpreter written in Rust :snake: :scream:
 
 #### Check out our [online demo](https://rustpython.github.io/demo/) running on WebAssembly.
 
-RustPython requires Rust latest stable version (e.g 1.38.0 at Oct 1st 2019). 
+RustPython requires Rust latest stable version (e.g 1.43.0 at May 24th 2020). 
 To check Rust version: `rustc --version` If you wish to update,
 `rustup update stable`.
 


### PR DESCRIPTION
Had issues installing with 1.40.0 which the readme implies could work. Thanks @youknowone realized it was out of date, thought I'd update to reflect that.