### PR TITLE
cformat.rs: fix remaining test_format.test_common_format failures

### DIFF
--- a/Lib/test/test_format.py
+++ b/Lib/test/test_format.py
@@ -94,8 +94,6 @@ def test_exc_common(formatstr, args, exception, excmsg):
 
 class FormatTest(unittest.TestCase):
 
-    # TODO: RUSTPYTHON
-    @unittest.expectedFailure
     def test_common_format(self):
         # test the format identifiers that work the same across
         # str, bytes, and bytearrays (integer, float, oct, hex)

--- a/Lib/test/test_types.py
+++ b/Lib/test/test_types.py
@@ -86,8 +86,6 @@ class TypesTests(unittest.TestCase):
         if float(1) == 1.0 and float(-1) == -1.0 and float(0) == 0.0: pass
         else: self.fail('float() does not work properly')
 
-    # TODO: RUSTPYTHON
-    @unittest.expectedFailure
     def test_float_to_string(self):
         def test(f, result):
             self.assertEqual(f.__format__('e'), result)

--- a/vm/src/cformat.rs
+++ b/vm/src/cformat.rs
@@ -167,16 +167,22 @@ impl CFormatSpec {
         string: String,
         fill_char: char,
         num_prefix_chars: Option<usize>,
+        fill_with_precision: bool,
     ) -> String {
+        let target_width = if fill_with_precision {
+            &self.precision
+        } else {
+            &self.min_field_width
+        };
         let mut num_chars = string.chars().count();
         if let Some(num_prefix_chars) = num_prefix_chars {
             num_chars += num_prefix_chars;
         }
         let num_chars = num_chars;
 
-        let width = match self.min_field_width {
-            Some(CFormatQuantity::Amount(width)) => cmp::max(width, num_chars),
-            _ => num_chars,
+        let width = match target_width {
+            Some(CFormatQuantity::Amount(width)) => cmp::max(width, &num_chars),
+            _ => &num_chars,
         };
         let fill_chars_needed = width.saturating_sub(num_chars);
         let fill_string = CFormatSpec::compute_fill_string(fill_char, fill_chars_needed);
@@ -204,7 +210,7 @@ impl CFormatSpec {
             }
             _ => string,
         };
-        self.fill_string(string, ' ', None)
+        self.fill_string(string, ' ', None, false)
     }
 
     pub(crate) fn format_string(&self, string: String) -> String {
@@ -282,14 +288,16 @@ impl CFormatSpec {
                 self.fill_string(
                     magnitude_string,
                     fill_char,
-                    Some(signed_prefix.chars().count())
-                )
+                    Some(signed_prefix.chars().count()),
+                    false
+                ),
             )
         } else {
             self.fill_string(
                 format!("{}{}{}", sign_string, prefix, magnitude_string),
                 ' ',
                 None,
+                false,
             )
         }
     }
@@ -347,11 +355,17 @@ impl CFormatSpec {
                 self.fill_string(
                     magnitude_string,
                     fill_char,
-                    Some(sign_string.chars().count())
+                    Some(sign_string.chars().count()),
+                    false
                 )
             )
         } else {
-            self.fill_string(format!("{}{}", sign_string, magnitude_string), ' ', None)
+            self.fill_string(
+                format!("{}{}", sign_string, magnitude_string),
+                ' ',
+                None,
+                false,
+            )
         };
 
         formatted

--- a/vm/src/cformat.rs
+++ b/vm/src/cformat.rs
@@ -188,7 +188,10 @@ impl CFormatSpec {
         let fill_string = CFormatSpec::compute_fill_string(fill_char, fill_chars_needed);
 
         if !fill_string.is_empty() {
-            if self.flags.contains(CConversionFlags::LEFT_ADJUST) {
+            // Don't left-adjust if precision-filling: that will always be prepending 0s to %d
+            // arguments, the LEFT_ADJUST flag will be used by a later call to fill_string with
+            // the 0-filled string as the string param.
+            if !fill_with_precision && self.flags.contains(CConversionFlags::LEFT_ADJUST) {
                 format!("{}{}", string, fill_string)
             } else {
                 format!("{}{}", fill_string, string)

--- a/vm/src/cformat.rs
+++ b/vm/src/cformat.rs
@@ -275,6 +275,8 @@ impl CFormatSpec {
             _ => self.flags.sign_string(),
         };
 
+        let padded_magnitude_string = self.fill_string(magnitude_string, '0', None, true);
+
         if self.flags.contains(CConversionFlags::ZERO_PAD) {
             let fill_char = if !self.flags.contains(CConversionFlags::LEFT_ADJUST) {
                 '0'
@@ -286,7 +288,7 @@ impl CFormatSpec {
                 "{}{}",
                 signed_prefix,
                 self.fill_string(
-                    magnitude_string,
+                    padded_magnitude_string,
                     fill_char,
                     Some(signed_prefix.chars().count()),
                     false
@@ -294,7 +296,7 @@ impl CFormatSpec {
             )
         } else {
             self.fill_string(
-                format!("{}{}{}", sign_string, prefix, magnitude_string),
+                format!("{}{}{}", sign_string, prefix, padded_magnitude_string),
                 ' ',
                 None,
                 false,

--- a/vm/src/cformat.rs
+++ b/vm/src/cformat.rs
@@ -343,7 +343,12 @@ impl CFormatSpec {
                     CFormatCase::Uppercase => float_ops::Case::Upper,
                 };
                 let magnitude = num.abs();
-                float_ops::format_general(precision, magnitude, case)
+                float_ops::format_general(
+                    precision,
+                    magnitude,
+                    case,
+                    self.flags.contains(CConversionFlags::ALTERNATE_FORM),
+                )
             }
             _ => unreachable!(),
         };

--- a/vm/src/cformat.rs
+++ b/vm/src/cformat.rs
@@ -612,7 +612,7 @@ fn try_update_quantity_from_tuple<'a, I: Iterator<Item = &'a PyObjectRef>>(
         Some(CFormatQuantity::FromValuesTuple) => match elements.next() {
             Some(width_obj) => {
                 if let Some(i) = width_obj.payload::<PyInt>() {
-                    let i = i.try_to_primitive::<isize>(vm)?.abs() as usize;
+                    let i = i.try_to_primitive::<i32>(vm)?.abs() as usize;
                     *q = Some(CFormatQuantity::Amount(i));
                     Ok(())
                 } else {
@@ -953,13 +953,13 @@ where
             return Ok(Some(CFormatQuantity::FromValuesTuple));
         }
         if let Some(i) = c.to_digit(10) {
-            let mut num = i as isize;
+            let mut num = i as i32;
             iter.next().unwrap();
             while let Some(&(index, c)) = iter.peek() {
                 if let Some(i) = c.into().to_digit(10) {
                     num = num
                         .checked_mul(10)
-                        .and_then(|num| num.checked_add(i as isize))
+                        .and_then(|num| num.checked_add(i as i32))
                         .ok_or((CFormatErrorType::IntTooBig, index))?;
                     iter.next().unwrap();
                 } else {

--- a/vm/src/format.rs
+++ b/vm/src/format.rs
@@ -376,6 +376,7 @@ impl FormatSpec {
                     precision,
                     magnitude,
                     float_ops::Case::Upper,
+                    false,
                 ))
             }
             Some(FormatType::GeneralFormatLower) => {
@@ -384,6 +385,7 @@ impl FormatSpec {
                     precision,
                     magnitude,
                     float_ops::Case::Lower,
+                    false,
                 ))
             }
             Some(FormatType::ExponentUpper) => Ok(float_ops::format_exponent(


### PR DESCRIPTION
With one exception, which I'll comment on inline. Otherwise, commits are atomic.