### PR TITLE
typo in slots.rs: SlotDesctuctor -> SlotDestructor

### DIFF
--- a/vm/src/slots.rs
+++ b/vm/src/slots.rs
@@ -99,7 +99,7 @@ impl std::fmt::Debug for PyTypeSlots {
 }
 
 #[pyimpl]
-pub trait SlotDesctuctor: PyValue {
+pub trait SlotDestructor: PyValue {
     #[pyslot]
     fn tp_del(zelf: &PyObjectRef, vm: &VirtualMachine) -> PyResult<()> {
         if let Some(zelf) = zelf.downcast_ref() {


### PR DESCRIPTION
Noticed this while working on #2814. Doesn't appear this trait is used anywhere yet (`rg Desctuctor` returned nothing else in the repo), so it was a simple fix.