### PR TITLE
set repr push to buffer directly

### DIFF
--- a/vm/src/builtins/set.rs
+++ b/vm/src/builtins/set.rs
@@ -209,39 +209,30 @@ impl PySetInner {
     }
 
     fn repr(&self, class_name: Option<&str>, vm: &VirtualMachine) -> PyResult<String> {
-        let mut repr_len = class_name.map_or(0, |name| name.len() + 2);
-        let mut parts = Vec::with_capacity(self.content.len());
-        for key in self.elements() {
-            let part = vm.to_repr(&key)?;
-            repr_len += part.as_str().len() + 2;
-            parts.push(part);
-        }
-        let (parts, repr_len) = (parts, repr_len);
-
-        let mut repr = String::with_capacity(repr_len);
+        let mut repr = String::new();
         if let Some(name) = class_name {
             repr.push_str(name);
             repr.push('(');
         }
         repr.push('{');
         {
-            let mut parts_iter = parts.into_iter();
+            let mut parts_iter = self.elements().into_iter().map(|o| vm.to_repr(&o));
             repr.push_str(
                 parts_iter
                     .next()
+                    .transpose()?
                     .expect("this is not called for empty set")
                     .as_str(),
             );
             for part in parts_iter {
                 repr.push_str(", ");
-                repr.push_str(part.as_str());
+                repr.push_str(part?.as_str());
             }
         }
         repr.push('}');
         if class_name.is_some() {
             repr.push(')');
         }
-        debug_assert_eq!(repr.len(), repr_len);
 
         Ok(repr)
     }


### PR DESCRIPTION
So, everything was wrong.
Allocating parts vector is useless.
Performance regression came from parts.
`format!`s and `join` looks somehow working well.

the best manually written version with parts vector didn't have any difference from original version