### PR TITLE
Fix whats_new.sh not finding libraries that are directories

### DIFF
--- a/extra_tests/generator/not_impl_modules_footer.txt
+++ b/extra_tests/generator/not_impl_modules_footer.txt
@@ -9,7 +9,7 @@ def dir_of_mod_or_default(module, default=None):
 
 mod_names = [
     name.decode() for name, ext in map(os.path.splitext, os.listdir(libdir))
-    if ext == b'.py' or os.path.isdir(f'{libdir}/{name}')]
+    if ext == b'.py' or os.path.isdir(os.path.join(libdir, name))]
 mod_names += list(sys.builtin_module_names)
 
 not_imported = {'not imported'}


### PR DESCRIPTION
I was wondering why `whats_left` says the entire `collections` module isn't implemented yet. It's because both `libdir` and `name` are `bytes`, when you format them into a string, you get a invalid path with `b''` in it.