### PR TITLE
migrate TryIntoRef to IntoPyStrRef 

### DIFF
--- a/vm/src/builtins/pystr.rs
+++ b/vm/src/builtins/pystr.rs
@@ -16,7 +16,7 @@ use crate::{
     stdlib::sys,
     utils::Either,
     IdProtocol, ItemProtocol, PyClassDef, PyClassImpl, PyComparisonValue, PyContext, PyObjectRef,
-    PyRef, PyResult, PyValue, TryIntoRef, TypeProtocol, VirtualMachine,
+    PyRef, PyResult, PyValue, TypeProtocol, VirtualMachine,
 };
 use ascii::{AsciiStr, AsciiString};
 use bstr::ByteSlice;
@@ -169,23 +169,41 @@ impl fmt::Display for PyStr {
     }
 }
 
-impl TryIntoRef<PyStr> for AsciiString {
+pub trait IntoPyStrRef {
+    fn into_pystr_ref(self, vm: &VirtualMachine) -> PyStrRef;
+}
+
+impl IntoPyStrRef for PyStrRef {
     #[inline]
-    fn try_into_ref(self, vm: &VirtualMachine) -> PyRef<PyStr> {
-        unsafe { PyStr::new_ascii_unchecked(self.into()) }.into_ref(vm)
+    fn into_pystr_ref(self, _vm: &VirtualMachine) -> PyRef<PyStr> {
+        self
     }
 }
 
-impl TryIntoRef<PyStr> for String {
+impl IntoPyStrRef for PyStr {
     #[inline]
-    fn try_into_ref(self, vm: &VirtualMachine) -> PyRef<PyStr> {
+    fn into_pystr_ref(self, vm: &VirtualMachine) -> PyRef<PyStr> {
+        self.into_ref(vm)
+    }
+}
+
+impl IntoPyStrRef for AsciiString {
+    #[inline]
+    fn into_pystr_ref(self, vm: &VirtualMachine) -> PyRef<PyStr> {
         PyStr::from(self).into_ref(vm)
     }
 }
 
-impl TryIntoRef<PyStr> for &str {
+impl IntoPyStrRef for String {
     #[inline]
-    fn try_into_ref(self, vm: &VirtualMachine) -> PyRef<PyStr> {
+    fn into_pystr_ref(self, vm: &VirtualMachine) -> PyRef<PyStr> {
+        PyStr::from(self).into_ref(vm)
+    }
+}
+
+impl IntoPyStrRef for &str {
+    #[inline]
+    fn into_pystr_ref(self, vm: &VirtualMachine) -> PyRef<PyStr> {
         PyStr::from(self).into_ref(vm)
     }
 }

--- a/vm/src/builtins/pystr.rs
+++ b/vm/src/builtins/pystr.rs
@@ -171,22 +171,22 @@ impl fmt::Display for PyStr {
 
 impl TryIntoRef<PyStr> for AsciiString {
     #[inline]
-    fn try_into_ref(self, vm: &VirtualMachine) -> PyResult<PyRef<PyStr>> {
-        Ok(unsafe { PyStr::new_ascii_unchecked(self.into()) }.into_ref(vm))
+    fn try_into_ref(self, vm: &VirtualMachine) -> PyRef<PyStr> {
+        unsafe { PyStr::new_ascii_unchecked(self.into()) }.into_ref(vm)
     }
 }
 
 impl TryIntoRef<PyStr> for String {
     #[inline]
-    fn try_into_ref(self, vm: &VirtualMachine) -> PyResult<PyRef<PyStr>> {
-        Ok(PyStr::from(self).into_ref(vm))
+    fn try_into_ref(self, vm: &VirtualMachine) -> PyRef<PyStr> {
+        PyStr::from(self).into_ref(vm)
     }
 }
 
 impl TryIntoRef<PyStr> for &str {
     #[inline]
-    fn try_into_ref(self, vm: &VirtualMachine) -> PyResult<PyRef<PyStr>> {
-        Ok(PyStr::from(self).into_ref(vm))
+    fn try_into_ref(self, vm: &VirtualMachine) -> PyRef<PyStr> {
+        PyStr::from(self).into_ref(vm)
     }
 }
 

--- a/vm/src/builtins/slice.rs
+++ b/vm/src/builtins/slice.rs
@@ -4,8 +4,8 @@ use super::{PyInt, PyIntRef, PyTupleRef, PyTypeRef};
 use crate::{
     function::{FuncArgs, IntoPyObject, OptionalArg},
     slots::{Comparable, Hashable, PyComparisonOp, SlotConstructor, Unhashable},
-    PyClassImpl, PyComparisonValue, PyContext, PyObjectRef, PyRef, PyResult, PyValue, TryIntoRef,
-    TypeProtocol, VirtualMachine,
+    PyClassImpl, PyComparisonValue, PyContext, PyObjectRef, PyRef, PyResult, PyValue, TypeProtocol,
+    VirtualMachine,
 };
 use num_bigint::{BigInt, ToBigInt};
 use num_traits::{One, Signed, Zero};
@@ -131,7 +131,7 @@ impl PySlice {
             step = One::one();
         } else {
             // Clone the value, not the reference.
-            let this_step: PyRef<PyInt> = self.step(vm).try_into_ref(vm)?;
+            let this_step: PyRef<PyInt> = self.step(vm).try_into_value(vm)?;
             step = this_step.as_bigint().clone();
 
             if step.is_zero() {
@@ -165,7 +165,7 @@ impl PySlice {
                 lower.clone()
             };
         } else {
-            let this_start: PyRef<PyInt> = self.start(vm).try_into_ref(vm)?;
+            let this_start: PyRef<PyInt> = self.start(vm).try_into_value(vm)?;
             start = this_start.as_bigint().clone();
 
             if start < Zero::zero() {
@@ -185,7 +185,7 @@ impl PySlice {
         if vm.is_none(&self.stop) {
             stop = if backwards { lower } else { upper };
         } else {
-            let this_stop: PyRef<PyInt> = self.stop(vm).try_into_ref(vm)?;
+            let this_stop: PyRef<PyInt> = self.stop(vm).try_into_value(vm)?;
             stop = this_stop.as_bigint().clone();
 
             if stop < Zero::zero() {

--- a/vm/src/builtins/weakproxy.rs
+++ b/vm/src/builtins/weakproxy.rs
@@ -47,14 +47,14 @@ impl SlotConstructor for PyWeakProxy {
 impl PyWeakProxy {
     // TODO: callbacks
     #[pymethod(magic)]
-    fn getattr(&self, attr_name: PyObjectRef, vm: &VirtualMachine) -> PyResult {
-        match self.weak.upgrade() {
-            Some(obj) => vm.get_attribute(obj, attr_name),
-            None => Err(vm.new_exception_msg(
+    fn getattr(&self, attr_name: PyStrRef, vm: &VirtualMachine) -> PyResult {
+        let obj = self.weak.upgrade().ok_or_else(|| {
+            vm.new_exception_msg(
                 vm.ctx.exceptions.reference_error.clone(),
                 "weakly-referenced object no longer exists".to_owned(),
-            )),
-        }
+            )
+        })?;
+        vm.get_attribute(obj, attr_name)
     }
 }
 

--- a/vm/src/pyobject.rs
+++ b/vm/src/pyobject.rs
@@ -626,15 +626,6 @@ impl<T: PyObjectPayload> TryIntoRef<T> for PyRef<T> {
     }
 }
 
-impl<T> TryIntoRef<T> for PyObjectRef
-where
-    T: PyValue,
-{
-    fn try_into_ref(self, vm: &VirtualMachine) -> PyResult<PyRef<T>> {
-        TryFromObject::try_from_object(vm, self)
-    }
-}
-
 /// Implemented by any type that can be created from a Python object.
 ///
 /// Any type that implements `TryFromObject` is automatically `FromArgs`, and

--- a/vm/src/pyobject.rs
+++ b/vm/src/pyobject.rs
@@ -407,11 +407,6 @@ impl<T: PyValue> IntoPyObject for PyRefExact<T> {
         self.obj.into()
     }
 }
-impl<T: PyValue> TryIntoRef<T> for PyRefExact<T> {
-    fn try_into_ref(self, _vm: &VirtualMachine) -> PyRef<T> {
-        self.obj
-    }
-}
 
 pub trait IdProtocol {
     fn get_id(&self) -> usize;
@@ -610,19 +605,6 @@ impl<T: TryFromObject> TryFromObject for Option<T> {
         } else {
             T::try_from_object(vm, obj).map(Some)
         }
-    }
-}
-
-/// Allows coercion of a types into PyRefs, so that we can write functions that can take
-/// refs, pyobject refs or basic types.
-pub trait TryIntoRef<T: PyObjectPayload> {
-    fn try_into_ref(self, vm: &VirtualMachine) -> PyRef<T>;
-}
-
-impl<T: PyObjectPayload> TryIntoRef<T> for PyRef<T> {
-    #[inline]
-    fn try_into_ref(self, _vm: &VirtualMachine) -> PyRef<T> {
-        self
     }
 }
 

--- a/vm/src/pyobject.rs
+++ b/vm/src/pyobject.rs
@@ -408,8 +408,8 @@ impl<T: PyValue> IntoPyObject for PyRefExact<T> {
     }
 }
 impl<T: PyValue> TryIntoRef<T> for PyRefExact<T> {
-    fn try_into_ref(self, _vm: &VirtualMachine) -> PyResult<PyRef<T>> {
-        Ok(self.obj)
+    fn try_into_ref(self, _vm: &VirtualMachine) -> PyRef<T> {
+        self.obj
     }
 }
 
@@ -616,13 +616,13 @@ impl<T: TryFromObject> TryFromObject for Option<T> {
 /// Allows coercion of a types into PyRefs, so that we can write functions that can take
 /// refs, pyobject refs or basic types.
 pub trait TryIntoRef<T: PyObjectPayload> {
-    fn try_into_ref(self, vm: &VirtualMachine) -> PyResult<PyRef<T>>;
+    fn try_into_ref(self, vm: &VirtualMachine) -> PyRef<T>;
 }
 
 impl<T: PyObjectPayload> TryIntoRef<T> for PyRef<T> {
     #[inline]
-    fn try_into_ref(self, _vm: &VirtualMachine) -> PyResult<PyRef<T>> {
-        Ok(self)
+    fn try_into_ref(self, _vm: &VirtualMachine) -> PyRef<T> {
+        self
     }
 }
 

--- a/vm/src/scope.rs
+++ b/vm/src/scope.rs
@@ -1,9 +1,9 @@
+use crate::{
+    builtins::{pystr::IntoPyStrRef, PyDictRef, PyStrRef},
+    function::IntoPyObject,
+    ItemProtocol, VirtualMachine,
+};
 use std::fmt;
-
-use crate::builtins::{PyDictRef, PyStr, PyStrRef};
-use crate::function::IntoPyObject;
-use crate::VirtualMachine;
-use crate::{ItemProtocol, TryIntoRef};
 
 #[derive(Clone)]
 pub struct Scope {
@@ -145,7 +145,7 @@ mod sealed {
     impl Sealed for super::PyStrRef {}
 }
 pub trait PyName:
-    sealed::Sealed + crate::dictdatatype::DictKey + Clone + IntoPyObject + TryIntoRef<PyStr>
+    sealed::Sealed + crate::dictdatatype::DictKey + Clone + IntoPyObject + IntoPyStrRef
 {
 }
 impl PyName for &str {}

--- a/vm/src/stdlib/errno.rs
+++ b/vm/src/stdlib/errno.rs
@@ -7,9 +7,11 @@ pub fn make_module(vm: &VirtualMachine) -> PyObjectRef {
         "errorcode" => errorcode.clone(),
     });
     for (name, code) in ERROR_CODES {
-        let name = vm.new_pyobj(*name);
+        let name = vm.ctx.new_str(*name);
         let code = vm.new_pyobj(*code);
-        errorcode.set_item(code.clone(), name.clone(), vm).unwrap();
+        errorcode
+            .set_item(code.clone(), name.clone().into(), vm)
+            .unwrap();
         vm.set_attr(&module, name, code).unwrap();
     }
     module

--- a/vm/src/stdlib/operator.rs
+++ b/vm/src/stdlib/operator.rs
@@ -21,7 +21,7 @@ mod _operator {
         },
         utils::Either,
         vm::ReprGuard,
-        IdProtocol, ItemProtocol, PyObjectRef, PyRef, PyResult, PyValue, TryIntoRef, TypeProtocol,
+        IdProtocol, ItemProtocol, PyObjectRef, PyRef, PyResult, PyValue, TypeProtocol,
         VirtualMachine,
     };
 
@@ -444,7 +444,7 @@ mod _operator {
             }
             let mut attrs = Vec::with_capacity(nattr);
             for o in args.args {
-                if let Ok(r) = o.try_into_ref(vm) {
+                if let Ok(r) = o.try_into_value(vm) {
                     attrs.push(r);
                 } else {
                     return Err(vm.new_type_error("attribute name must be a string".to_owned()));
@@ -598,7 +598,7 @@ mod _operator {
         type Args = (PyObjectRef, FuncArgs);
 
         fn py_new(cls: PyTypeRef, (name, args): Self::Args, vm: &VirtualMachine) -> PyResult {
-            if let Ok(name) = name.try_into_ref(vm) {
+            if let Ok(name) = name.try_into_value(vm) {
                 PyMethodCaller { name, args }.into_pyresult_with_type(vm, cls)
             } else {
                 Err(vm.new_type_error("method name must be a string".to_owned()))

--- a/vm/src/vm.rs
+++ b/vm/src/vm.rs
@@ -788,7 +788,7 @@ impl VirtualMachine {
     ) -> PyBaseExceptionRef {
         let import_error = self.ctx.exceptions.import_error.clone();
         let exc = self.new_exception_msg(import_error, msg);
-        self.set_attr(exc.as_object(), "name", name.try_into_ref(self).unwrap())
+        self.set_attr(exc.as_object(), "name", name.try_into_ref(self))
             .unwrap();
         exc
     }
@@ -921,7 +921,7 @@ impl VirtualMachine {
         from_list: Option<PyTupleTyped<PyStrRef>>,
         level: usize,
     ) -> PyResult {
-        self._import_inner(module.try_into_ref(self)?, from_list, level)
+        self._import_inner(module.try_into_ref(self), from_list, level)
     }
 
     fn _import_inner(
@@ -1366,7 +1366,7 @@ impl VirtualMachine {
     where
         T: TryIntoRef<PyStr>,
     {
-        let attr_name = attr_name.try_into_ref(self)?;
+        let attr_name = attr_name.try_into_ref(self);
         vm_trace!("vm.__getattribute__: {:?} {:?}", obj, attr_name);
         let getattro = obj
             .class()
@@ -1419,12 +1419,12 @@ impl VirtualMachine {
         K: TryIntoRef<PyStr>,
         V: Into<PyObjectRef>,
     {
-        let attr_name = attr_name.try_into_ref(self)?;
+        let attr_name = attr_name.try_into_ref(self);
         self.call_set_attr(obj, attr_name, Some(attr_value.into()))
     }
 
     pub fn del_attr(&self, obj: &PyObjectRef, attr_name: impl TryIntoRef<PyStr>) -> PyResult<()> {
-        let attr_name = attr_name.try_into_ref(self)?;
+        let attr_name = attr_name.try_into_ref(self);
         self.call_set_attr(obj, attr_name, None)
     }
 
@@ -2138,7 +2138,7 @@ impl VirtualMachine {
         attr_value: impl Into<PyObjectRef>,
     ) -> PyResult<()> {
         let val = attr_value.into();
-        object::setattr(module, attr_name.try_into_ref(self)?, Some(val), self)
+        object::setattr(module, attr_name.try_into_ref(self), Some(val), self)
     }
 }
 


### PR DESCRIPTION
For downcasting from `PyObjectRef`, `PyObjectRef::try_into_value` covers it. So it is duplication of features.

For converting to `PyValue`, implenting `Into` works well. Maybe we could add `IntoPyRef` for same usage later.

In spite of these reasons, `IntoPyRef<PyStr>` is widely used for convenient accessing to python maps. So I am keeping it for now.