### PR TITLE
add <code>IMMUTABLE</code> flag and set non-heaptype as immutable

### DIFF
--- a/vm/src/types/slot.rs
+++ b/vm/src/types/slot.rs
@@ -95,6 +95,7 @@ impl std::fmt::Debug for PyTypeSlots {
 bitflags! {
     #[non_exhaustive]
     pub struct PyTypeFlags: u64 {
+        const IMMUTABLETYPE = 1 << 8;
         const HEAPTYPE = 1 << 9;
         const BASETYPE = 1 << 10;
         const METHOD_DESCR = 1 << 17;


### PR DESCRIPTION
* as <code>PyType_Ready()</code> sets <code>Py_TPFLAGS_IMMUTABLETYPE</code> flag if <code>Py_TPFLAGS_HEAPTYPE</code> not set in CPython, add IMMUTABLETYPE flag and set it to non-heaptype.
* add error message when setting attribution of immutable types
```
>>>>> int.a = 1
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
TypeError: cannot set 'a' attribute of immutable type 'int'
```
--------------
* but it's not working correctly; some types might be/not be heaptype in CPython
```
>>>>> import io
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "D:\RustPython\Lib\io.py", line 83, in <module>
    UnsupportedOperation.__module__ = "io"
TypeError: cannot set '__module__' attribute of immutable type 'UnsupportedOperation'
```