### PR TITLE
Introduce `__text_signature__` property

### DIFF
--- a/vm/src/builtins/builtinfunc.rs
+++ b/vm/src/builtins/builtinfunc.rs
@@ -147,6 +147,7 @@ impl PyBuiltinFunction {
     fn text_signature(&self) -> Option<String> {
         self.value.doc.as_ref().and_then(|doc| {
             pytype::get_text_signature_from_internal_doc(self.value.name.as_str(), doc.as_str())
+                .map(|signature| signature.to_string())
         })
     }
 }
@@ -218,6 +219,7 @@ impl PyBuiltinMethod {
     fn text_signature(&self) -> Option<String> {
         self.value.doc.as_ref().and_then(|doc| {
             pytype::get_text_signature_from_internal_doc(self.value.name.as_str(), doc.as_str())
+                .map(|signature| signature.to_string())
         })
     }
     #[pymethod(magic)]

--- a/vm/src/builtins/builtinfunc.rs
+++ b/vm/src/builtins/builtinfunc.rs
@@ -1,6 +1,7 @@
 use std::fmt;
 
 use super::classmethod::PyClassMethod;
+use super::pytype;
 use crate::builtins::pystr::PyStrRef;
 use crate::builtins::pytype::PyTypeRef;
 use crate::function::{FuncArgs, PyNativeFunc};
@@ -142,6 +143,16 @@ impl PyBuiltinFunction {
     fn repr(&self) -> String {
         format!("<built-in function {}>", self.value.name)
     }
+    #[pyproperty(magic)]
+    fn text_signature(&self, vm: &VirtualMachine) -> PyObjectRef {
+        match self.value.doc.as_ref()
+            .and_then(|doc| pytype::get_text_signature_from_internal_doc(
+                self.value.name.as_str(),
+                doc.as_str())) {
+            Some(signature) => vm.ctx.new_str(signature),
+            None => vm.ctx.none(),
+        }
+    }
 }
 
 // `PyBuiltinMethod` is similar to both `PyMethodDescrObject` in
@@ -206,6 +217,16 @@ impl PyBuiltinMethod {
     #[pyproperty(magic)]
     fn doc(&self) -> Option<PyStrRef> {
         self.value.doc.clone()
+    }
+    #[pyproperty(magic)]
+    fn text_signature(&self, vm: &VirtualMachine) -> PyObjectRef {
+        match self.value.doc.as_ref()
+            .and_then(|doc| pytype::get_text_signature_from_internal_doc(
+                self.value.name.as_str(),
+                doc.as_str())) {
+            Some(signature) => vm.ctx.new_str(signature),
+            None => vm.ctx.none(),
+        }
     }
     #[pymethod(magic)]
     fn repr(&self) -> String {

--- a/vm/src/builtins/builtinfunc.rs
+++ b/vm/src/builtins/builtinfunc.rs
@@ -144,13 +144,10 @@ impl PyBuiltinFunction {
         format!("<built-in function {}>", self.value.name)
     }
     #[pyproperty(magic)]
-    fn text_signature(&self, vm: &VirtualMachine) -> PyObjectRef {
-        match self.value.doc.as_ref().and_then(|doc| {
+    fn text_signature(&self) -> Option<String> {
+        self.value.doc.as_ref().and_then(|doc| {
             pytype::get_text_signature_from_internal_doc(self.value.name.as_str(), doc.as_str())
-        }) {
-            Some(signature) => vm.ctx.new_str(signature),
-            None => vm.ctx.none(),
-        }
+        })
     }
 }
 
@@ -218,13 +215,10 @@ impl PyBuiltinMethod {
         self.value.doc.clone()
     }
     #[pyproperty(magic)]
-    fn text_signature(&self, vm: &VirtualMachine) -> PyObjectRef {
-        match self.value.doc.as_ref().and_then(|doc| {
+    fn text_signature(&self) -> Option<String> {
+        self.value.doc.as_ref().and_then(|doc| {
             pytype::get_text_signature_from_internal_doc(self.value.name.as_str(), doc.as_str())
-        }) {
-            Some(signature) => vm.ctx.new_str(signature),
-            None => vm.ctx.none(),
-        }
+        })
     }
     #[pymethod(magic)]
     fn repr(&self) -> String {

--- a/vm/src/builtins/builtinfunc.rs
+++ b/vm/src/builtins/builtinfunc.rs
@@ -145,10 +145,9 @@ impl PyBuiltinFunction {
     }
     #[pyproperty(magic)]
     fn text_signature(&self, vm: &VirtualMachine) -> PyObjectRef {
-        match self.value.doc.as_ref()
-            .and_then(|doc| pytype::get_text_signature_from_internal_doc(
-                self.value.name.as_str(),
-                doc.as_str())) {
+        match self.value.doc.as_ref().and_then(|doc| {
+            pytype::get_text_signature_from_internal_doc(self.value.name.as_str(), doc.as_str())
+        }) {
             Some(signature) => vm.ctx.new_str(signature),
             None => vm.ctx.none(),
         }
@@ -220,10 +219,9 @@ impl PyBuiltinMethod {
     }
     #[pyproperty(magic)]
     fn text_signature(&self, vm: &VirtualMachine) -> PyObjectRef {
-        match self.value.doc.as_ref()
-            .and_then(|doc| pytype::get_text_signature_from_internal_doc(
-                self.value.name.as_str(),
-                doc.as_str())) {
+        match self.value.doc.as_ref().and_then(|doc| {
+            pytype::get_text_signature_from_internal_doc(self.value.name.as_str(), doc.as_str())
+        }) {
             Some(signature) => vm.ctx.new_str(signature),
             None => vm.ctx.none(),
         }

--- a/vm/src/builtins/object.rs
+++ b/vm/src/builtins/object.rs
@@ -14,7 +14,13 @@ use crate::{
     PyContext, PyObject, PyObjectRef, PyResult, PyValue, TryFromObject, TypeProtocol,
 };
 
-/// The most base type
+/// object()
+/// --
+///
+/// The base class of the class hierarchy.
+///
+/// When called, it accepts no arguments and returns a new featureless
+/// instance that has no instance attributes and cannot be given any.
 #[pyclass(module = false, name = "object")]
 #[derive(Debug)]
 pub struct PyBaseObject;
@@ -27,6 +33,10 @@ impl PyValue for PyBaseObject {
 
 #[pyimpl(flags(BASETYPE))]
 impl PyBaseObject {
+    /// __new__($type, *args, **kwargs)
+    /// --
+    ///
+    /// Create and return a new object.  See help(type) for accurate signature.
     #[pyslot]
     fn tp_new(mut args: FuncArgs, vm: &VirtualMachine) -> PyResult {
         // more or less __new__ operator
@@ -82,6 +92,10 @@ impl PyBaseObject {
         Ok(res)
     }
 
+    /// __eq__($self, value, /)
+    /// --
+    ///
+    /// Return self==value.
     #[pymethod(magic)]
     fn eq(
         zelf: PyObjectRef,
@@ -90,6 +104,11 @@ impl PyBaseObject {
     ) -> PyResult<PyComparisonValue> {
         Self::cmp(&zelf, &other, PyComparisonOp::Eq, vm)
     }
+
+    /// __ne__($self, value, /)
+    /// --
+    ///
+    /// Return self!=value.
     #[pymethod(magic)]
     fn ne(
         zelf: PyObjectRef,
@@ -98,6 +117,11 @@ impl PyBaseObject {
     ) -> PyResult<PyComparisonValue> {
         Self::cmp(&zelf, &other, PyComparisonOp::Ne, vm)
     }
+
+    /// __lt__($self, value, /)
+    /// --
+    ///
+    /// Return self<value.
     #[pymethod(magic)]
     fn lt(
         zelf: PyObjectRef,
@@ -106,6 +130,11 @@ impl PyBaseObject {
     ) -> PyResult<PyComparisonValue> {
         Self::cmp(&zelf, &other, PyComparisonOp::Lt, vm)
     }
+
+    /// __le__($self, value, /)
+    /// --
+    ///
+    /// Return self<=value.
     #[pymethod(magic)]
     fn le(
         zelf: PyObjectRef,
@@ -114,6 +143,11 @@ impl PyBaseObject {
     ) -> PyResult<PyComparisonValue> {
         Self::cmp(&zelf, &other, PyComparisonOp::Le, vm)
     }
+
+    /// __ge__($self, value, /)
+    /// --
+    ///
+    /// Return self>=value.
     #[pymethod(magic)]
     fn ge(
         zelf: PyObjectRef,
@@ -122,6 +156,11 @@ impl PyBaseObject {
     ) -> PyResult<PyComparisonValue> {
         Self::cmp(&zelf, &other, PyComparisonOp::Ge, vm)
     }
+
+    /// __gt__($self, value, /)
+    /// --
+    ///
+    /// Return self>value.
     #[pymethod(magic)]
     fn gt(
         zelf: PyObjectRef,
@@ -131,6 +170,10 @@ impl PyBaseObject {
         Self::cmp(&zelf, &other, PyComparisonOp::Gt, vm)
     }
 
+    /// __setattr__($self, name, value /)
+    /// --
+    ///
+    /// Implement setattr(self, name, value).
     #[pymethod]
     fn __setattr__(
         obj: PyObjectRef,
@@ -141,6 +184,10 @@ impl PyBaseObject {
         setattr(&obj, attr_name, Some(value), vm)
     }
 
+    /// __delattr__($self, name, /)
+    /// --
+    ///
+    /// Implement delattr(self, name).
     #[pymethod]
     fn __delattr__(obj: PyObjectRef, attr_name: PyStrRef, vm: &VirtualMachine) -> PyResult<()> {
         setattr(&obj, attr_name, None, vm)
@@ -156,11 +203,19 @@ impl PyBaseObject {
         setattr(obj, attr_name, value, vm)
     }
 
+    /// __str__($self, /)
+    /// --
+    ///
+    /// Return str(self).
     #[pymethod(magic)]
     fn str(zelf: PyObjectRef, vm: &VirtualMachine) -> PyResult<PyStrRef> {
         vm.to_repr(&zelf)
     }
 
+    /// __repr__($self, /)
+    /// --
+    ///
+    /// Return repr(self).
     #[pymethod(magic)]
     fn repr(zelf: PyObjectRef) -> String {
         format!("<{} object at {:#x}>", zelf.class().name, zelf.get_id())
@@ -233,6 +288,10 @@ impl PyBaseObject {
         }
     }
 
+    /// __getattribute__($self, name, /)
+    /// --
+    ///
+    /// Return getattr(self, name).
     #[pymethod(name = "__getattribute__")]
     #[pyslot]
     pub(crate) fn getattro(obj: PyObjectRef, name: PyStrRef, vm: &VirtualMachine) -> PyResult {
@@ -262,6 +321,10 @@ impl PyBaseObject {
         Ok(zelf.get_id() as _)
     }
 
+    /// __hash__($self, /)
+    /// --
+    ///
+    /// Return hash(self).
     #[pymethod(magic)]
     fn hash(zelf: PyObjectRef, vm: &VirtualMachine) -> PyResult<PyHash> {
         Self::tp_hash(&zelf, vm)

--- a/vm/src/builtins/pytype.rs
+++ b/vm/src/builtins/pytype.rs
@@ -520,9 +520,9 @@ impl PyType {
 
     #[pyproperty(magic)]
     fn text_signature(&self) -> Option<String> {
-        let doc_string = self.get_attr("__doc__");
-        let doc: PyStrRef = doc_string.and_then(|o| o.downcast().ok())?;
-        get_text_signature_from_internal_doc(self.name().as_str(), doc.as_str())
+        self.slots
+            .doc
+            .and_then(|doc| get_text_signature_from_internal_doc(self.name().as_str(), doc))
             .map(|signature| signature.to_string())
     }
 }

--- a/vm/src/builtins/pytype.rs
+++ b/vm/src/builtins/pytype.rs
@@ -533,15 +533,12 @@ impl PyType {
 
 const SIGNATURE_END_MARKER: &str = ")\n--\n\n";
 fn skip_signature(doc: String) -> Option<String> {
-    if let Some(index) = doc.find(SIGNATURE_END_MARKER) {
-        Some(doc[..index + 1].to_owned())
-    } else {
-        None
-    }
+    doc.find(SIGNATURE_END_MARKER)
+        .map(|index| doc[..index + 1].to_owned())
 }
 
 fn find_signature(name: &str, doc: &str) -> Option<String> {
-    let dot_index = name.rfind(".");
+    let dot_index = name.rfind('.');
     let name = match dot_index {
         Some(index) => name[index + 1..].to_owned(),
         _ => name.to_owned(),
@@ -552,7 +549,7 @@ fn find_signature(name: &str, doc: &str) -> Option<String> {
     }
 
     let doc = doc[name.len()..].to_owned();
-    if doc.chars().nth(0).unwrap() != '(' {
+    if doc.chars().next().unwrap() != '(' {
         None
     } else {
         Some(doc)
@@ -563,7 +560,7 @@ pub(crate) fn get_text_signature_from_internal_doc(
     name: &str,
     internal_doc: &str,
 ) -> Option<String> {
-    find_signature(name, internal_doc).and_then(|signature| skip_signature(signature))
+    find_signature(name, internal_doc).and_then(skip_signature)
 }
 
 impl SlotGetattro for PyType {

--- a/vm/src/builtins/pytype.rs
+++ b/vm/src/builtins/pytype.rs
@@ -519,15 +519,12 @@ impl PyType {
     }
 
     #[pyproperty(magic)]
-    fn text_signature(&self, vm: &VirtualMachine) -> PyObjectRef {
+    fn text_signature(&self) -> Option<String> {
         let doc_string = self.get_attr("__doc__");
         let doc_string: Option<PyStrRef> = doc_string.and_then(|o| o.downcast().ok());
-        match doc_string.and_then(|doc| {
+        doc_string.and_then(|doc| {
             get_text_signature_from_internal_doc(self.name().as_str(), doc.as_str())
-        }) {
-            Some(doc) => vm.ctx.new_str(doc),
-            _ => vm.ctx.none(),
-        }
+        })
     }
 }
 

--- a/vm/src/builtins/pytype.rs
+++ b/vm/src/builtins/pytype.rs
@@ -528,11 +528,6 @@ impl PyType {
 }
 
 const SIGNATURE_END_MARKER: &str = ")\n--\n\n";
-fn skip_signature(doc: &str) -> Option<&str> {
-    doc.find(SIGNATURE_END_MARKER)
-        .map(|index| &doc[index + SIGNATURE_END_MARKER.len()..])
-}
-
 fn get_signature(doc: &str) -> Option<&str> {
     doc.find(SIGNATURE_END_MARKER)
         .map(|index| &doc[..index + 1])

--- a/vm/src/builtins/pytype.rs
+++ b/vm/src/builtins/pytype.rs
@@ -546,7 +546,7 @@ fn find_signature(name: &str, doc: &str) -> Option<String> {
     }
 
     let doc = doc[name.len()..].to_owned();
-    if doc.chars().next().unwrap() != '(' {
+    if !doc.starts_with('(') {
         None
     } else {
         Some(doc)

--- a/vm/src/builtins/pytype.rs
+++ b/vm/src/builtins/pytype.rs
@@ -522,7 +522,9 @@ impl PyType {
     fn text_signature(&self, vm: &VirtualMachine) -> PyObjectRef {
         let doc_string = self.get_attr("__doc__");
         let doc_string: Option<PyStrRef> = doc_string.and_then(|o| o.downcast().ok());
-        match doc_string.and_then(|doc| get_text_signature_from_internal_doc(self.name().as_str(), doc.as_str())) {
+        match doc_string.and_then(|doc| {
+            get_text_signature_from_internal_doc(self.name().as_str(), doc.as_str())
+        }) {
             Some(doc) => vm.ctx.new_str(doc),
             _ => vm.ctx.none(),
         }
@@ -557,7 +559,10 @@ fn find_signature(name: &str, doc: &str) -> Option<String> {
     }
 }
 
-pub(crate) fn get_text_signature_from_internal_doc(name: &str, internal_doc: &str) -> Option<String> {
+pub(crate) fn get_text_signature_from_internal_doc(
+    name: &str,
+    internal_doc: &str,
+) -> Option<String> {
     find_signature(name, internal_doc).and_then(|signature| skip_signature(signature))
 }
 

--- a/vm/src/builtins/pytype.rs
+++ b/vm/src/builtins/pytype.rs
@@ -530,6 +530,11 @@ impl PyType {
 const SIGNATURE_END_MARKER: &str = ")\n--\n\n";
 fn skip_signature(doc: &str) -> Option<&str> {
     doc.find(SIGNATURE_END_MARKER)
+        .map(|index| &doc[index + SIGNATURE_END_MARKER.len()..])
+}
+
+fn get_signature(doc: &str) -> Option<&str> {
+    doc.find(SIGNATURE_END_MARKER)
         .map(|index| &doc[..index + 1])
 }
 
@@ -547,7 +552,7 @@ pub(crate) fn get_text_signature_from_internal_doc<'a>(
     name: &str,
     internal_doc: &'a str,
 ) -> Option<&'a str> {
-    find_signature(name, internal_doc).and_then(skip_signature)
+    find_signature(name, internal_doc).and_then(get_signature)
 }
 
 impl SlotGetattro for PyType {

--- a/vm/src/pyobject.rs
+++ b/vm/src/pyobject.rs
@@ -1126,6 +1126,7 @@ pub trait PyClassImpl: PyClassDef {
         let mut slots = PyTypeSlots {
             flags: Self::TP_FLAGS,
             name: PyRwLock::new(Some(Self::TP_NAME.to_owned())),
+            doc: Self::DOC,
             ..Default::default()
         };
         Self::extend_slots(&mut slots);

--- a/vm/src/slots.rs
+++ b/vm/src/slots.rs
@@ -96,7 +96,9 @@ pub struct PyTypeSlots {
 
     // Flags to define presence of optional/expanded features
     pub flags: PyTpFlags,
+
     // tp_doc
+    pub doc: Option<&'static str>,
 
     // Strong reference on a heap type, borrowed reference on a static type
     // tp_base


### PR DESCRIPTION
This pull request tries to resolve #2410 

This pull request does:
- Fill 'object' type's missing docstrings 0b52d0c 
- Introduce new `__text_signature__` property to `PyType`, `PyBuiltinMethod`, `PyBuiltinFunction`. 40ab1c4 

## Code to verify compatibility

```python
print(object.__str__.__text_signature__)  # expected `($self, /)`
print(object.__text_signature__)  # expected `()`
print(type.__text_signature__)  # expected `None` (no output)
```

## References

- parse `__text_signature__` logic: https://github.com/python/cpython/blob/fa919fdf2583bdfead1df00e842f24f30b2a34bf/Objects/typeobject.c#L183-L203