### PR TITLE
Add `atanh` and `atan` to `cmath`

### DIFF
--- a/Lib/test/test_cmath.py
+++ b/Lib/test/test_cmath.py
@@ -56,9 +56,9 @@ class CMathTests(unittest.TestCase):
     #
     # list of all functions in cmath
     test_functions = [getattr(cmath, fname) for fname in [
-        'sin','cos','log','log10','sqrt','acosh','tan','tanh','asinh'
+        'sin','cos','log','log10','sqrt','acosh','tan','tanh','asinh', 'atan', 'atanh'
         # 'exp','acos','asin',
-        # 'atan','atanh','sinh','cosh'
+        # 'sinh','cosh'
         ]]
     # test first and second arguments independently for 2-argument log
     # test_functions.append(lambda x : cmath.log(x, 1729. + 0j))

--- a/vm/src/stdlib/cmath.rs
+++ b/vm/src/stdlib/cmath.rs
@@ -108,6 +108,18 @@ mod cmath {
         z.to_complex().acosh()
     }
 
+    /// Return the inverse tangent of z.
+    #[pyfunction]
+    fn atan(z: IntoPyComplex) -> Complex64 {
+        z.to_complex().atan()
+    }
+
+    /// Return the inverse hyperbolic tangent of z.
+    #[pyfunction]
+    fn atanh(z: IntoPyComplex) -> Complex64 {
+        z.to_complex().atanh()
+    }
+
     /// Return the tangent of z.
     #[pyfunction]
     fn tan(z: IntoPyComplex) -> Complex64 {


### PR DESCRIPTION
This implement `atan` and `atanh` in #3039

**Before**
```python
>>>>> import cmath
>>>>> cmath.atan(1)
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
AttributeError: module 'cmath' has no attribute 'atan'
>>>>> cmath.atanh(1)
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
AttributeError: module 'cmath' has no attribute 'atanh'
```

**After**
```python
>>>>> import cmath
>>>>> cmath.atan(2)
(1.1071487177940904+0j)
>>>>> cmath.atanh(2)
(0.5493061443340549-1.5707963267948966j)
```