### PR TITLE
Add missing `__str__` method in base types

### DIFF
--- a/vm/src/builtins/complex.rs
+++ b/vm/src/builtins/complex.rs
@@ -220,6 +220,7 @@ impl PyComplex {
         -self.value
     }
 
+    #[pymethod(name = "__str__")]
     #[pymethod(magic)]
     fn repr(&self) -> String {
         let Complex64 { re, im } = self.value;

--- a/vm/src/builtins/float.rs
+++ b/vm/src/builtins/float.rs
@@ -359,6 +359,7 @@ impl PyFloat {
         self.simple_op(other, |a, b| Ok(b - a), vm)
     }
 
+    #[pymethod(name = "__str__")]
     #[pymethod(magic)]
     fn repr(&self) -> String {
         float_ops::to_string(self.value)

--- a/vm/src/builtins/int.rs
+++ b/vm/src/builtins/int.rs
@@ -567,6 +567,7 @@ impl PyInt {
         !(&self.value)
     }
 
+    #[pymethod(name = "__str__")]
     #[pymethod(magic)]
     pub(crate) fn repr(&self) -> String {
         self.value.to_string()

--- a/vm/src/builtins/pybool.rs
+++ b/vm/src/builtins/pybool.rs
@@ -81,6 +81,7 @@ pub struct PyBool;
 
 #[pyimpl]
 impl PyBool {
+    #[pymethod(name = "__str__")]
     #[pymethod(magic)]
     fn repr(zelf: bool) -> String {
         if zelf { "True" } else { "False" }.to_owned()


### PR DESCRIPTION
According to `whats_left.sh` script printing,
there is no `__str__` for base types(int, float, complex, bool)

Therefore, str call for these types go to `PyBaseObject.str`
`PyBaseObject.str` method implementation call `vm.to_repr(&zelf)`.
With this implementation, str call for these types will be slightly improved in performance.

#### Before
```python
>>>>> a = 10
>>>>> a.__str__
<bound method object.__str__ of 10>
>>>>> a = complex(10, 20)
>>>>> a.__str__
<bound method object.__str__ of (10+20j)>
>>>>> a = float(10)
>>>>> a.__str__
<bound method object.__str__ of 10.0>
```
#### After
```python
>>>>> a = 10
>>>>> a.__str__
<bound method int.__str__ of 10>
>>>>> a = complex(10, 20)
>>>>> a.__str__
<bound method object.__str__ of (10+20j)>
>>>>> a = 10.3
>>>>> a.__str__
<bound method float.__str__ of 10.3>
```