### PR TITLE
Add `_socket` constants from CPython 3.10

### DIFF
--- a/Lib/test/test_socket.py
+++ b/Lib/test/test_socket.py
@@ -1717,6 +1717,8 @@ class GeneralModuleTests(unittest.TestCase):
             self.assertEqual(str(s.family), 'AddressFamily.AF_INET')
             self.assertEqual(str(s.type), 'SocketKind.SOCK_STREAM')
 
+    # TODO: RUSTPYTHON, AssertionError: 526337 != <SocketKind.SOCK_STREAM: 1>
+    @unittest.expectedFailure
     def test_socket_consistent_sock_type(self):
         SOCK_NONBLOCK = getattr(socket, 'SOCK_NONBLOCK', 0)
         SOCK_CLOEXEC = getattr(socket, 'SOCK_CLOEXEC', 0)
@@ -1873,6 +1875,8 @@ class BasicCANTest(unittest.TestCase):
 
     @unittest.skipUnless(hasattr(socket, "CAN_BCM"),
                          'socket.CAN_BCM required for this test.')
+    # TODO: RUSTPYTHON, AttributeError: module 'socket' has no attribute 'CAN_BCM_TX_SETUP'
+    @unittest.expectedFailure
     def testBCMConstants(self):
         socket.CAN_BCM
 
@@ -1913,12 +1917,16 @@ class BasicCANTest(unittest.TestCase):
         with socket.socket(socket.PF_CAN, socket.SOCK_DGRAM, socket.CAN_BCM) as s:
             pass
 
+    # TODO: RUSTPYTHON, OSError: bind(): bad family
+    @unittest.expectedFailure
     def testBindAny(self):
         with socket.socket(socket.PF_CAN, socket.SOCK_RAW, socket.CAN_RAW) as s:
             address = ('', )
             s.bind(address)
             self.assertEqual(s.getsockname(), address)
 
+    # TODO: RUSTPYTHON, AssertionError: "interface name too long" does not match "bind(): bad family"
+    @unittest.expectedFailure
     def testTooLongInterfaceName(self):
         # most systems limit IFNAMSIZ to 16, take 1024 to be sure
         with socket.socket(socket.PF_CAN, socket.SOCK_RAW, socket.CAN_RAW) as s:
@@ -4377,6 +4385,8 @@ class NonBlockingTCPTests(ThreadedTCPSocketTest):
     @unittest.skipUnless(hasattr(socket, 'SOCK_NONBLOCK'),
                          'test needs socket.SOCK_NONBLOCK')
     @support.requires_linux_version(2, 6, 28)
+    # TODO: RUSTPYTHON, AssertionError: None != 0
+    @unittest.expectedFailure
     def testInitNonBlocking(self):
         # create a socket with SOCK_NONBLOCK
         self.serv.close()
@@ -5395,6 +5405,8 @@ class InheritanceTest(unittest.TestCase):
     @unittest.skipUnless(hasattr(socket, "SOCK_CLOEXEC"),
                          "SOCK_CLOEXEC not defined")
     @support.requires_linux_version(2, 6, 28)
+    # TODO: RUSTPYTHON, AssertionError: 524289 != <SocketKind.SOCK_STREAM: 1>
+    @unittest.expectedFailure
     def test_SOCK_CLOEXEC(self):
         with socket.socket(socket.AF_INET,
                            socket.SOCK_STREAM | socket.SOCK_CLOEXEC) as s:
@@ -5487,6 +5499,8 @@ class NonblockConstantTest(unittest.TestCase):
             self.assertTrue(s.getblocking())
 
     @support.requires_linux_version(2, 6, 28)
+    # TODO: RUSTPYTHON, AssertionError: 2049 != <SocketKind.SOCK_STREAM: 1>
+    @unittest.expectedFailure
     def test_SOCK_NONBLOCK(self):
         # a lot of it seems silly and redundant, but I wanted to test that
         # changing back and forth worked ok
@@ -5910,6 +5924,8 @@ class LinuxKernelCryptoAPI(unittest.TestCase):
     # bpo-31705: On kernel older than 4.5, sendto() failed with ENOKEY,
     # at least on ppc64le architecture
     @support.requires_linux_version(4, 5)
+    # TODO: RUSTPYTHON, OSError: bind(): bad family
+    @unittest.expectedFailure
     def test_sha256(self):
         expected = bytes.fromhex("ba7816bf8f01cfea414140de5dae2223b00361a396"
                                  "177a9cb410ff61f20015ad")
@@ -5927,6 +5943,8 @@ class LinuxKernelCryptoAPI(unittest.TestCase):
                 op.send(b'')
                 self.assertEqual(op.recv(512), expected)
 
+    # TODO: RUSTPYTHON, OSError: bind(): bad family
+    @unittest.expectedFailure
     def test_hmac_sha1(self):
         expected = bytes.fromhex("effcdf6ae5eb2fa2d27416d5f184df9c259a7c79")
         with self.create_alg('hash', 'hmac(sha1)') as algo:
@@ -5939,6 +5957,8 @@ class LinuxKernelCryptoAPI(unittest.TestCase):
     # Although it should work with 3.19 and newer the test blocks on
     # Ubuntu 15.10 with Kernel 4.2.0-19.
     @support.requires_linux_version(4, 3)
+    # TODO: RUSTPYTHON, OSError: bind(): bad family
+    @unittest.expectedFailure
     def test_aes_cbc(self):
         key = bytes.fromhex('06a9214036b8a15b512e03d534120006')
         iv = bytes.fromhex('3dafba429d9eb430b422da802c9fac41')
@@ -5980,6 +6000,8 @@ class LinuxKernelCryptoAPI(unittest.TestCase):
             self.assertEqual(dec, msg * multiplier)
 
     @support.requires_linux_version(4, 9)  # see issue29324
+    # TODO: RUSTPYTHON, OSError: bind(): bad family
+    @unittest.expectedFailure
     def test_aead_aes_gcm(self):
         key = bytes.fromhex('c939cc13397c1d37de6ae0e1cb7c423c')
         iv = bytes.fromhex('b3d8cc017cbb89b39e0f67e2')
@@ -6043,6 +6065,8 @@ class LinuxKernelCryptoAPI(unittest.TestCase):
                 self.assertEqual(plain, res[assoclen:])
 
     @support.requires_linux_version(4, 3)  # see test_aes_cbc
+    # TODO: RUSTPYTHON, OSError: bind(): bad family
+    @unittest.expectedFailure
     def test_drbg_pr_sha256(self):
         # deterministic random bit generator, prediction resistance, sha256
         with self.create_alg('rng', 'drbg_pr_sha256') as algo:
@@ -6053,6 +6077,8 @@ class LinuxKernelCryptoAPI(unittest.TestCase):
                 rn = op.recv(32)
                 self.assertEqual(len(rn), 32)
 
+    # TODO: RUSTPYTHON, AttributeError: 'socket' object has no attribute 'sendmsg_afalg'
+    @unittest.expectedFailure
     def test_sendmsg_afalg_args(self):
         sock = socket.socket(socket.AF_ALG, socket.SOCK_SEQPACKET, 0)
         with sock:
@@ -6071,6 +6097,8 @@ class LinuxKernelCryptoAPI(unittest.TestCase):
             with self.assertRaises(TypeError):
                 sock.sendmsg_afalg(op=socket.ALG_OP_ENCRYPT, assoclen=-1)
 
+    # TODO: RUSTPYTHON, OSError: bind(): bad family
+    @unittest.expectedFailure
     def test_length_restriction(self):
         # bpo-35050, off-by-one error in length check
         sock = socket.socket(socket.AF_ALG, socket.SOCK_SEQPACKET, 0)

--- a/Lib/test/test_socket.py
+++ b/Lib/test/test_socket.py
@@ -1719,8 +1719,6 @@ class GeneralModuleTests(unittest.TestCase):
             self.assertEqual(str(s.family), 'AddressFamily.AF_INET')
             self.assertEqual(str(s.type), 'SocketKind.SOCK_STREAM')
 
-    # TODO: RUSTPYTHON, AssertionError: 526337 != <SocketKind.SOCK_STREAM: 1>
-    @unittest.expectedFailure
     def test_socket_consistent_sock_type(self):
         SOCK_NONBLOCK = getattr(socket, 'SOCK_NONBLOCK', 0)
         SOCK_CLOEXEC = getattr(socket, 'SOCK_CLOEXEC', 0)
@@ -1736,6 +1734,10 @@ class GeneralModuleTests(unittest.TestCase):
             self.assertEqual(s.type, socket.SOCK_STREAM)
             s.setblocking(False)
             self.assertEqual(s.type, socket.SOCK_STREAM)
+
+    # TODO: RUSTPYTHON, AssertionError: 526337 != <SocketKind.SOCK_STREAM: 1>
+    if sys.platform == "linux":
+        test_socket_consistent_sock_type = unittest.expectedFailure(test_socket_consistent_sock_type)
 
     def test_unknown_socket_family_repr(self):
         # Test that when created with a family that's not one of the known

--- a/Lib/test/test_socket.py
+++ b/Lib/test/test_socket.py
@@ -1389,6 +1389,8 @@ class GeneralModuleTests(unittest.TestCase):
     @unittest.skipUnless(os.name == "nt", "Windows specific")
     @unittest.skipUnless(hasattr(socket, 'SIO_LOOPBACK_FAST_PATH'),
                          'Loopback fast path support required for this test')
+    # TODO: RUSTPYTHON, AttributeError: 'socket' object has no attribute 'ioctl'
+    @unittest.expectedFailure
     def test_sio_loopback_fast_path(self):
         s = socket.socket()
         self.addCleanup(s.close)

--- a/stdlib/src/socket.rs
+++ b/stdlib/src/socket.rs
@@ -39,12 +39,12 @@ mod _socket {
         pub use winapi::shared::netioapi::{if_indextoname, if_nametoindex};
         pub use winapi::shared::ws2def::*;
         pub use winapi::shared::ws2ipdef::*;
-        pub use winapi::shared::ws2tcpip::*;
         pub use winapi::um::winsock2::{
             SD_BOTH as SHUT_RDWR, SD_RECEIVE as SHUT_RD, SD_SEND as SHUT_WR, SOCK_DGRAM, SOCK_RAW,
             SOCK_RDM, SOCK_SEQPACKET, SOCK_STREAM, SOL_SOCKET, SO_BROADCAST, SO_ERROR, SO_LINGER,
             SO_OOBINLINE, SO_REUSEADDR, SO_TYPE, *,
         };
+        pub use winapi::um::ws2tcpip::*;
     }
     // constants
     #[pyattr(name = "has_ipv6")]
@@ -537,12 +537,25 @@ mod _socket {
         target_os = "linux",
         target_os = "netbsd",
         target_os = "openbsd",
+        target_os = "redox"
+    ))]
+    #[pyattr]
+    use c::{SOCK_CLOEXEC, SOCK_NONBLOCK};
+
+    #[cfg(any(
+        target_os = "android",
+        target_os = "dragonfly",
+        target_os = "freebsd",
+        target_os = "fuchsia",
+        target_os = "linux",
+        target_os = "netbsd",
+        target_os = "openbsd",
         target_vendor = "apple"
     ))]
     #[pyattr]
     use c::{
         AF_ROUTE, AF_SNA, EAI_OVERFLOW, IPPROTO_GRE, IPPROTO_RSVP, IPPROTO_TP, IPV6_RECVPKTINFO,
-        MSG_DONTWAIT, SCM_RIGHTS, SOCK_CLOEXEC, SOCK_NONBLOCK, TCP_MAXSEG,
+        MSG_DONTWAIT, SCM_RIGHTS, TCP_MAXSEG,
     };
 
     #[cfg(any(

--- a/stdlib/src/socket.rs
+++ b/stdlib/src/socket.rs
@@ -40,9 +40,10 @@ mod _socket {
         pub use winapi::shared::ws2def::*;
         pub use winapi::shared::ws2ipdef::*;
         pub use winapi::um::winsock2::{
-            SD_BOTH as SHUT_RDWR, SD_RECEIVE as SHUT_RD, SD_SEND as SHUT_WR, SOCK_DGRAM, SOCK_RAW,
-            SOCK_RDM, SOCK_SEQPACKET, SOCK_STREAM, SOL_SOCKET, SO_BROADCAST, SO_ERROR, SO_LINGER,
-            SO_OOBINLINE, SO_REUSEADDR, SO_TYPE, *,
+            IPPORT_RESERVED, SD_BOTH as SHUT_RDWR, SD_RECEIVE as SHUT_RD, SD_SEND as SHUT_WR,
+            SOCK_DGRAM, SOCK_RAW, SOCK_RDM, SOCK_SEQPACKET, SOCK_STREAM, SOL_SOCKET, SO_BROADCAST,
+            SO_ERROR, SO_EXCLUSIVEADDRUSE, SO_LINGER, SO_OOBINLINE, SO_REUSEADDR, SO_TYPE,
+            SO_USELOOPBACK, *,
         };
         pub use winapi::um::ws2tcpip::*;
     }

--- a/stdlib/src/socket.rs
+++ b/stdlib/src/socket.rs
@@ -35,8 +35,11 @@ mod _socket {
     #[cfg(windows)]
     mod c {
         pub use winapi::shared::ifdef::IF_MAX_STRING_SIZE as IF_NAMESIZE;
+        pub use winapi::shared::mstcpip::*;
         pub use winapi::shared::netioapi::{if_indextoname, if_nametoindex};
         pub use winapi::shared::ws2def::*;
+        pub use winapi::shared::ws2ipdef::*;
+        pub use winapi::shared::ws2tcpip::*;
         pub use winapi::um::winsock2::{
             SD_BOTH as SHUT_RDWR, SD_RECEIVE as SHUT_RD, SD_SEND as SHUT_WR, SOCK_DGRAM, SOCK_RAW,
             SOCK_RDM, SOCK_SEQPACKET, SOCK_STREAM, SOL_SOCKET, SO_BROADCAST, SO_ERROR, SO_LINGER,
@@ -70,6 +73,567 @@ mod _socket {
     #[cfg(not(target_os = "redox"))]
     #[pyattr]
     use c::{SOCK_RAW, SOCK_RDM, SOCK_SEQPACKET};
+
+    #[cfg(target_os = "android")]
+    #[pyattr]
+    use c::{SOL_ATALK, SOL_AX25, SOL_IPX, SOL_NETROM, SOL_ROSE};
+
+    #[cfg(target_os = "freebsd")]
+    #[pyattr]
+    use c::SO_SETFIB;
+
+    #[cfg(target_os = "linux")]
+    #[pyattr]
+    use c::{
+        CAN_BCM, CAN_EFF_FLAG, CAN_EFF_MASK, CAN_ERR_FLAG, CAN_ERR_MASK, CAN_ISOTP, CAN_J1939,
+        CAN_RAW, CAN_RAW_ERR_FILTER, CAN_RAW_FD_FRAMES, CAN_RAW_FILTER, CAN_RAW_JOIN_FILTERS,
+        CAN_RAW_LOOPBACK, CAN_RAW_RECV_OWN_MSGS, CAN_RTR_FLAG, CAN_SFF_MASK, IPPROTO_MPTCP,
+        J1939_IDLE_ADDR, J1939_MAX_UNICAST_ADDR, J1939_NLA_BYTES_ACKED, J1939_NLA_PAD,
+        J1939_NO_ADDR, J1939_NO_NAME, J1939_NO_PGN, J1939_PGN_ADDRESS_CLAIMED,
+        J1939_PGN_ADDRESS_COMMANDED, J1939_PGN_MAX, J1939_PGN_PDU1_MAX, J1939_PGN_REQUEST,
+        SCM_J1939_DEST_ADDR, SCM_J1939_DEST_NAME, SCM_J1939_ERRQUEUE, SCM_J1939_PRIO, SOL_CAN_BASE,
+        SOL_CAN_RAW, SO_J1939_ERRQUEUE, SO_J1939_FILTER, SO_J1939_PROMISC, SO_J1939_SEND_PRIO,
+    };
+
+    #[cfg(all(target_os = "linux", target_env = "gnu"))]
+    #[pyattr]
+    use c::SOL_RDS;
+
+    #[cfg(target_os = "netbsd")]
+    #[pyattr]
+    use c::IPPROTO_VRRP;
+
+    #[cfg(target_vendor = "apple")]
+    #[pyattr]
+    use c::{AF_SYSTEM, PF_SYSTEM, SYSPROTO_CONTROL, TCP_KEEPALIVE};
+
+    #[cfg(windows)]
+    #[pyattr]
+    use c::{
+        IPPORT_RESERVED, IPPROTO_IPV4, RCVALL_IPLEVEL, RCVALL_OFF, RCVALL_ON,
+        RCVALL_SOCKETLEVELONLY, SIO_KEEPALIVE_VALS, SIO_LOOPBACK_FAST_PATH, SIO_RCVALL,
+        SO_EXCLUSIVEADDRUSE,
+    };
+
+    #[cfg(not(windows))]
+    #[pyattr]
+    const IPPORT_RESERVED: i32 = 1024;
+
+    #[pyattr]
+    const IPPORT_USERRESERVED: i32 = 5000;
+
+    #[cfg(any(unix, target_os = "android"))]
+    #[pyattr]
+    use c::{
+        EAI_SYSTEM, MSG_EOR, SO_ACCEPTCONN, SO_DEBUG, SO_DONTROUTE, SO_KEEPALIVE, SO_RCVBUF,
+        SO_RCVLOWAT, SO_RCVTIMEO, SO_SNDBUF, SO_SNDLOWAT, SO_SNDTIMEO,
+    };
+
+    #[cfg(any(target_os = "android", target_os = "linux"))]
+    #[pyattr]
+    use c::{
+        ALG_OP_DECRYPT, ALG_OP_ENCRYPT, ALG_SET_AEAD_ASSOCLEN, ALG_SET_AEAD_AUTHSIZE, ALG_SET_IV,
+        ALG_SET_KEY, ALG_SET_OP, IPV6_DSTOPTS, IPV6_NEXTHOP, IPV6_PATHMTU, IPV6_RECVDSTOPTS,
+        IPV6_RECVHOPLIMIT, IPV6_RECVHOPOPTS, IPV6_RECVPATHMTU, IPV6_RTHDRDSTOPTS,
+        IP_DEFAULT_MULTICAST_LOOP, IP_RECVOPTS, IP_RETOPTS, NETLINK_CRYPTO, NETLINK_DNRTMSG,
+        NETLINK_FIREWALL, NETLINK_IP6_FW, NETLINK_NFLOG, NETLINK_ROUTE, NETLINK_USERSOCK,
+        NETLINK_XFRM, SOL_ALG, SO_PASSSEC, SO_PEERSEC,
+    };
+
+    #[cfg(any(target_os = "android", target_vendor = "apple"))]
+    #[pyattr]
+    use c::{AI_DEFAULT, AI_MASK, AI_V4MAPPED_CFG};
+
+    #[cfg(any(target_os = "freebsd", target_os = "netbsd"))]
+    #[pyattr]
+    use c::MSG_NOTIFICATION;
+
+    #[cfg(any(target_os = "fuchsia", target_os = "linux"))]
+    #[pyattr]
+    use c::TCP_USER_TIMEOUT;
+
+    #[cfg(any(unix, target_os = "android", windows))]
+    #[pyattr]
+    use c::{
+        INADDR_BROADCAST, IPV6_MULTICAST_HOPS, IPV6_MULTICAST_IF, IPV6_MULTICAST_LOOP,
+        IPV6_UNICAST_HOPS, IPV6_V6ONLY, IP_ADD_MEMBERSHIP, IP_DROP_MEMBERSHIP, IP_MULTICAST_IF,
+        IP_MULTICAST_LOOP, IP_MULTICAST_TTL, IP_TTL,
+    };
+
+    #[cfg(any(unix, target_os = "android", windows))]
+    #[pyattr]
+    const INADDR_UNSPEC_GROUP: u32 = 0xe0000000;
+
+    #[cfg(any(unix, target_os = "android", windows))]
+    #[pyattr]
+    const INADDR_ALLHOSTS_GROUP: u32 = 0xe0000001;
+
+    #[cfg(any(unix, target_os = "android", windows))]
+    #[pyattr]
+    const INADDR_MAX_LOCAL_GROUP: u32 = 0xe00000ff;
+
+    #[cfg(any(target_os = "android", target_os = "fuchsia", target_os = "linux"))]
+    #[pyattr]
+    use c::{
+        AF_ALG, AF_ASH, AF_ATMPVC, AF_ATMSVC, AF_AX25, AF_BRIDGE, AF_CAN, AF_ECONET, AF_IRDA,
+        AF_LLC, AF_NETBEUI, AF_NETLINK, AF_NETROM, AF_PACKET, AF_PPPOX, AF_RDS, AF_SECURITY,
+        AF_TIPC, AF_VSOCK, AF_WANPIPE, AF_X25, IP_TRANSPARENT, MSG_CONFIRM, MSG_ERRQUEUE,
+        MSG_FASTOPEN, MSG_MORE, PF_CAN, PF_PACKET, PF_RDS, SCM_CREDENTIALS, SOL_IP, SOL_TIPC,
+        SOL_UDP, SO_BINDTODEVICE, SO_MARK, TCP_CORK, TCP_DEFER_ACCEPT, TCP_LINGER2, TCP_QUICKACK,
+        TCP_SYNCNT, TCP_WINDOW_CLAMP,
+    };
+
+    // gated on presence of AF_VSOCK:
+    #[cfg(any(target_os = "android", target_os = "fuchsia", target_os = "linux"))]
+    #[pyattr]
+    const SO_VM_SOCKETS_BUFFER_SIZE: u32 = 0;
+
+    // gated on presence of AF_VSOCK:
+    #[cfg(any(target_os = "android", target_os = "fuchsia", target_os = "linux"))]
+    #[pyattr]
+    const SO_VM_SOCKETS_BUFFER_MIN_SIZE: u32 = 1;
+
+    // gated on presence of AF_VSOCK:
+    #[cfg(any(target_os = "android", target_os = "fuchsia", target_os = "linux"))]
+    #[pyattr]
+    const SO_VM_SOCKETS_BUFFER_MAX_SIZE: u32 = 2;
+
+    // gated on presence of AF_VSOCK:
+    #[cfg(any(target_os = "android", target_os = "fuchsia", target_os = "linux"))]
+    #[pyattr]
+    const VMADDR_CID_ANY: u32 = 0xffffffff; // 0xffffffff
+
+    // gated on presence of AF_VSOCK:
+    #[cfg(any(target_os = "android", target_os = "fuchsia", target_os = "linux"))]
+    #[pyattr]
+    const VMADDR_PORT_ANY: u32 = 0xffffffff; // 0xffffffff
+
+    // gated on presence of AF_VSOCK:
+    #[cfg(any(target_os = "android", target_os = "fuchsia", target_os = "linux"))]
+    #[pyattr]
+    const VMADDR_CID_HOST: u32 = 2;
+
+    // gated on presence of AF_VSOCK:
+    #[cfg(any(target_os = "android", target_os = "fuchsia", target_os = "linux"))]
+    #[pyattr]
+    const VM_SOCKETS_INVALID_VERSION: u32 = 0xffffffff; // 0xffffffff
+
+    // TODO: gated on https://github.com/rust-lang/libc/pull/1662
+    // // gated on presence of AF_VSOCK:
+    // #[cfg(any(target_os = "android", target_os = "fuchsia", target_os = "linux"))]
+    // #[pyattr(name = "IOCTL_VM_SOCKETS_GET_LOCAL_CID", once)]
+    // fn ioctl_vm_sockets_get_local_cid(_vm: &VirtualMachine) -> i32 {
+    //     c::_IO(7, 0xb9)
+    // }
+
+    #[cfg(not(any(target_os = "android", target_os = "fuchsia", target_os = "linux")))]
+    #[pyattr]
+    const SOL_IP: i32 = 0;
+
+    #[cfg(not(any(target_os = "android", target_os = "fuchsia", target_os = "linux")))]
+    #[pyattr]
+    const SOL_UDP: i32 = 17;
+
+    #[cfg(any(target_os = "android", target_os = "linux", windows))]
+    #[pyattr]
+    use c::{IPV6_HOPOPTS, IPV6_RECVRTHDR, IPV6_RTHDR, IP_OPTIONS};
+
+    #[cfg(any(
+        target_os = "dragonfly",
+        target_os = "freebsd",
+        target_vendor = "apple"
+    ))]
+    #[pyattr]
+    use c::{IPPROTO_HELLO, IPPROTO_XTP, LOCAL_PEERCRED, MSG_EOF};
+
+    #[cfg(any(target_os = "netbsd", target_os = "openbsd", windows))]
+    #[pyattr]
+    use c::{MSG_BCAST, MSG_MCAST};
+
+    #[cfg(any(
+        target_os = "android",
+        target_os = "fuchsia",
+        target_os = "freebsd",
+        target_os = "linux"
+    ))]
+    #[pyattr]
+    use c::{IPPROTO_UDPLITE, TCP_CONGESTION};
+
+    #[cfg(any(
+        target_os = "android",
+        target_os = "fuchsia",
+        target_os = "freebsd",
+        target_os = "linux"
+    ))]
+    #[pyattr]
+    const UDPLITE_SEND_CSCOV: i32 = 10;
+
+    #[cfg(any(
+        target_os = "android",
+        target_os = "fuchsia",
+        target_os = "freebsd",
+        target_os = "linux"
+    ))]
+    #[pyattr]
+    const UDPLITE_RECV_CSCOV: i32 = 11;
+
+    #[cfg(any(
+        target_os = "android",
+        target_os = "fuchsia",
+        target_os = "linux",
+        target_os = "openbsd"
+    ))]
+    #[pyattr]
+    use c::AF_KEY;
+
+    #[cfg(any(
+        target_os = "android",
+        target_os = "fuchsia",
+        target_os = "linux",
+        target_os = "redox"
+    ))]
+    #[pyattr]
+    use c::SO_DOMAIN;
+
+    #[cfg(any(
+        target_os = "android",
+        target_os = "fuchsia",
+        all(
+            target_os = "linux",
+            any(
+                target_arch = "aarch64",
+                target_arch = "i686",
+                target_arch = "mips",
+                target_arch = "powerpc",
+                target_arch = "powerpc64",
+                target_arch = "powerpc64le",
+                target_arch = "riscv64gc",
+                target_arch = "s390x",
+                target_arch = "x86_64"
+            )
+        ),
+        target_os = "redox"
+    ))]
+    #[pyattr]
+    use c::SO_PRIORITY;
+
+    #[cfg(any(
+        target_os = "dragonfly",
+        target_os = "freebsd",
+        target_os = "netbsd",
+        target_os = "openbsd"
+    ))]
+    #[pyattr]
+    use c::IPPROTO_MOBILE;
+
+    #[cfg(any(
+        target_os = "dragonfly",
+        target_os = "freebsd",
+        target_os = "netbsd",
+        target_vendor = "apple"
+    ))]
+    #[pyattr]
+    use c::SCM_CREDS;
+
+    #[cfg(any(
+        target_os = "freebsd",
+        target_os = "fuchsia",
+        target_os = "linux",
+        target_vendor = "apple"
+    ))]
+    #[pyattr]
+    use c::TCP_FASTOPEN;
+
+    #[cfg(any(
+        target_os = "android",
+        target_os = "freebsd",
+        target_os = "fuchsia",
+        all(
+            target_os = "linux",
+            any(
+                target_arch = "aarch64",
+                target_arch = "i686",
+                target_arch = "mips",
+                target_arch = "powerpc",
+                target_arch = "powerpc64",
+                target_arch = "powerpc64le",
+                target_arch = "riscv64gc",
+                target_arch = "s390x",
+                target_arch = "x86_64"
+            )
+        ),
+        target_os = "redox"
+    ))]
+    #[pyattr]
+    use c::SO_PROTOCOL;
+
+    #[cfg(any(
+        target_os = "android",
+        target_os = "dragonfly",
+        target_os = "freebsd",
+        target_os = "linux",
+        windows
+    ))]
+    #[pyattr]
+    use c::IPV6_DONTFRAG;
+
+    #[cfg(any(
+        target_os = "android",
+        target_os = "dragonfly",
+        target_os = "fuchsia",
+        target_os = "linux",
+        target_os = "redox"
+    ))]
+    #[pyattr]
+    use c::{SO_PASSCRED, SO_PEERCRED};
+
+    #[cfg(any(
+        target_os = "android",
+        target_os = "freebsd",
+        target_os = "fuchsia",
+        target_os = "linux",
+        target_os = "netbsd"
+    ))]
+    #[pyattr]
+    use c::TCP_INFO;
+
+    #[cfg(any(
+        target_os = "android",
+        target_os = "freebsd",
+        target_os = "fuchsia",
+        target_os = "linux",
+        target_vendor = "apple"
+    ))]
+    #[pyattr]
+    use c::IP_RECVTOS;
+
+    #[cfg(any(
+        target_os = "android",
+        target_os = "netbsd",
+        target_os = "redox",
+        target_vendor = "apple",
+        windows
+    ))]
+    #[pyattr]
+    use c::NI_MAXSERV;
+
+    #[cfg(any(
+        target_os = "dragonfly",
+        target_os = "freebsd",
+        target_os = "netbsd",
+        target_os = "openbsd",
+        target_vendor = "apple"
+    ))]
+    #[pyattr]
+    use c::{IPPROTO_EON, IPPROTO_IPCOMP};
+
+    #[cfg(any(
+        target_os = "dragonfly",
+        target_os = "freebsd",
+        target_os = "netbsd",
+        target_vendor = "apple",
+        windows
+    ))]
+    #[pyattr]
+    use c::IPPROTO_ND;
+
+    #[cfg(any(
+        target_os = "android",
+        target_os = "dragonfly",
+        target_os = "freebsd",
+        target_os = "linux",
+        target_vendor = "apple",
+        windows
+    ))]
+    #[pyattr]
+    use c::{IPV6_CHECKSUM, IPV6_HOPLIMIT};
+
+    #[cfg(any(
+        target_os = "android",
+        target_os = "freebsd",
+        target_os = "fuchsia",
+        target_os = "linux",
+        target_os = "netbsd"
+    ))]
+    #[pyattr]
+    use c::IPPROTO_SCTP; // also in windows
+
+    #[cfg(any(
+        target_os = "android",
+        target_os = "freebsd",
+        target_os = "fuchsia",
+        target_os = "linux",
+        target_vendor = "apple",
+        windows
+    ))]
+    #[pyattr]
+    use c::{AI_ALL, AI_V4MAPPED};
+
+    #[cfg(any(
+        target_os = "android",
+        target_os = "linux",
+        target_os = "netbsd",
+        target_os = "openbsd",
+        target_vendor = "apple",
+        windows
+    ))]
+    #[pyattr]
+    use c::EAI_NODATA;
+
+    #[cfg(any(
+        target_os = "dragonfly",
+        target_os = "freebsd",
+        target_os = "netbsd",
+        target_os = "openbsd",
+        target_vendor = "apple",
+        windows
+    ))]
+    #[pyattr]
+    use c::{
+        AF_LINK, IPPROTO_GGP, IPV6_JOIN_GROUP, IPV6_LEAVE_GROUP, IP_RECVDSTADDR, SO_USELOOPBACK,
+    };
+
+    #[cfg(any(
+        target_os = "android",
+        target_os = "dragonfly",
+        target_os = "freebsd",
+        target_os = "fuchsia",
+        target_os = "linux",
+        target_os = "netbsd",
+        target_os = "openbsd"
+    ))]
+    #[pyattr]
+    use c::{MSG_CMSG_CLOEXEC, MSG_NOSIGNAL};
+
+    #[cfg(any(
+        target_os = "android",
+        target_os = "dragonfly",
+        target_os = "freebsd",
+        target_os = "fuchsia",
+        target_os = "linux",
+        target_os = "netbsd",
+        target_os = "redox"
+    ))]
+    #[pyattr]
+    use c::TCP_KEEPIDLE;
+
+    #[cfg(any(
+        target_os = "android",
+        target_os = "dragonfly",
+        target_os = "freebsd",
+        target_os = "fuchsia",
+        target_os = "linux",
+        target_os = "netbsd",
+        target_vendor = "apple"
+    ))]
+    #[pyattr]
+    use c::{TCP_KEEPCNT, TCP_KEEPINTVL};
+
+    #[cfg(any(
+        target_os = "android",
+        target_os = "dragonfly",
+        target_os = "freebsd",
+        target_os = "fuchsia",
+        target_os = "linux",
+        target_os = "netbsd",
+        target_os = "openbsd",
+        target_vendor = "apple"
+    ))]
+    #[pyattr]
+    use c::{
+        AF_ROUTE, AF_SNA, EAI_OVERFLOW, IPPROTO_GRE, IPPROTO_RSVP, IPPROTO_TP, IPV6_RECVPKTINFO,
+        MSG_DONTWAIT, SCM_RIGHTS, SOCK_CLOEXEC, SOCK_NONBLOCK, TCP_MAXSEG,
+    };
+
+    #[cfg(any(
+        target_os = "android",
+        target_os = "dragonfly",
+        target_os = "freebsd",
+        target_os = "linux",
+        target_os = "netbsd",
+        target_os = "openbsd",
+        target_vendor = "apple",
+        windows
+    ))]
+    #[pyattr]
+    use c::IPV6_PKTINFO;
+
+    #[cfg(any(
+        target_os = "android",
+        target_os = "freebsd",
+        target_os = "fuchsia",
+        target_os = "linux",
+        target_os = "netbsd",
+        target_os = "openbsd",
+        target_vendor = "apple",
+        windows
+    ))]
+    #[pyattr]
+    use c::AI_CANONNAME;
+
+    #[cfg(any(
+        target_os = "android",
+        target_os = "dragonfly",
+        target_os = "freebsd",
+        target_os = "fuchsia",
+        target_os = "linux",
+        target_os = "netbsd",
+        target_os = "openbsd",
+        target_vendor = "apple",
+        windows
+    ))]
+    #[pyattr]
+    use c::{
+        EAI_AGAIN, EAI_BADFLAGS, EAI_FAIL, EAI_FAMILY, EAI_MEMORY, EAI_NONAME, EAI_SERVICE,
+        EAI_SOCKTYPE, IPV6_RECVTCLASS, IPV6_TCLASS, IP_HDRINCL, IP_TOS, SOMAXCONN,
+    };
+
+    #[cfg(not(any(
+        target_os = "android",
+        target_os = "dragonfly",
+        target_os = "freebsd",
+        target_os = "fuchsia",
+        target_os = "linux",
+        target_os = "netbsd",
+        target_os = "openbsd",
+        target_vendor = "apple",
+        windows
+    )))]
+    #[pyattr]
+    const SOMAXCONN: i32 = 5; // Common value
+
+    // HERE IS WHERE THE BLUETOOTH CONSTANTS START
+    // TODO: there should be a more intelligent way of detecting bluetooth on a platform.
+    //       CPython uses header-detection, but blocks NetBSD and DragonFly BSD
+    #[cfg(any(
+        target_os = "android",
+        target_os = "freebsd",
+        target_os = "fuchsia",
+        target_os = "linux",
+        target_os = "openbsd"
+    ))]
+    #[pyattr]
+    use c::AF_BLUETOOTH;
+
+    #[cfg(any(
+        target_os = "android",
+        target_os = "freebsd",
+        target_os = "fuchsia",
+        target_os = "linux",
+        target_os = "openbsd"
+    ))]
+    #[pyattr]
+    const BDADDR_ANY: &str = "00:00:00:00:00:00";
+    #[cfg(any(
+        target_os = "android",
+        target_os = "freebsd",
+        target_os = "fuchsia",
+        target_os = "linux",
+        target_os = "openbsd"
+    ))]
+    #[pyattr]
+    const BDADDR_LOCAL: &str = "00:00:00:FF:FF:FF";
+    // HERE IS WHERE THE BLUETOOTH CONSTANTS END
 
     #[cfg(windows)]
     #[pyattr]


### PR DESCRIPTION
The following constants may be missing from either rust's `libc` or the `winapi` crate (as of 4 July 2022):

- `AF_AAL5`
- `NETLINK_SKIP`
- `NETLINK_W1`
- `NETLINK_TCPDIAG`
- `NETLINK_ARPD`
- `NETLINK_ROUTE6`
- `NETLINK_TAPBASE`
- `AF_QIPCRTR`
- `BLUETOOTH_PROTO_L2CAP`
- `BLUETOOTH_PROTO_HCI`
- `SOL_HCI_RAW`
- `SO_HCI_RAW_FILTER`
- `HCI_TIME_STAMP`
- `HCI_DATA_DIR`
- `BLUETOOTH_PROTO_RFCOMM`
- `BTPROTO_SCO`
- `PACKET_HOST`
- `PACKET_BROADCAST`
- `PACKET_MULTICAST`
- `PACKET_OTHERHOST`
- `PACKET_OUTGOING`
- `PACKET_LOOPBACK`
- `PACKET_FASTROUTE`
- `TIPC_ADDR_NAMESEQ`
- `TIPC_ADDR_NAME`
- `TIPC_ADDR_ID`
- `TIPC_ZONE_SCOPE`
- `TIPC_CLUSTER_SCOPE`
- `TIPC_NODE_SCOPE`
- `TIPC_IMPORTANCE`
- `TIPC_SRC_DROPPABLE`
- `TIPC_DEST_DROPPABLE`
- `TIPC_CONN_TIMEOUT`
- `TIPC_LOW_IMPORTANCE`
- `TIPC_MEDIUM_IMPORTANCE`
- `TIPC_HIGH_IMPORTANCE`
- `TIPC_CRITICAL_IMPORTANCE`
- `TIPC_SUB_PORTS`
- `TIPC_SUB_SERVICE`
- `TIPC_SUB_CANCEL`
- `TIPC_WAIT_FOREVER`
- `TIPC_PUBLISHED`
- `TIPC_WITHDRAWN`
- `TIPC_SUBSCR_TIMEOUT`
- `TIPC_CFG_SRV`
- `TIPC_TOP_SRV`
- `ALG_SET_PUBKEY`
- `ALG_OP_SIGN`
- `ALG_OP_VERIFY`
- `MSG_BTAG`
- `MSG_ETAG`
- `TX_SETUP`
- `TX_DELETE`
- `TX_READ`
- `TX_SEND`
- `RX_SETUP`
- `RX_DELETE`
- `RX_READ`
- `TX_STATUS`
- `TX_EXPIRED`
- `RX_STATUS`
- `RX_TIMEOUT`
- `RX_CHANGED`
- `SETTIMER`
- `STARTTIMER`
- `TX_COUNTEVT`
- `TX_ANNOUNCE`
- `TX_CP_CAN_ID`
- `RX_FILTER_ID`
- `RX_CHECK_DLC`
- `RX_NO_AUTOTIMER`
- `RX_ANNOUNCE_RESUME`
- `TX_RESET_MULTI_IDX`
- `RX_RTR_FRAME`
- `CAN_FD_FRAME`
- `J1939_EE_INFO_NONE`
- `J1939_EE_INFO_TX_ABORT`
- `J1939_FILTER_MAX`
- `RDS_CANCEL_SENT_TO`
- `RDS_GET_MR`
- `RDS_FREE_MR`
- `RDS_RECVERR`
- `RDS_CONG_MONITOR`
- `RDS_GET_MR_FOR_DEST`
- `IPPROTO_IPV4`
- `IPPROTO_BIP`
- `IPPORT_USERRESERVED`
- `INADDR_UNSPEC_GROUP`
- `INADDR_ALLHOSTS_GROUP`
- `INADDR_MAX_LOCAL_GROUP`
- `IP_RECVRETOPTS`
- `IP_MAX_MEMBERSHIPS`
- `IPV6_RTHDR_TYPE_0`
- `IPV6_USE_MIN_MTU`
- `TCP_NOTSENT_LOWAT`
- `IPX_TYPE`
- `RDS_CMSG_RDMA_ARGS`
- `RDS_CMSG_RDMA_DEST`
- `RDS_CMSG_RDMA_MAP`
- `RDS_CMSG_RDMA_STATUS`
- `RDS_CMSG_RDMA_UPDATE`
- `RDS_RDMA_READWRITE`
- `RDS_RDMA_FENCE`
- `RDS_RDMA_INVALIDATE`
- `RDS_RDMA_USE_ONCE`
- `RDS_RDMA_DONTWAIT`
- `RDS_RDMA_NOTIFY_ME`
- `RDS_RDMA_SILENT`
- `EAI_ADDRFAMILY`
- `EAI_BADHINTS`
- `EAI_PROTOCOL`
- `EAI_MAX`
- `RCVALL_MAX`
