### PR TITLE
implement `complex.__complex__`

### DIFF
--- a/extra_tests/snippets/complex.py
+++ b/extra_tests/snippets/complex.py
@@ -1,10 +1,15 @@
-# __complex__
-z = 3 + 4j
-assert z.__complex__() == z
-assert type(z.__complex__()) == complex
+import testutils
 
-class complex_subclass(complex):
-    pass
-z = complex_subclass(3 + 4j)
-assert z.__complex__() == 3 + 4j
-assert type(z.__complex__()) == complex
+# __complex__
+def test__complex__():
+    z = 3 + 4j
+    assert z.__complex__() == z
+    assert type(z.__complex__()) == complex
+    
+    class complex_subclass(complex):
+        pass
+    z = complex_subclass(3 + 4j)
+    assert z.__complex__() == 3 + 4j
+    assert type(z.__complex__()) == complex
+
+testutils.skip_if_unsupported(3,11,test__complex__)

--- a/extra_tests/snippets/complex.py
+++ b/extra_tests/snippets/complex.py
@@ -1,0 +1,10 @@
+# __complex__
+z = 3 + 4j
+assert z.__complex__() == z
+assert type(z.__complex__()) == complex
+
+class complex_subclass(complex):
+    pass
+z = complex_subclass(3 + 4j)
+assert z.__complex__() == 3 + 4j
+assert type(z.__complex__()) == complex

--- a/vm/src/builtins/complex.rs
+++ b/vm/src/builtins/complex.rs
@@ -89,6 +89,15 @@ impl PyComplex {
         self.value
     }
 
+    #[pymethod(magic)]
+    fn complex(zelf: PyRef<Self>, vm: &VirtualMachine) -> PyRef<PyComplex> {
+        if zelf.is(&vm.ctx.types.complex_type) {
+            zelf
+        } else {
+            PyComplex::from(zelf.value).into_ref(vm)
+        }
+    }
+
     #[pyproperty]
     fn real(&self) -> f64 {
         self.value.re


### PR DESCRIPTION
This revision implement `complex.__complex__` which will be added in cpython 3.11 for `typing` module.

### References
* https://docs.python.org/3.11/whatsnew/3.11.html#other-cpython-implementation-changes
* https://bugs.python.org/issue24234