### PR TITLE
PyObjectRef::try_into_value

### DIFF
--- a/stdlib/src/json.rs
+++ b/stdlib/src/json.rs
@@ -9,7 +9,7 @@ mod _json {
         function::{FuncArgs, IntoPyObject, IntoPyResult, OptionalArg},
         protocol::PyIterReturn,
         slots::{Callable, SlotConstructor},
-        IdProtocol, PyObjectRef, PyRef, PyResult, PyValue, TryFromObject, VirtualMachine,
+        IdProtocol, PyObjectRef, PyRef, PyResult, PyValue, VirtualMachine,
     };
     use num_bigint::BigInt;
     use std::str::FromStr;
@@ -251,7 +251,7 @@ mod _json {
         let get_error = || -> PyResult<_> {
             let cls = vm.try_class("json", "JSONDecodeError")?;
             let exc = vm.invoke(cls.as_object(), (e.msg, s, e.pos))?;
-            PyBaseExceptionRef::try_from_object(vm, exc)
+            exc.try_into_value(vm)
         };
         match get_error() {
             Ok(x) | Err(x) => x,

--- a/stdlib/src/select.rs
+++ b/stdlib/src/select.rs
@@ -1,4 +1,4 @@
-use crate::vm::{PyObjectRef, PyResult, TryFromBorrowedObject, TryFromObject, VirtualMachine};
+use crate::vm::{PyObjectRef, PyResult, TryFromObject, VirtualMachine};
 use std::{io, mem};
 
 pub(crate) fn make_module(vm: &VirtualMachine) -> PyObjectRef {
@@ -72,11 +72,11 @@ struct Selectable {
 
 impl TryFromObject for Selectable {
     fn try_from_object(vm: &VirtualMachine, obj: PyObjectRef) -> PyResult<Self> {
-        let fno = RawFd::try_from_borrowed_object(vm, &obj).or_else(|_| {
+        let fno = obj.try_borrow_to_object(vm).or_else(|_| {
             let meth = vm.get_method_or_type_error(obj.clone(), "fileno", || {
                 "select arg must be an int or object with a fileno() method".to_owned()
             })?;
-            RawFd::try_from_object(vm, vm.invoke(&meth, ())?)
+            vm.invoke(&meth, ())?.try_into_value(vm)
         })?;
         Ok(Selectable { obj, fno })
     }

--- a/stdlib/src/syslog.rs
+++ b/stdlib/src/syslog.rs
@@ -7,7 +7,7 @@ mod syslog {
         builtins::{PyStr, PyStrRef},
         function::{OptionalArg, OptionalOption},
         utils::ToCString,
-        PyObjectRef, PyResult, PyValue, TryFromObject, VirtualMachine,
+        PyObjectRef, PyResult, PyValue, VirtualMachine,
     };
     use std::{ffi::CStr, os::raw::c_char};
 
@@ -104,8 +104,8 @@ mod syslog {
     #[pyfunction]
     fn syslog(args: SysLogArgs, vm: &VirtualMachine) -> PyResult<()> {
         let (priority, msg) = match args.message_object.flatten() {
-            Some(s) => (i32::try_from_object(vm, args.priority)?, s),
-            None => (LOG_INFO, PyStrRef::try_from_object(vm, args.priority)?),
+            Some(s) => (args.priority.try_into_value(vm)?, s),
+            None => (LOG_INFO, args.priority.try_into_value(vm)?),
         };
 
         if global_ident().read().is_none() {

--- a/stdlib/src/termios.rs
+++ b/stdlib/src/termios.rs
@@ -58,13 +58,13 @@ mod termios {
                 })?
                 .clone();
         let mut termios = Termios::from_fd(fd).map_err(|e| termios_error(e, vm))?;
-        termios.c_iflag = TryFromObject::try_from_object(vm, iflag)?;
-        termios.c_oflag = TryFromObject::try_from_object(vm, oflag)?;
-        termios.c_cflag = TryFromObject::try_from_object(vm, cflag)?;
-        termios.c_lflag = TryFromObject::try_from_object(vm, lflag)?;
-        termios::cfsetispeed(&mut termios, TryFromObject::try_from_object(vm, ispeed)?)
+        termios.c_iflag = iflag.try_into_value(vm)?;
+        termios.c_oflag = oflag.try_into_value(vm)?;
+        termios.c_cflag = cflag.try_into_value(vm)?;
+        termios.c_lflag = lflag.try_into_value(vm)?;
+        termios::cfsetispeed(&mut termios, ispeed.try_into_value(vm)?)
             .map_err(|e| termios_error(e, vm))?;
-        termios::cfsetospeed(&mut termios, TryFromObject::try_from_object(vm, ospeed)?)
+        termios::cfsetospeed(&mut termios, ospeed.try_into_value(vm)?)
             .map_err(|e| termios_error(e, vm))?;
         let cc = PyListRef::try_from_object(vm, cc)?;
         {

--- a/vm/src/builtins/pytype.rs
+++ b/vm/src/builtins/pytype.rs
@@ -9,7 +9,7 @@ use crate::{
     slots::{self, Callable, PyTypeFlags, PyTypeSlots, SlotGetattro, SlotSetattro},
     utils::Either,
     IdProtocol, PyAttributes, PyClassImpl, PyContext, PyLease, PyObjectRef, PyRef, PyResult,
-    PyValue, TryFromObject, TypeProtocol, VirtualMachine,
+    PyValue, TypeProtocol, VirtualMachine,
 };
 use itertools::Itertools;
 use num_traits::ToPrimitive;
@@ -831,7 +831,7 @@ fn subtype_set_dict(obj: PyObjectRef, value: PyObjectRef, vm: &VirtualMachine) -
             descr_set(descr, obj, Some(value), vm)
         }
         None => {
-            object::object_set_dict(obj, PyDictRef::try_from_object(vm, value)?, vm)?;
+            object::object_set_dict(obj, value.try_into_value(vm)?, vm)?;
             Ok(())
         }
     }

--- a/vm/src/codecs.rs
+++ b/vm/src/codecs.rs
@@ -204,7 +204,7 @@ impl CodecsRegistry {
         let encoding = PyStr::from(encoding.into_owned()).into_ref(vm);
         for func in search_path {
             let res = vm.invoke(&func, (encoding.clone(),))?;
-            let res = <Option<PyCodec>>::try_from_object(vm, res)?;
+            let res: Option<PyCodec> = res.try_into_value(vm)?;
             if let Some(codec) = res {
                 let mut inner = self.inner.write();
                 // someone might have raced us to this, so use theirs
@@ -334,9 +334,9 @@ fn normalize_encoding_name(encoding: &str) -> Cow<'_, str> {
 // TODO: exceptions with custom payloads
 fn extract_unicode_error_range(err: &PyObjectRef, vm: &VirtualMachine) -> PyResult<Range<usize>> {
     let start = vm.get_attribute(err.clone(), "start")?;
-    let start = usize::try_from_object(vm, start)?;
+    let start = start.try_into_value(vm)?;
     let end = vm.get_attribute(err.clone(), "end")?;
-    let end = usize::try_from_object(vm, end)?;
+    let end = end.try_into_value(vm)?;
     Ok(Range { start, end })
 }
 

--- a/vm/src/exceptions.rs
+++ b/vm/src/exceptions.rs
@@ -249,7 +249,7 @@ pub fn invoke(
 ) -> PyResult<PyBaseExceptionRef> {
     // TODO: fast-path built-in exceptions by directly instantiating them? Is that really worth it?
     let res = vm.invoke(cls.as_object(), args)?;
-    PyBaseExceptionRef::try_from_object(vm, res)
+    res.try_into_value(vm)
 }
 
 impl ExceptionCtor {

--- a/vm/src/pyobject.rs
+++ b/vm/src/pyobject.rs
@@ -759,6 +759,22 @@ pub trait TryFromBorrowedObject: Sized {
     fn try_from_borrowed_object(vm: &VirtualMachine, obj: &PyObjectRef) -> PyResult<Self>;
 }
 
+impl PyObjectRef {
+    pub fn try_into_value<T>(self, vm: &VirtualMachine) -> PyResult<T>
+    where
+        T: TryFromObject,
+    {
+        T::try_from_object(vm, self)
+    }
+
+    pub fn try_borrow_to_object<T>(&self, vm: &VirtualMachine) -> PyResult<T>
+    where
+        T: TryFromBorrowedObject,
+    {
+        T::try_from_borrowed_object(vm, self)
+    }
+}
+
 /// Marks a type that has the exact same layout as PyObjectRef, e.g. a type that is
 /// `repr(transparent)` over PyObjectRef.
 ///

--- a/vm/src/slots.rs
+++ b/vm/src/slots.rs
@@ -4,8 +4,8 @@ use crate::{
     function::{FromArgs, FuncArgs, IntoPyResult, OptionalArg},
     protocol::{PyBuffer, PyIterReturn, PyMappingMethods},
     utils::Either,
-    IdProtocol, PyComparisonValue, PyObjectRef, PyRef, PyResult, PyValue, TryFromObject,
-    TypeProtocol, VirtualMachine,
+    IdProtocol, PyComparisonValue, PyObjectRef, PyRef, PyResult, PyValue, TypeProtocol,
+    VirtualMachine,
 };
 use crossbeam_utils::atomic::AtomicCell;
 use std::cmp::Ordering;
@@ -215,7 +215,7 @@ pub trait SlotDescriptor: PyValue {
     }
 
     fn _zelf(zelf: PyObjectRef, vm: &VirtualMachine) -> PyResult<PyRef<Self>> {
-        PyRef::<Self>::try_from_object(vm, zelf)
+        zelf.try_into_value(vm)
     }
 
     fn _unwrap(

--- a/vm/src/stdlib/ast.rs
+++ b/vm/src/stdlib/ast.rs
@@ -170,7 +170,7 @@ impl Node for usize {
     }
 
     fn ast_from_object(vm: &VirtualMachine, object: PyObjectRef) -> PyResult<Self> {
-        Self::try_from_object(vm, object)
+        object.try_into_value(vm)
     }
 }
 

--- a/vm/src/stdlib/io.rs
+++ b/vm/src/stdlib/io.rs
@@ -182,10 +182,10 @@ mod _io {
     ) -> PyResult<SeekFrom> {
         let seek = match how {
             OptionalArg::Present(0) | OptionalArg::Missing => {
-                SeekFrom::Start(u64::try_from_object(vm, offset)?)
+                SeekFrom::Start(offset.try_into_value(vm)?)
             }
-            OptionalArg::Present(1) => SeekFrom::Current(i64::try_from_object(vm, offset)?),
-            OptionalArg::Present(2) => SeekFrom::End(i64::try_from_object(vm, offset)?),
+            OptionalArg::Present(1) => SeekFrom::Current(offset.try_into_value(vm)?),
+            OptionalArg::Present(2) => SeekFrom::End(offset.try_into_value(vm)?),
             _ => return Err(vm.new_value_error("invalid value for how".to_owned())),
         };
         Ok(seek)
@@ -3537,9 +3537,7 @@ mod _io {
 
         // check file descriptor validity
         #[cfg(unix)]
-        if let Ok(crate::stdlib::os::PathOrFd::Fd(fd)) =
-            TryFromObject::try_from_object(vm, file.clone())
-        {
+        if let Ok(crate::stdlib::os::PathOrFd::Fd(fd)) = file.clone().try_into_value(vm) {
             nix::fcntl::fcntl(fd, nix::fcntl::F_GETFD)
                 .map_err(|_| crate::stdlib::os::errno_err(vm))?;
         }

--- a/vm/src/stdlib/time.rs
+++ b/vm/src/stdlib/time.rs
@@ -318,7 +318,7 @@ mod time {
             let invalid = || vm.new_value_error("invalid struct_time parameter".to_owned());
             macro_rules! field {
                 ($field:ident) => {
-                    TryFromObject::try_from_object(vm, self.$field.clone())?
+                    self.$field.clone().try_into_value(vm)?
                 };
             }
             let dt = NaiveDateTime::new(

--- a/vm/src/vm.rs
+++ b/vm/src/vm.rs
@@ -878,13 +878,13 @@ impl VirtualMachine {
             Ok(obj.clone().downcast().unwrap())
         } else {
             let s = self.call_special_method(obj.clone(), "__str__", ())?;
-            PyStrRef::try_from_object(self, s)
+            s.try_into_value(self)
         }
     }
 
     pub fn to_repr(&self, obj: &PyObjectRef) -> PyResult<PyStrRef> {
         let repr = self.call_special_method(obj.clone(), "__repr__", ())?;
-        PyStrRef::try_from_object(self, repr)
+        repr.try_into_value(self)
     }
 
     pub fn to_index_opt(&self, obj: PyObjectRef) -> Option<PyResult<PyIntRef>> {


### PR DESCRIPTION
as counterpart of TryFromObject::try_from_object

This is useful when the type to infer is known