### PR TITLE
Add Jit integration tests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -313,7 +313,7 @@ dependencies = [
  "atty",
  "bitflags",
  "strsim 0.8.0",
- "textwrap",
+ "textwrap 0.11.0",
  "unicode-width",
  "vec_map",
 ]
@@ -1649,6 +1649,7 @@ dependencies = [
  "rustpython-compiler",
  "syn",
  "syn-ext",
+ "textwrap 0.12.1",
 ]
 
 [[package]]
@@ -2058,6 +2059,15 @@ name = "textwrap"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d326610f408c7a4eb6f51c37c330e496b08506c9457c9d34287ecc38809fb060"
+dependencies = [
+ "unicode-width",
+]
+
+[[package]]
+name = "textwrap"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "203008d98caf094106cfaba70acfed15e18ed3ddb7d94e49baec153a2b462789"
 dependencies = [
  "unicode-width",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -49,6 +49,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6b602bfe940d21c130f3895acd65221e8a61270debe89d628b9cb4e3ccb8569b"
 
 [[package]]
+name = "approx"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0e60b75072ecd4168020818c0107f2857bb6c4e64252d8d3983f6263b40a5c3"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
 name = "arr_macro"
 version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1656,12 +1665,14 @@ dependencies = [
 name = "rustpython-jit"
 version = "0.1.2"
 dependencies = [
+ "approx",
  "cranelift",
  "cranelift-module",
  "cranelift-simplejit",
  "libffi",
  "num-traits",
  "rustpython-bytecode",
+ "rustpython-derive",
  "thiserror",
 ]
 

--- a/derive/Cargo.toml
+++ b/derive/Cargo.toml
@@ -19,3 +19,4 @@ rustpython-compiler = { path = "../compiler", version = "0.1.1" }
 rustpython-bytecode = { path = "../bytecode", version = "0.1.1" }
 maplit = "1.0"
 once_cell = "1.3.1"
+textwrap = "0.12.1"

--- a/derive/src/compile_bytecode.rs
+++ b/derive/src/compile_bytecode.rs
@@ -1,6 +1,6 @@
 //! Parsing and processing for this form:
 //! ```ignore
-//! py_compile_input!(
+//! py_compile!(
 //!     // either:
 //!     source = "python_source_code",
 //!     // or
@@ -24,7 +24,8 @@ use std::env;
 use std::fs;
 use std::path::{Path, PathBuf};
 use syn::parse::{Parse, ParseStream, Result as ParseResult};
-use syn::{self, parse2, Lit, LitByteStr, LitStr, Meta, Token};
+use syn::spanned::Spanned;
+use syn::{self, parse2, Lit, LitByteStr, LitStr, Macro, Meta, MetaNameValue, Token};
 
 static CARGO_MANIFEST_DIR: Lazy<PathBuf> = Lazy::new(|| {
     PathBuf::from(env::var_os("CARGO_MANIFEST_DIR").expect("CARGO_MANIFEST_DIR is not present"))
@@ -62,7 +63,25 @@ impl CompilationSource {
         mode: compile::Mode,
         module_name: String,
     ) -> Result<HashMap<String, FrozenModule>, Diagnostic> {
-        Ok(match &self.kind {
+        match &self.kind {
+            CompilationSourceKind::Dir(rel_path) => {
+                self.compile_dir(&CARGO_MANIFEST_DIR.join(rel_path), String::new(), mode)
+            }
+            _ => Ok(hashmap! {
+                module_name.clone() => FrozenModule {
+                    code: self.compile_single(mode, module_name)?,
+                    package: false,
+                },
+            }),
+        }
+    }
+
+    fn compile_single(
+        &self,
+        mode: compile::Mode,
+        module_name: String,
+    ) -> Result<CodeObject, Diagnostic> {
+        match &self.kind {
             CompilationSourceKind::File(rel_path) => {
                 let path = CARGO_MANIFEST_DIR.join(rel_path);
                 let source = fs::read_to_string(&path).map_err(|err| {
@@ -71,25 +90,17 @@ impl CompilationSource {
                         format!("Error reading file {:?}: {}", path, err),
                     )
                 })?;
-                hashmap! {
-                    module_name.clone() => FrozenModule {
-                        code: self.compile_string(&source, mode, module_name, || rel_path.display())?,
-                        package: false,
-                    },
-                }
+                self.compile_string(&source, mode, module_name, || rel_path.display())
             }
             CompilationSourceKind::SourceCode(code) => {
-                hashmap! {
-                    module_name.clone() => FrozenModule {
-                        code: self.compile_string(code, mode, module_name, || "string literal")?,
-                        package: false,
-                    },
-                }
+                self.compile_string(&textwrap::dedent(code), mode, module_name, || {
+                    "string literal"
+                })
             }
-            CompilationSourceKind::Dir(rel_path) => {
-                self.compile_dir(&CARGO_MANIFEST_DIR.join(rel_path), String::new(), mode)?
+            CompilationSourceKind::Dir(_) => {
+                unreachable!("Can't use compile_single with directory source")
             }
-        })
+        }
     }
 
     fn compile_dir(
@@ -157,7 +168,7 @@ struct PyCompileInput {
 }
 
 impl PyCompileInput {
-    fn parse(&self) -> Result<PyCompileArgs, Diagnostic> {
+    fn parse(&self, allow_dir: bool) -> Result<PyCompileArgs, Diagnostic> {
         let mut module_name = None;
         let mut mode = None;
         let mut source: Option<CompilationSource> = None;
@@ -214,6 +225,10 @@ impl PyCompileInput {
                         span: extract_spans(&name_value).unwrap(),
                     });
                 } else if ident == "dir" {
+                    if !allow_dir {
+                        bail_span!(ident, "py_compile doesn't accept dir")
+                    }
+
                     assert_source_empty(&source)?;
                     let path = match &name_value.lit {
                         Lit::Str(s) => PathBuf::from(s.value()),
@@ -236,7 +251,7 @@ impl PyCompileInput {
         let source = source.ok_or_else(|| {
             Diagnostic::span_error(
                 self.span,
-                "Must have either file or source in py_compile_bytecode!()",
+                "Must have either file or source in py_compile!()/py_freeze!()",
             )
         })?;
 
@@ -249,11 +264,32 @@ impl PyCompileInput {
     }
 }
 
+fn parse_meta(input: ParseStream) -> ParseResult<Meta> {
+    let path = input.call(syn::Path::parse_mod_style)?;
+    let eq_token: Token![=] = input.parse()?;
+    let span = input.span();
+    if input.peek(LitStr) {
+        Ok(Meta::NameValue(MetaNameValue {
+            path,
+            eq_token,
+            lit: Lit::Str(input.parse()?),
+        }))
+    } else if let Ok(mac) = input.parse::<Macro>() {
+        Ok(Meta::NameValue(MetaNameValue {
+            path,
+            eq_token,
+            lit: Lit::Str(LitStr::new(&mac.tokens.to_string(), mac.span())),
+        }))
+    } else {
+        Err(syn::Error::new(span, "Expected string or stringify macro"))
+    }
+}
+
 impl Parse for PyCompileInput {
     fn parse(input: ParseStream) -> ParseResult<Self> {
         let span = input.cursor().span();
         let metas = input
-            .parse_terminated::<Meta, Token![,]>(Meta::parse)?
+            .parse_terminated::<Meta, Token![,]>(parse_meta)?
             .into_iter()
             .collect();
         Ok(PyCompileInput { span, metas })
@@ -267,9 +303,27 @@ struct PyCompileArgs {
     crate_name: syn::Ident,
 }
 
-pub fn impl_py_compile_bytecode(input: TokenStream2) -> Result<TokenStream2, Diagnostic> {
+pub fn impl_py_compile(input: TokenStream2) -> Result<TokenStream2, Diagnostic> {
     let input: PyCompileInput = parse2(input)?;
-    let args = input.parse()?;
+    let args = input.parse(false)?;
+
+    let crate_name = args.crate_name;
+    let code = args.source.compile_single(args.mode, args.module_name)?;
+
+    let bytes = code.to_bytes();
+    let bytes = LitByteStr::new(&bytes, Span::call_site());
+
+    let output = quote! {
+        ::#crate_name::bytecode::CodeObject::from_bytes(#bytes)
+            .expect("Deserializing CodeObject failed")
+    };
+
+    Ok(output)
+}
+
+pub fn impl_py_freeze(input: TokenStream2) -> Result<TokenStream2, Diagnostic> {
+    let input: PyCompileInput = parse2(input)?;
+    let args = input.parse(true)?;
 
     let crate_name = args.crate_name;
     let code_map = args.source.compile(args.mode, args.module_name)?;

--- a/derive/src/lib.rs
+++ b/derive/src/lib.rs
@@ -62,6 +62,11 @@ pub fn pystruct_sequence(input: TokenStream) -> TokenStream {
 }
 
 #[proc_macro]
-pub fn py_compile_bytecode(input: TokenStream) -> TokenStream {
-    result_to_tokens(compile_bytecode::impl_py_compile_bytecode(input.into()))
+pub fn py_compile(input: TokenStream) -> TokenStream {
+    result_to_tokens(compile_bytecode::impl_py_compile(input.into()))
+}
+
+#[proc_macro]
+pub fn py_freeze(input: TokenStream) -> TokenStream {
+    result_to_tokens(compile_bytecode::impl_py_freeze(input.into()))
 }

--- a/examples/freeze/main.rs
+++ b/examples/freeze/main.rs
@@ -12,7 +12,7 @@ fn run(vm: &vm::VirtualMachine) -> vm::pyobject::PyResult<()> {
     // the file parameter is relevant to the directory where the crate's Cargo.toml is located, see $CARGO_MANIFEST_DIR:
     // https://doc.rust-lang.org/cargo/reference/environment-variables.html#environment-variables-cargo-sets-for-crates
     let modules: HashMap<String, vm::bytecode::FrozenModule> =
-        vm::py_compile_bytecode!(file = "examples/freeze/freeze.py");
+        vm::py_freeze!(file = "examples/freeze/freeze.py");
 
     let res = vm.run_code_obj(
         vm.ctx

--- a/examples/mini_repl.rs
+++ b/examples/mini_repl.rs
@@ -10,7 +10,7 @@ use std::sync::atomic::{AtomicBool, Ordering};
 // this needs to be in scope in order to insert things into scope.globals
 use vm::pyobject::ItemProtocol;
 
-// This has to be a macro because it uses the py_compile_bytecode macro,
+// This has to be a macro because it uses the py_compile macro,
 // which compiles python source to optimized bytecode at compile time, so that
 // the program you're embedding this into doesn't take longer to start up.
 macro_rules! add_python_function {
@@ -19,15 +19,7 @@ macro_rules! add_python_function {
         // (a PyRef is a special reference that points to something in the VirtualMachine)
         use vm::pyobject::PyValue;
 
-        // you can safely assume that only one module will be created when passing a source literal
-        // to py_compile_bytecode. However, it is also possible to pass directories, which may
-        // return more modules.
-        let (_, vm::bytecode::FrozenModule { code, .. }): (String, _) =
-            vm::py_compile_bytecode!(source = $src)
-                .into_iter()
-                .collect::<Vec<_>>()
-                .pop()
-                .expect("No modules found in the provided source!");
+        let code = vm::py_compile!(source = $src);
 
         // takes the first constant in the file that's a function
         let def = code

--- a/jit/Cargo.toml
+++ b/jit/Cargo.toml
@@ -7,11 +7,21 @@ repository = "https://github.com/RustPython/RustPython"
 license = "MIT"
 edition = "2018"
 
+autotests = false
+
 [dependencies]
 cranelift = "0.66.0"
 cranelift-module = "0.66.0"
 cranelift-simplejit = "0.66.0"
 num-traits = "0.2"
 libffi = "0.9.0"
-rustpython-bytecode = { path = "../bytecode", version = "0.1.1" }
+rustpython-bytecode = { path = "../bytecode", version = "0.1.2" }
 thiserror = "1.0"
+
+[dev-dependencies]
+approx = "0.3.2"
+rustpython-derive = { path = "../derive", version = "0.1.2" }
+
+[[test]]
+name = "integration"
+path = "tests/lib.rs"

--- a/jit/tests/common.rs
+++ b/jit/tests/common.rs
@@ -1,0 +1,184 @@
+use std::collections::HashMap;
+
+use rustpython_bytecode::bytecode::{CodeObject, Constant, Instruction, NameScope};
+use rustpython_jit::{CompiledCode, JitType};
+
+#[derive(Debug, Clone)]
+pub struct Function {
+    code: Box<CodeObject>,
+    name: String,
+    annotations: HashMap<String, StackValue>,
+}
+
+impl Function {
+    pub fn compile(self) -> CompiledCode {
+        let mut arg_types = Vec::new();
+        for arg in self.code.arg_names.iter() {
+            let arg_type = match self.annotations.get(arg) {
+                Some(StackValue::String(annotation)) => match annotation.as_str() {
+                    "int" => JitType::Int,
+                    "float" => JitType::Float,
+                    _ => panic!("Unrecognised jit type"),
+                },
+                _ => panic!("Argument have annotation"),
+            };
+            arg_types.push(arg_type);
+        }
+
+        rustpython_jit::compile(&self.code, &arg_types).expect("Compile failure")
+    }
+}
+
+#[derive(Debug, Clone)]
+enum StackValue {
+    String(String),
+    None,
+    Map(HashMap<String, StackValue>),
+    Code(Box<CodeObject>),
+    Function(Function),
+}
+
+impl From<Constant> for StackValue {
+    fn from(value: Constant) -> Self {
+        match value {
+            Constant::String { value } => StackValue::String(value),
+            Constant::None => StackValue::None,
+            Constant::Code { code } => StackValue::Code(code),
+            c => unimplemented!("constant {:?} isn't yet supported in py_function!", c),
+        }
+    }
+}
+
+pub struct StackMachine {
+    stack: Vec<StackValue>,
+    locals: HashMap<String, StackValue>,
+}
+
+impl StackMachine {
+    pub fn new() -> StackMachine {
+        StackMachine {
+            stack: Vec::new(),
+            locals: HashMap::new(),
+        }
+    }
+
+    pub fn run(&mut self, code: CodeObject) {
+        for instruction in code.instructions {
+            if self.process_instruction(instruction) {
+                break;
+            }
+        }
+    }
+
+    fn process_instruction(&mut self, instruction: Instruction) -> bool {
+        match instruction {
+            Instruction::LoadConst { value } => self.stack.push(value.into()),
+            Instruction::LoadName {
+                name,
+                scope: NameScope::Free,
+            } => self.stack.push(StackValue::String(name)),
+            Instruction::StoreName { name, .. } => {
+                self.locals.insert(name, self.stack.pop().unwrap());
+            }
+            Instruction::StoreAttr { .. } => {
+                // Do nothing except throw away the stack values
+                self.stack.pop().unwrap();
+                self.stack.pop().unwrap();
+            }
+            Instruction::BuildMap { size, .. } => {
+                let mut map = HashMap::new();
+                for _ in 0..size {
+                    let value = self.stack.pop().unwrap();
+                    let name = if let Some(StackValue::String(name)) = self.stack.pop() {
+                        name
+                    } else {
+                        unimplemented!("no string keys isn't yet supported in py_function!")
+                    };
+                    map.insert(name, value);
+                }
+                self.stack.push(StackValue::Map(map));
+            }
+            Instruction::MakeFunction => {
+                let name = if let Some(StackValue::String(name)) = self.stack.pop() {
+                    name
+                } else {
+                    panic!("Expected function name")
+                };
+                let code = if let Some(StackValue::Code(code)) = self.stack.pop() {
+                    code
+                } else {
+                    panic!("Expected function code")
+                };
+                let annotations = if let Some(StackValue::Map(map)) = self.stack.pop() {
+                    map
+                } else {
+                    panic!("Expected function annotations")
+                };
+                self.stack.push(StackValue::Function(Function {
+                    name,
+                    code,
+                    annotations,
+                }));
+            }
+            Instruction::Duplicate => {
+                let value = self.stack.last().unwrap().clone();
+                self.stack.push(value);
+            }
+            Instruction::Rotate { amount } => {
+                let mut values = Vec::new();
+
+                // Pop all values from stack:
+                for _ in 0..amount {
+                    values.push(self.stack.pop().unwrap());
+                }
+
+                // Push top of stack back first:
+                self.stack.push(values.remove(0));
+
+                // Push other value back in order:
+                for value in values.into_iter().rev() {
+                    self.stack.push(value);
+                }
+            }
+            Instruction::ReturnValue => return true,
+            _ => unimplemented!(
+                "instruction {:?} isn't yet supported in py_function!",
+                instruction
+            ),
+        }
+        return false;
+    }
+
+    pub fn get_function(&self, name: &str) -> Function {
+        if let Some(StackValue::Function(function)) = self.locals.get(name) {
+            function.clone()
+        } else {
+            panic!("There was no function named {}", name)
+        }
+    }
+}
+
+macro_rules! jit_function {
+    ($func_name:ident($($arg_name:ident:$arg_type:ty),*) -> $ret_type:ty => $($t:tt)*) => {
+        {
+            use std::convert::TryInto;
+
+            let code = rustpython_derive::py_compile!(
+                crate_name = "rustpython_bytecode",
+                source = $($t)*
+            );
+            let mut machine = $crate::common::StackMachine::new();
+            machine.run(code);
+            let jit_code = machine.get_function(stringify!($func_name)).compile();
+
+            move |$($arg_name:$arg_type),*| -> Result<$ret_type, rustpython_jit::JitArgumentError> {
+                jit_code
+                    .invoke(&[$($arg_name.into()),*])
+                    .map(|ret| match ret {
+                        Some(ret) => ret.try_into().expect("jit function returned unexpected type"),
+                        None => panic!("jit function unexpectedly returned None")
+                    })
+            }
+        }
+    };
+}

--- a/jit/tests/common.rs
+++ b/jit/tests/common.rs
@@ -128,17 +128,13 @@ impl StackMachine {
                 let mut values = Vec::new();
 
                 // Pop all values from stack:
-                for _ in 0..amount {
-                    values.push(self.stack.pop().unwrap());
-                }
+                values.extend(self.stack.drain(self.stack.len() - amount..));
 
                 // Push top of stack back first:
-                self.stack.push(values.remove(0));
+                self.stack.push(values.pop().unwrap());
 
                 // Push other value back in order:
-                for value in values.into_iter().rev() {
-                    self.stack.push(value);
-                }
+                self.stack.extend(values);
             }
             Instruction::ReturnValue => return true,
             _ => unimplemented!(

--- a/jit/tests/float_tests.rs
+++ b/jit/tests/float_tests.rs
@@ -1,0 +1,92 @@
+macro_rules! assert_approx_eq {
+    ($left:expr, $right:expr) => {
+        match ($left, $right) {
+            (Ok(lhs), Ok(rhs)) => approx::assert_relative_eq!(lhs, rhs),
+            (lhs, rhs) => assert_eq!(lhs, rhs),
+        }
+    };
+}
+
+macro_rules! assert_bits_eq {
+    ($left:expr, $right:expr) => {
+        match ($left, $right) {
+            (Ok(lhs), Ok(rhs)) => assert!(lhs.to_bits() == rhs.to_bits()),
+            (lhs, rhs) => assert_eq!(lhs, rhs),
+        }
+    };
+}
+
+#[test]
+fn test_add() {
+    let add = jit_function! { add(a:f64, b:f64) -> f64 => r##"
+        def add(a: float, b: float):
+            return a + b
+    "## };
+
+    assert_approx_eq!(add(5.5, 10.2), Ok(15.7));
+    assert_approx_eq!(add(-4.5, 7.6), Ok(3.1));
+    assert_approx_eq!(add(-5.2, -3.9), Ok(-9.1));
+    assert_bits_eq!(add(-5.2, f64::NAN), Ok(f64::NAN));
+    assert_eq!(add(2.0, f64::INFINITY), Ok(f64::INFINITY));
+    assert_eq!(add(-2.0, f64::NEG_INFINITY), Ok(f64::NEG_INFINITY));
+    assert_eq!(add(1.0, f64::NEG_INFINITY), Ok(f64::NEG_INFINITY));
+}
+
+#[test]
+fn test_sub() {
+    let sub = jit_function! { sub(a:f64, b:f64) -> f64 => r##"
+        def sub(a: float, b: float):
+            return a - b
+    "## };
+
+    assert_approx_eq!(sub(5.2, 3.6), Ok(1.6));
+    assert_approx_eq!(sub(3.4, 4.2), Ok(-0.8));
+    assert_approx_eq!(sub(-2.1, 1.3), Ok(-3.4));
+    assert_approx_eq!(sub(3.1, -1.3), Ok(4.4));
+    assert_bits_eq!(sub(-5.2, f64::NAN), Ok(f64::NAN));
+    assert_eq!(sub(f64::INFINITY, 2.0), Ok(f64::INFINITY));
+    assert_eq!(sub(-2.0, f64::NEG_INFINITY), Ok(f64::INFINITY));
+    assert_eq!(sub(1.0, f64::INFINITY), Ok(f64::NEG_INFINITY));
+}
+
+#[test]
+fn test_mul() {
+    let mul = jit_function! { mul(a:f64, b:f64) -> f64 => r##"
+        def mul(a: float, b: float):
+            return a * b
+    "## };
+
+    assert_approx_eq!(mul(5.2, 2.0), Ok(10.4));
+    assert_approx_eq!(mul(3.4, -1.7), Ok(-5.779999999999999));
+    assert_bits_eq!(mul(1.0, 0.0), Ok(0.0f64));
+    assert_bits_eq!(mul(1.0, -0.0), Ok(-0.0f64));
+    assert_bits_eq!(mul(-1.0, 0.0), Ok(-0.0f64));
+    assert_bits_eq!(mul(-1.0, -0.0), Ok(0.0f64));
+    assert_bits_eq!(mul(-5.2, f64::NAN), Ok(f64::NAN));
+    assert_eq!(mul(1.0, f64::INFINITY), Ok(f64::INFINITY));
+    assert_eq!(mul(1.0, f64::NEG_INFINITY), Ok(f64::NEG_INFINITY));
+    assert_eq!(mul(-1.0, f64::INFINITY), Ok(f64::NEG_INFINITY));
+    assert!(mul(0.0, f64::INFINITY).unwrap().is_nan());
+    assert_eq!(mul(f64::NEG_INFINITY, f64::INFINITY), Ok(f64::NEG_INFINITY));
+}
+
+#[test]
+fn test_div() {
+    let div = jit_function! { div(a:f64, b:f64) -> f64 => r##"
+        def div(a: float, b: float):
+            return a / b
+    "## };
+
+    assert_approx_eq!(div(5.2, 2.0), Ok(2.6));
+    assert_approx_eq!(div(3.4, -1.7), Ok(-2.0));
+    assert_eq!(div(1.0, 0.0), Ok(f64::INFINITY));
+    assert_eq!(div(1.0, -0.0), Ok(f64::NEG_INFINITY));
+    assert_eq!(div(-1.0, 0.0), Ok(f64::NEG_INFINITY));
+    assert_eq!(div(-1.0, -0.0), Ok(f64::INFINITY));
+    assert_bits_eq!(div(-5.2, f64::NAN), Ok(f64::NAN));
+    assert_eq!(div(f64::INFINITY, 2.0), Ok(f64::INFINITY));
+    assert_bits_eq!(div(-2.0, f64::NEG_INFINITY), Ok(0.0f64));
+    assert_bits_eq!(div(1.0, f64::INFINITY), Ok(0.0f64));
+    assert_bits_eq!(div(2.0, f64::NEG_INFINITY), Ok(-0.0f64));
+    assert_bits_eq!(div(-1.0, f64::INFINITY), Ok(-0.0f64));
+}

--- a/jit/tests/int_tests.rs
+++ b/jit/tests/int_tests.rs
@@ -1,0 +1,24 @@
+#[test]
+fn test_add() {
+    let add = jit_function! { add(a:i64, b:i64) -> i64 => r##"
+        def add(a: int, b: int):
+            return a + b
+    "## };
+
+    assert_eq!(add(5, 10), Ok(15));
+    assert_eq!(add(-5, 12), Ok(7));
+    assert_eq!(add(-5, -3), Ok(-8));
+}
+
+#[test]
+fn test_sub() {
+    let sub = jit_function! { sub(a:i64, b:i64) -> i64 => r##"
+        def sub(a: int, b: int):
+            return a - b
+    "## };
+
+    assert_eq!(sub(5, 10), Ok(-5));
+    assert_eq!(sub(12, 10), Ok(2));
+    assert_eq!(sub(7, 10), Ok(-3));
+    assert_eq!(sub(-3, -10), Ok(7));
+}

--- a/jit/tests/lib.rs
+++ b/jit/tests/lib.rs
@@ -2,3 +2,4 @@
 mod common;
 mod float_tests;
 mod int_tests;
+mod misc_tests;

--- a/jit/tests/lib.rs
+++ b/jit/tests/lib.rs
@@ -1,0 +1,4 @@
+#[macro_use]
+mod common;
+mod float_tests;
+mod int_tests;

--- a/jit/tests/misc_tests.rs
+++ b/jit/tests/misc_tests.rs
@@ -1,0 +1,67 @@
+use rustpython_jit::{AbiValue, JitArgumentError};
+
+// TODO currently broken
+// #[test]
+// fn test_no_return_value() {
+//     let func = jit_function! { func() => r##"
+//         def func():
+//             pass
+//     "## };
+//
+//     assert_eq!(func(), Ok(()));
+// }
+
+#[test]
+fn test_invoke() {
+    let func = jit_function! { func => r##"
+        def func(a: int, b: float):
+            return 1
+    "## };
+
+    assert_eq!(
+        func.invoke(&[AbiValue::Int(1)]),
+        Err(JitArgumentError::WrongNumberOfArguments)
+    );
+    assert_eq!(
+        func.invoke(&[AbiValue::Int(1), AbiValue::Float(2.0), AbiValue::Int(0)]),
+        Err(JitArgumentError::WrongNumberOfArguments)
+    );
+    assert_eq!(
+        func.invoke(&[AbiValue::Int(1), AbiValue::Int(1)]),
+        Err(JitArgumentError::ArgumentTypeMismatch)
+    );
+    assert_eq!(
+        func.invoke(&[AbiValue::Int(1), AbiValue::Float(2.0)]),
+        Ok(Some(AbiValue::Int(1)))
+    );
+}
+
+#[test]
+fn test_args_builder() {
+    let func = jit_function! { func=> r##"
+        def func(a: int, b: float):
+            return 1
+    "## };
+
+    let mut args_builder = func.args_builder();
+    assert_eq!(args_builder.set(0, AbiValue::Int(1)), Ok(()));
+    assert!(args_builder.is_set(0));
+    assert!(!args_builder.is_set(1));
+    assert_eq!(
+        args_builder.set(1, AbiValue::Int(1)),
+        Err(JitArgumentError::ArgumentTypeMismatch)
+    );
+    assert!(args_builder.is_set(0));
+    assert!(!args_builder.is_set(1));
+    assert!(args_builder.into_args().is_none());
+
+    let mut args_builder = func.args_builder();
+    assert_eq!(args_builder.set(0, AbiValue::Int(1)), Ok(()));
+    assert_eq!(args_builder.set(1, AbiValue::Float(1.0)), Ok(()));
+    assert!(args_builder.is_set(0));
+    assert!(args_builder.is_set(1));
+
+    let args = args_builder.into_args();
+    assert!(args.is_some());
+    assert_eq!(args.unwrap().invoke(), Some(AbiValue::Int(1)));
+}

--- a/vm/pylib-crate/src/lib.rs
+++ b/vm/pylib-crate/src/lib.rs
@@ -13,5 +13,5 @@ use {
 };
 #[cfg(feature = "compiled-bytecode")]
 pub fn frozen_stdlib() -> HashMap<String, FrozenModule> {
-    rustpython_derive::py_compile_bytecode!(dir = "Lib", crate_name = "rustpython_pylib")
+    rustpython_derive::py_freeze!(dir = "Lib", crate_name = "rustpython_pylib")
 }

--- a/vm/src/frozen.rs
+++ b/vm/src/frozen.rs
@@ -6,7 +6,7 @@ pub fn get_module_inits() -> HashMap<String, FrozenModule> {
 
     macro_rules! ext_modules {
         ($($t:tt)*) => {
-            modules.extend(py_compile_bytecode!($($t)*));
+            modules.extend(py_freeze!($($t)*));
         };
     }
 

--- a/vm/src/obj/objfunction.rs
+++ b/vm/src/obj/objfunction.rs
@@ -240,7 +240,7 @@ impl PyFunction {
         if let Some(jitted_code) = self.jitted_code.get() {
             match jitfunc::get_jit_args(self, &func_args, jitted_code, vm) {
                 Ok(args) => {
-                    return Ok(jitted_code.invoke(&args).into_pyobject(vm));
+                    return Ok(args.invoke().into_pyobject(vm));
                 }
                 Err(err) => info!(
                     "jit: function `{}` is falling back to being interpreted because of the \

--- a/wasm/lib/src/browser_module.rs
+++ b/wasm/lib/src/browser_module.rs
@@ -382,8 +382,7 @@ pub fn setup_browser_module(vm: &mut VirtualMachine) {
     state
         .stdlib_inits
         .insert("_browser".to_owned(), Box::new(make_module));
-    state.frozen.extend(py_compile_bytecode!(
-        file = "src/browser.py",
-        module_name = "browser",
-    ));
+    state
+        .frozen
+        .extend(py_freeze!(file = "src/browser.py", module_name = "browser",));
 }


### PR DESCRIPTION
This add a test utility macro `jit_function`, which allows declaring jitted python functions inside rust test functions. Example:
```rust
let add = jit_function! { add(a:i64, b:i64) -> i64 => r##"
    def add(a: int, b: int):
        return a + b
"## };
```
The above define the python function `add`, which is compiled to bytecode at compile time. That bytecode is then jitted into native code at runtime(we could also do this a compile time in the future). The return value of the macro is a lambda with the signature `fn(i64, i64) -> i64`.

As part of that I refactored `py_compile_bytecode` into two different macros `py_compile` and `py_freeze`.