### PR TITLE
Remove PyValue::into_object & Rename PyValue::into_simple_object to PyValue::into_object

### DIFF
--- a/vm/src/obj/objint.rs
+++ b/vm/src/obj/objint.rs
@@ -9,7 +9,6 @@ use num_traits::{One, Pow, Signed, ToPrimitive, Zero};
 use super::objbool::IntoPyBool;
 use super::objbytearray::PyByteArray;
 use super::objbytes::PyBytes;
-use super::objdict::PyDictRef;
 use super::objfloat;
 use super::objmemory::PyMemoryView;
 use super::objstr::{PyString, PyStringRef};
@@ -19,7 +18,7 @@ use crate::format::FormatSpec;
 use crate::function::{OptionalArg, PyFuncArgs};
 use crate::pyobject::{
     BorrowValue, IdProtocol, IntoPyObject, IntoPyResult, PyArithmaticValue, PyClassImpl,
-    PyComparisonValue, PyContext, PyObject, PyObjectRef, PyRef, PyResult, PyValue, TryFromObject,
+    PyComparisonValue, PyContext, PyObjectRef, PyRef, PyResult, PyValue, TryFromObject,
     TypeProtocol,
 };
 use crate::stdlib::array::PyArray;
@@ -76,21 +75,8 @@ impl PyValue for PyInt {
         vm.ctx.types.int_type.clone()
     }
 
-    fn into_simple_object(self, vm: &VirtualMachine) -> PyObjectRef {
+    fn into_object(self, vm: &VirtualMachine) -> PyObjectRef {
         vm.ctx.new_int(self.value)
-    }
-
-    fn into_object(
-        self,
-        vm: &VirtualMachine,
-        cls: PyClassRef,
-        dict: Option<PyDictRef>,
-    ) -> PyObjectRef {
-        if cls.is(&Self::class(vm)) {
-            vm.ctx.new_int(self.value)
-        } else {
-            PyObject::new(self, cls, dict)
-        }
     }
 }
 

--- a/vm/src/pyobject.rs
+++ b/vm/src/pyobject.rs
@@ -1036,7 +1036,7 @@ where
     T: PyValue + Sized,
 {
     fn into_pyobject(self, vm: &VirtualMachine) -> PyObjectRef {
-        PyValue::into_simple_object(self, vm)
+        PyValue::into_object(self, vm)
     }
 }
 
@@ -1148,17 +1148,8 @@ cfg_if::cfg_if! {
 pub trait PyValue: fmt::Debug + PyThreadingConstraint + Sized + 'static {
     fn class(vm: &VirtualMachine) -> PyClassRef;
 
-    fn into_simple_object(self, vm: &VirtualMachine) -> PyObjectRef {
+    fn into_object(self, vm: &VirtualMachine) -> PyObjectRef {
         self.into_ref(vm).into_object()
-    }
-
-    fn into_object(
-        self,
-        _vm: &VirtualMachine,
-        cls: PyClassRef,
-        dict: Option<PyDictRef>,
-    ) -> PyObjectRef {
-        PyObject::new(self, cls, dict)
     }
 
     fn into_ref(self, vm: &VirtualMachine) -> PyRef<Self> {

--- a/vm/src/stdlib/array.rs
+++ b/vm/src/stdlib/array.rs
@@ -214,7 +214,7 @@ macro_rules! def_array_enum {
                         let obj = PyArray {
                             array: PyRwLock::new(sliced)
                         }
-                        .into_simple_object(vm);
+                        .into_object(vm);
                         Ok(obj)
                     })*
                 }
@@ -432,7 +432,7 @@ macro_rules! def_array_enum {
                         let obj = PyArray {
                             array: PyRwLock::new(sliced)
                         }
-                        .into_simple_object(vm);
+                        .into_object(vm);
                         Ok(obj)
                     } else {
                         Err(vm.new_type_error("bad argument type for built-in operation".to_owned()))
@@ -460,7 +460,7 @@ macro_rules! def_array_enum {
                         PyArray {
                             array: PyRwLock::new(sliced)
                         }
-                        .into_simple_object(vm)
+                        .into_object(vm)
                     })*
                 }
             }


### PR DESCRIPTION
`PyValue::into_object` was first introduced here: https://github.com/RustPython/RustPython/pull/2079

It was originally intended to be used in `into_ref_with_type`.
However, the definition of `PyValue` has changed, and `into_object` is not used anywhere.

I also renamed `into_simple_object` to `into_object`