### PR TITLE
Fix `PyMappingProxy::get`

### DIFF
--- a/Lib/test/test_typechecks.py
+++ b/Lib/test/test_typechecks.py
@@ -50,8 +50,6 @@ class TypeChecksTest(unittest.TestCase):
         self.assertEqual(issubclass(Integer, Integer), True)
         self.assertEqual(issubclass(Integer, (Integer,)), True)
 
-    # TODO: RUSTPYTHON
-    @unittest.expectedFailure
     def testSubclassBehavior(self):
         self.assertEqual(issubclass(SubInt, Integer), True)
         self.assertEqual(issubclass(SubInt, (Integer,)), True)

--- a/Lib/test/test_typing.py
+++ b/Lib/test/test_typing.py
@@ -695,8 +695,6 @@ class ProtocolTests(BaseTestCase):
 
         self.assertIsInstance(f, HasCallProtocol)
 
-    # TODO: RUSTPYTHON
-    @unittest.expectedFailure
     def test_no_inheritance_from_nominal(self):
         class C: pass
 
@@ -719,8 +717,6 @@ class ProtocolTests(BaseTestCase):
         self.assertNotIsInstance(D(), E)
         self.assertNotIsInstance(E(), D)
 
-    # TODO: RUSTPYTHON
-    @unittest.expectedFailure
     def test_no_instantiation(self):
         class P(Protocol): pass
 
@@ -875,8 +871,6 @@ class ProtocolTests(BaseTestCase):
         with self.assertRaises(TypeError):
             issubclass(PG, PG[int])
 
-    # TODO: RUSTPYTHON
-    @unittest.expectedFailure
     def test_protocols_issubclass_non_callable(self):
         class C:
             x = 1
@@ -994,8 +988,6 @@ class ProtocolTests(BaseTestCase):
         self.assertIsInstance(C(1), P)
         self.assertIsInstance(C(1), PG)
 
-    # TODO: RUSTPYTHON
-    @unittest.expectedFailure
     def test_protocol_checks_after_subscript(self):
         class P(Protocol[T]): pass
         class C(P[T]): pass
@@ -1094,8 +1086,6 @@ class ProtocolTests(BaseTestCase):
         self.assertIsInstance(NonPR(), PR)
         self.assertIsSubclass(NonPR, PR)
 
-    # TODO: RUSTPYTHON
-    @unittest.expectedFailure
     def test_custom_subclasshook(self):
         class P(Protocol):
             x = 1
@@ -1125,8 +1115,6 @@ class ProtocolTests(BaseTestCase):
         with self.assertRaises(TypeError):
             issubclass(C(), P)
 
-    # TODO: RUSTPYTHON
-    @unittest.expectedFailure
     def test_defining_generic_protocols(self):
         T = TypeVar('T')
         S = TypeVar('S')
@@ -1192,8 +1180,6 @@ class ProtocolTests(BaseTestCase):
         with self.assertRaises(TypeError):
             PR[int, ClassVar]
 
-    # TODO: RUSTPYTHON
-    @unittest.expectedFailure
     def test_init_called(self):
         T = TypeVar('T')
 
@@ -1277,8 +1263,6 @@ class ProtocolTests(BaseTestCase):
         self.assertEqual(frozenset(typing._get_protocol_attrs(PG)),
                          frozenset({'x', 'meth'}))
 
-    # TODO: RUSTPYTHON
-    @unittest.expectedFailure
     def test_no_runtime_deco_on_nominal(self):
         with self.assertRaises(TypeError):
             @runtime_checkable
@@ -2894,8 +2878,6 @@ class GetTypeHintTests(BaseTestCase):
                      'default_b': Optional[mod_generics_cache.B]}
         self.assertEqual(gth(mod_generics_cache), mgc_hints)
 
-    # TODO: RUSTPYTHON
-    @unittest.expectedFailure
     def test_get_type_hints_classes(self):
         self.assertEqual(gth(ann_module.C),  # gth will find the right globalns
                          {'y': Optional[ann_module.C]})

--- a/vm/src/builtins/mappingproxy.rs
+++ b/vm/src/builtins/mappingproxy.rs
@@ -50,7 +50,7 @@ impl PyMappingProxy {
         let opt = match &self.mapping {
             MappingProxyInner::Class(class) => {
                 let key = PyStrRef::try_from_object(vm, key)?;
-                class.get_attr(key.as_str())
+                class.attributes.read().get(key.as_str()).cloned()
             }
             MappingProxyInner::Dict(obj) => obj.get_item(key, vm).ok(),
         };


### PR DESCRIPTION
# Overview

When we run the Python code like below:

```python
class A: ...

print(A.__dict__.items())
print(A.__dict__.get("__hash__", "NONE"))
```

We can't find `__hash__` anywhere and will see `NONE` output because there is no `__hash__` method.

Let's see the output from the execution result of CPython implementation.

```
dict_items([('__module__', '__main__'), ('__dict__', <attribute '__dict__' of 'A' objects>), ('__weakref__', <attribute '__weakref__' of 'A' objects>), ('__doc__', None)])
NONE
```

But RustPython implementation fetches the `object.__hash__` method though it doesn't have.

```
dict_items([('__dict__', <getset_descriptor object at 0x556b113c8460>), ('__module__', '__main__'), ('__qualname__', 'A'), ('__doc__', None)])
<method '__hash__' of 'object' objects>
```

So this pull request fixed the bug, similar with #2932.