### PR TITLE
Use pylib as a dependency of the rustpython binary in order to get a Lib path

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1294,6 +1294,7 @@ dependencies = [
  "num-traits",
  "rustpython-compiler",
  "rustpython-parser",
+ "rustpython-pylib",
  "rustpython-vm",
  "rustyline",
 ]
@@ -1368,7 +1369,6 @@ dependencies = [
 name = "rustpython-pylib"
 version = "0.1.0"
 dependencies = [
- "maplit",
  "rustpython-bytecode",
  "rustpython-derive",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,6 +6,7 @@ edition = "2018"
 description = "A python interpreter written in rust."
 repository = "https://github.com/RustPython/RustPython"
 license = "MIT"
+include = ["LICENSE", "Cargo.toml", "src/**/*.rs"]
 
 [workspace]
 members = [".", "derive", "vm", "wasm/lib", "parser", "compiler", "bytecode", "vm/pylib-crate", "common"]
@@ -15,7 +16,7 @@ name = "bench"
 path = "./benchmarks/bench.rs"
 
 [features]
-default = ["threading"]
+default = ["threading", "pylib"]
 flame-it = ["rustpython-vm/flame-it", "flame", "flamescope"]
 freeze-stdlib = ["rustpython-vm/freeze-stdlib"]
 threading = ["rustpython-vm/threading"]
@@ -29,6 +30,7 @@ clap = "2.33"
 rustpython-compiler = { path = "compiler", version = "0.1.1" }
 rustpython-parser = { path = "parser", version = "0.1.1" }
 rustpython-vm = { path = "vm", version = "0.1.1", default-features = false, features = ["compile-parse"] }
+pylib = { package = "rustpython-pylib", path = "vm/pylib-crate", version = "0.1.0", default-features = false, optional = true }
 dirs = { package = "dirs-next", version = "1.0" }
 num-traits = "0.2.8"
 cfg-if = "0.1"

--- a/Lib/test/test_json/test_tool.py
+++ b/Lib/test/test_json/test_tool.py
@@ -7,7 +7,6 @@ from test import support
 from test.support.script_helper import assert_python_ok
 
 
-@unittest.skip("TODO: RUSTPYTHON, rustpython -X faulthandler")
 class TestTool(unittest.TestCase):
     data = """
 

--- a/derive/src/lib.rs
+++ b/derive/src/lib.rs
@@ -59,17 +59,7 @@ pub fn pystruct_sequence(attr: TokenStream, item: TokenStream) -> TokenStream {
     result_to_tokens(pyclass::impl_pystruct_sequence(attr, item))
 }
 
-fn result_to_tokens_expr(result: Result<TokenStream2, Diagnostic>) -> TokenStream {
-    let tokens2 = result.unwrap_or_else(ToTokens::into_token_stream);
-    let ret = quote::quote! {
-        macro_rules! __proc_macro_call {
-            () => {{ #tokens2 }}
-        }
-    };
-    ret.into()
-}
-
 #[proc_macro]
 pub fn py_compile_bytecode(input: TokenStream) -> TokenStream {
-    result_to_tokens_expr(compile_bytecode::impl_py_compile_bytecode(input.into()))
+    result_to_tokens(compile_bytecode::impl_py_compile_bytecode(input.into()))
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -198,14 +198,14 @@ fn create_settings(matches: &ArgMatches) -> PySettings {
     // add the current directory to sys.path
     settings.path_list.push("".to_owned());
 
+    // BUILDTIME_RUSTPYTHONPATH should be set when distributing
     if let Some(paths) = option_env!("BUILDTIME_RUSTPYTHONPATH") {
         settings.path_list.extend(
             std::env::split_paths(paths).map(|path| path.into_os_string().into_string().unwrap()),
         )
-    } else if option_env!("RUSTPYTHONPATH").is_none() {
-        settings
-            .path_list
-            .push(concat!(env!("CARGO_MANIFEST_DIR"), "/Lib").to_owned());
+    } else {
+        #[cfg(all(feature = "pylib", not(feature = "freeze-stdlib")))]
+        settings.path_list.push(pylib::LIB_PATH.to_owned());
     }
 
     if !ignore_environment {

--- a/vm/pylib-crate/Cargo.toml
+++ b/vm/pylib-crate/Cargo.toml
@@ -2,9 +2,11 @@
 name = "rustpython-pylib"
 version = "0.1.0"
 authors = ["RustPython Team"]
+description = "A subset of the Python standard library for use with RustPython"
+repository = "https://github.com/RustPython/RustPython"
+license-file = "Lib/PSF-LICENSE"
 edition = "2018"
 include = ["Cargo.toml", "src/**/*.rs", "Lib/", "!Lib/**/test/", "!Lib/**/*.pyc"]
-license-file = "Lib/PSF-LICENSE"
 
 [features]
 default = ["compiled-bytecode"]

--- a/vm/pylib-crate/Cargo.toml
+++ b/vm/pylib-crate/Cargo.toml
@@ -3,7 +3,7 @@ name = "rustpython-pylib"
 version = "0.1.0"
 authors = ["RustPython Team"]
 edition = "2018"
-include = ["Cargo.toml", "src/**/*.rs", "Lib/**"]
+include = ["Cargo.toml", "src/**/*.rs", "Lib/", "!Lib/**/test/", "!Lib/**/*.pyc"]
 
 [features]
 default = ["compiled-bytecode"]

--- a/vm/pylib-crate/Cargo.toml
+++ b/vm/pylib-crate/Cargo.toml
@@ -4,7 +4,10 @@ version = "0.1.0"
 authors = ["RustPython Team"]
 edition = "2018"
 
+[features]
+default = ["compiled-bytecode"]
+compiled-bytecode = ["rustpython-derive", "rustpython-bytecode"]
+
 [dependencies]
-rustpython-derive = { version = "0.1.2", path = "../../derive" }
-rustpython-bytecode = { version = "0.1.2", path = "../../bytecode" }
-maplit = "1.0"
+rustpython-derive = { version = "0.1.2", path = "../../derive", optional = true }
+rustpython-bytecode = { version = "0.1.2", path = "../../bytecode", optional = true }

--- a/vm/pylib-crate/Cargo.toml
+++ b/vm/pylib-crate/Cargo.toml
@@ -3,6 +3,7 @@ name = "rustpython-pylib"
 version = "0.1.0"
 authors = ["RustPython Team"]
 edition = "2018"
+include = ["Cargo.toml", "src/**/*.rs", "Lib/**"]
 
 [features]
 default = ["compiled-bytecode"]

--- a/vm/pylib-crate/Cargo.toml
+++ b/vm/pylib-crate/Cargo.toml
@@ -4,6 +4,7 @@ version = "0.1.0"
 authors = ["RustPython Team"]
 edition = "2018"
 include = ["Cargo.toml", "src/**/*.rs", "Lib/", "!Lib/**/test/", "!Lib/**/*.pyc"]
+license-file = "Lib/PSF-LICENSE"
 
 [features]
 default = ["compiled-bytecode"]

--- a/vm/pylib-crate/src/lib.rs
+++ b/vm/pylib-crate/src/lib.rs
@@ -4,25 +4,14 @@
 
 extern crate self as rustpython_pylib;
 
-use rustpython_bytecode::bytecode::{self, FrozenModule};
-use std::collections::HashMap;
+pub const LIB_PATH: &str = concat!(env!("CARGO_MANIFEST_DIR"), "/Lib");
 
-use rustpython_derive::py_compile_bytecode as _py_compile_bytecode;
-#[macro_export]
-macro_rules! py_compile_bytecode {
-    ($($arg:tt)*) => {{
-        #[macro_use]
-        mod __m {
-            $crate::_py_compile_bytecode!($($arg)*);
-        }
-        __proc_macro_call!()
-    }};
-}
-
-mod __exports {
-    pub use maplit::hashmap;
-}
-
+#[cfg(feature = "compiled-bytecode")]
+use {
+    rustpython_bytecode::bytecode::{self, FrozenModule},
+    std::collections::HashMap,
+};
+#[cfg(feature = "compiled-bytecode")]
 pub fn frozen_stdlib() -> HashMap<String, FrozenModule> {
-    py_compile_bytecode!(dir = "Lib", crate_name = "rustpython_pylib")
+    rustpython_derive::py_compile_bytecode!(dir = "Lib", crate_name = "rustpython_pylib")
 }

--- a/vm/src/lib.rs
+++ b/vm/src/lib.rs
@@ -33,20 +33,6 @@ extern crate self as rustpython_vm;
 
 pub use rustpython_derive::*;
 
-#[doc(hidden)]
-pub use rustpython_derive::py_compile_bytecode as _py_compile_bytecode;
-
-#[macro_export]
-macro_rules! py_compile_bytecode {
-    ($($arg:tt)*) => {{
-        #[macro_use]
-        mod __m {
-            $crate::_py_compile_bytecode!($($arg)*);
-        }
-        __proc_macro_call!()
-    }};
-}
-
 //extern crate eval; use eval::eval::*;
 // use py_code_object::{Function, NativeType, PyCodeObject};
 
@@ -90,6 +76,5 @@ pub use rustpython_common as common;
 
 #[doc(hidden)]
 pub mod __exports {
-    pub use maplit::hashmap;
     pub use smallbox::smallbox;
 }


### PR DESCRIPTION
This should make sure that even if installed from crates.io, rustpython has access to the python standard library,
and it also allows access to the stdlib even when `-I` is passed, since the lib location is a `./configure` option
in CPython rather than it always assuming that PYTHONPATH will be set.