### PR TITLE
fix: __repr__ use collection subclass name

### DIFF
--- a/Lib/test/test_pprint.py
+++ b/Lib/test/test_pprint.py
@@ -154,8 +154,6 @@ class QueryTestCase(unittest.TestCase):
             self.assertFalse(pp.isreadable(unreadable),
                              "expected not isreadable for %r" % (unreadable,))
 
-    # TODO: RUSTPYTHON
-    @unittest.expectedFailure
     def test_same_as_repr(self):
         # Simple objects, small containers and classes that overwrite __repr__
         # For those the result should be the same as repr().
@@ -240,8 +238,6 @@ class QueryTestCase(unittest.TestCase):
         'third': 3}]"""
         self.assertEqual(pprint.pformat(o, indent=4, width=41), expected)
 
-    # TODO: RUSTPYTHON
-    @unittest.expectedFailure
     def test_width(self):
         expected = """\
 [[[[[[1, 2, 3],
@@ -358,8 +354,6 @@ mappingproxy(OrderedDict([('the', 0),
  others.should.not.be: like.this}"""
         self.assertEqual(DottedPrettyPrinter().pformat(o), exp)
 
-    # TODO: RUSTPYTHON
-    @unittest.expectedFailure
     def test_set_reprs(self):
         self.assertEqual(pprint.pformat(set()), 'set()')
         self.assertEqual(pprint.pformat(set(range(3))), '{0, 1, 2}')

--- a/Lib/test/test_set.py
+++ b/Lib/test/test_set.py
@@ -672,8 +672,6 @@ class TestSetSubclass(TestSet):
     def test_pickling(self):
         super().test_pickling()
 
-    # TODO: RUSTPYTHON
-    @unittest.expectedFailure
     def test_cyclical_repr(self):
         super().test_cyclical_repr()
 

--- a/extra_tests/snippets/bytearray.py
+++ b/extra_tests/snippets/bytearray.py
@@ -40,6 +40,16 @@ assert (
 )
 assert repr(bytearray(b"abcd")) == "bytearray(b'abcd')"
 
+class B(bytearray):
+    pass
+
+assert repr(B()) == "B(b'')"
+assert (
+    repr(B([0, 1, 9, 10, 11, 13, 31, 32, 33, 89, 120, 255]))
+    == "B(b'\\x00\\x01\\t\\n\\x0b\\r\\x1f !Yx\\xff')"
+)
+assert repr(B(b"abcd")) == "B(b'abcd')"
+
 # len
 assert len(bytearray("abcdé", "utf8")) == 6
 

--- a/extra_tests/snippets/deque.py
+++ b/extra_tests/snippets/deque.py
@@ -1,4 +1,5 @@
 from collections import deque
+from typing import Deque
 
 
 def test_deque_iterator__new__():
@@ -83,3 +84,12 @@ def test_deque_reverse_iterator__new__not_using_keyword_index():
 
 
 test_deque_reverse_iterator__new__not_using_keyword_index()
+
+assert repr(deque()) == "deque([])"
+assert repr(deque([1, 2, 3])) == "deque([1, 2, 3])"
+
+class D(deque):
+    pass
+
+assert repr(D()) == "D([])"
+assert repr(D([1, 2, 3])) == "D([1, 2, 3])"

--- a/extra_tests/snippets/set.py
+++ b/extra_tests/snippets/set.py
@@ -57,10 +57,22 @@ class Hashable(object):
     def __hash__(self):
         return id(self)
 
+assert repr(set()) == "set()"
+assert repr(set([1, 2, 3])) == "{1, 2, 3}"
 
 recursive = set()
 recursive.add(Hashable(recursive))
 assert repr(recursive) == "{set(...)}"
+
+class S(set):
+    pass
+
+assert repr(S()) == "S()"
+assert repr(S([1, 2, 3])) == "S({1, 2, 3})"
+
+recursive = S()
+recursive.add(Hashable(recursive))
+assert repr(recursive) == "S({S(...)})"
 
 a = set([1, 2, 3])
 assert len(a) == 3
@@ -367,3 +379,12 @@ non_empty_set.remove(1)
 assert 1 not in non_empty_set
 
 # TODO: Assert that adding the same thing to a set once it's already there doesn't do anything.
+
+assert repr(frozenset()) == "frozenset()"
+assert repr(frozenset([1, 2, 3])) == "frozenset({1, 2, 3})"
+
+class FS(frozenset):
+    pass
+
+assert repr(FS()) == "FS()"
+assert repr(FS([1, 2, 3])) == "FS({1, 2, 3})"

--- a/vm/src/builtins/bytearray.rs
+++ b/vm/src/builtins/bytearray.rs
@@ -127,8 +127,10 @@ impl PyByteArray {
     }
 
     #[pymethod(magic)]
-    fn repr(&self) -> String {
-        self.inner().repr("bytearray(", ")")
+    fn repr(zelf: PyRef<Self>, _vm: &VirtualMachine) -> PyResult<String> {
+        let class_name = zelf.class().name();
+        let s = zelf.inner().repr(&format!("{}(", class_name), ")");
+        Ok(s)
     }
 
     #[pymethod(magic)]


### PR DESCRIPTION
Addresses: https://github.com/RustPython/RustPython/issues/3217

This patch changes the `set`, `frozenset`, `deque` and `bytearray`
collections to use the subclass name in `__repr__`, if they are
subclassed.