### PR TITLE
implemented __repr__ method in impl_pyclass_sequence

### DIFF
--- a/derive/src/pyclass.rs
+++ b/derive/src/pyclass.rs
@@ -462,7 +462,7 @@ pub fn impl_pyclass(attr: AttributeArgs, item: Item) -> Result<TokenStream2, Dia
         ),
     };
 
-    let class_name = def_to_name(&ident, "pyclass", &attr)?;
+    let class_name = def_to_name(&ident, "pyclass", attr)?;
     let class_def = generate_class_def(&ident, &class_name, &attrs)?;
 
     let ret = quote! {
@@ -481,8 +481,8 @@ pub fn impl_pystruct_sequence(attr: AttributeArgs, item: Item) -> Result<TokenSt
             "#[pystruct_sequence] can only be on a struct declaration"
         )
     };
-    let class_name = def_to_name(&struc.ident, "pystruct_sequence", &attr)?;
-    let module_name = optional_attribute_arg("pystruct_sequence", "module", &attr)?;
+    let class_name = def_to_name(&struc.ident, "pystruct_sequence", attr.clone())?;
+    let module_name = optional_attribute_arg("pystruct_sequence", "module", attr)?;
     let py_class_name = module_class_name(module_name, &class_name);
     let class_def = generate_class_def(&struc.ident, &class_name, &struc.attrs)?;
     let mut properties = Vec::new();

--- a/derive/src/pymodule.rs
+++ b/derive/src/pymodule.rs
@@ -166,7 +166,7 @@ pub fn impl_pymodule(attr: AttributeArgs, item: Item) -> Result<TokenStream2, Di
         Item::Mod(m) => m,
         other => bail_span!(other, "#[pymodule] can only be on a module declaration"),
     };
-    let module_name = def_to_name(&module.ident, "pymodule", attr)?;
+    let module_name = def_to_name(&module.ident, "pymodule", &attr)?;
 
     let (_, content) = match module.content.as_mut() {
         Some(c) => c,

--- a/derive/src/pymodule.rs
+++ b/derive/src/pymodule.rs
@@ -166,7 +166,7 @@ pub fn impl_pymodule(attr: AttributeArgs, item: Item) -> Result<TokenStream2, Di
         Item::Mod(m) => m,
         other => bail_span!(other, "#[pymodule] can only be on a module declaration"),
     };
-    let module_name = def_to_name(&module.ident, "pymodule", &attr)?;
+    let module_name = def_to_name(&module.ident, "pymodule", attr)?;
 
     let (_, content) = match module.content.as_mut() {
         Some(c) => c,

--- a/derive/src/util.rs
+++ b/derive/src/util.rs
@@ -9,14 +9,14 @@ pub fn path_eq(path: &Path, s: &str) -> bool {
 pub fn def_to_name(
     ident: &Ident,
     attr_name: &'static str,
-    attr: AttributeArgs,
+    attr: &AttributeArgs,
 ) -> Result<String, Diagnostic> {
     let mut name = None;
     for attr in attr {
-        if let NestedMeta::Meta(meta) = attr {
-            if let Meta::NameValue(name_value) = meta {
+        if let NestedMeta::Meta(ref meta) = attr {
+            if let Meta::NameValue(ref name_value) = meta {
                 if path_eq(&name_value.path, "name") {
-                    if let Lit::Str(s) = name_value.lit {
+                    if let Lit::Str(ref s) = name_value.lit {
                         name = Some(s.value());
                     } else {
                         bail_span!(
@@ -30,6 +30,41 @@ pub fn def_to_name(
         }
     }
     Ok(name.unwrap_or_else(|| ident.to_string()))
+}
+
+pub fn optional_attribute_arg(
+    attr_name: &'static str,
+    arg_name: &'static str,
+    attr: &AttributeArgs,
+) -> Result<Option<String>, Diagnostic> {
+    let mut arg_value = None;
+    for attr in attr {
+        if let NestedMeta::Meta(ref meta) = attr {
+            if let Meta::NameValue(ref name_value) = meta {
+                if path_eq(&name_value.path, arg_name) {
+                    if let Lit::Str(ref lit) = name_value.lit {
+                        arg_value = Some(lit.value());
+                    } else {
+                        bail_span!(
+                            name_value.lit,
+                            "#[{}({} = ...)] must be a string",
+                            attr_name,
+                            arg_name
+                        );
+                    }
+                }
+            }
+        }
+    }
+    Ok(arg_value)
+}
+
+pub fn module_class_name(mod_name: Option<String>, class_name: &str) -> String {
+    if let Some(mod_name) = mod_name {
+        format!("{}.{}", mod_name, class_name)
+    } else {
+        class_name.into()
+    }
 }
 
 pub fn strip_prefix<'a>(s: &'a str, prefix: &str) -> Option<&'a str> {

--- a/derive/src/util.rs
+++ b/derive/src/util.rs
@@ -9,14 +9,14 @@ pub fn path_eq(path: &Path, s: &str) -> bool {
 pub fn def_to_name(
     ident: &Ident,
     attr_name: &'static str,
-    attr: &AttributeArgs,
+    attr: AttributeArgs,
 ) -> Result<String, Diagnostic> {
     let mut name = None;
     for attr in attr {
-        if let NestedMeta::Meta(ref meta) = attr {
-            if let Meta::NameValue(ref name_value) = meta {
+        if let NestedMeta::Meta(meta) = attr {
+            if let Meta::NameValue(name_value) = meta {
                 if path_eq(&name_value.path, "name") {
-                    if let Lit::Str(ref s) = name_value.lit {
+                    if let Lit::Str(s) = name_value.lit {
                         name = Some(s.value());
                     } else {
                         bail_span!(
@@ -35,14 +35,14 @@ pub fn def_to_name(
 pub fn optional_attribute_arg(
     attr_name: &'static str,
     arg_name: &'static str,
-    attr: &AttributeArgs,
+    attr: AttributeArgs,
 ) -> Result<Option<String>, Diagnostic> {
     let mut arg_value = None;
     for attr in attr {
-        if let NestedMeta::Meta(ref meta) = attr {
-            if let Meta::NameValue(ref name_value) = meta {
+        if let NestedMeta::Meta(meta) = attr {
+            if let Meta::NameValue(name_value) = meta {
                 if path_eq(&name_value.path, arg_name) {
-                    if let Lit::Str(ref lit) = name_value.lit {
+                    if let Lit::Str(lit) = name_value.lit {
                         arg_value = Some(lit.value());
                     } else {
                         bail_span!(

--- a/vm/src/pyhash.rs
+++ b/vm/src/pyhash.rs
@@ -104,7 +104,7 @@ pub fn hash_bigint(value: &BigInt) -> PyHash {
     }
 }
 
-#[pystruct_sequence(name = "sys.hash_info")]
+#[pystruct_sequence(module = "sys", name = "hash_info")]
 #[derive(Debug)]
 pub(crate) struct PyHashInfo {
     width: usize,

--- a/vm/src/stdlib/os.rs
+++ b/vm/src/stdlib/os.rs
@@ -801,7 +801,7 @@ fn os_scandir(path: OptionalArg<PyPathLike>, vm: &VirtualMachine) -> PyResult {
     }
 }
 
-#[pystruct_sequence(name = "os.stat_result")]
+#[pystruct_sequence(module = "os", name = "stat_result")]
 #[derive(Debug)]
 struct StatResult {
     st_mode: u32,
@@ -1373,7 +1373,7 @@ fn os_umask(mask: ModeT, _vm: &VirtualMachine) -> PyResult<ModeT> {
     Ok(ret_mask)
 }
 
-#[pystruct_sequence(name = "os.uname_result")]
+#[pystruct_sequence(module = "os", name = "uname_result")]
 #[derive(Debug)]
 #[cfg(unix)]
 struct UnameResult {
@@ -1930,7 +1930,7 @@ fn os_strerror(e: i32) -> String {
         .into_owned()
 }
 
-#[pystruct_sequence(name = "os.terminal_size")]
+#[pystruct_sequence(module = "os", name = "terminal_size")]
 #[allow(dead_code)]
 struct PyTerminalSize {
     columns: usize,

--- a/vm/src/stdlib/pwd.rs
+++ b/vm/src/stdlib/pwd.rs
@@ -8,7 +8,7 @@ use std::ptr::NonNull;
 
 use nix::unistd::{self, User};
 
-#[pystruct_sequence(name = "pwd.struct_passwd")]
+#[pystruct_sequence(module = "pwd", name = "struct_passwd")]
 struct Passwd {
     pw_name: String,
     pw_passwd: String,

--- a/vm/src/stdlib/time_module.rs
+++ b/vm/src/stdlib/time_module.rs
@@ -170,7 +170,7 @@ fn time_strptime(
     Ok(PyStructTime::new(vm, instant, -1).into_obj(vm))
 }
 
-#[pystruct_sequence(name = "time.struct_time")]
+#[pystruct_sequence(module = "time", name = "struct_time")]
 #[allow(dead_code)]
 struct PyStructTime {
     tm_year: PyObjectRef,

--- a/vm/src/version.rs
+++ b/vm/src/version.rs
@@ -7,7 +7,7 @@ const MICRO: usize = 0;
 const RELEASELEVEL: &str = "alpha";
 const SERIAL: usize = 0;
 
-#[pystruct_sequence(name = "version_info")]
+#[pystruct_sequence(module = "sys", name = "version_info")]
 #[derive(Default, Debug)]
 pub struct VersionInfo {
     major: usize,


### PR DESCRIPTION
Just implemented 'rustpython_vm::version::VersionInfo::repr' method, and added as value of property 'sys.version_info'.
It's now works, but refactoring is required.

Fix #1448