### PR TITLE
Fix `GenericAlias` parameter chaining

### DIFF
--- a/Lib/test/test_genericalias.py
+++ b/Lib/test/test_genericalias.py
@@ -173,8 +173,6 @@ class BaseTest(unittest.TestCase):
         self.assertEqual(a.__args__, (int,))
         self.assertEqual(a.__parameters__, ())
 
-    # TODO: RUSTPYTHON
-    @unittest.expectedFailure
     def test_parameters(self):
         from typing import List, Dict, Callable
         D0 = dict[str, int]
@@ -214,8 +212,6 @@ class BaseTest(unittest.TestCase):
         self.assertEqual(L5.__args__, (Callable[[K, V], K],))
         self.assertEqual(L5.__parameters__, (K, V))
 
-    # TODO: RUSTPYTHON
-    @unittest.expectedFailure
     def test_parameter_chaining(self):
         from typing import List, Dict, Union, Callable
         self.assertEqual(list[T][int], list[int])

--- a/extra_tests/snippets/test_typing.py
+++ b/extra_tests/snippets/test_typing.py
@@ -1,4 +1,0 @@
-from typing import TypeVar
-
-Y = TypeVar('Y')
-assert dict[str,Y][int] == dict[str, int]

--- a/vm/src/builtins/genericalias.rs
+++ b/vm/src/builtins/genericalias.rs
@@ -209,27 +209,33 @@ fn subs_tvars(
     argitems: &[PyObjectRef],
     vm: &VirtualMachine,
 ) -> PyResult {
-    obj.clone_class()
-        .get_attr("__parameters__")
+    obj.clone()
+        .get_attr("__parameters__", vm)
+        .ok()
         .and_then(|sub_params| {
             PyTupleRef::try_from_object(vm, sub_params)
                 .ok()
                 .map(|sub_params| {
-                    let sub_args = sub_params
-                        .as_slice()
-                        .iter()
-                        .map(|arg| {
-                            if let Some(idx) = tuple_index(params, arg) {
-                                argitems[idx].clone()
-                            } else {
-                                arg.clone()
-                            }
-                        })
-                        .collect::<Vec<_>>();
-                    let sub_args: PyObjectRef = PyTuple::new_ref(sub_args, &vm.ctx).into();
-                    obj.get_item(sub_args, vm)
+                    if sub_params.len() > 0 {
+                        let sub_args = sub_params
+                            .as_slice()
+                            .iter()
+                            .map(|arg| {
+                                if let Some(idx) = tuple_index(params, arg) {
+                                    argitems[idx].clone()
+                                } else {
+                                    arg.clone()
+                                }
+                            })
+                            .collect::<Vec<_>>();
+                        let sub_args: PyObjectRef = PyTuple::new_ref(sub_args, &vm.ctx).into();
+                        Some(obj.get_item(sub_args, vm))
+                    } else {
+                        None
+                    }
                 })
         })
+        .flatten()
         .unwrap_or(Ok(obj))
 }
 


### PR DESCRIPTION
This revision fix some misworking functions
* Fix original `make_parameters` & `subs_tvars`
* `test_parameters` and `test_parameter_chaining` tests now going success

I removed `extra_tests/snippets/test_typing.py` which I added in #3374, that I had been thought there are no tests for
using `TypeVar` with `GenericAlias`. It is actually covered by `test_parameter_chaining` in `test_genericalias.py`

@moreal Could you review this [commit](https://github.com/RustPython/RustPython/commit/59a2ade1cb3f3677e6c4c50b287f70548f76b333)? As you originally added this commit, I'd be a pleasure if you review this one 😊
In cpython, only they push parameters if they are not already exist. I fixed that mismatch between rustpython.