### PR TITLE
Support tuple type also for memoryview shape arg

### DIFF
--- a/Lib/test/test_base64.py
+++ b/Lib/test/test_base64.py
@@ -26,8 +26,6 @@ class LegacyBase64TestCase(unittest.TestCase):
         with self.assertWarns(DeprecationWarning):
             base64.decodestring(b"d3d3LnB5dGhvbi5vcmc=\n")
 
-    # TODO: RUSTPYTHON
-    @unittest.expectedFailure
     def test_encodebytes(self):
         eq = self.assertEqual
         eq(base64.encodebytes(b"www.python.org"), b"d3d3LnB5dGhvbi5vcmc=\n")
@@ -47,8 +45,6 @@ class LegacyBase64TestCase(unittest.TestCase):
         eq(base64.encodebytes(array('B', b'abc')), b'YWJj\n')
         self.check_type_errors(base64.encodebytes)
 
-    # TODO: RUSTPYTHON
-    @unittest.expectedFailure
     def test_decodebytes(self):
         eq = self.assertEqual
         eq(base64.decodebytes(b"d3d3LnB5dGhvbi5vcmc=\n"), b"www.python.org")
@@ -133,9 +129,6 @@ class BaseXYTestCase(unittest.TestCase):
         int_data = memoryview(bytes_data).cast('I')
         self.assertEqual(f(int_data), f(bytes_data))
 
-
-    # TODO: RUSTPYTHON
-    @unittest.expectedFailure
     def test_b64encode(self):
         eq = self.assertEqual
         # Test default alphabet
@@ -186,8 +179,6 @@ class BaseXYTestCase(unittest.TestCase):
                                b'\xd3V\xbeo\xf7\x1d', b'01a-b_cd')
         self.check_encode_type_errors(base64.urlsafe_b64encode)
 
-    # TODO: RUSTPYTHON
-    @unittest.expectedFailure
     def test_b64decode(self):
         eq = self.assertEqual
 
@@ -284,8 +275,6 @@ class BaseXYTestCase(unittest.TestCase):
         self.assertEqual(base64.b64decode(b'++[[//]]', b'[]'), res)
         self.assertEqual(base64.urlsafe_b64decode(b'++--//__'), res)
 
-    # TODO: RUSTPYTHON
-    @unittest.expectedFailure
     def test_b32encode(self):
         eq = self.assertEqual
         eq(base64.b32encode(b''), b'')
@@ -299,8 +288,6 @@ class BaseXYTestCase(unittest.TestCase):
         self.check_other_types(base64.b32encode, b'abcd', b'MFRGGZA=')
         self.check_encode_type_errors(base64.b32encode)
 
-    # TODO: RUSTPYTHON
-    @unittest.expectedFailure
     def test_b32decode(self):
         eq = self.assertEqual
         tests = {b'': b'',
@@ -375,8 +362,6 @@ class BaseXYTestCase(unittest.TestCase):
                 with self.assertRaises(binascii.Error):
                     base64.b32decode(data.decode('ascii'))
 
-    # TODO: RUSTPYTHON
-    @unittest.expectedFailure
     def test_b16encode(self):
         eq = self.assertEqual
         eq(base64.b16encode(b'\x01\x02\xab\xcd\xef'), b'0102ABCDEF')
@@ -415,8 +400,6 @@ class BaseXYTestCase(unittest.TestCase):
         # Incorrect "padding"
         self.assertRaises(binascii.Error, base64.b16decode, '010')
 
-    # TODO: RUSTPYTHON
-    @unittest.expectedFailure
     def test_a85encode(self):
         eq = self.assertEqual
 
@@ -467,8 +450,6 @@ class BaseXYTestCase(unittest.TestCase):
         eq(base64.a85encode(b' '*6, foldspaces=True, adobe=False), b'y+<U')
         eq(base64.a85encode(b' '*5, foldspaces=True, adobe=False), b'y+9')
 
-    # TODO: RUSTPYTHON
-    @unittest.expectedFailure
     def test_b85encode(self):
         eq = self.assertEqual
 
@@ -503,8 +484,6 @@ class BaseXYTestCase(unittest.TestCase):
         self.check_other_types(base64.b85encode, b"www.python.org",
                                b'cXxL#aCvlSZ*DGca%T')
 
-    # TODO: RUSTPYTHON
-    @unittest.expectedFailure
     def test_a85decode(self):
         eq = self.assertEqual
 
@@ -550,8 +529,6 @@ class BaseXYTestCase(unittest.TestCase):
         self.check_other_types(base64.a85decode, b'GB\\6`E-ZP=Df.1GEb>',
                                b"www.python.org")
 
-    # TODO: RUSTPYTHON
-    @unittest.expectedFailure
     def test_b85decode(self):
         eq = self.assertEqual
 

--- a/vm/src/builtins/memory.rs
+++ b/vm/src/builtins/memory.rs
@@ -10,6 +10,7 @@ use crate::{
     bytesinner::bytes_to_hex,
     function::{FuncArgs, IntoPyObject, OptionalArg},
     protocol::{BufferDescriptor, BufferMethods, PyBuffer, PyMappingMethods, VecBuffer},
+    sequence::SequenceOp,
     sliceable::wrap_index,
     stdlib::pystruct::FormatSpec,
     types::{AsBuffer, AsMapping, Comparable, Constructor, Hashable, PyComparisonOp},
@@ -629,16 +630,22 @@ impl PyMemoryView {
                 ));
             }
 
+            let tup;
+            let list;
+            let list_borrow;
             let shape = match shape {
-                Either::A(tup) => {
-                    let elements = tup.as_slice().iter().cloned().collect_vec();
-                    vm.ctx.new_list(elements)
+                Either::A(shape) => {
+                    tup = shape;
+                    tup.as_slice()
                 }
-                Either::B(list) => list,
+                Either::B(shape) => {
+                    list = shape;
+                    list_borrow = list.borrow_vec();
+                    list_borrow.as_slice()
+                }
             };
 
-            let shape_vec = shape.borrow_vec();
-            let shape_ndim = shape_vec.len();
+            let shape_ndim = shape.len();
             // TODO: MAX_NDIM
             if self.desc.ndim() != 1 && shape_ndim != 1 {
                 return Err(
@@ -659,7 +666,7 @@ impl PyMemoryView {
             let mut product_shape = itemsize;
             let mut dim_descriptor = Vec::with_capacity(shape_ndim);
 
-            for x in shape_vec.iter() {
+            for x in shape.iter() {
                 let x = usize::try_from_borrowed_object(vm, x)?;
 
                 if x > isize::MAX as usize / product_shape {

--- a/vm/src/builtins/memory.rs
+++ b/vm/src/builtins/memory.rs
@@ -876,7 +876,7 @@ struct CastArgs {
     #[pyarg(any)]
     format: PyStrRef,
     #[pyarg(any, optional)]
-    shape: OptionalArg<PyObjectRef>,
+    shape: OptionalArg<Either<PyTupleRef, PyListRef>>,
 }
 
 enum SubscriptNeedle {


### PR DESCRIPTION
## Description

This pr is to fix [test_base64.py](https://github.com/24seconds/RustPython/blob/dd773b3413017955db8639968b0a286adfa05e61/Lib/test/test_base64.py) test failure. Turned out most of them are related to `memoryview`'s `cast` function.

In the Cpython,  `cast` function's argument `shape` seems to support `list` and `tuple` type.
https://github.com/python/cpython/blob/af9ee57b96cb872df6574e36027cc753417605f9/Objects/memoryobject.c#L1367-L1418  

But RustPython currently supports `list` only. 
So this pr did those below
- Change `CastArgs` shape field type to `OptionalArg<PyObjectRef>`
- Check shape type is one of list or tuple
- convert shape properly

Because many `test_base64.py` tests are related to this problem, most of them are resolved after fix.

For the check, I ran these. If there is another thing that I should do, please give me guide :bow: 
```
cargo check
cargo fmt
cargo clippy
```