### PR TITLE
Add __format__ type check in f-string

### DIFF
--- a/vm/src/frame.rs
+++ b/vm/src/frame.rs
@@ -1076,8 +1076,16 @@ impl ExecutingFrame<'_> {
                 };
 
                 let spec = self.pop_value();
-                let formatted = vm.call_special_method(value, "__format__", (spec,))?;
-                self.push_value(formatted);
+                let formatted = vm
+                    .call_special_method(value, "__format__", (spec,))?
+                    .downcast::<PyStr>()
+                    .map_err(|formatted| {
+                        vm.new_type_error(format!(
+                            "__format__ must return a str, not {}",
+                            &formatted.class().name()
+                        ))
+                    })?;
+                self.push_value(formatted.into());
                 Ok(None)
             }
             bytecode::Instruction::PopException {} => {


### PR DESCRIPTION
RustPython doesn't check the return type of `__format__` in f-string, and will panic when `__format__` not returning `str`

```python
class A:
    def __format__(self, format_spec):
        return 0

a = A()
print(f'{a}')
# thread 'main' panicked at 'called `Option::unwrap()` on a `None` value', vm/src/frame.rs:623:59
```

It should raise `TypeError: __format__ must return a str, not int` instead, as what `format(a, '')` and `'{}'.format(a)` are doing.
