### PR TITLE
Adds .editorconfig file

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,17 @@
+# Check http://editorconfig.org for more information
+# This is the main config file for this project:
+root = true
+
+[*]
+charset = utf-8
+indent_style = space
+trim_trailing_whitespace = true
+end_of_line = lf
+insert_final_newline = true
+indent_size = 2
+
+[*.py]
+indent_size = 4
+
+[*.rs]
+indent_size = 4


### PR DESCRIPTION
It was really bothering me that my `vscode` was not adding 4 spaces as the default ident.

What is `editorconfig`? It is a tool to standartize things like new lines, idents, and whitespaces across different editors and different OSes.
Docs: https://editorconfig.org/