### PR TITLE
os: implement os-error-str according to CPython

### DIFF
--- a/Lib/test/test_posix.py
+++ b/Lib/test/test_posix.py
@@ -1424,8 +1424,6 @@ class PosixTester(unittest.TestCase):
                 # http://lists.freebsd.org/pipermail/freebsd-amd64/2012-January/014332.html
                 raise unittest.SkipTest("OSError raised!")
 
-    # TODO: RUSTPYTHON: AssertionError: "'doesnotexistfilename' -> 'noodly2'" not found in "(2, 'No such file or directory (os error 2)')"
-    @unittest.expectedFailure
     def test_path_error2(self):
         """
         Test functions that call path_error2(), providing two filenames in their exceptions.

--- a/Lib/test/test_tarfile.py
+++ b/Lib/test/test_tarfile.py
@@ -342,8 +342,6 @@ class CommonReadTest(ReadTest):
         finally:
             tar.close()
 
-    # TODO: RUSTPYTHON
-    @unittest.expectedFailure
     def test_non_existent_tarfile(self):
         # Test for issue11513: prevent non-existent gzipped tarfiles raising
         # multiple exceptions.


### PR DESCRIPTION
As was: "FileNotFoundError: [Errno 2] No such file or directory (os error 2)"
To be: "FileNotFoundError: [Errno 2] No such file or directory (os error 2): 'filename' -> 'filename2'"

Reference CPython implementation
```
if (self->filename) {
    if (self->filename2) {
        return PyUnicode_FromFormat("[Errno %S] %S: %R -> %R",
                                    OR_NONE(self->myerrno),
                                    OR_NONE(self->strerror),
                                    self->filename,
                                    self->filename2);
    } else {
        return PyUnicode_FromFormat("[Errno %S] %S: %R",
                                    OR_NONE(self->myerrno),
                                    OR_NONE(self->strerror),
                                    self->filename);
    }
}
if (self->myerrno && self->strerror)
    return PyUnicode_FromFormat("[Errno %S] %S",
                                self->myerrno, self->strerror);
```