### PR TITLE
Fix arguments for islice. 3 args are allowed.

### DIFF
--- a/Lib/test/test_itertools.py
+++ b/Lib/test/test_itertools.py
@@ -1746,8 +1746,6 @@ class TestExamples(unittest.TestCase):
     def test_map(self):
         self.assertEqual(list(map(pow, (2,3,10), (5,2,3))), [32, 9, 1000])
 
-    # TODO: RUSTPYTHON
-    @unittest.expectedFailure
     def test_islice(self):
         self.assertEqual(list(islice('ABCDEFG', 2)), list('AB'))
         self.assertEqual(list(islice('ABCDEFG', 2, 4)), list('CD'))
@@ -2650,9 +2648,7 @@ def test_main(verbose=None):
             counts[i] = sys.gettotalrefcount()
         print(counts)
 
-    # TODO: RUSTPYTHON this hangs or is very slow
-    # doctest the examples in the library reference
-    # support.run_doctest(sys.modules[__name__], verbose)
+    support.run_doctest(sys.modules[__name__], verbose)
 
 if __name__ == "__main__":
     test_main(verbose=True)

--- a/vm/src/stdlib/itertools.rs
+++ b/vm/src/stdlib/itertools.rs
@@ -5,6 +5,7 @@ mod decl {
     use crossbeam_utils::atomic::AtomicCell;
     use num_bigint::BigInt;
     use num_traits::{One, Signed, ToPrimitive, Zero};
+    use std::convert::TryFrom;
     use std::fmt;
 
     use crate::builtins::int::{self, PyInt, PyIntRef};
@@ -682,13 +683,24 @@ mod decl {
         }
     }
 
-    fn pyobject_to_opt_usize(obj: PyObjectRef, vm: &VirtualMachine) -> Option<usize> {
+    // Restrict obj to ints with value 0 <= val <= sys.maxsize (isize::MAX).
+    // On failure (out of range, non-int object) a ValueError is raised.
+    fn pyobject_to_opt_usize(obj: PyObjectRef, name: &str, vm: &VirtualMachine) -> PyResult<usize> {
         let is_int = obj.isinstance(&vm.ctx.types.int_type);
         if is_int {
-            int::get_value(&obj).to_usize()
-        } else {
-            None
+            let value = int::get_value(&obj).to_usize();
+            if let Some(value) = value {
+                // Only succeeds for values for which 0 <= value <= isize::MAX
+                if value <= usize::try_from(isize::MAX).unwrap() {
+                    return Ok(value);
+                }
+            }
         }
+        // We don't have an int or value was < 0 or > maxsize (isize::MAX)
+        return Err(vm.new_value_error(format!(
+            "{} argument for islice() must be None or an integer: 0 <= x <= sys.maxsize.",
+            name
+        )));
     }
 
     #[pyimpl(with(PyIter))]
@@ -702,38 +714,34 @@ mod decl {
                         args.args.len()
                     )));
                 }
-
                 2 => {
                     let (iter, stop): (PyObjectRef, PyObjectRef) = args.bind(vm)?;
-
                     (iter, 0usize, stop, 1usize)
                 }
                 _ => {
-                    let (iter, start, stop, step): (
-                        PyObjectRef,
-                        PyObjectRef,
-                        PyObjectRef,
-                        PyObjectRef,
-                    ) = args.bind(vm)?;
+                    let (iter, start, stop, step) = if args.args.len() == 3 {
+                        let (iter, start, stop): (PyObjectRef, PyObjectRef, PyObjectRef) =
+                            args.bind(vm)?;
+                        (iter, start, stop, 1usize)
+                    } else {
+                        let (iter, start, stop, step): (
+                            PyObjectRef,
+                            PyObjectRef,
+                            PyObjectRef,
+                            PyObjectRef,
+                        ) = args.bind(vm)?;
 
+                        let step = if !vm.is_none(&step) {
+                            pyobject_to_opt_usize(step, "Step", &vm)?
+                        } else {
+                            1usize
+                        };
+                        (iter, start, stop, step)
+                    };
                     let start = if !vm.is_none(&start) {
-                        pyobject_to_opt_usize(start, &vm).ok_or_else(|| {
-                        vm.new_value_error(
-                            "Indices for islice() must be None or an integer: 0 <= x <= sys.maxsize.".to_owned(),
-                        )
-                    })?
+                        pyobject_to_opt_usize(start, "Start", &vm)?
                     } else {
                         0usize
-                    };
-
-                    let step = if !vm.is_none(&step) {
-                        pyobject_to_opt_usize(step, &vm).ok_or_else(|| {
-                            vm.new_value_error(
-                                "Step for islice() must be a positive integer or None.".to_owned(),
-                            )
-                        })?
-                    } else {
-                        1usize
                     };
 
                     (iter, start, stop, step)
@@ -741,12 +749,7 @@ mod decl {
             };
 
             let stop = if !vm.is_none(&stop) {
-                Some(pyobject_to_opt_usize(stop, &vm).ok_or_else(|| {
-                    vm.new_value_error(
-                    "Stop argument for islice() must be None or an integer: 0 <= x <= sys.maxsize."
-                        .to_owned(),
-                )
-                })?)
+                Some(pyobject_to_opt_usize(stop, "Stop", &vm)?)
             } else {
                 None
             };
@@ -763,6 +766,7 @@ mod decl {
             .into_ref_with_type(vm, cls)
         }
     }
+
     impl PyIter for PyItertoolsIslice {
         fn next(zelf: &PyRef<Self>, vm: &VirtualMachine) -> PyResult {
             while zelf.cur.load() < zelf.next.load() {

--- a/vm/src/stdlib/itertools.rs
+++ b/vm/src/stdlib/itertools.rs
@@ -5,7 +5,6 @@ mod decl {
     use crossbeam_utils::atomic::AtomicCell;
     use num_bigint::BigInt;
     use num_traits::{One, Signed, ToPrimitive, Zero};
-    use std::convert::TryFrom;
     use std::fmt;
 
     use crate::builtins::int::{self, PyInt, PyIntRef};
@@ -685,13 +684,17 @@ mod decl {
 
     // Restrict obj to ints with value 0 <= val <= sys.maxsize (isize::MAX).
     // On failure (out of range, non-int object) a ValueError is raised.
-    fn pyobject_to_opt_usize(obj: PyObjectRef, name: &str, vm: &VirtualMachine) -> PyResult<usize> {
+    fn pyobject_to_opt_usize(
+        obj: PyObjectRef,
+        name: &'static str,
+        vm: &VirtualMachine,
+    ) -> PyResult<usize> {
         let is_int = obj.isinstance(&vm.ctx.types.int_type);
         if is_int {
             let value = int::get_value(&obj).to_usize();
             if let Some(value) = value {
                 // Only succeeds for values for which 0 <= value <= isize::MAX
-                if value <= usize::try_from(isize::MAX).unwrap() {
+                if value <= isize::MAX as usize {
                     return Ok(value);
                 }
             }


### PR DESCRIPTION
Fixes test for `islice` and also un-blocks doctest for `itertools` to finally be able to run. Also fixes acceptable values for `start`, `step` and `stop` to be in the range `0 <= value <= sys.maxsize` when they previously were in range `0 <= value <= usize::MAX`. 