### PR TITLE
Handle NotImplemented return from length_hint.

### DIFF
--- a/Lib/test/test_operator.py
+++ b/Lib/test/test_operator.py
@@ -516,11 +516,6 @@ class PyOperatorTestCase(OperatorTestCase, unittest.TestCase):
 class COperatorTestCase(OperatorTestCase, unittest.TestCase):
     module = c_operator
 
-    # TODO: RUSTPYTHON
-    @unittest.expectedFailure
-    def test_length_hint(self):
-        super().test_length_hint()
-
 
 class OperatorPickleTestCase:
     def copy(self, obj, proto):

--- a/vm/src/iterator.rs
+++ b/vm/src/iterator.rs
@@ -6,7 +6,7 @@ use crate::builtins::int::{self, PyInt};
 use crate::builtins::iter::PySequenceIterator;
 use crate::exceptions::PyBaseExceptionRef;
 use crate::vm::VirtualMachine;
-use crate::{PyObjectRef, PyResult, PyValue, TryFromObject, TypeProtocol};
+use crate::{IdProtocol, PyObjectRef, PyResult, PyValue, TryFromObject, TypeProtocol};
 use num_traits::Signed;
 
 /*
@@ -122,7 +122,12 @@ pub fn length_hint(vm: &VirtualMachine, iter: PyObjectRef) -> PyResult<Option<us
         None => return Ok(None),
     };
     let result = match vm.invoke(&hint, ()) {
-        Ok(res) => res,
+        Ok(res) => {
+            if res.is(&vm.ctx.not_implemented) {
+                return Ok(None);
+            }
+            res
+        }
         Err(e) => {
             return if e.isinstance(&vm.ctx.exceptions.type_error) {
                 Ok(None)


### PR DESCRIPTION
Essentially, by making `length_hint` take a `default` argument instead of returning an `Option`.