### PR TITLE
Correct `typing.re` initialization

### DIFF
--- a/Lib/test/test_typing.py
+++ b/Lib/test/test_typing.py
@@ -3895,8 +3895,6 @@ class RETests(BaseTestCase):
         self.assertEqual(repr(Match[str]), 'typing.Match[str]')
         self.assertEqual(repr(Match[bytes]), 'typing.Match[bytes]')
 
-    # TODO: RUSTPYTHON
-    @unittest.expectedFailure
     def test_re_submodule(self):
         from typing.re import Match, Pattern, __all__, __name__
         self.assertIs(Match, typing.Match)

--- a/Lib/typing.py
+++ b/Lib/typing.py
@@ -2012,7 +2012,5 @@ class re:
     Match = Match
 
 
-# XXX RustPython TODO: editable type.__name__
-# re.__name__ = __name__ + '.re'
-# sys.modules[re.__name__] = re
-sys.modules[__name__ + '.re'] = re
+re.__name__ = __name__ + '.re'
+sys.modules[re.__name__] = re


### PR DESCRIPTION
After #3527, `typing.re` initialization also became able to be corrected. This pull request does it.