### PR TITLE
rustpython_vm::protocol to hold protocols

### DIFF
--- a/vm/src/builtins/bytearray.rs
+++ b/vm/src/builtins/bytearray.rs
@@ -6,7 +6,6 @@ use super::pystr::PyStrRef;
 use super::pytype::PyTypeRef;
 use super::tuple::PyTupleRef;
 use crate::anystr::{self, AnyStr};
-use crate::buffer::{BufferOptions, PyBuffer, PyBufferInternal, ResizeGuard};
 use crate::bytesinner::{
     bytes_decode, bytes_from_object, value_from_object, ByteInnerFindOptions, ByteInnerNewOptions,
     ByteInnerPaddingOptions, ByteInnerSplitOptions, ByteInnerTranslateOptions, DecodeArgs,
@@ -19,6 +18,7 @@ use crate::common::lock::{
     PyRwLockWriteGuard,
 };
 use crate::function::{ArgIterable, FuncArgs, OptionalArg, OptionalOption};
+use crate::protocol::{BufferInternal, BufferOptions, PyBuffer, ResizeGuard};
 use crate::sliceable::{PySliceableSequence, PySliceableSequenceMut, SequenceIndex};
 use crate::slots::{
     AsBuffer, Callable, Comparable, Hashable, Iterable, IteratorIterable, PyComparisonOp, PyIter,
@@ -685,7 +685,7 @@ impl AsBuffer for PyByteArray {
     }
 }
 
-impl PyBufferInternal for PyRef<PyByteArray> {
+impl BufferInternal for PyRef<PyByteArray> {
     fn obj_bytes(&self) -> BorrowedValue<[u8]> {
         self.borrow_buf().into()
     }

--- a/vm/src/builtins/bytes.rs
+++ b/vm/src/builtins/bytes.rs
@@ -3,7 +3,6 @@ use super::int::PyIntRef;
 use super::pystr::PyStrRef;
 use super::pytype::PyTypeRef;
 use crate::anystr::{self, AnyStr};
-use crate::buffer::{BufferOptions, PyBuffer, PyBufferInternal};
 use crate::builtins::tuple::PyTupleRef;
 use crate::bytesinner::{
     bytes_decode, ByteInnerFindOptions, ByteInnerNewOptions, ByteInnerPaddingOptions,
@@ -12,6 +11,7 @@ use crate::bytesinner::{
 use crate::byteslike::ArgBytesLike;
 use crate::common::hash::PyHash;
 use crate::function::{ArgIterable, OptionalArg, OptionalOption};
+use crate::protocol::{BufferInternal, BufferOptions, PyBuffer};
 use crate::slots::{
     AsBuffer, Callable, Comparable, Hashable, Iterable, IteratorIterable, PyComparisonOp, PyIter,
     SlotConstructor,
@@ -533,7 +533,7 @@ impl AsBuffer for PyBytes {
     }
 }
 
-impl PyBufferInternal for PyRef<PyBytes> {
+impl BufferInternal for PyRef<PyBytes> {
     fn obj_bytes(&self) -> BorrowedValue<[u8]> {
         self.as_bytes().into()
     }

--- a/vm/src/builtins/memory.rs
+++ b/vm/src/builtins/memory.rs
@@ -1,4 +1,3 @@
-use crate::buffer::{BufferOptions, PyBuffer, PyBufferInternal};
 use crate::builtins::slice::PySliceRef;
 use crate::builtins::{PyBytes, PyBytesRef, PyList, PyListRef, PyStr, PyStrRef, PyTypeRef};
 use crate::bytesinner::bytes_to_hex;
@@ -9,6 +8,7 @@ use crate::common::{
     rc::PyRc,
 };
 use crate::function::{FuncArgs, OptionalArg};
+use crate::protocol::{BufferInternal, BufferOptions, PyBuffer};
 use crate::sliceable::{convert_slice, wrap_index, SequenceIndex};
 use crate::slots::{AsBuffer, Comparable, Hashable, PyComparisonOp, SlotConstructor};
 use crate::stdlib::pystruct::_struct::FormatSpec;
@@ -692,7 +692,7 @@ impl AsBuffer for PyMemoryView {
 
 #[derive(Debug)]
 struct Released;
-impl PyBufferInternal for Released {
+impl BufferInternal for Released {
     fn obj_bytes(&self) -> BorrowedValue<[u8]> {
         panic!();
     }
@@ -706,7 +706,7 @@ impl PyBufferInternal for Released {
     fn retain(&self) {}
 }
 
-impl PyBufferInternal for PyMemoryView {
+impl BufferInternal for PyMemoryView {
     // NOTE: This impl maybe is anti-pattern. Only used for internal usage.
     fn obj_bytes(&self) -> BorrowedValue<[u8]> {
         BorrowedValue::map(self.buffer.internal.obj_bytes(), |x| {
@@ -725,7 +725,7 @@ impl PyBufferInternal for PyMemoryView {
     fn retain(&self) {}
 }
 
-impl PyBufferInternal for PyRef<PyMemoryView> {
+impl BufferInternal for PyRef<PyMemoryView> {
     fn obj_bytes(&self) -> BorrowedValue<[u8]> {
         self.deref().obj_bytes()
     }

--- a/vm/src/byteslike.rs
+++ b/vm/src/byteslike.rs
@@ -1,6 +1,6 @@
-use crate::buffer::PyBuffer;
 use crate::builtins::PyStrRef;
 use crate::common::borrow::{BorrowedValue, BorrowedValueMut};
+use crate::protocol::PyBuffer;
 use crate::vm::VirtualMachine;
 use crate::{PyObjectRef, PyResult, TryFromBorrowedObject, TryFromObject};
 

--- a/vm/src/cformat.rs
+++ b/vm/src/cformat.rs
@@ -1,9 +1,9 @@
 //! Implementation of Printf-Style string formatting
 //! [https://docs.python.org/3/library/stdtypes.html#printf-style-string-formatting]
 
-use crate::buffer::PyBuffer;
 use crate::builtins::{int, try_f64_to_bigint, tuple, IntoPyFloat, PyBytes, PyFloat, PyInt, PyStr};
 use crate::common::float_ops;
+use crate::protocol::PyBuffer;
 use crate::{
     ItemProtocol, PyObjectRef, PyResult, TryFromBorrowedObject, TryFromObject, TypeProtocol,
     VirtualMachine,

--- a/vm/src/lib.rs
+++ b/vm/src/lib.rs
@@ -43,7 +43,6 @@ pub use rustpython_derive::*;
 pub mod macros;
 
 mod anystr;
-mod buffer;
 pub mod builtins;
 mod bytesinner;
 pub mod byteslike;
@@ -62,6 +61,7 @@ mod frozen;
 pub mod function;
 pub mod import;
 pub mod iterator;
+mod protocol;
 pub mod py_io;
 pub mod py_serde;
 mod pyobject;

--- a/vm/src/protocol/buffer.rs
+++ b/vm/src/protocol/buffer.rs
@@ -6,7 +6,7 @@ use crate::PyThreadingConstraint;
 use crate::{PyObjectRef, PyResult, TryFromBorrowedObject, TypeProtocol, VirtualMachine};
 use std::{borrow::Cow, fmt::Debug};
 
-pub trait PyBufferInternal: Debug + PyThreadingConstraint {
+pub trait BufferInternal: Debug + PyThreadingConstraint {
     /// Get the full inner buffer of this memory. You probably want [`as_contiguous()`], as
     /// `obj_bytes` doesn't take into account the range a memoryview might operate on, among other
     /// footguns.
@@ -24,13 +24,13 @@ pub trait PyBufferInternal: Debug + PyThreadingConstraint {
 pub struct PyBuffer {
     pub obj: PyObjectRef,
     pub options: BufferOptions,
-    pub(crate) internal: PyRc<dyn PyBufferInternal>,
+    pub(crate) internal: PyRc<dyn BufferInternal>,
 }
 
 impl PyBuffer {
     pub fn new(
         obj: PyObjectRef,
-        buffer: impl PyBufferInternal + 'static,
+        buffer: impl BufferInternal + 'static,
         options: BufferOptions,
     ) -> Self {
         buffer.retain();
@@ -119,7 +119,7 @@ impl TryFromBorrowedObject for PyBuffer {
 }
 
 // What we actually want to implement is:
-// impl<T> Drop for T where T: PyBufferInternal
+// impl<T> Drop for T where T: BufferInternal
 // but it is not supported by Rust
 impl Drop for PyBuffer {
     fn drop(&mut self) {

--- a/vm/src/protocol/mod.rs
+++ b/vm/src/protocol/mod.rs
@@ -1,0 +1,3 @@
+mod buffer;
+
+pub(crate) use buffer::{BufferInternal, BufferOptions, PyBuffer, ResizeGuard};

--- a/vm/src/slots.rs
+++ b/vm/src/slots.rs
@@ -1,8 +1,8 @@
-use crate::buffer::PyBuffer;
 use crate::builtins::{PyStrRef, PyTypeRef};
 use crate::common::hash::PyHash;
 use crate::common::lock::PyRwLock;
 use crate::function::{FromArgs, FuncArgs, OptionalArg};
+use crate::protocol::PyBuffer;
 use crate::utils::Either;
 use crate::VirtualMachine;
 use crate::{

--- a/vm/src/stdlib/array.rs
+++ b/vm/src/stdlib/array.rs
@@ -11,13 +11,13 @@ mod array {
         str::wchar_t,
     };
     use crate::{
-        buffer::{BufferOptions, PyBuffer, PyBufferInternal, ResizeGuard},
         builtins::{
             IntoPyFloat, PyByteArray, PyBytes, PyBytesRef, PyIntRef, PyList, PyListRef, PySliceRef,
             PyStr, PyStrRef, PyTypeRef,
         },
         byteslike::ArgBytesLike,
         function::{ArgIterable, OptionalArg},
+        protocol::{BufferInternal, BufferOptions, PyBuffer, ResizeGuard},
         sliceable::{saturate_index, PySliceableSequence, PySliceableSequenceMut, SequenceIndex},
         slots::{
             AsBuffer, Comparable, Iterable, IteratorIterable, PyComparisonOp, PyIter,
@@ -1140,7 +1140,7 @@ mod array {
         }
     }
 
-    impl PyBufferInternal for PyRef<PyArray> {
+    impl BufferInternal for PyRef<PyArray> {
         fn obj_bytes(&self) -> BorrowedValue<[u8]> {
             self.get_bytes().into()
         }

--- a/vm/src/stdlib/io.rs
+++ b/vm/src/stdlib/io.rs
@@ -74,7 +74,6 @@ mod _io {
     use std::io::{self, prelude::*, Cursor, SeekFrom};
     use std::ops::Range;
 
-    use crate::buffer::{BufferOptions, PyBuffer, PyBufferInternal, ResizeGuard};
     use crate::builtins::memory::PyMemoryView;
     use crate::builtins::{
         bytes::{PyBytes, PyBytesRef},
@@ -89,6 +88,7 @@ mod _io {
     use crate::common::rc::PyRc;
     use crate::exceptions::{self, PyBaseExceptionRef};
     use crate::function::{ArgIterable, FuncArgs, OptionalArg, OptionalOption};
+    use crate::protocol::{BufferInternal, BufferOptions, PyBuffer, ResizeGuard};
     use crate::slots::{Iterable, PyIter, SlotConstructor};
     use crate::utils::Either;
     use crate::vm::{ReprGuard, VirtualMachine};
@@ -1325,7 +1325,7 @@ mod _io {
         data: PyMutex<Vec<u8>>,
         range: Range<usize>,
     }
-    impl PyBufferInternal for BufferedRawBuffer {
+    impl BufferInternal for BufferedRawBuffer {
         fn obj_bytes(&self) -> BorrowedValue<[u8]> {
             BorrowedValue::map(self.data.lock().into(), |data| &data[self.range.clone()])
         }
@@ -3326,7 +3326,7 @@ mod _io {
         }
     }
 
-    impl PyBufferInternal for PyRef<BytesIO> {
+    impl BufferInternal for PyRef<BytesIO> {
         fn obj_bytes(&self) -> BorrowedValue<[u8]> {
             PyRwLockReadGuard::map(self.buffer.read(), |x| x.cursor.get_ref().as_slice()).into()
         }

--- a/vm/src/stdlib/os.rs
+++ b/vm/src/stdlib/os.rs
@@ -1,10 +1,10 @@
 use super::errno::errors;
 use crate::crt_fd::Fd;
 use crate::{
-    buffer::PyBuffer,
     builtins::{int, PyBytes, PyBytesRef, PySet, PyStr, PyStrRef},
     exceptions::{IntoPyException, PyBaseExceptionRef},
     function::{ArgumentError, FromArgs, FuncArgs},
+    protocol::PyBuffer,
     IntoPyObject, PyObjectRef, PyResult, PyValue, TryFromBorrowedObject, TryFromObject,
     TypeProtocol, VirtualMachine,
 };

--- a/vm/src/stdlib/sre.rs
+++ b/vm/src/stdlib/sre.rs
@@ -3,12 +3,12 @@ pub(crate) use _sre::make_module;
 #[pymodule]
 mod _sre {
     use crate::{
-        buffer::PyBuffer,
         builtins::{
             PyCallableIterator, PyDictRef, PyInt, PyList, PyListRef, PyStr, PyStrRef, PyTupleRef,
         },
         common::hash::PyHash,
         function::{ArgCallable, OptionalArg, PosArgs},
+        protocol::PyBuffer,
         slots::{Comparable, Hashable},
         IntoPyObject, ItemProtocol, PyComparisonValue, PyObjectRef, PyRef, PyResult, PyValue,
         TryFromBorrowedObject, TryFromObject, VirtualMachine,

--- a/vm/src/stdlib/winreg.rs
+++ b/vm/src/stdlib/winreg.rs
@@ -2,9 +2,8 @@
 
 use crate::common::lock::{PyRwLock, PyRwLockReadGuard, PyRwLockWriteGuard};
 use crate::{
-    builtins::{PyStrRef, PyTypeRef},
-    exceptions::IntoPyException,
-    PyClassImpl, PyObjectRef, PyRef, PyResult, PyValue, TryFromObject, VirtualMachine,
+    builtins::PyStrRef, exceptions::IntoPyException, PyClassImpl, PyObjectRef, PyRef, PyResult,
+    PyValue, TryFromObject, VirtualMachine,
 };
 use std::convert::TryInto;
 use std::ffi::OsStr;


### PR DESCRIPTION
I also renamed `PyBufferInternal` to `BufferInternal` because it is not a CPython type or concept.

replacement of similar work in #3104