### PR TITLE
Implement `syslog` module for unix

### DIFF
--- a/Lib/test/test_syslog.py
+++ b/Lib/test/test_syslog.py
@@ -1,0 +1,40 @@
+
+from test import support
+syslog = support.import_module("syslog") #skip if not supported
+import unittest
+
+# XXX(nnorwitz): This test sucks.  I don't know of a platform independent way
+# to verify that the messages were really logged.
+# The only purpose of this test is to verify the code doesn't crash or leak.
+
+class Test(unittest.TestCase):
+
+    def test_openlog(self):
+        syslog.openlog('python')
+        # Issue #6697.
+        self.assertRaises(UnicodeEncodeError, syslog.openlog, '\uD800')
+
+    def test_syslog(self):
+        syslog.openlog('python')
+        syslog.syslog('test message from python test_syslog')
+        syslog.syslog(syslog.LOG_ERR, 'test error from python test_syslog')
+
+    def test_closelog(self):
+        syslog.openlog('python')
+        syslog.closelog()
+
+    def test_setlogmask(self):
+        syslog.setlogmask(syslog.LOG_DEBUG)
+
+    def test_log_mask(self):
+        syslog.LOG_MASK(syslog.LOG_INFO)
+
+    def test_log_upto(self):
+        syslog.LOG_UPTO(syslog.LOG_INFO)
+
+    def test_openlog_noargs(self):
+        syslog.openlog()
+        syslog.syslog('test message from python test_syslog')
+
+if __name__ == "__main__":
+    unittest.main()

--- a/Lib/test/test_syslog.py
+++ b/Lib/test/test_syslog.py
@@ -9,6 +9,8 @@ import unittest
 
 class Test(unittest.TestCase):
 
+    # TODO: RUSTPYTHON
+    @unittest.expectedFailure
     def test_openlog(self):
         syslog.openlog('python')
         # Issue #6697.

--- a/vm/src/builtins/pystr.rs
+++ b/vm/src/builtins/pystr.rs
@@ -27,7 +27,7 @@ use rustpython_common::hash;
 use std::mem::size_of;
 use std::ops::Range;
 use std::string::ToString;
-use std::{char, ffi, fmt};
+use std::{char, fmt};
 use unic_ucd_bidi::BidiClass;
 use unic_ucd_category::GeneralCategory;
 use unic_ucd_ident::{is_xid_continue, is_xid_start};
@@ -349,10 +349,6 @@ impl PyStr {
             // SAFETY: Both PyStrKind::{Ascii, Utf8} are valid utf8 string
             std::str::from_utf8_unchecked(&self.bytes)
         }
-    }
-
-    pub fn to_cstring(&self, vm: &VirtualMachine) -> PyResult<ffi::CString> {
-        ffi::CString::new(self.as_str()).map_err(|err| err.into_pyexception(vm))
     }
 
     fn char_all<F>(&self, test: F) -> bool

--- a/vm/src/stdlib/mod.rs
+++ b/vm/src/stdlib/mod.rs
@@ -39,6 +39,8 @@ mod string;
 #[cfg(feature = "rustpython-compiler")]
 mod symtable;
 mod sysconfigdata;
+#[cfg(unix)]
+mod syslog;
 #[cfg(feature = "threading")]
 mod thread;
 mod time;
@@ -188,6 +190,7 @@ pub fn get_module_inits() -> StdlibMap {
         #[cfg(unix)]
         {
             "_posixsubprocess" => posixsubprocess::make_module,
+            "syslog" => syslog::make_module,
         }
         // Windows-only
         #[cfg(windows)]

--- a/vm/src/stdlib/os.rs
+++ b/vm/src/stdlib/os.rs
@@ -2048,6 +2048,7 @@ mod posix {
     use super::*;
 
     use crate::builtins::list::PyListRef;
+    use crate::utils::ToCString;
     use bitflags::bitflags;
     use nix::unistd::{self, Gid, Pid, Uid};
     #[allow(unused_imports)] // TODO: use will be unnecessary in edition 2021

--- a/vm/src/stdlib/socket.rs
+++ b/vm/src/stdlib/socket.rs
@@ -18,7 +18,7 @@ use crate::byteslike::{ArgBytesLike, ArgMemoryBuffer};
 use crate::common::lock::{PyMappedRwLockReadGuard, PyRwLock, PyRwLockReadGuard};
 use crate::exceptions::{IntoPyException, PyBaseExceptionRef};
 use crate::function::{FuncArgs, OptionalArg, OptionalOption};
-use crate::utils::Either;
+use crate::utils::{Either, ToCString};
 use crate::VirtualMachine;
 use crate::{
     IntoPyObject, PyClassImpl, PyObjectRef, PyRef, PyResult, PyValue, StaticType,

--- a/vm/src/stdlib/ssl.rs
+++ b/vm/src/stdlib/ssl.rs
@@ -6,7 +6,7 @@ use crate::common::lock::{PyRwLock, PyRwLockWriteGuard};
 use crate::exceptions::{create_exception_type, IntoPyException, PyBaseExceptionRef};
 use crate::function::OptionalArg;
 use crate::slots::SlotConstructor;
-use crate::utils::Either;
+use crate::utils::{Either, ToCString};
 use crate::VirtualMachine;
 use crate::{
     IntoPyObject, ItemProtocol, PyCallable, PyClassImpl, PyObjectRef, PyRef, PyResult, PyValue,

--- a/vm/src/stdlib/syslog.rs
+++ b/vm/src/stdlib/syslog.rs
@@ -1,0 +1,141 @@
+pub(crate) use syslog::make_module;
+
+#[pymodule(name = "syslog")]
+mod syslog {
+    use crate::builtins::pystr::{PyStr, PyStrRef};
+    use crate::common::lock::PyRwLock;
+    use crate::function::{OptionalArg, OptionalOption};
+    use crate::pyobject::PyValue;
+    use crate::utils::ToCString;
+    use crate::vm::VirtualMachine;
+    use crate::{PyObjectRef, PyResult, TryFromObject};
+    use std::{ffi::CStr, os::raw::c_char};
+
+    #[pyattr]
+    use libc::{
+        LOG_ALERT, LOG_AUTH, LOG_CONS, LOG_CRIT, LOG_DAEMON, LOG_DEBUG, LOG_EMERG, LOG_ERR,
+        LOG_INFO, LOG_KERN, LOG_LOCAL0, LOG_LOCAL1, LOG_LOCAL2, LOG_LOCAL3, LOG_LOCAL4, LOG_LOCAL5,
+        LOG_LOCAL6, LOG_LOCAL7, LOG_LPR, LOG_MAIL, LOG_NDELAY, LOG_NEWS, LOG_NOTICE, LOG_NOWAIT,
+        LOG_ODELAY, LOG_PID, LOG_SYSLOG, LOG_USER, LOG_UUCP, LOG_WARNING,
+    };
+
+    #[cfg(not(target_os = "redox"))]
+    #[pyattr]
+    use libc::{LOG_AUTHPRIV, LOG_CRON, LOG_PERROR};
+
+    fn get_argv(vm: &VirtualMachine) -> Option<PyStrRef> {
+        if let Some(argv) = vm.state.settings.argv.first() {
+            if !argv.is_empty() {
+                return Some(
+                    PyStr::from(match argv.find('\\') {
+                        Some(value) => &argv[value..],
+                        None => argv,
+                    })
+                    .into_ref(vm),
+                );
+            }
+        }
+        None
+    }
+
+    #[derive(Debug)]
+    enum GlobalIdent {
+        Explicit(Box<CStr>),
+        Implicit,
+    }
+
+    impl GlobalIdent {
+        fn as_ptr(&self) -> *const c_char {
+            match self {
+                GlobalIdent::Explicit(ref cstr) => cstr.as_ptr(),
+                GlobalIdent::Implicit => std::ptr::null(),
+            }
+        }
+    }
+
+    fn global_ident() -> &'static PyRwLock<Option<GlobalIdent>> {
+        rustpython_common::static_cell! {
+            static IDENT: PyRwLock<Option<GlobalIdent>>;
+        };
+        IDENT.get_or_init(|| PyRwLock::new(None))
+    }
+
+    #[derive(Default, FromArgs)]
+    struct OpenLogArgs {
+        #[pyarg(any, optional)]
+        ident: OptionalOption<PyStrRef>,
+        #[pyarg(any, optional)]
+        logoption: OptionalArg<i32>,
+        #[pyarg(any, optional)]
+        facility: OptionalArg<i32>,
+    }
+
+    #[pyfunction]
+    fn openlog(args: OpenLogArgs, vm: &VirtualMachine) -> PyResult<()> {
+        let logoption = args.logoption.unwrap_or(0);
+        let facility = args.facility.unwrap_or(LOG_USER);
+        let ident = match args.ident.flatten() {
+            Some(args) => Some(args.to_cstring(vm)?),
+            None => get_argv(vm).map(|argv| argv.to_cstring(vm)).transpose()?,
+        }
+        .map(|ident| ident.into_boxed_c_str());
+
+        let ident = match ident {
+            Some(ident) => GlobalIdent::Explicit(ident),
+            None => GlobalIdent::Implicit,
+        };
+
+        unsafe { libc::openlog(ident.as_ptr(), logoption, facility) };
+        *global_ident().write() = Some(ident);
+        Ok(())
+    }
+
+    #[derive(FromArgs)]
+    struct SysLogArgs {
+        #[pyarg(positional)]
+        priority: PyObjectRef,
+        #[pyarg(positional, optional)]
+        message_object: OptionalOption<PyStrRef>,
+    }
+
+    #[pyfunction]
+    fn syslog(args: SysLogArgs, vm: &VirtualMachine) -> PyResult<()> {
+        let (priority, msg) = match args.message_object.flatten() {
+            Some(s) => (i32::try_from_object(vm, args.priority)?, s),
+            None => (LOG_INFO, PyStrRef::try_from_object(vm, args.priority)?),
+        };
+
+        if global_ident().read().is_none() {
+            openlog(OpenLogArgs::default(), vm)?;
+        }
+
+        let (cformat, cmsg) = ("%s".to_cstring(vm)?, msg.to_cstring(vm)?);
+        unsafe { libc::syslog(priority, cformat.as_ptr(), cmsg.as_ptr()) };
+        Ok(())
+    }
+
+    #[pyfunction]
+    fn closelog() {
+        if global_ident().read().is_some() {
+            unsafe { libc::closelog() };
+            *global_ident().write() = None;
+        }
+    }
+
+    #[pyfunction]
+    fn setlogmask(maskpri: i32) -> i32 {
+        unsafe { libc::setlogmask(maskpri) }
+    }
+
+    #[inline]
+    #[pyfunction(name = "LOG_MASK")]
+    fn log_mask(pri: i32) -> i32 {
+        pri << 1
+    }
+
+    #[inline]
+    #[pyfunction(name = "LOG_UPTO")]
+    fn log_upto(pri: i32) -> i32 {
+        (1 << (pri + 1)) - 1
+    }
+}

--- a/vm/src/utils.rs
+++ b/vm/src/utils.rs
@@ -1,4 +1,5 @@
-use crate::builtins::PyFloat;
+use crate::builtins::{pystr::PyStr, PyFloat};
+use crate::exceptions::IntoPyException;
 use crate::{
     IntoPyObject, PyObjectRef, PyRef, PyResult, PyValue, TryFromObject, TypeProtocol,
     VirtualMachine,
@@ -107,5 +108,21 @@ impl TryFromObject for std::time::Duration {
 impl IntoPyObject for std::convert::Infallible {
     fn into_pyobject(self, _vm: &VirtualMachine) -> PyObjectRef {
         match self {}
+    }
+}
+
+pub trait ToCString {
+    fn to_cstring(&self, vm: &VirtualMachine) -> PyResult<std::ffi::CString>;
+}
+
+impl ToCString for &str {
+    fn to_cstring(&self, vm: &VirtualMachine) -> PyResult<std::ffi::CString> {
+        std::ffi::CString::new(*self).map_err(|err| err.into_pyexception(vm))
+    }
+}
+
+impl ToCString for PyStr {
+    fn to_cstring(&self, vm: &VirtualMachine) -> PyResult<std::ffi::CString> {
+        std::ffi::CString::new(self.as_ref()).map_err(|err| err.into_pyexception(vm))
     }
 }


### PR DESCRIPTION
This revision implement [`syslog`](https://docs.python.org/3.8/library/syslog.html) module.

```python
import syslog
syslog.syslog(syslog.LOG_INFO, "Hello syslog")
```
```bash
>> cat /var/log/syslog
...
Sep  8 22:02:25 DESKTOP-8N***B3 rustpython: Hello syslog
```

### Documentation
* https://docs.python.org/3.8/library/syslog.html
* https://docs.rs/libc/0.2.101/libc/fn.syslog.html
* https://pubs.opengroup.org/onlinepubs/007908799/xsh/syslog.h.html
---

But, before progressing, I cant figure out how to solve below problem
```python
import syslog
syslog.openlog("test-syslog", syslog.LOG_CONS, syslog.LOG_USER)
syslog.syslog(syslog.LOG_INFO, "Hello syslog")
syslog.closelog()
```
```bash
>> cat /var/log/syslog
...
Sep  8 22:06:51 DESKTOP-8N***B3 test-syslog: Hello syslog // Must printed like this
Sep  8 22:06:51 DESKTOP-8N***B3 ���FV: FV: Hello syslog // But something like this corrupted one
```

I use same routine for querying string for `openlog` & `syslog` but It's behaviour is seriously different.
Is there any idea please?