### PR TITLE
Fix objtuple.tp_new so that return cloned when a parameter is tuple

### DIFF
--- a/Lib/test/test_tuple.py
+++ b/Lib/test/test_tuple.py
@@ -26,8 +26,6 @@ class TupleTest(seq_tests.CommonTest):
         with self.assertRaisesRegex(TypeError, msg):
             t['a']
 
-    # TODO: RUSTPYTHON
-    @unittest.expectedFailure
     def test_constructors(self):
         super().test_constructors()
         # calling built-in types without argument must return empty

--- a/vm/src/obj/objtuple.rs
+++ b/vm/src/obj/objtuple.rs
@@ -6,9 +6,9 @@ use super::objsequence::get_item;
 use super::objtype::PyClassRef;
 use crate::function::OptionalArg;
 use crate::pyobject::{
-    self, BorrowValue, IntoPyObject,
+    self, BorrowValue, IdProtocol, IntoPyObject,
     PyArithmaticValue::{self, *},
-    PyClassImpl, PyComparisonValue, PyContext, PyObjectRef, PyRef, PyResult, PyValue,
+    PyClassImpl, PyComparisonValue, PyContext, PyObjectRef, PyRef, PyResult, PyValue, TypeProtocol,
 };
 use crate::sequence::{self, SimpleSeq};
 use crate::vm::{ReprGuard, VirtualMachine};
@@ -238,6 +238,10 @@ impl PyTuple {
         vm: &VirtualMachine,
     ) -> PyResult<PyTupleRef> {
         let elements = if let OptionalArg::Present(iterable) = iterable {
+            if iterable.lease_class().is(&cls) {
+                return Ok(PyRef::from_obj_unchecked(iterable));
+            }
+
             vm.extract_elements(&iterable)?
         } else {
             vec![]


### PR DESCRIPTION
Fix `objtuple.rs` `fn tp_new()` so that return cloned object when a parameter is tuple object.

```python
# test_tuple.py
def test_constructors(self):
    t0_3 = (0, 1, 2, 3)
    t0_3_bis = tuple(t0_3)
    self.assertTrue(t0_3 is t0_3_bis) # to pass this test
```