### PR TITLE
Fix #1986 which (-2) ** 0.5 yields NaN.

### DIFF
--- a/Lib/test/test_fractions.py
+++ b/Lib/test/test_fractions.py
@@ -392,8 +392,6 @@ class FractionTest(unittest.TestCase):
         self.assertTypedEquals(F(-2, 10), round(F(-15, 100), 1))
         self.assertTypedEquals(F(-2, 10), round(F(-25, 100), 1))
 
-    # TODO: RUSTPYTHON
-    @unittest.expectedFailure
     def testArithmetic(self):
         self.assertEqual(F(1, 2), F(1, 10) + F(2, 5))
         self.assertEqual(F(-3, 10), F(1, 10) - F(2, 5))

--- a/vm/src/obj/objfloat.rs
+++ b/vm/src/obj/objfloat.rs
@@ -139,7 +139,7 @@ pub fn float_pow(v1: f64, v2: f64, vm: &VirtualMachine) -> PyResult {
     if v1.is_zero() {
         let msg = format!("{} cannot be raised to a negative power", v1);
         Err(vm.new_zero_division_error(msg))
-    } else if v1.is_sign_negative() && v2.floor() != v2 {
+    } else if v1.is_sign_negative() && (v2.floor() - v2).abs() > f64::EPSILON {
         let v1 = Complex64::new(v1, 0.);
         let v2 = Complex64::new(v2, 0.);
         v1.powc(v2).into_pyobject(vm)


### PR DESCRIPTION
Fix #1986 

**Before:**
- RustPython
`>>>>> float.__rpow__(0.5, -2)`
`NaN`


**After:**
- RustPython
`>>>float.__rpow__(0.5, -2)`
`(0.00000000000000008659560562354934+1.4142135623730951j)`

- CPython 3.85
`>>> float.__rpow__(0.5, -2)`
`(8.659560562354934e-17+1.4142135623730951j)`