### PR TITLE
Implement `PyIter_Check`

### DIFF
--- a/vm/src/stdlib/builtins.rs
+++ b/vm/src/stdlib/builtins.rs
@@ -513,6 +513,13 @@ mod builtins {
         default_value: OptionalArg<PyObjectRef>,
         vm: &VirtualMachine,
     ) -> PyResult {
+        if !PyIter::check(&iterator) {
+            return Err(vm.new_type_error(format!(
+                "{} object is not an iterator",
+                iterator.class().name()
+            )));
+        }
+
         PyIter::new(iterator).next(vm).or_else(|err| {
             if err.isinstance(&vm.ctx.exceptions.stop_iteration) {
                 default_value.ok_or(err)


### PR DESCRIPTION
This revision may resolve #3176 

Add `check` method in `PyIter` as static method and use it at the proper location.
It can be also used in pickle, sqlite, etc (which is not yet implemented in RustPython).