### PR TITLE
arrow crash in windows

### DIFF
--- a/ast/src/location.rs
+++ b/ast/src/location.rs
@@ -34,7 +34,7 @@ impl Location {
                     self.desc,
                     self.line,
                     pad = self.loc.column,
-                    arrow = "↑",
+                    arrow = "^",
                 )
             }
         }


### PR DESCRIPTION
in windows, arrow is not shown
and crahsed.
changed to another arrow that's
compatible