### PR TITLE
Allow heap types' `__name__` setter

### DIFF
--- a/Lib/test/test_typing.py
+++ b/Lib/test/test_typing.py
@@ -3843,8 +3843,6 @@ class IOTests(BaseTestCase):
         a = stuff.__annotations__['a']
         self.assertEqual(a.__parameters__, ())
 
-    # TODO: RUSTPYTHON
-    @unittest.expectedFailure
     def test_io_submodule(self):
         from typing.io import IO, TextIO, BinaryIO, __all__, __name__
         self.assertIs(IO, typing.IO)

--- a/Lib/typing.py
+++ b/Lib/typing.py
@@ -1998,10 +1998,8 @@ class io:
     BinaryIO = BinaryIO
 
 
-# XXX RustPython TODO: editable type.__name__
-# io.__name__ = __name__ + '.io'
-# sys.modules[io.__name__] = io
-sys.modules[__name__ + '.io'] = io
+io.__name__ = __name__ + '.io'
+sys.modules[io.__name__] = io
 
 Pattern = _alias(stdlib_re.Pattern, AnyStr)
 Match = _alias(stdlib_re.Match, AnyStr)

--- a/vm/src/builtins/pytype.rs
+++ b/vm/src/builtins/pytype.rs
@@ -545,6 +545,29 @@ impl PyType {
         ))
     }
 
+    #[pyproperty(magic, setter)]
+    fn set_name(&self, value: PyObjectRef, vm: &VirtualMachine) -> PyResult<()> {
+        if !self.slots.flags.has_feature(PyTypeFlags::HEAPTYPE) {
+            Err(vm.new_type_error(format!(
+                "cannot set '{}' attribute of immutable type '{}'",
+                "__name__",
+                self.name()
+            )))
+        } else {
+            match value.downcast_ref::<PyStr>().map(|m| m.as_str()) {
+                Some(name) => {
+                    *self.slots.name.write() = Some(name.to_string());
+                    Ok(())
+                }
+                None => Err(vm.new_type_error(format!(
+                    "can only assign string to {}.__name__, not '{}'",
+                    self.name(),
+                    value.class().name()
+                ))),
+            }
+        }
+    }
+
     #[pyproperty(magic)]
     fn text_signature(&self) -> Option<String> {
         self.slots

--- a/vm/src/builtins/pytype.rs
+++ b/vm/src/builtins/pytype.rs
@@ -286,7 +286,12 @@ impl PyType {
 
     pub fn name(&self) -> BorrowedValue<str> {
         PyRwLockReadGuard::map(self.slots.name.read(), |slot_name| {
-            slot_name.as_ref().unwrap().rsplit('.').next().unwrap()
+            let name = slot_name.as_ref().unwrap();
+            if self.slots.flags.has_feature(PyTypeFlags::HEAPTYPE) {
+                name.as_str()
+            } else {
+                name.rsplit('.').next().unwrap()
+            }
         })
         .into()
     }


### PR DESCRIPTION
In CPython implementation, immutable types (usually bulletins types) doesn't allow `type.__name__` setter but heap types allow `<TYPE>.__name__` setter. For example, there is `typing.io`. You can see also the 2733202 commit.

So this pull request does:

- Allow heap types' `__name__` setter.
- Don't split the name if it is heap type.

### CPython 3.10.0

```python
>>> type.__name__ = "foo"
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
TypeError: cannot set '__name__' attribute of immutable type 'type'
>>> class io: ...
... 
>>> io.__name__ = "typing.io"
>>> io.__name__
'typing.io'
```

### RustPython

```python
>>>>> type.__name__ = "foo"
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
TypeError: cannot set '__name__' attribute of immutable type 'type'
>>>>> class io: ...
>>>>> io.__name__ = "typing.io"
>>>>> io.__name__
'typing.io'
```