### PR TITLE
Implement latin_1 in Rust

### DIFF
--- a/common/src/encodings.rs
+++ b/common/src/encodings.rs
@@ -229,22 +229,10 @@ pub mod latin_1 {
         Ok(out)
     }
 
-    pub fn decode<E: ErrorHandler>(data: &[u8], errors: &E) -> Result<(String, usize), E::Error> {
-        decode_utf8_compatible(
-            data,
-            errors,
-            |v| {
-                std::str::from_utf8(v).map_err(|e| {
-                    // SAFETY: as specified in valid_up_to's documentation, input[..e.valid_up_to()]
-                    //         is valid ascii & therefore valid utf8
-                    unsafe { make_decode_err(v, e.valid_up_to(), e.error_len()) }
-                })
-            },
-            |_rest, err_len| HandleResult::Error {
-                err_len,
-                reason: ERR_REASON,
-            },
-        )
+    pub fn decode<E: ErrorHandler>(data: &[u8], _errors: &E) -> Result<(String, usize), E::Error> {
+        let out: String = data.iter().map(|c| *c as char).collect();
+        let out_len = out.len();
+        Ok((out, out_len))
     }
 }
 

--- a/vm/src/stdlib/codecs.rs
+++ b/vm/src/stdlib/codecs.rs
@@ -317,7 +317,7 @@ mod _codecs {
 
     #[pyfunction]
     fn latin_1_encode(args: EncodeArgs, vm: &VirtualMachine) -> EncodeResult {
-        if args.s.as_ref().chars().all(|c| (c as u32) < 256) {
+        if args.s.is_ascii() {
             return Ok((args.s.as_str().as_bytes().to_vec(), args.s.byte_len()));
         }
         do_codec!(latin_1::encode, args, vm)

--- a/vm/src/stdlib/codecs.rs
+++ b/vm/src/stdlib/codecs.rs
@@ -316,6 +316,19 @@ mod _codecs {
     }
 
     #[pyfunction]
+    fn latin_1_encode(args: EncodeArgs, vm: &VirtualMachine) -> EncodeResult {
+        if args.s.as_ref().chars().all(|c| (c as u32) < 256) {
+            return Ok((args.s.as_str().as_bytes().to_vec(), args.s.byte_len()));
+        }
+        do_codec!(latin_1::encode, args, vm)
+    }
+
+    #[pyfunction]
+    fn latin_1_decode(args: DecodeArgsNoFinal, vm: &VirtualMachine) -> DecodeResult {
+        do_codec!(latin_1::decode, args, vm)
+    }
+
+    #[pyfunction]
     fn ascii_encode(args: EncodeArgs, vm: &VirtualMachine) -> EncodeResult {
         if args.s.is_ascii() {
             return Ok((args.s.as_str().as_bytes().to_vec(), args.s.byte_len()));
@@ -353,14 +366,6 @@ mod _codecs {
         }};
     }
 
-    #[pyfunction]
-    fn latin_1_encode(args: FuncArgs, vm: &VirtualMachine) -> PyResult {
-        delegate_pycodecs!(latin_1_encode, args, vm)
-    }
-    #[pyfunction]
-    fn latin_1_decode(args: FuncArgs, vm: &VirtualMachine) -> PyResult {
-        delegate_pycodecs!(latin_1_decode, args, vm)
-    }
     #[pyfunction]
     fn mbcs_encode(args: FuncArgs, vm: &VirtualMachine) -> PyResult {
         delegate_pycodecs!(mbcs_encode, args, vm)


### PR DESCRIPTION
~~Based on the PyPy implementation. The encoding function needs some work with respect to error handling.~~ **EDIT**: Now based on @coolreader18's `ascii` codec.

Requesting @coolreader18 as a potential reviewer, as they wrote the architecture for the `encodings` module and the error handling function(s).
