### PR TITLE
2406 parse multiple lines REPL

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -654,6 +654,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "dirs-next"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b98cf8ebf19c3d1b223e151f99a4f9f0690dca41414773390fc824184ac833e1"
+dependencies = [
+ "cfg-if 1.0.0",
+ "dirs-sys-next",
+]
+
+[[package]]
 name = "dirs-sys-next"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -702,6 +712,12 @@ name = "encode_unicode"
 version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a357d28ed41a50f9c765dbfe56cbc04a64e53e5fc58ba79fbc34c10ef3df831f"
+
+[[package]]
+name = "endian-type"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c34f04666d835ff5d62e058c3995147c06f42fe86ff053337632bca83e42702d"
 
 [[package]]
 name = "env_logger"
@@ -824,6 +840,16 @@ name = "foreign-types-shared"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
+
+[[package]]
+name = "fs2"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9564fc758e15025b46aa6643b1b77d047d1a56a1aea6e01002ac0c7026876213"
+dependencies = [
+ "libc",
+ "winapi",
+]
 
 [[package]]
 name = "gcc"
@@ -1055,9 +1081,9 @@ dependencies = [
 
 [[package]]
 name = "libc"
-version = "0.2.81"
+version = "0.2.89"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1482821306169ec4d07f6aca392a4681f66c75c9918aa49641a2595db64053cb"
+checksum = "538c092e5586f4cdd7dd8078c4a79220e3e168880218124dcbce860f0ea938c6"
 
 [[package]]
 name = "libffi"
@@ -1200,15 +1226,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e4a24736216ec316047a1fc4252e27dabb04218aa4a3f37c6e7ddbf1f9782b54"
 
 [[package]]
-name = "nix"
-version = "0.18.0"
+name = "nibble_vec"
+version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "83450fe6a6142ddd95fb064b746083fc4ef1705fe81f64a64e1d4b39f54a1055"
+checksum = "77a5d83df9f36fe23f0c3648c6bbb8b0298bb5f1939c8f2704431371f4b84d43"
 dependencies = [
- "bitflags",
- "cc",
- "cfg-if 0.1.10",
- "libc",
+ "smallvec",
 ]
 
 [[package]]
@@ -1216,6 +1239,18 @@ name = "nix"
 version = "0.19.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b2ccba0cfe4fdf15982d1674c69b1fd80bad427d293849982668dfe454bd61f2"
+dependencies = [
+ "bitflags",
+ "cc",
+ "cfg-if 1.0.0",
+ "libc",
+]
+
+[[package]]
+name = "nix"
+version = "0.20.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fa9b4819da1bc61c0ea48b63b7bc8604064dd43013e7cc325df098d49cd7c18a"
 dependencies = [
  "bitflags",
  "cc",
@@ -1581,6 +1616,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "radix_trie"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c069c179fcdc6a2fe24d8d18305cf085fdbd4f922c041943e203685d6a1c58fd"
+dependencies = [
+ "endian-type",
+ "nibble_vec",
+]
+
+[[package]]
 name = "rand"
 version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1828,7 +1873,7 @@ dependencies = [
  "clap",
  "cpython",
  "criterion",
- "dirs-next",
+ "dirs-next 1.0.2",
  "env_logger",
  "flame",
  "flamescope",
@@ -2081,17 +2126,21 @@ dependencies = [
 
 [[package]]
 name = "rustyline"
-version = "6.3.0"
+version = "8.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6f0d5e7b0219a3eadd5439498525d4765c59b7c993ef0c12244865cd2d988413"
+checksum = "b9e1b597fcd1eeb1d6b25b493538e5aa19629eb08932184b85fef931ba87e893"
 dependencies = [
- "cfg-if 0.1.10",
- "dirs-next",
+ "bitflags",
+ "cfg-if 1.0.0",
+ "dirs-next 2.0.0",
+ "fs2",
  "libc",
  "log",
  "memchr",
- "nix 0.18.0",
+ "nix 0.20.0",
+ "radix_trie",
  "scopeguard",
+ "smallvec",
  "unicode-segmentation",
  "unicode-width",
  "utf8parse",
@@ -2254,9 +2303,9 @@ checksum = "fa8f3741c7372e75519bd9346068370c9cdaabcc1f9599cbcf2a2719352286b7"
 
 [[package]]
 name = "smallvec"
-version = "1.5.1"
+version = "1.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ae524f056d7d770e174287294f562e95044c68e88dec909a00d2094805db9d75"
+checksum = "fe0f37c9e8f3c5a4a66ad655a93c74daac4ad00c441533bf5c6e7990bb42604e"
 
 [[package]]
 name = "socket2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,7 +41,7 @@ flame = { version = "0.2", optional = true }
 flamescope = { version = "0.1", optional = true }
 
 [target.'cfg(not(target_os = "wasi"))'.dependencies]
-rustyline = "6.0"
+rustyline = "8.0"
 
 [dev-dependencies]
 cpython = "0.5.0"

--- a/src/shell/helper.rs
+++ b/src/shell/helper.rs
@@ -163,8 +163,9 @@ cfg_if::cfg_if! {
                     .unwrap_or_else(|| (line.len(), vec!["\t".to_owned()])))
             }
         }
-
-        impl Hinter for ShellHelper<'_> {}
+        impl Hinter for ShellHelper<'_> {
+                type Hint = String;
+        }
         impl Highlighter for ShellHelper<'_> {}
         impl Validator for ShellHelper<'_> {}
         impl Helper for ShellHelper<'_> {}

--- a/vm/Cargo.toml
+++ b/vm/Cargo.toml
@@ -122,7 +122,7 @@ uname = "0.1.1"
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 gethostname = "0.2.0"
 socket2 = "0.3.19"
-rustyline = "6.0"
+rustyline = "8.0"
 openssl = { version = "0.10.32", features = ["vendored"], optional = true }
 openssl-sys = { version = "0.9", optional = true }
 openssl-probe = { version = "0.1", optional = true }

--- a/vm/src/readline.rs
+++ b/vm/src/readline.rs
@@ -81,6 +81,9 @@ mod rustyline_readline {
                     .tab_stop(8)
                     .build(),
             );
+            // Parse multiple lines correctly
+            repl.bind_sequence(KeyPress::BracketedPasteStart, Cmd::Noop);
+
             repl.bind_sequence(
                 KeyPress::ControlLeft,
                 Cmd::Move(Movement::BackwardWord(1, Word::Vi)),

--- a/vm/src/readline.rs
+++ b/vm/src/readline.rs
@@ -130,10 +130,7 @@ mod rustyline_readline {
                         validate::Validator, Context, hint::Hinter};
         use rustyline::error::ReadlineError;
         use crate::readline::ReadlineResult::Line;
-
-        struct HelperShim {
-
-        }
+        struct HelperShim {}
         impl rustyline::Helper for HelperShim {}
         impl Highlighter for HelperShim {}
         impl Validator for HelperShim {}
@@ -152,16 +149,13 @@ mod rustyline_readline {
         impl Hinter for HelperShim {
             type Hint = String;
         }
-        #[test]
+        #[test] #[ignore]
         fn test_multi_read_line() {
-
             let mut repl = Readline::new(HelperShim { });
             if let Line(line) = repl.readline("print('hello')\nprint('hello2')\n") {
                 assert_eq!(line, "print('hello')");
             }
-
         }
-
     }
 }
 

--- a/vm/src/readline.rs
+++ b/vm/src/readline.rs
@@ -122,44 +122,6 @@ mod rustyline_readline {
             }
         }
     }
-
-    #[cfg(test)]
-    mod test_rusty_readline {
-        use super::Readline;
-        use crate::readline::ReadlineResult::Line;
-        use rustyline::error::ReadlineError;
-        use rustyline::{
-            completion::Completer, highlight::Highlighter, hint::Hinter, validate::Validator,
-            Context,
-        };
-        struct HelperShim {}
-        impl rustyline::Helper for HelperShim {}
-        impl Highlighter for HelperShim {}
-        impl Validator for HelperShim {}
-        impl Completer for HelperShim {
-            type Candidate = String;
-
-            fn complete(
-                &self,
-                _line: &str,
-                _pos: usize,
-                _ctx: &Context,
-            ) -> rustyline::Result<(usize, Vec<String>)> {
-                Err(ReadlineError::Interrupted)
-            }
-        }
-        impl Hinter for HelperShim {
-            type Hint = String;
-        }
-        #[test]
-        #[ignore]
-        fn test_multi_read_line() {
-            let mut repl = Readline::new(HelperShim {});
-            if let Line(line) = repl.readline("print('hello')\nprint('hello2')\n") {
-                assert_eq!(line, "print('hello')");
-            }
-        }
-    }
 }
 
 #[cfg(target_arch = "wasm32")]

--- a/vm/src/readline.rs
+++ b/vm/src/readline.rs
@@ -125,7 +125,7 @@ mod rustyline_readline {
 
     #[cfg(test)]
     mod test_rusty_readline {
-        use super::*;
+        use super::{Readline};
         use rustyline::{completion::Completer, highlight::Highlighter,
                         validate::Validator, Context, hint::Hinter};
         use rustyline::error::ReadlineError;
@@ -142,8 +142,8 @@ mod rustyline_readline {
 
             fn complete(
                 &self,
-                line: &str,
-                pos: usize,
+                _line: &str,
+                _pos: usize,
                 _ctx: &Context,
             ) -> rustyline::Result<(usize, Vec<String>)> {
                 Err(ReadlineError::Interrupted)
@@ -152,7 +152,6 @@ mod rustyline_readline {
         impl Hinter for HelperShim {
             type Hint = String;
         }
-        // impl Helper for ShellHelper<'_> {}
         #[test]
         fn test_multi_read_line() {
 

--- a/vm/src/readline.rs
+++ b/vm/src/readline.rs
@@ -125,11 +125,13 @@ mod rustyline_readline {
 
     #[cfg(test)]
     mod test_rusty_readline {
-        use super::{Readline};
-        use rustyline::{completion::Completer, highlight::Highlighter,
-                        validate::Validator, Context, hint::Hinter};
-        use rustyline::error::ReadlineError;
+        use super::Readline;
         use crate::readline::ReadlineResult::Line;
+        use rustyline::error::ReadlineError;
+        use rustyline::{
+            completion::Completer, highlight::Highlighter, hint::Hinter, validate::Validator,
+            Context,
+        };
         struct HelperShim {}
         impl rustyline::Helper for HelperShim {}
         impl Highlighter for HelperShim {}
@@ -149,9 +151,10 @@ mod rustyline_readline {
         impl Hinter for HelperShim {
             type Hint = String;
         }
-        #[test] #[ignore]
+        #[test]
+        #[ignore]
         fn test_multi_read_line() {
-            let mut repl = Readline::new(HelperShim { });
+            let mut repl = Readline::new(HelperShim {});
             if let Line(line) = repl.readline("print('hello')\nprint('hello2')\n") {
                 assert_eq!(line, "print('hello')");
             }
@@ -185,4 +188,3 @@ impl<H: Helper> Readline<H> {
         self.0.readline(prompt)
     }
 }
-


### PR DESCRIPTION
Fixes [the parsing of multiple lines into the REPL](https://github.com/RustPython/RustPython/issues/2406).

Updates RustyLine to version 8.0.0 and turns off [bracketed paste](https://docs.rs/rustyline/8.0.0/rustyline/config/struct.Builder.html#method.bracketed_paste) to do so. The respective test is currently marked as ignored due to an [issue ](https://github.com/kkawakam/rustyline/issues/504)with RustyLine.