### PR TITLE
Fix zlib decompression

### DIFF
--- a/Lib/test/test_zipimport.py
+++ b/Lib/test/test_zipimport.py
@@ -1,0 +1,777 @@
+import sys
+import os
+import marshal
+import importlib
+import importlib.util
+import struct
+import time
+import unittest
+import unittest.mock
+
+from test import support
+
+from zipfile import ZipFile, ZipInfo, ZIP_STORED, ZIP_DEFLATED
+
+import zipimport
+import linecache
+import doctest
+import inspect
+import io
+from traceback import extract_tb, extract_stack, print_tb
+try:
+    import zlib
+except ImportError:
+    zlib = None
+
+test_src = """\
+def get_name():
+    return __name__
+def get_file():
+    return __file__
+"""
+test_co = compile(test_src, "<???>", "exec")
+raise_src = 'def do_raise(): raise TypeError\n'
+
+def make_pyc(co, mtime, size):
+    data = marshal.dumps(co)
+    if type(mtime) is type(0.0):
+        # Mac mtimes need a bit of special casing
+        if mtime < 0x7fffffff:
+            mtime = int(mtime)
+        else:
+            mtime = int(-0x100000000 + int(mtime))
+    pyc = (importlib.util.MAGIC_NUMBER +
+        struct.pack("<iii", 0, int(mtime), size & 0xFFFFFFFF) + data)
+    return pyc
+
+def module_path_to_dotted_name(path):
+    return path.replace(os.sep, '.')
+
+NOW = time.time()
+test_pyc = make_pyc(test_co, NOW, len(test_src))
+
+
+TESTMOD = "ziptestmodule"
+TESTPACK = "ziptestpackage"
+TESTPACK2 = "ziptestpackage2"
+TEMP_DIR = os.path.abspath("junk95142")
+TEMP_ZIP = os.path.abspath("junk95142.zip")
+
+pyc_file = importlib.util.cache_from_source(TESTMOD + '.py')
+pyc_ext = '.pyc'
+
+
+class ImportHooksBaseTestCase(unittest.TestCase):
+
+    def setUp(self):
+        self.path = sys.path[:]
+        self.meta_path = sys.meta_path[:]
+        self.path_hooks = sys.path_hooks[:]
+        sys.path_importer_cache.clear()
+        self.modules_before = support.modules_setup()
+
+    def tearDown(self):
+        sys.path[:] = self.path
+        sys.meta_path[:] = self.meta_path
+        sys.path_hooks[:] = self.path_hooks
+        sys.path_importer_cache.clear()
+        support.modules_cleanup(*self.modules_before)
+
+
+class UncompressedZipImportTestCase(ImportHooksBaseTestCase):
+
+    compression = ZIP_STORED
+
+    def setUp(self):
+        # We're reusing the zip archive path, so we must clear the
+        # cached directory info and linecache.
+        linecache.clearcache()
+        zipimport._zip_directory_cache.clear()
+        ImportHooksBaseTestCase.setUp(self)
+
+    def makeTree(self, files, dirName=TEMP_DIR):
+        # Create a filesystem based set of modules/packages
+        # defined by files under the directory dirName.
+        self.addCleanup(support.rmtree, dirName)
+
+        for name, (mtime, data) in files.items():
+            path = os.path.join(dirName, name)
+            if path[-1] == os.sep:
+                if not os.path.isdir(path):
+                    os.makedirs(path)
+            else:
+                dname = os.path.dirname(path)
+                if not os.path.isdir(dname):
+                    os.makedirs(dname)
+                with open(path, 'wb') as fp:
+                    fp.write(data)
+
+    def makeZip(self, files, zipName=TEMP_ZIP, **kw):
+        # Create a zip archive based set of modules/packages
+        # defined by files in the zip file zipName.  If the
+        # key 'stuff' exists in kw it is prepended to the archive.
+        self.addCleanup(support.unlink, zipName)
+
+        with ZipFile(zipName, "w") as z:
+            for name, (mtime, data) in files.items():
+                zinfo = ZipInfo(name, time.localtime(mtime))
+                zinfo.compress_type = self.compression
+                z.writestr(zinfo, data)
+            comment = kw.get("comment", None)
+            if comment is not None:
+                z.comment = comment
+
+        stuff = kw.get("stuff", None)
+        if stuff is not None:
+            # Prepend 'stuff' to the start of the zipfile
+            with open(zipName, "rb") as f:
+                data = f.read()
+            with open(zipName, "wb") as f:
+                f.write(stuff)
+                f.write(data)
+
+    def doTest(self, expected_ext, files, *modules, **kw):
+        self.makeZip(files, **kw)
+
+        sys.path.insert(0, TEMP_ZIP)
+
+        mod = importlib.import_module(".".join(modules))
+
+        call = kw.get('call')
+        if call is not None:
+            call(mod)
+
+        if expected_ext:
+            file = mod.get_file()
+            self.assertEqual(file, os.path.join(TEMP_ZIP,
+                                 *modules) + expected_ext)
+
+    def testAFakeZlib(self):
+        #
+        # This could cause a stack overflow before: importing zlib.py
+        # from a compressed archive would cause zlib to be imported
+        # which would find zlib.py in the archive, which would... etc.
+        #
+        # This test *must* be executed first: it must be the first one
+        # to trigger zipimport to import zlib (zipimport caches the
+        # zlib.decompress function object, after which the problem being
+        # tested here wouldn't be a problem anymore...
+        # (Hence the 'A' in the test method name: to make it the first
+        # item in a list sorted by name, like unittest.makeSuite() does.)
+        #
+        # This test fails on platforms on which the zlib module is
+        # statically linked, but the problem it tests for can't
+        # occur in that case (builtin modules are always found first),
+        # so we'll simply skip it then. Bug #765456.
+        #
+        if "zlib" in sys.builtin_module_names:
+            self.skipTest('zlib is a builtin module')
+        if "zlib" in sys.modules:
+            del sys.modules["zlib"]
+        files = {"zlib.py": (NOW, test_src)}
+        try:
+            self.doTest(".py", files, "zlib")
+        except ImportError:
+            if self.compression != ZIP_DEFLATED:
+                self.fail("expected test to not raise ImportError")
+        else:
+            if self.compression != ZIP_STORED:
+                self.fail("expected test to raise ImportError")
+
+    def testPy(self):
+        files = {TESTMOD + ".py": (NOW, test_src)}
+        self.doTest(".py", files, TESTMOD)
+
+    def testPyc(self):
+        files = {TESTMOD + pyc_ext: (NOW, test_pyc)}
+        self.doTest(pyc_ext, files, TESTMOD)
+
+    def testBoth(self):
+        files = {TESTMOD + ".py": (NOW, test_src),
+                 TESTMOD + pyc_ext: (NOW, test_pyc)}
+        self.doTest(pyc_ext, files, TESTMOD)
+
+    def testUncheckedHashBasedPyc(self):
+        source = b"state = 'old'"
+        source_hash = importlib.util.source_hash(source)
+        bytecode = importlib._bootstrap_external._code_to_hash_pyc(
+            compile(source, "???", "exec"),
+            source_hash,
+            False, # unchecked
+        )
+        files = {TESTMOD + ".py": (NOW, "state = 'new'"),
+                 TESTMOD + ".pyc": (NOW - 20, bytecode)}
+        def check(mod):
+            self.assertEqual(mod.state, 'old')
+        self.doTest(None, files, TESTMOD, call=check)
+
+    @unittest.mock.patch('_imp.check_hash_based_pycs', 'always')
+    def test_checked_hash_based_change_pyc(self):
+        source = b"state = 'old'"
+        source_hash = importlib.util.source_hash(source)
+        bytecode = importlib._bootstrap_external._code_to_hash_pyc(
+            compile(source, "???", "exec"),
+            source_hash,
+            False,
+        )
+        files = {TESTMOD + ".py": (NOW, "state = 'new'"),
+                 TESTMOD + ".pyc": (NOW - 20, bytecode)}
+        def check(mod):
+            self.assertEqual(mod.state, 'new')
+        self.doTest(None, files, TESTMOD, call=check)
+
+    def testEmptyPy(self):
+        files = {TESTMOD + ".py": (NOW, "")}
+        self.doTest(None, files, TESTMOD)
+
+    def testBadMagic(self):
+        # make pyc magic word invalid, forcing loading from .py
+        badmagic_pyc = bytearray(test_pyc)
+        badmagic_pyc[0] ^= 0x04  # flip an arbitrary bit
+        files = {TESTMOD + ".py": (NOW, test_src),
+                 TESTMOD + pyc_ext: (NOW, badmagic_pyc)}
+        self.doTest(".py", files, TESTMOD)
+
+    def testBadMagic2(self):
+        # make pyc magic word invalid, causing an ImportError
+        badmagic_pyc = bytearray(test_pyc)
+        badmagic_pyc[0] ^= 0x04  # flip an arbitrary bit
+        files = {TESTMOD + pyc_ext: (NOW, badmagic_pyc)}
+        try:
+            self.doTest(".py", files, TESTMOD)
+        except ImportError:
+            pass
+        else:
+            self.fail("expected ImportError; import from bad pyc")
+
+    def testBadMTime(self):
+        badtime_pyc = bytearray(test_pyc)
+        # flip the second bit -- not the first as that one isn't stored in the
+        # .py's mtime in the zip archive.
+        badtime_pyc[11] ^= 0x02
+        files = {TESTMOD + ".py": (NOW, test_src),
+                 TESTMOD + pyc_ext: (NOW, badtime_pyc)}
+        self.doTest(".py", files, TESTMOD)
+
+    def testPackage(self):
+        packdir = TESTPACK + os.sep
+        files = {packdir + "__init__" + pyc_ext: (NOW, test_pyc),
+                 packdir + TESTMOD + pyc_ext: (NOW, test_pyc)}
+        self.doTest(pyc_ext, files, TESTPACK, TESTMOD)
+
+    def testSubPackage(self):
+        # Test that subpackages function when loaded from zip
+        # archives.
+        packdir = TESTPACK + os.sep
+        packdir2 = packdir + TESTPACK2 + os.sep
+        files = {packdir + "__init__" + pyc_ext: (NOW, test_pyc),
+                 packdir2 + "__init__" + pyc_ext: (NOW, test_pyc),
+                 packdir2 + TESTMOD + pyc_ext: (NOW, test_pyc)}
+        self.doTest(pyc_ext, files, TESTPACK, TESTPACK2, TESTMOD)
+
+    def testSubNamespacePackage(self):
+        # Test that implicit namespace subpackages function
+        # when loaded from zip archives.
+        packdir = TESTPACK + os.sep
+        packdir2 = packdir + TESTPACK2 + os.sep
+        # The first two files are just directory entries (so have no data).
+        files = {packdir: (NOW, ""),
+                 packdir2: (NOW, ""),
+                 packdir2 + TESTMOD + pyc_ext: (NOW, test_pyc)}
+        self.doTest(pyc_ext, files, TESTPACK, TESTPACK2, TESTMOD)
+
+    def testMixedNamespacePackage(self):
+        # Test implicit namespace packages spread between a
+        # real filesystem and a zip archive.
+        packdir = TESTPACK + os.sep
+        packdir2 = packdir + TESTPACK2 + os.sep
+        packdir3 = packdir2 + TESTPACK + '3' + os.sep
+        files1 = {packdir: (NOW, ""),
+                  packdir + TESTMOD + pyc_ext: (NOW, test_pyc),
+                  packdir2: (NOW, ""),
+                  packdir3: (NOW, ""),
+                  packdir3 + TESTMOD + pyc_ext: (NOW, test_pyc),
+                  packdir2 + TESTMOD + '3' + pyc_ext: (NOW, test_pyc),
+                  packdir2 + TESTMOD + pyc_ext: (NOW, test_pyc)}
+        files2 = {packdir: (NOW, ""),
+                  packdir + TESTMOD + '2' + pyc_ext: (NOW, test_pyc),
+                  packdir2: (NOW, ""),
+                  packdir2 + TESTMOD + '2' + pyc_ext: (NOW, test_pyc),
+                  packdir2 + TESTMOD + pyc_ext: (NOW, test_pyc)}
+
+        zip1 = os.path.abspath("path1.zip")
+        self.makeZip(files1, zip1)
+
+        zip2 = TEMP_DIR
+        self.makeTree(files2, zip2)
+
+        # zip2 should override zip1.
+        sys.path.insert(0, zip1)
+        sys.path.insert(0, zip2)
+
+        mod = importlib.import_module(TESTPACK)
+
+        # if TESTPACK is functioning as a namespace pkg then
+        # there should be two entries in the __path__.
+        # First should be path2 and second path1.
+        self.assertEqual(2, len(mod.__path__))
+        p1, p2 = mod.__path__
+        self.assertEqual(os.path.basename(TEMP_DIR), p1.split(os.sep)[-2])
+        self.assertEqual("path1.zip", p2.split(os.sep)[-2])
+
+        # packdir3 should import as a namespace package.
+        # Its __path__ is an iterable of 1 element from zip1.
+        mod = importlib.import_module(packdir3.replace(os.sep, '.')[:-1])
+        self.assertEqual(1, len(mod.__path__))
+        mpath = list(mod.__path__)[0].split('path1.zip' + os.sep)[1]
+        self.assertEqual(packdir3[:-1], mpath)
+
+        # TESTPACK/TESTMOD only exists in path1.
+        mod = importlib.import_module('.'.join((TESTPACK, TESTMOD)))
+        self.assertEqual("path1.zip", mod.__file__.split(os.sep)[-3])
+
+        # And TESTPACK/(TESTMOD + '2') only exists in path2.
+        mod = importlib.import_module('.'.join((TESTPACK, TESTMOD + '2')))
+        self.assertEqual(os.path.basename(TEMP_DIR),
+                         mod.__file__.split(os.sep)[-3])
+
+        # One level deeper...
+        subpkg = '.'.join((TESTPACK, TESTPACK2))
+        mod = importlib.import_module(subpkg)
+        self.assertEqual(2, len(mod.__path__))
+        p1, p2 = mod.__path__
+        self.assertEqual(os.path.basename(TEMP_DIR), p1.split(os.sep)[-3])
+        self.assertEqual("path1.zip", p2.split(os.sep)[-3])
+
+        # subpkg.TESTMOD exists in both zips should load from zip2.
+        mod = importlib.import_module('.'.join((subpkg, TESTMOD)))
+        self.assertEqual(os.path.basename(TEMP_DIR),
+                         mod.__file__.split(os.sep)[-4])
+
+        # subpkg.TESTMOD + '2' only exists in zip2.
+        mod = importlib.import_module('.'.join((subpkg, TESTMOD + '2')))
+        self.assertEqual(os.path.basename(TEMP_DIR),
+                         mod.__file__.split(os.sep)[-4])
+
+        # Finally subpkg.TESTMOD + '3' only exists in zip1.
+        mod = importlib.import_module('.'.join((subpkg, TESTMOD + '3')))
+        self.assertEqual('path1.zip', mod.__file__.split(os.sep)[-4])
+
+    def testNamespacePackage(self):
+        # Test implicit namespace packages spread between multiple zip
+        # archives.
+        packdir = TESTPACK + os.sep
+        packdir2 = packdir + TESTPACK2 + os.sep
+        packdir3 = packdir2 + TESTPACK + '3' + os.sep
+        files1 = {packdir: (NOW, ""),
+                  packdir + TESTMOD + pyc_ext: (NOW, test_pyc),
+                  packdir2: (NOW, ""),
+                  packdir3: (NOW, ""),
+                  packdir3 + TESTMOD + pyc_ext: (NOW, test_pyc),
+                  packdir2 + TESTMOD + '3' + pyc_ext: (NOW, test_pyc),
+                  packdir2 + TESTMOD + pyc_ext: (NOW, test_pyc)}
+        zip1 = os.path.abspath("path1.zip")
+        self.makeZip(files1, zip1)
+
+        files2 = {packdir: (NOW, ""),
+                  packdir + TESTMOD + '2' + pyc_ext: (NOW, test_pyc),
+                  packdir2: (NOW, ""),
+                  packdir2 + TESTMOD + '2' + pyc_ext: (NOW, test_pyc),
+                  packdir2 + TESTMOD + pyc_ext: (NOW, test_pyc)}
+        zip2 = os.path.abspath("path2.zip")
+        self.makeZip(files2, zip2)
+
+        # zip2 should override zip1.
+        sys.path.insert(0, zip1)
+        sys.path.insert(0, zip2)
+
+        mod = importlib.import_module(TESTPACK)
+
+        # if TESTPACK is functioning as a namespace pkg then
+        # there should be two entries in the __path__.
+        # First should be path2 and second path1.
+        self.assertEqual(2, len(mod.__path__))
+        p1, p2 = mod.__path__
+        self.assertEqual("path2.zip", p1.split(os.sep)[-2])
+        self.assertEqual("path1.zip", p2.split(os.sep)[-2])
+
+        # packdir3 should import as a namespace package.
+        # Tts __path__ is an iterable of 1 element from zip1.
+        mod = importlib.import_module(packdir3.replace(os.sep, '.')[:-1])
+        self.assertEqual(1, len(mod.__path__))
+        mpath = list(mod.__path__)[0].split('path1.zip' + os.sep)[1]
+        self.assertEqual(packdir3[:-1], mpath)
+
+        # TESTPACK/TESTMOD only exists in path1.
+        mod = importlib.import_module('.'.join((TESTPACK, TESTMOD)))
+        self.assertEqual("path1.zip", mod.__file__.split(os.sep)[-3])
+
+        # And TESTPACK/(TESTMOD + '2') only exists in path2.
+        mod = importlib.import_module('.'.join((TESTPACK, TESTMOD + '2')))
+        self.assertEqual("path2.zip", mod.__file__.split(os.sep)[-3])
+
+        # One level deeper...
+        subpkg = '.'.join((TESTPACK, TESTPACK2))
+        mod = importlib.import_module(subpkg)
+        self.assertEqual(2, len(mod.__path__))
+        p1, p2 = mod.__path__
+        self.assertEqual("path2.zip", p1.split(os.sep)[-3])
+        self.assertEqual("path1.zip", p2.split(os.sep)[-3])
+
+        # subpkg.TESTMOD exists in both zips should load from zip2.
+        mod = importlib.import_module('.'.join((subpkg, TESTMOD)))
+        self.assertEqual('path2.zip', mod.__file__.split(os.sep)[-4])
+
+        # subpkg.TESTMOD + '2' only exists in zip2.
+        mod = importlib.import_module('.'.join((subpkg, TESTMOD + '2')))
+        self.assertEqual('path2.zip', mod.__file__.split(os.sep)[-4])
+
+        # Finally subpkg.TESTMOD + '3' only exists in zip1.
+        mod = importlib.import_module('.'.join((subpkg, TESTMOD + '3')))
+        self.assertEqual('path1.zip', mod.__file__.split(os.sep)[-4])
+
+    def testZipImporterMethods(self):
+        packdir = TESTPACK + os.sep
+        packdir2 = packdir + TESTPACK2 + os.sep
+        files = {packdir + "__init__" + pyc_ext: (NOW, test_pyc),
+                 packdir2 + "__init__" + pyc_ext: (NOW, test_pyc),
+                 packdir2 + TESTMOD + pyc_ext: (NOW, test_pyc),
+                 "spam" + pyc_ext: (NOW, test_pyc)}
+
+        self.addCleanup(support.unlink, TEMP_ZIP)
+        with ZipFile(TEMP_ZIP, "w") as z:
+            for name, (mtime, data) in files.items():
+                zinfo = ZipInfo(name, time.localtime(mtime))
+                zinfo.compress_type = self.compression
+                zinfo.comment = b"spam"
+                z.writestr(zinfo, data)
+
+        zi = zipimport.zipimporter(TEMP_ZIP)
+        self.assertEqual(zi.archive, TEMP_ZIP)
+        self.assertEqual(zi.is_package(TESTPACK), True)
+
+        find_mod = zi.find_module('spam')
+        self.assertIsNotNone(find_mod)
+        self.assertIsInstance(find_mod, zipimport.zipimporter)
+        self.assertFalse(find_mod.is_package('spam'))
+        load_mod = find_mod.load_module('spam')
+        self.assertEqual(find_mod.get_filename('spam'), load_mod.__file__)
+
+        mod = zi.load_module(TESTPACK)
+        self.assertEqual(zi.get_filename(TESTPACK), mod.__file__)
+
+        existing_pack_path = importlib.import_module(TESTPACK).__path__[0]
+        expected_path_path = os.path.join(TEMP_ZIP, TESTPACK)
+        self.assertEqual(existing_pack_path, expected_path_path)
+
+        self.assertEqual(zi.is_package(packdir + '__init__'), False)
+        self.assertEqual(zi.is_package(packdir + TESTPACK2), True)
+        self.assertEqual(zi.is_package(packdir2 + TESTMOD), False)
+
+        mod_path = packdir2 + TESTMOD
+        mod_name = module_path_to_dotted_name(mod_path)
+        mod = importlib.import_module(mod_name)
+        self.assertTrue(mod_name in sys.modules)
+        self.assertEqual(zi.get_source(TESTPACK), None)
+        self.assertEqual(zi.get_source(mod_path), None)
+        self.assertEqual(zi.get_filename(mod_path), mod.__file__)
+        # To pass in the module name instead of the path, we must use the
+        # right importer
+        loader = mod.__loader__
+        self.assertEqual(loader.get_source(mod_name), None)
+        self.assertEqual(loader.get_filename(mod_name), mod.__file__)
+
+        # test prefix and archivepath members
+        zi2 = zipimport.zipimporter(TEMP_ZIP + os.sep + TESTPACK)
+        self.assertEqual(zi2.archive, TEMP_ZIP)
+        self.assertEqual(zi2.prefix, TESTPACK + os.sep)
+
+    def testZipImporterMethodsInSubDirectory(self):
+        packdir = TESTPACK + os.sep
+        packdir2 = packdir + TESTPACK2 + os.sep
+        files = {packdir2 + "__init__" + pyc_ext: (NOW, test_pyc),
+                 packdir2 + TESTMOD + pyc_ext: (NOW, test_pyc)}
+
+        self.addCleanup(support.unlink, TEMP_ZIP)
+        with ZipFile(TEMP_ZIP, "w") as z:
+            for name, (mtime, data) in files.items():
+                zinfo = ZipInfo(name, time.localtime(mtime))
+                zinfo.compress_type = self.compression
+                zinfo.comment = b"eggs"
+                z.writestr(zinfo, data)
+
+        zi = zipimport.zipimporter(TEMP_ZIP + os.sep + packdir)
+        self.assertEqual(zi.archive, TEMP_ZIP)
+        self.assertEqual(zi.prefix, packdir)
+        self.assertEqual(zi.is_package(TESTPACK2), True)
+        mod = zi.load_module(TESTPACK2)
+        self.assertEqual(zi.get_filename(TESTPACK2), mod.__file__)
+
+        self.assertEqual(
+            zi.is_package(TESTPACK2 + os.sep + '__init__'), False)
+        self.assertEqual(
+            zi.is_package(TESTPACK2 + os.sep + TESTMOD), False)
+
+        pkg_path = TEMP_ZIP + os.sep + packdir + TESTPACK2
+        zi2 = zipimport.zipimporter(pkg_path)
+        find_mod_dotted = zi2.find_module(TESTMOD)
+        self.assertIsNotNone(find_mod_dotted)
+        self.assertIsInstance(find_mod_dotted, zipimport.zipimporter)
+        self.assertFalse(zi2.is_package(TESTMOD))
+        load_mod = find_mod_dotted.load_module(TESTMOD)
+        self.assertEqual(
+            find_mod_dotted.get_filename(TESTMOD), load_mod.__file__)
+
+        mod_path = TESTPACK2 + os.sep + TESTMOD
+        mod_name = module_path_to_dotted_name(mod_path)
+        mod = importlib.import_module(mod_name)
+        self.assertTrue(mod_name in sys.modules)
+        self.assertEqual(zi.get_source(TESTPACK2), None)
+        self.assertEqual(zi.get_source(mod_path), None)
+        self.assertEqual(zi.get_filename(mod_path), mod.__file__)
+        # To pass in the module name instead of the path, we must use the
+        # right importer.
+        loader = mod.__loader__
+        self.assertEqual(loader.get_source(mod_name), None)
+        self.assertEqual(loader.get_filename(mod_name), mod.__file__)
+
+    def testGetData(self):
+        self.addCleanup(support.unlink, TEMP_ZIP)
+        with ZipFile(TEMP_ZIP, "w") as z:
+            z.compression = self.compression
+            name = "testdata.dat"
+            data = bytes(x for x in range(256))
+            z.writestr(name, data)
+
+        zi = zipimport.zipimporter(TEMP_ZIP)
+        self.assertEqual(data, zi.get_data(name))
+        self.assertIn('zipimporter object', repr(zi))
+
+    def testImporterAttr(self):
+        src = """if 1:  # indent hack
+        def get_file():
+            return __file__
+        if __loader__.get_data("some.data") != b"some data":
+            raise AssertionError("bad data")\n"""
+        pyc = make_pyc(compile(src, "<???>", "exec"), NOW, len(src))
+        files = {TESTMOD + pyc_ext: (NOW, pyc),
+                 "some.data": (NOW, "some data")}
+        self.doTest(pyc_ext, files, TESTMOD)
+
+    def testDefaultOptimizationLevel(self):
+        # zipimport should use the default optimization level (#28131)
+        src = """if 1:  # indent hack
+        def test(val):
+            assert(val)
+            return val\n"""
+        files = {TESTMOD + '.py': (NOW, src)}
+        self.makeZip(files)
+        sys.path.insert(0, TEMP_ZIP)
+        mod = importlib.import_module(TESTMOD)
+        self.assertEqual(mod.test(1), 1)
+        self.assertRaises(AssertionError, mod.test, False)
+
+    def testImport_WithStuff(self):
+        # try importing from a zipfile which contains additional
+        # stuff at the beginning of the file
+        files = {TESTMOD + ".py": (NOW, test_src)}
+        self.doTest(".py", files, TESTMOD,
+                    stuff=b"Some Stuff"*31)
+
+    def assertModuleSource(self, module):
+        self.assertEqual(inspect.getsource(module), test_src)
+
+    def testGetSource(self):
+        files = {TESTMOD + ".py": (NOW, test_src)}
+        self.doTest(".py", files, TESTMOD, call=self.assertModuleSource)
+
+    def testGetCompiledSource(self):
+        pyc = make_pyc(compile(test_src, "<???>", "exec"), NOW, len(test_src))
+        files = {TESTMOD + ".py": (NOW, test_src),
+                 TESTMOD + pyc_ext: (NOW, pyc)}
+        self.doTest(pyc_ext, files, TESTMOD, call=self.assertModuleSource)
+
+    def runDoctest(self, callback):
+        files = {TESTMOD + ".py": (NOW, test_src),
+                 "xyz.txt": (NOW, ">>> log.append(True)\n")}
+        self.doTest(".py", files, TESTMOD, call=callback)
+
+    def doDoctestFile(self, module):
+        log = []
+        old_master, doctest.master = doctest.master, None
+        try:
+            doctest.testfile(
+                'xyz.txt', package=module, module_relative=True,
+                globs=locals()
+            )
+        finally:
+            doctest.master = old_master
+        self.assertEqual(log,[True])
+
+    def testDoctestFile(self):
+        self.runDoctest(self.doDoctestFile)
+
+    def doDoctestSuite(self, module):
+        log = []
+        doctest.DocFileTest(
+            'xyz.txt', package=module, module_relative=True,
+            globs=locals()
+        ).run()
+        self.assertEqual(log,[True])
+
+    def testDoctestSuite(self):
+        self.runDoctest(self.doDoctestSuite)
+
+    def doTraceback(self, module):
+        try:
+            module.do_raise()
+        except:
+            tb = sys.exc_info()[2].tb_next
+
+            f,lno,n,line = extract_tb(tb, 1)[0]
+            self.assertEqual(line, raise_src.strip())
+
+            f,lno,n,line = extract_stack(tb.tb_frame, 1)[0]
+            self.assertEqual(line, raise_src.strip())
+
+            s = io.StringIO()
+            print_tb(tb, 1, s)
+            self.assertTrue(s.getvalue().endswith(raise_src))
+        else:
+            raise AssertionError("This ought to be impossible")
+
+    def testTraceback(self):
+        files = {TESTMOD + ".py": (NOW, raise_src)}
+        self.doTest(None, files, TESTMOD, call=self.doTraceback)
+
+    @unittest.skipIf(support.TESTFN_UNENCODABLE is None,
+                     "need an unencodable filename")
+    def testUnencodable(self):
+        filename = support.TESTFN_UNENCODABLE + ".zip"
+        self.addCleanup(support.unlink, filename)
+        with ZipFile(filename, "w") as z:
+            zinfo = ZipInfo(TESTMOD + ".py", time.localtime(NOW))
+            zinfo.compress_type = self.compression
+            z.writestr(zinfo, test_src)
+        zipimport.zipimporter(filename).load_module(TESTMOD)
+
+    def testBytesPath(self):
+        filename = support.TESTFN + ".zip"
+        self.addCleanup(support.unlink, filename)
+        with ZipFile(filename, "w") as z:
+            zinfo = ZipInfo(TESTMOD + ".py", time.localtime(NOW))
+            zinfo.compress_type = self.compression
+            z.writestr(zinfo, test_src)
+
+        zipimport.zipimporter(filename)
+        zipimport.zipimporter(os.fsencode(filename))
+        with self.assertRaises(TypeError):
+            zipimport.zipimporter(bytearray(os.fsencode(filename)))
+        with self.assertRaises(TypeError):
+            zipimport.zipimporter(memoryview(os.fsencode(filename)))
+
+    def testComment(self):
+        files = {TESTMOD + ".py": (NOW, test_src)}
+        self.doTest(".py", files, TESTMOD, comment=b"comment")
+
+    def testBeginningCruftAndComment(self):
+        files = {TESTMOD + ".py": (NOW, test_src)}
+        self.doTest(".py", files, TESTMOD, stuff=b"cruft" * 64, comment=b"hi")
+
+    def testLargestPossibleComment(self):
+        files = {TESTMOD + ".py": (NOW, test_src)}
+        self.doTest(".py", files, TESTMOD, comment=b"c" * ((1 << 16) - 1))
+
+
+@support.requires_zlib
+class CompressedZipImportTestCase(UncompressedZipImportTestCase):
+    compression = ZIP_DEFLATED
+
+
+class BadFileZipImportTestCase(unittest.TestCase):
+    def assertZipFailure(self, filename):
+        self.assertRaises(zipimport.ZipImportError,
+                          zipimport.zipimporter, filename)
+
+    def testNoFile(self):
+        self.assertZipFailure('AdfjdkFJKDFJjdklfjs')
+
+    def testEmptyFilename(self):
+        self.assertZipFailure('')
+
+    def testBadArgs(self):
+        self.assertRaises(TypeError, zipimport.zipimporter, None)
+        self.assertRaises(TypeError, zipimport.zipimporter, TESTMOD, kwd=None)
+        self.assertRaises(TypeError, zipimport.zipimporter,
+                          list(os.fsencode(TESTMOD)))
+
+    def testFilenameTooLong(self):
+        self.assertZipFailure('A' * 33000)
+
+    def testEmptyFile(self):
+        support.unlink(TESTMOD)
+        support.create_empty_file(TESTMOD)
+        self.assertZipFailure(TESTMOD)
+
+    def testFileUnreadable(self):
+        support.unlink(TESTMOD)
+        fd = os.open(TESTMOD, os.O_CREAT, 000)
+        try:
+            os.close(fd)
+
+            with self.assertRaises(zipimport.ZipImportError) as cm:
+                zipimport.zipimporter(TESTMOD)
+        finally:
+            # If we leave "the read-only bit" set on Windows, nothing can
+            # delete TESTMOD, and later tests suffer bogus failures.
+            os.chmod(TESTMOD, 0o666)
+            support.unlink(TESTMOD)
+
+    def testNotZipFile(self):
+        support.unlink(TESTMOD)
+        fp = open(TESTMOD, 'w+')
+        fp.write('a' * 22)
+        fp.close()
+        self.assertZipFailure(TESTMOD)
+
+    # XXX: disabled until this works on Big-endian machines
+    def _testBogusZipFile(self):
+        support.unlink(TESTMOD)
+        fp = open(TESTMOD, 'w+')
+        fp.write(struct.pack('=I', 0x06054B50))
+        fp.write('a' * 18)
+        fp.close()
+        z = zipimport.zipimporter(TESTMOD)
+
+        try:
+            self.assertRaises(TypeError, z.find_module, None)
+            self.assertRaises(TypeError, z.load_module, None)
+            self.assertRaises(TypeError, z.is_package, None)
+            self.assertRaises(TypeError, z.get_code, None)
+            self.assertRaises(TypeError, z.get_data, None)
+            self.assertRaises(TypeError, z.get_source, None)
+
+            error = zipimport.ZipImportError
+            self.assertEqual(z.find_module('abc'), None)
+
+            self.assertRaises(error, z.load_module, 'abc')
+            self.assertRaises(error, z.get_code, 'abc')
+            self.assertRaises(OSError, z.get_data, 'abc')
+            self.assertRaises(error, z.get_source, 'abc')
+            self.assertRaises(error, z.is_package, 'abc')
+        finally:
+            zipimport._zip_directory_cache.clear()
+
+
+def test_main():
+    try:
+        support.run_unittest(
+              UncompressedZipImportTestCase,
+              CompressedZipImportTestCase,
+              BadFileZipImportTestCase,
+            )
+    finally:
+        support.unlink(TESTMOD)
+
+if __name__ == "__main__":
+    test_main()

--- a/Lib/test/test_zipimport.py
+++ b/Lib/test/test_zipimport.py
@@ -191,6 +191,8 @@ class UncompressedZipImportTestCase(ImportHooksBaseTestCase):
                  TESTMOD + pyc_ext: (NOW, test_pyc)}
         self.doTest(pyc_ext, files, TESTMOD)
 
+    # TODO: RUSTPYTHON
+    @unittest.expectedFailure
     def testUncheckedHashBasedPyc(self):
         source = b"state = 'old'"
         source_hash = importlib.util.source_hash(source)
@@ -205,6 +207,8 @@ class UncompressedZipImportTestCase(ImportHooksBaseTestCase):
             self.assertEqual(mod.state, 'old')
         self.doTest(None, files, TESTMOD, call=check)
 
+    # TODO: RUSTPYTHON
+    @unittest.expectedFailure
     @unittest.mock.patch('_imp.check_hash_based_pycs', 'always')
     def test_checked_hash_based_change_pyc(self):
         source = b"state = 'old'"
@@ -224,6 +228,8 @@ class UncompressedZipImportTestCase(ImportHooksBaseTestCase):
         files = {TESTMOD + ".py": (NOW, "")}
         self.doTest(None, files, TESTMOD)
 
+    # TODO: RUSTPYTHON
+    @unittest.expectedFailure
     def testBadMagic(self):
         # make pyc magic word invalid, forcing loading from .py
         badmagic_pyc = bytearray(test_pyc)
@@ -232,6 +238,8 @@ class UncompressedZipImportTestCase(ImportHooksBaseTestCase):
                  TESTMOD + pyc_ext: (NOW, badmagic_pyc)}
         self.doTest(".py", files, TESTMOD)
 
+    # TODO: RUSTPYTHON
+    @unittest.expectedFailure
     def testBadMagic2(self):
         # make pyc magic word invalid, causing an ImportError
         badmagic_pyc = bytearray(test_pyc)
@@ -244,6 +252,8 @@ class UncompressedZipImportTestCase(ImportHooksBaseTestCase):
         else:
             self.fail("expected ImportError; import from bad pyc")
 
+    # TODO: RUSTPYTHON
+    @unittest.expectedFailure
     def testBadMTime(self):
         badtime_pyc = bytearray(test_pyc)
         # flip the second bit -- not the first as that one isn't stored in the
@@ -713,6 +723,8 @@ class BadFileZipImportTestCase(unittest.TestCase):
         support.create_empty_file(TESTMOD)
         self.assertZipFailure(TESTMOD)
 
+    # TODO: RUSTPYTHON
+    @unittest.expectedFailure
     def testFileUnreadable(self):
         support.unlink(TESTMOD)
         fd = os.open(TESTMOD, os.O_CREAT, 000)

--- a/Lib/test/test_zlib.py
+++ b/Lib/test/test_zlib.py
@@ -185,8 +185,6 @@ class CompressTestCase(BaseCompressTestCase, unittest.TestCase):
                                          bufsize=zlib.DEF_BUF_SIZE),
                          HAMLET_SCENE)
 
-    # TODO: RUSTPYTHON
-    @unittest.expectedFailure
     def test_speech128(self):
         # compress more data
         data = HAMLET_SCENE * 128
@@ -215,8 +213,6 @@ class CompressTestCase(BaseCompressTestCase, unittest.TestCase):
     def test_big_decompress_buffer(self, size):
         self.check_big_decompress_buffer(size, zlib.decompress)
 
-    # TODO: RUSTPYTHON
-    @unittest.expectedFailure
     @bigmemtest(size=_4G, memuse=1)
     def test_large_bufsize(self, size):
         # Test decompress(bufsize) parameter greater than the internal limit
@@ -321,8 +317,6 @@ class CompressObjectTestCase(BaseCompressTestCase, unittest.TestCase):
         y2 = dco.flush()
         self.assertEqual(data, y1 + y2)
 
-    # TODO: RUSTPYTHON
-    @unittest.expectedFailure
     def test_decompinc(self, flush=False, source=None, cx=256, dcx=64):
         # compress object in steps, decompress object in steps
         source = source or HAMLET_SCENE
@@ -364,13 +358,9 @@ class CompressObjectTestCase(BaseCompressTestCase, unittest.TestCase):
         self.assertEqual(data, b''.join(bufs))
         # Failure means: "decompressobj with init options failed"
 
-    # TODO: RUSTPYTHON
-    @unittest.expectedFailure
     def test_decompincflush(self):
         self.test_decompinc(flush=True)
 
-    # TODO: RUSTPYTHON
-    @unittest.expectedFailure
     def test_decompimax(self, source=None, cx=256, dcx=64):
         # compress in steps, decompress in length-restricted steps
         source = source or HAMLET_SCENE
@@ -398,8 +388,6 @@ class CompressObjectTestCase(BaseCompressTestCase, unittest.TestCase):
         bufs.append(dco.flush())
         self.assertEqual(data, b''.join(bufs), 'Wrong data retrieved')
 
-    # TODO: RUSTPYTHON
-    @unittest.expectedFailure
     def test_decompressmaxlen(self, flush=False):
         # Check a decompression object with max_length specified
         data = HAMLET_SCENE * 128
@@ -432,8 +420,6 @@ class CompressObjectTestCase(BaseCompressTestCase, unittest.TestCase):
                 bufs.append(chunk)
         self.assertEqual(data, b''.join(bufs), 'Wrong data retrieved')
 
-    # TODO: RUSTPYTHON
-    @unittest.expectedFailure
     def test_decompressmaxlenflush(self):
         self.test_decompressmaxlen(flush=True)
 
@@ -445,7 +431,6 @@ class CompressObjectTestCase(BaseCompressTestCase, unittest.TestCase):
         self.assertRaises(ValueError, dco.decompress, b"", -1)
         self.assertEqual(b'', dco.unconsumed_tail)
 
-    @unittest.skip('TODO: RUSTPYTHON')
     def test_maxlen_large(self):
         # Sizes up to sys.maxsize should be accepted, although zlib is
         # internally limited to expressing sizes with unsigned int
@@ -540,7 +525,6 @@ class CompressObjectTestCase(BaseCompressTestCase, unittest.TestCase):
         # if decompressed data is different from the input data, choke.
         self.assertEqual(expanded, data, "17K random source doesn't match")
 
-    @unittest.skip('TODO: RUSTPYTHON')
     def test_empty_flush(self):
         # Test that calling .flush() on unused objects works.
         # (Bug #1083110 -- calling .flush() on decompress objects
@@ -584,8 +568,6 @@ class CompressObjectTestCase(BaseCompressTestCase, unittest.TestCase):
         self.assertEqual(do.decompress(d1), piece[100:])
         self.assertEqual(do.decompress(d2), piece[:-100])
 
-    # TODO: RUSTPYTHON
-    @unittest.expectedFailure
     def test_decompress_incomplete_stream(self):
         # This is 'foo', deflated
         x = b'x\x9cK\xcb\xcf\x07\x00\x02\x82\x01E'
@@ -599,8 +581,6 @@ class CompressObjectTestCase(BaseCompressTestCase, unittest.TestCase):
         y += dco.flush()
         self.assertEqual(y, b'foo')
 
-    # TODO: RUSTPYTHON
-    @unittest.expectedFailure
     def test_decompress_eof(self):
         x = b'x\x9cK\xcb\xcf\x07\x00\x02\x82\x01E'  # 'foo'
         dco = zlib.decompressobj()
@@ -612,7 +592,6 @@ class CompressObjectTestCase(BaseCompressTestCase, unittest.TestCase):
         dco.flush()
         self.assertTrue(dco.eof)
 
-    @unittest.skip('TODO: RUSTPYTHON')
     def test_decompress_eof_incomplete_stream(self):
         x = b'x\x9cK\xcb\xcf\x07\x00\x02\x82\x01E'  # 'foo'
         dco = zlib.decompressobj()
@@ -622,8 +601,6 @@ class CompressObjectTestCase(BaseCompressTestCase, unittest.TestCase):
         dco.flush()
         self.assertFalse(dco.eof)
 
-    # TODO: RUSTPYTHON
-    @unittest.expectedFailure
     def test_decompress_unused_data(self):
         # Repeated calls to decompress() after EOF should accumulate data in
         # dco.unused_data, instead of just storing the arg to the last call.
@@ -661,7 +638,6 @@ class CompressObjectTestCase(BaseCompressTestCase, unittest.TestCase):
         uncomp = dco.decompress(comp) + dco.flush()
         self.assertEqual(zdict, uncomp)
 
-    @unittest.skip('TODO: RUSTPYTHON')
     def test_flush_with_freed_input(self):
         # Issue #16411: decompressor accesses input to last decompress() call
         # in flush(), even if this object has been freed in the meanwhile.
@@ -674,7 +650,6 @@ class CompressObjectTestCase(BaseCompressTestCase, unittest.TestCase):
         data = zlib.compress(input2)
         self.assertEqual(dco.flush(), input1[1:])
 
-    @unittest.skip('TODO: RUSTPYTHON')
     @bigmemtest(size=_4G, memuse=1)
     def test_flush_large_length(self, size):
         # Test flush(length) parameter greater than internal limit UINT_MAX
@@ -684,7 +659,8 @@ class CompressObjectTestCase(BaseCompressTestCase, unittest.TestCase):
         dco.decompress(data, 1)
         self.assertEqual(dco.flush(size), input[1:])
 
-    @unittest.skip('TODO: RUSTPYTHON')
+    # TODO: RUSTPYTHON
+    @unittest.expectedFailure
     def test_flush_custom_length(self):
         input = HAMLET_SCENE * 10
         data = zlib.compress(input, 1)
@@ -781,14 +757,12 @@ class CompressObjectTestCase(BaseCompressTestCase, unittest.TestCase):
         compress = lambda s: c.compress(s) + c.flush()
         self.check_big_compress_buffer(size, compress)
 
-    @unittest.skip('TODO: RUSTPYTHON')
     @bigmemtest(size=_1G + 1024 * 1024, memuse=2)
     def test_big_decompress_buffer(self, size):
         d = zlib.decompressobj()
         decompress = lambda s: d.decompress(s) + d.flush()
         self.check_big_decompress_buffer(size, decompress)
 
-    @unittest.skip('TODO: RUSTPYTHON')
     @unittest.skipUnless(sys.maxsize > 2**32, 'requires 64bit platform')
     @bigmemtest(size=_4G + 100, memuse=4)
     def test_64bit_compress(self, size):
@@ -802,7 +776,6 @@ class CompressObjectTestCase(BaseCompressTestCase, unittest.TestCase):
         finally:
             comp = uncomp = data = None
 
-    @unittest.skip('TODO: RUSTPYTHON')
     @unittest.skipUnless(sys.maxsize > 2**32, 'requires 64bit platform')
     @bigmemtest(size=_4G + 100, memuse=3)
     def test_large_unused_data(self, size):
@@ -817,7 +790,6 @@ class CompressObjectTestCase(BaseCompressTestCase, unittest.TestCase):
         finally:
             unused = comp = do = None
 
-    @unittest.skip('TODO: RUSTPYTHON')
     @unittest.skipUnless(sys.maxsize > 2**32, 'requires 64bit platform')
     @bigmemtest(size=_4G + 100, memuse=5)
     def test_large_unconsumed_tail(self, size):


### PR DESCRIPTION
Fixed a couple of bugs with zlib decompression, and shared the core decompression routine between `zlib_decompress`, `Decompress.decompress`, and `Decompress.flush`.