### PR TITLE
better error message when pymethod/pyproperty signature is wrong

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1315,9 +1315,9 @@ dependencies = [
 
 [[package]]
 name = "openssl-probe"
-version = "0.1.4"
+version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "28988d872ab76095a6e6ac88d99b54fd267702734fd7ffe610ca27f533ddb95a"
+checksum = "77af24da69f9d9341038eba93a073b1fdaaa1b788221b00a69bce9e762cb32de"
 
 [[package]]
 name = "openssl-src"
@@ -2287,9 +2287,9 @@ dependencies = [
 
 [[package]]
 name = "syn-ext"
-version = "0.2.3"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9210542fa1f4811e2024f7ef22668ef8e035a54f6c9d4826faae8ae2885bd455"
+checksum = "ccfaff88a7edb37fd3a16f24b986500e4a6d4b87218d9b38255e208ca4a08848"
 dependencies = [
  "syn",
 ]

--- a/derive/Cargo.toml
+++ b/derive/Cargo.toml
@@ -12,7 +12,7 @@ proc-macro = true
 
 [dependencies]
 syn = { version = "1.0", features = ["full", "extra-traits"] }
-syn-ext = { version = "0.2.3", features = ["full"] }
+syn-ext = { version = "0.3.0", features = ["full"] }
 quote = "1.0"
 proc-macro2 = "1.0"
 rustpython-compiler = { path = "../compiler/porcelain", version = "0.1.1" }

--- a/derive/src/pyclass.rs
+++ b/derive/src/pyclass.rs
@@ -893,17 +893,17 @@ fn extract_impl_attrs(attr: AttributeArgs) -> std::result::Result<ExtractedImplA
                         };
                         if path_eq(&path, "PyRef") {
                             // special handling for PyRef
-                            withs.push(quote! {
+                            withs.push(quote_spanned! { path.span() =>
                                 PyRef::<Self>::impl_extend_class(ctx, class);
                             });
-                            with_slots.push(quote! {
+                            with_slots.push(quote_spanned! { path.span() =>
                                 PyRef::<Self>::extend_slots(slots);
                             });
                         } else {
-                            withs.push(quote! {
+                            withs.push(quote_spanned! { path.span() =>
                                 <Self as #path>::__extend_py_class(ctx, class);
                             });
-                            with_slots.push(quote! {
+                            with_slots.push(quote_spanned! { path.span() =>
                                 <Self as #path>::__extend_slots(slots);
                             });
                         }
@@ -913,7 +913,7 @@ fn extract_impl_attrs(attr: AttributeArgs) -> std::result::Result<ExtractedImplA
                         match meta {
                             NestedMeta::Meta(Meta::Path(path)) => {
                                 if let Some(ident) = path.get_ident() {
-                                    flags.push(quote! {
+                                    flags.push(quote_spanned! { ident.span() =>
                                         | ::rustpython_vm::slots::PyTpFlags::#ident.bits()
                                     });
                                 } else {

--- a/derive/src/pyclass.rs
+++ b/derive/src/pyclass.rs
@@ -451,7 +451,7 @@ where
                     other
                 ),
             };
-            quote! {
+            quote_spanned! { ident.span() =>
                 class.set_str_attr(
                     #py_name,
                     ctx.make_funcdef(#py_name, Self::#ident)
@@ -663,16 +663,16 @@ impl ToTokens for GetSetNursery {
             .iter()
             .map(|((name, cfgs), (getter, setter, deleter))| {
                 let setter = match setter {
-                    Some(setter) => quote_spanned! { setter.span()=> .with_set(&Self::#setter)},
+                    Some(setter) => quote_spanned! { setter.span() => .with_set(&Self::#setter)},
                     None => quote! {},
                 };
                 let deleter = match deleter {
                     Some(deleter) => {
-                        quote_spanned! { deleter.span()=> .with_delete(&Self::#deleter)}
+                        quote_spanned! { deleter.span() => .with_delete(&Self::#deleter)}
                     }
                     None => quote! {},
                 };
-                quote! {
+                quote_spanned! { getter.span() =>
                     #( #cfgs )*
                     class.set_str_attr(
                         #name,

--- a/derive/src/util.rs
+++ b/derive/src/util.rs
@@ -507,11 +507,7 @@ where
 
 // Best effort attempt to generate a template from which a
 // __text_signature__ can be created.
-pub(crate) fn get_sig<Item: ItemLike>(item: &Item, name: &str) -> String {
-    let sig = match item.function_or_method_impl().map(|f| f.sig()) {
-        Ok(sig) => sig,
-        _ => return "".to_owned(),
-    };
+pub(crate) fn text_signature(sig: &Signature, name: &str) -> String {
     let signature = func_sig(sig);
     if signature.starts_with("$self") {
         format!("{}({})", name, signature)


### PR DESCRIPTION
Make signature errors show the funciton signature instead of macro attribute