### PR TITLE
Fix CI failures with test_subprocess and/or test_os

### DIFF
--- a/Lib/test/test_subprocess.py
+++ b/Lib/test/test_subprocess.py
@@ -706,6 +706,7 @@ class ProcessTestCase(BaseTestCase):
         self.assertEqual(p.returncode, 0, err)
         self.assertEqual(out.rstrip(), b'test with stdout=1')
 
+    @unittest.skipIf(sys.platform != "win32", "TODO: RUSTPYTHON, takes a long time")
     def test_stdout_devnull(self):
         p = subprocess.Popen([sys.executable, "-c",
                               'for i in range(10240):'
@@ -714,6 +715,7 @@ class ProcessTestCase(BaseTestCase):
         p.wait()
         self.assertEqual(p.stdout, None)
 
+    @unittest.skipIf(sys.platform != "win32", "TODO: RUSTPYTHON, takes a long time")
     def test_stderr_devnull(self):
         p = subprocess.Popen([sys.executable, "-c",
                               'import sys\n'

--- a/Lib/test/test_subprocess.py
+++ b/Lib/test/test_subprocess.py
@@ -214,6 +214,10 @@ class ProcessTestCase(BaseTestCase):
                 input=None, text=True)
         self.assertNotIn('XX', output)
 
+    # TODO: RUSTPYTHON
+    if sys.platform != "win32":
+        test_check_output_input_none_text = unittest.expectedFailure(test_check_output_input_none_text)
+
     def test_check_output_input_none_universal_newlines(self):
         output = subprocess.check_output(
                 [sys.executable, "-c",

--- a/Lib/test/test_subprocess.py
+++ b/Lib/test/test_subprocess.py
@@ -1092,6 +1092,10 @@ class ProcessTestCase(BaseTestCase):
         self.assertTrue(stderr.startswith("eline2\neline6\neline7\n"))
 
     # TODO: RUSTPYTHON
+    if sys.platform == "win32":
+        test_universal_newlines_communicate_stdin_stdout_stderr = unittest.expectedFailure(test_universal_newlines_communicate_stdin_stdout_stderr)
+
+    # TODO: RUSTPYTHON
     @unittest.expectedFailure
     def test_universal_newlines_communicate_encodings(self):
         # Check that universal newlines mode works for various encodings,
@@ -1263,6 +1267,10 @@ class ProcessTestCase(BaseTestCase):
         # we should get the full line in return
         line = "line\n"
         self._test_bufsize_equal_one(line, line, universal_newlines=True)
+
+    # TODO: RUSTPYTHON
+    if sys.platform == "win32":
+        test_bufsize_equal_one_text_mode = unittest.expectedFailure(test_bufsize_equal_one_text_mode)
 
     # TODO: RUSTPYTHON
     @unittest.expectedFailure

--- a/Lib/test/test_subprocess.py
+++ b/Lib/test/test_subprocess.py
@@ -920,6 +920,7 @@ class ProcessTestCase(BaseTestCase):
         self.assertEqual(stdout, None)
         self.assertEqual(stderr, None)
 
+    @unittest.skipIf(sys.platform != "win32", "TODO: RUSTPYTHON, hangs")
     def test_communicate_pipe_buf(self):
         # communicate() with writes larger than pipe_buf
         # This test will probably deadlock rather than fail, if

--- a/Lib/test/test_subprocess.py
+++ b/Lib/test/test_subprocess.py
@@ -3263,6 +3263,8 @@ class Win32ProcessTestCase(BaseTestCase):
         with p:
             self.assertIn(b"physalis", p.stdout.read())
 
+    # TODO: RUSTPYTHON
+    @unittest.expectedFailure
     def test_shell_encodings(self):
         # Run command through the shell (string)
         for enc in ['ansi', 'oem']:

--- a/Lib/test/test_subprocess.py
+++ b/Lib/test/test_subprocess.py
@@ -207,8 +207,6 @@ class ProcessTestCase(BaseTestCase):
                 input=None)
         self.assertNotIn(b'XX', output)
 
-    # TODO: RUSTPYTHON
-    @unittest.expectedFailure
     def test_check_output_input_none_text(self):
         output = subprocess.check_output(
                 [sys.executable, "-c",
@@ -216,8 +214,6 @@ class ProcessTestCase(BaseTestCase):
                 input=None, text=True)
         self.assertNotIn('XX', output)
 
-    # TODO: RUSTPYTHON
-    @unittest.expectedFailure
     def test_check_output_input_none_universal_newlines(self):
         output = subprocess.check_output(
                 [sys.executable, "-c",
@@ -1036,8 +1032,6 @@ class ProcessTestCase(BaseTestCase):
     if sys.platform == "win32":
         test_universal_newlines_communicate = unittest.expectedFailure(test_universal_newlines_communicate)
 
-    # TODO: RUSTPYTHON
-    @unittest.expectedFailure
     def test_universal_newlines_communicate_stdin(self):
         # universal newlines through communicate(), with only stdin
         p = subprocess.Popen([sys.executable, "-c",
@@ -1052,8 +1046,6 @@ class ProcessTestCase(BaseTestCase):
         (stdout, stderr) = p.communicate("line1\nline3\n")
         self.assertEqual(p.returncode, 0)
 
-    # TODO: RUSTPYTHON
-    @unittest.expectedFailure
     def test_universal_newlines_communicate_input_none(self):
         # Test communicate(input=None) with universal newlines.
         #
@@ -1066,8 +1058,6 @@ class ProcessTestCase(BaseTestCase):
         p.communicate()
         self.assertEqual(p.returncode, 0)
 
-    # TODO: RUSTPYTHON
-    @unittest.expectedFailure
     def test_universal_newlines_communicate_stdin_stdout_stderr(self):
         # universal newlines through communicate(), with stdin, stdout, stderr
         p = subprocess.Popen([sys.executable, "-c",
@@ -1264,8 +1254,6 @@ class ProcessTestCase(BaseTestCase):
         self.assertEqual(p.returncode, 0)
         self.assertEqual(read_line, expected)
 
-    # TODO: RUSTPYTHON
-    @unittest.expectedFailure
     def test_bufsize_equal_one_text_mode(self):
         # line is flushed in text mode with bufsize=1.
         # we should get the full line in return


### PR DESCRIPTION
As observed in #2652, various tests failed around the time when #2645 and #2647 were both merged into the master branch. Submitting this as draft because I can't reproduce the `test_os` failure on my machine.
