### PR TITLE
Remove unnecessary slot wrapper addition

### DIFF
--- a/Lib/test/test_enum.py
+++ b/Lib/test/test_enum.py
@@ -1698,8 +1698,6 @@ class TestEnum(unittest.TestCase):
             test = 1
         self.assertEqual(Test.test.test, 'dynamic')
 
-    # TODO: RUSTPYTHON
-    @unittest.expectedFailure
     def test_no_duplicates(self):
         class UniqueEnum(Enum):
             def __init__(self, *args):

--- a/vm/src/builtins/pytype.rs
+++ b/vm/src/builtins/pytype.rs
@@ -467,8 +467,6 @@ impl PyType {
         let typ = new(metatype, name.as_str(), base, bases, attributes, slots)
             .map_err(|e| vm.new_type_error(e))?;
 
-        vm.ctx.add_slot_wrappers(&typ);
-
         // avoid deadlock
         let attributes = typ
             .attributes


### PR DESCRIPTION
This pull request resolves #2869.

## Before (RustPython)

```
>>>>> class A: ...
>>>>> A.__new__
<bound method __new__ of <class '__main__.A'>>
>>>>> object.__new__
<bound method __new__ of <class 'object'>>
>>>>> A.__new__ == object.__new__
False
```

## After (RustPython)

```
>>>>> class A: ...
>>>>> A.__new__
<bound method __new__ of <class 'object'>>
>>>>> object.__new__
<bound method __new__ of <class 'object'>>
>>>>> A.__new__ == object.__new__
True
```