### PR TITLE
fix github action for what is left data

### DIFF
--- a/.github/workflows/cron-ci.yaml
+++ b/.github/workflows/cron-ci.yaml
@@ -97,13 +97,13 @@ jobs:
         with:
           command: build
           args: --release --verbose
-      - name: collect what is left data
+      - name: Collect what is left data
         run: |
           chmod +x ./whats_left.sh
           ./whats_left.sh > whats_left.temp
         env:
           RUSTPYTHONPATH: ${{ github.workspace }}/Lib
-      - name: upload data to the website
+      - name: Upload data to the website
         env:
           SSHKEY: ${{ secrets.ACTIONS_TESTS_DATA_DEPLOY_KEY }}
           GITHUB_ACTOR: ${{ github.actor }}
@@ -116,7 +116,6 @@ jobs:
           cd website
           [ -f ./_data/whats_left.temp ] && cp ./_data/whats_left.temp ./_data/whats_left_lastrun.temp
           cp ../whats_left.temp ./_data/whats_left.temp
-          git add ./_data/whats_left_lastrun.temp
-          git add ./_data/whats_left.temp
-          git -c user.name="Github Actions" -c user.email="actions@github.com" commit -m "Update regression test results" --author="$GITHUB_ACTOR"
+          git add -A
+          git -c user.name="Github Actions" -c user.email="actions@github.com" commit -m "Update what is left results" --author="$GITHUB_ACTOR"
           git push


### PR DESCRIPTION
I noticed that the GitHub action for pushing `whats_left.sh` data to the website repo is broken.

<img width="826" alt="Screen Shot 2021-03-19 at 9 44 30 AM" src="https://user-images.githubusercontent.com/521705/111817161-4abed800-88a3-11eb-8519-7ecf1a0e5aa4.png">

I switched to using git add -A instead and I updated the commit message.
