### PR TITLE
os.execv implementation for unix systems

### DIFF
--- a/vm/src/stdlib/os.rs
+++ b/vm/src/stdlib/os.rs
@@ -1200,11 +1200,12 @@ fn os_execv(
     // TODO: argv_list to only accept tuples and lists
     // message: "TypeError: execv() arg 2 must be a tuple or list"
 
-    if path.to_string().contains("\0") {
-        return Err(vm.new_value_error("embedded null byte".to_owned()));
-    }
-
-    let path = ffi::CString::new(path.as_str()).unwrap();
+    let path = match ffi::CString::new(path.as_str()) {
+        Ok(s) => s,
+        Err(_) => {
+            return Err(vm.new_value_error("embedded null byte".to_owned()));
+        }
+    };
 
     if argv_list.iter(vm)?.count() == 0 {
         return Err(vm.new_value_error("execv() arg 2 must not be empty".to_owned()));

--- a/vm/src/stdlib/os.rs
+++ b/vm/src/stdlib/os.rs
@@ -1212,7 +1212,7 @@ fn os_execv(
     }
 
     for arg in argv_list.iter(vm)? {
-        if arg?.as_str().contains("\0") {
+        if arg?.as_str().contains('\0') {
             return Err(vm.new_value_error("embedded null byte".to_owned()));
         }
     }
@@ -1222,7 +1222,7 @@ fn os_execv(
         .map(|entry| ffi::CString::new(entry.unwrap().as_str()).unwrap())
         .collect();
 
-    if argv_list.first().unwrap().as_bytes().len() == 0 {
+    if argv_list.first().unwrap().as_bytes().is_empty() {
         return Err(vm.new_value_error("execv() arg 2 first element cannot be empty".to_owned()));
     }
 

--- a/vm/src/stdlib/os.rs
+++ b/vm/src/stdlib/os.rs
@@ -33,7 +33,6 @@ use crate::obj::objbytes::{PyBytes, PyBytesRef};
 use crate::obj::objdict::PyDictRef;
 use crate::obj::objint::{PyInt, PyIntRef};
 use crate::obj::objiter;
-use crate::obj::objlist::PyListRef;
 use crate::obj::objset::PySet;
 use crate::obj::objstr::{PyString, PyStringRef};
 use crate::obj::objtuple::PyTupleRef;
@@ -47,6 +46,8 @@ use crate::vm::VirtualMachine;
 // just to avoid unused import warnings
 #[cfg(unix)]
 use crate::obj::objdict::PyMapping;
+#[cfg(unix)]
+use crate::obj::objlist::PyListRef;
 #[cfg(unix)]
 use crate::pyobject::PyIterable;
 #[cfg(unix)]

--- a/vm/src/stdlib/os.rs
+++ b/vm/src/stdlib/os.rs
@@ -1198,7 +1198,7 @@ fn os_execv(
     vm: &VirtualMachine,
 ) -> PyResult<()> {
     // TODO: argv_list to only accept tuples and lists
-    // message: "TypeError: execv() arg 2 must be a tuple or list"
+    // "TypeError: execv() arg 2 must be a tuple or list"
 
     let path = match ffi::CString::new(path.as_str()) {
         Ok(s) => s,
@@ -1217,22 +1217,14 @@ fn os_execv(
         }
     }
 
-    if argv_list
-        .iter(vm)?
-        .next()
-        .unwrap()
-        .unwrap()
-        .to_string()
-        .len()
-        == 0
-    {
-        return Err(vm.new_value_error("execv() arg 2 first element cannot be empty".to_owned()));
-    }
-
     let argv_list: Vec<ffi::CString> = argv_list
         .iter(vm)?
         .map(|entry| ffi::CString::new(entry.unwrap().as_str()).unwrap())
         .collect();
+
+    if argv_list.first().unwrap().as_bytes().len() == 0 {
+        return Err(vm.new_value_error("execv() arg 2 first element cannot be empty".to_owned()));
+    }
 
     let argv: Vec<&ffi::CStr> = argv_list.iter().map(|entry| entry.as_c_str()).collect();
 

--- a/vm/src/stdlib/os.rs
+++ b/vm/src/stdlib/os.rs
@@ -1195,22 +1195,17 @@ fn os_chmod(
 fn os_execv(
     path: PyStringRef,
     argv_list: PyIterable<PyStringRef>,
-    vm: &VirtualMachine
-    ) -> PyResult<()> {
-
+    vm: &VirtualMachine,
+) -> PyResult<()> {
     let path = ffi::CString::new(path.as_str()).unwrap();
 
-    let argv_list: Vec<ffi::CString> = argv_list.iter(vm).unwrap().map(
-        |entry| ffi::CString::new(
-            entry
-            .unwrap()
-            .as_str()
-        ).unwrap()
-    ).collect();
-    
-    let argv: Vec<&ffi::CStr> = argv_list.iter().map(
-        |entry| entry.as_c_str()
-    ).collect();
+    let argv_list: Vec<ffi::CString> = argv_list
+        .iter(vm)
+        .unwrap()
+        .map(|entry| ffi::CString::new(entry.unwrap().as_str()).unwrap())
+        .collect();
+
+    let argv: Vec<&ffi::CStr> = argv_list.iter().map(|entry| entry.as_c_str()).collect();
 
     unistd::execv(&path, &argv)
         .map(|_ok| ())
@@ -2115,7 +2110,7 @@ pub fn make_module(vm: &VirtualMachine) -> PyObjectRef {
         #[cfg(not(target_os = "redox"))]
         SupportFunc::new(vm, "chroot", os_chroot, Some(false), None, None),
         SupportFunc::new(vm, "umask", os_umask, Some(false), Some(false), Some(false)),
-        SupportFunc::new(vm, "execv", os_execv, None, None, None)
+        SupportFunc::new(vm, "execv", os_execv, None, None, None),
     ]);
     let supports_fd = PySet::default().into_ref(vm);
     let supports_dir_fd = PySet::default().into_ref(vm);


### PR DESCRIPTION
This PR adds os.execv for unix systems which is a part of #1992
Uses nix::unistd::execv for implementation.
Would appreciate any help on line 1203 - temporary value referencing in closure while converting CString to &CStr