### PR TITLE
hide builtins::isinstance from rust interface

### DIFF
--- a/vm/src/builtins/make_module.rs
+++ b/vm/src/builtins/make_module.rs
@@ -407,7 +407,7 @@ mod decl {
     }
 
     #[pyfunction]
-    pub fn isinstance(obj: PyObjectRef, typ: PyObjectRef, vm: &VirtualMachine) -> PyResult<bool> {
+    fn isinstance(obj: PyObjectRef, typ: PyObjectRef, vm: &VirtualMachine) -> PyResult<bool> {
         vm.isinstance(&obj, &typ)
     }
 
@@ -913,7 +913,7 @@ mod decl {
     }
 }
 
-pub use decl::{ascii, isinstance, print};
+pub use decl::{ascii, print};
 
 pub fn make_module(vm: &VirtualMachine, module: PyObjectRef) {
     let ctx = &vm.ctx;

--- a/vm/src/builtins/mod.rs
+++ b/vm/src/builtins/mod.rs
@@ -80,4 +80,4 @@ pub(crate) mod zip;
 pub use zip::PyZip;
 
 mod make_module;
-pub use make_module::{ascii, isinstance, make_module, print};
+pub use make_module::{ascii, make_module, print};

--- a/vm/src/frame.rs
+++ b/vm/src/frame.rs
@@ -1730,9 +1730,7 @@ impl ExecutingFrame<'_> {
             bytecode::ComparisonOperator::IsNot => vm.ctx.new_bool(self._is_not(a, b)),
             bytecode::ComparisonOperator::In => vm.ctx.new_bool(self._in(vm, a, b)?),
             bytecode::ComparisonOperator::NotIn => vm.ctx.new_bool(self._not_in(vm, a, b)?),
-            bytecode::ComparisonOperator::ExceptionMatch => {
-                vm.ctx.new_bool(builtins::isinstance(a, b, vm)?)
-            }
+            bytecode::ComparisonOperator::ExceptionMatch => vm.ctx.new_bool(vm.isinstance(&a, &b)?),
         };
 
         self.push_value(value);

--- a/vm/src/stdlib/io.rs
+++ b/vm/src/stdlib/io.rs
@@ -3887,7 +3887,7 @@ mod fileio {
             zelf.mode.store(mode);
             let fd = if let Some(opener) = args.opener {
                 let fd = vm.invoke(&opener, (name.clone(), flags))?;
-                if !vm.isinstance(&fd, vm.ctx.types.int_type.as_object())? {
+                if !fd.isinstance(&vm.ctx.types.int_type) {
                     return Err(vm.new_type_error("expected integer from opener".to_owned()));
                 }
                 let fd = i32::try_from_object(vm, fd)?;


### PR DESCRIPTION
`PyObjectRef::isinstance()` and `VirtualMachine::isinstance` covers all the use cases.