### PR TITLE
Allow clippy::unnecessary_wraps lint, and rename "to_js" to "into_js"

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -148,12 +148,12 @@ jobs:
         uses: actions-rs/cargo@v1
         with:
           command: clippy
-          args: ${{ env.CARGO_ARGS }} ${{ env.NON_WASM_PACKAGES }} -- -Dwarnings
+          args: ${{ env.CARGO_ARGS }} ${{ env.NON_WASM_PACKAGES }} -- -Dwarnings -A clippy::unnecessary_wraps
       - name: run clippy on wasm
         uses: actions-rs/cargo@v1
         with:
           command: clippy
-          args: --manifest-path=wasm/lib/Cargo.toml -- -Dwarnings
+          args: --manifest-path=wasm/lib/Cargo.toml -- -Dwarnings -A clippy::unnecessary_wraps
       - uses: actions/setup-python@v1
         with:
           python-version: 3.8

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -148,12 +148,12 @@ jobs:
         uses: actions-rs/cargo@v1
         with:
           command: clippy
-          args: ${{ env.CARGO_ARGS }} ${{ env.NON_WASM_PACKAGES }} -- -Dwarnings -A clippy::unnecessary_wraps
+          args: ${{ env.CARGO_ARGS }} ${{ env.NON_WASM_PACKAGES }} -- -Dwarnings
       - name: run clippy on wasm
         uses: actions-rs/cargo@v1
         with:
           command: clippy
-          args: --manifest-path=wasm/lib/Cargo.toml -- -Dwarnings -A clippy::unnecessary_wraps
+          args: --manifest-path=wasm/lib/Cargo.toml -- -Dwarnings
       - uses: actions/setup-python@v1
         with:
           python-version: 3.8

--- a/jit/src/lib.rs
+++ b/jit/src/lib.rs
@@ -1,3 +1,4 @@
+#![allow(clippy::unnecessary_wraps)]
 use std::fmt;
 
 use cranelift::prelude::*;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -36,7 +36,7 @@
 //!
 //! The binary will have all the standard arguments of a python interpreter (including a REPL!) but
 //! it will have your modules loaded into the vm.
-#![allow(clippy::needless_doctest_main)]
+#![allow(clippy::needless_doctest_main, clippy::unnecessary_wraps)]
 
 #[macro_use]
 extern crate clap;

--- a/vm/src/lib.rs
+++ b/vm/src/lib.rs
@@ -10,6 +10,8 @@
 // to allow `mod foo {}` in foo.rs; clippy thinks this is a mistake/misunderstanding of
 // how `mod` works, but we want this sometimes for pymodule declarations
 #![allow(clippy::module_inception)]
+// to encourage good API design, see https://github.com/rust-lang/rust-clippy/issues/6726
+#![allow(clippy::unnecessary_wraps)]
 #![doc(html_logo_url = "https://raw.githubusercontent.com/RustPython/RustPython/master/logo.png")]
 #![doc(html_root_url = "https://docs.rs/rustpython-vm/")]
 

--- a/wasm/lib/src/convert.rs
+++ b/wasm/lib/src/convert.rs
@@ -261,10 +261,10 @@ pub fn syntax_err(err: CompileError) -> SyntaxError {
 }
 
 pub trait PyResultExt<T> {
-    fn to_js(&self, vm: &VirtualMachine) -> Result<T, JsValue>;
+    fn into_js(self, vm: &VirtualMachine) -> Result<T, JsValue>;
 }
 impl<T> PyResultExt<T> for PyResult<T> {
-    fn to_js(&self, vm: &VirtualMachine) -> Result<T, JsValue> {
+    fn into_js(self, vm: &VirtualMachine) -> Result<T, JsValue> {
         self.map_err(|err| py_err_to_js_err(vm, &err))
     }
 }

--- a/wasm/lib/src/convert.rs
+++ b/wasm/lib/src/convert.rs
@@ -261,10 +261,10 @@ pub fn syntax_err(err: CompileError) -> SyntaxError {
 }
 
 pub trait PyResultExt<T> {
-    fn to_js(self, vm: &VirtualMachine) -> Result<T, JsValue>;
+    fn to_js(&self, vm: &VirtualMachine) -> Result<T, JsValue>;
 }
 impl<T> PyResultExt<T> for PyResult<T> {
-    fn to_js(self, vm: &VirtualMachine) -> Result<T, JsValue> {
+    fn to_js(&self, vm: &VirtualMachine) -> Result<T, JsValue> {
         self.map_err(|err| py_err_to_js_err(vm, &err))
     }
 }

--- a/wasm/lib/src/vm_class.rs
+++ b/wasm/lib/src/vm_class.rs
@@ -285,7 +285,7 @@ impl WASMVirtualMachine {
             let sys_modules = vm
                 .get_attribute(vm.sys_module.clone(), "modules")
                 .into_js(vm)?;
-            sys_modules.set_item(name, module, vm).to_js(vm)?;
+            sys_modules.set_item(name, module, vm).into_js(vm)?;
 
             Ok(())
         })?
@@ -306,7 +306,7 @@ impl WASMVirtualMachine {
             let sys_modules = vm
                 .get_attribute(vm.sys_module.clone(), "modules")
                 .into_js(vm)?;
-            sys_modules.set_item(name, py_module, vm).to_js(vm)?;
+            sys_modules.set_item(name, py_module, vm).into_js(vm)?;
 
             Ok(())
         })?

--- a/wasm/lib/src/vm_class.rs
+++ b/wasm/lib/src/vm_class.rs
@@ -216,7 +216,7 @@ impl WASMVirtualMachine {
     pub fn add_to_scope(&self, name: String, value: JsValue) -> Result<(), JsValue> {
         self.with_vm(move |vm, StoredVirtualMachine { ref scope, .. }| {
             let value = convert::js_to_py(vm, value);
-            scope.globals.set_item(name, value, vm).to_js(vm)
+            scope.globals.set_item(name, value, vm).into_js(vm)
         })?
     }
 
@@ -265,7 +265,7 @@ impl WASMVirtualMachine {
             let attrs = vm.ctx.new_dict();
             attrs
                 .set_item("__name__", vm.ctx.new_str(name.clone()), vm)
-                .to_js(vm)?;
+                .into_js(vm)?;
 
             if let Some(imports) = imports {
                 for entry in convert::object_entries(&imports) {
@@ -273,18 +273,18 @@ impl WASMVirtualMachine {
                     let key: String = Object::from(key).to_string().into();
                     attrs
                         .set_item(key.as_str(), convert::js_to_py(vm, value), vm)
-                        .to_js(vm)?;
+                        .into_js(vm)?;
                 }
             }
 
             vm.run_code_obj(code, Scope::new(None, attrs.clone()))
-                .to_js(vm)?;
+                .into_js(vm)?;
 
             let module = vm.new_module(&name, attrs);
 
             let sys_modules = vm
                 .get_attribute(vm.sys_module.clone(), "modules")
-                .to_js(vm)?;
+                .into_js(vm)?;
             sys_modules.set_item(name, module, vm).to_js(vm)?;
 
             Ok(())
@@ -305,7 +305,7 @@ impl WASMVirtualMachine {
 
             let sys_modules = vm
                 .get_attribute(vm.sys_module.clone(), "modules")
-                .to_js(vm)?;
+                .into_js(vm)?;
             sys_modules.set_item(name, py_module, vm).to_js(vm)?;
 
             Ok(())


### PR DESCRIPTION
See rust-lang/rust-clippy#6726