### PR TITLE
revert git-add from precommit

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -56,7 +56,6 @@ criterion = "0.3"
 
 [package.metadata.precommit]
 fmt = "cargo fmt --all"
-git-add = "git add -u"
 
 [[bench]]
 name = "execution"


### PR DESCRIPTION
cc @eldpswp99 

I found this is breaking partial commit workflow at all.
`cargo clean` and rerunning will regenerate pre-commit.