### PR TITLE
Clean up bare occurunces of `[pyarg(any)]`

### DIFF
--- a/vm/src/builtins/enumerate.rs
+++ b/vm/src/builtins/enumerate.rs
@@ -30,7 +30,6 @@ impl PyValue for PyEnumerate {
 
 #[derive(FromArgs)]
 pub struct EnumerateArgs {
-    #[pyarg(any)]
     iterable: PyObjectRef,
     #[pyarg(any, optional)]
     start: OptionalArg<PyIntRef>,

--- a/vm/src/builtins/genericalias.rs
+++ b/vm/src/builtins/genericalias.rs
@@ -28,9 +28,7 @@ impl PyValue for PyGenericAlias {
 
 #[derive(FromArgs)]
 pub struct GenericAliasArgs {
-    #[pyarg(any)]
     origin: PyTypeRef,
-    #[pyarg(any)]
     arguments: PyObjectRef,
 }
 

--- a/vm/src/builtins/int.rs
+++ b/vm/src/builtins/int.rs
@@ -762,9 +762,7 @@ pub struct IntOptions {
 
 #[derive(FromArgs)]
 struct IntFromByteArgs {
-    #[pyarg(any)]
     bytes: PyBytesInner,
-    #[pyarg(any)]
     byteorder: PyStrRef,
     #[pyarg(named, optional)]
     signed: OptionalArg<IntoPyBool>,
@@ -772,9 +770,7 @@ struct IntFromByteArgs {
 
 #[derive(FromArgs)]
 struct IntToByteArgs {
-    #[pyarg(any)]
     length: PyIntRef,
-    #[pyarg(any)]
     byteorder: PyStrRef,
     #[pyarg(named, optional)]
     signed: OptionalArg<IntoPyBool>,

--- a/vm/src/builtins/make_module.rs
+++ b/vm/src/builtins/make_module.rs
@@ -96,11 +96,8 @@ mod decl {
     #[derive(FromArgs)]
     #[allow(dead_code)]
     struct CompileArgs {
-        #[pyarg(any)]
         source: PyObjectRef,
-        #[pyarg(any)]
         filename: PyStrRef,
-        #[pyarg(any)]
         mode: PyStrRef,
         #[pyarg(any, optional)]
         flags: OptionalArg<PyIntRef>,
@@ -569,9 +566,7 @@ mod decl {
 
     #[derive(FromArgs)]
     struct PowArgs {
-        #[pyarg(any)]
         base: PyObjectRef,
-        #[pyarg(any)]
         exp: PyObjectRef,
         #[pyarg(any, optional, name = "mod")]
         modulus: Option<PyObjectRef>,
@@ -700,7 +695,6 @@ mod decl {
 
     #[derive(FromArgs)]
     pub struct RoundArgs {
-        #[pyarg(any)]
         number: PyObjectRef,
         #[pyarg(any, optional)]
         ndigits: OptionalOption<PyObjectRef>,

--- a/vm/src/builtins/memory.rs
+++ b/vm/src/builtins/memory.rs
@@ -24,7 +24,6 @@ use std::ops::Deref;
 
 #[derive(FromArgs)]
 pub struct PyMemoryViewNewArgs {
-    #[pyarg(any)]
     object: PyObjectRef,
 }
 

--- a/vm/src/builtins/module.rs
+++ b/vm/src/builtins/module.rs
@@ -39,7 +39,6 @@ pub fn init_module_dict(
 
 #[derive(FromArgs)]
 struct ModuleInitArgs {
-    #[pyarg(any)]
     name: PyStrRef,
     #[pyarg(any, default)]
     doc: Option<PyStrRef>,

--- a/vm/src/stdlib/bisect.rs
+++ b/vm/src/stdlib/bisect.rs
@@ -11,9 +11,7 @@ mod _bisect {
 
     #[derive(FromArgs)]
     struct BisectArgs {
-        #[pyarg(any)]
         a: PyObjectRef,
-        #[pyarg(any)]
         x: PyObjectRef,
         #[pyarg(any, optional)]
         lo: OptionalArg<PyObjectRef>,

--- a/vm/src/stdlib/codecs.rs
+++ b/vm/src/stdlib/codecs.rs
@@ -28,7 +28,6 @@ mod _codecs {
 
     #[derive(FromArgs)]
     struct CodeArgs {
-        #[pyarg(any)]
         obj: PyObjectRef,
         #[pyarg(any, optional)]
         encoding: Option<PyStrRef>,

--- a/vm/src/stdlib/io.rs
+++ b/vm/src/stdlib/io.rs
@@ -1833,7 +1833,6 @@ mod _io {
 
     #[derive(FromArgs)]
     struct TextIOWrapperArgs {
-        #[pyarg(any)]
         buffer: PyObjectRef,
         #[pyarg(any, default)]
         encoding: Option<PyStrRef>,
@@ -3455,7 +3454,6 @@ mod _io {
 
     #[derive(FromArgs)]
     struct IoOpenArgs {
-        #[pyarg(any)]
         file: PyObjectRef,
         #[pyarg(any, optional)]
         mode: OptionalArg<PyStrRef>,

--- a/vm/src/stdlib/itertools.rs
+++ b/vm/src/stdlib/itertools.rs
@@ -260,7 +260,6 @@ mod decl {
 
     #[derive(FromArgs)]
     struct PyRepeatNewArgs {
-        #[pyarg(any)]
         object: PyObjectRef,
         #[pyarg(any, optional)]
         times: OptionalArg<PyIntRef>,

--- a/vm/src/stdlib/nt.rs
+++ b/vm/src/stdlib/nt.rs
@@ -46,9 +46,7 @@ pub(crate) mod module {
 
     #[derive(FromArgs)]
     pub(super) struct SimlinkArgs {
-        #[pyarg(any)]
         src: PyPathLike,
-        #[pyarg(any)]
         dst: PyPathLike,
         #[pyarg(flatten)]
         target_is_directory: TargetIsDirectory,

--- a/vm/src/stdlib/os.rs
+++ b/vm/src/stdlib/os.rs
@@ -427,9 +427,7 @@ pub(super) mod _os {
     #[cfg(any(unix, windows, target_os = "wasi"))]
     #[derive(FromArgs)]
     struct OpenArgs {
-        #[pyarg(any)]
         path: PyPathLike,
-        #[pyarg(any)]
         flags: i32,
         #[pyarg(any, default)]
         mode: Option<i32>,
@@ -888,19 +886,12 @@ pub(super) mod _os {
     #[pyclass(module = "os", name = "stat_result")]
     #[derive(Debug, PyStructSequence, FromArgs)]
     struct StatResult {
-        #[pyarg(any)]
         pub st_mode: BigInt,
-        #[pyarg(any)]
         pub st_ino: BigInt,
-        #[pyarg(any)]
         pub st_dev: BigInt,
-        #[pyarg(any)]
         pub st_nlink: BigInt,
-        #[pyarg(any)]
         pub st_uid: BigInt,
-        #[pyarg(any)]
         pub st_gid: BigInt,
-        #[pyarg(any)]
         pub st_size: BigInt,
         // TODO: unnamed structsequence fields
         #[pyarg(positional, default)]
@@ -1250,7 +1241,6 @@ pub(super) mod _os {
 
     #[derive(FromArgs)]
     struct UtimeArgs {
-        #[pyarg(any)]
         path: PyPathLike,
         #[pyarg(any, default)]
         times: Option<PyTupleRef>,

--- a/vm/src/stdlib/posix.rs
+++ b/vm/src/stdlib/posix.rs
@@ -291,9 +291,7 @@ pub mod module {
 
     #[derive(FromArgs)]
     pub(super) struct SimlinkArgs {
-        #[pyarg(any)]
         src: PyPathLike,
-        #[pyarg(any)]
         dst: PyPathLike,
         #[pyarg(flatten)]
         _target_is_directory: TargetIsDirectory,
@@ -496,7 +494,6 @@ pub mod module {
 
     #[derive(FromArgs)]
     pub struct SchedParamArg {
-        #[pyarg(any)]
         sched_priority: PyObjectRef,
     }
     impl SlotConstructor for SchedParam {
@@ -1689,13 +1686,9 @@ pub mod module {
     #[cfg(any(target_os = "linux", target_os = "macos"))]
     #[derive(FromArgs)]
     struct SendFileArgs {
-        #[pyarg(any)]
         out_fd: i32,
-        #[pyarg(any)]
         in_fd: i32,
-        #[pyarg(any)]
         offset: crate::crt_fd::Offset,
-        #[pyarg(any)]
         count: i64,
         #[cfg(target_os = "macos")]
         #[pyarg(any, optional)]

--- a/vm/src/stdlib/posix_compat.rs
+++ b/vm/src/stdlib/posix_compat.rs
@@ -29,9 +29,7 @@ pub(crate) mod module {
     #[derive(FromArgs)]
     #[allow(unused)]
     pub(super) struct SimlinkArgs {
-        #[pyarg(any)]
         src: PyPathLike,
-        #[pyarg(any)]
         dst: PyPathLike,
         #[pyarg(flatten)]
         _target_is_directory: TargetIsDirectory,

--- a/vm/src/stdlib/signal.rs
+++ b/vm/src/stdlib/signal.rs
@@ -175,7 +175,6 @@ pub(crate) mod _signal {
 
     #[derive(FromArgs)]
     struct SetWakeupFdArgs {
-        #[pyarg(any)]
         fd: WakeupFd,
         #[pyarg(named, default = "true")]
         warn_on_full_buffer: bool,

--- a/vm/src/stdlib/sre.rs
+++ b/vm/src/stdlib/sre.rs
@@ -92,7 +92,6 @@ mod _sre {
 
     #[derive(FromArgs)]
     struct StringArgs {
-        #[pyarg(any)]
         string: PyObjectRef,
         #[pyarg(any, default = "0")]
         pos: usize,
@@ -102,10 +101,8 @@ mod _sre {
 
     #[derive(FromArgs)]
     struct SubArgs {
-        #[pyarg(any)]
         // repl: Either<ArgCallable, PyStrRef>,
         repl: PyObjectRef,
-        #[pyarg(any)]
         string: PyObjectRef,
         #[pyarg(any, default = "0")]
         count: usize,
@@ -113,7 +110,6 @@ mod _sre {
 
     #[derive(FromArgs)]
     struct SplitArgs {
-        #[pyarg(any)]
         string: PyObjectRef,
         #[pyarg(any, default = "0")]
         maxsplit: isize,

--- a/vm/src/stdlib/ssl.rs
+++ b/vm/src/stdlib/ssl.rs
@@ -180,7 +180,6 @@ fn _ssl_enum_certificates(store_name: PyStrRef, vm: &VirtualMachine) -> PyResult
 
 #[derive(FromArgs)]
 struct Txt2ObjArgs {
-    #[pyarg(any)]
     txt: PyStrRef,
     #[pyarg(any, default = "false")]
     name: bool,
@@ -610,9 +609,7 @@ impl PySslContext {
 
 #[derive(FromArgs)]
 struct WrapSocketArgs {
-    #[pyarg(any)]
     sock: PyRef<PySocket>,
-    #[pyarg(any)]
     server_side: bool,
     #[pyarg(any, default)]
     server_hostname: Option<PyStrRef>,
@@ -634,7 +631,6 @@ struct LoadVerifyLocationsArgs {
 
 #[derive(FromArgs)]
 struct LoadCertChainArgs {
-    #[pyarg(any)]
     certfile: PyPathLike,
     #[pyarg(any, optional)]
     keyfile: Option<PyPathLike>,

--- a/vm/src/stdlib/winreg.rs
+++ b/vm/src/stdlib/winreg.rs
@@ -100,9 +100,7 @@ impl Hkey {
 
 #[derive(FromArgs)]
 struct OpenKeyArgs {
-    #[pyarg(any)]
     key: Hkey,
-    #[pyarg(any)]
     sub_key: Option<PyStrRef>,
     #[pyarg(any, default = "0")]
     reserved: i32,


### PR DESCRIPTION
Since it implies them being handled as `positional_or_keyword`. Alternatively, an argument without a `pyarg` attribute should be disallowed.