### PR TITLE
new wasm example: notebook inspired by alpha.iodide.io

### DIFF
--- a/wasm/notebook/package.json
+++ b/wasm/notebook/package.json
@@ -1,0 +1,39 @@
+{
+    "name": "app",
+    "version": "1.0.0",
+    "description": "Bindings to the RustPython library for WebAssembly",
+    "main": "index.js",
+    "dependencies": {
+        "codemirror": "^5.42.0",
+        "local-echo": "^0.2.0",
+        "xterm": "^3.8.0"
+    },
+    "devDependencies": {
+        "@wasm-tool/wasm-pack-plugin": "^1.1.0",
+        "clean-webpack-plugin": "^3.0.0",
+        "css-loader": "^3.4.1",
+        "html-webpack-plugin": "^3.2.0",
+        "mini-css-extract-plugin": "^0.9.0",
+        "raw-loader": "^4.0.0",
+        "serve": "^11.0.2",
+        "webpack": "^4.16.3",
+        "webpack-cli": "^3.1.0",
+        "webpack-dev-server": "^3.1.5"
+    },
+    "scripts": {
+        "dev": "webpack-dev-server -d",
+        "build": "webpack",
+        "dist": "webpack --mode production",
+        "test": "webpack --mode production && cd ../tests && pipenv run pytest"
+    },
+    "repository": {
+        "type": "git",
+        "url": "git+https://github.com/RustPython/RustPython.git"
+    },
+    "author": "Ryan Liddle",
+    "license": "MIT",
+    "bugs": {
+        "url": "https://github.com/RustPython/RustPython/issues"
+    },
+    "homepage": "https://github.com/RustPython/RustPython#readme"
+}

--- a/wasm/notebook/src/index.ejs
+++ b/wasm/notebook/src/index.ejs
@@ -1,0 +1,57 @@
+<!DOCTYPE html>
+<html>
+
+<head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <link defer async href="https://fonts.googleapis.com/css?family=Fira+Sans|Sen:800&display=swap" rel="stylesheet">
+    <title>🐍 RustPython Notebook</title>
+</head>
+
+<body>
+    <!-- navigation bar -->
+    <div class="nav-bar">
+        <div>
+            <button id="run-btn">run notebook &#9658; </button>
+            <button id="snippet-btn" class="secondary-btn mr-1">import code</button>
+        </div>
+        <div class="header">RustPython 🐍 😱 🤘</div>
+        <div><a href="https://github.com/RustPython/">github</a></div>
+    </div>
+
+    <!-- user interface elements for importing code -->
+    <div id="url-container" class="d-none">
+        <div><label for="url">public url: (uses github api file url for now)</label></div>
+        <div>
+            <input type="url" name="url" id="snippet-url">
+        </div>
+        <div>
+            <button id="fetch-code" class="secondary-btn">fetch</button>
+        </div>
+    </div>
+
+    <!-- code editor and output display -->
+    <!-- split view -->
+    <div class="split-view full-height">
+        <textarea id="code"></textarea>
+        <div id="console"></div>
+    </div>
+
+    <!-- errors and keyboard shortcuts -->
+    <div class="split-view">
+        <div>
+            <mark>errors</mark>
+            <div id="error"></div>
+        </div>
+        <div class="text-small mt-1">
+            <mark>Keyboard Shortcuts:</mark>
+            <div>
+                <div>Run code: 'Ctrl-Enter' or 'Cmd-Enter'</div>
+                <div>Decrease Indent: 'Shift-Tab' </div>
+                <div>Toggle comment: 'Ctrl-/' or 'Cmd-/'</div>
+            </div>
+        </div>
+    </div>
+</body>
+
+</html>

--- a/wasm/notebook/src/index.ejs
+++ b/wasm/notebook/src/index.ejs
@@ -13,20 +13,18 @@
     <div class="nav-bar">
         <div>
             <button id="run-btn">run notebook &#9658; </button>
-            <button id="snippet-btn" class="secondary-btn mr-1">import code</button>
+            <button id="snippet-btn" class="btn-secondary mr-1">import code</button>
         </div>
-        <div class="header">RustPython 🐍 😱 🤘</div>
-        <div><a href="https://github.com/RustPython/">github</a></div>
+        <div class="header item-center">RustPython 🐍 😱 🤘</div>
+        <div class="text-right"><a href="https://github.com/RustPython/">github</a></div>
     </div>
 
     <!-- user interface elements for importing code -->
-    <div id="url-container" class="d-none">
-        <div><label for="url">public url: (uses github api file url for now)</label></div>
+    <div id="url-container" class="d-none p-1 bg-light">
+        <div><label for="url">public url:</label></div>
         <div>
             <input type="url" name="url" id="snippet-url">
-        </div>
-        <div>
-            <button id="fetch-code" class="secondary-btn">fetch</button>
+            <button id="fetch-code" class="btn-secondary">fetch</button>
         </div>
     </div>
 
@@ -39,12 +37,12 @@
 
     <!-- errors and keyboard shortcuts -->
     <div class="split-view">
-        <div>
-            <mark>errors</mark>
+        <div class="mt-1">
+            <div class="header">Error(s):</div>
             <div id="error"></div>
         </div>
-        <div class="text-small mt-1">
-            <mark>Keyboard Shortcuts:</mark>
+        <div class="mt-1">
+            <div class="header">Keyboard Shortcuts:</div>
             <div>
                 <div>Run code: 'Ctrl-Enter' or 'Cmd-Enter'</div>
                 <div>Decrease Indent: 'Shift-Tab' </div>

--- a/wasm/notebook/src/index.js
+++ b/wasm/notebook/src/index.js
@@ -67,7 +67,6 @@ function runCodeFromTextarea() {
 }
 
 function onReady() {
-    // snippets.addEventListener('change', updateSnippet);
     document
         .getElementById('run-btn')
         .addEventListener('click', runCodeFromTextarea);
@@ -78,33 +77,30 @@ function onReady() {
     document.head.appendChild(readyElement);
 }
 
-// when clicking the import code button
-// show a UI with a url input + fetch button
-// only accepts api.github.com urls (for now)
-// add another function to parse a regular url
+// import button
+// show a url input + fetch button
+// takes a url where there is raw code
 fetchbtnElement.addEventListener("click", function () {
-    // https://developer.github.com/v3/repos/contents/#get-repository-content
-    // Format:
-    // https://api.github.com/repos/username/reponame/contents/filename.py
     let url = document
         .getElementById('snippet-url')
         .value;
     // minimal js fetch code
     // needs better error handling
     fetch(url)
-        .then(res => res.json())
-        .then(data => {
-            // The Python code is in data.content
-            // it is encoded with Base64. Use atob to decode it.
-            //https://developer.mozilla.org/en-US/docs/Web/API/WindowOrWorkerGlobalScope/atob
-            var decodedData = atob(data.content);
+        .then( response => {
+            if (!response.ok) { throw response }
+            return response.text() 
+        })
+        .then(text => {
             // set the value of the code editor
-            editor.setValue(decodedData);
+            editor.setValue(text);
+            // hide the ui
             urlConainerElement.classList.add("d-none");
         }).catch(err => {
+            // show the error as is for troubleshooting.
             document
-                .getElementById("errors")
-                .innerHTML = "Couldn't fetch code. Make sure the link is public."
+                .getElementById("error")
+                .innerHTML = err
         });
 
 });

--- a/wasm/notebook/src/index.js
+++ b/wasm/notebook/src/index.js
@@ -1,0 +1,114 @@
+import './style.css';
+import CodeMirror from 'codemirror';
+import 'codemirror/mode/python/python';
+import 'codemirror/addon/comment/comment';
+import 'codemirror/lib/codemirror.css';
+
+let rp;
+
+// UI elements
+const consoleElement = document.getElementById('console');
+const errorElement = document.getElementById('error');
+const fetchbtnElement = document.getElementById("fetch-code");
+const urlConainerElement = document.getElementById('url-container');
+
+// A dependency graph that contains any wasm must be imported asynchronously.
+import('rustpython')
+    .then(rustpy => {
+        rp = rustpy;
+        // so people can play around with it
+        window.rp = rustpy;
+        onReady();
+    })
+    .catch(e => {
+        console.error('Error importing `rustpython`:', e);
+        document.getElementById('error').textContent = e;
+    });
+
+// Code Mirror code editor 
+const editor = CodeMirror.fromTextArea(document.getElementById('code'), {
+    extraKeys: {
+        'Ctrl-Enter': runCodeFromTextarea,
+        'Cmd-Enter': runCodeFromTextarea,
+        'Shift-Tab': 'indentLess',
+        'Ctrl-/': 'toggleComment',
+        'Cmd-/': 'toggleComment',
+        Tab: editor => {
+            var spaces = Array(editor.getOption('indentUnit') + 1).join(' ');
+            editor.replaceSelection(spaces);
+        }
+    },
+    lineNumbers: true,
+    mode: 'text/x-python',
+    indentUnit: 4,
+    autofocus: true
+});
+
+// Runs the code the the code editor
+function runCodeFromTextarea() {
+    // Clean the console and errors
+    consoleElement.innerHTML = '';
+    errorElement.textContent = '';
+
+    const code = editor.getValue();
+    try {
+        rp.pyExec(code, {
+            stdout: output => {
+                consoleElement.innerHTML += output;
+            }
+        });
+    } catch (err) {
+        if (err instanceof WebAssembly.RuntimeError) {
+            err = window.__RUSTPYTHON_ERROR || err;
+        }
+        errorElement.textContent = err;
+        console.error(err);
+    }
+}
+
+function onReady() {
+    // snippets.addEventListener('change', updateSnippet);
+    document
+        .getElementById('run-btn')
+        .addEventListener('click', runCodeFromTextarea);
+
+    // so that the test knows that we're ready
+    const readyElement = document.createElement('div');
+    readyElement.id = 'rp_loaded';
+    document.head.appendChild(readyElement);
+}
+
+// when clicking the import code button
+// show a UI with a url input + fetch button
+// only accepts api.github.com urls (for now)
+// add another function to parse a regular url
+fetchbtnElement.addEventListener("click", function () {
+    // https://developer.github.com/v3/repos/contents/#get-repository-content
+    // Format:
+    // https://api.github.com/repos/username/reponame/contents/filename.py
+    let url = document
+        .getElementById('snippet-url')
+        .value;
+    // minimal js fetch code
+    // needs better error handling
+    fetch(url)
+        .then(res => res.json())
+        .then(data => {
+            // The Python code is in data.content
+            // it is encoded with Base64. Use atob to decode it.
+            //https://developer.mozilla.org/en-US/docs/Web/API/WindowOrWorkerGlobalScope/atob
+            var decodedData = atob(data.content);
+            // set the value of the code editor
+            editor.setValue(decodedData);
+            urlConainerElement.classList.add("d-none");
+        }).catch(err => {
+            document
+                .getElementById("errors")
+                .innerHTML = "Couldn't fetch code. Make sure the link is public."
+        });
+
+});
+
+document.getElementById("snippet-btn").addEventListener("click", function () {
+    urlConainerElement.classList.remove("d-none");
+});

--- a/wasm/notebook/src/style.css
+++ b/wasm/notebook/src/style.css
@@ -1,0 +1,110 @@
+.header {
+    font-family: 'Sen', sans-serif;
+    ;
+}
+
+.d-flex {
+    display: flex;
+}
+
+.d-none {
+    display: none;
+}
+
+.mr-1 {
+    margin-right: 1rem;
+}
+
+.mt-1 {
+    margin-top: 1rem;
+}
+
+.text-small {
+    font-size: 0.75rem;
+}
+
+mark {
+    background-color: #000;
+    color: #fff;
+    font-size: 0.75rem;
+}
+
+.nav-bar {
+    border-bottom: 2px solid #F74C00;
+    display: flex;
+    justify-content: space-between;
+    position: sticky;
+    top: 0px;
+    background-color: #fff;
+    height: 20px;
+    z-index: 99;
+}
+
+.split-view {
+    display: flex;
+    justify-content: space-between;
+}
+
+.split-view div {
+    flex-basis: 50%;
+}
+
+.full-height {
+    height: calc(90vh - 60px);
+}
+
+#console {
+    padding: 1rem;
+}
+
+.CodeMirror {
+    height: 90% !important;
+    border-right: 1px solid gray;
+}
+
+#run-btn,
+.secondary-btn {
+    border: 0px;
+    color: white;
+    cursor: pointer;
+}
+
+#run-btn {
+    background-color: #F74C00;
+}
+
+input[type="url"] {
+    border: 1px solid black;
+    border-radius: 0px;
+    width: 55%;
+    margin: 5px 0px 5px 0px;
+    font-size: 0.7rem;
+    padding: 4px;
+    font-family: monospace;
+}
+
+.url-container {
+    padding: 10px;
+    background-color: white;
+    font-size: smaller;
+}
+
+.secondary-btn {
+    background-color: #000;
+}
+
+.secondary-btn.active,
+.secondary-btn:hover {
+    background-color: #F74C00;
+}
+
+#error {
+    color: tomato;
+    margin-top: 10px;
+    font-family: monospace;
+    white-space: pre;
+}
+
+#code-wrapper {
+    position: relative;
+}

--- a/wasm/notebook/src/style.css
+++ b/wasm/notebook/src/style.css
@@ -1,6 +1,9 @@
+body {
+    font-family: 'Fira Sans', sans-serif;
+}
+
 .header {
-    font-family: 'Sen', sans-serif;
-    ;
+    font-family: 'Sen', sans-serif;;
 }
 
 .d-flex {
@@ -19,25 +22,39 @@
     margin-top: 1rem;
 }
 
-.text-small {
-    font-size: 0.75rem;
+.p-1 {
+    padding: 1rem;
+}
+
+.bg-light {
+    background-color: #f7f7f9;
 }
 
 mark {
     background-color: #000;
     color: #fff;
-    font-size: 0.75rem;
 }
 
 .nav-bar {
     border-bottom: 2px solid #F74C00;
     display: flex;
-    justify-content: space-between;
     position: sticky;
     top: 0px;
     background-color: #fff;
-    height: 20px;
     z-index: 99;
+}
+
+.nav-bar div {
+    width: 300px;
+}
+
+.item-center { 
+    flex-grow: 1;
+    text-align: center;
+}
+
+.text-right {
+    text-align: right;
 }
 
 .split-view {
@@ -55,18 +72,23 @@ mark {
 
 #console {
     padding: 1rem;
+    font-family: monospace;
+    font-size: 1.1rem;
 }
 
 .CodeMirror {
-    height: 90% !important;
-    border-right: 1px solid gray;
+    height: 100% !important;
+    border-right: 4px solid #f7f7f9;
 }
 
 #run-btn,
-.secondary-btn {
+.btn-secondary {
     border: 0px;
     color: white;
     cursor: pointer;
+    font-size: 1rem;
+    height: 25px;
+    vertical-align: middle;
 }
 
 #run-btn {
@@ -78,7 +100,7 @@ input[type="url"] {
     border-radius: 0px;
     width: 55%;
     margin: 5px 0px 5px 0px;
-    font-size: 0.7rem;
+    font-size: 0.9rem;
     padding: 4px;
     font-family: monospace;
 }
@@ -86,16 +108,10 @@ input[type="url"] {
 .url-container {
     padding: 10px;
     background-color: white;
-    font-size: smaller;
 }
 
-.secondary-btn {
+.btn-secondary{
     background-color: #000;
-}
-
-.secondary-btn.active,
-.secondary-btn:hover {
-    background-color: #F74C00;
 }
 
 #error {

--- a/wasm/notebook/webpack.config.js
+++ b/wasm/notebook/webpack.config.js
@@ -1,0 +1,72 @@
+const HtmlWebpackPlugin = require('html-webpack-plugin');
+const MiniCssExtractPlugin = require('mini-css-extract-plugin');
+const WasmPackPlugin = require('@wasm-tool/wasm-pack-plugin');
+const { CleanWebpackPlugin } = require('clean-webpack-plugin');
+
+const path = require('path');
+const fs = require('fs');
+
+const interval = setInterval(() => console.log('keepalive'), 1000 * 60 * 5);
+
+module.exports = (env = {}) => {
+    const config = {
+        entry: './src/index.js',
+        output: {
+            path: path.join(__dirname, 'dist'),
+            filename: 'index.js'
+        },
+        mode: 'development',
+        resolve: {
+            alias: {
+                rustpython: path.resolve(
+                    __dirname,
+                    env.rustpythonPkg || '../lib/pkg'
+                )
+            }
+        },
+        module: {
+            rules: [
+                {
+                    test: /\.css$/,
+                    use: [MiniCssExtractPlugin.loader, 'css-loader']
+                }
+            ]
+        },
+        plugins: [
+            new CleanWebpackPlugin(),
+            new HtmlWebpackPlugin({
+                filename: 'index.html',
+                template: 'src/index.ejs',
+                templateParameters: {
+                    snippets: fs
+                        .readdirSync(path.join(__dirname, 'snippets'))
+                        .map(filename =>
+                            path.basename(filename, path.extname(filename))
+                        ),
+                    defaultSnippetName: 'fibonacci',
+                    defaultSnippet: fs.readFileSync(
+                        path.join(__dirname, 'snippets/fibonacci.py')
+                    )
+                }
+            }),
+            new MiniCssExtractPlugin({
+                filename: 'styles.css'
+            }),
+            {
+                apply(compiler) {
+                    compiler.hooks.done.tap('clearInterval', () => {
+                        clearInterval(interval);
+                    });
+                }
+            }
+        ]
+    };
+    if (!env.noWasmPack) {
+        config.plugins.push(
+            new WasmPackPlugin({
+                crateDirectory: path.join(__dirname, '../lib')
+            })
+        );
+    }
+    return config;
+};

--- a/wasm/notebook/webpack.config.js
+++ b/wasm/notebook/webpack.config.js
@@ -37,17 +37,17 @@ module.exports = (env = {}) => {
             new HtmlWebpackPlugin({
                 filename: 'index.html',
                 template: 'src/index.ejs',
-                templateParameters: {
-                    snippets: fs
-                        .readdirSync(path.join(__dirname, 'snippets'))
-                        .map(filename =>
-                            path.basename(filename, path.extname(filename))
-                        ),
-                    defaultSnippetName: 'fibonacci',
-                    defaultSnippet: fs.readFileSync(
-                        path.join(__dirname, 'snippets/fibonacci.py')
-                    )
-                }
+                // templateParameters: {
+                    // snippets: fs
+                    //     .readdirSync(path.join(__dirname, 'snippets'))
+                    //     .map(filename =>
+                    //         path.basename(filename, path.extname(filename))
+                    //     ),
+                    // defaultSnippetName: 'fibonacci',
+                    // defaultSnippet: fs.readFileSync(
+                    //     path.join(__dirname, 'snippets/fibonacci.py')
+                    // )
+                // }
             }),
             new MiniCssExtractPlugin({
                 filename: 'styles.css'


### PR DESCRIPTION
This PR is for a new example under the `wasm` directory. Inspired by iodide, a Mozilla Project https://alpha.iodide.io/ (now abandoned).

This example re-uses the code from `wasm/demo` and adds a basic import code functionality from `api.github.com`

Here is how it looks like:
![Screenshot from 2020-09-14 21-51-25](https://user-images.githubusercontent.com/521705/93155827-f0b33f00-f6d4-11ea-9629-7fedabc93bd6.png)

Here is how the import works:
![Screenshot from 2020-09-14 21-53-25](https://user-images.githubusercontent.com/521705/93156058-599ab700-f6d5-11ea-8c68-3cbcc61fed11.png)

Here are the url for test imports (can be anything public as long as it uses the github api url):
https://api.github.com/repos/RustPython/RustPython/contents/wasm/demo/snippets/asyncbrowser.py
https://api.github.com/repos/RustPython/RustPython/contents/wasm/demo/snippets/fetch.py

Here is how the notebook looks like after fetching
![Screenshot from 2020-09-14 21-53-42](https://user-images.githubusercontent.com/521705/93156300-db8ae000-f6d5-11ea-8fcd-fb6c334ab227.png)

Then code execution 
![Screenshot from 2020-09-14 22-13-27](https://user-images.githubusercontent.com/521705/93157122-99629e00-f6d7-11ea-9410-d1710aba932a.png)


Changes:
- Removed xterm
- Changed the output from a text area to an HTML element (so later on, I can toy with adding markdown, graphs or interactive elements). If you print an html tag for example, it renders ;p 
- For faster load time, I disable the default snippet imports and execution
- Added the ability to import public python code from GitHub.
- Removed things in the UI

Submitting a PR and looking for feedback on:
- code
- UI tweaks
- features like should this only import from api.github.com or add others?
- Instead of this, should I try to do a notebook that looks like a Jupyter Lab Notebook instead?