### PR TITLE
Refactor sequence owner name into trait

### DIFF
--- a/Lib/test/list_tests.py
+++ b/Lib/test/list_tests.py
@@ -39,8 +39,6 @@ class CommonTest(seq_tests.CommonTest):
         with self.assertRaisesRegex(TypeError, msg):
             a['a']
 
-    # TODO: RUSTPYTHON
-    @unittest.expectedFailure
     def test_setitem_error(self):
         a = []
         msg = "list indices must be integers or slices"
@@ -107,8 +105,6 @@ class CommonTest(seq_tests.CommonTest):
         # Bug 3689: make sure list-reversed-iterator doesn't have __len__
         self.assertRaises(TypeError, len, reversed([1,2,3]))
 
-    # TODO: RUSTPYTHON
-    @unittest.expectedFailure
     def test_setitem(self):
         a = self.type2test([0, 1])
         a[0] = 0

--- a/Lib/test/test_bytes.py
+++ b/Lib/test/test_bytes.py
@@ -1122,8 +1122,6 @@ class ByteArrayTest(BaseBytesTest, unittest.TestCase):
         with self.assertRaisesRegex(TypeError, msg):
             b['a']
 
-    # TODO: RUSTPYTHON
-    @unittest.expectedFailure
     def test_setitem_error(self):
         b = bytearray(b'python')
         msg = "bytearray indices must be integers or slices"

--- a/vm/src/builtins/bytearray.rs
+++ b/vm/src/builtins/bytearray.rs
@@ -26,8 +26,8 @@ use crate::slots::{
 use crate::utils::Either;
 use crate::vm::VirtualMachine;
 use crate::{
-    IdProtocol, IntoPyObject, PyClassImpl, PyComparisonValue, PyContext, PyIterable, PyObjectRef,
-    PyRef, PyResult, PyValue, TypeProtocol,
+    IdProtocol, IntoPyObject, PyClassDef, PyClassImpl, PyComparisonValue, PyContext, PyIterable,
+    PyObjectRef, PyRef, PyResult, PyValue, TypeProtocol,
 };
 use bstr::ByteSlice;
 use crossbeam_utils::atomic::AtomicCell;
@@ -151,11 +151,11 @@ impl PyByteArray {
     #[pymethod(magic)]
     fn setitem(
         zelf: PyRef<Self>,
-        needle: SequenceIndex,
+        needle: PyObjectRef,
         value: PyObjectRef,
         vm: &VirtualMachine,
     ) -> PyResult<()> {
-        match needle {
+        match SequenceIndex::try_from_object_for(vm, needle, Self::NAME)? {
             SequenceIndex::Int(i) => {
                 let value = value_from_object(vm, &value)?;
                 let mut elements = zelf.borrow_buf_mut();
@@ -192,7 +192,7 @@ impl PyByteArray {
 
     #[pymethod(magic)]
     fn getitem(&self, needle: PyObjectRef, vm: &VirtualMachine) -> PyResult {
-        self.inner().getitem("bytearray", needle, vm)
+        self.inner().getitem(Self::NAME, needle, vm)
     }
 
     #[pymethod(magic)]

--- a/vm/src/builtins/bytes.rs
+++ b/vm/src/builtins/bytes.rs
@@ -151,7 +151,7 @@ impl PyBytes {
 
     #[pymethod(name = "__getitem__")]
     fn getitem(&self, needle: PyObjectRef, vm: &VirtualMachine) -> PyResult {
-        self.inner.getitem("byte", needle, vm)
+        self.inner.getitem("byte", needle, vm) // byte != Self::NAME
     }
 
     #[pymethod(name = "isalnum")]

--- a/vm/src/builtins/pystr.rs
+++ b/vm/src/builtins/pystr.rs
@@ -23,8 +23,8 @@ use crate::slots::{Comparable, Hashable, Iterable, PyComparisonOp, PyIter};
 use crate::utils::Either;
 use crate::VirtualMachine;
 use crate::{
-    IdProtocol, IntoPyObject, ItemProtocol, PyClassImpl, PyComparisonValue, PyContext, PyIterable,
-    PyObjectRef, PyRef, PyResult, PyValue, TryIntoRef, TypeProtocol,
+    IdProtocol, IntoPyObject, ItemProtocol, PyClassDef, PyClassImpl, PyComparisonValue, PyContext,
+    PyIterable, PyObjectRef, PyRef, PyResult, PyValue, TryIntoRef, TypeProtocol,
 };
 use rustpython_common::atomic::{self, PyAtomic, Radium};
 use rustpython_common::hash;
@@ -254,7 +254,7 @@ impl PyStr {
 
     #[pymethod(name = "__getitem__")]
     fn getitem(&self, needle: PyObjectRef, vm: &VirtualMachine) -> PyResult {
-        let s = match self.get_item(vm, needle, "string")? {
+        let s = match self.get_item(vm, needle, Self::NAME)? {
             Either::A(ch) => ch.to_string(),
             Either::B(s) => s,
         };

--- a/vm/src/builtins/tuple.rs
+++ b/vm/src/builtins/tuple.rs
@@ -19,8 +19,9 @@ use crate::slots::{Comparable, Hashable, Iterable, PyComparisonOp, PyIter};
 use crate::utils::Either;
 use crate::vm::{ReprGuard, VirtualMachine};
 use crate::{
-    IdProtocol, IntoPyObject, PyArithmaticValue, PyClassImpl, PyComparisonValue, PyContext,
-    PyObjectRef, PyRef, PyResult, PyValue, TransmuteFromObject, TryFromObject, TypeProtocol,
+    IdProtocol, IntoPyObject, PyArithmaticValue, PyClassDef, PyClassImpl, PyComparisonValue,
+    PyContext, PyObjectRef, PyRef, PyResult, PyValue, TransmuteFromObject, TryFromObject,
+    TypeProtocol,
 };
 
 /// tuple() -> empty tuple
@@ -182,7 +183,7 @@ impl PyTuple {
 
     #[pymethod(name = "__getitem__")]
     fn getitem(zelf: PyRef<Self>, needle: PyObjectRef, vm: &VirtualMachine) -> PyResult {
-        let result = match zelf.elements.as_ref().get_item(vm, needle, "tuple")? {
+        let result = match zelf.elements.as_ref().get_item(vm, needle, Self::NAME)? {
             Either::A(obj) => obj,
             Either::B(vec) => vm.ctx.new_tuple(vec),
         };

--- a/vm/src/bytesinner.rs
+++ b/vm/src/bytesinner.rs
@@ -335,11 +335,11 @@ impl PyBytesInner {
 
     pub fn getitem(
         &self,
-        name: &'static str,
+        owner_type: &'static str,
         needle: PyObjectRef,
         vm: &VirtualMachine,
     ) -> PyResult {
-        let obj = match self.elements.get_item(vm, needle, name)? {
+        let obj = match self.elements.get_item(vm, needle, owner_type)? {
             Either::A(byte) => vm.new_pyobj(byte),
             Either::B(bytes) => vm.ctx.new_bytes(bytes),
         };

--- a/vm/src/sliceable.rs
+++ b/vm/src/sliceable.rs
@@ -336,7 +336,7 @@ pub enum SequenceIndex {
 }
 
 impl SequenceIndex {
-    fn try_from_object_for(
+    pub fn try_from_object_for(
         vm: &VirtualMachine,
         obj: PyObjectRef,
         owner_type: &'static str,


### PR DESCRIPTION
This pull request adds the following changes:

 - Refactors owner_type argument in PySliceableSequence's indexing functions into a separate PySliceableSequenceOwner trait
 - Makes setitem tests in list_tests.py, test_bytes.py files work