### PR TITLE
Expose `types.GenericAlias.__getitem__`

### DIFF
--- a/vm/src/builtins/genericalias.rs
+++ b/vm/src/builtins/genericalias.rs
@@ -127,6 +127,58 @@ impl PyGenericAlias {
     }
 
     #[pymethod(magic)]
+    fn getitem(&self, needle: PyObjectRef, vm: &VirtualMachine) -> PyResult {
+        let num_params = self.parameters.len();
+        if num_params == 0 {
+            return Err(vm.new_type_error(format!(
+                "There are no type variables left in {}",
+                self.repr(vm)?
+            )));
+        }
+
+        let items = PyTupleRef::try_from_object(vm, needle.clone());
+        let arg_items = match items {
+            Ok(ref tuple) => tuple.as_slice(),
+            Err(_) => std::slice::from_ref(&needle),
+        };
+
+        let num_items = arg_items.len();
+        if num_params != num_items {
+            let plural = if num_items > num_params {
+                "many"
+            } else {
+                "few"
+            };
+            return Err(vm.new_type_error(format!(
+                "Too {} arguments for {}",
+                plural,
+                self.repr(vm)?
+            )));
+        }
+
+        let new_args = self
+            .args
+            .as_slice()
+            .iter()
+            .map(|arg| {
+                if is_typevar(arg) {
+                    let idx = tuple_index(&self.parameters, arg).unwrap();
+                    Ok(arg_items[idx].clone())
+                } else {
+                    subs_tvars(arg.clone(), &self.parameters, arg_items, vm)
+                }
+            })
+            .collect::<PyResult<Vec<_>>>()?;
+
+        Ok(PyGenericAlias::new(
+            self.origin.clone(),
+            PyTuple::new_ref(new_args, &vm.ctx).into(),
+            vm,
+        )
+        .into_object(vm))
+    }
+
+    #[pymethod(magic)]
     fn dir(&self, vm: &VirtualMachine) -> PyResult<PyList> {
         let dir = vm.dir(Some(self.origin()))?;
         for exc in ATTR_EXCEPTIONS.iter() {
@@ -238,57 +290,6 @@ fn subs_tvars(
 }
 
 impl PyGenericAlias {
-    fn getitem(&self, needle: PyObjectRef, vm: &VirtualMachine) -> PyResult {
-        let num_params = self.parameters.len();
-        if num_params == 0 {
-            return Err(vm.new_type_error(format!(
-                "There are no type variables left in {}",
-                self.repr(vm)?
-            )));
-        }
-
-        let items = PyTupleRef::try_from_object(vm, needle.clone());
-        let arg_items = match items {
-            Ok(ref tuple) => tuple.as_slice(),
-            Err(_) => std::slice::from_ref(&needle),
-        };
-
-        let num_items = arg_items.len();
-        if num_params != num_items {
-            let plural = if num_items > num_params {
-                "many"
-            } else {
-                "few"
-            };
-            return Err(vm.new_type_error(format!(
-                "Too {} arguments for {}",
-                plural,
-                self.repr(vm)?
-            )));
-        }
-
-        let new_args = self
-            .args
-            .as_slice()
-            .iter()
-            .map(|arg| {
-                if is_typevar(arg) {
-                    let idx = tuple_index(&self.parameters, arg).unwrap();
-                    Ok(arg_items[idx].clone())
-                } else {
-                    subs_tvars(arg.clone(), &self.parameters, arg_items, vm)
-                }
-            })
-            .collect::<PyResult<Vec<_>>>()?;
-
-        Ok(PyGenericAlias::new(
-            self.origin.clone(),
-            PyTuple::new_ref(new_args, &vm.ctx).into(),
-            vm,
-        )
-        .into_object(vm))
-    }
-
     const MAPPING_METHODS: PyMappingMethods = PyMappingMethods {
         length: None,
         subscript: Some(|mapping, needle, vm| {


### PR DESCRIPTION
## Description

While making #3497 work, I found `types.GenericAlias.__getitem__` wasn't exposed. This pull request just makes it 

## Check

You can run the below lines to test.

```
import typing
type(list[int]).__getitem__(list[typing.T], ...)  # expect list[...]
```

Before this pull request, you can see:

```
>>>>> import typing
>>>>> type(list[int]).__getitem__(list[typing.T], ...)
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
AttributeError: type object 'GenericAlias' has no attribute '__getitem__'. Did you mean: '__setattr__'?
```