### PR TITLE
make "frame" module public

### DIFF
--- a/vm/src/lib.rs
+++ b/vm/src/lib.rs
@@ -62,7 +62,7 @@ mod dictdatatype;
 pub mod eval;
 pub mod exceptions;
 pub mod format;
-mod frame;
+pub mod frame;
 mod frozen;
 pub mod function;
 pub mod import;


### PR DESCRIPTION
I'd like to have access to local py script variables after execution embedded script like that:

```Rust
    let frame = Frame::new(code_obj, scope).into_ref(&vm);
    vm.frames.borrow_mut().push(frame.clone());
    let result = frame.run(&vm);
    //Access locals here !!!
    let locals = frame.scope.get_locals();
    vm.frames.borrow_mut().pop();
```