### PR TITLE
os.rs - Minor typo fix for panic! macro

### DIFF
--- a/vm/src/stdlib/os.rs
+++ b/vm/src/stdlib/os.rs
@@ -1012,7 +1012,7 @@ fn os_symlink(
     } else if meta.is_dir() {
         win_fs::symlink_dir(src.path, dst.path)
     } else {
-        panic!("Uknown file type");
+        panic!("Unknown file type");
     };
     ret.map_err(|err| convert_io_error(vm, err))
 }


### PR DESCRIPTION
panic message has following typo: "Uknown file type"
fixed to "Unknown file type"