### PR TITLE
Fix failed test remainder in test_math

### DIFF
--- a/Lib/test/test_math.py
+++ b/Lib/test/test_math.py
@@ -1296,8 +1296,6 @@ class MathTests(unittest.TestCase):
         self.ftest('radians(-45)', math.radians(-45), -math.pi/4)
         self.ftest('radians(0)', math.radians(0), 0)
 
-    # TODO: RUSTPYTHON
-    @unittest.expectedFailure
     @requires_IEEE_754
     def testRemainder(self):
         from fractions import Fraction

--- a/vm/src/stdlib/math.rs
+++ b/vm/src/stdlib/math.rs
@@ -678,7 +678,7 @@ fn math_fmod(x: IntoPyFloat, y: IntoPyFloat, vm: &VirtualMachine) -> PyResult<f6
 fn math_remainder(x: IntoPyFloat, y: IntoPyFloat, vm: &VirtualMachine) -> PyResult<f64> {
     let x = x.to_f64();
     let y = y.to_f64();
-    
+
     if x.is_finite() && y.is_finite() {
         if y == 0.0 {
             return Err(vm.new_value_error("math domain error".to_owned()));
@@ -698,7 +698,7 @@ fn math_remainder(x: IntoPyFloat, y: IntoPyFloat, vm: &VirtualMachine) -> PyResu
         return Ok(1.0_f64.copysign(x) * r);
     }
     if x.is_finite() && y.is_infinite() {
-        return Ok(fmod(x, y))
+        return Ok(fmod(x, y));
     }
     if x.is_infinite() && y == 0.0 {
         return Err(vm.new_value_error("math domain error".to_owned()));

--- a/vm/src/stdlib/math.rs
+++ b/vm/src/stdlib/math.rs
@@ -697,29 +697,17 @@ fn math_remainder(x: IntoPyFloat, y: IntoPyFloat, vm: &VirtualMachine) -> PyResu
 
         return Ok(1.0_f64.copysign(x) * r);
     }
-    if x.is_finite() && y.is_infinite() {
-        return Ok(fmod(x, y));
-    }
-    if x.is_infinite() && y == 0.0 {
-        return Err(vm.new_value_error("math domain error".to_owned()));
-    }
     if x.is_infinite() && !y.is_nan() {
         return Err(vm.new_value_error("math domain error".to_owned()));
     }
-
-    if x.is_nan() {
-        return Ok(x);
-    }
-    if y.is_nan() {
-        return Ok(y);
-    }
-    if x.is_infinite() {
-        return Ok(std::f64::NAN);
+    if x.is_nan() || y.is_nan() {
+        return Ok(f64::NAN);
     }
     if y.is_infinite() {
-        return Err(vm.new_value_error("math domain error".to_owned()));
+        Ok(x)
+    } else {
+        Err(vm.new_value_error("math domain error".to_owned()))
     }
-    Ok(x)
 }
 
 #[derive(FromArgs)]

--- a/vm/src/stdlib/math.rs
+++ b/vm/src/stdlib/math.rs
@@ -678,9 +678,10 @@ fn math_fmod(x: IntoPyFloat, y: IntoPyFloat, vm: &VirtualMachine) -> PyResult<f6
 fn math_remainder(x: IntoPyFloat, y: IntoPyFloat, vm: &VirtualMachine) -> PyResult<f64> {
     let x = x.to_f64();
     let y = y.to_f64();
+    
     if x.is_finite() && y.is_finite() {
         if y == 0.0 {
-            return Ok(std::f64::NAN);
+            return Err(vm.new_value_error("math domain error".to_owned()));
         }
 
         let absx = x.abs();
@@ -695,6 +696,15 @@ fn math_remainder(x: IntoPyFloat, y: IntoPyFloat, vm: &VirtualMachine) -> PyResu
         };
 
         return Ok(1.0_f64.copysign(x) * r);
+    }
+    if x.is_finite() && y.is_infinite() {
+        return Ok(fmod(x, y))
+    }
+    if x.is_infinite() && y == 0.0 {
+        return Err(vm.new_value_error("math domain error".to_owned()));
+    }
+    if x.is_infinite() && !y.is_nan() {
+        return Err(vm.new_value_error("math domain error".to_owned()));
     }
 
     if x.is_nan() {


### PR DESCRIPTION
add conditions for below rules (specified in test codes)

1. remainder(x, inf) is x, for non-NaN non-infinite x
2. According to IEEE 754-2008 7.2(f)
 2-1. remainder(x, 0) for non-NaN x is invalid operation
 2-2. remainder(infinity, x) for non-NaN x is invalid operation