### PR TITLE
SlotConstructor and uniform tp_new signature

### DIFF
--- a/derive/src/pyclass.rs
+++ b/derive/src/pyclass.rs
@@ -476,14 +476,8 @@ where
         let slot_ident = item_meta.slot_name()?;
         let slot_name = slot_ident.to_string();
         let tokens = {
-            let into_func = if slot_name == "new" {
-                quote_spanned! {ident.span() =>
-                    ::rustpython_vm::function::IntoPyNativeFunc::into_func(Self::#ident)
-                }
-            } else {
-                quote_spanned! {ident.span() =>
-                    Self::#ident as _
-                }
+            let into_func = quote_spanned! {ident.span() =>
+                Self::#ident as _
             };
             const NON_ATOMIC_SLOTS: &[&str] = &["as_buffer"];
             if NON_ATOMIC_SLOTS.contains(&slot_name.as_str()) {

--- a/derive/src/pyclass.rs
+++ b/derive/src/pyclass.rs
@@ -485,7 +485,7 @@ where
                     Self::#ident as _
                 }
             };
-            const NON_ATOMIC_SLOTS: &[&str] = &["new", "as_buffer"];
+            const NON_ATOMIC_SLOTS: &[&str] = &["as_buffer"];
             if NON_ATOMIC_SLOTS.contains(&slot_name.as_str()) {
                 quote! {
                     slots.#slot_ident = Some(#into_func);

--- a/vm/src/builtins/bytearray.rs
+++ b/vm/src/builtins/bytearray.rs
@@ -102,8 +102,8 @@ pub(crate) fn init(context: &PyContext) {
 #[pyimpl(flags(BASETYPE), with(Hashable, Comparable, AsBuffer, Iterable))]
 impl PyByteArray {
     #[pyslot]
-    fn tp_new(cls: PyTypeRef, _args: FuncArgs, vm: &VirtualMachine) -> PyResult<PyRef<Self>> {
-        PyByteArray::default().into_ref_with_type(vm, cls)
+    fn tp_new(cls: PyTypeRef, _args: FuncArgs, vm: &VirtualMachine) -> PyResult {
+        PyByteArray::default().into_pyresult_with_type(vm, cls)
     }
 
     #[pymethod(magic)]

--- a/vm/src/builtins/classmethod.rs
+++ b/vm/src/builtins/classmethod.rs
@@ -1,7 +1,7 @@
 use super::pytype::PyTypeRef;
-use crate::slots::SlotDescriptor;
+use crate::slots::{SlotConstructor, SlotDescriptor};
 use crate::vm::VirtualMachine;
-use crate::{PyClassImpl, PyContext, PyObjectRef, PyRef, PyResult, PyValue, TypeProtocol};
+use crate::{PyClassImpl, PyContext, PyObjectRef, PyResult, PyValue, TypeProtocol};
 
 /// classmethod(function) -> method
 ///
@@ -54,13 +54,16 @@ impl SlotDescriptor for PyClassMethod {
     }
 }
 
-#[pyimpl(with(SlotDescriptor), flags(BASETYPE, HAS_DICT))]
-impl PyClassMethod {
-    #[pyslot]
-    fn tp_new(cls: PyTypeRef, callable: PyObjectRef, vm: &VirtualMachine) -> PyResult<PyRef<Self>> {
-        PyClassMethod { callable }.into_ref_with_type(vm, cls)
-    }
+impl SlotConstructor for PyClassMethod {
+    type Args = PyObjectRef;
 
+    fn py_new(cls: PyTypeRef, callable: Self::Args, vm: &VirtualMachine) -> PyResult {
+        PyClassMethod { callable }.into_pyresult_with_type(vm, cls)
+    }
+}
+
+#[pyimpl(with(SlotDescriptor, SlotConstructor), flags(BASETYPE, HAS_DICT))]
+impl PyClassMethod {
     #[pyproperty(magic)]
     fn func(&self) -> PyObjectRef {
         self.callable.clone()

--- a/vm/src/builtins/code.rs
+++ b/vm/src/builtins/code.rs
@@ -7,6 +7,7 @@ use std::ops::Deref;
 
 use super::{PyStrRef, PyTypeRef};
 use crate::bytecode::{self, BorrowedConstant, Constant, ConstantBag};
+use crate::function::FuncArgs;
 use crate::VirtualMachine;
 use crate::{
     IdProtocol, PyClassImpl, PyContext, PyObjectRef, PyRef, PyResult, PyValue, StaticType,
@@ -196,7 +197,7 @@ impl PyCode {}
 #[pyimpl]
 impl PyCodeRef {
     #[pyslot]
-    fn tp_new(_cls: PyTypeRef, vm: &VirtualMachine) -> PyResult<Self> {
+    fn tp_new(_cls: PyTypeRef, _args: FuncArgs, vm: &VirtualMachine) -> PyResult {
         Err(vm.new_type_error("Cannot directly create code object".to_owned()))
     }
 

--- a/vm/src/builtins/dict.rs
+++ b/vm/src/builtins/dict.rs
@@ -54,8 +54,8 @@ impl PyValue for PyDict {
 #[pyimpl(with(Hashable, Comparable, Iterable), flags(BASETYPE))]
 impl PyDict {
     #[pyslot]
-    fn tp_new(class: PyTypeRef, _args: FuncArgs, vm: &VirtualMachine) -> PyResult<PyRef<Self>> {
-        PyDict::default().into_ref_with_type(vm, class)
+    fn tp_new(cls: PyTypeRef, _args: FuncArgs, vm: &VirtualMachine) -> PyResult {
+        PyDict::default().into_pyresult_with_type(vm, cls)
     }
 
     #[pymethod(magic)]

--- a/vm/src/builtins/frame.rs
+++ b/vm/src/builtins/frame.rs
@@ -5,7 +5,9 @@
 use super::code::PyCodeRef;
 use super::dict::PyDictRef;
 use super::pystr::PyStrRef;
+use crate::builtins::PyTypeRef;
 use crate::frame::{Frame, FrameRef};
+use crate::function::FuncArgs;
 use crate::vm::VirtualMachine;
 use crate::{IdProtocol, PyClassImpl, PyContext, PyObjectRef, PyRef, PyResult};
 
@@ -19,7 +21,7 @@ impl Frame {}
 #[pyimpl]
 impl FrameRef {
     #[pyslot]
-    fn tp_new(_cls: FrameRef, vm: &VirtualMachine) -> PyResult<Self> {
+    fn tp_new(_cls: PyTypeRef, _args: FuncArgs, vm: &VirtualMachine) -> PyResult {
         Err(vm.new_type_error("Cannot directly create frame object".to_owned()))
     }
 

--- a/vm/src/builtins/int.rs
+++ b/vm/src/builtins/int.rs
@@ -238,7 +238,7 @@ fn inner_truediv(i1: &BigInt, i2: &BigInt, vm: &VirtualMachine) -> PyResult {
 impl SlotConstructor for PyInt {
     type Args = IntOptions;
 
-    fn py_new(cls: PyTypeRef, options: IntOptions, vm: &VirtualMachine) -> PyResult {
+    fn py_new(cls: PyTypeRef, options: Self::Args, vm: &VirtualMachine) -> PyResult {
         let value = if let OptionalArg::Present(val) = options.val_options {
             if let OptionalArg::Present(base) = options.base {
                 let base = vm

--- a/vm/src/builtins/int.rs
+++ b/vm/src/builtins/int.rs
@@ -2,7 +2,7 @@ use super::{float, IntoPyBool, PyByteArray, PyBytes, PyStr, PyStrRef, PyTypeRef}
 use crate::common::hash;
 use crate::format::FormatSpec;
 use crate::function::{OptionalArg, OptionalOption};
-use crate::slots::{Comparable, Hashable, PyComparisonOp};
+use crate::slots::{Comparable, Hashable, PyComparisonOp, SlotConstructor};
 use crate::VirtualMachine;
 use crate::{bytesinner::PyBytesInner, byteslike::try_bytes_like};
 use crate::{
@@ -235,7 +235,46 @@ fn inner_truediv(i1: &BigInt, i2: &BigInt, vm: &VirtualMachine) -> PyResult {
     }
 }
 
-#[pyimpl(flags(BASETYPE), with(Comparable, Hashable))]
+impl SlotConstructor for PyInt {
+    type Args = IntOptions;
+
+    fn py_new(cls: PyTypeRef, options: IntOptions, vm: &VirtualMachine) -> PyResult {
+        let value = if let OptionalArg::Present(val) = options.val_options {
+            if let OptionalArg::Present(base) = options.base {
+                let base = vm
+                    .to_index(&base)?
+                    .as_bigint()
+                    .to_u32()
+                    .filter(|&v| v == 0 || (2..=36).contains(&v))
+                    .ok_or_else(|| {
+                        vm.new_value_error("int() base must be >= 2 and <= 36, or 0".to_owned())
+                    })?;
+                try_int_radix(&val, base, vm)
+            } else {
+                let val = if cls.is(&vm.ctx.types.int_type) {
+                    match val.downcast_exact::<PyInt>(vm) {
+                        Ok(i) => {
+                            return Ok(i.into_pyobject(vm));
+                        }
+                        Err(val) => val,
+                    }
+                } else {
+                    val
+                };
+
+                try_int(&val, vm)
+            }
+        } else if let OptionalArg::Present(_) = options.base {
+            Err(vm.new_type_error("int() missing string argument".to_owned()))
+        } else {
+            Ok(Zero::zero())
+        }?;
+
+        Self::with_value(cls, value, vm).into_pyresult(vm)
+    }
+}
+
+#[pyimpl(flags(BASETYPE), with(Comparable, Hashable, SlotConstructor))]
 impl PyInt {
     fn with_value<T>(cls: PyTypeRef, value: T, vm: &VirtualMachine) -> PyResult<PyRef<Self>>
     where
@@ -256,42 +295,6 @@ impl PyInt {
 
     pub fn as_bigint(&self) -> &BigInt {
         &self.value
-    }
-
-    #[pyslot]
-    fn tp_new(cls: PyTypeRef, options: IntOptions, vm: &VirtualMachine) -> PyResult<PyRef<Self>> {
-        let value = if let OptionalArg::Present(val) = options.val_options {
-            if let OptionalArg::Present(base) = options.base {
-                let base = vm
-                    .to_index(&base)?
-                    .as_bigint()
-                    .to_u32()
-                    .filter(|&v| v == 0 || (2..=36).contains(&v))
-                    .ok_or_else(|| {
-                        vm.new_value_error("int() base must be >= 2 and <= 36, or 0".to_owned())
-                    })?;
-                try_int_radix(&val, base, vm)
-            } else {
-                let val = if cls.is(&vm.ctx.types.int_type) {
-                    match val.downcast_exact::<PyInt>(vm) {
-                        Ok(i) => {
-                            return Ok(i);
-                        }
-                        Err(val) => val,
-                    }
-                } else {
-                    val
-                };
-
-                try_int(&val, vm)
-            }
-        } else if let OptionalArg::Present(_) = options.base {
-            Err(vm.new_type_error("int() missing string argument".to_owned()))
-        } else {
-            Ok(Zero::zero())
-        }?;
-
-        Self::with_value(cls, value, vm)
     }
 
     #[inline]
@@ -735,7 +738,7 @@ impl Hashable for PyInt {
 }
 
 #[derive(FromArgs)]
-struct IntOptions {
+pub struct IntOptions {
     #[pyarg(positional, optional)]
     val_options: OptionalArg<PyObjectRef>,
     #[pyarg(any, optional)]

--- a/vm/src/builtins/list.rs
+++ b/vm/src/builtins/list.rs
@@ -16,7 +16,7 @@ use super::PyInt;
 use crate::common::lock::{
     PyMappedRwLockReadGuard, PyRwLock, PyRwLockReadGuard, PyRwLockWriteGuard,
 };
-use crate::function::OptionalArg;
+use crate::function::{FuncArgs, OptionalArg};
 use crate::sequence::{self, SimpleSeq};
 use crate::sliceable::{PySliceableSequence, PySliceableSequenceMut, SequenceIndex};
 use crate::slots::{Comparable, Hashable, Iterable, PyComparisonOp, PyIter, Unhashable};
@@ -397,12 +397,8 @@ impl PyList {
     }
 
     #[pyslot]
-    fn tp_new(
-        cls: PyTypeRef,
-        _iterable: OptionalArg<PyObjectRef>,
-        vm: &VirtualMachine,
-    ) -> PyResult<PyRef<Self>> {
-        PyList::default().into_ref_with_type(vm, cls)
+    fn tp_new(cls: PyTypeRef, _args: FuncArgs, vm: &VirtualMachine) -> PyResult {
+        PyList::default().into_pyresult_with_type(vm, cls)
     }
 
     #[pymethod(magic)]

--- a/vm/src/builtins/map.rs
+++ b/vm/src/builtins/map.rs
@@ -1,7 +1,7 @@
 use super::pytype::PyTypeRef;
 use crate::function::Args;
 use crate::iterator;
-use crate::slots::PyIter;
+use crate::slots::{PyIter, SlotConstructor};
 use crate::vm::VirtualMachine;
 use crate::{PyClassImpl, PyContext, PyObjectRef, PyRef, PyResult, PyValue};
 
@@ -22,15 +22,10 @@ impl PyValue for PyMap {
     }
 }
 
-#[pyimpl(with(PyIter), flags(BASETYPE))]
-impl PyMap {
-    #[pyslot]
-    fn tp_new(
-        cls: PyTypeRef,
-        function: PyObjectRef,
-        iterables: Args,
-        vm: &VirtualMachine,
-    ) -> PyResult<PyRef<Self>> {
+impl SlotConstructor for PyMap {
+    type Args = (PyObjectRef, Args<PyObjectRef>);
+
+    fn py_new(cls: PyTypeRef, (function, iterables): Self::Args, vm: &VirtualMachine) -> PyResult {
         let iterators = iterables
             .into_iter()
             .map(|iterable| iterator::get_iter(vm, iterable))
@@ -39,10 +34,12 @@ impl PyMap {
             mapper: function,
             iterators,
         }
-        .into_ref_with_type(vm, cls)
+        .into_pyresult_with_type(vm, cls)
     }
+}
 
-    /// Return an estimate of the number of items.
+#[pyimpl(with(PyIter, SlotConstructor), flags(BASETYPE))]
+impl PyMap {
     #[pymethod(magic)]
     fn length_hint(&self, vm: &VirtualMachine) -> PyResult<usize> {
         self.iterators.iter().try_fold(0, |prev, cur| {

--- a/vm/src/builtins/mappingproxy.rs
+++ b/vm/src/builtins/mappingproxy.rs
@@ -3,7 +3,7 @@ use super::pystr::PyStrRef;
 use super::pytype::PyTypeRef;
 use crate::function::OptionalArg;
 use crate::iterator;
-use crate::slots::Iterable;
+use crate::slots::{Iterable, SlotConstructor};
 use crate::vm::VirtualMachine;
 use crate::{
     IntoPyObject, ItemProtocol, PyClassImpl, PyContext, PyObjectRef, PyRef, PyResult, PyValue,
@@ -36,16 +36,19 @@ impl PyMappingProxy {
     }
 }
 
-#[pyimpl(with(Iterable))]
-impl PyMappingProxy {
-    #[pyslot]
-    fn tp_new(cls: PyTypeRef, mapping: PyObjectRef, vm: &VirtualMachine) -> PyResult<PyRef<Self>> {
+impl SlotConstructor for PyMappingProxy {
+    type Args = PyObjectRef;
+
+    fn py_new(cls: PyTypeRef, mapping: Self::Args, vm: &VirtualMachine) -> PyResult {
         Self {
             mapping: MappingProxyInner::Dict(mapping),
         }
-        .into_ref_with_type(vm, cls)
+        .into_pyresult_with_type(vm, cls)
     }
+}
 
+#[pyimpl(with(Iterable, SlotConstructor))]
+impl PyMappingProxy {
     fn get_inner(&self, key: PyObjectRef, vm: &VirtualMachine) -> PyResult<Option<PyObjectRef>> {
         let opt = match &self.mapping {
             MappingProxyInner::Class(class) => {

--- a/vm/src/builtins/module.rs
+++ b/vm/src/builtins/module.rs
@@ -53,8 +53,8 @@ struct ModuleInitArgs {
 #[pyimpl(with(SlotGetattro), flags(BASETYPE, HAS_DICT))]
 impl PyModule {
     #[pyslot]
-    fn tp_new(cls: PyTypeRef, _args: FuncArgs, vm: &VirtualMachine) -> PyResult<PyRef<Self>> {
-        PyModule {}.into_ref_with_type(vm, cls)
+    fn tp_new(cls: PyTypeRef, _args: FuncArgs, vm: &VirtualMachine) -> PyResult {
+        PyModule {}.into_pyresult_with_type(vm, cls)
     }
 
     #[pymethod(magic)]

--- a/vm/src/builtins/object.rs
+++ b/vm/src/builtins/object.rs
@@ -11,7 +11,7 @@ use crate::utils::Either;
 use crate::vm::VirtualMachine;
 use crate::{
     IdProtocol, ItemProtocol, PyArithmaticValue, PyAttributes, PyClassImpl, PyComparisonValue,
-    PyContext, PyObject, PyObjectRef, PyResult, PyValue, TryFromObject, TypeProtocol,
+    PyContext, PyObject, PyObjectRef, PyResult, PyValue, TypeProtocol,
 };
 
 /// object()
@@ -35,9 +35,8 @@ impl PyValue for PyBaseObject {
 impl PyBaseObject {
     /// Create and return a new object.  See help(type) for accurate signature.
     #[pyslot]
-    fn tp_new(mut args: FuncArgs, vm: &VirtualMachine) -> PyResult {
+    fn tp_new(cls: PyTypeRef, _args: FuncArgs, vm: &VirtualMachine) -> PyResult {
         // more or less __new__ operator
-        let cls = PyTypeRef::try_from_object(vm, args.shift())?;
         let dict = if cls.is(&vm.ctx.types.object_type) {
             None
         } else {

--- a/vm/src/builtins/property.rs
+++ b/vm/src/builtins/property.rs
@@ -91,14 +91,14 @@ impl SlotDescriptor for PyProperty {
 #[pyimpl(with(SlotDescriptor), flags(BASETYPE))]
 impl PyProperty {
     #[pyslot]
-    fn tp_new(cls: PyTypeRef, _args: FuncArgs, vm: &VirtualMachine) -> PyResult<PyRef<Self>> {
+    fn tp_new(cls: PyTypeRef, _args: FuncArgs, vm: &VirtualMachine) -> PyResult {
         PyProperty {
             getter: PyRwLock::new(None),
             setter: PyRwLock::new(None),
             deleter: PyRwLock::new(None),
             doc: PyRwLock::new(None),
         }
-        .into_ref_with_type(vm, cls)
+        .into_pyresult_with_type(vm, cls)
     }
 
     #[pymethod(magic)]

--- a/vm/src/builtins/pytype.rs
+++ b/vm/src/builtins/pytype.rs
@@ -151,6 +151,17 @@ impl PyType {
             }};
         }
         match name {
+            "__new__" => {
+                let func: slots::NewFunc =
+                    |cls: PyTypeRef, mut args: FuncArgs, vm: &VirtualMachine| {
+                        let new = vm
+                            .get_attribute_opt(cls.as_object().clone(), "__new__")?
+                            .unwrap();
+                        args.prepend_arg(cls.into_object());
+                        vm.invoke(&new, args)
+                    };
+                update_slot!(new, func);
+            }
             "__call__" => {
                 let func: slots::GenericMethod =
                     |zelf, args, vm| vm.call_special_method(zelf.clone(), "__call__", args);
@@ -442,10 +453,9 @@ impl PyType {
             let winner = calculate_meta_class(metatype.clone(), &bases, vm)?;
             let metatype = if !winner.is(&metatype) {
                 #[allow(clippy::redundant_clone)] // false positive
-                if let Some(ref tp_new) = winner.clone().slots.new {
+                if let Some(ref tp_new) = winner.clone().slots.new.load() {
                     // Pass it to the winner
-                    args.prepend_arg(winner.into_object());
-                    return tp_new(vm, args);
+                    return tp_new(winner, args, vm);
                 }
                 winner
             } else {
@@ -787,9 +797,8 @@ fn call_tp_new(
                 return vm.invoke(&new_meth, args);
             }
         }
-        if let Some(tp_new) = cls.slots.new.as_ref() {
-            args.prepend_arg(subtype.into_object());
-            return tp_new(vm, args);
+        if let Some(tp_new) = cls.slots.new.load() {
+            return tp_new(subtype, args, vm);
         }
     }
     unreachable!("Should be able to find a new slot somewhere in the mro")

--- a/vm/src/builtins/pytype.rs
+++ b/vm/src/builtins/pytype.rs
@@ -405,7 +405,7 @@ impl PyType {
         )
     }
     #[pyslot]
-    fn tp_new(metatype: PyTypeRef, mut args: FuncArgs, vm: &VirtualMachine) -> PyResult {
+    fn tp_new(metatype: PyTypeRef, args: FuncArgs, vm: &VirtualMachine) -> PyResult {
         vm_trace!("type.__new__ {:?}", args);
 
         let is_type_type = metatype.is(&vm.ctx.types.type_type);

--- a/vm/src/builtins/range.rs
+++ b/vm/src/builtins/range.rs
@@ -362,12 +362,12 @@ impl PyRange {
     }
 
     #[pyslot]
-    fn tp_new(args: FuncArgs, vm: &VirtualMachine) -> PyResult {
-        let range = if args.args.len() <= 2 {
-            let (cls, stop) = args.bind(vm)?;
+    fn tp_new(cls: PyTypeRef, args: FuncArgs, vm: &VirtualMachine) -> PyResult {
+        let range = if args.args.len() <= 1 {
+            let stop = args.bind(vm)?;
             PyRange::new(cls, stop, vm)
         } else {
-            let (cls, start, stop, step) = args.bind(vm)?;
+            let (start, stop, step) = args.bind(vm)?;
             PyRange::new_from(cls, start, stop, step, vm)
         }?;
 

--- a/vm/src/builtins/singletons.rs
+++ b/vm/src/builtins/singletons.rs
@@ -1,6 +1,9 @@
 use super::pytype::PyTypeRef;
+use crate::slots::SlotConstructor;
 use crate::vm::VirtualMachine;
-use crate::{IntoPyObject, PyClassImpl, PyContext, PyObjectRef, PyRef, PyValue, TypeProtocol};
+use crate::{
+    IntoPyObject, PyClassImpl, PyContext, PyObjectRef, PyRef, PyResult, PyValue, TypeProtocol,
+};
 
 #[pyclass(module = false, name = "NoneType")]
 #[derive(Debug)]
@@ -30,13 +33,16 @@ impl<T: IntoPyObject> IntoPyObject for Option<T> {
     }
 }
 
-#[pyimpl]
-impl PyNone {
-    #[pyslot]
-    fn tp_new(_: PyTypeRef, vm: &VirtualMachine) -> PyRef<Self> {
-        vm.ctx.none.clone()
-    }
+impl SlotConstructor for PyNone {
+    type Args = ();
 
+    fn py_new(_: PyTypeRef, _args: Self::Args, vm: &VirtualMachine) -> PyResult {
+        Ok(vm.ctx.none.clone().into_object())
+    }
+}
+
+#[pyimpl(with(SlotConstructor))]
+impl PyNone {
     #[pymethod(magic)]
     fn repr(&self) -> String {
         "None".to_owned()
@@ -59,13 +65,16 @@ impl PyValue for PyNotImplemented {
     }
 }
 
-#[pyimpl]
-impl PyNotImplemented {
-    #[pyslot]
-    fn tp_new(_: PyTypeRef, vm: &VirtualMachine) -> PyRef<Self> {
-        vm.ctx.not_implemented.clone()
-    }
+impl SlotConstructor for PyNotImplemented {
+    type Args = ();
 
+    fn py_new(_: PyTypeRef, _args: Self::Args, vm: &VirtualMachine) -> PyResult {
+        Ok(vm.ctx.not_implemented.clone().into_object())
+    }
+}
+
+#[pyimpl(with(SlotConstructor))]
+impl PyNotImplemented {
     // TODO: As per https://bugs.python.org/issue35712, using NotImplemented
     // in boolean contexts will need to raise a DeprecationWarning in 3.9
     // and, eventually, a TypeError.

--- a/vm/src/builtins/staticmethod.rs
+++ b/vm/src/builtins/staticmethod.rs
@@ -1,7 +1,7 @@
 use super::pytype::PyTypeRef;
-use crate::slots::SlotDescriptor;
+use crate::slots::{SlotConstructor, SlotDescriptor};
 use crate::vm::VirtualMachine;
-use crate::{PyClassImpl, PyContext, PyObjectRef, PyRef, PyResult, PyValue};
+use crate::{PyClassImpl, PyContext, PyObjectRef, PyResult, PyValue};
 
 #[pyclass(module = false, name = "staticmethod")]
 #[derive(Clone, Debug)]
@@ -33,13 +33,16 @@ impl From<PyObjectRef> for PyStaticMethod {
     }
 }
 
-#[pyimpl(with(SlotDescriptor), flags(BASETYPE, HAS_DICT))]
-impl PyStaticMethod {
-    #[pyslot]
-    fn tp_new(cls: PyTypeRef, callable: PyObjectRef, vm: &VirtualMachine) -> PyResult<PyRef<Self>> {
-        PyStaticMethod { callable }.into_ref_with_type(vm, cls)
+impl SlotConstructor for PyStaticMethod {
+    type Args = PyObjectRef;
+
+    fn py_new(cls: PyTypeRef, callable: Self::Args, vm: &VirtualMachine) -> PyResult {
+        PyStaticMethod { callable }.into_pyresult_with_type(vm, cls)
     }
 }
+
+#[pyimpl(with(SlotDescriptor, SlotConstructor), flags(BASETYPE, HAS_DICT))]
+impl PyStaticMethod {}
 
 pub fn init(context: &PyContext) {
     PyStaticMethod::extend_class(context, &context.types.staticmethod_type);

--- a/vm/src/builtins/tuple.rs
+++ b/vm/src/builtins/tuple.rs
@@ -15,7 +15,7 @@ use crate::common::hash::PyHash;
 use crate::function::OptionalArg;
 use crate::sequence::{self, SimpleSeq};
 use crate::sliceable::PySliceableSequence;
-use crate::slots::{Comparable, Hashable, Iterable, PyComparisonOp, PyIter};
+use crate::slots::{Comparable, Hashable, Iterable, PyComparisonOp, PyIter, SlotConstructor};
 use crate::utils::Either;
 use crate::vm::{ReprGuard, VirtualMachine};
 use crate::{
@@ -83,7 +83,36 @@ impl PyTupleRef {
     }
 }
 
-#[pyimpl(flags(BASETYPE), with(Hashable, Comparable, Iterable))]
+impl SlotConstructor for PyTuple {
+    type Args = OptionalArg<PyObjectRef>;
+
+    fn py_new(cls: PyTypeRef, iterable: Self::Args, vm: &VirtualMachine) -> PyResult {
+        let elements = if let OptionalArg::Present(iterable) = iterable {
+            let iterable = if cls.is(&vm.ctx.types.tuple_type) {
+                match iterable.downcast_exact::<Self>(vm) {
+                    Ok(tuple) => return Ok(tuple.into_object()),
+                    Err(iterable) => iterable,
+                }
+            } else {
+                iterable
+            };
+            vm.extract_elements(&iterable)?
+        } else {
+            vec![]
+        };
+        // Return empty tuple only for exact tuple types if the iterable is empty.
+        if elements.is_empty() && cls.is(&vm.ctx.types.tuple_type) {
+            Ok(vm.ctx.empty_tuple.clone().into_object())
+        } else {
+            Self {
+                elements: elements.into_boxed_slice(),
+            }
+            .into_pyresult_with_type(vm, cls)
+        }
+    }
+}
+
+#[pyimpl(flags(BASETYPE), with(Hashable, Comparable, Iterable, SlotConstructor))]
 impl PyTuple {
     /// Creating a new tuple with given boxed slice.
     /// NOTE: for usual case, you probably want to use PyTupleRef::with_elements.
@@ -253,36 +282,6 @@ impl PyTuple {
             PyTupleRef::with_elements(zelf.elements.clone().into_vec(), &vm.ctx)
         };
         (tup_arg,)
-    }
-
-    #[pyslot]
-    fn tp_new(
-        cls: PyTypeRef,
-        iterable: OptionalArg<PyObjectRef>,
-        vm: &VirtualMachine,
-    ) -> PyResult<PyRef<Self>> {
-        let elements = if let OptionalArg::Present(iterable) = iterable {
-            let iterable = if cls.is(&vm.ctx.types.tuple_type) {
-                match iterable.downcast_exact::<Self>(vm) {
-                    Ok(tuple) => return Ok(tuple),
-                    Err(iterable) => iterable,
-                }
-            } else {
-                iterable
-            };
-            vm.extract_elements(&iterable)?
-        } else {
-            vec![]
-        };
-        // Return empty tuple only for exact tuple types if the iterable is empty.
-        if elements.is_empty() && cls.is(&vm.ctx.types.tuple_type) {
-            Ok(vm.ctx.empty_tuple.clone())
-        } else {
-            Self {
-                elements: elements.into_boxed_slice(),
-            }
-            .into_ref_with_type(vm, cls)
-        }
     }
 }
 

--- a/vm/src/exceptions.rs
+++ b/vm/src/exceptions.rs
@@ -63,12 +63,8 @@ impl PyBaseException {
     }
 
     #[pyslot]
-    pub(crate) fn tp_new(
-        cls: PyTypeRef,
-        args: FuncArgs,
-        vm: &VirtualMachine,
-    ) -> PyResult<PyRef<Self>> {
-        PyBaseException::new(args.args, vm).into_ref_with_type(vm, cls)
+    pub(crate) fn tp_new(cls: PyTypeRef, args: FuncArgs, vm: &VirtualMachine) -> PyResult {
+        PyBaseException::new(args.args, vm).into_pyresult_with_type(vm, cls)
     }
 
     #[pymethod(magic)]
@@ -555,11 +551,7 @@ macro_rules! extends_exception {
         #[pyimpl(flags(BASETYPE, HAS_DICT))]
         impl $class_name {
             #[pyslot]
-            fn tp_new(
-                cls: PyTypeRef,
-                args: FuncArgs,
-                vm: &VirtualMachine,
-            ) -> PyResult<PyRef<PyBaseException>> {
+            fn tp_new(cls: PyTypeRef, args: FuncArgs, vm: &VirtualMachine) -> PyResult {
                 // We need this method, because of how `CPython` copies `init`
                 // from `BaseException` in `SimpleExtendsException` macro.
                 // See: `BaseException_new`

--- a/vm/src/macros.rs
+++ b/vm/src/macros.rs
@@ -34,11 +34,6 @@ macro_rules! py_class {
             py_class
         }
     };
-    (@extract_slots($ctx:expr, $slots:expr, (slot new), $value:expr)) => {
-        $slots.new = Some(
-            $crate::function::IntoPyNativeFunc::into_func($value)
-        );
-    };
     (@extract_slots($ctx:expr, $slots:expr, (slot $slot_name:ident), $value:expr)) => {
         $slots.$slot_name.store(Some($value));
     };

--- a/vm/src/pyobject.rs
+++ b/vm/src/pyobject.rs
@@ -1016,6 +1016,10 @@ pub trait PyValue: fmt::Debug + PyThreadingConstraint + Sized + 'static {
             )))
         }
     }
+
+    fn into_pyresult_with_type(self, vm: &VirtualMachine, cls: PyTypeRef) -> PyResult {
+        self.into_ref_with_type(vm, cls).into_pyresult(vm)
+    }
 }
 
 pub trait PyObjectPayload: Any + fmt::Debug + PyThreadingConstraint + 'static {}

--- a/vm/src/stdlib/itertools.rs
+++ b/vm/src/stdlib/itertools.rs
@@ -15,7 +15,7 @@ mod decl {
     use crate::common::rc::PyRc;
     use crate::function::{Args, FuncArgs, OptionalArg, OptionalOption};
     use crate::iterator::{call_next, get_all, get_iter, get_next_object};
-    use crate::slots::PyIter;
+    use crate::slots::{PyIter, SlotConstructor};
     use crate::vm::VirtualMachine;
     use crate::{
         IdProtocol, IntoPyObject, PyCallable, PyObjectRef, PyRef, PyResult, PyValue, PyWeakRef,
@@ -40,13 +40,13 @@ mod decl {
     #[pyimpl(with(PyIter))]
     impl PyItertoolsChain {
         #[pyslot]
-        fn tp_new(cls: PyTypeRef, args: FuncArgs, vm: &VirtualMachine) -> PyResult<PyRef<Self>> {
+        fn tp_new(cls: PyTypeRef, args: FuncArgs, vm: &VirtualMachine) -> PyResult {
             PyItertoolsChain {
                 iterables: args.args,
                 cur_idx: AtomicCell::new(0),
                 cached_iter: PyRwLock::new(None),
             }
-            .into_ref_with_type(vm, cls)
+            .into_pyresult_with_type(vm, cls)
         }
 
         #[pyclassmethod]
@@ -117,15 +117,22 @@ mod decl {
         }
     }
 
-    #[pyimpl(with(PyIter))]
-    impl PyItertoolsCompress {
-        #[pyslot]
-        fn tp_new(
+    #[derive(FromArgs)]
+    struct CompressNewArgs {
+        #[pyarg(positional)]
+        data: PyObjectRef,
+        #[pyarg(positional)]
+        selector: PyObjectRef,
+    }
+
+    impl SlotConstructor for PyItertoolsCompress {
+        type Args = CompressNewArgs;
+
+        fn py_new(
             cls: PyTypeRef,
-            data: PyObjectRef,
-            selector: PyObjectRef,
+            Self::Args { data, selector }: Self::Args,
             vm: &VirtualMachine,
-        ) -> PyResult<PyRef<Self>> {
+        ) -> PyResult {
             let data_iter = get_iter(vm, data)?;
             let selector_iter = get_iter(vm, selector)?;
 
@@ -133,9 +140,13 @@ mod decl {
                 data: data_iter,
                 selector: selector_iter,
             }
-            .into_ref_with_type(vm, cls)
+            .into_pyresult_with_type(vm, cls)
         }
     }
+
+    #[pyimpl(with(PyIter, SlotConstructor))]
+    impl PyItertoolsCompress {}
+
     impl PyIter for PyItertoolsCompress {
         fn next(zelf: &PyRef<Self>, vm: &VirtualMachine) -> PyResult {
             loop {
@@ -164,15 +175,23 @@ mod decl {
         }
     }
 
-    #[pyimpl(with(PyIter))]
-    impl PyItertoolsCount {
-        #[pyslot]
-        fn tp_new(
+    #[derive(FromArgs)]
+    struct CountNewArgs {
+        #[pyarg(positional, optional)]
+        start: OptionalArg<PyIntRef>,
+
+        #[pyarg(positional, optional)]
+        step: OptionalArg<PyIntRef>,
+    }
+
+    impl SlotConstructor for PyItertoolsCount {
+        type Args = CountNewArgs;
+
+        fn py_new(
             cls: PyTypeRef,
-            start: OptionalArg<PyIntRef>,
-            step: OptionalArg<PyIntRef>,
+            Self::Args { start, step }: Self::Args,
             vm: &VirtualMachine,
-        ) -> PyResult<PyRef<Self>> {
+        ) -> PyResult {
             let start = match start.into_option() {
                 Some(int) => int.as_bigint().clone(),
                 None => BigInt::zero(),
@@ -186,9 +205,12 @@ mod decl {
                 cur: PyRwLock::new(start),
                 step,
             }
-            .into_ref_with_type(vm, cls)
+            .into_pyresult_with_type(vm, cls)
         }
     }
+
+    #[pyimpl(with(PyIter, SlotConstructor))]
+    impl PyItertoolsCount {}
     impl PyIter for PyItertoolsCount {
         fn next(zelf: &PyRef<Self>, vm: &VirtualMachine) -> PyResult {
             let mut cur = zelf.cur.write();
@@ -213,14 +235,10 @@ mod decl {
         }
     }
 
-    #[pyimpl(with(PyIter))]
-    impl PyItertoolsCycle {
-        #[pyslot]
-        fn tp_new(
-            cls: PyTypeRef,
-            iterable: PyObjectRef,
-            vm: &VirtualMachine,
-        ) -> PyResult<PyRef<Self>> {
+    impl SlotConstructor for PyItertoolsCycle {
+        type Args = PyObjectRef;
+
+        fn py_new(cls: PyTypeRef, iterable: Self::Args, vm: &VirtualMachine) -> PyResult {
             let iter = get_iter(vm, iterable)?;
 
             PyItertoolsCycle {
@@ -228,9 +246,12 @@ mod decl {
                 saved: PyRwLock::new(Vec::new()),
                 index: AtomicCell::new(0),
             }
-            .into_ref_with_type(vm, cls)
+            .into_pyresult_with_type(vm, cls)
         }
     }
+
+    #[pyimpl(with(PyIter, SlotConstructor))]
+    impl PyItertoolsCycle {}
     impl PyIter for PyItertoolsCycle {
         fn next(zelf: &PyRef<Self>, vm: &VirtualMachine) -> PyResult {
             let item = if let Some(item) = get_next_object(vm, &zelf.iter)? {
@@ -277,14 +298,14 @@ mod decl {
         times: OptionalArg<PyIntRef>,
     }
 
-    #[pyimpl(with(PyIter), flags(BASETYPE))]
-    impl PyItertoolsRepeat {
-        #[pyslot]
-        fn tp_new(
+    impl SlotConstructor for PyItertoolsRepeat {
+        type Args = PyRepeatNewArgs;
+
+        fn py_new(
             cls: PyTypeRef,
-            PyRepeatNewArgs { object, times }: PyRepeatNewArgs,
+            Self::Args { object, times }: Self::Args,
             vm: &VirtualMachine,
-        ) -> PyResult<PyRef<Self>> {
+        ) -> PyResult {
             let times = match times.into_option() {
                 Some(int) => {
                     let val = int.as_bigint();
@@ -296,9 +317,12 @@ mod decl {
                 }
                 None => None,
             };
-            PyItertoolsRepeat { object, times }.into_ref_with_type(vm, cls)
+            PyItertoolsRepeat { object, times }.into_pyresult_with_type(vm, cls)
         }
+    }
 
+    #[pyimpl(with(PyIter, SlotConstructor), flags(BASETYPE))]
+    impl PyItertoolsRepeat {
         #[pymethod(magic)]
         fn length_hint(&self, vm: &VirtualMachine) -> PyResult {
             match self.times {
@@ -362,20 +386,30 @@ mod decl {
         }
     }
 
-    #[pyimpl(with(PyIter))]
-    impl PyItertoolsStarmap {
-        #[pyslot]
-        fn tp_new(
+    #[derive(FromArgs)]
+    struct StarmapNewArgs {
+        #[pyarg(positional)]
+        function: PyObjectRef,
+        #[pyarg(positional)]
+        iterable: PyObjectRef,
+    }
+
+    impl SlotConstructor for PyItertoolsStarmap {
+        type Args = StarmapNewArgs;
+
+        fn py_new(
             cls: PyTypeRef,
-            function: PyObjectRef,
-            iterable: PyObjectRef,
+            Self::Args { function, iterable }: Self::Args,
             vm: &VirtualMachine,
-        ) -> PyResult<PyRef<Self>> {
+        ) -> PyResult {
             let iter = get_iter(vm, iterable)?;
 
-            PyItertoolsStarmap { function, iter }.into_ref_with_type(vm, cls)
+            PyItertoolsStarmap { function, iter }.into_pyresult_with_type(vm, cls)
         }
     }
+
+    #[pyimpl(with(PyIter, SlotConstructor))]
+    impl PyItertoolsStarmap {}
     impl PyIter for PyItertoolsStarmap {
         fn next(zelf: &PyRef<Self>, vm: &VirtualMachine) -> PyResult {
             let obj = call_next(vm, &zelf.iter)?;
@@ -400,15 +434,25 @@ mod decl {
         }
     }
 
-    #[pyimpl(with(PyIter))]
-    impl PyItertoolsTakewhile {
-        #[pyslot]
-        fn tp_new(
+    #[derive(FromArgs)]
+    struct TakewhileNewArgs {
+        #[pyarg(positional)]
+        predicate: PyObjectRef,
+        #[pyarg(positional)]
+        iterable: PyObjectRef,
+    }
+
+    impl SlotConstructor for PyItertoolsTakewhile {
+        type Args = TakewhileNewArgs;
+
+        fn py_new(
             cls: PyTypeRef,
-            predicate: PyObjectRef,
-            iterable: PyObjectRef,
+            Self::Args {
+                predicate,
+                iterable,
+            }: Self::Args,
             vm: &VirtualMachine,
-        ) -> PyResult<PyRef<Self>> {
+        ) -> PyResult {
             let iter = get_iter(vm, iterable)?;
 
             PyItertoolsTakewhile {
@@ -416,9 +460,12 @@ mod decl {
                 iterable: iter,
                 stop_flag: AtomicCell::new(false),
             }
-            .into_ref_with_type(vm, cls)
+            .into_pyresult_with_type(vm, cls)
         }
     }
+
+    #[pyimpl(with(PyIter, SlotConstructor))]
+    impl PyItertoolsTakewhile {}
     impl PyIter for PyItertoolsTakewhile {
         fn next(zelf: &PyRef<Self>, vm: &VirtualMachine) -> PyResult {
             if zelf.stop_flag.load() {
@@ -455,15 +502,25 @@ mod decl {
         }
     }
 
-    #[pyimpl(with(PyIter))]
-    impl PyItertoolsDropwhile {
-        #[pyslot]
-        fn tp_new(
+    #[derive(FromArgs)]
+    struct DropwhileNewArgs {
+        #[pyarg(positional)]
+        predicate: PyCallable,
+        #[pyarg(positional)]
+        iterable: PyObjectRef,
+    }
+
+    impl SlotConstructor for PyItertoolsDropwhile {
+        type Args = DropwhileNewArgs;
+
+        fn py_new(
             cls: PyTypeRef,
-            predicate: PyCallable,
-            iterable: PyObjectRef,
+            Self::Args {
+                predicate,
+                iterable,
+            }: Self::Args,
             vm: &VirtualMachine,
-        ) -> PyResult<PyRef<Self>> {
+        ) -> PyResult {
             let iter = get_iter(vm, iterable)?;
 
             PyItertoolsDropwhile {
@@ -471,9 +528,12 @@ mod decl {
                 iterable: iter,
                 start_flag: AtomicCell::new(false),
             }
-            .into_ref_with_type(vm, cls)
+            .into_pyresult_with_type(vm, cls)
         }
     }
+
+    #[pyimpl(with(PyIter, SlotConstructor))]
+    impl PyItertoolsDropwhile {}
     impl PyIter for PyItertoolsDropwhile {
         fn next(zelf: &PyRef<Self>, vm: &VirtualMachine) -> PyResult {
             let predicate = &zelf.predicate;
@@ -551,10 +611,10 @@ mod decl {
         key: OptionalOption<PyObjectRef>,
     }
 
-    #[pyimpl(with(PyIter))]
-    impl PyItertoolsGroupBy {
-        #[pyslot]
-        fn tp_new(cls: PyTypeRef, args: GroupByArgs, vm: &VirtualMachine) -> PyResult<PyRef<Self>> {
+    impl SlotConstructor for PyItertoolsGroupBy {
+        type Args = GroupByArgs;
+
+        fn py_new(cls: PyTypeRef, args: Self::Args, vm: &VirtualMachine) -> PyResult {
             let iter = get_iter(vm, args.iterable)?;
 
             PyItertoolsGroupBy {
@@ -567,9 +627,12 @@ mod decl {
                     grouper: None,
                 }),
             }
-            .into_ref_with_type(vm, cls)
+            .into_pyresult_with_type(vm, cls)
         }
+    }
 
+    #[pyimpl(with(PyIter, SlotConstructor))]
+    impl PyItertoolsGroupBy {
         pub(super) fn advance(&self, vm: &VirtualMachine) -> PyResult<(PyObjectRef, PyObjectRef)> {
             let new_value = call_next(vm, &self.iterable)?;
             let new_key = if let Some(ref kf) = self.key_func {
@@ -709,7 +772,7 @@ mod decl {
     #[pyimpl(with(PyIter))]
     impl PyItertoolsIslice {
         #[pyslot]
-        fn tp_new(cls: PyTypeRef, args: FuncArgs, vm: &VirtualMachine) -> PyResult<PyRef<Self>> {
+        fn tp_new(cls: PyTypeRef, args: FuncArgs, vm: &VirtualMachine) -> PyResult {
             let (iter, start, stop, step) = match args.args.len() {
                 0 | 1 => {
                     return Err(vm.new_type_error(format!(
@@ -766,7 +829,7 @@ mod decl {
                 stop,
                 step,
             }
-            .into_ref_with_type(vm, cls)
+            .into_pyresult_with_type(vm, cls)
         }
     }
 
@@ -808,24 +871,37 @@ mod decl {
         }
     }
 
-    #[pyimpl(with(PyIter))]
-    impl PyItertoolsFilterFalse {
-        #[pyslot]
-        fn tp_new(
+    #[derive(FromArgs)]
+    struct FilterFalseNewArgs {
+        #[pyarg(positional)]
+        predicate: PyObjectRef,
+        #[pyarg(positional)]
+        iterable: PyObjectRef,
+    }
+
+    impl SlotConstructor for PyItertoolsFilterFalse {
+        type Args = FilterFalseNewArgs;
+
+        fn py_new(
             cls: PyTypeRef,
-            predicate: PyObjectRef,
-            iterable: PyObjectRef,
+            Self::Args {
+                predicate,
+                iterable,
+            }: Self::Args,
             vm: &VirtualMachine,
-        ) -> PyResult<PyRef<Self>> {
+        ) -> PyResult {
             let iter = get_iter(vm, iterable)?;
 
             PyItertoolsFilterFalse {
                 predicate,
                 iterable: iter,
             }
-            .into_ref_with_type(vm, cls)
+            .into_pyresult_with_type(vm, cls)
         }
     }
+
+    #[pyimpl(with(PyIter, SlotConstructor))]
+    impl PyItertoolsFilterFalse {}
     impl PyIter for PyItertoolsFilterFalse {
         fn next(zelf: &PyRef<Self>, vm: &VirtualMachine) -> PyResult {
             let predicate = &zelf.predicate;
@@ -871,14 +947,10 @@ mod decl {
         }
     }
 
-    #[pyimpl(with(PyIter))]
-    impl PyItertoolsAccumulate {
-        #[pyslot]
-        fn tp_new(
-            cls: PyTypeRef,
-            args: AccumulateArgs,
-            vm: &VirtualMachine,
-        ) -> PyResult<PyRef<Self>> {
+    impl SlotConstructor for PyItertoolsAccumulate {
+        type Args = AccumulateArgs;
+
+        fn py_new(cls: PyTypeRef, args: AccumulateArgs, vm: &VirtualMachine) -> PyResult {
             let iter = get_iter(vm, args.iterable)?;
 
             PyItertoolsAccumulate {
@@ -887,9 +959,13 @@ mod decl {
                 initial: args.initial.flatten(),
                 acc_value: PyRwLock::new(None),
             }
-            .into_ref_with_type(vm, cls)
+            .into_pyresult_with_type(vm, cls)
         }
     }
+
+    #[pyimpl(with(PyIter, SlotConstructor))]
+    impl PyItertoolsAccumulate {}
+
     impl PyIter for PyItertoolsAccumulate {
         fn next(zelf: &PyRef<Self>, vm: &VirtualMachine) -> PyResult {
             let iterable = &zelf.iterable;
@@ -952,32 +1028,25 @@ mod decl {
         }
     }
 
-    #[pyimpl(with(PyIter))]
-    impl PyItertoolsTee {
-        fn from_iter(iterable: PyObjectRef, vm: &VirtualMachine) -> PyResult {
-            let class = PyItertoolsTee::class(vm);
-            let it = get_iter(vm, iterable)?;
-            if it.class().is(PyItertoolsTee::class(vm)) {
-                return vm.call_method(&it, "__copy__", ());
-            }
-            Ok(PyItertoolsTee {
-                tee_data: PyItertoolsTeeData::new(it, vm)?,
-                index: AtomicCell::new(0),
-            }
-            .into_ref_with_type(vm, class.clone())?
-            .into_object())
-        }
+    #[derive(FromArgs)]
+    struct TeeNewArgs {
+        #[pyarg(positional)]
+        iterable: PyObjectRef,
+        #[pyarg(positional, optional)]
+        n: OptionalArg<usize>,
+    }
+
+    impl SlotConstructor for PyItertoolsTee {
+        type Args = TeeNewArgs;
 
         // TODO: make tee() a function, rename this class to itertools._tee and make
         // teedata a python class
-        #[pyslot]
         #[allow(clippy::new_ret_no_self)]
-        fn tp_new(
+        fn py_new(
             _cls: PyTypeRef,
-            iterable: PyObjectRef,
-            n: OptionalArg<usize>,
+            Self::Args { iterable, n }: Self::Args,
             vm: &VirtualMachine,
-        ) -> PyResult<PyTupleRef> {
+        ) -> PyResult {
             let n = n.unwrap_or(2);
 
             let copyable = if iterable.class().has_attr("__copy__") {
@@ -991,7 +1060,24 @@ mod decl {
                 tee_vec.push(vm.call_method(&copyable, "__copy__", ())?);
             }
 
-            Ok(PyTupleRef::with_elements(tee_vec, &vm.ctx))
+            Ok(PyTupleRef::with_elements(tee_vec, &vm.ctx).into_object())
+        }
+    }
+
+    #[pyimpl(with(PyIter, SlotConstructor))]
+    impl PyItertoolsTee {
+        fn from_iter(iterable: PyObjectRef, vm: &VirtualMachine) -> PyResult {
+            let class = PyItertoolsTee::class(vm);
+            let it = get_iter(vm, iterable)?;
+            if it.class().is(PyItertoolsTee::class(vm)) {
+                return vm.call_method(&it, "__copy__", ());
+            }
+            Ok(PyItertoolsTee {
+                tee_data: PyItertoolsTeeData::new(it, vm)?,
+                index: AtomicCell::new(0),
+            }
+            .into_ref_with_type(vm, class.clone())?
+            .into_object())
         }
 
         #[pymethod(magic)]
@@ -1034,17 +1120,11 @@ mod decl {
         repeat: OptionalArg<usize>,
     }
 
-    #[pyimpl(with(PyIter))]
-    impl PyItertoolsProduct {
-        #[pyslot]
-        fn tp_new(
-            cls: PyTypeRef,
-            iterables: Args<PyObjectRef>,
-            args: ProductArgs,
-            vm: &VirtualMachine,
-        ) -> PyResult<PyRef<Self>> {
-            let repeat = args.repeat.unwrap_or(1);
+    impl SlotConstructor for PyItertoolsProduct {
+        type Args = (Args<PyObjectRef>, ProductArgs);
 
+        fn py_new(cls: PyTypeRef, (iterables, args): Self::Args, vm: &VirtualMachine) -> PyResult {
+            let repeat = args.repeat.unwrap_or(1);
             let mut pools = Vec::new();
             for arg in iterables.into_iter() {
                 let it = get_iter(vm, arg)?;
@@ -1065,9 +1145,12 @@ mod decl {
                 cur: AtomicCell::new(l.wrapping_sub(1)),
                 stop: AtomicCell::new(false),
             }
-            .into_ref_with_type(vm, cls)
+            .into_pyresult_with_type(vm, cls)
         }
+    }
 
+    #[pyimpl(with(PyIter, SlotConstructor))]
+    impl PyItertoolsProduct {
         fn update_idxs(&self, mut idxs: PyRwLockWriteGuard<'_, Vec<usize>>) {
             if idxs.len() == 0 {
                 self.stop.store(true);
@@ -1137,15 +1220,22 @@ mod decl {
         }
     }
 
-    #[pyimpl(with(PyIter))]
-    impl PyItertoolsCombinations {
-        #[pyslot]
-        fn tp_new(
+    #[derive(FromArgs)]
+    struct CombinationsNewArgs {
+        #[pyarg(positional)]
+        iterable: PyObjectRef,
+        #[pyarg(positional)]
+        r: PyIntRef,
+    }
+
+    impl SlotConstructor for PyItertoolsCombinations {
+        type Args = CombinationsNewArgs;
+
+        fn py_new(
             cls: PyTypeRef,
-            iterable: PyObjectRef,
-            r: PyIntRef,
+            Self::Args { iterable, r }: Self::Args,
             vm: &VirtualMachine,
-        ) -> PyResult<PyRef<Self>> {
+        ) -> PyResult {
             let iter = get_iter(vm, iterable)?;
             let pool = get_all(vm, &iter)?;
 
@@ -1163,9 +1253,12 @@ mod decl {
                 r: AtomicCell::new(r),
                 exhausted: AtomicCell::new(r > n),
             }
-            .into_ref_with_type(vm, cls)
+            .into_pyresult_with_type(vm, cls)
         }
     }
+
+    #[pyimpl(with(PyIter, SlotConstructor))]
+    impl PyItertoolsCombinations {}
     impl PyIter for PyItertoolsCombinations {
         fn next(zelf: &PyRef<Self>, vm: &VirtualMachine) -> PyResult {
             // stop signal
@@ -1232,15 +1325,14 @@ mod decl {
         }
     }
 
-    #[pyimpl(with(PyIter))]
-    impl PyItertoolsCombinationsWithReplacement {
-        #[pyslot]
-        fn tp_new(
+    impl SlotConstructor for PyItertoolsCombinationsWithReplacement {
+        type Args = CombinationsNewArgs;
+
+        fn py_new(
             cls: PyTypeRef,
-            iterable: PyObjectRef,
-            r: PyIntRef,
+            Self::Args { iterable, r }: Self::Args,
             vm: &VirtualMachine,
-        ) -> PyResult<PyRef<Self>> {
+        ) -> PyResult {
             let iter = get_iter(vm, iterable)?;
             let pool = get_all(vm, &iter)?;
 
@@ -1258,9 +1350,13 @@ mod decl {
                 r: AtomicCell::new(r),
                 exhausted: AtomicCell::new(n == 0 && r > 0),
             }
-            .into_ref_with_type(vm, cls)
+            .into_pyresult_with_type(vm, cls)
         }
     }
+
+    #[pyimpl(with(PyIter, SlotConstructor))]
+    impl PyItertoolsCombinationsWithReplacement {}
+
     impl PyIter for PyItertoolsCombinationsWithReplacement {
         fn next(zelf: &PyRef<Self>, vm: &VirtualMachine) -> PyResult {
             // stop signal
@@ -1324,15 +1420,22 @@ mod decl {
         }
     }
 
-    #[pyimpl(with(PyIter))]
-    impl PyItertoolsPermutations {
-        #[pyslot]
-        fn tp_new(
+    #[derive(FromArgs)]
+    struct PermutationsNewArgs {
+        #[pyarg(positional)]
+        iterable: PyObjectRef,
+        #[pyarg(positional, optional)]
+        r: OptionalOption<PyObjectRef>,
+    }
+
+    impl SlotConstructor for PyItertoolsPermutations {
+        type Args = PermutationsNewArgs;
+
+        fn py_new(
             cls: PyTypeRef,
-            iterable: PyObjectRef,
-            r: OptionalOption<PyObjectRef>,
+            Self::Args { iterable, r }: Self::Args,
             vm: &VirtualMachine,
-        ) -> PyResult<PyRef<Self>> {
+        ) -> PyResult {
             let pool = vm.extract_elements(&iterable)?;
 
             let n = pool.len();
@@ -1361,9 +1464,12 @@ mod decl {
                 r: AtomicCell::new(r),
                 exhausted: AtomicCell::new(r > n),
             }
-            .into_ref_with_type(vm, cls)
+            .into_pyresult_with_type(vm, cls)
         }
     }
+
+    #[pyimpl(with(PyIter, SlotConstructor))]
+    impl PyItertoolsPermutations {}
     impl PyIter for PyItertoolsPermutations {
         fn next(zelf: &PyRef<Self>, vm: &VirtualMachine) -> PyResult {
             // stop signal
@@ -1431,6 +1537,30 @@ mod decl {
         }
     }
 
+    #[derive(FromArgs)]
+    struct ZipLongestArgs {
+        #[pyarg(named, optional)]
+        fillvalue: OptionalArg<PyObjectRef>,
+    }
+
+    impl SlotConstructor for PyItertoolsZipLongest {
+        type Args = (Args<PyObjectRef>, ZipLongestArgs);
+
+        fn py_new(cls: PyTypeRef, (iterables, args): Self::Args, vm: &VirtualMachine) -> PyResult {
+            let fillvalue = args.fillvalue.unwrap_or_none(vm);
+            let iterators = iterables
+                .into_iter()
+                .map(|iterable| get_iter(vm, iterable))
+                .collect::<Result<Vec<_>, _>>()?;
+
+            PyItertoolsZipLongest {
+                iterators,
+                fillvalue,
+            }
+            .into_pyresult_with_type(vm, cls)
+        }
+    }
+
     #[pyattr]
     #[pyclass(name = "zip_longest")]
     #[derive(Debug)]
@@ -1445,34 +1575,8 @@ mod decl {
         }
     }
 
-    #[derive(FromArgs)]
-    struct ZipLongestArgs {
-        #[pyarg(named, optional)]
-        fillvalue: OptionalArg<PyObjectRef>,
-    }
-
-    #[pyimpl(with(PyIter))]
-    impl PyItertoolsZipLongest {
-        #[pyslot]
-        fn tp_new(
-            cls: PyTypeRef,
-            iterables: Args,
-            args: ZipLongestArgs,
-            vm: &VirtualMachine,
-        ) -> PyResult<PyRef<Self>> {
-            let fillvalue = args.fillvalue.unwrap_or_none(vm);
-            let iterators = iterables
-                .into_iter()
-                .map(|iterable| get_iter(vm, iterable))
-                .collect::<Result<Vec<_>, _>>()?;
-
-            PyItertoolsZipLongest {
-                iterators,
-                fillvalue,
-            }
-            .into_ref_with_type(vm, cls)
-        }
-    }
+    #[pyimpl(with(PyIter, SlotConstructor))]
+    impl PyItertoolsZipLongest {}
     impl PyIter for PyItertoolsZipLongest {
         fn next(zelf: &PyRef<Self>, vm: &VirtualMachine) -> PyResult {
             if zelf.iterators.is_empty() {
@@ -1516,23 +1620,22 @@ mod decl {
         }
     }
 
-    #[pyimpl(with(PyIter))]
-    impl PyItertoolsPairwise {
-        #[pyslot]
-        fn tp_new(
-            cls: PyTypeRef,
-            iterable: PyObjectRef,
-            vm: &VirtualMachine,
-        ) -> PyResult<PyRef<Self>> {
+    impl SlotConstructor for PyItertoolsPairwise {
+        type Args = PyObjectRef;
+
+        fn py_new(cls: PyTypeRef, iterable: Self::Args, vm: &VirtualMachine) -> PyResult {
             let iterator = get_iter(vm, iterable)?;
 
             PyItertoolsPairwise {
                 iterator,
                 old: PyRwLock::new(None),
             }
-            .into_ref_with_type(vm, cls)
+            .into_pyresult_with_type(vm, cls)
         }
     }
+
+    #[pyimpl(with(PyIter, SlotConstructor))]
+    impl PyItertoolsPairwise {}
     impl PyIter for PyItertoolsPairwise {
         fn next(zelf: &PyRef<Self>, vm: &VirtualMachine) -> PyResult {
             let old = match zelf.old.read().clone() {

--- a/vm/src/stdlib/operator.rs
+++ b/vm/src/stdlib/operator.rs
@@ -22,8 +22,8 @@ mod _operator {
     use crate::function::OptionalArg;
     use crate::iterator;
     use crate::pyobject::TypeProtocol;
-    use crate::slots::Callable;
     use crate::slots::PyComparisonOp::{Eq, Ge, Gt, Le, Lt, Ne};
+    use crate::slots::{Callable, SlotConstructor};
     use crate::utils::Either;
     use crate::vm::ReprGuard;
     use crate::IdProtocol;
@@ -450,7 +450,7 @@ mod _operator {
     #[pyimpl(with(Callable))]
     impl PyAttrGetter {
         #[pyslot]
-        fn tp_new(cls: PyTypeRef, args: FuncArgs, vm: &VirtualMachine) -> PyResult<PyRef<Self>> {
+        fn tp_new(cls: PyTypeRef, args: FuncArgs, vm: &VirtualMachine) -> PyResult {
             let nattr = args.args.len();
             // Check we get no keyword and at least one positional.
             if !args.kwargs.is_empty() {
@@ -467,7 +467,7 @@ mod _operator {
                     return Err(vm.new_type_error("attribute name must be a string".to_owned()));
                 }
             }
-            PyAttrGetter { attrs }.into_ref_with_type(vm, cls)
+            PyAttrGetter { attrs }.into_pyresult_with_type(vm, cls)
         }
 
         #[pymethod(magic)]
@@ -553,7 +553,7 @@ mod _operator {
     #[pyimpl(with(Callable))]
     impl PyItemGetter {
         #[pyslot]
-        fn tp_new(cls: PyTypeRef, args: FuncArgs, vm: &VirtualMachine) -> PyResult<PyRef<Self>> {
+        fn tp_new(cls: PyTypeRef, args: FuncArgs, vm: &VirtualMachine) -> PyResult {
             // Check we get no keyword and at least one positional.
             if !args.kwargs.is_empty() {
                 return Err(vm.new_type_error("itemgetter() takes no keyword arguments".to_owned()));
@@ -561,7 +561,7 @@ mod _operator {
             if args.args.is_empty() {
                 return Err(vm.new_type_error("itemgetter expected 1 argument, got 0.".to_owned()));
             }
-            PyItemGetter { items: args.args }.into_ref_with_type(vm, cls)
+            PyItemGetter { items: args.args }.into_pyresult_with_type(vm, cls)
         }
 
         #[pymethod(magic)]
@@ -626,22 +626,20 @@ mod _operator {
         }
     }
 
-    #[pyimpl(with(Callable))]
-    impl PyMethodCaller {
-        #[pyslot]
-        fn tp_new(
-            cls: PyTypeRef,
-            name: PyObjectRef,
-            args: FuncArgs,
-            vm: &VirtualMachine,
-        ) -> PyResult<PyRef<Self>> {
+    impl SlotConstructor for PyMethodCaller {
+        type Args = (PyObjectRef, FuncArgs);
+
+        fn py_new(cls: PyTypeRef, (name, args): Self::Args, vm: &VirtualMachine) -> PyResult {
             if let Ok(name) = name.try_into_ref(vm) {
-                PyMethodCaller { name, args }.into_ref_with_type(vm, cls)
+                PyMethodCaller { name, args }.into_pyresult_with_type(vm, cls)
             } else {
                 Err(vm.new_type_error("method name must be a string".to_owned()))
             }
         }
+    }
 
+    #[pyimpl(with(Callable, SlotConstructor))]
+    impl PyMethodCaller {
         #[pymethod(magic)]
         fn repr(zelf: PyRef<Self>, vm: &VirtualMachine) -> PyResult<String> {
             let fmt = if let Some(_guard) = ReprGuard::enter(vm, zelf.as_object()) {

--- a/vm/src/stdlib/socket.rs
+++ b/vm/src/stdlib/socket.rs
@@ -191,8 +191,8 @@ impl PySocket {
     }
 
     #[pyslot]
-    fn tp_new(cls: PyTypeRef, _args: FuncArgs, vm: &VirtualMachine) -> PyResult<PyRef<Self>> {
-        Self::default().into_ref_with_type(vm, cls)
+    fn tp_new(cls: PyTypeRef, _args: FuncArgs, vm: &VirtualMachine) -> PyResult {
+        Self::default().into_pyresult_with_type(vm, cls)
     }
 
     #[pymethod(magic)]

--- a/vm/src/stdlib/thread.rs
+++ b/vm/src/stdlib/thread.rs
@@ -169,11 +169,11 @@ impl fmt::Debug for PyRLock {
 #[pyimpl]
 impl PyRLock {
     #[pyslot]
-    fn tp_new(cls: PyTypeRef, vm: &VirtualMachine) -> PyResult<PyRef<Self>> {
+    fn tp_new(cls: PyTypeRef, _args: FuncArgs, vm: &VirtualMachine) -> PyResult {
         PyRLock {
             mu: RawRMutex::INIT,
         }
-        .into_ref_with_type(vm, cls)
+        .into_pyresult_with_type(vm, cls)
     }
 
     #[pymethod]
@@ -321,11 +321,11 @@ impl PyLocal {
     }
 
     #[pyslot]
-    fn tp_new(cls: PyTypeRef, _args: FuncArgs, vm: &VirtualMachine) -> PyResult<PyRef<Self>> {
+    fn tp_new(cls: PyTypeRef, _args: FuncArgs, vm: &VirtualMachine) -> PyResult {
         PyLocal {
             data: ThreadLocal::new(),
         }
-        .into_ref_with_type(vm, cls)
+        .into_pyresult_with_type(vm, cls)
     }
 }
 

--- a/vm/src/stdlib/time.rs
+++ b/vm/src/stdlib/time.rs
@@ -9,7 +9,7 @@ use chrono::{Datelike, Timelike};
 
 use crate::builtins::pystr::PyStrRef;
 use crate::builtins::pytype::PyTypeRef;
-use crate::function::OptionalArg;
+use crate::function::{FuncArgs, OptionalArg};
 use crate::utils::Either;
 use crate::vm::VirtualMachine;
 use crate::{PyClassImpl, PyObjectRef, PyResult, PyStructSequence, TryFromObject};
@@ -227,9 +227,10 @@ impl PyStructTime {
     }
 
     #[pyslot]
-    fn tp_new(_cls: PyTypeRef, seq: PyObjectRef, vm: &VirtualMachine) -> PyResult<Self> {
+    fn tp_new(_cls: PyTypeRef, args: FuncArgs, vm: &VirtualMachine) -> PyResult {
         // cls is ignorable because this is not a basetype
-        Self::try_from_object(vm, seq)
+        let seq = args.bind(vm)?;
+        Ok(vm.new_pyobj(Self::try_from_object(vm, seq)?))
     }
 }
 


### PR DESCRIPTION
closes #2985 by implement them to modules using tp_new which does not have signature with
`tp_new(PyTypeRef, FuncArgs, &VirtualMachine) -> PyResult`

but it panics with vm initaliztion. with `thread 'main' panicked at 'removal index (is 0) should be < len (is 0)'`
due to the panic, i open with draft and work on it.

I would be thankful for any advice!