### PR TITLE
Unskip more macOS tests in CI

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -111,7 +111,6 @@ jobs:
         name: run cpython tests (macOS lightweight)
         run:
           target/release/rustpython -m test -v -x
-            test_bytearray
             test_long
             test_unicode
             test_array

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -111,7 +111,6 @@ jobs:
         name: run cpython tests (macOS lightweight)
         run:
           target/release/rustpython -m test -v -x
-            test_array
             test_asyncgen
             test_list
             test_complex

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -111,7 +111,6 @@ jobs:
         name: run cpython tests (macOS lightweight)
         run:
           target/release/rustpython -m test -v -x
-            test_set
             test_dis
             test_calendar
             test_http_cookiejar

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -111,8 +111,20 @@ jobs:
         name: run cpython tests (macOS lightweight)
         run:
           target/release/rustpython -m test -v -x
-            test_argparse test_json test_bytes test_bytearray test_long test_unicode test_array
-            test_asyncgen test_list test_complex test_json test_set test_dis test_calendar
+            test_argparse
+            test_json
+            test_bytes
+            test_bytearray
+            test_long
+            test_unicode
+            test_array
+            test_asyncgen
+            test_list
+            test_complex
+            test_json
+            test_set
+            test_dis
+            test_calendar
             test_http_cookiejar
       - if: runner.os == 'Windows'
         name: run cpython tests (windows partial - fixme)

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -111,7 +111,6 @@ jobs:
         name: run cpython tests (macOS lightweight)
         run:
           target/release/rustpython -m test -v -x
-            test_long
             test_unicode
             test_array
             test_asyncgen

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -36,14 +36,7 @@ jobs:
       - name: Set up the Mac environment
         run: brew install autoconf automake libtool
         if: runner.os == 'macOS'
-      - name: Cache cargo dependencies
-        uses: actions/cache@v2
-        with:
-          path: |
-              ~/.cargo/registry
-              ~/.cargo/git
-              target
-          key: ${{ runner.os }}-debug_opt3-${{ hashFiles('**/Cargo.lock') }}
+      - uses: Swatinem/rust-cache@v1
       - name: run rust tests
         uses: actions-rs/cargo@v1
         with:
@@ -76,14 +69,7 @@ jobs:
       - name: Set up the Mac environment
         run: brew install autoconf automake libtool
         if: runner.os == 'macOS'
-      - name: Cache cargo dependencies
-        uses: actions/cache@v2
-        with:
-          path: |
-              ~/.cargo/registry
-              ~/.cargo/git
-              target
-          key: ${{ runner.os }}-release-${{ hashFiles('**/Cargo.lock') }}
+      - uses: Swatinem/rust-cache@v1
       - name: build rustpython
         uses: actions-rs/cargo@v1
         with:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -111,7 +111,6 @@ jobs:
         name: run cpython tests (macOS lightweight)
         run:
           target/release/rustpython -m test -v -x
-            test_asyncgen
             test_list
             test_complex
             test_set

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -111,7 +111,6 @@ jobs:
         name: run cpython tests (macOS lightweight)
         run:
           target/release/rustpython -m test -v -x
-            test_complex
             test_set
             test_dis
             test_calendar

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -111,7 +111,6 @@ jobs:
         name: run cpython tests (macOS lightweight)
         run:
           target/release/rustpython -m test -v -x
-            test_bytes
             test_bytearray
             test_long
             test_unicode

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -111,7 +111,6 @@ jobs:
         name: run cpython tests (macOS lightweight)
         run:
           target/release/rustpython -m test -v -x
-            test_argparse
             test_json
             test_bytes
             test_bytearray

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -111,7 +111,6 @@ jobs:
         name: run cpython tests (macOS lightweight)
         run:
           target/release/rustpython -m test -v -x
-            test_unicode
             test_array
             test_asyncgen
             test_list

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -111,7 +111,6 @@ jobs:
         name: run cpython tests (macOS lightweight)
         run:
           target/release/rustpython -m test -v -x
-            test_list
             test_complex
             test_set
             test_dis

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -111,7 +111,6 @@ jobs:
         name: run cpython tests (macOS lightweight)
         run:
           target/release/rustpython -m test -v -x
-            test_calendar
             test_http_cookiejar
       - if: runner.os == 'Windows'
         name: run cpython tests (windows partial - fixme)

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -111,7 +111,6 @@ jobs:
         name: run cpython tests (macOS lightweight)
         run:
           target/release/rustpython -m test -v -x
-            test_dis
             test_calendar
             test_http_cookiejar
       - if: runner.os == 'Windows'

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -78,8 +78,6 @@ jobs:
         if: runner.os == 'macOS'
       - name: Cache cargo dependencies
         uses: actions/cache@v2
-        # cache gets corrupted for some reason on mac
-        if: runner.os != 'macOS'
         with:
           path: |
               ~/.cargo/registry

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -111,7 +111,6 @@ jobs:
         name: run cpython tests (macOS lightweight)
         run:
           target/release/rustpython -m test -v -x
-            test_json
             test_bytes
             test_bytearray
             test_long
@@ -120,7 +119,6 @@ jobs:
             test_asyncgen
             test_list
             test_complex
-            test_json
             test_set
             test_dis
             test_calendar


### PR DESCRIPTION
This PR will incrementally determine exactly which tests must be skipped on the macOS CI run. Submitting as draft until everything is narrowed down.
