### PR TITLE
Fix `math.floor` and `math.ceil` functions to match cpython behavior

### DIFF
--- a/Lib/test/test_math.py
+++ b/Lib/test/test_math.py
@@ -372,8 +372,6 @@ class MathTests(unittest.TestCase):
         self.assertTrue(math.isnan(math.atan2(NAN, INF)))
         self.assertTrue(math.isnan(math.atan2(NAN, NAN)))
 
-    # TODO: RUSTPYTHON
-    @unittest.expectedFailure
     def testCeil(self):
         self.assertRaises(TypeError, math.ceil)
         self.assertEqual(int, type(math.ceil(0.5)))
@@ -525,8 +523,6 @@ class MathTests(unittest.TestCase):
         with self.assertWarns(DeprecationWarning):
             self.assertRaises(OverflowError, math.factorial, 1e100)
 
-    # TODO: RUSTPYTHON
-    @unittest.expectedFailure
     def testFloor(self):
         self.assertRaises(TypeError, math.floor)
         self.assertEqual(int, type(math.floor(0.5)))

--- a/vm/src/stdlib/math.rs
+++ b/vm/src/stdlib/math.rs
@@ -295,13 +295,14 @@ fn math_trunc(value: PyObjectRef, vm: &VirtualMachine) -> PyResult {
 /// * `value` - Either a float or a python object which implements __ceil__
 /// * `vm` - Represents the python state.
 fn math_ceil(value: PyObjectRef, vm: &VirtualMachine) -> PyResult {
-    if value.isinstance(&vm.ctx.types.float_type) {
-        let v = float::get_value(&value);
-        let v = float::try_bigint(v.ceil(), vm)?;
-        Ok(vm.ctx.new_int(v))
-    } else {
-        try_magic_method("__ceil__", vm, &value)
+    let result_or_err = try_magic_method("__ceil__", vm, &value);
+    if result_or_err.is_err() {
+        if let Ok(Some(v)) = float::try_float_opt(&value, &vm) {
+            let v = float::try_bigint(v.ceil(), vm)?;
+            return Ok(vm.ctx.new_int(v));
+        }
     }
+    result_or_err
 }
 
 /// Applies floor to a float, returning an Integral.
@@ -311,13 +312,14 @@ fn math_ceil(value: PyObjectRef, vm: &VirtualMachine) -> PyResult {
 /// * `value` - Either a float or a python object which implements __ceil__
 /// * `vm` - Represents the python state.
 fn math_floor(value: PyObjectRef, vm: &VirtualMachine) -> PyResult {
-    if value.isinstance(&vm.ctx.types.float_type) {
-        let v = float::get_value(&value);
-        let v = float::try_bigint(v.floor(), vm)?;
-        Ok(vm.ctx.new_int(v))
-    } else {
-        try_magic_method("__floor__", vm, &value)
+    let result_or_err = try_magic_method("__floor__", vm, &value);
+    if result_or_err.is_err() {
+        if let Ok(Some(v)) = float::try_float_opt(&value, &vm) {
+            let v = float::try_bigint(v.floor(), vm)?;
+            return Ok(vm.ctx.new_int(v));
+        }
     }
+    result_or_err
 }
 
 fn math_frexp(value: IntoPyFloat) -> (f64, i32) {


### PR DESCRIPTION
Previously the `math.floor` and `math.ceil` functions did not work on subclasses of `float` or on types that implemented the `__float__` method. This change brings the `floor` and `ceil` implementations closer to the [cpython](https://github.com/python/cpython/blob/0837f99d3367ecf200033bbddfa05d061ae9f483/Modules/mathmodule.c#L1194) [versions](https://github.com/python/cpython/blob/0837f99d3367ecf200033bbddfa05d061ae9f483/Modules/mathmodule.c#L1257).