### PR TITLE
Implementation of __init_subclass__

### DIFF
--- a/Lib/test/test_subclassinit.py
+++ b/Lib/test/test_subclassinit.py
@@ -1,0 +1,284 @@
+import types
+import unittest
+
+
+class Test(unittest.TestCase):
+    def test_init_subclass(self):
+        class A:
+            initialized = False
+
+            def __init_subclass__(cls):
+                super().__init_subclass__()
+                cls.initialized = True
+
+        class B(A):
+            pass
+
+        self.assertFalse(A.initialized)
+        self.assertTrue(B.initialized)
+
+    def test_init_subclass_dict(self):
+        class A(dict):
+            initialized = False
+
+            def __init_subclass__(cls):
+                super().__init_subclass__()
+                cls.initialized = True
+
+        class B(A):
+            pass
+
+        self.assertFalse(A.initialized)
+        self.assertTrue(B.initialized)
+
+    def test_init_subclass_kwargs(self):
+        class A:
+            def __init_subclass__(cls, **kwargs):
+                cls.kwargs = kwargs
+
+        class B(A, x=3):
+            pass
+
+        self.assertEqual(B.kwargs, dict(x=3))
+
+    def test_init_subclass_error(self):
+        class A:
+            def __init_subclass__(cls):
+                raise RuntimeError
+
+        with self.assertRaises(RuntimeError):
+            class B(A):
+                pass
+
+    def test_init_subclass_wrong(self):
+        class A:
+            def __init_subclass__(cls, whatever):
+                pass
+
+        with self.assertRaises(TypeError):
+            class B(A):
+                pass
+
+    def test_init_subclass_skipped(self):
+        class BaseWithInit:
+            def __init_subclass__(cls, **kwargs):
+                super().__init_subclass__(**kwargs)
+                cls.initialized = cls
+
+        class BaseWithoutInit(BaseWithInit):
+            pass
+
+        class A(BaseWithoutInit):
+            pass
+
+        self.assertIs(A.initialized, A)
+        self.assertIs(BaseWithoutInit.initialized, BaseWithoutInit)
+
+    def test_init_subclass_diamond(self):
+        class Base:
+            def __init_subclass__(cls, **kwargs):
+                super().__init_subclass__(**kwargs)
+                cls.calls = []
+
+        class Left(Base):
+            pass
+
+        class Middle:
+            def __init_subclass__(cls, middle, **kwargs):
+                super().__init_subclass__(**kwargs)
+                cls.calls += [middle]
+
+        class Right(Base):
+            def __init_subclass__(cls, right="right", **kwargs):
+                super().__init_subclass__(**kwargs)
+                cls.calls += [right]
+
+        class A(Left, Middle, Right, middle="middle"):
+            pass
+
+        self.assertEqual(A.calls, ["right", "middle"])
+        self.assertEqual(Left.calls, [])
+        self.assertEqual(Right.calls, [])
+
+    def test_set_name(self):
+        class Descriptor:
+            def __set_name__(self, owner, name):
+                self.owner = owner
+                self.name = name
+
+        class A:
+            d = Descriptor()
+
+        self.assertEqual(A.d.name, "d")
+        self.assertIs(A.d.owner, A)
+
+    def test_set_name_metaclass(self):
+        class Meta(type):
+            def __new__(cls, name, bases, ns):
+                ret = super().__new__(cls, name, bases, ns)
+                self.assertEqual(ret.d.name, "d")
+                self.assertIs(ret.d.owner, ret)
+                return 0
+
+        class Descriptor:
+            def __set_name__(self, owner, name):
+                self.owner = owner
+                self.name = name
+
+        class A(metaclass=Meta):
+            d = Descriptor()
+        self.assertEqual(A, 0)
+
+    def test_set_name_error(self):
+        class Descriptor:
+            def __set_name__(self, owner, name):
+                1/0
+
+        with self.assertRaises(RuntimeError) as cm:
+            class NotGoingToWork:
+                attr = Descriptor()
+
+        exc = cm.exception
+        self.assertRegex(str(exc), r'\bNotGoingToWork\b')
+        self.assertRegex(str(exc), r'\battr\b')
+        self.assertRegex(str(exc), r'\bDescriptor\b')
+        self.assertIsInstance(exc.__cause__, ZeroDivisionError)
+
+    def test_set_name_wrong(self):
+        class Descriptor:
+            def __set_name__(self):
+                pass
+
+        with self.assertRaises(RuntimeError) as cm:
+            class NotGoingToWork:
+                attr = Descriptor()
+
+        exc = cm.exception
+        self.assertRegex(str(exc), r'\bNotGoingToWork\b')
+        self.assertRegex(str(exc), r'\battr\b')
+        self.assertRegex(str(exc), r'\bDescriptor\b')
+        self.assertIsInstance(exc.__cause__, TypeError)
+
+    def test_set_name_lookup(self):
+        resolved = []
+        class NonDescriptor:
+            def __getattr__(self, name):
+                resolved.append(name)
+
+        class A:
+            d = NonDescriptor()
+
+        self.assertNotIn('__set_name__', resolved,
+                         '__set_name__ is looked up in instance dict')
+
+    def test_set_name_init_subclass(self):
+        class Descriptor:
+            def __set_name__(self, owner, name):
+                self.owner = owner
+                self.name = name
+
+        class Meta(type):
+            def __new__(cls, name, bases, ns):
+                self = super().__new__(cls, name, bases, ns)
+                self.meta_owner = self.owner
+                self.meta_name = self.name
+                return self
+
+        class A:
+            def __init_subclass__(cls):
+                cls.owner = cls.d.owner
+                cls.name = cls.d.name
+
+        class B(A, metaclass=Meta):
+            d = Descriptor()
+
+        self.assertIs(B.owner, B)
+        self.assertEqual(B.name, 'd')
+        self.assertIs(B.meta_owner, B)
+        self.assertEqual(B.name, 'd')
+
+    def test_set_name_modifying_dict(self):
+        notified = []
+        class Descriptor:
+            def __set_name__(self, owner, name):
+                setattr(owner, name + 'x', None)
+                notified.append(name)
+
+        class A:
+            a = Descriptor()
+            b = Descriptor()
+            c = Descriptor()
+            d = Descriptor()
+            e = Descriptor()
+
+        self.assertCountEqual(notified, ['a', 'b', 'c', 'd', 'e'])
+
+    def test_errors(self):
+        class MyMeta(type):
+            pass
+
+        with self.assertRaises(TypeError):
+            class MyClass(metaclass=MyMeta, otherarg=1):
+                pass
+
+        with self.assertRaises(TypeError):
+            types.new_class("MyClass", (object,),
+                            dict(metaclass=MyMeta, otherarg=1))
+        types.prepare_class("MyClass", (object,),
+                            dict(metaclass=MyMeta, otherarg=1))
+
+        class MyMeta(type):
+            def __init__(self, name, bases, namespace, otherarg):
+                super().__init__(name, bases, namespace)
+
+        with self.assertRaises(TypeError):
+            class MyClass(metaclass=MyMeta, otherarg=1):
+                pass
+
+        class MyMeta(type):
+            def __new__(cls, name, bases, namespace, otherarg):
+                return super().__new__(cls, name, bases, namespace)
+
+            def __init__(self, name, bases, namespace, otherarg):
+                super().__init__(name, bases, namespace)
+                self.otherarg = otherarg
+
+        class MyClass(metaclass=MyMeta, otherarg=1):
+            pass
+
+        self.assertEqual(MyClass.otherarg, 1)
+
+    def test_errors_changed_pep487(self):
+        # These tests failed before Python 3.6, PEP 487
+        class MyMeta(type):
+            def __new__(cls, name, bases, namespace):
+                return super().__new__(cls, name=name, bases=bases,
+                                       dict=namespace)
+
+        with self.assertRaises(TypeError):
+            class MyClass(metaclass=MyMeta):
+                pass
+
+        class MyMeta(type):
+            def __new__(cls, name, bases, namespace, otherarg):
+                self = super().__new__(cls, name, bases, namespace)
+                self.otherarg = otherarg
+                return self
+
+        class MyClass(metaclass=MyMeta, otherarg=1):
+            pass
+
+        self.assertEqual(MyClass.otherarg, 1)
+
+    def test_type(self):
+        t = type('NewClass', (object,), {})
+        self.assertIsInstance(t, type)
+        self.assertEqual(t.__name__, 'NewClass')
+
+        with self.assertRaises(TypeError):
+            type(name='NewClass', bases=(object,), dict={})
+
+
+if __name__ == "__main__":
+    unittest.main()
+

--- a/Lib/test/test_subclassinit.py
+++ b/Lib/test/test_subclassinit.py
@@ -112,6 +112,8 @@ class Test(unittest.TestCase):
         self.assertEqual(A.d.name, "d")
         self.assertIs(A.d.owner, A)
 
+    #TODO: RUSTPYTHON
+    @unittest.expectedFailure
     def test_set_name_metaclass(self):
         class Meta(type):
             def __new__(cls, name, bases, ns):
@@ -197,6 +199,8 @@ class Test(unittest.TestCase):
         self.assertIs(B.meta_owner, B)
         self.assertEqual(B.name, 'd')
 
+    #TODO: RUSTPYTHON
+    @unittest.skip("infinite loops")
     def test_set_name_modifying_dict(self):
         notified = []
         class Descriptor:
@@ -213,6 +217,8 @@ class Test(unittest.TestCase):
 
         self.assertCountEqual(notified, ['a', 'b', 'c', 'd', 'e'])
 
+    #TODO: RUSTPYTHON
+    @unittest.expectedFailure
     def test_errors(self):
         class MyMeta(type):
             pass

--- a/vm/src/function.rs
+++ b/vm/src/function.rs
@@ -66,6 +66,15 @@ impl From<(&Args, &KwArgs)> for PyFuncArgs {
     }
 }
 
+impl From<KwArgs> for PyFuncArgs {
+    fn from(kwargs: KwArgs) -> Self {
+        PyFuncArgs {
+            args: Vec::new(),
+            kwargs: kwargs.into_iter().collect(),
+        }
+    }
+}
+
 impl FromArgs for PyFuncArgs {
     fn from_args(_vm: &VirtualMachine, args: &mut PyFuncArgs) -> Result<Self, ArgumentError> {
         Ok(mem::take(args))

--- a/vm/src/obj/objobject.rs
+++ b/vm/src/obj/objobject.rs
@@ -138,6 +138,11 @@ impl PyBaseObject {
         Ok(vm.ctx.not_implemented())
     }
 
+    #[pyclassmethod(magic)]
+    fn init_subclass(_cls: PyClassRef, vm: &VirtualMachine) -> PyResult {
+        Ok(vm.ctx.none())
+    }
+
     #[pymethod(magic)]
     pub fn dir(obj: PyObjectRef, vm: &VirtualMachine) -> PyResult<PyList> {
         let attributes: PyAttributes = obj.class().get_attributes();

--- a/vm/src/obj/objtype.rs
+++ b/vm/src/obj/objtype.rs
@@ -336,7 +336,11 @@ impl PyClassRef {
 
         if let Some(initter) = typ.get_super_attr("__init_subclass__") {
             let initter = vm
-                .call_get_descriptor_specific(initter.clone(), None, Some(typ.clone().into_object()))
+                .call_get_descriptor_specific(
+                    initter.clone(),
+                    None,
+                    Some(typ.clone().into_object()),
+                )
                 .unwrap_or(Ok(initter))?;
             vm.invoke(&initter, kwargs)?;
         };

--- a/vm/src/obj/objtype.rs
+++ b/vm/src/obj/objtype.rs
@@ -2,6 +2,7 @@ use parking_lot::RwLock;
 use std::collections::{HashMap, HashSet};
 use std::fmt;
 
+use super::objclassmethod::PyClassMethod;
 use super::objdict::PyDictRef;
 use super::objlist::PyList;
 use super::objmappingproxy::PyMappingProxy;
@@ -14,7 +15,7 @@ use crate::pyobject::{
     IdProtocol, PyAttributes, PyClassImpl, PyContext, PyIterable, PyLease, PyObject, PyObjectRef,
     PyRef, PyResult, PyValue, TypeProtocol,
 };
-use crate::slots::{PyClassSlots, PyTpFlags};
+use crate::slots::{PyClassSlots, PyTpFlags, SlotDescriptor};
 use crate::vm::VirtualMachine;
 use itertools::Itertools;
 use std::ops::Deref;
@@ -301,6 +302,12 @@ impl PyClassRef {
             }
         }
 
+        if let Some(f) = attributes.get_mut("__init_subclass__") {
+            if f.class().is(&vm.ctx.function_type()) {
+                *f = PyClassMethod::new(f.clone()).into_ref(vm).into_object();
+            }
+        }
+
         let typ = new(metatype, name.as_str(), base.clone(), bases, attributes)
             .map_err(|e| vm.new_type_error(e))?;
 
@@ -326,6 +333,20 @@ impl PyClassRef {
                 })?;
             }
         }
+
+        if let Some(initter) = typ.get_super_attr("__init_subclass__") {
+            let initter = PyClassMethod::descr_get(
+                vm,
+                initter,
+                None,
+                OptionalArg::Present(typ.clone().into_object()),
+            )?;
+            let init_args = PyFuncArgs {
+                args: Vec::new(),
+                kwargs: args.kwargs,
+            };
+            vm.invoke(&initter, init_args)?;
+        };
 
         Ok(typ.into_object())
     }

--- a/vm/src/obj/objtype.rs
+++ b/vm/src/obj/objtype.rs
@@ -336,8 +336,8 @@ impl PyClassRef {
 
         if let Some(initter) = typ.get_super_attr("__init_subclass__") {
             let initter = vm
-                .call_get_descriptor_specific(initter, None, Some(typ.clone().into_object()))
-                .unwrap()?;
+                .call_get_descriptor_specific(initter.clone(), None, Some(typ.clone().into_object()))
+                .unwrap_or(Ok(initter))?;
             vm.invoke(&initter, kwargs)?;
         };
 

--- a/vm/src/obj/objtype.rs
+++ b/vm/src/obj/objtype.rs
@@ -10,7 +10,7 @@ use super::objstaticmethod::PyStaticMethod;
 use super::objstr::PyStringRef;
 use super::objtuple::PyTuple;
 use super::objweakref::PyWeak;
-use crate::function::{OptionalArg, PyFuncArgs};
+use crate::function::{KwArgs, OptionalArg, PyFuncArgs};
 use crate::pyobject::{
     IdProtocol, PyAttributes, PyClassImpl, PyContext, PyIterable, PyLease, PyObject, PyObjectRef,
     PyRef, PyResult, PyValue, TypeProtocol,
@@ -258,7 +258,7 @@ impl PyClassRef {
             }));
         }
 
-        let (name, bases, dict): (PyStringRef, PyIterable<PyClassRef>, PyDictRef) =
+        let (name, bases, dict, kwargs): (PyStringRef, PyIterable<PyClassRef>, PyDictRef, KwArgs) =
             args.clone().bind(vm)?;
 
         let bases: Vec<PyClassRef> = bases.iter(vm)?.collect::<Result<Vec<_>, _>>()?;
@@ -341,10 +341,7 @@ impl PyClassRef {
                 None,
                 OptionalArg::Present(typ.clone().into_object()),
             )?;
-            let init_args = PyFuncArgs {
-                args: Vec::new(),
-                kwargs: args.kwargs,
-            };
+            let init_args = PyFuncArgs::from(kwargs);
             vm.invoke(&initter, init_args)?;
         };
 

--- a/vm/src/obj/objtype.rs
+++ b/vm/src/obj/objtype.rs
@@ -15,7 +15,7 @@ use crate::pyobject::{
     IdProtocol, PyAttributes, PyClassImpl, PyContext, PyIterable, PyLease, PyObject, PyObjectRef,
     PyRef, PyResult, PyValue, TypeProtocol,
 };
-use crate::slots::{PyClassSlots, PyTpFlags, SlotDescriptor};
+use crate::slots::{PyClassSlots, PyTpFlags};
 use crate::vm::VirtualMachine;
 use itertools::Itertools;
 use std::ops::Deref;
@@ -335,14 +335,10 @@ impl PyClassRef {
         }
 
         if let Some(initter) = typ.get_super_attr("__init_subclass__") {
-            let initter = PyClassMethod::descr_get(
-                vm,
-                initter,
-                None,
-                OptionalArg::Present(typ.clone().into_object()),
-            )?;
-            let init_args = PyFuncArgs::from(kwargs);
-            vm.invoke(&initter, init_args)?;
+            let initter = vm
+                .call_get_descriptor_specific(initter, None, Some(typ.clone().into_object()))
+                .unwrap()?;
+            vm.invoke(&initter, kwargs)?;
         };
 
         Ok(typ.into_object())


### PR DESCRIPTION
This implements `__init_subclass__` from [PEP 487](https://www.python.org/dev/peps/pep-0487/).

Closes #1346. Partially fixes issue  #356.