### PR TITLE
Add __index__ operator overriding class support for RangeIndex

### DIFF
--- a/Lib/test/test_index.py
+++ b/Lib/test/test_index.py
@@ -243,8 +243,6 @@ class NewSeqTestCase(SeqTestCase, unittest.TestCase):
 
 class RangeTestCase(unittest.TestCase):
 
-    # TODO: RUSTPYTHON
-    @unittest.expectedFailure
     def test_range(self):
         n = newstyle()
         n.ind = 5

--- a/vm/src/builtins/range.rs
+++ b/vm/src/builtins/range.rs
@@ -634,10 +634,13 @@ impl TryFromObject for RangeIndex {
         match_class!(match obj {
             i @ PyInt => Ok(RangeIndex::Int(i)),
             s @ PySlice => Ok(RangeIndex::Slice(s)),
-            obj => Err(vm.new_type_error(format!(
-                "sequence indices be integers or slices, not '{}'",
-                obj.class().name,
-            ))),
+            obj => {
+                let val = vm.to_index(&obj).map_err(|_| vm.new_type_error(format!(
+                    "sequence indices be integers or slices or classes that override __index__ operator, not '{}'",
+                    obj.class().name
+                )))?;
+                Ok(RangeIndex::Int(val))
+            }
         })
     }
 }


### PR DESCRIPTION
This revision fix **RangeTestCase.test_range** test in [test_index.py](https://github.com/RustPython/RustPython/blob/master/Lib/test/test_index.py#L248)

`TryFromObject` implementation for `RangeIndex` enum did not cover classes
that override `__index__` operator which cpython implementation is currently providing
(https://docs.python.org/3.8/library/operator.html#operator.__index__)

I add codes that cover the above case using `vm.to_index` method.

##### Before
```rust
impl TryFromObject for RangeIndex {
    fn try_from_object(vm: &VirtualMachine, obj: PyObjectRef) -> PyResult<Self> {
        match_class!(match obj {
            i @ PyInt => Ok(RangeIndex::Int(i)),
            s @ PySlice => Ok(RangeIndex::Slice(s)),
            obj => Err(vm.new_type_error(format!(
                "sequence indices be integers or slices, not '{}'",
                obj.class().name,
            ))),
        })
    }
}
```

##### After
```rust
impl TryFromObject for RangeIndex {
    fn try_from_object(vm: &VirtualMachine, obj: PyObjectRef) -> PyResult<Self> {
        match_class!(match obj {
            i @ PyInt => Ok(RangeIndex::Int(i)),
            s @ PySlice => Ok(RangeIndex::Slice(s)),
            obj => match vm.to_index(&obj) {
                Ok(val) => Ok(RangeIndex::Int(val)),
                Err(_) => Err(vm.new_type_error(format!(
                    "sequence indices be integers or slices or classes that override __index__ operator, not '{}'",
                    obj.class().name
                ))),
            },
        })
    }
}
```

