### PR TITLE
os: implement os.nice 

### DIFF
--- a/vm/src/stdlib/os.rs
+++ b/vm/src/stdlib/os.rs
@@ -2356,6 +2356,18 @@ mod posix {
     }
 
     #[pyfunction]
+    fn nice(increment: i32, vm: &VirtualMachine) -> PyResult<i32> {
+        use nix::errno::{errno, Errno};
+        Errno::clear();
+        let res = unsafe { libc::nice(increment) };
+        if res == -1 && errno() != 0 {
+            Err(errno_err(vm))
+        } else {
+            Ok(res)
+        }
+    }
+
+    #[pyfunction]
     fn get_inheritable(fd: RawFd, vm: &VirtualMachine) -> PyResult<bool> {
         use nix::fcntl::fcntl;
         use nix::fcntl::FcntlArg;


### PR DESCRIPTION
this implements `os.nice` (which linked to a unix system call, changing process priority) function. 

with this commit, rustpyhton works as below. 
```python 
>>>>> import os
>>>>> os.nice(0)
0
>>>>> os.nice(-1)
-1
>>>>> os.nice(-10)
-11
>>>>> os.nice(10)
-1
>>>>> os.nice(20)
19
>>>>> os.nice(20)
19
>>>>> os.nice(-20)
-1
>>>>> os.nice(-12)
-13
>>>>> os.nice(-100)
-20

``` 
