### PR TITLE
give an own module for buffer protocol + TryFromBorrowedObject

### DIFF
--- a/vm/src/buffer.rs
+++ b/vm/src/buffer.rs
@@ -1,0 +1,167 @@
+//! Buffer protocol
+
+use crate::common::borrow::{BorrowedValue, BorrowedValueMut};
+use crate::common::rc::PyRc;
+use crate::PyThreadingConstraint;
+use crate::{PyObjectRef, PyResult, TypeProtocol};
+use crate::{TryFromBorrowedObject, VirtualMachine};
+use std::{borrow::Cow, fmt::Debug, ops::Deref};
+
+pub trait PyBuffer: Debug + PyThreadingConstraint {
+    fn get_options(&self) -> &BufferOptions;
+    /// Get the full inner buffer of this memory. You probably want [`as_contiguous()`], as
+    /// `obj_bytes` doesn't take into account the range a memoryview might operate on, among other
+    /// footguns.
+    fn obj_bytes(&self) -> BorrowedValue<[u8]>;
+    /// Get the full inner buffer of this memory, mutably. You probably want
+    /// [`as_contiguous_mut()`], as `obj_bytes` doesn't take into account the range a memoryview
+    /// might operate on, among other footguns.
+    fn obj_bytes_mut(&self) -> BorrowedValueMut<[u8]>;
+    fn release(&self);
+
+    fn as_contiguous(&self) -> Option<BorrowedValue<[u8]>> {
+        if !self.get_options().contiguous {
+            return None;
+        }
+        Some(self.obj_bytes())
+    }
+
+    fn as_contiguous_mut(&self) -> Option<BorrowedValueMut<[u8]>> {
+        if !self.get_options().contiguous {
+            return None;
+        }
+        Some(self.obj_bytes_mut())
+    }
+
+    fn to_contiguous(&self) -> Vec<u8> {
+        self.obj_bytes().to_vec()
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct BufferOptions {
+    pub readonly: bool,
+    pub len: usize,
+    pub itemsize: usize,
+    pub contiguous: bool,
+    pub format: Cow<'static, str>,
+    // TODO: support multiple dimension array
+    pub ndim: usize,
+    pub shape: Vec<usize>,
+    pub strides: Vec<isize>,
+}
+
+impl BufferOptions {
+    pub const DEFAULT: Self = BufferOptions {
+        readonly: true,
+        len: 0,
+        itemsize: 1,
+        contiguous: true,
+        format: Cow::Borrowed("B"),
+        ndim: 1,
+        shape: Vec::new(),
+        strides: Vec::new(),
+    };
+}
+
+impl Default for BufferOptions {
+    fn default() -> Self {
+        Self::DEFAULT
+    }
+}
+
+#[derive(Debug)]
+pub struct PyBufferRef(Box<dyn PyBuffer>);
+
+impl TryFromBorrowedObject for PyBufferRef {
+    fn try_from_borrowed_object(vm: &VirtualMachine, obj: &PyObjectRef) -> PyResult<Self> {
+        let obj_cls = obj.class();
+        for cls in obj_cls.iter_mro() {
+            if let Some(f) = cls.slots.as_buffer.as_ref() {
+                return f(obj, vm).map(|x| PyBufferRef(x));
+            }
+        }
+        Err(vm.new_type_error(format!(
+            "a bytes-like object is required, not '{}'",
+            obj_cls.name
+        )))
+    }
+}
+
+impl Drop for PyBufferRef {
+    fn drop(&mut self) {
+        self.0.release();
+    }
+}
+
+impl Deref for PyBufferRef {
+    type Target = dyn PyBuffer;
+
+    fn deref(&self) -> &Self::Target {
+        self.0.deref()
+    }
+}
+
+impl PyBufferRef {
+    pub fn new(buffer: impl PyBuffer + 'static) -> Self {
+        Self(Box::new(buffer))
+    }
+
+    pub fn into_rcbuf(self) -> RcBuffer {
+        // move self.0 out of self; PyBufferRef impls Drop so it's tricky
+        let this = std::mem::ManuallyDrop::new(self);
+        let buf_box = unsafe { std::ptr::read(&this.0) };
+        RcBuffer(buf_box.into())
+    }
+}
+
+impl From<Box<dyn PyBuffer>> for PyBufferRef {
+    fn from(buffer: Box<dyn PyBuffer>) -> Self {
+        PyBufferRef(buffer)
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct RcBuffer(PyRc<dyn PyBuffer>);
+impl Deref for RcBuffer {
+    type Target = dyn PyBuffer;
+    fn deref(&self) -> &Self::Target {
+        self.0.deref()
+    }
+}
+
+impl Drop for RcBuffer {
+    fn drop(&mut self) {
+        // check if this is the last rc before the inner buffer gets dropped
+        if let Some(buf) = PyRc::get_mut(&mut self.0) {
+            buf.release()
+        }
+    }
+}
+
+impl PyBuffer for RcBuffer {
+    fn get_options(&self) -> &BufferOptions {
+        self.0.get_options()
+    }
+    fn obj_bytes(&self) -> BorrowedValue<[u8]> {
+        self.0.obj_bytes()
+    }
+    fn obj_bytes_mut(&self) -> BorrowedValueMut<[u8]> {
+        self.0.obj_bytes_mut()
+    }
+    fn release(&self) {}
+    fn as_contiguous(&self) -> Option<BorrowedValue<[u8]>> {
+        self.0.as_contiguous()
+    }
+    fn as_contiguous_mut(&self) -> Option<BorrowedValueMut<[u8]>> {
+        self.0.as_contiguous_mut()
+    }
+    fn to_contiguous(&self) -> Vec<u8> {
+        self.0.to_contiguous()
+    }
+}
+
+pub(crate) trait ResizeGuard<'a> {
+    type Resizable: 'a;
+    fn try_resizable(&'a self, vm: &VirtualMachine) -> PyResult<Self::Resizable>;
+}

--- a/vm/src/builtins/bytearray.rs
+++ b/vm/src/builtins/bytearray.rs
@@ -2,11 +2,11 @@
 use super::bytes::{PyBytes, PyBytesRef};
 use super::dict::PyDictRef;
 use super::int::PyIntRef;
-use super::memory::{BufferOptions, PyBuffer, ResizeGuard};
 use super::pystr::PyStrRef;
 use super::pytype::PyTypeRef;
 use super::tuple::PyTupleRef;
 use crate::anystr::{self, AnyStr};
+use crate::buffer::{BufferOptions, PyBuffer, ResizeGuard};
 use crate::bytesinner::{
     bytes_decode, bytes_from_object, value_from_object, ByteInnerFindOptions, ByteInnerNewOptions,
     ByteInnerPaddingOptions, ByteInnerSplitOptions, ByteInnerTranslateOptions, DecodeArgs,

--- a/vm/src/builtins/bytearray.rs
+++ b/vm/src/builtins/bytearray.rs
@@ -12,7 +12,7 @@ use crate::bytesinner::{
     ByteInnerPaddingOptions, ByteInnerSplitOptions, ByteInnerTranslateOptions, DecodeArgs,
     PyBytesInner,
 };
-use crate::byteslike::PyBytesLike;
+use crate::byteslike::ArgBytesLike;
 use crate::common::borrow::{BorrowedValue, BorrowedValueMut};
 use crate::common::lock::{
     PyMappedRwLockReadGuard, PyMappedRwLockWriteGuard, PyRwLock, PyRwLockReadGuard,
@@ -142,7 +142,7 @@ impl PyByteArray {
     }
 
     #[pymethod(magic)]
-    fn add(&self, other: PyBytesLike, vm: &VirtualMachine) -> PyObjectRef {
+    fn add(&self, other: ArgBytesLike, vm: &VirtualMachine) -> PyObjectRef {
         vm.ctx.new_bytearray(self.inner().add(&*other.borrow_buf()))
     }
 
@@ -190,7 +190,7 @@ impl PyByteArray {
     }
 
     #[pymethod(magic)]
-    fn iadd(zelf: PyRef<Self>, other: PyBytesLike, vm: &VirtualMachine) -> PyResult<PyRef<Self>> {
+    fn iadd(zelf: PyRef<Self>, other: ArgBytesLike, vm: &VirtualMachine) -> PyResult<PyRef<Self>> {
         zelf.try_resizable(vm)?
             .elements
             .extend(&*other.borrow_buf());

--- a/vm/src/builtins/bytearray.rs
+++ b/vm/src/builtins/bytearray.rs
@@ -20,9 +20,7 @@ use crate::common::lock::{
 };
 use crate::function::{FuncArgs, OptionalArg, OptionalOption};
 use crate::sliceable::{PySliceableSequence, PySliceableSequenceMut, SequenceIndex};
-use crate::slots::{
-    BufferProtocol, Comparable, Hashable, Iterable, PyComparisonOp, PyIter, Unhashable,
-};
+use crate::slots::{AsBuffer, Comparable, Hashable, Iterable, PyComparisonOp, PyIter, Unhashable};
 use crate::utils::Either;
 use crate::vm::VirtualMachine;
 use crate::{
@@ -99,7 +97,7 @@ pub(crate) fn init(context: &PyContext) {
     PyByteArrayIterator::extend_class(context, &context.types.bytearray_iterator_type);
 }
 
-#[pyimpl(flags(BASETYPE), with(Hashable, Comparable, BufferProtocol, Iterable))]
+#[pyimpl(flags(BASETYPE), with(Hashable, Comparable, AsBuffer, Iterable))]
 impl PyByteArray {
     #[pyslot]
     fn tp_new(cls: PyTypeRef, _args: FuncArgs, vm: &VirtualMachine) -> PyResult<PyRef<Self>> {
@@ -667,7 +665,7 @@ impl Comparable for PyByteArray {
     }
 }
 
-impl BufferProtocol for PyByteArray {
+impl AsBuffer for PyByteArray {
     fn get_buffer(zelf: &PyRef<Self>, _vm: &VirtualMachine) -> PyResult<Box<dyn PyBuffer>> {
         zelf.exports.fetch_add(1);
         let buf = ByteArrayBuffer {

--- a/vm/src/builtins/bytes.rs
+++ b/vm/src/builtins/bytes.rs
@@ -12,7 +12,7 @@ use crate::bytesinner::{
 use crate::byteslike::PyBytesLike;
 use crate::common::hash::PyHash;
 use crate::function::{OptionalArg, OptionalOption};
-use crate::slots::{BufferProtocol, Comparable, Hashable, Iterable, PyComparisonOp, PyIter};
+use crate::slots::{AsBuffer, Comparable, Hashable, Iterable, PyComparisonOp, PyIter};
 use crate::utils::Either;
 use crate::vm::VirtualMachine;
 use crate::{
@@ -96,7 +96,7 @@ pub(crate) fn init(context: &PyContext) {
     PyBytesIterator::extend_class(context, &context.types.bytes_iterator_type);
 }
 
-#[pyimpl(flags(BASETYPE), with(Hashable, Comparable, BufferProtocol, Iterable))]
+#[pyimpl(flags(BASETYPE), with(Hashable, Comparable, AsBuffer, Iterable))]
 impl PyBytes {
     #[pyslot]
     fn tp_new(
@@ -500,7 +500,7 @@ impl PyBytes {
     }
 }
 
-impl BufferProtocol for PyBytes {
+impl AsBuffer for PyBytes {
     fn get_buffer(zelf: &PyRef<Self>, _vm: &VirtualMachine) -> PyResult<Box<dyn PyBuffer>> {
         let buf = BytesBuffer {
             bytes: zelf.clone(),

--- a/vm/src/builtins/bytes.rs
+++ b/vm/src/builtins/bytes.rs
@@ -17,7 +17,7 @@ use crate::utils::Either;
 use crate::vm::VirtualMachine;
 use crate::{
     IdProtocol, IntoPyObject, PyClassImpl, PyComparisonValue, PyContext, PyIterable, PyObjectRef,
-    PyRef, PyResult, PyValue, TryFromBorrowedObject, TryFromObject, TypeProtocol,
+    PyRef, PyResult, PyValue, TryFromBorrowedObject, TypeProtocol,
 };
 use bstr::ByteSlice;
 use crossbeam_utils::atomic::AtomicCell;
@@ -602,8 +602,8 @@ impl PyIter for PyBytesIterator {
     }
 }
 
-impl TryFromObject for PyBytes {
-    fn try_from_object(vm: &VirtualMachine, obj: PyObjectRef) -> PyResult<Self> {
-        PyBytesInner::try_from_borrowed_object(vm, &obj).map(|x| x.into())
+impl TryFromBorrowedObject for PyBytes {
+    fn try_from_borrowed_object(vm: &VirtualMachine, obj: &PyObjectRef) -> PyResult<Self> {
+        PyBytesInner::try_from_borrowed_object(vm, obj).map(|x| x.into())
     }
 }

--- a/vm/src/builtins/bytes.rs
+++ b/vm/src/builtins/bytes.rs
@@ -9,7 +9,7 @@ use crate::bytesinner::{
     bytes_decode, ByteInnerFindOptions, ByteInnerNewOptions, ByteInnerPaddingOptions,
     ByteInnerSplitOptions, ByteInnerTranslateOptions, DecodeArgs, PyBytesInner,
 };
-use crate::byteslike::PyBytesLike;
+use crate::byteslike::ArgBytesLike;
 use crate::common::hash::PyHash;
 use crate::function::{OptionalArg, OptionalOption};
 use crate::slots::{AsBuffer, Comparable, Hashable, Iterable, PyComparisonOp, PyIter};
@@ -134,7 +134,7 @@ impl PyBytes {
     }
 
     #[pymethod(magic)]
-    fn add(&self, other: PyBytesLike, vm: &VirtualMachine) -> PyObjectRef {
+    fn add(&self, other: ArgBytesLike, vm: &VirtualMachine) -> PyObjectRef {
         vm.ctx.new_bytes(self.inner.add(&*other.borrow_buf()))
     }
 

--- a/vm/src/builtins/bytes.rs
+++ b/vm/src/builtins/bytes.rs
@@ -17,7 +17,7 @@ use crate::utils::Either;
 use crate::vm::VirtualMachine;
 use crate::{
     IdProtocol, IntoPyObject, PyClassImpl, PyComparisonValue, PyContext, PyIterable, PyObjectRef,
-    PyRef, PyResult, PyValue, TryFromObject, TypeProtocol,
+    PyRef, PyResult, PyValue, TryFromBorrowedObject, TryFromObject, TypeProtocol,
 };
 use bstr::ByteSlice;
 use crossbeam_utils::atomic::AtomicCell;
@@ -364,7 +364,7 @@ impl PyBytes {
 
     #[pymethod]
     fn partition(&self, sep: PyObjectRef, vm: &VirtualMachine) -> PyResult {
-        let sub = PyBytesInner::try_from_object(vm, sep.clone())?;
+        let sub = PyBytesInner::try_from_borrowed_object(vm, &sep)?;
         let (front, has_mid, back) = self.inner.partition(&sub, vm)?;
         Ok(vm.ctx.new_tuple(vec![
             vm.ctx.new_bytes(front),
@@ -379,7 +379,7 @@ impl PyBytes {
 
     #[pymethod]
     fn rpartition(&self, sep: PyObjectRef, vm: &VirtualMachine) -> PyResult {
-        let sub = PyBytesInner::try_from_object(vm, sep.clone())?;
+        let sub = PyBytesInner::try_from_borrowed_object(vm, &sep)?;
         let (back, has_mid, front) = self.inner.rpartition(&sub, vm)?;
         Ok(vm.ctx.new_tuple(vec![
             vm.ctx.new_bytes(front),
@@ -604,6 +604,6 @@ impl PyIter for PyBytesIterator {
 
 impl TryFromObject for PyBytes {
     fn try_from_object(vm: &VirtualMachine, obj: PyObjectRef) -> PyResult<Self> {
-        PyBytesInner::try_from_object(vm, obj).map(|x| x.into())
+        PyBytesInner::try_from_borrowed_object(vm, &obj).map(|x| x.into())
     }
 }

--- a/vm/src/builtins/bytes.rs
+++ b/vm/src/builtins/bytes.rs
@@ -1,14 +1,9 @@
-use bstr::ByteSlice;
-use crossbeam_utils::atomic::AtomicCell;
-use rustpython_common::borrow::{BorrowedValue, BorrowedValueMut};
-use std::mem::size_of;
-use std::ops::Deref;
-
 use super::dict::PyDictRef;
 use super::int::PyIntRef;
 use super::pystr::PyStrRef;
 use super::pytype::PyTypeRef;
 use crate::anystr::{self, AnyStr};
+use crate::buffer::{BufferOptions, PyBuffer};
 use crate::builtins::tuple::PyTupleRef;
 use crate::bytesinner::{
     bytes_decode, ByteInnerFindOptions, ByteInnerNewOptions, ByteInnerPaddingOptions,
@@ -24,8 +19,11 @@ use crate::{
     IdProtocol, IntoPyObject, PyClassImpl, PyComparisonValue, PyContext, PyIterable, PyObjectRef,
     PyRef, PyResult, PyValue, TryFromObject, TypeProtocol,
 };
-
-use crate::builtins::memory::{BufferOptions, PyBuffer};
+use bstr::ByteSlice;
+use crossbeam_utils::atomic::AtomicCell;
+use rustpython_common::borrow::{BorrowedValue, BorrowedValueMut};
+use std::mem::size_of;
+use std::ops::Deref;
 
 /// "bytes(iterable_of_ints) -> bytes\n\
 /// bytes(string, encoding[, errors]) -> bytes\n\

--- a/vm/src/builtins/make_module.rs
+++ b/vm/src/builtins/make_module.rs
@@ -20,7 +20,7 @@ mod decl {
     use crate::builtins::pystr::{PyStr, PyStrRef};
     use crate::builtins::pytype::PyTypeRef;
     use crate::builtins::{PyByteArray, PyBytes};
-    use crate::byteslike::PyBytesLike;
+    use crate::byteslike::ArgBytesLike;
     use crate::common::{hash::PyHash, str::to_ascii};
     #[cfg(feature = "rustpython-compiler")]
     use crate::compile;
@@ -563,7 +563,7 @@ mod decl {
     }
 
     #[pyfunction]
-    fn ord(string: Either<PyBytesLike, PyStrRef>, vm: &VirtualMachine) -> PyResult<u32> {
+    fn ord(string: Either<ArgBytesLike, PyStrRef>, vm: &VirtualMachine) -> PyResult<u32> {
         match string {
             Either::A(bytes) => bytes.with_ref(|bytes| {
                 let bytes_len = bytes.len();

--- a/vm/src/builtins/memory.rs
+++ b/vm/src/builtins/memory.rs
@@ -1,5 +1,4 @@
-use std::{borrow::Cow, fmt::Debug, ops::Deref};
-
+use crate::buffer::{BufferOptions, PyBuffer, PyBufferRef};
 use crate::builtins::bytes::{PyBytes, PyBytesRef};
 use crate::builtins::list::{PyList, PyListRef};
 use crate::builtins::pystr::{PyStr, PyStrRef};
@@ -9,7 +8,6 @@ use crate::bytesinner::bytes_to_hex;
 use crate::common::borrow::{BorrowedValue, BorrowedValueMut};
 use crate::common::hash::PyHash;
 use crate::common::lock::OnceCell;
-use crate::common::rc::PyRc;
 use crate::function::{FuncArgs, OptionalArg};
 use crate::sliceable::{convert_slice, saturate_range, wrap_index, SequenceIndex};
 use crate::slots::{BufferProtocol, Comparable, Hashable, PyComparisonOp};
@@ -17,165 +15,14 @@ use crate::stdlib::pystruct::_struct::FormatSpec;
 use crate::utils::Either;
 use crate::{
     IdProtocol, IntoPyObject, PyClassImpl, PyComparisonValue, PyContext, PyObjectRef, PyRef,
-    PyResult, PyThreadingConstraint, PyValue, TypeProtocol,
+    PyResult, PyValue, TypeProtocol,
 };
 use crate::{TryFromBorrowedObject, TryFromObject, VirtualMachine};
 use crossbeam_utils::atomic::AtomicCell;
 use itertools::Itertools;
 use num_bigint::BigInt;
 use num_traits::{One, Signed, ToPrimitive, Zero};
-
-#[derive(Debug)]
-pub struct PyBufferRef(Box<dyn PyBuffer>);
-
-impl TryFromBorrowedObject for PyBufferRef {
-    fn try_from_borrowed_object(vm: &VirtualMachine, obj: &PyObjectRef) -> PyResult<Self> {
-        let obj_cls = obj.class();
-        for cls in obj_cls.iter_mro() {
-            if let Some(f) = cls.slots.as_buffer.as_ref() {
-                return f(&obj, vm).map(|x| PyBufferRef(x));
-            }
-        }
-        Err(vm.new_type_error(format!(
-            "a bytes-like object is required, not '{}'",
-            obj_cls.name
-        )))
-    }
-}
-
-impl Drop for PyBufferRef {
-    fn drop(&mut self) {
-        self.0.release();
-    }
-}
-impl Deref for PyBufferRef {
-    type Target = dyn PyBuffer;
-
-    fn deref(&self) -> &Self::Target {
-        self.0.deref()
-    }
-}
-impl PyBufferRef {
-    pub fn new(buffer: impl PyBuffer + 'static) -> Self {
-        Self(Box::new(buffer))
-    }
-    pub fn into_rcbuf(self) -> RcBuffer {
-        // move self.0 out of self; PyBufferRef impls Drop so it's tricky
-        let this = std::mem::ManuallyDrop::new(self);
-        let buf_box = unsafe { std::ptr::read(&this.0) };
-        RcBuffer(buf_box.into())
-    }
-}
-impl From<Box<dyn PyBuffer>> for PyBufferRef {
-    fn from(buffer: Box<dyn PyBuffer>) -> Self {
-        PyBufferRef(buffer)
-    }
-}
-#[derive(Debug, Clone)]
-pub struct RcBuffer(PyRc<dyn PyBuffer>);
-impl Deref for RcBuffer {
-    type Target = dyn PyBuffer;
-    fn deref(&self) -> &Self::Target {
-        self.0.deref()
-    }
-}
-impl Drop for RcBuffer {
-    fn drop(&mut self) {
-        // check if this is the last rc before the inner buffer gets dropped
-        if let Some(buf) = PyRc::get_mut(&mut self.0) {
-            buf.release()
-        }
-    }
-}
-impl PyBuffer for RcBuffer {
-    fn get_options(&self) -> &BufferOptions {
-        self.0.get_options()
-    }
-    fn obj_bytes(&self) -> BorrowedValue<[u8]> {
-        self.0.obj_bytes()
-    }
-    fn obj_bytes_mut(&self) -> BorrowedValueMut<[u8]> {
-        self.0.obj_bytes_mut()
-    }
-    fn release(&self) {}
-    fn as_contiguous(&self) -> Option<BorrowedValue<[u8]>> {
-        self.0.as_contiguous()
-    }
-    fn as_contiguous_mut(&self) -> Option<BorrowedValueMut<[u8]>> {
-        self.0.as_contiguous_mut()
-    }
-    fn to_contiguous(&self) -> Vec<u8> {
-        self.0.to_contiguous()
-    }
-}
-
-pub trait PyBuffer: Debug + PyThreadingConstraint {
-    fn get_options(&self) -> &BufferOptions;
-    /// Get the full inner buffer of this memory. You probably want [`as_contiguous()`], as
-    /// `obj_bytes` doesn't take into account the range a memoryview might operate on, among other
-    /// footguns.
-    fn obj_bytes(&self) -> BorrowedValue<[u8]>;
-    /// Get the full inner buffer of this memory, mutably. You probably want
-    /// [`as_contiguous_mut()`], as `obj_bytes` doesn't take into account the range a memoryview
-    /// might operate on, among other footguns.
-    fn obj_bytes_mut(&self) -> BorrowedValueMut<[u8]>;
-    fn release(&self);
-
-    fn as_contiguous(&self) -> Option<BorrowedValue<[u8]>> {
-        if !self.get_options().contiguous {
-            return None;
-        }
-        Some(self.obj_bytes())
-    }
-
-    fn as_contiguous_mut(&self) -> Option<BorrowedValueMut<[u8]>> {
-        if !self.get_options().contiguous {
-            return None;
-        }
-        Some(self.obj_bytes_mut())
-    }
-
-    fn to_contiguous(&self) -> Vec<u8> {
-        self.obj_bytes().to_vec()
-    }
-}
-
-#[derive(Debug, Clone)]
-pub struct BufferOptions {
-    pub readonly: bool,
-    pub len: usize,
-    pub itemsize: usize,
-    pub contiguous: bool,
-    pub format: Cow<'static, str>,
-    // TODO: support multiple dimension array
-    pub ndim: usize,
-    pub shape: Vec<usize>,
-    pub strides: Vec<isize>,
-}
-
-impl BufferOptions {
-    pub const DEFAULT: Self = BufferOptions {
-        readonly: true,
-        len: 0,
-        itemsize: 1,
-        contiguous: true,
-        format: Cow::Borrowed("B"),
-        ndim: 1,
-        shape: Vec::new(),
-        strides: Vec::new(),
-    };
-}
-
-impl Default for BufferOptions {
-    fn default() -> Self {
-        Self::DEFAULT
-    }
-}
-
-pub(crate) trait ResizeGuard<'a> {
-    type Resizable: 'a;
-    fn try_resizable(&'a self, vm: &VirtualMachine) -> PyResult<Self::Resizable>;
-}
+use std::fmt::Debug;
 
 #[derive(FromArgs)]
 struct PyMemoryViewNewArgs {
@@ -393,7 +240,7 @@ impl PyMemoryView {
         let itemsize = zelf.options.itemsize;
 
         let obj = zelf.obj.clone();
-        let buffer = PyBufferRef(Box::new(zelf.clone()));
+        let buffer = PyBufferRef::new(zelf.clone());
         zelf.exports.fetch_add(1);
         let options = zelf.options.clone();
         let format_spec = zelf.format_spec.clone();
@@ -680,7 +527,7 @@ impl PyMemoryView {
     #[pymethod]
     fn toreadonly(zelf: PyRef<Self>, vm: &VirtualMachine) -> PyResult<PyRef<Self>> {
         zelf.try_not_released(vm)?;
-        let buffer = PyBufferRef(Box::new(zelf.clone()));
+        let buffer = PyBufferRef::new(zelf.clone());
         zelf.exports.fetch_add(1);
         Ok(PyMemoryView {
             obj: zelf.obj.clone(),
@@ -751,7 +598,7 @@ impl PyMemoryView {
             );
         }
 
-        let buffer = PyBufferRef(Box::new(zelf.clone()));
+        let buffer = PyBufferRef::new(zelf.clone());
         zelf.exports.fetch_add(1);
 
         Ok(PyMemoryView {

--- a/vm/src/builtins/memory.rs
+++ b/vm/src/builtins/memory.rs
@@ -10,7 +10,7 @@ use crate::common::hash::PyHash;
 use crate::common::lock::OnceCell;
 use crate::function::{FuncArgs, OptionalArg};
 use crate::sliceable::{convert_slice, saturate_range, wrap_index, SequenceIndex};
-use crate::slots::{BufferProtocol, Comparable, Hashable, PyComparisonOp};
+use crate::slots::{AsBuffer, Comparable, Hashable, PyComparisonOp};
 use crate::stdlib::pystruct::_struct::FormatSpec;
 use crate::utils::Either;
 use crate::{
@@ -51,7 +51,7 @@ pub struct PyMemoryView {
 
 type PyMemoryViewRef = PyRef<PyMemoryView>;
 
-#[pyimpl(with(Hashable, Comparable, BufferProtocol))]
+#[pyimpl(with(Hashable, Comparable, AsBuffer))]
 impl PyMemoryView {
     fn parse_format(format: &str, vm: &VirtualMachine) -> PyResult<FormatSpec> {
         FormatSpec::parse(format)
@@ -695,7 +695,7 @@ impl Drop for PyMemoryView {
     }
 }
 
-impl BufferProtocol for PyMemoryView {
+impl AsBuffer for PyMemoryView {
     fn get_buffer(zelf: &PyRef<Self>, vm: &VirtualMachine) -> PyResult<Box<dyn PyBuffer>> {
         if zelf.released.load() {
             Err(vm.new_value_error("operation forbidden on released memoryview object".to_owned()))

--- a/vm/src/bytesinner.rs
+++ b/vm/src/bytesinner.rs
@@ -18,7 +18,8 @@ use crate::slots::PyComparisonOp;
 use crate::utils::Either;
 use crate::vm::VirtualMachine;
 use crate::{
-    IdProtocol, PyComparisonValue, PyIterable, PyObjectRef, PyResult, PyValue, TryFromObject,
+    IdProtocol, PyComparisonValue, PyIterable, PyObjectRef, PyResult, PyValue,
+    TryFromBorrowedObject,
 };
 use rustpython_common::hash;
 
@@ -33,9 +34,9 @@ impl From<Vec<u8>> for PyBytesInner {
     }
 }
 
-impl TryFromObject for PyBytesInner {
-    fn try_from_object(vm: &VirtualMachine, obj: PyObjectRef) -> PyResult<Self> {
-        bytes_from_object(vm, &obj).map(Self::from)
+impl TryFromBorrowedObject for PyBytesInner {
+    fn try_from_borrowed_object(vm: &VirtualMachine, obj: &PyObjectRef) -> PyResult<Self> {
+        bytes_from_object(vm, obj).map(Self::from)
     }
 }
 
@@ -107,7 +108,7 @@ impl ByteInnerNewOptions {
                     self.check_args(vm)?;
                     if let Some(bytes_method) = vm.get_method(obj.clone(), "__bytes__") {
                         let bytes = vm.invoke(&bytes_method?, ())?;
-                        PyBytesInner::try_from_object(vm, bytes)
+                        PyBytesInner::try_from_borrowed_object(vm, &bytes)
                     } else {
                         Self::get_value_from_source(obj, vm)
                     }

--- a/vm/src/byteslike.rs
+++ b/vm/src/byteslike.rs
@@ -71,9 +71,9 @@ impl ArgBytesLike {
     }
 }
 
-impl TryFromObject for ArgBytesLike {
-    fn try_from_object(vm: &VirtualMachine, obj: PyObjectRef) -> PyResult<Self> {
-        Self::new(vm, &obj)
+impl TryFromBorrowedObject for ArgBytesLike {
+    fn try_from_borrowed_object(vm: &VirtualMachine, obj: &PyObjectRef) -> PyResult<Self> {
+        Self::new(vm, obj)
     }
 }
 
@@ -122,9 +122,9 @@ impl ArgMemoryBuffer {
     }
 }
 
-impl TryFromObject for ArgMemoryBuffer {
-    fn try_from_object(vm: &VirtualMachine, obj: PyObjectRef) -> PyResult<Self> {
-        Self::new(vm, &obj)
+impl TryFromBorrowedObject for ArgMemoryBuffer {
+    fn try_from_borrowed_object(vm: &VirtualMachine, obj: &PyObjectRef) -> PyResult<Self> {
+        Self::new(vm, obj)
     }
 }
 

--- a/vm/src/byteslike.rs
+++ b/vm/src/byteslike.rs
@@ -4,13 +4,17 @@ use crate::common::borrow::{BorrowedValue, BorrowedValueMut};
 use crate::vm::VirtualMachine;
 use crate::{PyObjectRef, PyResult, TryFromBorrowedObject, TryFromObject};
 
-#[derive(Debug)]
-pub struct PyBytesLike(PyBufferRef);
+// Python/getargs.c
 
+/// any bytes-like object. Like the `y*` format code for `PyArg_Parse` in CPython.
 #[derive(Debug)]
-pub struct PyRwBytesLike(PyBufferRef);
+pub struct ArgBytesLike(PyBufferRef);
 
-impl PyBytesLike {
+/// A memory buffer, read-write access. Like the `w*` format code for `PyArg_Parse` in CPython.
+#[derive(Debug)]
+pub struct ArgMemoryBuffer(PyBufferRef);
+
+impl ArgBytesLike {
     pub fn with_ref<F, R>(&self, f: F) -> R
     where
         F: FnOnce(&[u8]) -> R,
@@ -31,7 +35,7 @@ impl PyBytesLike {
     }
 }
 
-impl PyRwBytesLike {
+impl ArgMemoryBuffer {
     pub fn with_ref<F, R>(&self, f: F) -> R
     where
         F: FnOnce(&mut [u8]) -> R,
@@ -48,7 +52,7 @@ impl PyRwBytesLike {
     }
 }
 
-impl PyBytesLike {
+impl ArgBytesLike {
     pub fn new(vm: &VirtualMachine, obj: &PyObjectRef) -> PyResult<Self> {
         let buffer = PyBufferRef::try_from_borrowed_object(vm, obj)?;
         if buffer.get_options().contiguous {
@@ -67,7 +71,7 @@ impl PyBytesLike {
     }
 }
 
-impl TryFromObject for PyBytesLike {
+impl TryFromObject for ArgBytesLike {
     fn try_from_object(vm: &VirtualMachine, obj: PyObjectRef) -> PyResult<Self> {
         Self::new(vm, &obj)
     }
@@ -96,7 +100,7 @@ pub fn try_rw_bytes_like<R>(
         .ok_or_else(|| vm.new_type_error("buffer is not a read-write bytes-like object".to_owned()))
 }
 
-impl PyRwBytesLike {
+impl ArgMemoryBuffer {
     pub fn new(vm: &VirtualMachine, obj: &PyObjectRef) -> PyResult<Self> {
         let buffer = PyBufferRef::try_from_borrowed_object(vm, obj)?;
         let options = buffer.get_options();
@@ -118,27 +122,27 @@ impl PyRwBytesLike {
     }
 }
 
-impl TryFromObject for PyRwBytesLike {
+impl TryFromObject for ArgMemoryBuffer {
     fn try_from_object(vm: &VirtualMachine, obj: PyObjectRef) -> PyResult<Self> {
         Self::new(vm, &obj)
     }
 }
 
-/// A buffer or utf8 string. Like the `s*` format code for `PyArg_Parse` in CPython.
-pub enum BufOrStr {
-    Buf(PyBytesLike),
+/// A text string or bytes-like object. Like the `s*` format code for `PyArg_Parse` in CPython.
+pub enum ArgStrOrBytesLike {
+    Buf(ArgBytesLike),
     Str(PyStrRef),
 }
 
-impl TryFromObject for BufOrStr {
+impl TryFromObject for ArgStrOrBytesLike {
     fn try_from_object(vm: &VirtualMachine, obj: PyObjectRef) -> PyResult<Self> {
         obj.downcast()
             .map(Self::Str)
-            .or_else(|obj| PyBytesLike::try_from_object(vm, obj).map(Self::Buf))
+            .or_else(|obj| ArgBytesLike::try_from_object(vm, obj).map(Self::Buf))
     }
 }
 
-impl BufOrStr {
+impl ArgStrOrBytesLike {
     pub fn borrow_bytes(&self) -> BorrowedValue<'_, [u8]> {
         match self {
             Self::Buf(b) => b.borrow_buf(),

--- a/vm/src/byteslike.rs
+++ b/vm/src/byteslike.rs
@@ -1,4 +1,4 @@
-use crate::builtins::memory::PyBufferRef;
+use crate::buffer::PyBufferRef;
 use crate::builtins::PyStrRef;
 use crate::common::borrow::{BorrowedValue, BorrowedValueMut};
 use crate::vm::VirtualMachine;

--- a/vm/src/cformat.rs
+++ b/vm/src/cformat.rs
@@ -1,8 +1,8 @@
+use crate::buffer::PyBufferRef;
 /// Implementation of Printf-Style string formatting
 /// [https://docs.python.org/3/library/stdtypes.html#printf-style-string-formatting]
 use crate::builtins::float::{try_bigint, IntoPyFloat, PyFloat};
 use crate::builtins::int::{self, PyInt};
-use crate::builtins::memory::PyBufferRef;
 use crate::builtins::pystr::PyStr;
 use crate::builtins::{tuple, PyBytes};
 use crate::common::float_ops;

--- a/vm/src/cformat.rs
+++ b/vm/src/cformat.rs
@@ -7,7 +7,9 @@ use crate::builtins::pystr::PyStr;
 use crate::builtins::{tuple, PyBytes};
 use crate::common::float_ops;
 use crate::vm::VirtualMachine;
-use crate::{ItemProtocol, PyObjectRef, PyResult, TryFromObject, TypeProtocol};
+use crate::{
+    ItemProtocol, PyObjectRef, PyResult, TryFromBorrowedObject, TryFromObject, TypeProtocol,
+};
 use itertools::Itertools;
 use num_bigint::{BigInt, Sign};
 use num_traits::cast::ToPrimitive;
@@ -364,7 +366,7 @@ impl CFormatSpec {
                     Ok(s.into_bytes())
                 }
                 CFormatPreconversor::Str | CFormatPreconversor::Bytes => {
-                    if let Ok(buffer) = PyBufferRef::try_from_object(vm, obj.clone()) {
+                    if let Ok(buffer) = PyBufferRef::try_from_borrowed_object(vm, &obj) {
                         let guard;
                         let vec;
                         let bytes = match buffer.as_contiguous() {

--- a/vm/src/cformat.rs
+++ b/vm/src/cformat.rs
@@ -391,7 +391,7 @@ impl CFormatSpec {
                                 ))
                             })?
                             .invoke((), vm)?;
-                        let bytes = PyBytes::try_from_object(vm, bytes)?;
+                        let bytes = PyBytes::try_from_borrowed_object(vm, &bytes)?;
                         Ok(self.format_bytes(bytes.as_bytes()))
                     }
                 }

--- a/vm/src/lib.rs
+++ b/vm/src/lib.rs
@@ -43,6 +43,7 @@ pub use rustpython_derive::*;
 pub mod macros;
 
 mod anystr;
+mod buffer;
 pub mod builtins;
 mod bytesinner;
 pub mod byteslike;

--- a/vm/src/pyobject.rs
+++ b/vm/src/pyobject.rs
@@ -827,6 +827,18 @@ pub trait TryFromObject: Sized {
     fn try_from_object(vm: &VirtualMachine, obj: PyObjectRef) -> PyResult<Self>;
 }
 
+/// Rust-side only version of TryFromObject to reduce unnessessary Rc::clone
+impl<T: TryFromBorrowedObject> TryFromObject for T {
+    fn try_from_object(vm: &VirtualMachine, obj: PyObjectRef) -> PyResult<Self> {
+        TryFromBorrowedObject::try_from_borrowed_object(vm, &obj)
+    }
+}
+
+pub trait TryFromBorrowedObject: Sized {
+    /// Attempt to convert a Python object to a value of this type.
+    fn try_from_borrowed_object(vm: &VirtualMachine, obj: &PyObjectRef) -> PyResult<Self>;
+}
+
 /// Marks a type that has the exact same layout as PyObjectRef, e.g. a type that is
 /// `repr(transparent)` over PyObjectRef.
 ///

--- a/vm/src/slots.rs
+++ b/vm/src/slots.rs
@@ -1,6 +1,4 @@
-use std::cmp::Ordering;
-
-use crate::builtins::memory::PyBuffer;
+use crate::buffer::PyBuffer;
 use crate::builtins::pystr::PyStrRef;
 use crate::common::hash::PyHash;
 use crate::common::lock::PyRwLock;
@@ -12,6 +10,7 @@ use crate::{
     TypeProtocol,
 };
 use crossbeam_utils::atomic::AtomicCell;
+use std::cmp::Ordering;
 
 bitflags! {
     pub struct PyTpFlags: u64 {

--- a/vm/src/slots.rs
+++ b/vm/src/slots.rs
@@ -493,7 +493,7 @@ pub trait SlotSetattro: PyValue {
 }
 
 #[pyimpl]
-pub trait BufferProtocol: PyValue {
+pub trait AsBuffer: PyValue {
     #[pyslot]
     fn tp_as_buffer(zelf: &PyObjectRef, vm: &VirtualMachine) -> PyResult<Box<dyn PyBuffer>> {
         if let Some(zelf) = zelf.downcast_ref() {

--- a/vm/src/stdlib/array.rs
+++ b/vm/src/stdlib/array.rs
@@ -1,6 +1,6 @@
+use crate::buffer::{BufferOptions, PyBuffer, ResizeGuard};
 use crate::builtins::float::IntoPyFloat;
 use crate::builtins::list::{PyList, PyListRef};
-use crate::builtins::memory::{BufferOptions, PyBuffer, ResizeGuard};
 use crate::builtins::pystr::PyStrRef;
 use crate::builtins::pytype::PyTypeRef;
 use crate::builtins::slice::PySliceRef;

--- a/vm/src/stdlib/array.rs
+++ b/vm/src/stdlib/array.rs
@@ -13,7 +13,7 @@ use crate::common::lock::{
 };
 use crate::function::OptionalArg;
 use crate::sliceable::{saturate_index, PySliceableSequence, PySliceableSequenceMut};
-use crate::slots::{BufferProtocol, Comparable, Iterable, PyComparisonOp, PyIter};
+use crate::slots::{AsBuffer, Comparable, Iterable, PyComparisonOp, PyIter};
 use crate::utils::Either;
 use crate::VirtualMachine;
 use crate::{
@@ -488,7 +488,7 @@ impl From<ArrayContentType> for PyArray {
     }
 }
 
-#[pyimpl(flags(BASETYPE), with(Comparable, BufferProtocol, Iterable))]
+#[pyimpl(flags(BASETYPE), with(Comparable, AsBuffer, Iterable))]
 impl PyArray {
     fn read(&self) -> PyRwLockReadGuard<'_, ArrayContentType> {
         self.array.read()
@@ -848,7 +848,7 @@ impl Comparable for PyArray {
     }
 }
 
-impl BufferProtocol for PyArray {
+impl AsBuffer for PyArray {
     fn get_buffer(zelf: &PyRef<Self>, _vm: &VirtualMachine) -> PyResult<Box<dyn PyBuffer>> {
         zelf.exports.fetch_add(1);
         let array = zelf.read();

--- a/vm/src/stdlib/array.rs
+++ b/vm/src/stdlib/array.rs
@@ -5,7 +5,7 @@ use crate::builtins::pystr::PyStrRef;
 use crate::builtins::pytype::PyTypeRef;
 use crate::builtins::slice::PySliceRef;
 use crate::builtins::{PyByteArray, PyBytes};
-use crate::byteslike::{try_bytes_like, PyBytesLike};
+use crate::byteslike::{try_bytes_like, ArgBytesLike};
 use crate::common::borrow::{BorrowedValue, BorrowedValueMut};
 use crate::common::lock::{
     PyMappedRwLockReadGuard, PyMappedRwLockWriteGuard, PyRwLock, PyRwLockReadGuard,
@@ -585,7 +585,7 @@ impl PyArray {
     }
 
     #[pymethod]
-    fn frombytes(zelf: PyRef<Self>, b: PyBytesLike, vm: &VirtualMachine) -> PyResult<()> {
+    fn frombytes(zelf: PyRef<Self>, b: ArgBytesLike, vm: &VirtualMachine) -> PyResult<()> {
         let b = b.borrow_buf();
         let itemsize = zelf.read().itemsize();
         if b.len() % itemsize != 0 {

--- a/vm/src/stdlib/binascii.rs
+++ b/vm/src/stdlib/binascii.rs
@@ -5,7 +5,7 @@ mod decl {
     use crate::builtins::bytearray::{PyByteArray, PyByteArrayRef};
     use crate::builtins::bytes::{PyBytes, PyBytesRef};
     use crate::builtins::pystr::{PyStr, PyStrRef};
-    use crate::byteslike::PyBytesLike;
+    use crate::byteslike::ArgBytesLike;
     use crate::function::OptionalArg;
     use crate::vm::VirtualMachine;
     use crate::{PyObjectRef, PyResult, TryFromObject, TypeProtocol};
@@ -61,7 +61,7 @@ mod decl {
 
     #[pyfunction(name = "b2a_hex")]
     #[pyfunction]
-    fn hexlify(data: PyBytesLike) -> Vec<u8> {
+    fn hexlify(data: ArgBytesLike) -> Vec<u8> {
         data.with_ref(|bytes| {
             let mut hex = Vec::<u8>::with_capacity(bytes.len() * 2);
             for b in bytes.iter() {
@@ -135,7 +135,7 @@ mod decl {
     }
 
     #[pyfunction]
-    fn b2a_base64(data: PyBytesLike, NewlineArg { newline }: NewlineArg) -> Vec<u8> {
+    fn b2a_base64(data: ArgBytesLike, NewlineArg { newline }: NewlineArg) -> Vec<u8> {
         #[allow(clippy::redundant_closure)] // https://stackoverflow.com/questions/63916821
         let mut encoded = data.with_ref(|b| base64::encode(b)).into_bytes();
         if newline {

--- a/vm/src/stdlib/codecs.rs
+++ b/vm/src/stdlib/codecs.rs
@@ -5,7 +5,7 @@ mod _codecs {
     use std::ops::Range;
 
     use crate::builtins::{PyBytesRef, PyStr, PyStrRef, PyTuple};
-    use crate::byteslike::PyBytesLike;
+    use crate::byteslike::ArgBytesLike;
     use crate::codecs;
     use crate::common::encodings;
     use crate::exceptions::PyBaseExceptionRef;
@@ -202,7 +202,7 @@ mod _codecs {
     #[derive(FromArgs)]
     struct DecodeArgs {
         #[pyarg(positional)]
-        data: PyBytesLike,
+        data: ArgBytesLike,
         #[pyarg(positional, optional)]
         errors: Option<PyStrRef>,
         #[pyarg(positional, default = "false")]

--- a/vm/src/stdlib/fcntl.rs
+++ b/vm/src/stdlib/fcntl.rs
@@ -4,7 +4,7 @@ pub(crate) use fcntl::make_module;
 mod fcntl {
     use super::super::{io, os};
     use crate::builtins::int;
-    use crate::byteslike::{BufOrStr, PyRwBytesLike};
+    use crate::byteslike::{ArgMemoryBuffer, ArgStrOrBytesLike};
     use crate::function::OptionalArg;
     use crate::utils::Either;
     use crate::PyResult;
@@ -25,7 +25,7 @@ mod fcntl {
     fn fcntl(
         io::Fildes(fd): io::Fildes,
         cmd: i32,
-        arg: OptionalArg<Either<BufOrStr, int::PyIntRef>>,
+        arg: OptionalArg<Either<ArgStrOrBytesLike, int::PyIntRef>>,
         vm: &VirtualMachine,
     ) -> PyResult {
         let int = match arg {
@@ -59,7 +59,7 @@ mod fcntl {
     fn ioctl(
         fd: i32,
         request: i32,
-        arg: OptionalArg<Either<Either<PyRwBytesLike, BufOrStr>, i32>>,
+        arg: OptionalArg<Either<Either<ArgMemoryBuffer, ArgStrOrBytesLike>, i32>>,
         mutate_flag: OptionalArg<bool>,
         vm: &VirtualMachine,
     ) -> PyResult {

--- a/vm/src/stdlib/io.rs
+++ b/vm/src/stdlib/io.rs
@@ -77,9 +77,8 @@ mod _io {
     use std::io::{self, prelude::*, Cursor, SeekFrom};
     use std::ops::Range;
 
-    use crate::builtins::memory::{
-        BufferOptions, PyBuffer, PyBufferRef, PyMemoryView, ResizeGuard,
-    };
+    use crate::buffer::{BufferOptions, PyBuffer, PyBufferRef, ResizeGuard};
+    use crate::builtins::memory::PyMemoryView;
     use crate::builtins::{
         bytes::{PyBytes, PyBytesRef},
         pybool, pytype, PyByteArray, PyStr, PyStrRef, PyTypeRef,

--- a/vm/src/stdlib/io.rs
+++ b/vm/src/stdlib/io.rs
@@ -83,7 +83,7 @@ mod _io {
         bytes::{PyBytes, PyBytesRef},
         pybool, pytype, PyByteArray, PyStr, PyStrRef, PyTypeRef,
     };
-    use crate::byteslike::{PyBytesLike, PyRwBytesLike};
+    use crate::byteslike::{ArgBytesLike, ArgMemoryBuffer};
     use crate::common::borrow::{BorrowedValue, BorrowedValueMut};
     use crate::common::lock::{
         PyMappedThreadMutexGuard, PyMutex, PyRwLock, PyRwLockReadGuard, PyRwLockWriteGuard,
@@ -439,7 +439,7 @@ mod _io {
             let read = vm.get_attribute(instance, "read")?;
             let mut res = Vec::new();
             while size.map_or(true, |s| res.len() < s) {
-                let read_res = PyBytesLike::try_from_object(vm, vm.invoke(&read, (1,))?)?;
+                let read_res = ArgBytesLike::try_from_object(vm, vm.invoke(&read, (1,))?)?;
                 if read_res.with_ref(|b| b.is_empty()) {
                     break;
                 }
@@ -618,14 +618,14 @@ mod _io {
             method: &str,
             vm: &VirtualMachine,
         ) -> PyResult<usize> {
-            let b = PyRwBytesLike::new(vm, &bufobj)?;
+            let b = ArgMemoryBuffer::new(vm, &bufobj)?;
             let l = b.len();
             let data = vm.call_method(&zelf, method, (l,))?;
             if data.is(&bufobj) {
                 return Ok(l);
             }
             let mut buf = b.borrow_buf_mut();
-            let data = PyBytesLike::try_from_object(vm, data)?;
+            let data = ArgBytesLike::try_from_object(vm, data)?;
             let data = data.borrow_buf();
             match buf.get_mut(..data.len()) {
                 Some(slice) => {
@@ -912,7 +912,7 @@ mod _io {
             Ok(Some(n as usize))
         }
 
-        fn write(&mut self, obj: PyBytesLike, vm: &VirtualMachine) -> PyResult<usize> {
+        fn write(&mut self, obj: ArgBytesLike, vm: &VirtualMachine) -> PyResult<usize> {
             if !self.valid_read() && !self.valid_write() {
                 self.pos = 0;
                 self.raw_pos = 0;
@@ -1624,14 +1624,14 @@ mod _io {
             Ok(v)
         }
         #[pymethod]
-        fn readinto(&self, buf: PyRwBytesLike, vm: &VirtualMachine) -> PyResult<Option<usize>> {
+        fn readinto(&self, buf: ArgMemoryBuffer, vm: &VirtualMachine) -> PyResult<Option<usize>> {
             let mut data = self.reader().lock(vm)?;
             let raw = data.check_init(vm)?;
             ensure_unclosed(raw, "readinto of closed file", vm)?;
             data.readinto_generic(buf.into_buffer(), false, vm)
         }
         #[pymethod]
-        fn readinto1(&self, buf: PyRwBytesLike, vm: &VirtualMachine) -> PyResult<Option<usize>> {
+        fn readinto1(&self, buf: ArgMemoryBuffer, vm: &VirtualMachine) -> PyResult<Option<usize>> {
             let mut data = self.reader().lock(vm)?;
             let raw = data.check_init(vm)?;
             ensure_unclosed(raw, "readinto of closed file", vm)?;
@@ -1677,7 +1677,7 @@ mod _io {
         type Writer: BufferedMixin;
         fn writer(&self) -> &Self::Writer;
         #[pymethod]
-        fn write(&self, obj: PyBytesLike, vm: &VirtualMachine) -> PyResult<usize> {
+        fn write(&self, obj: ArgBytesLike, vm: &VirtualMachine) -> PyResult<usize> {
             let mut data = self.writer().lock(vm)?;
             let raw = data.check_init(vm)?;
             ensure_unclosed(raw, "write to closed file", vm)?;
@@ -2946,7 +2946,7 @@ mod _io {
             let chunk_size = std::cmp::max(self.chunk_size, size_hint);
             let input_chunk = vm.call_method(&self.buffer, method, (chunk_size,))?;
 
-            let buf = PyBytesLike::new(vm, &input_chunk).map_err(|_| {
+            let buf = ArgBytesLike::new(vm, &input_chunk).map_err(|_| {
                 vm.new_type_error(format!(
                     "underlying {}() should have returned a bytes-like object, not '{}'",
                     method,
@@ -3256,7 +3256,7 @@ mod _io {
     #[pyimpl]
     impl BytesIORef {
         #[pymethod]
-        fn write(self, data: PyBytesLike, vm: &VirtualMachine) -> PyResult<u64> {
+        fn write(self, data: ArgBytesLike, vm: &VirtualMachine) -> PyResult<u64> {
             let mut buffer = self.try_resizable(vm)?;
             match data.with_ref(|b| buffer.write(b)) {
                 Some(value) => Ok(value),
@@ -3284,7 +3284,7 @@ mod _io {
         }
 
         #[pymethod]
-        fn readinto(self, obj: PyRwBytesLike, vm: &VirtualMachine) -> PyResult<usize> {
+        fn readinto(self, obj: ArgMemoryBuffer, vm: &VirtualMachine) -> PyResult<usize> {
             let mut buf = self.buffer(vm)?;
             let ret = buf
                 .cursor
@@ -3724,7 +3724,7 @@ mod fileio {
     use super::Offset;
     use super::_io::*;
     use crate::builtins::{PyStr, PyStrRef, PyTypeRef};
-    use crate::byteslike::{PyBytesLike, PyRwBytesLike};
+    use crate::byteslike::{ArgBytesLike, ArgMemoryBuffer};
     use crate::crt_fd::Fd;
     use crate::exceptions::IntoPyException;
     use crate::function::OptionalOption;
@@ -4025,7 +4025,7 @@ mod fileio {
         }
 
         #[pymethod]
-        fn readinto(&self, obj: PyRwBytesLike, vm: &VirtualMachine) -> PyResult<usize> {
+        fn readinto(&self, obj: ArgMemoryBuffer, vm: &VirtualMachine) -> PyResult<usize> {
             if !self.mode.load().contains(Mode::READABLE) {
                 return Err(new_unsupported_operation(
                     vm,
@@ -4043,7 +4043,7 @@ mod fileio {
         }
 
         #[pymethod]
-        fn write(&self, obj: PyBytesLike, vm: &VirtualMachine) -> PyResult<usize> {
+        fn write(&self, obj: ArgBytesLike, vm: &VirtualMachine) -> PyResult<usize> {
             if !self.mode.load().contains(Mode::WRITABLE) {
                 return Err(new_unsupported_operation(
                     vm,

--- a/vm/src/stdlib/marshal.rs
+++ b/vm/src/stdlib/marshal.rs
@@ -5,7 +5,7 @@ mod decl {
     use crate::builtins::bytes::PyBytes;
     use crate::builtins::code::{PyCode, PyCodeRef};
     use crate::bytecode;
-    use crate::byteslike::PyBytesLike;
+    use crate::byteslike::ArgBytesLike;
     use crate::vm::VirtualMachine;
     use crate::{PyObjectRef, PyResult, TryFromObject};
 
@@ -21,7 +21,7 @@ mod decl {
     }
 
     #[pyfunction]
-    fn loads(code_bytes: PyBytesLike, vm: &VirtualMachine) -> PyResult<PyCode> {
+    fn loads(code_bytes: ArgBytesLike, vm: &VirtualMachine) -> PyResult<PyCode> {
         let code =
             bytecode::CodeObject::from_bytes(&*code_bytes.borrow_buf()).map_err(|e| match e {
                 bytecode::CodeDeserializeError::Eof => vm.new_exception_msg(
@@ -38,7 +38,7 @@ mod decl {
     #[pyfunction]
     fn load(f: PyObjectRef, vm: &VirtualMachine) -> PyResult<PyCode> {
         let read_res = vm.call_method(&f, "read", ())?;
-        let bytes = PyBytesLike::try_from_object(vm, read_res)?;
+        let bytes = ArgBytesLike::try_from_object(vm, read_res)?;
         loads(bytes, vm)
     }
 }

--- a/vm/src/stdlib/multiprocessing.rs
+++ b/vm/src/stdlib/multiprocessing.rs
@@ -4,7 +4,7 @@ pub(crate) use _multiprocessing::make_module;
 #[pymodule]
 mod _multiprocessing {
     use super::super::os;
-    use crate::byteslike::PyBytesLike;
+    use crate::byteslike::ArgBytesLike;
     use crate::PyResult;
     use crate::VirtualMachine;
     use winapi::um::winsock2::{self, SOCKET};
@@ -32,7 +32,7 @@ mod _multiprocessing {
     }
 
     #[pyfunction]
-    fn send(socket: usize, buf: PyBytesLike, vm: &VirtualMachine) -> PyResult<libc::c_int> {
+    fn send(socket: usize, buf: ArgBytesLike, vm: &VirtualMachine) -> PyResult<libc::c_int> {
         let ret = buf.with_ref(|b| unsafe {
             winsock2::send(socket as SOCKET, b.as_ptr() as *const _, b.len() as i32, 0)
         });

--- a/vm/src/stdlib/operator.rs
+++ b/vm/src/stdlib/operator.rs
@@ -15,7 +15,7 @@ mod _operator {
     use crate::builtins::pystr::PyStrRef;
     use crate::builtins::PyInt;
     use crate::builtins::PyTypeRef;
-    use crate::byteslike::PyBytesLike;
+    use crate::byteslike::ArgBytesLike;
     use crate::common::cmp;
     use crate::function::FuncArgs;
     use crate::function::KwArgs;
@@ -402,8 +402,8 @@ mod _operator {
     /// types and lengths of a and b--but not their values.
     #[pyfunction]
     fn _compare_digest(
-        a: Either<PyStrRef, PyBytesLike>,
-        b: Either<PyStrRef, PyBytesLike>,
+        a: Either<PyStrRef, ArgBytesLike>,
+        b: Either<PyStrRef, ArgBytesLike>,
         vm: &VirtualMachine,
     ) -> PyResult<bool> {
         let res = match (a, b) {

--- a/vm/src/stdlib/os.rs
+++ b/vm/src/stdlib/os.rs
@@ -21,7 +21,7 @@ use crate::builtins::pystr::{PyStr, PyStrRef};
 use crate::builtins::pytype::PyTypeRef;
 use crate::builtins::set::PySet;
 use crate::builtins::tuple::{PyTuple, PyTupleRef};
-use crate::byteslike::PyBytesLike;
+use crate::byteslike::ArgBytesLike;
 use crate::common::lock::PyRwLock;
 use crate::exceptions::{IntoPyException, PyBaseExceptionRef};
 use crate::function::{ArgumentError, FromArgs, FuncArgs, OptionalArg};
@@ -541,10 +541,10 @@ mod _os {
     fn _extract_vec_bytes(
         x: OptionalArg,
         vm: &VirtualMachine,
-    ) -> PyResult<Option<Vec<PyBytesLike>>> {
+    ) -> PyResult<Option<Vec<ArgBytesLike>>> {
         let inner = match x.into_option() {
             Some(v) => {
-                let v = vm.extract_elements::<PyBytesLike>(&v)?;
+                let v = vm.extract_elements::<ArgBytesLike>(&v)?;
                 if v.is_empty() {
                     None
                 } else {
@@ -575,7 +575,6 @@ mod _os {
         let headers = headers.as_deref();
 
         let trailers = _extract_vec_bytes(args.trailers, vm)?;
-
         let trailers = trailers
             .as_ref()
             .map(|v| v.iter().map(|b| b.borrow_buf()).collect::<Vec<_>>());
@@ -614,7 +613,7 @@ mod _os {
     }
 
     #[pyfunction]
-    fn write(fd: i32, data: PyBytesLike, vm: &VirtualMachine) -> PyResult {
+    fn write(fd: i32, data: ArgBytesLike, vm: &VirtualMachine) -> PyResult {
         let mut file = Fd(fd);
         let written = data
             .with_ref(|b| file.write(b))

--- a/vm/src/stdlib/pyexpat.rs
+++ b/vm/src/stdlib/pyexpat.rs
@@ -33,7 +33,7 @@ macro_rules! create_property {
 #[pymodule(name = "pyexpat")]
 mod _pyexpat {
     use crate::builtins::{PyStr, PyStrRef, PyTypeRef};
-    use crate::byteslike::PyBytesLike;
+    use crate::byteslike::ArgBytesLike;
     use crate::function::{IntoFuncArgs, OptionalArg};
     use crate::pyobject::StaticType;
     use crate::{
@@ -173,7 +173,7 @@ mod _pyexpat {
         fn parse_file(&self, file: PyObjectRef, vm: &VirtualMachine) -> PyResult<()> {
             // todo: read chunks at a time
             let read_res = vm.call_method(&file, "read", ())?;
-            let bytes_like = PyBytesLike::try_from_object(vm, read_res)?;
+            let bytes_like = ArgBytesLike::try_from_object(vm, read_res)?;
             let buf = bytes_like.borrow_buf().to_vec();
             let reader = Cursor::new(buf);
             let parser = self.create_config().create_reader(reader);

--- a/vm/src/stdlib/sre.rs
+++ b/vm/src/stdlib/sre.rs
@@ -2,13 +2,8 @@ pub(crate) use _sre::make_module;
 
 #[pymodule]
 mod _sre {
-    use crossbeam_utils::atomic::AtomicCell;
-    use itertools::Itertools;
-    use num_traits::ToPrimitive;
-    use rustpython_common::hash::PyHash;
-
+    use crate::buffer::PyBufferRef;
     use crate::builtins::list::PyListRef;
-    use crate::builtins::memory::PyBufferRef;
     use crate::builtins::tuple::PyTupleRef;
     use crate::builtins::{
         PyCallableIterator, PyDictRef, PyInt, PyList, PyStr, PyStrRef, PyTypeRef,
@@ -21,6 +16,10 @@ mod _sre {
         PyValue, StaticType, TryFromBorrowedObject, TryFromObject,
     };
     use core::str;
+    use crossbeam_utils::atomic::AtomicCell;
+    use itertools::Itertools;
+    use num_traits::ToPrimitive;
+    use rustpython_common::hash::PyHash;
     use sre_engine::constants::SreFlag;
     use sre_engine::engine::{lower_ascii, lower_unicode, upper_unicode, State, StrDrive};
 

--- a/vm/src/stdlib/sre.rs
+++ b/vm/src/stdlib/sre.rs
@@ -18,7 +18,7 @@ mod _sre {
     use crate::VirtualMachine;
     use crate::{
         IntoPyObject, ItemProtocol, PyCallable, PyComparisonValue, PyObjectRef, PyRef, PyResult,
-        PyValue, StaticType, TryFromObject,
+        PyValue, StaticType, TryFromBorrowedObject, TryFromObject,
     };
     use core::str;
     use sre_engine::constants::SreFlag;
@@ -153,7 +153,7 @@ mod _sre {
             let vec;
             let s;
             let str_drive = if self.isbytes {
-                buffer = PyBufferRef::try_from_object(vm, string.clone())?;
+                buffer = PyBufferRef::try_from_borrowed_object(vm, &string)?;
                 let bytes = match buffer.as_contiguous() {
                     Some(bytes) => {
                         guard = bytes;

--- a/vm/src/stdlib/zlib.rs
+++ b/vm/src/stdlib/zlib.rs
@@ -5,7 +5,7 @@ mod decl {
     use crate::builtins::bytes::{PyBytes, PyBytesRef};
     use crate::builtins::int::{self, PyIntRef};
     use crate::builtins::pytype::PyTypeRef;
-    use crate::byteslike::PyBytesLike;
+    use crate::byteslike::ArgBytesLike;
     use crate::common::lock::PyMutex;
     use crate::exceptions::PyBaseExceptionRef;
     use crate::function::OptionalArg;
@@ -66,7 +66,7 @@ mod decl {
 
     /// Compute an Adler-32 checksum of data.
     #[pyfunction]
-    fn adler32(data: PyBytesLike, begin_state: OptionalArg<PyIntRef>) -> u32 {
+    fn adler32(data: ArgBytesLike, begin_state: OptionalArg<PyIntRef>) -> u32 {
         data.with_ref(|data| {
             let begin_state = begin_state.map_or(1, |i| int::bigint_unsigned_mask(i.as_bigint()));
 
@@ -78,7 +78,7 @@ mod decl {
 
     /// Compute a CRC-32 checksum of data.
     #[pyfunction]
-    fn crc32(data: PyBytesLike, begin_state: OptionalArg<PyIntRef>) -> u32 {
+    fn crc32(data: ArgBytesLike, begin_state: OptionalArg<PyIntRef>) -> u32 {
         data.with_ref(|data| {
             let begin_state = begin_state.map_or(0, |i| int::bigint_unsigned_mask(i.as_bigint()));
 
@@ -100,7 +100,7 @@ mod decl {
 
     /// Returns a bytes object containing compressed data.
     #[pyfunction]
-    fn compress(data: PyBytesLike, level: OptionalArg<i32>, vm: &VirtualMachine) -> PyResult {
+    fn compress(data: ArgBytesLike, level: OptionalArg<i32>, vm: &VirtualMachine) -> PyResult {
         let compression = compression_from_int(level.into_option())
             .ok_or_else(|| new_zlib_error("Bad compression level", vm))?;
 
@@ -230,7 +230,7 @@ mod decl {
     /// Returns a bytes object containing the uncompressed data.
     #[pyfunction]
     fn decompress(
-        data: PyBytesLike,
+        data: ArgBytesLike,
         wbits: OptionalArg<i8>,
         bufsize: OptionalArg<usize>,
         vm: &VirtualMachine,
@@ -396,7 +396,7 @@ mod decl {
     #[derive(FromArgs)]
     struct DecompressArgs {
         #[pyarg(positional)]
-        data: PyBytesLike,
+        data: ArgBytesLike,
         #[pyarg(any, default = "0")]
         max_length: usize,
     }
@@ -407,7 +407,7 @@ mod decl {
         wbits: OptionalArg<i8>,
         #[cfg(feature = "zlib")]
         #[pyarg(any, optional)]
-        zdict: OptionalArg<PyBytesLike>,
+        zdict: OptionalArg<ArgBytesLike>,
     }
 
     #[pyfunction]
@@ -419,7 +419,7 @@ mod decl {
         // these aren't used.
         _mem_level: OptionalArg<i32>, // this is memLevel in CPython
         _strategy: OptionalArg<i32>,
-        _zdict: OptionalArg<PyBytesLike>,
+        _zdict: OptionalArg<ArgBytesLike>,
         vm: &VirtualMachine,
     ) -> PyResult<PyCompress> {
         let level = compression_from_int(level.into_option())
@@ -455,7 +455,7 @@ mod decl {
     #[pyimpl]
     impl PyCompress {
         #[pymethod]
-        fn compress(&self, data: PyBytesLike, vm: &VirtualMachine) -> PyResult<Vec<u8>> {
+        fn compress(&self, data: ArgBytesLike, vm: &VirtualMachine) -> PyResult<Vec<u8>> {
             let mut inner = self.inner.lock();
             data.with_ref(|b| inner.compress(b, vm))
         }

--- a/wasm/lib/src/convert.rs
+++ b/wasm/lib/src/convert.rs
@@ -2,7 +2,7 @@ use js_sys::{Array, ArrayBuffer, Object, Promise, Reflect, SyntaxError, Uint8Arr
 use wasm_bindgen::{closure::Closure, prelude::*, JsCast};
 
 use rustpython_parser::error::ParseErrorType;
-use rustpython_vm::byteslike::PyBytesLike;
+use rustpython_vm::byteslike::ArgBytesLike;
 use rustpython_vm::compile::{CompileError, CompileErrorType};
 use rustpython_vm::exceptions::PyBaseExceptionRef;
 use rustpython_vm::function::FuncArgs;
@@ -139,7 +139,7 @@ pub fn py_to_js(vm: &VirtualMachine, py_obj: PyObjectRef) -> JsValue {
         }
     }
 
-    if let Ok(bytes) = PyBytesLike::try_from_object(vm, py_obj.clone()) {
+    if let Ok(bytes) = ArgBytesLike::try_from_object(vm, py_obj.clone()) {
         bytes.with_ref(|bytes| unsafe {
             // `Uint8Array::view` is an `unsafe fn` because it provides
             // a direct view into the WASM linear memory; if you were to allocate

--- a/wasm/lib/src/convert.rs
+++ b/wasm/lib/src/convert.rs
@@ -8,7 +8,9 @@ use rustpython_vm::exceptions::PyBaseExceptionRef;
 use rustpython_vm::function::FuncArgs;
 use rustpython_vm::VirtualMachine;
 use rustpython_vm::{exceptions, py_serde};
-use rustpython_vm::{ItemProtocol, PyObjectRef, PyResult, PyValue, TryFromObject, TypeProtocol};
+use rustpython_vm::{
+    ItemProtocol, PyObjectRef, PyResult, PyValue, TryFromBorrowedObject, TypeProtocol,
+};
 
 use crate::js_module;
 use crate::vm_class::{stored_vm_from_wasm, WASMVirtualMachine};
@@ -139,7 +141,7 @@ pub fn py_to_js(vm: &VirtualMachine, py_obj: PyObjectRef) -> JsValue {
         }
     }
 
-    if let Ok(bytes) = ArgBytesLike::try_from_object(vm, py_obj.clone()) {
+    if let Ok(bytes) = ArgBytesLike::try_from_borrowed_object(vm, &py_obj) {
         bytes.with_ref(|bytes| unsafe {
             // `Uint8Array::view` is an `unsafe fn` because it provides
             // a direct view into the WASM linear memory; if you were to allocate


### PR DESCRIPTION
TryFromBorrowedObject reduces unnessessary cloning.

PyBuffer is a trait for buffer protocol but hidden in memory view codes. Giving it a sole module will be a guideline for future protocols.

renamed `PyBytesLike`, `PyRwBytesLike` and `BufOrStr` into `ArgBytesLike`, `ArgMemoryBuffer` and `ArgStrOrBytesLike` by following the description of `getarg.c`. Let's keep `Py` prefixes only for actual python objects.


closes #2854