### PR TITLE
Removes unused imports

### DIFF
--- a/vm/src/stdlib/os.rs
+++ b/vm/src/stdlib/os.rs
@@ -2110,7 +2110,7 @@ mod posix {
     #[cfg(any(target_os = "macos", target_os = "ios"))]
     fn getgroups_impl() -> nix::Result<Vec<Gid>> {
         use libc::{c_int, gid_t};
-        use nix::errno::{errno, Errno};
+        use nix::errno::Errno;
         use std::ptr;
         let ret = unsafe { libc::getgroups(0, ptr::null_mut()) };
         let mut groups = Vec::<Gid>::with_capacity(Errno::result(ret)? as usize);

--- a/vm/src/stdlib/os.rs
+++ b/vm/src/stdlib/os.rs
@@ -143,6 +143,7 @@ impl FsPath {
             Self::Bytes(_) => OutputMode::Bytes,
         }
     }
+    #[cfg(not(target_os = "redox"))]
     pub(crate) fn as_bytes(&self) -> &[u8] {
         // TODO: FS encodings
         match self {

--- a/vm/src/stdlib/posixsubprocess.rs
+++ b/vm/src/stdlib/posixsubprocess.rs
@@ -32,7 +32,7 @@ mod _posixsubprocess {
 
 use nix::{errno::Errno, unistd};
 use std::convert::Infallible as Never;
-use std::ffi::{CStr, CString};
+use std::ffi::CString;
 use std::io::{self, prelude::*};
 use std::os::unix::io::AsRawFd;
 

--- a/vm/src/stdlib/posixsubprocess.rs
+++ b/vm/src/stdlib/posixsubprocess.rs
@@ -36,7 +36,7 @@ use std::convert::Infallible as Never;
 use std::ffi::CStr;
 use std::ffi::CString;
 use std::io::{self, prelude::*};
-#[cfg(unix)]
+#[cfg(not(target_os = "redox"))]
 use std::os::unix::io::AsRawFd;
 
 use super::os;

--- a/vm/src/stdlib/posixsubprocess.rs
+++ b/vm/src/stdlib/posixsubprocess.rs
@@ -32,6 +32,8 @@ mod _posixsubprocess {
 
 use nix::{errno::Errno, unistd};
 use std::convert::Infallible as Never;
+#[cfg(not(target_os = "redox"))]
+use std::ffi::CStr;
 use std::ffi::CString;
 use std::io::{self, prelude::*};
 use std::os::unix::io::AsRawFd;

--- a/vm/src/stdlib/posixsubprocess.rs
+++ b/vm/src/stdlib/posixsubprocess.rs
@@ -36,6 +36,7 @@ use std::convert::Infallible as Never;
 use std::ffi::CStr;
 use std::ffi::CString;
 use std::io::{self, prelude::*};
+#[cfg(unix)]
 use std::os::unix::io::AsRawFd;
 
 use super::os;


### PR DESCRIPTION
Commit https://github.com/RustPython/RustPython/commit/ca5c07b9f35f0bbc7d697f1d9d8810a12bfdc85e introduces a number of `cargo` warnings about unused imports. This is a naive attempt to solve its warnings.