### PR TITLE
Optimize check_signals

### DIFF
--- a/vm/src/stdlib/signal.rs
+++ b/vm/src/stdlib/signal.rs
@@ -111,9 +111,10 @@ pub fn check_signals(vm: &VirtualMachine) -> PyResult<()> {
         None => return Ok(()),
     };
 
-    if !ANY_TRIGGERED.swap(false, Ordering::Relaxed) {
+    if !ANY_TRIGGERED.load(Ordering::Relaxed) {
         return Ok(());
     }
+    ANY_TRIGGERED.store(false, Ordering::Relaxed);
 
     trigger_signals(&signal_handlers.borrow(), vm)
 }


### PR DESCRIPTION
`swap` seems to be pretty slow, it took 5.66% of the time in my microbenchmarks. After the optimization, `check_signals` would only take 0.29% of the time. (from flamegraph).