### PR TITLE
Fix str.isspace to support unicode space characters

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1697,10 +1697,10 @@ dependencies = [
  "statrs",
  "thread_local",
  "uname",
- "unic-bidi",
  "unic-char-property",
  "unic-normal",
  "unic-ucd-age",
+ "unic-ucd-bidi",
  "unic-ucd-category",
  "unic-ucd-ident",
  "unicode-casing",
@@ -2083,16 +2083,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b72f89f0ca32e4db1c04e2a72f5345d59796d4866a1ee0609084569f73683dc8"
 dependencies = [
  "libc",
-]
-
-[[package]]
-name = "unic-bidi"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1356b759fb6a82050666f11dce4b6fe3571781f1449f3ef78074e408d468ec09"
-dependencies = [
- "matches",
- "unic-ucd-bidi",
 ]
 
 [[package]]

--- a/Lib/test/test_bool.py
+++ b/Lib/test/test_bool.py
@@ -204,8 +204,6 @@ class BoolTest(unittest.TestCase):
         self.assertIs(1 in {}, False)
         self.assertIs(1 in {1:1}, True)
 
-    # TODO: RUSTPYTHON
-    @unittest.expectedFailure
     def test_string(self):
         self.assertIs("xyz".endswith("z"), True)
         self.assertIs("xyz".endswith("x"), False)

--- a/Lib/test/test_unicode.py
+++ b/Lib/test/test_unicode.py
@@ -620,8 +620,6 @@ class UnicodeTest(string_tests.CommonTest,
         for ch in ['\U00010429', '\U0001044E', '\U0001F40D', '\U0001F46F']:
             self.assertFalse(ch.istitle(), '{!a} is not title'.format(ch))
 
-    # TODO: RUSTPYTHON
-    @unittest.expectedFailure
     def test_isspace(self):
         super().test_isspace()
         self.checkequalnofix(True, '\u2000', 'isspace')

--- a/vm/Cargo.toml
+++ b/vm/Cargo.toml
@@ -81,9 +81,9 @@ unicode_names2 = "0.4"
 # https://github.com/RustPython/RustPython/pull/832#discussion_r275428939
 unicode-casing = "0.1"
 # update version all at the same time
-unic-bidi          = "0.9"
 unic-char-property = "0.9"
 unic-normal        = "0.9"
+unic-ucd-bidi      = "0.9"
 unic-ucd-category  = "0.9"
 unic-ucd-age       = "0.9"
 unic-ucd-ident     = "0.9"

--- a/vm/src/stdlib/unicodedata.rs
+++ b/vm/src/stdlib/unicodedata.rs
@@ -9,10 +9,10 @@ use crate::pyobject::{PyClassImpl, PyObject, PyObjectRef, PyResult, PyValue};
 use crate::vm::VirtualMachine;
 
 use itertools::Itertools;
-use unic_bidi::BidiClass;
 use unic_char_property::EnumeratedCharProperty;
 use unic_normal::StrNormalForm;
 use unic_ucd_age::{Age, UnicodeVersion, UNICODE_VERSION};
+use unic_ucd_bidi::BidiClass;
 use unic_ucd_category::GeneralCategory;
 
 pub fn make_module(vm: &VirtualMachine) -> PyObjectRef {


### PR DESCRIPTION
This new behavior matches the Python documentation https://docs.python.org/3/library/stdtypes.html#str.isspace.