### PR TITLE
implement Unhashable for collections.deque

### DIFF
--- a/Lib/test/test_deque.py
+++ b/Lib/test/test_deque.py
@@ -590,8 +590,6 @@ class TestBasic(unittest.TestCase):
         self.assertRaises(TypeError, deque, 'abc', 2, 3);
         self.assertRaises(TypeError, deque, 1);
 
-    # TODO: RUSTPYTHON
-    @unittest.expectedFailure
     def test_hash(self):
         self.assertRaises(TypeError, hash, deque('abc'))
 

--- a/vm/src/stdlib/collections.rs
+++ b/vm/src/stdlib/collections.rs
@@ -5,7 +5,7 @@ mod _collections {
     use crate::builtins::pytype::PyTypeRef;
     use crate::common::lock::{PyRwLock, PyRwLockReadGuard, PyRwLockWriteGuard};
     use crate::function::OptionalArg;
-    use crate::slots::{Comparable, Iterable, PyComparisonOp, PyIter};
+    use crate::slots::{Comparable, Hashable, Iterable, PyComparisonOp, PyIter, Unhashable};
     use crate::vm::ReprGuard;
     use crate::VirtualMachine;
     use crate::{sequence, sliceable};
@@ -64,7 +64,7 @@ mod _collections {
         }
     }
 
-    #[pyimpl(flags(BASETYPE), with(Comparable, Iterable))]
+    #[pyimpl(flags(BASETYPE), with(Comparable, Hashable, Iterable))]
     impl PyDeque {
         #[pyslot]
         fn tp_new(
@@ -339,6 +339,8 @@ mod _collections {
                 .map(PyComparisonValue::Implemented)
         }
     }
+
+    impl Unhashable for PyDeque {}
 
     impl Iterable for PyDeque {
         fn iter(zelf: PyRef<Self>, vm: &VirtualMachine) -> PyResult {


### PR DESCRIPTION
Closes #2813.

I am assuming that the way this trait is structured (the struct must implement `Hashable`, which is then overruled by the implementation of `Unhashable`) is required by how Rust checks for trait implementations? Like the hash function wouldn't work otherwise.