### PR TITLE
os: Fix `DirEntry` is_file and is_dir function

### DIFF
--- a/Lib/test/test_os.py
+++ b/Lib/test/test_os.py
@@ -3869,8 +3869,6 @@ class TestScandir(unittest.TestCase):
         self.assertEqual(fspath,
                          os.path.join(os.fsencode(self.path),bytes_filename))
 
-    # TODO: RUSTPYTHON (FileNotFoundError: No such file or directory (os error 2))
-    @unittest.expectedFailure
     def test_removed_dir(self):
         path = os.path.join(self.path, 'dir')
 
@@ -3893,8 +3891,6 @@ class TestScandir(unittest.TestCase):
             self.assertRaises(FileNotFoundError, entry.stat)
             self.assertRaises(FileNotFoundError, entry.stat, follow_symlinks=False)
 
-    # TODO: RUSTPYTHON
-    @unittest.expectedFailure
     def test_removed_file(self):
         entry = self.create_file_entry()
         os.unlink(entry.path)
@@ -3914,8 +3910,6 @@ class TestScandir(unittest.TestCase):
             self.assertRaises(FileNotFoundError, entry.stat)
             self.assertRaises(FileNotFoundError, entry.stat, follow_symlinks=False)
 
-    # TODO: RUSTPYTHON
-    @unittest.expectedFailure
     def test_broken_symlink(self):
         if not support.can_symlink():
             return self.skipTest('cannot create symbolic link')

--- a/Lib/test/test_pathlib.py
+++ b/Lib/test/test_pathlib.py
@@ -1408,8 +1408,6 @@ class _BasePathTest(object):
         self.assertIn(cm.exception.errno, (errno.ENOTDIR,
                                            errno.ENOENT, errno.EINVAL))
 
-    # TODO: RUSTPYTHON
-    @unittest.expectedFailure
     def test_glob_common(self):
         def _check(glob, expected):
             self.assertEqual(set(glob), { P(BASE, q) for q in expected })
@@ -1434,8 +1432,6 @@ class _BasePathTest(object):
         else:
             _check(p.glob("*/fileB"), ['dirB/fileB', 'linkB/fileB'])
 
-    # TODO: RUSTPYTHON
-    @unittest.expectedFailure
     def test_rglob_common(self):
         def _check(glob, expected):
             self.assertEqual(set(glob), { P(BASE, q) for q in expected })

--- a/vm/src/stdlib/os.rs
+++ b/vm/src/stdlib/os.rs
@@ -747,9 +747,17 @@ mod _os {
             action: fn(fs::Metadata) -> bool,
             vm: &VirtualMachine,
         ) -> PyResult<bool> {
-            let meta = fs_metadata(self.entry.path(), follow_symlinks.0)
-                .map_err(|err| err.into_pyexception(vm))?;
-            Ok(action(meta))
+            match fs_metadata(self.entry.path(), follow_symlinks.0) {
+                Ok(meta) => Ok(action(meta)),
+                Err(e) => {
+                    // FileNotFoundError is caught and not raised
+                    if e.kind() == io::ErrorKind::NotFound {
+                        Ok(false)
+                    } else {
+                        Err(e.into_pyexception(vm))
+                    }
+                }
+            }
         }
 
         #[pymethod]


### PR DESCRIPTION
Change `perform_on_metadata` to fit python document and tests.

From [`os.DirEntry.is_dir()`](https://docs.python.org/3/library/os.html?highlight=direntry#os.DirEntry.is_dir)
> Return True if this entry is a directory or a symbolic link pointing to a directory;
> return False if the entry is or points to any other kind of file, or if it doesn’t exist anymore.
> ...
> This method can raise OSError, such as PermissionError, but FileNotFoundError is caught and not raised.

Related to #1175