### PR TITLE
Rename PyObjectView -> Py and PyValue -> PyPayload

### DIFF
--- a/common/src/rc.rs
+++ b/common/src/rc.rs
@@ -1,7 +1,7 @@
 #[cfg(not(feature = "threading"))]
-use std::rc::{Rc, Weak};
+use std::rc::Rc;
 #[cfg(feature = "threading")]
-use std::sync::{Arc, Weak};
+use std::sync::Arc;
 
 // type aliases instead of newtypes because you can't do `fn method(self: PyRc<Self>)` with a
 // newtype; requires the arbitrary_self_types unstable feature
@@ -10,5 +10,3 @@ use std::sync::{Arc, Weak};
 pub type PyRc<T> = Arc<T>;
 #[cfg(not(feature = "threading"))]
 pub type PyRc<T> = Rc<T>;
-
-pub type PyWeak<T> = Weak<T>;

--- a/derive/src/lib.rs
+++ b/derive/src/lib.rs
@@ -17,8 +17,8 @@ mod doc;
 mod from_args;
 mod pyclass;
 mod pymodule;
+mod pypayload;
 mod pystructseq;
-mod pyvalue;
 
 use error::{extract_spans, Diagnostic};
 use proc_macro2::TokenStream;
@@ -120,8 +120,8 @@ pub fn py_freeze(input: proc_macro::TokenStream) -> proc_macro::TokenStream {
     result_to_tokens(compile_bytecode::impl_py_freeze(input.into()))
 }
 
-#[proc_macro_derive(PyValue)]
-pub fn pyvalue(input: proc_macro::TokenStream) -> proc_macro::TokenStream {
+#[proc_macro_derive(PyPayload)]
+pub fn pypayload(input: proc_macro::TokenStream) -> proc_macro::TokenStream {
     let input = parse_macro_input!(input as DeriveInput);
-    result_to_tokens(pyvalue::impl_pyvalue(input))
+    result_to_tokens(pypayload::impl_pypayload(input))
 }

--- a/derive/src/pyclass.rs
+++ b/derive/src/pyclass.rs
@@ -364,7 +364,7 @@ pub(crate) fn impl_define_exception(exc_def: PyExceptionDef) -> Result<TokenStre
         pub struct #class_name {}
 
         // We need this to make extend mechanism work:
-        impl ::rustpython_vm::PyValue for #class_name {
+        impl ::rustpython_vm::PyPayload for #class_name {
             fn class(vm: &::rustpython_vm::VirtualMachine) -> &::rustpython_vm::builtins::PyTypeRef {
                 &vm.ctx.exceptions.#ctx_name
             }

--- a/derive/src/pypayload.rs
+++ b/derive/src/pypayload.rs
@@ -2,11 +2,11 @@ use proc_macro2::TokenStream;
 use quote::quote;
 use syn::{DeriveInput, Result};
 
-pub(crate) fn impl_pyvalue(input: DeriveInput) -> Result<TokenStream> {
+pub(crate) fn impl_pypayload(input: DeriveInput) -> Result<TokenStream> {
     let ty = &input.ident;
 
     let ret = quote! {
-        impl ::rustpython_vm::PyValue for #ty {
+        impl ::rustpython_vm::PyPayload for #ty {
             fn class(_vm: &::rustpython_vm::VirtualMachine) -> &rustpython_vm::builtins::PyTypeRef {
                 <Self as ::rustpython_vm::pyclass::StaticType>::static_type()
             }

--- a/stdlib/src/array.rs
+++ b/stdlib/src/array.rs
@@ -31,8 +31,7 @@ mod array {
                 AsBuffer, AsMapping, Comparable, Constructor, IterNext, IterNextIterable, Iterable,
                 PyComparisonOp,
             },
-            AsObject, PyObject, PyObjectRef, PyObjectView, PyPayload, PyRef, PyResult,
-            VirtualMachine,
+            AsObject, Py, PyObject, PyObjectRef, PyPayload, PyRef, PyResult, VirtualMachine,
         },
     };
     use itertools::Itertools;
@@ -1152,7 +1151,7 @@ mod array {
 
     impl Comparable for PyArray {
         fn cmp(
-            zelf: &PyObjectView<Self>,
+            zelf: &Py<Self>,
             other: &PyObject,
             op: PyComparisonOp,
             vm: &VirtualMachine,
@@ -1203,7 +1202,7 @@ mod array {
     }
 
     impl AsBuffer for PyArray {
-        fn as_buffer(zelf: &PyObjectView<Self>, _vm: &VirtualMachine) -> PyResult<PyBuffer> {
+        fn as_buffer(zelf: &Py<Self>, _vm: &VirtualMachine) -> PyResult<PyBuffer> {
             let array = zelf.read();
             let buf = PyBuffer::new(
                 zelf.to_owned().into(),
@@ -1254,7 +1253,7 @@ mod array {
     }
 
     impl AsMapping for PyArray {
-        fn as_mapping(_zelf: &PyObjectView<Self>, _vm: &VirtualMachine) -> PyMappingMethods {
+        fn as_mapping(_zelf: &Py<Self>, _vm: &VirtualMachine) -> PyMappingMethods {
             Self::MAPPING_METHODS
         }
     }
@@ -1291,7 +1290,7 @@ mod array {
 
     impl IterNextIterable for PyArrayIter {}
     impl IterNext for PyArrayIter {
-        fn next(zelf: &PyObjectView<Self>, vm: &VirtualMachine) -> PyResult<PyIterReturn> {
+        fn next(zelf: &Py<Self>, vm: &VirtualMachine) -> PyResult<PyIterReturn> {
             let pos = zelf.position.fetch_add(1, atomic::Ordering::SeqCst);
             let r = if let Some(item) = zelf.array.read().get(pos, vm) {
                 PyIterReturn::Return(item?)

--- a/stdlib/src/array.rs
+++ b/stdlib/src/array.rs
@@ -31,7 +31,7 @@ mod array {
                 AsBuffer, AsMapping, Comparable, Constructor, IterNext, IterNextIterable, Iterable,
                 PyComparisonOp,
             },
-            AsObject, PyObject, PyObjectRef, PyObjectView, PyRef, PyResult, PyValue,
+            AsObject, PyObject, PyObjectRef, PyObjectView, PyPayload, PyRef, PyResult,
             VirtualMachine,
         },
     };
@@ -583,7 +583,7 @@ mod array {
 
     #[pyattr]
     #[pyclass(name = "array")]
-    #[derive(Debug, PyValue)]
+    #[derive(Debug, PyPayload)]
     pub struct PyArray {
         array: PyRwLock<ArrayContentType>,
         exports: AtomicUsize,
@@ -1280,7 +1280,7 @@ mod array {
 
     #[pyattr]
     #[pyclass(name = "array_iterator")]
-    #[derive(Debug, PyValue)]
+    #[derive(Debug, PyPayload)]
     pub struct PyArrayIter {
         position: AtomicUsize,
         array: PyArrayRef,

--- a/stdlib/src/contextvars.rs
+++ b/stdlib/src/contextvars.rs
@@ -4,11 +4,11 @@ pub(crate) use _contextvars::make_module;
 mod _contextvars {
     use rustpython_vm::builtins::{PyFunction, PyStrRef, PyTypeRef};
     use rustpython_vm::function::{ArgCallable, FuncArgs, OptionalArg};
-    use rustpython_vm::{PyObjectRef, PyRef, PyResult, PyValue, VirtualMachine};
+    use rustpython_vm::{PyObjectRef, PyPayload, PyRef, PyResult, VirtualMachine};
 
     #[pyattr]
     #[pyclass(name)]
-    #[derive(Debug, PyValue)]
+    #[derive(Debug, PyPayload)]
     struct Context {}
 
     #[pyimpl]
@@ -75,7 +75,7 @@ mod _contextvars {
 
     #[pyattr]
     #[pyclass(name)]
-    #[derive(Debug, PyValue)]
+    #[derive(Debug, PyPayload)]
     struct ContextVar {
         #[allow(dead_code)] // TODO: RUSTPYTHON
         name: String,
@@ -147,7 +147,7 @@ mod _contextvars {
 
     #[pyattr]
     #[pyclass(name = "Token")]
-    #[derive(Debug, PyValue)]
+    #[derive(Debug, PyPayload)]
     struct ContextToken {}
 
     #[derive(FromArgs)]

--- a/stdlib/src/csv.rs
+++ b/stdlib/src/csv.rs
@@ -9,7 +9,7 @@ mod _csv {
         match_class,
         protocol::{PyIter, PyIterReturn},
         types::{IterNext, IterNextIterable},
-        AsObject, PyObjectRef, PyObjectView, PyResult, PyValue, TryFromObject, VirtualMachine,
+        AsObject, PyObjectRef, PyObjectView, PyPayload, PyResult, TryFromObject, VirtualMachine,
     };
     use itertools::{self, Itertools};
     use std::fmt;
@@ -153,7 +153,7 @@ mod _csv {
     }
 
     #[pyclass(noattr, module = "_csv", name = "reader")]
-    #[derive(PyValue)]
+    #[derive(PyPayload)]
     pub(super) struct Reader {
         iter: PyIter,
         state: PyMutex<ReadState>,
@@ -243,7 +243,7 @@ mod _csv {
     }
 
     #[pyclass(noattr, module = "_csv", name = "writer")]
-    #[derive(PyValue)]
+    #[derive(PyPayload)]
     pub(super) struct Writer {
         write: PyObjectRef,
         state: PyMutex<WriteState>,

--- a/stdlib/src/csv.rs
+++ b/stdlib/src/csv.rs
@@ -9,7 +9,7 @@ mod _csv {
         match_class,
         protocol::{PyIter, PyIterReturn},
         types::{IterNext, IterNextIterable},
-        AsObject, PyObjectRef, PyObjectView, PyPayload, PyResult, TryFromObject, VirtualMachine,
+        AsObject, Py, PyObjectRef, PyPayload, PyResult, TryFromObject, VirtualMachine,
     };
     use itertools::{self, Itertools};
     use std::fmt;
@@ -169,7 +169,7 @@ mod _csv {
     impl Reader {}
     impl IterNextIterable for Reader {}
     impl IterNext for Reader {
-        fn next(zelf: &PyObjectView<Self>, vm: &VirtualMachine) -> PyResult<PyIterReturn> {
+        fn next(zelf: &Py<Self>, vm: &VirtualMachine) -> PyResult<PyIterReturn> {
             let string = match zelf.iter.next(vm)? {
                 PyIterReturn::Return(obj) => obj,
                 PyIterReturn::StopIteration(v) => return Ok(PyIterReturn::StopIteration(v)),

--- a/stdlib/src/hashlib.rs
+++ b/stdlib/src/hashlib.rs
@@ -6,7 +6,7 @@ mod hashlib {
     use crate::vm::{
         builtins::{PyBytes, PyBytesRef, PyStrRef, PyTypeRef},
         function::{FuncArgs, OptionalArg},
-        PyResult, PyValue, VirtualMachine,
+        PyPayload, PyResult, VirtualMachine,
     };
     use blake2::{Blake2b512, Blake2s256};
     use digest::DynDigest;
@@ -46,7 +46,7 @@ mod hashlib {
 
     #[pyattr]
     #[pyclass(module = "hashlib", name = "hasher")]
-    #[derive(PyValue)]
+    #[derive(PyPayload)]
     struct PyHasher {
         name: String,
         buffer: PyRwLock<HashWrapper>,

--- a/stdlib/src/json.rs
+++ b/stdlib/src/json.rs
@@ -10,14 +10,14 @@ mod _json {
         function::OptionalArg,
         protocol::PyIterReturn,
         types::{Callable, Constructor},
-        AsObject, PyObjectRef, PyObjectView, PyResult, PyValue, VirtualMachine,
+        AsObject, PyObjectRef, PyObjectView, PyPayload, PyResult, VirtualMachine,
     };
     use num_bigint::BigInt;
     use std::str::FromStr;
 
     #[pyattr(name = "make_scanner")]
     #[pyclass(name = "Scanner")]
-    #[derive(Debug, PyValue)]
+    #[derive(Debug, PyPayload)]
     struct JsonScanner {
         strict: bool,
         object_hook: Option<PyObjectRef>,

--- a/stdlib/src/json.rs
+++ b/stdlib/src/json.rs
@@ -10,7 +10,7 @@ mod _json {
         function::OptionalArg,
         protocol::PyIterReturn,
         types::{Callable, Constructor},
-        AsObject, PyObjectRef, PyObjectView, PyPayload, PyResult, VirtualMachine,
+        AsObject, Py, PyObjectRef, PyPayload, PyResult, VirtualMachine,
     };
     use num_bigint::BigInt;
     use std::str::FromStr;
@@ -196,11 +196,7 @@ mod _json {
 
     impl Callable for JsonScanner {
         type Args = (PyStrRef, isize);
-        fn call(
-            zelf: &PyObjectView<Self>,
-            (pystr, idx): Self::Args,
-            vm: &VirtualMachine,
-        ) -> PyResult {
+        fn call(zelf: &Py<Self>, (pystr, idx): Self::Args, vm: &VirtualMachine) -> PyResult {
             if idx < 0 {
                 return Err(vm.new_value_error("idx cannot be negative".to_owned()));
             }

--- a/stdlib/src/pyexpat.rs
+++ b/stdlib/src/pyexpat.rs
@@ -35,7 +35,7 @@ mod _pyexpat {
         builtins::{PyStr, PyStrRef, PyTypeRef},
         function::ArgBytesLike,
         function::{IntoFuncArgs, OptionalArg},
-        PyContext, PyObjectRef, PyRef, PyResult, PyValue, TryFromObject, VirtualMachine,
+        PyContext, PyObjectRef, PyPayload, PyRef, PyResult, TryFromObject, VirtualMachine,
     };
     use rustpython_common::lock::PyRwLock;
     use std::io::Cursor;
@@ -44,7 +44,7 @@ mod _pyexpat {
 
     #[pyattr]
     #[pyclass(name = "xmlparser", module = false)]
-    #[derive(Debug, PyValue)]
+    #[derive(Debug, PyPayload)]
     pub struct PyExpatLikeXmlParser {
         start_element: MutableObject,
         end_element: MutableObject,

--- a/stdlib/src/pystruct.rs
+++ b/stdlib/src/pystruct.rs
@@ -16,7 +16,7 @@ pub(crate) mod _struct {
         match_class,
         protocol::PyIterReturn,
         types::{Constructor, IterNext, IterNextIterable},
-        AsObject, PyObjectRef, PyObjectView, PyPayload, PyResult, TryFromObject, VirtualMachine,
+        AsObject, Py, PyObjectRef, PyPayload, PyResult, TryFromObject, VirtualMachine,
     };
     use crossbeam_utils::atomic::AtomicCell;
 
@@ -206,7 +206,7 @@ pub(crate) mod _struct {
     }
     impl IterNextIterable for UnpackIterator {}
     impl IterNext for UnpackIterator {
-        fn next(zelf: &PyObjectView<Self>, vm: &VirtualMachine) -> PyResult<PyIterReturn> {
+        fn next(zelf: &Py<Self>, vm: &VirtualMachine) -> PyResult<PyIterReturn> {
             let size = zelf.format_spec.size;
             let offset = zelf.offset.fetch_add(size);
             zelf.buffer.with_ref(|buf| {

--- a/stdlib/src/pystruct.rs
+++ b/stdlib/src/pystruct.rs
@@ -16,7 +16,7 @@ pub(crate) mod _struct {
         match_class,
         protocol::PyIterReturn,
         types::{Constructor, IterNext, IterNextIterable},
-        AsObject, PyObjectRef, PyObjectView, PyResult, PyValue, TryFromObject, VirtualMachine,
+        AsObject, PyObjectRef, PyObjectView, PyPayload, PyResult, TryFromObject, VirtualMachine,
     };
     use crossbeam_utils::atomic::AtomicCell;
 
@@ -161,7 +161,7 @@ pub(crate) mod _struct {
 
     #[pyattr]
     #[pyclass(name = "unpack_iterator")]
-    #[derive(Debug, PyValue)]
+    #[derive(Debug, PyPayload)]
     struct UnpackIterator {
         format_spec: FormatSpec,
         buffer: ArgBytesLike,
@@ -238,7 +238,7 @@ pub(crate) mod _struct {
 
     #[pyattr]
     #[pyclass(name = "Struct")]
-    #[derive(Debug, PyValue)]
+    #[derive(Debug, PyPayload)]
     struct PyStruct {
         spec: FormatSpec,
         format: PyStrRef,

--- a/stdlib/src/random.rs
+++ b/stdlib/src/random.rs
@@ -9,7 +9,7 @@ mod _random {
         builtins::{PyInt, PyTypeRef},
         function::OptionalOption,
         types::Constructor,
-        PyObjectRef, PyResult, PyValue, VirtualMachine,
+        PyObjectRef, PyPayload, PyResult, VirtualMachine,
     };
     use num_bigint::{BigInt, Sign};
     use num_traits::{Signed, Zero};
@@ -56,7 +56,7 @@ mod _random {
 
     #[pyattr]
     #[pyclass(name = "Random")]
-    #[derive(Debug, PyValue)]
+    #[derive(Debug, PyPayload)]
     struct PyRandom {
         rng: PyMutex<PyRng>,
     }

--- a/stdlib/src/re.rs
+++ b/stdlib/src/re.rs
@@ -12,7 +12,7 @@ mod re {
         builtins::{PyInt, PyIntRef, PyStr, PyStrRef},
         convert::{ToPyObject, TryFromObject},
         function::{OptionalArg, PosArgs},
-        match_class, PyObjectRef, PyResult, PyValue, VirtualMachine,
+        match_class, PyObjectRef, PyResult, PyPayload, VirtualMachine,
     };
     use num_traits::Signed;
     use regex::bytes::{Captures, Regex, RegexBuilder};
@@ -21,7 +21,7 @@ mod re {
 
     #[pyattr]
     #[pyclass(module = "re", name = "Pattern")]
-    #[derive(Debug, PyValue)]
+    #[derive(Debug, PyPayload)]
     struct PyPattern {
         regex: Regex,
         pattern: String,
@@ -77,7 +77,7 @@ mod re {
     /// Inner data for a match object.
     #[pyattr]
     #[pyclass(module = "re", name = "Match")]
-    #[derive(PyValue)]
+    #[derive(PyPayload)]
     struct PyMatch {
         haystack: PyStrRef,
         captures: Vec<Option<Range<usize>>>,

--- a/stdlib/src/select.rs
+++ b/stdlib/src/select.rs
@@ -261,14 +261,14 @@ mod decl {
         use super::*;
         use crate::vm::{
             builtins::PyFloat, common::lock::PyMutex, convert::ToPyObject, function::OptionalArg,
-            stdlib::io::Fildes, AsObject, PyValue,
+            stdlib::io::Fildes, AsObject, PyPayload,
         };
         use libc::pollfd;
         use num_traits::ToPrimitive;
         use std::time;
 
         #[pyclass(module = "select", name = "poll")]
-        #[derive(Default, Debug, PyValue)]
+        #[derive(Default, Debug, PyPayload)]
         pub struct PyPoll {
             // keep sorted
             fds: PyMutex<Vec<pollfd>>,

--- a/stdlib/src/socket.rs
+++ b/stdlib/src/socket.rs
@@ -16,7 +16,7 @@ mod _socket {
         convert::{ToPyException, ToPyObject, TryFromBorrowedObject, TryFromObject},
         function::{ArgBytesLike, ArgMemoryBuffer, FuncArgs, OptionalArg, OptionalOption},
         utils::{Either, ToCString},
-        AsObject, PyObjectRef, PyResult, PyValue, VirtualMachine,
+        AsObject, PyObjectRef, PyPayload, PyResult, VirtualMachine,
     };
     use crossbeam_utils::atomic::AtomicCell;
     use num_traits::ToPrimitive;
@@ -231,7 +231,7 @@ mod _socket {
     #[pyattr(name = "socket")]
     #[pyattr(name = "SocketType")]
     #[pyclass(name = "socket")]
-    #[derive(Debug, PyValue)]
+    #[derive(Debug, PyPayload)]
     pub struct PySocket {
         kind: AtomicCell<i32>,
         family: AtomicCell<i32>,

--- a/stdlib/src/ssl.rs
+++ b/stdlib/src/ssl.rs
@@ -30,7 +30,7 @@ mod _ssl {
         },
         socket::{self, PySocket},
         vm::{
-            builtins::{PyBaseExceptionRef, PyStrRef, PyType, PyTypeRef},
+            builtins::{PyBaseExceptionRef, PyStrRef, PyType, PyTypeRef, PyWeak},
             convert::{ToPyException, ToPyObject},
             exceptions,
             function::{
@@ -39,7 +39,7 @@ mod _ssl {
             stdlib::os::PyPathLike,
             types::Constructor,
             utils::{Either, ToCString},
-            PyObjectRef, PyObjectWeak, PyRef, PyResult, PyValue, VirtualMachine,
+            PyObjectRef, PyRef, PyResult, PyValue, VirtualMachine,
         },
     };
     use crossbeam_utils::atomic::AtomicCell;
@@ -890,7 +890,7 @@ mod _ssl {
         stream: PyRwLock<ssl::SslStream<SocketStream>>,
         socket_type: SslServerOrClient,
         server_hostname: Option<PyStrRef>,
-        owner: PyRwLock<Option<PyObjectWeak>>,
+        owner: PyRwLock<Option<PyRef<PyWeak>>>,
     }
 
     impl fmt::Debug for PySslSocket {

--- a/stdlib/src/ssl.rs
+++ b/stdlib/src/ssl.rs
@@ -39,7 +39,7 @@ mod _ssl {
             stdlib::os::PyPathLike,
             types::Constructor,
             utils::{Either, ToCString},
-            PyObjectRef, PyRef, PyResult, PyValue, VirtualMachine,
+            PyObjectRef, PyPayload, PyRef, PyResult, VirtualMachine,
         },
     };
     use crossbeam_utils::atomic::AtomicCell;
@@ -415,7 +415,7 @@ mod _ssl {
 
     #[pyattr]
     #[pyclass(module = "ssl", name = "_SSLContext")]
-    #[derive(PyValue)]
+    #[derive(PyPayload)]
     struct PySslContext {
         ctx: PyRwLock<SslContextBuilder>,
         check_hostname: AtomicCell<bool>,
@@ -884,7 +884,7 @@ mod _ssl {
 
     #[pyattr]
     #[pyclass(module = "ssl", name = "_SSLSocket")]
-    #[derive(PyValue)]
+    #[derive(PyPayload)]
     struct PySslSocket {
         ctx: PyRef<PySslContext>,
         stream: PyRwLock<ssl::SslStream<SocketStream>>,
@@ -1400,7 +1400,7 @@ mod windows {
         vm::{
             builtins::{PyFrozenSet, PyStrRef},
             convert::ToPyException,
-            PyObjectRef, PyResult, PyValue, VirtualMachine,
+            PyObjectRef, PyPayload, PyResult, VirtualMachine,
         },
     };
 

--- a/stdlib/src/syslog.rs
+++ b/stdlib/src/syslog.rs
@@ -7,7 +7,7 @@ mod syslog {
         builtins::{PyStr, PyStrRef},
         function::{OptionalArg, OptionalOption},
         utils::ToCString,
-        PyObjectRef, PyResult, PyValue, VirtualMachine,
+        PyObjectRef, PyPayload, PyResult, VirtualMachine,
     };
     use std::{ffi::CStr, os::raw::c_char};
 

--- a/stdlib/src/unicodedata.rs
+++ b/stdlib/src/unicodedata.rs
@@ -1,7 +1,7 @@
 /* Access to the unicode database.
    See also: https://docs.python.org/3/library/unicodedata.html
 */
-use crate::vm::{PyObjectRef, PyValue, VirtualMachine};
+use crate::vm::{PyObjectRef, PyPayload, VirtualMachine};
 
 pub fn make_module(vm: &VirtualMachine) -> PyObjectRef {
     let module = unicodedata::make_module(vm);
@@ -25,7 +25,7 @@ pub fn make_module(vm: &VirtualMachine) -> PyObjectRef {
 #[pymodule]
 mod unicodedata {
     use crate::vm::{
-        builtins::PyStrRef, function::OptionalArg, PyObjectRef, PyRef, PyResult, PyValue,
+        builtins::PyStrRef, function::OptionalArg, PyObjectRef, PyPayload, PyRef, PyResult,
         VirtualMachine,
     };
     use itertools::Itertools;
@@ -37,7 +37,7 @@ mod unicodedata {
 
     #[pyattr]
     #[pyclass(name = "UCD")]
-    #[derive(Debug, PyValue)]
+    #[derive(Debug, PyPayload)]
     pub(super) struct Ucd {
         unic_version: UnicodeVersion,
     }

--- a/stdlib/src/zlib.rs
+++ b/stdlib/src/zlib.rs
@@ -6,7 +6,7 @@ mod zlib {
     use crate::vm::{
         builtins::{PyBaseExceptionRef, PyBytes, PyBytesRef, PyIntRef, PyTypeRef},
         function::{ArgBytesLike, OptionalArg, OptionalOption},
-        PyResult, PyValue, VirtualMachine,
+        PyPayload, PyResult, VirtualMachine,
     };
     use adler32::RollingAdler32 as Adler32;
     use crossbeam_utils::atomic::AtomicCell;
@@ -281,7 +281,7 @@ mod zlib {
     }
     #[pyattr]
     #[pyclass(name = "Decompress")]
-    #[derive(Debug, PyValue)]
+    #[derive(Debug, PyPayload)]
     struct PyDecompress {
         decompress: PyMutex<Decompress>,
         eof: AtomicCell<bool>,
@@ -447,7 +447,7 @@ mod zlib {
 
     #[pyattr]
     #[pyclass(name = "Compress")]
-    #[derive(Debug, PyValue)]
+    #[derive(Debug, PyPayload)]
     struct PyCompress {
         inner: PyMutex<CompressInner>,
     }

--- a/vm/src/builtins/asyncgenerator.rs
+++ b/vm/src/builtins/asyncgenerator.rs
@@ -7,7 +7,7 @@ use crate::{
     protocol::PyIterReturn,
     pyclass::PyClassImpl,
     types::{Constructor, IterNext, IterNextIterable, Unconstructible},
-    AsObject, PyContext, PyObjectRef, PyRef, PyResult, PyValue, VirtualMachine,
+    AsObject, PyContext, PyObjectRef, PyPayload, PyRef, PyResult, VirtualMachine,
 };
 
 use crossbeam_utils::atomic::AtomicCell;
@@ -20,7 +20,7 @@ pub struct PyAsyncGen {
 }
 type PyAsyncGenRef = PyRef<PyAsyncGen>;
 
-impl PyValue for PyAsyncGen {
+impl PyPayload for PyAsyncGen {
     fn class(vm: &VirtualMachine) -> &PyTypeRef {
         &vm.ctx.types.async_generator
     }
@@ -134,7 +134,7 @@ impl Unconstructible for PyAsyncGen {}
 #[pyclass(module = false, name = "async_generator_wrapped_value")]
 #[derive(Debug)]
 pub(crate) struct PyAsyncGenWrappedValue(pub PyObjectRef);
-impl PyValue for PyAsyncGenWrappedValue {
+impl PyPayload for PyAsyncGenWrappedValue {
     fn class(vm: &VirtualMachine) -> &PyTypeRef {
         &vm.ctx.types.async_generator_wrapped_value
     }
@@ -183,7 +183,7 @@ pub(crate) struct PyAsyncGenASend {
     value: PyObjectRef,
 }
 
-impl PyValue for PyAsyncGenASend {
+impl PyPayload for PyAsyncGenASend {
     fn class(vm: &VirtualMachine) -> &PyTypeRef {
         &vm.ctx.types.async_generator_asend
     }
@@ -278,7 +278,7 @@ pub(crate) struct PyAsyncGenAThrow {
     value: (PyObjectRef, PyObjectRef, PyObjectRef),
 }
 
-impl PyValue for PyAsyncGenAThrow {
+impl PyPayload for PyAsyncGenAThrow {
     fn class(vm: &VirtualMachine) -> &PyTypeRef {
         &vm.ctx.types.async_generator_athrow
     }

--- a/vm/src/builtins/asyncgenerator.rs
+++ b/vm/src/builtins/asyncgenerator.rs
@@ -264,7 +264,7 @@ impl PyAsyncGenASend {
 
 impl IterNextIterable for PyAsyncGenASend {}
 impl IterNext for PyAsyncGenASend {
-    fn next(zelf: &crate::PyObjectView<Self>, vm: &VirtualMachine) -> PyResult<PyIterReturn> {
+    fn next(zelf: &crate::Py<Self>, vm: &VirtualMachine) -> PyResult<PyIterReturn> {
         PyIterReturn::from_pyresult(zelf.send(vm.ctx.none(), vm), vm)
     }
 }
@@ -410,7 +410,7 @@ impl PyAsyncGenAThrow {
 
 impl IterNextIterable for PyAsyncGenAThrow {}
 impl IterNext for PyAsyncGenAThrow {
-    fn next(zelf: &crate::PyObjectView<Self>, vm: &VirtualMachine) -> PyResult<PyIterReturn> {
+    fn next(zelf: &crate::Py<Self>, vm: &VirtualMachine) -> PyResult<PyIterReturn> {
         PyIterReturn::from_pyresult(zelf.send(vm.ctx.none(), vm), vm)
     }
 }

--- a/vm/src/builtins/builtinfunc.rs
+++ b/vm/src/builtins/builtinfunc.rs
@@ -4,7 +4,7 @@ use crate::{
     function::{FuncArgs, IntoPyNativeFunc, PyNativeFunc},
     pyclass::PyClassImpl,
     types::{Callable, Constructor, GetDescriptor, Unconstructible},
-    AsObject, PyContext, PyObjectRef, PyRef, PyResult, PyValue, VirtualMachine,
+    AsObject, PyContext, PyObjectRef, PyPayload, PyRef, PyResult, VirtualMachine,
 };
 use std::fmt;
 
@@ -62,7 +62,7 @@ pub struct PyBuiltinFunction {
     module: Option<PyObjectRef>,
 }
 
-impl PyValue for PyBuiltinFunction {
+impl PyPayload for PyBuiltinFunction {
     fn class(vm: &VirtualMachine) -> &PyTypeRef {
         &vm.ctx.types.builtin_function_or_method_type
     }
@@ -167,7 +167,7 @@ pub struct PyBuiltinMethod {
     class: PyTypeRef,
 }
 
-impl PyValue for PyBuiltinMethod {
+impl PyPayload for PyBuiltinMethod {
     fn class(vm: &VirtualMachine) -> &PyTypeRef {
         &vm.ctx.types.method_descriptor_type
     }

--- a/vm/src/builtins/builtinfunc.rs
+++ b/vm/src/builtins/builtinfunc.rs
@@ -105,7 +105,7 @@ impl PyBuiltinFunction {
 impl Callable for PyBuiltinFunction {
     type Args = FuncArgs;
     #[inline]
-    fn call(zelf: &crate::PyObjectView<Self>, args: FuncArgs, vm: &VirtualMachine) -> PyResult {
+    fn call(zelf: &crate::Py<Self>, args: FuncArgs, vm: &VirtualMachine) -> PyResult {
         (zelf.value.func)(vm, args)
     }
 }
@@ -202,7 +202,7 @@ impl GetDescriptor for PyBuiltinMethod {
 impl Callable for PyBuiltinMethod {
     type Args = FuncArgs;
     #[inline]
-    fn call(zelf: &crate::PyObjectView<Self>, args: FuncArgs, vm: &VirtualMachine) -> PyResult {
+    fn call(zelf: &crate::Py<Self>, args: FuncArgs, vm: &VirtualMachine) -> PyResult {
         (zelf.value.func)(vm, args)
     }
 }

--- a/vm/src/builtins/bytearray.rs
+++ b/vm/src/builtins/bytearray.rs
@@ -33,7 +33,7 @@ use crate::{
         IterNextIterable, Iterable, PyComparisonOp, Unconstructible, Unhashable,
     },
     utils::Either,
-    AsObject, PyContext, PyObject, PyObjectRef, PyObjectView, PyPayload, PyRef, PyResult,
+    AsObject, Py, PyContext, PyObject, PyObjectRef, PyPayload, PyRef, PyResult,
     TryFromBorrowedObject, TryFromObject, VirtualMachine,
 };
 use bstr::ByteSlice;
@@ -303,7 +303,7 @@ impl PyByteArray {
         }
     }
 
-    fn irepeat(zelf: &crate::PyObjectView<Self>, n: isize, vm: &VirtualMachine) -> PyResult<()> {
+    fn irepeat(zelf: &crate::Py<Self>, n: isize, vm: &VirtualMachine) -> PyResult<()> {
         if n == 1 {
             return Ok(());
         }
@@ -714,7 +714,7 @@ impl PyByteArray {
 
 impl Comparable for PyByteArray {
     fn cmp(
-        zelf: &crate::PyObjectView<Self>,
+        zelf: &crate::Py<Self>,
         other: &PyObject,
         op: PyComparisonOp,
         vm: &VirtualMachine,
@@ -749,7 +749,7 @@ static BUFFER_METHODS: BufferMethods = BufferMethods {
 };
 
 impl AsBuffer for PyByteArray {
-    fn as_buffer(zelf: &PyObjectView<Self>, _vm: &VirtualMachine) -> PyResult<PyBuffer> {
+    fn as_buffer(zelf: &Py<Self>, _vm: &VirtualMachine) -> PyResult<PyBuffer> {
         Ok(PyBuffer::new(
             zelf.to_owned().into(),
             BufferDescriptor::simple(zelf.len(), false),
@@ -768,16 +768,13 @@ impl<'a> BufferResizeGuard<'a> for PyByteArray {
 }
 
 impl AsMapping for PyByteArray {
-    fn as_mapping(_zelf: &crate::PyObjectView<Self>, _vm: &VirtualMachine) -> PyMappingMethods {
+    fn as_mapping(_zelf: &crate::Py<Self>, _vm: &VirtualMachine) -> PyMappingMethods {
         Self::MAPPING_METHODS
     }
 }
 
 impl AsSequence for PyByteArray {
-    fn as_sequence(
-        _zelf: &PyObjectView<Self>,
-        _vm: &VirtualMachine,
-    ) -> Cow<'static, PySequenceMethods> {
+    fn as_sequence(_zelf: &Py<Self>, _vm: &VirtualMachine) -> Cow<'static, PySequenceMethods> {
         Cow::Borrowed(&Self::SEQUENCE_METHODS)
     }
 }
@@ -877,7 +874,7 @@ impl Unconstructible for PyByteArrayIterator {}
 
 impl IterNextIterable for PyByteArrayIterator {}
 impl IterNext for PyByteArrayIterator {
-    fn next(zelf: &crate::PyObjectView<Self>, vm: &VirtualMachine) -> PyResult<PyIterReturn> {
+    fn next(zelf: &crate::Py<Self>, vm: &VirtualMachine) -> PyResult<PyIterReturn> {
         zelf.internal.lock().next(|bytearray, pos| {
             let buf = bytearray.borrow_buf();
             Ok(PyIterReturn::from_result(

--- a/vm/src/builtins/bytearray.rs
+++ b/vm/src/builtins/bytearray.rs
@@ -33,7 +33,7 @@ use crate::{
         IterNextIterable, Iterable, PyComparisonOp, Unconstructible, Unhashable,
     },
     utils::Either,
-    AsObject, PyContext, PyObject, PyObjectRef, PyObjectView, PyRef, PyResult, PyValue,
+    AsObject, PyContext, PyObject, PyObjectRef, PyObjectView, PyPayload, PyRef, PyResult,
     TryFromBorrowedObject, TryFromObject, VirtualMachine,
 };
 use bstr::ByteSlice;
@@ -81,7 +81,7 @@ impl From<Vec<u8>> for PyByteArray {
     }
 }
 
-impl PyValue for PyByteArray {
+impl PyPayload for PyByteArray {
     fn class(vm: &VirtualMachine) -> &PyTypeRef {
         &vm.ctx.types.bytearray_type
     }
@@ -847,7 +847,7 @@ pub struct PyByteArrayIterator {
     internal: PyMutex<PositionIterInternal<PyByteArrayRef>>,
 }
 
-impl PyValue for PyByteArrayIterator {
+impl PyPayload for PyByteArrayIterator {
     fn class(vm: &VirtualMachine) -> &PyTypeRef {
         &vm.ctx.types.bytearray_iterator_type
     }

--- a/vm/src/builtins/bytes.rs
+++ b/vm/src/builtins/bytes.rs
@@ -20,7 +20,7 @@ use crate::{
         IterNextIterable, Iterable, PyComparisonOp, Unconstructible,
     },
     utils::Either,
-    AsObject, PyContext, PyObject, PyObjectRef, PyObjectView, PyPayload, PyRef, PyResult,
+    AsObject, Py, PyContext, PyObject, PyObjectRef, PyPayload, PyRef, PyResult,
     TryFromBorrowedObject, TryFromObject, VirtualMachine,
 };
 use bstr::ByteSlice;
@@ -565,7 +565,7 @@ static BUFFER_METHODS: BufferMethods = BufferMethods {
 };
 
 impl AsBuffer for PyBytes {
-    fn as_buffer(zelf: &PyObjectView<Self>, _vm: &VirtualMachine) -> PyResult<PyBuffer> {
+    fn as_buffer(zelf: &Py<Self>, _vm: &VirtualMachine) -> PyResult<PyBuffer> {
         let buf = PyBuffer::new(
             zelf.to_owned().into(),
             BufferDescriptor::simple(zelf.len(), true),
@@ -576,16 +576,13 @@ impl AsBuffer for PyBytes {
 }
 
 impl AsMapping for PyBytes {
-    fn as_mapping(_zelf: &PyObjectView<Self>, _vm: &VirtualMachine) -> PyMappingMethods {
+    fn as_mapping(_zelf: &Py<Self>, _vm: &VirtualMachine) -> PyMappingMethods {
         Self::MAPPING_METHODS
     }
 }
 
 impl AsSequence for PyBytes {
-    fn as_sequence(
-        _zelf: &PyObjectView<Self>,
-        _vm: &VirtualMachine,
-    ) -> Cow<'static, PySequenceMethods> {
+    fn as_sequence(_zelf: &Py<Self>, _vm: &VirtualMachine) -> Cow<'static, PySequenceMethods> {
         Cow::Borrowed(&Self::SEQUENCE_METHODS)
     }
 }
@@ -622,14 +619,14 @@ impl PyBytes {
 
 impl Hashable for PyBytes {
     #[inline]
-    fn hash(zelf: &crate::PyObjectView<Self>, vm: &VirtualMachine) -> PyResult<PyHash> {
+    fn hash(zelf: &crate::Py<Self>, vm: &VirtualMachine) -> PyResult<PyHash> {
         Ok(zelf.inner.hash(vm))
     }
 }
 
 impl Comparable for PyBytes {
     fn cmp(
-        zelf: &crate::PyObjectView<Self>,
+        zelf: &crate::Py<Self>,
         other: &PyObject,
         op: PyComparisonOp,
         vm: &VirtualMachine,
@@ -698,7 +695,7 @@ impl Unconstructible for PyBytesIterator {}
 
 impl IterNextIterable for PyBytesIterator {}
 impl IterNext for PyBytesIterator {
-    fn next(zelf: &crate::PyObjectView<Self>, vm: &VirtualMachine) -> PyResult<PyIterReturn> {
+    fn next(zelf: &crate::Py<Self>, vm: &VirtualMachine) -> PyResult<PyIterReturn> {
         zelf.internal.lock().next(|bytes, pos| {
             Ok(PyIterReturn::from_result(
                 bytes

--- a/vm/src/builtins/bytes.rs
+++ b/vm/src/builtins/bytes.rs
@@ -20,7 +20,7 @@ use crate::{
         IterNextIterable, Iterable, PyComparisonOp, Unconstructible,
     },
     utils::Either,
-    AsObject, PyContext, PyObject, PyObjectRef, PyObjectView, PyRef, PyResult, PyValue,
+    AsObject, PyContext, PyObject, PyObjectRef, PyObjectView, PyPayload, PyRef, PyResult,
     TryFromBorrowedObject, TryFromObject, VirtualMachine,
 };
 use bstr::ByteSlice;
@@ -73,7 +73,7 @@ impl AsRef<[u8]> for PyBytesRef {
     }
 }
 
-impl PyValue for PyBytes {
+impl PyPayload for PyBytes {
     fn class(vm: &VirtualMachine) -> &PyTypeRef {
         &vm.ctx.types.bytes_type
     }
@@ -667,7 +667,7 @@ pub struct PyBytesIterator {
     internal: PyMutex<PositionIterInternal<PyBytesRef>>,
 }
 
-impl PyValue for PyBytesIterator {
+impl PyPayload for PyBytesIterator {
     fn class(vm: &VirtualMachine) -> &PyTypeRef {
         &vm.ctx.types.bytes_iterator_type
     }

--- a/vm/src/builtins/classmethod.rs
+++ b/vm/src/builtins/classmethod.rs
@@ -3,7 +3,7 @@ use crate::{
     builtins::PyBoundMethod,
     pyclass::PyClassImpl,
     types::{Constructor, GetDescriptor},
-    AsObject, PyContext, PyObjectRef, PyRef, PyResult, PyValue, VirtualMachine,
+    AsObject, PyContext, PyObjectRef, PyPayload, PyRef, PyResult, VirtualMachine,
 };
 
 /// classmethod(function) -> method
@@ -38,7 +38,7 @@ impl From<PyObjectRef> for PyClassMethod {
     }
 }
 
-impl PyValue for PyClassMethod {
+impl PyPayload for PyClassMethod {
     fn class(vm: &VirtualMachine) -> &PyTypeRef {
         &vm.ctx.types.classmethod_type
     }

--- a/vm/src/builtins/code.rs
+++ b/vm/src/builtins/code.rs
@@ -7,7 +7,7 @@ use crate::{
     bytecode::{self, BorrowedConstant, Constant, ConstantBag},
     function::FuncArgs,
     pyclass::{PyClassImpl, StaticType},
-    AsObject, PyContext, PyObject, PyObjectRef, PyRef, PyResult, PyValue, VirtualMachine,
+    AsObject, PyContext, PyObject, PyObjectRef, PyPayload, PyRef, PyResult, VirtualMachine,
 };
 use num_traits::Zero;
 use std::{fmt, ops::Deref};
@@ -185,7 +185,7 @@ impl fmt::Debug for PyCode {
     }
 }
 
-impl PyValue for PyCode {
+impl PyPayload for PyCode {
     fn class(vm: &VirtualMachine) -> &PyTypeRef {
         &vm.ctx.types.code_type
     }

--- a/vm/src/builtins/complex.rs
+++ b/vm/src/builtins/complex.rs
@@ -387,7 +387,7 @@ impl PyComplex {
 
 impl Comparable for PyComplex {
     fn cmp(
-        zelf: &crate::PyObjectView<Self>,
+        zelf: &crate::Py<Self>,
         other: &PyObject,
         op: PyComparisonOp,
         vm: &VirtualMachine,
@@ -409,7 +409,7 @@ impl Comparable for PyComplex {
 
 impl Hashable for PyComplex {
     #[inline]
-    fn hash(zelf: &crate::PyObjectView<Self>, _vm: &VirtualMachine) -> PyResult<hash::PyHash> {
+    fn hash(zelf: &crate::Py<Self>, _vm: &VirtualMachine) -> PyResult<hash::PyHash> {
         Ok(hash::hash_complex(&zelf.value))
     }
 }

--- a/vm/src/builtins/complex.rs
+++ b/vm/src/builtins/complex.rs
@@ -8,7 +8,7 @@ use crate::{
     },
     pyclass::PyClassImpl,
     types::{Comparable, Constructor, Hashable, PyComparisonOp},
-    AsObject, PyContext, PyObject, PyObjectRef, PyRef, PyResult, PyValue, VirtualMachine,
+    AsObject, PyContext, PyObject, PyObjectRef, PyPayload, PyRef, PyResult, VirtualMachine,
 };
 use num_complex::Complex64;
 use num_traits::Zero;
@@ -23,7 +23,7 @@ pub struct PyComplex {
     value: Complex64,
 }
 
-impl PyValue for PyComplex {
+impl PyPayload for PyComplex {
     fn class(vm: &VirtualMachine) -> &PyTypeRef {
         &vm.ctx.types.complex_type
     }

--- a/vm/src/builtins/coroutine.rs
+++ b/vm/src/builtins/coroutine.rs
@@ -6,7 +6,7 @@ use crate::{
     protocol::PyIterReturn,
     pyclass::PyClassImpl,
     types::{Constructor, IterNext, IterNextIterable, Unconstructible},
-    AsObject, PyContext, PyObjectRef, PyRef, PyResult, PyValue, VirtualMachine,
+    AsObject, PyContext, PyObjectRef, PyPayload, PyRef, PyResult, VirtualMachine,
 };
 
 #[pyclass(module = false, name = "coroutine")]
@@ -16,7 +16,7 @@ pub struct PyCoroutine {
     inner: Coro,
 }
 
-impl PyValue for PyCoroutine {
+impl PyPayload for PyCoroutine {
     fn class(vm: &VirtualMachine) -> &PyTypeRef {
         &vm.ctx.types.coroutine_type
     }
@@ -120,7 +120,7 @@ pub struct PyCoroutineWrapper {
     coro: PyRef<PyCoroutine>,
 }
 
-impl PyValue for PyCoroutineWrapper {
+impl PyPayload for PyCoroutineWrapper {
     fn class(vm: &VirtualMachine) -> &PyTypeRef {
         &vm.ctx.types.coroutine_wrapper_type
     }

--- a/vm/src/builtins/coroutine.rs
+++ b/vm/src/builtins/coroutine.rs
@@ -108,7 +108,7 @@ impl Unconstructible for PyCoroutine {}
 
 impl IterNextIterable for PyCoroutine {}
 impl IterNext for PyCoroutine {
-    fn next(zelf: &crate::PyObjectView<Self>, vm: &VirtualMachine) -> PyResult<PyIterReturn> {
+    fn next(zelf: &crate::Py<Self>, vm: &VirtualMachine) -> PyResult<PyIterReturn> {
         Self::send(zelf.to_owned(), vm.ctx.none(), vm)
     }
 }
@@ -147,7 +147,7 @@ impl PyCoroutineWrapper {
 
 impl IterNextIterable for PyCoroutineWrapper {}
 impl IterNext for PyCoroutineWrapper {
-    fn next(zelf: &crate::PyObjectView<Self>, vm: &VirtualMachine) -> PyResult<PyIterReturn> {
+    fn next(zelf: &crate::Py<Self>, vm: &VirtualMachine) -> PyResult<PyIterReturn> {
         Self::send(zelf.to_owned(), vm.ctx.none(), vm)
     }
 }

--- a/vm/src/builtins/dict.rs
+++ b/vm/src/builtins/dict.rs
@@ -21,8 +21,7 @@ use crate::{
         IterNextIterable, Iterable, PyComparisonOp, Unconstructible, Unhashable,
     },
     vm::{ReprGuard, VirtualMachine},
-    AsObject, PyContext, PyObject, PyObjectRef, PyObjectView, PyPayload, PyRef, PyResult,
-    TryFromObject,
+    AsObject, Py, PyContext, PyObject, PyObjectRef, PyPayload, PyRef, PyResult, TryFromObject,
 };
 use rustpython_common::lock::PyMutex;
 use std::{borrow::Cow, fmt};
@@ -180,8 +179,8 @@ impl PyDict {
     }
 
     fn inner_cmp(
-        zelf: &PyObjectView<Self>,
-        other: &PyObjectView<PyDict>,
+        zelf: &Py<Self>,
+        other: &Py<PyDict>,
         op: PyComparisonOp,
         item: bool,
         vm: &VirtualMachine,
@@ -463,16 +462,13 @@ impl PyDict {
 }
 
 impl AsMapping for PyDict {
-    fn as_mapping(_zelf: &PyObjectView<Self>, _vm: &VirtualMachine) -> PyMappingMethods {
+    fn as_mapping(_zelf: &Py<Self>, _vm: &VirtualMachine) -> PyMappingMethods {
         Self::MAPPING_METHODS
     }
 }
 
 impl AsSequence for PyDict {
-    fn as_sequence(
-        _zelf: &PyObjectView<Self>,
-        _vm: &VirtualMachine,
-    ) -> Cow<'static, PySequenceMethods> {
+    fn as_sequence(_zelf: &Py<Self>, _vm: &VirtualMachine) -> Cow<'static, PySequenceMethods> {
         Cow::Borrowed(&Self::SEQUENCE_METHODS)
     }
 }
@@ -486,7 +482,7 @@ impl PyDict {
 
 impl Comparable for PyDict {
     fn cmp(
-        zelf: &PyObjectView<Self>,
+        zelf: &Py<Self>,
         other: &PyObject,
         op: PyComparisonOp,
         vm: &VirtualMachine,
@@ -506,7 +502,7 @@ impl Iterable for PyDict {
     }
 }
 
-impl PyObjectView<PyDict> {
+impl Py<PyDict> {
     #[inline]
     fn exact_dict(&self, vm: &VirtualMachine) -> bool {
         self.class().is(&vm.ctx.types.dict_type)
@@ -636,7 +632,7 @@ impl IntoIterator for &PyDictRef {
     }
 }
 
-impl IntoIterator for &PyObjectView<PyDict> {
+impl IntoIterator for &Py<PyDict> {
     type Item = (PyObjectRef, PyObjectRef);
     type IntoIter = DictIter;
 
@@ -794,7 +790,7 @@ macro_rules! dict_view {
         impl IterNextIterable for $iter_name {}
         impl IterNext for $iter_name {
             #[allow(clippy::redundant_closure_call)]
-            fn next(zelf: &PyObjectView<Self>, vm: &VirtualMachine) -> PyResult<PyIterReturn> {
+            fn next(zelf: &Py<Self>, vm: &VirtualMachine) -> PyResult<PyIterReturn> {
                 let mut internal = zelf.internal.lock();
                 let next = if let IterStatus::Active(dict) = &internal.status {
                     if dict.entries.has_changed_size(&zelf.size) {
@@ -872,7 +868,7 @@ macro_rules! dict_view {
         impl IterNextIterable for $reverse_iter_name {}
         impl IterNext for $reverse_iter_name {
             #[allow(clippy::redundant_closure_call)]
-            fn next(zelf: &PyObjectView<Self>, vm: &VirtualMachine) -> PyResult<PyIterReturn> {
+            fn next(zelf: &Py<Self>, vm: &VirtualMachine) -> PyResult<PyIterReturn> {
                 let mut internal = zelf.internal.lock();
                 let next = if let IterStatus::Active(dict) = &internal.status {
                     if dict.entries.has_changed_size(&zelf.size) {
@@ -994,7 +990,7 @@ trait ViewSetOps: DictView {
     }
 
     fn cmp(
-        zelf: &PyObjectView<Self>,
+        zelf: &Py<Self>,
         other: &PyObject,
         op: PyComparisonOp,
         vm: &VirtualMachine,
@@ -1041,7 +1037,7 @@ impl Unconstructible for PyDictKeys {}
 
 impl Comparable for PyDictKeys {
     fn cmp(
-        zelf: &PyObjectView<Self>,
+        zelf: &Py<Self>,
         other: &PyObject,
         op: PyComparisonOp,
         vm: &VirtualMachine,
@@ -1051,10 +1047,7 @@ impl Comparable for PyDictKeys {
 }
 
 impl AsSequence for PyDictKeys {
-    fn as_sequence(
-        _zelf: &PyObjectView<Self>,
-        _vm: &VirtualMachine,
-    ) -> Cow<'static, PySequenceMethods> {
+    fn as_sequence(_zelf: &Py<Self>, _vm: &VirtualMachine) -> Cow<'static, PySequenceMethods> {
         Cow::Borrowed(&Self::SEQUENCE_METHODS)
     }
 }
@@ -1098,7 +1091,7 @@ impl Unconstructible for PyDictItems {}
 
 impl Comparable for PyDictItems {
     fn cmp(
-        zelf: &PyObjectView<Self>,
+        zelf: &Py<Self>,
         other: &PyObject,
         op: PyComparisonOp,
         vm: &VirtualMachine,
@@ -1108,10 +1101,7 @@ impl Comparable for PyDictItems {
 }
 
 impl AsSequence for PyDictItems {
-    fn as_sequence(
-        _zelf: &PyObjectView<Self>,
-        _vm: &VirtualMachine,
-    ) -> Cow<'static, PySequenceMethods> {
+    fn as_sequence(_zelf: &Py<Self>, _vm: &VirtualMachine) -> Cow<'static, PySequenceMethods> {
         Cow::Borrowed(&Self::SEQUENCE_METHODS)
     }
 }
@@ -1133,10 +1123,7 @@ impl PyDictValues {}
 impl Unconstructible for PyDictValues {}
 
 impl AsSequence for PyDictValues {
-    fn as_sequence(
-        _zelf: &PyObjectView<Self>,
-        _vm: &VirtualMachine,
-    ) -> Cow<'static, PySequenceMethods> {
+    fn as_sequence(_zelf: &Py<Self>, _vm: &VirtualMachine) -> Cow<'static, PySequenceMethods> {
         Cow::Borrowed(&Self::SEQUENCE_METHODS)
     }
 }

--- a/vm/src/builtins/dict.rs
+++ b/vm/src/builtins/dict.rs
@@ -21,7 +21,7 @@ use crate::{
         IterNextIterable, Iterable, PyComparisonOp, Unconstructible, Unhashable,
     },
     vm::{ReprGuard, VirtualMachine},
-    AsObject, PyContext, PyObject, PyObjectRef, PyObjectView, PyRef, PyResult, PyValue,
+    AsObject, PyContext, PyObject, PyObjectRef, PyObjectView, PyPayload, PyRef, PyResult,
     TryFromObject,
 };
 use rustpython_common::lock::PyMutex;
@@ -52,7 +52,7 @@ impl fmt::Debug for PyDict {
     }
 }
 
-impl PyValue for PyDict {
+impl PyPayload for PyDict {
     fn class(vm: &VirtualMachine) -> &PyTypeRef {
         &vm.ctx.types.dict_type
     }
@@ -672,9 +672,9 @@ impl Iterator for DictIter {
 }
 
 #[pyimpl]
-trait DictView: PyValue + PyClassDef + Iterable
+trait DictView: PyPayload + PyClassDef + Iterable
 where
-    Self::ReverseIter: PyValue,
+    Self::ReverseIter: PyPayload,
 {
     type ReverseIter;
 
@@ -741,7 +741,7 @@ macro_rules! dict_view {
             }
         }
 
-        impl PyValue for $name {
+        impl PyPayload for $name {
             fn class(vm: &VirtualMachine) -> &PyTypeRef {
                 &vm.ctx.types.$class
             }
@@ -754,7 +754,7 @@ macro_rules! dict_view {
             pub internal: PyMutex<PositionIterInternal<PyDictRef>>,
         }
 
-        impl PyValue for $iter_name {
+        impl PyPayload for $iter_name {
             fn class(vm: &VirtualMachine) -> &PyTypeRef {
                 &vm.ctx.types.$iter_class
             }
@@ -827,7 +827,7 @@ macro_rules! dict_view {
             internal: PyMutex<PositionIterInternal<PyDictRef>>,
         }
 
-        impl PyValue for $reverse_iter_name {
+        impl PyPayload for $reverse_iter_name {
             fn class(vm: &VirtualMachine) -> &PyTypeRef {
                 &vm.ctx.types.$reverse_iter_class
             }

--- a/vm/src/builtins/enumerate.rs
+++ b/vm/src/builtins/enumerate.rs
@@ -65,7 +65,7 @@ impl PyEnumerate {
 
 impl IterNextIterable for PyEnumerate {}
 impl IterNext for PyEnumerate {
-    fn next(zelf: &crate::PyObjectView<Self>, vm: &VirtualMachine) -> PyResult<PyIterReturn> {
+    fn next(zelf: &crate::Py<Self>, vm: &VirtualMachine) -> PyResult<PyIterReturn> {
         let next_obj = match zelf.iterator.next(vm)? {
             PyIterReturn::StopIteration(v) => return Ok(PyIterReturn::StopIteration(v)),
             PyIterReturn::Return(obj) => obj,
@@ -124,7 +124,7 @@ impl PyReverseSequenceIterator {
 
 impl IterNextIterable for PyReverseSequenceIterator {}
 impl IterNext for PyReverseSequenceIterator {
-    fn next(zelf: &crate::PyObjectView<Self>, vm: &VirtualMachine) -> PyResult<PyIterReturn> {
+    fn next(zelf: &crate::Py<Self>, vm: &VirtualMachine) -> PyResult<PyIterReturn> {
         zelf.internal
             .lock()
             .rev_next(|obj, pos| PyIterReturn::from_getitem_result(obj.get_item(pos, vm), vm))

--- a/vm/src/builtins/enumerate.rs
+++ b/vm/src/builtins/enumerate.rs
@@ -6,7 +6,7 @@ use crate::{
     protocol::{PyIter, PyIterReturn},
     pyclass::PyClassImpl,
     types::{Constructor, IterNext, IterNextIterable},
-    AsObject, PyContext, PyObjectRef, PyRef, PyResult, PyValue, VirtualMachine,
+    AsObject, PyContext, PyObjectRef, PyPayload, PyRef, PyResult, VirtualMachine,
 };
 use num_bigint::BigInt;
 use num_traits::Zero;
@@ -18,7 +18,7 @@ pub struct PyEnumerate {
     iterator: PyIter,
 }
 
-impl PyValue for PyEnumerate {
+impl PyPayload for PyEnumerate {
     fn class(vm: &VirtualMachine) -> &PyTypeRef {
         &vm.ctx.types.enumerate_type
     }
@@ -83,7 +83,7 @@ pub struct PyReverseSequenceIterator {
     internal: PyMutex<PositionIterInternal<PyObjectRef>>,
 }
 
-impl PyValue for PyReverseSequenceIterator {
+impl PyPayload for PyReverseSequenceIterator {
     fn class(vm: &VirtualMachine) -> &PyTypeRef {
         &vm.ctx.types.reverse_iter_type
     }

--- a/vm/src/builtins/filter.rs
+++ b/vm/src/builtins/filter.rs
@@ -40,7 +40,7 @@ impl PyFilter {}
 
 impl IterNextIterable for PyFilter {}
 impl IterNext for PyFilter {
-    fn next(zelf: &crate::PyObjectView<Self>, vm: &VirtualMachine) -> PyResult<PyIterReturn> {
+    fn next(zelf: &crate::Py<Self>, vm: &VirtualMachine) -> PyResult<PyIterReturn> {
         let predicate = &zelf.predicate;
         loop {
             let next_obj = match zelf.iterator.next(vm)? {

--- a/vm/src/builtins/filter.rs
+++ b/vm/src/builtins/filter.rs
@@ -3,7 +3,7 @@ use crate::{
     protocol::{PyIter, PyIterReturn},
     pyclass::PyClassImpl,
     types::{Constructor, IterNext, IterNextIterable},
-    PyContext, PyObjectRef, PyResult, PyValue, VirtualMachine,
+    PyContext, PyObjectRef, PyPayload, PyResult, VirtualMachine,
 };
 
 /// filter(function or None, iterable) --> filter object
@@ -17,7 +17,7 @@ pub struct PyFilter {
     iterator: PyIter,
 }
 
-impl PyValue for PyFilter {
+impl PyPayload for PyFilter {
     fn class(vm: &VirtualMachine) -> &PyTypeRef {
         &vm.ctx.types.filter_type
     }

--- a/vm/src/builtins/float.rs
+++ b/vm/src/builtins/float.rs
@@ -511,7 +511,7 @@ impl PyFloat {
 
 impl Comparable for PyFloat {
     fn cmp(
-        zelf: &crate::PyObjectView<Self>,
+        zelf: &crate::Py<Self>,
         other: &PyObject,
         op: PyComparisonOp,
         vm: &VirtualMachine,
@@ -552,7 +552,7 @@ impl Comparable for PyFloat {
 
 impl Hashable for PyFloat {
     #[inline]
-    fn hash(zelf: &crate::PyObjectView<Self>, _vm: &VirtualMachine) -> PyResult<hash::PyHash> {
+    fn hash(zelf: &crate::Py<Self>, _vm: &VirtualMachine) -> PyResult<hash::PyHash> {
         Ok(hash::hash_float(zelf.to_f64()))
     }
 }

--- a/vm/src/builtins/float.rs
+++ b/vm/src/builtins/float.rs
@@ -10,7 +10,7 @@ use crate::{
     },
     pyclass::PyClassImpl,
     types::{Comparable, Constructor, Hashable, PyComparisonOp},
-    AsObject, PyContext, PyObject, PyObjectRef, PyRef, PyResult, PyValue, TryFromBorrowedObject,
+    AsObject, PyContext, PyObject, PyObjectRef, PyPayload, PyRef, PyResult, TryFromBorrowedObject,
     TryFromObject, VirtualMachine,
 };
 use num_bigint::{BigInt, ToBigInt};
@@ -31,7 +31,7 @@ impl PyFloat {
     }
 }
 
-impl PyValue for PyFloat {
+impl PyPayload for PyFloat {
     fn class(vm: &VirtualMachine) -> &PyTypeRef {
         &vm.ctx.types.float_type
     }

--- a/vm/src/builtins/function.rs
+++ b/vm/src/builtins/function.rs
@@ -422,7 +422,7 @@ impl GetDescriptor for PyFunction {
 impl Callable for PyFunction {
     type Args = FuncArgs;
     #[inline]
-    fn call(zelf: &crate::PyObjectView<Self>, args: FuncArgs, vm: &VirtualMachine) -> PyResult {
+    fn call(zelf: &crate::Py<Self>, args: FuncArgs, vm: &VirtualMachine) -> PyResult {
         zelf.invoke(args, vm)
     }
 }
@@ -437,7 +437,7 @@ pub struct PyBoundMethod {
 impl Callable for PyBoundMethod {
     type Args = FuncArgs;
     #[inline]
-    fn call(zelf: &crate::PyObjectView<Self>, mut args: FuncArgs, vm: &VirtualMachine) -> PyResult {
+    fn call(zelf: &crate::Py<Self>, mut args: FuncArgs, vm: &VirtualMachine) -> PyResult {
         args.prepend_arg(zelf.object.clone());
         vm.invoke(&zelf.function, args)
     }
@@ -445,7 +445,7 @@ impl Callable for PyBoundMethod {
 
 impl Comparable for PyBoundMethod {
     fn cmp(
-        zelf: &crate::PyObjectView<Self>,
+        zelf: &crate::Py<Self>,
         other: &PyObject,
         op: PyComparisonOp,
         _vm: &VirtualMachine,

--- a/vm/src/builtins/function.rs
+++ b/vm/src/builtins/function.rs
@@ -14,7 +14,7 @@ use crate::{
     pyclass::PyClassImpl,
     scope::Scope,
     types::{Callable, Comparable, Constructor, GetAttr, GetDescriptor, PyComparisonOp},
-    AsObject, PyContext, PyObject, PyObjectRef, PyRef, PyResult, PyValue, VirtualMachine,
+    AsObject, PyContext, PyObject, PyObjectRef, PyPayload, PyRef, PyResult, VirtualMachine,
 };
 #[cfg(feature = "jit")]
 use crate::{common::lock::OnceCell, convert::ToPyObject};
@@ -324,7 +324,7 @@ impl PyFunction {
     }
 }
 
-impl PyValue for PyFunction {
+impl PyPayload for PyFunction {
     fn class(vm: &VirtualMachine) -> &PyTypeRef {
         &vm.ctx.types.function_type
     }
@@ -565,7 +565,7 @@ impl PyBoundMethod {
     }
 }
 
-impl PyValue for PyBoundMethod {
+impl PyPayload for PyBoundMethod {
     fn class(vm: &VirtualMachine) -> &PyTypeRef {
         &vm.ctx.types.bound_method_type
     }
@@ -578,7 +578,7 @@ pub(crate) struct PyCell {
 }
 pub(crate) type PyCellRef = PyRef<PyCell>;
 
-impl PyValue for PyCell {
+impl PyPayload for PyCell {
     fn class(vm: &VirtualMachine) -> &PyTypeRef {
         &vm.ctx.types.cell_type
     }

--- a/vm/src/builtins/function/jitfunc.rs
+++ b/vm/src/builtins/function/jitfunc.rs
@@ -65,7 +65,7 @@ fn get_jit_arg_type(dict: &PyDictRef, name: &str, vm: &VirtualMachine) -> PyResu
 }
 
 pub fn get_jit_arg_types(
-    func: &crate::PyObjectView<PyFunction>,
+    func: &crate::Py<PyFunction>,
     vm: &VirtualMachine,
 ) -> PyResult<Vec<JitType>> {
     let arg_names = func.code.arg_names();

--- a/vm/src/builtins/generator.rs
+++ b/vm/src/builtins/generator.rs
@@ -10,7 +10,7 @@ use crate::{
     protocol::PyIterReturn,
     pyclass::PyClassImpl,
     types::{Constructor, IterNext, IterNextIterable, Unconstructible},
-    AsObject, PyContext, PyObjectRef, PyRef, PyResult, PyValue, VirtualMachine,
+    AsObject, PyContext, PyObjectRef, PyPayload, PyRef, PyResult, VirtualMachine,
 };
 
 #[pyclass(module = false, name = "generator")]
@@ -19,7 +19,7 @@ pub struct PyGenerator {
     inner: Coro,
 }
 
-impl PyValue for PyGenerator {
+impl PyPayload for PyGenerator {
     fn class(vm: &VirtualMachine) -> &PyTypeRef {
         &vm.ctx.types.generator_type
     }

--- a/vm/src/builtins/generator.rs
+++ b/vm/src/builtins/generator.rs
@@ -100,7 +100,7 @@ impl Unconstructible for PyGenerator {}
 
 impl IterNextIterable for PyGenerator {}
 impl IterNext for PyGenerator {
-    fn next(zelf: &crate::PyObjectView<Self>, vm: &VirtualMachine) -> PyResult<PyIterReturn> {
+    fn next(zelf: &crate::Py<Self>, vm: &VirtualMachine) -> PyResult<PyIterReturn> {
         Self::send(zelf.to_owned(), vm.ctx.none(), vm)
     }
 }

--- a/vm/src/builtins/genericalias.rs
+++ b/vm/src/builtins/genericalias.rs
@@ -6,8 +6,8 @@ use crate::{
     protocol::PyMappingMethods,
     pyclass::PyClassImpl,
     types::{AsMapping, Callable, Comparable, Constructor, GetAttr, Hashable, PyComparisonOp},
-    AsObject, PyContext, PyObject, PyObjectRef, PyObjectView, PyPayload, PyRef, PyResult,
-    TryFromObject, VirtualMachine,
+    AsObject, Py, PyContext, PyObject, PyObjectRef, PyPayload, PyRef, PyResult, TryFromObject,
+    VirtualMachine,
 };
 use std::fmt;
 
@@ -314,14 +314,14 @@ impl PyGenericAlias {
 }
 
 impl AsMapping for PyGenericAlias {
-    fn as_mapping(_zelf: &PyObjectView<Self>, _vm: &VirtualMachine) -> PyMappingMethods {
+    fn as_mapping(_zelf: &Py<Self>, _vm: &VirtualMachine) -> PyMappingMethods {
         Self::MAPPING_METHODS
     }
 }
 
 impl Callable for PyGenericAlias {
     type Args = FuncArgs;
-    fn call(zelf: &crate::PyObjectView<Self>, args: FuncArgs, vm: &VirtualMachine) -> PyResult {
+    fn call(zelf: &crate::Py<Self>, args: FuncArgs, vm: &VirtualMachine) -> PyResult {
         PyType::call(&zelf.origin, args, vm).map(|obj| {
             if let Err(exc) = obj.set_attr("__orig_class__", zelf.to_owned(), vm) {
                 if !exc.fast_isinstance(&vm.ctx.exceptions.attribute_error)
@@ -337,7 +337,7 @@ impl Callable for PyGenericAlias {
 
 impl Comparable for PyGenericAlias {
     fn cmp(
-        zelf: &crate::PyObjectView<Self>,
+        zelf: &crate::Py<Self>,
         other: &PyObject,
         op: PyComparisonOp,
         vm: &VirtualMachine,
@@ -361,7 +361,7 @@ impl Comparable for PyGenericAlias {
 
 impl Hashable for PyGenericAlias {
     #[inline]
-    fn hash(zelf: &crate::PyObjectView<Self>, vm: &VirtualMachine) -> PyResult<hash::PyHash> {
+    fn hash(zelf: &crate::Py<Self>, vm: &VirtualMachine) -> PyResult<hash::PyHash> {
         Ok(zelf.origin.as_object().hash(vm)? ^ zelf.args.as_object().hash(vm)?)
     }
 }

--- a/vm/src/builtins/genericalias.rs
+++ b/vm/src/builtins/genericalias.rs
@@ -6,7 +6,7 @@ use crate::{
     protocol::PyMappingMethods,
     pyclass::PyClassImpl,
     types::{AsMapping, Callable, Comparable, Constructor, GetAttr, Hashable, PyComparisonOp},
-    AsObject, PyContext, PyObject, PyObjectRef, PyObjectView, PyRef, PyResult, PyValue,
+    AsObject, PyContext, PyObject, PyObjectRef, PyObjectView, PyPayload, PyRef, PyResult,
     TryFromObject, VirtualMachine,
 };
 use std::fmt;
@@ -35,7 +35,7 @@ impl fmt::Debug for PyGenericAlias {
     }
 }
 
-impl PyValue for PyGenericAlias {
+impl PyPayload for PyGenericAlias {
     fn class(vm: &VirtualMachine) -> &PyTypeRef {
         &vm.ctx.types.generic_alias_type
     }

--- a/vm/src/builtins/getset.rs
+++ b/vm/src/builtins/getset.rs
@@ -8,7 +8,7 @@ use crate::{
     pyclass::PyClassImpl,
     pyobject::PyThreadingConstraint,
     types::{Constructor, GetDescriptor, Unconstructible},
-    AsObject, PyContext, PyObjectRef, PyRef, PyResult, PyValue, TryFromObject, VirtualMachine,
+    AsObject, PyContext, PyObjectRef, PyPayload, PyRef, PyResult, TryFromObject, VirtualMachine,
 };
 
 pub type PyGetterFunc = Box<py_dyn_fn!(dyn Fn(&VirtualMachine, PyObjectRef) -> PyResult)>;
@@ -38,7 +38,7 @@ where
 impl<F, S, R> IntoPyGetterFunc<(RefParam<S>, R, VirtualMachine)> for F
 where
     F: Fn(&S, &VirtualMachine) -> R + 'static + Send + Sync,
-    S: PyValue,
+    S: PyPayload,
     R: ToPyResult,
 {
     fn get(&self, obj: PyObjectRef, vm: &VirtualMachine) -> PyResult {
@@ -62,7 +62,7 @@ where
 impl<F, S, R> IntoPyGetterFunc<(RefParam<S>, R)> for F
 where
     F: Fn(&S) -> R + 'static + Send + Sync,
-    S: PyValue,
+    S: PyPayload,
     R: ToPyResult,
 {
     fn get(&self, obj: PyObjectRef, vm: &VirtualMachine) -> PyResult {
@@ -113,7 +113,7 @@ where
 impl<F, S, V, R> IntoPySetterFunc<(RefParam<S>, V, R, VirtualMachine)> for F
 where
     F: Fn(&S, V, &VirtualMachine) -> R + 'static + Send + Sync,
-    S: PyValue,
+    S: PyPayload,
     V: TryFromObject,
     R: IntoPyNoResult,
 {
@@ -141,7 +141,7 @@ where
 impl<F, S, V, R> IntoPySetterFunc<(RefParam<S>, V, R)> for F
 where
     F: Fn(&S, V) -> R + 'static + Send + Sync,
-    S: PyValue,
+    S: PyPayload,
     V: TryFromObject,
     R: IntoPyNoResult,
 {
@@ -174,7 +174,7 @@ where
 impl<F, S, R> IntoPyDeleterFunc<(RefParam<S>, R, VirtualMachine)> for F
 where
     F: Fn(&S, &VirtualMachine) -> R + 'static + Send + Sync,
-    S: PyValue,
+    S: PyPayload,
     R: IntoPyNoResult,
 {
     fn delete(&self, obj: PyObjectRef, vm: &VirtualMachine) -> PyResult<()> {
@@ -198,7 +198,7 @@ where
 impl<F, S, R> IntoPyDeleterFunc<(RefParam<S>, R)> for F
 where
     F: Fn(&S) -> R + 'static + Send + Sync,
-    S: PyValue,
+    S: PyPayload,
     R: IntoPyNoResult,
 {
     fn delete(&self, obj: PyObjectRef, vm: &VirtualMachine) -> PyResult<()> {
@@ -237,7 +237,7 @@ impl std::fmt::Debug for PyGetSet {
     }
 }
 
-impl PyValue for PyGetSet {
+impl PyPayload for PyGetSet {
     fn class(vm: &VirtualMachine) -> &PyTypeRef {
         &vm.ctx.types.getset_type
     }

--- a/vm/src/builtins/int.rs
+++ b/vm/src/builtins/int.rs
@@ -7,7 +7,7 @@ use crate::{
     function::{ArgIntoBool, OptionalArg, OptionalOption, PyArithmeticValue, PyComparisonValue},
     pyclass::PyClassImpl,
     types::{Comparable, Constructor, Hashable, PyComparisonOp},
-    AsObject, PyContext, PyObject, PyObjectRef, PyRef, PyResult, PyValue, TryFromBorrowedObject,
+    AsObject, PyContext, PyObject, PyObjectRef, PyPayload, PyRef, PyResult, TryFromBorrowedObject,
     VirtualMachine,
 };
 use bstr::ByteSlice;
@@ -53,7 +53,7 @@ where
     }
 }
 
-impl PyValue for PyInt {
+impl PyPayload for PyInt {
     fn class(vm: &VirtualMachine) -> &PyTypeRef {
         &vm.ctx.types.int_type
     }

--- a/vm/src/builtins/int.rs
+++ b/vm/src/builtins/int.rs
@@ -721,7 +721,7 @@ impl PyInt {
 
 impl Comparable for PyInt {
     fn cmp(
-        zelf: &crate::PyObjectView<Self>,
+        zelf: &crate::Py<Self>,
         other: &PyObject,
         op: PyComparisonOp,
         vm: &VirtualMachine,
@@ -735,7 +735,7 @@ impl Comparable for PyInt {
 
 impl Hashable for PyInt {
     #[inline]
-    fn hash(zelf: &crate::PyObjectView<Self>, _vm: &VirtualMachine) -> PyResult<hash::PyHash> {
+    fn hash(zelf: &crate::Py<Self>, _vm: &VirtualMachine) -> PyResult<hash::PyHash> {
         Ok(hash::hash_bigint(zelf.as_bigint()))
     }
 }

--- a/vm/src/builtins/iter.rs
+++ b/vm/src/builtins/iter.rs
@@ -211,7 +211,7 @@ impl PySequenceIterator {
 
 impl IterNextIterable for PySequenceIterator {}
 impl IterNext for PySequenceIterator {
-    fn next(zelf: &crate::PyObjectView<Self>, vm: &VirtualMachine) -> PyResult<PyIterReturn> {
+    fn next(zelf: &crate::Py<Self>, vm: &VirtualMachine) -> PyResult<PyIterReturn> {
         zelf.internal.lock().next(|obj, pos| {
             let seq = PySequence::with_methods(obj, zelf.seq_methods.clone());
             PyIterReturn::from_getitem_result(seq.get_item(pos as isize, vm), vm)
@@ -244,7 +244,7 @@ impl PyCallableIterator {
 
 impl IterNextIterable for PyCallableIterator {}
 impl IterNext for PyCallableIterator {
-    fn next(zelf: &crate::PyObjectView<Self>, vm: &VirtualMachine) -> PyResult<PyIterReturn> {
+    fn next(zelf: &crate::Py<Self>, vm: &VirtualMachine) -> PyResult<PyIterReturn> {
         let status = zelf.status.upgradable_read();
         let next = if let IterStatus::Active(callable) = &*status {
             let ret = callable.invoke((), vm)?;

--- a/vm/src/builtins/iter.rs
+++ b/vm/src/builtins/iter.rs
@@ -10,7 +10,7 @@ use crate::{
     protocol::{PyIterReturn, PySequence, PySequenceMethods},
     pyclass::PyClassImpl,
     types::{IterNext, IterNextIterable},
-    PyContext, PyObject, PyObjectRef, PyResult, PyValue, VirtualMachine,
+    PyContext, PyObject, PyObjectRef, PyPayload, PyResult, VirtualMachine,
 };
 use rustpython_common::{
     lock::{PyMutex, PyRwLock, PyRwLockUpgradableReadGuard},
@@ -168,7 +168,7 @@ pub struct PySequenceIterator {
     internal: PyMutex<PositionIterInternal<PyObjectRef>>,
 }
 
-impl PyValue for PySequenceIterator {
+impl PyPayload for PySequenceIterator {
     fn class(vm: &VirtualMachine) -> &PyTypeRef {
         &vm.ctx.types.iter_type
     }
@@ -226,7 +226,7 @@ pub struct PyCallableIterator {
     status: PyRwLock<IterStatus<ArgCallable>>,
 }
 
-impl PyValue for PyCallableIterator {
+impl PyPayload for PyCallableIterator {
     fn class(vm: &VirtualMachine) -> &PyTypeRef {
         &vm.ctx.types.callable_iterator
     }

--- a/vm/src/builtins/list.rs
+++ b/vm/src/builtins/list.rs
@@ -16,7 +16,7 @@ use crate::{
     },
     utils::collection_repr,
     vm::{ReprGuard, VirtualMachine},
-    AsObject, PyContext, PyObject, PyObjectRef, PyObjectView, PyPayload, PyRef, PyResult,
+    AsObject, Py, PyContext, PyObject, PyObjectRef, PyPayload, PyRef, PyResult,
 };
 use std::{borrow::Cow, fmt, ops::DerefMut};
 
@@ -129,11 +129,7 @@ impl PyList {
         self.concat(&other, vm)
     }
 
-    fn inplace_concat(
-        zelf: &PyObjectView<Self>,
-        other: &PyObject,
-        vm: &VirtualMachine,
-    ) -> PyObjectRef {
+    fn inplace_concat(zelf: &Py<Self>, other: &PyObject, vm: &VirtualMachine) -> PyObjectRef {
         if let Ok(mut seq) = PySequence::from(other).extract_cloned(Ok, vm) {
             zelf.borrow_vec_mut().append(&mut seq);
             zelf.to_owned().into()
@@ -392,14 +388,14 @@ impl PyList {
 }
 
 impl AsMapping for PyList {
-    fn as_mapping(_zelf: &crate::PyObjectView<Self>, _vm: &VirtualMachine) -> PyMappingMethods {
+    fn as_mapping(_zelf: &crate::Py<Self>, _vm: &VirtualMachine) -> PyMappingMethods {
         Self::MAPPING_METHODS
     }
 }
 
 impl AsSequence for PyList {
     fn as_sequence(
-        _zelf: &crate::PyObjectView<Self>,
+        _zelf: &crate::Py<Self>,
         _vm: &VirtualMachine,
     ) -> Cow<'static, PySequenceMethods> {
         Cow::Borrowed(&Self::SEQUENCE_METHDOS)
@@ -458,7 +454,7 @@ impl Iterable for PyList {
 
 impl Comparable for PyList {
     fn cmp(
-        zelf: &crate::PyObjectView<Self>,
+        zelf: &crate::Py<Self>,
         other: &PyObject,
         op: PyComparisonOp,
         vm: &VirtualMachine,
@@ -539,7 +535,7 @@ impl Unconstructible for PyListIterator {}
 
 impl IterNextIterable for PyListIterator {}
 impl IterNext for PyListIterator {
-    fn next(zelf: &crate::PyObjectView<Self>, _vm: &VirtualMachine) -> PyResult<PyIterReturn> {
+    fn next(zelf: &crate::Py<Self>, _vm: &VirtualMachine) -> PyResult<PyIterReturn> {
         zelf.internal.lock().next(|list, pos| {
             let vec = list.borrow_vec();
             Ok(PyIterReturn::from_result(vec.get(pos).cloned().ok_or(None)))
@@ -584,7 +580,7 @@ impl Unconstructible for PyListReverseIterator {}
 
 impl IterNextIterable for PyListReverseIterator {}
 impl IterNext for PyListReverseIterator {
-    fn next(zelf: &crate::PyObjectView<Self>, _vm: &VirtualMachine) -> PyResult<PyIterReturn> {
+    fn next(zelf: &crate::Py<Self>, _vm: &VirtualMachine) -> PyResult<PyIterReturn> {
         zelf.internal.lock().rev_next(|list, pos| {
             let vec = list.borrow_vec();
             Ok(PyIterReturn::from_result(vec.get(pos).cloned().ok_or(None)))

--- a/vm/src/builtins/list.rs
+++ b/vm/src/builtins/list.rs
@@ -16,7 +16,7 @@ use crate::{
     },
     utils::collection_repr,
     vm::{ReprGuard, VirtualMachine},
-    AsObject, PyContext, PyObject, PyObjectRef, PyObjectView, PyRef, PyResult, PyValue,
+    AsObject, PyContext, PyObject, PyObjectRef, PyObjectView, PyPayload, PyRef, PyResult,
 };
 use std::{borrow::Cow, fmt, ops::DerefMut};
 
@@ -51,7 +51,7 @@ impl FromIterator<PyObjectRef> for PyList {
     }
 }
 
-impl PyValue for PyList {
+impl PyPayload for PyList {
     fn class(vm: &VirtualMachine) -> &PyTypeRef {
         &vm.ctx.types.list_type
     }
@@ -508,7 +508,7 @@ pub struct PyListIterator {
     internal: PyMutex<PositionIterInternal<PyListRef>>,
 }
 
-impl PyValue for PyListIterator {
+impl PyPayload for PyListIterator {
     fn class(vm: &VirtualMachine) -> &PyTypeRef {
         &vm.ctx.types.list_iterator_type
     }
@@ -553,7 +553,7 @@ pub struct PyListReverseIterator {
     internal: PyMutex<PositionIterInternal<PyListRef>>,
 }
 
-impl PyValue for PyListReverseIterator {
+impl PyPayload for PyListReverseIterator {
     fn class(vm: &VirtualMachine) -> &PyTypeRef {
         &vm.ctx.types.list_reverseiterator_type
     }

--- a/vm/src/builtins/map.rs
+++ b/vm/src/builtins/map.rs
@@ -4,7 +4,7 @@ use crate::{
     protocol::{PyIter, PyIterReturn},
     pyclass::PyClassImpl,
     types::{Constructor, IterNext, IterNextIterable},
-    PyContext, PyObjectRef, PyResult, PyValue, VirtualMachine,
+    PyContext, PyObjectRef, PyPayload, PyResult, VirtualMachine,
 };
 
 /// map(func, *iterables) --> map object
@@ -18,7 +18,7 @@ pub struct PyMap {
     iterators: Vec<PyIter>,
 }
 
-impl PyValue for PyMap {
+impl PyPayload for PyMap {
     fn class(vm: &VirtualMachine) -> &PyTypeRef {
         &vm.ctx.types.map_type
     }

--- a/vm/src/builtins/map.rs
+++ b/vm/src/builtins/map.rs
@@ -47,7 +47,7 @@ impl PyMap {
 
 impl IterNextIterable for PyMap {}
 impl IterNext for PyMap {
-    fn next(zelf: &crate::PyObjectView<Self>, vm: &VirtualMachine) -> PyResult<PyIterReturn> {
+    fn next(zelf: &crate::Py<Self>, vm: &VirtualMachine) -> PyResult<PyIterReturn> {
         let mut next_objs = Vec::new();
         for iterator in zelf.iterators.iter() {
             let item = match iterator.next(vm)? {

--- a/vm/src/builtins/mappingproxy.rs
+++ b/vm/src/builtins/mappingproxy.rs
@@ -174,14 +174,14 @@ impl PyMappingProxy {
 }
 
 impl AsMapping for PyMappingProxy {
-    fn as_mapping(_zelf: &crate::PyObjectView<Self>, _vm: &VirtualMachine) -> PyMappingMethods {
+    fn as_mapping(_zelf: &crate::Py<Self>, _vm: &VirtualMachine) -> PyMappingMethods {
         Self::MAPPING_METHODS
     }
 }
 
 impl AsSequence for PyMappingProxy {
     fn as_sequence(
-        _zelf: &crate::PyObjectView<Self>,
+        _zelf: &crate::Py<Self>,
         _vm: &VirtualMachine,
     ) -> Cow<'static, PySequenceMethods> {
         Cow::Borrowed(&Self::SEQUENCE_METHODS)

--- a/vm/src/builtins/mappingproxy.rs
+++ b/vm/src/builtins/mappingproxy.rs
@@ -7,7 +7,7 @@ use crate::{
     protocol::{PyMapping, PyMappingMethods, PySequence, PySequenceMethods},
     pyclass::PyClassImpl,
     types::{AsMapping, AsSequence, Constructor, Iterable},
-    AsObject, PyContext, PyObject, PyObjectRef, PyRef, PyResult, PyValue, TryFromObject,
+    AsObject, PyContext, PyObject, PyObjectRef, PyPayload, PyRef, PyResult, TryFromObject,
     VirtualMachine,
 };
 
@@ -23,7 +23,7 @@ enum MappingProxyInner {
     Dict(PyObjectRef),
 }
 
-impl PyValue for PyMappingProxy {
+impl PyPayload for PyMappingProxy {
     fn class(vm: &VirtualMachine) -> &PyTypeRef {
         &vm.ctx.types.mappingproxy_type
     }

--- a/vm/src/builtins/memory.rs
+++ b/vm/src/builtins/memory.rs
@@ -19,7 +19,7 @@ use crate::{
     sliceable::wrap_index,
     types::{AsBuffer, AsMapping, AsSequence, Comparable, Constructor, Hashable, PyComparisonOp},
     utils::Either,
-    AsObject, PyContext, PyObject, PyObjectRef, PyObjectView, PyRef, PyResult, PyValue,
+    AsObject, PyContext, PyObject, PyObjectRef, PyObjectView, PyPayload, PyRef, PyResult,
     TryFromBorrowedObject, TryFromObject, VirtualMachine,
 };
 use crossbeam_utils::atomic::AtomicCell;
@@ -1041,7 +1041,7 @@ impl Hashable for PyMemoryView {
     }
 }
 
-impl PyValue for PyMemoryView {
+impl PyPayload for PyMemoryView {
     fn class(vm: &VirtualMachine) -> &PyTypeRef {
         &vm.ctx.types.memoryview_type
     }

--- a/vm/src/builtins/memory.rs
+++ b/vm/src/builtins/memory.rs
@@ -19,7 +19,7 @@ use crate::{
     sliceable::wrap_index,
     types::{AsBuffer, AsMapping, AsSequence, Comparable, Constructor, Hashable, PyComparisonOp},
     utils::Either,
-    AsObject, PyContext, PyObject, PyObjectRef, PyObjectView, PyPayload, PyRef, PyResult,
+    AsObject, Py, PyContext, PyObject, PyObjectRef, PyPayload, PyRef, PyResult,
     TryFromBorrowedObject, TryFromObject, VirtualMachine,
 };
 use crossbeam_utils::atomic::AtomicCell;
@@ -698,11 +698,7 @@ impl PyMemoryView {
         }
     }
 
-    fn eq(
-        zelf: &crate::PyObjectView<Self>,
-        other: &PyObject,
-        vm: &VirtualMachine,
-    ) -> PyResult<bool> {
+    fn eq(zelf: &crate::Py<Self>, other: &PyObject, vm: &VirtualMachine) -> PyResult<bool> {
         if zelf.is(other) {
             return Ok(true);
         }
@@ -931,7 +927,7 @@ static BUFFER_METHODS: BufferMethods = BufferMethods {
 };
 
 impl AsBuffer for PyMemoryView {
-    fn as_buffer(zelf: &PyObjectView<Self>, vm: &VirtualMachine) -> PyResult<PyBuffer> {
+    fn as_buffer(zelf: &Py<Self>, vm: &VirtualMachine) -> PyResult<PyBuffer> {
         if zelf.released.load() {
             Err(vm.new_value_error("operation forbidden on released memoryview object".to_owned()))
         } else {
@@ -973,16 +969,13 @@ impl PyMemoryView {
 }
 
 impl AsMapping for PyMemoryView {
-    fn as_mapping(_zelf: &PyObjectView<Self>, _vm: &VirtualMachine) -> PyMappingMethods {
+    fn as_mapping(_zelf: &Py<Self>, _vm: &VirtualMachine) -> PyMappingMethods {
         Self::MAPPING_METHODS
     }
 }
 
 impl AsSequence for PyMemoryView {
-    fn as_sequence(
-        _zelf: &PyObjectView<Self>,
-        _vm: &VirtualMachine,
-    ) -> Cow<'static, PySequenceMethods> {
+    fn as_sequence(_zelf: &Py<Self>, _vm: &VirtualMachine) -> Cow<'static, PySequenceMethods> {
         Cow::Borrowed(&Self::SEQUENCE_METHODS)
     }
 }
@@ -1005,7 +998,7 @@ impl PyMemoryView {
 
 impl Comparable for PyMemoryView {
     fn cmp(
-        zelf: &crate::PyObjectView<Self>,
+        zelf: &crate::Py<Self>,
         other: &PyObject,
         op: PyComparisonOp,
         vm: &VirtualMachine,
@@ -1026,7 +1019,7 @@ impl Comparable for PyMemoryView {
 }
 
 impl Hashable for PyMemoryView {
-    fn hash(zelf: &crate::PyObjectView<Self>, vm: &VirtualMachine) -> PyResult<PyHash> {
+    fn hash(zelf: &crate::Py<Self>, vm: &VirtualMachine) -> PyResult<PyHash> {
         zelf.hash
             .get_or_try_init(|| {
                 zelf.try_not_released(vm)?;

--- a/vm/src/builtins/module.rs
+++ b/vm/src/builtins/module.rs
@@ -1,8 +1,8 @@
 use super::pystr::IntoPyStrRef;
 use super::{PyDictRef, PyStr, PyStrRef, PyTypeRef};
 use crate::{
-    convert::ToPyObject, function::FuncArgs, pyclass::PyClassImpl, types::GetAttr, AsObject,
-    PyContext, PyObjectRef, PyObjectView, PyPayload, PyRef, PyResult, VirtualMachine,
+    convert::ToPyObject, function::FuncArgs, pyclass::PyClassImpl, types::GetAttr, AsObject, Py,
+    PyContext, PyObjectRef, PyPayload, PyRef, PyResult, VirtualMachine,
 };
 
 #[pyclass(module = false, name = "module")]
@@ -48,7 +48,7 @@ impl PyModule {
         zelf.init_module_dict(args.name.into(), args.doc.to_pyobject(vm), vm);
     }
 
-    fn getattr_inner(zelf: &PyObjectView<Self>, name: PyStrRef, vm: &VirtualMachine) -> PyResult {
+    fn getattr_inner(zelf: &Py<Self>, name: PyStrRef, vm: &VirtualMachine) -> PyResult {
         if let Some(attr) =
             vm.generic_getattribute_opt(zelf.to_owned().into(), name.clone(), None)?
         {
@@ -89,12 +89,12 @@ impl PyModule {
     }
 }
 
-impl PyObjectView<PyModule> {
+impl Py<PyModule> {
     // TODO: to be replaced by the commented-out dict method above once dictoffsets land
     pub fn dict(&self) -> PyDictRef {
         self.as_object().dict().unwrap()
     }
-    // TODO: should be on PyModule, not PyObjectView<PyModule>
+    // TODO: should be on PyModule, not Py<PyModule>
     pub(crate) fn init_module_dict(
         &self,
         name: PyObjectRef,

--- a/vm/src/builtins/module.rs
+++ b/vm/src/builtins/module.rs
@@ -2,14 +2,14 @@ use super::pystr::IntoPyStrRef;
 use super::{PyDictRef, PyStr, PyStrRef, PyTypeRef};
 use crate::{
     convert::ToPyObject, function::FuncArgs, pyclass::PyClassImpl, types::GetAttr, AsObject,
-    PyContext, PyObjectRef, PyObjectView, PyRef, PyResult, PyValue, VirtualMachine,
+    PyContext, PyObjectRef, PyObjectView, PyPayload, PyRef, PyResult, VirtualMachine,
 };
 
 #[pyclass(module = false, name = "module")]
 #[derive(Debug)]
 pub struct PyModule {}
 
-impl PyValue for PyModule {
+impl PyPayload for PyModule {
     fn class(vm: &VirtualMachine) -> &PyTypeRef {
         &vm.ctx.types.module_type
     }

--- a/vm/src/builtins/namespace.rs
+++ b/vm/src/builtins/namespace.rs
@@ -5,7 +5,7 @@ use crate::{
     pyclass::PyClassImpl,
     types::{Comparable, Constructor, PyComparisonOp},
     vm::ReprGuard,
-    AsObject, PyContext, PyObject, PyRef, PyResult, PyValue, VirtualMachine,
+    AsObject, PyContext, PyObject, PyPayload, PyRef, PyResult, VirtualMachine,
 };
 
 /// A simple attribute-based namespace.
@@ -15,7 +15,7 @@ use crate::{
 #[derive(Debug)]
 pub struct PyNamespace {}
 
-impl PyValue for PyNamespace {
+impl PyPayload for PyNamespace {
     fn class(vm: &VirtualMachine) -> &PyTypeRef {
         &vm.ctx.types.namespace_type
     }

--- a/vm/src/builtins/namespace.rs
+++ b/vm/src/builtins/namespace.rs
@@ -80,7 +80,7 @@ impl PyNamespace {
 
 impl Comparable for PyNamespace {
     fn cmp(
-        zelf: &crate::PyObjectView<Self>,
+        zelf: &crate::Py<Self>,
         other: &PyObject,
         op: PyComparisonOp,
         vm: &VirtualMachine,

--- a/vm/src/builtins/object.rs
+++ b/vm/src/builtins/object.rs
@@ -5,7 +5,7 @@ use crate::{
     pyclass::PyClassImpl,
     types::PyComparisonOp,
     utils::Either,
-    AsObject, PyContext, PyObject, PyObjectRef, PyResult, PyValue, VirtualMachine,
+    AsObject, PyContext, PyObject, PyObjectRef, PyPayload, PyResult, VirtualMachine,
 };
 
 /// object()
@@ -19,7 +19,7 @@ use crate::{
 #[derive(Debug)]
 pub struct PyBaseObject;
 
-impl PyValue for PyBaseObject {
+impl PyPayload for PyBaseObject {
     fn class(vm: &VirtualMachine) -> &PyTypeRef {
         &vm.ctx.types.object_type
     }

--- a/vm/src/builtins/property.rs
+++ b/vm/src/builtins/property.rs
@@ -5,7 +5,7 @@ use super::PyTypeRef;
 use crate::common::lock::PyRwLock;
 use crate::{
     function::FuncArgs, pyclass::PyClassImpl, types::GetDescriptor, AsObject, PyContext,
-    PyObjectRef, PyRef, PyResult, PyValue, TryFromObject, VirtualMachine,
+    PyObjectRef, PyPayload, PyRef, PyResult, TryFromObject, VirtualMachine,
 };
 
 /// Property attribute.
@@ -49,7 +49,7 @@ pub struct PyProperty {
     doc: PyRwLock<Option<PyObjectRef>>,
 }
 
-impl PyValue for PyProperty {
+impl PyPayload for PyProperty {
     fn class(vm: &VirtualMachine) -> &PyTypeRef {
         &vm.ctx.types.property_type
     }

--- a/vm/src/builtins/pybool.rs
+++ b/vm/src/builtins/pybool.rs
@@ -1,7 +1,7 @@
 use super::{PyInt, PyStrRef, PyTypeRef};
 use crate::{
     convert::ToPyObject, function::OptionalArg, pyclass::PyClassImpl, types::Constructor, AsObject,
-    PyContext, PyObject, PyObjectRef, PyResult, PyValue, TryFromBorrowedObject, VirtualMachine,
+    PyContext, PyObject, PyObjectRef, PyPayload, PyResult, TryFromBorrowedObject, VirtualMachine,
 };
 use num_bigint::Sign;
 use num_traits::Zero;
@@ -78,7 +78,7 @@ impl PyObjectRef {
 #[pyclass(name = "bool", module = false, base = "PyInt")]
 pub struct PyBool;
 
-impl PyValue for PyBool {
+impl PyPayload for PyBool {
     fn class(vm: &VirtualMachine) -> &PyTypeRef {
         &vm.ctx.types.bool_type
     }

--- a/vm/src/builtins/pystr.rs
+++ b/vm/src/builtins/pystr.rs
@@ -16,7 +16,7 @@ use crate::{
         AsMapping, AsSequence, Comparable, Constructor, Hashable, IterNext, IterNextIterable,
         Iterable, PyComparisonOp, Unconstructible,
     },
-    AsObject, PyContext, PyObject, PyObjectRef, PyObjectView, PyRef, PyResult, PyValue,
+    AsObject, PyContext, PyObject, PyObjectRef, PyObjectView, PyPayload, PyRef, PyResult,
     TryFromBorrowedObject, VirtualMachine,
 };
 use ascii::{AsciiStr, AsciiString};
@@ -227,7 +227,7 @@ pub struct PyStrIterator {
     internal: PyMutex<(PositionIterInternal<PyStrRef>, usize)>,
 }
 
-impl PyValue for PyStrIterator {
+impl PyPayload for PyStrIterator {
     fn class(vm: &VirtualMachine) -> &PyTypeRef {
         &vm.ctx.types.str_iterator_type
     }
@@ -1338,7 +1338,7 @@ pub(crate) fn encode_string(
     vm.state.codec_registry.encode_text(s, encoding, errors, vm)
 }
 
-impl PyValue for PyStr {
+impl PyPayload for PyStr {
     fn class(vm: &VirtualMachine) -> &PyTypeRef {
         &vm.ctx.types.str_type
     }

--- a/vm/src/builtins/pystr.rs
+++ b/vm/src/builtins/pystr.rs
@@ -16,7 +16,7 @@ use crate::{
         AsMapping, AsSequence, Comparable, Constructor, Hashable, IterNext, IterNextIterable,
         Iterable, PyComparisonOp, Unconstructible,
     },
-    AsObject, PyContext, PyObject, PyObjectRef, PyObjectView, PyPayload, PyRef, PyResult,
+    AsObject, Py, PyContext, PyObject, PyObjectRef, PyPayload, PyRef, PyResult,
     TryFromBorrowedObject, VirtualMachine,
 };
 use ascii::{AsciiStr, AsciiString};
@@ -261,7 +261,7 @@ impl Unconstructible for PyStrIterator {}
 
 impl IterNextIterable for PyStrIterator {}
 impl IterNext for PyStrIterator {
-    fn next(zelf: &crate::PyObjectView<Self>, vm: &VirtualMachine) -> PyResult<PyIterReturn> {
+    fn next(zelf: &crate::Py<Self>, vm: &VirtualMachine) -> PyResult<PyIterReturn> {
         let mut internal = zelf.internal.lock();
 
         if let IterStatus::Active(s) = &internal.0.status {
@@ -1245,14 +1245,14 @@ impl PyStrRef {
 
 impl Hashable for PyStr {
     #[inline]
-    fn hash(zelf: &crate::PyObjectView<Self>, vm: &VirtualMachine) -> PyResult<hash::PyHash> {
+    fn hash(zelf: &crate::Py<Self>, vm: &VirtualMachine) -> PyResult<hash::PyHash> {
         Ok(zelf.hash(vm))
     }
 }
 
 impl Comparable for PyStr {
     fn cmp(
-        zelf: &crate::PyObjectView<Self>,
+        zelf: &crate::Py<Self>,
         other: &PyObject,
         op: PyComparisonOp,
         _vm: &VirtualMachine,
@@ -1275,7 +1275,7 @@ impl Iterable for PyStr {
 }
 
 impl AsMapping for PyStr {
-    fn as_mapping(_zelf: &PyObjectView<Self>, _vm: &VirtualMachine) -> PyMappingMethods {
+    fn as_mapping(_zelf: &Py<Self>, _vm: &VirtualMachine) -> PyMappingMethods {
         Self::MAPPING_METHODS
     }
 }
@@ -1290,7 +1290,7 @@ impl PyStr {
 
 impl AsSequence for PyStr {
     fn as_sequence(
-        _zelf: &PyObjectView<Self>,
+        _zelf: &Py<Self>,
         _vm: &VirtualMachine,
     ) -> std::borrow::Cow<'static, PySequenceMethods> {
         std::borrow::Cow::Borrowed(&Self::SEQUENCE_METHDOS)

--- a/vm/src/builtins/pysuper.rs
+++ b/vm/src/builtins/pysuper.rs
@@ -8,7 +8,7 @@ use crate::{
     function::OptionalArg,
     pyclass::PyClassImpl,
     types::{Constructor, GetAttr, GetDescriptor},
-    AsObject, PyContext, PyObjectRef, PyRef, PyResult, PyValue, VirtualMachine,
+    AsObject, PyContext, PyObjectRef, PyPayload, PyRef, PyResult, VirtualMachine,
 };
 
 #[pyclass(module = false, name = "super")]
@@ -18,7 +18,7 @@ pub struct PySuper {
     obj: Option<(PyObjectRef, PyTypeRef)>,
 }
 
-impl PyValue for PySuper {
+impl PyPayload for PySuper {
     fn class(vm: &VirtualMachine) -> &PyTypeRef {
         &vm.ctx.types.super_type
     }

--- a/vm/src/builtins/pytype.rs
+++ b/vm/src/builtins/pytype.rs
@@ -680,7 +680,7 @@ impl GetAttr for PyType {
 
 impl SetAttr for PyType {
     fn setattro(
-        zelf: &crate::PyObjectView<Self>,
+        zelf: &crate::Py<Self>,
         attr_name: PyStrRef,
         value: Option<PyObjectRef>,
         vm: &VirtualMachine,
@@ -715,7 +715,7 @@ impl SetAttr for PyType {
 
 impl Callable for PyType {
     type Args = FuncArgs;
-    fn call(zelf: &crate::PyObjectView<Self>, args: FuncArgs, vm: &VirtualMachine) -> PyResult {
+    fn call(zelf: &crate::Py<Self>, args: FuncArgs, vm: &VirtualMachine) -> PyResult {
         vm_trace!("type_call: {:?}", zelf);
         let obj = call_slot_new(zelf.to_owned(), zelf.to_owned(), args.clone(), vm)?;
 

--- a/vm/src/builtins/pytype.rs
+++ b/vm/src/builtins/pytype.rs
@@ -11,7 +11,7 @@ use crate::{
     function::{FuncArgs, KwArgs, OptionalArg},
     pyclass::{PyClassImpl, StaticType},
     types::{Callable, GetAttr, PyTypeFlags, PyTypeSlots, SetAttr},
-    AsObject, PyContext, PyObjectRef, PyRef, PyResult, PyValue, VirtualMachine,
+    AsObject, PyContext, PyObjectRef, PyPayload, PyRef, PyResult, VirtualMachine,
 };
 use itertools::Itertools;
 use std::{
@@ -53,7 +53,7 @@ impl fmt::Debug for PyType {
     }
 }
 
-impl PyValue for PyType {
+impl PyPayload for PyType {
     fn class(vm: &VirtualMachine) -> &PyTypeRef {
         &vm.ctx.types.type_type
     }

--- a/vm/src/builtins/pytype.rs
+++ b/vm/src/builtins/pytype.rs
@@ -1,6 +1,6 @@
 use super::{
     mappingproxy::PyMappingProxy, object, pyunion, PyClassMethod, PyDictRef, PyList,
-    PyStaticMethod, PyStr, PyStrRef, PyTuple, PyTupleRef,
+    PyStaticMethod, PyStr, PyStrRef, PyTuple, PyTupleRef, PyWeak,
 };
 use crate::common::{
     ascii,
@@ -11,7 +11,7 @@ use crate::{
     function::{FuncArgs, KwArgs, OptionalArg},
     pyclass::{PyClassImpl, StaticType},
     types::{Callable, GetAttr, PyTypeFlags, PyTypeSlots, SetAttr},
-    AsObject, PyContext, PyObjectRef, PyObjectWeak, PyRef, PyResult, PyValue, VirtualMachine,
+    AsObject, PyContext, PyObjectRef, PyRef, PyResult, PyValue, VirtualMachine,
 };
 use itertools::Itertools;
 use std::{
@@ -29,7 +29,7 @@ pub struct PyType {
     pub base: Option<PyTypeRef>,
     pub bases: Vec<PyTypeRef>,
     pub mro: Vec<PyTypeRef>,
-    pub subclasses: PyRwLock<Vec<PyObjectWeak>>,
+    pub subclasses: PyRwLock<Vec<PyRef<PyWeak>>>,
     pub attributes: PyRwLock<PyAttributes>,
     pub slots: PyTypeSlots,
 }

--- a/vm/src/builtins/pyunion.rs
+++ b/vm/src/builtins/pyunion.rs
@@ -7,8 +7,8 @@ use crate::{
     protocol::PyMappingMethods,
     pyclass::PyClassImpl,
     types::{AsMapping, Comparable, GetAttr, Hashable, Iterable, PyComparisonOp},
-    AsObject, PyContext, PyObject, PyObjectRef, PyObjectView, PyPayload, PyRef, PyResult,
-    TryFromObject, VirtualMachine,
+    AsObject, Py, PyContext, PyObject, PyObjectRef, PyPayload, PyRef, PyResult, TryFromObject,
+    VirtualMachine,
 };
 use std::fmt;
 
@@ -232,14 +232,14 @@ impl PyUnion {
 }
 
 impl AsMapping for PyUnion {
-    fn as_mapping(_zelf: &PyObjectView<Self>, _vm: &VirtualMachine) -> PyMappingMethods {
+    fn as_mapping(_zelf: &Py<Self>, _vm: &VirtualMachine) -> PyMappingMethods {
         Self::MAPPING_METHODS
     }
 }
 
 impl Comparable for PyUnion {
     fn cmp(
-        zelf: &crate::PyObjectView<Self>,
+        zelf: &crate::Py<Self>,
         other: &PyObject,
         op: PyComparisonOp,
         vm: &VirtualMachine,
@@ -256,7 +256,7 @@ impl Comparable for PyUnion {
 
 impl Hashable for PyUnion {
     #[inline]
-    fn hash(zelf: &crate::PyObjectView<Self>, vm: &VirtualMachine) -> PyResult<hash::PyHash> {
+    fn hash(zelf: &crate::Py<Self>, vm: &VirtualMachine) -> PyResult<hash::PyHash> {
         let it = PyTuple::iter(zelf.args.clone(), vm);
         let set = PyFrozenSet::from_iter(vm, it)?;
         PyFrozenSet::hash(&set.into_ref(vm), vm)

--- a/vm/src/builtins/pyunion.rs
+++ b/vm/src/builtins/pyunion.rs
@@ -7,7 +7,7 @@ use crate::{
     protocol::PyMappingMethods,
     pyclass::PyClassImpl,
     types::{AsMapping, Comparable, GetAttr, Hashable, Iterable, PyComparisonOp},
-    AsObject, PyContext, PyObject, PyObjectRef, PyObjectView, PyRef, PyResult, PyValue,
+    AsObject, PyContext, PyObject, PyObjectRef, PyObjectView, PyPayload, PyRef, PyResult,
     TryFromObject, VirtualMachine,
 };
 use std::fmt;
@@ -26,7 +26,7 @@ impl fmt::Debug for PyUnion {
     }
 }
 
-impl PyValue for PyUnion {
+impl PyPayload for PyUnion {
     fn class(vm: &VirtualMachine) -> &PyTypeRef {
         &vm.ctx.types.union_type
     }

--- a/vm/src/builtins/range.rs
+++ b/vm/src/builtins/range.rs
@@ -9,7 +9,7 @@ use crate::{
         AsMapping, AsSequence, Comparable, Constructor, Hashable, IterNext, IterNextIterable,
         Iterable, PyComparisonOp, Unconstructible,
     },
-    AsObject, PyContext, PyObject, PyObjectRef, PyObjectView, PyRef, PyResult, PyValue,
+    AsObject, PyContext, PyObject, PyObjectRef, PyObjectView, PyPayload, PyRef, PyResult,
     TryFromObject, VirtualMachine,
 };
 use crossbeam_utils::atomic::AtomicCell;
@@ -74,7 +74,7 @@ pub struct PyRange {
     pub step: PyIntRef,
 }
 
-impl PyValue for PyRange {
+impl PyPayload for PyRange {
     fn class(vm: &VirtualMachine) -> &PyTypeRef {
         &vm.ctx.types.range_type
     }
@@ -528,7 +528,7 @@ pub struct PyLongRangeIterator {
     length: BigInt,
 }
 
-impl PyValue for PyLongRangeIterator {
+impl PyPayload for PyLongRangeIterator {
     fn class(vm: &VirtualMachine) -> &PyTypeRef {
         &vm.ctx.types.longrange_iterator_type
     }
@@ -593,7 +593,7 @@ pub struct PyRangeIterator {
     length: usize,
 }
 
-impl PyValue for PyRangeIterator {
+impl PyPayload for PyRangeIterator {
     fn class(vm: &VirtualMachine) -> &PyTypeRef {
         &vm.ctx.types.range_iterator_type
     }

--- a/vm/src/builtins/range.rs
+++ b/vm/src/builtins/range.rs
@@ -9,8 +9,8 @@ use crate::{
         AsMapping, AsSequence, Comparable, Constructor, Hashable, IterNext, IterNextIterable,
         Iterable, PyComparisonOp, Unconstructible,
     },
-    AsObject, PyContext, PyObject, PyObjectRef, PyObjectView, PyPayload, PyRef, PyResult,
-    TryFromObject, VirtualMachine,
+    AsObject, Py, PyContext, PyObject, PyObjectRef, PyPayload, PyRef, PyResult, TryFromObject,
+    VirtualMachine,
 };
 use crossbeam_utils::atomic::AtomicCell;
 use num_bigint::{BigInt, Sign};
@@ -414,14 +414,14 @@ impl PyRange {
 }
 
 impl AsMapping for PyRange {
-    fn as_mapping(_zelf: &crate::PyObjectView<Self>, _vm: &VirtualMachine) -> PyMappingMethods {
+    fn as_mapping(_zelf: &crate::Py<Self>, _vm: &VirtualMachine) -> PyMappingMethods {
         Self::MAPPING_METHODS
     }
 }
 
 impl AsSequence for PyRange {
     fn as_sequence(
-        _zelf: &crate::PyObjectView<Self>,
+        _zelf: &crate::Py<Self>,
         _vm: &VirtualMachine,
     ) -> Cow<'static, PySequenceMethods> {
         Cow::Borrowed(&Self::SEQUENCE_METHDOS)
@@ -429,7 +429,7 @@ impl AsSequence for PyRange {
 }
 
 impl Hashable for PyRange {
-    fn hash(zelf: &crate::PyObjectView<Self>, vm: &VirtualMachine) -> PyResult<PyHash> {
+    fn hash(zelf: &crate::Py<Self>, vm: &VirtualMachine) -> PyResult<PyHash> {
         let length = zelf.compute_length();
         let elements = if length.is_zero() {
             [vm.ctx.new_int(length).into(), vm.ctx.none(), vm.ctx.none()]
@@ -452,7 +452,7 @@ impl Hashable for PyRange {
 
 impl Comparable for PyRange {
     fn cmp(
-        zelf: &PyObjectView<Self>,
+        zelf: &Py<Self>,
         other: &PyObject,
         op: PyComparisonOp,
         _vm: &VirtualMachine,
@@ -567,7 +567,7 @@ impl Unconstructible for PyLongRangeIterator {}
 
 impl IterNextIterable for PyLongRangeIterator {}
 impl IterNext for PyLongRangeIterator {
-    fn next(zelf: &crate::PyObjectView<Self>, vm: &VirtualMachine) -> PyResult<PyIterReturn> {
+    fn next(zelf: &crate::Py<Self>, vm: &VirtualMachine) -> PyResult<PyIterReturn> {
         // TODO: In pathological case (index == usize::MAX) this can wrap around
         // (since fetch_add wraps). This would result in the iterator spinning again
         // from the beginning.
@@ -633,7 +633,7 @@ impl Unconstructible for PyRangeIterator {}
 
 impl IterNextIterable for PyRangeIterator {}
 impl IterNext for PyRangeIterator {
-    fn next(zelf: &crate::PyObjectView<Self>, vm: &VirtualMachine) -> PyResult<PyIterReturn> {
+    fn next(zelf: &crate::Py<Self>, vm: &VirtualMachine) -> PyResult<PyIterReturn> {
         // TODO: In pathological case (index == usize::MAX) this can wrap around
         // (since fetch_add wraps). This would result in the iterator spinning again
         // from the beginning.

--- a/vm/src/builtins/set.rs
+++ b/vm/src/builtins/set.rs
@@ -17,7 +17,7 @@ use crate::{
     },
     utils::collection_repr,
     vm::{ReprGuard, VirtualMachine},
-    AsObject, PyContext, PyObject, PyObjectRef, PyRef, PyResult, PyValue, TryFromObject,
+    AsObject, PyContext, PyObject, PyObjectRef, PyPayload, PyRef, PyResult, TryFromObject,
 };
 use std::borrow::Cow;
 use std::{fmt, ops::Deref};
@@ -70,13 +70,13 @@ impl fmt::Debug for PyFrozenSet {
     }
 }
 
-impl PyValue for PySet {
+impl PyPayload for PySet {
     fn class(vm: &VirtualMachine) -> &PyTypeRef {
         &vm.ctx.types.set_type
     }
 }
 
-impl PyValue for PyFrozenSet {
+impl PyPayload for PyFrozenSet {
     fn class(vm: &VirtualMachine) -> &PyTypeRef {
         &vm.ctx.types.frozenset_type
     }
@@ -971,7 +971,7 @@ impl fmt::Debug for PySetIterator {
     }
 }
 
-impl PyValue for PySetIterator {
+impl PyPayload for PySetIterator {
     fn class(vm: &VirtualMachine) -> &PyTypeRef {
         &vm.ctx.types.set_iterator_type
     }

--- a/vm/src/builtins/set.rs
+++ b/vm/src/builtins/set.rs
@@ -656,7 +656,7 @@ impl PySet {
 
 impl AsSequence for PySet {
     fn as_sequence(
-        _zelf: &crate::PyObjectView<Self>,
+        _zelf: &crate::Py<Self>,
         _vm: &VirtualMachine,
     ) -> Cow<'static, PySequenceMethods> {
         Cow::Borrowed(&Self::SEQUENCE_METHODS)
@@ -673,7 +673,7 @@ impl PySet {
 
 impl Comparable for PySet {
     fn cmp(
-        zelf: &crate::PyObjectView<Self>,
+        zelf: &crate::Py<Self>,
         other: &PyObject,
         op: PyComparisonOp,
         vm: &VirtualMachine,
@@ -896,7 +896,7 @@ impl PyFrozenSet {
 
 impl AsSequence for PyFrozenSet {
     fn as_sequence(
-        _zelf: &crate::PyObjectView<Self>,
+        _zelf: &crate::Py<Self>,
         _vm: &VirtualMachine,
     ) -> Cow<'static, PySequenceMethods> {
         Cow::Borrowed(&Self::SEQUENCE_METHODS)
@@ -913,14 +913,14 @@ impl PyFrozenSet {
 
 impl Hashable for PyFrozenSet {
     #[inline]
-    fn hash(zelf: &crate::PyObjectView<Self>, vm: &VirtualMachine) -> PyResult<PyHash> {
+    fn hash(zelf: &crate::Py<Self>, vm: &VirtualMachine) -> PyResult<PyHash> {
         zelf.inner.hash(vm)
     }
 }
 
 impl Comparable for PyFrozenSet {
     fn cmp(
-        zelf: &crate::PyObjectView<Self>,
+        zelf: &crate::Py<Self>,
         other: &PyObject,
         op: PyComparisonOp,
         vm: &VirtualMachine,
@@ -1004,7 +1004,7 @@ impl Unconstructible for PySetIterator {}
 
 impl IterNextIterable for PySetIterator {}
 impl IterNext for PySetIterator {
-    fn next(zelf: &crate::PyObjectView<Self>, vm: &VirtualMachine) -> PyResult<PyIterReturn> {
+    fn next(zelf: &crate::Py<Self>, vm: &VirtualMachine) -> PyResult<PyIterReturn> {
         let mut internal = zelf.internal.lock();
         let next = if let IterStatus::Active(dict) = &internal.status {
             if dict.has_changed_size(&zelf.size) {

--- a/vm/src/builtins/singletons.rs
+++ b/vm/src/builtins/singletons.rs
@@ -1,14 +1,14 @@
 use super::PyTypeRef;
 use crate::{
     convert::ToPyObject, pyclass::PyClassImpl, types::Constructor, AsObject, PyContext,
-    PyObjectRef, PyResult, PyValue, VirtualMachine,
+    PyObjectRef, PyPayload, PyResult, VirtualMachine,
 };
 
 #[pyclass(module = false, name = "NoneType")]
 #[derive(Debug)]
 pub struct PyNone;
 
-impl PyValue for PyNone {
+impl PyPayload for PyNone {
     fn class(vm: &VirtualMachine) -> &PyTypeRef {
         &vm.ctx.types.none_type
     }
@@ -56,7 +56,7 @@ impl PyNone {
 #[derive(Debug)]
 pub struct PyNotImplemented;
 
-impl PyValue for PyNotImplemented {
+impl PyPayload for PyNotImplemented {
     fn class(vm: &VirtualMachine) -> &PyTypeRef {
         &vm.ctx.types.not_implemented_type
     }

--- a/vm/src/builtins/slice.rs
+++ b/vm/src/builtins/slice.rs
@@ -213,7 +213,7 @@ impl PySlice {
 
 impl Comparable for PySlice {
     fn cmp(
-        zelf: &crate::PyObjectView<Self>,
+        zelf: &crate::Py<Self>,
         other: &PyObject,
         op: PyComparisonOp,
         vm: &VirtualMachine,

--- a/vm/src/builtins/slice.rs
+++ b/vm/src/builtins/slice.rs
@@ -5,7 +5,7 @@ use crate::{
     function::{FuncArgs, OptionalArg, PyComparisonValue},
     pyclass::PyClassImpl,
     types::{Comparable, Constructor, Hashable, PyComparisonOp, Unhashable},
-    AsObject, PyContext, PyObject, PyObjectRef, PyRef, PyResult, PyValue, VirtualMachine,
+    AsObject, PyContext, PyObject, PyObjectRef, PyPayload, PyRef, PyResult, VirtualMachine,
 };
 use num_bigint::{BigInt, ToBigInt};
 use num_traits::{One, Signed, ToPrimitive, Zero};
@@ -20,7 +20,7 @@ pub struct PySlice {
     pub step: Option<PyObjectRef>,
 }
 
-impl PyValue for PySlice {
+impl PyPayload for PySlice {
     fn class(vm: &VirtualMachine) -> &PyTypeRef {
         &vm.ctx.types.slice_type
     }
@@ -423,7 +423,7 @@ pub fn saturate_index(p: isize, len: usize) -> usize {
 #[derive(Debug)]
 pub struct PyEllipsis;
 
-impl PyValue for PyEllipsis {
+impl PyPayload for PyEllipsis {
     fn class(vm: &VirtualMachine) -> &PyTypeRef {
         &vm.ctx.types.ellipsis_type
     }

--- a/vm/src/builtins/staticmethod.rs
+++ b/vm/src/builtins/staticmethod.rs
@@ -80,7 +80,7 @@ impl PyStaticMethod {
 impl Callable for PyStaticMethod {
     type Args = FuncArgs;
     #[inline]
-    fn call(zelf: &crate::PyObjectView<Self>, args: FuncArgs, vm: &VirtualMachine) -> PyResult {
+    fn call(zelf: &crate::Py<Self>, args: FuncArgs, vm: &VirtualMachine) -> PyResult {
         vm.invoke(&zelf.callable, args)
     }
 }

--- a/vm/src/builtins/staticmethod.rs
+++ b/vm/src/builtins/staticmethod.rs
@@ -4,7 +4,7 @@ use crate::{
     function::{FuncArgs, IntoPyNativeFunc},
     pyclass::PyClassImpl,
     types::{Callable, Constructor, GetDescriptor},
-    PyContext, PyObjectRef, PyRef, PyResult, PyValue, VirtualMachine,
+    PyContext, PyObjectRef, PyPayload, PyRef, PyResult, VirtualMachine,
 };
 
 #[pyclass(module = false, name = "staticmethod")]
@@ -13,7 +13,7 @@ pub struct PyStaticMethod {
     pub callable: PyObjectRef,
 }
 
-impl PyValue for PyStaticMethod {
+impl PyPayload for PyStaticMethod {
     fn class(vm: &VirtualMachine) -> &PyTypeRef {
         &vm.ctx.types.staticmethod_type
     }

--- a/vm/src/builtins/traceback.rs
+++ b/vm/src/builtins/traceback.rs
@@ -1,5 +1,5 @@
 use super::PyTypeRef;
-use crate::{frame::FrameRef, pyclass::PyClassImpl, PyContext, PyRef, PyValue, VirtualMachine};
+use crate::{frame::FrameRef, pyclass::PyClassImpl, PyContext, PyPayload, PyRef, VirtualMachine};
 
 #[pyclass(module = false, name = "traceback")]
 #[derive(Debug)]
@@ -12,7 +12,7 @@ pub struct PyTraceback {
 
 pub type PyTracebackRef = PyRef<PyTraceback>;
 
-impl PyValue for PyTraceback {
+impl PyPayload for PyTraceback {
     fn class(vm: &VirtualMachine) -> &PyTypeRef {
         &vm.ctx.types.traceback_type
     }

--- a/vm/src/builtins/tuple.rs
+++ b/vm/src/builtins/tuple.rs
@@ -14,7 +14,7 @@ use crate::{
     },
     utils::collection_repr,
     vm::{ReprGuard, VirtualMachine},
-    AsObject, PyContext, PyObject, PyObjectRef, PyRef, PyResult, PyValue, TryFromObject,
+    AsObject, PyContext, PyObject, PyObjectRef, PyPayload, PyRef, PyResult, TryFromObject,
 };
 use std::{borrow::Cow, fmt, marker::PhantomData};
 
@@ -34,7 +34,7 @@ impl fmt::Debug for PyTuple {
     }
 }
 
-impl PyValue for PyTuple {
+impl PyPayload for PyTuple {
     fn class(vm: &VirtualMachine) -> &PyTypeRef {
         &vm.ctx.types.tuple_type
     }
@@ -404,7 +404,7 @@ pub(crate) struct PyTupleIterator {
     internal: PyMutex<PositionIterInternal<PyTupleRef>>,
 }
 
-impl PyValue for PyTupleIterator {
+impl PyPayload for PyTupleIterator {
     fn class(vm: &VirtualMachine) -> &PyTypeRef {
         &vm.ctx.types.tuple_iterator_type
     }

--- a/vm/src/builtins/tuple.rs
+++ b/vm/src/builtins/tuple.rs
@@ -322,14 +322,14 @@ impl PyTuple {
 }
 
 impl AsMapping for PyTuple {
-    fn as_mapping(_zelf: &crate::PyObjectView<Self>, _vm: &VirtualMachine) -> PyMappingMethods {
+    fn as_mapping(_zelf: &crate::Py<Self>, _vm: &VirtualMachine) -> PyMappingMethods {
         Self::MAPPING_METHODS
     }
 }
 
 impl AsSequence for PyTuple {
     fn as_sequence(
-        _zelf: &crate::PyObjectView<Self>,
+        _zelf: &crate::Py<Self>,
         _vm: &VirtualMachine,
     ) -> Cow<'static, PySequenceMethods> {
         Cow::Borrowed(&Self::SEQUENCE_METHDOS)
@@ -367,14 +367,14 @@ impl PyTuple {
 
 impl Hashable for PyTuple {
     #[inline]
-    fn hash(zelf: &crate::PyObjectView<Self>, vm: &VirtualMachine) -> PyResult<PyHash> {
+    fn hash(zelf: &crate::Py<Self>, vm: &VirtualMachine) -> PyResult<PyHash> {
         crate::utils::hash_iter(zelf.elements.iter(), vm)
     }
 }
 
 impl Comparable for PyTuple {
     fn cmp(
-        zelf: &crate::PyObjectView<Self>,
+        zelf: &crate::Py<Self>,
         other: &PyObject,
         op: PyComparisonOp,
         vm: &VirtualMachine,
@@ -435,7 +435,7 @@ impl Unconstructible for PyTupleIterator {}
 
 impl IterNextIterable for PyTupleIterator {}
 impl IterNext for PyTupleIterator {
-    fn next(zelf: &crate::PyObjectView<Self>, _vm: &VirtualMachine) -> PyResult<PyIterReturn> {
+    fn next(zelf: &crate::Py<Self>, _vm: &VirtualMachine) -> PyResult<PyIterReturn> {
         zelf.internal.lock().next(|tuple, pos| {
             Ok(PyIterReturn::from_result(
                 tuple.as_slice().get(pos).cloned().ok_or(None),

--- a/vm/src/builtins/weakproxy.rs
+++ b/vm/src/builtins/weakproxy.rs
@@ -73,7 +73,7 @@ impl PyWeakProxy {
 
 impl SetAttr for PyWeakProxy {
     fn setattro(
-        zelf: &crate::PyObjectView<Self>,
+        zelf: &crate::Py<Self>,
         attr_name: PyStrRef,
         value: Option<PyObjectRef>,
         vm: &VirtualMachine,

--- a/vm/src/builtins/weakproxy.rs
+++ b/vm/src/builtins/weakproxy.rs
@@ -1,15 +1,15 @@
-use super::{PyStrRef, PyTypeRef};
+use super::{PyStrRef, PyTypeRef, PyWeak};
 use crate::{
     function::OptionalArg,
     pyclass::PyClassImpl,
     types::{Constructor, SetAttr},
-    PyContext, PyObjectRef, PyObjectWeak, PyResult, PyValue, VirtualMachine,
+    PyContext, PyObjectRef, PyRef, PyResult, PyValue, VirtualMachine,
 };
 
 #[pyclass(module = false, name = "weakproxy")]
 #[derive(Debug)]
 pub struct PyWeakProxy {
-    weak: PyObjectWeak,
+    weak: PyRef<PyWeak>,
 }
 
 impl PyValue for PyWeakProxy {

--- a/vm/src/builtins/weakproxy.rs
+++ b/vm/src/builtins/weakproxy.rs
@@ -3,7 +3,7 @@ use crate::{
     function::OptionalArg,
     pyclass::PyClassImpl,
     types::{Constructor, SetAttr},
-    PyContext, PyObjectRef, PyRef, PyResult, PyValue, VirtualMachine,
+    PyContext, PyObjectRef, PyPayload, PyRef, PyResult, VirtualMachine,
 };
 
 #[pyclass(module = false, name = "weakproxy")]
@@ -12,7 +12,7 @@ pub struct PyWeakProxy {
     weak: PyRef<PyWeak>,
 }
 
-impl PyValue for PyWeakProxy {
+impl PyPayload for PyWeakProxy {
     fn class(vm: &VirtualMachine) -> &PyTypeRef {
         &vm.ctx.types.weakproxy_type
     }

--- a/vm/src/builtins/weakref.rs
+++ b/vm/src/builtins/weakref.rs
@@ -7,7 +7,7 @@ use crate::{
     function::OptionalArg,
     pyclass::PyClassImpl,
     types::{Callable, Comparable, Constructor, Hashable, PyComparisonOp},
-    AsObject, PyContext, PyObject, PyObjectRef, PyRef, PyResult, PyValue, VirtualMachine,
+    AsObject, PyContext, PyObject, PyObjectRef, PyPayload, PyRef, PyResult, VirtualMachine,
 };
 
 pub use crate::pyobject::PyWeak;
@@ -20,7 +20,7 @@ pub struct WeakNewArgs {
     callback: OptionalArg<PyObjectRef>,
 }
 
-impl PyValue for PyWeak {
+impl PyPayload for PyWeak {
     fn class(vm: &VirtualMachine) -> &PyTypeRef {
         &vm.ctx.types.weakref_type
     }

--- a/vm/src/builtins/weakref.rs
+++ b/vm/src/builtins/weakref.rs
@@ -29,7 +29,7 @@ impl PyPayload for PyWeak {
 impl Callable for PyWeak {
     type Args = ();
     #[inline]
-    fn call(zelf: &crate::PyObjectView<Self>, _: Self::Args, vm: &VirtualMachine) -> PyResult {
+    fn call(zelf: &crate::Py<Self>, _: Self::Args, vm: &VirtualMachine) -> PyResult {
         Ok(vm.unwrap_or_none(zelf.upgrade()))
     }
 }
@@ -71,7 +71,7 @@ impl PyWeak {
 }
 
 impl Hashable for PyWeak {
-    fn hash(zelf: &crate::PyObjectView<Self>, vm: &VirtualMachine) -> PyResult<PyHash> {
+    fn hash(zelf: &crate::Py<Self>, vm: &VirtualMachine) -> PyResult<PyHash> {
         let hash = match zelf.hash.load(Ordering::Relaxed) {
             hash::SENTINEL => {
                 let obj = zelf
@@ -97,7 +97,7 @@ impl Hashable for PyWeak {
 
 impl Comparable for PyWeak {
     fn cmp(
-        zelf: &crate::PyObjectView<Self>,
+        zelf: &crate::Py<Self>,
         other: &PyObject,
         op: PyComparisonOp,
         vm: &VirtualMachine,

--- a/vm/src/builtins/weakref.rs
+++ b/vm/src/builtins/weakref.rs
@@ -43,8 +43,7 @@ impl Constructor for PyWeak {
         vm: &VirtualMachine,
     ) -> PyResult {
         let weak = referent.downgrade_with_typ(callback.into_option(), cls, vm)?;
-        let pyref_weak: PyRef<PyWeak> = weak.into();
-        Ok(pyref_weak.into())
+        Ok(weak.into())
     }
 }
 

--- a/vm/src/builtins/zip.rs
+++ b/vm/src/builtins/zip.rs
@@ -5,7 +5,7 @@ use crate::{
     protocol::{PyIter, PyIterReturn},
     pyclass::PyClassImpl,
     types::{Constructor, IterNext, IterNextIterable},
-    AsObject, PyContext, PyObjectRef, PyRef, PyResult, PyValue, TryFromObject, VirtualMachine,
+    AsObject, PyContext, PyObjectRef, PyPayload, PyRef, PyResult, TryFromObject, VirtualMachine,
 };
 use rustpython_common::atomic::{self, PyAtomic, Radium};
 
@@ -16,7 +16,7 @@ pub struct PyZip {
     strict: PyAtomic<bool>,
 }
 
-impl PyValue for PyZip {
+impl PyPayload for PyZip {
     fn class(vm: &VirtualMachine) -> &PyTypeRef {
         &vm.ctx.types.zip_type
     }

--- a/vm/src/builtins/zip.rs
+++ b/vm/src/builtins/zip.rs
@@ -67,7 +67,7 @@ impl PyZip {
 
 impl IterNextIterable for PyZip {}
 impl IterNext for PyZip {
-    fn next(zelf: &crate::PyObjectView<Self>, vm: &VirtualMachine) -> PyResult<PyIterReturn> {
+    fn next(zelf: &crate::Py<Self>, vm: &VirtualMachine) -> PyResult<PyIterReturn> {
         if zelf.iterators.is_empty() {
             return Ok(PyIterReturn::StopIteration(None));
         }

--- a/vm/src/bytesinner.rs
+++ b/vm/src/bytesinner.rs
@@ -9,7 +9,7 @@ use crate::{
     sequence::{SequenceMutOp, SequenceOp},
     types::PyComparisonOp,
     utils::Either,
-    AsObject, PyObject, PyObjectRef, PyResult, PyValue, TryFromBorrowedObject, VirtualMachine,
+    AsObject, PyObject, PyObjectRef, PyPayload, PyResult, TryFromBorrowedObject, VirtualMachine,
 };
 use bstr::ByteSlice;
 use itertools::Itertools;

--- a/vm/src/codecs.rs
+++ b/vm/src/codecs.rs
@@ -2,7 +2,7 @@ use crate::{
     builtins::{PyBaseExceptionRef, PyBytesRef, PyStr, PyStrRef, PyTuple, PyTupleRef},
     common::{ascii, lock::PyRwLock},
     convert::ToPyObject,
-    AsObject, PyContext, PyObject, PyObjectRef, PyResult, PyValue, TryFromObject, VirtualMachine,
+    AsObject, PyContext, PyObject, PyObjectRef, PyPayload, PyResult, TryFromObject, VirtualMachine,
 };
 use std::{borrow::Cow, collections::HashMap, fmt::Write, ops::Range};
 

--- a/vm/src/convert/transmute_from.rs
+++ b/vm/src/convert/transmute_from.rs
@@ -1,5 +1,5 @@
 use crate::{
-    pyobject::{AsObject, PyObject, PyRef, PyResult, PyValue},
+    pyobject::{AsObject, PyObject, PyPayload, PyRef, PyResult},
     vm::VirtualMachine,
 };
 
@@ -13,7 +13,7 @@ pub unsafe trait TransmuteFromObject: Sized {
     fn check(vm: &VirtualMachine, obj: &PyObject) -> PyResult<()>;
 }
 
-unsafe impl<T: PyValue> TransmuteFromObject for PyRef<T> {
+unsafe impl<T: PyPayload> TransmuteFromObject for PyRef<T> {
     fn check(vm: &VirtualMachine, obj: &PyObject) -> PyResult<()> {
         let class = T::class(vm);
         if obj.fast_isinstance(class) {

--- a/vm/src/convert/try_from.rs
+++ b/vm/src/convert/try_from.rs
@@ -1,5 +1,5 @@
 use crate::{
-    pyobject::{AsObject, PyObject, PyObjectRef, PyRef, PyResult, PyValue},
+    pyobject::{AsObject, PyObject, PyObjectRef, PyPayload, PyRef, PyResult},
     vm::VirtualMachine,
 };
 
@@ -38,7 +38,7 @@ impl PyObject {
 
     pub fn try_value_with<T, F, R>(&self, f: F, vm: &VirtualMachine) -> PyResult<R>
     where
-        T: PyValue,
+        T: PyPayload,
         F: Fn(&T) -> PyResult<R>,
     {
         let class = T::class(vm);
@@ -63,7 +63,7 @@ pub trait TryFromBorrowedObject: Sized {
 
 impl<T> TryFromObject for PyRef<T>
 where
-    T: PyValue,
+    T: PyPayload,
 {
     #[inline]
     fn try_from_object(vm: &VirtualMachine, obj: PyObjectRef) -> PyResult<Self> {

--- a/vm/src/exceptions.rs
+++ b/vm/src/exceptions.rs
@@ -10,7 +10,7 @@ use crate::{
     pyclass::{PyClassImpl, StaticType},
     stdlib::sys,
     suggestion::offer_suggestions,
-    AsObject, PyContext, PyObjectRef, PyRef, PyResult, PyValue, TryFromObject, VirtualMachine,
+    AsObject, PyContext, PyObjectRef, PyPayload, PyRef, PyResult, TryFromObject, VirtualMachine,
 };
 use crossbeam_utils::atomic::AtomicCell;
 use itertools::Itertools;
@@ -27,7 +27,7 @@ impl std::fmt::Debug for PyBaseException {
     }
 }
 
-impl PyValue for PyBaseException {
+impl PyPayload for PyBaseException {
     fn class(vm: &VirtualMachine) -> &PyTypeRef {
         &vm.ctx.exceptions.base_exception_type
     }

--- a/vm/src/frame.rs
+++ b/vm/src/frame.rs
@@ -16,7 +16,7 @@ use crate::{
     scope::Scope,
     stdlib::builtins,
     types::PyComparisonOp,
-    AsObject, PyMethod, PyObject, PyObjectRef, PyRef, PyResult, PyValue, TryFromObject,
+    AsObject, PyMethod, PyObject, PyObjectRef, PyPayload, PyRef, PyResult, TryFromObject,
     VirtualMachine,
 };
 use indexmap::IndexMap;
@@ -113,7 +113,7 @@ pub struct Frame {
     state: PyMutex<FrameState>,
 }
 
-impl PyValue for Frame {
+impl PyPayload for Frame {
     fn class(vm: &VirtualMachine) -> &PyTypeRef {
         &vm.ctx.types.frame_type
     }

--- a/vm/src/function/argument.rs
+++ b/vm/src/function/argument.rs
@@ -1,7 +1,7 @@
 use crate::{
     builtins::{PyBaseExceptionRef, PyTupleRef, PyTypeRef},
     convert::ToPyObject,
-    AsObject, PyObjectRef, PyRef, PyResult, PyValue, TryFromObject, VirtualMachine,
+    AsObject, PyObjectRef, PyPayload, PyRef, PyResult, TryFromObject, VirtualMachine,
 };
 use indexmap::IndexMap;
 use itertools::Itertools;
@@ -406,7 +406,7 @@ impl<T> AsRef<[T]> for PosArgs<T> {
     }
 }
 
-impl<T: PyValue> PosArgs<PyRef<T>> {
+impl<T: PyPayload> PosArgs<PyRef<T>> {
     pub fn into_tuple(self, vm: &VirtualMachine) -> PyTupleRef {
         vm.ctx
             .new_tuple(self.0.into_iter().map(Into::into).collect())

--- a/vm/src/function/builtin.rs
+++ b/vm/src/function/builtin.rs
@@ -1,6 +1,7 @@
 use super::{FromArgs, FuncArgs};
 use crate::{
-    convert::ToPyResult, pyobject::PyThreadingConstraint, PyRef, PyResult, PyValue, VirtualMachine,
+    convert::ToPyResult, pyobject::PyThreadingConstraint, PyPayload, PyRef, PyResult,
+    VirtualMachine,
 };
 use std::marker::PhantomData;
 
@@ -83,7 +84,7 @@ macro_rules! into_py_native_func_tuple {
         impl<F, S, $($T,)* R> PyNativeFuncInternal<(RefParam<S>, $(OwnedParam<$T>,)*), R, VirtualMachine> for F
         where
             F: Fn(&S, $($T,)* &VirtualMachine) -> R + PyThreadingConstraint + 'static,
-            S: PyValue,
+            S: PyPayload,
             $($T: FromArgs,)*
             R: ToPyResult,
         {
@@ -110,7 +111,7 @@ macro_rules! into_py_native_func_tuple {
         impl<F, S, $($T,)* R> PyNativeFuncInternal<(RefParam<S>, $(OwnedParam<$T>,)*), R, ()> for F
         where
             F: Fn(&S, $($T,)*) -> R + PyThreadingConstraint + 'static,
-            S: PyValue,
+            S: PyPayload,
             $($T: FromArgs,)*
             R: ToPyResult,
         {

--- a/vm/src/function/protocol.rs
+++ b/vm/src/function/protocol.rs
@@ -3,7 +3,7 @@ use crate::{
     builtins::{iter::PySequenceIterator, PyDict, PyDictRef},
     convert::ToPyObject,
     protocol::{PyIter, PyIterIter, PyMapping, PyMappingMethods},
-    AsObject, PyObject, PyObjectRef, PyResult, PyValue, TryFromObject, VirtualMachine,
+    AsObject, PyObject, PyObjectRef, PyPayload, PyResult, TryFromObject, VirtualMachine,
 };
 use std::{borrow::Borrow, marker::PhantomData};
 

--- a/vm/src/import.rs
+++ b/vm/src/import.rs
@@ -8,7 +8,7 @@ use crate::{
     scope::Scope,
     version::get_git_revision,
     vm::{InitParameter, VirtualMachine},
-    AsObject, PyObjectRef, PyRef, PyResult, PyValue, TryFromObject,
+    AsObject, PyObjectRef, PyPayload, PyRef, PyResult, TryFromObject,
 };
 use rand::Rng;
 

--- a/vm/src/lib.rs
+++ b/vm/src/lib.rs
@@ -90,7 +90,7 @@ pub use self::convert::{TryFromBorrowedObject, TryFromObject};
 // pyobject items
 pub use self::pyobject::{AsObject, PyContext, PyMethod, PyRefExact, PyResult, PyValue};
 // pyobjectrc items
-pub use self::pyobject::{PyObject, PyObjectRef, PyObjectView, PyObjectWeak, PyRef, PyWeakRef};
+pub use self::pyobject::{PyObject, PyObjectRef, PyObjectView, PyRef, PyWeakRef};
 pub use self::types::PyStructSequence;
 pub use self::vm::{InitParameter, Interpreter, PySettings, VirtualMachine};
 

--- a/vm/src/lib.rs
+++ b/vm/src/lib.rs
@@ -90,7 +90,7 @@ pub use self::convert::{TryFromBorrowedObject, TryFromObject};
 // pyobject items
 pub use self::pyobject::{AsObject, PyContext, PyMethod, PyPayload, PyRefExact, PyResult};
 // pyobjectrc items
-pub use self::pyobject::{PyObject, PyObjectRef, PyObjectView, PyRef, PyWeakRef};
+pub use self::pyobject::{Py, PyObject, PyObjectRef, PyRef, PyWeakRef};
 pub use self::types::PyStructSequence;
 pub use self::vm::{InitParameter, Interpreter, PySettings, VirtualMachine};
 

--- a/vm/src/lib.rs
+++ b/vm/src/lib.rs
@@ -88,7 +88,7 @@ mod pyobject {
 // pub use self::Executor;
 pub use self::convert::{TryFromBorrowedObject, TryFromObject};
 // pyobject items
-pub use self::pyobject::{AsObject, PyContext, PyMethod, PyRefExact, PyResult, PyValue};
+pub use self::pyobject::{AsObject, PyContext, PyMethod, PyPayload, PyRefExact, PyResult};
 // pyobjectrc items
 pub use self::pyobject::{PyObject, PyObjectRef, PyObjectView, PyRef, PyWeakRef};
 pub use self::types::PyStructSequence;

--- a/vm/src/macros.rs
+++ b/vm/src/macros.rs
@@ -69,7 +69,7 @@ macro_rules! py_namespace {
 ///
 /// use rustpython_vm::match_class;
 /// use rustpython_vm::builtins::{PyFloat, PyInt};
-/// use rustpython_vm::{PyValue};
+/// use rustpython_vm::{PyPayload};
 ///
 /// # rustpython_vm::Interpreter::default().enter(|vm| {
 /// let obj = PyInt::from(0).into_pyobject(vm);
@@ -93,7 +93,7 @@ macro_rules! py_namespace {
 ///
 /// use rustpython_vm::match_class;
 /// use rustpython_vm::builtins::{PyFloat, PyInt};
-/// use rustpython_vm::{ PyValue};
+/// use rustpython_vm::{ PyPayload};
 ///
 /// # rustpython_vm::Interpreter::default().enter(|vm| {
 /// let obj = PyInt::from(0).into_pyobject(vm);

--- a/vm/src/protocol/buffer.rs
+++ b/vm/src/protocol/buffer.rs
@@ -9,8 +9,8 @@ use crate::{
     pyobject::PyObjectPayload,
     sliceable::wrap_index,
     types::{Constructor, Unconstructible},
-    AsObject, PyObject, PyObjectRef, PyObjectView, PyRef, PyResult, PyValue, TryFromBorrowedObject,
-    VirtualMachine,
+    AsObject, PyObject, PyObjectRef, PyObjectView, PyPayload, PyRef, PyResult,
+    TryFromBorrowedObject, VirtualMachine,
 };
 use itertools::Itertools;
 use std::{borrow::Cow, fmt::Debug, ops::Range};
@@ -65,7 +65,7 @@ impl PyBuffer {
     pub fn from_byte_vector(bytes: Vec<u8>, vm: &VirtualMachine) -> Self {
         let bytes_len = bytes.len();
         PyBuffer::new(
-            PyValue::into_pyobject(VecBuffer::from(bytes), vm),
+            PyPayload::into_pyobject(VecBuffer::from(bytes), vm),
             BufferDescriptor::simple(bytes_len, true),
             &VEC_BUFFER_METHODS,
         )
@@ -395,7 +395,7 @@ pub trait BufferResizeGuard<'a> {
 }
 
 #[pyclass(module = false, name = "vec_buffer")]
-#[derive(Debug, PyValue)]
+#[derive(Debug, PyPayload)]
 pub struct VecBuffer {
     data: PyMutex<Vec<u8>>,
 }

--- a/vm/src/protocol/buffer.rs
+++ b/vm/src/protocol/buffer.rs
@@ -9,8 +9,8 @@ use crate::{
     pyobject::PyObjectPayload,
     sliceable::wrap_index,
     types::{Constructor, Unconstructible},
-    AsObject, PyObject, PyObjectRef, PyObjectView, PyPayload, PyRef, PyResult,
-    TryFromBorrowedObject, VirtualMachine,
+    AsObject, Py, PyObject, PyObjectRef, PyPayload, PyRef, PyResult, TryFromBorrowedObject,
+    VirtualMachine,
 };
 use itertools::Itertools;
 use std::{borrow::Cow, fmt::Debug, ops::Range};
@@ -108,7 +108,7 @@ impl PyBuffer {
         f(v)
     }
 
-    pub fn obj_as<T: PyObjectPayload>(&self) -> &PyObjectView<T> {
+    pub fn obj_as<T: PyObjectPayload>(&self) -> &Py<T> {
         unsafe { self.obj.downcast_unchecked_ref() }
     }
 

--- a/vm/src/protocol/iter.rs
+++ b/vm/src/protocol/iter.rs
@@ -1,7 +1,7 @@
 use crate::{
     builtins::iter::PySequenceIterator,
     convert::{ToPyObject, ToPyResult},
-    AsObject, PyObject, PyObjectRef, PyResult, PyValue, TryFromObject, VirtualMachine,
+    AsObject, PyObject, PyObjectRef, PyPayload, PyResult, TryFromObject, VirtualMachine,
 };
 use std::borrow::Borrow;
 use std::ops::Deref;

--- a/vm/src/protocol/sequence.rs
+++ b/vm/src/protocol/sequence.rs
@@ -4,7 +4,7 @@ use crate::{
     convert::ToPyObject,
     function::PyArithmeticValue,
     protocol::PyMapping,
-    AsObject, PyObject, PyObjectRef, PyResult, PyValue, VirtualMachine,
+    AsObject, PyObject, PyObjectRef, PyPayload, PyResult, VirtualMachine,
 };
 use itertools::Itertools;
 use std::{

--- a/vm/src/pyobject.rs
+++ b/vm/src/pyobject.rs
@@ -18,7 +18,7 @@ use crate::{
     pyclass::{PyClassImpl, StaticType},
     types::{PyTypeFlags, PyTypeSlots, TypeZoo},
     VirtualMachine,
-    _pyobjectrc::{PyObject, PyObjectRef, PyObjectView, PyRef},
+    _pyobjectrc::{Py, PyObject, PyObjectRef, PyRef},
 };
 use num_bigint::BigInt;
 use num_traits::ToPrimitive;
@@ -347,7 +347,7 @@ where
         fmt::Display::fmt(&**self, f)
     }
 }
-impl<T: fmt::Display> fmt::Display for PyObjectView<T>
+impl<T: fmt::Display> fmt::Display for Py<T>
 where
     T: PyObjectPayload + fmt::Display,
 {
@@ -432,7 +432,7 @@ where
     /// Determines if `obj` actually an instance of `cls`, this doesn't call __instancecheck__, so only
     /// use this if `cls` is known to have not overridden the base __instancecheck__ magic method.
     #[inline]
-    fn fast_isinstance(&self, cls: &PyObjectView<PyType>) -> bool {
+    fn fast_isinstance(&self, cls: &Py<PyType>) -> bool {
         self.class().fast_issubclass(cls)
     }
 }

--- a/vm/src/pyobjectrc.rs
+++ b/vm/src/pyobjectrc.rs
@@ -1,3 +1,16 @@
+//! Essential types for object models
+//!
+//! +-------------------------+--------------+---------------+
+//! |       Management        |    Typed     |    Untyped    |
+//! +-------------------------+--------------+---------------+
+//! | Interpreter-independent | Py<T>        | PyObject      |
+//! | Reference-counted       | PyRef<T>     | PyObjectRef   |
+//! | Weak                    | PyWeakRef<T> | PyRef<PyWeak> |
+//! +-------------------------+--------------+---------------+
+//!
+//! PyRef<PyWeak> may looking like to be called as PyObjectWeak by the rule,
+//! but not to do to remember it is a PyRef object.
+
 use crate::common::atomic::{OncePtr, PyAtomic, Radium};
 use crate::common::linked_list::{Link, LinkedList, Pointers};
 use crate::common::lock::{PyMutex, PyMutexGuard, PyRwLock};

--- a/vm/src/pyobjectrc.rs
+++ b/vm/src/pyobjectrc.rs
@@ -544,7 +544,7 @@ impl PyObjectRef {
     /// If the downcast fails, the original ref is returned in as `Err` so
     /// another downcast can be attempted without unnecessary cloning.
     #[inline]
-    pub fn downcast_exact<T: PyObjectPayload + crate::PyValue>(
+    pub fn downcast_exact<T: PyObjectPayload + crate::PyPayload>(
         self,
         vm: &VirtualMachine,
     ) -> Result<PyRef<T>, Self> {
@@ -639,7 +639,7 @@ impl PyObject {
     }
 
     #[inline(always)]
-    pub fn payload_if_exact<T: PyObjectPayload + crate::PyValue>(
+    pub fn payload_if_exact<T: PyObjectPayload + crate::PyPayload>(
         &self,
         vm: &VirtualMachine,
     ) -> Option<&T> {
@@ -673,7 +673,7 @@ impl PyObject {
     }
 
     #[inline(always)]
-    pub fn payload_if_subclass<T: crate::PyValue>(&self, vm: &VirtualMachine) -> Option<&T> {
+    pub fn payload_if_subclass<T: crate::PyPayload>(&self, vm: &VirtualMachine) -> Option<&T> {
         if self.class().fast_issubclass(T::class(vm)) {
             self.payload()
         } else {
@@ -693,7 +693,7 @@ impl PyObject {
     }
 
     #[inline(always)]
-    pub fn downcast_ref_if_exact<T: PyObjectPayload + crate::PyValue>(
+    pub fn downcast_ref_if_exact<T: PyObjectPayload + crate::PyPayload>(
         &self,
         vm: &VirtualMachine,
     ) -> Option<&PyObjectView<T>> {

--- a/vm/src/stdlib/ast.rs
+++ b/vm/src/stdlib/ast.rs
@@ -8,7 +8,7 @@ mod gen;
 use crate::{
     builtins::{self, PyStrRef, PyTypeRef},
     pyclass::{PyClassImpl, StaticType},
-    AsObject, PyContext, PyObject, PyObjectRef, PyResult, PyValue, TryFromObject, VirtualMachine,
+    AsObject, PyContext, PyObject, PyObjectRef, PyPayload, PyResult, TryFromObject, VirtualMachine,
 };
 use num_complex::Complex64;
 use num_traits::{ToPrimitive, Zero};
@@ -21,12 +21,12 @@ use rustpython_parser::parser;
 #[pymodule]
 mod _ast {
     use crate::{
-        builtins::PyStrRef, function::FuncArgs, AsObject, PyObjectRef, PyResult, PyValue,
+        builtins::PyStrRef, function::FuncArgs, AsObject, PyObjectRef, PyPayload, PyResult,
         VirtualMachine,
     };
     #[pyattr]
     #[pyclass(module = "_ast", name = "AST")]
-    #[derive(Debug, PyValue)]
+    #[derive(Debug, PyPayload)]
     pub(crate) struct AstNode;
 
     #[pyimpl(flags(BASETYPE, HAS_DICT))]

--- a/vm/src/stdlib/builtins.rs
+++ b/vm/src/stdlib/builtins.rs
@@ -34,7 +34,7 @@ mod builtins {
         stdlib::sys,
         types::PyComparisonOp,
         utils::Either,
-        AsObject, PyObject, PyObjectRef, PyRef, PyResult, PyValue, TryFromObject, VirtualMachine,
+        AsObject, PyObject, PyObjectRef, PyPayload, PyRef, PyResult, TryFromObject, VirtualMachine,
     };
     use num_traits::{Signed, ToPrimitive, Zero};
 

--- a/vm/src/stdlib/collections.rs
+++ b/vm/src/stdlib/collections.rs
@@ -508,7 +508,7 @@ mod _collections {
 
     impl AsSequence for PyDeque {
         fn as_sequence(
-            _zelf: &crate::PyObjectView<Self>,
+            _zelf: &crate::Py<Self>,
             _vm: &VirtualMachine,
         ) -> std::borrow::Cow<'static, PySequenceMethods> {
             std::borrow::Cow::Borrowed(&Self::SEQUENCE_METHDOS)
@@ -552,7 +552,7 @@ mod _collections {
 
     impl Comparable for PyDeque {
         fn cmp(
-            zelf: &crate::PyObjectView<Self>,
+            zelf: &crate::Py<Self>,
             other: &PyObject,
             op: PyComparisonOp,
             vm: &VirtualMachine,
@@ -642,7 +642,7 @@ mod _collections {
 
     impl IterNextIterable for PyDequeIterator {}
     impl IterNext for PyDequeIterator {
-        fn next(zelf: &crate::PyObjectView<Self>, vm: &VirtualMachine) -> PyResult<PyIterReturn> {
+        fn next(zelf: &crate::Py<Self>, vm: &VirtualMachine) -> PyResult<PyIterReturn> {
             zelf.internal.lock().next(|deque, pos| {
                 if zelf.state != deque.state.load() {
                     return Err(vm.new_runtime_error("Deque mutated during iteration".to_owned()));
@@ -708,7 +708,7 @@ mod _collections {
 
     impl IterNextIterable for PyReverseDequeIterator {}
     impl IterNext for PyReverseDequeIterator {
-        fn next(zelf: &crate::PyObjectView<Self>, vm: &VirtualMachine) -> PyResult<PyIterReturn> {
+        fn next(zelf: &crate::Py<Self>, vm: &VirtualMachine) -> PyResult<PyIterReturn> {
             zelf.internal.lock().next(|deque, pos| {
                 if deque.state.load() != zelf.state {
                     return Err(vm.new_runtime_error("Deque mutated during iteration".to_owned()));

--- a/vm/src/stdlib/collections.rs
+++ b/vm/src/stdlib/collections.rs
@@ -19,7 +19,7 @@ mod _collections {
         },
         utils::collection_repr,
         vm::ReprGuard,
-        AsObject, PyObject, PyObjectRef, PyRef, PyResult, PyValue, VirtualMachine,
+        AsObject, PyObject, PyObjectRef, PyPayload, PyRef, PyResult, VirtualMachine,
     };
     use crossbeam_utils::atomic::AtomicCell;
     use std::cmp::max;
@@ -27,7 +27,7 @@ mod _collections {
 
     #[pyattr]
     #[pyclass(name = "deque")]
-    #[derive(Debug, Default, PyValue)]
+    #[derive(Debug, Default, PyPayload)]
     struct PyDeque {
         deque: PyRwLock<VecDeque<PyObjectRef>>,
         maxlen: Option<usize>,
@@ -577,7 +577,7 @@ mod _collections {
 
     #[pyattr]
     #[pyclass(name = "_deque_iterator")]
-    #[derive(Debug, PyValue)]
+    #[derive(Debug, PyPayload)]
     struct PyDequeIterator {
         state: usize,
         internal: PyMutex<PositionIterInternal<PyDequeRef>>,
@@ -657,7 +657,7 @@ mod _collections {
 
     #[pyattr]
     #[pyclass(name = "_deque_reverse_iterator")]
-    #[derive(Debug, PyValue)]
+    #[derive(Debug, PyPayload)]
     struct PyReverseDequeIterator {
         state: usize,
         // position is counting from the tail

--- a/vm/src/stdlib/imp.rs
+++ b/vm/src/stdlib/imp.rs
@@ -52,7 +52,7 @@ mod lock {
 mod _imp {
     use crate::{
         builtins::{PyBytesRef, PyCode, PyModule, PyStr, PyStrRef},
-        import, PyObjectRef, PyRef, PyResult, PyValue, TryFromObject, VirtualMachine,
+        import, PyObjectRef, PyPayload, PyRef, PyResult, TryFromObject, VirtualMachine,
     };
 
     #[pyfunction]

--- a/vm/src/stdlib/io.rs
+++ b/vm/src/stdlib/io.rs
@@ -536,7 +536,7 @@ mod _io {
         }
 
         #[cold]
-        fn del(_zelf: &crate::PyObjectView<Self>, _vm: &VirtualMachine) -> PyResult<()> {
+        fn del(_zelf: &crate::Py<Self>, _vm: &VirtualMachine) -> PyResult<()> {
             unreachable!("slot_del is implemented")
         }
     }
@@ -562,7 +562,7 @@ mod _io {
             })
         }
 
-        fn next(_zelf: &crate::PyObjectView<Self>, _vm: &VirtualMachine) -> PyResult<PyIterReturn> {
+        fn next(_zelf: &crate::Py<Self>, _vm: &VirtualMachine) -> PyResult<PyIterReturn> {
             unreachable!("slot_iternext is implemented")
         }
     }

--- a/vm/src/stdlib/io.rs
+++ b/vm/src/stdlib/io.rs
@@ -114,7 +114,7 @@ mod _io {
         types::{Constructor, Destructor, IterNext, Iterable},
         utils::Either,
         vm::{ReprGuard, VirtualMachine},
-        AsObject, PyContext, PyObject, PyObjectRef, PyRef, PyResult, PyValue,
+        AsObject, PyContext, PyObject, PyObjectRef, PyPayload, PyRef, PyResult,
         TryFromBorrowedObject, TryFromObject,
     };
     use bstr::ByteSlice;
@@ -369,7 +369,7 @@ mod _io {
 
     #[pyattr]
     #[pyclass(name = "_IOBase")]
-    #[derive(Debug, PyValue)]
+    #[derive(Debug, PyPayload)]
     struct _IOBase;
 
     #[pyimpl(with(IterNext, Destructor), flags(BASETYPE, HAS_DICT))]
@@ -1359,7 +1359,7 @@ mod _io {
     }
 
     #[pyimpl]
-    trait BufferedMixin: PyValue {
+    trait BufferedMixin: PyPayload {
         const READABLE: bool;
         const WRITABLE: bool;
         const SEEKABLE: bool = false;
@@ -1562,7 +1562,7 @@ mod _io {
     }
 
     #[pyimpl]
-    trait BufferedReadable: PyValue {
+    trait BufferedReadable: PyPayload {
         type Reader: BufferedMixin;
         fn reader(&self) -> &Self::Reader;
         #[pymethod]
@@ -1644,7 +1644,7 @@ mod _io {
 
     #[pyattr]
     #[pyclass(name = "BufferedReader", base = "_BufferedIOBase")]
-    #[derive(Debug, Default, PyValue)]
+    #[derive(Debug, Default, PyPayload)]
     struct BufferedReader {
         data: PyThreadMutex<BufferedData>,
     }
@@ -1671,7 +1671,7 @@ mod _io {
     }
 
     #[pyimpl]
-    trait BufferedWritable: PyValue {
+    trait BufferedWritable: PyPayload {
         type Writer: BufferedMixin;
         fn writer(&self) -> &Self::Writer;
         #[pymethod]
@@ -1693,7 +1693,7 @@ mod _io {
 
     #[pyattr]
     #[pyclass(name = "BufferedWriter", base = "_BufferedIOBase")]
-    #[derive(Debug, Default, PyValue)]
+    #[derive(Debug, Default, PyPayload)]
     struct BufferedWriter {
         data: PyThreadMutex<BufferedData>,
     }
@@ -1721,7 +1721,7 @@ mod _io {
 
     #[pyattr]
     #[pyclass(name = "BufferedRandom", base = "_BufferedIOBase")]
-    #[derive(Debug, Default, PyValue)]
+    #[derive(Debug, Default, PyPayload)]
     struct BufferedRandom {
         data: PyThreadMutex<BufferedData>,
     }
@@ -1759,7 +1759,7 @@ mod _io {
 
     #[pyattr]
     #[pyclass(name = "BufferedRWPair", base = "_BufferedIOBase")]
-    #[derive(Debug, Default, PyValue)]
+    #[derive(Debug, Default, PyPayload)]
     struct BufferedRWPair {
         read: BufferedReader,
         write: BufferedWriter,
@@ -2166,7 +2166,7 @@ mod _io {
 
     #[pyattr]
     #[pyclass(name = "TextIOWrapper", base = "_TextIOBase")]
-    #[derive(Debug, Default, PyValue)]
+    #[derive(Debug, Default, PyPayload)]
     struct TextIOWrapper {
         data: PyThreadMutex<Option<TextIOData>>,
     }
@@ -3022,7 +3022,7 @@ mod _io {
 
     #[pyattr]
     #[pyclass(name = "StringIO", base = "_TextIOBase")]
-    #[derive(Debug, PyValue)]
+    #[derive(Debug, PyPayload)]
     struct StringIO {
         buffer: PyRwLock<BufferedIO>,
         closed: AtomicCell<bool>,
@@ -3171,7 +3171,7 @@ mod _io {
 
     #[pyattr]
     #[pyclass(name = "BytesIO", base = "_BufferedIOBase")]
-    #[derive(Debug, PyValue)]
+    #[derive(Debug, PyPayload)]
     struct BytesIO {
         buffer: PyRwLock<BufferedIO>,
         closed: AtomicCell<bool>,
@@ -3686,7 +3686,7 @@ mod fileio {
         crt_fd::Fd,
         function::{ArgBytesLike, ArgMemoryBuffer, FuncArgs, OptionalArg, OptionalOption},
         stdlib::os,
-        AsObject, PyObjectRef, PyRef, PyResult, PyValue, TryFromObject, VirtualMachine,
+        AsObject, PyObjectRef, PyPayload, PyRef, PyResult, TryFromObject, VirtualMachine,
     };
     use crossbeam_utils::atomic::AtomicCell;
     use std::io::{Read, Write};
@@ -3792,7 +3792,7 @@ mod fileio {
 
     #[pyattr]
     #[pyclass(module = "io", name, base = "_RawIOBase")]
-    #[derive(Debug, PyValue)]
+    #[derive(Debug, PyPayload)]
     pub(super) struct FileIO {
         fd: AtomicCell<i32>,
         closefd: AtomicCell<bool>,

--- a/vm/src/stdlib/itertools.rs
+++ b/vm/src/stdlib/itertools.rs
@@ -13,7 +13,7 @@ mod decl {
         protocol::{PyIter, PyIterReturn},
         stdlib::sys,
         types::{Constructor, IterNext, IterNextIterable},
-        AsObject, PyObjectRef, PyObjectView, PyRef, PyResult, PyValue, PyWeakRef, VirtualMachine,
+        AsObject, PyObjectRef, PyObjectView, PyPayload, PyRef, PyResult, PyWeakRef, VirtualMachine,
     };
     use crossbeam_utils::atomic::AtomicCell;
     use num_bigint::BigInt;
@@ -22,7 +22,7 @@ mod decl {
 
     #[pyattr]
     #[pyclass(name = "chain")]
-    #[derive(Debug, PyValue)]
+    #[derive(Debug, PyPayload)]
     struct PyItertoolsChain {
         iterables: Vec<PyObjectRef>,
         cur_idx: AtomicCell<usize>,
@@ -99,7 +99,7 @@ mod decl {
 
     #[pyattr]
     #[pyclass(name = "compress")]
-    #[derive(Debug, PyValue)]
+    #[derive(Debug, PyPayload)]
     struct PyItertoolsCompress {
         data: PyIter,
         selector: PyIter,
@@ -148,7 +148,7 @@ mod decl {
 
     #[pyattr]
     #[pyclass(name = "count")]
-    #[derive(Debug, PyValue)]
+    #[derive(Debug, PyPayload)]
     struct PyItertoolsCount {
         cur: PyRwLock<BigInt>,
         step: BigInt,
@@ -202,7 +202,7 @@ mod decl {
 
     #[pyattr]
     #[pyclass(name = "cycle")]
-    #[derive(Debug, PyValue)]
+    #[derive(Debug, PyPayload)]
     struct PyItertoolsCycle {
         iter: PyIter,
         saved: PyRwLock<Vec<PyObjectRef>>,
@@ -251,7 +251,7 @@ mod decl {
 
     #[pyattr]
     #[pyclass(name = "repeat")]
-    #[derive(Debug, PyValue)]
+    #[derive(Debug, PyPayload)]
     struct PyItertoolsRepeat {
         object: PyObjectRef,
         times: Option<PyRwLock<usize>>,
@@ -331,7 +331,7 @@ mod decl {
 
     #[pyattr]
     #[pyclass(name = "starmap")]
-    #[derive(Debug, PyValue)]
+    #[derive(Debug, PyPayload)]
     struct PyItertoolsStarmap {
         function: PyObjectRef,
         iterable: PyIter,
@@ -376,7 +376,7 @@ mod decl {
 
     #[pyattr]
     #[pyclass(name = "takewhile")]
-    #[derive(Debug, PyValue)]
+    #[derive(Debug, PyPayload)]
     struct PyItertoolsTakewhile {
         predicate: PyObjectRef,
         iterable: PyIter,
@@ -440,7 +440,7 @@ mod decl {
 
     #[pyattr]
     #[pyclass(name = "dropwhile")]
-    #[derive(Debug, PyValue)]
+    #[derive(Debug, PyPayload)]
     struct PyItertoolsDropwhile {
         predicate: ArgCallable,
         iterable: PyIter,
@@ -531,7 +531,7 @@ mod decl {
 
     #[pyattr]
     #[pyclass(name = "groupby")]
-    #[derive(PyValue)]
+    #[derive(PyPayload)]
     struct PyItertoolsGroupBy {
         iterable: PyIter,
         key_func: Option<PyObjectRef>,
@@ -648,7 +648,7 @@ mod decl {
 
     #[pyattr]
     #[pyclass(name = "_grouper")]
-    #[derive(Debug, PyValue)]
+    #[derive(Debug, PyPayload)]
     struct PyItertoolsGrouper {
         groupby: PyRef<PyItertoolsGroupBy>,
     }
@@ -691,7 +691,7 @@ mod decl {
 
     #[pyattr]
     #[pyclass(name = "islice")]
-    #[derive(Debug, PyValue)]
+    #[derive(Debug, PyPayload)]
     struct PyItertoolsIslice {
         iterable: PyIter,
         cur: AtomicCell<usize>,
@@ -818,7 +818,7 @@ mod decl {
 
     #[pyattr]
     #[pyclass(name = "filterfalse")]
-    #[derive(Debug, PyValue)]
+    #[derive(Debug, PyPayload)]
     struct PyItertoolsFilterFalse {
         predicate: PyObjectRef,
         iterable: PyIter,
@@ -879,7 +879,7 @@ mod decl {
 
     #[pyattr]
     #[pyclass(name = "accumulate")]
-    #[derive(Debug, PyValue)]
+    #[derive(Debug, PyPayload)]
     struct PyItertoolsAccumulate {
         iterable: PyIter,
         binop: Option<PyObjectRef>,
@@ -977,7 +977,7 @@ mod decl {
 
     #[pyattr]
     #[pyclass(name = "tee")]
-    #[derive(Debug, PyValue)]
+    #[derive(Debug, PyPayload)]
     struct PyItertoolsTee {
         tee_data: PyRc<PyItertoolsTeeData>,
         index: AtomicCell<usize>,
@@ -1055,7 +1055,7 @@ mod decl {
 
     #[pyattr]
     #[pyclass(name = "product")]
-    #[derive(Debug, PyValue)]
+    #[derive(Debug, PyPayload)]
     struct PyItertoolsProduct {
         pools: Vec<Vec<PyObjectRef>>,
         idxs: PyRwLock<Vec<usize>>,
@@ -1153,7 +1153,7 @@ mod decl {
 
     #[pyattr]
     #[pyclass(name = "combinations")]
-    #[derive(Debug, PyValue)]
+    #[derive(Debug, PyPayload)]
     struct PyItertoolsCombinations {
         pool: Vec<PyObjectRef>,
         indices: PyRwLock<Vec<usize>>,
@@ -1252,7 +1252,7 @@ mod decl {
 
     #[pyattr]
     #[pyclass(name = "combinations_with_replacement")]
-    #[derive(Debug, PyValue)]
+    #[derive(Debug, PyPayload)]
     struct PyItertoolsCombinationsWithReplacement {
         pool: Vec<PyObjectRef>,
         indices: PyRwLock<Vec<usize>>,
@@ -1338,7 +1338,7 @@ mod decl {
 
     #[pyattr]
     #[pyclass(name = "permutations")]
-    #[derive(Debug, PyValue)]
+    #[derive(Debug, PyPayload)]
     struct PyItertoolsPermutations {
         pool: Vec<PyObjectRef>,               // Collected input iterable
         indices: PyRwLock<Vec<usize>>,        // One index per element in pool
@@ -1492,7 +1492,7 @@ mod decl {
 
     #[pyattr]
     #[pyclass(name = "zip_longest")]
-    #[derive(Debug, PyValue)]
+    #[derive(Debug, PyPayload)]
     struct PyItertoolsZipLongest {
         iterators: Vec<PyIter>,
         fillvalue: PyObjectRef,
@@ -1528,7 +1528,7 @@ mod decl {
 
     #[pyattr]
     #[pyclass(name = "pairwise")]
-    #[derive(Debug, PyValue)]
+    #[derive(Debug, PyPayload)]
     struct PyItertoolsPairwise {
         iterator: PyIter,
         old: PyRwLock<Option<PyObjectRef>>,

--- a/vm/src/stdlib/operator.rs
+++ b/vm/src/stdlib/operator.rs
@@ -20,7 +20,7 @@ mod _operator {
         },
         utils::Either,
         vm::ReprGuard,
-        AsObject, PyObjectRef, PyObjectView, PyRef, PyResult, PyValue, VirtualMachine,
+        AsObject, PyObjectRef, PyObjectView, PyPayload, PyRef, PyResult, VirtualMachine,
     };
 
     /// Same as a < b.
@@ -423,7 +423,7 @@ mod _operator {
     /// (r.name.first, r.name.last).
     #[pyattr]
     #[pyclass(name = "attrgetter")]
-    #[derive(Debug, PyValue)]
+    #[derive(Debug, PyPayload)]
     struct PyAttrGetter {
         attrs: Vec<PyStrRef>,
     }
@@ -517,7 +517,7 @@ mod _operator {
     /// After g = itemgetter(2, 5, 3), the call g(r) returns (r[2], r[5], r[3])
     #[pyattr]
     #[pyclass(name = "itemgetter")]
-    #[derive(Debug, PyValue)]
+    #[derive(Debug, PyPayload)]
     struct PyItemGetter {
         items: Vec<PyObjectRef>,
     }
@@ -583,7 +583,7 @@ mod _operator {
     /// r.name('date', foo=1).
     #[pyattr]
     #[pyclass(name = "methodcaller")]
-    #[derive(Debug, PyValue)]
+    #[derive(Debug, PyPayload)]
     struct PyMethodCaller {
         name: PyStrRef,
         args: FuncArgs,

--- a/vm/src/stdlib/operator.rs
+++ b/vm/src/stdlib/operator.rs
@@ -20,7 +20,7 @@ mod _operator {
         },
         utils::Either,
         vm::ReprGuard,
-        AsObject, PyObjectRef, PyObjectView, PyPayload, PyRef, PyResult, VirtualMachine,
+        AsObject, Py, PyObjectRef, PyPayload, PyRef, PyResult, VirtualMachine,
     };
 
     /// Same as a < b.
@@ -496,7 +496,7 @@ mod _operator {
 
     impl Callable for PyAttrGetter {
         type Args = PyObjectRef;
-        fn call(zelf: &PyObjectView<Self>, obj: Self::Args, vm: &VirtualMachine) -> PyResult {
+        fn call(zelf: &Py<Self>, obj: Self::Args, vm: &VirtualMachine) -> PyResult {
             // Handle case where we only have one attribute.
             if zelf.attrs.len() == 1 {
                 return Self::get_single_attr(obj, zelf.attrs[0].as_str(), vm);
@@ -561,7 +561,7 @@ mod _operator {
 
     impl Callable for PyItemGetter {
         type Args = PyObjectRef;
-        fn call(zelf: &PyObjectView<Self>, obj: Self::Args, vm: &VirtualMachine) -> PyResult {
+        fn call(zelf: &Py<Self>, obj: Self::Args, vm: &VirtualMachine) -> PyResult {
             // Handle case where we only have one attribute.
             if zelf.items.len() == 1 {
                 return obj.get_item(zelf.items[0].clone(), vm);
@@ -659,7 +659,7 @@ mod _operator {
         type Args = PyObjectRef;
 
         #[inline]
-        fn call(zelf: &PyObjectView<Self>, obj: Self::Args, vm: &VirtualMachine) -> PyResult {
+        fn call(zelf: &Py<Self>, obj: Self::Args, vm: &VirtualMachine) -> PyResult {
             vm.call_method(&obj, zelf.name.as_str(), zelf.args.clone())
         }
     }

--- a/vm/src/stdlib/os.rs
+++ b/vm/src/stdlib/os.rs
@@ -4,7 +4,7 @@ use crate::{
     crt_fd::Fd,
     function::{ArgumentError, FromArgs, FuncArgs},
     protocol::PyBuffer,
-    AsObject, PyObject, PyObjectRef, PyResult, PyValue, TryFromBorrowedObject, TryFromObject,
+    AsObject, PyObject, PyObjectRef, PyPayload, PyResult, TryFromBorrowedObject, TryFromObject,
     VirtualMachine,
 };
 use std::{
@@ -416,7 +416,7 @@ pub(super) mod _os {
         types::{IterNext, IterNextIterable, PyStructSequence},
         utils::Either,
         vm::{ReprGuard, VirtualMachine},
-        AsObject, PyObjectRef, PyRef, PyResult, PyValue, TryFromObject,
+        AsObject, PyObjectRef, PyPayload, PyRef, PyResult, TryFromObject,
     };
     use crossbeam_utils::atomic::AtomicCell;
     use itertools::Itertools;
@@ -703,7 +703,7 @@ pub(super) mod _os {
 
     #[pyattr]
     #[pyclass(name)]
-    #[derive(Debug, PyValue)]
+    #[derive(Debug, PyPayload)]
     struct DirEntry {
         entry: fs::DirEntry,
         mode: OutputMode,
@@ -875,7 +875,7 @@ pub(super) mod _os {
 
     #[pyattr]
     #[pyclass(name = "ScandirIter")]
-    #[derive(Debug, PyValue)]
+    #[derive(Debug, PyPayload)]
     struct ScandirIterator {
         entries: PyRwLock<fs::ReadDir>,
         exhausted: AtomicCell<bool>,

--- a/vm/src/stdlib/os.rs
+++ b/vm/src/stdlib/os.rs
@@ -901,7 +901,7 @@ pub(super) mod _os {
     }
     impl IterNextIterable for ScandirIterator {}
     impl IterNext for ScandirIterator {
-        fn next(zelf: &crate::PyObjectView<Self>, vm: &VirtualMachine) -> PyResult<PyIterReturn> {
+        fn next(zelf: &crate::Py<Self>, vm: &VirtualMachine) -> PyResult<PyIterReturn> {
             if zelf.exhausted.load() {
                 return Ok(PyIterReturn::StopIteration(None));
             }

--- a/vm/src/stdlib/posix.rs
+++ b/vm/src/stdlib/posix.rs
@@ -38,7 +38,7 @@ pub mod module {
         },
         types::Constructor,
         utils::{Either, ToCString},
-        AsObject, PyObjectRef, PyResult, PyValue, VirtualMachine,
+        AsObject, PyObjectRef, PyPayload, PyResult, VirtualMachine,
     };
     use bitflags::bitflags;
     use nix::{
@@ -522,7 +522,7 @@ pub mod module {
 
     #[pyattr]
     #[pyclass(name = "sched_param")]
-    #[derive(Debug, PyValue)]
+    #[derive(Debug, PyPayload)]
     struct SchedParam {
         sched_priority: PyObjectRef,
     }

--- a/vm/src/stdlib/sre.rs
+++ b/vm/src/stdlib/sre.rs
@@ -13,7 +13,7 @@ mod _sre {
         protocol::{PyBuffer, PyMappingMethods},
         stdlib::sys,
         types::{AsMapping, Comparable, Hashable},
-        PyObject, PyObjectRef, PyRef, PyResult, PyValue, TryFromBorrowedObject, TryFromObject,
+        PyObject, PyObjectRef, PyPayload, PyRef, PyResult, TryFromBorrowedObject, TryFromObject,
         VirtualMachine,
     };
     use core::str;
@@ -123,7 +123,7 @@ mod _sre {
 
     #[pyattr]
     #[pyclass(name = "Pattern")]
-    #[derive(Debug, PyValue)]
+    #[derive(Debug, PyPayload)]
     pub(crate) struct Pattern {
         pub pattern: PyObjectRef,
         pub flags: SreFlag,
@@ -541,7 +541,7 @@ mod _sre {
 
     #[pyattr]
     #[pyclass(name = "Match")]
-    #[derive(Debug, PyValue)]
+    #[derive(Debug, PyPayload)]
     pub(crate) struct Match {
         string: PyObjectRef,
         pattern: PyRef<Pattern>,
@@ -800,7 +800,7 @@ mod _sre {
 
     #[pyattr]
     #[pyclass(name = "SRE_Scanner")]
-    #[derive(Debug, PyValue)]
+    #[derive(Debug, PyPayload)]
     struct SreScanner {
         pattern: PyRef<Pattern>,
         string: PyObjectRef,

--- a/vm/src/stdlib/sre.rs
+++ b/vm/src/stdlib/sre.rs
@@ -504,7 +504,7 @@ mod _sre {
     }
 
     impl Hashable for Pattern {
-        fn hash(zelf: &crate::PyObjectView<Self>, vm: &VirtualMachine) -> PyResult<PyHash> {
+        fn hash(zelf: &crate::Py<Self>, vm: &VirtualMachine) -> PyResult<PyHash> {
             let hash = zelf.pattern.hash(vm)?;
             let (_, code, _) = unsafe { zelf.code.align_to::<u8>() };
             let hash = hash ^ vm.state.hash_secret.hash_bytes(code);
@@ -516,7 +516,7 @@ mod _sre {
 
     impl Comparable for Pattern {
         fn cmp(
-            zelf: &crate::PyObjectView<Self>,
+            zelf: &crate::Py<Self>,
             other: &PyObject,
             op: crate::types::PyComparisonOp,
             vm: &VirtualMachine,
@@ -793,7 +793,7 @@ mod _sre {
     }
 
     impl AsMapping for Match {
-        fn as_mapping(_zelf: &crate::PyObjectView<Self>, _vm: &VirtualMachine) -> PyMappingMethods {
+        fn as_mapping(_zelf: &crate::Py<Self>, _vm: &VirtualMachine) -> PyMappingMethods {
             Self::MAPPING_METHODS
         }
     }

--- a/vm/src/stdlib/symtable.rs
+++ b/vm/src/stdlib/symtable.rs
@@ -5,7 +5,7 @@ mod symtable {
     use crate::{
         builtins::PyStrRef,
         compile::{self, Symbol, SymbolScope, SymbolTable, SymbolTableType},
-        PyObjectRef, PyRef, PyResult, PyValue, VirtualMachine,
+        PyObjectRef, PyPayload, PyRef, PyResult, VirtualMachine,
     };
     use std::fmt;
 
@@ -39,7 +39,7 @@ mod symtable {
 
     #[pyattr]
     #[pyclass(name = "SymbolTable")]
-    #[derive(PyValue)]
+    #[derive(PyPayload)]
     struct PySymbolTable {
         symtable: SymbolTable,
     }
@@ -151,7 +151,7 @@ mod symtable {
 
     #[pyattr]
     #[pyclass(name = "Symbol")]
-    #[derive(PyValue)]
+    #[derive(PyPayload)]
     struct PySymbol {
         symbol: Symbol,
         namespaces: Vec<SymbolTable>,

--- a/vm/src/stdlib/thread.rs
+++ b/vm/src/stdlib/thread.rs
@@ -11,7 +11,7 @@ pub(crate) mod _thread {
         py_io,
         types::{Constructor, GetAttr, SetAttr},
         utils::Either,
-        AsObject, PyObjectRef, PyRef, PyResult, PyValue, VirtualMachine,
+        AsObject, PyObjectRef, PyPayload, PyRef, PyResult, VirtualMachine,
     };
     use parking_lot::{
         lock_api::{RawMutex as RawMutexT, RawMutexTimed, RawReentrantMutex},
@@ -95,7 +95,7 @@ pub(crate) mod _thread {
 
     #[pyattr(name = "LockType")]
     #[pyclass(module = "thread", name = "lock")]
-    #[derive(PyValue)]
+    #[derive(PyPayload)]
     struct Lock {
         mu: RawMutex,
     }
@@ -150,7 +150,7 @@ pub(crate) mod _thread {
     pub type RawRMutex = RawReentrantMutex<RawMutex, RawThreadId>;
     #[pyattr]
     #[pyclass(module = "thread", name = "RLock")]
-    #[derive(PyValue)]
+    #[derive(PyPayload)]
     struct RLock {
         mu: RawRMutex,
     }
@@ -305,7 +305,7 @@ pub(crate) mod _thread {
 
     #[pyattr]
     #[pyclass(module = "thread", name = "_local")]
-    #[derive(Debug, PyValue)]
+    #[derive(Debug, PyPayload)]
     struct Local {
         data: ThreadLocal<PyDictRef>,
     }

--- a/vm/src/stdlib/thread.rs
+++ b/vm/src/stdlib/thread.rs
@@ -345,7 +345,7 @@ pub(crate) mod _thread {
 
     impl SetAttr for Local {
         fn setattro(
-            zelf: &crate::PyObjectView<Self>,
+            zelf: &crate::Py<Self>,
             attr: PyStrRef,
             value: Option<PyObjectRef>,
             vm: &VirtualMachine,

--- a/vm/src/stdlib/weakref.rs
+++ b/vm/src/stdlib/weakref.rs
@@ -8,8 +8,10 @@ pub(crate) use _weakref::make_module;
 
 #[pymodule]
 mod _weakref {
-    use crate::builtins::{PyDictRef, PyTypeRef, PyWeak};
-    use crate::{PyObjectRef, PyRef, PyResult, VirtualMachine};
+    use crate::{
+        builtins::{PyDictRef, PyTypeRef, PyWeak},
+        PyObjectRef, PyResult, VirtualMachine,
+    };
 
     #[pyattr(name = "ref")]
     fn ref_(vm: &VirtualMachine) -> PyTypeRef {
@@ -40,7 +42,7 @@ mod _weakref {
     #[pyfunction]
     fn getweakrefs(obj: PyObjectRef) -> Vec<PyObjectRef> {
         match obj.get_weak_references() {
-            Some(v) => v.into_iter().map(|weak| PyRef::from(weak).into()).collect(),
+            Some(v) => v.into_iter().map(Into::into).collect(),
             None => vec![],
         }
     }

--- a/vm/src/stdlib/winreg.rs
+++ b/vm/src/stdlib/winreg.rs
@@ -29,7 +29,7 @@ pub(crate) fn make_module(vm: &VirtualMachine) -> PyObjectRef {
 mod winreg {
     use crate::common::lock::{PyRwLock, PyRwLockReadGuard, PyRwLockWriteGuard};
     use crate::{
-        builtins::PyStrRef, convert::ToPyException, PyObjectRef, PyRef, PyResult, PyValue,
+        builtins::PyStrRef, convert::ToPyException, PyObjectRef, PyPayload, PyRef, PyResult,
         TryFromObject, VirtualMachine,
     };
     use ::winreg::{enums::RegType, RegKey, RegValue};
@@ -53,7 +53,7 @@ mod winreg {
 
     #[pyattr]
     #[pyclass(module = "winreg", name = "HKEYType")]
-    #[derive(Debug, PyValue)]
+    #[derive(Debug, PyPayload)]
     struct PyHkey {
         key: PyRwLock<RegKey>,
     }

--- a/vm/src/suggestion.rs
+++ b/vm/src/suggestion.rs
@@ -2,7 +2,7 @@ use crate::{
     builtins::{PyStr, PyStrRef},
     exceptions::types::PyBaseExceptionRef,
     sliceable::SliceableSequenceOp,
-    AsObject, PyObjectRef, PyObjectView, VirtualMachine,
+    AsObject, Py, PyObjectRef, VirtualMachine,
 };
 use rustpython_common::str::levenshtein::{levenshtein_distance, MOVE_COST};
 use std::iter::ExactSizeIterator;
@@ -17,7 +17,7 @@ fn calculate_suggestions<'a>(
         return None;
     }
 
-    let mut suggestion: Option<&PyObjectView<PyStr>> = None;
+    let mut suggestion: Option<&Py<PyStr>> = None;
     let mut suggestion_distance = usize::MAX;
     let name = name.downcast_ref::<PyStr>()?;
 

--- a/vm/src/types/slot.rs
+++ b/vm/src/types/slot.rs
@@ -8,7 +8,7 @@ use crate::{
         PyBuffer, PyIterReturn, PyMapping, PyMappingMethods, PySequence, PySequenceMethods,
     },
     utils::Either,
-    AsObject, PyObject, PyObjectRef, PyObjectView, PyRef, PyResult, PyValue, VirtualMachine,
+    AsObject, PyObject, PyObjectRef, PyObjectView, PyPayload, PyRef, PyResult, VirtualMachine,
 };
 use crossbeam_utils::atomic::AtomicCell;
 use num_traits::{Signed, ToPrimitive};
@@ -392,7 +392,7 @@ impl PyType {
 }
 
 #[pyimpl]
-pub trait Constructor: PyValue {
+pub trait Constructor: PyPayload {
     type Args: FromArgs;
 
     #[inline]
@@ -406,7 +406,7 @@ pub trait Constructor: PyValue {
 }
 
 /// For types that cannot be instantiated through Python code.
-pub trait Unconstructible: PyValue {}
+pub trait Unconstructible: PyPayload {}
 
 impl<T> Constructor for T
 where
@@ -420,7 +420,7 @@ where
 }
 
 #[pyimpl]
-pub trait Destructor: PyValue {
+pub trait Destructor: PyPayload {
     #[inline] // for __del__
     #[pyslot]
     fn slot_del(zelf: &PyObject, vm: &VirtualMachine) -> PyResult<()> {
@@ -440,7 +440,7 @@ pub trait Destructor: PyValue {
 }
 
 #[pyimpl]
-pub trait Callable: PyValue {
+pub trait Callable: PyPayload {
     type Args: FromArgs;
 
     #[inline]
@@ -462,7 +462,7 @@ pub trait Callable: PyValue {
 }
 
 #[pyimpl]
-pub trait GetDescriptor: PyValue {
+pub trait GetDescriptor: PyPayload {
     #[pyslot]
     fn descr_get(
         zelf: PyObjectRef,
@@ -530,7 +530,7 @@ pub trait GetDescriptor: PyValue {
 }
 
 #[pyimpl]
-pub trait Hashable: PyValue {
+pub trait Hashable: PyPayload {
     #[inline]
     #[pyslot]
     fn slot_hash(zelf: &PyObject, vm: &VirtualMachine) -> PyResult<PyHash> {
@@ -550,7 +550,7 @@ pub trait Hashable: PyValue {
     fn hash(zelf: &PyObjectView<Self>, vm: &VirtualMachine) -> PyResult<PyHash>;
 }
 
-pub trait Unhashable: PyValue {}
+pub trait Unhashable: PyPayload {}
 
 impl<T> Hashable for T
 where
@@ -567,7 +567,7 @@ where
 }
 
 #[pyimpl]
-pub trait Comparable: PyValue {
+pub trait Comparable: PyPayload {
     #[inline]
     #[pyslot]
     fn slot_richcompare(
@@ -748,7 +748,7 @@ impl PyComparisonOp {
 }
 
 #[pyimpl]
-pub trait GetAttr: PyValue {
+pub trait GetAttr: PyPayload {
     #[pyslot]
     fn slot_getattro(obj: PyObjectRef, name: PyStrRef, vm: &VirtualMachine) -> PyResult {
         if let Ok(zelf) = obj.downcast::<Self>() {
@@ -769,7 +769,7 @@ pub trait GetAttr: PyValue {
 }
 
 #[pyimpl]
-pub trait SetAttr: PyValue {
+pub trait SetAttr: PyPayload {
     #[pyslot]
     #[inline]
     fn slot_setattro(
@@ -811,7 +811,7 @@ pub trait SetAttr: PyValue {
 }
 
 #[pyimpl]
-pub trait AsBuffer: PyValue {
+pub trait AsBuffer: PyPayload {
     // TODO: `flags` parameter
     #[inline]
     #[pyslot]
@@ -826,7 +826,7 @@ pub trait AsBuffer: PyValue {
 }
 
 #[pyimpl]
-pub trait AsMapping: PyValue {
+pub trait AsMapping: PyPayload {
     #[inline]
     #[pyslot]
     fn slot_as_mapping(zelf: &PyObject, vm: &VirtualMachine) -> PyMappingMethods {
@@ -842,7 +842,7 @@ pub trait AsMapping: PyValue {
 }
 
 #[pyimpl]
-pub trait AsSequence: PyValue {
+pub trait AsSequence: PyPayload {
     #[inline]
     #[pyslot]
     fn slot_as_sequence(zelf: &PyObject, vm: &VirtualMachine) -> Cow<'static, PySequenceMethods> {
@@ -861,7 +861,7 @@ pub trait AsSequence: PyValue {
 }
 
 #[pyimpl]
-pub trait Iterable: PyValue {
+pub trait Iterable: PyPayload {
     #[pyslot]
     #[pymethod(name = "__iter__")]
     fn slot_iter(zelf: PyObjectRef, vm: &VirtualMachine) -> PyResult {
@@ -877,7 +877,7 @@ pub trait Iterable: PyValue {
 
 // `Iterator` fits better, but to avoid confusion with rust std::iter::Iterator
 #[pyimpl(with(Iterable))]
-pub trait IterNext: PyValue + Iterable {
+pub trait IterNext: PyPayload + Iterable {
     #[pyslot]
     fn slot_iternext(zelf: &PyObject, vm: &VirtualMachine) -> PyResult<PyIterReturn> {
         if let Some(zelf) = zelf.downcast_ref() {
@@ -896,7 +896,7 @@ pub trait IterNext: PyValue + Iterable {
     }
 }
 
-pub trait IterNextIterable: PyValue {}
+pub trait IterNextIterable: PyPayload {}
 
 impl<T> Iterable for T
 where

--- a/vm/src/types/structseq.rs
+++ b/vm/src/types/structseq.rs
@@ -2,7 +2,7 @@ use crate::{
     builtins::{PyTuple, PyTupleRef, PyTypeRef},
     pyclass::{PyClassImpl, StaticType},
     pyobject::PyContext,
-    AsObject, PyObjectRef, PyRef, PyResult, PyValue, VirtualMachine,
+    AsObject, PyObjectRef, PyPayload, PyRef, PyResult, VirtualMachine,
 };
 
 #[pyimpl]

--- a/vm/src/vm.rs
+++ b/vm/src/vm.rs
@@ -24,8 +24,8 @@ use crate::{
     import,
     protocol::PyIterIter,
     scope::Scope,
-    signal, stdlib, AsObject, PyContext, PyObject, PyObjectRef, PyRef, PyRefExact, PyResult,
-    PyValue,
+    signal, stdlib, AsObject, PyContext, PyObject, PyObjectRef, PyPayload, PyRef, PyRefExact,
+    PyResult,
 };
 use crossbeam_utils::atomic::AtomicCell;
 use std::{

--- a/vm/src/vm_new.rs
+++ b/vm/src/vm_new.rs
@@ -10,7 +10,7 @@ use crate::{
     convert::ToPyObject,
     scope::Scope,
     vm::VirtualMachine,
-    AsObject, PyObject, PyObjectRef, PyRef, PyValue,
+    AsObject, PyObject, PyObjectRef, PyPayload, PyRef,
 };
 
 /// Collection of object creation helpers
@@ -23,7 +23,7 @@ impl VirtualMachine {
     pub fn new_pyref<T, P>(&self, value: T) -> PyRef<P>
     where
         T: Into<P>,
-        P: PyValue,
+        P: PyPayload,
     {
         value.into().into_ref(self)
     }

--- a/vm/src/vm_object.rs
+++ b/vm/src/vm_object.rs
@@ -2,7 +2,7 @@ use crate::{
     builtins::{PyBaseExceptionRef, PyList, PyStr},
     function::{FuncArgs, IntoFuncArgs},
     vm::VirtualMachine,
-    AsObject, PyMethod, PyObject, PyObjectRef, PyResult, PyValue,
+    AsObject, PyMethod, PyObject, PyObjectRef, PyPayload, PyResult,
 };
 
 /// Trace events for sys.settrace and sys.setprofile.

--- a/wasm/lib/src/browser_module.rs
+++ b/wasm/lib/src/browser_module.rs
@@ -12,7 +12,7 @@ mod _browser {
         function::{ArgCallable, OptionalArg},
         import::import_file,
         pyclass::PyClassImpl,
-        PyObjectRef, PyRef, PyResult, PyValue, VirtualMachine,
+        PyObjectRef, PyPayload, PyRef, PyResult, VirtualMachine,
     };
     use wasm_bindgen::{prelude::*, JsCast};
     use wasm_bindgen_futures::JsFuture;
@@ -161,7 +161,7 @@ mod _browser {
 
     #[pyattr]
     #[pyclass(module = "browser", name)]
-    #[derive(Debug, PyValue)]
+    #[derive(Debug, PyPayload)]
     struct Document {
         doc: web_sys::Document,
     }
@@ -193,7 +193,7 @@ mod _browser {
 
     #[pyattr]
     #[pyclass(module = "browser", name)]
-    #[derive(Debug, PyValue)]
+    #[derive(Debug, PyPayload)]
     struct Element {
         elem: web_sys::Element,
     }

--- a/wasm/lib/src/convert.rs
+++ b/wasm/lib/src/convert.rs
@@ -7,7 +7,7 @@ use rustpython_vm::{
     compile::{CompileError, CompileErrorType},
     exceptions,
     function::{ArgBytesLike, FuncArgs},
-    py_serde, AsObject, PyObjectRef, PyResult, PyValue, TryFromBorrowedObject, VirtualMachine,
+    py_serde, AsObject, PyObjectRef, PyPayload, PyResult, TryFromBorrowedObject, VirtualMachine,
 };
 use wasm_bindgen::{closure::Closure, prelude::*, JsCast};
 

--- a/wasm/lib/src/js_module.rs
+++ b/wasm/lib/src/js_module.rs
@@ -18,7 +18,7 @@ mod _js {
         function::{ArgCallable, OptionalArg, OptionalOption, PosArgs},
         protocol::PyIterReturn,
         types::{IterNext, IterNextIterable},
-        PyObjectRef, PyObjectView, PyRef, PyResult, PyValue, TryFromObject, VirtualMachine,
+        PyObjectRef, PyObjectView, PyPayload, PyRef, PyResult, TryFromObject, VirtualMachine,
     };
     use std::{cell, fmt, future};
     use wasm_bindgen::{closure::Closure, prelude::*, JsCast};
@@ -59,7 +59,7 @@ mod _js {
 
     #[pyattr]
     #[pyclass(module = "_js", name = "JSValue")]
-    #[derive(Debug, PyValue)]
+    #[derive(Debug, PyPayload)]
     pub struct PyJsValue {
         pub(crate) value: JsValue,
     }
@@ -291,7 +291,7 @@ mod _js {
 
     #[pyattr]
     #[pyclass(module = "_js", name = "JSClosure")]
-    #[derive(PyValue)]
+    #[derive(PyPayload)]
     struct JsClosure {
         closure: cell::RefCell<Option<(ClosureType, PyJsValueRef)>>,
         destroyed: cell::Cell<bool>,
@@ -386,7 +386,7 @@ mod _js {
 
     #[pyattr]
     #[pyclass(module = "_js", name = "Promise")]
-    #[derive(Debug, Clone, PyValue)]
+    #[derive(Debug, Clone, PyPayload)]
     pub struct PyPromise {
         value: PromiseKind,
     }
@@ -558,7 +558,7 @@ mod _js {
     }
 
     #[pyclass(noattr, module = "_js", name = "AwaitPromise")]
-    #[derive(PyValue)]
+    #[derive(PyPayload)]
     struct AwaitPromise {
         obj: cell::Cell<Option<PyObjectRef>>,
     }

--- a/wasm/lib/src/js_module.rs
+++ b/wasm/lib/src/js_module.rs
@@ -18,7 +18,7 @@ mod _js {
         function::{ArgCallable, OptionalArg, OptionalOption, PosArgs},
         protocol::PyIterReturn,
         types::{IterNext, IterNextIterable},
-        PyObjectRef, PyObjectView, PyPayload, PyRef, PyResult, TryFromObject, VirtualMachine,
+        Py, PyObjectRef, PyPayload, PyRef, PyResult, TryFromObject, VirtualMachine,
     };
     use std::{cell, fmt, future};
     use wasm_bindgen::{closure::Closure, prelude::*, JsCast};
@@ -606,7 +606,7 @@ mod _js {
 
     impl IterNextIterable for AwaitPromise {}
     impl IterNext for AwaitPromise {
-        fn next(zelf: &PyObjectView<Self>, vm: &VirtualMachine) -> PyResult<PyIterReturn> {
+        fn next(zelf: &Py<Self>, vm: &VirtualMachine) -> PyResult<PyIterReturn> {
             zelf.send(None, vm)
         }
     }

--- a/wasm/lib/src/vm_class.rs
+++ b/wasm/lib/src/vm_class.rs
@@ -8,7 +8,8 @@ use rustpython_vm::{
     builtins::PyWeak,
     compile::{self, Mode},
     scope::Scope,
-    InitParameter, Interpreter, PyObjectRef, PyRef, PyResult, PySettings, PyValue, VirtualMachine,
+    InitParameter, Interpreter, PyObjectRef, PyPayload, PyRef, PyResult, PySettings,
+    VirtualMachine,
 };
 use std::{
     cell::RefCell,

--- a/wasm/lib/src/vm_class.rs
+++ b/wasm/lib/src/vm_class.rs
@@ -5,10 +5,10 @@ use crate::{
 };
 use js_sys::{Object, TypeError};
 use rustpython_vm::{
+    builtins::PyWeak,
     compile::{self, Mode},
     scope::Scope,
-    InitParameter, Interpreter, PyObjectRef, PyObjectWeak, PyResult, PySettings, PyValue,
-    VirtualMachine,
+    InitParameter, Interpreter, PyObjectRef, PyRef, PyResult, PySettings, PyValue, VirtualMachine,
 };
 use std::{
     cell::RefCell,
@@ -197,7 +197,10 @@ impl WASMVirtualMachine {
         STORED_VMS.with(|cell| cell.borrow().contains_key(&self.id))
     }
 
-    pub(crate) fn push_held_rc(&self, obj: PyObjectRef) -> Result<PyResult<PyObjectWeak>, JsValue> {
+    pub(crate) fn push_held_rc(
+        &self,
+        obj: PyObjectRef,
+    ) -> Result<PyResult<PyRef<PyWeak>>, JsValue> {
         self.with_vm(|vm, stored_vm| {
             let weak = obj.downgrade(None, vm)?;
             stored_vm.held_objects.borrow_mut().push(obj);


### PR DESCRIPTION
As I remember, the name `Py` was @coolreader18's idea, right?

After reviewing their relationships, I agree this is a consistent and not confusing name than now, by showing their relationships in the name.

closes #3631