### PR TITLE
Add __length_hint__, __setstate__, __reduce__ for tuple iterator.

### DIFF
--- a/Lib/test/test_iter.py
+++ b/Lib/test/test_iter.py
@@ -311,8 +311,6 @@ class TestCase(unittest.TestCase):
         self.check_for_loop(iter([]), [])
 
     # Test a tuple
-    # TODO: RUSTPYTHON
-    @unittest.expectedFailure
     def test_iter_tuple(self):
         self.check_for_loop(iter((0,1,2,3,4,5,6,7,8,9)), list(range(10)))
 

--- a/Lib/test/test_iterlen.py
+++ b/Lib/test/test_iterlen.py
@@ -106,8 +106,6 @@ class TestTuple(TestInvariantWithoutMutations, unittest.TestCase):
     def setUp(self):
         self.it = iter(tuple(range(n)))
 
-    # TODO: RUSTPYTHON
-    @unittest.expectedFailure
     def test_invariant(self):
         super().test_invariant()
 

--- a/Lib/test/test_tuple.py
+++ b/Lib/test/test_tuple.py
@@ -345,8 +345,6 @@ class TupleTest(seq_tests.CommonTest):
         check(10)       # check our checking code
         check(1000000)
 
-    # TODO: RUSTPYTHON
-    @unittest.expectedFailure
     def test_iterator_pickle(self):
         # Userlist iterators don't support pickling yet since
         # they are based on generators.


### PR DESCRIPTION
Fixes a couple of issues with `tuple` iterator by adding these methods.