### PR TITLE
Adds `class` field to `PyGetSet` to fix `__qualname__`

### DIFF
--- a/derive/src/pyclass.rs
+++ b/derive/src/pyclass.rs
@@ -563,7 +563,7 @@ impl ToTokens for GetSetNursery {
                     class.set_str_attr(
                         #name,
                         ::rustpython_vm::PyObject::new(
-                            ::rustpython_vm::builtins::PyGetSet::new(#name.into())
+                            ::rustpython_vm::builtins::PyGetSet::new(#name.into(), class.clone())
                                 .with_get(&Self::#getter)
                                 #setter #deleter,
                             ctx.types.getset_type.clone(), None)

--- a/extra_tests/snippets/builtin_type.py
+++ b/extra_tests/snippets/builtin_type.py
@@ -140,3 +140,14 @@ assert type.__prepare__(1) == {}
 
 assert int.__prepare__() == {}
 assert int.__prepare__('name', (object, int), kw=True) == {}
+
+
+# Regression to
+# https://github.com/RustPython/RustPython/issues/2790
+
+# `#[pyproperty]`
+assert BaseException.args.__qualname__ == 'BaseException.args'
+# class extension without `#[pyproperty]` override
+assert Exception.args.__qualname__ == 'BaseException.args'
+# dynamic with `.new_readonly_getset`
+assert SyntaxError.msg.__qualname__ == 'SyntaxError.msg'

--- a/vm/src/builtins/bytearray.rs
+++ b/vm/src/builtins/bytearray.rs
@@ -93,7 +93,7 @@ pub(crate) fn init(context: &PyContext) {
     PyByteArray::extend_class(context, &context.types.bytearray_type);
     let bytearray_type = &context.types.bytearray_type;
     extend_class!(context, bytearray_type, {
-        "maketrans" => context.new_method("maketrans", PyBytesInner::maketrans, bytearray_type.clone()),
+        "maketrans" => context.new_method("maketrans", bytearray_type.clone(), PyBytesInner::maketrans),
     });
 
     PyByteArrayIterator::extend_class(context, &context.types.bytearray_iterator_type);

--- a/vm/src/builtins/bytes.rs
+++ b/vm/src/builtins/bytes.rs
@@ -93,7 +93,7 @@ pub(crate) fn init(context: &PyContext) {
     PyBytes::extend_class(context, &context.types.bytes_type);
     let bytes_type = &context.types.bytes_type;
     extend_class!(context, bytes_type, {
-        "maketrans" => context.new_method("maketrans", PyBytesInner::maketrans, bytes_type.clone()),
+        "maketrans" => context.new_method("maketrans", bytes_type.clone(), PyBytesInner::maketrans),
     });
     PyBytesIterator::extend_class(context, &context.types.bytes_iterator_type);
 }

--- a/vm/src/builtins/getset.rs
+++ b/vm/src/builtins/getset.rs
@@ -209,6 +209,7 @@ where
 #[pyclass(module = false, name = "getset_descriptor")]
 pub struct PyGetSet {
     name: String,
+    class: PyTypeRef,
     getter: Option<PyGetterFunc>,
     setter: Option<PySetterFunc>,
     deleter: Option<PyDeleterFunc>,
@@ -265,9 +266,10 @@ impl SlotDescriptor for PyGetSet {
 }
 
 impl PyGetSet {
-    pub fn new(name: String) -> Self {
+    pub fn new(name: String, class: PyTypeRef) -> Self {
         Self {
             name,
+            class,
             getter: None,
             setter: None,
             deleter: None,
@@ -353,6 +355,11 @@ impl PyGetSet {
     #[pyproperty(magic)]
     fn name(&self) -> String {
         self.name.clone()
+    }
+
+    #[pyproperty(magic)]
+    fn qualname(&self) -> String {
+        format!("{}.{}", self.class.tp_name(), self.name.clone())
     }
 }
 

--- a/vm/src/builtins/property.rs
+++ b/vm/src/builtins/property.rs
@@ -228,6 +228,11 @@ pub(crate) fn init(context: &PyContext) {
     // This is a bit unfortunate, but this instance attribute overlaps with the
     // class __doc__ string..
     extend_class!(context, &context.types.property_type, {
-        "__doc__" => context.new_getset("__doc__", PyProperty::doc_getter, PyProperty::doc_setter),
+        "__doc__" => context.new_getset(
+            "__doc__",
+            context.types.property_type.clone(),
+            PyProperty::doc_getter,
+            PyProperty::doc_setter,
+        ),
     });
 }

--- a/vm/src/builtins/pytype.rs
+++ b/vm/src/builtins/pytype.rs
@@ -445,8 +445,12 @@ impl PyType {
         if !attributes.contains_key("__dict__") {
             attributes.insert(
                 "__dict__".to_owned(),
-                vm.ctx
-                    .new_getset("__dict__", subtype_get_dict, subtype_set_dict),
+                vm.ctx.new_getset(
+                    "__dict__",
+                    vm.ctx.types.object_type.clone(),
+                    subtype_get_dict,
+                    subtype_set_dict,
+                ),
             );
         }
 

--- a/vm/src/exceptions.rs
+++ b/vm/src/exceptions.rs
@@ -653,7 +653,7 @@ impl ExceptionZoo {
         PyBaseException::extend_class(ctx, &excs.base_exception_type);
 
         extend_class!(ctx, &excs.syntax_error, {
-            "msg" => ctx.new_readonly_getset("msg", make_arg_getter(0)),
+            "msg" => ctx.new_readonly_getset("msg", excs.syntax_error.clone(), make_arg_getter(0)),
             // TODO: members
             "filename" => ctx.none(),
             "lineno" => ctx.none(),
@@ -662,27 +662,28 @@ impl ExceptionZoo {
         });
 
         extend_class!(ctx, &excs.system_exit, {
-            "code" => ctx.new_readonly_getset("code", system_exit_code),
+            "code" => ctx.new_readonly_getset("code", excs.system_exit.clone(), system_exit_code),
         });
 
         extend_class!(ctx, &excs.import_error, {
-            "__init__" => ctx.new_method("__init__", import_error_init, excs.import_error.clone()),
-            "msg" => ctx.new_readonly_getset("msg", make_arg_getter(0)),
+            "__init__" => ctx.new_method("__init__", excs.import_error.clone(), import_error_init),
+            "msg" => ctx.new_readonly_getset("msg", excs.import_error.clone(), make_arg_getter(0)),
         });
 
         extend_class!(ctx, &excs.stop_iteration, {
-            "value" => ctx.new_readonly_getset("value", make_arg_getter(0)),
+            "value" => ctx.new_readonly_getset("value", excs.stop_iteration.clone(), make_arg_getter(0)),
         });
 
         extend_class!(ctx, &excs.key_error, {
-            "__str__" => ctx.new_method("__str__", key_error_str, excs.key_error.clone()),
+            "__str__" => ctx.new_method("__str__", excs.key_error.clone(), key_error_str),
         });
 
-        let errno_getter = ctx.new_readonly_getset("errno", |exc: PyBaseExceptionRef| {
-            let args = exc.args();
-            let args = args.as_slice();
-            args.get(0).filter(|_| args.len() > 1).cloned()
-        });
+        let errno_getter =
+            ctx.new_readonly_getset("errno", excs.os_error.clone(), |exc: PyBaseExceptionRef| {
+                let args = exc.args();
+                let args = args.as_slice();
+                args.get(0).filter(|_| args.len() > 1).cloned()
+            });
         #[cfg(windows)]
         extend_class!(ctx, &excs.os_error, {
             // TODO: this isn't really accurate
@@ -690,31 +691,31 @@ impl ExceptionZoo {
         });
         extend_class!(ctx, &excs.os_error, {
             "errno" => errno_getter,
-            "strerror" => ctx.new_readonly_getset("strerror", make_arg_getter(1)),
+            "strerror" => ctx.new_readonly_getset("strerror", excs.os_error.clone(), make_arg_getter(1)),
         });
 
         extend_class!(ctx, &excs.unicode_decode_error, {
-            "encoding" => ctx.new_readonly_getset("encoding", make_arg_getter(0)),
-            "object" => ctx.new_readonly_getset("object", make_arg_getter(1)),
-            "start" => ctx.new_readonly_getset("start", make_arg_getter(2)),
-            "end" => ctx.new_readonly_getset("end", make_arg_getter(3)),
-            "reason" => ctx.new_readonly_getset("reason", make_arg_getter(4)),
+            "encoding" => ctx.new_readonly_getset("encoding", excs.unicode_decode_error.clone(), make_arg_getter(0)),
+            "object" => ctx.new_readonly_getset("object", excs.unicode_decode_error.clone(), make_arg_getter(1)),
+            "start" => ctx.new_readonly_getset("start", excs.unicode_decode_error.clone(), make_arg_getter(2)),
+            "end" => ctx.new_readonly_getset("end", excs.unicode_decode_error.clone(), make_arg_getter(3)),
+            "reason" => ctx.new_readonly_getset("reason", excs.unicode_decode_error.clone(), make_arg_getter(4)),
         });
 
         extend_class!(ctx, &excs.unicode_encode_error, {
-            "encoding" => ctx.new_readonly_getset("encoding", make_arg_getter(0)),
-            "object" => ctx.new_readonly_getset("object", make_arg_getter(1)),
-            "start" => ctx.new_readonly_getset("start", make_arg_getter(2)),
-            "end" => ctx.new_readonly_getset("end", make_arg_getter(3)),
-            "reason" => ctx.new_readonly_getset("reason", make_arg_getter(4)),
+            "encoding" => ctx.new_readonly_getset("encoding", excs.unicode_encode_error.clone(), make_arg_getter(0)),
+            "object" => ctx.new_readonly_getset("object", excs.unicode_encode_error.clone(), make_arg_getter(1)),
+            "start" => ctx.new_readonly_getset("start", excs.unicode_encode_error.clone(), make_arg_getter(2), ),
+            "end" => ctx.new_readonly_getset("end", excs.unicode_encode_error.clone(), make_arg_getter(3)),
+            "reason" => ctx.new_readonly_getset("reason", excs.unicode_encode_error.clone(), make_arg_getter(4)),
         });
 
         extend_class!(ctx, &excs.unicode_translate_error, {
-            "encoding" => ctx.new_readonly_getset("encoding", none_getter),
-            "object" => ctx.new_readonly_getset("object", make_arg_getter(0)),
-            "start" => ctx.new_readonly_getset("start", make_arg_getter(1)),
-            "end" => ctx.new_readonly_getset("end", make_arg_getter(2)),
-            "reason" => ctx.new_readonly_getset("reason", make_arg_getter(3)),
+            "encoding" => ctx.new_readonly_getset("encoding", excs.unicode_translate_error.clone(), none_getter),
+            "object" => ctx.new_readonly_getset("object", excs.unicode_translate_error.clone(), make_arg_getter(0)),
+            "start" => ctx.new_readonly_getset("start", excs.unicode_translate_error.clone(), make_arg_getter(1)),
+            "end" => ctx.new_readonly_getset("end", excs.unicode_translate_error.clone(), make_arg_getter(2)),
+            "reason" => ctx.new_readonly_getset("reason", excs.unicode_translate_error.clone(), make_arg_getter(3)),
         });
     }
 }

--- a/vm/src/stdlib/pyexpat.rs
+++ b/vm/src/stdlib/pyexpat.rs
@@ -18,9 +18,10 @@ pub fn make_module(vm: &VirtualMachine) -> PyObjectRef {
 }
 
 macro_rules! create_property {
-    ($ctx: expr, $attributes: expr, $name: expr, $element: ident) => {
+    ($ctx: expr, $attributes: expr, $name: expr, $class: expr, $element: ident) => {
         let attr = $ctx.new_getset(
             $name,
+            $class,
             move |this: &PyExpatLikeXmlParser| this.$element.read().clone(),
             move |this: &PyExpatLikeXmlParser, func: PyObjectRef| *this.$element.write() = func,
         );
@@ -88,11 +89,35 @@ mod _pyexpat {
         fn extend_class_with_fields(ctx: &PyContext, class: &PyTypeRef) {
             let mut attributes = class.attributes.write();
 
-            create_property!(ctx, attributes, "StartElementHandler", start_element);
-            create_property!(ctx, attributes, "EndElementHandler", end_element);
-            create_property!(ctx, attributes, "CharacterDataHandler", character_data);
-            create_property!(ctx, attributes, "EntityDeclHandler", entity_decl);
-            create_property!(ctx, attributes, "buffer_text", buffer_text);
+            create_property!(
+                ctx,
+                attributes,
+                "StartElementHandler",
+                class.clone(),
+                start_element
+            );
+            create_property!(
+                ctx,
+                attributes,
+                "EndElementHandler",
+                class.clone(),
+                end_element
+            );
+            create_property!(
+                ctx,
+                attributes,
+                "CharacterDataHandler",
+                class.clone(),
+                character_data
+            );
+            create_property!(
+                ctx,
+                attributes,
+                "EntityDeclHandler",
+                class.clone(),
+                entity_decl
+            );
+            create_property!(ctx, attributes, "buffer_text", class.clone(), buffer_text);
         }
 
         fn create_config(&self) -> xml::ParserConfig {

--- a/wasm/lib/src/js_module.rs
+++ b/wasm/lib/src/js_module.rs
@@ -620,7 +620,7 @@ pub fn make_module(vm: &VirtualMachine) -> PyObjectRef {
 
     let js_error = create_simple_type("JSError", &ctx.exceptions.exception_type);
     extend_class!(ctx, &js_error, {
-        "value" => ctx.new_readonly_getset("value", |exc: PyBaseExceptionRef| exc.get_arg(0)),
+        "value" => ctx.new_readonly_getset("value", js_error.clone(), |exc: PyBaseExceptionRef| exc.get_arg(0)),
     });
 
     AwaitPromise::make_class(ctx);

--- a/wasm/lib/src/wasm_builtins.rs
+++ b/wasm/lib/src/wasm_builtins.rs
@@ -29,12 +29,12 @@ pub fn make_stdout_object(
     let cls = py_class!(ctx, "JSStdout", &vm.ctx.types.object_type, {});
     let write_method = ctx.new_method(
         "write",
+        cls.clone(),
         move |_self: PyObjectRef, data: PyStrRef, vm: &VirtualMachine| -> PyResult<()> {
             write_f(data.as_str(), vm)
         },
-        cls.clone(),
     );
-    let flush_method = ctx.new_method("flush", |_self: PyObjectRef| {}, cls.clone());
+    let flush_method = ctx.new_method("flush", cls.clone(), |_self: PyObjectRef| {});
     extend_class!(ctx, cls, {
         "write" => write_method,
         "flush" => flush_method,


### PR DESCRIPTION
In the next PR I will also fix the `repr` of `getset` as well.

Changes:
- New `class` field on `PyGetSet`
- New arguments to `new_getset` and `new_readonly_getset`
- Fixed how `derive` is constructing types
- Fixes all `.new_getset` and `.new_readonly_getset` calls
- Also fixes recent `class` argument order in `new_method` from #2770 to be consistent: name, class, functions

CPython impl: https://github.com/python/cpython/blob/635bfe8162981332b36cc556bac78e869af579c2/Objects/descrobject.c#L572-L599

Closes #2790