### PR TITLE
Add missing `repr` for `mappingproxy`

### DIFF
--- a/Lib/test/test_dataclasses.py
+++ b/Lib/test/test_dataclasses.py
@@ -52,8 +52,6 @@ class TestCase(unittest.TestCase):
             class C:
                 x: int = field(default=1, default_factory=int)
 
-    # TODO: RUSTPYTHON
-    @unittest.expectedFailure
     def test_field_repr(self):
         int_field = field(default=1, init=True, repr=False)
         int_field.name = "id"

--- a/Lib/test/test_pprint.py
+++ b/Lib/test/test_pprint.py
@@ -323,8 +323,6 @@ OrderedDict([('the', 0),
              ('lazy', 7),
              ('dog', 8)])""")
 
-    # TODO: RUSTPYTHON
-    @unittest.expectedFailure
     def test_mapping_proxy(self):
         words = 'the quick brown fox jumped over a lazy dog'.split()
         d = dict(zip(words, itertools.count()))
@@ -657,8 +655,6 @@ frozenset2({0,
         self.assertEqual(pprint.pformat(dict.fromkeys(keys, 0)),
                          '{%r: 0, %r: 0}' % tuple(sorted(keys, key=id)))
 
-    # TODO: RUSTPYTHON
-    @unittest.expectedFailure
     def test_sort_orderable_and_unorderable_values(self):
         # Issue 22721:  sorted pprints is not stable
         a = Unorderable()

--- a/vm/src/builtins/mappingproxy.rs
+++ b/vm/src/builtins/mappingproxy.rs
@@ -137,6 +137,16 @@ impl PyMappingProxy {
             }
         }
     }
+    #[pymethod(magic)]
+    fn repr(&self, vm: &VirtualMachine) -> PyResult<String> {
+        let obj = match &self.mapping {
+            MappingProxyInner::Dict(d) => d.clone(),
+            MappingProxyInner::Class(c) => {
+                PyDict::from_attributes(c.attributes.read().clone(), vm)?.into_pyobject(vm)
+            }
+        };
+        Ok(format!("mappingproxy({})", vm.to_repr(&obj)?))
+    }
 }
 
 impl AsMapping for PyMappingProxy {


### PR DESCRIPTION
This revision implements `repr` method of `mappingproxy` type.

There are two case of `repr` in mapping proxy. 
### cpython
``` python
>>> mappingproxy = type(type.__dict__)
>>> mappingproxy({"ASCII": 256})
mappingproxy({'ASCII': 256})
>>> int.__dict__
mappingproxy({'__repr__': <slot wrapper '__repr__' of 'int' objects>, '__hash__': <slot wrapper '__hash__' of 'int' 
objects>, '__getattribute__': <slot wrapper '__getattribute__' of 'int' objects>, '__lt__': <slot wrapper '__lt__' of 'int' objects>, '__le__': 
<slot wrapper '__le__' of 'int' objects>, '__eq__':  .........(skip).......... })
```

But original rustpython just print `<mappingproxy object at 0x55dc213e7eb0>`.
With this fix, rustpython also print like cpython.

### rustpython
```python
>>>>> mappingproxy = type(type.__dict__)
>>>>> mappingproxy({"ASCII":256})
mappingproxy({'ASCII': 256})
>>>>> int.__dict__
mappingproxy({'conjugate': <method 'conjugate' of 'int' objects>, '__format__': <method '__format__' of 'int' objects>, '__lshift__': 
<method '__lshift__' of 'int' objects>, '__mod__': <method '__mod__' of 'int' objects>, ............(skip).............. })
```

---
In addition, `test_field_repr` in `test_dataclasses.py` and `test_mapping_proxy` & `test_sort_orderable_and_unorderable_values` in `test_pprint.py` now go works