### PR TITLE
stdlib/os.rs: update wrong-type exception text for __fspath__

### DIFF
--- a/Lib/test/test_posix.py
+++ b/Lib/test/test_posix.py
@@ -603,8 +603,6 @@ class PosixTester(unittest.TestCase):
                               os.O_RDONLY|os.O_EXLOCK|os.O_NONBLOCK)
             os.close(fd)
 
-    # TODO: RUSTPYTHON: AssertionError: "should be string, bytes, os.PathLike or integer, not" does not match "expected str, bytes or os.PathLike object, not 'float'"
-    @unittest.expectedFailure
     @unittest.skipUnless(hasattr(posix, 'fstat'),
                          'test needs posix.fstat()')
     def test_fstat(self):

--- a/vm/src/stdlib/os.rs
+++ b/vm/src/stdlib/os.rs
@@ -139,7 +139,7 @@ impl FsPath {
         };
         let method = vm.get_method_or_type_error(obj.clone(), "__fspath__", || {
             format!(
-                "expected str, bytes or os.PathLike object, not {}",
+                "should be string, bytes, os.PathLike or integer, not {}",
                 obj.class().name()
             )
         })?;


### PR DESCRIPTION
In CPython this error message is constructed by path_converter in
posixmodule.c[0].

[0] https://github.com/python/cpython/blob/main/Modules/posixmodule.c#L1260