### PR TITLE
Fix incorrect unwrapping

### DIFF
--- a/vm/src/frame.rs
+++ b/vm/src/frame.rs
@@ -1311,7 +1311,7 @@ impl ExecutingFrame<'_> {
             }
         } else {
             for (key, value) in self.pop_multiple(2 * size).tuples() {
-                map_obj.set_item(key, value, vm).unwrap();
+                map_obj.set_item(key, value, vm)?;
             }
         }
 


### PR DESCRIPTION
This pull request resolves #2799.

Because the implementation of [`ItemProtocol<T>.set_item(…)` for `PyDictRef`][itemprotocol-setitem-for-pydictref] can return `Err` having `TypeError` when `key` implemented [`Unhashable`][unhashable], it should not call `unwrap`. So, this pull request removed calling `unwrap` and used `?` operator.

[itemprotocol-setitem-for-pydictref]: https://github.com/RustPython/RustPython/blob/53b8067acd1af79c2081e9eb56586fa8955749fd/vm/src/builtins/dict.rs#L527-L534
[unhashable]: https://github.com/RustPython/RustPython/blob/53b8067acd1af79c2081e9eb56586fa8955749fd/vm/src/slots.rs#L219-L228