### PR TITLE
Move string intern to PyContext

### DIFF
--- a/stdlib/src/array.rs
+++ b/stdlib/src/array.rs
@@ -679,8 +679,10 @@ mod array {
         }
 
         #[pyproperty]
-        fn typecode(&self) -> String {
-            self.read().typecode().to_string()
+        fn typecode(&self, vm: &VirtualMachine) -> PyStrRef {
+            vm.ctx
+                .intern_string(self.read().typecode().to_string())
+                .into_pyref()
         }
 
         #[pyproperty]

--- a/vm/src/builtins/code.rs
+++ b/vm/src/builtins/code.rs
@@ -83,7 +83,7 @@ impl ConstantBag for PyObjBag<'_> {
             bytecode::ConstantData::Float { value } => ctx.new_float(value).into(),
             bytecode::ConstantData::Complex { value } => vm.new_pyobj(value),
             bytecode::ConstantData::Str { value } if value.len() <= 20 => {
-                vm.intern_string(value).into()
+                vm.ctx.intern_string(value).into_pyref().into()
             }
             bytecode::ConstantData::Str { value } => vm.ctx.new_str(value).into(),
             bytecode::ConstantData::Bytes { value } => ctx.new_bytes(value.to_vec()).into(),
@@ -109,7 +109,7 @@ impl ConstantBag for PyObjBag<'_> {
             bytecode::BorrowedConstant::Float { value } => ctx.new_float(value).into(),
             bytecode::BorrowedConstant::Complex { value } => vm.new_pyobj(value),
             bytecode::BorrowedConstant::Str { value } if value.len() <= 20 => {
-                vm.intern_string(value).into()
+                vm.ctx.intern_string(value).into_pyref().into()
             }
             bytecode::BorrowedConstant::Str { value } => vm.ctx.new_str(value).into(),
             bytecode::BorrowedConstant::Bytes { value } => ctx.new_bytes(value.to_vec()).into(),
@@ -130,10 +130,10 @@ impl ConstantBag for PyObjBag<'_> {
         PyConstant(obj)
     }
     fn make_name(&self, name: String) -> PyStrRef {
-        self.0.intern_string(name)
+        self.0.ctx.intern_string(name).into_pyref()
     }
     fn make_name_ref(&self, name: &str) -> PyStrRef {
-        self.0.intern_string(name)
+        self.0.ctx.intern_string(name).into_pyref()
     }
 }
 

--- a/vm/src/builtins/pybool.rs
+++ b/vm/src/builtins/pybool.rs
@@ -110,8 +110,12 @@ impl Constructor for PyBool {
 #[pyimpl(with(Constructor))]
 impl PyBool {
     #[pymethod(magic)]
-    fn repr(zelf: bool) -> String {
-        if zelf { "True" } else { "False" }.to_owned()
+    fn repr(zelf: bool, vm: &VirtualMachine) -> PyStrRef {
+        if zelf {
+            vm.ctx.true_str.clone()
+        } else {
+            vm.ctx.false_str.clone()
+        }
     }
 
     #[pymethod(magic)]

--- a/vm/src/dictdatatype.rs
+++ b/vm/src/dictdatatype.rs
@@ -81,7 +81,7 @@ struct DictInner<T> {
 
 impl<T: Clone> Clone for Dict<T> {
     fn clone(&self) -> Self {
-        Dict {
+        Self {
             inner: PyRwLock::new(self.inner.read().clone()),
         }
     }
@@ -89,7 +89,7 @@ impl<T: Clone> Clone for Dict<T> {
 
 impl<T> Default for Dict<T> {
     fn default() -> Self {
-        Dict {
+        Self {
             inner: PyRwLock::new(DictInner {
                 used: 0,
                 filled: 0,
@@ -440,6 +440,7 @@ impl<T: Clone> Dict<T> {
         Ok(res)
     }
 
+    #[allow(dead_code)]
     pub fn setdefault_entry<K, F>(
         &self,
         vm: &VirtualMachine,

--- a/vm/src/intern.rs
+++ b/vm/src/intern.rs
@@ -1,0 +1,113 @@
+use crate::{
+    builtins::{PyStr, PyTypeRef},
+    common::lock::PyRwLock,
+    convert::ToPyObject,
+    PyRef, PyRefExact,
+};
+use std::ops::Deref;
+
+#[derive(Debug)]
+pub struct StringPool {
+    inner: PyRwLock<std::collections::HashSet<CachedPyStrRef, ahash::RandomState>>,
+}
+
+impl Default for StringPool {
+    fn default() -> Self {
+        Self {
+            inner: PyRwLock::new(Default::default()),
+        }
+    }
+}
+
+impl Clone for StringPool {
+    fn clone(&self) -> Self {
+        Self {
+            inner: PyRwLock::new(self.inner.read().clone()),
+        }
+    }
+}
+
+impl StringPool {
+    #[inline]
+    pub unsafe fn intern<S: Internable>(&self, s: S, typ: PyTypeRef) -> PyRefExact<PyStr> {
+        if let Some(found) = self.inner.read().get(s.as_str()) {
+            return found.clone().inner;
+        }
+        let cache = CachedPyStrRef {
+            inner: s.into_pyref(typ),
+        };
+        self.inner.write().insert(cache.clone());
+        cache.inner
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct CachedPyStrRef {
+    inner: PyRefExact<PyStr>,
+}
+
+impl std::hash::Hash for CachedPyStrRef {
+    fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
+        self.inner.as_str().hash(state)
+    }
+}
+
+impl PartialEq for CachedPyStrRef {
+    fn eq(&self, other: &Self) -> bool {
+        self.inner.as_str() == other.inner.as_str()
+    }
+}
+
+impl Eq for CachedPyStrRef {}
+
+impl std::borrow::Borrow<str> for CachedPyStrRef {
+    fn borrow(&self) -> &str {
+        self.inner.as_str()
+    }
+}
+
+mod sealed {
+    use crate::{builtins::PyStr, pyobject::PyRefExact};
+
+    pub trait SealedInternable {}
+
+    impl SealedInternable for String {}
+
+    impl SealedInternable for &str {}
+
+    impl SealedInternable for PyRefExact<PyStr> {}
+}
+
+/// A sealed marker trait for `DictKey` types that always become an exact instance of `str`
+pub trait Internable: sealed::SealedInternable + crate::dictdatatype::DictKey + ToPyObject {
+    fn as_str(&self) -> &str;
+    fn into_pyref(self, str_type: PyTypeRef) -> PyRefExact<PyStr>;
+}
+
+impl Internable for String {
+    fn as_str(&self) -> &str {
+        String::as_str(self)
+    }
+    fn into_pyref(self, str_type: PyTypeRef) -> PyRefExact<PyStr> {
+        let obj = PyRef::new_ref(PyStr::from(self), str_type, None);
+        unsafe { PyRefExact::new_unchecked(obj) }
+    }
+}
+
+impl Internable for &str {
+    fn as_str(&self) -> &str {
+        self
+    }
+    fn into_pyref(self, str_type: PyTypeRef) -> PyRefExact<PyStr> {
+        self.to_owned().into_pyref(str_type)
+    }
+}
+
+impl Internable for PyRefExact<PyStr> {
+    fn as_str(&self) -> &str {
+        self.deref().as_str()
+    }
+    fn into_pyref(self, _str_type: PyTypeRef) -> PyRefExact<PyStr> {
+        self
+    }
+}

--- a/vm/src/lib.rs
+++ b/vm/src/lib.rs
@@ -61,6 +61,7 @@ pub mod frame;
 mod frozen;
 pub mod function;
 pub mod import;
+mod intern;
 pub mod protocol;
 pub mod py_io;
 pub mod py_serde;

--- a/vm/src/stdlib/sys.rs
+++ b/vm/src/stdlib/sys.rs
@@ -125,15 +125,17 @@ mod sys {
     }
 
     #[pyattr]
-    fn byteorder(_vm: &VirtualMachine) -> String {
+    fn byteorder(vm: &VirtualMachine) -> PyStrRef {
         // https://doc.rust-lang.org/reference/conditional-compilation.html#target_endian
-        if cfg!(target_endian = "little") {
-            "little".to_owned()
-        } else if cfg!(target_endian = "big") {
-            "big".to_owned()
-        } else {
-            "unknown".to_owned()
-        }
+        vm.ctx
+            .intern_string(if cfg!(target_endian = "little") {
+                "little"
+            } else if cfg!(target_endian = "big") {
+                "big"
+            } else {
+                "unknown"
+            })
+            .into_pyref()
     }
 
     #[pyattr]
@@ -452,8 +454,8 @@ mod sys {
     }
 
     #[pyfunction]
-    fn intern(s: PyRefExact<PyStr>, vm: &VirtualMachine) -> PyStrRef {
-        vm.intern_string(s)
+    fn intern(s: PyRefExact<PyStr>, vm: &VirtualMachine) -> PyRefExact<PyStr> {
+        vm.ctx.intern_string(s)
     }
 
     #[pyattr]

--- a/vm/src/vm.rs
+++ b/vm/src/vm.rs
@@ -12,7 +12,7 @@ use crate::{
         object,
         pystr::IntoPyStrRef,
         tuple::{PyTuple, PyTupleTyped},
-        PyBaseExceptionRef, PyDictRef, PyList, PyModule, PyStr, PyStrRef, PyTypeRef,
+        PyBaseExceptionRef, PyDictRef, PyList, PyModule, PyStrRef, PyTypeRef,
     },
     bytecode,
     codecs::CodecsRegistry,
@@ -24,8 +24,7 @@ use crate::{
     import,
     protocol::PyIterIter,
     scope::Scope,
-    signal, stdlib, AsObject, PyContext, PyObject, PyObjectRef, PyPayload, PyRef, PyRefExact,
-    PyResult,
+    signal, stdlib, AsObject, PyContext, PyObject, PyObjectRef, PyPayload, PyRef, PyResult,
 };
 use crossbeam_utils::atomic::AtomicCell;
 use std::{
@@ -899,16 +898,6 @@ impl VirtualMachine {
         code.map_bag(&code::PyObjBag(self))
     }
 
-    pub fn intern_string<S: Internable>(&self, s: S) -> PyStrRef {
-        let (s, ()) = self
-            .ctx
-            .string_cache
-            .setdefault_entry(self, s, || ())
-            .expect("string_cache lookup should never error");
-        s.downcast()
-            .expect("only strings should be in string_cache")
-    }
-
     #[doc(hidden)]
     pub fn __module_set_attr(
         &self,
@@ -951,27 +940,6 @@ impl VirtualMachine {
             .map(|code| PyCode::new(self.map_codeobj(code)).into_ref(self))
     }
 }
-
-mod sealed {
-    use super::*;
-
-    pub trait SealedInternable {}
-
-    impl SealedInternable for String {}
-
-    impl SealedInternable for &str {}
-
-    impl SealedInternable for PyRefExact<PyStr> {}
-}
-
-/// A sealed marker trait for `DictKey` types that always become an exact instance of `str`
-pub trait Internable: sealed::SealedInternable + crate::dictdatatype::DictKey + ToPyObject {}
-
-impl Internable for String {}
-
-impl Internable for &str {}
-
-impl Internable for PyRefExact<PyStr> {}
 
 pub struct ReprGuard<'vm> {
     vm: &'vm VirtualMachine,
@@ -1105,7 +1073,7 @@ impl PyThread {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::builtins::int;
+    use crate::builtins::{int, PyStr};
     use num_bigint::ToBigInt;
 
     #[test]


### PR DESCRIPTION
so that we can intern strings before vm or even without vm for preparation step.