### PR TITLE
Allow kwargs in itertools.combinations() signature

### DIFF
--- a/vm/src/stdlib/itertools.rs
+++ b/vm/src/stdlib/itertools.rs
@@ -1163,9 +1163,9 @@ mod decl {
 
     #[derive(FromArgs)]
     struct CombinationsNewArgs {
-        #[pyarg(positional)]
+        #[pyarg(any)]
         iterable: PyObjectRef,
-        #[pyarg(positional)]
+        #[pyarg(any)]
         r: PyIntRef,
     }
 


### PR DESCRIPTION
Fixes #3533
