### PR TITLE
PyClass -> PyType

### DIFF
--- a/derive/src/pyclass.rs
+++ b/derive/src/pyclass.rs
@@ -73,7 +73,7 @@ pub(crate) fn impl_pyimpl(
 
                     fn impl_extend_class(
                         ctx: &::rustpython_vm::pyobject::PyContext,
-                        class: &::rustpython_vm::obj::objtype::PyClassRef,
+                        class: &::rustpython_vm::obj::objtype::PyTypeRef,
                     ) {
                         #getset_impl
                         #extend_impl
@@ -81,7 +81,7 @@ pub(crate) fn impl_pyimpl(
                         #(#class_extensions)*
                     }
 
-                    fn extend_slots(slots: &mut ::rustpython_vm::slots::PyClassSlots) {
+                    fn extend_slots(slots: &mut ::rustpython_vm::slots::PyTypeSlots) {
                         #with_slots
                         #slots_impl
                     }
@@ -100,7 +100,7 @@ pub(crate) fn impl_pyimpl(
                 parse_quote! {
                     fn __extend_py_class(
                         ctx: &::rustpython_vm::pyobject::PyContext,
-                        class: &::rustpython_vm::obj::objtype::PyClassRef,
+                        class: &::rustpython_vm::obj::objtype::PyTypeRef,
                     ) {
                         #getset_impl
                         #extend_impl
@@ -108,7 +108,7 @@ pub(crate) fn impl_pyimpl(
                     }
                 },
                 parse_quote! {
-                    fn __extend_slots(slots: &mut ::rustpython_vm::slots::PyClassSlots) {
+                    fn __extend_slots(slots: &mut ::rustpython_vm::slots::PyTypeSlots) {
                         #slots_impl
                     }
                 },
@@ -162,7 +162,7 @@ fn generate_class_def(
 
     let base_class = if is_pystruct {
         quote! {
-            fn base_class(ctx: &::rustpython_vm::pyobject::PyContext) -> ::rustpython_vm::obj::objtype::PyClassRef {
+            fn base_class(ctx: &::rustpython_vm::pyobject::PyContext) -> ::rustpython_vm::obj::objtype::PyTypeRef {
                 ctx.types.tuple_type.clone()
             }
         }

--- a/vm/src/builtins.rs
+++ b/vm/src/builtins.rs
@@ -30,7 +30,7 @@ mod decl {
     use crate::obj::objlist::{PyList, SortOptions};
     use crate::obj::objsequence;
     use crate::obj::objstr::{PyStr, PyStrRef};
-    use crate::obj::objtype::{self, PyClassRef};
+    use crate::obj::objtype::{self, PyTypeRef};
     use crate::pyobject::{
         BorrowValue, Either, IdProtocol, ItemProtocol, PyCallable, PyIterable, PyObjectRef,
         PyResult, PyValue, TryFromObject, TypeProtocol,
@@ -400,7 +400,7 @@ mod decl {
     pub fn isinstance(obj: PyObjectRef, typ: PyObjectRef, vm: &VirtualMachine) -> PyResult<bool> {
         single_or_tuple_any(
             typ,
-            &|cls: &PyClassRef| vm.isinstance(&obj, cls),
+            &|cls: &PyTypeRef| vm.isinstance(&obj, cls),
             &|o| {
                 format!(
                     "isinstance() arg 2 must be a type or tuple of types, not {}",
@@ -412,10 +412,10 @@ mod decl {
     }
 
     #[pyfunction]
-    fn issubclass(subclass: PyClassRef, typ: PyObjectRef, vm: &VirtualMachine) -> PyResult<bool> {
+    fn issubclass(subclass: PyTypeRef, typ: PyObjectRef, vm: &VirtualMachine) -> PyResult<bool> {
         single_or_tuple_any(
             typ,
-            &|cls: &PyClassRef| vm.issubclass(&subclass, cls),
+            &|cls: &PyTypeRef| vm.issubclass(&subclass, cls),
             &|o| {
                 format!(
                     "issubclass() arg 2 must be a class or tuple of classes, not {}",
@@ -803,7 +803,7 @@ mod decl {
     pub fn __build_class__(
         function: PyFunctionRef,
         qualified_name: PyStrRef,
-        bases: Args<PyClassRef>,
+        bases: Args<PyTypeRef>,
         mut kwargs: KwArgs,
         vm: &VirtualMachine,
     ) -> PyResult {
@@ -815,7 +815,7 @@ mod decl {
         let name_obj = vm.ctx.new_str(name);
 
         let mut metaclass = if let Some(metaclass) = kwargs.pop_kwarg("metaclass") {
-            PyClassRef::try_from_object(vm, metaclass)?
+            PyTypeRef::try_from_object(vm, metaclass)?
         } else {
             vm.ctx.types.type_type.clone()
         };

--- a/vm/src/exceptions.rs
+++ b/vm/src/exceptions.rs
@@ -4,7 +4,7 @@ use crate::obj::objsingletons::{PyNone, PyNoneRef};
 use crate::obj::objstr::{PyStr, PyStrRef};
 use crate::obj::objtraceback::PyTracebackRef;
 use crate::obj::objtuple::{PyTuple, PyTupleRef};
-use crate::obj::objtype::{self, PyClass, PyClassRef};
+use crate::obj::objtype::{self, PyType, PyTypeRef};
 use crate::py_io::{self, Write};
 use crate::pyobject::{
     BorrowValue, IntoPyObject, PyClassDef, PyClassImpl, PyContext, PyIterable, PyObjectRef, PyRef,
@@ -44,7 +44,7 @@ pub trait IntoPyException {
 }
 
 impl PyValue for PyBaseException {
-    fn class(vm: &VirtualMachine) -> PyClassRef {
+    fn class(vm: &VirtualMachine) -> PyTypeRef {
         vm.ctx.exceptions.base_exception_type.clone()
     }
 }
@@ -62,7 +62,7 @@ impl PyBaseException {
     }
 
     #[pyslot]
-    fn tp_new(cls: PyClassRef, args: PyFuncArgs, vm: &VirtualMachine) -> PyResult<PyRef<Self>> {
+    fn tp_new(cls: PyTypeRef, args: PyFuncArgs, vm: &VirtualMachine) -> PyResult<PyRef<Self>> {
         PyBaseException::new(args.args, vm).into_ref_with_type(vm, cls)
     }
 
@@ -295,13 +295,13 @@ fn exception_args_as_string(
 
 #[derive(Clone)]
 pub enum ExceptionCtor {
-    Class(PyClassRef),
+    Class(PyTypeRef),
     Instance(PyBaseExceptionRef),
 }
 
 impl TryFromObject for ExceptionCtor {
     fn try_from_object(vm: &VirtualMachine, obj: PyObjectRef) -> PyResult<Self> {
-        obj.downcast::<PyClass>()
+        obj.downcast::<PyType>()
             .and_then(|cls| {
                 if objtype::issubclass(&cls, &vm.ctx.exceptions.base_exception_type) {
                     Ok(Self::Class(cls))
@@ -320,7 +320,7 @@ impl TryFromObject for ExceptionCtor {
 }
 
 pub fn invoke(
-    cls: PyClassRef,
+    cls: PyTypeRef,
     args: Vec<PyObjectRef>,
     vm: &VirtualMachine,
 ) -> PyResult<PyBaseExceptionRef> {
@@ -392,80 +392,80 @@ pub fn normalize(
 
 #[derive(Debug)]
 pub struct ExceptionZoo {
-    pub base_exception_type: PyClassRef,
-    pub system_exit: PyClassRef,
-    pub keyboard_interrupt: PyClassRef,
-    pub generator_exit: PyClassRef,
-    pub exception_type: PyClassRef,
-    pub stop_iteration: PyClassRef,
-    pub stop_async_iteration: PyClassRef,
-    pub arithmetic_error: PyClassRef,
-    pub floating_point_error: PyClassRef,
-    pub overflow_error: PyClassRef,
-    pub zero_division_error: PyClassRef,
-    pub assertion_error: PyClassRef,
-    pub attribute_error: PyClassRef,
-    pub buffer_error: PyClassRef,
-    pub eof_error: PyClassRef,
-    pub import_error: PyClassRef,
-    pub module_not_found_error: PyClassRef,
-    pub lookup_error: PyClassRef,
-    pub index_error: PyClassRef,
-    pub key_error: PyClassRef,
-    pub memory_error: PyClassRef,
-    pub name_error: PyClassRef,
-    pub unbound_local_error: PyClassRef,
-    pub os_error: PyClassRef,
-    pub blocking_io_error: PyClassRef,
-    pub child_process_error: PyClassRef,
-    pub connection_error: PyClassRef,
-    pub broken_pipe_error: PyClassRef,
-    pub connection_aborted_error: PyClassRef,
-    pub connection_refused_error: PyClassRef,
-    pub connection_reset_error: PyClassRef,
-    pub file_exists_error: PyClassRef,
-    pub file_not_found_error: PyClassRef,
-    pub interrupted_error: PyClassRef,
-    pub is_a_directory_error: PyClassRef,
-    pub not_a_directory_error: PyClassRef,
-    pub permission_error: PyClassRef,
-    pub process_lookup_error: PyClassRef,
-    pub timeout_error: PyClassRef,
-    pub reference_error: PyClassRef,
-    pub runtime_error: PyClassRef,
-    pub not_implemented_error: PyClassRef,
-    pub recursion_error: PyClassRef,
-    pub syntax_error: PyClassRef,
-    pub target_scope_error: PyClassRef,
-    pub indentation_error: PyClassRef,
-    pub tab_error: PyClassRef,
-    pub system_error: PyClassRef,
-    pub type_error: PyClassRef,
-    pub value_error: PyClassRef,
-    pub unicode_error: PyClassRef,
-    pub unicode_decode_error: PyClassRef,
-    pub unicode_encode_error: PyClassRef,
-    pub unicode_translate_error: PyClassRef,
+    pub base_exception_type: PyTypeRef,
+    pub system_exit: PyTypeRef,
+    pub keyboard_interrupt: PyTypeRef,
+    pub generator_exit: PyTypeRef,
+    pub exception_type: PyTypeRef,
+    pub stop_iteration: PyTypeRef,
+    pub stop_async_iteration: PyTypeRef,
+    pub arithmetic_error: PyTypeRef,
+    pub floating_point_error: PyTypeRef,
+    pub overflow_error: PyTypeRef,
+    pub zero_division_error: PyTypeRef,
+    pub assertion_error: PyTypeRef,
+    pub attribute_error: PyTypeRef,
+    pub buffer_error: PyTypeRef,
+    pub eof_error: PyTypeRef,
+    pub import_error: PyTypeRef,
+    pub module_not_found_error: PyTypeRef,
+    pub lookup_error: PyTypeRef,
+    pub index_error: PyTypeRef,
+    pub key_error: PyTypeRef,
+    pub memory_error: PyTypeRef,
+    pub name_error: PyTypeRef,
+    pub unbound_local_error: PyTypeRef,
+    pub os_error: PyTypeRef,
+    pub blocking_io_error: PyTypeRef,
+    pub child_process_error: PyTypeRef,
+    pub connection_error: PyTypeRef,
+    pub broken_pipe_error: PyTypeRef,
+    pub connection_aborted_error: PyTypeRef,
+    pub connection_refused_error: PyTypeRef,
+    pub connection_reset_error: PyTypeRef,
+    pub file_exists_error: PyTypeRef,
+    pub file_not_found_error: PyTypeRef,
+    pub interrupted_error: PyTypeRef,
+    pub is_a_directory_error: PyTypeRef,
+    pub not_a_directory_error: PyTypeRef,
+    pub permission_error: PyTypeRef,
+    pub process_lookup_error: PyTypeRef,
+    pub timeout_error: PyTypeRef,
+    pub reference_error: PyTypeRef,
+    pub runtime_error: PyTypeRef,
+    pub not_implemented_error: PyTypeRef,
+    pub recursion_error: PyTypeRef,
+    pub syntax_error: PyTypeRef,
+    pub target_scope_error: PyTypeRef,
+    pub indentation_error: PyTypeRef,
+    pub tab_error: PyTypeRef,
+    pub system_error: PyTypeRef,
+    pub type_error: PyTypeRef,
+    pub value_error: PyTypeRef,
+    pub unicode_error: PyTypeRef,
+    pub unicode_decode_error: PyTypeRef,
+    pub unicode_encode_error: PyTypeRef,
+    pub unicode_translate_error: PyTypeRef,
 
     #[cfg(feature = "jit")]
-    pub jit_error: PyClassRef,
+    pub jit_error: PyTypeRef,
 
-    pub warning: PyClassRef,
-    pub deprecation_warning: PyClassRef,
-    pub pending_deprecation_warning: PyClassRef,
-    pub runtime_warning: PyClassRef,
-    pub syntax_warning: PyClassRef,
-    pub user_warning: PyClassRef,
-    pub future_warning: PyClassRef,
-    pub import_warning: PyClassRef,
-    pub unicode_warning: PyClassRef,
-    pub bytes_warning: PyClassRef,
-    pub resource_warning: PyClassRef,
+    pub warning: PyTypeRef,
+    pub deprecation_warning: PyTypeRef,
+    pub pending_deprecation_warning: PyTypeRef,
+    pub runtime_warning: PyTypeRef,
+    pub syntax_warning: PyTypeRef,
+    pub user_warning: PyTypeRef,
+    pub future_warning: PyTypeRef,
+    pub import_warning: PyTypeRef,
+    pub unicode_warning: PyTypeRef,
+    pub bytes_warning: PyTypeRef,
+    pub resource_warning: PyTypeRef,
 }
 
 impl ExceptionZoo {
-    pub fn new(type_type: &PyClassRef, object_type: &PyClassRef) -> Self {
-        let create_exception_type = |name: &str, base: &PyClassRef| {
+    pub fn new(type_type: &PyTypeRef, object_type: &PyTypeRef) -> Self {
+        let create_exception_type = |name: &str, base: &PyTypeRef| {
             create_type_with_slots(name, type_type, base.clone(), PyBaseException::make_slots())
         };
         // Sorted By Hierarchy then alphabetized.

--- a/vm/src/frame.rs
+++ b/vm/src/frame.rs
@@ -22,7 +22,7 @@ use crate::obj::objslice::PySlice;
 use crate::obj::objstr::{self, PyStr, PyStrRef};
 use crate::obj::objtraceback::PyTraceback;
 use crate::obj::objtuple::PyTuple;
-use crate::obj::objtype::{self, PyClassRef};
+use crate::obj::objtype::{self, PyTypeRef};
 use crate::pyobject::{
     BorrowValue, IdProtocol, ItemProtocol, PyObjectRef, PyRef, PyResult, PyValue, TryFromObject,
     TypeProtocol,
@@ -100,7 +100,7 @@ pub struct Frame {
 }
 
 impl PyValue for Frame {
-    fn class(vm: &VirtualMachine) -> PyClassRef {
+    fn class(vm: &VirtualMachine) -> PyTypeRef {
         vm.ctx.types.frame_type.clone()
     }
 }

--- a/vm/src/function.rs
+++ b/vm/src/function.rs
@@ -8,7 +8,7 @@ use result_like::impl_option_like;
 
 use crate::exceptions::PyBaseExceptionRef;
 use crate::obj::objtuple::PyTupleRef;
-use crate::obj::objtype::{isinstance, PyClassRef};
+use crate::obj::objtype::{isinstance, PyTypeRef};
 use crate::pyobject::{
     BorrowValue, IntoPyResult, PyObjectRef, PyRef, PyResult, PyThreadingConstraint, PyValue,
     TryFromObject, TypeProtocol,
@@ -121,7 +121,7 @@ impl PyFuncArgs {
     pub fn get_optional_kwarg_with_type(
         &self,
         key: &str,
-        ty: PyClassRef,
+        ty: PyTypeRef,
         vm: &VirtualMachine,
     ) -> PyResult<Option<PyObjectRef>> {
         match self.get_optional_kwarg(key) {

--- a/vm/src/macros.rs
+++ b/vm/src/macros.rs
@@ -39,7 +39,7 @@ macro_rules! py_class {
     ( $ctx:expr, $class_name:expr, $class_base:expr, $flags:expr, { $($name:tt => $value:expr),* $(,)* }) => {
         {
             #[allow(unused_mut)]
-            let mut slots = $crate::slots::PyClassSlots::from_flags($crate::slots::PyTpFlags::DEFAULT | $flags);
+            let mut slots = $crate::slots::PyTypeSlots::from_flags($crate::slots::PyTpFlags::DEFAULT | $flags);
             $($crate::py_class!(@extract_slots($ctx, &mut slots, $name, $value));)*
             let py_class = $ctx.new_class($class_name, $class_base.clone(), slots);
             $($crate::py_class!(@extract_attrs($ctx, &py_class, $name, $value));)*

--- a/vm/src/obj/objasyncgenerator.rs
+++ b/vm/src/obj/objasyncgenerator.rs
@@ -1,6 +1,6 @@
 use super::objcode::PyCodeRef;
 use super::objcoroinner::{Coro, Variant};
-use super::objtype::{self, PyClassRef};
+use super::objtype::{self, PyTypeRef};
 use crate::exceptions::PyBaseExceptionRef;
 use crate::frame::FrameRef;
 use crate::function::OptionalArg;
@@ -18,7 +18,7 @@ pub struct PyAsyncGen {
 pub type PyAsyncGenRef = PyRef<PyAsyncGen>;
 
 impl PyValue for PyAsyncGen {
-    fn class(vm: &VirtualMachine) -> PyClassRef {
+    fn class(vm: &VirtualMachine) -> PyTypeRef {
         vm.ctx.types.async_generator.clone()
     }
 }
@@ -116,7 +116,7 @@ impl PyAsyncGen {
 #[derive(Debug)]
 pub(crate) struct PyAsyncGenWrappedValue(pub PyObjectRef);
 impl PyValue for PyAsyncGenWrappedValue {
-    fn class(vm: &VirtualMachine) -> PyClassRef {
+    fn class(vm: &VirtualMachine) -> PyTypeRef {
         vm.ctx.types.async_generator_wrapped_value.clone()
     }
 }
@@ -165,7 +165,7 @@ pub(crate) struct PyAsyncGenASend {
 }
 
 impl PyValue for PyAsyncGenASend {
-    fn class(vm: &VirtualMachine) -> PyClassRef {
+    fn class(vm: &VirtualMachine) -> PyTypeRef {
         vm.ctx.types.async_generator_asend.clone()
     }
 }
@@ -261,7 +261,7 @@ pub(crate) struct PyAsyncGenAThrow {
 }
 
 impl PyValue for PyAsyncGenAThrow {
-    fn class(vm: &VirtualMachine) -> PyClassRef {
+    fn class(vm: &VirtualMachine) -> PyTypeRef {
         vm.ctx.types.async_generator_athrow.clone()
     }
 }

--- a/vm/src/obj/objbuiltinfunc.rs
+++ b/vm/src/obj/objbuiltinfunc.rs
@@ -3,7 +3,7 @@ use std::fmt;
 use super::objclassmethod::PyClassMethod;
 use crate::function::{PyFuncArgs, PyNativeFunc};
 use crate::obj::objstr::PyStrRef;
-use crate::obj::objtype::PyClassRef;
+use crate::obj::objtype::PyTypeRef;
 use crate::pyobject::{
     PyClassImpl, PyContext, PyObject, PyObjectRef, PyRef, PyResult, PyValue, TypeProtocol,
 };
@@ -62,7 +62,7 @@ pub struct PyBuiltinFunction {
 }
 
 impl PyValue for PyBuiltinFunction {
-    fn class(vm: &VirtualMachine) -> PyClassRef {
+    fn class(vm: &VirtualMachine) -> PyTypeRef {
         vm.ctx.types.builtin_function_or_method_type.clone()
     }
 }
@@ -134,7 +134,7 @@ pub struct PyBuiltinMethod {
 }
 
 impl PyValue for PyBuiltinMethod {
-    fn class(vm: &VirtualMachine) -> PyClassRef {
+    fn class(vm: &VirtualMachine) -> PyTypeRef {
         vm.ctx.types.method_descriptor_type.clone()
     }
 }

--- a/vm/src/obj/objbytearray.rs
+++ b/vm/src/obj/objbytearray.rs
@@ -7,7 +7,7 @@ use super::objint::PyIntRef;
 use super::objiter;
 use super::objsequence::SequenceIndex;
 use super::objstr::PyStrRef;
-use super::objtype::PyClassRef;
+use super::objtype::PyTypeRef;
 use crate::anystr::{self, AnyStr};
 use crate::bytesinner::{
     bytes_decode, ByteInnerFindOptions, ByteInnerNewOptions, ByteInnerPaddingOptions,
@@ -79,7 +79,7 @@ impl From<Vec<u8>> for PyByteArray {
 }
 
 impl PyValue for PyByteArray {
-    fn class(vm: &VirtualMachine) -> PyClassRef {
+    fn class(vm: &VirtualMachine) -> PyTypeRef {
         vm.ctx.types.bytearray_type.clone()
     }
 }
@@ -99,7 +99,7 @@ pub(crate) fn init(context: &PyContext) {
 impl PyByteArray {
     #[pyslot]
     fn tp_new(
-        cls: PyClassRef,
+        cls: PyTypeRef,
         options: ByteInnerNewOptions,
         vm: &VirtualMachine,
     ) -> PyResult<PyByteArrayRef> {
@@ -533,16 +533,12 @@ impl PyByteArray {
     }
 
     #[pymethod(magic)]
-    fn reduce_ex(
-        zelf: PyRef<Self>,
-        _proto: usize,
-        vm: &VirtualMachine,
-    ) -> (PyClassRef, PyTupleRef) {
+    fn reduce_ex(zelf: PyRef<Self>, _proto: usize, vm: &VirtualMachine) -> (PyTypeRef, PyTupleRef) {
         Self::reduce(zelf, vm)
     }
 
     #[pymethod(magic)]
-    fn reduce(zelf: PyRef<Self>, vm: &VirtualMachine) -> (PyClassRef, PyTupleRef) {
+    fn reduce(zelf: PyRef<Self>, vm: &VirtualMachine) -> (PyTypeRef, PyTupleRef) {
         let bytes = PyBytes::from(zelf.borrow_value().elements.clone()).into_pyobject(vm);
         (
             Self::class(vm),
@@ -580,7 +576,7 @@ pub struct PyByteArrayIterator {
 }
 
 impl PyValue for PyByteArrayIterator {
-    fn class(vm: &VirtualMachine) -> PyClassRef {
+    fn class(vm: &VirtualMachine) -> PyTypeRef {
         vm.ctx.types.bytearray_iterator_type.clone()
     }
 }

--- a/vm/src/obj/objbytes.rs
+++ b/vm/src/obj/objbytes.rs
@@ -7,7 +7,7 @@ use super::objint::PyIntRef;
 use super::objiter;
 use super::objsequence::SequenceIndex;
 use super::objstr::PyStrRef;
-use super::objtype::PyClassRef;
+use super::objtype::PyTypeRef;
 use crate::anystr::{self, AnyStr};
 use crate::bytesinner::{
     bytes_decode, ByteInnerFindOptions, ByteInnerNewOptions, ByteInnerPaddingOptions,
@@ -72,7 +72,7 @@ impl Deref for PyBytes {
 }
 
 impl PyValue for PyBytes {
-    fn class(vm: &VirtualMachine) -> PyClassRef {
+    fn class(vm: &VirtualMachine) -> PyTypeRef {
         vm.ctx.types.bytes_type.clone()
     }
 }
@@ -90,7 +90,7 @@ pub(crate) fn init(context: &PyContext) {
 impl PyBytes {
     #[pyslot]
     fn tp_new(
-        cls: PyClassRef,
+        cls: PyTypeRef,
         options: ByteInnerNewOptions,
         vm: &VirtualMachine,
     ) -> PyResult<PyBytesRef> {
@@ -485,7 +485,7 @@ pub struct PyBytesIterator {
 }
 
 impl PyValue for PyBytesIterator {
-    fn class(vm: &VirtualMachine) -> PyClassRef {
+    fn class(vm: &VirtualMachine) -> PyTypeRef {
         vm.ctx.types.bytes_iterator_type.clone()
     }
 }

--- a/vm/src/obj/objclassmethod.rs
+++ b/vm/src/obj/objclassmethod.rs
@@ -1,4 +1,4 @@
-use super::objtype::PyClassRef;
+use super::objtype::PyTypeRef;
 use crate::pyobject::{
     PyClassImpl, PyContext, PyObjectRef, PyRef, PyResult, PyValue, TypeProtocol,
 };
@@ -39,7 +39,7 @@ impl From<PyObjectRef> for PyClassMethod {
 }
 
 impl PyValue for PyClassMethod {
-    fn class(vm: &VirtualMachine) -> PyClassRef {
+    fn class(vm: &VirtualMachine) -> PyTypeRef {
         vm.ctx.types.classmethod_type.clone()
     }
 }
@@ -61,7 +61,7 @@ impl SlotDescriptor for PyClassMethod {
 impl PyClassMethod {
     #[pyslot]
     fn tp_new(
-        cls: PyClassRef,
+        cls: PyTypeRef,
         callable: PyObjectRef,
         vm: &VirtualMachine,
     ) -> PyResult<PyClassMethodRef> {

--- a/vm/src/obj/objcode.rs
+++ b/vm/src/obj/objcode.rs
@@ -5,7 +5,7 @@
 use std::fmt;
 use std::ops::Deref;
 
-use super::objtype::PyClassRef;
+use super::objtype::PyTypeRef;
 use crate::bytecode;
 use crate::pyobject::{IdProtocol, PyClassImpl, PyContext, PyObjectRef, PyRef, PyResult, PyValue};
 use crate::vm::VirtualMachine;
@@ -37,7 +37,7 @@ impl fmt::Debug for PyCode {
 }
 
 impl PyValue for PyCode {
-    fn class(vm: &VirtualMachine) -> PyClassRef {
+    fn class(vm: &VirtualMachine) -> PyTypeRef {
         vm.ctx.types.code_type.clone()
     }
 }
@@ -45,7 +45,7 @@ impl PyValue for PyCode {
 #[pyimpl]
 impl PyCodeRef {
     #[pyslot]
-    fn new(_cls: PyClassRef, vm: &VirtualMachine) -> PyResult<PyRef<Self>> {
+    fn new(_cls: PyTypeRef, vm: &VirtualMachine) -> PyResult<PyRef<Self>> {
         Err(vm.new_type_error("Cannot directly create code object".to_owned()))
     }
 

--- a/vm/src/obj/objcomplex.rs
+++ b/vm/src/obj/objcomplex.rs
@@ -3,7 +3,7 @@ use num_traits::Zero;
 
 use super::objfloat;
 use super::objstr::PyStr;
-use super::objtype::{self, PyClassRef};
+use super::objtype::{self, PyTypeRef};
 use crate::pyobject::{
     BorrowValue, IntoPyObject, Never, PyArithmaticValue, PyClassImpl, PyComparisonValue, PyContext,
     PyObjectRef, PyRef, PyResult, PyValue, TypeProtocol,
@@ -24,7 +24,7 @@ pub struct PyComplex {
 type PyComplexRef = PyRef<PyComplex>;
 
 impl PyValue for PyComplex {
-    fn class(vm: &VirtualMachine) -> PyClassRef {
+    fn class(vm: &VirtualMachine) -> PyTypeRef {
         vm.ctx.types.complex_type.clone()
     }
 }
@@ -223,7 +223,7 @@ impl PyComplex {
     }
 
     #[pyslot]
-    fn tp_new(cls: PyClassRef, args: ComplexArgs, vm: &VirtualMachine) -> PyResult<PyComplexRef> {
+    fn tp_new(cls: PyTypeRef, args: ComplexArgs, vm: &VirtualMachine) -> PyResult<PyComplexRef> {
         let real = match args.real {
             None => Complex64::new(0.0, 0.0),
             Some(obj) => {

--- a/vm/src/obj/objcoroinner.rs
+++ b/vm/src/obj/objcoroinner.rs
@@ -1,4 +1,4 @@
-use super::objtype::{self, PyClassRef};
+use super::objtype::{self, PyTypeRef};
 use crate::exceptions::{self, PyBaseExceptionRef};
 use crate::frame::{ExecutionResult, FrameRef};
 use crate::pyobject::{PyObjectRef, PyResult};
@@ -24,7 +24,7 @@ impl Variant {
             Self::AsyncGen => "async generator",
         }
     }
-    fn stop_iteration(self, vm: &VirtualMachine) -> PyClassRef {
+    fn stop_iteration(self, vm: &VirtualMachine) -> PyTypeRef {
         match self {
             Self::AsyncGen => vm.ctx.exceptions.stop_async_iteration.clone(),
             _ => vm.ctx.exceptions.stop_iteration.clone(),

--- a/vm/src/obj/objcoroutine.rs
+++ b/vm/src/obj/objcoroutine.rs
@@ -1,7 +1,7 @@
 use super::objcode::PyCodeRef;
 use super::objcoroinner::{Coro, Variant};
 use super::objstr::PyStrRef;
-use super::objtype::PyClassRef;
+use super::objtype::PyTypeRef;
 use crate::frame::FrameRef;
 use crate::function::OptionalArg;
 use crate::pyobject::{PyClassImpl, PyContext, PyObjectRef, PyRef, PyResult, PyValue};
@@ -16,7 +16,7 @@ pub struct PyCoroutine {
 }
 
 impl PyValue for PyCoroutine {
-    fn class(vm: &VirtualMachine) -> PyClassRef {
+    fn class(vm: &VirtualMachine) -> PyTypeRef {
         vm.ctx.types.coroutine_type.clone()
     }
 }
@@ -102,7 +102,7 @@ pub struct PyCoroutineWrapper {
 }
 
 impl PyValue for PyCoroutineWrapper {
-    fn class(vm: &VirtualMachine) -> PyClassRef {
+    fn class(vm: &VirtualMachine) -> PyTypeRef {
         vm.ctx.types.coroutine_wrapper_type.clone()
     }
 }

--- a/vm/src/obj/objdict.rs
+++ b/vm/src/obj/objdict.rs
@@ -5,7 +5,7 @@ use std::mem::size_of;
 use super::objiter;
 use super::objset::PySet;
 use super::objstr;
-use super::objtype::{self, PyClassRef};
+use super::objtype::{self, PyTypeRef};
 use crate::dictdatatype::{self, DictKey};
 use crate::exceptions::PyBaseExceptionRef;
 use crate::function::{KwArgs, OptionalArg, PyFuncArgs};
@@ -43,7 +43,7 @@ impl fmt::Debug for PyDict {
 }
 
 impl PyValue for PyDict {
-    fn class(vm: &VirtualMachine) -> PyClassRef {
+    fn class(vm: &VirtualMachine) -> PyTypeRef {
         vm.ctx.types.dict_type.clone()
     }
 }
@@ -53,7 +53,7 @@ impl PyValue for PyDict {
 #[pyimpl(with(Hashable, Comparable), flags(BASETYPE))]
 impl PyDict {
     #[pyslot]
-    fn tp_new(class: PyClassRef, _args: PyFuncArgs, vm: &VirtualMachine) -> PyResult<PyRef<Self>> {
+    fn tp_new(class: PyTypeRef, _args: PyFuncArgs, vm: &VirtualMachine) -> PyResult<PyRef<Self>> {
         PyDict {
             entries: DictContentType::default(),
         }
@@ -128,7 +128,7 @@ impl PyDict {
 
     #[pyclassmethod]
     fn fromkeys(
-        class: PyClassRef,
+        class: PyTypeRef,
         iterable: PyIterable,
         value: OptionalArg<PyObjectRef>,
         vm: &VirtualMachine,
@@ -643,7 +643,7 @@ macro_rules! dict_iterator {
         }
 
         impl PyValue for $name {
-            fn class(vm: &VirtualMachine) -> PyClassRef {
+            fn class(vm: &VirtualMachine) -> PyTypeRef {
                 vm.ctx.types.$class.clone()
             }
         }
@@ -696,7 +696,7 @@ macro_rules! dict_iterator {
         }
 
         impl PyValue for $iter_name {
-            fn class(vm: &VirtualMachine) -> PyClassRef {
+            fn class(vm: &VirtualMachine) -> PyTypeRef {
                 vm.ctx.types.$iter_class.clone()
             }
         }
@@ -752,7 +752,7 @@ macro_rules! dict_iterator {
         }
 
         impl PyValue for $reverse_iter_name {
-            fn class(vm: &VirtualMachine) -> PyClassRef {
+            fn class(vm: &VirtualMachine) -> PyTypeRef {
                 vm.ctx.types.$reverse_iter_class.clone()
             }
         }

--- a/vm/src/obj/objenumerate.rs
+++ b/vm/src/obj/objenumerate.rs
@@ -6,7 +6,7 @@ use num_traits::Zero;
 
 use super::objint::PyIntRef;
 use super::objiter;
-use super::objtype::PyClassRef;
+use super::objtype::PyTypeRef;
 use crate::function::OptionalArg;
 use crate::pyobject::{BorrowValue, PyClassImpl, PyContext, PyObjectRef, PyRef, PyResult, PyValue};
 use crate::vm::VirtualMachine;
@@ -20,7 +20,7 @@ pub struct PyEnumerate {
 type PyEnumerateRef = PyRef<PyEnumerate>;
 
 impl PyValue for PyEnumerate {
-    fn class(vm: &VirtualMachine) -> PyClassRef {
+    fn class(vm: &VirtualMachine) -> PyTypeRef {
         vm.ctx.types.enumerate_type.clone()
     }
 }
@@ -29,7 +29,7 @@ impl PyValue for PyEnumerate {
 impl PyEnumerate {
     #[pyslot]
     fn tp_new(
-        cls: PyClassRef,
+        cls: PyTypeRef,
         iterable: PyObjectRef,
         start: OptionalArg<PyIntRef>,
         vm: &VirtualMachine,

--- a/vm/src/obj/objfilter.rs
+++ b/vm/src/obj/objfilter.rs
@@ -1,6 +1,6 @@
 use super::objbool;
 use super::objiter;
-use super::objtype::PyClassRef;
+use super::objtype::PyTypeRef;
 use crate::pyobject::{PyClassImpl, PyContext, PyObjectRef, PyRef, PyResult, PyValue};
 use crate::vm::VirtualMachine;
 
@@ -18,7 +18,7 @@ pub struct PyFilter {
 }
 
 impl PyValue for PyFilter {
-    fn class(vm: &VirtualMachine) -> PyClassRef {
+    fn class(vm: &VirtualMachine) -> PyTypeRef {
         vm.ctx.types.filter_type.clone()
     }
 }
@@ -27,7 +27,7 @@ impl PyValue for PyFilter {
 impl PyFilter {
     #[pyslot]
     fn tp_new(
-        cls: PyClassRef,
+        cls: PyTypeRef,
         function: PyObjectRef,
         iterable: PyObjectRef,
         vm: &VirtualMachine,

--- a/vm/src/obj/objfloat.rs
+++ b/vm/src/obj/objfloat.rs
@@ -6,7 +6,7 @@ use num_traits::{pow, ToPrimitive, Zero};
 use super::objbytes::PyBytes;
 use super::objint::{self, PyInt, PyIntRef};
 use super::objstr::{PyStr, PyStrRef};
-use super::objtype::PyClassRef;
+use super::objtype::PyTypeRef;
 use crate::format::FormatSpec;
 use crate::function::{OptionalArg, OptionalOption};
 use crate::pyobject::{
@@ -33,7 +33,7 @@ impl PyFloat {
 }
 
 impl PyValue for PyFloat {
-    fn class(vm: &VirtualMachine) -> PyClassRef {
+    fn class(vm: &VirtualMachine) -> PyTypeRef {
         vm.ctx.types.float_type.clone()
     }
 }
@@ -137,7 +137,7 @@ pub fn float_pow(v1: f64, v2: f64, vm: &VirtualMachine) -> PyResult {
 impl PyFloat {
     #[pyslot]
     fn tp_new(
-        cls: PyClassRef,
+        cls: PyTypeRef,
         arg: OptionalArg<PyObjectRef>,
         vm: &VirtualMachine,
     ) -> PyResult<PyFloatRef> {

--- a/vm/src/obj/objfunction.rs
+++ b/vm/src/obj/objfunction.rs
@@ -5,7 +5,7 @@ use super::objcode::PyCodeRef;
 use super::objdict::PyDictRef;
 use super::objstr::PyStrRef;
 use super::objtuple::PyTupleRef;
-use super::objtype::PyClassRef;
+use super::objtype::PyTypeRef;
 use crate::bytecode;
 use crate::frame::Frame;
 use crate::function::PyFuncArgs;
@@ -264,7 +264,7 @@ impl PyFunction {
 }
 
 impl PyValue for PyFunction {
-    fn class(vm: &VirtualMachine) -> PyClassRef {
+    fn class(vm: &VirtualMachine) -> PyTypeRef {
         vm.ctx.types.function_type.clone()
     }
 }
@@ -396,7 +396,7 @@ impl PyBoundMethod {
 }
 
 impl PyValue for PyBoundMethod {
-    fn class(vm: &VirtualMachine) -> PyClassRef {
+    fn class(vm: &VirtualMachine) -> PyTypeRef {
         vm.ctx.types.bound_method_type.clone()
     }
 }

--- a/vm/src/obj/objgenerator.rs
+++ b/vm/src/obj/objgenerator.rs
@@ -4,7 +4,7 @@
 
 use super::objcode::PyCodeRef;
 use super::objcoroinner::{Coro, Variant};
-use super::objtype::PyClassRef;
+use super::objtype::PyTypeRef;
 use crate::frame::FrameRef;
 use crate::function::OptionalArg;
 use crate::pyobject::{PyClassImpl, PyContext, PyObjectRef, PyRef, PyResult, PyValue};
@@ -19,7 +19,7 @@ pub struct PyGenerator {
 }
 
 impl PyValue for PyGenerator {
-    fn class(vm: &VirtualMachine) -> PyClassRef {
+    fn class(vm: &VirtualMachine) -> PyTypeRef {
         vm.ctx.types.generator_type.clone()
     }
 }

--- a/vm/src/obj/objgetset.rs
+++ b/vm/src/obj/objgetset.rs
@@ -1,7 +1,7 @@
 /*! Python `attribute` descriptor class. (PyGetSet)
 
 */
-use super::objtype::PyClassRef;
+use super::objtype::PyTypeRef;
 use crate::function::{OwnedParam, RefParam};
 use crate::pyobject::{
     IntoPyResult, PyClassImpl, PyContext, PyObjectRef, PyRef, PyResult, PyValue, TryFromObject,
@@ -173,7 +173,7 @@ impl std::fmt::Debug for PyGetSet {
 }
 
 impl PyValue for PyGetSet {
-    fn class(vm: &VirtualMachine) -> PyClassRef {
+    fn class(vm: &VirtualMachine) -> PyTypeRef {
         vm.ctx.types.getset_type.clone()
     }
 }

--- a/vm/src/obj/objint.rs
+++ b/vm/src/obj/objint.rs
@@ -13,7 +13,7 @@ use super::objbytes::PyBytes;
 use super::objfloat;
 use super::objmemory::PyMemoryView;
 use super::objstr::{PyStr, PyStrRef};
-use super::objtype::PyClassRef;
+use super::objtype::PyTypeRef;
 use crate::bytesinner::PyBytesInner;
 use crate::format::FormatSpec;
 use crate::function::{OptionalArg, PyFuncArgs};
@@ -73,7 +73,7 @@ where
 }
 
 impl PyValue for PyInt {
-    fn class(vm: &VirtualMachine) -> PyClassRef {
+    fn class(vm: &VirtualMachine) -> PyTypeRef {
         vm.ctx.types.int_type.clone()
     }
 
@@ -233,7 +233,7 @@ fn inner_truediv(i1: &BigInt, i2: &BigInt, vm: &VirtualMachine) -> PyResult {
 
 #[pyimpl(flags(BASETYPE), with(Comparable, Hashable))]
 impl PyInt {
-    fn with_value<T>(cls: PyClassRef, value: T, vm: &VirtualMachine) -> PyResult<PyIntRef>
+    fn with_value<T>(cls: PyTypeRef, value: T, vm: &VirtualMachine) -> PyResult<PyIntRef>
     where
         T: Into<BigInt> + ToPrimitive,
     {
@@ -251,7 +251,7 @@ impl PyInt {
     }
 
     #[pyslot]
-    fn tp_new(cls: PyClassRef, options: IntOptions, vm: &VirtualMachine) -> PyResult<PyIntRef> {
+    fn tp_new(cls: PyTypeRef, options: IntOptions, vm: &VirtualMachine) -> PyResult<PyIntRef> {
         let value = if let OptionalArg::Present(val) = options.val_options {
             if let OptionalArg::Present(base) = options.base {
                 let base = vm
@@ -557,7 +557,7 @@ impl PyInt {
 
     #[pyclassmethod]
     fn from_bytes(
-        cls: PyClassRef,
+        cls: PyTypeRef,
         args: IntFromByteArgs,
         vm: &VirtualMachine,
     ) -> PyResult<PyRef<Self>> {

--- a/vm/src/obj/objiter.rs
+++ b/vm/src/obj/objiter.rs
@@ -7,7 +7,7 @@ use num_traits::Signed;
 
 use super::objint::{self, PyInt};
 use super::objsequence;
-use super::objtype::{self, PyClassRef};
+use super::objtype::{self, PyTypeRef};
 use crate::exceptions::PyBaseExceptionRef;
 use crate::pyobject::{
     BorrowValue, PyCallable, PyClassImpl, PyContext, PyObjectRef, PyRef, PyResult, PyValue,
@@ -152,7 +152,7 @@ pub struct PySequenceIterator {
 }
 
 impl PyValue for PySequenceIterator {
-    fn class(vm: &VirtualMachine) -> PyClassRef {
+    fn class(vm: &VirtualMachine) -> PyTypeRef {
         vm.ctx.types.iter_type.clone()
     }
 }
@@ -225,7 +225,7 @@ pub struct PyCallableIterator {
 }
 
 impl PyValue for PyCallableIterator {
-    fn class(vm: &VirtualMachine) -> PyClassRef {
+    fn class(vm: &VirtualMachine) -> PyTypeRef {
         vm.ctx.types.callable_iterator.clone()
     }
 }

--- a/vm/src/obj/objlist.rs
+++ b/vm/src/obj/objlist.rs
@@ -12,7 +12,7 @@ use super::objsequence::{
     get_item, get_pos, get_saturated_pos, PySliceableSequenceMut, SequenceIndex,
 };
 use super::objslice::PySliceRef;
-use super::objtype::PyClassRef;
+use super::objtype::PyTypeRef;
 use crate::bytesinner;
 use crate::common::cell::{PyRwLock, PyRwLockReadGuard, PyRwLockWriteGuard};
 use crate::function::OptionalArg;
@@ -56,7 +56,7 @@ impl FromIterator<PyObjectRef> for PyList {
 }
 
 impl PyValue for PyList {
-    fn class(vm: &VirtualMachine) -> PyClassRef {
+    fn class(vm: &VirtualMachine) -> PyTypeRef {
         vm.ctx.types.list_type.clone()
     }
 }
@@ -394,7 +394,7 @@ impl PyList {
 
     #[pyslot]
     fn tp_new(
-        cls: PyClassRef,
+        cls: PyTypeRef,
         iterable: OptionalArg<PyObjectRef>,
         vm: &VirtualMachine,
     ) -> PyResult<PyListRef> {
@@ -462,7 +462,7 @@ pub struct PyListIterator {
 }
 
 impl PyValue for PyListIterator {
-    fn class(vm: &VirtualMachine) -> PyClassRef {
+    fn class(vm: &VirtualMachine) -> PyTypeRef {
         vm.ctx.types.list_iterator_type.clone()
     }
 }
@@ -501,7 +501,7 @@ pub struct PyListReverseIterator {
 }
 
 impl PyValue for PyListReverseIterator {
-    fn class(vm: &VirtualMachine) -> PyClassRef {
+    fn class(vm: &VirtualMachine) -> PyTypeRef {
         vm.ctx.types.list_reverseiterator_type.clone()
     }
 }

--- a/vm/src/obj/objmap.rs
+++ b/vm/src/obj/objmap.rs
@@ -1,5 +1,5 @@
 use super::objiter;
-use super::objtype::PyClassRef;
+use super::objtype::PyTypeRef;
 use crate::function::Args;
 use crate::pyobject::{PyClassImpl, PyContext, PyObjectRef, PyRef, PyResult, PyValue};
 use crate::vm::VirtualMachine;
@@ -17,7 +17,7 @@ pub struct PyMap {
 type PyMapRef = PyRef<PyMap>;
 
 impl PyValue for PyMap {
-    fn class(vm: &VirtualMachine) -> PyClassRef {
+    fn class(vm: &VirtualMachine) -> PyTypeRef {
         vm.ctx.types.map_type.clone()
     }
 }
@@ -26,7 +26,7 @@ impl PyValue for PyMap {
 impl PyMap {
     #[pyslot]
     fn tp_new(
-        cls: PyClassRef,
+        cls: PyTypeRef,
         function: PyObjectRef,
         iterables: Args,
         vm: &VirtualMachine,

--- a/vm/src/obj/objmappingproxy.rs
+++ b/vm/src/obj/objmappingproxy.rs
@@ -1,7 +1,7 @@
 use super::objdict::PyDict;
 use super::objiter;
 use super::objstr::PyStrRef;
-use super::objtype::PyClassRef;
+use super::objtype::PyTypeRef;
 use crate::function::OptionalArg;
 use crate::pyobject::{
     BorrowValue, IntoPyObject, ItemProtocol, PyClassImpl, PyContext, PyObjectRef, PyRef, PyResult,
@@ -17,28 +17,28 @@ pub struct PyMappingProxy {
 
 #[derive(Debug)]
 enum MappingProxyInner {
-    Class(PyClassRef),
+    Class(PyTypeRef),
     Dict(PyObjectRef),
 }
 
 pub type PyMappingProxyRef = PyRef<PyMappingProxy>;
 
 impl PyValue for PyMappingProxy {
-    fn class(vm: &VirtualMachine) -> PyClassRef {
+    fn class(vm: &VirtualMachine) -> PyTypeRef {
         vm.ctx.types.mappingproxy_type.clone()
     }
 }
 
 #[pyimpl]
 impl PyMappingProxy {
-    pub fn new(class: PyClassRef) -> PyMappingProxy {
+    pub fn new(class: PyTypeRef) -> PyMappingProxy {
         PyMappingProxy {
             mapping: MappingProxyInner::Class(class),
         }
     }
 
     #[pyslot]
-    fn tp_new(cls: PyClassRef, mapping: PyObjectRef, vm: &VirtualMachine) -> PyResult<PyRef<Self>> {
+    fn tp_new(cls: PyTypeRef, mapping: PyObjectRef, vm: &VirtualMachine) -> PyResult<PyRef<Self>> {
         PyMappingProxy {
             mapping: MappingProxyInner::Dict(mapping),
         }

--- a/vm/src/obj/objmemory.rs
+++ b/vm/src/obj/objmemory.rs
@@ -1,4 +1,4 @@
-use super::objtype::{issubclass, PyClassRef};
+use super::objtype::{issubclass, PyTypeRef};
 use crate::bytesinner::try_as_bytes;
 use crate::common::hash::PyHash;
 use crate::pyobject::{
@@ -27,7 +27,7 @@ impl PyMemoryView {
 
     #[pyslot]
     fn tp_new(
-        cls: PyClassRef,
+        cls: PyTypeRef,
         bytes_object: PyObjectRef,
         vm: &VirtualMachine,
     ) -> PyResult<PyMemoryViewRef> {
@@ -73,7 +73,7 @@ impl Hashable for PyMemoryView {
 }
 
 impl PyValue for PyMemoryView {
-    fn class(vm: &VirtualMachine) -> PyClassRef {
+    fn class(vm: &VirtualMachine) -> PyTypeRef {
         vm.ctx.types.memoryview_type.clone()
     }
 }

--- a/vm/src/obj/objmodule.rs
+++ b/vm/src/obj/objmodule.rs
@@ -1,6 +1,6 @@
 use super::objdict::PyDictRef;
 use super::objstr::{PyStr, PyStrRef};
-use super::objtype::PyClassRef;
+use super::objtype::PyTypeRef;
 use crate::function::{OptionalOption, PyFuncArgs};
 use crate::pyobject::{
     BorrowValue, IntoPyObject, ItemProtocol, PyClassImpl, PyContext, PyObjectRef, PyRef, PyResult,
@@ -14,7 +14,7 @@ pub struct PyModule {}
 pub type PyModuleRef = PyRef<PyModule>;
 
 impl PyValue for PyModule {
-    fn class(vm: &VirtualMachine) -> PyClassRef {
+    fn class(vm: &VirtualMachine) -> PyTypeRef {
         vm.ctx.types.module_type.clone()
     }
 }
@@ -45,7 +45,7 @@ pub fn init_module_dict(
 #[pyimpl(flags(BASETYPE, HAS_DICT))]
 impl PyModuleRef {
     #[pyslot]
-    fn tp_new(cls: PyClassRef, _args: PyFuncArgs, vm: &VirtualMachine) -> PyResult<PyModuleRef> {
+    fn tp_new(cls: PyTypeRef, _args: PyFuncArgs, vm: &VirtualMachine) -> PyResult<PyModuleRef> {
         PyModule {}.into_ref_with_type(vm, cls)
     }
 

--- a/vm/src/obj/objnamespace.rs
+++ b/vm/src/obj/objnamespace.rs
@@ -1,4 +1,4 @@
-use super::objtype::PyClassRef;
+use super::objtype::PyTypeRef;
 use crate::function::KwArgs;
 use crate::pyobject::{PyClassImpl, PyContext, PyRef, PyResult, PyValue};
 use crate::vm::VirtualMachine;
@@ -11,7 +11,7 @@ use crate::vm::VirtualMachine;
 pub struct PyNamespace;
 
 impl PyValue for PyNamespace {
-    fn class(vm: &VirtualMachine) -> PyClassRef {
+    fn class(vm: &VirtualMachine) -> PyTypeRef {
         vm.ctx.types.namespace_type.clone()
     }
 }
@@ -19,7 +19,7 @@ impl PyValue for PyNamespace {
 #[pyimpl(flags(BASETYPE, HAS_DICT))]
 impl PyNamespace {
     #[pyslot]
-    fn tp_new(cls: PyClassRef, kwargs: KwArgs, vm: &VirtualMachine) -> PyResult<PyRef<Self>> {
+    fn tp_new(cls: PyTypeRef, kwargs: KwArgs, vm: &VirtualMachine) -> PyResult<PyRef<Self>> {
         let zelf = PyNamespace.into_ref_with_type(vm, cls)?;
         for (name, value) in kwargs.into_iter() {
             vm.set_attr(zelf.as_object(), name, value)?;

--- a/vm/src/obj/objobject.rs
+++ b/vm/src/obj/objobject.rs
@@ -2,10 +2,10 @@ use super::objbool;
 use super::objdict::{PyDict, PyDictRef};
 use super::objlist::PyList;
 use super::objstr::PyStrRef;
-use super::objtype::PyClassRef;
+use super::objtype::PyTypeRef;
 use crate::common::hash::PyHash;
 use crate::function::{OptionalArg, PyFuncArgs};
-use crate::obj::objtype::PyClass;
+use crate::obj::objtype::PyType;
 use crate::pyobject::{
     BorrowValue, Either, IdProtocol, ItemProtocol, PyArithmaticValue, PyAttributes, PyClassImpl,
     PyComparisonValue, PyContext, PyObject, PyObjectRef, PyResult, PyValue, TryFromObject,
@@ -20,7 +20,7 @@ use crate::vm::VirtualMachine;
 pub struct PyBaseObject;
 
 impl PyValue for PyBaseObject {
-    fn class(vm: &VirtualMachine) -> PyClassRef {
+    fn class(vm: &VirtualMachine) -> PyTypeRef {
         vm.ctx.types.object_type.clone()
     }
 }
@@ -30,7 +30,7 @@ impl PyBaseObject {
     #[pyslot]
     fn tp_new(mut args: PyFuncArgs, vm: &VirtualMachine) -> PyResult {
         // more or less __new__ operator
-        let cls = PyClassRef::try_from_object(vm, args.shift())?;
+        let cls = PyTypeRef::try_from_object(vm, args.shift())?;
         let dict = if cls.is(&vm.ctx.types.object_type) {
             None
         } else {
@@ -181,7 +181,7 @@ impl PyBaseObject {
     }
 
     #[pyclassmethod(magic)]
-    fn init_subclass(_cls: PyClassRef) {}
+    fn init_subclass(_cls: PyTypeRef) {}
 
     #[pymethod(magic)]
     pub fn dir(obj: PyObjectRef, vm: &VirtualMachine) -> PyResult<PyList> {
@@ -221,7 +221,7 @@ impl PyBaseObject {
     #[pyproperty(name = "__class__", setter)]
     fn set_class(instance: PyObjectRef, value: PyObjectRef, vm: &VirtualMachine) -> PyResult<()> {
         if instance.payload_is::<PyBaseObject>() {
-            match value.downcast_generic::<PyClass>() {
+            match value.downcast_generic::<PyType>() {
                 Ok(cls) => {
                     // FIXME(#1979) cls instances might have a payload
                     *instance.typ.write() = cls;

--- a/vm/src/obj/objproperty.rs
+++ b/vm/src/obj/objproperty.rs
@@ -3,7 +3,7 @@
 */
 use crate::common::cell::PyRwLock;
 
-use super::objtype::PyClassRef;
+use super::objtype::PyTypeRef;
 use crate::pyobject::{
     PyClassImpl, PyContext, PyObjectRef, PyRef, PyResult, PyValue, TypeProtocol,
 };
@@ -52,7 +52,7 @@ pub struct PyProperty {
 }
 
 impl PyValue for PyProperty {
-    fn class(vm: &VirtualMachine) -> PyClassRef {
+    fn class(vm: &VirtualMachine) -> PyTypeRef {
         vm.ctx.types.property_type.clone()
     }
 }
@@ -92,7 +92,7 @@ impl SlotDescriptor for PyProperty {
 #[pyimpl(with(SlotDescriptor), flags(BASETYPE))]
 impl PyProperty {
     #[pyslot]
-    fn tp_new(cls: PyClassRef, args: PropertyArgs, vm: &VirtualMachine) -> PyResult<PyPropertyRef> {
+    fn tp_new(cls: PyTypeRef, args: PropertyArgs, vm: &VirtualMachine) -> PyResult<PyPropertyRef> {
         PyProperty {
             getter: args.fget,
             setter: args.fset,

--- a/vm/src/obj/objrange.rs
+++ b/vm/src/obj/objrange.rs
@@ -6,7 +6,7 @@ use num_traits::{One, Signed, Zero};
 use super::objint::{PyInt, PyIntRef};
 use super::objiter;
 use super::objslice::{PySlice, PySliceRef};
-use super::objtype::PyClassRef;
+use super::objtype::PyTypeRef;
 
 use crate::common::hash::PyHash;
 use crate::function::{OptionalArg, PyFuncArgs};
@@ -34,7 +34,7 @@ pub struct PyRange {
 }
 
 impl PyValue for PyRange {
-    fn class(vm: &VirtualMachine) -> PyClassRef {
+    fn class(vm: &VirtualMachine) -> PyTypeRef {
         vm.ctx.types.range_type.clone()
     }
 }
@@ -132,7 +132,7 @@ type PyRangeRef = PyRef<PyRange>;
 
 #[pyimpl(with(Hashable, Comparable))]
 impl PyRange {
-    fn new(cls: PyClassRef, stop: PyIntRef, vm: &VirtualMachine) -> PyResult<PyRangeRef> {
+    fn new(cls: PyTypeRef, stop: PyIntRef, vm: &VirtualMachine) -> PyResult<PyRangeRef> {
         PyRange {
             start: (0).into_pyref(vm),
             stop,
@@ -142,7 +142,7 @@ impl PyRange {
     }
 
     fn new_from(
-        cls: PyClassRef,
+        cls: PyTypeRef,
         start: PyIntRef,
         stop: PyIntRef,
         step: OptionalArg<PyIntRef>,
@@ -243,7 +243,7 @@ impl PyRange {
     }
 
     #[pymethod(name = "__reduce__")]
-    fn reduce(&self, vm: &VirtualMachine) -> (PyClassRef, PyObjectRef) {
+    fn reduce(&self, vm: &VirtualMachine) -> (PyTypeRef, PyObjectRef) {
         let range_paramters: Vec<PyObjectRef> = vec![&self.start, &self.stop, &self.step]
             .iter()
             .map(|x| x.as_object().clone())
@@ -378,7 +378,7 @@ pub struct PyRangeIterator {
 }
 
 impl PyValue for PyRangeIterator {
-    fn class(vm: &VirtualMachine) -> PyClassRef {
+    fn class(vm: &VirtualMachine) -> PyTypeRef {
         vm.ctx.types.range_iterator_type.clone()
     }
 }

--- a/vm/src/obj/objset.rs
+++ b/vm/src/obj/objset.rs
@@ -5,7 +5,7 @@ use rustpython_common::rc::PyRc;
 use std::fmt;
 
 use super::objiter;
-use super::objtype::{self, PyClassRef};
+use super::objtype::{self, PyTypeRef};
 use crate::dictdatatype;
 use crate::function::{Args, OptionalArg};
 use crate::pyobject::{
@@ -55,13 +55,13 @@ impl fmt::Debug for PyFrozenSet {
 }
 
 impl PyValue for PySet {
-    fn class(vm: &VirtualMachine) -> PyClassRef {
+    fn class(vm: &VirtualMachine) -> PyTypeRef {
         vm.ctx.types.set_type.clone()
     }
 }
 
 impl PyValue for PyFrozenSet {
-    fn class(vm: &VirtualMachine) -> PyClassRef {
+    fn class(vm: &VirtualMachine) -> PyTypeRef {
         vm.ctx.types.frozenset_type.clone()
     }
 }
@@ -318,7 +318,7 @@ macro_rules! multi_args_set {
 impl PySet {
     #[pyslot]
     fn tp_new(
-        cls: PyClassRef,
+        cls: PyTypeRef,
         iterable: OptionalArg<PyIterable>,
         vm: &VirtualMachine,
     ) -> PyResult<PySetRef> {
@@ -567,7 +567,7 @@ impl PyFrozenSet {
 
     #[pyslot]
     fn tp_new(
-        cls: PyClassRef,
+        cls: PyTypeRef,
         iterable: OptionalArg<PyIterable>,
         vm: &VirtualMachine,
     ) -> PyResult<PyFrozenSetRef> {
@@ -795,7 +795,7 @@ impl PySetIterator {
 }
 
 impl PyValue for PySetIterator {
-    fn class(vm: &VirtualMachine) -> PyClassRef {
+    fn class(vm: &VirtualMachine) -> PyTypeRef {
         vm.ctx.types.set_iterator_type.clone()
     }
 }

--- a/vm/src/obj/objsingletons.rs
+++ b/vm/src/obj/objsingletons.rs
@@ -1,4 +1,4 @@
-use super::objtype::PyClassRef;
+use super::objtype::PyTypeRef;
 use crate::pyobject::{
     IntoPyObject, PyClassImpl, PyContext, PyObjectRef, PyRef, PyValue, TypeProtocol,
 };
@@ -10,7 +10,7 @@ pub struct PyNone;
 pub type PyNoneRef = PyRef<PyNone>;
 
 impl PyValue for PyNone {
-    fn class(vm: &VirtualMachine) -> PyClassRef {
+    fn class(vm: &VirtualMachine) -> PyTypeRef {
         vm.ctx.none.class()
     }
 }
@@ -35,7 +35,7 @@ impl<T: IntoPyObject> IntoPyObject for Option<T> {
 #[pyimpl]
 impl PyNone {
     #[pyslot]
-    fn tp_new(_: PyClassRef, vm: &VirtualMachine) -> PyNoneRef {
+    fn tp_new(_: PyTypeRef, vm: &VirtualMachine) -> PyNoneRef {
         vm.ctx.none.clone()
     }
 
@@ -56,7 +56,7 @@ pub struct PyNotImplemented;
 pub type PyNotImplementedRef = PyRef<PyNotImplemented>;
 
 impl PyValue for PyNotImplemented {
-    fn class(vm: &VirtualMachine) -> PyClassRef {
+    fn class(vm: &VirtualMachine) -> PyTypeRef {
         vm.ctx.not_implemented.class()
     }
 }

--- a/vm/src/obj/objslice.rs
+++ b/vm/src/obj/objslice.rs
@@ -1,7 +1,7 @@
 // sliceobject.{h,c} in CPython
 
 use super::objint::PyInt;
-use super::objtype::PyClassRef;
+use super::objtype::PyTypeRef;
 use crate::function::{OptionalArg, PyFuncArgs};
 use crate::pyobject::{
     BorrowValue, IntoPyObject, PyClassImpl, PyComparisonValue, PyContext, PyObjectRef, PyRef,
@@ -21,7 +21,7 @@ pub struct PySlice {
 }
 
 impl PyValue for PySlice {
-    fn class(vm: &VirtualMachine) -> PyClassRef {
+    fn class(vm: &VirtualMachine) -> PyTypeRef {
         vm.ctx.types.slice_type.clone()
     }
 }
@@ -94,7 +94,7 @@ impl PySlice {
     }
 
     #[pyslot]
-    fn tp_new(cls: PyClassRef, args: PyFuncArgs, vm: &VirtualMachine) -> PyResult<PySliceRef> {
+    fn tp_new(cls: PyTypeRef, args: PyFuncArgs, vm: &VirtualMachine) -> PyResult<PySliceRef> {
         let slice: PySlice = match args.args.len() {
             0 => {
                 return Err(
@@ -287,7 +287,7 @@ fn to_index_value(vm: &VirtualMachine, obj: &PyObjectRef) -> PyResult<Option<Big
 pub struct PyEllipsis;
 
 impl PyValue for PyEllipsis {
-    fn class(vm: &VirtualMachine) -> PyClassRef {
+    fn class(vm: &VirtualMachine) -> PyTypeRef {
         vm.ctx.ellipsis.class()
     }
 }
@@ -295,7 +295,7 @@ impl PyValue for PyEllipsis {
 #[pyimpl]
 impl PyEllipsis {
     #[pyslot]
-    fn tp_new(_cls: PyClassRef, vm: &VirtualMachine) -> PyRef<Self> {
+    fn tp_new(_cls: PyTypeRef, vm: &VirtualMachine) -> PyRef<Self> {
         vm.ctx.ellipsis.clone()
     }
 

--- a/vm/src/obj/objstaticmethod.rs
+++ b/vm/src/obj/objstaticmethod.rs
@@ -1,4 +1,4 @@
-use super::objtype::PyClassRef;
+use super::objtype::PyTypeRef;
 use crate::pyobject::{PyClassImpl, PyContext, PyObjectRef, PyRef, PyResult, PyValue};
 use crate::slots::SlotDescriptor;
 use crate::vm::VirtualMachine;
@@ -11,7 +11,7 @@ pub struct PyStaticMethod {
 pub type PyStaticMethodRef = PyRef<PyStaticMethod>;
 
 impl PyValue for PyStaticMethod {
-    fn class(vm: &VirtualMachine) -> PyClassRef {
+    fn class(vm: &VirtualMachine) -> PyTypeRef {
         vm.ctx.types.staticmethod_type.clone()
     }
 }
@@ -38,7 +38,7 @@ impl From<PyObjectRef> for PyStaticMethod {
 impl PyStaticMethod {
     #[pyslot]
     fn tp_new(
-        cls: PyClassRef,
+        cls: PyTypeRef,
         callable: PyObjectRef,
         vm: &VirtualMachine,
     ) -> PyResult<PyStaticMethodRef> {

--- a/vm/src/obj/objstr.rs
+++ b/vm/src/obj/objstr.rs
@@ -17,7 +17,7 @@ use super::objdict::PyDict;
 use super::objint::{PyInt, PyIntRef};
 use super::objiter;
 use super::objsequence::{PySliceableSequence, SequenceIndex};
-use super::objtype::{self, PyClassRef};
+use super::objtype::{self, PyTypeRef};
 use crate::anystr::{self, adjust_indices, AnyStr, AnyStrContainer, AnyStrWrapper};
 use crate::exceptions::IntoPyException;
 use crate::format::{FormatSpec, FormatString, FromTemplate};
@@ -109,7 +109,7 @@ pub struct PyStringIterator {
 }
 
 impl PyValue for PyStringIterator {
-    fn class(vm: &VirtualMachine) -> PyClassRef {
+    fn class(vm: &VirtualMachine) -> PyTypeRef {
         vm.ctx.types.str_iterator_type.clone()
     }
 }
@@ -142,7 +142,7 @@ pub struct PyStringReverseIterator {
 }
 
 impl PyValue for PyStringReverseIterator {
-    fn class(vm: &VirtualMachine) -> PyClassRef {
+    fn class(vm: &VirtualMachine) -> PyTypeRef {
         vm.ctx.types.str_reverseiterator_type.clone()
     }
 }
@@ -179,7 +179,7 @@ struct StrArgs {
 #[pyimpl(flags(BASETYPE), with(Hashable, Comparable))]
 impl PyStr {
     #[pyslot]
-    fn tp_new(cls: PyClassRef, args: StrArgs, vm: &VirtualMachine) -> PyResult<PyStrRef> {
+    fn tp_new(cls: PyTypeRef, args: StrArgs, vm: &VirtualMachine) -> PyResult<PyStrRef> {
         let string: PyStrRef = match args.object {
             OptionalArg::Present(input) => {
                 if let OptionalArg::Present(enc) = args.encoding {
@@ -1091,7 +1091,7 @@ pub(crate) fn encode_string(
 }
 
 impl PyValue for PyStr {
-    fn class(vm: &VirtualMachine) -> PyClassRef {
+    fn class(vm: &VirtualMachine) -> PyTypeRef {
         vm.ctx.types.str_type.clone()
     }
 }

--- a/vm/src/obj/objtraceback.rs
+++ b/vm/src/obj/objtraceback.rs
@@ -1,5 +1,5 @@
 use crate::frame::FrameRef;
-use crate::obj::objtype::PyClassRef;
+use crate::obj::objtype::PyTypeRef;
 use crate::pyobject::{PyClassImpl, PyContext, PyRef, PyValue};
 use crate::vm::VirtualMachine;
 
@@ -15,7 +15,7 @@ pub struct PyTraceback {
 pub type PyTracebackRef = PyRef<PyTraceback>;
 
 impl PyValue for PyTraceback {
-    fn class(vm: &VirtualMachine) -> PyClassRef {
+    fn class(vm: &VirtualMachine) -> PyTypeRef {
         vm.ctx.types.traceback_type.clone()
     }
 }

--- a/vm/src/obj/objtuple.rs
+++ b/vm/src/obj/objtuple.rs
@@ -3,7 +3,7 @@ use std::fmt;
 
 use super::objiter;
 use super::objsequence::get_item;
-use super::objtype::PyClassRef;
+use super::objtype::PyTypeRef;
 use crate::function::OptionalArg;
 use crate::pyobject::{
     self, BorrowValue, Either, IdProtocol, IntoPyObject, PyArithmaticValue, PyClassImpl,
@@ -39,7 +39,7 @@ impl<'a> BorrowValue<'a> for PyTuple {
 }
 
 impl PyValue for PyTuple {
-    fn class(vm: &VirtualMachine) -> PyClassRef {
+    fn class(vm: &VirtualMachine) -> PyTypeRef {
         vm.ctx.types.tuple_type.clone()
     }
 }
@@ -214,7 +214,7 @@ impl PyTuple {
 
     #[pyslot]
     fn tp_new(
-        cls: PyClassRef,
+        cls: PyTypeRef,
         iterable: OptionalArg<PyObjectRef>,
         vm: &VirtualMachine,
     ) -> PyResult<PyRef<Self>> {
@@ -268,7 +268,7 @@ pub struct PyTupleIterator {
 }
 
 impl PyValue for PyTupleIterator {
-    fn class(vm: &VirtualMachine) -> PyClassRef {
+    fn class(vm: &VirtualMachine) -> PyTypeRef {
         vm.ctx.types.tuple_iterator_type.clone()
     }
 }

--- a/vm/src/obj/objweakproxy.rs
+++ b/vm/src/obj/objweakproxy.rs
@@ -1,4 +1,4 @@
-use super::objtype::PyClassRef;
+use super::objtype::PyTypeRef;
 use super::objweakref::PyWeak;
 use crate::function::OptionalArg;
 use crate::pyobject::{PyClassImpl, PyContext, PyObjectRef, PyRef, PyResult, PyValue};
@@ -11,7 +11,7 @@ pub struct PyWeakProxy {
 }
 
 impl PyValue for PyWeakProxy {
-    fn class(vm: &VirtualMachine) -> PyClassRef {
+    fn class(vm: &VirtualMachine) -> PyTypeRef {
         vm.ctx.types.weakproxy_type.clone()
     }
 }
@@ -23,7 +23,7 @@ impl PyWeakProxy {
     // TODO: callbacks
     #[pyslot]
     fn tp_new(
-        cls: PyClassRef,
+        cls: PyTypeRef,
         referent: PyObjectRef,
         callback: OptionalArg<PyObjectRef>,
         vm: &VirtualMachine,

--- a/vm/src/obj/objweakref.rs
+++ b/vm/src/obj/objweakref.rs
@@ -1,4 +1,4 @@
-use super::objtype::PyClassRef;
+use super::objtype::PyTypeRef;
 use crate::common::hash::PyHash;
 use crate::function::{OptionalArg, PyFuncArgs};
 use crate::pyobject::{
@@ -31,7 +31,7 @@ impl PyWeak {
 }
 
 impl PyValue for PyWeak {
-    fn class(vm: &VirtualMachine) -> PyClassRef {
+    fn class(vm: &VirtualMachine) -> PyTypeRef {
         vm.ctx.types.weakref_type.clone()
     }
 }
@@ -50,7 +50,7 @@ impl PyWeak {
     // TODO callbacks
     #[pyslot]
     fn tp_new(
-        cls: PyClassRef,
+        cls: PyTypeRef,
         referent: PyObjectRef,
         _callback: OptionalArg<PyObjectRef>,
         vm: &VirtualMachine,

--- a/vm/src/obj/objzip.rs
+++ b/vm/src/obj/objzip.rs
@@ -1,5 +1,5 @@
 use super::objiter;
-use super::objtype::PyClassRef;
+use super::objtype::PyTypeRef;
 use crate::function::Args;
 use crate::pyobject::{PyClassImpl, PyContext, PyObjectRef, PyRef, PyResult, PyValue};
 use crate::vm::VirtualMachine;
@@ -13,7 +13,7 @@ pub struct PyZip {
 }
 
 impl PyValue for PyZip {
-    fn class(vm: &VirtualMachine) -> PyClassRef {
+    fn class(vm: &VirtualMachine) -> PyTypeRef {
         vm.ctx.types.zip_type.clone()
     }
 }
@@ -21,7 +21,7 @@ impl PyValue for PyZip {
 #[pyimpl(flags(BASETYPE))]
 impl PyZip {
     #[pyslot]
-    fn tp_new(cls: PyClassRef, iterables: Args, vm: &VirtualMachine) -> PyResult<PyZipRef> {
+    fn tp_new(cls: PyTypeRef, iterables: Args, vm: &VirtualMachine) -> PyResult<PyZipRef> {
         let iterators = iterables
             .into_iter()
             .map(|iterable| objiter::get_iter(vm, &iterable))

--- a/vm/src/slots.rs
+++ b/vm/src/slots.rs
@@ -53,7 +53,7 @@ pub(crate) type CmpFunc = fn(
 ) -> PyResult<Either<PyObjectRef, PyComparisonValue>>;
 
 #[derive(Default)]
-pub struct PyClassSlots {
+pub struct PyTypeSlots {
     pub flags: PyTpFlags,
     pub name: PyRwLock<Option<String>>, // tp_name, not class name
     pub new: Option<PyNativeFunc>,
@@ -64,7 +64,7 @@ pub struct PyClassSlots {
     pub cmp: AtomicCell<Option<CmpFunc>>,
 }
 
-impl PyClassSlots {
+impl PyTypeSlots {
     pub fn from_flags(flags: PyTpFlags) -> Self {
         Self {
             flags,
@@ -73,9 +73,9 @@ impl PyClassSlots {
     }
 }
 
-impl std::fmt::Debug for PyClassSlots {
+impl std::fmt::Debug for PyTypeSlots {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        f.write_str("PyClassSlots")
+        f.write_str("PyTypeSlots")
     }
 }
 

--- a/vm/src/stdlib/array.rs
+++ b/vm/src/stdlib/array.rs
@@ -10,7 +10,7 @@ use crate::obj::objlist::PyList;
 use crate::obj::objsequence::{get_saturated_pos, PySliceableSequence, PySliceableSequenceMut};
 use crate::obj::objslice::PySliceRef;
 use crate::obj::objstr::PyStrRef;
-use crate::obj::objtype::PyClassRef;
+use crate::obj::objtype::PyTypeRef;
 use crate::pyobject::{
     BorrowValue, Either, IdProtocol, IntoPyObject, PyClassImpl, PyComparisonValue, PyIterable,
     PyObjectRef, PyRef, PyResult, PyValue, TryFromObject, TypeProtocol,
@@ -461,7 +461,7 @@ pub struct PyArray {
 pub type PyArrayRef = PyRef<PyArray>;
 
 impl PyValue for PyArray {
-    fn class(vm: &VirtualMachine) -> PyClassRef {
+    fn class(vm: &VirtualMachine) -> PyTypeRef {
         vm.class("array", "array")
     }
 }
@@ -478,7 +478,7 @@ impl PyArray {
 
     #[pyslot]
     fn tp_new(
-        cls: PyClassRef,
+        cls: PyTypeRef,
         spec: PyStrRef,
         init: OptionalArg<PyIterable>,
         vm: &VirtualMachine,
@@ -837,7 +837,7 @@ pub struct PyArrayIter {
 }
 
 impl PyValue for PyArrayIter {
-    fn class(vm: &VirtualMachine) -> PyClassRef {
+    fn class(vm: &VirtualMachine) -> PyTypeRef {
         vm.class("array", "arrayiterator")
     }
 }

--- a/vm/src/stdlib/ast.rs
+++ b/vm/src/stdlib/ast.rs
@@ -10,7 +10,7 @@ use num_complex::Complex64;
 use rustpython_parser::{ast, mode::Mode, parser};
 
 use crate::obj::objlist::PyListRef;
-use crate::obj::objtype::PyClassRef;
+use crate::obj::objtype::PyTypeRef;
 use crate::pyobject::{IntoPyObject, PyObjectRef, PyRef, PyResult, PyValue};
 use crate::slots::PyTpFlags;
 use crate::vm::VirtualMachine;
@@ -23,7 +23,7 @@ const MODULE_NAME: &str = "_ast";
 pub const PY_COMPILE_FLAG_AST_ONLY: i32 = 0x0400;
 
 impl PyValue for AstNode {
-    fn class(vm: &VirtualMachine) -> PyClassRef {
+    fn class(vm: &VirtualMachine) -> PyTypeRef {
         vm.class(MODULE_NAME, "AST")
     }
 }

--- a/vm/src/stdlib/collections.rs
+++ b/vm/src/stdlib/collections.rs
@@ -4,7 +4,7 @@ pub(crate) use _collections::make_module;
 mod _collections {
     use crate::common::cell::{PyRwLock, PyRwLockReadGuard, PyRwLockWriteGuard};
     use crate::function::OptionalArg;
-    use crate::obj::{objiter, objsequence, objtype::PyClassRef};
+    use crate::obj::{objiter, objsequence, objtype::PyTypeRef};
     use crate::pyobject::{
         PyClassImpl, PyComparisonValue, PyIterable, PyObjectRef, PyRef, PyResult, PyValue,
     };
@@ -27,7 +27,7 @@ mod _collections {
     type PyDequeRef = PyRef<PyDeque>;
 
     impl PyValue for PyDeque {
-        fn class(vm: &VirtualMachine) -> PyClassRef {
+        fn class(vm: &VirtualMachine) -> PyTypeRef {
             vm.class("_collections", "deque")
         }
     }
@@ -70,7 +70,7 @@ mod _collections {
     impl PyDeque {
         #[pyslot]
         fn tp_new(
-            cls: PyClassRef,
+            cls: PyTypeRef,
             iter: OptionalArg<PyIterable>,
             PyDequeOptions { maxlen }: PyDequeOptions,
             vm: &VirtualMachine,
@@ -359,7 +359,7 @@ mod _collections {
     }
 
     impl PyValue for PyDequeIterator {
-        fn class(vm: &VirtualMachine) -> PyClassRef {
+        fn class(vm: &VirtualMachine) -> PyTypeRef {
             vm.class("_collections", "_deque_iterator")
         }
     }

--- a/vm/src/stdlib/csv.rs
+++ b/vm/src/stdlib/csv.rs
@@ -6,7 +6,7 @@ use crate::common::cell::PyRwLock;
 use crate::function::PyFuncArgs;
 use crate::obj::objiter;
 use crate::obj::objstr::{self, PyStr};
-use crate::obj::objtype::PyClassRef;
+use crate::obj::objtype::PyTypeRef;
 use crate::pyobject::{
     BorrowValue, IntoPyObject, PyClassImpl, PyIterable, PyObjectRef, PyRef, PyResult, PyValue,
     TryFromObject, TypeProtocol,
@@ -136,7 +136,7 @@ impl Debug for Reader {
 }
 
 impl PyValue for Reader {
-    fn class(vm: &VirtualMachine) -> PyClassRef {
+    fn class(vm: &VirtualMachine) -> PyTypeRef {
         vm.class("_csv", "Reader")
     }
 }

--- a/vm/src/stdlib/hashlib.rs
+++ b/vm/src/stdlib/hashlib.rs
@@ -6,7 +6,7 @@ mod hashlib {
     use crate::function::{OptionalArg, PyFuncArgs};
     use crate::obj::objbytes::{PyBytes, PyBytesRef};
     use crate::obj::objstr::PyStrRef;
-    use crate::obj::objtype::PyClassRef;
+    use crate::obj::objtype::PyTypeRef;
     use crate::pyobject::{BorrowValue, PyClassImpl, PyResult, PyValue};
     use crate::vm::VirtualMachine;
     use std::fmt;
@@ -32,7 +32,7 @@ mod hashlib {
     }
 
     impl PyValue for PyHasher {
-        fn class(vm: &VirtualMachine) -> PyClassRef {
+        fn class(vm: &VirtualMachine) -> PyTypeRef {
             vm.class("hashlib", "hasher")
         }
     }
@@ -55,7 +55,7 @@ mod hashlib {
         }
 
         #[pyslot]
-        fn tp_new(_cls: PyClassRef, _args: PyFuncArgs, vm: &VirtualMachine) -> PyResult {
+        fn tp_new(_cls: PyTypeRef, _args: PyFuncArgs, vm: &VirtualMachine) -> PyResult {
             Ok(PyHasher::new("md5", HashWrapper::md5())
                 .into_ref(vm)
                 .into_object())

--- a/vm/src/stdlib/io.rs
+++ b/vm/src/stdlib/io.rs
@@ -27,7 +27,7 @@ mod _io {
     use crate::obj::objint;
     use crate::obj::objiter;
     use crate::obj::objstr::{self, PyStr, PyStrRef};
-    use crate::obj::objtype::{self, PyClassRef};
+    use crate::obj::objtype::{self, PyTypeRef};
     use crate::pyobject::{
         BorrowValue, IntoPyObject, PyClassImpl, PyContext, PyObjectRef, PyRef, PyResult, PyValue,
         TryFromObject,
@@ -811,7 +811,7 @@ mod _io {
     type StringIORef = PyRef<StringIO>;
 
     impl PyValue for StringIO {
-        fn class(vm: &VirtualMachine) -> PyClassRef {
+        fn class(vm: &VirtualMachine) -> PyTypeRef {
             vm.class("io", "StringIO")
         }
     }
@@ -828,7 +828,7 @@ mod _io {
 
         #[pyslot]
         fn tp_new(
-            cls: PyClassRef,
+            cls: PyTypeRef,
             object: OptionalArg<Option<PyObjectRef>>,
             _args: StringIOArgs,
             vm: &VirtualMachine,
@@ -944,7 +944,7 @@ mod _io {
     type BytesIORef = PyRef<BytesIO>;
 
     impl PyValue for BytesIO {
-        fn class(vm: &VirtualMachine) -> PyClassRef {
+        fn class(vm: &VirtualMachine) -> PyTypeRef {
             vm.class("io", "BytesIO")
         }
     }
@@ -961,7 +961,7 @@ mod _io {
 
         #[pyslot]
         fn tp_new(
-            cls: PyClassRef,
+            cls: PyTypeRef,
             object: OptionalArg<Option<PyBytesRef>>,
             vm: &VirtualMachine,
         ) -> PyResult<BytesIORef> {
@@ -1408,7 +1408,7 @@ mod fileio {
     use crate::obj::objbytearray::PyByteArray;
     use crate::obj::objint;
     use crate::obj::objstr::PyStrRef;
-    use crate::obj::objtype::PyClassRef;
+    use crate::obj::objtype::PyTypeRef;
     use crate::pyobject::{
         BorrowValue, BufferProtocol, Either, PyClassImpl, PyObjectRef, PyRef, PyResult, PyValue,
         TryFromObject,
@@ -1443,7 +1443,7 @@ mod fileio {
     type FileIORef = PyRef<FileIO>;
 
     impl PyValue for FileIO {
-        fn class(vm: &VirtualMachine) -> PyClassRef {
+        fn class(vm: &VirtualMachine) -> PyTypeRef {
             vm.class("_io", "FileIO")
         }
     }
@@ -1463,7 +1463,7 @@ mod fileio {
     #[pyimpl(flags(HAS_DICT))]
     impl FileIO {
         #[pyslot]
-        fn tp_new(cls: PyClassRef, _args: PyFuncArgs, vm: &VirtualMachine) -> PyResult<FileIORef> {
+        fn tp_new(cls: PyTypeRef, _args: PyFuncArgs, vm: &VirtualMachine) -> PyResult<FileIORef> {
             FileIO {
                 fd: AtomicCell::new(-1),
                 closefd: AtomicCell::new(false),
@@ -1662,7 +1662,7 @@ mod fileio {
         }
     }
 
-    pub fn make_fileio(ctx: &crate::pyobject::PyContext, raw_io_base: PyClassRef) -> PyClassRef {
+    pub fn make_fileio(ctx: &crate::pyobject::PyContext, raw_io_base: PyTypeRef) -> PyTypeRef {
         FileIO::make_class_with_base(ctx, raw_io_base)
     }
 }

--- a/vm/src/stdlib/itertools.rs
+++ b/vm/src/stdlib/itertools.rs
@@ -15,7 +15,7 @@ mod decl {
     use crate::obj::objint::{self, PyInt, PyIntRef};
     use crate::obj::objiter::{call_next, get_all, get_iter, get_next_object, new_stop_iteration};
     use crate::obj::objtuple::PyTupleRef;
-    use crate::obj::objtype::{self, PyClassRef};
+    use crate::obj::objtype::{self, PyTypeRef};
     use crate::pyobject::{
         BorrowValue, IdProtocol, IntoPyRef, PyCallable, PyClassImpl, PyObjectRc, PyObjectRef,
         PyObjectWeak, PyRef, PyResult, PyValue, TypeProtocol,
@@ -32,7 +32,7 @@ mod decl {
     }
 
     impl PyValue for PyItertoolsChain {
-        fn class(vm: &VirtualMachine) -> PyClassRef {
+        fn class(vm: &VirtualMachine) -> PyTypeRef {
             vm.class("itertools", "chain")
         }
     }
@@ -40,7 +40,7 @@ mod decl {
     #[pyimpl]
     impl PyItertoolsChain {
         #[pyslot]
-        fn tp_new(cls: PyClassRef, args: PyFuncArgs, vm: &VirtualMachine) -> PyResult<PyRef<Self>> {
+        fn tp_new(cls: PyTypeRef, args: PyFuncArgs, vm: &VirtualMachine) -> PyResult<PyRef<Self>> {
             PyItertoolsChain {
                 iterables: args.args,
                 cur_idx: AtomicCell::new(0),
@@ -92,7 +92,7 @@ mod decl {
 
         #[pyclassmethod(name = "from_iterable")]
         fn from_iterable(
-            cls: PyClassRef,
+            cls: PyTypeRef,
             iterable: PyObjectRef,
             vm: &VirtualMachine,
         ) -> PyResult<PyRef<Self>> {
@@ -117,7 +117,7 @@ mod decl {
     }
 
     impl PyValue for PyItertoolsCompress {
-        fn class(vm: &VirtualMachine) -> PyClassRef {
+        fn class(vm: &VirtualMachine) -> PyTypeRef {
             vm.class("itertools", "compress")
         }
     }
@@ -126,7 +126,7 @@ mod decl {
     impl PyItertoolsCompress {
         #[pyslot]
         fn tp_new(
-            cls: PyClassRef,
+            cls: PyTypeRef,
             data: PyObjectRef,
             selector: PyObjectRef,
             vm: &VirtualMachine,
@@ -169,7 +169,7 @@ mod decl {
     }
 
     impl PyValue for PyItertoolsCount {
-        fn class(vm: &VirtualMachine) -> PyClassRef {
+        fn class(vm: &VirtualMachine) -> PyTypeRef {
             vm.class("itertools", "count")
         }
     }
@@ -178,7 +178,7 @@ mod decl {
     impl PyItertoolsCount {
         #[pyslot]
         fn tp_new(
-            cls: PyClassRef,
+            cls: PyTypeRef,
             start: OptionalArg<PyIntRef>,
             step: OptionalArg<PyIntRef>,
             vm: &VirtualMachine,
@@ -223,7 +223,7 @@ mod decl {
     }
 
     impl PyValue for PyItertoolsCycle {
-        fn class(vm: &VirtualMachine) -> PyClassRef {
+        fn class(vm: &VirtualMachine) -> PyTypeRef {
             vm.class("itertools", "cycle")
         }
     }
@@ -232,7 +232,7 @@ mod decl {
     impl PyItertoolsCycle {
         #[pyslot]
         fn tp_new(
-            cls: PyClassRef,
+            cls: PyTypeRef,
             iterable: PyObjectRef,
             vm: &VirtualMachine,
         ) -> PyResult<PyRef<Self>> {
@@ -284,7 +284,7 @@ mod decl {
     }
 
     impl PyValue for PyItertoolsRepeat {
-        fn class(vm: &VirtualMachine) -> PyClassRef {
+        fn class(vm: &VirtualMachine) -> PyTypeRef {
             vm.class("itertools", "repeat")
         }
     }
@@ -293,7 +293,7 @@ mod decl {
     impl PyItertoolsRepeat {
         #[pyslot]
         fn tp_new(
-            cls: PyClassRef,
+            cls: PyTypeRef,
             object: PyObjectRef,
             times: OptionalArg<PyIntRef>,
             vm: &VirtualMachine,
@@ -342,7 +342,7 @@ mod decl {
     }
 
     impl PyValue for PyItertoolsStarmap {
-        fn class(vm: &VirtualMachine) -> PyClassRef {
+        fn class(vm: &VirtualMachine) -> PyTypeRef {
             vm.class("itertools", "starmap")
         }
     }
@@ -351,7 +351,7 @@ mod decl {
     impl PyItertoolsStarmap {
         #[pyslot]
         fn tp_new(
-            cls: PyClassRef,
+            cls: PyTypeRef,
             function: PyObjectRef,
             iterable: PyObjectRef,
             vm: &VirtualMachine,
@@ -385,7 +385,7 @@ mod decl {
     }
 
     impl PyValue for PyItertoolsTakewhile {
-        fn class(vm: &VirtualMachine) -> PyClassRef {
+        fn class(vm: &VirtualMachine) -> PyTypeRef {
             vm.class("itertools", "takewhile")
         }
     }
@@ -394,7 +394,7 @@ mod decl {
     impl PyItertoolsTakewhile {
         #[pyslot]
         fn tp_new(
-            cls: PyClassRef,
+            cls: PyTypeRef,
             predicate: PyObjectRef,
             iterable: PyObjectRef,
             vm: &VirtualMachine,
@@ -445,7 +445,7 @@ mod decl {
     }
 
     impl PyValue for PyItertoolsDropwhile {
-        fn class(vm: &VirtualMachine) -> PyClassRef {
+        fn class(vm: &VirtualMachine) -> PyTypeRef {
             vm.class("itertools", "dropwhile")
         }
     }
@@ -454,7 +454,7 @@ mod decl {
     impl PyItertoolsDropwhile {
         #[pyslot]
         fn tp_new(
-            cls: PyClassRef,
+            cls: PyTypeRef,
             predicate: PyCallable,
             iterable: PyObjectRef,
             vm: &VirtualMachine,
@@ -529,7 +529,7 @@ mod decl {
     }
 
     impl PyValue for PyItertoolsGroupBy {
-        fn class(vm: &VirtualMachine) -> PyClassRef {
+        fn class(vm: &VirtualMachine) -> PyTypeRef {
             vm.class("itertools", "groupby")
         }
     }
@@ -554,11 +554,7 @@ mod decl {
     #[pyimpl]
     impl PyItertoolsGroupBy {
         #[pyslot]
-        fn tp_new(
-            cls: PyClassRef,
-            args: GroupByArgs,
-            vm: &VirtualMachine,
-        ) -> PyResult<PyRef<Self>> {
+        fn tp_new(cls: PyTypeRef, args: GroupByArgs, vm: &VirtualMachine) -> PyResult<PyRef<Self>> {
             let iter = get_iter(vm, &args.iterable)?;
 
             PyItertoolsGroupBy {
@@ -640,7 +636,7 @@ mod decl {
     type PyItertoolsGrouperRef = PyRef<PyItertoolsGrouper>;
 
     impl PyValue for PyItertoolsGrouper {
-        fn class(vm: &VirtualMachine) -> PyClassRef {
+        fn class(vm: &VirtualMachine) -> PyTypeRef {
             vm.class("itertools", "_grouper")
         }
     }
@@ -694,7 +690,7 @@ mod decl {
     }
 
     impl PyValue for PyItertoolsIslice {
-        fn class(vm: &VirtualMachine) -> PyClassRef {
+        fn class(vm: &VirtualMachine) -> PyTypeRef {
             vm.class("itertools", "islice")
         }
     }
@@ -711,7 +707,7 @@ mod decl {
     #[pyimpl]
     impl PyItertoolsIslice {
         #[pyslot]
-        fn tp_new(cls: PyClassRef, args: PyFuncArgs, vm: &VirtualMachine) -> PyResult<PyRef<Self>> {
+        fn tp_new(cls: PyTypeRef, args: PyFuncArgs, vm: &VirtualMachine) -> PyResult<PyRef<Self>> {
             let (iter, start, stop, step) = match args.args.len() {
                 0 | 1 => {
                     return Err(vm.new_type_error(format!(
@@ -818,7 +814,7 @@ mod decl {
     }
 
     impl PyValue for PyItertoolsFilterFalse {
-        fn class(vm: &VirtualMachine) -> PyClassRef {
+        fn class(vm: &VirtualMachine) -> PyTypeRef {
             vm.class("itertools", "filterfalse")
         }
     }
@@ -827,7 +823,7 @@ mod decl {
     impl PyItertoolsFilterFalse {
         #[pyslot]
         fn tp_new(
-            cls: PyClassRef,
+            cls: PyTypeRef,
             predicate: PyObjectRef,
             iterable: PyObjectRef,
             vm: &VirtualMachine,
@@ -876,7 +872,7 @@ mod decl {
     }
 
     impl PyValue for PyItertoolsAccumulate {
-        fn class(vm: &VirtualMachine) -> PyClassRef {
+        fn class(vm: &VirtualMachine) -> PyTypeRef {
             vm.class("itertools", "accumulate")
         }
     }
@@ -885,7 +881,7 @@ mod decl {
     impl PyItertoolsAccumulate {
         #[pyslot]
         fn tp_new(
-            cls: PyClassRef,
+            cls: PyTypeRef,
             iterable: PyObjectRef,
             binop: OptionalArg<PyObjectRef>,
             vm: &VirtualMachine,
@@ -960,7 +956,7 @@ mod decl {
     }
 
     impl PyValue for PyItertoolsTee {
-        fn class(vm: &VirtualMachine) -> PyClassRef {
+        fn class(vm: &VirtualMachine) -> PyTypeRef {
             vm.class("itertools", "tee")
         }
     }
@@ -985,7 +981,7 @@ mod decl {
         #[pyslot]
         #[allow(clippy::new_ret_no_self)]
         fn tp_new(
-            _cls: PyClassRef,
+            _cls: PyTypeRef,
             iterable: PyObjectRef,
             n: OptionalArg<usize>,
             vm: &VirtualMachine,
@@ -1041,7 +1037,7 @@ mod decl {
     }
 
     impl PyValue for PyItertoolsProduct {
-        fn class(vm: &VirtualMachine) -> PyClassRef {
+        fn class(vm: &VirtualMachine) -> PyTypeRef {
             vm.class("itertools", "product")
         }
     }
@@ -1056,7 +1052,7 @@ mod decl {
     impl PyItertoolsProduct {
         #[pyslot]
         fn tp_new(
-            cls: PyClassRef,
+            cls: PyTypeRef,
             iterables: Args<PyObjectRef>,
             args: ProductArgs,
             vm: &VirtualMachine,
@@ -1158,7 +1154,7 @@ mod decl {
     }
 
     impl PyValue for PyItertoolsCombinations {
-        fn class(vm: &VirtualMachine) -> PyClassRef {
+        fn class(vm: &VirtualMachine) -> PyTypeRef {
             vm.class("itertools", "combinations")
         }
     }
@@ -1167,7 +1163,7 @@ mod decl {
     impl PyItertoolsCombinations {
         #[pyslot]
         fn tp_new(
-            cls: PyClassRef,
+            cls: PyTypeRef,
             iterable: PyObjectRef,
             r: PyIntRef,
             vm: &VirtualMachine,
@@ -1258,7 +1254,7 @@ mod decl {
     }
 
     impl PyValue for PyItertoolsCombinationsWithReplacement {
-        fn class(vm: &VirtualMachine) -> PyClassRef {
+        fn class(vm: &VirtualMachine) -> PyTypeRef {
             vm.class("itertools", "combinations_with_replacement")
         }
     }
@@ -1267,7 +1263,7 @@ mod decl {
     impl PyItertoolsCombinationsWithReplacement {
         #[pyslot]
         fn tp_new(
-            cls: PyClassRef,
+            cls: PyTypeRef,
             iterable: PyObjectRef,
             r: PyIntRef,
             vm: &VirtualMachine,
@@ -1355,7 +1351,7 @@ mod decl {
     }
 
     impl PyValue for PyItertoolsPermutations {
-        fn class(vm: &VirtualMachine) -> PyClassRef {
+        fn class(vm: &VirtualMachine) -> PyTypeRef {
             vm.class("itertools", "permutations")
         }
     }
@@ -1364,7 +1360,7 @@ mod decl {
     impl PyItertoolsPermutations {
         #[pyslot]
         fn tp_new(
-            cls: PyClassRef,
+            cls: PyTypeRef,
             iterable: PyObjectRef,
             r: OptionalOption<PyObjectRef>,
             vm: &VirtualMachine,
@@ -1482,7 +1478,7 @@ mod decl {
     }
 
     impl PyValue for PyItertoolsZipLongest {
-        fn class(vm: &VirtualMachine) -> PyClassRef {
+        fn class(vm: &VirtualMachine) -> PyTypeRef {
             vm.class("itertools", "zip_longest")
         }
     }
@@ -1497,7 +1493,7 @@ mod decl {
     impl PyItertoolsZipLongest {
         #[pyslot]
         fn tp_new(
-            cls: PyClassRef,
+            cls: PyTypeRef,
             iterables: Args,
             args: ZiplongestArgs,
             vm: &VirtualMachine,

--- a/vm/src/stdlib/json.rs
+++ b/vm/src/stdlib/json.rs
@@ -6,7 +6,7 @@ mod _json {
     use crate::function::PyFuncArgs;
     use crate::obj::objiter;
     use crate::obj::objstr::PyStrRef;
-    use crate::obj::{objbool, objtype::PyClassRef};
+    use crate::obj::{objbool, objtype::PyTypeRef};
     use crate::pyobject::{
         BorrowValue, IdProtocol, PyClassImpl, PyObjectRef, PyRef, PyResult, PyValue,
     };
@@ -30,7 +30,7 @@ mod _json {
     }
 
     impl PyValue for JsonScanner {
-        fn class(vm: &VirtualMachine) -> PyClassRef {
+        fn class(vm: &VirtualMachine) -> PyTypeRef {
             vm.class("_json", "make_scanner")
         }
     }
@@ -38,7 +38,7 @@ mod _json {
     #[pyimpl(with(Callable))]
     impl JsonScanner {
         #[pyslot]
-        fn tp_new(cls: PyClassRef, ctx: PyObjectRef, vm: &VirtualMachine) -> PyResult<PyRef<Self>> {
+        fn tp_new(cls: PyTypeRef, ctx: PyObjectRef, vm: &VirtualMachine) -> PyResult<PyRef<Self>> {
             let strict = objbool::boolval(vm, vm.get_attribute(ctx.clone(), "strict")?)?;
             let object_hook = vm.option_if_none(vm.get_attribute(ctx.clone(), "object_hook")?);
             let object_pairs_hook =

--- a/vm/src/stdlib/os.rs
+++ b/vm/src/stdlib/os.rs
@@ -21,7 +21,7 @@ use crate::obj::objiter;
 use crate::obj::objset::PySet;
 use crate::obj::objstr::{PyStr, PyStrRef};
 use crate::obj::objtuple::PyTupleRef;
-use crate::obj::objtype::PyClassRef;
+use crate::obj::objtype::PyTypeRef;
 use crate::pyobject::{
     BorrowValue, Either, IntoPyObject, ItemProtocol, PyClassImpl, PyObjectRef, PyRef, PyResult,
     PyStructSequence, PyValue, TryFromObject, TypeProtocol,
@@ -465,7 +465,7 @@ mod _os {
     }
 
     impl PyValue for DirEntry {
-        fn class(vm: &VirtualMachine) -> PyClassRef {
+        fn class(vm: &VirtualMachine) -> PyTypeRef {
             vm.class(super::MODULE_NAME, "DirEntry")
         }
     }
@@ -550,7 +550,7 @@ mod _os {
     }
 
     impl PyValue for ScandirIterator {
-        fn class(vm: &VirtualMachine) -> PyClassRef {
+        fn class(vm: &VirtualMachine) -> PyTypeRef {
             vm.class(super::MODULE_NAME, "ScandirIter")
         }
     }
@@ -1097,7 +1097,7 @@ mod posix {
         unsafe { File::from_raw_fd(raw_fileno as i32) }
     }
 
-    pub(super) fn convert_nix_errno(vm: &VirtualMachine, errno: Errno) -> PyClassRef {
+    pub(super) fn convert_nix_errno(vm: &VirtualMachine, errno: Errno) -> PyTypeRef {
         match errno {
             Errno::EPERM => vm.ctx.exceptions.permission_error.clone(),
             _ => vm.ctx.exceptions.os_error.clone(),

--- a/vm/src/stdlib/pystruct.rs
+++ b/vm/src/stdlib/pystruct.rs
@@ -27,7 +27,7 @@ mod _struct {
     use crate::function::Args;
     use crate::obj::{
         objbool::IntoPyBool, objbytes::PyBytesRef, objiter, objstr::PyStr, objstr::PyStrRef,
-        objtuple::PyTupleRef, objtype::PyClassRef,
+        objtuple::PyTupleRef, objtype::PyTypeRef,
     };
     use crate::pyobject::{
         BorrowValue, Either, PyClassImpl, PyObjectRef, PyRef, PyResult, PyValue, TryFromObject,
@@ -825,7 +825,7 @@ mod _struct {
     }
 
     impl PyValue for UnpackIterator {
-        fn class(vm: &VirtualMachine) -> PyClassRef {
+        fn class(vm: &VirtualMachine) -> PyTypeRef {
             vm.class("_struct", "unpack_iterator")
         }
     }
@@ -880,7 +880,7 @@ mod _struct {
     }
 
     impl PyValue for PyStruct {
-        fn class(vm: &VirtualMachine) -> PyClassRef {
+        fn class(vm: &VirtualMachine) -> PyTypeRef {
             vm.class("_struct", "Struct")
         }
     }
@@ -889,7 +889,7 @@ mod _struct {
     impl PyStruct {
         #[pyslot]
         fn tp_new(
-            cls: PyClassRef,
+            cls: PyTypeRef,
             fmt: Either<PyStrRef, PyBytesRef>,
             vm: &VirtualMachine,
         ) -> PyResult<PyRef<Self>> {

--- a/vm/src/stdlib/random.rs
+++ b/vm/src/stdlib/random.rs
@@ -7,7 +7,7 @@ mod _random {
     use crate::common::cell::PyMutex;
     use crate::function::OptionalOption;
     use crate::obj::objint::PyIntRef;
-    use crate::obj::objtype::PyClassRef;
+    use crate::obj::objtype::PyTypeRef;
     use crate::pyobject::{BorrowValue, PyClassImpl, PyRef, PyResult, PyValue};
     use crate::VirtualMachine;
     use num_bigint::{BigInt, Sign};
@@ -61,7 +61,7 @@ mod _random {
     }
 
     impl PyValue for PyRandom {
-        fn class(vm: &VirtualMachine) -> PyClassRef {
+        fn class(vm: &VirtualMachine) -> PyTypeRef {
             vm.class("_random", "Random")
         }
     }
@@ -69,7 +69,7 @@ mod _random {
     #[pyimpl(flags(BASETYPE))]
     impl PyRandom {
         #[pyslot(new)]
-        fn new(cls: PyClassRef, vm: &VirtualMachine) -> PyResult<PyRef<Self>> {
+        fn new(cls: PyTypeRef, vm: &VirtualMachine) -> PyResult<PyRef<Self>> {
             PyRandom {
                 rng: PyMutex::default(),
             }

--- a/vm/src/stdlib/re.rs
+++ b/vm/src/stdlib/re.rs
@@ -12,7 +12,7 @@ use std::ops::Range;
 use crate::function::{Args, OptionalArg};
 use crate::obj::objint::{PyInt, PyIntRef};
 use crate::obj::objstr::{PyStr, PyStrRef};
-use crate::obj::objtype::PyClassRef;
+use crate::obj::objtype::PyTypeRef;
 use crate::pyobject::{
     BorrowValue, IntoPyObject, PyClassImpl, PyObjectRef, PyResult, PyValue, TryFromObject,
 };
@@ -65,7 +65,7 @@ impl PyRegexFlags {
 }
 
 impl PyValue for PyPattern {
-    fn class(vm: &VirtualMachine) -> PyClassRef {
+    fn class(vm: &VirtualMachine) -> PyTypeRef {
         vm.class("re", "Pattern")
     }
 }
@@ -84,7 +84,7 @@ impl fmt::Debug for PyMatch {
 }
 
 impl PyValue for PyMatch {
-    fn class(vm: &VirtualMachine) -> PyClassRef {
+    fn class(vm: &VirtualMachine) -> PyTypeRef {
         vm.class("re", "Match")
     }
 }

--- a/vm/src/stdlib/socket.rs
+++ b/vm/src/stdlib/socket.rs
@@ -17,7 +17,7 @@ use crate::obj::objbytearray::PyByteArrayRef;
 use crate::obj::objbytes::PyBytesRef;
 use crate::obj::objstr::{PyStr, PyStrRef};
 use crate::obj::objtuple::PyTupleRef;
-use crate::obj::objtype::PyClassRef;
+use crate::obj::objtype::PyTypeRef;
 use crate::pyobject::{
     BorrowValue, Either, IntoPyObject, PyClassImpl, PyObjectRef, PyRef, PyResult, PyValue,
     TryFromObject,
@@ -64,7 +64,7 @@ pub struct PySocket {
 }
 
 impl PyValue for PySocket {
-    fn class(vm: &VirtualMachine) -> PyClassRef {
+    fn class(vm: &VirtualMachine) -> PyTypeRef {
         vm.class("_socket", "socket")
     }
 }
@@ -82,7 +82,7 @@ impl PySocket {
     }
 
     #[pyslot]
-    fn tp_new(cls: PyClassRef, _args: PyFuncArgs, vm: &VirtualMachine) -> PyResult<PyRef<Self>> {
+    fn tp_new(cls: PyTypeRef, _args: PyFuncArgs, vm: &VirtualMachine) -> PyResult<PyRef<Self>> {
         PySocket {
             kind: AtomicCell::default(),
             family: AtomicCell::default(),

--- a/vm/src/stdlib/ssl.rs
+++ b/vm/src/stdlib/ssl.rs
@@ -5,7 +5,7 @@ use crate::exceptions::{IntoPyException, PyBaseExceptionRef};
 use crate::function::OptionalArg;
 use crate::obj::objbytearray::PyByteArrayRef;
 use crate::obj::objstr::PyStrRef;
-use crate::obj::{objtype::PyClassRef, objweakref::PyWeak};
+use crate::obj::{objtype::PyTypeRef, objweakref::PyWeak};
 use crate::pyobject::{
     BorrowValue, Either, IntoPyObject, ItemProtocol, PyClassImpl, PyObjectRef, PyRef, PyResult,
     PyValue,
@@ -241,7 +241,7 @@ impl fmt::Debug for PySslContext {
 }
 
 impl PyValue for PySslContext {
-    fn class(vm: &VirtualMachine) -> PyClassRef {
+    fn class(vm: &VirtualMachine) -> PyTypeRef {
         vm.class("_ssl", "_SSLContext")
     }
 }
@@ -263,7 +263,7 @@ impl PySslContext {
     }
 
     #[pyslot]
-    fn tp_new(cls: PyClassRef, proto_version: i32, vm: &VirtualMachine) -> PyResult<PyRef<Self>> {
+    fn tp_new(cls: PyTypeRef, proto_version: i32, vm: &VirtualMachine) -> PyResult<PyRef<Self>> {
         let proto = SslVersion::try_from(proto_version)
             .map_err(|_| vm.new_value_error("invalid protocol version".to_owned()))?;
         let method = match proto {
@@ -520,7 +520,7 @@ impl fmt::Debug for PySslSocket {
 }
 
 impl PyValue for PySslSocket {
-    fn class(vm: &VirtualMachine) -> PyClassRef {
+    fn class(vm: &VirtualMachine) -> PyTypeRef {
         vm.class("_ssl", "_SSLSocket")
     }
 }
@@ -629,7 +629,7 @@ impl PySslSocket {
     }
 }
 
-fn ssl_error(vm: &VirtualMachine) -> PyClassRef {
+fn ssl_error(vm: &VirtualMachine) -> PyTypeRef {
     vm.class("_ssl", "SSLError")
 }
 

--- a/vm/src/stdlib/symtable.rs
+++ b/vm/src/stdlib/symtable.rs
@@ -5,7 +5,7 @@ mod decl {
     use std::fmt;
 
     use crate::obj::objstr::PyStrRef;
-    use crate::obj::objtype::PyClassRef;
+    use crate::obj::objtype::PyTypeRef;
     use crate::pyobject::{BorrowValue, PyClassImpl, PyRef, PyResult, PyValue};
     use crate::vm::VirtualMachine;
     use rustpython_compiler::{compile, error::CompileError, symboltable};
@@ -73,7 +73,7 @@ mod decl {
     }
 
     impl PyValue for PySymbolTable {
-        fn class(vm: &VirtualMachine) -> PyClassRef {
+        fn class(vm: &VirtualMachine) -> PyTypeRef {
             vm.class("symtable", "SymbolTable")
         }
     }
@@ -191,7 +191,7 @@ mod decl {
     }
 
     impl PyValue for PySymbol {
-        fn class(vm: &VirtualMachine) -> PyClassRef {
+        fn class(vm: &VirtualMachine) -> PyTypeRef {
             vm.class("symtable", "Symbol")
         }
     }

--- a/vm/src/stdlib/thread.rs
+++ b/vm/src/stdlib/thread.rs
@@ -4,7 +4,7 @@ use crate::function::{Args, KwArgs, OptionalArg, PyFuncArgs};
 use crate::obj::objdict::PyDictRef;
 use crate::obj::objstr::PyStrRef;
 use crate::obj::objtuple::PyTupleRef;
-use crate::obj::objtype::PyClassRef;
+use crate::obj::objtype::PyTypeRef;
 use crate::pyobject::{
     BorrowValue, Either, IdProtocol, ItemProtocol, PyCallable, PyClassImpl, PyObjectRef, PyRef,
     PyResult, PyValue, TypeProtocol,
@@ -99,7 +99,7 @@ struct PyLock {
 type PyLockRef = PyRef<PyLock>;
 
 impl PyValue for PyLock {
-    fn class(vm: &VirtualMachine) -> PyClassRef {
+    fn class(vm: &VirtualMachine) -> PyTypeRef {
         vm.class("_thread", "LockType")
     }
 }
@@ -152,7 +152,7 @@ struct PyRLock {
 }
 
 impl PyValue for PyRLock {
-    fn class(vm: &VirtualMachine) -> PyClassRef {
+    fn class(vm: &VirtualMachine) -> PyTypeRef {
         vm.class("_thread", "RLock")
     }
 }
@@ -166,7 +166,7 @@ impl fmt::Debug for PyRLock {
 #[pyimpl]
 impl PyRLock {
     #[pyslot]
-    fn tp_new(cls: PyClassRef, vm: &VirtualMachine) -> PyResult<PyRef<Self>> {
+    fn tp_new(cls: PyTypeRef, vm: &VirtualMachine) -> PyResult<PyRef<Self>> {
         PyRLock {
             mu: RawRMutex::INIT,
         }
@@ -291,7 +291,7 @@ struct PyLocal {
 }
 
 impl PyValue for PyLocal {
-    fn class(vm: &VirtualMachine) -> PyClassRef {
+    fn class(vm: &VirtualMachine) -> PyTypeRef {
         vm.class("_thread", "_local")
     }
 }
@@ -303,7 +303,7 @@ impl PyLocal {
     }
 
     #[pyslot]
-    fn tp_new(cls: PyClassRef, _args: PyFuncArgs, vm: &VirtualMachine) -> PyResult<PyRef<Self>> {
+    fn tp_new(cls: PyTypeRef, _args: PyFuncArgs, vm: &VirtualMachine) -> PyResult<PyRef<Self>> {
         PyLocal {
             data: ThreadLocal::new(),
         }

--- a/vm/src/stdlib/time_module.rs
+++ b/vm/src/stdlib/time_module.rs
@@ -10,7 +10,7 @@ use chrono::{Datelike, Timelike};
 use crate::function::OptionalArg;
 use crate::obj::objstr::PyStrRef;
 use crate::obj::objtuple::PyTupleRef;
-use crate::obj::objtype::PyClassRef;
+use crate::obj::objtype::PyTypeRef;
 use crate::pyobject::{
     BorrowValue, Either, PyClassImpl, PyObjectRef, PyResult, PyStructSequence, TryFromObject,
 };
@@ -224,7 +224,7 @@ impl PyStructTime {
     }
 
     #[pyslot]
-    fn tp_new(cls: PyClassRef, seq: PyObjectRef, vm: &VirtualMachine) -> PyResult<PyTupleRef> {
+    fn tp_new(cls: PyTypeRef, seq: PyObjectRef, vm: &VirtualMachine) -> PyResult<PyTupleRef> {
         Self::try_from_object(vm, seq)?.into_struct_sequence(vm, cls)
     }
 }

--- a/vm/src/stdlib/unicodedata.rs
+++ b/vm/src/stdlib/unicodedata.rs
@@ -4,7 +4,7 @@
 
 use crate::function::OptionalArg;
 use crate::obj::objstr::PyStrRef;
-use crate::obj::objtype::PyClassRef;
+use crate::obj::objtype::PyTypeRef;
 use crate::pyobject::{BorrowValue, PyClassImpl, PyObject, PyObjectRef, PyResult, PyValue};
 use crate::vm::VirtualMachine;
 
@@ -61,7 +61,7 @@ struct PyUCD {
 }
 
 impl PyValue for PyUCD {
-    fn class(vm: &VirtualMachine) -> PyClassRef {
+    fn class(vm: &VirtualMachine) -> PyTypeRef {
         vm.class("unicodedata", "UCD")
     }
 }

--- a/vm/src/stdlib/warnings.rs
+++ b/vm/src/stdlib/warnings.rs
@@ -4,7 +4,7 @@ pub(crate) use _warnings::make_module;
 mod _warnings {
     use crate::function::OptionalArg;
     use crate::obj::objstr::PyStrRef;
-    use crate::obj::objtype::{self, PyClassRef};
+    use crate::obj::objtype::{self, PyTypeRef};
     use crate::pyobject::{PyResult, TypeProtocol};
     use crate::vm::VirtualMachine;
 
@@ -13,7 +13,7 @@ mod _warnings {
         #[pyarg(positional_only, optional = false)]
         message: PyStrRef,
         #[pyarg(positional_or_keyword, optional = true)]
-        category: OptionalArg<PyClassRef>,
+        category: OptionalArg<PyTypeRef>,
         #[pyarg(positional_or_keyword, optional = true)]
         stacklevel: OptionalArg<u32>,
     }

--- a/vm/src/stdlib/winreg.rs
+++ b/vm/src/stdlib/winreg.rs
@@ -3,7 +3,7 @@ use crate::common::cell::{PyRwLock, PyRwLockReadGuard, PyRwLockWriteGuard};
 use crate::exceptions::IntoPyException;
 use crate::function::OptionalArg;
 use crate::obj::objstr::PyStrRef;
-use crate::obj::objtype::PyClassRef;
+use crate::obj::objtype::PyTypeRef;
 use crate::pyobject::{
     BorrowValue, PyClassImpl, PyObjectRef, PyRef, PyResult, PyValue, TryFromObject,
 };
@@ -25,7 +25,7 @@ type PyHKEYRef = PyRef<PyHKEY>;
 unsafe impl Sync for PyHKEY {}
 
 impl PyValue for PyHKEY {
-    fn class(vm: &VirtualMachine) -> PyClassRef {
+    fn class(vm: &VirtualMachine) -> PyTypeRef {
         vm.class("winreg", "HKEYType")
     }
 }

--- a/vm/src/stdlib/zlib.rs
+++ b/vm/src/stdlib/zlib.rs
@@ -7,7 +7,7 @@ mod decl {
     use crate::exceptions::PyBaseExceptionRef;
     use crate::function::OptionalArg;
     use crate::obj::objbytes::{PyBytes, PyBytesRef};
-    use crate::obj::objtype::PyClassRef;
+    use crate::obj::objtype::PyTypeRef;
     use crate::pyobject::{BorrowValue, IntoPyRef, PyClassImpl, PyResult, PyValue};
     use crate::types::create_type;
     use crate::vm::VirtualMachine;
@@ -35,7 +35,7 @@ mod decl {
     const DEF_BUF_SIZE: usize = 16 * 1024;
 
     #[pyattr]
-    fn error(vm: &VirtualMachine) -> PyClassRef {
+    fn error(vm: &VirtualMachine) -> PyTypeRef {
         create_type(
             "error",
             &vm.ctx.types.type_type,
@@ -218,7 +218,7 @@ mod decl {
         unconsumed_tail: PyMutex<PyBytesRef>,
     }
     impl PyValue for PyDecompress {
-        fn class(vm: &VirtualMachine) -> PyClassRef {
+        fn class(vm: &VirtualMachine) -> PyTypeRef {
             vm.class("zlib", "Decompress")
         }
     }
@@ -377,7 +377,7 @@ mod decl {
     }
 
     impl PyValue for PyCompress {
-        fn class(vm: &VirtualMachine) -> PyClassRef {
+        fn class(vm: &VirtualMachine) -> PyTypeRef {
             vm.class("zlib", "Compress")
         }
     }

--- a/vm/src/sysmodule.rs
+++ b/vm/src/sysmodule.rs
@@ -5,7 +5,7 @@ use crate::common::hash::{PyHash, PyUHash};
 use crate::frame::FrameRef;
 use crate::function::{Args, OptionalArg, PyFuncArgs};
 use crate::obj::objstr::PyStrRef;
-use crate::obj::objtype::PyClassRef;
+use crate::obj::objtype::PyTypeRef;
 use crate::pyobject::{
     IntoPyObject, ItemProtocol, PyClassImpl, PyContext, PyObjectRc, PyObjectRef, PyResult,
     PyStructSequence,
@@ -130,7 +130,7 @@ impl SysFlags {
     }
 
     #[pyslot]
-    fn tp_new(_cls: PyClassRef, _args: PyFuncArgs, vm: &VirtualMachine) -> PyResult {
+    fn tp_new(_cls: PyTypeRef, _args: PyFuncArgs, vm: &VirtualMachine) -> PyResult {
         Err(vm.new_type_error("cannot create 'sys.flags' instances".to_owned()))
     }
 }

--- a/vm/src/types.rs
+++ b/vm/src/types.rs
@@ -34,14 +34,14 @@ use crate::obj::objstr;
 use crate::obj::objsuper;
 use crate::obj::objtraceback;
 use crate::obj::objtuple;
-use crate::obj::objtype::{self, PyClass, PyClassRef};
+use crate::obj::objtype::{self, PyType, PyTypeRef};
 use crate::obj::objweakproxy;
 use crate::obj::objweakref;
 use crate::obj::objzip;
 use crate::pyobject::{
     PyAttributes, PyClassDef, PyClassImpl, PyContext, PyObject, PyObjectRc, PyObjectRef,
 };
-use crate::slots::PyClassSlots;
+use crate::slots::PyTypeSlots;
 use rustpython_common::{cell::PyRwLock, rc::PyRc};
 use std::mem::MaybeUninit;
 use std::ptr;
@@ -49,71 +49,71 @@ use std::ptr;
 /// Holder of references to builtin types.
 #[derive(Debug)]
 pub struct TypeZoo {
-    pub async_generator: PyClassRef,
-    pub async_generator_asend: PyClassRef,
-    pub async_generator_athrow: PyClassRef,
-    pub async_generator_wrapped_value: PyClassRef,
-    pub bytes_type: PyClassRef,
-    pub bytes_iterator_type: PyClassRef,
-    pub bytearray_type: PyClassRef,
-    pub bytearray_iterator_type: PyClassRef,
-    pub bool_type: PyClassRef,
-    pub callable_iterator: PyClassRef,
-    pub classmethod_type: PyClassRef,
-    pub code_type: PyClassRef,
-    pub coroutine_type: PyClassRef,
-    pub coroutine_wrapper_type: PyClassRef,
-    pub dict_type: PyClassRef,
-    pub enumerate_type: PyClassRef,
-    pub filter_type: PyClassRef,
-    pub float_type: PyClassRef,
-    pub frame_type: PyClassRef,
-    pub frozenset_type: PyClassRef,
-    pub generator_type: PyClassRef,
-    pub int_type: PyClassRef,
-    pub iter_type: PyClassRef,
-    pub complex_type: PyClassRef,
-    pub list_type: PyClassRef,
-    pub list_iterator_type: PyClassRef,
-    pub list_reverseiterator_type: PyClassRef,
-    pub str_iterator_type: PyClassRef,
-    pub str_reverseiterator_type: PyClassRef,
-    pub dict_keyiterator_type: PyClassRef,
-    pub dict_reversekeyiterator_type: PyClassRef,
-    pub dict_valueiterator_type: PyClassRef,
-    pub dict_reversevalueiterator_type: PyClassRef,
-    pub dict_itemiterator_type: PyClassRef,
-    pub dict_reverseitemiterator_type: PyClassRef,
-    pub dict_keys_type: PyClassRef,
-    pub dict_values_type: PyClassRef,
-    pub dict_items_type: PyClassRef,
-    pub map_type: PyClassRef,
-    pub memoryview_type: PyClassRef,
-    pub tuple_type: PyClassRef,
-    pub tuple_iterator_type: PyClassRef,
-    pub set_type: PyClassRef,
-    pub set_iterator_type: PyClassRef,
-    pub staticmethod_type: PyClassRef,
-    pub super_type: PyClassRef,
-    pub str_type: PyClassRef,
-    pub range_type: PyClassRef,
-    pub range_iterator_type: PyClassRef,
-    pub slice_type: PyClassRef,
-    pub type_type: PyClassRef,
-    pub zip_type: PyClassRef,
-    pub function_type: PyClassRef,
-    pub builtin_function_or_method_type: PyClassRef,
-    pub method_descriptor_type: PyClassRef,
-    pub property_type: PyClassRef,
-    pub getset_type: PyClassRef,
-    pub module_type: PyClassRef,
-    pub namespace_type: PyClassRef,
-    pub bound_method_type: PyClassRef,
-    pub weakref_type: PyClassRef,
-    pub weakproxy_type: PyClassRef,
-    pub mappingproxy_type: PyClassRef,
-    pub traceback_type: PyClassRef,
-    pub object_type: PyClassRef,
+    pub async_generator: PyTypeRef,
+    pub async_generator_asend: PyTypeRef,
+    pub async_generator_athrow: PyTypeRef,
+    pub async_generator_wrapped_value: PyTypeRef,
+    pub bytes_type: PyTypeRef,
+    pub bytes_iterator_type: PyTypeRef,
+    pub bytearray_type: PyTypeRef,
+    pub bytearray_iterator_type: PyTypeRef,
+    pub bool_type: PyTypeRef,
+    pub callable_iterator: PyTypeRef,
+    pub classmethod_type: PyTypeRef,
+    pub code_type: PyTypeRef,
+    pub coroutine_type: PyTypeRef,
+    pub coroutine_wrapper_type: PyTypeRef,
+    pub dict_type: PyTypeRef,
+    pub enumerate_type: PyTypeRef,
+    pub filter_type: PyTypeRef,
+    pub float_type: PyTypeRef,
+    pub frame_type: PyTypeRef,
+    pub frozenset_type: PyTypeRef,
+    pub generator_type: PyTypeRef,
+    pub int_type: PyTypeRef,
+    pub iter_type: PyTypeRef,
+    pub complex_type: PyTypeRef,
+    pub list_type: PyTypeRef,
+    pub list_iterator_type: PyTypeRef,
+    pub list_reverseiterator_type: PyTypeRef,
+    pub str_iterator_type: PyTypeRef,
+    pub str_reverseiterator_type: PyTypeRef,
+    pub dict_keyiterator_type: PyTypeRef,
+    pub dict_reversekeyiterator_type: PyTypeRef,
+    pub dict_valueiterator_type: PyTypeRef,
+    pub dict_reversevalueiterator_type: PyTypeRef,
+    pub dict_itemiterator_type: PyTypeRef,
+    pub dict_reverseitemiterator_type: PyTypeRef,
+    pub dict_keys_type: PyTypeRef,
+    pub dict_values_type: PyTypeRef,
+    pub dict_items_type: PyTypeRef,
+    pub map_type: PyTypeRef,
+    pub memoryview_type: PyTypeRef,
+    pub tuple_type: PyTypeRef,
+    pub tuple_iterator_type: PyTypeRef,
+    pub set_type: PyTypeRef,
+    pub set_iterator_type: PyTypeRef,
+    pub staticmethod_type: PyTypeRef,
+    pub super_type: PyTypeRef,
+    pub str_type: PyTypeRef,
+    pub range_type: PyTypeRef,
+    pub range_iterator_type: PyTypeRef,
+    pub slice_type: PyTypeRef,
+    pub type_type: PyTypeRef,
+    pub zip_type: PyTypeRef,
+    pub function_type: PyTypeRef,
+    pub builtin_function_or_method_type: PyTypeRef,
+    pub method_descriptor_type: PyTypeRef,
+    pub property_type: PyTypeRef,
+    pub getset_type: PyTypeRef,
+    pub module_type: PyTypeRef,
+    pub namespace_type: PyTypeRef,
+    pub bound_method_type: PyTypeRef,
+    pub weakref_type: PyTypeRef,
+    pub weakproxy_type: PyTypeRef,
+    pub mappingproxy_type: PyTypeRef,
+    pub traceback_type: PyTypeRef,
+    pub object_type: PyTypeRef,
 }
 
 impl Default for TypeZoo {
@@ -206,16 +206,16 @@ impl TypeZoo {
     }
 }
 
-pub fn create_type(name: &str, type_type: &PyClassRef, base: PyClassRef) -> PyClassRef {
+pub fn create_type(name: &str, type_type: &PyTypeRef, base: PyTypeRef) -> PyTypeRef {
     create_type_with_slots(name, type_type, base, Default::default())
 }
 
 pub fn create_type_with_slots(
     name: &str,
-    type_type: &PyClassRef,
-    base: PyClassRef,
-    slots: PyClassSlots,
-) -> PyClassRef {
+    type_type: &PyTypeRef,
+    base: PyTypeRef,
+    slots: PyTypeSlots,
+) -> PyTypeRef {
     let dict = PyAttributes::new();
     objtype::new(
         type_type.clone(),
@@ -251,25 +251,25 @@ macro_rules! partially_init {
     }};
 }
 
-fn init_type_hierarchy() -> (PyClassRef, PyClassRef) {
+fn init_type_hierarchy() -> (PyTypeRef, PyTypeRef) {
     // `type` inherits from `object`
     // and both `type` and `object are instances of `type`.
     // to produce this circular dependency, we need an unsafe block.
     // (and yes, this will never get dropped. TODO?)
     let (type_type, object_type) = {
-        type PyClassObj = PyObject<PyClass>;
+        type PyTypeObj = PyObject<PyType>;
         type UninitRef<T> = PyRwLock<PyRc<MaybeUninit<PyObject<T>>>>;
 
-        let type_payload = PyClass {
-            name: PyClassRef::NAME.to_owned(),
+        let type_payload = PyType {
+            name: PyTypeRef::NAME.to_owned(),
             base: None,
             bases: vec![],
             mro: vec![],
             subclasses: PyRwLock::default(),
             attributes: PyRwLock::new(PyAttributes::new()),
-            slots: objtype::PyClass::make_slots(),
+            slots: objtype::PyType::make_slots(),
         };
-        let object_payload = PyClass {
+        let object_payload = PyType {
             name: objobject::PyBaseObject::NAME.to_owned(),
             base: None,
             bases: vec![],
@@ -278,15 +278,15 @@ fn init_type_hierarchy() -> (PyClassRef, PyClassRef) {
             attributes: PyRwLock::new(PyAttributes::new()),
             slots: objobject::PyBaseObject::make_slots(),
         };
-        let type_type: PyRc<MaybeUninit<PyClassObj>> = PyRc::new(partially_init!(
-            PyObject::<PyClass> {
+        let type_type: PyRc<MaybeUninit<PyTypeObj>> = PyRc::new(partially_init!(
+            PyObject::<PyType> {
                 dict: None,
                 payload: type_payload,
             },
             Uninit { typ }
         ));
-        let object_type: PyRc<MaybeUninit<PyClassObj>> = PyRc::new(partially_init!(
-            PyObject::<PyClass> {
+        let object_type: PyRc<MaybeUninit<PyTypeObj>> = PyRc::new(partially_init!(
+            PyObject::<PyType> {
                 dict: None,
                 payload: object_payload,
             },
@@ -294,25 +294,24 @@ fn init_type_hierarchy() -> (PyClassRef, PyClassRef) {
         ));
 
         let object_type_ptr =
-            PyRc::into_raw(object_type) as *mut MaybeUninit<PyClassObj> as *mut PyClassObj;
+            PyRc::into_raw(object_type) as *mut MaybeUninit<PyTypeObj> as *mut PyTypeObj;
         let type_type_ptr =
-            PyRc::into_raw(type_type.clone()) as *mut MaybeUninit<PyClassObj> as *mut PyClassObj;
+            PyRc::into_raw(type_type.clone()) as *mut MaybeUninit<PyTypeObj> as *mut PyTypeObj;
 
         unsafe {
             ptr::write(
-                &mut (*object_type_ptr).typ as *mut PyRwLock<PyObjectRc<PyClass>>
-                    as *mut UninitRef<PyClass>,
+                &mut (*object_type_ptr).typ as *mut PyRwLock<PyObjectRc<PyType>>
+                    as *mut UninitRef<PyType>,
                 PyRwLock::new(type_type.clone()),
             );
             ptr::write(
-                &mut (*type_type_ptr).typ as *mut PyRwLock<PyObjectRc<PyClass>>
-                    as *mut UninitRef<PyClass>,
+                &mut (*type_type_ptr).typ as *mut PyRwLock<PyObjectRc<PyType>>
+                    as *mut UninitRef<PyType>,
                 PyRwLock::new(type_type),
             );
 
-            let type_type = PyClassRef::from_obj_unchecked(PyObjectRef::from_raw(type_type_ptr));
-            let object_type =
-                PyClassRef::from_obj_unchecked(PyObjectRef::from_raw(object_type_ptr));
+            let type_type = PyTypeRef::from_obj_unchecked(PyObjectRef::from_raw(type_type_ptr));
+            let object_type = PyTypeRef::from_obj_unchecked(PyObjectRef::from_raw(object_type_ptr));
 
             (*type_type_ptr).payload.mro = vec![object_type.clone()];
             (*type_type_ptr).payload.bases = vec![object_type.clone()];

--- a/vm/src/version.rs
+++ b/vm/src/version.rs
@@ -46,7 +46,7 @@ impl VersionInfo {
     };
     #[pyslot]
     fn tp_new(
-        _cls: crate::obj::objtype::PyClassRef,
+        _cls: crate::obj::objtype::PyTypeRef,
         _args: crate::function::PyFuncArgs,
         vm: &crate::VirtualMachine,
     ) -> crate::pyobject::PyResult {

--- a/wasm/lib/src/browser_module.rs
+++ b/wasm/lib/src/browser_module.rs
@@ -7,7 +7,7 @@ use wasm_bindgen_futures::{future_to_promise, JsFuture};
 use rustpython_vm::common::rc::PyRc;
 use rustpython_vm::function::{OptionalArg, PyFuncArgs};
 use rustpython_vm::import::import_file;
-use rustpython_vm::obj::{objdict::PyDictRef, objstr::PyStrRef, objtype::PyClassRef};
+use rustpython_vm::obj::{objdict::PyDictRef, objstr::PyStrRef, objtype::PyTypeRef};
 use rustpython_vm::pyobject::{
     BorrowValue, IntoPyObject, PyCallable, PyClassImpl, PyObject, PyObjectRef, PyRef, PyResult,
     PyValue,
@@ -163,7 +163,7 @@ pub struct PyPromise {
 pub type PyPromiseRef = PyRef<PyPromise>;
 
 impl PyValue for PyPromise {
-    fn class(vm: &VirtualMachine) -> PyClassRef {
+    fn class(vm: &VirtualMachine) -> PyTypeRef {
         vm.class("browser", "Promise")
     }
 }
@@ -259,7 +259,7 @@ struct Document {
 }
 
 impl PyValue for Document {
-    fn class(vm: &VirtualMachine) -> PyClassRef {
+    fn class(vm: &VirtualMachine) -> PyTypeRef {
         vm.class("browser", "Document")
     }
 }
@@ -285,7 +285,7 @@ struct Element {
 }
 
 impl PyValue for Element {
-    fn class(vm: &VirtualMachine) -> PyClassRef {
+    fn class(vm: &VirtualMachine) -> PyTypeRef {
         vm.class("browser", "Element")
     }
 }

--- a/wasm/lib/src/js_module.rs
+++ b/wasm/lib/src/js_module.rs
@@ -2,7 +2,7 @@ use js_sys::{Array, Object, Reflect};
 use rustpython_vm::common::rc::PyRc;
 use rustpython_vm::exceptions::PyBaseExceptionRef;
 use rustpython_vm::function::Args;
-use rustpython_vm::obj::{objfloat::PyFloatRef, objstr::PyStrRef, objtype::PyClassRef};
+use rustpython_vm::obj::{objfloat::PyFloatRef, objstr::PyStrRef, objtype::PyTypeRef};
 use rustpython_vm::pyobject::{
     BorrowValue, PyClassImpl, PyObjectRef, PyRef, PyResult, PyValue, TryFromObject,
 };
@@ -42,7 +42,7 @@ unsafe impl Send for PyJsValue {}
 unsafe impl Sync for PyJsValue {}
 
 impl PyValue for PyJsValue {
-    fn class(vm: &VirtualMachine) -> PyClassRef {
+    fn class(vm: &VirtualMachine) -> PyTypeRef {
         vm.class("_js", "JsValue")
     }
 }


### PR DESCRIPTION
We referes this type everywhere `type` both in Python and internal code.

this seems giving confusion for new comers and doesn't seem giving any advantage.

Let me know if I am missing some benefits from this.