### PR TITLE
Follow the latest `itertools` module

### DIFF
--- a/Lib/test/test_itertools.py
+++ b/Lib/test/test_itertools.py
@@ -120,8 +120,6 @@ class TestBasicOps(unittest.TestCase):
             c = expand(compare[took:])
             self.assertEqual(a, c);
 
-    # TODO: RUSTPYTHON
-    @unittest.expectedFailure
     def test_accumulate(self):
         self.assertEqual(list(accumulate(range(10))),               # one positional arg
                           [0, 1, 3, 6, 10, 15, 21, 28, 36, 45])
@@ -148,14 +146,18 @@ class TestBasicOps(unittest.TestCase):
                          [2, 16, 144, 720, 5040, 0, 0, 0, 0, 0])
         with self.assertRaises(TypeError):
             list(accumulate(s, chr))                                # unary-operation
-        for proto in range(pickle.HIGHEST_PROTOCOL + 1):
-            self.pickletest(proto, accumulate(range(10)))           # test pickling
-            self.pickletest(proto, accumulate(range(10), initial=7))
         self.assertEqual(list(accumulate([10, 5, 1], initial=None)), [10, 15, 16])
         self.assertEqual(list(accumulate([10, 5, 1], initial=100)), [100, 110, 115, 116])
         self.assertEqual(list(accumulate([], initial=100)), [100])
         with self.assertRaises(TypeError):
             list(accumulate([10, 20], 100))
+
+    # TODO: RUSTPYTHON
+    @unittest.expectedFailure
+    def test_accumulate_pickle(self):
+        for proto in range(pickle.HIGHEST_PROTOCOL + 1):
+            self.pickletest(proto, accumulate(range(10)))           # test pickling
+            self.pickletest(proto, accumulate(range(10), initial=7))
 
     def test_chain(self):
 

--- a/vm/src/stdlib/itertools.rs
+++ b/vm/src/stdlib/itertools.rs
@@ -860,7 +860,7 @@ mod decl {
                         None => vm._add(&value, &obj)?,
                         Some(op) => vm.invoke(op, vec![value, obj])?,
                     }
-                },
+                }
             };
             *zelf.acc_value.write() = Some(next_acc_value.clone());
 


### PR DESCRIPTION
I make `itertools.accumulate` follow the latest signature `itertools.accumulate(iterable[, func, *, initial=None])`, and split the tests on `accumulate` into two parts.

Now, only `pickletest`s fail.

```
test_accumulate (__main__.TestBasicOps) ... ok
test_accumulate_pickle (__main__.TestBasicOps) ... expected failure
```