### PR TITLE
add mutation check in dict.merge

### DIFF
--- a/Lib/test/test_dict.py
+++ b/Lib/test/test_dict.py
@@ -1226,8 +1226,6 @@ class DictTest(unittest.TestCase):
                 d.popitem()
         self.check_reentrant_insertion(mutate)
 
-    # TODO: RUSTPYTHON
-    @unittest.expectedFailure
     def test_merge_and_mutate(self):
         class X:
             def __hash__(self):

--- a/vm/src/builtins/dict.rs
+++ b/vm/src/builtins/dict.rs
@@ -77,8 +77,12 @@ impl PyDict {
         if let OptionalArg::Present(dict_obj) = dict_obj {
             let dicted: Result<PyDictRef, _> = dict_obj.clone().downcast_exact(vm);
             if let Ok(dict_obj) = dicted {
-                for (key, value) in dict_obj {
+                let dict_size = &dict_obj.size();
+                for (key, value) in &dict_obj {
                     dict.insert(vm, key, value)?;
+                }
+                if dict_obj.entries.has_changed_size(dict_size) {
+                    return Err(vm.new_runtime_error("dict mutated during update".to_owned()));
                 }
             } else if let Some(keys) = vm.get_method(dict_obj.clone(), "keys") {
                 let keys = iterator::get_iter(vm, vm.invoke(&keys?, ())?)?;


### PR DESCRIPTION
add mutation check logic in `dict.merge` when the param is dict instance
