### PR TITLE
resolve deque deadlock using state

### DIFF
--- a/Lib/test/test_deque.py
+++ b/Lib/test/test_deque.py
@@ -115,7 +115,6 @@ class TestBasic(unittest.TestCase):
             d = deque('abc')
             d.maxlen = 10
 
-    @unittest.skip("TODO: RUSTPYTHON hangs")
     def test_count(self):
         for s in ('', 'abracadabra', 'simsalabim'*500+'abc'):
             s = list(s)
@@ -165,7 +164,6 @@ class TestBasic(unittest.TestCase):
                 self.assertEqual(x >  y, list(x) >  list(y), (x,y))
                 self.assertEqual(x >= y, list(x) >= list(y), (x,y))
 
-    @unittest.skip("TODO: RUSTPYTHON hangs")
     def test_contains(self):
         n = 200
 
@@ -186,7 +184,6 @@ class TestBasic(unittest.TestCase):
         with self.assertRaises(RuntimeError):
             n in d
 
-    @unittest.skip("TODO: RUSTPYTHON hangs")
     def test_contains_count_stop_crashes(self):
         class A:
             def __eq__(self, other):
@@ -269,7 +266,8 @@ class TestBasic(unittest.TestCase):
         self.assertRaises(IndexError, d.__getitem__, 0)
         self.assertRaises(IndexError, d.__getitem__, -1)
 
-    @unittest.skip("TODO: RUSTPYTHON hangs")
+    # TODO: RUSTPYTHON
+    @unittest.expectedFailure
     def test_index(self):
         for n in 1, 2, 30, 40, 200:
 
@@ -525,7 +523,6 @@ class TestBasic(unittest.TestCase):
         d.clear()               # clear an empty deque
         self.assertEqual(list(d), [])
 
-    @unittest.skip("TODO: RUSTPYTHON hangs")
     def test_remove(self):
         d = deque('abcdefghcij')
         d.remove('c')

--- a/vm/src/stdlib/collections.rs
+++ b/vm/src/stdlib/collections.rs
@@ -27,6 +27,8 @@ mod _collections {
     struct PyDeque {
         deque: PyRwLock<VecDeque<PyObjectRef>>,
         maxlen: Option<usize>,
+        /* incremented whenever the indices move */
+        state: AtomicCell<usize>,
     }
 
     type PyDequeRef = PyRef<PyDeque>;
@@ -140,11 +142,13 @@ mod _collections {
                     deque.extend(elements);
                 }
             }
+
             Ok(())
         }
 
         #[pymethod]
         fn append(&self, obj: PyObjectRef) {
+            self.state.fetch_add(1);
             let mut deque = self.borrow_deque_mut();
             if self.maxlen == Some(deque.len()) {
                 deque.pop_front();
@@ -154,6 +158,7 @@ mod _collections {
 
         #[pymethod]
         fn appendleft(&self, obj: PyObjectRef) {
+            self.state.fetch_add(1);
             let mut deque = self.borrow_deque_mut();
             if self.maxlen == Some(deque.len()) {
                 deque.pop_back();
@@ -163,6 +168,7 @@ mod _collections {
 
         #[pymethod]
         fn clear(&self) {
+            self.state.fetch_add(1);
             self.borrow_deque_mut().clear()
         }
 
@@ -171,15 +177,28 @@ mod _collections {
             PyDeque {
                 deque: PyRwLock::new(self.borrow_deque().clone()),
                 maxlen: self.maxlen,
+                state: AtomicCell::new(self.state.load()),
             }
+        }
+
+        fn get_cloned_vec_deque(
+            &self,
+            deque: PyRwLockReadGuard<'_, VecDeque<PyObjectRef>>,
+        ) -> VecDeque<PyObjectRef> {
+            deque.iter().cloned().collect::<VecDeque<PyObjectRef>>()
         }
 
         #[pymethod]
         fn count(&self, obj: PyObjectRef, vm: &VirtualMachine) -> PyResult<usize> {
             let mut count = 0;
-            for elem in self.borrow_deque().iter() {
+            let start_state = self.state.load();
+            for elem in self.get_cloned_vec_deque(self.borrow_deque()).iter() {
                 if vm.identical_or_equal(elem, &obj)? {
                     count += 1;
+                }
+
+                if start_state != self.state.load() {
+                    return Err(vm.new_runtime_error("deque mutated during iteration".to_owned()));
                 }
             }
             Ok(count)
@@ -188,6 +207,7 @@ mod _collections {
         #[pymethod]
         fn extend(&self, iter: PyObjectRef, vm: &VirtualMachine) -> PyResult<()> {
             // TODO: use length_hint here and for extendleft
+            self.state.fetch_add(1);
             let max_len = self.maxlen;
             let mut elements: Vec<PyObjectRef> = vm.extract_elements(&iter)?;
             if let Some(max_len) = max_len {
@@ -206,6 +226,7 @@ mod _collections {
 
         #[pymethod]
         fn extendleft(&self, iter: PyIterable, vm: &VirtualMachine) -> PyResult<()> {
+            self.state.fetch_add(1);
             for elem in iter.iter(vm)? {
                 self.appendleft(elem?);
             }
@@ -220,11 +241,17 @@ mod _collections {
             stop: OptionalArg<usize>,
             vm: &VirtualMachine,
         ) -> PyResult<usize> {
-            let deque = self.borrow_deque();
+            let deque = self.get_cloned_vec_deque(self.borrow_deque());
             let start = start.unwrap_or(0);
+            let start_state = self.state.load();
             let stop = stop.unwrap_or_else(|| deque.len());
             for (i, elem) in deque.iter().skip(start).take(stop - start).enumerate() {
-                if vm.identical_or_equal(elem, &obj)? {
+                let is_element = vm.identical_or_equal(elem, &obj)?;
+
+                if start_state != self.state.load() {
+                    return Err(vm.new_runtime_error("deque mutated during iteration".to_owned()));
+                }
+                if is_element {
                     return Ok(i);
                 }
             }
@@ -237,6 +264,7 @@ mod _collections {
 
         #[pymethod]
         fn insert(&self, idx: i32, obj: PyObjectRef, vm: &VirtualMachine) -> PyResult<()> {
+            self.state.fetch_add(1);
             let mut deque = self.borrow_deque_mut();
 
             if self.maxlen == Some(deque.len()) {
@@ -262,6 +290,7 @@ mod _collections {
 
         #[pymethod]
         fn pop(&self, vm: &VirtualMachine) -> PyResult {
+            self.state.fetch_add(1);
             self.borrow_deque_mut()
                 .pop_back()
                 .ok_or_else(|| vm.new_index_error("pop from an empty deque".to_owned()))
@@ -269,6 +298,7 @@ mod _collections {
 
         #[pymethod]
         fn popleft(&self, vm: &VirtualMachine) -> PyResult {
+            self.state.fetch_add(1);
             self.borrow_deque_mut()
                 .pop_front()
                 .ok_or_else(|| vm.new_index_error("pop from an empty deque".to_owned()))
@@ -276,7 +306,9 @@ mod _collections {
 
         #[pymethod]
         fn remove(&self, obj: PyObjectRef, vm: &VirtualMachine) -> PyResult {
-            let mut deque = self.borrow_deque_mut();
+            let deque: VecDeque<_> = self.get_cloned_vec_deque(self.borrow_deque());
+            let start_state = self.state.load();
+
             let mut idx = None;
             for (i, elem) in deque.iter().enumerate() {
                 if vm.identical_or_equal(elem, &obj)? {
@@ -284,8 +316,14 @@ mod _collections {
                     break;
                 }
             }
-            idx.map(|idx| deque.remove(idx).unwrap())
-                .ok_or_else(|| vm.new_value_error("deque.remove(x): x not in deque".to_owned()))
+            let mut deque = self.borrow_deque_mut();
+            if start_state != self.state.load() {
+                Err(vm.new_index_error("deque mutated during remove().".to_owned()))
+            } else {
+                self.state.fetch_add(1);
+                idx.map(|idx| deque.remove(idx).unwrap())
+                    .ok_or_else(|| vm.new_value_error("deque.remove(x): x not in deque".to_owned()))
+            }
         }
 
         #[pymethod]
@@ -308,6 +346,7 @@ mod _collections {
 
         #[pymethod]
         fn rotate(&self, mid: OptionalArg<isize>) {
+            self.state.fetch_add(1);
             let mut deque = self.borrow_deque_mut();
             let mid = mid.unwrap_or(1);
             if mid < 0 {
@@ -368,8 +407,14 @@ mod _collections {
 
         #[pymethod(magic)]
         fn contains(&self, needle: PyObjectRef, vm: &VirtualMachine) -> PyResult<bool> {
-            for element in self.borrow_deque().iter() {
-                if vm.identical_or_equal(element, &needle)? {
+            let start_state = self.state.load();
+            for element in self.get_cloned_vec_deque(self.borrow_deque()).iter() {
+                let is_element = vm.identical_or_equal(element, &needle)?;
+
+                if start_state != self.state.load() {
+                    return Err(vm.new_runtime_error("deque mutated during iteration".to_owned()));
+                }
+                if is_element {
                     return Ok(true);
                 }
             }
@@ -391,6 +436,7 @@ mod _collections {
             PyDeque {
                 deque: PyRwLock::new(deque),
                 maxlen: self.maxlen,
+                state: AtomicCell::new(0),
             }
         }
 
@@ -447,7 +493,8 @@ mod _collections {
     struct PyDequeIterator {
         position: AtomicCell<usize>,
         status: AtomicCell<IterStatus>,
-        length: usize, // To track length immutability.
+        length: usize,
+        // To track length immutability.
         deque: PyDequeRef,
     }
 
@@ -510,7 +557,8 @@ mod _collections {
     struct PyReverseDequeIterator {
         position: AtomicCell<usize>,
         status: AtomicCell<IterStatus>,
-        length: usize, // To track length immutability.
+        length: usize,
+        // To track length immutability.
         deque: PyDequeRef,
     }
 


### PR DESCRIPTION
resolve deque deadlock while iteration

by using CPython method, added state property to PyDeque.

by using state, RustPython can detect mutation while iterating.
