### PR TITLE
Fix error type in itertools.count constructor

### DIFF
--- a/vm/src/stdlib/itertools.rs
+++ b/vm/src/stdlib/itertools.rs
@@ -197,7 +197,7 @@ mod decl {
             let start = start.into_option().unwrap_or_else(|| vm.new_pyobj(0));
             let step = step.into_option().unwrap_or_else(|| vm.new_pyobj(1));
             if !PyNumber::check(&start, vm) || !PyNumber::check(&step, vm) {
-                return Err(vm.new_value_error("a number is require".to_owned()));
+                return Err(vm.new_type_error("a number is required".to_owned()));
             }
 
             PyItertoolsCount {


### PR DESCRIPTION
c.f. https://github.com/python/cpython/blob/cf1732619a61f7b7b5223ebaf6be6455d28257f2/Modules/itertoolsmodule.c#L4178-L4182
