### PR TITLE
adjust dict reverse iterator next to new dict entries structure

### DIFF
--- a/Lib/test/test_dict.py
+++ b/Lib/test/test_dict.py
@@ -1340,8 +1340,6 @@ class DictTest(unittest.TestCase):
 
         self.assertRaises(RuntimeError, iter_and_mutate)
 
-    # TODO: RUSTPYTHON
-    @unittest.expectedFailure
     def test_reversed(self):
         d = {"a": 1, "b": 2, "foo": 0, "c": 3, "d": 4}
         del d["foo"]

--- a/vm/src/builtins/dict.rs
+++ b/vm/src/builtins/dict.rs
@@ -753,7 +753,7 @@ macro_rules! dict_iterator {
         impl $reverse_iter_name {
             fn new(dict: PyDictRef) -> Self {
                 $reverse_iter_name {
-                    position: AtomicCell::new(1),
+                    position: AtomicCell::new(0),
                     size: dict.size(),
                     dict,
                     status: AtomicCell::new(IterStatus::Active),
@@ -782,10 +782,10 @@ macro_rules! dict_iterator {
                                 "dictionary changed size during iteration".to_owned(),
                             ));
                         }
-                        let count = zelf.position.fetch_add(1);
-                        match zelf.dict.len().checked_sub(count) {
-                            Some(mut pos) => {
-                                let (key, value) = zelf.dict.entries.next_entry(&mut pos).unwrap();
+                        let mut position = zelf.position.load();
+                        match zelf.dict.entries.next_entry_reversed(&mut position) {
+                            Some((key, value)) => {
+                                zelf.position.store(position);
                                 Ok(($result_fn)(vm, key, value))
                             }
                             None => {

--- a/vm/src/builtins/dict.rs
+++ b/vm/src/builtins/dict.rs
@@ -782,12 +782,8 @@ macro_rules! dict_iterator {
                                 "dictionary changed size during iteration".to_owned(),
                             ));
                         }
-                        let mut position = zelf.position.load();
-                        match zelf.dict.entries.next_entry_reversed(&mut position) {
-                            Some((key, value)) => {
-                                zelf.position.store(position);
-                                Ok(($result_fn)(vm, key, value))
-                            }
+                        match zelf.dict.entries.next_entry_reversed(&zelf.position) {
+                            Some((key, value)) => Ok(($result_fn)(vm, key, value)),
                             None => {
                                 zelf.status.store(IterStatus::Exhausted);
                                 Err(vm.new_stop_iteration())

--- a/vm/src/dictdatatype.rs
+++ b/vm/src/dictdatatype.rs
@@ -487,6 +487,19 @@ impl<T: Clone> Dict<T> {
         }
     }
 
+    pub fn next_entry_reversed(&self, position: &mut EntryIndex) -> Option<(PyObjectRef, T)> {
+        let inner = self.read();
+        let mut position_index = inner.entries.len().checked_sub(*position + 1)?;
+        loop {
+            let entry = inner.entries.get(position_index)?;
+            *position += 1;
+            if let Some(entry) = entry {
+                break Some((entry.key.clone(), entry.value.clone()));
+            }
+            position_index = position_index.checked_sub(1)?;
+        }
+    }
+
     pub fn len_from_entry_index(&self, position: EntryIndex) -> usize {
         self.read().entries.len() - position
     }


### PR DESCRIPTION
dict entries was changed due to remain order even when delete any element. #2902 

in this PR, i only adjust dict reverse iterator next function to this new dict entries structure.

however, there remains some issue about detecting the change while iteration.
before, the size change was equivalent to the change of the dictionary entries, so it was easy to detect it
however, making deletion not to erase entries, and insertion occurs on next_new_entry_idx, it is hard to detect change during iteration.
all iterators with dict may have this issue.