### PR TITLE
Implementation of chown, lchown and fchown for the os module

### DIFF
--- a/tests/snippets/stdlib_os.py
+++ b/tests/snippets/stdlib_os.py
@@ -10,16 +10,17 @@ assert fd > 0
 
 os.close(fd)
 assert_raises(OSError, lambda: os.read(fd, 10))
-assert_raises(FileNotFoundError, lambda: os.open('DOES_NOT_EXIST', os.O_RDONLY))
-assert_raises(FileNotFoundError, lambda: os.open('DOES_NOT_EXIST', os.O_WRONLY))
-assert_raises(FileNotFoundError, lambda: os.rename('DOES_NOT_EXIST', 'DOES_NOT_EXIST 2'))
+assert_raises(FileNotFoundError,
+              lambda: os.open('DOES_NOT_EXIST', os.O_RDONLY))
+assert_raises(FileNotFoundError,
+              lambda: os.open('DOES_NOT_EXIST', os.O_WRONLY))
+assert_raises(FileNotFoundError,
+              lambda: os.rename('DOES_NOT_EXIST', 'DOES_NOT_EXIST 2'))
 
 try:
-	os.open('DOES_NOT_EXIST', 0)
+    os.open('DOES_NOT_EXIST', 0)
 except OSError as err:
-	assert err.errno == 2
-
-
+    assert err.errno == 2
 
 assert os.O_RDONLY == 0
 assert os.O_WRONLY == 1
@@ -28,7 +29,7 @@ assert os.O_RDWR == 2
 ENV_KEY = "TEST_ENV_VAR"
 ENV_VALUE = "value"
 
-assert os.getenv(ENV_KEY) == None
+assert os.getenv(ENV_KEY) is None
 assert ENV_KEY not in os.environ
 assert os.getenv(ENV_KEY, 5) == 5
 os.environ[ENV_KEY] = ENV_VALUE
@@ -36,31 +37,32 @@ assert ENV_KEY in os.environ
 assert os.getenv(ENV_KEY) == ENV_VALUE
 del os.environ[ENV_KEY]
 assert ENV_KEY not in os.environ
-assert os.getenv(ENV_KEY) == None
+assert os.getenv(ENV_KEY) is None
 
 if os.name == "posix":
-	os.putenv(ENV_KEY, ENV_VALUE)
-	os.unsetenv(ENV_KEY)
-	assert os.getenv(ENV_KEY) == None
+    os.putenv(ENV_KEY, ENV_VALUE)
+    os.unsetenv(ENV_KEY)
+    assert os.getenv(ENV_KEY) is None
 
 assert os.curdir == "."
 assert os.pardir == ".."
 assert os.extsep == "."
 
 if os.name == "nt":
-	assert os.sep == "\\"
-	assert os.linesep == "\r\n"
-	assert os.altsep == "/"
-	assert os.pathsep == ";"
+    assert os.sep == "\\"
+    assert os.linesep == "\r\n"
+    assert os.altsep == "/"
+    assert os.pathsep == ";"
 else:
-	assert os.sep == "/"
-	assert os.linesep == "\n"
-	assert os.altsep == None
-	assert os.pathsep == ":"
+    assert os.sep == "/"
+    assert os.linesep == "\n"
+    assert os.altsep is None
+    assert os.pathsep == ":"
 
 assert os.fspath("Testing") == "Testing"
 assert os.fspath(b"Testing") == b"Testing"
-assert_raises(TypeError, lambda: os.fspath([1,2,3]))
+assert_raises(TypeError, lambda: os.fspath([1, 2, 3]))
+
 
 class TestWithTempDir():
     def __enter__(self):
@@ -69,7 +71,8 @@ class TestWithTempDir():
         else:
             base_folder = "/tmp"
 
-        name = os.path.join(base_folder, "rustpython_test_os_" + str(int(time.time())))
+        name = os.path.join(base_folder,
+                            "rustpython_test_os_" + str(int(time.time())))
 
         while os.path.isdir(name):
             name = name + "_"
@@ -80,6 +83,7 @@ class TestWithTempDir():
 
     def __exit__(self, exc_type, exc_val, exc_tb):
         pass
+
 
 class TestWithTempCurrentDir():
     def __enter__(self):
@@ -100,174 +104,179 @@ CONTENT2 = b"rustpython"
 CONTENT3 = b"BOYA"
 
 with TestWithTempDir() as tmpdir:
-	fname = os.path.join(tmpdir, FILE_NAME)
-	fd = os.open(fname, os.O_WRONLY | os.O_CREAT | os.O_EXCL)
-	assert os.write(fd, CONTENT2) == len(CONTENT2)
-	os.close(fd)
+    fname = os.path.join(tmpdir, FILE_NAME)
+    fd = os.open(fname, os.O_WRONLY | os.O_CREAT | os.O_EXCL)
+    assert os.write(fd, CONTENT2) == len(CONTENT2)
+    os.close(fd)
 
-	fd = os.open(fname, os.O_WRONLY | os.O_APPEND)
-	assert os.write(fd, CONTENT3) == len(CONTENT3)
-	os.close(fd)
+    fd = os.open(fname, os.O_WRONLY | os.O_APPEND)
+    assert os.write(fd, CONTENT3) == len(CONTENT3)
+    os.close(fd)
 
-	assert_raises(FileExistsError, lambda: os.open(fname, os.O_WRONLY | os.O_CREAT | os.O_EXCL))
+    assert_raises(FileExistsError,
+                  lambda: os.open(fname, os.O_WRONLY | os.O_CREAT | os.O_EXCL))
 
-	fd = os.open(fname, os.O_RDONLY)
-	assert os.read(fd, len(CONTENT2)) == CONTENT2
-	assert os.read(fd, len(CONTENT3)) == CONTENT3
-	os.close(fd)
+    fd = os.open(fname, os.O_RDONLY)
+    assert os.read(fd, len(CONTENT2)) == CONTENT2
+    assert os.read(fd, len(CONTENT3)) == CONTENT3
+    os.close(fd)
 
-	fname3 = os.path.join(tmpdir, FILE_NAME3)
-	os.rename(fname, fname3)
-	assert os.path.exists(fname) == False
-	assert os.path.exists(fname3) == True
+    fname3 = os.path.join(tmpdir, FILE_NAME3)
+    os.rename(fname, fname3)
+    assert os.path.exists(fname) is False
+    assert os.path.exists(fname3) is True
 
-	fd = os.open(fname3, 0)
-	assert os.read(fd, len(CONTENT2) + len(CONTENT3)) == CONTENT2 + CONTENT3
-	os.close(fd)
+    fd = os.open(fname3, 0)
+    assert os.read(fd, len(CONTENT2) + len(CONTENT3)) == CONTENT2 + CONTENT3
+    os.close(fd)
 
-	assert not os.isatty(fd)
+    assert not os.isatty(fd)
 
-  # TODO: get os.lseek working on windows
-	if os.name != 'nt':
-		fd = os.open(fname3, 0)
-		assert os.read(fd, len(CONTENT2)) == CONTENT2
-		assert os.read(fd, len(CONTENT3)) == CONTENT3
-		os.lseek(fd, len(CONTENT2), os.SEEK_SET)
-		assert os.read(fd, len(CONTENT3)) == CONTENT3
-		os.close(fd)
+    # TODO: get os.lseek working on windows
+    if os.name != 'nt':
+        fd = os.open(fname3, 0)
+        assert os.read(fd, len(CONTENT2)) == CONTENT2
+        assert os.read(fd, len(CONTENT3)) == CONTENT3
+        os.lseek(fd, len(CONTENT2), os.SEEK_SET)
+        assert os.read(fd, len(CONTENT3)) == CONTENT3
+        os.close(fd)
 
-	os.rename(fname3, fname)
-	assert os.path.exists(fname3) == False
-	assert os.path.exists(fname) == True
+    os.rename(fname3, fname)
+    assert os.path.exists(fname3) is False
+    assert os.path.exists(fname) is True
 
-	# wait a little bit to ensure that the file times aren't the same
-	time.sleep(0.1)
+    # wait a little bit to ensure that the file times aren't the same
+    time.sleep(0.1)
 
-	fname2 = os.path.join(tmpdir, FILE_NAME2)
-	with open(fname2, "wb"):
-		pass
-	folder = os.path.join(tmpdir, FOLDER)
-	os.mkdir(folder)
+    fname2 = os.path.join(tmpdir, FILE_NAME2)
+    with open(fname2, "wb"):
+        pass
+    folder = os.path.join(tmpdir, FOLDER)
+    os.mkdir(folder)
 
-	symlink_file = os.path.join(tmpdir, SYMLINK_FILE)
-	os.symlink(fname, symlink_file)
-	symlink_folder = os.path.join(tmpdir, SYMLINK_FOLDER)
-	os.symlink(folder, symlink_folder)
+    symlink_file = os.path.join(tmpdir, SYMLINK_FILE)
+    os.symlink(fname, symlink_file)
+    symlink_folder = os.path.join(tmpdir, SYMLINK_FOLDER)
+    os.symlink(folder, symlink_folder)
 
-	names = set()
-	paths = set()
-	dirs = set()
-	dirs_no_symlink = set()
-	files = set()
-	files_no_symlink = set()
-	symlinks = set()
-	for dir_entry in os.scandir(tmpdir):
-		names.add(dir_entry.name)
-		paths.add(dir_entry.path)
-		if dir_entry.is_dir():
-			assert stat.S_ISDIR(dir_entry.stat().st_mode) == True
-			dirs.add(dir_entry.name)
-		if dir_entry.is_dir(follow_symlinks=False):
-			assert stat.S_ISDIR(dir_entry.stat().st_mode) == True
-			dirs_no_symlink.add(dir_entry.name)
-		if dir_entry.is_file():
-			files.add(dir_entry.name)
-			assert stat.S_ISREG(dir_entry.stat().st_mode) == True
-		if dir_entry.is_file(follow_symlinks=False):
-			files_no_symlink.add(dir_entry.name)
-			assert stat.S_ISREG(dir_entry.stat().st_mode) == True
-		if dir_entry.is_symlink():
-			symlinks.add(dir_entry.name)
+    names = set()
+    paths = set()
+    dirs = set()
+    dirs_no_symlink = set()
+    files = set()
+    files_no_symlink = set()
+    symlinks = set()
+    for dir_entry in os.scandir(tmpdir):
+        names.add(dir_entry.name)
+        paths.add(dir_entry.path)
+        if dir_entry.is_dir():
+            assert stat.S_ISDIR(dir_entry.stat().st_mode) is True
+            dirs.add(dir_entry.name)
+        if dir_entry.is_dir(follow_symlinks=False):
+            assert stat.S_ISDIR(dir_entry.stat().st_mode) is True
+            dirs_no_symlink.add(dir_entry.name)
+        if dir_entry.is_file():
+            files.add(dir_entry.name)
+            assert stat.S_ISREG(dir_entry.stat().st_mode) is True
+        if dir_entry.is_file(follow_symlinks=False):
+            files_no_symlink.add(dir_entry.name)
+            assert stat.S_ISREG(dir_entry.stat().st_mode) is True
+        if dir_entry.is_symlink():
+            symlinks.add(dir_entry.name)
 
-	assert names == set([FILE_NAME, FILE_NAME2, FOLDER, SYMLINK_FILE, SYMLINK_FOLDER])
-	assert paths == set([fname, fname2, folder, symlink_file, symlink_folder])
-	assert dirs == set([FOLDER, SYMLINK_FOLDER])
-	assert dirs_no_symlink == set([FOLDER])
-	assert files == set([FILE_NAME, FILE_NAME2, SYMLINK_FILE])
-	assert files_no_symlink == set([FILE_NAME, FILE_NAME2])
-	assert symlinks == set([SYMLINK_FILE, SYMLINK_FOLDER])
+    assert names == set(
+        [FILE_NAME, FILE_NAME2, FOLDER, SYMLINK_FILE, SYMLINK_FOLDER])
+    assert paths == set([fname, fname2, folder, symlink_file, symlink_folder])
+    assert dirs == set([FOLDER, SYMLINK_FOLDER])
+    assert dirs_no_symlink == set([FOLDER])
+    assert files == set([FILE_NAME, FILE_NAME2, SYMLINK_FILE])
+    assert files_no_symlink == set([FILE_NAME, FILE_NAME2])
+    assert symlinks == set([SYMLINK_FILE, SYMLINK_FOLDER])
 
-	# Stat
-	stat_res = os.stat(fname)
-	print(stat_res.st_mode)
-	assert stat.S_ISREG(stat_res.st_mode) == True
-	print(stat_res.st_ino)
-	print(stat_res.st_dev)
-	print(stat_res.st_nlink)
-	print(stat_res.st_uid)
-	print(stat_res.st_gid)
-	print(stat_res.st_size)
-	assert stat_res.st_size == len(CONTENT2) + len(CONTENT3)
-	print(stat_res.st_atime)
-	print(stat_res.st_ctime)
-	print(stat_res.st_mtime)
-	# test that it all of these times are greater than the 10 May 2019, when this test was written
-	assert stat_res.st_atime > 1557500000
-	assert stat_res.st_ctime > 1557500000
-	assert stat_res.st_mtime > 1557500000
+    # Stat
+    stat_res = os.stat(fname)
+    print(stat_res.st_mode)
+    assert stat.S_ISREG(stat_res.st_mode) is True
+    print(stat_res.st_ino)
+    print(stat_res.st_dev)
+    print(stat_res.st_nlink)
+    print(stat_res.st_uid)
+    print(stat_res.st_gid)
+    print(stat_res.st_size)
+    assert stat_res.st_size == len(CONTENT2) + len(CONTENT3)
+    print(stat_res.st_atime)
+    print(stat_res.st_ctime)
+    print(stat_res.st_mtime)
+    # test that it all of these times are greater than the 10 May 2019,
+    # when this test was written
+    assert stat_res.st_atime > 1557500000
+    assert stat_res.st_ctime > 1557500000
+    assert stat_res.st_mtime > 1557500000
 
-	bytes_stats_res = os.stat(fname.encode())
+    bytes_stats_res = os.stat(fname.encode())
 
-	stat_file2 = os.stat(fname2)
-	print(stat_file2.st_ctime)
-	assert stat_file2.st_ctime > stat_res.st_ctime
+    stat_file2 = os.stat(fname2)
+    print(stat_file2.st_ctime)
+    assert stat_file2.st_ctime > stat_res.st_ctime
 
-	# wait a little bit to ensures that the access/modify time will change
-	time.sleep(0.1)
+    # wait a little bit to ensures that the access/modify time will change
+    time.sleep(0.1)
 
-	old_atime = stat_res.st_atime
-	old_mtime = stat_res.st_mtime
+    old_atime = stat_res.st_atime
+    old_mtime = stat_res.st_mtime
 
-	fd = os.open(fname, os.O_RDWR)
-	os.write(fd, CONTENT)
-	os.fsync(fd)
+    fd = os.open(fname, os.O_RDWR)
+    os.write(fd, CONTENT)
+    os.fsync(fd)
 
-	# wait a little bit to ensures that the access/modify time is different
-	time.sleep(0.1)
+    # wait a little bit to ensures that the access/modify time is different
+    time.sleep(0.1)
 
-	os.read(fd, 1)
-	os.fsync(fd)
-	os.close(fd)
+    os.read(fd, 1)
+    os.fsync(fd)
+    os.close(fd)
 
-	# retrieve update file stats
-	stat_res = os.stat(fname)
-	print(stat_res.st_atime)
-	print(stat_res.st_ctime)
-	print(stat_res.st_mtime)
-	if os.name != "nt":
-		# access time on windows has a resolution ranging from 1 hour to 1 day
-		# https://docs.microsoft.com/en-gb/windows/desktop/api/minwinbase/ns-minwinbase-filetime
-		assert stat_res.st_atime > old_atime, "Access time should be update"
-		assert stat_res.st_atime > stat_res.st_mtime
-	assert stat_res.st_mtime > old_mtime, "Modified time should be update"
+    # retrieve update file stats
+    stat_res = os.stat(fname)
+    print(stat_res.st_atime)
+    print(stat_res.st_ctime)
+    print(stat_res.st_mtime)
+    if os.name != "nt":
+        # access time on windows has a resolution ranging from 1 hour to 1 day
+        # https://docs.microsoft.com/en-gb/windows/desktop/api/minwinbase/ns-minwinbase-filetime
+        assert stat_res.st_atime > old_atime, "Access time should be update"
+        assert stat_res.st_atime > stat_res.st_mtime
+    assert stat_res.st_mtime > old_mtime, "Modified time should be update"
 
-	# stat default is follow_symlink=True
-	os.stat(fname).st_ino == os.stat(symlink_file).st_ino
-	os.stat(fname).st_mode == os.stat(symlink_file).st_mode
+    # stat default is follow_symlink=True
+    os.stat(fname).st_ino == os.stat(symlink_file).st_ino
+    os.stat(fname).st_mode == os.stat(symlink_file).st_mode
 
-	os.stat(fname, follow_symlinks=False).st_ino == os.stat(symlink_file, follow_symlinks=False).st_ino
-	os.stat(fname, follow_symlinks=False).st_mode == os.stat(symlink_file, follow_symlinks=False).st_mode
+    os.stat(fname, follow_symlinks=False).st_ino == os.stat(
+        symlink_file, follow_symlinks=False).st_ino
+    os.stat(fname, follow_symlinks=False).st_mode == os.stat(
+        symlink_file, follow_symlinks=False).st_mode
 
-	# os.chmod
-	if os.name != "nt":
-	    os.chmod(fname, 0o666)
-	    assert oct(os.stat(fname).st_mode) == '0o100666'
+    # os.chmod
+    if os.name != "nt":
+        os.chmod(fname, 0o666)
+        assert oct(os.stat(fname).st_mode) == '0o100666'
 
-	# os.path
-	assert os.path.exists(fname) == True
-	assert os.path.exists("NO_SUCH_FILE") == False
-	assert os.path.isfile(fname) == True
-	assert os.path.isdir(folder) == True
-	assert os.path.isfile(folder) == False
-	assert os.path.isdir(fname) == False
+    # os.path
+    assert os.path.exists(fname) is True
+    assert os.path.exists("NO_SUCH_FILE") is False
+    assert os.path.isfile(fname) is True
+    assert os.path.isdir(folder) is True
+    assert os.path.isfile(folder) is False
+    assert os.path.isdir(fname) is False
 
-	assert os.path.basename(fname) == FILE_NAME
-	assert os.path.dirname(fname) == tmpdir
+    assert os.path.basename(fname) == FILE_NAME
+    assert os.path.dirname(fname) == tmpdir
 
-	with TestWithTempCurrentDir():
-		os.chdir(tmpdir)
-		assert os.path.realpath(os.getcwd()) == os.path.realpath(tmpdir)
-		assert os.path.exists(FILE_NAME)
+    with TestWithTempCurrentDir():
+        os.chdir(tmpdir)
+        assert os.path.realpath(os.getcwd()) == os.path.realpath(tmpdir)
+        assert os.path.exists(FILE_NAME)
 
 # supports
 assert isinstance(os.supports_fd, set)
@@ -367,7 +376,6 @@ if sys.platform.startswith('linux') or sys.platform.startswith('freebsd'):
         os.close(rfd)
         os.close(wfd)
 
-
 with TestWithTempDir() as tmpdir:
     for i in range(0, 4):
         file_name = os.path.join(tmpdir, 'file' + str(i))
@@ -386,10 +394,13 @@ with TestWithTempDir() as tmpdir:
 
     dir_iter.close()
 
-    expected_files_bytes = [(file.encode(), os.path.join(tmpdir, file).encode()) for file in expected_files]
+    expected_files_bytes = [(file.encode(), os.path.join(tmpdir,
+                                                         file).encode())
+                            for file in expected_files]
 
     dir_iter_bytes = os.scandir(tmpdir.encode())
-    collected_files_bytes = [(dir_entry.name, dir_entry.path) for dir_entry in dir_iter_bytes]
+    collected_files_bytes = [(dir_entry.name, dir_entry.path)
+                             for dir_entry in dir_iter_bytes]
 
     assert set(collected_files_bytes) == set(expected_files_bytes)
 
@@ -399,7 +410,8 @@ with TestWithTempDir() as tmpdir:
     assert set(collected_files) == set(expected_files)
 
     collected_files = os.listdir(tmpdir.encode())
-    assert set(collected_files) == set([file.encode() for file in expected_files ])
+    assert set(collected_files) == set(
+        [file.encode() for file in expected_files])
 
     with TestWithTempCurrentDir():
         os.chdir(tmpdir)
@@ -414,5 +426,3 @@ if "win" not in sys.platform:
 
     for arg in [None, 1, 1.0, TabError]:
         assert_raises(TypeError, os.system, arg)
-
-

--- a/vm/src/stdlib/os.rs
+++ b/vm/src/stdlib/os.rs
@@ -2130,7 +2130,7 @@ pub fn make_module(vm: &VirtualMachine) -> PyObjectRef {
         SupportFunc::new(vm, "chmod", os_chmod, Some(false), Some(false), Some(false)),
         #[cfg(not(target_os = "redox"))]
         SupportFunc::new(vm, "chroot", os_chroot, Some(false), None, None),
-        SupportFunc::new(vm, "chown", os_chown, Some(false), Some(false), Some(false)),
+        SupportFunc::new(vm, "chown", os_chown, None, Some(true), Some(true)),
         SupportFunc::new(vm, "umask", os_umask, Some(false), Some(false), Some(false)),
     ]);
     let supports_fd = PySet::default().into_ref(vm);

--- a/vm/src/stdlib/os.rs
+++ b/vm/src/stdlib/os.rs
@@ -1074,10 +1074,12 @@ fn os_chown(
         return Err(vm.new_os_error(String::from("Specified gid is not valid.")));
     };
 
-    let flag = match follow_symlinks.follow_symlinks {
-        true => nix::unistd::FchownatFlags::FollowSymlink,
-        false => nix::unistd::FchownatFlags::NoFollowSymlink,
+    let flag = if follow_symlinks.follow_symlinks {
+        nix::unistd::FchownatFlags::FollowSymlink
+    } else {
+        nix::unistd::FchownatFlags::NoFollowSymlink
     };
+
     let dir_fd: Option<std::os::unix::io::RawFd> = match dir_fd.dir_fd {
         Some(int_ref) => Some(i32::try_from_object(&vm, int_ref.as_object().clone())?),
         None => None,


### PR DESCRIPTION
Hello all,

I am trying to implement the chown function for the os module (https://docs.python.org/3/library/os.html#os.chown), because of issue #1175 .
I am a new contributor and I'd like to have feedback on this first take at the implementation. It is not finished yet but I have a few questions and I wanted to be sure that I am going in the good direction.

As of now, the chown function works properly given that you invoke rustpython with root permissions. I can successfully change uid and gid of a file, or use -1 to preserve them. I am having a few issue with the path to file, it does not seem yet to accept unix shorthands like ~ (FileNotFound error, might come from nix lib, need to investigate).
I have not tested dir_fd and _follow_symlink yet since I am not sure how to handle these arguments with defaults values.
More particularly, in line 1988, I am not sure to understand how to initialise a new SupportFunc, what it actually is and why it takes Options on bool rather than bool. I took example on other functions and used false in the Options but I think it should be true since this function supports use of file descriptors and following symlinks, unless I did not understand properly what the bool means here.

I am planning on implementing lchown and fchown after this by using to this first chown function.

I am planning to write proper unit tests but I have no clue on how to write them and what you are expecting as proper tests.

Finally, in the python doc, it says that these functions raises AuditingEvents. I am not familiar with this, is it supported in rustpython yet ? Should I care about this ?

Thanks for your feedback