### PR TITLE
Retain order of keys in dict when deleting a key

### DIFF
--- a/Lib/test/test_collections.py
+++ b/Lib/test/test_collections.py
@@ -1974,8 +1974,6 @@ class TestCounter(unittest.TestCase):
         self.assertRaises(TypeError, Counter, (), ())
         self.assertRaises(TypeError, Counter.__init__)
 
-    # TODO: RUSTPYTHON
-    @unittest.expectedFailure
     def test_order_preservation(self):
         # Input order dictates items() order
         self.assertEqual(list(Counter('abracadabra').items()),

--- a/Lib/test/test_dict.py
+++ b/Lib/test/test_dict.py
@@ -1346,8 +1346,6 @@ class DictTest(unittest.TestCase):
 
         self.assertRaises(RuntimeError, iter_and_mutate)
 
-    # TODO: RUSTPYTHON
-    @unittest.expectedFailure
     def test_reversed(self):
         d = {"a": 1, "b": 2, "foo": 0, "c": 3, "d": 4}
         del d["foo"]

--- a/vm/src/dictdatatype.rs
+++ b/vm/src/dictdatatype.rs
@@ -557,10 +557,13 @@ impl<T: Clone> Dict<T> {
         let removed = if entry_index == inner.used {
             inner.entries.pop().unwrap()
         } else {
-            let last_index = inner.entries.last().unwrap().index;
-            let removed = inner.entries.remove(entry_index);
-            inner.indices[last_index] = IndexEntry::FREE;
-            removed
+            let entries_rem = entry_index + 1;
+            let entries_len = inner.entries.len();
+            for move_entry_idx in entries_rem..entries_len {
+                let index_index = inner.entries[move_entry_idx].index;
+                inner.indices[index_index] = move_entry_idx as i64 - 1;
+            }
+            inner.entries.remove(entry_index)
         };
         Ok(Some(removed))
     }

--- a/vm/src/dictdatatype.rs
+++ b/vm/src/dictdatatype.rs
@@ -558,8 +558,8 @@ impl<T: Clone> Dict<T> {
             inner.entries.pop().unwrap()
         } else {
             let last_index = inner.entries.last().unwrap().index;
-            let removed = inner.entries.swap_remove(entry_index);
-            inner.indices[last_index] = entry_index as i64;
+            let removed = inner.entries.remove(entry_index);
+            inner.indices[last_index] = IndexEntry::FREE;
             removed
         };
         Ok(Some(removed))


### PR DESCRIPTION
This patch makes dictionaries retain the order of elements after deleting a key (the correct behavior in CPython). 