### PR TITLE
Document browser module availability in WASM Demo 

### DIFF
--- a/wasm/demo/src/index.ejs
+++ b/wasm/demo/src/index.ejs
@@ -67,6 +67,13 @@
             </li>
         </ul>
 
+        <p>
+            Limited Interaction with browser is possible from Python by using
+            the <code>browser</code> module. Browser APIs such as
+            <code>alert()</code>, <code>confirm()</code>, <code>prompt()</code>
+            and <code>fetch()</code> are included in the module.
+        </p>
+
         <a href="https://github.com/RustPython/RustPython">
             <img
                 style="position: absolute; top: 0; right: 0; border: 0;"


### PR DESCRIPTION
I couldn't find full documentation for the browser module anywhere where users could be pointed at but was able to scratch up some basic functionality by reading the related python and Rust code as well as using using `dir(browser)` in the RustPython demo.

Need for this came from the fact that I was running scripts that used the builtin `input()` function. Browsers don't have `stdin` that could be plugged in nicely to support `input()` command but I was able to monkey patch it in the end with:
```
import browser
input = browser.prompt
```

which worked just fine with my use cases. Just documenting the fact that the module exists can already save good amount of time from others.