### PR TITLE
check '=' character in environment variable name in os.execve to pass test_os.py

### DIFF
--- a/vm/src/stdlib/os.rs
+++ b/vm/src/stdlib/os.rs
@@ -1575,6 +1575,11 @@ mod posix {
                     PyPathLike::try_from_object(&vm, k)?,
                     PyPathLike::try_from_object(&vm, v)?,
                 );
+
+                if key.path.display().to_string().contains('=') {
+                    return Err(vm.new_value_error("illegal environment variable name".to_owned()));
+                }
+
                 ffi::CString::new(format!("{}={}", key.path.display(), value.path.display()))
                     .map_err(|_| vm.new_value_error("embedded null character".to_owned()))
             })


### PR DESCRIPTION
## About
after merging #2101, test_os.py just crashes without any message. By examining test_execve_invalid_env, it turned out that the initial implementation does not throw ValueError when an equal character `=` exists in the environment variable name. This PR fixes this issue.

## Result
```
> cargo run Lib/test/test_os.py
     Finished dev [unoptimized + debuginfo] target(s) in 21.27s
     Running `target/debug/rustpython Lib/test/test_os.py`
.sssssssssssssssss.s.s..xs..sxxx.xssxs..x.s...xsss.sxxssxxssssssssssssssssssss....x.Tested current directory length: 872
.x.xxxx..s.xxs...ss.Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
OverflowError: Int value cannot fit into Rust u32
x.s......ssssssssssssssssssssssssssss...sssxss....ss.s.....x.......x..s.sssssssss.sssxsssssssssssssxsxs...sssssssssssssssssssssssssssssssssssssssssss
----------------------------------------------------------------------
Ran 253 tests in 45.978s

OK (skipped=163, expected failures=27)
```