### PR TITLE
Clean up overflow cases.

### DIFF
--- a/stdlib/src/array.rs
+++ b/stdlib/src/array.rs
@@ -31,7 +31,6 @@ mod array {
     use crossbeam_utils::atomic::AtomicCell;
     use itertools::Itertools;
     use lexical_core::Integer;
-    use num_traits::ToPrimitive;
     use std::cmp::Ordering;
     use std::convert::{TryFrom, TryInto};
     use std::{fmt, os::raw};
@@ -1320,11 +1319,7 @@ mod array {
                         obj.class().name()
                     ))
                 })?
-                .as_bigint()
-                .to_i32()
-                .ok_or_else(|| {
-                    vm.new_overflow_error("Python int too large to convert to C int".into())
-                })?
+                .try_to_primitive::<i32>(vm)?
                 .try_u8_or_max()
                 .try_into()
                 .map_err(|_| {

--- a/stdlib/src/bisect.rs
+++ b/stdlib/src/bisect.rs
@@ -6,7 +6,6 @@ mod _bisect {
         function::OptionalArg, slots::PyComparisonOp::Lt, ItemProtocol, PyObjectRef, PyResult,
         VirtualMachine,
     };
-    use num_traits::ToPrimitive;
     use std::convert::TryFrom;
 
     #[derive(FromArgs)]
@@ -26,11 +25,7 @@ mod _bisect {
         vm: &VirtualMachine,
     ) -> PyResult<Option<isize>> {
         Ok(match arg {
-            OptionalArg::Present(v) => {
-                Some(vm.to_index(&v)?.as_bigint().to_isize().ok_or_else(|| {
-                    vm.new_index_error("cannot fit 'int' into an index-sized integer".to_owned())
-                })?)
-            }
+            OptionalArg::Present(v) => Some(vm.to_index(&v)?.try_to_primitive(vm)?),
             OptionalArg::Missing => None,
         })
     }

--- a/vm/src/builtins/int.rs
+++ b/vm/src/builtins/int.rs
@@ -646,9 +646,7 @@ impl PyInt {
             return Err(vm.new_overflow_error("can't convert negative int to unsigned".to_owned()));
         }
 
-        let byte_len = args.length.as_bigint().to_usize().ok_or_else(|| {
-            vm.new_overflow_error("Python int too large to convert to C ssize_t".to_owned())
-        })?;
+        let byte_len = args.length.try_to_primitive(vm)?;
 
         let mut origin_bytes = match (args.byteorder.as_str(), signed) {
             ("big", true) => value.to_signed_bytes_be(),

--- a/vm/src/stdlib/builtins.rs
+++ b/vm/src/stdlib/builtins.rs
@@ -88,7 +88,11 @@ mod builtins {
 
     #[pyfunction]
     fn chr(i: PyIntRef, vm: &VirtualMachine) -> PyResult<String> {
-        match i.as_bigint().to_u32().and_then(char::from_u32) {
+        match i
+            .try_to_primitive::<isize>(vm)?
+            .to_u32()
+            .and_then(char::from_u32)
+        {
             Some(value) => Ok(value.to_string()),
             None => Err(vm.new_value_error("chr() arg not in range(0x110000)".to_owned())),
         }

--- a/vm/src/stdlib/itertools.rs
+++ b/vm/src/stdlib/itertools.rs
@@ -269,10 +269,7 @@ mod decl {
         ) -> PyResult {
             let times = match times.into_option() {
                 Some(int) => {
-                    let val = int.as_bigint();
-                    if *val > BigInt::from(sys::MAXSIZE) {
-                        return Err(vm.new_overflow_error("Cannot fit in isize.".to_owned()));
-                    }
+                    let val: isize = int.try_to_primitive(vm)?;
                     // times always >= 0.
                     Some(PyRwLock::new(val.to_usize().unwrap_or(0)))
                 }


### PR DESCRIPTION
by using `try_to_primitive`. There's probably other cases where the error is explicitly handled yet.