### PR TITLE
impl `#[derive(PyValue)]` for static_type

### DIFF
--- a/derive/src/lib.rs
+++ b/derive/src/lib.rs
@@ -17,6 +17,7 @@ mod from_args;
 mod pyclass;
 mod pymodule;
 mod pystructseq;
+mod pyvalue;
 
 use error::{extract_spans, Diagnostic};
 use proc_macro::TokenStream;
@@ -94,4 +95,10 @@ pub fn py_compile(input: TokenStream) -> TokenStream {
 #[proc_macro]
 pub fn py_freeze(input: TokenStream) -> TokenStream {
     result_to_tokens(compile_bytecode::impl_py_freeze(input.into()))
+}
+
+#[proc_macro_derive(PyValue)]
+pub fn pyvalue(input: TokenStream) -> TokenStream {
+    let input = parse_macro_input!(input as DeriveInput);
+    result_to_tokens(pyvalue::impl_pyvalue(input))
 }

--- a/derive/src/pyvalue.rs
+++ b/derive/src/pyvalue.rs
@@ -1,0 +1,17 @@
+use super::Diagnostic;
+use proc_macro2::TokenStream;
+use quote::quote;
+use syn::DeriveInput;
+
+pub(crate) fn impl_pyvalue(input: DeriveInput) -> std::result::Result<TokenStream, Diagnostic> {
+    let ty = &input.ident;
+
+    let ret = quote! {
+        impl ::rustpython_vm::PyValue for #ty {
+            fn class(_vm: &VirtualMachine) -> &PyTypeRef {
+                Self::static_type()
+            }
+        }
+    };
+    Ok(ret)
+}

--- a/vm/src/stdlib/array.rs
+++ b/vm/src/stdlib/array.rs
@@ -589,19 +589,13 @@ mod array {
 
     #[pyattr]
     #[pyclass(name = "array")]
-    #[derive(Debug)]
+    #[derive(Debug, PyValue)]
     pub struct PyArray {
         array: PyRwLock<ArrayContentType>,
         exports: AtomicCell<usize>,
     }
 
     pub type PyArrayRef = PyRef<PyArray>;
-
-    impl PyValue for PyArray {
-        fn class(_vm: &VirtualMachine) -> &PyTypeRef {
-            Self::static_type()
-        }
-    }
 
     impl From<ArrayContentType> for PyArray {
         fn from(array: ArrayContentType) -> Self {
@@ -1198,16 +1192,10 @@ mod array {
 
     #[pyattr]
     #[pyclass(name = "array_iterator")]
-    #[derive(Debug)]
+    #[derive(Debug, PyValue)]
     pub struct PyArrayIter {
         position: AtomicCell<usize>,
         array: PyArrayRef,
-    }
-
-    impl PyValue for PyArrayIter {
-        fn class(_vm: &VirtualMachine) -> &PyTypeRef {
-            Self::static_type()
-        }
     }
 
     #[pyimpl(with(PyIter))]

--- a/vm/src/stdlib/ast.rs
+++ b/vm/src/stdlib/ast.rs
@@ -44,7 +44,7 @@ fn get_node_field_opt(
 }
 
 #[pyclass(module = "_ast", name = "AST")]
-#[derive(Debug)]
+#[derive(Debug, PyValue)]
 pub(crate) struct AstNode;
 
 #[pyimpl(flags(HAS_DICT))]
@@ -83,12 +83,6 @@ impl AstNode {
 
 const MODULE_NAME: &str = "_ast";
 pub const PY_COMPILE_FLAG_AST_ONLY: i32 = 0x0400;
-
-impl PyValue for AstNode {
-    fn class(_vm: &VirtualMachine) -> &PyTypeRef {
-        Self::static_type()
-    }
-}
 
 trait Node: Sized {
     fn ast_to_object(self, vm: &VirtualMachine) -> PyObjectRef;

--- a/vm/src/stdlib/collections.rs
+++ b/vm/src/stdlib/collections.rs
@@ -26,7 +26,7 @@ mod _collections {
 
     #[pyattr]
     #[pyclass(name = "deque")]
-    #[derive(Debug, Default)]
+    #[derive(Debug, Default, PyValue)]
     struct PyDeque {
         deque: PyRwLock<VecDeque<PyObjectRef>>,
         maxlen: Option<usize>,
@@ -34,12 +34,6 @@ mod _collections {
     }
 
     type PyDequeRef = PyRef<PyDeque>;
-
-    impl PyValue for PyDeque {
-        fn class(_vm: &VirtualMachine) -> &PyTypeRef {
-            Self::static_type()
-        }
-    }
 
     #[derive(FromArgs)]
     struct PyDequeOptions {
@@ -577,18 +571,12 @@ mod _collections {
 
     #[pyattr]
     #[pyclass(name = "_deque_iterator")]
-    #[derive(Debug)]
+    #[derive(Debug, PyValue)]
     struct PyDequeIterator {
         position: AtomicCell<usize>,
         status: AtomicCell<IterStatus>,
         length: usize, // To track length immutability.
         deque: PyDequeRef,
-    }
-
-    impl PyValue for PyDequeIterator {
-        fn class(_vm: &VirtualMachine) -> &PyTypeRef {
-            Self::static_type()
-        }
     }
 
     #[derive(FromArgs)]
@@ -680,18 +668,12 @@ mod _collections {
 
     #[pyattr]
     #[pyclass(name = "_deque_reverse_iterator")]
-    #[derive(Debug)]
+    #[derive(Debug, PyValue)]
     struct PyReverseDequeIterator {
         position: AtomicCell<usize>,
         status: AtomicCell<IterStatus>,
         length: usize, // To track length immutability.
         deque: PyDequeRef,
-    }
-
-    impl PyValue for PyReverseDequeIterator {
-        fn class(_vm: &VirtualMachine) -> &PyTypeRef {
-            Self::static_type()
-        }
     }
 
     impl SlotConstructor for PyReverseDequeIterator {

--- a/vm/src/stdlib/csv.rs
+++ b/vm/src/stdlib/csv.rs
@@ -86,6 +86,7 @@ struct ReadState {
 }
 
 #[pyclass(module = "_csv", name = "reader")]
+#[derive(PyValue)]
 struct Reader {
     iter: PyObjectRef,
     state: PyMutex<ReadState>,
@@ -94,12 +95,6 @@ struct Reader {
 impl fmt::Debug for Reader {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "_csv.reader")
-    }
-}
-
-impl PyValue for Reader {
-    fn class(_vm: &VirtualMachine) -> &PyTypeRef {
-        Self::static_type()
     }
 }
 
@@ -193,6 +188,7 @@ struct WriteState {
 }
 
 #[pyclass(module = "_csv", name = "writer")]
+#[derive(PyValue)]
 struct Writer {
     write: PyObjectRef,
     state: PyMutex<WriteState>,
@@ -201,12 +197,6 @@ struct Writer {
 impl fmt::Debug for Writer {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "_csv.writer")
-    }
-}
-
-impl PyValue for Writer {
-    fn class(_vm: &VirtualMachine) -> &PyTypeRef {
-        Self::static_type()
     }
 }
 

--- a/vm/src/stdlib/hashlib.rs
+++ b/vm/src/stdlib/hashlib.rs
@@ -19,6 +19,7 @@ mod hashlib {
 
     #[pyattr]
     #[pyclass(module = "hashlib", name = "hasher")]
+    #[derive(PyValue)]
     struct PyHasher {
         name: String,
         buffer: PyRwLock<HashWrapper>,
@@ -27,12 +28,6 @@ mod hashlib {
     impl fmt::Debug for PyHasher {
         fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
             write!(f, "hasher {}", self.name)
-        }
-    }
-
-    impl PyValue for PyHasher {
-        fn class(_vm: &VirtualMachine) -> &PyTypeRef {
-            Self::static_type()
         }
     }
 

--- a/vm/src/stdlib/io.rs
+++ b/vm/src/stdlib/io.rs
@@ -1638,14 +1638,9 @@ mod _io {
 
     #[pyattr]
     #[pyclass(name = "BufferedReader", base = "_BufferedIOBase")]
-    #[derive(Debug, Default)]
+    #[derive(Debug, Default, PyValue)]
     struct BufferedReader {
         data: PyThreadMutex<BufferedData>,
-    }
-    impl PyValue for BufferedReader {
-        fn class(_vm: &VirtualMachine) -> &PyTypeRef {
-            Self::static_type()
-        }
     }
     impl BufferedMixin for BufferedReader {
         const READABLE: bool = true;
@@ -1692,14 +1687,9 @@ mod _io {
 
     #[pyattr]
     #[pyclass(name = "BufferedWriter", base = "_BufferedIOBase")]
-    #[derive(Debug, Default)]
+    #[derive(Debug, Default, PyValue)]
     struct BufferedWriter {
         data: PyThreadMutex<BufferedData>,
-    }
-    impl PyValue for BufferedWriter {
-        fn class(_vm: &VirtualMachine) -> &PyTypeRef {
-            Self::static_type()
-        }
     }
     impl BufferedMixin for BufferedWriter {
         const READABLE: bool = false;
@@ -1725,14 +1715,9 @@ mod _io {
 
     #[pyattr]
     #[pyclass(name = "BufferedRandom", base = "_BufferedIOBase")]
-    #[derive(Debug, Default)]
+    #[derive(Debug, Default, PyValue)]
     struct BufferedRandom {
         data: PyThreadMutex<BufferedData>,
-    }
-    impl PyValue for BufferedRandom {
-        fn class(_vm: &VirtualMachine) -> &PyTypeRef {
-            Self::static_type()
-        }
     }
     impl BufferedMixin for BufferedRandom {
         const READABLE: bool = true;
@@ -1768,15 +1753,10 @@ mod _io {
 
     #[pyattr]
     #[pyclass(name = "BufferedRWPair", base = "_BufferedIOBase")]
-    #[derive(Debug, Default)]
+    #[derive(Debug, Default, PyValue)]
     struct BufferedRWPair {
         read: BufferedReader,
         write: BufferedWriter,
-    }
-    impl PyValue for BufferedRWPair {
-        fn class(_vm: &VirtualMachine) -> &PyTypeRef {
-            Self::static_type()
-        }
     }
     impl BufferedReadable for BufferedRWPair {
         type Reader = BufferedReader;
@@ -2182,14 +2162,9 @@ mod _io {
 
     #[pyattr]
     #[pyclass(name = "TextIOWrapper", base = "_TextIOBase")]
-    #[derive(Debug, Default)]
+    #[derive(Debug, Default, PyValue)]
     struct TextIOWrapper {
         data: PyThreadMutex<Option<TextIOData>>,
-    }
-    impl PyValue for TextIOWrapper {
-        fn class(_vm: &VirtualMachine) -> &PyTypeRef {
-            Self::static_type()
-        }
     }
 
     #[pyimpl(flags(BASETYPE))]
@@ -3043,19 +3018,13 @@ mod _io {
 
     #[pyattr]
     #[pyclass(name = "StringIO", base = "_TextIOBase")]
-    #[derive(Debug)]
+    #[derive(Debug, PyValue)]
     struct StringIO {
         buffer: PyRwLock<BufferedIO>,
         closed: AtomicCell<bool>,
     }
 
     type StringIORef = PyRef<StringIO>;
-
-    impl PyValue for StringIO {
-        fn class(_vm: &VirtualMachine) -> &PyTypeRef {
-            Self::static_type()
-        }
-    }
 
     #[derive(FromArgs)]
     struct StringIONewArgs {
@@ -3198,7 +3167,7 @@ mod _io {
 
     #[pyattr]
     #[pyclass(name = "BytesIO", base = "_BufferedIOBase")]
-    #[derive(Debug)]
+    #[derive(Debug, PyValue)]
     struct BytesIO {
         buffer: PyRwLock<BufferedIO>,
         closed: AtomicCell<bool>,
@@ -3206,12 +3175,6 @@ mod _io {
     }
 
     type BytesIORef = PyRef<BytesIO>;
-
-    impl PyValue for BytesIO {
-        fn class(_vm: &VirtualMachine) -> &PyTypeRef {
-            Self::static_type()
-        }
-    }
 
     impl SlotConstructor for BytesIO {
         type Args = OptionalArg<Option<PyBytesRef>>;
@@ -3823,18 +3786,12 @@ mod fileio {
 
     #[pyattr]
     #[pyclass(module = "io", name, base = "_RawIOBase")]
-    #[derive(Debug)]
+    #[derive(Debug, PyValue)]
     pub(super) struct FileIO {
         fd: AtomicCell<i32>,
         closefd: AtomicCell<bool>,
         mode: AtomicCell<Mode>,
         seekable: AtomicCell<Option<bool>>,
-    }
-
-    impl PyValue for FileIO {
-        fn class(_vm: &VirtualMachine) -> &PyTypeRef {
-            Self::static_type()
-        }
     }
 
     #[derive(FromArgs)]

--- a/vm/src/stdlib/itertools.rs
+++ b/vm/src/stdlib/itertools.rs
@@ -24,17 +24,11 @@ mod decl {
 
     #[pyattr]
     #[pyclass(name = "chain")]
-    #[derive(Debug)]
+    #[derive(Debug, PyValue)]
     struct PyItertoolsChain {
         iterables: Vec<PyObjectRef>,
         cur_idx: AtomicCell<usize>,
         cached_iter: PyRwLock<Option<PyObjectRef>>,
-    }
-
-    impl PyValue for PyItertoolsChain {
-        fn class(_vm: &VirtualMachine) -> &PyTypeRef {
-            Self::static_type()
-        }
     }
 
     #[pyimpl(with(PyIter))]
@@ -102,16 +96,10 @@ mod decl {
 
     #[pyattr]
     #[pyclass(name = "compress")]
-    #[derive(Debug)]
+    #[derive(Debug, PyValue)]
     struct PyItertoolsCompress {
         data: PyObjectRef,
         selector: PyObjectRef,
-    }
-
-    impl PyValue for PyItertoolsCompress {
-        fn class(_vm: &VirtualMachine) -> &PyTypeRef {
-            Self::static_type()
-        }
     }
 
     #[derive(FromArgs)]
@@ -160,16 +148,10 @@ mod decl {
 
     #[pyattr]
     #[pyclass(name = "count")]
-    #[derive(Debug)]
+    #[derive(Debug, PyValue)]
     struct PyItertoolsCount {
         cur: PyRwLock<BigInt>,
         step: BigInt,
-    }
-
-    impl PyValue for PyItertoolsCount {
-        fn class(_vm: &VirtualMachine) -> &PyTypeRef {
-            Self::static_type()
-        }
     }
 
     #[derive(FromArgs)]
@@ -219,17 +201,11 @@ mod decl {
 
     #[pyattr]
     #[pyclass(name = "cycle")]
-    #[derive(Debug)]
+    #[derive(Debug, PyValue)]
     struct PyItertoolsCycle {
         iter: PyObjectRef,
         saved: PyRwLock<Vec<PyObjectRef>>,
         index: AtomicCell<usize>,
-    }
-
-    impl PyValue for PyItertoolsCycle {
-        fn class(_vm: &VirtualMachine) -> &PyTypeRef {
-            Self::static_type()
-        }
     }
 
     impl SlotConstructor for PyItertoolsCycle {
@@ -275,16 +251,10 @@ mod decl {
 
     #[pyattr]
     #[pyclass(name = "repeat")]
-    #[derive(Debug)]
+    #[derive(Debug, PyValue)]
     struct PyItertoolsRepeat {
         object: PyObjectRef,
         times: Option<PyRwLock<usize>>,
-    }
-
-    impl PyValue for PyItertoolsRepeat {
-        fn class(_vm: &VirtualMachine) -> &PyTypeRef {
-            Self::static_type()
-        }
     }
 
     #[derive(FromArgs)]
@@ -371,16 +341,10 @@ mod decl {
 
     #[pyattr]
     #[pyclass(name = "starmap")]
-    #[derive(Debug)]
+    #[derive(Debug, PyValue)]
     struct PyItertoolsStarmap {
         function: PyObjectRef,
         iter: PyObjectRef,
-    }
-
-    impl PyValue for PyItertoolsStarmap {
-        fn class(_vm: &VirtualMachine) -> &PyTypeRef {
-            Self::static_type()
-        }
     }
 
     #[derive(FromArgs)]
@@ -418,17 +382,11 @@ mod decl {
 
     #[pyattr]
     #[pyclass(name = "takewhile")]
-    #[derive(Debug)]
+    #[derive(Debug, PyValue)]
     struct PyItertoolsTakewhile {
         predicate: PyObjectRef,
         iterable: PyObjectRef,
         stop_flag: AtomicCell<bool>,
-    }
-
-    impl PyValue for PyItertoolsTakewhile {
-        fn class(_vm: &VirtualMachine) -> &PyTypeRef {
-            Self::static_type()
-        }
     }
 
     #[derive(FromArgs)]
@@ -486,17 +444,11 @@ mod decl {
 
     #[pyattr]
     #[pyclass(name = "dropwhile")]
-    #[derive(Debug)]
+    #[derive(Debug, PyValue)]
     struct PyItertoolsDropwhile {
         predicate: PyCallable,
         iterable: PyObjectRef,
         start_flag: AtomicCell<bool>,
-    }
-
-    impl PyValue for PyItertoolsDropwhile {
-        fn class(_vm: &VirtualMachine) -> &PyTypeRef {
-            Self::static_type()
-        }
     }
 
     #[derive(FromArgs)]
@@ -579,16 +531,11 @@ mod decl {
 
     #[pyattr]
     #[pyclass(name = "groupby")]
+    #[derive(PyValue)]
     struct PyItertoolsGroupBy {
         iterable: PyObjectRef,
         key_func: Option<PyObjectRef>,
         state: PyMutex<GroupByState>,
-    }
-
-    impl PyValue for PyItertoolsGroupBy {
-        fn class(_vm: &VirtualMachine) -> &PyTypeRef {
-            Self::static_type()
-        }
     }
 
     impl fmt::Debug for PyItertoolsGroupBy {
@@ -680,18 +627,12 @@ mod decl {
 
     #[pyattr]
     #[pyclass(name = "_grouper")]
-    #[derive(Debug)]
+    #[derive(Debug, PyValue)]
     struct PyItertoolsGrouper {
         groupby: PyRef<PyItertoolsGroupBy>,
     }
 
     type PyItertoolsGrouperRef = PyRef<PyItertoolsGrouper>;
-
-    impl PyValue for PyItertoolsGrouper {
-        fn class(_vm: &VirtualMachine) -> &PyTypeRef {
-            Self::static_type()
-        }
-    }
 
     #[pyimpl(with(PyIter))]
     impl PyItertoolsGrouper {}
@@ -727,19 +668,13 @@ mod decl {
 
     #[pyattr]
     #[pyclass(name = "islice")]
-    #[derive(Debug)]
+    #[derive(Debug, PyValue)]
     struct PyItertoolsIslice {
         iterable: PyObjectRef,
         cur: AtomicCell<usize>,
         next: AtomicCell<usize>,
         stop: Option<usize>,
         step: usize,
-    }
-
-    impl PyValue for PyItertoolsIslice {
-        fn class(_vm: &VirtualMachine) -> &PyTypeRef {
-            Self::static_type()
-        }
     }
 
     // Restrict obj to ints with value 0 <= val <= sys.maxsize (isize::MAX).
@@ -856,16 +791,10 @@ mod decl {
 
     #[pyattr]
     #[pyclass(name = "filterfalse")]
-    #[derive(Debug)]
+    #[derive(Debug, PyValue)]
     struct PyItertoolsFilterFalse {
         predicate: PyObjectRef,
         iterable: PyObjectRef,
-    }
-
-    impl PyValue for PyItertoolsFilterFalse {
-        fn class(_vm: &VirtualMachine) -> &PyTypeRef {
-            Self::static_type()
-        }
     }
 
     #[derive(FromArgs)]
@@ -921,7 +850,7 @@ mod decl {
 
     #[pyattr]
     #[pyclass(name = "accumulate")]
-    #[derive(Debug)]
+    #[derive(Debug, PyValue)]
     struct PyItertoolsAccumulate {
         iterable: PyObjectRef,
         binop: Option<PyObjectRef>,
@@ -936,12 +865,6 @@ mod decl {
         func: OptionalOption<PyObjectRef>,
         #[pyarg(named, optional)]
         initial: OptionalOption<PyObjectRef>,
-    }
-
-    impl PyValue for PyItertoolsAccumulate {
-        fn class(_vm: &VirtualMachine) -> &PyTypeRef {
-            Self::static_type()
-        }
     }
 
     impl SlotConstructor for PyItertoolsAccumulate {
@@ -1013,16 +936,10 @@ mod decl {
 
     #[pyattr]
     #[pyclass(name = "tee")]
-    #[derive(Debug)]
+    #[derive(Debug, PyValue)]
     struct PyItertoolsTee {
         tee_data: PyRc<PyItertoolsTeeData>,
         index: AtomicCell<usize>,
-    }
-
-    impl PyValue for PyItertoolsTee {
-        fn class(_vm: &VirtualMachine) -> &PyTypeRef {
-            Self::static_type()
-        }
     }
 
     #[derive(FromArgs)]
@@ -1097,18 +1014,12 @@ mod decl {
 
     #[pyattr]
     #[pyclass(name = "product")]
-    #[derive(Debug)]
+    #[derive(Debug, PyValue)]
     struct PyItertoolsProduct {
         pools: Vec<Vec<PyObjectRef>>,
         idxs: PyRwLock<Vec<usize>>,
         cur: AtomicCell<usize>,
         stop: AtomicCell<bool>,
-    }
-
-    impl PyValue for PyItertoolsProduct {
-        fn class(_vm: &VirtualMachine) -> &PyTypeRef {
-            Self::static_type()
-        }
     }
 
     #[derive(FromArgs)]
@@ -1200,18 +1111,12 @@ mod decl {
 
     #[pyattr]
     #[pyclass(name = "combinations")]
-    #[derive(Debug)]
+    #[derive(Debug, PyValue)]
     struct PyItertoolsCombinations {
         pool: Vec<PyObjectRef>,
         indices: PyRwLock<Vec<usize>>,
         r: AtomicCell<usize>,
         exhausted: AtomicCell<bool>,
-    }
-
-    impl PyValue for PyItertoolsCombinations {
-        fn class(_vm: &VirtualMachine) -> &PyTypeRef {
-            Self::static_type()
-        }
     }
 
     #[derive(FromArgs)]
@@ -1304,18 +1209,12 @@ mod decl {
 
     #[pyattr]
     #[pyclass(name = "combinations_with_replacement")]
-    #[derive(Debug)]
+    #[derive(Debug, PyValue)]
     struct PyItertoolsCombinationsWithReplacement {
         pool: Vec<PyObjectRef>,
         indices: PyRwLock<Vec<usize>>,
         r: AtomicCell<usize>,
         exhausted: AtomicCell<bool>,
-    }
-
-    impl PyValue for PyItertoolsCombinationsWithReplacement {
-        fn class(_vm: &VirtualMachine) -> &PyTypeRef {
-            Self::static_type()
-        }
     }
 
     impl SlotConstructor for PyItertoolsCombinationsWithReplacement {
@@ -1395,7 +1294,7 @@ mod decl {
 
     #[pyattr]
     #[pyclass(name = "permutations")]
-    #[derive(Debug)]
+    #[derive(Debug, PyValue)]
     struct PyItertoolsPermutations {
         pool: Vec<PyObjectRef>,               // Collected input iterable
         indices: PyRwLock<Vec<usize>>,        // One index per element in pool
@@ -1403,12 +1302,6 @@ mod decl {
         result: PyRwLock<Option<Vec<usize>>>, // Indexes of the most recently returned result
         r: AtomicCell<usize>,                 // Size of result tuple
         exhausted: AtomicCell<bool>,          // Set when the iterator is exhausted
-    }
-
-    impl PyValue for PyItertoolsPermutations {
-        fn class(_vm: &VirtualMachine) -> &PyTypeRef {
-            Self::static_type()
-        }
     }
 
     #[derive(FromArgs)]
@@ -1554,16 +1447,10 @@ mod decl {
 
     #[pyattr]
     #[pyclass(name = "zip_longest")]
-    #[derive(Debug)]
+    #[derive(Debug, PyValue)]
     struct PyItertoolsZipLongest {
         iterators: Vec<PyObjectRef>,
         fillvalue: PyObjectRef,
-    }
-
-    impl PyValue for PyItertoolsZipLongest {
-        fn class(_vm: &VirtualMachine) -> &PyTypeRef {
-            Self::static_type()
-        }
     }
 
     #[pyimpl(with(PyIter, SlotConstructor))]
@@ -1599,16 +1486,10 @@ mod decl {
 
     #[pyattr]
     #[pyclass(name = "pairwise")]
-    #[derive(Debug)]
+    #[derive(Debug, PyValue)]
     struct PyItertoolsPairwise {
         iterator: PyObjectRef,
         old: PyRwLock<Option<PyObjectRef>>,
-    }
-
-    impl PyValue for PyItertoolsPairwise {
-        fn class(_vm: &VirtualMachine) -> &PyTypeRef {
-            Self::static_type()
-        }
     }
 
     impl SlotConstructor for PyItertoolsPairwise {

--- a/vm/src/stdlib/json.rs
+++ b/vm/src/stdlib/json.rs
@@ -20,7 +20,7 @@ mod _json {
 
     #[pyattr(name = "make_scanner")]
     #[pyclass(name = "Scanner")]
-    #[derive(Debug)]
+    #[derive(Debug, PyValue)]
     struct JsonScanner {
         strict: bool,
         object_hook: Option<PyObjectRef>,
@@ -29,12 +29,6 @@ mod _json {
         parse_int: Option<PyObjectRef>,
         parse_constant: PyObjectRef,
         ctx: PyObjectRef,
-    }
-
-    impl PyValue for JsonScanner {
-        fn class(_vm: &VirtualMachine) -> &PyTypeRef {
-            Self::static_type()
-        }
     }
 
     impl SlotConstructor for JsonScanner {

--- a/vm/src/stdlib/operator.rs
+++ b/vm/src/stdlib/operator.rs
@@ -436,15 +436,9 @@ mod _operator {
     /// (r.name.first, r.name.last).
     #[pyattr]
     #[pyclass(name = "attrgetter")]
-    #[derive(Debug)]
+    #[derive(Debug, PyValue)]
     struct PyAttrGetter {
         attrs: Vec<PyStrRef>,
-    }
-
-    impl PyValue for PyAttrGetter {
-        fn class(_vm: &VirtualMachine) -> &PyTypeRef {
-            Self::static_type()
-        }
     }
 
     #[pyimpl(with(Callable))]
@@ -539,15 +533,9 @@ mod _operator {
     /// After g = itemgetter(2, 5, 3), the call g(r) returns (r[2], r[5], r[3])
     #[pyattr]
     #[pyclass(name = "itemgetter")]
-    #[derive(Debug)]
+    #[derive(Debug, PyValue)]
     struct PyItemGetter {
         items: Vec<PyObjectRef>,
-    }
-
-    impl PyValue for PyItemGetter {
-        fn class(_vm: &VirtualMachine) -> &PyTypeRef {
-            Self::static_type()
-        }
     }
 
     #[pyimpl(with(Callable))]
@@ -614,16 +602,10 @@ mod _operator {
     /// r.name('date', foo=1).
     #[pyattr]
     #[pyclass(name = "methodcaller")]
-    #[derive(Debug)]
+    #[derive(Debug, PyValue)]
     struct PyMethodCaller {
         name: PyStrRef,
         args: FuncArgs,
-    }
-
-    impl PyValue for PyMethodCaller {
-        fn class(_vm: &VirtualMachine) -> &PyTypeRef {
-            Self::static_type()
-        }
     }
 
     impl SlotConstructor for PyMethodCaller {

--- a/vm/src/stdlib/os.rs
+++ b/vm/src/stdlib/os.rs
@@ -787,7 +787,7 @@ mod _os {
 
     #[pyattr]
     #[pyclass(name)]
-    #[derive(Debug)]
+    #[derive(Debug, PyValue)]
     struct DirEntry {
         entry: fs::DirEntry,
         mode: OutputMode,
@@ -795,12 +795,6 @@ mod _os {
         lstat: OnceCell<PyObjectRef>,
         #[cfg(not(unix))]
         ino: AtomicCell<Option<u64>>,
-    }
-
-    impl PyValue for DirEntry {
-        fn class(_vm: &VirtualMachine) -> &PyTypeRef {
-            Self::static_type()
-        }
     }
 
     #[pyimpl]
@@ -959,17 +953,11 @@ mod _os {
 
     #[pyattr]
     #[pyclass(name = "ScandirIter")]
-    #[derive(Debug)]
+    #[derive(Debug, PyValue)]
     struct ScandirIterator {
         entries: PyRwLock<fs::ReadDir>,
         exhausted: AtomicCell<bool>,
         mode: OutputMode,
-    }
-
-    impl PyValue for ScandirIterator {
-        fn class(_vm: &VirtualMachine) -> &PyTypeRef {
-            Self::static_type()
-        }
     }
 
     #[pyimpl(with(PyIter))]
@@ -2486,15 +2474,9 @@ mod posix {
 
     #[pyattr]
     #[pyclass(name = "sched_param")]
-    #[derive(Debug)]
+    #[derive(Debug, PyValue)]
     struct SchedParam {
         sched_priority: PyObjectRef,
-    }
-
-    impl PyValue for SchedParam {
-        fn class(_vm: &VirtualMachine) -> &PyTypeRef {
-            Self::static_type()
-        }
     }
 
     impl TryFromObject for SchedParam {

--- a/vm/src/stdlib/pyexpat.rs
+++ b/vm/src/stdlib/pyexpat.rs
@@ -48,7 +48,7 @@ mod _pyexpat {
 
     #[pyattr]
     #[pyclass(name = "xmlparser", module = false)]
-    #[derive(Debug)]
+    #[derive(Debug, PyValue)]
     pub struct PyExpatLikeXmlParser {
         start_element: MutableObject,
         end_element: MutableObject,
@@ -57,12 +57,6 @@ mod _pyexpat {
         buffer_text: MutableObject,
     }
     type PyExpatLikeXmlParserRef = PyRef<PyExpatLikeXmlParser>;
-
-    impl PyValue for PyExpatLikeXmlParser {
-        fn class(_vm: &VirtualMachine) -> &PyTypeRef {
-            Self::static_type()
-        }
-    }
 
     #[inline]
     fn invoke_handler<T>(vm: &VirtualMachine, handler: &MutableObject, args: T)

--- a/vm/src/stdlib/pystruct.rs
+++ b/vm/src/stdlib/pystruct.rs
@@ -789,7 +789,7 @@ pub(crate) mod _struct {
 
     #[pyattr]
     #[pyclass(name = "unpack_iterator")]
-    #[derive(Debug)]
+    #[derive(Debug, PyValue)]
     struct UnpackIterator {
         format_spec: FormatSpec,
         buffer: ArgBytesLike,
@@ -822,12 +822,6 @@ pub(crate) mod _struct {
                     offset: AtomicCell::new(0),
                 })
             }
-        }
-    }
-
-    impl PyValue for UnpackIterator {
-        fn class(_vm: &VirtualMachine) -> &PyTypeRef {
-            Self::static_type()
         }
     }
 
@@ -870,16 +864,10 @@ pub(crate) mod _struct {
 
     #[pyattr]
     #[pyclass(name = "Struct")]
-    #[derive(Debug)]
+    #[derive(Debug, PyValue)]
     struct PyStruct {
         spec: FormatSpec,
         fmt_str: PyStrRef,
-    }
-
-    impl PyValue for PyStruct {
-        fn class(_vm: &VirtualMachine) -> &PyTypeRef {
-            Self::static_type()
-        }
     }
 
     impl SlotConstructor for PyStruct {

--- a/vm/src/stdlib/random.rs
+++ b/vm/src/stdlib/random.rs
@@ -56,15 +56,9 @@ mod _random {
 
     #[pyattr]
     #[pyclass(name = "Random")]
-    #[derive(Debug)]
+    #[derive(Debug, PyValue)]
     struct PyRandom {
         rng: PyMutex<PyRng>,
-    }
-
-    impl PyValue for PyRandom {
-        fn class(_vm: &VirtualMachine) -> &PyTypeRef {
-            Self::static_type()
-        }
     }
 
     impl SlotConstructor for PyRandom {

--- a/vm/src/stdlib/re.rs
+++ b/vm/src/stdlib/re.rs
@@ -17,7 +17,7 @@ use crate::vm::VirtualMachine;
 use crate::{IntoPyObject, PyClassImpl, PyObjectRef, PyResult, PyValue, StaticType, TryFromObject};
 
 #[pyclass(module = "re", name = "Pattern")]
-#[derive(Debug)]
+#[derive(Debug, PyValue)]
 struct PyPattern {
     regex: Regex,
     pattern: String,
@@ -62,14 +62,9 @@ impl PyRegexFlags {
     }
 }
 
-impl PyValue for PyPattern {
-    fn class(_vm: &VirtualMachine) -> &PyTypeRef {
-        Self::static_type()
-    }
-}
-
 /// Inner data for a match object.
 #[pyclass(module = "re", name = "Match")]
+#[derive(PyValue)]
 struct PyMatch {
     haystack: PyStrRef,
     captures: Vec<Option<Range<usize>>>,
@@ -78,12 +73,6 @@ struct PyMatch {
 impl fmt::Debug for PyMatch {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "Match()")
-    }
-}
-
-impl PyValue for PyMatch {
-    fn class(_vm: &VirtualMachine) -> &PyTypeRef {
-        Self::static_type()
     }
 }
 
@@ -246,7 +235,9 @@ fn do_split(
     let split = output
         .into_iter()
         .map(|v| {
-            vm.unwrap_or_none(v.map(|v| vm.ctx.new_utf8_str(String::from_utf8_lossy(v).into_owned())))
+            vm.unwrap_or_none(
+                v.map(|v| vm.ctx.new_utf8_str(String::from_utf8_lossy(v).into_owned())),
+            )
         })
         .collect();
     Ok(vm.ctx.new_list(split))

--- a/vm/src/stdlib/select.rs
+++ b/vm/src/stdlib/select.rs
@@ -264,16 +264,10 @@ mod decl {
         use std::time;
 
         #[pyclass(module = "select", name = "poll")]
-        #[derive(Default, Debug)]
+        #[derive(Default, Debug, PyValue)]
         pub struct PyPoll {
             // keep sorted
             fds: PyMutex<Vec<pollfd>>,
-        }
-
-        impl PyValue for PyPoll {
-            fn class(_vm: &VirtualMachine) -> &PyTypeRef {
-                Self::static_type()
-            }
         }
 
         #[inline]

--- a/vm/src/stdlib/socket.rs
+++ b/vm/src/stdlib/socket.rs
@@ -142,7 +142,7 @@ impl Default for NullableSocket {
 }
 
 #[pyclass(module = "socket", name = "socket")]
-#[derive(Debug)]
+#[derive(Debug, PyValue)]
 pub struct PySocket {
     kind: AtomicCell<i32>,
     family: AtomicCell<i32>,
@@ -160,12 +160,6 @@ impl Default for PySocket {
             timeout: AtomicCell::new(-1.0),
             sock: PyRwLock::new(NullableSocket::invalid()),
         }
-    }
-}
-
-impl PyValue for PySocket {
-    fn class(_vm: &VirtualMachine) -> &PyTypeRef {
-        Self::static_type()
     }
 }
 

--- a/vm/src/stdlib/sre.rs
+++ b/vm/src/stdlib/sre.rs
@@ -122,7 +122,7 @@ mod _sre {
 
     #[pyattr]
     #[pyclass(name = "Pattern")]
-    #[derive(Debug)]
+    #[derive(Debug, PyValue)]
     pub(crate) struct Pattern {
         pub pattern: PyObjectRef,
         pub flags: SreFlag,
@@ -131,12 +131,6 @@ mod _sre {
         pub groupindex: PyDictRef,
         pub indexgroup: Vec<Option<PyStrRef>>,
         pub isbytes: bool,
-    }
-
-    impl PyValue for Pattern {
-        fn class(_vm: &VirtualMachine) -> &PyTypeRef {
-            Self::static_type()
-        }
     }
 
     #[pyimpl(with(Hashable, Comparable))]
@@ -561,7 +555,7 @@ mod _sre {
 
     #[pyattr]
     #[pyclass(name = "Match")]
-    #[derive(Debug)]
+    #[derive(Debug, PyValue)]
     pub(crate) struct Match {
         string: PyObjectRef,
         pattern: PyRef<Pattern>,
@@ -569,11 +563,6 @@ mod _sre {
         endpos: usize,
         lastindex: isize,
         regs: Vec<(isize, isize)>,
-    }
-    impl PyValue for Match {
-        fn class(_vm: &VirtualMachine) -> &PyTypeRef {
-            Self::static_type()
-        }
     }
 
     #[pyimpl]
@@ -804,18 +793,13 @@ mod _sre {
 
     #[pyattr]
     #[pyclass(name = "SRE_Scanner")]
-    #[derive(Debug)]
+    #[derive(Debug, PyValue)]
     struct SreScanner {
         pattern: PyRef<Pattern>,
         string: PyObjectRef,
         start: AtomicCell<usize>,
         end: usize,
         must_advance: AtomicCell<bool>,
-    }
-    impl PyValue for SreScanner {
-        fn class(_vm: &VirtualMachine) -> &PyTypeRef {
-            Self::static_type()
-        }
     }
 
     #[pyimpl]

--- a/vm/src/stdlib/ssl.rs
+++ b/vm/src/stdlib/ssl.rs
@@ -248,6 +248,7 @@ fn _ssl_rand_pseudo_bytes(n: i32, vm: &VirtualMachine) -> PyResult<(Vec<u8>, boo
 }
 
 #[pyclass(module = "ssl", name = "_SSLContext")]
+#[derive(PyValue)]
 struct PySslContext {
     ctx: PyRwLock<SslContextBuilder>,
     check_hostname: AtomicCell<bool>,
@@ -257,12 +258,6 @@ struct PySslContext {
 impl fmt::Debug for PySslContext {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.pad("_SSLContext")
-    }
-}
-
-impl PyValue for PySslContext {
-    fn class(_vm: &VirtualMachine) -> &PyTypeRef {
-        Self::static_type()
     }
 }
 
@@ -716,6 +711,7 @@ fn socket_closed_error(vm: &VirtualMachine) -> PyBaseExceptionRef {
 }
 
 #[pyclass(module = "ssl", name = "_SSLSocket")]
+#[derive(PyValue)]
 struct PySslSocket {
     ctx: PyRef<PySslContext>,
     stream: PyRwLock<ssl::SslStream<PySocketRef>>,
@@ -727,12 +723,6 @@ struct PySslSocket {
 impl fmt::Debug for PySslSocket {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.pad("_SSLSocket")
-    }
-}
-
-impl PyValue for PySslSocket {
-    fn class(_vm: &VirtualMachine) -> &PyTypeRef {
-        Self::static_type()
     }
 }
 

--- a/vm/src/stdlib/symtable.rs
+++ b/vm/src/stdlib/symtable.rs
@@ -40,6 +40,7 @@ mod decl {
 
     #[pyattr]
     #[pyclass(name = "SymbolTable")]
+    #[derive(PyValue)]
     struct PySymbolTable {
         symtable: SymbolTable,
     }
@@ -47,12 +48,6 @@ mod decl {
     impl fmt::Debug for PySymbolTable {
         fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
             write!(f, "SymbolTable()")
-        }
-    }
-
-    impl PyValue for PySymbolTable {
-        fn class(_vm: &VirtualMachine) -> &PyTypeRef {
-            Self::static_type()
         }
     }
 
@@ -157,6 +152,7 @@ mod decl {
 
     #[pyattr]
     #[pyclass(name = "Symbol")]
+    #[derive(PyValue)]
     struct PySymbol {
         symbol: Symbol,
         namespaces: Vec<SymbolTable>,
@@ -165,12 +161,6 @@ mod decl {
     impl fmt::Debug for PySymbol {
         fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
             write!(f, "Symbol()")
-        }
-    }
-
-    impl PyValue for PySymbol {
-        fn class(_vm: &VirtualMachine) -> &PyTypeRef {
-            Self::static_type()
         }
     }
 

--- a/vm/src/stdlib/thread.rs
+++ b/vm/src/stdlib/thread.rs
@@ -96,16 +96,11 @@ macro_rules! repr_lock_impl {
 }
 
 #[pyclass(module = "thread", name = "lock")]
+#[derive(PyValue)]
 struct PyLock {
     mu: RawMutex,
 }
 type PyLockRef = PyRef<PyLock>;
-
-impl PyValue for PyLock {
-    fn class(_vm: &VirtualMachine) -> &PyTypeRef {
-        Self::static_type()
-    }
-}
 
 impl fmt::Debug for PyLock {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
@@ -150,14 +145,9 @@ impl PyLock {
 
 pub type RawRMutex = RawReentrantMutex<RawMutex, RawThreadId>;
 #[pyclass(module = "thread", name = "RLock")]
+#[derive(PyValue)]
 struct PyRLock {
     mu: RawRMutex,
-}
-
-impl PyValue for PyRLock {
-    fn class(_vm: &VirtualMachine) -> &PyTypeRef {
-        Self::static_type()
-    }
 }
 
 impl fmt::Debug for PyRLock {
@@ -303,15 +293,9 @@ fn _thread_count(vm: &VirtualMachine) -> usize {
 }
 
 #[pyclass(module = "thread", name = "_local")]
-#[derive(Debug)]
+#[derive(Debug, PyValue)]
 struct PyLocal {
     data: ThreadLocal<PyDictRef>,
-}
-
-impl PyValue for PyLocal {
-    fn class(_vm: &VirtualMachine) -> &PyTypeRef {
-        Self::static_type()
-    }
 }
 
 #[pyimpl(with(SlotGetattro, SlotSetattro), flags(BASETYPE))]

--- a/vm/src/stdlib/unicodedata.rs
+++ b/vm/src/stdlib/unicodedata.rs
@@ -55,15 +55,9 @@ pub fn make_module(vm: &VirtualMachine) -> PyObjectRef {
 }
 
 #[pyclass(module = "unicodedata", name = "UCD")]
-#[derive(Debug)]
+#[derive(Debug, PyValue)]
 struct PyUCD {
     unic_version: UnicodeVersion,
-}
-
-impl PyValue for PyUCD {
-    fn class(_vm: &VirtualMachine) -> &PyTypeRef {
-        Self::static_type()
-    }
 }
 
 impl Default for PyUCD {

--- a/vm/src/stdlib/winreg.rs
+++ b/vm/src/stdlib/winreg.rs
@@ -13,7 +13,7 @@ use winapi::shared::winerror;
 use winreg::{enums::RegType, RegKey, RegValue};
 
 #[pyclass(module = "winreg", name = "HKEYType")]
-#[derive(Debug)]
+#[derive(Debug, PyValue)]
 struct PyHKEY {
     key: PyRwLock<RegKey>,
 }
@@ -21,12 +21,6 @@ type PyHKEYRef = PyRef<PyHKEY>;
 
 // TODO: fix this
 unsafe impl Sync for PyHKEY {}
-
-impl PyValue for PyHKEY {
-    fn class(_vm: &VirtualMachine) -> &PyTypeRef {
-        Self::static_type()
-    }
-}
 
 #[pyimpl]
 impl PyHKEY {

--- a/vm/src/stdlib/zlib.rs
+++ b/vm/src/stdlib/zlib.rs
@@ -270,17 +270,12 @@ mod decl {
     }
     #[pyattr]
     #[pyclass(name = "Decompress")]
-    #[derive(Debug)]
+    #[derive(Debug, PyValue)]
     struct PyDecompress {
         decompress: PyMutex<Decompress>,
         eof: AtomicCell<bool>,
         unused_data: PyMutex<PyBytesRef>,
         unconsumed_tail: PyMutex<PyBytesRef>,
-    }
-    impl PyValue for PyDecompress {
-        fn class(_vm: &VirtualMachine) -> &PyTypeRef {
-            Self::static_type()
-        }
     }
     #[pyimpl]
     impl PyDecompress {
@@ -441,15 +436,9 @@ mod decl {
 
     #[pyattr]
     #[pyclass(name = "Compress")]
-    #[derive(Debug)]
+    #[derive(Debug, PyValue)]
     struct PyCompress {
         inner: PyMutex<CompressInner>,
-    }
-
-    impl PyValue for PyCompress {
-        fn class(_vm: &VirtualMachine) -> &PyTypeRef {
-            Self::static_type()
-        }
     }
 
     #[pyimpl]

--- a/wasm/lib/src/browser_module.rs
+++ b/wasm/lib/src/browser_module.rs
@@ -153,15 +153,9 @@ fn browser_cancel_animation_frame(id: i32, vm: &VirtualMachine) -> PyResult<()> 
 }
 
 #[pyclass(module = "browser", name)]
-#[derive(Debug)]
+#[derive(Debug, PyValue)]
 struct Document {
     doc: web_sys::Document,
-}
-
-impl PyValue for Document {
-    fn class(_vm: &VirtualMachine) -> &PyTypeRef {
-        Self::static_type()
-    }
 }
 
 #[pyimpl]
@@ -179,15 +173,9 @@ impl Document {
 }
 
 #[pyclass(module = "browser", name)]
-#[derive(Debug)]
+#[derive(Debug, PyValue)]
 struct Element {
     elem: web_sys::Element,
-}
-
-impl PyValue for Element {
-    fn class(_vm: &VirtualMachine) -> &PyTypeRef {
-        Self::static_type()
-    }
 }
 
 #[pyimpl]

--- a/wasm/lib/src/js_module.rs
+++ b/wasm/lib/src/js_module.rs
@@ -51,17 +51,11 @@ extern "C" {
 }
 
 #[pyclass(module = "_js", name = "JSValue")]
-#[derive(Debug)]
+#[derive(Debug, PyValue)]
 pub struct PyJsValue {
     pub(crate) value: JsValue,
 }
 type PyJsValueRef = PyRef<PyJsValue>;
-
-impl PyValue for PyJsValue {
-    fn class(_vm: &VirtualMachine) -> &PyTypeRef {
-        Self::static_type()
-    }
-}
 
 impl AsRef<JsValue> for PyJsValue {
     fn as_ref(&self) -> &JsValue {
@@ -281,6 +275,7 @@ struct NewObjectOptions {
 type ClosureType = Closure<dyn FnMut(JsValue, Box<[JsValue]>) -> Result<JsValue, JsValue>>;
 
 #[pyclass(module = "_js", name = "JSClosure")]
+#[derive(PyValue)]
 struct JsClosure {
     closure: cell::RefCell<Option<(ClosureType, PyJsValueRef)>>,
     destroyed: cell::Cell<bool>,
@@ -290,12 +285,6 @@ struct JsClosure {
 impl fmt::Debug for JsClosure {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         f.pad("JsClosure")
-    }
-}
-
-impl PyValue for JsClosure {
-    fn class(_vm: &VirtualMachine) -> &PyTypeRef {
-        Self::static_type()
     }
 }
 
@@ -380,7 +369,7 @@ impl JsClosure {
 }
 
 #[pyclass(module = "_js", name = "Promise")]
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PyValue)]
 pub struct PyPromise {
     value: PromiseKind,
 }
@@ -392,12 +381,6 @@ enum PromiseKind {
     PyProm { then: PyObjectRef },
     PyResolved(PyObjectRef),
     PyRejected(PyBaseExceptionRef),
-}
-
-impl PyValue for PyPromise {
-    fn class(_vm: &VirtualMachine) -> &PyTypeRef {
-        Self::static_type()
-    }
 }
 
 #[pyimpl]
@@ -548,6 +531,7 @@ impl PyPromise {
 }
 
 #[pyclass(module = "_js", name = "AwaitPromise")]
+#[derive(PyValue)]
 struct AwaitPromise {
     obj: cell::Cell<Option<PyObjectRef>>,
 }
@@ -555,12 +539,6 @@ struct AwaitPromise {
 impl fmt::Debug for AwaitPromise {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("AwaitPromise").finish()
-    }
-}
-
-impl PyValue for AwaitPromise {
-    fn class(_vm: &VirtualMachine) -> &PyTypeRef {
-        Self::static_type()
     }
 }
 


### PR DESCRIPTION
This seems a big change but actually it is a simple macro that will produce the following implementation

```rust
impl ::rustpython_vm::PyValue for #ty {
    fn class(_vm: &VirtualMachine) -> &PyTypeRef {
        Self::static_type()
    }
}
```