### PR TITLE
os: argument in listdir should be optional

### DIFF
--- a/Lib/test/test_os.py
+++ b/Lib/test/test_os.py
@@ -2127,8 +2127,6 @@ class Pep383Tests(unittest.TestCase):
     def tearDown(self):
         shutil.rmtree(self.dir)
 
-    # TODO: RUSTPYTHON (TypeError: Expected at least 1 arguments (0 given))
-    @unittest.expectedFailure
     def test_listdir(self):
         expected = self.unicodefn
         found = set(os.listdir(self.dir))

--- a/Lib/test/test_posix.py
+++ b/Lib/test/test_posix.py
@@ -811,8 +811,6 @@ class PosixTester(unittest.TestCase):
     def test_listdir(self):
         self.assertIn(support.TESTFN, posix.listdir(os.curdir))
 
-    # TODO: RUSTPYTHON
-    @unittest.expectedFailure
     def test_listdir_default(self):
         # When listdir is called without argument,
         # it's the same as listdir(os.curdir).

--- a/vm/src/stdlib/os.rs
+++ b/vm/src/stdlib/os.rs
@@ -635,7 +635,11 @@ mod _os {
     const LISTDIR_FD: bool = cfg!(all(unix, not(target_os = "redox")));
 
     #[pyfunction]
-    fn listdir(path: PathOrFd, vm: &VirtualMachine) -> PyResult {
+    fn listdir(path: OptionalArg<PathOrFd>, vm: &VirtualMachine) -> PyResult {
+        let path = match path {
+            OptionalArg::Present(path) => path,
+            OptionalArg::Missing => PathOrFd::Path(PyPathLike::new_str(".")),
+        };
         let list = match path {
             PathOrFd::Path(path) => {
                 let dir_iter = fs::read_dir(&path).map_err(|err| err.into_pyexception(vm))?;


### PR DESCRIPTION
From `listdir(path)` to `listdir(path='.')`