### PR TITLE
Implement objcomplex::parse_str() to replace Complex64::from_str()

### DIFF
--- a/tests/snippets/builtin_complex.py
+++ b/tests/snippets/builtin_complex.py
@@ -164,3 +164,48 @@ assert complex("5-2j") == 5 - 2j
 assert complex("-2j") == -2j
 assert_raises(TypeError, lambda: complex("5+2j", 1))
 assert_raises(ValueError, lambda: complex("abc"))
+
+assert complex("1+10j") == 1+10j
+assert complex(10) == 10+0j
+assert complex(10.0) == 10+0j
+assert complex(10) == 10+0j
+assert complex(10+0j) == 10+0j
+assert complex(1, 10) == 1+10j
+assert complex(1, 10) == 1+10j
+assert complex(1, 10.0) == 1+10j
+assert complex(1, 10) == 1+10j
+assert complex(1, 10) == 1+10j
+assert complex(1, 10.0) == 1+10j
+assert complex(1.0, 10) == 1+10j
+assert complex(1.0, 10) == 1+10j
+assert complex(1.0, 10.0) == 1+10j
+assert complex(3.14+0j) == 3.14+0j
+assert complex(3.14) == 3.14+0j
+assert complex(314) == 314.0+0j
+assert complex(314) == 314.0+0j
+assert complex(3.14+0j, 0j) == 3.14+0j
+assert complex(3.14, 0.0) == 3.14+0j
+assert complex(314, 0) == 314.0+0j
+assert complex(314, 0) == 314.0+0j
+assert complex(0j, 3.14j) == -3.14+0j
+assert complex(0.0, 3.14j) == -3.14+0j
+assert complex(0j, 3.14) == 3.14j
+assert complex(0.0, 3.14) == 3.14j
+assert complex("1") == 1+0j
+assert complex("1j") == 1j
+assert complex() == 0
+assert complex("-1") == -1
+assert complex("+1") == +1
+assert complex("(1+2j)") == 1+2j
+assert complex("(1.3+2.2j)") == 1.3+2.2j
+assert complex("3.14+1J") == 3.14+1j
+assert complex(" ( +3.14-6J )") == 3.14-6j
+assert complex(" ( +3.14-J )") == 3.14-1j
+assert complex(" ( +3.14+j )") == 3.14+1j
+assert complex("J") == 1j
+assert complex("( j )") == 1j
+assert complex("+J") == 1j
+assert complex("( -j)") == -1j
+assert complex('1e-500') == 0.0 + 0.0j
+assert complex('-1e-500j') == 0.0 - 0.0j
+assert complex('-1e-500+1e-500j') == -0.0 + 0.0j

--- a/vm/src/obj/objcomplex.rs
+++ b/vm/src/obj/objcomplex.rs
@@ -1,4 +1,3 @@
-use itertools::Itertools;
 use num_complex::Complex64;
 use num_traits::Zero;
 
@@ -325,8 +324,8 @@ fn parse_str(s: &str) -> Option<Complex64> {
         Some(mut s) => {
             let mut real = 0.0;
             // Find the central +/- operator. If it exists, parse the real part.
-            for (i, (a, b)) in s.chars().tuple_windows().enumerate() {
-                if (b == '+' || b == '-') && !(a == 'e' || a == 'E') {
+            for (i, w) in s.as_bytes().windows(2).enumerate() {
+                if (w[1] == b'+' || w[1] == b'-') && !(w[0] == b'e' || w[0] == b'E') {
                     real = float_ops::parse_str(&s[..=i])?;
                     s = &s[i + 1..];
                 }

--- a/vm/src/obj/objcomplex.rs
+++ b/vm/src/obj/objcomplex.rs
@@ -328,6 +328,7 @@ fn parse_str(s: &str) -> Option<Complex64> {
                 if (w[1] == b'+' || w[1] == b'-') && !(w[0] == b'e' || w[0] == b'E') {
                     real = float_ops::parse_str(&s[..=i])?;
                     s = &s[i + 1..];
+                    break;
                 }
             }
 


### PR DESCRIPTION
`Complex64::from_str()` was used to parse a complex number from a string, but its implementation is quite different from how python's complex() should work.
For example, it cannot parse `"(1+2j)"`, `"J"`, or `"1_000"` - it throws `ValueError`.

The new function `objcomplex::parse_str()` handles parentheses correctly, allows capital `J`, and uses `float_ops::parse_str()` to parse float numbers.
I copied some tests from `test_complex.py` into snippets and made them work.