### PR TITLE
Fix compilation on unix platforms with i32 c_long

### DIFF
--- a/vm/src/stdlib/os.rs
+++ b/vm/src/stdlib/os.rs
@@ -1932,7 +1932,7 @@ mod _os {
                 Err(io::Error::from(Errno::last()).into_pyexception(vm))
             }
         } else {
-            Ok(Some(raw))
+            Ok(Some(raw as i64))
         }
     }
 

--- a/vm/src/stdlib/os.rs
+++ b/vm/src/stdlib/os.rs
@@ -1912,7 +1912,7 @@ mod _os {
         path: PathOrFd,
         ConfName(name): ConfName,
         vm: &VirtualMachine,
-    ) -> PyResult<Option<i64>> {
+    ) -> PyResult<Option<libc::c_long>> {
         use nix::errno::{self, Errno};
 
         Errno::clear();
@@ -1932,13 +1932,13 @@ mod _os {
                 Err(io::Error::from(Errno::last()).into_pyexception(vm))
             }
         } else {
-            Ok(Some(raw as i64))
+            Ok(Some(raw))
         }
     }
 
     #[cfg(unix)]
     #[pyfunction]
-    fn fpathconf(fd: i32, name: ConfName, vm: &VirtualMachine) -> PyResult<Option<i64>> {
+    fn fpathconf(fd: i32, name: ConfName, vm: &VirtualMachine) -> PyResult<Option<libc::c_long>> {
         pathconf(PathOrFd::Fd(fd), name, vm)
     }
 


### PR DESCRIPTION
Targets such as i686-unknown-linux-gnu have a [c_long definition of i32](https://docs.rs/libc/0.2/i686-unknown-linux-gnu/libc/type.c_long.html), so assuming that [`libc::pathconf`](https://docs.rs/libc/0.2.102/i686-unknown-linux-gnu/libc/fn.pathconf.html) returns an i64 will cause a compilation error on such platforms.

This patch fixes that by adding a cast to i64, which is valid as `c_long` is only ever i32 or i64, meaning this is either a no-op or a sign extension.