### PR TITLE
Fix formatting of decimal powers below 1 million

### DIFF
--- a/extra_tests/snippets/strings.py
+++ b/extra_tests/snippets/strings.py
@@ -545,6 +545,8 @@ assert '{:e}'.format(float('-inf')) == '-inf'
 assert '{:E}'.format(float('inf')) == 'INF'
 
 # Test g & G formatting
+assert '{:g}'.format(10.0) == '10'
+assert '{:g}'.format(100000.0) == '100000'
 assert '{:g}'.format(123456.78901234567890) == '123457'
 assert '{:.0g}'.format(123456.78901234567890) == '1e+05'
 assert '{:.1g}'.format(123456.78901234567890) == '1e+05'


### PR DESCRIPTION
The previous implementation truncated all decimal powers of 10.0 below 1 million (by default) to 1, because it cut away any
combination of trailing 0's and .'s. 
(Powers of 10.0 beginning with 1000000.0 are formatted to an exponential format and thus not affected by the bug.)
My fix now checks whether the number string to truncate represents a floating point value at all and if that is the case, truncation stops at the decimal point.
(The check whether there is a decimal point in the string to truncate is necessary as `format!("{:.*}", precision, magnitude)` with `precision==0` does return strings without a decimal point; truncating those is fatal)