### PR TITLE
Fix test_vars in test_builtins.

### DIFF
--- a/Lib/test/test_builtin.py
+++ b/Lib/test/test_builtin.py
@@ -1377,8 +1377,6 @@ class BuiltinTest(unittest.TestCase):
             return {'a':2}
         __dict__ = property(fget=getDict)
 
-    # TODO: RUSTPYTHON
-    @unittest.expectedFailure
     def test_vars(self):
         self.assertEqual(set(vars()), set(dir()))
         self.assertEqual(set(vars(sys)), set(dir(sys)))

--- a/vm/src/builtins/make_module.rs
+++ b/vm/src/builtins/make_module.rs
@@ -819,7 +819,9 @@ mod decl {
     #[pyfunction]
     fn vars(obj: OptionalArg, vm: &VirtualMachine) -> PyResult {
         if let OptionalArg::Present(obj) = obj {
-            vm.get_attribute(obj, "__dict__")
+            vm.get_attribute(obj, "__dict__").map_err(|_| {
+                vm.new_type_error("vars() argument must have __dict__ attribute".to_owned())
+            })
         } else {
             Ok(vm.current_locals()?.into_object())
         }


### PR DESCRIPTION
`vars` raises a `TypeError` if `__dict__` doesn't exist on the supplied object. 