### PR TITLE
Fix deque `repr` to print correct format

### DIFF
--- a/vm/src/stdlib/collections.rs
+++ b/vm/src/stdlib/collections.rs
@@ -420,7 +420,12 @@ mod _collections {
                     .maxlen
                     .map(|maxlen| format!(", maxlen={}", maxlen))
                     .unwrap_or_default();
-                format!("deque([{}]{})", elements.into_iter().format(", "), maxlen)
+                format!(
+                    "{}([{}]{})",
+                    zelf.class().name(),
+                    elements.into_iter().format(", "),
+                    maxlen
+                )
             } else {
                 "[...]".to_owned()
             };


### PR DESCRIPTION
This fixes `PyDeque.repr` in #3217 

**before**
```python
>>>>> from collections import deque
>>>>> class MyDeque(deque): pass
>>>>> MyDeque()
deque([])
```

**after**
```python
>>>>> from collections import deque
>>>>> class MyDeque(deque): pass
>>>>> MyDeque()
MyDeque([])
```