### PR TITLE
Test: move import_helper out

### DIFF
--- a/Lib/test/libregrtest/main.py
+++ b/Lib/test/libregrtest/main.py
@@ -20,7 +20,7 @@ from test.libregrtest.runtest import (
 from test.libregrtest.setup import setup_tests
 from test.libregrtest.utils import removepy, count, format_duration, printlist
 from test import support
-from test.support import os_helper
+from test.support import os_helper, import_helper
 
 
 # When tests are run from the Python build directory, it is best practice
@@ -412,7 +412,7 @@ class Regrtest:
             # Unload the newly imported modules (best effort finalization)
             for module in sys.modules.keys():
                 if module not in save_modules and module.startswith("test."):
-                    support.unload(module)
+                    import_helper.unload(module)
 
         if previous_test:
             print(previous_test)

--- a/Lib/test/libregrtest/runtest.py
+++ b/Lib/test/libregrtest/runtest.py
@@ -11,7 +11,7 @@ import traceback
 import unittest
 
 from test import support
-from test.support import os_helper
+from test.support import os_helper, import_helper
 from test.libregrtest.refleak import dash_R, clear_caches
 from test.libregrtest.save_env import saved_test_environment
 from test.libregrtest.utils import print_warning
@@ -202,7 +202,7 @@ def _runtest_inner2(ns, test_name):
     abstest = get_abs_module(ns, test_name)
 
     # remove the module from sys.module to reload it if it was already imported
-    support.unload(abstest)
+    import_helper.unload(abstest)
 
     the_module = importlib.import_module(abstest)
 

--- a/Lib/test/support/__init__.py
+++ b/Lib/test/support/__init__.py
@@ -79,9 +79,7 @@ __all__ = [
     # exceptions
     "Error", "TestFailed", "TestDidNotRun", "ResourceDenied",
     # imports
-    "import_module", "import_fresh_module", "CleanImport",
     # modules
-    "unload", "forget",
     # io
     "record_original_stdout", "get_original_stdout", "captured_stdout",
     "captured_stdin", "captured_stderr",
@@ -198,21 +196,6 @@ class ResourceDenied(unittest.SkipTest):
     and unexpected skips.
     """
 
-@contextlib.contextmanager
-def _ignore_deprecated_imports(ignore=True):
-    """Context manager to suppress package and module deprecation
-    warnings when importing them.
-
-    If ignore is False, this context manager has no effect.
-    """
-    if ignore:
-        with warnings.catch_warnings():
-            warnings.filterwarnings("ignore", ".+ (module|package)",
-                                    DeprecationWarning)
-            yield
-    else:
-        yield
-
 
 def ignore_warnings(*, category):
     """Decorator to suppress deprecation warnings.
@@ -228,52 +211,6 @@ def ignore_warnings(*, category):
                 return test(self, *args, **kwargs)
         return wrapper
     return decorator
-
-
-def import_module(name, deprecated=False, *, required_on=()):
-    """Import and return the module to be tested, raising SkipTest if
-    it is not available.
-
-    If deprecated is True, any module or package deprecation messages
-    will be suppressed. If a module is required on a platform but optional for
-    others, set required_on to an iterable of platform prefixes which will be
-    compared against sys.platform.
-    """
-    with _ignore_deprecated_imports(deprecated):
-        try:
-            return importlib.import_module(name)
-        except ImportError as msg:
-            if sys.platform.startswith(tuple(required_on)):
-                raise
-            raise unittest.SkipTest(str(msg))
-
-
-def _save_and_remove_module(name, orig_modules):
-    """Helper function to save and remove a module from sys.modules
-
-    Raise ImportError if the module can't be imported.
-    """
-    # try to import the module and raise an error if it can't be imported
-    if name not in sys.modules:
-        __import__(name)
-        del sys.modules[name]
-    for modname in list(sys.modules):
-        if modname == name or modname.startswith(name + '.'):
-            orig_modules[modname] = sys.modules[modname]
-            del sys.modules[modname]
-
-def _save_and_block_module(name, orig_modules):
-    """Helper function to save and block a module in sys.modules
-
-    Return True if the module was in sys.modules, False otherwise.
-    """
-    saved = True
-    try:
-        orig_modules[name] = sys.modules[name]
-    except KeyError:
-        saved = False
-    sys.modules[name] = None
-    return saved
 
 
 def anticipate_failure(condition):
@@ -304,56 +241,6 @@ def load_package_tests(pkg_dir, loader, standard_tests, pattern):
     return standard_tests
 
 
-def import_fresh_module(name, fresh=(), blocked=(), deprecated=False):
-    """Import and return a module, deliberately bypassing sys.modules.
-
-    This function imports and returns a fresh copy of the named Python module
-    by removing the named module from sys.modules before doing the import.
-    Note that unlike reload, the original module is not affected by
-    this operation.
-
-    *fresh* is an iterable of additional module names that are also removed
-    from the sys.modules cache before doing the import.
-
-    *blocked* is an iterable of module names that are replaced with None
-    in the module cache during the import to ensure that attempts to import
-    them raise ImportError.
-
-    The named module and any modules named in the *fresh* and *blocked*
-    parameters are saved before starting the import and then reinserted into
-    sys.modules when the fresh import is complete.
-
-    Module and package deprecation messages are suppressed during this import
-    if *deprecated* is True.
-
-    This function will raise ImportError if the named module cannot be
-    imported.
-    """
-    # NOTE: test_heapq, test_json and test_warnings include extra sanity checks
-    # to make sure that this utility function is working as expected
-    with _ignore_deprecated_imports(deprecated):
-        # Keep track of modules saved for later restoration as well
-        # as those which just need a blocking entry removed
-        orig_modules = {}
-        names_to_remove = []
-        _save_and_remove_module(name, orig_modules)
-        try:
-            for fresh_name in fresh:
-                _save_and_remove_module(fresh_name, orig_modules)
-            for blocked_name in blocked:
-                if not _save_and_block_module(blocked_name, orig_modules):
-                    names_to_remove.append(blocked_name)
-            fresh_module = importlib.import_module(name)
-        except ImportError:
-            fresh_module = None
-        finally:
-            for orig_name, module in orig_modules.items():
-                sys.modules[orig_name] = module
-            for name_to_remove in names_to_remove:
-                del sys.modules[name_to_remove]
-        return fresh_module
-
-
 def get_attribute(obj, name):
     """Get an attribute, raising SkipTest if AttributeError is raised."""
     try:
@@ -381,12 +268,6 @@ def record_original_stdout(stdout):
 
 def get_original_stdout():
     return _original_stdout or sys.stdout
-
-def unload(name):
-    try:
-        del sys.modules[name]
-    except KeyError:
-        pass
 
 def _force_run(path, func, *args):
     try:
@@ -527,34 +408,6 @@ def rmtree(path):
         _rmtree(path)
     except FileNotFoundError:
         pass
-
-def make_legacy_pyc(source):
-    """Move a PEP 3147/488 pyc file to its legacy pyc location.
-
-    :param source: The file system path to the source file.  The source file
-        does not need to exist, however the PEP 3147/488 pyc file must exist.
-    :return: The file system path to the legacy pyc file.
-    """
-    pyc_file = importlib.util.cache_from_source(source)
-    up_one = os.path.dirname(os.path.abspath(source))
-    legacy_pyc = os.path.join(up_one, source + 'c')
-    os.rename(pyc_file, legacy_pyc)
-    return legacy_pyc
-
-def forget(modname):
-    """'Forget' a module was ever imported.
-
-    This removes the module from sys.modules and deletes any PEP 3147/488 or
-    legacy .pyc files.
-    """
-    unload(modname)
-    for dirname in sys.path:
-        source = os.path.join(dirname, modname + '.py')
-        # It doesn't matter if they exist or not, unlink all possible
-        # combinations of PEP 3147/488 and legacy pyc files.
-        unlink(source + 'c')
-        for opt in ('', 1, 2):
-            unlink(importlib.util.cache_from_source(source, optimization=opt))
 
 # Check whether a gui is actually available
 def _is_gui_available():
@@ -1224,62 +1077,6 @@ def check_no_resource_warning(testcase):
     with check_no_warnings(testcase, category=ResourceWarning, force_gc=True):
         yield
 
-
-class CleanImport(object):
-    """Context manager to force import to return a new module reference.
-
-    This is useful for testing module-level behaviours, such as
-    the emission of a DeprecationWarning on import.
-
-    Use like this:
-
-        with CleanImport("foo"):
-            importlib.import_module("foo") # new reference
-    """
-
-    def __init__(self, *module_names):
-        self.original_modules = sys.modules.copy()
-        for module_name in module_names:
-            if module_name in sys.modules:
-                module = sys.modules[module_name]
-                # It is possible that module_name is just an alias for
-                # another module (e.g. stub for modules renamed in 3.x).
-                # In that case, we also need delete the real module to clear
-                # the import cache.
-                if module.__name__ != module_name:
-                    del sys.modules[module.__name__]
-                del sys.modules[module_name]
-
-    def __enter__(self):
-        return self
-
-    def __exit__(self, *ignore_exc):
-        sys.modules.update(self.original_modules)
-
-
-class DirsOnSysPath(object):
-    """Context manager to temporarily add directories to sys.path.
-
-    This makes a copy of sys.path, appends any directories given
-    as positional arguments, then reverts sys.path to the copied
-    settings when the context ends.
-
-    Note that *all* sys.path modifications in the body of the
-    context manager, including replacement of the object,
-    will be reverted at the end of the block.
-    """
-
-    def __init__(self, *paths):
-        self.original_value = sys.path[:]
-        self.original_object = sys.path
-        sys.path.extend(paths)
-
-    def __enter__(self):
-        return self
-
-    def __exit__(self, *ignore_exc):
-        sys.path = self.original_object
-        sys.path[:] = self.original_value
 
 
 class TransientResource(object):
@@ -2024,25 +1821,6 @@ def print_warning(msg):
 # log warnings even if sys.stderr is captured temporarily by a test.
 print_warning.orig_stderr = sys.stderr
 
-def modules_setup():
-    return sys.modules.copy(),
-
-def modules_cleanup(oldmodules):
-    # Encoders/decoders are registered permanently within the internal
-    # codec cache. If we destroy the corresponding modules their
-    # globals will be set to None which will trip up the cached functions.
-    encodings = [(k, v) for k, v in sys.modules.items()
-                 if k.startswith('encodings.')]
-    sys.modules.clear()
-    sys.modules.update(encodings)
-    # XXX: This kind of problem can affect more than just encodings. In particular
-    # extension modules (such as _ssl) don't cope with reloading properly.
-    # Really, test modules should be cleaning out the test specific modules they
-    # know they added (ala test_runpy) rather than relying on this function (as
-    # test_importhooks and test_pkg do currently).
-    # Implicitly imported *real* modules should be left alone (see issue 10556).
-    sys.modules.update(oldmodules)
-
 #=======================================================================
 # Threading support to prevent reporting refleaks when running regrtest.py -R
 
@@ -2075,8 +1853,7 @@ def threading_cleanup(*original_values):
         if values == original_values:
             break
 
-        if not count:
-            # Display a warning at the first iteration
+        if not count: # Display a warning at the first iteration
             environment_altered = True
             dangling_threads = values[1]
             print_warning(f"threading_cleanup() failed to cleanup "

--- a/Lib/test/support/import_helper.py
+++ b/Lib/test/support/import_helper.py
@@ -1,0 +1,355 @@
+import contextlib
+# TODO: RUSTPYTHON
+# import _imp
+import importlib
+import importlib.util
+import os
+import sys
+import unittest
+import warnings
+
+from .os_helper import unlink
+
+
+@contextlib.contextmanager
+def _ignore_deprecated_imports(ignore=True):
+    """Context manager to suppress package and module deprecation
+    warnings when importing them.
+
+    If ignore is False, this context manager has no effect.
+    """
+    if ignore:
+        with warnings.catch_warnings():
+            warnings.filterwarnings("ignore", ".+ (module|package)",
+                                    DeprecationWarning)
+            yield
+    else:
+        yield
+
+
+def unload(name):
+    try:
+        del sys.modules[name]
+    except KeyError:
+        pass
+
+
+def forget(modname):
+    """'Forget' a module was ever imported.
+
+    This removes the module from sys.modules and deletes any PEP 3147/488 or
+    legacy .pyc files.
+    """
+    unload(modname)
+    for dirname in sys.path:
+        source = os.path.join(dirname, modname + '.py')
+        # It doesn't matter if they exist or not, unlink all possible
+        # combinations of PEP 3147/488 and legacy pyc files.
+        unlink(source + 'c')
+        for opt in ('', 1, 2):
+            unlink(importlib.util.cache_from_source(source, optimization=opt))
+
+
+def make_legacy_pyc(source):
+    """Move a PEP 3147/488 pyc file to its legacy pyc location.
+
+    :param source: The file system path to the source file.  The source file
+        does not need to exist, however the PEP 3147/488 pyc file must exist.
+    :return: The file system path to the legacy pyc file.
+    """
+    pyc_file = importlib.util.cache_from_source(source)
+    up_one = os.path.dirname(os.path.abspath(source))
+    legacy_pyc = os.path.join(up_one, source + 'c')
+    os.rename(pyc_file, legacy_pyc)
+    return legacy_pyc
+
+
+def import_module(name, deprecated=False, *, required_on=()):
+    """Import and return the module to be tested, raising SkipTest if
+    it is not available.
+
+    If deprecated is True, any module or package deprecation messages
+    will be suppressed. If a module is required on a platform but optional for
+    others, set required_on to an iterable of platform prefixes which will be
+    compared against sys.platform.
+    """
+    with _ignore_deprecated_imports(deprecated):
+        try:
+            return importlib.import_module(name)
+        except ImportError as msg:
+            if sys.platform.startswith(tuple(required_on)):
+                raise
+            raise unittest.SkipTest(str(msg))
+
+
+def _save_and_remove_modules(names):
+    orig_modules = {}
+    prefixes = tuple(name + '.' for name in names)
+    for modname in list(sys.modules):
+        if modname in names or modname.startswith(prefixes):
+            orig_modules[modname] = sys.modules.pop(modname)
+    return orig_modules
+
+
+# XXX RUSTPYTHON: need _imp._override_frozen_modules_for_tests
+# @contextlib.contextmanager
+# def frozen_modules(enabled=True):
+#     """Force frozen modules to be used (or not).
+
+#     This only applies to modules that haven't been imported yet.
+#     Also, some essential modules will always be imported frozen.
+#     """
+#     _imp._override_frozen_modules_for_tests(1 if enabled else -1)
+#     try:
+#         yield
+#     finally:
+#         _imp._override_frozen_modules_for_tests(0)
+
+
+# XXX RUSTPYTHON: new implementation needs fronzen_modules
+# def import_fresh_module(name, fresh=(), blocked=(), *,
+#                         deprecated=False,
+#                         usefrozen=False,
+#                         ):
+#     """Import and return a module, deliberately bypassing sys.modules.
+
+#     This function imports and returns a fresh copy of the named Python module
+#     by removing the named module from sys.modules before doing the import.
+#     Note that unlike reload, the original module is not affected by
+#     this operation.
+
+#     *fresh* is an iterable of additional module names that are also removed
+#     from the sys.modules cache before doing the import. If one of these
+#     modules can't be imported, None is returned.
+
+#     *blocked* is an iterable of module names that are replaced with None
+#     in the module cache during the import to ensure that attempts to import
+#     them raise ImportError.
+
+#     The named module and any modules named in the *fresh* and *blocked*
+#     parameters are saved before starting the import and then reinserted into
+#     sys.modules when the fresh import is complete.
+
+#     Module and package deprecation messages are suppressed during this import
+#     if *deprecated* is True.
+
+#     This function will raise ImportError if the named module cannot be
+#     imported.
+
+#     If "usefrozen" is False (the default) then the frozen importer is
+#     disabled (except for essential modules like importlib._bootstrap).
+#     """
+#     # NOTE: test_heapq, test_json and test_warnings include extra sanity checks
+#     # to make sure that this utility function is working as expected
+#     with _ignore_deprecated_imports(deprecated):
+#         # Keep track of modules saved for later restoration as well
+#         # as those which just need a blocking entry removed
+#         fresh = list(fresh)
+#         blocked = list(blocked)
+#         names = {name, *fresh, *blocked}
+#         orig_modules = _save_and_remove_modules(names)
+#         for modname in blocked:
+#             sys.modules[modname] = None
+
+#         try:
+#             with frozen_modules(usefrozen):
+#                 # Return None when one of the "fresh" modules can not be imported.
+#                 try:
+#                     for modname in fresh:
+#                         __import__(modname)
+#                 except ImportError:
+#                     return None
+#                 return importlib.import_module(name)
+#         finally:
+#             _save_and_remove_modules(names)
+#             sys.modules.update(orig_modules)
+
+
+# TODO RUSTPYTHON: old implementation
+def _save_and_remove_module(name, orig_modules):
+    """Helper function to save and remove a module from sys.modules
+    Raise ImportError if the module can't be imported.
+    """
+    # try to import the module and raise an error if it can't be imported
+    if name not in sys.modules:
+        __import__(name)
+        del sys.modules[name]
+    for modname in list(sys.modules):
+        if modname == name or modname.startswith(name + '.'):
+            orig_modules[modname] = sys.modules[modname]
+            del sys.modules[modname]
+
+
+# TODO RUSTPYTHON: old implementation
+def _save_and_block_module(name, orig_modules):
+    """Helper function to save and block a module in sys.modules
+
+    Return True if the module was in sys.modules, False otherwise.
+    """
+    saved = True
+    try:
+        orig_modules[name] = sys.modules[name]
+    except KeyError:
+        saved = False
+    sys.modules[name] = None
+    return saved
+
+
+# TODO RUSTPYTHON: old implementation
+def import_fresh_module(name, fresh=(), blocked=(), deprecated=False):
+    """Import and return a module, deliberately bypassing sys.modules.
+    This function imports and returns a fresh copy of the named Python module
+    by removing the named module from sys.modules before doing the import.
+    Note that unlike reload, the original module is not affected by
+    this operation.
+    *fresh* is an iterable of additional module names that are also removed
+    from the sys.modules cache before doing the import.
+    *blocked* is an iterable of module names that are replaced with None
+    in the module cache during the import to ensure that attempts to import
+    them raise ImportError.
+    The named module and any modules named in the *fresh* and *blocked*
+    parameters are saved before starting the import and then reinserted into
+    sys.modules when the fresh import is complete.
+    Module and package deprecation messages are suppressed during this import
+    if *deprecated* is True.
+    This function will raise ImportError if the named module cannot be
+    imported.
+    """
+    # NOTE: test_heapq, test_json and test_warnings include extra sanity checks
+    # to make sure that this utility function is working as expected
+    with _ignore_deprecated_imports(deprecated):
+        # Keep track of modules saved for later restoration as well
+        # as those which just need a blocking entry removed
+        orig_modules = {}
+        names_to_remove = []
+        _save_and_remove_module(name, orig_modules)
+        try:
+            for fresh_name in fresh:
+                _save_and_remove_module(fresh_name, orig_modules)
+            for blocked_name in blocked:
+                if not _save_and_block_module(blocked_name, orig_modules):
+                    names_to_remove.append(blocked_name)
+            fresh_module = importlib.import_module(name)
+        except ImportError:
+            fresh_module = None
+        finally:
+            for orig_name, module in orig_modules.items():
+                sys.modules[orig_name] = module
+            for name_to_remove in names_to_remove:
+                del sys.modules[name_to_remove]
+        return fresh_module
+
+# TODO RUSTPYTHON: new implementation needs fronzen_modules
+# class CleanImport(object):
+#     """Context manager to force import to return a new module reference.
+
+#     This is useful for testing module-level behaviours, such as
+#     the emission of a DeprecationWarning on import.
+
+#     Use like this:
+
+#         with CleanImport("foo"):
+#             importlib.import_module("foo") # new reference
+
+#     If "usefrozen" is False (the default) then the frozen importer is
+#     disabled (except for essential modules like importlib._bootstrap).
+#     """
+
+#     def __init__(self, *module_names, usefrozen=False):
+#         self.original_modules = sys.modules.copy()
+#         for module_name in module_names:
+#             if module_name in sys.modules:
+#                 module = sys.modules[module_name]
+#                 # It is possible that module_name is just an alias for
+#                 # another module (e.g. stub for modules renamed in 3.x).
+#                 # In that case, we also need delete the real module to clear
+#                 # the import cache.
+#                 if module.__name__ != module_name:
+#                     del sys.modules[module.__name__]
+#                 del sys.modules[module_name]
+#         self._frozen_modules = frozen_modules(usefrozen)
+
+#     def __enter__(self):
+#         self._frozen_modules.__enter__()
+#         return self
+
+#     def __exit__(self, *ignore_exc):
+#         sys.modules.update(self.original_modules)
+#         self._frozen_modules.__exit__(*ignore_exc)
+
+
+# TODO RUSTPYTHON: old implementation
+class CleanImport(object):
+    """Context manager to force import to return a new module reference.
+    This is useful for testing module-level behaviours, such as
+    the emission of a DeprecationWarning on import.
+    Use like this:
+        with CleanImport("foo"):
+            importlib.import_module("foo") # new reference
+    """
+
+    def __init__(self, *module_names):
+        self.original_modules = sys.modules.copy()
+        for module_name in module_names:
+            if module_name in sys.modules:
+                module = sys.modules[module_name]
+                # It is possible that module_name is just an alias for
+                # another module (e.g. stub for modules renamed in 3.x).
+                # In that case, we also need delete the real module to clear
+                # the import cache.
+                if module.__name__ != module_name:
+                    del sys.modules[module.__name__]
+                del sys.modules[module_name]
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *ignore_exc):
+        sys.modules.update(self.original_modules)
+
+
+class DirsOnSysPath(object):
+    """Context manager to temporarily add directories to sys.path.
+
+    This makes a copy of sys.path, appends any directories given
+    as positional arguments, then reverts sys.path to the copied
+    settings when the context ends.
+
+    Note that *all* sys.path modifications in the body of the
+    context manager, including replacement of the object,
+    will be reverted at the end of the block.
+    """
+
+    def __init__(self, *paths):
+        self.original_value = sys.path[:]
+        self.original_object = sys.path
+        sys.path.extend(paths)
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *ignore_exc):
+        sys.path = self.original_object
+        sys.path[:] = self.original_value
+
+
+def modules_setup():
+    return sys.modules.copy(),
+
+
+def modules_cleanup(oldmodules):
+    # Encoders/decoders are registered permanently within the internal
+    # codec cache. If we destroy the corresponding modules their
+    # globals will be set to None which will trip up the cached functions.
+    encodings = [(k, v) for k, v in sys.modules.items()
+                 if k.startswith('encodings.')]
+    sys.modules.clear()
+    sys.modules.update(encodings)
+    # XXX: This kind of problem can affect more than just encodings.
+    # In particular extension modules (such as _ssl) don't cope
+    # with reloading properly. Really, test modules should be cleaning
+    # out the test specific modules they know they added (ala test_runpy)
+    # rather than relying on this function (as test_importhooks and test_pkg
+    # do currently). Implicitly imported *real* modules should be left alone
+    # (see issue 10556).
+    sys.modules.update(oldmodules)

--- a/Lib/test/support/script_helper.py
+++ b/Lib/test/support/script_helper.py
@@ -11,7 +11,8 @@ import py_compile
 import zipfile
 
 from importlib.util import source_from_cache
-from test.support import make_legacy_pyc, strip_python_stderr
+from test.support import strip_python_stderr
+from test.support.import_helper import make_legacy_pyc
 
 
 # Cached result of the expensive test performed in the function below.

--- a/Lib/test/test_asyncgen.py
+++ b/Lib/test/test_asyncgen.py
@@ -2,7 +2,7 @@ import inspect
 import types
 import unittest
 
-from test.support import import_module
+from test.support.import_helper import import_module
 asyncio = import_module("asyncio")
 
 

--- a/Lib/test/test_bisect.py
+++ b/Lib/test/test_bisect.py
@@ -1,10 +1,11 @@
 import sys
 import unittest
 from test import support
+from test.support import import_helper
 from collections import UserList
 
-py_bisect = support.import_fresh_module('bisect', blocked=['_bisect'])
-c_bisect = support.import_fresh_module('bisect', fresh=['bisect'])
+py_bisect = import_helper.import_fresh_module('bisect', blocked=['_bisect'])
+c_bisect = import_helper.import_fresh_module('bisect', fresh=['bisect'])
 
 class Range(object):
     """A trivial range()-like object that has an insert() method."""

--- a/Lib/test/test_bytes.py
+++ b/Lib/test/test_bytes.py
@@ -18,7 +18,7 @@ import unittest
 import test.support
 import test.string_tests
 import test.list_tests
-from test.support import bigaddrspacetest, MAX_Py_ssize_t
+from test.support import bigaddrspacetest, MAX_Py_ssize_t, import_helper
 from test.support.script_helper import assert_python_failure
 
 
@@ -977,7 +977,7 @@ class BaseBytesTest:
         self.assertEqual(c, b'hllo')
 
     def test_sq_item(self):
-        _testcapi = test.support.import_module('_testcapi')
+        _testcapi = import_helper.import_module('_testcapi')
         obj = self.type2test((42,))
         with self.assertRaises(IndexError):
             _testcapi.sequence_getitem(obj, -2)
@@ -1034,8 +1034,8 @@ class BytesTest(BaseBytesTest, unittest.TestCase):
 
     # Test PyBytes_FromFormat()
     def test_from_format(self):
-        ctypes = test.support.import_module('ctypes')
-        _testcapi = test.support.import_module('_testcapi')
+        ctypes = import_helper.import_module('ctypes')
+        _testcapi = import_helper.import_module('_testcapi')
         from ctypes import pythonapi, py_object
         from ctypes import (
             c_int, c_uint,

--- a/Lib/test/test_cmd.py
+++ b/Lib/test/test_cmd.py
@@ -9,6 +9,7 @@ import sys
 import unittest
 import io
 from test import support
+from test.support import import_helper
 
 class samplecmdclass(cmd.Cmd):
     """
@@ -225,7 +226,7 @@ def test_main(verbose=None):
     support.run_unittest(TestAlternateInput)
 
 def test_coverage(coverdir):
-    trace = support.import_module('trace')
+    trace = import_helper.import_module('trace')
     tracer=trace.Trace(ignoredirs=[sys.base_prefix, sys.base_exec_prefix,],
                         trace=0, count=1)
     tracer.run('import importlib; importlib.reload(cmd); test_main()')

--- a/Lib/test/test_cmd_line.py
+++ b/Lib/test/test_cmd_line.py
@@ -718,7 +718,7 @@ class CmdLineTest(unittest.TestCase):
 
     def check_warnings_filters(self, cmdline_option, envvar, use_pywarning=False):
         if use_pywarning:
-            code = ("import sys; from test.support import import_fresh_module; "
+            code = ("import sys; from test.support.import_helper import import_fresh_module; "
                     "warnings = import_fresh_module('warnings', blocked=['_warnings']); ")
         else:
             code = "import sys, warnings; "

--- a/Lib/test/test_cmd_line_script.py
+++ b/Lib/test/test_cmd_line_script.py
@@ -17,7 +17,7 @@ from test import support
 from test.support.script_helper import (
     make_pkg, make_script, make_zip_pkg, make_zip_script,
     assert_python_ok, assert_python_failure, spawn_python, kill_python)
-from test.support import os_helper
+from test.support import os_helper, import_helper
 
 verbose = support.verbose
 
@@ -238,7 +238,7 @@ class CmdLineTest(unittest.TestCase):
             script_name = _make_test_script(script_dir, 'script')
             py_compile.compile(script_name, doraise=True)
             os.remove(script_name)
-            pyc_file = support.make_legacy_pyc(script_name)
+            pyc_file = import_helper.make_legacy_pyc(script_name)
             self._check_script(pyc_file, pyc_file,
                                pyc_file, script_dir, None,
                                importlib.machinery.SourcelessFileLoader)
@@ -255,7 +255,7 @@ class CmdLineTest(unittest.TestCase):
             script_name = _make_test_script(script_dir, '__main__')
             py_compile.compile(script_name, doraise=True)
             os.remove(script_name)
-            pyc_file = support.make_legacy_pyc(script_name)
+            pyc_file = import_helper.make_legacy_pyc(script_name)
             self._check_script(script_dir, pyc_file, script_dir,
                                script_dir, '',
                                importlib.machinery.SourcelessFileLoader)
@@ -355,7 +355,7 @@ class CmdLineTest(unittest.TestCase):
             script_name = _make_test_script(pkg_dir, '__main__')
             compiled_name = py_compile.compile(script_name, doraise=True)
             os.remove(script_name)
-            pyc_file = support.make_legacy_pyc(script_name)
+            pyc_file = import_helper.make_legacy_pyc(script_name)
             self._check_script(["-m", "test_pkg"], pyc_file,
                                pyc_file, script_dir, 'test_pkg',
                                importlib.machinery.SourcelessFileLoader,

--- a/Lib/test/test_code_module.py
+++ b/Lib/test/test_code_module.py
@@ -4,9 +4,9 @@ import unittest
 from textwrap import dedent
 from contextlib import ExitStack
 from unittest import mock
-from test import support
+from test.support import import_helper
 
-code = support.import_module('code')
+code = import_helper.import_module('code')
 
 
 class TestInteractiveConsole(unittest.TestCase):

--- a/Lib/test/test_dbm.py
+++ b/Lib/test/test_dbm.py
@@ -3,10 +3,10 @@
 import unittest
 import glob
 import test.support
-from test.support import os_helper
+from test.support import os_helper, import_helper
 
 # Skip tests if dbm module doesn't exist.
-dbm = test.support.import_module('dbm')
+dbm = import_helper.import_module('dbm')
 
 try:
     from dbm import ndbm
@@ -181,7 +181,7 @@ class WhichDBTestCase(unittest.TestCase):
         self.filename = os_helper.TESTFN
         self.d = dbm.open(self.filename, 'c')
         self.d.close()
-        self.dbm = test.support.import_fresh_module('dbm')
+        self.dbm = import_helper.import_fresh_module('dbm')
 
     def test_keys(self):
         self.d = dbm.open(self.filename, 'c')

--- a/Lib/test/test_decimal.py
+++ b/Lib/test/test_decimal.py
@@ -34,8 +34,9 @@ import numbers
 import locale
 from test.support import (run_unittest, run_doctest, is_resource_enabled,
                           requires_IEEE_754, requires_docstrings)
-from test.support import (import_fresh_module, TestFailed,
-                          run_with_locale, cpython_only)
+from test.support import (TestFailed, run_with_locale,
+                          cpython_only)
+from test.support.import_helper import import_fresh_module
 import random
 import inspect
 import threading

--- a/Lib/test/test_exceptions.py
+++ b/Lib/test/test_exceptions.py
@@ -12,8 +12,9 @@ from test.support import (captured_stderr, check_impl_detail,
                           cpython_only, gc_collect,
                           no_tracing, script_helper,
                           SuppressCrashReport,
-                          import_module, check_warnings,)
+                          check_warnings,)
 from test.support.os_helper import TESTFN, unlink
+from test.support.import_helper import import_module
 from test import support
 
 class NaiveException(Exception):

--- a/Lib/test/test_functools.py
+++ b/Lib/test/test_functools.py
@@ -8,6 +8,7 @@ import pickle
 from random import choice
 import sys
 from test import support
+from test.support import import_helper
 import threading
 import time
 import typing
@@ -18,10 +19,10 @@ import contextlib
 
 import functools
 
-py_functools = support.import_fresh_module('functools', blocked=['_functools'])
-c_functools = support.import_fresh_module('functools', fresh=['_functools'])
+py_functools = import_helper.import_fresh_module('functools', blocked=['_functools'])
+c_functools = import_helper.import_fresh_module('functools', fresh=['_functools'])
 
-decimal = support.import_fresh_module('decimal', fresh=['_decimal'])
+decimal = import_helper.import_fresh_module('decimal', fresh=['_decimal'])
 
 @contextlib.contextmanager
 def replaced_module(name, replacement):

--- a/Lib/test/test_future.py
+++ b/Lib/test/test_future.py
@@ -4,6 +4,7 @@ import __future__
 import ast
 import unittest
 from test import support
+from test.support import import_helper
 from textwrap import dedent
 import os
 import re
@@ -24,17 +25,17 @@ class FutureTest(unittest.TestCase):
         self.assertEqual(err.offset, offset)
 
     def test_future1(self):
-        with support.CleanImport('future_test1'):
+        with import_helper.CleanImport('future_test1'):
             from test import future_test1
             self.assertEqual(future_test1.result, 6)
 
     def test_future2(self):
-        with support.CleanImport('future_test2'):
+        with import_helper.CleanImport('future_test2'):
             from test import future_test2
             self.assertEqual(future_test2.result, 6)
 
     def test_future3(self):
-        with support.CleanImport('test_future3'):
+        with import_helper.CleanImport('test_future3'):
             from test import test_future3
 
     def test_badfuture3(self):
@@ -120,7 +121,7 @@ class FutureTest(unittest.TestCase):
             self.fail("syntax error didn't occur")
 
     def test_multiple_features(self):
-        with support.CleanImport("test.test_future5"):
+        with import_helper.CleanImport("test.test_future5"):
             from test import test_future5
 
     def test_unicode_literals_exec(self):

--- a/Lib/test/test_gzip.py
+++ b/Lib/test/test_gzip.py
@@ -11,10 +11,10 @@ import sys
 import unittest
 from subprocess import PIPE, Popen
 from test import support
-from test.support import _4G, bigmemtest, os_helper
+from test.support import _4G, bigmemtest, os_helper, import_helper
 from test.support.script_helper import assert_python_ok, assert_python_failure
 
-gzip = support.import_module('gzip')
+gzip = import_helper.import_module('gzip')
 
 data1 = b"""  int length=DEFAULTALLOC, err = Z_OK;
   PyObject *RetVal;

--- a/Lib/test/test_hashlib.py
+++ b/Lib/test/test_hashlib.py
@@ -18,7 +18,8 @@ import threading
 import unittest
 import warnings
 from test import support
-from test.support import _4G, bigmemtest, import_fresh_module
+from test.support import _4G, bigmemtest
+from test.support.import_helper import import_fresh_module
 from http.client import HTTPException
 
 # Were we compiled --with-pydebug or with #define Py_DEBUG?

--- a/Lib/test/test_heapq.py
+++ b/Lib/test/test_heapq.py
@@ -5,11 +5,12 @@ import unittest
 import doctest
 
 from test import support
+from test.support import import_helper
 from unittest import TestCase, skipUnless
 from operator import itemgetter
 
-py_heapq = support.import_fresh_module('heapq', blocked=['_heapq'])
-c_heapq = support.import_fresh_module('heapq', fresh=['_heapq'])
+py_heapq = import_helper.import_fresh_module('heapq', blocked=['_heapq'])
+c_heapq = import_helper.import_fresh_module('heapq', fresh=['_heapq'])
 
 # _heapq.nlargest/nsmallest are saved in heapq._nlargest/_smallest when
 # _heapq is imported, so check them there

--- a/Lib/test/test_imp.py
+++ b/Lib/test/test_imp.py
@@ -5,7 +5,7 @@ import os.path
 import py_compile
 import sys
 from test import support
-from test.support import script_helper, os_helper
+from test.support import script_helper, os_helper, import_helper
 import unittest
 import warnings
 with warnings.catch_warnings():
@@ -211,7 +211,7 @@ class ImportTests(unittest.TestCase):
 
     def test_load_from_source(self):
         # Verify that the imp module can correctly load and find .py files
-        # XXX (ncoghlan): It would be nice to use support.CleanImport
+        # XXX (ncoghlan): It would be nice to use import_helper.CleanImport
         # here, but that breaks because the os module registers some
         # handlers in copy_reg on import. Since CleanImport doesn't
         # revert that registration, the module is left in a broken
@@ -408,12 +408,12 @@ class ReloadTests(unittest.TestCase):
             imp.reload(os)
 
     def test_extension(self):
-        with support.CleanImport('time'):
+        with import_helper.CleanImport('time'):
             import time
             imp.reload(time)
 
     def test_builtin(self):
-        with support.CleanImport('marshal'):
+        with import_helper.CleanImport('marshal'):
             import marshal
             imp.reload(marshal)
 

--- a/Lib/test/test_importlib/import_/test_packages.py
+++ b/Lib/test/test_importlib/import_/test_packages.py
@@ -2,6 +2,7 @@ from .. import util
 import sys
 import unittest
 from test import support
+from test.support import import_helper
 
 
 class ParentModuleTests:
@@ -98,7 +99,7 @@ class ParentModuleTests:
                 try:
                     submodule = self.__import__(subname)
                 finally:
-                    support.unload(subname)
+                    import_helper.unload(subname)
 
 
 (Frozen_ParentTests,

--- a/Lib/test/test_importlib/source/test_file_loader.py
+++ b/Lib/test/test_importlib/source/test_file_loader.py
@@ -17,7 +17,7 @@ import types
 import unittest
 import warnings
 
-from test.support import make_legacy_pyc, unload
+from test.support.import_helper import unload, make_legacy_pyc
 
 from test.test_py_compile import without_source_date_epoch
 from test.test_py_compile import SourceDateEpochTestMeta

--- a/Lib/test/test_importlib/source/test_finder.py
+++ b/Lib/test/test_importlib/source/test_finder.py
@@ -9,7 +9,7 @@ import py_compile
 import stat
 import sys
 import tempfile
-from test.support import make_legacy_pyc
+from test.support.import_helper import make_legacy_pyc
 import unittest
 import warnings
 

--- a/Lib/test/test_importlib/test_abc.py
+++ b/Lib/test/test_importlib/test_abc.py
@@ -2,7 +2,7 @@ import io
 import marshal
 import os
 import sys
-from test import support
+from test.support import import_helper
 import types
 import unittest
 from unittest import mock
@@ -29,7 +29,7 @@ class InheritanceTests:
         self.superclasses = [getattr(self.abc, class_name)
                              for class_name in self.superclass_names]
         if hasattr(self, 'subclass_names'):
-            # Because test.support.import_fresh_module() creates a new
+            # Because import_helper.import_fresh_module() creates a new
             # importlib._bootstrap per module, inheritance checks fail when
             # checking across module boundaries (i.e. the _bootstrap in abc is
             # not the same as the one in machinery). That means stealing one of
@@ -566,8 +566,8 @@ class InspectLoaderLoadModuleTests:
     module_name = 'blah'
 
     def setUp(self):
-        support.unload(self.module_name)
-        self.addCleanup(support.unload, self.module_name)
+        import_helper.unload(self.module_name)
+        self.addCleanup(import_helper.unload, self.module_name)
 
     def load(self, loader):
         spec = self.util.spec_from_loader(self.module_name, loader)

--- a/Lib/test/test_importlib/test_api.py
+++ b/Lib/test/test_importlib/test_api.py
@@ -8,6 +8,7 @@ import os.path
 import sys
 from test import support
 from test.support import os_helper
+from test.support import import_helper
 import types
 import unittest
 import warnings
@@ -201,7 +202,7 @@ class ReloadTests:
     def test_reload_modules(self):
         for mod in ('tokenize', 'time', 'marshal'):
             with self.subTest(module=mod):
-                with support.CleanImport(mod):
+                with import_helper.CleanImport(mod):
                     module = self.init.import_module(mod)
                     self.init.reload(module)
 
@@ -222,7 +223,7 @@ class ReloadTests:
                 self.assertEqual(reloaded.spam, 3)
 
     def test_reload_missing_loader(self):
-        with support.CleanImport('types'):
+        with import_helper.CleanImport('types'):
             import types
             loader = types.__loader__
             del types.__loader__
@@ -233,7 +234,7 @@ class ReloadTests:
             self.assertEqual(reloaded.__loader__.path, loader.path)
 
     def test_reload_loader_replaced(self):
-        with support.CleanImport('types'):
+        with import_helper.CleanImport('types'):
             import types
             types.__loader__ = None
             self.init.invalidate_caches()
@@ -247,7 +248,7 @@ class ReloadTests:
         name = 'spam'
         with os_helper.temp_cwd(None) as cwd:
             with test_util.uncache('spam'):
-                with support.DirsOnSysPath(cwd):
+                with import_helper.DirsOnSysPath(cwd):
                     # Start as a plain module.
                     self.init.invalidate_caches()
                     path = os.path.join(cwd, name + '.py')
@@ -298,7 +299,7 @@ class ReloadTests:
         name = 'spam'
         with os_helper.temp_cwd(None) as cwd:
             with test_util.uncache('spam'):
-                with support.DirsOnSysPath(cwd):
+                with import_helper.DirsOnSysPath(cwd):
                     # Start as a namespace package.
                     self.init.invalidate_caches()
                     bad_path = os.path.join(cwd, name, '__init.py')

--- a/Lib/test/test_importlib/test_spec.py
+++ b/Lib/test/test_importlib/test_spec.py
@@ -6,7 +6,7 @@ util = test_util.import_importlib('importlib.util')
 
 import os.path
 import pathlib
-from test.support import CleanImport
+from test.support.import_helper import CleanImport
 import unittest
 import sys
 import warnings

--- a/Lib/test/test_importlib/test_windows.py
+++ b/Lib/test/test_importlib/test_windows.py
@@ -6,11 +6,12 @@ import re
 import sys
 import unittest
 from test import support
+from test.support import import_helper
 from distutils.util import get_platform
 from contextlib import contextmanager
 from .util import temp_module
 
-support.import_module('winreg', required_on=['win'])
+import_helper.import_module('winreg', required_on=['win'])
 from winreg import (
     CreateKey, HKEY_CURRENT_USER,
     SetValue, REG_SZ, KEY_ALL_ACCESS,

--- a/Lib/test/test_importlib/util.py
+++ b/Lib/test/test_importlib/util.py
@@ -11,7 +11,7 @@ import os
 import os.path
 from pathlib import Path, PurePath
 from test import support
-from test.support import os_helper
+from test.support import os_helper, import_helper
 import unittest
 import sys
 import tempfile
@@ -55,8 +55,8 @@ _extension_details()
 def import_importlib(module_name):
     """Import a module from importlib both w/ and w/o _frozen_importlib."""
     fresh = ('importlib',) if '.' in module_name else ()
-    frozen = support.import_fresh_module(module_name)
-    source = support.import_fresh_module(module_name, fresh=fresh,
+    frozen = import_helper.import_fresh_module(module_name)
+    source = import_helper.import_fresh_module(module_name, fresh=fresh,
                                          blocked=('_frozen_importlib', '_frozen_importlib_external'))
     return {'Frozen': frozen, 'Source': source}
 
@@ -150,7 +150,7 @@ def temp_module(name, content='', *, pkg=False):
     conflicts = [n for n in sys.modules if n.partition('.')[0] == name]
     with os_helper.temp_cwd(None) as cwd:
         with uncache(name, *conflicts):
-            with support.DirsOnSysPath(cwd):
+            with import_helper.DirsOnSysPath(cwd):
                 invalidate_caches()
 
                 location = os.path.join(cwd, name)
@@ -562,8 +562,8 @@ class ZipSetupBase:
             pass
 
     def setUp(self):
-        modules = support.modules_setup()
-        self.addCleanup(support.modules_cleanup, *modules)
+        modules = import_helper.modules_setup()
+        self.addCleanup(import_helper.modules_cleanup, *modules)
 
 
 class ZipSetup(ZipSetupBase):

--- a/Lib/test/test_io.py
+++ b/Lib/test/test_io.py
@@ -37,7 +37,7 @@ import weakref
 from collections import deque, UserList
 from itertools import cycle, count
 from test import support
-from test.support import os_helper
+from test.support import os_helper, import_helper
 from test.support.script_helper import assert_python_ok, run_python_until_end
 from test.support.os_helper import FakePath
 
@@ -4568,7 +4568,7 @@ class SignalsTest(unittest.TestCase):
         """Check that a buffered write, when it gets interrupted (either
         returning a partial result or EINTR), properly invokes the signal
         handler and retries if the latter returned successfully."""
-        select = support.import_module("select")
+        select = import_helper.import_module("select")
 
         # A quantity that exceeds the buffer size of an anonymous pipe's
         # write end.

--- a/Lib/test/test_json/__init__.py
+++ b/Lib/test/test_json/__init__.py
@@ -4,12 +4,13 @@ import doctest
 import unittest
 
 from test import support
+from test.support import import_helper
 
 # import json with and without accelerations
 # XXX RUSTPYTHON: we don't import _json as fresh since the fresh module isn't placed
 # into the sys.modules cache, and therefore the vm can't recognize the _json.Scanner class
-cjson = support.import_fresh_module('json') #, fresh=['_json'])
-pyjson = support.import_fresh_module('json', blocked=['_json'])
+cjson = import_helper.import_fresh_module('json') #, fresh=['_json'])
+pyjson = import_helper.import_fresh_module('json', blocked=['_json'])
 # JSONDecodeError is cached inside the _json module
 cjson.JSONDecodeError = cjson.decoder.JSONDecodeError = json.JSONDecodeError
 

--- a/Lib/test/test_memoryview.py
+++ b/Lib/test/test_memoryview.py
@@ -6,6 +6,7 @@
 
 import unittest
 import test.support
+from test.support import import_helper
 import sys
 # import gc  # XXX: RUSTPYTHON
 import weakref
@@ -523,7 +524,7 @@ class ArrayMemorySliceSliceTest(unittest.TestCase,
 class OtherTest(unittest.TestCase):
     def test_ctypes_cast(self):
         # Issue 15944: Allow all source formats when casting to bytes.
-        ctypes = test.support.import_module("ctypes")
+        ctypes = import_helper.import_module("ctypes")
         p6 = bytes(ctypes.c_double(0.6))
 
         d = ctypes.c_double()

--- a/Lib/test/test_operator.py
+++ b/Lib/test/test_operator.py
@@ -3,9 +3,10 @@ import pickle
 import sys
 
 from test import support
+from test.support import import_helper
 
-py_operator = support.import_fresh_module('operator', blocked=['_operator'])
-c_operator = support.import_fresh_module('operator', fresh=['_operator'])
+py_operator = import_helper.import_fresh_module('operator', blocked=['_operator'])
+c_operator = import_helper.import_fresh_module('operator', fresh=['_operator'])
 
 class Seq1:
     def __init__(self, lst):

--- a/Lib/test/test_ordered_dict.py
+++ b/Lib/test/test_ordered_dict.py
@@ -10,10 +10,11 @@ import unittest
 import weakref
 from collections.abc import MutableMapping
 from test import mapping_tests, support
+from test.support import import_helper
 
 
-py_coll = support.import_fresh_module('collections', blocked=['_collections'])
-c_coll = support.import_fresh_module('collections', fresh=['_collections'])
+py_coll = import_helper.import_fresh_module('collections', blocked=['_collections'])
+c_coll = import_helper.import_fresh_module('collections', fresh=['_collections'])
 
 
 @contextlib.contextmanager

--- a/Lib/test/test_os.py
+++ b/Lib/test/test_os.py
@@ -31,8 +31,7 @@ import unittest
 import uuid
 import warnings
 from test import support
-# TODO: RUSTPYTHON
-# from test.support import import_helper
+from test.support import import_helper
 from test.support import os_helper
 # TODO: RUSTPYTHON
 # from test.support import socket_helper
@@ -2852,8 +2851,8 @@ class Win32JunctionTests(unittest.TestCase):
 @unittest.skipUnless(sys.platform == "win32", "Win32 specific tests")
 class Win32NtTests(unittest.TestCase):
     def test_getfinalpathname_handles(self):
-        nt = support.import_module('nt')
-        ctypes = support.import_module('ctypes')
+        nt = import_helper.import_module('nt')
+        ctypes = import_helper.import_module('ctypes')
         import ctypes.wintypes
 
         kernel = ctypes.WinDLL('Kernel32.dll', use_last_error=True)

--- a/Lib/test/test_pathlib.py
+++ b/Lib/test/test_pathlib.py
@@ -12,7 +12,7 @@ import unittest
 from unittest import mock
 
 from test import support
-from test.support import os_helper
+from test.support import os_helper, import_helper
 from test.support.os_helper import TESTFN, FakePath
 
 try:
@@ -2184,7 +2184,7 @@ class PosixPathTest(_BasePathTest, unittest.TestCase):
                          'pwd module does not expose getpwall()')
     def test_expanduser(self):
         P = self.cls
-        support.import_module('pwd')
+        import_helper.import_module('pwd')
         import pwd
         pwdent = pwd.getpwuid(os.getuid())
         username = pwdent.pw_name

--- a/Lib/test/test_pkgutil.py
+++ b/Lib/test/test_pkgutil.py
@@ -1,4 +1,5 @@
-from test.support import run_unittest, unload, check_warnings, CleanImport
+from test.support import run_unittest, check_warnings
+from test.support.import_helper import unload, CleanImport
 import unittest
 import sys
 import importlib

--- a/Lib/test/test_posix.py
+++ b/Lib/test/test_posix.py
@@ -1,11 +1,11 @@
 "Test posix functions"
 
 from test import support
-from test.support import os_helper
+from test.support import os_helper, import_helper
 from test.support.script_helper import assert_python_ok
 
 # Skip these tests if there is no posix module.
-posix = support.import_module('posix')
+posix = import_helper.import_module('posix')
 
 import errno
 import sys

--- a/Lib/test/test_posixpath.py
+++ b/Lib/test/test_posixpath.py
@@ -3,7 +3,7 @@ import posixpath
 import unittest
 from posixpath import realpath, abspath, dirname, basename
 from test import support, test_genericpath
-from test.support import os_helper
+from test.support import os_helper, import_helper
 from test.support.os_helper import FakePath
 from unittest import mock
 
@@ -270,7 +270,7 @@ class PosixPathTest(unittest.TestCase):
                     self.assertEqual(posixpath.expanduser("~/foo"), "/foo")
 
     def test_expanduser_pwd(self):
-        pwd = support.import_module('pwd')
+        pwd = import_helper.import_module('pwd')
 
         self.assertIsInstance(posixpath.expanduser("~/"), str)
         self.assertIsInstance(posixpath.expanduser(b"~/"), bytes)

--- a/Lib/test/test_pty.py
+++ b/Lib/test/test_pty.py
@@ -1,4 +1,5 @@
-from test.support import verbose, import_module, reap_children
+from test.support import verbose, reap_children
+from test.support.import_helper import import_module
 
 # Skip these tests if termios is not available
 import_module('termios')

--- a/Lib/test/test_pwd.py
+++ b/Lib/test/test_pwd.py
@@ -1,8 +1,9 @@
 import sys
 import unittest
 from test import support
+from test.support import import_helper
 
-pwd = support.import_module('pwd')
+pwd = import_helper.import_module('pwd')
 
 @unittest.skipUnless(hasattr(pwd, 'getpwall'), 'Does not have getpwall()')
 class PwdTest(unittest.TestCase):

--- a/Lib/test/test_queue.py
+++ b/Lib/test/test_queue.py
@@ -7,9 +7,10 @@ import time
 import unittest
 import weakref
 from test import support
+from test.support import import_helper
 
-py_queue = support.import_fresh_module('queue', blocked=['_queue'])
-c_queue = support.import_fresh_module('queue', fresh=['_queue'])
+py_queue = import_helper.import_fresh_module('queue', blocked=['_queue'])
+c_queue = import_helper.import_fresh_module('queue', fresh=['_queue'])
 need_c_queue = unittest.skipUnless(c_queue, "No _queue module found")
 
 QUEUE_SIZE = 5

--- a/Lib/test/test_resource.py
+++ b/Lib/test/test_resource.py
@@ -2,10 +2,10 @@ import contextlib
 import sys
 import unittest
 from test import support
-from test.support import os_helper
+from test.support import os_helper, import_helper
 import time
 
-resource = support.import_module('resource')
+resource = import_helper.import_module('resource')
 
 # This test is checking a few specific problem spots with the resource module.
 

--- a/Lib/test/test_runpy.py
+++ b/Lib/test/test_runpy.py
@@ -12,10 +12,10 @@ import tempfile
 import textwrap
 import unittest
 import warnings
-from test.support import (
-    forget, make_legacy_pyc, unload, verbose, no_tracing)
+from test.support import verbose, no_tracing
 from test.support.os_helper import create_empty_file, temp_dir
 from test.support.script_helper import make_script, make_zip_script
+from test.support.import_helper import unload, forget, make_legacy_pyc
 
 
 import runpy

--- a/Lib/test/test_stat.py
+++ b/Lib/test/test_stat.py
@@ -2,9 +2,9 @@ import unittest
 import os
 import socket
 import sys
-from test.support import (import_fresh_module,
-                          skip_unless_bind_unix_socket)
+from test.support import skip_unless_bind_unix_socket
 from test.support.os_helper import TESTFN
+from test.support.import_helper import import_fresh_module
 
 c_stat = import_fresh_module('stat', fresh=['_stat'])
 py_stat = import_fresh_module('stat', blocked=['_stat'])

--- a/Lib/test/test_statistics.py
+++ b/Lib/test/test_statistics.py
@@ -14,11 +14,11 @@ import pickle
 import random
 import sys
 import unittest
-from test import support
 
 from decimal import Decimal
 from fractions import Fraction
 from test import support
+from test.support import import_helper
 
 
 # Module to be tested.
@@ -179,8 +179,8 @@ class _DoNothing:
 # We prefer this for testing numeric values that may not be exactly equal,
 # and avoid using TestCase.assertAlmostEqual, because it sucks :-)
 
-py_statistics = support.import_fresh_module('statistics', blocked=['_statistics'])
-c_statistics = support.import_fresh_module('statistics', fresh=['_statistics'])
+py_statistics = import_helper.import_fresh_module('statistics', blocked=['_statistics'])
+c_statistics = import_helper.import_fresh_module('statistics', fresh=['_statistics'])
 
 
 class TestModules(unittest.TestCase):

--- a/Lib/test/test_subprocess.py
+++ b/Lib/test/test_subprocess.py
@@ -18,7 +18,7 @@ import shutil
 import threading
 import gc
 import textwrap
-from test.support import os_helper
+from test.support import os_helper, import_helper
 from test.support.os_helper import FakePath
 
 try:
@@ -2772,7 +2772,7 @@ class POSIXProcessTestCase(BaseTestCase):
     def test_select_unbuffered(self):
         # Issue #11459: bufsize=0 should really set the pipes as
         # unbuffered (and therefore let select() work properly).
-        select = support.import_module("select")
+        select = import_helper.import_module("select")
         p = subprocess.Popen([sys.executable, "-c",
                               'import sys;'
                               'sys.stdout.write("apple")'],

--- a/Lib/test/test_sundry.py
+++ b/Lib/test/test_sundry.py
@@ -3,6 +3,7 @@ import importlib
 import platform
 import sys
 from test import support
+from test.support import import_helper
 import unittest
 
 class TestUntestedModules(unittest.TestCase):
@@ -11,7 +12,7 @@ class TestUntestedModules(unittest.TestCase):
         with support.check_warnings(quiet=True):
             for name in untested:
                 try:
-                    support.import_module('test.test_{}'.format(name))
+                    import_helper.import_module('test.test_{}'.format(name))
                 except unittest.SkipTest:
                     importlib.import_module(name)
                 else:

--- a/Lib/test/test_support.py
+++ b/Lib/test/test_support.py
@@ -13,7 +13,7 @@ import textwrap
 import time
 import unittest
 from test import support
-from test.support import script_helper, os_helper
+from test.support import script_helper, os_helper, import_helper
 
 TESTFN = os_helper.TESTFN
 
@@ -21,11 +21,11 @@ TESTFN = os_helper.TESTFN
 class TestSupport(unittest.TestCase):
 
     def test_import_module(self):
-        support.import_module("ftplib")
-        self.assertRaises(unittest.SkipTest, support.import_module, "foo")
+        import_helper.import_module("ftplib")
+        self.assertRaises(unittest.SkipTest, import_helper.import_module, "foo")
 
     def test_import_fresh_module(self):
-        support.import_fresh_module("ftplib")
+        import_helper.import_fresh_module("ftplib")
 
     def test_get_attribute(self):
         self.assertEqual(support.get_attribute(self, "test_get_attribute"),
@@ -39,7 +39,7 @@ class TestSupport(unittest.TestCase):
     def test_unload(self):
         import sched
         self.assertIn("sched", sys.modules)
-        support.unload("sched")
+        import_helper.unload("sched")
         self.assertNotIn("sched", sys.modules)
 
     def test_unlink(self):
@@ -83,7 +83,7 @@ class TestSupport(unittest.TestCase):
             mod = __import__(TESTFN)
             self.assertIn(TESTFN, sys.modules)
 
-            support.forget(TESTFN)
+            import_helper.forget(TESTFN)
             self.assertNotIn(TESTFN, sys.modules)
         finally:
             del sys.path[0]
@@ -291,11 +291,11 @@ class TestSupport(unittest.TestCase):
 
     def test_CleanImport(self):
         import importlib
-        with support.CleanImport("asyncore"):
+        with import_helper.CleanImport("asyncore"):
             importlib.import_module("asyncore")
 
     def test_DirsOnSysPath(self):
-        with support.DirsOnSysPath('foo', 'bar'):
+        with import_helper.DirsOnSysPath('foo', 'bar'):
             self.assertIn("foo", sys.path)
             self.assertIn("bar", sys.path)
         self.assertNotIn("foo", sys.path)

--- a/Lib/test/test_sysconfig.py
+++ b/Lib/test/test_sysconfig.py
@@ -5,10 +5,10 @@ import subprocess
 import shutil
 from copy import copy
 
-from test.support import (import_module, check_warnings,
-                          captured_stdout, PythonSymlink)
+from test.support import check_warnings, captured_stdout, PythonSymlink
 from test.support.os_helper import (TESTFN, unlink, skip_unless_symlink,
                                     change_cwd)
+from test.support.import_helper import import_module
 
 import sysconfig
 from sysconfig import (get_paths, get_platform, get_config_vars,

--- a/Lib/test/test_syslog.py
+++ b/Lib/test/test_syslog.py
@@ -1,6 +1,6 @@
 
-from test import support
-syslog = support.import_module("syslog") #skip if not supported
+from test.support import import_helper
+syslog = import_helper.import_module("syslog") #skip if not supported
 import unittest
 
 # XXX(nnorwitz): This test sucks.  I don't know of a platform independent way

--- a/Lib/test/test_threading.py
+++ b/Lib/test/test_threading.py
@@ -3,9 +3,10 @@ Tests for the threading module.
 """
 
 import test.support
-from test.support import (verbose, import_module, cpython_only,
+from test.support import (verbose, cpython_only,
                           requires_type_collecting)
 from test.support.script_helper import assert_python_ok, assert_python_failure
+from test.support.import_helper import import_module
 
 import random
 import sys

--- a/Lib/test/test_unicode.py
+++ b/Lib/test/test_unicode.py
@@ -15,6 +15,7 @@ import unicodedata
 import unittest
 import warnings
 from test import support, string_tests
+from test.support import import_helper
 
 # Error handling (bad decoder return)
 def search_function(encoding):
@@ -2504,7 +2505,7 @@ class CAPITest(unittest.TestCase):
 
     # Test PyUnicode_FromFormat()
     def test_from_format(self):
-        support.import_module('ctypes')
+        import_helper.import_module('ctypes')
         from ctypes import (
             pythonapi, py_object, sizeof,
             c_int, c_long, c_longlong, c_ssize_t,
@@ -2745,7 +2746,7 @@ class CAPITest(unittest.TestCase):
     @support.cpython_only
     def test_aswidechar(self):
         from _testcapi import unicode_aswidechar
-        support.import_module('ctypes')
+        import_helper.import_module('ctypes')
         from ctypes import c_wchar, sizeof
 
         wchar, size = unicode_aswidechar('abcdef', 2)
@@ -2783,7 +2784,7 @@ class CAPITest(unittest.TestCase):
     @support.cpython_only
     def test_aswidecharstring(self):
         from _testcapi import unicode_aswidecharstring
-        support.import_module('ctypes')
+        import_helper.import_module('ctypes')
         from ctypes import c_wchar, sizeof
 
         wchar, size = unicode_aswidecharstring('abc')

--- a/Lib/test/test_uuid.py
+++ b/Lib/test/test_uuid.py
@@ -1,5 +1,6 @@
 import unittest
 from test import support
+from test.support import import_helper
 import builtins
 import contextlib
 import copy
@@ -10,8 +11,8 @@ import sys
 import weakref
 from unittest import mock
 
-py_uuid = support.import_fresh_module('uuid', blocked=['_uuid'])
-c_uuid = support.import_fresh_module('uuid', fresh=['_uuid'])
+py_uuid = import_helper.import_fresh_module('uuid', blocked=['_uuid'])
+c_uuid = import_helper.import_fresh_module('uuid', fresh=['_uuid'])
 
 def importable(name):
     try:

--- a/Lib/test/test_venv.py
+++ b/Lib/test/test_venv.py
@@ -15,9 +15,9 @@ import struct
 import subprocess
 import sys
 import tempfile
-from test.support import (captured_stdout, captured_stderr, requires_zlib,
-                          import_module)
+from test.support import captured_stdout, captured_stderr, requires_zlib
 from test.support.os_helper import (can_symlink, EnvironmentVarGuard, rmtree)
+from test.support.import_helper import import_module
 import threading
 import unittest
 import venv

--- a/Lib/test/test_weakref.py
+++ b/Lib/test/test_weakref.py
@@ -2050,6 +2050,7 @@ class FinalizeTestCase(unittest.TestCase):
         assert f3.atexit == True
         assert f4.atexit == True
 
+    @unittest.skipIf(sys.platform == 'win32', 'TODO: RUSTPYTHON Windows')
     def test_atexit(self):
         prog = ('from test.test_weakref import FinalizeTestCase;'+
                 'FinalizeTestCase.run_in_child()')

--- a/Lib/test/test_webbrowser.py
+++ b/Lib/test/test_webbrowser.py
@@ -5,7 +5,7 @@ import sys
 import subprocess
 from unittest import mock
 from test import support
-from test.support import os_helper
+from test.support import os_helper, import_helper
 
 
 URL = 'http://www.example.com'
@@ -285,7 +285,7 @@ class ImportTest(unittest.TestCase):
     # TODO: RUSTPYTHON
     @unittest.expectedFailure
     def test_register(self):
-        webbrowser = support.import_fresh_module('webbrowser')
+        webbrowser = import_helper.import_fresh_module('webbrowser')
         self.assertIsNone(webbrowser._tryorder)
         self.assertFalse(webbrowser._browsers)
 
@@ -301,7 +301,7 @@ class ImportTest(unittest.TestCase):
     # TODO: RUSTPYTHON
     @unittest.expectedFailure
     def test_get(self):
-        webbrowser = support.import_fresh_module('webbrowser')
+        webbrowser = import_helper.import_fresh_module('webbrowser')
         self.assertIsNone(webbrowser._tryorder)
         self.assertFalse(webbrowser._browsers)
 
@@ -310,24 +310,24 @@ class ImportTest(unittest.TestCase):
         self.assertIsNotNone(webbrowser._tryorder)
 
     def test_synthesize(self):
-        webbrowser = support.import_fresh_module('webbrowser')
+        webbrowser = import_helper.import_fresh_module('webbrowser')
         name = os.path.basename(sys.executable).lower()
         webbrowser.register(name, None, webbrowser.GenericBrowser(name))
         webbrowser.get(sys.executable)
 
     def test_environment(self):
-        webbrowser = support.import_fresh_module('webbrowser')
+        webbrowser = import_helper.import_fresh_module('webbrowser')
         try:
             browser = webbrowser.get().name
         except (webbrowser.Error, AttributeError) as err:
             self.skipTest(str(err))
         with os_helper.EnvironmentVarGuard() as env:
             env["BROWSER"] = browser
-            webbrowser = support.import_fresh_module('webbrowser')
+            webbrowser = import_helper.import_fresh_module('webbrowser')
             webbrowser.get()
 
     def test_environment_preferred(self):
-        webbrowser = support.import_fresh_module('webbrowser')
+        webbrowser = import_helper.import_fresh_module('webbrowser')
         try:
             webbrowser.get()
             least_preferred_browser = webbrowser.get(webbrowser._tryorder[-1]).name
@@ -336,12 +336,12 @@ class ImportTest(unittest.TestCase):
 
         with os_helper.EnvironmentVarGuard() as env:
             env["BROWSER"] = least_preferred_browser
-            webbrowser = support.import_fresh_module('webbrowser')
+            webbrowser = import_helper.import_fresh_module('webbrowser')
             self.assertEqual(webbrowser.get().name, least_preferred_browser)
 
         with os_helper.EnvironmentVarGuard() as env:
             env["BROWSER"] = sys.executable
-            webbrowser = support.import_fresh_module('webbrowser')
+            webbrowser = import_helper.import_fresh_module('webbrowser')
             self.assertEqual(webbrowser.get().name, sys.executable)
 
 

--- a/Lib/test/test_xml_etree.py
+++ b/Lib/test/test_xml_etree.py
@@ -24,8 +24,9 @@ import weakref
 from functools import partial
 from itertools import product, islice
 from test import support
-from test.support import findfile, import_fresh_module, gc_collect, swap_attr, os_helper
+from test.support import findfile, gc_collect, swap_attr, os_helper
 from test.support.os_helper import TESTFN
+from test.support.import_helper import import_fresh_module
 
 # pyET is the pure-Python implementation.
 #

--- a/Lib/test/test_zipimport.py
+++ b/Lib/test/test_zipimport.py
@@ -9,7 +9,7 @@ import unittest
 import unittest.mock
 
 from test import support
-from test.support import os_helper
+from test.support import os_helper, import_helper
 
 from zipfile import ZipFile, ZipInfo, ZIP_STORED, ZIP_DEFLATED
 
@@ -69,14 +69,14 @@ class ImportHooksBaseTestCase(unittest.TestCase):
         self.meta_path = sys.meta_path[:]
         self.path_hooks = sys.path_hooks[:]
         sys.path_importer_cache.clear()
-        self.modules_before = support.modules_setup()
+        self.modules_before = import_helper.modules_setup()
 
     def tearDown(self):
         sys.path[:] = self.path
         sys.meta_path[:] = self.meta_path
         sys.path_hooks[:] = self.path_hooks
         sys.path_importer_cache.clear()
-        support.modules_cleanup(*self.modules_before)
+        import_helper.modules_cleanup(*self.modules_before)
 
 
 class UncompressedZipImportTestCase(ImportHooksBaseTestCase):

--- a/Lib/test/test_zlib.py
+++ b/Lib/test/test_zlib.py
@@ -5,9 +5,9 @@ import copy
 import pickle
 import random
 import sys
-from test.support import bigmemtest, _1G, _4G
+from test.support import bigmemtest, _1G, _4G, import_helper
 
-zlib = support.import_module('zlib')
+zlib = import_helper.import_module('zlib')
 
 requires_Compress_copy = unittest.skipUnless(
         hasattr(zlib.compressobj(), "copy"),

--- a/Lib/unittest/test/test_discovery.py
+++ b/Lib/unittest/test/test_discovery.py
@@ -5,6 +5,7 @@ import sys
 import types
 import pickle
 from test import support
+from test.support import import_helper
 import test.test_importlib.util
 
 import unittest
@@ -844,7 +845,7 @@ class TestDiscovery(unittest.TestCase):
 
         with unittest.mock.patch('builtins.__import__', _import):
             # Since loader.discover() can modify sys.path, restore it when done.
-            with support.DirsOnSysPath():
+            with import_helper.DirsOnSysPath():
                 # Make sure to remove 'package' from sys.modules when done.
                 with test.test_importlib.util.uncache('package'):
                     suite = loader.discover('package')
@@ -861,7 +862,7 @@ class TestDiscovery(unittest.TestCase):
 
         with unittest.mock.patch('builtins.__import__', _import):
             # Since loader.discover() can modify sys.path, restore it when done.
-            with support.DirsOnSysPath():
+            with import_helper.DirsOnSysPath():
                 # Make sure to remove 'package' from sys.modules when done.
                 with test.test_importlib.util.uncache('package'):
                     with self.assertRaises(TypeError) as cm:


### PR DESCRIPTION
This PR only cover the change for Lib/test/support/import_helper.py and reflect the changes necessary for other tests to use.
Mostly of the part is `from test.support import xxx` --> `from test.support.import_helper import xxx` etc.

`import_fresh_module` and `CleanImport` still use old implementation because it need `_imp._override_frozen_modules_for_tests` and it is currently not there.