### PR TITLE
Add missing tests from cpython 3.8

### DIFF
--- a/Lib/binhex.py
+++ b/Lib/binhex.py
@@ -1,0 +1,479 @@
+"""Macintosh binhex compression/decompression.
+
+easy interface:
+binhex(inputfilename, outputfilename)
+hexbin(inputfilename, outputfilename)
+"""
+
+#
+# Jack Jansen, CWI, August 1995.
+#
+# The module is supposed to be as compatible as possible. Especially the
+# easy interface should work "as expected" on any platform.
+# XXXX Note: currently, textfiles appear in mac-form on all platforms.
+# We seem to lack a simple character-translate in python.
+# (we should probably use ISO-Latin-1 on all but the mac platform).
+# XXXX The simple routines are too simple: they expect to hold the complete
+# files in-core. Should be fixed.
+# XXXX It would be nice to handle AppleDouble format on unix
+# (for servers serving macs).
+# XXXX I don't understand what happens when you get 0x90 times the same byte on
+# input. The resulting code (xx 90 90) would appear to be interpreted as an
+# escaped *value* of 0x90. All coders I've seen appear to ignore this nicety...
+#
+import io
+import os
+import struct
+import binascii
+
+__all__ = ["binhex","hexbin","Error"]
+
+class Error(Exception):
+    pass
+
+# States (what have we written)
+_DID_HEADER = 0
+_DID_DATA = 1
+
+# Various constants
+REASONABLY_LARGE = 32768  # Minimal amount we pass the rle-coder
+LINELEN = 64
+RUNCHAR = b"\x90"
+
+#
+# This code is no longer byte-order dependent
+
+
+class FInfo:
+    def __init__(self):
+        self.Type = '????'
+        self.Creator = '????'
+        self.Flags = 0
+
+def getfileinfo(name):
+    finfo = FInfo()
+    with io.open(name, 'rb') as fp:
+        # Quick check for textfile
+        data = fp.read(512)
+        if 0 not in data:
+            finfo.Type = 'TEXT'
+        fp.seek(0, 2)
+        dsize = fp.tell()
+    dir, file = os.path.split(name)
+    file = file.replace(':', '-', 1)
+    return file, finfo, dsize, 0
+
+class openrsrc:
+    def __init__(self, *args):
+        pass
+
+    def read(self, *args):
+        return b''
+
+    def write(self, *args):
+        pass
+
+    def close(self):
+        pass
+
+class _Hqxcoderengine:
+    """Write data to the coder in 3-byte chunks"""
+
+    def __init__(self, ofp):
+        self.ofp = ofp
+        self.data = b''
+        self.hqxdata = b''
+        self.linelen = LINELEN - 1
+
+    def write(self, data):
+        self.data = self.data + data
+        datalen = len(self.data)
+        todo = (datalen // 3) * 3
+        data = self.data[:todo]
+        self.data = self.data[todo:]
+        if not data:
+            return
+        self.hqxdata = self.hqxdata + binascii.b2a_hqx(data)
+        self._flush(0)
+
+    def _flush(self, force):
+        first = 0
+        while first <= len(self.hqxdata) - self.linelen:
+            last = first + self.linelen
+            self.ofp.write(self.hqxdata[first:last] + b'\r')
+            self.linelen = LINELEN
+            first = last
+        self.hqxdata = self.hqxdata[first:]
+        if force:
+            self.ofp.write(self.hqxdata + b':\r')
+
+    def close(self):
+        if self.data:
+            self.hqxdata = self.hqxdata + binascii.b2a_hqx(self.data)
+        self._flush(1)
+        self.ofp.close()
+        del self.ofp
+
+class _Rlecoderengine:
+    """Write data to the RLE-coder in suitably large chunks"""
+
+    def __init__(self, ofp):
+        self.ofp = ofp
+        self.data = b''
+
+    def write(self, data):
+        self.data = self.data + data
+        if len(self.data) < REASONABLY_LARGE:
+            return
+        rledata = binascii.rlecode_hqx(self.data)
+        self.ofp.write(rledata)
+        self.data = b''
+
+    def close(self):
+        if self.data:
+            rledata = binascii.rlecode_hqx(self.data)
+            self.ofp.write(rledata)
+        self.ofp.close()
+        del self.ofp
+
+class BinHex:
+    def __init__(self, name_finfo_dlen_rlen, ofp):
+        name, finfo, dlen, rlen = name_finfo_dlen_rlen
+        close_on_error = False
+        if isinstance(ofp, str):
+            ofname = ofp
+            ofp = io.open(ofname, 'wb')
+            close_on_error = True
+        try:
+            ofp.write(b'(This file must be converted with BinHex 4.0)\r\r:')
+            hqxer = _Hqxcoderengine(ofp)
+            self.ofp = _Rlecoderengine(hqxer)
+            self.crc = 0
+            if finfo is None:
+                finfo = FInfo()
+            self.dlen = dlen
+            self.rlen = rlen
+            self._writeinfo(name, finfo)
+            self.state = _DID_HEADER
+        except:
+            if close_on_error:
+                ofp.close()
+            raise
+
+    def _writeinfo(self, name, finfo):
+        nl = len(name)
+        if nl > 63:
+            raise Error('Filename too long')
+        d = bytes([nl]) + name.encode("latin-1") + b'\0'
+        tp, cr = finfo.Type, finfo.Creator
+        if isinstance(tp, str):
+            tp = tp.encode("latin-1")
+        if isinstance(cr, str):
+            cr = cr.encode("latin-1")
+        d2 = tp + cr
+
+        # Force all structs to be packed with big-endian
+        d3 = struct.pack('>h', finfo.Flags)
+        d4 = struct.pack('>ii', self.dlen, self.rlen)
+        info = d + d2 + d3 + d4
+        self._write(info)
+        self._writecrc()
+
+    def _write(self, data):
+        self.crc = binascii.crc_hqx(data, self.crc)
+        self.ofp.write(data)
+
+    def _writecrc(self):
+        # XXXX Should this be here??
+        # self.crc = binascii.crc_hqx('\0\0', self.crc)
+        if self.crc < 0:
+            fmt = '>h'
+        else:
+            fmt = '>H'
+        self.ofp.write(struct.pack(fmt, self.crc))
+        self.crc = 0
+
+    def write(self, data):
+        if self.state != _DID_HEADER:
+            raise Error('Writing data at the wrong time')
+        self.dlen = self.dlen - len(data)
+        self._write(data)
+
+    def close_data(self):
+        if self.dlen != 0:
+            raise Error('Incorrect data size, diff=%r' % (self.rlen,))
+        self._writecrc()
+        self.state = _DID_DATA
+
+    def write_rsrc(self, data):
+        if self.state < _DID_DATA:
+            self.close_data()
+        if self.state != _DID_DATA:
+            raise Error('Writing resource data at the wrong time')
+        self.rlen = self.rlen - len(data)
+        self._write(data)
+
+    def close(self):
+        if self.state is None:
+            return
+        try:
+            if self.state < _DID_DATA:
+                self.close_data()
+            if self.state != _DID_DATA:
+                raise Error('Close at the wrong time')
+            if self.rlen != 0:
+                raise Error("Incorrect resource-datasize, diff=%r" % (self.rlen,))
+            self._writecrc()
+        finally:
+            self.state = None
+            ofp = self.ofp
+            del self.ofp
+            ofp.close()
+
+def binhex(inp, out):
+    """binhex(infilename, outfilename): create binhex-encoded copy of a file"""
+    finfo = getfileinfo(inp)
+    ofp = BinHex(finfo, out)
+
+    with io.open(inp, 'rb') as ifp:
+        # XXXX Do textfile translation on non-mac systems
+        while True:
+            d = ifp.read(128000)
+            if not d: break
+            ofp.write(d)
+        ofp.close_data()
+
+    ifp = openrsrc(inp, 'rb')
+    while True:
+        d = ifp.read(128000)
+        if not d: break
+        ofp.write_rsrc(d)
+    ofp.close()
+    ifp.close()
+
+class _Hqxdecoderengine:
+    """Read data via the decoder in 4-byte chunks"""
+
+    def __init__(self, ifp):
+        self.ifp = ifp
+        self.eof = 0
+
+    def read(self, totalwtd):
+        """Read at least wtd bytes (or until EOF)"""
+        decdata = b''
+        wtd = totalwtd
+        #
+        # The loop here is convoluted, since we don't really now how
+        # much to decode: there may be newlines in the incoming data.
+        while wtd > 0:
+            if self.eof: return decdata
+            wtd = ((wtd + 2) // 3) * 4
+            data = self.ifp.read(wtd)
+            #
+            # Next problem: there may not be a complete number of
+            # bytes in what we pass to a2b. Solve by yet another
+            # loop.
+            #
+            while True:
+                try:
+                    decdatacur, self.eof = binascii.a2b_hqx(data)
+                    break
+                except binascii.Incomplete:
+                    pass
+                newdata = self.ifp.read(1)
+                if not newdata:
+                    raise Error('Premature EOF on binhex file')
+                data = data + newdata
+            decdata = decdata + decdatacur
+            wtd = totalwtd - len(decdata)
+            if not decdata and not self.eof:
+                raise Error('Premature EOF on binhex file')
+        return decdata
+
+    def close(self):
+        self.ifp.close()
+
+class _Rledecoderengine:
+    """Read data via the RLE-coder"""
+
+    def __init__(self, ifp):
+        self.ifp = ifp
+        self.pre_buffer = b''
+        self.post_buffer = b''
+        self.eof = 0
+
+    def read(self, wtd):
+        if wtd > len(self.post_buffer):
+            self._fill(wtd - len(self.post_buffer))
+        rv = self.post_buffer[:wtd]
+        self.post_buffer = self.post_buffer[wtd:]
+        return rv
+
+    def _fill(self, wtd):
+        self.pre_buffer = self.pre_buffer + self.ifp.read(wtd + 4)
+        if self.ifp.eof:
+            self.post_buffer = self.post_buffer + \
+                binascii.rledecode_hqx(self.pre_buffer)
+            self.pre_buffer = b''
+            return
+
+        #
+        # Obfuscated code ahead. We have to take care that we don't
+        # end up with an orphaned RUNCHAR later on. So, we keep a couple
+        # of bytes in the buffer, depending on what the end of
+        # the buffer looks like:
+        # '\220\0\220' - Keep 3 bytes: repeated \220 (escaped as \220\0)
+        # '?\220' - Keep 2 bytes: repeated something-else
+        # '\220\0' - Escaped \220: Keep 2 bytes.
+        # '?\220?' - Complete repeat sequence: decode all
+        # otherwise: keep 1 byte.
+        #
+        mark = len(self.pre_buffer)
+        if self.pre_buffer[-3:] == RUNCHAR + b'\0' + RUNCHAR:
+            mark = mark - 3
+        elif self.pre_buffer[-1:] == RUNCHAR:
+            mark = mark - 2
+        elif self.pre_buffer[-2:] == RUNCHAR + b'\0':
+            mark = mark - 2
+        elif self.pre_buffer[-2:-1] == RUNCHAR:
+            pass # Decode all
+        else:
+            mark = mark - 1
+
+        self.post_buffer = self.post_buffer + \
+            binascii.rledecode_hqx(self.pre_buffer[:mark])
+        self.pre_buffer = self.pre_buffer[mark:]
+
+    def close(self):
+        self.ifp.close()
+
+class HexBin:
+    def __init__(self, ifp):
+        if isinstance(ifp, str):
+            ifp = io.open(ifp, 'rb')
+        #
+        # Find initial colon.
+        #
+        while True:
+            ch = ifp.read(1)
+            if not ch:
+                raise Error("No binhex data found")
+            # Cater for \r\n terminated lines (which show up as \n\r, hence
+            # all lines start with \r)
+            if ch == b'\r':
+                continue
+            if ch == b':':
+                break
+
+        hqxifp = _Hqxdecoderengine(ifp)
+        self.ifp = _Rledecoderengine(hqxifp)
+        self.crc = 0
+        self._readheader()
+
+    def _read(self, len):
+        data = self.ifp.read(len)
+        self.crc = binascii.crc_hqx(data, self.crc)
+        return data
+
+    def _checkcrc(self):
+        filecrc = struct.unpack('>h', self.ifp.read(2))[0] & 0xffff
+        #self.crc = binascii.crc_hqx('\0\0', self.crc)
+        # XXXX Is this needed??
+        self.crc = self.crc & 0xffff
+        if filecrc != self.crc:
+            raise Error('CRC error, computed %x, read %x'
+                        % (self.crc, filecrc))
+        self.crc = 0
+
+    def _readheader(self):
+        len = self._read(1)
+        fname = self._read(ord(len))
+        rest = self._read(1 + 4 + 4 + 2 + 4 + 4)
+        self._checkcrc()
+
+        type = rest[1:5]
+        creator = rest[5:9]
+        flags = struct.unpack('>h', rest[9:11])[0]
+        self.dlen = struct.unpack('>l', rest[11:15])[0]
+        self.rlen = struct.unpack('>l', rest[15:19])[0]
+
+        self.FName = fname
+        self.FInfo = FInfo()
+        self.FInfo.Creator = creator
+        self.FInfo.Type = type
+        self.FInfo.Flags = flags
+
+        self.state = _DID_HEADER
+
+    def read(self, *n):
+        if self.state != _DID_HEADER:
+            raise Error('Read data at wrong time')
+        if n:
+            n = n[0]
+            n = min(n, self.dlen)
+        else:
+            n = self.dlen
+        rv = b''
+        while len(rv) < n:
+            rv = rv + self._read(n-len(rv))
+        self.dlen = self.dlen - n
+        return rv
+
+    def close_data(self):
+        if self.state != _DID_HEADER:
+            raise Error('close_data at wrong time')
+        if self.dlen:
+            dummy = self._read(self.dlen)
+        self._checkcrc()
+        self.state = _DID_DATA
+
+    def read_rsrc(self, *n):
+        if self.state == _DID_HEADER:
+            self.close_data()
+        if self.state != _DID_DATA:
+            raise Error('Read resource data at wrong time')
+        if n:
+            n = n[0]
+            n = min(n, self.rlen)
+        else:
+            n = self.rlen
+        self.rlen = self.rlen - n
+        return self._read(n)
+
+    def close(self):
+        if self.state is None:
+            return
+        try:
+            if self.rlen:
+                dummy = self.read_rsrc(self.rlen)
+            self._checkcrc()
+        finally:
+            self.state = None
+            self.ifp.close()
+
+def hexbin(inp, out):
+    """hexbin(infilename, outfilename) - Decode binhexed file"""
+    ifp = HexBin(inp)
+    finfo = ifp.FInfo
+    if not out:
+        out = ifp.FName
+
+    with io.open(out, 'wb') as ofp:
+        # XXXX Do translation on non-mac systems
+        while True:
+            d = ifp.read(128000)
+            if not d: break
+            ofp.write(d)
+    ifp.close_data()
+
+    d = ifp.read_rsrc(128000)
+    if d:
+        ofp = openrsrc(out, 'wb')
+        ofp.write(d)
+        while True:
+            d = ifp.read_rsrc(128000)
+            if not d: break
+            ofp.write(d)
+        ofp.close()
+
+    ifp.close()

--- a/Lib/test/test__osx_support.py
+++ b/Lib/test/test__osx_support.py
@@ -1,0 +1,327 @@
+"""
+Test suite for _osx_support: shared OS X support functions.
+"""
+
+import os
+import platform
+import stat
+import sys
+import unittest
+
+import test.support
+
+import _osx_support
+
+@unittest.skipUnless(sys.platform.startswith("darwin"), "requires OS X")
+class Test_OSXSupport(unittest.TestCase):
+
+    def setUp(self):
+        self.maxDiff = None
+        self.prog_name = 'bogus_program_xxxx'
+        self.temp_path_dir = os.path.abspath(os.getcwd())
+        self.env = test.support.EnvironmentVarGuard()
+        self.addCleanup(self.env.__exit__)
+        for cv in ('CFLAGS', 'LDFLAGS', 'CPPFLAGS',
+                            'BASECFLAGS', 'BLDSHARED', 'LDSHARED', 'CC',
+                            'CXX', 'PY_CFLAGS', 'PY_LDFLAGS', 'PY_CPPFLAGS',
+                            'PY_CORE_CFLAGS', 'PY_CORE_LDFLAGS'):
+            if cv in self.env:
+                self.env.unset(cv)
+
+    def add_expected_saved_initial_values(self, config_vars, expected_vars):
+        # Ensure that the initial values for all modified config vars
+        # are also saved with modified keys.
+        expected_vars.update(('_OSX_SUPPORT_INITIAL_'+ k,
+                config_vars[k]) for k in config_vars
+                    if config_vars[k] != expected_vars[k])
+
+    def test__find_executable(self):
+        if self.env['PATH']:
+            self.env['PATH'] = self.env['PATH'] + ':'
+        self.env['PATH'] = self.env['PATH'] + os.path.abspath(self.temp_path_dir)
+        test.support.unlink(self.prog_name)
+        self.assertIsNone(_osx_support._find_executable(self.prog_name))
+        self.addCleanup(test.support.unlink, self.prog_name)
+        with open(self.prog_name, 'w') as f:
+            f.write("#!/bin/sh\n/bin/echo OK\n")
+        os.chmod(self.prog_name, stat.S_IRWXU)
+        self.assertEqual(self.prog_name,
+                            _osx_support._find_executable(self.prog_name))
+
+    def test__read_output(self):
+        if self.env['PATH']:
+            self.env['PATH'] = self.env['PATH'] + ':'
+        self.env['PATH'] = self.env['PATH'] + os.path.abspath(self.temp_path_dir)
+        test.support.unlink(self.prog_name)
+        self.addCleanup(test.support.unlink, self.prog_name)
+        with open(self.prog_name, 'w') as f:
+            f.write("#!/bin/sh\n/bin/echo ExpectedOutput\n")
+        os.chmod(self.prog_name, stat.S_IRWXU)
+        self.assertEqual('ExpectedOutput',
+                            _osx_support._read_output(self.prog_name))
+
+    def test__find_build_tool(self):
+        out = _osx_support._find_build_tool('cc')
+        self.assertTrue(os.path.isfile(out),
+                            'cc not found - check xcode-select')
+
+    def test__get_system_version(self):
+        self.assertTrue(platform.mac_ver()[0].startswith(
+                                    _osx_support._get_system_version()))
+
+    def test__remove_original_values(self):
+        config_vars = {
+        'CC': 'gcc-test -pthreads',
+        }
+        expected_vars = {
+        'CC': 'clang -pthreads',
+        }
+        cv = 'CC'
+        newvalue = 'clang -pthreads'
+        _osx_support._save_modified_value(config_vars, cv, newvalue)
+        self.assertNotEqual(expected_vars, config_vars)
+        _osx_support._remove_original_values(config_vars)
+        self.assertEqual(expected_vars, config_vars)
+
+    def test__save_modified_value(self):
+        config_vars = {
+        'CC': 'gcc-test -pthreads',
+        }
+        expected_vars = {
+        'CC': 'clang -pthreads',
+        }
+        self.add_expected_saved_initial_values(config_vars, expected_vars)
+        cv = 'CC'
+        newvalue = 'clang -pthreads'
+        _osx_support._save_modified_value(config_vars, cv, newvalue)
+        self.assertEqual(expected_vars, config_vars)
+
+    def test__save_modified_value_unchanged(self):
+        config_vars = {
+        'CC': 'gcc-test -pthreads',
+        }
+        expected_vars = config_vars.copy()
+        cv = 'CC'
+        newvalue = 'gcc-test -pthreads'
+        _osx_support._save_modified_value(config_vars, cv, newvalue)
+        self.assertEqual(expected_vars, config_vars)
+
+    def test__supports_universal_builds(self):
+        import platform
+        mac_ver_tuple = tuple(int(i) for i in
+                            platform.mac_ver()[0].split('.')[0:2])
+        self.assertEqual(mac_ver_tuple >= (10, 4),
+                            _osx_support._supports_universal_builds())
+
+    def test__find_appropriate_compiler(self):
+        compilers = (
+                        ('gcc-test', 'i686-apple-darwin11-llvm-gcc-4.2'),
+                        ('clang', 'clang version 3.1'),
+                    )
+        config_vars = {
+        'CC': 'gcc-test -pthreads',
+        'CXX': 'cc++-test',
+        'CFLAGS': '-fno-strict-aliasing  -g -O3 -arch ppc -arch i386  ',
+        'LDFLAGS': '-arch ppc -arch i386   -g',
+        'CPPFLAGS': '-I. -isysroot /Developer/SDKs/MacOSX10.4u.sdk',
+        'BLDSHARED': 'gcc-test -bundle -arch ppc -arch i386 -g',
+        'LDSHARED': 'gcc-test -bundle -arch ppc -arch i386 '
+                        '-isysroot /Developer/SDKs/MacOSX10.4u.sdk -g',
+        }
+        expected_vars = {
+        'CC': 'clang -pthreads',
+        'CXX': 'clang++',
+        'CFLAGS': '-fno-strict-aliasing  -g -O3 -arch ppc -arch i386  ',
+        'LDFLAGS': '-arch ppc -arch i386   -g',
+        'CPPFLAGS': '-I. -isysroot /Developer/SDKs/MacOSX10.4u.sdk',
+        'BLDSHARED': 'clang -bundle -arch ppc -arch i386 -g',
+        'LDSHARED': 'clang -bundle -arch ppc -arch i386 '
+                        '-isysroot /Developer/SDKs/MacOSX10.4u.sdk -g',
+        }
+        self.add_expected_saved_initial_values(config_vars, expected_vars)
+
+        suffix = (':' + self.env['PATH']) if self.env['PATH'] else ''
+        self.env['PATH'] = os.path.abspath(self.temp_path_dir) + suffix
+        for c_name, c_output in compilers:
+            test.support.unlink(c_name)
+            self.addCleanup(test.support.unlink, c_name)
+            with open(c_name, 'w') as f:
+                f.write("#!/bin/sh\n/bin/echo " + c_output)
+            os.chmod(c_name, stat.S_IRWXU)
+        self.assertEqual(expected_vars,
+                            _osx_support._find_appropriate_compiler(
+                                    config_vars))
+
+    def test__remove_universal_flags(self):
+        config_vars = {
+        'CFLAGS': '-fno-strict-aliasing  -g -O3 -arch ppc -arch i386  ',
+        'LDFLAGS': '-arch ppc -arch i386   -g',
+        'CPPFLAGS': '-I. -isysroot /Developer/SDKs/MacOSX10.4u.sdk',
+        'BLDSHARED': 'gcc-4.0 -bundle  -arch ppc -arch i386 -g',
+        'LDSHARED': 'gcc-4.0 -bundle  -arch ppc -arch i386 '
+                        '-isysroot /Developer/SDKs/MacOSX10.4u.sdk -g',
+        }
+        expected_vars = {
+        'CFLAGS': '-fno-strict-aliasing  -g -O3    ',
+        'LDFLAGS': '    -g',
+        'CPPFLAGS': '-I.  ',
+        'BLDSHARED': 'gcc-4.0 -bundle    -g',
+        'LDSHARED': 'gcc-4.0 -bundle      -g',
+        }
+        self.add_expected_saved_initial_values(config_vars, expected_vars)
+
+        self.assertEqual(expected_vars,
+                            _osx_support._remove_universal_flags(
+                                    config_vars))
+
+    def test__remove_universal_flags_alternate(self):
+        # bpo-38360: also test the alternate single-argument form of -isysroot
+        config_vars = {
+        'CFLAGS': '-fno-strict-aliasing  -g -O3 -arch ppc -arch i386  ',
+        'LDFLAGS': '-arch ppc -arch i386   -g',
+        'CPPFLAGS': '-I. -isysroot/Developer/SDKs/MacOSX10.4u.sdk',
+        'BLDSHARED': 'gcc-4.0 -bundle  -arch ppc -arch i386 -g',
+        'LDSHARED': 'gcc-4.0 -bundle  -arch ppc -arch i386 '
+                        '-isysroot/Developer/SDKs/MacOSX10.4u.sdk -g',
+        }
+        expected_vars = {
+        'CFLAGS': '-fno-strict-aliasing  -g -O3    ',
+        'LDFLAGS': '    -g',
+        'CPPFLAGS': '-I.  ',
+        'BLDSHARED': 'gcc-4.0 -bundle    -g',
+        'LDSHARED': 'gcc-4.0 -bundle      -g',
+        }
+        self.add_expected_saved_initial_values(config_vars, expected_vars)
+
+        self.assertEqual(expected_vars,
+                            _osx_support._remove_universal_flags(
+                                    config_vars))
+
+    def test__remove_unsupported_archs(self):
+        config_vars = {
+        'CC': 'clang',
+        'CFLAGS': '-fno-strict-aliasing  -g -O3 -arch ppc -arch i386  ',
+        'LDFLAGS': '-arch ppc -arch i386   -g',
+        'CPPFLAGS': '-I. -isysroot /Developer/SDKs/MacOSX10.4u.sdk',
+        'BLDSHARED': 'gcc-4.0 -bundle  -arch ppc -arch i386 -g',
+        'LDSHARED': 'gcc-4.0 -bundle  -arch ppc -arch i386 '
+                        '-isysroot /Developer/SDKs/MacOSX10.4u.sdk -g',
+        }
+        expected_vars = {
+        'CC': 'clang',
+        'CFLAGS': '-fno-strict-aliasing  -g -O3  -arch i386  ',
+        'LDFLAGS': ' -arch i386   -g',
+        'CPPFLAGS': '-I. -isysroot /Developer/SDKs/MacOSX10.4u.sdk',
+        'BLDSHARED': 'gcc-4.0 -bundle   -arch i386 -g',
+        'LDSHARED': 'gcc-4.0 -bundle   -arch i386 '
+                        '-isysroot /Developer/SDKs/MacOSX10.4u.sdk -g',
+        }
+        self.add_expected_saved_initial_values(config_vars, expected_vars)
+
+        suffix = (':' + self.env['PATH']) if self.env['PATH'] else ''
+        self.env['PATH'] = os.path.abspath(self.temp_path_dir) + suffix
+        c_name = 'clang'
+        test.support.unlink(c_name)
+        self.addCleanup(test.support.unlink, c_name)
+        # exit status 255 means no PPC support in this compiler chain
+        with open(c_name, 'w') as f:
+            f.write("#!/bin/sh\nexit 255")
+        os.chmod(c_name, stat.S_IRWXU)
+        self.assertEqual(expected_vars,
+                            _osx_support._remove_unsupported_archs(
+                                    config_vars))
+
+    def test__override_all_archs(self):
+        self.env['ARCHFLAGS'] = '-arch x86_64'
+        config_vars = {
+        'CC': 'clang',
+        'CFLAGS': '-fno-strict-aliasing  -g -O3 -arch ppc -arch i386  ',
+        'LDFLAGS': '-arch ppc -arch i386   -g',
+        'CPPFLAGS': '-I. -isysroot /Developer/SDKs/MacOSX10.4u.sdk',
+        'BLDSHARED': 'gcc-4.0 -bundle  -arch ppc -arch i386 -g',
+        'LDSHARED': 'gcc-4.0 -bundle -arch ppc -arch i386 '
+                        '-isysroot /Developer/SDKs/MacOSX10.4u.sdk -g',
+        }
+        expected_vars = {
+        'CC': 'clang',
+        'CFLAGS': '-fno-strict-aliasing  -g -O3     -arch x86_64',
+        'LDFLAGS': '    -g -arch x86_64',
+        'CPPFLAGS': '-I. -isysroot /Developer/SDKs/MacOSX10.4u.sdk',
+        'BLDSHARED': 'gcc-4.0 -bundle    -g -arch x86_64',
+        'LDSHARED': 'gcc-4.0 -bundle   -isysroot '
+                        '/Developer/SDKs/MacOSX10.4u.sdk -g -arch x86_64',
+        }
+        self.add_expected_saved_initial_values(config_vars, expected_vars)
+
+        self.assertEqual(expected_vars,
+                            _osx_support._override_all_archs(
+                                    config_vars))
+
+    def test__check_for_unavailable_sdk(self):
+        config_vars = {
+        'CC': 'clang',
+        'CFLAGS': '-fno-strict-aliasing  -g -O3 -arch ppc -arch i386  '
+                        '-isysroot /Developer/SDKs/MacOSX10.1.sdk',
+        'LDFLAGS': '-arch ppc -arch i386   -g',
+        'CPPFLAGS': '-I. -isysroot /Developer/SDKs/MacOSX10.1.sdk',
+        'BLDSHARED': 'gcc-4.0 -bundle  -arch ppc -arch i386 -g',
+        'LDSHARED': 'gcc-4.0 -bundle  -arch ppc -arch i386 '
+                        '-isysroot /Developer/SDKs/MacOSX10.1.sdk -g',
+        }
+        expected_vars = {
+        'CC': 'clang',
+        'CFLAGS': '-fno-strict-aliasing  -g -O3 -arch ppc -arch i386  '
+                        ' ',
+        'LDFLAGS': '-arch ppc -arch i386   -g',
+        'CPPFLAGS': '-I.  ',
+        'BLDSHARED': 'gcc-4.0 -bundle  -arch ppc -arch i386 -g',
+        'LDSHARED': 'gcc-4.0 -bundle  -arch ppc -arch i386 '
+                        ' -g',
+        }
+        self.add_expected_saved_initial_values(config_vars, expected_vars)
+
+        self.assertEqual(expected_vars,
+                            _osx_support._check_for_unavailable_sdk(
+                                    config_vars))
+
+    def test__check_for_unavailable_sdk_alternate(self):
+        # bpo-38360: also test the alternate single-argument form of -isysroot
+        config_vars = {
+        'CC': 'clang',
+        'CFLAGS': '-fno-strict-aliasing  -g -O3 -arch ppc -arch i386  '
+                        '-isysroot/Developer/SDKs/MacOSX10.1.sdk',
+        'LDFLAGS': '-arch ppc -arch i386   -g',
+        'CPPFLAGS': '-I. -isysroot/Developer/SDKs/MacOSX10.1.sdk',
+        'BLDSHARED': 'gcc-4.0 -bundle  -arch ppc -arch i386 -g',
+        'LDSHARED': 'gcc-4.0 -bundle  -arch ppc -arch i386 '
+                        '-isysroot/Developer/SDKs/MacOSX10.1.sdk -g',
+        }
+        expected_vars = {
+        'CC': 'clang',
+        'CFLAGS': '-fno-strict-aliasing  -g -O3 -arch ppc -arch i386  '
+                        ' ',
+        'LDFLAGS': '-arch ppc -arch i386   -g',
+        'CPPFLAGS': '-I.  ',
+        'BLDSHARED': 'gcc-4.0 -bundle  -arch ppc -arch i386 -g',
+        'LDSHARED': 'gcc-4.0 -bundle  -arch ppc -arch i386 '
+                        ' -g',
+        }
+        self.add_expected_saved_initial_values(config_vars, expected_vars)
+
+        self.assertEqual(expected_vars,
+                            _osx_support._check_for_unavailable_sdk(
+                                    config_vars))
+
+    def test_get_platform_osx(self):
+        # Note, get_platform_osx is currently tested more extensively
+        # indirectly by test_sysconfig and test_distutils
+        config_vars = {
+        'CFLAGS': '-fno-strict-aliasing  -g -O3 -arch ppc -arch i386  '
+                        '-isysroot /Developer/SDKs/MacOSX10.1.sdk',
+        'MACOSX_DEPLOYMENT_TARGET': '10.6',
+        }
+        result = _osx_support.get_platform_osx(config_vars, ' ', ' ', ' ')
+        self.assertEqual(('macosx', '10.6', 'fat'), result)
+
+if __name__ == "__main__":
+    unittest.main()

--- a/Lib/test/test__osx_support.py
+++ b/Lib/test/test__osx_support.py
@@ -174,6 +174,8 @@ class Test_OSXSupport(unittest.TestCase):
                             _osx_support._remove_universal_flags(
                                     config_vars))
 
+    # TODO: RUSTPYTHON
+    @unittest.expectedFailure
     def test__remove_universal_flags_alternate(self):
         # bpo-38360: also test the alternate single-argument form of -isysroot
         config_vars = {
@@ -284,6 +286,8 @@ class Test_OSXSupport(unittest.TestCase):
                             _osx_support._check_for_unavailable_sdk(
                                     config_vars))
 
+    # TODO: RUSTPYTHON
+    @unittest.expectedFailure
     def test__check_for_unavailable_sdk_alternate(self):
         # bpo-38360: also test the alternate single-argument form of -isysroot
         config_vars = {

--- a/Lib/test/test_binhex.py
+++ b/Lib/test/test_binhex.py
@@ -1,0 +1,65 @@
+"""Test script for the binhex C module
+
+   Uses the mechanism of the python binhex module
+   Based on an original test by Roger E. Masse.
+"""
+import binhex
+import unittest
+from test import support
+
+
+class BinHexTestCase(unittest.TestCase):
+
+    def setUp(self):
+        self.fname1 = support.TESTFN + "1"
+        self.fname2 = support.TESTFN + "2"
+        self.fname3 = support.TESTFN + "very_long_filename__very_long_filename__very_long_filename__very_long_filename__"
+
+    def tearDown(self):
+        support.unlink(self.fname1)
+        support.unlink(self.fname2)
+        support.unlink(self.fname3)
+
+    DATA = b'Jack is my hero'
+
+    def test_binhex(self):
+        with open(self.fname1, 'wb') as f:
+            f.write(self.DATA)
+
+        binhex.binhex(self.fname1, self.fname2)
+
+        binhex.hexbin(self.fname2, self.fname1)
+
+        with open(self.fname1, 'rb') as f:
+            finish = f.readline()
+
+        self.assertEqual(self.DATA, finish)
+
+    def test_binhex_error_on_long_filename(self):
+        """
+        The testcase fails if no exception is raised when a filename parameter provided to binhex.binhex()
+        is too long, or if the exception raised in binhex.binhex() is not an instance of binhex.Error.
+        """
+        f3 = open(self.fname3, 'wb')
+        f3.close()
+
+        self.assertRaises(binhex.Error, binhex.binhex, self.fname3, self.fname2)
+
+    def test_binhex_line_endings(self):
+        # bpo-29566: Ensure the line endings are those for macOS 9
+        with open(self.fname1, 'wb') as f:
+            f.write(self.DATA)
+
+        binhex.binhex(self.fname1, self.fname2)
+
+        with open(self.fname2, 'rb') as fp:
+            contents = fp.read()
+
+        self.assertNotIn(b'\n', contents)
+
+def test_main():
+    support.run_unittest(BinHexTestCase)
+
+
+if __name__ == "__main__":
+    test_main()

--- a/Lib/test/test_binhex.py
+++ b/Lib/test/test_binhex.py
@@ -22,6 +22,7 @@ class BinHexTestCase(unittest.TestCase):
 
     DATA = b'Jack is my hero'
 
+    @unittest.skip("TODO: RUSTPYTHON, AttributeError: module 'binascii' has no attribute 'crc_hqx'")
     def test_binhex(self):
         with open(self.fname1, 'wb') as f:
             f.write(self.DATA)
@@ -45,6 +46,7 @@ class BinHexTestCase(unittest.TestCase):
 
         self.assertRaises(binhex.Error, binhex.binhex, self.fname3, self.fname2)
 
+    @unittest.skip("TODO: RUSTPYTHON, AttributeError: module 'binascii' has no attribute 'crc_hqx'")
     def test_binhex_line_endings(self):
         # bpo-29566: Ensure the line endings are those for macOS 9
         with open(self.fname1, 'wb') as f:

--- a/Lib/test/test_cmd_line_script.py
+++ b/Lib/test/test_cmd_line_script.py
@@ -1,0 +1,723 @@
+# tests command line execution of scripts
+
+import contextlib
+import importlib
+import importlib.machinery
+import zipimport
+import unittest
+import sys
+import os
+import os.path
+import py_compile
+import subprocess
+import io
+
+import textwrap
+from test import support
+from test.support.script_helper import (
+    make_pkg, make_script, make_zip_pkg, make_zip_script,
+    assert_python_ok, assert_python_failure, spawn_python, kill_python)
+
+verbose = support.verbose
+
+example_args = ['test1', 'test2', 'test3']
+
+test_source = """\
+# Script may be run with optimisation enabled, so don't rely on assert
+# statements being executed
+def assertEqual(lhs, rhs):
+    if lhs != rhs:
+        raise AssertionError('%r != %r' % (lhs, rhs))
+def assertIdentical(lhs, rhs):
+    if lhs is not rhs:
+        raise AssertionError('%r is not %r' % (lhs, rhs))
+# Check basic code execution
+result = ['Top level assignment']
+def f():
+    result.append('Lower level reference')
+f()
+assertEqual(result, ['Top level assignment', 'Lower level reference'])
+# Check population of magic variables
+assertEqual(__name__, '__main__')
+from importlib.machinery import BuiltinImporter
+_loader = __loader__ if __loader__ is BuiltinImporter else type(__loader__)
+print('__loader__==%a' % _loader)
+print('__file__==%a' % __file__)
+print('__cached__==%a' % __cached__)
+print('__package__==%r' % __package__)
+# Check PEP 451 details
+import os.path
+if __package__ is not None:
+    print('__main__ was located through the import system')
+    assertIdentical(__spec__.loader, __loader__)
+    expected_spec_name = os.path.splitext(os.path.basename(__file__))[0]
+    if __package__:
+        expected_spec_name = __package__ + "." + expected_spec_name
+    assertEqual(__spec__.name, expected_spec_name)
+    assertEqual(__spec__.parent, __package__)
+    assertIdentical(__spec__.submodule_search_locations, None)
+    assertEqual(__spec__.origin, __file__)
+    if __spec__.cached is not None:
+        assertEqual(__spec__.cached, __cached__)
+# Check the sys module
+import sys
+assertIdentical(globals(), sys.modules[__name__].__dict__)
+if __spec__ is not None:
+    # XXX: We're not currently making __main__ available under its real name
+    pass # assertIdentical(globals(), sys.modules[__spec__.name].__dict__)
+from test import test_cmd_line_script
+example_args_list = test_cmd_line_script.example_args
+assertEqual(sys.argv[1:], example_args_list)
+print('sys.argv[0]==%a' % sys.argv[0])
+print('sys.path[0]==%a' % sys.path[0])
+# Check the working directory
+import os
+print('cwd==%a' % os.getcwd())
+"""
+
+def _make_test_script(script_dir, script_basename, source=test_source):
+    to_return = make_script(script_dir, script_basename, source)
+    importlib.invalidate_caches()
+    return to_return
+
+def _make_test_zip_pkg(zip_dir, zip_basename, pkg_name, script_basename,
+                       source=test_source, depth=1):
+    to_return = make_zip_pkg(zip_dir, zip_basename, pkg_name, script_basename,
+                             source, depth)
+    importlib.invalidate_caches()
+    return to_return
+
+class CmdLineTest(unittest.TestCase):
+    def _check_output(self, script_name, exit_code, data,
+                             expected_file, expected_argv0,
+                             expected_path0, expected_package,
+                             expected_loader, expected_cwd=None):
+        if verbose > 1:
+            print("Output from test script %r:" % script_name)
+            print(repr(data))
+        self.assertEqual(exit_code, 0)
+        printed_loader = '__loader__==%a' % expected_loader
+        printed_file = '__file__==%a' % expected_file
+        printed_package = '__package__==%r' % expected_package
+        printed_argv0 = 'sys.argv[0]==%a' % expected_argv0
+        printed_path0 = 'sys.path[0]==%a' % expected_path0
+        if expected_cwd is None:
+            expected_cwd = os.getcwd()
+        printed_cwd = 'cwd==%a' % expected_cwd
+        if verbose > 1:
+            print('Expected output:')
+            print(printed_file)
+            print(printed_package)
+            print(printed_argv0)
+            print(printed_cwd)
+        self.assertIn(printed_loader.encode('utf-8'), data)
+        self.assertIn(printed_file.encode('utf-8'), data)
+        self.assertIn(printed_package.encode('utf-8'), data)
+        self.assertIn(printed_argv0.encode('utf-8'), data)
+        self.assertIn(printed_path0.encode('utf-8'), data)
+        self.assertIn(printed_cwd.encode('utf-8'), data)
+
+    def _check_script(self, script_exec_args, expected_file,
+                            expected_argv0, expected_path0,
+                            expected_package, expected_loader,
+                            *cmd_line_switches, cwd=None, **env_vars):
+        if isinstance(script_exec_args, str):
+            script_exec_args = [script_exec_args]
+        run_args = [*support.optim_args_from_interpreter_flags(),
+                    *cmd_line_switches, *script_exec_args, *example_args]
+        rc, out, err = assert_python_ok(
+            *run_args, __isolated=False, __cwd=cwd, **env_vars
+        )
+        self._check_output(script_exec_args, rc, out + err, expected_file,
+                           expected_argv0, expected_path0,
+                           expected_package, expected_loader, cwd)
+
+    def _check_import_error(self, script_exec_args, expected_msg,
+                            *cmd_line_switches, cwd=None, **env_vars):
+        if isinstance(script_exec_args, str):
+            script_exec_args = (script_exec_args,)
+        else:
+            script_exec_args = tuple(script_exec_args)
+        run_args = cmd_line_switches + script_exec_args
+        rc, out, err = assert_python_failure(
+            *run_args, __isolated=False, __cwd=cwd, **env_vars
+        )
+        if verbose > 1:
+            print(f'Output from test script {script_exec_args!r:}')
+            print(repr(err))
+            print('Expected output: %r' % expected_msg)
+        self.assertIn(expected_msg.encode('utf-8'), err)
+
+    def test_dash_c_loader(self):
+        rc, out, err = assert_python_ok("-c", "print(__loader__)")
+        expected = repr(importlib.machinery.BuiltinImporter).encode("utf-8")
+        self.assertIn(expected, out)
+
+    def test_stdin_loader(self):
+        # Unfortunately, there's no way to automatically test the fully
+        # interactive REPL, since that code path only gets executed when
+        # stdin is an interactive tty.
+        p = spawn_python()
+        try:
+            p.stdin.write(b"print(__loader__)\n")
+            p.stdin.flush()
+        finally:
+            out = kill_python(p)
+        expected = repr(importlib.machinery.BuiltinImporter).encode("utf-8")
+        self.assertIn(expected, out)
+
+    @contextlib.contextmanager
+    def interactive_python(self, separate_stderr=False):
+        if separate_stderr:
+            p = spawn_python('-i', stderr=subprocess.PIPE)
+            stderr = p.stderr
+        else:
+            p = spawn_python('-i', stderr=subprocess.STDOUT)
+            stderr = p.stdout
+        try:
+            # Drain stderr until prompt
+            while True:
+                data = stderr.read(4)
+                if data == b">>> ":
+                    break
+                stderr.readline()
+            yield p
+        finally:
+            kill_python(p)
+            stderr.close()
+
+    def check_repl_stdout_flush(self, separate_stderr=False):
+        with self.interactive_python(separate_stderr) as p:
+            p.stdin.write(b"print('foo')\n")
+            p.stdin.flush()
+            self.assertEqual(b'foo', p.stdout.readline().strip())
+
+    def check_repl_stderr_flush(self, separate_stderr=False):
+        with self.interactive_python(separate_stderr) as p:
+            p.stdin.write(b"1/0\n")
+            p.stdin.flush()
+            stderr = p.stderr if separate_stderr else p.stdout
+            self.assertIn(b'Traceback ', stderr.readline())
+            self.assertIn(b'File "<stdin>"', stderr.readline())
+            self.assertIn(b'ZeroDivisionError', stderr.readline())
+
+    def test_repl_stdout_flush(self):
+        self.check_repl_stdout_flush()
+
+    def test_repl_stdout_flush_separate_stderr(self):
+        self.check_repl_stdout_flush(True)
+
+    def test_repl_stderr_flush(self):
+        self.check_repl_stderr_flush()
+
+    def test_repl_stderr_flush_separate_stderr(self):
+        self.check_repl_stderr_flush(True)
+
+    def test_basic_script(self):
+        with support.temp_dir() as script_dir:
+            script_name = _make_test_script(script_dir, 'script')
+            self._check_script(script_name, script_name, script_name,
+                               script_dir, None,
+                               importlib.machinery.SourceFileLoader)
+
+    def test_script_compiled(self):
+        with support.temp_dir() as script_dir:
+            script_name = _make_test_script(script_dir, 'script')
+            py_compile.compile(script_name, doraise=True)
+            os.remove(script_name)
+            pyc_file = support.make_legacy_pyc(script_name)
+            self._check_script(pyc_file, pyc_file,
+                               pyc_file, script_dir, None,
+                               importlib.machinery.SourcelessFileLoader)
+
+    def test_directory(self):
+        with support.temp_dir() as script_dir:
+            script_name = _make_test_script(script_dir, '__main__')
+            self._check_script(script_dir, script_name, script_dir,
+                               script_dir, '',
+                               importlib.machinery.SourceFileLoader)
+
+    def test_directory_compiled(self):
+        with support.temp_dir() as script_dir:
+            script_name = _make_test_script(script_dir, '__main__')
+            py_compile.compile(script_name, doraise=True)
+            os.remove(script_name)
+            pyc_file = support.make_legacy_pyc(script_name)
+            self._check_script(script_dir, pyc_file, script_dir,
+                               script_dir, '',
+                               importlib.machinery.SourcelessFileLoader)
+
+    def test_directory_error(self):
+        with support.temp_dir() as script_dir:
+            msg = "can't find '__main__' module in %r" % script_dir
+            self._check_import_error(script_dir, msg)
+
+    def test_zipfile(self):
+        with support.temp_dir() as script_dir:
+            script_name = _make_test_script(script_dir, '__main__')
+            zip_name, run_name = make_zip_script(script_dir, 'test_zip', script_name)
+            self._check_script(zip_name, run_name, zip_name, zip_name, '',
+                               zipimport.zipimporter)
+
+    def test_zipfile_compiled_timestamp(self):
+        with support.temp_dir() as script_dir:
+            script_name = _make_test_script(script_dir, '__main__')
+            compiled_name = py_compile.compile(
+                script_name, doraise=True,
+                invalidation_mode=py_compile.PycInvalidationMode.TIMESTAMP)
+            zip_name, run_name = make_zip_script(script_dir, 'test_zip', compiled_name)
+            self._check_script(zip_name, run_name, zip_name, zip_name, '',
+                               zipimport.zipimporter)
+
+    def test_zipfile_compiled_checked_hash(self):
+        with support.temp_dir() as script_dir:
+            script_name = _make_test_script(script_dir, '__main__')
+            compiled_name = py_compile.compile(
+                script_name, doraise=True,
+                invalidation_mode=py_compile.PycInvalidationMode.CHECKED_HASH)
+            zip_name, run_name = make_zip_script(script_dir, 'test_zip', compiled_name)
+            self._check_script(zip_name, run_name, zip_name, zip_name, '',
+                               zipimport.zipimporter)
+
+    def test_zipfile_compiled_unchecked_hash(self):
+        with support.temp_dir() as script_dir:
+            script_name = _make_test_script(script_dir, '__main__')
+            compiled_name = py_compile.compile(
+                script_name, doraise=True,
+                invalidation_mode=py_compile.PycInvalidationMode.UNCHECKED_HASH)
+            zip_name, run_name = make_zip_script(script_dir, 'test_zip', compiled_name)
+            self._check_script(zip_name, run_name, zip_name, zip_name, '',
+                               zipimport.zipimporter)
+
+    def test_zipfile_error(self):
+        with support.temp_dir() as script_dir:
+            script_name = _make_test_script(script_dir, 'not_main')
+            zip_name, run_name = make_zip_script(script_dir, 'test_zip', script_name)
+            msg = "can't find '__main__' module in %r" % zip_name
+            self._check_import_error(zip_name, msg)
+
+    def test_module_in_package(self):
+        with support.temp_dir() as script_dir:
+            pkg_dir = os.path.join(script_dir, 'test_pkg')
+            make_pkg(pkg_dir)
+            script_name = _make_test_script(pkg_dir, 'script')
+            self._check_script(["-m", "test_pkg.script"], script_name, script_name,
+                               script_dir, 'test_pkg',
+                               importlib.machinery.SourceFileLoader,
+                               cwd=script_dir)
+
+    def test_module_in_package_in_zipfile(self):
+        with support.temp_dir() as script_dir:
+            zip_name, run_name = _make_test_zip_pkg(script_dir, 'test_zip', 'test_pkg', 'script')
+            self._check_script(["-m", "test_pkg.script"], run_name, run_name,
+                               script_dir, 'test_pkg', zipimport.zipimporter,
+                               PYTHONPATH=zip_name, cwd=script_dir)
+
+    def test_module_in_subpackage_in_zipfile(self):
+        with support.temp_dir() as script_dir:
+            zip_name, run_name = _make_test_zip_pkg(script_dir, 'test_zip', 'test_pkg', 'script', depth=2)
+            self._check_script(["-m", "test_pkg.test_pkg.script"], run_name, run_name,
+                               script_dir, 'test_pkg.test_pkg',
+                               zipimport.zipimporter,
+                               PYTHONPATH=zip_name, cwd=script_dir)
+
+    def test_package(self):
+        with support.temp_dir() as script_dir:
+            pkg_dir = os.path.join(script_dir, 'test_pkg')
+            make_pkg(pkg_dir)
+            script_name = _make_test_script(pkg_dir, '__main__')
+            self._check_script(["-m", "test_pkg"], script_name,
+                               script_name, script_dir, 'test_pkg',
+                               importlib.machinery.SourceFileLoader,
+                               cwd=script_dir)
+
+    def test_package_compiled(self):
+        with support.temp_dir() as script_dir:
+            pkg_dir = os.path.join(script_dir, 'test_pkg')
+            make_pkg(pkg_dir)
+            script_name = _make_test_script(pkg_dir, '__main__')
+            compiled_name = py_compile.compile(script_name, doraise=True)
+            os.remove(script_name)
+            pyc_file = support.make_legacy_pyc(script_name)
+            self._check_script(["-m", "test_pkg"], pyc_file,
+                               pyc_file, script_dir, 'test_pkg',
+                               importlib.machinery.SourcelessFileLoader,
+                               cwd=script_dir)
+
+    def test_package_error(self):
+        with support.temp_dir() as script_dir:
+            pkg_dir = os.path.join(script_dir, 'test_pkg')
+            make_pkg(pkg_dir)
+            msg = ("'test_pkg' is a package and cannot "
+                   "be directly executed")
+            self._check_import_error(["-m", "test_pkg"], msg, cwd=script_dir)
+
+    def test_package_recursion(self):
+        with support.temp_dir() as script_dir:
+            pkg_dir = os.path.join(script_dir, 'test_pkg')
+            make_pkg(pkg_dir)
+            main_dir = os.path.join(pkg_dir, '__main__')
+            make_pkg(main_dir)
+            msg = ("Cannot use package as __main__ module; "
+                   "'test_pkg' is a package and cannot "
+                   "be directly executed")
+            self._check_import_error(["-m", "test_pkg"], msg, cwd=script_dir)
+
+    def test_issue8202(self):
+        # Make sure package __init__ modules see "-m" in sys.argv0 while
+        # searching for the module to execute
+        with support.temp_dir() as script_dir:
+            with support.change_cwd(path=script_dir):
+                pkg_dir = os.path.join(script_dir, 'test_pkg')
+                make_pkg(pkg_dir, "import sys; print('init_argv0==%r' % sys.argv[0])")
+                script_name = _make_test_script(pkg_dir, 'script')
+                rc, out, err = assert_python_ok('-m', 'test_pkg.script', *example_args, __isolated=False)
+                if verbose > 1:
+                    print(repr(out))
+                expected = "init_argv0==%r" % '-m'
+                self.assertIn(expected.encode('utf-8'), out)
+                self._check_output(script_name, rc, out,
+                                   script_name, script_name, script_dir, 'test_pkg',
+                                   importlib.machinery.SourceFileLoader)
+
+    def test_issue8202_dash_c_file_ignored(self):
+        # Make sure a "-c" file in the current directory
+        # does not alter the value of sys.path[0]
+        with support.temp_dir() as script_dir:
+            with support.change_cwd(path=script_dir):
+                with open("-c", "w") as f:
+                    f.write("data")
+                    rc, out, err = assert_python_ok('-c',
+                        'import sys; print("sys.path[0]==%r" % sys.path[0])',
+                        __isolated=False)
+                    if verbose > 1:
+                        print(repr(out))
+                    expected = "sys.path[0]==%r" % ''
+                    self.assertIn(expected.encode('utf-8'), out)
+
+    def test_issue8202_dash_m_file_ignored(self):
+        # Make sure a "-m" file in the current directory
+        # does not alter the value of sys.path[0]
+        with support.temp_dir() as script_dir:
+            script_name = _make_test_script(script_dir, 'other')
+            with support.change_cwd(path=script_dir):
+                with open("-m", "w") as f:
+                    f.write("data")
+                    rc, out, err = assert_python_ok('-m', 'other', *example_args,
+                                                    __isolated=False)
+                    self._check_output(script_name, rc, out,
+                                      script_name, script_name, script_dir, '',
+                                      importlib.machinery.SourceFileLoader)
+
+    def test_issue20884(self):
+        # On Windows, script with encoding cookie and LF line ending
+        # will be failed.
+        with support.temp_dir() as script_dir:
+            script_name = os.path.join(script_dir, "issue20884.py")
+            with open(script_name, "w", newline='\n') as f:
+                f.write("#coding: iso-8859-1\n")
+                f.write('"""\n')
+                for _ in range(30):
+                    f.write('x'*80 + '\n')
+                f.write('"""\n')
+
+            with support.change_cwd(path=script_dir):
+                rc, out, err = assert_python_ok(script_name)
+            self.assertEqual(b"", out)
+            self.assertEqual(b"", err)
+
+    @contextlib.contextmanager
+    def setup_test_pkg(self, *args):
+        with support.temp_dir() as script_dir, \
+                support.change_cwd(path=script_dir):
+            pkg_dir = os.path.join(script_dir, 'test_pkg')
+            make_pkg(pkg_dir, *args)
+            yield pkg_dir
+
+    def check_dash_m_failure(self, *args):
+        rc, out, err = assert_python_failure('-m', *args, __isolated=False)
+        if verbose > 1:
+            print(repr(out))
+        self.assertEqual(rc, 1)
+        return err
+
+    def test_dash_m_error_code_is_one(self):
+        # If a module is invoked with the -m command line flag
+        # and results in an error that the return code to the
+        # shell is '1'
+        with self.setup_test_pkg() as pkg_dir:
+            script_name = _make_test_script(pkg_dir, 'other',
+                                            "if __name__ == '__main__': raise ValueError")
+            err = self.check_dash_m_failure('test_pkg.other', *example_args)
+            self.assertIn(b'ValueError', err)
+
+    def test_dash_m_errors(self):
+        # Exercise error reporting for various invalid package executions
+        tests = (
+            ('builtins', br'No code object available'),
+            ('builtins.x', br'Error while finding module specification.*'
+                br'ModuleNotFoundError'),
+            ('builtins.x.y', br'Error while finding module specification.*'
+                br'ModuleNotFoundError.*No module named.*not a package'),
+            ('os.path', br'loader.*cannot handle'),
+            ('importlib', br'No module named.*'
+                br'is a package and cannot be directly executed'),
+            ('importlib.nonexistent', br'No module named'),
+            ('.unittest', br'Relative module names not supported'),
+        )
+        for name, regex in tests:
+            with self.subTest(name):
+                rc, _, err = assert_python_failure('-m', name)
+                self.assertEqual(rc, 1)
+                self.assertRegex(err, regex)
+                self.assertNotIn(b'Traceback', err)
+
+    def test_dash_m_bad_pyc(self):
+        with support.temp_dir() as script_dir, \
+                support.change_cwd(path=script_dir):
+            os.mkdir('test_pkg')
+            # Create invalid *.pyc as empty file
+            with open('test_pkg/__init__.pyc', 'wb'):
+                pass
+            err = self.check_dash_m_failure('test_pkg')
+            self.assertRegex(err,
+                br'Error while finding module specification.*'
+                br'ImportError.*bad magic number')
+            self.assertNotIn(b'is a package', err)
+            self.assertNotIn(b'Traceback', err)
+
+    def test_dash_m_init_traceback(self):
+        # These were wrapped in an ImportError and tracebacks were
+        # suppressed; see Issue 14285
+        exceptions = (ImportError, AttributeError, TypeError, ValueError)
+        for exception in exceptions:
+            exception = exception.__name__
+            init = "raise {0}('Exception in __init__.py')".format(exception)
+            with self.subTest(exception), \
+                    self.setup_test_pkg(init) as pkg_dir:
+                err = self.check_dash_m_failure('test_pkg')
+                self.assertIn(exception.encode('ascii'), err)
+                self.assertIn(b'Exception in __init__.py', err)
+                self.assertIn(b'Traceback', err)
+
+    def test_dash_m_main_traceback(self):
+        # Ensure that an ImportError's traceback is reported
+        with self.setup_test_pkg() as pkg_dir:
+            main = "raise ImportError('Exception in __main__ module')"
+            _make_test_script(pkg_dir, '__main__', main)
+            err = self.check_dash_m_failure('test_pkg')
+            self.assertIn(b'ImportError', err)
+            self.assertIn(b'Exception in __main__ module', err)
+            self.assertIn(b'Traceback', err)
+
+    def test_pep_409_verbiage(self):
+        # Make sure PEP 409 syntax properly suppresses
+        # the context of an exception
+        script = textwrap.dedent("""\
+            try:
+                raise ValueError
+            except:
+                raise NameError from None
+            """)
+        with support.temp_dir() as script_dir:
+            script_name = _make_test_script(script_dir, 'script', script)
+            exitcode, stdout, stderr = assert_python_failure(script_name)
+            text = stderr.decode('ascii').split('\n')
+            self.assertEqual(len(text), 4)
+            self.assertTrue(text[0].startswith('Traceback'))
+            self.assertTrue(text[1].startswith('  File '))
+            self.assertTrue(text[3].startswith('NameError'))
+
+    def test_non_ascii(self):
+        # Mac OS X denies the creation of a file with an invalid UTF-8 name.
+        # Windows allows creating a name with an arbitrary bytes name, but
+        # Python cannot a undecodable bytes argument to a subprocess.
+        if (support.TESTFN_UNDECODABLE
+        and sys.platform not in ('win32', 'darwin')):
+            name = os.fsdecode(support.TESTFN_UNDECODABLE)
+        elif support.TESTFN_NONASCII:
+            name = support.TESTFN_NONASCII
+        else:
+            self.skipTest("need support.TESTFN_NONASCII")
+
+        # Issue #16218
+        source = 'print(ascii(__file__))\n'
+        script_name = _make_test_script(os.curdir, name, source)
+        self.addCleanup(support.unlink, script_name)
+        rc, stdout, stderr = assert_python_ok(script_name)
+        self.assertEqual(
+            ascii(script_name),
+            stdout.rstrip().decode('ascii'),
+            'stdout=%r stderr=%r' % (stdout, stderr))
+        self.assertEqual(0, rc)
+
+    def test_issue20500_exit_with_exception_value(self):
+        script = textwrap.dedent("""\
+            import sys
+            error = None
+            try:
+                raise ValueError('some text')
+            except ValueError as err:
+                error = err
+
+            if error:
+                sys.exit(error)
+            """)
+        with support.temp_dir() as script_dir:
+            script_name = _make_test_script(script_dir, 'script', script)
+            exitcode, stdout, stderr = assert_python_failure(script_name)
+            text = stderr.decode('ascii')
+            self.assertEqual(text, "some text")
+
+    def test_syntaxerror_unindented_caret_position(self):
+        script = "1 + 1 = 2\n"
+        with support.temp_dir() as script_dir:
+            script_name = _make_test_script(script_dir, 'script', script)
+            exitcode, stdout, stderr = assert_python_failure(script_name)
+            text = io.TextIOWrapper(io.BytesIO(stderr), 'ascii').read()
+            # Confirm that the caret is located under the first 1 character
+            self.assertIn("\n    1 + 1 = 2\n    ^", text)
+
+    def test_syntaxerror_indented_caret_position(self):
+        script = textwrap.dedent("""\
+            if True:
+                1 + 1 = 2
+            """)
+        with support.temp_dir() as script_dir:
+            script_name = _make_test_script(script_dir, 'script', script)
+            exitcode, stdout, stderr = assert_python_failure(script_name)
+            text = io.TextIOWrapper(io.BytesIO(stderr), 'ascii').read()
+            # Confirm that the caret is located under the first 1 character
+            self.assertIn("\n    1 + 1 = 2\n    ^", text)
+
+            # Try the same with a form feed at the start of the indented line
+            script = (
+                "if True:\n"
+                "\f    1 + 1 = 2\n"
+            )
+            script_name = _make_test_script(script_dir, "script", script)
+            exitcode, stdout, stderr = assert_python_failure(script_name)
+            text = io.TextIOWrapper(io.BytesIO(stderr), "ascii").read()
+            self.assertNotIn("\f", text)
+            self.assertIn("\n    1 + 1 = 2\n    ^", text)
+
+    def test_syntaxerror_multi_line_fstring(self):
+        script = 'foo = f"""{}\nfoo"""\n'
+        with support.temp_dir() as script_dir:
+            script_name = _make_test_script(script_dir, 'script', script)
+            exitcode, stdout, stderr = assert_python_failure(script_name)
+            self.assertEqual(
+                stderr.splitlines()[-3:],
+                [
+                    b'    foo = f"""{}',
+                    b'          ^',
+                    b'SyntaxError: f-string: empty expression not allowed',
+                ],
+            )
+
+    def test_syntaxerror_invalid_escape_sequence_multi_line(self):
+        script = 'foo = """\\q\n"""\n'
+        with support.temp_dir() as script_dir:
+            script_name = _make_test_script(script_dir, 'script', script)
+            exitcode, stdout, stderr = assert_python_failure(
+                '-Werror', script_name,
+            )
+            self.assertEqual(
+                stderr.splitlines()[-3:],
+                [
+                    b'    foo = """\\q',
+                    b'          ^',
+                    b'SyntaxError: invalid escape sequence \\q',
+                ],
+            )
+
+    def test_consistent_sys_path_for_direct_execution(self):
+        # This test case ensures that the following all give the same
+        # sys.path configuration:
+        #
+        #    ./python -s script_dir/__main__.py
+        #    ./python -s script_dir
+        #    ./python -I script_dir
+        script = textwrap.dedent("""\
+            import sys
+            for entry in sys.path:
+                print(entry)
+            """)
+        # Always show full path diffs on errors
+        self.maxDiff = None
+        with support.temp_dir() as work_dir, support.temp_dir() as script_dir:
+            script_name = _make_test_script(script_dir, '__main__', script)
+            # Reference output comes from directly executing __main__.py
+            # We omit PYTHONPATH and user site to align with isolated mode
+            p = spawn_python("-Es", script_name, cwd=work_dir)
+            out_by_name = kill_python(p).decode().splitlines()
+            self.assertEqual(out_by_name[0], script_dir)
+            self.assertNotIn(work_dir, out_by_name)
+            # Directory execution should give the same output
+            p = spawn_python("-Es", script_dir, cwd=work_dir)
+            out_by_dir = kill_python(p).decode().splitlines()
+            self.assertEqual(out_by_dir, out_by_name)
+            # As should directory execution in isolated mode
+            p = spawn_python("-I", script_dir, cwd=work_dir)
+            out_by_dir_isolated = kill_python(p).decode().splitlines()
+            self.assertEqual(out_by_dir_isolated, out_by_dir, out_by_name)
+
+    def test_consistent_sys_path_for_module_execution(self):
+        # This test case ensures that the following both give the same
+        # sys.path configuration:
+        #    ./python -sm script_pkg.__main__
+        #    ./python -sm script_pkg
+        #
+        # And that this fails as unable to find the package:
+        #    ./python -Im script_pkg
+        script = textwrap.dedent("""\
+            import sys
+            for entry in sys.path:
+                print(entry)
+            """)
+        # Always show full path diffs on errors
+        self.maxDiff = None
+        with support.temp_dir() as work_dir:
+            script_dir = os.path.join(work_dir, "script_pkg")
+            os.mkdir(script_dir)
+            script_name = _make_test_script(script_dir, '__main__', script)
+            # Reference output comes from `-m script_pkg.__main__`
+            # We omit PYTHONPATH and user site to better align with the
+            # direct execution test cases
+            p = spawn_python("-sm", "script_pkg.__main__", cwd=work_dir)
+            out_by_module = kill_python(p).decode().splitlines()
+            self.assertEqual(out_by_module[0], work_dir)
+            self.assertNotIn(script_dir, out_by_module)
+            # Package execution should give the same output
+            p = spawn_python("-sm", "script_pkg", cwd=work_dir)
+            out_by_package = kill_python(p).decode().splitlines()
+            self.assertEqual(out_by_package, out_by_module)
+            # Isolated mode should fail with an import error
+            exitcode, stdout, stderr = assert_python_failure(
+                "-Im", "script_pkg", cwd=work_dir
+            )
+            traceback_lines = stderr.decode().splitlines()
+            self.assertIn("No module named script_pkg", traceback_lines[-1])
+
+    def test_nonexisting_script(self):
+        # bpo-34783: "./python script.py" must not crash
+        # if the script file doesn't exist.
+        # (Skip test for macOS framework builds because sys.excutable name
+        #  is not the actual Python executable file name.
+        script = 'nonexistingscript.py'
+        self.assertFalse(os.path.exists(script))
+
+        proc = spawn_python(script, text=True,
+                            stdout=subprocess.PIPE,
+                            stderr=subprocess.PIPE)
+        out, err = proc.communicate()
+        self.assertIn(": can't open file ", err)
+        self.assertNotEqual(proc.returncode, 0)
+
+
+def test_main():
+    support.run_unittest(CmdLineTest)
+    support.reap_children()
+
+if __name__ == '__main__':
+    test_main()

--- a/Lib/test/test_cmd_line_script.py
+++ b/Lib/test/test_cmd_line_script.py
@@ -148,11 +148,15 @@ class CmdLineTest(unittest.TestCase):
             print('Expected output: %r' % expected_msg)
         self.assertIn(expected_msg.encode('utf-8'), err)
 
+    # TODO: RUSTPYTHON
+    @unittest.expectedFailure
     def test_dash_c_loader(self):
         rc, out, err = assert_python_ok("-c", "print(__loader__)")
         expected = repr(importlib.machinery.BuiltinImporter).encode("utf-8")
         self.assertIn(expected, out)
 
+    # TODO: RUSTPYTHON
+    @unittest.expectedFailure
     def test_stdin_loader(self):
         # Unfortunately, there's no way to automatically test the fully
         # interactive REPL, since that code path only gets executed when
@@ -201,18 +205,24 @@ class CmdLineTest(unittest.TestCase):
             self.assertIn(b'File "<stdin>"', stderr.readline())
             self.assertIn(b'ZeroDivisionError', stderr.readline())
 
+    @unittest.skip("TODO: RUSTPYTHON, test hang in middle")
     def test_repl_stdout_flush(self):
         self.check_repl_stdout_flush()
 
+    @unittest.skip("TODO: RUSTPYTHON, test hang in middle")
     def test_repl_stdout_flush_separate_stderr(self):
         self.check_repl_stdout_flush(True)
 
+    @unittest.skip("TODO: RUSTPYTHON, test hang in middle")
     def test_repl_stderr_flush(self):
         self.check_repl_stderr_flush()
 
+    @unittest.skip("TODO: RUSTPYTHON, test hang in middle")
     def test_repl_stderr_flush_separate_stderr(self):
         self.check_repl_stderr_flush(True)
 
+    # TODO: RUSTPYTHON
+    @unittest.expectedFailure
     def test_basic_script(self):
         with support.temp_dir() as script_dir:
             script_name = _make_test_script(script_dir, 'script')
@@ -220,6 +230,8 @@ class CmdLineTest(unittest.TestCase):
                                script_dir, None,
                                importlib.machinery.SourceFileLoader)
 
+    # TODO: RUSTPYTHON
+    @unittest.expectedFailure
     def test_script_compiled(self):
         with support.temp_dir() as script_dir:
             script_name = _make_test_script(script_dir, 'script')
@@ -230,6 +242,8 @@ class CmdLineTest(unittest.TestCase):
                                pyc_file, script_dir, None,
                                importlib.machinery.SourcelessFileLoader)
 
+    # TODO: RUSTPYTHON
+    @unittest.expectedFailure
     def test_directory(self):
         with support.temp_dir() as script_dir:
             script_name = _make_test_script(script_dir, '__main__')
@@ -237,6 +251,8 @@ class CmdLineTest(unittest.TestCase):
                                script_dir, '',
                                importlib.machinery.SourceFileLoader)
 
+    # TODO: RUSTPYTHON
+    @unittest.expectedFailure
     def test_directory_compiled(self):
         with support.temp_dir() as script_dir:
             script_name = _make_test_script(script_dir, '__main__')
@@ -247,11 +263,15 @@ class CmdLineTest(unittest.TestCase):
                                script_dir, '',
                                importlib.machinery.SourcelessFileLoader)
 
+    # TODO: RUSTPYTHON
+    @unittest.expectedFailure
     def test_directory_error(self):
         with support.temp_dir() as script_dir:
             msg = "can't find '__main__' module in %r" % script_dir
             self._check_import_error(script_dir, msg)
 
+    # TODO: RUSTPYTHON
+    @unittest.expectedFailure
     def test_zipfile(self):
         with support.temp_dir() as script_dir:
             script_name = _make_test_script(script_dir, '__main__')
@@ -259,6 +279,8 @@ class CmdLineTest(unittest.TestCase):
             self._check_script(zip_name, run_name, zip_name, zip_name, '',
                                zipimport.zipimporter)
 
+    # TODO: RUSTPYTHON
+    @unittest.expectedFailure
     def test_zipfile_compiled_timestamp(self):
         with support.temp_dir() as script_dir:
             script_name = _make_test_script(script_dir, '__main__')
@@ -269,6 +291,7 @@ class CmdLineTest(unittest.TestCase):
             self._check_script(zip_name, run_name, zip_name, zip_name, '',
                                zipimport.zipimporter)
 
+    @unittest.skip("TODO: RUSTPYTHON, TypeError: object of type 'NoneType' has no len()")
     def test_zipfile_compiled_checked_hash(self):
         with support.temp_dir() as script_dir:
             script_name = _make_test_script(script_dir, '__main__')
@@ -279,6 +302,7 @@ class CmdLineTest(unittest.TestCase):
             self._check_script(zip_name, run_name, zip_name, zip_name, '',
                                zipimport.zipimporter)
 
+    @unittest.skip("TODO: RUSTPYTHON, TypeError: object of type 'NoneType' has no len()")
     def test_zipfile_compiled_unchecked_hash(self):
         with support.temp_dir() as script_dir:
             script_name = _make_test_script(script_dir, '__main__')
@@ -289,6 +313,8 @@ class CmdLineTest(unittest.TestCase):
             self._check_script(zip_name, run_name, zip_name, zip_name, '',
                                zipimport.zipimporter)
 
+    # TODO: RUSTPYTHON
+    @unittest.expectedFailure
     def test_zipfile_error(self):
         with support.temp_dir() as script_dir:
             script_name = _make_test_script(script_dir, 'not_main')
@@ -296,6 +322,8 @@ class CmdLineTest(unittest.TestCase):
             msg = "can't find '__main__' module in %r" % zip_name
             self._check_import_error(zip_name, msg)
 
+    # TODO: RUSTPYTHON
+    @unittest.expectedFailure
     def test_module_in_package(self):
         with support.temp_dir() as script_dir:
             pkg_dir = os.path.join(script_dir, 'test_pkg')
@@ -306,6 +334,8 @@ class CmdLineTest(unittest.TestCase):
                                importlib.machinery.SourceFileLoader,
                                cwd=script_dir)
 
+    # TODO: RUSTPYTHON
+    @unittest.expectedFailure
     def test_module_in_package_in_zipfile(self):
         with support.temp_dir() as script_dir:
             zip_name, run_name = _make_test_zip_pkg(script_dir, 'test_zip', 'test_pkg', 'script')
@@ -313,6 +343,8 @@ class CmdLineTest(unittest.TestCase):
                                script_dir, 'test_pkg', zipimport.zipimporter,
                                PYTHONPATH=zip_name, cwd=script_dir)
 
+    # TODO: RUSTPYTHON
+    @unittest.expectedFailure
     def test_module_in_subpackage_in_zipfile(self):
         with support.temp_dir() as script_dir:
             zip_name, run_name = _make_test_zip_pkg(script_dir, 'test_zip', 'test_pkg', 'script', depth=2)
@@ -321,6 +353,8 @@ class CmdLineTest(unittest.TestCase):
                                zipimport.zipimporter,
                                PYTHONPATH=zip_name, cwd=script_dir)
 
+    # TODO: RUSTPYTHON
+    @unittest.expectedFailure
     def test_package(self):
         with support.temp_dir() as script_dir:
             pkg_dir = os.path.join(script_dir, 'test_pkg')
@@ -331,6 +365,8 @@ class CmdLineTest(unittest.TestCase):
                                importlib.machinery.SourceFileLoader,
                                cwd=script_dir)
 
+    # TODO: RUSTPYTHON
+    @unittest.expectedFailure
     def test_package_compiled(self):
         with support.temp_dir() as script_dir:
             pkg_dir = os.path.join(script_dir, 'test_pkg')
@@ -363,6 +399,8 @@ class CmdLineTest(unittest.TestCase):
                    "be directly executed")
             self._check_import_error(["-m", "test_pkg"], msg, cwd=script_dir)
 
+    # TODO: RUSTPYTHON
+    @unittest.expectedFailure
     def test_issue8202(self):
         # Make sure package __init__ modules see "-m" in sys.argv0 while
         # searching for the module to execute
@@ -380,6 +418,8 @@ class CmdLineTest(unittest.TestCase):
                                    script_name, script_name, script_dir, 'test_pkg',
                                    importlib.machinery.SourceFileLoader)
 
+    # TODO: RUSTPYTHON
+    @unittest.expectedFailure
     def test_issue8202_dash_c_file_ignored(self):
         # Make sure a "-c" file in the current directory
         # does not alter the value of sys.path[0]
@@ -395,6 +435,8 @@ class CmdLineTest(unittest.TestCase):
                     expected = "sys.path[0]==%r" % ''
                     self.assertIn(expected.encode('utf-8'), out)
 
+    # TODO: RUSTPYTHON
+    @unittest.expectedFailure
     def test_issue8202_dash_m_file_ignored(self):
         # Make sure a "-m" file in the current directory
         # does not alter the value of sys.path[0]
@@ -510,6 +552,8 @@ class CmdLineTest(unittest.TestCase):
             self.assertIn(b'Exception in __main__ module', err)
             self.assertIn(b'Traceback', err)
 
+    # TODO: RUSTPYTHON
+    @unittest.expectedFailure
     def test_pep_409_verbiage(self):
         # Make sure PEP 409 syntax properly suppresses
         # the context of an exception
@@ -528,6 +572,7 @@ class CmdLineTest(unittest.TestCase):
             self.assertTrue(text[1].startswith('  File '))
             self.assertTrue(text[3].startswith('NameError'))
 
+    @unittest.skip("TODO: RUSTPYTHON, TypeError: Expected type 'str', not 'bytes'")
     def test_non_ascii(self):
         # Mac OS X denies the creation of a file with an invalid UTF-8 name.
         # Windows allows creating a name with an arbitrary bytes name, but
@@ -551,6 +596,8 @@ class CmdLineTest(unittest.TestCase):
             'stdout=%r stderr=%r' % (stdout, stderr))
         self.assertEqual(0, rc)
 
+    # TODO: RUSTPYTHON
+    @unittest.expectedFailure
     def test_issue20500_exit_with_exception_value(self):
         script = textwrap.dedent("""\
             import sys
@@ -569,6 +616,7 @@ class CmdLineTest(unittest.TestCase):
             text = stderr.decode('ascii')
             self.assertEqual(text, "some text")
 
+    @unittest.skip("TODO: RUSTPYTHON, UnicodeDecodeError")
     def test_syntaxerror_unindented_caret_position(self):
         script = "1 + 1 = 2\n"
         with support.temp_dir() as script_dir:
@@ -578,6 +626,7 @@ class CmdLineTest(unittest.TestCase):
             # Confirm that the caret is located under the first 1 character
             self.assertIn("\n    1 + 1 = 2\n    ^", text)
 
+    @unittest.skip("TODO: RUSTPYTHON, UnicodeDecodeError")
     def test_syntaxerror_indented_caret_position(self):
         script = textwrap.dedent("""\
             if True:
@@ -601,6 +650,8 @@ class CmdLineTest(unittest.TestCase):
             self.assertNotIn("\f", text)
             self.assertIn("\n    1 + 1 = 2\n    ^", text)
 
+    # TODO: RUSTPYTHON
+    @unittest.expectedFailure
     def test_syntaxerror_multi_line_fstring(self):
         script = 'foo = f"""{}\nfoo"""\n'
         with support.temp_dir() as script_dir:
@@ -615,6 +666,8 @@ class CmdLineTest(unittest.TestCase):
                 ],
             )
 
+    # TODO: RUSTPYTHON
+    @unittest.expectedFailure
     def test_syntaxerror_invalid_escape_sequence_multi_line(self):
         script = 'foo = """\\q\n"""\n'
         with support.temp_dir() as script_dir:
@@ -631,6 +684,8 @@ class CmdLineTest(unittest.TestCase):
                 ],
             )
 
+    # TODO: RUSTPYTHON
+    @unittest.expectedFailure
     def test_consistent_sys_path_for_direct_execution(self):
         # This test case ensures that the following all give the same
         # sys.path configuration:
@@ -662,6 +717,8 @@ class CmdLineTest(unittest.TestCase):
             out_by_dir_isolated = kill_python(p).decode().splitlines()
             self.assertEqual(out_by_dir_isolated, out_by_dir, out_by_name)
 
+    # TODO: RUSTPYTHON
+    @unittest.expectedFailure
     def test_consistent_sys_path_for_module_execution(self):
         # This test case ensures that the following both give the same
         # sys.path configuration:
@@ -699,6 +756,8 @@ class CmdLineTest(unittest.TestCase):
             traceback_lines = stderr.decode().splitlines()
             self.assertIn("No module named script_pkg", traceback_lines[-1])
 
+    # TODO: RUSTPYTHON
+    @unittest.expectedFailure
     def test_nonexisting_script(self):
         # bpo-34783: "./python script.py" must not crash
         # if the script file doesn't exist.

--- a/Lib/test/test_codeccallbacks.py
+++ b/Lib/test/test_codeccallbacks.py
@@ -1,0 +1,1081 @@
+import codecs
+import html.entities
+import sys
+import unicodedata
+import unittest
+
+
+class PosReturn:
+    # this can be used for configurable callbacks
+
+    def __init__(self):
+        self.pos = 0
+
+    def handle(self, exc):
+        oldpos = self.pos
+        realpos = oldpos
+        if realpos<0:
+            realpos = len(exc.object) + realpos
+        # if we don't advance this time, terminate on the next call
+        # otherwise we'd get an endless loop
+        if realpos <= exc.start:
+            self.pos = len(exc.object)
+        return ("<?>", oldpos)
+
+# A UnicodeEncodeError object with a bad start attribute
+class BadStartUnicodeEncodeError(UnicodeEncodeError):
+    def __init__(self):
+        UnicodeEncodeError.__init__(self, "ascii", "", 0, 1, "bad")
+        self.start = []
+
+# A UnicodeEncodeError object with a bad object attribute
+class BadObjectUnicodeEncodeError(UnicodeEncodeError):
+    def __init__(self):
+        UnicodeEncodeError.__init__(self, "ascii", "", 0, 1, "bad")
+        self.object = []
+
+# A UnicodeDecodeError object without an end attribute
+class NoEndUnicodeDecodeError(UnicodeDecodeError):
+    def __init__(self):
+        UnicodeDecodeError.__init__(self, "ascii", bytearray(b""), 0, 1, "bad")
+        del self.end
+
+# A UnicodeDecodeError object with a bad object attribute
+class BadObjectUnicodeDecodeError(UnicodeDecodeError):
+    def __init__(self):
+        UnicodeDecodeError.__init__(self, "ascii", bytearray(b""), 0, 1, "bad")
+        self.object = []
+
+# A UnicodeTranslateError object without a start attribute
+class NoStartUnicodeTranslateError(UnicodeTranslateError):
+    def __init__(self):
+        UnicodeTranslateError.__init__(self, "", 0, 1, "bad")
+        del self.start
+
+# A UnicodeTranslateError object without an end attribute
+class NoEndUnicodeTranslateError(UnicodeTranslateError):
+    def __init__(self):
+        UnicodeTranslateError.__init__(self,  "", 0, 1, "bad")
+        del self.end
+
+# A UnicodeTranslateError object without an object attribute
+class NoObjectUnicodeTranslateError(UnicodeTranslateError):
+    def __init__(self):
+        UnicodeTranslateError.__init__(self, "", 0, 1, "bad")
+        del self.object
+
+class CodecCallbackTest(unittest.TestCase):
+
+    def test_xmlcharrefreplace(self):
+        # replace unencodable characters which numeric character entities.
+        # For ascii, latin-1 and charmaps this is completely implemented
+        # in C and should be reasonably fast.
+        s = "\u30b9\u30d1\u30e2 \xe4nd eggs"
+        self.assertEqual(
+            s.encode("ascii", "xmlcharrefreplace"),
+            b"&#12473;&#12497;&#12514; &#228;nd eggs"
+        )
+        self.assertEqual(
+            s.encode("latin-1", "xmlcharrefreplace"),
+            b"&#12473;&#12497;&#12514; \xe4nd eggs"
+        )
+
+    def test_xmlcharnamereplace(self):
+        # This time use a named character entity for unencodable
+        # characters, if one is available.
+
+        def xmlcharnamereplace(exc):
+            if not isinstance(exc, UnicodeEncodeError):
+                raise TypeError("don't know how to handle %r" % exc)
+            l = []
+            for c in exc.object[exc.start:exc.end]:
+                try:
+                    l.append("&%s;" % html.entities.codepoint2name[ord(c)])
+                except KeyError:
+                    l.append("&#%d;" % ord(c))
+            return ("".join(l), exc.end)
+
+        codecs.register_error(
+            "test.xmlcharnamereplace", xmlcharnamereplace)
+
+        sin = "\xab\u211c\xbb = \u2329\u1234\u20ac\u232a"
+        sout = b"&laquo;&real;&raquo; = &lang;&#4660;&euro;&rang;"
+        self.assertEqual(sin.encode("ascii", "test.xmlcharnamereplace"), sout)
+        sout = b"\xab&real;\xbb = &lang;&#4660;&euro;&rang;"
+        self.assertEqual(sin.encode("latin-1", "test.xmlcharnamereplace"), sout)
+        sout = b"\xab&real;\xbb = &lang;&#4660;\xa4&rang;"
+        self.assertEqual(sin.encode("iso-8859-15", "test.xmlcharnamereplace"), sout)
+
+    def test_uninamereplace(self):
+        # We're using the names from the unicode database this time,
+        # and we're doing "syntax highlighting" here, i.e. we include
+        # the replaced text in ANSI escape sequences. For this it is
+        # useful that the error handler is not called for every single
+        # unencodable character, but for a complete sequence of
+        # unencodable characters, otherwise we would output many
+        # unnecessary escape sequences.
+
+        def uninamereplace(exc):
+            if not isinstance(exc, UnicodeEncodeError):
+                raise TypeError("don't know how to handle %r" % exc)
+            l = []
+            for c in exc.object[exc.start:exc.end]:
+                l.append(unicodedata.name(c, "0x%x" % ord(c)))
+            return ("\033[1m%s\033[0m" % ", ".join(l), exc.end)
+
+        codecs.register_error(
+            "test.uninamereplace", uninamereplace)
+
+        sin = "\xac\u1234\u20ac\u8000"
+        sout = b"\033[1mNOT SIGN, ETHIOPIC SYLLABLE SEE, EURO SIGN, CJK UNIFIED IDEOGRAPH-8000\033[0m"
+        self.assertEqual(sin.encode("ascii", "test.uninamereplace"), sout)
+
+        sout = b"\xac\033[1mETHIOPIC SYLLABLE SEE, EURO SIGN, CJK UNIFIED IDEOGRAPH-8000\033[0m"
+        self.assertEqual(sin.encode("latin-1", "test.uninamereplace"), sout)
+
+        sout = b"\xac\033[1mETHIOPIC SYLLABLE SEE\033[0m\xa4\033[1mCJK UNIFIED IDEOGRAPH-8000\033[0m"
+        self.assertEqual(sin.encode("iso-8859-15", "test.uninamereplace"), sout)
+
+    def test_backslashescape(self):
+        # Does the same as the "unicode-escape" encoding, but with different
+        # base encodings.
+        sin = "a\xac\u1234\u20ac\u8000\U0010ffff"
+        sout = b"a\\xac\\u1234\\u20ac\\u8000\\U0010ffff"
+        self.assertEqual(sin.encode("ascii", "backslashreplace"), sout)
+
+        sout = b"a\xac\\u1234\\u20ac\\u8000\\U0010ffff"
+        self.assertEqual(sin.encode("latin-1", "backslashreplace"), sout)
+
+        sout = b"a\xac\\u1234\xa4\\u8000\\U0010ffff"
+        self.assertEqual(sin.encode("iso-8859-15", "backslashreplace"), sout)
+
+    def test_nameescape(self):
+        # Does the same as backslashescape, but prefers ``\N{...}`` escape
+        # sequences.
+        sin = "a\xac\u1234\u20ac\u8000\U0010ffff"
+        sout = (b'a\\N{NOT SIGN}\\N{ETHIOPIC SYLLABLE SEE}\\N{EURO SIGN}'
+                b'\\N{CJK UNIFIED IDEOGRAPH-8000}\\U0010ffff')
+        self.assertEqual(sin.encode("ascii", "namereplace"), sout)
+
+        sout = (b'a\xac\\N{ETHIOPIC SYLLABLE SEE}\\N{EURO SIGN}'
+                b'\\N{CJK UNIFIED IDEOGRAPH-8000}\\U0010ffff')
+        self.assertEqual(sin.encode("latin-1", "namereplace"), sout)
+
+        sout = (b'a\xac\\N{ETHIOPIC SYLLABLE SEE}\xa4'
+                b'\\N{CJK UNIFIED IDEOGRAPH-8000}\\U0010ffff')
+        self.assertEqual(sin.encode("iso-8859-15", "namereplace"), sout)
+
+    def test_decoding_callbacks(self):
+        # This is a test for a decoding callback handler
+        # that allows the decoding of the invalid sequence
+        # "\xc0\x80" and returns "\x00" instead of raising an error.
+        # All other illegal sequences will be handled strictly.
+        def relaxedutf8(exc):
+            if not isinstance(exc, UnicodeDecodeError):
+                raise TypeError("don't know how to handle %r" % exc)
+            if exc.object[exc.start:exc.start+2] == b"\xc0\x80":
+                return ("\x00", exc.start+2) # retry after two bytes
+            else:
+                raise exc
+
+        codecs.register_error("test.relaxedutf8", relaxedutf8)
+
+        # all the "\xc0\x80" will be decoded to "\x00"
+        sin = b"a\x00b\xc0\x80c\xc3\xbc\xc0\x80\xc0\x80"
+        sout = "a\x00b\x00c\xfc\x00\x00"
+        self.assertEqual(sin.decode("utf-8", "test.relaxedutf8"), sout)
+
+        # "\xc0\x81" is not valid and a UnicodeDecodeError will be raised
+        sin = b"\xc0\x80\xc0\x81"
+        self.assertRaises(UnicodeDecodeError, sin.decode,
+                          "utf-8", "test.relaxedutf8")
+
+    def test_charmapencode(self):
+        # For charmap encodings the replacement string will be
+        # mapped through the encoding again. This means, that
+        # to be able to use e.g. the "replace" handler, the
+        # charmap has to have a mapping for "?".
+        charmap = dict((ord(c), bytes(2*c.upper(), 'ascii')) for c in "abcdefgh")
+        sin = "abc"
+        sout = b"AABBCC"
+        self.assertEqual(codecs.charmap_encode(sin, "strict", charmap)[0], sout)
+
+        sin = "abcA"
+        self.assertRaises(UnicodeError, codecs.charmap_encode, sin, "strict", charmap)
+
+        charmap[ord("?")] = b"XYZ"
+        sin = "abcDEF"
+        sout = b"AABBCCXYZXYZXYZ"
+        self.assertEqual(codecs.charmap_encode(sin, "replace", charmap)[0], sout)
+
+        charmap[ord("?")] = "XYZ" # wrong type in mapping
+        self.assertRaises(TypeError, codecs.charmap_encode, sin, "replace", charmap)
+
+    def test_callbacks(self):
+        def handler1(exc):
+            r = range(exc.start, exc.end)
+            if isinstance(exc, UnicodeEncodeError):
+                l = ["<%d>" % ord(exc.object[pos]) for pos in r]
+            elif isinstance(exc, UnicodeDecodeError):
+                l = ["<%d>" % exc.object[pos] for pos in r]
+            else:
+                raise TypeError("don't know how to handle %r" % exc)
+            return ("[%s]" % "".join(l), exc.end)
+
+        codecs.register_error("test.handler1", handler1)
+
+        def handler2(exc):
+            if not isinstance(exc, UnicodeDecodeError):
+                raise TypeError("don't know how to handle %r" % exc)
+            l = ["<%d>" % exc.object[pos] for pos in range(exc.start, exc.end)]
+            return ("[%s]" % "".join(l), exc.end+1) # skip one character
+
+        codecs.register_error("test.handler2", handler2)
+
+        s = b"\x00\x81\x7f\x80\xff"
+
+        self.assertEqual(
+            s.decode("ascii", "test.handler1"),
+            "\x00[<129>]\x7f[<128>][<255>]"
+        )
+        self.assertEqual(
+            s.decode("ascii", "test.handler2"),
+            "\x00[<129>][<128>]"
+        )
+
+        self.assertEqual(
+            b"\\u3042\\u3xxx".decode("unicode-escape", "test.handler1"),
+            "\u3042[<92><117><51>]xxx"
+        )
+
+        self.assertEqual(
+            b"\\u3042\\u3xx".decode("unicode-escape", "test.handler1"),
+            "\u3042[<92><117><51>]xx"
+        )
+
+        self.assertEqual(
+            codecs.charmap_decode(b"abc", "test.handler1", {ord("a"): "z"})[0],
+            "z[<98>][<99>]"
+        )
+
+        self.assertEqual(
+            "g\xfc\xdfrk".encode("ascii", "test.handler1"),
+            b"g[<252><223>]rk"
+        )
+
+        self.assertEqual(
+            "g\xfc\xdf".encode("ascii", "test.handler1"),
+            b"g[<252><223>]"
+        )
+
+    def test_longstrings(self):
+        # test long strings to check for memory overflow problems
+        errors = [ "strict", "ignore", "replace", "xmlcharrefreplace",
+                   "backslashreplace", "namereplace"]
+        # register the handlers under different names,
+        # to prevent the codec from recognizing the name
+        for err in errors:
+            codecs.register_error("test." + err, codecs.lookup_error(err))
+        l = 1000
+        errors += [ "test." + err for err in errors ]
+        for uni in [ s*l for s in ("x", "\u3042", "a\xe4") ]:
+            for enc in ("ascii", "latin-1", "iso-8859-1", "iso-8859-15",
+                        "utf-8", "utf-7", "utf-16", "utf-32"):
+                for err in errors:
+                    try:
+                        uni.encode(enc, err)
+                    except UnicodeError:
+                        pass
+
+    def check_exceptionobjectargs(self, exctype, args, msg):
+        # Test UnicodeError subclasses: construction, attribute assignment and __str__ conversion
+        # check with one missing argument
+        self.assertRaises(TypeError, exctype, *args[:-1])
+        # check with one argument too much
+        self.assertRaises(TypeError, exctype, *(args + ["too much"]))
+        # check with one argument of the wrong type
+        wrongargs = [ "spam", b"eggs", b"spam", 42, 1.0, None ]
+        for i in range(len(args)):
+            for wrongarg in wrongargs:
+                if type(wrongarg) is type(args[i]):
+                    continue
+                # build argument array
+                callargs = []
+                for j in range(len(args)):
+                    if i==j:
+                        callargs.append(wrongarg)
+                    else:
+                        callargs.append(args[i])
+                self.assertRaises(TypeError, exctype, *callargs)
+
+        # check with the correct number and type of arguments
+        exc = exctype(*args)
+        self.assertEqual(str(exc), msg)
+
+    def test_unicodeencodeerror(self):
+        self.check_exceptionobjectargs(
+            UnicodeEncodeError,
+            ["ascii", "g\xfcrk", 1, 2, "ouch"],
+            "'ascii' codec can't encode character '\\xfc' in position 1: ouch"
+        )
+        self.check_exceptionobjectargs(
+            UnicodeEncodeError,
+            ["ascii", "g\xfcrk", 1, 4, "ouch"],
+            "'ascii' codec can't encode characters in position 1-3: ouch"
+        )
+        self.check_exceptionobjectargs(
+            UnicodeEncodeError,
+            ["ascii", "\xfcx", 0, 1, "ouch"],
+            "'ascii' codec can't encode character '\\xfc' in position 0: ouch"
+        )
+        self.check_exceptionobjectargs(
+            UnicodeEncodeError,
+            ["ascii", "\u0100x", 0, 1, "ouch"],
+            "'ascii' codec can't encode character '\\u0100' in position 0: ouch"
+        )
+        self.check_exceptionobjectargs(
+            UnicodeEncodeError,
+            ["ascii", "\uffffx", 0, 1, "ouch"],
+            "'ascii' codec can't encode character '\\uffff' in position 0: ouch"
+        )
+        self.check_exceptionobjectargs(
+            UnicodeEncodeError,
+            ["ascii", "\U00010000x", 0, 1, "ouch"],
+            "'ascii' codec can't encode character '\\U00010000' in position 0: ouch"
+        )
+
+    def test_unicodedecodeerror(self):
+        self.check_exceptionobjectargs(
+            UnicodeDecodeError,
+            ["ascii", bytearray(b"g\xfcrk"), 1, 2, "ouch"],
+            "'ascii' codec can't decode byte 0xfc in position 1: ouch"
+        )
+        self.check_exceptionobjectargs(
+            UnicodeDecodeError,
+            ["ascii", bytearray(b"g\xfcrk"), 1, 3, "ouch"],
+            "'ascii' codec can't decode bytes in position 1-2: ouch"
+        )
+
+    def test_unicodetranslateerror(self):
+        self.check_exceptionobjectargs(
+            UnicodeTranslateError,
+            ["g\xfcrk", 1, 2, "ouch"],
+            "can't translate character '\\xfc' in position 1: ouch"
+        )
+        self.check_exceptionobjectargs(
+            UnicodeTranslateError,
+            ["g\u0100rk", 1, 2, "ouch"],
+            "can't translate character '\\u0100' in position 1: ouch"
+        )
+        self.check_exceptionobjectargs(
+            UnicodeTranslateError,
+            ["g\uffffrk", 1, 2, "ouch"],
+            "can't translate character '\\uffff' in position 1: ouch"
+        )
+        self.check_exceptionobjectargs(
+            UnicodeTranslateError,
+            ["g\U00010000rk", 1, 2, "ouch"],
+            "can't translate character '\\U00010000' in position 1: ouch"
+        )
+        self.check_exceptionobjectargs(
+            UnicodeTranslateError,
+            ["g\xfcrk", 1, 3, "ouch"],
+            "can't translate characters in position 1-2: ouch"
+        )
+
+    def test_badandgoodstrictexceptions(self):
+        # "strict" complains about a non-exception passed in
+        self.assertRaises(
+            TypeError,
+            codecs.strict_errors,
+            42
+        )
+        # "strict" complains about the wrong exception type
+        self.assertRaises(
+            Exception,
+            codecs.strict_errors,
+            Exception("ouch")
+        )
+
+        # If the correct exception is passed in, "strict" raises it
+        self.assertRaises(
+            UnicodeEncodeError,
+            codecs.strict_errors,
+            UnicodeEncodeError("ascii", "\u3042", 0, 1, "ouch")
+        )
+        self.assertRaises(
+            UnicodeDecodeError,
+            codecs.strict_errors,
+            UnicodeDecodeError("ascii", bytearray(b"\xff"), 0, 1, "ouch")
+        )
+        self.assertRaises(
+            UnicodeTranslateError,
+            codecs.strict_errors,
+            UnicodeTranslateError("\u3042", 0, 1, "ouch")
+        )
+
+    def test_badandgoodignoreexceptions(self):
+        # "ignore" complains about a non-exception passed in
+        self.assertRaises(
+           TypeError,
+           codecs.ignore_errors,
+           42
+        )
+        # "ignore" complains about the wrong exception type
+        self.assertRaises(
+           TypeError,
+           codecs.ignore_errors,
+           UnicodeError("ouch")
+        )
+        # If the correct exception is passed in, "ignore" returns an empty replacement
+        self.assertEqual(
+            codecs.ignore_errors(
+                UnicodeEncodeError("ascii", "a\u3042b", 1, 2, "ouch")),
+            ("", 2)
+        )
+        self.assertEqual(
+            codecs.ignore_errors(
+                UnicodeDecodeError("ascii", bytearray(b"a\xffb"), 1, 2, "ouch")),
+            ("", 2)
+        )
+        self.assertEqual(
+            codecs.ignore_errors(
+                UnicodeTranslateError("a\u3042b", 1, 2, "ouch")),
+            ("", 2)
+        )
+
+    def test_badandgoodreplaceexceptions(self):
+        # "replace" complains about a non-exception passed in
+        self.assertRaises(
+           TypeError,
+           codecs.replace_errors,
+           42
+        )
+        # "replace" complains about the wrong exception type
+        self.assertRaises(
+           TypeError,
+           codecs.replace_errors,
+           UnicodeError("ouch")
+        )
+        self.assertRaises(
+            TypeError,
+            codecs.replace_errors,
+            BadObjectUnicodeEncodeError()
+        )
+        self.assertRaises(
+            TypeError,
+            codecs.replace_errors,
+            BadObjectUnicodeDecodeError()
+        )
+        # With the correct exception, "replace" returns an "?" or "\ufffd" replacement
+        self.assertEqual(
+            codecs.replace_errors(
+                UnicodeEncodeError("ascii", "a\u3042b", 1, 2, "ouch")),
+            ("?", 2)
+        )
+        self.assertEqual(
+            codecs.replace_errors(
+                UnicodeDecodeError("ascii", bytearray(b"a\xffb"), 1, 2, "ouch")),
+            ("\ufffd", 2)
+        )
+        self.assertEqual(
+            codecs.replace_errors(
+                UnicodeTranslateError("a\u3042b", 1, 2, "ouch")),
+            ("\ufffd", 2)
+        )
+
+    def test_badandgoodxmlcharrefreplaceexceptions(self):
+        # "xmlcharrefreplace" complains about a non-exception passed in
+        self.assertRaises(
+           TypeError,
+           codecs.xmlcharrefreplace_errors,
+           42
+        )
+        # "xmlcharrefreplace" complains about the wrong exception types
+        self.assertRaises(
+           TypeError,
+           codecs.xmlcharrefreplace_errors,
+           UnicodeError("ouch")
+        )
+        # "xmlcharrefreplace" can only be used for encoding
+        self.assertRaises(
+            TypeError,
+            codecs.xmlcharrefreplace_errors,
+            UnicodeDecodeError("ascii", bytearray(b"\xff"), 0, 1, "ouch")
+        )
+        self.assertRaises(
+            TypeError,
+            codecs.xmlcharrefreplace_errors,
+            UnicodeTranslateError("\u3042", 0, 1, "ouch")
+        )
+        # Use the correct exception
+        cs = (0, 1, 9, 10, 99, 100, 999, 1000, 9999, 10000, 99999, 100000,
+              999999, 1000000)
+        cs += (0xd800, 0xdfff)
+        s = "".join(chr(c) for c in cs)
+        self.assertEqual(
+            codecs.xmlcharrefreplace_errors(
+                UnicodeEncodeError("ascii", "a" + s + "b",
+                                   1, 1 + len(s), "ouch")
+            ),
+            ("".join("&#%d;" % c for c in cs), 1 + len(s))
+        )
+
+    def test_badandgoodbackslashreplaceexceptions(self):
+        # "backslashreplace" complains about a non-exception passed in
+        self.assertRaises(
+           TypeError,
+           codecs.backslashreplace_errors,
+           42
+        )
+        # "backslashreplace" complains about the wrong exception types
+        self.assertRaises(
+           TypeError,
+           codecs.backslashreplace_errors,
+           UnicodeError("ouch")
+        )
+        # Use the correct exception
+        tests = [
+            ("\u3042", "\\u3042"),
+            ("\n", "\\x0a"),
+            ("a", "\\x61"),
+            ("\x00", "\\x00"),
+            ("\xff", "\\xff"),
+            ("\u0100", "\\u0100"),
+            ("\uffff", "\\uffff"),
+            ("\U00010000", "\\U00010000"),
+            ("\U0010ffff", "\\U0010ffff"),
+            # Lone surrogates
+            ("\ud800", "\\ud800"),
+            ("\udfff", "\\udfff"),
+            ("\ud800\udfff", "\\ud800\\udfff"),
+        ]
+        for s, r in tests:
+            with self.subTest(str=s):
+                self.assertEqual(
+                    codecs.backslashreplace_errors(
+                        UnicodeEncodeError("ascii", "a" + s + "b",
+                                           1, 1 + len(s), "ouch")),
+                    (r, 1 + len(s))
+                )
+                self.assertEqual(
+                    codecs.backslashreplace_errors(
+                        UnicodeTranslateError("a" + s + "b",
+                                              1, 1 + len(s), "ouch")),
+                    (r, 1 + len(s))
+                )
+        tests = [
+            (b"a", "\\x61"),
+            (b"\n", "\\x0a"),
+            (b"\x00", "\\x00"),
+            (b"\xff", "\\xff"),
+        ]
+        for b, r in tests:
+            with self.subTest(bytes=b):
+                self.assertEqual(
+                    codecs.backslashreplace_errors(
+                        UnicodeDecodeError("ascii", bytearray(b"a" + b + b"b"),
+                                           1, 2, "ouch")),
+                    (r, 2)
+                )
+
+    def test_badandgoodnamereplaceexceptions(self):
+        # "namereplace" complains about a non-exception passed in
+        self.assertRaises(
+           TypeError,
+           codecs.namereplace_errors,
+           42
+        )
+        # "namereplace" complains about the wrong exception types
+        self.assertRaises(
+           TypeError,
+           codecs.namereplace_errors,
+           UnicodeError("ouch")
+        )
+        # "namereplace" can only be used for encoding
+        self.assertRaises(
+            TypeError,
+            codecs.namereplace_errors,
+            UnicodeDecodeError("ascii", bytearray(b"\xff"), 0, 1, "ouch")
+        )
+        self.assertRaises(
+            TypeError,
+            codecs.namereplace_errors,
+            UnicodeTranslateError("\u3042", 0, 1, "ouch")
+        )
+        # Use the correct exception
+        tests = [
+            ("\u3042", "\\N{HIRAGANA LETTER A}"),
+            ("\x00", "\\x00"),
+            ("\ufbf9", "\\N{ARABIC LIGATURE UIGHUR KIRGHIZ YEH WITH "
+                       "HAMZA ABOVE WITH ALEF MAKSURA ISOLATED FORM}"),
+            ("\U000e007f", "\\N{CANCEL TAG}"),
+            ("\U0010ffff", "\\U0010ffff"),
+            # Lone surrogates
+            ("\ud800", "\\ud800"),
+            ("\udfff", "\\udfff"),
+            ("\ud800\udfff", "\\ud800\\udfff"),
+        ]
+        for s, r in tests:
+            with self.subTest(str=s):
+                self.assertEqual(
+                    codecs.namereplace_errors(
+                        UnicodeEncodeError("ascii", "a" + s + "b",
+                                           1, 1 + len(s), "ouch")),
+                    (r, 1 + len(s))
+                )
+
+    def test_badandgoodsurrogateescapeexceptions(self):
+        surrogateescape_errors = codecs.lookup_error('surrogateescape')
+        # "surrogateescape" complains about a non-exception passed in
+        self.assertRaises(
+           TypeError,
+           surrogateescape_errors,
+           42
+        )
+        # "surrogateescape" complains about the wrong exception types
+        self.assertRaises(
+           TypeError,
+           surrogateescape_errors,
+           UnicodeError("ouch")
+        )
+        # "surrogateescape" can not be used for translating
+        self.assertRaises(
+            TypeError,
+            surrogateescape_errors,
+            UnicodeTranslateError("\udc80", 0, 1, "ouch")
+        )
+        # Use the correct exception
+        for s in ("a", "\udc7f", "\udd00"):
+            with self.subTest(str=s):
+                self.assertRaises(
+                    UnicodeEncodeError,
+                    surrogateescape_errors,
+                    UnicodeEncodeError("ascii", s, 0, 1, "ouch")
+                )
+        self.assertEqual(
+            surrogateescape_errors(
+                UnicodeEncodeError("ascii", "a\udc80b", 1, 2, "ouch")),
+            (b"\x80", 2)
+        )
+        self.assertRaises(
+            UnicodeDecodeError,
+            surrogateescape_errors,
+            UnicodeDecodeError("ascii", bytearray(b"a"), 0, 1, "ouch")
+        )
+        self.assertEqual(
+            surrogateescape_errors(
+                UnicodeDecodeError("ascii", bytearray(b"a\x80b"), 1, 2, "ouch")),
+            ("\udc80", 2)
+        )
+
+    def test_badandgoodsurrogatepassexceptions(self):
+        surrogatepass_errors = codecs.lookup_error('surrogatepass')
+        # "surrogatepass" complains about a non-exception passed in
+        self.assertRaises(
+           TypeError,
+           surrogatepass_errors,
+           42
+        )
+        # "surrogatepass" complains about the wrong exception types
+        self.assertRaises(
+           TypeError,
+           surrogatepass_errors,
+           UnicodeError("ouch")
+        )
+        # "surrogatepass" can not be used for translating
+        self.assertRaises(
+            TypeError,
+            surrogatepass_errors,
+            UnicodeTranslateError("\ud800", 0, 1, "ouch")
+        )
+        # Use the correct exception
+        for enc in ("utf-8", "utf-16le", "utf-16be", "utf-32le", "utf-32be"):
+            with self.subTest(encoding=enc):
+                self.assertRaises(
+                    UnicodeEncodeError,
+                    surrogatepass_errors,
+                    UnicodeEncodeError(enc, "a", 0, 1, "ouch")
+                )
+                self.assertRaises(
+                    UnicodeDecodeError,
+                    surrogatepass_errors,
+                    UnicodeDecodeError(enc, "a".encode(enc), 0, 1, "ouch")
+                )
+        for s in ("\ud800", "\udfff", "\ud800\udfff"):
+            with self.subTest(str=s):
+                self.assertRaises(
+                    UnicodeEncodeError,
+                    surrogatepass_errors,
+                    UnicodeEncodeError("ascii", s, 0, len(s), "ouch")
+                )
+        tests = [
+            ("utf-8", "\ud800", b'\xed\xa0\x80', 3),
+            ("utf-16le", "\ud800", b'\x00\xd8', 2),
+            ("utf-16be", "\ud800", b'\xd8\x00', 2),
+            ("utf-32le", "\ud800", b'\x00\xd8\x00\x00', 4),
+            ("utf-32be", "\ud800", b'\x00\x00\xd8\x00', 4),
+            ("utf-8", "\udfff", b'\xed\xbf\xbf', 3),
+            ("utf-16le", "\udfff", b'\xff\xdf', 2),
+            ("utf-16be", "\udfff", b'\xdf\xff', 2),
+            ("utf-32le", "\udfff", b'\xff\xdf\x00\x00', 4),
+            ("utf-32be", "\udfff", b'\x00\x00\xdf\xff', 4),
+            ("utf-8", "\ud800\udfff", b'\xed\xa0\x80\xed\xbf\xbf', 3),
+            ("utf-16le", "\ud800\udfff", b'\x00\xd8\xff\xdf', 2),
+            ("utf-16be", "\ud800\udfff", b'\xd8\x00\xdf\xff', 2),
+            ("utf-32le", "\ud800\udfff", b'\x00\xd8\x00\x00\xff\xdf\x00\x00', 4),
+            ("utf-32be", "\ud800\udfff", b'\x00\x00\xd8\x00\x00\x00\xdf\xff', 4),
+        ]
+        for enc, s, b, n in tests:
+            with self.subTest(encoding=enc, str=s, bytes=b):
+                self.assertEqual(
+                    surrogatepass_errors(
+                        UnicodeEncodeError(enc, "a" + s + "b",
+                                           1, 1 + len(s), "ouch")),
+                    (b, 1 + len(s))
+                )
+                self.assertEqual(
+                    surrogatepass_errors(
+                        UnicodeDecodeError(enc, bytearray(b"a" + b[:n] + b"b"),
+                                           1, 1 + n, "ouch")),
+                    (s[:1], 1 + n)
+                )
+
+    def test_badhandlerresults(self):
+        results = ( 42, "foo", (1,2,3), ("foo", 1, 3), ("foo", None), ("foo",), ("foo", 1, 3), ("foo", None), ("foo",) )
+        encs = ("ascii", "latin-1", "iso-8859-1", "iso-8859-15")
+
+        for res in results:
+            codecs.register_error("test.badhandler", lambda x: res)
+            for enc in encs:
+                self.assertRaises(
+                    TypeError,
+                    "\u3042".encode,
+                    enc,
+                    "test.badhandler"
+                )
+            for (enc, bytes) in (
+                ("ascii", b"\xff"),
+                ("utf-8", b"\xff"),
+                ("utf-7", b"+x-"),
+            ):
+                self.assertRaises(
+                    TypeError,
+                    bytes.decode,
+                    enc,
+                    "test.badhandler"
+                )
+
+    def test_lookup(self):
+        self.assertEqual(codecs.strict_errors, codecs.lookup_error("strict"))
+        self.assertEqual(codecs.ignore_errors, codecs.lookup_error("ignore"))
+        self.assertEqual(codecs.strict_errors, codecs.lookup_error("strict"))
+        self.assertEqual(
+            codecs.xmlcharrefreplace_errors,
+            codecs.lookup_error("xmlcharrefreplace")
+        )
+        self.assertEqual(
+            codecs.backslashreplace_errors,
+            codecs.lookup_error("backslashreplace")
+        )
+        self.assertEqual(
+            codecs.namereplace_errors,
+            codecs.lookup_error("namereplace")
+        )
+
+    def test_unencodablereplacement(self):
+        def unencrepl(exc):
+            if isinstance(exc, UnicodeEncodeError):
+                return ("\u4242", exc.end)
+            else:
+                raise TypeError("don't know how to handle %r" % exc)
+        codecs.register_error("test.unencreplhandler", unencrepl)
+        for enc in ("ascii", "iso-8859-1", "iso-8859-15"):
+            self.assertRaises(
+                UnicodeEncodeError,
+                "\u4242".encode,
+                enc,
+                "test.unencreplhandler"
+            )
+
+    def test_badregistercall(self):
+        # enhance coverage of:
+        # Modules/_codecsmodule.c::register_error()
+        # Python/codecs.c::PyCodec_RegisterError()
+        self.assertRaises(TypeError, codecs.register_error, 42)
+        self.assertRaises(TypeError, codecs.register_error, "test.dummy", 42)
+
+    def test_badlookupcall(self):
+        # enhance coverage of:
+        # Modules/_codecsmodule.c::lookup_error()
+        self.assertRaises(TypeError, codecs.lookup_error)
+
+    def test_unknownhandler(self):
+        # enhance coverage of:
+        # Modules/_codecsmodule.c::lookup_error()
+        self.assertRaises(LookupError, codecs.lookup_error, "test.unknown")
+
+    def test_xmlcharrefvalues(self):
+        # enhance coverage of:
+        # Python/codecs.c::PyCodec_XMLCharRefReplaceErrors()
+        # and inline implementations
+        v = (1, 5, 10, 50, 100, 500, 1000, 5000, 10000, 50000, 100000,
+             500000, 1000000)
+        s = "".join([chr(x) for x in v])
+        codecs.register_error("test.xmlcharrefreplace", codecs.xmlcharrefreplace_errors)
+        for enc in ("ascii", "iso-8859-15"):
+            for err in ("xmlcharrefreplace", "test.xmlcharrefreplace"):
+                s.encode(enc, err)
+
+    def test_decodehelper(self):
+        # enhance coverage of:
+        # Objects/unicodeobject.c::unicode_decode_call_errorhandler()
+        # and callers
+        self.assertRaises(LookupError, b"\xff".decode, "ascii", "test.unknown")
+
+        def baddecodereturn1(exc):
+            return 42
+        codecs.register_error("test.baddecodereturn1", baddecodereturn1)
+        self.assertRaises(TypeError, b"\xff".decode, "ascii", "test.baddecodereturn1")
+        self.assertRaises(TypeError, b"\\".decode, "unicode-escape", "test.baddecodereturn1")
+        self.assertRaises(TypeError, b"\\x0".decode, "unicode-escape", "test.baddecodereturn1")
+        self.assertRaises(TypeError, b"\\x0y".decode, "unicode-escape", "test.baddecodereturn1")
+        self.assertRaises(TypeError, b"\\Uffffeeee".decode, "unicode-escape", "test.baddecodereturn1")
+        self.assertRaises(TypeError, b"\\uyyyy".decode, "raw-unicode-escape", "test.baddecodereturn1")
+
+        def baddecodereturn2(exc):
+            return ("?", None)
+        codecs.register_error("test.baddecodereturn2", baddecodereturn2)
+        self.assertRaises(TypeError, b"\xff".decode, "ascii", "test.baddecodereturn2")
+
+        handler = PosReturn()
+        codecs.register_error("test.posreturn", handler.handle)
+
+        # Valid negative position
+        handler.pos = -1
+        self.assertEqual(b"\xff0".decode("ascii", "test.posreturn"), "<?>0")
+
+        # Valid negative position
+        handler.pos = -2
+        self.assertEqual(b"\xff0".decode("ascii", "test.posreturn"), "<?><?>")
+
+        # Negative position out of bounds
+        handler.pos = -3
+        self.assertRaises(IndexError, b"\xff0".decode, "ascii", "test.posreturn")
+
+        # Valid positive position
+        handler.pos = 1
+        self.assertEqual(b"\xff0".decode("ascii", "test.posreturn"), "<?>0")
+
+        # Largest valid positive position (one beyond end of input)
+        handler.pos = 2
+        self.assertEqual(b"\xff0".decode("ascii", "test.posreturn"), "<?>")
+
+        # Invalid positive position
+        handler.pos = 3
+        self.assertRaises(IndexError, b"\xff0".decode, "ascii", "test.posreturn")
+
+        # Restart at the "0"
+        handler.pos = 6
+        self.assertEqual(b"\\uyyyy0".decode("raw-unicode-escape", "test.posreturn"), "<?>0")
+
+        class D(dict):
+            def __getitem__(self, key):
+                raise ValueError
+        self.assertRaises(UnicodeError, codecs.charmap_decode, b"\xff", "strict", {0xff: None})
+        self.assertRaises(ValueError, codecs.charmap_decode, b"\xff", "strict", D())
+        self.assertRaises(TypeError, codecs.charmap_decode, b"\xff", "strict", {0xff: sys.maxunicode+1})
+
+    def test_encodehelper(self):
+        # enhance coverage of:
+        # Objects/unicodeobject.c::unicode_encode_call_errorhandler()
+        # and callers
+        self.assertRaises(LookupError, "\xff".encode, "ascii", "test.unknown")
+
+        def badencodereturn1(exc):
+            return 42
+        codecs.register_error("test.badencodereturn1", badencodereturn1)
+        self.assertRaises(TypeError, "\xff".encode, "ascii", "test.badencodereturn1")
+
+        def badencodereturn2(exc):
+            return ("?", None)
+        codecs.register_error("test.badencodereturn2", badencodereturn2)
+        self.assertRaises(TypeError, "\xff".encode, "ascii", "test.badencodereturn2")
+
+        handler = PosReturn()
+        codecs.register_error("test.posreturn", handler.handle)
+
+        # Valid negative position
+        handler.pos = -1
+        self.assertEqual("\xff0".encode("ascii", "test.posreturn"), b"<?>0")
+
+        # Valid negative position
+        handler.pos = -2
+        self.assertEqual("\xff0".encode("ascii", "test.posreturn"), b"<?><?>")
+
+        # Negative position out of bounds
+        handler.pos = -3
+        self.assertRaises(IndexError, "\xff0".encode, "ascii", "test.posreturn")
+
+        # Valid positive position
+        handler.pos = 1
+        self.assertEqual("\xff0".encode("ascii", "test.posreturn"), b"<?>0")
+
+        # Largest valid positive position (one beyond end of input
+        handler.pos = 2
+        self.assertEqual("\xff0".encode("ascii", "test.posreturn"), b"<?>")
+
+        # Invalid positive position
+        handler.pos = 3
+        self.assertRaises(IndexError, "\xff0".encode, "ascii", "test.posreturn")
+
+        handler.pos = 0
+
+        class D(dict):
+            def __getitem__(self, key):
+                raise ValueError
+        for err in ("strict", "replace", "xmlcharrefreplace",
+                    "backslashreplace", "namereplace", "test.posreturn"):
+            self.assertRaises(UnicodeError, codecs.charmap_encode, "\xff", err, {0xff: None})
+            self.assertRaises(ValueError, codecs.charmap_encode, "\xff", err, D())
+            self.assertRaises(TypeError, codecs.charmap_encode, "\xff", err, {0xff: 300})
+
+    def test_translatehelper(self):
+        # enhance coverage of:
+        # Objects/unicodeobject.c::unicode_encode_call_errorhandler()
+        # and callers
+        # (Unfortunately the errors argument is not directly accessible
+        # from Python, so we can't test that much)
+        class D(dict):
+            def __getitem__(self, key):
+                raise ValueError
+        #self.assertRaises(ValueError, "\xff".translate, D())
+        self.assertRaises(ValueError, "\xff".translate, {0xff: sys.maxunicode+1})
+        self.assertRaises(TypeError, "\xff".translate, {0xff: ()})
+
+    def test_bug828737(self):
+        charmap = {
+            ord("&"): "&amp;",
+            ord("<"): "&lt;",
+            ord(">"): "&gt;",
+            ord('"'): "&quot;",
+        }
+
+        for n in (1, 10, 100, 1000):
+            text = 'abc<def>ghi'*n
+            text.translate(charmap)
+
+    def test_mutatingdecodehandler(self):
+        baddata = [
+            ("ascii", b"\xff"),
+            ("utf-7", b"++"),
+            ("utf-8",  b"\xff"),
+            ("utf-16", b"\xff"),
+            ("utf-32", b"\xff"),
+            ("unicode-escape", b"\\u123g"),
+            ("raw-unicode-escape", b"\\u123g"),
+        ]
+
+        def replacing(exc):
+            if isinstance(exc, UnicodeDecodeError):
+                exc.object = 42
+                return ("\u4242", 0)
+            else:
+                raise TypeError("don't know how to handle %r" % exc)
+        codecs.register_error("test.replacing", replacing)
+
+        for (encoding, data) in baddata:
+            with self.assertRaises(TypeError):
+                data.decode(encoding, "test.replacing")
+
+        def mutating(exc):
+            if isinstance(exc, UnicodeDecodeError):
+                exc.object = b""
+                return ("\u4242", 0)
+            else:
+                raise TypeError("don't know how to handle %r" % exc)
+        codecs.register_error("test.mutating", mutating)
+        # If the decoder doesn't pick up the modified input the following
+        # will lead to an endless loop
+        for (encoding, data) in baddata:
+            self.assertEqual(data.decode(encoding, "test.mutating"), "\u4242")
+
+    # issue32583
+    def test_crashing_decode_handler(self):
+        # better generating one more character to fill the extra space slot
+        # so in debug build it can steadily fail
+        def forward_shorter_than_end(exc):
+            if isinstance(exc, UnicodeDecodeError):
+                # size one character, 0 < forward < exc.end
+                return ('\ufffd', exc.start+1)
+            else:
+                raise TypeError("don't know how to handle %r" % exc)
+        codecs.register_error(
+            "test.forward_shorter_than_end", forward_shorter_than_end)
+
+        self.assertEqual(
+            b'\xd8\xd8\xd8\xd8\xd8\x00\x00\x00'.decode(
+                'utf-16-le', 'test.forward_shorter_than_end'),
+            '\ufffd\ufffd\ufffd\ufffd\xd8\x00'
+        )
+        self.assertEqual(
+            b'\xd8\xd8\xd8\xd8\x00\xd8\x00\x00'.decode(
+                'utf-16-be', 'test.forward_shorter_than_end'),
+            '\ufffd\ufffd\ufffd\ufffd\xd8\x00'
+        )
+        self.assertEqual(
+            b'\x11\x11\x11\x11\x11\x00\x00\x00\x00\x00\x00'.decode(
+                'utf-32-le', 'test.forward_shorter_than_end'),
+            '\ufffd\ufffd\ufffd\u1111\x00'
+        )
+        self.assertEqual(
+            b'\x11\x11\x11\x00\x00\x11\x11\x00\x00\x00\x00'.decode(
+                'utf-32-be', 'test.forward_shorter_than_end'),
+            '\ufffd\ufffd\ufffd\u1111\x00'
+        )
+
+        def replace_with_long(exc):
+            if isinstance(exc, UnicodeDecodeError):
+                exc.object = b"\x00" * 8
+                return ('\ufffd', exc.start)
+            else:
+                raise TypeError("don't know how to handle %r" % exc)
+        codecs.register_error("test.replace_with_long", replace_with_long)
+
+        self.assertEqual(
+            b'\x00'.decode('utf-16', 'test.replace_with_long'),
+            '\ufffd\x00\x00\x00\x00'
+        )
+        self.assertEqual(
+            b'\x00'.decode('utf-32', 'test.replace_with_long'),
+            '\ufffd\x00\x00'
+        )
+
+
+    def test_fake_error_class(self):
+        handlers = [
+            codecs.strict_errors,
+            codecs.ignore_errors,
+            codecs.replace_errors,
+            codecs.backslashreplace_errors,
+            codecs.namereplace_errors,
+            codecs.xmlcharrefreplace_errors,
+            codecs.lookup_error('surrogateescape'),
+            codecs.lookup_error('surrogatepass'),
+        ]
+        for cls in UnicodeEncodeError, UnicodeDecodeError, UnicodeTranslateError:
+            class FakeUnicodeError(str):
+                __class__ = cls
+            for handler in handlers:
+                with self.subTest(handler=handler, error_class=cls):
+                    self.assertRaises(TypeError, handler, FakeUnicodeError())
+            class FakeUnicodeError(Exception):
+                __class__ = cls
+            for handler in handlers:
+                with self.subTest(handler=handler, error_class=cls):
+                    with self.assertRaises((TypeError, FakeUnicodeError)):
+                        handler(FakeUnicodeError())
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/Lib/test/test_codeccallbacks.py
+++ b/Lib/test/test_codeccallbacks.py
@@ -190,6 +190,7 @@ class CodecCallbackTest(unittest.TestCase):
         self.assertRaises(UnicodeDecodeError, sin.decode,
                           "utf-8", "test.relaxedutf8")
 
+    @unittest.skip("TODO: RUSTPYTHON, TypeError: character mapping must return integer, None or str")
     def test_charmapencode(self):
         # For charmap encodings the replacement string will be
         # mapped through the encoding again. This means, that
@@ -268,6 +269,7 @@ class CodecCallbackTest(unittest.TestCase):
             b"g[<252><223>]"
         )
 
+    @unittest.skip("TODO: RUSTPYTHON, AttributeError: module 'codecs' has no attribute 'utf_32_encode'")
     def test_longstrings(self):
         # test long strings to check for memory overflow problems
         errors = [ "strict", "ignore", "replace", "xmlcharrefreplace",
@@ -312,6 +314,8 @@ class CodecCallbackTest(unittest.TestCase):
         exc = exctype(*args)
         self.assertEqual(str(exc), msg)
 
+    # TODO: RUSTPYTHON
+    @unittest.expectedFailure
     def test_unicodeencodeerror(self):
         self.check_exceptionobjectargs(
             UnicodeEncodeError,
@@ -344,6 +348,8 @@ class CodecCallbackTest(unittest.TestCase):
             "'ascii' codec can't encode character '\\U00010000' in position 0: ouch"
         )
 
+    # TODO: RUSTPYTHON
+    @unittest.expectedFailure
     def test_unicodedecodeerror(self):
         self.check_exceptionobjectargs(
             UnicodeDecodeError,
@@ -356,6 +362,8 @@ class CodecCallbackTest(unittest.TestCase):
             "'ascii' codec can't decode bytes in position 1-2: ouch"
         )
 
+    # TODO: RUSTPYTHON
+    @unittest.expectedFailure
     def test_unicodetranslateerror(self):
         self.check_exceptionobjectargs(
             UnicodeTranslateError,
@@ -444,6 +452,7 @@ class CodecCallbackTest(unittest.TestCase):
             ("", 2)
         )
 
+    @unittest.skip("TODO: RUSTPYTHON, AttributeError: attribute 'object' of 'BadObjectUnicodeEncodeError' objects is not writable")
     def test_badandgoodreplaceexceptions(self):
         # "replace" complains about a non-exception passed in
         self.assertRaises(
@@ -484,6 +493,8 @@ class CodecCallbackTest(unittest.TestCase):
             ("\ufffd", 2)
         )
 
+    # TODO: RUSTPYTHON
+    @unittest.expectedFailure
     def test_badandgoodxmlcharrefreplaceexceptions(self):
         # "xmlcharrefreplace" complains about a non-exception passed in
         self.assertRaises(
@@ -521,6 +532,7 @@ class CodecCallbackTest(unittest.TestCase):
             ("".join("&#%d;" % c for c in cs), 1 + len(s))
         )
 
+    @unittest.skip("TODO: RUSTPYTHON, TypeError: Expected type 'bytes', not 'bytearray'")
     def test_badandgoodbackslashreplaceexceptions(self):
         # "backslashreplace" complains about a non-exception passed in
         self.assertRaises(
@@ -579,6 +591,8 @@ class CodecCallbackTest(unittest.TestCase):
                     (r, 2)
                 )
 
+    # TODO: RUSTPYTHON
+    @unittest.expectedFailure
     def test_badandgoodnamereplaceexceptions(self):
         # "namereplace" complains about a non-exception passed in
         self.assertRaises(
@@ -625,6 +639,7 @@ class CodecCallbackTest(unittest.TestCase):
                     (r, 1 + len(s))
                 )
 
+    @unittest.skip("TODO: RUSTPYTHON, UnicodeEncodeError: ('ascii', 'a�b', 1, 2, 'ouch')")
     def test_badandgoodsurrogateescapeexceptions(self):
         surrogateescape_errors = codecs.lookup_error('surrogateescape')
         # "surrogateescape" complains about a non-exception passed in
@@ -669,6 +684,7 @@ class CodecCallbackTest(unittest.TestCase):
             ("\udc80", 2)
         )
 
+    @unittest.skip("TODO: RUSTPYTHON, TypeError: Expected type 'str', not 'bytes'")
     def test_badandgoodsurrogatepassexceptions(self):
         surrogatepass_errors = codecs.lookup_error('surrogatepass')
         # "surrogatepass" complains about a non-exception passed in
@@ -741,6 +757,8 @@ class CodecCallbackTest(unittest.TestCase):
                     (s[:1], 1 + n)
                 )
 
+    # TODO: RUSTPYTHON
+    @unittest.expectedFailure
     def test_badhandlerresults(self):
         results = ( 42, "foo", (1,2,3), ("foo", 1, 3), ("foo", None), ("foo",), ("foo", 1, 3), ("foo", None), ("foo",) )
         encs = ("ascii", "latin-1", "iso-8859-1", "iso-8859-15")
@@ -783,6 +801,8 @@ class CodecCallbackTest(unittest.TestCase):
             codecs.lookup_error("namereplace")
         )
 
+    # TODO: RUSTPYTHON
+    @unittest.expectedFailure
     def test_unencodablereplacement(self):
         def unencrepl(exc):
             if isinstance(exc, UnicodeEncodeError):
@@ -798,6 +818,8 @@ class CodecCallbackTest(unittest.TestCase):
                 "test.unencreplhandler"
             )
 
+    # TODO: RUSTPYTHON
+    @unittest.expectedFailure
     def test_badregistercall(self):
         # enhance coverage of:
         # Modules/_codecsmodule.c::register_error()
@@ -886,6 +908,8 @@ class CodecCallbackTest(unittest.TestCase):
         self.assertRaises(ValueError, codecs.charmap_decode, b"\xff", "strict", D())
         self.assertRaises(TypeError, codecs.charmap_decode, b"\xff", "strict", {0xff: sys.maxunicode+1})
 
+    # TODO: RUSTPYTHON
+    @unittest.expectedFailure
     def test_encodehelper(self):
         # enhance coverage of:
         # Objects/unicodeobject.c::unicode_encode_call_errorhandler()
@@ -965,6 +989,7 @@ class CodecCallbackTest(unittest.TestCase):
             text = 'abc<def>ghi'*n
             text.translate(charmap)
 
+    @unittest.skip("TODO: RUSTPYTHON, AttributeError: attribute 'object' of 'UnicodeDecodeError' objects is not writable")
     def test_mutatingdecodehandler(self):
         baddata = [
             ("ascii", b"\xff"),
@@ -1001,6 +1026,8 @@ class CodecCallbackTest(unittest.TestCase):
             self.assertEqual(data.decode(encoding, "test.mutating"), "\u4242")
 
     # issue32583
+    # TODO: RUSTPYTHON
+    @unittest.expectedFailure
     def test_crashing_decode_handler(self):
         # better generating one more character to fill the extra space slot
         # so in debug build it can steadily fail

--- a/Lib/test/test_trace.py
+++ b/Lib/test/test_trace.py
@@ -122,6 +122,8 @@ class TestLineCounts(unittest.TestCase):
         self.tracer = Trace(count=1, trace=0, countfuncs=0, countcallers=0)
         self.my_py_filename = fix_ext_py(__file__)
 
+    # TODO: RUSTPYTHON
+    @unittest.expectedFailure
     def test_traced_func_linear(self):
         result = self.tracer.runfunc(traced_func_linear, 2, 5)
         self.assertEqual(result, 7)
@@ -134,6 +136,8 @@ class TestLineCounts(unittest.TestCase):
 
         self.assertEqual(self.tracer.results().counts, expected)
 
+    # TODO: RUSTPYTHON
+    @unittest.expectedFailure
     def test_traced_func_loop(self):
         self.tracer.runfunc(traced_func_loop, 2, 3)
 
@@ -146,6 +150,8 @@ class TestLineCounts(unittest.TestCase):
         }
         self.assertEqual(self.tracer.results().counts, expected)
 
+    # TODO: RUSTPYTHON
+    @unittest.expectedFailure
     def test_traced_func_importing(self):
         self.tracer.runfunc(traced_func_importing, 2, 5)
 
@@ -158,6 +164,8 @@ class TestLineCounts(unittest.TestCase):
 
         self.assertEqual(self.tracer.results().counts, expected)
 
+    # TODO: RUSTPYTHON
+    @unittest.expectedFailure
     def test_trace_func_generator(self):
         self.tracer.runfunc(traced_func_calling_generator)
 
@@ -173,6 +181,8 @@ class TestLineCounts(unittest.TestCase):
         }
         self.assertEqual(self.tracer.results().counts, expected)
 
+    # TODO: RUSTPYTHON
+    @unittest.expectedFailure
     def test_trace_list_comprehension(self):
         self.tracer.runfunc(traced_caller_list_comprehension)
 
@@ -188,6 +198,8 @@ class TestLineCounts(unittest.TestCase):
         }
         self.assertEqual(self.tracer.results().counts, expected)
 
+    # TODO: RUSTPYTHON
+    @unittest.expectedFailure
     def test_traced_decorated_function(self):
         self.tracer.runfunc(traced_decorated_function)
 
@@ -207,6 +219,8 @@ class TestLineCounts(unittest.TestCase):
         }
         self.assertEqual(self.tracer.results().counts, expected)
 
+    # TODO: RUSTPYTHON
+    @unittest.expectedFailure
     def test_linear_methods(self):
         # XXX todo: later add 'static_method_linear' and 'class_method_linear'
         # here, once issue1764286 is resolved
@@ -230,6 +244,7 @@ class TestRunExecCounts(unittest.TestCase):
         self.my_py_filename = fix_ext_py(__file__)
         self.addCleanup(sys.settrace, sys.gettrace())
 
+    @unittest.skip("TODO: RUSTPYTHON, KeyError: ('Lib/test/test_trace.py', 43)")
     def test_exec_counts(self):
         self.tracer = Trace(count=1, trace=0, countfuncs=0, countcallers=0)
         code = r'''traced_func_loop(2, 5)'''
@@ -264,6 +279,7 @@ class TestFuncs(unittest.TestCase):
         if self._saved_tracefunc is not None:
             sys.settrace(self._saved_tracefunc)
 
+    @unittest.skip("TODO: RUSTPYTHON, NotImplementedError")
     def test_simple_caller(self):
         self.tracer.runfunc(traced_func_simple_caller, 1)
 
@@ -273,6 +289,7 @@ class TestFuncs(unittest.TestCase):
         }
         self.assertEqual(self.tracer.results().calledfuncs, expected)
 
+    @unittest.skip("TODO: RUSTPYTHON, NotImplementedError")
     def test_arg_errors(self):
         res = self.tracer.runfunc(traced_capturer, 1, 2, self=3, func=4)
         self.assertEqual(res, ((1, 2), {'self': 3, 'func': 4}))
@@ -282,6 +299,7 @@ class TestFuncs(unittest.TestCase):
         with self.assertRaises(TypeError):
             self.tracer.runfunc()
 
+    @unittest.skip("TODO: RUSTPYTHON, NotImplementedError")
     def test_loop_caller_importing(self):
         self.tracer.runfunc(traced_func_importing_caller, 1)
 
@@ -294,6 +312,7 @@ class TestFuncs(unittest.TestCase):
         }
         self.assertEqual(self.tracer.results().calledfuncs, expected)
 
+    @unittest.skip("TODO: RUSTPYTHON, NotImplementedError")
     @unittest.skipIf(hasattr(sys, 'gettrace') and sys.gettrace(),
                      'pre-existing trace function throws off measurements')
     def test_inst_method_calling(self):
@@ -307,6 +326,7 @@ class TestFuncs(unittest.TestCase):
         }
         self.assertEqual(self.tracer.results().calledfuncs, expected)
 
+    @unittest.skip("TODO: RUSTPYTHON, NotImplementedError")
     def test_traced_decorated_function(self):
         self.tracer.runfunc(traced_decorated_function)
 
@@ -364,6 +384,8 @@ class TestCoverage(unittest.TestCase):
         r = tracer.results()
         r.write_results(show_missing=True, summary=True, coverdir=TESTFN)
 
+    # TODO: RUSTPYTHON
+    @unittest.expectedFailure
     def test_coverage(self):
         tracer = trace.Trace(trace=0, count=1)
         with captured_stdout() as stdout:
@@ -387,6 +409,8 @@ class TestCoverage(unittest.TestCase):
             files = os.listdir(TESTFN)
             self.assertEqual(files, ['_importlib.cover'])  # Ignore __import__
 
+    # TODO: RUSTPYTHON
+    @unittest.expectedFailure
     def test_issue9936(self):
         tracer = trace.Trace(trace=0, count=1)
         modname = 'test.tracedmodules.testmod'
@@ -442,6 +466,8 @@ class TestCoverageCommandLineOutput(unittest.TestCase):
         unlink(self.codefile)
         unlink(self.coverfile)
 
+    # TODO: RUSTPYTHON
+    @unittest.expectedFailure
     def test_cover_files_written_no_highlight(self):
         # Test also that the cover file for the trace module is not created
         # (issue #34171).
@@ -462,6 +488,8 @@ class TestCoverageCommandLineOutput(unittest.TestCase):
                 "           print('unreachable')\n"
             )
 
+    # TODO: RUSTPYTHON
+    @unittest.expectedFailure
     def test_cover_files_written_with_highlight(self):
         argv = '-m trace --count --missing'.split() + [self.codefile]
         status, stdout, stderr = assert_python_ok(*argv)
@@ -489,6 +517,8 @@ class TestCommandLine(unittest.TestCase):
             *_, stderr = assert_python_failure('-m', 'trace', *args)
             self.assertIn(message, stderr)
 
+    # TODO: RUSTPYTHON
+    @unittest.expectedFailure
     def test_listfuncs_flag_success(self):
         filename = TESTFN + '.py'
         modulename = os.path.basename(TESTFN)
@@ -501,6 +531,8 @@ class TestCommandLine(unittest.TestCase):
             expected = f'filename: {filename}, modulename: {modulename}, funcname: <module>'
             self.assertIn(expected.encode(), stdout)
 
+    # TODO: RUSTPYTHON
+    @unittest.expectedFailure
     def test_sys_argv_list(self):
         with open(TESTFN, 'w', encoding='utf-8') as fd:
             self.addCleanup(unlink, TESTFN)
@@ -511,6 +543,8 @@ class TestCommandLine(unittest.TestCase):
         status, trace_stdout, stderr = assert_python_ok('-m', 'trace', '-l', TESTFN)
         self.assertIn(direct_stdout.strip(), trace_stdout)
 
+    # TODO: RUSTPYTHON
+    @unittest.expectedFailure
     def test_count_and_summary(self):
         filename = f'{TESTFN}.py'
         coverfilename = f'{TESTFN}.cover'
@@ -534,6 +568,8 @@ class TestCommandLine(unittest.TestCase):
         self.assertIn('lines   cov%   module   (path)', stdout)
         self.assertIn(f'6   100%   {modulename}   ({filename})', stdout)
 
+    # TODO: RUSTPYTHON
+    @unittest.expectedFailure
     def test_run_as_module(self):
         assert_python_ok('-m', 'trace', '-l', '--module', 'timeit', '-n', '1')
         assert_python_failure('-m', 'trace', '-l', '--module', 'not_a_module_zzz')

--- a/Lib/test/test_trace.py
+++ b/Lib/test/test_trace.py
@@ -1,0 +1,543 @@
+import os
+import sys
+from test.support import TESTFN, TESTFN_UNICODE, FS_NONASCII, rmtree, unlink, captured_stdout
+from test.support.script_helper import assert_python_ok, assert_python_failure
+import textwrap
+import unittest
+
+import trace
+from trace import Trace
+
+from test.tracedmodules import testmod
+
+#------------------------------- Utilities -----------------------------------#
+
+def fix_ext_py(filename):
+    """Given a .pyc filename converts it to the appropriate .py"""
+    if filename.endswith('.pyc'):
+        filename = filename[:-1]
+    return filename
+
+def my_file_and_modname():
+    """The .py file and module name of this file (__file__)"""
+    modname = os.path.splitext(os.path.basename(__file__))[0]
+    return fix_ext_py(__file__), modname
+
+def get_firstlineno(func):
+    return func.__code__.co_firstlineno
+
+#-------------------- Target functions for tracing ---------------------------#
+#
+# The relative line numbers of lines in these functions matter for verifying
+# tracing. Please modify the appropriate tests if you change one of the
+# functions. Absolute line numbers don't matter.
+#
+
+def traced_func_linear(x, y):
+    a = x
+    b = y
+    c = a + b
+    return c
+
+def traced_func_loop(x, y):
+    c = x
+    for i in range(5):
+        c += y
+    return c
+
+def traced_func_importing(x, y):
+    return x + y + testmod.func(1)
+
+def traced_func_simple_caller(x):
+    c = traced_func_linear(x, x)
+    return c + x
+
+def traced_func_importing_caller(x):
+    k = traced_func_simple_caller(x)
+    k += traced_func_importing(k, x)
+    return k
+
+def traced_func_generator(num):
+    c = 5       # executed once
+    for i in range(num):
+        yield i + c
+
+def traced_func_calling_generator():
+    k = 0
+    for i in traced_func_generator(10):
+        k += i
+
+def traced_doubler(num):
+    return num * 2
+
+def traced_capturer(*args, **kwargs):
+    return args, kwargs
+
+def traced_caller_list_comprehension():
+    k = 10
+    mylist = [traced_doubler(i) for i in range(k)]
+    return mylist
+
+def traced_decorated_function():
+    def decorator1(f):
+        return f
+    def decorator_fabric():
+        def decorator2(f):
+            return f
+        return decorator2
+    @decorator1
+    @decorator_fabric()
+    def func():
+        pass
+    func()
+
+
+class TracedClass(object):
+    def __init__(self, x):
+        self.a = x
+
+    def inst_method_linear(self, y):
+        return self.a + y
+
+    def inst_method_calling(self, x):
+        c = self.inst_method_linear(x)
+        return c + traced_func_linear(x, c)
+
+    @classmethod
+    def class_method_linear(cls, y):
+        return y * 2
+
+    @staticmethod
+    def static_method_linear(y):
+        return y * 2
+
+
+#------------------------------ Test cases -----------------------------------#
+
+
+class TestLineCounts(unittest.TestCase):
+    """White-box testing of line-counting, via runfunc"""
+    def setUp(self):
+        self.addCleanup(sys.settrace, sys.gettrace())
+        self.tracer = Trace(count=1, trace=0, countfuncs=0, countcallers=0)
+        self.my_py_filename = fix_ext_py(__file__)
+
+    def test_traced_func_linear(self):
+        result = self.tracer.runfunc(traced_func_linear, 2, 5)
+        self.assertEqual(result, 7)
+
+        # all lines are executed once
+        expected = {}
+        firstlineno = get_firstlineno(traced_func_linear)
+        for i in range(1, 5):
+            expected[(self.my_py_filename, firstlineno +  i)] = 1
+
+        self.assertEqual(self.tracer.results().counts, expected)
+
+    def test_traced_func_loop(self):
+        self.tracer.runfunc(traced_func_loop, 2, 3)
+
+        firstlineno = get_firstlineno(traced_func_loop)
+        expected = {
+            (self.my_py_filename, firstlineno + 1): 1,
+            (self.my_py_filename, firstlineno + 2): 6,
+            (self.my_py_filename, firstlineno + 3): 5,
+            (self.my_py_filename, firstlineno + 4): 1,
+        }
+        self.assertEqual(self.tracer.results().counts, expected)
+
+    def test_traced_func_importing(self):
+        self.tracer.runfunc(traced_func_importing, 2, 5)
+
+        firstlineno = get_firstlineno(traced_func_importing)
+        expected = {
+            (self.my_py_filename, firstlineno + 1): 1,
+            (fix_ext_py(testmod.__file__), 2): 1,
+            (fix_ext_py(testmod.__file__), 3): 1,
+        }
+
+        self.assertEqual(self.tracer.results().counts, expected)
+
+    def test_trace_func_generator(self):
+        self.tracer.runfunc(traced_func_calling_generator)
+
+        firstlineno_calling = get_firstlineno(traced_func_calling_generator)
+        firstlineno_gen = get_firstlineno(traced_func_generator)
+        expected = {
+            (self.my_py_filename, firstlineno_calling + 1): 1,
+            (self.my_py_filename, firstlineno_calling + 2): 11,
+            (self.my_py_filename, firstlineno_calling + 3): 10,
+            (self.my_py_filename, firstlineno_gen + 1): 1,
+            (self.my_py_filename, firstlineno_gen + 2): 11,
+            (self.my_py_filename, firstlineno_gen + 3): 10,
+        }
+        self.assertEqual(self.tracer.results().counts, expected)
+
+    def test_trace_list_comprehension(self):
+        self.tracer.runfunc(traced_caller_list_comprehension)
+
+        firstlineno_calling = get_firstlineno(traced_caller_list_comprehension)
+        firstlineno_called = get_firstlineno(traced_doubler)
+        expected = {
+            (self.my_py_filename, firstlineno_calling + 1): 1,
+            # List compehentions work differently in 3.x, so the count
+            # below changed compared to 2.x.
+            (self.my_py_filename, firstlineno_calling + 2): 12,
+            (self.my_py_filename, firstlineno_calling + 3): 1,
+            (self.my_py_filename, firstlineno_called + 1): 10,
+        }
+        self.assertEqual(self.tracer.results().counts, expected)
+
+    def test_traced_decorated_function(self):
+        self.tracer.runfunc(traced_decorated_function)
+
+        firstlineno = get_firstlineno(traced_decorated_function)
+        expected = {
+            (self.my_py_filename, firstlineno + 1): 1,
+            (self.my_py_filename, firstlineno + 2): 1,
+            (self.my_py_filename, firstlineno + 3): 1,
+            (self.my_py_filename, firstlineno + 4): 1,
+            (self.my_py_filename, firstlineno + 5): 1,
+            (self.my_py_filename, firstlineno + 6): 1,
+            (self.my_py_filename, firstlineno + 7): 1,
+            (self.my_py_filename, firstlineno + 8): 1,
+            (self.my_py_filename, firstlineno + 9): 1,
+            (self.my_py_filename, firstlineno + 10): 1,
+            (self.my_py_filename, firstlineno + 11): 1,
+        }
+        self.assertEqual(self.tracer.results().counts, expected)
+
+    def test_linear_methods(self):
+        # XXX todo: later add 'static_method_linear' and 'class_method_linear'
+        # here, once issue1764286 is resolved
+        #
+        for methname in ['inst_method_linear',]:
+            tracer = Trace(count=1, trace=0, countfuncs=0, countcallers=0)
+            traced_obj = TracedClass(25)
+            method = getattr(traced_obj, methname)
+            tracer.runfunc(method, 20)
+
+            firstlineno = get_firstlineno(method)
+            expected = {
+                (self.my_py_filename, firstlineno + 1): 1,
+            }
+            self.assertEqual(tracer.results().counts, expected)
+
+
+class TestRunExecCounts(unittest.TestCase):
+    """A simple sanity test of line-counting, via runctx (exec)"""
+    def setUp(self):
+        self.my_py_filename = fix_ext_py(__file__)
+        self.addCleanup(sys.settrace, sys.gettrace())
+
+    def test_exec_counts(self):
+        self.tracer = Trace(count=1, trace=0, countfuncs=0, countcallers=0)
+        code = r'''traced_func_loop(2, 5)'''
+        code = compile(code, __file__, 'exec')
+        self.tracer.runctx(code, globals(), vars())
+
+        firstlineno = get_firstlineno(traced_func_loop)
+        expected = {
+            (self.my_py_filename, firstlineno + 1): 1,
+            (self.my_py_filename, firstlineno + 2): 6,
+            (self.my_py_filename, firstlineno + 3): 5,
+            (self.my_py_filename, firstlineno + 4): 1,
+        }
+
+        # When used through 'run', some other spurious counts are produced, like
+        # the settrace of threading, which we ignore, just making sure that the
+        # counts fo traced_func_loop were right.
+        #
+        for k in expected.keys():
+            self.assertEqual(self.tracer.results().counts[k], expected[k])
+
+
+class TestFuncs(unittest.TestCase):
+    """White-box testing of funcs tracing"""
+    def setUp(self):
+        self.addCleanup(sys.settrace, sys.gettrace())
+        self.tracer = Trace(count=0, trace=0, countfuncs=1)
+        self.filemod = my_file_and_modname()
+        self._saved_tracefunc = sys.gettrace()
+
+    def tearDown(self):
+        if self._saved_tracefunc is not None:
+            sys.settrace(self._saved_tracefunc)
+
+    def test_simple_caller(self):
+        self.tracer.runfunc(traced_func_simple_caller, 1)
+
+        expected = {
+            self.filemod + ('traced_func_simple_caller',): 1,
+            self.filemod + ('traced_func_linear',): 1,
+        }
+        self.assertEqual(self.tracer.results().calledfuncs, expected)
+
+    def test_arg_errors(self):
+        res = self.tracer.runfunc(traced_capturer, 1, 2, self=3, func=4)
+        self.assertEqual(res, ((1, 2), {'self': 3, 'func': 4}))
+        with self.assertWarns(DeprecationWarning):
+            res = self.tracer.runfunc(func=traced_capturer, arg=1)
+        self.assertEqual(res, ((), {'arg': 1}))
+        with self.assertRaises(TypeError):
+            self.tracer.runfunc()
+
+    def test_loop_caller_importing(self):
+        self.tracer.runfunc(traced_func_importing_caller, 1)
+
+        expected = {
+            self.filemod + ('traced_func_simple_caller',): 1,
+            self.filemod + ('traced_func_linear',): 1,
+            self.filemod + ('traced_func_importing_caller',): 1,
+            self.filemod + ('traced_func_importing',): 1,
+            (fix_ext_py(testmod.__file__), 'testmod', 'func'): 1,
+        }
+        self.assertEqual(self.tracer.results().calledfuncs, expected)
+
+    @unittest.skipIf(hasattr(sys, 'gettrace') and sys.gettrace(),
+                     'pre-existing trace function throws off measurements')
+    def test_inst_method_calling(self):
+        obj = TracedClass(20)
+        self.tracer.runfunc(obj.inst_method_calling, 1)
+
+        expected = {
+            self.filemod + ('TracedClass.inst_method_calling',): 1,
+            self.filemod + ('TracedClass.inst_method_linear',): 1,
+            self.filemod + ('traced_func_linear',): 1,
+        }
+        self.assertEqual(self.tracer.results().calledfuncs, expected)
+
+    def test_traced_decorated_function(self):
+        self.tracer.runfunc(traced_decorated_function)
+
+        expected = {
+            self.filemod + ('traced_decorated_function',): 1,
+            self.filemod + ('decorator_fabric',): 1,
+            self.filemod + ('decorator2',): 1,
+            self.filemod + ('decorator1',): 1,
+            self.filemod + ('func',): 1,
+        }
+        self.assertEqual(self.tracer.results().calledfuncs, expected)
+
+
+class TestCallers(unittest.TestCase):
+    """White-box testing of callers tracing"""
+    def setUp(self):
+        self.addCleanup(sys.settrace, sys.gettrace())
+        self.tracer = Trace(count=0, trace=0, countcallers=1)
+        self.filemod = my_file_and_modname()
+
+    @unittest.skipIf(hasattr(sys, 'gettrace') and sys.gettrace(),
+                     'pre-existing trace function throws off measurements')
+    @unittest.skip("TODO: RUSTPYTHON")
+    def test_loop_caller_importing(self):
+        self.tracer.runfunc(traced_func_importing_caller, 1)
+
+        expected = {
+            ((os.path.splitext(trace.__file__)[0] + '.py', 'trace', 'Trace.runfunc'),
+                (self.filemod + ('traced_func_importing_caller',))): 1,
+            ((self.filemod + ('traced_func_simple_caller',)),
+                (self.filemod + ('traced_func_linear',))): 1,
+            ((self.filemod + ('traced_func_importing_caller',)),
+                (self.filemod + ('traced_func_simple_caller',))): 1,
+            ((self.filemod + ('traced_func_importing_caller',)),
+                (self.filemod + ('traced_func_importing',))): 1,
+            ((self.filemod + ('traced_func_importing',)),
+                (fix_ext_py(testmod.__file__), 'testmod', 'func')): 1,
+        }
+        self.assertEqual(self.tracer.results().callers, expected)
+
+
+# Created separately for issue #3821
+class TestCoverage(unittest.TestCase):
+    def setUp(self):
+        self.addCleanup(sys.settrace, sys.gettrace())
+
+    def tearDown(self):
+        rmtree(TESTFN)
+        unlink(TESTFN)
+
+    def _coverage(self, tracer,
+                  cmd='import test.support, test.test_pprint;'
+                      'test.support.run_unittest(test.test_pprint.QueryTestCase)'):
+        tracer.run(cmd)
+        r = tracer.results()
+        r.write_results(show_missing=True, summary=True, coverdir=TESTFN)
+
+    def test_coverage(self):
+        tracer = trace.Trace(trace=0, count=1)
+        with captured_stdout() as stdout:
+            self._coverage(tracer)
+        stdout = stdout.getvalue()
+        self.assertIn("pprint.py", stdout)
+        self.assertIn("case.py", stdout)   # from unittest
+        files = os.listdir(TESTFN)
+        self.assertIn("pprint.cover", files)
+        self.assertIn("unittest.case.cover", files)
+
+    def test_coverage_ignore(self):
+        # Ignore all files, nothing should be traced nor printed
+        libpath = os.path.normpath(os.path.dirname(os.__file__))
+        # sys.prefix does not work when running from a checkout
+        tracer = trace.Trace(ignoredirs=[sys.base_prefix, sys.base_exec_prefix,
+                             libpath], trace=0, count=1)
+        with captured_stdout() as stdout:
+            self._coverage(tracer)
+        if os.path.exists(TESTFN):
+            files = os.listdir(TESTFN)
+            self.assertEqual(files, ['_importlib.cover'])  # Ignore __import__
+
+    def test_issue9936(self):
+        tracer = trace.Trace(trace=0, count=1)
+        modname = 'test.tracedmodules.testmod'
+        # Ensure that the module is executed in import
+        if modname in sys.modules:
+            del sys.modules[modname]
+        cmd = ("import test.tracedmodules.testmod as t;"
+               "t.func(0); t.func2();")
+        with captured_stdout() as stdout:
+            self._coverage(tracer, cmd)
+        stdout.seek(0)
+        stdout.readline()
+        coverage = {}
+        for line in stdout:
+            lines, cov, module = line.split()[:3]
+            coverage[module] = (int(lines), int(cov[:-1]))
+        # XXX This is needed to run regrtest.py as a script
+        modname = trace._fullmodname(sys.modules[modname].__file__)
+        self.assertIn(modname, coverage)
+        self.assertEqual(coverage[modname], (5, 100))
+
+### Tests that don't mess with sys.settrace and can be traced
+### themselves TODO: Skip tests that do mess with sys.settrace when
+### regrtest is invoked with -T option.
+class Test_Ignore(unittest.TestCase):
+    def test_ignored(self):
+        jn = os.path.join
+        ignore = trace._Ignore(['x', 'y.z'], [jn('foo', 'bar')])
+        self.assertTrue(ignore.names('x.py', 'x'))
+        self.assertFalse(ignore.names('xy.py', 'xy'))
+        self.assertFalse(ignore.names('y.py', 'y'))
+        self.assertTrue(ignore.names(jn('foo', 'bar', 'baz.py'), 'baz'))
+        self.assertFalse(ignore.names(jn('bar', 'z.py'), 'z'))
+        # Matched before.
+        self.assertTrue(ignore.names(jn('bar', 'baz.py'), 'baz'))
+
+# Created for Issue 31908 -- CLI utility not writing cover files
+class TestCoverageCommandLineOutput(unittest.TestCase):
+
+    codefile = 'tmp.py'
+    coverfile = 'tmp.cover'
+
+    def setUp(self):
+        with open(self.codefile, 'w', encoding='iso-8859-15') as f:
+            f.write(textwrap.dedent('''\
+                # coding: iso-8859-15
+                x = 'spœm'
+                if []:
+                    print('unreachable')
+            '''))
+
+    def tearDown(self):
+        unlink(self.codefile)
+        unlink(self.coverfile)
+
+    def test_cover_files_written_no_highlight(self):
+        # Test also that the cover file for the trace module is not created
+        # (issue #34171).
+        tracedir = os.path.dirname(os.path.abspath(trace.__file__))
+        tracecoverpath = os.path.join(tracedir, 'trace.cover')
+        unlink(tracecoverpath)
+
+        argv = '-m trace --count'.split() + [self.codefile]
+        status, stdout, stderr = assert_python_ok(*argv)
+        self.assertEqual(stderr, b'')
+        self.assertFalse(os.path.exists(tracecoverpath))
+        self.assertTrue(os.path.exists(self.coverfile))
+        with open(self.coverfile, encoding='iso-8859-15') as f:
+            self.assertEqual(f.read(),
+                "       # coding: iso-8859-15\n"
+                "    1: x = 'spœm'\n"
+                "    1: if []:\n"
+                "           print('unreachable')\n"
+            )
+
+    def test_cover_files_written_with_highlight(self):
+        argv = '-m trace --count --missing'.split() + [self.codefile]
+        status, stdout, stderr = assert_python_ok(*argv)
+        self.assertTrue(os.path.exists(self.coverfile))
+        with open(self.coverfile, encoding='iso-8859-15') as f:
+            self.assertEqual(f.read(), textwrap.dedent('''\
+                       # coding: iso-8859-15
+                    1: x = 'spœm'
+                    1: if []:
+                >>>>>>     print('unreachable')
+            '''))
+
+class TestCommandLine(unittest.TestCase):
+
+    def test_failures(self):
+        _errors = (
+            (b'progname is missing: required with the main options', '-l', '-T'),
+            (b'cannot specify both --listfuncs and (--trace or --count)', '-lc'),
+            (b'argument -R/--no-report: not allowed with argument -r/--report', '-rR'),
+            (b'must specify one of --trace, --count, --report, --listfuncs, or --trackcalls', '-g'),
+            (b'-r/--report requires -f/--file', '-r'),
+            (b'--summary can only be used with --count or --report', '-sT'),
+            (b'unrecognized arguments: -y', '-y'))
+        for message, *args in _errors:
+            *_, stderr = assert_python_failure('-m', 'trace', *args)
+            self.assertIn(message, stderr)
+
+    def test_listfuncs_flag_success(self):
+        filename = TESTFN + '.py'
+        modulename = os.path.basename(TESTFN)
+        with open(filename, 'w', encoding='utf-8') as fd:
+            self.addCleanup(unlink, filename)
+            fd.write("a = 1\n")
+            status, stdout, stderr = assert_python_ok('-m', 'trace', '-l', filename,
+                                                      PYTHONIOENCODING='utf-8')
+            self.assertIn(b'functions called:', stdout)
+            expected = f'filename: {filename}, modulename: {modulename}, funcname: <module>'
+            self.assertIn(expected.encode(), stdout)
+
+    def test_sys_argv_list(self):
+        with open(TESTFN, 'w', encoding='utf-8') as fd:
+            self.addCleanup(unlink, TESTFN)
+            fd.write("import sys\n")
+            fd.write("print(type(sys.argv))\n")
+
+        status, direct_stdout, stderr = assert_python_ok(TESTFN)
+        status, trace_stdout, stderr = assert_python_ok('-m', 'trace', '-l', TESTFN)
+        self.assertIn(direct_stdout.strip(), trace_stdout)
+
+    def test_count_and_summary(self):
+        filename = f'{TESTFN}.py'
+        coverfilename = f'{TESTFN}.cover'
+        modulename = os.path.basename(TESTFN)
+        with open(filename, 'w', encoding='utf-8') as fd:
+            self.addCleanup(unlink, filename)
+            self.addCleanup(unlink, coverfilename)
+            fd.write(textwrap.dedent("""\
+                x = 1
+                y = 2
+
+                def f():
+                    return x + y
+
+                for i in range(10):
+                    f()
+            """))
+        status, stdout, _ = assert_python_ok('-m', 'trace', '-cs', filename)
+        stdout = stdout.decode()
+        self.assertEqual(status, 0)
+        self.assertIn('lines   cov%   module   (path)', stdout)
+        self.assertIn(f'6   100%   {modulename}   ({filename})', stdout)
+
+    def test_run_as_module(self):
+        assert_python_ok('-m', 'trace', '-l', '--module', 'timeit', '-n', '1')
+        assert_python_failure('-m', 'trace', '-l', '--module', 'not_a_module_zzz')
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/Lib/test/test_zipapp.py
+++ b/Lib/test/test_zipapp.py
@@ -1,0 +1,403 @@
+"""Test harness for the zipapp module."""
+
+import io
+import pathlib
+import stat
+import sys
+import tempfile
+import unittest
+import zipapp
+import zipfile
+from test.support import requires_zlib
+
+from unittest.mock import patch
+
+class ZipAppTest(unittest.TestCase):
+
+    """Test zipapp module functionality."""
+
+    def setUp(self):
+        tmpdir = tempfile.TemporaryDirectory()
+        self.addCleanup(tmpdir.cleanup)
+        self.tmpdir = pathlib.Path(tmpdir.name)
+
+    def test_create_archive(self):
+        # Test packing a directory.
+        source = self.tmpdir / 'source'
+        source.mkdir()
+        (source / '__main__.py').touch()
+        target = self.tmpdir / 'source.pyz'
+        zipapp.create_archive(str(source), str(target))
+        self.assertTrue(target.is_file())
+
+    def test_create_archive_with_pathlib(self):
+        # Test packing a directory using Path objects for source and target.
+        source = self.tmpdir / 'source'
+        source.mkdir()
+        (source / '__main__.py').touch()
+        target = self.tmpdir / 'source.pyz'
+        zipapp.create_archive(source, target)
+        self.assertTrue(target.is_file())
+
+    def test_create_archive_with_subdirs(self):
+        # Test packing a directory includes entries for subdirectories.
+        source = self.tmpdir / 'source'
+        source.mkdir()
+        (source / '__main__.py').touch()
+        (source / 'foo').mkdir()
+        (source / 'bar').mkdir()
+        (source / 'foo' / '__init__.py').touch()
+        target = io.BytesIO()
+        zipapp.create_archive(str(source), target)
+        target.seek(0)
+        with zipfile.ZipFile(target, 'r') as z:
+            self.assertIn('foo/', z.namelist())
+            self.assertIn('bar/', z.namelist())
+
+    def test_create_archive_with_filter(self):
+        # Test packing a directory and using filter to specify
+        # which files to include.
+        def skip_pyc_files(path):
+            return path.suffix != '.pyc'
+        source = self.tmpdir / 'source'
+        source.mkdir()
+        (source / '__main__.py').touch()
+        (source / 'test.py').touch()
+        (source / 'test.pyc').touch()
+        target = self.tmpdir / 'source.pyz'
+
+        zipapp.create_archive(source, target, filter=skip_pyc_files)
+        with zipfile.ZipFile(target, 'r') as z:
+            self.assertIn('__main__.py', z.namelist())
+            self.assertIn('test.py', z.namelist())
+            self.assertNotIn('test.pyc', z.namelist())
+
+    def test_create_archive_filter_exclude_dir(self):
+        # Test packing a directory and using a filter to exclude a
+        # subdirectory (ensures that the path supplied to include
+        # is relative to the source location, as expected).
+        def skip_dummy_dir(path):
+            return path.parts[0] != 'dummy'
+        source = self.tmpdir / 'source'
+        source.mkdir()
+        (source / '__main__.py').touch()
+        (source / 'test.py').touch()
+        (source / 'dummy').mkdir()
+        (source / 'dummy' / 'test2.py').touch()
+        target = self.tmpdir / 'source.pyz'
+
+        zipapp.create_archive(source, target, filter=skip_dummy_dir)
+        with zipfile.ZipFile(target, 'r') as z:
+            self.assertEqual(len(z.namelist()), 2)
+            self.assertIn('__main__.py', z.namelist())
+            self.assertIn('test.py', z.namelist())
+
+    def test_create_archive_default_target(self):
+        # Test packing a directory to the default name.
+        source = self.tmpdir / 'source'
+        source.mkdir()
+        (source / '__main__.py').touch()
+        zipapp.create_archive(str(source))
+        expected_target = self.tmpdir / 'source.pyz'
+        self.assertTrue(expected_target.is_file())
+
+    @requires_zlib
+    def test_create_archive_with_compression(self):
+        # Test packing a directory into a compressed archive.
+        source = self.tmpdir / 'source'
+        source.mkdir()
+        (source / '__main__.py').touch()
+        (source / 'test.py').touch()
+        target = self.tmpdir / 'source.pyz'
+
+        zipapp.create_archive(source, target, compressed=True)
+        with zipfile.ZipFile(target, 'r') as z:
+            for name in ('__main__.py', 'test.py'):
+                self.assertEqual(z.getinfo(name).compress_type,
+                                 zipfile.ZIP_DEFLATED)
+
+    def test_no_main(self):
+        # Test that packing a directory with no __main__.py fails.
+        source = self.tmpdir / 'source'
+        source.mkdir()
+        (source / 'foo.py').touch()
+        target = self.tmpdir / 'source.pyz'
+        with self.assertRaises(zipapp.ZipAppError):
+            zipapp.create_archive(str(source), str(target))
+
+    def test_main_and_main_py(self):
+        # Test that supplying a main argument with __main__.py fails.
+        source = self.tmpdir / 'source'
+        source.mkdir()
+        (source / '__main__.py').touch()
+        target = self.tmpdir / 'source.pyz'
+        with self.assertRaises(zipapp.ZipAppError):
+            zipapp.create_archive(str(source), str(target), main='pkg.mod:fn')
+
+    def test_main_written(self):
+        # Test that the __main__.py is written correctly.
+        source = self.tmpdir / 'source'
+        source.mkdir()
+        (source / 'foo.py').touch()
+        target = self.tmpdir / 'source.pyz'
+        zipapp.create_archive(str(source), str(target), main='pkg.mod:fn')
+        with zipfile.ZipFile(str(target), 'r') as z:
+            self.assertIn('__main__.py', z.namelist())
+            self.assertIn(b'pkg.mod.fn()', z.read('__main__.py'))
+
+    def test_main_only_written_once(self):
+        # Test that we don't write multiple __main__.py files.
+        # The initial implementation had this bug; zip files allow
+        # multiple entries with the same name
+        source = self.tmpdir / 'source'
+        source.mkdir()
+        # Write 2 files, as the original bug wrote __main__.py
+        # once for each file written :-(
+        # See http://bugs.python.org/review/23491/diff/13982/Lib/zipapp.py#newcode67Lib/zipapp.py:67
+        # (line 67)
+        (source / 'foo.py').touch()
+        (source / 'bar.py').touch()
+        target = self.tmpdir / 'source.pyz'
+        zipapp.create_archive(str(source), str(target), main='pkg.mod:fn')
+        with zipfile.ZipFile(str(target), 'r') as z:
+            self.assertEqual(1, z.namelist().count('__main__.py'))
+
+    def test_main_validation(self):
+        # Test that invalid values for main are rejected.
+        source = self.tmpdir / 'source'
+        source.mkdir()
+        target = self.tmpdir / 'source.pyz'
+        problems = [
+            '', 'foo', 'foo:', ':bar', '12:bar', 'a.b.c.:d',
+            '.a:b', 'a:b.', 'a:.b', 'a:silly name'
+        ]
+        for main in problems:
+            with self.subTest(main=main):
+                with self.assertRaises(zipapp.ZipAppError):
+                    zipapp.create_archive(str(source), str(target), main=main)
+
+    def test_default_no_shebang(self):
+        # Test that no shebang line is written to the target by default.
+        source = self.tmpdir / 'source'
+        source.mkdir()
+        (source / '__main__.py').touch()
+        target = self.tmpdir / 'source.pyz'
+        zipapp.create_archive(str(source), str(target))
+        with target.open('rb') as f:
+            self.assertNotEqual(f.read(2), b'#!')
+
+    def test_custom_interpreter(self):
+        # Test that a shebang line with a custom interpreter is written
+        # correctly.
+        source = self.tmpdir / 'source'
+        source.mkdir()
+        (source / '__main__.py').touch()
+        target = self.tmpdir / 'source.pyz'
+        zipapp.create_archive(str(source), str(target), interpreter='python')
+        with target.open('rb') as f:
+            self.assertEqual(f.read(2), b'#!')
+            self.assertEqual(b'python\n', f.readline())
+
+    def test_pack_to_fileobj(self):
+        # Test that we can pack to a file object.
+        source = self.tmpdir / 'source'
+        source.mkdir()
+        (source / '__main__.py').touch()
+        target = io.BytesIO()
+        zipapp.create_archive(str(source), target, interpreter='python')
+        self.assertTrue(target.getvalue().startswith(b'#!python\n'))
+
+    def test_read_shebang(self):
+        # Test that we can read the shebang line correctly.
+        source = self.tmpdir / 'source'
+        source.mkdir()
+        (source / '__main__.py').touch()
+        target = self.tmpdir / 'source.pyz'
+        zipapp.create_archive(str(source), str(target), interpreter='python')
+        self.assertEqual(zipapp.get_interpreter(str(target)), 'python')
+
+    def test_read_missing_shebang(self):
+        # Test that reading the shebang line of a file without one returns None.
+        source = self.tmpdir / 'source'
+        source.mkdir()
+        (source / '__main__.py').touch()
+        target = self.tmpdir / 'source.pyz'
+        zipapp.create_archive(str(source), str(target))
+        self.assertEqual(zipapp.get_interpreter(str(target)), None)
+
+    def test_modify_shebang(self):
+        # Test that we can change the shebang of a file.
+        source = self.tmpdir / 'source'
+        source.mkdir()
+        (source / '__main__.py').touch()
+        target = self.tmpdir / 'source.pyz'
+        zipapp.create_archive(str(source), str(target), interpreter='python')
+        new_target = self.tmpdir / 'changed.pyz'
+        zipapp.create_archive(str(target), str(new_target), interpreter='python2.7')
+        self.assertEqual(zipapp.get_interpreter(str(new_target)), 'python2.7')
+
+    def test_write_shebang_to_fileobj(self):
+        # Test that we can change the shebang of a file, writing the result to a
+        # file object.
+        source = self.tmpdir / 'source'
+        source.mkdir()
+        (source / '__main__.py').touch()
+        target = self.tmpdir / 'source.pyz'
+        zipapp.create_archive(str(source), str(target), interpreter='python')
+        new_target = io.BytesIO()
+        zipapp.create_archive(str(target), new_target, interpreter='python2.7')
+        self.assertTrue(new_target.getvalue().startswith(b'#!python2.7\n'))
+
+    def test_read_from_pathobj(self):
+        # Test that we can copy an archive using a pathlib.Path object
+        # for the source.
+        source = self.tmpdir / 'source'
+        source.mkdir()
+        (source / '__main__.py').touch()
+        target1 = self.tmpdir / 'target1.pyz'
+        target2 = self.tmpdir / 'target2.pyz'
+        zipapp.create_archive(source, target1, interpreter='python')
+        zipapp.create_archive(target1, target2, interpreter='python2.7')
+        self.assertEqual(zipapp.get_interpreter(target2), 'python2.7')
+
+    def test_read_from_fileobj(self):
+        # Test that we can copy an archive using an open file object.
+        source = self.tmpdir / 'source'
+        source.mkdir()
+        (source / '__main__.py').touch()
+        target = self.tmpdir / 'source.pyz'
+        temp_archive = io.BytesIO()
+        zipapp.create_archive(str(source), temp_archive, interpreter='python')
+        new_target = io.BytesIO()
+        temp_archive.seek(0)
+        zipapp.create_archive(temp_archive, new_target, interpreter='python2.7')
+        self.assertTrue(new_target.getvalue().startswith(b'#!python2.7\n'))
+
+    def test_remove_shebang(self):
+        # Test that we can remove the shebang from a file.
+        source = self.tmpdir / 'source'
+        source.mkdir()
+        (source / '__main__.py').touch()
+        target = self.tmpdir / 'source.pyz'
+        zipapp.create_archive(str(source), str(target), interpreter='python')
+        new_target = self.tmpdir / 'changed.pyz'
+        zipapp.create_archive(str(target), str(new_target), interpreter=None)
+        self.assertEqual(zipapp.get_interpreter(str(new_target)), None)
+
+    def test_content_of_copied_archive(self):
+        # Test that copying an archive doesn't corrupt it.
+        source = self.tmpdir / 'source'
+        source.mkdir()
+        (source / '__main__.py').touch()
+        target = io.BytesIO()
+        zipapp.create_archive(str(source), target, interpreter='python')
+        new_target = io.BytesIO()
+        target.seek(0)
+        zipapp.create_archive(target, new_target, interpreter=None)
+        new_target.seek(0)
+        with zipfile.ZipFile(new_target, 'r') as z:
+            self.assertEqual(set(z.namelist()), {'__main__.py'})
+
+    # (Unix only) tests that archives with shebang lines are made executable
+    @unittest.skipIf(sys.platform == 'win32',
+                     'Windows does not support an executable bit')
+    def test_shebang_is_executable(self):
+        # Test that an archive with a shebang line is made executable.
+        source = self.tmpdir / 'source'
+        source.mkdir()
+        (source / '__main__.py').touch()
+        target = self.tmpdir / 'source.pyz'
+        zipapp.create_archive(str(source), str(target), interpreter='python')
+        self.assertTrue(target.stat().st_mode & stat.S_IEXEC)
+
+    @unittest.skipIf(sys.platform == 'win32',
+                     'Windows does not support an executable bit')
+    def test_no_shebang_is_not_executable(self):
+        # Test that an archive with no shebang line is not made executable.
+        source = self.tmpdir / 'source'
+        source.mkdir()
+        (source / '__main__.py').touch()
+        target = self.tmpdir / 'source.pyz'
+        zipapp.create_archive(str(source), str(target), interpreter=None)
+        self.assertFalse(target.stat().st_mode & stat.S_IEXEC)
+
+
+class ZipAppCmdlineTest(unittest.TestCase):
+
+    """Test zipapp module command line API."""
+
+    def setUp(self):
+        tmpdir = tempfile.TemporaryDirectory()
+        self.addCleanup(tmpdir.cleanup)
+        self.tmpdir = pathlib.Path(tmpdir.name)
+
+    def make_archive(self):
+        # Test that an archive with no shebang line is not made executable.
+        source = self.tmpdir / 'source'
+        source.mkdir()
+        (source / '__main__.py').touch()
+        target = self.tmpdir / 'source.pyz'
+        zipapp.create_archive(source, target)
+        return target
+
+    def test_cmdline_create(self):
+        # Test the basic command line API.
+        source = self.tmpdir / 'source'
+        source.mkdir()
+        (source / '__main__.py').touch()
+        args = [str(source)]
+        zipapp.main(args)
+        target = source.with_suffix('.pyz')
+        self.assertTrue(target.is_file())
+
+    def test_cmdline_copy(self):
+        # Test copying an archive.
+        original = self.make_archive()
+        target = self.tmpdir / 'target.pyz'
+        args = [str(original), '-o', str(target)]
+        zipapp.main(args)
+        self.assertTrue(target.is_file())
+
+    def test_cmdline_copy_inplace(self):
+        # Test copying an archive in place fails.
+        original = self.make_archive()
+        target = self.tmpdir / 'target.pyz'
+        args = [str(original), '-o', str(original)]
+        with self.assertRaises(SystemExit) as cm:
+            zipapp.main(args)
+        # Program should exit with a non-zero return code.
+        self.assertTrue(cm.exception.code)
+
+    def test_cmdline_copy_change_main(self):
+        # Test copying an archive doesn't allow changing __main__.py.
+        original = self.make_archive()
+        target = self.tmpdir / 'target.pyz'
+        args = [str(original), '-o', str(target), '-m', 'foo:bar']
+        with self.assertRaises(SystemExit) as cm:
+            zipapp.main(args)
+        # Program should exit with a non-zero return code.
+        self.assertTrue(cm.exception.code)
+
+    @patch('sys.stdout', new_callable=io.StringIO)
+    def test_info_command(self, mock_stdout):
+        # Test the output of the info command.
+        target = self.make_archive()
+        args = [str(target), '--info']
+        with self.assertRaises(SystemExit) as cm:
+            zipapp.main(args)
+        # Program should exit with a zero return code.
+        self.assertEqual(cm.exception.code, 0)
+        self.assertEqual(mock_stdout.getvalue(), "Interpreter: <none>\n")
+
+    def test_info_error(self):
+        # Test the info command fails when the archive does not exist.
+        target = self.tmpdir / 'dummy.pyz'
+        args = [str(target), '--info']
+        with self.assertRaises(SystemExit) as cm:
+            zipapp.main(args)
+        # Program should exit with a non-zero return code.
+        self.assertTrue(cm.exception.code)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/Lib/test/test_zipapp.py
+++ b/Lib/test/test_zipapp.py
@@ -310,6 +310,8 @@ class ZipAppTest(unittest.TestCase):
         zipapp.create_archive(str(source), str(target), interpreter='python')
         self.assertTrue(target.stat().st_mode & stat.S_IEXEC)
 
+    # TODO: RUSTPYTHON
+    @unittest.expectedFailure
     @unittest.skipIf(sys.platform == 'win32',
                      'Windows does not support an executable bit')
     def test_no_shebang_is_not_executable(self):

--- a/Lib/test/tracedmodules/__init__.py
+++ b/Lib/test/tracedmodules/__init__.py
@@ -1,0 +1,4 @@
+"""This package contains modules that help testing the trace.py module. Note
+that the exact location of functions in these modules is important, as trace.py
+takes the real line numbers into account.
+"""

--- a/Lib/test/tracedmodules/testmod.py
+++ b/Lib/test/tracedmodules/testmod.py
@@ -1,0 +1,9 @@
+def func(x):
+    b = x + 1
+    return b + 2
+
+def func2():
+    """Test function for issue 9936 """
+    return (1,
+            2,
+            3)

--- a/Lib/trace.py
+++ b/Lib/trace.py
@@ -1,0 +1,756 @@
+#!/usr/bin/env python3
+
+# portions copyright 2001, Autonomous Zones Industries, Inc., all rights...
+# err...  reserved and offered to the public under the terms of the
+# Python 2.2 license.
+# Author: Zooko O'Whielacronx
+# http://zooko.com/
+# mailto:zooko@zooko.com
+#
+# Copyright 2000, Mojam Media, Inc., all rights reserved.
+# Author: Skip Montanaro
+#
+# Copyright 1999, Bioreason, Inc., all rights reserved.
+# Author: Andrew Dalke
+#
+# Copyright 1995-1997, Automatrix, Inc., all rights reserved.
+# Author: Skip Montanaro
+#
+# Copyright 1991-1995, Stichting Mathematisch Centrum, all rights reserved.
+#
+#
+# Permission to use, copy, modify, and distribute this Python software and
+# its associated documentation for any purpose without fee is hereby
+# granted, provided that the above copyright notice appears in all copies,
+# and that both that copyright notice and this permission notice appear in
+# supporting documentation, and that the name of neither Automatrix,
+# Bioreason or Mojam Media be used in advertising or publicity pertaining to
+# distribution of the software without specific, written prior permission.
+#
+"""program/module to trace Python program or function execution
+
+Sample use, command line:
+  trace.py -c -f counts --ignore-dir '$prefix' spam.py eggs
+  trace.py -t --ignore-dir '$prefix' spam.py eggs
+  trace.py --trackcalls spam.py eggs
+
+Sample use, programmatically
+  import sys
+
+  # create a Trace object, telling it what to ignore, and whether to
+  # do tracing or line-counting or both.
+  tracer = trace.Trace(ignoredirs=[sys.base_prefix, sys.base_exec_prefix,],
+                       trace=0, count=1)
+  # run the new command using the given tracer
+  tracer.run('main()')
+  # make a report, placing output in /tmp
+  r = tracer.results()
+  r.write_results(show_missing=True, coverdir="/tmp")
+"""
+__all__ = ['Trace', 'CoverageResults']
+
+import linecache
+import os
+import sys
+import sysconfig
+import token
+import tokenize
+import inspect
+import gc
+import dis
+import pickle
+from time import monotonic as _time
+
+import threading
+
+PRAGMA_NOCOVER = "#pragma NO COVER"
+
+class _Ignore:
+    def __init__(self, modules=None, dirs=None):
+        self._mods = set() if not modules else set(modules)
+        self._dirs = [] if not dirs else [os.path.normpath(d)
+                                          for d in dirs]
+        self._ignore = { '<string>': 1 }
+
+    def names(self, filename, modulename):
+        if modulename in self._ignore:
+            return self._ignore[modulename]
+
+        # haven't seen this one before, so see if the module name is
+        # on the ignore list.
+        if modulename in self._mods:  # Identical names, so ignore
+            self._ignore[modulename] = 1
+            return 1
+
+        # check if the module is a proper submodule of something on
+        # the ignore list
+        for mod in self._mods:
+            # Need to take some care since ignoring
+            # "cmp" mustn't mean ignoring "cmpcache" but ignoring
+            # "Spam" must also mean ignoring "Spam.Eggs".
+            if modulename.startswith(mod + '.'):
+                self._ignore[modulename] = 1
+                return 1
+
+        # Now check that filename isn't in one of the directories
+        if filename is None:
+            # must be a built-in, so we must ignore
+            self._ignore[modulename] = 1
+            return 1
+
+        # Ignore a file when it contains one of the ignorable paths
+        for d in self._dirs:
+            # The '+ os.sep' is to ensure that d is a parent directory,
+            # as compared to cases like:
+            #  d = "/usr/local"
+            #  filename = "/usr/local.py"
+            # or
+            #  d = "/usr/local.py"
+            #  filename = "/usr/local.py"
+            if filename.startswith(d + os.sep):
+                self._ignore[modulename] = 1
+                return 1
+
+        # Tried the different ways, so we don't ignore this module
+        self._ignore[modulename] = 0
+        return 0
+
+def _modname(path):
+    """Return a plausible module name for the patch."""
+
+    base = os.path.basename(path)
+    filename, ext = os.path.splitext(base)
+    return filename
+
+def _fullmodname(path):
+    """Return a plausible module name for the path."""
+
+    # If the file 'path' is part of a package, then the filename isn't
+    # enough to uniquely identify it.  Try to do the right thing by
+    # looking in sys.path for the longest matching prefix.  We'll
+    # assume that the rest is the package name.
+
+    comparepath = os.path.normcase(path)
+    longest = ""
+    for dir in sys.path:
+        dir = os.path.normcase(dir)
+        if comparepath.startswith(dir) and comparepath[len(dir)] == os.sep:
+            if len(dir) > len(longest):
+                longest = dir
+
+    if longest:
+        base = path[len(longest) + 1:]
+    else:
+        base = path
+    # the drive letter is never part of the module name
+    drive, base = os.path.splitdrive(base)
+    base = base.replace(os.sep, ".")
+    if os.altsep:
+        base = base.replace(os.altsep, ".")
+    filename, ext = os.path.splitext(base)
+    return filename.lstrip(".")
+
+class CoverageResults:
+    def __init__(self, counts=None, calledfuncs=None, infile=None,
+                 callers=None, outfile=None):
+        self.counts = counts
+        if self.counts is None:
+            self.counts = {}
+        self.counter = self.counts.copy() # map (filename, lineno) to count
+        self.calledfuncs = calledfuncs
+        if self.calledfuncs is None:
+            self.calledfuncs = {}
+        self.calledfuncs = self.calledfuncs.copy()
+        self.callers = callers
+        if self.callers is None:
+            self.callers = {}
+        self.callers = self.callers.copy()
+        self.infile = infile
+        self.outfile = outfile
+        if self.infile:
+            # Try to merge existing counts file.
+            try:
+                with open(self.infile, 'rb') as f:
+                    counts, calledfuncs, callers = pickle.load(f)
+                self.update(self.__class__(counts, calledfuncs, callers))
+            except (OSError, EOFError, ValueError) as err:
+                print(("Skipping counts file %r: %s"
+                                      % (self.infile, err)), file=sys.stderr)
+
+    def is_ignored_filename(self, filename):
+        """Return True if the filename does not refer to a file
+        we want to have reported.
+        """
+        return filename.startswith('<') and filename.endswith('>')
+
+    def update(self, other):
+        """Merge in the data from another CoverageResults"""
+        counts = self.counts
+        calledfuncs = self.calledfuncs
+        callers = self.callers
+        other_counts = other.counts
+        other_calledfuncs = other.calledfuncs
+        other_callers = other.callers
+
+        for key in other_counts:
+            counts[key] = counts.get(key, 0) + other_counts[key]
+
+        for key in other_calledfuncs:
+            calledfuncs[key] = 1
+
+        for key in other_callers:
+            callers[key] = 1
+
+    def write_results(self, show_missing=True, summary=False, coverdir=None):
+        """
+        Write the coverage results.
+
+        :param show_missing: Show lines that had no hits.
+        :param summary: Include coverage summary per module.
+        :param coverdir: If None, the results of each module are placed in its
+                         directory, otherwise it is included in the directory
+                         specified.
+        """
+        if self.calledfuncs:
+            print()
+            print("functions called:")
+            calls = self.calledfuncs
+            for filename, modulename, funcname in sorted(calls):
+                print(("filename: %s, modulename: %s, funcname: %s"
+                       % (filename, modulename, funcname)))
+
+        if self.callers:
+            print()
+            print("calling relationships:")
+            lastfile = lastcfile = ""
+            for ((pfile, pmod, pfunc), (cfile, cmod, cfunc)) \
+                    in sorted(self.callers):
+                if pfile != lastfile:
+                    print()
+                    print("***", pfile, "***")
+                    lastfile = pfile
+                    lastcfile = ""
+                if cfile != pfile and lastcfile != cfile:
+                    print("  -->", cfile)
+                    lastcfile = cfile
+                print("    %s.%s -> %s.%s" % (pmod, pfunc, cmod, cfunc))
+
+        # turn the counts data ("(filename, lineno) = count") into something
+        # accessible on a per-file basis
+        per_file = {}
+        for filename, lineno in self.counts:
+            lines_hit = per_file[filename] = per_file.get(filename, {})
+            lines_hit[lineno] = self.counts[(filename, lineno)]
+
+        # accumulate summary info, if needed
+        sums = {}
+
+        for filename, count in per_file.items():
+            if self.is_ignored_filename(filename):
+                continue
+
+            if filename.endswith(".pyc"):
+                filename = filename[:-1]
+
+            if coverdir is None:
+                dir = os.path.dirname(os.path.abspath(filename))
+                modulename = _modname(filename)
+            else:
+                dir = coverdir
+                if not os.path.exists(dir):
+                    os.makedirs(dir)
+                modulename = _fullmodname(filename)
+
+            # If desired, get a list of the line numbers which represent
+            # executable content (returned as a dict for better lookup speed)
+            if show_missing:
+                lnotab = _find_executable_linenos(filename)
+            else:
+                lnotab = {}
+            source = linecache.getlines(filename)
+            coverpath = os.path.join(dir, modulename + ".cover")
+            with open(filename, 'rb') as fp:
+                encoding, _ = tokenize.detect_encoding(fp.readline)
+            n_hits, n_lines = self.write_results_file(coverpath, source,
+                                                      lnotab, count, encoding)
+            if summary and n_lines:
+                percent = int(100 * n_hits / n_lines)
+                sums[modulename] = n_lines, percent, modulename, filename
+
+
+        if summary and sums:
+            print("lines   cov%   module   (path)")
+            for m in sorted(sums):
+                n_lines, percent, modulename, filename = sums[m]
+                print("%5d   %3d%%   %s   (%s)" % sums[m])
+
+        if self.outfile:
+            # try and store counts and module info into self.outfile
+            try:
+                with open(self.outfile, 'wb') as f:
+                    pickle.dump((self.counts, self.calledfuncs, self.callers),
+                                f, 1)
+            except OSError as err:
+                print("Can't save counts files because %s" % err, file=sys.stderr)
+
+    def write_results_file(self, path, lines, lnotab, lines_hit, encoding=None):
+        """Return a coverage results file in path."""
+        # ``lnotab`` is a dict of executable lines, or a line number "table"
+
+        try:
+            outfile = open(path, "w", encoding=encoding)
+        except OSError as err:
+            print(("trace: Could not open %r for writing: %s "
+                                  "- skipping" % (path, err)), file=sys.stderr)
+            return 0, 0
+
+        n_lines = 0
+        n_hits = 0
+        with outfile:
+            for lineno, line in enumerate(lines, 1):
+                # do the blank/comment match to try to mark more lines
+                # (help the reader find stuff that hasn't been covered)
+                if lineno in lines_hit:
+                    outfile.write("%5d: " % lines_hit[lineno])
+                    n_hits += 1
+                    n_lines += 1
+                elif lineno in lnotab and not PRAGMA_NOCOVER in line:
+                    # Highlight never-executed lines, unless the line contains
+                    # #pragma: NO COVER
+                    outfile.write(">>>>>> ")
+                    n_lines += 1
+                else:
+                    outfile.write("       ")
+                outfile.write(line.expandtabs(8))
+
+        return n_hits, n_lines
+
+def _find_lines_from_code(code, strs):
+    """Return dict where keys are lines in the line number table."""
+    linenos = {}
+
+    for _, lineno in dis.findlinestarts(code):
+        if lineno not in strs:
+            linenos[lineno] = 1
+
+    return linenos
+
+def _find_lines(code, strs):
+    """Return lineno dict for all code objects reachable from code."""
+    # get all of the lineno information from the code of this scope level
+    linenos = _find_lines_from_code(code, strs)
+
+    # and check the constants for references to other code objects
+    for c in code.co_consts:
+        if inspect.iscode(c):
+            # find another code object, so recurse into it
+            linenos.update(_find_lines(c, strs))
+    return linenos
+
+def _find_strings(filename, encoding=None):
+    """Return a dict of possible docstring positions.
+
+    The dict maps line numbers to strings.  There is an entry for
+    line that contains only a string or a part of a triple-quoted
+    string.
+    """
+    d = {}
+    # If the first token is a string, then it's the module docstring.
+    # Add this special case so that the test in the loop passes.
+    prev_ttype = token.INDENT
+    with open(filename, encoding=encoding) as f:
+        tok = tokenize.generate_tokens(f.readline)
+        for ttype, tstr, start, end, line in tok:
+            if ttype == token.STRING:
+                if prev_ttype == token.INDENT:
+                    sline, scol = start
+                    eline, ecol = end
+                    for i in range(sline, eline + 1):
+                        d[i] = 1
+            prev_ttype = ttype
+    return d
+
+def _find_executable_linenos(filename):
+    """Return dict where keys are line numbers in the line number table."""
+    try:
+        with tokenize.open(filename) as f:
+            prog = f.read()
+            encoding = f.encoding
+    except OSError as err:
+        print(("Not printing coverage data for %r: %s"
+                              % (filename, err)), file=sys.stderr)
+        return {}
+    code = compile(prog, filename, "exec")
+    strs = _find_strings(filename, encoding)
+    return _find_lines(code, strs)
+
+class Trace:
+    def __init__(self, count=1, trace=1, countfuncs=0, countcallers=0,
+                 ignoremods=(), ignoredirs=(), infile=None, outfile=None,
+                 timing=False):
+        """
+        @param count true iff it should count number of times each
+                     line is executed
+        @param trace true iff it should print out each line that is
+                     being counted
+        @param countfuncs true iff it should just output a list of
+                     (filename, modulename, funcname,) for functions
+                     that were called at least once;  This overrides
+                     `count' and `trace'
+        @param ignoremods a list of the names of modules to ignore
+        @param ignoredirs a list of the names of directories to ignore
+                     all of the (recursive) contents of
+        @param infile file from which to read stored counts to be
+                     added into the results
+        @param outfile file in which to write the results
+        @param timing true iff timing information be displayed
+        """
+        self.infile = infile
+        self.outfile = outfile
+        self.ignore = _Ignore(ignoremods, ignoredirs)
+        self.counts = {}   # keys are (filename, linenumber)
+        self.pathtobasename = {} # for memoizing os.path.basename
+        self.donothing = 0
+        self.trace = trace
+        self._calledfuncs = {}
+        self._callers = {}
+        self._caller_cache = {}
+        self.start_time = None
+        if timing:
+            self.start_time = _time()
+        if countcallers:
+            self.globaltrace = self.globaltrace_trackcallers
+        elif countfuncs:
+            self.globaltrace = self.globaltrace_countfuncs
+        elif trace and count:
+            self.globaltrace = self.globaltrace_lt
+            self.localtrace = self.localtrace_trace_and_count
+        elif trace:
+            self.globaltrace = self.globaltrace_lt
+            self.localtrace = self.localtrace_trace
+        elif count:
+            self.globaltrace = self.globaltrace_lt
+            self.localtrace = self.localtrace_count
+        else:
+            # Ahem -- do nothing?  Okay.
+            self.donothing = 1
+
+    def run(self, cmd):
+        import __main__
+        dict = __main__.__dict__
+        self.runctx(cmd, dict, dict)
+
+    def runctx(self, cmd, globals=None, locals=None):
+        if globals is None: globals = {}
+        if locals is None: locals = {}
+        if not self.donothing:
+            threading.settrace(self.globaltrace)
+            sys.settrace(self.globaltrace)
+        try:
+            exec(cmd, globals, locals)
+        finally:
+            if not self.donothing:
+                sys.settrace(None)
+                threading.settrace(None)
+
+    def runfunc(*args, **kw):
+        if len(args) >= 2:
+            self, func, *args = args
+        elif not args:
+            raise TypeError("descriptor 'runfunc' of 'Trace' object "
+                            "needs an argument")
+        elif 'func' in kw:
+            func = kw.pop('func')
+            self, *args = args
+            import warnings
+            warnings.warn("Passing 'func' as keyword argument is deprecated",
+                          DeprecationWarning, stacklevel=2)
+        else:
+            raise TypeError('runfunc expected at least 1 positional argument, '
+                            'got %d' % (len(args)-1))
+
+        result = None
+        if not self.donothing:
+            sys.settrace(self.globaltrace)
+        try:
+            result = func(*args, **kw)
+        finally:
+            if not self.donothing:
+                sys.settrace(None)
+        return result
+    runfunc.__text_signature__ = '($self, func, /, *args, **kw)'
+
+    def file_module_function_of(self, frame):
+        code = frame.f_code
+        filename = code.co_filename
+        if filename:
+            modulename = _modname(filename)
+        else:
+            modulename = None
+
+        funcname = code.co_name
+        clsname = None
+        if code in self._caller_cache:
+            if self._caller_cache[code] is not None:
+                clsname = self._caller_cache[code]
+        else:
+            self._caller_cache[code] = None
+            ## use of gc.get_referrers() was suggested by Michael Hudson
+            # all functions which refer to this code object
+            funcs = [f for f in gc.get_referrers(code)
+                         if inspect.isfunction(f)]
+            # require len(func) == 1 to avoid ambiguity caused by calls to
+            # new.function(): "In the face of ambiguity, refuse the
+            # temptation to guess."
+            if len(funcs) == 1:
+                dicts = [d for d in gc.get_referrers(funcs[0])
+                             if isinstance(d, dict)]
+                if len(dicts) == 1:
+                    classes = [c for c in gc.get_referrers(dicts[0])
+                                   if hasattr(c, "__bases__")]
+                    if len(classes) == 1:
+                        # ditto for new.classobj()
+                        clsname = classes[0].__name__
+                        # cache the result - assumption is that new.* is
+                        # not called later to disturb this relationship
+                        # _caller_cache could be flushed if functions in
+                        # the new module get called.
+                        self._caller_cache[code] = clsname
+        if clsname is not None:
+            funcname = "%s.%s" % (clsname, funcname)
+
+        return filename, modulename, funcname
+
+    def globaltrace_trackcallers(self, frame, why, arg):
+        """Handler for call events.
+
+        Adds information about who called who to the self._callers dict.
+        """
+        if why == 'call':
+            # XXX Should do a better job of identifying methods
+            this_func = self.file_module_function_of(frame)
+            parent_func = self.file_module_function_of(frame.f_back)
+            self._callers[(parent_func, this_func)] = 1
+
+    def globaltrace_countfuncs(self, frame, why, arg):
+        """Handler for call events.
+
+        Adds (filename, modulename, funcname) to the self._calledfuncs dict.
+        """
+        if why == 'call':
+            this_func = self.file_module_function_of(frame)
+            self._calledfuncs[this_func] = 1
+
+    def globaltrace_lt(self, frame, why, arg):
+        """Handler for call events.
+
+        If the code block being entered is to be ignored, returns `None',
+        else returns self.localtrace.
+        """
+        if why == 'call':
+            code = frame.f_code
+            filename = frame.f_globals.get('__file__', None)
+            if filename:
+                # XXX _modname() doesn't work right for packages, so
+                # the ignore support won't work right for packages
+                modulename = _modname(filename)
+                if modulename is not None:
+                    ignore_it = self.ignore.names(filename, modulename)
+                    if not ignore_it:
+                        if self.trace:
+                            print((" --- modulename: %s, funcname: %s"
+                                   % (modulename, code.co_name)))
+                        return self.localtrace
+            else:
+                return None
+
+    def localtrace_trace_and_count(self, frame, why, arg):
+        if why == "line":
+            # record the file name and line number of every trace
+            filename = frame.f_code.co_filename
+            lineno = frame.f_lineno
+            key = filename, lineno
+            self.counts[key] = self.counts.get(key, 0) + 1
+
+            if self.start_time:
+                print('%.2f' % (_time() - self.start_time), end=' ')
+            bname = os.path.basename(filename)
+            print("%s(%d): %s" % (bname, lineno,
+                                  linecache.getline(filename, lineno)), end='')
+        return self.localtrace
+
+    def localtrace_trace(self, frame, why, arg):
+        if why == "line":
+            # record the file name and line number of every trace
+            filename = frame.f_code.co_filename
+            lineno = frame.f_lineno
+
+            if self.start_time:
+                print('%.2f' % (_time() - self.start_time), end=' ')
+            bname = os.path.basename(filename)
+            print("%s(%d): %s" % (bname, lineno,
+                                  linecache.getline(filename, lineno)), end='')
+        return self.localtrace
+
+    def localtrace_count(self, frame, why, arg):
+        if why == "line":
+            filename = frame.f_code.co_filename
+            lineno = frame.f_lineno
+            key = filename, lineno
+            self.counts[key] = self.counts.get(key, 0) + 1
+        return self.localtrace
+
+    def results(self):
+        return CoverageResults(self.counts, infile=self.infile,
+                               outfile=self.outfile,
+                               calledfuncs=self._calledfuncs,
+                               callers=self._callers)
+
+def main():
+    import argparse
+
+    parser = argparse.ArgumentParser()
+    parser.add_argument('--version', action='version', version='trace 2.0')
+
+    grp = parser.add_argument_group('Main options',
+            'One of these (or --report) must be given')
+
+    grp.add_argument('-c', '--count', action='store_true',
+            help='Count the number of times each line is executed and write '
+                 'the counts to <module>.cover for each module executed, in '
+                 'the module\'s directory. See also --coverdir, --file, '
+                 '--no-report below.')
+    grp.add_argument('-t', '--trace', action='store_true',
+            help='Print each line to sys.stdout before it is executed')
+    grp.add_argument('-l', '--listfuncs', action='store_true',
+            help='Keep track of which functions are executed at least once '
+                 'and write the results to sys.stdout after the program exits. '
+                 'Cannot be specified alongside --trace or --count.')
+    grp.add_argument('-T', '--trackcalls', action='store_true',
+            help='Keep track of caller/called pairs and write the results to '
+                 'sys.stdout after the program exits.')
+
+    grp = parser.add_argument_group('Modifiers')
+
+    _grp = grp.add_mutually_exclusive_group()
+    _grp.add_argument('-r', '--report', action='store_true',
+            help='Generate a report from a counts file; does not execute any '
+                 'code. --file must specify the results file to read, which '
+                 'must have been created in a previous run with --count '
+                 '--file=FILE')
+    _grp.add_argument('-R', '--no-report', action='store_true',
+            help='Do not generate the coverage report files. '
+                 'Useful if you want to accumulate over several runs.')
+
+    grp.add_argument('-f', '--file',
+            help='File to accumulate counts over several runs')
+    grp.add_argument('-C', '--coverdir',
+            help='Directory where the report files go. The coverage report '
+                 'for <package>.<module> will be written to file '
+                 '<dir>/<package>/<module>.cover')
+    grp.add_argument('-m', '--missing', action='store_true',
+            help='Annotate executable lines that were not executed with '
+                 '">>>>>> "')
+    grp.add_argument('-s', '--summary', action='store_true',
+            help='Write a brief summary for each file to sys.stdout. '
+                 'Can only be used with --count or --report')
+    grp.add_argument('-g', '--timing', action='store_true',
+            help='Prefix each line with the time since the program started. '
+                 'Only used while tracing')
+
+    grp = parser.add_argument_group('Filters',
+            'Can be specified multiple times')
+    grp.add_argument('--ignore-module', action='append', default=[],
+            help='Ignore the given module(s) and its submodules '
+                 '(if it is a package). Accepts comma separated list of '
+                 'module names.')
+    grp.add_argument('--ignore-dir', action='append', default=[],
+            help='Ignore files in the given directory '
+                 '(multiple directories can be joined by os.pathsep).')
+
+    parser.add_argument('--module', action='store_true', default=False,
+                        help='Trace a module. ')
+    parser.add_argument('progname', nargs='?',
+            help='file to run as main program')
+    parser.add_argument('arguments', nargs=argparse.REMAINDER,
+            help='arguments to the program')
+
+    opts = parser.parse_args()
+
+    if opts.ignore_dir:
+        _prefix = sysconfig.get_path("stdlib")
+        _exec_prefix = sysconfig.get_path("platstdlib")
+
+    def parse_ignore_dir(s):
+        s = os.path.expanduser(os.path.expandvars(s))
+        s = s.replace('$prefix', _prefix).replace('$exec_prefix', _exec_prefix)
+        return os.path.normpath(s)
+
+    opts.ignore_module = [mod.strip()
+                          for i in opts.ignore_module for mod in i.split(',')]
+    opts.ignore_dir = [parse_ignore_dir(s)
+                       for i in opts.ignore_dir for s in i.split(os.pathsep)]
+
+    if opts.report:
+        if not opts.file:
+            parser.error('-r/--report requires -f/--file')
+        results = CoverageResults(infile=opts.file, outfile=opts.file)
+        return results.write_results(opts.missing, opts.summary, opts.coverdir)
+
+    if not any([opts.trace, opts.count, opts.listfuncs, opts.trackcalls]):
+        parser.error('must specify one of --trace, --count, --report, '
+                     '--listfuncs, or --trackcalls')
+
+    if opts.listfuncs and (opts.count or opts.trace):
+        parser.error('cannot specify both --listfuncs and (--trace or --count)')
+
+    if opts.summary and not opts.count:
+        parser.error('--summary can only be used with --count or --report')
+
+    if opts.progname is None:
+        parser.error('progname is missing: required with the main options')
+
+    t = Trace(opts.count, opts.trace, countfuncs=opts.listfuncs,
+              countcallers=opts.trackcalls, ignoremods=opts.ignore_module,
+              ignoredirs=opts.ignore_dir, infile=opts.file,
+              outfile=opts.file, timing=opts.timing)
+    try:
+        if opts.module:
+            import runpy
+            module_name = opts.progname
+            mod_name, mod_spec, code = runpy._get_module_details(module_name)
+            sys.argv = [code.co_filename, *opts.arguments]
+            globs = {
+                '__name__': '__main__',
+                '__file__': code.co_filename,
+                '__package__': mod_spec.parent,
+                '__loader__': mod_spec.loader,
+                '__spec__': mod_spec,
+                '__cached__': None,
+            }
+        else:
+            sys.argv = [opts.progname, *opts.arguments]
+            sys.path[0] = os.path.dirname(opts.progname)
+
+            with open(opts.progname, 'rb') as fp:
+                code = compile(fp.read(), opts.progname, 'exec')
+            # try to emulate __main__ namespace as much as possible
+            globs = {
+                '__file__': opts.progname,
+                '__name__': '__main__',
+                '__package__': None,
+                '__cached__': None,
+            }
+        t.runctx(code, globs, globs)
+    except OSError as err:
+        sys.exit("Cannot run file %r because: %s" % (sys.argv[0], err))
+    except SystemExit:
+        pass
+
+    results = t.results()
+
+    if not opts.no_report:
+        results.write_results(opts.missing, opts.summary, opts.coverdir)
+
+if __name__=='__main__':
+    main()

--- a/Lib/zipapp.py
+++ b/Lib/zipapp.py
@@ -1,0 +1,206 @@
+import contextlib
+import os
+import pathlib
+import shutil
+import stat
+import sys
+import zipfile
+
+__all__ = ['ZipAppError', 'create_archive', 'get_interpreter']
+
+
+# The __main__.py used if the users specifies "-m module:fn".
+# Note that this will always be written as UTF-8 (module and
+# function names can be non-ASCII in Python 3).
+# We add a coding cookie even though UTF-8 is the default in Python 3
+# because the resulting archive may be intended to be run under Python 2.
+MAIN_TEMPLATE = """\
+# -*- coding: utf-8 -*-
+import {module}
+{module}.{fn}()
+"""
+
+
+# The Windows launcher defaults to UTF-8 when parsing shebang lines if the
+# file has no BOM. So use UTF-8 on Windows.
+# On Unix, use the filesystem encoding.
+if sys.platform.startswith('win'):
+    shebang_encoding = 'utf-8'
+else:
+    shebang_encoding = sys.getfilesystemencoding()
+
+
+class ZipAppError(ValueError):
+    pass
+
+
+@contextlib.contextmanager
+def _maybe_open(archive, mode):
+    if isinstance(archive, (str, os.PathLike)):
+        with open(archive, mode) as f:
+            yield f
+    else:
+        yield archive
+
+
+def _write_file_prefix(f, interpreter):
+    """Write a shebang line."""
+    if interpreter:
+        shebang = b'#!' + interpreter.encode(shebang_encoding) + b'\n'
+        f.write(shebang)
+
+
+def _copy_archive(archive, new_archive, interpreter=None):
+    """Copy an application archive, modifying the shebang line."""
+    with _maybe_open(archive, 'rb') as src:
+        # Skip the shebang line from the source.
+        # Read 2 bytes of the source and check if they are #!.
+        first_2 = src.read(2)
+        if first_2 == b'#!':
+            # Discard the initial 2 bytes and the rest of the shebang line.
+            first_2 = b''
+            src.readline()
+
+        with _maybe_open(new_archive, 'wb') as dst:
+            _write_file_prefix(dst, interpreter)
+            # If there was no shebang, "first_2" contains the first 2 bytes
+            # of the source file, so write them before copying the rest
+            # of the file.
+            dst.write(first_2)
+            shutil.copyfileobj(src, dst)
+
+    if interpreter and isinstance(new_archive, str):
+        os.chmod(new_archive, os.stat(new_archive).st_mode | stat.S_IEXEC)
+
+
+def create_archive(source, target=None, interpreter=None, main=None,
+                   filter=None, compressed=False):
+    """Create an application archive from SOURCE.
+
+    The SOURCE can be the name of a directory, or a filename or a file-like
+    object referring to an existing archive.
+
+    The content of SOURCE is packed into an application archive in TARGET,
+    which can be a filename or a file-like object.  If SOURCE is a directory,
+    TARGET can be omitted and will default to the name of SOURCE with .pyz
+    appended.
+
+    The created application archive will have a shebang line specifying
+    that it should run with INTERPRETER (there will be no shebang line if
+    INTERPRETER is None), and a __main__.py which runs MAIN (if MAIN is
+    not specified, an existing __main__.py will be used).  It is an error
+    to specify MAIN for anything other than a directory source with no
+    __main__.py, and it is an error to omit MAIN if the directory has no
+    __main__.py.
+    """
+    # Are we copying an existing archive?
+    source_is_file = False
+    if hasattr(source, 'read') and hasattr(source, 'readline'):
+        source_is_file = True
+    else:
+        source = pathlib.Path(source)
+        if source.is_file():
+            source_is_file = True
+
+    if source_is_file:
+        _copy_archive(source, target, interpreter)
+        return
+
+    # We are creating a new archive from a directory.
+    if not source.exists():
+        raise ZipAppError("Source does not exist")
+    has_main = (source / '__main__.py').is_file()
+    if main and has_main:
+        raise ZipAppError(
+            "Cannot specify entry point if the source has __main__.py")
+    if not (main or has_main):
+        raise ZipAppError("Archive has no entry point")
+
+    main_py = None
+    if main:
+        # Check that main has the right format.
+        mod, sep, fn = main.partition(':')
+        mod_ok = all(part.isidentifier() for part in mod.split('.'))
+        fn_ok = all(part.isidentifier() for part in fn.split('.'))
+        if not (sep == ':' and mod_ok and fn_ok):
+            raise ZipAppError("Invalid entry point: " + main)
+        main_py = MAIN_TEMPLATE.format(module=mod, fn=fn)
+
+    if target is None:
+        target = source.with_suffix('.pyz')
+    elif not hasattr(target, 'write'):
+        target = pathlib.Path(target)
+
+    with _maybe_open(target, 'wb') as fd:
+        _write_file_prefix(fd, interpreter)
+        compression = (zipfile.ZIP_DEFLATED if compressed else
+                       zipfile.ZIP_STORED)
+        with zipfile.ZipFile(fd, 'w', compression=compression) as z:
+            for child in source.rglob('*'):
+                arcname = child.relative_to(source)
+                if filter is None or filter(arcname):
+                    z.write(child, arcname.as_posix())
+            if main_py:
+                z.writestr('__main__.py', main_py.encode('utf-8'))
+
+    if interpreter and not hasattr(target, 'write'):
+        target.chmod(target.stat().st_mode | stat.S_IEXEC)
+
+
+def get_interpreter(archive):
+    with _maybe_open(archive, 'rb') as f:
+        if f.read(2) == b'#!':
+            return f.readline().strip().decode(shebang_encoding)
+
+
+def main(args=None):
+    """Run the zipapp command line interface.
+
+    The ARGS parameter lets you specify the argument list directly.
+    Omitting ARGS (or setting it to None) works as for argparse, using
+    sys.argv[1:] as the argument list.
+    """
+    import argparse
+
+    parser = argparse.ArgumentParser()
+    parser.add_argument('--output', '-o', default=None,
+            help="The name of the output archive. "
+                 "Required if SOURCE is an archive.")
+    parser.add_argument('--python', '-p', default=None,
+            help="The name of the Python interpreter to use "
+                 "(default: no shebang line).")
+    parser.add_argument('--main', '-m', default=None,
+            help="The main function of the application "
+                 "(default: use an existing __main__.py).")
+    parser.add_argument('--compress', '-c', action='store_true',
+            help="Compress files with the deflate method. "
+                 "Files are stored uncompressed by default.")
+    parser.add_argument('--info', default=False, action='store_true',
+            help="Display the interpreter from the archive.")
+    parser.add_argument('source',
+            help="Source directory (or existing archive).")
+
+    args = parser.parse_args(args)
+
+    # Handle `python -m zipapp archive.pyz --info`.
+    if args.info:
+        if not os.path.isfile(args.source):
+            raise SystemExit("Can only get info for an archive file")
+        interpreter = get_interpreter(args.source)
+        print("Interpreter: {}".format(interpreter or "<none>"))
+        sys.exit(0)
+
+    if os.path.isfile(args.source):
+        if args.output is None or (os.path.exists(args.output) and
+                                   os.path.samefile(args.source, args.output)):
+            raise SystemExit("In-place editing of archives is not supported")
+        if args.main:
+            raise SystemExit("Cannot change the main function when copying")
+
+    create_archive(args.source, args.output,
+                   interpreter=args.python, main=args.main,
+                   compressed=args.compress)
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
This revision add six missing tests from cpython 3.8
* `test_zipapp.py`
* `test_trace.py`
* `test_binhex.py`
* `test_codeccallback.py`
* `test_cmd_line_script.py`
* `test__osx_support.py`