### PR TITLE
Fix test_chr by raising a ValueError on chr(-1) instead of OverflowError

### DIFF
--- a/Lib/test/test_builtin.py
+++ b/Lib/test/test_builtin.py
@@ -287,8 +287,6 @@ class BuiltinTest(unittest.TestCase):
         c3 = C3()
         self.assertTrue(callable(c3))
 
-    # TODO: RUSTPYTHON
-    @unittest.expectedFailure
     def test_chr(self):
         self.assertEqual(chr(32), ' ')
         self.assertEqual(chr(65), 'A')

--- a/vm/src/stdlib/builtins.rs
+++ b/vm/src/stdlib/builtins.rs
@@ -35,7 +35,7 @@ mod builtins {
         IdProtocol, ItemProtocol, PyArithmeticValue, PyClassImpl, PyObjectRef, PyRef, PyResult,
         PyValue, TryFromObject, TypeProtocol, VirtualMachine,
     };
-    use num_traits::{Signed, Zero};
+    use num_traits::{Signed, ToPrimitive, Zero};
 
     #[pyfunction]
     fn abs(x: PyObjectRef, vm: &VirtualMachine) -> PyResult {
@@ -87,8 +87,8 @@ mod builtins {
     }
 
     #[pyfunction]
-    fn chr(i: u32, vm: &VirtualMachine) -> PyResult<String> {
-        match std::char::from_u32(i) {
+    fn chr(i: PyIntRef, vm: &VirtualMachine) -> PyResult<String> {
+        match i.as_bigint().to_u32().and_then(char::from_u32) {
             Some(value) => Ok(value.to_string()),
             None => Err(vm.new_value_error("chr() arg not in range(0x110000)".to_owned())),
         }


### PR DESCRIPTION
`test_chr` used to fail on `chr(-1)` because it would fail to convert the -1 to u32 in `try_to_primitive`, raising an OverflowError.

By changing the received value to a `BigInt`, we're able to match [chr's docs](https://docs.python.org/3.8/library/functions.html#chr) and always raise a `ValueError` if the value is out of range. Note that CPython in turn may raise an `OverflowError` if the argument is too high (platform dependent as it depends on int size), even if it's not documented anywhere.

Another option would be to change the received value to `i32`.