### PR TITLE
Fixes clippy on macos

### DIFF
--- a/vm/src/stdlib/io.rs
+++ b/vm/src/stdlib/io.rs
@@ -98,6 +98,7 @@ mod _io {
         StaticType, TryFromObject, TypeProtocol,
     };
 
+    #[allow(clippy::let_and_return)]
     fn validate_whence(whence: i32) -> bool {
         let x = (0..=2).contains(&whence);
         cfg_if::cfg_if! {


### PR DESCRIPTION
For some reason I was having an error from `clippy` locally:
<img width="752" alt="Снимок экрана 2021-08-01 в 12 05 46" src="https://user-images.githubusercontent.com/4660275/127765638-9145d526-877e-478b-8299-0e109325698d.png">

It was quite annoying, so I have fixed it:
<img width="752" alt="Снимок экрана 2021-08-01 в 12 07 14" src="https://user-images.githubusercontent.com/4660275/127765646-ed4acd79-82a8-4ea0-a1b0-a409a25cdca8.png">
