### PR TITLE
vm::function::{Args -> PosArgs}

### DIFF
--- a/vm/src/builtins/make_module.rs
+++ b/vm/src/builtins/make_module.rs
@@ -26,7 +26,7 @@ mod decl {
     #[cfg(feature = "rustpython-compiler")]
     use crate::compile;
     use crate::function::{
-        ArgCallable, ArgIterable, Args, FuncArgs, KwArgs, OptionalArg, OptionalOption,
+        ArgCallable, ArgIterable, FuncArgs, KwArgs, OptionalArg, OptionalOption, PosArgs,
     };
     use crate::iterator;
     use crate::readline::{Readline, ReadlineResult};
@@ -652,7 +652,7 @@ mod decl {
     }
 
     #[pyfunction]
-    pub fn print(objects: Args, options: PrintOptions, vm: &VirtualMachine) -> PyResult<()> {
+    pub fn print(objects: PosArgs, options: PrintOptions, vm: &VirtualMachine) -> PyResult<()> {
         let file = match options.file {
             Some(f) => f,
             None => sysmodule::get_stdout(vm)?,
@@ -809,7 +809,7 @@ mod decl {
     pub fn __build_class__(
         function: PyFunctionRef,
         qualified_name: PyStrRef,
-        bases: Args,
+        bases: PosArgs,
         mut kwargs: KwArgs,
         vm: &VirtualMachine,
     ) -> PyResult {

--- a/vm/src/builtins/map.rs
+++ b/vm/src/builtins/map.rs
@@ -1,5 +1,5 @@
 use super::pytype::PyTypeRef;
-use crate::function::Args;
+use crate::function::PosArgs;
 use crate::iterator;
 use crate::slots::{PyIter, SlotConstructor};
 use crate::vm::VirtualMachine;
@@ -23,7 +23,7 @@ impl PyValue for PyMap {
 }
 
 impl SlotConstructor for PyMap {
-    type Args = (PyObjectRef, Args<PyObjectRef>);
+    type Args = (PyObjectRef, PosArgs<PyObjectRef>);
 
     fn py_new(cls: PyTypeRef, (function, iterables): Self::Args, vm: &VirtualMachine) -> PyResult {
         let iterators = iterables

--- a/vm/src/builtins/set.rs
+++ b/vm/src/builtins/set.rs
@@ -6,7 +6,7 @@ use crate::common::hash::PyHash;
 use crate::common::rc::PyRc;
 use crate::dictdatatype;
 use crate::dictdatatype::DictSize;
-use crate::function::{ArgIterable, Args, FuncArgs, OptionalArg};
+use crate::function::{ArgIterable, FuncArgs, OptionalArg, PosArgs};
 use crate::slots::{
     Comparable, Hashable, Iterable, PyComparisonOp, PyIter, SlotConstructor, Unhashable,
 };
@@ -243,7 +243,7 @@ impl PySetInner {
         }
     }
 
-    fn update(&self, others: Args<ArgIterable>, vm: &VirtualMachine) -> PyResult<()> {
+    fn update(&self, others: PosArgs<ArgIterable>, vm: &VirtualMachine) -> PyResult<()> {
         for iterable in others {
             for item in iterable.iter(vm)? {
                 self.add(item?, vm)?;
@@ -252,7 +252,11 @@ impl PySetInner {
         Ok(())
     }
 
-    fn intersection_update(&self, others: Args<ArgIterable>, vm: &VirtualMachine) -> PyResult<()> {
+    fn intersection_update(
+        &self,
+        others: PosArgs<ArgIterable>,
+        vm: &VirtualMachine,
+    ) -> PyResult<()> {
         let mut temp_inner = self.copy();
         self.clear();
         for iterable in others {
@@ -267,7 +271,7 @@ impl PySetInner {
         Ok(())
     }
 
-    fn difference_update(&self, others: Args<ArgIterable>, vm: &VirtualMachine) -> PyResult<()> {
+    fn difference_update(&self, others: PosArgs<ArgIterable>, vm: &VirtualMachine) -> PyResult<()> {
         for iterable in others {
             for item in iterable.iter(vm)? {
                 self.content.delete_if_exists(vm, &item?)?;
@@ -278,7 +282,7 @@ impl PySetInner {
 
     fn symmetric_difference_update(
         &self,
-        others: Args<ArgIterable>,
+        others: PosArgs<ArgIterable>,
         vm: &VirtualMachine,
     ) -> PyResult<()> {
         for iterable in others {
@@ -378,7 +382,7 @@ impl PySet {
             self.clear();
         }
         if let OptionalArg::Present(it) = iterable {
-            self.update(Args::new(vec![it]), vm)?;
+            self.update(PosArgs::new(vec![it]), vm)?;
         }
         Ok(())
     }
@@ -406,24 +410,24 @@ impl PySet {
     }
 
     #[pymethod]
-    fn union(&self, others: Args<ArgIterable>, vm: &VirtualMachine) -> PyResult<Self> {
+    fn union(&self, others: PosArgs<ArgIterable>, vm: &VirtualMachine) -> PyResult<Self> {
         multi_args_set!(vm, others, self, union)
     }
 
     #[pymethod]
-    fn intersection(&self, others: Args<ArgIterable>, vm: &VirtualMachine) -> PyResult<Self> {
+    fn intersection(&self, others: PosArgs<ArgIterable>, vm: &VirtualMachine) -> PyResult<Self> {
         multi_args_set!(vm, others, self, intersection)
     }
 
     #[pymethod]
-    fn difference(&self, others: Args<ArgIterable>, vm: &VirtualMachine) -> PyResult<Self> {
+    fn difference(&self, others: PosArgs<ArgIterable>, vm: &VirtualMachine) -> PyResult<Self> {
         multi_args_set!(vm, others, self, difference)
     }
 
     #[pymethod]
     fn symmetric_difference(
         &self,
-        others: Args<ArgIterable>,
+        others: PosArgs<ArgIterable>,
         vm: &VirtualMachine,
     ) -> PyResult<Self> {
         multi_args_set!(vm, others, self, symmetric_difference)
@@ -518,13 +522,17 @@ impl PySet {
     }
 
     #[pymethod]
-    fn update(&self, others: Args<ArgIterable>, vm: &VirtualMachine) -> PyResult<()> {
+    fn update(&self, others: PosArgs<ArgIterable>, vm: &VirtualMachine) -> PyResult<()> {
         self.inner.update(others, vm)?;
         Ok(())
     }
 
     #[pymethod]
-    fn intersection_update(&self, others: Args<ArgIterable>, vm: &VirtualMachine) -> PyResult<()> {
+    fn intersection_update(
+        &self,
+        others: PosArgs<ArgIterable>,
+        vm: &VirtualMachine,
+    ) -> PyResult<()> {
         self.inner.intersection_update(others, vm)?;
         Ok(())
     }
@@ -536,7 +544,7 @@ impl PySet {
     }
 
     #[pymethod]
-    fn difference_update(&self, others: Args<ArgIterable>, vm: &VirtualMachine) -> PyResult<()> {
+    fn difference_update(&self, others: PosArgs<ArgIterable>, vm: &VirtualMachine) -> PyResult<()> {
         self.inner.difference_update(others, vm)?;
         Ok(())
     }
@@ -550,7 +558,7 @@ impl PySet {
     #[pymethod]
     fn symmetric_difference_update(
         &self,
-        others: Args<ArgIterable>,
+        others: PosArgs<ArgIterable>,
         vm: &VirtualMachine,
     ) -> PyResult<()> {
         self.inner.symmetric_difference_update(others, vm)?;
@@ -673,24 +681,24 @@ impl PyFrozenSet {
     }
 
     #[pymethod]
-    fn union(&self, others: Args<ArgIterable>, vm: &VirtualMachine) -> PyResult<Self> {
+    fn union(&self, others: PosArgs<ArgIterable>, vm: &VirtualMachine) -> PyResult<Self> {
         multi_args_frozenset!(vm, others, self, union)
     }
 
     #[pymethod]
-    fn intersection(&self, others: Args<ArgIterable>, vm: &VirtualMachine) -> PyResult<Self> {
+    fn intersection(&self, others: PosArgs<ArgIterable>, vm: &VirtualMachine) -> PyResult<Self> {
         multi_args_frozenset!(vm, others, self, intersection)
     }
 
     #[pymethod]
-    fn difference(&self, others: Args<ArgIterable>, vm: &VirtualMachine) -> PyResult<Self> {
+    fn difference(&self, others: PosArgs<ArgIterable>, vm: &VirtualMachine) -> PyResult<Self> {
         multi_args_frozenset!(vm, others, self, difference)
     }
 
     #[pymethod]
     fn symmetric_difference(
         &self,
-        others: Args<ArgIterable>,
+        others: PosArgs<ArgIterable>,
         vm: &VirtualMachine,
     ) -> PyResult<Self> {
         multi_args_frozenset!(vm, others, self, symmetric_difference)
@@ -787,7 +795,7 @@ impl Iterable for PyFrozenSet {
 }
 
 struct SetIterable {
-    iterable: Args<ArgIterable>,
+    iterable: PosArgs<ArgIterable>,
 }
 
 impl TryFromObject for SetIterable {
@@ -799,7 +807,7 @@ impl TryFromObject for SetIterable {
             // the class lease needs to be drop to be able to return the object
             drop(class);
             Ok(SetIterable {
-                iterable: Args::new(vec![ArgIterable::try_from_object(vm, obj)?]),
+                iterable: PosArgs::new(vec![ArgIterable::try_from_object(vm, obj)?]),
             })
         } else {
             Err(vm.new_type_error(format!("{} is not a subtype of set or frozenset", class)))

--- a/vm/src/builtins/zip.rs
+++ b/vm/src/builtins/zip.rs
@@ -1,5 +1,5 @@
 use super::pytype::PyTypeRef;
-use crate::function::Args;
+use crate::function::PosArgs;
 use crate::iterator;
 use crate::slots::{PyIter, SlotConstructor};
 use crate::vm::VirtualMachine;
@@ -18,7 +18,7 @@ impl PyValue for PyZip {
 }
 
 impl SlotConstructor for PyZip {
-    type Args = Args;
+    type Args = PosArgs;
 
     fn py_new(cls: PyTypeRef, iterables: Self::Args, vm: &VirtualMachine) -> PyResult {
         let iterators = iterables

--- a/vm/src/stdlib/itertools.rs
+++ b/vm/src/stdlib/itertools.rs
@@ -8,7 +8,7 @@ mod decl {
     };
     use crate::{
         builtins::{int, PyInt, PyIntRef, PyTupleRef, PyTypeRef},
-        function::{ArgCallable, Args, FuncArgs, OptionalArg, OptionalOption},
+        function::{ArgCallable, FuncArgs, OptionalArg, OptionalOption, PosArgs},
         iterator::{call_next, get_iter, get_next_object},
         slots::{PyIter, SlotConstructor},
         IdProtocol, IntoPyObject, PyObjectRef, PyRef, PyResult, PyValue, PyWeakRef, StaticType,
@@ -1026,7 +1026,7 @@ mod decl {
     }
 
     impl SlotConstructor for PyItertoolsProduct {
-        type Args = (Args<PyObjectRef>, ProductArgs);
+        type Args = (PosArgs<PyObjectRef>, ProductArgs);
 
         fn py_new(cls: PyTypeRef, (iterables, args): Self::Args, vm: &VirtualMachine) -> PyResult {
             let repeat = args.repeat.unwrap_or(1);
@@ -1425,7 +1425,7 @@ mod decl {
     }
 
     impl SlotConstructor for PyItertoolsZipLongest {
-        type Args = (Args<PyObjectRef>, ZipLongestArgs);
+        type Args = (PosArgs<PyObjectRef>, ZipLongestArgs);
 
         fn py_new(cls: PyTypeRef, (iterables, args): Self::Args, vm: &VirtualMachine) -> PyResult {
             let fillvalue = args.fillvalue.unwrap_or_none(vm);

--- a/vm/src/stdlib/math.rs
+++ b/vm/src/stdlib/math.rs
@@ -6,7 +6,7 @@ mod math {
         builtins::{
             try_bigint_to_f64, try_f64_to_bigint, IntoPyFloat, PyFloatRef, PyInt, PyIntRef,
         },
-        function::{ArgIterable, Args, OptionalArg},
+        function::{ArgIterable, OptionalArg, PosArgs},
         utils::Either,
         PyObjectRef, PyResult, PySequence, TypeProtocol, VirtualMachine,
     };
@@ -227,7 +227,7 @@ mod math {
     }
 
     #[pyfunction]
-    fn hypot(coordinates: Args<IntoPyFloat>) -> f64 {
+    fn hypot(coordinates: PosArgs<IntoPyFloat>) -> f64 {
         let mut coordinates = IntoPyFloat::vec_into_f64(coordinates.into_vec());
         let mut max = 0.0;
         let mut has_nan = false;
@@ -478,7 +478,7 @@ mod math {
         }
     }
 
-    fn math_perf_arb_len_int_op<F>(args: Args<PyIntRef>, op: F, default: BigInt) -> BigInt
+    fn math_perf_arb_len_int_op<F>(args: PosArgs<PyIntRef>, op: F, default: BigInt) -> BigInt
     where
         F: Fn(&BigInt, &PyInt) -> BigInt,
     {
@@ -498,13 +498,13 @@ mod math {
     }
 
     #[pyfunction]
-    fn gcd(args: Args<PyIntRef>) -> BigInt {
+    fn gcd(args: PosArgs<PyIntRef>) -> BigInt {
         use num_integer::Integer;
         math_perf_arb_len_int_op(args, |x, y| x.gcd(y.as_bigint()), BigInt::zero())
     }
 
     #[pyfunction]
-    fn lcm(args: Args<PyIntRef>) -> BigInt {
+    fn lcm(args: PosArgs<PyIntRef>) -> BigInt {
         use num_integer::Integer;
         math_perf_arb_len_int_op(args, |x, y| x.lcm(y.as_bigint()), BigInt::one())
     }

--- a/vm/src/stdlib/pystruct.rs
+++ b/vm/src/stdlib/pystruct.rs
@@ -19,7 +19,7 @@ pub(crate) mod _struct {
         byteslike::{ArgBytesLike, ArgMemoryBuffer},
         common::str::wchar_t,
         exceptions::PyBaseExceptionRef,
-        function::Args,
+        function::PosArgs,
         slots::{PyIter, SlotConstructor},
         utils::Either,
         IntoPyObject, PyObjectRef, PyRef, PyResult, PyValue, StaticType, TryFromObject,
@@ -722,7 +722,7 @@ pub(crate) mod _struct {
     #[pyfunction]
     fn pack(
         fmt: Either<PyStrRef, PyBytesRef>,
-        args: Args,
+        args: PosArgs,
         vm: &VirtualMachine,
     ) -> PyResult<Vec<u8>> {
         let format_spec = FormatSpec::decode_and_parse(vm, &fmt)?;
@@ -734,7 +734,7 @@ pub(crate) mod _struct {
         fmt: Either<PyStrRef, PyBytesRef>,
         buffer: ArgMemoryBuffer,
         offset: isize,
-        args: Args,
+        args: PosArgs,
         vm: &VirtualMachine,
     ) -> PyResult<()> {
         let format_spec = FormatSpec::decode_and_parse(vm, &fmt)?;
@@ -899,7 +899,7 @@ pub(crate) mod _struct {
         }
 
         #[pymethod]
-        fn pack(&self, args: Args, vm: &VirtualMachine) -> PyResult<Vec<u8>> {
+        fn pack(&self, args: PosArgs, vm: &VirtualMachine) -> PyResult<Vec<u8>> {
             self.spec.pack(args.into_vec(), vm)
         }
 
@@ -908,7 +908,7 @@ pub(crate) mod _struct {
             &self,
             buffer: ArgMemoryBuffer,
             offset: isize,
-            args: Args,
+            args: PosArgs,
             vm: &VirtualMachine,
         ) -> PyResult<()> {
             let offset = get_buffer_offset(buffer.len(), offset, self.size(), true, vm)?;

--- a/vm/src/stdlib/re.rs
+++ b/vm/src/stdlib/re.rs
@@ -11,7 +11,7 @@ use std::ops::Range;
 use crate::
     {builtins::{
     PyInt, PyIntRef, PyStr, PyStrRef, PyTypeRef},
-    function::{Args, OptionalArg},
+    function::{PosArgs, OptionalArg},
     VirtualMachine, IntoPyObject, PyClassImpl, PyObjectRef, PyResult, PyValue, StaticType, TryFromObject};
 
 #[pyclass(module = "re", name = "Pattern")]
@@ -387,7 +387,7 @@ impl PyMatch {
     }
 
     #[pymethod]
-    fn group(&self, groups: Args, vm: &VirtualMachine) -> PyResult {
+    fn group(&self, groups: PosArgs, vm: &VirtualMachine) -> PyResult {
         let mut groups = groups.into_vec();
         match groups.len() {
             0 => Ok(self

--- a/vm/src/stdlib/sre.rs
+++ b/vm/src/stdlib/sre.rs
@@ -9,7 +9,7 @@ mod _sre {
             PyTypeRef,
         },
         common::hash::PyHash,
-        function::{ArgCallable, Args, OptionalArg},
+        function::{ArgCallable, OptionalArg, PosArgs},
         slots::{Comparable, Hashable},
         IntoPyObject, ItemProtocol, PyComparisonValue, PyObjectRef, PyRef, PyResult, PyValue,
         StaticType, TryFromBorrowedObject, TryFromObject, VirtualMachine,
@@ -663,7 +663,7 @@ mod _sre {
         }
 
         #[pymethod]
-        fn group(&self, args: Args<PyObjectRef>, vm: &VirtualMachine) -> PyResult {
+        fn group(&self, args: PosArgs<PyObjectRef>, vm: &VirtualMachine) -> PyResult {
             self.pattern
                 .with_str_drive(self.string.clone(), vm, |str_drive| {
                     let args = args.into_vec();

--- a/vm/src/sysmodule.rs
+++ b/vm/src/sysmodule.rs
@@ -4,7 +4,7 @@ use std::{env, mem, path};
 use crate::builtins::{PyStr, PyStrRef, PyTypeRef};
 use crate::common::hash::{PyHash, PyUHash};
 use crate::frame::FrameRef;
-use crate::function::{Args, FuncArgs, OptionalArg};
+use crate::function::{FuncArgs, OptionalArg, PosArgs};
 use crate::vm::{PySettings, VirtualMachine};
 use crate::{builtins, exceptions, py_io, version};
 use crate::{
@@ -261,7 +261,7 @@ fn sys_displayhook(obj: PyObjectRef, vm: &VirtualMachine) -> PyResult<()> {
     vm.set_attr(&vm.builtins, "_", vm.ctx.none())?;
     // TODO: catch encoding errors
     let repr = vm.to_repr(&obj)?.into_object();
-    builtins::print(Args::new(vec![repr]), Default::default(), vm)?;
+    builtins::print(PosArgs::new(vec![repr]), Default::default(), vm)?;
     vm.set_attr(&vm.builtins, "_", obj)?;
     Ok(())
 }

--- a/wasm/lib/src/js_module.rs
+++ b/wasm/lib/src/js_module.rs
@@ -8,7 +8,7 @@ use wasm_bindgen_futures::{future_to_promise, JsFuture};
 
 use rustpython_vm::builtins::{PyFloatRef, PyStrRef, PyTypeRef};
 use rustpython_vm::exceptions::PyBaseExceptionRef;
-use rustpython_vm::function::{Args, OptionalArg, OptionalOption};
+use rustpython_vm::function::{OptionalArg, OptionalOption, PosArgs};
 use rustpython_vm::slots::PyIter;
 use rustpython_vm::types::create_simple_type;
 use rustpython_vm::VirtualMachine;
@@ -166,7 +166,7 @@ impl PyJsValue {
     #[pymethod]
     fn call(
         &self,
-        args: Args<PyJsValueRef>,
+        args: PosArgs<PyJsValueRef>,
         opts: CallOptions,
         vm: &VirtualMachine,
     ) -> PyResult<PyJsValue> {
@@ -186,7 +186,7 @@ impl PyJsValue {
     fn call_method(
         &self,
         name: JsProperty,
-        args: Args<PyJsValueRef>,
+        args: PosArgs<PyJsValueRef>,
         vm: &VirtualMachine,
     ) -> PyResult<PyJsValue> {
         let js_args = args.iter().map(|x| x.as_ref()).collect::<Array>();
@@ -198,7 +198,7 @@ impl PyJsValue {
     #[pymethod]
     fn construct(
         &self,
-        args: Args<PyJsValueRef>,
+        args: PosArgs<PyJsValueRef>,
         opts: NewObjectOptions,
         vm: &VirtualMachine,
     ) -> PyResult<PyJsValue> {


### PR DESCRIPTION
split from #3104 

`vm::function::Args` needs to be exposed to define functions, but `Args` is too common name.