### PR TITLE
Fix BufferedReader over a SocketIO to properly read the right amount

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -783,9 +783,9 @@ dependencies = [
 
 [[package]]
 name = "flate2"
-version = "1.0.19"
+version = "1.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7411863d55df97a419aa64cb4d2f167103ea9d767e2c54a1868b7ac3f6b47129"
+checksum = "cd3aec53de10fe96d7d8c565eb17f2c687bb5518a2ec453b5b1252964526abe0"
 dependencies = [
  "cfg-if 1.0.0",
  "crc32fast",

--- a/vm/Cargo.toml
+++ b/vm/Cargo.toml
@@ -124,7 +124,7 @@ num_cpus = "1"
 
 [target.'cfg(not(any(target_arch = "wasm32", target_os = "redox")))'.dependencies]
 dns-lookup = "1.0"
-flate2 = { version = "1.0", features = ["zlib"], default-features = false }
+flate2 = { version = "1.0.20", features = ["zlib"], default-features = false }
 libz-sys = "1.0"
 
 [target.'cfg(windows)'.dependencies]

--- a/vm/src/builtins/memory.rs
+++ b/vm/src/builtins/memory.rs
@@ -95,7 +95,13 @@ impl Buffer for RcBuffer {
 
 pub trait Buffer: Debug + PyThreadingConstraint {
     fn get_options(&self) -> &BufferOptions;
+    /// Get the full inner buffer of this memory. You probably want [`as_contiguous()`], as
+    /// `obj_bytes` doesn't take into account the range a memoryview might operate on, among other
+    /// footguns.
     fn obj_bytes(&self) -> BorrowedValue<[u8]>;
+    /// Get the full inner buffer of this memory, mutably. You probably want
+    /// [`as_contiguous_mut()`], as `obj_bytes` doesn't take into account the range a memoryview
+    /// might operate on, among other footguns.
     fn obj_bytes_mut(&self) -> BorrowedValueMut<[u8]>;
     fn release(&self);
 

--- a/vm/src/py_io.rs
+++ b/vm/src/py_io.rs
@@ -30,25 +30,6 @@ impl Write for PyWriter<'_> {
     }
 }
 
-pub fn write_all(
-    mut buf: &[u8],
-    mut write: impl FnMut(&[u8]) -> io::Result<usize>,
-) -> io::Result<()> {
-    while !buf.is_empty() {
-        match write(buf) {
-            Ok(0) => {
-                return Err(io::Error::new(
-                    io::ErrorKind::WriteZero,
-                    "failed to write whole buffer",
-                ))
-            }
-            Ok(n) => buf = &buf[n..],
-            Err(e) => return Err(e),
-        }
-    }
-    Ok(())
-}
-
 pub fn file_readline(obj: &PyObjectRef, size: Option<usize>, vm: &VirtualMachine) -> PyResult {
     let args = size.map_or_else(Vec::new, |size| vec![vm.ctx.new_int(size)]);
     let ret = vm.call_method(obj, "readline", args)?;

--- a/vm/src/stdlib/select.rs
+++ b/vm/src/stdlib/select.rs
@@ -13,18 +13,18 @@ pub(crate) fn make_module(vm: &VirtualMachine) -> PyObjectRef {
 
 #[cfg(unix)]
 mod platform {
-    pub(super) use libc::{fd_set, select, timeval, FD_ISSET, FD_SET, FD_SETSIZE, FD_ZERO};
-    pub(super) use std::os::unix::io::RawFd;
+    pub use libc::{fd_set, select, timeval, FD_ISSET, FD_SET, FD_SETSIZE, FD_ZERO};
+    pub use std::os::unix::io::RawFd;
 }
 
 #[allow(non_snake_case)]
 #[cfg(windows)]
 mod platform {
-    pub(super) use winapi::um::winsock2::{fd_set, select, timeval, FD_SETSIZE, SOCKET as RawFd};
+    pub use winapi::um::winsock2::{fd_set, select, timeval, FD_SETSIZE, SOCKET as RawFd};
 
     // from winsock2.h: https://gist.github.com/piscisaureus/906386#file-winsock2-h-L128-L141
 
-    pub(super) unsafe fn FD_SET(fd: RawFd, set: *mut fd_set) {
+    pub unsafe fn FD_SET(fd: RawFd, set: *mut fd_set) {
         let mut i = 0;
         for idx in 0..(*set).fd_count as usize {
             i = idx;
@@ -40,17 +40,18 @@ mod platform {
         }
     }
 
-    pub(super) unsafe fn FD_ZERO(set: *mut fd_set) {
+    pub unsafe fn FD_ZERO(set: *mut fd_set) {
         (*set).fd_count = 0;
     }
 
-    pub(super) unsafe fn FD_ISSET(fd: RawFd, set: *mut fd_set) -> bool {
+    pub unsafe fn FD_ISSET(fd: RawFd, set: *mut fd_set) -> bool {
         use winapi::um::winsock2::__WSAFDIsSet;
         __WSAFDIsSet(fd as _, set) != 0
     }
 }
 
-use platform::{timeval, RawFd};
+pub use platform::timeval;
+use platform::RawFd;
 
 struct Selectable {
     obj: PyObjectRef,

--- a/vm/src/stdlib/socket.rs
+++ b/vm/src/stdlib/socket.rs
@@ -703,6 +703,7 @@ fn sock_select(sock: &Socket, kind: SelectKind, interval: Option<Duration>) -> i
         let mut writes = select::FdSet::new();
         let mut errs = select::FdSet::new();
 
+        let fd = fd as usize;
         match kind {
             SelectKind::Read => reads.insert(fd),
             SelectKind::Write => writes.insert(fd),
@@ -712,7 +713,7 @@ fn sock_select(sock: &Socket, kind: SelectKind, interval: Option<Duration>) -> i
             }
         }
 
-        let mut interval = interval.map(|dur| libc::timeval {
+        let mut interval = interval.map(|dur| select::timeval {
             tv_sec: dur.as_secs() as _,
             tv_usec: dur.subsec_micros() as _,
         });

--- a/vm/src/stdlib/socket.rs
+++ b/vm/src/stdlib/socket.rs
@@ -6,7 +6,7 @@ use socket2::{Domain, Protocol, Socket, Type as SocketType};
 use std::convert::TryFrom;
 use std::io;
 use std::net::{Ipv4Addr, Ipv6Addr, Shutdown, SocketAddr, ToSocketAddrs};
-use std::time::Duration;
+use std::time::{Duration, Instant};
 
 use crate::builtins::bytes::PyBytesRef;
 use crate::builtins::pystr::{PyStr, PyStrRef};
@@ -20,7 +20,7 @@ use crate::pyobject::{
     BorrowValue, Either, IntoPyObject, PyClassImpl, PyObjectRef, PyRef, PyResult, PyValue,
     StaticType, TryFromObject,
 };
-use crate::{py_io, VirtualMachine};
+use crate::VirtualMachine;
 
 #[cfg(unix)]
 type RawSocket = std::os::unix::io::RawFd;
@@ -130,11 +130,57 @@ impl PySocket {
         Ok(())
     }
 
-    fn sock_op<F, R>(&self, vm: &VirtualMachine, mut f: F) -> PyResult<R>
+    fn sock_op<F, R>(&self, vm: &VirtualMachine, select: SelectKind, f: F) -> PyResult<R>
     where
         F: FnMut() -> io::Result<R>,
     {
+        let timeout = self.timeout.load();
+        let timeout = if timeout > 0.0 {
+            Some(Duration::from_secs_f64(timeout))
+        } else {
+            None
+        };
+        self.sock_op_timeout(vm, select, timeout, f)
+    }
+
+    fn sock_op_timeout<F, R>(
+        &self,
+        vm: &VirtualMachine,
+        select: SelectKind,
+        timeout: Option<Duration>,
+        mut f: F,
+    ) -> PyResult<R>
+    where
+        F: FnMut() -> io::Result<R>,
+    {
+        let mut deadline: Option<Instant> = None;
+
         loop {
+            if timeout.is_some() || matches!(select, SelectKind::Connect) {
+                let interval = timeout.map(|dur| match deadline {
+                    Some(d) => d
+                        .checked_duration_since(Instant::now())
+                        // past the deadline already
+                        .ok_or_else(|| timeout_error(vm)),
+                    None => {
+                        let dl = Instant::now() + dur;
+                        deadline = Some(dl);
+                        Ok(dur)
+                    }
+                });
+                let interval = interval.transpose()?;
+                let res = sock_select(&self.sock(), select, interval);
+                match res {
+                    Ok(true) => return Err(timeout_error(vm)),
+                    Err(e) if e.kind() == io::ErrorKind::Interrupted => {
+                        vm.check_signals()?;
+                        continue;
+                    }
+                    Err(e) => return Err(convert_sock_error(vm, e)),
+                    Ok(false) => {} // no timeout, continue as normal
+                }
+            }
+
             let err = loop {
                 // loop on interrupt
                 match f() {
@@ -143,7 +189,7 @@ impl PySocket {
                     Err(e) => break e,
                 }
             };
-            if self.timeout.load() > 0.0 && err.kind() == io::ErrorKind::WouldBlock {
+            if timeout.is_some() && err.kind() == io::ErrorKind::WouldBlock {
                 continue;
             }
             return Err(convert_sock_error(vm, err));
@@ -153,14 +199,35 @@ impl PySocket {
     #[pymethod]
     fn connect(&self, address: Address, vm: &VirtualMachine) -> PyResult<()> {
         let sock_addr = get_addr(vm, address, Some(self.family.load()))?;
-        let timeout = self.timeout.load();
-        let res = if timeout > 0.0 {
-            let timeout = Duration::from_secs_f64(timeout);
-            self.sock().connect_timeout(&sock_addr, timeout)
-        } else {
-            self.sock().connect(&sock_addr)
+
+        let err = match self.sock().connect(&sock_addr) {
+            Ok(()) => return Ok(()),
+            Err(e) => e,
         };
-        res.map_err(|err| convert_sock_error(vm, err))
+
+        let wait_connect = if err.kind() == io::ErrorKind::Interrupted {
+            vm.check_signals()?;
+            self.timeout.load() != 0.0
+        } else {
+            self.timeout.load() > 0.0 && err.raw_os_error() == Some(libc::EINPROGRESS)
+        };
+
+        if wait_connect {
+            // basically, connect() is async, and it registers an "error" on the socket when it's
+            // done connecting. SelectKind::Connect fills the errorfds fd_set, so if we wake up
+            // from poll and the error is EISCONN then we know that the connect is done
+            self.sock_op(vm, SelectKind::Connect, || {
+                let sock = self.sock();
+                let err = sock.take_error()?;
+                match err {
+                    Some(e) if e.raw_os_error() == Some(libc::EISCONN) => Ok(()),
+                    Some(e) => Err(e),
+                    None => Ok(()),
+                }
+            })
+        } else {
+            Err(convert_sock_error(vm, err))
+        }
     }
 
     #[pymethod]
@@ -182,11 +249,7 @@ impl PySocket {
 
     #[pymethod]
     fn _accept(&self, vm: &VirtualMachine) -> PyResult<(RawSocket, AddrTuple)> {
-        let (sock, addr) = self
-            .sock()
-            .accept()
-            .map_err(|err| convert_sock_error(vm, err))?;
-
+        let (sock, addr) = self.sock_op(vm, SelectKind::Read, || self.sock().accept())?;
         let fd = into_sock_fileno(sock);
         Ok((fd, get_addr_tuple(addr)))
     }
@@ -201,7 +264,9 @@ impl PySocket {
         let flags = flags.unwrap_or(0);
         let mut buffer = vec![0u8; bufsize];
         let sock = self.sock();
-        let n = self.sock_op(vm, || sock.recv_with_flags(&mut buffer, flags))?;
+        let n = self.sock_op(vm, SelectKind::Read, || {
+            sock.recv_with_flags(&mut buffer, flags)
+        })?;
         buffer.truncate(n);
         Ok(buffer)
     }
@@ -215,7 +280,9 @@ impl PySocket {
     ) -> PyResult<usize> {
         let flags = flags.unwrap_or(0);
         let sock = self.sock();
-        buf.with_ref(|buf| self.sock_op(vm, || sock.recv_with_flags(buf, flags)))
+        self.sock_op(vm, SelectKind::Read, || {
+            buf.with_ref(|buf| sock.recv_with_flags(buf, flags))
+        })
     }
 
     #[pymethod]
@@ -227,10 +294,9 @@ impl PySocket {
     ) -> PyResult<(Vec<u8>, AddrTuple)> {
         let flags = flags.unwrap_or(0);
         let mut buffer = vec![0u8; bufsize];
-        let (n, addr) = self
-            .sock()
-            .recv_from_with_flags(&mut buffer, flags)
-            .map_err(|err| convert_sock_error(vm, err))?;
+        let (n, addr) = self.sock_op(vm, SelectKind::Read, || {
+            self.sock().recv_from_with_flags(&mut buffer, flags)
+        })?;
         buffer.truncate(n);
         Ok((buffer, get_addr_tuple(addr)))
     }
@@ -243,9 +309,9 @@ impl PySocket {
         vm: &VirtualMachine,
     ) -> PyResult<usize> {
         let flags = flags.unwrap_or(0);
-        bytes
-            .with_ref(|b| self.sock().send_with_flags(b, flags))
-            .map_err(|err| convert_sock_error(vm, err))
+        self.sock_op(vm, SelectKind::Write, || {
+            bytes.with_ref(|b| self.sock().send_with_flags(b, flags))
+        })
     }
 
     #[pymethod]
@@ -256,10 +322,42 @@ impl PySocket {
         vm: &VirtualMachine,
     ) -> PyResult<()> {
         let flags = flags.unwrap_or(0);
-        let sock = self.sock();
-        bytes
-            .with_ref(|buf| py_io::write_all(buf, |b| sock.send_with_flags(b, flags)))
-            .map_err(|err| convert_sock_error(vm, err))
+
+        let timeout = self.timeout.load();
+        let timeout = if timeout > 0.0 {
+            Some(Duration::from_secs_f64(timeout))
+        } else {
+            None
+        };
+
+        let mut deadline: Option<Instant> = None;
+
+        let buf_len = bytes.len();
+        let mut buf_offset = 0;
+        // now we have like 3 layers of interrupt loop :)
+        while buf_offset < buf_len {
+            let interval = timeout.map(|dur| match deadline {
+                Some(d) => d
+                    .checked_duration_since(Instant::now())
+                    // past the deadline already
+                    .ok_or_else(|| timeout_error(vm)),
+                None => {
+                    let dl = Instant::now() + dur;
+                    deadline = Some(dl);
+                    Ok(dur)
+                }
+            });
+            let interval = interval.transpose()?;
+            self.sock_op_timeout(vm, SelectKind::Write, interval, || {
+                bytes.with_ref(|b| {
+                    let subbuf = &b[buf_offset..];
+                    buf_offset += self.sock().send_with_flags(subbuf, flags)?;
+                    Ok(())
+                })
+            })?;
+            vm.check_signals()?;
+        }
+        Ok(())
     }
 
     #[pymethod]
@@ -269,13 +367,12 @@ impl PySocket {
         address: Address,
         flags: OptionalArg<i32>,
         vm: &VirtualMachine,
-    ) -> PyResult<()> {
+    ) -> PyResult<usize> {
         let flags = flags.unwrap_or(0);
         let addr = get_addr(vm, address, Some(self.family.load()))?;
-        bytes
-            .with_ref(|b| self.sock().send_to_with_flags(b, &addr, flags))
-            .map_err(|err| convert_sock_error(vm, err))?;
-        Ok(())
+        self.sock_op(vm, SelectKind::Write, || {
+            bytes.with_ref(|b| self.sock().send_to_with_flags(b, &addr, flags))
+        })
     }
 
     #[pymethod]
@@ -324,12 +421,9 @@ impl PySocket {
     #[pymethod]
     fn setblocking(&self, block: bool, vm: &VirtualMachine) -> PyResult<()> {
         self.timeout.store(if block { -1.0 } else { 0.0 });
-        let timeout = if block {
-            Some(Duration::from_secs(0))
-        } else {
-            None
-        };
-        self.settimeout_sock(Some(block), timeout, vm)
+        self.sock()
+            .set_nonblocking(!block)
+            .map_err(|err| convert_sock_error(vm, err))
     }
 
     #[pymethod]
@@ -342,33 +436,15 @@ impl PySocket {
         // timeout is None: blocking, no timeout
         // timeout is 0: non-blocking, no timeout
         // otherwise: timeout is timeout, don't change blocking
-        let (block, timeout, f64_timeout) = match timeout {
-            None => (Some(true), None, -1.0),
-            Some(d) if d == Duration::from_secs(0) => (Some(false), None, 0.0),
-            Some(d) => (None, Some(d), d.as_secs_f64()),
+        let (block, timeout) = match timeout {
+            None => (true, -1.0),
+            Some(d) if d == Duration::from_secs(0) => (false, 0.0),
+            Some(d) => (true, d.as_secs_f64()),
         };
-        self.timeout.store(f64_timeout);
-        self.settimeout_sock(block, timeout, vm)
-    }
-
-    fn settimeout_sock(
-        &self,
-        block: Option<bool>,
-        timeout: Option<Duration>,
-        vm: &VirtualMachine,
-    ) -> PyResult<()> {
+        self.timeout.store(timeout);
         self.sock()
-            .set_read_timeout(timeout)
-            .map_err(|err| convert_sock_error(vm, err))?;
-        self.sock()
-            .set_write_timeout(timeout)
-            .map_err(|err| convert_sock_error(vm, err))?;
-        if let Some(blocking) = block {
-            self.sock()
-                .set_nonblocking(!blocking)
-                .map_err(|err| convert_sock_error(vm, err))?;
-        }
-        Ok(())
+            .set_nonblocking(!block)
+            .map_err(|err| convert_sock_error(vm, err))
     }
 
     #[pymethod]
@@ -585,6 +661,71 @@ fn _socket_getservbyname(
     }
     let port = unsafe { (*serv).s_port };
     Ok(vm.ctx.new_int(u16::from_be(port as u16)))
+}
+
+#[derive(Copy, Clone)]
+enum SelectKind {
+    Read,
+    Write,
+    Connect,
+}
+
+/// returns true if timed out
+fn sock_select(sock: &Socket, kind: SelectKind, interval: Option<Duration>) -> io::Result<bool> {
+    let fd = sock_fileno(sock);
+    #[cfg(unix)]
+    {
+        let mut pollfd = libc::pollfd {
+            fd,
+            events: match kind {
+                SelectKind::Read => libc::POLLIN,
+                SelectKind::Write => libc::POLLOUT,
+                SelectKind::Connect => libc::POLLOUT | libc::POLLERR,
+            },
+            revents: 0,
+        };
+        let timeout = match interval {
+            Some(d) => d.as_millis() as _,
+            None => -1,
+        };
+        let ret = unsafe { libc::poll(&mut pollfd, 1, timeout) };
+        if ret < 0 {
+            Err(io::Error::last_os_error())
+        } else {
+            Ok(ret == 0)
+        }
+    }
+    #[cfg(windows)]
+    {
+        use crate::stdlib::select;
+
+        let mut reads = select::FdSet::new();
+        let mut writes = select::FdSet::new();
+        let mut errs = select::FdSet::new();
+
+        match kind {
+            SelectKind::Read => reads.insert(fd),
+            SelectKind::Write => writes.insert(fd),
+            SelectKind::Connect => {
+                writes.insert(fd);
+                errs.insert(fd);
+            }
+        }
+
+        let mut interval = interval.map(|dur| libc::timeval {
+            tv_sec: dur.as_secs() as _,
+            tv_usec: dur.subsec_micros() as _,
+        });
+
+        select::select(
+            fd as i32 + 1,
+            &mut reads,
+            &mut writes,
+            &mut errs,
+            interval.as_mut(),
+        )
+        .map(|ret| ret == 0)
+    }
 }
 
 #[derive(FromArgs)]
@@ -852,6 +993,10 @@ fn convert_sock_error(vm: &VirtualMachine, err: io::Error) -> PyBaseExceptionRef
     } else {
         err.into_pyexception(vm)
     }
+}
+
+fn timeout_error(vm: &VirtualMachine) -> PyBaseExceptionRef {
+    vm.new_exception_msg(TIMEOUT_ERROR.get().unwrap().clone(), "timed out".to_owned())
 }
 
 fn get_ipv6_addr_str(ipv6: Ipv6Addr) -> String {


### PR DESCRIPTION
This gets basic `requests` functionality working:

```sh
$ mkdir deps
$ pip install -t deps requests
<snip>
$ cd deps
$ rustpython
```
```py
>>>>> import requests
>>>>> res = requests.get("http://httpbin.org/get")
>>>>> res.json()
{'args': {}, 'headers': {'Accept': '*/*', 'Accept-Encoding': 'gzip, deflate', 'Host': 'httpbin.org', 'User-Agent': 'python-requests/2.25.1', 'X-Amzn-Trace-Id': 'Root=1-600ce51d-187d27d01dae14c54f63f539'}, 'origin': '99.104.70.102', 'url': 'http://httpbin.org/get'}
```

I spent a lot of time debugging this, but I think the key thing that stopped it from hanging forever in `SocketIO.readinto` was fixing `_io` to use `as_contiguous` instead of `obj_bytes`, which wasn't taking the range of a memoryview into account, as well as changing a `>` to a `>=` in `_io`.
