### PR TITLE
os: symlink use `FromArgs` for arguments

### DIFF
--- a/Lib/test/test_os.py
+++ b/Lib/test/test_os.py
@@ -279,8 +279,6 @@ class FileTests(unittest.TestCase):
             dir_fd=None)
         os.close(f)
 
-    # TODO: RUSTPYTHON (TypeError: Expected at least 2 arguments (0 given))
-    @unittest.expectedFailure
     def test_symlink_keywords(self):
         symlink = support.get_attribute(os, "symlink")
         try:


### PR DESCRIPTION
Pass `FileTests.test_symlink_keywords` in `test_os.py`

Related to #1175