### PR TITLE
Avoid hanging when mutating __index__ is used.

### DIFF
--- a/Lib/test/test_xml_etree.py
+++ b/Lib/test/test_xml_etree.py
@@ -2515,7 +2515,6 @@ class BadElementTest(ElementTestCase, unittest.TestCase):
         e.append(ET.Element('child'))
         e[0:10:X()]  # shouldn't crash
 
-    @unittest.skip("TODO: RUSTPYTHON, hangs")
     def test_ass_subscr(self):
         # Issue #27863
         class X:

--- a/extra_tests/snippets/indexing.py
+++ b/extra_tests/snippets/indexing.py
@@ -1,0 +1,41 @@
+""" Test that indexing ops don't hang when an object with a mutating
+__index__ is used."""
+from testutils import assert_raises
+from array import array
+
+
+class BadIndex:
+    def __index__(self):
+        # assign ourselves, makes it easy to re-use with
+        # all mutable collections.
+        e[:] = e
+        return 1
+
+
+def run_setitem():
+    with assert_raises(IndexError):
+        e[BadIndex()] = 42
+    e[BadIndex():0:-1] = e
+    e[0:BadIndex():1] = e
+    e[0:10:BadIndex()] = e
+
+
+def run_delitem():
+    del e[BadIndex():0:-1]
+    del e[0:BadIndex():1]
+    del e[0:10:BadIndex()]
+
+# Check list
+e = []
+run_setitem()
+run_delitem()
+
+# Check bytearray
+e = bytearray()
+run_setitem()
+run_delitem()
+
+# Check array
+e = array('b')
+run_setitem()
+run_delitem()

--- a/vm/src/builtins/memory.rs
+++ b/vm/src/builtins/memory.rs
@@ -9,7 +9,7 @@ use crate::common::borrow::{BorrowedValue, BorrowedValueMut};
 use crate::common::hash::PyHash;
 use crate::common::lock::OnceCell;
 use crate::function::{FuncArgs, OptionalArg};
-use crate::sliceable::{convert_slice, saturate_range, wrap_index, SequenceIndex};
+use crate::sliceable::{saturate_range, wrap_index, SeqSlice, SequenceIndex};
 use crate::slots::{AsBuffer, Comparable, Hashable, PyComparisonOp};
 use crate::stdlib::pystruct::_struct::FormatSpec;
 use crate::utils::Either;
@@ -405,7 +405,8 @@ impl PyMemoryView {
             return diff_err();
         }
 
-        let (range, step, is_negative_step) = convert_slice(&slice, zelf.options.len, vm)?;
+        let (range, step, is_negative_step) =
+            SeqSlice::new(slice, vm)?.convert(zelf.options.len, vm)?;
 
         let bytes = items.to_contiguous();
         assert_eq!(bytes.len(), len * itemsize);


### PR DESCRIPTION
In short, a mutating `__index__` could be called that tried to lock the collection and cause a deadlock.

This separates the steps by first converting using `__index__` and then safely converting into a rust `Range` in the `PySliceableSequence(Mut)` traits.