### PR TITLE
os: Fix openpty test

### DIFF
--- a/Lib/test/test_os.py
+++ b/Lib/test/test_os.py
@@ -3616,8 +3616,6 @@ class FDInheritanceTests(unittest.TestCase):
         self.assertEqual(os.dup2(fd, fd3, inheritable=False), fd3)
         self.assertFalse(os.get_inheritable(fd3))
 
-    # TODO: RUSTPYTHON
-    @unittest.expectedFailure
     @unittest.skipUnless(hasattr(os, 'openpty'), "need os.openpty()")
     def test_openpty(self):
         master_fd, slave_fd = os.openpty()

--- a/vm/src/stdlib/os.rs
+++ b/vm/src/stdlib/os.rs
@@ -2371,6 +2371,9 @@ mod posix {
     #[pyfunction]
     fn openpty(vm: &VirtualMachine) -> PyResult {
         let r = nix::pty::openpty(None, None).map_err(|err| err.into_pyexception(vm))?;
+        for fd in &[r.master, r.slave] {
+            raw_set_inheritable(*fd, false).map_err(|e| e.into_pyexception(vm))?;
+        }
         Ok(vm
             .ctx
             .new_tuple(vec![vm.ctx.new_int(r.master), vm.ctx.new_int(r.slave)]))


### PR DESCRIPTION
Make openpty return non-inheritable file descriptors

Related to #1175