### PR TITLE
correctly set __module__ and __name__ for builtin exceptions

### DIFF
--- a/extra_tests/snippets/stdlib_binascii.py
+++ b/extra_tests/snippets/stdlib_binascii.py
@@ -50,3 +50,9 @@ assert_equal(
     "☢🐣  ᖇ𝓤𝕊тⓟ𝕐𝕥卄σ𝔫  ♬👣".encode(),
 )
 
+for exc, expected_name in [
+    (binascii.Error, "Error"),
+    (binascii.Incomplete, "Incomplete"),
+]:
+    assert exc.__module__ == "binascii"
+    assert exc.__name__ == expected_name

--- a/extra_tests/snippets/stdlib_socket.py
+++ b/extra_tests/snippets/stdlib_socket.py
@@ -156,3 +156,11 @@ with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as listener:
 	with assert_raises(OSError): # TODO: check that it raises a socket.timeout
 		# testing that it doesn't work with the timeout; that it stops blocking eventually
 		connection.recv(len(MESSAGE_A))
+
+for exc, expected_name in [
+    (socket.gaierror, "gaierror"),
+    (socket.herror, "herror"),
+    (socket.timeout, "timeout"),
+]:
+    assert exc.__module__ == "socket"
+    assert exc.__name__ == expected_name

--- a/extra_tests/snippets/stdlib_struct.py
+++ b/extra_tests/snippets/stdlib_struct.py
@@ -71,3 +71,6 @@ assert data == b'\1'
 
 data = struct.pack('?', [])
 assert data == b'\0'
+
+assert struct.error.__module__ == "struct"
+assert struct.error.__name__ == "error"

--- a/extra_tests/snippets/stdlib_termios.py
+++ b/extra_tests/snippets/stdlib_termios.py
@@ -1,0 +1,13 @@
+def _test_termios():
+    # These tests are in a function so we can only run them if termios is available
+    assert termios.error.__module__ == "termios"
+    assert termios.error.__name__ == "error"
+
+
+try:
+    import termios
+except ImportError:
+    # Not all platforms have termios, noop
+    pass
+else:
+    _test_termios()

--- a/stdlib/src/binascii.rs
+++ b/stdlib/src/binascii.rs
@@ -19,7 +19,8 @@ mod decl {
         BINASCII_ERROR
             .get_or_init(|| {
                 vm.ctx.new_class(
-                    "binascii.Error",
+                    Some("binascii"),
+                    "Error",
                     &vm.ctx.exceptions.value_error,
                     Default::default(),
                 )
@@ -35,7 +36,8 @@ mod decl {
         BINASCII_INCOMPLTE
             .get_or_init(|| {
                 vm.ctx.new_class(
-                    "binascii.Incomplete",
+                    Some("binascii"),
+                    "Incomplete",
                     &vm.ctx.exceptions.exception_type,
                     Default::default(),
                 )

--- a/stdlib/src/socket.rs
+++ b/stdlib/src/socket.rs
@@ -89,7 +89,8 @@ mod _socket {
         ERROR
             .get_or_init(|| {
                 vm.ctx.new_class(
-                    "socket.timeout",
+                    Some("socket"),
+                    "timeout",
                     &vm.ctx.exceptions.os_error,
                     Default::default(),
                 )
@@ -104,7 +105,8 @@ mod _socket {
         ERROR
             .get_or_init(|| {
                 vm.ctx.new_class(
-                    "socket.herror",
+                    Some("socket"),
+                    "herror",
                     &vm.ctx.exceptions.os_error,
                     Default::default(),
                 )
@@ -119,7 +121,8 @@ mod _socket {
         ERROR
             .get_or_init(|| {
                 vm.ctx.new_class(
-                    "socket.gaierror",
+                    Some("socket"),
+                    "gaierror",
                     &vm.ctx.exceptions.os_error,
                     Default::default(),
                 )

--- a/stdlib/src/termios.rs
+++ b/stdlib/src/termios.rs
@@ -108,7 +108,8 @@ mod termios {
         TERMIOS_ERROR
             .get_or_init(|| {
                 vm.ctx.new_class(
-                    "termios.error",
+                    Some("termios"),
+                    "error",
                     &vm.ctx.exceptions.os_error,
                     Default::default(),
                 )

--- a/vm/src/macros.rs
+++ b/vm/src/macros.rs
@@ -19,7 +19,7 @@ macro_rules! py_class {
             #[allow(unused_mut)]
             let mut slots = $crate::types::PyTypeSlots::from_flags($crate::types::PyTypeFlags::DEFAULT | $flags);
             $($crate::py_class!(@extract_slots($ctx, &mut slots, $name, $value));)*
-            let py_class = $ctx.new_class($class_name, $class_base, slots);
+            let py_class = $ctx.new_class(None, $class_name, $class_base, slots);
             $($crate::py_class!(@extract_attrs($ctx, &py_class, $name, $value));)*
             py_class
         }

--- a/vm/src/pyobject.rs
+++ b/vm/src/pyobject.rs
@@ -221,11 +221,21 @@ impl PyContext {
         PyDict::new_ref(self)
     }
 
-    pub fn new_class(&self, name: &str, base: &PyTypeRef, slots: PyTypeSlots) -> PyTypeRef {
+    pub fn new_class(
+        &self,
+        module: Option<&str>,
+        name: &str,
+        base: &PyTypeRef,
+        slots: PyTypeSlots,
+    ) -> PyTypeRef {
+        let mut attrs = PyAttributes::default();
+        if let Some(module) = module {
+            attrs.insert("__module__".to_string(), self.new_str(module).into());
+        };
         PyType::new_ref(
             name,
             vec![base.clone()],
-            Default::default(),
+            attrs,
             slots,
             self.types.type_type.clone(),
         )

--- a/vm/src/stdlib/pystruct.rs
+++ b/vm/src/stdlib/pystruct.rs
@@ -968,7 +968,8 @@ pub(crate) mod _struct {
         STRUCT_ERROR
             .get_or_init(|| {
                 vm.ctx.new_class(
-                    "struct.error",
+                    Some("struct"),
+                    "error",
                     &vm.ctx.exceptions.exception_type,
                     Default::default(),
                 )


### PR DESCRIPTION
In CPython's PyErr_NewException[0], the dotted "module.name" passed in is
split on that dot: the content before the dot is set as __module__ in
the created exception class, and the content after it is set as
__name__.

This commit mirrors that behaviour, by introducing a `module` argument
to `PyContext.new_class`: if Some("module_name") is passed, it will be
set as `__module__`.  All exception-creating uses of `new_class` are
updated to pass in their module and class names separately.

[0] https://github.com/python/cpython/blob/main/Python/errors.c#L1082-L1087