### PR TITLE
Remove HEAPTYPE flag from builtins.

### DIFF
--- a/Lib/test/test_ast.py
+++ b/Lib/test/test_ast.py
@@ -565,6 +565,8 @@ class AST_Tests(unittest.TestCase):
         x = ast.Sub()
         self.assertEqual(x._fields, ())
 
+    # TODO: RUSTPYTHON _ast classes should be HEAPTYPES (except for _ast.AST)
+    @unittest.expectedFailure
     def test_pickling(self):
         import pickle
         mods = [pickle]

--- a/Lib/test/test_collections.py
+++ b/Lib/test/test_collections.py
@@ -491,8 +491,6 @@ class TestNamedTuple(unittest.TestCase):
         self.assertEqual(b2, tuple(b2_expected))
         self.assertEqual(b._fields, tuple(names))
 
-    # TODO: RUSTPYTHON
-    @unittest.expectedFailure
     def test_pickle(self):
         p = TestNT(x=10, y=20, z=30)
         for module in (pickle,):

--- a/Lib/test/test_configparser.py
+++ b/Lib/test/test_configparser.py
@@ -1702,6 +1702,8 @@ class CoverageOneHundredTestCase(unittest.TestCase):
 class ExceptionPicklingTestCase(unittest.TestCase):
     """Tests for issue #13760: ConfigParser exceptions are not picklable."""
 
+    # TODO: RUSTPYTHON Exception.__reduce__ missing.
+    @unittest.expectedFailure
     def test_error(self):
         import pickle
         e1 = configparser.Error('value')

--- a/Lib/test/test_enum.py
+++ b/Lib/test/test_enum.py
@@ -1191,8 +1191,6 @@ class TestEnum(unittest.TestCase):
             b = 3
             c = ...
 
-    # TODO: RUSTPYTHON
-    @unittest.expectedFailure
     def test_subclasses_with_getnewargs(self):
         class NamedInt(int):
             __qualname__ = 'NamedInt'       # needed for pickle protocol 4

--- a/Lib/unittest/test/test_discovery.py
+++ b/Lib/unittest/test/test_discovery.py
@@ -498,6 +498,8 @@ class TestDiscovery(unittest.TestCase):
         with self.assertRaises(ImportError):
             test.test_this_does_not_exist()
 
+    # TODO: RUSTPYTHON ImportError.__reduce__ missing
+    @unittest.expectedFailure
     def test_discover_with_init_modules_that_fail_to_import(self):
         vfs = {abspath('/foo'): ['my_package'],
                abspath('/foo/my_package'): ['__init__.py', 'test_module.py']}

--- a/vm/src/builtins/pytype.rs
+++ b/vm/src/builtins/pytype.rs
@@ -467,6 +467,10 @@ impl PyType {
             }
         }
 
+        // TODO: how do we know if it should have a dict?
+        // All *classes* should have a dict. Exceptions are *instances* of
+        // classes that define __slots__ and instances of built-in classes
+        // (with exceptions, e.g function)
         if !attributes.contains_key("__dict__") {
             attributes.insert(
                 "__dict__".to_owned(),
@@ -479,9 +483,10 @@ impl PyType {
             );
         }
 
-        // TODO: how do we know if it should have a dict?
-        let flags = base.slots.flags | PyTpFlags::HAS_DICT;
-
+        // TODO: Flags is currently initialized with HAS_DICT. Should be
+        // updated when __slots__ are supported (toggling the flag off if
+        // a class has __slots__ defined).
+        let flags = PyTpFlags::heap_type_flags() | PyTpFlags::HAS_DICT;
         let slots = PyTypeSlots::from_flags(flags);
 
         let typ = new(metatype, name.as_str(), base, bases, attributes, slots)

--- a/vm/src/builtins/pytype.rs
+++ b/vm/src/builtins/pytype.rs
@@ -467,7 +467,6 @@ impl PyType {
             }
         }
 
-        // TODO: how do we know if it should have a dict?
         // All *classes* should have a dict. Exceptions are *instances* of
         // classes that define __slots__ and instances of built-in classes
         // (with exceptions, e.g function)

--- a/vm/src/slots.rs
+++ b/vm/src/slots.rs
@@ -25,8 +25,16 @@ bitflags! {
 }
 
 impl PyTpFlags {
+    // Default used for both built-in and normal classes: empty, for now.
     // CPython default: Py_TPFLAGS_HAVE_STACKLESS_EXTENSION | Py_TPFLAGS_HAVE_VERSION_TAG
-    pub const DEFAULT: Self = Self::HEAPTYPE;
+    pub const DEFAULT: Self = Self::empty();
+
+    // CPython: See initialization of flags in type_new.
+    /// Used for types created in Python. Subclassable and are a
+    /// heaptype.
+    pub fn heap_type_flags() -> Self {
+        Self::DEFAULT | Self::HEAPTYPE | Self::BASETYPE
+    }
 
     pub fn has_feature(self, flag: Self) -> bool {
         self.contains(flag)


### PR DESCRIPTION
`HEAPTYPE` isn't set for built-in types, instead only used for dynamically created types. (see `<bltin_type>.__flags__ & (1 << 9)`)

The errors that appear now are a result of this, `copyreg` doesn't know how to `__reduce__` types that don't have the `HEAPTYPE` flag so any builtins that lack it require an implementation of `__reduce__` (currently, `Exception` types and types defined in `_ast` it seems).