### PR TITLE
Separate IntoPyObject and IntoPyResult

### DIFF
--- a/derive/src/pyclass.rs
+++ b/derive/src/pyclass.rs
@@ -524,7 +524,7 @@ pub fn impl_pystruct_sequence(attr: AttributeArgs, item: Item) -> Result<TokenSt
                     vec![#(::rustpython_vm::pyobject::IntoPyObject::into_pyobject(
                         ::std::clone::Clone::clone(&self.#field_names),
                         vm,
-                    )?),*],
+                    )),*],
                 );
                 ::rustpython_vm::pyobject::PyValue::into_ref_with_type(tuple, vm, cls)
             }

--- a/vm/src/dictdatatype.rs
+++ b/vm/src/dictdatatype.rs
@@ -157,7 +157,7 @@ impl<T: Clone> Dict<T> {
                     hash_value,
                 } => {
                     // New key:
-                    self.unchecked_push(hash_index, hash_value, key.into_pyobject(vm)?, value);
+                    self.unchecked_push(hash_index, hash_value, key.into_pyobject(vm), value);
                     break Ok(());
                 }
             }

--- a/vm/src/format.rs
+++ b/vm/src/format.rs
@@ -1,7 +1,7 @@
 use crate::exceptions::PyBaseExceptionRef;
 use crate::function::PyFuncArgs;
 use crate::obj::{objstr, objtype};
-use crate::pyobject::{IntoPyObject, ItemProtocol, PyObjectRef, PyResult, TypeProtocol};
+use crate::pyobject::{ItemProtocol, PyObjectRef, PyResult, TypeProtocol};
 use crate::vm::VirtualMachine;
 use itertools::{Itertools, PeekingNext};
 use num_bigint::{BigInt, Sign};
@@ -823,8 +823,7 @@ impl FormatString {
                                 argument = vm.get_attribute(argument, attribute.as_str())?;
                             }
                             FieldNamePart::Index(index) => {
-                                // TODO Implement DictKey for usize so we can pass index directly
-                                argument = argument.get_item(&index.into_pyobject(vm), vm)?;
+                                argument = argument.get_item(index, vm)?;
                             }
                             FieldNamePart::StringIndex(index) => {
                                 argument = argument.get_item(&index, vm)?;

--- a/vm/src/format.rs
+++ b/vm/src/format.rs
@@ -564,6 +564,7 @@ pub(crate) enum FormatParseError {
 }
 
 impl FormatParseError {
+    // TODO: IntoPyException
     pub fn into_pyobject(self, vm: &VirtualMachine) -> PyBaseExceptionRef {
         match self {
             FormatParseError::UnmatchedBracket => {
@@ -823,7 +824,7 @@ impl FormatString {
                             }
                             FieldNamePart::Index(index) => {
                                 // TODO Implement DictKey for usize so we can pass index directly
-                                argument = argument.get_item(&index.into_pyobject(vm)?, vm)?;
+                                argument = argument.get_item(&index.into_pyobject(vm), vm)?;
                             }
                             FieldNamePart::StringIndex(index) => {
                                 argument = argument.get_item(&index, vm)?;

--- a/vm/src/frame.rs
+++ b/vm/src/frame.rs
@@ -947,7 +947,7 @@ impl ExecutingFrame<'_> {
     fn execute_subscript(&mut self, vm: &VirtualMachine) -> FrameResult {
         let b_ref = self.pop_value();
         let a_ref = self.pop_value();
-        let value = a_ref.get_item(&b_ref, vm)?;
+        let value = a_ref.get_item(b_ref, vm)?;
         self.push_value(value);
         Ok(None)
     }
@@ -963,7 +963,7 @@ impl ExecutingFrame<'_> {
     fn execute_delete_subscript(&mut self, vm: &VirtualMachine) -> FrameResult {
         let idx = self.pop_value();
         let obj = self.pop_value();
-        obj.del_item(&idx, vm)?;
+        obj.del_item(idx, vm)?;
         Ok(None)
     }
 
@@ -987,7 +987,7 @@ impl ExecutingFrame<'_> {
                 })?;
                 for (key, value) in dict {
                     if for_call {
-                        if map_obj.contains_key(&key, vm) {
+                        if map_obj.contains_key(key.clone(), vm) {
                             let key_repr = vm.to_repr(&key)?;
                             let msg = format!(
                                 "got multiple values for keyword argument {}",

--- a/vm/src/obj/objbool.rs
+++ b/vm/src/obj/objbool.rs
@@ -13,8 +13,8 @@ use super::objstr::PyStringRef;
 use super::objtype;
 
 impl IntoPyObject for bool {
-    fn into_pyobject(self, vm: &VirtualMachine) -> PyResult {
-        Ok(vm.ctx.new_bool(self))
+    fn into_pyobject(self, vm: &VirtualMachine) -> PyObjectRef {
+        vm.ctx.new_bool(self)
     }
 }
 
@@ -112,7 +112,7 @@ impl PyBool {
 
     #[pymethod(name = "__ror__")]
     #[pymethod(magic)]
-    fn or(lhs: PyObjectRef, rhs: PyObjectRef, vm: &VirtualMachine) -> PyResult {
+    fn or(lhs: PyObjectRef, rhs: PyObjectRef, vm: &VirtualMachine) -> PyObjectRef {
         if objtype::isinstance(&lhs, &vm.ctx.types.bool_type)
             && objtype::isinstance(&rhs, &vm.ctx.types.bool_type)
         {
@@ -126,7 +126,7 @@ impl PyBool {
 
     #[pymethod(name = "__rand__")]
     #[pymethod(magic)]
-    fn and(lhs: PyObjectRef, rhs: PyObjectRef, vm: &VirtualMachine) -> PyResult {
+    fn and(lhs: PyObjectRef, rhs: PyObjectRef, vm: &VirtualMachine) -> PyObjectRef {
         if objtype::isinstance(&lhs, &vm.ctx.types.bool_type)
             && objtype::isinstance(&rhs, &vm.ctx.types.bool_type)
         {
@@ -140,7 +140,7 @@ impl PyBool {
 
     #[pymethod(name = "__rxor__")]
     #[pymethod(magic)]
-    fn xor(lhs: PyObjectRef, rhs: PyObjectRef, vm: &VirtualMachine) -> PyResult {
+    fn xor(lhs: PyObjectRef, rhs: PyObjectRef, vm: &VirtualMachine) -> PyObjectRef {
         if objtype::isinstance(&lhs, &vm.ctx.types.bool_type)
             && objtype::isinstance(&rhs, &vm.ctx.types.bool_type)
         {

--- a/vm/src/obj/objbytes.rs
+++ b/vm/src/obj/objbytes.rs
@@ -59,8 +59,8 @@ impl From<Vec<u8>> for PyBytes {
 }
 
 impl IntoPyObject for Vec<u8> {
-    fn into_pyobject(self, vm: &VirtualMachine) -> PyResult {
-        Ok(vm.ctx.new_bytes(self))
+    fn into_pyobject(self, vm: &VirtualMachine) -> PyObjectRef {
+        vm.ctx.new_bytes(self)
     }
 }
 

--- a/vm/src/obj/objcomplex.rs
+++ b/vm/src/obj/objcomplex.rs
@@ -32,8 +32,8 @@ impl PyValue for PyComplex {
 }
 
 impl IntoPyObject for Complex64 {
-    fn into_pyobject(self, vm: &VirtualMachine) -> PyResult {
-        Ok(vm.ctx.new_complex(self))
+    fn into_pyobject(self, vm: &VirtualMachine) -> PyObjectRef {
+        vm.ctx.new_complex(self)
     }
 }
 
@@ -81,10 +81,10 @@ impl PyComplex {
     where
         F: Fn(Complex64, Complex64) -> Complex64,
     {
-        try_complex(&other, vm)?.map_or_else(
-            || Ok(vm.ctx.not_implemented()),
+        Ok(try_complex(&other, vm)?.map_or_else(
+            || vm.ctx.not_implemented(),
             |other| op(self.value, other).into_pyobject(vm),
-        )
+        ))
     }
 
     #[pymethod(name = "__add__")]

--- a/vm/src/obj/objdict.rs
+++ b/vm/src/obj/objdict.rs
@@ -282,7 +282,7 @@ impl PyDictRef {
 
         if let Some(method_or_err) = vm.get_method(self.clone().into_object(), "__missing__") {
             let method = method_or_err?;
-            Ok(Some(vm.invoke(&method, vec![key.into_pyobject(vm)?])?))
+            Ok(Some(vm.invoke(&method, vec![key.into_pyobject(vm)])?))
         } else {
             Ok(None)
         }
@@ -419,7 +419,7 @@ impl PyDictRef {
     }
 
     pub fn contains_key<T: IntoPyObject>(&self, key: T, vm: &VirtualMachine) -> bool {
-        let key = key.into_pyobject(vm).unwrap();
+        let key = key.into_pyobject(vm);
         self.entries.contains(vm, &key).unwrap()
     }
 

--- a/vm/src/obj/objdict.rs
+++ b/vm/src/obj/objdict.rs
@@ -75,7 +75,7 @@ impl PyDictRef {
             } else if let Some(keys) = vm.get_method(dict_obj.clone(), "keys") {
                 let keys = objiter::get_iter(vm, &vm.invoke(&keys?, vec![])?)?;
                 while let Some(key) = objiter::get_next_object(vm, &keys)? {
-                    let val = dict_obj.get_item(&key, vm)?;
+                    let val = dict_obj.get_item(key.clone(), vm)?;
                     dict.insert(vm, key, val)?;
                 }
             } else {

--- a/vm/src/obj/objfloat.rs
+++ b/vm/src/obj/objfloat.rs
@@ -10,8 +10,8 @@ use super::objtype::PyClassRef;
 use crate::format::FormatSpec;
 use crate::function::{OptionalArg, OptionalOption};
 use crate::pyobject::{
-    IntoPyObject, PyArithmaticValue::*, PyClassImpl, PyComparisonValue, PyContext, PyObjectRef,
-    PyRef, PyResult, PyValue, TryFromObject, TypeProtocol,
+    IntoPyObject, IntoPyResult, PyArithmaticValue::*, PyClassImpl, PyComparisonValue, PyContext,
+    PyObjectRef, PyRef, PyResult, PyValue, TryFromObject, TypeProtocol,
 };
 use crate::vm::VirtualMachine;
 use rustpython_common::{float_ops, hash};
@@ -36,13 +36,13 @@ impl PyValue for PyFloat {
 }
 
 impl IntoPyObject for f64 {
-    fn into_pyobject(self, vm: &VirtualMachine) -> PyResult {
-        Ok(vm.ctx.new_float(self))
+    fn into_pyobject(self, vm: &VirtualMachine) -> PyObjectRef {
+        vm.ctx.new_float(self)
     }
 }
 impl IntoPyObject for f32 {
-    fn into_pyobject(self, vm: &VirtualMachine) -> PyResult {
-        Ok(vm.ctx.new_float(f64::from(self)))
+    fn into_pyobject(self, vm: &VirtualMachine) -> PyObjectRef {
+        vm.ctx.new_float(f64::from(self))
     }
 }
 
@@ -142,9 +142,9 @@ pub fn float_pow(v1: f64, v2: f64, vm: &VirtualMachine) -> PyResult {
     } else if v1.is_sign_negative() && (v2.floor() - v2).abs() > f64::EPSILON {
         let v1 = Complex64::new(v1, 0.);
         let v2 = Complex64::new(v2, 0.);
-        v1.powc(v2).into_pyobject(vm)
+        Ok(v1.powc(v2).into_pyobject(vm))
     } else {
-        v1.powf(v2).into_pyobject(vm)
+        Ok(v1.powf(v2).into_pyobject(vm))
     }
 }
 
@@ -259,7 +259,7 @@ impl PyFloat {
     {
         try_float(&other, vm)?.map_or_else(
             || Ok(vm.ctx.not_implemented()),
-            |other| op(self.value, other).into_pyobject(vm),
+            |other| op(self.value, other).into_pyresult(vm),
         )
     }
 
@@ -270,7 +270,7 @@ impl PyFloat {
     {
         try_float(&other, vm)?.map_or_else(
             || Ok(vm.ctx.not_implemented()),
-            |other| op(self.value, other).into_pyobject(vm),
+            |other| op(self.value, other).into_pyresult(vm),
         )
     }
 

--- a/vm/src/obj/objint.rs
+++ b/vm/src/obj/objint.rs
@@ -16,8 +16,8 @@ use crate::bytesinner::PyBytesInner;
 use crate::format::FormatSpec;
 use crate::function::{OptionalArg, PyFuncArgs};
 use crate::pyobject::{
-    IdProtocol, IntoPyObject, PyArithmaticValue, PyClassImpl, PyComparisonValue, PyContext,
-    PyObjectRef, PyRef, PyResult, PyValue, TryFromObject, TypeProtocol,
+    IdProtocol, IntoPyObject, IntoPyResult, PyArithmaticValue, PyClassImpl, PyComparisonValue,
+    PyContext, PyObjectRef, PyRef, PyResult, PyValue, TryFromObject, TypeProtocol,
 };
 use crate::stdlib::array::PyArray;
 use crate::vm::VirtualMachine;
@@ -62,8 +62,8 @@ impl PyInt {
 }
 
 impl IntoPyObject for BigInt {
-    fn into_pyobject(self, vm: &VirtualMachine) -> PyResult {
-        Ok(vm.ctx.new_int(self))
+    fn into_pyobject(self, vm: &VirtualMachine) -> PyObjectRef {
+        vm.ctx.new_int(self)
     }
 }
 
@@ -76,8 +76,8 @@ impl PyValue for PyInt {
 macro_rules! impl_into_pyobject_int {
     ($($t:ty)*) => {$(
         impl IntoPyObject for $t {
-            fn into_pyobject(self, vm: &VirtualMachine) -> PyResult {
-                Ok(vm.ctx.new_int(self))
+            fn into_pyobject(self, vm: &VirtualMachine) -> PyObjectRef {
+                vm.ctx.new_int(self)
             }
         }
     )*};
@@ -121,7 +121,7 @@ fn inner_pow(int1: &BigInt, int2: &BigInt, vm: &VirtualMachine) -> PyResult {
     if int2.is_negative() {
         let v1 = try_float(int1, vm)?;
         let v2 = try_float(int2, vm)?;
-        objfloat::float_pow(v1, v2, vm).into_pyobject(vm)
+        objfloat::float_pow(v1, v2, vm).into_pyresult(vm)
     } else {
         Ok(if let Some(v2) = int2.to_u64() {
             vm.ctx.new_int(Pow::pow(int1, v2))

--- a/vm/src/obj/objmappingproxy.rs
+++ b/vm/src/obj/objmappingproxy.rs
@@ -50,7 +50,7 @@ impl PyMappingProxy {
                 let key = PyStringRef::try_from_object(vm, key)?;
                 class.get_attr(key.as_str())
             }
-            MappingProxyInner::Dict(obj) => obj.get_item(&key, vm).ok(),
+            MappingProxyInner::Dict(obj) => obj.get_item(key, vm).ok(),
         };
         Ok(opt)
     }

--- a/vm/src/obj/objmemory.rs
+++ b/vm/src/obj/objmemory.rs
@@ -60,7 +60,7 @@ impl PyMemoryView {
 
     #[pymethod(name = "__getitem__")]
     fn getitem(&self, needle: PyObjectRef, vm: &VirtualMachine) -> PyResult {
-        self.obj_ref.get_item(&needle, vm)
+        self.obj_ref.get_item(needle, vm)
     }
 
     #[pymethod(magic)]

--- a/vm/src/obj/objnone.rs
+++ b/vm/src/obj/objnone.rs
@@ -18,16 +18,16 @@ impl PyValue for PyNone {
 // This allows a built-in function to not return a value, mapping to
 // Python's behavior of returning `None` in this situation.
 impl IntoPyObject for () {
-    fn into_pyobject(self, vm: &VirtualMachine) -> PyResult {
-        Ok(vm.ctx.none())
+    fn into_pyobject(self, vm: &VirtualMachine) -> PyObjectRef {
+        vm.ctx.none()
     }
 }
 
 impl<T: IntoPyObject> IntoPyObject for Option<T> {
-    fn into_pyobject(self, vm: &VirtualMachine) -> PyResult {
+    fn into_pyobject(self, vm: &VirtualMachine) -> PyObjectRef {
         match self {
             Some(x) => x.into_pyobject(vm),
-            None => Ok(vm.ctx.none()),
+            None => vm.ctx.none(),
         }
     }
 }

--- a/vm/src/obj/objstr.rs
+++ b/vm/src/obj/objstr.rs
@@ -953,7 +953,7 @@ impl PyString {
 
         let mut translated = String::new();
         for c in self.value.chars() {
-            match table.get_item(&(c as u32).into_pyobject(vm), vm) {
+            match table.get_item((c as u32).into_pyobject(vm), vm) {
                 Ok(value) => {
                     if let Some(text) = value.payload::<PyString>() {
                         translated.push_str(&text.value);

--- a/vm/src/obj/objstr.rs
+++ b/vm/src/obj/objstr.rs
@@ -953,7 +953,7 @@ impl PyString {
 
         let mut translated = String::new();
         for c in self.value.chars() {
-            match table.get_item(&(c as u32).into_pyobject(vm)?, vm) {
+            match table.get_item(&(c as u32).into_pyobject(vm), vm) {
                 Ok(value) => {
                     if let Some(text) = value.payload::<PyString>() {
                         translated.push_str(&text.value);
@@ -1000,7 +1000,7 @@ impl PyString {
                                 new_dict.set_item(vm.new_int(c as u32), vm.get_none(), vm)?;
                             }
                         }
-                        new_dict.into_pyobject(vm)
+                        Ok(new_dict.into_pyobject(vm))
                     } else {
                         Err(vm.new_value_error(
                             "the first two maketrans arguments must have equal length".to_owned(),
@@ -1019,14 +1019,14 @@ impl PyString {
                     for (key, val) in dict {
                         if let Some(num) = key.payload::<PyInt>() {
                             new_dict.set_item(
-                                num.as_bigint().to_i32().into_pyobject(vm)?,
+                                num.as_bigint().to_i32().into_pyobject(vm),
                                 val,
                                 vm,
                             )?;
                         } else if let Some(string) = key.payload::<PyString>() {
                             if string.len() == 1 {
                                 let num_value = string.value.chars().next().unwrap() as u32;
-                                new_dict.set_item(num_value.into_pyobject(vm)?, val, vm)?;
+                                new_dict.set_item(num_value.into_pyobject(vm), val, vm)?;
                             } else {
                                 return Err(vm.new_value_error(
                                     "string keys in translate table must be of length 1".to_owned(),
@@ -1034,7 +1034,7 @@ impl PyString {
                             }
                         }
                     }
-                    new_dict.into_pyobject(vm)
+                    Ok(new_dict.into_pyobject(vm))
                 }
                 _ => Err(vm.new_value_error(
                     "if you give only one argument to maketrans it must be a dict".to_owned(),
@@ -1100,20 +1100,20 @@ impl PyValue for PyString {
 }
 
 impl IntoPyObject for String {
-    fn into_pyobject(self, vm: &VirtualMachine) -> PyResult {
-        Ok(vm.ctx.new_str(self))
+    fn into_pyobject(self, vm: &VirtualMachine) -> PyObjectRef {
+        vm.ctx.new_str(self)
     }
 }
 
 impl IntoPyObject for &str {
-    fn into_pyobject(self, vm: &VirtualMachine) -> PyResult {
-        Ok(vm.ctx.new_str(self.to_owned()))
+    fn into_pyobject(self, vm: &VirtualMachine) -> PyObjectRef {
+        vm.ctx.new_str(self.to_owned())
     }
 }
 
 impl IntoPyObject for &String {
-    fn into_pyobject(self, vm: &VirtualMachine) -> PyResult {
-        Ok(vm.ctx.new_str(self.clone()))
+    fn into_pyobject(self, vm: &VirtualMachine) -> PyObjectRef {
+        vm.ctx.new_str(self.clone())
     }
 }
 

--- a/vm/src/obj/objtuple.rs
+++ b/vm/src/obj/objtuple.rs
@@ -45,8 +45,8 @@ impl PyValue for PyTuple {
 macro_rules! impl_intopyobj_tuple {
     ($(($T:ident, $idx:tt)),+) => {
         impl<$($T: IntoPyObject),*> IntoPyObject for ($($T,)*) {
-            fn into_pyobject(self, vm: &VirtualMachine) -> PyResult {
-                Ok(vm.ctx.new_tuple(vec![$(self.$idx.into_pyobject(vm)?),*]))
+            fn into_pyobject(self, vm: &VirtualMachine) -> PyObjectRef {
+                vm.ctx.new_tuple(vec![$(self.$idx.into_pyobject(vm)),*])
             }
         }
     };

--- a/vm/src/pyobject.rs
+++ b/vm/src/pyobject.rs
@@ -965,15 +965,15 @@ where
     T: IntoPyObject,
 {
     fn get_item(&self, key: T, vm: &VirtualMachine) -> PyResult {
-        vm.call_method(self, "__getitem__", key.into_pyobject(vm)?)
+        vm.call_method(self, "__getitem__", key.into_pyobject(vm))
     }
 
     fn set_item(&self, key: T, value: PyObjectRef, vm: &VirtualMachine) -> PyResult {
-        vm.call_method(self, "__setitem__", vec![key.into_pyobject(vm)?, value])
+        vm.call_method(self, "__setitem__", vec![key.into_pyobject(vm), value])
     }
 
     fn del_item(&self, key: T, vm: &VirtualMachine) -> PyResult {
-        vm.call_method(self, "__delitem__", key.into_pyobject(vm)?)
+        vm.call_method(self, "__delitem__", key.into_pyobject(vm))
     }
 }
 
@@ -1151,45 +1151,36 @@ pub trait TryFromObject: Sized {
 /// and should be implemented by many primitive Rust types, allowing a built-in
 /// function to simply return a `bool` or a `usize` for example.
 pub trait IntoPyObject {
-    fn into_pyobject(self, vm: &VirtualMachine) -> PyResult;
+    fn into_pyobject(self, vm: &VirtualMachine) -> PyObjectRef;
 }
 
 impl<T> IntoPyObject for PyRef<T> {
-    fn into_pyobject(self, _vm: &VirtualMachine) -> PyResult {
-        Ok(self.obj)
+    fn into_pyobject(self, _vm: &VirtualMachine) -> PyObjectRef {
+        self.obj
     }
 }
 
 impl<T> IntoPyObject for &PyRef<T> {
-    fn into_pyobject(self, _vm: &VirtualMachine) -> PyResult {
-        Ok(self.obj.clone())
+    fn into_pyobject(self, _vm: &VirtualMachine) -> PyObjectRef {
+        self.obj.clone()
     }
 }
 
 impl IntoPyObject for PyCallable {
-    fn into_pyobject(self, _vm: &VirtualMachine) -> PyResult {
-        Ok(self.into_object())
+    fn into_pyobject(self, _vm: &VirtualMachine) -> PyObjectRef {
+        self.into_object()
     }
 }
 
 impl IntoPyObject for PyObjectRef {
-    fn into_pyobject(self, _vm: &VirtualMachine) -> PyResult {
-        Ok(self)
+    fn into_pyobject(self, _vm: &VirtualMachine) -> PyObjectRef {
+        self
     }
 }
 
 impl IntoPyObject for &PyObjectRef {
-    fn into_pyobject(self, _vm: &VirtualMachine) -> PyResult {
-        Ok(self.clone())
-    }
-}
-
-impl<T> IntoPyObject for PyResult<T>
-where
-    T: IntoPyObject,
-{
-    fn into_pyobject(self, vm: &VirtualMachine) -> PyResult {
-        self.and_then(|res| T::into_pyobject(res, vm))
+    fn into_pyobject(self, _vm: &VirtualMachine) -> PyObjectRef {
+        self.clone()
     }
 }
 
@@ -1199,8 +1190,30 @@ impl<T> IntoPyObject for T
 where
     T: PyValue + Sized,
 {
-    fn into_pyobject(self, vm: &VirtualMachine) -> PyResult {
-        Ok(PyObject::new(self, T::class(vm), None))
+    fn into_pyobject(self, vm: &VirtualMachine) -> PyObjectRef {
+        PyObject::new(self, T::class(vm), None)
+    }
+}
+
+pub trait IntoPyResult {
+    fn into_pyresult(self, vm: &VirtualMachine) -> PyResult;
+}
+
+impl<T> IntoPyResult for T
+where
+    T: IntoPyObject,
+{
+    fn into_pyresult(self, vm: &VirtualMachine) -> PyResult {
+        Ok(self.into_pyobject(vm))
+    }
+}
+
+impl<T> IntoPyResult for PyResult<T>
+where
+    T: IntoPyObject,
+{
+    fn into_pyresult(self, vm: &VirtualMachine) -> PyResult {
+        self.map(|res| T::into_pyobject(res, vm))
     }
 }
 
@@ -1434,10 +1447,10 @@ impl<T> IntoPyObject for PyArithmaticValue<T>
 where
     T: IntoPyObject,
 {
-    fn into_pyobject(self, vm: &VirtualMachine) -> PyResult {
+    fn into_pyobject(self, vm: &VirtualMachine) -> PyObjectRef {
         match self {
             PyArithmaticValue::Implemented(v) => v.into_pyobject(vm),
-            PyArithmaticValue::NotImplemented => Ok(vm.ctx.not_implemented()),
+            PyArithmaticValue::NotImplemented => vm.ctx.not_implemented(),
         }
     }
 }

--- a/vm/src/pyobject.rs
+++ b/vm/src/pyobject.rs
@@ -1160,12 +1160,6 @@ impl<T> IntoPyObject for PyRef<T> {
     }
 }
 
-impl<T> IntoPyObject for &PyRef<T> {
-    fn into_pyobject(self, _vm: &VirtualMachine) -> PyObjectRef {
-        self.obj.clone()
-    }
-}
-
 impl IntoPyObject for PyCallable {
     fn into_pyobject(self, _vm: &VirtualMachine) -> PyObjectRef {
         self.into_object()
@@ -1175,12 +1169,6 @@ impl IntoPyObject for PyCallable {
 impl IntoPyObject for PyObjectRef {
     fn into_pyobject(self, _vm: &VirtualMachine) -> PyObjectRef {
         self
-    }
-}
-
-impl IntoPyObject for &PyObjectRef {
-    fn into_pyobject(self, _vm: &VirtualMachine) -> PyObjectRef {
-        self.clone()
     }
 }
 

--- a/vm/src/stdlib/csv.rs
+++ b/vm/src/stdlib/csv.rs
@@ -68,7 +68,7 @@ pub fn build_reader(
 ) -> PyResult {
     let config = ReaderOption::new(args, vm)?;
 
-    Reader::new(iterable, config).into_ref(vm).into_pyobject(vm)
+    Ok(Reader::new(iterable, config).into_ref(vm).into_pyobject(vm))
 }
 
 fn into_strings(iterable: &PyIterable<PyObjectRef>, vm: &VirtualMachine) -> PyResult<Vec<String>> {
@@ -152,7 +152,7 @@ impl Reader {
     #[pymethod(name = "__iter__")]
     fn iter(this: PyRef<Self>, vm: &VirtualMachine) -> PyResult {
         this.state.write().cast_to_reader(vm)?;
-        this.into_pyobject(vm)
+        Ok(this.into_pyobject(vm))
     }
 
     #[pymethod(name = "__next__")]
@@ -167,7 +167,7 @@ impl Reader {
                         let iter = records
                             .into_iter()
                             .map(|bytes| bytes.into_pyobject(vm))
-                            .collect::<PyResult<Vec<_>>>()?;
+                            .collect::<Vec<_>>();
                         Ok(vm.ctx.new_list(iter))
                     }
                     Err(_err) => {

--- a/vm/src/stdlib/socket.rs
+++ b/vm/src/stdlib/socket.rs
@@ -551,7 +551,7 @@ fn socket_getaddrinfo(opts: GAIOptions, vm: &VirtualMachine) -> PyResult {
                         Some(s) => vm.new_str(s),
                         None => vm.get_none(),
                     },
-                    get_addr_tuple(ai.sockaddr).into_pyobject(vm).unwrap(),
+                    get_addr_tuple(ai.sockaddr).into_pyobject(vm),
                 ])
             })
         })

--- a/vm/src/stdlib/ssl.rs
+++ b/vm/src/stdlib/ssl.rs
@@ -770,7 +770,7 @@ pub fn make_module(vm: &VirtualMachine) -> PyObjectRef {
         // Constants
         "OPENSSL_VERSION" => ctx.new_str(openssl::version::version().to_owned()),
         "OPENSSL_VERSION_NUMBER" => ctx.new_int(openssl::version::number()),
-        "OPENSSL_VERSION_INFO" => parse_version_info(openssl::version::number()).into_pyobject(vm).unwrap(),
+        "OPENSSL_VERSION_INFO" => parse_version_info(openssl::version::number()).into_pyobject(vm),
         "PROTOCOL_SSLv2" => ctx.new_int(SslVersion::Ssl2 as u32),
         "PROTOCOL_SSLv3" => ctx.new_int(SslVersion::Ssl3 as u32),
         "PROTOCOL_SSLv23" => ctx.new_int(SslVersion::Tls as u32),

--- a/vm/src/stdlib/string.rs
+++ b/vm/src/stdlib/string.rs
@@ -21,7 +21,7 @@ mod _string {
         format_spec: Option<String>,
         preconversion_spec: Option<char>,
         vm: &VirtualMachine,
-    ) -> PyResult {
+    ) -> PyObjectRef {
         let tuple = (
             literal,
             field_name,
@@ -51,7 +51,7 @@ mod _string {
                         Some(format_spec),
                         preconversion_spec,
                         vm,
-                    )?);
+                    ));
                 }
                 FormatPart::Literal(text) => literal.push_str(&text),
             }
@@ -63,7 +63,7 @@ mod _string {
                 None,
                 None,
                 vm,
-            )?);
+            ));
         }
         Ok(result.into())
     }
@@ -77,17 +77,17 @@ mod _string {
 
         let first = match field_name.field_type {
             FieldType::Auto => vm.new_str("".to_owned()),
-            FieldType::Index(index) => index.into_pyobject(vm)?,
-            FieldType::Keyword(attribute) => attribute.into_pyobject(vm)?,
+            FieldType::Index(index) => index.into_pyobject(vm),
+            FieldType::Keyword(attribute) => attribute.into_pyobject(vm),
         };
 
         let rest = field_name
             .parts
             .iter()
             .map(|p| match p {
-                FieldNamePart::Attribute(attribute) => (true, attribute).into_pyobject(vm).unwrap(),
-                FieldNamePart::StringIndex(index) => (false, index).into_pyobject(vm).unwrap(),
-                FieldNamePart::Index(index) => (false, *index).into_pyobject(vm).unwrap(),
+                FieldNamePart::Attribute(attribute) => (true, attribute).into_pyobject(vm),
+                FieldNamePart::StringIndex(index) => (false, index).into_pyobject(vm),
+                FieldNamePart::Index(index) => (false, *index).into_pyobject(vm),
             })
             .collect();
 

--- a/vm/src/sysmodule.rs
+++ b/vm/src/sysmodule.rs
@@ -576,12 +576,8 @@ settrace() -- set the global debug tracing function
     module_names.push("sys".to_owned());
     module_names.push("builtins".to_owned());
     module_names.sort();
-    let builtin_module_names = ctx.new_tuple(
-        module_names
-            .iter()
-            .map(|v| v.into_pyobject(vm).unwrap())
-            .collect(),
-    );
+    let builtin_module_names =
+        ctx.new_tuple(module_names.iter().map(|v| v.into_pyobject(vm)).collect());
     let modules = ctx.new_dict();
 
     let prefix = option_env!("RUSTPYTHON_PREFIX").unwrap_or("/usr/local");


### PR DESCRIPTION
This separation removes a lot of unnessessary unwrapping.