### PR TITLE
support cancel previous CI workflow

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -5,6 +5,13 @@ on:
 
 name: CI
 
+# Cancel previous workflows if they are the same workflow on same ref (branch/tags)
+# with the same event (push/pull_request) even they are in progress.
+# This setting will help reduce the number of duplicated workflows.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}-${{ github.event_name }}
+  cancel-in-progress: true
+
 env:
   CARGO_ARGS: --features ssl,jit
   NON_WASM_PACKAGES: >


### PR DESCRIPTION
Cancel previous workflows if they are the same workflow on the same ref (branch/tags)
with the same event (push/pull_request) even if they are in progress.
So that we don't waste time to verify a previous commit - what we're interested in is the latest view.
