### PR TITLE
Fix file reading failure in non-ascii path on `not_impl_gen.py`

### DIFF
--- a/tests/not_impl_gen.py
+++ b/tests/not_impl_gen.py
@@ -104,7 +104,6 @@ def get_module_methods(name):
             return None
         except Exception as e:
             print("!!! {} skipped because {}: {}".format(name, type(e).__name__, str(e)))
-1
 
 def gen_modules(header, footer, output):
     output.write(header.read())
@@ -141,4 +140,3 @@ for name, gen_func in gen_funcs.items():
         footer=open(f"generator/not_impl_{name}_footer.txt"),
         output=open(f"snippets/whats_left_{name}.py", "w"),
     )
-

--- a/tests/not_impl_gen.py
+++ b/tests/not_impl_gen.py
@@ -104,7 +104,7 @@ def get_module_methods(name):
             return None
         except Exception as e:
             print("!!! {} skipped because {}: {}".format(name, type(e).__name__, str(e)))
-
+1
 
 def gen_modules(header, footer, output):
     output.write(header.read())
@@ -124,7 +124,7 @@ def gen_modules(header, footer, output):
     print(
         f"""
 cpymods = {modules!r}
-libdir = {os.path.abspath("../Lib/")!r}
+libdir = {os.path.abspath("../Lib/").encode('utf8')!r}
 """,
         file=output,
     )


### PR DESCRIPTION
```
===== MODULES =====
[2020-07-13T14:46:47Z ERROR rustpython] Failed reading file 'tests/snippets/whats_left_modules.py': InvalidData
```

![Broken unicode characters in libdir](https://user-images.githubusercontent.com/7413880/87318365-329ff780-c563-11ea-9c54-96797e2ad197.png)

I discovered a issue when launching `./whats_left.sh` fails to read modules. Turns out it was because of non-ASCII path, so I created this small fix to solve this.

The issue is only confirmed on a Windows 10 machine with non-unicode codepage.