### PR TITLE
Add support for indexing and attribute access inside format strings

### DIFF
--- a/Lib/test/test_string.py
+++ b/Lib/test/test_string.py
@@ -1,0 +1,480 @@
+import unittest
+import string
+from string import Template
+
+
+class ModuleTest(unittest.TestCase):
+
+    def test_attrs(self):
+        # While the exact order of the items in these attributes is not
+        # technically part of the "language spec", in practice there is almost
+        # certainly user code that depends on the order, so de-facto it *is*
+        # part of the spec.
+        self.assertEqual(string.whitespace, ' \t\n\r\x0b\x0c')
+        self.assertEqual(string.ascii_lowercase, 'abcdefghijklmnopqrstuvwxyz')
+        self.assertEqual(string.ascii_uppercase, 'ABCDEFGHIJKLMNOPQRSTUVWXYZ')
+        self.assertEqual(string.ascii_letters, string.ascii_lowercase + string.ascii_uppercase)
+        self.assertEqual(string.digits, '0123456789')
+        self.assertEqual(string.hexdigits, string.digits + 'abcdefABCDEF')
+        self.assertEqual(string.octdigits, '01234567')
+        self.assertEqual(string.punctuation, '!"#$%&\'()*+,-./:;<=>?@[\\]^_`{|}~')
+        self.assertEqual(string.printable, string.digits + string.ascii_lowercase + string.ascii_uppercase + string.punctuation + string.whitespace)
+
+    def test_capwords(self):
+        self.assertEqual(string.capwords('abc def ghi'), 'Abc Def Ghi')
+        self.assertEqual(string.capwords('abc\tdef\nghi'), 'Abc Def Ghi')
+        self.assertEqual(string.capwords('abc\t   def  \nghi'), 'Abc Def Ghi')
+        self.assertEqual(string.capwords('ABC DEF GHI'), 'Abc Def Ghi')
+        self.assertEqual(string.capwords('ABC-DEF-GHI', '-'), 'Abc-Def-Ghi')
+        self.assertEqual(string.capwords('ABC-def DEF-ghi GHI'), 'Abc-def Def-ghi Ghi')
+        self.assertEqual(string.capwords('   aBc  DeF   '), 'Abc Def')
+        self.assertEqual(string.capwords('\taBc\tDeF\t'), 'Abc Def')
+        self.assertEqual(string.capwords('\taBc\tDeF\t', '\t'), '\tAbc\tDef\t')
+
+    def test_basic_formatter(self):
+        fmt = string.Formatter()
+        self.assertEqual(fmt.format("foo"), "foo")
+        self.assertEqual(fmt.format("foo{0}", "bar"), "foobar")
+        self.assertEqual(fmt.format("foo{1}{0}-{1}", "bar", 6), "foo6bar-6")
+        self.assertRaises(TypeError, fmt.format)
+        self.assertRaises(TypeError, string.Formatter.format)
+
+    def test_format_keyword_arguments(self):
+        fmt = string.Formatter()
+        self.assertEqual(fmt.format("-{arg}-", arg='test'), '-test-')
+        self.assertRaises(KeyError, fmt.format, "-{arg}-")
+        self.assertEqual(fmt.format("-{self}-", self='test'), '-test-')
+        self.assertRaises(KeyError, fmt.format, "-{self}-")
+        self.assertEqual(fmt.format("-{format_string}-", format_string='test'),
+                         '-test-')
+        self.assertRaises(KeyError, fmt.format, "-{format_string}-")
+        with self.assertRaisesRegex(TypeError, "format_string"):
+            fmt.format(format_string="-{arg}-", arg='test')
+
+    def test_auto_numbering(self):
+        fmt = string.Formatter()
+        self.assertEqual(fmt.format('foo{}{}', 'bar', 6),
+                         'foo{}{}'.format('bar', 6))
+        self.assertEqual(fmt.format('foo{1}{num}{1}', None, 'bar', num=6),
+                         'foo{1}{num}{1}'.format(None, 'bar', num=6))
+        self.assertEqual(fmt.format('{:^{}}', 'bar', 6),
+                         '{:^{}}'.format('bar', 6))
+        self.assertEqual(fmt.format('{:^{}} {}', 'bar', 6, 'X'),
+                         '{:^{}} {}'.format('bar', 6, 'X'))
+        self.assertEqual(fmt.format('{:^{pad}}{}', 'foo', 'bar', pad=6),
+                         '{:^{pad}}{}'.format('foo', 'bar', pad=6))
+
+        with self.assertRaises(ValueError):
+            fmt.format('foo{1}{}', 'bar', 6)
+
+        with self.assertRaises(ValueError):
+            fmt.format('foo{}{1}', 'bar', 6)
+
+    def test_conversion_specifiers(self):
+        fmt = string.Formatter()
+        self.assertEqual(fmt.format("-{arg!r}-", arg='test'), "-'test'-")
+        self.assertEqual(fmt.format("{0!s}", 'test'), 'test')
+        self.assertRaises(ValueError, fmt.format, "{0!h}", 'test')
+        # issue13579
+        self.assertEqual(fmt.format("{0!a}", 42), '42')
+        self.assertEqual(fmt.format("{0!a}",  string.ascii_letters),
+            "'abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ'")
+        self.assertEqual(fmt.format("{0!a}",  chr(255)), "'\\xff'")
+        self.assertEqual(fmt.format("{0!a}",  chr(256)), "'\\u0100'")
+
+    def test_name_lookup(self):
+        fmt = string.Formatter()
+        class AnyAttr:
+            def __getattr__(self, attr):
+                return attr
+        x = AnyAttr()
+        self.assertEqual(fmt.format("{0.lumber}{0.jack}", x), 'lumberjack')
+        with self.assertRaises(AttributeError):
+            fmt.format("{0.lumber}{0.jack}", '')
+
+    def test_index_lookup(self):
+        fmt = string.Formatter()
+        lookup = ["eggs", "and", "spam"]
+        self.assertEqual(fmt.format("{0[2]}{0[0]}", lookup), 'spameggs')
+        with self.assertRaises(IndexError):
+            fmt.format("{0[2]}{0[0]}", [])
+        with self.assertRaises(KeyError):
+            fmt.format("{0[2]}{0[0]}", {})
+
+    def test_override_get_value(self):
+        class NamespaceFormatter(string.Formatter):
+            def __init__(self, namespace={}):
+                string.Formatter.__init__(self)
+                self.namespace = namespace
+
+            def get_value(self, key, args, kwds):
+                if isinstance(key, str):
+                    try:
+                        # Check explicitly passed arguments first
+                        return kwds[key]
+                    except KeyError:
+                        return self.namespace[key]
+                else:
+                    string.Formatter.get_value(key, args, kwds)
+
+        fmt = NamespaceFormatter({'greeting':'hello'})
+        self.assertEqual(fmt.format("{greeting}, world!"), 'hello, world!')
+
+
+    def test_override_format_field(self):
+        class CallFormatter(string.Formatter):
+            def format_field(self, value, format_spec):
+                return format(value(), format_spec)
+
+        fmt = CallFormatter()
+        self.assertEqual(fmt.format('*{0}*', lambda : 'result'), '*result*')
+
+
+    def test_override_convert_field(self):
+        class XFormatter(string.Formatter):
+            def convert_field(self, value, conversion):
+                if conversion == 'x':
+                    return None
+                return super().convert_field(value, conversion)
+
+        fmt = XFormatter()
+        self.assertEqual(fmt.format("{0!r}:{0!x}", 'foo', 'foo'), "'foo':None")
+
+
+    def test_override_parse(self):
+        class BarFormatter(string.Formatter):
+            # returns an iterable that contains tuples of the form:
+            # (literal_text, field_name, format_spec, conversion)
+            def parse(self, format_string):
+                for field in format_string.split('|'):
+                    if field[0] == '+':
+                        # it's markup
+                        field_name, _, format_spec = field[1:].partition(':')
+                        yield '', field_name, format_spec, None
+                    else:
+                        yield field, None, None, None
+
+        fmt = BarFormatter()
+        self.assertEqual(fmt.format('*|+0:^10s|*', 'foo'), '*   foo    *')
+
+    def test_check_unused_args(self):
+        class CheckAllUsedFormatter(string.Formatter):
+            def check_unused_args(self, used_args, args, kwargs):
+                # Track which arguments actually got used
+                unused_args = set(kwargs.keys())
+                unused_args.update(range(0, len(args)))
+
+                for arg in used_args:
+                    unused_args.remove(arg)
+
+                if unused_args:
+                    raise ValueError("unused arguments")
+
+        fmt = CheckAllUsedFormatter()
+        self.assertEqual(fmt.format("{0}", 10), "10")
+        self.assertEqual(fmt.format("{0}{i}", 10, i=100), "10100")
+        self.assertEqual(fmt.format("{0}{i}{1}", 10, 20, i=100), "1010020")
+        self.assertRaises(ValueError, fmt.format, "{0}{i}{1}", 10, 20, i=100, j=0)
+        self.assertRaises(ValueError, fmt.format, "{0}", 10, 20)
+        self.assertRaises(ValueError, fmt.format, "{0}", 10, 20, i=100)
+        self.assertRaises(ValueError, fmt.format, "{i}", 10, 20, i=100)
+
+    def test_vformat_recursion_limit(self):
+        fmt = string.Formatter()
+        args = ()
+        kwargs = dict(i=100)
+        with self.assertRaises(ValueError) as err:
+            fmt._vformat("{i}", args, kwargs, set(), -1)
+        self.assertIn("recursion", str(err.exception))
+
+
+# Template tests (formerly housed in test_pep292.py)
+
+class Bag:
+    pass
+
+class Mapping:
+    def __getitem__(self, name):
+        obj = self
+        for part in name.split('.'):
+            try:
+                obj = getattr(obj, part)
+            except AttributeError:
+                raise KeyError(name)
+        return obj
+
+
+class TestTemplate(unittest.TestCase):
+    def test_regular_templates(self):
+        s = Template('$who likes to eat a bag of $what worth $$100')
+        self.assertEqual(s.substitute(dict(who='tim', what='ham')),
+                         'tim likes to eat a bag of ham worth $100')
+        self.assertRaises(KeyError, s.substitute, dict(who='tim'))
+        self.assertRaises(TypeError, Template.substitute)
+
+    def test_regular_templates_with_braces(self):
+        s = Template('$who likes ${what} for ${meal}')
+        d = dict(who='tim', what='ham', meal='dinner')
+        self.assertEqual(s.substitute(d), 'tim likes ham for dinner')
+        self.assertRaises(KeyError, s.substitute,
+                          dict(who='tim', what='ham'))
+
+    def test_regular_templates_with_upper_case(self):
+        s = Template('$WHO likes ${WHAT} for ${MEAL}')
+        d = dict(WHO='tim', WHAT='ham', MEAL='dinner')
+        self.assertEqual(s.substitute(d), 'tim likes ham for dinner')
+
+    def test_regular_templates_with_non_letters(self):
+        s = Template('$_wh0_ likes ${_w_h_a_t_} for ${mea1}')
+        d = dict(_wh0_='tim', _w_h_a_t_='ham', mea1='dinner')
+        self.assertEqual(s.substitute(d), 'tim likes ham for dinner')
+
+    def test_escapes(self):
+        eq = self.assertEqual
+        s = Template('$who likes to eat a bag of $$what worth $$100')
+        eq(s.substitute(dict(who='tim', what='ham')),
+           'tim likes to eat a bag of $what worth $100')
+        s = Template('$who likes $$')
+        eq(s.substitute(dict(who='tim', what='ham')), 'tim likes $')
+
+    def test_percents(self):
+        eq = self.assertEqual
+        s = Template('%(foo)s $foo ${foo}')
+        d = dict(foo='baz')
+        eq(s.substitute(d), '%(foo)s baz baz')
+        eq(s.safe_substitute(d), '%(foo)s baz baz')
+
+    def test_stringification(self):
+        eq = self.assertEqual
+        s = Template('tim has eaten $count bags of ham today')
+        d = dict(count=7)
+        eq(s.substitute(d), 'tim has eaten 7 bags of ham today')
+        eq(s.safe_substitute(d), 'tim has eaten 7 bags of ham today')
+        s = Template('tim has eaten ${count} bags of ham today')
+        eq(s.substitute(d), 'tim has eaten 7 bags of ham today')
+
+    def test_tupleargs(self):
+        eq = self.assertEqual
+        s = Template('$who ate ${meal}')
+        d = dict(who=('tim', 'fred'), meal=('ham', 'kung pao'))
+        eq(s.substitute(d), "('tim', 'fred') ate ('ham', 'kung pao')")
+        eq(s.safe_substitute(d), "('tim', 'fred') ate ('ham', 'kung pao')")
+
+    def test_SafeTemplate(self):
+        eq = self.assertEqual
+        s = Template('$who likes ${what} for ${meal}')
+        eq(s.safe_substitute(dict(who='tim')), 'tim likes ${what} for ${meal}')
+        eq(s.safe_substitute(dict(what='ham')), '$who likes ham for ${meal}')
+        eq(s.safe_substitute(dict(what='ham', meal='dinner')),
+           '$who likes ham for dinner')
+        eq(s.safe_substitute(dict(who='tim', what='ham')),
+           'tim likes ham for ${meal}')
+        eq(s.safe_substitute(dict(who='tim', what='ham', meal='dinner')),
+           'tim likes ham for dinner')
+
+    def test_invalid_placeholders(self):
+        raises = self.assertRaises
+        s = Template('$who likes $')
+        raises(ValueError, s.substitute, dict(who='tim'))
+        s = Template('$who likes ${what)')
+        raises(ValueError, s.substitute, dict(who='tim'))
+        s = Template('$who likes $100')
+        raises(ValueError, s.substitute, dict(who='tim'))
+        # Template.idpattern should match to only ASCII characters.
+        # https://bugs.python.org/issue31672
+        s = Template("$who likes $\u0131")  # (DOTLESS I)
+        raises(ValueError, s.substitute, dict(who='tim'))
+        s = Template("$who likes $\u0130")  # (LATIN CAPITAL LETTER I WITH DOT ABOVE)
+        raises(ValueError, s.substitute, dict(who='tim'))
+
+    def test_idpattern_override(self):
+        class PathPattern(Template):
+            idpattern = r'[_a-z][._a-z0-9]*'
+        m = Mapping()
+        m.bag = Bag()
+        m.bag.foo = Bag()
+        m.bag.foo.who = 'tim'
+        m.bag.what = 'ham'
+        s = PathPattern('$bag.foo.who likes to eat a bag of $bag.what')
+        self.assertEqual(s.substitute(m), 'tim likes to eat a bag of ham')
+
+    def test_flags_override(self):
+        class MyPattern(Template):
+            flags = 0
+        s = MyPattern('$wHO likes ${WHAT} for ${meal}')
+        d = dict(wHO='tim', WHAT='ham', meal='dinner', w='fred')
+        self.assertRaises(ValueError, s.substitute, d)
+        self.assertEqual(s.safe_substitute(d), 'fredHO likes ${WHAT} for dinner')
+
+    def test_idpattern_override_inside_outside(self):
+        # bpo-1198569: Allow the regexp inside and outside braces to be
+        # different when deriving from Template.
+        class MyPattern(Template):
+            idpattern = r'[a-z]+'
+            braceidpattern = r'[A-Z]+'
+            flags = 0
+        m = dict(foo='foo', BAR='BAR')
+        s = MyPattern('$foo ${BAR}')
+        self.assertEqual(s.substitute(m), 'foo BAR')
+
+    def test_idpattern_override_inside_outside_invalid_unbraced(self):
+        # bpo-1198569: Allow the regexp inside and outside braces to be
+        # different when deriving from Template.
+        class MyPattern(Template):
+            idpattern = r'[a-z]+'
+            braceidpattern = r'[A-Z]+'
+            flags = 0
+        m = dict(foo='foo', BAR='BAR')
+        s = MyPattern('$FOO')
+        self.assertRaises(ValueError, s.substitute, m)
+        s = MyPattern('${bar}')
+        self.assertRaises(ValueError, s.substitute, m)
+
+    def test_pattern_override(self):
+        class MyPattern(Template):
+            pattern = r"""
+            (?P<escaped>@{2})                   |
+            @(?P<named>[_a-z][._a-z0-9]*)       |
+            @{(?P<braced>[_a-z][._a-z0-9]*)}    |
+            (?P<invalid>@)
+            """
+        m = Mapping()
+        m.bag = Bag()
+        m.bag.foo = Bag()
+        m.bag.foo.who = 'tim'
+        m.bag.what = 'ham'
+        s = MyPattern('@bag.foo.who likes to eat a bag of @bag.what')
+        self.assertEqual(s.substitute(m), 'tim likes to eat a bag of ham')
+
+        class BadPattern(Template):
+            pattern = r"""
+            (?P<badname>.*)                     |
+            (?P<escaped>@{2})                   |
+            @(?P<named>[_a-z][._a-z0-9]*)       |
+            @{(?P<braced>[_a-z][._a-z0-9]*)}    |
+            (?P<invalid>@)                      |
+            """
+        s = BadPattern('@bag.foo.who likes to eat a bag of @bag.what')
+        self.assertRaises(ValueError, s.substitute, {})
+        self.assertRaises(ValueError, s.safe_substitute, {})
+
+    def test_braced_override(self):
+        class MyTemplate(Template):
+            pattern = r"""
+            \$(?:
+              (?P<escaped>$)                     |
+              (?P<named>[_a-z][_a-z0-9]*)        |
+              @@(?P<braced>[_a-z][_a-z0-9]*)@@   |
+              (?P<invalid>)                      |
+           )
+           """
+
+        tmpl = 'PyCon in $@@location@@'
+        t = MyTemplate(tmpl)
+        self.assertRaises(KeyError, t.substitute, {})
+        val = t.substitute({'location': 'Cleveland'})
+        self.assertEqual(val, 'PyCon in Cleveland')
+
+    def test_braced_override_safe(self):
+        class MyTemplate(Template):
+            pattern = r"""
+            \$(?:
+              (?P<escaped>$)                     |
+              (?P<named>[_a-z][_a-z0-9]*)        |
+              @@(?P<braced>[_a-z][_a-z0-9]*)@@   |
+              (?P<invalid>)                      |
+           )
+           """
+
+        tmpl = 'PyCon in $@@location@@'
+        t = MyTemplate(tmpl)
+        self.assertEqual(t.safe_substitute(), tmpl)
+        val = t.safe_substitute({'location': 'Cleveland'})
+        self.assertEqual(val, 'PyCon in Cleveland')
+
+    def test_invalid_with_no_lines(self):
+        # The error formatting for invalid templates
+        # has a special case for no data that the default
+        # pattern can't trigger (always has at least '$')
+        # So we craft a pattern that is always invalid
+        # with no leading data.
+        class MyTemplate(Template):
+            pattern = r"""
+              (?P<invalid>) |
+              unreachable(
+                (?P<named>)   |
+                (?P<braced>)  |
+                (?P<escaped>)
+              )
+            """
+        s = MyTemplate('')
+        with self.assertRaises(ValueError) as err:
+            s.substitute({})
+        self.assertIn('line 1, col 1', str(err.exception))
+
+    def test_unicode_values(self):
+        s = Template('$who likes $what')
+        d = dict(who='t\xffm', what='f\xfe\fed')
+        self.assertEqual(s.substitute(d), 't\xffm likes f\xfe\x0ced')
+
+    def test_keyword_arguments(self):
+        eq = self.assertEqual
+        s = Template('$who likes $what')
+        eq(s.substitute(who='tim', what='ham'), 'tim likes ham')
+        eq(s.substitute(dict(who='tim'), what='ham'), 'tim likes ham')
+        eq(s.substitute(dict(who='fred', what='kung pao'),
+                        who='tim', what='ham'),
+           'tim likes ham')
+        s = Template('the mapping is $mapping')
+        eq(s.substitute(dict(foo='none'), mapping='bozo'),
+           'the mapping is bozo')
+        eq(s.substitute(dict(mapping='one'), mapping='two'),
+           'the mapping is two')
+
+        s = Template('the self is $self')
+        eq(s.substitute(self='bozo'), 'the self is bozo')
+
+    def test_keyword_arguments_safe(self):
+        eq = self.assertEqual
+        raises = self.assertRaises
+        s = Template('$who likes $what')
+        eq(s.safe_substitute(who='tim', what='ham'), 'tim likes ham')
+        eq(s.safe_substitute(dict(who='tim'), what='ham'), 'tim likes ham')
+        eq(s.safe_substitute(dict(who='fred', what='kung pao'),
+                        who='tim', what='ham'),
+           'tim likes ham')
+        s = Template('the mapping is $mapping')
+        eq(s.safe_substitute(dict(foo='none'), mapping='bozo'),
+           'the mapping is bozo')
+        eq(s.safe_substitute(dict(mapping='one'), mapping='two'),
+           'the mapping is two')
+        d = dict(mapping='one')
+        raises(TypeError, s.substitute, d, {})
+        raises(TypeError, s.safe_substitute, d, {})
+
+        s = Template('the self is $self')
+        eq(s.safe_substitute(self='bozo'), 'the self is bozo')
+
+    def test_delimiter_override(self):
+        eq = self.assertEqual
+        raises = self.assertRaises
+        class AmpersandTemplate(Template):
+            delimiter = '&'
+        s = AmpersandTemplate('this &gift is for &{who} &&')
+        eq(s.substitute(gift='bud', who='you'), 'this bud is for you &')
+        raises(KeyError, s.substitute)
+        eq(s.safe_substitute(gift='bud', who='you'), 'this bud is for you &')
+        eq(s.safe_substitute(), 'this &gift is for &{who} &')
+        s = AmpersandTemplate('this &gift is for &{who} &')
+        raises(ValueError, s.substitute, dict(gift='bud', who='you'))
+        eq(s.safe_substitute(), 'this &gift is for &{who} &')
+
+        class PieDelims(Template):
+            delimiter = '@'
+        s = PieDelims('@who likes to eat a bag of @{what} worth $100')
+        self.assertEqual(s.substitute(dict(who='tim', what='ham')),
+                         'tim likes to eat a bag of ham worth $100')
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/Lib/test/test_string.py
+++ b/Lib/test/test_string.py
@@ -272,6 +272,8 @@ class TestTemplate(unittest.TestCase):
         eq(s.safe_substitute(dict(who='tim', what='ham', meal='dinner')),
            'tim likes ham for dinner')
 
+    # TODO: RUSTPYTHON
+    @unittest.expectedFailure
     def test_invalid_placeholders(self):
         raises = self.assertRaises
         s = Template('$who likes $')
@@ -298,6 +300,8 @@ class TestTemplate(unittest.TestCase):
         s = PathPattern('$bag.foo.who likes to eat a bag of $bag.what')
         self.assertEqual(s.substitute(m), 'tim likes to eat a bag of ham')
 
+    # TODO: RUSTPYTHON
+    @unittest.expectedFailure
     def test_flags_override(self):
         class MyPattern(Template):
             flags = 0
@@ -317,6 +321,8 @@ class TestTemplate(unittest.TestCase):
         s = MyPattern('$foo ${BAR}')
         self.assertEqual(s.substitute(m), 'foo BAR')
 
+    # TODO: RUSTPYTHON
+    @unittest.expectedFailure
     def test_idpattern_override_inside_outside_invalid_unbraced(self):
         # bpo-1198569: Allow the regexp inside and outside braces to be
         # different when deriving from Template.
@@ -455,6 +461,8 @@ class TestTemplate(unittest.TestCase):
         s = Template('the self is $self')
         eq(s.safe_substitute(self='bozo'), 'the self is bozo')
 
+    # TODO: RUSTPYTHON
+    @unittest.expectedFailure
     def test_delimiter_override(self):
         eq = self.assertEqual
         raises = self.assertRaises

--- a/Lib/test/test_unicode.py
+++ b/Lib/test/test_unicode.py
@@ -1273,8 +1273,6 @@ class UnicodeTest(string_tests.CommonTest,
         self.assertEqual("{!s}".format(n), 'N(data)')
         self.assertRaises(TypeError, "{}".format, n)
 
-    # TODO: RUSTPYTHON
-    @unittest.expectedFailure
     def test_format_map(self):
         self.assertEqual(''.format_map({}), '')
         self.assertEqual('a'.format_map({}), 'a')
@@ -2958,8 +2956,6 @@ class CAPITest(unittest.TestCase):
                 self.assertEqual(getargs_s_hash(s), chr(k).encode() * (i + 1))
 
 class StringModuleTest(unittest.TestCase):
-    # TODO: RUSTPYTHON
-    @unittest.expectedFailure
     def test_formatter_parser(self):
         def parse(format):
             return list(_string.formatter_parser(format))
@@ -2993,8 +2989,6 @@ class StringModuleTest(unittest.TestCase):
 
         self.assertRaises(TypeError, _string.formatter_parser, 1)
 
-    # TODO: RUSTPYTHON
-    @unittest.expectedFailure
     def test_formatter_field_name_split(self):
         def split(name):
             items = list(_string.formatter_field_name_split(name))

--- a/vm/src/format.rs
+++ b/vm/src/format.rs
@@ -856,7 +856,7 @@ impl FormatString {
                 auto_argument_index += 1;
                 arguments
                     .args
-                    .get(auto_argument_index)
+                    .get(auto_argument_index - 1)
                     .cloned()
                     .ok_or_else(|| vm.new_index_error("tuple index out of range".to_owned()))
             }

--- a/vm/src/format.rs
+++ b/vm/src/format.rs
@@ -1082,10 +1082,7 @@ mod tests {
             ],
         });
 
-        assert_eq!(
-            FormatString::from_str("abcd{1}:{key}"),
-            expected
-        );
+        assert_eq!(FormatString::from_str("abcd{1}:{key}"), expected);
     }
 
     #[test]
@@ -1110,10 +1107,7 @@ mod tests {
             ],
         });
 
-        assert_eq!(
-            FormatString::from_str("{{{key}}}ddfe"),
-            expected
-        );
+        assert_eq!(FormatString::from_str("{{{key}}}ddfe"), expected);
     }
 
     #[test]

--- a/vm/src/format.rs
+++ b/vm/src/format.rs
@@ -1083,7 +1083,7 @@ mod tests {
         });
 
         assert_eq!(
-            FormatString::from_str("abcd{1}:{key}", &PyFuncArgs::default()),
+            FormatString::from_str("abcd{1}:{key}"),
             expected
         );
     }
@@ -1091,7 +1091,7 @@ mod tests {
     #[test]
     fn test_format_parse_fail() {
         assert_eq!(
-            FormatString::from_str("{s", &PyFuncArgs::default()),
+            FormatString::from_str("{s"),
             Err(FormatParseError::UnmatchedBracket)
         );
     }
@@ -1111,7 +1111,7 @@ mod tests {
         });
 
         assert_eq!(
-            FormatString::from_str("{{{key}}}ddfe", &PyFuncArgs::default()),
+            FormatString::from_str("{{{key}}}ddfe"),
             expected
         );
     }

--- a/vm/src/format.rs
+++ b/vm/src/format.rs
@@ -685,7 +685,7 @@ impl FormatString {
         if first_char == '{' || first_char == '}' {
             let maybe_next_char = chars.next();
             // if we see a bracket, it has to be escaped by doubling up to be in a literal
-            if maybe_next_char.is_some() && maybe_next_char.unwrap() != first_char {
+            if maybe_next_char.is_none() || maybe_next_char.unwrap() != first_char {
                 return Err(FormatParseError::UnescapedStartBracketInLiteral);
             } else {
                 return Ok((first_char, chars.as_str()));

--- a/vm/src/obj/objlist.rs
+++ b/vm/src/obj/objlist.rs
@@ -1,4 +1,5 @@
 use std::fmt;
+use std::iter::FromIterator;
 use std::mem::size_of;
 use std::ops::{DerefMut, Range};
 
@@ -44,6 +45,12 @@ impl From<Vec<PyObjectRef>> for PyList {
         PyList {
             elements: PyRwLock::new(elements),
         }
+    }
+}
+
+impl FromIterator<PyObjectRef> for PyList {
+    fn from_iter<T: IntoIterator<Item = PyObjectRef>>(iter: T) -> Self {
+        Vec::from_iter(iter).into()
     }
 }
 

--- a/vm/src/stdlib/string.rs
+++ b/vm/src/stdlib/string.rs
@@ -76,9 +76,9 @@ mod _string {
         let field_name = FieldName::parse(text.as_str()).map_err(|e| e.into_pyobject(vm))?;
 
         let first = match field_name.field_type {
-            FieldType::AutoSpec => vm.new_str("".to_owned()),
-            FieldType::IndexSpec(index) => index.into_pyobject(vm)?,
-            FieldType::KeywordSpec(attribute) => attribute.into_pyobject(vm)?,
+            FieldType::Auto => vm.new_str("".to_owned()),
+            FieldType::Index(index) => index.into_pyobject(vm)?,
+            FieldType::Keyword(attribute) => attribute.into_pyobject(vm)?,
         };
 
         let rest = field_name

--- a/vm/src/stdlib/string.rs
+++ b/vm/src/stdlib/string.rs
@@ -1,12 +1,96 @@
 /* String builtin module
  */
 
-use crate::pyobject::PyObjectRef;
-use crate::vm::VirtualMachine;
+pub(crate) use _string::make_module;
 
-pub fn make_module(vm: &VirtualMachine) -> PyObjectRef {
-    // let ctx = &vm.ctx;
+#[pymodule]
+mod _string {
+    use std::mem;
 
-    // Constants:
-    py_module!(vm, "_string", {})
+    use crate::format::{
+        FieldName, FieldNamePart, FieldType, FormatPart, FormatString, FromTemplate,
+    };
+    use crate::obj::objlist::PyList;
+    use crate::obj::objstr::PyStringRef;
+    use crate::pyobject::{IntoPyObject, PyObjectRef, PyResult};
+    use crate::vm::VirtualMachine;
+
+    fn create_format_part(
+        literal: String,
+        field_name: Option<String>,
+        format_spec: Option<String>,
+        preconversion_spec: Option<char>,
+        vm: &VirtualMachine,
+    ) -> PyResult {
+        let tuple = (
+            literal,
+            field_name,
+            format_spec,
+            preconversion_spec.map(|c| c.to_string()),
+        );
+        tuple.into_pyobject(vm)
+    }
+
+    #[pyfunction]
+    fn formatter_parser(text: PyStringRef, vm: &VirtualMachine) -> PyResult<PyList> {
+        let format_string =
+            FormatString::from_str(text.as_str()).map_err(|e| e.into_pyobject(vm))?;
+
+        let mut result = Vec::new();
+        let mut literal = String::new();
+        for part in format_string.format_parts {
+            match part {
+                FormatPart::Field {
+                    field_name,
+                    preconversion_spec,
+                    format_spec,
+                } => {
+                    result.push(create_format_part(
+                        mem::take(&mut literal),
+                        Some(field_name),
+                        Some(format_spec),
+                        preconversion_spec,
+                        vm,
+                    )?);
+                }
+                FormatPart::Literal(text) => literal.push_str(&text),
+            }
+        }
+        if !literal.is_empty() {
+            result.push(create_format_part(
+                mem::take(&mut literal),
+                None,
+                None,
+                None,
+                vm,
+            )?);
+        }
+        Ok(result.into())
+    }
+
+    #[pyfunction]
+    fn formatter_field_name_split(
+        text: PyStringRef,
+        vm: &VirtualMachine,
+    ) -> PyResult<(PyObjectRef, PyList)> {
+        let field_name = FieldName::parse(text.as_str()).map_err(|e| e.into_pyobject(vm))?;
+
+        let first = match field_name.field_type {
+            FieldType::AutoSpec => vm.new_str("".to_owned()),
+            FieldType::IndexSpec(index) => index.into_pyobject(vm)?,
+            FieldType::KeywordSpec(attribute) => attribute.into_pyobject(vm)?,
+        };
+
+        let rest = field_name
+            .parts
+            .iter()
+            .map(|p| match p {
+                FieldNamePart::Attribute(attribute) => (true, attribute).into_pyobject(vm).unwrap(),
+                FieldNamePart::StringIndex(index) => (false, index).into_pyobject(vm).unwrap(),
+                FieldNamePart::Index(index) => (false, *index).into_pyobject(vm).unwrap(),
+            })
+            .collect();
+
+        Ok((first, rest))
+    }
 }


### PR DESCRIPTION
- Adds support for: `"{a.attr}".format(...)` and `"{l[0]}".format(...)`
- Also, adds the couple of underlying functions behind `string.Formatter`

For #1983