### PR TITLE
Unskip more Windows tests in CI

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -100,10 +100,30 @@ jobs:
         name: run cpython tests (windows partial - fixme)
         run:
           target/release/rustpython -m test -v -x
-            test_argparse test_json test_bytes test_long test_pwd test_bool test_cgi test_complex
-            test_exception_hierarchy test_glob test_iter test_list test_os test_pathlib
-            test_py_compile test_set test_shutil test_sys test_unicode test_unittest test_venv
-            test_zipimport test_importlib test_io
+            test_argparse
+            test_json
+            test_bytes
+            test_long
+            test_pwd
+            test_bool
+            test_cgi
+            test_complex
+            test_exception_hierarchy
+            test_glob
+            test_iter
+            test_list
+            test_os
+            test_pathlib
+            test_py_compile
+            test_set
+            test_shutil
+            test_sys
+            test_unicode
+            test_unittest
+            test_venv
+            test_zipimport
+            test_importlib
+            test_io
 
   lint:
     name: Check Rust code with rustfmt and clippy

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -100,7 +100,6 @@ jobs:
         name: run cpython tests (windows partial - fixme)
         run:
           target/release/rustpython -m test -v -x
-            test_argparse
             test_json
             test_bytes
             test_long


### PR DESCRIPTION
This PR will incrementally determine exactly which tests must be skipped on the Windows CI run. Submitting as draft until everything is narrowed down.

NOTE: This differs from #2584 in a couple of ways:

- I'm essentially flying blind, as I currently don't own a machine with Windows that I can tinker on.
- Apparently, the Windows CI behaves differently from local machines. I expect quite a few force-pushes.
