### PR TITLE
Cleans up `pyclassmethod` definition

### DIFF
--- a/vm/src/stdlib/itertools.rs
+++ b/vm/src/stdlib/itertools.rs
@@ -49,7 +49,7 @@ mod decl {
             .into_ref_with_type(vm, cls)
         }
 
-        #[pyclassmethod(name = "from_iterable")]
+        #[pyclassmethod]
         fn from_iterable(
             cls: PyTypeRef,
             iterable: PyObjectRef,


### PR DESCRIPTION
Only a single `pyclassmethod` was invalid 🎉 

I think that this is the last PR in this series: https://github.com/RustPython/RustPython/pull/2867
All other usages like `pyattr` and `pyslot` are fine 👍 
