### PR TITLE
Fix test_long::test_huge_rshift

### DIFF
--- a/Lib/test/test_long.py
+++ b/Lib/test/test_long.py
@@ -953,8 +953,6 @@ class LongTest(unittest.TestCase):
     def test_huge_lshift(self, size):
         self.assertEqual(1 << (sys.maxsize + 1000), 1 << 1000 << sys.maxsize)
 
-    # TODO: RUSTPYTHON
-    @unittest.expectedFailure
     def test_huge_rshift(self):
         self.assertEqual(42 >> (1 << 1000), 0)
         self.assertEqual((-42) >> (1 << 1000), -1)

--- a/vm/src/builtins/int.rs
+++ b/vm/src/builtins/int.rs
@@ -166,9 +166,7 @@ where
     } else if int1.is_zero() {
         Ok(vm.ctx.new_int(0).into())
     } else {
-        let int2 = int2.to_usize().ok_or_else(|| {
-            vm.new_overflow_error("the number is too large to convert to int".to_owned())
-        })?;
+        let int2 = int2.min(&BigInt::from(usize::MAX)).to_usize().unwrap();
         Ok(vm.ctx.new_int(shift_op(int1, int2)).into())
     }
 }


### PR DESCRIPTION
A BigUint is represented as a vector of BigDigits and it seems that in Rust no allocations can have a size larger than `isize::MAX`. `usize::MAX` is sufficient for shifting purposes here.

Guided by @youknowone in PyCon APAC 2022 spring sprint