### PR TITLE
Use rustpython_common via public name.

### DIFF
--- a/derive/src/pyclass.rs
+++ b/derive/src/pyclass.rs
@@ -204,8 +204,8 @@ fn generate_class_def(
         }
 
         impl ::rustpython_vm::StaticType for #ident {
-            fn static_cell() -> &'static ::rustpython_common::static_cell::StaticCell<::rustpython_vm::builtins::PyTypeRef> {
-                ::rustpython_common::static_cell! {
+            fn static_cell() -> &'static ::rustpython_vm::common::static_cell::StaticCell<::rustpython_vm::builtins::PyTypeRef> {
+                ::rustpython_vm::common::static_cell! {
                     static CELL: ::rustpython_vm::builtins::PyTypeRef;
                 }
                 &CELL


### PR DESCRIPTION
Using `rustpython_common` results in lookup errors in `pymodule/pyclass` macros when using rustpython as a dependency. 