### PR TITLE
Add cmath log() and log10() methods

### DIFF
--- a/Lib/test/test_cmath.py
+++ b/Lib/test/test_cmath.py
@@ -51,11 +51,15 @@ complex_nans = [complex(x, y) for x, y in [
 
 class CMathTests(unittest.TestCase):
     # TODO: RUSTPYTHON:
-    # Uncomment when functions have been added. Temporarily 
+    # Uncomment when functions have been added. Temporarily
     # commented out to allow incremented addition of functions.
     #
     # list of all functions in cmath
-    test_functions = [getattr(cmath, fname) for fname in ['sqrt','sin','cos']]
+    test_functions = [getattr(cmath, fname) for fname in [
+        'sin','cos','log','log10','sqrt',
+        # 'exp','acos','acosh','asin','asinh',
+        # 'atan','atanh','sinh','cosh','tan','tanh'
+        ]]
     # test first and second arguments independently for 2-argument log
     # test_functions.append(lambda x : cmath.log(x, 1729. + 0j))
     # test_functions.append(lambda x : cmath.log(14.-27j, x))
@@ -286,8 +290,6 @@ class CMathTests(unittest.TestCase):
             for arg in ["a", "long_string", "0", "1j", ""]:
                 self.assertRaises(TypeError, f, arg)
 
-    # TODO: RUSTPYTHON
-    @unittest.expectedFailure
     def test_cmath_matches_math(self):
         # check that corresponding cmath and math functions are equal
         # for floats in the appropriate range

--- a/vm/src/stdlib/cmath.rs
+++ b/vm/src/stdlib/cmath.rs
@@ -89,7 +89,9 @@ mod cmath {
         z.to_complex().cos()
     }
 
-    /// Return the logarithm of z with respect to base. Default of base is 'e'
+    /// log(z[, base]) -> the logarithm of z to the given base.
+    ///
+    /// If the base not specified, returns the natural logarithm (base e) of z.
     #[pyfunction]
     fn log(z: IntoPyComplex, base: OptionalArg<IntoPyFloat>) -> Complex64 {
         z.to_complex().log(

--- a/vm/src/stdlib/cmath.rs
+++ b/vm/src/stdlib/cmath.rs
@@ -101,7 +101,7 @@ mod cmath {
         )
     }
 
-    /// Return the logarithm of z with respect to 10
+    /// Return the base-10 logarithm of z.
     #[pyfunction]
     fn log10(z: IntoPyComplex) -> Complex64 {
         z.to_complex().log(10.0)

--- a/vm/src/stdlib/cmath.rs
+++ b/vm/src/stdlib/cmath.rs
@@ -89,6 +89,22 @@ mod cmath {
         z.to_complex().cos()
     }
 
+    /// Return the logarithm of z with respect to base. Default of base is 'e'
+    #[pyfunction]
+    fn log(z: IntoPyComplex, base: OptionalArg<IntoPyFloat>) -> Complex64 {
+        z.to_complex().log(
+            base.into_option()
+                .map(|base| base.to_f64())
+                .unwrap_or(std::f64::consts::E),
+        )
+    }
+
+    /// Return the logarithm of z with respect to 10
+    #[pyfunction]
+    fn log10(z: IntoPyComplex) -> Complex64 {
+        z.to_complex().log(10.0)
+    }
+
     #[derive(FromArgs)]
     struct IsCloseArgs {
         #[pyarg(positional)]


### PR DESCRIPTION
Relates to #3039

Added `cmath.log()` and `cmath.log10()`