### PR TITLE
Add `math_perm` method

### DIFF
--- a/Lib/test/test_math.py
+++ b/Lib/test/test_math.py
@@ -1814,8 +1814,6 @@ class MathTests(unittest.TestCase):
         self.assertEqual(type(prod([1, decimal.Decimal(2.0), 3, 4, 5, 6])),
                          decimal.Decimal)
 
-    # TODO: RUSTPYTHON
-    @unittest.expectedFailure
     def testPerm(self):
         perm = math.perm
         factorial = math.factorial
@@ -1839,7 +1837,7 @@ class MathTests(unittest.TestCase):
         # Test one argument form
         for n in range(20):
             self.assertEqual(perm(n), factorial(n))
-            self.assertEqual(perm(n, None), factorial(n))
+            # self.assertEqual(perm(n, None), factorial(n)) # TODO: RUSTPYTHON
 
         # Raises TypeError if any argument is non-integer or argument count is
         # not 1 or 2

--- a/Lib/test/test_math.py
+++ b/Lib/test/test_math.py
@@ -1837,7 +1837,7 @@ class MathTests(unittest.TestCase):
         # Test one argument form
         for n in range(20):
             self.assertEqual(perm(n), factorial(n))
-            # self.assertEqual(perm(n, None), factorial(n)) # TODO: RUSTPYTHON
+            self.assertEqual(perm(n, None), factorial(n))
 
         # Raises TypeError if any argument is non-integer or argument count is
         # not 1 or 2

--- a/vm/src/stdlib/math.rs
+++ b/vm/src/stdlib/math.rs
@@ -516,12 +516,13 @@ fn math_perm(
     vm: &VirtualMachine,
 ) -> PyResult<BigInt> {
     let n = n.as_bigint();
-    let v: BigInt = match k {
-        OptionalArg::Missing => n.clone(),
-        OptionalArg::Present(x) => match x {
-            Some(xi) => xi.as_bigint().clone(),
-            None => n.clone(),
-        },
+    let k_ref;
+    let v = match k.flatten() {
+        Some(k) => {
+            k_ref = k;
+            k_ref.as_bigint()
+        }
+        None => n,
     };
 
     if n.is_negative() || v.is_negative() {

--- a/vm/src/stdlib/math.rs
+++ b/vm/src/stdlib/math.rs
@@ -510,11 +510,18 @@ fn math_factorial(value: PyIntRef, vm: &VirtualMachine) -> PyResult<BigInt> {
     Ok(product)
 }
 
-fn math_perm(n: PyIntRef, k: OptionalArg<PyIntRef>, vm: &VirtualMachine) -> PyResult<BigInt> {
+fn math_perm(
+    n: PyIntRef,
+    k: OptionalArg<Option<PyIntRef>>,
+    vm: &VirtualMachine,
+) -> PyResult<BigInt> {
     let n = n.as_bigint();
     let v: BigInt = match k {
         OptionalArg::Missing => n.clone(),
-        OptionalArg::Present(x) => x.as_bigint().clone(),
+        OptionalArg::Present(x) => match x {
+            Some(xi) => xi.as_bigint().clone(),
+            None => n.clone(),
+        },
     };
 
     if n.is_negative() || v.is_negative() {

--- a/vm/src/stdlib/math.rs
+++ b/vm/src/stdlib/math.rs
@@ -528,12 +528,12 @@ fn math_perm(
     if n.is_negative() || v.is_negative() {
         return Err(vm.new_value_error("perm() not defined for negative values".to_owned()));
     }
-    if &v > n {
+    if v > n {
         return Ok(BigInt::zero());
     }
     let mut result = BigInt::one();
     let mut current = n.clone();
-    let tmp = n - &v;
+    let tmp = n - v;
     while current > tmp {
         result *= &current;
         current -= 1;

--- a/vm/src/stdlib/math.rs
+++ b/vm/src/stdlib/math.rs
@@ -510,6 +510,29 @@ fn math_factorial(value: PyIntRef, vm: &VirtualMachine) -> PyResult<BigInt> {
     Ok(product)
 }
 
+fn math_perm(n: PyIntRef, k: OptionalArg<PyIntRef>, vm: &VirtualMachine) -> PyResult<BigInt> {
+    let n = n.as_bigint();
+    let v: BigInt = match k {
+        OptionalArg::Missing => n.clone(),
+        OptionalArg::Present(x) => x.as_bigint().clone(),
+    };
+
+    if n.is_negative() || v.is_negative() {
+        return Err(vm.new_value_error("perm() not defined for negative values".to_owned()));
+    }
+    if &v > n {
+        return Ok(BigInt::zero());
+    }
+    let mut result = BigInt::one();
+    let mut current = n.clone();
+    let tmp = n - &v;
+    while current > tmp {
+        result *= &current;
+        current -= 1;
+    }
+    Ok(result)
+}
+
 fn math_comb(n: PyIntRef, k: PyIntRef, vm: &VirtualMachine) -> PyResult<BigInt> {
     let mut k = k.as_bigint();
     let n = n.as_bigint();
@@ -694,6 +717,9 @@ pub fn make_module(vm: &VirtualMachine) -> PyObjectRef {
 
         // Factorial function
         "factorial" => named_function!(ctx, math, factorial),
+
+        // Permutation function
+        "perm" => named_function!(ctx, math, perm),
 
         // Combination function
         "comb" => named_function!(ctx, math, comb),


### PR DESCRIPTION
Added `math_perm` method.

Unfortunately, test only fails when `k` is `None`.