### PR TITLE
CI runs platform-independent and platform-dependent tests separately

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -142,20 +142,24 @@ jobs:
         run: pipenv run pytest -v
         working-directory: ./extra_tests
       - if: runner.os == 'Linux'
-        name: run cpython tests
-        run: target/release/rustpython -m test -v
-      - if: runner.os == 'macOS'
-        name: run cpython tests (macOS lightweight)
+        name: run cpython platform-independent tests
         run:
           target/release/rustpython -m test -v
+            test_argparse test_json test_bytes test_long test_unicode test_array
+            test_asyncgen test_list test_complex test_json test_set test_dis test_calendar
+      - if: runner.os != 'Windows'
+        name: run cpython platform-dependent tests
+        run: target/release/rustpython -m test -v -x
+            test_argparse test_json test_bytes test_long test_unicode test_array
+            test_asyncgen test_list test_complex test_json test_set test_dis test_calendar
       - if: runner.os == 'Windows'
-        name: run cpython tests (windows partial - fixme)
+        name: run cpython platform-dependent tests (windows partial - fixme)
         run:
           target/release/rustpython -m test -v -x
-            test_argparse test_json test_bytes test_long test_pwd test_bool test_cgi test_complex
-            test_exception_hierarchy test_glob test_iter test_list test_os test_pathlib
-            test_py_compile test_set test_shutil test_sys test_unicode test_unittest test_venv
-            test_zipimport test_importlib test_io
+            test_argparse test_json test_bytes test_long test_unicode test_array
+            test_asyncgen test_list test_complex test_json test_set test_dis test_calendar
+            test_pwd test_bool test_cgi test_exception_hierarchy test_glob test_iter test_os test_pathlib
+            test_py_compile test_set test_shutil test_sys test_unittest test_venv test_zipimport test_importlib test_io
       - if: runner.os == 'Linux'
         name: check that --install-pip succeeds
         run: |


### PR DESCRIPTION
#2584  allowed to run all macOS tests, but it is not preferred due to CI cost.

Now CI job is separated, so it will be easier to detect the segments.

cc @fanninpm 