### PR TITLE
format PyStructSequence with = instead of :

### DIFF
--- a/vm/src/pyobject.rs
+++ b/vm/src/pyobject.rs
@@ -1129,7 +1129,7 @@ pub trait PyStructSequence: StaticType + PyClassImpl + Sized + 'static {
     fn repr(zelf: PyRef<PyTuple>, vm: &VirtualMachine) -> PyResult<String> {
         let format_field = |(value, name)| {
             let s = vm.to_repr(value)?;
-            Ok(format!("{}: {}", name, s))
+            Ok(format!("{}={}", name, s))
         };
         let (body, suffix) =
             if let Some(_guard) = rustpython_vm::vm::ReprGuard::enter(vm, zelf.as_object()) {


### PR DESCRIPTION
On CPython `import os; print(os.stat('.'))` will print 

```
os.stat_result(st_mode=16877, st_ino=11403492, st_dev=64769, st_nlink=69, st_uid=1001, st_gid=1001, st_size=4096, st_atime=1612956818, st_mtime=1612952241, st_ctime=1612952241)
```

and on RustPython

```
os.stat_result(st_mode: 16893, st_ino: 4277, st_dev: 64769, st_nlink: 22, st_uid: 1001, st_gid: 1001, st_size: 4096, __st_atime_int: 1612992970, __st_mtime_int: 1612816814, __st_ctime_int: 1612816814, st_atime: 1612992970.2450392, st_mtime: 1612816814.5084808, st_ctime: 1612816814.5084808, st_atime_ns: 1612992970245039341, st_mtime_ns: 1612816814508480761, st_ctime_ns: 1612816814508480761)
```

Is this formatting used for some other object?