### PR TITLE
Solve some lexical error with underscore

### DIFF
--- a/Lib/test/test_grammar.py
+++ b/Lib/test/test_grammar.py
@@ -179,8 +179,6 @@ class TokenTests(unittest.TestCase):
         self.assertEqual(1 if 0else 0, 0)
         self.assertRaises(SyntaxError, eval, "0 if 1Else 0")
 
-    # TODO: RUSTPYTHON
-    @unittest.expectedFailure
     def test_underscore_literals(self):
         for lit in VALID_UNDERSCORE_LITERALS:
             self.assertEqual(eval(lit), eval(lit.replace('_', '')))

--- a/parser/src/lexer.rs
+++ b/parser/src/lexer.rs
@@ -315,10 +315,21 @@ where
 
             // 1e6 for example:
             if self.chr0 == Some('e') || self.chr0 == Some('E') {
+                if self.chr1 == Some('_') {
+                    return Err(LexicalError {
+                        error: LexicalErrorType::OtherError("Invalid Syntax".to_owned()),
+                        location: self.get_pos(),
+                    });
+                }
                 value_text.push(self.next_char().unwrap().to_ascii_lowercase());
-
                 // Optional +/-
                 if self.chr0 == Some('-') || self.chr0 == Some('+') {
+                    if self.chr1 == Some('_') {
+                        return Err(LexicalError {
+                            error: LexicalErrorType::OtherError("Invalid Syntax".to_owned()),
+                            location: self.get_pos(),
+                        });
+                    }
                     value_text.push(self.next_char().unwrap());
                 }
 


### PR DESCRIPTION
This commit is to pass the test `test_underscore_literals` in `test_grammar.py`.