### PR TITLE
Optimize the size of Instruction

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1814,6 +1814,7 @@ dependencies = [
  "itertools",
  "log",
  "num-complex",
+ "num-traits",
  "rustpython-ast",
  "rustpython-bytecode",
  "rustpython-parser",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -756,26 +756,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e88a8acf291dafb59c2d96e8f59828f3838bb1a70398823ade51a84de6a6deed"
 
 [[package]]
-name = "fehler"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d5729fe49ba028cd550747b6e62cd3d841beccab5390aa398538c31a2d983635"
-dependencies = [
- "fehler-macros",
-]
-
-[[package]]
-name = "fehler-macros"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ccb5acb1045ebbfa222e2c50679e392a71dd77030b78fb0189f2d9c5974400f9"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
 name = "fixedbitset"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1129,16 +1109,13 @@ dependencies = [
 ]
 
 [[package]]
-name = "lz-fear"
-version = "0.1.1"
+name = "lz4_flex"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "06aad1ce45e4ccf7a8d7d43e0c3ad38dc5d2255174a5f29a3c39d961fbc6181d"
+checksum = "2e7bea5a3a7bb3c040adc89eadadee33c3d39371b20dd980c952dd2642867b99"
 dependencies = [
- "bitflags",
  "byteorder",
- "fehler",
- "thiserror",
- "twox-hash",
+ "quick-error",
 ]
 
 [[package]]
@@ -1769,7 +1746,7 @@ dependencies = [
  "bitflags",
  "bstr",
  "itertools",
- "lz-fear",
+ "lz4_flex",
  "num-bigint",
  "num-complex",
  "serde",
@@ -2393,16 +2370,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "75cf45bb0bef80604d001caaec0d09da99611b3c0fd39d3080468875cdb65645"
 dependencies = [
  "serde",
-]
-
-[[package]]
-name = "twox-hash"
-version = "1.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "04f8ab788026715fa63b31960869617cba39117e520eb415b0139543e325ab59"
-dependencies = [
- "cfg-if 0.1.10",
- "static_assertions",
 ]
 
 [[package]]

--- a/bytecode/Cargo.toml
+++ b/bytecode/Cargo.toml
@@ -11,7 +11,7 @@ license = "MIT"
 [dependencies]
 bincode =  "1.1"
 bitflags = "1.1"
-lz-fear = "0.1"
+lz4_flex = "0.4"
 num-bigint = { version = "0.3", features = ["serde"] }
 num-complex = { version = "0.3", features = ["serde"] }
 serde = { version = "1.0", features = ["derive"] }

--- a/bytecode/src/bytecode.rs
+++ b/bytecode/src/bytecode.rs
@@ -225,7 +225,9 @@ pub enum Instruction {
     },
     Duplicate,
     GetIter,
-    Continue,
+    Continue {
+        target: Label,
+    },
     Break,
     Jump {
         target: Label,
@@ -598,7 +600,8 @@ impl<C: Constant> CodeObject<C> {
                 | SetupExcept { handler: l }
                 | SetupWith { end: l }
                 | SetupAsyncWith { end: l }
-                | SetupLoop { end: l } => {
+                | SetupLoop { end: l }
+                | Continue { target: l } => {
                     label_targets.insert(*l);
                 }
 
@@ -838,7 +841,7 @@ impl Instruction {
             Rotate { amount } => w!(Rotate, amount),
             Duplicate => w!(Duplicate),
             GetIter => w!(GetIter),
-            Continue => w!(Continue),
+            Continue { target } => w!(Continue, target),
             Break => w!(Break),
             Jump { target } => w!(Jump, target),
             JumpIfTrue { target } => w!(JumpIfTrue, target),

--- a/bytecode/src/bytecode.rs
+++ b/bytecode/src/bytecode.rs
@@ -117,15 +117,12 @@ pub struct CodeObject<C: Constant = ConstantData> {
 bitflags! {
     #[derive(Serialize, Deserialize)]
     pub struct CodeFlags: u16 {
-        const HAS_DEFAULTS = 0x01;
-        const HAS_KW_ONLY_DEFAULTS = 0x02;
-        const HAS_ANNOTATIONS = 0x04;
-        const NEW_LOCALS = 0x08;
-        const IS_GENERATOR = 0x10;
-        const IS_COROUTINE = 0x20;
-        const HAS_VARARGS = 0x40;
-        const HAS_VARKEYWORDS = 0x80;
-        const IS_OPTIMIZED = 0x0100;
+        const NEW_LOCALS = 0x01;
+        const IS_GENERATOR = 0x02;
+        const IS_COROUTINE = 0x04;
+        const HAS_VARARGS = 0x08;
+        const HAS_VARKEYWORDS = 0x10;
+        const IS_OPTIMIZED = 0x20;
     }
 }
 
@@ -250,7 +247,7 @@ pub enum Instruction {
     JumpIfFalseOrPop {
         target: Label,
     },
-    MakeFunction,
+    MakeFunction(MakeFunctionFlags),
     CallFunctionPositional {
         nargs: usize,
     },
@@ -368,6 +365,16 @@ pub enum Instruction {
 }
 
 use self::Instruction::*;
+
+bitflags! {
+    #[derive(Serialize, Deserialize)]
+    pub struct MakeFunctionFlags: u8 {
+        const CLOSURE = 0x01;
+        const ANNOTATIONS = 0x02;
+        const KW_ONLY_DEFAULTS = 0x04;
+        const DEFAULTS = 0x08;
+    }
+}
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub enum ConstantData {
@@ -876,7 +883,7 @@ impl Instruction {
             JumpIfFalse { target } => w!(JumpIfFalse, target),
             JumpIfTrueOrPop { target } => w!(JumpIfTrueOrPop, target),
             JumpIfFalseOrPop { target } => w!(JumpIfFalseOrPop, target),
-            MakeFunction => w!(MakeFunction),
+            MakeFunction(flags) => w!(MakeFunction, format_args!("{:?}", flags)),
             CallFunctionPositional { nargs } => w!(CallFunctionPositional, nargs),
             CallFunctionKeyword { nargs } => w!(CallFunctionKeyword, nargs),
             CallFunctionEx { has_kwargs } => w!(CallFunctionEx, has_kwargs),

--- a/compiler/Cargo.toml
+++ b/compiler/Cargo.toml
@@ -13,6 +13,7 @@ itertools = "0.9"
 rustpython-bytecode = { path = "../bytecode", version = "0.1.1" }
 rustpython-ast = { path = "../ast" }
 num-complex = { version = "0.3", features = ["serde"] }
+num-traits = "0.2"
 log = "0.4"
 arrayvec = "0.5"
 

--- a/compiler/src/error.rs
+++ b/compiler/src/error.rs
@@ -37,6 +37,7 @@ pub enum CompileErrorType {
     InvalidFuturePlacement,
     InvalidFutureFeature(String),
     FunctionImportStar,
+    TooManyStarUnpack,
 }
 
 impl fmt::Display for CompileErrorType {
@@ -69,6 +70,9 @@ impl fmt::Display for CompileErrorType {
             }
             CompileErrorType::FunctionImportStar => {
                 write!(f, "import * only allowed at module level")
+            }
+            CompileErrorType::TooManyStarUnpack => {
+                write!(f, "too many expressions in star-unpacking assignment")
             }
         }
     }

--- a/compiler/src/lib.rs
+++ b/compiler/src/lib.rs
@@ -1,5 +1,4 @@
-//! Compile a Python AST or source code into bytecode consumable by RustPython or
-//! (eventually) CPython.
+//! Compile a Python AST or source code into bytecode consumable by RustPython.
 #![doc(html_logo_url = "https://raw.githubusercontent.com/RustPython/RustPython/master/logo.png")]
 #![doc(html_root_url = "https://docs.rs/rustpython-compiler/")]
 

--- a/jit/src/instructions.rs
+++ b/jit/src/instructions.rs
@@ -320,7 +320,7 @@ impl<'a, 'b> FunctionCompiler<'a, 'b> {
                     _ => Err(JitCompileError::NotSupported),
                 }
             }
-            Instruction::BinaryOperation { op, .. } => {
+            Instruction::BinaryOperation { op } | Instruction::BinaryOperationInplace { op } => {
                 // the rhs is popped off first
                 let b = self.stack.pop().ok_or(JitCompileError::BadBytecode)?;
                 let a = self.stack.pop().ok_or(JitCompileError::BadBytecode)?;

--- a/jit/tests/common.rs
+++ b/jit/tests/common.rs
@@ -78,13 +78,15 @@ impl StackMachine {
         names: &[String],
     ) -> bool {
         match instruction {
-            Instruction::LoadConst { idx } => self.stack.push(constants[idx].clone().into()),
-            Instruction::LoadNameAny(idx) => {
-                self.stack.push(StackValue::String(names[idx].clone()))
+            Instruction::LoadConst { idx } => {
+                self.stack.push(constants[idx as usize].clone().into())
             }
+            Instruction::LoadNameAny(idx) => self
+                .stack
+                .push(StackValue::String(names[idx as usize].clone())),
             Instruction::StoreLocal(idx) => {
                 self.locals
-                    .insert(names[idx].clone(), self.stack.pop().unwrap());
+                    .insert(names[idx as usize].clone(), self.stack.pop().unwrap());
             }
             Instruction::StoreAttr { .. } => {
                 // Do nothing except throw away the stack values
@@ -104,7 +106,7 @@ impl StackMachine {
                 }
                 self.stack.push(StackValue::Map(map));
             }
-            Instruction::MakeFunction => {
+            Instruction::MakeFunction(_flags) => {
                 let name = if let Some(StackValue::String(name)) = self.stack.pop() {
                     name
                 } else {
@@ -134,7 +136,7 @@ impl StackMachine {
                 let mut values = Vec::new();
 
                 // Pop all values from stack:
-                values.extend(self.stack.drain(self.stack.len() - amount..));
+                values.extend(self.stack.drain(self.stack.len() - amount as usize..));
 
                 // Push top of stack back first:
                 self.stack.push(values.pop().unwrap());

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -510,7 +510,7 @@ fn run_rustpython(vm: &VirtualMachine, matches: &ArgMatches) -> PyResult<()> {
     vm.get_attribute(vm.sys_module.clone(), "modules")?
         .set_item("__main__", main_module, vm)?;
 
-    let site_result = vm.import("site", &[], 0);
+    let site_result = vm.import("site", None, 0);
 
     if site_result.is_err() {
         warn!(
@@ -559,7 +559,7 @@ fn run_command(vm: &VirtualMachine, scope: Scope, source: String) -> PyResult<()
 
 fn run_module(vm: &VirtualMachine, module: &str) -> PyResult<()> {
     debug!("Running module {}", module);
-    let runpy = vm.import("runpy", &[], 0)?;
+    let runpy = vm.import("runpy", None, 0)?;
     let run_module_as_main = vm.get_attribute(runpy, "_run_module_as_main")?;
     vm.invoke(&run_module_as_main, (module,))?;
     Ok(())

--- a/vm/src/builtins/frame.rs
+++ b/vm/src/builtins/frame.rs
@@ -73,7 +73,7 @@ impl FrameRef {
     }
 
     #[pyproperty]
-    fn f_lasti(self) -> usize {
+    fn f_lasti(self) -> u32 {
         self.lasti()
     }
 

--- a/vm/src/builtins/module.rs
+++ b/vm/src/builtins/module.rs
@@ -82,7 +82,7 @@ impl PyModule {
 
     #[pymethod(magic)]
     fn repr(zelf: PyRef<Self>, vm: &VirtualMachine) -> PyResult {
-        let importlib = vm.import("_frozen_importlib", &[], 0)?;
+        let importlib = vm.import("_frozen_importlib", None, 0)?;
         let module_repr = vm.get_attribute(importlib, "_module_repr")?;
         vm.invoke(&module_repr, (zelf,))
     }

--- a/vm/src/builtins/object.rs
+++ b/vm/src/builtins/object.rs
@@ -314,11 +314,11 @@ pub fn init(context: &PyContext) {
 
 fn common_reduce(obj: PyObjectRef, proto: usize, vm: &VirtualMachine) -> PyResult {
     if proto >= 2 {
-        let reducelib = vm.import("__reducelib", &[], 0)?;
+        let reducelib = vm.import("__reducelib", None, 0)?;
         let reduce_2 = vm.get_attribute(reducelib, "reduce_2")?;
         vm.invoke(&reduce_2, (obj,))
     } else {
-        let copyreg = vm.import("copyreg", &[], 0)?;
+        let copyreg = vm.import("copyreg", None, 0)?;
         let reduce_ex = vm.get_attribute(copyreg, "_reduce_ex")?;
         vm.invoke(&reduce_ex, (obj, proto))
     }

--- a/vm/src/builtins/pystr.rs
+++ b/vm/src/builtins/pystr.rs
@@ -95,12 +95,14 @@ impl fmt::Display for PyStr {
 }
 
 impl TryIntoRef<PyStr> for String {
+    #[inline]
     fn try_into_ref(self, vm: &VirtualMachine) -> PyResult<PyRef<PyStr>> {
         Ok(PyStr::from(self).into_ref(vm))
     }
 }
 
 impl TryIntoRef<PyStr> for &str {
+    #[inline]
     fn try_into_ref(self, vm: &VirtualMachine) -> PyResult<PyRef<PyStr>> {
         Ok(PyStr::from(self).into_ref(vm))
     }

--- a/vm/src/builtins/traceback.rs
+++ b/vm/src/builtins/traceback.rs
@@ -8,7 +8,7 @@ use crate::vm::VirtualMachine;
 pub struct PyTraceback {
     pub next: Option<PyTracebackRef>, // TODO: Make mutable
     pub frame: FrameRef,
-    pub lasti: usize,
+    pub lasti: u32,
     pub lineno: usize,
 }
 
@@ -22,7 +22,7 @@ impl PyValue for PyTraceback {
 
 #[pyimpl]
 impl PyTraceback {
-    pub fn new(next: Option<PyRef<Self>>, frame: FrameRef, lasti: usize, lineno: usize) -> Self {
+    pub fn new(next: Option<PyRef<Self>>, frame: FrameRef, lasti: u32, lineno: usize) -> Self {
         PyTraceback {
             next,
             frame,
@@ -37,7 +37,7 @@ impl PyTraceback {
     }
 
     #[pyproperty(name = "tb_lasti")]
-    fn lasti(&self) -> usize {
+    fn lasti(&self) -> u32 {
         self.lasti
     }
 

--- a/vm/src/builtins/tuple.rs
+++ b/vm/src/builtins/tuple.rs
@@ -317,6 +317,7 @@ impl<T: TransmuteFromObject> TryFromObject for PyTupleTyped<T> {
 
 impl<'a, T: TransmuteFromObject + 'a> BorrowValue<'a> for PyTupleTyped<T> {
     type Borrowed = &'a [T];
+    #[inline]
     fn borrow_value(&'a self) -> Self::Borrowed {
         unsafe { &*(self.tuple.borrow_value() as *const [PyObjectRef] as *const [T]) }
     }
@@ -325,5 +326,19 @@ impl<'a, T: TransmuteFromObject + 'a> BorrowValue<'a> for PyTupleTyped<T> {
 impl<T: TransmuteFromObject + fmt::Debug> fmt::Debug for PyTupleTyped<T> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         self.borrow_value().fmt(f)
+    }
+}
+
+impl<T: TransmuteFromObject> From<PyTupleTyped<T>> for PyTupleRef {
+    #[inline]
+    fn from(tup: PyTupleTyped<T>) -> Self {
+        tup.tuple
+    }
+}
+
+impl<T: TransmuteFromObject> IntoPyObject for PyTupleTyped<T> {
+    #[inline]
+    fn into_pyobject(self, _vm: &VirtualMachine) -> PyObjectRef {
+        self.tuple.into_object()
     }
 }

--- a/vm/src/import.rs
+++ b/vm/src/import.rs
@@ -36,7 +36,7 @@ pub(crate) fn init_importlib(
             let install_external = vm.get_attribute(importlib, "_install_external_importers")?;
             vm.invoke(&install_external, ())?;
             // Set pyc magic number to commit hash. Should be changed when bytecode will be more stable.
-            let importlib_external = vm.import("_frozen_importlib_external", &[], 0)?;
+            let importlib_external = vm.import("_frozen_importlib_external", None, 0)?;
             let mut magic = get_git_revision().into_bytes();
             magic.truncate(4);
             if magic.len() != 4 {
@@ -44,7 +44,7 @@ pub(crate) fn init_importlib(
             }
             vm.set_attr(&importlib_external, "MAGIC_NUMBER", vm.ctx.new_bytes(magic))?;
             let zipimport_res = (|| -> PyResult<()> {
-                let zipimport = vm.import("zipimport", &[], 0)?;
+                let zipimport = vm.import("zipimport", None, 0)?;
                 let zipimporter = vm.get_attribute(zipimport, "zipimporter")?;
                 let path_hooks = vm.get_attribute(vm.sys_module.clone(), "path_hooks")?;
                 let path_hooks = list::PyListRef::try_from_object(vm, path_hooks)?;

--- a/vm/src/pyobject.rs
+++ b/vm/src/pyobject.rs
@@ -763,6 +763,7 @@ pub trait TryIntoRef<T: PyObjectPayload> {
 }
 
 impl<T: PyObjectPayload> TryIntoRef<T> for PyRef<T> {
+    #[inline]
     fn try_into_ref(self, _vm: &VirtualMachine) -> PyResult<PyRef<T>> {
         Ok(self)
     }

--- a/vm/src/pyobjectrc.rs
+++ b/vm/src/pyobjectrc.rs
@@ -317,7 +317,7 @@ impl Drop for PyObjectRef {
                         Ok(v) => println!("{}", v.to_string()),
                         Err(_) => println!("{}", del_method.class().name),
                     }
-                    let tb_module = vm.import("traceback", &[], 0).unwrap();
+                    let tb_module = vm.import("traceback", None, 0).unwrap();
                     // TODO: set exc traceback
                     let print_stack = vm.get_attribute(tb_module, "print_stack").unwrap();
                     vm.invoke(&print_stack, ()).unwrap();


### PR DESCRIPTION
This reduces the size of the Instruction enum from 56 bytes to 16 bytes, which should help with memory usage as well as a (very) slight performance boost:
```
Benchmark #1: ./rustpython-norm benchmarks/pystone.py 50000
  Time (mean ± σ):      3.655 s ±  0.119 s    [User: 3.637 s, System: 0.007 s]
  Range (min … max):    3.522 s …  3.853 s    10 runs
 
Benchmark #2: ./rustpython-opt benchmarks/pystone.py 50000
  Time (mean ± σ):      3.624 s ±  0.074 s    [User: 3.601 s, System: 0.008 s]
  Range (min … max):    3.557 s …  3.783 s    10 runs
 
Summary
  './rustpython-opt benchmarks/pystone.py 50000' ran
    1.01 ± 0.04 times faster than './rustpython-norm benchmarks/pystone.py 50000'
```

The instructions I changed were either a) flattening an inner enum, like `CallFunction { CallType } -> CallFunction{Positional,Keyword,Ex}` b) not in many hot paths, like Import, or c) provided redundant information, like SetupLoop, whose `start` field always pointed to `lasti+1`

Edit: well, SetupLoop isn't actually like that, but there was a way around it
