### PR TITLE
Pass function refs to single_or_tuple_any

### DIFF
--- a/vm/src/builtins.rs
+++ b/vm/src/builtins.rs
@@ -372,8 +372,8 @@ mod decl {
     pub fn isinstance(obj: PyObjectRef, typ: PyObjectRef, vm: &VirtualMachine) -> PyResult<bool> {
         single_or_tuple_any(
             typ,
-            |cls: &PyClassRef| vm.isinstance(&obj, cls),
-            |o| {
+            &|cls: &PyClassRef| vm.isinstance(&obj, cls),
+            &|o| {
                 format!(
                     "isinstance() arg 2 must be a type or tuple of types, not {}",
                     o.lease_class()
@@ -387,8 +387,8 @@ mod decl {
     fn issubclass(subclass: PyClassRef, typ: PyObjectRef, vm: &VirtualMachine) -> PyResult<bool> {
         single_or_tuple_any(
             typ,
-            |cls: &PyClassRef| vm.issubclass(&subclass, cls),
-            |o| {
+            &|cls: &PyClassRef| vm.issubclass(&subclass, cls),
+            &|o| {
                 format!(
                     "issubclass() arg 2 must be a class or tuple of classes, not {}",
                     o.lease_class()

--- a/vm/src/pystr.rs
+++ b/vm/src/pystr.rs
@@ -224,8 +224,8 @@ where
             let value = self.get_bytes(range);
             single_or_tuple_any(
                 affix,
-                |s: &T| Ok(func(value, s)),
-                |o| {
+                &|s: &T| Ok(func(value, s)),
+                &|o| {
                     format!(
                         "{} first arg must be {} or a tuple of {}, not {}",
                         func_name,


### PR DESCRIPTION
The reference of `Fn` object also implements `Fn`.

Passing refs will solve the ownership problem with recursive calls, so the `Checker` struct can be removed.