### PR TITLE
PyIter protocol object

### DIFF
--- a/vm/src/builtins/asyncgenerator.rs
+++ b/vm/src/builtins/asyncgenerator.rs
@@ -4,7 +4,7 @@ use crate::{
     coroutine::{Coro, Variant},
     frame::FrameRef,
     function::OptionalArg,
-    slots::{IteratorIterable, PyIter},
+    slots::{IteratorIterable, SlotIterator},
     IdProtocol, PyClassImpl, PyContext, PyObjectRef, PyRef, PyResult, PyValue, TypeProtocol,
     VirtualMachine,
 };
@@ -182,7 +182,7 @@ impl PyValue for PyAsyncGenASend {
     }
 }
 
-#[pyimpl(with(PyIter))]
+#[pyimpl(with(SlotIterator))]
 impl PyAsyncGenASend {
     #[pymethod(name = "__await__")]
     fn r#await(zelf: PyRef<Self>, _vm: &VirtualMachine) -> PyRef<Self> {
@@ -255,7 +255,7 @@ impl PyAsyncGenASend {
 }
 
 impl IteratorIterable for PyAsyncGenASend {}
-impl PyIter for PyAsyncGenASend {
+impl SlotIterator for PyAsyncGenASend {
     fn next(zelf: &PyRef<Self>, vm: &VirtualMachine) -> PyResult {
         zelf.send(vm.ctx.none(), vm)
     }
@@ -276,7 +276,7 @@ impl PyValue for PyAsyncGenAThrow {
     }
 }
 
-#[pyimpl(with(PyIter))]
+#[pyimpl(with(SlotIterator))]
 impl PyAsyncGenAThrow {
     #[pymethod(name = "__await__")]
     fn r#await(zelf: PyRef<Self>, _vm: &VirtualMachine) -> PyRef<Self> {
@@ -397,7 +397,7 @@ impl PyAsyncGenAThrow {
 }
 
 impl IteratorIterable for PyAsyncGenAThrow {}
-impl PyIter for PyAsyncGenAThrow {
+impl SlotIterator for PyAsyncGenAThrow {
     fn next(zelf: &PyRef<Self>, vm: &VirtualMachine) -> PyResult {
         zelf.send(vm.ctx.none(), vm)
     }

--- a/vm/src/builtins/bytearray.rs
+++ b/vm/src/builtins/bytearray.rs
@@ -19,7 +19,7 @@ use crate::{
     sliceable::{PySliceableSequence, PySliceableSequenceMut, SequenceIndex},
     slots::{
         AsBuffer, Callable, Comparable, Hashable, Iterable, IteratorIterable, PyComparisonOp,
-        PyIter, Unhashable,
+        SlotIterator, Unhashable,
     },
     utils::Either,
     IdProtocol, IntoPyObject, PyClassDef, PyClassImpl, PyComparisonValue, PyContext, PyObjectRef,
@@ -741,10 +741,10 @@ impl PyValue for PyByteArrayIterator {
     }
 }
 
-#[pyimpl(with(PyIter))]
+#[pyimpl(with(SlotIterator))]
 impl PyByteArrayIterator {}
 impl IteratorIterable for PyByteArrayIterator {}
-impl PyIter for PyByteArrayIterator {
+impl SlotIterator for PyByteArrayIterator {
     fn next(zelf: &PyRef<Self>, vm: &VirtualMachine) -> PyResult {
         let pos = zelf.position.fetch_add(1);
         if let Some(&ret) = zelf.bytearray.borrow_buf().get(pos) {

--- a/vm/src/builtins/bytes.rs
+++ b/vm/src/builtins/bytes.rs
@@ -10,7 +10,7 @@ use crate::{
     protocol::{BufferInternal, BufferOptions, PyBuffer},
     slots::{
         AsBuffer, Callable, Comparable, Hashable, Iterable, IteratorIterable, PyComparisonOp,
-        PyIter, SlotConstructor,
+        SlotConstructor, SlotIterator,
     },
     utils::Either,
     IdProtocol, IntoPyObject, IntoPyResult, PyClassImpl, PyComparisonValue, PyContext, PyObjectRef,
@@ -594,10 +594,10 @@ impl PyValue for PyBytesIterator {
     }
 }
 
-#[pyimpl(with(PyIter))]
+#[pyimpl(with(SlotIterator))]
 impl PyBytesIterator {}
 impl IteratorIterable for PyBytesIterator {}
-impl PyIter for PyBytesIterator {
+impl SlotIterator for PyBytesIterator {
     fn next(zelf: &PyRef<Self>, vm: &VirtualMachine) -> PyResult {
         let pos = zelf.position.fetch_add(1);
         if let Some(&ret) = zelf.bytes.as_bytes().get(pos) {

--- a/vm/src/builtins/coroutine.rs
+++ b/vm/src/builtins/coroutine.rs
@@ -3,7 +3,7 @@ use crate::{
     coroutine::{Coro, Variant},
     frame::FrameRef,
     function::OptionalArg,
-    slots::{IteratorIterable, PyIter},
+    slots::{IteratorIterable, SlotIterator},
     IdProtocol, PyClassImpl, PyContext, PyObjectRef, PyRef, PyResult, PyValue, VirtualMachine,
 };
 
@@ -19,7 +19,7 @@ impl PyValue for PyCoroutine {
     }
 }
 
-#[pyimpl(with(PyIter))]
+#[pyimpl(with(SlotIterator))]
 impl PyCoroutine {
     pub fn as_coro(&self) -> &Coro {
         &self.inner
@@ -102,7 +102,7 @@ impl PyCoroutine {
 }
 
 impl IteratorIterable for PyCoroutine {}
-impl PyIter for PyCoroutine {
+impl SlotIterator for PyCoroutine {
     fn next(zelf: &PyRef<Self>, vm: &VirtualMachine) -> PyResult {
         zelf.send(vm.ctx.none(), vm)
     }
@@ -120,7 +120,7 @@ impl PyValue for PyCoroutineWrapper {
     }
 }
 
-#[pyimpl(with(PyIter))]
+#[pyimpl(with(SlotIterator))]
 impl PyCoroutineWrapper {
     #[pymethod]
     fn send(&self, val: PyObjectRef, vm: &VirtualMachine) -> PyResult {
@@ -140,7 +140,7 @@ impl PyCoroutineWrapper {
 }
 
 impl IteratorIterable for PyCoroutineWrapper {}
-impl PyIter for PyCoroutineWrapper {
+impl SlotIterator for PyCoroutineWrapper {
     fn next(zelf: &PyRef<Self>, vm: &VirtualMachine) -> PyResult {
         zelf.send(vm.ctx.none(), vm)
     }

--- a/vm/src/builtins/dict.rs
+++ b/vm/src/builtins/dict.rs
@@ -85,13 +85,13 @@ impl PyDict {
                     return Err(vm.new_runtime_error("dict mutated during update".to_owned()));
                 }
             } else if let Some(keys) = vm.get_method(dict_obj.clone(), "keys") {
-                let keys = iterator::get_iter(vm, vm.invoke(&keys?, ())?)?;
+                let keys = vm.invoke(&keys?, ())?.get_iter(vm)?;
                 while let Some(key) = iterator::get_next_object(vm, &keys)? {
                     let val = dict_obj.get_item(key.clone(), vm)?;
                     dict.insert(vm, key, val)?;
                 }
             } else {
-                let iter = iterator::get_iter(vm, dict_obj)?;
+                let iter = dict_obj.get_iter(vm)?;
                 loop {
                     fn err(vm: &VirtualMachine) -> PyBaseExceptionRef {
                         vm.new_value_error("Iterator must have exactly two elements".to_owned())
@@ -100,7 +100,7 @@ impl PyDict {
                         Some(obj) => obj,
                         None => break,
                     };
-                    let elem_iter = iterator::get_iter(vm, element)?;
+                    let elem_iter = element.get_iter(vm)?;
                     let key = iterator::get_next_object(vm, &elem_iter)?.ok_or_else(|| err(vm))?;
                     let value =
                         iterator::get_next_object(vm, &elem_iter)?.ok_or_else(|| err(vm))?;

--- a/vm/src/builtins/dict.rs
+++ b/vm/src/builtins/dict.rs
@@ -5,7 +5,9 @@ use crate::{
     dictdatatype::{self, DictKey},
     function::{ArgIterable, FuncArgs, KwArgs, OptionalArg},
     iterator,
-    slots::{Comparable, Hashable, Iterable, IteratorIterable, PyComparisonOp, PyIter, Unhashable},
+    slots::{
+        Comparable, Hashable, Iterable, IteratorIterable, PyComparisonOp, SlotIterator, Unhashable,
+    },
     vm::{ReprGuard, VirtualMachine},
     IdProtocol, IntoPyObject, ItemProtocol,
     PyArithmaticValue::*,
@@ -708,7 +710,7 @@ macro_rules! dict_iterator {
             }
         }
 
-        #[pyimpl(with(PyIter))]
+        #[pyimpl(with(SlotIterator))]
         impl $iter_name {
             fn new(dict: PyDictRef) -> Self {
                 $iter_name {
@@ -730,7 +732,7 @@ macro_rules! dict_iterator {
         }
 
         impl IteratorIterable for $iter_name {}
-        impl PyIter for $iter_name {
+        impl SlotIterator for $iter_name {
             #[allow(clippy::redundant_closure_call)]
             fn next(zelf: &PyRef<Self>, vm: &VirtualMachine) -> PyResult {
                 match zelf.status.load() {
@@ -769,7 +771,7 @@ macro_rules! dict_iterator {
             }
         }
 
-        #[pyimpl(with(PyIter))]
+        #[pyimpl(with(SlotIterator))]
         impl $reverse_iter_name {
             fn new(dict: PyDictRef) -> Self {
                 $reverse_iter_name {
@@ -791,7 +793,7 @@ macro_rules! dict_iterator {
         }
 
         impl IteratorIterable for $reverse_iter_name {}
-        impl PyIter for $reverse_iter_name {
+        impl SlotIterator for $reverse_iter_name {
             #[allow(clippy::redundant_closure_call)]
             fn next(zelf: &PyRef<Self>, vm: &VirtualMachine) -> PyResult {
                 match zelf.status.load() {

--- a/vm/src/builtins/enumerate.rs
+++ b/vm/src/builtins/enumerate.rs
@@ -6,7 +6,7 @@ use super::{
 use crate::common::lock::PyRwLock;
 use crate::{
     function::OptionalArg,
-    iterator,
+    protocol::PyIter,
     slots::{IteratorIterable, SlotConstructor, SlotIterator},
     IntoPyObject, ItemProtocol, PyClassImpl, PyContext, PyObjectRef, PyRef, PyResult, PyValue,
     TypeProtocol, VirtualMachine,
@@ -19,7 +19,7 @@ use num_traits::Zero;
 #[derive(Debug)]
 pub struct PyEnumerate {
     counter: PyRwLock<BigInt>,
-    iterator: PyObjectRef,
+    iterator: PyIter,
 }
 
 impl PyValue for PyEnumerate {
@@ -30,7 +30,7 @@ impl PyValue for PyEnumerate {
 
 #[derive(FromArgs)]
 pub struct EnumerateArgs {
-    iterable: PyObjectRef,
+    iterator: PyIter,
     #[pyarg(any, optional)]
     start: OptionalArg<PyIntRef>,
 }
@@ -38,11 +38,12 @@ pub struct EnumerateArgs {
 impl SlotConstructor for PyEnumerate {
     type Args = EnumerateArgs;
 
-    fn py_new(cls: PyTypeRef, args: Self::Args, vm: &VirtualMachine) -> PyResult {
-        let counter = args
-            .start
-            .map_or_else(BigInt::zero, |start| start.as_bigint().clone());
-        let iterator = iterator::get_iter(vm, args.iterable)?;
+    fn py_new(
+        cls: PyTypeRef,
+        Self::Args { iterator, start }: Self::Args,
+        vm: &VirtualMachine,
+    ) -> PyResult {
+        let counter = start.map_or_else(BigInt::zero, |start| start.as_bigint().clone());
         PyEnumerate {
             counter: PyRwLock::new(counter),
             iterator,
@@ -57,7 +58,7 @@ impl PyEnumerate {}
 impl IteratorIterable for PyEnumerate {}
 impl SlotIterator for PyEnumerate {
     fn next(zelf: &PyRef<Self>, vm: &VirtualMachine) -> PyResult {
-        let next_obj = iterator::call_next(vm, &zelf.iterator)?;
+        let next_obj = zelf.iterator.next(vm)?;
         let mut counter = zelf.counter.write();
         let position = counter.clone();
         *counter += 1;

--- a/vm/src/builtins/enumerate.rs
+++ b/vm/src/builtins/enumerate.rs
@@ -7,7 +7,7 @@ use crate::common::lock::PyRwLock;
 use crate::{
     function::OptionalArg,
     iterator,
-    slots::{IteratorIterable, PyIter, SlotConstructor},
+    slots::{IteratorIterable, SlotConstructor, SlotIterator},
     IntoPyObject, ItemProtocol, PyClassImpl, PyContext, PyObjectRef, PyRef, PyResult, PyValue,
     TypeProtocol, VirtualMachine,
 };
@@ -51,11 +51,11 @@ impl SlotConstructor for PyEnumerate {
     }
 }
 
-#[pyimpl(with(PyIter, SlotConstructor), flags(BASETYPE))]
+#[pyimpl(with(SlotIterator, SlotConstructor), flags(BASETYPE))]
 impl PyEnumerate {}
 
 impl IteratorIterable for PyEnumerate {}
-impl PyIter for PyEnumerate {
+impl SlotIterator for PyEnumerate {
     fn next(zelf: &PyRef<Self>, vm: &VirtualMachine) -> PyResult {
         let next_obj = iterator::call_next(vm, &zelf.iterator)?;
         let mut counter = zelf.counter.write();
@@ -79,7 +79,7 @@ impl PyValue for PyReverseSequenceIterator {
     }
 }
 
-#[pyimpl(with(PyIter))]
+#[pyimpl(with(SlotIterator))]
 impl PyReverseSequenceIterator {
     pub fn new(obj: PyObjectRef, len: usize) -> Self {
         Self {
@@ -137,7 +137,7 @@ impl PyReverseSequenceIterator {
 }
 
 impl IteratorIterable for PyReverseSequenceIterator {}
-impl PyIter for PyReverseSequenceIterator {
+impl SlotIterator for PyReverseSequenceIterator {
     fn next(zelf: &PyRef<Self>, vm: &VirtualMachine) -> PyResult {
         if let Exhausted = zelf.status.load() {
             return Err(vm.new_stop_iteration());

--- a/vm/src/builtins/filter.rs
+++ b/vm/src/builtins/filter.rs
@@ -1,7 +1,7 @@
 use super::PyTypeRef;
 use crate::{
     iterator,
-    slots::{IteratorIterable, PyIter, SlotConstructor},
+    slots::{IteratorIterable, SlotConstructor, SlotIterator},
     PyClassImpl, PyContext, PyObjectRef, PyRef, PyResult, PyValue, VirtualMachine,
 };
 
@@ -48,11 +48,11 @@ impl SlotConstructor for PyFilter {
     }
 }
 
-#[pyimpl(with(PyIter, SlotConstructor), flags(BASETYPE))]
+#[pyimpl(with(SlotIterator, SlotConstructor), flags(BASETYPE))]
 impl PyFilter {}
 
 impl IteratorIterable for PyFilter {}
-impl PyIter for PyFilter {
+impl SlotIterator for PyFilter {
     fn next(zelf: &PyRef<Self>, vm: &VirtualMachine) -> PyResult {
         let predicate = &zelf.predicate;
         let iterator = &zelf.iterator;

--- a/vm/src/builtins/generator.rs
+++ b/vm/src/builtins/generator.rs
@@ -7,7 +7,7 @@ use crate::{
     coroutine::{Coro, Variant},
     frame::FrameRef,
     function::OptionalArg,
-    slots::{IteratorIterable, PyIter},
+    slots::{IteratorIterable, SlotIterator},
     IdProtocol, PyClassImpl, PyContext, PyObjectRef, PyRef, PyResult, PyValue, VirtualMachine,
 };
 
@@ -23,7 +23,7 @@ impl PyValue for PyGenerator {
     }
 }
 
-#[pyimpl(with(PyIter))]
+#[pyimpl(with(SlotIterator))]
 impl PyGenerator {
     pub fn as_coro(&self) -> &Coro {
         &self.inner
@@ -95,7 +95,7 @@ impl PyGenerator {
 }
 
 impl IteratorIterable for PyGenerator {}
-impl PyIter for PyGenerator {
+impl SlotIterator for PyGenerator {
     fn next(zelf: &PyRef<Self>, vm: &VirtualMachine) -> PyResult {
         zelf.send(vm.ctx.none(), vm)
     }

--- a/vm/src/builtins/iter.rs
+++ b/vm/src/builtins/iter.rs
@@ -5,7 +5,7 @@
 use super::{int, PyInt, PyTypeRef};
 use crate::{
     function::ArgCallable,
-    slots::{IteratorIterable, PyIter},
+    slots::{IteratorIterable, SlotIterator},
     ItemProtocol, PyClassImpl, PyContext, PyObjectRef, PyRef, PyResult, PyValue, TypeProtocol,
     VirtualMachine,
 };
@@ -34,7 +34,7 @@ impl PyValue for PySequenceIterator {
     }
 }
 
-#[pyimpl(with(PyIter))]
+#[pyimpl(with(SlotIterator))]
 impl PySequenceIterator {
     pub fn new(obj: PyObjectRef) -> Self {
         Self {
@@ -91,7 +91,7 @@ impl PySequenceIterator {
 }
 
 impl IteratorIterable for PySequenceIterator {}
-impl PyIter for PySequenceIterator {
+impl SlotIterator for PySequenceIterator {
     fn next(zelf: &PyRef<Self>, vm: &VirtualMachine) -> PyResult {
         if let IterStatus::Exhausted = zelf.status.load() {
             return Err(vm.new_stop_iteration());
@@ -122,7 +122,7 @@ impl PyValue for PyCallableIterator {
     }
 }
 
-#[pyimpl(with(PyIter))]
+#[pyimpl(with(SlotIterator))]
 impl PyCallableIterator {
     pub fn new(callable: ArgCallable, sentinel: PyObjectRef) -> Self {
         Self {
@@ -134,7 +134,7 @@ impl PyCallableIterator {
 }
 
 impl IteratorIterable for PyCallableIterator {}
-impl PyIter for PyCallableIterator {
+impl SlotIterator for PyCallableIterator {
     fn next(zelf: &PyRef<Self>, vm: &VirtualMachine) -> PyResult {
         if let IterStatus::Exhausted = zelf.status.load() {
             return Err(vm.new_stop_iteration());

--- a/vm/src/builtins/list.rs
+++ b/vm/src/builtins/list.rs
@@ -10,7 +10,9 @@ use crate::{
     function::{ArgIterable, FuncArgs, OptionalArg},
     sequence::{self, SimpleSeq},
     sliceable::{PySliceableSequence, PySliceableSequenceMut, SequenceIndex},
-    slots::{Comparable, Hashable, Iterable, IteratorIterable, PyComparisonOp, PyIter, Unhashable},
+    slots::{
+        Comparable, Hashable, Iterable, IteratorIterable, PyComparisonOp, SlotIterator, Unhashable,
+    },
     utils::Either,
     vm::{ReprGuard, VirtualMachine},
     PyClassDef, PyClassImpl, PyComparisonValue, PyContext, PyObjectRef, PyRef, PyResult, PyValue,
@@ -484,7 +486,7 @@ impl PyValue for PyListIterator {
     }
 }
 
-#[pyimpl(with(PyIter))]
+#[pyimpl(with(SlotIterator))]
 impl PyListIterator {
     #[pymethod(magic)]
     fn length_hint(&self) -> usize {
@@ -521,7 +523,7 @@ impl PyListIterator {
 }
 
 impl IteratorIterable for PyListIterator {}
-impl PyIter for PyListIterator {
+impl SlotIterator for PyListIterator {
     fn next(zelf: &PyRef<Self>, vm: &VirtualMachine) -> PyResult {
         if let Exhausted = zelf.status.load() {
             return Err(vm.new_stop_iteration());
@@ -551,7 +553,7 @@ impl PyValue for PyListReverseIterator {
     }
 }
 
-#[pyimpl(with(PyIter))]
+#[pyimpl(with(SlotIterator))]
 impl PyListReverseIterator {
     #[pymethod(magic)]
     fn length_hint(&self) -> usize {
@@ -595,7 +597,7 @@ impl PyListReverseIterator {
 }
 
 impl IteratorIterable for PyListReverseIterator {}
-impl PyIter for PyListReverseIterator {
+impl SlotIterator for PyListReverseIterator {
     fn next(zelf: &PyRef<Self>, vm: &VirtualMachine) -> PyResult {
         if let Exhausted = zelf.status.load() {
             return Err(vm.new_stop_iteration());

--- a/vm/src/builtins/map.rs
+++ b/vm/src/builtins/map.rs
@@ -2,7 +2,7 @@ use super::PyTypeRef;
 use crate::{
     function::PosArgs,
     iterator,
-    slots::{IteratorIterable, PyIter, SlotConstructor},
+    slots::{IteratorIterable, SlotConstructor, SlotIterator},
     PyClassImpl, PyContext, PyObjectRef, PyRef, PyResult, PyValue, VirtualMachine,
 };
 
@@ -39,7 +39,7 @@ impl SlotConstructor for PyMap {
     }
 }
 
-#[pyimpl(with(PyIter, SlotConstructor), flags(BASETYPE))]
+#[pyimpl(with(SlotIterator, SlotConstructor), flags(BASETYPE))]
 impl PyMap {
     #[pymethod(magic)]
     fn length_hint(&self, vm: &VirtualMachine) -> PyResult<usize> {
@@ -52,7 +52,7 @@ impl PyMap {
 }
 
 impl IteratorIterable for PyMap {}
-impl PyIter for PyMap {
+impl SlotIterator for PyMap {
     fn next(zelf: &PyRef<Self>, vm: &VirtualMachine) -> PyResult {
         let next_objs = zelf
             .iterators

--- a/vm/src/builtins/mappingproxy.rs
+++ b/vm/src/builtins/mappingproxy.rs
@@ -1,7 +1,6 @@
 use super::{PyDict, PyStrRef, PyTypeRef};
 use crate::{
     function::OptionalArg,
-    iterator,
     slots::{Iterable, SlotConstructor},
     IntoPyObject, ItemProtocol, PyClassImpl, PyContext, PyObjectRef, PyRef, PyResult, PyValue,
     TryFromObject, VirtualMachine,
@@ -137,7 +136,8 @@ impl Iterable for PyMappingProxy {
                 PyDict::from_attributes(c.attributes.read().clone(), vm)?.into_pyobject(vm)
             }
         };
-        iterator::get_iter(vm, obj)
+        let iter = obj.get_iter(vm)?;
+        Ok(iter.into_object())
     }
 }
 

--- a/vm/src/builtins/pystr.rs
+++ b/vm/src/builtins/pystr.rs
@@ -10,7 +10,8 @@ use crate::{
     function::{ArgIterable, FuncArgs, OptionalArg, OptionalOption},
     sliceable::PySliceableSequence,
     slots::{
-        Comparable, Hashable, Iterable, IteratorIterable, PyComparisonOp, PyIter, SlotConstructor,
+        Comparable, Hashable, Iterable, IteratorIterable, PyComparisonOp, SlotConstructor,
+        SlotIterator,
     },
     utils::Either,
     IdProtocol, IntoPyObject, ItemProtocol, PyClassDef, PyClassImpl, PyComparisonValue, PyContext,
@@ -179,7 +180,7 @@ impl PyValue for PyStrIterator {
     }
 }
 
-#[pyimpl(with(PyIter))]
+#[pyimpl(with(SlotIterator))]
 impl PyStrIterator {
     #[pymethod(magic)]
     fn length_hint(&self) -> usize {
@@ -228,7 +229,7 @@ impl PyStrIterator {
 }
 
 impl IteratorIterable for PyStrIterator {}
-impl PyIter for PyStrIterator {
+impl SlotIterator for PyStrIterator {
     fn next(zelf: &PyRef<Self>, vm: &VirtualMachine) -> PyResult {
         if let Exhausted = zelf.status.load() {
             return Err(vm.new_stop_iteration());

--- a/vm/src/builtins/range.rs
+++ b/vm/src/builtins/range.rs
@@ -3,7 +3,7 @@ use crate::common::hash::PyHash;
 use crate::{
     function::{FuncArgs, OptionalArg},
     iterator,
-    slots::{Comparable, Hashable, Iterable, IteratorIterable, PyComparisonOp, PyIter},
+    slots::{Comparable, Hashable, Iterable, IteratorIterable, PyComparisonOp, SlotIterator},
     IdProtocol, IntoPyRef, PyClassImpl, PyContext, PyObjectRef, PyRef, PyResult, PyValue,
     TryFromObject, TypeProtocol, VirtualMachine,
 };
@@ -478,7 +478,7 @@ impl PyValue for PyLongRangeIterator {
     }
 }
 
-#[pyimpl(with(PyIter))]
+#[pyimpl(with(SlotIterator))]
 impl PyLongRangeIterator {
     #[pyslot]
     fn slot_new(_cls: PyTypeRef, _args: FuncArgs, vm: &VirtualMachine) -> PyResult {
@@ -514,7 +514,7 @@ impl PyLongRangeIterator {
 }
 
 impl IteratorIterable for PyLongRangeIterator {}
-impl PyIter for PyLongRangeIterator {
+impl SlotIterator for PyLongRangeIterator {
     fn next(zelf: &PyRef<Self>, vm: &VirtualMachine) -> PyResult {
         // TODO: In pathological case (index == usize::MAX) this can wrap around
         // (since fetch_add wraps). This would result in the iterator spinning again
@@ -547,7 +547,7 @@ impl PyValue for PyRangeIterator {
     }
 }
 
-#[pyimpl(with(PyIter))]
+#[pyimpl(with(SlotIterator))]
 impl PyRangeIterator {
     #[pyslot]
     fn slot_new(_cls: PyTypeRef, _args: FuncArgs, vm: &VirtualMachine) -> PyResult {
@@ -584,7 +584,7 @@ impl PyRangeIterator {
 }
 
 impl IteratorIterable for PyRangeIterator {}
-impl PyIter for PyRangeIterator {
+impl SlotIterator for PyRangeIterator {
     fn next(zelf: &PyRef<Self>, vm: &VirtualMachine) -> PyResult {
         // TODO: In pathological case (index == usize::MAX) this can wrap around
         // (since fetch_add wraps). This would result in the iterator spinning again

--- a/vm/src/builtins/range.rs
+++ b/vm/src/builtins/range.rs
@@ -30,7 +30,7 @@ fn iter_search(
     vm: &VirtualMachine,
 ) -> PyResult<usize> {
     let mut count = 0;
-    let iter = iterator::get_iter(vm, obj)?;
+    let iter = obj.get_iter(vm)?;
     while let Some(element) = iterator::get_next_object(vm, &iter)? {
         if vm.bool_eq(&item, &element)? {
             match flag {

--- a/vm/src/builtins/set.rs
+++ b/vm/src/builtins/set.rs
@@ -7,8 +7,8 @@ use crate::{
     dictdatatype::{self, DictSize},
     function::{ArgIterable, FuncArgs, OptionalArg, PosArgs},
     slots::{
-        Comparable, Hashable, Iterable, IteratorIterable, PyComparisonOp, PyIter, SlotConstructor,
-        Unhashable,
+        Comparable, Hashable, Iterable, IteratorIterable, PyComparisonOp, SlotConstructor,
+        SlotIterator, Unhashable,
     },
     vm::{ReprGuard, VirtualMachine},
     IdProtocol, PyClassImpl, PyComparisonValue, PyContext, PyObjectRef, PyRef, PyResult, PyValue,
@@ -833,7 +833,7 @@ impl PyValue for PySetIterator {
     }
 }
 
-#[pyimpl(with(PyIter))]
+#[pyimpl(with(SlotIterator))]
 impl PySetIterator {
     #[pymethod(magic)]
     fn length_hint(&self) -> usize {
@@ -862,7 +862,7 @@ impl PySetIterator {
 }
 
 impl IteratorIterable for PySetIterator {}
-impl PyIter for PySetIterator {
+impl SlotIterator for PySetIterator {
     fn next(zelf: &PyRef<Self>, vm: &VirtualMachine) -> PyResult {
         match zelf.status.load() {
             IterStatus::Exhausted => Err(vm.new_stop_iteration()),

--- a/vm/src/builtins/tuple.rs
+++ b/vm/src/builtins/tuple.rs
@@ -9,7 +9,8 @@ use crate::{
     sequence::{self, SimpleSeq},
     sliceable::PySliceableSequence,
     slots::{
-        Comparable, Hashable, Iterable, IteratorIterable, PyComparisonOp, PyIter, SlotConstructor,
+        Comparable, Hashable, Iterable, IteratorIterable, PyComparisonOp, SlotConstructor,
+        SlotIterator,
     },
     utils::Either,
     vm::{ReprGuard, VirtualMachine},
@@ -330,7 +331,7 @@ impl PyValue for PyTupleIterator {
     }
 }
 
-#[pyimpl(with(PyIter))]
+#[pyimpl(with(SlotIterator))]
 impl PyTupleIterator {
     #[pymethod(magic)]
     fn length_hint(&self) -> usize {
@@ -376,7 +377,7 @@ impl PyTupleIterator {
 }
 
 impl IteratorIterable for PyTupleIterator {}
-impl PyIter for PyTupleIterator {
+impl SlotIterator for PyTupleIterator {
     fn next(zelf: &PyRef<Self>, vm: &VirtualMachine) -> PyResult {
         if let Exhausted = zelf.status.load() {
             return Err(vm.new_stop_iteration());

--- a/vm/src/builtins/zip.rs
+++ b/vm/src/builtins/zip.rs
@@ -2,7 +2,7 @@ use super::PyTypeRef;
 use crate::{
     function::PosArgs,
     iterator,
-    slots::{IteratorIterable, PyIter, SlotConstructor},
+    slots::{IteratorIterable, SlotConstructor, SlotIterator},
     PyClassImpl, PyContext, PyObjectRef, PyRef, PyResult, PyValue, VirtualMachine,
 };
 
@@ -30,11 +30,11 @@ impl SlotConstructor for PyZip {
     }
 }
 
-#[pyimpl(with(PyIter, SlotConstructor), flags(BASETYPE))]
+#[pyimpl(with(SlotIterator, SlotConstructor), flags(BASETYPE))]
 impl PyZip {}
 
 impl IteratorIterable for PyZip {}
-impl PyIter for PyZip {
+impl SlotIterator for PyZip {
     fn next(zelf: &PyRef<Self>, vm: &VirtualMachine) -> PyResult {
         if zelf.iterators.is_empty() {
             Err(vm.new_stop_iteration())

--- a/vm/src/function/argument.rs
+++ b/vm/src/function/argument.rs
@@ -1,7 +1,7 @@
 use super::IntoFuncArgs;
-use crate::builtins::iter::PySequenceIterator;
 use crate::{
-    iterator, PyObjectRef, PyResult, PyValue, TryFromObject, TypeProtocol, VirtualMachine,
+    builtins::iter::PySequenceIterator, iterator, protocol::PyIter, PyObjectRef, PyResult, PyValue,
+    TryFromObject, TypeProtocol, VirtualMachine,
 };
 use std::marker::PhantomData;
 
@@ -102,7 +102,7 @@ where
     type Item = PyResult<T>;
 
     fn next(&mut self) -> Option<Self::Item> {
-        iterator::get_next_object(self.vm, &self.obj)
+        iterator::get_next_object(self.vm, &PyIter::new(&self.obj))
             .transpose()
             .map(|x| x.and_then(|obj| T::try_from_object(self.vm, obj)))
     }

--- a/vm/src/protocol/iter.rs
+++ b/vm/src/protocol/iter.rs
@@ -1,0 +1,118 @@
+use crate::IntoPyObject;
+use crate::{
+    builtins::iter::PySequenceIterator, PyObjectRef, PyResult, PyValue, TryFromObject,
+    TypeProtocol, VirtualMachine,
+};
+use std::borrow::Borrow;
+use std::ops::Deref;
+
+/// Iterator Protocol
+// https://docs.python.org/3/c-api/iter.html
+#[derive(Debug, Clone)]
+#[repr(transparent)]
+pub struct PyIter<T = PyObjectRef>(T)
+where
+    T: Borrow<PyObjectRef>;
+
+impl PyIter<PyObjectRef> {
+    pub fn into_object(self) -> PyObjectRef {
+        self.0
+    }
+}
+
+impl<T> PyIter<T>
+where
+    T: Borrow<PyObjectRef>,
+{
+    pub fn new(obj: T) -> Self {
+        Self(obj)
+    }
+    pub fn as_object(&self) -> &PyObjectRef {
+        self.0.borrow()
+    }
+    pub fn next(&self, vm: &VirtualMachine) -> PyResult {
+        let iternext = {
+            self.0
+                .borrow()
+                .class()
+                .mro_find_map(|x| x.slots.iternext.load())
+                .ok_or_else(|| {
+                    vm.new_type_error(format!(
+                        "'{}' object is not an iterator",
+                        self.0.borrow().class().name()
+                    ))
+                })?
+        };
+        iternext(self.0.borrow(), vm)
+    }
+}
+
+impl<T> Borrow<PyObjectRef> for PyIter<T>
+where
+    T: Borrow<PyObjectRef>,
+{
+    fn borrow(&self) -> &PyObjectRef {
+        self.0.borrow()
+    }
+}
+
+impl<T> Deref for PyIter<T>
+where
+    T: Borrow<PyObjectRef>,
+{
+    type Target = PyObjectRef;
+    fn deref(&self) -> &Self::Target {
+        self.0.borrow()
+    }
+}
+
+impl IntoPyObject for PyIter<PyObjectRef> {
+    fn into_pyobject(self, _vm: &VirtualMachine) -> PyObjectRef {
+        self.into_object()
+    }
+}
+
+impl TryFromObject for PyIter<PyObjectRef> {
+    // This helper function is called at multiple places. First, it is called
+    // in the vm when a for loop is entered. Next, it is used when the builtin
+    // function 'iter' is called.
+    fn try_from_object(vm: &VirtualMachine, iter_target: PyObjectRef) -> PyResult<Self> {
+        let getiter = {
+            let cls = iter_target.class();
+            cls.mro_find_map(|x| x.slots.iter.load())
+        };
+        if let Some(getiter) = getiter {
+            let iter = getiter(iter_target, vm)?;
+            let cls = iter.class();
+            let is_iter = cls.iter_mro().any(|x| x.slots.iternext.load().is_some());
+            if is_iter {
+                drop(cls);
+                Ok(Self(iter))
+            } else {
+                Err(vm.new_type_error(format!(
+                    "iter() returned non-iterator of type '{}'",
+                    cls.name()
+                )))
+            }
+        } else {
+            vm.get_method_or_type_error(iter_target.clone(), "__getitem__", || {
+                format!("'{}' object is not iterable", iter_target.class().name())
+            })?;
+            Ok(Self(
+                PySequenceIterator::new(iter_target)
+                    .into_ref(vm)
+                    .into_object(),
+            ))
+        }
+    }
+}
+
+impl PyObjectRef {
+    /// Takes an object and returns an iterator for it.
+    /// This is typically a new iterator but if the argument is an iterator, this
+    /// returns itself.
+    pub fn get_iter(self, vm: &VirtualMachine) -> PyResult<PyIter> {
+        // PyObject_GetIter
+        PyIter::try_from_object(vm, self)
+    }
+}

--- a/vm/src/protocol/mod.rs
+++ b/vm/src/protocol/mod.rs
@@ -1,3 +1,5 @@
 mod buffer;
+mod iter;
 
 pub(crate) use buffer::{BufferInternal, BufferOptions, PyBuffer, ResizeGuard};
+pub use iter::PyIter;

--- a/vm/src/slots.rs
+++ b/vm/src/slots.rs
@@ -548,7 +548,7 @@ pub trait Iterable: PyValue {
 }
 
 #[pyimpl(with(Iterable))]
-pub trait PyIter: PyValue + Iterable {
+pub trait SlotIterator: PyValue + Iterable {
     #[pyslot]
     fn slot_iternext(zelf: &PyObjectRef, vm: &VirtualMachine) -> PyResult {
         if let Some(zelf) = zelf.downcast_ref() {

--- a/vm/src/stdlib/array.rs
+++ b/vm/src/stdlib/array.rs
@@ -19,8 +19,8 @@ mod array {
         protocol::{BufferInternal, BufferOptions, PyBuffer, ResizeGuard},
         sliceable::{saturate_index, PySliceableSequence, PySliceableSequenceMut, SequenceIndex},
         slots::{
-            AsBuffer, Comparable, Iterable, IteratorIterable, PyComparisonOp, PyIter,
-            SlotConstructor,
+            AsBuffer, Comparable, Iterable, IteratorIterable, PyComparisonOp, SlotConstructor,
+            SlotIterator,
         },
         IdProtocol, IntoPyObject, IntoPyResult, PyComparisonValue, PyObjectRef, PyRef, PyResult,
         PyValue, TryFromObject, TypeProtocol, VirtualMachine,
@@ -1193,11 +1193,11 @@ mod array {
         array: PyArrayRef,
     }
 
-    #[pyimpl(with(PyIter))]
+    #[pyimpl(with(SlotIterator))]
     impl PyArrayIter {}
 
     impl IteratorIterable for PyArrayIter {}
-    impl PyIter for PyArrayIter {
+    impl SlotIterator for PyArrayIter {
         fn next(zelf: &PyRef<Self>, vm: &VirtualMachine) -> PyResult {
             let pos = zelf.position.fetch_add(1);
             if let Some(item) = zelf.array.read().getitem_by_idx(pos, vm)? {

--- a/vm/src/stdlib/collections.rs
+++ b/vm/src/stdlib/collections.rs
@@ -11,8 +11,8 @@ mod _collections {
         function::{FuncArgs, KwArgs, OptionalArg},
         sequence, sliceable,
         slots::{
-            Comparable, Hashable, Iterable, IteratorIterable, PyComparisonOp, PyIter,
-            SlotConstructor, Unhashable,
+            Comparable, Hashable, Iterable, IteratorIterable, PyComparisonOp, SlotConstructor,
+            SlotIterator, Unhashable,
         },
         vm::ReprGuard,
         PyComparisonValue, PyObjectRef, PyRef, PyResult, PyValue, TypeProtocol, VirtualMachine,
@@ -609,7 +609,7 @@ mod _collections {
         }
     }
 
-    #[pyimpl(with(PyIter, SlotConstructor))]
+    #[pyimpl(with(SlotIterator, SlotConstructor))]
     impl PyDequeIterator {
         pub(crate) fn new(deque: PyDequeRef) -> Self {
             PyDequeIterator {
@@ -641,7 +641,7 @@ mod _collections {
     }
 
     impl IteratorIterable for PyDequeIterator {}
-    impl PyIter for PyDequeIterator {
+    impl SlotIterator for PyDequeIterator {
         fn next(zelf: &PyRef<Self>, vm: &VirtualMachine) -> PyResult {
             match zelf.status.load() {
                 Exhausted => Err(vm.new_stop_iteration()),
@@ -698,7 +698,7 @@ mod _collections {
         }
     }
 
-    #[pyimpl(with(PyIter, SlotConstructor))]
+    #[pyimpl(with(SlotIterator, SlotConstructor))]
     impl PyReverseDequeIterator {
         #[pymethod(magic)]
         fn length_hint(&self) -> usize {
@@ -721,7 +721,7 @@ mod _collections {
     }
 
     impl IteratorIterable for PyReverseDequeIterator {}
-    impl PyIter for PyReverseDequeIterator {
+    impl SlotIterator for PyReverseDequeIterator {
         fn next(zelf: &PyRef<Self>, vm: &VirtualMachine) -> PyResult {
             match zelf.status.load() {
                 Exhausted => Err(vm.new_stop_iteration()),

--- a/vm/src/stdlib/csv.rs
+++ b/vm/src/stdlib/csv.rs
@@ -3,7 +3,7 @@ use crate::{
     builtins::{PyStr, PyStrRef},
     function::{ArgIterable, ArgumentError, FromArgs, FuncArgs},
     iterator,
-    slots::{IteratorIterable, PyIter},
+    slots::{IteratorIterable, SlotIterator},
     types::create_simple_type,
     PyClassImpl, PyObjectRef, PyRef, PyResult, PyValue, TryFromObject, TypeProtocol,
     VirtualMachine,
@@ -95,10 +95,10 @@ impl fmt::Debug for Reader {
     }
 }
 
-#[pyimpl(with(PyIter))]
+#[pyimpl(with(SlotIterator))]
 impl Reader {}
 impl IteratorIterable for Reader {}
-impl PyIter for Reader {
+impl SlotIterator for Reader {
     fn next(zelf: &PyRef<Self>, vm: &VirtualMachine) -> PyResult {
         let string = iterator::call_next(vm, &zelf.iter)?;
         let string = string.downcast::<PyStr>().map_err(|obj| {

--- a/vm/src/stdlib/functools.rs
+++ b/vm/src/stdlib/functools.rs
@@ -3,23 +3,21 @@ pub(crate) use _functools::make_module;
 #[pymodule]
 mod _functools {
     use crate::function::OptionalArg;
-    use crate::iterator;
+    use crate::protocol::PyIter;
     use crate::vm::VirtualMachine;
     use crate::{PyObjectRef, PyResult, TypeProtocol};
 
     #[pyfunction]
     fn reduce(
         function: PyObjectRef,
-        sequence: PyObjectRef,
+        iterator: PyIter,
         start_value: OptionalArg<PyObjectRef>,
         vm: &VirtualMachine,
     ) -> PyResult {
-        let iterator = iterator::get_iter(vm, sequence)?;
-
         let start_value = if let OptionalArg::Present(val) = start_value {
             val
         } else {
-            iterator::call_next(vm, &iterator).map_err(|err| {
+            iterator.next(vm).map_err(|err| {
                 if err.isinstance(&vm.ctx.exceptions.stop_iteration) {
                     let exc_type = vm.ctx.exceptions.type_error.clone();
                     vm.new_exception_msg(
@@ -34,7 +32,7 @@ mod _functools {
 
         let mut accumulator = start_value;
 
-        while let Ok(next_obj) = iterator::call_next(vm, &iterator) {
+        while let Ok(next_obj) = iterator.next(vm) {
             accumulator = vm.invoke(&function, vec![accumulator, next_obj])?
         }
 

--- a/vm/src/stdlib/io.rs
+++ b/vm/src/stdlib/io.rs
@@ -86,7 +86,7 @@ mod _io {
             ArgBytesLike, ArgIterable, ArgMemoryBuffer, FuncArgs, OptionalArg, OptionalOption,
         },
         protocol::{BufferInternal, BufferOptions, PyBuffer, ResizeGuard},
-        slots::{Iterable, PyIter, SlotConstructor},
+        slots::{Iterable, SlotConstructor, SlotIterator},
         utils::Either,
         vm::{ReprGuard, VirtualMachine},
         IdProtocol, IntoPyObject, PyContext, PyObjectRef, PyRef, PyResult, PyValue, StaticType,
@@ -344,7 +344,7 @@ mod _io {
     #[derive(Debug, PyValue)]
     struct _IOBase;
 
-    #[pyimpl(with(PyIter), flags(BASETYPE, HAS_DICT))]
+    #[pyimpl(with(SlotIterator), flags(BASETYPE, HAS_DICT))]
     impl _IOBase {
         #[pymethod]
         fn seek(
@@ -523,7 +523,7 @@ mod _io {
         }
     }
 
-    impl PyIter for _IOBase {
+    impl SlotIterator for _IOBase {
         fn slot_iternext(zelf: &PyObjectRef, vm: &VirtualMachine) -> PyResult {
             let line = vm.call_method(zelf, "readline", ())?;
             if !line.clone().try_to_bool(vm)? {

--- a/vm/src/stdlib/itertools.rs
+++ b/vm/src/stdlib/itertools.rs
@@ -10,7 +10,7 @@ mod decl {
         builtins::{int, PyInt, PyIntRef, PyTupleRef, PyTypeRef},
         function::{ArgCallable, FuncArgs, OptionalArg, OptionalOption, PosArgs},
         iterator::{call_next, get_iter, get_next_object},
-        slots::{IteratorIterable, PyIter, SlotConstructor},
+        slots::{IteratorIterable, SlotConstructor, SlotIterator},
         IdProtocol, IntoPyObject, PyObjectRef, PyRef, PyResult, PyValue, PyWeakRef, TypeProtocol,
         VirtualMachine,
     };
@@ -28,7 +28,7 @@ mod decl {
         cached_iter: PyRwLock<Option<PyObjectRef>>,
     }
 
-    #[pyimpl(with(PyIter))]
+    #[pyimpl(with(SlotIterator))]
     impl PyItertoolsChain {
         #[pyslot]
         fn slot_new(cls: PyTypeRef, args: FuncArgs, vm: &VirtualMachine) -> PyResult {
@@ -55,7 +55,7 @@ mod decl {
         }
     }
     impl IteratorIterable for PyItertoolsChain {}
-    impl PyIter for PyItertoolsChain {
+    impl SlotIterator for PyItertoolsChain {
         fn next(zelf: &PyRef<Self>, vm: &VirtualMachine) -> PyResult {
             loop {
                 let pos = zelf.cur_idx.load();
@@ -127,11 +127,11 @@ mod decl {
         }
     }
 
-    #[pyimpl(with(PyIter, SlotConstructor))]
+    #[pyimpl(with(SlotIterator, SlotConstructor))]
     impl PyItertoolsCompress {}
 
     impl IteratorIterable for PyItertoolsCompress {}
-    impl PyIter for PyItertoolsCompress {
+    impl SlotIterator for PyItertoolsCompress {
         fn next(zelf: &PyRef<Self>, vm: &VirtualMachine) -> PyResult {
             loop {
                 let sel_obj = call_next(vm, &zelf.selector)?;
@@ -187,10 +187,10 @@ mod decl {
         }
     }
 
-    #[pyimpl(with(PyIter, SlotConstructor))]
+    #[pyimpl(with(SlotIterator, SlotConstructor))]
     impl PyItertoolsCount {}
     impl IteratorIterable for PyItertoolsCount {}
-    impl PyIter for PyItertoolsCount {
+    impl SlotIterator for PyItertoolsCount {
         fn next(zelf: &PyRef<Self>, vm: &VirtualMachine) -> PyResult {
             let mut cur = zelf.cur.write();
             let result = cur.clone();
@@ -223,10 +223,10 @@ mod decl {
         }
     }
 
-    #[pyimpl(with(PyIter, SlotConstructor))]
+    #[pyimpl(with(SlotIterator, SlotConstructor))]
     impl PyItertoolsCycle {}
     impl IteratorIterable for PyItertoolsCycle {}
-    impl PyIter for PyItertoolsCycle {
+    impl SlotIterator for PyItertoolsCycle {
         fn next(zelf: &PyRef<Self>, vm: &VirtualMachine) -> PyResult {
             let item = if let Some(item) = get_next_object(vm, &zelf.iter)? {
                 zelf.saved.write().push(item.clone());
@@ -288,7 +288,7 @@ mod decl {
         }
     }
 
-    #[pyimpl(with(PyIter, SlotConstructor), flags(BASETYPE))]
+    #[pyimpl(with(SlotIterator, SlotConstructor), flags(BASETYPE))]
     impl PyItertoolsRepeat {
         #[pymethod(magic)]
         fn length_hint(&self, vm: &VirtualMachine) -> PyResult {
@@ -327,7 +327,7 @@ mod decl {
     }
 
     impl IteratorIterable for PyItertoolsRepeat {}
-    impl PyIter for PyItertoolsRepeat {
+    impl SlotIterator for PyItertoolsRepeat {
         fn next(zelf: &PyRef<Self>, vm: &VirtualMachine) -> PyResult {
             if let Some(ref times) = zelf.times {
                 let mut times = times.write();
@@ -370,10 +370,10 @@ mod decl {
         }
     }
 
-    #[pyimpl(with(PyIter, SlotConstructor))]
+    #[pyimpl(with(SlotIterator, SlotConstructor))]
     impl PyItertoolsStarmap {}
     impl IteratorIterable for PyItertoolsStarmap {}
-    impl PyIter for PyItertoolsStarmap {
+    impl SlotIterator for PyItertoolsStarmap {
         fn next(zelf: &PyRef<Self>, vm: &VirtualMachine) -> PyResult {
             let obj = call_next(vm, &zelf.iter)?;
             let function = &zelf.function;
@@ -421,10 +421,10 @@ mod decl {
         }
     }
 
-    #[pyimpl(with(PyIter, SlotConstructor))]
+    #[pyimpl(with(SlotIterator, SlotConstructor))]
     impl PyItertoolsTakewhile {}
     impl IteratorIterable for PyItertoolsTakewhile {}
-    impl PyIter for PyItertoolsTakewhile {
+    impl SlotIterator for PyItertoolsTakewhile {
         fn next(zelf: &PyRef<Self>, vm: &VirtualMachine) -> PyResult {
             if zelf.stop_flag.load() {
                 return Err(vm.new_stop_iteration());
@@ -484,10 +484,10 @@ mod decl {
         }
     }
 
-    #[pyimpl(with(PyIter, SlotConstructor))]
+    #[pyimpl(with(SlotIterator, SlotConstructor))]
     impl PyItertoolsDropwhile {}
     impl IteratorIterable for PyItertoolsDropwhile {}
-    impl PyIter for PyItertoolsDropwhile {
+    impl SlotIterator for PyItertoolsDropwhile {
         fn next(zelf: &PyRef<Self>, vm: &VirtualMachine) -> PyResult {
             let predicate = &zelf.predicate;
             let iterable = &zelf.iterable;
@@ -579,7 +579,7 @@ mod decl {
         }
     }
 
-    #[pyimpl(with(PyIter, SlotConstructor))]
+    #[pyimpl(with(SlotIterator, SlotConstructor))]
     impl PyItertoolsGroupBy {
         pub(super) fn advance(&self, vm: &VirtualMachine) -> PyResult<(PyObjectRef, PyObjectRef)> {
             let new_value = call_next(vm, &self.iterable)?;
@@ -592,7 +592,7 @@ mod decl {
         }
     }
     impl IteratorIterable for PyItertoolsGroupBy {}
-    impl PyIter for PyItertoolsGroupBy {
+    impl SlotIterator for PyItertoolsGroupBy {
         fn next(zelf: &PyRef<Self>, vm: &VirtualMachine) -> PyResult {
             let mut state = zelf.state.lock();
             state.grouper = None;
@@ -639,10 +639,10 @@ mod decl {
 
     type PyItertoolsGrouperRef = PyRef<PyItertoolsGrouper>;
 
-    #[pyimpl(with(PyIter))]
+    #[pyimpl(with(SlotIterator))]
     impl PyItertoolsGrouper {}
     impl IteratorIterable for PyItertoolsGrouper {}
-    impl PyIter for PyItertoolsGrouper {
+    impl SlotIterator for PyItertoolsGrouper {
         fn next(zelf: &PyRef<Self>, vm: &VirtualMachine) -> PyResult {
             let old_key = {
                 let mut state = zelf.groupby.state.lock();
@@ -707,7 +707,7 @@ mod decl {
         )));
     }
 
-    #[pyimpl(with(PyIter))]
+    #[pyimpl(with(SlotIterator))]
     impl PyItertoolsIslice {
         #[pyslot]
         fn slot_new(cls: PyTypeRef, args: FuncArgs, vm: &VirtualMachine) -> PyResult {
@@ -772,7 +772,7 @@ mod decl {
     }
 
     impl IteratorIterable for PyItertoolsIslice {}
-    impl PyIter for PyItertoolsIslice {
+    impl SlotIterator for PyItertoolsIslice {
         fn next(zelf: &PyRef<Self>, vm: &VirtualMachine) -> PyResult {
             while zelf.cur.load() < zelf.next.load() {
                 call_next(vm, &zelf.iterable)?;
@@ -833,10 +833,10 @@ mod decl {
         }
     }
 
-    #[pyimpl(with(PyIter, SlotConstructor))]
+    #[pyimpl(with(SlotIterator, SlotConstructor))]
     impl PyItertoolsFilterFalse {}
     impl IteratorIterable for PyItertoolsFilterFalse {}
-    impl PyIter for PyItertoolsFilterFalse {
+    impl SlotIterator for PyItertoolsFilterFalse {
         fn next(zelf: &PyRef<Self>, vm: &VirtualMachine) -> PyResult {
             let predicate = &zelf.predicate;
             let iterable = &zelf.iterable;
@@ -891,11 +891,11 @@ mod decl {
         }
     }
 
-    #[pyimpl(with(PyIter, SlotConstructor))]
+    #[pyimpl(with(SlotIterator, SlotConstructor))]
     impl PyItertoolsAccumulate {}
 
     impl IteratorIterable for PyItertoolsAccumulate {}
-    impl PyIter for PyItertoolsAccumulate {
+    impl SlotIterator for PyItertoolsAccumulate {
         fn next(zelf: &PyRef<Self>, vm: &VirtualMachine) -> PyResult {
             let iterable = &zelf.iterable;
 
@@ -987,7 +987,7 @@ mod decl {
         }
     }
 
-    #[pyimpl(with(PyIter, SlotConstructor))]
+    #[pyimpl(with(SlotIterator, SlotConstructor))]
     impl PyItertoolsTee {
         fn from_iter(iterable: PyObjectRef, vm: &VirtualMachine) -> PyResult {
             let class = PyItertoolsTee::class(vm);
@@ -1014,7 +1014,7 @@ mod decl {
         }
     }
     impl IteratorIterable for PyItertoolsTee {}
-    impl PyIter for PyItertoolsTee {
+    impl SlotIterator for PyItertoolsTee {
         fn next(zelf: &PyRef<Self>, vm: &VirtualMachine) -> PyResult {
             let value = zelf.tee_data.get_item(vm, zelf.index.load())?;
             zelf.index.fetch_add(1);
@@ -1064,7 +1064,7 @@ mod decl {
         }
     }
 
-    #[pyimpl(with(PyIter, SlotConstructor))]
+    #[pyimpl(with(SlotIterator, SlotConstructor))]
     impl PyItertoolsProduct {
         fn update_idxs(&self, mut idxs: PyRwLockWriteGuard<'_, Vec<usize>>) {
             if idxs.len() == 0 {
@@ -1090,7 +1090,7 @@ mod decl {
         }
     }
     impl IteratorIterable for PyItertoolsProduct {}
-    impl PyIter for PyItertoolsProduct {
+    impl SlotIterator for PyItertoolsProduct {
         fn next(zelf: &PyRef<Self>, vm: &VirtualMachine) -> PyResult {
             // stop signal
             if zelf.stop.load() {
@@ -1166,10 +1166,10 @@ mod decl {
         }
     }
 
-    #[pyimpl(with(PyIter, SlotConstructor))]
+    #[pyimpl(with(SlotIterator, SlotConstructor))]
     impl PyItertoolsCombinations {}
     impl IteratorIterable for PyItertoolsCombinations {}
-    impl PyIter for PyItertoolsCombinations {
+    impl SlotIterator for PyItertoolsCombinations {
         fn next(zelf: &PyRef<Self>, vm: &VirtualMachine) -> PyResult {
             // stop signal
             if zelf.exhausted.load() {
@@ -1256,11 +1256,11 @@ mod decl {
         }
     }
 
-    #[pyimpl(with(PyIter, SlotConstructor))]
+    #[pyimpl(with(SlotIterator, SlotConstructor))]
     impl PyItertoolsCombinationsWithReplacement {}
 
     impl IteratorIterable for PyItertoolsCombinationsWithReplacement {}
-    impl PyIter for PyItertoolsCombinationsWithReplacement {
+    impl SlotIterator for PyItertoolsCombinationsWithReplacement {
         fn next(zelf: &PyRef<Self>, vm: &VirtualMachine) -> PyResult {
             // stop signal
             if zelf.exhausted.load() {
@@ -1365,10 +1365,10 @@ mod decl {
         }
     }
 
-    #[pyimpl(with(PyIter, SlotConstructor))]
+    #[pyimpl(with(SlotIterator, SlotConstructor))]
     impl PyItertoolsPermutations {}
     impl IteratorIterable for PyItertoolsPermutations {}
-    impl PyIter for PyItertoolsPermutations {
+    impl SlotIterator for PyItertoolsPermutations {
         fn next(zelf: &PyRef<Self>, vm: &VirtualMachine) -> PyResult {
             // stop signal
             if zelf.exhausted.load() {
@@ -1467,10 +1467,10 @@ mod decl {
         fillvalue: PyObjectRef,
     }
 
-    #[pyimpl(with(PyIter, SlotConstructor))]
+    #[pyimpl(with(SlotIterator, SlotConstructor))]
     impl PyItertoolsZipLongest {}
     impl IteratorIterable for PyItertoolsZipLongest {}
-    impl PyIter for PyItertoolsZipLongest {
+    impl SlotIterator for PyItertoolsZipLongest {
         fn next(zelf: &PyRef<Self>, vm: &VirtualMachine) -> PyResult {
             if zelf.iterators.is_empty() {
                 Err(vm.new_stop_iteration())
@@ -1521,10 +1521,10 @@ mod decl {
         }
     }
 
-    #[pyimpl(with(PyIter, SlotConstructor))]
+    #[pyimpl(with(SlotIterator, SlotConstructor))]
     impl PyItertoolsPairwise {}
     impl IteratorIterable for PyItertoolsPairwise {}
-    impl PyIter for PyItertoolsPairwise {
+    impl SlotIterator for PyItertoolsPairwise {
         fn next(zelf: &PyRef<Self>, vm: &VirtualMachine) -> PyResult {
             let old = match zelf.old.read().clone() {
                 None => call_next(vm, &zelf.iterator)?,

--- a/vm/src/stdlib/operator.rs
+++ b/vm/src/stdlib/operator.rs
@@ -14,6 +14,7 @@ mod _operator {
         builtins::{PyInt, PyIntRef, PyStrRef, PyTypeRef},
         function::{ArgBytesLike, FuncArgs, KwArgs, OptionalArg},
         iterator,
+        protocol::PyIter,
         slots::{
             Callable,
             PyComparisonOp::{Eq, Ge, Gt, Le, Lt, Ne},
@@ -217,10 +218,9 @@ mod _operator {
 
     /// Return the number of occurrences of b in a.
     #[pyfunction(name = "countOf")]
-    fn count_of(a: PyObjectRef, b: PyObjectRef, vm: &VirtualMachine) -> PyResult<usize> {
+    fn count_of(a: PyIter, b: PyObjectRef, vm: &VirtualMachine) -> PyResult<usize> {
         let mut count: usize = 0;
-        let iter = iterator::get_iter(vm, a)?;
-        while let Some(element) = iterator::get_next_object(vm, &iter)? {
+        while let Some(element) = iterator::get_next_object(vm, &a)? {
             if element.is(&b) || vm.bool_eq(&b, &element)? {
                 count += 1;
             }
@@ -242,10 +242,9 @@ mod _operator {
 
     /// Return the number of occurrences of b in a.
     #[pyfunction(name = "indexOf")]
-    fn index_of(a: PyObjectRef, b: PyObjectRef, vm: &VirtualMachine) -> PyResult<usize> {
+    fn index_of(a: PyIter, b: PyObjectRef, vm: &VirtualMachine) -> PyResult<usize> {
         let mut index: usize = 0;
-        let iter = iterator::get_iter(vm, a)?;
-        while let Some(element) = iterator::get_next_object(vm, &iter)? {
+        while let Some(element) = iterator::get_next_object(vm, &a)? {
             if element.is(&b) || vm.bool_eq(&b, &element)? {
                 return Ok(index);
             }

--- a/vm/src/stdlib/os.rs
+++ b/vm/src/stdlib/os.rs
@@ -406,7 +406,7 @@ pub(super) mod _os {
         crt_fd::{Fd, Offset},
         exceptions::IntoPyException,
         function::{ArgBytesLike, FuncArgs, OptionalArg},
-        slots::{IteratorIterable, PyIter},
+        slots::{IteratorIterable, SlotIterator},
         suppress_iph,
         utils::Either,
         vm::{ReprGuard, VirtualMachine},
@@ -855,7 +855,7 @@ pub(super) mod _os {
         mode: OutputMode,
     }
 
-    #[pyimpl(with(PyIter))]
+    #[pyimpl(with(SlotIterator))]
     impl ScandirIterator {
         #[pymethod]
         fn close(&self) {
@@ -873,7 +873,7 @@ pub(super) mod _os {
         }
     }
     impl IteratorIterable for ScandirIterator {}
-    impl PyIter for ScandirIterator {
+    impl SlotIterator for ScandirIterator {
         fn next(zelf: &PyRef<Self>, vm: &VirtualMachine) -> PyResult {
             if zelf.exhausted.load() {
                 return Err(vm.new_stop_iteration());

--- a/vm/src/stdlib/pystruct.rs
+++ b/vm/src/stdlib/pystruct.rs
@@ -18,7 +18,7 @@ pub(crate) mod _struct {
         },
         common::str::wchar_t,
         function::{ArgBytesLike, ArgMemoryBuffer, PosArgs},
-        slots::{IteratorIterable, PyIter, SlotConstructor},
+        slots::{IteratorIterable, SlotConstructor, SlotIterator},
         utils::Either,
         IntoPyObject, PyObjectRef, PyRef, PyResult, PyValue, TryFromObject, VirtualMachine,
     };
@@ -823,7 +823,7 @@ pub(crate) mod _struct {
         }
     }
 
-    #[pyimpl(with(PyIter))]
+    #[pyimpl(with(SlotIterator))]
     impl UnpackIterator {
         #[pymethod(magic)]
         fn length_hint(&self) -> usize {
@@ -831,7 +831,7 @@ pub(crate) mod _struct {
         }
     }
     impl IteratorIterable for UnpackIterator {}
-    impl PyIter for UnpackIterator {
+    impl SlotIterator for UnpackIterator {
         fn next(zelf: &PyRef<Self>, vm: &VirtualMachine) -> PyResult {
             let size = zelf.format_spec.size;
             let offset = zelf.offset.fetch_add(size);

--- a/vm/src/vm.rs
+++ b/vm/src/vm.rs
@@ -1270,7 +1270,7 @@ impl VirtualMachine {
                 .map(|obj| func(obj.clone()))
                 .collect()
         } else {
-            let iter = iterator::get_iter(self, value.clone())?;
+            let iter = value.clone().get_iter(self)?;
             let cap = match iterator::length_hint(self, value.clone()) {
                 Err(e) if e.class().is(&self.ctx.exceptions.runtime_error) => return Err(e),
                 Ok(Some(value)) => value,
@@ -1318,7 +1318,7 @@ impl VirtualMachine {
             ref t @ PyTuple => Ok(t.as_slice().iter().cloned().map(f).collect()),
             // TODO: put internal iterable type
             obj => {
-                let iter = iterator::get_iter(self, obj.clone())?;
+                let iter = obj.clone().get_iter(self)?;
                 let cap = match iterator::length_hint(self, obj.clone()) {
                     Err(e) if e.class().is(&self.ctx.exceptions.runtime_error) => {
                         return Ok(Err(e))
@@ -1926,7 +1926,7 @@ impl VirtualMachine {
 
     // https://docs.python.org/3/reference/expressions.html#membership-test-operations
     fn _membership_iter_search(&self, haystack: PyObjectRef, needle: PyObjectRef) -> PyResult {
-        let iter = iterator::get_iter(self, haystack)?;
+        let iter = haystack.get_iter(self)?;
         loop {
             if let Some(element) = iterator::get_next_object(self, &iter)? {
                 if self.bool_eq(&needle, &element)? {

--- a/wasm/lib/src/js_module.rs
+++ b/wasm/lib/src/js_module.rs
@@ -9,7 +9,7 @@ use wasm_bindgen_futures::{future_to_promise, JsFuture};
 use rustpython_vm::builtins::PyBaseExceptionRef;
 use rustpython_vm::builtins::{PyFloatRef, PyStrRef, PyTypeRef};
 use rustpython_vm::function::{OptionalArg, OptionalOption, PosArgs};
-use rustpython_vm::slots::{IteratorIterable, PyIter};
+use rustpython_vm::slots::{IteratorIterable, SlotIterator};
 use rustpython_vm::types::create_simple_type;
 use rustpython_vm::VirtualMachine;
 use rustpython_vm::{
@@ -549,7 +549,7 @@ impl fmt::Debug for AwaitPromise {
     }
 }
 
-#[pyimpl(with(PyIter))]
+#[pyimpl(with(SlotIterator))]
 impl AwaitPromise {
     #[pymethod]
     fn send(&self, val: Option<PyObjectRef>, vm: &VirtualMachine) -> PyResult {
@@ -588,7 +588,7 @@ impl AwaitPromise {
 }
 
 impl IteratorIterable for AwaitPromise {}
-impl PyIter for AwaitPromise {
+impl SlotIterator for AwaitPromise {
     fn next(zelf: &PyRef<Self>, vm: &VirtualMachine) -> PyResult {
         zelf.send(None, vm)
     }


### PR DESCRIPTION
~based on #3115 and #3116~

will be part of #3104 because `PyIter` is required for stdlib modules