### PR TITLE
Change `os.rs` to build on musl-libc

### DIFF
--- a/vm/src/stdlib/os.rs
+++ b/vm/src/stdlib/os.rs
@@ -1562,7 +1562,8 @@ mod _os {
         // Safety: p_offset_src and p_offset_dst is a unique pointer for offset_src and offset_dst respectively,
         // and will only be freed after this function ends.
         let ret = unsafe {
-            libc::copy_file_range(
+            libc::syscall(
+                libc::SYS_copy_file_range,
                 args.src,
                 p_offset_src as *mut i64,
                 args.dst,


### PR DESCRIPTION
On `musl-libc`-based targets, `libc::copy_file_range` is not provided, but `libc::syscall` and `libc::SYS_copy_file_range` are supported. This pull request use them instead of `libc::copy_file_range`.