### PR TITLE
Fix tests in os

### DIFF
--- a/Lib/test/test_os.py
+++ b/Lib/test/test_os.py
@@ -3630,15 +3630,13 @@ class PathTConverterTests(unittest.TestCase):
     # function, cleanup function)
     functions = [
         ('stat', True, (), None),
-        ('lstat', False, (), None),
+        ('lstat', True, (), None),
         ('access', False, (os.F_OK,), None),
         ('chflags', False, (0,), None),
         ('lchflags', False, (0,), None),
         ('open', False, (0,), getattr(os, 'close', None)),
     ]
 
-    # TODO: RUSTPYTHON
-    @unittest.expectedFailure
     def test_path_t_converter(self):
         str_filename = support.TESTFN
         if os.name == 'nt':

--- a/Lib/test/test_os.py
+++ b/Lib/test/test_os.py
@@ -3681,8 +3681,6 @@ class PathTConverterTests(unittest.TestCase):
                             'os.PathLike'):
                         fn(fd, *extra_args)
 
-    # TODO: RUSTPYTHON
-    @unittest.expectedFailure
     def test_path_t_converter_and_custom_class(self):
         msg = r'__fspath__\(\) to return str or bytes, not %s'
         with self.assertRaisesRegex(TypeError, msg % r'int'):

--- a/vm/src/stdlib/os.rs
+++ b/vm/src/stdlib/os.rs
@@ -158,14 +158,14 @@ fn fspath(obj: PyObjectRef, check_for_nul: bool, vm: &VirtualMachine) -> PyResul
     }
     let method = vm.get_method_or_type_error(obj.clone(), "__fspath__", || {
         format!(
-            "expected str, bytes or os.PathLike object, not '{}'",
+            "expected str, bytes or os.PathLike object, not {}",
             obj.class().name
         )
     })?;
     let result = vm.invoke(&method, ())?;
     match1(&result)?.ok_or_else(|| {
         vm.new_type_error(format!(
-            "expected {}.__fspath__() to return str or bytes, not '{}'",
+            "expected {}.__fspath__() to return str or bytes, not {}",
             obj.class().name,
             result.class().name,
         ))


### PR DESCRIPTION
1. `lstat` support `dir_fd` parameter
2. Change error message for fspath to match unittest