### PR TITLE
Correct typo of types manually created

### DIFF
--- a/stdlib/src/csv.rs
+++ b/stdlib/src/csv.rs
@@ -32,7 +32,7 @@ mod _csv {
 
     #[pyattr(name = "Error")]
     fn error(vm: &VirtualMachine) -> PyTypeRef {
-        PyType::new_simple_ref("Error", &vm.ctx.exceptions.exception_type).unwrap()
+        PyType::new_simple_ref("_csv.Error", &vm.ctx.exceptions.exception_type).unwrap()
     }
 
     #[pyfunction]

--- a/stdlib/src/ssl.rs
+++ b/stdlib/src/ssl.rs
@@ -181,7 +181,7 @@ mod _ssl {
         }
         ERROR
             .get_or_init(|| {
-                PyType::new_simple_ref("SSLError", &vm.ctx.exceptions.os_error).unwrap()
+                PyType::new_simple_ref("ssl.SSLError", &vm.ctx.exceptions.os_error).unwrap()
             })
             .clone()
     }
@@ -195,7 +195,7 @@ mod _ssl {
             .get_or_init(|| {
                 let ssl_error = ssl_error(vm);
                 PyType::new_ref(
-                    "SSLCertVerificationError",
+                    "ssl.SSLCertVerificationError",
                     vec![ssl_error, vm.ctx.exceptions.value_error.clone()],
                     Default::default(),
                     PyBaseException::make_slots(),
@@ -212,7 +212,7 @@ mod _ssl {
             static ERROR: PyTypeRef;
         }
         ERROR
-            .get_or_init(|| PyType::new_simple_ref("SSLZeroReturnError", &ssl_error(vm)).unwrap())
+            .get_or_init(|| PyType::new_simple_ref("ssl.SSLZeroReturnError", &ssl_error(vm)).unwrap())
             .clone()
     }
 
@@ -222,7 +222,7 @@ mod _ssl {
             static ERROR: PyTypeRef;
         }
         ERROR
-            .get_or_init(|| PyType::new_simple_ref("SSLWantReadError", &ssl_error(vm)).unwrap())
+            .get_or_init(|| PyType::new_simple_ref("ssl.SSLWantReadError", &ssl_error(vm)).unwrap())
             .clone()
     }
 
@@ -232,7 +232,7 @@ mod _ssl {
             static ERROR: PyTypeRef;
         }
         ERROR
-            .get_or_init(|| PyType::new_simple_ref("SSLWantWriteError", &ssl_error(vm)).unwrap())
+            .get_or_init(|| PyType::new_simple_ref("ssl.SSLWantWriteError", &ssl_error(vm)).unwrap())
             .clone()
     }
 
@@ -242,7 +242,7 @@ mod _ssl {
             static ERROR: PyTypeRef;
         }
         ERROR
-            .get_or_init(|| PyType::new_simple_ref("SSLSyscallError", &ssl_error(vm)).unwrap())
+            .get_or_init(|| PyType::new_simple_ref("ssl.SSLSyscallError", &ssl_error(vm)).unwrap())
             .clone()
     }
 
@@ -252,7 +252,7 @@ mod _ssl {
             static ERROR: PyTypeRef;
         }
         ERROR
-            .get_or_init(|| PyType::new_simple_ref("SSLEOFError", &ssl_error(vm)).unwrap())
+            .get_or_init(|| PyType::new_simple_ref("ssl.SSLEOFError", &ssl_error(vm)).unwrap())
             .clone()
     }
 

--- a/stdlib/src/ssl.rs
+++ b/stdlib/src/ssl.rs
@@ -212,7 +212,9 @@ mod _ssl {
             static ERROR: PyTypeRef;
         }
         ERROR
-            .get_or_init(|| PyType::new_simple_ref("ssl.SSLZeroReturnError", &ssl_error(vm)).unwrap())
+            .get_or_init(|| {
+                PyType::new_simple_ref("ssl.SSLZeroReturnError", &ssl_error(vm)).unwrap()
+            })
             .clone()
     }
 
@@ -232,7 +234,9 @@ mod _ssl {
             static ERROR: PyTypeRef;
         }
         ERROR
-            .get_or_init(|| PyType::new_simple_ref("ssl.SSLWantWriteError", &ssl_error(vm)).unwrap())
+            .get_or_init(|| {
+                PyType::new_simple_ref("ssl.SSLWantWriteError", &ssl_error(vm)).unwrap()
+            })
             .clone()
     }
 

--- a/stdlib/src/zlib.rs
+++ b/stdlib/src/zlib.rs
@@ -56,7 +56,7 @@ mod zlib {
 
     #[pyattr]
     fn error(vm: &VirtualMachine) -> PyTypeRef {
-        PyType::new_simple_ref("error", &vm.ctx.exceptions.exception_type).unwrap()
+        PyType::new_simple_ref("zlib.error", &vm.ctx.exceptions.exception_type).unwrap()
     }
 
     /// Compute an Adler-32 checksum of data.


### PR DESCRIPTION
This pull request fixes typo of types manually created. You can check these changes are valid fixups through the below lines:

```python
# test.py
import _csv, zlib, _ssl
print(_csv.Error, zlib.error, _ssl.SSLError, _ssl.SSLCertVerificationError, _ssl.SSLZeroReturnError, _ssl.SSLWantReadError, _ssl.SSLWantWriteError, _ssl.SSLSyscallError, _ssl.SSLEOFError)
```

## CPython (3.9.7)

`python3 test.py`

```
<class '_csv.Error'> <class 'zlib.error'> <class 'ssl.SSLError'> <class 'ssl.SSLCertVerificationError'> <class 'ssl.SSLZeroReturnError'> <class 'ssl.SSLWantReadError'> <class 'ssl.SSLWantWriteError'> <class 'ssl.SSLSyscallError'> <class 'ssl.SSLEOFError'>
```

## RustPython ([current main](https://github.com/RustPython/RustPython/tree/5f158f2c6f92d785865569659e90beb72008d306))

`cargo run --features=ssl -- test.py`

```
<class 'Error'> <class 'error'> <class 'SSLError'> <class 'SSLCertVerificationError'> <class 'SSLZeroReturnError'> <class 'SSLWantReadError'> <class 'SSLWantWriteError'> <class 'SSLSyscallError'> <class 'SSLEOFError'>
```

## RustPython (current pull request)

`cargo run --features=ssl -- test.py`

```
<class '_csv.Error'> <class 'zlib.error'> <class 'ssl.SSLError'> <class 'ssl.SSLCertVerificationError'> <class 'ssl.SSLZeroReturnError'> <class 'ssl.SSLWantReadError'> <class 'ssl.SSLWantWriteError'> <class 'ssl.SSLSyscallError'> <class 'ssl.SSLEOFError'>
```

