### PR TITLE
Cleanup lists of tests in ci.yaml

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -177,7 +177,6 @@ jobs:
             test_pathlib
             test_pwd
             test_py_compile
-            test_set
             test_shutil
             test_sys
             test_unittest


### PR DESCRIPTION
I deduplicated the list of platform-independent tests and sequestered it to an environment variable for reusability. I then sorted the resulting two lists (platform-independent and Windows-only) and took out duplicate entries of `test_json` and `test_set`.
