### PR TITLE
Fix miscalculation when reversing a range.

### DIFF
--- a/Lib/test/test_range.py
+++ b/Lib/test/test_range.py
@@ -582,8 +582,6 @@ class RangeTest(unittest.TestCase):
         self.assertNotIn(10, r)
         self.assertNotIn("", r)
 
-    # TODO: RUSTPYTHON
-    @unittest.expectedFailure
     def test_reverse_iteration(self):
         for r in [range(10),
                   range(0),

--- a/vm/src/builtins/range.rs
+++ b/vm/src/builtins/range.rs
@@ -188,19 +188,17 @@ impl PyRange {
 
         // compute the last element that is actually contained within the range
         // this is the new start
-        let remainder = ((stop - start) % step).abs();
+        let remainder = (stop - start) % step;
         let new_start = if remainder.is_zero() {
             stop - step
         } else {
             stop - &remainder
         };
-
         let new_stop: BigInt = match step.sign() {
             Sign::Plus => start - 1,
             Sign::Minus => start + 1,
             Sign::NoSign => unreachable!(),
         };
-
         let reversed = PyRange {
             start: new_start.into_pyref(vm),
             stop: new_stop.into_pyref(vm),


### PR DESCRIPTION
which caused the test failure.