### PR TITLE
add iskeyword None check

### DIFF
--- a/Lib/test/test_keyword.py
+++ b/Lib/test/test_keyword.py
@@ -9,8 +9,6 @@ class Test_iskeyword(unittest.TestCase):
     def test_uppercase_true_is_not_a_keyword(self):
         self.assertFalse(keyword.iskeyword('TRUE'))
 
-    # TODO: RUSTPYTHON
-    @unittest.expectedFailure
     def test_none_value_is_not_a_keyword(self):
         self.assertFalse(keyword.iskeyword(None))
 

--- a/vm/src/stdlib/keyword.rs
+++ b/vm/src/stdlib/keyword.rs
@@ -6,13 +6,17 @@ mod decl {
     use itertools::Itertools;
     use rustpython_parser::lexer;
 
-    use crate::builtins::pystr::PyStrRef;
+    use crate::builtins::PyStr;
     use crate::vm::VirtualMachine;
     use crate::PyObjectRef;
 
     #[pyfunction]
-    fn iskeyword(s: PyStrRef) -> bool {
-        lexer::KEYWORDS.contains_key(s.as_str())
+    fn iskeyword(s: PyObjectRef) -> bool {
+        if let Some(s) = s.payload::<PyStr>() {
+            lexer::KEYWORDS.contains_key(s.as_str())
+        } else {
+            false
+        }
     }
 
     #[pyattr]


### PR DESCRIPTION
there was one todo in test_keyword.py

before: s was PyStrRef, it failed to handle None
after: convert s to PyObjectRef and add None check