### PR TITLE
Fallback to __name__ if __qualname__ isn't available.

### DIFF
--- a/vm/src/builtins/function.rs
+++ b/vm/src/builtins/function.rs
@@ -453,7 +453,7 @@ impl PyBoundMethod {
             if let Some(qname) = vm.get_attribute_opt(self.function.clone(), "__qualname__")? {
                 Some(qname)
             } else {
-                vm.get_attribute_opt(self.function.clone(), "__qualname__")?
+                vm.get_attribute_opt(self.function.clone(), "__name__")?
             };
         let funcname: Option<PyStrRef> = funcname.and_then(|o| o.downcast().ok());
         Ok(format!(


### PR DESCRIPTION
Fix small mistake. Bound methods of builtins (which still don't have `__qualname__` set) were repr'ed with `?` because of this.

CPython differentiates between bound methods for Python classes and bound methods for builtins and the `repr` for one uses `__qualname__` while for the other `__name__`. Doubt this discrepancy is of much concern, though.