### PR TITLE
tuple optimization

### DIFF
--- a/derive/src/pystructseq.rs
+++ b/derive/src/pystructseq.rs
@@ -36,7 +36,7 @@ pub(crate) fn impl_pystruct_sequence(
                     self.#field_names,
                     vm,
                 )),*];
-                unsafe { ::rustpython_vm::obj::objtuple::PyTuple::_new(items) }
+                items.into_boxed_slice().into()
             }
         }
     };

--- a/derive/src/pystructseq.rs
+++ b/derive/src/pystructseq.rs
@@ -36,7 +36,7 @@ pub(crate) fn impl_pystruct_sequence(
                     self.#field_names,
                     vm,
                 )),*];
-                items.into_boxed_slice().into()
+                ::rustpython_vm::obj::objtuple::PyTuple::_new(items.into_boxed_slice())
             }
         }
     };

--- a/derive/src/pystructseq.rs
+++ b/derive/src/pystructseq.rs
@@ -36,7 +36,7 @@ pub(crate) fn impl_pystruct_sequence(
                     self.#field_names,
                     vm,
                 )),*];
-                items.into()
+                unsafe { ::rustpython_vm::obj::objtuple::PyTuple::_new(items) }
             }
         }
     };

--- a/vm/src/exceptions.rs
+++ b/vm/src/exceptions.rs
@@ -57,7 +57,7 @@ impl PyBaseException {
             cause: PyRwLock::new(None),
             context: PyRwLock::new(None),
             suppress_context: AtomicCell::new(false),
-            args: PyRwLock::new(PyTuple::from(args).into_ref(vm)),
+            args: PyRwLock::new(PyTupleRef::with_elements(args, &vm.ctx)),
         }
     }
 
@@ -68,7 +68,7 @@ impl PyBaseException {
 
     #[pymethod(name = "__init__")]
     fn init(&self, args: PyFuncArgs, vm: &VirtualMachine) -> PyResult<()> {
-        *self.args.write() = PyTuple::from(args.args).into_ref(vm);
+        *self.args.write() = PyTupleRef::with_elements(args.args, &vm.ctx);
         Ok(())
     }
 
@@ -80,7 +80,7 @@ impl PyBaseException {
     #[pyproperty(setter)]
     fn set_args(&self, args: PyIterable, vm: &VirtualMachine) -> PyResult<()> {
         let args = args.iter(vm)?.collect::<PyResult<Vec<_>>>()?;
-        *self.args.write() = PyTuple::from(args).into_ref(vm);
+        *self.args.write() = PyTupleRef::with_elements(args, &vm.ctx);
         Ok(())
     }
 

--- a/vm/src/obj/objbytearray.rs
+++ b/vm/src/obj/objbytearray.rs
@@ -17,7 +17,7 @@ use crate::byteslike::PyBytesLike;
 use crate::common::cell::{PyRwLock, PyRwLockReadGuard, PyRwLockWriteGuard};
 use crate::function::{OptionalArg, OptionalOption};
 use crate::obj::objbytes::PyBytes;
-use crate::obj::objtuple::PyTuple;
+use crate::obj::objtuple::PyTupleRef;
 use crate::pyobject::{
     BorrowValue, Either, IdProtocol, IntoPyObject, PyClassImpl, PyComparisonValue, PyContext,
     PyIterable, PyObjectRef, PyRef, PyResult, PyValue, TryFromObject,
@@ -533,14 +533,21 @@ impl PyByteArray {
     }
 
     #[pymethod(magic)]
-    fn reduce_ex(zelf: PyRef<Self>, _proto: usize, vm: &VirtualMachine) -> (PyClassRef, PyTuple) {
+    fn reduce_ex(
+        zelf: PyRef<Self>,
+        _proto: usize,
+        vm: &VirtualMachine,
+    ) -> (PyClassRef, PyTupleRef) {
         Self::reduce(zelf, vm)
     }
 
     #[pymethod(magic)]
-    fn reduce(zelf: PyRef<Self>, vm: &VirtualMachine) -> (PyClassRef, PyTuple) {
+    fn reduce(zelf: PyRef<Self>, vm: &VirtualMachine) -> (PyClassRef, PyTupleRef) {
         let bytes = PyBytes::from(zelf.borrow_value().elements.clone()).into_pyobject(vm);
-        (Self::class(vm), PyTuple::from(vec![bytes]))
+        (
+            Self::class(vm),
+            PyTupleRef::with_elements(vec![bytes], &vm.ctx),
+        )
     }
 }
 

--- a/vm/src/obj/objbytes.rs
+++ b/vm/src/obj/objbytes.rs
@@ -15,7 +15,7 @@ use crate::bytesinner::{
 };
 use crate::byteslike::PyBytesLike;
 use crate::function::{OptionalArg, OptionalOption};
-use crate::obj::objtuple::{PyTuple, PyTupleRef};
+use crate::obj::objtuple::PyTupleRef;
 use crate::pyobject::{
     BorrowValue, Either, IntoPyObject, PyClassImpl, PyComparisonValue, PyContext, PyIterable,
     PyObjectRef, PyRef, PyResult, PyValue, TryFromObject,
@@ -452,7 +452,7 @@ impl PyBytes {
             .iter()
             .map(|x| x.into_pyobject(vm))
             .collect();
-        PyTuple::from(param).into_ref(vm)
+        PyTupleRef::with_elements(param, &vm.ctx)
     }
 }
 

--- a/vm/src/obj/objlist.rs
+++ b/vm/src/obj/objlist.rs
@@ -17,7 +17,7 @@ use crate::bytesinner;
 use crate::common::cell::{PyRwLock, PyRwLockReadGuard, PyRwLockWriteGuard};
 use crate::function::OptionalArg;
 use crate::pyobject::{
-    BorrowValue, PyClassImpl, PyComparisonValue, PyContext, PyIterable, PyObjectRef, PyRef,
+    BorrowValue, Either, PyClassImpl, PyComparisonValue, PyContext, PyIterable, PyObjectRef, PyRef,
     PyResult, PyValue, TryFromObject, TypeProtocol,
 };
 use crate::sequence::{self, SimpleSeq};
@@ -192,7 +192,12 @@ impl PyList {
 
     #[pymethod(name = "__getitem__")]
     fn getitem(zelf: PyRef<Self>, needle: PyObjectRef, vm: &VirtualMachine) -> PyResult {
-        get_item(vm, zelf.as_object(), &zelf.borrow_value(), needle)
+        Ok(
+            match get_item(vm, zelf.as_object(), &zelf.borrow_value(), needle)? {
+                Either::A(obj) => obj,
+                Either::B(vec) => vm.ctx.new_list(vec),
+            },
+        )
     }
 
     #[pymethod(name = "__iter__")]

--- a/vm/src/obj/objrange.rs
+++ b/vm/src/obj/objrange.rs
@@ -6,7 +6,6 @@ use num_traits::{One, Signed, Zero};
 use super::objint::{PyInt, PyIntRef};
 use super::objiter;
 use super::objslice::{PySlice, PySliceRef};
-use super::objtuple::PyTuple;
 use super::objtype::PyClassRef;
 
 use crate::common::hash::PyHash;
@@ -244,12 +243,12 @@ impl PyRange {
     }
 
     #[pymethod(name = "__reduce__")]
-    fn reduce(&self, vm: &VirtualMachine) -> (PyClassRef, PyTuple) {
+    fn reduce(&self, vm: &VirtualMachine) -> (PyClassRef, PyObjectRef) {
         let range_paramters: Vec<PyObjectRef> = vec![&self.start, &self.stop, &self.step]
             .iter()
             .map(|x| x.as_object().clone())
             .collect();
-        let range_paramters_tuple = PyTuple::from(range_paramters);
+        let range_paramters_tuple = vm.ctx.new_tuple(range_paramters);
         (vm.ctx.types.range_type.clone(), range_paramters_tuple)
     }
 

--- a/vm/src/obj/objsequence.rs
+++ b/vm/src/obj/objsequence.rs
@@ -481,18 +481,14 @@ pub fn get_item(
             sequence.lease_class().name
         ))
     })?;
-    let items = if sequence.payload::<PyList>().is_some() {
+    let items = if sequence.payload_is::<PyList>() {
         PyObject::new(
             PyList::from(elements.get_slice_items(vm, slice)?),
             sequence.class(),
             None,
         )
-    } else if sequence.payload::<PyTuple>().is_some() {
-        PyObject::new(
-            PyTuple::from(elements.get_slice_items(vm, slice)?),
-            sequence.class(),
-            None,
-        )
+    } else if sequence.payload_is::<PyTuple>() {
+        vm.ctx.new_tuple(elements.get_slice_items(vm, slice)?)
     } else {
         panic!("sequence get_item called for non-sequence")
     };

--- a/vm/src/obj/objsequence.rs
+++ b/vm/src/obj/objsequence.rs
@@ -4,12 +4,10 @@ use num_bigint::BigInt;
 use num_traits::{One, Signed, ToPrimitive, Zero};
 
 use super::objint::{PyInt, PyIntRef};
-use super::objlist::PyList;
 use super::objsingletons::PyNone;
 use super::objslice::{PySlice, PySliceRef};
-use super::objtuple::PyTuple;
 use crate::function::OptionalArg;
-use crate::pyobject::{BorrowValue, PyObject, PyObjectRef, PyResult, TryFromObject, TypeProtocol};
+use crate::pyobject::{BorrowValue, Either, PyObjectRef, PyResult, TryFromObject, TypeProtocol};
 use crate::vm::VirtualMachine;
 
 pub trait PySliceableSequenceMut {
@@ -465,34 +463,23 @@ pub fn get_item(
     sequence: &PyObjectRef,
     elements: &[PyObjectRef],
     subscript: PyObjectRef,
-) -> PyResult {
+) -> PyResult<Either<PyObjectRef, Vec<PyObjectRef>>> {
     if let Some(i) = subscript.payload::<PyInt>() {
         let value = i.borrow_value().to_isize().ok_or_else(|| {
             vm.new_index_error("cannot fit 'int' into an index-sized integer".to_owned())
         })?;
         let pos_index = get_pos(value, elements.len())
             .ok_or_else(|| vm.new_index_error("Index out of bounds!".to_owned()))?;
-        return Ok(elements[pos_index].clone());
-    }
-
-    let slice = subscript.payload::<PySlice>().ok_or_else(|| {
-        vm.new_type_error(format!(
-            "{} indices must be integers or slices",
-            sequence.lease_class().name
-        ))
-    })?;
-    let items = if sequence.payload_is::<PyList>() {
-        PyObject::new(
-            PyList::from(elements.get_slice_items(vm, slice)?),
-            sequence.class(),
-            None,
-        )
-    } else if sequence.payload_is::<PyTuple>() {
-        vm.ctx.new_tuple(elements.get_slice_items(vm, slice)?)
+        Ok(Either::A(elements[pos_index].clone()))
     } else {
-        panic!("sequence get_item called for non-sequence")
-    };
-    Ok(items)
+        let slice = subscript.payload::<PySlice>().ok_or_else(|| {
+            vm.new_type_error(format!(
+                "{} indices must be integers or slices",
+                sequence.lease_class().name
+            ))
+        })?;
+        Ok(Either::B(elements.get_slice_items(vm, slice)?))
+    }
 }
 
 //Check if given arg could be used with PySliceableSequence.get_slice_range()

--- a/vm/src/obj/objtuple.rs
+++ b/vm/src/obj/objtuple.rs
@@ -30,12 +30,6 @@ impl fmt::Debug for PyTuple {
     }
 }
 
-impl From<Box<[PyObjectRef]>> for PyTuple {
-    fn from(elements: Box<[PyObjectRef]>) -> Self {
-        PyTuple { elements }
-    }
-}
-
 impl<'a> BorrowValue<'a> for PyTuple {
     type Borrowed = &'a [PyObjectRef];
 
@@ -93,6 +87,13 @@ pub(crate) fn get_value(obj: &PyObjectRef) -> &[PyObjectRef] {
 
 #[pyimpl(flags(BASETYPE), with(Hashable, Comparable))]
 impl PyTuple {
+    /// Creating a new tuple with given boxed slice.
+    /// NOTE: for usual case, you probably want to use PyTupleRef::with_elements.
+    /// Calling this function implies trying micro optimization for non-zero-sized tuple.
+    pub(crate) fn _new(elements: Box<[PyObjectRef]>) -> Self {
+        Self { elements }
+    }
+
     #[pymethod(name = "__add__")]
     fn add(
         zelf: PyRef<Self>,

--- a/vm/src/obj/objtuple.rs
+++ b/vm/src/obj/objtuple.rs
@@ -6,7 +6,7 @@ use super::objsequence::get_item;
 use super::objtype::PyClassRef;
 use crate::function::OptionalArg;
 use crate::pyobject::{
-    self, BorrowValue, IdProtocol, IntoPyObject,
+    self, BorrowValue, Either, IdProtocol, IntoPyObject,
     PyArithmaticValue::{self, *},
     PyClassImpl, PyComparisonValue, PyContext, PyObjectRef, PyRef, PyResult, PyValue,
 };
@@ -168,7 +168,12 @@ impl PyTuple {
 
     #[pymethod(name = "__getitem__")]
     fn getitem(zelf: PyRef<Self>, needle: PyObjectRef, vm: &VirtualMachine) -> PyResult {
-        get_item(vm, zelf.as_object(), &zelf.elements, needle)
+        Ok(
+            match get_item(vm, zelf.as_object(), &zelf.elements, needle)? {
+                Either::A(obj) => obj,
+                Either::B(vec) => vm.ctx.new_tuple(vec),
+            },
+        )
     }
 
     #[pymethod(name = "index")]

--- a/vm/src/obj/objtype.rs
+++ b/vm/src/obj/objtype.rs
@@ -184,7 +184,7 @@ impl PyClass {
     #[pyproperty(name = "__mro__")]
     fn get_mro(zelf: PyRef<Self>) -> PyTuple {
         let elements: Vec<PyObjectRef> = zelf.iter_mro().map(|x| x.as_object().clone()).collect();
-        PyTuple::from(elements)
+        unsafe { PyTuple::_new(elements) }
     }
 
     #[pyproperty(magic)]

--- a/vm/src/obj/objtype.rs
+++ b/vm/src/obj/objtype.rs
@@ -184,7 +184,7 @@ impl PyClass {
     #[pyproperty(name = "__mro__")]
     fn get_mro(zelf: PyRef<Self>) -> PyTuple {
         let elements: Vec<PyObjectRef> = zelf.iter_mro().map(|x| x.as_object().clone()).collect();
-        unsafe { PyTuple::_new(elements) }
+        elements.into_boxed_slice().into()
     }
 
     #[pyproperty(magic)]

--- a/vm/src/obj/objtype.rs
+++ b/vm/src/obj/objtype.rs
@@ -184,7 +184,7 @@ impl PyClass {
     #[pyproperty(name = "__mro__")]
     fn get_mro(zelf: PyRef<Self>) -> PyTuple {
         let elements: Vec<PyObjectRef> = zelf.iter_mro().map(|x| x.as_object().clone()).collect();
-        elements.into_boxed_slice().into()
+        PyTuple::_new(elements.into_boxed_slice())
     }
 
     #[pyproperty(magic)]

--- a/vm/src/pyobject.rs
+++ b/vm/src/pyobject.rs
@@ -140,7 +140,7 @@ impl PyContext {
         let false_value = create_object(PyInt::from(0), &types.bool_type);
 
         let empty_tuple = create_object(
-            PyTuple::from(Vec::new().into_boxed_slice()),
+            PyTuple::_new(Vec::new().into_boxed_slice()),
             &types.tuple_type,
         );
 

--- a/vm/src/pyobject.rs
+++ b/vm/src/pyobject.rs
@@ -260,9 +260,7 @@ impl PyContext {
     }
 
     pub fn new_dict(&self) -> PyDictRef {
-        PyObject::new(PyDict::default(), self.types.dict_type.clone(), None)
-            .downcast()
-            .unwrap()
+        PyRef::new_ref(PyDict::default(), self.types.dict_type.clone(), None)
     }
 
     pub fn new_class(&self, name: &str, base: PyClassRef, slots: PyClassSlots) -> PyClassRef {
@@ -345,13 +343,11 @@ impl PyContext {
     }
 
     pub fn new_code_object(&self, code: bytecode::CodeObject) -> PyCodeRef {
-        PyObject::new(
+        PyRef::new_ref(
             objcode::PyCode::new(code),
             self.types.code_type.clone(),
             None,
         )
-        .downcast()
-        .unwrap()
     }
 
     pub fn new_pyfunction(

--- a/vm/src/pyobject.rs
+++ b/vm/src/pyobject.rs
@@ -139,7 +139,7 @@ impl PyContext {
         let true_value = create_object(PyInt::from(1), &types.bool_type);
         let false_value = create_object(PyInt::from(0), &types.bool_type);
 
-        let empty_tuple = create_object(PyTuple::from(vec![]), &types.tuple_type);
+        let empty_tuple = create_object(unsafe { PyTuple::_new(Vec::new()) }, &types.tuple_type);
 
         let tp_new_wrapper = create_object(
             PyFuncDef::from(objtype::tp_new_wrapper.into_func()).into_function(),
@@ -246,11 +246,7 @@ impl PyContext {
     }
 
     pub fn new_tuple(&self, elements: Vec<PyObjectRef>) -> PyObjectRef {
-        if elements.is_empty() {
-            self.empty_tuple.clone().into_object()
-        } else {
-            PyObject::new(PyTuple::from(elements), self.types.tuple_type.clone(), None)
-        }
+        PyTupleRef::with_elements(elements, self).into_object()
     }
 
     pub fn new_list(&self, elements: Vec<PyObjectRef>) -> PyObjectRef {

--- a/vm/src/pyobject.rs
+++ b/vm/src/pyobject.rs
@@ -139,7 +139,10 @@ impl PyContext {
         let true_value = create_object(PyInt::from(1), &types.bool_type);
         let false_value = create_object(PyInt::from(0), &types.bool_type);
 
-        let empty_tuple = create_object(unsafe { PyTuple::_new(Vec::new()) }, &types.tuple_type);
+        let empty_tuple = create_object(
+            PyTuple::from(Vec::new().into_boxed_slice()),
+            &types.tuple_type,
+        );
 
         let tp_new_wrapper = create_object(
             PyFuncDef::from(objtype::tp_new_wrapper.into_func()).into_function(),

--- a/vm/src/stdlib/itertools.rs
+++ b/vm/src/stdlib/itertools.rs
@@ -14,7 +14,7 @@ mod decl {
     use crate::obj::objbool;
     use crate::obj::objint::{self, PyInt, PyIntRef};
     use crate::obj::objiter::{call_next, get_all, get_iter, get_next_object, new_stop_iteration};
-    use crate::obj::objtuple::PyTuple;
+    use crate::obj::objtuple::PyTupleRef;
     use crate::obj::objtype::{self, PyClassRef};
     use crate::pyobject::{
         BorrowValue, IdProtocol, IntoPyRef, PyCallable, PyClassImpl, PyObjectRc, PyObjectRef,
@@ -988,7 +988,7 @@ mod decl {
             iterable: PyObjectRef,
             n: OptionalArg<usize>,
             vm: &VirtualMachine,
-        ) -> PyResult<PyRef<PyTuple>> {
+        ) -> PyResult<PyTupleRef> {
             let n = n.unwrap_or(2);
 
             let copyable = if iterable.lease_class().has_attr("__copy__") {
@@ -1003,7 +1003,7 @@ mod decl {
                 tee_vec.push(vm.call_method(&copyable, "__copy__", no_args)?);
             }
 
-            Ok(PyTuple::from(tee_vec).into_ref(vm))
+            Ok(PyTupleRef::with_elements(tee_vec, &vm.ctx))
         }
 
         #[pymethod(name = "__copy__")]
@@ -1104,18 +1104,17 @@ mod decl {
             }
 
             let idxs = self.idxs.write();
-
-            let res = PyTuple::from(
+            let res = vm.ctx.new_tuple(
                 pools
                     .iter()
                     .zip(idxs.iter())
                     .map(|(pool, idx)| pool[*idx].clone())
-                    .collect::<Vec<PyObjectRef>>(),
+                    .collect(),
             );
 
             self.update_idxs(idxs);
 
-            Ok(res.into_object(vm))
+            Ok(res)
         }
 
         fn update_idxs(&self, mut idxs: PyRwLockWriteGuard<'_, Vec<usize>>) {
@@ -1212,12 +1211,12 @@ mod decl {
                 return Ok(vm.ctx.new_tuple(vec![]));
             }
 
-            let res = PyTuple::from(
+            let res = vm.ctx.new_tuple(
                 self.indices
                     .read()
                     .iter()
                     .map(|&i| self.pool[i].clone())
-                    .collect::<Vec<PyObjectRef>>(),
+                    .collect(),
             );
 
             let mut indices = self.indices.write();
@@ -1243,7 +1242,7 @@ mod decl {
                 }
             }
 
-            Ok(res.into_object(vm))
+            Ok(res)
         }
     }
 


### PR DESCRIPTION
- Reuse empty tuple singleton
- Remove typecheck from objsequence::get_item
- tuple internal uses `Box<[PyObjectRef]>` instead of vec