### PR TITLE
Fix complex.__repr__ handling of nan

### DIFF
--- a/vm/src/builtins/complex.rs
+++ b/vm/src/builtins/complex.rs
@@ -305,10 +305,26 @@ impl PyComplex {
     #[pymethod(magic)]
     fn repr(&self) -> String {
         let Complex64 { re, im } = self.value;
-        if re == 0.0 {
+        let re_part = if re.is_nan() {
+            "nan".to_string()
+        } else {
+            format!("{}", re)
+        };
+        let im_part = if im.is_nan() {
+            if re == 0.0 {
+                "nanj".to_string()
+            } else {
+                "+nanj".to_string()
+            }
+        } else if re == 0.0 {
             format!("{}j", im)
         } else {
-            format!("({}{:+}j)", re, im)
+            format!("{:+}j", im)
+        };
+        if re == 0.0 {
+            format!("{}", im_part)
+        } else {
+            format!("({}{})", re_part, im_part)
         }
     }
 


### PR DESCRIPTION
This PR will fix https://github.com/RustPython/RustPython/issues/3182

### Tested Scenarios 
```python
# default examples taken from issue:
>>>>> complex(0, float('nan'))
nanj
>>>>> complex(float('nan'), float('nan'))
(nan+nanj)
>>>>> complex(float('nan'), -float('nan'))
(nan+nanj)
>>>>> complex(-float('nan'), float('nan'))
(nan+nanj)
# some random complex numbers to also check it out manually
>>>>> 10j
10j
>>>>> 1-10j
(1-10j)
>>>>> complex(10, float('10'))
(10+10j)
>>>>> complex(-10, float('10'))
(-10+10j)
complex(10, float('nan'))
(10+nanj)
>>>>> complex(float('nan'), 10)
(nan+10j)
>>>>> complex(float('nan'), 1)
(nan+1j)
```

I am really new to Rust so feel free to give any constructive criticism 🥊 