### PR TITLE
Fixes that `id()` of `tuple` was changing on `* 1`

### DIFF
--- a/Lib/test/seq_tests.py
+++ b/Lib/test/seq_tests.py
@@ -311,8 +311,6 @@ class CommonTest(unittest.TestCase):
                 return str(key) + '!!!'
         self.assertEqual(next(iter(T((1,2)))), 1)
 
-    # TODO: RUSTPYTHON
-    @unittest.expectedFailure
     def test_repeat(self):
         for m in range(4):
             s = tuple(range(m))

--- a/vm/src/builtins/tuple.rs
+++ b/vm/src/builtins/tuple.rs
@@ -172,7 +172,7 @@ impl PyTuple {
     fn mul(zelf: PyRef<Self>, counter: isize, vm: &VirtualMachine) -> PyRef<Self> {
         if zelf.elements.is_empty() || counter == 0 {
             vm.ctx.empty_tuple.clone()
-        } else if counter == 1 && zelf.clone_class().is(PyTuple::class(vm)) {
+        } else if counter == 1 && zelf.class().is(&vm.ctx.types.tuple_type) {
             // Special case: when some `tuple` is multiplied by `1`,
             // nothing really happens, we need to return an object itself
             // with the same `id()` to be compatible with CPython.

--- a/vm/src/builtins/tuple.rs
+++ b/vm/src/builtins/tuple.rs
@@ -169,11 +169,17 @@ impl PyTuple {
 
     #[pymethod(name = "__mul__")]
     #[pymethod(name = "__rmul__")]
-    fn mul(&self, counter: isize, vm: &VirtualMachine) -> PyRef<Self> {
-        if self.elements.is_empty() || counter == 0 {
+    fn mul(zelf: PyRef<Self>, counter: isize, vm: &VirtualMachine) -> PyRef<Self> {
+        if zelf.elements.is_empty() || counter == 0 {
             vm.ctx.empty_tuple.clone()
+        } else if counter == 1 && zelf.clone_class().is(PyTuple::class(vm)) {
+            // Special case: when some `tuple` is multiplied by `1`,
+            // nothing really happens, we need to return an object itself
+            // with the same `id()` to be compatible with CPython.
+            // This only works for `tuple` itself, not its subclasses.
+            zelf
         } else {
-            let elements = sequence::seq_mul(&self.elements, counter)
+            let elements = sequence::seq_mul(&zelf.elements, counter)
                 .cloned()
                 .collect::<Vec<_>>()
                 .into_boxed_slice();


### PR DESCRIPTION
Refs #2840

Reference: https://github.com/python/cpython/blob/c0ab59f7de1906feee21c057ad433fad924d1e38/Objects/tupleobject.c#L560-L567