### PR TITLE
Add missing `__annotations__`  variable into main module

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -520,6 +520,17 @@ fn write_profile(matches: &ArgMatches) -> Result<(), Box<dyn std::error::Error>>
 fn run_rustpython(vm: &VirtualMachine, matches: &ArgMatches) -> PyResult<()> {
     let scope = vm.new_scope_with_builtins();
     let main_module = vm.new_module("__main__", scope.globals.clone());
+    let ann_dict = vm.ctx.new_dict();
+    let main_module_dict = main_module.dict();
+
+    if main_module_dict.is_none()
+        || main_module_dict
+            .unwrap()
+            .set_item("__annotations__", ann_dict.as_object().to_owned(), vm)
+            .is_err()
+    {
+        error!("Failed to initialize __main__.__annotations__")
+    }
 
     vm.get_attribute(vm.sys_module.clone(), "modules")?
         .set_item("__main__", main_module, vm)?;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -520,17 +520,17 @@ fn write_profile(matches: &ArgMatches) -> Result<(), Box<dyn std::error::Error>>
 fn run_rustpython(vm: &VirtualMachine, matches: &ArgMatches) -> PyResult<()> {
     let scope = vm.new_scope_with_builtins();
     let main_module = vm.new_module("__main__", scope.globals.clone());
-    let ann_dict = vm.ctx.new_dict();
-    let main_module_dict = main_module.dict();
-
-    if main_module_dict.is_none()
-        || main_module_dict
-            .unwrap()
-            .set_item("__annotations__", ann_dict.as_object().to_owned(), vm)
-            .is_err()
-    {
-        error!("Failed to initialize __main__.__annotations__")
-    }
+    main_module
+        .dict()
+        .and_then(|d| {
+            d.set_item(
+                "__annotations__",
+                vm.ctx.new_dict().as_object().to_owned(),
+                vm,
+            )
+            .ok()
+        })
+        .expect("Failed to initialize __main__.__annotations__");
 
     vm.get_attribute(vm.sys_module.clone(), "modules")?
         .set_item("__main__", main_module, vm)?;


### PR DESCRIPTION
This pull request resolves #2822.

For testing, please see #2822 's testcases. 🙏🏻 

I tried to code like [CPython `add_main_module` does](https://github.com/python/cpython/blob/fa919fdf2583bdfead1df00e842f24f30b2a34bf/Python/pylifecycle.c#L1612-L1658).