### PR TITLE
os: Add support for fd and dir_fd in `listdir`, `stat`, `fstat`

### DIFF
--- a/Lib/test/test_os.py
+++ b/Lib/test/test_os.py
@@ -3958,8 +3958,8 @@ class TestScandir(unittest.TestCase):
             self.assertIs(type(entry.name), bytes)
             self.assertIs(type(entry.path), bytes)
 
-    @unittest.skipUnless(os.listdir in os.supports_fd,
-                         'fd support for listdir required for this test.')
+    @unittest.skipUnless(os.scandir in os.supports_fd,
+                         'fd support for scandir required for this test.')
     def test_fd(self):
         self.assertIn(os.scandir, os.supports_fd)
         self.create_file('file.txt')

--- a/Lib/test/test_os.py
+++ b/Lib/test/test_os.py
@@ -3958,6 +3958,7 @@ class TestScandir(unittest.TestCase):
             self.assertIs(type(entry.name), bytes)
             self.assertIs(type(entry.path), bytes)
 
+    # TODO: RUSTPYTHON (scandir needs to have supports_fd)
     @unittest.skipUnless(os.scandir in os.supports_fd,
                          'fd support for scandir required for this test.')
     def test_fd(self):

--- a/vm/src/stdlib/os.rs
+++ b/vm/src/stdlib/os.rs
@@ -170,7 +170,7 @@ fn path_from_fd(raw_fd: i64) -> Result<PathBuf, String> {
             };
             Ok(path)
         } else {
-            Err(vm.new_os_error("fd not supported on wasi yet".to_owned()));
+            Err("fd not supported on wasi yet");
         }
     }
 }

--- a/vm/src/stdlib/os.rs
+++ b/vm/src/stdlib/os.rs
@@ -900,7 +900,7 @@ mod _os {
     #[pyfunction]
     fn stat(
         file: Either<PyPathLike, i64>,
-        dir_fd: super::DirFd,
+        dir_fd: DirFd,
         follow_symlinks: FollowSymlinks,
         vm: &VirtualMachine,
     ) -> PyResult {
@@ -1259,8 +1259,8 @@ mod _os {
             SupportFunc::new(vm, "replace", rename, Some(false), Some(false), None), // TODO: Fix replace
             SupportFunc::new(vm, "rmdir", rmdir, Some(false), Some(false), None),
             SupportFunc::new(vm, "scandir", scandir, Some(false), None, None),
-            SupportFunc::new(vm, "stat", stat, Some(false), Some(false), Some(false)),
-            SupportFunc::new(vm, "fstat", stat, Some(false), Some(false), Some(false)),
+            SupportFunc::new(vm, "stat", stat, Some(true), Some(true), Some(true)),
+            SupportFunc::new(vm, "fstat", stat, Some(true), Some(true), Some(true)),
             SupportFunc::new(vm, "symlink", platform::symlink, None, Some(false), None),
             // truncate Some None None
             SupportFunc::new(vm, "unlink", remove, Some(false), Some(false), None),

--- a/vm/src/stdlib/os.rs
+++ b/vm/src/stdlib/os.rs
@@ -162,15 +162,17 @@ impl TryFromObject for PyPathLike {
 fn path_from_fd(raw_fd: i64) -> Result<PathBuf, String> {
     cfg_if::cfg_if! {
         if #[cfg(any(target_os = "linux", target_os = "macos", windows))] {
-            let path = match rust_file(raw_fd).path() {
+            let file = rust_file(raw_fd);
+            let path = match file.path() {
                 Ok(path) => path,
-                Err(_) => {
-                    return Err(format!("Cannot determine path of fd: {:?}", raw_fd));
+                Err(e) => {
+                    return Err(format!("{:?} Cannot determine path of fd: {:?}", e, raw_fd));
                 }
             };
+            raw_file_number(file);  // Do not consume `raw_fd`
             Ok(path)
         } else {
-            Err("fd not supported on wasi yet");
+            Err("fd not supported on wasi yet".to_owned());
         }
     }
 }


### PR DESCRIPTION
This PR would like to add support for `os.fwalk` which need 
`{open, stat} <= supports_dir_fd and {listdir, stat} <= supports_fd` 

So I add support for dir_fd and fd for each functions.

In listdir, I use same approach as make_path to add support_fd.

Noted that, test coverage doesn't increase due to the lack of 3rd argument in `os.symlink`.