### PR TITLE
Enhance pyclass/pymodule

### DIFF
--- a/derive/src/util.rs
+++ b/derive/src/util.rs
@@ -210,6 +210,10 @@ impl<'a> ItemMeta<'a> {
         Ok(self._str("name")?.unwrap_or_else(|| self.ident.to_string()))
     }
 
+    pub fn optional_name(&self) -> Option<String> {
+        self.simple_name().ok()
+    }
+
     pub fn method_name(&self) -> Result<String, Diagnostic> {
         let name = self._str("name")?;
         let magic = self._bool("magic")?;

--- a/derive/src/util.rs
+++ b/derive/src/util.rs
@@ -75,7 +75,16 @@ pub fn strip_prefix<'a>(s: &'a str, prefix: &str) -> Option<&'a str> {
     }
 }
 
+#[derive(PartialEq)]
+pub enum ItemType {
+    Fn,
+    Method,
+    Struct,
+    Enum,
+}
+
 pub struct ItemIdent<'a> {
+    pub typ: ItemType,
     pub attrs: &'a mut Vec<Attribute>,
     pub ident: &'a Ident,
 }

--- a/derive/src/util.rs
+++ b/derive/src/util.rs
@@ -2,11 +2,11 @@ use super::Diagnostic;
 use std::collections::HashMap;
 use syn::{Attribute, AttributeArgs, Ident, Lit, Meta, NestedMeta, Path};
 
-pub fn path_eq(path: &Path, s: &str) -> bool {
+pub(crate) fn path_eq(path: &Path, s: &str) -> bool {
     path.get_ident().map_or(false, |id| id == s)
 }
 
-pub fn def_to_name(
+pub(crate) fn def_to_name(
     ident: &Ident,
     attr_name: &'static str,
     attr: AttributeArgs,
@@ -32,7 +32,7 @@ pub fn def_to_name(
     Ok(name.unwrap_or_else(|| ident.to_string()))
 }
 
-pub fn optional_attribute_arg(
+pub(crate) fn optional_attribute_arg(
     attr_name: &'static str,
     arg_name: &'static str,
     attr: AttributeArgs,
@@ -59,7 +59,7 @@ pub fn optional_attribute_arg(
     Ok(arg_value)
 }
 
-pub fn module_class_name(mod_name: Option<String>, class_name: &str) -> String {
+pub(crate) fn module_class_name(mod_name: Option<String>, class_name: &str) -> String {
     if let Some(mod_name) = mod_name {
         format!("{}.{}", mod_name, class_name)
     } else {
@@ -67,11 +67,19 @@ pub fn module_class_name(mod_name: Option<String>, class_name: &str) -> String {
     }
 }
 
-pub fn strip_prefix<'a>(s: &'a str, prefix: &str) -> Option<&'a str> {
+pub(crate) fn strip_prefix<'a>(s: &'a str, prefix: &str) -> Option<&'a str> {
     if s.starts_with(prefix) {
         Some(&s[prefix.len()..])
     } else {
         None
+    }
+}
+
+pub(crate) fn meta_into_nesteds(meta: Meta) -> Result<Vec<NestedMeta>, Meta> {
+    match meta {
+        Meta::Path(_) => Ok(Vec::new()),
+        Meta::List(list) => Ok(list.nested.into_iter().collect()),
+        Meta::NameValue(_) => Err(meta),
     }
 }
 
@@ -81,6 +89,7 @@ pub enum ItemType {
     Method,
     Struct,
     Enum,
+    Const,
 }
 
 pub struct ItemIdent<'a> {

--- a/vm/src/stdlib/dis.rs
+++ b/vm/src/stdlib/dis.rs
@@ -1,57 +1,56 @@
-use crate::bytecode::CodeFlags;
-use crate::obj::objcode::PyCodeRef;
-use crate::obj::objstr::PyStringRef;
-use crate::pyobject::{BorrowValue, ItemProtocol, PyObjectRef, PyResult, TryFromObject};
-use crate::vm::VirtualMachine;
-use rustpython_compiler::compile;
+pub(crate) use decl::make_module;
 
-fn dis_dis(obj: PyObjectRef, vm: &VirtualMachine) -> PyResult {
-    // Method or function:
-    if let Ok(co) = vm.get_attribute(obj.clone(), "__code__") {
-        return dis_disassemble(co, vm);
+#[pymodule(name = "dis")]
+mod decl {
+    use crate::bytecode::CodeFlags;
+    use crate::obj::objcode::PyCodeRef;
+    use crate::obj::objdict::PyDictRef;
+    use crate::obj::objstr::PyStringRef;
+    use crate::pyobject::{BorrowValue, ItemProtocol, PyObjectRef, PyResult, TryFromObject};
+    use crate::vm::VirtualMachine;
+    use rustpython_compiler::compile;
+
+    #[pyfunction]
+    fn dis(obj: PyObjectRef, vm: &VirtualMachine) -> PyResult {
+        // Method or function:
+        if let Ok(co) = vm.get_attribute(obj.clone(), "__code__") {
+            return disassemble(co, vm);
+        }
+
+        // String:
+        if let Ok(co_str) = PyStringRef::try_from_object(vm, obj.clone()) {
+            let code = vm
+                .compile(
+                    co_str.borrow_value(),
+                    compile::Mode::Exec,
+                    "<string>".to_owned(),
+                )
+                .map_err(|err| vm.new_syntax_error(&err))?
+                .into_object();
+            return disassemble(code, vm);
+        }
+
+        disassemble(obj, vm)
     }
 
-    // String:
-    if let Ok(co_str) = PyStringRef::try_from_object(vm, obj.clone()) {
-        let code = vm
-            .compile(
-                co_str.borrow_value(),
-                compile::Mode::Exec,
-                "<string>".to_owned(),
+    #[pyfunction]
+    fn disassemble(co: PyObjectRef, vm: &VirtualMachine) -> PyResult {
+        let code = &PyCodeRef::try_from_object(vm, co)?.code;
+        print!("{}", code);
+        Ok(vm.get_none())
+    }
+
+    #[pyattr(name = "COMPILER_FLAG_NAMES")]
+    fn compiler_flag_names(vm: &VirtualMachine) -> PyDictRef {
+        let dict = vm.ctx.new_dict();
+        for (name, flag) in CodeFlags::NAME_MAPPING {
+            dict.set_item(
+                vm.ctx.new_int(flag.bits()),
+                vm.ctx.new_str((*name).to_owned()),
+                vm,
             )
-            .map_err(|err| vm.new_syntax_error(&err))?
-            .into_object();
-        return dis_disassemble(code, vm);
+            .unwrap();
+        }
+        dict
     }
-
-    dis_disassemble(obj, vm)
-}
-
-fn dis_disassemble(co: PyObjectRef, vm: &VirtualMachine) -> PyResult {
-    let code = &PyCodeRef::try_from_object(vm, co)?.code;
-    print!("{}", code);
-    Ok(vm.get_none())
-}
-
-fn dis_compiler_flag_names(vm: &VirtualMachine) -> PyObjectRef {
-    let dict = vm.ctx.new_dict();
-    for (name, flag) in CodeFlags::NAME_MAPPING {
-        dict.set_item(
-            vm.ctx.new_int(flag.bits()),
-            vm.ctx.new_str((*name).to_owned()),
-            vm,
-        )
-        .unwrap();
-    }
-    dict.into_object()
-}
-
-pub fn make_module(vm: &VirtualMachine) -> PyObjectRef {
-    let ctx = &vm.ctx;
-
-    py_module!(vm, "dis", {
-        "dis" => ctx.new_function(dis_dis),
-        "disassemble" => ctx.new_function(dis_disassemble),
-        "COMPILER_FLAG_NAMES" => dis_compiler_flag_names(vm),
-    })
 }

--- a/vm/src/stdlib/faulthandler.rs
+++ b/vm/src/stdlib/faulthandler.rs
@@ -1,60 +1,62 @@
-use crate::frame::FrameRef;
-use crate::function::OptionalArg;
-use crate::pyobject::PyObjectRef;
-use crate::vm::VirtualMachine;
+pub(crate) use decl::make_module;
 
-fn dump_frame(frame: &FrameRef) {
-    eprintln!(
-        "  File \"{}\", line {} in {}",
-        frame.code.source_path,
-        frame.current_location().row(),
-        frame.code.obj_name
-    )
-}
+#[pymodule(name = "faulthandler")]
+mod decl {
+    use crate::frame::FrameRef;
+    use crate::function::OptionalArg;
+    use crate::vm::VirtualMachine;
 
-fn dump_traceback(_file: OptionalArg<i64>, _all_threads: OptionalArg<bool>, vm: &VirtualMachine) {
-    eprintln!("Stack (most recent call first):");
-
-    for frame in vm.frames.borrow().iter() {
-        dump_frame(frame);
+    fn dump_frame(frame: &FrameRef) {
+        eprintln!(
+            "  File \"{}\", line {} in {}",
+            frame.code.source_path,
+            frame.current_location().row(),
+            frame.code.obj_name
+        )
     }
-}
 
-#[derive(FromArgs)]
-#[allow(unused)]
-struct EnableArgs {
-    #[pyarg(positional_or_keyword, default = "None")]
-    file: Option<i64>,
-    #[pyarg(positional_or_keyword, default = "true")]
-    all_threads: bool,
-}
+    #[pyfunction]
+    fn dump_traceback(
+        _file: OptionalArg<i64>,
+        _all_threads: OptionalArg<bool>,
+        vm: &VirtualMachine,
+    ) {
+        eprintln!("Stack (most recent call first):");
 
-fn enable(_args: EnableArgs) {
-    // TODO
-}
+        for frame in vm.frames.borrow().iter() {
+            dump_frame(frame);
+        }
+    }
 
-#[derive(FromArgs)]
-#[allow(unused)]
-struct RegisterArgs {
-    #[pyarg(positional_only)]
-    signum: i64,
-    #[pyarg(positional_or_keyword, default = "None")]
-    file: Option<i64>,
-    #[pyarg(positional_or_keyword, default = "true")]
-    all_threads: bool,
-    #[pyarg(positional_or_keyword, default = "false")]
-    chain: bool,
-}
+    #[derive(FromArgs)]
+    #[allow(unused)]
+    struct EnableArgs {
+        #[pyarg(positional_or_keyword, default = "None")]
+        file: Option<i64>,
+        #[pyarg(positional_or_keyword, default = "true")]
+        all_threads: bool,
+    }
 
-fn register(_args: RegisterArgs) {
-    // TODO
-}
+    #[pyfunction]
+    fn enable(_args: EnableArgs) {
+        // TODO
+    }
 
-pub fn make_module(vm: &VirtualMachine) -> PyObjectRef {
-    let ctx = &vm.ctx;
-    py_module!(vm, "faulthandler", {
-        "dump_traceback" => ctx.new_function(dump_traceback),
-        "enable" => ctx.new_function(enable),
-        "register" => ctx.new_function(register),
-    })
+    #[derive(FromArgs)]
+    #[allow(unused)]
+    struct RegisterArgs {
+        #[pyarg(positional_only)]
+        signum: i64,
+        #[pyarg(positional_or_keyword, default = "None")]
+        file: Option<i64>,
+        #[pyarg(positional_or_keyword, default = "true")]
+        all_threads: bool,
+        #[pyarg(positional_or_keyword, default = "false")]
+        chain: bool,
+    }
+
+    #[pyfunction]
+    fn register(_args: RegisterArgs) {
+        // TODO
+    }
 }

--- a/vm/src/stdlib/functools.rs
+++ b/vm/src/stdlib/functools.rs
@@ -1,46 +1,44 @@
-use crate::function::OptionalArg;
-use crate::obj::objiter;
-use crate::obj::objtype;
-use crate::pyobject::{PyObjectRef, PyResult};
-use crate::vm::VirtualMachine;
+pub(crate) use _functools::make_module;
 
-pub fn make_module(vm: &VirtualMachine) -> PyObjectRef {
-    let ctx = &vm.ctx;
+#[pymodule]
+mod _functools {
+    use crate::function::OptionalArg;
+    use crate::obj::objiter;
+    use crate::obj::objtype;
+    use crate::pyobject::{PyObjectRef, PyResult};
+    use crate::vm::VirtualMachine;
 
-    py_module!(vm, "_functools", {
-        "reduce" => ctx.new_function(functools_reduce),
-    })
-}
+    #[pyfunction]
+    fn reduce(
+        function: PyObjectRef,
+        sequence: PyObjectRef,
+        start_value: OptionalArg<PyObjectRef>,
+        vm: &VirtualMachine,
+    ) -> PyResult {
+        let iterator = objiter::get_iter(vm, &sequence)?;
 
-fn functools_reduce(
-    function: PyObjectRef,
-    sequence: PyObjectRef,
-    start_value: OptionalArg<PyObjectRef>,
-    vm: &VirtualMachine,
-) -> PyResult {
-    let iterator = objiter::get_iter(vm, &sequence)?;
+        let start_value = if let OptionalArg::Present(val) = start_value {
+            val
+        } else {
+            objiter::call_next(vm, &iterator).map_err(|err| {
+                if objtype::isinstance(&err, &vm.ctx.exceptions.stop_iteration) {
+                    let exc_type = vm.ctx.exceptions.type_error.clone();
+                    vm.new_exception_msg(
+                        exc_type,
+                        "reduce() of empty sequence with no initial value".to_owned(),
+                    )
+                } else {
+                    err
+                }
+            })?
+        };
 
-    let start_value = if let OptionalArg::Present(val) = start_value {
-        val
-    } else {
-        objiter::call_next(vm, &iterator).map_err(|err| {
-            if objtype::isinstance(&err, &vm.ctx.exceptions.stop_iteration) {
-                let exc_type = vm.ctx.exceptions.type_error.clone();
-                vm.new_exception_msg(
-                    exc_type,
-                    "reduce() of empty sequence with no initial value".to_owned(),
-                )
-            } else {
-                err
-            }
-        })?
-    };
+        let mut accumulator = start_value;
 
-    let mut accumulator = start_value;
+        while let Ok(next_obj) = objiter::call_next(vm, &iterator) {
+            accumulator = vm.invoke(&function, vec![accumulator, next_obj])?
+        }
 
-    while let Ok(next_obj) = objiter::call_next(vm, &iterator) {
-        accumulator = vm.invoke(&function, vec![accumulator, next_obj])?
+        Ok(accumulator)
     }
-
-    Ok(accumulator)
 }

--- a/vm/src/stdlib/json.rs
+++ b/vm/src/stdlib/json.rs
@@ -1,242 +1,244 @@
-use crate::obj::objiter;
-use crate::obj::objstr::PyStringRef;
-use crate::obj::{objbool, objtype::PyClassRef};
-use crate::pyobject::{
-    BorrowValue, IdProtocol, PyClassImpl, PyObjectRef, PyRef, PyResult, PyValue,
-};
-use crate::VirtualMachine;
-
-use num_bigint::BigInt;
-use std::str::FromStr;
-
+pub(crate) use _json::make_module;
 mod machinery;
 
-#[pyclass(name = "Scanner")]
-#[derive(Debug)]
-struct JsonScanner {
-    strict: bool,
-    object_hook: Option<PyObjectRef>,
-    object_pairs_hook: Option<PyObjectRef>,
-    parse_float: Option<PyObjectRef>,
-    parse_int: Option<PyObjectRef>,
-    parse_constant: PyObjectRef,
-    ctx: PyObjectRef,
-}
+#[pymodule]
+mod _json {
+    use crate::obj::objiter;
+    use crate::obj::objstr::PyStringRef;
+    use crate::obj::{objbool, objtype::PyClassRef};
+    use crate::pyobject::{
+        BorrowValue, IdProtocol, PyClassImpl, PyObjectRef, PyRef, PyResult, PyValue,
+    };
+    use crate::VirtualMachine;
 
-impl PyValue for JsonScanner {
-    fn class(vm: &VirtualMachine) -> PyClassRef {
-        vm.class("_json", "make_scanner")
-    }
-}
+    use num_bigint::BigInt;
+    use std::str::FromStr;
 
-#[pyimpl]
-impl JsonScanner {
-    #[pyslot]
-    fn tp_new(cls: PyClassRef, ctx: PyObjectRef, vm: &VirtualMachine) -> PyResult<PyRef<Self>> {
-        let strict = objbool::boolval(vm, vm.get_attribute(ctx.clone(), "strict")?)?;
-        let object_hook = vm.option_if_none(vm.get_attribute(ctx.clone(), "object_hook")?);
-        let object_pairs_hook =
-            vm.option_if_none(vm.get_attribute(ctx.clone(), "object_pairs_hook")?);
-        let parse_float = vm.get_attribute(ctx.clone(), "parse_float")?;
-        let parse_float = if vm.is_none(&parse_float) || parse_float.is(&vm.ctx.types.float_type) {
-            None
-        } else {
-            Some(parse_float)
-        };
-        let parse_int = vm.get_attribute(ctx.clone(), "parse_int")?;
-        let parse_int = if vm.is_none(&parse_int) || parse_int.is(&vm.ctx.types.int_type) {
-            None
-        } else {
-            Some(parse_int)
-        };
-        let parse_constant = vm.get_attribute(ctx.clone(), "parse_constant")?;
-
-        Self {
-            strict,
-            object_hook,
-            object_pairs_hook,
-            parse_float,
-            parse_int,
-            parse_constant,
-            ctx,
-        }
-        .into_ref_with_type(vm, cls)
+    #[pyattr(name = "make_scanner")]
+    #[pyclass(name = "Scanner")]
+    #[derive(Debug)]
+    struct JsonScanner {
+        strict: bool,
+        object_hook: Option<PyObjectRef>,
+        object_pairs_hook: Option<PyObjectRef>,
+        parse_float: Option<PyObjectRef>,
+        parse_int: Option<PyObjectRef>,
+        parse_constant: PyObjectRef,
+        ctx: PyObjectRef,
     }
 
-    fn parse(
-        &self,
-        s: &str,
-        pystr: PyStringRef,
-        idx: usize,
-        scan_once: PyObjectRef,
-        vm: &VirtualMachine,
-    ) -> PyResult {
-        let c = s
-            .chars()
-            .next()
-            .ok_or_else(|| objiter::stop_iter_with_value(vm.ctx.new_int(idx), vm))?;
-        let next_idx = idx + c.len_utf8();
-        match c {
-            '"' => {
-                // TODO: parse the string in rust
-                let parse_str = vm.get_attribute(self.ctx.clone(), "parse_string")?;
-                return vm.invoke(
-                    &parse_str,
-                    vec![
-                        pystr.into_object(),
-                        vm.ctx.new_int(next_idx),
-                        vm.ctx.new_bool(self.strict),
-                    ],
-                );
-            }
-            '{' => {
-                // TODO: parse the object in rust
-                let parse_obj = vm.get_attribute(self.ctx.clone(), "parse_object")?;
-                return vm.invoke(
-                    &parse_obj,
-                    vec![
-                        vm.ctx
-                            .new_tuple(vec![pystr.into_object(), vm.ctx.new_int(next_idx)]),
-                        vm.ctx.new_bool(self.strict),
-                        scan_once,
-                        self.object_hook.clone().unwrap_or_else(|| vm.get_none()),
-                        self.object_pairs_hook
-                            .clone()
-                            .unwrap_or_else(|| vm.get_none()),
-                    ],
-                );
-            }
-            '[' => {
-                // TODO: parse the array in rust
-                let parse_array = vm.get_attribute(self.ctx.clone(), "parse_array")?;
-                return vm.invoke(
-                    &parse_array,
-                    vec![
-                        vm.ctx
-                            .new_tuple(vec![pystr.into_object(), vm.ctx.new_int(next_idx)]),
-                        scan_once,
-                    ],
-                );
-            }
-            _ => {}
+    impl PyValue for JsonScanner {
+        fn class(vm: &VirtualMachine) -> PyClassRef {
+            vm.class("_json", "make_scanner")
         }
-
-        macro_rules! parse_const {
-            ($s:literal, $val:expr) => {
-                if s.starts_with($s) {
-                    return Ok(vm.ctx.new_tuple(vec![$val, vm.ctx.new_int(idx + $s.len())]));
-                }
-            };
-        }
-
-        parse_const!("null", vm.get_none());
-        parse_const!("true", vm.ctx.new_bool(true));
-        parse_const!("false", vm.ctx.new_bool(false));
-
-        if let Some((res, len)) = self.parse_number(s, vm) {
-            return Ok(vm.ctx.new_tuple(vec![res?, vm.ctx.new_int(idx + len)]));
-        }
-
-        macro_rules! parse_constant {
-            ($s:literal) => {
-                if s.starts_with($s) {
-                    return Ok(vm.ctx.new_tuple(vec![
-                        vm.invoke(&self.parse_constant, vec![vm.ctx.new_str($s.to_owned())])?,
-                        vm.ctx.new_int(idx + $s.len()),
-                    ]));
-                }
-            };
-        }
-
-        parse_constant!("NaN");
-        parse_constant!("Infinity");
-        parse_constant!("-Infinity");
-
-        Err(objiter::stop_iter_with_value(vm.ctx.new_int(idx), vm))
     }
 
-    fn parse_number(&self, s: &str, vm: &VirtualMachine) -> Option<(PyResult, usize)> {
-        let mut has_neg = false;
-        let mut has_decimal = false;
-        let mut has_exponent = false;
-        let mut has_e_sign = false;
-        let mut i = 0;
-        for c in s.chars() {
-            match c {
-                '-' if i == 0 => has_neg = true,
-                n if n.is_ascii_digit() => {}
-                '.' if !has_decimal => has_decimal = true,
-                'e' | 'E' if !has_exponent => has_exponent = true,
-                '+' | '-' if !has_e_sign => has_e_sign = true,
-                _ => break,
-            }
-            i += 1;
-        }
-        if i == 0 || (i == 1 && has_neg) {
-            return None;
-        }
-        let buf = &s[..i];
-        let ret = if has_decimal || has_exponent {
-            // float
-            if let Some(ref parse_float) = self.parse_float {
-                vm.invoke(parse_float, vec![vm.ctx.new_str(buf)])
+    #[pyimpl]
+    impl JsonScanner {
+        #[pyslot]
+        fn tp_new(cls: PyClassRef, ctx: PyObjectRef, vm: &VirtualMachine) -> PyResult<PyRef<Self>> {
+            let strict = objbool::boolval(vm, vm.get_attribute(ctx.clone(), "strict")?)?;
+            let object_hook = vm.option_if_none(vm.get_attribute(ctx.clone(), "object_hook")?);
+            let object_pairs_hook =
+                vm.option_if_none(vm.get_attribute(ctx.clone(), "object_pairs_hook")?);
+            let parse_float = vm.get_attribute(ctx.clone(), "parse_float")?;
+            let parse_float =
+                if vm.is_none(&parse_float) || parse_float.is(&vm.ctx.types.float_type) {
+                    None
+                } else {
+                    Some(parse_float)
+                };
+            let parse_int = vm.get_attribute(ctx.clone(), "parse_int")?;
+            let parse_int = if vm.is_none(&parse_int) || parse_int.is(&vm.ctx.types.int_type) {
+                None
             } else {
-                Ok(vm.ctx.new_float(f64::from_str(buf).unwrap()))
+                Some(parse_int)
+            };
+            let parse_constant = vm.get_attribute(ctx.clone(), "parse_constant")?;
+
+            Self {
+                strict,
+                object_hook,
+                object_pairs_hook,
+                parse_float,
+                parse_int,
+                parse_constant,
+                ctx,
             }
-        } else if let Some(ref parse_int) = self.parse_int {
-            vm.invoke(parse_int, vec![vm.ctx.new_str(buf)])
-        } else {
-            Ok(vm.ctx.new_int(BigInt::from_str(buf).unwrap()))
-        };
-        Some((ret, buf.len()))
-    }
-
-    #[pyslot]
-    fn call(zelf: PyRef<Self>, pystr: PyStringRef, idx: isize, vm: &VirtualMachine) -> PyResult {
-        if idx < 0 {
-            return Err(vm.new_value_error("idx cannot be negative".to_owned()));
+            .into_ref_with_type(vm, cls)
         }
-        let idx = idx as usize;
-        let mut chars = pystr.borrow_value().chars();
-        if idx > 0 {
-            chars
-                .nth(idx - 1)
+
+        fn parse(
+            &self,
+            s: &str,
+            pystr: PyStringRef,
+            idx: usize,
+            scan_once: PyObjectRef,
+            vm: &VirtualMachine,
+        ) -> PyResult {
+            let c = s
+                .chars()
+                .next()
                 .ok_or_else(|| objiter::stop_iter_with_value(vm.ctx.new_int(idx), vm))?;
+            let next_idx = idx + c.len_utf8();
+            match c {
+                '"' => {
+                    // TODO: parse the string in rust
+                    let parse_str = vm.get_attribute(self.ctx.clone(), "parse_string")?;
+                    return vm.invoke(
+                        &parse_str,
+                        vec![
+                            pystr.into_object(),
+                            vm.ctx.new_int(next_idx),
+                            vm.ctx.new_bool(self.strict),
+                        ],
+                    );
+                }
+                '{' => {
+                    // TODO: parse the object in rust
+                    let parse_obj = vm.get_attribute(self.ctx.clone(), "parse_object")?;
+                    return vm.invoke(
+                        &parse_obj,
+                        vec![
+                            vm.ctx
+                                .new_tuple(vec![pystr.into_object(), vm.ctx.new_int(next_idx)]),
+                            vm.ctx.new_bool(self.strict),
+                            scan_once,
+                            self.object_hook.clone().unwrap_or_else(|| vm.get_none()),
+                            self.object_pairs_hook
+                                .clone()
+                                .unwrap_or_else(|| vm.get_none()),
+                        ],
+                    );
+                }
+                '[' => {
+                    // TODO: parse the array in rust
+                    let parse_array = vm.get_attribute(self.ctx.clone(), "parse_array")?;
+                    return vm.invoke(
+                        &parse_array,
+                        vec![
+                            vm.ctx
+                                .new_tuple(vec![pystr.into_object(), vm.ctx.new_int(next_idx)]),
+                            scan_once,
+                        ],
+                    );
+                }
+                _ => {}
+            }
+
+            macro_rules! parse_const {
+                ($s:literal, $val:expr) => {
+                    if s.starts_with($s) {
+                        return Ok(vm.ctx.new_tuple(vec![$val, vm.ctx.new_int(idx + $s.len())]));
+                    }
+                };
+            }
+
+            parse_const!("null", vm.get_none());
+            parse_const!("true", vm.ctx.new_bool(true));
+            parse_const!("false", vm.ctx.new_bool(false));
+
+            if let Some((res, len)) = self.parse_number(s, vm) {
+                return Ok(vm.ctx.new_tuple(vec![res?, vm.ctx.new_int(idx + len)]));
+            }
+
+            macro_rules! parse_constant {
+                ($s:literal) => {
+                    if s.starts_with($s) {
+                        return Ok(vm.ctx.new_tuple(vec![
+                            vm.invoke(&self.parse_constant, vec![vm.ctx.new_str($s.to_owned())])?,
+                            vm.ctx.new_int(idx + $s.len()),
+                        ]));
+                    }
+                };
+            }
+
+            parse_constant!("NaN");
+            parse_constant!("Infinity");
+            parse_constant!("-Infinity");
+
+            Err(objiter::stop_iter_with_value(vm.ctx.new_int(idx), vm))
         }
-        zelf.parse(
-            chars.as_str(),
-            pystr.clone(),
-            idx,
-            zelf.clone().into_object(),
-            vm,
-        )
+
+        fn parse_number(&self, s: &str, vm: &VirtualMachine) -> Option<(PyResult, usize)> {
+            let mut has_neg = false;
+            let mut has_decimal = false;
+            let mut has_exponent = false;
+            let mut has_e_sign = false;
+            let mut i = 0;
+            for c in s.chars() {
+                match c {
+                    '-' if i == 0 => has_neg = true,
+                    n if n.is_ascii_digit() => {}
+                    '.' if !has_decimal => has_decimal = true,
+                    'e' | 'E' if !has_exponent => has_exponent = true,
+                    '+' | '-' if !has_e_sign => has_e_sign = true,
+                    _ => break,
+                }
+                i += 1;
+            }
+            if i == 0 || (i == 1 && has_neg) {
+                return None;
+            }
+            let buf = &s[..i];
+            let ret = if has_decimal || has_exponent {
+                // float
+                if let Some(ref parse_float) = self.parse_float {
+                    vm.invoke(parse_float, vec![vm.ctx.new_str(buf.to_owned())])
+                } else {
+                    Ok(vm.ctx.new_float(f64::from_str(buf).unwrap()))
+                }
+            } else if let Some(ref parse_int) = self.parse_int {
+                vm.invoke(parse_int, vec![vm.ctx.new_str(buf.to_owned())])
+            } else {
+                Ok(vm.ctx.new_int(BigInt::from_str(buf).unwrap()))
+            };
+            Some((ret, buf.len()))
+        }
+
+        #[pyslot]
+        fn call(
+            zelf: PyRef<Self>,
+            pystr: PyStringRef,
+            idx: isize,
+            vm: &VirtualMachine,
+        ) -> PyResult {
+            if idx < 0 {
+                return Err(vm.new_value_error("idx cannot be negative".to_owned()));
+            }
+            let idx = idx as usize;
+            let mut chars = pystr.borrow_value().chars();
+            if idx > 0 {
+                chars
+                    .nth(idx - 1)
+                    .ok_or_else(|| objiter::stop_iter_with_value(vm.ctx.new_int(idx), vm))?;
+            }
+            zelf.parse(
+                chars.as_str(),
+                pystr.clone(),
+                idx,
+                zelf.clone().into_object(),
+                vm,
+            )
+        }
     }
-}
 
-fn encode_string(s: &str, ascii_only: bool) -> String {
-    let mut buf = Vec::<u8>::with_capacity(s.len() + 2);
-    machinery::write_json_string(s, ascii_only, &mut buf)
-        // writing to a vec can't fail
-        .unwrap_or_else(|_| unsafe { std::hint::unreachable_unchecked() });
-    // TODO: verify that the implementation is correct enough to use `from_utf8_unchecked`
-    String::from_utf8(buf).expect("invalid utf-8 in json output")
-}
+    fn encode_string(s: &str, ascii_only: bool) -> String {
+        let mut buf = Vec::<u8>::with_capacity(s.len() + 2);
+        super::machinery::write_json_string(s, ascii_only, &mut buf)
+            // writing to a vec can't fail
+            .unwrap_or_else(|_| unsafe { std::hint::unreachable_unchecked() });
+        // TODO: verify that the implementation is correct enough to use `from_utf8_unchecked`
+        String::from_utf8(buf).expect("invalid utf-8 in json output")
+    }
 
-fn _json_encode_basestring(s: PyStringRef) -> String {
-    encode_string(s.borrow_value(), false)
-}
+    #[pyfunction]
+    fn encode_basestring(s: PyStringRef) -> String {
+        encode_string(s.borrow_value(), false)
+    }
 
-fn _json_encode_basestring_ascii(s: PyStringRef) -> String {
-    encode_string(s.borrow_value(), true)
-}
-
-pub fn make_module(vm: &VirtualMachine) -> PyObjectRef {
-    let ctx = &vm.ctx;
-    let scanner_cls = JsonScanner::make_class(ctx);
-    scanner_cls.set_str_attr("__module__", vm.ctx.new_str("_json"));
-    py_module!(vm, "_json", {
-        "make_scanner" => scanner_cls,
-        "encode_basestring" => named_function!(ctx, _json, encode_basestring),
-        "encode_basestring_ascii" => named_function!(ctx, _json, encode_basestring_ascii),
-    })
+    #[pyfunction]
+    fn encode_basestring_ascii(s: PyStringRef) -> String {
+        encode_string(s.borrow_value(), true)
+    }
 }

--- a/vm/src/stdlib/keyword.rs
+++ b/vm/src/stdlib/keyword.rs
@@ -1,32 +1,29 @@
-/*
- * Testing if a string is a keyword.
- */
+/// Testing if a string is a keyword.
+pub(crate) use decl::make_module;
 
-use rustpython_parser::lexer;
+#[pymodule(name = "keyword")]
+mod decl {
+    use rustpython_parser::lexer;
 
-use crate::obj::objstr::PyStringRef;
-use crate::pyobject::{BorrowValue, PyObjectRef, PyResult};
-use crate::vm::VirtualMachine;
+    use crate::obj::objstr::PyStringRef;
+    use crate::pyobject::{BorrowValue, PyObjectRef, PyResult};
+    use crate::vm::VirtualMachine;
 
-fn keyword_iskeyword(s: PyStringRef, vm: &VirtualMachine) -> PyResult {
-    let keywords = lexer::get_keywords();
-    let value = keywords.contains_key(s.borrow_value());
-    let value = vm.ctx.new_bool(value);
-    Ok(value)
-}
+    #[pyfunction]
+    fn iskeyword(s: PyStringRef, vm: &VirtualMachine) -> PyResult {
+        let keywords = lexer::get_keywords();
+        let value = keywords.contains_key(s.borrow_value());
+        let value = vm.ctx.new_bool(value);
+        Ok(value)
+    }
 
-pub fn make_module(vm: &VirtualMachine) -> PyObjectRef {
-    let ctx = &vm.ctx;
-
-    let keyword_kwlist = ctx.new_list(
-        lexer::get_keywords()
-            .keys()
-            .map(|k| ctx.new_str(k))
-            .collect(),
-    );
-
-    py_module!(vm, "keyword", {
-        "iskeyword" => ctx.new_function(keyword_iskeyword),
-        "kwlist" => keyword_kwlist
-    })
+    #[pyattr]
+    fn kwlist(vm: &VirtualMachine) -> PyObjectRef {
+        vm.ctx.new_list(
+            lexer::get_keywords()
+                .keys()
+                .map(|k| vm.ctx.new_str(k.to_owned()))
+                .collect(),
+        )
+    }
 }

--- a/vm/src/stdlib/marshal.rs
+++ b/vm/src/stdlib/marshal.rs
@@ -1,24 +1,22 @@
-use crate::bytecode;
-use crate::obj::objbytes::{PyBytes, PyBytesRef};
-use crate::obj::objcode::{PyCode, PyCodeRef};
-use crate::pyobject::{PyObjectRef, PyResult};
-use crate::vm::VirtualMachine;
+pub(crate) use decl::make_module;
 
-fn marshal_dumps(co: PyCodeRef) -> PyBytes {
-    PyBytes::from(co.code.to_bytes())
-}
+#[pymodule(name = "marshal")]
+mod decl {
+    use crate::bytecode;
+    use crate::obj::objbytes::{PyBytes, PyBytesRef};
+    use crate::obj::objcode::{PyCode, PyCodeRef};
+    use crate::pyobject::PyResult;
+    use crate::vm::VirtualMachine;
 
-fn marshal_loads(code_bytes: PyBytesRef, vm: &VirtualMachine) -> PyResult<PyCode> {
-    let code = bytecode::CodeObject::from_bytes(&code_bytes)
-        .map_err(|_| vm.new_value_error("Couldn't deserialize python bytecode".to_owned()))?;
-    Ok(PyCode { code })
-}
+    #[pyfunction]
+    fn dumps(co: PyCodeRef) -> PyBytes {
+        PyBytes::from(co.code.to_bytes())
+    }
 
-pub fn make_module(vm: &VirtualMachine) -> PyObjectRef {
-    let ctx = &vm.ctx;
-
-    py_module!(vm, "marshal", {
-        "loads" => ctx.new_function(marshal_loads),
-        "dumps" => ctx.new_function(marshal_dumps),
-    })
+    #[pyfunction]
+    fn loads(code_bytes: PyBytesRef, vm: &VirtualMachine) -> PyResult<PyCode> {
+        let code = bytecode::CodeObject::from_bytes(&code_bytes)
+            .map_err(|_| vm.new_value_error("Couldn't deserialize python bytecode".to_owned()))?;
+        Ok(PyCode { code })
+    }
 }

--- a/vm/src/stdlib/multiprocessing.rs
+++ b/vm/src/stdlib/multiprocessing.rs
@@ -1,65 +1,49 @@
-#[allow(unused_imports)]
-use crate::byteslike::PyBytesLike;
-#[allow(unused_imports)]
-use crate::pyobject::{PyObjectRef, PyResult};
-use crate::VirtualMachine;
+pub(crate) use _multiprocessing::make_module;
 
 #[cfg(windows)]
-use winapi::um::winsock2::{self, SOCKET};
+#[pymodule]
+mod _multiprocessing {
+    use super::super::os;
+    use crate::byteslike::PyBytesLike;
+    use crate::pyobject::PyResult;
+    use crate::VirtualMachine;
+    use winapi::um::winsock2::{self, SOCKET};
 
-#[cfg(windows)]
-fn multiprocessing_closesocket(socket: usize, vm: &VirtualMachine) -> PyResult<()> {
-    let res = unsafe { winsock2::closesocket(socket as SOCKET) };
-    if res == 0 {
-        Err(super::os::errno_err(vm))
-    } else {
-        Ok(())
+    #[pyfunction]
+    fn closesocket(socket: usize, vm: &VirtualMachine) -> PyResult<()> {
+        let res = unsafe { winsock2::closesocket(socket as SOCKET) };
+        if res == 0 {
+            Err(os::errno_err(vm))
+        } else {
+            Ok(())
+        }
     }
-}
 
-#[cfg(windows)]
-fn multiprocessing_recv(socket: usize, size: usize, vm: &VirtualMachine) -> PyResult<libc::c_int> {
-    let mut buf = vec![0 as libc::c_char; size];
-    let nread =
-        unsafe { winsock2::recv(socket as SOCKET, buf.as_mut_ptr() as *mut _, size as i32, 0) };
-    if nread < 0 {
-        Err(super::os::errno_err(vm))
-    } else {
-        Ok(nread)
+    #[pyfunction]
+    fn recv(socket: usize, size: usize, vm: &VirtualMachine) -> PyResult<libc::c_int> {
+        let mut buf = vec![0 as libc::c_char; size];
+        let nread =
+            unsafe { winsock2::recv(socket as SOCKET, buf.as_mut_ptr() as *mut _, size as i32, 0) };
+        if nread < 0 {
+            Err(os::errno_err(vm))
+        } else {
+            Ok(nread)
+        }
     }
-}
 
-#[cfg(windows)]
-fn multiprocessing_send(
-    socket: usize,
-    buf: PyBytesLike,
-    vm: &VirtualMachine,
-) -> PyResult<libc::c_int> {
-    let ret = buf.with_ref(|b| unsafe {
-        winsock2::send(socket as SOCKET, b.as_ptr() as *const _, b.len() as i32, 0)
-    });
-    if ret < 0 {
-        Err(super::os::errno_err(vm))
-    } else {
-        Ok(ret)
+    #[pyfunction]
+    fn send(socket: usize, buf: PyBytesLike, vm: &VirtualMachine) -> PyResult<libc::c_int> {
+        let ret = buf.with_ref(|b| unsafe {
+            winsock2::send(socket as SOCKET, b.as_ptr() as *const _, b.len() as i32, 0)
+        });
+        if ret < 0 {
+            Err(os::errno_err(vm))
+        } else {
+            Ok(ret)
+        }
     }
-}
-
-pub fn make_module(vm: &VirtualMachine) -> PyObjectRef {
-    let module = py_module!(vm, "_multiprocessing", {});
-    extend_module_platform_specific(vm, &module);
-    module
-}
-
-#[cfg(windows)]
-fn extend_module_platform_specific(vm: &VirtualMachine, module: &PyObjectRef) {
-    let ctx = &vm.ctx;
-    extend_module!(vm, module, {
-        "closesocket" => ctx.new_function(multiprocessing_closesocket),
-        "recv" => ctx.new_function(multiprocessing_recv),
-        "send" => ctx.new_function(multiprocessing_send),
-    })
 }
 
 #[cfg(not(windows))]
-fn extend_module_platform_specific(_vm: &VirtualMachine, _module: &PyObjectRef) {}
+#[pymodule]
+mod _multiprocessing {}

--- a/vm/src/stdlib/os.rs
+++ b/vm/src/stdlib/os.rs
@@ -883,12 +883,9 @@ impl<'a> SupportFunc {
 
 pub fn make_module(vm: &VirtualMachine) -> PyObjectRef {
     let ctx = &vm.ctx;
-    let environ = platform::_environ(vm);
     let module = platform::make_module(vm);
 
     extend_module!(vm, module, {
-        "environ" => environ,
-
         "O_RDONLY" => ctx.new_int(libc::O_RDONLY),
         "O_WRONLY" => ctx.new_int(libc::O_WRONLY),
         "O_RDWR" => ctx.new_int(libc::O_RDWR),
@@ -1119,7 +1116,8 @@ mod posix {
         Ok(ffi::OsStr::from_bytes(b))
     }
 
-    pub(super) fn _environ(vm: &VirtualMachine) -> PyDictRef {
+    #[pyattr]
+    fn environ(vm: &VirtualMachine) -> PyDictRef {
         let environ = vm.ctx.new_dict();
         use std::os::unix::ffi::OsStringExt;
         for (key, value) in env::vars_os() {
@@ -2234,7 +2232,8 @@ mod nt {
         m
     }
 
-    pub(super) fn _environ(vm: &VirtualMachine) -> PyDictRef {
+    #[pyattr]
+    fn environ(vm: &VirtualMachine) -> PyDictRef {
         let environ = vm.ctx.new_dict();
 
         for (key, value) in env::vars() {
@@ -2540,7 +2539,8 @@ mod minor {
         unimplemented!();
     }
 
-    pub(super) fn _environ(vm: &VirtualMachine) -> PyDictRef {
+    #[pyattr]
+    fn environ(vm: &VirtualMachine) -> PyDictRef {
         vm.ctx.new_dict()
     }
 

--- a/vm/src/stdlib/os.rs
+++ b/vm/src/stdlib/os.rs
@@ -247,6 +247,35 @@ mod _os {
     use super::platform::OpenFlags;
     use super::*;
 
+    #[pyattr]
+    const O_RDONLY: libc::c_int = libc::O_RDONLY;
+    #[pyattr]
+    const O_WRONLY: libc::c_int = libc::O_WRONLY;
+    #[pyattr]
+    const O_RDWR: libc::c_int = libc::O_RDWR;
+    #[pyattr]
+    const O_APPEND: libc::c_int = libc::O_APPEND;
+    #[pyattr]
+    const O_EXCL: libc::c_int = libc::O_EXCL;
+    #[pyattr]
+    const O_CREAT: libc::c_int = libc::O_CREAT;
+    #[pyattr]
+    const O_TRUNC: libc::c_int = libc::O_TRUNC;
+    #[pyattr]
+    pub(super) const F_OK: u8 = 0;
+    #[pyattr]
+    pub(super) const R_OK: u8 = 4;
+    #[pyattr]
+    pub(super) const W_OK: u8 = 2;
+    #[pyattr]
+    pub(super) const X_OK: u8 = 1;
+    #[pyattr]
+    const SEEK_SET: libc::c_int = libc::SEEK_SET;
+    #[pyattr]
+    const SEEK_CUR: libc::c_int = libc::SEEK_CUR;
+    #[pyattr]
+    const SEEK_END: libc::c_int = libc::SEEK_END;
+
     #[pyfunction]
     fn close(fileno: i64) {
         //The File type automatically closes when it goes out of scope.
@@ -882,25 +911,7 @@ impl<'a> SupportFunc {
 }
 
 pub fn make_module(vm: &VirtualMachine) -> PyObjectRef {
-    let ctx = &vm.ctx;
     let module = platform::make_module(vm);
-
-    extend_module!(vm, module, {
-        "O_RDONLY" => ctx.new_int(libc::O_RDONLY),
-        "O_WRONLY" => ctx.new_int(libc::O_WRONLY),
-        "O_RDWR" => ctx.new_int(libc::O_RDWR),
-        "O_APPEND" => ctx.new_int(libc::O_APPEND),
-        "O_EXCL" => ctx.new_int(libc::O_EXCL),
-        "O_CREAT" => ctx.new_int(libc::O_CREAT),
-        "O_TRUNC" => ctx.new_int(libc::O_TRUNC),
-        "F_OK" => ctx.new_int(0),
-        "R_OK" => ctx.new_int(4),
-        "W_OK" => ctx.new_int(2),
-        "X_OK" => ctx.new_int(1),
-        "SEEK_SET" => ctx.new_int(libc::SEEK_SET),
-        "SEEK_CUR" => ctx.new_int(libc::SEEK_CUR),
-        "SEEK_END" => ctx.new_int(libc::SEEK_END),
-    });
 
     _os::extend_module(&vm, &module);
     platform::extend_module_platform_specific(&vm, &module);
@@ -1000,10 +1011,10 @@ mod posix {
     // Flags for os_access
     bitflags! {
         pub struct AccessFlags: u8{
-            const F_OK = 0;
-            const R_OK = 4;
-            const W_OK = 2;
-            const X_OK = 1;
+            const F_OK = super::_os::F_OK;
+            const R_OK = super::_os::R_OK;
+            const W_OK = super::_os::W_OK;
+            const X_OK = super::_os::X_OK;
         }
     }
 

--- a/vm/src/stdlib/os.rs
+++ b/vm/src/stdlib/os.rs
@@ -914,7 +914,6 @@ pub fn make_module(vm: &VirtualMachine) -> PyObjectRef {
     let module = platform::make_module(vm);
 
     _os::extend_module(&vm, &module);
-    platform::extend_module_platform_specific(&vm, &module);
 
     let support_funcs = _os::support_funcs(vm);
     let supports_fd = PySet::default().into_ref(vm);
@@ -980,7 +979,102 @@ mod posix {
     pub(super) use std::os::unix::fs::OpenOptionsExt;
     use std::os::unix::io::RawFd;
 
+    #[pyattr]
+    const WNOHANG: libc::c_int = libc::WNOHANG;
+    #[pyattr]
+    const EX_OK: i8 = exitcode::OK as i8;
+    #[pyattr]
+    const EX_USAGE: i8 = exitcode::USAGE as i8;
+    #[pyattr]
+    const EX_DATAERR: i8 = exitcode::DATAERR as i8;
+    #[pyattr]
+    const EX_NOINPUT: i8 = exitcode::NOINPUT as i8;
+    #[pyattr]
+    const EX_NOUSER: i8 = exitcode::NOUSER as i8;
+    #[pyattr]
+    const EX_NOHOST: i8 = exitcode::NOHOST as i8;
+    #[pyattr]
+    const EX_UNAVAILABLE: i8 = exitcode::UNAVAILABLE as i8;
+    #[pyattr]
+    const EX_SOFTWARE: i8 = exitcode::SOFTWARE as i8;
+    #[pyattr]
+    const EX_OSERR: i8 = exitcode::OSERR as i8;
+    #[pyattr]
+    const EX_OSFILE: i8 = exitcode::OSFILE as i8;
+    #[pyattr]
+    const EX_CANTCREAT: i8 = exitcode::CANTCREAT as i8;
+    #[pyattr]
+    const EX_IOERR: i8 = exitcode::IOERR as i8;
+    #[pyattr]
+    const EX_TEMPFAIL: i8 = exitcode::TEMPFAIL as i8;
+    #[pyattr]
+    const EX_PROTOCOL: i8 = exitcode::PROTOCOL as i8;
+    #[pyattr]
+    const EX_NOPERM: i8 = exitcode::NOPERM as i8;
+    #[pyattr]
+    const EX_CONFIG: i8 = exitcode::CONFIG as i8;
+    #[pyattr]
+    const O_NONBLOCK: libc::c_int = libc::O_NONBLOCK;
+    #[pyattr]
+    const O_CLOEXEC: libc::c_int = libc::O_CLOEXEC;
+
+    #[cfg(not(target_os = "redox"))]
+    #[pyattr]
+    const O_DSYNC: libc::c_int = libc::O_DSYNC;
+    #[cfg(not(target_os = "redox"))]
+    #[pyattr]
+    const O_NDELAY: libc::c_int = libc::O_NDELAY;
+    #[cfg(not(target_os = "redox"))]
+    #[pyattr]
+    const O_NOCTTY: libc::c_int = libc::O_NOCTTY;
+
+    // cfg taken from nix
+    #[cfg(any(
+        target_os = "dragonfly",
+        target_os = "freebsd",
+        all(
+            target_os = "linux",
+            not(any(target_env = "musl", target_arch = "mips", target_arch = "mips64"))
+        )
+    ))]
+    #[pyattr]
+    const SEEK_DATA: i8 = unistd::Whence::SeekData as i8;
+    #[cfg(any(
+        target_os = "dragonfly",
+        target_os = "freebsd",
+        all(
+            target_os = "linux",
+            not(any(target_env = "musl", target_arch = "mips", target_arch = "mips64"))
+        )
+    ))]
+    #[pyattr]
+    const SEEK_HOLE: i8 = unistd::Whence::SeekHole as i8;
+
+    #[cfg(any(target_os = "linux", target_os = "freebsd", target_os = "macos"))]
+    #[pyattr]
+    const POSIX_SPAWN_OPEN: i32 = PosixSpawnFileActionIdentifier::Open as i32;
+    #[cfg(any(target_os = "linux", target_os = "freebsd", target_os = "macos"))]
+    #[pyattr]
+    const POSIX_SPAWN_CLOSE: i32 = PosixSpawnFileActionIdentifier::Close as i32;
+    #[cfg(any(target_os = "linux", target_os = "freebsd", target_os = "macos"))]
+    #[pyattr]
+    const POSIX_SPAWN_DUP2: i32 = PosixSpawnFileActionIdentifier::Dup2 as i32;
+
+    #[cfg(target_os = "macos")]
+    #[pyattr]
+    const _COPYFILE_DATA: u32 = 1 << 3;
+
     pub(super) type OpenFlags = i32;
+
+    // Flags for os_access
+    bitflags! {
+        pub struct AccessFlags: u8{
+            const F_OK = super::_os::F_OK;
+            const R_OK = super::_os::R_OK;
+            const W_OK = super::_os::W_OK;
+            const X_OK = super::_os::X_OK;
+        }
+    }
 
     impl PyPathLike {
         pub fn into_bytes(self) -> Vec<u8> {
@@ -1005,16 +1099,6 @@ mod posix {
         match errno {
             Errno::EPERM => vm.ctx.exceptions.permission_error.clone(),
             _ => vm.ctx.exceptions.os_error.clone(),
-        }
-    }
-
-    // Flags for os_access
-    bitflags! {
-        pub struct AccessFlags: u8{
-            const F_OK = super::_os::F_OK;
-            const R_OK = super::_os::R_OK;
-            const W_OK = super::_os::W_OK;
-            const X_OK = super::_os::X_OK;
         }
     }
 
@@ -2027,8 +2111,7 @@ mod posix {
             flags: u32,               // copyfile_flags_t
         ) -> libc::c_int;
     }
-    #[cfg(target_os = "macos")]
-    const COPYFILE_DATA: u32 = 1 << 3;
+
     #[cfg(target_os = "macos")]
     #[pyfunction]
     fn _fcopyfile(in_fd: i32, out_fd: i32, flags: i32, vm: &VirtualMachine) -> PyResult<()> {
@@ -2038,75 +2121,6 @@ mod posix {
         } else {
             Ok(())
         }
-    }
-
-    pub(super) fn extend_module_platform_specific(vm: &VirtualMachine, module: &PyObjectRef) {
-        let ctx = &vm.ctx;
-
-        extend_module!(vm, module, {
-            "WNOHANG" => ctx.new_int(libc::WNOHANG),
-            "EX_OK" => ctx.new_int(exitcode::OK as i8),
-            "EX_USAGE" => ctx.new_int(exitcode::USAGE as i8),
-            "EX_DATAERR" => ctx.new_int(exitcode::DATAERR as i8),
-            "EX_NOINPUT" => ctx.new_int(exitcode::NOINPUT as i8),
-            "EX_NOUSER" => ctx.new_int(exitcode::NOUSER as i8),
-            "EX_NOHOST" => ctx.new_int(exitcode::NOHOST as i8),
-            "EX_UNAVAILABLE" => ctx.new_int(exitcode::UNAVAILABLE as i8),
-            "EX_SOFTWARE" => ctx.new_int(exitcode::SOFTWARE as i8),
-            "EX_OSERR" => ctx.new_int(exitcode::OSERR as i8),
-            "EX_OSFILE" => ctx.new_int(exitcode::OSFILE as i8),
-            "EX_CANTCREAT" => ctx.new_int(exitcode::CANTCREAT as i8),
-            "EX_IOERR" => ctx.new_int(exitcode::IOERR as i8),
-            "EX_TEMPFAIL" => ctx.new_int(exitcode::TEMPFAIL as i8),
-            "EX_PROTOCOL" => ctx.new_int(exitcode::PROTOCOL as i8),
-            "EX_NOPERM" => ctx.new_int(exitcode::NOPERM as i8),
-            "EX_CONFIG" => ctx.new_int(exitcode::CONFIG as i8),
-            "O_NONBLOCK" => ctx.new_int(libc::O_NONBLOCK),
-            "O_CLOEXEC" => ctx.new_int(libc::O_CLOEXEC),
-        });
-
-        #[cfg(not(target_os = "redox"))]
-        extend_module!(vm, module, {
-
-            "O_DSYNC" => ctx.new_int(libc::O_DSYNC),
-            "O_NDELAY" => ctx.new_int(libc::O_NDELAY),
-            "O_NOCTTY" => ctx.new_int(libc::O_NOCTTY),
-        });
-
-        // cfg taken from nix
-        #[cfg(any(
-            target_os = "dragonfly",
-            target_os = "freebsd",
-            all(
-                target_os = "linux",
-                not(any(target_env = "musl", target_arch = "mips", target_arch = "mips64"))
-            )
-        ))]
-        extend_module!(vm, module, {
-            "SEEK_DATA" => ctx.new_int(unistd::Whence::SeekData as i8),
-            "SEEK_HOLE" => ctx.new_int(unistd::Whence::SeekHole as i8)
-        });
-        // cfg from nix
-        #[cfg(any(
-            target_os = "android",
-            target_os = "dragonfly",
-            target_os = "emscripten",
-            target_os = "freebsd",
-            target_os = "linux",
-            target_os = "netbsd",
-            target_os = "openbsd"
-        ))]
-        #[cfg(any(target_os = "linux", target_os = "freebsd", target_os = "macos"))]
-        extend_module!(vm, module, {
-            "POSIX_SPAWN_OPEN" => ctx.new_int(i32::from(PosixSpawnFileActionIdentifier::Open)),
-            "POSIX_SPAWN_CLOSE" => ctx.new_int(i32::from(PosixSpawnFileActionIdentifier::Close)),
-            "POSIX_SPAWN_DUP2" => ctx.new_int(i32::from(PosixSpawnFileActionIdentifier::Dup2)),
-        });
-
-        #[cfg(target_os = "macos")]
-        extend_module!(vm, module, {
-            "_COPYFILE_DATA" => ctx.new_int(COPYFILE_DATA),
-        });
     }
 
     pub(super) fn support_funcs(vm: &VirtualMachine) -> Vec<SupportFunc> {
@@ -2136,6 +2150,9 @@ mod nt {
     use std::os::windows::io::RawHandle;
     #[cfg(target_env = "msvc")]
     use winapi::vc::vcruntime::intptr_t;
+
+    #[pyattr]
+    const O_BINARY: libc::c_int = libc::O_BINARY;
 
     pub(super) type OpenFlags = u32;
 
@@ -2479,13 +2496,6 @@ mod nt {
         }
     }
 
-    pub(super) fn extend_module_platform_specific(vm: &VirtualMachine, module: &PyObjectRef) {
-        let ctx = &vm.ctx;
-        extend_module!(vm, module, {
-            "O_BINARY" => ctx.new_int(libc::O_BINARY),
-        });
-    }
-
     pub(super) fn support_funcs(_vm: &VirtualMachine) -> Vec<SupportFunc> {
         Vec::new()
     }
@@ -2554,8 +2564,6 @@ mod minor {
     fn environ(vm: &VirtualMachine) -> PyDictRef {
         vm.ctx.new_dict()
     }
-
-    pub fn extend_module_platform_specific(_vm: &VirtualMachine, _module: &PyObjectRef) {}
 
     pub(super) fn support_funcs(_vm: &VirtualMachine) -> Vec<SupportFunc> {
         Vec::new()

--- a/vm/src/stdlib/select.rs
+++ b/vm/src/stdlib/select.rs
@@ -1,25 +1,29 @@
-use crate::exceptions::IntoPyException;
-use crate::function::OptionalOption;
-use crate::pyobject::{Either, PyObjectRef, PyResult, TryFromObject};
+use crate::pyobject::{PyObjectRef, PyResult, TryFromObject};
 use crate::vm::VirtualMachine;
-use std::{io, mem};
+
+pub(crate) fn make_module(vm: &VirtualMachine) -> PyObjectRef {
+    #[cfg(windows)]
+    {
+        let _ = unsafe { winapi::um::winsock2::WSAStartup(0x0101, &mut std::mem::zeroed()) };
+    }
+
+    decl::make_module(vm)
+}
 
 #[cfg(unix)]
-type RawFd = i32;
+mod platform {
+    pub(super) use libc::{fd_set, select, timeval, FD_ISSET, FD_SET, FD_SETSIZE, FD_ZERO};
+    pub(super) use std::os::unix::io::RawFd;
+}
 
-#[cfg(unix)]
-use libc::{select, timeval};
-
-#[cfg(windows)]
-use winapi::um::winsock2::{select, timeval, WSAStartup, SOCKET as RawFd};
-
-// from winsock2.h: https://gist.github.com/piscisaureus/906386#file-winsock2-h-L128-L141
-#[cfg(windows)]
 #[allow(non_snake_case)]
-mod fdset_ops {
-    pub use winapi::um::winsock2::{__WSAFDIsSet, fd_set, FD_SETSIZE, SOCKET};
+#[cfg(windows)]
+mod platform {
+    pub(super) use winapi::um::winsock2::{fd_set, select, timeval, FD_SETSIZE, SOCKET as RawFd};
 
-    pub unsafe fn FD_SET(fd: SOCKET, set: *mut fd_set) {
+    // from winsock2.h: https://gist.github.com/piscisaureus/906386#file-winsock2-h-L128-L141
+
+    pub(super) unsafe fn FD_SET(fd: RawFd, set: *mut fd_set) {
         let mut i = 0;
         for idx in 0..(*set).fd_count as usize {
             i = idx;
@@ -35,18 +39,17 @@ mod fdset_ops {
         }
     }
 
-    pub unsafe fn FD_ZERO(set: *mut fd_set) {
+    pub(super) unsafe fn FD_ZERO(set: *mut fd_set) {
         (*set).fd_count = 0;
     }
 
-    pub unsafe fn FD_ISSET(fd: SOCKET, set: *mut fd_set) -> bool {
+    pub(super) unsafe fn FD_ISSET(fd: RawFd, set: *mut fd_set) -> bool {
+        use winapi::um::winsock2::__WSAFDIsSet;
         __WSAFDIsSet(fd as _, set) != 0
     }
 }
-#[cfg(unix)]
-use libc as fdset_ops;
 
-use fdset_ops::{fd_set, FD_ISSET, FD_SET, FD_SETSIZE, FD_ZERO};
+use platform::{timeval, RawFd};
 
 struct Selectable {
     obj: PyObjectRef,
@@ -66,31 +69,31 @@ impl TryFromObject for Selectable {
 }
 
 #[repr(C)]
-struct FdSet(fd_set);
+struct FdSet(platform::fd_set);
 
 impl FdSet {
     pub fn new() -> FdSet {
         // it's just ints, and all the code that's actually
         // interacting with it is in C, so it's safe to zero
-        let mut fdset = mem::MaybeUninit::zeroed();
-        unsafe { FD_ZERO(fdset.as_mut_ptr()) };
+        let mut fdset = std::mem::MaybeUninit::zeroed();
+        unsafe { platform::FD_ZERO(fdset.as_mut_ptr()) };
         FdSet(unsafe { fdset.assume_init() })
     }
 
     pub fn insert(&mut self, fd: RawFd) {
-        unsafe { FD_SET(fd, &mut self.0) };
+        unsafe { platform::FD_SET(fd, &mut self.0) };
     }
 
     pub fn contains(&mut self, fd: RawFd) -> bool {
-        unsafe { FD_ISSET(fd, &mut self.0) }
+        unsafe { platform::FD_ISSET(fd, &mut self.0) }
     }
 
     pub fn clear(&mut self) {
-        unsafe { FD_ZERO(&mut self.0) };
+        unsafe { platform::FD_ZERO(&mut self.0) };
     }
 
     pub fn highest(&mut self) -> Option<RawFd> {
-        for i in (0..FD_SETSIZE as RawFd).rev() {
+        for i in (0..platform::FD_SETSIZE as RawFd).rev() {
             if self.contains(i) {
                 return Some(i);
             }
@@ -107,103 +110,104 @@ fn sec_to_timeval(sec: f64) -> timeval {
     }
 }
 
-fn select_select(
-    rlist: PyObjectRef,
-    wlist: PyObjectRef,
-    xlist: PyObjectRef,
-    timeout: OptionalOption<Either<f64, isize>>,
-    vm: &VirtualMachine,
-) -> PyResult<(PyObjectRef, PyObjectRef, PyObjectRef)> {
-    let mut timeout = timeout.flatten().map(|e| match e {
-        Either::A(f) => f,
-        Either::B(i) => i as f64,
-    });
-    if let Some(timeout) = timeout {
-        if timeout < 0.0 {
-            return Err(vm.new_value_error("timeout must be positive".to_owned()));
-        }
-    }
-    let deadline = timeout.map(|s| super::time_module::get_time() + s);
+#[pymodule(name = "select")]
+mod decl {
+    use super::super::time_module;
+    use super::*;
+    use crate::exceptions::IntoPyException;
+    use crate::function::OptionalOption;
+    use crate::pyobject::{Either, PyObjectRef, PyResult};
+    use crate::vm::VirtualMachine;
 
-    let seq2set = |list| -> PyResult<(Vec<Selectable>, FdSet)> {
-        let v = vm.extract_elements::<Selectable>(list)?;
-        let mut fds = FdSet::new();
-        for fd in &v {
-            fds.insert(fd.fno);
-        }
-        Ok((v, fds))
-    };
-
-    let (rlist, mut r) = seq2set(&rlist)?;
-    let (wlist, mut w) = seq2set(&wlist)?;
-    let (xlist, mut x) = seq2set(&xlist)?;
-
-    if rlist.is_empty() && wlist.is_empty() && xlist.is_empty() {
-        let empty = vm.ctx.new_list(vec![]);
-        return Ok((empty.clone(), empty.clone(), empty));
-    }
-
-    let nfds = [&mut r, &mut w, &mut x]
-        .iter_mut()
-        .filter_map(|set| set.highest())
-        .max()
-        .map_or(0, |n| n + 1) as i32;
-
-    let (select_res, err) = loop {
-        let mut tv = timeout.map(sec_to_timeval);
-        let timeout_ptr = match tv {
-            Some(ref mut tv) => tv as *mut _,
-            None => std::ptr::null_mut(),
-        };
-        let res = unsafe { select(nfds, &mut r.0, &mut w.0, &mut x.0, timeout_ptr) };
-
-        let err = io::Error::last_os_error();
-
-        if res >= 0 || err.kind() != io::ErrorKind::Interrupted {
-            break (res, err);
-        }
-
-        vm.check_signals()?;
-
-        if let Some(ref mut timeout) = timeout {
-            *timeout = deadline.unwrap() - super::time_module::get_time();
-            if *timeout < 0.0 {
-                r.clear();
-                w.clear();
-                x.clear();
-                break (0, err);
+    #[pyfunction]
+    fn select(
+        rlist: PyObjectRef,
+        wlist: PyObjectRef,
+        xlist: PyObjectRef,
+        timeout: OptionalOption<Either<f64, isize>>,
+        vm: &VirtualMachine,
+    ) -> PyResult<(PyObjectRef, PyObjectRef, PyObjectRef)> {
+        let mut timeout = timeout.flatten().map(|e| match e {
+            Either::A(f) => f,
+            Either::B(i) => i as f64,
+        });
+        if let Some(timeout) = timeout {
+            if timeout < 0.0 {
+                return Err(vm.new_value_error("timeout must be positive".to_owned()));
             }
-            // retry select() if we haven't reached the deadline yet
         }
-    };
+        let deadline = timeout.map(|s| time_module::get_time() + s);
 
-    if select_res < 0 {
-        return Err(err.into_pyexception(vm));
+        let seq2set = |list| -> PyResult<(Vec<Selectable>, FdSet)> {
+            let v = vm.extract_elements::<Selectable>(list)?;
+            let mut fds = FdSet::new();
+            for fd in &v {
+                fds.insert(fd.fno);
+            }
+            Ok((v, fds))
+        };
+
+        let (rlist, mut r) = seq2set(&rlist)?;
+        let (wlist, mut w) = seq2set(&wlist)?;
+        let (xlist, mut x) = seq2set(&xlist)?;
+
+        if rlist.is_empty() && wlist.is_empty() && xlist.is_empty() {
+            let empty = vm.ctx.new_list(vec![]);
+            return Ok((empty.clone(), empty.clone(), empty));
+        }
+
+        let nfds = [&mut r, &mut w, &mut x]
+            .iter_mut()
+            .filter_map(|set| set.highest())
+            .max()
+            .map_or(0, |n| n + 1) as i32;
+
+        let (select_res, err) = loop {
+            let mut tv = timeout.map(sec_to_timeval);
+            let timeout_ptr = match tv {
+                Some(ref mut tv) => tv as *mut _,
+                None => std::ptr::null_mut(),
+            };
+            let res =
+                unsafe { super::platform::select(nfds, &mut r.0, &mut w.0, &mut x.0, timeout_ptr) };
+
+            let err = std::io::Error::last_os_error();
+
+            if res >= 0 || err.kind() != std::io::ErrorKind::Interrupted {
+                break (res, err);
+            }
+
+            vm.check_signals()?;
+
+            if let Some(ref mut timeout) = timeout {
+                *timeout = deadline.unwrap() - time_module::get_time();
+                if *timeout < 0.0 {
+                    r.clear();
+                    w.clear();
+                    x.clear();
+                    break (0, err);
+                }
+                // retry select() if we haven't reached the deadline yet
+            }
+        };
+
+        if select_res < 0 {
+            return Err(err.into_pyexception(vm));
+        }
+
+        let set2list = |list: Vec<Selectable>, mut set: FdSet| {
+            vm.ctx.new_list(
+                list.into_iter()
+                    .filter(|fd| set.contains(fd.fno))
+                    .map(|fd| fd.obj)
+                    .collect(),
+            )
+        };
+
+        let rlist = set2list(rlist, r);
+        let wlist = set2list(wlist, w);
+        let xlist = set2list(xlist, x);
+
+        Ok((rlist, wlist, xlist))
     }
-
-    let set2list = |list: Vec<Selectable>, mut set: FdSet| {
-        vm.ctx.new_list(
-            list.into_iter()
-                .filter(|fd| set.contains(fd.fno))
-                .map(|fd| fd.obj)
-                .collect(),
-        )
-    };
-
-    let rlist = set2list(rlist, r);
-    let wlist = set2list(wlist, w);
-    let xlist = set2list(xlist, x);
-
-    Ok((rlist, wlist, xlist))
-}
-
-pub fn make_module(vm: &VirtualMachine) -> PyObjectRef {
-    #[cfg(windows)]
-    {
-        let _ = unsafe { WSAStartup(0x0101, &mut mem::zeroed()) };
-    }
-
-    py_module!(vm, "select", {
-        "select" => vm.ctx.new_function(select_select),
-    })
 }


### PR DESCRIPTION
- Fix duplicated attribute checker for pyclass/pymodule
- `pyattr` for values from const and calcaulated (from function)
- py* macro doesn't allow mismatched item type
- pymodule inject `__module__` field of member class
- `pyattr` can explicitly create attribute for `pyclass` in `pymodule`
  - if function or method require similar work, it can be expanded.

- worked on a few modules with upper features