### PR TITLE
Add target_is_directory parameter for symlink function

### DIFF
--- a/vm/src/stdlib/os.rs
+++ b/vm/src/stdlib/os.rs
@@ -156,6 +156,7 @@ pub fn errno_err(vm: &VirtualMachine) -> PyBaseExceptionRef {
     convert_io_error(vm, io::Error::last_os_error())
 }
 
+#[allow(dead_code)]
 #[derive(FromArgs, Default)]
 pub struct TargetIsDirectory {
     #[pyarg(keyword_only, default = "false")]

--- a/vm/src/stdlib/os.rs
+++ b/vm/src/stdlib/os.rs
@@ -157,6 +157,12 @@ pub fn errno_err(vm: &VirtualMachine) -> PyBaseExceptionRef {
 }
 
 #[derive(FromArgs, Default)]
+pub struct TargetIsDirectory {
+    #[pyarg(keyword_only, default = "false")]
+    target_is_directory: bool,
+}
+
+#[derive(FromArgs, Default)]
 pub struct DirFd {
     #[pyarg(keyword_only, default = "None")]
     dir_fd: Option<PyIntRef>,
@@ -596,6 +602,7 @@ mod _os {
     pub(super) fn symlink(
         src: PyPathLike,
         dst: PyPathLike,
+        _target_is_directory: TargetIsDirectory,
         dir_fd: DirFd,
         vm: &VirtualMachine,
     ) -> PyResult<()> {
@@ -1196,6 +1203,7 @@ mod posix {
     pub(super) fn symlink(
         src: PyPathLike,
         dst: PyPathLike,
+        _target_is_directory: TargetIsDirectory,
         dir_fd: DirFd,
         vm: &VirtualMachine,
     ) -> PyResult<()> {
@@ -2183,6 +2191,7 @@ mod nt {
     pub(super) fn symlink(
         src: PyPathLike,
         dst: PyPathLike,
+        _target_is_directory: TargetIsDirectory,
         _dir_fd: DirFd,
         vm: &VirtualMachine,
     ) -> PyResult<()> {


### PR DESCRIPTION
`target_is_directory` parameter is required for `symlink` function.

https://docs.python.org/3/library/os.html#os.symlink