### PR TITLE
Implement `bytes.__bytes__`

### DIFF
--- a/extra_tests/snippets/bytes.py
+++ b/extra_tests/snippets/bytes.py
@@ -1,4 +1,4 @@
-from testutils import assert_raises
+from testutils import assert_raises, skip_if_unsupported
 
 # new
 assert bytes([1, 2, 3])
@@ -616,14 +616,15 @@ assert b'rust%bpython%b' % (b' ', b'!') == b'rust python!'
 assert b'x=%i y=%f' % (1, 2.5) == b'x=1 y=2.500000'
 
 # __bytes__
-foo = b'foo\x00bar'
-assert foo.__bytes__() == foo
-assert type(foo.__bytes__()) == bytes
-class bytes_subclass(bytes):
-    pass
-bar = bytes_subclass(b'bar\x00foo')
-assert bar.__bytes__() == bar
-assert type(bar.__bytes__()) == bytes
+def test__bytes__():
+    foo = b'foo\x00bar'
+    assert foo.__bytes__() == foo
+    assert type(foo.__bytes__()) == bytes
+    class bytes_subclass(bytes):
+        pass
+    bar = bytes_subclass(b'bar\x00foo')
+    assert bar.__bytes__() == bar
+    assert type(bar.__bytes__()) == bytes
 
 class A:
     def __bytes__(self):
@@ -666,3 +667,5 @@ class B1(bytearray):
         return me
 b = B1.fromhex('a0a1a2')
 assert b.foo == 'bar'
+
+skip_if_unsupported(3,11,test__bytes__)

--- a/extra_tests/snippets/bytes.py
+++ b/extra_tests/snippets/bytes.py
@@ -615,6 +615,16 @@ assert b'\xe4\xb8\xad\xe6\x96\x87\xe5\xad\x97'.decode('utf-8') == '中文字'
 assert b'rust%bpython%b' % (b' ', b'!') == b'rust python!'
 assert b'x=%i y=%f' % (1, 2.5) == b'x=1 y=2.500000'
 
+# __bytes__
+foo = b'foo\x00bar'
+assert foo.__bytes__() == foo
+assert type(foo.__bytes__()) == bytes
+class bytes_subclass(bytes):
+    pass
+bar = bytes_subclass(b'bar\x00foo')
+assert bar.__bytes__() == bar
+assert type(bar.__bytes__()) == bytes
+
 class A:
     def __bytes__(self):
         return b"bytess"

--- a/vm/src/builtins/bytes.rs
+++ b/vm/src/builtins/bytes.rs
@@ -129,6 +129,15 @@ impl PyBytes {
     }
 
     #[pymethod(magic)]
+    fn bytes(zelf: PyRef<Self>, vm: &VirtualMachine) -> PyRef<Self> {
+        if zelf.is(&vm.ctx.types.bytes_type) {
+            zelf
+        } else {
+            PyBytes::from(zelf.inner.clone()).into_ref(vm)
+        }
+    }
+
+    #[pymethod(magic)]
     fn sizeof(&self) -> usize {
         size_of::<Self>() + self.inner.elements.len() * size_of::<u8>()
     }


### PR DESCRIPTION
This revision implement `bytes.__bytes__` in cpython 3.11 for typing module.

### References
* https://docs.python.org/3.11/whatsnew/3.11.html#other-cpython-implementation-changes
* https://bugs.python.org/issue24234