### PR TITLE
Fix cell_lock, remove the RwLock<BufferOptions> from bytearray

### DIFF
--- a/common/src/lock/cell_lock.rs
+++ b/common/src/lock/cell_lock.rs
@@ -93,7 +93,7 @@ unsafe impl RawRwLock for RawCellRwLock {
     #[inline]
     fn lock_exclusive(&self) {
         if !self.try_lock_exclusive() {
-            deadlock("exclusively", "RwLock")
+            deadlock("exclusively ", "RwLock")
         }
         self.state.set(WRITER_BIT)
     }
@@ -126,7 +126,7 @@ unsafe impl RawRwLockDowngrade for RawCellRwLock {
 unsafe impl RawRwLockUpgrade for RawCellRwLock {
     #[inline]
     fn lock_upgradable(&self) {
-        if self.try_lock_upgradable() {
+        if !self.try_lock_upgradable() {
             deadlock("upgradably+sharedly ", "RwLock")
         }
     }
@@ -176,7 +176,7 @@ unsafe impl RawRwLockRecursive for RawCellRwLock {
     #[inline]
     fn lock_shared_recursive(&self) {
         if !self.try_lock_shared_recursive() {
-            deadlock("recursively+sharedly", "RwLock")
+            deadlock("recursively+sharedly ", "RwLock")
         }
     }
 

--- a/vm/src/builtins/bytearray.rs
+++ b/vm/src/builtins/bytearray.rs
@@ -697,8 +697,8 @@ impl Buffer for ByteArrayBuffer {
         self.bytearray.exports.fetch_sub(1);
     }
 
-    fn get_options(&self) -> BorrowedValue<BufferOptions> {
-        (&self.options).into()
+    fn get_options(&self) -> &BufferOptions {
+        &self.options
     }
 }
 

--- a/vm/src/builtins/bytearray.rs
+++ b/vm/src/builtins/bytearray.rs
@@ -14,9 +14,7 @@ use crate::bytesinner::{
 };
 use crate::byteslike::PyBytesLike;
 use crate::common::borrow::{BorrowedValue, BorrowedValueMut};
-use crate::common::lock::{
-    PyRwLock, PyRwLockReadGuard, PyRwLockUpgradableReadGuard, PyRwLockWriteGuard,
-};
+use crate::common::lock::{PyRwLock, PyRwLockReadGuard, PyRwLockWriteGuard};
 use crate::function::{OptionalArg, OptionalOption};
 use crate::pyobject::{
     BorrowValue, Either, IdProtocol, IntoPyObject, PyClassImpl, PyComparisonValue, PyContext,
@@ -45,7 +43,6 @@ use std::mem::size_of;
 pub struct PyByteArray {
     inner: PyRwLock<PyBytesInner>,
     exports: AtomicCell<usize>,
-    buffer_options: PyRwLock<Option<Box<BufferOptions>>>,
 }
 
 pub type PyByteArrayRef = PyRef<PyByteArray>;
@@ -63,7 +60,6 @@ impl PyByteArray {
         PyByteArray {
             inner: PyRwLock::new(inner),
             exports: AtomicCell::new(0),
-            buffer_options: PyRwLock::new(None),
         }
     }
 
@@ -667,40 +663,42 @@ impl Comparable for PyByteArray {
 impl BufferProtocol for PyByteArray {
     fn get_buffer(zelf: &PyRef<Self>, _vm: &VirtualMachine) -> PyResult<Box<dyn Buffer>> {
         zelf.exports.fetch_add(1);
-        Ok(Box::new(zelf.clone()))
+        let buf = ByteArrayBuffer {
+            bytearray: zelf.clone(),
+            options: BufferOptions {
+                readonly: false,
+                len: zelf.len(),
+                ..Default::default()
+            },
+        };
+        Ok(Box::new(buf))
     }
 }
 
-impl Buffer for PyByteArrayRef {
+#[derive(Debug)]
+struct ByteArrayBuffer {
+    bytearray: PyByteArrayRef,
+    options: BufferOptions,
+}
+
+impl Buffer for ByteArrayBuffer {
     fn obj_bytes(&self) -> BorrowedValue<[u8]> {
-        PyRwLockReadGuard::map(self.borrow_value(), |x| x.elements.as_slice()).into()
+        PyRwLockReadGuard::map(self.bytearray.borrow_value(), |x| x.elements.as_slice()).into()
     }
 
     fn obj_bytes_mut(&self) -> BorrowedValueMut<[u8]> {
-        PyRwLockWriteGuard::map(self.borrow_value_mut(), |x| x.elements.as_mut_slice()).into()
+        PyRwLockWriteGuard::map(self.bytearray.borrow_value_mut(), |x| {
+            x.elements.as_mut_slice()
+        })
+        .into()
     }
 
     fn release(&self) {
-        let mut w = self.buffer_options.write();
-        if self.exports.fetch_sub(1) == 1 {
-            *w = None;
-        }
+        self.bytearray.exports.fetch_sub(1);
     }
 
     fn get_options(&self) -> BorrowedValue<BufferOptions> {
-        let guard = self.buffer_options.upgradable_read();
-        let guard = if guard.is_none() {
-            let mut w = PyRwLockUpgradableReadGuard::upgrade(guard);
-            *w = Some(Box::new(BufferOptions {
-                readonly: false,
-                len: self.len(),
-                ..Default::default()
-            }));
-            PyRwLockWriteGuard::downgrade(w)
-        } else {
-            PyRwLockUpgradableReadGuard::downgrade(guard)
-        };
-        PyRwLockReadGuard::map(guard, |x| x.as_ref().unwrap().as_ref()).into()
+        (&self.options).into()
     }
 }
 

--- a/vm/src/byteslike.rs
+++ b/vm/src/byteslike.rs
@@ -97,11 +97,13 @@ pub fn try_rw_bytes_like<R>(
 impl PyRwBytesLike {
     pub fn new(vm: &VirtualMachine, obj: &PyObjectRef) -> PyResult<Self> {
         let buffer = try_buffer_from_object(vm, &obj)?;
-        if !buffer.get_options().contiguous {
+        let options = buffer.get_options();
+        if !options.contiguous {
             Err(vm.new_type_error("non-contiguous buffer is not a bytes-like object".to_owned()))
-        } else if buffer.get_options().readonly {
+        } else if options.readonly {
             Err(vm.new_type_error("buffer is not a read-write bytes-like object".to_owned()))
         } else {
+            drop(options);
             Ok(Self(buffer))
         }
     }

--- a/vm/src/byteslike.rs
+++ b/vm/src/byteslike.rs
@@ -103,7 +103,6 @@ impl PyRwBytesLike {
         } else if options.readonly {
             Err(vm.new_type_error("buffer is not a read-write bytes-like object".to_owned()))
         } else {
-            drop(options);
             Ok(Self(buffer))
         }
     }


### PR DESCRIPTION
@qingshi163 could you take a look at this?

`rustpython` built without threading was panicking with `deadlock: tried to upgradably+sharedly lock a CellRwLock twice` in `ByteArray::get_options()`. The changes in memory.rs are because I thought it was a legit deadlock but it turned out to just be a type in `cell_lock.rs`, and I made the Buffer type for bytearray a separate type that stores the options directly in it, to avoid some overhead with the RwLock inside of `PyByteArray`