### PR TITLE
Add __index__ operator overriding class support for SequenceIndex

### DIFF
--- a/Lib/test/test_index.py
+++ b/Lib/test/test_index.py
@@ -101,8 +101,6 @@ class SeqTestCase:
         self.o2 = newstyle()
         self.n2 = newstyle()
 
-    # TODO: RUSTPYTHON
-    @unittest.expectedFailure
     def test_index(self):
         self.o.ind = -2
         self.n.ind = 2
@@ -140,8 +138,6 @@ class SeqTestCase:
         self.assertEqual(self.o * self.seq, self.seq * 3)
         self.assertEqual(self.n * self.seq, self.seq * 2)
 
-    # TODO: RUSTPYTHON
-    @unittest.expectedFailure
     def test_wrappers(self):
         self.o.ind = 4
         self.n.ind = 5
@@ -169,8 +165,6 @@ class SeqTestCase:
 class ListTestCase(SeqTestCase, unittest.TestCase):
     seq = [0,10,20,30,40,50]
 
-    # TODO: RUSTPYTHON
-    @unittest.expectedFailure
     def test_setdelitem(self):
         self.o.ind = -2
         self.n.ind = 2

--- a/vm/src/sliceable.rs
+++ b/vm/src/sliceable.rs
@@ -349,11 +349,21 @@ impl SequenceIndex {
                 .ok_or_else(|| vm
                     .new_index_error("cannot fit 'int' into an index-sized integer".to_owned())),
             s @ PySlice => Ok(SequenceIndex::Slice(s)),
-            obj => Err(vm.new_type_error(format!(
-                "{} indices must be integers or slices, not {}",
-                owner_type,
-                obj.class().name,
-            ))),
+            obj => {
+                let val = vm.to_index(&obj).map_err(|_| vm.new_type_error(format!(
+                    "{} indices must be integers or slices or classes that override __index__ operator, not '{}'",
+                    owner_type,
+                    obj.class().name
+                )))?;
+                val.as_bigint()
+                    .to_isize()
+                    .map(SequenceIndex::Int)
+                    .ok_or_else(|| {
+                        vm.new_index_error(
+                            "cannot fit 'int' into an index-sized integer".to_owned(),
+                        )
+                    })
+            }
         })
     }
 }

--- a/vm/src/sliceable.rs
+++ b/vm/src/sliceable.rs
@@ -341,30 +341,21 @@ impl SequenceIndex {
         obj: PyObjectRef,
         owner_type: &'static str,
     ) -> PyResult<Self> {
-        match_class!(match obj {
-            i @ PyInt => i
-                .as_bigint()
-                .to_isize()
-                .map(SequenceIndex::Int)
-                .ok_or_else(|| vm
-                    .new_index_error("cannot fit 'int' into an index-sized integer".to_owned())),
-            s @ PySlice => Ok(SequenceIndex::Slice(s)),
+        let idx = match_class!(match obj {
+            i @ PyInt => i.as_bigint().to_isize(),
+            s @ PySlice => return Ok(SequenceIndex::Slice(s)),
             obj => {
                 let val = vm.to_index(&obj).map_err(|_| vm.new_type_error(format!(
                     "{} indices must be integers or slices or classes that override __index__ operator, not '{}'",
                     owner_type,
                     obj.class().name
                 )))?;
-                val.as_bigint()
-                    .to_isize()
-                    .map(SequenceIndex::Int)
-                    .ok_or_else(|| {
-                        vm.new_index_error(
-                            "cannot fit 'int' into an index-sized integer".to_owned(),
-                        )
-                    })
+                val.as_bigint().to_isize()
             }
-        })
+        }).ok_or_else(|| {
+            vm.new_index_error("cannot fit 'int' into an index-sized integer".to_owned())
+        })?;
+        Ok(SequenceIndex::Int(idx))
     }
 }
 


### PR DESCRIPTION
This revision fix three test cases in [test_index.py](https://github.com/RustPython/RustPython/blob/master/Lib/test/test_index.py)
* `SeqTestCase.test_index`
* `SeqTestCase.test_wrappers`
* `ListTestCase.test_setdelitem`

All these three cases' failures were caused by not supporting classes
that override `__index__` operator when indexing sequence type.

This commit implement almost same routine with PR(#2807) which also did not
support classes that override `__index__` operator in range indexing.