### PR TITLE
Don't panic on #[pyattr] use foo::bar::baz;

### DIFF
--- a/derive/src/util.rs
+++ b/derive/src/util.rs
@@ -467,7 +467,6 @@ where
         UseTree::Path(path) => match &*path.tree {
             UseTree::Name(name) => f(&name.ident, true)?,
             UseTree::Rename(rename) => f(&rename.rename, true)?,
-            UseTree::Path(_) => unreachable!(),
             other => iter_use_tree_idents(other, &mut f)?,
         },
         other => iter_use_tree_idents(other, &mut f)?,


### PR DESCRIPTION
I got this when I did:

```rust
#[pyattr]
use super::foo::BAR as BAZ;
```
So I think it makes sense not to panic here