### PR TITLE
Use associated constants instead of module constants.

### DIFF
--- a/common/src/float_ops.rs
+++ b/common/src/float_ops.rs
@@ -97,7 +97,7 @@ pub fn parse_str(literal: &str) -> Option<f64> {
 }
 
 pub fn is_integer(v: f64) -> bool {
-    (v - v.round()).abs() < std::f64::EPSILON
+    (v - v.round()).abs() < f64::EPSILON
 }
 
 #[derive(Debug)]

--- a/vm/src/anystr.rs
+++ b/vm/src/anystr.rs
@@ -69,9 +69,9 @@ fn saturate_to_isize(py_int: PyIntRef) -> isize {
     let big = py_int.as_bigint();
     big.to_isize().unwrap_or_else(|| {
         if big.is_negative() {
-            std::isize::MIN
+            isize::MIN
         } else {
-            std::isize::MAX
+            isize::MAX
         }
     })
 }

--- a/vm/src/builtins/pystr.rs
+++ b/vm/src/builtins/pystr.rs
@@ -394,7 +394,7 @@ impl PyStr {
                 ch if (ch as u32) < 0x10000 => 6, // \uHHHH
                 _ => 10,                          // \uHHHHHHHH
             };
-            if out_len > (std::isize::MAX as usize) - incr {
+            if out_len > (isize::MAX as usize) - incr {
                 return Err(vm.new_overflow_error("string is too long to generate repr".to_owned()));
             }
             out_len += incr;

--- a/vm/src/bytesinner.rs
+++ b/vm/src/bytesinner.rs
@@ -832,7 +832,7 @@ impl PyBytesInner {
             return self.elements.clone();
         };
 
-        let mut count = maxcount.unwrap_or(std::usize::MAX) - 1;
+        let mut count = maxcount.unwrap_or(usize::MAX) - 1;
         for offset in iter {
             new[offset..offset + len].clone_from_slice(to.elements.as_slice());
             count -= 1;
@@ -860,7 +860,7 @@ impl PyBytesInner {
         //    result_len = self_len + count * (to_len-from_len)
         debug_assert!(count > 0);
         if to.len() as isize - from.len() as isize
-            > (std::isize::MAX - self.elements.len() as isize) / count as isize
+            > (isize::MAX - self.elements.len() as isize) / count as isize
         {
             return Err(vm.new_overflow_error("replace bytes is too long".to_owned()));
         }

--- a/vm/src/stdlib/cmath.rs
+++ b/vm/src/stdlib/cmath.rs
@@ -10,9 +10,9 @@ pub(crate) fn make_module(vm: &VirtualMachine) -> PyObjectRef {
         "pi" => ctx.new_float(std::f64::consts::PI),
         "e" => ctx.new_float(std::f64::consts::E),
         "tau" => ctx.new_float(2.0 * std::f64::consts::PI),
-        "inf" => ctx.new_float(std::f64::INFINITY),
+        "inf" => ctx.new_float(f64::INFINITY),
         "infj" => ctx.new_complex(num_complex::Complex64::new(0., std::f64::INFINITY)),
-        "nan" => ctx.new_float(std::f64::NAN),
+        "nan" => ctx.new_float(f64::NAN),
         "nanj" => ctx.new_complex(num_complex::Complex64::new(0., std::f64::NAN)),
     });
 

--- a/vm/src/stdlib/math.rs
+++ b/vm/src/stdlib/math.rs
@@ -327,7 +327,7 @@ fn math_gamma(x: IntoPyFloat) -> f64 {
     } else if x.is_nan() || x.is_sign_positive() {
         x
     } else {
-        std::f64::NAN
+        f64::NAN
     }
 }
 
@@ -338,7 +338,7 @@ fn math_lgamma(x: IntoPyFloat) -> f64 {
     } else if x.is_nan() {
         x
     } else {
-        std::f64::INFINITY
+        f64::INFINITY
     }
 }
 
@@ -822,7 +822,7 @@ pub fn make_module(vm: &VirtualMachine) -> PyObjectRef {
         "pi" => ctx.new_float(std::f64::consts::PI), // 3.14159...
         "e" => ctx.new_float(std::f64::consts::E), // 2.71..
         "tau" => ctx.new_float(2.0 * std::f64::consts::PI),
-        "inf" => ctx.new_float(std::f64::INFINITY),
-        "nan" => ctx.new_float(std::f64::NAN)
+        "inf" => ctx.new_float(f64::INFINITY),
+        "nan" => ctx.new_float(f64::NAN)
     })
 }

--- a/vm/src/sysmodule.rs
+++ b/vm/src/sysmodule.rs
@@ -14,7 +14,7 @@ use crate::{
 /*
  * The magic sys module.
  */
-const MAXSIZE: usize = std::isize::MAX as usize;
+const MAXSIZE: usize = isize::MAX as usize;
 const MAXUNICODE: u32 = std::char::MAX as u32;
 
 fn argv(vm: &VirtualMachine) -> PyObjectRef {


### PR DESCRIPTION
Replace occurrences of module constants with associated constants since the latter will be deprecated at some point as per their docs. Only change not made is in `math_remainder` since #3037 will take care of that.