### PR TITLE
Implement os.execv on Windows

### DIFF
--- a/vm/src/obj/objstr.rs
+++ b/vm/src/obj/objstr.rs
@@ -1133,6 +1133,15 @@ impl TryFromObject for std::ffi::CString {
     }
 }
 
+impl TryFromObject for std::ffi::OsString {
+    fn try_from_object(vm: &VirtualMachine, obj: PyObjectRef) -> PyResult<Self> {
+        use std::str::FromStr;
+
+        let s = PyStringRef::try_from_object(vm, obj)?;
+        Ok(std::ffi::OsString::from_str(s.borrow_value()).unwrap())
+    }
+}
+
 type SplitArgs<'a> = pystr::SplitArgs<'a, PyStringRef, str, char>;
 
 #[derive(FromArgs)]

--- a/vm/src/stdlib/os.rs
+++ b/vm/src/stdlib/os.rs
@@ -2428,6 +2428,87 @@ mod nt {
     ) {
     }
 
+    #[cfg(target_env = "msvc")]
+    extern "C" {
+        fn _wexecv(cmdname: *const u16, argv: *const *const u16) -> intptr_t;
+    }
+
+    #[cfg(target_env = "msvc")]
+    #[pyfunction]
+    fn execv(path: PyStringRef, argv_list: Either<PyListRef, PyTupleRef>, vm: &VirtualMachine) {
+        use std::iter::once;
+        use std::os::windows::prelude::*;
+
+        let path: Vec<u16> = ffi::OsString::from_str(path.as_str())
+            .unwrap()
+            .encode_wide()
+            .chain(once(0u16))
+            .collect();
+
+        let argv: Vec<ffi::OsString> = match argv_list {
+            Either::A(list) => vm.extract_elements(list.as_object())?,
+            Either::B(tuple) => vm.extract_elements(tuple.as_object())?,
+        };
+
+        if argv.is_empty() {
+            return Err(vm.new_value_error("execv() arg 2 must not be empty".to_owned()));
+        }
+
+        if argv.first().unwrap().to_bytes().is_empty() {
+            return Err(
+                vm.new_value_error("execv() arg 2 first element cannot be empty".to_owned())
+            );
+        }
+
+        let argv = argv.map(|s| s.encode_wide().chain(once(0u16)).collect::<Vec<u16>>());
+
+        // see https://docs.microsoft.com/en-us/cpp/c-runtime-library/reference/execv-wexecv#return-value
+        const E2BIG: i32 = 7;
+        const EACCES: i32 = 13;
+        const EINVAL: i32 = 22;
+        const EMFILE: i32 = 24;
+        const ENOENT: i32 = 2;
+        const ENOEXEC: i32 = 8;
+        const ENOMEM: i32 = 12;
+
+        if (unsafe { _wexecv(&path, &argv) } == -1) {
+            let mut errno = 0;
+            unsafe { _get_errno(&mut errno) };
+            match errno {
+                // TODO: cleanup MSVCRT errno handling (as well as waitpid)
+                E2BIG => Err(vm.new_exception_msg(
+                    vm.ctx.exceptions.os_error.clone(),
+                    "E2BIG: Argument list too long".to_owned(),
+                )),
+                EACCES => Err(vm.new_exception_msg(
+                    vm.ctx.exceptions.os_error.clone(),
+                    "EACCES: Permission denied".to_owned(),
+                )),
+                EINVAL => Err(vm.new_exception_msg(
+                    vm.ctx.exceptions.os_error.clone(),
+                    "EINVAL: Invalid argument".to_owned(),
+                )),
+                EMFILE => Err(vm.new_exception_msg(
+                    vm.ctx.exceptions.os_error.clone(),
+                    "EMFILE: Too many open files".to_owned(),
+                )),
+                ENOENT => Err(vm.new_exception_msg(
+                    vm.ctx.exceptions.os_error.clone(),
+                    "ENOENT: No such file or directory".to_owned(),
+                )),
+                ENOEXEC => Err(vm.new_exception_msg(
+                    vm.ctx.exceptions.os_error.clone(),
+                    "ENOEXEC: Exec format error".to_owned(),
+                )),
+                ENOMEM => Err(vm.new_exception_msg(
+                    vm.ctx.exceptions.os_error.clone(),
+                    "ENOMEM: Not enough memory".to_owned(),
+                )),
+                _ => unreachable!(),
+            }
+        }
+    }
+
     pub(super) fn extend_module_platform_specific(vm: &VirtualMachine, module: &PyObjectRef) {
         let ctx = &vm.ctx;
         extend_module!(vm, module, {

--- a/vm/src/stdlib/os.rs
+++ b/vm/src/stdlib/os.rs
@@ -2478,7 +2478,7 @@ mod nt {
             .chain(once(std::ptr::null()))
             .collect();
 
-        if (unsafe { _wexecv(path.as_ptr(), argv_execv.as_ptr()) } == -1) {
+        if (unsafe { suppress_iph!(_wexecv(path.as_ptr(), argv_execv.as_ptr())) } == -1) {
             Err(errno_err(vm))
         } else {
             Ok(())

--- a/vm/src/stdlib/os.rs
+++ b/vm/src/stdlib/os.rs
@@ -2456,12 +2456,11 @@ mod nt {
             Either::B(tuple) => vm.extract_elements(tuple.as_object())?,
         };
 
-        if argv.is_empty() {
-            return Err(vm.new_value_error("execv() arg 2 must not be empty".to_owned()));
-        }
+        let first = argv
+            .first()
+            .ok_or_else(|| vm.new_value_error("execv() arg 2 must not be empty".to_owned()))?;
 
-        // unwrap is safe, since argv is not empty there has to be a item unless race condition happens
-        if argv.first().unwrap().is_empty() {
+        if first.is_empty() {
             return Err(
                 vm.new_value_error("execv() arg 2 first element cannot be empty".to_owned())
             );


### PR DESCRIPTION
This PR implements `os.execv` via MSVCRT's `_wexec`, which is used in CPython too.