### PR TITLE
Remove unnecessary linebreak

### DIFF
--- a/ast/src/location.rs
+++ b/ast/src/location.rs
@@ -30,7 +30,7 @@ impl Location {
             fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
                 write!(
                     f,
-                    "{}\n{}\n{arrow:>pad$}",
+                    "{}\n{}{arrow:>pad$}",
                     self.desc,
                     self.line,
                     pad = self.loc.column,


### PR DESCRIPTION
I think the error message has unnecessary linebreak.

When we execute `eval("1.0e_1")`
* in CPython
```bash
>>> eval("1.0e_1")
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "<string>", line 1
    1.0e_1
       ^
SyntaxError: unexpected EOF while parsing
```

* in RustPython
```bash
>>>>> eval("1.0e_1")
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
SyntaxError: Invalid Syntax at line 1 column 4
1.0e_1
                 
   ↑
```
