### PR TITLE
make dict copy order when copied from ordered dict

### DIFF
--- a/Lib/test/test_dict.py
+++ b/Lib/test/test_dict.py
@@ -1347,8 +1347,6 @@ class DictTest(unittest.TestCase):
         self.assertEqual(list(r), list('dcba'))
         self.assertRaises(StopIteration, next, r)
 
-    # TODO: RUSTPYTHON
-    @unittest.expectedFailure
     def test_dict_copy_order(self):
         # bpo-34320
         od = collections.OrderedDict([('a', 1), ('b', 2)])

--- a/vm/src/builtins/dict.rs
+++ b/vm/src/builtins/dict.rs
@@ -75,7 +75,7 @@ impl PyDict {
         vm: &VirtualMachine,
     ) -> PyResult<()> {
         if let OptionalArg::Present(dict_obj) = dict_obj {
-            let dicted: Result<PyDictRef, _> = dict_obj.clone().downcast();
+            let dicted: Result<PyDictRef, _> = dict_obj.clone().downcast_exact(vm);
             if let Ok(dict_obj) = dicted {
                 for (key, value) in dict_obj {
                     dict.insert(vm, key, value)?;


### PR DESCRIPTION
make dict to copy order even when copied from ordered dict

```
from collections import OrderedDict

od = OrderedDict([('a', 1), ('b', 2)])
od.move_to_end('a')
expected = list(od.items())
copy = dict(od)
print(copy)
```
before : `{'a': 1, 'b': 2}`
after : `{'b': 2, 'a': 1}`