### PR TITLE
Changed the drain into into_iter on types.rs

### DIFF
--- a/vm/src/builtins/type.rs
+++ b/vm/src/builtins/type.rs
@@ -267,7 +267,7 @@ impl PyType {
     fn dir(zelf: PyRef<Self>, vm: &VirtualMachine) -> PyList {
         let attributes: Vec<PyObjectRef> = zelf
             .get_attributes()
-            .drain(..)
+            .into_iter()
             .map(|(k, _)| vm.ctx.new_str(k).into())
             .collect();
         PyList::from(attributes)


### PR DESCRIPTION
I have changed the drain(..) to into_inter() as discussed in #3660 . 