### PR TITLE
Remove staled comments

### DIFF
--- a/extra_tests/not_impl_gen.py
+++ b/extra_tests/not_impl_gen.py
@@ -72,8 +72,6 @@ def attr_is_not_inherited(type_, attr):
 
 
 def extra_info(obj):
-    # RustPython doesn't support __text_signature__ for getting signatures of builtins
-    # https://github.com/RustPython/RustPython/issues/2410
     if callable(obj) and not inspect._signature_is_builtin(obj):
         try:
             sig = str(inspect.signature(obj))


### PR DESCRIPTION
https://github.com/RustPython/RustPython/issues/2410 was resolved by #2904. So this pull request removes the staled lines from `extra_tests/not_impl_gen.py`