### PR TITLE
Don't skip pathlib tests that actually succeed (on my machine)

### DIFF
--- a/Lib/test/test_pathlib.py
+++ b/Lib/test/test_pathlib.py
@@ -619,7 +619,6 @@ class _BasePurePathTest(object):
         self.assertRaises(ValueError, p.relative_to, '')
         self.assertRaises(ValueError, p.relative_to, P('a'))
 
-    @unittest.skip("TODO: RUSTPYTHON")
     def test_pickling_common(self):
         P = self.cls
         p = P('/a/b')
@@ -1332,7 +1331,6 @@ class _BasePathTest(object):
         p = P(P('').absolute().anchor) / '~'
         self.assertEqual(p.expanduser(), p)
 
-    @unittest.skip("TODO: RUSTPYTHON")
     def test_exists(self):
         P = self.cls
         p = P(BASE)
@@ -1350,7 +1348,6 @@ class _BasePathTest(object):
         self.assertIs(False, P(BASE + '\udfff').exists())
         self.assertIs(False, P(BASE + '\x00').exists())
 
-    @unittest.skip("TODO: RUSTPYTHON")
     def test_open_common(self):
         p = self.cls(BASE)
         with (p / 'fileA').open('r') as f:
@@ -1363,7 +1360,6 @@ class _BasePathTest(object):
             self.assertIsInstance(f, io.RawIOBase)
             self.assertEqual(f.read().strip(), b"this is file A")
 
-    @unittest.skip("TODO: RUSTPYTHON")
     def test_read_write_bytes(self):
         p = self.cls(BASE)
         (p / 'fileA').write_bytes(b'abcdefg')
@@ -1372,7 +1368,6 @@ class _BasePathTest(object):
         self.assertRaises(TypeError, (p / 'fileA').write_bytes, 'somestr')
         self.assertEqual((p / 'fileA').read_bytes(), b'abcdefg')
 
-    @unittest.skip("TODO: RUSTPYTHON")
     def test_read_write_text(self):
         p = self.cls(BASE)
         (p / 'fileA').write_text('äbcdefg', encoding='latin-1')
@@ -1411,7 +1406,6 @@ class _BasePathTest(object):
         self.assertIn(cm.exception.errno, (errno.ENOTDIR,
                                            errno.ENOENT, errno.EINVAL))
 
-    @unittest.skip("TODO: RUSTPYTHON")
     def test_glob_common(self):
         def _check(glob, expected):
             self.assertEqual(set(glob), { P(BASE, q) for q in expected })
@@ -1436,7 +1430,6 @@ class _BasePathTest(object):
         else:
             _check(p.glob("*/fileB"), ['dirB/fileB', 'linkB/fileB'])
 
-    @unittest.skip("TODO: RUSTPYTHON")
     def test_rglob_common(self):
         def _check(glob, expected):
             self.assertEqual(set(glob), { P(BASE, q) for q in expected })
@@ -1699,7 +1692,6 @@ class _BasePathTest(object):
         self.assertEqual(os.stat(r).st_size, size)
         self.assertFileNotFound(q.stat)
 
-    @unittest.skip("TODO: RUSTPYTHON")
     def test_touch_common(self):
         P = self.cls(BASE)
         p = P / 'newfileA'
@@ -1724,7 +1716,6 @@ class _BasePathTest(object):
         self.assertTrue(p.exists())
         self.assertRaises(OSError, p.touch, exist_ok=False)
 
-    @unittest.skip("TODO: RUSTPYTHON")
     def test_touch_nochange(self):
         P = self.cls(BASE)
         p = P / 'fileA'
@@ -1743,8 +1734,6 @@ class _BasePathTest(object):
             p.mkdir()
         self.assertEqual(cm.exception.errno, errno.EEXIST)
 
-    # TODO: RUSTPYTHON
-    @unittest.expectedFailure
     def test_mkdir_parents(self):
         # Creating a chain of directories.
         p = self.cls(BASE, 'newdirB', 'newdirC')
@@ -1892,7 +1881,6 @@ class _BasePathTest(object):
         self.assertTrue(link.is_dir())
         self.assertTrue(list(link.iterdir()))
 
-    @unittest.skip("TODO: RUSTPYTHON")
     def test_is_dir(self):
         P = self.cls(BASE)
         self.assertTrue((P / 'dirA').is_dir())
@@ -1906,7 +1894,6 @@ class _BasePathTest(object):
         self.assertIs((P / 'dirA\udfff').is_dir(), False)
         self.assertIs((P / 'dirA\x00').is_dir(), False)
 
-    @unittest.skip("TODO: RUSTPYTHON")
     def test_is_file(self):
         P = self.cls(BASE)
         self.assertTrue((P / 'fileA').is_file())
@@ -1921,7 +1908,6 @@ class _BasePathTest(object):
         self.assertIs((P / 'fileA\x00').is_file(), False)
 
     @only_posix
-    @unittest.skip("TODO: RUSTPYTHON")
     def test_is_mount(self):
         P = self.cls(BASE)
         R = self.cls('/')  # TODO: Work out Windows.
@@ -1935,7 +1921,6 @@ class _BasePathTest(object):
         self.assertIs(self.cls('/\udfff').is_mount(), False)
         self.assertIs(self.cls('/\x00').is_mount(), False)
 
-    @unittest.skip("TODO: RUSTPYTHON")
     def test_is_symlink(self):
         P = self.cls(BASE)
         self.assertFalse((P / 'fileA').is_symlink())
@@ -1952,7 +1937,6 @@ class _BasePathTest(object):
             self.assertIs((P / 'linkA\udfff').is_file(), False)
             self.assertIs((P / 'linkA\x00').is_file(), False)
 
-    @unittest.skip("TODO: RUSTPYTHON")
     def test_is_fifo_false(self):
         P = self.cls(BASE)
         self.assertFalse((P / 'fileA').is_fifo())
@@ -1963,7 +1947,6 @@ class _BasePathTest(object):
         self.assertIs((P / 'fileA\x00').is_fifo(), False)
 
     @unittest.skipUnless(hasattr(os, "mkfifo"), "os.mkfifo() required")
-    @unittest.skip("TODO: RUSTPYTHON")
     def test_is_fifo_true(self):
         P = self.cls(BASE, 'myfifo')
         try:
@@ -1976,7 +1959,6 @@ class _BasePathTest(object):
         self.assertIs(self.cls(BASE, 'myfifo\udfff').is_fifo(), False)
         self.assertIs(self.cls(BASE, 'myfifo\x00').is_fifo(), False)
 
-    @unittest.skip("TODO: RUSTPYTHON")
     def test_is_socket_false(self):
         P = self.cls(BASE)
         self.assertFalse((P / 'fileA').is_socket())
@@ -1987,7 +1969,6 @@ class _BasePathTest(object):
         self.assertIs((P / 'fileA\x00').is_socket(), False)
 
     @unittest.skipUnless(hasattr(socket, "AF_UNIX"), "Unix sockets required")
-    @unittest.skip("TODO: RUSTPYTHON")
     def test_is_socket_true(self):
         P = self.cls(BASE, 'mysock')
         sock = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
@@ -2004,7 +1985,6 @@ class _BasePathTest(object):
         self.assertIs(self.cls(BASE, 'mysock\udfff').is_socket(), False)
         self.assertIs(self.cls(BASE, 'mysock\x00').is_socket(), False)
 
-    @unittest.skip("TODO: RUSTPYTHON")
     def test_is_block_device_false(self):
         P = self.cls(BASE)
         self.assertFalse((P / 'fileA').is_block_device())
@@ -2014,7 +1994,6 @@ class _BasePathTest(object):
         self.assertIs((P / 'fileA\udfff').is_block_device(), False)
         self.assertIs((P / 'fileA\x00').is_block_device(), False)
 
-    @unittest.skip("TODO: RUSTPYTHON")
     def test_is_char_device_false(self):
         P = self.cls(BASE)
         self.assertFalse((P / 'fileA').is_char_device())
@@ -2024,7 +2003,6 @@ class _BasePathTest(object):
         self.assertIs((P / 'fileA\udfff').is_char_device(), False)
         self.assertIs((P / 'fileA\x00').is_char_device(), False)
 
-    @unittest.skip("TODO: RUSTPYTHON")
     def test_is_char_device_true(self):
         # Under Unix, /dev/null should generally be a char device.
         P = self.cls('/dev/null')
@@ -2036,7 +2014,6 @@ class _BasePathTest(object):
         self.assertIs(self.cls('/dev/null\udfff').is_char_device(), False)
         self.assertIs(self.cls('/dev/null\x00').is_char_device(), False)
 
-    @unittest.skip("TODO: RUSTPYTHON")
     def test_pickling_common(self):
         p = self.cls(BASE, 'fileA')
         for proto in range(0, pickle.HIGHEST_PROTOCOL + 1):
@@ -2044,8 +2021,6 @@ class _BasePathTest(object):
             pp = pickle.loads(dumped)
             self.assertEqual(pp.stat(), p.stat())
 
-    # TODO: RUSTPYTHON
-    @unittest.expectedFailure
     def test_parts_interning(self):
         P = self.cls
         p = P('/usr/bin/foo')
@@ -2138,7 +2113,6 @@ class PosixPathTest(_BasePathTest, unittest.TestCase):
         with self.assertRaises(RuntimeError):
             print(path.resolve(strict))
 
-    @unittest.skip("TODO: RUSTPYTHON")
     def test_open_mode(self):
         old_mask = os.umask(0)
         self.addCleanup(os.umask, old_mask)
@@ -2153,7 +2127,6 @@ class PosixPathTest(_BasePathTest, unittest.TestCase):
         st = os.stat(join('other_new_file'))
         self.assertEqual(stat.S_IMODE(st.st_mode), 0o644)
 
-    @unittest.skip("TODO: RUSTPYTHON")
     def test_touch_mode(self):
         old_mask = os.umask(0)
         self.addCleanup(os.umask, old_mask)
@@ -2190,7 +2163,6 @@ class PosixPathTest(_BasePathTest, unittest.TestCase):
         # Non-strict
         self._check_symlink_loop(BASE, 'linkW', 'foo', strict=False)
 
-    @unittest.skip("TODO: RUSTPYTHON")
     def test_glob(self):
         P = self.cls
         p = P(BASE)
@@ -2199,7 +2171,6 @@ class PosixPathTest(_BasePathTest, unittest.TestCase):
         self.assertEqual(given, expect)
         self.assertEqual(set(p.glob("FILEa*")), set())
 
-    @unittest.skip("TODO: RUSTPYTHON")
     def test_rglob(self):
         P = self.cls
         p = P(BASE, "dirC")
@@ -2257,7 +2228,6 @@ class PosixPathTest(_BasePathTest, unittest.TestCase):
 
     @unittest.skipIf(sys.platform != "darwin",
                      "Bad file descriptor in /dev/fd affects only macOS")
-    @unittest.skip("TODO: RUSTPYTHON")
     def test_handling_bad_descriptor(self):
         try:
             file_descriptors = list(pathlib.Path('/dev/fd').rglob("*"))[3:]


### PR DESCRIPTION
There are a bunch of tests in `test_pathlib.py` that actually succeed when I run them on my machine. Perhaps something changed after they had been marked to be skipped? I'll let the CI be the judge of that.