### PR TITLE
Introduce `types.GenericAlias` type

### DIFF
--- a/Lib/test/test_types.py
+++ b/Lib/test/test_types.py
@@ -793,6 +793,8 @@ class MappingProxyTests(unittest.TestCase):
         self.assertEqual(set(view.values()), set(values))
         self.assertEqual(set(view.items()), set(items))
 
+    # TODO: RUSTPYTHON
+    @unittest.expectedFailure
     def test_reversed(self):
         d = {'a': 1, 'b': 2, 'foo': 0, 'c': 3, 'd': 4}
         mp = self.mappingproxy(d)
@@ -811,6 +813,8 @@ class MappingProxyTests(unittest.TestCase):
         self.assertEqual(view['key1'], 70)
         self.assertEqual(copy['key1'], 27)
 
+    # TODO: RUSTPYTHON
+    @unittest.expectedFailure
     def test_union(self):
         mapping = {'a': 0, 'b': 1, 'c': 2}
         view = self.mappingproxy(mapping)

--- a/Lib/test/test_types.py
+++ b/Lib/test/test_types.py
@@ -474,7 +474,7 @@ class TypesTests(unittest.TestCase):
 
         # No format code means use g, but must have a decimal
         # and a number after the decimal.  This is tricky, because
-        # a totaly empty format specifier means something else.
+        # a totally empty format specifier means something else.
         # So, just use a sign flag
         test(1e200, '+g', '+1e+200')
         test(1e200, '+', '+1e+200')
@@ -638,8 +638,13 @@ class MappingProxyTests(unittest.TestCase):
         self.assertEqual(attrs, {
              '__contains__',
              '__getitem__',
+             '__class_getitem__',
+             '__ior__',
              '__iter__',
              '__len__',
+             '__or__',
+             '__reversed__',
+             '__ror__',
              'copy',
              'get',
              'items',
@@ -788,6 +793,14 @@ class MappingProxyTests(unittest.TestCase):
         self.assertEqual(set(view.values()), set(values))
         self.assertEqual(set(view.items()), set(items))
 
+    def test_reversed(self):
+        d = {'a': 1, 'b': 2, 'foo': 0, 'c': 3, 'd': 4}
+        mp = self.mappingproxy(d)
+        del d['foo']
+        r = reversed(mp)
+        self.assertEqual(list(r), list('dcba'))
+        self.assertRaises(StopIteration, next, r)
+
     def test_copy(self):
         original = {'key1': 27, 'key2': 51, 'key3': 93}
         view = self.mappingproxy(original)
@@ -797,6 +810,22 @@ class MappingProxyTests(unittest.TestCase):
         original['key1'] = 70
         self.assertEqual(view['key1'], 70)
         self.assertEqual(copy['key1'], 27)
+
+    def test_union(self):
+        mapping = {'a': 0, 'b': 1, 'c': 2}
+        view = self.mappingproxy(mapping)
+        with self.assertRaises(TypeError):
+            view | [('r', 2), ('d', 2)]
+        with self.assertRaises(TypeError):
+            [('r', 2), ('d', 2)] | view
+        with self.assertRaises(TypeError):
+            view |= [('r', 2), ('d', 2)]
+        other = {'c': 3, 'p': 0}
+        self.assertDictEqual(view | other, {'a': 0, 'b': 1, 'c': 3, 'p': 0})
+        self.assertDictEqual(other | view, {'c': 2, 'p': 0, 'a': 0, 'b': 1})
+        self.assertEqual(view, {'a': 0, 'b': 1, 'c': 2})
+        self.assertDictEqual(mapping, {'a': 0, 'b': 1, 'c': 2})
+        self.assertDictEqual(other, {'c': 3, 'p': 0})
 
 
 class ClassCreationTests(unittest.TestCase):
@@ -1261,8 +1290,8 @@ class SimpleNamespaceTests(unittest.TestCase):
         ns2._y = 5
         name = "namespace"
 
-        self.assertEqual(repr(ns1), "{name}(w=3, x=1, y=2)".format(name=name))
-        self.assertEqual(repr(ns2), "{name}(_y=5, x='spam')".format(name=name))
+        self.assertEqual(repr(ns1), "{name}(x=1, y=2, w=3)".format(name=name))
+        self.assertEqual(repr(ns2), "{name}(x='spam', _y=5)".format(name=name))
 
     # TODO: RUSTPYTHON
     @unittest.expectedFailure
@@ -1315,7 +1344,7 @@ class SimpleNamespaceTests(unittest.TestCase):
         ns3.spam = ns2
         name = "namespace"
         repr1 = "{name}(c='cookie', spam={name}(...))".format(name=name)
-        repr2 = "{name}(spam={name}(spam={name}(...), x=1))".format(name=name)
+        repr2 = "{name}(spam={name}(x=1, spam={name}(...)))".format(name=name)
 
         self.assertEqual(repr(ns1), repr1)
         self.assertEqual(repr(ns2), repr2)

--- a/Lib/types.py
+++ b/Lib/types.py
@@ -296,4 +296,7 @@ def coroutine(func):
     return wrapped
 
 
+GenericAlias = type(list[int])
+
+
 __all__ = [n for n in globals() if n[:1] != '_']

--- a/vm/src/builtins/genericalias.rs
+++ b/vm/src/builtins/genericalias.rs
@@ -1,0 +1,166 @@
+use crate::builtins::{PyStr, PyTuple, PyTupleRef, PyTypeRef};
+use crate::common::hash;
+use crate::slots::{Hashable, SlotConstructor};
+use crate::{
+    IdProtocol, PyClassImpl, PyContext, PyObjectRef, PyRef, PyResult, PyValue, TryFromObject,
+    TypeProtocol, VirtualMachine,
+};
+use std::fmt;
+
+#[pyclass(module = "types", name = "GenericAlias")]
+pub struct PyGenericAlias {
+    origin: PyTypeRef,
+    args: PyTupleRef,
+    parameters: PyTupleRef,
+}
+
+pub type PyGenericAliasRef = PyRef<PyGenericAlias>;
+
+impl fmt::Debug for PyGenericAlias {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        f.write_str("GenericAlias")
+    }
+}
+
+impl PyValue for PyGenericAlias {
+    fn class(vm: &VirtualMachine) -> &PyTypeRef {
+        &vm.ctx.types.generic_alias_type
+    }
+}
+
+#[derive(FromArgs)]
+pub struct GenericAliasArgs {
+    #[pyarg(any)]
+    origin: PyTypeRef,
+    #[pyarg(any)]
+    arguments: PyObjectRef,
+}
+
+impl SlotConstructor for PyGenericAlias {
+    type Args = GenericAliasArgs;
+
+    fn py_new(cls: PyTypeRef, args: Self::Args, vm: &VirtualMachine) -> PyResult {
+        PyGenericAlias::new(args.origin, args.arguments, vm).into_pyresult_with_type(vm, cls)
+    }
+}
+
+#[pyimpl(with(Hashable), flags(BASETYPE))]
+impl PyGenericAlias {
+    pub fn new(origin: PyTypeRef, args: PyObjectRef, vm: &VirtualMachine) -> Self {
+        let args: PyTupleRef = if let Ok(tuple) = PyTupleRef::try_from_object(vm, args.clone()) {
+            tuple
+        } else {
+            vm.ctx
+                .new_tuple(vec![args])
+                .downcast::<PyTuple>()
+                .ok()
+                .unwrap()
+        };
+
+        Self {
+            origin,
+            args: args.clone(),
+            parameters: make_parameters(args, vm),
+        }
+    }
+
+    #[pymethod(magic)]
+    fn repr(&self, vm: &VirtualMachine) -> PyResult<String> {
+        fn repr_item(obj: PyObjectRef, vm: &VirtualMachine) -> PyResult<String> {
+            if obj.is(&vm.ctx.ellipsis) {
+                return Ok("...".to_string());
+            }
+
+            if vm.get_attribute_opt(obj.clone(), "__origin__")?.is_some()
+                && vm.get_attribute_opt(obj.clone(), "__args__")?.is_some()
+            {
+                return Ok(vm.to_repr(&obj)?.as_str().to_string());
+            }
+
+            match (
+                vm.get_attribute_opt(obj.clone(), "__qualname__")?
+                    .and_then(|o| o.downcast_ref::<PyStr>().map(|n| n.as_str().to_string())),
+                vm.get_attribute_opt(obj.clone(), "__module__")?
+                    .and_then(|o| o.downcast_ref::<PyStr>().map(|m| m.as_str().to_string())),
+            ) {
+                (None, _) | (_, None) => Ok(vm.to_repr(&obj)?.as_str().to_string()),
+                (Some(qualname), Some(module)) => Ok(if module == "builtins" {
+                    qualname
+                } else {
+                    format!("{}.{}", module, qualname)
+                }),
+            }
+        }
+
+        Ok(format!(
+            "{}[{}]",
+            repr_item(self.origin.as_object().clone(), vm)?,
+            self.args
+                .as_slice()
+                .iter()
+                .map(|o| repr_item(o.clone(), vm))
+                .collect::<PyResult<Vec<_>>>()?
+                .join(", ")
+        ))
+    }
+
+    #[pyproperty(magic)]
+    fn parameters(&self) -> PyObjectRef {
+        self.parameters.as_object().clone()
+    }
+
+    #[pyproperty(magic)]
+    fn args(&self) -> PyObjectRef {
+        self.args.as_object().clone()
+    }
+
+    #[pyproperty(magic)]
+    fn origin(&self) -> PyObjectRef {
+        self.origin.as_object().clone()
+    }
+}
+
+fn is_typevar(obj: PyObjectRef) -> bool {
+    let class = obj.class();
+    class.tp_name() == "TypeVar"
+        && match class.get_attr("__module__") {
+            Some(o) => o
+                .downcast_ref::<PyStr>()
+                .map(|s| s.as_str() == "typing")
+                .unwrap_or(false),
+            None => false,
+        }
+}
+
+fn make_parameters(args: PyTupleRef, vm: &VirtualMachine) -> PyTupleRef {
+    let mut parameters: Vec<PyObjectRef> = vec![];
+    for arg in args.as_slice() {
+        if is_typevar(arg.clone()) {
+            parameters.push(arg.clone());
+        } else if let Ok(tuple) = vm
+            .get_attribute(arg.clone(), "__parameters__")
+            .and_then(|obj| PyTupleRef::try_from_object(vm, obj))
+        {
+            for subparam in tuple.as_slice() {
+                parameters.push(subparam.clone());
+            }
+        }
+    }
+
+    vm.ctx
+        .new_tuple(parameters)
+        .downcast::<PyTuple>()
+        .ok()
+        .unwrap()
+}
+
+impl Hashable for PyGenericAlias {
+    fn hash(zelf: &PyRef<Self>, vm: &VirtualMachine) -> PyResult<hash::PyHash> {
+        Ok(vm._hash(zelf.origin.as_object())? ^ vm._hash(zelf.args.as_object())?)
+    }
+}
+
+pub fn init(context: &PyContext) {
+    let generic_alias_type = &context.types.generic_alias_type;
+    PyGenericAlias::extend_class(context, generic_alias_type);
+}

--- a/vm/src/builtins/list.rs
+++ b/vm/src/builtins/list.rs
@@ -5,6 +5,7 @@ use std::ops::DerefMut;
 
 use crossbeam_utils::atomic::AtomicCell;
 
+use super::genericalias::{PyGenericAlias, PyGenericAliasRef};
 use super::int;
 use super::iter::{
     IterStatus,
@@ -410,6 +411,11 @@ impl PyList {
         };
         std::mem::swap(self.borrow_vec_mut().deref_mut(), &mut elements);
         Ok(())
+    }
+
+    #[pyclassmethod(magic)]
+    fn class_getitem(cls: PyTypeRef, args: PyObjectRef, vm: &VirtualMachine) -> PyGenericAliasRef {
+        PyGenericAlias::new(cls, args, vm).into_ref(vm)
     }
 }
 

--- a/vm/src/builtins/list.rs
+++ b/vm/src/builtins/list.rs
@@ -5,7 +5,7 @@ use std::ops::DerefMut;
 
 use crossbeam_utils::atomic::AtomicCell;
 
-use super::genericalias::{PyGenericAlias, PyGenericAliasRef};
+use super::genericalias::PyGenericAlias;
 use super::int;
 use super::iter::{
     IterStatus,
@@ -414,8 +414,8 @@ impl PyList {
     }
 
     #[pyclassmethod(magic)]
-    fn class_getitem(cls: PyTypeRef, args: PyObjectRef, vm: &VirtualMachine) -> PyGenericAliasRef {
-        PyGenericAlias::new(cls, args, vm).into_ref(vm)
+    fn class_getitem(cls: PyTypeRef, args: PyObjectRef, vm: &VirtualMachine) -> PyGenericAlias {
+        PyGenericAlias::new(cls, args, vm)
     }
 }
 

--- a/vm/src/builtins/mod.rs
+++ b/vm/src/builtins/mod.rs
@@ -78,6 +78,7 @@ pub(crate) mod weakref;
 pub use weakref::PyWeak;
 pub(crate) mod zip;
 pub use zip::PyZip;
+pub(crate) mod genericalias;
 
 mod make_module;
 pub use make_module::{ascii, make_module, print};

--- a/vm/src/types.rs
+++ b/vm/src/types.rs
@@ -13,6 +13,7 @@ use crate::builtins::float;
 use crate::builtins::frame;
 use crate::builtins::function;
 use crate::builtins::generator;
+use crate::builtins::genericalias;
 use crate::builtins::getset;
 use crate::builtins::int;
 use crate::builtins::iter;
@@ -114,6 +115,7 @@ pub struct TypeZoo {
     pub ellipsis_type: PyTypeRef,
     pub none_type: PyTypeRef,
     pub not_implemented_type: PyTypeRef,
+    pub generic_alias_type: PyTypeRef,
 }
 
 impl TypeZoo {
@@ -199,6 +201,7 @@ impl TypeZoo {
             method_descriptor_type: builtinfunc::PyBuiltinMethod::init_bare_type().clone(),
             none_type: singletons::PyNone::init_bare_type().clone(),
             not_implemented_type: singletons::PyNotImplemented::init_bare_type().clone(),
+            generic_alias_type: genericalias::PyGenericAlias::init_bare_type().clone(),
         }
     }
 
@@ -244,6 +247,7 @@ impl TypeZoo {
         namespace::init(context);
         mappingproxy::init(context);
         traceback::init(context);
+        genericalias::init(context);
     }
 }
 


### PR DESCRIPTION
## Overview

- Introduce `types.GenericAlias` type.  [7790ecb]
- Add `list.__class_getitem__` method.  [057a748]
- Bump `types` module to CPython 3.9.7 [ea53510, b9cf020]

## Description

This pull request will resolve #3079.

This pull request introduces `types.GenericAlias` type, introduced in CPython 3.9, and is the type of `list[int]` or `dict[str, int]`. It can be accessed from `types` module. And there are some features not been implemented yet.

### About tests

As more description, this `types.GenericAlias` type has a test named `test.test_genericalias` but the test requires `contextvars`:

```python
Traceback (most recent call last):
  File "Lib/test/test_genericalias.py", line 12, in <module>
    from contextvars import ContextVar, Token
ModuleNotFoundError: No module named 'contextvars'
```

And `contextvars` requires `_contextvars`:

```python
Traceback (most recent call last):
  File "Lib/test/test_genericalias.py", line 12, in <module>
    from contextvars import ContextVar, Token
  File "/home/moreal/github/RustPython/RustPython/vm/pylib-crate/Lib/contextvars.py", line 1, in <module>
    from _contextvars import Context, ContextVar, Token, copy_context
ModuleNotFoundError: No module named '_contextvars'
```

The test should be added after the `_contextvars` module is introduced.

## References

- https://docs.python.org/3/whatsnew/3.9.html#type-hinting-generics-in-standard-collections
  - PEP 585: https://www.python.org/dev/peps/pep-0585/
- https://docs.python.org/3/library/stdtypes.html?highlight=genericalias#generic-alias-type
- CPython v3.9.7 implementation: https://github.com/python/cpython/blob/v3.9.7/Objects/genericaliasobject.c