### PR TITLE
Handle recursions when comparing objects.

### DIFF
--- a/Lib/test/test_copy.py
+++ b/Lib/test/test_copy.py
@@ -370,7 +370,6 @@ class TestCopy(unittest.TestCase):
         self.assertIsNot(x, y)
         self.assertIsNot(x[0], y[0])
 
-    @unittest.skip("TODO: RUSTPYTHON, segmentation fault")
     def test_deepcopy_reflexive_list(self):
         x = []
         x.append(x)
@@ -398,7 +397,6 @@ class TestCopy(unittest.TestCase):
         y = copy.deepcopy(x)
         self.assertIs(x, y)
 
-    @unittest.skip("TODO: RUSTPYTHON, segmentation fault")
     def test_deepcopy_reflexive_tuple(self):
         x = ([],)
         x[0].append(x)
@@ -416,7 +414,6 @@ class TestCopy(unittest.TestCase):
         self.assertIsNot(x, y)
         self.assertIsNot(x["foo"], y["foo"])
 
-    @unittest.skip("TODO: RUSTPYTHON, segmentation fault")
     def test_deepcopy_reflexive_dict(self):
         x = {}
         x['foo'] = x

--- a/vm/src/vm.rs
+++ b/vm/src/vm.rs
@@ -1873,8 +1873,6 @@ impl VirtualMachine {
         op: PyComparisonOp,
     ) -> PyResult<Either<PyObjectRef, bool>> {
         let swapped = op.swapped();
-        // TODO: _Py_EnterRecursiveCall(tstate, " in comparison")
-
         let call_cmp = |obj: &PyObjectRef, other, op| {
             let cmp = obj
                 .class()
@@ -1893,17 +1891,19 @@ impl VirtualMachine {
             !v_class.is(&w_class) && w_class.issubclass(&v_class)
         };
         if is_strict_subclass {
-            let res = call_cmp(w, v, swapped)?;
+            let res = self.with_recursion("in comparison", || call_cmp(w, v, swapped))?;
             checked_reverse_op = true;
             if let PyArithmeticValue::Implemented(x) = res {
                 return Ok(x);
             }
         }
-        if let PyArithmeticValue::Implemented(x) = call_cmp(v, w, op)? {
+        if let PyArithmeticValue::Implemented(x) =
+            self.with_recursion("in comparison", || call_cmp(v, w, op))?
+        {
             return Ok(x);
         }
         if !checked_reverse_op {
-            let res = call_cmp(w, v, swapped)?;
+            let res = self.with_recursion("in comparison", || call_cmp(w, v, swapped))?;
             if let PyArithmeticValue::Implemented(x) = res {
                 return Ok(x);
             }
@@ -1913,7 +1913,6 @@ impl VirtualMachine {
             PyComparisonOp::Ne => Ok(Either::B(!v.is(&w))),
             _ => Err(self.new_unsupported_binop_error(v, w, op.operator_token())),
         }
-        // TODO: _Py_LeaveRecursiveCall(tstate);
     }
 
     pub fn bool_cmp(&self, a: &PyObjectRef, b: &PyObjectRef, op: PyComparisonOp) -> PyResult<bool> {


### PR DESCRIPTION
there might be other test cases that now don't hang but I couldn't find them.