### PR TITLE
Declare ourselves as Python 3.9

### DIFF
--- a/Lib/site.py
+++ b/Lib/site.py
@@ -265,13 +265,14 @@ def _getuserbase():
 def _get_path(userbase):
     version = sys.version_info
 
+    # XXX RUSTPYTHON: we replace pythonx.y with rustpythonx.y
     if os.name == 'nt':
-        return f'{userbase}\\Python{version[0]}{version[1]}\\site-packages'
+        return f'{userbase}\\RustPython{version[0]}{version[1]}\\site-packages'
 
     if sys.platform == 'darwin' and sys._framework:
-        return f'{userbase}/lib/python/site-packages'
+        return f'{userbase}/lib/rustpython/site-packages'
 
-    return f'{userbase}/lib/python{version[0]}.{version[1]}/site-packages'
+    return f'{userbase}/lib/rustpython{version[0]}.{version[1]}/site-packages'
 
 
 def getuserbase():

--- a/Lib/sysconfig.py
+++ b/Lib/sysconfig.py
@@ -80,6 +80,12 @@ _INSTALL_SCHEMES = {
         },
     }
 
+# XXX RUSTPYTHON: replace python with rustpython in all these paths
+for group in _INSTALL_SCHEMES.values():
+    for key in group.keys():
+        group[key] = group[key].replace("Python", "RustPython").replace("python", "rustpython")
+
+
 _SCHEME_KEYS = ('stdlib', 'platstdlib', 'purelib', 'platlib', 'include',
                 'scripts', 'data')
 

--- a/Lib/test/test_builtin.py
+++ b/Lib/test/test_builtin.py
@@ -17,6 +17,7 @@ import traceback
 import types
 import unittest
 import warnings
+from functools import partial
 from contextlib import ExitStack
 from operator import neg
 from test.support import (
@@ -1143,10 +1144,23 @@ class BuiltinTest(unittest.TestCase):
         self.assertAlmostEqual(pow(-1, 0.5), 1j)
         self.assertAlmostEqual(pow(-1, 1/3), 0.5 + 0.8660254037844386j)
 
-        self.assertRaises(ValueError, pow, -1, -2, 3)
+        # See test_pow for additional tests for three-argument pow.
+        self.assertEqual(pow(-1, -2, 3), 1)
         self.assertRaises(ValueError, pow, 1, 2, 0)
 
         self.assertRaises(TypeError, pow)
+
+        # Test passing in arguments as keywords.
+        self.assertEqual(pow(0, exp=0), 1)
+        self.assertEqual(pow(base=2, exp=4), 16)
+        self.assertEqual(pow(base=5, exp=2, mod=14), 11)
+        twopow = partial(pow, base=2)
+        self.assertEqual(twopow(exp=5), 32)
+        fifth_power = partial(pow, exp=5)
+        self.assertEqual(fifth_power(2), 32)
+        mod10 = partial(pow, mod=10)
+        self.assertEqual(mod10(2, 6), 4)
+        self.assertEqual(mod10(exp=6, base=2), 4)
 
     def test_input(self):
         self.write_testfile()

--- a/Lib/test/test_pow.py
+++ b/Lib/test/test_pow.py
@@ -1,3 +1,4 @@
+import math
 import unittest
 
 class PowTest(unittest.TestCase):
@@ -118,6 +119,31 @@ class PowTest(unittest.TestCase):
             eq(pow(a, fiveto), expected)
             eq(pow(a, -fiveto), expected)
         eq(expected, 1.0)   # else we didn't push fiveto to evenness
+
+    def test_negative_exponent(self):
+        for a in range(-50, 50):
+            for m in range(-50, 50):
+                with self.subTest(a=a, m=m):
+                    if m != 0 and math.gcd(a, m) == 1:
+                        # Exponent -1 should give an inverse, with the
+                        # same sign as m.
+                        inv = pow(a, -1, m)
+                        self.assertEqual(inv, inv % m)
+                        self.assertEqual((inv * a - 1) % m, 0)
+
+                        # Larger exponents
+                        self.assertEqual(pow(a, -2, m), pow(inv, 2, m))
+                        self.assertEqual(pow(a, -3, m), pow(inv, 3, m))
+                        self.assertEqual(pow(a, -1001, m), pow(inv, 1001, m))
+
+                    else:
+                        with self.assertRaises(ValueError):
+                            pow(a, -1, m)
+                        with self.assertRaises(ValueError):
+                            pow(a, -2, m)
+                        with self.assertRaises(ValueError):
+                            pow(a, -1001, m)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 # [RustPython](https://rustpython.github.io/)
 
-A Python-3 (CPython >= 3.5.0) Interpreter written in Rust :snake: :scream:
+A Python-3 (CPython >= 3.8.0) Interpreter written in Rust :snake: :scream:
 :metal:.
 
 [![Build Status](https://github.com/RustPython/RustPython/workflows/CI/badge.svg)](https://github.com/RustPython/RustPython/actions?query=workflow%3ACI)

--- a/extra_tests/snippets/math_basics.py
+++ b/extra_tests/snippets/math_basics.py
@@ -49,11 +49,7 @@ assert pow(2, 4, 5) == 1
 assert_raises(TypeError, pow, 2, 4, 5.0)
 assert_raises(TypeError, pow, 2, 4.0, 5)
 assert_raises(TypeError, pow, 2.0, 4, 5)
-from sys import version_info
-if version_info < (3, 8):
-  assert_raises(ValueError, pow, 2, -1, 5)
-else:  # https://docs.python.org/3/whatsnew/3.8.html#other-language-changes
-  assert pow(2, -1, 5) == 3 
+assert pow(2, -1, 5) == 3
 assert_raises(ValueError, pow, 2, 2, 0)
 
 # bitwise

--- a/vm/src/builtins/int.rs
+++ b/vm/src/builtins/int.rs
@@ -465,7 +465,11 @@ impl PyInt {
                                     None
                                 }
                             }
-                            let a = inverse(a % modulus, modulus).unwrap();
+                            let a = inverse(a % modulus, modulus).ok_or_else(|| {
+                                vm.new_value_error(
+                                    "base is not invertible for the given modulus".to_owned(),
+                                )
+                            })?;
                             let b = -b;
                             a.modpow(&b, modulus)
                         } else {

--- a/vm/src/builtins/make_module.rs
+++ b/vm/src/builtins/make_module.rs
@@ -594,15 +594,25 @@ mod decl {
         }
     }
 
+    #[derive(FromArgs)]
+    struct PowArgs {
+        #[pyarg(any)]
+        base: PyObjectRef,
+        #[pyarg(any)]
+        exp: PyObjectRef,
+        #[pyarg(any, optional, name = "mod")]
+        modulus: Option<PyObjectRef>,
+    }
+
     #[allow(clippy::suspicious_else_formatting)]
     #[pyfunction]
-    fn pow(
-        x: PyObjectRef,
-        y: PyObjectRef,
-        mod_value: OptionalOption<PyObjectRef>,
-        vm: &VirtualMachine,
-    ) -> PyResult {
-        match mod_value.flatten() {
+    fn pow(args: PowArgs, vm: &VirtualMachine) -> PyResult {
+        let PowArgs {
+            base: x,
+            exp: y,
+            modulus,
+        } = args;
+        match modulus {
             None => vm.call_or_reflection(&x, &y, "__pow__", "__rpow__", |vm, x, y| {
                 Err(vm.new_unsupported_binop_error(x, y, "pow"))
             }),

--- a/vm/src/stdlib/sysconfigdata.rs
+++ b/vm/src/stdlib/sysconfigdata.rs
@@ -1,12 +1,19 @@
 use crate::pyobject::{ItemProtocol, PyObjectRef};
 use crate::VirtualMachine;
 
+use crate::sysmodule::MULTIARCH;
+
 pub fn make_module(vm: &VirtualMachine) -> PyObjectRef {
     let vars = vm.ctx.new_dict();
     macro_rules! hashmap {
-        ($($key:literal => $value:literal),*) => {{
-            $(vars.set_item($key, vm.ctx.new_str($value.to_owned()), vm).unwrap();)*
+        ($($key:literal => $value:expr),*$(,)?) => {{
+            $(vars.set_item($key, vm.ctx.new_str($value), vm).unwrap();)*
         }};
+    }
+    hashmap! {
+        // fake shared module extension
+        "EXT_SUFFIX" => format!(".rustpython-{}", MULTIARCH),
+        "MULTIARCH" => MULTIARCH,
     }
     include!(concat!(env!("OUT_DIR"), "/env_vars.rs"));
 

--- a/vm/src/sysmodule.rs
+++ b/vm/src/sysmodule.rs
@@ -398,7 +398,7 @@ const ABIFLAGS: &str = "";
 // not the same as CPython (e.g. rust's x86_x64-unknown-linux-gnu is just x86_64-linux-gnu)
 // but hopefully that's just an implementation detail? TODO: copy CPython's multiarch exactly,
 // https://github.com/python/cpython/blob/3.8/configure.ac#L725
-const MULTIARCH: &str = env!("RUSTPYTHON_TARGET_TRIPLE");
+pub(crate) const MULTIARCH: &str = env!("RUSTPYTHON_TARGET_TRIPLE");
 
 pub(crate) fn sysconfigdata_name() -> String {
     format!("_sysconfigdata_{}_{}_{}", ABIFLAGS, PLATFORM, MULTIARCH)

--- a/vm/src/version.rs
+++ b/vm/src/version.rs
@@ -7,7 +7,7 @@ use chrono::Local;
 use std::time::{Duration, UNIX_EPOCH};
 
 const MAJOR: usize = 3;
-const MINOR: usize = 5;
+const MINOR: usize = 9;
 const MICRO: usize = 0;
 const RELEASELEVEL: &str = "alpha";
 const RELEASELEVEL_N: usize = 0xA;

--- a/wasm/lib/README.md
+++ b/wasm/lib/README.md
@@ -1,6 +1,6 @@
 # RustPython
 
-A Python-3 (CPython >= 3.5.0) Interpreter written in Rust.
+A Python-3 (CPython >= 3.8.0) Interpreter written in Rust.
 
 [![Build Status](https://travis-ci.org/RustPython/RustPython.svg?branch=master)](https://travis-ci.org/RustPython/RustPython)
 [![License: MIT](https://img.shields.io/badge/License-MIT-green.svg)](https://opensource.org/licenses/MIT)


### PR DESCRIPTION
Python 3.5 is pretty old at this point, and I think we generally try to keep up with the latest features (e.g. assignment expression, self-documenting fstrings), so I think it makes sense to say we're 3.9. I put 3.8 in the READMEs because I don't think we have full 3.9 compatibility yet and 3.8 is more used, but I'm not really sure if that makes a difference :shrug:
