### PR TITLE
support deque.insert when idx is gte to len

### DIFF
--- a/Lib/test/test_deque.py
+++ b/Lib/test/test_deque.py
@@ -328,8 +328,6 @@ class TestBasic(unittest.TestCase):
         with self.assertRaises(ValueError):
             i = d.index("Hello world", 0, 4)
 
-    # TODO: RUSTPYTHON
-    @unittest.expectedFailure
     def test_insert(self):
         # Test to make sure insert behaves like lists
         elements = 'ABCDEFGHI'

--- a/vm/src/stdlib/collections.rs
+++ b/vm/src/stdlib/collections.rs
@@ -180,8 +180,8 @@ mod _collections {
                 } else {
                     deque.len() - ((-idx) as usize)
                 }
-            } else if idx as usize >= deque.len() {
-                deque.len() - 1
+            } else if idx as usize > deque.len() {
+                deque.len()
             } else {
                 idx as usize
             };


### PR DESCRIPTION
before: 

when idx >= len it doesn't insert the element to the end
it inserted to index len-1

after:  

when idx >= len it inserts the element to the end of the deque