### PR TITLE
Make tuple(empty_iterable) return empty_tuple

### DIFF
--- a/vm/src/builtins/tuple.rs
+++ b/vm/src/builtins/tuple.rs
@@ -258,10 +258,16 @@ impl PyTuple {
             vm.extract_elements(&iterable)?
         } else {
             vec![]
+        };
+        // Return empty tuple only for exact tuple types if the iterable is empty.
+        if elements.is_empty() && cls.is(&vm.ctx.types.tuple_type) {
+            Ok(vm.ctx.empty_tuple.clone())
+        } else {
+            Self {
+                elements: elements.into_boxed_slice(),
+            }
+            .into_ref_with_type(vm, cls)
         }
-        .into_boxed_slice();
-
-        Self { elements }.into_ref_with_type(vm, cls)
     }
 }
 


### PR DESCRIPTION
The `empty_tuple` was currently only returned if an empty tuple was created with literal syntax (via the `BuildTuple` instruction) or if passed explicitly to `tuple` i.e `tuple(())`. This PR makes `tuple(iterable)`, where `iterable` is empty, also return `empty_tuple`.