### PR TITLE
Fix broken module_names in compile_dir for sub-directories

### DIFF
--- a/derive/src/compile_bytecode.rs
+++ b/derive/src/compile_bytecode.rs
@@ -143,7 +143,11 @@ impl CompilationSource {
             if path.is_dir() {
                 code_map.extend(self.compile_dir(
                     &path,
-                    format!("{}{}", parent, file_name),
+                    if parent.is_empty() {
+                        file_name.to_string()
+                    } else {
+                        format!("{}.{}", parent, file_name)
+                    },
                     mode,
                 )?);
             } else if file_name.ends_with(".py") {

--- a/extra_tests/snippets/stdlib_dir_module.py
+++ b/extra_tests/snippets/stdlib_dir_module.py
@@ -26,3 +26,6 @@ except AttributeError as e:
     assert 'dir_module' not in str(e)
 else:
     assert False
+
+from dir_module import dir_module_inner
+assert dir_module_inner.__name__ == 'dir_module.dir_module_inner'


### PR DESCRIPTION
Assume we have a directory structure like this:
```
test
  nested_test_1
    nested_test_2
```


Expected module names are:
```
nested_test_1
nested_test-1.nested_test-2
```

However in the actual result was:
```
nested_test_1
nested_test-1nested_test-2
```
the '.' separator missing