### PR TITLE
Add .mailmap

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -1,0 +1,8 @@
+#
+# This list is used by git-shortlog to aggregate contributions.  It is
+# necessary when either the author's full name is not always written
+# the same way, and/or the same author contributes from different
+# email addresses.
+#
+
+Noa <33094578+coolreader18@users.noreply.github.com>


### PR DESCRIPTION
`.mailmap` makes sure that contributor emails are mapped to correct full names, regardless of the author-/comitter-name on the commit: https://git-scm.com/docs/gitmailmap

The note at the top is taken from rust-lang/rust's mailmap file.
