### PR TITLE
Change dis.dis to take strings to decompile

### DIFF
--- a/Lib/test/test_dis.py
+++ b/Lib/test/test_dis.py
@@ -1,0 +1,30 @@
+import unittest
+import dis
+from test.support import captured_stdout
+
+
+# This only tests that it prints something in order
+# to avoid changing this test if the bytecode changes
+class TestDis(unittest.TestCase):
+    def test_dis(self):
+        test_cases = (self.test_dis, "x = 2; print(x)")
+
+        for case in test_cases:
+            with self.subTest(case=case):
+                with captured_stdout() as stdout:
+                    dis.dis(case)
+                self.assertNotEqual("", stdout.getvalue())
+
+    def test_disassemble(self):
+        # In CPython this would raise an AttributeError, not a
+        # TypeError because dis is implemented in python in CPython and
+        # as such the type mismatch wouldn't be caught immeadiately
+        with self.assertRaises(TypeError):
+            dis.disassemble(self.test_disassemble)
+        with captured_stdout() as stdout:
+            dis.dis(self.test_disassemble.__code__)
+        self.assertNotEqual("", stdout.getvalue())
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/Lib/test/test_dis.py
+++ b/Lib/test/test_dis.py
@@ -1,29 +1,59 @@
+import subprocess
+import sys
 import unittest
-import dis
-from test.support import captured_stdout
-
 
 # This only tests that it prints something in order
 # to avoid changing this test if the bytecode changes
-class TestDis(unittest.TestCase):
-    def test_dis(self):
-        test_cases = (self.test_dis, "x = 2; print(x)")
 
-        for case in test_cases:
-            with self.subTest(case=case):
-                with captured_stdout() as stdout:
-                    dis.dis(case)
-                self.assertNotEqual("", stdout.getvalue())
+# These tests start a new process instead of redirecting stdout because
+# stdout is being written to by rust code, which currently can't be
+# redirected by reassigning sys.stdout
+
+
+class TestDis(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.setup = """
+import dis
+def tested_func(): pass
+"""
+        cls.command = (sys.executable, "-c")
+
+    def test_dis(self):
+        test_code = f"""
+{self.setup}
+dis.dis(tested_func)
+dis.dis("x = 2; print(x)")
+"""
+
+        result = subprocess.run(
+            self.command + (test_code,), capture_output=True
+        )
+        self.assertNotEqual("", result.stdout.decode())
+        self.assertEqual("", result.stderr.decode())
 
     def test_disassemble(self):
+        test_code = f"""
+{self.setup}
+dis.disassemble(tested_func)
+"""
+        result = subprocess.run(
+            self.command + (test_code,), capture_output=True
+        )
         # In CPython this would raise an AttributeError, not a
         # TypeError because dis is implemented in python in CPython and
         # as such the type mismatch wouldn't be caught immeadiately
-        with self.assertRaises(TypeError):
-            dis.disassemble(self.test_disassemble)
-        with captured_stdout() as stdout:
-            dis.dis(self.test_disassemble.__code__)
-        self.assertNotEqual("", stdout.getvalue())
+        self.assertIn("TypeError", result.stderr.decode())
+
+        test_code = f"""
+{self.setup}
+dis.disassemble(tested_func.__code__)
+"""
+        result = subprocess.run(
+            self.command + (test_code,), capture_output=True
+        )
+        self.assertNotEqual("", result.stdout.decode())
+        self.assertEqual("", result.stderr.decode())
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Currently, the dis function from the dis module can only take functions to decompile. This changes it so that strings, when passed to dis, are compiled then disassembled.
This also includes tests for the dis module.