### PR TITLE
Implement msvcrt.SetErrorMode

### DIFF
--- a/vm/src/stdlib/msvcrt.rs
+++ b/vm/src/stdlib/msvcrt.rs
@@ -4,9 +4,9 @@ use crate::obj::objstr::PyStringRef;
 use crate::pyobject::{PyObjectRef, PyResult};
 use crate::VirtualMachine;
 
+use itertools::Itertools;
 use winapi::shared::minwindef::UINT;
 use winapi::um::errhandlingapi::SetErrorMode;
-use itertools::Itertools;
 
 extern "C" {
     fn _getch() -> i32;

--- a/vm/src/stdlib/msvcrt.rs
+++ b/vm/src/stdlib/msvcrt.rs
@@ -6,7 +6,6 @@ use crate::VirtualMachine;
 
 use winapi::shared::minwindef::UINT;
 use winapi::um::errhandlingapi::SetErrorMode;
-
 use itertools::Itertools;
 
 extern "C" {


### PR DESCRIPTION
This allows to start running CPython test suites on Windows, although some cases are still failing.