### PR TITLE
Fix failure -- use PyStrRef to extract String.

### DIFF
--- a/vm/src/stdlib/os.rs
+++ b/vm/src/stdlib/os.rs
@@ -1696,12 +1696,7 @@ mod _os {
         fn try_from_object(vm: &VirtualMachine, obj: PyObjectRef) -> PyResult<Self> {
             match obj.downcast::<int::PyInt>() {
                 Ok(int) => int::try_to_primitive(int.as_bigint(), vm).map(Self::Val),
-                Err(obj) => {
-                    let cstring = std::ffi::CString::try_from_object(vm, obj)?;
-                    cstring.into_string().map(Self::Name).map_err(|e| {
-                        vm.new_os_error(format!("error while parsing string: {:?}", e))
-                    })
-                }
+                Err(obj) => PyStrRef::try_from_object(vm, obj).map(|o| Self::Name(o.to_string())),
             }
         }
     }


### PR DESCRIPTION
Most recent PR removed the `TryFromObject` implementation for `CString` which was used in another PR that was added before it. This uses `PyStrRef` to do the same thing and should fix the error.