### PR TITLE
tp_ -> slot_

### DIFF
--- a/derive/src/pyclass.rs
+++ b/derive/src/pyclass.rs
@@ -70,7 +70,7 @@ pub(crate) fn impl_pyimpl(
             quote! {
                 #imp
                 impl ::rustpython_vm::PyClassImpl for #ty {
-                    const TP_FLAGS: ::rustpython_vm::slots::PyTpFlags = ::rustpython_vm::slots::PyTpFlags::from_bits_truncate(#flags);
+                    const TP_FLAGS: ::rustpython_vm::slots::PyTypeFlags = ::rustpython_vm::slots::PyTypeFlags::from_bits_truncate(#flags);
 
                     fn impl_extend_class(
                         ctx: &::rustpython_vm::PyContext,
@@ -300,16 +300,16 @@ pub(crate) fn impl_define_exception(
         base_class,
         ctx_name,
         docs,
-        tp_new,
+        slot_new,
         init,
     } = exc_def;
 
     // We need this method, because of how `CPython` copies `__new__`
     // from `BaseException` in `SimpleExtendsException` macro.
     // See: `BaseException_new`
-    let tp_new_slot = match tp_new {
-        Some(tp_call) => quote! { #tp_call(cls, args, vm) },
-        None => quote! { #base_class::tp_new(cls, args, vm) },
+    let slot_new_impl = match slot_new {
+        Some(slot_call) => quote! { #slot_call(cls, args, vm) },
+        None => quote! { #base_class::slot_new(cls, args, vm) },
     };
 
     // We need this method, because of how `CPython` copies `__init__`
@@ -336,12 +336,12 @@ pub(crate) fn impl_define_exception(
         #[pyimpl(flags(BASETYPE, HAS_DICT))]
         impl #class_name {
             #[pyslot]
-            pub(crate) fn tp_new(
+            pub(crate) fn slot_new(
                 cls: ::rustpython_vm::builtins::PyTypeRef,
                 args: ::rustpython_vm::function::FuncArgs,
                 vm: &::rustpython_vm::VirtualMachine,
             ) -> ::rustpython_vm::PyResult {
-                #tp_new_slot
+                #slot_new_impl
             }
 
             #[pymethod(magic)]
@@ -849,7 +849,7 @@ impl SlotItemMeta {
             }
         } else {
             let ident_str = self.inner().item_name();
-            let name = if let Some(stripped) = ident_str.strip_prefix("tp_") {
+            let name = if let Some(stripped) = ident_str.strip_prefix("slot_") {
                 proc_macro2::Ident::new(stripped, inner.item_ident.span())
             } else {
                 inner.item_ident.clone()
@@ -877,11 +877,11 @@ fn extract_impl_attrs(
 ) -> std::result::Result<ExtractedImplAttrs, Diagnostic> {
     let mut withs = Vec::new();
     let mut with_slots = Vec::new();
-    let mut flags = vec![quote! { ::rustpython_vm::slots::PyTpFlags::DEFAULT.bits() }];
+    let mut flags = vec![quote! { ::rustpython_vm::slots::PyTypeFlags::DEFAULT.bits() }];
     #[cfg(debug_assertions)]
     {
         flags.push(quote! {
-            | ::rustpython_vm::slots::PyTpFlags::_CREATED_WITH_FLAGS.bits()
+            | ::rustpython_vm::slots::PyTypeFlags::_CREATED_WITH_FLAGS.bits()
         });
     }
 
@@ -919,7 +919,7 @@ fn extract_impl_attrs(
                             NestedMeta::Meta(Meta::Path(path)) => {
                                 if let Some(ident) = path.get_ident() {
                                     flags.push(quote_spanned! { ident.span() =>
-                                        | ::rustpython_vm::slots::PyTpFlags::#ident.bits()
+                                        | ::rustpython_vm::slots::PyTypeFlags::#ident.bits()
                                     });
                                 } else {
                                     bail_span!(
@@ -1048,8 +1048,8 @@ pub(crate) struct PyExceptionDef {
     pub ctx_name: Ident,
     pub docs: LitStr,
 
-    /// Holds optional `tp_new` slot to be used instead of a default one:
-    pub tp_new: Option<Ident>,
+    /// Holds optional `slot_new` slot to be used instead of a default one:
+    pub slot_new: Option<Ident>,
     /// We also store `__init__` magic method, that can
     pub init: Option<Ident>,
 }
@@ -1068,7 +1068,7 @@ impl Parse for PyExceptionDef {
         let docs: LitStr = input.parse()?;
         input.parse::<Option<Token![,]>>()?;
 
-        let tp_new: Option<Ident> = input.parse()?;
+        let slot_new: Option<Ident> = input.parse()?;
         input.parse::<Option<Token![,]>>()?;
 
         let init: Option<Ident> = input.parse()?;
@@ -1079,7 +1079,7 @@ impl Parse for PyExceptionDef {
             base_class,
             ctx_name,
             docs,
-            tp_new,
+            slot_new,
             init,
         })
     }

--- a/vm/src/builtins/bytearray.rs
+++ b/vm/src/builtins/bytearray.rs
@@ -98,7 +98,7 @@ pub(crate) fn init(context: &PyContext) {
 #[pyimpl(flags(BASETYPE), with(Hashable, Comparable, AsBuffer, Iterable))]
 impl PyByteArray {
     #[pyslot]
-    fn tp_new(cls: PyTypeRef, _args: FuncArgs, vm: &VirtualMachine) -> PyResult {
+    fn slot_new(cls: PyTypeRef, _args: FuncArgs, vm: &VirtualMachine) -> PyResult {
         PyByteArray::default().into_pyresult_with_type(vm, cls)
     }
 

--- a/vm/src/builtins/code.rs
+++ b/vm/src/builtins/code.rs
@@ -193,7 +193,7 @@ impl PyCode {}
 #[pyimpl]
 impl PyRef<PyCode> {
     #[pyslot]
-    fn tp_new(_cls: PyTypeRef, _args: FuncArgs, vm: &VirtualMachine) -> PyResult {
+    fn slot_new(_cls: PyTypeRef, _args: FuncArgs, vm: &VirtualMachine) -> PyResult {
         Err(vm.new_type_error("Cannot directly create code object".to_owned()))
     }
 

--- a/vm/src/builtins/dict.rs
+++ b/vm/src/builtins/dict.rs
@@ -52,7 +52,7 @@ impl PyValue for PyDict {
 #[pyimpl(with(Hashable, Comparable, Iterable), flags(BASETYPE))]
 impl PyDict {
     #[pyslot]
-    fn tp_new(cls: PyTypeRef, _args: FuncArgs, vm: &VirtualMachine) -> PyResult {
+    fn slot_new(cls: PyTypeRef, _args: FuncArgs, vm: &VirtualMachine) -> PyResult {
         PyDict::default().into_pyresult_with_type(vm, cls)
     }
 

--- a/vm/src/builtins/frame.rs
+++ b/vm/src/builtins/frame.rs
@@ -19,7 +19,7 @@ impl Frame {}
 #[pyimpl]
 impl FrameRef {
     #[pyslot]
-    fn tp_new(_cls: PyTypeRef, _args: FuncArgs, vm: &VirtualMachine) -> PyResult {
+    fn slot_new(_cls: PyTypeRef, _args: FuncArgs, vm: &VirtualMachine) -> PyResult {
         Err(vm.new_type_error("Cannot directly create frame object".to_owned()))
     }
 

--- a/vm/src/builtins/genericalias.rs
+++ b/vm/src/builtins/genericalias.rs
@@ -115,7 +115,7 @@ impl PyGenericAlias {
 
 fn is_typevar(obj: PyObjectRef) -> bool {
     let class = obj.class();
-    class.tp_name() == "TypeVar"
+    class.slot_name() == "TypeVar"
         && class
             .get_attr("__module__")
             .and_then(|o| o.downcast_ref::<PyStr>().map(|s| s.as_str() == "typing"))

--- a/vm/src/builtins/getset.rs
+++ b/vm/src/builtins/getset.rs
@@ -358,7 +358,7 @@ impl PyGetSet {
 
     #[pyproperty(magic)]
     fn qualname(&self) -> String {
-        format!("{}.{}", self.class.tp_name(), self.name.clone())
+        format!("{}.{}", self.class.slot_name(), self.name.clone())
     }
 }
 

--- a/vm/src/builtins/list.rs
+++ b/vm/src/builtins/list.rs
@@ -392,7 +392,7 @@ impl PyList {
     }
 
     #[pyslot]
-    fn tp_new(cls: PyTypeRef, _args: FuncArgs, vm: &VirtualMachine) -> PyResult {
+    fn slot_new(cls: PyTypeRef, _args: FuncArgs, vm: &VirtualMachine) -> PyResult {
         PyList::default().into_pyresult_with_type(vm, cls)
     }
 

--- a/vm/src/builtins/module.rs
+++ b/vm/src/builtins/module.rs
@@ -47,7 +47,7 @@ struct ModuleInitArgs {
 #[pyimpl(with(SlotGetattro), flags(BASETYPE, HAS_DICT))]
 impl PyModule {
     #[pyslot]
-    fn tp_new(cls: PyTypeRef, _args: FuncArgs, vm: &VirtualMachine) -> PyResult {
+    fn slot_new(cls: PyTypeRef, _args: FuncArgs, vm: &VirtualMachine) -> PyResult {
         PyModule {}.into_pyresult_with_type(vm, cls)
     }
 
@@ -56,7 +56,7 @@ impl PyModule {
         debug_assert!(crate::TypeProtocol::class(zelf.as_object())
             .slots
             .flags
-            .has_feature(crate::slots::PyTpFlags::HAS_DICT));
+            .has_feature(crate::slots::PyTypeFlags::HAS_DICT));
         init_module_dict(
             vm,
             &zelf.as_object().dict().unwrap(),

--- a/vm/src/builtins/object.rs
+++ b/vm/src/builtins/object.rs
@@ -27,7 +27,7 @@ impl PyValue for PyBaseObject {
 impl PyBaseObject {
     /// Create and return a new object.  See help(type) for accurate signature.
     #[pyslot]
-    fn tp_new(cls: PyTypeRef, _args: FuncArgs, vm: &VirtualMachine) -> PyResult {
+    fn slot_new(cls: PyTypeRef, _args: FuncArgs, vm: &VirtualMachine) -> PyResult {
         // more or less __new__ operator
         let dict = if cls.is(&vm.ctx.types.object_type) {
             None
@@ -38,7 +38,7 @@ impl PyBaseObject {
     }
 
     #[pyslot]
-    fn tp_richcompare(
+    fn slot_richcompare(
         zelf: &PyObjectRef,
         other: &PyObjectRef,
         op: PyComparisonOp,
@@ -158,7 +158,7 @@ impl PyBaseObject {
     }
 
     #[pyslot]
-    fn tp_setattro(
+    fn slot_setattro(
         obj: &PyObjectRef,
         attr_name: PyStrRef,
         value: Option<PyObjectRef>,
@@ -194,7 +194,7 @@ impl PyBaseObject {
             )),
             _ => Some(format!(
                 "<{} object at {:#x}>",
-                class.tp_name(),
+                class.slot_name(),
                 zelf.get_id()
             )),
         }
@@ -294,14 +294,14 @@ impl PyBaseObject {
     }
 
     #[pyslot]
-    fn tp_hash(zelf: &PyObjectRef, _vm: &VirtualMachine) -> PyResult<PyHash> {
+    fn slot_hash(zelf: &PyObjectRef, _vm: &VirtualMachine) -> PyResult<PyHash> {
         Ok(zelf.get_id() as _)
     }
 
     /// Return hash(self).
     #[pymethod(magic)]
     fn hash(zelf: PyObjectRef, vm: &VirtualMachine) -> PyResult<PyHash> {
-        Self::tp_hash(&zelf, vm)
+        Self::slot_hash(&zelf, vm)
     }
 }
 

--- a/vm/src/builtins/property.rs
+++ b/vm/src/builtins/property.rs
@@ -88,7 +88,7 @@ impl SlotDescriptor for PyProperty {
 #[pyimpl(with(SlotDescriptor), flags(BASETYPE))]
 impl PyProperty {
     #[pyslot]
-    fn tp_new(cls: PyTypeRef, _args: FuncArgs, vm: &VirtualMachine) -> PyResult {
+    fn slot_new(cls: PyTypeRef, _args: FuncArgs, vm: &VirtualMachine) -> PyResult {
         PyProperty {
             getter: PyRwLock::new(None),
             setter: PyRwLock::new(None),

--- a/vm/src/builtins/range.rs
+++ b/vm/src/builtins/range.rs
@@ -359,7 +359,7 @@ impl PyRange {
     }
 
     #[pyslot]
-    fn tp_new(cls: PyTypeRef, args: FuncArgs, vm: &VirtualMachine) -> PyResult {
+    fn slot_new(cls: PyTypeRef, args: FuncArgs, vm: &VirtualMachine) -> PyResult {
         let range = if args.args.len() <= 1 {
             let stop = args.bind(vm)?;
             PyRange::new(cls, stop, vm)
@@ -481,7 +481,7 @@ impl PyValue for PyLongRangeIterator {
 #[pyimpl(with(PyIter))]
 impl PyLongRangeIterator {
     #[pyslot]
-    fn tp_new(_cls: PyTypeRef, _args: FuncArgs, vm: &VirtualMachine) -> PyResult {
+    fn slot_new(_cls: PyTypeRef, _args: FuncArgs, vm: &VirtualMachine) -> PyResult {
         Err(vm.new_type_error("cannot create 'longrange_iterator' instances".to_owned()))
     }
 
@@ -550,7 +550,7 @@ impl PyValue for PyRangeIterator {
 #[pyimpl(with(PyIter))]
 impl PyRangeIterator {
     #[pyslot]
-    fn tp_new(_cls: PyTypeRef, _args: FuncArgs, vm: &VirtualMachine) -> PyResult {
+    fn slot_new(_cls: PyTypeRef, _args: FuncArgs, vm: &VirtualMachine) -> PyResult {
         Err(vm.new_type_error("cannot create 'range_iterator' instances".to_owned()))
     }
 

--- a/vm/src/builtins/set.rs
+++ b/vm/src/builtins/set.rs
@@ -369,7 +369,7 @@ macro_rules! multi_args_set {
 #[pyimpl(with(Hashable, Comparable, Iterable), flags(BASETYPE))]
 impl PySet {
     #[pyslot]
-    fn tp_new(cls: PyTypeRef, _args: FuncArgs, vm: &VirtualMachine) -> PyResult {
+    fn slot_new(cls: PyTypeRef, _args: FuncArgs, vm: &VirtualMachine) -> PyResult {
         PySet::default().into_pyresult_with_type(vm, cls)
     }
 

--- a/vm/src/builtins/slice.rs
+++ b/vm/src/builtins/slice.rs
@@ -92,7 +92,7 @@ impl PySlice {
     }
 
     #[pyslot]
-    fn tp_new(cls: PyTypeRef, args: FuncArgs, vm: &VirtualMachine) -> PyResult {
+    fn slot_new(cls: PyTypeRef, args: FuncArgs, vm: &VirtualMachine) -> PyResult {
         let slice: PySlice = match args.args.len() {
             0 => {
                 return Err(

--- a/vm/src/exceptions.rs
+++ b/vm/src/exceptions.rs
@@ -423,7 +423,7 @@ impl PyBaseException {
     }
 
     #[pyslot]
-    pub(crate) fn tp_new(cls: PyTypeRef, args: FuncArgs, vm: &VirtualMachine) -> PyResult {
+    pub(crate) fn slot_new(cls: PyTypeRef, args: FuncArgs, vm: &VirtualMachine) -> PyResult {
         PyBaseException::new(args.args, vm).into_pyresult_with_type(vm, cls)
     }
 
@@ -1077,7 +1077,7 @@ pub(super) mod types {
     }
 
     fn base_exception_new(cls: PyTypeRef, args: FuncArgs, vm: &VirtualMachine) -> PyResult {
-        PyBaseException::tp_new(cls, args, vm)
+        PyBaseException::slot_new(cls, args, vm)
     }
 
     fn import_error_init(

--- a/vm/src/macros.rs
+++ b/vm/src/macros.rs
@@ -21,12 +21,12 @@ macro_rules! extend_module {
 #[macro_export]
 macro_rules! py_class {
     ( $ctx:expr, $class_name:expr, $class_base:expr, { $($name:tt => $value:expr),* $(,)* }) => {
-        py_class!($ctx, $class_name, $class_base, $crate::slots::PyTpFlags::BASETYPE, { $($name => $value),* })
+        py_class!($ctx, $class_name, $class_base, $crate::slots::PyTypeFlags::BASETYPE, { $($name => $value),* })
     };
     ( $ctx:expr, $class_name:expr, $class_base:expr, $flags:expr, { $($name:tt => $value:expr),* $(,)* }) => {
         {
             #[allow(unused_mut)]
-            let mut slots = $crate::slots::PyTypeSlots::from_flags($crate::slots::PyTpFlags::DEFAULT | $flags);
+            let mut slots = $crate::slots::PyTypeSlots::from_flags($crate::slots::PyTypeFlags::DEFAULT | $flags);
             $($crate::py_class!(@extract_slots($ctx, &mut slots, $name, $value));)*
             let py_class = $ctx.new_class($class_name, $class_base, slots);
             $($crate::py_class!(@extract_attrs($ctx, &py_class, $name, $value));)*

--- a/vm/src/slots.rs
+++ b/vm/src/slots.rs
@@ -13,7 +13,7 @@ use crossbeam_utils::atomic::AtomicCell;
 use std::cmp::Ordering;
 
 bitflags! {
-    pub struct PyTpFlags: u64 {
+    pub struct PyTypeFlags: u64 {
         const HEAPTYPE = 1 << 9;
         const BASETYPE = 1 << 10;
         const METHOD_DESCR = 1 << 17;
@@ -24,7 +24,7 @@ bitflags! {
     }
 }
 
-impl PyTpFlags {
+impl PyTypeFlags {
     // Default used for both built-in and normal classes: empty, for now.
     // CPython default: Py_TPFLAGS_HAVE_STACKLESS_EXTENSION | Py_TPFLAGS_HAVE_VERSION_TAG
     pub const DEFAULT: Self = Self::empty();
@@ -46,7 +46,7 @@ impl PyTpFlags {
     }
 }
 
-impl Default for PyTpFlags {
+impl Default for PyTypeFlags {
     fn default() -> Self {
         Self::DEFAULT
     }
@@ -73,6 +73,8 @@ pub(crate) type BufferFunc = fn(&PyObjectRef, &VirtualMachine) -> PyResult<PyBuf
 pub(crate) type IterFunc = fn(PyObjectRef, &VirtualMachine) -> PyResult;
 pub(crate) type IterNextFunc = fn(&PyObjectRef, &VirtualMachine) -> PyResult;
 
+// The corresponding field in CPython is `tp_` prefixed.
+// e.g. name -> tp_name
 #[derive(Default)]
 pub struct PyTypeSlots {
     pub name: PyRwLock<Option<String>>, // tp_name, not class name
@@ -104,7 +106,7 @@ pub struct PyTypeSlots {
     pub iternext: AtomicCell<Option<IterNextFunc>>,
 
     // Flags to define presence of optional/expanded features
-    pub flags: PyTpFlags,
+    pub flags: PyTypeFlags,
 
     // tp_doc
     pub doc: Option<&'static str>,
@@ -129,7 +131,7 @@ pub struct PyTypeSlots {
 }
 
 impl PyTypeSlots {
-    pub fn from_flags(flags: PyTpFlags) -> Self {
+    pub fn from_flags(flags: PyTypeFlags) -> Self {
         Self {
             flags,
             ..Default::default()
@@ -148,7 +150,7 @@ pub trait SlotConstructor: PyValue {
     type Args: FromArgs;
 
     #[pyslot]
-    fn tp_new(cls: PyTypeRef, args: FuncArgs, vm: &VirtualMachine) -> PyResult {
+    fn slot_new(cls: PyTypeRef, args: FuncArgs, vm: &VirtualMachine) -> PyResult {
         let args: Self::Args = args.bind(vm)?;
         Self::py_new(cls, args, vm)
     }
@@ -159,7 +161,7 @@ pub trait SlotConstructor: PyValue {
 #[pyimpl]
 pub trait SlotDestructor: PyValue {
     #[pyslot]
-    fn tp_del(zelf: &PyObjectRef, vm: &VirtualMachine) -> PyResult<()> {
+    fn slot_del(zelf: &PyObjectRef, vm: &VirtualMachine) -> PyResult<()> {
         if let Some(zelf) = zelf.downcast_ref() {
             Self::del(zelf, vm)
         } else {
@@ -178,7 +180,7 @@ pub trait SlotDestructor: PyValue {
 #[pyimpl]
 pub trait Callable: PyValue {
     #[pyslot]
-    fn tp_call(zelf: &PyObjectRef, args: FuncArgs, vm: &VirtualMachine) -> PyResult {
+    fn slot_call(zelf: &PyObjectRef, args: FuncArgs, vm: &VirtualMachine) -> PyResult {
         if let Some(zelf) = zelf.downcast_ref() {
             Self::call(zelf, args, vm)
         } else {
@@ -238,8 +240,8 @@ pub trait SlotDescriptor: PyValue {
             //                  "descriptor '%V' for '%.100s' objects "
             //                  "doesn't apply to a '%.100s' object",
             //                  descr_name((PyDescrObject *)descr), "?",
-            //                  descr->d_type->tp_name,
-            //                  obj->ob_type->tp_name);
+            //                  descr->d_type->slot_name,
+            //                  obj->ob_type->slot_name);
             //     *pres = NULL;
             //     return 1;
             // } else {
@@ -261,7 +263,7 @@ pub trait SlotDescriptor: PyValue {
 #[pyimpl]
 pub trait Hashable: PyValue {
     #[pyslot]
-    fn tp_hash(zelf: &PyObjectRef, vm: &VirtualMachine) -> PyResult<PyHash> {
+    fn slot_hash(zelf: &PyObjectRef, vm: &VirtualMachine) -> PyResult<PyHash> {
         if let Some(zelf) = zelf.downcast_ref() {
             Self::hash(zelf, vm)
         } else {
@@ -291,7 +293,7 @@ where
 #[pyimpl]
 pub trait Comparable: PyValue {
     #[pyslot]
-    fn tp_richcompare(
+    fn slot_richcompare(
         zelf: &PyObjectRef,
         other: &PyObjectRef,
         op: PyComparisonOp,
@@ -460,7 +462,7 @@ impl PyComparisonOp {
 #[pyimpl]
 pub trait SlotGetattro: PyValue {
     #[pyslot]
-    fn tp_getattro(obj: PyObjectRef, name: PyStrRef, vm: &VirtualMachine) -> PyResult {
+    fn slot_getattro(obj: PyObjectRef, name: PyStrRef, vm: &VirtualMachine) -> PyResult {
         if let Ok(zelf) = obj.downcast::<Self>() {
             Self::getattro(zelf, name, vm)
         } else {
@@ -480,7 +482,7 @@ pub trait SlotGetattro: PyValue {
 #[pyimpl]
 pub trait SlotSetattro: PyValue {
     #[pyslot]
-    fn tp_setattro(
+    fn slot_setattro(
         obj: &PyObjectRef,
         name: PyStrRef,
         value: Option<PyObjectRef>,
@@ -520,7 +522,7 @@ pub trait SlotSetattro: PyValue {
 pub trait AsBuffer: PyValue {
     // TODO: `flags` parameter
     #[pyslot]
-    fn tp_as_buffer(zelf: &PyObjectRef, vm: &VirtualMachine) -> PyResult<PyBuffer> {
+    fn slot_as_buffer(zelf: &PyObjectRef, vm: &VirtualMachine) -> PyResult<PyBuffer> {
         let zelf = zelf
             .downcast_ref()
             .ok_or_else(|| vm.new_type_error("unexpected payload for as_buffer".to_owned()))?;
@@ -534,7 +536,7 @@ pub trait AsBuffer: PyValue {
 pub trait Iterable: PyValue {
     #[pyslot]
     #[pymethod(name = "__iter__")]
-    fn tp_iter(zelf: PyObjectRef, vm: &VirtualMachine) -> PyResult {
+    fn slot_iter(zelf: PyObjectRef, vm: &VirtualMachine) -> PyResult {
         if let Ok(zelf) = zelf.downcast() {
             Self::iter(zelf, vm)
         } else {
@@ -548,7 +550,7 @@ pub trait Iterable: PyValue {
 #[pyimpl(with(Iterable))]
 pub trait PyIter: PyValue + Iterable {
     #[pyslot]
-    fn tp_iternext(zelf: &PyObjectRef, vm: &VirtualMachine) -> PyResult {
+    fn slot_iternext(zelf: &PyObjectRef, vm: &VirtualMachine) -> PyResult {
         if let Some(zelf) = zelf.downcast_ref() {
             Self::next(zelf, vm)
         } else {
@@ -560,7 +562,7 @@ pub trait PyIter: PyValue + Iterable {
 
     #[pymethod]
     fn __next__(zelf: PyObjectRef, vm: &VirtualMachine) -> PyResult {
-        Self::tp_iternext(&zelf, vm)
+        Self::slot_iternext(&zelf, vm)
     }
 }
 
@@ -570,10 +572,10 @@ impl<T> Iterable for T
 where
     T: IteratorIterable,
 {
-    fn tp_iter(zelf: PyObjectRef, _vm: &VirtualMachine) -> PyResult {
+    fn slot_iter(zelf: PyObjectRef, _vm: &VirtualMachine) -> PyResult {
         Ok(zelf)
     }
     fn iter(_zelf: PyRef<Self>, _vm: &VirtualMachine) -> PyResult {
-        unreachable!("tp_iter is implemented");
+        unreachable!("slot_iter is implemented");
     }
 }

--- a/vm/src/stdlib/collections.rs
+++ b/vm/src/stdlib/collections.rs
@@ -73,7 +73,7 @@ mod _collections {
     #[pyimpl(flags(BASETYPE), with(Comparable, Hashable, Iterable))]
     impl PyDeque {
         #[pyslot]
-        fn tp_new(cls: PyTypeRef, _args: FuncArgs, vm: &VirtualMachine) -> PyResult {
+        fn slot_new(cls: PyTypeRef, _args: FuncArgs, vm: &VirtualMachine) -> PyResult {
             PyDeque::default().into_pyresult_with_type(vm, cls)
         }
 

--- a/vm/src/stdlib/hashlib.rs
+++ b/vm/src/stdlib/hashlib.rs
@@ -48,7 +48,7 @@ mod hashlib {
         }
 
         #[pyslot]
-        fn tp_new(_cls: PyTypeRef, _args: FuncArgs, vm: &VirtualMachine) -> PyResult {
+        fn slot_new(_cls: PyTypeRef, _args: FuncArgs, vm: &VirtualMachine) -> PyResult {
             Ok(PyHasher::new("md5", HashWrapper::md5())
                 .into_ref(vm)
                 .into_object())

--- a/vm/src/stdlib/io.rs
+++ b/vm/src/stdlib/io.rs
@@ -380,14 +380,14 @@ mod _io {
         }
 
         #[pyslot]
-        fn tp_del(instance: &PyObjectRef, vm: &VirtualMachine) -> PyResult<()> {
+        fn slot_del(instance: &PyObjectRef, vm: &VirtualMachine) -> PyResult<()> {
             let _ = vm.call_method(instance, "close", ());
             Ok(())
         }
 
         #[pymethod(magic)]
         fn del(instance: PyObjectRef, vm: &VirtualMachine) -> PyResult<()> {
-            Self::tp_del(&instance, vm)
+            Self::slot_del(&instance, vm)
         }
 
         #[pymethod(magic)]
@@ -513,18 +513,18 @@ mod _io {
     }
 
     impl Iterable for _IOBase {
-        fn tp_iter(zelf: PyObjectRef, vm: &VirtualMachine) -> PyResult {
+        fn slot_iter(zelf: PyObjectRef, vm: &VirtualMachine) -> PyResult {
             check_closed(&zelf, vm)?;
             Ok(zelf)
         }
 
         fn iter(_zelf: PyRef<Self>, _vm: &VirtualMachine) -> PyResult {
-            unreachable!("tp_iter is implemented")
+            unreachable!("slot_iter is implemented")
         }
     }
 
     impl PyIter for _IOBase {
-        fn tp_iternext(zelf: &PyObjectRef, vm: &VirtualMachine) -> PyResult {
+        fn slot_iternext(zelf: &PyObjectRef, vm: &VirtualMachine) -> PyResult {
             let line = vm.call_method(zelf, "readline", ())?;
             if !line.clone().try_to_bool(vm)? {
                 Err(vm.new_stop_iteration())
@@ -534,7 +534,7 @@ mod _io {
         }
 
         fn next(_zelf: &PyRef<Self>, _vm: &VirtualMachine) -> PyResult {
-            unreachable!("tp_iternext is implemented")
+            unreachable!("slot_iternext is implemented")
         }
     }
 
@@ -1370,7 +1370,7 @@ mod _io {
                 } else {
                     Err(vm.new_runtime_error(format!(
                         "reentrant call inside {}.__repr__",
-                        obj.class().tp_name()
+                        obj.class().slot_name()
                     )))
                 }
             }
@@ -1520,11 +1520,11 @@ mod _io {
         fn repr(zelf: PyObjectRef, vm: &VirtualMachine) -> PyResult<String> {
             let name_repr = repr_fileobj_name(&zelf, vm)?;
             let cls = zelf.class();
-            let tp_name = cls.tp_name();
+            let slot_name = cls.slot_name();
             let repr = if let Some(name_repr) = name_repr {
-                format!("<{} name={}>", tp_name, name_repr)
+                format!("<{} name={}>", slot_name, name_repr)
             } else {
-                format!("<{}>", tp_name)
+                format!("<{}>", slot_name)
             };
             Ok(repr)
         }
@@ -1665,7 +1665,7 @@ mod _io {
     #[pyimpl(with(BufferedMixin, BufferedReadable), flags(BASETYPE, HAS_DICT))]
     impl BufferedReader {
         #[pyslot]
-        fn tp_new(cls: PyTypeRef, _args: FuncArgs, vm: &VirtualMachine) -> PyResult {
+        fn slot_new(cls: PyTypeRef, _args: FuncArgs, vm: &VirtualMachine) -> PyResult {
             Self::default().into_pyresult_with_type(vm, cls)
         }
     }
@@ -1714,7 +1714,7 @@ mod _io {
     #[pyimpl(with(BufferedMixin, BufferedWritable), flags(BASETYPE, HAS_DICT))]
     impl BufferedWriter {
         #[pyslot]
-        fn tp_new(cls: PyTypeRef, _args: FuncArgs, vm: &VirtualMachine) -> PyResult {
+        fn slot_new(cls: PyTypeRef, _args: FuncArgs, vm: &VirtualMachine) -> PyResult {
             Self::default().into_pyresult_with_type(vm, cls)
         }
     }
@@ -1752,7 +1752,7 @@ mod _io {
     )]
     impl BufferedRandom {
         #[pyslot]
-        fn tp_new(cls: PyTypeRef, _args: FuncArgs, vm: &VirtualMachine) -> PyResult {
+        fn slot_new(cls: PyTypeRef, _args: FuncArgs, vm: &VirtualMachine) -> PyResult {
             Self::default().into_pyresult_with_type(vm, cls)
         }
     }
@@ -1779,7 +1779,7 @@ mod _io {
     #[pyimpl(with(BufferedReadable, BufferedWritable), flags(BASETYPE, HAS_DICT))]
     impl BufferedRWPair {
         #[pyslot]
-        fn tp_new(cls: PyTypeRef, _args: FuncArgs, vm: &VirtualMachine) -> PyResult {
+        fn slot_new(cls: PyTypeRef, _args: FuncArgs, vm: &VirtualMachine) -> PyResult {
             Self::default().into_pyresult_with_type(vm, cls)
         }
         #[pymethod(magic)]
@@ -2175,7 +2175,7 @@ mod _io {
     #[pyimpl(flags(BASETYPE))]
     impl TextIOWrapper {
         #[pyslot]
-        fn tp_new(cls: PyTypeRef, _args: FuncArgs, vm: &VirtualMachine) -> PyResult {
+        fn slot_new(cls: PyTypeRef, _args: FuncArgs, vm: &VirtualMachine) -> PyResult {
             Self::default().into_pyresult_with_type(vm, cls)
         }
 
@@ -3817,7 +3817,7 @@ mod fileio {
     #[pyimpl(flags(BASETYPE, HAS_DICT))]
     impl FileIO {
         #[pyslot]
-        fn tp_new(cls: PyTypeRef, _args: FuncArgs, vm: &VirtualMachine) -> PyResult {
+        fn slot_new(cls: PyTypeRef, _args: FuncArgs, vm: &VirtualMachine) -> PyResult {
             FileIO {
                 fd: AtomicCell::new(-1),
                 closefd: AtomicCell::new(false),

--- a/vm/src/stdlib/itertools.rs
+++ b/vm/src/stdlib/itertools.rs
@@ -31,7 +31,7 @@ mod decl {
     #[pyimpl(with(PyIter))]
     impl PyItertoolsChain {
         #[pyslot]
-        fn tp_new(cls: PyTypeRef, args: FuncArgs, vm: &VirtualMachine) -> PyResult {
+        fn slot_new(cls: PyTypeRef, args: FuncArgs, vm: &VirtualMachine) -> PyResult {
             PyItertoolsChain {
                 iterables: args.args,
                 cur_idx: AtomicCell::new(0),
@@ -710,7 +710,7 @@ mod decl {
     #[pyimpl(with(PyIter))]
     impl PyItertoolsIslice {
         #[pyslot]
-        fn tp_new(cls: PyTypeRef, args: FuncArgs, vm: &VirtualMachine) -> PyResult {
+        fn slot_new(cls: PyTypeRef, args: FuncArgs, vm: &VirtualMachine) -> PyResult {
             let (iter, start, stop, step) = match args.args.len() {
                 0 | 1 => {
                     return Err(vm.new_type_error(format!(

--- a/vm/src/stdlib/operator.rs
+++ b/vm/src/stdlib/operator.rs
@@ -435,7 +435,7 @@ mod _operator {
     #[pyimpl(with(Callable))]
     impl PyAttrGetter {
         #[pyslot]
-        fn tp_new(cls: PyTypeRef, args: FuncArgs, vm: &VirtualMachine) -> PyResult {
+        fn slot_new(cls: PyTypeRef, args: FuncArgs, vm: &VirtualMachine) -> PyResult {
             let nattr = args.args.len();
             // Check we get no keyword and at least one positional.
             if !args.kwargs.is_empty() {
@@ -532,7 +532,7 @@ mod _operator {
     #[pyimpl(with(Callable))]
     impl PyItemGetter {
         #[pyslot]
-        fn tp_new(cls: PyTypeRef, args: FuncArgs, vm: &VirtualMachine) -> PyResult {
+        fn slot_new(cls: PyTypeRef, args: FuncArgs, vm: &VirtualMachine) -> PyResult {
             // Check we get no keyword and at least one positional.
             if !args.kwargs.is_empty() {
                 return Err(vm.new_type_error("itemgetter() takes no keyword arguments".to_owned()));

--- a/vm/src/stdlib/os.rs
+++ b/vm/src/stdlib/os.rs
@@ -991,7 +991,7 @@ pub(super) mod _os {
         }
 
         #[pyslot]
-        fn tp_new(_cls: PyTypeRef, args: FuncArgs, vm: &VirtualMachine) -> PyResult {
+        fn slot_new(_cls: PyTypeRef, args: FuncArgs, vm: &VirtualMachine) -> PyResult {
             let flatten_args = |r: &[PyObjectRef]| {
                 let mut vec_args = Vec::from(r);
                 loop {

--- a/vm/src/stdlib/socket.rs
+++ b/vm/src/stdlib/socket.rs
@@ -456,7 +456,7 @@ impl PySocket {
 #[pyimpl(flags(BASETYPE))]
 impl PySocket {
     #[pyslot]
-    fn tp_new(cls: PyTypeRef, _args: FuncArgs, vm: &VirtualMachine) -> PyResult {
+    fn slot_new(cls: PyTypeRef, _args: FuncArgs, vm: &VirtualMachine) -> PyResult {
         Self::default().into_pyresult_with_type(vm, cls)
     }
 

--- a/vm/src/stdlib/sys.rs
+++ b/vm/src/stdlib/sys.rs
@@ -145,7 +145,7 @@ impl SysFlags {
     }
 
     #[pyslot]
-    fn tp_new(_cls: PyTypeRef, _args: FuncArgs, vm: &VirtualMachine) -> PyResult {
+    fn slot_new(_cls: PyTypeRef, _args: FuncArgs, vm: &VirtualMachine) -> PyResult {
         Err(vm.new_type_error("cannot create 'sys.flags' instances".to_owned()))
     }
 }

--- a/vm/src/stdlib/thread.rs
+++ b/vm/src/stdlib/thread.rs
@@ -154,7 +154,7 @@ impl fmt::Debug for PyRLock {
 #[pyimpl]
 impl PyRLock {
     #[pyslot]
-    fn tp_new(cls: PyTypeRef, _args: FuncArgs, vm: &VirtualMachine) -> PyResult {
+    fn slot_new(cls: PyTypeRef, _args: FuncArgs, vm: &VirtualMachine) -> PyResult {
         PyRLock {
             mu: RawRMutex::INIT,
         }
@@ -300,7 +300,7 @@ impl PyLocal {
     }
 
     #[pyslot]
-    fn tp_new(cls: PyTypeRef, _args: FuncArgs, vm: &VirtualMachine) -> PyResult {
+    fn slot_new(cls: PyTypeRef, _args: FuncArgs, vm: &VirtualMachine) -> PyResult {
         PyLocal {
             data: ThreadLocal::new(),
         }

--- a/vm/src/stdlib/time.rs
+++ b/vm/src/stdlib/time.rs
@@ -329,7 +329,7 @@ mod time {
         }
 
         #[pyslot]
-        fn tp_new(_cls: PyTypeRef, args: FuncArgs, vm: &VirtualMachine) -> PyResult {
+        fn slot_new(_cls: PyTypeRef, args: FuncArgs, vm: &VirtualMachine) -> PyResult {
             // cls is ignorable because this is not a basetype
             let seq = args.bind(vm)?;
             Ok(vm.new_pyobj(Self::try_from_object(vm, seq)?))

--- a/vm/src/version.rs
+++ b/vm/src/version.rs
@@ -45,7 +45,7 @@ impl VersionInfo {
         serial: SERIAL,
     };
     #[pyslot]
-    fn tp_new(
+    fn slot_new(
         _cls: crate::builtins::pytype::PyTypeRef,
         _args: crate::function::FuncArgs,
         vm: &crate::VirtualMachine,


### PR DESCRIPTION
`tp_` prefix is originated from CPython code, which conventionally use those kind of type prefixes for member fields.

RustPython is not following the naming policy, so it doesn't give any meaning to readers.
Renaming it will give more clear meanings about the type `PyTypeSlots` and slot implementation methods name.