### PR TITLE
Fix index and overflow error in itertools

### DIFF
--- a/vm/src/stdlib/itertools.rs
+++ b/vm/src/stdlib/itertools.rs
@@ -1374,7 +1374,7 @@ mod decl {
             PyItertoolsPermutations {
                 pool,
                 indices: PyRwLock::new((0..n).collect()),
-                cycles: PyRwLock::new((0..r).map(|i| n - i).collect()),
+                cycles: PyRwLock::new((0..r.min(n)).map(|i| n - i).collect()),
                 result: PyRwLock::new(None),
                 r: AtomicCell::new(r),
                 exhausted: AtomicCell::new(r > n),
@@ -1417,7 +1417,7 @@ mod decl {
                         // rotation: indices[i:] = indices[i+1:] + indices[i:i+1]
                         let index = indices[i];
                         for j in i..n - 1 {
-                            indices[j] = indices[j + i];
+                            indices[j] = indices[j + 1];
                         }
                         indices[n - 1] = index;
                         cycles[i] = n - i;


### PR DESCRIPTION
1) fix index error (refer to [CPython](https://github.com/python/cpython/blob/fa5d7251987c70a9c5d58b59a0b36ac9287eaafa/Modules/itertoolsmodule.c#L3258))
```
test_permutations (__main__.TestBasicOps) ... thread 'main' panicked at 'index out of bounds: the len is 4 but the index is 4', vm/src/stdlib/itertools.rs:1420:42
```
2) fix overflow error in debug mode when r > n

