### PR TITLE
Add missing `SlotGetattro` for `GenericAlias`

### DIFF
--- a/vm/src/builtins/genericalias.rs
+++ b/vm/src/builtins/genericalias.rs
@@ -52,7 +52,7 @@ impl SlotConstructor for PyGenericAlias {
     }
 }
 
-#[pyimpl(with(Hashable, SlotGetattro), flags(BASETYPE))]
+#[pyimpl(with(Hashable, SlotConstructor, SlotGetattro), flags(BASETYPE))]
 impl PyGenericAlias {
     pub fn new(origin: PyTypeRef, args: PyObjectRef, vm: &VirtualMachine) -> Self {
         let args: PyTupleRef = if let Ok(tuple) = PyTupleRef::try_from_object(vm, args.clone()) {


### PR DESCRIPTION
This revision implements `SlotGetattro` for `GenericAlias` in `types` module.
In addition, `SlotConstructor` was missing in `#[pyimpl]` for `GenericAlias`. I fixed it