### PR TITLE
Implement remove method of array

### DIFF
--- a/vm/src/stdlib/array.rs
+++ b/vm/src/stdlib/array.rs
@@ -105,6 +105,20 @@ macro_rules! def_array_enum {
                 }
             }
 
+            fn remove(&mut self, obj: PyObjectRef, vm: &VirtualMachine) -> PyResult<()>{
+                match self {
+                    $(ArrayContentType::$n(v) => {
+                        let val = $t::try_from_object(vm, obj)?;
+                        if let Some(pos) = v.iter().position(|&a| a == val) {
+                            v.remove(pos);
+                        } else {
+                            return Err(vm.new_value_error("array.remove(x): x not in array".to_owned()));
+                        }
+                    })*
+                }
+                Ok(())
+            }
+
             fn frombytes(&mut self, b: &[u8]) {
                 match self {
                     $(ArrayContentType::$n(v) => {
@@ -296,6 +310,11 @@ impl PyArray {
     #[pymethod]
     fn count(&self, x: PyObjectRef, vm: &VirtualMachine) -> PyResult<usize> {
         self.borrow_value().count(x, vm)
+    }
+
+    #[pymethod]
+    fn remove(&self, x: PyObjectRef, vm: &VirtualMachine) -> PyResult<()> {
+        self.borrow_value_mut().remove(x, vm)
     }
 
     #[pymethod]


### PR DESCRIPTION
Implement remove method of array (vm/src/stdlib/array.rs)
I didn't uncommented TODO because there are still error with another problem.

### In unit test <test_remove> in test_array.py
#### Before
```
======================================================================
ERROR: test_remove (__main__.UnsignedShortTest)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "Lib/test/test_array.py", line 953, in test_remove
    self.assertRaises(ValueError, a.remove, self.outside)
AttributeError: 'array' object has no attribute 'remove'

----------------------------------------------------------------------
```

#### After
```
======================================================================
ERROR: test_remove (__main__.UnsignedShortTest)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "Lib/test/test_array.py", line 955, in test_remove
    self.assertRaises(ValueError, a.remove, None)
  File "/home/clemado1/workspace/RustPython/Lib/unittest/case.py", line 746, in assertRaises
    context = None
  File "/home/clemado1/workspace/RustPython/Lib/unittest/case.py", line 743, in assertRaises
    return context.handle('assertRaises', args, kwargs)
  File "/home/clemado1/workspace/RustPython/Lib/unittest/case.py", line 743, in assertRaises
    return context.handle('assertRaises', args, kwargs)
  File "/home/clemado1/workspace/RustPython/Lib/unittest/case.py", line 181, in handle
    self = None
  File "/home/clemado1/workspace/RustPython/Lib/unittest/case.py", line 178, in handle
    callable_obj(*args, **kwargs)
  File "/home/clemado1/workspace/RustPython/Lib/unittest/case.py", line 178, in handle
    callable_obj(*args, **kwargs)
TypeError: Expected type <class 'int'>, not <class 'NoneType'>

----------------------------------------------------------------------
```