### PR TITLE
Allow None parameter for remove, index, count method of array

### DIFF
--- a/Lib/test/test_array.py
+++ b/Lib/test/test_array.py
@@ -918,8 +918,6 @@ class BaseTest:
                     del a[start:stop:step]
                     self.assertEqual(a, array.array(self.typecode, L))
 
-    # TODO: RUSTPYTHON
-    @unittest.expectedFailure
     def test_index(self):
         example = 2*self.example
         a = array.array(self.typecode, example)
@@ -929,8 +927,6 @@ class BaseTest:
         self.assertRaises(ValueError, a.index, None)
         self.assertRaises(ValueError, a.index, self.outside)
 
-    # TODO: RUSTPYTHON
-    @unittest.expectedFailure
     def test_count(self):
         example = 2*self.example
         a = array.array(self.typecode, example)
@@ -940,8 +936,6 @@ class BaseTest:
         self.assertEqual(a.count(self.outside), 0)
         self.assertEqual(a.count(None), 0)
 
-    # TODO: RUSTPYTHON
-    @unittest.expectedFailure
     def test_remove(self):
         for x in self.example:
             example = 2*self.example


### PR DESCRIPTION
I changed return type to `Option` because when a parameter is None, `$t::try_from_object(vm, obj)` cause `TypeError` unlike CPython. But I'm not sure the way to compare value is good way.


### Before
```
======================================================================
ERROR: test_remove (__main__.UnsignedShortTest)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "Lib/test/test_array.py", line 955, in test_remove
    self.assertRaises(ValueError, a.remove, None)
  File "/home/clemado1/workspace/RustPython/Lib/unittest/case.py", line 746, in assertRaises
    context = None
  File "/home/clemado1/workspace/RustPython/Lib/unittest/case.py", line 743, in assertRaises
    return context.handle('assertRaises', args, kwargs)
  File "/home/clemado1/workspace/RustPython/Lib/unittest/case.py", line 743, in assertRaises
    return context.handle('assertRaises', args, kwargs)
  File "/home/clemado1/workspace/RustPython/Lib/unittest/case.py", line 181, in handle
    self = None
  File "/home/clemado1/workspace/RustPython/Lib/unittest/case.py", line 178, in handle
    callable_obj(*args, **kwargs)
  File "/home/clemado1/workspace/RustPython/Lib/unittest/case.py", line 178, in handle
    callable_obj(*args, **kwargs)
TypeError: Expected type <class 'int'>, not <class 'NoneType'>
```