### PR TITLE
Switch to using parking_lot::Mutex instead of std::sync::Mutex

### DIFF
--- a/derive/src/pyclass.rs
+++ b/derive/src/pyclass.rs
@@ -275,7 +275,7 @@ fn extract_impl_items(mut items: Vec<ItemIdent>) -> Result<TokenStream2, Diagnos
                 #transform(Self::#item_ident)
             };
             Some(quote! {
-                (*class.slots.write().unwrap()).#slot_ident = Some(#into_func);
+                (*class.slots.write()).#slot_ident = Some(#into_func);
             })
         }
         _ => None,

--- a/vm/src/macros.rs
+++ b/vm/src/macros.rs
@@ -37,7 +37,7 @@ macro_rules! py_class {
         {
             let py_class = $ctx.new_class($class_name, $class_base);
             // FIXME: setting flag here probably wrong
-            py_class.slots.write().unwrap().flags |= $crate::slots::PyTpFlags::BASETYPE;
+            py_class.slots.write().flags |= $crate::slots::PyTpFlags::BASETYPE;
             $crate::extend_class!($ctx, &py_class, { $($name => $value),* });
             py_class
         }
@@ -54,7 +54,7 @@ macro_rules! extend_class {
     };
 
     (@set_attr($ctx:expr, $class:expr, (slot $slot_name:ident), $value:expr)) => {
-        $class.slots.write().unwrap().$slot_name = Some(
+        $class.slots.write().$slot_name = Some(
             $crate::function::IntoPyNativeFunc::into_func($value)
         );
     };

--- a/vm/src/obj/objbytearray.rs
+++ b/vm/src/obj/objbytearray.rs
@@ -1,10 +1,10 @@
 //! Implementation of the python bytearray object.
 use bstr::ByteSlice;
 use crossbeam_utils::atomic::AtomicCell;
+use parking_lot::{RwLock, RwLockReadGuard, RwLockWriteGuard};
 use std::convert::TryFrom;
 use std::mem::size_of;
 use std::str::FromStr;
-use std::sync::{RwLock, RwLockReadGuard, RwLockWriteGuard};
 
 use super::objbyteinner::{
     ByteInnerFindOptions, ByteInnerNewOptions, ByteInnerPaddingOptions, ByteInnerSplitOptions,
@@ -58,11 +58,11 @@ impl PyByteArray {
     }
 
     pub fn borrow_value(&self) -> RwLockReadGuard<'_, PyByteInner> {
-        self.inner.read().unwrap()
+        self.inner.read()
     }
 
     pub fn borrow_value_mut(&self) -> RwLockWriteGuard<'_, PyByteInner> {
-        self.inner.write().unwrap()
+        self.inner.write()
     }
 }
 

--- a/vm/src/obj/objcoroinner.rs
+++ b/vm/src/obj/objcoroinner.rs
@@ -5,7 +5,7 @@ use crate::pyobject::{PyObjectRef, PyResult};
 use crate::vm::VirtualMachine;
 
 use crossbeam_utils::atomic::AtomicCell;
-use std::sync::RwLock;
+use parking_lot::RwLock;
 
 #[derive(Debug, PartialEq, Clone, Copy)]
 pub enum Variant {
@@ -69,10 +69,10 @@ impl Coro {
         let curr_exception_stack_len = vm.exceptions.borrow().len();
         vm.exceptions
             .borrow_mut()
-            .append(&mut self.exceptions.write().unwrap());
+            .append(&mut self.exceptions.write());
         let result = vm.with_frame(self.frame.clone(), func);
         std::mem::swap(
-            &mut *self.exceptions.write().unwrap(),
+            &mut *self.exceptions.write(),
             &mut vm
                 .exceptions
                 .borrow_mut()

--- a/vm/src/obj/objenumerate.rs
+++ b/vm/src/obj/objenumerate.rs
@@ -1,5 +1,5 @@
+use parking_lot::RwLock;
 use std::ops::AddAssign;
-use std::sync::RwLock;
 
 use num_bigint::BigInt;
 use num_traits::Zero;
@@ -50,7 +50,7 @@ impl PyEnumerate {
     #[pymethod(name = "__next__")]
     fn next(&self, vm: &VirtualMachine) -> PyResult<(BigInt, PyObjectRef)> {
         let next_obj = objiter::call_next(vm, &self.iterator)?;
-        let mut counter = self.counter.write().unwrap();
+        let mut counter = self.counter.write();
         let position = counter.clone();
         AddAssign::add_assign(&mut counter as &mut BigInt, 1);
         Ok((position, next_obj))

--- a/vm/src/obj/objlist.rs
+++ b/vm/src/obj/objlist.rs
@@ -1,11 +1,11 @@
 use std::fmt;
 use std::mem::size_of;
 use std::ops::{DerefMut, Range};
-use std::sync::{RwLock, RwLockReadGuard, RwLockWriteGuard};
 
 use crossbeam_utils::atomic::AtomicCell;
 use num_bigint::{BigInt, ToBigInt};
 use num_traits::{One, Signed, ToPrimitive, Zero};
+use parking_lot::{RwLock, RwLockReadGuard, RwLockWriteGuard};
 
 use super::objbool;
 use super::objbyteinner;
@@ -55,11 +55,11 @@ impl PyValue for PyList {
 
 impl PyList {
     pub fn borrow_elements(&self) -> RwLockReadGuard<'_, Vec<PyObjectRef>> {
-        self.elements.read().unwrap()
+        self.elements.read()
     }
 
     pub fn borrow_elements_mut(&self) -> RwLockWriteGuard<'_, Vec<PyObjectRef>> {
-        self.elements.write().unwrap()
+        self.elements.write()
     }
 
     pub(crate) fn get_byte_inner(

--- a/vm/src/obj/objmappingproxy.rs
+++ b/vm/src/obj/objmappingproxy.rs
@@ -87,7 +87,7 @@ impl PyMappingProxy {
             MappingProxyInner::Dict(d) => d.clone(),
             MappingProxyInner::Class(c) => {
                 // TODO: something that's much more efficient than this
-                PyDictRef::from_attributes(c.attributes.read().unwrap().clone(), vm)?.into_object()
+                PyDictRef::from_attributes(c.attributes.read().clone(), vm)?.into_object()
             }
         };
         objiter::get_iter(vm, &obj)
@@ -97,7 +97,7 @@ impl PyMappingProxy {
         let obj = match &self.mapping {
             MappingProxyInner::Dict(d) => d.clone(),
             MappingProxyInner::Class(c) => {
-                PyDictRef::from_attributes(c.attributes.read().unwrap().clone(), vm)?.into_object()
+                PyDictRef::from_attributes(c.attributes.read().clone(), vm)?.into_object()
             }
         };
         vm.call_method(&obj, "items", vec![])
@@ -107,7 +107,7 @@ impl PyMappingProxy {
         let obj = match &self.mapping {
             MappingProxyInner::Dict(d) => d.clone(),
             MappingProxyInner::Class(c) => {
-                PyDictRef::from_attributes(c.attributes.read().unwrap().clone(), vm)?.into_object()
+                PyDictRef::from_attributes(c.attributes.read().clone(), vm)?.into_object()
             }
         };
         vm.call_method(&obj, "keys", vec![])
@@ -117,7 +117,7 @@ impl PyMappingProxy {
         let obj = match &self.mapping {
             MappingProxyInner::Dict(d) => d.clone(),
             MappingProxyInner::Class(c) => {
-                PyDictRef::from_attributes(c.attributes.read().unwrap().clone(), vm)?.into_object()
+                PyDictRef::from_attributes(c.attributes.read().clone(), vm)?.into_object()
             }
         };
         vm.call_method(&obj, "values", vec![])

--- a/vm/src/obj/objproperty.rs
+++ b/vm/src/obj/objproperty.rs
@@ -1,7 +1,7 @@
 /*! Python `property` descriptor class.
 
 */
-use std::sync::RwLock;
+use parking_lot::RwLock;
 
 use super::objtype::PyClassRef;
 use crate::function::OptionalArg;
@@ -141,11 +141,11 @@ impl PyProperty {
     }
 
     fn doc_getter(&self) -> Option<PyObjectRef> {
-        self.doc.read().unwrap().clone()
+        self.doc.read().clone()
     }
 
     fn doc_setter(&self, value: PyObjectRef, vm: &VirtualMachine) {
-        *self.doc.write().unwrap() = py_none_to_option(vm, &value);
+        *self.doc.write() = py_none_to_option(vm, &value);
     }
 
     // Python builder functions

--- a/vm/src/sequence.rs
+++ b/vm/src/sequence.rs
@@ -1,7 +1,7 @@
 use crate::pyobject::{IdProtocol, PyObjectRef, PyResult};
 use crate::vm::VirtualMachine;
+use parking_lot::{RwLockReadGuard, RwLockWriteGuard};
 use std::ops::Deref;
-use std::sync::{RwLockReadGuard, RwLockWriteGuard};
 
 type DynPyIter<'a> = Box<dyn ExactSizeIterator<Item = &'a PyObjectRef> + 'a>;
 

--- a/vm/src/stdlib/array.rs
+++ b/vm/src/stdlib/array.rs
@@ -10,8 +10,8 @@ use crate::pyobject::{
 };
 use crate::VirtualMachine;
 
+use parking_lot::{RwLock, RwLockReadGuard, RwLockWriteGuard};
 use std::fmt;
-use std::sync::{RwLock, RwLockReadGuard, RwLockWriteGuard};
 
 use crossbeam_utils::atomic::AtomicCell;
 
@@ -239,11 +239,11 @@ impl PyValue for PyArray {
 #[pyimpl(flags(BASETYPE))]
 impl PyArray {
     fn borrow_value(&self) -> RwLockReadGuard<'_, ArrayContentType> {
-        self.array.read().unwrap()
+        self.array.read()
     }
 
     fn borrow_value_mut(&self) -> RwLockWriteGuard<'_, ArrayContentType> {
-        self.array.write().unwrap()
+        self.array.write()
     }
 
     #[pyslot]

--- a/vm/src/stdlib/collections.rs
+++ b/vm/src/stdlib/collections.rs
@@ -12,8 +12,8 @@ mod _collections {
     use crate::vm::ReprGuard;
     use crate::VirtualMachine;
     use itertools::Itertools;
+    use parking_lot::{RwLock, RwLockReadGuard, RwLockWriteGuard};
     use std::collections::VecDeque;
-    use std::sync::{RwLock, RwLockReadGuard, RwLockWriteGuard};
 
     use crossbeam_utils::atomic::AtomicCell;
 
@@ -39,11 +39,11 @@ mod _collections {
 
     impl PyDeque {
         fn borrow_deque(&self) -> RwLockReadGuard<'_, VecDeque<PyObjectRef>> {
-            self.deque.read().unwrap()
+            self.deque.read()
         }
 
         fn borrow_deque_mut(&self) -> RwLockWriteGuard<'_, VecDeque<PyObjectRef>> {
-            self.deque.write().unwrap()
+            self.deque.write()
         }
     }
 

--- a/vm/src/stdlib/csv.rs
+++ b/vm/src/stdlib/csv.rs
@@ -1,5 +1,5 @@
+use parking_lot::RwLock;
 use std::fmt::{self, Debug, Formatter};
-use std::sync::RwLock;
 
 use csv as rust_csv;
 use itertools::join;
@@ -152,13 +152,13 @@ impl Reader {
 impl Reader {
     #[pymethod(name = "__iter__")]
     fn iter(this: PyRef<Self>, vm: &VirtualMachine) -> PyResult {
-        this.state.write().unwrap().cast_to_reader(vm)?;
+        this.state.write().cast_to_reader(vm)?;
         this.into_pyobject(vm)
     }
 
     #[pymethod(name = "__next__")]
     fn next(&self, vm: &VirtualMachine) -> PyResult {
-        let mut state = self.state.write().unwrap();
+        let mut state = self.state.write();
         state.cast_to_reader(vm)?;
 
         if let ReadState::CsvIter(ref mut reader) = &mut *state {

--- a/vm/src/stdlib/hashlib.rs
+++ b/vm/src/stdlib/hashlib.rs
@@ -4,8 +4,8 @@ use crate::obj::objstr::PyStringRef;
 use crate::obj::objtype::PyClassRef;
 use crate::pyobject::{PyClassImpl, PyObjectRef, PyResult, PyValue};
 use crate::vm::VirtualMachine;
+use parking_lot::{RwLock, RwLockReadGuard, RwLockWriteGuard};
 use std::fmt;
-use std::sync::{RwLock, RwLockReadGuard, RwLockWriteGuard};
 
 use blake2::{Blake2b, Blake2s};
 use digest::DynDigest;
@@ -42,11 +42,11 @@ impl PyHasher {
     }
 
     fn borrow_value(&self) -> RwLockReadGuard<'_, HashWrapper> {
-        self.buffer.read().unwrap()
+        self.buffer.read()
     }
 
     fn borrow_value_mut(&self) -> RwLockWriteGuard<'_, HashWrapper> {
-        self.buffer.write().unwrap()
+        self.buffer.write()
     }
 
     #[pyslot]

--- a/vm/src/stdlib/io.rs
+++ b/vm/src/stdlib/io.rs
@@ -1,9 +1,9 @@
 /*
  * I/O core tools.
  */
+use parking_lot::{RwLock, RwLockWriteGuard};
 use std::fs;
 use std::io::{self, prelude::*, Cursor, SeekFrom};
-use std::sync::{RwLock, RwLockWriteGuard};
 
 use crossbeam_utils::atomic::AtomicCell;
 use num_traits::ToPrimitive;
@@ -136,7 +136,7 @@ impl PyValue for PyStringIO {
 impl PyStringIORef {
     fn buffer(&self, vm: &VirtualMachine) -> PyResult<RwLockWriteGuard<'_, BufferedIO>> {
         if !self.closed.load() {
-            Ok(self.buffer.write().unwrap())
+            Ok(self.buffer.write())
         } else {
             Err(vm.new_value_error("I/O operation on closed file.".to_owned()))
         }
@@ -259,7 +259,7 @@ impl PyValue for PyBytesIO {
 impl PyBytesIORef {
     fn buffer(&self, vm: &VirtualMachine) -> PyResult<RwLockWriteGuard<'_, BufferedIO>> {
         if !self.closed.load() {
-            Ok(self.buffer.write().unwrap())
+            Ok(self.buffer.write())
         } else {
             Err(vm.new_value_error("I/O operation on closed file.".to_owned()))
         }

--- a/vm/src/stdlib/os.rs
+++ b/vm/src/stdlib/os.rs
@@ -1,3 +1,4 @@
+use parking_lot::RwLock;
 use std::ffi;
 use std::fs::File;
 use std::fs::OpenOptions;
@@ -6,7 +7,6 @@ use std::io::{self, ErrorKind, Read, Write};
 use std::os::unix::fs::OpenOptionsExt;
 #[cfg(windows)]
 use std::os::windows::fs::OpenOptionsExt;
-use std::sync::RwLock;
 use std::time::{Duration, SystemTime};
 use std::{env, fs};
 
@@ -727,7 +727,7 @@ impl ScandirIterator {
             return Err(objiter::new_stop_iteration(vm));
         }
 
-        match self.entries.write().unwrap().next() {
+        match self.entries.write().next() {
             Some(entry) => match entry {
                 Ok(entry) => Ok(DirEntry {
                     entry,

--- a/vm/src/stdlib/random.rs
+++ b/vm/src/stdlib/random.rs
@@ -13,7 +13,7 @@ mod _random {
     use num_traits::Signed;
     use rand::{rngs::StdRng, RngCore, SeedableRng};
 
-    use std::sync::Mutex;
+    use parking_lot::Mutex;
 
     #[derive(Debug)]
     enum PyRng {
@@ -78,7 +78,7 @@ mod _random {
 
         #[pymethod]
         fn random(&self) -> f64 {
-            let mut rng = self.rng.lock().unwrap();
+            let mut rng = self.rng.lock();
             mt19937::gen_res53(&mut *rng)
         }
 
@@ -95,12 +95,12 @@ mod _random {
                 }
             };
 
-            *self.rng.lock().unwrap() = new_rng;
+            *self.rng.lock() = new_rng;
         }
 
         #[pymethod]
         fn getrandbits(&self, k: usize) -> BigInt {
-            let mut rng = self.rng.lock().unwrap();
+            let mut rng = self.rng.lock();
             let mut k = k;
             let mut gen_u32 = |k| rng.next_u32() >> (32 - k) as u32;
 

--- a/vm/src/stdlib/socket.rs
+++ b/vm/src/stdlib/socket.rs
@@ -1,6 +1,6 @@
+use parking_lot::{RwLock, RwLockReadGuard, RwLockWriteGuard};
 use std::io::{self, prelude::*};
 use std::net::{Ipv4Addr, Shutdown, SocketAddr, ToSocketAddrs};
-use std::sync::{RwLock, RwLockReadGuard, RwLockWriteGuard};
 use std::time::Duration;
 
 use byteorder::{BigEndian, ByteOrder};
@@ -76,11 +76,11 @@ pub type PySocketRef = PyRef<PySocket>;
 #[pyimpl(flags(BASETYPE))]
 impl PySocket {
     fn sock(&self) -> RwLockReadGuard<'_, Socket> {
-        self.sock.read().unwrap()
+        self.sock.read()
     }
 
     fn sock_mut(&self) -> RwLockWriteGuard<'_, Socket> {
-        self.sock.write().unwrap()
+        self.sock.write()
     }
 
     #[pyslot]
@@ -127,7 +127,7 @@ impl PySocket {
             self.proto.store(proto);
             sock
         };
-        *self.sock.write().unwrap() = sock;
+        *self.sock.write() = sock;
         Ok(())
     }
 

--- a/vm/src/stdlib/winreg.rs
+++ b/vm/src/stdlib/winreg.rs
@@ -1,7 +1,7 @@
 #![allow(non_snake_case)]
+use parking_lot::{RwLock, RwLockReadGuard, RwLockWriteGuard};
 use std::convert::TryInto;
 use std::io;
-use std::sync::{RwLock, RwLockReadGuard, RwLockWriteGuard};
 
 use super::os;
 use crate::function::OptionalArg;
@@ -38,11 +38,11 @@ impl PyHKEY {
     }
 
     fn key(&self) -> RwLockReadGuard<'_, RegKey> {
-        self.key.read().unwrap()
+        self.key.read()
     }
 
     fn key_mut(&self) -> RwLockWriteGuard<'_, RegKey> {
-        self.key.write().unwrap()
+        self.key.write()
     }
 
     #[pymethod]

--- a/vm/src/types.rs
+++ b/vm/src/types.rs
@@ -40,9 +40,10 @@ use crate::obj::objweakproxy;
 use crate::obj::objweakref;
 use crate::obj::objzip;
 use crate::pyobject::{PyAttributes, PyContext, PyObject};
+use parking_lot::RwLock;
 use std::mem::MaybeUninit;
 use std::ptr;
-use std::sync::{Arc, RwLock};
+use std::sync::Arc;
 
 /// Holder of references to builtin types.
 #[derive(Debug)]
@@ -350,7 +351,6 @@ fn init_type_hierarchy() -> (PyClassRef, PyClassRef) {
     object_type
         .subclasses
         .write()
-        .unwrap()
         .push(objweakref::PyWeak::downgrade(&type_type.as_object()));
 
     (type_type, object_type)


### PR DESCRIPTION
All of the benefits of `parking_lot::Mutex` over the std one are listed in its
[readme](https://github.com/Amanieu/parking_lot#features), but the ones that apply
to us are copied here:

* Mutex and Once only require 1 byte of storage space, while Condvar and RwLock only require 1 word of storage space. On the other hand the standard library primitives require a dynamically allocated Box to hold OS-specific synchronization primitives. The small size of Mutex in particular encourages the use of fine-grained locks to increase parallelism.
  * less allocation is always good for performance, especially when all PyObjects are allocated and most require Mutexes
* Uncontended lock acquisition and release is done through fast inline paths which only require a single atomic operation.
  * good, since a lot of Python code will only be run single-threaded
* RwLock takes advantage of hardware lock elision on processors that support it, which can lead to huge performance wins with many readers.
  * requires nightly, but we could either build release binaries on nightly or wait until this is possible on stable
* RwLock uses a task-fair locking policy, which avoids reader and writer starvation, whereas the standard library version makes no guarantees.
  * not sure if this is super necessary but it would definitely benefit the GIL-less experiment we're doing here