### PR TITLE
Fix problems with different hash values for str and bytes

### DIFF
--- a/Lib/test/test_builtin.py
+++ b/Lib/test/test_builtin.py
@@ -691,8 +691,6 @@ class BuiltinTest(unittest.TestCase):
                 raise ValueError
         self.assertRaises(ValueError, hasattr, B(), "b")
 
-    # TODO: RUSTPYTHON
-    @unittest.expectedFailure
     def test_hash(self):
         hash(None)
         self.assertEqual(hash(1), hash(1))

--- a/common/src/hash.rs
+++ b/common/src/hash.rs
@@ -118,5 +118,5 @@ pub fn hash_bigint(value: &BigInt) -> PyHash {
 }
 
 pub fn hash_str(value: &str) -> PyHash {
-    hash_value(value)
+    hash_value(value.as_bytes())
 }


### PR DESCRIPTION
In cpython, the hash values of str and bytes were the same, so the rustpython was modified the same.