### PR TITLE
Change OSError and its subclasses attributes

### DIFF
--- a/Lib/test/test_exception_hierarchy.py
+++ b/Lib/test/test_exception_hierarchy.py
@@ -130,8 +130,6 @@ class AttributesTest(unittest.TestCase):
         else:
             self.assertNotIn('winerror', dir(OSError))
 
-    # TODO: RUSTPYTHON
-    @unittest.expectedFailure
     def test_posix_error(self):
         e = OSError(EEXIST, "File already exists", "foo.txt")
         self.assertEqual(e.errno, EEXIST)

--- a/Lib/test/test_fileio.py
+++ b/Lib/test/test_fileio.py
@@ -391,8 +391,6 @@ class PyAutoFileTests(AutoFileTests, unittest.TestCase):
     FileIO = _pyio.FileIO
     modulename = '_pyio'
 
-    # TODO: RUSTPYTHON
-    @unittest.expectedFailure
     def testOpendir(self):
         super().testOpendir()
 

--- a/Lib/test/test_io.py
+++ b/Lib/test/test_io.py
@@ -1745,8 +1745,6 @@ class BufferedWriterTest(unittest.TestCase, CommonBufferedTests):
     def test_writes_and_truncates(self):
         self.check_writes(lambda bufio: bufio.truncate(bufio.tell()))
 
-    # TODO: RUSTPYTHON
-    @unittest.expectedFailure
     def test_write_non_blocking(self):
         raw = self.MockNonBlockWriterIO()
         bufio = self.tp(raw, 8)
@@ -4346,13 +4344,9 @@ class MiscIOTest(unittest.TestCase):
                 with self.open(os_helper.TESTFN, **kwargs) as f:
                     self.assertRaises(TypeError, pickle.dumps, f, protocol)
 
-    # TODO: RUSTPYTHON
-    @unittest.expectedFailure
     def test_nonblock_pipe_write_bigbuf(self):
         self._test_nonblock_pipe_write(16*1024)
 
-    # TODO: RUSTPYTHON
-    @unittest.expectedFailure
     def test_nonblock_pipe_write_smallbuf(self):
         self._test_nonblock_pipe_write(1024)
 

--- a/Lib/test/test_subprocess.py
+++ b/Lib/test/test_subprocess.py
@@ -1549,8 +1549,6 @@ class ProcessTestCase(BaseTestCase):
         fds_after_exception = os.listdir(fd_directory)
         self.assertEqual(fds_before_popen, fds_after_exception)
 
-    # TODO: RUSTPYTHON
-    @unittest.expectedFailure
     @unittest.skipIf(mswindows, "behavior currently not supported on Windows")
     def test_file_not_found_includes_filename(self):
         with self.assertRaises(FileNotFoundError) as c:

--- a/vm/src/stdlib/io.rs
+++ b/vm/src/stdlib/io.rs
@@ -33,8 +33,14 @@ impl ToPyException for std::io::Error {
                 .unwrap_or(excs.os_error),
         };
         let errno = self.raw_os_error().to_pyobject(vm);
-        let msg = vm.ctx.new_str(self.to_string()).into();
-        vm.new_exception(exc_type.to_owned(), vec![errno, msg])
+        let msg: PyObjectRef = vm.ctx.new_str(self.to_string()).into();
+        if let Ok(exception) =
+            vm.invoke_exception(exc_type.to_owned(), vec![errno.clone(), msg.clone()])
+        {
+            exception
+        } else {
+            vm.new_exception(exc_type.to_owned(), vec![errno, msg])
+        }
     }
 }
 


### PR DESCRIPTION
This PR provides specified attribute "characters_written" to BlockingIOError. Other unnecessary attributes are ignored in BlockingIOError such as winerror, filename, filename2.