### PR TITLE
Further tweaking whats_left: allow differing implementation

### DIFF
--- a/extra_tests/not_impl_gen.py
+++ b/extra_tests/not_impl_gen.py
@@ -172,7 +172,7 @@ def scan_modules():
     return list(modules.keys())
 
 
-def dir_of_mod_or_error(module_name):
+def dir_of_mod_or_error(module_name, keep_other=True):
     # Importing modules causes ('Constant String', 2, None, 4) and
     # "Hello world!" to be printed to stdout.
     f = io.StringIO()
@@ -189,7 +189,7 @@ def dir_of_mod_or_error(module_name):
         item = getattr(module, item_name)
         item_mod = inspect.getmodule(item)
         # don't repeat items imported from other modules
-        if item_mod is module or item_mod is None:
+        if keep_other or item_mod is module or item_mod is None:
             result[item_name] = extra_info(item)
     return result
 
@@ -201,7 +201,8 @@ def gen_modules():
     for mod_name in scan_modules():
         if mod_name in ("this", "antigravity") or mod_name in PEP_594_MODULES:
             continue
-        dir_result = dir_of_mod_or_error(mod_name)
+        # when generating CPython list, ignore items defined by other modules
+        dir_result = dir_of_mod_or_error(mod_name, keep_other=False)
         if isinstance(dir_result, Exception):
             print(
                 f"!!! {mod_name} skipped because {type(dir_result).__name__}: {str(dir_result)}",


### PR DESCRIPTION
In #2760 I introduced a regression. Sometimes RustPython will have an object defined in a different module from the one CPython defines it in. This is probably fine (implementations can be different) as long as the code is working (which this script doesn't test anyway).

For example, CPython's `posix` module defines its own `chdir`, `cpu_count`, etc. In RustPython the implementations are coming from `os.py` (maybe actually in `os.rs`?). Or for instance, CPython `sys.stderr` has no module defined (`getmodule` returns `None`) but RustPython will return `_io`. In these cases I think we'd want to count those as implemented, even though the code location is different.

So, this just adds an option `keep_other` to the scanning code. When in CPython, the script only keeps members from the module itself (as well as those that are undefined), to reduce redundancy in the output. But in the RustPython code it will consider anything, in case implementations are coming from other modules.

This takes another 177 lines off the output 😁 