### PR TITLE
Fix comparison in codecs.rs that always failed

### DIFF
--- a/vm/src/codecs.rs
+++ b/vm/src/codecs.rs
@@ -530,7 +530,7 @@ fn get_standard_encoding(encoding: &str) -> (usize, StandardEncoding) {
             }
         }
         return (byte_length, standard_encoding);
-    } else if encoding.to_lowercase() == "CP_UTF8" {
+    } else if encoding == "CP_UTF8" {
         return (3, StandardEncoding::Utf8);
     }
     (0, StandardEncoding::Unknown)


### PR DESCRIPTION
Thanks to @coolreader18 for pointing this out [here.](https://github.com/RustPython/RustPython/pull/3002#discussion_r706352084)
