### PR TITLE
Fix frozenset copy to return self

### DIFF
--- a/Lib/test/test_set.py
+++ b/Lib/test/test_set.py
@@ -738,8 +738,6 @@ class TestFrozenSet(TestJointOps, unittest.TestCase):
             results.add(hash(self.thetype(seq)))
         self.assertEqual(len(results), 1)
 
-    # TODO: RUSTPYTHON
-    @unittest.expectedFailure
     def test_copy(self):
         dup = self.s.copy()
         self.assertEqual(id(self.s), id(dup))

--- a/vm/src/builtins/set.rs
+++ b/vm/src/builtins/set.rs
@@ -605,10 +605,8 @@ impl PyFrozenSet {
     }
 
     #[pymethod]
-    fn copy(&self) -> Self {
-        Self {
-            inner: self.inner.copy(),
-        }
+    fn copy(zelf: PyRef<Self>) -> PyRef<Self> {
+        zelf
     }
 
     #[pymethod(name = "__contains__")]

--- a/vm/src/builtins/set.rs
+++ b/vm/src/builtins/set.rs
@@ -605,8 +605,15 @@ impl PyFrozenSet {
     }
 
     #[pymethod]
-    fn copy(zelf: PyRef<Self>) -> PyRef<Self> {
-        zelf
+    fn copy(zelf: PyRef<Self>, vm: &VirtualMachine) -> PyRef<Self> {
+        if zelf.class().is(&vm.ctx.types.frozenset_type) {
+            zelf
+        } else {
+            Self {
+                inner: zelf.inner.copy(),
+            }
+            .into_ref(vm)
+        }
     }
 
     #[pymethod(name = "__contains__")]


### PR DESCRIPTION
This revision fixes issue #2877

implementation referenced on `imul` method of `PyList`.

#### Before
```python
>>>>> f = frozenset(range(1000))
>>>>> f2 = f.copy()
>>>>> f is f2
False
```

#### After
```python
>>>>> f = frozenset(range(1000))
>>>>> f2 = f.copy()
>>>>> f is f2
True
```