### PR TITLE
make dict iterator use atomic operation

### DIFF
--- a/vm/src/builtins/dict.rs
+++ b/vm/src/builtins/dict.rs
@@ -578,7 +578,7 @@ impl Iterator for DictIter {
     type Item = (PyObjectRef, PyObjectRef);
 
     fn next(&mut self) -> Option<Self::Item> {
-        self.dict.entries._next_entry(&mut self.position)
+        self.dict.entries.next_entry(&mut self.position)
     }
 
     fn size_hint(&self) -> (usize, Option<usize>) {
@@ -718,7 +718,7 @@ macro_rules! dict_iterator {
                                 "dictionary changed size during iteration".to_owned(),
                             ));
                         }
-                        match zelf.dict.entries.next_entry(&zelf.position) {
+                        match zelf.dict.entries.next_entry_atomic(&zelf.position) {
                             Some((key, value)) => Ok(($result_fn)(vm, key, value)),
                             None => {
                                 zelf.status.store(IterStatus::Exhausted);
@@ -778,7 +778,7 @@ macro_rules! dict_iterator {
                                 "dictionary changed size during iteration".to_owned(),
                             ));
                         }
-                        match zelf.dict.entries.next_entry_reversed(&zelf.position) {
+                        match zelf.dict.entries.next_entry_atomic_reversed(&zelf.position) {
                             Some((key, value)) => Ok(($result_fn)(vm, key, value)),
                             None => {
                                 zelf.status.store(IterStatus::Exhausted);

--- a/vm/src/builtins/dict.rs
+++ b/vm/src/builtins/dict.rs
@@ -578,7 +578,7 @@ impl Iterator for DictIter {
     type Item = (PyObjectRef, PyObjectRef);
 
     fn next(&mut self) -> Option<Self::Item> {
-        self.dict.entries.next_entry(&mut self.position)
+        self.dict.entries._next_entry(&mut self.position)
     }
 
     fn size_hint(&self) -> (usize, Option<usize>) {
@@ -718,12 +718,8 @@ macro_rules! dict_iterator {
                                 "dictionary changed size during iteration".to_owned(),
                             ));
                         }
-                        let mut position = zelf.position.load();
-                        match zelf.dict.entries.next_entry(&mut position) {
-                            Some((key, value)) => {
-                                zelf.position.store(position);
-                                Ok(($result_fn)(vm, key, value))
-                            }
+                        match zelf.dict.entries.next_entry(&zelf.position) {
+                            Some((key, value)) => Ok(($result_fn)(vm, key, value)),
                             None => {
                                 zelf.status.store(IterStatus::Exhausted);
                                 Err(vm.new_stop_iteration())

--- a/vm/src/dictdatatype.rs
+++ b/vm/src/dictdatatype.rs
@@ -477,7 +477,7 @@ impl<T: Clone> Dict<T> {
         self.read().size()
     }
 
-    pub fn _next_entry(&self, position: &mut EntryIndex) -> Option<(PyObjectRef, T)> {
+    pub fn next_entry(&self, position: &mut EntryIndex) -> Option<(PyObjectRef, T)> {
         let inner = self.read();
         loop {
             let entry = inner.entries.get(*position)?;
@@ -488,7 +488,7 @@ impl<T: Clone> Dict<T> {
         }
     }
 
-    pub fn next_entry(&self, position: &AtomicCell<usize>) -> Option<(PyObjectRef, T)> {
+    pub fn next_entry_atomic(&self, position: &AtomicCell<usize>) -> Option<(PyObjectRef, T)> {
         let inner = self.read();
         loop {
             let position_usize = position.fetch_add(1);
@@ -499,7 +499,10 @@ impl<T: Clone> Dict<T> {
         }
     }
 
-    pub fn next_entry_reversed(&self, position: &AtomicCell<usize>) -> Option<(PyObjectRef, T)> {
+    pub fn next_entry_atomic_reversed(
+        &self,
+        position: &AtomicCell<usize>,
+    ) -> Option<(PyObjectRef, T)> {
         let inner = self.read();
         loop {
             let position_usize = position.fetch_add(1);

--- a/vm/src/dictdatatype.rs
+++ b/vm/src/dictdatatype.rs
@@ -477,11 +477,22 @@ impl<T: Clone> Dict<T> {
         self.read().size()
     }
 
-    pub fn next_entry(&self, position: &mut EntryIndex) -> Option<(PyObjectRef, T)> {
+    pub fn _next_entry(&self, position: &mut EntryIndex) -> Option<(PyObjectRef, T)> {
         let inner = self.read();
         loop {
             let entry = inner.entries.get(*position)?;
             *position += 1;
+            if let Some(entry) = entry {
+                break Some((entry.key.clone(), entry.value.clone()));
+            }
+        }
+    }
+
+    pub fn next_entry(&self, position: &AtomicCell<usize>) -> Option<(PyObjectRef, T)> {
+        let inner = self.read();
+        loop {
+            let position_usize = position.fetch_add(1);
+            let entry = inner.entries.get(position_usize)?;
             if let Some(entry) = entry {
                 break Some((entry.key.clone(), entry.value.clone()));
             }


### PR DESCRIPTION
in #2915, there was a comment to use only fetch_add, not using load & store to maintain atomic operation.

since dict iterator has this load & store, change to use fetch_add.