### PR TITLE
Correct `object.__repr__`

### DIFF
--- a/Lib/test/test_dataclasses.py
+++ b/Lib/test/test_dataclasses.py
@@ -2166,8 +2166,6 @@ class TestRepr(unittest.TestCase):
         self.assertEqual(repr(C.D(0)), 'TestRepr.test_repr.<locals>.C.D(i=0)')
         self.assertEqual(repr(C.E()), 'TestRepr.test_repr.<locals>.C.E()')
 
-    # TODO: RUSTPYTHON
-    @unittest.expectedFailure
     def test_no_repr(self):
         # Test a class with no __repr__ and repr=False.
         @dataclass(repr=False)

--- a/Lib/test/test_reprlib.py
+++ b/Lib/test/test_reprlib.py
@@ -318,8 +318,6 @@ class bar:
         # Module name may be prefixed with "test.", depending on how run.
         self.assertEqual(repr(bar.bar), "<class '%s.bar'>" % bar.__name__)
 
-    # TODO: RUSTPYTHON
-    @unittest.expectedFailure
     def test_instance(self):
         self._check_path_limitations('baz')
         write_file(os.path.join(self.subpkgname, 'baz.py'), '''\
@@ -332,8 +330,6 @@ class baz:
         self.assertTrue(repr(ibaz).startswith(
             "<%s.baz object at 0x" % baz.__name__))
 
-    # TODO: RUSTPYTHON
-    @unittest.expectedFailure
     def test_method(self):
         self._check_path_limitations('qux')
         eq = self.assertEqual

--- a/vm/src/builtins/pytype.rs
+++ b/vm/src/builtins/pytype.rs
@@ -313,7 +313,7 @@ impl PyType {
     }
 
     #[pyproperty(magic)]
-    fn qualname(&self, vm: &VirtualMachine) -> PyObjectRef {
+    pub fn qualname(&self, vm: &VirtualMachine) -> PyObjectRef {
         self.attributes
             .read()
             .get("__qualname__")
@@ -330,7 +330,7 @@ impl PyType {
     }
 
     #[pyproperty(magic)]
-    fn module(&self, vm: &VirtualMachine) -> PyObjectRef {
+    pub fn module(&self, vm: &VirtualMachine) -> PyObjectRef {
         // TODO: Implement getting the actual module a builtin type is from
         self.attributes
             .read()


### PR DESCRIPTION
This pull request fixes `object.__repr__` implementation.

## References

- [`object_repr` implementation](https://github.com/python/cpython/blob/f9242d50b18572ef0d584a1c815ed08d1a38e4f4/Objects/typeobject.c#L4518-L4544)