### PR TITLE
Fix failed test pow in test_math

### DIFF
--- a/Lib/test/test_math.py
+++ b/Lib/test/test_math.py
@@ -1142,8 +1142,6 @@ class MathTests(unittest.TestCase):
         self.assertTrue(math.isnan(modf_nan[0]))
         self.assertTrue(math.isnan(modf_nan[1]))
 
-    # TODO: RUSTPYTHON
-    @unittest.expectedFailure
     def testPow(self):
         self.assertRaises(TypeError, math.pow)
         self.ftest('pow(0,1)', math.pow(0,1), 0)

--- a/vm/src/stdlib/math.rs
+++ b/vm/src/stdlib/math.rs
@@ -131,8 +131,21 @@ fn math_log1p(x: IntoPyFloat) -> f64 {
 make_math_func!(math_log2, log2);
 make_math_func!(math_log10, log10);
 
-fn math_pow(x: IntoPyFloat, y: IntoPyFloat) -> f64 {
-    x.to_f64().powf(y.to_f64())
+fn math_pow(x: IntoPyFloat, y: IntoPyFloat, vm: &VirtualMachine) -> PyResult<f64> {
+    let x = x.to_f64();
+    let y = y.to_f64();
+    
+    if x < 0.0 && x.is_finite() && y.fract() != 0.0 && y.is_finite() {
+        return Err(vm.new_value_error("math domain error".to_owned()));
+    }
+
+    if x == 0.0 && y < 0.0 {
+        return Err(vm.new_value_error("math domain error".to_owned()));
+    }
+
+    let value = x.powf(y);
+
+    return Ok(value);
 }
 
 fn math_sqrt(value: IntoPyFloat, vm: &VirtualMachine) -> PyResult<f64> {

--- a/vm/src/stdlib/math.rs
+++ b/vm/src/stdlib/math.rs
@@ -145,7 +145,7 @@ fn math_pow(x: IntoPyFloat, y: IntoPyFloat, vm: &VirtualMachine) -> PyResult<f64
 
     let value = x.powf(y);
 
-    return Ok(value);
+    Ok(value)
 }
 
 fn math_sqrt(value: IntoPyFloat, vm: &VirtualMachine) -> PyResult<f64> {

--- a/vm/src/stdlib/math.rs
+++ b/vm/src/stdlib/math.rs
@@ -134,7 +134,7 @@ make_math_func!(math_log10, log10);
 fn math_pow(x: IntoPyFloat, y: IntoPyFloat, vm: &VirtualMachine) -> PyResult<f64> {
     let x = x.to_f64();
     let y = y.to_f64();
-    
+
     if x < 0.0 && x.is_finite() && y.fract() != 0.0 && y.is_finite() {
         return Err(vm.new_value_error("math domain error".to_owned()));
     }


### PR DESCRIPTION
add two conditions to raise ValueError for input values

case 1: NaN, when both input values are finite, and base is negative and exponent is non-integer
case 2: divde by zero, when base is 0 exponent is negative value