### PR TITLE
Makes args of `type.__prepare__` optional

### DIFF
--- a/extra_tests/snippets/builtin_type.py
+++ b/extra_tests/snippets/builtin_type.py
@@ -135,5 +135,8 @@ assert type.__prepare__('name', (bytes, str)) == {}
 assert type.__prepare__(a=1, b=2) == {}
 assert type.__prepare__('name', (object, int), kw=True) == {}
 
+# Previously we needed `name` to be `str`:
+assert type.__prepare__(1) == {}
+
 assert int.__prepare__() == {}
 assert int.__prepare__('name', (object, int), kw=True) == {}

--- a/extra_tests/snippets/builtin_type.py
+++ b/extra_tests/snippets/builtin_type.py
@@ -123,3 +123,17 @@ def custom_func():
     pass
 
 assert custom_func.__qualname__ == 'custom_func'
+
+
+# Regression to
+# https://github.com/RustPython/RustPython/issues/2762
+
+assert type.__prepare__() == {}
+assert type.__prepare__('name') == {}
+assert type.__prepare__('name', object) == {}
+assert type.__prepare__('name', (bytes, str)) == {}
+assert type.__prepare__(a=1, b=2) == {}
+assert type.__prepare__('name', (object, int), kw=True) == {}
+
+assert int.__prepare__() == {}
+assert int.__prepare__('name', (object, int), kw=True) == {}

--- a/vm/src/builtins/pytype.rs
+++ b/vm/src/builtins/pytype.rs
@@ -343,9 +343,10 @@ impl PyType {
             .insert("__module__".to_owned(), value);
     }
 
-    #[pymethod(magic)]
+    #[pyclassmethod(magic)]
     fn prepare(
-        _name: OptionalArg<PyStrRef>,
+        _cls: PyTypeRef,
+        _name: OptionalArg<PyObjectRef>,
         _bases: OptionalArg<PyObjectRef>,
         _kwargs: KwArgs,
         vm: &VirtualMachine,

--- a/vm/src/builtins/pytype.rs
+++ b/vm/src/builtins/pytype.rs
@@ -16,7 +16,7 @@ use super::staticmethod::PyStaticMethod;
 use super::tuple::PyTuple;
 use super::weakref::PyWeak;
 use crate::builtins::tuple::PyTupleTyped;
-use crate::function::{FuncArgs, KwArgs};
+use crate::function::{FuncArgs, KwArgs, OptionalArg};
 use crate::slots::{self, Callable, PyTpFlags, PyTypeSlots, SlotGetattro, SlotSetattro};
 use crate::utils::Either;
 use crate::vm::VirtualMachine;
@@ -345,8 +345,8 @@ impl PyType {
 
     #[pymethod(magic)]
     fn prepare(
-        _name: PyStrRef,
-        _bases: PyObjectRef,
+        _name: OptionalArg<PyStrRef>,
+        _bases: OptionalArg<PyObjectRef>,
         _kwargs: KwArgs,
         vm: &VirtualMachine,
     ) -> PyDictRef {


### PR DESCRIPTION
Closes #2762

Now it matches the CPython behavior: 
<img width="752" alt="Снимок экрана 2021-08-08 в 12 07 28" src="https://user-images.githubusercontent.com/4660275/128626952-249b7854-53c2-4543-ad24-89d220efae85.png">

Changes:
- now `__prepare__` is a `classmethod`
- first argument can be any object, not just `str`
- all arguments are optional

https://docs.python.org/3/reference/datamodel.html#preparing-the-class-namespace