### PR TITLE
Fix list entering deadlock in several methods

### DIFF
--- a/extra_tests/snippets/list.py
+++ b/extra_tests/snippets/list.py
@@ -635,3 +635,24 @@ assert it.__length_hint__() == 0
 
 a = [*[1, 2], 3, *[4, 5]]
 assert a == [1, 2, 3, 4, 5]
+
+# Test for list entering daedlock or not (https://github.com/RustPython/RustPython/pull/2933)
+class MutatingCompare:
+    def __eq__(self, other):
+        self.list.pop()
+        return True
+
+m = MutatingCompare()
+
+l = [1, 2, 3, m, 4]
+m.list = l
+l.count(4) # TODO: assert l.count(4) == 1
+
+l = [1, 2, 3, m, 4]
+m.list = l
+assert l.index(4) == 3
+
+l = [1, 2, 3, m, 4]
+m.list = l
+l.remove(4) 
+assert_raises(ValueError, lambda: l.index(4)) # element 4 must not be in the list

--- a/vm/src/builtins/list.rs
+++ b/vm/src/builtins/list.rs
@@ -260,9 +260,10 @@ impl PyList {
 
     #[pymethod]
     fn count(&self, needle: PyObjectRef, vm: &VirtualMachine) -> PyResult<usize> {
+        let elements = self.borrow_vec().to_vec();
         let mut count: usize = 0;
-        for element in self.borrow_vec().to_vec().iter() {
-            if vm.identical_or_equal(element, &needle)? {
+        for elem in elements.iter() {
+            if vm.identical_or_equal(elem, &needle)? {
                 count += 1;
             }
         }
@@ -271,8 +272,9 @@ impl PyList {
 
     #[pymethod(magic)]
     fn contains(&self, needle: PyObjectRef, vm: &VirtualMachine) -> PyResult<bool> {
-        for element in self.borrow_vec().to_vec().iter() {
-            if vm.identical_or_equal(element, &needle)? {
+        let elements = self.borrow_vec().to_vec();
+        for elem in elements.iter() {
+            if vm.identical_or_equal(elem, &needle)? {
                 return Ok(true);
             }
         }
@@ -302,9 +304,8 @@ impl PyList {
                 stop = 0;
             }
         }
-        for (index, element) in self
-            .borrow_vec()
-            .to_vec()
+        let elements = self.borrow_vec().to_vec();
+        for (index, element) in elements
             .iter()
             .enumerate()
             .take(stop as usize)
@@ -335,8 +336,9 @@ impl PyList {
 
     #[pymethod]
     fn remove(&self, needle: PyObjectRef, vm: &VirtualMachine) -> PyResult<()> {
+        let elements = self.borrow_vec().to_vec();
         let mut ri: Option<usize> = None;
-        for (index, element) in self.borrow_vec().to_vec().iter().enumerate() {
+        for (index, element) in elements.iter().enumerate() {
             if vm.identical_or_equal(element, &needle)? {
                 ri = Some(index);
                 break;

--- a/vm/src/builtins/list.rs
+++ b/vm/src/builtins/list.rs
@@ -260,6 +260,7 @@ impl PyList {
 
     #[pymethod]
     fn count(&self, needle: PyObjectRef, vm: &VirtualMachine) -> PyResult<usize> {
+        // TODO: to_vec() cause copy which leads to cost O(N). It need to be improved.
         let elements = self.borrow_vec().to_vec();
         let mut count: usize = 0;
         for elem in elements.iter() {
@@ -272,6 +273,7 @@ impl PyList {
 
     #[pymethod(magic)]
     fn contains(&self, needle: PyObjectRef, vm: &VirtualMachine) -> PyResult<bool> {
+        // TODO: to_vec() cause copy which leads to cost O(N). It need to be improved.
         let elements = self.borrow_vec().to_vec();
         for elem in elements.iter() {
             if vm.identical_or_equal(elem, &needle)? {
@@ -304,6 +306,7 @@ impl PyList {
                 stop = 0;
             }
         }
+        // TODO: to_vec() cause copy which leads to cost O(N). It need to be improved.
         let elements = self.borrow_vec().to_vec();
         for (index, element) in elements
             .iter()
@@ -336,6 +339,7 @@ impl PyList {
 
     #[pymethod]
     fn remove(&self, needle: PyObjectRef, vm: &VirtualMachine) -> PyResult<()> {
+        // TODO: to_vec() cause copy which leads to cost O(N). It need to be improved.
         let elements = self.borrow_vec().to_vec();
         let mut ri: Option<usize> = None;
         for (index, element) in elements.iter().enumerate() {


### PR DESCRIPTION
This revision fix #2919 in some part.

Current `count`, `contains`, `remove` and `index` methods in `PyList` implementation does not unlock the read guard before entering loop.
If there is something try to lock the write guard while iterating loops, rustpython die.

With this fix, there is no more deadlock, but resulting values from that methods slightly incompatible with cpython.
```python
class test:
	def __eq__(self, other):
		self.d.pop()
		return True
t = test()
d = [1,2,t,3,4]
t.d = d
d.count(4) 
# Rustpython : 2
# CPython : 1
```
