### PR TITLE
Proof of concept JIT compiler

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -6,7 +6,7 @@ on:
 name: CI
 
 env:
-  CARGO_ARGS: --features ssl
+  CARGO_ARGS: --features ssl jit
 
 jobs:
   rust_tests:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -6,7 +6,7 @@ on:
 name: CI
 
 env:
-  CARGO_ARGS: --features ssl jit
+  CARGO_ARGS: --features "ssl jit"
 
 jobs:
   rust_tests:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1538,6 +1538,8 @@ dependencies = [
  "cranelift",
  "cranelift-module",
  "cranelift-simplejit",
+ "num-traits",
+ "rustpython-bytecode",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1500,6 +1500,7 @@ dependencies = [
  "num-bigint",
  "num-complex",
  "num-traits",
+ "once_cell",
  "parking_lot",
  "rand",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -37,6 +37,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "anyhow"
+version = "1.0.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6b602bfe940d21c130f3895acd65221e8a61270debe89d628b9cb4e3ccb8569b"
+
+[[package]]
 name = "arr_macro"
 version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -290,6 +296,117 @@ dependencies = [
 ]
 
 [[package]]
+name = "cranelift"
+version = "0.66.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4fc21c925da7fbb64597c86521b59726426fb660ad30f898a01b957f39d15558"
+dependencies = [
+ "cranelift-codegen",
+ "cranelift-frontend",
+]
+
+[[package]]
+name = "cranelift-bforest"
+version = "0.66.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8dcc286b052ee24a1e5a222e7c1125e6010ad35b0f248709b9b3737a8fedcfdf"
+dependencies = [
+ "cranelift-entity",
+]
+
+[[package]]
+name = "cranelift-codegen"
+version = "0.66.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d9badfe36176cb653506091693bc2bb1970c9bddfcd6ec7fac404f7eaec6f38"
+dependencies = [
+ "byteorder",
+ "cranelift-bforest",
+ "cranelift-codegen-meta",
+ "cranelift-codegen-shared",
+ "cranelift-entity",
+ "log",
+ "regalloc",
+ "smallvec",
+ "target-lexicon",
+ "thiserror",
+]
+
+[[package]]
+name = "cranelift-codegen-meta"
+version = "0.66.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3c3f460031861e4f4ad510be62b2ae50bba6cc886b598a36f9c0a970feab9598"
+dependencies = [
+ "cranelift-codegen-shared",
+ "cranelift-entity",
+]
+
+[[package]]
+name = "cranelift-codegen-shared"
+version = "0.66.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76ad12409e922e7697cd0bdc7dc26992f64a77c31880dfe5e3c7722f4710206d"
+
+[[package]]
+name = "cranelift-entity"
+version = "0.66.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d97cdc58972ea065d107872cfb9079f4c92ade78a8af85aaff519a65b5d13f71"
+
+[[package]]
+name = "cranelift-frontend"
+version = "0.66.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2ef419efb4f94ecc02e5d9fbcc910d2bb7f0040e2de570e63a454f883bc891d6"
+dependencies = [
+ "cranelift-codegen",
+ "log",
+ "smallvec",
+ "target-lexicon",
+]
+
+[[package]]
+name = "cranelift-module"
+version = "0.66.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "001d9b320ce30999c618db554ae9b23ec16d410493a502be674e2ef146bbdf0d"
+dependencies = [
+ "anyhow",
+ "cranelift-codegen",
+ "cranelift-entity",
+ "log",
+ "thiserror",
+]
+
+[[package]]
+name = "cranelift-native"
+version = "0.66.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e69d44d59826eef6794066ac2c0f4ad3975f02d97030c60dbc04e3886adf36e"
+dependencies = [
+ "cranelift-codegen",
+ "raw-cpuid",
+ "target-lexicon",
+]
+
+[[package]]
+name = "cranelift-simplejit"
+version = "0.66.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7506acda1b0df5419e8de5f1706cfcd8779d3d40d70c179f361e647fe9b18f0"
+dependencies = [
+ "cranelift-codegen",
+ "cranelift-module",
+ "cranelift-native",
+ "errno",
+ "libc",
+ "region",
+ "target-lexicon",
+ "winapi",
+]
+
+[[package]]
 name = "crc"
 version = "1.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -460,6 +577,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "errno"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6eab5ee3df98a279d9b316b1af6ac95422127b1290317e6d18c1743c99418b01"
+dependencies = [
+ "errno-dragonfly",
+ "libc",
+ "winapi",
+]
+
+[[package]]
+name = "errno-dragonfly"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "14ca354e36190500e1e1fb267c647932382b54053c50b14970856c0b00a35067"
+dependencies = [
+ "gcc",
+ "libc",
+]
+
+[[package]]
 name = "exitcode"
 version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -546,6 +684,12 @@ name = "foreign-types-shared"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
+
+[[package]]
+name = "gcc"
+version = "0.3.55"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f5f3913fa0bfe7ee1fd8248b6b9f42a5af4b9d65ec2dd2c3c26132b950ecfc2"
 
 [[package]]
 name = "generic-array"
@@ -778,6 +922,15 @@ name = "lz4-compression"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "761104bf97f13a3caf47d822498a0760a10d00d220148bac2669f63fc3bb8270"
+
+[[package]]
+name = "mach"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b823e83b2affd8f40a9ee8c29dbc56404c1e34cd2710921f2801e2cf29527afa"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "maplit"
@@ -1181,6 +1334,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "raw-cpuid"
+version = "7.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4a349ca83373cfa5d6dbb66fd76e58b2cca08da71a5f6400de0a0a6a9bceeaf"
+dependencies = [
+ "bitflags",
+ "cc",
+ "rustc_version",
+]
+
+[[package]]
 name = "redox_syscall"
 version = "0.1.57"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1195,6 +1359,17 @@ dependencies = [
  "getrandom",
  "redox_syscall",
  "rust-argon2",
+]
+
+[[package]]
+name = "regalloc"
+version = "0.0.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9ba8aaf5fe7cf307c6dbdaeed85478961d29e25e3bee5169e11b92fa9f027a8"
+dependencies = [
+ "log",
+ "rustc-hash",
+ "smallvec",
 ]
 
 [[package]]
@@ -1225,6 +1400,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "26412eb97c6b088a6997e05f69403a802a92d520de2f8e63c2b65f9e0f47c4e8"
 
 [[package]]
+name = "region"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "877e54ea2adcd70d80e9179344c97f93ef0dffd6b03e1f4529e6e83ab2fa9ae0"
+dependencies = [
+ "bitflags",
+ "libc",
+ "mach",
+ "winapi",
+]
+
+[[package]]
 name = "result-like"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1244,6 +1431,12 @@ dependencies = [
  "constant_time_eq",
  "crossbeam-utils",
 ]
+
+[[package]]
+name = "rustc-hash"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
 
 [[package]]
 name = "rustc_version"
@@ -1339,6 +1532,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustpython-jit"
+version = "0.1.2"
+dependencies = [
+ "cranelift",
+ "cranelift-module",
+ "cranelift-simplejit",
+]
+
+[[package]]
 name = "rustpython-parser"
 version = "0.1.2"
 dependencies = [
@@ -1422,6 +1624,7 @@ dependencies = [
  "rustpython-common",
  "rustpython-compiler",
  "rustpython-derive",
+ "rustpython-jit",
  "rustpython-parser",
  "rustpython-pylib",
  "rustyline",
@@ -1693,6 +1896,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "target-lexicon"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab0e7238dcc7b40a7be719a25365910f6807bd864f4cce6b2e6b873658e2b19d"
+
+[[package]]
 name = "term"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1719,6 +1928,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d326610f408c7a4eb6f51c37c330e496b08506c9457c9d34287ecc38809fb060"
 dependencies = [
  "unicode-width",
+]
+
+[[package]]
+name = "thiserror"
+version = "1.0.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7dfdd070ccd8ccb78f4ad66bf1982dc37f620ef696c6b5028fe2ed83dd3d0d08"
+dependencies = [
+ "thiserror-impl",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "1.0.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bd80fc12f73063ac132ac92aceea36734f04a1d93c1240c6944e23a3b8841793"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ license = "MIT"
 include = ["LICENSE", "Cargo.toml", "src/**/*.rs"]
 
 [workspace]
-members = [".", "derive", "vm", "wasm/lib", "parser", "compiler", "bytecode", "vm/pylib-crate", "common"]
+members = [".", "derive", "vm", "wasm/lib", "parser", "compiler", "bytecode", "vm/pylib-crate", "common", "jit"]
 
 [[bench]]
 name = "bench"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,6 +19,7 @@ path = "./benchmarks/bench.rs"
 default = ["threading", "pylib"]
 flame-it = ["rustpython-vm/flame-it", "flame", "flamescope"]
 freeze-stdlib = ["rustpython-vm/freeze-stdlib"]
+jit = ["rustpython-vm/jit"]
 threading = ["rustpython-vm/threading"]
 
 ssl = ["rustpython-vm/ssl"]

--- a/common/Cargo.toml
+++ b/common/Cargo.toml
@@ -15,6 +15,7 @@ num-bigint = "0.3"
 lexical-core = "0.7"
 hexf-parse = "0.1.0"
 cfg-if = "0.1"
+once_cell = "1.4.1"
 
 [dev-dependencies]
 rand = "0.7.3"

--- a/common/src/cell.rs
+++ b/common/src/cell.rs
@@ -1,4 +1,8 @@
 #[cfg(feature = "threading")]
+pub use once_cell::sync::{Lazy, OnceCell};
+#[cfg(not(feature = "threading"))]
+pub use once_cell::unsync::{Lazy, OnceCell};
+#[cfg(feature = "threading")]
 use parking_lot::{
     MappedRwLockReadGuard, MappedRwLockWriteGuard, Mutex, MutexGuard, RwLock, RwLockReadGuard,
     RwLockWriteGuard,

--- a/jit/Cargo.toml
+++ b/jit/Cargo.toml
@@ -1,0 +1,14 @@
+[package]
+name = "rustpython-jit"
+version = "0.1.2"
+description = "Experimental JIT(just in time) compiler for python code."
+authors = [ "RustPython Team" ]
+repository = "https://github.com/RustPython/RustPython"
+license = "MIT"
+edition = "2018"
+
+[dependencies]
+cranelift = "0.66.0"
+cranelift-module = "0.66.0"
+cranelift-simplejit = "0.66.0"
+

--- a/jit/Cargo.toml
+++ b/jit/Cargo.toml
@@ -11,4 +11,5 @@ edition = "2018"
 cranelift = "0.66.0"
 cranelift-module = "0.66.0"
 cranelift-simplejit = "0.66.0"
-
+num-traits = "0.2"
+rustpython-bytecode = { path = "../bytecode", version = "0.1.1" }

--- a/jit/src/instructions.rs
+++ b/jit/src/instructions.rs
@@ -1,0 +1,41 @@
+use cranelift::prelude::*;
+use num_traits::cast::ToPrimitive;
+use rustpython_bytecode::bytecode::{Constant, Instruction};
+
+use super::JITCompileError;
+
+pub struct FunctionCompiler<'a, 'b> {
+    builder: &'a mut FunctionBuilder<'b>,
+    stack: Vec<Value>,
+}
+
+impl<'a, 'b> FunctionCompiler<'a, 'b> {
+    pub fn new(builder: &'a mut FunctionBuilder<'b>) -> FunctionCompiler<'a, 'b> {
+        FunctionCompiler {
+            builder,
+            stack: Vec::new(),
+        }
+    }
+
+    pub fn add_instruction(&mut self, instruction: &Instruction) -> Result<(), JITCompileError> {
+        match instruction {
+            Instruction::LoadConst {
+                value: Constant::Integer { value },
+            } => {
+                let val = self.builder.ins().iconst(
+                    types::I64,
+                    value.to_i64().ok_or(JITCompileError::NotSupported)?,
+                );
+                self.stack.push(val);
+                Ok(())
+            }
+            Instruction::ReturnValue => {
+                self.builder
+                    .ins()
+                    .return_(&[self.stack.pop().ok_or(JITCompileError::BadBytecode)?]);
+                Ok(())
+            }
+            _ => Err(JITCompileError::NotSupported),
+        }
+    }
+}

--- a/jit/src/instructions.rs
+++ b/jit/src/instructions.rs
@@ -1,12 +1,14 @@
+use std::collections::HashMap;
 use cranelift::prelude::*;
 use num_traits::cast::ToPrimitive;
-use rustpython_bytecode::bytecode::{Constant, Instruction};
+use rustpython_bytecode::bytecode::{BinaryOperator, Constant, Instruction, NameScope};
 
 use super::JITCompileError;
 
 pub struct FunctionCompiler<'a, 'b> {
     builder: &'a mut FunctionBuilder<'b>,
     stack: Vec<Value>,
+    variables: HashMap<String, Variable>
 }
 
 impl<'a, 'b> FunctionCompiler<'a, 'b> {
@@ -14,11 +16,36 @@ impl<'a, 'b> FunctionCompiler<'a, 'b> {
         FunctionCompiler {
             builder,
             stack: Vec::new(),
+            variables: HashMap::new()
         }
     }
 
     pub fn add_instruction(&mut self, instruction: &Instruction) -> Result<(), JITCompileError> {
         match instruction {
+            Instruction::LoadName {
+                name,
+                scope: NameScope::Local
+            } => {
+                let var = self.variables.get(name).ok_or(JITCompileError::BadBytecode)?;
+                self.stack.push(self.builder.use_var(*var));
+                Ok(())
+            }
+            Instruction::StoreName {
+                name,
+                scope: NameScope::Local
+            } => {
+                let var = match self.variables.get(name) {
+                    Some(var) => *var,
+                    None => {
+                        let var = Variable::new(self.variables.len());
+                        self.variables.insert(name.clone(), var);
+                        self.builder.declare_var(var, types::I64);
+                        var
+                    }
+                };
+                self.builder.def_var(var, self.stack.pop().ok_or(JITCompileError::BadBytecode)?);
+                Ok(())
+            }
             Instruction::LoadConst {
                 value: Constant::Integer { value },
             } => {
@@ -34,6 +61,28 @@ impl<'a, 'b> FunctionCompiler<'a, 'b> {
                     .ins()
                     .return_(&[self.stack.pop().ok_or(JITCompileError::BadBytecode)?]);
                 Ok(())
+            }
+            Instruction::BinaryOperation {
+                op,
+                ..
+            } => {
+                let a = self.stack.pop().ok_or(JITCompileError::BadBytecode)?;
+                let b = self.stack.pop().ok_or(JITCompileError::BadBytecode)?;
+                match op {
+                    BinaryOperator::Add => {
+                        let (out, carry) = self.builder.ins().iadd_ifcout(a, b);
+                        self.builder.ins().trapif(IntCC::Overflow, carry, TrapCode::IntegerOverflow);
+                        self.stack.push(out);
+                        Ok(())
+                    }
+                    BinaryOperator::Subtract => {
+                        let (out, carry) = self.builder.ins().isub_ifbout(a, b);
+                        self.builder.ins().trapif(IntCC::Overflow, carry, TrapCode::IntegerOverflow);
+                        self.stack.push(out);
+                        Ok(())
+                    }
+                    _ => Err(JITCompileError::NotSupported),
+                }
             }
             _ => Err(JITCompileError::NotSupported),
         }

--- a/jit/src/lib.rs
+++ b/jit/src/lib.rs
@@ -44,13 +44,13 @@ impl Error for JITCompileError {
     }
 }
 
-struct JIT {
+struct Jit {
     builder_context: FunctionBuilderContext,
     ctx: codegen::Context,
     module: Module<SimpleJITBackend>,
 }
 
-impl JIT {
+impl Jit {
     fn new() -> Self {
         let builder = SimpleJITBuilder::new(cranelift_module::default_libcall_names());
         let module = Module::new(builder);
@@ -104,7 +104,7 @@ impl JIT {
 }
 
 pub fn compile(bytecode: &bytecode::CodeObject) -> Result<CompiledCode, JITCompileError> {
-    let mut jit = JIT::new();
+    let mut jit = Jit::new();
 
     let id = jit.build_function(bytecode)?;
 

--- a/jit/src/lib.rs
+++ b/jit/src/lib.rs
@@ -1,0 +1,92 @@
+use std::fmt;
+use std::mem;
+
+use cranelift::prelude::*;
+use cranelift_module::{Backend, Module, Linkage, FuncId};
+use cranelift_simplejit::{SimpleJITBackend, SimpleJITBuilder};
+
+
+struct JIT {
+    builder_context: FunctionBuilderContext,
+    ctx: codegen::Context,
+    module: Module<SimpleJITBackend>,
+}
+
+impl JIT {
+    fn new() -> Self {
+        let builder = SimpleJITBuilder::new(cranelift_module::default_libcall_names());
+        let module = Module::new(builder);
+        Self {
+            builder_context: FunctionBuilderContext::new(),
+            ctx: module.make_context(),
+            module,
+        }
+    }
+
+    fn build_function(&mut self) -> FuncId {
+        let id = self
+            .module
+            .declare_function("jitted", Linkage::Export, &self.ctx.func.signature)
+            .unwrap();
+
+        let mut builder = FunctionBuilder::new(&mut self.ctx.func, &mut self.builder_context);
+        let entry_block = builder.create_block();
+        // builder.append_block_params_for_function_params(entry_block);
+        builder.switch_to_block(entry_block);
+        // builder.seal_block(entry_block);
+        builder.ins().return_(&[]);
+        builder.finalize();
+
+        self.module
+            .define_function(id, &mut self.ctx, &mut codegen::binemit::NullTrapSink {})
+            .unwrap();
+
+        self.module.clear_context(&mut self.ctx);
+
+        id
+    }
+}
+
+pub fn compile() -> CompiledCode {
+
+    let mut jit = JIT::new();
+
+    let id = jit.build_function();
+
+    jit.module.finalize_definitions();
+
+    let code = jit.module.get_finalized_function(id);
+    CompiledCode {
+        code,
+        memory: jit.module.finish()
+    }
+}
+
+pub struct CompiledCode {
+    code: *const u8,
+    memory: <SimpleJITBackend as Backend>::Product
+}
+
+impl CompiledCode {
+    pub fn invoke(&self) {
+        let func = unsafe { mem::transmute::<_, fn()>(self.code) };
+        func()
+    }
+}
+
+unsafe impl Send for CompiledCode {}
+
+impl Drop for CompiledCode {
+    fn drop(&mut self) {
+        // SAFETY: The only pointer that this memory will also be dropped now
+        unsafe {
+            self.memory.free_memory()
+        }
+    }
+}
+
+impl fmt::Debug for CompiledCode {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str("[compiled code]")
+    }
+}

--- a/jit/src/lib.rs
+++ b/jit/src/lib.rs
@@ -130,6 +130,7 @@ impl CompiledCode {
 }
 
 unsafe impl Send for CompiledCode {}
+unsafe impl Sync for CompiledCode {}
 
 impl Drop for CompiledCode {
     fn drop(&mut self) {

--- a/jit/src/lib.rs
+++ b/jit/src/lib.rs
@@ -1,10 +1,48 @@
+use std::error::Error;
 use std::fmt;
 use std::mem;
 
 use cranelift::prelude::*;
-use cranelift_module::{Backend, Module, Linkage, FuncId};
+use cranelift_module::{Backend, FuncId, Linkage, Module, ModuleError};
 use cranelift_simplejit::{SimpleJITBackend, SimpleJITBuilder};
 
+use rustpython_bytecode::bytecode;
+
+mod instructions;
+
+use self::instructions::FunctionCompiler;
+
+#[derive(Debug)]
+pub enum JITCompileError {
+    NotSupported,
+    BadBytecode,
+    CraneliftError(ModuleError),
+}
+
+impl From<ModuleError> for JITCompileError {
+    fn from(err: ModuleError) -> Self {
+        JITCompileError::CraneliftError(err)
+    }
+}
+
+impl fmt::Display for JITCompileError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match *self {
+            JITCompileError::NotSupported => f.write_str("Function can't be jitted."),
+            JITCompileError::BadBytecode => f.write_str("Bad bytecode."),
+            JITCompileError::CraneliftError(ref err) => err.fmt(f),
+        }
+    }
+}
+
+impl Error for JITCompileError {
+    fn source(&self) -> Option<&(dyn Error + 'static)> {
+        match *self {
+            JITCompileError::CraneliftError(ref err) => Some(err),
+            _ => None,
+        }
+    }
+}
 
 struct JIT {
     builder_context: FunctionBuilderContext,
@@ -23,53 +61,70 @@ impl JIT {
         }
     }
 
-    fn build_function(&mut self) -> FuncId {
-        let id = self
-            .module
-            .declare_function("jitted", Linkage::Export, &self.ctx.func.signature)
-            .unwrap();
+    fn build_function(
+        &mut self,
+        bytecode: &bytecode::CodeObject,
+    ) -> Result<FuncId, JITCompileError> {
+        // currently always returns an int
+        self.ctx
+            .func
+            .signature
+            .returns
+            .push(AbiParam::new(types::I64));
+
+        let id = self.module.declare_function(
+            &format!("jit_{}", bytecode.obj_name),
+            Linkage::Export,
+            &self.ctx.func.signature,
+        )?;
 
         let mut builder = FunctionBuilder::new(&mut self.ctx.func, &mut self.builder_context);
         let entry_block = builder.create_block();
         // builder.append_block_params_for_function_params(entry_block);
         builder.switch_to_block(entry_block);
-        // builder.seal_block(entry_block);
-        builder.ins().return_(&[]);
+        builder.seal_block(entry_block);
+
+        {
+            let mut compiler = FunctionCompiler::new(&mut builder);
+
+            for instruction in &bytecode.instructions {
+                compiler.add_instruction(instruction)?;
+            }
+        };
+
         builder.finalize();
 
         self.module
-            .define_function(id, &mut self.ctx, &mut codegen::binemit::NullTrapSink {})
-            .unwrap();
+            .define_function(id, &mut self.ctx, &mut codegen::binemit::NullTrapSink {})?;
 
         self.module.clear_context(&mut self.ctx);
 
-        id
+        Ok(id)
     }
 }
 
-pub fn compile() -> CompiledCode {
-
+pub fn compile(bytecode: &bytecode::CodeObject) -> Result<CompiledCode, JITCompileError> {
     let mut jit = JIT::new();
 
-    let id = jit.build_function();
+    let id = jit.build_function(bytecode)?;
 
     jit.module.finalize_definitions();
 
     let code = jit.module.get_finalized_function(id);
-    CompiledCode {
+    Ok(CompiledCode {
         code,
-        memory: jit.module.finish()
-    }
+        memory: jit.module.finish(),
+    })
 }
 
 pub struct CompiledCode {
     code: *const u8,
-    memory: <SimpleJITBackend as Backend>::Product
+    memory: <SimpleJITBackend as Backend>::Product,
 }
 
 impl CompiledCode {
-    pub fn invoke(&self) {
-        let func = unsafe { mem::transmute::<_, fn()>(self.code) };
+    pub fn invoke(&self) -> i64 {
+        let func = unsafe { mem::transmute::<_, fn() -> i64>(self.code) };
         func()
     }
 }
@@ -79,9 +134,7 @@ unsafe impl Send for CompiledCode {}
 impl Drop for CompiledCode {
     fn drop(&mut self) {
         // SAFETY: The only pointer that this memory will also be dropped now
-        unsafe {
-            self.memory.free_memory()
-        }
+        unsafe { self.memory.free_memory() }
     }
 }
 

--- a/tests/snippets/jit.py
+++ b/tests/snippets/jit.py
@@ -1,0 +1,12 @@
+
+def foo():
+    a = 5
+    return 10 + a
+
+
+assert foo() == 15
+
+if hasattr(foo, "__jit__"):
+    print("Has jit")
+    foo.__jit__()
+    assert foo() == 15

--- a/tests/test_snippets.py
+++ b/tests/test_snippets.py
@@ -138,7 +138,7 @@ class SampleTestCase(unittest.TestCase):
 
         # cargo stuff
         profile_args = [] if RUST_DEBUG else ["--release"]
-        subprocess.check_call(["cargo", "build", "--features", *RUSTPYTHON_FEATURES, *profile_args])
+        subprocess.check_call(["cargo", "build", "--features", ",".join(RUSTPYTHON_FEATURES), *profile_args])
 
     @classmethod
     def tearDownClass(cls):

--- a/tests/test_snippets.py
+++ b/tests/test_snippets.py
@@ -25,6 +25,8 @@ TEST_DIRS = {_TestType.functional: os.path.join(TEST_ROOT, "snippets")}
 CPYTHON_RUNNER_DIR = os.path.abspath(os.path.join(ROOT_DIR, "py_code_object"))
 RUSTPYTHON_RUNNER_DIR = os.path.abspath(os.path.join(ROOT_DIR))
 RUSTPYTHON_LIB_DIR = os.path.abspath(os.path.join(ROOT_DIR, "Lib"))
+RUSTPYTHON_FEATURES = ["jit"]
+
 
 @contextlib.contextmanager
 def pushd(path):
@@ -136,7 +138,7 @@ class SampleTestCase(unittest.TestCase):
 
         # cargo stuff
         profile_args = [] if RUST_DEBUG else ["--release"]
-        subprocess.check_call(["cargo", "build", *profile_args])
+        subprocess.check_call(["cargo", "build", "--features", *RUSTPYTHON_FEATURES, *profile_args])
 
     @classmethod
     def tearDownClass(cls):

--- a/vm/Cargo.toml
+++ b/vm/Cargo.toml
@@ -13,6 +13,7 @@ default = ["compile-parse", "threading"]
 vm-tracing-logging = []
 flame-it = ["flame", "flamer"]
 freeze-stdlib = ["rustpython-pylib"]
+jit = ["rustpython-jit"]
 threading = ["rustpython-common/threading"]
 compile-parse = ["rustpython-parser", "rustpython-compiler"]
 
@@ -43,7 +44,7 @@ rustpython-derive = { path = "../derive", version = "0.1.2" }
 rustpython-parser = { path = "../parser", optional = true, version = "0.1.2" }
 rustpython-compiler = { path = "../compiler", optional = true, version = "0.1.2" }
 rustpython-bytecode = { path = "../bytecode", version = "0.1.2" }
-rustpython-jit = { path = "../jit", version = "0.1.2" }
+rustpython-jit = { path = "../jit", optional = true, version = "0.1.2" }
 rustpython-pylib = { path = "pylib-crate", optional = true, version = "0.1.0" }
 serde = { version = "1.0.66", features = ["derive"] }
 byteorder = "1.2.6"

--- a/vm/Cargo.toml
+++ b/vm/Cargo.toml
@@ -43,6 +43,7 @@ rustpython-derive = { path = "../derive", version = "0.1.2" }
 rustpython-parser = { path = "../parser", optional = true, version = "0.1.2" }
 rustpython-compiler = { path = "../compiler", optional = true, version = "0.1.2" }
 rustpython-bytecode = { path = "../bytecode", version = "0.1.2" }
+rustpython-jit = { path = "../jit", version = "0.1.2" }
 rustpython-pylib = { path = "pylib-crate", optional = true, version = "0.1.0" }
 serde = { version = "1.0.66", features = ["derive"] }
 byteorder = "1.2.6"

--- a/vm/src/obj/objfunction.rs
+++ b/vm/src/obj/objfunction.rs
@@ -301,18 +301,15 @@ impl PyFunction {
         self.scope.globals.clone()
     }
 
-    #[allow(unused_variables)]
+    #[cfg(feature = "jit")]
     #[pymethod(magic)]
     fn jit(&self, vm: &VirtualMachine) -> PyResult<()> {
-        // TODO move cfg onto function when https://github.com/RustPython/RustPython/pull/2120 lands
-        #[cfg(feature = "jit")]
-        {
-            self.jitted_code.get_or_try_init(|| {
+        self.jitted_code
+            .get_or_try_init(|| {
                 rustpython_jit::compile(&self.code.code)
                     .map_err(|err| vm.new_runtime_error(err.to_string()))
-            })?;
-        }
-        Ok(())
+            })
+            .map(drop)
     }
 }
 


### PR DESCRIPTION
Proof of concept for a JIT(just in time) compiler, that compiles python functions down to native code.

This uses https://github.com/bytecodealliance/wasmtime/tree/main/cranelift to do the heavy lifting of generating the native code.

Currently this can successfully compile the following:
```python
def foo():
    a = 9_223
    return 10 + a
```

As a proof of concept, this has very limited functionality:
- only handles functions that take no arguments and return an integer
- only handles a very limited set of bytecodes
- aborts if operations overflow