### PR TITLE
Fix OverflowError at collections.rs

### DIFF
--- a/Lib/test/seq_tests.py
+++ b/Lib/test/seq_tests.py
@@ -362,8 +362,6 @@ class CommonTest(unittest.TestCase):
 
         self.assertRaises(BadExc, a.count, BadCmp())
 
-    # TODO: RUSTPYTHON
-    @unittest.expectedFailure
     def test_index(self):
         u = self.type2test([0, 1])
         self.assertEqual(u.index(0), 0)

--- a/extra_tests/snippets/stdlib_collections_deque.py
+++ b/extra_tests/snippets/stdlib_collections_deque.py
@@ -1,3 +1,4 @@
+from testutils import assert_raises
 from collections import deque
 from typing import Deque
 
@@ -93,3 +94,6 @@ class D(deque):
 
 assert repr(D()) == "D([])"
 assert repr(D([1, 2, 3])) == "D([1, 2, 3])"
+
+
+assert_raises(ValueError, lambda: deque().index(10,0,10000000000000000000000000))

--- a/vm/src/builtins/tuple.rs
+++ b/vm/src/builtins/tuple.rs
@@ -8,8 +8,8 @@ use crate::{
     protocol::{PyIterReturn, PyMappingMethods, PySequenceMethods},
     recursion::ReprGuard,
     sequence::SequenceExt,
-    sliceable::{SequenceIndex, SliceableSequenceOp},
     sliceable::pyint_saturate_index,
+    sliceable::{SequenceIndex, SliceableSequenceOp},
     types::{
         AsMapping, AsSequence, Comparable, Constructor, Hashable, IterNext, IterNextIterable,
         Iterable, PyComparisonOp, Unconstructible,

--- a/vm/src/builtins/tuple.rs
+++ b/vm/src/builtins/tuple.rs
@@ -1,4 +1,4 @@
-use super::{PositionIterInternal, PyGenericAlias, PyType, PyTypeRef};
+use super::{PositionIterInternal, PyGenericAlias, PyIntRef, PyType, PyTypeRef};
 use crate::common::{hash::PyHash, lock::PyMutex};
 use crate::{
     class::PyClassImpl,
@@ -9,7 +9,7 @@ use crate::{
     recursion::ReprGuard,
     sequence::SequenceExt,
     sliceable::{SequenceIndex, SliceableSequenceOp},
-    stdlib::sys,
+    sliceable::pyint_saturate_index,
     types::{
         AsMapping, AsSequence, Comparable, Constructor, Hashable, IterNext, IterNextIterable,
         Iterable, PyComparisonOp, Unconstructible,
@@ -281,24 +281,17 @@ impl PyTuple {
     fn index(
         &self,
         needle: PyObjectRef,
-        start: OptionalArg<isize>,
-        stop: OptionalArg<isize>,
+        start: OptionalArg<PyObjectRef>,
+        stop: OptionalArg<PyObjectRef>,
         vm: &VirtualMachine,
     ) -> PyResult<usize> {
-        let mut start = start.into_option().unwrap_or(0);
-        if start < 0 {
-            start += self.len() as isize;
-            if start < 0 {
-                start = 0;
-            }
-        }
-        let mut stop = stop.into_option().unwrap_or(sys::MAXSIZE);
-        if stop < 0 {
-            stop += self.len() as isize;
-            if stop < 0 {
-                stop = 0;
-            }
-        }
+        let len = self.len();
+        let saturate = |obj: PyObjectRef, len| -> PyResult<_> {
+            obj.try_into_value(vm)
+                .map(|int: PyIntRef| pyint_saturate_index(int, len))
+        };
+        let start = start.map_or(Ok(0), |i| saturate(i, len))?;
+        let stop = stop.map_or(Ok(len), |i| saturate(i, len))?;
         for (index, element) in self
             .elements
             .iter()

--- a/vm/src/stdlib/collections.rs
+++ b/vm/src/stdlib/collections.rs
@@ -5,8 +5,7 @@ mod _collections {
     use crate::{
         builtins::{
             IterStatus::{Active, Exhausted},
-            PositionIterInternal, PyGenericAlias, PyInt, PyTypeRef,
-            PyIntRef,
+            PositionIterInternal, PyGenericAlias, PyInt, PyIntRef, PyTypeRef,
         },
         common::lock::{PyMutex, PyRwLock, PyRwLockReadGuard, PyRwLockWriteGuard},
         function::{FuncArgs, KwArgs, OptionalArg, PyComparisonValue},
@@ -179,7 +178,8 @@ mod _collections {
                 Ok(index)
             } else {
                 Err(vm.new_value_error(
-                    needle.repr(vm)
+                    needle
+                        .repr(vm)
                         .map(|repr| format!("{} is not in deque", repr))
                         .unwrap_or_else(|_| String::new()),
                 ))

--- a/vm/src/stdlib/collections.rs
+++ b/vm/src/stdlib/collections.rs
@@ -166,12 +166,12 @@ mod _collections {
             let start_state = self.state.load();
 
             let len = self.len();
-            let saturate = |obj: PyObjectRef, len| -> PyResult<_> {
-                obj.try_into_value(vm)
+            let saturate = |i: PyObjectRef, len| -> PyResult<_> {
+                i.try_into_value(vm)
                     .map(|int: PyIntRef| pyint_saturate_index(int, len))
             };
-            let start = start.map_or(Ok(0), |obj| saturate(obj, len))?;
-            let stop = stop.map_or(Ok(len), |obj| saturate(obj, len))?;
+            let start = start.map_or(Ok(0), |i| saturate(i, len))?;
+            let stop = stop.map_or(Ok(len), |i| saturate(i, len))?;
             let index = self.mut_index_range(vm, &obj, start..stop)?;
             if start_state != self.state.load() {
                 Err(vm.new_runtime_error("deque mutated during iteration".to_owned()))

--- a/vm/src/stdlib/collections.rs
+++ b/vm/src/stdlib/collections.rs
@@ -158,7 +158,7 @@ mod _collections {
         #[pymethod]
         fn index(
             &self,
-            obj: PyObjectRef,
+            needle: PyObjectRef,
             start: OptionalArg<PyObjectRef>,
             stop: OptionalArg<PyObjectRef>,
             vm: &VirtualMachine,
@@ -166,20 +166,20 @@ mod _collections {
             let start_state = self.state.load();
 
             let len = self.len();
-            let saturate = |i: PyObjectRef, len| -> PyResult<_> {
-                i.try_into_value(vm)
+            let saturate = |obj: PyObjectRef, len| -> PyResult<_> {
+                obj.try_into_value(vm)
                     .map(|int: PyIntRef| pyint_saturate_index(int, len))
             };
             let start = start.map_or(Ok(0), |i| saturate(i, len))?;
             let stop = stop.map_or(Ok(len), |i| saturate(i, len))?;
-            let index = self.mut_index_range(vm, &obj, start..stop)?;
+            let index = self.mut_index_range(vm, &needle, start..stop)?;
             if start_state != self.state.load() {
                 Err(vm.new_runtime_error("deque mutated during iteration".to_owned()))
             } else if let Some(index) = index.into() {
                 Ok(index)
             } else {
                 Err(vm.new_value_error(
-                    obj.repr(vm)
+                    needle.repr(vm)
                         .map(|repr| format!("{} is not in deque", repr))
                         .unwrap_or_else(|_| String::new()),
                 ))


### PR DESCRIPTION
Fix OverflowError when an integer value larger than Rust's isize is entered in the index method of deque.
and add test case for checking this error

before
```
>>>>> from collections import deque
>>>>> deq = deque()
>>>>> deq.index(92233720368547758090,0,11111111111111111111111111111111111111)
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
OverflowError: Python int too large to convert to Rust isize
```

after
```
>>>>> from collections import deque
>>>>> deq = deque()
>>>>> deq.index(92233720368547758090,0,11111111111111111111111111111111111111)
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
ValueError: 92233720368547758090 is not in deque
```
