### PR TITLE
fix `not_impl.py` path for black in `whats_left.sh`

### DIFF
--- a/whats_left.sh
+++ b/whats_left.sh
@@ -19,7 +19,7 @@ export RUSTPYTHONPATH=Lib
 
 # This takes a while
 if command -v black &> /dev/null; then
-    black -q extra_tests/snippets/not_impl.py
+    black -q extra_tests/not_impl.py
 fi
 
 # show the building first, so people aren't confused why it's taking so long to


### PR DESCRIPTION
Hi! 👋

First of all, thanks a lot for this project. This is my first PR, don't hesitate to tell me if I'm completely off the topic! 

I wanted to see where I could help so I run `whats_left.sh` (on MacOS Monterey). Unfortunately Black was not able to find the generated file `not_impl.py`.

```
Usage: black [OPTIONS] [SRC]...
Try 'black -h' for help.

Error: Invalid value for '[SRC]...': Path 'extra_tests/snippets/not_impl.py' does not exist.
```

I found out that this file was generated inside `extra_tests/` directory and not in `extra_tests/snippets/` so I just fixed the path in `whats_left.sh`.
After this little fix, it works as expected. 

Have a good day,
Matthieu.