### PR TITLE
resolve deque.rotate panic

### DIFF
--- a/Lib/test/test_deque.py
+++ b/Lib/test/test_deque.py
@@ -436,7 +436,6 @@ class TestBasic(unittest.TestCase):
             self.assertEqual(list(d), data[:i])
         self.assertRaises(TypeError, d.reverse, 1)          # Arity is zero
 
-    @unittest.skip("TODO: RUSTPYTHON panics")
     def test_rotate(self):
         s = tuple('abcde')
         n = len(s)

--- a/vm/src/stdlib/collections.rs
+++ b/vm/src/stdlib/collections.rs
@@ -374,11 +374,13 @@ mod _collections {
         fn rotate(&self, mid: OptionalArg<isize>) {
             self.state.fetch_add(1);
             let mut deque = self.borrow_deque_mut();
-            let mid = mid.unwrap_or(1);
-            if mid < 0 {
-                deque.rotate_left(-mid as usize);
-            } else {
-                deque.rotate_right(mid as usize);
+            if !deque.is_empty() {
+                let mid = mid.unwrap_or(1) % deque.len() as isize;
+                if mid.is_negative() {
+                    deque.rotate_left(-mid as usize);
+                } else {
+                    deque.rotate_right(mid as usize);
+                }
             }
         }
 


### PR DESCRIPTION
this PR resolves `deque.rotate` panics when abs(mid) is larger than deque length

