### PR TITLE
Refactor Buffer Protocol (mostly namings)

### DIFF
--- a/derive/src/pyclass.rs
+++ b/derive/src/pyclass.rs
@@ -395,7 +395,8 @@ where
                     Self::#ident as _
                 }
             };
-            if slot_name == "new" || slot_name == "buffer" {
+            const NON_ATOMIC_SLOTS: &[&str] = &["new", "as_buffer"];
+            if NON_ATOMIC_SLOTS.contains(&slot_name.as_str()) {
                 quote! {
                     slots.#slot_ident = Some(#into_func);
                 }

--- a/vm/src/builtins/bytearray.rs
+++ b/vm/src/builtins/bytearray.rs
@@ -2,7 +2,7 @@
 use super::bytes::{PyBytes, PyBytesRef};
 use super::dict::PyDictRef;
 use super::int::PyIntRef;
-use super::memory::{Buffer, BufferOptions, ResizeGuard};
+use super::memory::{BufferOptions, PyBuffer, ResizeGuard};
 use super::pystr::PyStrRef;
 use super::pytype::PyTypeRef;
 use super::tuple::PyTupleRef;
@@ -668,7 +668,7 @@ impl Comparable for PyByteArray {
 }
 
 impl BufferProtocol for PyByteArray {
-    fn get_buffer(zelf: &PyRef<Self>, _vm: &VirtualMachine) -> PyResult<Box<dyn Buffer>> {
+    fn get_buffer(zelf: &PyRef<Self>, _vm: &VirtualMachine) -> PyResult<Box<dyn PyBuffer>> {
         zelf.exports.fetch_add(1);
         let buf = ByteArrayBuffer {
             bytearray: zelf.clone(),
@@ -688,7 +688,7 @@ struct ByteArrayBuffer {
     options: BufferOptions,
 }
 
-impl Buffer for ByteArrayBuffer {
+impl PyBuffer for ByteArrayBuffer {
     fn obj_bytes(&self) -> BorrowedValue<[u8]> {
         self.bytearray.borrow_buf().into()
     }

--- a/vm/src/builtins/bytes.rs
+++ b/vm/src/builtins/bytes.rs
@@ -25,7 +25,7 @@ use crate::{
     PyResult, PyValue, TryFromObject, TypeProtocol,
 };
 
-use crate::builtins::memory::{Buffer, BufferOptions};
+use crate::builtins::memory::{BufferOptions, PyBuffer};
 
 /// "bytes(iterable_of_ints) -> bytes\n\
 /// bytes(string, encoding[, errors]) -> bytes\n\
@@ -495,7 +495,7 @@ impl PyBytes {
 }
 
 impl BufferProtocol for PyBytes {
-    fn get_buffer(zelf: &PyRef<Self>, _vm: &VirtualMachine) -> PyResult<Box<dyn Buffer>> {
+    fn get_buffer(zelf: &PyRef<Self>, _vm: &VirtualMachine) -> PyResult<Box<dyn PyBuffer>> {
         let buf = BytesBuffer {
             bytes: zelf.clone(),
             options: BufferOptions {
@@ -513,7 +513,7 @@ struct BytesBuffer {
     options: BufferOptions,
 }
 
-impl Buffer for BytesBuffer {
+impl PyBuffer for BytesBuffer {
     fn obj_bytes(&self) -> BorrowedValue<[u8]> {
         self.bytes.as_bytes().into()
     }

--- a/vm/src/builtins/memory.rs
+++ b/vm/src/builtins/memory.rs
@@ -15,50 +15,67 @@ use crate::sliceable::{convert_slice, saturate_range, wrap_index, SequenceIndex}
 use crate::slots::{BufferProtocol, Comparable, Hashable, PyComparisonOp};
 use crate::stdlib::pystruct::_struct::FormatSpec;
 use crate::utils::Either;
-use crate::VirtualMachine;
 use crate::{
     IdProtocol, IntoPyObject, PyClassImpl, PyComparisonValue, PyContext, PyObjectRef, PyRef,
     PyResult, PyThreadingConstraint, PyValue, TypeProtocol,
 };
+use crate::{TryFromObject, VirtualMachine};
 use crossbeam_utils::atomic::AtomicCell;
 use itertools::Itertools;
 use num_bigint::BigInt;
 use num_traits::{One, Signed, ToPrimitive, Zero};
 
 #[derive(Debug)]
-pub struct BufferRef(Box<dyn Buffer>);
-impl Drop for BufferRef {
+pub struct PyBufferRef(Box<dyn PyBuffer>);
+
+impl TryFromObject for PyBufferRef {
+    // FIXME: `obj: &PyObjectRef` is enough
+    fn try_from_object(vm: &VirtualMachine, obj: PyObjectRef) -> PyResult<Self> {
+        let obj_cls = obj.class();
+        for cls in obj_cls.iter_mro() {
+            if let Some(f) = cls.slots.as_buffer.as_ref() {
+                return f(&obj, vm).map(|x| PyBufferRef(x));
+            }
+        }
+        Err(vm.new_type_error(format!(
+            "a bytes-like object is required, not '{}'",
+            obj_cls.name
+        )))
+    }
+}
+
+impl Drop for PyBufferRef {
     fn drop(&mut self) {
         self.0.release();
     }
 }
-impl Deref for BufferRef {
-    type Target = dyn Buffer;
+impl Deref for PyBufferRef {
+    type Target = dyn PyBuffer;
 
     fn deref(&self) -> &Self::Target {
         self.0.deref()
     }
 }
-impl BufferRef {
-    pub fn new(buffer: impl Buffer + 'static) -> Self {
+impl PyBufferRef {
+    pub fn new(buffer: impl PyBuffer + 'static) -> Self {
         Self(Box::new(buffer))
     }
     pub fn into_rcbuf(self) -> RcBuffer {
-        // move self.0 out of self; BufferRef impls Drop so it's tricky
+        // move self.0 out of self; PyBufferRef impls Drop so it's tricky
         let this = std::mem::ManuallyDrop::new(self);
         let buf_box = unsafe { std::ptr::read(&this.0) };
         RcBuffer(buf_box.into())
     }
 }
-impl From<Box<dyn Buffer>> for BufferRef {
-    fn from(buffer: Box<dyn Buffer>) -> Self {
-        BufferRef(buffer)
+impl From<Box<dyn PyBuffer>> for PyBufferRef {
+    fn from(buffer: Box<dyn PyBuffer>) -> Self {
+        PyBufferRef(buffer)
     }
 }
 #[derive(Debug, Clone)]
-pub struct RcBuffer(PyRc<dyn Buffer>);
+pub struct RcBuffer(PyRc<dyn PyBuffer>);
 impl Deref for RcBuffer {
-    type Target = dyn Buffer;
+    type Target = dyn PyBuffer;
     fn deref(&self) -> &Self::Target {
         self.0.deref()
     }
@@ -71,7 +88,7 @@ impl Drop for RcBuffer {
         }
     }
 }
-impl Buffer for RcBuffer {
+impl PyBuffer for RcBuffer {
     fn get_options(&self) -> &BufferOptions {
         self.0.get_options()
     }
@@ -93,7 +110,7 @@ impl Buffer for RcBuffer {
     }
 }
 
-pub trait Buffer: Debug + PyThreadingConstraint {
+pub trait PyBuffer: Debug + PyThreadingConstraint {
     fn get_options(&self) -> &BufferOptions;
     /// Get the full inner buffer of this memory. You probably want [`as_contiguous()`], as
     /// `obj_bytes` doesn't take into account the range a memoryview might operate on, among other
@@ -171,7 +188,7 @@ struct PyMemoryViewNewArgs {
 #[derive(Debug)]
 pub struct PyMemoryView {
     obj: PyObjectRef,
-    buffer: BufferRef,
+    buffer: PyBufferRef,
     options: BufferOptions,
     pub(crate) released: AtomicCell<bool>,
     // start should always less or equal to the stop
@@ -195,7 +212,11 @@ impl PyMemoryView {
             .map_err(|msg| vm.new_exception_msg(vm.ctx.types.memoryview_type.clone(), msg))
     }
 
-    pub fn from_buffer(obj: PyObjectRef, buffer: BufferRef, vm: &VirtualMachine) -> PyResult<Self> {
+    pub fn from_buffer(
+        obj: PyObjectRef,
+        buffer: PyBufferRef,
+        vm: &VirtualMachine,
+    ) -> PyResult<Self> {
         // when we get a buffer means the buffered object is size locked
         // so we can assume the buffer's options will never change as long
         // as memoryview is still alive
@@ -219,7 +240,7 @@ impl PyMemoryView {
 
     pub fn from_buffer_range(
         obj: PyObjectRef,
-        buffer: BufferRef,
+        buffer: PyBufferRef,
         range: std::ops::Range<usize>,
         vm: &VirtualMachine,
     ) -> PyResult<Self> {
@@ -256,7 +277,7 @@ impl PyMemoryView {
         args: PyMemoryViewNewArgs,
         vm: &VirtualMachine,
     ) -> PyResult<PyRef<Self>> {
-        let buffer = try_buffer_from_object(vm, &args.object)?;
+        let buffer = PyBufferRef::try_from_object(vm, args.object.clone())?;
         let zelf = PyMemoryView::from_buffer(args.object, buffer, vm)?;
         zelf.into_ref_with_type(vm, cls)
     }
@@ -373,7 +394,7 @@ impl PyMemoryView {
         let itemsize = zelf.options.itemsize;
 
         let obj = zelf.obj.clone();
-        let buffer = BufferRef(Box::new(zelf.clone()));
+        let buffer = PyBufferRef(Box::new(zelf.clone()));
         zelf.exports.fetch_add(1);
         let options = zelf.options.clone();
         let format_spec = zelf.format_spec.clone();
@@ -517,7 +538,7 @@ impl PyMemoryView {
         items: PyObjectRef,
         vm: &VirtualMachine,
     ) -> PyResult<()> {
-        let items = try_buffer_from_object(vm, &items)?;
+        let items = PyBufferRef::try_from_object(vm, items)?;
         let options = items.get_options();
         let len = options.len;
         let itemsize = options.itemsize;
@@ -660,7 +681,7 @@ impl PyMemoryView {
     #[pymethod]
     fn toreadonly(zelf: PyRef<Self>, vm: &VirtualMachine) -> PyResult<PyRef<Self>> {
         zelf.try_not_released(vm)?;
-        let buffer = BufferRef(Box::new(zelf.clone()));
+        let buffer = PyBufferRef(Box::new(zelf.clone()));
         zelf.exports.fetch_add(1);
         Ok(PyMemoryView {
             obj: zelf.obj.clone(),
@@ -731,7 +752,7 @@ impl PyMemoryView {
             );
         }
 
-        let buffer = BufferRef(Box::new(zelf.clone()));
+        let buffer = PyBufferRef(Box::new(zelf.clone()));
         zelf.exports.fetch_add(1);
 
         Ok(PyMemoryView {
@@ -761,7 +782,7 @@ impl PyMemoryView {
             return Ok(false);
         }
 
-        let other = match try_buffer_from_object(vm, other) {
+        let other = match PyBufferRef::try_from_object(vm, other.clone()) {
             Ok(buf) => buf,
             Err(_) => return Ok(false),
         };
@@ -829,7 +850,7 @@ impl Drop for PyMemoryView {
 }
 
 impl BufferProtocol for PyMemoryView {
-    fn get_buffer(zelf: &PyRef<Self>, vm: &VirtualMachine) -> PyResult<Box<dyn Buffer>> {
+    fn get_buffer(zelf: &PyRef<Self>, vm: &VirtualMachine) -> PyResult<Box<dyn PyBuffer>> {
         if zelf.released.load() {
             Err(vm.new_value_error("operation forbidden on released memoryview object".to_owned()))
         } else {
@@ -838,7 +859,7 @@ impl BufferProtocol for PyMemoryView {
     }
 }
 
-impl Buffer for PyMemoryViewRef {
+impl PyBuffer for PyMemoryViewRef {
     fn get_options(&self) -> &BufferOptions {
         &self.options
     }
@@ -938,19 +959,6 @@ impl PyValue for PyMemoryView {
 
 pub(crate) fn init(ctx: &PyContext) {
     PyMemoryView::extend_class(ctx, &ctx.types.memoryview_type)
-}
-
-pub fn try_buffer_from_object(vm: &VirtualMachine, obj: &PyObjectRef) -> PyResult<BufferRef> {
-    let obj_cls = obj.class();
-    for cls in obj_cls.iter_mro() {
-        if let Some(f) = cls.slots.as_buffer.as_ref() {
-            return f(obj, vm).map(|x| BufferRef(x));
-        }
-    }
-    Err(vm.new_type_error(format!(
-        "a bytes-like object is required, not '{}'",
-        obj_cls.name
-    )))
 }
 
 fn format_unpack(

--- a/vm/src/builtins/memory.rs
+++ b/vm/src/builtins/memory.rs
@@ -943,7 +943,7 @@ pub(crate) fn init(ctx: &PyContext) {
 pub fn try_buffer_from_object(vm: &VirtualMachine, obj: &PyObjectRef) -> PyResult<BufferRef> {
     let obj_cls = obj.class();
     for cls in obj_cls.iter_mro() {
-        if let Some(f) = cls.slots.buffer.as_ref() {
+        if let Some(f) = cls.slots.as_buffer.as_ref() {
             return f(obj, vm).map(|x| BufferRef(x));
         }
     }

--- a/vm/src/cformat.rs
+++ b/vm/src/cformat.rs
@@ -2,8 +2,9 @@
 /// [https://docs.python.org/3/library/stdtypes.html#printf-style-string-formatting]
 use crate::builtins::float::{try_bigint, IntoPyFloat, PyFloat};
 use crate::builtins::int::{self, PyInt};
+use crate::builtins::memory::PyBufferRef;
 use crate::builtins::pystr::PyStr;
-use crate::builtins::{memory::try_buffer_from_object, tuple, PyBytes};
+use crate::builtins::{tuple, PyBytes};
 use crate::common::float_ops;
 use crate::vm::VirtualMachine;
 use crate::{ItemProtocol, PyObjectRef, PyResult, TryFromObject, TypeProtocol};
@@ -363,7 +364,7 @@ impl CFormatSpec {
                     Ok(s.into_bytes())
                 }
                 CFormatPreconversor::Str | CFormatPreconversor::Bytes => {
-                    if let Ok(buffer) = try_buffer_from_object(vm, &obj) {
+                    if let Ok(buffer) = PyBufferRef::try_from_object(vm, obj.clone()) {
                         let guard;
                         let vec;
                         let bytes = match buffer.as_contiguous() {

--- a/vm/src/slots.rs
+++ b/vm/src/slots.rs
@@ -1,6 +1,6 @@
 use std::cmp::Ordering;
 
-use crate::builtins::memory::Buffer;
+use crate::builtins::memory::PyBuffer;
 use crate::builtins::pystr::PyStrRef;
 use crate::common::hash::PyHash;
 use crate::common::lock::PyRwLock;
@@ -61,7 +61,7 @@ pub(crate) type CmpFunc = fn(
 pub(crate) type GetattroFunc = fn(PyObjectRef, PyStrRef, &VirtualMachine) -> PyResult;
 pub(crate) type SetattroFunc =
     fn(&PyObjectRef, PyStrRef, Option<PyObjectRef>, &VirtualMachine) -> PyResult<()>;
-pub(crate) type BufferFunc = fn(&PyObjectRef, &VirtualMachine) -> PyResult<Box<dyn Buffer>>;
+pub(crate) type BufferFunc = fn(&PyObjectRef, &VirtualMachine) -> PyResult<Box<dyn PyBuffer>>;
 pub(crate) type IterFunc = fn(PyObjectRef, &VirtualMachine) -> PyResult;
 pub(crate) type IterNextFunc = fn(&PyObjectRef, &VirtualMachine) -> PyResult;
 
@@ -496,7 +496,7 @@ pub trait SlotSetattro: PyValue {
 #[pyimpl]
 pub trait BufferProtocol: PyValue {
     #[pyslot]
-    fn tp_as_buffer(zelf: &PyObjectRef, vm: &VirtualMachine) -> PyResult<Box<dyn Buffer>> {
+    fn tp_as_buffer(zelf: &PyObjectRef, vm: &VirtualMachine) -> PyResult<Box<dyn PyBuffer>> {
         if let Some(zelf) = zelf.downcast_ref() {
             Self::get_buffer(zelf, vm)
         } else {
@@ -504,7 +504,7 @@ pub trait BufferProtocol: PyValue {
         }
     }
 
-    fn get_buffer(zelf: &PyRef<Self>, vm: &VirtualMachine) -> PyResult<Box<dyn Buffer>>;
+    fn get_buffer(zelf: &PyRef<Self>, vm: &VirtualMachine) -> PyResult<Box<dyn PyBuffer>>;
 }
 
 #[pyimpl]

--- a/vm/src/slots.rs
+++ b/vm/src/slots.rs
@@ -67,20 +67,55 @@ pub(crate) type IterNextFunc = fn(&PyObjectRef, &VirtualMachine) -> PyResult;
 
 #[derive(Default)]
 pub struct PyTypeSlots {
-    pub flags: PyTpFlags,
     pub name: PyRwLock<Option<String>>, // tp_name, not class name
-    pub new: Option<PyNativeFunc>,
-    pub del: AtomicCell<Option<DelFunc>>,
-    pub call: AtomicCell<Option<GenericMethod>>,
-    pub descr_get: AtomicCell<Option<DescrGetFunc>>,
-    pub descr_set: AtomicCell<Option<DescrSetFunc>>,
+    // tp_basicsize, tp_itemsize
+
+    // Methods to implement standard operations
+
+    // Method suites for standard classes
+    // tp_as_number
+    // tp_as_sequence
+    // tp_as_mapping
+
+    // More standard operations (here for binary compatibility)
     pub hash: AtomicCell<Option<HashFunc>>,
-    pub cmp: AtomicCell<Option<CmpFunc>>,
+    pub call: AtomicCell<Option<GenericMethod>>,
+    // tp_str
     pub getattro: AtomicCell<Option<GetattroFunc>>,
     pub setattro: AtomicCell<Option<SetattroFunc>>,
+
+    // Functions to access object as input/output buffer
     pub as_buffer: Option<BufferFunc>,
+
+    // Assigned meaning in release 2.1
+    // rich comparisons
+    pub cmp: AtomicCell<Option<CmpFunc>>,
+
+    // Iterators
     pub iter: AtomicCell<Option<IterFunc>>,
     pub iternext: AtomicCell<Option<IterNextFunc>>,
+
+    // Flags to define presence of optional/expanded features
+    pub flags: PyTpFlags,
+    // tp_doc
+
+    // Strong reference on a heap type, borrowed reference on a static type
+    // tp_base
+    // tp_dict
+    pub descr_get: AtomicCell<Option<DescrGetFunc>>,
+    pub descr_set: AtomicCell<Option<DescrSetFunc>>,
+    // tp_dictoffset
+    // tp_init
+    // tp_alloc
+    pub new: Option<PyNativeFunc>,
+    // tp_free
+    // tp_is_gc
+    // tp_bases
+    // tp_mro
+    // tp_cache
+    // tp_subclasses
+    // tp_weaklist
+    pub del: AtomicCell<Option<DelFunc>>,
 }
 
 impl PyTypeSlots {

--- a/vm/src/slots.rs
+++ b/vm/src/slots.rs
@@ -78,7 +78,7 @@ pub struct PyTypeSlots {
     pub cmp: AtomicCell<Option<CmpFunc>>,
     pub getattro: AtomicCell<Option<GetattroFunc>>,
     pub setattro: AtomicCell<Option<SetattroFunc>>,
-    pub buffer: Option<BufferFunc>,
+    pub as_buffer: Option<BufferFunc>,
     pub iter: AtomicCell<Option<IterFunc>>,
     pub iternext: AtomicCell<Option<IterNextFunc>>,
 }
@@ -461,7 +461,7 @@ pub trait SlotSetattro: PyValue {
 #[pyimpl]
 pub trait BufferProtocol: PyValue {
     #[pyslot]
-    fn tp_buffer(zelf: &PyObjectRef, vm: &VirtualMachine) -> PyResult<Box<dyn Buffer>> {
+    fn tp_as_buffer(zelf: &PyObjectRef, vm: &VirtualMachine) -> PyResult<Box<dyn Buffer>> {
         if let Some(zelf) = zelf.downcast_ref() {
             Self::get_buffer(zelf, vm)
         } else {

--- a/vm/src/stdlib/array.rs
+++ b/vm/src/stdlib/array.rs
@@ -1,6 +1,6 @@
 use crate::builtins::float::IntoPyFloat;
 use crate::builtins::list::{PyList, PyListRef};
-use crate::builtins::memory::{Buffer, BufferOptions, ResizeGuard};
+use crate::builtins::memory::{BufferOptions, PyBuffer, ResizeGuard};
 use crate::builtins::pystr::PyStrRef;
 use crate::builtins::pytype::PyTypeRef;
 use crate::builtins::slice::PySliceRef;
@@ -853,7 +853,7 @@ impl Comparable for PyArray {
 }
 
 impl BufferProtocol for PyArray {
-    fn get_buffer(zelf: &PyRef<Self>, _vm: &VirtualMachine) -> PyResult<Box<dyn Buffer>> {
+    fn get_buffer(zelf: &PyRef<Self>, _vm: &VirtualMachine) -> PyResult<Box<dyn PyBuffer>> {
         zelf.exports.fetch_add(1);
         let array = zelf.read();
         let buf = ArrayBuffer {
@@ -876,7 +876,7 @@ struct ArrayBuffer {
     options: BufferOptions,
 }
 
-impl Buffer for ArrayBuffer {
+impl PyBuffer for ArrayBuffer {
     fn obj_bytes(&self) -> BorrowedValue<[u8]> {
         self.array.get_bytes().into()
     }

--- a/vm/src/stdlib/sre.rs
+++ b/vm/src/stdlib/sre.rs
@@ -8,7 +8,7 @@ mod _sre {
     use rustpython_common::hash::PyHash;
 
     use crate::builtins::list::PyListRef;
-    use crate::builtins::memory::try_buffer_from_object;
+    use crate::builtins::memory::PyBufferRef;
     use crate::builtins::tuple::PyTupleRef;
     use crate::builtins::{
         PyCallableIterator, PyDictRef, PyInt, PyList, PyStr, PyStrRef, PyTypeRef,
@@ -153,7 +153,7 @@ mod _sre {
             let vec;
             let s;
             let str_drive = if self.isbytes {
-                buffer = try_buffer_from_object(vm, &string)?;
+                buffer = PyBufferRef::try_from_object(vm, string.clone())?;
                 let bytes = match buffer.as_contiguous() {
                     Some(bytes) => {
                         guard = bytes;


### PR DESCRIPTION
- tp_buffer -> tp_as_buffer by following CPython name
- Buffer -> PyBuffer
- try_buffer_from_object -> PyBufferRef::try_from_object
- sorted type slots