### PR TITLE
make magic method new to follow cpython way

### DIFF
--- a/vm/src/builtins/function.rs
+++ b/vm/src/builtins/function.rs
@@ -541,8 +541,6 @@ impl PyBoundMethod {
             // Special case: we work with `__new__`, which is not really a method.
             // It is a function, so its `__qualname__` is just `__new__`.
             // We need to add object's part manually.
-            // Note: at the moment, `__new__` in the form of `tp_new_wrapper`
-            // is the only instance of `builtin_function_or_method_type`.
             let obj_name = vm.get_attribute_opt(self.object.clone(), "__qualname__")?;
             let obj_name: Option<PyStrRef> = obj_name.and_then(|o| o.downcast().ok());
             return Ok(vm.ctx.new_str(format!(

--- a/vm/src/builtins/object.rs
+++ b/vm/src/builtins/object.rs
@@ -3,6 +3,7 @@ use super::list::PyList;
 use super::pybool;
 use super::pystr::{PyStr, PyStrRef};
 use super::pytype::PyTypeRef;
+use crate::builtins::pytype;
 use crate::builtins::pytype::PyType;
 use crate::common::hash::PyHash;
 use crate::function::FuncArgs;
@@ -33,6 +34,11 @@ impl PyValue for PyBaseObject {
 
 #[pyimpl(flags(BASETYPE))]
 impl PyBaseObject {
+    #[pyclassmethod(magic)]
+    fn new(cls: PyTypeRef, args: FuncArgs, vm: &VirtualMachine) -> PyResult {
+        let (subtype, args): (PyTypeRef, FuncArgs) = args.bind(vm)?;
+        pytype::call_tp_new(cls, subtype, args, vm)
+    }
     /// Create and return a new object.  See help(type) for accurate signature.
     #[pyslot]
     fn tp_new(cls: PyTypeRef, _args: FuncArgs, vm: &VirtualMachine) -> PyResult {

--- a/vm/src/builtins/object.rs
+++ b/vm/src/builtins/object.rs
@@ -35,7 +35,7 @@ impl PyValue for PyBaseObject {
 #[pyimpl(flags(BASETYPE))]
 impl PyBaseObject {
     #[pyclassmethod(magic)]
-    fn new(cls: PyTypeRef, args: FuncArgs, vm: &VirtualMachine) -> PyResult {
+    pub(crate) fn new(cls: PyTypeRef, args: FuncArgs, vm: &VirtualMachine) -> PyResult {
         let (subtype, args): (PyTypeRef, FuncArgs) = args.bind(vm)?;
         pytype::call_tp_new(cls, subtype, args, vm)
     }

--- a/vm/src/builtins/object.rs
+++ b/vm/src/builtins/object.rs
@@ -2,9 +2,7 @@ use super::dict::{PyDict, PyDictRef};
 use super::list::PyList;
 use super::pybool;
 use super::pystr::{PyStr, PyStrRef};
-use super::pytype::PyTypeRef;
-use crate::builtins::pytype;
-use crate::builtins::pytype::PyType;
+use super::pytype::{PyType, PyTypeRef};
 use crate::common::hash::PyHash;
 use crate::function::FuncArgs;
 use crate::slots::PyComparisonOp;
@@ -34,11 +32,6 @@ impl PyValue for PyBaseObject {
 
 #[pyimpl(flags(BASETYPE))]
 impl PyBaseObject {
-    #[pyclassmethod(magic)]
-    pub(crate) fn new(cls: PyTypeRef, args: FuncArgs, vm: &VirtualMachine) -> PyResult {
-        let (subtype, args): (PyTypeRef, FuncArgs) = args.bind(vm)?;
-        pytype::call_tp_new(cls, subtype, args, vm)
-    }
     /// Create and return a new object.  See help(type) for accurate signature.
     #[pyslot]
     fn tp_new(cls: PyTypeRef, _args: FuncArgs, vm: &VirtualMachine) -> PyResult {
@@ -370,8 +363,8 @@ pub(crate) fn setattr(
     }
 }
 
-pub fn init(context: &PyContext) {
-    PyBaseObject::extend_class(context, &context.types.object_type);
+pub fn init(ctx: &PyContext) {
+    PyBaseObject::extend_class(ctx, &ctx.types.object_type);
 }
 
 fn common_reduce(obj: PyObjectRef, proto: usize, vm: &VirtualMachine) -> PyResult {

--- a/vm/src/builtins/pytype.rs
+++ b/vm/src/builtins/pytype.rs
@@ -239,6 +239,19 @@ impl PyTypeRef {
 
 #[pyimpl(with(SlotGetattro, SlotSetattro, Callable), flags(BASETYPE))]
 impl PyType {
+    #[pymethod]
+    pub(crate) fn __new__(zelf: PyRef<Self>, args: FuncArgs, vm: &VirtualMachine) -> PyResult {
+        let (subtype, args): (PyRef<Self>, FuncArgs) = args.bind(vm)?;
+        if !subtype.issubclass(&zelf) {
+            return Err(vm.new_type_error(format!(
+                "{zelf}.__new__({subtype}): {subtype} is not a subtype of {zelf}",
+                zelf = zelf.name(),
+                subtype = subtype.name(),
+            )));
+        }
+        call_tp_new(zelf, subtype, args, vm)
+    }
+
     #[pyproperty(name = "__mro__")]
     fn get_mro(zelf: PyRef<Self>) -> PyTuple {
         let elements: Vec<PyObjectRef> = zelf.iter_mro().map(|x| x.as_object().clone()).collect();

--- a/vm/src/builtins/pytype.rs
+++ b/vm/src/builtins/pytype.rs
@@ -765,41 +765,18 @@ impl<T: DerefToPyType> DerefToPyType for &'_ T {
     }
 }
 
-fn call_tp_new(
+pub(crate) fn call_tp_new(
     typ: PyTypeRef,
     subtype: PyTypeRef,
-    mut args: FuncArgs,
+    args: FuncArgs,
     vm: &VirtualMachine,
 ) -> PyResult {
     for cls in typ.deref().iter_mro() {
-        if let Some(new_meth) = cls.get_attr("__new__") {
-            if !vm.ctx.is_tp_new_wrapper(&new_meth) {
-                let new_meth = vm.call_if_get_descriptor(new_meth, typ.clone().into_object())?;
-                args.prepend_arg(typ.clone().into_object());
-                return vm.invoke(&new_meth, args);
-            }
-        }
         if let Some(tp_new) = cls.slots.new.load() {
             return tp_new(subtype, args, vm);
         }
     }
     unreachable!("Should be able to find a new slot somewhere in the mro")
-}
-
-pub fn tp_new_wrapper(
-    zelf: PyTypeRef,
-    cls: PyTypeRef,
-    args: FuncArgs,
-    vm: &VirtualMachine,
-) -> PyResult {
-    if !cls.issubclass(&zelf) {
-        return Err(vm.new_type_error(format!(
-            "{zelf}.__new__({cls}): {cls} is not a subtype of {zelf}",
-            zelf = zelf.name(),
-            cls = cls.name(),
-        )));
-    }
-    call_tp_new(zelf, cls, args, vm)
 }
 
 fn take_next_base(bases: &mut Vec<Vec<PyTypeRef>>) -> Option<PyTypeRef> {

--- a/vm/src/builtins/pytype.rs
+++ b/vm/src/builtins/pytype.rs
@@ -239,7 +239,7 @@ impl PyTypeRef {
 
 #[pyimpl(with(SlotGetattro, SlotSetattro, Callable), flags(BASETYPE))]
 impl PyType {
-    #[pymethod]
+    // bound method for every type
     pub(crate) fn __new__(zelf: PyRef<Self>, args: FuncArgs, vm: &VirtualMachine) -> PyResult {
         let (subtype, args): (PyRef<Self>, FuncArgs) = args.bind(vm)?;
         if !subtype.issubclass(&zelf) {

--- a/vm/src/macros.rs
+++ b/vm/src/macros.rs
@@ -30,7 +30,6 @@ macro_rules! py_class {
             $($crate::py_class!(@extract_slots($ctx, &mut slots, $name, $value));)*
             let py_class = $ctx.new_class($class_name, $class_base, slots);
             $($crate::py_class!(@extract_attrs($ctx, &py_class, $name, $value));)*
-            $ctx.add_slot_wrappers(&py_class);
             py_class
         }
     };
@@ -50,7 +49,6 @@ macro_rules! extend_class {
         $(
             $class.set_str_attr($name, $value);
         )*
-        $ctx.add_slot_wrappers(&$class);
     };
 }
 

--- a/vm/src/pyobject.rs
+++ b/vm/src/pyobject.rs
@@ -126,7 +126,7 @@ impl PyContext {
 
         let new_str = PyRef::new_ref(pystr::PyStr::from("__new__"), types.str_type.clone(), None);
         let tp_new_wrapper = create_object(
-            PyNativeFuncDef::new(object::PyBaseObject::new.into_func(), new_str).into_function(),
+            PyNativeFuncDef::new(PyType::__new__.into_func(), new_str).into_function(),
             &types.builtin_function_or_method_type,
         )
         .into_object();
@@ -1094,6 +1094,11 @@ pub trait PyClassImpl: PyClassDef {
         }
         if let Some(module_name) = Self::MODULE_NAME {
             class.set_str_attr("__module__", ctx.new_str(module_name));
+        }
+        if class.slots.new.load().is_some() {
+            let bound =
+                ctx.new_bound_method(ctx.tp_new_wrapper.clone(), class.clone().into_object());
+            class.set_str_attr("__new__", bound);
         }
     }
 

--- a/vm/src/pyobject.rs
+++ b/vm/src/pyobject.rs
@@ -87,6 +87,7 @@ pub struct PyContext {
     pub int_cache_pool: Vec<PyIntRef>,
     // there should only be exact objects of str in here, no non-strs and no subclasses
     pub(crate) string_cache: Dict<()>,
+    tp_new_wrapper: PyObjectRef,
 }
 
 // Basic objects:
@@ -123,6 +124,13 @@ impl PyContext {
 
         let string_cache = Dict::default();
 
+        let new_str = PyRef::new_ref(pystr::PyStr::from("__new__"), types.str_type.clone(), None);
+        let tp_new_wrapper = create_object(
+            PyNativeFuncDef::new(object::PyBaseObject::new.into_func(), new_str).into_function(),
+            &types.builtin_function_or_method_type,
+        )
+        .into_object();
+
         let context = PyContext {
             true_value,
             false_value,
@@ -136,6 +144,7 @@ impl PyContext {
             exceptions,
             int_cache_pool,
             string_cache,
+            tp_new_wrapper,
         };
         TypeZoo::extend(&context);
         exceptions::ExceptionZoo::extend(&context);


### PR DESCRIPTION
this issue was first mentioned in #2974 
This makes tp_new to be called by `object.__new__`

for example, with `tuple.__new__`

before: `<bound method __new__ of <class 'tuple'>>`
after: `<bound method object.__new__ of <class 'tuple'>>`

well, i have problem with controlling the new with pysuper, i remain this as draft now
I would be thankful for any advice!


