### PR TITLE
Fix repr for complex numbers involving NaN

### DIFF
--- a/Lib/test/test_cmath.py
+++ b/Lib/test/test_cmath.py
@@ -160,8 +160,6 @@ class CMathTests(unittest.TestCase):
         self.assertAlmostEqual(cmath.e, e_expected, places=9,
             msg="cmath.e is {}; should be {}".format(cmath.e, e_expected))
 
-    # TODO: RUSTPYTHON
-    @unittest.expectedFailure
     def test_infinity_and_nan_constants(self):
         self.assertEqual(cmath.inf.real, math.inf)
         self.assertEqual(cmath.inf.imag, 0.0)

--- a/Lib/test/test_complex.py
+++ b/Lib/test/test_complex.py
@@ -460,8 +460,6 @@ class ComplexTest(unittest.TestCase):
         for num in nums:
             self.assertAlmostEqual((num.real**2 + num.imag**2)  ** 0.5, abs(num))
 
-    # TODO: RUSTPYTHON
-    @unittest.expectedFailure
     def test_repr_str(self):
         def test(v, expected, test_fn=self.assertEqual):
             test_fn(repr(v), expected)

--- a/vm/src/builtins/complex.rs
+++ b/vm/src/builtins/complex.rs
@@ -305,10 +305,13 @@ impl PyComplex {
     #[pymethod(magic)]
     fn repr(&self) -> String {
         let Complex64 { re, im } = self.value;
+        // converting to lowercase to format "NaN" as "nan"
         if re == 0.0 {
-            format!("{}j", im)
+            format!("{}j", im).to_lowercase()
+        } else if im.is_nan() {
+            format!("({}+{:+}j)", re, im).to_lowercase()
         } else {
-            format!("({}{:+}j)", re, im)
+            format!("({}{:+}j)", re, im).to_lowercase()
         }
     }
 


### PR DESCRIPTION
Using `to_lowercase()` to format "NaN" as "nan" feels a bit hacky. Happy to make changes if there's a better way.