### PR TITLE
Add `asinh` function to `cmath`

### DIFF
--- a/Lib/test/test_cmath.py
+++ b/Lib/test/test_cmath.py
@@ -56,8 +56,8 @@ class CMathTests(unittest.TestCase):
     #
     # list of all functions in cmath
     test_functions = [getattr(cmath, fname) for fname in [
-        'sin','cos','log','log10','sqrt','acosh','tan','tanh'
-        # 'exp','acos','asin','asinh',
+        'sin','cos','log','log10','sqrt','acosh','tan','tanh','asinh'
+        # 'exp','acos','asin',
         # 'atan','atanh','sinh','cosh'
         ]]
     # test first and second arguments independently for 2-argument log

--- a/vm/src/stdlib/cmath.rs
+++ b/vm/src/stdlib/cmath.rs
@@ -120,6 +120,12 @@ mod cmath {
         z.to_complex().tanh()
     }
 
+    /// Return the inverse hyperbolic sine of z.
+    #[pyfunction]
+    fn asinh(z: IntoPyComplex) -> Complex64 {
+        z.to_complex().asinh()
+    }
+
     #[derive(FromArgs)]
     struct IsCloseArgs {
         #[pyarg(positional)]


### PR DESCRIPTION
This implement `asinh` in #3039

**Before**
```python
>>>>> import cmath
>>>>> cmath.asinh(2)
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
AttributeError: module 'cmath' has no attribute 'asinh'
```

**After**
```python
>>>>> import cmath
>>>>> cmath.asinh(2)
(1.4436354751788103+0j)
```