### PR TITLE
Implement `sys.getwindowsversion` 

### DIFF
--- a/tests/snippets/stdlib_os.py
+++ b/tests/snippets/stdlib_os.py
@@ -491,3 +491,26 @@ if "win" not in sys.platform:
 
     for arg in [None, 1, 1.0, TabError]:
         assert_raises(TypeError, os.system, arg)
+
+if sys.platform.startswith("win"):
+	winver = sys.getwindowsversion()
+
+	# the biggest value of wSuiteMask (https://docs.microsoft.com/en-us/windows/win32/api/winnt/ns-winnt-osversioninfoexa#members).
+	all_masks = 0x00000004 | 0x00000400 | 0x00004000 | 0x00000080 | 0x00000002 | 0x00000040 | 0x00000200 | \
+		0x00000100 | 0x00000001 | 0x00000020 | 0x00002000 | 0x00000010 | 0x00008000 | 0x00020000
+
+	# We really can't test if the results are correct, so it just checks for meaningful value
+	assert winver.major > 0
+	assert winver.minor >= 0
+	assert winver.build > 0
+	assert winver.platform == 2
+	assert isinstance(winver.service_pack, str)
+	assert 0 <= winver.suite_mask <= all_masks
+	assert 1 <= winver.product_type <= 3
+
+	# XXX if platform_version is implemented correctly, this'll break on compatiblity mode or a build without manifest
+	assert winver.major == winver.platform_version[0]
+	assert winver.minor == winver.platform_version[1]
+	assert winver.build == winver.platform_version[2]
+
+

--- a/vm/src/sysmodule.rs
+++ b/vm/src/sysmodule.rs
@@ -231,7 +231,7 @@ fn sys_displayhook(obj: PyObjectRef, vm: &VirtualMachine) -> PyResult<()> {
     Ok(())
 }
 
-#[pystruct_sequence(name = "sys.getwindowsversion")]
+#[pystruct_sequence(module = "sys", name = "getwindowsversion")]
 #[derive(Default, Debug)]
 #[cfg(windows)]
 struct WindowsVersion {

--- a/vm/src/sysmodule.rs
+++ b/vm/src/sysmodule.rs
@@ -267,7 +267,8 @@ fn sys_getwindowsversion(vm: &VirtualMachine) -> PyResult<PyTupleRef> {
         Err(vm.new_os_error("failed to get windows version".to_owned()))
     } else {
         let service_pack = {
-            let sp = OsString::from_wide(&version.szCSDVersion);
+            let (last, _) = version.szCSDVersion.iter().take_while(|&x| x != &0).enumerate().last().unwrap_or((0, &0));
+            let sp = OsString::from_wide(&version.szCSDVersion[..last]);
             if let Ok(string) = sp.into_string() {
                 string
             } else {

--- a/vm/src/sysmodule.rs
+++ b/vm/src/sysmodule.rs
@@ -232,7 +232,7 @@ fn sys_displayhook(obj: PyObjectRef, vm: &VirtualMachine) -> PyResult<()> {
     Ok(())
 }
 
-#[pystruct_sequence(name = "sys.getwindowsversion")]
+#[pystruct_sequence(name = "sys.getwindowsversion_type")]
 #[derive(Default, Debug)]
 #[cfg(windows)]
 struct WindowsVersion {
@@ -286,7 +286,7 @@ fn sys_getwindowsversion(vm: &VirtualMachine) -> PyResult<PyTupleRef> {
             suite_mask: version.wSuiteMask,
             product_type: version.wProductType,
             platform_version: (version.dwMajorVersion, version.dwMinorVersion, version.dwBuildNumber) // TODO Provide accurate version, like CPython impl
-        }.into_struct_sequence(vm, vm.try_class("sys", "windows_version")?)
+        }.into_struct_sequence(vm, vm.try_class("sys", "getwindowsversion_type")?)
     }
 }
 
@@ -504,6 +504,15 @@ settrace() -- set the global debug tracing function
       "displayhook" => ctx.new_function(sys_displayhook),
       "__displayhook__" => ctx.new_function(sys_displayhook),
     });
+
+    #[cfg(windows)]
+    {
+        let getwindowsversion = WindowsVersion::make_class(ctx);
+        extend_module!(vm, module, {
+            "getwindowsversion" => ctx.new_function(sys_getwindowsversion),
+            "getwindowsversion_type" => getwindowsversion, 
+        })
+    }
 
     modules.set_item("sys", module.clone(), vm).unwrap();
     modules.set_item("builtins", builtins.clone(), vm).unwrap();

--- a/vm/src/sysmodule.rs
+++ b/vm/src/sysmodule.rs
@@ -231,7 +231,7 @@ fn sys_displayhook(obj: PyObjectRef, vm: &VirtualMachine) -> PyResult<()> {
     Ok(())
 }
 
-#[pystruct_sequence(name = "sys.getwindowsversion_type")]
+#[pystruct_sequence(name = "sys.getwindowsversion")]
 #[derive(Default, Debug)]
 #[cfg(windows)]
 struct WindowsVersion {
@@ -299,7 +299,7 @@ fn sys_getwindowsversion(vm: &VirtualMachine) -> PyResult<crate::obj::objtuple::
                 version.dwBuildNumber,
             ), // TODO Provide accurate version, like CPython impl
         }
-        .into_struct_sequence(vm, vm.try_class("sys", "getwindowsversion_type")?)
+        .into_struct_sequence(vm, vm.try_class("sys", "_getwindowsversion_type")?)
     }
 }
 
@@ -523,7 +523,7 @@ settrace() -- set the global debug tracing function
         let getwindowsversion = WindowsVersion::make_class(ctx);
         extend_module!(vm, module, {
             "getwindowsversion" => ctx.new_function(sys_getwindowsversion),
-            "getwindowsversion_type" => getwindowsversion,
+            "_getwindowsversion_type" => getwindowsversion, // XXX: This is not a python spec but required by current RustPython implementation
         })
     }
 


### PR DESCRIPTION
This PR fixes #1996.

# Note
>In Windows 8.1 and Windows 10, the GetVersion and GetVersionEx functions have been deprecated. In Windows 10, the VerifyVersionInfo function has also been deprecated. While you can still call the deprecated functions, if your application does not specifically target Windows 8.1 or Windows 10, the functions will return the Windows 8 version (6.2). - [Targeting your application for Windows](https://docs.microsoft.com/en-us/windows/win32/sysinfo/targeting-your-application-at-windows-8-1)

* Since Windows 8.1 and later versions return 6.2 for non-manifested application, for now, this function will report the Windows version as 6.2 on modern systems. This can be fixed by adding a manifest with `embed_resource` crate.
* `platform_version` returns the result from `GetVersionExW`, which is not accurate when running application in compatibility mode.