### PR TITLE
cformat.rs: fixes to get two test_format.py tests passing

### DIFF
--- a/Lib/test/test_format.py
+++ b/Lib/test/test_format.py
@@ -284,8 +284,6 @@ class FormatTest(unittest.TestCase):
         test_exc_common('%x', 3.14, TypeError,
                         "%x format: an integer is required, not float")
 
-    # TODO: RUSTPYTHON
-    @unittest.expectedFailure
     def test_str_format(self):
         testformat("%r", "\u0378", "'\\u0378'")  # non printable
         testformat("%a", "\u0378", "'\\u0378'")  # non printable

--- a/Lib/test/test_format.py
+++ b/Lib/test/test_format.py
@@ -317,8 +317,6 @@ class FormatTest(unittest.TestCase):
             else:
                 raise TestFailed('"%*d"%(maxsize, -127) should fail')
 
-    # TODO: RUSTPYTHON
-    @unittest.expectedFailure
     def test_bytes_and_bytearray_format(self):
         # %c will insert a single byte, either from an int in range(256), or
         # from a bytes argument of length 1, not from a str.

--- a/vm/src/cformat.rs
+++ b/vm/src/cformat.rs
@@ -177,7 +177,7 @@ impl CFormatSpec {
             Some(CFormatQuantity::Amount(width)) => cmp::max(width, num_chars),
             _ => num_chars,
         };
-        let fill_chars_needed = width - num_chars;
+        let fill_chars_needed = width.saturating_sub(num_chars);
         let fill_string = CFormatSpec::compute_fill_string(fill_char, fill_chars_needed);
 
         if !fill_string.is_empty() {
@@ -563,7 +563,7 @@ fn try_update_quantity_from_tuple<'a, I: Iterator<Item = &'a PyObjectRef>>(
         Some(CFormatQuantity::FromValuesTuple) => match elements.next() {
             Some(width_obj) => {
                 if let Some(i) = width_obj.payload::<PyInt>() {
-                    let i = i.try_to_primitive::<isize>(vm)? as usize;
+                    let i = i.try_to_primitive::<isize>(vm)?.abs() as usize;
                     *q = Some(CFormatQuantity::Amount(i));
                     Ok(())
                 } else {
@@ -917,7 +917,7 @@ where
                     break;
                 }
             }
-            return Ok(Some(CFormatQuantity::Amount(num as usize)));
+            return Ok(Some(CFormatQuantity::Amount(num.abs() as usize)));
         }
     }
     Ok(None)

--- a/vm/src/cformat.rs
+++ b/vm/src/cformat.rs
@@ -666,7 +666,8 @@ impl CFormatBytes {
 
         let is_mapping = values_obj.class().has_attr("__getitem__")
             && !values_obj.isinstance(&vm.ctx.types.tuple_type)
-            && !values_obj.isinstance(&vm.ctx.types.str_type);
+            && !values_obj.isinstance(&vm.ctx.types.bytes_type)
+            && !values_obj.isinstance(&vm.ctx.types.bytearray_type);
 
         if num_specifiers == 0 {
             // literal only

--- a/vm/src/cformat.rs
+++ b/vm/src/cformat.rs
@@ -360,10 +360,11 @@ impl CFormatSpec {
     fn bytes_format(&self, vm: &VirtualMachine, obj: PyObjectRef) -> PyResult<Vec<u8>> {
         match &self.format_type {
             CFormatType::String(preconversor) => match preconversor {
+                // Unlike strings, %r and %a are identical for bytes: the behaviour corresponds to
+                // %a for strings (not %r)
                 CFormatPreconversor::Repr | CFormatPreconversor::Ascii => {
-                    let s = obj.repr(vm)?;
-                    let s = self.format_string(s.as_str().to_owned());
-                    Ok(s.into_bytes())
+                    let b = builtins::ascii(obj, vm)?.into();
+                    Ok(b)
                 }
                 CFormatPreconversor::Str | CFormatPreconversor::Bytes => {
                     if let Ok(buffer) = PyBuffer::try_from_borrowed_object(vm, &obj) {

--- a/vm/src/cformat.rs
+++ b/vm/src/cformat.rs
@@ -440,12 +440,9 @@ impl CFormatSpec {
             CFormatType::Character => {
                 if let Some(i) = obj.payload::<PyInt>() {
                     let ch = i
-                        .as_bigint()
-                        .to_u32()
-                        .and_then(std::char::from_u32)
-                        .ok_or_else(|| {
-                            vm.new_overflow_error("%c arg not in range(0x110000)".to_owned())
-                        })?;
+                        .try_to_primitive::<u8>(vm)
+                        .map_err(|_| vm.new_overflow_error("%c arg not in range(256)".to_owned()))?
+                        as char;
                     return Ok(self.format_char(ch).into_bytes());
                 }
                 if let Some(b) = obj.payload::<PyBytes>() {

--- a/vm/src/cformat.rs
+++ b/vm/src/cformat.rs
@@ -684,7 +684,7 @@ impl CFormatBytes {
                 Ok(result)
             } else {
                 Err(vm.new_type_error(
-                    "not all arguments converted during string formatting".to_owned(),
+                    "not all arguments converted during bytes formatting".to_owned(),
                 ))
             };
         }
@@ -740,8 +740,7 @@ impl CFormatBytes {
 
         // check that all arguments were converted
         if value_iter.next().is_some() && !is_mapping {
-            Err(vm
-                .new_type_error("not all arguments converted during string formatting".to_owned()))
+            Err(vm.new_type_error("not all arguments converted during bytes formatting".to_owned()))
         } else {
             Ok(result)
         }


### PR DESCRIPTION
Fixing up string formatting only required fixing how %a was handled, and a tweak to exception text.

Bytes formatting appears to have been based on the string formatting code, so didn't capture where CPython behaves differently between bytes and str formatting, and didn't handle bytearrays at all: the changes there are a little more involved.

I've made atomic commits, so reviewing commit-wise should work.