### PR TITLE
math: raise OverflowError when result is infinite

### DIFF
--- a/Lib/test/test_math.py
+++ b/Lib/test/test_math.py
@@ -1020,8 +1020,6 @@ class MathTests(unittest.TestCase):
         self.assertRaises(TypeError, lcm, 120, 0, 84.0)
         # self.assertEqual(lcm(MyIndexable(120), MyIndexable(84)), 840) # TODO: RUSTPYTHON
 
-    # TODO: RUSTPYTHON
-    @unittest.expectedFailure
     def testLdexp(self):
         self.assertRaises(TypeError, math.ldexp)
         self.ftest('ldexp(0,1)', math.ldexp(0,1), 0)

--- a/Lib/test/test_math.py
+++ b/Lib/test/test_math.py
@@ -471,8 +471,6 @@ class MathTests(unittest.TestCase):
         self.ftest('degrees(-pi/4)', math.degrees(-math.pi/4), -45.0)
         self.ftest('degrees(0)', math.degrees(0), 0)
 
-    # TODO: RUSTPYTHON
-    @unittest.expectedFailure
     def testExp(self):
         self.assertRaises(TypeError, math.exp)
         self.ftest('exp(-1)', math.exp(-1), 1/math.e)
@@ -1565,8 +1563,6 @@ class MathTests(unittest.TestCase):
     # still fails this part of the test on some platforms.  For now, we only
     # *run* test_exceptions() in verbose mode, so that this isn't normally
     # tested.
-        # TODO: RUSTPYTHON
-    @unittest.expectedFailure
     @unittest.skipUnless(verbose, 'requires verbose mode')
     def test_exceptions(self):
         try:

--- a/vm/src/stdlib/math.rs
+++ b/vm/src/stdlib/math.rs
@@ -20,8 +20,10 @@ use std::cmp::Ordering;
 // Helper macro:
 macro_rules! make_math_func {
     ( $fname:ident, $fun:ident ) => {
-        fn $fname(value: IntoPyFloat) -> f64 {
-            value.to_f64().$fun()
+        fn $fname(value: IntoPyFloat, vm: &VirtualMachine) -> PyResult<f64> {
+            let value = value.to_f64();
+            let result = value.$fun();
+            result_or_overflow(value, result, vm)
         }
     };
 }
@@ -32,6 +34,17 @@ macro_rules! make_math_func_bool {
             value.to_f64().$fun()
         }
     };
+}
+
+#[inline]
+fn result_or_overflow(value: f64, result: f64, vm: &VirtualMachine) -> PyResult<f64> {
+    if !result.is_finite() && value.is_finite() {
+        // CPython doesn't return `inf` when called with finite
+        // values, it raises OverflowError instead.
+        Err(vm.new_overflow_error("math range error".to_owned()))
+    } else {
+        Ok(result)
+    }
 }
 
 // Number theory functions:
@@ -342,7 +355,8 @@ fn math_ldexp(
         Either::A(f) => f.to_f64(),
         Either::B(z) => int::to_float(z.as_bigint(), vm)?,
     };
-    Ok(value * (2_f64).powf(int::to_float(i.as_bigint(), vm)?))
+    let result = value * (2_f64).powf(int::to_float(i.as_bigint(), vm)?);
+    result_or_overflow(value, result, vm)
 }
 
 fn math_perf_arb_len_int_op<F>(args: Args<PyIntRef>, op: F, default: BigInt) -> BigInt

--- a/vm/src/stdlib/math.rs
+++ b/vm/src/stdlib/math.rs
@@ -355,8 +355,14 @@ fn math_ldexp(
         Either::A(f) => f.to_f64(),
         Either::B(z) => int::to_float(z.as_bigint(), vm)?,
     };
-    let result = value * (2_f64).powf(int::to_float(i.as_bigint(), vm)?);
-    result_or_overflow(value, result, vm)
+
+    if value == 0_f64 || !value.is_finite() {
+        // NaNs, zeros and infinities are returned unchanged
+        Ok(value)
+    } else {
+        let result = value * (2_f64).powf(int::to_float(i.as_bigint(), vm)?);
+        result_or_overflow(value, result, vm)
+    }
 }
 
 fn math_perf_arb_len_int_op<F>(args: Args<PyIntRef>, op: F, default: BigInt) -> BigInt


### PR DESCRIPTION
Matches CPython behavior.

For example, `math.exp(1e6)` raises `OverflowError` in cpython, but the previous RustPython implementation just returned `inf`.