### PR TITLE
Ignore CPython specific testing/template modules. 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,4 +18,4 @@ flamescope.json
 /.cargo/config
 
 extra_tests/snippets/resources
-extra_tests/snippets/not_impl.py
+extra_tests/not_impl.py

--- a/extra_tests/not_impl_gen.py
+++ b/extra_tests/not_impl_gen.py
@@ -379,5 +379,5 @@ def remove_one_indent(s):
 compare_src = inspect.getsourcelines(compare)[0][1:]
 output += "".join(remove_one_indent(line) for line in compare_src)
 
-with open("snippets/not_impl.py", "w") as f:
+with open("not_impl.py", "w") as f:
     f.write(output + "\n")

--- a/whats_left.sh
+++ b/whats_left.sh
@@ -26,4 +26,4 @@ fi
 # run whats_left
 cargo build --release
 
-cargo run --release -q -- extra_tests/snippets/not_impl.py
+cargo run --release -q -- extra_tests/not_impl.py


### PR DESCRIPTION
which aren't directly applicable for RustPython. (I've added [skip ci], since this isn't tested anywhere and a run would be pointless)