### PR TITLE
Allow non-types as metaclass argument.

### DIFF
--- a/Lib/test/test_types.py
+++ b/Lib/test/test_types.py
@@ -987,8 +987,6 @@ class ClassCreationTests(unittest.TestCase):
         self.assertIs(ns, expected_ns)
         self.assertEqual(len(kwds), 0)
 
-    # TODO: RUSTPYTHON
-    @unittest.expectedFailure
     def test_bad___prepare__(self):
         # __prepare__() must return a mapping.
         class BadMeta(type):


### PR DESCRIPTION
Passing an object as a value for `metaclass` in a class statement shouldn't error. Unfortunately, `__prepare__` isn't currently found for objects so this work isn't complete yet.