### PR TITLE
Fix deque repr hang if element __repr__ mutates.

### DIFF
--- a/extra_tests/snippets/stdlib_collections.py
+++ b/extra_tests/snippets/stdlib_collections.py
@@ -44,3 +44,15 @@ assert d <= d
 assert not (d < d)
 assert d == d
 assert not (d != d)
+
+
+# Test that calling an evil __repr__ can't hang deque
+class BadRepr:
+    def __repr__(self):
+        self.d.pop()
+        return ''
+
+b = BadRepr()
+d = deque([1, b, 2])
+b.d = d
+repr(d)

--- a/vm/src/stdlib/collections.rs
+++ b/vm/src/stdlib/collections.rs
@@ -382,8 +382,8 @@ mod _collections {
         #[pymethod(magic)]
         fn repr(zelf: PyRef<Self>, vm: &VirtualMachine) -> PyResult<String> {
             let repr = if let Some(_guard) = ReprGuard::enter(vm, zelf.as_object()) {
-                let elements = zelf
-                    .borrow_deque()
+                let deque = zelf.borrow_deque().clone();
+                let elements = deque
                     .iter()
                     .map(|obj| vm.to_repr(obj))
                     .collect::<Result<Vec<_>, _>>()?;


### PR DESCRIPTION
a small follow up to #2934 