### PR TITLE
Run tests/clippy on all crates

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -7,6 +7,15 @@ name: CI
 
 env:
   CARGO_ARGS: --features "ssl jit"
+  NON_WASM_PACKAGES: >
+    -p rustpython-bytecode
+    -p rustpython-common
+    -p rustpython-compiler
+    -p rustpython-parser
+    -p rustpython-vm
+    -p rustpython-jit
+    -p rustpython-derive
+    -p rustpython
 
 jobs:
   rust_tests:
@@ -38,7 +47,7 @@ jobs:
         uses: actions-rs/cargo@v1
         with:
           command: test
-          args: --verbose ${{ env.CARGO_ARGS }}
+          args: --verbose ${{ env.CARGO_ARGS }} ${{ env.NON_WASM_PACKAGES }}
       - name: check compilation without threading
         uses: actions-rs/cargo@v1
         with:
@@ -124,7 +133,7 @@ jobs:
         uses: actions-rs/cargo@v1
         with:
           command: clippy
-          args: ${{ env.CARGO_ARGS }} -- -Dwarnings
+          args: ${{ env.CARGO_ARGS }} ${{ env.NON_WASM_PACKAGES }} -- -Dwarnings
       - name: run clippy on wasm
         uses: actions-rs/cargo@v1
         with:


### PR DESCRIPTION
Fairly recently we removed passing `--all` when running clippy/tests on CI as the wasm crate can't handle be compiled with the threading feature, but that caused rust tests that aren't in the root crate to not be run on CI.

Split from #2187 

cc @coolreader18 