### PR TITLE
Lib: Update operator.py to follow CPython's implementation

### DIFF
--- a/Lib/operator.py
+++ b/Lib/operator.py
@@ -155,10 +155,10 @@ def contains(a, b):
     return b in a
 
 def countOf(a, b):
-    "Return the number of times b occurs in a."
+    "Return the number of items in a which are, or which equal, b."
     count = 0
     for i in a:
-        if i == b:
+        if i is b or i == b:
             count += 1
     return count
 
@@ -173,7 +173,7 @@ def getitem(a, b):
 def indexOf(a, b):
     "Return the first index of b in a."
     for i, j in enumerate(a):
-        if j == b:
+        if j is b or j == b:
             return i
     else:
         raise ValueError('sequence.index(x): x not in sequence')

--- a/Lib/test/test_operator.py
+++ b/Lib/test/test_operator.py
@@ -144,6 +144,11 @@ class OperatorTestCase:
         self.assertRaises(TypeError, operator.countOf, None, None)
         self.assertEqual(operator.countOf([1, 2, 1, 3, 1, 4], 3), 1)
         self.assertEqual(operator.countOf([1, 2, 1, 3, 1, 4], 5), 0)
+        # is but not ==
+        nan = float("nan")
+        self.assertEqual(operator.countOf([nan, nan, 21], nan), 2)
+        # == but not is
+        self.assertEqual(operator.countOf([{}, 1, {}, 2], {}), 2)
 
     def test_delitem(self):
         operator = self.module
@@ -178,6 +183,9 @@ class OperatorTestCase:
         self.assertRaises(TypeError, operator.indexOf, None, None)
         self.assertEqual(operator.indexOf([4, 3, 2, 1], 3), 1)
         self.assertRaises(ValueError, operator.indexOf, [4, 3, 2, 1], 0)
+        nan = float("nan")
+        self.assertEqual(operator.indexOf([nan, nan, 21], nan), 0)
+        self.assertEqual(operator.indexOf([{}, 1, {}, 2], {}), 0)
 
     def test_invert(self):
         operator = self.module


### PR DESCRIPTION
There was an inconsistent implementation issue between C and Python versions from CPython.
The regression did not happen until the CPython user doesn't use _operator module.
But since RustPython only uses pure Python implementation, the implementation should be updated.

ref: https://bugs.python.org/issue44558
