### PR TITLE
Unified value borrow interface for PyValue

### DIFF
--- a/derive/src/pyclass.rs
+++ b/derive/src/pyclass.rs
@@ -530,10 +530,11 @@ pub fn impl_pystruct_sequence(attr: AttributeArgs, item: Item) -> Result<TokenSt
             }
 
             fn repr(zelf: rustpython_vm::pyobject::PyRef<rustpython_vm::obj::objtuple::PyTuple>, vm: &rustpython_vm::VirtualMachine) -> ::rustpython_vm::pyobject::PyResult<String> {
+                use rustpython_vm::pyobject::BorrowValue;
                 let s = if let Some(_guard) = rustpython_vm::vm::ReprGuard::enter(zelf.as_object()) {
                         let field_names = vec![#(stringify!(#field_names)),*];
                         let mut fields = Vec::new();
-                        for (value, field_name) in zelf.as_slice().iter().zip(field_names.iter()) {
+                        for (value, field_name) in zelf.borrow_value().iter().zip(field_names.iter()) {
                                 let s = vm.to_repr(value)?;
                                 fields.push(format!("{}: {}", field_name, s));
                         }

--- a/src/main.rs
+++ b/src/main.rs
@@ -10,7 +10,7 @@ use rustpython_vm::{
     exceptions::print_exception,
     match_class,
     obj::{objint::PyInt, objtype},
-    pyobject::{ItemProtocol, PyResult},
+    pyobject::{BorrowValue, ItemProtocol, PyResult},
     scope::Scope,
     util, InitParameter, PySettings, VirtualMachine,
 };
@@ -57,7 +57,7 @@ fn main() {
                 1 => match_class!(match args.as_slice()[0].clone() {
                     i @ PyInt => {
                         use num_traits::cast::ToPrimitive;
-                        process::exit(i.as_bigint().to_i32().unwrap_or(0));
+                        process::exit(i.borrow_value().to_i32().unwrap_or(0));
                     }
                     arg => {
                         if vm.is_none(&arg) {

--- a/src/main.rs
+++ b/src/main.rs
@@ -52,9 +52,9 @@ fn main() {
     if let Err(err) = res {
         if objtype::isinstance(&err, &vm.ctx.exceptions.system_exit) {
             let args = err.args();
-            match args.as_slice().len() {
+            match args.borrow_value().len() {
                 0 => return,
-                1 => match_class!(match args.as_slice()[0].clone() {
+                1 => match_class!(match args.borrow_value()[0].clone() {
                     i @ PyInt => {
                         use num_traits::cast::ToPrimitive;
                         process::exit(i.borrow_value().to_i32().unwrap_or(0));

--- a/src/shell.rs
+++ b/src/shell.rs
@@ -6,7 +6,7 @@ use rustpython_vm::readline::{Readline, ReadlineResult};
 use rustpython_vm::{
     exceptions::{print_exception, PyBaseExceptionRef},
     obj::objtype,
-    pyobject::PyResult,
+    pyobject::{BorrowValue, PyResult},
     scope::Scope,
     VirtualMachine,
 };
@@ -61,7 +61,7 @@ pub fn run_shell(vm: &VirtualMachine, scope: Scope) -> PyResult<()> {
             .get_attribute(vm.sys_module.clone(), prompt_name)
             .and_then(|prompt| vm.to_str(&prompt));
         let prompt = match prompt {
-            Ok(ref s) => s.as_str(),
+            Ok(ref s) => s.borrow_value(),
             Err(_) => "",
         };
         let result = match repl.readline(prompt) {

--- a/src/shell/helper.rs
+++ b/src/shell/helper.rs
@@ -1,5 +1,5 @@
 use rustpython_vm::obj::objstr::PyStringRef;
-use rustpython_vm::pyobject::{PyIterable, PyResult, TryFromObject};
+use rustpython_vm::pyobject::{BorrowValue, PyIterable, PyResult, TryFromObject};
 use rustpython_vm::scope::{NameProtocol, Scope};
 use rustpython_vm::VirtualMachine;
 
@@ -104,7 +104,7 @@ impl<'vm> ShellHelper<'vm> {
             .filter(|res| {
                 res.as_ref()
                     .ok()
-                    .map_or(true, |s| s.as_str().starts_with(word_start))
+                    .map_or(true, |s| s.borrow_value().starts_with(word_start))
             })
             .collect::<Result<Vec<_>, _>>()
             .ok()?;
@@ -117,7 +117,7 @@ impl<'vm> ShellHelper<'vm> {
             let no_underscore = all_completions
                 .iter()
                 .cloned()
-                .filter(|s| !s.as_str().starts_with('_'))
+                .filter(|s| !s.borrow_value().starts_with('_'))
                 .collect::<Vec<_>>();
 
             // if there are only completions that start with a '_', give them all of the
@@ -130,13 +130,13 @@ impl<'vm> ShellHelper<'vm> {
         };
 
         // sort the completions alphabetically
-        completions.sort_by(|a, b| std::cmp::Ord::cmp(a.as_str(), b.as_str()));
+        completions.sort_by(|a, b| std::cmp::Ord::cmp(a.borrow_value(), b.borrow_value()));
 
         Some((
             startpos,
             completions
                 .into_iter()
-                .map(|s| s.as_str().to_owned())
+                .map(|s| s.borrow_value().to_owned())
                 .collect(),
         ))
     }

--- a/vm/src/builtins.rs
+++ b/vm/src/builtins.rs
@@ -28,8 +28,8 @@ mod decl {
     use crate::obj::objstr::{PyString, PyStringRef};
     use crate::obj::objtype::{self, PyClassRef};
     use crate::pyobject::{
-        Either, IdProtocol, ItemProtocol, PyCallable, PyIterable, PyObjectRef, PyResult, PyValue,
-        TryFromObject, TypeProtocol,
+        BorrowValue, Either, IdProtocol, ItemProtocol, PyCallable, PyIterable, PyObjectRef,
+        PyResult, PyValue, TryFromObject, TypeProtocol,
     };
     use crate::readline::{Readline, ReadlineResult};
     use crate::scope::Scope;
@@ -76,7 +76,7 @@ mod decl {
 
     #[pyfunction]
     fn bin(x: PyIntRef) -> String {
-        let x = x.as_bigint();
+        let x = x.borrow_value();
         if x.is_negative() {
             format!("-0b{:b}", x.abs())
         } else {
@@ -338,7 +338,7 @@ mod decl {
 
     #[pyfunction]
     fn hex(number: PyIntRef, vm: &VirtualMachine) -> PyResult {
-        let n = number.as_bigint();
+        let n = number.borrow_value();
         let s = if n.is_negative() {
             format!("-0x{:x}", -n)
         } else {
@@ -544,7 +544,7 @@ mod decl {
 
     #[pyfunction]
     fn oct(number: PyIntRef, vm: &VirtualMachine) -> PyResult {
-        let n = number.as_bigint();
+        let n = number.borrow_value();
         let s = if n.is_negative() {
             format!("-0o{:o}", n.abs())
         } else {
@@ -616,7 +616,7 @@ mod decl {
                             .to_owned(),
                     ));
                 }
-                let m = m.as_bigint();
+                let m = m.borrow_value();
                 if m.is_zero() {
                     return Err(vm.new_value_error("pow() 3rd argument cannot be 0".to_owned()));
                 }

--- a/vm/src/bytesinner.rs
+++ b/vm/src/bytesinner.rs
@@ -37,7 +37,7 @@ impl TryFromObject for PyBytesInner {
     fn try_from_object(vm: &VirtualMachine, obj: PyObjectRef) -> PyResult<Self> {
         match_class!(match obj {
             i @ PyBytes => Ok(PyBytesInner {
-                elements: i.get_value().to_vec()
+                elements: i.borrow_value().to_vec()
             }),
             j @ PyByteArray => Ok(PyBytesInner {
                 elements: j.borrow_value().elements.to_vec()
@@ -75,7 +75,7 @@ impl ByteInnerNewOptions {
                 if let Ok(input) = eval.downcast::<PyString>() {
                     let bytes = objstr::encode_string(input, Some(enc), None, vm)?;
                     Ok(PyBytesInner {
-                        elements: bytes.get_value().to_vec(),
+                        elements: bytes.borrow_value().to_vec(),
                     })
                 } else {
                     Err(vm.new_type_error("encoding without a string argument".to_owned()))
@@ -108,7 +108,7 @@ impl ByteInnerNewOptions {
                             vm.new_type_error("string argument without an encoding".to_owned())
                         );
                     }
-                    i @ PyBytes => Ok(i.get_value().to_vec()),
+                    i @ PyBytes => Ok(i.borrow_value().to_vec()),
                     j @ PyByteArray => Ok(j.borrow_value().elements.to_vec()),
                     obj => {
                         // TODO: only support this method in the bytes() constructor
@@ -1140,7 +1140,7 @@ where
     F: Fn(&[u8]) -> R,
 {
     match_class!(match obj {
-        i @ PyBytes => Some(f(i.get_value())),
+        i @ PyBytes => Some(f(i.borrow_value())),
         j @ PyByteArray => Some(f(&j.borrow_value().elements)),
         _ => None,
     })

--- a/vm/src/byteslike.rs
+++ b/vm/src/byteslike.rs
@@ -1,7 +1,7 @@
 use crate::obj::objbytearray::{PyByteArray, PyByteArrayRef};
 use crate::obj::objbytes::{PyBytes, PyBytesRef};
 use crate::pyobject::PyObjectRef;
-use crate::pyobject::{PyResult, TryFromObject, TypeProtocol};
+use crate::pyobject::{BorrowValue, PyResult, TryFromObject, TypeProtocol};
 use crate::stdlib::array::{PyArray, PyArrayRef};
 use crate::vm::VirtualMachine;
 
@@ -41,7 +41,7 @@ impl PyBytesLike {
 
     pub fn to_cow(&self) -> std::borrow::Cow<[u8]> {
         match self {
-            PyBytesLike::Bytes(b) => b.get_value().into(),
+            PyBytesLike::Bytes(b) => b.borrow_value().into(),
             PyBytesLike::Bytearray(b) => b.borrow_value().elements.clone().into(),
             PyBytesLike::Array(array) => array.tobytes().into(),
         }
@@ -50,7 +50,7 @@ impl PyBytesLike {
     #[inline]
     pub fn with_ref<R>(&self, f: impl FnOnce(&[u8]) -> R) -> R {
         match self {
-            PyBytesLike::Bytes(b) => f(b.get_value()),
+            PyBytesLike::Bytes(b) => f(b.borrow_value()),
             PyBytesLike::Bytearray(b) => f(&b.borrow_value().elements),
             PyBytesLike::Array(array) => f(&*array.get_bytes()),
         }

--- a/vm/src/cformat.rs
+++ b/vm/src/cformat.rs
@@ -2,7 +2,9 @@
 /// [https://docs.python.org/3/library/stdtypes.html#printf-style-string-formatting]
 use crate::format::get_num_digits;
 use crate::obj::{objfloat, objint, objstr, objtuple, objtype};
-use crate::pyobject::{ItemProtocol, PyObjectRef, PyResult, TryFromObject, TypeProtocol};
+use crate::pyobject::{
+    BorrowValue, ItemProtocol, PyObjectRef, PyResult, TryFromObject, TypeProtocol,
+};
 use crate::vm::VirtualMachine;
 use num_bigint::{BigInt, Sign};
 use num_traits::cast::ToPrimitive;
@@ -295,7 +297,7 @@ impl CFormatSpec {
                         vm.call_method(&obj.clone(), "decode", vec![])?,
                     )?,
                 };
-                Ok(self.format_string(result.as_str().to_owned()))
+                Ok(self.format_string(result.borrow_value().to_owned()))
             }
             CFormatType::Number(number_type) => {
                 if !objtype::isinstance(&obj, &vm.ctx.types.int_type) {

--- a/vm/src/dictdatatype.rs
+++ b/vm/src/dictdatatype.rs
@@ -4,7 +4,7 @@
 /// And: http://code.activestate.com/recipes/578375/
 use crate::common::cell::{PyRwLock, PyRwLockReadGuard, PyRwLockWriteGuard};
 use crate::obj::objstr::{PyString, PyStringRef};
-use crate::pyobject::{IdProtocol, IntoPyObject, PyObjectRef, PyResult};
+use crate::pyobject::{BorrowValue, IdProtocol, IntoPyObject, PyObjectRef, PyResult};
 use crate::vm::VirtualMachine;
 use rustpython_common::hash;
 use std::collections::HashMap;
@@ -447,7 +447,7 @@ impl DictKey for PyStringRef {
         if self.is(other_key) {
             Ok(true)
         } else if let Some(py_str_value) = other_key.payload::<PyString>() {
-            Ok(py_str_value.as_str() == self.as_str())
+            Ok(py_str_value.borrow_value() == self.borrow_value())
         } else {
             vm.bool_eq(self.clone().into_object(), other_key.clone())
         }
@@ -472,7 +472,7 @@ impl DictKey for &str {
 
     fn key_eq(&self, vm: &VirtualMachine, other_key: &PyObjectRef) -> PyResult<bool> {
         if let Some(py_str_value) = other_key.payload::<PyString>() {
-            Ok(py_str_value.as_str() == *self)
+            Ok(py_str_value.borrow_value() == *self)
         } else {
             // Fall back to PyObjectRef implementation.
             let s = vm.ctx.new_str(*self);

--- a/vm/src/function.rs
+++ b/vm/src/function.rs
@@ -10,7 +10,7 @@ use crate::exceptions::PyBaseExceptionRef;
 use crate::obj::objtuple::PyTupleRef;
 use crate::obj::objtype::{isinstance, PyClassRef};
 use crate::pyobject::{
-    IntoPyResult, PyObjectRef, PyRef, PyResult, PyValue, TryFromObject, TypeProtocol,
+    BorrowValue, IntoPyResult, PyObjectRef, PyRef, PyResult, PyValue, TryFromObject, TypeProtocol,
 };
 use crate::vm::VirtualMachine;
 
@@ -620,7 +620,7 @@ where
                 Err(_) => {
                     let tuple = PyTupleRef::try_from_object(vm, obj.clone())
                         .map_err(|_| vm.new_type_error((self.message)(&obj)))?;
-                    for obj in tuple.as_slice().iter() {
+                    for obj in tuple.borrow_value().iter() {
                         if self.check(&obj, vm)? {
                             return Ok(true);
                         }

--- a/vm/src/macros.rs
+++ b/vm/src/macros.rs
@@ -116,13 +116,13 @@ macro_rules! py_namespace {
 /// use rustpython_vm::match_class;
 /// use rustpython_vm::obj::objfloat::PyFloat;
 /// use rustpython_vm::obj::objint::PyInt;
-/// use rustpython_vm::pyobject::PyValue;
+/// use rustpython_vm::pyobject::{PyValue, BorrowValue};
 ///
 /// let vm: VirtualMachine = Default::default();
 /// let obj = PyInt::from(0).into_ref(&vm).into_object();
 ///
 /// let int_value = match_class!(match obj {
-///     i @ PyInt => i.as_bigint().clone(),
+///     i @ PyInt => i.borrow_value().clone(),
 ///     f @ PyFloat => f.to_f64().to_bigint().unwrap(),
 ///     obj => panic!("non-numeric object {}", obj),
 /// });

--- a/vm/src/obj/objbool.rs
+++ b/vm/src/obj/objbool.rs
@@ -103,7 +103,7 @@ impl PyBool {
         format_spec: PyStringRef,
         vm: &VirtualMachine,
     ) -> PyResult<PyStringRef> {
-        if format_spec.as_str().is_empty() {
+        if format_spec.borrow_value().is_empty() {
             vm.to_str(&obj)
         } else {
             Err(vm.new_type_error("unsupported format string passed to bool.__format__".to_owned()))

--- a/vm/src/obj/objbool.rs
+++ b/vm/src/obj/objbool.rs
@@ -3,8 +3,8 @@ use num_traits::Zero;
 
 use crate::function::{OptionalArg, PyFuncArgs};
 use crate::pyobject::{
-    IdProtocol, IntoPyObject, PyClassImpl, PyContext, PyObjectRef, PyResult, TryFromObject,
-    TypeProtocol,
+    BorrowValue, IdProtocol, IntoPyObject, PyClassImpl, PyContext, PyObjectRef, PyResult,
+    TryFromObject, TypeProtocol,
 };
 use crate::vm::VirtualMachine;
 
@@ -59,7 +59,7 @@ pub fn boolval(vm: &VirtualMachine, obj: PyObjectRef) -> PyResult<bool> {
                 let bool_obj = vm.invoke(&method, PyFuncArgs::default())?;
                 match bool_obj.payload::<PyInt>() {
                     Some(int_obj) => {
-                        let len_val = int_obj.as_bigint();
+                        let len_val = int_obj.borrow_value();
                         if len_val.sign() == Sign::Minus {
                             return Err(
                                 vm.new_value_error("__len__() should return >= 0".to_owned())
@@ -185,7 +185,7 @@ pub fn not(vm: &VirtualMachine, obj: &PyObjectRef) -> PyResult<bool> {
 
 // Retrieve inner int value:
 pub fn get_value(obj: &PyObjectRef) -> bool {
-    !obj.payload::<PyInt>().unwrap().as_bigint().is_zero()
+    !obj.payload::<PyInt>().unwrap().borrow_value().is_zero()
 }
 
 pub fn get_py_int(obj: &PyObjectRef) -> &PyInt {

--- a/vm/src/obj/objbytearray.rs
+++ b/vm/src/obj/objbytearray.rs
@@ -16,8 +16,8 @@ use crate::bytesinner::{
 use crate::common::cell::{PyRwLock, PyRwLockReadGuard, PyRwLockWriteGuard};
 use crate::function::{OptionalArg, OptionalOption};
 use crate::pyobject::{
-    Either, PyClassImpl, PyComparisonValue, PyContext, PyIterable, PyObjectRef, PyRef, PyResult,
-    PyValue, TryFromObject, TypeProtocol,
+    BorrowValue, Either, PyClassImpl, PyComparisonValue, PyContext, PyIterable, PyObjectRef, PyRef,
+    PyResult, PyValue, TryFromObject, TypeProtocol,
 };
 use crate::pystr::{self, PyCommonString};
 use crate::vm::VirtualMachine;
@@ -338,7 +338,7 @@ impl PyByteArray {
 
     #[pymethod(name = "remove")]
     fn remove(&self, x: PyIntRef, vm: &VirtualMachine) -> PyResult<()> {
-        let x = x.as_bigint().byte_or(vm)?;
+        let x = x.borrow_value().byte_or(vm)?;
 
         let bytes = &mut self.borrow_value_mut().elements;
         let pos = bytes
@@ -480,7 +480,7 @@ impl PyByteArray {
     fn append(&self, x: PyIntRef, vm: &VirtualMachine) -> PyResult<()> {
         self.borrow_value_mut()
             .elements
-            .push(x.as_bigint().byte_or(vm)?);
+            .push(x.borrow_value().byte_or(vm)?);
         Ok(())
     }
 
@@ -489,7 +489,7 @@ impl PyByteArray {
         for x in iterable_of_ints.iter(vm)? {
             let x = x?;
             let x = PyIntRef::try_from_object(vm, x)?;
-            let x = x.as_bigint().byte_or(vm)?;
+            let x = x.borrow_value().byte_or(vm)?;
             self.borrow_value_mut().elements.push(x);
         }
 
@@ -504,7 +504,7 @@ impl PyByteArray {
             .to_isize()
             .ok_or_else(|| vm.new_overflow_error("bytearray too big".to_owned()))?;
 
-        let x = x.as_bigint().byte_or(vm)?;
+        let x = x.borrow_value().byte_or(vm)?;
 
         if index >= len {
             bytes.push(x);

--- a/vm/src/obj/objbytearray.rs
+++ b/vm/src/obj/objbytearray.rs
@@ -256,7 +256,7 @@ impl PyByteArray {
 
     #[pymethod]
     fn fromhex(string: PyStringRef, vm: &VirtualMachine) -> PyResult<PyByteArray> {
-        Ok(PyBytesInner::fromhex(string.as_str(), vm)?.into())
+        Ok(PyBytesInner::fromhex(string.borrow_value(), vm)?.into())
     }
 
     #[pymethod(name = "center")]
@@ -590,7 +590,7 @@ impl PyByteArray {
                 vm.new_type_error(format!(
                     "'{}' decoder returned '{}' instead of 'str'; use codecs.encode() to \
                      encode arbitrary types",
-                    encoding.as_ref().map_or("utf-8", |s| s.as_str()),
+                    encoding.as_ref().map_or("utf-8", |s| s.borrow_value()),
                     obj.lease_class().name,
                 ))
             })

--- a/vm/src/obj/objbytearray.rs
+++ b/vm/src/obj/objbytearray.rs
@@ -41,6 +41,14 @@ pub struct PyByteArray {
 
 pub type PyByteArrayRef = PyRef<PyByteArray>;
 
+impl<'a> BorrowValue<'a> for PyByteArray {
+    type Borrowed = PyRwLockReadGuard<'a, PyBytesInner>;
+
+    fn borrow_value(&'a self) -> Self::Borrowed {
+        self.inner.read()
+    }
+}
+
 impl PyByteArray {
     fn from_inner(inner: PyBytesInner) -> Self {
         PyByteArray {
@@ -48,20 +56,22 @@ impl PyByteArray {
         }
     }
 
-    pub fn borrow_value(&self) -> PyRwLockReadGuard<'_, PyBytesInner> {
-        self.inner.read()
-    }
-
     pub fn borrow_value_mut(&self) -> PyRwLockWriteGuard<'_, PyBytesInner> {
         self.inner.write()
     }
 }
 
+impl From<PyBytesInner> for PyByteArray {
+    fn from(inner: PyBytesInner) -> Self {
+        Self {
+            inner: PyRwLock::new(inner),
+        }
+    }
+}
+
 impl From<Vec<u8>> for PyByteArray {
     fn from(elements: Vec<u8>) -> Self {
-        Self {
-            inner: PyRwLock::new(PyBytesInner { elements }),
-        }
+        Self::from(PyBytesInner { elements })
     }
 }
 

--- a/vm/src/obj/objbytes.rs
+++ b/vm/src/obj/objbytes.rs
@@ -14,7 +14,7 @@ use crate::bytesinner::{
 };
 use crate::function::{OptionalArg, OptionalOption};
 use crate::pyobject::{
-    Either, IntoPyObject,
+    BorrowValue, Either, IntoPyObject,
     PyArithmaticValue::{self, *},
     PyClassImpl, PyComparisonValue, PyContext, PyIterable, PyObjectRef, PyRef, PyResult, PyValue,
     TryFromObject, TypeProtocol,
@@ -40,8 +40,10 @@ pub struct PyBytes {
 
 pub type PyBytesRef = PyRef<PyBytes>;
 
-impl PyBytes {
-    pub fn get_value(&self) -> &[u8] {
+impl<'a> BorrowValue<'a> for PyBytes {
+    type Borrowed = &'a [u8];
+
+    fn borrow_value(&'a self) -> Self::Borrowed {
         &self.inner.elements
     }
 }
@@ -504,7 +506,7 @@ impl PyBytesIterator {
     #[pymethod(name = "__next__")]
     fn next(&self, vm: &VirtualMachine) -> PyResult<u8> {
         let pos = self.position.fetch_add(1);
-        if let Some(&ret) = self.bytes.get_value().get(pos) {
+        if let Some(&ret) = self.bytes.borrow_value().get(pos) {
             Ok(ret)
         } else {
             Err(objiter::new_stop_iteration(vm))

--- a/vm/src/obj/objbytes.rs
+++ b/vm/src/obj/objbytes.rs
@@ -238,7 +238,7 @@ impl PyBytes {
 
     #[pymethod]
     fn fromhex(string: PyStringRef, vm: &VirtualMachine) -> PyResult<PyBytes> {
-        Ok(PyBytesInner::fromhex(string.as_str(), vm)?.into())
+        Ok(PyBytesInner::fromhex(string.borrow_value(), vm)?.into())
     }
 
     #[pymethod(name = "center")]
@@ -481,7 +481,7 @@ impl PyBytes {
                 vm.new_type_error(format!(
                     "'{}' decoder returned '{}' instead of 'str'; use codecs.encode() to \
                      encode arbitrary types",
-                    encoding.as_ref().map_or("utf-8", |s| s.as_str()),
+                    encoding.as_ref().map_or("utf-8", |s| s.borrow_value()),
                     obj.lease_class().name,
                 ))
             })

--- a/vm/src/obj/objcomplex.rs
+++ b/vm/src/obj/objcomplex.rs
@@ -245,7 +245,7 @@ impl PyComplex {
                             "complex() can't take second arg if first is a string".to_owned(),
                         ));
                     }
-                    let value = Complex64::from_str(s.as_str())
+                    let value = Complex64::from_str(s.borrow_value())
                         .map_err(|err| vm.new_value_error(err.to_string()))?;
                     return PyComplex { value }.into_ref_with_type(vm, cls);
                 }

--- a/vm/src/obj/objcomplex.rs
+++ b/vm/src/obj/objcomplex.rs
@@ -9,7 +9,8 @@ use super::objstr::PyString;
 use super::objtype::PyClassRef;
 use crate::function::OptionalArg;
 use crate::pyobject::{
-    IntoPyObject, PyClassImpl, PyContext, PyObjectRef, PyRef, PyResult, PyValue, TypeProtocol,
+    BorrowValue, IntoPyObject, PyClassImpl, PyContext, PyObjectRef, PyRef, PyResult, PyValue,
+    TypeProtocol,
 };
 use crate::vm::VirtualMachine;
 use rustpython_common::hash;
@@ -233,7 +234,7 @@ impl PyComplex {
             OptionalArg::Missing => 0.0,
             OptionalArg::Present(obj) => match_class!(match obj {
                 i @ PyInt => {
-                    objint::try_float(i.as_bigint(), vm)?
+                    objint::try_float(i.borrow_value(), vm)?
                 }
                 f @ PyFloat => {
                     f.to_f64()

--- a/vm/src/obj/objdict.rs
+++ b/vm/src/obj/objdict.rs
@@ -9,8 +9,8 @@ use crate::dictdatatype::{self, DictKey};
 use crate::exceptions::PyBaseExceptionRef;
 use crate::function::{KwArgs, OptionalArg, PyFuncArgs};
 use crate::pyobject::{
-    IdProtocol, IntoPyObject, ItemProtocol, PyAttributes, PyClassImpl, PyContext, PyIterable,
-    PyObjectRef, PyRef, PyResult, PyValue, TryFromObject, TypeProtocol,
+    BorrowValue, IdProtocol, IntoPyObject, ItemProtocol, PyAttributes, PyClassImpl, PyContext,
+    PyIterable, PyObjectRef, PyRef, PyResult, PyValue, TryFromObject, TypeProtocol,
 };
 use crate::vm::{ReprGuard, VirtualMachine};
 
@@ -199,7 +199,11 @@ impl PyDictRef {
             for (key, value) in self {
                 let key_repr = vm.to_repr(&key)?;
                 let value_repr = vm.to_repr(&value)?;
-                str_parts.push(format!("{}: {}", key_repr.as_str(), value_repr.as_str()));
+                str_parts.push(format!(
+                    "{}: {}",
+                    key_repr.borrow_value(),
+                    value_repr.borrow_value()
+                ));
             }
 
             format!("{{{}}}", str_parts.join(", "))
@@ -571,7 +575,7 @@ macro_rules! dict_iterator {
                     let mut str_parts = vec![];
                     for (key, value) in zelf.dict.clone() {
                         let s = vm.to_repr(&$result_fn(vm, key, value))?;
-                        str_parts.push(s.as_str().to_owned());
+                        str_parts.push(s.borrow_value().to_owned());
                     }
                     format!("{}([{}])", $class_name, str_parts.join(", "))
                 } else {

--- a/vm/src/obj/objenumerate.rs
+++ b/vm/src/obj/objenumerate.rs
@@ -8,7 +8,7 @@ use super::objint::PyIntRef;
 use super::objiter;
 use super::objtype::PyClassRef;
 use crate::function::OptionalArg;
-use crate::pyobject::{PyClassImpl, PyContext, PyObjectRef, PyRef, PyResult, PyValue};
+use crate::pyobject::{BorrowValue, PyClassImpl, PyContext, PyObjectRef, PyRef, PyResult, PyValue};
 use crate::vm::VirtualMachine;
 
 #[pyclass]
@@ -35,7 +35,7 @@ impl PyEnumerate {
         vm: &VirtualMachine,
     ) -> PyResult<PyEnumerateRef> {
         let counter = match start {
-            OptionalArg::Present(start) => start.as_bigint().clone(),
+            OptionalArg::Present(start) => start.borrow_value().clone(),
             OptionalArg::Missing => BigInt::zero(),
         };
 

--- a/vm/src/obj/objfloat.rs
+++ b/vm/src/obj/objfloat.rs
@@ -529,7 +529,7 @@ fn to_float(vm: &VirtualMachine, obj: &PyObjectRef) -> PyResult<f64> {
             vm.new_value_error(format!("could not convert string to float: '{}'", s))
         })?
     } else if let Some(bytes) = obj.payload_if_subclass::<PyBytes>(vm) {
-        lexical_core::parse(bytes.get_value()).map_err(|_| {
+        lexical_core::parse(bytes.borrow_value()).map_err(|_| {
             vm.new_value_error(format!(
                 "could not convert string to float: '{}'",
                 bytes.repr()

--- a/vm/src/obj/objfloat.rs
+++ b/vm/src/obj/objfloat.rs
@@ -187,7 +187,7 @@ impl PyFloat {
 
     #[pymethod(name = "__format__")]
     fn format(&self, spec: PyStringRef, vm: &VirtualMachine) -> PyResult<String> {
-        match FormatSpec::parse(spec.as_str())
+        match FormatSpec::parse(spec.borrow_value())
             .and_then(|format_spec| format_spec.format_float(self.value))
         {
             Ok(string) => Ok(string),
@@ -508,7 +508,7 @@ impl PyFloat {
 
     #[pymethod]
     fn fromhex(repr: PyStringRef, vm: &VirtualMachine) -> PyResult<f64> {
-        float_ops::from_hex(repr.as_str().trim()).ok_or_else(|| {
+        float_ops::from_hex(repr.borrow_value().trim()).ok_or_else(|| {
             vm.new_value_error("invalid hexadecimal floating-point string".to_owned())
         })
     }
@@ -525,7 +525,7 @@ fn to_float(vm: &VirtualMachine, obj: &PyObjectRef) -> PyResult<f64> {
     } else if let Some(int) = obj.payload_if_subclass::<PyInt>(vm) {
         objint::try_float(int.borrow_value(), vm)?
     } else if let Some(s) = obj.payload_if_subclass::<PyString>(vm) {
-        float_ops::parse_str(s.as_str().trim()).ok_or_else(|| {
+        float_ops::parse_str(s.borrow_value().trim()).ok_or_else(|| {
             vm.new_value_error(format!("could not convert string to float: '{}'", s))
         })?
     } else if let Some(bytes) = obj.payload_if_subclass::<PyBytes>(vm) {

--- a/vm/src/obj/objfunction.rs
+++ b/vm/src/obj/objfunction.rs
@@ -163,7 +163,8 @@ impl PyFunction {
         // Add missing positional arguments, if we have fewer positional arguments than the
         // function definition calls for
         if nargs < nexpected_args {
-            let num_defaults_available = self.defaults.as_ref().map_or(0, |d| d.as_slice().len());
+            let num_defaults_available =
+                self.defaults.as_ref().map_or(0, |d| d.borrow_value().len());
 
             // Given the number of defaults available, check all the arguments for which we
             // _don't_ have defaults; if any are missing, raise an exception
@@ -183,7 +184,7 @@ impl PyFunction {
                 )));
             }
             if let Some(defaults) = &self.defaults {
-                let defaults = defaults.as_slice();
+                let defaults = defaults.borrow_value();
                 // We have sufficient defaults, so iterate over the corresponding names and use
                 // the default if we don't already have a value
                 for (default_index, i) in (required_args..nexpected_args).enumerate() {

--- a/vm/src/obj/objfunction.rs
+++ b/vm/src/obj/objfunction.rs
@@ -10,8 +10,8 @@ use crate::obj::objasyncgenerator::PyAsyncGen;
 use crate::obj::objcoroutine::PyCoroutine;
 use crate::obj::objgenerator::PyGenerator;
 use crate::pyobject::{
-    IdProtocol, ItemProtocol, PyClassImpl, PyContext, PyObjectRef, PyRef, PyResult, PyValue,
-    TypeProtocol,
+    BorrowValue, IdProtocol, ItemProtocol, PyClassImpl, PyContext, PyObjectRef, PyRef, PyResult,
+    PyValue, TypeProtocol,
 };
 use crate::scope::Scope;
 use crate::slots::{SlotCall, SlotDescriptor};
@@ -314,7 +314,7 @@ impl PyBoundMethod {
     fn repr(&self, vm: &VirtualMachine) -> PyResult<String> {
         Ok(format!(
             "<bound method of {}>",
-            vm.to_repr(&self.object)?.as_str()
+            vm.to_repr(&self.object)?.borrow_value()
         ))
     }
 
@@ -325,7 +325,7 @@ impl PyBoundMethod {
 
     #[pymethod(magic)]
     fn getattribute(zelf: PyRef<Self>, name: PyStringRef, vm: &VirtualMachine) -> PyResult {
-        if let Some(obj) = zelf.get_class_attr(name.as_str()) {
+        if let Some(obj) = zelf.get_class_attr(name.borrow_value()) {
             return vm.call_if_get_descriptor(obj, zelf.into_object());
         }
         vm.get_attribute(zelf.function.clone(), name)

--- a/vm/src/obj/objint.rs
+++ b/vm/src/obj/objint.rs
@@ -761,7 +761,7 @@ pub(crate) fn to_int(vm: &VirtualMachine, obj: &PyObjectRef) -> PyResult<BigInt>
             bytes_to_int(s.as_bytes(), base)
         }
         bytes @ PyBytes => {
-            let bytes = bytes.get_value();
+            let bytes = bytes.borrow_value();
             bytes_to_int(bytes, base)
         }
         bytearray @ PyByteArray => {
@@ -814,7 +814,7 @@ fn to_int_radix(vm: &VirtualMachine, obj: &PyObjectRef, base: u32) -> PyResult<B
             bytes_to_int(s.as_bytes(), base)
         }
         bytes @ PyBytes => {
-            let bytes = bytes.get_value();
+            let bytes = bytes.borrow_value();
             bytes_to_int(bytes, base)
         }
         bytearray @ PyByteArray => {

--- a/vm/src/obj/objint.rs
+++ b/vm/src/obj/objint.rs
@@ -18,8 +18,9 @@ use crate::bytesinner::PyBytesInner;
 use crate::format::FormatSpec;
 use crate::function::{OptionalArg, PyFuncArgs};
 use crate::pyobject::{
-    IdProtocol, IntoPyObject, IntoPyResult, PyArithmaticValue, PyClassImpl, PyComparisonValue,
-    PyContext, PyObject, PyObjectRef, PyRef, PyResult, PyValue, TryFromObject, TypeProtocol, BorrowValue
+    BorrowValue, IdProtocol, IntoPyObject, IntoPyResult, PyArithmaticValue, PyClassImpl,
+    PyComparisonValue, PyContext, PyObject, PyObjectRef, PyRef, PyResult, PyValue, TryFromObject,
+    TypeProtocol,
 };
 use crate::stdlib::array::PyArray;
 use crate::vm::VirtualMachine;
@@ -567,7 +568,7 @@ impl PyInt {
 
     #[pymethod(name = "__format__")]
     fn format(&self, spec: PyStringRef, vm: &VirtualMachine) -> PyResult<String> {
-        match FormatSpec::parse(spec.as_str())
+        match FormatSpec::parse(spec.borrow_value())
             .and_then(|format_spec| format_spec.format_int(&self.value))
         {
             Ok(string) => Ok(string),
@@ -615,7 +616,7 @@ impl PyInt {
             false
         };
 
-        let value = match (args.byteorder.as_str(), signed) {
+        let value = match (args.byteorder.borrow_value(), signed) {
             ("big", true) => BigInt::from_signed_bytes_be(&args.bytes.elements),
             ("big", false) => BigInt::from_bytes_be(Sign::Plus, &args.bytes.elements),
             ("little", true) => BigInt::from_signed_bytes_le(&args.bytes.elements),
@@ -650,7 +651,7 @@ impl PyInt {
             );
         };
 
-        let mut origin_bytes = match args.byteorder.as_str() {
+        let mut origin_bytes = match args.byteorder.borrow_value() {
             "big" => match signed {
                 true => value.to_signed_bytes_be(),
                 false => value.to_bytes_be().1,
@@ -677,7 +678,7 @@ impl PyInt {
         };
 
         let mut bytes = vec![];
-        match args.byteorder.as_str() {
+        match args.byteorder.borrow_value() {
             "big" => {
                 bytes = append_bytes;
                 bytes.append(&mut origin_bytes);
@@ -757,7 +758,7 @@ pub(crate) fn to_int(vm: &VirtualMachine, obj: &PyObjectRef) -> PyResult<BigInt>
     let base = 10;
     let opt = match_class!(match obj.clone() {
         string @ PyString => {
-            let s = string.as_str();
+            let s = string.borrow_value();
             bytes_to_int(s.as_bytes(), base)
         }
         bytes @ PyBytes => {
@@ -810,7 +811,7 @@ fn to_int_radix(vm: &VirtualMachine, obj: &PyObjectRef, base: u32) -> PyResult<B
 
     let opt = match_class!(match obj.clone() {
         string @ PyString => {
-            let s = string.as_str();
+            let s = string.borrow_value();
             bytes_to_int(s.as_bytes(), base)
         }
         bytes @ PyBytes => {

--- a/vm/src/obj/objiter.rs
+++ b/vm/src/obj/objiter.rs
@@ -99,7 +99,7 @@ pub fn stop_iter_with_value(val: PyObjectRef, vm: &VirtualMachine) -> PyBaseExce
 pub fn stop_iter_value(vm: &VirtualMachine, exc: &PyBaseExceptionRef) -> PyResult {
     let args = exc.args();
     let val = args
-        .as_slice()
+        .borrow_value()
         .first()
         .cloned()
         .unwrap_or_else(|| vm.get_none());

--- a/vm/src/obj/objiter.rs
+++ b/vm/src/obj/objiter.rs
@@ -10,8 +10,8 @@ use super::objsequence;
 use super::objtype::{self, PyClassRef};
 use crate::exceptions::PyBaseExceptionRef;
 use crate::pyobject::{
-    PyCallable, PyClassImpl, PyContext, PyObjectRef, PyRef, PyResult, PyValue, TryFromObject,
-    TypeProtocol,
+    BorrowValue, PyCallable, PyClassImpl, PyContext, PyObjectRef, PyRef, PyResult, PyValue,
+    TryFromObject, TypeProtocol,
 };
 use crate::vm::VirtualMachine;
 
@@ -139,7 +139,7 @@ pub fn length_hint(vm: &VirtualMachine, iter: PyObjectRef) -> PyResult<Option<us
                 result.lease_class().name
             ))
         })?
-        .as_bigint();
+        .borrow_value();
     if result.is_negative() {
         return Err(vm.new_value_error("__length_hint__() should return >= 0".to_owned()));
     }

--- a/vm/src/obj/objlist.rs
+++ b/vm/src/obj/objlist.rs
@@ -425,7 +425,7 @@ impl PyList {
             let mut str_parts = Vec::with_capacity(elements.len());
             for elem in elements.iter() {
                 let s = vm.to_repr(elem)?;
-                str_parts.push(s.as_str().to_owned());
+                str_parts.push(s.borrow_value().to_owned());
             }
             format!("[{}]", str_parts.join(", "))
         } else {
@@ -491,7 +491,7 @@ impl PyList {
             }
         }
         let needle_str = vm.to_str(&needle)?;
-        Err(vm.new_value_error(format!("'{}' is not in list", needle_str.as_str())))
+        Err(vm.new_value_error(format!("'{}' is not in list", needle_str.borrow_value())))
     }
 
     #[pymethod]
@@ -526,7 +526,7 @@ impl PyList {
             Ok(())
         } else {
             let needle_str = vm.to_str(&needle)?;
-            Err(vm.new_value_error(format!("'{}' is not in list", needle_str.as_str())))
+            Err(vm.new_value_error(format!("'{}' is not in list", needle_str.borrow_value())))
         }
     }
 

--- a/vm/src/obj/objlist.rs
+++ b/vm/src/obj/objlist.rs
@@ -17,8 +17,8 @@ use crate::bytesinner;
 use crate::common::cell::{PyRwLock, PyRwLockReadGuard, PyRwLockWriteGuard};
 use crate::function::OptionalArg;
 use crate::pyobject::{
-    IdProtocol, PyArithmaticValue::*, PyClassImpl, PyComparisonValue, PyContext, PyIterable,
-    PyObjectRef, PyRef, PyResult, PyValue, TryFromObject, TypeProtocol,
+    BorrowValue, IdProtocol, PyArithmaticValue::*, PyClassImpl, PyComparisonValue, PyContext,
+    PyIterable, PyObjectRef, PyRef, PyResult, PyValue, TryFromObject, TypeProtocol,
 };
 use crate::sequence::{self, SimpleSeq};
 use crate::vm::{ReprGuard, VirtualMachine};
@@ -60,20 +60,24 @@ impl PyValue for PyList {
     }
 }
 
-impl PyList {
-    pub fn borrow_elements(&self) -> PyRwLockReadGuard<'_, Vec<PyObjectRef>> {
+impl<'a> BorrowValue<'a> for PyList {
+    type Borrowed = PyRwLockReadGuard<'a, Vec<PyObjectRef>>;
+
+    fn borrow_value(&'a self) -> Self::Borrowed {
         self.elements.read()
     }
+}
 
-    pub fn borrow_elements_mut(&self) -> PyRwLockWriteGuard<'_, Vec<PyObjectRef>> {
+impl PyList {
+    pub fn borrow_value_mut(&self) -> PyRwLockWriteGuard<'_, Vec<PyObjectRef>> {
         self.elements.write()
     }
 
     pub(crate) fn to_byte_inner(&self, vm: &VirtualMachine) -> PyResult<bytesinner::PyBytesInner> {
-        let mut elements = Vec::<u8>::with_capacity(self.borrow_elements().len());
-        for elem in self.borrow_elements().iter() {
+        let mut elements = Vec::<u8>::with_capacity(self.borrow_value().len());
+        for elem in self.borrow_value().iter() {
             match PyIntRef::try_from_object(vm, elem.clone()) {
-                Ok(result) => match result.as_bigint().to_u8() {
+                Ok(result) => match result.borrow_value().to_u8() {
                     Some(result) => elements.push(result),
                     None => {
                         return Err(vm.new_value_error("bytes must be in range (0, 256)".to_owned()))
@@ -105,19 +109,19 @@ pub type PyListRef = PyRef<PyList>;
 impl PyList {
     #[pymethod]
     pub(crate) fn append(&self, x: PyObjectRef) {
-        self.borrow_elements_mut().push(x);
+        self.borrow_value_mut().push(x);
     }
 
     #[pymethod]
     fn extend(&self, x: PyObjectRef, vm: &VirtualMachine) -> PyResult<()> {
         let mut new_elements = vm.extract_elements(&x)?;
-        self.borrow_elements_mut().append(&mut new_elements);
+        self.borrow_value_mut().append(&mut new_elements);
         Ok(())
     }
 
     #[pymethod]
     pub(crate) fn insert(&self, position: isize, element: PyObjectRef) {
-        let mut elements = self.borrow_elements_mut();
+        let mut elements = self.borrow_value_mut();
         let vec_len = elements.len().to_isize().unwrap();
         // This unbounded position can be < 0 or > vec.len()
         let unbounded_position = if position < 0 {
@@ -133,8 +137,8 @@ impl PyList {
     #[pymethod(name = "__add__")]
     fn add(&self, other: PyObjectRef, vm: &VirtualMachine) -> PyResult {
         if let Some(other) = other.payload_if_subclass::<PyList>(vm) {
-            let e1 = self.borrow_elements().clone();
-            let e2 = other.borrow_elements().clone();
+            let e1 = self.borrow_value().clone();
+            let e2 = other.borrow_value().clone();
             let elements = e1.iter().chain(e2.iter()).cloned().collect();
             Ok(vm.ctx.new_list(elements))
         } else {
@@ -150,7 +154,7 @@ impl PyList {
     fn iadd(zelf: PyRef<Self>, other: PyObjectRef, vm: &VirtualMachine) -> PyResult {
         if let Ok(new_elements) = vm.extract_elements(&other) {
             let mut e = new_elements;
-            zelf.borrow_elements_mut().append(&mut e);
+            zelf.borrow_value_mut().append(&mut e);
             Ok(zelf.into_object())
         } else {
             Ok(vm.ctx.not_implemented())
@@ -159,37 +163,37 @@ impl PyList {
 
     #[pymethod(name = "__bool__")]
     fn bool(&self) -> bool {
-        !self.borrow_elements().is_empty()
+        !self.borrow_value().is_empty()
     }
 
     #[pymethod]
     fn clear(&self) {
-        self.borrow_elements_mut().clear();
+        self.borrow_value_mut().clear();
     }
 
     #[pymethod]
     fn copy(&self, vm: &VirtualMachine) -> PyObjectRef {
-        vm.ctx.new_list(self.borrow_elements().clone())
+        vm.ctx.new_list(self.borrow_value().clone())
     }
 
     #[pymethod(name = "__len__")]
     fn len(&self) -> usize {
-        self.borrow_elements().len()
+        self.borrow_value().len()
     }
 
     #[pymethod(name = "__sizeof__")]
     fn sizeof(&self) -> usize {
-        size_of::<Self>() + self.borrow_elements().capacity() * size_of::<PyObjectRef>()
+        size_of::<Self>() + self.borrow_value().capacity() * size_of::<PyObjectRef>()
     }
 
     #[pymethod]
     fn reverse(&self) {
-        self.borrow_elements_mut().reverse();
+        self.borrow_value_mut().reverse();
     }
 
     #[pymethod(name = "__reversed__")]
     fn reversed(zelf: PyRef<Self>) -> PyListReverseIterator {
-        let final_position = zelf.borrow_elements().len();
+        let final_position = zelf.borrow_value().len();
         PyListReverseIterator {
             position: AtomicCell::new(final_position as isize),
             list: zelf,
@@ -198,12 +202,7 @@ impl PyList {
 
     #[pymethod(name = "__getitem__")]
     fn getitem(zelf: PyRef<Self>, needle: PyObjectRef, vm: &VirtualMachine) -> PyResult {
-        get_item(
-            vm,
-            zelf.as_object(),
-            &zelf.borrow_elements(),
-            needle.clone(),
-        )
+        get_item(vm, zelf.as_object(), &zelf.borrow_value(), needle.clone())
     }
 
     #[pymethod(name = "__iter__")]
@@ -233,7 +232,7 @@ impl PyList {
     }
 
     fn setindex(&self, index: isize, value: PyObjectRef, vm: &VirtualMachine) -> PyResult {
-        let mut elements = self.borrow_elements_mut();
+        let mut elements = self.borrow_value_mut();
         if let Some(pos_index) = get_pos(index, elements.len()) {
             elements[pos_index] = value;
             Ok(vm.get_none())
@@ -252,7 +251,7 @@ impl PyList {
         let items: Result<Vec<PyObjectRef>, _> = sec.iter(vm)?.collect();
         let items = items?;
 
-        let elements = self.borrow_elements_mut();
+        let elements = self.borrow_value_mut();
         if step.is_zero() {
             Err(vm.new_value_error("slice step cannot be zero".to_owned()))
         } else if step.is_positive() {
@@ -422,7 +421,7 @@ impl PyList {
     #[pymethod(name = "__repr__")]
     fn repr(zelf: PyRef<Self>, vm: &VirtualMachine) -> PyResult<String> {
         let s = if let Some(_guard) = ReprGuard::enter(zelf.as_object()) {
-            let elements = zelf.borrow_elements().clone();
+            let elements = zelf.borrow_value().clone();
             let mut str_parts = Vec::with_capacity(elements.len());
             for elem in elements.iter() {
                 let s = vm.to_repr(elem)?;
@@ -442,7 +441,7 @@ impl PyList {
 
     #[pymethod(name = "__mul__")]
     fn mul(&self, counter: isize, vm: &VirtualMachine) -> PyObjectRef {
-        let new_elements = sequence::seq_mul(&*self.borrow_elements(), counter)
+        let new_elements = sequence::seq_mul(&*self.borrow_value(), counter)
             .cloned()
             .collect();
         vm.ctx.new_list(new_elements)
@@ -455,7 +454,7 @@ impl PyList {
 
     #[pymethod(name = "__imul__")]
     fn imul(zelf: PyRef<Self>, counter: isize) -> PyRef<Self> {
-        let mut elements = zelf.borrow_elements_mut();
+        let mut elements = zelf.borrow_value_mut();
         let mut new_elements: Vec<PyObjectRef> =
             sequence::seq_mul(&*elements, counter).cloned().collect();
         std::mem::swap(elements.deref_mut(), &mut new_elements);
@@ -465,7 +464,7 @@ impl PyList {
     #[pymethod]
     fn count(&self, needle: PyObjectRef, vm: &VirtualMachine) -> PyResult<usize> {
         let mut count: usize = 0;
-        for element in self.borrow_elements().clone().iter() {
+        for element in self.borrow_value().clone().iter() {
             if vm.identical_or_equal(element, &needle)? {
                 count += 1;
             }
@@ -475,7 +474,7 @@ impl PyList {
 
     #[pymethod(name = "__contains__")]
     fn contains(&self, needle: PyObjectRef, vm: &VirtualMachine) -> PyResult<bool> {
-        for element in self.borrow_elements().clone().iter() {
+        for element in self.borrow_value().clone().iter() {
             if vm.identical_or_equal(element, &needle)? {
                 return Ok(true);
             }
@@ -486,7 +485,7 @@ impl PyList {
 
     #[pymethod]
     fn index(&self, needle: PyObjectRef, vm: &VirtualMachine) -> PyResult<usize> {
-        for (index, element) in self.borrow_elements().clone().iter().enumerate() {
+        for (index, element) in self.borrow_value().clone().iter().enumerate() {
             if vm.identical_or_equal(element, &needle)? {
                 return Ok(index);
             }
@@ -498,7 +497,7 @@ impl PyList {
     #[pymethod]
     fn pop(&self, i: OptionalArg<isize>, vm: &VirtualMachine) -> PyResult {
         let mut i = i.into_option().unwrap_or(-1);
-        let mut elements = self.borrow_elements_mut();
+        let mut elements = self.borrow_value_mut();
         if i < 0 {
             i += elements.len() as isize;
         }
@@ -514,7 +513,7 @@ impl PyList {
     #[pymethod]
     fn remove(&self, needle: PyObjectRef, vm: &VirtualMachine) -> PyResult<()> {
         let mut ri: Option<usize> = None;
-        for (index, element) in self.borrow_elements().clone().iter().enumerate() {
+        for (index, element) in self.borrow_value().clone().iter().enumerate() {
             if vm.identical_or_equal(element, &needle)? {
                 ri = Some(index);
                 break;
@@ -523,7 +522,7 @@ impl PyList {
 
         if let Some(index) = ri {
             // TODO: Check if value was removed after lock released
-            self.borrow_elements_mut().remove(index);
+            self.borrow_value_mut().remove(index);
             Ok(())
         } else {
             let needle_str = vm.to_str(&needle)?;
@@ -538,8 +537,8 @@ impl PyList {
     {
         let r = if let Some(other) = other.payload_if_subclass::<PyList>(vm) {
             Implemented(op(
-                self.borrow_elements().boxed_iter(),
-                other.borrow_elements().boxed_iter(),
+                self.borrow_value().boxed_iter(),
+                other.borrow_value().boxed_iter(),
             )?)
         } else {
             NotImplemented
@@ -598,7 +597,7 @@ impl PyList {
     }
 
     fn delindex(&self, index: isize, vm: &VirtualMachine) -> PyResult<()> {
-        let mut elements = self.borrow_elements_mut();
+        let mut elements = self.borrow_value_mut();
         if let Some(pos_index) = get_pos(index, elements.len()) {
             elements.remove(pos_index);
             Ok(())
@@ -612,7 +611,7 @@ impl PyList {
         let stop = slice.stop_index(vm)?;
         let step = slice.step_index(vm)?.unwrap_or_else(BigInt::one);
 
-        let elements = self.borrow_elements_mut();
+        let elements = self.borrow_value_mut();
         if step.is_zero() {
             Err(vm.new_value_error("slice step cannot be zero".to_owned()))
         } else if step.is_positive() {
@@ -734,9 +733,9 @@ impl PyList {
         // replace list contents with [] for duration of sort.
         // this prevents keyfunc from messing with the list and makes it easy to
         // check if it tries to append elements to it.
-        let mut elements = std::mem::take(self.borrow_elements_mut().deref_mut());
+        let mut elements = std::mem::take(self.borrow_value_mut().deref_mut());
         do_sort(vm, &mut elements, options.key, options.reverse)?;
-        std::mem::swap(self.borrow_elements_mut().deref_mut(), &mut elements);
+        std::mem::swap(self.borrow_value_mut().deref_mut(), &mut elements);
 
         if !elements.is_empty() {
             return Err(vm.new_value_error("list modified during sort".to_owned()));
@@ -843,7 +842,7 @@ impl PyValue for PyListIterator {
 impl PyListIterator {
     #[pymethod(name = "__next__")]
     fn next(&self, vm: &VirtualMachine) -> PyResult {
-        let list = self.list.borrow_elements();
+        let list = self.list.borrow_value();
         let pos = self.position.fetch_add(1);
         if let Some(obj) = list.get(pos) {
             Ok(obj.clone())
@@ -859,7 +858,7 @@ impl PyListIterator {
 
     #[pymethod(name = "__length_hint__")]
     fn length_hint(&self) -> usize {
-        let list = self.list.borrow_elements();
+        let list = self.list.borrow_value();
         let pos = self.position.load();
         list.len().saturating_sub(pos)
     }
@@ -882,7 +881,7 @@ impl PyValue for PyListReverseIterator {
 impl PyListReverseIterator {
     #[pymethod(name = "__next__")]
     fn next(&self, vm: &VirtualMachine) -> PyResult {
-        let list = self.list.borrow_elements();
+        let list = self.list.borrow_value();
         let pos = self.position.fetch_sub(1);
         if pos > 0 {
             if let Some(ret) = list.get(pos as usize - 1) {

--- a/vm/src/obj/objmappingproxy.rs
+++ b/vm/src/obj/objmappingproxy.rs
@@ -4,7 +4,8 @@ use super::objstr::PyStringRef;
 use super::objtype::PyClassRef;
 use crate::function::OptionalArg;
 use crate::pyobject::{
-    ItemProtocol, PyClassImpl, PyContext, PyObjectRef, PyRef, PyResult, PyValue, TryFromObject,
+    BorrowValue, ItemProtocol, PyClassImpl, PyContext, PyObjectRef, PyRef, PyResult, PyValue,
+    TryFromObject,
 };
 use crate::vm::VirtualMachine;
 
@@ -48,7 +49,7 @@ impl PyMappingProxy {
         let opt = match &self.mapping {
             MappingProxyInner::Class(class) => {
                 let key = PyStringRef::try_from_object(vm, key)?;
-                class.get_attr(key.as_str())
+                class.get_attr(key.borrow_value())
             }
             MappingProxyInner::Dict(obj) => obj.get_item(key, vm).ok(),
         };
@@ -75,7 +76,7 @@ impl PyMappingProxy {
         match &self.mapping {
             MappingProxyInner::Class(class) => {
                 let key = PyStringRef::try_from_object(vm, key)?;
-                Ok(vm.new_bool(class.has_attr(key.as_str())))
+                Ok(vm.new_bool(class.has_attr(key.borrow_value())))
             }
             MappingProxyInner::Dict(obj) => vm._membership(obj.clone(), key),
         }

--- a/vm/src/obj/objmodule.rs
+++ b/vm/src/obj/objmodule.rs
@@ -3,7 +3,7 @@ use super::objstr::{PyString, PyStringRef};
 use super::objtype::PyClassRef;
 use crate::function::OptionalOption;
 use crate::pyobject::{
-    ItemProtocol, PyClassImpl, PyContext, PyObjectRef, PyRef, PyResult, PyValue,
+    BorrowValue, ItemProtocol, PyClassImpl, PyContext, PyObjectRef, PyRef, PyResult, PyValue,
 };
 use crate::vm::VirtualMachine;
 
@@ -70,7 +70,10 @@ impl PyModuleRef {
             None,
         )
         .unwrap_or(None)
-        .and_then(|obj| obj.payload::<PyString>().map(|s| s.as_str().to_owned()))
+        .and_then(|obj| {
+            obj.payload::<PyString>()
+                .map(|s| s.borrow_value().to_owned())
+        })
     }
 
     #[pymethod(magic)]

--- a/vm/src/obj/objrange.rs
+++ b/vm/src/obj/objrange.rs
@@ -11,8 +11,8 @@ use super::objtype::PyClassRef;
 
 use crate::function::{OptionalArg, PyFuncArgs};
 use crate::pyobject::{
-    self, IntoPyRef, PyClassImpl, PyContext, PyObjectRef, PyRef, PyResult, PyValue, TryFromObject,
-    TypeProtocol,
+    self, BorrowValue, IntoPyRef, PyClassImpl, PyContext, PyObjectRef, PyRef, PyResult, PyValue,
+    TryFromObject, TypeProtocol,
 };
 use crate::vm::VirtualMachine;
 use rustpython_common::hash::PyHash;
@@ -42,19 +42,21 @@ impl PyValue for PyRange {
 impl PyRange {
     #[inline]
     fn offset(&self, value: &BigInt) -> Option<BigInt> {
-        let start = self.start.as_bigint();
-        let stop = self.stop.as_bigint();
-        let step = self.step.as_bigint();
+        let start = self.start.borrow_value();
+        let stop = self.stop.borrow_value();
+        let step = self.step.borrow_value();
         match step.sign() {
             Sign::Plus if value >= start && value < stop => Some(value - start),
-            Sign::Minus if value <= self.start.as_bigint() && value > stop => Some(start - value),
+            Sign::Minus if value <= self.start.borrow_value() && value > stop => {
+                Some(start - value)
+            }
             _ => None,
         }
     }
 
     #[inline]
     pub fn index_of(&self, value: &BigInt) -> Option<BigInt> {
-        let step = self.step.as_bigint();
+        let step = self.step.borrow_value();
         match self.offset(value) {
             Some(ref offset) if offset.is_multiple_of(step) => Some((offset / step).abs()),
             Some(_) | None => None,
@@ -63,21 +65,21 @@ impl PyRange {
 
     #[inline]
     pub fn is_empty(&self) -> bool {
-        let start = self.start.as_bigint();
-        let stop = self.stop.as_bigint();
-        let step = self.step.as_bigint();
+        let start = self.start.borrow_value();
+        let stop = self.stop.borrow_value();
+        let step = self.step.borrow_value();
         (start <= stop && step.is_negative()) || (start >= stop && step.is_positive())
     }
 
     #[inline]
     pub fn forward(&self) -> bool {
-        self.start.as_bigint() < self.stop.as_bigint()
+        self.start.borrow_value() < self.stop.borrow_value()
     }
 
     #[inline]
     pub fn get(&self, index: &BigInt) -> Option<BigInt> {
-        let start = self.start.as_bigint();
-        let step = self.step.as_bigint();
+        let start = self.start.borrow_value();
+        let step = self.step.borrow_value();
         let index = index.clone();
         if self.is_empty() {
             return None;
@@ -104,9 +106,9 @@ impl PyRange {
 
     #[inline]
     fn length(&self) -> BigInt {
-        let start = self.start.as_bigint();
-        let stop = self.stop.as_bigint();
-        let step = self.step.as_bigint();
+        let start = self.start.borrow_value();
+        let stop = self.stop.borrow_value();
+        let step = self.step.borrow_value();
 
         match step.sign() {
             Sign::Plus if start < stop => (stop - start - 1usize) / step + 1,
@@ -147,7 +149,7 @@ impl PyRange {
         vm: &VirtualMachine,
     ) -> PyResult<PyRangeRef> {
         let step = step.unwrap_or_else(|| (1).into_pyref(vm));
-        if step.as_bigint().is_zero() {
+        if step.borrow_value().is_zero() {
             return Err(vm.new_value_error("range() arg 3 must not be zero".to_owned()));
         }
         PyRange { start, stop, step }.into_ref_with_type(vm, cls)
@@ -178,9 +180,9 @@ impl PyRange {
 
     #[pymethod(name = "__reversed__")]
     fn reversed(&self, vm: &VirtualMachine) -> PyRangeIterator {
-        let start = self.start.as_bigint();
-        let stop = self.stop.as_bigint();
-        let step = self.step.as_bigint();
+        let start = self.start.borrow_value();
+        let stop = self.stop.borrow_value();
+        let step = self.step.borrow_value();
 
         // compute the last element that is actually contained within the range
         // this is the new start
@@ -216,7 +218,7 @@ impl PyRange {
 
     #[pymethod(name = "__repr__")]
     fn repr(&self) -> String {
-        if self.step.as_bigint().is_one() {
+        if self.step.borrow_value().is_one() {
             format!("range({}, {})", self.start, self.stop)
         } else {
             format!("range({}, {}, {})", self.start, self.stop, self.step)
@@ -231,8 +233,8 @@ impl PyRange {
     #[pymethod(name = "__contains__")]
     fn contains(&self, needle: PyObjectRef) -> bool {
         if let Ok(int) = needle.downcast::<PyInt>() {
-            match self.offset(int.as_bigint()) {
-                Some(ref offset) => offset.is_multiple_of(self.step.as_bigint()),
+            match self.offset(int.borrow_value()) {
+                Some(ref offset) => offset.is_multiple_of(self.step.borrow_value()),
                 None => false,
             }
         } else {
@@ -249,11 +251,11 @@ impl PyRange {
             return true;
         }
 
-        if self.start.as_bigint() != rhs.start.as_bigint() {
+        if self.start.borrow_value() != rhs.start.borrow_value() {
             return false;
         }
-        let step = self.step.as_bigint();
-        if step.is_one() || step == rhs.step.as_bigint() {
+        let step = self.step.borrow_value();
+        if step.is_one() || step == rhs.step.borrow_value() {
             return true;
         }
 
@@ -313,7 +315,7 @@ impl PyRange {
     #[pymethod(name = "index")]
     fn index(&self, needle: PyObjectRef, vm: &VirtualMachine) -> PyResult<BigInt> {
         if let Ok(int) = needle.downcast::<PyInt>() {
-            match self.index_of(int.as_bigint()) {
+            match self.index_of(int.borrow_value()) {
                 Some(idx) => Ok(idx),
                 None => Err(vm.new_value_error(format!("{} is not in range", int))),
             }
@@ -325,7 +327,7 @@ impl PyRange {
     #[pymethod(name = "count")]
     fn count(&self, item: PyObjectRef) -> usize {
         if let Ok(int) = item.downcast::<PyInt>() {
-            if self.index_of(int.as_bigint()).is_some() {
+            if self.index_of(int.borrow_value()).is_some() {
                 1
             } else {
                 0
@@ -344,9 +346,9 @@ impl PyRange {
                 let range_step = &self.step;
                 let range_start = &self.start;
 
-                substep *= range_step.as_bigint();
-                substart = (substart * range_step.as_bigint()) + range_start.as_bigint();
-                substop = (substop * range_step.as_bigint()) + range_start.as_bigint();
+                substep *= range_step.borrow_value();
+                substart = (substart * range_step.borrow_value()) + range_start.borrow_value();
+                substop = (substop * range_step.borrow_value()) + range_start.borrow_value();
 
                 Ok(PyRange {
                     start: substart.into_pyref(vm),
@@ -356,7 +358,7 @@ impl PyRange {
                 .into_ref(vm)
                 .into_object())
             }
-            RangeIndex::Int(index) => match self.get(index.as_bigint()) {
+            RangeIndex::Int(index) => match self.get(index.borrow_value()) {
                 Some(value) => Ok(vm.ctx.new_int(value)),
                 None => Err(vm.new_index_error("range object index out of range".to_owned())),
             },

--- a/vm/src/obj/objset.rs
+++ b/vm/src/obj/objset.rs
@@ -8,8 +8,8 @@ use super::objtype::{self, PyClassRef};
 use crate::dictdatatype;
 use crate::function::{Args, OptionalArg};
 use crate::pyobject::{
-    self, PyClassImpl, PyContext, PyIterable, PyObjectRef, PyRef, PyResult, PyValue, TryFromObject,
-    TypeProtocol,
+    self, BorrowValue, PyClassImpl, PyContext, PyIterable, PyObjectRef, PyRef, PyResult, PyValue,
+    TryFromObject, TypeProtocol,
 };
 use crate::vm::{ReprGuard, VirtualMachine};
 use rustpython_common::hash::PyHash;
@@ -250,7 +250,7 @@ impl PySetInner {
         let mut str_parts = Vec::with_capacity(self.content.len());
         for key in self.content.keys() {
             let part = vm.to_repr(&key)?;
-            str_parts.push(part.as_str().to_owned());
+            str_parts.push(part.borrow_value().to_owned());
         }
 
         Ok(format!("{{{}}}", str_parts.join(", ")))

--- a/vm/src/obj/objslice.rs
+++ b/vm/src/obj/objslice.rs
@@ -2,7 +2,8 @@ use super::objint::PyInt;
 use super::objtype::PyClassRef;
 use crate::function::{OptionalArg, PyFuncArgs};
 use crate::pyobject::{
-    IdProtocol, PyClassImpl, PyContext, PyObjectRef, PyRef, PyResult, PyValue, TryIntoRef,
+    BorrowValue, IdProtocol, PyClassImpl, PyContext, PyObjectRef, PyRef, PyResult, PyValue,
+    TryIntoRef,
 };
 use crate::vm::VirtualMachine;
 use num_bigint::{BigInt, ToBigInt};
@@ -169,7 +170,7 @@ impl PySlice {
         } else {
             // Clone the value, not the reference.
             let this_step: PyRef<PyInt> = self.step(vm).try_into_ref(vm)?;
-            step = this_step.as_bigint().clone();
+            step = this_step.borrow_value().clone();
 
             if step.is_zero() {
                 return Err(vm.new_value_error("slice step cannot be zero.".to_owned()));
@@ -203,7 +204,7 @@ impl PySlice {
             };
         } else {
             let this_start: PyRef<PyInt> = self.start(vm).try_into_ref(vm)?;
-            start = this_start.as_bigint().clone();
+            start = this_start.borrow_value().clone();
 
             if start < Zero::zero() {
                 // From end of array
@@ -223,7 +224,7 @@ impl PySlice {
             stop = if backwards { lower } else { upper };
         } else {
             let this_stop: PyRef<PyInt> = self.stop(vm).try_into_ref(vm)?;
-            stop = this_stop.as_bigint().clone();
+            stop = this_stop.borrow_value().clone();
 
             if stop < Zero::zero() {
                 // From end of array
@@ -307,7 +308,7 @@ impl PySlice {
     #[pymethod(name = "indices")]
     fn indices(&self, length: PyObjectRef, vm: &VirtualMachine) -> PyResult {
         if let Some(length) = length.payload::<PyInt>() {
-            let (start, stop, step) = self.inner_indices(length.as_bigint(), vm)?;
+            let (start, stop, step) = self.inner_indices(length.borrow_value(), vm)?;
             Ok(vm
                 .ctx
                 .new_tuple(vec![vm.new_int(start), vm.new_int(stop), vm.new_int(step)]))
@@ -327,7 +328,7 @@ fn to_index_value(vm: &VirtualMachine, obj: &PyObjectRef) -> PyResult<Option<Big
             "slice indices must be integers or None or have an __index__ method".to_owned(),
         ))
     })?;
-    Ok(Some(result.as_bigint().clone()))
+    Ok(Some(result.borrow_value().clone()))
 }
 
 pub fn init(context: &PyContext) {

--- a/vm/src/obj/objslice.rs
+++ b/vm/src/obj/objslice.rs
@@ -62,9 +62,9 @@ impl PySlice {
 
         Ok(format!(
             "slice({}, {}, {})",
-            start_repr.as_str(),
-            stop_repr.as_str(),
-            step_repr.as_str()
+            start_repr.borrow_value(),
+            stop_repr.borrow_value(),
+            step_repr.borrow_value()
         ))
     }
 

--- a/vm/src/obj/objstr.rs
+++ b/vm/src/obj/objstr.rs
@@ -50,9 +50,16 @@ pub struct PyString {
     len: AtomicCell<Option<usize>>,
 }
 
-impl PyString {
-    #[inline]
-    pub fn as_str(&self) -> &str {
+impl<'a> BorrowValue<'a> for PyString {
+    type Borrowed = &'a str;
+
+    fn borrow_value(&'a self) -> Self::Borrowed {
+        &self.value
+    }
+}
+
+impl AsRef<str> for PyString {
+    fn as_ref(&self) -> &str {
         &self.value
     }
 }
@@ -196,7 +203,7 @@ impl PyString {
         if string.class().is(&cls) {
             Ok(string)
         } else {
-            PyString::from(string.as_str()).into_ref_with_type(vm, cls)
+            PyString::from(string.borrow_value()).into_ref_with_type(vm, cls)
         }
     }
 
@@ -502,7 +509,7 @@ impl PyString {
             args,
             "endswith",
             "str",
-            |s, x: &PyStringRef| s.ends_with(x.as_str()),
+            |s, x: &PyStringRef| s.ends_with(x.borrow_value()),
             vm,
         )
     }
@@ -513,7 +520,7 @@ impl PyString {
             args,
             "startswith",
             "str",
-            |s, x: &PyStringRef| s.starts_with(x.as_str()),
+            |s, x: &PyStringRef| s.starts_with(x.borrow_value()),
             vm,
         )
     }
@@ -609,7 +616,7 @@ impl PyString {
 
     #[pymethod(name = "__format__")]
     fn format_str(&self, spec: PyStringRef, vm: &VirtualMachine) -> PyResult<String> {
-        match FormatSpec::parse(spec.as_str())
+        match FormatSpec::parse(spec.borrow_value())
             .and_then(|format_spec| format_spec.format_string(&self.value))
         {
             Ok(string) => Ok(string),
@@ -1088,7 +1095,7 @@ pub(crate) fn encode_string(
             vm.new_type_error(format!(
                 "'{}' encoder returned '{}' instead of 'bytes'; use codecs.encode() to \
                  encode arbitrary types",
-                encoding.as_ref().map_or("utf-8", |s| s.as_str()),
+                encoding.as_ref().map_or("utf-8", |s| s.borrow_value()),
                 obj.lease_class().name,
             ))
         })
@@ -1121,7 +1128,7 @@ impl IntoPyObject for &String {
 impl TryFromObject for std::ffi::CString {
     fn try_from_object(vm: &VirtualMachine, obj: PyObjectRef) -> PyResult<Self> {
         let s = PyStringRef::try_from_object(vm, obj)?;
-        Self::new(s.as_str().to_owned())
+        Self::new(s.borrow_value().to_owned())
             .map_err(|_| vm.new_value_error("embedded null character".to_owned()))
     }
 }

--- a/vm/src/obj/objstr.rs
+++ b/vm/src/obj/objstr.rs
@@ -23,8 +23,8 @@ use crate::exceptions::IntoPyException;
 use crate::format::{FormatSpec, FormatString, FromTemplate};
 use crate::function::{OptionalArg, OptionalOption, PyFuncArgs};
 use crate::pyobject::{
-    IdProtocol, IntoPyObject, ItemProtocol, PyClassImpl, PyContext, PyIterable, PyObjectRef, PyRef,
-    PyResult, PyValue, TryFromObject, TryIntoRef, TypeProtocol,
+    BorrowValue, IdProtocol, IntoPyObject, ItemProtocol, PyClassImpl, PyContext, PyIterable,
+    PyObjectRef, PyRef, PyResult, PyValue, TryFromObject, TryIntoRef, TypeProtocol,
 };
 use crate::pystr::{
     self, adjust_indices, PyCommonString, PyCommonStringContainer, PyCommonStringWrapper,
@@ -959,7 +959,7 @@ impl PyString {
                     if let Some(text) = value.payload::<PyString>() {
                         translated.push_str(&text.value);
                     } else if let Some(bigint) = value.payload::<PyInt>() {
-                        match bigint.as_bigint().to_u32().and_then(std::char::from_u32) {
+                        match bigint.borrow_value().to_u32().and_then(std::char::from_u32) {
                             Some(ch) => translated.push(ch as char),
                             None => {
                                 return Err(vm.new_value_error(
@@ -1020,7 +1020,7 @@ impl PyString {
                     for (key, val) in dict {
                         if let Some(num) = key.payload::<PyInt>() {
                             new_dict.set_item(
-                                num.as_bigint().to_i32().into_pyobject(vm),
+                                num.borrow_value().to_i32().into_pyobject(vm),
                                 val,
                                 vm,
                             )?;

--- a/vm/src/obj/objsuper.rs
+++ b/vm/src/obj/objsuper.rs
@@ -10,8 +10,8 @@ use super::objstr::PyStringRef;
 use super::objtype::{self, PyClass, PyClassRef};
 use crate::function::OptionalArg;
 use crate::pyobject::{
-    IdProtocol, PyClassImpl, PyContext, PyObjectRef, PyRef, PyResult, PyValue, TryFromObject,
-    TypeProtocol,
+    BorrowValue, IdProtocol, PyClassImpl, PyContext, PyObjectRef, PyRef, PyResult, PyValue,
+    TryFromObject, TypeProtocol,
 };
 use crate::scope::NameProtocol;
 use crate::slots::SlotDescriptor;
@@ -65,7 +65,7 @@ impl PySuper {
         let mut it = obj_type.iter_mro().peekable();
         for _ in it.peeking_take_while(|cls| !cls.is(&zelf.typ)) {}
         for cls in it.skip(1) {
-            if let Some(descr) = cls.get_attr(name.as_str()) {
+            if let Some(descr) = cls.get_attr(name.borrow_value()) {
                 return vm
                     .call_get_descriptor_specific(
                         descr.clone(),

--- a/vm/src/obj/objtuple.rs
+++ b/vm/src/obj/objtuple.rs
@@ -6,7 +6,7 @@ use super::objsequence::get_item;
 use super::objtype::PyClassRef;
 use crate::function::OptionalArg;
 use crate::pyobject::{
-    self, IntoPyObject,
+    self, BorrowValue, IntoPyObject,
     PyArithmaticValue::{self, *},
     PyClassImpl, PyComparisonValue, PyContext, PyObjectRef, PyRef, PyResult, PyValue,
 };
@@ -179,7 +179,7 @@ impl PyTuple {
             let mut str_parts = Vec::with_capacity(zelf.elements.len());
             for elem in zelf.elements.iter() {
                 let s = vm.to_repr(elem)?;
-                str_parts.push(s.as_str().to_owned());
+                str_parts.push(s.borrow_value().to_owned());
             }
 
             if str_parts.len() == 1 {

--- a/vm/src/py_serde.rs
+++ b/vm/src/py_serde.rs
@@ -87,7 +87,7 @@ impl<'s> serde::Serialize for PyObjectSerializer<'s> {
         } else if let Some(list) = self.pyobject.payload_if_subclass::<PyList>(self.vm) {
             serialize_seq_elements(serializer, &list.borrow_value())
         } else if let Some(tuple) = self.pyobject.payload_if_subclass::<PyTuple>(self.vm) {
-            serialize_seq_elements(serializer, tuple.as_slice())
+            serialize_seq_elements(serializer, tuple.borrow_value())
         } else if objtype::isinstance(self.pyobject, &self.vm.ctx.types.dict_type) {
             let dict: PyDictRef = self.pyobject.clone().downcast().unwrap();
             let pairs: Vec<_> = dict.into_iter().collect();

--- a/vm/src/py_serde.rs
+++ b/vm/src/py_serde.rs
@@ -7,7 +7,7 @@ use crate::obj::{
     objbool, objdict::PyDictRef, objfloat, objint, objlist::PyList, objstr, objtuple::PyTuple,
     objtype,
 };
-use crate::pyobject::{IdProtocol, ItemProtocol, PyObjectRef, TypeProtocol};
+use crate::pyobject::{BorrowValue, IdProtocol, ItemProtocol, PyObjectRef, TypeProtocol};
 use crate::VirtualMachine;
 
 #[inline]
@@ -85,7 +85,7 @@ impl<'s> serde::Serialize for PyObjectSerializer<'s> {
                 serializer.serialize_i64(v.to_i64().ok_or_else(int_too_large)?)
             }
         } else if let Some(list) = self.pyobject.payload_if_subclass::<PyList>(self.vm) {
-            serialize_seq_elements(serializer, &list.borrow_elements())
+            serialize_seq_elements(serializer, &list.borrow_value())
         } else if let Some(tuple) = self.pyobject.payload_if_subclass::<PyTuple>(self.vm) {
             serialize_seq_elements(serializer, tuple.as_slice())
         } else if objtype::isinstance(self.pyobject, &self.vm.ctx.types.dict_type) {

--- a/vm/src/pyobject.rs
+++ b/vm/src/pyobject.rs
@@ -1337,6 +1337,11 @@ pub trait PyValue: fmt::Debug + PyThreadingConstraint + Sized + 'static {
     }
 }
 
+pub trait BorrowValue<'a>: PyValue {
+    type Borrowed: 'a + Deref;
+    fn borrow_value(&'a self) -> Self::Borrowed;
+}
+
 pub trait PyObjectPayload: Any + fmt::Debug + PyThreadingConstraint + 'static {
     fn as_any(&self) -> &dyn Any;
 }

--- a/vm/src/pystr.rs
+++ b/vm/src/pystr.rs
@@ -1,7 +1,9 @@
 use crate::cformat::CFormatString;
 use crate::function::{single_or_tuple_any, OptionalOption};
 use crate::obj::objint::PyIntRef;
-use crate::pyobject::{PyIterator, PyObjectRef, PyResult, TryFromObject, TypeProtocol};
+use crate::pyobject::{
+    BorrowValue, PyIterator, PyObjectRef, PyResult, TryFromObject, TypeProtocol,
+};
 use crate::vm::VirtualMachine;
 use num_traits::{cast::ToPrimitive, sign::Signed};
 use std::str::FromStr;
@@ -77,7 +79,7 @@ impl StartsEndsWithArgs {
 }
 
 fn cap_to_isize(py_int: PyIntRef) -> isize {
-    let big = py_int.as_bigint();
+    let big = py_int.borrow_value();
     big.to_isize().unwrap_or_else(|| {
         if big.is_negative() {
             std::isize::MIN

--- a/vm/src/stdlib/array.rs
+++ b/vm/src/stdlib/array.rs
@@ -5,8 +5,8 @@ use crate::obj::objstr::PyStringRef;
 use crate::obj::objtype::PyClassRef;
 use crate::obj::{objbool, objiter};
 use crate::pyobject::{
-    Either, IntoPyObject, PyClassImpl, PyIterable, PyObjectRef, PyRef, PyResult, PyValue,
-    TryFromObject,
+    BorrowValue, Either, IntoPyObject, PyClassImpl, PyIterable, PyObjectRef, PyRef, PyResult,
+    PyValue, TryFromObject,
 };
 use crate::VirtualMachine;
 
@@ -345,7 +345,7 @@ impl PyArray {
 
     #[pymethod]
     fn frombytes(&self, b: PyBytesRef, vm: &VirtualMachine) -> PyResult<()> {
-        let b = b.get_value();
+        let b = b.borrow_value();
         let itemsize = self.borrow_value().itemsize();
         if b.len() % itemsize != 0 {
             return Err(vm.new_value_error("bytes length not a multiple of item size".to_owned()));

--- a/vm/src/stdlib/array.rs
+++ b/vm/src/stdlib/array.rs
@@ -284,8 +284,8 @@ impl PyArray {
         init: OptionalArg<PyIterable>,
         vm: &VirtualMachine,
     ) -> PyResult<PyArrayRef> {
-        let spec = match spec.as_str().len() {
-            1 => spec.as_str().chars().next().unwrap(),
+        let spec = match spec.borrow_value().len() {
+            1 => spec.borrow_value().chars().next().unwrap(),
             _ => {
                 return Err(vm.new_type_error(
                     "array() argument 1 must be a unicode character, not str".to_owned(),

--- a/vm/src/stdlib/binascii.rs
+++ b/vm/src/stdlib/binascii.rs
@@ -24,7 +24,7 @@ mod decl {
                 b @ PyBytes => Ok(SerializedData::Bytes(b)),
                 b @ PyByteArray => Ok(SerializedData::Buffer(b)),
                 a @ PyString => {
-                    if a.as_str().is_ascii() {
+                    if a.borrow_value().is_ascii() {
                         Ok(SerializedData::Ascii(a))
                     } else {
                         Err(vm.new_value_error(
@@ -46,7 +46,7 @@ mod decl {
             match self {
                 SerializedData::Bytes(b) => f(b.borrow_value()),
                 SerializedData::Buffer(b) => f(&b.borrow_value().elements),
-                SerializedData::Ascii(a) => f(a.as_str().as_bytes()),
+                SerializedData::Ascii(a) => f(a.borrow_value().as_bytes()),
             }
         }
     }

--- a/vm/src/stdlib/binascii.rs
+++ b/vm/src/stdlib/binascii.rs
@@ -7,7 +7,7 @@ mod decl {
     use crate::obj::objbytearray::{PyByteArray, PyByteArrayRef};
     use crate::obj::objbytes::{PyBytes, PyBytesRef};
     use crate::obj::objstr::{PyString, PyStringRef};
-    use crate::pyobject::{PyObjectRef, PyResult, TryFromObject, TypeProtocol};
+    use crate::pyobject::{BorrowValue, PyObjectRef, PyResult, TryFromObject, TypeProtocol};
     use crate::vm::VirtualMachine;
     use crc::{crc32, Hasher32};
     use itertools::Itertools;
@@ -44,7 +44,7 @@ mod decl {
         #[inline]
         pub fn with_ref<R>(&self, f: impl FnOnce(&[u8]) -> R) -> R {
             match self {
-                SerializedData::Bytes(b) => f(b.get_value()),
+                SerializedData::Bytes(b) => f(b.borrow_value()),
                 SerializedData::Buffer(b) => f(&b.borrow_value().elements),
                 SerializedData::Ascii(a) => f(a.as_str().as_bytes()),
             }

--- a/vm/src/stdlib/csv.rs
+++ b/vm/src/stdlib/csv.rs
@@ -8,8 +8,10 @@ use crate::function::PyFuncArgs;
 use crate::obj::objiter;
 use crate::obj::objstr::{self, PyString};
 use crate::obj::objtype::PyClassRef;
-use crate::pyobject::{IntoPyObject, TryFromObject, TypeProtocol};
-use crate::pyobject::{PyClassImpl, PyIterable, PyObjectRef, PyRef, PyResult, PyValue};
+use crate::pyobject::{
+    BorrowValue, IntoPyObject, PyClassImpl, PyIterable, PyObjectRef, PyRef, PyResult, PyValue,
+    TryFromObject, TypeProtocol,
+};
 use crate::types::create_type;
 use crate::VirtualMachine;
 
@@ -76,7 +78,7 @@ fn into_strings(iterable: &PyIterable<PyObjectRef>, vm: &VirtualMachine) -> PyRe
         .iter(vm)?
         .map(|py_obj_ref| {
             match_class!(match py_obj_ref? {
-                py_str @ PyString => Ok(py_str.as_str().trim().to_owned()),
+                py_str @ PyString => Ok(py_str.borrow_value().trim().to_owned()),
                 obj => {
                     let msg = format!(
             "iterator should return strings, not {} (did you open the file in text mode?)",

--- a/vm/src/stdlib/dis.rs
+++ b/vm/src/stdlib/dis.rs
@@ -1,7 +1,7 @@
 use crate::bytecode::CodeFlags;
 use crate::obj::objcode::PyCodeRef;
 use crate::obj::objstr::PyStringRef;
-use crate::pyobject::{ItemProtocol, PyObjectRef, PyResult, TryFromObject};
+use crate::pyobject::{BorrowValue, ItemProtocol, PyObjectRef, PyResult, TryFromObject};
 use crate::vm::VirtualMachine;
 use rustpython_compiler::compile;
 
@@ -14,7 +14,11 @@ fn dis_dis(obj: PyObjectRef, vm: &VirtualMachine) -> PyResult {
     // String:
     if let Ok(co_str) = PyStringRef::try_from_object(vm, obj.clone()) {
         let code = vm
-            .compile(co_str.as_str(), compile::Mode::Exec, "<string>".to_owned())
+            .compile(
+                co_str.borrow_value(),
+                compile::Mode::Exec,
+                "<string>".to_owned(),
+            )
             .map_err(|err| vm.new_syntax_error(&err))?
             .into_object();
         return dis_disassemble(code, vm);

--- a/vm/src/stdlib/hashlib.rs
+++ b/vm/src/stdlib/hashlib.rs
@@ -3,7 +3,7 @@ use crate::function::{OptionalArg, PyFuncArgs};
 use crate::obj::objbytes::{PyBytes, PyBytesRef};
 use crate::obj::objstr::PyStringRef;
 use crate::obj::objtype::PyClassRef;
-use crate::pyobject::{PyClassImpl, PyObjectRef, PyResult, PyValue};
+use crate::pyobject::{BorrowValue, PyClassImpl, PyObjectRef, PyResult, PyValue};
 use crate::vm::VirtualMachine;
 use std::fmt;
 
@@ -68,7 +68,7 @@ impl PyHasher {
 
     #[pymethod(name = "update")]
     fn update(&self, data: PyBytesRef, vm: &VirtualMachine) -> PyResult {
-        self.borrow_value_mut().input(data.get_value());
+        self.borrow_value_mut().input(data.borrow_value());
         Ok(vm.get_none())
     }
 

--- a/vm/src/stdlib/hashlib.rs
+++ b/vm/src/stdlib/hashlib.rs
@@ -93,7 +93,7 @@ fn hashlib_new(
     data: OptionalArg<PyBytesRef>,
     vm: &VirtualMachine,
 ) -> PyResult<PyHasher> {
-    match name.as_str() {
+    match name.borrow_value() {
         "md5" => md5(data, vm),
         "sha1" => sha1(data, vm),
         "sha224" => sha224(data, vm),

--- a/vm/src/stdlib/io.rs
+++ b/vm/src/stdlib/io.rs
@@ -20,7 +20,8 @@ use crate::obj::objiter;
 use crate::obj::objstr::{self, PyString, PyStringRef};
 use crate::obj::objtype::{self, PyClassRef};
 use crate::pyobject::{
-    BufferProtocol, Either, IntoPyObject, PyObjectRef, PyRef, PyResult, PyValue, TryFromObject,
+    BorrowValue, BufferProtocol, Either, IntoPyObject, PyObjectRef, PyRef, PyResult, PyValue,
+    TryFromObject,
 };
 use crate::vm::VirtualMachine;
 
@@ -393,7 +394,7 @@ fn bytes_io_new(
 ) -> PyResult<PyBytesIORef> {
     let raw_bytes = object
         .flatten()
-        .map_or_else(Vec::new, |input| input.get_value().to_vec());
+        .map_or_else(Vec::new, |input| input.borrow_value().to_vec());
 
     PyBytesIO {
         buffer: PyRwLock::new(BufferedIO::new(Cursor::new(raw_bytes))),

--- a/vm/src/stdlib/itertools.rs
+++ b/vm/src/stdlib/itertools.rs
@@ -17,8 +17,8 @@ mod decl {
     use crate::obj::objtuple::PyTuple;
     use crate::obj::objtype::{self, PyClassRef};
     use crate::pyobject::{
-        IdProtocol, IntoPyRef, PyCallable, PyClassImpl, PyObject, PyObjectRef, PyRef, PyResult,
-        PyValue, TypeProtocol,
+        BorrowValue, IdProtocol, IntoPyRef, PyCallable, PyClassImpl, PyObject, PyObjectRef, PyRef,
+        PyResult, PyValue, TypeProtocol,
     };
     use crate::vm::VirtualMachine;
 
@@ -181,11 +181,11 @@ mod decl {
             vm: &VirtualMachine,
         ) -> PyResult<PyRef<Self>> {
             let start = match start.into_option() {
-                Some(int) => int.as_bigint().clone(),
+                Some(int) => int.borrow_value().clone(),
                 None => BigInt::zero(),
             };
             let step = match step.into_option() {
-                Some(int) => int.as_bigint().clone(),
+                Some(int) => int.borrow_value().clone(),
                 None => BigInt::one(),
             };
 
@@ -294,7 +294,7 @@ mod decl {
             vm: &VirtualMachine,
         ) -> PyResult<PyRef<Self>> {
             let times = match times.into_option() {
-                Some(int) => Some(PyRwLock::new(int.as_bigint().clone())),
+                Some(int) => Some(PyRwLock::new(int.borrow_value().clone())),
                 None => None,
             };
 
@@ -1158,7 +1158,7 @@ mod decl {
             let iter = get_iter(vm, &iterable)?;
             let pool = get_all(vm, &iter)?;
 
-            let r = r.as_bigint();
+            let r = r.borrow_value();
             if r.is_negative() {
                 return Err(vm.new_value_error("r must be non-negative".to_owned()));
             }
@@ -1257,7 +1257,7 @@ mod decl {
             let iter = get_iter(vm, &iterable)?;
             let pool = get_all(vm, &iter)?;
 
-            let r = r.as_bigint();
+            let r = r.borrow_value();
             if r.is_negative() {
                 return Err(vm.new_value_error("r must be non-negative".to_owned()));
             }
@@ -1361,7 +1361,7 @@ mod decl {
                     let val = r
                         .payload::<PyInt>()
                         .ok_or_else(|| vm.new_type_error("Expected int as r".to_owned()))?
-                        .as_bigint();
+                        .borrow_value();
 
                     if val.is_negative() {
                         return Err(vm.new_value_error("r must be non-negative".to_owned()));

--- a/vm/src/stdlib/json.rs
+++ b/vm/src/stdlib/json.rs
@@ -1,7 +1,9 @@
 use crate::obj::objiter;
 use crate::obj::objstr::PyStringRef;
 use crate::obj::{objbool, objtype::PyClassRef};
-use crate::pyobject::{IdProtocol, PyClassImpl, PyObjectRef, PyRef, PyResult, PyValue};
+use crate::pyobject::{
+    BorrowValue, IdProtocol, PyClassImpl, PyObjectRef, PyRef, PyResult, PyValue,
+};
 use crate::VirtualMachine;
 
 use num_bigint::BigInt;
@@ -195,7 +197,7 @@ impl JsonScanner {
             return Err(vm.new_value_error("idx cannot be negative".to_owned()));
         }
         let idx = idx as usize;
-        let mut chars = pystr.as_str().chars();
+        let mut chars = pystr.borrow_value().chars();
         if idx > 0 {
             chars
                 .nth(idx - 1)
@@ -221,11 +223,11 @@ fn encode_string(s: &str, ascii_only: bool) -> String {
 }
 
 fn _json_encode_basestring(s: PyStringRef) -> String {
-    encode_string(s.as_str(), false)
+    encode_string(s.borrow_value(), false)
 }
 
 fn _json_encode_basestring_ascii(s: PyStringRef) -> String {
-    encode_string(s.as_str(), true)
+    encode_string(s.borrow_value(), true)
 }
 
 pub fn make_module(vm: &VirtualMachine) -> PyObjectRef {

--- a/vm/src/stdlib/keyword.rs
+++ b/vm/src/stdlib/keyword.rs
@@ -5,12 +5,12 @@
 use rustpython_parser::lexer;
 
 use crate::obj::objstr::PyStringRef;
-use crate::pyobject::{PyObjectRef, PyResult};
+use crate::pyobject::{BorrowValue, PyObjectRef, PyResult};
 use crate::vm::VirtualMachine;
 
 fn keyword_iskeyword(s: PyStringRef, vm: &VirtualMachine) -> PyResult {
     let keywords = lexer::get_keywords();
-    let value = keywords.contains_key(s.as_str());
+    let value = keywords.contains_key(s.borrow_value());
     let value = vm.ctx.new_bool(value);
     Ok(value)
 }

--- a/vm/src/stdlib/msvcrt.rs
+++ b/vm/src/stdlib/msvcrt.rs
@@ -1,7 +1,7 @@
 use super::os::errno_err;
 use crate::obj::objbytes::PyBytesRef;
 use crate::obj::objstr::PyStringRef;
-use crate::pyobject::{PyObjectRef, PyResult};
+use crate::pyobject::{BorrowValue, PyObjectRef, PyResult};
 use crate::VirtualMachine;
 
 use itertools::Itertools;
@@ -41,7 +41,7 @@ fn msvcrt_putch(b: PyBytesRef, vm: &VirtualMachine) -> PyResult<()> {
     Ok(())
 }
 fn msvcrt_putwch(s: PyStringRef, vm: &VirtualMachine) -> PyResult<()> {
-    let c = s.as_str().chars().exactly_one().map_err(|_| {
+    let c = s.borrow_value().chars().exactly_one().map_err(|_| {
         vm.new_type_error("putch() argument must be a string of length 1".to_owned())
     })?;
     unsafe { suppress_iph!(_putwch(c as u16)) };

--- a/vm/src/stdlib/msvcrt.rs
+++ b/vm/src/stdlib/msvcrt.rs
@@ -34,7 +34,7 @@ fn msvcrt_getwche() -> String {
     std::char::from_u32(c).unwrap().to_string()
 }
 fn msvcrt_putch(b: PyBytesRef, vm: &VirtualMachine) -> PyResult<()> {
-    let &c = b.get_value().iter().exactly_one().map_err(|_| {
+    let &c = b.borrow_value().iter().exactly_one().map_err(|_| {
         vm.new_type_error("putch() argument must be a byte string of length 1".to_owned())
     })?;
     unsafe { suppress_iph!(_putch(c.into())) };

--- a/vm/src/stdlib/operator.rs
+++ b/vm/src/stdlib/operator.rs
@@ -2,7 +2,7 @@ use crate::byteslike::PyBytesLike;
 use crate::function::OptionalArg;
 use crate::obj::objstr::PyStringRef;
 use crate::obj::{objiter, objtype};
-use crate::pyobject::{Either, PyObjectRef, PyResult, TypeProtocol};
+use crate::pyobject::{BorrowValue, Either, PyObjectRef, PyResult, TypeProtocol};
 use crate::VirtualMachine;
 use volatile::Volatile;
 
@@ -76,12 +76,12 @@ fn operator_compare_digest(
 ) -> PyResult<bool> {
     let res = match (a, b) {
         (Either::A(a), Either::A(b)) => {
-            if !a.as_str().is_ascii() || !b.as_str().is_ascii() {
+            if !a.borrow_value().is_ascii() || !b.borrow_value().is_ascii() {
                 return Err(vm.new_type_error(
                     "comparing strings with non-ASCII characters is not supported".to_owned(),
                 ));
             }
-            timing_safe_cmp(a.as_str().as_bytes(), b.as_str().as_bytes())
+            timing_safe_cmp(a.borrow_value().as_bytes(), b.borrow_value().as_bytes())
         }
         (Either::B(a), Either::B(b)) => a.with_ref(|a| b.with_ref(|b| timing_safe_cmp(a, b))),
         _ => {

--- a/vm/src/stdlib/os.rs
+++ b/vm/src/stdlib/os.rs
@@ -748,7 +748,7 @@ mod _os {
     #[pyfunction]
     fn utime(args: UtimeArgs, vm: &VirtualMachine) -> PyResult<()> {
         let parse_tup = |tup: PyTupleRef| -> Option<(i64, i64)> {
-            let tup = tup.as_slice();
+            let tup = tup.borrow_value();
             if tup.len() != 2 {
                 return None;
             }
@@ -1807,7 +1807,7 @@ mod posix {
             if let Some(it) = self.file_actions {
                 for action in it.iter(vm)? {
                     let action = action?;
-                    let (id, args) = action.as_slice().split_first().ok_or_else(|| {
+                    let (id, args) = action.borrow_value().split_first().ok_or_else(|| {
                         vm.new_type_error(
                             "Each file_actions element must be a non-empty tuple".to_owned(),
                         )

--- a/vm/src/stdlib/os.rs
+++ b/vm/src/stdlib/os.rs
@@ -23,8 +23,8 @@ use crate::obj::objstr::{PyString, PyStringRef};
 use crate::obj::objtuple::PyTupleRef;
 use crate::obj::objtype::PyClassRef;
 use crate::pyobject::{
-    Either, ItemProtocol, PyClassImpl, PyObjectRef, PyRef, PyResult, PyValue, TryFromObject,
-    TypeProtocol,
+    BorrowValue, Either, ItemProtocol, PyClassImpl, PyObjectRef, PyRef, PyResult, PyValue,
+    TryFromObject, TypeProtocol,
 };
 use crate::vm::VirtualMachine;
 
@@ -752,7 +752,7 @@ mod _os {
             if tup.len() != 2 {
                 return None;
             }
-            let i = |e: &PyObjectRef| e.clone().downcast::<PyInt>().ok()?.as_bigint().to_i64();
+            let i = |e: &PyObjectRef| e.clone().downcast::<PyInt>().ok()?.borrow_value().to_i64();
             Some((i(&tup[0])?, i(&tup[1])?))
         };
         let (acc, modif) = match (args.times, args.ns) {

--- a/vm/src/stdlib/os.rs
+++ b/vm/src/stdlib/os.rs
@@ -408,11 +408,11 @@ mod _os {
     ) -> PyResult<()> {
         let key: &ffi::OsStr = match key {
             Either::A(ref s) => s.as_str().as_ref(),
-            Either::B(ref b) => bytes_as_osstr(b.get_value(), vm)?,
+            Either::B(ref b) => bytes_as_osstr(b.borrow_value(), vm)?,
         };
         let value: &ffi::OsStr = match value {
             Either::A(ref s) => s.as_str().as_ref(),
-            Either::B(ref b) => bytes_as_osstr(b.get_value(), vm)?,
+            Either::B(ref b) => bytes_as_osstr(b.borrow_value(), vm)?,
         };
         env::set_var(key, value);
         Ok(())
@@ -422,7 +422,7 @@ mod _os {
     fn unsetenv(key: Either<PyStringRef, PyBytesRef>, vm: &VirtualMachine) -> PyResult<()> {
         let key: &ffi::OsStr = match key {
             Either::A(ref s) => s.as_str().as_ref(),
-            Either::B(ref b) => bytes_as_osstr(b.get_value(), vm)?,
+            Either::B(ref b) => bytes_as_osstr(b.borrow_value(), vm)?,
         };
         env::remove_var(key);
         Ok(())

--- a/vm/src/stdlib/pwd.rs
+++ b/vm/src/stdlib/pwd.rs
@@ -44,7 +44,7 @@ impl From<User> for Passwd {
 }
 
 fn pwd_getpwnam(name: PyStringRef, vm: &VirtualMachine) -> PyResult {
-    match User::from_name(name.as_str()).map_err(|err| err.into_pyexception(vm))? {
+    match User::from_name(name.borrow_value()).map_err(|err| err.into_pyexception(vm))? {
         Some(user) => Ok(Passwd::from(user)
             .into_struct_sequence(vm, vm.try_class("pwd", "struct_passwd")?)?
             .into_object()),

--- a/vm/src/stdlib/pystruct.rs
+++ b/vm/src/stdlib/pystruct.rs
@@ -92,7 +92,7 @@ mod _struct {
             fmt: &Either<PyStringRef, PyBytesRef>,
         ) -> PyResult<FormatSpec> {
             let decoded_fmt = match fmt {
-                Either::A(string) => string.as_str(),
+                Either::A(string) => string.borrow_value(),
                 Either::B(bytes) if bytes.is_ascii() => std::str::from_utf8(&bytes).unwrap(),
                 _ => {
                     return Err(vm.new_unicode_decode_error(

--- a/vm/src/stdlib/pystruct.rs
+++ b/vm/src/stdlib/pystruct.rs
@@ -29,7 +29,7 @@ mod _struct {
         objtuple::PyTuple, objtype::PyClassRef,
     };
     use crate::pyobject::{
-        Either, PyClassImpl, PyObjectRef, PyRef, PyResult, PyValue, TryFromObject,
+        BorrowValue, Either, PyClassImpl, PyObjectRef, PyRef, PyResult, PyValue, TryFromObject,
     };
     use crate::VirtualMachine;
 
@@ -440,7 +440,7 @@ mod _struct {
         length: usize,
     ) -> PyResult<()> {
         let mut v = PyBytesRef::try_from_object(vm, arg.clone())?
-            .get_value()
+            .borrow_value()
             .to_vec();
         v.resize(length, 0);
         match data.write_all(&v) {
@@ -456,7 +456,7 @@ mod _struct {
         length: usize,
     ) -> PyResult<()> {
         let mut v = PyBytesRef::try_from_object(vm, arg.clone())?
-            .get_value()
+            .borrow_value()
             .to_vec();
         let string_length = std::cmp::min(std::cmp::min(v.len(), 255), length - 1);
         data.write_u8(string_length as u8).unwrap();
@@ -893,7 +893,7 @@ mod _struct {
             let spec = FormatSpec::decode_and_parse(vm, &fmt)?;
             let fmt_str = match fmt {
                 Either::A(s) => s,
-                Either::B(b) => PyString::from(std::str::from_utf8(b.get_value()).unwrap())
+                Either::B(b) => PyString::from(std::str::from_utf8(b.borrow_value()).unwrap())
                     .into_ref_with_type(vm, vm.ctx.str_type())?,
             };
             PyStruct { spec, fmt_str }.into_ref_with_type(vm, cls)

--- a/vm/src/stdlib/random.rs
+++ b/vm/src/stdlib/random.rs
@@ -8,7 +8,7 @@ mod _random {
     use crate::function::OptionalOption;
     use crate::obj::objint::PyIntRef;
     use crate::obj::objtype::PyClassRef;
-    use crate::pyobject::{PyClassImpl, PyRef, PyResult, PyValue};
+    use crate::pyobject::{BorrowValue, PyClassImpl, PyRef, PyResult, PyValue};
     use crate::VirtualMachine;
     use num_bigint::{BigInt, Sign};
     use num_traits::Signed;
@@ -86,7 +86,7 @@ mod _random {
             let new_rng = match n.flatten() {
                 None => PyRng::default(),
                 Some(n) => {
-                    let (_, mut key) = n.as_bigint().abs().to_u32_digits();
+                    let (_, mut key) = n.borrow_value().abs().to_u32_digits();
                     if cfg!(target_endian = "big") {
                         key.reverse();
                     }

--- a/vm/src/stdlib/re.rs
+++ b/vm/src/stdlib/re.rs
@@ -13,7 +13,7 @@ use crate::function::{Args, OptionalArg};
 use crate::obj::objint::{PyInt, PyIntRef};
 use crate::obj::objstr::{PyString, PyStringRef};
 use crate::obj::objtype::PyClassRef;
-use crate::pyobject::{PyClassImpl, PyObjectRef, PyResult, PyValue, TryFromObject};
+use crate::pyobject::{BorrowValue, PyClassImpl, PyObjectRef, PyResult, PyValue, TryFromObject};
 use crate::vm::VirtualMachine;
 
 #[pyclass(name = "Pattern")]
@@ -225,7 +225,7 @@ fn do_split(
 ) -> PyResult {
     if maxsplit
         .as_ref()
-        .map_or(false, |i| i.as_bigint().is_negative())
+        .map_or(false, |i| i.borrow_value().is_negative())
     {
         return Ok(vm.ctx.new_list(vec![search_text.into_object()]));
     }

--- a/vm/src/stdlib/re.rs
+++ b/vm/src/stdlib/re.rs
@@ -97,7 +97,7 @@ fn re_match(
     vm: &VirtualMachine,
 ) -> PyResult {
     let flags = extract_flags(flags);
-    let regex = make_regex(vm, pattern.as_str(), flags)?;
+    let regex = make_regex(vm, pattern.borrow_value(), flags)?;
     do_match(vm, &regex, string)
 }
 
@@ -108,7 +108,7 @@ fn re_search(
     vm: &VirtualMachine,
 ) -> PyResult {
     let flags = extract_flags(flags);
-    let regex = make_regex(vm, pattern.as_str(), flags)?;
+    let regex = make_regex(vm, pattern.borrow_value(), flags)?;
     do_search(vm, &regex, string)
 }
 
@@ -121,7 +121,7 @@ fn re_sub(
     vm: &VirtualMachine,
 ) -> PyResult {
     let flags = extract_flags(flags);
-    let regex = make_regex(vm, pattern.as_str(), flags)?;
+    let regex = make_regex(vm, pattern.borrow_value(), flags)?;
     let limit = count.unwrap_or(0);
     do_sub(vm, &regex, repl, string, limit)
 }
@@ -133,7 +133,7 @@ fn re_findall(
     vm: &VirtualMachine,
 ) -> PyResult {
     let flags = extract_flags(flags);
-    let regex = make_regex(vm, pattern.as_str(), flags)?;
+    let regex = make_regex(vm, pattern.borrow_value(), flags)?;
     do_findall(vm, &regex, string)
 }
 
@@ -145,7 +145,7 @@ fn re_split(
     vm: &VirtualMachine,
 ) -> PyResult {
     let flags = extract_flags(flags);
-    let regex = make_regex(vm, pattern.as_str(), flags)?;
+    let regex = make_regex(vm, pattern.borrow_value(), flags)?;
     do_split(vm, &regex, string, maxsplit.into_option())
 }
 
@@ -157,9 +157,9 @@ fn do_sub(
     limit: usize,
 ) -> PyResult {
     let out = pattern.regex.replacen(
-        search_text.as_str().as_bytes(),
+        search_text.borrow_value().as_bytes(),
         limit,
-        repl.as_str().as_bytes(),
+        repl.borrow_value().as_bytes(),
     );
     let out = String::from_utf8_lossy(&out).into_owned();
     Ok(vm.new_str(out))
@@ -171,14 +171,14 @@ fn do_match(vm: &VirtualMachine, pattern: &PyPattern, search_text: PyStringRef) 
     regex.push_str(pattern.regex.as_str());
     let regex = Regex::new(&regex).unwrap();
 
-    match regex.captures(search_text.as_str().as_bytes()) {
+    match regex.captures(search_text.borrow_value().as_bytes()) {
         None => Ok(vm.get_none()),
         Some(captures) => Ok(create_match(vm, search_text.clone(), captures)),
     }
 }
 
 fn do_search(vm: &VirtualMachine, regex: &PyPattern, search_text: PyStringRef) -> PyResult {
-    match regex.regex.captures(search_text.as_str().as_bytes()) {
+    match regex.regex.captures(search_text.borrow_value().as_bytes()) {
         None => Ok(vm.get_none()),
         Some(captures) => Ok(create_match(vm, search_text.clone(), captures)),
     }
@@ -187,7 +187,7 @@ fn do_search(vm: &VirtualMachine, regex: &PyPattern, search_text: PyStringRef) -
 fn do_findall(vm: &VirtualMachine, pattern: &PyPattern, search_text: PyStringRef) -> PyResult {
     let out = pattern
         .regex
-        .captures_iter(search_text.as_str().as_bytes())
+        .captures_iter(search_text.borrow_value().as_bytes())
         .map(|captures| match captures.len() {
             1 => {
                 let full = captures.get(0).unwrap().as_bytes();
@@ -233,7 +233,7 @@ fn do_split(
         .map(|i| usize::try_from_object(vm, i.into_object()))
         .transpose()?
         .unwrap_or(0);
-    let text = search_text.as_str().as_bytes();
+    let text = search_text.borrow_value().as_bytes();
     // essentially Regex::split, but it outputs captures as well
     let mut output = Vec::new();
     let mut last = 0;
@@ -309,11 +309,11 @@ fn re_compile(
     vm: &VirtualMachine,
 ) -> PyResult<PyPattern> {
     let flags = extract_flags(flags);
-    make_regex(vm, pattern.as_str(), flags)
+    make_regex(vm, pattern.borrow_value(), flags)
 }
 
 fn re_escape(pattern: PyStringRef) -> String {
-    regex::escape(pattern.as_str())
+    regex::escape(pattern.borrow_value())
 }
 
 fn re_purge(_vm: &VirtualMachine) {}
@@ -332,9 +332,10 @@ impl PyPattern {
 
     #[pymethod(name = "sub")]
     fn sub(&self, repl: PyStringRef, text: PyStringRef, vm: &VirtualMachine) -> PyResult {
-        let replaced_text = self
-            .regex
-            .replace_all(text.as_str().as_bytes(), repl.as_str().as_bytes());
+        let replaced_text = self.regex.replace_all(
+            text.borrow_value().as_bytes(),
+            repl.borrow_value().as_bytes(),
+        );
         let replaced_text = String::from_utf8_lossy(&replaced_text).into_owned();
         Ok(vm.ctx.new_str(replaced_text))
     }
@@ -386,7 +387,7 @@ impl PyMatch {
     }
 
     fn subgroup(&self, bounds: (usize, usize), vm: &VirtualMachine) -> PyObjectRef {
-        vm.new_str(self.haystack.as_str()[bounds.0..bounds.1].to_owned())
+        vm.new_str(self.haystack.borrow_value()[bounds.0..bounds.1].to_owned())
     }
 
     fn get_bounds(&self, id: PyObjectRef, vm: &VirtualMachine) -> PyResult<Option<(usize, usize)>> {

--- a/vm/src/stdlib/socket.rs
+++ b/vm/src/stdlib/socket.rs
@@ -19,7 +19,8 @@ use crate::obj::objstr::{PyString, PyStringRef};
 use crate::obj::objtuple::PyTupleRef;
 use crate::obj::objtype::PyClassRef;
 use crate::pyobject::{
-    Either, IntoPyObject, PyClassImpl, PyObjectRef, PyRef, PyResult, PyValue, TryFromObject,
+    BorrowValue, Either, IntoPyObject, PyClassImpl, PyObjectRef, PyRef, PyResult, PyValue,
+    TryFromObject,
 };
 use crate::vm::VirtualMachine;
 
@@ -434,7 +435,7 @@ struct Address {
 impl ToSocketAddrs for Address {
     type Iter = std::vec::IntoIter<SocketAddr>;
     fn to_socket_addrs(&self) -> io::Result<Self::Iter> {
-        (self.host.as_str(), self.port).to_socket_addrs()
+        (self.host.borrow_value(), self.port).to_socket_addrs()
     }
 }
 
@@ -445,7 +446,7 @@ impl TryFromObject for Address {
             Err(vm.new_type_error("Address tuple should have only 2 values".to_owned()))
         } else {
             let host = PyStringRef::try_from_object(vm, tuple.as_slice()[0].clone())?;
-            let host = if host.as_str().is_empty() {
+            let host = if host.borrow_value().is_empty() {
                 PyString::from("0.0.0.0").into_ref(vm)
             } else {
                 host
@@ -478,12 +479,12 @@ fn socket_gethostname(vm: &VirtualMachine) -> PyResult {
 
 #[cfg(all(unix, not(target_os = "redox")))]
 fn socket_sethostname(hostname: PyStringRef, vm: &VirtualMachine) -> PyResult<()> {
-    sethostname(hostname.as_str()).map_err(|err| err.into_pyexception(vm))
+    sethostname(hostname.borrow_value()).map_err(|err| err.into_pyexception(vm))
 }
 
 fn socket_inet_aton(ip_string: PyStringRef, vm: &VirtualMachine) -> PyResult {
     ip_string
-        .as_str()
+        .borrow_value()
         .parse::<Ipv4Addr>()
         .map(|ip_addr| vm.ctx.new_bytes(ip_addr.octets().to_vec()))
         .map_err(|_| vm.new_os_error("illegal IP address string passed to inet_aton".to_owned()))
@@ -523,10 +524,10 @@ fn socket_getaddrinfo(opts: GAIOptions, vm: &VirtualMachine) -> PyResult {
         flags: opts.flags,
     };
 
-    let host = opts.host.as_ref().map(|s| s.as_str());
+    let host = opts.host.as_ref().map(|s| s.borrow_value());
     let port = opts.port.as_ref().map(|p| -> std::borrow::Cow<str> {
         match p {
-            Either::A(ref s) => s.as_str().into(),
+            Either::A(ref s) => s.borrow_value().into(),
             Either::B(i) => i.to_string().into(),
         }
     });
@@ -563,7 +564,7 @@ fn socket_gethostbyaddr(
     vm: &VirtualMachine,
 ) -> PyResult<(String, PyObjectRef, PyObjectRef)> {
     // TODO: figure out how to do this properly
-    let ai = dns_lookup::getaddrinfo(Some(addr.as_str()), None, None)
+    let ai = dns_lookup::getaddrinfo(Some(addr.borrow_value()), None, None)
         .map_err(|e| convert_sock_error(vm, e.into()))?
         .next()
         .unwrap()

--- a/vm/src/stdlib/socket.rs
+++ b/vm/src/stdlib/socket.rs
@@ -442,16 +442,16 @@ impl ToSocketAddrs for Address {
 impl TryFromObject for Address {
     fn try_from_object(vm: &VirtualMachine, obj: PyObjectRef) -> PyResult<Self> {
         let tuple = PyTupleRef::try_from_object(vm, obj)?;
-        if tuple.as_slice().len() != 2 {
+        if tuple.borrow_value().len() != 2 {
             Err(vm.new_type_error("Address tuple should have only 2 values".to_owned()))
         } else {
-            let host = PyStringRef::try_from_object(vm, tuple.as_slice()[0].clone())?;
+            let host = PyStringRef::try_from_object(vm, tuple.borrow_value()[0].clone())?;
             let host = if host.borrow_value().is_empty() {
                 PyString::from("0.0.0.0").into_ref(vm)
             } else {
                 host
             };
-            let port = u16::try_from_object(vm, tuple.as_slice()[1].clone())?;
+            let port = u16::try_from_object(vm, tuple.borrow_value()[1].clone())?;
             Ok(Address { host, port })
         }
     }

--- a/vm/src/stdlib/string.rs
+++ b/vm/src/stdlib/string.rs
@@ -13,7 +13,7 @@ mod _string {
     };
     use crate::obj::objlist::PyList;
     use crate::obj::objstr::PyStringRef;
-    use crate::pyobject::{IntoPyObject, PyObjectRef, PyResult};
+    use crate::pyobject::{BorrowValue, IntoPyObject, PyObjectRef, PyResult};
     use crate::vm::VirtualMachine;
 
     fn create_format_part(
@@ -35,7 +35,7 @@ mod _string {
     #[pyfunction]
     fn formatter_parser(text: PyStringRef, vm: &VirtualMachine) -> PyResult<PyList> {
         let format_string =
-            FormatString::from_str(text.as_str()).map_err(|e| e.into_pyexception(vm))?;
+            FormatString::from_str(text.borrow_value()).map_err(|e| e.into_pyexception(vm))?;
 
         let mut result = Vec::new();
         let mut literal = String::new();
@@ -74,7 +74,8 @@ mod _string {
         text: PyStringRef,
         vm: &VirtualMachine,
     ) -> PyResult<(PyObjectRef, PyList)> {
-        let field_name = FieldName::parse(text.as_str()).map_err(|e| e.into_pyexception(vm))?;
+        let field_name =
+            FieldName::parse(text.borrow_value()).map_err(|e| e.into_pyexception(vm))?;
 
         let first = match field_name.field_type {
             FieldType::Auto => vm.new_str("".to_owned()),

--- a/vm/src/stdlib/symtable.rs
+++ b/vm/src/stdlib/symtable.rs
@@ -5,7 +5,7 @@ use rustpython_parser::parser;
 
 use crate::obj::objstr::PyStringRef;
 use crate::obj::objtype::PyClassRef;
-use crate::pyobject::{PyClassImpl, PyObjectRef, PyRef, PyResult, PyValue};
+use crate::pyobject::{BorrowValue, PyClassImpl, PyObjectRef, PyRef, PyResult, PyValue};
 use crate::vm::VirtualMachine;
 
 pub fn make_module(vm: &VirtualMachine) -> PyObjectRef {
@@ -30,11 +30,11 @@ fn symtable_symtable(
     vm: &VirtualMachine,
 ) -> PyResult<PySymbolTableRef> {
     let mode = mode
-        .as_str()
+        .borrow_value()
         .parse::<compile::Mode>()
         .map_err(|err| vm.new_value_error(err.to_string()))?;
 
-    let symtable = source_to_symtable(source.as_str(), mode, filename.as_str())
+    let symtable = source_to_symtable(source.borrow_value(), mode, filename.borrow_value())
         .map_err(|err| vm.new_syntax_error(&err))?;
 
     let py_symbol_table = to_py_symbol_table(symtable);
@@ -105,7 +105,7 @@ impl PySymbolTable {
 
     #[pymethod(name = "lookup")]
     fn lookup(&self, name: PyStringRef, vm: &VirtualMachine) -> PyResult<PySymbolRef> {
-        let name = name.as_str();
+        let name = name.borrow_value();
         if let Some(symbol) = self.symtable.symbols.get(name) {
             Ok(PySymbol {
                 symbol: symbol.clone(),

--- a/vm/src/stdlib/thread.rs
+++ b/vm/src/stdlib/thread.rs
@@ -229,7 +229,7 @@ fn thread_start_new_thread(
     }
     let res = thread_builder.spawn(move || {
         let vm = &thread_vm;
-        let args = Args::from(args.as_slice().to_owned());
+        let args = Args::from(args.borrow_value().to_owned());
         let kwargs = KwArgs::from(kwargs.map_or_else(Default::default, |k| k.to_attributes()));
         if let Err(exc) = func.invoke(PyFuncArgs::from((args, kwargs)), vm) {
             // TODO: sys.unraisablehook

--- a/vm/src/stdlib/thread.rs
+++ b/vm/src/stdlib/thread.rs
@@ -6,8 +6,8 @@ use crate::obj::objstr::PyStringRef;
 use crate::obj::objtuple::PyTupleRef;
 use crate::obj::objtype::PyClassRef;
 use crate::pyobject::{
-    Either, IdProtocol, ItemProtocol, PyCallable, PyClassImpl, PyObjectRef, PyRef, PyResult,
-    PyValue, TypeProtocol,
+    BorrowValue, Either, IdProtocol, ItemProtocol, PyCallable, PyClassImpl, PyObjectRef, PyRef,
+    PyResult, PyValue, TypeProtocol,
 };
 use crate::vm::VirtualMachine;
 
@@ -238,7 +238,7 @@ fn thread_start_new_thread(
             let repr = vm.to_repr(&func.into_object()).ok();
             let repr = repr
                 .as_ref()
-                .map_or("<object repr() failed>", |s| s.as_str());
+                .map_or("<object repr() failed>", |s| s.borrow_value());
             writeln!(stderr, "Exception ignored in thread started by: {}", repr)
                 .and_then(|()| exceptions::write_exception(&mut stderr, vm, &exc))
                 .ok();
@@ -306,7 +306,7 @@ impl PyLocal {
     #[pymethod(magic)]
     fn getattribute(zelf: PyRef<Self>, attr: PyStringRef, vm: &VirtualMachine) -> PyResult {
         let ldict = zelf.ldict(vm);
-        if attr.as_str() == "__dict__" {
+        if attr.borrow_value() == "__dict__" {
             Ok(ldict.into_object())
         } else {
             let zelf = zelf.into_object();
@@ -324,7 +324,7 @@ impl PyLocal {
         value: PyObjectRef,
         vm: &VirtualMachine,
     ) -> PyResult<()> {
-        if attr.as_str() == "__dict__" {
+        if attr.borrow_value() == "__dict__" {
             Err(vm.new_attribute_error(format!(
                 "{} attribute '__dict__' is read-only",
                 zelf.as_object()
@@ -337,7 +337,7 @@ impl PyLocal {
 
     #[pymethod(magic)]
     fn delattr(zelf: PyRef<Self>, attr: PyStringRef, vm: &VirtualMachine) -> PyResult<()> {
-        if attr.as_str() == "__dict__" {
+        if attr.borrow_value() == "__dict__" {
             Err(vm.new_attribute_error(format!(
                 "{} attribute '__dict__' is read-only",
                 zelf.as_object()

--- a/vm/src/stdlib/time_module.rs
+++ b/vm/src/stdlib/time_module.rs
@@ -11,7 +11,7 @@ use crate::function::OptionalArg;
 use crate::obj::objstr::PyStringRef;
 use crate::obj::objtuple::PyTupleRef;
 use crate::obj::objtype::PyClassRef;
-use crate::pyobject::{Either, PyClassImpl, PyObjectRef, PyResult, TryFromObject};
+use crate::pyobject::{BorrowValue, Either, PyClassImpl, PyObjectRef, PyResult, TryFromObject};
 use crate::vm::VirtualMachine;
 
 #[cfg(unix)]
@@ -152,7 +152,7 @@ fn time_strftime(
         OptionalArg::Present(t) => t.to_date_time(vm)?,
         OptionalArg::Missing => default,
     };
-    let formatted_time = instant.format(format.as_str()).to_string();
+    let formatted_time = instant.format(format.borrow_value()).to_string();
     Ok(vm.ctx.new_str(formatted_time))
 }
 
@@ -162,10 +162,10 @@ fn time_strptime(
     vm: &VirtualMachine,
 ) -> PyResult {
     let format = match format {
-        OptionalArg::Present(ref format) => format.as_str(),
+        OptionalArg::Present(ref format) => format.borrow_value(),
         OptionalArg::Missing => "%a %b %H:%M:%S %Y",
     };
-    let instant = NaiveDateTime::parse_from_str(string.as_str(), format)
+    let instant = NaiveDateTime::parse_from_str(string.borrow_value(), format)
         .map_err(|e| vm.new_value_error(format!("Parse error: {:?}", e)))?;
     Ok(PyStructTime::new(vm, instant, -1).into_obj(vm))
 }

--- a/vm/src/stdlib/tokenize.rs
+++ b/vm/src/stdlib/tokenize.rs
@@ -4,14 +4,13 @@
 
 use std::iter::FromIterator;
 
+use crate::obj::objstr::PyStringRef;
+use crate::pyobject::{BorrowValue, PyObjectRef, PyResult};
+use crate::vm::VirtualMachine;
 use rustpython_parser::lexer;
 
-use crate::obj::objstr::PyStringRef;
-use crate::pyobject::{PyObjectRef, PyResult};
-use crate::vm::VirtualMachine;
-
 fn tokenize_tokenize(s: PyStringRef, vm: &VirtualMachine) -> PyResult {
-    let source = s.as_str();
+    let source = s.borrow_value();
 
     // TODO: implement generator when the time has come.
     let lexer1 = lexer::make_tokenizer(source);

--- a/vm/src/stdlib/unicodedata.rs
+++ b/vm/src/stdlib/unicodedata.rs
@@ -5,7 +5,7 @@
 use crate::function::OptionalArg;
 use crate::obj::objstr::PyStringRef;
 use crate::obj::objtype::PyClassRef;
-use crate::pyobject::{PyClassImpl, PyObject, PyObjectRef, PyResult, PyValue};
+use crate::pyobject::{BorrowValue, PyClassImpl, PyObject, PyObjectRef, PyResult, PyValue};
 use crate::vm::VirtualMachine;
 
 use itertools::Itertools;
@@ -82,9 +82,13 @@ impl PyUCD {
     }
 
     fn extract_char(&self, character: PyStringRef, vm: &VirtualMachine) -> PyResult<Option<char>> {
-        let c = character.as_str().chars().exactly_one().map_err(|_| {
-            vm.new_type_error("argument must be an unicode character, not str".to_owned())
-        })?;
+        let c = character
+            .borrow_value()
+            .chars()
+            .exactly_one()
+            .map_err(|_| {
+                vm.new_type_error("argument must be an unicode character, not str".to_owned())
+            })?;
 
         if self.check_age(c) {
             Ok(Some(c))
@@ -104,7 +108,7 @@ impl PyUCD {
 
     #[pymethod]
     fn lookup(&self, name: PyStringRef, vm: &VirtualMachine) -> PyResult<String> {
-        if let Some(character) = unicode_names2::character(name.as_str()) {
+        if let Some(character) = unicode_names2::character(name.borrow_value()) {
             if self.check_age(character) {
                 return Ok(character.to_string());
             }
@@ -150,8 +154,8 @@ impl PyUCD {
         unistr: PyStringRef,
         vm: &VirtualMachine,
     ) -> PyResult<String> {
-        let text = unistr.as_str();
-        let normalized_text = match form.as_str() {
+        let text = unistr.borrow_value();
+        let normalized_text = match form.borrow_value() {
             "NFC" => text.nfc().collect::<String>(),
             "NFKC" => text.nfkc().collect::<String>(),
             "NFD" => text.nfd().collect::<String>(),

--- a/vm/src/stdlib/winreg.rs
+++ b/vm/src/stdlib/winreg.rs
@@ -4,7 +4,9 @@ use crate::exceptions::IntoPyException;
 use crate::function::OptionalArg;
 use crate::obj::objstr::PyStringRef;
 use crate::obj::objtype::PyClassRef;
-use crate::pyobject::{PyClassImpl, PyObjectRef, PyRef, PyResult, PyValue, TryFromObject};
+use crate::pyobject::{
+    BorrowValue, PyClassImpl, PyObjectRef, PyRef, PyResult, PyValue, TryFromObject,
+};
 use crate::VirtualMachine;
 
 use std::convert::TryInto;
@@ -112,7 +114,7 @@ fn winreg_OpenKey(
         return Err(vm.new_value_error("reserved param must be 0".to_owned()));
     }
 
-    let subkey = subkey.as_ref().map_or("", |s| s.as_str());
+    let subkey = subkey.as_ref().map_or("", |s| s.borrow_value());
     let key = key
         .with_key(|k| k.open_subkey_with_flags(subkey, access))
         .map_err(|e| e.into_pyexception(vm))?;
@@ -125,7 +127,7 @@ fn winreg_QueryValue(
     subkey: Option<PyStringRef>,
     vm: &VirtualMachine,
 ) -> PyResult<String> {
-    let subkey = subkey.as_ref().map_or("", |s| s.as_str());
+    let subkey = subkey.as_ref().map_or("", |s| s.borrow_value());
     key.with_key(|k| k.get_value(subkey))
         .map_err(|e| e.into_pyexception(vm))
 }
@@ -135,7 +137,7 @@ fn winreg_QueryValueEx(
     subkey: Option<PyStringRef>,
     vm: &VirtualMachine,
 ) -> PyResult<(PyObjectRef, usize)> {
-    let subkey = subkey.as_ref().map_or("", |s| s.as_str());
+    let subkey = subkey.as_ref().map_or("", |s| s.borrow_value());
     key.with_key(|k| k.get_raw_value(subkey))
         .map_err(|e| e.into_pyexception(vm))
         .and_then(|regval| {

--- a/vm/src/stdlib/zlib.rs
+++ b/vm/src/stdlib/zlib.rs
@@ -4,7 +4,7 @@ use crate::exceptions::PyBaseExceptionRef;
 use crate::function::OptionalArg;
 use crate::obj::objbytes::{PyBytes, PyBytesRef};
 use crate::obj::objtype::PyClassRef;
-use crate::pyobject::{IntoPyRef, PyClassImpl, PyObjectRef, PyResult, PyValue};
+use crate::pyobject::{BorrowValue, IntoPyRef, PyClassImpl, PyObjectRef, PyResult, PyValue};
 use crate::types::create_type;
 use crate::vm::VirtualMachine;
 
@@ -53,7 +53,7 @@ pub fn make_module(vm: &VirtualMachine) -> PyObjectRef {
 
 /// Compute an Adler-32 checksum of data.
 fn zlib_adler32(data: PyBytesRef, begin_state: OptionalArg<i32>, vm: &VirtualMachine) -> PyResult {
-    let data = data.get_value();
+    let data = data.borrow_value();
 
     let begin_state = begin_state.unwrap_or(1);
 
@@ -67,7 +67,7 @@ fn zlib_adler32(data: PyBytesRef, begin_state: OptionalArg<i32>, vm: &VirtualMac
 
 /// Compute a CRC-32 checksum of data.
 fn zlib_crc32(data: PyBytesRef, begin_state: OptionalArg<i32>, vm: &VirtualMachine) -> PyResult {
-    let data = data.get_value();
+    let data = data.borrow_value();
 
     let begin_state = begin_state.unwrap_or(0);
 
@@ -250,7 +250,7 @@ impl PyDecompress {
         if stream_end && !leftover.is_empty() {
             let mut unused_data = self.unused_data.lock();
             let unused: Vec<_> = unused_data
-                .get_value()
+                .borrow_value()
                 .iter()
                 .chain(leftover)
                 .copied()
@@ -266,7 +266,7 @@ impl PyDecompress {
         } else {
             Some(args.max_length)
         };
-        let data = args.data.get_value();
+        let data = args.data.borrow_value();
 
         let mut d = self.decompress.lock();
         let orig_in = d.total_in();

--- a/vm/src/vm.rs
+++ b/vm/src/vm.rs
@@ -892,7 +892,7 @@ impl VirtualMachine {
             value
                 .payload::<PyTuple>()
                 .unwrap()
-                .as_slice()
+                .borrow_value()
                 .iter()
                 .map(|obj| T::try_from_object(self, obj.clone()))
                 .collect()

--- a/vm/src/vm.rs
+++ b/vm/src/vm.rs
@@ -40,8 +40,8 @@ use crate::obj::objstr::{PyString, PyStringRef};
 use crate::obj::objtuple::PyTuple;
 use crate::obj::objtype::{self, PyClassRef};
 use crate::pyobject::{
-    IdProtocol, ItemProtocol, PyContext, PyObject, PyObjectRef, PyRef, PyResult, PyValue,
-    TryFromObject, TryIntoRef, TypeProtocol, BorrowValue
+    BorrowValue, IdProtocol, ItemProtocol, PyContext, PyObject, PyObjectRef, PyRef, PyResult,
+    PyValue, TryFromObject, TryIntoRef, TypeProtocol,
 };
 use crate::scope::Scope;
 use crate::stdlib;
@@ -655,7 +655,7 @@ impl VirtualMachine {
 
     pub fn to_pystr<'a, T: Into<&'a PyObjectRef>>(&'a self, obj: T) -> PyResult<String> {
         let py_str_obj = self.to_str(obj.into())?;
-        Ok(py_str_obj.as_str().to_owned())
+        Ok(py_str_obj.borrow_value().to_owned())
     }
 
     pub fn to_repr(&self, obj: &PyObjectRef) -> PyResult<PyStringRef> {
@@ -666,7 +666,7 @@ impl VirtualMachine {
     pub fn to_ascii(&self, obj: &PyObjectRef) -> PyResult {
         let repr = self.call_method(obj, "__repr__", vec![])?;
         let repr: PyStringRef = TryFromObject::try_from_object(self, repr)?;
-        let ascii = to_ascii(repr.as_str());
+        let ascii = to_ascii(repr.borrow_value());
         Ok(self.new_str(ascii))
     }
 
@@ -1023,7 +1023,7 @@ impl VirtualMachine {
         name_str: PyStringRef,
         dict: Option<PyDictRef>,
     ) -> PyResult<Option<PyObjectRef>> {
-        let name = name_str.as_str();
+        let name = name_str.borrow_value();
         let cls = obj.class();
 
         if let Some(attr) = cls.get_attr(&name) {
@@ -1037,7 +1037,7 @@ impl VirtualMachine {
         let dict = dict.or_else(|| obj.dict());
 
         let attr = if let Some(dict) = dict {
-            dict.get_item_option(name_str.as_str(), self)?
+            dict.get_item_option(name, self)?
         } else {
             None
         };

--- a/vm/src/vm.rs
+++ b/vm/src/vm.rs
@@ -41,7 +41,7 @@ use crate::obj::objtuple::PyTuple;
 use crate::obj::objtype::{self, PyClassRef};
 use crate::pyobject::{
     IdProtocol, ItemProtocol, PyContext, PyObject, PyObjectRef, PyRef, PyResult, PyValue,
-    TryFromObject, TryIntoRef, TypeProtocol,
+    TryFromObject, TryIntoRef, TypeProtocol, BorrowValue
 };
 use crate::scope::Scope;
 use crate::stdlib;
@@ -900,7 +900,7 @@ impl VirtualMachine {
             value
                 .payload::<PyList>()
                 .unwrap()
-                .borrow_elements()
+                .borrow_value()
                 .iter()
                 .map(|obj| T::try_from_object(self, obj.clone()))
                 .collect()
@@ -1412,7 +1412,7 @@ impl VirtualMachine {
         // TODO: tp_hash
         let hash_obj = self.call_method(obj, "__hash__", vec![])?;
         match hash_obj.payload_if_subclass::<PyInt>(self) {
-            Some(py_int) => Ok(rustpython_common::hash::hash_bigint(py_int.as_bigint())),
+            Some(py_int) => Ok(rustpython_common::hash::hash_bigint(py_int.borrow_value())),
             None => Err(self.new_type_error("__hash__ method should return an integer".to_owned())),
         }
     }

--- a/wasm/lib/src/js_module.rs
+++ b/wasm/lib/src/js_module.rs
@@ -3,7 +3,9 @@ use rustpython_vm::common::rc::PyRc;
 use rustpython_vm::exceptions::PyBaseExceptionRef;
 use rustpython_vm::function::Args;
 use rustpython_vm::obj::{objfloat::PyFloatRef, objstr::PyStringRef, objtype::PyClassRef};
-use rustpython_vm::pyobject::{PyClassImpl, PyObjectRef, PyRef, PyResult, PyValue, TryFromObject};
+use rustpython_vm::pyobject::{
+    BorrowValue, PyClassImpl, PyObjectRef, PyRef, PyResult, PyValue, TryFromObject,
+};
 use rustpython_vm::types::create_type;
 use rustpython_vm::VirtualMachine;
 use wasm_bindgen::{prelude::*, JsCast};
@@ -61,7 +63,7 @@ impl TryFromObject for JsProperty {
 impl JsProperty {
     fn into_jsvalue(self) -> JsValue {
         match self {
-            JsProperty::Str(s) => s.as_str().into(),
+            JsProperty::Str(s) => s.borrow_value().into(),
             JsProperty::Js(value) => value.value.clone(),
         }
     }
@@ -88,7 +90,7 @@ impl PyJsValue {
 
     #[pymethod]
     fn new_from_str(&self, s: PyStringRef) -> PyJsValue {
-        PyJsValue::new(s.as_str())
+        PyJsValue::new(s.borrow_value())
     }
 
     #[pymethod]

--- a/wasm/lib/src/wasm_builtins.rs
+++ b/wasm/lib/src/wasm_builtins.rs
@@ -7,7 +7,7 @@
 use web_sys::{self, console};
 
 use rustpython_vm::obj::objstr::PyStringRef;
-use rustpython_vm::pyobject::{PyObjectRef, PyResult};
+use rustpython_vm::pyobject::{BorrowValue, PyObjectRef, PyResult};
 use rustpython_vm::VirtualMachine;
 
 pub(crate) fn window() -> web_sys::Window {
@@ -26,7 +26,7 @@ pub fn make_stdout_object(
     let ctx = &vm.ctx;
     let write_method = ctx.new_method(
         move |_self: PyObjectRef, data: PyStringRef, vm: &VirtualMachine| -> PyResult<()> {
-            write_f(data.as_str(), vm)
+            write_f(data.borrow_value(), vm)
         },
     );
     let flush_method = ctx.new_method(|_self: PyObjectRef| {});


### PR DESCRIPTION
This trait will allow `PyObjectRef::borrow_value()` which probably be useful to replace `obj*::get_value`.

```rust
    pub fn borrow_value<'a, B, T>(&'a self) -> Option<B> where
        T: PyObjectPayload + BorrowValue<'a, Borrowed=B>,
        B: 'a + Deref,
    {
        self.payload::<T>().map(BorrowValue::borrow_value)
    }
```