### PR TITLE
PyObjectRc: thin wrapper for PyObjectRef inner Rc

### DIFF
--- a/vm/src/builtins.rs
+++ b/vm/src/builtins.rs
@@ -444,7 +444,7 @@ mod decl {
                             .to_owned(),
                     ));
                 }
-                args.args.clone()
+                args.args
             }
             std::cmp::Ordering::Equal => vm.extract_elements(&args.args[0])?,
             std::cmp::Ordering::Less => {

--- a/vm/src/lib.rs
+++ b/vm/src/lib.rs
@@ -57,6 +57,7 @@ pub mod obj;
 mod py_io;
 pub mod py_serde;
 pub mod pyobject;
+mod pyobjectrc;
 mod pystr;
 pub mod readline;
 pub mod scope;

--- a/vm/src/macros.rs
+++ b/vm/src/macros.rs
@@ -225,7 +225,7 @@ macro_rules! flame_guard {
 #[macro_export]
 macro_rules! class_or_notimplemented {
     ($vm:expr, $t:ty, $obj:expr) => {
-        match $crate::pyobject::PyObject::downcast::<$t>($obj) {
+        match $crate::pyobject::PyObjectRef::downcast::<$t>($obj) {
             Ok(pyref) => pyref,
             Err(_) => return Ok(PyArithmaticValue::NotImplemented),
         }

--- a/vm/src/obj/objtype.rs
+++ b/vm/src/obj/objtype.rs
@@ -62,7 +62,7 @@ impl PyClassRef {
             let module = zelf.attributes.read().get("__module__").cloned();
             let new_name = if let Some(module) = module {
                 // FIXME: "unknown" case is a bug.
-                let module_str = PyStringRef::try_from_object(vm, module.clone())
+                let module_str = PyStringRef::try_from_object(vm, module)
                     .map_or("<unknown>".to_owned(), |m| m.borrow_value().to_owned());
                 format!("{}.{}", module_str, &zelf.name)
             } else {

--- a/vm/src/obj/objweakref.rs
+++ b/vm/src/obj/objweakref.rs
@@ -26,7 +26,7 @@ impl PyWeak {
     }
 
     pub fn upgrade(&self) -> Option<PyObjectRef> {
-        PyObjectRc::upgrade_weak(&self.referent)
+        self.referent.upgrade()
     }
 }
 

--- a/vm/src/pyobject.rs
+++ b/vm/src/pyobject.rs
@@ -1187,15 +1187,6 @@ pub trait PyValue: fmt::Debug + PyThreadingConstraint + Sized + 'static {
     }
 }
 
-impl<T> PyValue for std::mem::MaybeUninit<T>
-where
-    T: PyValue,
-{
-    fn class(vm: &VirtualMachine) -> PyClassRef {
-        T::class(vm)
-    }
-}
-
 pub trait BorrowValue<'a>: PyValue {
     type Borrowed: 'a + Deref;
     fn borrow_value(&'a self) -> Self::Borrowed;

--- a/vm/src/pyobject.rs
+++ b/vm/src/pyobject.rs
@@ -35,7 +35,7 @@ use crate::obj::objstaticmethod::PyStaticMethod;
 use crate::obj::objstr;
 use crate::obj::objtuple::{PyTuple, PyTupleRef};
 use crate::obj::objtype::{self, PyClass, PyClassRef};
-pub use crate::pyobjectrc::PyObjectRc;
+pub use crate::pyobjectrc::{PyObjectRc, PyObjectWeak};
 use crate::scope::Scope;
 use crate::slots::{PyClassSlots, PyTpFlags};
 use crate::types::{create_type, create_type_with_slots, initialize_types, TypeZoo};

--- a/vm/src/pyobjectrc.rs
+++ b/vm/src/pyobjectrc.rs
@@ -1,112 +1,146 @@
 use crate::common::rc::{PyRc, PyWeak};
-use crate::pyobject::{DynPyObject, IdProtocol, PyObject, PyObjectPayload, PyRef, PyValue};
-use crate::vm::VirtualMachine;
+use crate::pyobject::{IdProtocol, PyObject, PyObjectPayload};
 use std::borrow;
-use std::convert::From;
 use std::fmt;
 use std::ops::Deref;
 
-#[derive(Clone)]
-pub struct PyObjectRc {
-    inner: PyRc<DynPyObject>,
+pub struct PyObjectRc<T = dyn PyObjectPayload>
+where
+    T: ?Sized + PyObjectPayload,
+{
+    inner: PyRc<PyObject<T>>,
 }
 
-pub type PyObjectWeak = PyWeak<DynPyObject>;
+pub type PyObjectWeak<T = dyn PyObjectPayload> = PyWeak<PyObject<T>>;
 
-type InnerRc = PyRc<DynPyObject>;
-
-impl PyObjectRc {
-    /// # Safety
-    /// if rc is dropped without wrapping again, drop will not be called
-    unsafe fn into_rc(this: Self) -> PyRc<DynPyObject> {
-        std::mem::transmute(this)
-    }
-
-    pub fn into_raw(this: Self) -> *const DynPyObject {
-        PyRc::into_raw(unsafe { Self::into_rc(this) })
+impl<T> PyObjectRc<T>
+where
+    T: ?Sized + PyObjectPayload,
+{
+    pub fn into_raw(this: Self) -> *const PyObject<T> {
+        let ptr = PyRc::as_ptr(&this.inner);
+        std::mem::forget(this);
+        ptr
     }
 
     /// # Safety
     /// See PyRc::from_raw
-    pub unsafe fn from_raw(ptr: *const DynPyObject) -> Self {
-        PyRc::from_raw(ptr).into()
+    pub unsafe fn from_raw(ptr: *const PyObject<T>) -> Self {
+        Self {
+            inner: PyRc::from_raw(ptr),
+        }
+    }
+
+    pub fn new(value: PyObject<T>) -> Self
+    where
+        T: Sized,
+    {
+        Self {
+            inner: PyRc::new(value),
+        }
     }
 
     pub fn strong_count(this: &Self) -> usize {
-        InnerRc::strong_count(this)
+        PyRc::strong_count(&this.inner)
     }
 
     pub fn weak_count(this: &Self) -> usize {
-        InnerRc::weak_count(this)
+        PyRc::weak_count(&this.inner)
     }
 
-    pub fn downgrade(this: &Self) -> PyObjectWeak {
-        InnerRc::downgrade(&this.inner)
+    pub fn downgrade(this: &Self) -> PyObjectWeak<T> {
+        PyRc::downgrade(&this.inner)
     }
 
-    pub fn upgrade_weak(weak: &PyObjectWeak) -> Option<Self> {
+    pub fn upgrade_weak(weak: &PyObjectWeak<T>) -> Option<Self> {
         weak.upgrade().map(|inner| PyObjectRc { inner })
     }
 }
 
 #[cfg(feature = "threading")]
-unsafe impl Send for PyObjectRc {}
+unsafe impl<T> Send for PyObjectRc<T> where T: ?Sized + PyObjectPayload {}
 #[cfg(feature = "threading")]
-unsafe impl Sync for PyObjectRc {}
+unsafe impl<T> Sync for PyObjectRc<T> where T: ?Sized + PyObjectPayload {}
 
-impl From<PyRc<DynPyObject>> for PyObjectRc {
-    fn from(rc: PyRc<DynPyObject>) -> PyObjectRc {
-        Self { inner: rc }
-    }
-}
-
-impl<P: PyObjectPayload> From<PyRc<PyObject<P>>> for PyObjectRc {
-    fn from(rc: PyRc<PyObject<P>>) -> PyObjectRc {
-        Self { inner: rc }
-    }
-}
-
-impl Deref for PyObjectRc {
-    type Target = PyRc<DynPyObject>;
+impl<T> Deref for PyObjectRc<T>
+where
+    T: ?Sized + PyObjectPayload,
+{
+    type Target = PyRc<PyObject<T>>;
 
     #[inline]
-    fn deref(&self) -> &PyRc<DynPyObject> {
+    fn deref(&self) -> &PyRc<PyObject<T>> {
         &self.inner
     }
 }
 
-impl fmt::Display for PyObjectRc {
+impl<T> Clone for PyObjectRc<T>
+where
+    T: ?Sized + PyObjectPayload,
+{
+    fn clone(&self) -> Self {
+        PyObjectRc {
+            inner: self.inner.clone(),
+        }
+    }
+}
+
+impl<T> fmt::Display for PyObjectRc<T>
+where
+    T: ?Sized + PyObjectPayload,
+    PyObject<T>: fmt::Display,
+{
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         self.inner.fmt(f)
     }
 }
 
-impl fmt::Debug for PyObjectRc {
+impl<T> fmt::Debug for PyObjectRc<T>
+where
+    T: ?Sized + PyObjectPayload,
+    PyObject<T>: fmt::Debug,
+{
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         self.inner.fmt(f)
     }
 }
 
-impl fmt::Pointer for PyObjectRc {
+impl<T> fmt::Pointer for PyObjectRc<T>
+where
+    T: ?Sized + PyObjectPayload,
+    PyObject<T>: fmt::Pointer,
+{
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         self.inner.fmt(f)
     }
 }
 
-impl borrow::Borrow<DynPyObject> for PyObjectRc {
-    fn borrow(&self) -> &DynPyObject {
+impl<T> borrow::Borrow<T> for PyObjectRc<T>
+where
+    T: ?Sized + PyObjectPayload,
+    PyRc<PyObject<T>>: borrow::Borrow<T>,
+{
+    fn borrow(&self) -> &T {
         self.inner.borrow()
     }
 }
 
-impl borrow::Borrow<PyRc<DynPyObject>> for PyObjectRc {
-    fn borrow(&self) -> &PyRc<DynPyObject> {
+impl<T> borrow::Borrow<PyRc<PyObject<T>>> for PyObjectRc<T>
+where
+    T: ?Sized + PyObjectPayload,
+    PyRc<PyObject<T>>: borrow::Borrow<PyRc<PyObject<T>>>,
+{
+    fn borrow(&self) -> &PyRc<PyObject<T>> {
         &self.inner
     }
 }
 
-impl AsRef<DynPyObject> for PyObjectRc {
-    fn as_ref(&self) -> &DynPyObject {
+impl<T> AsRef<T> for PyObjectRc<T>
+where
+    T: ?Sized + PyObjectPayload,
+    PyRc<PyObject<T>>: AsRef<T>,
+{
+    fn as_ref(&self) -> &T {
         self.inner.as_ref()
     }
 }
@@ -114,22 +148,5 @@ impl AsRef<DynPyObject> for PyObjectRc {
 impl IdProtocol for PyObjectRc {
     fn get_id(&self) -> usize {
         self.inner.get_id()
-    }
-}
-
-impl PyObjectRc {
-    pub fn downcast<T: PyObjectPayload + PyValue>(self) -> Result<PyRef<T>, Self> {
-        unsafe { PyObjectRc::into_rc(self) }.downcast()
-    }
-
-    pub fn downcast_exact<T: PyObjectPayload + PyValue>(
-        self,
-        vm: &VirtualMachine,
-    ) -> Result<PyRef<T>, Self> {
-        unsafe { PyObjectRc::into_rc(self) }.downcast_exact(vm)
-    }
-
-    pub fn downcast_generic<T: PyObjectPayload>(self) -> Result<PyRc<PyObject<T>>, Self> {
-        unsafe { PyObjectRc::into_rc(self) }.downcast_generic()
     }
 }

--- a/vm/src/pyobjectrc.rs
+++ b/vm/src/pyobjectrc.rs
@@ -66,11 +66,11 @@ impl<T> Deref for PyObjectRc<T>
 where
     T: ?Sized + PyObjectPayload,
 {
-    type Target = PyRc<PyObject<T>>;
+    type Target = PyObject<T>;
 
     #[inline]
-    fn deref(&self) -> &PyRc<PyObject<T>> {
-        &self.inner
+    fn deref(&self) -> &PyObject<T> {
+        self.inner.deref()
     }
 }
 
@@ -122,16 +122,6 @@ where
 {
     fn borrow(&self) -> &T {
         self.inner.borrow()
-    }
-}
-
-impl<T> borrow::Borrow<PyRc<PyObject<T>>> for PyObjectRc<T>
-where
-    T: ?Sized + PyObjectPayload,
-    PyRc<PyObject<T>>: borrow::Borrow<PyRc<PyObject<T>>>,
-{
-    fn borrow(&self) -> &PyRc<PyObject<T>> {
-        &self.inner
     }
 }
 

--- a/vm/src/pyobjectrc.rs
+++ b/vm/src/pyobjectrc.rs
@@ -7,20 +7,51 @@ use std::ops::Deref;
 pub struct PyObjectRc<T = dyn PyObjectPayload>
 where
     T: ?Sized + PyObjectPayload,
+    PyRc<PyObject<T>>: AsPyObjectRef,
 {
     inner: PyRc<PyObject<T>>,
 }
 
 pub type PyObjectWeak<T = dyn PyObjectPayload> = PyWeak<PyObject<T>>;
 
+pub trait AsPyObjectRef {
+    fn _as_ref(self) -> PyRc<PyObject<dyn PyObjectPayload>>;
+}
+
+impl<T> AsPyObjectRef for PyRc<PyObject<T>>
+where
+    T: PyObjectPayload,
+{
+    fn _as_ref(self) -> PyRc<PyObject<dyn PyObjectPayload>> {
+        self
+    }
+}
+
+impl AsPyObjectRef for PyRc<PyObject<dyn PyObjectPayload>> {
+    fn _as_ref(self) -> PyRc<PyObject<dyn PyObjectPayload>> {
+        self
+    }
+}
+
 impl<T> PyObjectRc<T>
 where
     T: ?Sized + PyObjectPayload,
+    PyRc<PyObject<T>>: AsPyObjectRef,
 {
     pub fn into_raw(this: Self) -> *const PyObject<T> {
         let ptr = PyRc::as_ptr(&this.inner);
         std::mem::forget(this);
         ptr
+    }
+
+    unsafe fn into_rc(this: Self) -> PyRc<PyObject<T>> {
+        std::mem::transmute(this)
+    }
+
+    pub fn into_ref(this: Self) -> PyObjectRc<dyn PyObjectPayload> {
+        PyObjectRc::<dyn PyObjectPayload> {
+            inner: unsafe { Self::into_rc(this) }._as_ref(),
+        }
     }
 
     /// # Safety
@@ -58,13 +89,24 @@ where
 }
 
 #[cfg(feature = "threading")]
-unsafe impl<T> Send for PyObjectRc<T> where T: ?Sized + PyObjectPayload {}
+unsafe impl<T> Send for PyObjectRc<T>
+where
+    T: ?Sized + PyObjectPayload,
+    PyRc<PyObject<T>>: AsPyObjectRef,
+{
+}
 #[cfg(feature = "threading")]
-unsafe impl<T> Sync for PyObjectRc<T> where T: ?Sized + PyObjectPayload {}
+unsafe impl<T> Sync for PyObjectRc<T>
+where
+    T: ?Sized + PyObjectPayload,
+    PyRc<PyObject<T>>: AsPyObjectRef,
+{
+}
 
 impl<T> Deref for PyObjectRc<T>
 where
     T: ?Sized + PyObjectPayload,
+    PyRc<PyObject<T>>: AsPyObjectRef,
 {
     type Target = PyObject<T>;
 
@@ -77,6 +119,7 @@ where
 impl<T> Clone for PyObjectRc<T>
 where
     T: ?Sized + PyObjectPayload,
+    PyRc<PyObject<T>>: AsPyObjectRef,
 {
     fn clone(&self) -> Self {
         PyObjectRc {
@@ -88,6 +131,7 @@ where
 impl<T> fmt::Display for PyObjectRc<T>
 where
     T: ?Sized + PyObjectPayload,
+    PyRc<PyObject<T>>: AsPyObjectRef,
     PyObject<T>: fmt::Display,
 {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
@@ -98,6 +142,7 @@ where
 impl<T> fmt::Debug for PyObjectRc<T>
 where
     T: ?Sized + PyObjectPayload,
+    PyRc<PyObject<T>>: AsPyObjectRef,
     PyObject<T>: fmt::Debug,
 {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
@@ -108,6 +153,7 @@ where
 impl<T> fmt::Pointer for PyObjectRc<T>
 where
     T: ?Sized + PyObjectPayload,
+    PyRc<PyObject<T>>: AsPyObjectRef,
     PyObject<T>: fmt::Pointer,
 {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
@@ -118,7 +164,7 @@ where
 impl<T> borrow::Borrow<T> for PyObjectRc<T>
 where
     T: ?Sized + PyObjectPayload,
-    PyRc<PyObject<T>>: borrow::Borrow<T>,
+    PyRc<PyObject<T>>: AsPyObjectRef + borrow::Borrow<T>,
 {
     fn borrow(&self) -> &T {
         self.inner.borrow()
@@ -128,7 +174,7 @@ where
 impl<T> AsRef<T> for PyObjectRc<T>
 where
     T: ?Sized + PyObjectPayload,
-    PyRc<PyObject<T>>: AsRef<T>,
+    PyRc<PyObject<T>>: AsPyObjectRef + AsRef<T>,
 {
     fn as_ref(&self) -> &T {
         self.inner.as_ref()

--- a/vm/src/pyobjectrc.rs
+++ b/vm/src/pyobjectrc.rs
@@ -1,0 +1,135 @@
+use crate::common::rc::{PyRc, PyWeak};
+use crate::pyobject::{DynPyObject, IdProtocol, PyObject, PyObjectPayload, PyRef, PyValue};
+use crate::vm::VirtualMachine;
+use std::borrow;
+use std::convert::From;
+use std::fmt;
+use std::ops::Deref;
+
+#[derive(Clone)]
+pub struct PyObjectRc {
+    inner: PyRc<DynPyObject>,
+}
+
+pub type PyObjectWeak = PyWeak<DynPyObject>;
+
+type InnerRc = PyRc<DynPyObject>;
+
+impl PyObjectRc {
+    /// # Safety
+    /// if rc is dropped without wrapping again, drop will not be called
+    unsafe fn into_rc(this: Self) -> PyRc<DynPyObject> {
+        std::mem::transmute(this)
+    }
+
+    pub fn into_raw(this: Self) -> *const DynPyObject {
+        PyRc::into_raw(unsafe { Self::into_rc(this) })
+    }
+
+    /// # Safety
+    /// See PyRc::from_raw
+    pub unsafe fn from_raw(ptr: *const DynPyObject) -> Self {
+        PyRc::from_raw(ptr).into()
+    }
+
+    pub fn strong_count(this: &Self) -> usize {
+        InnerRc::strong_count(this)
+    }
+
+    pub fn weak_count(this: &Self) -> usize {
+        InnerRc::weak_count(this)
+    }
+
+    pub fn downgrade(this: &Self) -> PyObjectWeak {
+        InnerRc::downgrade(&this.inner)
+    }
+
+    pub fn upgrade_weak(weak: &PyObjectWeak) -> Option<Self> {
+        weak.upgrade().map(|inner| PyObjectRc { inner })
+    }
+}
+
+#[cfg(feature = "threading")]
+unsafe impl Send for PyObjectRc {}
+#[cfg(feature = "threading")]
+unsafe impl Sync for PyObjectRc {}
+
+impl From<PyRc<DynPyObject>> for PyObjectRc {
+    fn from(rc: PyRc<DynPyObject>) -> PyObjectRc {
+        Self { inner: rc }
+    }
+}
+
+impl<P: PyObjectPayload> From<PyRc<PyObject<P>>> for PyObjectRc {
+    fn from(rc: PyRc<PyObject<P>>) -> PyObjectRc {
+        Self { inner: rc }
+    }
+}
+
+impl Deref for PyObjectRc {
+    type Target = PyRc<DynPyObject>;
+
+    #[inline]
+    fn deref(&self) -> &PyRc<DynPyObject> {
+        &self.inner
+    }
+}
+
+impl fmt::Display for PyObjectRc {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        self.inner.fmt(f)
+    }
+}
+
+impl fmt::Debug for PyObjectRc {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        self.inner.fmt(f)
+    }
+}
+
+impl fmt::Pointer for PyObjectRc {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        self.inner.fmt(f)
+    }
+}
+
+impl borrow::Borrow<DynPyObject> for PyObjectRc {
+    fn borrow(&self) -> &DynPyObject {
+        self.inner.borrow()
+    }
+}
+
+impl borrow::Borrow<PyRc<DynPyObject>> for PyObjectRc {
+    fn borrow(&self) -> &PyRc<DynPyObject> {
+        &self.inner
+    }
+}
+
+impl AsRef<DynPyObject> for PyObjectRc {
+    fn as_ref(&self) -> &DynPyObject {
+        self.inner.as_ref()
+    }
+}
+
+impl IdProtocol for PyObjectRc {
+    fn get_id(&self) -> usize {
+        self.inner.get_id()
+    }
+}
+
+impl PyObjectRc {
+    pub fn downcast<T: PyObjectPayload + PyValue>(self) -> Result<PyRef<T>, Self> {
+        unsafe { PyObjectRc::into_rc(self) }.downcast()
+    }
+
+    pub fn downcast_exact<T: PyObjectPayload + PyValue>(
+        self,
+        vm: &VirtualMachine,
+    ) -> Result<PyRef<T>, Self> {
+        unsafe { PyObjectRc::into_rc(self) }.downcast_exact(vm)
+    }
+
+    pub fn downcast_generic<T: PyObjectPayload>(self) -> Result<PyRc<PyObject<T>>, Self> {
+        unsafe { PyObjectRc::into_rc(self) }.downcast_generic()
+    }
+}

--- a/vm/src/stdlib/itertools.rs
+++ b/vm/src/stdlib/itertools.rs
@@ -9,7 +9,7 @@ mod decl {
     use std::iter;
 
     use crate::common::cell::{PyMutex, PyRwLock, PyRwLockWriteGuard};
-    use crate::common::rc::{PyRc, PyWeak};
+    use crate::common::rc::PyRc;
     use crate::function::{Args, OptionalArg, OptionalOption, PyFuncArgs};
     use crate::obj::objbool;
     use crate::obj::objint::{self, PyInt, PyIntRef};
@@ -17,8 +17,8 @@ mod decl {
     use crate::obj::objtuple::PyTuple;
     use crate::obj::objtype::{self, PyClassRef};
     use crate::pyobject::{
-        BorrowValue, IdProtocol, IntoPyRef, PyCallable, PyClassImpl, PyObject, PyObjectRef, PyRef,
-        PyResult, PyValue, TypeProtocol,
+        BorrowValue, IdProtocol, IntoPyRef, PyCallable, PyClassImpl, PyObjectRc, PyObjectRef,
+        PyObjectWeak, PyRef, PyResult, PyValue, TypeProtocol,
     };
     use crate::vm::VirtualMachine;
 
@@ -498,7 +498,7 @@ mod decl {
         current_value: Option<PyObjectRef>,
         current_key: Option<PyObjectRef>,
         next_group: bool,
-        grouper: Option<PyWeak<PyObject<PyItertoolsGrouper>>>,
+        grouper: Option<PyObjectWeak<PyItertoolsGrouper>>,
     }
 
     impl fmt::Debug for GroupByState {
@@ -609,7 +609,7 @@ mod decl {
             }
             .into_ref(vm);
 
-            state.grouper = Some(PyRc::downgrade(&grouper.clone().into_typed_pyobj()));
+            state.grouper = Some(PyObjectRc::downgrade(&grouper.clone().into_typed_pyobj()));
             Ok((state.current_key.as_ref().unwrap().clone(), grouper))
         }
 

--- a/vm/src/stdlib/weakref.rs
+++ b/vm/src/stdlib/weakref.rs
@@ -6,11 +6,11 @@
 //!
 
 use crate::pyobject::PyObjectRef;
+use crate::pyobjectrc::PyObjectRc;
 use crate::vm::VirtualMachine;
-use rustpython_common::rc::PyRc;
 
 fn weakref_getweakrefcount(obj: PyObjectRef) -> usize {
-    PyRc::weak_count(&obj)
+    PyObjectRc::weak_count(&obj)
 }
 
 fn weakref_getweakrefs(_obj: PyObjectRef, vm: &VirtualMachine) -> PyObjectRef {

--- a/vm/src/stdlib/weakref.rs
+++ b/vm/src/stdlib/weakref.rs
@@ -5,8 +5,7 @@
 //! - [rust weak struct](https://doc.rust-lang.org/std/rc/struct.Weak.html)
 //!
 
-use crate::pyobject::PyObjectRef;
-use crate::pyobjectrc::PyObjectRc;
+use crate::pyobject::{PyObjectRc, PyObjectRef};
 use crate::vm::VirtualMachine;
 
 fn weakref_getweakrefcount(obj: PyObjectRef) -> usize {

--- a/vm/src/sysmodule.rs
+++ b/vm/src/sysmodule.rs
@@ -1,17 +1,17 @@
 use num_traits::ToPrimitive;
 use std::{env, mem, path};
 
+use crate::common::hash::{PyHash, PyUHash};
 use crate::frame::FrameRef;
 use crate::function::{Args, OptionalArg, PyFuncArgs};
 use crate::obj::objstr::PyStringRef;
 use crate::obj::objtype::PyClassRef;
 use crate::pyobject::{
-    IntoPyObject, ItemProtocol, PyClassImpl, PyContext, PyObjectRef, PyResult, PyStructSequence,
+    IntoPyObject, ItemProtocol, PyClassImpl, PyContext, PyObjectRc, PyObjectRef, PyResult,
+    PyStructSequence,
 };
 use crate::vm::{PySettings, VirtualMachine};
 use crate::{builtins, exceptions, py_io, version};
-use rustpython_common::hash::{PyHash, PyUHash};
-use rustpython_common::rc::PyRc;
 
 /*
  * The magic sys module.
@@ -130,7 +130,7 @@ impl SysFlags {
 }
 
 fn sys_getrefcount(obj: PyObjectRef) -> usize {
-    PyRc::strong_count(&obj)
+    PyObjectRc::strong_count(&obj)
 }
 
 fn sys_getsizeof(obj: PyObjectRef) -> usize {

--- a/vm/src/types.rs
+++ b/vm/src/types.rs
@@ -39,7 +39,7 @@ use crate::obj::objtype::{self, PyClass, PyClassRef};
 use crate::obj::objweakproxy;
 use crate::obj::objweakref;
 use crate::obj::objzip;
-use crate::pyobject::{PyAttributes, PyClassDef, PyClassImpl, PyContext, PyObject};
+use crate::pyobject::{PyAttributes, PyClassDef, PyClassImpl, PyContext, PyObject, PyObjectRef};
 use crate::slots::PyClassSlots;
 use rustpython_common::{cell::PyRwLock, rc::PyRc};
 use std::mem::MaybeUninit;
@@ -309,8 +309,9 @@ fn init_type_hierarchy() -> (PyClassRef, PyClassRef) {
                 PyRwLock::new(type_type),
             );
 
-            let type_type = PyClassRef::from_obj_unchecked(PyRc::from_raw(type_type_ptr));
-            let object_type = PyClassRef::from_obj_unchecked(PyRc::from_raw(object_type_ptr));
+            let type_type = PyClassRef::from_obj_unchecked(PyObjectRef::from_raw(type_type_ptr));
+            let object_type =
+                PyClassRef::from_obj_unchecked(PyObjectRef::from_raw(object_type_ptr));
 
             (*type_type_ptr).payload.mro = vec![object_type.clone()];
             (*type_type_ptr).payload.bases = vec![object_type.clone()];

--- a/vm/src/types.rs
+++ b/vm/src/types.rs
@@ -39,7 +39,9 @@ use crate::obj::objtype::{self, PyClass, PyClassRef};
 use crate::obj::objweakproxy;
 use crate::obj::objweakref;
 use crate::obj::objzip;
-use crate::pyobject::{PyAttributes, PyClassDef, PyClassImpl, PyContext, PyObject, PyObjectRef};
+use crate::pyobject::{
+    PyAttributes, PyClassDef, PyClassImpl, PyContext, PyObject, PyObjectRc, PyObjectRef,
+};
 use crate::slots::PyClassSlots;
 use rustpython_common::{cell::PyRwLock, rc::PyRc};
 use std::mem::MaybeUninit;
@@ -259,35 +261,37 @@ fn init_type_hierarchy() -> (PyClassRef, PyClassRef) {
     // (and yes, this will never get dropped. TODO?)
     let (type_type, object_type) = {
         type PyClassObj = PyObject<PyClass>;
-        type UninitRef<T> = PyRwLock<PyRc<MaybeUninit<T>>>;
+        type UninitRef<T> = PyRwLock<PyRc<MaybeUninit<PyObject<T>>>>;
 
+        let type_payload = PyClass {
+            name: PyClassRef::NAME.to_owned(),
+            base: None,
+            bases: vec![],
+            mro: vec![],
+            subclasses: PyRwLock::default(),
+            attributes: PyRwLock::new(PyAttributes::new()),
+            slots: objtype::PyClassRef::make_slots(),
+        };
+        let object_payload = PyClass {
+            name: objobject::PyBaseObject::NAME.to_owned(),
+            base: None,
+            bases: vec![],
+            mro: vec![],
+            subclasses: PyRwLock::default(),
+            attributes: PyRwLock::new(PyAttributes::new()),
+            slots: objobject::PyBaseObject::make_slots(),
+        };
         let type_type: PyRc<MaybeUninit<PyClassObj>> = PyRc::new(partially_init!(
             PyObject::<PyClass> {
                 dict: None,
-                payload: PyClass {
-                    name: PyClassRef::NAME.to_owned(),
-                    base: None,
-                    bases: vec![],
-                    mro: vec![],
-                    subclasses: PyRwLock::default(),
-                    attributes: PyRwLock::new(PyAttributes::new()),
-                    slots: objtype::PyClassRef::make_slots(),
-                },
+                payload: type_payload,
             },
             Uninit { typ }
         ));
         let object_type: PyRc<MaybeUninit<PyClassObj>> = PyRc::new(partially_init!(
             PyObject::<PyClass> {
                 dict: None,
-                payload: PyClass {
-                    name: objobject::PyBaseObject::NAME.to_owned(),
-                    base: None,
-                    bases: vec![],
-                    mro: vec![],
-                    subclasses: PyRwLock::default(),
-                    attributes: PyRwLock::new(PyAttributes::new()),
-                    slots: objobject::PyBaseObject::make_slots(),
-                },
+                payload: object_payload,
             },
             Uninit { typ },
         ));
@@ -299,13 +303,13 @@ fn init_type_hierarchy() -> (PyClassRef, PyClassRef) {
 
         unsafe {
             ptr::write(
-                &mut (*object_type_ptr).typ as *mut PyRwLock<PyRc<PyClassObj>>
-                    as *mut UninitRef<PyClassObj>,
+                &mut (*object_type_ptr).typ as *mut PyRwLock<PyObjectRc<PyClass>>
+                    as *mut UninitRef<PyClass>,
                 PyRwLock::new(type_type.clone()),
             );
             ptr::write(
-                &mut (*type_type_ptr).typ as *mut PyRwLock<PyRc<PyClassObj>>
-                    as *mut UninitRef<PyClassObj>,
+                &mut (*type_type_ptr).typ as *mut PyRwLock<PyObjectRc<PyClass>>
+                    as *mut UninitRef<PyClass>,
                 PyRwLock::new(type_type),
             );
 

--- a/vm/src/vm.rs
+++ b/vm/src/vm.rs
@@ -741,7 +741,7 @@ impl VirtualMachine {
     pub fn isinstance(&self, obj: &PyObjectRef, cls: &PyClassRef) -> PyResult<bool> {
         // cpython first does an exact check on the type, although documentation doesn't state that
         // https://github.com/python/cpython/blob/a24107b04c1277e3c1105f98aff5bfa3a98b33a0/Objects/abstract.c#L2408
-        if PyRc::ptr_eq(&obj.class().into_object(), cls.as_object()) {
+        if obj.class().is(cls) {
             Ok(true)
         } else {
             let ret = self.call_method(cls.as_object(), "__instancecheck__", vec![obj.clone()])?;

--- a/wasm/lib/src/convert.rs
+++ b/wasm/lib/src/convert.rs
@@ -76,9 +76,11 @@ pub fn py_to_js(vm: &VirtualMachine, py_obj: PyObjectRef) -> JsValue {
             let closure =
                 move |args: Option<Array>, kwargs: Option<Object>| -> Result<JsValue, JsValue> {
                     let py_obj = match wasm_vm.assert_valid() {
-                        Ok(_) => weak_py_obj
-                            .upgrade()
-                            .expect("weak_py_obj to be valid if VM is valid"),
+                        Ok(_) => PyObjectRef::from(
+                            weak_py_obj
+                                .upgrade()
+                                .expect("weak_py_obj to be valid if VM is valid"),
+                        ),
                         Err(err) => {
                             return Err(err);
                         }

--- a/wasm/lib/src/convert.rs
+++ b/wasm/lib/src/convert.rs
@@ -76,7 +76,8 @@ pub fn py_to_js(vm: &VirtualMachine, py_obj: PyObjectRef) -> JsValue {
             let closure =
                 move |args: Option<Array>, kwargs: Option<Object>| -> Result<JsValue, JsValue> {
                     let py_obj = match wasm_vm.assert_valid() {
-                        Ok(_) => PyObjectRef::upgrade_weak(&weak_py_obj)
+                        Ok(_) => weak_py_obj
+                            .upgrade()
                             .expect("weak_py_obj to be valid if VM is valid"),
                         Err(err) => {
                             return Err(err);

--- a/wasm/lib/src/convert.rs
+++ b/wasm/lib/src/convert.rs
@@ -76,11 +76,8 @@ pub fn py_to_js(vm: &VirtualMachine, py_obj: PyObjectRef) -> JsValue {
             let closure =
                 move |args: Option<Array>, kwargs: Option<Object>| -> Result<JsValue, JsValue> {
                     let py_obj = match wasm_vm.assert_valid() {
-                        Ok(_) => PyObjectRef::from(
-                            weak_py_obj
-                                .upgrade()
-                                .expect("weak_py_obj to be valid if VM is valid"),
-                        ),
+                        Ok(_) => PyObjectRef::upgrade_weak(&weak_py_obj)
+                            .expect("weak_py_obj to be valid if VM is valid"),
                         Err(err) => {
                             return Err(err);
                         }

--- a/wasm/lib/src/vm_class.rs
+++ b/wasm/lib/src/vm_class.rs
@@ -179,7 +179,7 @@ impl WASMVirtualMachine {
         obj: PyObjectRef,
     ) -> Result<PyWeak<PyObject<dyn PyObjectPayload>>, JsValue> {
         self.with(|stored_vm| {
-            let weak = PyRc::downgrade(&obj);
+            let weak = PyObjectRef::downgrade(&obj);
             stored_vm.held_objects.borrow_mut().push(obj);
             weak
         })

--- a/wasm/lib/src/vm_class.rs
+++ b/wasm/lib/src/vm_class.rs
@@ -6,8 +6,8 @@ use js_sys::{Object, TypeError};
 use wasm_bindgen::prelude::*;
 
 use rustpython_compiler::compile;
-use rustpython_vm::common::rc::{PyRc, PyWeak};
-use rustpython_vm::pyobject::{ItemProtocol, PyObject, PyObjectPayload, PyObjectRef, PyValue};
+use rustpython_vm::common::rc::PyRc;
+use rustpython_vm::pyobject::{ItemProtocol, PyObjectRef, PyObjectWeak, PyValue};
 use rustpython_vm::scope::{NameProtocol, Scope};
 use rustpython_vm::{InitParameter, PySettings, VirtualMachine};
 
@@ -174,10 +174,7 @@ impl WASMVirtualMachine {
         STORED_VMS.with(|cell| cell.borrow().contains_key(&self.id))
     }
 
-    pub(crate) fn push_held_rc(
-        &self,
-        obj: PyObjectRef,
-    ) -> Result<PyWeak<PyObject<dyn PyObjectPayload>>, JsValue> {
+    pub(crate) fn push_held_rc(&self, obj: PyObjectRef) -> Result<PyObjectWeak, JsValue> {
         self.with(|stored_vm| {
             let weak = PyObjectRef::downgrade(&obj);
             stored_vm.held_objects.borrow_mut().push(obj);


### PR DESCRIPTION
Split `__del__` unrelated part from #2128 

this patch will be base of any kind of drop implementation