### PR TITLE
Add macOS development requirements.

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -30,6 +30,9 @@ RustPython requires the following:
       from the [Python website](https://www.python.org/downloads/), or
       using a third-party distribution, such as 
       [Anaconda](https://www.anaconda.com/distribution/).
+- [macOS] Make sure autoconf, automake, libtool are installed
+    - To install with [Homebrew](https://brew.sh), enter 
+      `brew install autoconf automake libtool`
 - [Optional] The Python package, `pytest`, is used for testing Python code
   snippets. To install, enter `python3 -m pip install pytest`.
 

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -30,7 +30,8 @@ RustPython requires the following:
       from the [Python website](https://www.python.org/downloads/), or
       using a third-party distribution, such as 
       [Anaconda](https://www.anaconda.com/distribution/).
-- [macOS] Make sure autoconf, automake, libtool are installed
+- [macOS] In case of libffi-sys compilation error, make sure autoconf, automake,
+   libtool are installed
     - To install with [Homebrew](https://brew.sh), enter 
       `brew install autoconf automake libtool`
 - [Optional] The Python package, `pytest`, is used for testing Python code


### PR DESCRIPTION
autoconf, automake, and libtool are required as an external dependencies on macOS.
This PR adds the guide at DEVELOPMENT.md

After Rust update, I've experienced errors regarding the compilation of [libffi-sys](https://crates.io/crates/libffi-sys), and after some trial and error, installing automake and libtool solved the problem for me.