### PR TITLE
Switch clippy to beta

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -220,7 +220,7 @@ jobs:
       - uses: actions-rs/toolchain@v1
         with:
             profile: minimal
-            toolchain: nightly
+            toolchain: beta
             components: rustfmt, clippy
             override: true
       - name: run rustfmt


### PR DESCRIPTION
Once 1.62 is relased, we can switch back to stable.
