### PR TITLE
DictKey for str shares same hash with PyString

### DIFF
--- a/common/src/hash.rs
+++ b/common/src/hash.rs
@@ -23,6 +23,17 @@ pub const SEED_BITS: usize = std::mem::size_of::<PyHash>() * 2 * 8;
 
 // pub const CUTOFF: usize = 7;
 
+#[inline]
+pub fn mod_int(value: i64) -> PyHash {
+    value % MODULUS as i64
+}
+
+pub fn hash_value<T: Hash + ?Sized>(data: &T) -> PyHash {
+    let mut hasher = DefaultHasher::new();
+    data.hash(&mut hasher);
+    mod_int(hasher.finish() as PyHash)
+}
+
 pub fn hash_float(value: f64) -> PyHash {
     // cpython _Py_HashDouble
     if !value.is_finite() {
@@ -68,12 +79,6 @@ pub fn hash_float(value: f64) -> PyHash {
     x as PyHash * value.signum() as PyHash
 }
 
-pub fn hash_value<T: Hash + ?Sized>(data: &T) -> PyHash {
-    let mut hasher = DefaultHasher::new();
-    data.hash(&mut hasher);
-    hasher.finish() as PyHash
-}
-
 pub fn hash_iter<'a, T: 'a, I, F, E>(iter: I, hashf: F) -> Result<PyHash, E>
 where
     I: IntoIterator<Item = &'a T>,
@@ -84,7 +89,7 @@ where
         let item_hash = hashf(element)?;
         item_hash.hash(&mut hasher);
     }
-    Ok(hasher.finish() as PyHash)
+    Ok(mod_int(hasher.finish() as PyHash))
 }
 
 pub fn hash_iter_unordered<'a, T: 'a, I, F, E>(iter: I, hashf: F) -> Result<PyHash, E>
@@ -98,12 +103,20 @@ where
         // xor is commutative and hash should be independent of order
         hash ^= item_hash;
     }
-    Ok(hash)
+    Ok(mod_int(hash))
 }
 
 pub fn hash_bigint(value: &BigInt) -> PyHash {
-    match value.to_i64() {
-        Some(i64_value) => (i64_value % MODULUS as i64),
-        None => (value % MODULUS).to_i64().unwrap(),
-    }
+    value.to_i64().map_or_else(
+        || {
+            (value % MODULUS).to_i64().unwrap_or_else(||
+            // guaranteed to be safe by mod
+            unsafe { std::hint::unreachable_unchecked() })
+        },
+        mod_int,
+    )
+}
+
+pub fn hash_str(value: &str) -> PyHash {
+    hash_value(value)
 }

--- a/vm/src/obj/objint.rs
+++ b/vm/src/obj/objint.rs
@@ -419,7 +419,7 @@ impl PyInt {
     }
 
     #[pymethod(name = "__hash__")]
-    pub fn hash(&self) -> hash::PyHash {
+    fn hash(&self) -> hash::PyHash {
         hash::hash_bigint(&self.value)
     }
 

--- a/vm/src/obj/objstr.rs
+++ b/vm/src/obj/objstr.rs
@@ -283,7 +283,7 @@ impl PyString {
     #[pymethod(name = "__hash__")]
     pub(crate) fn hash(&self) -> hash::PyHash {
         self.hash.load().unwrap_or_else(|| {
-            let hash = hash::hash_value(&self.value);
+            let hash = hash::hash_str(&self.value);
             self.hash.store(Some(hash));
             hash
         })

--- a/vm/src/vm.rs
+++ b/vm/src/vm.rs
@@ -1407,11 +1407,11 @@ impl VirtualMachine {
     }
 
     pub fn _hash(&self, obj: &PyObjectRef) -> PyResult<rustpython_common::hash::PyHash> {
+        // TODO: tp_hash
         let hash_obj = self.call_method(obj, "__hash__", vec![])?;
-        if let Some(hash_value) = hash_obj.payload_if_subclass::<PyInt>(self) {
-            Ok(hash_value.hash())
-        } else {
-            Err(self.new_type_error("__hash__ method should return an integer".to_owned()))
+        match hash_obj.payload_if_subclass::<PyInt>(self) {
+            Some(py_int) => Ok(rustpython_common::hash::hash_bigint(py_int.as_bigint())),
+            None => Err(self.new_type_error("__hash__ method should return an integer".to_owned())),
         }
     }
 


### PR DESCRIPTION
Creating a new PR from #2035 due to crash.

Do anyone know why changing str hash function causes crash?