### PR TITLE
Suggestion: remove PEP 594 "dead batteries" from whats_left.sh

### DIFF
--- a/extra_tests/not_impl_gen.py
+++ b/extra_tests/not_impl_gen.py
@@ -17,7 +17,9 @@ from contextlib import redirect_stdout
 from pydoc import ModuleScanner
 
 
-DEAD_BATTERIES = {
+# modules suggested for deprecation by PEP 594 (www.python.org/dev/peps/pep-0594/)
+# some of these might be implemented, but they are not a priority
+PEP_594_MODULES = {
     "aifc",
     "asynchat",
     "asyncore",
@@ -194,7 +196,7 @@ def gen_modules():
     # e.g. printing something or opening a webpage
     modules = {}
     for mod_name in scan_modules():
-        if mod_name in ("this", "antigravity") or mod_name in DEAD_BATTERIES:
+        if mod_name in ("this", "antigravity") or mod_name in PEP_594_MODULES:
             continue
         dir_result = dir_of_mod_or_error(mod_name)
         if isinstance(dir_result, Exception):

--- a/extra_tests/not_impl_gen.py
+++ b/extra_tests/not_impl_gen.py
@@ -17,6 +17,37 @@ from contextlib import redirect_stdout
 from pydoc import ModuleScanner
 
 
+DEAD_BATTERIES = {
+    "aifc",
+    "asynchat",
+    "asyncore",
+    "audioop",
+    "binhex",
+    "cgi",
+    "cgitb",
+    "chunk",
+    "crypt",
+    "formatter",
+    "fpectl",
+    "imghdr",
+    "imp",
+    "macpath",
+    "msilib",
+    "nntplib",
+    "nis",
+    "ossaudiodev",
+    "parser",
+    "pipes",
+    "smtpd",
+    "sndhdr",
+    "spwd",
+    "sunau",
+    "telnetlib",
+    "uu",
+    "xdrlib",
+}
+
+
 sys.path = [
     path
     for path in sys.path
@@ -163,7 +194,7 @@ def gen_modules():
     # e.g. printing something or opening a webpage
     modules = {}
     for mod_name in scan_modules():
-        if mod_name in ("this", "antigravity"):
+        if mod_name in ("this", "antigravity") or mod_name in DEAD_BATTERIES:
             continue
         dir_result = dir_of_mod_or_error(mod_name)
         if isinstance(dir_result, Exception):


### PR DESCRIPTION
In this PR I simply modified the `not_impl_gen.py` script to ignore all of the modules listed in [PEP 594](https://www.python.org/dev/peps/pep-0594/#deprecated-modules) as "dead batteries". While that PEP is still a draft, some form of it is likely to be accepted eventually.

My main intention here was to just take some things off the TODO list that are probably less important. This change takes 11 modules off the list and a total of 74 items (in terms of lines of output). Of course there are still ~2760 items left. :joy: 

This is just a suggestion! This change doesn't preclude implementing these modules--indeed some of the modules on the list are already implemented. But I don't think people should invest too much time or effort in fixing or maintaining code that isn't being maintained in CPython itself.