### PR TITLE
socket: resolve addresses according to socket family (ipv4/6)

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,7 +1,7 @@
 on:
   push:
     branches: [master, release]
-  pull_request:  
+  pull_request:
 
 name: CI
 
@@ -16,7 +16,6 @@ env:
     -p rustpython-jit
     -p rustpython-derive
     -p rustpython
-  RUSTPYTHON_NO_IPV6: 1
 
 jobs:
   rust_tests:


### PR DESCRIPTION
Fixes #2241

As I said on the issue:
> std::net::ToSocketAddrs does its job. host: "localhost" result: Ok(IntoIter([[::1]:5555, 127.0.0.1:5555]))
> Then get_addr() just reads the first one (which is IPv6 on my system).
> -> We then pass this IPv6 address to an IPv4 socket <-
> So get_addr() just need to be aware of PySocket::family and to filter incompatible IPs

I'm not a fan of `IpAddrFmt` but it's the cleanest way I found to do this.
I also removed `RUSTPYTHON_NO_IPV6` since it's no longer necessary :)