### PR TITLE
Test Annotation Framework for Imported CPython test

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -75,8 +75,8 @@ When importing tests from CPython, please follow the following rules.
 1. Import complete files and document the version of the imported file and the major version this file relates to, e.g., 3.8.
 2. In any case, keep the name of the original tests and test cases unmodified, such that it can always be traced to the original one from CPython.
 3. Modify or substitute test cases, if required, to make them pass. We propose to
- - modify test cases only when threre is only a minor deviation from the original behaviour. E.g., when the text of an error message does not match.
- - substitute test cases when there are severe deviations from the original is required. E.g., when it is necessary to introduce new variables or change the logic of the test or split a test case in several test cases.
+ - modify test cases only when there is only a minor deviation from the original behaviour. E.g., when the text of an error message does not match.
+ - substitute test cases when severe deviations from the original is required. E.g., when it is necessary to introduce new variables or change the logic of the test or split a test case in several test cases.
 4. Add further test cases.
 5. Annotate each test case with:
  - Original and unmodified test case that is supposed to be passed: no annotation is required, but when you want to be more verbose you can use @rpt.imported.original
@@ -84,7 +84,7 @@ When importing tests from CPython, please follow the following rules.
  - Original and unmodified test case that is not executing, causes panic, breaks RustPython, etc.: @rpt.imported.skip
  - Original but modified test case: @rpt.imported.modified
  - Substituted test cases: @prt.imported.substituted (Note: this leads to skipping this test as it is considered as distirbung, by setting the parameter `run=True` it is executed but expected to fail.)
- - New test cases that substitue an original test case: @rpt.ours.subst and refer to the substituted original test cases.
+ - New test cases that substitute for an original test case: @rpt.ours.subst and refer to the substituted original test cases.
  - New test cases that extend an existing test case: @rpt.ours.extends and refers to the extended test case.
  - New test cases without direct relation to an original CPython test case: @rpt.ours.new
  
@@ -112,7 +112,6 @@ exists a raw html viewer which is currently broken, and we welcome a PR to fix i
 
 Understanding a new codebase takes time. Here's a brief view of the
 repository's structure:
-.
 - `bytecode/src`: python bytecode representation in rust structures
 - `compiler/src`: python compilation to bytecode
 - `derive/src`: Rust language extensions and macros specific to rustpython

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -46,7 +46,16 @@ Python code should follow the
 
 ## Testing
 
-To test RustPython's functionality, a collection of Python snippets is located
+RustPython uses three classes of tests. First, rust unit tests, second, our 
+own tests written in python, and last, tests imported from CPython. 
+
+Rust unit tests can be run with `cargo`:
+
+```shell
+$ cargo test --all
+```
+
+Our own collection of tests, called snippets, to test RustPython's functionality is located
 in the `tests/snippets` directory and can be run using `pytest`:
 
 ```shell
@@ -54,11 +63,32 @@ $ cd tests
 $ pytest -v
 ```
 
-Rust unit tests can be run with `cargo`:
+A set of annotated CPython tests are located in `Lib/tests`. Execute them by
 
 ```shell
-$ cargo test --all
+$ cargo run --release -- -m test
 ```
+
+
+### Creating tests
+When importing tests from CPython, please follow the following rules.
+1. Import complete files and document the version of the imported file and the major version this file relates to, e.g., 3.8.
+2. In any case, keep the name of the original tests and test cases unmodified, such that it can always be traced to the original one from CPython.
+3. Modify or substitute test cases, if required, to make them pass. We propose to
+ - modify test cases only when threre is only a minor deviation from the original behaviour. E.g., when the text of an error message does not match.
+ - substitute test cases when there are severe deviations from the original is required. E.g., when it is necessary to introduce new variables or change the logic of the test or split a test case in several test cases.
+4. Add further test cases.
+5. Annotate each test case with:
+ - Original and unmodified test case that is supposed to be passed: no annotation is required, but when you want to be more verbose you can use @rpt.imported.original
+ - Original and unmodified test case that is supposed to be failed: @rpt.imported.fail
+ - Original and unmodified test case that is not executing, causes panic, breaks RustPython, etc.: @rpt.imported.skip
+ - Original but modified test case: @rpt.imported.modified
+ - Substituted test cases: @prt.imported.substituted (Note: this leads to skipping this test as it is considered as distirbung, by setting the parameter `run=True` it is executed but expected to fail.)
+ - New test cases that substitue an original test case: @rpt.ours.subst and refer to the substituted original test cases.
+ - New test cases that extend an existing test case: @rpt.ours.extends and refers to the extended test case.
+ - New test cases without direct relation to an original CPython test case: @rpt.ours.new
+ 
+
 
 ## Profiling
 
@@ -82,7 +112,7 @@ exists a raw html viewer which is currently broken, and we welcome a PR to fix i
 
 Understanding a new codebase takes time. Here's a brief view of the
 repository's structure:
-
+.
 - `bytecode/src`: python bytecode representation in rust structures
 - `compiler/src`: python compilation to bytecode
 - `derive/src`: Rust language extensions and macros specific to rustpython

--- a/Lib/test/librptest/__init__.py
+++ b/Lib/test/librptest/__init__.py
@@ -1,0 +1,5 @@
+
+
+from .rptest import *
+from .core import *
+

--- a/Lib/test/librptest/core.py
+++ b/Lib/test/librptest/core.py
@@ -1,10 +1,10 @@
-
-
-import types
-
 '''
 Core Functions Logic to manage and evaluate test case annotations.
 '''
+
+import types
+
+
 
 substitutions = {}
 marked_test_cases = {}

--- a/Lib/test/librptest/core.py
+++ b/Lib/test/librptest/core.py
@@ -19,11 +19,11 @@ def add_subst(fct, subst, reason=None):
     else:
         substitutions[fct]=set([(subst, reason)])
 
-### Returns True if a fucntion is substituted otherwise False.
+### Returns True if a function is substituted otherwise False.
 def is_subsituted(fct):
     return fct in substitutions
 
-### Returns a list of functions that are beeing  used as substitutes of the 
+### Returns a list of functions that are being used as substitutes of the 
 ### original function fct. Does not fail and returns an empty set if the function
 ### has no known substitutes.
 def get_substitutions(fct):
@@ -32,8 +32,8 @@ def get_substitutions(fct):
     except:
         return set()
 
-### Add a function that is marked as beeing substituted 
-### When the function is alread known, nothing happens.
+### Add a function that is marked as being substituted 
+### When the function is already known, nothing happens.
 def register_subst(fct):
     if not fct in substitutions:
         substitutions[fct]=set()

--- a/Lib/test/librptest/core.py
+++ b/Lib/test/librptest/core.py
@@ -3,6 +3,7 @@ Core Functions Logic to manage and evaluate test case annotations.
 '''
 
 import types
+import collections
 
 
 
@@ -20,7 +21,7 @@ def add_subst(fct, subst, reason=None):
         substitutions[fct]=set([(subst, reason)])
 
 ### Returns True if a function is substituted otherwise False.
-def is_subsituted(fct):
+def is_substituted(fct):
     return fct in substitutions
 
 ### Returns a list of functions that are being used as substitutes of the 

--- a/Lib/test/librptest/core.py
+++ b/Lib/test/librptest/core.py
@@ -1,0 +1,76 @@
+
+
+import types
+
+'''
+Core Functions Logic to manage and evaluate test case annotations.
+'''
+
+substitutions = {}
+marked_test_cases = {}
+
+### Adds a function as a substitute of the original function fct.
+def add_subst(fct, subst, reason=None):
+    if fct==None:
+        return
+    
+    if fct in substitutions:
+        substitutions[fct].add((subst, reason))
+    else:
+        substitutions[fct]=set([(subst, reason)])
+
+### Returns True if a fucntion is substituted otherwise False.
+def is_subsituted(fct):
+    return fct in substitutions
+
+### Returns a list of functions that are beeing  used as substitutes of the 
+### original function fct. Does not fail and returns an empty set if the function
+### has no known substitutes.
+def get_substitutions(fct):
+    try:
+        return substitutions[fct]
+    except:
+        return set()
+
+### Add a function that is marked as beeing substituted 
+### When the function is alread known, nothing happens.
+def register_subst(fct):
+    if not fct in substitutions:
+        substitutions[fct]=set()
+
+def get_all_substitutions():
+    return substitutions
+
+def decorate_test_case_with_reason(tc_or_reason, deco, *args, **kwargs):
+    if isinstance(tc_or_reason, types.FunctionType):
+        return deco(tc_or_reason, *args, **kwargs)
+    else:
+        # expect that it is a reason
+        def decorator(test_case):
+            return deco(test_case)
+        return decorator
+
+def mark_test_case_or_reason(tc_or_reason, marker):
+    def mark(test_case):
+        if marker in marked_test_cases:
+            marked_test_cases[marker].add(test_case)
+        else:
+            marked_test_cases[marker] = set([test_case])
+
+    def decorator(test_case):
+        mark(test_case)
+        return test_case
+
+    if isinstance(tc_or_reason, types.FunctionType):
+        mark(tc_or_reason)
+        return tc_or_reason
+    else:
+        return decorator
+
+    
+
+def get_marked_test_cases(marker):
+    try:
+        return marked_test_cases[marker]
+    except:
+        return set()

--- a/Lib/test/librptest/imported.py
+++ b/Lib/test/librptest/imported.py
@@ -1,0 +1,37 @@
+
+
+import types
+import unittest
+from .core import decorate_test_case_with_reason, mark_test_case_or_reason, get_marked_test_cases
+
+class OriginalMarker:pass
+class ModifiedMarker:pass
+
+
+'''
+Front end for RPT for imported test cases.
+'''
+
+def get_originals():
+    return get_marked_test_cases(OriginalMarker)
+
+def original(test_case):
+    mark_test_case_or_reason(test_case, OriginalMarker)
+    return test_case
+
+
+def skip(reason):
+    return decorate_test_case_with_reason(reason, unittest.skip)
+
+def fail(reason):
+    return decorate_test_case_with_reason(reason, unittest.expectedFailure)
+
+def mark_as_modified(reason):
+    return reason
+
+def modified(reason):
+    return decorate_test_case_with_reason(reason, mark_as_modified)
+
+def substituted(reason=None,run=False):
+    fct=unittest.skip if not run else unittest.expectedFailure
+    return decorate_test_case_with_reason(reason, fct)

--- a/Lib/test/librptest/imported.py
+++ b/Lib/test/librptest/imported.py
@@ -1,4 +1,6 @@
-
+'''
+Front end for RPT for imported test cases.
+'''
 
 import types
 import unittest
@@ -8,9 +10,7 @@ class OriginalMarker:pass
 class ModifiedMarker:pass
 
 
-'''
-Front end for RPT for imported test cases.
-'''
+
 
 def get_originals():
     return get_marked_test_cases(OriginalMarker)

--- a/Lib/test/librptest/ours.py
+++ b/Lib/test/librptest/ours.py
@@ -1,12 +1,13 @@
+'''
+Front End for own test cases in imported test files.
+'''
 
 import types
 
 from .core import mark_test_case_or_reason, get_marked_test_cases, add_subst, get_substitutions as core_get_subs
 
 
-'''
-Front End for own test cases in imported test files.
-'''
+
 
 
 class MarkNew:pass

--- a/Lib/test/librptest/ours.py
+++ b/Lib/test/librptest/ours.py
@@ -1,0 +1,32 @@
+
+import types
+
+from .core import mark_test_case_or_reason, get_marked_test_cases, add_subst, get_substitutions as core_get_subs
+
+
+'''
+Front End for own test cases in imported test files.
+'''
+
+
+class MarkNew:pass
+class MarkExtension:pass
+
+
+
+def new(test_case):
+    return mark_test_case_or_reason(test_case, MarkNew)
+
+def get_news():
+    return get_marked_test_cases(MarkNew)
+
+def subst(original_tc, reason=None):
+    def sub_decorator(new_tc):
+        add_subst(original_tc, new_tc, reason)
+    return sub_decorator
+
+def get_substitutions(fct):
+    if isinstance(fct, types.FunctionType):
+        fct=fct.__name__
+
+    return core_get_subs(fct)

--- a/Lib/test/librptest/rptest.py
+++ b/Lib/test/librptest/rptest.py
@@ -1,0 +1,51 @@
+
+
+from .imported import original
+from .ours import *
+from .core import *
+
+import unittest
+import types
+import re
+
+# regex to parse urls
+url_regex = re.compile(
+        r'^(?:http|ftp)s?://' # http:// or https://
+        r'(?:(?:[A-Z0-9](?:[A-Z0-9-]{0,61}[A-Z0-9])?\.)+(?:[A-Z]{2,6}\.?|[A-Z0-9-]{2,}\.?)|' #domain...
+        r'localhost|' #localhost...
+        r'\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3})' # ...or ip
+        r'(?::\d+)?' # optional port
+        r'(?:/?|[/?]\S+)$', re.IGNORECASE)
+
+
+def originated_from(major_version, minor_version, original_file_link):
+    '''
+    Annotates a test case class with the python version it relates to and the link to the original file.
+    '''
+    def decorator(test):
+        return test
+
+    assert re.match(url_regex, original_file_link)!=None
+
+    return decorator
+
+
+
+def print_eval():
+    def print_results(res, headline):
+        print(headline)
+        for r in res:
+            print('   '+r)
+        print('\n')
+    
+    print('*******************')
+    print('RPT\n')
+
+    news=get_marked_test_cases(MarkNew)
+    news=[f.__name__ for f in news]
+    print_results(news, 'New Test Cases added to test set')
+
+    subs=get_all_substitutions()
+    res=[r[0] + 'is substituted by ' + str([ f[0].__name__ for f in r[1]]) for r in subs.items()]
+    print_results(res, 'Substituted Test Cases')
+

--- a/Lib/test/test_complex.py
+++ b/Lib/test/test_complex.py
@@ -1,0 +1,712 @@
+import unittest
+import Lib.test.librptest as rpt
+from test import support
+from test.test_grammar import (VALID_UNDERSCORE_LITERALS,
+                               INVALID_UNDERSCORE_LITERALS)
+
+from random import random
+from math import atan2, isnan, copysign
+import operator
+
+INF = float("inf")
+NAN = float("nan")
+# These tests ensure that complex math does the right thing
+
+@rpt.originated_from(3,9,'https://github.com/python/cpython/blob/f9bab74d5b34c64cf061e1629ff5f3092a4ca9b3/Lib/test/test_complex.py')
+class ComplexTest(unittest.TestCase):
+
+    def assertAlmostEqual(self, a, b):
+        if isinstance(a, complex):
+            if isinstance(b, complex):
+                unittest.TestCase.assertAlmostEqual(self, a.real, b.real)
+                unittest.TestCase.assertAlmostEqual(self, a.imag, b.imag)
+            else:
+                unittest.TestCase.assertAlmostEqual(self, a.real, b)
+                unittest.TestCase.assertAlmostEqual(self, a.imag, 0.)
+        else:
+            if isinstance(b, complex):
+                unittest.TestCase.assertAlmostEqual(self, a, b.real)
+                unittest.TestCase.assertAlmostEqual(self, 0., b.imag)
+            else:
+                unittest.TestCase.assertAlmostEqual(self, a, b)
+
+    def assertCloseAbs(self, x, y, eps=1e-9):
+        """Return true iff floats x and y "are close"."""
+        # put the one with larger magnitude second
+        if abs(x) > abs(y):
+            x, y = y, x
+        if y == 0:
+            return abs(x) < eps
+        if x == 0:
+            return abs(y) < eps
+        # check that relative difference < eps
+        self.assertTrue(abs((x-y)/y) < eps)
+
+    def assertFloatsAreIdentical(self, x, y):
+        """assert that floats x and y are identical, in the sense that:
+        (1) both x and y are nans, or
+        (2) both x and y are infinities, with the same sign, or
+        (3) both x and y are zeros, with the same sign, or
+        (4) x and y are both finite and nonzero, and x == y
+
+        """
+        msg = 'floats {!r} and {!r} are not identical'
+
+        if isnan(x) or isnan(y):
+            if isnan(x) and isnan(y):
+                return
+        elif x == y:
+            if x != 0.0:
+                return
+            # both zero; check that signs match
+            elif copysign(1.0, x) == copysign(1.0, y):
+                return
+            else:
+                msg += ': zeros have different signs'
+        self.fail(msg.format(x, y))
+
+    def assertClose(self, x, y, eps=1e-9):
+        """Return true iff complexes x and y "are close"."""
+        self.assertCloseAbs(x.real, y.real, eps)
+        self.assertCloseAbs(x.imag, y.imag, eps)
+
+    def check_div(self, x, y):
+        """Compute complex z=x*y, and check that z/x==y and z/y==x."""
+        z = x * y
+        if x != 0:
+            q = z / x
+            self.assertClose(q, y)
+            q = z.__truediv__(x)
+            self.assertClose(q, y)
+        if y != 0:
+            q = z / y
+            self.assertClose(q, x)
+            q = z.__truediv__(y)
+            self.assertClose(q, x)
+
+    @rpt.imported.fail
+    def test_truediv(self):
+        simple_real = [float(i) for i in range(-5, 6)]
+        simple_complex = [complex(x, y) for x in simple_real for y in simple_real]
+        for x in simple_complex:
+            for y in simple_complex:
+                self.check_div(x, y)
+
+        # A naive complex division algorithm (such as in 2.0) is very prone to
+        # nonsense errors for these (overflows and underflows).
+        self.check_div(complex(1e200, 1e200), 1+0j)
+        self.check_div(complex(1e-200, 1e-200), 1+0j)
+
+        # Just for fun.
+        for i in range(100):
+            self.check_div(complex(random(), random()),
+                           complex(random(), random()))
+
+        self.assertRaises(ZeroDivisionError, complex.__truediv__, 1+1j, 0+0j)
+        self.assertRaises(OverflowError, pow, 1e200+1j, 1e200+1j)
+
+        self.assertAlmostEqual(complex.__truediv__(2+0j, 1+1j), 1-1j)
+        self.assertRaises(ZeroDivisionError, complex.__truediv__, 1+1j, 0+0j)
+
+        for denom_real, denom_imag in [(0, NAN), (NAN, 0), (NAN, NAN)]:
+            z = complex(0, 0) / complex(denom_real, denom_imag)
+            self.assertTrue(isnan(z.real))
+            self.assertTrue(isnan(z.imag))
+
+    def test_floordiv(self):
+        self.assertRaises(TypeError, complex.__floordiv__, 3+0j, 1.5+0j)
+        self.assertRaises(TypeError, complex.__floordiv__, 3+0j, 0+0j)
+
+    def test_richcompare(self):
+        self.assertIs(complex.__eq__(1+1j, 1<<10000), False)
+        self.assertIs(complex.__lt__(1+1j, None), NotImplemented)
+        self.assertIs(complex.__eq__(1+1j, 1+1j), True)
+        self.assertIs(complex.__eq__(1+1j, 2+2j), False)
+        self.assertIs(complex.__ne__(1+1j, 1+1j), False)
+        self.assertIs(complex.__ne__(1+1j, 2+2j), True)
+        for i in range(1, 100):
+            f = i / 100.0
+            self.assertIs(complex.__eq__(f+0j, f), True)
+            self.assertIs(complex.__ne__(f+0j, f), False)
+            self.assertIs(complex.__eq__(complex(f, f), f), False)
+            self.assertIs(complex.__ne__(complex(f, f), f), True)
+        self.assertIs(complex.__lt__(1+1j, 2+2j), NotImplemented)
+        self.assertIs(complex.__le__(1+1j, 2+2j), NotImplemented)
+        self.assertIs(complex.__gt__(1+1j, 2+2j), NotImplemented)
+        self.assertIs(complex.__ge__(1+1j, 2+2j), NotImplemented)
+        self.assertRaises(TypeError, operator.lt, 1+1j, 2+2j)
+        self.assertRaises(TypeError, operator.le, 1+1j, 2+2j)
+        self.assertRaises(TypeError, operator.gt, 1+1j, 2+2j)
+        self.assertRaises(TypeError, operator.ge, 1+1j, 2+2j)
+        self.assertIs(operator.eq(1+1j, 1+1j), True)
+        self.assertIs(operator.eq(1+1j, 2+2j), False)
+        self.assertIs(operator.ne(1+1j, 1+1j), False)
+        self.assertIs(operator.ne(1+1j, 2+2j), True)
+
+    @rpt.imported.fail
+    def test_richcompare_boundaries(self):
+        def check(n, deltas, is_equal, imag = 0.0):
+            for delta in deltas:
+                i = n + delta
+                z = complex(i, imag)
+                self.assertIs(complex.__eq__(z, i), is_equal(delta))
+                self.assertIs(complex.__ne__(z, i), not is_equal(delta))
+        # For IEEE-754 doubles the following should hold:
+        #    x in [2 ** (52 + i), 2 ** (53 + i + 1)] -> x mod 2 ** i == 0
+        # where the interval is representable, of course.
+        for i in range(1, 10):
+            pow = 52 + i
+            mult = 2 ** i
+            check(2 ** pow, range(1, 101), lambda delta: delta % mult == 0)
+            check(2 ** pow, range(1, 101), lambda delta: False, float(i))
+        check(2 ** 53, range(-100, 0), lambda delta: True)
+
+    def test_mod(self):
+        # % is no longer supported on complex numbers
+        self.assertRaises(TypeError, (1+1j).__mod__, 0+0j)
+        self.assertRaises(TypeError, lambda: (3.33+4.43j) % 0)
+        self.assertRaises(TypeError, (1+1j).__mod__, 4.3j)
+
+    def test_divmod(self):
+        self.assertRaises(TypeError, divmod, 1+1j, 1+0j)
+        self.assertRaises(TypeError, divmod, 1+1j, 0+0j)
+
+    @rpt.imported.fail
+    def test_pow(self):
+        self.assertAlmostEqual(pow(1+1j, 0+0j), 1.0)
+        self.assertAlmostEqual(pow(0+0j, 2+0j), 0.0)
+        self.assertRaises(ZeroDivisionError, pow, 0+0j, 1j)
+        self.assertAlmostEqual(pow(1j, -1), 1/1j)
+        self.assertAlmostEqual(pow(1j, 200), 1)
+        self.assertRaises(ValueError, pow, 1+1j, 1+1j, 1+1j)
+
+        a = 3.33+4.43j
+        self.assertEqual(a ** 0j, 1)
+        self.assertEqual(a ** 0.+0.j, 1)
+
+        self.assertEqual(3j ** 0j, 1)
+        self.assertEqual(3j ** 0, 1)
+
+        try:
+            0j ** a
+        except ZeroDivisionError:
+            pass
+        else:
+            self.fail("should fail 0.0 to negative or complex power")
+
+        try:
+            0j ** (3-2j)
+        except ZeroDivisionError:
+            pass
+        else:
+            self.fail("should fail 0.0 to negative or complex power")
+
+        # The following is used to exercise certain code paths
+        self.assertEqual(a ** 105, a ** 105)
+        self.assertEqual(a ** -105, a ** -105)
+        self.assertEqual(a ** -30, a ** -30)
+
+        self.assertEqual(0.0j ** 0, 1)
+
+        b = 5.1+2.3j
+        self.assertRaises(ValueError, pow, a, b, 0)
+
+    def test_boolcontext(self):
+        for i in range(100):
+            self.assertTrue(complex(random() + 1e-6, random() + 1e-6))
+        self.assertTrue(not complex(0.0, 0.0))
+
+    def test_conjugate(self):
+        self.assertClose(complex(5.3, 9.8).conjugate(), 5.3-9.8j)
+
+    @rpt.imported.modified('commented out failing checks')
+    def test_constructor(self):
+        class OS:
+            def __init__(self, value): self.value = value
+            def __complex__(self): return self.value
+        class NS(object):
+            def __init__(self, value): self.value = value
+            def __complex__(self): return self.value
+        #self.assertEqual(complex(OS(1+10j)), 1+10j)
+        #self.assertEqual(complex(NS(1+10j)), 1+10j)
+        self.assertRaises(TypeError, complex, OS(None))
+        self.assertRaises(TypeError, complex, NS(None))
+        self.assertRaises(TypeError, complex, {})
+        self.assertRaises(TypeError, complex, NS(1.5))
+        self.assertRaises(TypeError, complex, NS(1))
+
+        self.assertAlmostEqual(complex("1+10j"), 1+10j)
+        self.assertAlmostEqual(complex(10), 10+0j)
+        self.assertAlmostEqual(complex(10.0), 10+0j)
+        self.assertAlmostEqual(complex(10), 10+0j)
+        #self.assertAlmostEqual(complex(10+0j), 10+0j)
+        self.assertAlmostEqual(complex(1,10), 1+10j)
+        self.assertAlmostEqual(complex(1,10), 1+10j)
+        self.assertAlmostEqual(complex(1,10.0), 1+10j)
+        self.assertAlmostEqual(complex(1,10), 1+10j)
+        self.assertAlmostEqual(complex(1,10), 1+10j)
+        self.assertAlmostEqual(complex(1,10.0), 1+10j)
+        self.assertAlmostEqual(complex(1.0,10), 1+10j)
+        self.assertAlmostEqual(complex(1.0,10), 1+10j)
+        self.assertAlmostEqual(complex(1.0,10.0), 1+10j)
+        #self.assertAlmostEqual(complex(3.14+0j), 3.14+0j)
+        self.assertAlmostEqual(complex(3.14), 3.14+0j)
+        self.assertAlmostEqual(complex(314), 314.0+0j)
+        self.assertAlmostEqual(complex(314), 314.0+0j)
+        #self.assertAlmostEqual(complex(3.14+0j, 0j), 3.14+0j)
+        self.assertAlmostEqual(complex(3.14, 0.0), 3.14+0j)
+        self.assertAlmostEqual(complex(314, 0), 314.0+0j)
+        self.assertAlmostEqual(complex(314, 0), 314.0+0j)
+        #self.assertAlmostEqual(complex(0j, 3.14j), -3.14+0j)
+        #self.assertAlmostEqual(complex(0.0, 3.14j), -3.14+0j)
+        #self.assertAlmostEqual(complex(0j, 3.14), 3.14j)
+        #self.assertAlmostEqual(complex(0.0, 3.14), 3.14j)
+        self.assertAlmostEqual(complex("1"), 1+0j)
+        self.assertAlmostEqual(complex("1j"), 1j)
+        self.assertAlmostEqual(complex(),  0)
+        self.assertAlmostEqual(complex("-1"), -1)
+        self.assertAlmostEqual(complex("+1"), +1)
+        #self.assertAlmostEqual(complex("(1+2j)"), 1+2j)
+        #self.assertAlmostEqual(complex("(1.3+2.2j)"), 1.3+2.2j)
+        #self.assertAlmostEqual(complex("3.14+1J"), 3.14+1j)
+        #self.assertAlmostEqual(complex(" ( +3.14-6J )"), 3.14-6j)
+        #self.assertAlmostEqual(complex(" ( +3.14-J )"), 3.14-1j)
+        #self.assertAlmostEqual(complex(" ( +3.14+j )"), 3.14+1j)
+        #self.assertAlmostEqual(complex("J"), 1j)
+        #self.assertAlmostEqual(complex("( j )"), 1j)
+        #self.assertAlmostEqual(complex("+J"), 1j)
+        #self.assertAlmostEqual(complex("( -j)"), -1j)
+        self.assertAlmostEqual(complex('1e-500'), 0.0 + 0.0j)
+        #self.assertAlmostEqual(complex('-1e-500j'), 0.0 - 0.0j)
+        #self.assertAlmostEqual(complex('-1e-500+1e-500j'), -0.0 + 0.0j)
+
+        class complex2(complex): pass
+        #self.assertAlmostEqual(complex(complex2(1+1j)), 1+1j)
+        #self.assertAlmostEqual(complex(real=17, imag=23), 17+23j)
+        #self.assertAlmostEqual(complex(real=17+23j), 17+23j)
+        #self.assertAlmostEqual(complex(real=17+23j, imag=23), 17+46j)
+        #self.assertAlmostEqual(complex(real=1+2j, imag=3+4j), -3+5j)
+
+        # check that the sign of a zero in the real or imaginary part
+        # is preserved when constructing from two floats.  (These checks
+        # are harmless on systems without support for signed zeros.)
+        def split_zeros(x):
+            """Function that produces different results for 0. and -0."""
+            return atan2(x, -1.)
+
+        self.assertEqual(split_zeros(complex(1., 0.).imag), split_zeros(0.))
+        self.assertEqual(split_zeros(complex(1., -0.).imag), split_zeros(-0.))
+        self.assertEqual(split_zeros(complex(0., 1.).real), split_zeros(0.))
+        self.assertEqual(split_zeros(complex(-0., 1.).real), split_zeros(-0.))
+
+        c = 3.14 + 1j
+        #self.assertTrue(complex(c) is c)
+        del c
+
+        self.assertRaises(TypeError, complex, "1", "1")
+        #self.assertRaises(TypeError, complex, 1, "1")
+
+        # SF bug 543840:  complex(string) accepts strings with \0
+        # Fixed in 2.3.
+        self.assertRaises(ValueError, complex, '1+1j\0j')
+
+        self.assertRaises(TypeError, int, 5+3j)
+        self.assertRaises(TypeError, int, 5+3j)
+        self.assertRaises(TypeError, float, 5+3j)
+        self.assertRaises(ValueError, complex, "")
+        self.assertRaises(TypeError, complex, None)
+        self.assertRaisesRegex(TypeError, "not 'NoneType'", complex, None)
+        self.assertRaises(ValueError, complex, "\0")
+        self.assertRaises(ValueError, complex, "3\09")
+        self.assertRaises(TypeError, complex, "1", "2")
+        self.assertRaises(TypeError, complex, "1", 42)
+        #self.assertRaises(TypeError, complex, 1, "2")
+        self.assertRaises(ValueError, complex, "1+")
+        self.assertRaises(ValueError, complex, "1+1j+1j")
+        self.assertRaises(ValueError, complex, "--")
+        self.assertRaises(ValueError, complex, "(1+2j")
+        self.assertRaises(ValueError, complex, "1+2j)")
+        self.assertRaises(ValueError, complex, "1+(2j)")
+        self.assertRaises(ValueError, complex, "(1+2j)123")
+        self.assertRaises(ValueError, complex, "x")
+        #self.assertRaises(ValueError, complex, "1j+2")
+        self.assertRaises(ValueError, complex, "1e1ej")
+        self.assertRaises(ValueError, complex, "1e++1ej")
+        self.assertRaises(ValueError, complex, ")1+2j(")
+        self.assertRaisesRegex(
+            TypeError,
+            "first argument must be a string or a number, not 'dict'",
+            complex, {1:2}, 1)
+ 
+ #       self.assertRaisesRegex(
+#            TypeError,
+#            "second argument must be a number, not 'dict'",
+#            complex, 1, {1:2})
+        self.assertRaises(TypeError,complex, 1, {1:2}) # RustPython replacement of previous check
+
+        # the following three are accepted by Python 2.6
+        self.assertRaises(ValueError, complex, "1..1j")
+        self.assertRaises(ValueError, complex, "1.11.1j")
+        self.assertRaises(ValueError, complex, "1e1.1j")
+
+        # check that complex accepts long unicode strings
+        self.assertEqual(type(complex("1"*500)), complex)
+        # check whitespace processing
+        #self.assertEqual(complex('\N{EM SPACE}(\N{EN SPACE}1+1j ) '), 1+1j)
+        # Invalid unicode string
+        # See bpo-34087
+        self.assertRaises(ValueError, complex, '\u3053\u3093\u306b\u3061\u306f')
+
+        class EvilExc(Exception):
+            pass
+
+        class evilcomplex:
+            def __complex__(self):
+                raise EvilExc
+
+        #self.assertRaises(EvilExc, complex, evilcomplex())
+
+        class float2:
+            def __init__(self, value):
+                self.value = value
+            def __float__(self):
+                return self.value
+
+        #self.assertAlmostEqual(complex(float2(42.)), 42)
+        #self.assertAlmostEqual(complex(real=float2(17.), imag=float2(23.)), 17+23j)
+        self.assertRaises(TypeError, complex, float2(None))
+
+        class MyIndex:
+            def __init__(self, value):
+                self.value = value
+            def __index__(self):
+                return self.value
+
+        #self.assertAlmostEqual(complex(MyIndex(42)), 42.0+0.0j)
+        #self.assertAlmostEqual(complex(123, MyIndex(42)), 123.0+42.0j)
+        #self.assertRaises(OverflowError, complex, MyIndex(2**2000))
+        #self.assertRaises(OverflowError, complex, 123, MyIndex(2**2000))
+
+        class MyInt:
+            def __int__(self):
+                return 42
+
+        self.assertRaises(TypeError, complex, MyInt())
+        self.assertRaises(TypeError, complex, 123, MyInt())
+
+        class complex0(complex):
+            """Test usage of __complex__() when inheriting from 'complex'"""
+            def __complex__(self):
+                return 42j
+
+        class complex1(complex):
+            """Test usage of __complex__() with a __new__() method"""
+            def __new__(self, value=0j):
+                return complex.__new__(self, 2*value)
+            def __complex__(self):
+                return self
+
+        class complex2(complex):
+            """Make sure that __complex__() calls fail if anything other than a
+            complex is returned"""
+            def __complex__(self):
+                return None
+
+        #self.assertEqual(complex(complex0(1j)), 42j)
+        #with self.assertWarns(DeprecationWarning):
+        #    self.assertEqual(complex(complex1(1j)), 2j)
+        #self.assertRaises(TypeError, complex, complex2(1j))
+
+    #@support.requires_IEEE_754
+    @rpt.imported.skip('requires IEEE 745')
+    def test_constructor_special_numbers(self):
+        class complex2(complex):
+            pass
+        for x in 0.0, -0.0, INF, -INF, NAN:
+            for y in 0.0, -0.0, INF, -INF, NAN:
+                with self.subTest(x=x, y=y):
+                    z = complex(x, y)
+                    self.assertFloatsAreIdentical(z.real, x)
+                    self.assertFloatsAreIdentical(z.imag, y)
+                    z = complex2(x, y)
+                    self.assertIs(type(z), complex2)
+                    self.assertFloatsAreIdentical(z.real, x)
+                    self.assertFloatsAreIdentical(z.imag, y)
+                    z = complex(complex2(x, y))
+                    self.assertIs(type(z), complex)
+                    self.assertFloatsAreIdentical(z.real, x)
+                    self.assertFloatsAreIdentical(z.imag, y)
+                    z = complex2(complex(x, y))
+                    self.assertIs(type(z), complex2)
+                    self.assertFloatsAreIdentical(z.real, x)
+                    self.assertFloatsAreIdentical(z.imag, y)
+
+    @rpt.imported.fail
+    def test_underscores(self):
+        # check underscores
+        for lit in VALID_UNDERSCORE_LITERALS:
+            if not any(ch in lit for ch in 'xXoObB'):
+                self.assertEqual(complex(lit), eval(lit))
+                self.assertEqual(complex(lit), complex(lit.replace('_', '')))
+        for lit in INVALID_UNDERSCORE_LITERALS:
+            if lit in ('0_7', '09_99'):  # octals are not recognized here
+                continue
+            if not any(ch in lit for ch in 'xXoObB'):
+                self.assertRaises(ValueError, complex, lit)
+
+    def test_hash(self):
+        for x in range(-30, 30):
+            self.assertEqual(hash(x), hash(complex(x, 0)))
+            x /= 3.0    # now check against floating point
+            self.assertEqual(hash(x), hash(complex(x, 0.)))
+
+    @rpt.imported.fail
+    def test_abs(self):
+        nums = [complex(x/3., y/7.) for x in range(-9,9) for y in range(-9,9)]
+        for num in nums:
+            self.assertAlmostEqual((num.real**2 + num.imag**2)  ** 0.5, abs(num))
+
+    @rpt.imported.fail
+    def test_repr_str(self):
+        def test(v, expected, test_fn=self.assertEqual):
+            test_fn(repr(v), expected)
+            test_fn(str(v), expected)
+
+        test(1+6j, '(1+6j)')
+        test(1-6j, '(1-6j)')
+
+        test(-(1+0j), '(-1+-0j)', test_fn=self.assertNotEqual)
+
+        test(complex(1., INF), "(1+infj)")
+        test(complex(1., -INF), "(1-infj)")
+        test(complex(INF, 1), "(inf+1j)")
+        test(complex(-INF, INF), "(-inf+infj)")
+        test(complex(NAN, 1), "(nan+1j)")
+        test(complex(1, NAN), "(1+nanj)")
+        test(complex(NAN, NAN), "(nan+nanj)")
+
+        test(complex(0, INF), "infj")
+        test(complex(0, -INF), "-infj")
+        test(complex(0, NAN), "nanj")
+
+        self.assertEqual(1-6j,complex(repr(1-6j)))
+        self.assertEqual(1+6j,complex(repr(1+6j)))
+        self.assertEqual(-6j,complex(repr(-6j)))
+        self.assertEqual(6j,complex(repr(6j)))
+
+    #@support.requires_IEEE_754
+    @rpt.imported.skip('requires IEEE 754')
+    def test_negative_zero_repr_str(self):
+        def test(v, expected, test_fn=self.assertEqual):
+            test_fn(repr(v), expected)
+            test_fn(str(v), expected)
+
+        test(complex(0., 1.),   "1j")
+        test(complex(-0., 1.),  "(-0+1j)")
+        test(complex(0., -1.),  "-1j")
+        test(complex(-0., -1.), "(-0-1j)")
+
+        test(complex(0., 0.),   "0j")
+        test(complex(0., -0.),  "-0j")
+        test(complex(-0., 0.),  "(-0+0j)")
+        test(complex(-0., -0.), "(-0-0j)")
+
+    def test_neg(self):
+        self.assertEqual(-(1+6j), -1-6j)
+
+    def test_getnewargs(self):
+        self.assertEqual((1+2j).__getnewargs__(), (1.0, 2.0))
+        self.assertEqual((1-2j).__getnewargs__(), (1.0, -2.0))
+        self.assertEqual((2j).__getnewargs__(), (0.0, 2.0))
+        self.assertEqual((-0j).__getnewargs__(), (0.0, -0.0))
+        self.assertEqual(complex(0, INF).__getnewargs__(), (0.0, INF))
+        self.assertEqual(complex(INF, 0).__getnewargs__(), (INF, 0.0))
+
+    #@support.requires_IEEE_754
+    @rpt.imported.skip('requires IEEE 745')
+    def test_plus_minus_0j(self):
+        # test that -0j and 0j literals are not identified
+        z1, z2 = 0j, -0j
+        self.assertEqual(atan2(z1.imag, -1.), atan2(0., -1.))
+        self.assertEqual(atan2(z2.imag, -1.), atan2(-0., -1.))
+
+    #@support.requires_IEEE_754
+    @rpt.imported.skip('requires IEEE 745')
+    def test_negated_imaginary_literal(self):
+        z0 = -0j
+        z1 = -7j
+        z2 = -1e1000j
+        # Note: In versions of Python < 3.2, a negated imaginary literal
+        # accidentally ended up with real part 0.0 instead of -0.0, thanks to a
+        # modification during CST -> AST translation (see issue #9011).  That's
+        # fixed in Python 3.2.
+        self.assertFloatsAreIdentical(z0.real, -0.0)
+        self.assertFloatsAreIdentical(z0.imag, -0.0)
+        self.assertFloatsAreIdentical(z1.real, -0.0)
+        self.assertFloatsAreIdentical(z1.imag, -7.0)
+        self.assertFloatsAreIdentical(z2.real, -0.0)
+        self.assertFloatsAreIdentical(z2.imag, -INF)
+
+    #@support.requires_IEEE_754
+    @rpt.imported.skip('requires IEEE 745')
+    def test_overflow(self):
+        self.assertEqual(complex("1e500"), complex(INF, 0.0))
+        self.assertEqual(complex("-1e500j"), complex(0.0, -INF))
+        self.assertEqual(complex("-1e500+1.8e308j"), complex(-INF, INF))
+
+    #@support.requires_IEEE_754
+    @rpt.imported.skip('requires IEEE 745')
+    def test_repr_roundtrip(self):
+        vals = [0.0, 1e-500, 1e-315, 1e-200, 0.0123, 3.1415, 1e50, INF, NAN]
+        vals += [-v for v in vals]
+
+        # complex(repr(z)) should recover z exactly, even for complex
+        # numbers involving an infinity, nan, or negative zero
+        for x in vals:
+            for y in vals:
+                z = complex(x, y)
+                roundtrip = complex(repr(z))
+                self.assertFloatsAreIdentical(z.real, roundtrip.real)
+                self.assertFloatsAreIdentical(z.imag, roundtrip.imag)
+
+        # if we predefine some constants, then eval(repr(z)) should
+        # also work, except that it might change the sign of zeros
+        inf, nan = float('inf'), float('nan')
+        infj, nanj = complex(0.0, inf), complex(0.0, nan)
+        for x in vals:
+            for y in vals:
+                z = complex(x, y)
+                roundtrip = eval(repr(z))
+                # adding 0.0 has no effect beside changing -0.0 to 0.0
+                self.assertFloatsAreIdentical(0.0 + z.real,
+                                              0.0 + roundtrip.real)
+                self.assertFloatsAreIdentical(0.0 + z.imag,
+                                              0.0 + roundtrip.imag)
+
+    @rpt.imported.skip('skipping format tests as they are currently depending on local settings')
+    def test_format(self):
+        # empty format string is same as str()
+        self.assertEqual(format(1+3j, ''), str(1+3j))
+        self.assertEqual(format(1.5+3.5j, ''), str(1.5+3.5j))
+        self.assertEqual(format(3j, ''), str(3j))
+        self.assertEqual(format(3.2j, ''), str(3.2j))
+        self.assertEqual(format(3+0j, ''), str(3+0j))
+        self.assertEqual(format(3.2+0j, ''), str(3.2+0j))
+
+        # empty presentation type should still be analogous to str,
+        # even when format string is nonempty (issue #5920).
+        self.assertEqual(format(3.2+0j, '-'), str(3.2+0j))
+        self.assertEqual(format(3.2+0j, '<'), str(3.2+0j))
+        z = 4/7. - 100j/7.
+        self.assertEqual(format(z, ''), str(z))
+        self.assertEqual(format(z, '-'), str(z))
+        self.assertEqual(format(z, '<'), str(z))
+        self.assertEqual(format(z, '10'), str(z))
+        z = complex(0.0, 3.0)
+        self.assertEqual(format(z, ''), str(z))
+        self.assertEqual(format(z, '-'), str(z))
+        self.assertEqual(format(z, '<'), str(z))
+        self.assertEqual(format(z, '2'), str(z))
+        z = complex(-0.0, 2.0)
+        self.assertEqual(format(z, ''), str(z))
+        self.assertEqual(format(z, '-'), str(z))
+        self.assertEqual(format(z, '<'), str(z))
+        self.assertEqual(format(z, '3'), str(z))
+
+        self.assertEqual(format(1+3j, 'g'), '1+3j')
+        self.assertEqual(format(3j, 'g'), '0+3j')
+        self.assertEqual(format(1.5+3.5j, 'g'), '1.5+3.5j')
+
+        self.assertEqual(format(1.5+3.5j, '+g'), '+1.5+3.5j')
+        self.assertEqual(format(1.5-3.5j, '+g'), '+1.5-3.5j')
+        self.assertEqual(format(1.5-3.5j, '-g'), '1.5-3.5j')
+        self.assertEqual(format(1.5+3.5j, ' g'), ' 1.5+3.5j')
+        self.assertEqual(format(1.5-3.5j, ' g'), ' 1.5-3.5j')
+        self.assertEqual(format(-1.5+3.5j, ' g'), '-1.5+3.5j')
+        self.assertEqual(format(-1.5-3.5j, ' g'), '-1.5-3.5j')
+
+        self.assertEqual(format(-1.5-3.5e-20j, 'g'), '-1.5-3.5e-20j')
+        self.assertEqual(format(-1.5-3.5j, 'f'), '-1.500000-3.500000j')
+        self.assertEqual(format(-1.5-3.5j, 'F'), '-1.500000-3.500000j')
+        self.assertEqual(format(-1.5-3.5j, 'e'), '-1.500000e+00-3.500000e+00j')
+        self.assertEqual(format(-1.5-3.5j, '.2e'), '-1.50e+00-3.50e+00j')
+        self.assertEqual(format(-1.5-3.5j, '.2E'), '-1.50E+00-3.50E+00j')
+        self.assertEqual(format(-1.5e10-3.5e5j, '.2G'), '-1.5E+10-3.5E+05j')
+
+        self.assertEqual(format(1.5+3j, '<20g'),  '1.5+3j              ')
+        self.assertEqual(format(1.5+3j, '*<20g'), '1.5+3j**************')
+        self.assertEqual(format(1.5+3j, '>20g'),  '              1.5+3j')
+        self.assertEqual(format(1.5+3j, '^20g'),  '       1.5+3j       ')
+        self.assertEqual(format(1.5+3j, '<20'),   '(1.5+3j)            ')
+        self.assertEqual(format(1.5+3j, '>20'),   '            (1.5+3j)')
+        self.assertEqual(format(1.5+3j, '^20'),   '      (1.5+3j)      ')
+        self.assertEqual(format(1.123-3.123j, '^20.2'), '     (1.1-3.1j)     ')
+
+        self.assertEqual(format(1.5+3j, '20.2f'), '          1.50+3.00j')
+        self.assertEqual(format(1.5+3j, '>20.2f'), '          1.50+3.00j')
+        self.assertEqual(format(1.5+3j, '<20.2f'), '1.50+3.00j          ')
+        self.assertEqual(format(1.5e20+3j, '<20.2f'), '150000000000000000000.00+3.00j')
+        self.assertEqual(format(1.5e20+3j, '>40.2f'), '          150000000000000000000.00+3.00j')
+        self.assertEqual(format(1.5e20+3j, '^40,.2f'), '  150,000,000,000,000,000,000.00+3.00j  ')
+        self.assertEqual(format(1.5e21+3j, '^40,.2f'), ' 1,500,000,000,000,000,000,000.00+3.00j ')
+        self.assertEqual(format(1.5e21+3000j, ',.2f'), '1,500,000,000,000,000,000,000.00+3,000.00j')
+
+        # Issue 7094: Alternate formatting (specified by #)
+        self.assertEqual(format(1+1j, '.0e'), '1e+00+1e+00j')
+        self.assertEqual(format(1+1j, '#.0e'), '1.e+00+1.e+00j')
+        self.assertEqual(format(1+1j, '.0f'), '1+1j')
+        self.assertEqual(format(1+1j, '#.0f'), '1.+1.j')
+        self.assertEqual(format(1.1+1.1j, 'g'), '1.1+1.1j')
+        self.assertEqual(format(1.1+1.1j, '#g'), '1.10000+1.10000j')
+
+        # Alternate doesn't make a difference for these, they format the same with or without it
+        self.assertEqual(format(1+1j, '.1e'),  '1.0e+00+1.0e+00j')
+        self.assertEqual(format(1+1j, '#.1e'), '1.0e+00+1.0e+00j')
+        self.assertEqual(format(1+1j, '.1f'),  '1.0+1.0j')
+        self.assertEqual(format(1+1j, '#.1f'), '1.0+1.0j')
+
+        # Misc. other alternate tests
+        self.assertEqual(format((-1.5+0.5j), '#f'), '-1.500000+0.500000j')
+        self.assertEqual(format((-1.5+0.5j), '#.0f'), '-2.+0.j')
+        self.assertEqual(format((-1.5+0.5j), '#e'), '-1.500000e+00+5.000000e-01j')
+        self.assertEqual(format((-1.5+0.5j), '#.0e'), '-2.e+00+5.e-01j')
+        self.assertEqual(format((-1.5+0.5j), '#g'), '-1.50000+0.500000j')
+        self.assertEqual(format((-1.5+0.5j), '.0g'), '-2+0.5j')
+        self.assertEqual(format((-1.5+0.5j), '#.0g'), '-2.+0.5j')
+
+        # zero padding is invalid
+        self.assertRaises(ValueError, (1.5+0.5j).__format__, '010f')
+
+        # '=' alignment is invalid
+        self.assertRaises(ValueError, (1.5+3j).__format__, '=20')
+
+        # integer presentation types are an error
+        for t in 'bcdoxX':
+            self.assertRaises(ValueError, (1.5+0.5j).__format__, t)
+
+        # make sure everything works in ''.format()
+        self.assertEqual('*{0:.3f}*'.format(3.14159+2.71828j), '*3.142+2.718j*')
+
+        # issue 3382
+        self.assertEqual(format(complex(NAN, NAN), 'f'), 'nan+nanj')
+        self.assertEqual(format(complex(1, NAN), 'f'), '1.000000+nanj')
+        self.assertEqual(format(complex(NAN, 1), 'f'), 'nan+1.000000j')
+        self.assertEqual(format(complex(NAN, -1), 'f'), 'nan-1.000000j')
+        self.assertEqual(format(complex(NAN, NAN), 'F'), 'NAN+NANj')
+        self.assertEqual(format(complex(1, NAN), 'F'), '1.000000+NANj')
+        self.assertEqual(format(complex(NAN, 1), 'F'), 'NAN+1.000000j')
+        self.assertEqual(format(complex(NAN, -1), 'F'), 'NAN-1.000000j')
+        self.assertEqual(format(complex(INF, INF), 'f'), 'inf+infj')
+        self.assertEqual(format(complex(1, INF), 'f'), '1.000000+infj')
+        self.assertEqual(format(complex(INF, 1), 'f'), 'inf+1.000000j')
+        self.assertEqual(format(complex(INF, -1), 'f'), 'inf-1.000000j')
+        self.assertEqual(format(complex(INF, INF), 'F'), 'INF+INFj')
+        self.assertEqual(format(complex(1, INF), 'F'), '1.000000+INFj')
+        self.assertEqual(format(complex(INF, 1), 'F'), 'INF+1.000000j')
+        self.assertEqual(format(complex(INF, -1), 'F'), 'INF-1.000000j')
+
+def test_main():
+    support.run_unittest(ComplexTest)
+
+if __name__ == "__main__":
+    test_main()

--- a/Lib/test/test_complex.py
+++ b/Lib/test/test_complex.py
@@ -1,5 +1,5 @@
 import unittest
-import Lib.test.librptest as rpt
+import test.librptest as rpt
 from test import support
 from test.test_grammar import (VALID_UNDERSCORE_LITERALS,
                                INVALID_UNDERSCORE_LITERALS)

--- a/Lib/test/test_rpt.py
+++ b/Lib/test/test_rpt.py
@@ -1,7 +1,7 @@
 
 
 import unittest
-import Lib.test.librptest as rpt
+import test.librptest as rpt
 
 import math
 

--- a/Lib/test/test_rpt.py
+++ b/Lib/test/test_rpt.py
@@ -1,0 +1,151 @@
+
+
+import unittest
+import Lib.test.librptest as rpt
+
+import math
+
+executed = set()
+
+@rpt.originated_from(3,8,'https://foo.de')
+class RPTTest(unittest.TestCase):
+    '''
+    Demonstrates the usage of RPT and tests it.
+
+    Basically it is tested that each test that is not supposed to be skipped is executed. 
+    Therefore each test case needs to call self.report_run() with the test function as parameter.
+    Test cases that are supposed to be skipped are determined by their name.
+    '''
+    
+
+    @rpt.imported.original
+    def test_imported_00(self):
+        self.report_run(RPTTest.test_imported_00)
+        self.assertEqual(42,42)
+
+    # The following shows a bad pratctice as the annotation 
+    # mechanisms are bypassed
+    # using 36 as it is more for the insiders
+    @rpt.imported.modified
+    def test_imported_01(self):
+        self.report_run(RPTTest.test_imported_01)
+        self.assertEqual(36,36)
+
+    # A better practice is shown here, where the reason for 
+    # the modification is given in annotation itself.
+    @rpt.imported.modified("Modified for strings")
+    def test_imported_02(self): 
+        self.report_run(RPTTest.test_imported_02)
+        self.assertEqual('36','36')
+
+
+    # skipping a test as it does not apply here
+    @rpt.imported.skip
+    def test_skipping_00(self):
+        self.report_run(RPTTest.test_skipping_00)
+        self.assertTrue(False)
+
+    # skipping a test as it will break RustPython
+    # using an endless loop is not a realy good idea but 
+    # the only way how to break the test indepently from 
+    # the python implementation
+    @rpt.imported.skip
+    def test_skipping_01(self):
+        self.report_run(RPTTest.test_skipping_01)
+        #while True:pass
+
+    @rpt.imported.skip('This test breaks completely because ...')
+    def test_skipping_02(self):
+        self.report_run(RPTTest.test_skipping_02)
+        #while True:pass
+
+    @rpt.imported.fail
+    def test_fail_00(self):
+        self.report_run(RPTTest.test_fail_00)
+        self.assertTrue(False)
+
+    @rpt.imported.fail('This test fails because ...')
+    def test_fail_01(self):
+        self.report_run(RPTTest.test_fail_01)
+        self.assertTrue(False)
+
+    @rpt.imported.substituted
+    def test_substskip_00(self):
+        self.report_run(RPTTest.test_substskip_00)
+        #while True:pass
+
+    @rpt.imported.substituted('Replace this because of')
+    def test_substskip_01(self):
+        self.report_run(RPTTest.test_substskip_01)
+        #while True:pass
+
+    @rpt.imported.substituted('Replace this because of', run=False)
+    def test_substskip_02(self):
+        self.report_run(RPTTest.test_substskip_02)
+        while True: pass
+
+    @rpt.imported.substituted('Replace this  because of .. but still execute and expect failure', run=True)
+    def test_subst_03(self):
+        self.report_run(RPTTest.test_subst_03)
+        self.assertTrue(False)
+
+    @rpt.imported.substituted(run=False)
+    def test_substskip_04(self):
+        self.report_run(RPTTest.test_substskip_04)
+        while True: pass
+
+    @rpt.imported.substituted(run=True)
+    def test_subst_05(self):
+        self.report_run(RPTTest.test_subst_05)
+        self.assertTrue(False)
+
+    @rpt.ours.subst('RPTTest.test_subst_05')
+    def test_subst_06(self):
+        self.report_run(RPTTest.test_subst_06)
+
+    @rpt.ours.new
+    def test_ours_00(self):
+        self.report_run(RPTTest.test_ours_00)
+
+    # ensure by odd naming that these tests run at the end. This might be a problem 
+    # when shuffling the execution order.
+
+    def test_zzz_meta_00(self):
+        self.report_run(RPTTest.test_zzz_meta_00)
+        orig_names=set([f.__name__ for f in rpt.imported.get_originals()])
+        self.assertTrue(self.test_imported_00.__name__ in orig_names)
+
+    def test_zzz_meta_01(self):
+        self.report_run(RPTTest.test_zzz_meta_01)
+        self.assertIn(RPTTest.test_ours_00.__name__, [f.__name__ for f in rpt.ours.get_news()])
+
+    def test_zzz_meta_02(self):
+        self.report_run(RPTTest.test_zzz_meta_02)
+        res=rpt.ours.get_substitutions('RPTTest.test_subst_05')
+        self.assertIn('test_subst_06', set([f[0].__name__ for f in res]))
+        
+    def test_zzz_meta_99(self):
+        self.report_run(RPTTest.test_zzz_meta_01)
+        print(f'{[f.__name__ for f in executed]}')
+
+
+    this_run=None
+
+    def tearDown(self):
+        xor = lambda x,y: (x and not y) or (not x and y)
+        shall_skip = self._testMethodName.find('test_skipping')>=0 or self._testMethodName.find('test_substskip')>=0
+        has_executed = self.this_run != None
+        self.assertTrue(xor(shall_skip, has_executed))
+        
+
+    def report_run(self, test_case):
+        executed.add(test_case)
+        self.this_run=test_case
+        print()
+
+
+
+if __name__ == "__main__":
+    unittest.main(exit=False)
+    rpt.print_eval()
+    


### PR DESCRIPTION
When importing test currentlyfrom CPython,  they need to be annotated with comments like 
> \# TODO RustPython
or 
> \# TODO: RustPython

or how ever the author likes. Further the original file revision and the orignating python (language) revision is missing in most of the imported tests, what makes tracking nearly impossible. 
To improve the convention base "solution", I propose a python annotation framework using decorators to properly annotate the imported test cases, such that they can be tracked and evaluated in a comprehnesive and comfortable way.
Examples can be seen in Lib/test/test_rpt.py.

This the initial implementation. The core functionality is there and tested, but, e.g., the reporting is very rudimentary and more for demonstration purpoposes.