### PR TITLE
rename for name consistency

### DIFF
--- a/stdlib/src/array.rs
+++ b/stdlib/src/array.rs
@@ -263,7 +263,7 @@ mod array {
                 fn getitem_by_index(&self, i: isize, vm: &VirtualMachine) -> PyResult {
                     match self {
                         $(ArrayContentType::$n(v) => {
-                            v.get_item_by_index(vm, i).map(|x| x.to_pyresult(vm))?
+                            v.getitem_by_index(vm, i).map(|x| x.to_pyresult(vm))?
                         })*
                     }
                 }
@@ -271,7 +271,7 @@ mod array {
                 fn getitem_by_slice(&self, slice: SaturatedSlice, vm: &VirtualMachine) -> PyResult {
                     match self {
                         $(ArrayContentType::$n(v) => {
-                            let r = v.get_item_by_slice(vm, slice)?;
+                            let r = v.getitem_by_slice(vm, slice)?;
                             let array = PyArray::from(ArrayContentType::$n(r));
                             array.to_pyresult(vm)
                         })*

--- a/stdlib/src/array.rs
+++ b/stdlib/src/array.rs
@@ -287,7 +287,7 @@ mod array {
                     match self {
                         $(ArrayContentType::$n(v) => {
                             let value = <$t>::try_into_from_object(vm, value)?;
-                            v.set_item_by_index(vm, i, value)
+                            v.setitem_by_index(vm, i, value)
                         })*
                     }
                 }
@@ -300,7 +300,7 @@ mod array {
                 ) -> PyResult<()> {
                     match self {
                         $(Self::$n(elements) => if let ArrayContentType::$n(items) = items {
-                            elements.set_item_by_slice(vm, slice, items)
+                            elements.setitem_by_slice(vm, slice, items)
                         } else {
                             Err(vm.new_type_error(
                                 "bad argument type for built-in operation".to_owned()
@@ -317,7 +317,7 @@ mod array {
                 ) -> PyResult<()> {
                     match self {
                         $(Self::$n(elements) => if let ArrayContentType::$n(items) = items {
-                            elements.set_item_by_slice_no_resize(vm, slice, items)
+                            elements.setitem_by_slice_no_resize(vm, slice, items)
                         } else {
                             Err(vm.new_type_error(
                                 "bad argument type for built-in operation".to_owned()

--- a/stdlib/src/mmap.rs
+++ b/stdlib/src/mmap.rs
@@ -444,7 +444,7 @@ mod mmap {
             length: Some(|seq, _vm| Ok(Self::sequence_downcast(seq).len())),
             item: Some(|seq, i, vm| {
                 let zelf = Self::sequence_downcast(seq);
-                zelf.get_item_by_index(i, vm)
+                zelf.getitem_by_index(i, vm)
             }),
             ass_item: Some(|seq, i, value, vm| {
                 let zelf = Self::sequence_downcast(seq);
@@ -917,7 +917,7 @@ mod mmap {
             Ok(())
         }
 
-        fn get_item_by_index(&self, i: isize, vm: &VirtualMachine) -> PyResult<PyObjectRef> {
+        fn getitem_by_index(&self, i: isize, vm: &VirtualMachine) -> PyResult<PyObjectRef> {
             let i = wrap_index(i, self.len())
                 .ok_or_else(|| vm.new_index_error("mmap index out of range".to_owned()))?;
 
@@ -971,7 +971,7 @@ mod mmap {
 
         fn _getitem(&self, needle: &PyObject, vm: &VirtualMachine) -> PyResult<PyObjectRef> {
             match SequenceIndex::try_from_borrowed_object(vm, needle, "mmap")? {
-                SequenceIndex::Int(i) => self.get_item_by_index(i, vm),
+                SequenceIndex::Int(i) => self.getitem_by_index(i, vm),
                 SequenceIndex::Slice(slice) => self.getitem_by_slice(&slice, vm),
             }
         }

--- a/vm/src/builtins/bytearray.rs
+++ b/vm/src/builtins/bytearray.rs
@@ -209,11 +209,11 @@ impl PyByteArray {
         match SequenceIndex::try_from_borrowed_object(vm, needle, "bytearray")? {
             SequenceIndex::Int(i) => self
                 .borrow_buf()
-                .get_item_by_index(vm, i)
+                .getitem_by_index(vm, i)
                 .map(|x| vm.ctx.new_int(x).into()),
             SequenceIndex::Slice(slice) => self
                 .borrow_buf()
-                .get_item_by_slice(vm, slice)
+                .getitem_by_slice(vm, slice)
                 .map(|x| Self::new_ref(x, &vm.ctx).into()),
         }
     }
@@ -800,7 +800,7 @@ impl AsSequence for PyByteArray {
         item: Some(|seq, i, vm| {
             Self::sequence_downcast(seq)
                 .borrow_buf()
-                .get_item_by_index(vm, i)
+                .getitem_by_index(vm, i)
                 .map(|x| vm.ctx.new_bytes(vec![x]).into())
         }),
         ass_item: Some(|seq, i, value, vm| {

--- a/vm/src/builtins/bytearray.rs
+++ b/vm/src/builtins/bytearray.rs
@@ -160,7 +160,7 @@ impl PyByteArray {
 
     fn _setitem_by_index(&self, i: isize, value: PyObjectRef, vm: &VirtualMachine) -> PyResult<()> {
         let value = value_from_object(vm, &value)?;
-        self.borrow_buf_mut().set_item_by_index(vm, i, value)
+        self.borrow_buf_mut().setitem_by_index(vm, i, value)
     }
 
     fn _setitem(
@@ -178,10 +178,10 @@ impl PyByteArray {
                     bytes_from_object(vm, &value)?
                 };
                 if let Some(mut w) = zelf.try_resizable_opt() {
-                    w.elements.set_item_by_slice(vm, slice, &items)
+                    w.elements.setitem_by_slice(vm, slice, &items)
                 } else {
                     zelf.borrow_buf_mut()
-                        .set_item_by_slice_no_resize(vm, slice, &items)
+                        .setitem_by_slice_no_resize(vm, slice, &items)
                 }
             }
         }

--- a/vm/src/builtins/bytes.rs
+++ b/vm/src/builtins/bytes.rs
@@ -171,12 +171,12 @@ impl PyBytes {
             SequenceIndex::Int(i) => self
                 .inner
                 .elements
-                .get_item_by_index(vm, i)
+                .getitem_by_index(vm, i)
                 .map(|x| vm.ctx.new_int(x).into()),
             SequenceIndex::Slice(slice) => self
                 .inner
                 .elements
-                .get_item_by_slice(vm, slice)
+                .getitem_by_slice(vm, slice)
                 .map(|x| vm.ctx.new_bytes(x).into()),
         }
     }
@@ -595,7 +595,7 @@ impl AsSequence for PyBytes {
             Self::sequence_downcast(seq)
                 .inner
                 .elements
-                .get_item_by_index(vm, i)
+                .getitem_by_index(vm, i)
                 .map(|x| vm.ctx.new_bytes(vec![x]).into())
         }),
         contains: Some(|seq, other, vm| {

--- a/vm/src/builtins/list.rs
+++ b/vm/src/builtins/list.rs
@@ -198,10 +198,10 @@ impl PyList {
 
     fn _getitem(&self, needle: &PyObject, vm: &VirtualMachine) -> PyResult {
         match SequenceIndex::try_from_borrowed_object(vm, needle, "list")? {
-            SequenceIndex::Int(i) => self.borrow_vec().get_item_by_index(vm, i),
+            SequenceIndex::Int(i) => self.borrow_vec().getitem_by_index(vm, i),
             SequenceIndex::Slice(slice) => self
                 .borrow_vec()
-                .get_item_by_slice(vm, slice)
+                .getitem_by_slice(vm, slice)
                 .map(|x| vm.ctx.new_list(x).into()),
         }
     }
@@ -446,7 +446,7 @@ impl AsSequence for PyList {
         item: Some(|seq, i, vm| {
             Self::sequence_downcast(seq)
                 .borrow_vec()
-                .get_item_by_index(vm, i)
+                .getitem_by_index(vm, i)
         }),
         ass_item: Some(|seq, i, value, vm| {
             let zelf = Self::sequence_downcast(seq);

--- a/vm/src/builtins/list.rs
+++ b/vm/src/builtins/list.rs
@@ -213,10 +213,10 @@ impl PyList {
 
     fn _setitem(&self, needle: &PyObject, value: PyObjectRef, vm: &VirtualMachine) -> PyResult<()> {
         match SequenceIndex::try_from_borrowed_object(vm, needle, "list")? {
-            SequenceIndex::Int(index) => self.borrow_vec_mut().set_item_by_index(vm, index, value),
+            SequenceIndex::Int(index) => self.borrow_vec_mut().setitem_by_index(vm, index, value),
             SequenceIndex::Slice(slice) => {
                 let sec = extract_cloned(&*value, Ok, vm)?;
-                self.borrow_vec_mut().set_item_by_slice(vm, slice, &sec)
+                self.borrow_vec_mut().setitem_by_slice(vm, slice, &sec)
             }
         }
     }
@@ -451,7 +451,7 @@ impl AsSequence for PyList {
         ass_item: Some(|seq, i, value, vm| {
             let zelf = Self::sequence_downcast(seq);
             if let Some(value) = value {
-                zelf.borrow_vec_mut().set_item_by_index(vm, i, value)
+                zelf.borrow_vec_mut().setitem_by_index(vm, i, value)
             } else {
                 zelf.borrow_vec_mut().del_item_by_index(vm, i)
             }

--- a/vm/src/builtins/str.rs
+++ b/vm/src/builtins/str.rs
@@ -443,8 +443,8 @@ impl PyStr {
 
     fn _getitem(&self, needle: &PyObject, vm: &VirtualMachine) -> PyResult {
         match SequenceIndex::try_from_borrowed_object(vm, needle, "str")? {
-            SequenceIndex::Int(i) => self.get_item_by_index(vm, i).map(|x| x.to_string()),
-            SequenceIndex::Slice(slice) => self.get_item_by_slice(vm, slice),
+            SequenceIndex::Int(i) => self.getitem_by_index(vm, i).map(|x| x.to_string()),
+            SequenceIndex::Slice(slice) => self.getitem_by_slice(vm, slice),
         }
         .map(|x| self.new_substr(x).into_ref(vm).into())
     }
@@ -1321,7 +1321,7 @@ impl AsSequence for PyStr {
         }),
         item: Some(|seq, i, vm| {
             let zelf = Self::sequence_downcast(seq);
-            zelf.get_item_by_index(vm, i)
+            zelf.getitem_by_index(vm, i)
                 .map(|x| zelf.new_substr(x.to_string()).into_ref(vm).into())
         }),
         contains: Some(|seq, needle, vm| Self::sequence_downcast(seq)._contains(needle, vm)),

--- a/vm/src/builtins/tuple.rs
+++ b/vm/src/builtins/tuple.rs
@@ -264,10 +264,10 @@ impl PyTuple {
 
     fn _getitem(&self, needle: &PyObject, vm: &VirtualMachine) -> PyResult {
         match SequenceIndex::try_from_borrowed_object(vm, needle, "tuple")? {
-            SequenceIndex::Int(i) => self.elements.get_item_by_index(vm, i),
+            SequenceIndex::Int(i) => self.elements.getitem_by_index(vm, i),
             SequenceIndex::Slice(slice) => self
                 .elements
-                .get_item_by_slice(vm, slice)
+                .getitem_by_slice(vm, slice)
                 .map(|x| vm.ctx.new_tuple(x).into()),
         }
     }
@@ -373,7 +373,7 @@ impl AsSequence for PyTuple {
         }),
         item: Some(|seq, i, vm| {
             let zelf = Self::sequence_downcast(seq);
-            zelf.elements.get_item_by_index(vm, i)
+            zelf.elements.getitem_by_index(vm, i)
         }),
         contains: Some(|seq, needle, vm| {
             let zelf = Self::sequence_downcast(seq);

--- a/vm/src/sliceable.rs
+++ b/vm/src/sliceable.rs
@@ -24,7 +24,7 @@ where
     where
         I: Iterator<Item = usize>;
 
-    fn set_item_by_index(
+    fn setitem_by_index(
         &mut self,
         vm: &VirtualMachine,
         index: isize,
@@ -38,7 +38,7 @@ where
         Ok(())
     }
 
-    fn set_item_by_slice_no_resize(
+    fn setitem_by_slice_no_resize(
         &mut self,
         vm: &VirtualMachine,
         slice: SaturatedSlice,
@@ -60,7 +60,7 @@ where
         }
     }
 
-    fn set_item_by_slice(
+    fn setitem_by_slice(
         &mut self,
         vm: &VirtualMachine,
         slice: SaturatedSlice,

--- a/vm/src/sliceable.rs
+++ b/vm/src/sliceable.rs
@@ -182,7 +182,7 @@ pub trait SliceableSequenceOp {
         saturate_index(p, self.len())
     }
 
-    fn get_item_by_slice(
+    fn getitem_by_slice(
         &self,
         _vm: &VirtualMachine,
         slice: SaturatedSlice,
@@ -204,7 +204,7 @@ pub trait SliceableSequenceOp {
         Ok(sliced)
     }
 
-    fn get_item_by_index(&self, vm: &VirtualMachine, index: isize) -> PyResult<Self::Item> {
+    fn getitem_by_index(&self, vm: &VirtualMachine, index: isize) -> PyResult<Self::Item> {
         let pos = self
             .wrap_index(index)
             .ok_or_else(|| vm.new_index_error("index out of range".to_owned()))?;


### PR DESCRIPTION
closed #3786

* rename `get_item_by_index` to `getitem_by_index`
* rename `get_item_by_slice` to `getitem_by_slice`
* rename `set_item_by_index` to `setitem_by_index`
* rename `set_item_by_slice` to `setitem_by_slice`