### PR TITLE
PEP 498 compatibility: parenthesized expressions for f-strings

### DIFF
--- a/ast/src/location.rs
+++ b/ast/src/location.rs
@@ -68,6 +68,10 @@ impl Location {
         self.column += 1;
     }
 
+    pub fn go_left(&mut self) {
+        self.column -= 1;
+    }
+
     pub fn newline(&mut self) {
         self.row += 1;
         self.column = 1;


### PR DESCRIPTION
Since we are already adding parentheses, we don't need to trim(), this also improves location information for `f'{  b  }`! 