### PR TITLE
Fixed `test_bytearray_translate` Error

### DIFF
--- a/Lib/test/test_builtin.py
+++ b/Lib/test/test_builtin.py
@@ -1695,8 +1695,6 @@ class BuiltinTest(unittest.TestCase):
         self.assertEqual(bin(-(2**65)), '-0b1' + '0' * 65)
         self.assertEqual(bin(-(2**65-1)), '-0b' + '1' * 65)
 
-    # TODO: RUSTPYTHON
-    @unittest.expectedFailure
     def test_bytearray_translate(self):
         x = bytearray(b"abc")
         self.assertRaises(ValueError, x.translate, b"1", 1)

--- a/vm/src/bytesinner.rs
+++ b/vm/src/bytesinner.rs
@@ -211,7 +211,7 @@ impl ByteInnerTranslateOptions {
     pub fn get_value(self, vm: &VirtualMachine) -> PyResult<(Vec<u8>, Vec<u8>)> {
         let table = self.table.map_or_else(
             || Ok((0..=255).collect::<Vec<u8>>()),
-            |v: PyObjectRef| {
+            |v| {
                 let bytes = v
                     .try_into_value::<PyBytesInner>(vm)
                     .ok()


### PR DESCRIPTION
FileName: `test_builtin.py`
FunctionName: `test_bytearray_translate`
Error: RustPython was throwing wrong `Error`, RustPython was throwing `TypeError`