### PR TITLE
Manually implement a vtable for PyObjectRef

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -161,6 +161,21 @@ jobs:
         run: python -m pip install flake8
       - name: run lint
         run: flake8 . --count --exclude=./.*,./Lib,./vm/Lib  --select=E9,F63,F7,F82 --show-source --statistics
+  miri:
+    name: Run tests under miri
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@master
+      - uses: actions-rs/toolchain@v1
+        with:
+            profile: minimal
+            toolchain: nightly
+            components: miri
+            override: true
+      - name: Run tests under miri
+        # miri-ignore-leaks because the type-object circular reference means that there will always be
+        # a memory leak, at least until we have proper cyclic gc
+        run: MIRIFLAGS='-Zmiri-ignore-leaks' cargo +nightly miri test -p rustpython-vm -- miri_test
 
   wasm:
     name: Check the WASM package and demo

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1894,6 +1894,7 @@ dependencies = [
  "sha2",
  "sha3",
  "socket2",
+ "static_assertions",
  "statrs",
  "thiserror",
  "thread_local",

--- a/vm/Cargo.toml
+++ b/vm/Cargo.toml
@@ -79,6 +79,7 @@ cfg-if = "0.1.10"
 timsort = "0.1"
 thiserror = "1.0"
 atty = "0.2"
+static_assertions = "1.1"
 
 ## unicode stuff
 unicode_names2 = "0.4"

--- a/vm/src/builtins/code.rs
+++ b/vm/src/builtins/code.rs
@@ -198,7 +198,7 @@ impl PyCode {}
 #[pyimpl]
 impl PyCodeRef {
     #[pyslot]
-    fn tp_new(_cls: PyTypeRef, vm: &VirtualMachine) -> PyResult<PyRef<Self>> {
+    fn tp_new(_cls: PyTypeRef, vm: &VirtualMachine) -> PyResult<Self> {
         Err(vm.new_type_error("Cannot directly create code object".to_owned()))
     }
 

--- a/vm/src/builtins/dict.rs
+++ b/vm/src/builtins/dict.rs
@@ -597,7 +597,7 @@ macro_rules! dict_iterator {
                 let s = if let Some(_guard) = ReprGuard::enter(vm, zelf.as_object()) {
                     let mut str_parts = vec![];
                     for (key, value) in zelf.dict.clone() {
-                        let s = vm.to_repr(&$result_fn(vm, key, value))?;
+                        let s = vm.to_repr(&($result_fn)(vm, key, value))?;
                         str_parts.push(s.borrow_value().to_owned());
                     }
                     format!("{}([{}])", $class_name, str_parts.join(", "))
@@ -694,7 +694,7 @@ macro_rules! dict_iterator {
                 match zelf.dict.entries.next_entry(&mut position) {
                     Some((key, value)) => {
                         zelf.position.store(position);
-                        Ok($result_fn(vm, key, value))
+                        Ok(($result_fn)(vm, key, value))
                     }
                     None => Err(vm.new_stop_iteration()),
                 }
@@ -743,7 +743,7 @@ macro_rules! dict_iterator {
                 match zelf.dict.len().checked_sub(count) {
                     Some(mut pos) => {
                         let (key, value) = zelf.dict.entries.next_entry(&mut pos).unwrap();
-                        Ok($result_fn(vm, key, value))
+                        Ok(($result_fn)(vm, key, value))
                     }
                     None => {
                         zelf.position.store(std::isize::MAX as usize);

--- a/vm/src/builtins/object.rs
+++ b/vm/src/builtins/object.rs
@@ -217,10 +217,10 @@ impl PyBaseObject {
     #[pyproperty(name = "__class__", setter)]
     fn set_class(instance: PyObjectRef, value: PyObjectRef, vm: &VirtualMachine) -> PyResult<()> {
         if instance.payload_is::<PyBaseObject>() {
-            match value.downcast_generic::<PyType>() {
+            match value.downcast::<PyType>() {
                 Ok(cls) => {
                     // FIXME(#1979) cls instances might have a payload
-                    *instance.typ.write() = cls;
+                    *instance.class_lock().write() = cls;
                     Ok(())
                 }
                 Err(value) => {

--- a/vm/src/builtins/pystr.rs
+++ b/vm/src/builtins/pystr.rs
@@ -240,7 +240,10 @@ impl PyStr {
         if other.isinstance(&vm.ctx.types.str_type) {
             Ok(self.value.py_add(borrow_value(&other)))
         } else {
-            Err(vm.new_type_error(format!("Cannot add {} and {}", self, other)))
+            Err(vm.new_type_error(format!(
+                "can only concatenate str (not \"{}\") to str",
+                other.class().name
+            )))
         }
     }
 

--- a/vm/src/builtins/weakref.rs
+++ b/vm/src/builtins/weakref.rs
@@ -2,9 +2,9 @@ use super::pytype::PyTypeRef;
 use crate::common::hash::PyHash;
 use crate::function::{FuncArgs, OptionalArg};
 use crate::pyobject::{
-    IdProtocol, PyClassImpl, PyContext, PyObjectRef, PyRef, PyResult, PyValue, TypeProtocol,
+    IdProtocol, PyClassImpl, PyContext, PyObjectRef, PyObjectWeak, PyRef, PyResult, PyValue,
+    TypeProtocol,
 };
-use crate::pyobjectrc::{PyObjectRc, PyObjectWeak};
 use crate::slots::{Callable, Comparable, Hashable, PyComparisonOp};
 use crate::vm::VirtualMachine;
 
@@ -20,7 +20,7 @@ pub struct PyWeak {
 impl PyWeak {
     pub fn downgrade(obj: &PyObjectRef) -> PyWeak {
         PyWeak {
-            referent: PyObjectRc::downgrade(obj),
+            referent: PyObjectRef::downgrade(obj),
             hash: AtomicCell::new(None),
         }
     }

--- a/vm/src/bytesinner.rs
+++ b/vm/src/bytesinner.rs
@@ -14,8 +14,8 @@ use crate::byteslike::try_bytes_like;
 use crate::cformat::CFormatBytes;
 use crate::function::{OptionalArg, OptionalOption};
 use crate::pyobject::{
-    BorrowValue, Either, IdProtocol, PyComparisonValue, PyIterable, PyObjectRef, PyRef, PyResult,
-    PyValue, TryFromObject, TypeProtocol,
+    BorrowValue, Either, IdProtocol, PyComparisonValue, PyIterable, PyObjectRef, PyResult, PyValue,
+    TryFromObject, TypeProtocol,
 };
 use crate::sliceable::PySliceableSequence;
 use crate::slots::PyComparisonOp;
@@ -91,10 +91,10 @@ impl ByteInnerNewOptions {
 
     pub fn get_bytes(mut self, cls: PyTypeRef, vm: &VirtualMachine) -> PyResult<PyBytesRef> {
         let inner = if let OptionalArg::Present(source) = self.source.take() {
-            if source.class().is(&PyBytes::class(vm)) && cls.is(&PyBytes::class(vm)) {
-                return self
-                    .check_args(vm)
-                    .map(|_| unsafe { PyRef::from_obj_unchecked(source) });
+            if cls.is(&PyBytes::class(vm)) {
+                if let Ok(source) = source.clone().downcast_exact(vm) {
+                    return self.check_args(vm).map(|()| source);
+                }
             }
 
             match_class!(match source {

--- a/vm/src/pyobjectrc.rs
+++ b/vm/src/pyobjectrc.rs
@@ -410,6 +410,11 @@ pub(crate) fn init_type_hierarchy() -> (PyTypeRef, PyTypeRef) {
         type PyTypeObj = PyObject<PyType>;
         type UninitRef<T> = PyRwLock<PyRc<MaybeUninit<PyInner<T>>>>;
 
+        // We cast between these 2 types, so make sure (at compile time) that there's no change in
+        // layout when we wrap PyInner<PyTypeObj> in MaybeUninit<>
+        static_assertions::assert_eq_size!(MaybeUninit<PyInner<PyTypeObj>>, PyInner<PyTypeObj>);
+        static_assertions::assert_eq_align!(MaybeUninit<PyInner<PyTypeObj>>, PyInner<PyTypeObj>);
+
         let type_payload = PyType {
             name: PyTypeRef::NAME.to_owned(),
             base: None,

--- a/vm/src/pyobjectrc.rs
+++ b/vm/src/pyobjectrc.rs
@@ -1,80 +1,99 @@
 use crate::common::rc::{PyRc, PyWeak};
-use crate::pyobject::{IdProtocol, PyObject, PyObjectPayload, TypeProtocol};
-use std::borrow;
+use crate::pyobject::{self, IdProtocol, PyObject, PyObjectPayload, TypeProtocol};
+use crate::VirtualMachine;
+use std::any::TypeId;
 use std::fmt;
+use std::marker::PhantomData;
+use std::mem::ManuallyDrop;
 use std::ops::Deref;
 
-pub struct PyObjectRc<T = dyn PyObjectPayload>
-where
-    T: ?Sized + PyObjectPayload,
-    PyRc<PyObject<T>>: AsPyObjectRef,
-{
-    inner: PyRc<PyObject<T>>,
+struct Erased;
+
+struct PyObjVTable {
+    drop: unsafe fn(*mut PyObject<Erased>),
+    debug: unsafe fn(*const PyObject<Erased>, &mut fmt::Formatter) -> fmt::Result,
+}
+unsafe fn drop_obj<T: PyObjectPayload>(x: *mut PyObject<Erased>) {
+    std::ptr::drop_in_place(x as *mut PyObject<T>)
+}
+unsafe fn debug_obj<T: PyObjectPayload>(
+    x: *const PyObject<Erased>,
+    f: &mut fmt::Formatter,
+) -> fmt::Result {
+    let x = &*x.cast::<PyObject<T>>();
+    fmt::Debug::fmt(x, f)
 }
 
-pub struct PyObjectWeak<T = dyn PyObjectPayload>
-where
-    T: ?Sized + PyObjectPayload,
-{
-    inner: PyWeak<PyObject<T>>,
+macro_rules! make_vtable {
+    ($t:ty) => {
+        &PyObjVTable {
+            drop: drop_obj::<$t>,
+            debug: debug_obj::<$t>,
+        }
+    };
 }
 
-pub trait AsPyObjectRef {
-    fn _as_ref(self) -> PyRc<PyObject<dyn PyObjectPayload>>;
+#[repr(C)]
+struct PyInner<T> {
+    // TODO: move typeid into vtable once TypeId::of is const
+    typeid: TypeId,
+    vtable: &'static PyObjVTable,
+    value: ManuallyDrop<PyObject<T>>,
 }
 
-impl<T> AsPyObjectRef for PyRc<PyObject<T>>
-where
-    T: PyObjectPayload,
-{
-    fn _as_ref(self) -> PyRc<PyObject<dyn PyObjectPayload>> {
-        self
+impl<T: PyObjectPayload> PyInner<T> {
+    fn new(value: PyObject<T>) -> Self {
+        PyInner {
+            typeid: TypeId::of::<T>(),
+            vtable: make_vtable!(T),
+            value: ManuallyDrop::new(value),
+        }
     }
 }
 
-impl AsPyObjectRef for PyRc<PyObject<dyn PyObjectPayload>> {
-    fn _as_ref(self) -> PyRc<PyObject<dyn PyObjectPayload>> {
-        self
+impl<T> Drop for PyInner<T> {
+    fn drop(&mut self) {
+        let erased = &mut *self.value as *mut _ as *mut PyObject<Erased>;
+        unsafe { (self.vtable.drop)(erased) }
     }
 }
 
-impl<T> PyObjectRc<T>
-where
-    T: ?Sized + PyObjectPayload,
-    PyRc<PyObject<T>>: AsPyObjectRef,
-{
-    pub fn into_raw(this: Self) -> *const PyObject<T> {
+/// The `PyObjectRef` is one of the most used types. It is a reference to a
+/// python object. A single python object can have multiple references, and
+/// this reference counting is accounted for by this type. Use the `.clone()`
+/// method to create a new reference and increment the amount of references
+/// to the python object by 1.
+#[derive(Clone)]
+pub struct PyObjectRef {
+    inner: PyRc<PyInner<Erased>>,
+}
+
+#[derive(Clone)]
+pub struct PyObjectWeak {
+    inner: PyWeak<PyInner<Erased>>,
+}
+
+pub enum RawPyObject {}
+
+impl PyObjectRef {
+    pub fn into_raw(this: Self) -> *const RawPyObject {
         let ptr = PyRc::as_ptr(&this.inner);
         std::mem::forget(this);
-        ptr
-    }
-
-    unsafe fn into_rc(this: Self) -> PyRc<PyObject<T>> {
-        let raw = Self::into_raw(this);
-        PyRc::from_raw(raw)
-    }
-
-    pub fn into_ref(this: Self) -> PyObjectRc<dyn PyObjectPayload> {
-        PyObjectRc::<dyn PyObjectPayload> {
-            inner: unsafe { Self::into_rc(this) }._as_ref(),
-        }
+        ptr.cast()
     }
 
     /// # Safety
     /// See PyRc::from_raw
-    pub unsafe fn from_raw(ptr: *const PyObject<T>) -> Self {
+    pub unsafe fn from_raw(ptr: *const RawPyObject) -> Self {
         Self {
-            inner: PyRc::from_raw(ptr),
+            inner: PyRc::from_raw(ptr.cast()),
         }
     }
 
-    pub fn new(value: PyObject<T>) -> Self
-    where
-        T: Sized,
-    {
-        Self {
-            inner: PyRc::new(value),
-        }
+    pub fn new<T: PyObjectPayload>(value: PyObject<T>) -> Self {
+        let inner = PyRc::into_raw(PyRc::new(PyInner::<T>::new(value)));
+        let inner = unsafe { PyRc::from_raw(inner as *const PyInner<Erased>) };
+        Self { inner }
     }
 
     pub fn strong_count(this: &Self) -> usize {
@@ -85,68 +104,136 @@ where
         PyRc::weak_count(&this.inner)
     }
 
-    pub fn downgrade(this: &Self) -> PyObjectWeak<T> {
+    pub fn downgrade(this: &Self) -> PyObjectWeak {
         PyObjectWeak {
             inner: PyRc::downgrade(&this.inner),
         }
     }
+
+    pub fn payload_is<T: PyObjectPayload>(&self) -> bool {
+        self.inner.typeid == TypeId::of::<T>()
+    }
+
+    pub fn payload<T: PyObjectPayload>(&self) -> Option<&T> {
+        if self.payload_is::<T>() {
+            // we cast to a PyObject first because we don't know T's exact offset because of varying alignment,
+            // but we *do* know that PyObject<T> is always
+            let pyobj =
+                unsafe { &*(&*self.inner.value as *const PyObject<Erased> as *const PyObject<T>) };
+            Some(&pyobj.payload)
+        } else {
+            None
+        }
+    }
+
+    /// Attempt to downcast this reference to a subclass.
+    ///
+    /// If the downcast fails, the original ref is returned in as `Err` so
+    /// another downcast can be attempted without unnecessary cloning.
+    pub fn downcast<T: PyObjectPayload>(self) -> Result<PyRef<T>, Self> {
+        if self.payload_is::<T>() {
+            Ok(unsafe { PyRef::from_obj_unchecked(self) })
+        } else {
+            Err(self)
+        }
+    }
+
+    pub fn downcast_ref<T: PyObjectPayload>(&self) -> Option<&PyRef<T>> {
+        if self.payload_is::<T>() {
+            // when payload exacts, PyObjectRef == PyRef { PyObject }
+            Some(unsafe { &*(self as *const PyObjectRef as *const PyRef<T>) })
+        } else {
+            None
+        }
+    }
+
+    pub(crate) fn class_lock(&self) -> &crate::common::lock::PyRwLock<crate::builtins::PyTypeRef> {
+        &self.inner.value.typ
+    }
+
+    // ideally we'd be able to define these in pyobject.rs, but method visibility rules are weird
+
+    /// Attempt to downcast this reference to the specific class that is associated `T`.
+    ///
+    /// If the downcast fails, the original ref is returned in as `Err` so
+    /// another downcast can be attempted without unnecessary cloning.
+    pub fn downcast_exact<T: PyObjectPayload + pyobject::PyValue>(
+        self,
+        vm: &VirtualMachine,
+    ) -> Result<PyRef<T>, Self> {
+        if self.class().is(T::class(vm)) {
+            // TODO: is this always true?
+            assert!(
+                self.payload_is::<T>(),
+                "obj.__class__ is T::class() but payload is not T"
+            );
+            Ok(unsafe { PyRef::from_obj_unchecked(self) })
+        } else {
+            Err(self)
+        }
+    }
+
+    #[inline]
+    pub fn payload_if_exact<T: PyObjectPayload + pyobject::PyValue>(
+        &self,
+        vm: &VirtualMachine,
+    ) -> Option<&T> {
+        if self.class().is(T::class(vm)) {
+            self.payload()
+        } else {
+            None
+        }
+    }
+
+    pub fn dict(&self) -> Option<crate::builtins::PyDictRef> {
+        self.inner.value.dict()
+    }
+    /// Set the dict field. Returns `Err(dict)` if this object does not have a dict field
+    /// in the first place.
+    pub fn set_dict(
+        &self,
+        dict: crate::builtins::PyDictRef,
+    ) -> Result<(), crate::builtins::PyDictRef> {
+        self.inner.value.set_dict(dict)
+    }
+
+    #[inline]
+    pub fn payload_if_subclass<T: pyobject::PyValue>(
+        &self,
+        vm: &crate::VirtualMachine,
+    ) -> Option<&T> {
+        if self.class().issubclass(T::class(vm)) {
+            self.payload()
+        } else {
+            None
+        }
+    }
 }
 
-impl<T: ?Sized + PyObjectPayload> IdProtocol for PyObjectRc<T>
-where
-    PyRc<PyObject<T>>: IdProtocol + AsPyObjectRef,
-{
+impl IdProtocol for PyObjectRef {
     fn get_id(&self) -> usize {
         self.inner.get_id()
     }
 }
 
-impl<T> PyObjectWeak<T>
-where
-    T: ?Sized + PyObjectPayload,
-    PyRc<PyObject<T>>: AsPyObjectRef,
-{
-    pub fn upgrade(&self) -> Option<PyObjectRc<T>> {
-        self.inner.upgrade().map(|inner| PyObjectRc { inner })
+impl PyObjectWeak {
+    pub fn upgrade(&self) -> Option<PyObjectRef> {
+        self.inner.upgrade().map(|inner| PyObjectRef { inner })
     }
 }
 
-#[cfg(feature = "threading")]
-unsafe impl<T> Send for PyObjectRc<T>
-where
-    T: ?Sized + PyObjectPayload,
-    PyRc<PyObject<T>>: AsPyObjectRef,
-{
-}
-#[cfg(feature = "threading")]
-unsafe impl<T> Sync for PyObjectRc<T>
-where
-    T: ?Sized + PyObjectPayload,
-    PyRc<PyObject<T>>: AsPyObjectRef,
-{
-}
-
-#[cfg(feature = "threading")]
-unsafe impl<T> Send for PyObjectWeak<T> where T: ?Sized + PyObjectPayload {}
-#[cfg(feature = "threading")]
-unsafe impl<T> Sync for PyObjectWeak<T> where T: ?Sized + PyObjectPayload {}
-
-impl<T> Drop for PyObjectRc<T>
-where
-    T: ?Sized + PyObjectPayload,
-    PyRc<PyObject<T>>: AsPyObjectRef,
-{
+impl Drop for PyObjectRef {
     fn drop(&mut self) {
         use crate::pyobject::BorrowValue;
 
-        // PyObjectRc will drop the value when its count goes to 0
+        // PyObjectRef will drop the value when its count goes to 0
         if PyRc::strong_count(&self.inner) != 1 {
             return;
         }
 
         // CPython-compatible drop implementation
-        let zelf = Self::into_ref(self.clone());
-        if let Some(del_slot) = zelf.class().mro_find_map(|cls| cls.slots.del.load()) {
+        let zelf = self.clone();
+        if let Some(del_slot) = self.class().mro_find_map(|cls| cls.slots.del.load()) {
             crate::vm::thread::with_vm(&zelf, |vm| {
                 if let Err(e) = del_slot(&zelf, vm) {
                     // exception in del will be ignored but printed
@@ -169,146 +256,263 @@ where
             });
         }
 
-        let _ = unsafe { PyObjectRc::<dyn PyObjectPayload>::into_rc(zelf) };
-        debug_assert!(PyRc::strong_count(&self.inner) == 1); // make sure to keep same state
+        // __del__ might have resurrected the object, but that's fine, strong_count would be >1 now
     }
 }
 
-impl<T> Deref for PyObjectRc<T>
-where
-    T: ?Sized + PyObjectPayload,
-    PyRc<PyObject<T>>: AsPyObjectRef,
-{
-    type Target = PyObject<T>;
-
-    #[inline]
-    fn deref(&self) -> &PyObject<T> {
-        self.inner.deref()
+impl fmt::Debug for PyObjectRef {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        unsafe { (self.inner.vtable.debug)(&*self.inner.value, f) }
     }
 }
 
-impl<T> Clone for PyObjectRc<T>
-where
-    T: ?Sized + PyObjectPayload,
-    PyRc<PyObject<T>>: AsPyObjectRef,
-{
+impl fmt::Debug for PyObjectWeak {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "(PyWeak)")
+    }
+}
+
+/// A reference to a Python object.
+///
+/// Note that a `PyRef<T>` can only deref to a shared / immutable reference.
+/// It is the payload type's responsibility to handle (possibly concurrent)
+/// mutability with locks or concurrent data structures if required.
+///
+/// A `PyRef<T>` can be directly returned from a built-in function to handle
+/// situations (such as when implementing in-place methods such as `__iadd__`)
+/// where a reference to the same object must be returned.
+#[derive(Debug)]
+#[repr(transparent)]
+pub struct PyRef<T: PyObjectPayload> {
+    // invariant: this obj must always have payload of type T
+    obj: PyObjectRef,
+    _payload: PhantomData<PyRc<T>>,
+}
+
+impl<T: PyObjectPayload> Clone for PyRef<T> {
     fn clone(&self) -> Self {
-        PyObjectRc {
-            inner: self.inner.clone(),
+        Self {
+            obj: self.obj.clone(),
+            _payload: PhantomData,
         }
     }
 }
 
-impl<T> fmt::Display for PyObjectRc<T>
-where
-    T: ?Sized + PyObjectPayload,
-    PyRc<PyObject<T>>: AsPyObjectRef,
-    PyObject<T>: fmt::Display,
-{
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        self.inner.fmt(f)
-    }
-}
-
-impl<T> fmt::Debug for PyObjectRc<T>
-where
-    T: ?Sized + PyObjectPayload,
-    PyRc<PyObject<T>>: AsPyObjectRef,
-    PyObject<T>: fmt::Debug,
-{
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        self.inner.fmt(f)
-    }
-}
-
-impl<T> fmt::Pointer for PyObjectRc<T>
-where
-    T: ?Sized + PyObjectPayload,
-    PyRc<PyObject<T>>: AsPyObjectRef,
-    PyObject<T>: fmt::Pointer,
-{
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        self.inner.fmt(f)
-    }
-}
-
-impl<T> borrow::Borrow<T> for PyObjectRc<T>
-where
-    T: ?Sized + PyObjectPayload,
-    PyRc<PyObject<T>>: AsPyObjectRef + borrow::Borrow<T>,
-{
-    fn borrow(&self) -> &T {
-        self.inner.borrow()
-    }
-}
-
-impl<T> borrow::BorrowMut<T> for PyObjectRc<T>
-where
-    T: ?Sized + PyObjectPayload,
-    PyRc<PyObject<T>>: AsPyObjectRef + borrow::BorrowMut<T>,
-{
-    fn borrow_mut(&mut self) -> &mut T {
-        self.inner.borrow_mut()
-    }
-}
-
-impl<T> AsRef<T> for PyObjectRc<T>
-where
-    T: ?Sized + PyObjectPayload,
-    PyRc<PyObject<T>>: AsPyObjectRef + AsRef<T>,
-{
-    fn as_ref(&self) -> &T {
-        self.inner.as_ref()
-    }
-}
-
-impl<T> Clone for PyObjectWeak<T>
-where
-    T: ?Sized + PyObjectPayload,
-{
-    fn clone(&self) -> Self {
-        PyObjectWeak {
-            inner: self.inner.clone(),
+impl<T: PyObjectPayload> PyRef<T> {
+    /// Safety: payload type of `obj` must be `T`
+    unsafe fn from_obj_unchecked(obj: PyObjectRef) -> Self {
+        PyRef {
+            obj,
+            _payload: PhantomData,
         }
     }
-}
 
-impl<T> fmt::Debug for PyObjectWeak<T>
-where
-    T: ?Sized + PyObjectPayload,
-    PyObject<T>: fmt::Debug,
-{
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        self.inner.fmt(f)
+    #[inline(always)]
+    pub fn as_object(&self) -> &PyObjectRef {
+        &self.obj
+    }
+
+    #[inline(always)]
+    pub fn into_object(self) -> PyObjectRef {
+        self.obj
+    }
+
+    pub fn downgrade(this: &Self) -> PyWeakRef<T> {
+        PyWeakRef {
+            weak: PyObjectRef::downgrade(&this.obj),
+            _payload: PhantomData,
+        }
+    }
+
+    // ideally we'd be able to define this in pyobject.rs, but method visibility rules are weird
+    #[allow(clippy::new_ret_no_self)]
+    pub fn new_ref(
+        payload: T,
+        typ: crate::builtins::PyTypeRef,
+        dict: Option<crate::builtins::PyDictRef>,
+    ) -> Self {
+        let obj = PyObject::new(payload, typ, dict);
+        // SAFETY: we just created the object from a payload of type T
+        unsafe { Self::from_obj_unchecked(obj) }
     }
 }
 
-impl<T> borrow::Borrow<T> for PyObjectWeak<T>
+impl<T> Deref for PyRef<T>
 where
-    T: ?Sized + PyObjectPayload,
-    PyWeak<PyObject<T>>: borrow::Borrow<T>,
+    T: PyObjectPayload,
 {
-    fn borrow(&self) -> &T {
-        self.inner.borrow()
+    type Target = T;
+
+    fn deref(&self) -> &T {
+        let obj =
+            unsafe { &*(&*self.obj.inner.value as *const PyObject<Erased> as *const PyObject<T>) };
+        &obj.payload
     }
 }
 
-impl<T> borrow::BorrowMut<T> for PyObjectWeak<T>
-where
-    T: ?Sized + PyObjectPayload,
-    PyWeak<PyObject<T>>: borrow::BorrowMut<T>,
-{
-    fn borrow_mut(&mut self) -> &mut T {
-        self.inner.borrow_mut()
+pub struct PyWeakRef<T: PyObjectPayload> {
+    weak: PyObjectWeak,
+    _payload: PhantomData<PyWeak<T>>,
+}
+
+impl<T: PyObjectPayload> PyWeakRef<T> {
+    pub fn upgrade(&self) -> Option<PyRef<T>> {
+        self.weak.upgrade().map(|obj| unsafe {
+            // SAFETY: PyWeakRef<T> is only ever created from a PyRef<T>
+            PyRef::from_obj_unchecked(obj)
+        })
     }
 }
 
-impl<T> AsRef<T> for PyObjectWeak<T>
-where
-    T: ?Sized + PyObjectPayload,
-    PyWeak<PyObject<T>>: AsRef<T>,
-{
-    fn as_ref(&self) -> &T {
-        self.inner.as_ref()
+impl TypeProtocol for PyObjectRef {
+    fn class(&self) -> pyobject::PyLease<'_, crate::builtins::PyType> {
+        self.inner.value.class()
+    }
+}
+
+/// Paritally initialize a struct, ensuring that all fields are
+/// either given values or explicitly left uninitialized
+macro_rules! partially_init {
+    (
+        $ty:path {$($init_field:ident: $init_value:expr),*$(,)?},
+        Uninit { $($uninit_field:ident),*$(,)? }$(,)?
+    ) => {{
+        // check all the fields are there but *don't* actually run it
+        if false {
+            #[allow(invalid_value, dead_code, unreachable_code)]
+            let _ = {$ty {
+                $($init_field: $init_value,)*
+                $($uninit_field: unreachable!(),)*
+            }};
+        }
+        let mut m = ::std::mem::MaybeUninit::<$ty>::uninit();
+        #[allow(unused_unsafe)]
+        unsafe {
+            $(::std::ptr::write(&mut (*m.as_mut_ptr()).$init_field, $init_value);)*
+        }
+        m
+    }};
+}
+
+use crate::builtins::PyTypeRef;
+pub(crate) fn init_type_hierarchy() -> (PyTypeRef, PyTypeRef) {
+    use crate::builtins::{object, PyType, PyWeak};
+    use crate::common::lock::PyRwLock;
+    use crate::pyobject::{PyAttributes, PyClassDef, PyClassImpl};
+    use std::mem::MaybeUninit;
+    use std::ptr;
+
+    // `type` inherits from `object`
+    // and both `type` and `object are instances of `type`.
+    // to produce this circular dependency, we need an unsafe block.
+    // (and yes, this will never get dropped. TODO?)
+    let (type_type, object_type) = {
+        type PyTypeObj = PyObject<PyType>;
+        type UninitRef<T> = PyRwLock<PyRc<MaybeUninit<PyInner<T>>>>;
+
+        let type_payload = PyType {
+            name: PyTypeRef::NAME.to_owned(),
+            base: None,
+            bases: vec![],
+            mro: vec![],
+            subclasses: PyRwLock::default(),
+            attributes: PyRwLock::new(PyAttributes::new()),
+            slots: PyType::make_slots(),
+        };
+        let object_payload = PyType {
+            name: object::PyBaseObject::NAME.to_owned(),
+            base: None,
+            bases: vec![],
+            mro: vec![],
+            subclasses: PyRwLock::default(),
+            attributes: PyRwLock::new(PyAttributes::new()),
+            slots: object::PyBaseObject::make_slots(),
+        };
+        let type_type = PyRc::new(partially_init!(
+            PyInner::<PyType> {
+                typeid: TypeId::of::<PyType>(),
+                vtable: make_vtable!(PyType),
+            },
+            Uninit { value }
+        ));
+        let object_type = PyRc::new(partially_init!(
+            PyInner::<PyType> {
+                typeid: TypeId::of::<PyType>(),
+                vtable: make_vtable!(PyType),
+                // dict: None,
+                // payload: object_payload,
+            },
+            Uninit { value },
+        ));
+
+        let object_type_ptr = PyRc::into_raw(object_type) as *mut MaybeUninit<PyInner<PyType>>
+            as *mut PyInner<PyType>;
+        let type_type_ptr = PyRc::into_raw(type_type.clone()) as *mut MaybeUninit<PyInner<PyType>>
+            as *mut PyInner<PyType>;
+
+        unsafe {
+            // TODO: make this part of the partially_init!() method
+            // partially initialize the inner PyObject of PyInner
+            std::ptr::write(
+                &mut (*type_type_ptr).value as *mut ManuallyDrop<PyTypeObj>
+                    as *mut MaybeUninit<PyTypeObj>,
+                partially_init!(
+                    PyTypeObj {
+                        dict: None,
+                        payload: type_payload,
+                    },
+                    Uninit { typ }
+                ),
+            );
+            std::ptr::write(
+                &mut (*object_type_ptr).value as *mut ManuallyDrop<PyTypeObj>
+                    as *mut MaybeUninit<PyTypeObj>,
+                partially_init!(
+                    PyTypeObj {
+                        dict: None,
+                        payload: object_payload,
+                    },
+                    Uninit { typ }
+                ),
+            );
+
+            ptr::write(
+                &mut (*object_type_ptr).value.typ as *mut PyRwLock<PyTypeRef>
+                    as *mut UninitRef<PyType>,
+                PyRwLock::new(type_type.clone()),
+            );
+            ptr::write(
+                &mut (*type_type_ptr).value.typ as *mut PyRwLock<PyTypeRef>
+                    as *mut UninitRef<PyType>,
+                PyRwLock::new(type_type),
+            );
+
+            let type_type =
+                PyTypeRef::from_obj_unchecked(PyObjectRef::from_raw(type_type_ptr.cast()));
+            let object_type =
+                PyTypeRef::from_obj_unchecked(PyObjectRef::from_raw(object_type_ptr.cast()));
+
+            (*type_type_ptr).value.payload.mro = vec![object_type.clone()];
+            (*type_type_ptr).value.payload.bases = vec![object_type.clone()];
+            (*type_type_ptr).value.payload.base = Some(object_type.clone());
+
+            (type_type, object_type)
+        }
+    };
+
+    object_type
+        .subclasses
+        .write()
+        .push(PyWeak::downgrade(&type_type.as_object()));
+
+    (type_type, object_type)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    #[test]
+    fn test_type_initialization() {
+        let _ = init_type_hierarchy();
     }
 }

--- a/vm/src/pyobjectrc.rs
+++ b/vm/src/pyobjectrc.rs
@@ -517,7 +517,7 @@ pub(crate) fn init_type_hierarchy() -> (PyTypeRef, PyTypeRef) {
 mod tests {
     use super::*;
     #[test]
-    fn test_type_initialization() {
+    fn miri_test_type_initialization() {
         let _ = init_type_hierarchy();
     }
 }

--- a/vm/src/stdlib/io.rs
+++ b/vm/src/stdlib/io.rs
@@ -809,7 +809,7 @@ mod _io {
                     .into_pyobject(vm);
 
                 // TODO: loop if write() raises an interrupt
-                call_method(vm, self.raw.as_ref().unwrap(), "write", (memobj.clone(),))?
+                call_method(vm, self.raw.as_ref().unwrap(), "write", (memobj,))?
             } else {
                 let options = BufferOptions {
                     len,

--- a/vm/src/stdlib/itertools.rs
+++ b/vm/src/stdlib/itertools.rs
@@ -16,8 +16,8 @@ mod decl {
     use crate::function::{Args, FuncArgs, OptionalArg, OptionalOption};
     use crate::iterator::{call_next, get_all, get_iter, get_next_object};
     use crate::pyobject::{
-        BorrowValue, IdProtocol, IntoPyObject, PyCallable, PyObjectRc, PyObjectRef, PyObjectWeak,
-        PyRef, PyResult, PyValue, StaticType, TypeProtocol,
+        BorrowValue, IdProtocol, IntoPyObject, PyCallable, PyObjectRef, PyRef, PyResult, PyValue,
+        PyWeakRef, StaticType, TypeProtocol,
     };
     use crate::slots::PyIter;
     use crate::vm::VirtualMachine;
@@ -458,7 +458,7 @@ mod decl {
         current_value: Option<PyObjectRef>,
         current_key: Option<PyObjectRef>,
         next_group: bool,
-        grouper: Option<PyObjectWeak<PyItertoolsGrouper>>,
+        grouper: Option<PyWeakRef<PyItertoolsGrouper>>,
     }
 
     impl fmt::Debug for GroupByState {
@@ -573,7 +573,7 @@ mod decl {
             }
             .into_ref(vm);
 
-            state.grouper = Some(PyObjectRc::downgrade(&grouper.clone().into_typed_pyobj()));
+            state.grouper = Some(PyRef::downgrade(&grouper));
             Ok((state.current_key.as_ref().unwrap().clone(), grouper).into_pyobject(vm))
         }
     }

--- a/vm/src/stdlib/pystruct.rs
+++ b/vm/src/stdlib/pystruct.rs
@@ -445,7 +445,7 @@ pub(crate) mod _struct {
     where
         T: num_traits::PrimInt + for<'a> std::convert::TryFrom<&'a BigInt>,
     {
-        match vm.to_index_opt(arg.clone()) {
+        match vm.to_index_opt(arg) {
             Some(index) => try_to_primitive(index?.borrow_value(), vm),
             None => Err(new_struct_error(
                 vm,

--- a/vm/src/stdlib/weakref.rs
+++ b/vm/src/stdlib/weakref.rs
@@ -5,11 +5,11 @@
 //! - [rust weak struct](https://doc.rust-lang.org/std/rc/struct.Weak.html)
 //!
 
-use crate::pyobject::{PyObjectRc, PyObjectRef};
+use crate::pyobject::PyObjectRef;
 use crate::vm::VirtualMachine;
 
 fn weakref_getweakrefcount(obj: PyObjectRef) -> usize {
-    PyObjectRc::weak_count(&obj)
+    PyObjectRef::weak_count(&obj)
 }
 
 fn weakref_getweakrefs(_obj: PyObjectRef, vm: &VirtualMachine) -> PyObjectRef {

--- a/vm/src/sysmodule.rs
+++ b/vm/src/sysmodule.rs
@@ -6,8 +6,7 @@ use crate::common::hash::{PyHash, PyUHash};
 use crate::frame::FrameRef;
 use crate::function::{Args, FuncArgs, OptionalArg};
 use crate::pyobject::{
-    ItemProtocol, PyClassImpl, PyContext, PyObjectRc, PyObjectRef, PyRefExact, PyResult,
-    PyStructSequence,
+    ItemProtocol, PyClassImpl, PyContext, PyObjectRef, PyRefExact, PyResult, PyStructSequence,
 };
 use crate::vm::{PySettings, VirtualMachine};
 use crate::{builtins, exceptions, py_io, version};
@@ -137,7 +136,7 @@ impl SysFlags {
 }
 
 fn sys_getrefcount(obj: PyObjectRef) -> usize {
-    PyObjectRc::strong_count(&obj)
+    PyObjectRef::strong_count(&obj)
 }
 
 fn sys_getsizeof(obj: PyObjectRef) -> usize {


### PR DESCRIPTION
You can see a lot of the rationale for this in the comment at the top of `pyobjectrc.rs`. Here's the benchmark info:

```
Benchmark #1: ./rustpython-norm benchmarks/pystone.py 50000
  Time (mean ± σ):      6.282 s ±  0.198 s    [User: 6.247 s, System: 0.016 s]
  Range (min … max):    5.911 s …  6.542 s    10 runs
 
Benchmark #2: ./rustpython-opt benchmarks/pystone.py 50000
  Time (mean ± σ):      4.887 s ±  0.171 s    [User: 4.866 s, System: 0.008 s]
  Range (min … max):    4.687 s …  5.283 s    10 runs
 
Summary
  './rustpython-opt benchmarks/pystone.py 50000' ran
    1.29 ± 0.06 times faster than './rustpython-norm benchmarks/pystone.py 50000'
```