### PR TITLE
Initialize with init for mutable builtins.

### DIFF
--- a/Lib/test/list_tests.py
+++ b/Lib/test/list_tests.py
@@ -12,8 +12,6 @@ from test import support, seq_tests
 
 class CommonTest(seq_tests.CommonTest):
 
-    # TODO: RUSTPYTHON
-    @unittest.expectedFailure
     def test_init(self):
         # Iterable arg is optional
         self.assertEqual(self.type2test([]), self.type2test())

--- a/Lib/test/test_set.py
+++ b/Lib/test/test_set.py
@@ -47,8 +47,6 @@ class TestJointOps:
         self.s = self.thetype(word)
         self.d = dict.fromkeys(word)
 
-    # TODO: RUSTPYTHON
-    @unittest.expectedFailure
     def test_new_or_init(self):
         self.assertRaises(TypeError, self.thetype, [], 2)
         self.assertRaises(TypeError, set().__init__, a=1)
@@ -386,8 +384,6 @@ class TestSet(TestJointOps, unittest.TestCase):
     def test_contains(self):
         super().test_contains()
 
-    # TODO: RUSTPYTHON
-    @unittest.expectedFailure
     def test_init(self):
         s = self.thetype()
         s.__init__(self.word)

--- a/vm/src/builtins/dict.rs
+++ b/vm/src/builtins/dict.rs
@@ -54,10 +54,7 @@ impl PyValue for PyDict {
 impl PyDict {
     #[pyslot]
     fn tp_new(class: PyTypeRef, _args: FuncArgs, vm: &VirtualMachine) -> PyResult<PyRef<Self>> {
-        PyDict {
-            entries: DictContentType::default(),
-        }
-        .into_ref_with_type(vm, class)
+        PyDict::default().into_ref_with_type(vm, class)
     }
 
     #[pymethod(magic)]

--- a/vm/src/builtins/list.rs
+++ b/vm/src/builtins/list.rs
@@ -391,16 +391,21 @@ impl PyList {
     #[pyslot]
     fn tp_new(
         cls: PyTypeRef,
-        iterable: OptionalArg<PyObjectRef>,
+        _iterable: OptionalArg<PyObjectRef>,
         vm: &VirtualMachine,
     ) -> PyResult<PyRef<Self>> {
-        let elements = if let OptionalArg::Present(iterable) = iterable {
+        PyList::default().into_ref_with_type(vm, cls)
+    }
+
+    #[pymethod(name = "__init__")]
+    fn init(&self, iterable: OptionalArg<PyObjectRef>, vm: &VirtualMachine) -> PyResult<()> {
+        let mut elements = if let OptionalArg::Present(iterable) = iterable {
             vm.extract_elements(&iterable)?
         } else {
             vec![]
         };
-
-        PyList::from(elements).into_ref_with_type(vm, cls)
+        std::mem::swap(self.borrow_vec_mut().deref_mut(), &mut elements);
+        Ok(())
     }
 }
 


### PR DESCRIPTION
This moves the initialization from the arguments into `__init__`. `dict` already did this, this just fixes the behavior for `list` and `set`.