### PR TITLE
OSError with filename and filename2

### DIFF
--- a/Lib/test/test_fileio.py
+++ b/Lib/test/test_fileio.py
@@ -219,9 +219,10 @@ class AutoFileTests:
         self.assertRaises(TypeError, self.f.writelines)
         self.assertRaises(ValueError, self.f.writelines, b'')
 
-    # TODO: RUSTPYTHON
-    @unittest.expectedFailure
     def testOpendir(self):
+        # TODO: RUSTPYTHON
+        if sys.platform == "win32":
+            testOpendir = unittest.expectedFailure(testOpendir)
         # Issue 3703: opening a directory should fill the errno
         # Windows always returns "[Errno 13]: Permission denied
         # Unix uses fstat and returns "[Errno 21]: Is a directory"
@@ -379,10 +380,20 @@ class CAutoFileTests(AutoFileTests, unittest.TestCase):
     def testOpenDirFD(self):
         super().testOpenDirFD()
 
+    # TODO: RUSTPYTHON
+    @unittest.expectedFailure
+    def testOpendir(self):
+        super().testOpendir()
+
 @unittest.skipIf(sys.platform == "win32", "TODO: RUSTPYTHON, test setUp errors on Windows")
 class PyAutoFileTests(AutoFileTests, unittest.TestCase):
     FileIO = _pyio.FileIO
     modulename = '_pyio'
+
+    # TODO: RUSTPYTHON
+    @unittest.expectedFailure
+    def testOpendir(self):
+        super().testOpendir()
 
 
 class OtherFileTests:

--- a/Lib/test/test_urllib.py
+++ b/Lib/test/test_urllib.py
@@ -516,8 +516,6 @@ Connection: close
         finally:
             self.unfakehttp()
 
-    # TODO: RUSTPYTHON
-    @unittest.expectedFailure
     def test_missing_localfile(self):
         # Test for #10836
         with self.assertRaises(urllib.error.URLError) as e:

--- a/Lib/test/test_urllib.py
+++ b/Lib/test/test_urllib.py
@@ -541,8 +541,6 @@ Connection: close
         with self.assertRaises(urllib.error.URLError):
             urlopen(tmp_fileurl)
 
-    # TODO: RUSTPYTHON
-    @unittest.expectedFailure
     def test_ftp_nohost(self):
         test_ftp_url = 'ftp:///path'
         with self.assertRaises(urllib.error.URLError) as e:
@@ -550,8 +548,6 @@ Connection: close
         self.assertFalse(e.exception.filename)
         self.assertTrue(e.exception.reason)
 
-    # TODO: RUSTPYTHON
-    @unittest.expectedFailure
     def test_ftp_nonexisting(self):
         with self.assertRaises(urllib.error.URLError) as e:
             urlopen('ftp://localhost/a/file/which/doesnot/exists.py')

--- a/vm/src/exceptions.rs
+++ b/vm/src/exceptions.rs
@@ -1167,8 +1167,14 @@ impl ExceptionZoo {
                 args.get(0).filter(|_| args.len() > 1).cloned()
             });
         extend_exception!(PyOSError, ctx, &excs.os_error, {
+            // POSIX exception code
             "errno" => errno_getter.clone(),
+            // exception strerror
             "strerror" => ctx.new_readonly_getset("strerror", excs.os_error.clone(), make_arg_getter(1)),
+            // exception filename
+            "filename" => ctx.none(),
+            // second exception filename
+            "filename2" => ctx.none(),
         });
         // TODO: this isn't really accurate
         #[cfg(windows)]

--- a/vm/src/stdlib/os.rs
+++ b/vm/src/stdlib/os.rs
@@ -53,6 +53,7 @@ impl OutputMode {
     }
 }
 
+#[derive(Clone)]
 pub struct PyPathLike {
     pub path: PathBuf,
     pub(super) mode: OutputMode,
@@ -205,6 +206,7 @@ impl TryFromObject for PyPathLike {
     }
 }
 
+#[derive(Clone)]
 pub(crate) enum PathOrFd {
     Path(PyPathLike),
     Fd(i32),
@@ -216,6 +218,12 @@ impl TryFromObject for PathOrFd {
             Ok(int) => int::try_to_primitive(int.as_bigint(), vm).map(Self::Fd),
             Err(obj) => PyPathLike::try_from_object(vm, obj).map(Self::Path),
         }
+    }
+}
+
+impl From<PyPathLike> for PathOrFd {
+    fn from(path: PyPathLike) -> Self {
+        Self::Path(path)
     }
 }
 
@@ -260,8 +268,11 @@ pub struct IOErrorWithFilename {
 }
 
 impl IOErrorWithFilename {
-    pub fn new(error: io::Error, path: &PyPathLike, vm: &VirtualMachine) -> Self {
-        let filename = path.filename(vm).unwrap_or_else(|_| vm.ctx.none());
+    pub(crate) fn new(error: io::Error, path: impl Into<PathOrFd>, vm: &VirtualMachine) -> Self {
+        let filename = match path.into() {
+            PathOrFd::Path(path) => path.filename(vm).unwrap_or_else(|_| vm.ctx.none()),
+            PathOrFd::Fd(fd) => vm.ctx.new_int(fd),
+        };
         IOErrorWithFilename { error, filename }
     }
 }
@@ -486,7 +497,7 @@ pub(super) mod _os {
         };
         #[cfg(not(windows))]
         let fd = {
-            let name = name.into_cstring(vm)?;
+            let name = name.clone().into_cstring(vm)?;
             #[cfg(not(target_os = "wasi"))]
             let flags = flags | libc::O_CLOEXEC;
             #[cfg(not(target_os = "redox"))]
@@ -501,7 +512,8 @@ pub(super) mod _os {
                 Fd::open(&name, flags, mode)
             }
         };
-        fd.map(|fd| fd.0).map_err(|e| e.into_pyexception(vm))
+        fd.map(|fd| fd.0)
+            .map_err(|e| IOErrorWithFilename::new(e, name, vm).into_pyexception(vm))
     }
 
     #[pyfunction]
@@ -543,7 +555,7 @@ pub(super) mod _os {
         } else {
             fs::remove_file(&path)
         };
-        res.map_err(|err| IOErrorWithFilename::new(err, &path, vm).into_pyexception(vm))
+        res.map_err(|err| IOErrorWithFilename::new(err, path, vm).into_pyexception(vm))
     }
 
     #[cfg(not(windows))]
@@ -580,7 +592,8 @@ pub(super) mod _os {
     #[pyfunction]
     fn rmdir(path: PyPathLike, dir_fd: DirFd<0>, vm: &VirtualMachine) -> PyResult<()> {
         let [] = dir_fd.0;
-        fs::remove_dir(path).map_err(|err| err.into_pyexception(vm))
+        fs::remove_dir(&path)
+            .map_err(|err| IOErrorWithFilename::new(err, path, vm).into_pyexception(vm))
     }
 
     const LISTDIR_FD: bool = cfg!(all(unix, not(target_os = "redox")));
@@ -594,7 +607,9 @@ pub(super) mod _os {
                 dir_iter
                     .map(|entry| match entry {
                         Ok(entry_path) => path.mode.process_path(entry_path.file_name(), vm),
-                        Err(e) => Err(IOErrorWithFilename::new(e, &path, vm).into_pyexception(vm)),
+                        Err(e) => {
+                            Err(IOErrorWithFilename::new(e, path.clone(), vm).into_pyexception(vm))
+                        }
                     })
                     .collect::<PyResult<_>>()?
             }
@@ -1146,8 +1161,8 @@ pub(super) mod _os {
         follow_symlinks: FollowSymlinks,
         vm: &VirtualMachine,
     ) -> PyResult {
-        let stat = stat_inner(file, dir_fd, follow_symlinks)
-            .map_err(|e| e.into_pyexception(vm))?
+        let stat = stat_inner(file.clone(), dir_fd, follow_symlinks)
+            .map_err(|e| IOErrorWithFilename::new(e, file, vm).into_pyexception(vm))?
             .ok_or_else(|| crate::exceptions::cstring_error(vm))?;
         Ok(StatResult::from_stat(&stat).into_pyobject(vm))
     }
@@ -1186,7 +1201,7 @@ pub(super) mod _os {
     #[pyfunction]
     fn chdir(path: PyPathLike, vm: &VirtualMachine) -> PyResult<()> {
         env::set_current_dir(&path.path)
-            .map_err(|err| IOErrorWithFilename::new(err, &path, vm).into_pyexception(vm))
+            .map_err(|err| IOErrorWithFilename::new(err, path, vm).into_pyexception(vm))
     }
 
     #[pyfunction]


### PR DESCRIPTION
Implement OSError members `filename` and `filename2` by adding a new
struct `IOErrorWithFilename` will implement `IntoPyException`.

This PR will *NOT* pass more CPython test(*) but will allow user to
access `attr:filename` in OSError exception which IMO is a important
feacture.

The reason why CPython test failed before is `AttributeError: 'FileNotFoundError' object has no attribute 'filename'`
After this PR the reason will become `AssertionError: ...`
This is because CPython check the identity of `err.filename` to equal the input `filename` which means the only to pass this test is to store the `filename` object directly into `PyPathLike` or `PathOrFd` and return *the* `filename` if error which is how CPython deal with this with `path_t->object`.