### PR TITLE
Update test for support/os_helper.py (second attempt)

### DIFF
--- a/Lib/test/libregrtest/cmdline.py
+++ b/Lib/test/libregrtest/cmdline.py
@@ -2,6 +2,7 @@ import argparse
 import os
 import sys
 from test import support
+from test.support import os_helper
 
 
 USAGE = """\
@@ -280,7 +281,7 @@ def _create_parser():
 def relative_filename(string):
     # CWD is replaced with a temporary dir before calling main(), so we
     # join it with the saved CWD so it ends up where the user expects.
-    return os.path.join(support.SAVEDCWD, string)
+    return os.path.join(os_helper.SAVEDCWD, string)
 
 
 def huntrleaks(string):

--- a/Lib/test/libregrtest/main.py
+++ b/Lib/test/libregrtest/main.py
@@ -20,6 +20,7 @@ from test.libregrtest.runtest import (
 from test.libregrtest.setup import setup_tests
 from test.libregrtest.utils import removepy, count, format_duration, printlist
 from test import support
+from test.support import os_helper
 
 
 # When tests are run from the Python build directory, it is best practice
@@ -199,7 +200,7 @@ class Regrtest:
             # regex to match 'test_builtin' in line:
             # '0:00:00 [  4/400] test_builtin -- test_dict took 1 sec'
             regex = re.compile(r'\btest_[a-zA-Z0-9_]+\b')
-            with open(os.path.join(support.SAVEDCWD, self.ns.fromfile)) as fp:
+            with open(os.path.join(os_helper.SAVEDCWD, self.ns.fromfile)) as fp:
                 for line in fp:
                     line = line.split('#', 1)[0]
                     line = line.strip()
@@ -542,7 +543,7 @@ class Regrtest:
         for k, v in totals.items():
             root.set(k, str(v))
 
-        xmlpath = os.path.join(support.SAVEDCWD, self.ns.xmlpath)
+        xmlpath = os.path.join(os_helper.SAVEDCWD, self.ns.xmlpath)
         with open(xmlpath, 'wb') as f:
             for s in ET.tostringlist(root):
                 f.write(s)
@@ -568,8 +569,8 @@ class Regrtest:
         # Run the tests in a context manager that temporarily changes the CWD to a
         # temporary and writable directory.  If it's not possible to create or
         # change the CWD, the original CWD will be used.  The original CWD is
-        # available from support.SAVEDCWD.
-        with support.temp_cwd(test_cwd, quiet=True):
+        # available from os_helper.SAVEDCWD.
+        with os_helper.temp_cwd(test_cwd, quiet=True):
             self._main(tests, kwargs)
 
     def getloadavg(self):

--- a/Lib/test/libregrtest/refleak.py
+++ b/Lib/test/libregrtest/refleak.py
@@ -61,7 +61,7 @@ def dash_R(ns, test_name, test_func):
         return int_pool.setdefault(value, value)
 
     nwarmup, ntracked, fname = ns.huntrleaks
-    fname = os.path.join(support.SAVEDCWD, fname)
+    fname = os.path.join(os_helper.SAVEDCWD, fname)
     repcount = nwarmup + ntracked
 
     # Pre-allocate to ensure that the loop doesn't allocate anything new

--- a/Lib/test/libregrtest/runtest.py
+++ b/Lib/test/libregrtest/runtest.py
@@ -11,6 +11,7 @@ import traceback
 import unittest
 
 from test import support
+from test.support import os_helper
 from test.libregrtest.refleak import dash_R, clear_caches
 from test.libregrtest.save_env import saved_test_environment
 from test.libregrtest.utils import print_warning
@@ -298,7 +299,7 @@ def cleanup_test_droppings(test_name, verbose):
     # since if a test leaves a file open, it cannot be deleted by name (while
     # there's nothing we can do about that here either, we can display the
     # name of the offending test, which is a real help).
-    for name in (support.TESTFN,
+    for name in (os_helper.TESTFN,
                  "db_home",
                 ):
         if not os.path.exists(name):

--- a/Lib/test/libregrtest/runtest_mp.py
+++ b/Lib/test/libregrtest/runtest_mp.py
@@ -46,7 +46,7 @@ def run_test_in_subprocess(testname, ns):
                             stderr=subprocess.PIPE,
                             universal_newlines=True,
                             close_fds=(os.name != 'nt'),
-                            cwd=support.SAVEDCWD)
+                            cwd=os_helper.SAVEDCWD)
 
 
 def run_tests_worker(worker_args):

--- a/Lib/test/libregrtest/save_env.py
+++ b/Lib/test/libregrtest/save_env.py
@@ -9,6 +9,7 @@ import sysconfig
 import threading
 import warnings
 from test import support
+from test.support import os_helper
 from test.libregrtest.utils import print_warning
 try:
     import _multiprocessing, multiprocessing.process
@@ -228,12 +229,12 @@ class saved_test_environment:
         return sorted(fn + ('/' if os.path.isdir(fn) else '')
                       for fn in os.listdir())
     def restore_files(self, saved_value):
-        fn = support.TESTFN
+        fn = os_helper.TESTFN
         if fn not in saved_value and (fn + '/') not in saved_value:
             if os.path.isfile(fn):
-                support.unlink(fn)
+                os_helper.unlink(fn)
             elif os.path.isdir(fn):
-                support.rmtree(fn)
+                os_helper.rmtree(fn)
 
     _lc = [getattr(locale, lc) for lc in dir(locale)
            if lc.startswith('LC_')]

--- a/Lib/test/libregrtest/win_utils.py
+++ b/Lib/test/libregrtest/win_utils.py
@@ -55,7 +55,7 @@ class WindowsLoadTracker():
 
         # Spawn off the load monitor
         command = ['typeperf', COUNTER_NAME, '-si', str(SAMPLING_INTERVAL)]
-        self.p = subprocess.Popen(command, stdout=command_stdout, cwd=support.SAVEDCWD)
+        self.p = subprocess.Popen(command, stdout=command_stdout, cwd=os_helper.SAVEDCWD)
 
         # Close our copy of the write end of the pipe
         os.close(command_stdout)

--- a/Lib/test/list_tests.py
+++ b/Lib/test/list_tests.py
@@ -8,6 +8,7 @@ import unittest
 from functools import cmp_to_key
 
 from test import support, seq_tests
+from test.support import os_helper
 
 
 class CommonTest(seq_tests.CommonTest):
@@ -73,12 +74,12 @@ class CommonTest(seq_tests.CommonTest):
         d.append(d)
         d.append(400)
         try:
-            with open(support.TESTFN, "w") as fo:
+            with open(os_helper.TESTFN, "w") as fo:
                 fo.write(str(d))
-            with open(support.TESTFN, "r") as fo:
+            with open(os_helper.TESTFN, "r") as fo:
                 self.assertEqual(fo.read(), repr(d))
         finally:
-            os.remove(support.TESTFN)
+            os.remove(os_helper.TESTFN)
 
     def test_set_subscript(self):
         a = self.type2test(range(20))

--- a/Lib/test/support/__init__.py
+++ b/Lib/test/support/__init__.py
@@ -4,7 +4,6 @@ if __name__ != 'test.support':
     raise ImportError('support must be imported from the test package')
 
 import asyncio.events
-import collections.abc
 import contextlib
 import errno
 import faulthandler
@@ -163,12 +162,30 @@ SHORT_TIMEOUT = 30.0
 # option.
 LONG_TIMEOUT = 5 * 60.0
 
+# TEST_HOME_DIR refers to the top level directory of the "test" package
+# that contains Python's regression test suite
+TEST_SUPPORT_DIR = os.path.dirname(os.path.abspath(__file__))
+TEST_HOME_DIR = os.path.dirname(TEST_SUPPORT_DIR)
+STDLIB_DIR = os.path.dirname(TEST_HOME_DIR)
+REPO_ROOT = os.path.dirname(STDLIB_DIR)
+
 
 class Error(Exception):
     """Base class for regression test exceptions."""
 
 class TestFailed(Error):
     """Test failed."""
+
+class TestFailedWithDetails(TestFailed):
+    """Test failed."""
+    def __init__(self, msg, errors, failures):
+        self.msg = msg
+        self.errors = errors
+        self.failures = failures
+        super().__init__(msg, errors, failures)
+
+    def __str__(self):
+        return self.msg
 
 class TestDidNotRun(Error):
     """Test did not run any subtests."""
@@ -279,9 +296,7 @@ def load_package_tests(pkg_dir, loader, standard_tests, pattern):
     """
     if pattern is None:
         pattern = "test*"
-    top_dir = os.path.dirname(              # Lib
-                  os.path.dirname(              # test
-                      os.path.dirname(__file__)))   # support
+    top_dir = STDLIB_DIR
     package_tests = loader.discover(start_dir=pkg_dir,
                                     top_level_dir=top_dir,
                                     pattern=pattern)
@@ -442,7 +457,7 @@ if sys.platform.startswith("win"):
                 try:
                     mode = os.lstat(fullname).st_mode
                 except OSError as exc:
-                    print("support.rmtree(): os.lstat(%r) failed with %s" % (fullname, exc),
+                    print("os_helper.rmtree(): os.lstat(%r) failed with %s" % (fullname, exc),
                           file=sys.__stderr__)
                     mode = 0
                 if stat.S_ISDIR(mode):
@@ -545,8 +560,11 @@ def forget(modname):
 def _is_gui_available():
     if hasattr(_is_gui_available, 'result'):
         return _is_gui_available.result
+    import platform
     reason = None
-    if sys.platform.startswith('win'):
+    if sys.platform.startswith('win') and platform.win32_is_iot():
+        reason = "gui is not available on Windows IoT Core"
+    elif sys.platform.startswith('win'):
         # if Python is running as a service (such as the buildbot service),
         # gui interaction may be disallowed
         import ctypes
@@ -640,25 +658,25 @@ def _requires_unix_version(sysname, min_version):
     For example, @_requires_unix_version('FreeBSD', (7, 2)) raises SkipTest if
     the FreeBSD version is less than 7.2.
     """
-    def decorator(func):
-        @functools.wraps(func)
-        def wrapper(*args, **kw):
-            if platform.system() == sysname:
-                version_txt = platform.release().split('-', 1)[0]
-                try:
-                    version = tuple(map(int, version_txt.split('.')))
-                except ValueError:
-                    pass
-                else:
-                    if version < min_version:
-                        min_version_txt = '.'.join(map(str, min_version))
-                        raise unittest.SkipTest(
-                            "%s version %s or higher required, not %s"
-                            % (sysname, min_version_txt, version_txt))
-            return func(*args, **kw)
-        wrapper.min_version = min_version
-        return wrapper
-    return decorator
+    import platform
+    min_version_txt = '.'.join(map(str, min_version))
+    version_txt = platform.release().split('-', 1)[0]
+    if platform.system() == sysname:
+        try:
+            version = tuple(map(int, version_txt.split('.')))
+        except ValueError:
+            skip = False
+        else:
+            skip = version < min_version
+    else:
+        skip = False
+
+    return unittest.skipIf(
+        skip,
+        f"{sysname} version {min_version_txt} or higher required, not "
+        f"{version_txt}"
+    )
+
 
 def requires_freebsd_version(*min_version):
     """Decorator raising SkipTest if the OS is FreeBSD and the FreeBSD version is
@@ -689,6 +707,7 @@ def requires_mac_ver(*min_version):
         @functools.wraps(func)
         def wrapper(*args, **kw):
             if sys.platform == 'darwin':
+                import platform
                 version_txt = platform.mac_ver()[0]
                 try:
                     version = tuple(map(int, version_txt.split('.')))
@@ -705,6 +724,16 @@ def requires_mac_ver(*min_version):
         return wrapper
     return decorator
 
+
+def skip_if_buildbot(reason=None):
+    """Decorator raising SkipTest if running on a buildbot."""
+    if not reason:
+        reason = 'not suitable for buildbots'
+    if sys.platform == 'win32':
+        isbuildbot = os.environ.get('USERNAME') == 'Buildbot'
+    else:
+        isbuildbot = os.environ.get('USER') == 'buildbot'
+    return unittest.skipIf(isbuildbot, reason)
 
 def requires_hashdigest(digestname, openssl=None):
     """Decorator raising SkipTest if a hashing algorithm is not available
@@ -888,8 +917,8 @@ PIPE_MAX_SIZE = 4 * 1024 * 1024 + 1
 # A constant likely larger than the underlying OS socket buffer size, to make
 # writes blocking.
 # The socket buffer sizes can usually be tuned system-wide (e.g. through sysctl
-# on Linux), or on a per-socket basis (SO_SNDBUF/SO_RCVBUF). See issue #18643
-# for a discussion of this number).
+# on Linux), or on a per-socket basis (SO_SNDBUF/SO_RCVBUF).  See issue #18643
+# for a discussion of this number.
 SOCK_MAX_SIZE = 16 * 1024 * 1024 + 1
 
 # # decorator for skipping tests on non-IEEE 754 platforms
@@ -910,155 +939,14 @@ is_jython = sys.platform.startswith('java')
 
 is_android = hasattr(sys, 'getandroidapilevel')
 
-if sys.platform != 'win32':
+if sys.platform not in ('win32', 'vxworks'):
     unix_shell = '/system/bin/sh' if is_android else '/bin/sh'
 else:
     unix_shell = None
 
-# Filename used for testing
-if os.name == 'java':
-    # Jython disallows @ in module names
-    TESTFN = '$test'
-else:
-    TESTFN = '@test'
-
-# Disambiguate TESTFN for parallel testing, while letting it remain a valid
-# module name.
-TESTFN = "{}_{}_tmp".format(TESTFN, os.getpid())
-
 # Define the URL of a dedicated HTTP server for the network tests.
 # The URL must use clear-text HTTP: no redirection to encrypted HTTPS.
 TEST_HTTP_URL = "http://www.pythontest.net"
-
-# FS_NONASCII: non-ASCII character encodable by os.fsencode(),
-# or None if there is no such character.
-FS_NONASCII = None
-for character in (
-    # First try printable and common characters to have a readable filename.
-    # For each character, the encoding list are just example of encodings able
-    # to encode the character (the list is not exhaustive).
-
-    # U+00E6 (Latin Small Letter Ae): cp1252, iso-8859-1
-    '\u00E6',
-    # U+0130 (Latin Capital Letter I With Dot Above): cp1254, iso8859_3
-    '\u0130',
-    # U+0141 (Latin Capital Letter L With Stroke): cp1250, cp1257
-    '\u0141',
-    # U+03C6 (Greek Small Letter Phi): cp1253
-    '\u03C6',
-    # U+041A (Cyrillic Capital Letter Ka): cp1251
-    '\u041A',
-    # U+05D0 (Hebrew Letter Alef): Encodable to cp424
-    '\u05D0',
-    # U+060C (Arabic Comma): cp864, cp1006, iso8859_6, mac_arabic
-    '\u060C',
-    # U+062A (Arabic Letter Teh): cp720
-    '\u062A',
-    # U+0E01 (Thai Character Ko Kai): cp874
-    '\u0E01',
-
-    # Then try more "special" characters. "special" because they may be
-    # interpreted or displayed differently depending on the exact locale
-    # encoding and the font.
-
-    # U+00A0 (No-Break Space)
-    '\u00A0',
-    # U+20AC (Euro Sign)
-    '\u20AC',
-):
-    try:
-        # If Python is set up to use the legacy 'mbcs' in Windows,
-        # 'replace' error mode is used, and encode() returns b'?'
-        # for characters missing in the ANSI codepage
-        if os.fsdecode(os.fsencode(character)) != character:
-            raise UnicodeError
-    except UnicodeError:
-        pass
-    else:
-        FS_NONASCII = character
-        break
-
-# TESTFN_UNICODE is a non-ascii filename
-TESTFN_UNICODE = TESTFN + "-\xe0\xf2\u0258\u0141\u011f"
-if sys.platform == 'darwin':
-    # In Mac OS X's VFS API file names are, by definition, canonically
-    # decomposed Unicode, encoded using UTF-8. See QA1173:
-    # http://developer.apple.com/mac/library/qa/qa2001/qa1173.html
-    import unicodedata
-    TESTFN_UNICODE = unicodedata.normalize('NFD', TESTFN_UNICODE)
-TESTFN_ENCODING = sys.getfilesystemencoding()
-
-# TESTFN_UNENCODABLE is a filename (str type) that should *not* be able to be
-# encoded by the filesystem encoding (in strict mode). It can be None if we
-# cannot generate such filename.
-TESTFN_UNENCODABLE = None
-if os.name == 'nt':
-    # skip win32s (0) or Windows 9x/ME (1)
-    if sys.getwindowsversion().platform >= 2:
-        # Different kinds of characters from various languages to minimize the
-        # probability that the whole name is encodable to MBCS (issue #9819)
-        TESTFN_UNENCODABLE = TESTFN + "-\u5171\u0141\u2661\u0363\uDC80"
-        try:
-            TESTFN_UNENCODABLE.encode(TESTFN_ENCODING)
-        except UnicodeEncodeError:
-            pass
-        else:
-            print('WARNING: The filename %r CAN be encoded by the filesystem encoding (%s). '
-                  'Unicode filename tests may not be effective'
-                  % (TESTFN_UNENCODABLE, TESTFN_ENCODING),
-                  file=sys.__stderr__)
-            TESTFN_UNENCODABLE = None
-# # Mac OS X denies unencodable filenames (invalid utf-8)
-# elif sys.platform != 'darwin':
-#     try:
-#         # ascii and utf-8 cannot encode the byte 0xff
-#         b'\xff'.decode(TESTFN_ENCODING)
-#     except UnicodeDecodeError:
-#         # 0xff will be encoded using the surrogate character u+DCFF
-#         TESTFN_UNENCODABLE = TESTFN \
-#             + b'-\xff'.decode(TESTFN_ENCODING, 'surrogateescape')
-#     else:
-#         # File system encoding (eg. ISO-8859-* encodings) can encode
-#         # the byte 0xff. Skip some unicode filename tests.
-#         pass
-
-# TESTFN_UNDECODABLE is a filename (bytes type) that should *not* be able to be
-# decoded from the filesystem encoding (in strict mode). It can be None if we
-# cannot generate such filename (ex: the latin1 encoding can decode any byte
-# sequence). On UNIX, TESTFN_UNDECODABLE can be decoded by os.fsdecode() thanks
-# to the surrogateescape error handler (PEP 383), but not from the filesystem
-# encoding in strict mode.
-TESTFN_UNDECODABLE = None
-for name in (
-    # b'\xff' is not decodable by os.fsdecode() with code page 932. Windows
-    # accepts it to create a file or a directory, or don't accept to enter to
-    # such directory (when the bytes name is used). So test b'\xe7' first: it is
-    # not decodable from cp932.
-    b'\xe7w\xf0',
-    # undecodable from ASCII, UTF-8
-    b'\xff',
-    # undecodable from iso8859-3, iso8859-6, iso8859-7, cp424, iso8859-8, cp856
-    # and cp857
-    b'\xae\xd5'
-    # undecodable from UTF-8 (UNIX and Mac OS X)
-    b'\xed\xb2\x80', b'\xed\xb4\x80',
-    # undecodable from shift_jis, cp869, cp874, cp932, cp1250, cp1251, cp1252,
-    # cp1253, cp1254, cp1255, cp1257, cp1258
-    b'\x81\x98',
-):
-    try:
-        name.decode(TESTFN_ENCODING)
-    except UnicodeDecodeError:
-        TESTFN_UNDECODABLE = os.fsencode(TESTFN) + name
-        break
-
-if FS_NONASCII:
-    TESTFN_NONASCII = TESTFN + '-' + FS_NONASCII
-else:
-    TESTFN_NONASCII = None
-
-# Save the initial cwd
-SAVEDCWD = os.getcwd()
 
 # Set by libregrtest/main.py so we can skip tests that are not
 # useful for PGO
@@ -1068,120 +956,27 @@ PGO = False
 # PGO task.  If this is True, PGO is also True.
 PGO_EXTENDED = False
 
-@contextlib.contextmanager
-def temp_dir(path=None, quiet=False):
-    """Return a context manager that creates a temporary directory.
-
-    Arguments:
-
-      path: the directory to create temporarily.  If omitted or None,
-        defaults to creating a temporary directory using tempfile.mkdtemp.
-
-      quiet: if False (the default), the context manager raises an exception
-        on error.  Otherwise, if the path is specified and cannot be
-        created, only a warning is issued.
-
-    """
-    dir_created = False
-    if path is None:
-        path = tempfile.mkdtemp()
-        dir_created = True
-        path = os.path.realpath(path)
-    else:
-        try:
-            os.mkdir(path)
-            dir_created = True
-        except OSError as exc:
-            if not quiet:
-                raise
-            warnings.warn(f'tests may fail, unable to create '
-                          f'temporary directory {path!r}: {exc}',
-                          RuntimeWarning, stacklevel=3)
-    if dir_created:
-        pid = os.getpid()
-    try:
-        yield path
-    finally:
-        # In case the process forks, let only the parent remove the
-        # directory. The child has a different process id. (bpo-30028)
-        if dir_created and pid == os.getpid():
-            try:
-                rmtree(path)
-            except OSError as exc:
-                # XXX RUSTPYTHON: something something async file removal?
-                #                 also part of the thing with rmtree()
-                #                 throwing PermissionError, I think
-                if os.path.exists(path):
-                    if not quiet:
-                        raise
-                    warnings.warn(f'unable to remove temporary'
-                                  f'directory {path!r}: {exc}',
-                                  RuntimeWarning, stacklevel=3)
-
-@contextlib.contextmanager
-def change_cwd(path, quiet=False):
-    """Return a context manager that changes the current working directory.
-
-    Arguments:
-
-      path: the directory to use as the temporary current working directory.
-
-      quiet: if False (the default), the context manager raises an exception
-        on error.  Otherwise, it issues only a warning and keeps the current
-        working directory the same.
-
-    """
-    saved_dir = os.getcwd()
-    try:
-        os.chdir(os.path.realpath(path))
-    except OSError as exc:
-        if not quiet:
-            raise
-        warnings.warn(f'tests may fail, unable to change the current working '
-                      f'directory to {path!r}: {exc}',
-                      RuntimeWarning, stacklevel=3)
-    try:
-        yield os.getcwd()
-    finally:
-        os.chdir(saved_dir)
-
-
-@contextlib.contextmanager
-def temp_cwd(name='tempcwd', quiet=False):
-    """
-    Context manager that temporarily creates and changes the CWD.
-
-    The function temporarily changes the current working directory
-    after creating a temporary directory in the current directory with
-    name *name*.  If *name* is None, the temporary directory is
-    created using tempfile.mkdtemp.
-
-    If *quiet* is False (default) and it is not possible to
-    create or change the CWD, an error is raised.  If *quiet* is True,
-    only a warning is raised and the original CWD is used.
-
-    """
-    with temp_dir(path=name, quiet=quiet) as temp_path:
-        with change_cwd(temp_path, quiet=quiet) as cwd_dir:
-            yield cwd_dir
-
-if hasattr(os, "umask"):
-    @contextlib.contextmanager
-    def temp_umask(umask):
-        """Context manager that temporarily sets the process umask."""
-        oldmask = os.umask(umask)
-        try:
-            yield
-        finally:
-            os.umask(oldmask)
-
-# TEST_HOME_DIR refers to the top level directory of the "test" package
-# that contains Python's regression test suite
-TEST_SUPPORT_DIR = os.path.dirname(os.path.abspath(__file__))
-TEST_HOME_DIR = os.path.dirname(TEST_SUPPORT_DIR)
-
 # TEST_DATA_DIR is used as a target download location for remote resources
 TEST_DATA_DIR = os.path.join(TEST_HOME_DIR, "data")
+
+
+def darwin_malloc_err_warning(test_name):
+    """Assure user that loud errors generated by macOS libc's malloc are
+    expected."""
+    if sys.platform != 'darwin':
+        return
+
+    import shutil
+    msg = ' NOTICE '
+    detail = (f'{test_name} may generate "malloc can\'t allocate region"\n'
+              'warnings on macOS systems. This behavior is known. Do not\n'
+              'report a bug unless tests are also failing. See bpo-40928.')
+
+    padding, _ = shutil.get_terminal_size()
+    print(msg.center(padding, '-'))
+    print(detail)
+    print('-' * padding)
+
 
 def findfile(filename, subdir=None):
     """Try to find a file on sys.path or in the test directory.  If it is not
@@ -1201,10 +996,6 @@ def findfile(filename, subdir=None):
         if os.path.exists(fn): return fn
     return filename
 
-def create_empty_file(filename):
-    """Create an empty file. If the file already exists, truncate it."""
-    fd = os.open(filename, os.O_WRONLY | os.O_CREAT | os.O_TRUNC)
-    os.close(fd)
 
 def sortdict(dict):
     "Like repr(dict), but in sorted order."
@@ -1212,19 +1003,6 @@ def sortdict(dict):
     reprpairs = ["%r: %r" % pair for pair in items]
     withcommas = ", ".join(reprpairs)
     return "{%s}" % withcommas
-
-def make_bad_fd():
-    """
-    Create an invalid file descriptor by opening and closing a file and return
-    its fd.
-    """
-    file = open(TESTFN, "wb")
-    try:
-        return file.fileno()
-    finally:
-        file.close()
-        unlink(TESTFN)
-
 
 def check_syntax_error(testcase, statement, errtext='', *, lineno=None, offset=None):
     with testcase.assertRaisesRegex(SyntaxError, errtext) as cm:
@@ -1266,6 +1044,11 @@ def check_syntax_warning(testcase, statement, errtext='', *, lineno=1, offset=No
 
 def open_urlresource(url, *args, **kw):
     import urllib.request, urllib.parse
+    from .os_helper import unlink
+    try:
+        import gzip
+    except ImportError:
+        gzip = None
 
     check = kw.pop('check', None)
 
@@ -1296,7 +1079,7 @@ def open_urlresource(url, *args, **kw):
     opener = urllib.request.build_opener()
     if gzip:
         opener.addheaders.append(('Accept-Encoding', 'gzip'))
-    f = opener.open(url, timeout=15)
+    f = opener.open(url, timeout=INTERNET_TIMEOUT)
     if gzip and f.headers.get('Content-Encoding') == 'gzip':
         f = gzip.GzipFile(fileobj=f)
     try:
@@ -1472,59 +1255,6 @@ class CleanImport(object):
 
     def __exit__(self, *ignore_exc):
         sys.modules.update(self.original_modules)
-
-
-class EnvironmentVarGuard(collections.abc.MutableMapping):
-
-    """Class to help protect the environment variable properly.  Can be used as
-    a context manager."""
-
-    def __init__(self):
-        self._environ = os.environ
-        self._changed = {}
-
-    def __getitem__(self, envvar):
-        return self._environ[envvar]
-
-    def __setitem__(self, envvar, value):
-        # Remember the initial value on the first access
-        if envvar not in self._changed:
-            self._changed[envvar] = self._environ.get(envvar)
-        self._environ[envvar] = value
-
-    def __delitem__(self, envvar):
-        # Remember the initial value on the first access
-        if envvar not in self._changed:
-            self._changed[envvar] = self._environ.get(envvar)
-        if envvar in self._environ:
-            del self._environ[envvar]
-
-    def keys(self):
-        return self._environ.keys()
-
-    def __iter__(self):
-        return iter(self._environ)
-
-    def __len__(self):
-        return len(self._environ)
-
-    def set(self, envvar, value):
-        self[envvar] = value
-
-    def unset(self, envvar):
-        del self[envvar]
-
-    def __enter__(self):
-        return self
-
-    def __exit__(self, *ignore_exc):
-        for (k, v) in self._changed.items():
-            if v is None:
-                if k in self._environ:
-                    del self._environ[k]
-            else:
-                self._environ[k] = v
-        os.environ = self._environ
 
 
 class DirsOnSysPath(object):
@@ -1737,6 +1467,7 @@ def gc_collect():
     longer than expected.  This function tries its best to force all garbage
     objects to disappear.
     """
+    # TODO: RUSTPYTHON (comment out before)
     # gc.collect()
     # if is_jython:
     #     time.sleep(0.1)
@@ -1746,6 +1477,7 @@ def gc_collect():
 
 @contextlib.contextmanager
 def disable_gc():
+    # TODO: RUSTPYTHON (comment out before)
     # have_gc = gc.isenabled()
     # gc.disable()
     # try:
@@ -1784,12 +1516,15 @@ _TPFLAGS_HAVE_GC = 1<<14
 _TPFLAGS_HEAPTYPE = 1<<9
 
 def check_sizeof(test, o, size):
-    import _testcapi
+    try:
+        import _testinternalcapi
+    except ImportError:
+        raise unittest.SkipTest("_testinternalcapi required")
     result = sys.getsizeof(o)
     # add GC header size
     if ((type(o) == type) and (o.__flags__ & _TPFLAGS_HEAPTYPE) or\
         ((type(o) != type) and (type(o).__flags__ & _TPFLAGS_HAVE_GC))):
-        size += _testcapi.SIZEOF_PYGC_HEAD
+        size += _testinternalcapi.SIZEOF_PYGC_HEAD
     msg = 'wrong size for %s: got %d, expected %d' \
             % (type(o), result, size)
     test.assertEqual(result, size, msg)
@@ -1798,9 +1533,8 @@ def check_sizeof(test, o, size):
 # Decorator for running a function in a different locale, correctly resetting
 # it afterwards.
 
+@contextlib.contextmanager
 def run_with_locale(catstr, *locales):
-    def decorator(func):
-        def inner(*args, **kwds):
             try:
                 import locale
                 category = getattr(locale, catstr)
@@ -1819,16 +1553,11 @@ def run_with_locale(catstr, *locales):
                     except:
                         pass
 
-            # now run the function, resetting the locale on exceptions
             try:
-                return func(*args, **kwds)
+                yield
             finally:
                 if locale and orig_locale:
                     locale.setlocale(category, orig_locale)
-        inner.__name__ = func.__name__
-        inner.__doc__ = func.__doc__
-        return inner
-    return decorator
 
 #=======================================================================
 # Decorator for running a function in a specific timezone, correctly
@@ -1907,6 +1636,7 @@ class _MemoryWatchdog:
         self.started = False
 
     def start(self):
+        import warnings
         try:
             f = open(self.procfile, 'r')
         except OSError as e:
@@ -1915,6 +1645,7 @@ class _MemoryWatchdog:
             sys.stderr.flush()
             return
 
+        import subprocess
         with f:
             watchdog_script = findfile("memory_watchdog.py")
             self.mem_watchdog = subprocess.Popen([sys.executable, watchdog_script],
@@ -2048,7 +1779,7 @@ def check_impl_detail(**guards):
           if check_impl_detail(cpython=False):  # everywhere except on CPython
     """
     guards, default = _parse_guards(guards)
-    return guards.get(platform.python_implementation().lower(), default)
+    return guards.get(sys.implementation.name, default)
 
 
 def no_tracing(func):
@@ -2111,7 +1842,9 @@ def _run_suite(suite):
         else:
             err = "multiple errors occurred"
             if not verbose: err += "; run in verbose mode for details"
-        raise TestFailed(err)
+        errors = [(str(tc), exc_str) for tc, exc_str in result.errors]
+        failures = [(str(tc), exc_str) for tc, exc_str in result.failures]
+        raise TestFailedWithDetails(err, errors, failures)
 
 
 # By default, don't filter tests
@@ -2182,6 +1915,7 @@ def _compile_match_function(patterns):
         # The test.bisect_cmd utility only uses such full test identifiers.
         func = set(patterns).__contains__
     else:
+        import fnmatch
         regex = '|'.join(map(fnmatch.translate, patterns))
         # The search *is* case sensitive on purpose:
         # don't use flags=re.IGNORECASE
@@ -2206,17 +1940,18 @@ def _compile_match_function(patterns):
 def run_unittest(*classes):
     """Run tests from unittest.TestCase-derived classes."""
     valid_types = (unittest.TestSuite, unittest.TestCase)
+    loader = unittest.TestLoader()
     suite = unittest.TestSuite()
     for cls in classes:
         if isinstance(cls, str):
             if cls in sys.modules:
-                suite.addTest(unittest.findTestCases(sys.modules[cls]))
+                suite.addTest(loader.loadTestsFromModule(sys.modules[cls]))
             else:
                 raise ValueError("str arguments must be keys in sys.modules")
         elif isinstance(cls, valid_types):
             suite.addTest(cls)
         else:
-            suite.addTest(unittest.makeSuite(cls))
+            suite.addTest(loader.loadTestsFromTestCase(cls))
     _filter_suite(suite, match_test)
     _run_suite(suite)
 
@@ -2270,11 +2005,24 @@ def run_doctest(module, verbosity=None, optionflags=0):
 #=======================================================================
 # Support for saving and restoring the imported modules.
 
+def flush_std_streams():
+    if sys.stdout is not None:
+        sys.stdout.flush()
+    if sys.stderr is not None:
+        sys.stderr.flush()
+
+
 def print_warning(msg):
-    # bpo-39983: Print into sys.__stderr__ to display the warning even
-    # when sys.stderr is captured temporarily by a test
+    # bpo-45410: Explicitly flush stdout to keep logs in order
+    flush_std_streams()
+    stream = print_warning.orig_stderr
     for line in msg.splitlines():
-        print(f"Warning -- {line}", file=sys.__stderr__, flush=True)
+        print(f"Warning -- {line}", file=stream)
+    stream.flush()
+
+# bpo-39983: Store the original sys.stderr at Python startup to be able to
+# log warnings even if sys.stderr is captured temporarily by a test.
+print_warning.orig_stderr = sys.stderr
 
 def modules_setup():
     return sys.modules.copy(),
@@ -2302,7 +2050,7 @@ def modules_cleanup(oldmodules):
 # to check if a test modified the environment. The flag should be set to False
 # before running a new test.
 #
-# For example, threading_cleanup() sets the flag is the function fails
+# For example, threading_helper.threading_cleanup() sets the flag is the function fails
 # to cleanup threads.
 environment_altered = False
 
@@ -2548,11 +2296,13 @@ requires_type_collecting = unittest.skipIf(hasattr(sys, 'getcounts'),
 def args_from_interpreter_flags():
     """Return a list of command-line arguments reproducing the current
     settings in sys.flags and sys.warnoptions."""
+    import subprocess
     return subprocess._args_from_interpreter_flags()
 
 def optim_args_from_interpreter_flags():
     """Return a list of command-line arguments reproducing the current
     optimization settings in sys.flags."""
+    import subprocess
     return subprocess._optim_args_from_interpreter_flags()
 
 #============================================================
@@ -2621,28 +2371,6 @@ class Matcher(object):
         return result
 
 
-_can_symlink = None
-def can_symlink():
-    global _can_symlink
-    if _can_symlink is not None:
-        return _can_symlink
-    symlink_path = TESTFN + "can_symlink"
-    try:
-        os.symlink(TESTFN, symlink_path)
-        can = True
-    except (OSError, NotImplementedError, AttributeError):
-        can = False
-    else:
-        os.remove(symlink_path)
-    _can_symlink = can
-    return can
-
-def skip_unless_symlink(test):
-    """Skip decorator for tests that require functional symlink"""
-    ok = can_symlink()
-    msg = "Requires functional symlink implementation"
-    return test if ok else unittest.skip(msg)(test)
-
 _buggy_ucrt = None
 def skip_if_buggy_ucrt_strfptime(test):
     """
@@ -2654,6 +2382,7 @@ def skip_if_buggy_ucrt_strfptime(test):
     See bpo-37552 [Windows] strptime/strftime return invalid
     results with UCRT version 17763.615
     """
+    import locale
     global _buggy_ucrt
     if _buggy_ucrt is None:
         if(sys.platform == 'win32' and
@@ -2667,6 +2396,8 @@ def skip_if_buggy_ucrt_strfptime(test):
 class PythonSymlink:
     """Creates a symlink for the current Python executable"""
     def __init__(self, link=None):
+        from .os_helper import TESTFN
+
         self.link = link or os.path.abspath(TESTFN)
         self._linked = []
         self.real = os.path.realpath(sys.executable)
@@ -2681,6 +2412,7 @@ class PythonSymlink:
 
     if sys.platform == "win32":
         def _platform_specific(self):
+            import glob
             import _winapi
 
             if os.path.lexists(self.real) and not os.path.exists(self.real):
@@ -2695,7 +2427,7 @@ class PythonSymlink:
                 dll,
                 os.path.join(dest_dir, os.path.basename(dll))
             ))
-            for runtime in glob.glob(os.path.join(src_dir, "vcruntime*.dll")):
+            for runtime in glob.glob(os.path.join(glob.escape(src_dir), "vcruntime*.dll")):
                 self._also_link.append((
                     runtime,
                     os.path.join(dest_dir, os.path.basename(runtime))
@@ -2704,7 +2436,7 @@ class PythonSymlink:
             self._env = {k.upper(): os.getenv(k) for k in os.environ}
             self._env["PYTHONHOME"] = os.path.dirname(self.real)
             if sysconfig.is_python_build(True):
-                self._env["PYTHONPATH"] = os.path.dirname(os.__file__)
+                self._env["PYTHONPATH"] = STDLIB_DIR
 
     def __enter__(self):
         os.symlink(self.real, self.link)
@@ -2723,6 +2455,7 @@ class PythonSymlink:
                     print("failed to clean up {}: {}".format(link, ex))
 
     def _call(self, python, args, env, returncode):
+        import subprocess
         cmd = [python, *args]
         p = subprocess.Popen(cmd, stdout=subprocess.PIPE,
                              stderr=subprocess.PIPE, env=env)
@@ -2742,43 +2475,6 @@ class PythonSymlink:
         return self._call(self.link, args, self._env, returncode)
 
 
-_can_xattr = None
-def can_xattr():
-    global _can_xattr
-    if _can_xattr is not None:
-        return _can_xattr
-    if not hasattr(os, "setxattr"):
-        can = False
-    else:
-        tmp_dir = tempfile.mkdtemp()
-        tmp_fp, tmp_name = tempfile.mkstemp(dir=tmp_dir)
-        try:
-            with open(TESTFN, "wb") as fp:
-                try:
-                    # TESTFN & tempfile may use different file systems with
-                    # different capabilities
-                    os.setxattr(tmp_fp, b"user.test", b"")
-                    os.setxattr(tmp_name, b"trusted.foo", b"42")
-                    os.setxattr(fp.fileno(), b"user.test", b"")
-                    # Kernels < 2.6.39 don't respect setxattr flags.
-                    kernel_version = platform.release()
-                    m = re.match(r"2.6.(\d{1,2})", kernel_version)
-                    can = m is None or int(m.group(1)) >= 39
-                except OSError:
-                    can = False
-        finally:
-            unlink(TESTFN)
-            unlink(tmp_name)
-            rmdir(tmp_dir)
-    _can_xattr = can
-    return can
-
-def skip_unless_xattr(test):
-    """Skip decorator for tests that require functional extended attributes"""
-    ok = can_xattr()
-    msg = "no non-broken extended attribute support"
-    return test if ok else unittest.skip(msg)(test)
-
 def skip_if_pgo_task(test):
     """Skip decorator for tests not run in (non-extended) PGO task"""
     ok = not PGO or PGO_EXTENDED
@@ -2788,6 +2484,7 @@ def skip_if_pgo_task(test):
 _bind_nix_socket_error = None
 def skip_unless_bind_unix_socket(test):
     """Decorator for tests requiring a functional bind() for unix sockets."""
+    from .os_helper import TESTFN
     if not hasattr(socket, 'AF_UNIX'):
         return unittest.skip('No UNIX Sockets')(test)
     global _bind_nix_socket_error
@@ -2808,18 +2505,6 @@ def skip_unless_bind_unix_socket(test):
         return test
 
 
-def fs_is_case_insensitive(directory):
-    """Detects if the file system for the specified directory is case-insensitive."""
-    with tempfile.NamedTemporaryFile(dir=directory) as base:
-        base_path = base.name
-        case_path = base_path.upper()
-        if case_path == base_path:
-            case_path = base_path.lower()
-        try:
-            return os.path.samefile(base_path, case_path)
-        except FileNotFoundError:
-            return False
-
 
 def detect_api_mismatch(ref_api, other_api, *, ignore=()):
     """Returns the set of items in ref_api not in other_api, except for a
@@ -2837,7 +2522,7 @@ def detect_api_mismatch(ref_api, other_api, *, ignore=()):
 
 
 def check__all__(test_case, module, name_of_module=None, extra=(),
-                 blacklist=()):
+                 not_exported=()):
     """Assert that the __all__ variable of 'module' contains all public names.
 
     The module's public names (its API) are detected automatically based on
@@ -2854,7 +2539,7 @@ def check__all__(test_case, module, name_of_module=None, extra=(),
     '__module__' attribute. If provided, it will be added to the
     automatically detected ones.
 
-    The 'blacklist' argument can be a set of names that must not be treated
+    The 'not_exported' argument can be a set of names that must not be treated
     as part of the public API even though their names indicate otherwise.
 
     Usage:
@@ -2870,10 +2555,10 @@ def check__all__(test_case, module, name_of_module=None, extra=(),
         class OtherTestCase(unittest.TestCase):
             def test__all__(self):
                 extra = {'BAR_CONST', 'FOO_CONST'}
-                blacklist = {'baz'}  # Undocumented name.
+                not_exported = {'baz'}  # Undocumented name.
                 # bar imports part of its API from _bar.
                 support.check__all__(self, bar, ('bar', '_bar'),
-                                     extra=extra, blacklist=blacklist)
+                                     extra=extra, not_exported=not_exported)
 
     """
 
@@ -2885,7 +2570,7 @@ def check__all__(test_case, module, name_of_module=None, extra=(),
     expected = set(extra)
 
     for name in dir(module):
-        if name.startswith('_') or name in blacklist:
+        if name.startswith('_') or name in not_exported:
             continue
         obj = getattr(module, name)
         if (getattr(obj, '__module__', None) in name_of_module or
@@ -2893,6 +2578,27 @@ def check__all__(test_case, module, name_of_module=None, extra=(),
                  not isinstance(obj, types.ModuleType))):
             expected.add(name)
     test_case.assertCountEqual(module.__all__, expected)
+
+
+def suppress_msvcrt_asserts(verbose=False):
+    try:
+        import msvcrt
+    except ImportError:
+        return
+
+    msvcrt.SetErrorMode(msvcrt.SEM_FAILCRITICALERRORS
+                        | msvcrt.SEM_NOALIGNMENTFAULTEXCEPT
+                        | msvcrt.SEM_NOGPFAULTERRORBOX
+                        | msvcrt.SEM_NOOPENFILEERRORBOX)
+
+    # CrtSetReportMode() is only available in debug build
+    if hasattr(msvcrt, 'CrtSetReportMode'):
+        for m in [msvcrt.CRT_WARN, msvcrt.CRT_ERROR, msvcrt.CRT_ASSERT]:
+            if verbose:
+                msvcrt.CrtSetReportMode(m, msvcrt.CRTDBG_MODE_FILE)
+                msvcrt.CrtSetReportFile(m, msvcrt.CRTDBG_FILE_STDERR)
+            else:
+                msvcrt.CrtSetReportMode(m, 0)
 
 
 class SuppressCrashReport:
@@ -2906,30 +2612,25 @@ class SuppressCrashReport:
 
     def __enter__(self):
         """On Windows, disable Windows Error Reporting dialogs using
-        SetErrorMode.
+        SetErrorMode() and CrtSetReportMode().
 
         On UNIX, try to save the previous core file size limit, then set
         soft limit to 0.
         """
         if sys.platform.startswith('win'):
             # see http://msdn.microsoft.com/en-us/library/windows/desktop/ms680621.aspx
-            # GetErrorMode is not available on Windows XP and Windows Server 2003,
-            # but SetErrorMode returns the previous value, so we can use that
-            import ctypes
-            self._k32 = ctypes.windll.kernel32
-            SEM_NOGPFAULTERRORBOX = 0x02
-            self.old_value = self._k32.SetErrorMode(SEM_NOGPFAULTERRORBOX)
-            self._k32.SetErrorMode(self.old_value | SEM_NOGPFAULTERRORBOX)
-
-            # Suppress assert dialogs in debug builds
-            # (see http://bugs.python.org/issue23314)
             try:
                 import msvcrt
-                msvcrt.CrtSetReportMode
-            except (AttributeError, ImportError):
-                # no msvcrt or a release build
-                pass
-            else:
+            except ImportError:
+                return
+
+            self.old_value = msvcrt.GetErrorMode()
+
+            msvcrt.SetErrorMode(self.old_value | msvcrt.SEM_NOGPFAULTERRORBOX)
+
+            # bpo-23314: Suppress assert dialogs in debug builds.
+            # CrtSetReportMode() is only available in debug build.
+            if hasattr(msvcrt, 'CrtSetReportMode'):
                 self.old_modes = {}
                 for report_type in [msvcrt.CRT_WARN,
                                     msvcrt.CRT_ERROR,
@@ -2941,15 +2642,21 @@ class SuppressCrashReport:
                     self.old_modes[report_type] = old_mode, old_file
 
         else:
-            if resource is not None:
+            try:
+                import resource
+                self.resource = resource
+            except ImportError:
+                self.resource = None
+            if self.resource is not None:
                 try:
-                    self.old_value = resource.getrlimit(resource.RLIMIT_CORE)
-                    resource.setrlimit(resource.RLIMIT_CORE,
+                    self.old_value = self.resource.getrlimit(self.resource.RLIMIT_CORE)
+                    self.resource.setrlimit(self.resource.RLIMIT_CORE,
                                        (0, self.old_value[1]))
                 except (ValueError, OSError):
                     pass
 
             if sys.platform == 'darwin':
+                import subprocess
                 # Check if the 'Crash Reporter' on OSX was configured
                 # in 'Developer' mode and warn that it will get triggered
                 # when it is.
@@ -2975,17 +2682,17 @@ class SuppressCrashReport:
             return
 
         if sys.platform.startswith('win'):
-            self._k32.SetErrorMode(self.old_value)
+            import msvcrt
+            msvcrt.SetErrorMode(self.old_value)
 
             if self.old_modes:
-                import msvcrt
                 for report_type, (old_mode, old_file) in self.old_modes.items():
                     msvcrt.CrtSetReportMode(report_type, old_mode)
                     msvcrt.CrtSetReportFile(report_type, old_file)
         else:
-            if resource is not None:
+            if self.resource is not None:
                 try:
-                    resource.setrlimit(resource.RLIMIT_CORE, self.old_value)
+                    self.resource.setrlimit(self.resource.RLIMIT_CORE, self.old_value)
                 except (ValueError, OSError):
                     pass
 
@@ -3044,6 +2751,7 @@ def run_in_subinterp(code):
     return _testcapi.run_in_subinterp(code)
 
 
+# TODO: RUSTPYTHON (comment out before)
 # def check_free_after_iterating(test, iter, cls, args=()):
 #     class A(cls):
 #         def __del__(self):
@@ -3072,9 +2780,16 @@ def missing_compiler_executable(cmd_names=[]):
     missing.
 
     """
-    from distutils import ccompiler, sysconfig, spawn
+    # TODO (PEP 632): alternate check without using distutils
+    from distutils import ccompiler, sysconfig, spawn, errors
     compiler = ccompiler.new_compiler()
     sysconfig.customize_compiler(compiler)
+    if compiler.compiler_type == "msvc":
+        # MSVC has no executables, so check whether initialization succeeds
+        try:
+            compiler.initialize()
+        except errors.DistutilsPlatformError:
+            return "msvc"
     for name in compiler.executables:
         if cmd_names and name not in cmd_names:
             continue
@@ -3096,6 +2811,7 @@ def setswitchinterval(interval):
     if is_android and interval < minimum_interval:
         global _is_android_emulator
         if _is_android_emulator is None:
+            import subprocess
             _is_android_emulator = (subprocess.check_output(
                                ['getprop', 'ro.kernel.qemu']).strip() == b'1')
         if _is_android_emulator:
@@ -3105,6 +2821,8 @@ def setswitchinterval(interval):
 
 @contextlib.contextmanager
 def disable_faulthandler():
+    import faulthandler
+
     # use sys.__stderr__ instead of sys.stderr, since regrtest replaces
     # sys.stderr with a StringIO which has no file descriptor when a test
     # is run with -W/--verbose3.
@@ -3117,65 +2835,6 @@ def disable_faulthandler():
     finally:
         if is_enabled:
             faulthandler.enable(file=fd, all_threads=True)
-
-
-def fd_count():
-    """Count the number of open file descriptors.
-    """
-    if sys.platform.startswith(('linux', 'freebsd')):
-        try:
-            names = os.listdir("/proc/self/fd")
-            # Subtract one because listdir() internally opens a file
-            # descriptor to list the content of the /proc/self/fd/ directory.
-            return len(names) - 1
-        except FileNotFoundError:
-            pass
-
-    MAXFD = 256
-    if hasattr(os, 'sysconf'):
-        try:
-            MAXFD = os.sysconf("SC_OPEN_MAX")
-        except OSError:
-            pass
-
-    old_modes = None
-    if sys.platform == 'win32':
-        # bpo-25306, bpo-31009: Call CrtSetReportMode() to not kill the process
-        # on invalid file descriptor if Python is compiled in debug mode
-        try:
-            import msvcrt
-            msvcrt.CrtSetReportMode
-        except (AttributeError, ImportError):
-            # no msvcrt or a release build
-            pass
-        else:
-            old_modes = {}
-            for report_type in (msvcrt.CRT_WARN,
-                                msvcrt.CRT_ERROR,
-                                msvcrt.CRT_ASSERT):
-                old_modes[report_type] = msvcrt.CrtSetReportMode(report_type, 0)
-
-    try:
-        count = 0
-        for fd in range(MAXFD):
-            try:
-                # Prefer dup() over fstat(). fstat() can require input/output
-                # whereas dup() doesn't.
-                fd2 = os.dup(fd)
-            except OSError as e:
-                if e.errno != errno.EBADF:
-                    raise
-            else:
-                os.close(fd2)
-                count += 1
-    finally:
-        if old_modes is not None:
-            for report_type in (msvcrt.CRT_WARN,
-                                msvcrt.CRT_ERROR,
-                                msvcrt.CRT_ASSERT):
-                msvcrt.CrtSetReportMode(report_type, old_modes[report_type])
-
-    return count
 
 
 class SaveSignals:
@@ -3222,24 +2881,6 @@ def with_pymalloc():
     return _testcapi.WITH_PYMALLOC
 
 
-class FakePath:
-    """Simple implementing of the path protocol.
-    """
-    def __init__(self, path):
-        self.path = path
-
-    def __repr__(self):
-        return f'<FakePath {self.path!r}>'
-
-    def __fspath__(self):
-        if (isinstance(self.path, BaseException) or
-            isinstance(self.path, type) and
-                issubclass(self.path, BaseException)):
-            raise self.path
-        else:
-            return self.path
-
-
 class _ALWAYS_EQ:
     """
     Object that is equal to anything.
@@ -3250,6 +2891,19 @@ class _ALWAYS_EQ:
         return False
 
 ALWAYS_EQ = _ALWAYS_EQ()
+
+class _NEVER_EQ:
+    """
+    Object that is not equal to anything.
+    """
+    def __eq__(self, other):
+        return False
+    def __ne__(self, other):
+        return True
+    def __hash__(self):
+        return 1
+
+NEVER_EQ = _NEVER_EQ()
 
 @functools.total_ordering
 class _LARGEST:
@@ -3277,6 +2931,7 @@ SMALLEST = _SMALLEST()
 
 def maybe_get_event_loop_policy():
     """Return the global event loop policy if one is set, else return None."""
+    import asyncio.events
     return asyncio.events._event_loop_policy
 
 # Helpers for testing hashing.
@@ -3426,7 +3081,9 @@ def wait_process(pid, *, exitcode, timeout=None):
     """
     Wait until process pid completes and check that the process exit code is
     exitcode.
+
     Raise an AssertionError if the process exit code is not equal to exitcode.
+
     If the process runs longer than timeout seconds (SHORT_TIMEOUT by default),
     kill the process (if signal.SIGKILL is available) and raise an
     AssertionError. The timeout feature is not available on Windows.
@@ -3471,3 +3128,87 @@ def wait_process(pid, *, exitcode, timeout=None):
     # sanity check: it should not fail in practice
     if pid2 != pid:
         raise AssertionError(f"pid {pid2} != pid {pid}")
+
+def skip_if_broken_multiprocessing_synchronize():
+    """
+    Skip tests if the multiprocessing.synchronize module is missing, if there
+    is no available semaphore implementation, or if creating a lock raises an
+    OSError (on Linux only).
+    """
+    from .import_helper import import_module
+
+    # Skip tests if the _multiprocessing extension is missing.
+    import_module('_multiprocessing')
+
+    # Skip tests if there is no available semaphore implementation:
+    # multiprocessing.synchronize requires _multiprocessing.SemLock.
+    synchronize = import_module('multiprocessing.synchronize')
+
+    if sys.platform == "linux":
+        try:
+            # bpo-38377: On Linux, creating a semaphore fails with OSError
+            # if the current user does not have the permission to create
+            # a file in /dev/shm/ directory.
+            synchronize.Lock(ctx=None)
+        except OSError as exc:
+            raise unittest.SkipTest(f"broken multiprocessing SemLock: {exc!r}")
+
+
+def check_disallow_instantiation(testcase, tp, *args, **kwds):
+    """
+    Check that given type cannot be instantiated using *args and **kwds.
+
+    See bpo-43916: Add Py_TPFLAGS_DISALLOW_INSTANTIATION type flag.
+    """
+    mod = tp.__module__
+    name = tp.__name__
+    if mod != 'builtins':
+        qualname = f"{mod}.{name}"
+    else:
+        qualname = f"{name}"
+    msg = f"cannot create '{re.escape(qualname)}' instances"
+    testcase.assertRaisesRegex(TypeError, msg, tp, *args, **kwds)
+
+@contextlib.contextmanager
+def infinite_recursion(max_depth=75):
+    """Set a lower limit for tests that interact with infinite recursions
+    (e.g test_ast.ASTHelpers_Test.test_recursion_direct) since on some
+    debug windows builds, due to not enough functions being inlined the
+    stack size might not handle the default recursion limit (1000). See
+    bpo-11105 for details."""
+
+    original_depth = sys.getrecursionlimit()
+    try:
+        sys.setrecursionlimit(max_depth)
+        yield
+    finally:
+        sys.setrecursionlimit(original_depth)
+
+def ignore_deprecations_from(module: str, *, like: str) -> object:
+    token = object()
+    warnings.filterwarnings(
+        "ignore",
+        category=DeprecationWarning,
+        module=module,
+        message=like + fr"(?#support{id(token)})",
+    )
+    return token
+
+def clear_ignored_deprecations(*tokens: object) -> None:
+    if not tokens:
+        raise ValueError("Provide token or tokens returned by ignore_deprecations_from")
+
+    new_filters = []
+    endswith = tuple(rf"(?#support{id(token)})" for token in tokens)
+    for action, message, category, module, lineno in warnings.filters:
+        if action == "ignore" and category is DeprecationWarning:
+            if isinstance(message, re.Pattern):
+                msg = message.pattern
+            else:
+                msg = message or ""
+            if msg.endswith(endswith):
+                continue
+        new_filters.append((action, message, category, module, lineno))
+    if warnings.filters != new_filters:
+        warnings.filters[:] = new_filters
+        warnings._filters_mutated()

--- a/Lib/test/support/os_helper.py
+++ b/Lib/test/support/os_helper.py
@@ -1,0 +1,617 @@
+import collections.abc
+import contextlib
+import errno
+import os
+import re
+import stat
+import sys
+import time
+import unittest
+import warnings
+
+
+# Filename used for testing
+if os.name == 'java':
+    # Jython disallows @ in module names
+    TESTFN_ASCII = '$test'
+else:
+    TESTFN_ASCII = '@test'
+
+# Disambiguate TESTFN for parallel testing, while letting it remain a valid
+# module name.
+TESTFN_ASCII = "{}_{}_tmp".format(TESTFN_ASCII, os.getpid())
+
+# TESTFN_UNICODE is a non-ascii filename
+TESTFN_UNICODE = TESTFN_ASCII + "-\xe0\xf2\u0258\u0141\u011f"
+if sys.platform == 'darwin':
+    # In Mac OS X's VFS API file names are, by definition, canonically
+    # decomposed Unicode, encoded using UTF-8. See QA1173:
+    # http://developer.apple.com/mac/library/qa/qa2001/qa1173.html
+    import unicodedata
+    TESTFN_UNICODE = unicodedata.normalize('NFD', TESTFN_UNICODE)
+
+# TESTFN_UNENCODABLE is a filename (str type) that should *not* be able to be
+# encoded by the filesystem encoding (in strict mode). It can be None if we
+# cannot generate such filename.
+TESTFN_UNENCODABLE = None
+if os.name == 'nt':
+    # skip win32s (0) or Windows 9x/ME (1)
+    if sys.getwindowsversion().platform >= 2:
+        # Different kinds of characters from various languages to minimize the
+        # probability that the whole name is encodable to MBCS (issue #9819)
+        TESTFN_UNENCODABLE = TESTFN_ASCII + "-\u5171\u0141\u2661\u0363\uDC80"
+        try:
+            TESTFN_UNENCODABLE.encode(sys.getfilesystemencoding())
+        except UnicodeEncodeError:
+            pass
+        else:
+            print('WARNING: The filename %r CAN be encoded by the filesystem '
+                  'encoding (%s). Unicode filename tests may not be effective'
+                  % (TESTFN_UNENCODABLE, sys.getfilesystemencoding()))
+            TESTFN_UNENCODABLE = None
+# TODO: RUSTPYTHON comment out before
+# # Mac OS X denies unencodable filenames (invalid utf-8)
+# elif sys.platform != 'darwin':
+#     try:
+#         # ascii and utf-8 cannot encode the byte 0xff
+#         b'\xff'.decode(sys.getfilesystemencoding())
+#     except UnicodeDecodeError:
+#         # 0xff will be encoded using the surrogate character u+DCFF
+#         TESTFN_UNENCODABLE = TESTFN_ASCII \
+#             + b'-\xff'.decode(sys.getfilesystemencoding(), 'surrogateescape')
+#     else:
+#         # File system encoding (eg. ISO-8859-* encodings) can encode
+#         # the byte 0xff. Skip some unicode filename tests.
+#         pass
+
+# FS_NONASCII: non-ASCII character encodable by os.fsencode(),
+# or an empty string if there is no such character.
+FS_NONASCII = ''
+for character in (
+    # First try printable and common characters to have a readable filename.
+    # For each character, the encoding list are just example of encodings able
+    # to encode the character (the list is not exhaustive).
+
+    # U+00E6 (Latin Small Letter Ae): cp1252, iso-8859-1
+    '\u00E6',
+    # U+0130 (Latin Capital Letter I With Dot Above): cp1254, iso8859_3
+    '\u0130',
+    # U+0141 (Latin Capital Letter L With Stroke): cp1250, cp1257
+    '\u0141',
+    # U+03C6 (Greek Small Letter Phi): cp1253
+    '\u03C6',
+    # U+041A (Cyrillic Capital Letter Ka): cp1251
+    '\u041A',
+    # U+05D0 (Hebrew Letter Alef): Encodable to cp424
+    '\u05D0',
+    # U+060C (Arabic Comma): cp864, cp1006, iso8859_6, mac_arabic
+    '\u060C',
+    # U+062A (Arabic Letter Teh): cp720
+    '\u062A',
+    # U+0E01 (Thai Character Ko Kai): cp874
+    '\u0E01',
+
+    # Then try more "special" characters. "special" because they may be
+    # interpreted or displayed differently depending on the exact locale
+    # encoding and the font.
+
+    # U+00A0 (No-Break Space)
+    '\u00A0',
+    # U+20AC (Euro Sign)
+    '\u20AC',
+):
+    try:
+        # If Python is set up to use the legacy 'mbcs' in Windows,
+        # 'replace' error mode is used, and encode() returns b'?'
+        # for characters missing in the ANSI codepage
+        if os.fsdecode(os.fsencode(character)) != character:
+            raise UnicodeError
+    except UnicodeError:
+        pass
+    else:
+        FS_NONASCII = character
+        break
+
+# Save the initial cwd
+SAVEDCWD = os.getcwd()
+
+# TESTFN_UNDECODABLE is a filename (bytes type) that should *not* be able to be
+# decoded from the filesystem encoding (in strict mode). It can be None if we
+# cannot generate such filename (ex: the latin1 encoding can decode any byte
+# sequence). On UNIX, TESTFN_UNDECODABLE can be decoded by os.fsdecode() thanks
+# to the surrogateescape error handler (PEP 383), but not from the filesystem
+# encoding in strict mode.
+TESTFN_UNDECODABLE = None
+for name in (
+    # b'\xff' is not decodable by os.fsdecode() with code page 932. Windows
+    # accepts it to create a file or a directory, or don't accept to enter to
+    # such directory (when the bytes name is used). So test b'\xe7' first:
+    # it is not decodable from cp932.
+    b'\xe7w\xf0',
+    # undecodable from ASCII, UTF-8
+    b'\xff',
+    # undecodable from iso8859-3, iso8859-6, iso8859-7, cp424, iso8859-8, cp856
+    # and cp857
+    b'\xae\xd5'
+    # undecodable from UTF-8 (UNIX and Mac OS X)
+    b'\xed\xb2\x80', b'\xed\xb4\x80',
+    # undecodable from shift_jis, cp869, cp874, cp932, cp1250, cp1251, cp1252,
+    # cp1253, cp1254, cp1255, cp1257, cp1258
+    b'\x81\x98',
+):
+    try:
+        name.decode(sys.getfilesystemencoding())
+    except UnicodeDecodeError:
+        TESTFN_UNDECODABLE = os.fsencode(TESTFN_ASCII) + name
+        break
+
+if FS_NONASCII:
+    TESTFN_NONASCII = TESTFN_ASCII + FS_NONASCII
+else:
+    TESTFN_NONASCII = None
+TESTFN = TESTFN_NONASCII or TESTFN_ASCII
+
+
+def make_bad_fd():
+    """
+    Create an invalid file descriptor by opening and closing a file and return
+    its fd.
+    """
+    file = open(TESTFN, "wb")
+    try:
+        return file.fileno()
+    finally:
+        file.close()
+        unlink(TESTFN)
+
+
+_can_symlink = None
+
+
+def can_symlink():
+    global _can_symlink
+    if _can_symlink is not None:
+        return _can_symlink
+    symlink_path = TESTFN + "can_symlink"
+    try:
+        os.symlink(TESTFN, symlink_path)
+        can = True
+    except (OSError, NotImplementedError, AttributeError):
+        can = False
+    else:
+        os.remove(symlink_path)
+    _can_symlink = can
+    return can
+
+
+def skip_unless_symlink(test):
+    """Skip decorator for tests that require functional symlink"""
+    ok = can_symlink()
+    msg = "Requires functional symlink implementation"
+    return test if ok else unittest.skip(msg)(test)
+
+
+_can_xattr = None
+
+
+def can_xattr():
+    import tempfile
+    global _can_xattr
+    if _can_xattr is not None:
+        return _can_xattr
+    if not hasattr(os, "setxattr"):
+        can = False
+    else:
+        import platform
+        tmp_dir = tempfile.mkdtemp()
+        tmp_fp, tmp_name = tempfile.mkstemp(dir=tmp_dir)
+        try:
+            with open(TESTFN, "wb") as fp:
+                try:
+                    # TESTFN & tempfile may use different file systems with
+                    # different capabilities
+                    os.setxattr(tmp_fp, b"user.test", b"")
+                    os.setxattr(tmp_name, b"trusted.foo", b"42")
+                    os.setxattr(fp.fileno(), b"user.test", b"")
+                    # Kernels < 2.6.39 don't respect setxattr flags.
+                    kernel_version = platform.release()
+                    m = re.match(r"2.6.(\d{1,2})", kernel_version)
+                    can = m is None or int(m.group(1)) >= 39
+                except OSError:
+                    can = False
+        finally:
+            unlink(TESTFN)
+            unlink(tmp_name)
+            rmdir(tmp_dir)
+    _can_xattr = can
+    return can
+
+
+def skip_unless_xattr(test):
+    """Skip decorator for tests that require functional extended attributes"""
+    ok = can_xattr()
+    msg = "no non-broken extended attribute support"
+    return test if ok else unittest.skip(msg)(test)
+
+
+def unlink(filename):
+    try:
+        _unlink(filename)
+    except (FileNotFoundError, NotADirectoryError):
+        pass
+
+
+if sys.platform.startswith("win"):
+    def _waitfor(func, pathname, waitall=False):
+        # Perform the operation
+        func(pathname)
+        # Now setup the wait loop
+        if waitall:
+            dirname = pathname
+        else:
+            dirname, name = os.path.split(pathname)
+            dirname = dirname or '.'
+        # Check for `pathname` to be removed from the filesystem.
+        # The exponential backoff of the timeout amounts to a total
+        # of ~1 second after which the deletion is probably an error
+        # anyway.
+        # Testing on an i7@4.3GHz shows that usually only 1 iteration is
+        # required when contention occurs.
+        timeout = 0.001
+        while timeout < 1.0:
+            # Note we are only testing for the existence of the file(s) in
+            # the contents of the directory regardless of any security or
+            # access rights.  If we have made it this far, we have sufficient
+            # permissions to do that much using Python's equivalent of the
+            # Windows API FindFirstFile.
+            # Other Windows APIs can fail or give incorrect results when
+            # dealing with files that are pending deletion.
+            L = os.listdir(dirname)
+            if not (L if waitall else name in L):
+                return
+            # Increase the timeout and try again
+            time.sleep(timeout)
+            timeout *= 2
+        warnings.warn('tests may fail, delete still pending for ' + pathname,
+                      RuntimeWarning, stacklevel=4)
+
+    def _unlink(filename):
+        _waitfor(os.unlink, filename)
+
+    def _rmdir(dirname):
+        _waitfor(os.rmdir, dirname)
+
+    def _rmtree(path):
+        from test.support import _force_run
+
+        def _rmtree_inner(path):
+            for name in _force_run(path, os.listdir, path):
+                fullname = os.path.join(path, name)
+                try:
+                    mode = os.lstat(fullname).st_mode
+                except OSError as exc:
+                    print("os_helper.rmtree(): os.lstat(%r) failed with %s"
+                          % (fullname, exc),
+                          file=sys.__stderr__)
+                    mode = 0
+                if stat.S_ISDIR(mode):
+                    _waitfor(_rmtree_inner, fullname, waitall=True)
+                    _force_run(fullname, os.rmdir, fullname)
+                else:
+                    _force_run(fullname, os.unlink, fullname)
+        _waitfor(_rmtree_inner, path, waitall=True)
+        _waitfor(lambda p: _force_run(p, os.rmdir, p), path)
+
+    def _longpath(path):
+        try:
+            import ctypes
+        except ImportError:
+            # No ctypes means we can't expands paths.
+            pass
+        else:
+            buffer = ctypes.create_unicode_buffer(len(path) * 2)
+            length = ctypes.windll.kernel32.GetLongPathNameW(path, buffer,
+                                                             len(buffer))
+            if length:
+                return buffer[:length]
+        return path
+else:
+    _unlink = os.unlink
+    _rmdir = os.rmdir
+
+    def _rmtree(path):
+        import shutil
+        try:
+            shutil.rmtree(path)
+            return
+        except OSError:
+            pass
+
+        def _rmtree_inner(path):
+            from test.support import _force_run
+            for name in _force_run(path, os.listdir, path):
+                fullname = os.path.join(path, name)
+                try:
+                    mode = os.lstat(fullname).st_mode
+                except OSError:
+                    mode = 0
+                if stat.S_ISDIR(mode):
+                    _rmtree_inner(fullname)
+                    _force_run(path, os.rmdir, fullname)
+                else:
+                    _force_run(path, os.unlink, fullname)
+        _rmtree_inner(path)
+        os.rmdir(path)
+
+    def _longpath(path):
+        return path
+
+
+def rmdir(dirname):
+    try:
+        _rmdir(dirname)
+    except FileNotFoundError:
+        pass
+
+
+def rmtree(path):
+    try:
+        _rmtree(path)
+    except FileNotFoundError:
+        pass
+
+
+@contextlib.contextmanager
+def temp_dir(path=None, quiet=False):
+    """Return a context manager that creates a temporary directory.
+
+    Arguments:
+
+      path: the directory to create temporarily.  If omitted or None,
+        defaults to creating a temporary directory using tempfile.mkdtemp.
+
+      quiet: if False (the default), the context manager raises an exception
+        on error.  Otherwise, if the path is specified and cannot be
+        created, only a warning is issued.
+
+    """
+    import tempfile
+    dir_created = False
+    if path is None:
+        path = tempfile.mkdtemp()
+        dir_created = True
+        path = os.path.realpath(path)
+    else:
+        try:
+            os.mkdir(path)
+            dir_created = True
+        except OSError as exc:
+            if not quiet:
+                raise
+            warnings.warn(f'tests may fail, unable to create '
+                          f'temporary directory {path!r}: {exc}',
+                          RuntimeWarning, stacklevel=3)
+    if dir_created:
+        pid = os.getpid()
+    try:
+        yield path
+    finally:
+        # In case the process forks, let only the parent remove the
+        # directory. The child has a different process id. (bpo-30028)
+        if dir_created and pid == os.getpid():
+            rmtree(path)
+
+
+@contextlib.contextmanager
+def change_cwd(path, quiet=False):
+    """Return a context manager that changes the current working directory.
+
+    Arguments:
+
+      path: the directory to use as the temporary current working directory.
+
+      quiet: if False (the default), the context manager raises an exception
+        on error.  Otherwise, it issues only a warning and keeps the current
+        working directory the same.
+
+    """
+    saved_dir = os.getcwd()
+    try:
+        os.chdir(os.path.realpath(path))
+    except OSError as exc:
+        if not quiet:
+            raise
+        warnings.warn(f'tests may fail, unable to change the current working '
+                      f'directory to {path!r}: {exc}',
+                      RuntimeWarning, stacklevel=3)
+    try:
+        yield os.getcwd()
+    finally:
+        os.chdir(saved_dir)
+
+
+@contextlib.contextmanager
+def temp_cwd(name='tempcwd', quiet=False):
+    """
+    Context manager that temporarily creates and changes the CWD.
+
+    The function temporarily changes the current working directory
+    after creating a temporary directory in the current directory with
+    name *name*.  If *name* is None, the temporary directory is
+    created using tempfile.mkdtemp.
+
+    If *quiet* is False (default) and it is not possible to
+    create or change the CWD, an error is raised.  If *quiet* is True,
+    only a warning is raised and the original CWD is used.
+
+    """
+    with temp_dir(path=name, quiet=quiet) as temp_path:
+        with change_cwd(temp_path, quiet=quiet) as cwd_dir:
+            yield cwd_dir
+
+
+def create_empty_file(filename):
+    """Create an empty file. If the file already exists, truncate it."""
+    fd = os.open(filename, os.O_WRONLY | os.O_CREAT | os.O_TRUNC)
+    os.close(fd)
+
+
+def fs_is_case_insensitive(directory):
+    """Detects if the file system for the specified directory
+    is case-insensitive."""
+    import tempfile
+    with tempfile.NamedTemporaryFile(dir=directory) as base:
+        base_path = base.name
+        case_path = base_path.upper()
+        if case_path == base_path:
+            case_path = base_path.lower()
+        try:
+            return os.path.samefile(base_path, case_path)
+        except FileNotFoundError:
+            return False
+
+
+class FakePath:
+    """Simple implementing of the path protocol.
+    """
+    def __init__(self, path):
+        self.path = path
+
+    def __repr__(self):
+        return f'<FakePath {self.path!r}>'
+
+    def __fspath__(self):
+        if (isinstance(self.path, BaseException) or
+            isinstance(self.path, type) and
+                issubclass(self.path, BaseException)):
+            raise self.path
+        else:
+            return self.path
+
+
+def fd_count():
+    """Count the number of open file descriptors.
+    """
+    if sys.platform.startswith(('linux', 'freebsd')):
+        try:
+            names = os.listdir("/proc/self/fd")
+            # Subtract one because listdir() internally opens a file
+            # descriptor to list the content of the /proc/self/fd/ directory.
+            return len(names) - 1
+        except FileNotFoundError:
+            pass
+
+    MAXFD = 256
+    if hasattr(os, 'sysconf'):
+        try:
+            MAXFD = os.sysconf("SC_OPEN_MAX")
+        except OSError:
+            pass
+
+    old_modes = None
+    if sys.platform == 'win32':
+        # bpo-25306, bpo-31009: Call CrtSetReportMode() to not kill the process
+        # on invalid file descriptor if Python is compiled in debug mode
+        try:
+            import msvcrt
+            msvcrt.CrtSetReportMode
+        except (AttributeError, ImportError):
+            # no msvcrt or a release build
+            pass
+        else:
+            old_modes = {}
+            for report_type in (msvcrt.CRT_WARN,
+                                msvcrt.CRT_ERROR,
+                                msvcrt.CRT_ASSERT):
+                old_modes[report_type] = msvcrt.CrtSetReportMode(report_type,
+                                                                 0)
+
+    try:
+        count = 0
+        for fd in range(MAXFD):
+            try:
+                # Prefer dup() over fstat(). fstat() can require input/output
+                # whereas dup() doesn't.
+                fd2 = os.dup(fd)
+            except OSError as e:
+                if e.errno != errno.EBADF:
+                    raise
+            else:
+                os.close(fd2)
+                count += 1
+    finally:
+        if old_modes is not None:
+            for report_type in (msvcrt.CRT_WARN,
+                                msvcrt.CRT_ERROR,
+                                msvcrt.CRT_ASSERT):
+                msvcrt.CrtSetReportMode(report_type, old_modes[report_type])
+
+    return count
+
+
+if hasattr(os, "umask"):
+    @contextlib.contextmanager
+    def temp_umask(umask):
+        """Context manager that temporarily sets the process umask."""
+        oldmask = os.umask(umask)
+        try:
+            yield
+        finally:
+            os.umask(oldmask)
+
+
+class EnvironmentVarGuard(collections.abc.MutableMapping):
+
+    """Class to help protect the environment variable properly.  Can be used as
+    a context manager."""
+
+    def __init__(self):
+        self._environ = os.environ
+        self._changed = {}
+
+    def __getitem__(self, envvar):
+        return self._environ[envvar]
+
+    def __setitem__(self, envvar, value):
+        # Remember the initial value on the first access
+        if envvar not in self._changed:
+            self._changed[envvar] = self._environ.get(envvar)
+        self._environ[envvar] = value
+
+    def __delitem__(self, envvar):
+        # Remember the initial value on the first access
+        if envvar not in self._changed:
+            self._changed[envvar] = self._environ.get(envvar)
+        if envvar in self._environ:
+            del self._environ[envvar]
+
+    def keys(self):
+        return self._environ.keys()
+
+    def __iter__(self):
+        return iter(self._environ)
+
+    def __len__(self):
+        return len(self._environ)
+
+    def set(self, envvar, value):
+        self[envvar] = value
+
+    def unset(self, envvar):
+        del self[envvar]
+
+    def copy(self):
+        # We do what os.environ.copy() does.
+        return dict(self)
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *ignore_exc):
+        for (k, v) in self._changed.items():
+            if v is None:
+                if k in self._environ:
+                    del self._environ[k]
+            else:
+                self._environ[k] = v
+        os.environ = self._environ

--- a/Lib/test/test__osx_support.py
+++ b/Lib/test/test__osx_support.py
@@ -9,6 +9,7 @@ import sys
 import unittest
 
 import test.support
+from test.support import os_helper
 
 import _osx_support
 
@@ -19,7 +20,7 @@ class Test_OSXSupport(unittest.TestCase):
         self.maxDiff = None
         self.prog_name = 'bogus_program_xxxx'
         self.temp_path_dir = os.path.abspath(os.getcwd())
-        self.env = test.support.EnvironmentVarGuard()
+        self.env = os_helper.EnvironmentVarGuard()
         self.addCleanup(self.env.__exit__)
         for cv in ('CFLAGS', 'LDFLAGS', 'CPPFLAGS',
                             'BASECFLAGS', 'BLDSHARED', 'LDSHARED', 'CC',

--- a/Lib/test/test_argparse.py
+++ b/Lib/test/test_argparse.py
@@ -13,6 +13,7 @@ import argparse
 from io import StringIO
 
 from test import support
+from test.support import os_helper
 from unittest import mock
 class StdIOBuffer(StringIO):
     pass
@@ -23,7 +24,7 @@ class TestCase(unittest.TestCase):
         # The tests assume that line wrapping occurs at 80 columns, but this
         # behaviour can be overridden by setting the COLUMNS environment
         # variable.  To ensure that this width is used, set COLUMNS to 80.
-        env = support.EnvironmentVarGuard()
+        env = os_helper.EnvironmentVarGuard()
         env['COLUMNS'] = '80'
         self.addCleanup(env.__exit__)
 
@@ -3244,7 +3245,7 @@ class TestShortColumns(HelpTestCase):
     but we don't want any exceptions thrown in such cases. Only ugly representation.
     '''
     def setUp(self):
-        env = support.EnvironmentVarGuard()
+        env = os_helper.EnvironmentVarGuard()
         env.set("COLUMNS", '15')
         self.addCleanup(env.__exit__)
 

--- a/Lib/test/test_array.py
+++ b/Lib/test/test_array.py
@@ -4,7 +4,7 @@
 
 import unittest
 from test import support
-from test.support import _2G
+from test.support import _2G, os_helper
 import weakref
 import pickle
 import operator
@@ -371,13 +371,13 @@ class BaseTest:
     def test_tofromfile(self):
         a = array.array(self.typecode, 2*self.example)
         self.assertRaises(TypeError, a.tofile)
-        support.unlink(support.TESTFN)
-        f = open(support.TESTFN, 'wb')
+        os_helper.unlink(os_helper.TESTFN)
+        f = open(os_helper.TESTFN, 'wb')
         try:
             a.tofile(f)
             f.close()
             b = array.array(self.typecode)
-            f = open(support.TESTFN, 'rb')
+            f = open(os_helper.TESTFN, 'rb')
             self.assertRaises(TypeError, b.fromfile)
             b.fromfile(f, len(self.example))
             self.assertEqual(b, array.array(self.typecode, self.example))
@@ -388,27 +388,27 @@ class BaseTest:
         finally:
             if not f.closed:
                 f.close()
-            support.unlink(support.TESTFN)
+            os_helper.unlink(os_helper.TESTFN)
 
     def test_fromfile_ioerror(self):
         # Issue #5395: Check if fromfile raises a proper OSError
         # instead of EOFError.
         a = array.array(self.typecode)
-        f = open(support.TESTFN, 'wb')
+        f = open(os_helper.TESTFN, 'wb')
         try:
             self.assertRaises(OSError, a.fromfile, f, len(self.example))
         finally:
             f.close()
-            support.unlink(support.TESTFN)
+            os_helper.unlink(os_helper.TESTFN)
 
     def test_filewrite(self):
         a = array.array(self.typecode, 2*self.example)
-        f = open(support.TESTFN, 'wb')
+        f = open(os_helper.TESTFN, 'wb')
         try:
             f.write(a)
             f.close()
             b = array.array(self.typecode)
-            f = open(support.TESTFN, 'rb')
+            f = open(os_helper.TESTFN, 'rb')
             b.fromfile(f, len(self.example))
             self.assertEqual(b, array.array(self.typecode, self.example))
             self.assertNotEqual(a, b)
@@ -418,7 +418,7 @@ class BaseTest:
         finally:
             if not f.closed:
                 f.close()
-            support.unlink(support.TESTFN)
+            os_helper.unlink(os_helper.TESTFN)
 
     def test_tofromlist(self):
         a = array.array(self.typecode, 2*self.example)

--- a/Lib/test/test_asyncore.py
+++ b/Lib/test/test_asyncore.py
@@ -10,6 +10,7 @@ import struct
 import threading
 
 from test import support
+from test.support import os_helper
 from io import BytesIO
 
 if support.PGO:
@@ -91,7 +92,7 @@ def bind_af_aware(sock, addr):
     """Helper function to bind a socket according to its family."""
     if HAS_UNIX_SOCKETS and sock.family == socket.AF_UNIX:
         # Make sure the path doesn't exist.
-        support.unlink(addr)
+        os_helper.unlink(addr)
         support.bind_unix_socket(sock, addr)
     else:
         sock.bind(addr)
@@ -368,14 +369,14 @@ class DispatcherWithSendTests(unittest.TestCase):
 class FileWrapperTest(unittest.TestCase):
     def setUp(self):
         self.d = b"It's not dead, it's sleeping!"
-        with open(support.TESTFN, 'wb') as file:
+        with open(os_helper.TESTFN, 'wb') as file:
             file.write(self.d)
 
     def tearDown(self):
-        support.unlink(support.TESTFN)
+        os_helper.unlink(os_helper.TESTFN)
 
     def test_recv(self):
-        fd = os.open(support.TESTFN, os.O_RDONLY)
+        fd = os.open(os_helper.TESTFN, os.O_RDONLY)
         w = asyncore.file_wrapper(fd)
         os.close(fd)
 
@@ -389,20 +390,20 @@ class FileWrapperTest(unittest.TestCase):
     def test_send(self):
         d1 = b"Come again?"
         d2 = b"I want to buy some cheese."
-        fd = os.open(support.TESTFN, os.O_WRONLY | os.O_APPEND)
+        fd = os.open(os_helper.TESTFN, os.O_WRONLY | os.O_APPEND)
         w = asyncore.file_wrapper(fd)
         os.close(fd)
 
         w.write(d1)
         w.send(d2)
         w.close()
-        with open(support.TESTFN, 'rb') as file:
+        with open(os_helper.TESTFN, 'rb') as file:
             self.assertEqual(file.read(), self.d + d1 + d2)
 
     @unittest.skipUnless(hasattr(asyncore, 'file_dispatcher'),
                          'asyncore.file_dispatcher required')
     def test_dispatcher(self):
-        fd = os.open(support.TESTFN, os.O_RDONLY)
+        fd = os.open(os_helper.TESTFN, os.O_RDONLY)
         data = []
         class FileDispatcher(asyncore.file_dispatcher):
             def handle_read(self):
@@ -414,7 +415,7 @@ class FileWrapperTest(unittest.TestCase):
 
     def test_resource_warning(self):
         # Issue #11453
-        fd = os.open(support.TESTFN, os.O_RDONLY)
+        fd = os.open(os_helper.TESTFN, os.O_RDONLY)
         f = asyncore.file_wrapper(fd)
 
         os.close(fd)
@@ -423,7 +424,7 @@ class FileWrapperTest(unittest.TestCase):
             support.gc_collect()
 
     def test_close_twice(self):
-        fd = os.open(support.TESTFN, os.O_RDONLY)
+        fd = os.open(os_helper.TESTFN, os.O_RDONLY)
         f = asyncore.file_wrapper(fd)
         os.close(fd)
 
@@ -803,10 +804,10 @@ class TestAPI_UseIPv6Sockets(BaseTestAPI):
 class TestAPI_UseUnixSockets(BaseTestAPI):
     if HAS_UNIX_SOCKETS:
         family = socket.AF_UNIX
-    addr = support.TESTFN
+    addr = os_helper.TESTFN
 
     def tearDown(self):
-        support.unlink(self.addr)
+        os_helper.unlink(self.addr)
         BaseTestAPI.tearDown(self)
 
 class TestAPI_UseIPv4Select(TestAPI_UseIPv4Sockets, unittest.TestCase):

--- a/Lib/test/test_base64.py
+++ b/Lib/test/test_base64.py
@@ -4,7 +4,7 @@ import base64
 import binascii
 import os
 from array import array
-from test.support import script_helper
+from test.support import script_helper, os_helper
 
 
 class LegacyBase64TestCase(unittest.TestCase):
@@ -683,8 +683,8 @@ class BaseXYTestCase(unittest.TestCase):
 
 class TestMain(unittest.TestCase):
     def tearDown(self):
-        if os.path.exists(support.TESTFN):
-            os.unlink(support.TESTFN)
+        if os.path.exists(os_helper.TESTFN):
+            os.unlink(os_helper.TESTFN)
 
     def get_output(self, *args):
         return script_helper.assert_python_ok('-m', 'base64', *args).out
@@ -698,9 +698,9 @@ class TestMain(unittest.TestCase):
         ))
 
     def test_encode_file(self):
-        with open(support.TESTFN, 'wb') as fp:
+        with open(os_helper.TESTFN, 'wb') as fp:
             fp.write(b'a\xffb\n')
-        output = self.get_output('-e', support.TESTFN)
+        output = self.get_output('-e', os_helper.TESTFN)
         self.assertEqual(output.rstrip(), b'Yf9iCg==')
 
     def test_encode_from_stdin(self):
@@ -710,9 +710,9 @@ class TestMain(unittest.TestCase):
         self.assertIsNone(err)
 
     def test_decode(self):
-        with open(support.TESTFN, 'wb') as fp:
+        with open(os_helper.TESTFN, 'wb') as fp:
             fp.write(b'Yf9iCg==')
-        output = self.get_output('-d', support.TESTFN)
+        output = self.get_output('-d', os_helper.TESTFN)
         self.assertEqual(output.rstrip(), b'a\xffb')
 
 if __name__ == '__main__':

--- a/Lib/test/test_binhex.py
+++ b/Lib/test/test_binhex.py
@@ -6,19 +6,20 @@
 import binhex
 import unittest
 from test import support
+from test.support import os_helper
 
 
 class BinHexTestCase(unittest.TestCase):
 
     def setUp(self):
-        self.fname1 = support.TESTFN + "1"
-        self.fname2 = support.TESTFN + "2"
-        self.fname3 = support.TESTFN + "very_long_filename__very_long_filename__very_long_filename__very_long_filename__"
+        self.fname1 = os_helper.TESTFN + "1"
+        self.fname2 = os_helper.TESTFN + "2"
+        self.fname3 = os_helper.TESTFN + "very_long_filename__very_long_filename__very_long_filename__very_long_filename__"
 
     def tearDown(self):
-        support.unlink(self.fname1)
-        support.unlink(self.fname2)
-        support.unlink(self.fname3)
+        os_helper.unlink(self.fname1)
+        os_helper.unlink(self.fname2)
+        os_helper.unlink(self.fname3)
 
     DATA = b'Jack is my hero'
 

--- a/Lib/test/test_bool.py
+++ b/Lib/test/test_bool.py
@@ -2,6 +2,7 @@
 
 import unittest
 from test import support
+from test.support import os_helper
 
 import os
 
@@ -22,12 +23,12 @@ class BoolTest(unittest.TestCase):
 
     def test_print(self):
         try:
-            with open(support.TESTFN, "w") as fo:
+            with open(os_helper.TESTFN, "w") as fo:
                 print(False, True, file=fo)
-            with open(support.TESTFN, "r") as fi:
+            with open(os_helper.TESTFN, "r") as fi:
                 self.assertEqual(fi.read(), 'False True\n')
         finally:
-            os.remove(support.TESTFN)
+            os.remove(os_helper.TESTFN)
 
     def test_repr(self):
         self.assertEqual(repr(False), 'False')
@@ -245,11 +246,11 @@ class BoolTest(unittest.TestCase):
 
     def test_fileclosed(self):
         try:
-            with open(support.TESTFN, "w") as f:
+            with open(os_helper.TESTFN, "w") as f:
                 self.assertIs(f.closed, False)
             self.assertIs(f.closed, True)
         finally:
-            os.remove(support.TESTFN)
+            os.remove(os_helper.TESTFN)
 
     def test_types(self):
         # types are always true.

--- a/Lib/test/test_buffer.py
+++ b/Lib/test/test_buffer.py
@@ -16,6 +16,7 @@
 import contextlib
 import unittest
 from test import support
+from test.support import os_helper
 from itertools import permutations, product
 from random import randrange, sample, choice
 import warnings
@@ -39,7 +40,7 @@ except ImportError:
     ctypes = None
 
 try:
-    with support.EnvironmentVarGuard() as os.environ, \
+    with os_helper.EnvironmentVarGuard() as os.environ, \
          warnings.catch_warnings():
         from numpy import ndarray as numpy_array
 except ImportError:

--- a/Lib/test/test_bufio.py
+++ b/Lib/test/test_bufio.py
@@ -1,5 +1,6 @@
 import unittest
 from test import support
+from test.support import os_helper
 
 import io # C implementation.
 import _pyio as pyio # Python implementation.
@@ -17,18 +18,18 @@ class BufferSizeTest:
         # .readline()s deliver what we wrote.
 
         # Ensure we can open TESTFN for writing.
-        support.unlink(support.TESTFN)
+        os_helper.unlink(os_helper.TESTFN)
 
         # Since C doesn't guarantee we can write/read arbitrary bytes in text
         # files, use binary mode.
-        f = self.open(support.TESTFN, "wb")
+        f = self.open(os_helper.TESTFN, "wb")
         try:
             # write once with \n and once without
             f.write(s)
             f.write(b"\n")
             f.write(s)
             f.close()
-            f = open(support.TESTFN, "rb")
+            f = open(os_helper.TESTFN, "rb")
             line = f.readline()
             self.assertEqual(line, s + b"\n")
             line = f.readline()
@@ -37,7 +38,7 @@ class BufferSizeTest:
             self.assertFalse(line) # Must be at EOF
             f.close()
         finally:
-            support.unlink(support.TESTFN)
+            os_helper.unlink(os_helper.TESTFN)
 
     def drive_one(self, pattern):
         for length in lengths:

--- a/Lib/test/test_builtin.py
+++ b/Lib/test/test_builtin.py
@@ -20,9 +20,9 @@ import warnings
 from functools import partial
 from contextlib import ExitStack
 from operator import neg
-from test.support import (
-    EnvironmentVarGuard, TESTFN, check_warnings, swap_attr, unlink)
+from test.support import check_warnings, swap_attr
 from test.support.script_helper import assert_python_ok
+from test.support.os_helper import EnvironmentVarGuard, TESTFN, unlink
 from unittest.mock import MagicMock, patch
 try:
     import pty, signal

--- a/Lib/test/test_calendar.py
+++ b/Lib/test/test_calendar.py
@@ -912,12 +912,12 @@ class CommandLineTestCase(unittest.TestCase):
 
 class MiscTestCase(unittest.TestCase):
     def test__all__(self):
-        blacklist = {'mdays', 'January', 'February', 'EPOCH',
+        not_exported = {'mdays', 'January', 'February', 'EPOCH',
                      'MONDAY', 'TUESDAY', 'WEDNESDAY', 'THURSDAY', 'FRIDAY',
                      'SATURDAY', 'SUNDAY', 'different_locale', 'c',
                      'prweek', 'week', 'format', 'formatstring', 'main',
                      'monthlen', 'prevmonth', 'nextmonth'}
-        support.check__all__(self, calendar, blacklist=blacklist)
+        support.check__all__(self, calendar, not_exported=not_exported)
 
 
 class TestSubClassingCase(unittest.TestCase):

--- a/Lib/test/test_cgi.py
+++ b/Lib/test/test_cgi.py
@@ -578,9 +578,9 @@ this is the content of the fake file
             ("form-data", {"name": "files", "filename": 'fo"o;bar'}))
 
     def test_all(self):
-        blacklist = {"logfile", "logfp", "initlog", "dolog", "nolog",
+        not_exported = {"logfile", "logfp", "initlog", "dolog", "nolog",
                      "closelog", "log", "maxlen", "valid_boundary"}
-        support.check__all__(self, cgi, blacklist=blacklist)
+        support.check__all__(self, cgi, not_exported=not_exported)
 
 
 BOUNDARY = "---------------------------721837373350705526688164684"

--- a/Lib/test/test_cgitb.py
+++ b/Lib/test/test_cgitb.py
@@ -1,4 +1,4 @@
-from test.support import temp_dir
+from test.support.os_helper import temp_dir
 from test.support.script_helper import assert_python_failure
 import unittest
 import sys

--- a/Lib/test/test_cmd_line.py
+++ b/Lib/test/test_cmd_line.py
@@ -12,6 +12,7 @@ from test.support.script_helper import (
     spawn_python, kill_python, assert_python_ok, assert_python_failure,
     interpreter_requires_environment
 )
+from test.support import os_helper
 
 
 # Debug build?
@@ -156,11 +157,11 @@ class CmdLineTest(unittest.TestCase):
         # All good if execution is successful
         assert_python_ok('-c', 'pass')
 
-    @unittest.skipUnless(support.FS_NONASCII, 'need support.FS_NONASCII')
+    @unittest.skipUnless(os_helper.FS_NONASCII, 'need os_helper.FS_NONASCII')
     def test_non_ascii(self):
         # Test handling of non-ascii data
         command = ("assert(ord(%r) == %s)"
-                   % (support.FS_NONASCII, ord(support.FS_NONASCII)))
+                   % (os_helper.FS_NONASCII, ord(os_helper.FS_NONASCII)))
         assert_python_ok('-c', command)
 
     # On Windows, pass bytes to subprocess doesn't test how Python decodes the
@@ -526,8 +527,8 @@ class CmdLineTest(unittest.TestCase):
         # Issue #15001: PyRun_SimpleFileExFlags() did crash because it kept a
         # borrowed reference to the dict of __main__ module and later modify
         # the dict whereas the module was destroyed
-        filename = support.TESTFN
-        self.addCleanup(support.unlink, filename)
+        filename = os_helper.TESTFN
+        self.addCleanup(os_helper.unlink, filename)
         with open(filename, "w") as script:
             print("import sys", file=script)
             print("del sys.modules['__main__']", file=script)
@@ -566,7 +567,7 @@ class CmdLineTest(unittest.TestCase):
             # dummyvar to prevent extraneous -E
             dummyvar="")
         self.assertEqual(out.strip(), b'1 1 1')
-        with support.temp_cwd() as tmpdir:
+        with os_helper.temp_cwd() as tmpdir:
             fake = os.path.join(tmpdir, "uuid.py")
             main = os.path.join(tmpdir, "main.py")
             with open(fake, "w") as f:
@@ -632,7 +633,7 @@ class CmdLineTest(unittest.TestCase):
             elif opt is not None:
                 args[:0] = ['-X', f'pycache_prefix={opt}']
             with self.subTest(envval=envval, opt=opt):
-                with support.temp_cwd():
+                with os_helper.temp_cwd():
                     assert_python_ok(*args, **env)
 
     def run_xdev(self, *args, check_exitcode=True, xdev=True):

--- a/Lib/test/test_cmd_line_script.py
+++ b/Lib/test/test_cmd_line_script.py
@@ -17,6 +17,7 @@ from test import support
 from test.support.script_helper import (
     make_pkg, make_script, make_zip_pkg, make_zip_script,
     assert_python_ok, assert_python_failure, spawn_python, kill_python)
+from test.support import os_helper
 
 verbose = support.verbose
 
@@ -224,7 +225,7 @@ class CmdLineTest(unittest.TestCase):
     # TODO: RUSTPYTHON
     @unittest.expectedFailure
     def test_basic_script(self):
-        with support.temp_dir() as script_dir:
+        with os_helper.temp_dir() as script_dir:
             script_name = _make_test_script(script_dir, 'script')
             self._check_script(script_name, script_name, script_name,
                                script_dir, None,
@@ -233,7 +234,7 @@ class CmdLineTest(unittest.TestCase):
     # TODO: RUSTPYTHON
     @unittest.expectedFailure
     def test_script_compiled(self):
-        with support.temp_dir() as script_dir:
+        with os_helper.temp_dir() as script_dir:
             script_name = _make_test_script(script_dir, 'script')
             py_compile.compile(script_name, doraise=True)
             os.remove(script_name)
@@ -243,14 +244,14 @@ class CmdLineTest(unittest.TestCase):
                                importlib.machinery.SourcelessFileLoader)
 
     def test_directory(self):
-        with support.temp_dir() as script_dir:
+        with os_helper.temp_dir() as script_dir:
             script_name = _make_test_script(script_dir, '__main__')
             self._check_script(script_dir, script_name, script_dir,
                                script_dir, '',
                                importlib.machinery.SourceFileLoader)
 
     def test_directory_compiled(self):
-        with support.temp_dir() as script_dir:
+        with os_helper.temp_dir() as script_dir:
             script_name = _make_test_script(script_dir, '__main__')
             py_compile.compile(script_name, doraise=True)
             os.remove(script_name)
@@ -260,19 +261,19 @@ class CmdLineTest(unittest.TestCase):
                                importlib.machinery.SourcelessFileLoader)
 
     def test_directory_error(self):
-        with support.temp_dir() as script_dir:
+        with os_helper.temp_dir() as script_dir:
             msg = "can't find '__main__' module in %r" % script_dir
             self._check_import_error(script_dir, msg)
 
     def test_zipfile(self):
-        with support.temp_dir() as script_dir:
+        with os_helper.temp_dir() as script_dir:
             script_name = _make_test_script(script_dir, '__main__')
             zip_name, run_name = make_zip_script(script_dir, 'test_zip', script_name)
             self._check_script(zip_name, run_name, zip_name, zip_name, '',
                                zipimport.zipimporter)
 
     def test_zipfile_compiled_timestamp(self):
-        with support.temp_dir() as script_dir:
+        with os_helper.temp_dir() as script_dir:
             script_name = _make_test_script(script_dir, '__main__')
             compiled_name = py_compile.compile(
                 script_name, doraise=True,
@@ -284,7 +285,7 @@ class CmdLineTest(unittest.TestCase):
     # TODO: RUSTPYTHON
     @unittest.expectedFailure
     def test_zipfile_compiled_checked_hash(self):
-        with support.temp_dir() as script_dir:
+        with os_helper.temp_dir() as script_dir:
             script_name = _make_test_script(script_dir, '__main__')
             compiled_name = py_compile.compile(
                 script_name, doraise=True,
@@ -296,7 +297,7 @@ class CmdLineTest(unittest.TestCase):
     # TODO: RUSTPYTHON
     @unittest.expectedFailure
     def test_zipfile_compiled_unchecked_hash(self):
-        with support.temp_dir() as script_dir:
+        with os_helper.temp_dir() as script_dir:
             script_name = _make_test_script(script_dir, '__main__')
             compiled_name = py_compile.compile(
                 script_name, doraise=True,
@@ -306,14 +307,14 @@ class CmdLineTest(unittest.TestCase):
                                zipimport.zipimporter)
 
     def test_zipfile_error(self):
-        with support.temp_dir() as script_dir:
+        with os_helper.temp_dir() as script_dir:
             script_name = _make_test_script(script_dir, 'not_main')
             zip_name, run_name = make_zip_script(script_dir, 'test_zip', script_name)
             msg = "can't find '__main__' module in %r" % zip_name
             self._check_import_error(zip_name, msg)
 
     def test_module_in_package(self):
-        with support.temp_dir() as script_dir:
+        with os_helper.temp_dir() as script_dir:
             pkg_dir = os.path.join(script_dir, 'test_pkg')
             make_pkg(pkg_dir)
             script_name = _make_test_script(pkg_dir, 'script')
@@ -323,14 +324,14 @@ class CmdLineTest(unittest.TestCase):
                                cwd=script_dir)
 
     def test_module_in_package_in_zipfile(self):
-        with support.temp_dir() as script_dir:
+        with os_helper.temp_dir() as script_dir:
             zip_name, run_name = _make_test_zip_pkg(script_dir, 'test_zip', 'test_pkg', 'script')
             self._check_script(["-m", "test_pkg.script"], run_name, run_name,
                                script_dir, 'test_pkg', zipimport.zipimporter,
                                PYTHONPATH=zip_name, cwd=script_dir)
 
     def test_module_in_subpackage_in_zipfile(self):
-        with support.temp_dir() as script_dir:
+        with os_helper.temp_dir() as script_dir:
             zip_name, run_name = _make_test_zip_pkg(script_dir, 'test_zip', 'test_pkg', 'script', depth=2)
             self._check_script(["-m", "test_pkg.test_pkg.script"], run_name, run_name,
                                script_dir, 'test_pkg.test_pkg',
@@ -338,7 +339,7 @@ class CmdLineTest(unittest.TestCase):
                                PYTHONPATH=zip_name, cwd=script_dir)
 
     def test_package(self):
-        with support.temp_dir() as script_dir:
+        with os_helper.temp_dir() as script_dir:
             pkg_dir = os.path.join(script_dir, 'test_pkg')
             make_pkg(pkg_dir)
             script_name = _make_test_script(pkg_dir, '__main__')
@@ -348,7 +349,7 @@ class CmdLineTest(unittest.TestCase):
                                cwd=script_dir)
 
     def test_package_compiled(self):
-        with support.temp_dir() as script_dir:
+        with os_helper.temp_dir() as script_dir:
             pkg_dir = os.path.join(script_dir, 'test_pkg')
             make_pkg(pkg_dir)
             script_name = _make_test_script(pkg_dir, '__main__')
@@ -361,7 +362,7 @@ class CmdLineTest(unittest.TestCase):
                                cwd=script_dir)
 
     def test_package_error(self):
-        with support.temp_dir() as script_dir:
+        with os_helper.temp_dir() as script_dir:
             pkg_dir = os.path.join(script_dir, 'test_pkg')
             make_pkg(pkg_dir)
             msg = ("'test_pkg' is a package and cannot "
@@ -369,7 +370,7 @@ class CmdLineTest(unittest.TestCase):
             self._check_import_error(["-m", "test_pkg"], msg, cwd=script_dir)
 
     def test_package_recursion(self):
-        with support.temp_dir() as script_dir:
+        with os_helper.temp_dir() as script_dir:
             pkg_dir = os.path.join(script_dir, 'test_pkg')
             make_pkg(pkg_dir)
             main_dir = os.path.join(pkg_dir, '__main__')
@@ -384,8 +385,8 @@ class CmdLineTest(unittest.TestCase):
     def test_issue8202(self):
         # Make sure package __init__ modules see "-m" in sys.argv0 while
         # searching for the module to execute
-        with support.temp_dir() as script_dir:
-            with support.change_cwd(path=script_dir):
+        with os_helper.temp_dir() as script_dir:
+            with os_helper.change_cwd(path=script_dir):
                 pkg_dir = os.path.join(script_dir, 'test_pkg')
                 make_pkg(pkg_dir, "import sys; print('init_argv0==%r' % sys.argv[0])")
                 script_name = _make_test_script(pkg_dir, 'script')
@@ -403,8 +404,8 @@ class CmdLineTest(unittest.TestCase):
     def test_issue8202_dash_c_file_ignored(self):
         # Make sure a "-c" file in the current directory
         # does not alter the value of sys.path[0]
-        with support.temp_dir() as script_dir:
-            with support.change_cwd(path=script_dir):
+        with os_helper.temp_dir() as script_dir:
+            with os_helper.change_cwd(path=script_dir):
                 with open("-c", "w") as f:
                     f.write("data")
                     rc, out, err = assert_python_ok('-c',
@@ -418,9 +419,9 @@ class CmdLineTest(unittest.TestCase):
     def test_issue8202_dash_m_file_ignored(self):
         # Make sure a "-m" file in the current directory
         # does not alter the value of sys.path[0]
-        with support.temp_dir() as script_dir:
+        with os_helper.temp_dir() as script_dir:
             script_name = _make_test_script(script_dir, 'other')
-            with support.change_cwd(path=script_dir):
+            with os_helper.change_cwd(path=script_dir):
                 with open("-m", "w") as f:
                     f.write("data")
                     rc, out, err = assert_python_ok('-m', 'other', *example_args,
@@ -432,7 +433,7 @@ class CmdLineTest(unittest.TestCase):
     def test_issue20884(self):
         # On Windows, script with encoding cookie and LF line ending
         # will be failed.
-        with support.temp_dir() as script_dir:
+        with os_helper.temp_dir() as script_dir:
             script_name = os.path.join(script_dir, "issue20884.py")
             with open(script_name, "w", newline='\n') as f:
                 f.write("#coding: iso-8859-1\n")
@@ -441,15 +442,15 @@ class CmdLineTest(unittest.TestCase):
                     f.write('x'*80 + '\n')
                 f.write('"""\n')
 
-            with support.change_cwd(path=script_dir):
+            with os_helper.change_cwd(path=script_dir):
                 rc, out, err = assert_python_ok(script_name)
             self.assertEqual(b"", out)
             self.assertEqual(b"", err)
 
     @contextlib.contextmanager
     def setup_test_pkg(self, *args):
-        with support.temp_dir() as script_dir, \
-                support.change_cwd(path=script_dir):
+        with os_helper.temp_dir() as script_dir, \
+                os_helper.change_cwd(path=script_dir):
             pkg_dir = os.path.join(script_dir, 'test_pkg')
             make_pkg(pkg_dir, *args)
             yield pkg_dir
@@ -493,8 +494,8 @@ class CmdLineTest(unittest.TestCase):
                 self.assertNotIn(b'Traceback', err)
 
     def test_dash_m_bad_pyc(self):
-        with support.temp_dir() as script_dir, \
-                support.change_cwd(path=script_dir):
+        with os_helper.temp_dir() as script_dir, \
+                os_helper.change_cwd(path=script_dir):
             os.mkdir('test_pkg')
             # Create invalid *.pyc as empty file
             with open('test_pkg/__init__.pyc', 'wb'):
@@ -541,7 +542,7 @@ class CmdLineTest(unittest.TestCase):
             except:
                 raise NameError from None
             """)
-        with support.temp_dir() as script_dir:
+        with os_helper.temp_dir() as script_dir:
             script_name = _make_test_script(script_dir, 'script', script)
             exitcode, stdout, stderr = assert_python_failure(script_name)
             text = stderr.decode('ascii').split('\n')
@@ -554,18 +555,18 @@ class CmdLineTest(unittest.TestCase):
         # Mac OS X denies the creation of a file with an invalid UTF-8 name.
         # Windows allows creating a name with an arbitrary bytes name, but
         # Python cannot a undecodable bytes argument to a subprocess.
-        if (support.TESTFN_UNDECODABLE
+        if (os_helper.TESTFN_UNDECODABLE
         and sys.platform not in ('win32', 'darwin')):
-            name = os.fsdecode(support.TESTFN_UNDECODABLE)
-        elif support.TESTFN_NONASCII:
-            name = support.TESTFN_NONASCII
+            name = os.fsdecode(os_helper.TESTFN_UNDECODABLE)
+        elif os_helper.TESTFN_NONASCII:
+            name = os_helper.TESTFN_NONASCII
         else:
-            self.skipTest("need support.TESTFN_NONASCII")
+            self.skipTest("need os_helper.TESTFN_NONASCII")
 
         # Issue #16218
         source = 'print(ascii(__file__))\n'
         script_name = _make_test_script(os.curdir, name, source)
-        self.addCleanup(support.unlink, script_name)
+        self.addCleanup(os_helper.unlink, script_name)
         rc, stdout, stderr = assert_python_ok(script_name)
         self.assertEqual(
             ascii(script_name),
@@ -591,7 +592,7 @@ class CmdLineTest(unittest.TestCase):
             if error:
                 sys.exit(error)
             """)
-        with support.temp_dir() as script_dir:
+        with os_helper.temp_dir() as script_dir:
             script_name = _make_test_script(script_dir, 'script', script)
             exitcode, stdout, stderr = assert_python_failure(script_name)
             text = stderr.decode('ascii')
@@ -601,7 +602,7 @@ class CmdLineTest(unittest.TestCase):
     @unittest.expectedFailure
     def test_syntaxerror_unindented_caret_position(self):
         script = "1 + 1 = 2\n"
-        with support.temp_dir() as script_dir:
+        with os_helper.temp_dir() as script_dir:
             script_name = _make_test_script(script_dir, 'script', script)
             exitcode, stdout, stderr = assert_python_failure(script_name)
             text = io.TextIOWrapper(io.BytesIO(stderr), 'ascii').read()
@@ -615,7 +616,7 @@ class CmdLineTest(unittest.TestCase):
             if True:
                 1 + 1 = 2
             """)
-        with support.temp_dir() as script_dir:
+        with os_helper.temp_dir() as script_dir:
             script_name = _make_test_script(script_dir, 'script', script)
             exitcode, stdout, stderr = assert_python_failure(script_name)
             text = io.TextIOWrapper(io.BytesIO(stderr), 'ascii').read()
@@ -637,7 +638,7 @@ class CmdLineTest(unittest.TestCase):
     @unittest.expectedFailure
     def test_syntaxerror_multi_line_fstring(self):
         script = 'foo = f"""{}\nfoo"""\n'
-        with support.temp_dir() as script_dir:
+        with os_helper.temp_dir() as script_dir:
             script_name = _make_test_script(script_dir, 'script', script)
             exitcode, stdout, stderr = assert_python_failure(script_name)
             self.assertEqual(
@@ -653,7 +654,7 @@ class CmdLineTest(unittest.TestCase):
     @unittest.expectedFailure
     def test_syntaxerror_invalid_escape_sequence_multi_line(self):
         script = 'foo = """\\q\n"""\n'
-        with support.temp_dir() as script_dir:
+        with os_helper.temp_dir() as script_dir:
             script_name = _make_test_script(script_dir, 'script', script)
             exitcode, stdout, stderr = assert_python_failure(
                 '-Werror', script_name,
@@ -683,7 +684,7 @@ class CmdLineTest(unittest.TestCase):
             """)
         # Always show full path diffs on errors
         self.maxDiff = None
-        with support.temp_dir() as work_dir, support.temp_dir() as script_dir:
+        with os_helper.temp_dir() as work_dir, os_helper.temp_dir() as script_dir:
             script_name = _make_test_script(script_dir, '__main__', script)
             # Reference output comes from directly executing __main__.py
             # We omit PYTHONPATH and user site to align with isolated mode
@@ -715,7 +716,7 @@ class CmdLineTest(unittest.TestCase):
             """)
         # Always show full path diffs on errors
         self.maxDiff = None
-        with support.temp_dir() as work_dir:
+        with os_helper.temp_dir() as work_dir:
             script_dir = os.path.join(work_dir, "script_pkg")
             os.mkdir(script_dir)
             script_name = _make_test_script(script_dir, '__main__', script)

--- a/Lib/test/test_codecs.py
+++ b/Lib/test/test_codecs.py
@@ -8,6 +8,7 @@ import encodings
 from unittest import mock
 
 from test import support
+from test.support import os_helper
 
 try:
     import _testcapi
@@ -839,11 +840,11 @@ class UTF16Test(ReadTest, unittest.TestCase):
         s1 = 'Hello\r\nworld\r\n'
 
         s = s1.encode(self.encoding)
-        self.addCleanup(support.unlink, support.TESTFN)
-        with open(support.TESTFN, 'wb') as fp:
+        self.addCleanup(os_helper.unlink, os_helper.TESTFN)
+        with open(os_helper.TESTFN, 'wb') as fp:
             fp.write(s)
         with support.check_warnings(('', DeprecationWarning)):
-            reader = codecs.open(support.TESTFN, 'U', encoding=self.encoding)
+            reader = codecs.open(os_helper.TESTFN, 'U', encoding=self.encoding)
         with reader:
             self.assertEqual(reader.read(), s1)
 
@@ -1891,10 +1892,10 @@ class CodecsModuleTest(unittest.TestCase):
             getattr(codecs, api)
 
     def test_open(self):
-        self.addCleanup(support.unlink, support.TESTFN)
+        self.addCleanup(os_helper.unlink, os_helper.TESTFN)
         for mode in ('w', 'r', 'r+', 'w+', 'a', 'a+'):
             with self.subTest(mode), \
-                    codecs.open(support.TESTFN, mode, 'ascii') as file:
+                    codecs.open(os_helper.TESTFN, mode, 'ascii') as file:
                 self.assertIsInstance(file, codecs.StreamReaderWriter)
 
     def test_undefined(self):
@@ -1912,7 +1913,7 @@ class CodecsModuleTest(unittest.TestCase):
         mock_open = mock.mock_open()
         with mock.patch('builtins.open', mock_open) as file:
             with self.assertRaises(LookupError):
-                codecs.open(support.TESTFN, 'wt', 'invalid-encoding')
+                codecs.open(os_helper.TESTFN, 'wt', 'invalid-encoding')
 
             file().close.assert_called()
 
@@ -2754,10 +2755,10 @@ class BomTest(unittest.TestCase):
                  "utf-32",
                  "utf-32-le",
                  "utf-32-be")
-        self.addCleanup(support.unlink, support.TESTFN)
+        self.addCleanup(os_helper.unlink, os_helper.TESTFN)
         for encoding in tests:
             # Check if the BOM is written only once
-            with codecs.open(support.TESTFN, 'w+', encoding=encoding) as f:
+            with codecs.open(os_helper.TESTFN, 'w+', encoding=encoding) as f:
                 f.write(data)
                 f.write(data)
                 f.seek(0)
@@ -2766,7 +2767,7 @@ class BomTest(unittest.TestCase):
                 self.assertEqual(f.read(), data * 2)
 
             # Check that the BOM is written after a seek(0)
-            with codecs.open(support.TESTFN, 'w+', encoding=encoding) as f:
+            with codecs.open(os_helper.TESTFN, 'w+', encoding=encoding) as f:
                 f.write(data[0])
                 self.assertNotEqual(f.tell(), 0)
                 f.seek(0)
@@ -2775,7 +2776,7 @@ class BomTest(unittest.TestCase):
                 self.assertEqual(f.read(), data)
 
             # (StreamWriter) Check that the BOM is written after a seek(0)
-            with codecs.open(support.TESTFN, 'w+', encoding=encoding) as f:
+            with codecs.open(os_helper.TESTFN, 'w+', encoding=encoding) as f:
                 f.writer.write(data[0])
                 self.assertNotEqual(f.writer.tell(), 0)
                 f.writer.seek(0)
@@ -2785,7 +2786,7 @@ class BomTest(unittest.TestCase):
 
             # Check that the BOM is not written after a seek() at a position
             # different than the start
-            with codecs.open(support.TESTFN, 'w+', encoding=encoding) as f:
+            with codecs.open(os_helper.TESTFN, 'w+', encoding=encoding) as f:
                 f.write(data)
                 f.seek(f.tell())
                 f.write(data)
@@ -2794,7 +2795,7 @@ class BomTest(unittest.TestCase):
 
             # (StreamWriter) Check that the BOM is not written after a seek()
             # at a position different than the start
-            with codecs.open(support.TESTFN, 'w+', encoding=encoding) as f:
+            with codecs.open(os_helper.TESTFN, 'w+', encoding=encoding) as f:
                 f.writer.write(data)
                 f.writer.seek(f.writer.tell())
                 f.writer.write(data)

--- a/Lib/test/test_compile.py
+++ b/Lib/test/test_compile.py
@@ -7,7 +7,8 @@ import _ast
 import tempfile
 import types
 from test import support
-from test.support import script_helper, FakePath
+from test.support import script_helper
+from test.support.os_helper import FakePath
 
 class TestSpecifics(unittest.TestCase):
 

--- a/Lib/test/test_complex.py
+++ b/Lib/test/test_complex.py
@@ -1,5 +1,6 @@
 import unittest
 from test import support
+from test.support import os_helper
 from test.test_grammar import (VALID_UNDERSCORE_LITERALS,
                                INVALID_UNDERSCORE_LITERALS)
 
@@ -514,15 +515,15 @@ class ComplexTest(unittest.TestCase):
 
         fo = None
         try:
-            fo = open(support.TESTFN, "w")
+            fo = open(os_helper.TESTFN, "w")
             print(a, b, file=fo)
             fo.close()
-            fo = open(support.TESTFN, "r")
+            fo = open(os_helper.TESTFN, "r")
             self.assertEqual(fo.read(), ("%s %s\n" % (a, b)))
         finally:
             if (fo is not None) and (not fo.closed):
                 fo.close()
-            support.unlink(support.TESTFN)
+            os_helper.unlink(os_helper.TESTFN)
 
     def test_getnewargs(self):
         self.assertEqual((1+2j).__getnewargs__(), (1.0, 2.0))

--- a/Lib/test/test_configparser.py
+++ b/Lib/test/test_configparser.py
@@ -8,6 +8,7 @@ import unittest
 import warnings
 
 from test import support
+from test.support import os_helper
 
 
 class SortedDict(collections.UserDict):
@@ -1073,17 +1074,17 @@ class MultilineValuesTestCase(BasicTestCase, unittest.TestCase):
             cf.add_section(s)
             for j in range(10):
                 cf.set(s, 'lovely_spam{}'.format(j), self.wonderful_spam)
-        with open(support.TESTFN, 'w') as f:
+        with open(os_helper.TESTFN, 'w') as f:
             cf.write(f)
 
     def tearDown(self):
-        os.unlink(support.TESTFN)
+        os.unlink(os_helper.TESTFN)
 
     def test_dominating_multiline_values(self):
         # We're reading from file because this is where the code changed
         # during performance updates in Python 3.2
         cf_from_file = self.newconfig()
-        with open(support.TESTFN) as f:
+        with open(os_helper.TESTFN) as f:
             cf_from_file.read_file(f)
         self.assertEqual(cf_from_file.get('section8', 'lovely_spam4'),
                          self.wonderful_spam.replace('\t\n', '\n'))
@@ -2161,8 +2162,8 @@ class BlatantOverrideConvertersTestCase(unittest.TestCase):
 
 class MiscTestCase(unittest.TestCase):
     def test__all__(self):
-        blacklist = {"Error"}
-        support.check__all__(self, configparser, blacklist=blacklist)
+        not_exported = {"Error"}
+        support.check__all__(self, configparser, not_exported=not_exported)
 
 
 if __name__ == '__main__':

--- a/Lib/test/test_contextlib.py
+++ b/Lib/test/test_contextlib.py
@@ -7,6 +7,7 @@ import threading
 import unittest
 from contextlib import *  # Tests __all__
 from test import support
+from test.support import os_helper
 import weakref
 
 
@@ -329,7 +330,7 @@ class FileContextTestCase(unittest.TestCase):
                     1 / 0
             self.assertTrue(f.closed)
         finally:
-            support.unlink(tfn)
+            os_helper.unlink(tfn)
 
 class LockContextTestCase(unittest.TestCase):
 

--- a/Lib/test/test_dbm.py
+++ b/Lib/test/test_dbm.py
@@ -3,6 +3,7 @@
 import unittest
 import glob
 import test.support
+from test.support import os_helper
 
 # Skip tests if dbm module doesn't exist.
 dbm = test.support.import_module('dbm')
@@ -12,7 +13,7 @@ try:
 except ImportError:
     ndbm = None
 
-_fname = test.support.TESTFN
+_fname = os_helper.TESTFN
 
 #
 # Iterates over every database module supported by dbm currently available,
@@ -34,7 +35,7 @@ def delete_files():
     # we don't know the precise name the underlying database uses
     # so we use glob to locate all names
     for f in glob.glob(glob.escape(_fname) + "*"):
-        test.support.unlink(f)
+        os_helper.unlink(f)
 
 
 class AnyDBMTestCase:
@@ -74,7 +75,7 @@ class AnyDBMTestCase:
 
     def test_anydbm_creation_n_file_exists_with_invalid_contents(self):
         # create an empty file
-        test.support.create_empty_file(_fname)
+        os_helper.create_empty_file(_fname)
         with dbm.open(_fname, 'n') as f:
             self.assertEqual(len(f), 0)
 
@@ -169,7 +170,7 @@ class WhichDBTestCase(unittest.TestCase):
         # Issue 17198: check that ndbm which is referenced in whichdb is defined
         db_file = '{}_ndbm.db'.format(_fname)
         with open(db_file, 'w'):
-            self.addCleanup(test.support.unlink, db_file)
+            self.addCleanup(os_helper.unlink, db_file)
         self.assertIsNone(self.dbm.whichdb(db_file[:-3]))
 
     def tearDown(self):
@@ -177,7 +178,7 @@ class WhichDBTestCase(unittest.TestCase):
 
     def setUp(self):
         delete_files()
-        self.filename = test.support.TESTFN
+        self.filename = os_helper.TESTFN
         self.d = dbm.open(self.filename, 'c')
         self.d.close()
         self.dbm = test.support.import_fresh_module('dbm')

--- a/Lib/test/test_dbm_dumb.py
+++ b/Lib/test/test_dbm_dumb.py
@@ -10,9 +10,10 @@ import stat
 import unittest
 import dbm.dumb as dumbdbm
 from test import support
+from test.support import os_helper
 from functools import partial
 
-_fname = support.TESTFN
+_fname = os_helper.TESTFN
 
 def _delete_files():
     for ext in [".dir", ".dat", ".bak"]:
@@ -264,7 +265,7 @@ class DumbDBMTestCase(unittest.TestCase):
                 dumbdbm.open(_fname, flag)
 
     def test_readonly_files(self):
-        with support.temp_dir() as dir:
+        with os_helper.temp_dir() as dir:
             fname = os.path.join(dir, 'db')
             with dumbdbm.open(fname, 'n') as f:
                 self.assertEqual(list(f.keys()), [])
@@ -277,12 +278,12 @@ class DumbDBMTestCase(unittest.TestCase):
                 self.assertEqual(sorted(f.keys()), sorted(self._dict))
                 f.close()  # don't write
 
-    @unittest.skipUnless(support.TESTFN_NONASCII,
+    @unittest.skipUnless(os_helper.TESTFN_NONASCII,
                          'requires OS support of non-ASCII encodings')
     def test_nonascii_filename(self):
-        filename = support.TESTFN_NONASCII
+        filename = os_helper.TESTFN_NONASCII
         for suffix in ['.dir', '.dat', '.bak']:
-            self.addCleanup(support.unlink, filename + suffix)
+            self.addCleanup(os_helper.unlink, filename + suffix)
         with dumbdbm.open(filename, 'c') as db:
             db[b'key'] = b'value'
         self.assertTrue(os.path.exists(filename + '.dat'))

--- a/Lib/test/test_deque.py
+++ b/Lib/test/test_deque.py
@@ -1,6 +1,7 @@
 from collections import deque
 import unittest
 from test import support, seq_tests
+from test.support import os_helper
 import gc
 import weakref
 import copy
@@ -66,28 +67,28 @@ class TestBasic(unittest.TestCase):
         self.assertEqual(list(d), [7, 8, 9])
         d = deque(range(200), maxlen=10)
         d.append(d)
-        support.unlink(support.TESTFN)
-        fo = open(support.TESTFN, "w")
+        os_helper.unlink(os_helper.TESTFN)
+        fo = open(os_helper.TESTFN, "w")
         try:
             fo.write(str(d))
             fo.close()
-            fo = open(support.TESTFN, "r")
+            fo = open(os_helper.TESTFN, "r")
             self.assertEqual(fo.read(), repr(d))
         finally:
             fo.close()
-            support.unlink(support.TESTFN)
+            os_helper.unlink(os_helper.TESTFN)
 
         d = deque(range(10), maxlen=None)
         self.assertEqual(repr(d), 'deque([0, 1, 2, 3, 4, 5, 6, 7, 8, 9])')
-        fo = open(support.TESTFN, "w")
+        fo = open(os_helper.TESTFN, "w")
         try:
             fo.write(str(d))
             fo.close()
-            fo = open(support.TESTFN, "r")
+            fo = open(os_helper.TESTFN, "r")
             self.assertEqual(fo.read(), repr(d))
         finally:
             fo.close()
-            support.unlink(support.TESTFN)
+            os_helper.unlink(os_helper.TESTFN)
 
     def test_maxlen_zero(self):
         it = iter(range(100))
@@ -539,15 +540,15 @@ class TestBasic(unittest.TestCase):
         d = deque(range(200))
         d.append(d)
         try:
-            support.unlink(support.TESTFN)
-            fo = open(support.TESTFN, "w")
+            os_helper.unlink(os_helper.TESTFN)
+            fo = open(os_helper.TESTFN, "w")
             print(d, file=fo, end='')
             fo.close()
-            fo = open(support.TESTFN, "r")
+            fo = open(os_helper.TESTFN, "r")
             self.assertEqual(fo.read(), repr(d))
         finally:
             fo.close()
-            support.unlink(support.TESTFN)
+            os_helper.unlink(os_helper.TESTFN)
 
     def test_init(self):
         self.assertRaises(TypeError, deque, 'abc', 2, 3);

--- a/Lib/test/test_exceptions.py
+++ b/Lib/test/test_exceptions.py
@@ -8,11 +8,14 @@ import pickle
 import weakref
 import errno
 
-from test.support import (TESTFN, captured_stderr, check_impl_detail,
-                          check_warnings, cpython_only, gc_collect, run_unittest,
-                          no_tracing, unlink, import_module, script_helper,
-                          SuppressCrashReport)
+from test.support import (captured_stderr, check_impl_detail,
+                          cpython_only, gc_collect,
+                          no_tracing, script_helper,
+                          SuppressCrashReport,
+                          import_module, check_warnings,)
+from test.support.os_helper import TESTFN, unlink
 from test import support
+
 class NaiveException(Exception):
     def __init__(self, x):
         self.x = x

--- a/Lib/test/test_file.py
+++ b/Lib/test/test_file.py
@@ -7,8 +7,9 @@ from weakref import proxy
 import io
 import _pyio as pyio
 
-from test.support import TESTFN
 from test import support
+from test.support import os_helper
+from test.support.os_helper import TESTFN
 from collections import UserList
 
 class AutoFileTests:
@@ -20,7 +21,7 @@ class AutoFileTests:
     def tearDown(self):
         if self.f:
             self.f.close()
-        support.unlink(TESTFN)
+        os_helper.unlink(TESTFN)
 
     def testWeakRefs(self):
         # verify weak references
@@ -140,7 +141,7 @@ class PyAutoFileTests(AutoFileTests, unittest.TestCase):
 class OtherFileTests:
 
     def tearDown(self):
-        support.unlink(TESTFN)
+        os_helper.unlink(TESTFN)
 
     def testModeStrings(self):
         # check invalid mode strings

--- a/Lib/test/test_fileio.py
+++ b/Lib/test/test_fileio.py
@@ -9,8 +9,9 @@ from array import array
 from weakref import proxy
 from functools import wraps
 
-from test.support import (TESTFN, TESTFN_UNICODE, check_warnings, run_unittest,
-                          make_bad_fd, cpython_only, swap_attr)
+from test.support import (check_warnings, run_unittest,
+                          cpython_only, swap_attr)
+from test.support.os_helper import TESTFN, TESTFN_UNICODE, make_bad_fd
 from collections import UserList
 
 import _io  # C implementation of io

--- a/Lib/test/test_ftplib.py
+++ b/Lib/test/test_ftplib.py
@@ -1080,10 +1080,10 @@ class TestTimeouts(TestCase):
 
 class MiscTestCase(TestCase):
     def test__all__(self):
-        blacklist = {'MSG_OOB', 'FTP_PORT', 'MAXLINE', 'CRLF', 'B_CRLF',
+        not_exported = {'MSG_OOB', 'FTP_PORT', 'MAXLINE', 'CRLF', 'B_CRLF',
                      'Error', 'parse150', 'parse227', 'parse229', 'parse257',
                      'print_line', 'ftpcp', 'test'}
-        support.check__all__(self, ftplib, blacklist=blacklist)
+        support.check__all__(self, ftplib, not_exported=not_exported)
 
 
 def test_main():

--- a/Lib/test/test_genericpath.py
+++ b/Lib/test/test_genericpath.py
@@ -8,8 +8,9 @@ import sys
 import unittest
 import warnings
 from test import support
+from test.support import os_helper
 from test.support.script_helper import assert_python_ok
-from test.support import FakePath
+from test.support.os_helper import FakePath
 
 
 def create_file(filename, data=b'foo'):
@@ -97,8 +98,8 @@ class GenericTest:
                     self.assertNotEqual(s1[n:n+1], s2[n:n+1])
 
     def test_getsize(self):
-        filename = support.TESTFN
-        self.addCleanup(support.unlink, filename)
+        filename = os_helper.TESTFN
+        self.addCleanup(os_helper.unlink, filename)
 
         create_file(filename, b'Hello')
         self.assertEqual(self.pathmodule.getsize(filename), 5)
@@ -108,8 +109,8 @@ class GenericTest:
         self.assertEqual(self.pathmodule.getsize(filename), 12)
 
     def test_filetime(self):
-        filename = support.TESTFN
-        self.addCleanup(support.unlink, filename)
+        filename = os_helper.TESTFN
+        self.addCleanup(os_helper.unlink, filename)
 
         create_file(filename, b'foo')
 
@@ -126,9 +127,9 @@ class GenericTest:
         )
 
     def test_exists(self):
-        filename = support.TESTFN
+        filename = os_helper.TESTFN
         bfilename = os.fsencode(filename)
-        self.addCleanup(support.unlink, filename)
+        self.addCleanup(os_helper.unlink, filename)
 
         self.assertIs(self.pathmodule.exists(filename), False)
         self.assertIs(self.pathmodule.exists(bfilename), False)
@@ -163,7 +164,7 @@ class GenericTest:
         self.assertFalse(self.pathmodule.exists(r))
 
     def test_isdir(self):
-        filename = support.TESTFN
+        filename = os_helper.TESTFN
         bfilename = os.fsencode(filename)
         self.assertIs(self.pathmodule.isdir(filename), False)
         self.assertIs(self.pathmodule.isdir(bfilename), False)
@@ -178,7 +179,7 @@ class GenericTest:
             self.assertIs(self.pathmodule.isdir(filename), False)
             self.assertIs(self.pathmodule.isdir(bfilename), False)
         finally:
-            support.unlink(filename)
+            os_helper.unlink(filename)
 
         try:
             os.mkdir(filename)
@@ -188,7 +189,7 @@ class GenericTest:
             support.rmdir(filename)
 
     def test_isfile(self):
-        filename = support.TESTFN
+        filename = os_helper.TESTFN
         bfilename = os.fsencode(filename)
         self.assertIs(self.pathmodule.isfile(filename), False)
         self.assertIs(self.pathmodule.isfile(bfilename), False)
@@ -203,7 +204,7 @@ class GenericTest:
             self.assertIs(self.pathmodule.isfile(filename), True)
             self.assertIs(self.pathmodule.isfile(bfilename), True)
         finally:
-            support.unlink(filename)
+            os_helper.unlink(filename)
 
         try:
             os.mkdir(filename)
@@ -213,10 +214,10 @@ class GenericTest:
             support.rmdir(filename)
 
     def test_samefile(self):
-        file1 = support.TESTFN
-        file2 = support.TESTFN + "2"
-        self.addCleanup(support.unlink, file1)
-        self.addCleanup(support.unlink, file2)
+        file1 = os_helper.TESTFN
+        file2 = os_helper.TESTFN + "2"
+        self.addCleanup(os_helper.unlink, file1)
+        self.addCleanup(os_helper.unlink, file2)
 
         create_file(file1)
         self.assertTrue(self.pathmodule.samefile(file1, file1))
@@ -227,10 +228,10 @@ class GenericTest:
         self.assertRaises(TypeError, self.pathmodule.samefile)
 
     def _test_samefile_on_link_func(self, func):
-        test_fn1 = support.TESTFN
-        test_fn2 = support.TESTFN + "2"
-        self.addCleanup(support.unlink, test_fn1)
-        self.addCleanup(support.unlink, test_fn2)
+        test_fn1 = os_helper.TESTFN
+        test_fn2 = os_helper.TESTFN + "2"
+        self.addCleanup(os_helper.unlink, test_fn1)
+        self.addCleanup(os_helper.unlink, test_fn2)
 
         create_file(test_fn1)
 
@@ -241,7 +242,7 @@ class GenericTest:
         create_file(test_fn2)
         self.assertFalse(self.pathmodule.samefile(test_fn1, test_fn2))
 
-    @support.skip_unless_symlink
+    @os_helper.skip_unless_symlink
     def test_samefile_on_symlink(self):
         self._test_samefile_on_link_func(os.symlink)
 
@@ -256,10 +257,10 @@ class GenericTest:
             self.skipTest('os.link(): %s' % e)
 
     def test_samestat(self):
-        test_fn1 = support.TESTFN
-        test_fn2 = support.TESTFN + "2"
-        self.addCleanup(support.unlink, test_fn1)
-        self.addCleanup(support.unlink, test_fn2)
+        test_fn1 = os_helper.TESTFN
+        test_fn2 = os_helper.TESTFN + "2"
+        self.addCleanup(os_helper.unlink, test_fn1)
+        self.addCleanup(os_helper.unlink, test_fn2)
 
         create_file(test_fn1)
         stat1 = os.stat(test_fn1)
@@ -272,10 +273,10 @@ class GenericTest:
         self.assertRaises(TypeError, self.pathmodule.samestat)
 
     def _test_samestat_on_link_func(self, func):
-        test_fn1 = support.TESTFN + "1"
-        test_fn2 = support.TESTFN + "2"
-        self.addCleanup(support.unlink, test_fn1)
-        self.addCleanup(support.unlink, test_fn2)
+        test_fn1 = os_helper.TESTFN + "1"
+        test_fn2 = os_helper.TESTFN + "2"
+        self.addCleanup(os_helper.unlink, test_fn1)
+        self.addCleanup(os_helper.unlink, test_fn2)
 
         create_file(test_fn1)
         func(test_fn1, test_fn2)
@@ -287,7 +288,7 @@ class GenericTest:
         self.assertFalse(self.pathmodule.samestat(os.stat(test_fn1),
                                                   os.stat(test_fn2)))
 
-    @support.skip_unless_symlink
+    @os_helper.skip_unless_symlink
     def test_samestat_on_symlink(self):
         self._test_samestat_on_link_func(os.symlink)
 
@@ -302,8 +303,8 @@ class GenericTest:
             self.skipTest('os.link(): %s' % e)
 
     def test_sameopenfile(self):
-        filename = support.TESTFN
-        self.addCleanup(support.unlink, filename)
+        filename = os_helper.TESTFN
+        self.addCleanup(os_helper.unlink, filename)
         create_file(filename)
 
         with open(filename, "rb", 0) as fp1:
@@ -406,7 +407,7 @@ class CommonTest(GenericTest):
 
     def test_expandvars(self):
         expandvars = self.pathmodule.expandvars
-        with support.EnvironmentVarGuard() as env:
+        with os_helper.EnvironmentVarGuard() as env:
             env.clear()
             env["foo"] = "bar"
             env["{foo"] = "baz1"
@@ -435,14 +436,14 @@ class CommonTest(GenericTest):
             self.assertEqual(expandvars(b"$foo$foo"), b"barbar")
             self.assertEqual(expandvars(b"$bar$bar"), b"$bar$bar")
 
-    @unittest.skipUnless(support.FS_NONASCII, 'need support.FS_NONASCII')
+    @unittest.skipUnless(os_helper.FS_NONASCII, 'need os_helper.FS_NONASCII')
     def test_expandvars_nonascii(self):
         expandvars = self.pathmodule.expandvars
         def check(value, expected):
             self.assertEqual(expandvars(value), expected)
-        with support.EnvironmentVarGuard() as env:
+        with os_helper.EnvironmentVarGuard() as env:
             env.clear()
-            nonascii = support.FS_NONASCII
+            nonascii = os_helper.FS_NONASCII
             env['spam'] = nonascii
             env[nonascii] = 'ham' + nonascii
             check(nonascii, nonascii)
@@ -501,26 +502,26 @@ class CommonTest(GenericTest):
             # FS encoding is probably ASCII
             pass
         else:
-            with support.temp_cwd(unicwd):
+            with os_helper.temp_cwd(unicwd):
                 for path in ('', 'fuu', 'f\xf9\xf9', '/fuu', 'U:\\'):
                     self.assertIsInstance(abspath(path), str)
 
     def test_nonascii_abspath(self):
-        if (support.TESTFN_UNDECODABLE
+        if (os_helper.TESTFN_UNDECODABLE
         # Mac OS X denies the creation of a directory with an invalid
         # UTF-8 name. Windows allows creating a directory with an
         # arbitrary bytes name, but fails to enter this directory
         # (when the bytes name is used).
         and sys.platform not in ('win32', 'darwin')):
-            name = support.TESTFN_UNDECODABLE
-        elif support.TESTFN_NONASCII:
-            name = support.TESTFN_NONASCII
+            name = os_helper.TESTFN_UNDECODABLE
+        elif os_helper.TESTFN_NONASCII:
+            name = os_helper.TESTFN_NONASCII
         else:
-            self.skipTest("need support.TESTFN_NONASCII")
+            self.skipTest("need os_helper.TESTFN_NONASCII")
 
         with warnings.catch_warnings():
             warnings.simplefilter("ignore", DeprecationWarning)
-            with support.temp_cwd(name):
+            with os_helper.temp_cwd(name):
                 self.test_abspath()
 
     def test_join_errors(self):
@@ -566,9 +567,9 @@ class CommonTest(GenericTest):
 class PathLikeTests(unittest.TestCase):
 
     def setUp(self):
-        self.file_name = support.TESTFN.lower()
-        self.file_path = FakePath(support.TESTFN)
-        self.addCleanup(support.unlink, self.file_name)
+        self.file_name = os_helper.TESTFN.lower()
+        self.file_path = FakePath(os_helper.TESTFN)
+        self.addCleanup(os_helper.unlink, self.file_name)
         create_file(self.file_name, b"test_genericpath.PathLikeTests")
 
     def assertPathEqual(self, func):

--- a/Lib/test/test_getopt.py
+++ b/Lib/test/test_getopt.py
@@ -1,7 +1,8 @@
 # test_getopt.py
 # David Goodger <dgoodger@bigfoot.com> 2000-08-19
 
-from test.support import verbose, run_doctest, EnvironmentVarGuard
+from test.support import verbose, run_doctest
+from test.support.os_helper import EnvironmentVarGuard
 import unittest
 
 import getopt

--- a/Lib/test/test_glob.py
+++ b/Lib/test/test_glob.py
@@ -4,8 +4,8 @@ import shutil
 import sys
 import unittest
 
-from test.support import (TESTFN, skip_unless_symlink,
-                          can_symlink, create_empty_file, change_cwd)
+from test.support.os_helper import (TESTFN, skip_unless_symlink,
+                                    can_symlink, create_empty_file, change_cwd)
 
 
 class GlobTests(unittest.TestCase):

--- a/Lib/test/test_gzip.py
+++ b/Lib/test/test_gzip.py
@@ -11,7 +11,7 @@ import sys
 import unittest
 from subprocess import PIPE, Popen
 from test import support
-from test.support import _4G, bigmemtest
+from test.support import _4G, bigmemtest, os_helper
 from test.support.script_helper import assert_python_ok, assert_python_failure
 
 gzip = support.import_module('gzip')
@@ -29,7 +29,7 @@ data2 = b"""/* zlibmodule.c -- gzip-compatible data compression */
 """
 
 
-TEMPDIR = os.path.abspath(support.TESTFN) + '-gzdir'
+TEMPDIR = os.path.abspath(os_helper.TESTFN) + '-gzdir'
 
 
 class UnseekableIO(io.BytesIO):
@@ -44,13 +44,13 @@ class UnseekableIO(io.BytesIO):
 
 
 class BaseTest(unittest.TestCase):
-    filename = support.TESTFN
+    filename = os_helper.TESTFN
 
     def setUp(self):
-        support.unlink(self.filename)
+        os_helper.unlink(self.filename)
 
     def tearDown(self):
-        support.unlink(self.filename)
+        os_helper.unlink(self.filename)
 
 
 class TestGzip(BaseTest):
@@ -286,7 +286,7 @@ class TestGzip(BaseTest):
         self.test_write()
         with gzip.GzipFile(self.filename, 'r') as f:
             self.assertEqual(f.myfileobj.mode, 'rb')
-        support.unlink(self.filename)
+        os_helper.unlink(self.filename)
         with gzip.GzipFile(self.filename, 'x') as f:
             self.assertEqual(f.myfileobj.mode, 'xb')
 
@@ -487,7 +487,7 @@ class TestGzip(BaseTest):
                     self.assertEqual(g.mode, gzip.READ)
         for mode in "wb", "ab", "xb":
             if "x" in mode:
-                support.unlink(self.filename)
+                os_helper.unlink(self.filename)
             with open(self.filename, mode) as f:
                 with gzip.GzipFile(fileobj=f) as g:
                     self.assertEqual(g.mode, gzip.WRITE)
@@ -599,7 +599,7 @@ class TestOpen(BaseTest):
 
         with self.assertRaises(FileExistsError):
             gzip.open(self.filename, "xb")
-        support.unlink(self.filename)
+        os_helper.unlink(self.filename)
         with gzip.open(self.filename, "xb") as f:
             f.write(uncompressed)
         with open(self.filename, "rb") as f:
@@ -636,7 +636,7 @@ class TestOpen(BaseTest):
 
         with self.assertRaises(FileExistsError):
             gzip.open(self.filename, "x")
-        support.unlink(self.filename)
+        os_helper.unlink(self.filename)
         with gzip.open(self.filename, "x") as f:
             f.write(uncompressed)
         with open(self.filename, "rb") as f:
@@ -730,7 +730,7 @@ def create_and_remove_directory(directory):
             try:
                 return function(*args, **kwargs)
             finally:
-                support.rmtree(directory)
+                os_helper.rmtree(directory)
         return wrapper
     return decorator
 

--- a/Lib/test/test_http_cookiejar.py
+++ b/Lib/test/test_http_cookiejar.py
@@ -3,6 +3,7 @@
 import os
 import re
 import test.support
+from test.support import os_helper
 import time
 import unittest
 import urllib.request
@@ -330,14 +331,14 @@ def _interact(cookiejar, url, set_cookie_hdrs, hdr_name):
 
 class FileCookieJarTests(unittest.TestCase):
     def test_constructor_with_str(self):
-        filename = test.support.TESTFN
+        filename = os_helper.TESTFN
         c = LWPCookieJar(filename)
         self.assertEqual(c.filename, filename)
 
     # TODO: RUSTPYTHON
     @unittest.expectedFailure
     def test_constructor_with_path_like(self):
-        filename = pathlib.Path(test.support.TESTFN)
+        filename = pathlib.Path(os_helper.TESTFN)
         c = LWPCookieJar(filename)
         self.assertEqual(c.filename, os.fspath(filename))
 
@@ -359,7 +360,7 @@ class FileCookieJarTests(unittest.TestCase):
 
     def test_lwp_valueless_cookie(self):
         # cookies with no value should be saved and loaded consistently
-        filename = test.support.TESTFN
+        filename = os_helper.TESTFN
         c = LWPCookieJar()
         interact_netscape(c, "http://www.acme.com/", 'boo')
         self.assertEqual(c._cookies["www.acme.com"]["/"]["boo"].value, None)
@@ -374,7 +375,7 @@ class FileCookieJarTests(unittest.TestCase):
 
     def test_bad_magic(self):
         # OSErrors (eg. file doesn't exist) are allowed to propagate
-        filename = test.support.TESTFN
+        filename = os_helper.TESTFN
         for cookiejar_class in LWPCookieJar, MozillaCookieJar:
             c = cookiejar_class()
             try:
@@ -483,7 +484,7 @@ class CookieTests(unittest.TestCase):
     def test_missing_value(self):
         # missing = sign in Cookie: header is regarded by Mozilla as a missing
         # name, and by http.cookiejar as a missing value
-        filename = test.support.TESTFN
+        filename = os_helper.TESTFN
         c = MozillaCookieJar(filename)
         interact_netscape(c, "http://www.acme.com/", 'eggs')
         interact_netscape(c, "http://www.acme.com/", '"spam"; path=/foo/')
@@ -1731,7 +1732,7 @@ class LWPCookieTests(unittest.TestCase):
         self.assertEqual(len(c), 6)
 
         # save and restore
-        filename = test.support.TESTFN
+        filename = os_helper.TESTFN
 
         try:
             c.save(filename, ignore_discard=True)
@@ -1771,7 +1772,7 @@ class LWPCookieTests(unittest.TestCase):
         # Save / load Mozilla/Netscape cookie file format.
         year_plus_one = time.localtime()[0] + 1
 
-        filename = test.support.TESTFN
+        filename = os_helper.TESTFN
 
         c = MozillaCookieJar(filename,
                              policy=DefaultCookiePolicy(rfc2965=True))

--- a/Lib/test/test_httplib.py
+++ b/Lib/test/test_httplib.py
@@ -13,6 +13,7 @@ import unittest
 TestCase = unittest.TestCase
 
 from test import support
+from test.support import os_helper
 
 here = os.path.dirname(__file__)
 # Self-signed cert file for 'localhost'
@@ -1916,10 +1917,10 @@ class RequestBodyTest(TestCase):
         self.assertEqual(b'body\xc1', f.read())
 
     def test_text_file_body(self):
-        self.addCleanup(support.unlink, support.TESTFN)
-        with open(support.TESTFN, "w") as f:
+        self.addCleanup(os_helper.unlink, os_helper.TESTFN)
+        with open(os_helper.TESTFN, "w") as f:
             f.write("body")
-        with open(support.TESTFN) as f:
+        with open(os_helper.TESTFN) as f:
             self.conn.request("PUT", "/url", f)
             message, f = self.get_headers_and_fp()
             self.assertEqual("text/plain", message.get_content_type())
@@ -1931,10 +1932,10 @@ class RequestBodyTest(TestCase):
             self.assertEqual(b'4\r\nbody\r\n0\r\n\r\n', f.read())
 
     def test_binary_file_body(self):
-        self.addCleanup(support.unlink, support.TESTFN)
-        with open(support.TESTFN, "wb") as f:
+        self.addCleanup(os_helper.unlink, os_helper.TESTFN)
+        with open(os_helper.TESTFN, "wb") as f:
             f.write(b"body\xc1")
-        with open(support.TESTFN, "rb") as f:
+        with open(os_helper.TESTFN, "rb") as f:
             self.conn.request("PUT", "/url", f)
             message, f = self.get_headers_and_fp()
             self.assertEqual("text/plain", message.get_content_type())

--- a/Lib/test/test_httpservers.py
+++ b/Lib/test/test_httpservers.py
@@ -29,6 +29,7 @@ from io import BytesIO
 
 import unittest
 from test import support
+from test.support import os_helper
 
 
 class NoLogRequestHandler:
@@ -64,7 +65,7 @@ class TestServerThread(threading.Thread):
 class BaseTestCase(unittest.TestCase):
     def setUp(self):
         self._threads = support.threading_setup()
-        os.environ = support.EnvironmentVarGuard()
+        os.environ = os_helper.EnvironmentVarGuard()
         self.server_started = threading.Event()
         self.thread = TestServerThread(self, self.request_handler)
         self.thread.start()
@@ -391,13 +392,13 @@ class SimpleHTTPServerTestCase(BaseTestCase):
                      'undecodable name cannot always be decoded on macOS')
     @unittest.skipIf(sys.platform == 'win32',
                      'undecodable name cannot be decoded on win32')
-    @unittest.skipUnless(support.TESTFN_UNDECODABLE,
-                         'need support.TESTFN_UNDECODABLE')
+    @unittest.skipUnless(os_helper.TESTFN_UNDECODABLE,
+                         'need os_helper.TESTFN_UNDECODABLE')
     def test_undecodable_filename(self):
         enc = sys.getfilesystemencoding()
-        filename = os.fsdecode(support.TESTFN_UNDECODABLE) + '.txt'
+        filename = os.fsdecode(os_helper.TESTFN_UNDECODABLE) + '.txt'
         with open(os.path.join(self.tempdir, filename), 'wb') as f:
-            f.write(support.TESTFN_UNDECODABLE)
+            f.write(os_helper.TESTFN_UNDECODABLE)
         response = self.request(self.base_url + '/')
         if sys.platform == 'darwin':
             # On Mac OS the HFS+ filesystem replaces bytes that aren't valid
@@ -414,7 +415,7 @@ class SimpleHTTPServerTestCase(BaseTestCase):
                       .encode(enc, 'surrogateescape'), body)
         response = self.request(self.base_url + '/' + quotedname)
         self.check_status_and_reason(response, HTTPStatus.OK,
-                                     data=support.TESTFN_UNDECODABLE)
+                                     data=os_helper.TESTFN_UNDECODABLE)
 
     def test_get(self):
         #constructs the path relative to the root directory of the HTTPServer
@@ -616,7 +617,7 @@ class CGIHTTPServerTestCase(BaseTestCase):
         # The shebang line should be pure ASCII: use symlink if possible.
         # See issue #7668.
         self._pythonexe_symlink = None
-        if support.can_symlink():
+        if os_helper.can_symlink():
             self.pythonexe = os.path.join(self.parent_dir, 'python')
             self._pythonexe_symlink = support.PythonSymlink(self.pythonexe).__enter__()
         else:

--- a/Lib/test/test_imp.py
+++ b/Lib/test/test_imp.py
@@ -5,7 +5,7 @@ import os.path
 import py_compile
 import sys
 from test import support
-from test.support import script_helper
+from test.support import script_helper, os_helper
 import unittest
 import warnings
 with warnings.catch_warnings():
@@ -114,8 +114,8 @@ class ImportTests(unittest.TestCase):
             self.assertEqual(file.encoding, 'cp1252')
         finally:
             del sys.path[0]
-            support.unlink(temp_mod_name + '.py')
-            support.unlink(temp_mod_name + '.pyc')
+            os_helper.unlink(temp_mod_name + '.py')
+            os_helper.unlink(temp_mod_name + '.pyc')
 
     def test_issue5604(self):
         # Test cannot cover imp.load_compiled function.
@@ -199,10 +199,10 @@ class ImportTests(unittest.TestCase):
         finally:
             del sys.path[0]
             for ext in ('.py', '.pyc'):
-                support.unlink(temp_mod_name + ext)
-                support.unlink(init_file_name + ext)
-            support.rmtree(test_package_name)
-            support.rmtree('__pycache__')
+                os_helper.unlink(temp_mod_name + ext)
+                os_helper.unlink(init_file_name + ext)
+            os_helper.rmtree(test_package_name)
+            os_helper.rmtree('__pycache__')
 
     def test_issue9319(self):
         path = os.path.dirname(__file__)
@@ -220,7 +220,7 @@ class ImportTests(unittest.TestCase):
         # workaround
         orig_path = os.path
         orig_getenv = os.getenv
-        with support.EnvironmentVarGuard():
+        with os_helper.EnvironmentVarGuard():
             x = imp.find_module("os")
             self.addCleanup(x[0].close)
             new_os = imp.load_module("os", *x)
@@ -306,11 +306,11 @@ class ImportTests(unittest.TestCase):
     @unittest.skipIf(sys.dont_write_bytecode,
         "test meaningful only when writing bytecode")
     def test_bug7732(self):
-        with support.temp_cwd():
-            source = support.TESTFN + '.py'
+        with os_helper.temp_cwd():
+            source = os_helper.TESTFN + '.py'
             os.mkdir(source)
             self.assertRaisesRegex(ImportError, '^No module',
-                imp.find_module, support.TESTFN, ["."])
+                imp.find_module, os_helper.TESTFN, ["."])
 
     def test_multiple_calls_to_get_data(self):
         # Issue #18755: make sure multiple calls to get_data() can succeed.
@@ -377,7 +377,7 @@ class ImportTests(unittest.TestCase):
     @unittest.expectedFailure
     def test_find_and_load_checked_pyc(self):
         # issue 34056
-        with support.temp_cwd():
+        with os_helper.temp_cwd():
             with open('mymod.py', 'wb') as fp:
                 fp.write(b'x = 42\n')
             py_compile.compile(
@@ -403,7 +403,7 @@ class ReloadTests(unittest.TestCase):
         # state after reversion. Reinitialising the module contents
         # and just reverting os.environ to its previous state is an OK
         # workaround
-        with support.EnvironmentVarGuard():
+        with os_helper.EnvironmentVarGuard():
             import os
             imp.reload(os)
 
@@ -456,10 +456,10 @@ class PEP3147Tests(unittest.TestCase):
 
 
 class NullImporterTests(unittest.TestCase):
-    @unittest.skipIf(support.TESTFN_UNENCODABLE is None,
+    @unittest.skipIf(os_helper.TESTFN_UNENCODABLE is None,
                      "Need an undecodeable filename")
     def test_unencodeable(self):
-        name = support.TESTFN_UNENCODABLE
+        name = os_helper.TESTFN_UNENCODABLE
         os.mkdir(name)
         try:
             self.assertRaises(ImportError, imp.NullImporter, name)

--- a/Lib/test/test_importlib/extension/test_case_sensitivity.py
+++ b/Lib/test/test_importlib/extension/test_case_sensitivity.py
@@ -1,5 +1,6 @@
 from importlib import _bootstrap_external
 from test import support
+from test.support import os_helper
 import unittest
 
 from .. import util
@@ -22,14 +23,14 @@ class ExtensionModuleCaseSensitivityTest(util.CASEOKTestBase):
         return finder.find_module(bad_name)
 
     def test_case_sensitive(self):
-        with support.EnvironmentVarGuard() as env:
+        with os_helper.EnvironmentVarGuard() as env:
             env.unset('PYTHONCASEOK')
             self.caseok_env_changed(should_exist=False)
             loader = self.find_module()
             self.assertIsNone(loader)
 
     def test_case_insensitivity(self):
-        with support.EnvironmentVarGuard() as env:
+        with os_helper.EnvironmentVarGuard() as env:
             env.set('PYTHONCASEOK', '1')
             self.caseok_env_changed(should_exist=True)
             loader = self.find_module()

--- a/Lib/test/test_importlib/source/test_case_sensitivity.py
+++ b/Lib/test/test_importlib/source/test_case_sensitivity.py
@@ -1,12 +1,15 @@
 """Test case-sensitivity (PEP 235)."""
+import sys
+
 from .. import util
 
 importlib = util.import_importlib('importlib')
 machinery = util.import_importlib('importlib.machinery')
 
 import os
-from test import support as test_support
+from test.support import os_helper
 import unittest
+import warnings
 
 
 @util.case_insensitive_tests
@@ -38,8 +41,9 @@ class CaseSensitivityTest(util.CASEOKTestBase):
             insensitive_finder = self.finder(insensitive_path)
             return self.find(sensitive_finder), self.find(insensitive_finder)
 
+    @unittest.skipIf(sys.flags.ignore_environment, 'ignore_environment flag was set')
     def test_sensitive(self):
-        with test_support.EnvironmentVarGuard() as env:
+        with os_helper.EnvironmentVarGuard() as env:
             env.unset('PYTHONCASEOK')
             self.caseok_env_changed(should_exist=False)
             sensitive, insensitive = self.sensitivity_test()
@@ -47,8 +51,9 @@ class CaseSensitivityTest(util.CASEOKTestBase):
             self.assertIn(self.name, sensitive.get_filename(self.name))
             self.assertIsNone(insensitive)
 
+    @unittest.skipIf(sys.flags.ignore_environment, 'ignore_environment flag was set')
     def test_insensitive(self):
-        with test_support.EnvironmentVarGuard() as env:
+        with os_helper.EnvironmentVarGuard() as env:
             env.set('PYTHONCASEOK', '1')
             self.caseok_env_changed(should_exist=True)
             sensitive, insensitive = self.sensitivity_test()
@@ -60,6 +65,8 @@ class CaseSensitivityTest(util.CASEOKTestBase):
 
 class CaseSensitivityTestPEP302(CaseSensitivityTest):
     def find(self, finder):
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore", DeprecationWarning)
         return finder.find_module(self.name)
 
 

--- a/Lib/test/test_importlib/test_api.py
+++ b/Lib/test/test_importlib/test_api.py
@@ -7,6 +7,7 @@ machinery = test_util.import_importlib('importlib.machinery')
 import os.path
 import sys
 from test import support
+from test.support import os_helper
 import types
 import unittest
 import warnings
@@ -244,7 +245,7 @@ class ReloadTests:
 
     def test_reload_location_changed(self):
         name = 'spam'
-        with support.temp_cwd(None) as cwd:
+        with os_helper.temp_cwd(None) as cwd:
             with test_util.uncache('spam'):
                 with support.DirsOnSysPath(cwd):
                     # Start as a plain module.
@@ -257,7 +258,7 @@ class ReloadTests:
                                 '__cached__': cached,
                                 '__doc__': None,
                                 }
-                    support.create_empty_file(path)
+                    os_helper.create_empty_file(path)
                     module = self.init.import_module(name)
                     ns = vars(module).copy()
                     loader = ns.pop('__loader__')
@@ -295,7 +296,7 @@ class ReloadTests:
 
     def test_reload_namespace_changed(self):
         name = 'spam'
-        with support.temp_cwd(None) as cwd:
+        with os_helper.temp_cwd(None) as cwd:
             with test_util.uncache('spam'):
                 with support.DirsOnSysPath(cwd):
                     # Start as a namespace package.

--- a/Lib/test/test_importlib/util.py
+++ b/Lib/test/test_importlib/util.py
@@ -11,6 +11,7 @@ import os
 import os.path
 from pathlib import Path, PurePath
 from test import support
+from test.support import os_helper
 import unittest
 import sys
 import tempfile
@@ -147,7 +148,7 @@ def uncache(*names):
 @contextlib.contextmanager
 def temp_module(name, content='', *, pkg=False):
     conflicts = [n for n in sys.modules if n.partition('.')[0] == name]
-    with support.temp_cwd(None) as cwd:
+    with os_helper.temp_cwd(None) as cwd:
         with uncache(name, *conflicts):
             with support.DirsOnSysPath(cwd):
                 invalidate_caches()
@@ -385,7 +386,7 @@ def create_modules(*names):
             state_manager.__exit__(None, None, None)
         if uncache_manager is not None:
             uncache_manager.__exit__(None, None, None)
-        support.rmtree(temp_dir)
+        os_helper.rmtree(temp_dir)
 
 
 def mock_path_hook(*entries, importer):

--- a/Lib/test/test_io.py
+++ b/Lib/test/test_io.py
@@ -37,8 +37,9 @@ import weakref
 from collections import deque, UserList
 from itertools import cycle, count
 from test import support
+from test.support import os_helper
 from test.support.script_helper import assert_python_ok, run_python_until_end
-from test.support import FakePath
+from test.support.os_helper import FakePath
 
 import codecs
 import io  # C implementation of io
@@ -314,10 +315,10 @@ class PyMockNonBlockWriterIO(MockNonBlockWriterIO, pyio.RawIOBase):
 class IOTest(unittest.TestCase):
 
     def setUp(self):
-        support.unlink(support.TESTFN)
+        os_helper.unlink(os_helper.TESTFN)
 
     def tearDown(self):
-        support.unlink(support.TESTFN)
+        os_helper.unlink(os_helper.TESTFN)
 
     def write_ops(self, f):
         self.assertEqual(f.write(b"blah."), 5)
@@ -402,19 +403,19 @@ class IOTest(unittest.TestCase):
         # Try writing on a file opened in read mode and vice-versa.
         exc = self.UnsupportedOperation
         for mode in ("w", "wb"):
-            with self.open(support.TESTFN, mode) as fp:
+            with self.open(os_helper.TESTFN, mode) as fp:
                 self.assertRaises(exc, fp.read)
                 self.assertRaises(exc, fp.readline)
-        with self.open(support.TESTFN, "wb", buffering=0) as fp:
+        with self.open(os_helper.TESTFN, "wb", buffering=0) as fp:
             self.assertRaises(exc, fp.read)
             self.assertRaises(exc, fp.readline)
-        with self.open(support.TESTFN, "rb", buffering=0) as fp:
+        with self.open(os_helper.TESTFN, "rb", buffering=0) as fp:
             self.assertRaises(exc, fp.write, b"blah")
             self.assertRaises(exc, fp.writelines, [b"blah\n"])
-        with self.open(support.TESTFN, "rb") as fp:
+        with self.open(os_helper.TESTFN, "rb") as fp:
             self.assertRaises(exc, fp.write, b"blah")
             self.assertRaises(exc, fp.writelines, [b"blah\n"])
-        with self.open(support.TESTFN, "r") as fp:
+        with self.open(os_helper.TESTFN, "r") as fp:
             self.assertRaises(exc, fp.write, "blah")
             self.assertRaises(exc, fp.writelines, ["blah\n"])
             # Non-zero seeking from current or end pos
@@ -535,33 +536,33 @@ class IOTest(unittest.TestCase):
             self.assertRaises(ValueError, self.open, bytes_fn, 'w')
 
     def test_raw_file_io(self):
-        with self.open(support.TESTFN, "wb", buffering=0) as f:
+        with self.open(os_helper.TESTFN, "wb", buffering=0) as f:
             self.assertEqual(f.readable(), False)
             self.assertEqual(f.writable(), True)
             self.assertEqual(f.seekable(), True)
             self.write_ops(f)
-        with self.open(support.TESTFN, "rb", buffering=0) as f:
+        with self.open(os_helper.TESTFN, "rb", buffering=0) as f:
             self.assertEqual(f.readable(), True)
             self.assertEqual(f.writable(), False)
             self.assertEqual(f.seekable(), True)
             self.read_ops(f)
 
     def test_buffered_file_io(self):
-        with self.open(support.TESTFN, "wb") as f:
+        with self.open(os_helper.TESTFN, "wb") as f:
             self.assertEqual(f.readable(), False)
             self.assertEqual(f.writable(), True)
             self.assertEqual(f.seekable(), True)
             self.write_ops(f)
-        with self.open(support.TESTFN, "rb") as f:
+        with self.open(os_helper.TESTFN, "rb") as f:
             self.assertEqual(f.readable(), True)
             self.assertEqual(f.writable(), False)
             self.assertEqual(f.seekable(), True)
             self.read_ops(f, True)
 
     def test_readline(self):
-        with self.open(support.TESTFN, "wb") as f:
+        with self.open(os_helper.TESTFN, "wb") as f:
             f.write(b"abc\ndef\nxyzzy\nfoo\x00bar\nanother line")
-        with self.open(support.TESTFN, "rb") as f:
+        with self.open(os_helper.TESTFN, "rb") as f:
             self.assertEqual(f.readline(), b"abc\n")
             self.assertEqual(f.readline(10), b"def\n")
             self.assertEqual(f.readline(2), b"xy")
@@ -569,7 +570,7 @@ class IOTest(unittest.TestCase):
             self.assertEqual(f.readline(), b"foo\x00bar\n")
             self.assertEqual(f.readline(None), b"another line")
             self.assertRaises(TypeError, f.readline, 5.3)
-        with self.open(support.TESTFN, "r") as f:
+        with self.open(os_helper.TESTFN, "r") as f:
             self.assertRaises(TypeError, f.readline, 5.3)
 
     def test_readline_nonsizeable(self):
@@ -604,20 +605,20 @@ class IOTest(unittest.TestCase):
             support.requires(
                 'largefile',
                 'test requires %s bytes and a long time to run' % self.LARGE)
-        with self.open(support.TESTFN, "w+b", 0) as f:
+        with self.open(os_helper.TESTFN, "w+b", 0) as f:
             self.large_file_ops(f)
-        with self.open(support.TESTFN, "w+b") as f:
+        with self.open(os_helper.TESTFN, "w+b") as f:
             self.large_file_ops(f)
 
     def test_with_open(self):
         for bufsize in (0, 100):
             f = None
-            with self.open(support.TESTFN, "wb", bufsize) as f:
+            with self.open(os_helper.TESTFN, "wb", bufsize) as f:
                 f.write(b"xxx")
             self.assertEqual(f.closed, True)
             f = None
             try:
-                with self.open(support.TESTFN, "wb", bufsize) as f:
+                with self.open(os_helper.TESTFN, "wb", bufsize) as f:
                     1/0
             except ZeroDivisionError:
                 self.assertEqual(f.closed, True)
@@ -626,13 +627,13 @@ class IOTest(unittest.TestCase):
 
     # issue 5008
     def test_append_mode_tell(self):
-        with self.open(support.TESTFN, "wb") as f:
+        with self.open(os_helper.TESTFN, "wb") as f:
             f.write(b"xxx")
-        with self.open(support.TESTFN, "ab", buffering=0) as f:
+        with self.open(os_helper.TESTFN, "ab", buffering=0) as f:
             self.assertEqual(f.tell(), 3)
-        with self.open(support.TESTFN, "ab") as f:
+        with self.open(os_helper.TESTFN, "ab") as f:
             self.assertEqual(f.tell(), 3)
-        with self.open(support.TESTFN, "a") as f:
+        with self.open(os_helper.TESTFN, "a") as f:
             self.assertGreater(f.tell(), 0)
 
     def test_destructor(self):
@@ -653,12 +654,12 @@ class IOTest(unittest.TestCase):
                 record.append(3)
                 super().flush()
         with support.check_warnings(('', ResourceWarning)):
-            f = MyFileIO(support.TESTFN, "wb")
+            f = MyFileIO(os_helper.TESTFN, "wb")
             f.write(b"xxx")
             del f
             support.gc_collect()
             self.assertEqual(record, [1, 2, 3])
-            with self.open(support.TESTFN, "rb") as f:
+            with self.open(os_helper.TESTFN, "rb") as f:
                 self.assertEqual(f.read(), b"xxx")
 
     def _check_base_destructor(self, base):
@@ -704,9 +705,9 @@ class IOTest(unittest.TestCase):
         self._check_base_destructor(self.TextIOBase)
 
     def test_close_flushes(self):
-        with self.open(support.TESTFN, "wb") as f:
+        with self.open(os_helper.TESTFN, "wb") as f:
             f.write(b"xxx")
-        with self.open(support.TESTFN, "rb") as f:
+        with self.open(os_helper.TESTFN, "rb") as f:
             self.assertEqual(f.read(), b"xxx")
 
     def test_array_writes(self):
@@ -717,25 +718,25 @@ class IOTest(unittest.TestCase):
                 self.assertEqual(f.write(a), n)
                 f.writelines((a,))
         check(self.BytesIO())
-        check(self.FileIO(support.TESTFN, "w"))
+        check(self.FileIO(os_helper.TESTFN, "w"))
         check(self.BufferedWriter(self.MockRawIO()))
         check(self.BufferedRandom(self.MockRawIO()))
         check(self.BufferedRWPair(self.MockRawIO(), self.MockRawIO()))
 
     def test_closefd(self):
-        self.assertRaises(ValueError, self.open, support.TESTFN, 'w',
+        self.assertRaises(ValueError, self.open, os_helper.TESTFN, 'w',
                           closefd=False)
 
     def test_read_closed(self):
-        with self.open(support.TESTFN, "w") as f:
+        with self.open(os_helper.TESTFN, "w") as f:
             f.write("egg\n")
-        with self.open(support.TESTFN, "r") as f:
+        with self.open(os_helper.TESTFN, "r") as f:
             file = self.open(f.fileno(), "r", closefd=False)
             self.assertEqual(file.read(), "egg\n")
             file.seek(0)
             file.close()
             self.assertRaises(ValueError, file.read)
-        with self.open(support.TESTFN, "rb") as f:
+        with self.open(os_helper.TESTFN, "rb") as f:
             file = self.open(f.fileno(), "rb", closefd=False)
             self.assertEqual(file.read()[:3], b"egg")
             file.close()
@@ -743,12 +744,12 @@ class IOTest(unittest.TestCase):
 
     def test_no_closefd_with_filename(self):
         # can't use closefd in combination with a file name
-        self.assertRaises(ValueError, self.open, support.TESTFN, "r", closefd=False)
+        self.assertRaises(ValueError, self.open, os_helper.TESTFN, "r", closefd=False)
 
     def test_closefd_attr(self):
-        with self.open(support.TESTFN, "wb") as f:
+        with self.open(os_helper.TESTFN, "wb") as f:
             f.write(b"egg\n")
-        with self.open(support.TESTFN, "r") as f:
+        with self.open(os_helper.TESTFN, "r") as f:
             self.assertEqual(f.buffer.raw.closefd, True)
             file = self.open(f.fileno(), "r", closefd=False)
             self.assertEqual(file.buffer.raw.closefd, False)
@@ -759,14 +760,14 @@ class IOTest(unittest.TestCase):
         # FileIO objects are collected, and collecting them flushes
         # all data to disk.
         with support.check_warnings(('', ResourceWarning)):
-            f = self.FileIO(support.TESTFN, "wb")
+            f = self.FileIO(os_helper.TESTFN, "wb")
             f.write(b"abcxxx")
             f.f = f
             wr = weakref.ref(f)
             del f
             support.gc_collect()
         self.assertIsNone(wr(), wr)
-        with self.open(support.TESTFN, "rb") as f:
+        with self.open(os_helper.TESTFN, "rb") as f:
             self.assertEqual(f.read(), b"abcxxx")
 
     def test_unbounded_file(self):
@@ -803,29 +804,29 @@ class IOTest(unittest.TestCase):
     def test_flush_error_on_close(self):
         # raw file
         # Issue #5700: io.FileIO calls flush() after file closed
-        self.check_flush_error_on_close(support.TESTFN, 'wb', buffering=0)
-        fd = os.open(support.TESTFN, os.O_WRONLY|os.O_CREAT)
+        self.check_flush_error_on_close(os_helper.TESTFN, 'wb', buffering=0)
+        fd = os.open(os_helper.TESTFN, os.O_WRONLY|os.O_CREAT)
         self.check_flush_error_on_close(fd, 'wb', buffering=0)
-        fd = os.open(support.TESTFN, os.O_WRONLY|os.O_CREAT)
+        fd = os.open(os_helper.TESTFN, os.O_WRONLY|os.O_CREAT)
         self.check_flush_error_on_close(fd, 'wb', buffering=0, closefd=False)
         os.close(fd)
         # buffered io
-        self.check_flush_error_on_close(support.TESTFN, 'wb')
-        fd = os.open(support.TESTFN, os.O_WRONLY|os.O_CREAT)
+        self.check_flush_error_on_close(os_helper.TESTFN, 'wb')
+        fd = os.open(os_helper.TESTFN, os.O_WRONLY|os.O_CREAT)
         self.check_flush_error_on_close(fd, 'wb')
-        fd = os.open(support.TESTFN, os.O_WRONLY|os.O_CREAT)
+        fd = os.open(os_helper.TESTFN, os.O_WRONLY|os.O_CREAT)
         self.check_flush_error_on_close(fd, 'wb', closefd=False)
         os.close(fd)
         # text io
-        self.check_flush_error_on_close(support.TESTFN, 'w')
-        fd = os.open(support.TESTFN, os.O_WRONLY|os.O_CREAT)
+        self.check_flush_error_on_close(os_helper.TESTFN, 'w')
+        fd = os.open(os_helper.TESTFN, os.O_WRONLY|os.O_CREAT)
         self.check_flush_error_on_close(fd, 'w')
-        fd = os.open(support.TESTFN, os.O_WRONLY|os.O_CREAT)
+        fd = os.open(os_helper.TESTFN, os.O_WRONLY|os.O_CREAT)
         self.check_flush_error_on_close(fd, 'w', closefd=False)
         os.close(fd)
 
     def test_multi_close(self):
-        f = self.open(support.TESTFN, "wb", buffering=0)
+        f = self.open(os_helper.TESTFN, "wb", buffering=0)
         f.close()
         f.close()
         f.close()
@@ -856,9 +857,9 @@ class IOTest(unittest.TestCase):
             self.assertTrue(hasattr(obj, "__dict__"))
 
     def test_opener(self):
-        with self.open(support.TESTFN, "w") as f:
+        with self.open(os_helper.TESTFN, "w") as f:
             f.write("egg\n")
-        fd = os.open(support.TESTFN, os.O_RDONLY)
+        fd = os.open(os_helper.TESTFN, os.O_RDONLY)
         def opener(path, flags):
             return fd
         with self.open("non-existent", "r", opener=opener) as f:
@@ -895,12 +896,12 @@ class IOTest(unittest.TestCase):
     def test_nonbuffered_textio(self):
         with support.check_no_resource_warning(self):
             with self.assertRaises(ValueError):
-                self.open(support.TESTFN, 'w', buffering=0)
+                self.open(os_helper.TESTFN, 'w', buffering=0)
 
     def test_invalid_newline(self):
         with support.check_no_resource_warning(self):
             with self.assertRaises(ValueError):
-                self.open(support.TESTFN, 'w', newline='invalid')
+                self.open(os_helper.TESTFN, 'w', newline='invalid')
 
     def test_buffered_readinto_mixin(self):
         # Test the implementation provided by BufferedIOBase
@@ -923,10 +924,10 @@ class IOTest(unittest.TestCase):
             with self.open(path, "r") as f:
                 self.assertEqual(f.read(), "egg\n")
 
-        check_path_succeeds(FakePath(support.TESTFN))
-        check_path_succeeds(FakePath(support.TESTFN.encode('utf-8')))
+        check_path_succeeds(FakePath(os_helper.TESTFN))
+        check_path_succeeds(FakePath(os_helper.TESTFN.encode('utf-8')))
 
-        with self.open(support.TESTFN, "w") as f:
+        with self.open(os_helper.TESTFN, "w") as f:
             bad_path = FakePath(f.fileno())
             with self.assertRaises(TypeError):
                 self.open(bad_path, 'w')
@@ -941,7 +942,7 @@ class IOTest(unittest.TestCase):
 
         # ensure that refcounting is correct with some error conditions
         with self.assertRaisesRegex(ValueError, 'read/write/append mode'):
-            self.open(FakePath(support.TESTFN), 'rwxa')
+            self.open(FakePath(os_helper.TESTFN), 'rwxa')
 
     def test_RawIOBase_readall(self):
         # Exercise the default unlimited RawIOBase.read() and readall()
@@ -1462,9 +1463,9 @@ class BufferedReaderTest(unittest.TestCase, CommonBufferedTests):
             l = list(range(256)) * N
             random.shuffle(l)
             s = bytes(bytearray(l))
-            with self.open(support.TESTFN, "wb") as f:
+            with self.open(os_helper.TESTFN, "wb") as f:
                 f.write(s)
-            with self.open(support.TESTFN, self.read_mode, buffering=0) as raw:
+            with self.open(os_helper.TESTFN, self.read_mode, buffering=0) as raw:
                 bufio = self.tp(raw, 8)
                 errors = []
                 results = []
@@ -1490,7 +1491,7 @@ class BufferedReaderTest(unittest.TestCase, CommonBufferedTests):
                     c = bytes(bytearray([i]))
                     self.assertEqual(s.count(c), N)
         finally:
-            support.unlink(support.TESTFN)
+            os_helper.unlink(os_helper.TESTFN)
 
     def test_unseekable(self):
         bufio = self.tp(self.MockUnseekableIO(b"A" * 10))
@@ -1576,9 +1577,9 @@ class CBufferedReaderTest(BufferedReaderTest, SizeofTest):
     def test_garbage_collection(self):
         # C BufferedReader objects are collected.
         # The Python version has __del__, so it ends into gc.garbage instead
-        self.addCleanup(support.unlink, support.TESTFN)
+        self.addCleanup(os_helper.unlink, os_helper.TESTFN)
         with support.check_warnings(('', ResourceWarning)):
-            rawio = self.FileIO(support.TESTFN, "w+b")
+            rawio = self.FileIO(os_helper.TESTFN, "w+b")
             f = self.tp(rawio)
             f.f = f
             wr = weakref.ref(f)
@@ -1788,26 +1789,26 @@ class BufferedWriterTest(unittest.TestCase, CommonBufferedTests):
 
     def test_truncate(self):
         # Truncate implicitly flushes the buffer.
-        self.addCleanup(support.unlink, support.TESTFN)
-        with self.open(support.TESTFN, self.write_mode, buffering=0) as raw:
+        self.addCleanup(os_helper.unlink, os_helper.TESTFN)
+        with self.open(os_helper.TESTFN, self.write_mode, buffering=0) as raw:
             bufio = self.tp(raw, 8)
             bufio.write(b"abcdef")
             self.assertEqual(bufio.truncate(3), 3)
             self.assertEqual(bufio.tell(), 6)
-        with self.open(support.TESTFN, "rb", buffering=0) as f:
+        with self.open(os_helper.TESTFN, "rb", buffering=0) as f:
             self.assertEqual(f.read(), b"abc")
 
     def test_truncate_after_write(self):
         # Ensure that truncate preserves the file position after
         # writes longer than the buffer size.
         # Issue: https://bugs.python.org/issue32228
-        self.addCleanup(support.unlink, support.TESTFN)
-        with self.open(support.TESTFN, "wb") as f:
+        self.addCleanup(os_helper.unlink, os_helper.TESTFN)
+        with self.open(os_helper.TESTFN, "wb") as f:
             # Fill with some buffer
             f.write(b'\x00' * 10000)
         buffer_sizes = [8192, 4096, 200]
         for buffer_size in buffer_sizes:
-            with self.open(support.TESTFN, "r+b", buffering=buffer_size) as f:
+            with self.open(os_helper.TESTFN, "r+b", buffering=buffer_size) as f:
                 f.write(b'\x00' * (buffer_size + 1))
                 # After write write_pos and write_end are set to 0
                 f.read(1)
@@ -1835,7 +1836,7 @@ class BufferedWriterTest(unittest.TestCase, CommonBufferedTests):
             # writing the buffer to the raw streams. This is in addition
             # to concurrency issues due to switching threads in the middle
             # of Python code.
-            with self.open(support.TESTFN, self.write_mode, buffering=0) as raw:
+            with self.open(os_helper.TESTFN, self.write_mode, buffering=0) as raw:
                 bufio = self.tp(raw, 8)
                 errors = []
                 def f():
@@ -1855,12 +1856,12 @@ class BufferedWriterTest(unittest.TestCase, CommonBufferedTests):
                 self.assertFalse(errors,
                     "the following exceptions were caught: %r" % errors)
                 bufio.close()
-            with self.open(support.TESTFN, "rb") as f:
+            with self.open(os_helper.TESTFN, "rb") as f:
                 s = f.read()
             for i in range(256):
                 self.assertEqual(s.count(bytes([i])), N)
         finally:
-            support.unlink(support.TESTFN)
+            os_helper.unlink(os_helper.TESTFN)
 
     def test_misbehaved_io(self):
         rawio = self.MisbehavedRawIO()
@@ -1931,9 +1932,9 @@ class CBufferedWriterTest(BufferedWriterTest, SizeofTest):
         # C BufferedWriter objects are collected, and collecting them flushes
         # all data to disk.
         # The Python version has __del__, so it ends into gc.garbage instead
-        self.addCleanup(support.unlink, support.TESTFN)
+        self.addCleanup(os_helper.unlink, os_helper.TESTFN)
         with support.check_warnings(('', ResourceWarning)):
-            rawio = self.FileIO(support.TESTFN, "w+b")
+            rawio = self.FileIO(os_helper.TESTFN, "w+b")
             f = self.tp(rawio)
             f.write(b"123xxx")
             f.x = f
@@ -1941,7 +1942,7 @@ class CBufferedWriterTest(BufferedWriterTest, SizeofTest):
             del f
             support.gc_collect()
         self.assertIsNone(wr(), wr)
-        with self.open(support.TESTFN, "rb") as f:
+        with self.open(os_helper.TESTFN, "rb") as f:
             self.assertEqual(f.read(), b"123xxx")
 
     # TODO: RUSTPYTHON
@@ -2594,10 +2595,10 @@ class TextIOWrapperTest(unittest.TestCase):
     def setUp(self):
         self.testdata = b"AAA\r\nBBB\rCCC\r\nDDD\nEEE\r\n"
         self.normalized = b"AAA\nBBB\nCCC\nDDD\nEEE\n".decode("ascii")
-        support.unlink(support.TESTFN)
+        os_helper.unlink(os_helper.TESTFN)
 
     def tearDown(self):
-        support.unlink(support.TESTFN)
+        os_helper.unlink(os_helper.TESTFN)
 
     def test_constructor(self):
         r = self.BytesIO(b"\xc3\xa9\n\n")
@@ -2935,11 +2936,11 @@ class TextIOWrapperTest(unittest.TestCase):
     def test_basic_io(self):
         for chunksize in (1, 2, 3, 4, 5, 15, 16, 17, 31, 32, 33, 63, 64, 65):
             for enc in "ascii", "latin-1", "utf-8" :# , "utf-16-be", "utf-16-le":
-                f = self.open(support.TESTFN, "w+", encoding=enc)
+                f = self.open(os_helper.TESTFN, "w+", encoding=enc)
                 f._CHUNK_SIZE = chunksize
                 self.assertEqual(f.write("abc"), 3)
                 f.close()
-                f = self.open(support.TESTFN, "r+", encoding=enc)
+                f = self.open(os_helper.TESTFN, "r+", encoding=enc)
                 f._CHUNK_SIZE = chunksize
                 self.assertEqual(f.tell(), 0)
                 self.assertEqual(f.read(), "abc")
@@ -2984,7 +2985,7 @@ class TextIOWrapperTest(unittest.TestCase):
         self.assertEqual(rlines, wlines)
 
     def test_telling(self):
-        f = self.open(support.TESTFN, "w+", encoding="utf-8")
+        f = self.open(os_helper.TESTFN, "w+", encoding="utf-8")
         p0 = f.tell()
         f.write("\xff\n")
         p1 = f.tell()
@@ -3012,9 +3013,9 @@ class TextIOWrapperTest(unittest.TestCase):
         u_suffix = "\u8888\n"
         suffix = bytes(u_suffix.encode("utf-8"))
         line = prefix + suffix
-        with self.open(support.TESTFN, "wb") as f:
+        with self.open(os_helper.TESTFN, "wb") as f:
             f.write(line*2)
-        with self.open(support.TESTFN, "r", encoding="utf-8") as f:
+        with self.open(os_helper.TESTFN, "r", encoding="utf-8") as f:
             s = f.read(prefix_size)
             self.assertEqual(s, str(prefix, "ascii"))
             self.assertEqual(f.tell(), prefix_size)
@@ -3023,9 +3024,9 @@ class TextIOWrapperTest(unittest.TestCase):
     def test_seeking_too(self):
         # Regression test for a specific bug
         data = b'\xe0\xbf\xbf\n'
-        with self.open(support.TESTFN, "wb") as f:
+        with self.open(os_helper.TESTFN, "wb") as f:
             f.write(data)
-        with self.open(support.TESTFN, "r", encoding="utf-8") as f:
+        with self.open(os_helper.TESTFN, "r", encoding="utf-8") as f:
             f._CHUNK_SIZE  # Just test that it exists
             f._CHUNK_SIZE = 2
             f.readline()
@@ -3039,17 +3040,17 @@ class TextIOWrapperTest(unittest.TestCase):
         def test_seek_and_tell_with_data(data, min_pos=0):
             """Tell/seek to various points within a data stream and ensure
             that the decoded data returned by read() is consistent."""
-            f = self.open(support.TESTFN, 'wb')
+            f = self.open(os_helper.TESTFN, 'wb')
             f.write(data)
             f.close()
-            f = self.open(support.TESTFN, encoding='test_decoder')
+            f = self.open(os_helper.TESTFN, encoding='test_decoder')
             f._CHUNK_SIZE = CHUNK_SIZE
             decoded = f.read()
             f.close()
 
             for i in range(min_pos, len(decoded) + 1): # seek positions
                 for j in [1, 5, len(decoded) - i]: # read lengths
-                    f = self.open(support.TESTFN, encoding='test_decoder')
+                    f = self.open(os_helper.TESTFN, encoding='test_decoder')
                     self.assertEqual(f.read(i), decoded[:i])
                     cookie = f.tell()
                     self.assertEqual(f.read(j), decoded[i:i + j])
@@ -3081,11 +3082,11 @@ class TextIOWrapperTest(unittest.TestCase):
     # TODO: RUSTPYTHON
     @unittest.expectedFailure
     def test_multibyte_seek_and_tell(self):
-        f = self.open(support.TESTFN, "w", encoding="euc_jp")
+        f = self.open(os_helper.TESTFN, "w", encoding="euc_jp")
         f.write("AB\n\u3046\u3048\n")
         f.close()
 
-        f = self.open(support.TESTFN, "r", encoding="euc_jp")
+        f = self.open(os_helper.TESTFN, "r", encoding="euc_jp")
         self.assertEqual(f.readline(), "AB\n")
         p0 = f.tell()
         self.assertEqual(f.readline(), "\u3046\u3048\n")
@@ -3098,7 +3099,7 @@ class TextIOWrapperTest(unittest.TestCase):
     # TODO: RUSTPYTHON
     @unittest.expectedFailure
     def test_seek_with_encoder_state(self):
-        f = self.open(support.TESTFN, "w", encoding="euc_jis_2004")
+        f = self.open(os_helper.TESTFN, "w", encoding="euc_jis_2004")
         f.write("\u00e6\u0300")
         p0 = f.tell()
         f.write("\u00e6")
@@ -3106,7 +3107,7 @@ class TextIOWrapperTest(unittest.TestCase):
         f.write("\u0300")
         f.close()
 
-        f = self.open(support.TESTFN, "r", encoding="euc_jis_2004")
+        f = self.open(os_helper.TESTFN, "r", encoding="euc_jis_2004")
         self.assertEqual(f.readline(), "\u00e6\u0300\u0300")
         f.close()
 
@@ -3254,7 +3255,7 @@ class TextIOWrapperTest(unittest.TestCase):
     @unittest.expectedFailure
     def test_append_bom(self):
         # The BOM is not written again when appending to a non-empty file
-        filename = support.TESTFN
+        filename = os_helper.TESTFN
         for charset in ('utf-8-sig', 'utf-16', 'utf-32'):
             with self.open(filename, 'w', encoding=charset) as f:
                 f.write('aaa')
@@ -3271,7 +3272,7 @@ class TextIOWrapperTest(unittest.TestCase):
     @unittest.expectedFailure
     def test_seek_bom(self):
         # Same test, but when seeking manually
-        filename = support.TESTFN
+        filename = os_helper.TESTFN
         for charset in ('utf-8-sig', 'utf-16', 'utf-32'):
             with self.open(filename, 'w', encoding=charset) as f:
                 f.write('aaa')
@@ -3288,7 +3289,7 @@ class TextIOWrapperTest(unittest.TestCase):
     @unittest.expectedFailure
     def test_seek_append_bom(self):
         # Same test, but first seek to the start and then to the end
-        filename = support.TESTFN
+        filename = os_helper.TESTFN
         for charset in ('utf-8-sig', 'utf-16', 'utf-32'):
             with self.open(filename, 'w', encoding=charset) as f:
                 f.write('aaa')
@@ -3300,16 +3301,16 @@ class TextIOWrapperTest(unittest.TestCase):
                 self.assertEqual(f.read(), 'aaaxxx'.encode(charset))
 
     def test_errors_property(self):
-        with self.open(support.TESTFN, "w") as f:
+        with self.open(os_helper.TESTFN, "w") as f:
             self.assertEqual(f.errors, "strict")
-        with self.open(support.TESTFN, "w", errors="replace") as f:
+        with self.open(os_helper.TESTFN, "w", errors="replace") as f:
             self.assertEqual(f.errors, "replace")
 
     @support.no_tracing
     def test_threads_write(self):
         # Issue6750: concurrent writes could duplicate data
         event = threading.Event()
-        with self.open(support.TESTFN, "w", buffering=1) as f:
+        with self.open(os_helper.TESTFN, "w", buffering=1) as f:
             def run(n):
                 text = "Thread%03d\n" % n
                 event.wait()
@@ -3318,7 +3319,7 @@ class TextIOWrapperTest(unittest.TestCase):
                        for x in range(20)]
             with support.start_threads(threads, event.set):
                 time.sleep(0.02)
-        with self.open(support.TESTFN) as f:
+        with self.open(os_helper.TESTFN) as f:
             content = f.read()
             for n in range(20):
                 self.assertEqual(content.count("Thread%03d\n" % n), 1)
@@ -3892,7 +3893,7 @@ class CTextIOWrapperTest(TextIOWrapperTest):
         # all data to disk.
         # The Python version has __del__, so it ends in gc.garbage instead.
         with support.check_warnings(('', ResourceWarning)):
-            rawio = io.FileIO(support.TESTFN, "wb")
+            rawio = io.FileIO(os_helper.TESTFN, "wb")
             b = self.BufferedWriter(rawio)
             t = self.TextIOWrapper(b, encoding="ascii")
             t.write("456def")
@@ -3901,7 +3902,7 @@ class CTextIOWrapperTest(TextIOWrapperTest):
             del t
             support.gc_collect()
         self.assertIsNone(wr(), wr)
-        with self.open(support.TESTFN, "rb") as f:
+        with self.open(os_helper.TESTFN, "rb") as f:
             self.assertEqual(f.read(), b"456def")
 
     def test_rwpair_cleared_before_textio(self):
@@ -4069,7 +4070,7 @@ class PyIncrementalNewlineDecoderTest(IncrementalNewlineDecoderTest):
 class MiscIOTest(unittest.TestCase):
 
     def tearDown(self):
-        support.unlink(support.TESTFN)
+        os_helper.unlink(os_helper.TESTFN)
 
     def test___all__(self):
         for name in self.io.__all__:
@@ -4083,23 +4084,23 @@ class MiscIOTest(unittest.TestCase):
                 self.assertTrue(issubclass(obj, self.IOBase))
 
     def test_attributes(self):
-        f = self.open(support.TESTFN, "wb", buffering=0)
+        f = self.open(os_helper.TESTFN, "wb", buffering=0)
         self.assertEqual(f.mode, "wb")
         f.close()
 
         # XXX RUSTPYTHON: universal mode is deprecated anyway, so I
         #                 feel fine about skipping it
         # with support.check_warnings(('', DeprecationWarning)):
-        #     f = self.open(support.TESTFN, "U")
-        # self.assertEqual(f.name,            support.TESTFN)
-        # self.assertEqual(f.buffer.name,     support.TESTFN)
-        # self.assertEqual(f.buffer.raw.name, support.TESTFN)
+        #     f = self.open(os_helper.TESTFN, "U")
+        # self.assertEqual(f.name,            os_helper.TESTFN)
+        # self.assertEqual(f.buffer.name,     os_helper.TESTFN)
+        # self.assertEqual(f.buffer.raw.name, os_helper.TESTFN)
         # self.assertEqual(f.mode,            "U")
         # self.assertEqual(f.buffer.mode,     "rb")
         # self.assertEqual(f.buffer.raw.mode, "rb")
         # f.close()
 
-        f = self.open(support.TESTFN, "w+")
+        f = self.open(os_helper.TESTFN, "w+")
         self.assertEqual(f.mode,            "w+")
         self.assertEqual(f.buffer.mode,     "rb+") # Does it really matter?
         self.assertEqual(f.buffer.raw.mode, "rb+")
@@ -4141,7 +4142,7 @@ class MiscIOTest(unittest.TestCase):
                 {"mode": "w+", "buffering": 2},
                 {"mode": "w+b", "buffering": 0},
             ]:
-            f = self.open(support.TESTFN, **kwargs)
+            f = self.open(os_helper.TESTFN, **kwargs)
             f.close()
             self.assertRaises(ValueError, f.flush)
             self.assertRaises(ValueError, f.fileno)
@@ -4193,17 +4194,17 @@ class MiscIOTest(unittest.TestCase):
         self.assertIsInstance(self.TextIOBase, abc.ABCMeta)
 
     def _check_abc_inheritance(self, abcmodule):
-        with self.open(support.TESTFN, "wb", buffering=0) as f:
+        with self.open(os_helper.TESTFN, "wb", buffering=0) as f:
             self.assertIsInstance(f, abcmodule.IOBase)
             self.assertIsInstance(f, abcmodule.RawIOBase)
             self.assertNotIsInstance(f, abcmodule.BufferedIOBase)
             self.assertNotIsInstance(f, abcmodule.TextIOBase)
-        with self.open(support.TESTFN, "wb") as f:
+        with self.open(os_helper.TESTFN, "wb") as f:
             self.assertIsInstance(f, abcmodule.IOBase)
             self.assertNotIsInstance(f, abcmodule.RawIOBase)
             self.assertIsInstance(f, abcmodule.BufferedIOBase)
             self.assertNotIsInstance(f, abcmodule.TextIOBase)
-        with self.open(support.TESTFN, "w") as f:
+        with self.open(os_helper.TESTFN, "w") as f:
             self.assertIsInstance(f, abcmodule.IOBase)
             self.assertNotIsInstance(f, abcmodule.RawIOBase)
             self.assertNotIsInstance(f, abcmodule.BufferedIOBase)
@@ -4229,9 +4230,9 @@ class MiscIOTest(unittest.TestCase):
     # TODO: RUSTPYTHON
     @unittest.expectedFailure
     def test_warn_on_dealloc(self):
-        self._check_warn_on_dealloc(support.TESTFN, "wb", buffering=0)
-        self._check_warn_on_dealloc(support.TESTFN, "wb")
-        self._check_warn_on_dealloc(support.TESTFN, "w")
+        self._check_warn_on_dealloc(os_helper.TESTFN, "wb", buffering=0)
+        self._check_warn_on_dealloc(os_helper.TESTFN, "wb")
+        self._check_warn_on_dealloc(os_helper.TESTFN, "w")
 
     def _check_warn_on_dealloc_fd(self, *args, **kwargs):
         fds = []
@@ -4274,7 +4275,7 @@ class MiscIOTest(unittest.TestCase):
                 {"mode": "w+b", "buffering": 0},
             ]:
             for protocol in range(pickle.HIGHEST_PROTOCOL + 1):
-                with self.open(support.TESTFN, **kwargs) as f:
+                with self.open(os_helper.TESTFN, **kwargs) as f:
                     self.assertRaises(TypeError, pickle.dumps, f, protocol)
 
     # TODO: RUSTPYTHON
@@ -4341,20 +4342,20 @@ class MiscIOTest(unittest.TestCase):
 
     def test_create_fail(self):
         # 'x' mode fails if file is existing
-        with self.open(support.TESTFN, 'w'):
+        with self.open(os_helper.TESTFN, 'w'):
             pass
-        self.assertRaises(FileExistsError, self.open, support.TESTFN, 'x')
+        self.assertRaises(FileExistsError, self.open, os_helper.TESTFN, 'x')
 
     def test_create_writes(self):
         # 'x' mode opens for writing
-        with self.open(support.TESTFN, 'xb') as f:
+        with self.open(os_helper.TESTFN, 'xb') as f:
             f.write(b"spam")
-        with self.open(support.TESTFN, 'rb') as f:
+        with self.open(os_helper.TESTFN, 'rb') as f:
             self.assertEqual(b"spam", f.read())
 
     def test_open_allargs(self):
         # there used to be a buffer overflow in the parser for rawmode
-        self.assertRaises(ValueError, self.open, support.TESTFN, 'rwax+')
+        self.assertRaises(ValueError, self.open, os_helper.TESTFN, 'rwax+')
 
 
 class CMiscIOTest(MiscIOTest):

--- a/Lib/test/test_iter.py
+++ b/Lib/test/test_iter.py
@@ -2,8 +2,9 @@
 
 import sys
 import unittest
-from test.support import run_unittest, TESTFN, unlink, cpython_only
+from test.support import run_unittest, cpython_only
 # from test.support import check_free_after_iterating
+from test.support.os_helper import TESTFN, unlink
 import pickle
 import collections.abc
 

--- a/Lib/test/test_json/test_tool.py
+++ b/Lib/test/test_json/test_tool.py
@@ -4,6 +4,7 @@ import textwrap
 import unittest
 from subprocess import Popen, PIPE
 from test import support
+from test.support import os_helper
 from test.support.script_helper import assert_python_ok
 
 
@@ -90,7 +91,7 @@ class TestTool(unittest.TestCase):
         self.assertEqual(err, b'')
 
     def _create_infile(self, data=None):
-        infile = support.TESTFN
+        infile = os_helper.TESTFN
         with open(infile, "w", encoding="utf-8") as fp:
             self.addCleanup(os.remove, infile)
             fp.write(data or self.data)
@@ -120,7 +121,7 @@ class TestTool(unittest.TestCase):
 
     def test_infile_outfile(self):
         infile = self._create_infile()
-        outfile = support.TESTFN + '.out'
+        outfile = os_helper.TESTFN + '.out'
         rc, out, err = assert_python_ok('-m', 'json.tool', infile, outfile)
         self.addCleanup(os.remove, outfile)
         with open(outfile, "r") as fp:

--- a/Lib/test/test_linecache.py
+++ b/Lib/test/test_linecache.py
@@ -6,6 +6,7 @@ import os.path
 import tempfile
 import tokenize
 from test import support
+from test.support import os_helper
 
 
 FILENAME = linecache.__file__
@@ -44,7 +45,7 @@ class TempFile:
         with tempfile.NamedTemporaryFile(delete=False) as fp:
             self.file_name = fp.name
             fp.write(self.file_byte_string)
-        self.addCleanup(support.unlink, self.file_name)
+        self.addCleanup(os_helper.unlink, self.file_name)
 
 
 class GetLineTestsGoodData(TempFile):
@@ -124,10 +125,10 @@ class LineCacheTests(unittest.TestCase):
         self.assertEqual(empty, [])
 
     def test_no_ending_newline(self):
-        self.addCleanup(support.unlink, support.TESTFN)
-        with open(support.TESTFN, "w") as fp:
+        self.addCleanup(os_helper.unlink, os_helper.TESTFN)
+        with open(os_helper.TESTFN, "w") as fp:
             fp.write(SOURCE_3)
-        lines = linecache.getlines(support.TESTFN)
+        lines = linecache.getlines(os_helper.TESTFN)
         self.assertEqual(lines, ["\n", "def f():\n", "    return 3\n"])
 
     def test_clearcache(self):
@@ -150,8 +151,8 @@ class LineCacheTests(unittest.TestCase):
     def test_checkcache(self):
         getline = linecache.getline
         # Create a source file and cache its contents
-        source_name = support.TESTFN + '.py'
-        self.addCleanup(support.unlink, source_name)
+        source_name = os_helper.TESTFN + '.py'
+        self.addCleanup(os_helper.unlink, source_name)
         with open(source_name, 'w') as source:
             source.write(SOURCE_1)
         getline(source_name, 1)

--- a/Lib/test/test_mimetypes.py
+++ b/Lib/test/test_mimetypes.py
@@ -62,7 +62,7 @@ class MimeTypesTestCase(unittest.TestCase):
         # Unreadable file returns None
         self.assertIsNone(mimetypes.read_mime_types("non-existent"))
 
-        with support.temp_dir() as directory:
+        with os_helper.temp_dir() as directory:
             data = "x-application/x-unittest pyunit\n"
             file = pathlib.Path(directory, "sample.mimetype")
             file.write_text(data)
@@ -72,7 +72,7 @@ class MimeTypesTestCase(unittest.TestCase):
         # bpo-41048: read_mime_types should read the rule file with 'utf-8' encoding.
         # Not with locale encoding. _bootlocale has been imported because io.open(...)
         # uses it.
-        with support.temp_dir() as directory:
+        with os_helper.temp_dir() as directory:
             data = "application/no-mans-land  Fran\u00E7ais"
             file = pathlib.Path(directory, "sample.mimetype")
             file.write_text(data, encoding='utf-8')

--- a/Lib/test/test_netrc.py
+++ b/Lib/test/test_netrc.py
@@ -1,5 +1,6 @@
 import netrc, os, unittest, sys, tempfile, textwrap
 from test import support
+from test.support import os_helper
 
 
 class NetrcTestCase(unittest.TestCase):
@@ -108,16 +109,16 @@ class NetrcTestCase(unittest.TestCase):
     def test_security(self):
         # This test is incomplete since we are normally not run as root and
         # therefore can't test the file ownership being wrong.
-        d = support.TESTFN
+        d = os_helper.TESTFN
         os.mkdir(d)
-        self.addCleanup(support.rmtree, d)
+        self.addCleanup(os_helper.rmtree, d)
         fn = os.path.join(d, '.netrc')
         with open(fn, 'wt') as f:
             f.write("""\
                 machine foo.domain.com login bar password pass
                 default login foo password pass
                 """)
-        with support.EnvironmentVarGuard() as environ:
+        with os_helper.EnvironmentVarGuard() as environ:
             environ.set('HOME', d)
             os.chmod(fn, 0o600)
             nrc = netrc.netrc()
@@ -127,10 +128,10 @@ class NetrcTestCase(unittest.TestCase):
             self.assertRaises(netrc.NetrcParseError, netrc.netrc)
 
     def test_file_not_found_in_home(self):
-        d = support.TESTFN
+        d = os_helper.TESTFN
         os.mkdir(d)
-        self.addCleanup(support.rmtree, d)
-        with support.EnvironmentVarGuard() as environ:
+        self.addCleanup(os_helper.rmtree, d)
+        with os_helper.EnvironmentVarGuard() as environ:
             environ.set('HOME', d)
             self.assertRaises(FileNotFoundError, netrc.netrc)
 
@@ -140,9 +141,9 @@ class NetrcTestCase(unittest.TestCase):
 
     @unittest.skipIf(sys.platform == "win32", "TODO: RUSTPYTHON, permission error from remnant directory")
     def test_home_not_set(self):
-        fake_home = support.TESTFN
+        fake_home = os_helper.TESTFN
         os.mkdir(fake_home)
-        self.addCleanup(support.rmtree, fake_home)
+        self.addCleanup(os_helper.rmtree, fake_home)
         fake_netrc_path = os.path.join(fake_home, '.netrc')
         with open(fake_netrc_path, 'w') as f:
             f.write('machine foo.domain.com login bar password pass')
@@ -153,7 +154,7 @@ class NetrcTestCase(unittest.TestCase):
 
         def fake_expanduser(s):
             called.append(s)
-            with support.EnvironmentVarGuard() as environ:
+            with os_helper.EnvironmentVarGuard() as environ:
                 environ.set('HOME', fake_home)
                 environ.set('USERPROFILE', fake_home)
                 result = orig_expanduser(s)

--- a/Lib/test/test_ntpath.py
+++ b/Lib/test/test_ntpath.py
@@ -3,7 +3,9 @@ import os
 import sys
 import unittest
 import warnings
-from test.support import TestFailed, FakePath
+from test.support import TestFailed
+from test.support import os_helper
+from test.support.os_helper import FakePath
 from test import support, test_genericpath
 from tempfile import TemporaryFile
 
@@ -254,40 +256,40 @@ class TestNtpath(NtpathTestCase):
         tester("ntpath.realpath('\\'.join(['..'] * 50))",
                ntpath.splitdrive(expected)[0] + '\\')
 
-    @support.skip_unless_symlink
+    @os_helper.skip_unless_symlink
     @unittest.skipUnless(HAVE_GETFINALPATHNAME, 'need _getfinalpathname')
     def test_realpath_basic(self):
-        ABSTFN = ntpath.abspath(support.TESTFN)
+        ABSTFN = ntpath.abspath(os_helper.TESTFN)
         open(ABSTFN, "wb").close()
-        self.addCleanup(support.unlink, ABSTFN)
-        self.addCleanup(support.unlink, ABSTFN + "1")
+        self.addCleanup(os_helper.unlink, ABSTFN)
+        self.addCleanup(os_helper.unlink, ABSTFN + "1")
 
         os.symlink(ABSTFN, ABSTFN + "1")
         self.assertPathEqual(ntpath.realpath(ABSTFN + "1"), ABSTFN)
         self.assertPathEqual(ntpath.realpath(os.fsencode(ABSTFN + "1")),
                          os.fsencode(ABSTFN))
 
-    @support.skip_unless_symlink
+    @os_helper.skip_unless_symlink
     @unittest.skipUnless(HAVE_GETFINALPATHNAME, 'need _getfinalpathname')
     def test_realpath_relative(self):
-        ABSTFN = ntpath.abspath(support.TESTFN)
+        ABSTFN = ntpath.abspath(os_helper.TESTFN)
         open(ABSTFN, "wb").close()
-        self.addCleanup(support.unlink, ABSTFN)
-        self.addCleanup(support.unlink, ABSTFN + "1")
+        self.addCleanup(os_helper.unlink, ABSTFN)
+        self.addCleanup(os_helper.unlink, ABSTFN + "1")
 
         os.symlink(ABSTFN, ntpath.relpath(ABSTFN + "1"))
         self.assertPathEqual(ntpath.realpath(ABSTFN + "1"), ABSTFN)
 
     # TODO: RUSTPYTHON
     @unittest.expectedFailure
-    @support.skip_unless_symlink
+    @os_helper.skip_unless_symlink
     @unittest.skipUnless(HAVE_GETFINALPATHNAME, 'need _getfinalpathname')
     def test_realpath_broken_symlinks(self):
-        ABSTFN = ntpath.abspath(support.TESTFN)
+        ABSTFN = ntpath.abspath(os_helper.TESTFN)
         os.mkdir(ABSTFN)
-        self.addCleanup(support.rmtree, ABSTFN)
+        self.addCleanup(os_helper.rmtree, ABSTFN)
 
-        with support.change_cwd(ABSTFN):
+        with os_helper.change_cwd(ABSTFN):
             os.mkdir("subdir")
             os.chdir("subdir")
             os.symlink(".", "recursive")
@@ -338,18 +340,18 @@ class TestNtpath(NtpathTestCase):
                                  os.fsencode(ABSTFN + r"\missing"))
 
     @unittest.skip("TODO: RUSTPYTHON, leaves behind TESTFN")
-    @support.skip_unless_symlink
+    @os_helper.skip_unless_symlink
     @unittest.skipUnless(HAVE_GETFINALPATHNAME, 'need _getfinalpathname')
     def test_realpath_symlink_loops(self):
         # Symlink loops are non-deterministic as to which path is returned, but
         # it will always be the fully resolved path of one member of the cycle
-        ABSTFN = ntpath.abspath(support.TESTFN)
-        self.addCleanup(support.unlink, ABSTFN)
-        self.addCleanup(support.unlink, ABSTFN + "1")
-        self.addCleanup(support.unlink, ABSTFN + "2")
-        self.addCleanup(support.unlink, ABSTFN + "y")
-        self.addCleanup(support.unlink, ABSTFN + "c")
-        self.addCleanup(support.unlink, ABSTFN + "a")
+        ABSTFN = ntpath.abspath(os_helper.TESTFN)
+        self.addCleanup(os_helper.unlink, ABSTFN)
+        self.addCleanup(os_helper.unlink, ABSTFN + "1")
+        self.addCleanup(os_helper.unlink, ABSTFN + "2")
+        self.addCleanup(os_helper.unlink, ABSTFN + "y")
+        self.addCleanup(os_helper.unlink, ABSTFN + "c")
+        self.addCleanup(os_helper.unlink, ABSTFN + "a")
 
         os.symlink(ABSTFN, ABSTFN)
         self.assertPathEqual(ntpath.realpath(ABSTFN), ABSTFN)
@@ -384,14 +386,14 @@ class TestNtpath(NtpathTestCase):
         # Test using relative path as well.
         self.assertPathEqual(ntpath.realpath(ntpath.basename(ABSTFN)), ABSTFN)
 
-    @support.skip_unless_symlink
+    @os_helper.skip_unless_symlink
     @unittest.skipUnless(HAVE_GETFINALPATHNAME, 'need _getfinalpathname')
     def test_realpath_symlink_prefix(self):
-        ABSTFN = ntpath.abspath(support.TESTFN)
-        self.addCleanup(support.unlink, ABSTFN + "3")
-        self.addCleanup(support.unlink, "\\\\?\\" + ABSTFN + "3.")
-        self.addCleanup(support.unlink, ABSTFN + "3link")
-        self.addCleanup(support.unlink, ABSTFN + "3.link")
+        ABSTFN = ntpath.abspath(os_helper.TESTFN)
+        self.addCleanup(os_helper.unlink, ABSTFN + "3")
+        self.addCleanup(os_helper.unlink, "\\\\?\\" + ABSTFN + "3.")
+        self.addCleanup(os_helper.unlink, ABSTFN + "3link")
+        self.addCleanup(os_helper.unlink, ABSTFN + "3.link")
 
         with open(ABSTFN + "3", "wb") as f:
             f.write(b'0')
@@ -425,12 +427,12 @@ class TestNtpath(NtpathTestCase):
     @unittest.skipUnless(HAVE_GETFINALPATHNAME, 'need _getfinalpathname')
     @unittest.skipUnless(HAVE_GETSHORTPATHNAME, 'need _getshortpathname')
     def test_realpath_cwd(self):
-        ABSTFN = ntpath.abspath(support.TESTFN)
+        ABSTFN = ntpath.abspath(os_helper.TESTFN)
 
-        support.unlink(ABSTFN)
-        support.rmtree(ABSTFN)
+        os_helper.unlink(ABSTFN)
+        os_helper.rmtree(ABSTFN)
         os.mkdir(ABSTFN)
-        self.addCleanup(support.rmtree, ABSTFN)
+        self.addCleanup(os_helper.rmtree, ABSTFN)
 
         test_dir_long = ntpath.join(ABSTFN, "MyVeryLongDirectoryName")
         os.mkdir(test_dir_long)
@@ -444,15 +446,15 @@ class TestNtpath(NtpathTestCase):
 
         self.assertPathEqual(test_file_long, ntpath.realpath(test_file_short))
 
-        with support.change_cwd(test_dir_long):
+        with os_helper.change_cwd(test_dir_long):
             self.assertPathEqual(test_file_long, ntpath.realpath("file.txt"))
-        with support.change_cwd(test_dir_long.lower()):
+        with os_helper.change_cwd(test_dir_long.lower()):
             self.assertPathEqual(test_file_long, ntpath.realpath("file.txt"))
-        with support.change_cwd(test_dir_short):
+        with os_helper.change_cwd(test_dir_short):
             self.assertPathEqual(test_file_long, ntpath.realpath("file.txt"))
 
     def test_expandvars(self):
-        with support.EnvironmentVarGuard() as env:
+        with os_helper.EnvironmentVarGuard() as env:
             env.clear()
             env["foo"] = "bar"
             env["{foo"] = "baz1"
@@ -477,13 +479,13 @@ class TestNtpath(NtpathTestCase):
             tester('ntpath.expandvars("\'%foo%\'%bar")', "\'%foo%\'%bar")
             tester('ntpath.expandvars("bar\'%foo%")', "bar\'%foo%")
 
-    @unittest.skipUnless(support.FS_NONASCII, 'need support.FS_NONASCII')
+    @unittest.skipUnless(os_helper.FS_NONASCII, 'need os_helper.FS_NONASCII')
     def test_expandvars_nonascii(self):
         def check(value, expected):
             tester('ntpath.expandvars(%r)' % value, expected)
-        with support.EnvironmentVarGuard() as env:
+        with os_helper.EnvironmentVarGuard() as env:
             env.clear()
-            nonascii = support.FS_NONASCII
+            nonascii = os_helper.FS_NONASCII
             env['spam'] = nonascii
             env[nonascii] = 'ham' + nonascii
             check('$spam bar', '%s bar' % nonascii)
@@ -500,7 +502,7 @@ class TestNtpath(NtpathTestCase):
     def test_expanduser(self):
         tester('ntpath.expanduser("test")', 'test')
 
-        with support.EnvironmentVarGuard() as env:
+        with os_helper.EnvironmentVarGuard() as env:
             env.clear()
             tester('ntpath.expanduser("~test")', '~test')
 
@@ -536,7 +538,7 @@ class TestNtpath(NtpathTestCase):
     @unittest.skipUnless(nt, "abspath requires 'nt' module")
     def test_abspath(self):
         tester('ntpath.abspath("C:\\")', "C:\\")
-        with support.temp_cwd(support.TESTFN) as cwd_dir: # bpo-31047
+        with os_helper.temp_cwd(os_helper.TESTFN) as cwd_dir: # bpo-31047
             tester('ntpath.abspath("")', cwd_dir)
             tester('ntpath.abspath(" ")', cwd_dir + "\\ ")
             tester('ntpath.abspath("?")', cwd_dir + "\\?")
@@ -548,7 +550,7 @@ class TestNtpath(NtpathTestCase):
         tester('ntpath.relpath(ntpath.abspath("a"))', 'a')
         tester('ntpath.relpath("a/b")', 'a\\b')
         tester('ntpath.relpath("../a/b")', '..\\a\\b')
-        with support.temp_cwd(support.TESTFN) as cwd_dir:
+        with os_helper.temp_cwd(os_helper.TESTFN) as cwd_dir:
             currentdir = ntpath.basename(cwd_dir)
             tester('ntpath.relpath("a", "../b")', '..\\'+currentdir+'\\a')
             tester('ntpath.relpath("a/b", "../c")', '..\\'+currentdir+'\\a\\b')
@@ -668,7 +670,7 @@ class TestNtpath(NtpathTestCase):
         self.assertTrue(ntpath.ismount(b"\\\\.\\c:\\"))
         self.assertTrue(ntpath.ismount(b"\\\\.\\C:\\"))
 
-        with support.temp_dir() as d:
+        with os_helper.temp_dir() as d:
             self.assertFalse(ntpath.ismount(d))
 
         if sys.platform == "win32":
@@ -678,7 +680,7 @@ class TestNtpath(NtpathTestCase):
             # locations below cannot then refer to mount points
             #
             drive, path = ntpath.splitdrive(sys.executable)
-            with support.change_cwd(ntpath.dirname(sys.executable)):
+            with os_helper.change_cwd(ntpath.dirname(sys.executable)):
                 self.assertFalse(ntpath.ismount(drive.lower()))
                 self.assertFalse(ntpath.ismount(drive.upper()))
 
@@ -765,9 +767,9 @@ class PathLikeTests(NtpathTestCase):
     path = ntpath
 
     def setUp(self):
-        self.file_name = support.TESTFN.lower()
-        self.file_path = FakePath(support.TESTFN)
-        self.addCleanup(support.unlink, self.file_name)
+        self.file_name = os_helper.TESTFN.lower()
+        self.file_path = FakePath(os_helper.TESTFN)
+        self.addCleanup(os_helper.unlink, self.file_name)
         with open(self.file_name, 'xb', 0) as file:
             file.write(b"test_ntpath.PathLikeTests")
 

--- a/Lib/test/test_optparse.py
+++ b/Lib/test/test_optparse.py
@@ -14,6 +14,7 @@ import unittest
 
 from io import StringIO
 from test import support
+from test.support import os_helper
 
 
 import optparse
@@ -1021,10 +1022,10 @@ class TestExtendAddTypes(BaseTest):
         self.parser.add_option("-f", "--file", type="file", dest="file")
 
     def tearDown(self):
-        if os.path.isdir(support.TESTFN):
-            os.rmdir(support.TESTFN)
-        elif os.path.isfile(support.TESTFN):
-            os.unlink(support.TESTFN)
+        if os.path.isdir(os_helper.TESTFN):
+            os.rmdir(os_helper.TESTFN)
+        elif os.path.isfile(os_helper.TESTFN):
+            os.unlink(os_helper.TESTFN)
 
     class MyOption (Option):
         def check_file(option, opt, value):
@@ -1039,21 +1040,21 @@ class TestExtendAddTypes(BaseTest):
         TYPE_CHECKER["file"] = check_file
 
     def test_filetype_ok(self):
-        support.create_empty_file(support.TESTFN)
-        self.assertParseOK(["--file", support.TESTFN, "-afoo"],
-                           {'file': support.TESTFN, 'a': 'foo'},
+        os_helper.create_empty_file(os_helper.TESTFN)
+        self.assertParseOK(["--file", os_helper.TESTFN, "-afoo"],
+                           {'file': os_helper.TESTFN, 'a': 'foo'},
                            [])
 
     def test_filetype_noexist(self):
-        self.assertParseFail(["--file", support.TESTFN, "-afoo"],
+        self.assertParseFail(["--file", os_helper.TESTFN, "-afoo"],
                              "%s: file does not exist" %
-                             support.TESTFN)
+                             os_helper.TESTFN)
 
     def test_filetype_notfile(self):
-        os.mkdir(support.TESTFN)
-        self.assertParseFail(["--file", support.TESTFN, "-afoo"],
+        os.mkdir(os_helper.TESTFN)
+        self.assertParseFail(["--file", os_helper.TESTFN, "-afoo"],
                              "%s: not a regular file" %
-                             support.TESTFN)
+                             os_helper.TESTFN)
 
 
 class TestExtendAddActions(BaseTest):
@@ -1497,7 +1498,7 @@ class TestHelp(BaseTest):
         # we must restore its original value -- otherwise, this test
         # screws things up for other tests when it's part of the Python
         # test suite.
-        with support.EnvironmentVarGuard() as env:
+        with os_helper.EnvironmentVarGuard() as env:
             env['COLUMNS'] = str(columns)
             return InterceptingOptionParser(option_list=options)
 
@@ -1522,7 +1523,7 @@ class TestHelp(BaseTest):
         self.assertHelpEquals(_expected_help_long_opts_first)
 
     def test_help_title_formatter(self):
-        with support.EnvironmentVarGuard() as env:
+        with os_helper.EnvironmentVarGuard() as env:
             env["COLUMNS"] = "80"
             self.parser.formatter = TitledHelpFormatter()
             self.assertHelpEquals(_expected_help_title_formatter)
@@ -1651,8 +1652,8 @@ class TestParseNumber(BaseTest):
 
 class MiscTestCase(unittest.TestCase):
     def test__all__(self):
-        blacklist = {'check_builtin', 'AmbiguousOptionError', 'NO_DEFAULT'}
-        support.check__all__(self, optparse, blacklist=blacklist)
+        not_exported = {'check_builtin', 'AmbiguousOptionError', 'NO_DEFAULT'}
+        support.check__all__(self, optparse, not_exported=not_exported)
 
 
 def test_main():

--- a/Lib/test/test_os.py
+++ b/Lib/test/test_os.py
@@ -2,8 +2,6 @@
 # does add tests for a few functions which have been determined to be more
 # portable than they had been thought to be.
 
-import asynchat
-import asyncore
 import codecs
 import contextlib
 import decimal
@@ -12,24 +10,40 @@ import fnmatch
 import fractions
 import itertools
 import locale
+# TODO: RUSTPYTHON
 # import mmap
 import os
 import pickle
+import select
 import shutil
 import signal
 import socket
 import stat
+import struct
 import subprocess
 import sys
 import sysconfig
 import tempfile
 import threading
 import time
+import types
 import unittest
 import uuid
 import warnings
 from test import support
+# TODO: RUSTPYTHON
+# from test.support import import_helper
+from test.support import os_helper
+# TODO: RUSTPYTHON
+# from test.support import socket_helper
+# from test.support import threading_helper
+# from test.support import warnings_helper
 from platform import win32_is_iot
+
+with warnings.catch_warnings():
+    warnings.simplefilter('ignore', DeprecationWarning)
+    import asynchat
+    import asyncore
 
 try:
     import resource
@@ -53,8 +67,10 @@ try:
 except ImportError:
     INT_MAX = PY_SSIZE_T_MAX = sys.maxsize
 
+
 from test.support.script_helper import assert_python_ok
-from test.support import unix_shell, FakePath
+from test.support import unix_shell
+from test.support.os_helper import FakePath
 
 
 root_in_posix = False
@@ -83,6 +99,11 @@ def create_file(filename, content=b'content'):
         fp.write(content)
 
 
+# bpo-41625: On AIX, splice() only works with a socket, not with a pipe.
+requires_splice_pipe = unittest.skipIf(sys.platform.startswith("aix"),
+                                       'on AIX, splice() only accepts sockets')
+
+
 class MiscTests(unittest.TestCase):
     def test_getcwd(self):
         cwd = os.getcwd()
@@ -101,12 +122,16 @@ class MiscTests(unittest.TestCase):
         # than MAX_PATH if long paths support is disabled:
         # see RtlAreLongPathsEnabled().
         min_len = 2000   # characters
+        # On VxWorks, PATH_MAX is defined as 1024 bytes. Creating a path
+        # longer than PATH_MAX will fail.
+        if sys.platform == 'vxworks':
+            min_len = 1000
         dirlen = 200     # characters
         dirname = 'python_test_dir_'
         dirname = dirname + ('a' * (dirlen - len(dirname)))
 
         with tempfile.TemporaryDirectory() as tmpdir:
-            with support.change_cwd(tmpdir) as path:
+            with os_helper.change_cwd(tmpdir) as path:
                 expected = path
 
                 while True:
@@ -150,17 +175,17 @@ class MiscTests(unittest.TestCase):
 # Tests creating TESTFN
 class FileTests(unittest.TestCase):
     def setUp(self):
-        if os.path.lexists(support.TESTFN):
-            os.unlink(support.TESTFN)
+        if os.path.lexists(os_helper.TESTFN):
+            os.unlink(os_helper.TESTFN)
     tearDown = setUp
 
     def test_access(self):
-        f = os.open(support.TESTFN, os.O_CREAT|os.O_RDWR)
+        f = os.open(os_helper.TESTFN, os.O_CREAT|os.O_RDWR)
         os.close(f)
-        self.assertTrue(os.access(support.TESTFN, os.W_OK))
+        self.assertTrue(os.access(os_helper.TESTFN, os.W_OK))
 
     def test_closerange(self):
-        first = os.open(support.TESTFN, os.O_CREAT|os.O_RDWR)
+        first = os.open(os_helper.TESTFN, os.O_CREAT|os.O_RDWR)
         # We must allocate two consecutive file descriptors, otherwise
         # it will mess up other file descriptors (perhaps even the three
         # standard ones).
@@ -182,14 +207,14 @@ class FileTests(unittest.TestCase):
 
     @support.cpython_only
     def test_rename(self):
-        path = support.TESTFN
+        path = os_helper.TESTFN
         old = sys.getrefcount(path)
         self.assertRaises(TypeError, os.rename, path, 0)
         new = sys.getrefcount(path)
         self.assertEqual(old, new)
 
     def test_read(self):
-        with open(support.TESTFN, "w+b") as fobj:
+        with open(os_helper.TESTFN, "w+b") as fobj:
             fobj.write(b"spam")
             fobj.flush()
             fd = fobj.fileno()
@@ -205,12 +230,12 @@ class FileTests(unittest.TestCase):
                          "needs INT_MAX < PY_SSIZE_T_MAX")
     @support.bigmemtest(size=INT_MAX + 10, memuse=1, dry_run=False)
     def test_large_read(self, size):
-        self.addCleanup(support.unlink, support.TESTFN)
-        create_file(support.TESTFN, b'test')
+        self.addCleanup(os_helper.unlink, os_helper.TESTFN)
+        create_file(os_helper.TESTFN, b'test')
 
         # Issue #21932: Make sure that os.read() does not raise an
         # OverflowError for size larger than INT_MAX
-        with open(support.TESTFN, "rb") as fp:
+        with open(os_helper.TESTFN, "rb") as fp:
             data = os.read(fp.fileno(), size)
 
         # The test does not try to read more than 2 GiB at once because the
@@ -219,13 +244,13 @@ class FileTests(unittest.TestCase):
 
     def test_write(self):
         # os.write() accepts bytes- and buffer-like objects but not strings
-        fd = os.open(support.TESTFN, os.O_CREAT | os.O_WRONLY)
+        fd = os.open(os_helper.TESTFN, os.O_CREAT | os.O_WRONLY)
         self.assertRaises(TypeError, os.write, fd, "beans")
         os.write(fd, b"bacon\n")
         os.write(fd, bytearray(b"eggs\n"))
         os.write(fd, memoryview(b"spam\n"))
         os.close(fd)
-        with open(support.TESTFN, "rb") as fobj:
+        with open(os_helper.TESTFN, "rb") as fobj:
             self.assertEqual(fobj.read().splitlines(),
                 [b"bacon", b"eggs", b"spam"])
 
@@ -249,12 +274,12 @@ class FileTests(unittest.TestCase):
         self.write_windows_console(sys.executable, "-u", "-c", code)
 
     def fdopen_helper(self, *args):
-        fd = os.open(support.TESTFN, os.O_RDONLY)
-        f = os.fdopen(fd, *args)
+        fd = os.open(os_helper.TESTFN, os.O_RDONLY)
+        f = os.fdopen(fd, *args, encoding="utf-8")
         f.close()
 
     def test_fdopen(self):
-        fd = os.open(support.TESTFN, os.O_CREAT|os.O_RDWR)
+        fd = os.open(os_helper.TESTFN, os.O_CREAT|os.O_RDWR)
         os.close(fd)
 
         self.fdopen_helper()
@@ -262,16 +287,16 @@ class FileTests(unittest.TestCase):
         self.fdopen_helper('r', 100)
 
     def test_replace(self):
-        TESTFN2 = support.TESTFN + ".2"
-        self.addCleanup(support.unlink, support.TESTFN)
-        self.addCleanup(support.unlink, TESTFN2)
+        TESTFN2 = os_helper.TESTFN + ".2"
+        self.addCleanup(os_helper.unlink, os_helper.TESTFN)
+        self.addCleanup(os_helper.unlink, TESTFN2)
 
-        create_file(support.TESTFN, b"1")
+        create_file(os_helper.TESTFN, b"1")
         create_file(TESTFN2, b"2")
 
-        os.replace(support.TESTFN, TESTFN2)
-        self.assertRaises(FileNotFoundError, os.stat, support.TESTFN)
-        with open(TESTFN2, 'r') as f:
+        os.replace(os_helper.TESTFN, TESTFN2)
+        self.assertRaises(FileNotFoundError, os.stat, os_helper.TESTFN)
+        with open(TESTFN2, 'r', encoding='utf-8') as f:
             self.assertEqual(f.read(), "1")
 
     def test_open_keywords(self):
@@ -282,7 +307,7 @@ class FileTests(unittest.TestCase):
     def test_symlink_keywords(self):
         symlink = support.get_attribute(os, "symlink")
         try:
-            symlink(src='target', dst=support.TESTFN,
+            symlink(src='target', dst=os_helper.TESTFN,
                 target_is_directory=False, dir_fd=None)
         except (NotImplementedError, OSError):
             pass  # No OS support or unprivileged user
@@ -294,18 +319,18 @@ class FileTests(unittest.TestCase):
 
     @unittest.skipUnless(hasattr(os, 'copy_file_range'), 'test needs os.copy_file_range()')
     def test_copy_file_range(self):
-        TESTFN2 = support.TESTFN + ".3"
+        TESTFN2 = os_helper.TESTFN + ".3"
         data = b'0123456789'
 
-        create_file(support.TESTFN, data)
-        self.addCleanup(support.unlink, support.TESTFN)
+        create_file(os_helper.TESTFN, data)
+        self.addCleanup(os_helper.unlink, os_helper.TESTFN)
 
-        in_file = open(support.TESTFN, 'rb')
+        in_file = open(os_helper.TESTFN, 'rb')
         self.addCleanup(in_file.close)
         in_fd = in_file.fileno()
 
         out_file = open(TESTFN2, 'w+b')
-        self.addCleanup(support.unlink, TESTFN2)
+        self.addCleanup(os_helper.unlink, TESTFN2)
         self.addCleanup(out_file.close)
         out_fd = out_file.fileno()
 
@@ -328,21 +353,21 @@ class FileTests(unittest.TestCase):
 
     @unittest.skipUnless(hasattr(os, 'copy_file_range'), 'test needs os.copy_file_range()')
     def test_copy_file_range_offset(self):
-        TESTFN4 = support.TESTFN + ".4"
+        TESTFN4 = os_helper.TESTFN + ".4"
         data = b'0123456789'
         bytes_to_copy = 6
         in_skip = 3
         out_seek = 5
 
-        create_file(support.TESTFN, data)
-        self.addCleanup(support.unlink, support.TESTFN)
+        create_file(os_helper.TESTFN, data)
+        self.addCleanup(os_helper.unlink, os_helper.TESTFN)
 
-        in_file = open(support.TESTFN, 'rb')
+        in_file = open(os_helper.TESTFN, 'rb')
         self.addCleanup(in_file.close)
         in_fd = in_file.fileno()
 
         out_file = open(TESTFN4, 'w+b')
-        self.addCleanup(support.unlink, TESTFN4)
+        self.addCleanup(os_helper.unlink, TESTFN4)
         self.addCleanup(out_file.close)
         out_fd = out_file.fileno()
 
@@ -371,11 +396,131 @@ class FileTests(unittest.TestCase):
             self.assertEqual(read[out_seek:],
                              data[in_skip:in_skip+i])
 
+    @unittest.skipUnless(hasattr(os, 'splice'), 'test needs os.splice()')
+    def test_splice_invalid_values(self):
+        with self.assertRaises(ValueError):
+            os.splice(0, 1, -10)
+
+    @unittest.skipUnless(hasattr(os, 'splice'), 'test needs os.splice()')
+    @requires_splice_pipe
+    def test_splice(self):
+        TESTFN2 = os_helper.TESTFN + ".3"
+        data = b'0123456789'
+
+        create_file(os_helper.TESTFN, data)
+        self.addCleanup(os_helper.unlink, os_helper.TESTFN)
+
+        in_file = open(os_helper.TESTFN, 'rb')
+        self.addCleanup(in_file.close)
+        in_fd = in_file.fileno()
+
+        read_fd, write_fd = os.pipe()
+        self.addCleanup(lambda: os.close(read_fd))
+        self.addCleanup(lambda: os.close(write_fd))
+
+        try:
+            i = os.splice(in_fd, write_fd, 5)
+        except OSError as e:
+            # Handle the case in which Python was compiled
+            # in a system with the syscall but without support
+            # in the kernel.
+            if e.errno != errno.ENOSYS:
+                raise
+            self.skipTest(e)
+        else:
+            # The number of copied bytes can be less than
+            # the number of bytes originally requested.
+            self.assertIn(i, range(0, 6));
+
+            self.assertEqual(os.read(read_fd, 100), data[:i])
+
+    @unittest.skipUnless(hasattr(os, 'splice'), 'test needs os.splice()')
+    @requires_splice_pipe
+    def test_splice_offset_in(self):
+        TESTFN4 = os_helper.TESTFN + ".4"
+        data = b'0123456789'
+        bytes_to_copy = 6
+        in_skip = 3
+
+        create_file(os_helper.TESTFN, data)
+        self.addCleanup(os_helper.unlink, os_helper.TESTFN)
+
+        in_file = open(os_helper.TESTFN, 'rb')
+        self.addCleanup(in_file.close)
+        in_fd = in_file.fileno()
+
+        read_fd, write_fd = os.pipe()
+        self.addCleanup(lambda: os.close(read_fd))
+        self.addCleanup(lambda: os.close(write_fd))
+
+        try:
+            i = os.splice(in_fd, write_fd, bytes_to_copy, offset_src=in_skip)
+        except OSError as e:
+            # Handle the case in which Python was compiled
+            # in a system with the syscall but without support
+            # in the kernel.
+            if e.errno != errno.ENOSYS:
+                raise
+            self.skipTest(e)
+        else:
+            # The number of copied bytes can be less than
+            # the number of bytes originally requested.
+            self.assertIn(i, range(0, bytes_to_copy+1));
+
+            read = os.read(read_fd, 100)
+            # 012 are skipped (in_skip)
+            # 345678 are copied in the file (in_skip + bytes_to_copy)
+            self.assertEqual(read, data[in_skip:in_skip+i])
+
+    @unittest.skipUnless(hasattr(os, 'splice'), 'test needs os.splice()')
+    @requires_splice_pipe
+    def test_splice_offset_out(self):
+        TESTFN4 = os_helper.TESTFN + ".4"
+        data = b'0123456789'
+        bytes_to_copy = 6
+        out_seek = 3
+
+        create_file(os_helper.TESTFN, data)
+        self.addCleanup(os_helper.unlink, os_helper.TESTFN)
+
+        read_fd, write_fd = os.pipe()
+        self.addCleanup(lambda: os.close(read_fd))
+        self.addCleanup(lambda: os.close(write_fd))
+        os.write(write_fd, data)
+
+        out_file = open(TESTFN4, 'w+b')
+        self.addCleanup(os_helper.unlink, TESTFN4)
+        self.addCleanup(out_file.close)
+        out_fd = out_file.fileno()
+
+        try:
+            i = os.splice(read_fd, out_fd, bytes_to_copy, offset_dst=out_seek)
+        except OSError as e:
+            # Handle the case in which Python was compiled
+            # in a system with the syscall but without support
+            # in the kernel.
+            if e.errno != errno.ENOSYS:
+                raise
+            self.skipTest(e)
+        else:
+            # The number of copied bytes can be less than
+            # the number of bytes originally requested.
+            self.assertIn(i, range(0, bytes_to_copy+1));
+
+            with open(TESTFN4, 'rb') as in_file:
+                read = in_file.read()
+            # seeked bytes (5) are zero'ed
+            self.assertEqual(read[:out_seek], b'\x00'*out_seek)
+            # 012 are skipped (in_skip)
+            # 345678 are copied in the file (in_skip + bytes_to_copy)
+            self.assertEqual(read[out_seek:], data[:i])
+
+
 # Test attributes on return values from os.*stat* family.
 class StatAttributeTests(unittest.TestCase):
     def setUp(self):
-        self.fname = support.TESTFN
-        self.addCleanup(support.unlink, self.fname)
+        self.fname = os_helper.TESTFN
+        self.addCleanup(os_helper.unlink, self.fname)
         create_file(self.fname, b"ABC")
 
     def check_stat_attributes(self, fname):
@@ -560,7 +705,7 @@ class StatAttributeTests(unittest.TestCase):
             0)
 
         # test directory st_file_attributes (FILE_ATTRIBUTE_DIRECTORY set)
-        dirname = support.TESTFN + "dir"
+        dirname = os_helper.TESTFN + "dir"
         os.mkdir(dirname)
         self.addCleanup(os.rmdir, dirname)
 
@@ -577,7 +722,7 @@ class StatAttributeTests(unittest.TestCase):
         # os.environ['TEMP'] should be located on a volume that
         # supports file ACLs.
         fname = os.path.join(os.environ['TEMP'], self.fname)
-        self.addCleanup(support.unlink, fname)
+        self.addCleanup(os_helper.unlink, fname)
         create_file(fname, b'ABC')
         # Deny the right to [S]YNCHRONIZE on the file to
         # force CreateFile to fail with ERROR_ACCESS_DENIED.
@@ -602,10 +747,10 @@ class StatAttributeTests(unittest.TestCase):
 
 class UtimeTests(unittest.TestCase):
     def setUp(self):
-        self.dirname = support.TESTFN
+        self.dirname = os_helper.TESTFN
         self.fname = os.path.join(self.dirname, "f1")
 
-        self.addCleanup(support.rmtree, self.dirname)
+        self.addCleanup(os_helper.rmtree, self.dirname)
         os.mkdir(self.dirname)
         create_file(self.fname)
 
@@ -824,185 +969,311 @@ class UtimeTests(unittest.TestCase):
 
 from test import mapping_tests
 
-# TODO: RUSTPYTHON (KeyError: 'surrogateescape')
-# class EnvironTests(mapping_tests.BasicTestMappingProtocol):
-#     """check that os.environ object conform to mapping protocol"""
-#     type2test = None
+class EnvironTests(mapping_tests.BasicTestMappingProtocol):
+    """check that os.environ object conform to mapping protocol"""
+    type2test = None
 
-#     def setUp(self):
-#         self.__save = dict(os.environ)
-#         if os.supports_bytes_environ:
-#             self.__saveb = dict(os.environb)
-#         for key, value in self._reference().items():
-#             os.environ[key] = value
+    def setUp(self):
+        self.__save = dict(os.environ)
+        if os.supports_bytes_environ:
+            self.__saveb = dict(os.environb)
+        for key, value in self._reference().items():
+            os.environ[key] = value
 
-#     def tearDown(self):
-#         os.environ.clear()
-#         os.environ.update(self.__save)
-#         if os.supports_bytes_environ:
-#             os.environb.clear()
-#             os.environb.update(self.__saveb)
+    def tearDown(self):
+        os.environ.clear()
+        os.environ.update(self.__save)
+        if os.supports_bytes_environ:
+            os.environb.clear()
+            os.environb.update(self.__saveb)
 
-#     def _reference(self):
-#         return {"KEY1":"VALUE1", "KEY2":"VALUE2", "KEY3":"VALUE3"}
+    def _reference(self):
+        return {"KEY1":"VALUE1", "KEY2":"VALUE2", "KEY3":"VALUE3"}
 
-#     def _empty_mapping(self):
-#         os.environ.clear()
-#         return os.environ
+    def _empty_mapping(self):
+        os.environ.clear()
+        return os.environ
 
-#     # Bug 1110478
-#     @unittest.skipUnless(unix_shell and os.path.exists(unix_shell),
-#                          'requires a shell')
-#     def test_update2(self):
-#         os.environ.clear()
-#         os.environ.update(HELLO="World")
-#         with os.popen("%s -c 'echo $HELLO'" % unix_shell) as popen:
-#             value = popen.read().strip()
-#             self.assertEqual(value, "World")
+    # Bug 1110478
+    @unittest.skipUnless(unix_shell and os.path.exists(unix_shell),
+                         'requires a shell')
+    @unittest.skipUnless(hasattr(os, 'popen'), "needs os.popen()")
+    def test_update2(self):
+        os.environ.clear()
+        os.environ.update(HELLO="World")
+        with os.popen("%s -c 'echo $HELLO'" % unix_shell) as popen:
+            value = popen.read().strip()
+            self.assertEqual(value, "World")
 
-#     @unittest.skipUnless(unix_shell and os.path.exists(unix_shell),
-#                          'requires a shell')
-#     def test_os_popen_iter(self):
-#         with os.popen("%s -c 'echo \"line1\nline2\nline3\"'"
-#                       % unix_shell) as popen:
-#             it = iter(popen)
-#             self.assertEqual(next(it), "line1\n")
-#             self.assertEqual(next(it), "line2\n")
-#             self.assertEqual(next(it), "line3\n")
-#             self.assertRaises(StopIteration, next, it)
+    @unittest.skipUnless(unix_shell and os.path.exists(unix_shell),
+                         'requires a shell')
+    @unittest.skipUnless(hasattr(os, 'popen'), "needs os.popen()")
+    def test_os_popen_iter(self):
+        with os.popen("%s -c 'echo \"line1\nline2\nline3\"'"
+                      % unix_shell) as popen:
+            it = iter(popen)
+            self.assertEqual(next(it), "line1\n")
+            self.assertEqual(next(it), "line2\n")
+            self.assertEqual(next(it), "line3\n")
+            self.assertRaises(StopIteration, next, it)
 
-#     # Verify environ keys and values from the OS are of the
-#     # correct str type.
-#     def test_keyvalue_types(self):
-#         for key, val in os.environ.items():
-#             self.assertEqual(type(key), str)
-#             self.assertEqual(type(val), str)
+    # Verify environ keys and values from the OS are of the
+    # correct str type.
+    def test_keyvalue_types(self):
+        for key, val in os.environ.items():
+            self.assertEqual(type(key), str)
+            self.assertEqual(type(val), str)
 
-#     def test_items(self):
-#         for key, value in self._reference().items():
-#             self.assertEqual(os.environ.get(key), value)
+    def test_items(self):
+        for key, value in self._reference().items():
+            self.assertEqual(os.environ.get(key), value)
 
-#     # Issue 7310
-#     def test___repr__(self):
-#         """Check that the repr() of os.environ looks like environ({...})."""
-#         env = os.environ
-#         self.assertEqual(repr(env), 'environ({{{}}})'.format(', '.join(
-#             '{!r}: {!r}'.format(key, value)
-#             for key, value in env.items())))
+    # Issue 7310
+    def test___repr__(self):
+        """Check that the repr() of os.environ looks like environ({...})."""
+        env = os.environ
+        formatted_items = ", ".join(
+            f"{key!r}: {value!r}"
+            for key, value in env.items()
+        )
+        self.assertEqual(repr(env), f"environ({{{formatted_items}}})")
 
-#     def test_get_exec_path(self):
-#         defpath_list = os.defpath.split(os.pathsep)
-#         test_path = ['/monty', '/python', '', '/flying/circus']
-#         test_env = {'PATH': os.pathsep.join(test_path)}
+    def test_get_exec_path(self):
+        defpath_list = os.defpath.split(os.pathsep)
+        test_path = ['/monty', '/python', '', '/flying/circus']
+        test_env = {'PATH': os.pathsep.join(test_path)}
 
-#         saved_environ = os.environ
-#         try:
-#             os.environ = dict(test_env)
-#             # Test that defaulting to os.environ works.
-#             self.assertSequenceEqual(test_path, os.get_exec_path())
-#             self.assertSequenceEqual(test_path, os.get_exec_path(env=None))
-#         finally:
-#             os.environ = saved_environ
+        saved_environ = os.environ
+        try:
+            os.environ = dict(test_env)
+            # Test that defaulting to os.environ works.
+            self.assertSequenceEqual(test_path, os.get_exec_path())
+            self.assertSequenceEqual(test_path, os.get_exec_path(env=None))
+        finally:
+            os.environ = saved_environ
 
-#         # No PATH environment variable
-#         self.assertSequenceEqual(defpath_list, os.get_exec_path({}))
-#         # Empty PATH environment variable
-#         self.assertSequenceEqual(('',), os.get_exec_path({'PATH':''}))
-#         # Supplied PATH environment variable
-#         self.assertSequenceEqual(test_path, os.get_exec_path(test_env))
+        # No PATH environment variable
+        self.assertSequenceEqual(defpath_list, os.get_exec_path({}))
+        # Empty PATH environment variable
+        self.assertSequenceEqual(('',), os.get_exec_path({'PATH':''}))
+        # Supplied PATH environment variable
+        self.assertSequenceEqual(test_path, os.get_exec_path(test_env))
 
-#         if os.supports_bytes_environ:
-#             # env cannot contain 'PATH' and b'PATH' keys
-#             try:
-#                 # ignore BytesWarning warning
-#                 with warnings.catch_warnings(record=True):
-#                     mixed_env = {'PATH': '1', b'PATH': b'2'}
-#             except BytesWarning:
-#                 # mixed_env cannot be created with python -bb
-#                 pass
-#             else:
-#                 self.assertRaises(ValueError, os.get_exec_path, mixed_env)
+        if os.supports_bytes_environ:
+            # env cannot contain 'PATH' and b'PATH' keys
+            try:
+                # ignore BytesWarning warning
+                with warnings.catch_warnings(record=True):
+                    mixed_env = {'PATH': '1', b'PATH': b'2'}
+            except BytesWarning:
+                # mixed_env cannot be created with python -bb
+                pass
+            else:
+                self.assertRaises(ValueError, os.get_exec_path, mixed_env)
 
-#             # bytes key and/or value
-#             self.assertSequenceEqual(os.get_exec_path({b'PATH': b'abc'}),
-#                 ['abc'])
-#             self.assertSequenceEqual(os.get_exec_path({b'PATH': 'abc'}),
-#                 ['abc'])
-#             self.assertSequenceEqual(os.get_exec_path({'PATH': b'abc'}),
-#                 ['abc'])
+            # bytes key and/or value
+            self.assertSequenceEqual(os.get_exec_path({b'PATH': b'abc'}),
+                ['abc'])
+            self.assertSequenceEqual(os.get_exec_path({b'PATH': 'abc'}),
+                ['abc'])
+            self.assertSequenceEqual(os.get_exec_path({'PATH': b'abc'}),
+                ['abc'])
 
-#     @unittest.skipUnless(os.supports_bytes_environ,
-#                          "os.environb required for this test.")
-#     def test_environb(self):
-#         # os.environ -> os.environb
-#         value = 'euro\u20ac'
-#         try:
-#             value_bytes = value.encode(sys.getfilesystemencoding(),
-#                                        'surrogateescape')
-#         except UnicodeEncodeError:
-#             msg = "U+20AC character is not encodable to %s" % (
-#                 sys.getfilesystemencoding(),)
-#             self.skipTest(msg)
-#         os.environ['unicode'] = value
-#         self.assertEqual(os.environ['unicode'], value)
-#         self.assertEqual(os.environb[b'unicode'], value_bytes)
+    @unittest.skipUnless(os.supports_bytes_environ,
+                         "os.environb required for this test.")
+    # TODO: RUSTPYTHON (KeyError: 'surrogateescape')
+    @unittest.expectedFailure
+    def test_environb(self):
+        # os.environ -> os.environb
+        value = 'euro\u20ac'
+        try:
+            value_bytes = value.encode(sys.getfilesystemencoding(),
+                                       'surrogateescape')
+        except UnicodeEncodeError:
+            msg = "U+20AC character is not encodable to %s" % (
+                sys.getfilesystemencoding(),)
+            self.skipTest(msg)
+        os.environ['unicode'] = value
+        self.assertEqual(os.environ['unicode'], value)
+        self.assertEqual(os.environb[b'unicode'], value_bytes)
 
-#         # os.environb -> os.environ
-#         value = b'\xff'
-#         os.environb[b'bytes'] = value
-#         self.assertEqual(os.environb[b'bytes'], value)
-#         value_str = value.decode(sys.getfilesystemencoding(), 'surrogateescape')
-#         self.assertEqual(os.environ['bytes'], value_str)
+        # os.environb -> os.environ
+        value = b'\xff'
+        os.environb[b'bytes'] = value
+        self.assertEqual(os.environb[b'bytes'], value)
+        value_str = value.decode(sys.getfilesystemencoding(), 'surrogateescape')
+        self.assertEqual(os.environ['bytes'], value_str)
 
-#     # On OS X < 10.6, unsetenv() doesn't return a value (bpo-13415).
-#     @support.requires_mac_ver(10, 6)
-#     def test_unset_error(self):
-#         if sys.platform == "win32":
-#             # an environment variable is limited to 32,767 characters
-#             key = 'x' * 50000
-#             self.assertRaises(ValueError, os.environ.__delitem__, key)
-#         else:
-#             # "=" is not allowed in a variable name
-#             key = 'key='
-#             self.assertRaises(OSError, os.environ.__delitem__, key)
+    def test_putenv_unsetenv(self):
+        name = "PYTHONTESTVAR"
+        value = "testvalue"
+        code = f'import os; print(repr(os.environ.get({name!r})))'
 
-#     def test_key_type(self):
-#         missing = 'missingkey'
-#         self.assertNotIn(missing, os.environ)
+        with os_helper.EnvironmentVarGuard() as env:
+            env.pop(name, None)
 
-#         with self.assertRaises(KeyError) as cm:
-#             os.environ[missing]
-#         self.assertIs(cm.exception.args[0], missing)
-#         self.assertTrue(cm.exception.__suppress_context__)
+            os.putenv(name, value)
+            proc = subprocess.run([sys.executable, '-c', code], check=True,
+                                  stdout=subprocess.PIPE, text=True)
+            self.assertEqual(proc.stdout.rstrip(), repr(value))
 
-#         with self.assertRaises(KeyError) as cm:
-#             del os.environ[missing]
-#         self.assertIs(cm.exception.args[0], missing)
-#         self.assertTrue(cm.exception.__suppress_context__)
+            os.unsetenv(name)
+            proc = subprocess.run([sys.executable, '-c', code], check=True,
+                                  stdout=subprocess.PIPE, text=True)
+            self.assertEqual(proc.stdout.rstrip(), repr(None))
 
-#     def _test_environ_iteration(self, collection):
-#         iterator = iter(collection)
-#         new_key = "__new_key__"
+    # On OS X < 10.6, unsetenv() doesn't return a value (bpo-13415).
+    @support.requires_mac_ver(10, 6)
+    def test_putenv_unsetenv_error(self):
+        # Empty variable name is invalid.
+        # "=" and null character are not allowed in a variable name.
+        for name in ('', '=name', 'na=me', 'name=', 'name\0', 'na\0me'):
+            self.assertRaises((OSError, ValueError), os.putenv, name, "value")
+            self.assertRaises((OSError, ValueError), os.unsetenv, name)
 
-#         next(iterator)  # start iteration over os.environ.items
+        if sys.platform == "win32":
+            # On Windows, an environment variable string ("name=value" string)
+            # is limited to 32,767 characters
+            longstr = 'x' * 32_768
+            self.assertRaises(ValueError, os.putenv, longstr, "1")
+            self.assertRaises(ValueError, os.putenv, "X", longstr)
+            self.assertRaises(ValueError, os.unsetenv, longstr)
 
-#         # add a new key in os.environ mapping
-#         os.environ[new_key] = "test_environ_iteration"
+    def test_key_type(self):
+        missing = 'missingkey'
+        self.assertNotIn(missing, os.environ)
 
-#         try:
-#             next(iterator)  # force iteration over modified mapping
-#             self.assertEqual(os.environ[new_key], "test_environ_iteration")
-#         finally:
-#             del os.environ[new_key]
+        with self.assertRaises(KeyError) as cm:
+            os.environ[missing]
+        self.assertIs(cm.exception.args[0], missing)
+        self.assertTrue(cm.exception.__suppress_context__)
 
-#     def test_iter_error_when_changing_os_environ(self):
-#         self._test_environ_iteration(os.environ)
+        with self.assertRaises(KeyError) as cm:
+            del os.environ[missing]
+        self.assertIs(cm.exception.args[0], missing)
+        self.assertTrue(cm.exception.__suppress_context__)
 
-#     def test_iter_error_when_changing_os_environ_items(self):
-#         self._test_environ_iteration(os.environ.items())
+    def _test_environ_iteration(self, collection):
+        iterator = iter(collection)
+        new_key = "__new_key__"
 
-#     def test_iter_error_when_changing_os_environ_values(self):
-#         self._test_environ_iteration(os.environ.values())
+        next(iterator)  # start iteration over os.environ.items
+
+        # add a new key in os.environ mapping
+        os.environ[new_key] = "test_environ_iteration"
+
+        try:
+            next(iterator)  # force iteration over modified mapping
+            self.assertEqual(os.environ[new_key], "test_environ_iteration")
+        finally:
+            del os.environ[new_key]
+
+    def test_iter_error_when_changing_os_environ(self):
+        self._test_environ_iteration(os.environ)
+
+    def test_iter_error_when_changing_os_environ_items(self):
+        self._test_environ_iteration(os.environ.items())
+
+    def test_iter_error_when_changing_os_environ_values(self):
+        self._test_environ_iteration(os.environ.values())
+
+    def _test_underlying_process_env(self, var, expected):
+        if not (unix_shell and os.path.exists(unix_shell)):
+            return
+
+        with os.popen(f"{unix_shell} -c 'echo ${var}'") as popen:
+            value = popen.read().strip()
+
+        self.assertEqual(expected, value)
+
+    # TODO: RUSTPYTHON (KeyError: 'surrogateescape')
+    @unittest.expectedFailure
+    def test_or_operator(self):
+        overridden_key = '_TEST_VAR_'
+        original_value = 'original_value'
+        os.environ[overridden_key] = original_value
+
+        new_vars_dict = {'_A_': '1', '_B_': '2', overridden_key: '3'}
+        expected = dict(os.environ)
+        expected.update(new_vars_dict)
+
+        actual = os.environ | new_vars_dict
+        self.assertDictEqual(expected, actual)
+        self.assertEqual('3', actual[overridden_key])
+
+        new_vars_items = new_vars_dict.items()
+        self.assertIs(NotImplemented, os.environ.__or__(new_vars_items))
+
+        self._test_underlying_process_env('_A_', '')
+        self._test_underlying_process_env(overridden_key, original_value)
+
+    # TODO: RUSTPYTHON (KeyError: 'surrogateescape')
+    @unittest.expectedFailure
+    def test_ior_operator(self):
+        overridden_key = '_TEST_VAR_'
+        os.environ[overridden_key] = 'original_value'
+
+        new_vars_dict = {'_A_': '1', '_B_': '2', overridden_key: '3'}
+        expected = dict(os.environ)
+        expected.update(new_vars_dict)
+
+        os.environ |= new_vars_dict
+        self.assertEqual(expected, os.environ)
+        self.assertEqual('3', os.environ[overridden_key])
+
+        self._test_underlying_process_env('_A_', '1')
+        self._test_underlying_process_env(overridden_key, '3')
+
+    def test_ior_operator_invalid_dicts(self):
+        os_environ_copy = os.environ.copy()
+        with self.assertRaises(TypeError):
+            dict_with_bad_key = {1: '_A_'}
+            os.environ |= dict_with_bad_key
+
+        with self.assertRaises(TypeError):
+            dict_with_bad_val = {'_A_': 1}
+            os.environ |= dict_with_bad_val
+
+        # Check nothing was added.
+        self.assertEqual(os_environ_copy, os.environ)
+
+    # TODO: RUSTPYTHON (KeyError: 'surrogateescape')
+    @unittest.expectedFailure
+    def test_ior_operator_key_value_iterable(self):
+        overridden_key = '_TEST_VAR_'
+        os.environ[overridden_key] = 'original_value'
+
+        new_vars_items = (('_A_', '1'), ('_B_', '2'), (overridden_key, '3'))
+        expected = dict(os.environ)
+        expected.update(new_vars_items)
+
+        os.environ |= new_vars_items
+        self.assertEqual(expected, os.environ)
+        self.assertEqual('3', os.environ[overridden_key])
+
+        self._test_underlying_process_env('_A_', '1')
+        self._test_underlying_process_env(overridden_key, '3')
+
+    # TODO: RUSTPYTHON (KeyError: 'surrogateescape')
+    @unittest.expectedFailure
+    def test_ror_operator(self):
+        overridden_key = '_TEST_VAR_'
+        original_value = 'original_value'
+        os.environ[overridden_key] = original_value
+
+        new_vars_dict = {'_A_': '1', '_B_': '2', overridden_key: '3'}
+        expected = dict(new_vars_dict)
+        expected.update(os.environ)
+
+        actual = new_vars_dict | os.environ
+        self.assertDictEqual(expected, actual)
+        self.assertEqual(original_value, actual[overridden_key])
+
+        new_vars_items = new_vars_dict.items()
+        self.assertIs(NotImplemented, os.environ.__ror__(new_vars_items))
+
+        self._test_underlying_process_env('_A_', '')
+        self._test_underlying_process_env(overridden_key, original_value)
 
 
 class WalkTests(unittest.TestCase):
@@ -1017,7 +1288,7 @@ class WalkTests(unittest.TestCase):
 
     def setUp(self):
         join = os.path.join
-        self.addCleanup(support.rmtree, support.TESTFN)
+        self.addCleanup(os_helper.rmtree, os_helper.TESTFN)
 
         # Build:
         #     TESTFN/
@@ -1036,7 +1307,7 @@ class WalkTests(unittest.TestCase):
         #           broken_link3
         #       TEST2/
         #         tmp4              a lone file
-        self.walk_path = join(support.TESTFN, "TEST1")
+        self.walk_path = join(os_helper.TESTFN, "TEST1")
         self.sub1_path = join(self.walk_path, "SUB1")
         self.sub11_path = join(self.sub1_path, "SUB11")
         sub2_path = join(self.walk_path, "SUB2")
@@ -1046,8 +1317,8 @@ class WalkTests(unittest.TestCase):
         tmp3_path = join(sub2_path, "tmp3")
         tmp5_path = join(sub21_path, "tmp3")
         self.link_path = join(sub2_path, "link")
-        t2_path = join(support.TESTFN, "TEST2")
-        tmp4_path = join(support.TESTFN, "TEST2", "tmp4")
+        t2_path = join(os_helper.TESTFN, "TEST2")
+        tmp4_path = join(os_helper.TESTFN, "TEST2", "tmp4")
         broken_link_path = join(sub2_path, "broken_link")
         broken_link2_path = join(sub2_path, "broken_link2")
         broken_link3_path = join(sub2_path, "broken_link3")
@@ -1059,10 +1330,10 @@ class WalkTests(unittest.TestCase):
         os.makedirs(t2_path)
 
         for path in tmp1_path, tmp2_path, tmp3_path, tmp4_path, tmp5_path:
-            with open(path, "x") as f:
+            with open(path, "x", encoding='utf-8') as f:
                 f.write("I'm " + path + " and proud of it.  Blame test_os.\n")
 
-        if support.can_symlink():
+        if os_helper.can_symlink():
             os.symlink(os.path.abspath(t2_path), self.link_path)
             os.symlink('broken', broken_link_path, True)
             os.symlink(join('tmp3', 'broken'), broken_link2_path, True)
@@ -1145,7 +1416,7 @@ class WalkTests(unittest.TestCase):
                          self.sub2_tree)
 
     def test_walk_symlink(self):
-        if not support.can_symlink():
+        if not os_helper.can_symlink():
             self.skipTest("need symlink support")
 
         # Walk, following symlinks.
@@ -1181,7 +1452,7 @@ class WalkTests(unittest.TestCase):
 
     def test_walk_many_open_files(self):
         depth = 30
-        base = os.path.join(support.TESTFN, 'deep')
+        base = os.path.join(os_helper.TESTFN, 'deep')
         p = os.path.join(base, *(['d']*depth))
         os.makedirs(p)
 
@@ -1231,13 +1502,13 @@ class FwalkTests(WalkTests):
                 self.assertEqual(expected[root], (set(dirs), set(files)))
 
     def test_compare_to_walk(self):
-        kwargs = {'top': support.TESTFN}
+        kwargs = {'top': os_helper.TESTFN}
         self._compare_to_walk(kwargs, kwargs)
 
     def test_dir_fd(self):
         try:
             fd = os.open(".", os.O_RDONLY)
-            walk_kwargs = {'top': support.TESTFN}
+            walk_kwargs = {'top': os_helper.TESTFN}
             fwalk_kwargs = walk_kwargs.copy()
             fwalk_kwargs['dir_fd'] = fd
             self._compare_to_walk(walk_kwargs, fwalk_kwargs)
@@ -1247,7 +1518,7 @@ class FwalkTests(WalkTests):
     def test_yields_correct_dir_fd(self):
         # check returned file descriptors
         for topdown, follow_symlinks in itertools.product((True, False), repeat=2):
-            args = support.TESTFN, topdown, None
+            args = os_helper.TESTFN, topdown, None
             for root, dirs, files, rootfd in self.fwalk(*args, follow_symlinks=follow_symlinks):
                 # check that the FD is valid
                 os.fstat(rootfd)
@@ -1263,7 +1534,7 @@ class FwalkTests(WalkTests):
         minfd = os.dup(1)
         os.close(minfd)
         for i in range(256):
-            for x in self.fwalk(support.TESTFN):
+            for x in self.fwalk(os_helper.TESTFN):
                 pass
         newfd = os.dup(1)
         self.addCleanup(os.close, newfd)
@@ -1321,10 +1592,10 @@ class BytesFwalkTests(FwalkTests):
 
 class MakedirTests(unittest.TestCase):
     def setUp(self):
-        os.mkdir(support.TESTFN)
+        os.mkdir(os_helper.TESTFN)
 
     def test_makedir(self):
-        base = support.TESTFN
+        base = os_helper.TESTFN
         path = os.path.join(base, 'dir1', 'dir2', 'dir3')
         os.makedirs(path)             # Should work
         path = os.path.join(base, 'dir1', 'dir2', 'dir3', 'dir4')
@@ -1339,8 +1610,8 @@ class MakedirTests(unittest.TestCase):
         os.makedirs(path)
 
     def test_mode(self):
-        with support.temp_umask(0o002):
-            base = support.TESTFN
+        with os_helper.temp_umask(0o002):
+            base = os_helper.TESTFN
             parent = os.path.join(base, 'dir1')
             path = os.path.join(parent, 'dir2')
             os.makedirs(path, 0o555)
@@ -1351,7 +1622,7 @@ class MakedirTests(unittest.TestCase):
                 self.assertEqual(os.stat(parent).st_mode & 0o777, 0o775)
 
     def test_exist_ok_existing_directory(self):
-        path = os.path.join(support.TESTFN, 'dir1')
+        path = os.path.join(os_helper.TESTFN, 'dir1')
         mode = 0o777
         old_mask = os.umask(0o022)
         os.makedirs(path, mode)
@@ -1365,18 +1636,18 @@ class MakedirTests(unittest.TestCase):
         os.makedirs(os.path.abspath('/'), exist_ok=True)
 
     def test_exist_ok_s_isgid_directory(self):
-        path = os.path.join(support.TESTFN, 'dir1')
+        path = os.path.join(os_helper.TESTFN, 'dir1')
         S_ISGID = stat.S_ISGID
         mode = 0o777
         old_mask = os.umask(0o022)
         try:
             existing_testfn_mode = stat.S_IMODE(
-                    os.lstat(support.TESTFN).st_mode)
+                    os.lstat(os_helper.TESTFN).st_mode)
             try:
-                os.chmod(support.TESTFN, existing_testfn_mode | S_ISGID)
+                os.chmod(os_helper.TESTFN, existing_testfn_mode | S_ISGID)
             except PermissionError:
                 raise unittest.SkipTest('Cannot set S_ISGID for dir.')
-            if (os.lstat(support.TESTFN).st_mode & S_ISGID != S_ISGID):
+            if (os.lstat(os_helper.TESTFN).st_mode & S_ISGID != S_ISGID):
                 raise unittest.SkipTest('No support for S_ISGID dir mode.')
             # The os should apply S_ISGID from the parent dir for us, but
             # this test need not depend on that behavior.  Be explicit.
@@ -1392,9 +1663,9 @@ class MakedirTests(unittest.TestCase):
             os.umask(old_mask)
 
     def test_exist_ok_existing_regular_file(self):
-        base = support.TESTFN
-        path = os.path.join(support.TESTFN, 'dir1')
-        with open(path, 'w') as f:
+        base = os_helper.TESTFN
+        path = os.path.join(os_helper.TESTFN, 'dir1')
+        with open(path, 'w', encoding='utf-8') as f:
             f.write('abc')
         self.assertRaises(OSError, os.makedirs, path)
         self.assertRaises(OSError, os.makedirs, path, exist_ok=False)
@@ -1402,12 +1673,12 @@ class MakedirTests(unittest.TestCase):
         os.remove(path)
 
     def tearDown(self):
-        path = os.path.join(support.TESTFN, 'dir1', 'dir2', 'dir3',
+        path = os.path.join(os_helper.TESTFN, 'dir1', 'dir2', 'dir3',
                             'dir4', 'dir5', 'dir6')
         # If the tests failed, the bottom-most directory ('../dir6')
         # may not have been created, so we look for the outermost directory
         # that exists.
-        while not os.path.exists(path) and path != support.TESTFN:
+        while not os.path.exists(path) and path != os_helper.TESTFN:
             path = os.path.dirname(path)
 
         os.removedirs(path)
@@ -1418,17 +1689,17 @@ class ChownFileTests(unittest.TestCase):
 
     @classmethod
     def setUpClass(cls):
-        os.mkdir(support.TESTFN)
+        os.mkdir(os_helper.TESTFN)
 
     def test_chown_uid_gid_arguments_must_be_index(self):
-        stat = os.stat(support.TESTFN)
+        stat = os.stat(os_helper.TESTFN)
         uid = stat.st_uid
         gid = stat.st_gid
         for value in (-1.0, -1j, decimal.Decimal(-1), fractions.Fraction(-2, 2)):
-            self.assertRaises(TypeError, os.chown, support.TESTFN, value, gid)
-            self.assertRaises(TypeError, os.chown, support.TESTFN, uid, value)
-        self.assertIsNone(os.chown(support.TESTFN, uid, gid))
-        self.assertIsNone(os.chown(support.TESTFN, -1, -1))
+            self.assertRaises(TypeError, os.chown, os_helper.TESTFN, value, gid)
+            self.assertRaises(TypeError, os.chown, os_helper.TESTFN, uid, value)
+        self.assertIsNone(os.chown(os_helper.TESTFN, uid, gid))
+        self.assertIsNone(os.chown(os_helper.TESTFN, -1, -1))
 
     @unittest.skipUnless(hasattr(os, 'getgroups'), 'need os.getgroups')
     def test_chown_gid(self):
@@ -1437,61 +1708,61 @@ class ChownFileTests(unittest.TestCase):
             self.skipTest("test needs at least 2 groups")
 
         gid_1, gid_2 = groups[:2]
-        uid = os.stat(support.TESTFN).st_uid
+        uid = os.stat(os_helper.TESTFN).st_uid
 
-        os.chown(support.TESTFN, uid, gid_1)
-        gid = os.stat(support.TESTFN).st_gid
+        os.chown(os_helper.TESTFN, uid, gid_1)
+        gid = os.stat(os_helper.TESTFN).st_gid
         self.assertEqual(gid, gid_1)
 
-        os.chown(support.TESTFN, uid, gid_2)
-        gid = os.stat(support.TESTFN).st_gid
+        os.chown(os_helper.TESTFN, uid, gid_2)
+        gid = os.stat(os_helper.TESTFN).st_gid
         self.assertEqual(gid, gid_2)
 
     @unittest.skipUnless(root_in_posix and len(all_users) > 1,
                          "test needs root privilege and more than one user")
     def test_chown_with_root(self):
         uid_1, uid_2 = all_users[:2]
-        gid = os.stat(support.TESTFN).st_gid
-        os.chown(support.TESTFN, uid_1, gid)
-        uid = os.stat(support.TESTFN).st_uid
+        gid = os.stat(os_helper.TESTFN).st_gid
+        os.chown(os_helper.TESTFN, uid_1, gid)
+        uid = os.stat(os_helper.TESTFN).st_uid
         self.assertEqual(uid, uid_1)
-        os.chown(support.TESTFN, uid_2, gid)
-        uid = os.stat(support.TESTFN).st_uid
+        os.chown(os_helper.TESTFN, uid_2, gid)
+        uid = os.stat(os_helper.TESTFN).st_uid
         self.assertEqual(uid, uid_2)
 
     @unittest.skipUnless(not root_in_posix and len(all_users) > 1,
                          "test needs non-root account and more than one user")
     def test_chown_without_permission(self):
         uid_1, uid_2 = all_users[:2]
-        gid = os.stat(support.TESTFN).st_gid
+        gid = os.stat(os_helper.TESTFN).st_gid
         with self.assertRaises(PermissionError):
-            os.chown(support.TESTFN, uid_1, gid)
-            os.chown(support.TESTFN, uid_2, gid)
+            os.chown(os_helper.TESTFN, uid_1, gid)
+            os.chown(os_helper.TESTFN, uid_2, gid)
 
     @classmethod
     def tearDownClass(cls):
-        os.rmdir(support.TESTFN)
+        os.rmdir(os_helper.TESTFN)
 
 
 class RemoveDirsTests(unittest.TestCase):
     def setUp(self):
-        os.makedirs(support.TESTFN)
+        os.makedirs(os_helper.TESTFN)
 
     def tearDown(self):
-        support.rmtree(support.TESTFN)
+        os_helper.rmtree(os_helper.TESTFN)
 
     def test_remove_all(self):
-        dira = os.path.join(support.TESTFN, 'dira')
+        dira = os.path.join(os_helper.TESTFN, 'dira')
         os.mkdir(dira)
         dirb = os.path.join(dira, 'dirb')
         os.mkdir(dirb)
         os.removedirs(dirb)
         self.assertFalse(os.path.exists(dirb))
         self.assertFalse(os.path.exists(dira))
-        self.assertFalse(os.path.exists(support.TESTFN))
+        self.assertFalse(os.path.exists(os_helper.TESTFN))
 
     def test_remove_partial(self):
-        dira = os.path.join(support.TESTFN, 'dira')
+        dira = os.path.join(os_helper.TESTFN, 'dira')
         os.mkdir(dira)
         dirb = os.path.join(dira, 'dirb')
         os.mkdir(dirb)
@@ -1499,10 +1770,10 @@ class RemoveDirsTests(unittest.TestCase):
         os.removedirs(dirb)
         self.assertFalse(os.path.exists(dirb))
         self.assertTrue(os.path.exists(dira))
-        self.assertTrue(os.path.exists(support.TESTFN))
+        self.assertTrue(os.path.exists(os_helper.TESTFN))
 
     def test_remove_nothing(self):
-        dira = os.path.join(support.TESTFN, 'dira')
+        dira = os.path.join(os_helper.TESTFN, 'dira')
         os.mkdir(dira)
         dirb = os.path.join(dira, 'dirb')
         os.mkdir(dirb)
@@ -1511,7 +1782,7 @@ class RemoveDirsTests(unittest.TestCase):
             os.removedirs(dirb)
         self.assertTrue(os.path.exists(dirb))
         self.assertTrue(os.path.exists(dira))
-        self.assertTrue(os.path.exists(support.TESTFN))
+        self.assertTrue(os.path.exists(os_helper.TESTFN))
 
 
 class DevNullTests(unittest.TestCase):
@@ -1649,8 +1920,8 @@ class URandomFDTests(unittest.TestCase):
     def test_urandom_fd_reopened(self):
         # Issue #21207: urandom() should detect its fd to /dev/urandom
         # changed to something else, and reopen it.
-        self.addCleanup(support.unlink, support.TESTFN)
-        create_file(support.TESTFN, b"x" * 256)
+        self.addCleanup(os_helper.unlink, os_helper.TESTFN)
+        create_file(os_helper.TESTFN, b"x" * 256)
 
         code = """if 1:
             import os
@@ -1676,7 +1947,7 @@ class URandomFDTests(unittest.TestCase):
                     os.dup2(new_fd, fd)
                 sys.stdout.buffer.write(os.urandom(4))
                 sys.stdout.buffer.write(os.urandom(4))
-            """.format(TESTFN=support.TESTFN)
+            """.format(TESTFN=os_helper.TESTFN)
         rc, out, err = assert_python_ok('-Sc', code)
         self.assertEqual(len(out), 8)
         self.assertNotEqual(out[0:4], out[4:8])
@@ -1828,40 +2099,40 @@ class ExecTests(unittest.TestCase):
 class Win32ErrorTests(unittest.TestCase):
     def setUp(self):
         try:
-            os.stat(support.TESTFN)
+            os.stat(os_helper.TESTFN)
         except FileNotFoundError:
             exists = False
         except OSError as exc:
             exists = True
             self.fail("file %s must not exist; os.stat failed with %s"
-                      % (support.TESTFN, exc))
+                      % (os_helper.TESTFN, exc))
         else:
-            self.fail("file %s must not exist" % support.TESTFN)
+            self.fail("file %s must not exist" % os_helper.TESTFN)
 
     def test_rename(self):
-        self.assertRaises(OSError, os.rename, support.TESTFN, support.TESTFN+".bak")
+        self.assertRaises(OSError, os.rename, os_helper.TESTFN, os_helper.TESTFN+".bak")
 
     def test_remove(self):
-        self.assertRaises(OSError, os.remove, support.TESTFN)
+        self.assertRaises(OSError, os.remove, os_helper.TESTFN)
 
     def test_chdir(self):
-        self.assertRaises(OSError, os.chdir, support.TESTFN)
+        self.assertRaises(OSError, os.chdir, os_helper.TESTFN)
 
     def test_mkdir(self):
-        self.addCleanup(support.unlink, support.TESTFN)
+        self.addCleanup(os_helper.unlink, os_helper.TESTFN)
 
-        with open(support.TESTFN, "x") as f:
-            self.assertRaises(OSError, os.mkdir, support.TESTFN)
+        with open(os_helper.TESTFN, "x") as f:
+            self.assertRaises(OSError, os.mkdir, os_helper.TESTFN)
 
     def test_utime(self):
-        self.assertRaises(OSError, os.utime, support.TESTFN, None)
+        self.assertRaises(OSError, os.utime, os_helper.TESTFN, None)
 
     def test_chmod(self):
-        self.assertRaises(OSError, os.chmod, support.TESTFN, 0)
+        self.assertRaises(OSError, os.chmod, os_helper.TESTFN, 0)
 
 
 class TestInvalidFD(unittest.TestCase):
-    singles = ["fchdir", "dup", "fdopen", "fdatasync", "fstat",
+    singles = ["fchdir", "dup", "fdatasync", "fstat",
                "fstatvfs", "fsync", "tcgetpgrp", "ttyname"]
     #singles.append("close")
     #We omit close because it doesn't raise an exception on some platforms
@@ -1869,28 +2140,29 @@ class TestInvalidFD(unittest.TestCase):
         def helper(self):
             if  hasattr(os, f):
                 self.check(getattr(os, f))
-
-
         return helper
     for f in singles:
         locals()["test_"+f] = get_single(f)
 
-    def check(self, f, *args):
+    def check(self, f, *args, **kwargs):
         try:
-            f(support.make_bad_fd(), *args)
+            f(os_helper.make_bad_fd(), *args, **kwargs)
         except OSError as e:
             self.assertEqual(e.errno, errno.EBADF)
         else:
             self.fail("%r didn't raise an OSError with a bad file descriptor"
                       % f)
 
+    def test_fdopen(self):
+        self.check(os.fdopen, encoding="utf-8")
+
     @unittest.skipUnless(hasattr(os, 'isatty'), 'test needs os.isatty()')
     def test_isatty(self):
-        self.assertEqual(os.isatty(support.make_bad_fd()), False)
+        self.assertEqual(os.isatty(os_helper.make_bad_fd()), False)
 
     @unittest.skipUnless(hasattr(os, 'closerange'), 'test needs os.closerange()')
     def test_closerange(self):
-        fd = support.make_bad_fd()
+        fd = os_helper.make_bad_fd()
         # Make sure none of the descriptors we are about to close are
         # currently valid (issue 6542).
         for i in range(10):
@@ -1964,8 +2236,8 @@ class TestInvalidFD(unittest.TestCase):
 
 class LinkTests(unittest.TestCase):
     def setUp(self):
-        self.file1 = support.TESTFN
-        self.file2 = os.path.join(support.TESTFN + "2")
+        self.file1 = os_helper.TESTFN
+        self.file2 = os.path.join(os_helper.TESTFN + "2")
 
     def tearDown(self):
         for file in (self.file1, self.file2):
@@ -1979,7 +2251,7 @@ class LinkTests(unittest.TestCase):
             os.link(file1, file2)
         except PermissionError as e:
             self.skipTest('os.link(): %s' % e)
-        with open(file1, "r") as f1, open(file2, "r") as f2:
+        with open(file1, "rb") as f1, open(file2, "rb") as f2:
             self.assertTrue(os.path.sameopenfile(f1.fileno(), f2.fileno()))
 
     def test_link(self):
@@ -2070,12 +2342,12 @@ class PosixUidGidTests(unittest.TestCase):
 @unittest.skipIf(sys.platform == "win32", "Posix specific tests")
 class Pep383Tests(unittest.TestCase):
     def setUp(self):
-        if support.TESTFN_UNENCODABLE:
-            self.dir = support.TESTFN_UNENCODABLE
-        elif support.TESTFN_NONASCII:
-            self.dir = support.TESTFN_NONASCII
+        if os_helper.TESTFN_UNENCODABLE:
+            self.dir = os_helper.TESTFN_UNENCODABLE
+        elif os_helper.TESTFN_NONASCII:
+            self.dir = os_helper.TESTFN_NONASCII
         else:
-            self.dir = support.TESTFN
+            self.dir = os_helper.TESTFN
         self.bdir = os.fsencode(self.dir)
 
         bytesfn = []
@@ -2085,11 +2357,11 @@ class Pep383Tests(unittest.TestCase):
             except UnicodeEncodeError:
                 return
             bytesfn.append(fn)
-        add_filename(support.TESTFN_UNICODE)
-        if support.TESTFN_UNENCODABLE:
-            add_filename(support.TESTFN_UNENCODABLE)
-        if support.TESTFN_NONASCII:
-            add_filename(support.TESTFN_NONASCII)
+        add_filename(os_helper.TESTFN_UNICODE)
+        if os_helper.TESTFN_UNENCODABLE:
+            add_filename(os_helper.TESTFN_UNENCODABLE)
+        if os_helper.TESTFN_NONASCII:
+            add_filename(os_helper.TESTFN_NONASCII)
         if not bytesfn:
             self.skipTest("couldn't create any non-ascii filename")
 
@@ -2097,7 +2369,7 @@ class Pep383Tests(unittest.TestCase):
         os.mkdir(self.dir)
         try:
             for fn in bytesfn:
-                support.create_empty_file(os.path.join(self.bdir, fn))
+                os_helper.create_empty_file(os.path.join(self.bdir, fn))
                 fn = os.fsdecode(fn)
                 if fn in self.unicodefn:
                     raise ValueError("duplicate filename")
@@ -2265,41 +2537,41 @@ class Win32ListdirTests(unittest.TestCase):
         self.created_paths = []
         for i in range(2):
             dir_name = 'SUB%d' % i
-            dir_path = os.path.join(support.TESTFN, dir_name)
+            dir_path = os.path.join(os_helper.TESTFN, dir_name)
             file_name = 'FILE%d' % i
-            file_path = os.path.join(support.TESTFN, file_name)
+            file_path = os.path.join(os_helper.TESTFN, file_name)
             os.makedirs(dir_path)
-            with open(file_path, 'w') as f:
+            with open(file_path, 'w', encoding='utf-8') as f:
                 f.write("I'm %s and proud of it. Blame test_os.\n" % file_path)
             self.created_paths.extend([dir_name, file_name])
         self.created_paths.sort()
 
     def tearDown(self):
-        shutil.rmtree(support.TESTFN)
+        shutil.rmtree(os_helper.TESTFN)
 
     def test_listdir_no_extended_path(self):
         """Test when the path is not an "extended" path."""
         # unicode
         self.assertEqual(
-                sorted(os.listdir(support.TESTFN)),
+                sorted(os.listdir(os_helper.TESTFN)),
                 self.created_paths)
 
         # bytes
         self.assertEqual(
-                sorted(os.listdir(os.fsencode(support.TESTFN))),
+                sorted(os.listdir(os.fsencode(os_helper.TESTFN))),
                 [os.fsencode(path) for path in self.created_paths])
 
     def test_listdir_extended_path(self):
         """Test when the path starts with '\\\\?\\'."""
         # See: http://msdn.microsoft.com/en-us/library/windows/desktop/aa365247(v=vs.85).aspx#maxpath
         # unicode
-        path = '\\\\?\\' + os.path.abspath(support.TESTFN)
+        path = '\\\\?\\' + os.path.abspath(os_helper.TESTFN)
         self.assertEqual(
                 sorted(os.listdir(path)),
                 self.created_paths)
 
         # bytes
-        path = b'\\\\?\\' + os.fsencode(os.path.abspath(support.TESTFN))
+        path = b'\\\\?\\' + os.fsencode(os.path.abspath(os_helper.TESTFN))
         self.assertEqual(
                 sorted(os.listdir(path)),
                 [os.fsencode(path) for path in self.created_paths])
@@ -2342,32 +2614,32 @@ class ReadlinkTests(unittest.TestCase):
         self.assertRaises(FileNotFoundError, os.readlink,
                           FakePath('missing-link'))
 
-    @support.skip_unless_symlink
+    @os_helper.skip_unless_symlink
     def test_pathlike(self):
         os.symlink(self.filelink_target, self.filelink)
-        self.addCleanup(support.unlink, self.filelink)
+        self.addCleanup(os_helper.unlink, self.filelink)
         filelink = FakePath(self.filelink)
         self.assertPathEqual(os.readlink(filelink), self.filelink_target)
 
-    @support.skip_unless_symlink
+    @os_helper.skip_unless_symlink
     def test_pathlike_bytes(self):
         os.symlink(self.filelinkb_target, self.filelinkb)
-        self.addCleanup(support.unlink, self.filelinkb)
+        self.addCleanup(os_helper.unlink, self.filelinkb)
         path = os.readlink(FakePath(self.filelinkb))
         self.assertPathEqual(path, self.filelinkb_target)
         self.assertIsInstance(path, bytes)
 
-    @support.skip_unless_symlink
+    @os_helper.skip_unless_symlink
     def test_bytes(self):
         os.symlink(self.filelinkb_target, self.filelinkb)
-        self.addCleanup(support.unlink, self.filelinkb)
+        self.addCleanup(os_helper.unlink, self.filelinkb)
         path = os.readlink(self.filelinkb)
         self.assertPathEqual(path, self.filelinkb_target)
         self.assertIsInstance(path, bytes)
 
 
 @unittest.skipUnless(sys.platform == "win32", "Win32 specific tests")
-@support.skip_unless_symlink
+@os_helper.skip_unless_symlink
 class Win32SymlinkTests(unittest.TestCase):
     filelink = 'filelinktest'
     filelink_target = os.path.abspath(__file__)
@@ -2438,10 +2710,10 @@ class Win32SymlinkTests(unittest.TestCase):
         self.assertNotEqual(os.lstat(bytes_link), os.stat(bytes_link))
 
     def test_12084(self):
-        level1 = os.path.abspath(support.TESTFN)
+        level1 = os.path.abspath(os_helper.TESTFN)
         level2 = os.path.join(level1, "level2")
         level3 = os.path.join(level2, "level3")
-        self.addCleanup(support.rmtree, level1)
+        self.addCleanup(os_helper.rmtree, level1)
 
         os.mkdir(level1)
         os.mkdir(level2)
@@ -2627,7 +2899,7 @@ class Win32NtTests(unittest.TestCase):
 
         self.assertEqual(0, handle_delta)
 
-@support.skip_unless_symlink
+@os_helper.skip_unless_symlink
 class NonLocalSymlinkTests(unittest.TestCase):
 
     def setUp(self):
@@ -2676,6 +2948,7 @@ class FSEncodingTests(unittest.TestCase):
 
 
 class DeviceEncodingTests(unittest.TestCase):
+
     # TODO: RUSTPYTHON (AttributeError: module 'os' has no attribute 'device_encoding')
     @unittest.expectedFailure
     def test_bad_fd(self):
@@ -2701,7 +2974,7 @@ class PidTests(unittest.TestCase):
         # We are the parent of our subprocess
         self.assertEqual(int(stdout), os.getpid())
 
-    def check_waitpid(self, code, exitcode):
+    def check_waitpid(self, code, exitcode, callback=None):
         if sys.platform == 'win32':
             # On Windows, os.spawnv() simply joins arguments with spaces:
             # arguments need to be quoted
@@ -2710,12 +2983,13 @@ class PidTests(unittest.TestCase):
             args = [sys.executable, '-c', code]
         pid = os.spawnv(os.P_NOWAIT, sys.executable, args)
 
+        if callback is not None:
+            callback(pid)
+
+        # don't use support.wait_process() to test directly os.waitpid()
+        # and os.waitstatus_to_exitcode()
         pid2, status = os.waitpid(pid, 0)
-        if sys.platform == 'win32':
-            self.assertEqual(status, exitcode << 8)
-        else:
-            self.assertTrue(os.WIFEXITED(status), status)
-            self.assertEqual(os.WEXITSTATUS(status), exitcode)
+        self.assertEqual(os.waitstatus_to_exitcode(status), exitcode)
         self.assertEqual(pid2, pid)
 
     # TODO: RUSTPYTHON (AttributeError: module 'os' has no attribute 'spawnv')
@@ -2725,25 +2999,55 @@ class PidTests(unittest.TestCase):
 
     # TODO: RUSTPYTHON (AttributeError: module 'os' has no attribute 'spawnv')
     @unittest.expectedFailure
-    def test_waitpid_exitcode(self):
+    def test_waitstatus_to_exitcode(self):
         exitcode = 23
         code = f'import sys; sys.exit({exitcode})'
         self.check_waitpid(code, exitcode=exitcode)
 
+        with self.assertRaises(TypeError):
+            os.waitstatus_to_exitcode(0.0)
+
     @unittest.skipUnless(sys.platform == 'win32', 'win32-specific test')
     def test_waitpid_windows(self):
-        # bpo-40138: test os.waitpid() with exit code larger than INT_MAX.
+        # bpo-40138: test os.waitpid() and os.waitstatus_to_exitcode()
+        # with exit code larger than INT_MAX.
         STATUS_CONTROL_C_EXIT = 0xC000013A
         code = f'import _winapi; _winapi.ExitProcess({STATUS_CONTROL_C_EXIT})'
         self.check_waitpid(code, exitcode=STATUS_CONTROL_C_EXIT)
+
+    @unittest.skipUnless(sys.platform == 'win32', 'win32-specific test')
+    def test_waitstatus_to_exitcode_windows(self):
+        max_exitcode = 2 ** 32 - 1
+        for exitcode in (0, 1, 5, max_exitcode):
+            self.assertEqual(os.waitstatus_to_exitcode(exitcode << 8),
+                             exitcode)
+
+        # invalid values
+        with self.assertRaises(ValueError):
+            os.waitstatus_to_exitcode((max_exitcode + 1) << 8)
+        with self.assertRaises(OverflowError):
+            os.waitstatus_to_exitcode(-1)
+
+    # TODO: RUSTPYTHON (AttributeError: module 'os' has no attribute 'spawnv')
+    @unittest.expectedFailure
+    # Skip the test on Windows
+    @unittest.skipUnless(hasattr(signal, 'SIGKILL'), 'need signal.SIGKILL')
+    def test_waitstatus_to_exitcode_kill(self):
+        code = f'import time; time.sleep({support.LONG_TIMEOUT})'
+        signum = signal.SIGKILL
+
+        def kill_process(pid):
+            os.kill(pid, signum)
+
+        self.check_waitpid(code, exitcode=-signum, callback=kill_process)
 
 
 class SpawnTests(unittest.TestCase):
     def create_args(self, *, with_env=False, use_bytes=False):
         self.exitcode = 17
 
-        filename = support.TESTFN
-        self.addCleanup(support.unlink, filename)
+        filename = os_helper.TESTFN
+        self.addCleanup(os_helper.unlink, filename)
 
         if not with_env:
             code = 'import sys; sys.exit(%s)' % self.exitcode
@@ -2756,7 +3060,7 @@ class SpawnTests(unittest.TestCase):
             code = ('import sys, os; magic = os.environ[%r]; sys.exit(%s)'
                     % (self.key, self.exitcode))
 
-        with open(filename, "w") as fp:
+        with open(filename, "w", encoding="utf-8") as fp:
             fp.write(code)
 
         args = [sys.executable, filename]
@@ -2797,6 +3101,10 @@ class SpawnTests(unittest.TestCase):
         exitcode = os.spawnv(os.P_WAIT, args[0], args)
         self.assertEqual(exitcode, self.exitcode)
 
+        # Test for PyUnicode_FSConverter()
+        exitcode = os.spawnv(os.P_WAIT, FakePath(args[0]), args)
+        self.assertEqual(exitcode, self.exitcode)
+
     @requires_os_func('spawnve')
     def test_spawnve(self):
         args = self.create_args(with_env=True)
@@ -2819,14 +3127,7 @@ class SpawnTests(unittest.TestCase):
     def test_nowait(self):
         args = self.create_args()
         pid = os.spawnv(os.P_NOWAIT, args[0], args)
-        result = os.waitpid(pid, 0)
-        self.assertEqual(result[0], pid)
-        status = result[1]
-        if hasattr(os, 'WIFEXITED'):
-            self.assertTrue(os.WIFEXITED(status))
-            self.assertEqual(os.WEXITSTATUS(status), self.exitcode)
-        else:
-            self.assertEqual(status, self.exitcode << 8)
+        support.wait_process(pid, exitcode=self.exitcode)
 
     @requires_os_func('spawnve')
     def test_spawnve_bytes(self):
@@ -2897,9 +3198,9 @@ class SpawnTests(unittest.TestCase):
             self.assertEqual(exitcode, 127)
 
         # equal character in the environment variable value
-        filename = support.TESTFN
-        self.addCleanup(support.unlink, filename)
-        with open(filename, "w") as fp:
+        filename = os_helper.TESTFN
+        self.addCleanup(os_helper.unlink, filename)
+        with open(filename, "w", encoding="utf-8") as fp:
             fp.write('import sys, os\n'
                      'if os.getenv("FRUIT") != "orange=lemon":\n'
                      '    raise AssertionError')
@@ -3053,12 +3354,12 @@ class TestSendfile(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
         cls.key = support.threading_setup()
-        create_file(support.TESTFN, cls.DATA)
+        create_file(os_helper.TESTFN, cls.DATA)
 
     @classmethod
     def tearDownClass(cls):
         support.threading_cleanup(*cls.key)
-        support.unlink(support.TESTFN)
+        os_helper.unlink(os_helper.TESTFN)
 
     def setUp(self):
         self.server = SendfileTestServer((support.HOST, 0))
@@ -3069,7 +3370,7 @@ class TestSendfile(unittest.TestCase):
         # synchronize by waiting for "220 ready" response
         self.client.recv(1024)
         self.sockno = self.client.fileno()
-        self.file = open(support.TESTFN, 'rb')
+        self.file = open(os_helper.TESTFN, 'rb')
         self.fileno = self.file.fileno()
 
     def tearDown(self):
@@ -3201,10 +3502,10 @@ class TestSendfile(unittest.TestCase):
 
     @requires_headers_trailers
     def test_trailers(self):
-        TESTFN2 = support.TESTFN + "2"
+        TESTFN2 = os_helper.TESTFN + "2"
         file_data = b"abcdef"
 
-        self.addCleanup(support.unlink, TESTFN2)
+        self.addCleanup(os_helper.unlink, TESTFN2)
         create_file(TESTFN2, file_data)
 
         with open(TESTFN2, 'rb') as f:
@@ -3268,8 +3569,8 @@ def supports_extended_attributes():
 class ExtendedAttributeTests(unittest.TestCase):
 
     def _check_xattrs_str(self, s, getxattr, setxattr, removexattr, listxattr, **kwargs):
-        fn = support.TESTFN
-        self.addCleanup(support.unlink, fn)
+        fn = os_helper.TESTFN
+        self.addCleanup(os_helper.unlink, fn)
         create_file(fn)
 
         with self.assertRaises(OSError) as cm:
@@ -3317,10 +3618,10 @@ class ExtendedAttributeTests(unittest.TestCase):
 
     def _check_xattrs(self, *args, **kwargs):
         self._check_xattrs_str(str, *args, **kwargs)
-        support.unlink(support.TESTFN)
+        os_helper.unlink(os_helper.TESTFN)
 
         self._check_xattrs_str(os.fsencode, *args, **kwargs)
-        support.unlink(support.TESTFN)
+        os_helper.unlink(os_helper.TESTFN)
 
     def test_simple(self):
         self._check_xattrs(os.getxattr, os.setxattr, os.removexattr,
@@ -3374,7 +3675,11 @@ class TermsizeTests(unittest.TestCase):
         should work too.
         """
         try:
-            size = subprocess.check_output(['stty', 'size']).decode().split()
+            size = (
+                subprocess.check_output(
+                    ["stty", "size"], stderr=subprocess.DEVNULL, text=True
+                ).split()
+            )
         except (FileNotFoundError, subprocess.CalledProcessError,
                 PermissionError):
             self.skipTest("stty invocation failed")
@@ -3408,6 +3713,89 @@ class MemfdCreateTests(unittest.TestCase):
         self.assertFalse(os.get_inheritable(fd2))
 
 
+@unittest.skipUnless(hasattr(os, 'eventfd'), 'requires os.eventfd')
+@support.requires_linux_version(2, 6, 30)
+class EventfdTests(unittest.TestCase):
+    def test_eventfd_initval(self):
+        def pack(value):
+            """Pack as native uint64_t
+            """
+            return struct.pack("@Q", value)
+        size = 8  # read/write 8 bytes
+        initval = 42
+        fd = os.eventfd(initval)
+        self.assertNotEqual(fd, -1)
+        self.addCleanup(os.close, fd)
+        self.assertFalse(os.get_inheritable(fd))
+
+        # test with raw read/write
+        res = os.read(fd, size)
+        self.assertEqual(res, pack(initval))
+
+        os.write(fd, pack(23))
+        res = os.read(fd, size)
+        self.assertEqual(res, pack(23))
+
+        os.write(fd, pack(40))
+        os.write(fd, pack(2))
+        res = os.read(fd, size)
+        self.assertEqual(res, pack(42))
+
+        # test with eventfd_read/eventfd_write
+        os.eventfd_write(fd, 20)
+        os.eventfd_write(fd, 3)
+        res = os.eventfd_read(fd)
+        self.assertEqual(res, 23)
+
+    def test_eventfd_semaphore(self):
+        initval = 2
+        flags = os.EFD_CLOEXEC | os.EFD_SEMAPHORE | os.EFD_NONBLOCK
+        fd = os.eventfd(initval, flags)
+        self.assertNotEqual(fd, -1)
+        self.addCleanup(os.close, fd)
+
+        # semaphore starts has initval 2, two reads return '1'
+        res = os.eventfd_read(fd)
+        self.assertEqual(res, 1)
+        res = os.eventfd_read(fd)
+        self.assertEqual(res, 1)
+        # third read would block
+        with self.assertRaises(BlockingIOError):
+            os.eventfd_read(fd)
+        with self.assertRaises(BlockingIOError):
+            os.read(fd, 8)
+
+        # increase semaphore counter, read one
+        os.eventfd_write(fd, 1)
+        res = os.eventfd_read(fd)
+        self.assertEqual(res, 1)
+        # next read would block, too
+        with self.assertRaises(BlockingIOError):
+            os.eventfd_read(fd)
+
+    def test_eventfd_select(self):
+        flags = os.EFD_CLOEXEC | os.EFD_NONBLOCK
+        fd = os.eventfd(0, flags)
+        self.assertNotEqual(fd, -1)
+        self.addCleanup(os.close, fd)
+
+        # counter is zero, only writeable
+        rfd, wfd, xfd = select.select([fd], [fd], [fd], 0)
+        self.assertEqual((rfd, wfd, xfd), ([], [fd], []))
+
+        # counter is non-zero, read and writeable
+        os.eventfd_write(fd, 23)
+        rfd, wfd, xfd = select.select([fd], [fd], [fd], 0)
+        self.assertEqual((rfd, wfd, xfd), ([fd], [fd], []))
+        self.assertEqual(os.eventfd_read(fd), 23)
+
+        # counter at max, only readable
+        os.eventfd_write(fd, (2**64) - 2)
+        rfd, wfd, xfd = select.select([fd], [fd], [fd], 0)
+        self.assertEqual((rfd, wfd, xfd), ([fd], [], []))
+        os.eventfd_read(fd)
+
+
 class OSErrorTests(unittest.TestCase):
     def setUp(self):
         class Str(str):
@@ -3415,16 +3803,16 @@ class OSErrorTests(unittest.TestCase):
 
         self.bytes_filenames = []
         self.unicode_filenames = []
-        if support.TESTFN_UNENCODABLE is not None:
-            decoded = support.TESTFN_UNENCODABLE
+        if os_helper.TESTFN_UNENCODABLE is not None:
+            decoded = os_helper.TESTFN_UNENCODABLE
         else:
-            decoded = support.TESTFN
+            decoded = os_helper.TESTFN
         self.unicode_filenames.append(decoded)
         self.unicode_filenames.append(Str(decoded))
-        if support.TESTFN_UNDECODABLE is not None:
-            encoded = support.TESTFN_UNDECODABLE
+        if os_helper.TESTFN_UNDECODABLE is not None:
+            encoded = os_helper.TESTFN_UNDECODABLE
         else:
-            encoded = os.fsencode(support.TESTFN)
+            encoded = os.fsencode(os_helper.TESTFN)
         self.bytes_filenames.append(encoded)
         self.bytes_filenames.append(bytearray(encoded))
         self.bytes_filenames.append(memoryview(encoded))
@@ -3546,6 +3934,33 @@ class FDInheritanceTests(unittest.TestCase):
         self.assertEqual(fcntl.fcntl(fd, fcntl.F_GETFD) & fcntl.FD_CLOEXEC,
                          0)
 
+    @unittest.skipUnless(hasattr(os, 'O_PATH'), "need os.O_PATH")
+    def test_get_set_inheritable_o_path(self):
+        fd = os.open(__file__, os.O_PATH)
+        self.addCleanup(os.close, fd)
+        self.assertEqual(os.get_inheritable(fd), False)
+
+        os.set_inheritable(fd, True)
+        self.assertEqual(os.get_inheritable(fd), True)
+
+        os.set_inheritable(fd, False)
+        self.assertEqual(os.get_inheritable(fd), False)
+
+    def test_get_set_inheritable_badf(self):
+        fd = os_helper.make_bad_fd()
+
+        with self.assertRaises(OSError) as ctx:
+            os.get_inheritable(fd)
+        self.assertEqual(ctx.exception.errno, errno.EBADF)
+
+        with self.assertRaises(OSError) as ctx:
+            os.set_inheritable(fd, True)
+        self.assertEqual(ctx.exception.errno, errno.EBADF)
+
+        with self.assertRaises(OSError) as ctx:
+            os.set_inheritable(fd, False)
+        self.assertEqual(ctx.exception.errno, errno.EBADF)
+
     def test_open(self):
         fd = os.open(__file__, os.O_RDONLY)
         self.addCleanup(os.close, fd)
@@ -3614,22 +4029,24 @@ class PathTConverterTests(unittest.TestCase):
     # function, cleanup function)
     functions = [
         ('stat', True, (), None),
-        ('lstat', True, (), None),
+        ('lstat', False, (), None),
         ('access', False, (os.F_OK,), None),
         ('chflags', False, (0,), None),
         ('lchflags', False, (0,), None),
         ('open', False, (0,), getattr(os, 'close', None)),
     ]
 
+    # TODO: RUSTPYTHON (AssertionError: TypeError not raised)
+    @unittest.expectedFailure
     def test_path_t_converter(self):
-        str_filename = support.TESTFN
+        str_filename = os_helper.TESTFN
         if os.name == 'nt':
             bytes_fspath = bytes_filename = None
         else:
-            bytes_filename = support.TESTFN.encode('ascii')
+            bytes_filename = os.fsencode(os_helper.TESTFN)
             bytes_fspath = FakePath(bytes_filename)
         fd = os.open(FakePath(str_filename), os.O_WRONLY|os.O_CREAT)
-        self.addCleanup(support.unlink, support.TESTFN)
+        self.addCleanup(os_helper.unlink, os_helper.TESTFN)
         self.addCleanup(os.close, fd)
 
         int_fspath = FakePath(fd)
@@ -3697,13 +4114,35 @@ class ExportsTests(unittest.TestCase):
         self.assertIn('walk', os.__all__)
 
 
+class TestDirEntry(unittest.TestCase):
+    def setUp(self):
+        self.path = os.path.realpath(os_helper.TESTFN)
+        self.addCleanup(os_helper.rmtree, self.path)
+        os.mkdir(self.path)
+
+    # TODO: RUSTPYTHON (AssertionError: TypeError not raised by DirEntry)
+    @unittest.expectedFailure
+    def test_uninstantiable(self):
+        self.assertRaises(TypeError, os.DirEntry)
+
+    # TODO: RUSTPYTHON (pickle.PicklingError: Can't pickle <class '_os.DirEntry'>: it's not found as _os.DirEntry)
+    @unittest.expectedFailure
+    def test_unpickable(self):
+        filename = create_file(os.path.join(self.path, "file.txt"), b'python')
+        entry = [entry for entry in os.scandir(self.path)].pop()
+        self.assertIsInstance(entry, os.DirEntry)
+        self.assertEqual(entry.name, "file.txt")
+        import pickle
+        self.assertRaises(TypeError, pickle.dumps, entry, filename)
+
+
 class TestScandir(unittest.TestCase):
     check_no_resource_warning = support.check_no_resource_warning
 
     def setUp(self):
-        self.path = os.path.realpath(support.TESTFN)
+        self.path = os.path.realpath(os_helper.TESTFN)
         self.bytes_path = os.fsencode(self.path)
-        self.addCleanup(support.rmtree, self.path)
+        self.addCleanup(os_helper.rmtree, self.path)
         os.mkdir(self.path)
 
     def create_file(self, name="file.txt"):
@@ -3730,6 +4169,20 @@ class TestScandir(unittest.TestCase):
                                  (stat1, stat2, attr))
         else:
             self.assertEqual(stat1, stat2)
+
+    # TODO: RUSTPPYTHON (AssertionError: TypeError not raised by ScandirIter)
+    @unittest.expectedFailure
+    def test_uninstantiable(self):
+        scandir_iter = os.scandir(self.path)
+        self.assertRaises(TypeError, type(scandir_iter))
+        scandir_iter.close()
+
+    def test_unpickable(self):
+        filename = self.create_file("file.txt")
+        scandir_iter = os.scandir(self.path)
+        import pickle
+        self.assertRaises(TypeError, pickle.dumps, scandir_iter, filename)
+        scandir_iter.close()
 
     def check_entry(self, entry, name, is_dir, is_file, is_symlink):
         self.assertIsInstance(entry, os.DirEntry)
@@ -3762,7 +4215,7 @@ class TestScandir(unittest.TestCase):
     @unittest.skipIf(sys.platform == "linux", "TODO: RUSTPYTHON, flaky test")
     def test_attributes(self):
         link = hasattr(os, 'link')
-        symlink = support.can_symlink()
+        symlink = os_helper.can_symlink()
 
         dirname = os.path.join(self.path, "dir")
         os.mkdir(dirname)
@@ -3886,7 +4339,7 @@ class TestScandir(unittest.TestCase):
             self.assertRaises(FileNotFoundError, entry.stat, follow_symlinks=False)
 
     def test_broken_symlink(self):
-        if not support.can_symlink():
+        if not os_helper.can_symlink():
             return self.skipTest('cannot create symbolic link')
 
         filename = self.create_file("file.txt")
@@ -3936,14 +4389,15 @@ class TestScandir(unittest.TestCase):
             self.assertIs(type(entry.name), bytes)
             self.assertIs(type(entry.path), bytes)
 
-    # TODO: RUSTPYTHON (scandir needs to have supports_fd)
-    @unittest.skipUnless(os.scandir in os.supports_fd,
-                         'fd support for scandir required for this test.')
+    # TODO: RUSTPYTHON
+    @unittest.expectedFailure
+    @unittest.skipUnless(os.listdir in os.supports_fd,
+                         'fd support for listdir required for this test.')
     def test_fd(self):
         self.assertIn(os.scandir, os.supports_fd)
         self.create_file('file.txt')
         expected_names = ['file.txt']
-        if support.can_symlink():
+        if os_helper.can_symlink():
             os.symlink('file.txt', os.path.join(self.path, 'link'))
             expected_names.append('link')
 
@@ -4090,6 +4544,11 @@ class TestPEP519(unittest.TestCase):
             pass
         self.assertFalse(issubclass(FakePath, A))
         self.assertTrue(issubclass(FakePath, os.PathLike))
+
+    # TODO: RUSTPYTHON (TypeError: 'ABCMeta' object is not subscriptable)
+    @unittest.expectedFailure
+    def test_pathlike_class_getitem(self):
+        self.assertIsInstance(os.PathLike[bytes], types.GenericAlias)
 
 
 class TimesTests(unittest.TestCase):

--- a/Lib/test/test_os.py
+++ b/Lib/test/test_os.py
@@ -3551,13 +3551,13 @@ def supports_extended_attributes():
         return False
 
     try:
-        with open(support.TESTFN, "xb", 0) as fp:
+        with open(os_helper.TESTFN, "xb", 0) as fp:
             try:
                 os.setxattr(fp.fileno(), b"user.test", b"")
             except OSError:
                 return False
     finally:
-        support.unlink(support.TESTFN)
+        os_helper.unlink(os_helper.TESTFN)
 
     return True
 

--- a/Lib/test/test_pkgimport.py
+++ b/Lib/test/test_pkgimport.py
@@ -7,7 +7,7 @@ import tempfile
 import unittest
 
 from importlib.util import cache_from_source
-from test.support import create_empty_file
+from test.support.os_helper import create_empty_file
 
 class TestImport(unittest.TestCase):
 

--- a/Lib/test/test_platform.py
+++ b/Lib/test/test_platform.py
@@ -8,6 +8,7 @@ import unittest
 from unittest import mock
 
 from test import support
+from test.support import os_helper
 
 class PlatformTest(unittest.TestCase):
     def clear_caches(self):
@@ -18,7 +19,7 @@ class PlatformTest(unittest.TestCase):
     def test_architecture(self):
         res = platform.architecture()
 
-    @support.skip_unless_symlink
+    @os_helper.skip_unless_symlink
     def test_architecture_via_symlink(self): # issue3762
         # On Windows, the EXE needs to know where pythonXY.dll and *.pyd is at
         # so we add the directory to the path, PYTHONHOME and PYTHONPATH.
@@ -45,7 +46,7 @@ class PlatformTest(unittest.TestCase):
             return r
 
         real = os.path.realpath(sys.executable)
-        link = os.path.abspath(support.TESTFN)
+        link = os.path.abspath(os_helper.TESTFN)
         os.symlink(real, link)
         try:
             self.assertEqual(get(real), get(link, env=env))
@@ -198,7 +199,7 @@ class PlatformTest(unittest.TestCase):
         # using it, per
         # http://blogs.msdn.com/david.wang/archive/2006/03/26/HOWTO-Detect-Process-Bitness.aspx
         try:
-            with support.EnvironmentVarGuard() as environ:
+            with os_helper.EnvironmentVarGuard() as environ:
                 if 'PROCESSOR_ARCHITEW6432' in environ:
                     del environ['PROCESSOR_ARCHITEW6432']
                 environ['PROCESSOR_ARCHITECTURE'] = 'foo'
@@ -285,8 +286,8 @@ class PlatformTest(unittest.TestCase):
             executable = sys.executable
         platform.libc_ver(executable)
 
-        filename = support.TESTFN
-        self.addCleanup(support.unlink, filename)
+        filename = os_helper.TESTFN
+        self.addCleanup(os_helper.unlink, filename)
 
         with mock.patch('os.confstr', create=True, return_value='mock 1.0'):
             # test os.confstr() code path

--- a/Lib/test/test_posix.py
+++ b/Lib/test/test_posix.py
@@ -1,6 +1,7 @@
 "Test posix functions"
 
 from test import support
+from test.support import os_helper
 from test.support.script_helper import assert_python_ok
 
 # Skip these tests if there is no posix module.
@@ -20,7 +21,7 @@ import warnings
 import textwrap
 
 _DUMMY_SYMLINK = os.path.join(tempfile.gettempdir(),
-                              support.TESTFN + '-dummy-symlink')
+                              os_helper.TESTFN + '-dummy-symlink')
 
 requires_32b = unittest.skipUnless(sys.maxsize < 2**32,
         'test is only meaningful on 32-bit builds')
@@ -42,9 +43,9 @@ class PosixTester(unittest.TestCase):
 
     def setUp(self):
         # create empty file
-        fp = open(support.TESTFN, 'w+')
+        fp = open(os_helper.TESTFN, 'w+')
         fp.close()
-        self.teardown_files = [ support.TESTFN ]
+        self.teardown_files = [ os_helper.TESTFN ]
         self._warnings_manager = support.check_warnings()
         self._warnings_manager.__enter__()
         warnings.filterwarnings('ignore', '.* potential security risk .*',
@@ -52,7 +53,7 @@ class PosixTester(unittest.TestCase):
 
     def tearDown(self):
         for teardown_file in self.teardown_files:
-            support.unlink(teardown_file)
+            os_helper.unlink(teardown_file)
         self._warnings_manager.__exit__(None, None, None)
 
     def testNoArgFunctions(self):
@@ -153,7 +154,7 @@ class PosixTester(unittest.TestCase):
     @unittest.skipUnless(hasattr(posix, 'fstatvfs'),
                          'test needs posix.fstatvfs()')
     def test_fstatvfs(self):
-        fp = open(support.TESTFN)
+        fp = open(os_helper.TESTFN)
         try:
             self.assertTrue(posix.fstatvfs(fp.fileno()))
             self.assertTrue(posix.statvfs(fp.fileno()))
@@ -163,7 +164,7 @@ class PosixTester(unittest.TestCase):
     @unittest.skipUnless(hasattr(posix, 'ftruncate'),
                          'test needs posix.ftruncate()')
     def test_ftruncate(self):
-        fp = open(support.TESTFN, 'w+')
+        fp = open(os_helper.TESTFN, 'w+')
         try:
             # we need to have some data to truncate
             fp.write('test')
@@ -174,10 +175,10 @@ class PosixTester(unittest.TestCase):
 
     @unittest.skipUnless(hasattr(posix, 'truncate'), "test needs posix.truncate()")
     def test_truncate(self):
-        with open(support.TESTFN, 'w') as fp:
+        with open(os_helper.TESTFN, 'w') as fp:
             fp.write('test')
             fp.flush()
-        posix.truncate(support.TESTFN, 0)
+        posix.truncate(os_helper.TESTFN, 0)
 
     @unittest.skipUnless(getattr(os, 'execve', None) in os.supports_fd, "test needs execve() to support the fd parameter")
     @unittest.skipUnless(hasattr(os, 'fork'), "test needs os.fork()")
@@ -268,7 +269,7 @@ class PosixTester(unittest.TestCase):
 
     @unittest.skipUnless(hasattr(posix, 'lockf'), "test needs posix.lockf()")
     def test_lockf(self):
-        fd = os.open(support.TESTFN, os.O_WRONLY | os.O_CREAT)
+        fd = os.open(os_helper.TESTFN, os.O_WRONLY | os.O_CREAT)
         try:
             os.write(fd, b'test')
             os.lseek(fd, 0, os.SEEK_SET)
@@ -280,7 +281,7 @@ class PosixTester(unittest.TestCase):
 
     @unittest.skipUnless(hasattr(posix, 'pread'), "test needs posix.pread()")
     def test_pread(self):
-        fd = os.open(support.TESTFN, os.O_RDWR | os.O_CREAT)
+        fd = os.open(os_helper.TESTFN, os.O_RDWR | os.O_CREAT)
         try:
             os.write(fd, b'test')
             os.lseek(fd, 0, os.SEEK_SET)
@@ -292,7 +293,7 @@ class PosixTester(unittest.TestCase):
 
     @unittest.skipUnless(hasattr(posix, 'preadv'), "test needs posix.preadv()")
     def test_preadv(self):
-        fd = os.open(support.TESTFN, os.O_RDWR | os.O_CREAT)
+        fd = os.open(os_helper.TESTFN, os.O_RDWR | os.O_CREAT)
         try:
             os.write(fd, b'test1tt2t3t5t6t6t8')
             buf = [bytearray(i) for i in [5, 3, 2]]
@@ -304,7 +305,7 @@ class PosixTester(unittest.TestCase):
     @unittest.skipUnless(hasattr(posix, 'preadv'), "test needs posix.preadv()")
     @unittest.skipUnless(hasattr(posix, 'RWF_HIPRI'), "test needs posix.RWF_HIPRI")
     def test_preadv_flags(self):
-        fd = os.open(support.TESTFN, os.O_RDWR | os.O_CREAT)
+        fd = os.open(os_helper.TESTFN, os.O_RDWR | os.O_CREAT)
         try:
             os.write(fd, b'test1tt2t3t5t6t6t8')
             buf = [bytearray(i) for i in [5, 3, 2]]
@@ -326,7 +327,7 @@ class PosixTester(unittest.TestCase):
     @unittest.skipUnless(hasattr(posix, 'preadv'), "test needs posix.preadv()")
     @requires_32b
     def test_preadv_overflow_32bits(self):
-        fd = os.open(support.TESTFN, os.O_RDWR | os.O_CREAT)
+        fd = os.open(os_helper.TESTFN, os.O_RDWR | os.O_CREAT)
         try:
             buf = [bytearray(2**16)] * 2**15
             with self.assertRaises(OSError) as cm:
@@ -338,7 +339,7 @@ class PosixTester(unittest.TestCase):
 
     @unittest.skipUnless(hasattr(posix, 'pwrite'), "test needs posix.pwrite()")
     def test_pwrite(self):
-        fd = os.open(support.TESTFN, os.O_RDWR | os.O_CREAT)
+        fd = os.open(os_helper.TESTFN, os.O_RDWR | os.O_CREAT)
         try:
             os.write(fd, b'test')
             os.lseek(fd, 0, os.SEEK_SET)
@@ -349,7 +350,7 @@ class PosixTester(unittest.TestCase):
 
     @unittest.skipUnless(hasattr(posix, 'pwritev'), "test needs posix.pwritev()")
     def test_pwritev(self):
-        fd = os.open(support.TESTFN, os.O_RDWR | os.O_CREAT)
+        fd = os.open(os_helper.TESTFN, os.O_RDWR | os.O_CREAT)
         try:
             os.write(fd, b"xx")
             os.lseek(fd, 0, os.SEEK_SET)
@@ -364,7 +365,7 @@ class PosixTester(unittest.TestCase):
     @unittest.skipUnless(hasattr(posix, 'pwritev'), "test needs posix.pwritev()")
     @unittest.skipUnless(hasattr(posix, 'os.RWF_SYNC'), "test needs os.RWF_SYNC")
     def test_pwritev_flags(self):
-        fd = os.open(support.TESTFN, os.O_RDWR | os.O_CREAT)
+        fd = os.open(os_helper.TESTFN, os.O_RDWR | os.O_CREAT)
         try:
             os.write(fd,b"xx")
             os.lseek(fd, 0, os.SEEK_SET)
@@ -379,7 +380,7 @@ class PosixTester(unittest.TestCase):
     @unittest.skipUnless(hasattr(posix, 'pwritev'), "test needs posix.pwritev()")
     @requires_32b
     def test_pwritev_overflow_32bits(self):
-        fd = os.open(support.TESTFN, os.O_RDWR | os.O_CREAT)
+        fd = os.open(os_helper.TESTFN, os.O_RDWR | os.O_CREAT)
         try:
             with self.assertRaises(OSError) as cm:
                 os.pwritev(fd, [b"x" * 2**16] * 2**15, 0)
@@ -390,7 +391,7 @@ class PosixTester(unittest.TestCase):
     @unittest.skipUnless(hasattr(posix, 'posix_fallocate'),
         "test needs posix.posix_fallocate()")
     def test_posix_fallocate(self):
-        fd = os.open(support.TESTFN, os.O_WRONLY | os.O_CREAT)
+        fd = os.open(os_helper.TESTFN, os.O_WRONLY | os.O_CREAT)
         try:
             posix.posix_fallocate(fd, 0, 10)
         except OSError as inst:
@@ -419,7 +420,7 @@ class PosixTester(unittest.TestCase):
     @unittest.skipUnless(hasattr(posix, 'posix_fadvise'),
         "test needs posix.posix_fadvise()")
     def test_posix_fadvise(self):
-        fd = os.open(support.TESTFN, os.O_RDONLY)
+        fd = os.open(os_helper.TESTFN, os.O_RDONLY)
         try:
             posix.posix_fadvise(fd, 0, 0, posix.POSIX_FADV_WILLNEED)
         finally:
@@ -437,7 +438,7 @@ class PosixTester(unittest.TestCase):
     @unittest.skipUnless(os.utime in os.supports_fd, "test needs fd support in os.utime")
     def test_utime_with_fd(self):
         now = time.time()
-        fd = os.open(support.TESTFN, os.O_RDONLY)
+        fd = os.open(os_helper.TESTFN, os.O_RDONLY)
         try:
             posix.utime(fd)
             posix.utime(fd, None)
@@ -458,17 +459,17 @@ class PosixTester(unittest.TestCase):
     @unittest.skipUnless(os.utime in os.supports_follow_symlinks, "test needs follow_symlinks support in os.utime")
     def test_utime_nofollow_symlinks(self):
         now = time.time()
-        posix.utime(support.TESTFN, None, follow_symlinks=False)
-        self.assertRaises(TypeError, posix.utime, support.TESTFN, (None, None), follow_symlinks=False)
-        self.assertRaises(TypeError, posix.utime, support.TESTFN, (now, None), follow_symlinks=False)
-        self.assertRaises(TypeError, posix.utime, support.TESTFN, (None, now), follow_symlinks=False)
-        posix.utime(support.TESTFN, (int(now), int(now)), follow_symlinks=False)
-        posix.utime(support.TESTFN, (now, now), follow_symlinks=False)
-        posix.utime(support.TESTFN, follow_symlinks=False)
+        posix.utime(os_helper.TESTFN, None, follow_symlinks=False)
+        self.assertRaises(TypeError, posix.utime, os_helper.TESTFN, (None, None), follow_symlinks=False)
+        self.assertRaises(TypeError, posix.utime, os_helper.TESTFN, (now, None), follow_symlinks=False)
+        self.assertRaises(TypeError, posix.utime, os_helper.TESTFN, (None, now), follow_symlinks=False)
+        posix.utime(os_helper.TESTFN, (int(now), int(now)), follow_symlinks=False)
+        posix.utime(os_helper.TESTFN, (now, now), follow_symlinks=False)
+        posix.utime(os_helper.TESTFN, follow_symlinks=False)
 
     @unittest.skipUnless(hasattr(posix, 'writev'), "test needs posix.writev()")
     def test_writev(self):
-        fd = os.open(support.TESTFN, os.O_RDWR | os.O_CREAT)
+        fd = os.open(os_helper.TESTFN, os.O_RDWR | os.O_CREAT)
         try:
             n = os.writev(fd, (b'test1', b'tt2', b't3'))
             self.assertEqual(n, 10)
@@ -491,7 +492,7 @@ class PosixTester(unittest.TestCase):
     @unittest.skipUnless(hasattr(posix, 'writev'), "test needs posix.writev()")
     @requires_32b
     def test_writev_overflow_32bits(self):
-        fd = os.open(support.TESTFN, os.O_RDWR | os.O_CREAT)
+        fd = os.open(os_helper.TESTFN, os.O_RDWR | os.O_CREAT)
         try:
             with self.assertRaises(OSError) as cm:
                 os.writev(fd, [b"x" * 2**16] * 2**15)
@@ -501,7 +502,7 @@ class PosixTester(unittest.TestCase):
 
     @unittest.skipUnless(hasattr(posix, 'readv'), "test needs posix.readv()")
     def test_readv(self):
-        fd = os.open(support.TESTFN, os.O_RDWR | os.O_CREAT)
+        fd = os.open(os_helper.TESTFN, os.O_RDWR | os.O_CREAT)
         try:
             os.write(fd, b'test1tt2t3')
             os.lseek(fd, 0, os.SEEK_SET)
@@ -524,7 +525,7 @@ class PosixTester(unittest.TestCase):
     @unittest.skipUnless(hasattr(posix, 'readv'), "test needs posix.readv()")
     @requires_32b
     def test_readv_overflow_32bits(self):
-        fd = os.open(support.TESTFN, os.O_RDWR | os.O_CREAT)
+        fd = os.open(os_helper.TESTFN, os.O_RDWR | os.O_CREAT)
         try:
             buf = [bytearray(2**16)] * 2**15
             with self.assertRaises(OSError) as cm:
@@ -537,7 +538,7 @@ class PosixTester(unittest.TestCase):
     @unittest.skipUnless(hasattr(posix, 'dup'),
                          'test needs posix.dup()')
     def test_dup(self):
-        fp = open(support.TESTFN)
+        fp = open(os_helper.TESTFN)
         try:
             fd = posix.dup(fp.fileno())
             self.assertIsInstance(fd, int)
@@ -554,8 +555,8 @@ class PosixTester(unittest.TestCase):
     @unittest.skipUnless(hasattr(posix, 'dup2'),
                          'test needs posix.dup2()')
     def test_dup2(self):
-        fp1 = open(support.TESTFN)
-        fp2 = open(support.TESTFN)
+        fp1 = open(os_helper.TESTFN)
+        fp2 = open(os_helper.TESTFN)
         try:
             posix.dup2(fp1.fileno(), fp2.fileno())
         finally:
@@ -565,40 +566,40 @@ class PosixTester(unittest.TestCase):
     @unittest.skipUnless(hasattr(os, 'O_CLOEXEC'), "needs os.O_CLOEXEC")
     @support.requires_linux_version(2, 6, 23)
     def test_oscloexec(self):
-        fd = os.open(support.TESTFN, os.O_RDONLY|os.O_CLOEXEC)
+        fd = os.open(os_helper.TESTFN, os.O_RDONLY|os.O_CLOEXEC)
         self.addCleanup(os.close, fd)
         self.assertFalse(os.get_inheritable(fd))
 
     @unittest.skipUnless(hasattr(posix, 'O_EXLOCK'),
                          'test needs posix.O_EXLOCK')
     def test_osexlock(self):
-        fd = os.open(support.TESTFN,
+        fd = os.open(os_helper.TESTFN,
                      os.O_WRONLY|os.O_EXLOCK|os.O_CREAT)
-        self.assertRaises(OSError, os.open, support.TESTFN,
+        self.assertRaises(OSError, os.open, os_helper.TESTFN,
                           os.O_WRONLY|os.O_EXLOCK|os.O_NONBLOCK)
         os.close(fd)
 
         if hasattr(posix, "O_SHLOCK"):
-            fd = os.open(support.TESTFN,
+            fd = os.open(os_helper.TESTFN,
                          os.O_WRONLY|os.O_SHLOCK|os.O_CREAT)
-            self.assertRaises(OSError, os.open, support.TESTFN,
+            self.assertRaises(OSError, os.open, os_helper.TESTFN,
                               os.O_WRONLY|os.O_EXLOCK|os.O_NONBLOCK)
             os.close(fd)
 
     @unittest.skipUnless(hasattr(posix, 'O_SHLOCK'),
                          'test needs posix.O_SHLOCK')
     def test_osshlock(self):
-        fd1 = os.open(support.TESTFN,
+        fd1 = os.open(os_helper.TESTFN,
                      os.O_WRONLY|os.O_SHLOCK|os.O_CREAT)
-        fd2 = os.open(support.TESTFN,
+        fd2 = os.open(os_helper.TESTFN,
                       os.O_WRONLY|os.O_SHLOCK|os.O_CREAT)
         os.close(fd2)
         os.close(fd1)
 
         if hasattr(posix, "O_EXLOCK"):
-            fd = os.open(support.TESTFN,
+            fd = os.open(os_helper.TESTFN,
                          os.O_WRONLY|os.O_SHLOCK|os.O_CREAT)
-            self.assertRaises(OSError, os.open, support.TESTFN,
+            self.assertRaises(OSError, os.open, os_helper.TESTFN,
                               os.O_RDONLY|os.O_EXLOCK|os.O_NONBLOCK)
             os.close(fd)
 
@@ -607,7 +608,7 @@ class PosixTester(unittest.TestCase):
     @unittest.skipUnless(hasattr(posix, 'fstat'),
                          'test needs posix.fstat()')
     def test_fstat(self):
-        fp = open(support.TESTFN)
+        fp = open(os_helper.TESTFN)
         try:
             self.assertTrue(posix.fstat(fp.fileno()))
             self.assertTrue(posix.stat(fp.fileno()))
@@ -621,58 +622,58 @@ class PosixTester(unittest.TestCase):
     # TODO: RUSTPYTHON: AssertionError: DeprecationWarning not triggered by stat
     @unittest.expectedFailure
     def test_stat(self):
-        self.assertTrue(posix.stat(support.TESTFN))
-        self.assertTrue(posix.stat(os.fsencode(support.TESTFN)))
+        self.assertTrue(posix.stat(os_helper.TESTFN))
+        self.assertTrue(posix.stat(os.fsencode(os_helper.TESTFN)))
 
         self.assertWarnsRegex(DeprecationWarning,
                 'should be string, bytes, os.PathLike or integer, not',
-                posix.stat, bytearray(os.fsencode(support.TESTFN)))
+                posix.stat, bytearray(os.fsencode(os_helper.TESTFN)))
         self.assertRaisesRegex(TypeError,
                 'should be string, bytes, os.PathLike or integer, not',
                 posix.stat, None)
         self.assertRaisesRegex(TypeError,
                 'should be string, bytes, os.PathLike or integer, not',
-                posix.stat, list(support.TESTFN))
+                posix.stat, list(os_helper.TESTFN))
         self.assertRaisesRegex(TypeError,
                 'should be string, bytes, os.PathLike or integer, not',
-                posix.stat, list(os.fsencode(support.TESTFN)))
+                posix.stat, list(os.fsencode(os_helper.TESTFN)))
 
     @unittest.skipUnless(hasattr(posix, 'mkfifo'), "don't have mkfifo()")
     def test_mkfifo(self):
-        support.unlink(support.TESTFN)
+        os_helper.unlink(os_helper.TESTFN)
         try:
-            posix.mkfifo(support.TESTFN, stat.S_IRUSR | stat.S_IWUSR)
+            posix.mkfifo(os_helper.TESTFN, stat.S_IRUSR | stat.S_IWUSR)
         except PermissionError as e:
             self.skipTest('posix.mkfifo(): %s' % e)
-        self.assertTrue(stat.S_ISFIFO(posix.stat(support.TESTFN).st_mode))
+        self.assertTrue(stat.S_ISFIFO(posix.stat(os_helper.TESTFN).st_mode))
 
     @unittest.skipUnless(hasattr(posix, 'mknod') and hasattr(stat, 'S_IFIFO'),
                          "don't have mknod()/S_IFIFO")
     def test_mknod(self):
         # Test using mknod() to create a FIFO (the only use specified
         # by POSIX).
-        support.unlink(support.TESTFN)
+        os_helper.unlink(os_helper.TESTFN)
         mode = stat.S_IFIFO | stat.S_IRUSR | stat.S_IWUSR
         try:
-            posix.mknod(support.TESTFN, mode, 0)
+            posix.mknod(os_helper.TESTFN, mode, 0)
         except OSError as e:
             # Some old systems don't allow unprivileged users to use
             # mknod(), or only support creating device nodes.
             self.assertIn(e.errno, (errno.EPERM, errno.EINVAL, errno.EACCES))
         else:
-            self.assertTrue(stat.S_ISFIFO(posix.stat(support.TESTFN).st_mode))
+            self.assertTrue(stat.S_ISFIFO(posix.stat(os_helper.TESTFN).st_mode))
 
         # Keyword arguments are also supported
-        support.unlink(support.TESTFN)
+        os_helper.unlink(os_helper.TESTFN)
         try:
-            posix.mknod(path=support.TESTFN, mode=mode, device=0,
+            posix.mknod(path=os_helper.TESTFN, mode=mode, device=0,
                 dir_fd=None)
         except OSError as e:
             self.assertIn(e.errno, (errno.EPERM, errno.EINVAL, errno.EACCES))
 
     @unittest.skipUnless(hasattr(posix, 'makedev'), 'test needs posix.makedev()')
     def test_makedev(self):
-        st = posix.stat(support.TESTFN)
+        st = posix.stat(os_helper.TESTFN)
         dev = st.st_dev
         self.assertIsInstance(dev, int)
         self.assertGreaterEqual(dev, 0)
@@ -761,19 +762,19 @@ class PosixTester(unittest.TestCase):
     @unittest.skipUnless(hasattr(posix, 'chown'), "test needs os.chown()")
     def test_chown(self):
         # raise an OSError if the file does not exist
-        os.unlink(support.TESTFN)
-        self.assertRaises(OSError, posix.chown, support.TESTFN, -1, -1)
+        os.unlink(os_helper.TESTFN)
+        self.assertRaises(OSError, posix.chown, os_helper.TESTFN, -1, -1)
 
         # re-create the file
-        support.create_empty_file(support.TESTFN)
-        self._test_all_chown_common(posix.chown, support.TESTFN, posix.stat)
+        os_helper.create_empty_file(os_helper.TESTFN)
+        self._test_all_chown_common(posix.chown, os_helper.TESTFN, posix.stat)
 
     @unittest.skipUnless(hasattr(posix, 'fchown'), "test needs os.fchown()")
     def test_fchown(self):
-        os.unlink(support.TESTFN)
+        os.unlink(os_helper.TESTFN)
 
         # re-create the file
-        test_file = open(support.TESTFN, 'w')
+        test_file = open(os_helper.TESTFN, 'w')
         try:
             fd = test_file.fileno()
             self._test_all_chown_common(posix.fchown, fd,
@@ -783,29 +784,29 @@ class PosixTester(unittest.TestCase):
 
     @unittest.skipUnless(hasattr(posix, 'lchown'), "test needs os.lchown()")
     def test_lchown(self):
-        os.unlink(support.TESTFN)
+        os.unlink(os_helper.TESTFN)
         # create a symlink
-        os.symlink(_DUMMY_SYMLINK, support.TESTFN)
-        self._test_all_chown_common(posix.lchown, support.TESTFN,
+        os.symlink(_DUMMY_SYMLINK, os_helper.TESTFN)
+        self._test_all_chown_common(posix.lchown, os_helper.TESTFN,
                                     getattr(posix, 'lstat', None))
 
     @unittest.skipUnless(hasattr(posix, 'chdir'), 'test needs posix.chdir()')
     def test_chdir(self):
         posix.chdir(os.curdir)
-        self.assertRaises(OSError, posix.chdir, support.TESTFN)
+        self.assertRaises(OSError, posix.chdir, os_helper.TESTFN)
 
     def test_listdir(self):
-        self.assertIn(support.TESTFN, posix.listdir(os.curdir))
+        self.assertIn(os_helper.TESTFN, posix.listdir(os.curdir))
 
     def test_listdir_default(self):
         # When listdir is called without argument,
         # it's the same as listdir(os.curdir).
-        self.assertIn(support.TESTFN, posix.listdir())
+        self.assertIn(os_helper.TESTFN, posix.listdir())
 
     def test_listdir_bytes(self):
         # When listdir is called with a bytes object,
         # the returned strings are of type bytes.
-        self.assertIn(os.fsencode(support.TESTFN), posix.listdir(b'.'))
+        self.assertIn(os.fsencode(os_helper.TESTFN), posix.listdir(b'.'))
 
     # TODO: RUSTPYTHON: AssertionError: DeprecationWarning not triggered
     @unittest.expectedFailure
@@ -813,7 +814,7 @@ class PosixTester(unittest.TestCase):
         for cls in bytearray, memoryview:
             with self.assertWarns(DeprecationWarning):
                 names = posix.listdir(cls(b'.'))
-            self.assertIn(os.fsencode(support.TESTFN), names)
+            self.assertIn(os.fsencode(os_helper.TESTFN), names)
             for name in names:
                 self.assertIs(type(name), bytes)
 
@@ -834,7 +835,7 @@ class PosixTester(unittest.TestCase):
 
     @unittest.skipUnless(hasattr(posix, 'access'), 'test needs posix.access()')
     def test_access(self):
-        self.assertTrue(posix.access(support.TESTFN, os.R_OK))
+        self.assertTrue(posix.access(os_helper.TESTFN, os.R_OK))
 
     @unittest.skipUnless(hasattr(posix, 'umask'), 'test needs posix.umask()')
     def test_umask(self):
@@ -893,12 +894,12 @@ class PosixTester(unittest.TestCase):
     @unittest.skipUnless(hasattr(posix, 'utime'), 'test needs posix.utime()')
     def test_utime(self):
         now = time.time()
-        posix.utime(support.TESTFN, None)
-        self.assertRaises(TypeError, posix.utime, support.TESTFN, (None, None))
-        self.assertRaises(TypeError, posix.utime, support.TESTFN, (now, None))
-        self.assertRaises(TypeError, posix.utime, support.TESTFN, (None, now))
-        posix.utime(support.TESTFN, (int(now), int(now)))
-        posix.utime(support.TESTFN, (now, now))
+        posix.utime(os_helper.TESTFN, None)
+        self.assertRaises(TypeError, posix.utime, os_helper.TESTFN, (None, None))
+        self.assertRaises(TypeError, posix.utime, os_helper.TESTFN, (now, None))
+        self.assertRaises(TypeError, posix.utime, os_helper.TESTFN, (None, now))
+        posix.utime(os_helper.TESTFN, (int(now), int(now)))
+        posix.utime(os_helper.TESTFN, (now, now))
 
     def _test_chflags_regular_file(self, chflags_func, target_file, **kwargs):
         st = os.stat(target_file)
@@ -926,20 +927,20 @@ class PosixTester(unittest.TestCase):
 
     @unittest.skipUnless(hasattr(posix, 'chflags'), 'test needs os.chflags()')
     def test_chflags(self):
-        self._test_chflags_regular_file(posix.chflags, support.TESTFN)
+        self._test_chflags_regular_file(posix.chflags, os_helper.TESTFN)
 
     @unittest.skipUnless(hasattr(posix, 'lchflags'), 'test needs os.lchflags()')
     def test_lchflags_regular_file(self):
-        self._test_chflags_regular_file(posix.lchflags, support.TESTFN)
-        self._test_chflags_regular_file(posix.chflags, support.TESTFN, follow_symlinks=False)
+        self._test_chflags_regular_file(posix.lchflags, os_helper.TESTFN)
+        self._test_chflags_regular_file(posix.chflags, os_helper.TESTFN, follow_symlinks=False)
 
     @unittest.skipUnless(hasattr(posix, 'lchflags'), 'test needs os.lchflags()')
     def test_lchflags_symlink(self):
-        testfn_st = os.stat(support.TESTFN)
+        testfn_st = os.stat(os_helper.TESTFN)
 
         self.assertTrue(hasattr(testfn_st, 'st_flags'))
 
-        os.symlink(support.TESTFN, _DUMMY_SYMLINK)
+        os.symlink(os_helper.TESTFN, _DUMMY_SYMLINK)
         self.teardown_files.append(_DUMMY_SYMLINK)
         dummy_symlink_st = os.lstat(_DUMMY_SYMLINK)
 
@@ -957,7 +958,7 @@ class PosixTester(unittest.TestCase):
                 msg = 'chflag UF_IMMUTABLE not supported by underlying fs'
                 self.skipTest(msg)
             try:
-                new_testfn_st = os.stat(support.TESTFN)
+                new_testfn_st = os.stat(os_helper.TESTFN)
                 new_dummy_symlink_st = os.lstat(_DUMMY_SYMLINK)
 
                 self.assertEqual(testfn_st.st_flags, new_testfn_st.st_flags)
@@ -993,7 +994,7 @@ class PosixTester(unittest.TestCase):
     def test_getcwd_long_pathnames(self):
         dirname = 'getcwd-test-directory-0123456789abcdef-01234567890abcdef'
         curdir = os.getcwd()
-        base_path = os.path.abspath(support.TESTFN) + '.getcwd'
+        base_path = os.path.abspath(os_helper.TESTFN) + '.getcwd'
 
         try:
             os.mkdir(base_path)
@@ -1023,7 +1024,7 @@ class PosixTester(unittest.TestCase):
 
         finally:
             os.chdir(curdir)
-            support.rmtree(base_path)
+            os_helper.rmtree(base_path)
 
     @unittest.skipUnless(hasattr(posix, 'getgrouplist'), "test needs posix.getgrouplist()")
     @unittest.skipUnless(hasattr(pwd, 'getpwuid'), "test needs pwd.getpwuid()")
@@ -1067,53 +1068,53 @@ class PosixTester(unittest.TestCase):
     def test_access_dir_fd(self):
         f = posix.open(posix.getcwd(), posix.O_RDONLY)
         try:
-            self.assertTrue(posix.access(support.TESTFN, os.R_OK, dir_fd=f))
+            self.assertTrue(posix.access(os_helper.TESTFN, os.R_OK, dir_fd=f))
         finally:
             posix.close(f)
 
     @unittest.skipUnless(os.chmod in os.supports_dir_fd, "test needs dir_fd support in os.chmod()")
     def test_chmod_dir_fd(self):
-        os.chmod(support.TESTFN, stat.S_IRUSR)
+        os.chmod(os_helper.TESTFN, stat.S_IRUSR)
 
         f = posix.open(posix.getcwd(), posix.O_RDONLY)
         try:
-            posix.chmod(support.TESTFN, stat.S_IRUSR | stat.S_IWUSR, dir_fd=f)
+            posix.chmod(os_helper.TESTFN, stat.S_IRUSR | stat.S_IWUSR, dir_fd=f)
 
-            s = posix.stat(support.TESTFN)
+            s = posix.stat(os_helper.TESTFN)
             self.assertEqual(s[0] & stat.S_IRWXU, stat.S_IRUSR | stat.S_IWUSR)
         finally:
             posix.close(f)
 
     @unittest.skipUnless(os.chown in os.supports_dir_fd, "test needs dir_fd support in os.chown()")
     def test_chown_dir_fd(self):
-        support.unlink(support.TESTFN)
-        support.create_empty_file(support.TESTFN)
+        os_helper.unlink(os_helper.TESTFN)
+        os_helper.create_empty_file(os_helper.TESTFN)
 
         f = posix.open(posix.getcwd(), posix.O_RDONLY)
         try:
-            posix.chown(support.TESTFN, os.getuid(), os.getgid(), dir_fd=f)
+            posix.chown(os_helper.TESTFN, os.getuid(), os.getgid(), dir_fd=f)
         finally:
             posix.close(f)
 
     @unittest.skipUnless(os.stat in os.supports_dir_fd, "test needs dir_fd support in os.stat()")
     def test_stat_dir_fd(self):
-        support.unlink(support.TESTFN)
-        with open(support.TESTFN, 'w') as outfile:
+        os_helper.unlink(os_helper.TESTFN)
+        with open(os_helper.TESTFN, 'w') as outfile:
             outfile.write("testline\n")
 
         f = posix.open(posix.getcwd(), posix.O_RDONLY)
         try:
-            s1 = posix.stat(support.TESTFN)
-            s2 = posix.stat(support.TESTFN, dir_fd=f)
+            s1 = posix.stat(os_helper.TESTFN)
+            s2 = posix.stat(os_helper.TESTFN, dir_fd=f)
             self.assertEqual(s1, s2)
-            s2 = posix.stat(support.TESTFN, dir_fd=None)
+            s2 = posix.stat(os_helper.TESTFN, dir_fd=None)
             self.assertEqual(s1, s2)
             self.assertRaisesRegex(TypeError, 'should be integer or None, not',
-                    posix.stat, support.TESTFN, dir_fd=posix.getcwd())
+                    posix.stat, os_helper.TESTFN, dir_fd=posix.getcwd())
             self.assertRaisesRegex(TypeError, 'should be integer or None, not',
-                    posix.stat, support.TESTFN, dir_fd=float(f))
+                    posix.stat, os_helper.TESTFN, dir_fd=float(f))
             self.assertRaises(OverflowError,
-                    posix.stat, support.TESTFN, dir_fd=10**20)
+                    posix.stat, os_helper.TESTFN, dir_fd=10**20)
         finally:
             posix.close(f)
 
@@ -1122,24 +1123,24 @@ class PosixTester(unittest.TestCase):
         f = posix.open(posix.getcwd(), posix.O_RDONLY)
         try:
             now = time.time()
-            posix.utime(support.TESTFN, None, dir_fd=f)
-            posix.utime(support.TESTFN, dir_fd=f)
-            self.assertRaises(TypeError, posix.utime, support.TESTFN, now, dir_fd=f)
-            self.assertRaises(TypeError, posix.utime, support.TESTFN, (None, None), dir_fd=f)
-            self.assertRaises(TypeError, posix.utime, support.TESTFN, (now, None), dir_fd=f)
-            self.assertRaises(TypeError, posix.utime, support.TESTFN, (None, now), dir_fd=f)
-            self.assertRaises(TypeError, posix.utime, support.TESTFN, (now, "x"), dir_fd=f)
-            posix.utime(support.TESTFN, (int(now), int(now)), dir_fd=f)
-            posix.utime(support.TESTFN, (now, now), dir_fd=f)
-            posix.utime(support.TESTFN,
+            posix.utime(os_helper.TESTFN, None, dir_fd=f)
+            posix.utime(os_helper.TESTFN, dir_fd=f)
+            self.assertRaises(TypeError, posix.utime, os_helper.TESTFN, now, dir_fd=f)
+            self.assertRaises(TypeError, posix.utime, os_helper.TESTFN, (None, None), dir_fd=f)
+            self.assertRaises(TypeError, posix.utime, os_helper.TESTFN, (now, None), dir_fd=f)
+            self.assertRaises(TypeError, posix.utime, os_helper.TESTFN, (None, now), dir_fd=f)
+            self.assertRaises(TypeError, posix.utime, os_helper.TESTFN, (now, "x"), dir_fd=f)
+            posix.utime(os_helper.TESTFN, (int(now), int(now)), dir_fd=f)
+            posix.utime(os_helper.TESTFN, (now, now), dir_fd=f)
+            posix.utime(os_helper.TESTFN,
                     (int(now), int((now - int(now)) * 1e9)), dir_fd=f)
-            posix.utime(support.TESTFN, dir_fd=f,
+            posix.utime(os_helper.TESTFN, dir_fd=f,
                             times=(int(now), int((now - int(now)) * 1e9)))
 
             # try dir_fd and follow_symlinks together
             if os.utime in os.supports_follow_symlinks:
                 try:
-                    posix.utime(support.TESTFN, follow_symlinks=False, dir_fd=f)
+                    posix.utime(os_helper.TESTFN, follow_symlinks=False, dir_fd=f)
                 except ValueError:
                     # whoops!  using both together not supported on this platform.
                     pass
@@ -1151,53 +1152,53 @@ class PosixTester(unittest.TestCase):
     def test_link_dir_fd(self):
         f = posix.open(posix.getcwd(), posix.O_RDONLY)
         try:
-            posix.link(support.TESTFN, support.TESTFN + 'link', src_dir_fd=f, dst_dir_fd=f)
+            posix.link(os_helper.TESTFN, os_helper.TESTFN + 'link', src_dir_fd=f, dst_dir_fd=f)
         except PermissionError as e:
             self.skipTest('posix.link(): %s' % e)
         else:
             # should have same inodes
-            self.assertEqual(posix.stat(support.TESTFN)[1],
-                posix.stat(support.TESTFN + 'link')[1])
+            self.assertEqual(posix.stat(os_helper.TESTFN)[1],
+                posix.stat(os_helper.TESTFN + 'link')[1])
         finally:
             posix.close(f)
-            support.unlink(support.TESTFN + 'link')
+            os_helper.unlink(os_helper.TESTFN + 'link')
 
     @unittest.skipUnless(os.mkdir in os.supports_dir_fd, "test needs dir_fd support in os.mkdir()")
     def test_mkdir_dir_fd(self):
         f = posix.open(posix.getcwd(), posix.O_RDONLY)
         try:
-            posix.mkdir(support.TESTFN + 'dir', dir_fd=f)
-            posix.stat(support.TESTFN + 'dir') # should not raise exception
+            posix.mkdir(os_helper.TESTFN + 'dir', dir_fd=f)
+            posix.stat(os_helper.TESTFN + 'dir') # should not raise exception
         finally:
             posix.close(f)
-            support.rmtree(support.TESTFN + 'dir')
+            os_helper.rmtree(os_helper.TESTFN + 'dir')
 
     @unittest.skipUnless((os.mknod in os.supports_dir_fd) and hasattr(stat, 'S_IFIFO'),
                          "test requires both stat.S_IFIFO and dir_fd support for os.mknod()")
     def test_mknod_dir_fd(self):
         # Test using mknodat() to create a FIFO (the only use specified
         # by POSIX).
-        support.unlink(support.TESTFN)
+        os_helper.unlink(os_helper.TESTFN)
         mode = stat.S_IFIFO | stat.S_IRUSR | stat.S_IWUSR
         f = posix.open(posix.getcwd(), posix.O_RDONLY)
         try:
-            posix.mknod(support.TESTFN, mode, 0, dir_fd=f)
+            posix.mknod(os_helper.TESTFN, mode, 0, dir_fd=f)
         except OSError as e:
             # Some old systems don't allow unprivileged users to use
             # mknod(), or only support creating device nodes.
             self.assertIn(e.errno, (errno.EPERM, errno.EINVAL, errno.EACCES))
         else:
-            self.assertTrue(stat.S_ISFIFO(posix.stat(support.TESTFN).st_mode))
+            self.assertTrue(stat.S_ISFIFO(posix.stat(os_helper.TESTFN).st_mode))
         finally:
             posix.close(f)
 
     @unittest.skipUnless(os.open in os.supports_dir_fd, "test needs dir_fd support in os.open()")
     def test_open_dir_fd(self):
-        support.unlink(support.TESTFN)
-        with open(support.TESTFN, 'w') as outfile:
+        os_helper.unlink(os_helper.TESTFN)
+        with open(os_helper.TESTFN, 'w') as outfile:
             outfile.write("testline\n")
         a = posix.open(posix.getcwd(), posix.O_RDONLY)
-        b = posix.open(support.TESTFN, posix.O_RDONLY, dir_fd=a)
+        b = posix.open(os_helper.TESTFN, posix.O_RDONLY, dir_fd=a)
         try:
             res = posix.read(b, 9).decode(encoding="utf-8")
             self.assertEqual("testline\n", res)
@@ -1207,27 +1208,27 @@ class PosixTester(unittest.TestCase):
 
     @unittest.skipUnless(os.readlink in os.supports_dir_fd, "test needs dir_fd support in os.readlink()")
     def test_readlink_dir_fd(self):
-        os.symlink(support.TESTFN, support.TESTFN + 'link')
+        os.symlink(os_helper.TESTFN, os_helper.TESTFN + 'link')
         f = posix.open(posix.getcwd(), posix.O_RDONLY)
         try:
-            self.assertEqual(posix.readlink(support.TESTFN + 'link'),
-                posix.readlink(support.TESTFN + 'link', dir_fd=f))
+            self.assertEqual(posix.readlink(os_helper.TESTFN + 'link'),
+                posix.readlink(os_helper.TESTFN + 'link', dir_fd=f))
         finally:
-            support.unlink(support.TESTFN + 'link')
+            os_helper.unlink(os_helper.TESTFN + 'link')
             posix.close(f)
 
     @unittest.skipUnless(os.rename in os.supports_dir_fd, "test needs dir_fd support in os.rename()")
     def test_rename_dir_fd(self):
-        support.unlink(support.TESTFN)
-        support.create_empty_file(support.TESTFN + 'ren')
+        os_helper.unlink(os_helper.TESTFN)
+        os_helper.create_empty_file(os_helper.TESTFN + 'ren')
         f = posix.open(posix.getcwd(), posix.O_RDONLY)
         try:
-            posix.rename(support.TESTFN + 'ren', support.TESTFN, src_dir_fd=f, dst_dir_fd=f)
+            posix.rename(os_helper.TESTFN + 'ren', os_helper.TESTFN, src_dir_fd=f, dst_dir_fd=f)
         except:
-            posix.rename(support.TESTFN + 'ren', support.TESTFN)
+            posix.rename(os_helper.TESTFN + 'ren', os_helper.TESTFN)
             raise
         else:
-            posix.stat(support.TESTFN) # should not raise exception
+            posix.stat(os_helper.TESTFN) # should not raise exception
         finally:
             posix.close(f)
 
@@ -1245,24 +1246,24 @@ class PosixTester(unittest.TestCase):
     def test_symlink_dir_fd(self):
         f = posix.open(posix.getcwd(), posix.O_RDONLY)
         try:
-            posix.symlink(support.TESTFN, support.TESTFN + 'link', dir_fd=f)
-            self.assertEqual(posix.readlink(support.TESTFN + 'link'), support.TESTFN)
+            posix.symlink(os_helper.TESTFN, os_helper.TESTFN + 'link', dir_fd=f)
+            self.assertEqual(posix.readlink(os_helper.TESTFN + 'link'), os_helper.TESTFN)
         finally:
             posix.close(f)
-            support.unlink(support.TESTFN + 'link')
+            os_helper.unlink(os_helper.TESTFN + 'link')
 
     @unittest.skipUnless(os.unlink in os.supports_dir_fd, "test needs dir_fd support in os.unlink()")
     def test_unlink_dir_fd(self):
         f = posix.open(posix.getcwd(), posix.O_RDONLY)
-        support.create_empty_file(support.TESTFN + 'del')
-        posix.stat(support.TESTFN + 'del') # should not raise exception
+        os_helper.create_empty_file(os_helper.TESTFN + 'del')
+        posix.stat(os_helper.TESTFN + 'del') # should not raise exception
         try:
-            posix.unlink(support.TESTFN + 'del', dir_fd=f)
+            posix.unlink(os_helper.TESTFN + 'del', dir_fd=f)
         except:
-            support.unlink(support.TESTFN + 'del')
+            os_helper.unlink(os_helper.TESTFN + 'del')
             raise
         else:
-            self.assertRaises(OSError, posix.stat, support.TESTFN + 'link')
+            self.assertRaises(OSError, posix.stat, os_helper.TESTFN + 'link')
         finally:
             posix.close(f)
 
@@ -1271,15 +1272,15 @@ class PosixTester(unittest.TestCase):
     # @unittest.skipUnless(os.mkfifo in os.supports_dir_fd, "test needs dir_fd support in os.mkfifo()")
     @unittest.expectedFailure
     def test_mkfifo_dir_fd(self):
-        support.unlink(support.TESTFN)
+        os_helper.unlink(os_helper.TESTFN)
         f = posix.open(posix.getcwd(), posix.O_RDONLY)
         try:
             try:
-                posix.mkfifo(support.TESTFN,
+                posix.mkfifo(os_helper.TESTFN,
                              stat.S_IRUSR | stat.S_IWUSR, dir_fd=f)
             except PermissionError as e:
                 self.skipTest('posix.mkfifo(): %s' % e)
-            self.assertTrue(stat.S_ISFIFO(posix.stat(support.TESTFN).st_mode))
+            self.assertTrue(stat.S_ISFIFO(posix.stat(os_helper.TESTFN).st_mode))
         finally:
             posix.close(f)
 
@@ -1406,7 +1407,7 @@ class PosixTester(unittest.TestCase):
         # behaviour:
         # os.SEEK_DATA = current position
         # os.SEEK_HOLE = end of file position
-        with open(support.TESTFN, 'r+b') as fp:
+        with open(os_helper.TESTFN, 'r+b') as fp:
             fp.write(b"hello")
             fp.flush()
             size = fp.tell()
@@ -1433,7 +1434,7 @@ class PosixTester(unittest.TestCase):
             if function is None:
                 continue
 
-            for dst in ("noodly2", support.TESTFN):
+            for dst in ("noodly2", os_helper.TESTFN):
                 try:
                     function('doesnotexistfilename', dst)
                 except OSError as e:
@@ -1443,10 +1444,10 @@ class PosixTester(unittest.TestCase):
                 self.fail("No valid path_error2() test for os." + name)
 
     def test_path_with_null_character(self):
-        fn = support.TESTFN
+        fn = os_helper.TESTFN
         fn_with_NUL = fn + '\0'
-        self.addCleanup(support.unlink, fn)
-        support.unlink(fn)
+        self.addCleanup(os_helper.unlink, fn)
+        os_helper.unlink(fn)
         fd = None
         try:
             with self.assertRaises(ValueError):
@@ -1461,10 +1462,10 @@ class PosixTester(unittest.TestCase):
         self.assertRaises(ValueError, os.stat, fn_with_NUL)
 
     def test_path_with_null_byte(self):
-        fn = os.fsencode(support.TESTFN)
+        fn = os.fsencode(os_helper.TESTFN)
         fn_with_NUL = fn + b'\0'
-        self.addCleanup(support.unlink, fn)
-        support.unlink(fn)
+        self.addCleanup(os_helper.unlink, fn)
+        os_helper.unlink(fn)
         fd = None
         try:
             with self.assertRaises(ValueError):
@@ -1539,8 +1540,8 @@ class _PosixSpawnMixin:
         return (sys.executable, '-I', '-S', *args)
 
     def test_returns_pid(self):
-        pidfile = support.TESTFN
-        self.addCleanup(support.unlink, pidfile)
+        pidfile = os_helper.TESTFN
+        self.addCleanup(os_helper.unlink, pidfile)
         script = f"""if 1:
             import os
             with open({pidfile!r}, "w") as pidfile:
@@ -1570,8 +1571,8 @@ class _PosixSpawnMixin:
     # TODO: RUSTPYTHON: TypeError: '_Environ' object is not a mapping
     @unittest.expectedFailure
     def test_specify_environment(self):
-        envfile = support.TESTFN
-        self.addCleanup(support.unlink, envfile)
+        envfile = os_helper.TESTFN
+        self.addCleanup(os_helper.unlink, envfile)
         script = f"""if 1:
             import os
             with open({envfile!r}, "w") as envfile:
@@ -1831,8 +1832,8 @@ class _PosixSpawnMixin:
                                            os.O_RDONLY, 0)])
 
     def test_open_file(self):
-        outfile = support.TESTFN
-        self.addCleanup(support.unlink, outfile)
+        outfile = os_helper.TESTFN
+        self.addCleanup(os_helper.unlink, outfile)
         script = """if 1:
             import sys
             sys.stdout.write("hello")
@@ -1853,8 +1854,8 @@ class _PosixSpawnMixin:
     # TODO: RUSTPYTHON: FileNotFoundError: [Errno 2] No such file or directory (os error 2): '@test_55144_tmp' -> 'None'
     @unittest.expectedFailure
     def test_close_file(self):
-        closefile = support.TESTFN
-        self.addCleanup(support.unlink, closefile)
+        closefile = os_helper.TESTFN
+        self.addCleanup(os_helper.unlink, closefile)
         script = f"""if 1:
             import os
             try:
@@ -1872,8 +1873,8 @@ class _PosixSpawnMixin:
             self.assertEqual(f.read(), 'is closed %d' % errno.EBADF)
 
     def test_dup2(self):
-        dupfile = support.TESTFN
-        self.addCleanup(support.unlink, dupfile)
+        dupfile = os_helper.TESTFN
+        self.addCleanup(os_helper.unlink, dupfile)
         script = """if 1:
             import sys
             sys.stdout.write("hello")
@@ -1899,11 +1900,11 @@ class TestPosixSpawn(unittest.TestCase, _PosixSpawnMixin):
 class TestPosixSpawnP(unittest.TestCase, _PosixSpawnMixin):
     spawn_func = getattr(posix, 'posix_spawnp', None)
 
-    @support.skip_unless_symlink
+    @os_helper.skip_unless_symlink
     def test_posix_spawnp(self):
         # Use a symlink to create a program in its own temporary directory
         temp_dir = tempfile.mkdtemp()
-        self.addCleanup(support.rmtree, temp_dir)
+        self.addCleanup(os_helper.rmtree, temp_dir)
 
         program = 'posix_spawnp_test_program.exe'
         program_fullpath = os.path.join(temp_dir, program)
@@ -2032,7 +2033,7 @@ class TestPosixWeaklinking(unittest.TestCase):
                 os.link("source", "target",  src_dir_fd=0, dst_dir_fd=0)
 
             # issue 41355: !HAVE_LINKAT code path ignores the follow_symlinks flag
-            with support.temp_dir() as base_path:
+            with os_helper.temp_dir() as base_path:
                 link_path = os.path.join(base_path, "link")
                 target_path = os.path.join(base_path, "target")
                 source_path = os.path.join(base_path, "source")

--- a/Lib/test/test_posixpath.py
+++ b/Lib/test/test_posixpath.py
@@ -173,10 +173,6 @@ class PosixPathTest(unittest.TestCase):
         self.assertIs(posixpath.islink(os_helper.TESTFN + "\x00"), False)
         self.assertIs(posixpath.islink(os.fsencode(os_helper.TESTFN) + b"\x00"), False)
 
-    # TODO: RUSTPYTHON
-    if os.name == "nt":
-        test_islink = unittest.expectedFailure(test_islink)
-
     def test_ismount(self):
         self.assertIs(posixpath.ismount("/"), True)
         self.assertIs(posixpath.ismount(b"/"), True)

--- a/Lib/test/test_posixpath.py
+++ b/Lib/test/test_posixpath.py
@@ -3,7 +3,8 @@ import posixpath
 import unittest
 from posixpath import realpath, abspath, dirname, basename
 from test import support, test_genericpath
-from test.support import FakePath
+from test.support import os_helper
+from test.support.os_helper import FakePath
 from unittest import mock
 
 try:
@@ -15,7 +16,7 @@ except ImportError:
 # An absolute path to a temporary filename for testing. We can't rely on TESTFN
 # being an absolute path, so we need this.
 
-ABSTFN = abspath(support.TESTFN)
+ABSTFN = abspath(os_helper.TESTFN)
 
 def skip_if_ABSTFN_contains_backslash(test):
     """
@@ -40,8 +41,8 @@ class PosixPathTest(unittest.TestCase):
 
     def tearDown(self):
         for suffix in ["", "1", "2"]:
-            support.unlink(support.TESTFN + suffix)
-            safe_rmdir(support.TESTFN + suffix)
+            os_helper.unlink(os_helper.TESTFN + suffix)
+            safe_rmdir(os_helper.TESTFN + suffix)
 
     def test_join(self):
         self.assertEqual(posixpath.join("/foo", "bar", "/bar", "baz"),
@@ -152,25 +153,25 @@ class PosixPathTest(unittest.TestCase):
         self.assertEqual(posixpath.dirname(b"//foo//bar"), b"//foo")
 
     def test_islink(self):
-        self.assertIs(posixpath.islink(support.TESTFN + "1"), False)
-        self.assertIs(posixpath.lexists(support.TESTFN + "2"), False)
+        self.assertIs(posixpath.islink(os_helper.TESTFN + "1"), False)
+        self.assertIs(posixpath.lexists(os_helper.TESTFN + "2"), False)
 
-        with open(support.TESTFN + "1", "wb") as f:
+        with open(os_helper.TESTFN + "1", "wb") as f:
             f.write(b"foo")
-        self.assertIs(posixpath.islink(support.TESTFN + "1"), False)
+        self.assertIs(posixpath.islink(os_helper.TESTFN + "1"), False)
 
-        if support.can_symlink():
-            os.symlink(support.TESTFN + "1", support.TESTFN + "2")
-            self.assertIs(posixpath.islink(support.TESTFN + "2"), True)
-            os.remove(support.TESTFN + "1")
-            self.assertIs(posixpath.islink(support.TESTFN + "2"), True)
-            self.assertIs(posixpath.exists(support.TESTFN + "2"), False)
-            self.assertIs(posixpath.lexists(support.TESTFN + "2"), True)
+        if os_helper.can_symlink():
+            os.symlink(os_helper.TESTFN + "1", os_helper.TESTFN + "2")
+            self.assertIs(posixpath.islink(os_helper.TESTFN + "2"), True)
+            os.remove(os_helper.TESTFN + "1")
+            self.assertIs(posixpath.islink(os_helper.TESTFN + "2"), True)
+            self.assertIs(posixpath.exists(os_helper.TESTFN + "2"), False)
+            self.assertIs(posixpath.lexists(os_helper.TESTFN + "2"), True)
 
-        self.assertIs(posixpath.islink(support.TESTFN + "\udfff"), False)
-        self.assertIs(posixpath.islink(os.fsencode(support.TESTFN) + b"\xff"), False)
-        self.assertIs(posixpath.islink(support.TESTFN + "\x00"), False)
-        self.assertIs(posixpath.islink(os.fsencode(support.TESTFN) + b"\x00"), False)
+        self.assertIs(posixpath.islink(os_helper.TESTFN + "\udfff"), False)
+        self.assertIs(posixpath.islink(os.fsencode(os_helper.TESTFN) + b"\xff"), False)
+        self.assertIs(posixpath.islink(os_helper.TESTFN + "\x00"), False)
+        self.assertIs(posixpath.islink(os.fsencode(os_helper.TESTFN) + b"\x00"), False)
 
     # TODO: RUSTPYTHON
     if os.name == "nt":
@@ -194,7 +195,7 @@ class PosixPathTest(unittest.TestCase):
         self.assertIs(posixpath.ismount('/\x00'), False)
         self.assertIs(posixpath.ismount(b'/\x00'), False)
 
-    @unittest.skipUnless(support.can_symlink(),
+    @unittest.skipUnless(os_helper.can_symlink(),
                          "Test requires symlink support")
     def test_ismount_symlinks(self):
         # Symlinks are never mountpoints.
@@ -253,7 +254,7 @@ class PosixPathTest(unittest.TestCase):
         self.assertEqual(posixpath.expanduser(b"foo"), b"foo")
 
     def test_expanduser_home_envvar(self):
-        with support.EnvironmentVarGuard() as env:
+        with os_helper.EnvironmentVarGuard() as env:
             env['HOME'] = '/home/victor'
             self.assertEqual(posixpath.expanduser("~"), "/home/victor")
 
@@ -289,7 +290,7 @@ class PosixPathTest(unittest.TestCase):
         self.assertIsInstance(posixpath.expanduser(b"~root/"), bytes)
         self.assertIsInstance(posixpath.expanduser(b"~foo/"), bytes)
 
-        with support.EnvironmentVarGuard() as env:
+        with os_helper.EnvironmentVarGuard() as env:
             # expanduser should fall back to using the password database
             del env['HOME']
 
@@ -356,7 +357,7 @@ class PosixPathTest(unittest.TestCase):
             os.symlink(ABSTFN+"1", ABSTFN)
             self.assertEqual(realpath(ABSTFN), ABSTFN+"1")
         finally:
-            support.unlink(ABSTFN)
+            os_helper.unlink(ABSTFN)
 
     @unittest.skipUnless(hasattr(os, "symlink"),
                          "Missing symlink implementation")
@@ -366,7 +367,7 @@ class PosixPathTest(unittest.TestCase):
             os.symlink(posixpath.relpath(ABSTFN+"1"), ABSTFN)
             self.assertEqual(realpath(ABSTFN), ABSTFN+"1")
         finally:
-            support.unlink(ABSTFN)
+            os_helper.unlink(ABSTFN)
 
     @unittest.skipUnless(hasattr(os, "symlink"),
                          "Missing symlink implementation")
@@ -400,15 +401,15 @@ class PosixPathTest(unittest.TestCase):
             self.assertEqual(realpath(ABSTFN+"c"), ABSTFN+"c")
 
             # Test using relative path as well.
-            with support.change_cwd(dirname(ABSTFN)):
+            with os_helper.change_cwd(dirname(ABSTFN)):
                 self.assertEqual(realpath(basename(ABSTFN)), ABSTFN)
         finally:
-            support.unlink(ABSTFN)
-            support.unlink(ABSTFN+"1")
-            support.unlink(ABSTFN+"2")
-            support.unlink(ABSTFN+"y")
-            support.unlink(ABSTFN+"c")
-            support.unlink(ABSTFN+"a")
+            os_helper.unlink(ABSTFN)
+            os_helper.unlink(ABSTFN+"1")
+            os_helper.unlink(ABSTFN+"2")
+            os_helper.unlink(ABSTFN+"y")
+            os_helper.unlink(ABSTFN+"c")
+            os_helper.unlink(ABSTFN+"a")
 
     @unittest.skipUnless(hasattr(os, "symlink"),
                          "Missing symlink implementation")
@@ -421,8 +422,8 @@ class PosixPathTest(unittest.TestCase):
             os.symlink('self/self/self', ABSTFN + '/link')
             self.assertEqual(realpath(ABSTFN + '/link'), ABSTFN)
         finally:
-            support.unlink(ABSTFN + '/self')
-            support.unlink(ABSTFN + '/link')
+            os_helper.unlink(ABSTFN + '/self')
+            os_helper.unlink(ABSTFN + '/link')
             safe_rmdir(ABSTFN)
 
     @unittest.skipUnless(hasattr(os, "symlink"),
@@ -438,11 +439,11 @@ class PosixPathTest(unittest.TestCase):
             self.assertEqual(realpath(ABSTFN + '/%d' % depth), ABSTFN)
 
             # Test using relative path as well.
-            with support.change_cwd(ABSTFN):
+            with os_helper.change_cwd(ABSTFN):
                 self.assertEqual(realpath('%d' % depth), ABSTFN)
         finally:
             for i in range(depth + 1):
-                support.unlink(ABSTFN + '/%d' % i)
+                os_helper.unlink(ABSTFN + '/%d' % i)
             safe_rmdir(ABSTFN)
 
     @unittest.skipUnless(hasattr(os, "symlink"),
@@ -458,10 +459,10 @@ class PosixPathTest(unittest.TestCase):
             os.mkdir(ABSTFN + "/y")
             os.symlink(ABSTFN + "/y", ABSTFN + "/k")
 
-            with support.change_cwd(ABSTFN + "/k"):
+            with os_helper.change_cwd(ABSTFN + "/k"):
                 self.assertEqual(realpath("a"), ABSTFN + "/y/a")
         finally:
-            support.unlink(ABSTFN + "/k")
+            os_helper.unlink(ABSTFN + "/k")
             safe_rmdir(ABSTFN + "/y")
             safe_rmdir(ABSTFN)
 
@@ -485,11 +486,11 @@ class PosixPathTest(unittest.TestCase):
             # Absolute path.
             self.assertEqual(realpath(ABSTFN + "/link-y/.."), ABSTFN + "/k")
             # Relative path.
-            with support.change_cwd(dirname(ABSTFN)):
+            with os_helper.change_cwd(dirname(ABSTFN)):
                 self.assertEqual(realpath(basename(ABSTFN) + "/link-y/.."),
                                  ABSTFN + "/k")
         finally:
-            support.unlink(ABSTFN + "/link-y")
+            os_helper.unlink(ABSTFN + "/link-y")
             safe_rmdir(ABSTFN + "/k/y")
             safe_rmdir(ABSTFN + "/k")
             safe_rmdir(ABSTFN)
@@ -505,12 +506,12 @@ class PosixPathTest(unittest.TestCase):
             os.mkdir(ABSTFN)
             os.mkdir(ABSTFN + "/k")
             os.symlink(ABSTFN, ABSTFN + "link")
-            with support.change_cwd(dirname(ABSTFN)):
+            with os_helper.change_cwd(dirname(ABSTFN)):
                 base = basename(ABSTFN)
                 self.assertEqual(realpath(base + "link"), ABSTFN)
                 self.assertEqual(realpath(base + "link/k"), ABSTFN + "/k")
         finally:
-            support.unlink(ABSTFN + "link")
+            os_helper.unlink(ABSTFN + "link")
             safe_rmdir(ABSTFN + "/k")
             safe_rmdir(ABSTFN)
 
@@ -679,9 +680,9 @@ class PathLikeTests(unittest.TestCase):
     path = posixpath
 
     def setUp(self):
-        self.file_name = support.TESTFN.lower()
-        self.file_path = FakePath(support.TESTFN)
-        self.addCleanup(support.unlink, self.file_name)
+        self.file_name = os_helper.TESTFN.lower()
+        self.file_path = FakePath(os_helper.TESTFN)
+        self.addCleanup(os_helper.unlink, self.file_name)
         with open(self.file_name, 'xb', 0) as file:
             file.write(b"test_posixpath.PathLikeTests")
 

--- a/Lib/test/test_posixpath.py
+++ b/Lib/test/test_posixpath.py
@@ -173,6 +173,10 @@ class PosixPathTest(unittest.TestCase):
         self.assertIs(posixpath.islink(os_helper.TESTFN + "\x00"), False)
         self.assertIs(posixpath.islink(os.fsencode(os_helper.TESTFN) + b"\x00"), False)
 
+    # TODO: RUSTPYTHON
+    if os.name == "nt":
+        test_islink = unittest.expectedFailure(test_islink)
+
     def test_ismount(self):
         self.assertIs(posixpath.ismount("/"), True)
         self.assertIs(posixpath.ismount(b"/"), True)

--- a/Lib/test/test_py_compile.py
+++ b/Lib/test/test_py_compile.py
@@ -9,13 +9,14 @@ import tempfile
 import unittest
 
 from test import support
+from test.support import os_helper
 
 
 def without_source_date_epoch(fxn):
     """Runs function with SOURCE_DATE_EPOCH unset."""
     @functools.wraps(fxn)
     def wrapper(*args, **kwargs):
-        with support.EnvironmentVarGuard() as env:
+        with os_helper.EnvironmentVarGuard() as env:
             env.unset('SOURCE_DATE_EPOCH')
             return fxn(*args, **kwargs)
     return wrapper
@@ -25,7 +26,7 @@ def with_source_date_epoch(fxn):
     """Runs function with SOURCE_DATE_EPOCH set."""
     @functools.wraps(fxn)
     def wrapper(*args, **kwargs):
-        with support.EnvironmentVarGuard() as env:
+        with os_helper.EnvironmentVarGuard() as env:
             env['SOURCE_DATE_EPOCH'] = '123456789'
             return fxn(*args, **kwargs)
     return wrapper
@@ -101,7 +102,7 @@ class PyCompileTestsBase:
         self.assertTrue(os.path.exists(self.cache_path))
 
     def test_cwd(self):
-        with support.change_cwd(self.directory):
+        with os_helper.change_cwd(self.directory):
             py_compile.compile(os.path.basename(self.source_path),
                                os.path.basename(self.pyc_path))
         self.assertTrue(os.path.exists(self.pyc_path))

--- a/Lib/test/test_regrtest.py
+++ b/Lib/test/test_regrtest.py
@@ -945,6 +945,7 @@ class ArgsTestCase(BaseTestCase):
         """)
         self.check_leak(code, 'file descriptors')
 
+    @unittest.skipIf(sys.platform == 'win32', 'TODO: RUSTPYTHON Windows')
     def test_list_tests(self):
         # test --list-tests
         tests = [self.create_test() for i in range(5)]
@@ -952,6 +953,7 @@ class ArgsTestCase(BaseTestCase):
         self.assertEqual(output.rstrip().splitlines(),
                          tests)
 
+    @unittest.skipIf(sys.platform == 'win32', 'TODO: RUSTPYTHON Windows')
     def test_list_cases(self):
         # test --list-cases
         code = textwrap.dedent("""

--- a/Lib/test/test_regrtest.py
+++ b/Lib/test/test_regrtest.py
@@ -19,6 +19,7 @@ import textwrap
 import unittest
 from test import libregrtest
 from test import support
+from test.support import os_helper
 from test.libregrtest import utils
 
 
@@ -166,12 +167,12 @@ class ParseArgsTestCase(unittest.TestCase):
                 self.assertEqual(ns.ignore_tests, ['pattern'])
                 self.checkError([opt], 'expected one argument')
 
-        self.addCleanup(support.unlink, support.TESTFN)
-        with open(support.TESTFN, "w") as fp:
+        self.addCleanup(os_helper.unlink, os_helper.TESTFN)
+        with open(os_helper.TESTFN, "w") as fp:
             print('matchfile1', file=fp)
             print('matchfile2', file=fp)
 
-        filename = os.path.abspath(support.TESTFN)
+        filename = os.path.abspath(os_helper.TESTFN)
         ns = libregrtest._parse_args(['-m', 'match',
                                       '--ignorefile', filename])
         self.assertEqual(ns.ignore_tests,
@@ -188,12 +189,12 @@ class ParseArgsTestCase(unittest.TestCase):
                                       '-m', 'pattern2'])
         self.assertEqual(ns.match_tests, ['pattern1', 'pattern2'])
 
-        self.addCleanup(support.unlink, support.TESTFN)
-        with open(support.TESTFN, "w") as fp:
+        self.addCleanup(os_helper.unlink, os_helper.TESTFN)
+        with open(os_helper.TESTFN, "w") as fp:
             print('matchfile1', file=fp)
             print('matchfile2', file=fp)
 
-        filename = os.path.abspath(support.TESTFN)
+        filename = os.path.abspath(os_helper.TESTFN)
         ns = libregrtest._parse_args(['-m', 'match',
                                       '--matchfile', filename])
         self.assertEqual(ns.match_tests,
@@ -242,7 +243,7 @@ class ParseArgsTestCase(unittest.TestCase):
 
     def test_testdir(self):
         ns = libregrtest._parse_args(['--testdir', 'foo'])
-        self.assertEqual(ns.testdir, os.path.join(support.SAVEDCWD, 'foo'))
+        self.assertEqual(ns.testdir, os.path.join(os_helper.SAVEDCWD, 'foo'))
         self.checkError(['--testdir'], 'expected one argument')
 
     def test_runleaks(self):
@@ -289,7 +290,7 @@ class ParseArgsTestCase(unittest.TestCase):
             with self.subTest(opt=opt):
                 ns = libregrtest._parse_args([opt, 'foo'])
                 self.assertEqual(ns.coverdir,
-                                 os.path.join(support.SAVEDCWD, 'foo'))
+                                 os.path.join(os_helper.SAVEDCWD, 'foo'))
                 self.checkError([opt], 'expected one argument')
 
     def test_nocoverdir(self):
@@ -368,7 +369,7 @@ class BaseTestCase(unittest.TestCase):
         self.testdir = os.path.realpath(os.path.dirname(__file__))
 
         self.tmptestdir = tempfile.mkdtemp()
-        self.addCleanup(support.rmtree, self.tmptestdir)
+        self.addCleanup(os_helper.rmtree, self.tmptestdir)
 
     def create_test(self, name=None, code=None):
         if not name:
@@ -389,7 +390,7 @@ class BaseTestCase(unittest.TestCase):
         name = self.TESTNAME_PREFIX + name
         path = os.path.join(self.tmptestdir, name + '.py')
 
-        self.addCleanup(support.unlink, path)
+        self.addCleanup(os_helper.unlink, path)
         # Use 'x' mode to ensure that we do not override existing tests
         try:
             with open(path, 'x', encoding='utf-8') as fp:
@@ -778,8 +779,8 @@ class ArgsTestCase(BaseTestCase):
         # Write the list of files using a format similar to regrtest output:
         # [1/2] test_1
         # [2/2] test_2
-        filename = support.TESTFN
-        self.addCleanup(support.unlink, filename)
+        filename = os_helper.TESTFN
+        self.addCleanup(os_helper.unlink, filename)
 
         # test format '0:00:00 [2/7] test_opcodes -- test_grammar took 0 sec'
         with open(filename, "w") as fp:
@@ -900,7 +901,7 @@ class ArgsTestCase(BaseTestCase):
         test = self.create_test('huntrleaks', code=code)
 
         filename = 'reflog.txt'
-        self.addCleanup(support.unlink, filename)
+        self.addCleanup(os_helper.unlink, filename)
         output = self.run_tests('--huntrleaks', '3:3:', test,
                                 exitcode=2,
                                 stderr=subprocess.STDOUT)
@@ -1013,8 +1014,8 @@ class ArgsTestCase(BaseTestCase):
         testname = self.create_test(code=code)
 
         # only run a subset
-        filename = support.TESTFN
-        self.addCleanup(support.unlink, filename)
+        filename = os_helper.TESTFN
+        self.addCleanup(os_helper.unlink, filename)
 
         subset = [
             # only ignore the method name
@@ -1054,8 +1055,8 @@ class ArgsTestCase(BaseTestCase):
         self.assertEqual(methods, all_methods)
 
         # only run a subset
-        filename = support.TESTFN
-        self.addCleanup(support.unlink, filename)
+        filename = os_helper.TESTFN
+        self.addCleanup(os_helper.unlink, filename)
 
         subset = [
             # only match the method name

--- a/Lib/test/test_reprlib.py
+++ b/Lib/test/test_reprlib.py
@@ -10,7 +10,8 @@ import importlib
 import importlib.util
 import unittest
 
-from test.support import create_empty_file, verbose
+from test.support import verbose
+from test.support.os_helper import create_empty_file
 from reprlib import repr as r # Don't shadow builtin repr
 from reprlib import Repr
 from reprlib import recursive_repr

--- a/Lib/test/test_resource.py
+++ b/Lib/test/test_resource.py
@@ -2,6 +2,7 @@ import contextlib
 import sys
 import unittest
 from test import support
+from test.support import os_helper
 import time
 
 resource = support.import_module('resource')
@@ -53,7 +54,7 @@ class ResourceTest(unittest.TestCase):
                     limit_set = True
                 except ValueError:
                     limit_set = False
-                f = open(support.TESTFN, "wb")
+                f = open(os_helper.TESTFN, "wb")
                 try:
                     f.write(b"X" * 1024)
                     try:
@@ -79,7 +80,7 @@ class ResourceTest(unittest.TestCase):
             finally:
                 if limit_set:
                     resource.setrlimit(resource.RLIMIT_FSIZE, (cur, max))
-                support.unlink(support.TESTFN)
+                os_helper.unlink(os_helper.TESTFN)
 
     def test_fsize_toobig(self):
         # Be sure that setrlimit is checking for really large values

--- a/Lib/test/test_runpy.py
+++ b/Lib/test/test_runpy.py
@@ -13,8 +13,8 @@ import textwrap
 import unittest
 import warnings
 from test.support import (
-    forget, make_legacy_pyc, unload, verbose, no_tracing,
-    create_empty_file, temp_dir)
+    forget, make_legacy_pyc, unload, verbose, no_tracing)
+from test.support.os_helper import create_empty_file, temp_dir
 from test.support.script_helper import make_script, make_zip_script
 
 

--- a/Lib/test/test_set.py
+++ b/Lib/test/test_set.py
@@ -1,5 +1,6 @@
 import unittest
 from test import support
+from test.support import os_helper
 # import gc
 import weakref
 import operator
@@ -321,15 +322,15 @@ class TestJointOps:
         w = ReprWrapper()
         s = self.thetype([w])
         w.value = s
-        fo = open(support.TESTFN, "w")
+        fo = open(os_helper.TESTFN, "w")
         try:
             fo.write(str(s))
             fo.close()
-            fo = open(support.TESTFN, "r")
+            fo = open(os_helper.TESTFN, "r")
             self.assertEqual(fo.read(), repr(s))
         finally:
             fo.close()
-            support.unlink(support.TESTFN)
+            os_helper.unlink(os_helper.TESTFN)
 
     # TODO: RUSTPYTHON
     @unittest.expectedFailure
@@ -828,14 +829,14 @@ class TestBasicOps:
 
     def test_print(self):
         try:
-            fo = open(support.TESTFN, "w")
+            fo = open(os_helper.TESTFN, "w")
             fo.write(str(self.set))
             fo.close()
-            fo = open(support.TESTFN, "r")
+            fo = open(os_helper.TESTFN, "r")
             self.assertEqual(fo.read(), repr(self.set))
         finally:
             fo.close()
-            support.unlink(support.TESTFN)
+            os_helper.unlink(os_helper.TESTFN)
 
     def test_length(self):
         self.assertEqual(len(self.set), self.length)

--- a/Lib/test/test_shelve.py
+++ b/Lib/test/test_shelve.py
@@ -2,6 +2,7 @@ import unittest
 import shelve
 import glob
 from test import support
+from test.support import os_helper
 from collections.abc import MutableMapping
 from test.test_dbm import dbm_iterator
 
@@ -45,7 +46,7 @@ class TestCase(unittest.TestCase):
 
     def tearDown(self):
         for f in glob.glob(self.fn+"*"):
-            support.unlink(f)
+            os_helper.unlink(f)
 
     def test_close(self):
         d1 = {}
@@ -186,7 +187,7 @@ class TestShelveBase(mapping_tests.BasicTestMappingProtocol):
         self._db = []
         if not self._in_mem:
             for f in glob.glob(self.fn+"*"):
-                support.unlink(f)
+                os_helper.unlink(f)
 
 class TestAsciiFileShelve(TestShelveBase):
     _args={'protocol':0}

--- a/Lib/test/test_shutil.py
+++ b/Lib/test/test_shutil.py
@@ -30,7 +30,8 @@ except ImportError:
     posix = None
 
 from test import support
-from test.support import TESTFN, FakePath
+from test.support import os_helper
+from test.support.os_helper import TESTFN, FakePath
 
 TESTFN2 = TESTFN + "2"
 MACOS = sys.platform.startswith("darwin")
@@ -140,9 +141,9 @@ def supports_file2file_sendfile():
                     return True
     finally:
         if srcname is not None:
-            support.unlink(srcname)
+            os_helper.unlink(srcname)
         if dstname is not None:
-            support.unlink(dstname)
+            os_helper.unlink(dstname)
 
 
 SUPPORTS_SENDFILE = supports_file2file_sendfile()
@@ -193,7 +194,7 @@ class TestShutil(unittest.TestCase):
         self.assertIsInstance(victim, bytes)
         shutil.rmtree(victim)
 
-    @support.skip_unless_symlink
+    @os_helper.skip_unless_symlink
     def test_rmtree_fails_on_symlink(self):
         tmp = self.mkdtemp()
         dir_ = os.path.join(tmp, 'dir')
@@ -212,7 +213,7 @@ class TestShutil(unittest.TestCase):
         self.assertEqual(errors[0][1], link)
         self.assertIsInstance(errors[0][2][1], OSError)
 
-    @support.skip_unless_symlink
+    @os_helper.skip_unless_symlink
     def test_rmtree_works_on_symlinks(self):
         tmp = self.mkdtemp()
         dir1 = os.path.join(tmp, 'dir1')
@@ -324,7 +325,7 @@ class TestShutil(unittest.TestCase):
 
         self.child_file_path = os.path.join(TESTFN, 'a')
         self.child_dir_path = os.path.join(TESTFN, 'b')
-        support.create_empty_file(self.child_file_path)
+        os_helper.create_empty_file(self.child_file_path)
         os.mkdir(self.child_dir_path)
         old_dir_mode = os.stat(TESTFN).st_mode
         old_child_file_mode = os.stat(self.child_file_path).st_mode
@@ -387,7 +388,7 @@ class TestShutil(unittest.TestCase):
         finally:
             os.lstat = orig_lstat
 
-    @support.skip_unless_symlink
+    @os_helper.skip_unless_symlink
     def test_copymode_follow_symlinks(self):
         tmp_dir = self.mkdtemp()
         src = os.path.join(tmp_dir, 'foo')
@@ -420,7 +421,7 @@ class TestShutil(unittest.TestCase):
             self.assertEqual(os.stat(src).st_mode, os.stat(dst).st_mode)
 
     @unittest.skipUnless(hasattr(os, 'lchmod'), 'requires os.lchmod')
-    @support.skip_unless_symlink
+    @os_helper.skip_unless_symlink
     def test_copymode_symlink_to_symlink(self):
         tmp_dir = self.mkdtemp()
         src = os.path.join(tmp_dir, 'foo')
@@ -450,7 +451,7 @@ class TestShutil(unittest.TestCase):
         self.assertEqual(os.stat(src).st_mode, os.stat(dst).st_mode)
 
     @unittest.skipIf(hasattr(os, 'lchmod'), 'requires os.lchmod to be missing')
-    @support.skip_unless_symlink
+    @os_helper.skip_unless_symlink
     def test_copymode_symlink_to_symlink_wo_lchmod(self):
         tmp_dir = self.mkdtemp()
         src = os.path.join(tmp_dir, 'foo')
@@ -463,7 +464,7 @@ class TestShutil(unittest.TestCase):
         os.symlink(dst, dst_link)
         shutil.copymode(src_link, dst_link, follow_symlinks=False)  # silent fail
 
-    @support.skip_unless_symlink
+    @os_helper.skip_unless_symlink
     def test_copystat_symlinks(self):
         tmp_dir = self.mkdtemp()
         src = os.path.join(tmp_dir, 'foo')
@@ -533,7 +534,7 @@ class TestShutil(unittest.TestCase):
         finally:
             os.chflags = old_chflags
 
-    @support.skip_unless_xattr
+    @os_helper.skip_unless_xattr
     def test_copyxattr(self):
         tmp_dir = self.mkdtemp()
         src = os.path.join(tmp_dir, 'foo')
@@ -597,8 +598,8 @@ class TestShutil(unittest.TestCase):
         self.assertEqual(os.getxattr(dst, 'user.the_value'), b'fiddly')
         self.assertEqual(os.getxattr(dstro, 'user.the_value'), b'fiddly')
 
-    @support.skip_unless_symlink
-    @support.skip_unless_xattr
+    @os_helper.skip_unless_symlink
+    @os_helper.skip_unless_xattr
     @unittest.skipUnless(hasattr(os, 'geteuid') and os.geteuid() == 0,
                          'root privileges required')
     def test_copyxattr_symlinks(self):
@@ -622,7 +623,7 @@ class TestShutil(unittest.TestCase):
         shutil._copyxattr(src_link, dst, follow_symlinks=False)
         self.assertEqual(os.getxattr(dst, 'trusted.foo'), b'43')
 
-    @support.skip_unless_symlink
+    @os_helper.skip_unless_symlink
     def test_copy_symlinks(self):
         tmp_dir = self.mkdtemp()
         src = os.path.join(tmp_dir, 'foo')
@@ -645,7 +646,7 @@ class TestShutil(unittest.TestCase):
             self.assertEqual(os.lstat(src_link).st_mode,
                              os.lstat(dst).st_mode)
 
-    @support.skip_unless_symlink
+    @os_helper.skip_unless_symlink
     def test_copy2_symlinks(self):
         tmp_dir = self.mkdtemp()
         src = os.path.join(tmp_dir, 'foo')
@@ -680,7 +681,7 @@ class TestShutil(unittest.TestCase):
         if hasattr(os, 'lchflags') and hasattr(src_link_stat, 'st_flags'):
             self.assertEqual(src_link_stat.st_flags, dst_stat.st_flags)
 
-    @support.skip_unless_xattr
+    @os_helper.skip_unless_xattr
     def test_copy2_xattr(self):
         tmp_dir = self.mkdtemp()
         src = os.path.join(tmp_dir, 'foo')
@@ -693,7 +694,7 @@ class TestShutil(unittest.TestCase):
                 os.getxattr(dst, 'user.foo'))
         os.remove(dst)
 
-    @support.skip_unless_symlink
+    @os_helper.skip_unless_symlink
     def test_copyfile_symlinks(self):
         tmp_dir = self.mkdtemp()
         src = os.path.join(tmp_dir, 'src')
@@ -785,7 +786,7 @@ class TestShutil(unittest.TestCase):
         with self.assertRaises(FileExistsError):
             shutil.copytree(src_dir, dst_dir, dirs_exist_ok=False)
 
-    @support.skip_unless_symlink
+    @os_helper.skip_unless_symlink
     def test_copytree_symlinks(self):
         tmp_dir = self.mkdtemp()
         src_dir = os.path.join(tmp_dir, 'src')
@@ -975,9 +976,9 @@ class TestShutil(unittest.TestCase):
 
         flag = []
         src = tempfile.mkdtemp()
-        self.addCleanup(support.rmtree, src)
+        self.addCleanup(os_helper.rmtree, src)
         dst = tempfile.mktemp()
-        self.addCleanup(support.rmtree, dst)
+        self.addCleanup(os_helper.rmtree, dst)
         with open(os.path.join(src, 'foo'), 'w') as f:
             f.close()
         shutil.copytree(src, dst, copy_function=custom_cpfun)
@@ -1003,7 +1004,7 @@ class TestShutil(unittest.TestCase):
         finally:
             shutil.rmtree(TESTFN, ignore_errors=True)
 
-    @support.skip_unless_symlink
+    @os_helper.skip_unless_symlink
     def test_dont_copy_file_onto_symlink_to_itself(self):
         # bug 851123.
         os.mkdir(TESTFN)
@@ -1023,7 +1024,7 @@ class TestShutil(unittest.TestCase):
         finally:
             shutil.rmtree(TESTFN, ignore_errors=True)
 
-    @support.skip_unless_symlink
+    @os_helper.skip_unless_symlink
     def test_rmtree_on_symlink(self):
         # bug 1669.
         os.mkdir(TESTFN)
@@ -1067,7 +1068,7 @@ class TestShutil(unittest.TestCase):
             os.remove(TESTFN)
 
     @unittest.skipUnless(hasattr(os, "mkfifo"), 'requires os.mkfifo()')
-    @support.skip_unless_symlink
+    @os_helper.skip_unless_symlink
     def test_copytree_named_pipe(self):
         os.mkdir(TESTFN)
         try:
@@ -1106,7 +1107,7 @@ class TestShutil(unittest.TestCase):
         shutil.copytree(src_dir, dst_dir, copy_function=_copy)
         self.assertEqual(len(copied), 2)
 
-    @support.skip_unless_symlink
+    @os_helper.skip_unless_symlink
     def test_copytree_dangling_symlinks(self):
 
         # a dangling symlink raises an error at the end
@@ -1127,7 +1128,7 @@ class TestShutil(unittest.TestCase):
         shutil.copytree(src_dir, dst_dir, symlinks=True)
         self.assertIn('test.txt', os.listdir(dst_dir))
 
-    @support.skip_unless_symlink
+    @os_helper.skip_unless_symlink
     def test_copytree_symlink_dir(self):
         src_dir = self.mkdtemp()
         dst_dir = os.path.join(self.mkdtemp(), 'destination')
@@ -1192,7 +1193,7 @@ class TestShutil(unittest.TestCase):
         work_dir = os.path.dirname(tmpdir2)
         rel_base_name = os.path.join(os.path.basename(tmpdir2), 'archive')
 
-        with support.change_cwd(work_dir):
+        with os_helper.change_cwd(work_dir):
             base_name = os.path.abspath(rel_base_name)
             tarball = make_archive(rel_base_name, 'gztar', root_dir, '.')
 
@@ -1206,7 +1207,7 @@ class TestShutil(unittest.TestCase):
                                    './file1', './file2', './sub/file3'])
 
         # trying an uncompressed one
-        with support.change_cwd(work_dir):
+        with os_helper.change_cwd(work_dir):
             tarball = make_archive(rel_base_name, 'tar', root_dir, '.')
         self.assertEqual(tarball, base_name + '.tar')
         self.assertTrue(os.path.isfile(tarball))
@@ -1281,7 +1282,7 @@ class TestShutil(unittest.TestCase):
         work_dir = os.path.dirname(tmpdir2)
         rel_base_name = os.path.join(os.path.basename(tmpdir2), 'archive')
 
-        with support.change_cwd(work_dir):
+        with os_helper.change_cwd(work_dir):
             base_name = os.path.abspath(rel_base_name)
             res = make_archive(rel_base_name, 'zip', root_dir)
 
@@ -1294,7 +1295,7 @@ class TestShutil(unittest.TestCase):
                      'dist/file1', 'dist/file2', 'dist/sub/file3',
                      'outer'])
 
-        with support.change_cwd(work_dir):
+        with os_helper.change_cwd(work_dir):
             base_name = os.path.abspath(rel_base_name)
             res = make_archive(rel_base_name, 'zip', root_dir, base_dir)
 
@@ -1346,7 +1347,7 @@ class TestShutil(unittest.TestCase):
 
         # now check the ZIP file using `unzip -t`
         zip_cmd = ['unzip', '-t', archive]
-        with support.change_cwd(root_dir):
+        with os_helper.change_cwd(root_dir):
             try:
                 subprocess.check_output(zip_cmd, stderr=subprocess.STDOUT)
             except subprocess.CalledProcessError as exc:
@@ -1396,7 +1397,7 @@ class TestShutil(unittest.TestCase):
         base_name = os.path.join(self.mkdtemp(), 'archive')
         group = grp.getgrgid(0)[0]
         owner = pwd.getpwuid(0)[0]
-        with support.change_cwd(root_dir):
+        with os_helper.change_cwd(root_dir):
             archive_name = make_archive(base_name, 'gztar', root_dir, 'dist',
                                         owner=owner, group=group)
 
@@ -1430,7 +1431,7 @@ class TestShutil(unittest.TestCase):
     def test_make_tarfile_in_curdir(self):
         # Issue #21280
         root_dir = self.mkdtemp()
-        with support.change_cwd(root_dir):
+        with os_helper.change_cwd(root_dir):
             self.assertEqual(make_archive('test', 'tar'), 'test.tar')
             self.assertTrue(os.path.isfile('test.tar'))
 
@@ -1438,7 +1439,7 @@ class TestShutil(unittest.TestCase):
     def test_make_zipfile_in_curdir(self):
         # Issue #21280
         root_dir = self.mkdtemp()
-        with support.change_cwd(root_dir):
+        with os_helper.change_cwd(root_dir):
             self.assertEqual(make_archive('test', 'zip'), 'test.zip')
             self.assertTrue(os.path.isfile('test.zip'))
 
@@ -1695,18 +1696,18 @@ class TestWhich(unittest.TestCase):
         # that exists, it should be returned.
         base_dir, tail_dir = os.path.split(self.dir)
         relpath = os.path.join(tail_dir, self.file)
-        with support.change_cwd(path=base_dir):
+        with os_helper.change_cwd(path=base_dir):
             rv = shutil.which(relpath, path=self.temp_dir)
             self.assertEqual(rv, relpath)
         # But it shouldn't be searched in PATH directories (issue #16957).
-        with support.change_cwd(path=self.dir):
+        with os_helper.change_cwd(path=self.dir):
             rv = shutil.which(relpath, path=base_dir)
             self.assertIsNone(rv)
 
     def test_cwd(self):
         # Issue #16957
         base_dir = os.path.dirname(self.dir)
-        with support.change_cwd(path=self.dir):
+        with os_helper.change_cwd(path=self.dir):
             rv = shutil.which(self.file, path=base_dir)
             if sys.platform == "win32":
                 # Windows: current directory implicitly on PATH
@@ -1727,7 +1728,7 @@ class TestWhich(unittest.TestCase):
 
     def test_relative_path(self):
         base_dir, tail_dir = os.path.split(self.dir)
-        with support.change_cwd(path=base_dir):
+        with os_helper.change_cwd(path=base_dir):
             rv = shutil.which(self.file, path=tail_dir)
             self.assertEqual(rv, os.path.join(tail_dir, self.file))
 
@@ -1745,19 +1746,19 @@ class TestWhich(unittest.TestCase):
         self.assertEqual(rv, self.temp_file.name[:-4] + self.ext)
 
     def test_environ_path(self):
-        with support.EnvironmentVarGuard() as env:
+        with os_helper.EnvironmentVarGuard() as env:
             env['PATH'] = self.env_path
             rv = shutil.which(self.file)
             self.assertEqual(rv, self.temp_file.name)
 
     def test_environ_path_empty(self):
         # PATH='': no match
-        with support.EnvironmentVarGuard() as env:
+        with os_helper.EnvironmentVarGuard() as env:
             env['PATH'] = ''
             with unittest.mock.patch('os.confstr', return_value=self.dir, \
                                      create=True), \
                  support.swap_attr(os, 'defpath', self.dir), \
-                 support.change_cwd(self.dir):
+                 os_helper.change_cwd(self.dir):
                 rv = shutil.which(self.file)
                 self.assertIsNone(rv)
 
@@ -1770,7 +1771,7 @@ class TestWhich(unittest.TestCase):
             expected_cwd = os.path.join(curdir, expected_cwd)
 
         # PATH=':': explicitly looks in the current directory
-        with support.EnvironmentVarGuard() as env:
+        with os_helper.EnvironmentVarGuard() as env:
             env['PATH'] = os.pathsep
             with unittest.mock.patch('os.confstr', return_value=self.dir, \
                                      create=True), \
@@ -1779,12 +1780,12 @@ class TestWhich(unittest.TestCase):
                 self.assertIsNone(rv)
 
                 # look in current directory
-                with support.change_cwd(self.dir):
+                with os_helper.change_cwd(self.dir):
                     rv = shutil.which(self.file)
                     self.assertEqual(rv, expected_cwd)
 
     def test_environ_path_missing(self):
-        with support.EnvironmentVarGuard() as env:
+        with os_helper.EnvironmentVarGuard() as env:
             env.pop('PATH', None)
 
             # without confstr
@@ -1803,14 +1804,14 @@ class TestWhich(unittest.TestCase):
 
     def test_empty_path(self):
         base_dir = os.path.dirname(self.dir)
-        with support.change_cwd(path=self.dir), \
-             support.EnvironmentVarGuard() as env:
+        with os_helper.change_cwd(path=self.dir), \
+             os_helper.EnvironmentVarGuard() as env:
             env['PATH'] = self.env_path
             rv = shutil.which(self.file, path='')
             self.assertIsNone(rv)
 
     def test_empty_path_no_PATH(self):
-        with support.EnvironmentVarGuard() as env:
+        with os_helper.EnvironmentVarGuard() as env:
             env.pop('PATH', None)
             rv = shutil.which(self.file)
             self.assertIsNone(rv)
@@ -1827,7 +1828,7 @@ class TestWhich(unittest.TestCase):
         program = os.path.basename(temp_filexyz.name)
         program = os.path.splitext(program)[0]
 
-        with support.EnvironmentVarGuard() as env:
+        with os_helper.EnvironmentVarGuard() as env:
             env['PATHEXT'] = ext
             rv = shutil.which(program, path=self.temp_dir)
             self.assertEqual(rv, temp_filexyz.name)
@@ -1967,7 +1968,7 @@ class TestMove(unittest.TestCase):
         finally:
             shutil.rmtree(TESTFN, ignore_errors=True)
 
-    @support.skip_unless_symlink
+    @os_helper.skip_unless_symlink
     @mock_rename
     def test_move_file_symlink(self):
         dst = os.path.join(self.src_dir, 'bar')
@@ -1976,7 +1977,7 @@ class TestMove(unittest.TestCase):
         self.assertTrue(os.path.islink(self.dst_file))
         self.assertTrue(os.path.samefile(self.src_file, self.dst_file))
 
-    @support.skip_unless_symlink
+    @os_helper.skip_unless_symlink
     @mock_rename
     def test_move_file_symlink_to_dir(self):
         filename = "bar"
@@ -1987,7 +1988,7 @@ class TestMove(unittest.TestCase):
         self.assertTrue(os.path.islink(final_link))
         self.assertTrue(os.path.samefile(self.src_file, final_link))
 
-    @support.skip_unless_symlink
+    @os_helper.skip_unless_symlink
     @mock_rename
     def test_move_dangling_symlink(self):
         src = os.path.join(self.src_dir, 'baz')
@@ -1998,7 +1999,7 @@ class TestMove(unittest.TestCase):
         self.assertTrue(os.path.islink(dst_link))
         self.assertEqual(os.path.realpath(src), os.path.realpath(dst_link))
 
-    @support.skip_unless_symlink
+    @os_helper.skip_unless_symlink
     @mock_rename
     def test_move_dir_symlink(self):
         src = os.path.join(self.src_dir, 'baz')
@@ -2032,8 +2033,8 @@ class TestMove(unittest.TestCase):
         moved = []
         def _copy(src, dst):
             moved.append((src, dst))
-        support.create_empty_file(os.path.join(self.src_dir, 'child'))
-        support.create_empty_file(os.path.join(self.src_dir, 'child1'))
+        os_helper.create_empty_file(os.path.join(self.src_dir, 'child'))
+        os_helper.create_empty_file(os.path.join(self.src_dir, 'child1'))
         shutil.move(self.src_dir, self.dst_dir, copy_function=_copy)
         self.assertEqual(len(moved), 3)
 
@@ -2171,11 +2172,11 @@ class TestCopyFileObj(unittest.TestCase):
 
     @classmethod
     def tearDownClass(cls):
-        support.unlink(TESTFN)
-        support.unlink(TESTFN2)
+        os_helper.unlink(TESTFN)
+        os_helper.unlink(TESTFN2)
 
     def tearDown(self):
-        support.unlink(TESTFN2)
+        os_helper.unlink(TESTFN2)
 
     @contextlib.contextmanager
     def get_files(self):
@@ -2220,7 +2221,7 @@ class TestCopyFileObj(unittest.TestCase):
         with tempfile.NamedTemporaryFile(delete=False) as f:
             f.write(b'foo')
         fname = f.name
-        self.addCleanup(support.unlink, fname)
+        self.addCleanup(os_helper.unlink, fname)
         with unittest.mock.patch("shutil._copyfileobj_readinto") as m:
             shutil.copyfile(fname, TESTFN2)
         self.assertEqual(m.call_args[0][2], 3)
@@ -2229,7 +2230,7 @@ class TestCopyFileObj(unittest.TestCase):
         with tempfile.NamedTemporaryFile(delete=False) as f:
             pass
         fname = f.name
-        self.addCleanup(support.unlink, fname)
+        self.addCleanup(os_helper.unlink, fname)
         with unittest.mock.patch("shutil._copyfileobj_readinto") as m:
             shutil.copyfile(fname, TESTFN2)
         assert not m.called
@@ -2251,10 +2252,10 @@ class _ZeroCopyFileTest(object):
 
     @classmethod
     def tearDownClass(cls):
-        support.unlink(TESTFN)
+        os_helper.unlink(TESTFN)
 
     def tearDown(self):
-        support.unlink(TESTFN2)
+        os_helper.unlink(TESTFN2)
 
     @contextlib.contextmanager
     def get_files(self):
@@ -2300,8 +2301,8 @@ class _ZeroCopyFileTest(object):
     def test_empty_file(self):
         srcname = TESTFN + 'src'
         dstname = TESTFN + 'dst'
-        self.addCleanup(lambda: support.unlink(srcname))
-        self.addCleanup(lambda: support.unlink(dstname))
+        self.addCleanup(lambda: os_helper.unlink(srcname))
+        self.addCleanup(lambda: os_helper.unlink(dstname))
         with open(srcname, "wb"):
             pass
 
@@ -2427,9 +2428,9 @@ class TestZeroCopySendfile(_ZeroCopyFileTest, unittest.TestCase):
             # sendfile() are the same.
             self.assertEqual(blocksize, os.path.getsize(TESTFN))
             # ...unless we're dealing with a small file.
-            support.unlink(TESTFN2)
+            os_helper.unlink(TESTFN2)
             write_file(TESTFN2, b"hello", binary=True)
-            self.addCleanup(support.unlink, TESTFN2 + '3')
+            self.addCleanup(os_helper.unlink, TESTFN2 + '3')
             self.assertRaises(ZeroDivisionError,
                               shutil.copyfile, TESTFN2, TESTFN2 + '3')
             blocksize = m.call_args[0][3]
@@ -2479,20 +2480,20 @@ class TermsizeTests(unittest.TestCase):
     def test_os_environ_first(self):
         "Check if environment variables have precedence"
 
-        with support.EnvironmentVarGuard() as env:
+        with os_helper.EnvironmentVarGuard() as env:
             env['COLUMNS'] = '777'
             del env['LINES']
             size = shutil.get_terminal_size()
         self.assertEqual(size.columns, 777)
 
-        with support.EnvironmentVarGuard() as env:
+        with os_helper.EnvironmentVarGuard() as env:
             del env['COLUMNS']
             env['LINES'] = '888'
             size = shutil.get_terminal_size()
         self.assertEqual(size.lines, 888)
 
     def test_bad_environ(self):
-        with support.EnvironmentVarGuard() as env:
+        with os_helper.EnvironmentVarGuard() as env:
             env['COLUMNS'] = 'xxx'
             env['LINES'] = 'yyy'
             size = shutil.get_terminal_size()
@@ -2516,7 +2517,7 @@ class TermsizeTests(unittest.TestCase):
             self.skipTest("stty invocation failed")
         expected = (int(size[1]), int(size[0])) # reversed order
 
-        with support.EnvironmentVarGuard() as env:
+        with os_helper.EnvironmentVarGuard() as env:
             del env['LINES']
             del env['COLUMNS']
             actual = shutil.get_terminal_size()
@@ -2524,7 +2525,7 @@ class TermsizeTests(unittest.TestCase):
         self.assertEqual(expected, actual)
 
     def test_fallback(self):
-        with support.EnvironmentVarGuard() as env:
+        with os_helper.EnvironmentVarGuard() as env:
             del env['LINES']
             del env['COLUMNS']
 

--- a/Lib/test/test_signal.py
+++ b/Lib/test/test_signal.py
@@ -10,6 +10,7 @@ import threading
 import time
 import unittest
 from test import support
+from test.support import os_helper
 from test.support.script_helper import assert_python_ok, spawn_python
 try:
     import _testcapi
@@ -171,7 +172,7 @@ class WakeupFDTests(unittest.TestCase):
             signal.set_wakeup_fd(signal.SIGINT, False)
 
     def test_invalid_fd(self):
-        fd = support.make_bad_fd()
+        fd = os_helper.make_bad_fd()
         self.assertRaises((ValueError, OSError),
                           signal.set_wakeup_fd, fd)
 

--- a/Lib/test/test_socket.py
+++ b/Lib/test/test_socket.py
@@ -1,5 +1,6 @@
 import unittest
 from test import support
+from test.support import os_helper
 
 import errno
 import io
@@ -645,7 +646,7 @@ class UnixSocketTestBase(SocketTestBase):
     def bindSock(self, sock):
         path = tempfile.mktemp(dir=self.dir_path)
         support.bind_unix_socket(sock, path)
-        self.addCleanup(support.unlink, path)
+        self.addCleanup(os_helper.unlink, path)
 
 class UnixStreamBase(UnixSocketTestBase):
     """Base class for Unix-domain SOCK_STREAM tests."""
@@ -1835,14 +1836,14 @@ class GeneralModuleTests(unittest.TestCase):
     def test_socket_fileno_requires_valid_fd(self):
         WSAENOTSOCK = 10038
         with self.assertRaises(OSError) as cm:
-            socket.socket(fileno=support.make_bad_fd())
+            socket.socket(fileno=os_helper.make_bad_fd())
         self.assertIn(cm.exception.errno, (errno.EBADF, WSAENOTSOCK))
 
         with self.assertRaises(OSError) as cm:
             socket.socket(
                 socket.AF_INET,
                 socket.SOCK_STREAM,
-                fileno=support.make_bad_fd())
+                fileno=os_helper.make_bad_fd())
         self.assertIn(cm.exception.errno, (errno.EBADF, WSAENOTSOCK))
 
     def test_socket_fileno_requires_socket_fd(self):
@@ -5136,16 +5137,16 @@ class TestUnixDomain(unittest.TestCase):
 
     def testStrAddr(self):
         # Test binding to and retrieving a normal string pathname.
-        path = os.path.abspath(support.TESTFN)
+        path = os.path.abspath(os_helper.TESTFN)
         self.bind(self.sock, path)
-        self.addCleanup(support.unlink, path)
+        self.addCleanup(os_helper.unlink, path)
         self.assertEqual(self.sock.getsockname(), path)
 
     def testBytesAddr(self):
         # Test binding to a bytes pathname.
-        path = os.path.abspath(support.TESTFN)
+        path = os.path.abspath(os_helper.TESTFN)
         self.bind(self.sock, self.encoded(path))
-        self.addCleanup(support.unlink, path)
+        self.addCleanup(os_helper.unlink, path)
         self.assertEqual(self.sock.getsockname(), path)
 
     # TODO: RUSTPYTHON, surrogateescape
@@ -5156,17 +5157,17 @@ class TestUnixDomain(unittest.TestCase):
         path = os.path.abspath(support.TESTFN_UNICODE)
         b = self.encoded(path)
         self.bind(self.sock, b.decode("ascii", "surrogateescape"))
-        self.addCleanup(support.unlink, path)
+        self.addCleanup(os_helper.unlink, path)
         self.assertEqual(self.sock.getsockname(), path)
 
     def testUnencodableAddr(self):
         # Test binding to a pathname that cannot be encoded in the
         # file system encoding.
-        if support.TESTFN_UNENCODABLE is None:
+        if os_helper.TESTFN_UNENCODABLE is None:
             self.skipTest("No unencodable filename available")
-        path = os.path.abspath(support.TESTFN_UNENCODABLE)
+        path = os.path.abspath(os_helper.TESTFN_UNENCODABLE)
         self.bind(self.sock, path)
-        self.addCleanup(support.unlink, path)
+        self.addCleanup(os_helper.unlink, path)
         self.assertEqual(self.sock.getsockname(), path)
 
 
@@ -5641,16 +5642,16 @@ class SendfileUsingSendTest(ThreadedTCPSocketTest):
 
         chunk = b"".join([random.choice(string.ascii_letters).encode()
                           for i in range(cls.BUFSIZE)])
-        with open(support.TESTFN, 'wb') as f:
+        with open(os_helper.TESTFN, 'wb') as f:
             for csize in chunks(cls.FILESIZE, cls.BUFSIZE):
                 f.write(chunk)
-        with open(support.TESTFN, 'rb') as f:
+        with open(os_helper.TESTFN, 'rb') as f:
             cls.FILEDATA = f.read()
             assert len(cls.FILEDATA) == cls.FILESIZE
 
     @classmethod
     def tearDownClass(cls):
-        support.unlink(support.TESTFN)
+        os_helper.unlink(os_helper.TESTFN)
 
     def accept_conn(self):
         self.serv.settimeout(MAIN_TIMEOUT)
@@ -5677,7 +5678,7 @@ class SendfileUsingSendTest(ThreadedTCPSocketTest):
 
     def _testRegularFile(self):
         address = self.serv.getsockname()
-        file = open(support.TESTFN, 'rb')
+        file = open(os_helper.TESTFN, 'rb')
         with socket.create_connection(address) as sock, file as file:
             meth = self.meth_from_sock(sock)
             sent = meth(file)
@@ -5712,9 +5713,9 @@ class SendfileUsingSendTest(ThreadedTCPSocketTest):
 
     def _testEmptyFileSend(self):
         address = self.serv.getsockname()
-        filename = support.TESTFN + "2"
+        filename = os_helper.TESTFN + "2"
         with open(filename, 'wb'):
-            self.addCleanup(support.unlink, filename)
+            self.addCleanup(os_helper.unlink, filename)
         file = open(filename, 'rb')
         with socket.create_connection(address) as sock, file as file:
             meth = self.meth_from_sock(sock)
@@ -5731,7 +5732,7 @@ class SendfileUsingSendTest(ThreadedTCPSocketTest):
 
     def _testOffset(self):
         address = self.serv.getsockname()
-        file = open(support.TESTFN, 'rb')
+        file = open(os_helper.TESTFN, 'rb')
         with socket.create_connection(address) as sock, file as file:
             meth = self.meth_from_sock(sock)
             sent = meth(file, offset=5000)
@@ -5748,7 +5749,7 @@ class SendfileUsingSendTest(ThreadedTCPSocketTest):
 
     def _testCount(self):
         address = self.serv.getsockname()
-        file = open(support.TESTFN, 'rb')
+        file = open(os_helper.TESTFN, 'rb')
         with socket.create_connection(address, timeout=2) as sock, file as file:
             count = 5000007
             meth = self.meth_from_sock(sock)
@@ -5768,7 +5769,7 @@ class SendfileUsingSendTest(ThreadedTCPSocketTest):
 
     def _testCountSmall(self):
         address = self.serv.getsockname()
-        file = open(support.TESTFN, 'rb')
+        file = open(os_helper.TESTFN, 'rb')
         with socket.create_connection(address, timeout=2) as sock, file as file:
             count = 1
             meth = self.meth_from_sock(sock)
@@ -5787,7 +5788,7 @@ class SendfileUsingSendTest(ThreadedTCPSocketTest):
 
     def _testCountWithOffset(self):
         address = self.serv.getsockname()
-        file = open(support.TESTFN, 'rb')
+        file = open(os_helper.TESTFN, 'rb')
         with socket.create_connection(address, timeout=2) as sock, file as file:
             count = 100007
             meth = self.meth_from_sock(sock)
@@ -5806,7 +5807,7 @@ class SendfileUsingSendTest(ThreadedTCPSocketTest):
 
     def _testNonBlocking(self):
         address = self.serv.getsockname()
-        file = open(support.TESTFN, 'rb')
+        file = open(os_helper.TESTFN, 'rb')
         with socket.create_connection(address) as sock, file as file:
             sock.setblocking(False)
             meth = self.meth_from_sock(sock)
@@ -5822,7 +5823,7 @@ class SendfileUsingSendTest(ThreadedTCPSocketTest):
 
     def _testWithTimeout(self):
         address = self.serv.getsockname()
-        file = open(support.TESTFN, 'rb')
+        file = open(os_helper.TESTFN, 'rb')
         with socket.create_connection(address, timeout=2) as sock, file as file:
             meth = self.meth_from_sock(sock)
             sent = meth(file)
@@ -5839,7 +5840,7 @@ class SendfileUsingSendTest(ThreadedTCPSocketTest):
 
     def _testWithTimeoutTriggeredSend(self):
         address = self.serv.getsockname()
-        with open(support.TESTFN, 'rb') as file:
+        with open(os_helper.TESTFN, 'rb') as file:
             with socket.create_connection(address) as sock:
                 sock.settimeout(0.01)
                 meth = self.meth_from_sock(sock)
@@ -5855,17 +5856,17 @@ class SendfileUsingSendTest(ThreadedTCPSocketTest):
         pass
 
     def test_errors(self):
-        with open(support.TESTFN, 'rb') as file:
+        with open(os_helper.TESTFN, 'rb') as file:
             with socket.socket(type=socket.SOCK_DGRAM) as s:
                 meth = self.meth_from_sock(s)
                 self.assertRaisesRegex(
                     ValueError, "SOCK_STREAM", meth, file)
-        with open(support.TESTFN, 'rt') as file:
+        with open(os_helper.TESTFN, 'rt') as file:
             with socket.socket() as s:
                 meth = self.meth_from_sock(s)
                 self.assertRaisesRegex(
                     ValueError, "binary mode", meth, file)
-        with open(support.TESTFN, 'rb') as file:
+        with open(os_helper.TESTFN, 'rb') as file:
             with socket.socket() as s:
                 meth = self.meth_from_sock(s)
                 self.assertRaisesRegex(TypeError, "positive integer",

--- a/Lib/test/test_socketserver.py
+++ b/Lib/test/test_socketserver.py
@@ -14,7 +14,7 @@ import unittest
 import socketserver
 
 import test.support
-from test.support import reap_children, reap_threads, verbose
+from test.support import reap_children, reap_threads, verbose, os_helper
 
 
 test.support.requires("network")
@@ -306,7 +306,7 @@ class ErrorHandlerTest(unittest.TestCase):
     KeyboardInterrupt are not passed."""
 
     def tearDown(self):
-        test.support.unlink(test.support.TESTFN)
+        test.os_helper.unlink(test.os_helper.TESTFN)
 
     def test_sync_handled(self):
         BaseErrorTestServer(ValueError)
@@ -336,7 +336,7 @@ class ErrorHandlerTest(unittest.TestCase):
         self.check_result(handled=False)
 
     def check_result(self, handled):
-        with open(test.support.TESTFN) as log:
+        with open(test.os_helper.TESTFN) as log:
             expected = 'Handler called\n' + 'Error handled\n' * handled
             self.assertEqual(log.read(), expected)
 
@@ -354,7 +354,7 @@ class BaseErrorTestServer(socketserver.TCPServer):
         self.wait_done()
 
     def handle_error(self, request, client_address):
-        with open(test.support.TESTFN, 'a') as log:
+        with open(test.os_helper.TESTFN, 'a') as log:
             log.write('Error handled\n')
 
     def wait_done(self):
@@ -363,7 +363,7 @@ class BaseErrorTestServer(socketserver.TCPServer):
 
 class BadHandler(socketserver.BaseRequestHandler):
     def handle(self):
-        with open(test.support.TESTFN, 'a') as log:
+        with open(test.os_helper.TESTFN, 'a') as log:
             log.write('Handler called\n')
         raise self.server.exception('Test error')
 

--- a/Lib/test/test_stat.py
+++ b/Lib/test/test_stat.py
@@ -2,8 +2,9 @@ import unittest
 import os
 import socket
 import sys
-from test.support import (TESTFN, import_fresh_module,
+from test.support import (import_fresh_module,
                           skip_unless_bind_unix_socket)
+from test.support.os_helper import TESTFN
 
 c_stat = import_fresh_module('stat', fresh=['_stat'])
 py_stat = import_fresh_module('stat', blocked=['_stat'])

--- a/Lib/test/test_subprocess.py
+++ b/Lib/test/test_subprocess.py
@@ -18,7 +18,8 @@ import shutil
 import threading
 import gc
 import textwrap
-from test.support import FakePath
+from test.support import os_helper
+from test.support.os_helper import FakePath
 
 try:
     import _testcapi
@@ -382,7 +383,7 @@ class ProcessTestCase(BaseTestCase):
         # Normalize an expected cwd (for Tru64 support).
         # We can't use os.path.realpath since it doesn't expand Tru64 {memb}
         # strings.  See bug #1063571.
-        with support.change_cwd(cwd):
+        with os_helper.change_cwd(cwd):
             return os.getcwd()
 
     # For use in the test_cwd* tests below.
@@ -433,7 +434,7 @@ class ProcessTestCase(BaseTestCase):
         # is relative.
         python_dir, python_base = self._split_python_path()
         rel_python = os.path.join(os.curdir, python_base)
-        with support.temp_cwd() as wrong_dir:
+        with os_helper.temp_cwd() as wrong_dir:
             # Before calling with the correct cwd, confirm that the call fails
             # without cwd and with the wrong cwd.
             self.assertRaises(FileNotFoundError, subprocess.Popen,
@@ -450,7 +451,7 @@ class ProcessTestCase(BaseTestCase):
         python_dir, python_base = self._split_python_path()
         rel_python = os.path.join(os.curdir, python_base)
         doesntexist = "somethingyoudonthave"
-        with support.temp_cwd() as wrong_dir:
+        with os_helper.temp_cwd() as wrong_dir:
             # Before calling with the correct cwd, confirm that the call fails
             # without cwd and with the wrong cwd.
             self.assertRaises(FileNotFoundError, subprocess.Popen,
@@ -468,7 +469,7 @@ class ProcessTestCase(BaseTestCase):
         python_dir, python_base = self._split_python_path()
         abs_python = os.path.join(python_dir, python_base)
         rel_python = os.path.join(os.curdir, python_base)
-        with support.temp_dir() as wrong_dir:
+        with os_helper.temp_dir() as wrong_dir:
             # Before calling with an absolute path, confirm that using a
             # relative path fails.
             self.assertRaises(FileNotFoundError, subprocess.Popen,
@@ -1102,7 +1103,7 @@ class ProcessTestCase(BaseTestCase):
         try:
             for i in range(max_handles):
                 try:
-                    tmpfile = os.path.join(tmpdir, support.TESTFN)
+                    tmpfile = os.path.join(tmpdir, os_helper.TESTFN)
                     handles.append(os.open(tmpfile, os.O_WRONLY|os.O_CREAT))
                 except OSError as e:
                     if e.errno != errno.EMFILE:

--- a/Lib/test/test_support.py
+++ b/Lib/test/test_support.py
@@ -642,14 +642,8 @@ class TestSupport(unittest.TestCase):
 
     def check_print_warning(self, msg, expected):
         stderr = io.StringIO()
-
-        old_stderr = sys.__stderr__
-        try:
-            sys.__stderr__ = stderr
+        with support.swap_attr(support.print_warning, 'orig_stderr', stderr):
             support.print_warning(msg)
-        finally:
-            sys.__stderr__ = old_stderr
-
         self.assertEqual(stderr.getvalue(), expected)
 
     def test_print_warning(self):

--- a/Lib/test/test_sys.py
+++ b/Lib/test/test_sys.py
@@ -1,4 +1,5 @@
 from test import support
+from test.support import os_helper
 from test.support.script_helper import assert_python_ok, assert_python_failure
 import builtins
 import codecs
@@ -651,7 +652,7 @@ class SysModuleTest(unittest.TestCase):
         out = p.communicate()[0].strip()
         self.assertEqual(out, b'\xbd')
 
-    @unittest.skipUnless(test.support.FS_NONASCII,
+    @unittest.skipUnless(os_helper.FS_NONASCII,
                          'requires OS support of non-ASCII encodings')
     @unittest.skipUnless(sys.getfilesystemencoding() == locale.getpreferredencoding(False),
                          'requires FS encoding to match locale')
@@ -660,10 +661,10 @@ class SysModuleTest(unittest.TestCase):
 
         env["PYTHONIOENCODING"] = ""
         p = subprocess.Popen([sys.executable, "-c",
-                                'print(%a)' % test.support.FS_NONASCII],
+                                'print(%a)' % os_helper.FS_NONASCII],
                                 stdout=subprocess.PIPE, env=env)
         out = p.communicate()[0].strip()
-        self.assertEqual(out, os.fsencode(test.support.FS_NONASCII))
+        self.assertEqual(out, os.fsencode(os_helper.FS_NONASCII))
 
     @unittest.skipIf(sys.base_prefix != sys.prefix,
                      'Test is not venv-compatible')

--- a/Lib/test/test_sysconfig.py
+++ b/Lib/test/test_sysconfig.py
@@ -5,9 +5,10 @@ import subprocess
 import shutil
 from copy import copy
 
-from test.support import (import_module, TESTFN, unlink, check_warnings,
-                          captured_stdout, skip_unless_symlink, change_cwd,
-                          PythonSymlink)
+from test.support import (import_module, check_warnings,
+                          captured_stdout, PythonSymlink)
+from test.support.os_helper import (TESTFN, unlink, skip_unless_symlink,
+                                    change_cwd)
 
 import sysconfig
 from sysconfig import (get_paths, get_platform, get_config_vars,

--- a/Lib/test/test_tarfile.py
+++ b/Lib/test/test_tarfile.py
@@ -11,7 +11,7 @@ import unittest.mock
 import tarfile
 
 from test import support
-from test.support import script_helper, requires_hashdigest
+from test.support import script_helper, requires_hashdigest, os_helper
 
 # Check for our compression modules.
 try:
@@ -30,7 +30,7 @@ except ImportError:
 def sha256sum(data):
     return sha256(data).hexdigest()
 
-TEMPDIR = os.path.abspath(support.TESTFN) + "-tardir"
+TEMPDIR = os.path.abspath(os_helper.TESTFN) + "-tardir"
 tarextdir = TEMPDIR + '-extract-test'
 tarname = support.findfile("testtar.tar")
 gzipname = os.path.join(TEMPDIR, "testtar.tar.gz")
@@ -552,21 +552,21 @@ class MiscReadTestBase(CommonReadTest):
 
     @unittest.skipUnless(hasattr(os, "link"),
                          "Missing hardlink implementation")
-    @support.skip_unless_symlink
+    @os_helper.skip_unless_symlink
     def test_extract_hardlink(self):
         # Test hardlink extraction (e.g. bug #857297).
         with tarfile.open(tarname, errorlevel=1, encoding="iso8859-1") as tar:
             tar.extract("ustar/regtype", TEMPDIR)
-            self.addCleanup(support.unlink, os.path.join(TEMPDIR, "ustar/regtype"))
+            self.addCleanup(os_helper.unlink, os.path.join(TEMPDIR, "ustar/regtype"))
 
             tar.extract("ustar/lnktype", TEMPDIR)
-            self.addCleanup(support.unlink, os.path.join(TEMPDIR, "ustar/lnktype"))
+            self.addCleanup(os_helper.unlink, os.path.join(TEMPDIR, "ustar/lnktype"))
             with open(os.path.join(TEMPDIR, "ustar/lnktype"), "rb") as f:
                 data = f.read()
             self.assertEqual(sha256sum(data), sha256_regtype)
 
             tar.extract("ustar/symtype", TEMPDIR)
-            self.addCleanup(support.unlink, os.path.join(TEMPDIR, "ustar/symtype"))
+            self.addCleanup(os_helper.unlink, os.path.join(TEMPDIR, "ustar/symtype"))
             with open(os.path.join(TEMPDIR, "ustar/symtype"), "rb") as f:
                 data = f.read()
             self.assertEqual(sha256sum(data), sha256_regtype)
@@ -599,7 +599,7 @@ class MiscReadTestBase(CommonReadTest):
                 self.assertEqual(tarinfo.mtime, file_mtime, errmsg)
         finally:
             tar.close()
-            support.rmtree(DIR)
+            os_helper.rmtree(DIR)
 
     # TODO: RUSTPYTHON
     if sys.platform == "win32":
@@ -618,7 +618,7 @@ class MiscReadTestBase(CommonReadTest):
                 if sys.platform != "win32":
                     self.assertEqual(os.stat(extracted).st_mode & 0o777, 0o755)
         finally:
-            support.rmtree(DIR)
+            os_helper.rmtree(DIR)
 
     # TODO: RUSTPYTHON
     if sys.platform == "win32":
@@ -626,7 +626,7 @@ class MiscReadTestBase(CommonReadTest):
 
     def test_extractall_pathlike_name(self):
         DIR = pathlib.Path(TEMPDIR) / "extractall"
-        with support.temp_dir(DIR), \
+        with os_helper.temp_dir(DIR), \
              tarfile.open(tarname, encoding="iso8859-1") as tar:
             directories = [t for t in tar if t.isdir()]
             tar.extractall(DIR, directories)
@@ -641,7 +641,7 @@ class MiscReadTestBase(CommonReadTest):
     def test_extract_pathlike_name(self):
         dirtype = "ustar/dirtype"
         DIR = pathlib.Path(TEMPDIR) / "extractall"
-        with support.temp_dir(DIR), \
+        with os_helper.temp_dir(DIR), \
              tarfile.open(tarname, encoding="iso8859-1") as tar:
             tarinfo = tar.getmember(dirtype)
             tar.extract(tarinfo, path=DIR)
@@ -669,7 +669,7 @@ class MiscReadTestBase(CommonReadTest):
             else:
                 self.fail("ReadError not raised")
         finally:
-            support.unlink(empty)
+            os_helper.unlink(empty)
 
     # TODO: RUSTPYTHON
     @unittest.expectedFailure
@@ -1037,7 +1037,7 @@ class GNUReadTest(LongnameTest, ReadTest, unittest.TestCase):
                 fobj.write(b'x' * 4096)
                 fobj.truncate()
             s = os.stat(name)
-            support.unlink(name)
+            os_helper.unlink(name)
             return (s.st_blocks * 512 < s.st_size)
         else:
             return False
@@ -1204,8 +1204,8 @@ class WriteTest(WriteTestBase, unittest.TestCase):
             finally:
                 tar.close()
         finally:
-            support.unlink(os.path.join(path, "1"))
-            support.unlink(os.path.join(path, "2"))
+            os_helper.unlink(os.path.join(path, "1"))
+            os_helper.unlink(os.path.join(path, "2"))
             support.rmdir(path)
 
     def test_gettarinfo_pathlike_name(self):
@@ -1240,14 +1240,14 @@ class WriteTest(WriteTestBase, unittest.TestCase):
             finally:
                 tar.close()
         finally:
-            support.unlink(target)
-            support.unlink(link)
+            os_helper.unlink(target)
+            os_helper.unlink(link)
 
     # TODO: RUSTPYTHON
     if sys.platform == "win32":
         test_link_size = unittest.expectedFailure(test_link_size)
 
-    @support.skip_unless_symlink
+    @os_helper.skip_unless_symlink
     def test_symlink_size(self):
         path = os.path.join(TEMPDIR, "symlink")
         os.symlink("link_target", path)
@@ -1259,7 +1259,7 @@ class WriteTest(WriteTestBase, unittest.TestCase):
             finally:
                 tar.close()
         finally:
-            support.unlink(path)
+            os_helper.unlink(path)
 
     # TODO: RUSTPYTHON
     if sys.platform == "win32":
@@ -1276,7 +1276,7 @@ class WriteTest(WriteTestBase, unittest.TestCase):
             self.assertEqual(tar.getnames(), [],
                     "added the archive to itself")
 
-            with support.change_cwd(TEMPDIR):
+            with os_helper.change_cwd(TEMPDIR):
                 tar.add(dstname)
             self.assertEqual(tar.getnames(), [],
                     "added the archive to itself")
@@ -1289,7 +1289,7 @@ class WriteTest(WriteTestBase, unittest.TestCase):
         try:
             for name in ("foo", "bar", "baz"):
                 name = os.path.join(tempdir, name)
-                support.create_empty_file(name)
+                os_helper.create_empty_file(name)
 
             def filter(tarinfo):
                 if os.path.basename(tarinfo.name) == "bar":
@@ -1317,7 +1317,7 @@ class WriteTest(WriteTestBase, unittest.TestCase):
             finally:
                 tar.close()
         finally:
-            support.rmtree(tempdir)
+            os_helper.rmtree(tempdir)
 
     # Guarantee that stored pathnames are not modified. Don't
     # remove ./ or ../ or double slashes. Still make absolute
@@ -1328,7 +1328,7 @@ class WriteTest(WriteTestBase, unittest.TestCase):
         # and compare the stored name with the original.
         foo = os.path.join(TEMPDIR, "foo")
         if not dir:
-            support.create_empty_file(foo)
+            os_helper.create_empty_file(foo)
         else:
             os.mkdir(foo)
 
@@ -1345,14 +1345,14 @@ class WriteTest(WriteTestBase, unittest.TestCase):
             tar.close()
 
         if not dir:
-            support.unlink(foo)
+            os_helper.unlink(foo)
         else:
             support.rmdir(foo)
 
         self.assertEqual(t.name, cmp_path or path.replace(os.sep, "/"))
 
 
-    @support.skip_unless_symlink
+    @os_helper.skip_unless_symlink
     def test_extractall_symlinks(self):
         # Test if extractall works properly when tarfile contains symlinks
         tempdir = os.path.join(TEMPDIR, "testsymlinks")
@@ -1375,8 +1375,8 @@ class WriteTest(WriteTestBase, unittest.TestCase):
                 except OSError:
                     self.fail("extractall failed with symlinked files")
         finally:
-            support.unlink(temparchive)
-            support.rmtree(tempdir)
+            os_helper.unlink(temparchive)
+            os_helper.rmtree(tempdir)
 
     # TODO: RUSTPYTHON
     if sys.platform != "win32":
@@ -1408,7 +1408,7 @@ class WriteTest(WriteTestBase, unittest.TestCase):
 
     def test_cwd(self):
         # Test adding the current working directory.
-        with support.change_cwd(TEMPDIR):
+        with os_helper.change_cwd(TEMPDIR):
             tar = tarfile.open(tmpname, self.mode)
             try:
                 tar.add(".")
@@ -1499,7 +1499,7 @@ class StreamWriteTest(WriteTestBase, unittest.TestCase):
         # Test for issue #8464: Create files with correct
         # permissions.
         if os.path.exists(tmpname):
-            support.unlink(tmpname)
+            os_helper.unlink(tmpname)
 
         original_umask = os.umask(0o022)
         try:
@@ -1620,7 +1620,7 @@ class CreateTest(WriteTestBase, unittest.TestCase):
     file_path = os.path.join(TEMPDIR, "spameggs42")
 
     def setUp(self):
-        support.unlink(tmpname)
+        os_helper.unlink(tmpname)
 
     @classmethod
     def setUpClass(cls):
@@ -1629,7 +1629,7 @@ class CreateTest(WriteTestBase, unittest.TestCase):
 
     @classmethod
     def tearDownClass(cls):
-        support.unlink(cls.file_path)
+        os_helper.unlink(cls.file_path)
 
     def test_create(self):
         with tarfile.open(tmpname, self.mode) as tobj:
@@ -1744,8 +1744,8 @@ class HardlinkTest(unittest.TestCase):
 
     def tearDown(self):
         self.tar.close()
-        support.unlink(self.foo)
-        support.unlink(self.bar)
+        os_helper.unlink(self.foo)
+        os_helper.unlink(self.bar)
 
     def test_add_twice(self):
         # The same name will be added as a REGTYPE every
@@ -2074,7 +2074,7 @@ class AppendTestBase:
     def setUp(self):
         self.tarname = tmpname
         if os.path.exists(self.tarname):
-            support.unlink(self.tarname)
+            os_helper.unlink(self.tarname)
 
     def _create_testtar(self, mode="w:"):
         with tarfile.open(tarname, encoding="iso8859-1") as src:
@@ -2287,7 +2287,7 @@ class MiscTest(unittest.TestCase):
             tarfile.itn(0x10000000000, 6, tarfile.GNU_FORMAT)
 
     def test__all__(self):
-        blacklist = {'version', 'grp', 'pwd', 'symlink_exception',
+        not_exported = {'version', 'grp', 'pwd', 'symlink_exception',
                      'NUL', 'BLOCKSIZE', 'RECORDSIZE', 'GNU_MAGIC',
                      'POSIX_MAGIC', 'LENGTH_NAME', 'LENGTH_LINK',
                      'LENGTH_PREFIX', 'REGTYPE', 'AREGTYPE', 'LNKTYPE',
@@ -2302,7 +2302,7 @@ class MiscTest(unittest.TestCase):
                      'EOFHeaderError', 'InvalidHeaderError',
                      'SubsequentHeaderError', 'ExFileObject',
                      'main'}
-        support.check__all__(self, tarfile, blacklist=blacklist)
+        support.check__all__(self, tarfile, not_exported=not_exported)
 
 
 class CommandLineTest(unittest.TestCase):
@@ -2319,7 +2319,7 @@ class CommandLineTest(unittest.TestCase):
         files = [support.findfile('tokenize_tests.txt'),
                  support.findfile('tokenize_tests-no-coding-cookie-'
                                   'and-utf8-bom-sig-only.txt')]
-        self.addCleanup(support.unlink, tar_name)
+        self.addCleanup(os_helper.unlink, tar_name)
         with tarfile.open(tar_name, 'w') as tf:
             for tardata in files:
                 tf.add(tardata, arcname=os.path.basename(tardata))
@@ -2368,7 +2368,7 @@ class CommandLineTest(unittest.TestCase):
                     self.assertEqual(out, b'')
                     self.assertEqual(rc, 1)
                 finally:
-                    support.unlink(tmpname)
+                    os_helper.unlink(tmpname)
 
     # TODO: RUSTPYTHON
     @unittest.expectedFailure
@@ -2414,7 +2414,7 @@ class CommandLineTest(unittest.TestCase):
                 with tarfile.open(tmpname) as tar:
                     tar.getmembers()
             finally:
-                support.unlink(tmpname)
+                os_helper.unlink(tmpname)
 
     def test_create_command_verbose(self):
         files = [support.findfile('tokenize_tests.txt'),
@@ -2427,7 +2427,7 @@ class CommandLineTest(unittest.TestCase):
                 with tarfile.open(tmpname) as tar:
                     tar.getmembers()
             finally:
-                support.unlink(tmpname)
+                os_helper.unlink(tmpname)
 
     def test_create_command_dotless_filename(self):
         files = [support.findfile('tokenize_tests.txt')]
@@ -2437,7 +2437,7 @@ class CommandLineTest(unittest.TestCase):
             with tarfile.open(dotlessname) as tar:
                 tar.getmembers()
         finally:
-            support.unlink(dotlessname)
+            os_helper.unlink(dotlessname)
 
     def test_create_command_dot_started_filename(self):
         tar_name = os.path.join(TEMPDIR, ".testtar")
@@ -2448,7 +2448,7 @@ class CommandLineTest(unittest.TestCase):
             with tarfile.open(tar_name) as tar:
                 tar.getmembers()
         finally:
-            support.unlink(tar_name)
+            os_helper.unlink(tar_name)
 
     def test_create_command_compressed(self):
         files = [support.findfile('tokenize_tests.txt'),
@@ -2463,40 +2463,40 @@ class CommandLineTest(unittest.TestCase):
                 with filetype.taropen(tar_name) as tar:
                     tar.getmembers()
             finally:
-                support.unlink(tar_name)
+                os_helper.unlink(tar_name)
 
     def test_extract_command(self):
         self.make_simple_tarfile(tmpname)
         for opt in '-e', '--extract':
             try:
-                with support.temp_cwd(tarextdir):
+                with os_helper.temp_cwd(tarextdir):
                     out = self.tarfilecmd(opt, tmpname)
                 self.assertEqual(out, b'')
             finally:
-                support.rmtree(tarextdir)
+                os_helper.rmtree(tarextdir)
 
     def test_extract_command_verbose(self):
         self.make_simple_tarfile(tmpname)
         for opt in '-v', '--verbose':
             try:
-                with support.temp_cwd(tarextdir):
+                with os_helper.temp_cwd(tarextdir):
                     out = self.tarfilecmd(opt, '-e', tmpname)
                 self.assertIn(b' file is extracted.', out)
             finally:
-                support.rmtree(tarextdir)
+                os_helper.rmtree(tarextdir)
 
     def test_extract_command_different_directory(self):
         self.make_simple_tarfile(tmpname)
         try:
-            with support.temp_cwd(tarextdir):
+            with os_helper.temp_cwd(tarextdir):
                 out = self.tarfilecmd('-e', tmpname, 'spamdir')
             self.assertEqual(out, b'')
         finally:
-            support.rmtree(tarextdir)
+            os_helper.rmtree(tarextdir)
 
     def test_extract_command_invalid_file(self):
         zipname = support.findfile('zipdir.zip')
-        with support.temp_cwd(tarextdir):
+        with os_helper.temp_cwd(tarextdir):
             rc, out, err = self.tarfilecmd_failure('-e', zipname)
         self.assertIn(b' is not a tar archive.', err)
         self.assertEqual(out, b'')
@@ -2759,7 +2759,7 @@ class NumericOwnerTest(unittest.TestCase):
 
 
 def setUpModule():
-    support.unlink(TEMPDIR)
+    os_helper.unlink(TEMPDIR)
     os.makedirs(TEMPDIR)
 
     global testtarnames
@@ -2770,14 +2770,14 @@ def setUpModule():
     # Create compressed tarfiles.
     for c in GzipTest, Bz2Test, LzmaTest:
         if c.open:
-            support.unlink(c.tarname)
+            os_helper.unlink(c.tarname)
             testtarnames.append(c.tarname)
             with c.open(c.tarname, "wb") as tar:
                 tar.write(data)
 
 def tearDownModule():
     if os.path.exists(TEMPDIR):
-        support.rmtree(TEMPDIR)
+        os_helper.rmtree(TEMPDIR)
 
 if __name__ == "__main__":
     unittest.main()

--- a/Lib/test/test_tempfile.py
+++ b/Lib/test/test_tempfile.py
@@ -15,7 +15,7 @@ from unittest import mock
 
 import unittest
 from test import support
-from test.support import script_helper
+from test.support import script_helper, os_helper
 
 
 has_textmode = (tempfile._text_openflags != tempfile._bin_openflags)
@@ -232,7 +232,7 @@ class TestCandidateTempdirList(BaseTestCase):
         # _candidate_tempdir_list contains the expected directories
 
         # Make sure the interesting environment variables are all set.
-        with support.EnvironmentVarGuard() as env:
+        with os_helper.EnvironmentVarGuard() as env:
             for envname in 'TMPDIR', 'TEMP', 'TMP':
                 dirname = os.getenv(envname)
                 if not dirname:
@@ -318,7 +318,7 @@ def _inside_empty_temp_dir():
         with support.swap_attr(tempfile, 'tempdir', dir):
             yield
     finally:
-        support.rmtree(dir)
+        os_helper.rmtree(dir)
 
 
 def _mock_candidate_names(*names):
@@ -602,7 +602,7 @@ class TestGetTempDir(BaseTestCase):
         case_sensitive_tempdir = tempfile.mkdtemp("-Temp")
         _tempdir, tempfile.tempdir = tempfile.tempdir, None
         try:
-            with support.EnvironmentVarGuard() as env:
+            with os_helper.EnvironmentVarGuard() as env:
                 # Fake the first env var which is checked as a candidate
                 env["TMPDIR"] = case_sensitive_tempdir
                 self.assertEqual(tempfile.gettempdir(), case_sensitive_tempdir)
@@ -958,7 +958,7 @@ class TestNamedTemporaryFile(BaseTestCase):
 
     def test_bad_mode(self):
         dir = tempfile.mkdtemp()
-        self.addCleanup(support.rmtree, dir)
+        self.addCleanup(os_helper.rmtree, dir)
         with self.assertRaises(ValueError):
             tempfile.NamedTemporaryFile(mode='wr', dir=dir)
         with self.assertRaises(TypeError):
@@ -1364,7 +1364,7 @@ class TestTemporaryDirectory(BaseTestCase):
         finally:
             os.rmdir(dir)
 
-    @support.skip_unless_symlink
+    @os_helper.skip_unless_symlink
     def test_cleanup_with_symlink_to_a_directory(self):
         # cleanup() should not follow symlinks to directories (issue #12464)
         d1 = self.do_create()

--- a/Lib/test/test_threading.py
+++ b/Lib/test/test_threading.py
@@ -1376,9 +1376,9 @@ class MiscTestCase(unittest.TestCase):
     @unittest.expectedFailure
     def test__all__(self):
         extra = {"ThreadError"}
-        blacklist = {'currentThread', 'activeCount'}
+        not_exported = {'currentThread', 'activeCount'}
         support.check__all__(self, threading, ('threading', '_thread'),
-                             extra=extra, blacklist=blacklist)
+                             extra=extra, not_exported=not_exported)
 
 
 class InterruptMainTests(unittest.TestCase):

--- a/Lib/test/test_tokenize.py
+++ b/Lib/test/test_tokenize.py
@@ -1,4 +1,5 @@
 from test import support
+from test.support import os_helper
 from tokenize import (tokenize, _tokenize, untokenize, NUMBER, NAME, OP,
                      STRING, ENDMARKER, ENCODING, tok_name, detect_encoding,
                      open as tokenize_open, Untokenizer, generate_tokens,
@@ -1306,8 +1307,8 @@ class TestDetectEncoding(TestCase):
         self.assertEqual(consumed_lines, [b'print("#coding=fake")'])
 
     def test_open(self):
-        filename = support.TESTFN + '.py'
-        self.addCleanup(support.unlink, filename)
+        filename = os_helper.TESTFN + '.py'
+        self.addCleanup(os_helper.unlink, filename)
 
         # test coding cookie
         for encoding in ('iso-8859-15', 'utf-8'):

--- a/Lib/test/test_trace.py
+++ b/Lib/test/test_trace.py
@@ -1,6 +1,7 @@
 import os
 import sys
-from test.support import TESTFN, TESTFN_UNICODE, FS_NONASCII, rmtree, unlink, captured_stdout
+from test.support import captured_stdout
+from test.support.os_helper import TESTFN, TESTFN_UNICODE, FS_NONASCII, rmtree, unlink
 from test.support.script_helper import assert_python_ok, assert_python_failure
 import textwrap
 import unittest

--- a/Lib/test/test_traceback.py
+++ b/Lib/test/test_traceback.py
@@ -7,7 +7,8 @@ import sys
 import unittest
 import re
 from test import support
-from test.support import TESTFN, Error, captured_output, unlink, cpython_only
+from test.support import Error, captured_output, cpython_only
+from test.support.os_helper import TESTFN, unlink
 from test.support.script_helper import assert_python_ok
 import textwrap
 

--- a/Lib/test/test_unicode_file.py
+++ b/Lib/test/test_unicode_file.py
@@ -2,16 +2,17 @@
 # We don't test many operations on files other than
 # that their names can be used with Unicode characters.
 import os, glob, time, shutil
+import sys
 import unicodedata
 
 import unittest
-from test.support import run_unittest
 from test.support.os_helper import (rmtree, change_cwd, TESTFN_UNICODE,
     TESTFN_UNENCODABLE, create_empty_file)
 
+
 if not os.path.supports_unicode_filenames:
     try:
-        TESTFN_UNICODE.encode(TESTFN_ENCODING)
+        TESTFN_UNICODE.encode(sys.getfilesystemencoding())
     except (UnicodeError, TypeError):
         # Either the file system encoding is None, or the file name
         # cannot be encoded in the file system encoding.
@@ -134,8 +135,6 @@ class TestUnicodeFiles(unittest.TestCase):
             self._do_directory(TESTFN_UNENCODABLE+ext,
                                TESTFN_UNENCODABLE+ext)
 
-def test_main():
-    run_unittest(__name__)
 
 if __name__ == "__main__":
-    test_main()
+    unittest.main()

--- a/Lib/test/test_unicode_file.py
+++ b/Lib/test/test_unicode_file.py
@@ -5,8 +5,9 @@ import os, glob, time, shutil
 import unicodedata
 
 import unittest
-from test.support import (run_unittest, rmtree, change_cwd,
-    TESTFN_ENCODING, TESTFN_UNICODE, TESTFN_UNENCODABLE, create_empty_file)
+from test.support import run_unittest
+from test.support.os_helper import (rmtree, change_cwd, TESTFN_UNICODE,
+    TESTFN_UNENCODABLE, create_empty_file)
 
 if not os.path.supports_unicode_filenames:
     try:

--- a/Lib/test/test_unicode_file_functions.py
+++ b/Lib/test/test_unicode_file_functions.py
@@ -6,6 +6,7 @@ import unittest
 import warnings
 from unicodedata import normalize
 from test import support
+from test.support import os_helper
 
 filenames = [
     '1_abc',
@@ -62,14 +63,14 @@ class UnicodeFileTests(unittest.TestCase):
 
     def setUp(self):
         try:
-            os.mkdir(support.TESTFN)
+            os.mkdir(os_helper.TESTFN)
         except FileExistsError:
             pass
-        self.addCleanup(support.rmtree, support.TESTFN)
+        self.addCleanup(os_helper.rmtree, os_helper.TESTFN)
 
         files = set()
         for name in self.files:
-            name = os.path.join(support.TESTFN, self.norm(name))
+            name = os.path.join(os_helper.TESTFN, self.norm(name))
             with open(name, 'wb') as f:
                 f.write((name+'\n').encode("utf-8"))
             os.stat(name)
@@ -150,9 +151,9 @@ class UnicodeFileTests(unittest.TestCase):
         sf0 = set(self.files)
         with warnings.catch_warnings():
             warnings.simplefilter("ignore", DeprecationWarning)
-            f1 = os.listdir(support.TESTFN.encode(sys.getfilesystemencoding()))
-        f2 = os.listdir(support.TESTFN)
-        sf2 = set(os.path.join(support.TESTFN, f) for f in f2)
+            f1 = os.listdir(os_helper.TESTFN.encode(sys.getfilesystemencoding()))
+        f2 = os.listdir(os_helper.TESTFN)
+        sf2 = set(os.path.join(os_helper.TESTFN, f) for f in f2)
         self.assertEqual(sf0, sf2, "%a != %a" % (sf0, sf2))
         self.assertEqual(len(f1), len(f2))
 
@@ -162,9 +163,9 @@ class UnicodeFileTests(unittest.TestCase):
             os.rename("tmp", name)
 
     def test_directory(self):
-        dirname = os.path.join(support.TESTFN, 'Gr\xfc\xdf-\u66e8\u66e9\u66eb')
+        dirname = os.path.join(os_helper.TESTFN, 'Gr\xfc\xdf-\u66e8\u66e9\u66eb')
         filename = '\xdf-\u66e8\u66e9\u66eb'
-        with support.temp_cwd(dirname):
+        with os_helper.temp_cwd(dirname):
             with open(filename, 'wb') as f:
                 f.write((filename + '\n').encode("utf-8"))
             os.access(filename,os.R_OK)

--- a/Lib/test/test_urllib.py
+++ b/Lib/test/test_urllib.py
@@ -1538,6 +1538,7 @@ class Pathname_Tests(unittest.TestCase):
 
     @unittest.skipUnless(sys.platform == 'win32',
                          'test specific to the nturl2path functions.')
+    @unittest.expectedFailure
     def test_prefixes(self):
         # Test special prefixes are correctly handled in pathname2url()
         given = '\\\\?\\C:\\dir'

--- a/Lib/test/test_urllib.py
+++ b/Lib/test/test_urllib.py
@@ -9,6 +9,7 @@ import io
 import unittest
 from unittest.mock import patch
 from test import support
+from test.support import os_helper
 import os
 try:
     import ssl
@@ -145,18 +146,18 @@ class urlopen_FileTests(unittest.TestCase):
         # Create a temp file to use for testing
         self.text = bytes("test_urllib: %s\n" % self.__class__.__name__,
                           "ascii")
-        f = open(support.TESTFN, 'wb')
+        f = open(os_helper.TESTFN, 'wb')
         try:
             f.write(self.text)
         finally:
             f.close()
-        self.pathname = support.TESTFN
+        self.pathname = os_helper.TESTFN
         self.returned_obj = urlopen("file:%s" % self.pathname)
 
     def tearDown(self):
         """Shut down the open object"""
         self.returned_obj.close()
-        os.remove(support.TESTFN)
+        os.remove(os_helper.TESTFN)
 
     def test_interface(self):
         # Make sure object returned by urlopen() has the specified methods
@@ -220,7 +221,7 @@ class ProxyTests(unittest.TestCase):
 
     def setUp(self):
         # Records changes to env vars
-        self.env = support.EnvironmentVarGuard()
+        self.env = os_helper.EnvironmentVarGuard()
         # Delete all proxy related env vars
         for k in list(os.environ):
             if 'proxy' in k.lower():
@@ -692,10 +693,10 @@ class urlretrieve_FileTests(unittest.TestCase):
         self.tempFiles = []
 
         # Create a temporary file.
-        self.registerFileForCleanUp(support.TESTFN)
+        self.registerFileForCleanUp(os_helper.TESTFN)
         self.text = b'testing urllib.urlretrieve'
         try:
-            FILE = open(support.TESTFN, 'wb')
+            FILE = open(os_helper.TESTFN, 'wb')
             FILE.write(self.text)
             FILE.close()
         finally:
@@ -738,18 +739,18 @@ class urlretrieve_FileTests(unittest.TestCase):
     def test_basic(self):
         # Make sure that a local file just gets its own location returned and
         # a headers value is returned.
-        result = urllib.request.urlretrieve("file:%s" % support.TESTFN)
-        self.assertEqual(result[0], support.TESTFN)
+        result = urllib.request.urlretrieve("file:%s" % os_helper.TESTFN)
+        self.assertEqual(result[0], os_helper.TESTFN)
         self.assertIsInstance(result[1], email.message.Message,
                               "did not get an email.message.Message instance "
                               "as second returned value")
 
     def test_copy(self):
         # Test that setting the filename argument works.
-        second_temp = "%s.2" % support.TESTFN
+        second_temp = "%s.2" % os_helper.TESTFN
         self.registerFileForCleanUp(second_temp)
         result = urllib.request.urlretrieve(self.constructLocalFileUrl(
-            support.TESTFN), second_temp)
+            os_helper.TESTFN), second_temp)
         self.assertEqual(second_temp, result[0])
         self.assertTrue(os.path.exists(second_temp), "copy of the file was not "
                                                   "made")
@@ -770,10 +771,10 @@ class urlretrieve_FileTests(unittest.TestCase):
             self.assertIsInstance(file_size, int)
             self.assertEqual(block_count, count_holder[0])
             count_holder[0] = count_holder[0] + 1
-        second_temp = "%s.2" % support.TESTFN
+        second_temp = "%s.2" % os_helper.TESTFN
         self.registerFileForCleanUp(second_temp)
         urllib.request.urlretrieve(
-            self.constructLocalFileUrl(support.TESTFN),
+            self.constructLocalFileUrl(os_helper.TESTFN),
             second_temp, hooktester)
 
     def test_reporthook_0_bytes(self):
@@ -783,7 +784,7 @@ class urlretrieve_FileTests(unittest.TestCase):
             _report.append((block_count, block_read_size, file_size))
         srcFileName = self.createNewTempFile()
         urllib.request.urlretrieve(self.constructLocalFileUrl(srcFileName),
-            support.TESTFN, hooktester)
+            os_helper.TESTFN, hooktester)
         self.assertEqual(len(report), 1)
         self.assertEqual(report[0][2], 0)
 
@@ -796,7 +797,7 @@ class urlretrieve_FileTests(unittest.TestCase):
             _report.append((block_count, block_read_size, file_size))
         srcFileName = self.createNewTempFile(b"x" * 5)
         urllib.request.urlretrieve(self.constructLocalFileUrl(srcFileName),
-            support.TESTFN, hooktester)
+            os_helper.TESTFN, hooktester)
         self.assertEqual(len(report), 2)
         self.assertEqual(report[0][2], 5)
         self.assertEqual(report[1][2], 5)
@@ -810,7 +811,7 @@ class urlretrieve_FileTests(unittest.TestCase):
             _report.append((block_count, block_read_size, file_size))
         srcFileName = self.createNewTempFile(b"x" * 8193)
         urllib.request.urlretrieve(self.constructLocalFileUrl(srcFileName),
-            support.TESTFN, hooktester)
+            os_helper.TESTFN, hooktester)
         self.assertEqual(len(report), 3)
         self.assertEqual(report[0][2], 8193)
         self.assertEqual(report[0][1], 8192)
@@ -1543,7 +1544,7 @@ class URLopener_Tests(FakeHTTPMixin, unittest.TestCase):
 
     @support.ignore_warnings(category=DeprecationWarning)
     def test_urlopener_retrieve_file(self):
-        with support.temp_dir() as tmpdir:
+        with os_helper.temp_dir() as tmpdir:
             fd, tmpfile = tempfile.mkstemp(dir=tmpdir)
             os.close(fd)
             fileurl = "file:" + urllib.request.pathname2url(tmpfile)

--- a/Lib/test/test_urllib2.py
+++ b/Lib/test/test_urllib2.py
@@ -1,5 +1,6 @@
 import unittest
 from test import support
+from test.support import os_helper
 from test import test_urllib
 
 import os
@@ -772,7 +773,7 @@ class HandlerTests(unittest.TestCase):
         h = urllib.request.FileHandler()
         o = h.parent = MockOpener()
 
-        TESTFN = support.TESTFN
+        TESTFN = os_helper.TESTFN
         urlpath = sanepathname2url(os.path.abspath(TESTFN))
         towrite = b"hello, world\n"
         urls = [

--- a/Lib/test/test_urllib2net.py
+++ b/Lib/test/test_urllib2net.py
@@ -1,5 +1,6 @@
 import unittest
 from test import support
+from test.support import os_helper
 from test.test_urllib2 import sanepathname2url
 
 import os
@@ -112,7 +113,7 @@ class OtherNetworkTests(unittest.TestCase):
         self._test_urls(urls, self._extra_handlers())
 
     def test_file(self):
-        TESTFN = support.TESTFN
+        TESTFN = os_helper.TESTFN
         f = open(TESTFN, 'w')
         try:
             f.write('hi there\n')

--- a/Lib/test/test_urllibnet.py
+++ b/Lib/test/test_urllibnet.py
@@ -1,5 +1,6 @@
 import unittest
 from test import support
+from test.support import os_helper
 
 import contextlib
 import socket
@@ -152,7 +153,7 @@ class urlretrieveNetworkTests(unittest.TestCase):
             try:
                 yield file_location, info
             finally:
-                support.unlink(file_location)
+                os_helper.unlink(file_location)
 
     def test_basic(self):
         # Test basic functionality.
@@ -166,8 +167,8 @@ class urlretrieveNetworkTests(unittest.TestCase):
     def test_specified_path(self):
         # Make sure that specifying the location of the file to write to works.
         with self.urlretrieve(self.logo,
-                              support.TESTFN) as (file_location, info):
-            self.assertEqual(file_location, support.TESTFN)
+                              os_helper.TESTFN) as (file_location, info):
+            self.assertEqual(file_location, os_helper.TESTFN)
             self.assertTrue(os.path.exists(file_location))
             with open(file_location, 'rb') as f:
                 self.assertTrue(f.read(), "reading from temporary file failed")

--- a/Lib/test/test_uu.py
+++ b/Lib/test/test_uu.py
@@ -4,7 +4,6 @@ Nick Mathewson
 """
 
 import unittest
-from test import support
 from test.support import os_helper
 
 import os
@@ -187,8 +186,9 @@ class UUStdIOTest(unittest.TestCase):
 class UUFileTest(unittest.TestCase):
 
     def setUp(self):
-        self.tmpin  = os_helper.TESTFN + "i"
-        self.tmpout = os_helper.TESTFN + "o"
+        # uu.encode() supports only ASCII file names
+        self.tmpin  = os_helper.TESTFN_ASCII + "i"
+        self.tmpout = os_helper.TESTFN_ASCII + "o"
         self.addCleanup(os_helper.unlink, self.tmpin)
         self.addCleanup(os_helper.unlink, self.tmpout)
 

--- a/Lib/test/test_uu.py
+++ b/Lib/test/test_uu.py
@@ -5,6 +5,7 @@ Nick Mathewson
 
 import unittest
 from test import support
+from test.support import os_helper
 
 import os
 import stat
@@ -186,10 +187,10 @@ class UUStdIOTest(unittest.TestCase):
 class UUFileTest(unittest.TestCase):
 
     def setUp(self):
-        self.tmpin  = support.TESTFN + "i"
-        self.tmpout = support.TESTFN + "o"
-        self.addCleanup(support.unlink, self.tmpin)
-        self.addCleanup(support.unlink, self.tmpout)
+        self.tmpin  = os_helper.TESTFN + "i"
+        self.tmpout = os_helper.TESTFN + "o"
+        self.addCleanup(os_helper.unlink, self.tmpin)
+        self.addCleanup(os_helper.unlink, self.tmpout)
 
     # TODO: RUSTPYTHON
     @unittest.expectedFailure

--- a/Lib/test/test_venv.py
+++ b/Lib/test/test_venv.py
@@ -16,8 +16,8 @@ import subprocess
 import sys
 import tempfile
 from test.support import (captured_stdout, captured_stderr, requires_zlib,
-                          can_symlink, EnvironmentVarGuard, rmtree,
                           import_module)
+from test.support.os_helper import (can_symlink, EnvironmentVarGuard, rmtree)
 import threading
 import unittest
 import venv

--- a/Lib/test/test_webbrowser.py
+++ b/Lib/test/test_webbrowser.py
@@ -5,6 +5,7 @@ import sys
 import subprocess
 from unittest import mock
 from test import support
+from test.support import os_helper
 
 
 URL = 'http://www.example.com'
@@ -320,7 +321,7 @@ class ImportTest(unittest.TestCase):
             browser = webbrowser.get().name
         except (webbrowser.Error, AttributeError) as err:
             self.skipTest(str(err))
-        with support.EnvironmentVarGuard() as env:
+        with os_helper.EnvironmentVarGuard() as env:
             env["BROWSER"] = browser
             webbrowser = support.import_fresh_module('webbrowser')
             webbrowser.get()
@@ -333,12 +334,12 @@ class ImportTest(unittest.TestCase):
         except (webbrowser.Error, AttributeError, IndexError) as err:
             self.skipTest(str(err))
 
-        with support.EnvironmentVarGuard() as env:
+        with os_helper.EnvironmentVarGuard() as env:
             env["BROWSER"] = least_preferred_browser
             webbrowser = support.import_fresh_module('webbrowser')
             self.assertEqual(webbrowser.get().name, least_preferred_browser)
 
-        with support.EnvironmentVarGuard() as env:
+        with os_helper.EnvironmentVarGuard() as env:
             env["BROWSER"] = sys.executable
             webbrowser = support.import_fresh_module('webbrowser')
             self.assertEqual(webbrowser.get().name, sys.executable)

--- a/Lib/test/test_xml_etree.py
+++ b/Lib/test/test_xml_etree.py
@@ -24,7 +24,8 @@ import weakref
 from functools import partial
 from itertools import product, islice
 from test import support
-from test.support import TESTFN, findfile, import_fresh_module, gc_collect, swap_attr
+from test.support import findfile, import_fresh_module, gc_collect, swap_attr, os_helper
+from test.support.os_helper import TESTFN
 
 # pyET is the pure-Python implementation.
 #
@@ -123,7 +124,7 @@ class ModuleTest(unittest.TestCase):
 
     def test_all(self):
         names = ("xml.etree.ElementTree", "_elementtree")
-        support.check__all__(self, ET, names, blacklist=("HTML_EMPTY",))
+        support.check__all__(self, ET, names, not_exported=("HTML_EMPTY",))
 
 
 def serialize(elem, to_string=True, encoding='unicode', **options):
@@ -649,7 +650,7 @@ class ElementTreeTest(unittest.TestCase):
         self.assertEqual(str(cm.exception),
                 'junk after document element: line 1, column 12')
 
-        self.addCleanup(support.unlink, TESTFN)
+        self.addCleanup(os_helper.unlink, TESTFN)
         with open(TESTFN, "wb") as f:
             f.write(b"<document />junk")
         it = iterparse(TESTFN)
@@ -3642,7 +3643,7 @@ class IOTest(unittest.TestCase):
     # TODO: RUSTPYTHON
     @unittest.expectedFailure
     def test_write_to_filename(self):
-        self.addCleanup(support.unlink, TESTFN)
+        self.addCleanup(os_helper.unlink, TESTFN)
         tree = ET.ElementTree(ET.XML('''<site />'''))
         tree.write(TESTFN)
         with open(TESTFN, 'rb') as f:
@@ -3651,7 +3652,7 @@ class IOTest(unittest.TestCase):
     # TODO: RUSTPYTHON
     @unittest.expectedFailure
     def test_write_to_text_file(self):
-        self.addCleanup(support.unlink, TESTFN)
+        self.addCleanup(os_helper.unlink, TESTFN)
         tree = ET.ElementTree(ET.XML('''<site />'''))
         with open(TESTFN, 'w', encoding='utf-8') as f:
             tree.write(f, encoding='unicode')
@@ -3662,7 +3663,7 @@ class IOTest(unittest.TestCase):
     # TODO: RUSTPYTHON
     @unittest.expectedFailure
     def test_write_to_binary_file(self):
-        self.addCleanup(support.unlink, TESTFN)
+        self.addCleanup(os_helper.unlink, TESTFN)
         tree = ET.ElementTree(ET.XML('''<site />'''))
         with open(TESTFN, 'wb') as f:
             tree.write(f)
@@ -3673,7 +3674,7 @@ class IOTest(unittest.TestCase):
     # TODO: RUSTPYTHON
     @unittest.expectedFailure
     def test_write_to_binary_file_with_bom(self):
-        self.addCleanup(support.unlink, TESTFN)
+        self.addCleanup(os_helper.unlink, TESTFN)
         tree = ET.ElementTree(ET.XML('''<site />'''))
         # test BOM writing to buffered file
         with open(TESTFN, 'wb') as f:

--- a/Lib/test/test_xmlrpc.py
+++ b/Lib/test/test_xmlrpc.py
@@ -15,6 +15,7 @@ import re
 import io
 import contextlib
 from test import support
+from test.support import os_helper
 
 try:
     import gzip
@@ -1459,7 +1460,7 @@ class CGIHandlerTestCase(unittest.TestCase):
         self.cgi = None
 
     def test_cgi_get(self):
-        with support.EnvironmentVarGuard() as env:
+        with os_helper.EnvironmentVarGuard() as env:
             env['REQUEST_METHOD'] = 'GET'
             # if the method is GET and no request_text is given, it runs handle_get
             # get sysout output
@@ -1493,7 +1494,7 @@ class CGIHandlerTestCase(unittest.TestCase):
         </methodCall>
         """
 
-        with support.EnvironmentVarGuard() as env, \
+        with os_helper.EnvironmentVarGuard() as env, \
              captured_stdout(encoding=self.cgi.encoding) as data_out, \
              support.captured_stdin() as data_in:
             data_in.write(data)

--- a/Lib/test/test_zipfile.py
+++ b/Lib/test/test_zipfile.py
@@ -19,9 +19,9 @@ from tempfile import TemporaryFile
 from random import randint, random, getrandbits
 
 from test.support import script_helper
-from test.support import (TESTFN, findfile, unlink, rmtree, temp_dir, temp_cwd,
-                          requires_zlib, requires_bz2, requires_lzma,
+from test.support import (findfile, requires_zlib, requires_bz2, requires_lzma,
                           captured_stdout)
+from test.support.os_helper import TESTFN, unlink, rmtree, temp_dir, temp_cwd
 
 TESTFN2 = TESTFN + "2"
 TESTFNDIR = TESTFN + "d"

--- a/Lib/test/test_zipimport.py
+++ b/Lib/test/test_zipimport.py
@@ -9,6 +9,7 @@ import unittest
 import unittest.mock
 
 from test import support
+from test.support import os_helper
 
 from zipfile import ZipFile, ZipInfo, ZIP_STORED, ZIP_DEFLATED
 
@@ -92,7 +93,7 @@ class UncompressedZipImportTestCase(ImportHooksBaseTestCase):
     def makeTree(self, files, dirName=TEMP_DIR):
         # Create a filesystem based set of modules/packages
         # defined by files under the directory dirName.
-        self.addCleanup(support.rmtree, dirName)
+        self.addCleanup(os_helper.rmtree, dirName)
 
         for name, (mtime, data) in files.items():
             path = os.path.join(dirName, name)
@@ -110,7 +111,7 @@ class UncompressedZipImportTestCase(ImportHooksBaseTestCase):
         # Create a zip archive based set of modules/packages
         # defined by files in the zip file zipName.  If the
         # key 'stuff' exists in kw it is prepended to the archive.
-        self.addCleanup(support.unlink, zipName)
+        self.addCleanup(os_helper.unlink, zipName)
 
         with ZipFile(zipName, "w") as z:
             for name, (mtime, data) in files.items():
@@ -442,7 +443,7 @@ class UncompressedZipImportTestCase(ImportHooksBaseTestCase):
                  packdir2 + TESTMOD + pyc_ext: (NOW, test_pyc),
                  "spam" + pyc_ext: (NOW, test_pyc)}
 
-        self.addCleanup(support.unlink, TEMP_ZIP)
+        self.addCleanup(os_helper.unlink, TEMP_ZIP)
         with ZipFile(TEMP_ZIP, "w") as z:
             for name, (mtime, data) in files.items():
                 zinfo = ZipInfo(name, time.localtime(mtime))
@@ -496,7 +497,7 @@ class UncompressedZipImportTestCase(ImportHooksBaseTestCase):
         files = {packdir2 + "__init__" + pyc_ext: (NOW, test_pyc),
                  packdir2 + TESTMOD + pyc_ext: (NOW, test_pyc)}
 
-        self.addCleanup(support.unlink, TEMP_ZIP)
+        self.addCleanup(os_helper.unlink, TEMP_ZIP)
         with ZipFile(TEMP_ZIP, "w") as z:
             for name, (mtime, data) in files.items():
                 zinfo = ZipInfo(name, time.localtime(mtime))
@@ -540,7 +541,7 @@ class UncompressedZipImportTestCase(ImportHooksBaseTestCase):
         self.assertEqual(loader.get_filename(mod_name), mod.__file__)
 
     def testGetData(self):
-        self.addCleanup(support.unlink, TEMP_ZIP)
+        self.addCleanup(os_helper.unlink, TEMP_ZIP)
         with ZipFile(TEMP_ZIP, "w") as z:
             z.compression = self.compression
             name = "testdata.dat"
@@ -648,11 +649,11 @@ class UncompressedZipImportTestCase(ImportHooksBaseTestCase):
         files = {TESTMOD + ".py": (NOW, raise_src)}
         self.doTest(None, files, TESTMOD, call=self.doTraceback)
 
-    @unittest.skipIf(support.TESTFN_UNENCODABLE is None,
+    @unittest.skipIf(os_helper.TESTFN_UNENCODABLE is None,
                      "need an unencodable filename")
     def testUnencodable(self):
-        filename = support.TESTFN_UNENCODABLE + ".zip"
-        self.addCleanup(support.unlink, filename)
+        filename = os_helper.TESTFN_UNENCODABLE + ".zip"
+        self.addCleanup(os_helper.unlink, filename)
         with ZipFile(filename, "w") as z:
             zinfo = ZipInfo(TESTMOD + ".py", time.localtime(NOW))
             zinfo.compress_type = self.compression
@@ -660,8 +661,8 @@ class UncompressedZipImportTestCase(ImportHooksBaseTestCase):
         zipimport.zipimporter(filename).load_module(TESTMOD)
 
     def testBytesPath(self):
-        filename = support.TESTFN + ".zip"
-        self.addCleanup(support.unlink, filename)
+        filename = os_helper.TESTFN + ".zip"
+        self.addCleanup(os_helper.unlink, filename)
         with ZipFile(filename, "w") as z:
             zinfo = ZipInfo(TESTMOD + ".py", time.localtime(NOW))
             zinfo.compress_type = self.compression
@@ -713,12 +714,12 @@ class BadFileZipImportTestCase(unittest.TestCase):
         self.assertZipFailure('A' * 33000)
 
     def testEmptyFile(self):
-        support.unlink(TESTMOD)
-        support.create_empty_file(TESTMOD)
+        os_helper.unlink(TESTMOD)
+        os_helper.create_empty_file(TESTMOD)
         self.assertZipFailure(TESTMOD)
 
     def testFileUnreadable(self):
-        support.unlink(TESTMOD)
+        os_helper.unlink(TESTMOD)
         fd = os.open(TESTMOD, os.O_CREAT, 000)
         try:
             os.close(fd)
@@ -729,10 +730,10 @@ class BadFileZipImportTestCase(unittest.TestCase):
             # If we leave "the read-only bit" set on Windows, nothing can
             # delete TESTMOD, and later tests suffer bogus failures.
             os.chmod(TESTMOD, 0o666)
-            support.unlink(TESTMOD)
+            os_helper.unlink(TESTMOD)
 
     def testNotZipFile(self):
-        support.unlink(TESTMOD)
+        os_helper.unlink(TESTMOD)
         fp = open(TESTMOD, 'w+')
         fp.write('a' * 22)
         fp.close()
@@ -740,7 +741,7 @@ class BadFileZipImportTestCase(unittest.TestCase):
 
     # XXX: disabled until this works on Big-endian machines
     def _testBogusZipFile(self):
-        support.unlink(TESTMOD)
+        os_helper.unlink(TESTMOD)
         fp = open(TESTMOD, 'w+')
         fp.write(struct.pack('=I', 0x06054B50))
         fp.write('a' * 18)
@@ -775,7 +776,7 @@ def test_main():
               BadFileZipImportTestCase,
             )
     finally:
-        support.unlink(TESTMOD)
+        os_helper.unlink(TESTMOD)
 
 if __name__ == "__main__":
     test_main()


### PR DESCRIPTION
Second attempt to update `test/support/os_helper.py` (original #3433)

Plan to update all code under Lib/test/support.
This PR only cover the change for Lib/test/support/os_helper.py and reflect the changes necessary for other tests to use.
It is already a big one so I decide to make a PR for this and plan for others (import_helper, socket_helper...) to go for another PR.
Mostly of the part is from test.support import TESTFN --> from test.support.os_helper import TESTFN etc..

Follow up for #3424