### PR TITLE
Add compile::Mode::BlockExpr

### DIFF
--- a/compiler/src/mode.rs
+++ b/compiler/src/mode.rs
@@ -3,10 +3,13 @@ pub enum Mode {
     Exec,
     Eval,
     Single,
+    BlockExpr,
 }
 
 impl std::str::FromStr for Mode {
     type Err = ModeParseError;
+
+    // To support `builtins.compile()` `mode` argument
     fn from_str(s: &str) -> Result<Self, ModeParseError> {
         match s {
             "exec" => Ok(Mode::Exec),

--- a/vm/src/stdlib/ast.rs
+++ b/vm/src/stdlib/ast.rs
@@ -269,13 +269,14 @@ pub(crate) fn compile(
     vm: &VirtualMachine,
     object: PyObjectRef,
     filename: &str,
-    _mode: compile::Mode,
+    mode: compile::Mode,
 ) -> PyResult {
     let opts = vm.compile_opts();
     let ast = Node::ast_from_object(vm, object)?;
-    let code = rustpython_compiler_core::compile::compile_top(&ast, filename.to_owned(), opts)
-        // TODO: use vm.new_syntax_error()
-        .map_err(|err| vm.new_value_error(err.to_string()))?;
+    let code =
+        rustpython_compiler_core::compile::compile_top(&ast, filename.to_owned(), mode, opts)
+            // TODO: use vm.new_syntax_error()
+            .map_err(|err| vm.new_value_error(err.to_string()))?;
     Ok(vm.ctx.new_code(code).into())
 }
 

--- a/vm/src/vm/mod.rs
+++ b/vm/src/vm/mod.rs
@@ -767,6 +767,18 @@ impl VirtualMachine {
         self.run_code_obj(code_obj, scope)
     }
 
+    pub fn run_block_expr(&self, scope: Scope, source: &str) -> PyResult {
+        let code_obj = self
+            .compile(
+                source,
+                crate::compile::Mode::BlockExpr,
+                "<embedded>".to_owned(),
+            )
+            .map_err(|err| self.new_syntax_error(&err))?;
+        // trace!("Code object: {:?}", code_obj.borrow());
+        self.run_code_obj(code_obj, scope)
+    }
+
     pub fn run_module(&self, module: &str) -> PyResult<()> {
         let runpy = self.import("runpy", None, 0)?;
         let run_module_as_main = runpy.get_attr("_run_module_as_main", self)?;


### PR DESCRIPTION
This is helpful to evaluate python code and get expression back

example: https://github.com/RustPython/RustPython/pull/3667/commits/718b013201423b6d2b5e7afddaf95d85303eb256