### PR TITLE
Fix Clippy warnings introduced in Rust 1.52

### DIFF
--- a/compiler/src/symboltable.rs
+++ b/compiler/src/symboltable.rs
@@ -1074,10 +1074,8 @@ impl SymbolTableBuilder {
     ) -> SymbolTableResult {
         // Evaluate eventual default parameters:
         self.scan_expressions(&args.defaults, ExpressionContext::Load)?;
-        for kw_default in &args.kw_defaults {
-            if let Some(expression) = kw_default {
-                self.scan_expression(&expression, ExpressionContext::Load)?;
-            }
+        for expression in args.kw_defaults.iter().flatten() {
+            self.scan_expression(&expression, ExpressionContext::Load)?;
         }
 
         // Annotations are scanned in outer scope:

--- a/parser/src/lexer.rs
+++ b/parser/src/lexer.rs
@@ -717,7 +717,7 @@ where
             }
         }
 
-        Ok(IndentationLevel { spaces, tabs })
+        Ok(IndentationLevel { tabs, spaces })
     }
 
     fn handle_indentations(&mut self) -> Result<(), LexicalError> {

--- a/vm/src/builtins/complex.rs
+++ b/vm/src/builtins/complex.rs
@@ -48,10 +48,8 @@ pub fn init(context: &PyContext) {
 fn to_op_complex(value: &PyObjectRef, vm: &VirtualMachine) -> PyResult<Option<Complex64>> {
     let r = if let Some(complex) = value.payload_if_subclass::<PyComplex>(vm) {
         Some(complex.value)
-    } else if let Some(float) = float::to_op_float(value, vm)? {
-        Some(Complex64::new(float, 0.0))
     } else {
-        None
+        float::to_op_float(value, vm)?.map(|float| Complex64::new(float, 0.0))
     };
     Ok(r)
 }

--- a/vm/src/builtins/dict.rs
+++ b/vm/src/builtins/dict.rs
@@ -587,7 +587,6 @@ impl Iterator for DictIter {
         self.dict
             .entries
             .next_entry(&mut self.position)
-            .map(|(key, value)| (key, value))
     }
 
     fn size_hint(&self) -> (usize, Option<usize>) {

--- a/vm/src/builtins/dict.rs
+++ b/vm/src/builtins/dict.rs
@@ -584,10 +584,10 @@ impl Iterator for DictIter {
     type Item = (PyObjectRef, PyObjectRef);
 
     fn next(&mut self) -> Option<Self::Item> {
-        match self.dict.entries.next_entry(&mut self.position) {
-            Some((key, value)) => Some((key, value)),
-            None => None,
-        }
+        self.dict
+            .entries
+            .next_entry(&mut self.position)
+            .map(|(key, value)| (key, value))
     }
 
     fn size_hint(&self) -> (usize, Option<usize>) {

--- a/vm/src/builtins/dict.rs
+++ b/vm/src/builtins/dict.rs
@@ -584,9 +584,7 @@ impl Iterator for DictIter {
     type Item = (PyObjectRef, PyObjectRef);
 
     fn next(&mut self) -> Option<Self::Item> {
-        self.dict
-            .entries
-            .next_entry(&mut self.position)
+        self.dict.entries.next_entry(&mut self.position)
     }
 
     fn size_hint(&self) -> (usize, Option<usize>) {

--- a/vm/src/builtins/function.rs
+++ b/vm/src/builtins/function.rs
@@ -449,15 +449,12 @@ impl PyBoundMethod {
 
     #[pymethod(magic)]
     fn repr(&self, vm: &VirtualMachine) -> PyResult<String> {
-        let funcname = if let Some(qname) =
-            vm.get_attribute_opt(self.function.clone(), "__qualname__")?
-        {
-            Some(qname)
-        } else if let Some(name) = vm.get_attribute_opt(self.function.clone(), "__qualname__")? {
-            Some(name)
-        } else {
-            None
-        };
+        let funcname =
+            if let Some(qname) = vm.get_attribute_opt(self.function.clone(), "__qualname__")? {
+                Some(qname)
+            } else {
+                vm.get_attribute_opt(self.function.clone(), "__qualname__")?
+            };
         let funcname: Option<PyStrRef> = funcname.and_then(|o| o.downcast().ok());
         Ok(format!(
             "<bound method {} of {}>",

--- a/vm/src/frame.rs
+++ b/vm/src/frame.rs
@@ -439,10 +439,8 @@ impl ExecutingFrame<'_> {
             // variable is Some
             let thrower = if let Some(coro) = self.builtin_coro(coro) {
                 Some(Either::A(coro))
-            } else if let Some(meth) = vm.get_attribute_opt(coro.clone(), "throw")? {
-                Some(Either::B(meth))
             } else {
-                None
+                vm.get_attribute_opt(coro.clone(), "throw")?.map(Either::B)
             };
             if let Some(thrower) = thrower {
                 let ret = match thrower {

--- a/vm/src/function.rs
+++ b/vm/src/function.rs
@@ -219,11 +219,10 @@ impl FuncArgs {
     }
 
     pub fn check_kwargs_empty(&self, vm: &VirtualMachine) -> Option<PyBaseExceptionRef> {
-        if let Some(k) = self.kwargs.keys().next() {
-            Some(vm.new_type_error(format!("Unexpected keyword argument {}", k)))
-        } else {
-            None
-        }
+        self.kwargs
+            .keys()
+            .next()
+            .map(|k| vm.new_type_error(format!("Unexpected keyword argument {}", k)))
     }
 }
 

--- a/vm/src/py_serde.rs
+++ b/vm/src/py_serde.rs
@@ -16,7 +16,7 @@ pub fn serialize<S>(
 where
     S: serde::Serializer,
 {
-    PyObjectSerializer { vm, pyobject }.serialize(serializer)
+    PyObjectSerializer { pyobject, vm }.serialize(serializer)
 }
 
 #[inline]
@@ -39,7 +39,7 @@ pub struct PyObjectSerializer<'s> {
 
 impl<'s> PyObjectSerializer<'s> {
     pub fn new(vm: &'s VirtualMachine, pyobject: &'s PyObjectRef) -> Self {
-        PyObjectSerializer { vm, pyobject }
+        PyObjectSerializer { pyobject, vm }
     }
 
     fn clone_with_object(&self, pyobject: &'s PyObjectRef) -> PyObjectSerializer {

--- a/vm/src/pyobject.rs
+++ b/vm/src/pyobject.rs
@@ -143,10 +143,10 @@ impl PyContext {
         let context = PyContext {
             true_value,
             false_value,
-            not_implemented,
             none,
             empty_tuple,
             ellipsis,
+            not_implemented,
 
             types,
             exceptions,

--- a/vm/src/stdlib/itertools.rs
+++ b/vm/src/stdlib/itertools.rs
@@ -278,10 +278,9 @@ mod decl {
             times: OptionalArg<PyIntRef>,
             vm: &VirtualMachine,
         ) -> PyResult<PyRef<Self>> {
-            let times = match times.into_option() {
-                Some(int) => Some(PyRwLock::new(int.borrow_value().clone())),
-                None => None,
-            };
+            let times = times
+                .into_option()
+                .map(|int| PyRwLock::new(int.borrow_value().clone()));
 
             PyItertoolsRepeat { object, times }.into_ref_with_type(vm, cls)
         }

--- a/vm/src/stdlib/ssl.rs
+++ b/vm/src/stdlib/ssl.rs
@@ -911,6 +911,7 @@ fn cert_to_py(vm: &VirtualMachine, cert: &X509Ref, binary: bool) -> PyResult {
         )?;
         dict.set_item("notAfter", vm.ctx.new_str(cert.not_after().to_string()), vm)?;
 
+        #[allow(clippy::manual_map)]
         if let Some(names) = cert.subject_alt_names() {
             let san = names
                 .iter()


### PR DESCRIPTION
Clippy warnings fixed:

- [`inconsistent_struct_constructor`](https://rust-lang.github.io/rust-clippy/master/index.html#inconsistent_struct_constructor)
- [`manual_flatten`](https://rust-lang.github.io/rust-clippy/master/index.html#manual_flatten)
- [`manual_map`](https://rust-lang.github.io/rust-clippy/master/index.html#manual_map)
