### PR TITLE
Give the `rustpython` crate a library component

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -1,0 +1,3 @@
+pub fn main() {
+    rustpython::run(|_vm| {})
+}


### PR DESCRIPTION
A possible replacement for native extension modules for the moment.