### PR TITLE
Add extra check in test_py_compile for Big Sur and/or Apple Silicon

### DIFF
--- a/Lib/test/test_py_compile.py
+++ b/Lib/test/test_py_compile.py
@@ -115,7 +115,7 @@ class PyCompileTestsBase:
 
     # TODO: RUSTPYTHON
     import platform
-    if sys.platform == "darwin" and platform.release() != "20.3.0":
+    if sys.platform == "darwin" and int(platform.release().split(".")[0]) < 20:
         test_relative_path = unittest.expectedFailure(test_relative_path)
 
     @unittest.skipIf(hasattr(os, 'geteuid') and os.geteuid() == 0,

--- a/Lib/test/test_py_compile.py
+++ b/Lib/test/test_py_compile.py
@@ -114,7 +114,8 @@ class PyCompileTestsBase:
         self.assertFalse(os.path.exists(self.cache_path))
 
     # TODO: RUSTPYTHON
-    if sys.platform == "darwin":
+    import platform
+    if sys.platform == "darwin" and platform.machine() != "arm64":
         test_relative_path = unittest.expectedFailure(test_relative_path)
 
     @unittest.skipIf(hasattr(os, 'geteuid') and os.geteuid() == 0,

--- a/Lib/test/test_py_compile.py
+++ b/Lib/test/test_py_compile.py
@@ -115,7 +115,7 @@ class PyCompileTestsBase:
 
     # TODO: RUSTPYTHON
     import platform
-    if sys.platform == "darwin" and platform.machine() != "arm64":
+    if sys.platform == "darwin" and platform.release() != "20.3.0":
         test_relative_path = unittest.expectedFailure(test_relative_path)
 
     @unittest.skipIf(hasattr(os, 'geteuid') and os.geteuid() == 0,


### PR DESCRIPTION
I don't know if this has to do with the operating system or the architecture. Does anyone have an Intel Mac running Big Sur that can test this patch's effectiveness?
