### PR TITLE
suggestion: corelib only expose pymodules

### DIFF
--- a/vm/src/builtins/memory.rs
+++ b/vm/src/builtins/memory.rs
@@ -7,11 +7,11 @@ use crate::common::{
 };
 use crate::{
     bytesinner::bytes_to_hex,
+    corelib::_struct::FormatSpec,
     function::{FuncArgs, OptionalArg},
     protocol::{BufferInternal, BufferOptions, PyBuffer},
     sliceable::{convert_slice, wrap_index, SequenceIndex},
     slots::{AsBuffer, Comparable, Hashable, PyComparisonOp, SlotConstructor},
-    stdlib::pystruct::_struct::FormatSpec,
     utils::Either,
     IdProtocol, IntoPyObject, PyClassImpl, PyComparisonValue, PyContext, PyObjectRef, PyRef,
     PyResult, PyValue, TryFromBorrowedObject, TryFromObject, TypeProtocol, VirtualMachine,

--- a/vm/src/corelib.rs
+++ b/vm/src/corelib.rs
@@ -1,0 +1,5 @@
+#[cfg(windows)]
+pub use super::stdlib::nt::module as nt;
+#[cfg(unix)]
+pub use super::stdlib::posix::module as posix;
+pub use super::stdlib::{pystruct::_struct, time::time};

--- a/vm/src/lib.rs
+++ b/vm/src/lib.rs
@@ -48,6 +48,7 @@ mod bytesinner;
 pub mod byteslike;
 pub mod cformat;
 mod codecs;
+pub mod corelib;
 mod coroutine;
 #[cfg(any(unix, windows, target_os = "wasi"))]
 mod crt_fd;

--- a/vm/src/stdlib/mod.rs
+++ b/vm/src/stdlib/mod.rs
@@ -38,7 +38,7 @@ mod sysconfigdata;
 mod syslog;
 #[cfg(feature = "threading")]
 mod thread;
-mod time;
+pub(crate) mod time;
 mod unicodedata;
 mod warnings;
 mod weakref;

--- a/vm/src/stdlib/nt.rs
+++ b/vm/src/stdlib/nt.rs
@@ -421,11 +421,11 @@ pub(crate) mod module {
 #[macro_export]
 macro_rules! suppress_iph {
     ($e:expr) => {{
-        let old = $crate::stdlib::nt::module::_set_thread_local_invalid_parameter_handler(
-            $crate::stdlib::nt::module::silent_iph_handler,
+        let old = $crate::corelib::nt::_set_thread_local_invalid_parameter_handler(
+            $crate::corelib::nt::silent_iph_handler,
         );
         let ret = $e;
-        $crate::stdlib::nt::module::_set_thread_local_invalid_parameter_handler(old);
+        $crate::corelib::nt::_set_thread_local_invalid_parameter_handler(old);
         ret
     }};
 }

--- a/vm/src/stdlib/pystruct.rs
+++ b/vm/src/stdlib/pystruct.rs
@@ -10,7 +10,7 @@
  */
 
 #[pymodule]
-pub(crate) mod _struct {
+pub mod _struct {
     use crate::{
         builtins::{
             bytes::PyBytesRef, float, pybool::IntoPyBool, pystr::PyStr, pystr::PyStrRef,

--- a/vm/src/stdlib/select.rs
+++ b/vm/src/stdlib/select.rs
@@ -150,7 +150,7 @@ fn sec_to_timeval(sec: f64) -> timeval {
 mod decl {
     use super::*;
     use crate::{
-        exceptions::IntoPyException, function::OptionalOption, stdlib::time, utils::Either,
+        corelib::time, exceptions::IntoPyException, function::OptionalOption, utils::Either,
         PyObjectRef, PyResult, VirtualMachine,
     };
 
@@ -171,7 +171,7 @@ mod decl {
                 return Err(vm.new_value_error("timeout must be positive".to_owned()));
             }
         }
-        let deadline = timeout.map(|s| time::get_time(vm).unwrap() + s);
+        let deadline = timeout.map(|s| time::time(vm).unwrap() + s);
 
         let seq2set = |list| -> PyResult<(Vec<Selectable>, FdSet)> {
             let v = vm.extract_elements::<Selectable>(list)?;
@@ -210,7 +210,7 @@ mod decl {
             vm.check_signals()?;
 
             if let Some(ref mut timeout) = timeout {
-                *timeout = deadline.unwrap() - time::get_time(vm).unwrap();
+                *timeout = deadline.unwrap() - time::time(vm).unwrap();
                 if *timeout < 0.0 {
                     r.clear();
                     w.clear();

--- a/vm/src/stdlib/time.rs
+++ b/vm/src/stdlib/time.rs
@@ -15,12 +15,12 @@ pub(crate) fn make_module(vm: &VirtualMachine) -> PyObjectRef {
 }
 
 #[cfg(any(not(target_arch = "wasm32"), target_os = "wasi"))]
-pub(crate) fn get_time(vm: &VirtualMachine) -> PyResult<f64> {
+fn get_time(vm: &VirtualMachine) -> PyResult<f64> {
     Ok(duration_since_system_now(vm)?.as_secs_f64())
 }
 
 #[cfg(all(target_arch = "wasm32", not(target_os = "wasi")))]
-pub(crate) fn get_time(_vm: &VirtualMachine) -> PyResult<f64> {
+fn get_time(_vm: &VirtualMachine) -> PyResult<f64> {
     use wasm_bindgen::prelude::*;
     #[wasm_bindgen]
     extern "C" {
@@ -41,7 +41,7 @@ fn duration_since_system_now(vm: &VirtualMachine) -> PyResult<std::time::Duratio
 }
 
 #[pymodule(name = "time")]
-mod time {
+pub mod time {
     use crate::{
         builtins::{PyStrRef, PyTypeRef},
         function::{FuncArgs, OptionalArg},
@@ -84,7 +84,7 @@ mod time {
 
     #[pyfunction(name = "perf_counter")] // TODO: fix
     #[pyfunction]
-    fn time(vm: &VirtualMachine) -> PyResult<f64> {
+    pub fn time(vm: &VirtualMachine) -> PyResult<f64> {
         super::get_time(vm)
     }
 


### PR DESCRIPTION
This is a sugestion about module public api.

What users should see in our module public api?
My suggestion is the same as Python.

So, if there is `time.time()` in Python, `corelib::time::time()` in Rust.

To achieve this, we need to expose inner pymodule to public api, not the outer one currently in `vm::stdlib`
