### PR TITLE
Add the filecmp module from cpython v3.10.2

### DIFF
--- a/Lib/filecmp.py
+++ b/Lib/filecmp.py
@@ -1,0 +1,313 @@
+"""Utilities for comparing files and directories.
+
+Classes:
+    dircmp
+
+Functions:
+    cmp(f1, f2, shallow=True) -> int
+    cmpfiles(a, b, common) -> ([], [], [])
+    clear_cache()
+
+"""
+
+import os
+import stat
+from itertools import filterfalse
+from types import GenericAlias
+
+__all__ = ['clear_cache', 'cmp', 'dircmp', 'cmpfiles', 'DEFAULT_IGNORES']
+
+_cache = {}
+BUFSIZE = 8*1024
+
+DEFAULT_IGNORES = [
+    'RCS', 'CVS', 'tags', '.git', '.hg', '.bzr', '_darcs', '__pycache__']
+
+def clear_cache():
+    """Clear the filecmp cache."""
+    _cache.clear()
+
+def cmp(f1, f2, shallow=True):
+    """Compare two files.
+
+    Arguments:
+
+    f1 -- First file name
+
+    f2 -- Second file name
+
+    shallow -- treat files as identical if their stat signatures (type, size,
+               mtime) are identical. Otherwise, files are considered different
+               if their sizes or contents differ.  [default: True]
+
+    Return value:
+
+    True if the files are the same, False otherwise.
+
+    This function uses a cache for past comparisons and the results,
+    with cache entries invalidated if their stat information
+    changes.  The cache may be cleared by calling clear_cache().
+
+    """
+
+    s1 = _sig(os.stat(f1))
+    s2 = _sig(os.stat(f2))
+    if s1[0] != stat.S_IFREG or s2[0] != stat.S_IFREG:
+        return False
+    if shallow and s1 == s2:
+        return True
+    if s1[1] != s2[1]:
+        return False
+
+    outcome = _cache.get((f1, f2, s1, s2))
+    if outcome is None:
+        outcome = _do_cmp(f1, f2)
+        if len(_cache) > 100:      # limit the maximum size of the cache
+            clear_cache()
+        _cache[f1, f2, s1, s2] = outcome
+    return outcome
+
+def _sig(st):
+    return (stat.S_IFMT(st.st_mode),
+            st.st_size,
+            st.st_mtime)
+
+def _do_cmp(f1, f2):
+    bufsize = BUFSIZE
+    with open(f1, 'rb') as fp1, open(f2, 'rb') as fp2:
+        while True:
+            b1 = fp1.read(bufsize)
+            b2 = fp2.read(bufsize)
+            if b1 != b2:
+                return False
+            if not b1:
+                return True
+
+# Directory comparison class.
+#
+class dircmp:
+    """A class that manages the comparison of 2 directories.
+
+    dircmp(a, b, ignore=None, hide=None)
+      A and B are directories.
+      IGNORE is a list of names to ignore,
+        defaults to DEFAULT_IGNORES.
+      HIDE is a list of names to hide,
+        defaults to [os.curdir, os.pardir].
+
+    High level usage:
+      x = dircmp(dir1, dir2)
+      x.report() -> prints a report on the differences between dir1 and dir2
+       or
+      x.report_partial_closure() -> prints report on differences between dir1
+            and dir2, and reports on common immediate subdirectories.
+      x.report_full_closure() -> like report_partial_closure,
+            but fully recursive.
+
+    Attributes:
+     left_list, right_list: The files in dir1 and dir2,
+        filtered by hide and ignore.
+     common: a list of names in both dir1 and dir2.
+     left_only, right_only: names only in dir1, dir2.
+     common_dirs: subdirectories in both dir1 and dir2.
+     common_files: files in both dir1 and dir2.
+     common_funny: names in both dir1 and dir2 where the type differs between
+        dir1 and dir2, or the name is not stat-able.
+     same_files: list of identical files.
+     diff_files: list of filenames which differ.
+     funny_files: list of files which could not be compared.
+     subdirs: a dictionary of dircmp instances (or MyDirCmp instances if this
+       object is of type MyDirCmp, a subclass of dircmp), keyed by names
+       in common_dirs.
+     """
+
+    def __init__(self, a, b, ignore=None, hide=None): # Initialize
+        self.left = a
+        self.right = b
+        if hide is None:
+            self.hide = [os.curdir, os.pardir] # Names never to be shown
+        else:
+            self.hide = hide
+        if ignore is None:
+            self.ignore = DEFAULT_IGNORES
+        else:
+            self.ignore = ignore
+
+    def phase0(self): # Compare everything except common subdirectories
+        self.left_list = _filter(os.listdir(self.left),
+                                 self.hide+self.ignore)
+        self.right_list = _filter(os.listdir(self.right),
+                                  self.hide+self.ignore)
+        self.left_list.sort()
+        self.right_list.sort()
+
+    def phase1(self): # Compute common names
+        a = dict(zip(map(os.path.normcase, self.left_list), self.left_list))
+        b = dict(zip(map(os.path.normcase, self.right_list), self.right_list))
+        self.common = list(map(a.__getitem__, filter(b.__contains__, a)))
+        self.left_only = list(map(a.__getitem__, filterfalse(b.__contains__, a)))
+        self.right_only = list(map(b.__getitem__, filterfalse(a.__contains__, b)))
+
+    def phase2(self): # Distinguish files, directories, funnies
+        self.common_dirs = []
+        self.common_files = []
+        self.common_funny = []
+
+        for x in self.common:
+            a_path = os.path.join(self.left, x)
+            b_path = os.path.join(self.right, x)
+
+            ok = 1
+            try:
+                a_stat = os.stat(a_path)
+            except OSError:
+                # print('Can\'t stat', a_path, ':', why.args[1])
+                ok = 0
+            try:
+                b_stat = os.stat(b_path)
+            except OSError:
+                # print('Can\'t stat', b_path, ':', why.args[1])
+                ok = 0
+
+            if ok:
+                a_type = stat.S_IFMT(a_stat.st_mode)
+                b_type = stat.S_IFMT(b_stat.st_mode)
+                if a_type != b_type:
+                    self.common_funny.append(x)
+                elif stat.S_ISDIR(a_type):
+                    self.common_dirs.append(x)
+                elif stat.S_ISREG(a_type):
+                    self.common_files.append(x)
+                else:
+                    self.common_funny.append(x)
+            else:
+                self.common_funny.append(x)
+
+    def phase3(self): # Find out differences between common files
+        xx = cmpfiles(self.left, self.right, self.common_files)
+        self.same_files, self.diff_files, self.funny_files = xx
+
+    def phase4(self): # Find out differences between common subdirectories
+        # A new dircmp (or MyDirCmp if dircmp was subclassed) object is created
+        # for each common subdirectory,
+        # these are stored in a dictionary indexed by filename.
+        # The hide and ignore properties are inherited from the parent
+        self.subdirs = {}
+        for x in self.common_dirs:
+            a_x = os.path.join(self.left, x)
+            b_x = os.path.join(self.right, x)
+            self.subdirs[x]  = self.__class__(a_x, b_x, self.ignore, self.hide)
+
+    def phase4_closure(self): # Recursively call phase4() on subdirectories
+        self.phase4()
+        for sd in self.subdirs.values():
+            sd.phase4_closure()
+
+    def report(self): # Print a report on the differences between a and b
+        # Output format is purposely lousy
+        print('diff', self.left, self.right)
+        if self.left_only:
+            self.left_only.sort()
+            print('Only in', self.left, ':', self.left_only)
+        if self.right_only:
+            self.right_only.sort()
+            print('Only in', self.right, ':', self.right_only)
+        if self.same_files:
+            self.same_files.sort()
+            print('Identical files :', self.same_files)
+        if self.diff_files:
+            self.diff_files.sort()
+            print('Differing files :', self.diff_files)
+        if self.funny_files:
+            self.funny_files.sort()
+            print('Trouble with common files :', self.funny_files)
+        if self.common_dirs:
+            self.common_dirs.sort()
+            print('Common subdirectories :', self.common_dirs)
+        if self.common_funny:
+            self.common_funny.sort()
+            print('Common funny cases :', self.common_funny)
+
+    def report_partial_closure(self): # Print reports on self and on subdirs
+        self.report()
+        for sd in self.subdirs.values():
+            print()
+            sd.report()
+
+    def report_full_closure(self): # Report on self and subdirs recursively
+        self.report()
+        for sd in self.subdirs.values():
+            print()
+            sd.report_full_closure()
+
+    methodmap = dict(subdirs=phase4,
+                     same_files=phase3, diff_files=phase3, funny_files=phase3,
+                     common_dirs = phase2, common_files=phase2, common_funny=phase2,
+                     common=phase1, left_only=phase1, right_only=phase1,
+                     left_list=phase0, right_list=phase0)
+
+    def __getattr__(self, attr):
+        if attr not in self.methodmap:
+            raise AttributeError(attr)
+        self.methodmap[attr](self)
+        return getattr(self, attr)
+
+    __class_getitem__ = classmethod(GenericAlias)
+
+
+def cmpfiles(a, b, common, shallow=True):
+    """Compare common files in two directories.
+
+    a, b -- directory names
+    common -- list of file names found in both directories
+    shallow -- if true, do comparison based solely on stat() information
+
+    Returns a tuple of three lists:
+      files that compare equal
+      files that are different
+      filenames that aren't regular files.
+
+    """
+    res = ([], [], [])
+    for x in common:
+        ax = os.path.join(a, x)
+        bx = os.path.join(b, x)
+        res[_cmp(ax, bx, shallow)].append(x)
+    return res
+
+
+# Compare two files.
+# Return:
+#       0 for equal
+#       1 for different
+#       2 for funny cases (can't stat, etc.)
+#
+def _cmp(a, b, sh, abs=abs, cmp=cmp):
+    try:
+        return not abs(cmp(a, b, sh))
+    except OSError:
+        return 2
+
+
+# Return a copy with items that occur in skip removed.
+#
+def _filter(flist, skip):
+    return list(filterfalse(skip.__contains__, flist))
+
+
+# Demonstration and testing.
+#
+def demo():
+    import sys
+    import getopt
+    options, args = getopt.getopt(sys.argv[1:], 'r')
+    if len(args) != 2:
+        raise getopt.GetoptError('need exactly two args', None)
+    dd = dircmp(args[0], args[1])
+    if ('-r', '') in options:
+        dd.report_full_closure()
+    else:
+        dd.report()
+
+if __name__ == '__main__':
+    demo()

--- a/Lib/filecmp.py
+++ b/Lib/filecmp.py
@@ -10,7 +10,10 @@ Functions:
 
 """
 
-import os
+try:
+    import os
+except ImportError:
+    import _dummy_os as os
 import stat
 from itertools import filterfalse
 from types import GenericAlias

--- a/Lib/test/test_filecmp.py
+++ b/Lib/test/test_filecmp.py
@@ -1,0 +1,250 @@
+import filecmp
+import os
+import shutil
+import tempfile
+import unittest
+
+from test import support
+from test.support import os_helper
+
+
+class FileCompareTestCase(unittest.TestCase):
+    def setUp(self):
+        self.name = os_helper.TESTFN
+        self.name_same = os_helper.TESTFN + '-same'
+        self.name_diff = os_helper.TESTFN + '-diff'
+        data = 'Contents of file go here.\n'
+        for name in [self.name, self.name_same, self.name_diff]:
+            with open(name, 'w', encoding="utf-8") as output:
+                output.write(data)
+
+        with open(self.name_diff, 'a+', encoding="utf-8") as output:
+            output.write('An extra line.\n')
+        self.dir = tempfile.gettempdir()
+
+    def tearDown(self):
+        os.unlink(self.name)
+        os.unlink(self.name_same)
+        os.unlink(self.name_diff)
+
+    def test_matching(self):
+        self.assertTrue(filecmp.cmp(self.name, self.name),
+                        "Comparing file to itself fails")
+        self.assertTrue(filecmp.cmp(self.name, self.name, shallow=False),
+                        "Comparing file to itself fails")
+        self.assertTrue(filecmp.cmp(self.name, self.name_same),
+                        "Comparing file to identical file fails")
+        self.assertTrue(filecmp.cmp(self.name, self.name_same, shallow=False),
+                        "Comparing file to identical file fails")
+
+    def test_different(self):
+        self.assertFalse(filecmp.cmp(self.name, self.name_diff),
+                    "Mismatched files compare as equal")
+        self.assertFalse(filecmp.cmp(self.name, self.dir),
+                    "File and directory compare as equal")
+
+    def test_cache_clear(self):
+        first_compare = filecmp.cmp(self.name, self.name_same, shallow=False)
+        second_compare = filecmp.cmp(self.name, self.name_diff, shallow=False)
+        filecmp.clear_cache()
+        self.assertTrue(len(filecmp._cache) == 0,
+                        "Cache not cleared after calling clear_cache")
+
+class DirCompareTestCase(unittest.TestCase):
+    def setUp(self):
+        tmpdir = tempfile.gettempdir()
+        self.dir = os.path.join(tmpdir, 'dir')
+        self.dir_same = os.path.join(tmpdir, 'dir-same')
+        self.dir_diff = os.path.join(tmpdir, 'dir-diff')
+
+        # Another dir is created under dir_same, but it has a name from the
+        # ignored list so it should not affect testing results.
+        self.dir_ignored = os.path.join(self.dir_same, '.hg')
+
+        self.caseinsensitive = os.path.normcase('A') == os.path.normcase('a')
+        data = 'Contents of file go here.\n'
+        for dir in (self.dir, self.dir_same, self.dir_diff, self.dir_ignored):
+            shutil.rmtree(dir, True)
+            os.mkdir(dir)
+            subdir_path = os.path.join(dir, 'subdir')
+            os.mkdir(subdir_path)
+            if self.caseinsensitive and dir is self.dir_same:
+                fn = 'FiLe'     # Verify case-insensitive comparison
+            else:
+                fn = 'file'
+            with open(os.path.join(dir, fn), 'w', encoding="utf-8") as output:
+                output.write(data)
+
+        with open(os.path.join(self.dir_diff, 'file2'), 'w', encoding="utf-8") as output:
+            output.write('An extra file.\n')
+
+    def tearDown(self):
+        for dir in (self.dir, self.dir_same, self.dir_diff):
+            shutil.rmtree(dir)
+
+    def test_default_ignores(self):
+        self.assertIn('.hg', filecmp.DEFAULT_IGNORES)
+
+    def test_cmpfiles(self):
+        self.assertTrue(filecmp.cmpfiles(self.dir, self.dir, ['file']) ==
+                        (['file'], [], []),
+                        "Comparing directory to itself fails")
+        self.assertTrue(filecmp.cmpfiles(self.dir, self.dir_same, ['file']) ==
+                        (['file'], [], []),
+                        "Comparing directory to same fails")
+
+        # Try it with shallow=False
+        self.assertTrue(filecmp.cmpfiles(self.dir, self.dir, ['file'],
+                                         shallow=False) ==
+                        (['file'], [], []),
+                        "Comparing directory to itself fails")
+        self.assertTrue(filecmp.cmpfiles(self.dir, self.dir_same, ['file'],
+                                         shallow=False),
+                        "Comparing directory to same fails")
+
+        # Add different file2
+        with open(os.path.join(self.dir, 'file2'), 'w', encoding="utf-8") as output:
+            output.write('Different contents.\n')
+
+        self.assertFalse(filecmp.cmpfiles(self.dir, self.dir_same,
+                                     ['file', 'file2']) ==
+                    (['file'], ['file2'], []),
+                    "Comparing mismatched directories fails")
+
+
+    def _assert_lists(self, actual, expected):
+        """Assert that two lists are equal, up to ordering."""
+        self.assertEqual(sorted(actual), sorted(expected))
+
+
+    def test_dircmp(self):
+        # Check attributes for comparison of two identical directories
+        left_dir, right_dir = self.dir, self.dir_same
+        d = filecmp.dircmp(left_dir, right_dir)
+        self.assertEqual(d.left, left_dir)
+        self.assertEqual(d.right, right_dir)
+        if self.caseinsensitive:
+            self._assert_lists(d.left_list, ['file', 'subdir'])
+            self._assert_lists(d.right_list, ['FiLe', 'subdir'])
+        else:
+            self._assert_lists(d.left_list, ['file', 'subdir'])
+            self._assert_lists(d.right_list, ['file', 'subdir'])
+        self._assert_lists(d.common, ['file', 'subdir'])
+        self._assert_lists(d.common_dirs, ['subdir'])
+        self.assertEqual(d.left_only, [])
+        self.assertEqual(d.right_only, [])
+        self.assertEqual(d.same_files, ['file'])
+        self.assertEqual(d.diff_files, [])
+        expected_report = [
+            "diff {} {}".format(self.dir, self.dir_same),
+            "Identical files : ['file']",
+            "Common subdirectories : ['subdir']",
+        ]
+        self._assert_report(d.report, expected_report)
+
+        # Check attributes for comparison of two different directories (right)
+        left_dir, right_dir = self.dir, self.dir_diff
+        d = filecmp.dircmp(left_dir, right_dir)
+        self.assertEqual(d.left, left_dir)
+        self.assertEqual(d.right, right_dir)
+        self._assert_lists(d.left_list, ['file', 'subdir'])
+        self._assert_lists(d.right_list, ['file', 'file2', 'subdir'])
+        self._assert_lists(d.common, ['file', 'subdir'])
+        self._assert_lists(d.common_dirs, ['subdir'])
+        self.assertEqual(d.left_only, [])
+        self.assertEqual(d.right_only, ['file2'])
+        self.assertEqual(d.same_files, ['file'])
+        self.assertEqual(d.diff_files, [])
+        expected_report = [
+            "diff {} {}".format(self.dir, self.dir_diff),
+            "Only in {} : ['file2']".format(self.dir_diff),
+            "Identical files : ['file']",
+            "Common subdirectories : ['subdir']",
+        ]
+        self._assert_report(d.report, expected_report)
+
+        # Check attributes for comparison of two different directories (left)
+        left_dir, right_dir = self.dir, self.dir_diff
+        shutil.move(
+            os.path.join(self.dir_diff, 'file2'),
+            os.path.join(self.dir, 'file2')
+        )
+        d = filecmp.dircmp(left_dir, right_dir)
+        self.assertEqual(d.left, left_dir)
+        self.assertEqual(d.right, right_dir)
+        self._assert_lists(d.left_list, ['file', 'file2', 'subdir'])
+        self._assert_lists(d.right_list, ['file', 'subdir'])
+        self._assert_lists(d.common, ['file', 'subdir'])
+        self.assertEqual(d.left_only, ['file2'])
+        self.assertEqual(d.right_only, [])
+        self.assertEqual(d.same_files, ['file'])
+        self.assertEqual(d.diff_files, [])
+        expected_report = [
+            "diff {} {}".format(self.dir, self.dir_diff),
+            "Only in {} : ['file2']".format(self.dir),
+            "Identical files : ['file']",
+            "Common subdirectories : ['subdir']",
+        ]
+        self._assert_report(d.report, expected_report)
+
+        # Add different file2
+        with open(os.path.join(self.dir_diff, 'file2'), 'w', encoding="utf-8") as output:
+            output.write('Different contents.\n')
+        d = filecmp.dircmp(self.dir, self.dir_diff)
+        self.assertEqual(d.same_files, ['file'])
+        self.assertEqual(d.diff_files, ['file2'])
+        expected_report = [
+            "diff {} {}".format(self.dir, self.dir_diff),
+            "Identical files : ['file']",
+            "Differing files : ['file2']",
+            "Common subdirectories : ['subdir']",
+        ]
+        self._assert_report(d.report, expected_report)
+
+    def test_dircmp_subdirs_type(self):
+        """Check that dircmp.subdirs respects subclassing."""
+        class MyDirCmp(filecmp.dircmp):
+            pass
+        d = MyDirCmp(self.dir, self.dir_diff)
+        sub_dirs = d.subdirs
+        self.assertEqual(list(sub_dirs.keys()), ['subdir'])
+        sub_dcmp = sub_dirs['subdir']
+        self.assertEqual(type(sub_dcmp), MyDirCmp)
+
+    def test_report_partial_closure(self):
+        left_dir, right_dir = self.dir, self.dir_same
+        d = filecmp.dircmp(left_dir, right_dir)
+        left_subdir = os.path.join(left_dir, 'subdir')
+        right_subdir = os.path.join(right_dir, 'subdir')
+        expected_report = [
+            "diff {} {}".format(self.dir, self.dir_same),
+            "Identical files : ['file']",
+            "Common subdirectories : ['subdir']",
+            '',
+            "diff {} {}".format(left_subdir, right_subdir),
+        ]
+        self._assert_report(d.report_partial_closure, expected_report)
+
+    def test_report_full_closure(self):
+        left_dir, right_dir = self.dir, self.dir_same
+        d = filecmp.dircmp(left_dir, right_dir)
+        left_subdir = os.path.join(left_dir, 'subdir')
+        right_subdir = os.path.join(right_dir, 'subdir')
+        expected_report = [
+            "diff {} {}".format(self.dir, self.dir_same),
+            "Identical files : ['file']",
+            "Common subdirectories : ['subdir']",
+            '',
+            "diff {} {}".format(left_subdir, right_subdir),
+        ]
+        self._assert_report(d.report_full_closure, expected_report)
+
+    def _assert_report(self, dircmp_report, expected_report_lines):
+        with support.captured_stdout() as stdout:
+            dircmp_report()
+            report_lines = stdout.getvalue().strip().split('\n')
+            self.assertEqual(report_lines, expected_report_lines)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/Lib/test/test_genericalias.py
+++ b/Lib/test/test_genericalias.py
@@ -19,7 +19,7 @@ try:
 except ImportError:
     ctypes = None
 from difflib import SequenceMatcher
-# XXX RUSTPYTHON TODO: from filecmp import dircmp
+from filecmp import dircmp
 # XXX RUSTPYTHON TODO: from fileinput import FileInput
 from itertools import chain
 from http.cookies import Morsel
@@ -51,7 +51,7 @@ class BaseTest(unittest.TestCase):
     generic_types = [type, tuple, list, dict, set, frozenset, enumerate,
                      defaultdict, deque,
                      SequenceMatcher,
-                     # XXX RUSTPYTHON TODO: dircmp,
+                     dircmp,
                      # XXX RUSTPYTHON TODO: FileInput,
                      OrderedDict, Counter, UserDict, UserList,
                      Pattern, Match,


### PR DESCRIPTION
Copy `filecmp` module and tests from cpython v3.10.2
Enable `filecmp` in Lib/test/test_genericalias.py

Run the tests:
```
$ cargo run --release -- -m test test_filecmp -v

== RustPython 3.9.0alpha (heads/module-filecmp:7b7378509, Jan 23 2022, 21:05:31) [rustc 1.58.1]
== macOS-11.6.1-x86_64-64bit little-endian
== cwd: /private/var/folders/fv/652pf8d94lg8fmxym5m8g9xh0000gn/T/test_python_607
== CPU count: 8
== encodings: locale=UTF-8, FS=utf-8
Run tests sequentially
0:00:00 load avg: 8.81 [1/1] test_filecmp
test_cmpfiles (test.test_filecmp.DirCompareTestCase) ... ok
test_default_ignores (test.test_filecmp.DirCompareTestCase) ... ok
test_dircmp (test.test_filecmp.DirCompareTestCase) ... ok
test_dircmp_subdirs_type (test.test_filecmp.DirCompareTestCase)
Check that dircmp.subdirs respects subclassing. ... ok
test_report_full_closure (test.test_filecmp.DirCompareTestCase) ... ok
test_report_partial_closure (test.test_filecmp.DirCompareTestCase) ... ok
test_cache_clear (test.test_filecmp.FileCompareTestCase) ... ok
test_different (test.test_filecmp.FileCompareTestCase) ... ok
test_matching (test.test_filecmp.FileCompareTestCase) ... ok

----------------------------------------------------------------------

Ran 9 tests in 0.041s

OK
test_filecmp passed

== Tests result: SUCCESS ==

1 test OK.

Total duration: 97 ms
Tests result: SUCCESS
```

```
$ ./whats_left.sh
```

| BEFORE                    | AFTER                     |
| ------------------------- | ------------------------- |
| ...                       | ...                       |
| curses (entire module)    | curses (entire module)    |
| ensurepip (entire module) | ensurepip (entire module) |
| filecmp (entire module)   | ❌️                        |
| fileinput (entire module) | fileinput (entire module) |
| graphlib (entire module)  | graphlib (entire module)  |
| ...                       | ...                       |
|                           |                           |
| out of 275 modules:       | out of 275 modules:       |
|   not_implemented 85      |   not_implemented 84 ⚠️   |
|   failed_to_import 0      |   failed_to_import 0      |
|   missing_items 102       |   missing_items 102       |
|   mismatched_items 61     |   mismatched_items 61     |
