### PR TITLE
Fix default format(float) result when the number is too big

### DIFF
--- a/extra_tests/snippets/floats.py
+++ b/extra_tests/snippets/floats.py
@@ -487,6 +487,17 @@ assert float(1e-4).__repr__() == "0.0001"
 assert float(1.2345678901234567890).__repr__() == "1.2345678901234567"
 assert float(1.2345678901234567890e308).__repr__() == "1.2345678901234567e+308"
 
+assert format(1e15) == "1000000000000000.0"
+assert format(1e16) == "1e+16"
+assert format(1e308) == "1e+308"
+assert format(1e309) == "inf"
+assert format(1e-323) == "1e-323"
+assert format(1e-324) == "0.0"
+assert format(1e-5) == "1e-05"
+assert format(1e-4) == "0.0001"
+assert format(1.2345678901234567890) == "1.2345678901234567"
+assert format(1.2345678901234567890e308) == "1.2345678901234567e+308"
+
 assert float('0_0') == 0.0
 assert float('.0') == 0.0
 assert float('0.') == 0.0

--- a/vm/src/format.rs
+++ b/vm/src/format.rs
@@ -404,8 +404,6 @@ impl FormatSpec {
                 match magnitude {
                     magnitude if magnitude.is_nan() => Ok("nan".to_owned()),
                     magnitude if magnitude.is_infinite() => Ok("inf".to_owned()),
-                    // Using the Debug format here to prevent the automatic conversion of floats
-                    // ending in .0 to their integer representation (e.g., 1.0 -> 1)
                     _ => Ok(float_ops::to_string(magnitude)),
                 }
             }

--- a/vm/src/format.rs
+++ b/vm/src/format.rs
@@ -400,13 +400,11 @@ impl FormatSpec {
                 magnitude if magnitude.is_infinite() => Ok("inf%".to_owned()),
                 _ => Ok(format!("{:.*}%", precision, magnitude * 100.0)),
             },
-            None => {
-                match magnitude {
-                    magnitude if magnitude.is_nan() => Ok("nan".to_owned()),
-                    magnitude if magnitude.is_infinite() => Ok("inf".to_owned()),
-                    _ => Ok(float_ops::to_string(magnitude)),
-                }
-            }
+            None => match magnitude {
+                magnitude if magnitude.is_nan() => Ok("nan".to_owned()),
+                magnitude if magnitude.is_infinite() => Ok("inf".to_owned()),
+                _ => Ok(float_ops::to_string(magnitude)),
+            },
         };
 
         if raw_magnitude_string_result.is_err() {

--- a/vm/src/format.rs
+++ b/vm/src/format.rs
@@ -1,4 +1,5 @@
 use crate::builtins::pystr;
+use crate::common::float_ops;
 use crate::exceptions::{IntoPyException, PyBaseExceptionRef};
 use crate::function::FuncArgs;
 use crate::pyobject::{ItemProtocol, PyObjectRef, PyResult, TypeProtocol};
@@ -405,7 +406,7 @@ impl FormatSpec {
                     magnitude if magnitude.is_infinite() => Ok("inf".to_owned()),
                     // Using the Debug format here to prevent the automatic conversion of floats
                     // ending in .0 to their integer representation (e.g., 1.0 -> 1)
-                    _ => Ok(format!("{:?}", magnitude)),
+                    _ => Ok(float_ops::to_string(magnitude)),
                 }
             }
         };


### PR DESCRIPTION
Before this change, format(1e16) returns '10000000000000000.0' in RustPython while CPython 3.7 returns '1e+16'.
After this change, format(1e16) returns '1e+16' in RustPython too.