### PR TITLE
Fix `str.join` (#3841)

### DIFF
--- a/vm/src/builtins/str.rs
+++ b/vm/src/builtins/str.rs
@@ -928,9 +928,13 @@ impl PyStr {
     }
 
     #[pymethod]
-    fn join(&self, iterable: ArgIterable<PyStrRef>, vm: &VirtualMachine) -> PyResult<String> {
-        let iter = iterable.iter(vm)?;
-        self.as_str().py_join(iter)
+    fn join(&self, iterable: ArgIterable<PyStrRef>, vm: &VirtualMachine) -> PyResult<PyStrRef> {
+        let mut iter = iterable.iter(vm)?;
+
+        match iter.size_hint().0 {
+          1 => Ok(iter.next().unwrap().unwrap()),
+          _ => Ok(vm.ctx.new_str(self.as_str().py_join(iter).unwrap()))
+        }
     }
 
     // FIXME: two traversals of str is expensive


### PR DESCRIPTION
Fix #3841.