### PR TITLE
Add weak proxy str

### DIFF
--- a/Lib/test/test_deque.py
+++ b/Lib/test/test_deque.py
@@ -889,8 +889,6 @@ class TestSubclass(unittest.TestCase):
             for d in DequeWithBadIter('abc'), DequeWithBadIter('abc', 2):
                 self.assertRaises(TypeError, pickle.dumps, d, proto)
 
-    # TODO: RUSTPYTHON
-    @unittest.expectedFailure
     def test_weakref(self):
         d = deque('gallahad')
         p = weakref.proxy(d)

--- a/Lib/test/test_set.py
+++ b/Lib/test/test_set.py
@@ -613,8 +613,6 @@ class TestSet(TestJointOps, unittest.TestCase):
         t ^= t
         self.assertEqual(t, self.thetype())
 
-    # TODO: RUSTPYTHON
-    @unittest.expectedFailure
     def test_weakref(self):
         s = self.thetype('gallahad')
         p = weakref.proxy(s)

--- a/vm/src/builtins/weakproxy.rs
+++ b/vm/src/builtins/weakproxy.rs
@@ -70,6 +70,16 @@ impl PyWeakProxy {
         })?;
         obj.get_attr(attr_name, vm)
     }
+    #[pymethod(magic)]
+    fn str(&self, vm: &VirtualMachine) -> PyResult<PyStrRef> {
+        match self.weak.upgrade() {
+            Some(obj) => obj.str(vm),
+            None => Err(vm.new_exception_msg(
+                vm.ctx.exceptions.reference_error.clone(),
+                "weakly-referenced object no longer exists".to_owned(),
+            )),
+        }
+    }
 }
 
 impl SetAttr for PyWeakProxy {

--- a/vm/src/builtins/weakproxy.rs
+++ b/vm/src/builtins/weakproxy.rs
@@ -62,24 +62,23 @@ impl PyWeakProxy {
     // TODO: callbacks
     #[pymethod(magic)]
     fn getattr(&self, attr_name: PyStrRef, vm: &VirtualMachine) -> PyResult {
-        let obj = self.weak.upgrade().ok_or_else(|| {
-            vm.new_exception_msg(
-                vm.ctx.exceptions.reference_error.clone(),
-                "weakly-referenced object no longer exists".to_owned(),
-            )
-        })?;
+        let obj = self.weak.upgrade().ok_or_else(|| new_reference_error(vm))?;
         obj.get_attr(attr_name, vm)
     }
     #[pymethod(magic)]
     fn str(&self, vm: &VirtualMachine) -> PyResult<PyStrRef> {
         match self.weak.upgrade() {
             Some(obj) => obj.str(vm),
-            None => Err(vm.new_exception_msg(
-                vm.ctx.exceptions.reference_error.clone(),
-                "weakly-referenced object no longer exists".to_owned(),
-            )),
+            None => Err(new_reference_error(vm)),
         }
     }
+}
+
+fn new_reference_error(vm: &VirtualMachine) -> PyRef<super::PyBaseException> {
+    vm.new_exception_msg(
+        vm.ctx.exceptions.reference_error.clone(),
+        "weakly-referenced object no longer exists".to_owned(),
+    )
 }
 
 impl SetAttr for PyWeakProxy {


### PR DESCRIPTION
After a  weakReference and str() call, the two values were different in comparison, resulting in an error
I found it, "weakproxy object" is not have "\_\_str__()" so calling by "parent object" in "\_\_str__()" 
So I added in "weakproxy. rs"  made it and "str()"method is work normally