### PR TITLE
Fix unhashable type error message

### DIFF
--- a/vm/src/slots.rs
+++ b/vm/src/slots.rs
@@ -7,7 +7,10 @@ use crate::common::lock::PyRwLock;
 use crate::function::{FuncArgs, OptionalArg, PyNativeFunc};
 use crate::utils::Either;
 use crate::VirtualMachine;
-use crate::{IdProtocol, TypeProtocol, PyComparisonValue, PyObjectRef, PyRef, PyResult, PyValue, TryFromObject};
+use crate::{
+    IdProtocol, PyComparisonValue, PyObjectRef, PyRef, PyResult, PyValue, TryFromObject,
+    TypeProtocol,
+};
 use crossbeam_utils::atomic::AtomicCell;
 
 bitflags! {
@@ -223,10 +226,7 @@ where
     T: Unhashable,
 {
     fn hash(_zelf: &PyRef<Self>, vm: &VirtualMachine) -> PyResult<PyHash> {
-        let msg = format!(
-            "unhashable type: '{}'",
-            _zelf.class().name
-        );
+        let msg = format!("unhashable type: '{}'", _zelf.class().name);
         Err(vm.new_type_error(msg))
     }
 }

--- a/vm/src/slots.rs
+++ b/vm/src/slots.rs
@@ -7,7 +7,7 @@ use crate::common::lock::PyRwLock;
 use crate::function::{FuncArgs, OptionalArg, PyNativeFunc};
 use crate::utils::Either;
 use crate::VirtualMachine;
-use crate::{IdProtocol, PyComparisonValue, PyObjectRef, PyRef, PyResult, PyValue, TryFromObject};
+use crate::{IdProtocol, TypeProtocol, PyComparisonValue, PyObjectRef, PyRef, PyResult, PyValue, TryFromObject};
 use crossbeam_utils::atomic::AtomicCell;
 
 bitflags! {
@@ -223,7 +223,11 @@ where
     T: Unhashable,
 {
     fn hash(_zelf: &PyRef<Self>, vm: &VirtualMachine) -> PyResult<PyHash> {
-        Err(vm.new_type_error("unhashable type".to_owned()))
+        let msg = format!(
+            "unhashable type: '{}'",
+            _zelf.class().name
+        );
+        Err(vm.new_type_error(msg))
     }
 }
 

--- a/vm/src/slots.rs
+++ b/vm/src/slots.rs
@@ -226,8 +226,7 @@ where
     T: Unhashable,
 {
     fn hash(_zelf: &PyRef<Self>, vm: &VirtualMachine) -> PyResult<PyHash> {
-        let msg = format!("unhashable type: '{}'", _zelf.class().name);
-        Err(vm.new_type_error(msg))
+        Err(vm.new_type_error(format!("unhashable type: '{}'", _zelf.class().name)))
     }
 }
 


### PR DESCRIPTION
This pull request resolves #2800 by fixing the message format of the error raised by `hash` built-in function.

After this pull request, the message will have compatibility with CPython implementation and will have more rich information about error. 😎 

You can check the changes by executing below lines at [the current master branch commit](https://github.com/RustPython/RustPython/commit/53b8067acd1af79c2081e9eb56586fa8955749fd) and [this pull request HEAD commit](https://github.com/RustPython/RustPython/commits/fcfc15778d5937b7626ac39d2239a9eabfb85769).

```python
hash(dict())
hash(set())
```