### PR TITLE
add __new__ method to deque iterator and reverse iterator

### DIFF
--- a/Lib/test/test_deque.py
+++ b/Lib/test/test_deque.py
@@ -646,8 +646,6 @@ class TestBasic(unittest.TestCase):
                 self.assertEqual(id(e[-1]), id(e))
                 self.assertEqual(e.maxlen, d.maxlen)
 
-    # TODO: RUSTPYTHON
-    @unittest.expectedFailure
     def test_iterator_pickle(self):
         orig = deque(range(200))
         data = [i*1.01 for i in orig]
@@ -729,8 +727,6 @@ class TestBasic(unittest.TestCase):
         for s in ('abcd', range(2000)):
             self.assertEqual(list(reversed(deque(s))), list(reversed(s)))
 
-    # TODO: RUSTPYTHON
-    @unittest.expectedFailure
     def test_reversed_new(self):
         klass = type(reversed(deque()))
         for s in ('abcd', range(2000)):

--- a/extra_tests/snippets/deque.py
+++ b/extra_tests/snippets/deque.py
@@ -45,7 +45,7 @@ def test_deque_iterator__new__not_using_keyword_index():
             assert (list(d) == list(s))
 
 
-# test_deque_iterator__new__not_using_keyword_index()
+test_deque_iterator__new__not_using_keyword_index()
 
 
 def test_deque_reverse_iterator__new__positional_index():
@@ -82,4 +82,4 @@ def test_deque_reverse_iterator__new__not_using_keyword_index():
             assert (list(d) == list(reversed(s)))
 
 
-# test_deque_reverse_iterator__new__not_using_keyword_index()
+test_deque_reverse_iterator__new__not_using_keyword_index()

--- a/extra_tests/snippets/deque.py
+++ b/extra_tests/snippets/deque.py
@@ -1,0 +1,85 @@
+from collections import deque
+
+
+def test_deque_iterator__new__():
+    klass = type(iter(deque()))
+    s = 'abcd'
+    d = klass(deque(s))
+    assert (list(d) == list(s))
+
+
+test_deque_iterator__new__()
+
+
+def test_deque_iterator__new__positional_index():
+    klass = type(iter(deque()))
+
+    # index between 0 and len
+    for s in ('abcd', range(2000)):
+        for i in range(len(s)):
+            d = klass(deque(s), i)
+            assert (list(d) == list(s)[i:])
+
+    # negative index
+    for s in ('abcd', range(2000)):
+        for i in range(-1000, 0):
+            d = klass(deque(s), i)
+            assert (list(d) == list(s))
+
+    # index ge len
+    for s in ('abcd', range(2000)):
+        for i in range(len(s), 4000):
+            d = klass(deque(s), i)
+            assert (list(d) == list())
+
+
+test_deque_iterator__new__positional_index()
+
+
+def test_deque_iterator__new__not_using_keyword_index():
+    klass = type(iter(deque()))
+
+    for s in ('abcd', range(2000)):
+        for i in range(-1000, 4000):
+            d = klass(deque(s), index=i)
+            assert (list(d) == list(s))
+
+
+# test_deque_iterator__new__not_using_keyword_index()
+
+
+def test_deque_reverse_iterator__new__positional_index():
+    klass = type(reversed(deque()))
+
+    # index between 0 and len
+    for s in ('abcd', range(2000)):
+        for i in range(len(s)):
+            d = klass(deque(s), i)
+            assert (list(d) == list(reversed(s))[i:])
+
+    # negative index
+    for s in ('abcd', range(2000)):
+        for i in range(-1000, 0):
+            d = klass(deque(s), i)
+            assert (list(d) == list(reversed(s)))
+
+    # index ge len
+    for s in ('abcd', range(2000)):
+        for i in range(len(s), 4000):
+            d = klass(deque(s), i)
+            assert (list(d) == list())
+
+
+test_deque_reverse_iterator__new__positional_index()
+
+
+def test_deque_reverse_iterator__new__not_using_keyword_index():
+    klass = type(reversed(deque()))
+
+    for s in ('abcd', range(2000)):
+        for i in range(-1000, 4000):
+            d = klass(deque(s), index=i)
+            assert (list(d) == list(reversed(s)))
+
+
+# test_deque_reverse_iterator__new__not_using_keyword_index()

--- a/vm/src/stdlib/collections.rs
+++ b/vm/src/stdlib/collections.rs
@@ -3,7 +3,7 @@ pub(crate) use _collections::make_module;
 #[pymodule]
 mod _collections {
     use crate::common::lock::{PyRwLock, PyRwLockReadGuard, PyRwLockWriteGuard};
-    use crate::function::{FuncArgs, OptionalArg};
+    use crate::function::{FuncArgs, KwArgs, OptionalArg};
     use crate::slots::{Comparable, Hashable, Iterable, PyComparisonOp, PyIter, Unhashable};
     use crate::vm::ReprGuard;
     use crate::VirtualMachine;
@@ -603,6 +603,7 @@ mod _collections {
         fn tp_new(
             cls: PyTypeRef,
             DequeIterArgs { deque, index }: DequeIterArgs,
+            _kwargs: KwArgs,
             vm: &VirtualMachine,
         ) -> PyResult<PyRef<Self>> {
             let len = deque.len();
@@ -693,6 +694,7 @@ mod _collections {
         fn tp_new(
             cls: PyTypeRef,
             DequeIterArgs { deque, index }: DequeIterArgs,
+            _kwargs: KwArgs,
             vm: &VirtualMachine,
         ) -> PyResult<PyRef<Self>> {
             let len = deque.len();


### PR DESCRIPTION
add `__new__` function to deque iterator, and reverse deque iterator

this allows to create iterator instance using type instance. for example,
```
klass = type(iter(deque()))
a = klass(deque('abcd'))
```
creates a deque iterator instance