### PR TITLE
acos & acosh for missing  cmath functions

### DIFF
--- a/Lib/test/test_cmath.py
+++ b/Lib/test/test_cmath.py
@@ -55,7 +55,7 @@ class CMathTests(unittest.TestCase):
     # commented out to allow incremented addition of functions.
     #
     # list of all functions in cmath
-    test_functions = [getattr(cmath, fname) for fname in ['sqrt','sin','cos']]
+    test_functions = [getattr(cmath, fname) for fname in ['sqrt','sin','cos','acos', 'acosh']]
     # test first and second arguments independently for 2-argument log
     # test_functions.append(lambda x : cmath.log(x, 1729. + 0j))
     # test_functions.append(lambda x : cmath.log(14.-27j, x))

--- a/vm/src/stdlib/cmath.rs
+++ b/vm/src/stdlib/cmath.rs
@@ -73,6 +73,20 @@ mod cmath {
         result_or_overflow(z, z.exp(), vm)
     }
 
+    /// Return the arc cosine of z.
+    #[pyfunction]
+    fn acos(z: IntoPyComplex, vm: &VirtualMachine) -> PyResult<Complex64> {
+        let z = z.to_complex();
+        result_or_overflow(z, z.acos(), vm)
+    }
+
+    /// Return the inverse hyperbolic cosine of z.
+    #[pyfunction]
+    fn acosh(z: IntoPyComplex, vm: &VirtualMachine) -> PyResult<Complex64> {
+        let z = z.to_complex();
+        result_or_overflow(z, z.acosh(), vm)
+    }
+
     #[derive(FromArgs)]
     struct IsCloseArgs {
         #[pyarg(positional)]


### PR DESCRIPTION
Related issue: https://github.com/RustPython/RustPython/issues/3039

