### PR TITLE
Rename AsBuffer::{as_buffer -> tp_as_buffer, get_buffer -> as_buffer}

### DIFF
--- a/vm/src/builtins/bytearray.rs
+++ b/vm/src/builtins/bytearray.rs
@@ -667,7 +667,7 @@ impl Comparable for PyByteArray {
 }
 
 impl AsBuffer for PyByteArray {
-    fn get_buffer(zelf: &PyRef<Self>, _vm: &VirtualMachine) -> PyResult<PyBuffer> {
+    fn as_buffer(zelf: &PyRef<Self>, _vm: &VirtualMachine) -> PyResult<PyBuffer> {
         let buffer = PyBuffer::new(
             zelf.as_object().clone(),
             zelf.clone(),

--- a/vm/src/builtins/bytes.rs
+++ b/vm/src/builtins/bytes.rs
@@ -515,7 +515,7 @@ impl PyBytes {
 }
 
 impl AsBuffer for PyBytes {
-    fn get_buffer(zelf: &PyRef<Self>, _vm: &VirtualMachine) -> PyResult<PyBuffer> {
+    fn as_buffer(zelf: &PyRef<Self>, _vm: &VirtualMachine) -> PyResult<PyBuffer> {
         let buf = PyBuffer::new(
             zelf.as_object().clone(),
             zelf.clone(),

--- a/vm/src/builtins/memory.rs
+++ b/vm/src/builtins/memory.rs
@@ -676,7 +676,7 @@ impl PyMemoryView {
 }
 
 impl AsBuffer for PyMemoryView {
-    fn get_buffer(zelf: &PyRef<Self>, vm: &VirtualMachine) -> PyResult<PyBuffer> {
+    fn as_buffer(zelf: &PyRef<Self>, vm: &VirtualMachine) -> PyResult<PyBuffer> {
         if zelf.released.load() {
             Err(vm.new_value_error("operation forbidden on released memoryview object".to_owned()))
         } else {

--- a/vm/src/slots.rs
+++ b/vm/src/slots.rs
@@ -520,14 +520,14 @@ pub trait SlotSetattro: PyValue {
 pub trait AsBuffer: PyValue {
     // TODO: `flags` parameter
     #[pyslot]
-    fn as_buffer(zelf: &PyObjectRef, vm: &VirtualMachine) -> PyResult<PyBuffer> {
+    fn tp_as_buffer(zelf: &PyObjectRef, vm: &VirtualMachine) -> PyResult<PyBuffer> {
         let zelf = zelf
             .downcast_ref()
-            .ok_or_else(|| vm.new_type_error("unexpected payload for get_buffer".to_owned()))?;
-        Self::get_buffer(zelf, vm)
+            .ok_or_else(|| vm.new_type_error("unexpected payload for as_buffer".to_owned()))?;
+        Self::as_buffer(zelf, vm)
     }
 
-    fn get_buffer(zelf: &PyRef<Self>, vm: &VirtualMachine) -> PyResult<PyBuffer>;
+    fn as_buffer(zelf: &PyRef<Self>, vm: &VirtualMachine) -> PyResult<PyBuffer>;
 }
 
 #[pyimpl]

--- a/vm/src/stdlib/array.rs
+++ b/vm/src/stdlib/array.rs
@@ -1123,7 +1123,7 @@ mod array {
     }
 
     impl AsBuffer for PyArray {
-        fn get_buffer(zelf: &PyRef<Self>, _vm: &VirtualMachine) -> PyResult<PyBuffer> {
+        fn as_buffer(zelf: &PyRef<Self>, _vm: &VirtualMachine) -> PyResult<PyBuffer> {
             let array = zelf.read();
             let buf = PyBuffer::new(
                 zelf.as_object().clone(),


### PR DESCRIPTION
to follow other slot convention