### PR TITLE
Arguments wrapping in zlib functions

### DIFF
--- a/Lib/test/test_zlib.py
+++ b/Lib/test/test_zlib.py
@@ -167,8 +167,6 @@ class CompressTestCase(BaseCompressTestCase, unittest.TestCase):
         x = zlib.compress(HAMLET_SCENE)
         self.assertEqual(zlib.decompress(x), HAMLET_SCENE)
 
-    # TODO: RUSTPYTHON
-    @unittest.expectedFailure
     def test_keywords(self):
         x = zlib.compress(HAMLET_SCENE, level=3)
         self.assertEqual(zlib.decompress(x), HAMLET_SCENE)


### PR DESCRIPTION
In this revision, 
* Arguments wrapping has been done in both zlib `compress` and `decompress` functions .
* In `test/test_zlib.py`, test_keywords unit test is completed.

