### PR TITLE
Fix module.__new__ to give uninitialized object.

### DIFF
--- a/Lib/test/test_module.py
+++ b/Lib/test/test_module.py
@@ -32,8 +32,6 @@ class ModuleTests(unittest.TestCase):
             pass
         self.assertEqual(foo.__doc__, ModuleType.__doc__)
 
-    # TODO: RUSTPYTHON
-    @unittest.expectedFailure
     def test_uninitialized_missing_getattr(self):
         # Issue 8297
         # test the text in the AttributeError of an uninitialized module
@@ -82,8 +80,6 @@ class ModuleTests(unittest.TestCase):
                           "__loader__": None, "__package__": None,
                           "__spec__": None})
 
-    # TODO: RUSTPYTHON
-    @unittest.expectedFailure
     def test_reinit(self):
         # Reinitialization should not replace the __dict__
         foo = ModuleType("foo", "foodoc\u1234")


### PR DESCRIPTION
**Before**
- CPython 3.7.4
```python
>>> import sys
>>> ModuleType = type(sys)
>>> ModuleType.__new__(ModuleType)
<module '?'>

>>> ModuleType("new_module_name")
<module 'new_module_name'>
```
- RustPython
```python
>>>>> ModuleType.__new__(ModuleType)
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
TypeError: Expected at least 2 arguments (1 given)

>>>>> ModuleType("new_module_name")
<module 'new_module_name'>
```

**After**
- RustPython
```python
>>>>> ModuleType.__new__(ModuleType)
<module '?'>

>>>>> ModuleType("new_module_name")
<module 'new_module_name'>
```