### PR TITLE
Add derive(Serialize, Deserialize) to FrozenModule

### DIFF
--- a/bytecode/src/bytecode.rs
+++ b/bytecode/src/bytecode.rs
@@ -658,6 +658,7 @@ impl fmt::Debug for CodeObject {
     }
 }
 
+#[derive(Serialize, Deserialize)]
 pub struct FrozenModule {
     pub code: CodeObject,
     pub package: bool,


### PR DESCRIPTION
This is so that a frozen module tree can be represented as a single bytestring, specifically for [`RustPython/pyckitup`](https://github.com/RustPython/pyckitup)