### PR TITLE
Guarantee recursion_depth is never higher than recursion_limit

### DIFF
--- a/vm/src/stdlib/sys.rs
+++ b/vm/src/stdlib/sys.rs
@@ -479,7 +479,7 @@ mod sys {
             })?;
         let recursion_depth = vm.current_recursion_depth();
 
-        if recursion_limit > recursion_depth + 1 {
+        if recursion_limit > recursion_depth {
             vm.recursion_limit.set(recursion_limit);
             Ok(())
         } else {

--- a/vm/src/vm.rs
+++ b/vm/src/vm.rs
@@ -538,8 +538,9 @@ impl VirtualMachine {
         self.with_frame(frame, |f| f.run(self))
     }
 
+    // To be called right before raising the recursion depth.
     fn check_recursive_call(&self, _where: &str) -> PyResult<()> {
-        if self.recursion_depth.get() > self.recursion_limit.get() {
+        if self.recursion_depth.get() >= self.recursion_limit.get() {
             Err(self.new_recursion_error(format!("maximum recursion depth exceeded {}", _where)))
         } else {
             Ok(())


### PR DESCRIPTION
Found very small improvements on the recursion stuff after last PR. Although not essential, I think it's easier to reason about it this way:

Since `check_recursive_call` is called BEFORE incrementing the recursion_depth, I've changed the comparison from `>` to `>=` (and also reordered to be closer to the call site). This way, we can guarantee the recursion_depth is never higher than the limit.

In `sys.rs`, I've removed the + 1, matching the CPython behavior, refusing the new `recursion_limit` only if it the depth has reached the new limit already, but not if `recursion_depth == recursion_limit - 1`.