### PR TITLE
Fix a number of range issues.

### DIFF
--- a/Lib/test/test_range.py
+++ b/Lib/test/test_range.py
@@ -255,8 +255,6 @@ class RangeTest(unittest.TestCase):
         self.assertRaises(TypeError, range, 0.0, 0.0, 1)
         self.assertRaises(TypeError, range, 0.0, 0.0, 1.0)
 
-    # TODO: RUSTPYTHON
-    @unittest.expectedFailure
     def test_index(self):
         u = range(2)
         self.assertEqual(u.index(0), 0)
@@ -332,8 +330,6 @@ class RangeTest(unittest.TestCase):
         with self.assertRaises(TypeError):
             range(0, 10)[:IN()]
 
-    # TODO: RUSTPYTHON
-    @unittest.expectedFailure
     def test_count(self):
         self.assertEqual(range(3).count(-1), 0)
         self.assertEqual(range(3).count(0), 1)
@@ -432,8 +428,6 @@ class RangeTest(unittest.TestCase):
         with self.assertRaises(TypeError):
             range([], 1, -1)
 
-    # TODO: RUSTPYTHON
-    @unittest.expectedFailure
     def test_types(self):
         # Non-integer objects *equal* to any of the range's items are supposed
         # to be contained in the range.
@@ -490,8 +484,10 @@ class RangeTest(unittest.TestCase):
         self.assertNotIn(-1, r)
         self.assertNotIn(1, r)
 
-    # TODO: RUSTPYTHON
-    @unittest.expectedFailure
+    # TODO: RUSTPYTHON.
+    # NOTE: Test passes, fast iterators are required for this to not
+    #       take ~ 1m.
+    @unittest.skip
     def test_range_iterators(self):
         # exercise 'fast' iterators, that use a rangeiterobject internally.
         # see issue 7298
@@ -546,8 +542,6 @@ class RangeTest(unittest.TestCase):
             check(0, -1)
             check(-1, -3, -1)
 
-    # TODO: RUSTPYTHON
-    @unittest.expectedFailure
     def test_contains(self):
         r = range(10)
         self.assertIn(0, r)


### PR DESCRIPTION
In short:

1. Added fallback for when item isn't found via `index/count/contains`, iterate through the range and invoke `__eq__` with every element.
2. Contains has a fast lane only for exact ints. Subclasses should fall back to normal slow iteration described in 1.
3. Use similar logic as cpython/ironpython when calculating new start,stop,step in `__reverse__`. There's some corner cases current approach doesn't cover. (see `reversed(range(-2, -1, -3))` for an example)
4. `is_empty` just invokes `length`.

All in all, 5 more tests should now pass.