### PR TITLE
Fix error message for named expression syntax errors

### DIFF
--- a/Lib/test/test_named_expressions.py
+++ b/Lib/test/test_named_expressions.py
@@ -4,32 +4,24 @@ GLOBAL_VAR = None
 
 class NamedExpressionInvalidTest(unittest.TestCase):
 
-    # TODO: RUSTPYTHON
-    @unittest.expectedFailure # wrong error message
     def test_named_expression_invalid_01(self):
         code = """x := 0"""
 
         with self.assertRaisesRegex(SyntaxError, "invalid syntax"):
             exec(code, {}, {})
 
-    # TODO: RUSTPYTHON
-    @unittest.expectedFailure # wrong error message
     def test_named_expression_invalid_02(self):
         code = """x = y := 0"""
 
         with self.assertRaisesRegex(SyntaxError, "invalid syntax"):
             exec(code, {}, {})
 
-    # TODO: RUSTPYTHON
-    @unittest.expectedFailure # wrong error message
     def test_named_expression_invalid_03(self):
         code = """y := f(x)"""
 
         with self.assertRaisesRegex(SyntaxError, "invalid syntax"):
             exec(code, {}, {})
 
-    # TODO: RUSTPYTHON
-    @unittest.expectedFailure # wrong error message
     def test_named_expression_invalid_04(self):
         code = """y0 = y1 := f(x)"""
 
@@ -44,32 +36,24 @@ class NamedExpressionInvalidTest(unittest.TestCase):
         with self.assertRaisesRegex(SyntaxError, "cannot use assignment expressions with tuple"):
             exec(code, {}, {})
 
-    # TODO: RUSTPYTHON
-    @unittest.expectedFailure # wrong error message
     def test_named_expression_invalid_07(self):
         code = """def spam(a = b := 42): pass"""
 
         with self.assertRaisesRegex(SyntaxError, "invalid syntax"):
             exec(code, {}, {})
 
-    # TODO: RUSTPYTHON
-    @unittest.expectedFailure # wrong error message
     def test_named_expression_invalid_08(self):
         code = """def spam(a: b := 42 = 5): pass"""
 
         with self.assertRaisesRegex(SyntaxError, "invalid syntax"):
             exec(code, {}, {})
 
-    # TODO: RUSTPYTHON
-    @unittest.expectedFailure # wrong error message
     def test_named_expression_invalid_09(self):
         code = """spam(a=b := 'c')"""
 
         with self.assertRaisesRegex(SyntaxError, "invalid syntax"):
             exec(code, {}, {})
 
-    # TODO: RUSTPYTHON
-    @unittest.expectedFailure # wrong error message
     def test_named_expression_invalid_10(self):
         code = """spam(x = y := f(x))"""
 
@@ -97,8 +81,6 @@ class NamedExpressionInvalidTest(unittest.TestCase):
             "positional argument follows keyword argument"):
             exec(code, {}, {})
 
-    # TODO: RUSTPYTHON
-    @unittest.expectedFailure # wrong error message
     def test_named_expression_invalid_14(self):
         code = """(x := lambda: y := 1)"""
 
@@ -114,16 +96,12 @@ class NamedExpressionInvalidTest(unittest.TestCase):
             "cannot use assignment expressions with lambda"):
             exec(code, {}, {})
 
-    # TODO: RUSTPYTHON
-    @unittest.expectedFailure # wrong error message
     def test_named_expression_invalid_16(self):
         code = "[i + 1 for i in i := [1,2]]"
 
         with self.assertRaisesRegex(SyntaxError, "invalid syntax"):
             exec(code, {}, {})
 
-    # TODO: RUSTPYTHON
-    @unittest.expectedFailure # wrong error message
     def test_named_expression_invalid_17(self):
         code = "[i := 0, j := 1 for i, j in [(1, 2), (3, 4)]]"
 

--- a/parser/src/error.rs
+++ b/parser/src/error.rs
@@ -196,7 +196,7 @@ impl fmt::Display for ParseErrorType {
                 } else if expected.as_deref() == Some("Indent") {
                     write!(f, "expected an indented block")
                 } else {
-                    write!(f, "Got unexpected token {}", tok)
+                    write!(f, "invalid syntax. Got unexpected token {}", tok)
                 }
             }
             ParseErrorType::Lexical(ref error) => write!(f, "{}", error),


### PR DESCRIPTION
This is my first PR. Really excited about this project!

I left the fine-grained error message (E.g., "Got unexpected token ...") because I thought this was helpful to users. This is different than Python 3.8's error message, but still conforms to the unittest expectations (contains "invalid syntax"). LMK if you would prefer the RustPython and CPython to be more consistent. Happy to make any changes.

RustPython:
![image](https://user-images.githubusercontent.com/37349208/135731471-64ffd42f-cf43-47da-8fd4-420f43481051.png)

Python 3.8
![image](https://user-images.githubusercontent.com/37349208/135731487-b3618f19-cdc9-42d1-89ed-5a537b41d4c5.png)
