### PR TITLE
Make the correctness of the bytecode in PyCode a safety invariant

### DIFF
--- a/compiler/codegen/src/compile.rs
+++ b/compiler/codegen/src/compile.rs
@@ -16,8 +16,8 @@ use num_complex::Complex64;
 use num_traits::ToPrimitive;
 use rustpython_ast as ast;
 use rustpython_compiler_core::{
-    self as bytecode, Arg as OpArgMarker, CodeObject, ConstantData, Instruction, Location, NameIdx,
-    OpArg, OpArgType,
+    self as bytecode, Arg as OpArgMarker, CodeObject, CodeObjectInner, ConstantData, Instruction,
+    Location, NameIdx, OpArg, OpArgType,
 };
 use std::borrow::Cow;
 
@@ -1219,7 +1219,7 @@ impl Compiler {
         self.store_name(name)
     }
 
-    fn build_closure(&mut self, code: &CodeObject) -> bool {
+    fn build_closure(&mut self, code: &CodeObjectInner) -> bool {
         if code.freevars.is_empty() {
             return false;
         }

--- a/compiler/codegen/src/ir.rs
+++ b/compiler/codegen/src/ir.rs
@@ -2,8 +2,8 @@ use std::ops;
 
 use crate::IndexSet;
 use rustpython_compiler_core::{
-    CodeFlags, CodeObject, CodeUnit, ConstantData, InstrDisplayContext, Instruction, Label,
-    Location, OpArg,
+    CodeFlags, CodeObject, CodeObjectInner, CodeUnit, ConstantData, InstrDisplayContext,
+    Instruction, Label, Location, OpArg,
 };
 
 #[derive(Copy, Clone, PartialEq, Eq, Debug)]
@@ -151,7 +151,7 @@ impl CodeInfo {
             locations.clear()
         }
 
-        CodeObject {
+        let code_object = CodeObjectInner {
             flags,
             posonlyarg_count,
             arg_count,
@@ -169,7 +169,10 @@ impl CodeInfo {
             cellvars: cellvar_cache.into_iter().collect(),
             freevars: freevar_cache.into_iter().collect(),
             cell2arg,
-        }
+        };
+
+        // SAFETY: we assume that the compiler produces correct output
+        unsafe { CodeObject::new(code_object) }
     }
 
     fn cell2arg(&self) -> Option<Box<[isize]>> {

--- a/examples/dis.rs
+++ b/examples/dis.rs
@@ -42,7 +42,7 @@ fn main() {
         .arg(
             Arg::with_name("no_expand")
                 .help(
-                    "Don't expand CodeObject LoadConst instructions to show \
+                    "Don't expand CodeObjectInner LoadConst instructions to show \
                      the instructions inside",
                 )
                 .long("no-expand")

--- a/vm/src/frame.rs
+++ b/vm/src/frame.rs
@@ -739,7 +739,7 @@ impl ExecutingFrame<'_> {
                 let item = self.pop_value();
                 let obj = self.nth_value(i.get(arg));
                 let list: &Py<PyList> = unsafe {
-                    // SAFETY: trust compiler
+                    // SAFETY: invariants of CodeObject
                     obj.downcast_unchecked_ref()
                 };
                 list.append(item);
@@ -749,7 +749,7 @@ impl ExecutingFrame<'_> {
                 let item = self.pop_value();
                 let obj = self.nth_value(i.get(arg));
                 let set: &Py<PySet> = unsafe {
-                    // SAFETY: trust compiler
+                    // SAFETY: invariants of CodeObject
                     obj.downcast_unchecked_ref()
                 };
                 set.add(item, vm)?;
@@ -760,7 +760,7 @@ impl ExecutingFrame<'_> {
                 let key = self.pop_value();
                 let obj = self.nth_value(i.get(arg));
                 let dict: &Py<PyDict> = unsafe {
-                    // SAFETY: trust compiler
+                    // SAFETY: invariants of CodeObject
                     obj.downcast_unchecked_ref()
                 };
                 dict.set_item(&*key, value, vm)?;

--- a/vm/src/stdlib/marshal.rs
+++ b/vm/src/stdlib/marshal.rs
@@ -378,13 +378,16 @@ mod decl {
                     return Err(too_short_error(vm));
                 }
                 let (bytes, buf) = buf.split_at(len);
-                let code = bytecode::CodeObject::from_bytes(bytes).map_err(|e| match e {
+                let code = bytecode::CodeObjectInner::from_bytes(bytes).map_err(|e| match e {
                     bytecode::CodeDeserializeError::Eof => vm.new_exception_msg(
                         vm.ctx.exceptions.eof_error.to_owned(),
                         "End of file while deserializing bytecode".to_owned(),
                     ),
                     _ => vm.new_value_error("Couldn't deserialize python bytecode".to_owned()),
                 })?;
+                // SAFETY: none, really 😬 but CPython trusts Python to give it invalid bytecode and do all
+                // kinds of other unsafe actions, so we'll just sorta follow suit
+                let code = unsafe { bytecode::CodeObject::new(code) };
                 (vm.ctx.new_code(code).into(), buf)
             }
         };


### PR DESCRIPTION
A cherrypick of an olllld WIP branch. Sep 2020! Figured if we're gonna be eliding bounds checks in Frame now I may as well bring this back.