### PR TITLE
Fixed bug where sys.executable returned an absolute path instead of a relative path

### DIFF
--- a/vm/src/sysmodule.rs
+++ b/vm/src/sysmodule.rs
@@ -29,7 +29,7 @@ fn argv(vm: &VirtualMachine) -> PyObjectRef {
 
 fn executable(ctx: &PyContext) -> PyObjectRef {
     if let Ok(path) = env::current_exe() {
-        if let Some(path) = path.to_str() {
+        if let Ok(path) = path.into_os_string().into_string() {
             return ctx.new_str(path);
         }
     }

--- a/vm/src/sysmodule.rs
+++ b/vm/src/sysmodule.rs
@@ -28,11 +28,12 @@ fn argv(vm: &VirtualMachine) -> PyObjectRef {
 }
 
 fn executable(ctx: &PyContext) -> PyObjectRef {
-    if let Some(arg) = env::args().next() {
-        ctx.new_str(arg)
-    } else {
-        ctx.none()
+    if let Ok(path) = env::current_exe() {
+        if let Some(path) = path.to_str() {
+            return ctx.new_str(path);
+        }
     }
+    ctx.none()
 }
 
 fn _base_executable(ctx: &PyContext) -> PyObjectRef {


### PR DESCRIPTION
Before, sys.executable returned a relative path, unlike what the [documentation](https://docs.python.org/3/library/sys.html#sys.executable) says. This makes sys.executable return an absolute path.