### PR TITLE
Correct `object.__repr__` format

### DIFF
--- a/Lib/test/test_reprlib.py
+++ b/Lib/test/test_reprlib.py
@@ -318,8 +318,6 @@ class bar:
         # Module name may be prefixed with "test.", depending on how run.
         self.assertEqual(repr(bar.bar), "<class '%s.bar'>" % bar.__name__)
 
-    # TODO: RUSTPYTHON
-    @unittest.expectedFailure
     def test_instance(self):
         self._check_path_limitations('baz')
         write_file(os.path.join(self.subpkgname, 'baz.py'), '''\
@@ -332,8 +330,6 @@ class baz:
         self.assertTrue(repr(ibaz).startswith(
             "<%s.baz object at 0x" % baz.__name__))
 
-    # TODO: RUSTPYTHON
-    @unittest.expectedFailure
     def test_method(self):
         self._check_path_limitations('qux')
         eq = self.assertEqual

--- a/vm/src/builtins/object.rs
+++ b/vm/src/builtins/object.rs
@@ -185,7 +185,11 @@ impl PyBaseObject {
     /// Return repr(self).
     #[pymethod(magic)]
     fn repr(zelf: PyObjectRef) -> String {
-        format!("<{} object at {:#x}>", zelf.class().name, zelf.get_id())
+        format!(
+            "<{} object at {:#x}>",
+            zelf.class().tp_name(),
+            zelf.get_id()
+        )
     }
 
     #[pyclassmethod(magic)]


### PR DESCRIPTION
## Overview

Before this pull request, there was a bug where `object`'s repr message is not compatible with CPython implementation.

When you run the below code:

```python
class A:
    def a(self):
        class C:
            ...
        print(repr(C()))

print(repr(A()))
A().a()
```

CPython implementation prints the following lines:

```
<__main__.A object at 0x7f9411fca7f0>
<__main__.A.a.<locals>.C object at 0x7f9411fca790>
```

But RustPython implementation does:

```
<A object at 0x555d487e75c0>
<C object at 0x555d487bdc20>
```

## Reason

It was because `object.__repr__` used only `__name__` without `__module__`, `__qualname__`. 😢 

https://github.com/RustPython/RustPython/blob/f1e81c991e3a0eec3708110075e6bb5a3c280e72/vm/src/builtins/object.rs#L185-L189

## References

- [`object.__repr__` CPython implementation](https://github.com/python/cpython/blob/7e246a3a7b43762480ee4fe0cfb859e8e997a8c8/Objects/typeobject.c#L4517-L4544)