### PR TITLE
Add os in detect requires environment script

### DIFF
--- a/Lib/test/support/script_helper.py
+++ b/Lib/test/support/script_helper.py
@@ -44,7 +44,7 @@ def interpreter_requires_environment():
         # Try running an interpreter with -E to see if it works or not.
         try:
             subprocess.check_call([sys.executable, '-E',
-                                   '-c', 'import sys; sys.exit(0)'])
+                                   '-c', 'import os, sys; sys.exit(0)'])
         except subprocess.CalledProcessError:
             __cached_interp_requires_environment = True
         else:


### PR DESCRIPTION
Before this patch, you need to set PYTHONHOME to run the test suite.
Now it will automatically detect whether you need environment for your interpreter.