### PR TITLE
fix panic when parsing invalid decimal, close #3796

### DIFF
--- a/extra_tests/snippets/syntax_decimal.py
+++ b/extra_tests/snippets/syntax_decimal.py
@@ -1,0 +1,6 @@
+try:
+    eval("0.E")
+except SyntaxError:
+   pass
+else:
+  assert False

--- a/parser/src/lexer.rs
+++ b/parser/src/lexer.rs
@@ -300,7 +300,10 @@ where
                 value_text.push_str(&self.radix_run(10));
             }
 
-            let value = f64::from_str(&value_text).unwrap();
+            let value = f64::from_str(&value_text).map_err(|_| LexicalError {
+                error: LexicalErrorType::OtherError("Invalid decimal literal".to_owned()),
+                location: self.get_pos(),
+            })?;
             // Parse trailing 'j':
             if self.chr0 == Some('j') || self.chr0 == Some('J') {
                 self.next_char();


### PR DESCRIPTION
Try to fix #3796 

In cpython:

```
>>> 0.E
  File "<stdin>", line 1
    0.E
     ^
SyntaxError: invalid decimal literal
```

After this patch , RustPython:

```
Welcome to the magnificent Rust Python 0.1.2 interpreter 😱 🖖
>>>>> 0.E
SyntaxError: Invalid decimal literal at line 1 column 4
0.E
   ^
```

