### PR TITLE
Adds `__subclasshook__` to `type`

### DIFF
--- a/extra_tests/snippets/builtin_type.py
+++ b/extra_tests/snippets/builtin_type.py
@@ -151,3 +151,10 @@ assert BaseException.args.__qualname__ == 'BaseException.args'
 assert Exception.args.__qualname__ == 'BaseException.args'
 # dynamic with `.new_readonly_getset`
 assert SyntaxError.msg.__qualname__ == 'SyntaxError.msg'
+
+
+# Regression to
+# https://github.com/RustPython/RustPython/issues/2794
+
+assert type.__subclasshook__.__qualname__ == 'type.__subclasshook__'
+assert object.__subclasshook__.__qualname__ == 'object.__subclasshook__'

--- a/vm/src/builtins/pytype.rs
+++ b/vm/src/builtins/pytype.rs
@@ -290,6 +290,11 @@ impl PyType {
         subclass.issubclass(&zelf)
     }
 
+    #[pyclassmethod(magic)]
+    fn subclasshook(_args: FuncArgs, vm: &VirtualMachine) -> PyObjectRef {
+        vm.ctx.not_implemented()
+    }
+
     #[pyproperty(magic)]
     fn name(&self) -> String {
         self.name.clone()


### PR DESCRIPTION
Implementation now matches CPython: https://github.com/python/cpython/blob/cee67fa66129b5d1db5c8aa3884338f82f0da3de/Objects/typeobject.c#L5380-L5384

Closes #2794