### PR TITLE
Implement `object.__sizeof__`

### DIFF
--- a/vm/src/builtins/object.rs
+++ b/vm/src/builtins/object.rs
@@ -4,7 +4,7 @@ use crate::{
     class::PyClassImpl,
     function::Either,
     function::{FuncArgs, PyArithmeticValue, PyComparisonValue},
-    types::PyComparisonOp,
+    types::{PyComparisonOp, SizeOf},
     AsObject, Context, Py, PyObject, PyObjectRef, PyPayload, PyResult, VirtualMachine,
 };
 
@@ -25,7 +25,7 @@ impl PyPayload for PyBaseObject {
     }
 }
 
-#[pyimpl(flags(BASETYPE))]
+#[pyimpl(flags(BASETYPE), with(SizeOf))]
 impl PyBaseObject {
     /// Create and return a new object.  See help(type) for accurate signature.
     #[pyslot]
@@ -331,10 +331,11 @@ impl PyBaseObject {
     fn hash(zelf: PyObjectRef, vm: &VirtualMachine) -> PyResult<PyHash> {
         Self::slot_hash(&zelf, vm)
     }
+}
 
-    #[pymethod(magic)]
-    fn sizeof(zelf: PyObjectRef) -> usize {
-        zelf.class().slots.basicsize
+impl SizeOf for PyBaseObject {
+    fn sizeof(zelf: &Py<Self>) -> PyResult<usize> {
+        Ok(zelf.class().slots.basicsize)
     }
 }
 


### PR DESCRIPTION
This pull request may close https://github.com/RustPython/RustPython/issues/356.

This pull request implements `object.__sizeof__` fully, except for setting all types' `ob_size`. It introduces `PyVarObject.ob_size` field and `tp_itemsize` slot. Also it provides a way to setup `itemsize` slot with `pyclass` macro.

`ob_size` field is used to calculate variable object's size with `itemsize` (`ob_size * itemsize + basicsize`).

Because this pull request modified the core part like (`PyInner` and `PyObjectRef`) and I felt the next work can be more bigger, I cut this part and request a review for this pull request.

----

Related codes:

- CPython `object.__sizeof__` impl: https://github.com/python/cpython/blob/e5d8dbdd304935dbd0631ee9605efb501332f792/Objects/typeobject.c#L5520-L5533
- CPython `PyVarObject`: https://github.com/python/cpython/blob/fa2b8b75eb2b8a0193d587e02b488a73579118fc/Include/object.h#L111-L114

-----

The next work will be to call `set_ob_size`.