### PR TITLE
Fix panic in itertools pruduct

### DIFF
--- a/Lib/test/test_itertools.py
+++ b/Lib/test/test_itertools.py
@@ -392,8 +392,8 @@ class TestBasicOps(unittest.TestCase):
         self.assertEqual(len(set(map(id, cwr('abcde', 3)))), 1)
         self.assertNotEqual(len(set(map(id, list(cwr('abcde', 3))))), 1)
 
-    # TODO: RUSTPYTHON - panics with 'index out of bounds: the len is 0 but the index is 18446744073709551615'
-    @unittest.skip("panics")
+    # TODO: RUSTPYTHON
+    @unittest.expectedFailure
     def test_permutations(self):
         self.assertRaises(TypeError, permutations)              # too few arguments
         self.assertRaises(TypeError, permutations, 'abc', 2, 1) # too many arguments
@@ -467,8 +467,6 @@ class TestBasicOps(unittest.TestCase):
         self.assertEqual(len(set(map(id, permutations('abcde', 3)))), 1)
         self.assertNotEqual(len(set(map(id, list(permutations('abcde', 3))))), 1)
 
-    # TODO: RUSTPYTHON - panics with 'index out of bounds: the len is 0 but the index is 18446744073709551615'
-    @unittest.skip("panics")
     def test_combinatorics(self):
         # Test relationships between product(), permutations(),
         # combinations() and combinations_with_replacement().
@@ -1055,8 +1053,6 @@ class TestBasicOps(unittest.TestCase):
         self.assertEqual(next(it), (1, 2))
         self.assertRaises(RuntimeError, next, it)
 
-    # TODO: RUSTPYTHON - panics with 'index out of bounds: the len is 0 but the index is 18446744073709551615'
-    @unittest.skip("panics")
     def test_product(self):
         for args, result in [
             ([], [()]),                     # zero iterables
@@ -1125,8 +1121,8 @@ class TestBasicOps(unittest.TestCase):
         self.assertEqual(len(set(map(id, product('abc', 'def')))), 1)
         self.assertNotEqual(len(set(map(id, list(product('abc', 'def'))))), 1)
 
-    # TODO: RUSTPYTHON - panics with 'index out of bounds: the len is 0 but the index is 18446744073709551615'
-    @unittest.skip("panics")
+    # TODO: RUSTPYTHON
+    @unittest.expectedFailure
     def test_product_pickling(self):
         # check copy, deepcopy, pickle
         for args, result in [

--- a/vm/src/stdlib/itertools.rs
+++ b/vm/src/stdlib/itertools.rs
@@ -1067,7 +1067,7 @@ mod decl {
             PyItertoolsProduct {
                 pools,
                 idxs: PyRwLock::new(vec![0; l]),
-                cur: AtomicCell::new(l - 1),
+                cur: AtomicCell::new(l.wrapping_sub(1)),
                 stop: AtomicCell::new(false),
             }
             .into_ref_with_type(vm, cls)
@@ -1104,6 +1104,11 @@ mod decl {
         }
 
         fn update_idxs(&self, mut idxs: PyRwLockWriteGuard<'_, Vec<usize>>) {
+            if idxs.len() == 0 {
+                self.stop.store(true);
+                return;
+            }
+
             let cur = self.cur.load();
             let lst_idx = &self.pools[cur].len() - 1;
 


### PR DESCRIPTION
I fixed panic caused by attempt to subtract with overflow.
But `test_permutations` and `test_product_pickling` still have error at `self.pickletest`.