### PR TITLE
Adds `__rmul__` to `collections.deque`

### DIFF
--- a/Lib/test/test_deque.py
+++ b/Lib/test/test_deque.py
@@ -355,8 +355,6 @@ class TestBasic(unittest.TestCase):
             else:
                 self.assertEqual(d[i-1], 'Z')
 
-    # TODO: RUSTPYTHON
-    @unittest.expectedFailure
     def test_imul(self):
         for n in (-10, -1, 0, 1, 2, 10, 1000):
             d = deque()

--- a/Lib/test/test_deque.py
+++ b/Lib/test/test_deque.py
@@ -388,8 +388,6 @@ class TestBasic(unittest.TestCase):
             self.assertEqual(d, deque(('abcdef' * n)[-500:]))
             self.assertEqual(d.maxlen, 500)
 
-    # TODO: RUSTPYTHON
-    @unittest.expectedFailure
     def test_mul(self):
         d = deque('abc')
         self.assertEqual(d * -5, deque())
@@ -1003,11 +1001,11 @@ class TestSequence(seq_tests.CommonTest):
     def test_free_after_iterating(self):
         # For now, bypass tests that require slicing
         self.skipTest("Exhausted deque iterator doesn't free a deque")
-    
+
     @unittest.skip("TODO: RUSTPYTHON TypeError: unexpected payload for __eq__")
     def test_pickle(self):
         pass
-        
+
     def test_iadd(self):
         pass
 

--- a/vm/src/stdlib/collections.rs
+++ b/vm/src/stdlib/collections.rs
@@ -307,10 +307,10 @@ mod _collections {
         fn mul(&self, n: isize) -> Self {
             let deque: SimpleSeqDeque = self.borrow_deque().into();
             let mul = sequence::seq_mul(&deque, n);
-            let skipped = if let Some(maxlen) = self.maxlen.load() {
-                mul.len() - maxlen
-            } else {
-                0
+            let mul_len = mul.len();
+            let skipped = match self.maxlen.load() {
+                Some(maxlen) if mul_len > maxlen => mul_len - maxlen,
+                _ => 0,
             };
             let deque = mul.skip(skipped).cloned().collect();
             PyDeque {

--- a/vm/src/stdlib/collections.rs
+++ b/vm/src/stdlib/collections.rs
@@ -303,6 +303,7 @@ mod _collections {
         }
 
         #[pymethod(magic)]
+        #[pymethod(name = "__rmul__")]
         fn mul(&self, n: isize) -> Self {
             let deque: SimpleSeqDeque = self.borrow_deque().into();
             let mul = sequence::seq_mul(&deque, n);

--- a/vm/src/stdlib/collections.rs
+++ b/vm/src/stdlib/collections.rs
@@ -307,11 +307,11 @@ mod _collections {
         fn mul(&self, n: isize) -> Self {
             let deque: SimpleSeqDeque = self.borrow_deque().into();
             let mul = sequence::seq_mul(&deque, n);
-            let mul_len = mul.len();
-            let skipped = match self.maxlen.load() {
-                Some(maxlen) if mul_len > maxlen => mul_len - maxlen,
-                _ => 0,
-            };
+            let skipped = self
+                .maxlen
+                .load()
+                .map(|maxlen| mul.len().wrapping_sub(maxlen))
+                .unwrap_or(0);
             let deque = mul.skip(skipped).cloned().collect();
             PyDeque {
                 deque: PyRwLock::new(deque),

--- a/vm/src/stdlib/collections.rs
+++ b/vm/src/stdlib/collections.rs
@@ -310,8 +310,9 @@ mod _collections {
             let skipped = self
                 .maxlen
                 .load()
-                .map(|maxlen| mul.len().wrapping_sub(maxlen))
+                .and_then(|maxlen| mul.len().checked_sub(maxlen))
                 .unwrap_or(0);
+
             let deque = mul.skip(skipped).cloned().collect();
             PyDeque {
                 deque: PyRwLock::new(deque),


### PR DESCRIPTION
Closes #2834

Note: at the moment almost all collections are missing `MemoryError` corner case, like here: https://github.com/python/cpython/blob/d1ae57027fc39ff60dcfc1b63881400e5ca3ce56/Modules/_collectionsmodule.c#L709-L711

I guess that this is out of scope of this task, related:
- https://github.com/RustPython/RustPython/issues/1750
- https://github.com/RustPython/RustPython/pull/1779

I think that some tests in `test_deque` might hang because of that.