### PR TITLE
Changed pyclass name of PyArray and PyArrayIter #3612

### DIFF
--- a/extra_tests/snippets/stdlib_array.py
+++ b/extra_tests/snippets/stdlib_array.py
@@ -105,12 +105,3 @@ u = array('u', test_str)
 if u.itemsize >= 4:
     assert u.__reduce_ex__(1)[1][1] == list(test_str)
     assert loads(dumps(u, 1)) == loads(dumps(u, 3))
-
-# test array name
-a = array('b', [])
-assert str(a.__class__) == "<class 'array.array'>"
-assert str(a.__class__.__name__) == "array"
-# test arrayiterator name
-i = iter(a)
-assert str(i.__class__) == "<class 'arrayiterator'>"
-assert str(i.__class__.__name__) == "arrayiterator"

--- a/extra_tests/snippets/stdlib_array.py
+++ b/extra_tests/snippets/stdlib_array.py
@@ -105,3 +105,12 @@ u = array('u', test_str)
 if u.itemsize >= 4:
     assert u.__reduce_ex__(1)[1][1] == list(test_str)
     assert loads(dumps(u, 1)) == loads(dumps(u, 3))
+
+# test array name
+a = array('b', [])
+assert str(a.__class__) == "<class 'array.array'>"
+assert str(a.__class__.__name__) == "array"
+# test arrayiterator name
+i = iter(a)
+assert str(i.__class__) == "<class 'arrayiterator'>"
+assert str(i.__class__.__name__) == "arrayiterator"

--- a/extra_tests/snippets/stdlib_array.py
+++ b/extra_tests/snippets/stdlib_array.py
@@ -105,3 +105,10 @@ u = array('u', test_str)
 if u.itemsize >= 4:
     assert u.__reduce_ex__(1)[1][1] == list(test_str)
     assert loads(dumps(u, 1)) == loads(dumps(u, 3))
+
+# test array name
+a = array('b', [])
+assert str(a.__class__.__name__) == "array"
+# test arrayiterator name
+i = iter(a)
+assert str(i.__class__.__name__) == "arrayiterator"

--- a/stdlib/src/array.rs
+++ b/stdlib/src/array.rs
@@ -1280,7 +1280,7 @@ mod array {
     }
 
     #[pyattr]
-    #[pyclass(name = "array_iterator")]
+    #[pyclass(name = "arrayiterator")]
     #[derive(Debug, PyPayload)]
     pub struct PyArrayIter {
         position: AtomicUsize,

--- a/stdlib/src/array.rs
+++ b/stdlib/src/array.rs
@@ -581,7 +581,7 @@ mod array {
     }
 
     #[pyattr]
-    #[pyclass(name = "array.array")]
+    #[pyclass(name = "array")]
     #[derive(Debug, PyPayload)]
     pub struct PyArray {
         array: PyRwLock<ArrayContentType>,
@@ -1280,7 +1280,7 @@ mod array {
     }
 
     #[pyattr]
-    #[pyclass(name = "arrayiterator")]
+    #[pyclass(name = "array_iterator")]
     #[derive(Debug, PyPayload)]
     pub struct PyArrayIter {
         position: AtomicUsize,

--- a/stdlib/src/array.rs
+++ b/stdlib/src/array.rs
@@ -581,7 +581,7 @@ mod array {
     }
 
     #[pyattr]
-    #[pyclass(name = "array")]
+    #[pyclass(name = "array.array")]
     #[derive(Debug, PyPayload)]
     pub struct PyArray {
         array: PyRwLock<ArrayContentType>,
@@ -1280,7 +1280,7 @@ mod array {
     }
 
     #[pyattr]
-    #[pyclass(name = "array_iterator")]
+    #[pyclass(name = "arrayiterator")]
     #[derive(Debug, PyPayload)]
     pub struct PyArrayIter {
         position: AtomicUsize,


### PR DESCRIPTION
Resolves #3612 

The issue is

> The name of array.array iterator has to be array_iterator but arrayiterator in RustPython.

but it is "The name of array.array iterator has to be **arrayiterator** but **array_iterator** in RustPython", right?

and I also changed also PyArray's name, 
because it looks different from [CPython's](https://github.com/python/cpython/blob/3.8/Modules/arraymodule.c#L2838).
