### PR TITLE
IntoPyException

### DIFF
--- a/vm/src/exceptions.rs
+++ b/vm/src/exceptions.rs
@@ -40,6 +40,10 @@ impl fmt::Debug for PyBaseException {
 
 pub type PyBaseExceptionRef = PyRef<PyBaseException>;
 
+pub trait IntoPyException {
+    fn into_pyexception(self, vm: &VirtualMachine) -> PyBaseExceptionRef;
+}
+
 impl PyValue for PyBaseException {
     const HAVE_DICT: bool = true;
 

--- a/vm/src/stdlib/select.rs
+++ b/vm/src/stdlib/select.rs
@@ -1,3 +1,4 @@
+use crate::exceptions::IntoPyException;
 use crate::function::OptionalOption;
 use crate::pyobject::{Either, PyObjectRef, PyResult, TryFromObject};
 use crate::vm::VirtualMachine;
@@ -177,7 +178,7 @@ fn select_select(
     };
 
     if select_res < 0 {
-        return Err(super::os::convert_io_error(vm, err));
+        return Err(err.into_pyexception(vm));
     }
 
     let set2list = |list: Vec<Selectable>, mut set: FdSet| {

--- a/vm/src/stdlib/thread.rs
+++ b/vm/src/stdlib/thread.rs
@@ -1,5 +1,5 @@
 /// Implementation of the _thread module
-use crate::exceptions;
+use crate::exceptions::{self, IntoPyException};
 use crate::function::{Args, KwArgs, OptionalArg, PyFuncArgs};
 use crate::obj::objdict::PyDictRef;
 use crate::obj::objstr::PyStringRef;
@@ -256,7 +256,7 @@ fn thread_start_new_thread(
         vm.state.thread_count.fetch_add(1);
         thread_to_id(&handle.thread())
     })
-    .map_err(|err| super::os::convert_io_error(vm, err))
+    .map_err(|err| err.into_pyexception(vm))
 }
 
 thread_local!(static SENTINELS: RefCell<Vec<PyLockRef>> = RefCell::default());

--- a/vm/src/stdlib/winreg.rs
+++ b/vm/src/stdlib/winreg.rs
@@ -1,15 +1,14 @@
 #![allow(non_snake_case)]
 use crate::common::cell::{PyRwLock, PyRwLockReadGuard, PyRwLockWriteGuard};
-use std::convert::TryInto;
-use std::io;
-
-use super::os;
+use crate::exceptions::IntoPyException;
 use crate::function::OptionalArg;
 use crate::obj::objstr::PyStringRef;
 use crate::obj::objtype::PyClassRef;
 use crate::pyobject::{PyClassImpl, PyObjectRef, PyRef, PyResult, PyValue, TryFromObject};
 use crate::VirtualMachine;
 
+use std::convert::TryInto;
+use std::io;
 use winapi::shared::winerror;
 use winreg::{enums::RegType, RegKey, RegValue};
 
@@ -116,7 +115,7 @@ fn winreg_OpenKey(
     let subkey = subkey.as_ref().map_or("", |s| s.as_str());
     let key = key
         .with_key(|k| k.open_subkey_with_flags(subkey, access))
-        .map_err(|e| os::convert_io_error(vm, e))?;
+        .map_err(|e| e.into_pyexception(vm))?;
 
     Ok(PyHKEY::new(key))
 }
@@ -128,7 +127,7 @@ fn winreg_QueryValue(
 ) -> PyResult<String> {
     let subkey = subkey.as_ref().map_or("", |s| s.as_str());
     key.with_key(|k| k.get_value(subkey))
-        .map_err(|e| os::convert_io_error(vm, e))
+        .map_err(|e| e.into_pyexception(vm))
 }
 
 fn winreg_QueryValueEx(
@@ -138,7 +137,7 @@ fn winreg_QueryValueEx(
 ) -> PyResult<(PyObjectRef, usize)> {
     let subkey = subkey.as_ref().map_or("", |s| s.as_str());
     key.with_key(|k| k.get_raw_value(subkey))
-        .map_err(|e| os::convert_io_error(vm, e))
+        .map_err(|e| e.into_pyexception(vm))
         .and_then(|regval| {
             let ty = regval.vtype.clone() as usize;
             Ok((reg_to_py(regval, vm)?, ty))
@@ -152,7 +151,7 @@ fn winreg_EnumKey(key: Hkey, index: u32, vm: &VirtualMachine) -> PyResult<String
                 winerror::ERROR_NO_MORE_ITEMS as i32,
             ))
         })
-        .map_err(|e| os::convert_io_error(vm, e))
+        .map_err(|e| e.into_pyexception(vm))
 }
 
 fn winreg_EnumValue(
@@ -166,7 +165,7 @@ fn winreg_EnumValue(
                 winerror::ERROR_NO_MORE_ITEMS as i32,
             ))
         })
-        .map_err(|e| os::convert_io_error(vm, e))
+        .map_err(|e| e.into_pyexception(vm))
         .and_then(|(name, value)| {
             let ty = value.vtype.clone() as usize;
             Ok((name, reg_to_py(value, vm)?, ty))


### PR DESCRIPTION
This trait make possible converting rust errors to python errors in idiomatic form.

I accidently mixed up a bit of os module edits but didn't fix the commits to be splited again. Let me know if i'd better to split them again.