### PR TITLE
Run test suites like how CPython runs theirs

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -191,14 +191,14 @@ jobs:
       - if: runner.os == 'Linux'
         name: run cpython platform-independent tests
         run:
-          target/release/rustpython -m test -v ${{ env.PLATFORM_INDEPENDENT_TESTS }}
+          target/release/rustpython -m test -j 1 -u all --slowest --fail-env-changed -v ${{ env.PLATFORM_INDEPENDENT_TESTS }}
       - if: runner.os != 'Windows'
         name: run cpython platform-dependent tests
-        run: target/release/rustpython -m test -v -x ${{ env.PLATFORM_INDEPENDENT_TESTS }}
+        run: target/release/rustpython -m test -j 1 -u all --slowest --fail-env-changed -v -x ${{ env.PLATFORM_INDEPENDENT_TESTS }}
       - if: runner.os == 'Windows'
         name: run cpython platform-dependent tests (windows partial - fixme)
         run:
-          target/release/rustpython -m test -v -x ${{ env.PLATFORM_INDEPENDENT_TESTS }}
+          target/release/rustpython -m test -j 1 -u all --slowest --fail-env-changed -v -x ${{ env.PLATFORM_INDEPENDENT_TESTS }}
             test_bool
             test_cgi
             test_exception_hierarchy

--- a/Lib/test/test_ntpath.py
+++ b/Lib/test/test_ntpath.py
@@ -271,6 +271,17 @@ class TestNtpath(NtpathTestCase):
 
     @os_helper.skip_unless_symlink
     @unittest.skipUnless(HAVE_GETFINALPATHNAME, 'need _getfinalpathname')
+    def test_realpath_strict(self):
+        # Bug #43757: raise FileNotFoundError in strict mode if we encounter
+        # a path that does not exist.
+        ABSTFN = ntpath.abspath(os_helper.TESTFN)
+        os.symlink(ABSTFN + "1", ABSTFN)
+        self.addCleanup(os_helper.unlink, ABSTFN)
+        self.assertRaises(FileNotFoundError, ntpath.realpath, ABSTFN, strict=True)
+        self.assertRaises(FileNotFoundError, ntpath.realpath, ABSTFN + "2", strict=True)
+
+    @os_helper.skip_unless_symlink
+    @unittest.skipUnless(HAVE_GETFINALPATHNAME, 'need _getfinalpathname')
     def test_realpath_relative(self):
         ABSTFN = ntpath.abspath(os_helper.TESTFN)
         open(ABSTFN, "wb").close()
@@ -343,8 +354,9 @@ class TestNtpath(NtpathTestCase):
     @os_helper.skip_unless_symlink
     @unittest.skipUnless(HAVE_GETFINALPATHNAME, 'need _getfinalpathname')
     def test_realpath_symlink_loops(self):
-        # Symlink loops are non-deterministic as to which path is returned, but
-        # it will always be the fully resolved path of one member of the cycle
+        # Symlink loops in non-strict mode are non-deterministic as to which
+        # path is returned, but it will always be the fully resolved path of
+        # one member of the cycle
         ABSTFN = ntpath.abspath(os_helper.TESTFN)
         self.addCleanup(os_helper.unlink, ABSTFN)
         self.addCleanup(os_helper.unlink, ABSTFN + "1")
@@ -385,6 +397,50 @@ class TestNtpath(NtpathTestCase):
 
         # Test using relative path as well.
         self.assertPathEqual(ntpath.realpath(ntpath.basename(ABSTFN)), ABSTFN)
+
+    @os_helper.skip_unless_symlink
+    @unittest.skipUnless(HAVE_GETFINALPATHNAME, 'need _getfinalpathname')
+    def test_realpath_symlink_loops_strict(self):
+        # Symlink loops raise OSError in strict mode
+        ABSTFN = ntpath.abspath(os_helper.TESTFN)
+        self.addCleanup(os_helper.unlink, ABSTFN)
+        self.addCleanup(os_helper.unlink, ABSTFN + "1")
+        self.addCleanup(os_helper.unlink, ABSTFN + "2")
+        self.addCleanup(os_helper.unlink, ABSTFN + "y")
+        self.addCleanup(os_helper.unlink, ABSTFN + "c")
+        self.addCleanup(os_helper.unlink, ABSTFN + "a")
+
+        os.symlink(ABSTFN, ABSTFN)
+        self.assertRaises(OSError, ntpath.realpath, ABSTFN, strict=True)
+
+        os.symlink(ABSTFN + "1", ABSTFN + "2")
+        os.symlink(ABSTFN + "2", ABSTFN + "1")
+        self.assertRaises(OSError, ntpath.realpath, ABSTFN + "1", strict=True)
+        self.assertRaises(OSError, ntpath.realpath, ABSTFN + "2", strict=True)
+        self.assertRaises(OSError, ntpath.realpath, ABSTFN + "1\\x", strict=True)
+        # Windows eliminates '..' components before resolving links, so the
+        # following call is not expected to raise.
+        self.assertPathEqual(ntpath.realpath(ABSTFN + "1\\..", strict=True),
+                             ntpath.dirname(ABSTFN))
+        self.assertRaises(OSError, ntpath.realpath, ABSTFN + "1\\..\\x", strict=True)
+        os.symlink(ABSTFN + "x", ABSTFN + "y")
+        self.assertRaises(OSError, ntpath.realpath, ABSTFN + "1\\..\\"
+                                             + ntpath.basename(ABSTFN) + "y",
+                                             strict=True)
+        self.assertRaises(OSError, ntpath.realpath,
+                          ABSTFN + "1\\..\\" + ntpath.basename(ABSTFN) + "1",
+                          strict=True)
+
+        os.symlink(ntpath.basename(ABSTFN) + "a\\b", ABSTFN + "a")
+        self.assertRaises(OSError, ntpath.realpath, ABSTFN + "a", strict=True)
+
+        os.symlink("..\\" + ntpath.basename(ntpath.dirname(ABSTFN))
+                   + "\\" + ntpath.basename(ABSTFN) + "c", ABSTFN + "c")
+        self.assertRaises(OSError, ntpath.realpath, ABSTFN + "c", strict=True)
+
+        # Test using relative path as well.
+        self.assertRaises(OSError, ntpath.realpath, ntpath.basename(ABSTFN),
+                          strict=True)
 
     @os_helper.skip_unless_symlink
     @unittest.skipUnless(HAVE_GETFINALPATHNAME, 'need _getfinalpathname')
@@ -506,34 +562,47 @@ class TestNtpath(NtpathTestCase):
             env.clear()
             tester('ntpath.expanduser("~test")', '~test')
 
-            env['HOMEPATH'] = 'eric\\idle'
             env['HOMEDRIVE'] = 'C:\\'
-            tester('ntpath.expanduser("~test")', 'C:\\eric\\test')
-            tester('ntpath.expanduser("~")', 'C:\\eric\\idle')
+            env['HOMEPATH'] = 'Users\\eric'
+            env['USERNAME'] = 'eric'
+            tester('ntpath.expanduser("~test")', 'C:\\Users\\test')
+            tester('ntpath.expanduser("~")', 'C:\\Users\\eric')
 
             del env['HOMEDRIVE']
-            tester('ntpath.expanduser("~test")', 'eric\\test')
-            tester('ntpath.expanduser("~")', 'eric\\idle')
+            tester('ntpath.expanduser("~test")', 'Users\\test')
+            tester('ntpath.expanduser("~")', 'Users\\eric')
 
             env.clear()
-            env['USERPROFILE'] = 'C:\\eric\\idle'
-            tester('ntpath.expanduser("~test")', 'C:\\eric\\test')
-            tester('ntpath.expanduser("~")', 'C:\\eric\\idle')
+            env['USERPROFILE'] = 'C:\\Users\\eric'
+            env['USERNAME'] = 'eric'
+            tester('ntpath.expanduser("~test")', 'C:\\Users\\test')
+            tester('ntpath.expanduser("~")', 'C:\\Users\\eric')
             tester('ntpath.expanduser("~test\\foo\\bar")',
-                   'C:\\eric\\test\\foo\\bar')
+                   'C:\\Users\\test\\foo\\bar')
             tester('ntpath.expanduser("~test/foo/bar")',
-                   'C:\\eric\\test/foo/bar')
+                   'C:\\Users\\test/foo/bar')
             tester('ntpath.expanduser("~\\foo\\bar")',
-                   'C:\\eric\\idle\\foo\\bar')
+                   'C:\\Users\\eric\\foo\\bar')
             tester('ntpath.expanduser("~/foo/bar")',
-                   'C:\\eric\\idle/foo/bar')
+                   'C:\\Users\\eric/foo/bar')
 
             # bpo-36264: ignore `HOME` when set on windows
             env.clear()
             env['HOME'] = 'F:\\'
-            env['USERPROFILE'] = 'C:\\eric\\idle'
-            tester('ntpath.expanduser("~test")', 'C:\\eric\\test')
-            tester('ntpath.expanduser("~")', 'C:\\eric\\idle')
+            env['USERPROFILE'] = 'C:\\Users\\eric'
+            env['USERNAME'] = 'eric'
+            tester('ntpath.expanduser("~test")', 'C:\\Users\\test')
+            tester('ntpath.expanduser("~")', 'C:\\Users\\eric')
+
+            # bpo-39899: don't guess another user's home directory if
+            # `%USERNAME% != basename(%USERPROFILE%)`
+            env.clear()
+            env['USERPROFILE'] = 'C:\\Users\\eric'
+            env['USERNAME'] = 'idle'
+            tester('ntpath.expanduser("~test")', '~test')
+            tester('ntpath.expanduser("~")', 'C:\\Users\\eric')
+
+
 
     @unittest.skipUnless(nt, "abspath requires 'nt' module")
     def test_abspath(self):
@@ -728,9 +797,6 @@ class NtCommonTest(test_genericpath.CommonTest, unittest.TestCase):
     pathmodule = ntpath
     attributes = ['relpath']
 
-    def test_expandvars_nonascii(self):
-        super().test_expandvars_nonascii()
-
     # TODO: RUSTPYTHON
     if sys.platform == "linux":
         @unittest.expectedFailure
@@ -767,7 +833,7 @@ class PathLikeTests(NtpathTestCase):
     path = ntpath
 
     def setUp(self):
-        self.file_name = os_helper.TESTFN.lower()
+        self.file_name = os_helper.TESTFN
         self.file_path = FakePath(os_helper.TESTFN)
         self.addCleanup(os_helper.unlink, self.file_name)
         with open(self.file_name, 'xb', 0) as file:
@@ -778,6 +844,8 @@ class PathLikeTests(NtpathTestCase):
 
     def test_path_normcase(self):
         self._check_function(self.path.normcase)
+        if sys.platform == 'win32':
+            self.assertEqual(ntpath.normcase('\u03a9\u2126'), 'ωΩ')
 
     def test_path_isabs(self):
         self._check_function(self.path.isabs)

--- a/Lib/test/test_ntpath.py
+++ b/Lib/test/test_ntpath.py
@@ -555,6 +555,8 @@ class TestNtpath(NtpathTestCase):
             check('%spam%bar', '%sbar' % nonascii)
             check('%{}%bar'.format(nonascii), 'ham%sbar' % nonascii)
 
+    # TODO: RUSTPYTHON
+    @unittest.expectedFailure
     def test_expanduser(self):
         tester('ntpath.expanduser("test")', 'test')
 

--- a/Lib/test/test_ntpath.py
+++ b/Lib/test/test_ntpath.py
@@ -280,6 +280,10 @@ class TestNtpath(NtpathTestCase):
         self.assertRaises(FileNotFoundError, ntpath.realpath, ABSTFN, strict=True)
         self.assertRaises(FileNotFoundError, ntpath.realpath, ABSTFN + "2", strict=True)
 
+    # TODO: RUSTPYTHON, TypeError: got an unexpected keyword argument 'strict'
+    if sys.platform == "win32":
+        test_realpath_strict = unittest.expectedFailure(test_realpath_strict)
+
     @os_helper.skip_unless_symlink
     @unittest.skipUnless(HAVE_GETFINALPATHNAME, 'need _getfinalpathname')
     def test_realpath_relative(self):
@@ -441,6 +445,10 @@ class TestNtpath(NtpathTestCase):
         # Test using relative path as well.
         self.assertRaises(OSError, ntpath.realpath, ntpath.basename(ABSTFN),
                           strict=True)
+
+    # TODO: RUSTPYTHON, FileExistsError: [Errno 183] Cannot create a file when that file already exists. (os error 183): 'None' -> 'None'
+    if sys.platform == "win32":
+        test_realpath_symlink_loops_strict = unittest.expectedFailure(test_realpath_symlink_loops_strict)
 
     @os_helper.skip_unless_symlink
     @unittest.skipUnless(HAVE_GETFINALPATHNAME, 'need _getfinalpathname')
@@ -639,6 +647,10 @@ class TestNtpath(NtpathTestCase):
         tester('ntpath.relpath("/a", "/a")', '.')
         tester('ntpath.relpath("/a/b", "/a/b")', '.')
         tester('ntpath.relpath("c:/foo", "C:/FOO")', '.')
+
+    # TODO: RUSTPYTHON, FileExistsError: [Errno 183] Cannot create a file when that file already exists. (os error 183): 'None' -> 'None'
+    if sys.platform == "win32":
+        test_relpath = unittest.expectedFailure(test_relpath)
 
     def test_commonpath(self):
         def check(paths, expected):
@@ -848,6 +860,10 @@ class PathLikeTests(NtpathTestCase):
         self._check_function(self.path.normcase)
         if sys.platform == 'win32':
             self.assertEqual(ntpath.normcase('\u03a9\u2126'), 'ωΩ')
+
+    # TODO: RUSTPYTHON, AssertionError: 'ωω' != 'ωΩ'
+    if sys.platform == "win32":
+        test_path_normcase = unittest.expectedFailure(test_path_normcase)
 
     def test_path_isabs(self):
         self._check_function(self.path.isabs)

--- a/Lib/test/test_ntpath.py
+++ b/Lib/test/test_ntpath.py
@@ -517,6 +517,7 @@ class TestNtpath(NtpathTestCase):
         with os_helper.change_cwd(test_dir_short):
             self.assertPathEqual(test_file_long, ntpath.realpath("file.txt"))
 
+    @unittest.skipIf(sys.platform == "win32", "TODO: RUSTPYTHON, ValueError: illegal environment variable name")
     def test_expandvars(self):
         with os_helper.EnvironmentVarGuard() as env:
             env.clear()
@@ -543,6 +544,7 @@ class TestNtpath(NtpathTestCase):
             tester('ntpath.expandvars("\'%foo%\'%bar")', "\'%foo%\'%bar")
             tester('ntpath.expandvars("bar\'%foo%")', "bar\'%foo%")
 
+    @unittest.skipIf(sys.platform == "win32", "TODO: RUSTPYTHON, ValueError: illegal environment variable name")
     @unittest.skipUnless(os_helper.FS_NONASCII, 'need os_helper.FS_NONASCII')
     def test_expandvars_nonascii(self):
         def check(value, expected):
@@ -810,6 +812,14 @@ class TestNtpath(NtpathTestCase):
 class NtCommonTest(test_genericpath.CommonTest, unittest.TestCase):
     pathmodule = ntpath
     attributes = ['relpath']
+
+    @unittest.skipIf(sys.platform == "win32", "TODO: RUSTPYTHON, ValueError: illegal environment variable name")
+    def test_expandvars(self): # TODO: RUSTPYTHON, remove when this passes
+        super().test_expandvars() # TODO: RUSTPYTHON, remove when this passes
+
+    @unittest.skipIf(sys.platform == "win32", "TODO: RUSTPYTHON, ValueError: illegal environment variable name")
+    def test_expandvars_nonascii(self): # TODO: RUSTPYTHON, remove when this passes
+        super().test_expandvars_nonascii() # TODO: RUSTPYTHON, remove when this passes
 
     # TODO: RUSTPYTHON
     if sys.platform == "linux":

--- a/Lib/test/test_script_helper.py
+++ b/Lib/test/test_script_helper.py
@@ -82,6 +82,7 @@ class TestScriptHelperEnvironment(unittest.TestCase):
         # Reset the private cached state.
         script_helper.__dict__['__cached_interp_requires_environment'] = None
 
+    @unittest.skipIf(sys.platform == "win32", "TODO: RUSTPYTHON, ValueError: illegal environment variable name")
     @mock.patch('subprocess.check_call')
     def test_interpreter_requires_environment_true(self, mock_check_call):
         with mock.patch.dict(os.environ):
@@ -91,6 +92,7 @@ class TestScriptHelperEnvironment(unittest.TestCase):
             self.assertTrue(script_helper.interpreter_requires_environment())
             self.assertEqual(1, mock_check_call.call_count)
 
+    @unittest.skipIf(sys.platform == "win32", "TODO: RUSTPYTHON, ValueError: illegal environment variable name")
     @mock.patch('subprocess.check_call')
     def test_interpreter_requires_environment_false(self, mock_check_call):
         with mock.patch.dict(os.environ):
@@ -100,6 +102,7 @@ class TestScriptHelperEnvironment(unittest.TestCase):
             self.assertFalse(script_helper.interpreter_requires_environment())
             self.assertEqual(1, mock_check_call.call_count)
 
+    @unittest.skipIf(sys.platform == "win32", "TODO: RUSTPYTHON, ValueError: illegal environment variable name")
     @mock.patch('subprocess.check_call')
     def test_interpreter_requires_environment_details(self, mock_check_call):
         with mock.patch.dict(os.environ):
@@ -112,6 +115,7 @@ class TestScriptHelperEnvironment(unittest.TestCase):
             self.assertEqual(sys.executable, check_call_command[0])
             self.assertIn('-E', check_call_command)
 
+    @unittest.skipIf(sys.platform == "win32", "TODO: RUSTPYTHON, ValueError: illegal environment variable name")
     @mock.patch('subprocess.check_call')
     def test_interpreter_requires_environment_with_pythonhome(self, mock_check_call):
         with mock.patch.dict(os.environ):

--- a/Lib/test/test_socket.py
+++ b/Lib/test/test_socket.py
@@ -1487,8 +1487,6 @@ class GeneralModuleTests(unittest.TestCase):
 
     @unittest.skipUnless(support.is_resource_enabled('network'),
                          'network is not enabled')
-    # TODO: RUSTPYTHON, socket.gethostbyname_ex
-    @unittest.expectedFailure
     def test_idna(self):
         # Check for internet access before running test
         # (issue #12804, issue #25138).
@@ -1503,6 +1501,10 @@ class GeneralModuleTests(unittest.TestCase):
         # this may not work if the forward lookup chooses the IPv6 address, as that doesn't
         # have a reverse entry yet
         # socket.gethostbyaddr('испытание.python.org')
+
+    # TODO: RUSTPYTHON, socket.gethostbyname_ex
+    if sys.platform != "darwin":
+        test_idna = unittest.expectedFailure(test_idna)
 
     def check_sendall_interrupted(self, with_timeout):
         # socketpair() is not strictly required, but it makes things easier.

--- a/Lib/test/test_socketserver.py
+++ b/Lib/test/test_socketserver.py
@@ -185,10 +185,18 @@ class SocketServerTest(unittest.TestCase):
                         socketserver.StreamRequestHandler,
                         self.stream_examine)
 
+    # TODO: RUSTPYTHON, AssertionError: -1 != 18446744073709551615
+    if os.name == "nt":
+        test_TCPServer = unittest.expectedFailure(test_TCPServer)
+
     def test_ThreadingTCPServer(self):
         self.run_server(socketserver.ThreadingTCPServer,
                         socketserver.StreamRequestHandler,
                         self.stream_examine)
+
+    # TODO: RUSTPYTHON, AssertionError: -1 != 18446744073709551615
+    if os.name == "nt":
+        test_ThreadingTCPServer = unittest.expectedFailure(test_ThreadingTCPServer)
 
     @requires_forking
     def test_ForkingTCPServer(self):
@@ -222,10 +230,18 @@ class SocketServerTest(unittest.TestCase):
                         socketserver.DatagramRequestHandler,
                         self.dgram_examine)
 
+    # TODO: RUSTPYTHON, AssertionError: -1 != 18446744073709551615
+    if os.name == "nt":
+        test_UDPServer = unittest.expectedFailure(test_UDPServer)
+
     def test_ThreadingUDPServer(self):
         self.run_server(socketserver.ThreadingUDPServer,
                         socketserver.DatagramRequestHandler,
                         self.dgram_examine)
+
+    # TODO: RUSTPYTHON, AssertionError: -1 != 18446744073709551615
+    if os.name == "nt":
+        test_ThreadingUDPServer = unittest.expectedFailure(test_ThreadingUDPServer)
 
     @requires_forking
     def test_ForkingUDPServer(self):
@@ -301,6 +317,10 @@ class SocketServerTest(unittest.TestCase):
                                     socketserver.StreamRequestHandler) as server:
             pass
         self.assertEqual(-1, server.socket.fileno())
+
+    # TODO: RUSTPYTHON, AssertionError: -1 != 18446744073709551615
+    if os.name == "nt":
+        test_context_manager = unittest.expectedFailure(test_context_manager)
 
 
 class ErrorHandlerTest(unittest.TestCase):

--- a/Lib/test/test_strtod.py
+++ b/Lib/test/test_strtod.py
@@ -219,7 +219,8 @@ class StrtodTests(unittest.TestCase):
                 s = '{}e{}'.format(digits, exponent)
                 self.check_strtod(s)
 
-    # TODO: RUSTPYTHON
+    @unittest.skipIf(sys.platform == "win32", "TODO: RUSTPYTHON, possibly flaky test on Windows?")
+    # TODO: RUSTPYTHON, Incorrectly rounded str->float conversion for -07e-321
     @unittest.expectedFailure
     def test_parsing(self):
         # make '0' more likely to be chosen than other digits

--- a/Lib/test/test_urllib2_localnet.py
+++ b/Lib/test/test_urllib2_localnet.py
@@ -357,6 +357,7 @@ class ProxyAuthTests(unittest.TestCase):
         self.server.stop()
         self.server = None
 
+    @unittest.skipIf(os.name == "nt", "TODO: RUSTPYTHON, ValueError: illegal environment variable name")
     def test_proxy_with_bad_password_raises_httperror(self):
         self.proxy_digest_handler.add_password(self.REALM, self.URL,
                                                self.USER, self.PASSWD+"bad")
@@ -365,12 +366,14 @@ class ProxyAuthTests(unittest.TestCase):
                           self.opener.open,
                           self.URL)
 
+    @unittest.skipIf(os.name == "nt", "TODO: RUSTPYTHON, ValueError: illegal environment variable name")
     def test_proxy_with_no_password_raises_httperror(self):
         self.digest_auth_handler.set_qop("auth")
         self.assertRaises(urllib.error.HTTPError,
                           self.opener.open,
                           self.URL)
 
+    @unittest.skipIf(os.name == "nt", "TODO: RUSTPYTHON, ValueError: illegal environment variable name")
     def test_proxy_qop_auth_works(self):
         self.proxy_digest_handler.add_password(self.REALM, self.URL,
                                                self.USER, self.PASSWD)
@@ -379,6 +382,7 @@ class ProxyAuthTests(unittest.TestCase):
             while result.read():
                 pass
 
+    @unittest.skipIf(os.name == "nt", "TODO: RUSTPYTHON, ValueError: illegal environment variable name")
     def test_proxy_qop_auth_int_works_or_throws_urlerror(self):
         self.proxy_digest_handler.add_password(self.REALM, self.URL,
                                                self.USER, self.PASSWD)
@@ -500,6 +504,7 @@ class TestUrlopen(unittest.TestCase):
         handler.port = server.port
         return handler
 
+    @unittest.skipIf(os.name == "nt", "TODO: RUSTPYTHON, ValueError: illegal environment variable name")
     def test_redirection(self):
         expected_response = b"We got here..."
         responses = [
@@ -513,6 +518,7 @@ class TestUrlopen(unittest.TestCase):
         self.assertEqual(data, expected_response)
         self.assertEqual(handler.requests, ["/", "/somewhere_else"])
 
+    @unittest.skipIf(os.name == "nt", "TODO: RUSTPYTHON, ValueError: illegal environment variable name")
     def test_chunked(self):
         expected_response = b"hello world"
         chunked_start = (
@@ -527,6 +533,7 @@ class TestUrlopen(unittest.TestCase):
         data = self.urlopen("http://localhost:%s/" % handler.port)
         self.assertEqual(data, expected_response)
 
+    @unittest.skipIf(os.name == "nt", "TODO: RUSTPYTHON, ValueError: illegal environment variable name")
     def test_404(self):
         expected_response = b"Bad bad bad..."
         handler = self.start_server([(404, [], expected_response)])
@@ -542,6 +549,7 @@ class TestUrlopen(unittest.TestCase):
         self.assertEqual(data, expected_response)
         self.assertEqual(handler.requests, ["/weeble"])
 
+    @unittest.skipIf(os.name == "nt", "TODO: RUSTPYTHON, ValueError: illegal environment variable name")
     def test_200(self):
         expected_response = b"pycon 2008..."
         handler = self.start_server([(200, [], expected_response)])
@@ -549,6 +557,7 @@ class TestUrlopen(unittest.TestCase):
         self.assertEqual(data, expected_response)
         self.assertEqual(handler.requests, ["/bizarre"])
 
+    @unittest.skipIf(os.name == "nt", "TODO: RUSTPYTHON, ValueError: illegal environment variable name")
     def test_200_with_parameters(self):
         expected_response = b"pycon 2008..."
         handler = self.start_server([(200, [], expected_response)])
@@ -559,6 +568,7 @@ class TestUrlopen(unittest.TestCase):
 
     # TODO: RUSTPYTHON
     @unittest.expectedFailure
+    @unittest.skipIf(os.name == "nt", "TODO: RUSTPYTHON, ValueError: illegal environment variable name")
     def test_https(self):
         handler = self.start_https_server()
         context = ssl.create_default_context(cafile=CERT_localhost)
@@ -567,6 +577,7 @@ class TestUrlopen(unittest.TestCase):
 
     # TODO: RUSTPYTHON
     @unittest.expectedFailure
+    @unittest.skipIf(os.name == "nt", "TODO: RUSTPYTHON, ValueError: illegal environment variable name")
     def test_https_with_cafile(self):
         handler = self.start_https_server(certfile=CERT_localhost)
         with warnings_helper.check_warnings(('', DeprecationWarning)):
@@ -584,6 +595,7 @@ class TestUrlopen(unittest.TestCase):
                 self.urlopen("https://localhost:%s/bizarre" % handler.port,
                              cafile=CERT_fakehostname)
 
+    @unittest.skipIf(os.name == "nt", "TODO: RUSTPYTHON, ValueError: illegal environment variable name")
     def test_https_with_cadefault(self):
         handler = self.start_https_server(certfile=CERT_localhost)
         # Self-signed cert should fail verification with system certificate store
@@ -594,6 +606,7 @@ class TestUrlopen(unittest.TestCase):
 
     # TODO: RUSTPYTHON
     @unittest.expectedFailure
+    @unittest.skipIf(os.name == "nt", "TODO: RUSTPYTHON, ValueError: illegal environment variable name")
     def test_https_sni(self):
         if ssl is None:
             self.skipTest("ssl module required")
@@ -610,6 +623,7 @@ class TestUrlopen(unittest.TestCase):
         self.urlopen("https://localhost:%s" % handler.port, context=context)
         self.assertEqual(sni_name, "localhost")
 
+    @unittest.skipIf(os.name == "nt", "TODO: RUSTPYTHON, ValueError: illegal environment variable name")
     def test_sending_headers(self):
         handler = self.start_server()
         req = urllib.request.Request("http://localhost:%s/" % handler.port,
@@ -618,6 +632,7 @@ class TestUrlopen(unittest.TestCase):
             pass
         self.assertEqual(handler.headers_received["Range"], "bytes=20-39")
 
+    @unittest.skipIf(os.name == "nt", "TODO: RUSTPYTHON, ValueError: illegal environment variable name")
     def test_basic(self):
         handler = self.start_server()
         with urllib.request.urlopen("http://localhost:%s" % handler.port) as open_url:
@@ -626,6 +641,7 @@ class TestUrlopen(unittest.TestCase):
                              "urlopen lacks the %s attribute" % attr)
             self.assertTrue(open_url.read(), "calling 'read' failed")
 
+    @unittest.skipIf(os.name == "nt", "TODO: RUSTPYTHON, ValueError: illegal environment variable name")
     def test_info(self):
         handler = self.start_server()
         open_url = urllib.request.urlopen(
@@ -637,6 +653,7 @@ class TestUrlopen(unittest.TestCase):
                               "instance of email.message.Message")
         self.assertEqual(info_obj.get_content_subtype(), "plain")
 
+    @unittest.skipIf(os.name == "nt", "TODO: RUSTPYTHON, ValueError: illegal environment variable name")
     def test_geturl(self):
         # Make sure same URL as opened is returned by geturl.
         handler = self.start_server()
@@ -645,6 +662,7 @@ class TestUrlopen(unittest.TestCase):
             url = open_url.geturl()
         self.assertEqual(url, "http://localhost:%s" % handler.port)
 
+    @unittest.skipIf(os.name == "nt", "TODO: RUSTPYTHON, ValueError: illegal environment variable name")
     def test_iteration(self):
         expected_response = b"pycon 2008..."
         handler = self.start_server([(200, [], expected_response)])
@@ -652,6 +670,7 @@ class TestUrlopen(unittest.TestCase):
         for line in data:
             self.assertEqual(line, expected_response)
 
+    @unittest.skipIf(os.name == "nt", "TODO: RUSTPYTHON, ValueError: illegal environment variable name")
     def test_line_iteration(self):
         lines = [b"We\n", b"got\n", b"here\n", b"verylong " * 8192 + b"\n"]
         expected_response = b"".join(lines)

--- a/Lib/test/test_xmlrpc.py
+++ b/Lib/test/test_xmlrpc.py
@@ -394,11 +394,6 @@ class SimpleXMLRPCDispatcherTestCase(unittest.TestCase):
         self.assertIsNone(exc_ctx.exception.__cause__)
         self.assertIsNone(exc_ctx.exception.__context__)
 
-    # TODO: RUSTPYTHON
-    import os
-    if os.getenv("CI"):
-        test_call_registered_func = unittest.expectedFailure(test_call_registered_func)
-
     def test_call_instance_func(self):
         """Calls a registered instance attribute as a function"""
         # Makes sure any exception raised inside the function has no other
@@ -417,11 +412,6 @@ class SimpleXMLRPCDispatcherTestCase(unittest.TestCase):
         self.assertEqual(exc_ctx.exception.args, (exp_params,))
         self.assertIsNone(exc_ctx.exception.__cause__)
         self.assertIsNone(exc_ctx.exception.__context__)
-
-    # TODO: RUSTPYTHON
-    import os
-    if os.getenv("CI"):
-        test_call_instance_func = unittest.expectedFailure(test_call_instance_func)
 
     def test_call_dispatch_func(self):
         """Calls the registered instance's `_dispatch` function"""
@@ -443,11 +433,6 @@ class SimpleXMLRPCDispatcherTestCase(unittest.TestCase):
         self.assertEqual(exc_ctx.exception.args, (exp_method, exp_params))
         self.assertIsNone(exc_ctx.exception.__cause__)
         self.assertIsNone(exc_ctx.exception.__context__)
-
-    # TODO: RUSTPYTHON
-    import os
-    if os.getenv("CI"):
-        test_call_dispatch_func = unittest.expectedFailure(test_call_dispatch_func)
 
     def test_registered_func_is_none(self):
         """Calls explicitly registered function which is None"""

--- a/Lib/test/test_yield_from.py
+++ b/Lib/test/test_yield_from.py
@@ -298,11 +298,6 @@ class TestPEP380Operation(unittest.TestCase):
             "Finishing g1",
         ])
 
-    # TODO: RUSTPYTHON
-    import os
-    if os.getenv("CI"):
-        test_handing_exception_while_delegating_close = unittest.expectedFailure(test_handing_exception_while_delegating_close)
-
     def test_delegating_throw(self):
         """
         Test delegating 'throw'
@@ -888,11 +883,6 @@ class TestPEP380Operation(unittest.TestCase):
             "Enter g",
             "Enter f",
         ])
-
-    # TODO: RUSTPYTHON
-    import os
-    if os.getenv("CI"):
-        test_throwing_GeneratorExit_into_subgen_that_raises = unittest.expectedFailure(test_throwing_GeneratorExit_into_subgen_that_raises)
 
     def test_yield_from_empty(self):
         def g():


### PR DESCRIPTION
The extra flags come from the `buildbottest` rule in CPython's Makefile.

This will enable checking the tests we've been skipping by default (such as network-based tests). This will also report the top 10 slowest tests and will mark a test as failed if it altered the execution environment.
