### PR TITLE
Add new and bool for NotImplemented.

### DIFF
--- a/Lib/test/test_builtin.py
+++ b/Lib/test/test_builtin.py
@@ -1561,8 +1561,6 @@ class BuiltinTest(unittest.TestCase):
         self.assertRaises(ValueError, x.translate, b"1", 1)
         self.assertRaises(TypeError, x.translate, b"1"*256, 1)
 
-    # TODO: RUSTPYTHON
-    @unittest.expectedFailure
     def test_construct_singletons(self):
         for const in None, Ellipsis, NotImplemented:
             tp = type(const)

--- a/vm/src/builtins/singletons.rs
+++ b/vm/src/builtins/singletons.rs
@@ -61,6 +61,19 @@ impl PyValue for PyNotImplemented {
 
 #[pyimpl]
 impl PyNotImplemented {
+    #[pyslot]
+    fn tp_new(_: PyTypeRef, vm: &VirtualMachine) -> PyRef<Self> {
+        vm.ctx.not_implemented.clone()
+    }
+
+    // TODO: As per https://bugs.python.org/issue35712, using NotImplemented
+    // in boolean contexts will need to raise a DeprecationWarning in 3.9
+    // and, eventually, a TypeError.
+    #[pymethod(magic)]
+    fn bool(&self) -> bool {
+        true
+    }
+
     #[pymethod(magic)]
     fn repr(&self) -> String {
         "NotImplemented".to_owned()


### PR DESCRIPTION
`__new__` simply returns the singleton. While `bool(NotImplemented)` already returned `True`, it is added since it will need to raise a warning in the future.