### PR TITLE
Document bytecode file

### DIFF
--- a/bytecode/src/lib.rs
+++ b/bytecode/src/lib.rs
@@ -14,6 +14,7 @@ use std::collections::BTreeSet;
 use std::{fmt, hash};
 
 /// Sourcecode location.
+/// TODO start, end, middle?
 #[derive(Clone, Copy, Debug, Default, PartialEq, Serialize, Deserialize)]
 pub struct Location {
     row: usize,
@@ -21,28 +22,47 @@ pub struct Location {
 }
 
 impl Location {
+    /// Creates a new Location object at the given row and column.
+    ///
+    /// # Example
+    /// ```
+    /// use rustpython_bytecode::Location;
+    /// let loc = Location::new(10, 10);
+    /// ```
     pub fn new(row: usize, column: usize) -> Self {
         Location { row, column }
     }
 
+    /// Current row
     pub fn row(&self) -> usize {
         self.row
     }
 
+    /// Current column
     pub fn column(&self) -> usize {
         self.column
     }
 }
 
+/// A Constant object is
+/// TODO unclear
 pub trait Constant: Sized {
     type Name: AsRef<str>;
+
+    /// Tranforms the given Constant to a BorrowedConstant
     fn borrow_constant(&self) -> BorrowedConstant<Self>;
+    /// Get the data this Constant holds.
     fn into_data(self) -> ConstantData {
         self.borrow_constant().into_data()
     }
+    /// Map this Constant to a Bag's constant
+    ///
+    /// TODO Unclear.
     fn map_constant<Bag: ConstantBag>(self, bag: &Bag) -> Bag::Constant {
         bag.make_constant(self.into_data())
     }
+
+    /// Maps the name for the given Bag.
     fn map_name<Bag: ConstantBag>(
         name: Self::Name,
         bag: &Bag,
@@ -50,6 +70,7 @@ pub trait Constant: Sized {
         bag.make_name_ref(name.as_ref())
     }
 }
+
 impl Constant for ConstantData {
     type Name = String;
     fn borrow_constant(&self) -> BorrowedConstant<Self> {
@@ -77,6 +98,7 @@ impl Constant for ConstantData {
     }
 }
 
+/// A Constant Bag
 pub trait ConstantBag: Sized {
     type Constant: Constant;
     fn make_constant(&self, constant: ConstantData) -> Self::Constant;
@@ -91,6 +113,7 @@ pub trait ConstantBag: Sized {
 
 #[derive(Clone)]
 pub struct BasicBag;
+
 impl ConstantBag for BasicBag {
     type Constant = ConstantData;
     fn make_constant(&self, constant: ConstantData) -> Self::Constant {
@@ -157,6 +180,7 @@ impl CodeFlags {
 // XXX: if you add a new instruction that stores a Label, make sure to add it in
 // Instruction::label_arg{,_mut}
 pub struct Label(pub u32);
+
 impl fmt::Display for Label {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         self.0.fmt(f)
@@ -176,6 +200,7 @@ pub enum ConversionFlag {
     Repr,
 }
 
+/// The kind of Raise that occurred.
 #[derive(Copy, Clone, Debug, PartialEq, Serialize, Deserialize)]
 pub enum RaiseKind {
     Reraise,
@@ -188,11 +213,15 @@ pub type NameIdx = u32;
 /// A Single bytecode instruction.
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub enum Instruction {
+    /// Importing by name
     ImportName {
         idx: NameIdx,
     },
+    /// Importing without name
     ImportNameless,
+    /// Import *
     ImportStar,
+    /// from ... import ...
     ImportFrom {
         idx: NameIdx,
     },
@@ -400,6 +429,15 @@ bitflags! {
     }
 }
 
+/// A Constant (which usually encapsulates data within it)
+///
+/// # Examples
+/// ```
+/// use rustpython_bytecode::ConstantData;
+/// let a = ConstantData::Float {value: 120f64};
+/// let b = ConstantData::Boolean {value: false};
+/// assert_ne!(a, b);
+/// ```
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub enum ConstantData {
     Tuple { elements: Vec<ConstantData> },
@@ -436,6 +474,7 @@ impl PartialEq for ConstantData {
         }
     }
 }
+
 impl Eq for ConstantData {}
 
 impl hash::Hash for ConstantData {
@@ -460,6 +499,7 @@ impl hash::Hash for ConstantData {
     }
 }
 
+/// A borrowed Constant
 pub enum BorrowedConstant<'a, C: Constant> {
     Integer { value: &'a BigInt },
     Float { value: f64 },
@@ -472,7 +512,9 @@ pub enum BorrowedConstant<'a, C: Constant> {
     None,
     Ellipsis,
 }
+
 type BorrowedTupleIter<'a, C> = Box<dyn Iterator<Item = BorrowedConstant<'a, C>> + 'a>;
+
 impl<C: Constant> BorrowedConstant<'_, C> {
     // takes `self` because we need to consume the iterator
     pub fn fmt_display(self, f: &mut fmt::Formatter) -> fmt::Result {
@@ -530,6 +572,7 @@ impl<C: Constant> BorrowedConstant<'_, C> {
     }
 }
 
+/// The possible comparison operators
 #[derive(Debug, Copy, Clone, PartialEq, Serialize, Deserialize)]
 pub enum ComparisonOperator {
     Greater,
@@ -542,9 +585,19 @@ pub enum ComparisonOperator {
     NotIn,
     Is,
     IsNot,
+    /// two exceptions that match?
+    /// TODO clarify
     ExceptionMatch,
 }
 
+/// The possible Binary operators
+/// # Examples
+///
+/// ```
+/// use rustpython_bytecode::Instruction::BinaryOperation;
+/// use rustpython_bytecode::BinaryOperator::Add;
+/// let op = BinaryOperation {op: Add};
+/// ```
 #[derive(Debug, Copy, Clone, PartialEq, Serialize, Deserialize)]
 pub enum BinaryOperator {
     Power,
@@ -562,6 +615,7 @@ pub enum BinaryOperator {
     Or,
 }
 
+/// The possible unary operators
 #[derive(Debug, Copy, Clone, PartialEq, Serialize, Deserialize)]
 pub enum UnaryOperator {
     Not,
@@ -578,6 +632,8 @@ pub enum BlockType {
 }
 */
 
+/// Argument structure
+/// TODO is this for parameters or arguments?
 pub struct Arguments<'a, N: AsRef<str>> {
     pub posonlyargs: &'a [N],
     pub args: &'a [N],
@@ -604,7 +660,12 @@ impl<N: AsRef<str>> fmt::Debug for Arguments<'_, N> {
 }
 
 impl<C: Constant> CodeObject<C> {
-    // like inspect.getargs
+    /// Get all arguments of the code object
+    /// like inspect.getargs
+    /// # Examples
+    ///
+    /// TODO I'm not sure what is the best way to construct a CodeObject
+    ///
     pub fn arg_names(&self) -> Arguments<C::Name> {
         let nargs = self.arg_count;
         let nkwargs = self.kwonlyarg_count;
@@ -635,6 +696,7 @@ impl<C: Constant> CodeObject<C> {
         }
     }
 
+    /// Return the labels targeted by the instructions of this CodeObject
     pub fn label_targets(&self) -> BTreeSet<Label> {
         let mut label_targets = BTreeSet::new();
         for instruction in &*self.instructions {
@@ -677,6 +739,7 @@ impl<C: Constant> CodeObject<C> {
         Ok(())
     }
 
+    /// Recursively display this CodeObject
     pub fn display_expand_codeobjects(&self) -> impl fmt::Display + '_ {
         struct Display<'a, C: Constant>(&'a CodeObject<C>);
         impl<C: Constant> fmt::Display for Display<'_, C> {
@@ -687,6 +750,8 @@ impl<C: Constant> CodeObject<C> {
         Display(self)
     }
 
+    /// Map this CodeObject to one that holds a Bag::Constant
+    /// TODO add example
     pub fn map_bag<Bag: ConstantBag>(self, bag: &Bag) -> CodeObject<Bag::Constant> {
         let map_names = |names: Box<[C::Name]>| {
             names
@@ -721,6 +786,8 @@ impl<C: Constant> CodeObject<C> {
         }
     }
 
+    /// Same as `map_bag` but clones `self`
+    /// TODO add example
     pub fn map_clone_bag<Bag: ConstantBag>(&self, bag: &Bag) -> CodeObject<Bag::Constant> {
         let map_names = |names: &[C::Name]| {
             names
@@ -754,12 +821,16 @@ impl<C: Constant> CodeObject<C> {
     }
 }
 
+/// Error that occurs during code deserialization
 #[derive(Debug)]
 #[non_exhaustive]
 pub enum CodeDeserializeError {
+    /// Unexpected End Of File
     Eof,
+    /// Invalid Bytecode
     Other,
 }
+
 impl fmt::Display for CodeDeserializeError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match self {
@@ -768,6 +839,7 @@ impl fmt::Display for CodeDeserializeError {
         }
     }
 }
+
 impl std::error::Error for CodeDeserializeError {}
 
 impl CodeObject<ConstantData> {
@@ -850,6 +922,16 @@ impl Instruction {
         }
     }
 
+    /// Whether this is an unconditional branching
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use rustpython_bytecode::{Instruction, Label};
+    /// let label = Label(0xF);
+    /// let jump_inst = Instruction::Jump {target: label};
+    /// assert!(jump_inst.unconditional_branch())
+    /// ```
     pub fn unconditional_branch(&self) -> bool {
         matches!(
             self,
@@ -857,6 +939,20 @@ impl Instruction {
         )
     }
 
+    /// What effect this instruction has on the stack
+    ///
+    /// TODO what exactly do the numbers represent?
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use rustpython_bytecode::{Instruction, Label, UnaryOperator};
+    /// let jump_instruction = Instruction::Jump {target: Label(0xF)};
+    /// let invert_instruction = Instruction::UnaryOperation {op: UnaryOperator::Invert};
+    /// assert_eq!(jump_instruction.stack_effect(true), 0);
+    /// assert_eq!(invert_instruction.stack_effect(false), 0);
+    /// ```
+    ///
     pub fn stack_effect(&self, jump: bool) -> i32 {
         match self {
             ImportName { .. } | ImportNameless => -1,
@@ -1130,6 +1226,8 @@ impl<C: Constant> fmt::Debug for CodeObject<C> {
     }
 }
 
+/// A frozen module. Holds a code object and whether it is part of a package
+/// TODO example
 #[derive(Serialize, Deserialize, Debug)]
 pub struct FrozenModule<C: Constant = ConstantData> {
     #[serde(bound(
@@ -1146,6 +1244,7 @@ pub mod frozen_lib {
     use std::convert::TryInto;
     use std::io;
 
+    /// Decode a library to a iterable of frozen modules
     pub fn decode_lib(bytes: &[u8]) -> FrozenModulesIter {
         let data = lz4_flex::decompress_size_prepended(bytes).unwrap();
         let r = VecReader { data, pos: 0 };
@@ -1183,6 +1282,7 @@ pub mod frozen_lib {
 
     impl ExactSizeIterator for FrozenModulesIter {}
 
+    /// Encode the given iterator of frozen modules into a compressed vector of bytes
     pub fn encode_lib<'a, I>(lib: I) -> Vec<u8>
     where
         I: IntoIterator<Item = (&'a str, &'a FrozenModule)>,

--- a/bytecode/src/lib.rs
+++ b/bytecode/src/lib.rs
@@ -211,17 +211,20 @@ pub enum RaiseKind {
 pub type NameIdx = u32;
 
 /// A Single bytecode instruction.
+/// For details on the instructions that do not have documentation here,
+/// see the [dis library](https://docs.python.org/3/library/dis.html#python-bytecode-instructions)
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub enum Instruction {
-    /// Importing by name
     ImportName {
         idx: NameIdx,
     },
-    /// Importing without name
+    /// Importing without name.
+    /// *This is not present in the dis library*
     ImportNameless,
     /// Import *
     ImportStar,
-    /// from ... import ...
+    /// Loads all symbols not starting with `'_' directly from the module TOS to the local namespace.
+    /// The module is popped after loading all names. This opcode implements `from module import *`.
     ImportFrom {
         idx: NameIdx,
     },
@@ -267,6 +270,7 @@ pub enum Instruction {
     CompareOperation {
         op: ComparisonOperator,
     },
+    /// Removes the top-of-stack (TOS) item.
     Pop,
     Rotate {
         amount: u32,

--- a/derive/src/compile_bytecode.rs
+++ b/derive/src/compile_bytecode.rs
@@ -32,8 +32,11 @@ static CARGO_MANIFEST_DIR: Lazy<PathBuf> = Lazy::new(|| {
 });
 
 enum CompilationSourceKind {
+    /// Source is a File (Path)
     File(PathBuf),
+    /// Direct Raw sourcecode
     SourceCode(String),
+    /// Source is a directory
     Dir(PathBuf),
 }
 


### PR DESCRIPTION
Adds documentation for the bytecode crate. 

Remaining issue: Should all the instructions have their documentation copied over from the dis library to keep that localized? As was mentioned in #2510, it may be clearer to keep it here and highlight the differences.
Alternatively, a short guide on how to examine the bytecode could be added, though perhaps not in this module

Split off from #2532 to reduce the sections touched by a single PR.
