### PR TITLE
Optimize method call performance

### DIFF
--- a/vm/src/builtins/pytype.rs
+++ b/vm/src/builtins/pytype.rs
@@ -629,7 +629,7 @@ fn subtype_get_dict(obj: PyObjectRef, vm: &VirtualMachine) -> PyResult {
     // TODO: obj.class().as_pyref() need to be supported
     let cls = obj.clone_class();
     let ret = match find_base_dict_descr(&cls, vm) {
-        Some(descr) => vm.call_get_descriptor(descr, obj).unwrap_or_else(|| {
+        Some(descr) => vm.call_get_descriptor(descr, obj).unwrap_or_else(|_| {
             Err(vm.new_type_error(format!(
                 "this __dict__ descriptor does not support '{}' objects",
                 cls.name

--- a/vm/src/function.rs
+++ b/vm/src/function.rs
@@ -26,6 +26,11 @@ where
     }
 }
 
+macro_rules! count {
+    () => (0usize);
+    ( $x:tt $($xs:tt)* ) => (1usize + count!($($xs)*));
+}
+
 // A tuple of values that each implement `IntoPyObject` represents a sequence of
 // arguments that can be bound and passed to a built-in function.
 macro_rules! into_func_args_from_tuple {
@@ -37,7 +42,9 @@ macro_rules! into_func_args_from_tuple {
             #[inline]
             fn into_args(self, vm: &VirtualMachine) -> FuncArgs {
                 let ($($n,)*) = self;
-                vec![$($n.into_pyobject(vm),)*].into()
+                let mut result = Vec::with_capacity(count!($($n,)*) + 1);
+                $(result.push($n.into_pyobject(vm), );)*
+                result.into()
             }
         }
     };

--- a/vm/src/vm.rs
+++ b/vm/src/vm.rs
@@ -939,19 +939,25 @@ impl VirtualMachine {
         descr: PyObjectRef,
         obj: Option<PyObjectRef>,
         cls: Option<PyObjectRef>,
-    ) -> Option<PyResult> {
+    ) -> Result<PyResult, PyObjectRef> {
         let descr_get = descr.class().mro_find_map(|cls| cls.slots.descr_get.load());
-        descr_get.map(|descr_get| descr_get(descr, obj, cls, self))
+        match descr_get {
+            Some(descr_get) => Ok(descr_get(descr, obj, cls, self)),
+            None => Err(descr),
+        }
     }
 
-    pub fn call_get_descriptor(&self, descr: PyObjectRef, obj: PyObjectRef) -> Option<PyResult> {
+    pub fn call_get_descriptor(
+        &self,
+        descr: PyObjectRef,
+        obj: PyObjectRef,
+    ) -> Result<PyResult, PyObjectRef> {
         let cls = obj.clone_class().into_object();
         self.call_get_descriptor_specific(descr, Some(obj), Some(cls))
     }
 
     pub fn call_if_get_descriptor(&self, attr: PyObjectRef, obj: PyObjectRef) -> PyResult {
-        self.call_get_descriptor(attr.clone(), obj)
-            .unwrap_or(Ok(attr))
+        self.call_get_descriptor(attr, obj).unwrap_or_else(Ok)
     }
 
     pub fn call_method<T>(&self, obj: &PyObjectRef, method_name: &str, args: T) -> PyResult
@@ -1252,7 +1258,7 @@ impl VirtualMachine {
 
         if let Some(ref attr) = cls_attr {
             if attr.class().has_attr("__set__") {
-                if let Some(r) = self.call_get_descriptor(attr.clone(), obj.clone()) {
+                if let Ok(r) = self.call_get_descriptor(attr.clone(), obj.clone()) {
                     return r.map(Some);
                 }
             }


### PR DESCRIPTION
This would improve the performance for method calls a bit:

Microbenchmark:
```python
s = 0
for i in range(1000000):
    s += 1
```
Result:
```
Benchmark #1: ./rustpython-master test.py
  Time (mean ± σ):     870.1 ms ±   8.1 ms    [User: 867.4 ms, System: 2.5 ms]
  Range (min … max):   858.6 ms … 884.0 ms    10 runs
 
Benchmark #2: ./rustpython-opt test.py
  Time (mean ± σ):     857.7 ms ±   7.1 ms    [User: 853.8 ms, System: 3.3 ms]
  Range (min … max):   841.8 ms … 866.0 ms    10 runs
 
Summary
  './rustpython-opt test.py' ran
    1.01 ± 0.01 times faster than './rustpython-master test.py'

------

Benchmark #1: ./rustpython-master-nothreading test.py
  Time (mean ± σ):     520.8 ms ±   6.6 ms    [User: 517.9 ms, System: 2.7 ms]
  Range (min … max):   512.6 ms … 530.6 ms    10 runs
 
Benchmark #2: ./rustpython-opt-nothreading test.py
  Time (mean ± σ):     486.7 ms ±  25.9 ms    [User: 483.7 ms, System: 2.9 ms]
  Range (min … max):   464.2 ms … 551.0 ms    10 runs
 
Summary
  './rustpython-opt-nothreading test.py' ran
    1.07 ± 0.06 times faster than './rustpython-master-nothreading test.py'
```

pystone benchmark:
```
Benchmark #1: ./rustpython-master benches/benchmarks/pystone.py
  Time (mean ± σ):      2.873 s ±  0.012 s    [User: 2.869 s, System: 0.002 s]
  Range (min … max):    2.860 s …  2.902 s    10 runs
 
Benchmark #2: ./rustpython-opt benches/benchmarks/pystone.py
  Time (mean ± σ):      2.838 s ±  0.011 s    [User: 2.835 s, System: 0.002 s]
  Range (min … max):    2.825 s …  2.859 s    10 runs
 
Summary
  './rustpython-opt benches/benchmarks/pystone.py' ran
    1.01 ± 0.01 times faster than './rustpython-master benches/benchmarks/pystone.py'

------

Benchmark #1: ./rustpython-master-nothreading benches/benchmarks/pystone.py
  Time (mean ± σ):      1.879 s ±  0.023 s    [User: 1.875 s, System: 0.003 s]
  Range (min … max):    1.846 s …  1.923 s    10 runs
 
Benchmark #2: ./rustpython-opt-nothreading benches/benchmarks/pystone.py
  Time (mean ± σ):      1.845 s ±  0.025 s    [User: 1.840 s, System: 0.003 s]
  Range (min … max):    1.807 s …  1.876 s    10 runs
 
Summary
  './rustpython-opt-nothreading benches/benchmarks/pystone.py' ran
    1.02 ± 0.02 times faster than './rustpython-master-nothreading benches/benchmarks/pystone.py'
```