### PR TITLE
os: Fix `open` keyword arguments

### DIFF
--- a/Lib/test/test_os.py
+++ b/Lib/test/test_os.py
@@ -274,8 +274,6 @@ class FileTests(unittest.TestCase):
         with open(TESTFN2, 'r') as f:
             self.assertEqual(f.read(), "1")
 
-    # TODO: RUSTPYTHON (TypeError: Expected at least 2 arguments (0 given))
-    @unittest.expectedFailure
     def test_open_keywords(self):
         f = os.open(path=__file__, flags=os.O_RDONLY, mode=0o777,
             dir_fd=None)

--- a/vm/src/stdlib/io.rs
+++ b/vm/src/stdlib/io.rs
@@ -2878,13 +2878,7 @@ mod fileio {
                         vm.new_value_error("Cannot use closefd=False with file name".to_owned())
                     );
                 }
-                os::open(
-                    path,
-                    flags as _,
-                    OptionalArg::Missing,
-                    Default::default(),
-                    vm,
-                )?
+                os::open(path, flags as _, None, Default::default(), vm)?
             };
 
             if mode.contains(Mode::APPENDING) {

--- a/vm/src/stdlib/os.rs
+++ b/vm/src/stdlib/os.rs
@@ -357,11 +357,29 @@ mod _os {
     }
 
     #[cfg(any(unix, windows, target_os = "wasi"))]
+    #[derive(FromArgs)]
+    struct OpenArgs {
+        #[pyarg(any)]
+        path: PyPathLike,
+        #[pyarg(any)]
+        flags: OpenFlags,
+        #[pyarg(any, default)]
+        mode: Option<PyIntRef>,
+        #[pyarg(flatten)]
+        dir_fd: DirFd,
+    }
+
+    #[cfg(any(unix, windows, target_os = "wasi"))]
     #[pyfunction]
-    pub(crate) fn open(
+    fn open(args: OpenArgs, vm: &VirtualMachine) -> PyResult<i64> {
+        os_open(args.path, args.flags, args.mode, args.dir_fd, vm)
+    }
+
+    #[cfg(any(unix, windows, target_os = "wasi"))]
+    pub(crate) fn os_open(
         name: PyPathLike,
         flags: OpenFlags,
-        _mode: OptionalArg<PyIntRef>,
+        _mode: Option<PyIntRef>,
         dir_fd: DirFd,
         vm: &VirtualMachine,
     ) -> PyResult<i64> {
@@ -1412,7 +1430,7 @@ pub fn make_module(vm: &VirtualMachine) -> PyObjectRef {
 
     module
 }
-pub(crate) use _os::open;
+pub(crate) use _os::os_open as open;
 
 fn to_seconds_from_unix_epoch(sys_time: SystemTime) -> f64 {
     match sys_time.duration_since(SystemTime::UNIX_EPOCH) {


### PR DESCRIPTION
Following code used to fail due to the way used to define
os.open in rust. To fix this, we need to use `FromArgs`
to define `struct OpenArgs {...}`.
```
f = os.open(path=__file__, flags=os.O_RDONLY, mode=0o777, dir_fd=None)
```

Noted that the original `open` is now rename to `rust_open`
and is also exported. The only usage of `rust_open` is only in `io.rs`.

Related to #1175