### PR TITLE
wasm/notebook: mobile and tablet responsive layout

### DIFF
--- a/wasm/notebook/src/index.ejs
+++ b/wasm/notebook/src/index.ejs
@@ -12,7 +12,7 @@
 <body>
 
 <div class="d-flex">
-    <div class="header item-center">RustPython 🐍 😱 🤘</div>
+    <div class="header md-flex-grow text-center">RustPython 🐍 😱 🤘</div>
     <div>
         <a target="_blank" class="d-md-none mr-px-5 text-black" href="https://github.com/RustPython/RustPython/tree/master/wasm/notebook">how this works</a>
         <a target="_blank" class="text-black" href="https://github.com/RustPython/"> github</a>
@@ -21,26 +21,28 @@
    
     <!-- navigation bar -->
     <div class="nav-bar mt-px-5">
-        <div class="nav-bar-links d-flex d-flex-space-between">
-            <div class="d-flex">
-                <a href="#" id="run-btn" class="bg-orange text-white mr-px-5">run &#9658; </a>
-                <ul class="list-inline" id="buffers-list"></ul>
-                <a href="#" id="new-tab" class="bg-light mr-px-5 text-black">new tab</a>
-                <a href="#popup" id="import-code" class="bg-light mr-px-5 text-black">import code</a>
+        <div class="nav-bar-links d-flex d-flex-space-between d-sm-flex-direction-column">
+            <div class="d-flex d-sm-flex-direction-column ">
+                <a href="#" id="run-btn" class="bg-orange mr-px-5 text-white">run &#9658; </a>
+                <ul class="list-inline sm-mt-5px" id="buffers-list"></ul>
+                <ul class="list-inline sm-mt-5px">
+                    <li class="bg-light mr-px-5"> <a href="#" class="text-black" id="new-tab">new tab</a></li>
+                    <li class="bg-light mr-px-5"><a href="#popup" class="text-black" id="import-code">import code</a></li>
+                </ul>
             </div>
-            
-            <div class="nav-bar-links d-flex">
-                <a href="#" id="split-view" class="d-md-none bg-light mr-px-5 text-black">split view</a>
-                <a href="#" id="default-view" class="bg-light mr-px-5  text-black">default view</a>
-                <a href="#" id="reader-view" class="bg-light text-black">reader view</a>
+            <div class="nav-bar-links d-flex sm-mt-5px">
+                <ul class="list-inline ">
+                    <li class="d-md-none bg-light"><a href="#" id="split-view" class="mr-px-5 text-black">split view</a></li>
+                    <li class="d-md-none bg-light"><a href="#" id="default-view" class="mr-px-5  text-black">default view</a></li>
+                    <li class="d-md-none bg-light"><a href="#" id="reader-view" class="text-black">reader view</a></li>
+                </ul>
             </div>
-            
         </div>
     </div>
 
     <!-- code editor and output display -->
     <!-- split view -->
-    <div class="split-view full-height">
+    <div class="split-view full-height d-sm-flex-direction-column ">
         <div id="primary-editor"></div>
         <div id="secondary-editor" class="d-none">
             <select class="item-right" id="buffers-selection"></select>

--- a/wasm/notebook/src/index.ejs
+++ b/wasm/notebook/src/index.ejs
@@ -14,7 +14,7 @@
 <div class="d-flex">
     <div class="header item-center">RustPython 🐍 😱 🤘</div>
     <div>
-        <a target="_blank" class="mr-px-5 text-black" href="https://github.com/RustPython/RustPython/tree/master/wasm/notebook">how this works</a>
+        <a target="_blank" class="d-md-none mr-px-5 text-black" href="https://github.com/RustPython/RustPython/tree/master/wasm/notebook">how this works</a>
         <a target="_blank" class="text-black" href="https://github.com/RustPython/"> github</a>
     </div>
 </div>
@@ -30,7 +30,7 @@
             </div>
             
             <div class="nav-bar-links d-flex">
-                <a href="#" id="split-view" class="bg-light mr-px-5 text-black">split view</a>
+                <a href="#" id="split-view" class="d-md-none bg-light mr-px-5 text-black">split view</a>
                 <a href="#" id="default-view" class="bg-light mr-px-5  text-black">default view</a>
                 <a href="#" id="reader-view" class="bg-light text-black">reader view</a>
             </div>

--- a/wasm/notebook/src/style.css
+++ b/wasm/notebook/src/style.css
@@ -59,9 +59,8 @@ h6 {
     color: #fff;
 }
 
-.item-center {
+.flex-grow {
     flex-grow: 1;
-    text-align: center;
 }
 
 .item-right {
@@ -72,6 +71,10 @@ h6 {
 
 .text-right {
     text-align: right;
+}
+
+.text-center {
+    text-align: center;
 }
 
 .text-black {
@@ -241,6 +244,13 @@ input[type='url'] {
     overflow: auto;
 }
 
+@media screen and (min-width: 768px) {
+    .md-flex-grow {
+        flex-grow: 1;
+    }
+    
+}
+
 @media screen and (max-width: 768px) {
     .box {
         width: 70%;
@@ -254,4 +264,15 @@ input[type='url'] {
         display: none;
     }
 
+    .d-sm-flex-direction-column {
+        flex-direction: column;
+    }
+
+    .sm-mt-5px {
+        margin-top: 5px !important;
+    }
+
+    #run-btn {
+        width: 45px;
+    }
 }

--- a/wasm/notebook/src/style.css
+++ b/wasm/notebook/src/style.css
@@ -172,7 +172,7 @@ ul.list-inline li {
 input[type='url'] {
     border: 1px solid black;
     border-radius: 0px;
-    width: 85%;
+    width: 75%;
     font-size: 1rem;
     padding: 4px;
     font-family: monospace;
@@ -241,7 +241,7 @@ input[type='url'] {
     overflow: auto;
 }
 
-@media screen and (max-width: 700px) {
+@media screen and (max-width: 768px) {
     .box {
         width: 70%;
     }
@@ -249,4 +249,9 @@ input[type='url'] {
     .popup {
         width: 70%;
     }
+
+    .d-md-none {
+        display: none;
+    }
+
 }


### PR DESCRIPTION
This PR adds responsive layout to `wasm/notebook` on phone and ipad/tablets.

The notebook looked decent/good on phone and iPad (especially when the iPad is flipped horizontally).  Since I think those devices would be mostly used for reading code, not writing it, imho the layout is good enough for now (It can be better on phones tho). 

Here are some screenshots from tests on real devices. There is a problem with Chrome on Android (will open an issue).

## iPad (safari)  

![4031D3DD-5347-4ABE-A701-DDB95F7BFF9A](https://user-images.githubusercontent.com/521705/101559726-b71a6900-398f-11eb-8327-14c0186942f0.png)


## Android (Firefox)


![Screenshot_20201208_193255](https://user-images.githubusercontent.com/521705/101558954-0cee1180-398e-11eb-81df-7c31153be6bb.jpg  )

## Android (Chrome)

needs fixing, will create an issue.

![Screenshot_20201208_193819_com android chrome](https://user-images.githubusercontent.com/521705/101559900-22fcd180-3990-11eb-9508-3ecd3f72cbe4.jpg)



