### PR TITLE
move init_winsock to nt

### DIFF
--- a/vm/src/stdlib/nt.rs
+++ b/vm/src/stdlib/nt.rs
@@ -429,3 +429,11 @@ macro_rules! suppress_iph {
         ret
     }};
 }
+
+pub fn init_winsock() {
+    static WSA_INIT: parking_lot::Once = parking_lot::Once::new();
+    WSA_INIT.call_once(|| unsafe {
+        let mut wsa_data = std::mem::MaybeUninit::uninit();
+        let _ = winapi::um::winsock2::WSAStartup(0x0101, wsa_data.as_mut_ptr());
+    })
+}

--- a/vm/src/stdlib/select.rs
+++ b/vm/src/stdlib/select.rs
@@ -2,7 +2,9 @@ use crate::{PyObjectRef, PyResult, TryFromBorrowedObject, TryFromObject, Virtual
 use std::{io, mem};
 
 pub(crate) fn make_module(vm: &VirtualMachine) -> PyObjectRef {
-    super::socket::init_winsock();
+    #[cfg(windows)]
+    super::nt::init_winsock();
+
     #[cfg(unix)]
     {
         use crate::PyClassImpl;

--- a/vm/src/stdlib/signal.rs
+++ b/vm/src/stdlib/signal.rs
@@ -193,7 +193,7 @@ pub(crate) mod _signal {
 
         #[cfg(windows)]
         let is_socket = if fd != INVALID_WAKEUP {
-            crate::stdlib::socket::init_winsock();
+            crate::stdlib::nt::init_winsock();
             let mut res = 0i32;
             let mut res_size = std::mem::size_of::<i32>() as i32;
             let res = unsafe {

--- a/vm/src/stdlib/socket.rs
+++ b/vm/src/stdlib/socket.rs
@@ -1819,7 +1819,8 @@ rustpython_common::static_cell! {
 }
 
 pub fn make_module(vm: &VirtualMachine) -> PyObjectRef {
-    init_winsock();
+    #[cfg(windows)]
+    super::nt::init_winsock();
 
     let ctx = &vm.ctx;
     let socket_timeout = TIMEOUT_ERROR
@@ -1978,15 +1979,4 @@ fn extend_module_platform_specific(vm: &VirtualMachine, module: &PyObjectRef) {
     extend_module!(vm, module, {
         "sethostname" => named_function!(ctx, _socket, sethostname),
     });
-}
-
-pub fn init_winsock() {
-    #[cfg(windows)]
-    {
-        static WSA_INIT: parking_lot::Once = parking_lot::Once::new();
-        WSA_INIT.call_once(|| unsafe {
-            let mut wsa_data = std::mem::MaybeUninit::uninit();
-            let _ = winapi::um::winsock2::WSAStartup(0x0101, wsa_data.as_mut_ptr());
-        })
-    }
 }


### PR DESCRIPTION
`socket` is stdlib but `signal` in vm requires this init. For now, we don't have any option to disable signal. So this might be ok.
Any better idea?