### PR TITLE
Serialize entire frozen hashmap to bytes

### DIFF
--- a/examples/freeze/main.rs
+++ b/examples/freeze/main.rs
@@ -1,5 +1,3 @@
-use std::collections::HashMap;
-
 use rustpython_vm as vm;
 
 fn main() -> vm::pyobject::PyResult<()> {
@@ -11,13 +9,9 @@ fn run(vm: &vm::VirtualMachine) -> vm::pyobject::PyResult<()> {
 
     // the file parameter is relevant to the directory where the crate's Cargo.toml is located, see $CARGO_MANIFEST_DIR:
     // https://doc.rust-lang.org/cargo/reference/environment-variables.html#environment-variables-cargo-sets-for-crates
-    let modules: HashMap<String, vm::bytecode::FrozenModule> =
-        vm::py_freeze!(file = "examples/freeze/freeze.py");
+    let module = vm::py_compile!(file = "examples/freeze/freeze.py");
 
-    let res = vm.run_code_obj(
-        vm.new_code_object(modules.get("frozen").unwrap().code.clone()),
-        scope,
-    );
+    let res = vm.run_code_obj(vm.new_code_object(module), scope);
 
     if let Err(err) = res {
         vm::exceptions::print_exception(&vm, err);

--- a/vm/pylib-crate/src/lib.rs
+++ b/vm/pylib-crate/src/lib.rs
@@ -5,8 +5,8 @@
 pub const LIB_PATH: &str = concat!(env!("CARGO_MANIFEST_DIR"), "/Lib");
 
 #[cfg(feature = "compiled-bytecode")]
-use {rustpython_bytecode::FrozenModule, std::collections::HashMap};
+use rustpython_bytecode::FrozenModule;
 #[cfg(feature = "compiled-bytecode")]
-pub fn frozen_stdlib() -> HashMap<String, FrozenModule> {
+pub fn frozen_stdlib() -> impl Iterator<Item = (String, FrozenModule)> {
     rustpython_derive::py_freeze!(dir = "Lib", crate_name = "rustpython_bytecode")
 }

--- a/vm/src/frozen.rs
+++ b/vm/src/frozen.rs
@@ -1,7 +1,6 @@
 use crate::builtins::code;
 use crate::bytecode;
 use crate::VirtualMachine;
-use std::collections::HashMap;
 
 pub fn map_frozen<'a>(
     vm: &'a VirtualMachine,
@@ -19,18 +18,19 @@ pub fn map_frozen<'a>(
         })
 }
 
-pub fn get_module_inits(
-    vm: &VirtualMachine,
-) -> HashMap<String, code::FrozenModule, ahash::RandomState> {
-    let mut modules = HashMap::default();
-
+pub fn get_module_inits() -> impl Iterator<Item = (String, bytecode::FrozenModule)> {
+    let iter = std::iter::empty();
     macro_rules! ext_modules {
-        ($($t:tt)*) => {
-            modules.extend(map_frozen(vm, py_freeze!($($t)*)));
+        ($iter:ident, ($modules:expr)) => {
+            let $iter = $iter.chain($modules);
+        };
+        ($iter:ident, $($t:tt)*) => {
+            ext_modules!($iter, (py_freeze!($($t)*)))
         };
     }
 
     ext_modules!(
+        iter,
         source = "initialized = True; print(\"Hello world!\")\n",
         module_name = "__hello__",
     );
@@ -39,19 +39,15 @@ pub fn get_module_inits(
     // in theory be implemented in Rust, but are easiest to do in Python for one reason or another.
     // Includes _importlib_bootstrap and _importlib_bootstrap_external
     // For Windows: did you forget to run `powershell scripts\symlinks-to-hardlinks.ps1`?
-    ext_modules!(dir = "Lib/python_builtins/");
+    ext_modules!(iter, dir = "Lib/python_builtins/");
 
     #[cfg(not(feature = "freeze-stdlib"))]
-    {
-        // core stdlib Python modules that the vm calls into, but are still used in Python
-        // application code, e.g. copyreg
-        ext_modules!(dir = "Lib/core_modules/");
-    }
+    // core stdlib Python modules that the vm calls into, but are still used in Python
+    // application code, e.g. copyreg
+    ext_modules!(iter, dir = "Lib/core_modules/");
     // if we're on freeze-stdlib, the core stdlib modules will be included anyway
     #[cfg(feature = "freeze-stdlib")]
-    {
-        modules.extend(map_frozen(vm, rustpython_pylib::frozen_stdlib()));
-    }
+    ext_modules!(iter, (rustpython_pylib::frozen_stdlib()));
 
-    modules
+    iter
 }

--- a/vm/src/vm.rs
+++ b/vm/src/vm.rs
@@ -282,7 +282,7 @@ impl VirtualMachine {
             initialized: false,
         };
 
-        let frozen = frozen::get_module_inits(&vm);
+        let frozen = frozen::map_frozen(&vm, frozen::get_module_inits()).collect();
         PyRc::get_mut(&mut vm.state).unwrap().frozen = frozen;
 
         module::init_module_dict(


### PR DESCRIPTION
So instead of `hashmap! { "a" => decode(b"....."), "b" => decode(b"......") }`, it's just `decode(b"<map>")`

release binary sizes:

|        | default | freeze-stdlib |
| :----- | ------: | ------------: |
| master | 18296   | 29908         |
| libmap | 18292   | 24832         |

My hunch on this was that putting all the data in the same buffer gives lz4 more opportunity to deduplicate, and I'm pretty sure that's what made the difference in binary size.