### PR TITLE
Add `builtin.__self__`.

### DIFF
--- a/vm/src/builtins/builtinfunc.rs
+++ b/vm/src/builtins/builtinfunc.rs
@@ -121,6 +121,10 @@ impl PyBuiltinFunction {
     fn doc(&self) -> Option<PyStrRef> {
         self.value.doc.clone()
     }
+    #[pyproperty(name = "__self__")]
+    fn get_self(&self, vm: &VirtualMachine) -> PyObjectRef {
+        vm.ctx.none()
+    }
     #[pymethod(magic)]
     fn reduce(&self) -> PyStrRef {
         // TODO: return (getattr, (self.object, self.name)) if this is a method


### PR DESCRIPTION
Note a discrepancy: in the [Reference manual](https://docs.python.org/3/reference/datamodel.html), it is stated that `__self__` for builtins should return `None`. This is what I've currently done.

On the other hand, `CPython` currently returns the module the function is defined in. 

If the module is to be returned, what's the best way to do it? Yank it from the `globals` using the module name?