### PR TITLE
GitHub Actions housekeeping

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -26,7 +26,7 @@ jobs:
         os: [macos-latest, ubuntu-latest, windows-latest]
       fail-fast: false
     steps:
-      - uses: actions/checkout@master
+      - uses: actions/checkout@v2
       - uses: actions-rs/toolchain@v1
       - name: Set up the Windows environment
         shell: bash
@@ -57,7 +57,7 @@ jobs:
         os: [macos-latest, ubuntu-latest, windows-latest]
       fail-fast: false
     steps:
-      - uses: actions/checkout@master
+      - uses: actions/checkout@v2
       - uses: actions-rs/toolchain@v1
       - uses: actions/setup-python@v2
         with:
@@ -77,7 +77,7 @@ jobs:
         with:
           command: build
           args: --release --verbose ${{ env.CARGO_ARGS }}
-      - uses: actions/setup-python@v1
+      - uses: actions/setup-python@v2
         with:
           python-version: 3.8
       - name: Install pipenv
@@ -115,7 +115,7 @@ jobs:
     name: Check Rust code with rustfmt and clippy
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@master
+      - uses: actions/checkout@v2
       - uses: actions-rs/toolchain@v1
         with:
             profile: minimal
@@ -137,7 +137,7 @@ jobs:
         with:
           command: clippy
           args: --manifest-path=wasm/lib/Cargo.toml -- -Dwarnings
-      - uses: actions/setup-python@v1
+      - uses: actions/setup-python@v2
         with:
           python-version: 3.8
       - name: install flake8
@@ -153,7 +153,7 @@ jobs:
     name: Run tests under miri
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@master
+      - uses: actions/checkout@v2
       - uses: actions-rs/toolchain@v1
         with:
             profile: minimal
@@ -170,7 +170,7 @@ jobs:
     needs: rust_tests
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@master
+      - uses: actions/checkout@v2
       - name: Cache cargo dependencies
         uses: actions/cache@v2
         with:
@@ -188,7 +188,7 @@ jobs:
           wget https://github.com/mozilla/geckodriver/releases/download/v0.24.0/geckodriver-v0.24.0-linux32.tar.gz
           mkdir geckodriver
           tar -xzf geckodriver-v0.24.0-linux32.tar.gz -C geckodriver
-      - uses: actions/setup-python@v1
+      - uses: actions/setup-python@v2
         with:
           python-version: 3.8
       - name: Install pipenv
@@ -220,4 +220,3 @@ jobs:
           PUBLISH_DIR: ./wasm/demo/dist
           EXTERNAL_REPOSITORY: RustPython/demo
           PUBLISH_BRANCH: master
-

--- a/.github/workflows/cron-ci.yaml
+++ b/.github/workflows/cron-ci.yaml
@@ -12,7 +12,7 @@ jobs:
     container:
       image: redoxos/redoxer:latest
     steps:
-      - uses: actions/checkout@master
+      - uses: actions/checkout@v2
       - name: prepare repository for redoxer compilation
         run: bash scripts/redox/uncomment-cargo.sh
       - name: compile for redox
@@ -22,7 +22,7 @@ jobs:
     name: Collect code coverage data
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@master
+      - uses: actions/checkout@v2
       - uses: actions-rs/toolchain@v1
         with:
           toolchain: nightly
@@ -35,7 +35,7 @@ jobs:
           args: --release --verbose
         env:
           RUSTC_WRAPPER: './scripts/codecoverage-rustc-wrapper.sh'
-      - uses: actions/setup-python@v1
+      - uses: actions/setup-python@v2
         with:
           python-version: 3.8
       - name: Install pipenv
@@ -69,7 +69,7 @@ jobs:
     name: Collect regression test data
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@master
+      - uses: actions/checkout@v2
       - name: build rustpython
         uses: actions-rs/cargo@v1
         with:
@@ -99,7 +99,7 @@ jobs:
     name: Collect what is left data
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@master
+      - uses: actions/checkout@v2
       - name: build rustpython
         uses: actions-rs/cargo@v1
         with:
@@ -132,7 +132,7 @@ jobs:
     name: Collect benchmark data
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@master
+      - uses: actions/checkout@v2
       - run: cargo install cargo-criterion
       - name: build benchmarks
         run: cargo build --release --benches


### PR DESCRIPTION
- Updates `actions/setup-python`
- Uses `v2` instead of `master` for `actions/checkout`

All other versions are fine 👍 