### PR TITLE
Make the FromArgs derive less verbose

### DIFF
--- a/derive/src/from_args.rs
+++ b/derive/src/from_args.rs
@@ -131,7 +131,7 @@ fn generate_field(field: &Field) -> Result<TokenStream2, Diagnostic> {
     if let Some(name) = name {
         if name.to_string().starts_with("_phantom") {
             return Ok(quote! {
-                #name: std::marker::PhantomData,
+                #name: ::std::marker::PhantomData,
             });
         }
     }
@@ -205,7 +205,7 @@ pub fn impl_from_args(input: DeriveInput) -> Result<TokenStream2, Diagnostic> {
             fn from_args(
                 vm: &::rustpython_vm::VirtualMachine,
                 args: &mut ::rustpython_vm::function::PyFuncArgs
-            ) -> Result<Self, ::rustpython_vm::function::ArgumentError> {
+            ) -> ::std::result::Result<Self, ::rustpython_vm::function::ArgumentError> {
                 Ok(#name { #fields })
             }
         }

--- a/derive/src/pymodule.rs
+++ b/derive/src/pymodule.rs
@@ -63,7 +63,7 @@ pub fn impl_pymodule(
         },
         parse_quote! {
             pub(crate) fn extend_module(
-                vm: &::rustpython_vm::vm::VirtualMachine,
+                vm: &::rustpython_vm::VirtualMachine,
                 module: &::rustpython_vm::pyobject::PyObjectRef,
             ) {
                 #module_extend_items
@@ -72,7 +72,7 @@ pub fn impl_pymodule(
         parse_quote! {
             #[allow(dead_code)]
             pub(crate) fn make_module(
-                vm: &::rustpython_vm::vm::VirtualMachine
+                vm: &::rustpython_vm::VirtualMachine
             ) -> ::rustpython_vm::pyobject::PyObjectRef {
                 let module = vm.new_module(MODULE_NAME, vm.ctx.new_dict());
                 extend_module(vm, &module);

--- a/vm/src/anystr.rs
+++ b/vm/src/anystr.rs
@@ -15,9 +15,9 @@ where
     S: ?Sized + AnyStr<'a, E>,
     E: Copy,
 {
-    #[pyarg(positional_or_keyword, default = "None")]
+    #[pyarg(any, default)]
     sep: Option<T>,
-    #[pyarg(positional_or_keyword, default = "-1")]
+    #[pyarg(any, default = "-1")]
     maxsplit: isize,
     _phantom1: std::marker::PhantomData<&'a S>,
     _phantom2: std::marker::PhantomData<E>,
@@ -45,13 +45,13 @@ where
 
 #[derive(FromArgs)]
 pub struct SplitLinesArgs {
-    #[pyarg(positional_or_keyword, default = "false")]
+    #[pyarg(any, default = "false")]
     pub keepends: bool,
 }
 
 #[derive(FromArgs)]
 pub struct ExpandTabsArgs {
-    #[pyarg(positional_or_keyword, default = "8")]
+    #[pyarg(any, default = "8")]
     tabsize: isize,
 }
 
@@ -63,11 +63,11 @@ impl ExpandTabsArgs {
 
 #[derive(FromArgs)]
 pub struct StartsEndsWithArgs {
-    #[pyarg(positional_only, optional = false)]
+    #[pyarg(positional)]
     affix: PyObjectRef,
-    #[pyarg(positional_only, default = "None")]
+    #[pyarg(positional, default)]
     start: Option<PyIntRef>,
-    #[pyarg(positional_only, default = "None")]
+    #[pyarg(positional, default)]
     end: Option<PyIntRef>,
 }
 

--- a/vm/src/builtins.rs
+++ b/vm/src/builtins.rs
@@ -107,17 +107,17 @@ mod decl {
     #[derive(FromArgs)]
     #[allow(dead_code)]
     struct CompileArgs {
-        #[pyarg(positional_only, optional = false)]
+        #[pyarg(positional)]
         source: Either<PyStrRef, PyBytesRef>,
-        #[pyarg(positional_only, optional = false)]
+        #[pyarg(positional)]
         filename: PyStrRef,
-        #[pyarg(positional_only, optional = false)]
+        #[pyarg(positional)]
         mode: PyStrRef,
-        #[pyarg(positional_or_keyword, optional = true)]
+        #[pyarg(any, optional)]
         flags: OptionalArg<PyIntRef>,
-        #[pyarg(positional_or_keyword, optional = true)]
+        #[pyarg(any, optional)]
         dont_inherit: OptionalArg<bool>,
-        #[pyarg(positional_or_keyword, optional = true)]
+        #[pyarg(any, optional)]
         optimize: OptionalArg<PyIntRef>,
     }
 
@@ -188,10 +188,10 @@ mod decl {
     #[cfg(feature = "rustpython-compiler")]
     #[derive(FromArgs)]
     struct ScopeArgs {
-        #[pyarg(positional_or_keyword, default = "None")]
+        #[pyarg(any, default)]
         globals: Option<PyDictRef>,
         // TODO: support any mapping for `locals`
-        #[pyarg(positional_or_keyword, default = "None")]
+        #[pyarg(any, default)]
         locals: Option<PyDictRef>,
     }
 
@@ -669,13 +669,13 @@ mod decl {
 
     #[derive(Debug, Default, FromArgs)]
     pub struct PrintOptions {
-        #[pyarg(keyword_only, default = "None")]
+        #[pyarg(named, default)]
         sep: Option<PyStrRef>,
-        #[pyarg(keyword_only, default = "None")]
+        #[pyarg(named, default)]
         end: Option<PyStrRef>,
-        #[pyarg(keyword_only, default = "IntoPyBool::FALSE")]
+        #[pyarg(named, default = "IntoPyBool::FALSE")]
         flush: IntoPyBool,
-        #[pyarg(keyword_only, default = "None")]
+        #[pyarg(named, default)]
         file: Option<PyObjectRef>,
     }
 

--- a/vm/src/bytesinner.rs
+++ b/vm/src/bytesinner.rs
@@ -64,11 +64,11 @@ impl TryFromObject for PyBytesInner {
 
 #[derive(FromArgs)]
 pub struct ByteInnerNewOptions {
-    #[pyarg(positional_or_keyword, optional = true)]
+    #[pyarg(any, optional)]
     source: OptionalArg<PyObjectRef>,
-    #[pyarg(positional_or_keyword, optional = true)]
+    #[pyarg(any, optional)]
     encoding: OptionalArg<PyStrRef>,
-    #[pyarg(positional_or_keyword, optional = true)]
+    #[pyarg(any, optional)]
     errors: OptionalArg<PyStrRef>,
 }
 
@@ -155,11 +155,11 @@ impl ByteInnerNewOptions {
 
 #[derive(FromArgs)]
 pub struct ByteInnerFindOptions {
-    #[pyarg(positional_only, optional = false)]
+    #[pyarg(positional)]
     sub: Either<PyBytesInner, PyIntRef>,
-    #[pyarg(positional_only, default = "None")]
+    #[pyarg(positional, default)]
     start: Option<PyIntRef>,
-    #[pyarg(positional_only, default = "None")]
+    #[pyarg(positional, default)]
     end: Option<PyIntRef>,
 }
 
@@ -180,9 +180,9 @@ impl ByteInnerFindOptions {
 
 #[derive(FromArgs)]
 pub struct ByteInnerPaddingOptions {
-    #[pyarg(positional_only, optional = false)]
+    #[pyarg(positional)]
     width: isize,
-    #[pyarg(positional_only, optional = true)]
+    #[pyarg(positional, optional)]
     fillchar: OptionalArg<PyObjectRef>,
 }
 
@@ -207,9 +207,9 @@ impl ByteInnerPaddingOptions {
 
 #[derive(FromArgs)]
 pub struct ByteInnerTranslateOptions {
-    #[pyarg(positional_only, optional = false)]
+    #[pyarg(positional)]
     table: Either<PyBytesInner, PyNoneRef>,
-    #[pyarg(positional_or_keyword, optional = true)]
+    #[pyarg(any, optional)]
     delete: OptionalArg<PyBytesInner>,
 }
 
@@ -1190,9 +1190,9 @@ impl<'s> AnyStr<'s, u8> for [u8] {
 
 #[derive(FromArgs)]
 pub struct DecodeArgs {
-    #[pyarg(positional_or_keyword, default = "None")]
+    #[pyarg(any, default)]
     encoding: Option<PyStrRef>,
-    #[pyarg(positional_or_keyword, default = "None")]
+    #[pyarg(any, default)]
     errors: Option<PyStrRef>,
 }
 

--- a/vm/src/function.rs
+++ b/vm/src/function.rs
@@ -244,6 +244,23 @@ pub trait FromArgs: Sized {
     fn from_args(vm: &VirtualMachine, args: &mut PyFuncArgs) -> Result<Self, ArgumentError>;
 }
 
+pub trait FromArgOptional {
+    type Inner: TryFromObject;
+    fn from_inner(x: Self::Inner) -> Self;
+}
+impl<T: TryFromObject> FromArgOptional for OptionalArg<T> {
+    type Inner = T;
+    fn from_inner(x: T) -> Self {
+        Self::Present(x)
+    }
+}
+impl<T: TryFromObject> FromArgOptional for T {
+    type Inner = Self;
+    fn from_inner(x: Self) -> Self {
+        x
+    }
+}
+
 /// A map of keyword arguments to their values.
 ///
 /// A built-in function with a `KwArgs` parameter is analagous to a Python

--- a/vm/src/obj/objcomplex.rs
+++ b/vm/src/obj/objcomplex.rs
@@ -308,9 +308,9 @@ impl Hashable for PyComplex {
 
 #[derive(FromArgs)]
 struct ComplexArgs {
-    #[pyarg(positional_or_keyword, default = "None")]
+    #[pyarg(any, default)]
     real: Option<PyObjectRef>,
-    #[pyarg(positional_or_keyword, default = "None")]
+    #[pyarg(any, default)]
     imag: Option<PyObjectRef>,
 }
 

--- a/vm/src/obj/objint.rs
+++ b/vm/src/obj/objint.rs
@@ -691,29 +691,29 @@ impl Hashable for PyInt {
 
 #[derive(FromArgs)]
 struct IntOptions {
-    #[pyarg(positional_only, optional = true)]
+    #[pyarg(positional, optional)]
     val_options: OptionalArg<PyObjectRef>,
-    #[pyarg(positional_or_keyword, optional = true)]
+    #[pyarg(any, optional)]
     base: OptionalArg<PyObjectRef>,
 }
 
 #[derive(FromArgs)]
 struct IntFromByteArgs {
-    #[pyarg(positional_or_keyword)]
+    #[pyarg(any)]
     bytes: PyBytesInner,
-    #[pyarg(positional_or_keyword)]
+    #[pyarg(any)]
     byteorder: PyStrRef,
-    #[pyarg(keyword_only, optional = true)]
+    #[pyarg(named, optional)]
     signed: OptionalArg<IntoPyBool>,
 }
 
 #[derive(FromArgs)]
 struct IntToByteArgs {
-    #[pyarg(positional_or_keyword)]
+    #[pyarg(any)]
     length: PyIntRef,
-    #[pyarg(positional_or_keyword)]
+    #[pyarg(any)]
     byteorder: PyStrRef,
-    #[pyarg(keyword_only, optional = true)]
+    #[pyarg(named, optional)]
     signed: OptionalArg<IntoPyBool>,
 }
 

--- a/vm/src/obj/objlist.rs
+++ b/vm/src/obj/objlist.rs
@@ -95,9 +95,9 @@ impl PyList {
 
 #[derive(FromArgs, Default)]
 pub(crate) struct SortOptions {
-    #[pyarg(keyword_only, default = "None")]
+    #[pyarg(named, default)]
     key: Option<PyObjectRef>,
-    #[pyarg(keyword_only, default = "false")]
+    #[pyarg(named, default = "false")]
     reverse: bool,
 }
 

--- a/vm/src/obj/objproperty.rs
+++ b/vm/src/obj/objproperty.rs
@@ -61,13 +61,13 @@ pub type PyPropertyRef = PyRef<PyProperty>;
 
 #[derive(FromArgs)]
 struct PropertyArgs {
-    #[pyarg(positional_or_keyword, default = "None")]
+    #[pyarg(any, default)]
     fget: Option<PyObjectRef>,
-    #[pyarg(positional_or_keyword, default = "None")]
+    #[pyarg(any, default)]
     fset: Option<PyObjectRef>,
-    #[pyarg(positional_or_keyword, default = "None")]
+    #[pyarg(any, default)]
     fdel: Option<PyObjectRef>,
-    #[pyarg(positional_or_keyword, default = "None")]
+    #[pyarg(any, default)]
     doc: Option<PyObjectRef>,
 }
 

--- a/vm/src/obj/objstr.rs
+++ b/vm/src/obj/objstr.rs
@@ -168,11 +168,11 @@ impl PyStringReverseIterator {
 
 #[derive(FromArgs)]
 struct StrArgs {
-    #[pyarg(positional_or_keyword, optional = true)]
+    #[pyarg(any, optional)]
     object: OptionalArg<PyObjectRef>,
-    #[pyarg(positional_or_keyword, optional = true)]
+    #[pyarg(any, optional)]
     encoding: OptionalArg<PyStrRef>,
-    #[pyarg(positional_or_keyword, optional = true)]
+    #[pyarg(any, optional)]
     errors: OptionalArg<PyStrRef>,
 }
 
@@ -1072,9 +1072,9 @@ impl Comparable for PyStr {
 
 #[derive(FromArgs)]
 struct EncodeArgs {
-    #[pyarg(positional_or_keyword, default = "None")]
+    #[pyarg(any, default)]
     encoding: Option<PyStrRef>,
-    #[pyarg(positional_or_keyword, default = "None")]
+    #[pyarg(any, default)]
     errors: Option<PyStrRef>,
 }
 
@@ -1141,11 +1141,11 @@ type SplitArgs<'a> = anystr::SplitArgs<'a, PyStrRef, str, char>;
 
 #[derive(FromArgs)]
 pub struct FindArgs {
-    #[pyarg(positional_only, optional = false)]
+    #[pyarg(positional)]
     sub: PyStrRef,
-    #[pyarg(positional_only, default = "None")]
+    #[pyarg(positional, default)]
     start: Option<PyIntRef>,
-    #[pyarg(positional_only, default = "None")]
+    #[pyarg(positional, default)]
     end: Option<PyIntRef>,
 }
 

--- a/vm/src/stdlib/binascii.rs
+++ b/vm/src/stdlib/binascii.rs
@@ -114,7 +114,7 @@ mod decl {
 
     #[derive(FromArgs)]
     struct NewlineArg {
-        #[pyarg(keyword_only, default = "true")]
+        #[pyarg(named, default = "true")]
         newline: bool,
     }
 

--- a/vm/src/stdlib/collections.rs
+++ b/vm/src/stdlib/collections.rs
@@ -32,7 +32,7 @@ mod _collections {
 
     #[derive(FromArgs)]
     struct PyDequeOptions {
-        #[pyarg(positional_or_keyword, default = "None")]
+        #[pyarg(any, default)]
         maxlen: Option<usize>,
     }
 

--- a/vm/src/stdlib/faulthandler.rs
+++ b/vm/src/stdlib/faulthandler.rs
@@ -31,9 +31,9 @@ mod decl {
     #[derive(FromArgs)]
     #[allow(unused)]
     struct EnableArgs {
-        #[pyarg(positional_or_keyword, default = "None")]
+        #[pyarg(any, default)]
         file: Option<i64>,
-        #[pyarg(positional_or_keyword, default = "true")]
+        #[pyarg(any, default = "true")]
         all_threads: bool,
     }
 
@@ -45,13 +45,13 @@ mod decl {
     #[derive(FromArgs)]
     #[allow(unused)]
     struct RegisterArgs {
-        #[pyarg(positional_only)]
+        #[pyarg(positional)]
         signum: i64,
-        #[pyarg(positional_or_keyword, default = "None")]
+        #[pyarg(any, default)]
         file: Option<i64>,
-        #[pyarg(positional_or_keyword, default = "true")]
+        #[pyarg(any, default = "true")]
         all_threads: bool,
-        #[pyarg(positional_or_keyword, default = "false")]
+        #[pyarg(any, default = "false")]
         chain: bool,
     }
 

--- a/vm/src/stdlib/io.rs
+++ b/vm/src/stdlib/io.rs
@@ -38,7 +38,7 @@ mod _io {
     pub(super) struct OptionalSize {
         // In a few functions, the default value is -1 rather than None.
         // Make sure the default value doesn't affect compatibility.
-        #[pyarg(positional_only, default = "None")]
+        #[pyarg(positional, default)]
         size: Option<isize>,
     }
 
@@ -607,13 +607,13 @@ mod _io {
 
     #[derive(FromArgs)]
     struct TextIOWrapperArgs {
-        #[pyarg(positional_or_keyword, optional = false)]
+        #[pyarg(any)]
         buffer: PyObjectRef,
-        #[pyarg(positional_or_keyword, default = "None")]
+        #[pyarg(any, default)]
         encoding: Option<PyStrRef>,
-        #[pyarg(positional_or_keyword, default = "None")]
+        #[pyarg(any, default)]
         errors: Option<PyStrRef>,
-        #[pyarg(positional_or_keyword, default = "None")]
+        #[pyarg(any, default)]
         newline: Option<PyStrRef>,
     }
 
@@ -795,7 +795,7 @@ mod _io {
 
     #[derive(FromArgs)]
     struct StringIOArgs {
-        #[pyarg(positional_or_keyword, default = "None")]
+        #[pyarg(any, default)]
         #[allow(dead_code)]
         // TODO: use this
         newline: Option<PyStrRef>,
@@ -1133,17 +1133,17 @@ mod _io {
     #[derive(FromArgs)]
     #[allow(unused)]
     pub struct OpenArgs {
-        #[pyarg(positional_or_keyword, default = "-1")]
+        #[pyarg(any, default = "-1")]
         buffering: isize,
-        #[pyarg(positional_or_keyword, default = "None")]
+        #[pyarg(any, default)]
         encoding: Option<PyStrRef>,
-        #[pyarg(positional_or_keyword, default = "None")]
+        #[pyarg(any, default)]
         errors: Option<PyStrRef>,
-        #[pyarg(positional_or_keyword, default = "None")]
+        #[pyarg(any, default)]
         newline: Option<PyStrRef>,
-        #[pyarg(positional_or_keyword, default = "true")]
+        #[pyarg(any, default = "true")]
         closefd: bool,
-        #[pyarg(positional_or_keyword, default = "None")]
+        #[pyarg(any, default)]
         opener: Option<PyObjectRef>,
     }
     impl Default for OpenArgs {
@@ -1450,13 +1450,13 @@ mod fileio {
 
     #[derive(FromArgs)]
     struct FileIOArgs {
-        #[pyarg(positional_only)]
+        #[pyarg(positional)]
         name: Either<PyStrRef, i64>,
-        #[pyarg(positional_or_keyword, default = "None")]
+        #[pyarg(any, default)]
         mode: Option<PyStrRef>,
-        #[pyarg(positional_or_keyword, default = "true")]
+        #[pyarg(any, default = "true")]
         closefd: bool,
-        #[pyarg(positional_or_keyword, default = "None")]
+        #[pyarg(any, default)]
         opener: Option<PyObjectRef>,
     }
 

--- a/vm/src/stdlib/itertools.rs
+++ b/vm/src/stdlib/itertools.rs
@@ -547,7 +547,7 @@ mod decl {
     #[derive(FromArgs)]
     struct GroupByArgs {
         iterable: PyObjectRef,
-        #[pyarg(positional_or_keyword, optional = true)]
+        #[pyarg(any, optional)]
         key: OptionalOption<PyObjectRef>,
     }
 
@@ -1044,7 +1044,7 @@ mod decl {
 
     #[derive(FromArgs)]
     struct ProductArgs {
-        #[pyarg(keyword_only, optional = true)]
+        #[pyarg(named, optional)]
         repeat: OptionalArg<usize>,
     }
 
@@ -1485,7 +1485,7 @@ mod decl {
 
     #[derive(FromArgs)]
     struct ZiplongestArgs {
-        #[pyarg(keyword_only, optional = true)]
+        #[pyarg(named, optional)]
         fillvalue: OptionalArg<PyObjectRef>,
     }
 

--- a/vm/src/stdlib/math.rs
+++ b/vm/src/stdlib/math.rs
@@ -47,13 +47,13 @@ make_math_func_bool!(math_isnan, is_nan);
 
 #[derive(FromArgs)]
 struct IsCloseArgs {
-    #[pyarg(positional_only, optional = false)]
+    #[pyarg(positional)]
     a: IntoPyFloat,
-    #[pyarg(positional_only, optional = false)]
+    #[pyarg(positional)]
     b: IntoPyFloat,
-    #[pyarg(keyword_only, optional = true)]
+    #[pyarg(named, optional)]
     rel_tol: OptionalArg<IntoPyFloat>,
-    #[pyarg(keyword_only, optional = true)]
+    #[pyarg(named, optional)]
     abs_tol: OptionalArg<IntoPyFloat>,
 }
 

--- a/vm/src/stdlib/os.rs
+++ b/vm/src/stdlib/os.rs
@@ -198,19 +198,19 @@ pub fn errno_err(vm: &VirtualMachine) -> PyBaseExceptionRef {
 #[allow(dead_code)]
 #[derive(FromArgs, Default)]
 pub struct TargetIsDirectory {
-    #[pyarg(keyword_only, default = "false")]
+    #[pyarg(named, default = "false")]
     target_is_directory: bool,
 }
 
 #[derive(FromArgs, Default)]
 pub struct DirFd {
-    #[pyarg(keyword_only, default = "None")]
+    #[pyarg(named, default)]
     dir_fd: Option<PyIntRef>,
 }
 
 #[derive(FromArgs)]
 struct FollowSymlinks {
-    #[pyarg(keyword_only, default = "true")]
+    #[pyarg(named, default = "true")]
     follow_symlinks: bool,
 }
 
@@ -769,11 +769,11 @@ mod _os {
 
     #[derive(FromArgs)]
     struct UtimeArgs {
-        #[pyarg(positional_or_keyword)]
+        #[pyarg(any)]
         path: PyPathLike,
-        #[pyarg(positional_or_keyword, default = "None")]
+        #[pyarg(any, default)]
         times: Option<PyTupleRef>,
-        #[pyarg(keyword_only, default = "None")]
+        #[pyarg(named, default)]
         ns: Option<PyTupleRef>,
         #[pyarg(flatten)]
         _dir_fd: DirFd,
@@ -1913,15 +1913,15 @@ mod posix {
     #[cfg(any(target_os = "linux", target_os = "freebsd", target_os = "macos"))]
     #[derive(FromArgs)]
     pub(super) struct PosixSpawnArgs {
-        #[pyarg(positional_only)]
+        #[pyarg(positional)]
         path: PyPathLike,
-        #[pyarg(positional_only)]
+        #[pyarg(positional)]
         args: PyIterable<PyPathLike>,
-        #[pyarg(positional_only)]
+        #[pyarg(positional)]
         env: PyMapping,
-        #[pyarg(keyword_only, default = "None")]
+        #[pyarg(named, default)]
         file_actions: Option<PyIterable<PyTupleRef>>,
-        #[pyarg(keyword_only, default = "None")]
+        #[pyarg(named, default)]
         setsigdef: Option<PyIterable<i32>>,
     }
 

--- a/vm/src/stdlib/posixsubprocess.rs
+++ b/vm/src/stdlib/posixsubprocess.rs
@@ -43,7 +43,7 @@ macro_rules! gen_args {
     ($($field:ident: $t:ty),*$(,)?) => {
         #[derive(FromArgs)]
         struct ForkExecArgs {
-            $(#[pyarg(positional_only)] $field: $t,)*
+            $(#[pyarg(positional)] $field: $t,)*
         }
     };
 }

--- a/vm/src/stdlib/pystruct.rs
+++ b/vm/src/stdlib/pystruct.rs
@@ -769,7 +769,7 @@ mod _struct {
     #[derive(FromArgs)]
     struct UpdateFromArgs {
         buffer: PyBytesLike,
-        #[pyarg(positional_or_keyword, default = "0")]
+        #[pyarg(any, default = "0")]
         offset: isize,
     }
 

--- a/vm/src/stdlib/socket.rs
+++ b/vm/src/stdlib/socket.rs
@@ -500,18 +500,18 @@ fn socket_inet_ntoa(packed_ip: PyBytesRef, vm: &VirtualMachine) -> PyResult {
 
 #[derive(FromArgs)]
 struct GAIOptions {
-    #[pyarg(positional_only)]
+    #[pyarg(positional)]
     host: Option<PyStrRef>,
-    #[pyarg(positional_only)]
+    #[pyarg(positional)]
     port: Option<Either<PyStrRef, i32>>,
 
-    #[pyarg(positional_only, default = "0")]
+    #[pyarg(positional, default = "0")]
     family: i32,
-    #[pyarg(positional_only, default = "0")]
+    #[pyarg(positional, default = "0")]
     ty: i32,
-    #[pyarg(positional_only, default = "0")]
+    #[pyarg(positional, default = "0")]
     proto: i32,
-    #[pyarg(positional_only, default = "0")]
+    #[pyarg(positional, default = "0")]
     flags: i32,
 }
 

--- a/vm/src/stdlib/ssl.rs
+++ b/vm/src/stdlib/ssl.rs
@@ -153,9 +153,9 @@ fn ssl_enum_certificates(store_name: PyStrRef, vm: &VirtualMachine) -> PyResult<
 
 #[derive(FromArgs)]
 struct Txt2ObjArgs {
-    #[pyarg(positional_or_keyword)]
+    #[pyarg(any)]
     txt: CString,
-    #[pyarg(positional_or_keyword, default = "false")]
+    #[pyarg(any, default = "false")]
     name: bool,
 }
 fn ssl_txt2obj(args: Txt2ObjArgs, vm: &VirtualMachine) -> PyResult<PyNid> {
@@ -482,25 +482,25 @@ impl PySslContext {
 #[derive(FromArgs)]
 // #[allow(dead_code)]
 struct WrapSocketArgs {
-    #[pyarg(positional_or_keyword)]
+    #[pyarg(any)]
     sock: PySocketRef,
-    #[pyarg(positional_or_keyword)]
+    #[pyarg(any)]
     server_side: bool,
-    #[pyarg(positional_or_keyword, default = "None")]
+    #[pyarg(any, default)]
     server_hostname: Option<PyStrRef>,
-    #[pyarg(keyword_only, default = "None")]
+    #[pyarg(named, default)]
     owner: Option<PyObjectRef>,
-    #[pyarg(keyword_only, default = "None")]
+    #[pyarg(named, default)]
     session: Option<PyObjectRef>,
 }
 
 #[derive(FromArgs)]
 struct LoadVerifyLocationsArgs {
-    #[pyarg(positional_or_keyword, default = "None")]
+    #[pyarg(any, default)]
     cafile: Option<CString>,
-    #[pyarg(positional_or_keyword, default = "None")]
+    #[pyarg(any, default)]
     capath: Option<CString>,
-    #[pyarg(positional_or_keyword, default = "None")]
+    #[pyarg(any, default)]
     cadata: Option<Either<PyStrRef, PyBytesLike>>,
 }
 

--- a/vm/src/stdlib/thread.rs
+++ b/vm/src/stdlib/thread.rs
@@ -35,9 +35,9 @@ const TIMEOUT_MAX: f64 = (PY_TIMEOUT_MAX / 1_000_000) as f64;
 
 #[derive(FromArgs)]
 struct AcquireArgs {
-    #[pyarg(positional_or_keyword, default = "true")]
+    #[pyarg(any, default = "true")]
     blocking: bool,
-    #[pyarg(positional_or_keyword, default = "Either::A(-1.0)")]
+    #[pyarg(any, default = "Either::A(-1.0)")]
     timeout: Either<f64, i64>,
 }
 

--- a/vm/src/stdlib/warnings.rs
+++ b/vm/src/stdlib/warnings.rs
@@ -10,11 +10,11 @@ mod _warnings {
 
     #[derive(FromArgs)]
     struct WarnArgs {
-        #[pyarg(positional_only, optional = false)]
+        #[pyarg(positional)]
         message: PyStrRef,
-        #[pyarg(positional_or_keyword, optional = true)]
+        #[pyarg(any, optional)]
         category: OptionalArg<PyTypeRef>,
-        #[pyarg(positional_or_keyword, optional = true)]
+        #[pyarg(any, optional)]
         stacklevel: OptionalArg<u32>,
     }
 

--- a/vm/src/stdlib/winapi.rs
+++ b/vm/src/stdlib/winapi.rs
@@ -106,23 +106,23 @@ fn _winapi_GetFileType(h: usize, vm: &VirtualMachine) -> PyResult<u32> {
 
 #[derive(FromArgs)]
 struct CreateProcessArgs {
-    #[pyarg(positional_only)]
+    #[pyarg(positional)]
     name: Option<PyStrRef>,
-    #[pyarg(positional_only)]
+    #[pyarg(positional)]
     command_line: Option<PyStrRef>,
-    #[pyarg(positional_only)]
+    #[pyarg(positional)]
     _proc_attrs: PyObjectRef,
-    #[pyarg(positional_only)]
+    #[pyarg(positional)]
     _thread_attrs: PyObjectRef,
-    #[pyarg(positional_only)]
+    #[pyarg(positional)]
     inherit_handles: i32,
-    #[pyarg(positional_only)]
+    #[pyarg(positional)]
     creation_flags: u32,
-    #[pyarg(positional_only)]
+    #[pyarg(positional)]
     env_mapping: Option<PyMapping>,
-    #[pyarg(positional_only)]
+    #[pyarg(positional)]
     current_dir: Option<PyStrRef>,
-    #[pyarg(positional_only)]
+    #[pyarg(positional)]
     startup_info: PyObjectRef,
 }
 

--- a/vm/src/stdlib/zlib.rs
+++ b/vm/src/stdlib/zlib.rs
@@ -332,9 +332,9 @@ mod decl {
 
     #[derive(FromArgs)]
     struct DecompressArgs {
-        #[pyarg(positional_only)]
+        #[pyarg(positional)]
         data: PyBytesRef,
-        #[pyarg(positional_or_keyword, default = "0")]
+        #[pyarg(any, default = "0")]
         max_length: usize,
     }
 

--- a/wasm/lib/src/browser_module.rs
+++ b/wasm/lib/src/browser_module.rs
@@ -42,15 +42,15 @@ impl FetchResponseFormat {
 
 #[derive(FromArgs)]
 struct FetchArgs {
-    #[pyarg(keyword_only, default = "None")]
+    #[pyarg(named, default)]
     response_format: Option<PyStrRef>,
-    #[pyarg(keyword_only, default = "None")]
+    #[pyarg(named, default)]
     method: Option<PyStrRef>,
-    #[pyarg(keyword_only, default = "None")]
+    #[pyarg(named, default)]
     headers: Option<PyDictRef>,
-    #[pyarg(keyword_only, default = "None")]
+    #[pyarg(named, default)]
     body: Option<PyObjectRef>,
-    #[pyarg(keyword_only, default = "None")]
+    #[pyarg(named, default)]
     content_type: Option<PyStrRef>,
 }
 

--- a/wasm/lib/src/js_module.rs
+++ b/wasm/lib/src/js_module.rs
@@ -231,13 +231,13 @@ impl PyJsValue {
 
 #[derive(FromArgs)]
 struct CallOptions {
-    #[pyarg(keyword_only, default = "None")]
+    #[pyarg(named, default)]
     this: Option<PyJsValueRef>,
 }
 
 #[derive(FromArgs)]
 struct NewObjectOptions {
-    #[pyarg(keyword_only, default = "None")]
+    #[pyarg(named, default)]
     prototype: Option<PyJsValueRef>,
 }
 


### PR DESCRIPTION
I don't think the `FromArgOptional` trait is the perfect solution to combining
`optional` and `default`, but I think it's ok.
