### PR TITLE
os: Implement getgroups

### DIFF
--- a/Lib/test/test_posix.py
+++ b/Lib/test/test_posix.py
@@ -766,8 +766,6 @@ class PosixTester(unittest.TestCase):
             self.assertRaises(TypeError, chown_func, first_param, uid, t(gid))
             check_stat(uid, gid)
 
-    # TODO: RUSTPYTHON: AttributeError: module 'os' has no attribute 'getgroups'
-    @unittest.expectedFailure
     @unittest.skipUnless(hasattr(posix, 'chown'), "test needs os.chown()")
     def test_chown(self):
         # raise an OSError if the file does not exist
@@ -778,8 +776,6 @@ class PosixTester(unittest.TestCase):
         support.create_empty_file(support.TESTFN)
         self._test_all_chown_common(posix.chown, support.TESTFN, posix.stat)
 
-    # TODO: RUSTPYTHON: AttributeError: module 'os' has no attribute 'getgroups'
-    @unittest.expectedFailure
     @unittest.skipUnless(hasattr(posix, 'fchown'), "test needs os.fchown()")
     def test_fchown(self):
         os.unlink(support.TESTFN)
@@ -793,8 +789,6 @@ class PosixTester(unittest.TestCase):
         finally:
             test_file.close()
 
-    # TODO: RUSTPYTHON: AttributeError: module 'os' has no attribute 'getgroups'
-    @unittest.expectedFailure
     @unittest.skipUnless(hasattr(posix, 'lchown'), "test needs os.lchown()")
     def test_lchown(self):
         os.unlink(support.TESTFN)
@@ -1049,8 +1043,6 @@ class PosixTester(unittest.TestCase):
         self.assertIn(group, posix.getgrouplist(user, group))
 
 
-    # TODO: RUSTPYTHON: AttributeError: module 'posix' has no attribute 'getgroups'
-    @unittest.expectedFailure
     @unittest.skipUnless(hasattr(os, 'getegid'), "test needs os.getegid()")
     def test_getgroups(self):
         with os.popen('id -G 2>/dev/null') as idg:

--- a/vm/src/stdlib/os.rs
+++ b/vm/src/stdlib/os.rs
@@ -1860,7 +1860,7 @@ mod posix {
         let others_permissions = get_permissions(others_mode);
 
         let user_id = nix::unistd::getuid();
-        let groups_ids = getgroups()?;
+        let groups_ids = getgroups_impl()?;
 
         if file_owner == user_id {
             Ok(owner_permissions)
@@ -1872,7 +1872,7 @@ mod posix {
     }
 
     #[cfg(any(target_os = "macos", target_os = "ios"))]
-    fn getgroups() -> nix::Result<Vec<Gid>> {
+    fn getgroups_impl() -> nix::Result<Vec<Gid>> {
         use libc::{c_int, gid_t};
         use std::ptr;
         let ret = unsafe { libc::getgroups(0, ptr::null_mut()) };
@@ -1891,11 +1891,22 @@ mod posix {
     }
 
     #[cfg(not(any(target_os = "macos", target_os = "ios", target_os = "redox")))]
-    use nix::unistd::getgroups;
+    use nix::unistd::getgroups as getgroups_impl;
 
     #[cfg(target_os = "redox")]
-    fn getgroups() -> nix::Result<Vec<Gid>> {
+    fn getgroups_impl() -> nix::Result<Vec<Gid>> {
         Err(nix::Error::UnsupportedOperation)
+    }
+
+    #[pyfunction]
+    fn getgroups(vm: &VirtualMachine) -> PyResult {
+        let group_ids = getgroups_impl().map_err(|e| e.into_pyexception(vm))?;
+        Ok(vm.ctx.new_list(
+            group_ids
+                .into_iter()
+                .map(|gid| vm.ctx.new_int(gid.as_raw()))
+                .collect(),
+        ))
     }
 
     #[pyfunction]


### PR DESCRIPTION
`getgroups` is already implement in rust, just wrap the function to let it be used in python.