### PR TITLE
Implement lt, le, gt, ge method of array

### DIFF
--- a/vm/src/obj/objbyteinner.rs
+++ b/vm/src/obj/objbyteinner.rs
@@ -115,11 +115,11 @@ impl ByteInnerNewOptions {
                             let bytes = vm.invoke(&bytes_method?, vec![])?;
                             return PyByteInner::try_from_object(vm, bytes);
                         }
-                        let elements = vm.extract_elements(&obj).or_else(|_| {
-                            Err(vm.new_type_error(format!(
+                        let elements = vm.extract_elements(&obj).map_err(|_| {
+                            vm.new_type_error(format!(
                                 "cannot convert '{}' object to bytes",
                                 obj.class().name
-                            )))
+                            ))
                         })?;
 
                         let mut data_bytes = vec![];

--- a/vm/src/stdlib/array.rs
+++ b/vm/src/stdlib/array.rs
@@ -412,6 +412,78 @@ impl PyArray {
         }
     }
 
+    #[pymethod(name = "__lt__")]
+    fn lt(lhs: PyObjectRef, rhs: PyObjectRef, vm: &VirtualMachine) -> PyResult {
+        let lhs = class_or_notimplemented!(vm, Self, lhs);
+        let rhs = class_or_notimplemented!(vm, Self, rhs);
+        let lhs = lhs.borrow_value();
+        let rhs = rhs.borrow_value();
+
+        for (a, b) in lhs.iter(vm).zip(rhs.iter(vm)) {
+            let lt = objbool::boolval(vm, vm._lt(a?, b?)?)?;
+
+            if lt {
+                return Ok(vm.new_bool(true));
+            }
+        }
+
+        Ok(vm.new_bool(lhs.len() < rhs.len()))
+    }
+
+    #[pymethod(name = "__le__")]
+    fn le(lhs: PyObjectRef, rhs: PyObjectRef, vm: &VirtualMachine) -> PyResult {
+        let lhs = class_or_notimplemented!(vm, Self, lhs);
+        let rhs = class_or_notimplemented!(vm, Self, rhs);
+        let lhs = lhs.borrow_value();
+        let rhs = rhs.borrow_value();
+
+        for (a, b) in lhs.iter(vm).zip(rhs.iter(vm)) {
+            let le = objbool::boolval(vm, vm._le(a?, b?)?)?;
+
+            if le {
+                return Ok(vm.new_bool(true));
+            }
+        }
+
+        Ok(vm.new_bool(lhs.len() <= rhs.len()))
+    }
+
+    #[pymethod(name = "__gt__")]
+    fn gt(lhs: PyObjectRef, rhs: PyObjectRef, vm: &VirtualMachine) -> PyResult {
+        let lhs = class_or_notimplemented!(vm, Self, lhs);
+        let rhs = class_or_notimplemented!(vm, Self, rhs);
+        let lhs = lhs.borrow_value();
+        let rhs = rhs.borrow_value();
+
+        for (a, b) in lhs.iter(vm).zip(rhs.iter(vm)) {
+            let gt = objbool::boolval(vm, vm._gt(a?, b?)?)?;
+
+            if gt {
+                return Ok(vm.new_bool(true));
+            }
+        }
+
+        Ok(vm.new_bool(lhs.len() > rhs.len()))
+    }
+
+    #[pymethod(name = "__ge__")]
+    fn ge(lhs: PyObjectRef, rhs: PyObjectRef, vm: &VirtualMachine) -> PyResult {
+        let lhs = class_or_notimplemented!(vm, Self, lhs);
+        let rhs = class_or_notimplemented!(vm, Self, rhs);
+        let lhs = lhs.borrow_value();
+        let rhs = rhs.borrow_value();
+
+        for (a, b) in lhs.iter(vm).zip(rhs.iter(vm)) {
+            let ge = objbool::boolval(vm, vm._ge(a?, b?)?)?;
+
+            if ge {
+                return Ok(vm.new_bool(true));
+            }
+        }
+
+        Ok(vm.new_bool(lhs.len() >= rhs.len()))
+    }
+
     #[pymethod(name = "__len__")]
     fn len(&self) -> usize {
         self.borrow_value().len()

--- a/vm/src/stdlib/os.rs
+++ b/vm/src/stdlib/os.rs
@@ -1118,7 +1118,7 @@ fn os_set_blocking(fd: RawFd, blocking: bool, vm: &VirtualMachine) -> PyResult<(
         }
         Ok(())
     };
-    _set_flag().or_else(|err| Err(convert_nix_error(vm, err)))
+    _set_flag().map_err(|err| convert_nix_error(vm, err))
 }
 
 #[cfg(unix)]
@@ -1128,10 +1128,10 @@ fn os_pipe(vm: &VirtualMachine) -> PyResult<(RawFd, RawFd)> {
     let (rfd, wfd) = pipe().map_err(|err| convert_nix_error(vm, err))?;
     os_set_inheritable(rfd.into(), false, vm)
         .and_then(|_| os_set_inheritable(wfd.into(), false, vm))
-        .or_else(|err| {
+        .map_err(|err| {
             let _ = close(rfd);
             let _ = close(wfd);
-            Err(err)
+            err
         })?;
     Ok((rfd, wfd))
 }


### PR DESCRIPTION
- Test case `BaseTest.test_cmp` in `Lib/test/test_array.py` is failing because there are no compare method of array.
- `BaseTest.test_cmp` is still failing after this PR because multiply methods of array are not implemented.