### PR TITLE
Skip tests that cause RustPython to hang.

### DIFF
--- a/Lib/test/lock_tests.py
+++ b/Lib/test/lock_tests.py
@@ -128,6 +128,7 @@ class BaseLockTests(BaseTestCase):
         self.assertFalse(result[0])
         lock.release()
 
+    @unittest.skip("TODO: RUSTPYTHON, sometimes hangs")
     def test_acquire_contended(self):
         lock = self.locktype()
         lock.acquire()

--- a/Lib/test/lock_tests.py
+++ b/Lib/test/lock_tests.py
@@ -161,6 +161,7 @@ class BaseLockTests(BaseTestCase):
         # Check the lock is unacquired
         Bunch(f, 1).wait_for_finished()
 
+    @unittest.skip("TODO: RUSTPYTHON, sometimes hangs")
     def test_thread_leak(self):
         # The lock shouldn't leak a Thread instance when used from a foreign
         # (non-threading) thread.

--- a/Lib/test/test_importlib/test_locks.py
+++ b/Lib/test/test_importlib/test_locks.py
@@ -87,6 +87,7 @@ class DeadlockAvoidanceTests:
         self.assertEqual(len(results), NTHREADS)
         return results
 
+    @unittest.skip("TODO: RUSTPYTHON, sometimes hangs")
     def test_deadlock(self):
         results = self.run_deadlock_avoidance_test(True)
         # At least one of the threads detected a potential deadlock on its


### PR DESCRIPTION
Temporarily so that other PRs don't get stalled until its fixed. Note that these don't hang consistently, they do hang often, though.