### PR TITLE
Add rxor, rand, ror and rsub operators in dict_keys

### DIFF
--- a/Lib/test/test_dict.py
+++ b/Lib/test/test_dict.py
@@ -642,8 +642,6 @@ class DictTest(unittest.TestCase):
         with self.assertRaises(RuntimeError):
             d3.items() > d2.items()
 
-    # TODO: RUSTPYTHON
-    @unittest.expectedFailure
     def test_dictview_set_operations_on_keys(self):
         k1 = {1:1, 2:2}.keys()
         k2 = {1:1, 2:2, 3:3}.keys()

--- a/vm/src/builtins/dict.rs
+++ b/vm/src/builtins/dict.rs
@@ -912,7 +912,39 @@ dict_view! {
 }
 
 #[pyimpl(with(DictView, Comparable, Iterable))]
-impl PyDictKeys {}
+impl PyDictKeys {
+    #[pymethod(name = "__rxor__")]
+    #[pymethod(magic)]
+    fn xor(zelf: PyRef<Self>, other: ArgIterable, vm: &VirtualMachine) -> PyResult<PySet> {
+        let zelf = Self::to_set(zelf, vm)?;
+        let inner = zelf.symmetric_difference(other, vm)?;
+        Ok(PySet { inner })
+    }
+
+    #[pymethod(name = "__rand__")]
+    #[pymethod(magic)]
+    fn and(zelf: PyRef<Self>, other: ArgIterable, vm: &VirtualMachine) -> PyResult<PySet> {
+        let zelf = Self::to_set(zelf, vm)?;
+        let inner = zelf.intersection(other, vm)?;
+        Ok(PySet { inner })
+    }
+
+    #[pymethod(name = "__ror__")]
+    #[pymethod(magic)]
+    fn or(zelf: PyRef<Self>, other: ArgIterable, vm: &VirtualMachine) -> PyResult<PySet> {
+        let zelf = Self::to_set(zelf, vm)?;
+        let inner = zelf.union(other, vm)?;
+        Ok(PySet { inner })
+    }
+
+    #[pymethod(name = "__rsub__")]
+    #[pymethod(magic)]
+    fn sub(zelf: PyRef<Self>, other: ArgIterable, vm: &VirtualMachine) -> PyResult<PySet> {
+        let zelf = Self::to_set(zelf, vm)?;
+        let inner = zelf.difference(other, vm)?;
+        Ok(PySet { inner })
+    }
+}
 
 #[pyimpl(with(DictView, Comparable, Iterable))]
 impl PyDictValues {}


### PR DESCRIPTION
ref #3249

Added `PyDictKeys::{xor, and, or, sub}` and removed expected failure test annotation from `test_dictview_set_operations_on_keys`.