### PR TITLE
Implement missing Iterator & ReverseIterator and its methods

### DIFF
--- a/Lib/test/test_iter.py
+++ b/Lib/test/test_iter.py
@@ -313,8 +313,6 @@ class TestCase(unittest.TestCase):
         self.check_for_loop(iter(range(10)), list(range(10)))
 
     # Test a string
-    # TODO: RUSTPYTHON
-    @unittest.expectedFailure
     def test_iter_string(self):
         self.check_for_loop(iter("abcde"), ["a", "b", "c", "d", "e"])
 

--- a/vm/src/builtins/pystr.rs
+++ b/vm/src/builtins/pystr.rs
@@ -4,7 +4,6 @@ use std::string::ToString;
 use std::{char, ffi, fmt};
 
 use crossbeam_utils::atomic::AtomicCell;
-
 use itertools::Itertools;
 use num_traits::ToPrimitive;
 use unic_ucd_bidi::BidiClass;


### PR DESCRIPTION
This revision implements the missing `PyTuple` reverse iterator and methods for `PyStrIterator` and `PyReverseIterator`

#### PyTupleReverseIterator
```python
>>>>> t = reversed(tuple('hello'))
>>>>> t.__reduce__()
(<built-in function iter>, (('h', 'e', 'l', 'l', 'o'),), 4)
>>>>> t.__setstate__(2)
>>>>> t.__reduce__()
(<built-in function iter>, (('h', 'e', 'l', 'l', 'o'),), 2)
>>>>> operator.length_hint(t)
3
>>>>> list(t)
['l', 'e', 'h']
```

#### PyStrIterator
```python
>>>>> s = 'hello'
>>>>> s = iter('hello')
>>>>> s.__reduce__()
(<built-in function iter>, ('hello',), 0)
>>>>> s.__setstate__(2)
>>>>> s.__reduce__()
(<built-in function iter>, ('hello',), 2)
>>>>> operator.length_hint(s)
3
>>>>> list(s)
['l', 'l', 'o']
```

#### PyStrReverseIterator
```python
>>>>> s = reversed('hello')
>>>>> s.__reduce__()
(<built-in function reversed>, ('hello',), 4)
>>>>> s.__setstate__(2)
>>>>> s.__reduce__()
(<built-in function reversed>, ('hello',), 2)
>>>>> operator.length_hint(s)
3
>>>>> list(s)
['l', 'e', 'h']
```

These changes solve some part of `TestReversed.test_len` in [test_enumerate.py](https://github.com/RustPython/RustPython/blob/master/Lib/test/test_enumerate.py#L177).
I also look into some cpython codes for fixing the rest of failed test in `test_len`,  current implementation of [`iterator::length_hint`](https://github.com/RustPython/RustPython/blob/master/vm/src/iterator.rs#L109) need to be replaced by `sequence protocol`. 
Therefore I add trivial comments about it.