### PR TITLE
Fixes `type.__module__` issue, refs #2310

### DIFF
--- a/extra_tests/snippets/builtin_type.py
+++ b/extra_tests/snippets/builtin_type.py
@@ -3,5 +3,7 @@ assert type.__qualname__ == 'type'
 assert type.__name__ == 'type'
 assert isinstance(type.__doc__, str)
 
+# Regression to
+# https://github.com/RustPython/RustPython/issues/2310
 import builtins
 assert builtins.iter.__class__.__module__ == 'builtins'

--- a/extra_tests/snippets/builtin_type.py
+++ b/extra_tests/snippets/builtin_type.py
@@ -23,3 +23,11 @@ assert B.__qualname__ == 'BB'
 # https://github.com/RustPython/RustPython/issues/2310
 import builtins
 assert builtins.iter.__class__.__module__ == 'builtins'
+assert builtins.iter.__class__.__qualname__ == 'builtin_function_or_method'
+
+try:
+    builtins.iter.__class__.__docs__
+except AttributeError:
+    assert True
+else:
+    assert False, 'Attribute error was not raised'

--- a/extra_tests/snippets/builtin_type.py
+++ b/extra_tests/snippets/builtin_type.py
@@ -3,6 +3,22 @@ assert type.__qualname__ == 'type'
 assert type.__name__ == 'type'
 assert isinstance(type.__doc__, str)
 
+
+class A(type):
+    pass
+
+
+class B(type):
+    __module__ = 'b'
+    __qualname__ = 'BB'
+
+
+assert A.__module__ == '__main__'
+assert A.__qualname__ == 'A'
+assert B.__module__ == 'b'
+assert B.__qualname__ == 'BB'
+
+
 # Regression to
 # https://github.com/RustPython/RustPython/issues/2310
 import builtins

--- a/extra_tests/snippets/builtin_type.py
+++ b/extra_tests/snippets/builtin_type.py
@@ -1,0 +1,6 @@
+assert type.__module__ == 'builtins'
+assert type.__qualname__ == 'type'
+assert isinstance(type.__doc__, str)
+
+import builtins
+assert builtins.iter.__class__.__module__ == 'builtins'

--- a/extra_tests/snippets/builtin_type.py
+++ b/extra_tests/snippets/builtin_type.py
@@ -1,5 +1,6 @@
 assert type.__module__ == 'builtins'
 assert type.__qualname__ == 'type'
+assert type.__name__ == 'type'
 assert isinstance(type.__doc__, str)
 
 import builtins

--- a/extra_tests/snippets/builtin_type.py
+++ b/extra_tests/snippets/builtin_type.py
@@ -25,9 +25,7 @@ import builtins
 assert builtins.iter.__class__.__module__ == 'builtins'
 assert builtins.iter.__class__.__qualname__ == 'builtin_function_or_method'
 
-try:
-    builtins.iter.__class__.__docs__
-except AttributeError:
-    assert True
-else:
-    assert False, 'Attribute error was not raised'
+assert iter.__class__.__module__ == 'builtins'
+assert iter.__class__.__qualname__ == 'builtin_function_or_method'
+assert type(iter).__module__ == 'builtins'
+assert type(iter).__qualname__ == 'builtin_function_or_method'

--- a/extra_tests/snippets/builtin_type.py
+++ b/extra_tests/snippets/builtin_type.py
@@ -2,6 +2,8 @@ assert type.__module__ == 'builtins'
 assert type.__qualname__ == 'type'
 assert type.__name__ == 'type'
 assert isinstance(type.__doc__, str)
+assert object.__qualname__ == 'object'
+assert int.__qualname__ == 'int'
 
 
 class A(type):
@@ -13,10 +15,23 @@ class B(type):
     __qualname__ = 'BB'
 
 
+class C:
+    pass
+
+
+class D:
+    __module__ = 'd'
+    __qualname__ = 'DD'
+
+
 assert A.__module__ == '__main__'
 assert A.__qualname__ == 'A'
 assert B.__module__ == 'b'
 assert B.__qualname__ == 'BB'
+assert C.__module__ == '__main__'
+assert C.__qualname__ == 'C'
+assert D.__module__ == 'd'
+assert D.__qualname__ == 'DD'
 
 
 # Regression to

--- a/vm/src/builtins/builtinfunc.rs
+++ b/vm/src/builtins/builtinfunc.rs
@@ -202,10 +202,5 @@ impl PyBuiltinMethod {
 
 pub fn init(context: &PyContext) {
     PyBuiltinFunction::extend_class(context, &context.types.builtin_function_or_method_type);
-    extend_class!(context, &context.types.builtin_function_or_method_type, {
-        "__qualname__" => context.new_str("builtin_function_or_method"),
-        "__module__" => context.new_str("builtins"),
-    });
-
     PyBuiltinMethod::extend_class(context, &context.types.method_descriptor_type);
 }

--- a/vm/src/builtins/builtinfunc.rs
+++ b/vm/src/builtins/builtinfunc.rs
@@ -55,7 +55,7 @@ impl PyNativeFuncDef {
     }
 }
 
-#[pyclass(name = "builtin_function_or_method", module = "builtins")]
+#[pyclass(name = "builtin_function_or_method", module = false)]
 pub struct PyBuiltinFunction {
     value: PyNativeFuncDef,
     module: Option<PyObjectRef>,
@@ -137,6 +137,11 @@ impl PyBuiltinFunction {
     #[pymethod(magic)]
     fn repr(&self) -> String {
         format!("<built-in function {}>", self.value.name)
+    }
+
+    #[extend_class]
+    fn extend_class_with_fields(ctx: &PyContext, class: &PyTypeRef) {
+        class.set_str_attr("__module__", ctx.new_str("builtins"));
     }
 }
 

--- a/vm/src/builtins/builtinfunc.rs
+++ b/vm/src/builtins/builtinfunc.rs
@@ -138,11 +138,6 @@ impl PyBuiltinFunction {
     fn repr(&self) -> String {
         format!("<built-in function {}>", self.value.name)
     }
-
-    #[extend_class]
-    fn extend_class_with_fields(ctx: &PyContext, class: &PyTypeRef) {
-        class.set_str_attr("__module__", ctx.new_str("builtins"));
-    }
 }
 
 #[pyclass(module = false, name = "method_descriptor")]
@@ -207,5 +202,10 @@ impl PyBuiltinMethod {
 
 pub fn init(context: &PyContext) {
     PyBuiltinFunction::extend_class(context, &context.types.builtin_function_or_method_type);
+    extend_class!(context, &context.types.builtin_function_or_method_type, {
+        "__qualname__" => context.new_str("builtin_function_or_method"),
+        "__module__" => context.new_str("builtins"),
+    });
+
     PyBuiltinMethod::extend_class(context, &context.types.method_descriptor_type);
 }

--- a/vm/src/builtins/builtinfunc.rs
+++ b/vm/src/builtins/builtinfunc.rs
@@ -55,7 +55,7 @@ impl PyNativeFuncDef {
     }
 }
 
-#[pyclass(name = "builtin_function_or_method", module = false)]
+#[pyclass(name = "builtin_function_or_method", module = "builtins")]
 pub struct PyBuiltinFunction {
     value: PyNativeFuncDef,
     module: Option<PyObjectRef>,

--- a/vm/src/builtins/pytype.rs
+++ b/vm/src/builtins/pytype.rs
@@ -493,12 +493,6 @@ impl PyType {
             "Setting __dict__ attribute on a type isn't yet implemented".to_owned(),
         ))
     }
-
-    #[extend_class]
-    fn extend_class_with_fields(ctx: &PyContext, class: &PyTypeRef) {
-        class.set_str_attr("__module__", ctx.new_str("builtins"));
-        class.set_str_attr("__qualname__", ctx.new_str("type"));
-    }
 }
 
 impl SlotGetattro for PyType {
@@ -655,6 +649,10 @@ fn subtype_set_dict(obj: PyObjectRef, value: PyObjectRef, vm: &VirtualMachine) -
 
 pub(crate) fn init(ctx: &PyContext) {
     PyType::extend_class(ctx, &ctx.types.type_type);
+    extend_class!(ctx, &ctx.types.type_type, {
+        "__module__" => ctx.new_str("builtins"),
+        "__qualname__" => ctx.new_str("type"),
+    });
 }
 
 impl PyLease<'_, PyType> {

--- a/vm/src/builtins/pytype.rs
+++ b/vm/src/builtins/pytype.rs
@@ -493,6 +493,12 @@ impl PyType {
             "Setting __dict__ attribute on a type isn't yet implemented".to_owned(),
         ))
     }
+
+    #[extend_class]
+    fn extend_class_with_fields(ctx: &PyContext, class: &PyTypeRef) {
+        class.set_str_attr("__module__", ctx.new_str("builtins"));
+        class.set_str_attr("__qualname__", ctx.new_str("type"));
+    }
 }
 
 impl SlotGetattro for PyType {

--- a/vm/src/builtins/pytype.rs
+++ b/vm/src/builtins/pytype.rs
@@ -307,10 +307,12 @@ impl PyType {
             .get("__qualname__")
             .cloned()
             // We need to exclude this method from going into recursion:
-            .and_then(|found| if found.isinstance(&vm.ctx.types.getset_type) {
-                None
-            } else {
-                Some(found)
+            .and_then(|found| {
+                if found.isinstance(&vm.ctx.types.getset_type) {
+                    None
+                } else {
+                    Some(found)
+                }
             })
             .unwrap_or_else(|| vm.ctx.new_str(self.name.clone()))
     }
@@ -323,10 +325,12 @@ impl PyType {
             .get("__module__")
             .cloned()
             // We need to exclude this method from going into recursion:
-            .and_then(|found| if found.isinstance(&vm.ctx.types.getset_type) {
-                None
-            } else {
-                Some(found)
+            .and_then(|found| {
+                if found.isinstance(&vm.ctx.types.getset_type) {
+                    None
+                } else {
+                    Some(found)
+                }
             })
             .unwrap_or_else(|| vm.ctx.new_str("builtins"))
     }


### PR DESCRIPTION
Previously `type.__module__` was returning `<getset descriptor>`.
It happend because this code:

```rust
#[pyproperty(magic)]
    fn module(&self, vm: &VirtualMachine) -> PyObjectRef {
        // TODO: Implement getting the actual module a builtin type is from
        self.attributes
            .read()
            .get("__module__")
            .cloned()
            .unwrap_or_else(|| vm.ctx.new_str("builtins"))
    }
```

was able to find `__module__` in `self.attributes`. But, it was the method `#[pyproperty(magic)] fn module` definition itself.
The same happened to `__qualname__` as well.

I've added a simple test to ensure that it is now correct.

Closes #2310