### PR TITLE
Fix online documentation URL in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,7 +157,7 @@ make cool projects:
 Currently along with other areas of the project, documentation is still in an
 early phase.
 
-You can read the [online documentation](https://docs.rs/rustpython-vm) for the
+You can read the [online documentation](https://docs.rs/rustpython) for the
 latest release, or the [user guide](https://rustpython.github.io/docs/).
 
 You can also generate documentation locally by running:


### PR DESCRIPTION
> You can read the [online documentation](https://docs.rs/rustpython-vm) for the latest release, or the [user guide](https://rustpython.github.io/docs/).

### Current behaviour
Currently **online documentation** URL navigate to: https://docs.rs/rustpython-vm.
URL seems to be broken.

### Expected behaviour
I belive it should be: https://docs.rs/rustpython.