### PR TITLE
Bump recursion limit to match CPython's

### DIFF
--- a/Lib/test/test_threading.py
+++ b/Lib/test/test_threading.py
@@ -1069,6 +1069,13 @@ class ThreadingExceptionTests(BaseTestCase):
         # for threads
         script = """if True:
             import threading
+            # TODO: RUSTPYTHON
+            # Following lines set the recursion limit to previous default of 512
+            # for the execution of this process. Without this, the test runners
+            # on Github fail. Ideally, at a future point this should be removed.
+            import os, sys
+            if os.getenv("CI"):
+                sys.setrecursionlimit(512)
 
             def recurse():
                 return recurse()

--- a/vm/src/vm.rs
+++ b/vm/src/vm.rs
@@ -286,7 +286,7 @@ impl VirtualMachine {
             profile_func,
             trace_func,
             use_tracing: Cell::new(false),
-            recursion_limit: Cell::new(if cfg!(debug_assertions) { 256 } else { 512 }),
+            recursion_limit: Cell::new(if cfg!(debug_assertions) { 256 } else { 1000 }),
             signal_handlers: Some(Box::new(signal_handlers)),
             repr_guards: RefCell::default(),
             state: PyRc::new(PyGlobalState {


### PR DESCRIPTION
Closes #2948 

Second attempt at this. Just noticed a new process is spawned so the increase needs to be done in the script executed.