### PR TITLE
Use inspect.getmodule to prevent redundant output in whats_left.sh

### DIFF
--- a/extra_tests/not_impl_gen.py
+++ b/extra_tests/not_impl_gen.py
@@ -187,7 +187,10 @@ def dir_of_mod_or_error(module_name):
     result = {}
     for item_name in item_names:
         item = getattr(module, item_name)
-        result[item_name] = extra_info(item)
+        item_mod = inspect.getmodule(item)
+        # don't repeat items imported from other modules
+        if item_mod is module or item_mod is None:
+            result[item_name] = extra_info(item)
     return result
 
 


### PR DESCRIPTION
As I (very slowly) progress toward making an actual contribution, I wanted to propose a tweak to `whats_left.sh`. In its current form, the script uses `dir` to crawl the modules and this means that there is some redundant output from items defined somewhere else. A big culprit is `__loader__` (see #2732) but there are others. In total this shaves 388 (redundant) lines from the output. The `missing_items` and `mismatched_items` go down but I think that was because they overcounted before.

Another thing I noticed in the output is that for some entries, RustPython is actually _better_ than the CPython implementation. Many of the entries in `operator` have a signature, where the CPython version returns `None`. I'm not sure it makes sense to include those in the output but that's a separate change.