### PR TITLE
support deque.extend recursive call

### DIFF
--- a/Lib/test/test_deque.py
+++ b/Lib/test/test_deque.py
@@ -205,7 +205,6 @@ class TestBasic(unittest.TestCase):
         with self.assertRaises(RuntimeError):
             _ = d.count(3)
 
-    @unittest.skip("TODO: RUSTPYTHON hangs")
     def test_extend(self):
         d = deque('a')
         self.assertRaises(TypeError, d.extend, 1)

--- a/extra_tests/snippets/stdlib_collections.py
+++ b/extra_tests/snippets/stdlib_collections.py
@@ -16,7 +16,7 @@ d = deque([1, 2, 3], 5)
 
 d.extend([4, 5, 6])
 
-assert d == deque([2, 3, 4, 5, 6])
+assert d == deque([2, 3, 4, 5, 6]), d
 
 d.remove(4)
 

--- a/vm/src/stdlib/collections.rs
+++ b/vm/src/stdlib/collections.rs
@@ -137,17 +137,13 @@ mod _collections {
         fn extend(zelf: PyRef<Self>, iter: PyObjectRef, vm: &VirtualMachine) -> PyResult<()> {
             // TODO: use length_hint here and for extendleft
             if zelf.is(&iter) {
-                let iter =
-                    PyIterable::try_from_object(vm, PyDeque::iter(zelf.copy().into_ref(vm), vm)?)?;
-                for elem in iter.iter(vm)? {
-                    zelf.append(elem?)
-                }
-                Ok(())
+                let copied: Vec<PyObjectRef> = vm.extract_elements(zelf.as_object())?;
+                zelf._extend(copied.into_iter().map(Ok))?;
             } else {
                 let iter = PyIterable::try_from_object(vm, iter)?;
-
-                zelf._extend(iter.iter(vm)?)
+                zelf._extend(iter.iter(vm)?)?;
             }
+            Ok(())
         }
 
         #[pymethod]

--- a/vm/src/stdlib/collections.rs
+++ b/vm/src/stdlib/collections.rs
@@ -133,14 +133,13 @@ mod _collections {
             let max_len = zelf.maxlen.load();
             let mut elements: Vec<PyObjectRef> = vm.extract_elements(&iter)?;
             if let Some(max_len) = max_len {
-                let cut_len = max_len as isize - elements.len() as isize;
-                if cut_len > 0 {
+                if max_len > elements.len() {
                     let mut deque = zelf.borrow_deque_mut();
-                    let drain_until = deque.len().saturating_sub(cut_len as usize);
+                    let drain_until = deque.len().saturating_sub(max_len - elements.len());
                     deque.drain(..drain_until);
                 } else {
                     zelf.borrow_deque_mut().clear();
-                    elements.drain(..(-cut_len) as usize);
+                    elements.drain(..(elements.len() - max_len));
                 }
             }
             zelf.borrow_deque_mut().extend(elements);


### PR DESCRIPTION
before: RustPython hangs when

	d = deque('a')
	d.extend(d)

after: it extends to the copy of it

I'll fix the temporary change in deque.__iadd__ with another PR