### PR TITLE
Check for MemoryErrors when repeating sequences.

### DIFF
--- a/Lib/test/test_array.py
+++ b/Lib/test/test_array.py
@@ -1508,7 +1508,6 @@ class DoubleTest(FPTest, unittest.TestCase):
     typecode = 'd'
     minitemsize = 8
 
-    @unittest.skip("TODO: RUSTPYTHON, thread 'main' panicked at 'capacity overflow'")
     def test_alloc_overflow(self):
         from sys import maxsize
         a = array.array('d', [-1]*65536)

--- a/Lib/test/test_bytes.py
+++ b/Lib/test/test_bytes.py
@@ -396,7 +396,6 @@ class BaseBytesTest:
         self.assertRaises(TypeError, lambda: b1 + "def")
         self.assertRaises(TypeError, lambda: "abc" + b2)
 
-    @unittest.skip("TODO: RUSTPYTHON, thread 'main' panicked at 'capacity overflow'")
     def test_repeat(self):
         for b in b"abc", self.type2test(b"abc"):
             self.assertEqual(b * 3, b"abcabcabc")

--- a/Lib/test/test_list.py
+++ b/Lib/test/test_list.py
@@ -61,7 +61,6 @@ class ListTest(list_tests.CommonTest):
         self.assertEqual(len([0]), 1)
         self.assertEqual(len([0, 1, 2]), 3)
 
-    @unittest.skip("TODO: RUSTPYTHON, thread 'main' panicked at 'capacity overflow'")
     def test_overflow(self):
         lst = [4, 5, 6, 7]
         n = int((sys.maxsize*2+2) // len(lst))

--- a/vm/src/builtins/list.rs
+++ b/vm/src/builtins/list.rs
@@ -237,25 +237,21 @@ impl PyList {
     }
 
     #[pymethod(magic)]
-    fn mul(&self, counter: isize, vm: &VirtualMachine) -> PyObjectRef {
-        let new_elements = sequence::seq_mul(&self.borrow_vec(), counter)
+    #[pymethod(name = "__rmul__")]
+    fn mul(&self, value: isize, vm: &VirtualMachine) -> PyResult {
+        let new_elements = sequence::seq_mul(vm, &self.borrow_vec(), value)?
             .cloned()
             .collect();
-        vm.ctx.new_list(new_elements)
+        Ok(vm.ctx.new_list(new_elements))
     }
 
     #[pymethod(magic)]
-    fn rmul(&self, counter: isize, vm: &VirtualMachine) -> PyObjectRef {
-        self.mul(counter, vm)
-    }
-
-    #[pymethod(magic)]
-    fn imul(zelf: PyRef<Self>, counter: isize) -> PyRef<Self> {
+    fn imul(zelf: PyRef<Self>, value: isize, vm: &VirtualMachine) -> PyResult<PyRef<Self>> {
         let mut elements = zelf.borrow_vec_mut();
         let mut new_elements: Vec<PyObjectRef> =
-            sequence::seq_mul(&*elements, counter).cloned().collect();
+            sequence::seq_mul(vm, &*elements, value)?.cloned().collect();
         std::mem::swap(elements.deref_mut(), &mut new_elements);
-        zelf.clone()
+        Ok(zelf.clone())
     }
 
     #[pymethod]

--- a/vm/src/builtins/tuple.rs
+++ b/vm/src/builtins/tuple.rs
@@ -169,22 +169,22 @@ impl PyTuple {
 
     #[pymethod(name = "__rmul__")]
     #[pymethod(magic)]
-    fn mul(zelf: PyRef<Self>, counter: isize, vm: &VirtualMachine) -> PyRef<Self> {
-        if zelf.elements.is_empty() || counter == 0 {
+    fn mul(zelf: PyRef<Self>, value: isize, vm: &VirtualMachine) -> PyResult<PyRef<Self>> {
+        Ok(if zelf.elements.is_empty() || value == 0 {
             vm.ctx.empty_tuple.clone()
-        } else if counter == 1 && zelf.class().is(&vm.ctx.types.tuple_type) {
+        } else if value == 1 && zelf.class().is(&vm.ctx.types.tuple_type) {
             // Special case: when some `tuple` is multiplied by `1`,
             // nothing really happens, we need to return an object itself
             // with the same `id()` to be compatible with CPython.
             // This only works for `tuple` itself, not its subclasses.
             zelf
         } else {
-            let elements = sequence::seq_mul(&zelf.elements, counter)
+            let elements = sequence::seq_mul(vm, &zelf.elements, value)?
                 .cloned()
                 .collect::<Vec<_>>()
                 .into_boxed_slice();
             Self { elements }.into_ref(vm)
-        }
+        })
     }
 
     #[pymethod(magic)]

--- a/vm/src/bytesinner.rs
+++ b/vm/src/bytesinner.rs
@@ -964,8 +964,8 @@ impl PyBytesInner {
             .format(vm, values)
     }
 
-    pub fn repeat(&self, n: isize) -> Vec<u8> {
-        self.elements.repeat(n.to_usize().unwrap_or(0))
+    pub fn repeat(&self, n: usize) -> Vec<u8> {
+        self.elements.repeat(n)
     }
 }
 

--- a/vm/src/sequence.rs
+++ b/vm/src/sequence.rs
@@ -1,7 +1,6 @@
 use crate::slots::PyComparisonOp;
 use crate::vm::VirtualMachine;
 use crate::{PyObjectRef, PyResult};
-use num_traits::cast::ToPrimitive;
 
 pub(super) type DynPyIter<'a> = Box<dyn ExactSizeIterator<Item = &'a PyObjectRef> + 'a>;
 
@@ -94,15 +93,15 @@ impl<'a> Iterator for SeqMul<'a> {
     }
 }
 
-pub(crate) fn seq_mul(seq: &impl SimpleSeq, repetitions: isize) -> SeqMul {
-    let repetitions = if seq.len() > 0 {
-        repetitions.to_usize().unwrap_or(0)
-    } else {
-        0
-    };
-    SeqMul {
-        seq,
-        repetitions,
-        iter: None,
-    }
+pub(crate) fn seq_mul<'a>(
+    vm: &VirtualMachine,
+    seq: &'a impl SimpleSeq,
+    repetitions: isize,
+) -> PyResult<SeqMul<'a>> {
+    vm.check_repeat_or_memory_error(seq.len(), repetitions)
+        .map(|repetitions| SeqMul {
+            seq,
+            repetitions,
+            iter: None,
+        })
 }

--- a/vm/src/stdlib/collections.rs
+++ b/vm/src/stdlib/collections.rs
@@ -454,20 +454,20 @@ mod _collections {
 
         #[pymethod(magic)]
         #[pymethod(name = "__rmul__")]
-        fn mul(&self, n: isize) -> Self {
+        fn mul(&self, value: isize, vm: &VirtualMachine) -> PyResult<Self> {
             let deque: SimpleSeqDeque = self.borrow_deque().into();
-            let mul = sequence::seq_mul(&deque, n);
+            let mul = sequence::seq_mul(vm, &deque, value)?;
             let skipped = self
                 .maxlen
                 .and_then(|maxlen| mul.len().checked_sub(maxlen))
                 .unwrap_or(0);
 
             let deque = mul.skip(skipped).cloned().collect();
-            PyDeque {
+            Ok(PyDeque {
                 deque: PyRwLock::new(deque),
                 maxlen: self.maxlen,
                 state: AtomicCell::new(0),
-            }
+            })
         }
 
         #[pymethod(magic)]

--- a/vm/src/vm.rs
+++ b/vm/src/vm.rs
@@ -784,6 +784,11 @@ impl VirtualMachine {
         self.new_exception_msg(runtime_error, msg)
     }
 
+    pub fn new_memory_error(&self, msg: String) -> PyBaseExceptionRef {
+        let memory_error_type = self.ctx.exceptions.memory_error.clone();
+        self.new_exception_msg(memory_error_type, msg)
+    }
+
     pub fn new_stop_iteration(&self) -> PyBaseExceptionRef {
         let stop_iteration_type = self.ctx.exceptions.stop_iteration.clone();
         self.new_exception_empty(stop_iteration_type)
@@ -1843,6 +1848,18 @@ impl VirtualMachine {
                 obj.class().name
             )))
         })
+    }
+
+    /// Checks that the multiplication is able to be performed. On Ok returns the
+    /// index as a usize for sequences to be able to use immediately.
+    pub fn check_repeat_or_memory_error(&self, length: usize, n: isize) -> PyResult<usize> {
+        let n = n.to_usize().unwrap_or(0);
+        if n > 0 && length > isize::MAX as usize / n {
+            // Empty message is currently used in CPython.
+            Err(self.new_memory_error("".to_owned()))
+        } else {
+            Ok(n)
+        }
     }
 
     // https://docs.python.org/3/reference/expressions.html#membership-test-operations


### PR DESCRIPTION
This add the checking required to detect *most* of the `MemoryError`s during `repeat`. In addition to that, I've renamed most arguments for the repeat value to `value` to match CPython's and made the internal multiplication functions take `usize`'s since the conversion can be performed earlier.