### PR TITLE
metaclass support for #[pyclass] macro

### DIFF
--- a/derive/src/util.rs
+++ b/derive/src/util.rs
@@ -233,7 +233,7 @@ impl ItemMeta for SimpleItemMeta {
 pub(crate) struct ClassItemMeta(ItemMetaInner);
 
 impl ItemMeta for ClassItemMeta {
-    const ALLOWED_NAMES: &'static [&'static str] = &["module", "name", "base"];
+    const ALLOWED_NAMES: &'static [&'static str] = &["module", "name", "base", "metaclass"];
 
     fn from_inner(inner: ItemMetaInner) -> Self {
         Self(inner)
@@ -270,6 +270,10 @@ impl ClassItemMeta {
 
     pub fn base(&self) -> Result<Option<String>> {
         self.inner()._optional_str("base")
+    }
+
+    pub fn metaclass(&self) -> Result<Option<String>> {
+        self.inner()._optional_str("metaclass")
     }
 
     pub fn module(&self) -> Result<Option<String>> {


### PR DESCRIPTION
to support nessessary feature for #2364

example usage: https://github.com/RustPython/RustPython/commit/efabe9b1b460ff8e2055419a6f5c51856f7c42b7#diff-60f7a4d8aa16c48a7f721ca4e79294d8369af2d4ed8a68a83570557ae41182d0R282