### PR TITLE
add a github workflow to save whats left to the website repo

### DIFF
--- a/.github/workflows/cron-ci.yaml
+++ b/.github/workflows/cron-ci.yaml
@@ -86,3 +86,37 @@ jobs:
           git add ./_data/regrtests_results.json
           git -c user.name="Github Actions" -c user.email="actions@github.com" commit -m "Update regression test results" --author="$GITHUB_ACTOR"
           git push
+
+  whatsleft:
+    name: Collect what is left data
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@master
+      - name: build rustpython
+        uses: actions-rs/cargo@v1
+        with:
+          command: build
+          args: --release --verbose
+      - name: collect what is left data
+        run: |
+          chmod +x ./whats_left.sh
+          ./whats_left.sh > whats_left.temp
+        env:
+          RUSTPYTHONPATH: ${{ github.workspace }}/Lib
+      - name: upload data to the website
+        env:
+          SSHKEY: ${{ secrets.ACTIONS_TESTS_DATA_DEPLOY_KEY }}
+          GITHUB_ACTOR: ${{ github.actor }}
+        run: |
+          echo "$SSHKEY" >~/github_key
+          chmod 600 ~/github_key
+          export GIT_SSH_COMMAND="ssh -i ~/github_key"
+
+          git clone git@github.com:RustPython/rustpython.github.io.git website
+          cd website
+          [ -f ./_data/whats_left.temp ] && cp ./_data/whats_left.temp ./_data/whats_left_lastrun.temp
+          cp ../whats_left.temp ./_data/whats_left.temp
+          git add ./_data/whats_left_lastrun.temp
+          git add ./_data/whats_left.temp
+          git -c user.name="Github Actions" -c user.email="actions@github.com" commit -m "Update regression test results" --author="$GITHUB_ACTOR"
+          git push


### PR DESCRIPTION
This PR fixes #2400.

I added a new job that runs the `whats_left.sh` script 

```bash
 chmod +x ./whats_left.sh
./whats_left.sh > whats_left.temp
```

Then after cloning the website and cd-ing into it, it does:

``` bash
git clone git@github.com:RustPython/rustpython.github.io.git website
cd website
[ -f ./_data/whats_left.temp ] && cp ./_data/whats_left.temp ./_data/whats_left_lastrun.temp
cp ../whats_left.temp ./_data/whats_left.temp
git add ./_data/whats_left_lastrun.temp
git add ./_data/whats_left.temp
```

which translates to:
- check if website/_data/whats_left.temp exits (on the first run it won't)
- make a copy of that to a "lastrun" file
- the goal is to have the last run and the what's left now, so we can do a diff then show what has been recently finished (kind of a basic "tada"-log  🎉  )
- replace whatsleft
- commit and push
