### PR TITLE
Fixes typos in vm/

### DIFF
--- a/Lib/importlib/_bootstrap_external.py
+++ b/Lib/importlib/_bootstrap_external.py
@@ -1097,7 +1097,7 @@ class ExtensionFileLoader(FileLoader, _LoaderBasics):
         return hash(self.name) ^ hash(self.path)
 
     def create_module(self, spec):
-        """Create an unitialized extension module"""
+        """Create an uninitialized extension module"""
         module = _bootstrap._call_with_frames_removed(
             _imp.create_dynamic, spec)
         _bootstrap._verbose_message('extension module {!r} loaded from {!r}',

--- a/vm/src/builtins/dict.rs
+++ b/vm/src/builtins/dict.rs
@@ -462,7 +462,7 @@ impl PyDictRef {
         key: K,
         vm: &VirtualMachine,
     ) -> PyResult<Option<PyObjectRef>> {
-        // Test if this object is a true dict, or mabye a subclass?
+        // Test if this object is a true dict, or maybe a subclass?
         // If it is a dict, we can directly invoke inner_get_item_option,
         // and prevent the creation of the KeyError exception.
         // Also note, that we prevent the creation of a full PyStr object

--- a/vm/src/builtins/float.rs
+++ b/vm/src/builtins/float.rs
@@ -409,8 +409,9 @@ impl PyFloat {
                 None if ndigits.is_positive() => i32::MAX,
                 None => i32::MIN,
             };
-            let float = float_ops::round_float_digits(self.value, ndigits)
-                .ok_or_else(|| vm.new_overflow_error("overflow ocurred during round".to_owned()))?;
+            let float = float_ops::round_float_digits(self.value, ndigits).ok_or_else(|| {
+                vm.new_overflow_error("overflow occurred during round".to_owned())
+            })?;
             vm.ctx.new_float(float)
         } else {
             let fract = self.value.fract();

--- a/vm/src/builtins/set.rs
+++ b/vm/src/builtins/set.rs
@@ -633,7 +633,7 @@ impl PyFrozenSet {
             vec![]
         };
 
-        // Return empty fs if iterable passed is emtpy and only for exact fs types.
+        // Return empty fs if iterable passed is empty and only for exact fs types.
         if elements.is_empty() && cls.is(&vm.ctx.types.frozenset_type) {
             Ok(vm.ctx.empty_frozenset.clone())
         } else {

--- a/vm/src/frame.rs
+++ b/vm/src/frame.rs
@@ -424,7 +424,7 @@ impl ExecutingFrame<'_> {
         }
     }
 
-    /// Ok(Err(e)) means that an error ocurred while calling throw() and the generator should try
+    /// Ok(Err(e)) means that an error occurred while calling throw() and the generator should try
     /// sending it
     fn gen_throw(
         &mut self,

--- a/vm/src/function.rs
+++ b/vm/src/function.rs
@@ -311,7 +311,7 @@ impl<T: TryFromObject> FromArgOptional for T {
 
 /// A map of keyword arguments to their values.
 ///
-/// A built-in function with a `KwArgs` parameter is analagous to a Python
+/// A built-in function with a `KwArgs` parameter is analogous to a Python
 /// function with `**kwargs`. All remaining keyword arguments are extracted
 /// (and hence the function will permit an arbitrary number of them).
 ///

--- a/vm/src/import.rs
+++ b/vm/src/import.rs
@@ -95,7 +95,7 @@ pub fn import_builtin(vm: &VirtualMachine, module_name: &str) -> PyResult {
         .get(module_name)
         .ok_or_else(|| {
             vm.new_import_error(
-                format!("Cannot import bultin module {}", module_name),
+                format!("Cannot import builtin module {}", module_name),
                 module_name,
             )
         })

--- a/vm/src/pyobject.rs
+++ b/vm/src/pyobject.rs
@@ -848,7 +848,7 @@ pub trait TryFromObject: Sized {
     fn try_from_object(vm: &VirtualMachine, obj: PyObjectRef) -> PyResult<Self>;
 }
 
-/// Rust-side only version of TryFromObject to reduce unnessessary Rc::clone
+/// Rust-side only version of TryFromObject to reduce unnecessary Rc::clone
 impl<T: TryFromBorrowedObject> TryFromObject for T {
     fn try_from_object(vm: &VirtualMachine, obj: PyObjectRef) -> PyResult<Self> {
         TryFromBorrowedObject::try_from_borrowed_object(vm, &obj)

--- a/vm/src/stdlib/collections.rs
+++ b/vm/src/stdlib/collections.rs
@@ -131,7 +131,7 @@ mod _collections {
                 deque.clear();
                 unsafe {
                     // `maxlen` is better to be defined as UnsafeCell in common practice,
-                    // but then more type works without any safety benifits
+                    // but then more type works without any safety benefits
                     let unsafe_maxlen =
                         &zelf.maxlen as *const _ as *const std::cell::UnsafeCell<Option<usize>>;
                     *(*unsafe_maxlen).get() = maxlen;

--- a/vm/src/stdlib/imp.rs
+++ b/vm/src/stdlib/imp.rs
@@ -71,7 +71,7 @@ fn _imp_create_builtin(spec: PyObjectRef, vm: &VirtualMachine) -> PyResult {
 }
 
 fn _imp_exec_builtin(_mod: PyModuleRef) -> i32 {
-    // TOOD: Should we do something here?
+    // TODO: Should we do something here?
     0
 }
 

--- a/vm/src/stdlib/io.rs
+++ b/vm/src/stdlib/io.rs
@@ -549,7 +549,7 @@ mod _io {
         #[pymethod]
         fn read(instance: PyObjectRef, size: OptionalSize, vm: &VirtualMachine) -> PyResult {
             if let Some(size) = size.to_usize() {
-                // FIXME: unnessessary zero-init
+                // FIXME: unnecessary zero-init
                 let b = PyByteArray::from(vec![0; size]).into_ref(vm);
                 let n = <Option<usize>>::try_from_object(
                     vm,

--- a/vm/src/stdlib/itertools.rs
+++ b/vm/src/stdlib/itertools.rs
@@ -586,7 +586,7 @@ mod decl {
             state.grouper = None;
 
             if !state.next_group {
-                // FIXME: unnecessary clone. current_key always exist until assinging new
+                // FIXME: unnecessary clone. current_key always exist until assigning new
                 let current_key = state.current_key.clone();
                 drop(state);
 

--- a/vm/src/stdlib/operator.rs
+++ b/vm/src/stdlib/operator.rs
@@ -224,7 +224,7 @@ mod _operator {
         vm._membership(a, b)
     }
 
-    /// Return the number of occurences of b in a.
+    /// Return the number of occurrences of b in a.
     #[pyfunction(name = "countOf")]
     fn count_of(a: PyObjectRef, b: PyObjectRef, vm: &VirtualMachine) -> PyResult<usize> {
         let mut count: usize = 0;
@@ -249,7 +249,7 @@ mod _operator {
         a.get_item(b, vm)
     }
 
-    /// Return the number of occurences of b in a.
+    /// Return the number of occurrences of b in a.
     #[pyfunction(name = "indexOf")]
     fn index_of(a: PyObjectRef, b: PyObjectRef, vm: &VirtualMachine) -> PyResult<usize> {
         let mut index: usize = 0;

--- a/vm/src/stdlib/pystruct.rs
+++ b/vm/src/stdlib/pystruct.rs
@@ -237,7 +237,7 @@ pub(crate) mod _struct {
             // First determine "@", "<", ">","!" or "="
             let endianness = parse_endianness(&mut chars);
 
-            // Now, analyze struct string furter:
+            // Now, analyze struct string further:
             let (codes, size, arg_count) = parse_format_codes(&mut chars, endianness)
                 .map_err(|err| new_struct_error(vm, err))?;
 

--- a/vm/src/stdlib/signal.rs
+++ b/vm/src/stdlib/signal.rs
@@ -154,8 +154,8 @@ fn trigger_signals(
     vm: &VirtualMachine,
 ) -> PyResult<()> {
     for (signum, trigger) in TRIGGERS.iter().enumerate().skip(1) {
-        let triggerd = trigger.swap(false, Ordering::Relaxed);
-        if triggerd {
+        let triggered = trigger.swap(false, Ordering::Relaxed);
+        if triggered {
             if let Some(handler) = &signal_handlers[signum] {
                 if vm.is_callable(handler) {
                     vm.invoke(handler, (signum, vm.ctx.none()))?;

--- a/vm/src/stdlib/sre.rs
+++ b/vm/src/stdlib/sre.rs
@@ -76,7 +76,7 @@ mod _sre {
     ) -> PyResult<Pattern> {
         // FIXME:
         // pattern could only be None if called by re.Scanner
-        // re.Scanner has no offical API and in CPython's implement
+        // re.Scanner has no official API and in CPython's implement
         // isbytes will be hanging (-1)
         // here is just a hack to let re.Scanner works only with str not bytes
         let isbytes = !vm.is_none(&pattern) && !pattern.payload_is::<PyStr>();

--- a/vm/src/stdlib/time.rs
+++ b/vm/src/stdlib/time.rs
@@ -61,7 +61,7 @@ pub fn get_time() -> f64 {
 fn time_time_ns(_vm: &VirtualMachine) -> u64 {
     match SystemTime::now().duration_since(UNIX_EPOCH) {
         Ok(v) => v.as_nanos() as u64,
-        Err(_) => unsafe { std::hint::unreachable_unchecked() }, // guaranted to be not to be happen with now() + UNIX_EPOCH,
+        Err(_) => unsafe { std::hint::unreachable_unchecked() }, // guaranteed to be not to be happen with now() + UNIX_EPOCH,
     }
 }
 

--- a/vm/src/stdlib/winapi.rs
+++ b/vm/src/stdlib/winapi.rs
@@ -25,22 +25,22 @@ fn husize(h: HANDLE) -> usize {
     h as usize
 }
 
-trait Convertable {
+trait Convertible {
     fn is_err(&self) -> bool;
 }
 
-impl Convertable for HANDLE {
+impl Convertible for HANDLE {
     fn is_err(&self) -> bool {
         *self == handleapi::INVALID_HANDLE_VALUE
     }
 }
-impl Convertable for i32 {
+impl Convertible for i32 {
     fn is_err(&self) -> bool {
         *self == 0
     }
 }
 
-fn cvt<T: Convertable>(vm: &VirtualMachine, res: T) -> PyResult<T> {
+fn cvt<T: Convertible>(vm: &VirtualMachine, res: T) -> PyResult<T> {
     if res.is_err() {
         Err(errno_err(vm))
     } else {

--- a/vm/src/sysmodule.rs
+++ b/vm/src/sysmodule.rs
@@ -604,7 +604,7 @@ prefix -- prefix used to find the Python library
 thread_info -- a struct sequence with information about the thread implementation.
 version -- the version of this interpreter as a string
 version_info -- version information as a named tuple
-_base_executable -- __PYVENV_LAUNCHER__ enviroment variable if defined, else sys.executable.
+_base_executable -- __PYVENV_LAUNCHER__ environment variable if defined, else sys.executable.
 
 __stdin__ -- the original stdin; don't touch!
 __stdout__ -- the original stdout; don't touch!

--- a/vm/src/vm.rs
+++ b/vm/src/vm.rs
@@ -377,7 +377,7 @@ impl VirtualMachine {
 
         let res = inner_init();
 
-        self.expect_pyresult(res, "initializiation failed");
+        self.expect_pyresult(res, "initialization failed");
 
         self.initialized = true;
     }
@@ -1658,7 +1658,7 @@ impl VirtualMachine {
                 .unwrap();
             Ok(match cmp(obj, other, op, self)? {
                 Either::A(obj) => PyArithmaticValue::from_object(self, obj).map(Either::A),
-                Either::B(arithmatic) => arithmatic.map(Either::B),
+                Either::B(arithmetic) => arithmetic.map(Either::B),
             })
         };
 


### PR DESCRIPTION
I used `codespell -L crate,struc,ser,ans,numer -w vm/`
https://github.com/codespell-project/codespell