### PR TITLE
os: fix stat_result test

### DIFF
--- a/Lib/test/test_os.py
+++ b/Lib/test/test_os.py
@@ -443,13 +443,9 @@ class StatAttributeTests(unittest.TestCase):
         except TypeError:
             pass
 
-    # TODO: RUSTPYTHON
-    @unittest.expectedFailure
     def test_stat_attributes(self):
         self.check_stat_attributes(self.fname)
 
-    # TODO: RUSTPYTHON
-    @unittest.expectedFailure
     def test_stat_attributes_bytes(self):
         try:
             fname = self.fname.encode(sys.getfilesystemencoding())

--- a/vm/src/builtins/int.rs
+++ b/vm/src/builtins/int.rs
@@ -118,6 +118,12 @@ impl_try_from_object_int!(
     (u64, to_u64),
 );
 
+impl TryFromBorrowedObject for BigInt {
+    fn try_from_borrowed_object(vm: &VirtualMachine, obj: &PyObjectRef) -> PyResult<Self> {
+        try_value_from_borrowed_object(vm, obj, |int: &PyInt| Ok(int.as_bigint().clone()))
+    }
+}
+
 // _PyLong_AsUnsignedLongMask
 pub fn bigint_unsigned_mask(v: &BigInt) -> u32 {
     v.to_u32()


### PR DESCRIPTION
Implement tp_new for `stat_result`

To unpack args, this PR implement a `flatten_args` closure to
unpack args like
```
args = (1, 2, 3, 4, 5, 6)
args = ((1, 2, 3, 4, 5, 6))
args = (((1, 2, 3, 4, 5, 6)))  # from pickle load
```