### PR TITLE
Remove slot_new for longrange_iterator.

### DIFF
--- a/vm/src/builtins/range.rs
+++ b/vm/src/builtins/range.rs
@@ -515,11 +515,6 @@ impl PyValue for PyLongRangeIterator {
 
 #[pyimpl(with(Constructor, IterNext))]
 impl PyLongRangeIterator {
-    #[pyslot]
-    fn slot_new(_cls: PyTypeRef, _args: FuncArgs, vm: &VirtualMachine) -> PyResult {
-        Err(vm.new_type_error("cannot create 'longrange_iterator' instances".to_owned()))
-    }
-
     #[pymethod(magic)]
     fn length_hint(&self) -> BigInt {
         let index = BigInt::from(self.index.load());


### PR DESCRIPTION
`Unconstructible` handles forbidding instantiation.