### PR TITLE
Run benchmarks in CI

### DIFF
--- a/.github/workflows/cron-ci.yaml
+++ b/.github/workflows/cron-ci.yaml
@@ -119,3 +119,37 @@ jobs:
           git add -A
           git -c user.name="Github Actions" -c user.email="actions@github.com" commit -m "Update what is left results" --author="$GITHUB_ACTOR"
           git push
+
+  benchmark:
+    name: Collect benchmark data
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@master
+      - name: collect execution benchmark data
+        run: cargo bench --bench execution
+      - name: collect microbenchmarks data
+        run: cargo bench --bench microbenchmarks
+      - name: restructure generated files
+        run: |
+          cd ./target/criterion
+          find -type d -name cpython | xargs rm -rf
+          find -type d -name rustpython | xargs rm -rf
+          find -maxdepth 2 -type d -name report | xargs rm -rf
+          find -type f -not -name violin.svg | xargs rm -rf
+          for file in $(find -type f -name violin.svg); do mv $file $(echo $file | sed -E "s_\./([^/]+)/([^/]+)/report/violin\.svg_./\1/\2.svg_"); done
+          find -mindepth 2 -maxdepth 2 -type d | xargs rm -rf
+      - name: upload benchmark data to the website
+        env:
+          SSHKEY: ${{ secrets.ACTIONS_TESTS_DATA_DEPLOY_KEY }}
+        run: |
+          echo "$SSHKEY" >~/github_key
+          chmod 600 ~/github_key
+          export GIT_SSH_COMMAND="ssh -i ~/github_key"
+
+          git clone git@github.com:RustPython/rustpython.github.io.git website
+          cd website
+          rm -rf ./assets/criterion
+          cp -r ../target/criterion ./assets/criterion
+          git add ./assets/criterion
+          git -c user.name="Github Actions" -c user.email="actions@github.com" commit -m "Update benchmark results"
+          git push


### PR DESCRIPTION
The first half of #2396:
- run benchmarks
- restructure the folders and rename the generated SVG's to simplify displaying them
- upload/commit the generated data to [RustPython/rustpython.github.io](https://github.com/RustPython/rustpython.github.io)

The second half (actually displaying the data) will be implemented in [RustPython/rustpython.github.io](https://github.com/RustPython/rustpython.github.io).

I considered moving the `restructure generated files` 'run' to a separate script file to add some comments, but I decided that that was not 'worth' the extra file. Be sure to let me know if people have a different opinion on this.

The for loop renames files as follows: `./execution/mandelbrot.py/report/violin.svg` -> `./execution/mandelbrot.py.svg`.