### PR TITLE
Fix union args

### DIFF
--- a/Lib/test/test_types.py
+++ b/Lib/test/test_types.py
@@ -755,8 +755,6 @@ class UnionTests(unittest.TestCase):
         self.assertIs((int | TV)[int], int)
         self.assertIs((TV | int)[int], int)
 
-    # TODO: RUSTPYTHON
-    @unittest.expectedFailure
     def test_union_args(self):
         def check(arg, expected):
             clear_typing_caches()

--- a/vm/src/builtins/genericalias.rs
+++ b/vm/src/builtins/genericalias.rs
@@ -194,7 +194,7 @@ impl PyGenericAlias {
     fn ror(zelf: PyObjectRef, other: PyObjectRef, vm: &VirtualMachine) -> PyObjectRef {
         type_::_or(other, zelf, vm)
     }
-    
+
     #[pymethod(magic)]
     fn or(zelf: PyObjectRef, other: PyObjectRef, vm: &VirtualMachine) -> PyObjectRef {
         type_::_or(zelf, other, vm)

--- a/vm/src/builtins/genericalias.rs
+++ b/vm/src/builtins/genericalias.rs
@@ -1,3 +1,4 @@
+use super::union_;
 use crate::{
     builtins::{PyList, PyStr, PyStrRef, PyTuple, PyTupleRef, PyType, PyTypeRef},
     class::PyClassImpl,
@@ -187,6 +188,17 @@ impl PyGenericAlias {
     fn subclasscheck(_zelf: PyRef<Self>, _obj: PyObjectRef, vm: &VirtualMachine) -> PyResult {
         Err(vm
             .new_type_error("issubclass() argument 2 cannot be a parameterized generic".to_owned()))
+    }
+
+    #[pymethod(name = "__ror__")]
+    #[pymethod(magic)]
+    fn or(zelf: PyObjectRef, other: PyObjectRef, vm: &VirtualMachine) -> PyObjectRef {
+        if !union_::is_unionable(zelf.clone(), vm) || !union_::is_unionable(other.clone(), vm) {
+            return vm.ctx.not_implemented();
+        }
+
+        let tuple = PyTuple::new_ref(vec![zelf, other], &vm.ctx);
+        union_::make_union(tuple, vm)
     }
 }
 

--- a/vm/src/builtins/genericalias.rs
+++ b/vm/src/builtins/genericalias.rs
@@ -192,12 +192,12 @@ impl PyGenericAlias {
 
     #[pymethod(magic)]
     fn ror(zelf: PyObjectRef, other: PyObjectRef, vm: &VirtualMachine) -> PyObjectRef {
-        type_::_or(other, zelf, vm)
+        type_::or_(other, zelf, vm)
     }
 
     #[pymethod(magic)]
     fn or(zelf: PyObjectRef, other: PyObjectRef, vm: &VirtualMachine) -> PyObjectRef {
-        type_::_or(zelf, other, vm)
+        type_::or_(zelf, other, vm)
     }
 }
 

--- a/vm/src/builtins/genericalias.rs
+++ b/vm/src/builtins/genericalias.rs
@@ -190,7 +190,16 @@ impl PyGenericAlias {
             .new_type_error("issubclass() argument 2 cannot be a parameterized generic".to_owned()))
     }
 
-    #[pymethod(name = "__ror__")]
+    #[pymethod(magic)]
+    fn ror(zelf: PyObjectRef, other: PyObjectRef, vm: &VirtualMachine) -> PyObjectRef {
+        if !union_::is_unionable(zelf.clone(), vm) || !union_::is_unionable(other.clone(), vm) {
+            return vm.ctx.not_implemented();
+        }
+
+        let tuple = PyTuple::new_ref(vec![other, zelf], &vm.ctx);
+        union_::make_union(tuple, vm)
+    }
+
     #[pymethod(magic)]
     fn or(zelf: PyObjectRef, other: PyObjectRef, vm: &VirtualMachine) -> PyObjectRef {
         if !union_::is_unionable(zelf.clone(), vm) || !union_::is_unionable(other.clone(), vm) {

--- a/vm/src/builtins/genericalias.rs
+++ b/vm/src/builtins/genericalias.rs
@@ -1,4 +1,4 @@
-use super::union_;
+use super::type_;
 use crate::{
     builtins::{PyList, PyStr, PyStrRef, PyTuple, PyTupleRef, PyType, PyTypeRef},
     class::PyClassImpl,
@@ -192,22 +192,12 @@ impl PyGenericAlias {
 
     #[pymethod(magic)]
     fn ror(zelf: PyObjectRef, other: PyObjectRef, vm: &VirtualMachine) -> PyObjectRef {
-        if !union_::is_unionable(zelf.clone(), vm) || !union_::is_unionable(other.clone(), vm) {
-            return vm.ctx.not_implemented();
-        }
-
-        let tuple = PyTuple::new_ref(vec![other, zelf], &vm.ctx);
-        union_::make_union(tuple, vm)
+        type_::_or(other, zelf, vm)
     }
-
+    
     #[pymethod(magic)]
     fn or(zelf: PyObjectRef, other: PyObjectRef, vm: &VirtualMachine) -> PyObjectRef {
-        if !union_::is_unionable(zelf.clone(), vm) || !union_::is_unionable(other.clone(), vm) {
-            return vm.ctx.not_implemented();
-        }
-
-        let tuple = PyTuple::new_ref(vec![zelf, other], &vm.ctx);
-        union_::make_union(tuple, vm)
+        type_::_or(zelf, other, vm)
     }
 }
 

--- a/vm/src/builtins/singletons.rs
+++ b/vm/src/builtins/singletons.rs
@@ -1,6 +1,5 @@
-use super::{PyType, PyTypeRef, union_};
+use super::{PyType, PyTypeRef};
 use crate::{
-    builtins::PyTuple,
     class::PyClassImpl, convert::ToPyObject, types::Constructor, Context, Py, PyObjectRef,
     PyPayload, PyResult, VirtualMachine,
 };
@@ -47,29 +46,9 @@ impl PyNone {
         "None".to_owned()
     }
 
-    // NoneType has no __args__ function,
-    // so it fails that an union type includes 'None'
-    // in "test_types::UnionTests::test_union_args".
-
-    // #[pyproperty(magic)]
-    // fn args(&self) -> PyObjectRef {
-    //     self.args.clone().into()
-    // }
-
     #[pymethod(magic)]
     fn bool(&self) -> bool {
         false
-    }
-
-    #[pymethod(name = "__ror__")]
-    #[pymethod(magic)]
-    fn or(zelf: PyObjectRef, other: PyObjectRef, vm: &VirtualMachine) -> PyObjectRef {
-        if !union_::is_unionable(zelf.clone(), vm) || !union_::is_unionable(other.clone(), vm) {
-            return vm.ctx.not_implemented();
-        }
-
-        let tuple = PyTuple::new_ref(vec![zelf, other], &vm.ctx);
-        union_::make_union(tuple, vm)
     }
 }
 

--- a/vm/src/builtins/type.rs
+++ b/vm/src/builtins/type.rs
@@ -405,22 +405,12 @@ impl PyType {
 
     #[pymethod(magic)]
     pub fn ror(zelf: PyObjectRef, other: PyObjectRef, vm: &VirtualMachine) -> PyObjectRef {
-        if !union_::is_unionable(zelf.clone(), vm) || !union_::is_unionable(other.clone(), vm) {
-            return vm.ctx.not_implemented();
-        }
-
-        let tuple = PyTuple::new_ref(vec![other, zelf], &vm.ctx);
-        union_::make_union(tuple, vm)
+        _or(other, zelf, vm)
     }
 
     #[pymethod(magic)]
     pub fn or(zelf: PyObjectRef, other: PyObjectRef, vm: &VirtualMachine) -> PyObjectRef {
-        if !union_::is_unionable(zelf.clone(), vm) || !union_::is_unionable(other.clone(), vm) {
-            return vm.ctx.not_implemented();
-        }
-
-        let tuple = PyTuple::new_ref(vec![zelf, other], &vm.ctx);
-        union_::make_union(tuple, vm)
+        _or(zelf, other, vm)
     }
 
     #[pyslot]
@@ -834,6 +824,16 @@ pub(crate) fn call_slot_new(
     }
     unreachable!("Should be able to find a new slot somewhere in the mro")
 }
+
+pub(super) fn _or(zelf: PyObjectRef, other: PyObjectRef, vm: &VirtualMachine) -> PyObjectRef {
+    if !union_::is_unionable(zelf.clone(), vm) || !union_::is_unionable(other.clone(), vm) {
+        return vm.ctx.not_implemented();
+    }
+
+    let tuple = PyTuple::new_ref(vec![zelf, other], &vm.ctx);
+    union_::make_union(tuple, vm)
+}
+
 
 fn take_next_base(bases: &mut [Vec<PyTypeRef>]) -> Option<PyTypeRef> {
     for base in bases.iter() {

--- a/vm/src/builtins/type.rs
+++ b/vm/src/builtins/type.rs
@@ -834,7 +834,6 @@ pub(super) fn _or(zelf: PyObjectRef, other: PyObjectRef, vm: &VirtualMachine) ->
     union_::make_union(tuple, vm)
 }
 
-
 fn take_next_base(bases: &mut [Vec<PyTypeRef>]) -> Option<PyTypeRef> {
     for base in bases.iter() {
         let head = base[0].clone();

--- a/vm/src/builtins/type.rs
+++ b/vm/src/builtins/type.rs
@@ -403,7 +403,16 @@ impl PyType {
         zelf.iter_mro().map(|cls| cls.clone().into()).collect()
     }
 
-    #[pymethod(name = "__ror__")]
+    #[pymethod(magic)]
+    pub fn ror(zelf: PyObjectRef, other: PyObjectRef, vm: &VirtualMachine) -> PyObjectRef {
+        if !union_::is_unionable(zelf.clone(), vm) || !union_::is_unionable(other.clone(), vm) {
+            return vm.ctx.not_implemented();
+        }
+
+        let tuple = PyTuple::new_ref(vec![other, zelf], &vm.ctx);
+        union_::make_union(tuple, vm)
+    }
+
     #[pymethod(magic)]
     pub fn or(zelf: PyObjectRef, other: PyObjectRef, vm: &VirtualMachine) -> PyObjectRef {
         if !union_::is_unionable(zelf.clone(), vm) || !union_::is_unionable(other.clone(), vm) {

--- a/vm/src/builtins/type.rs
+++ b/vm/src/builtins/type.rs
@@ -405,12 +405,12 @@ impl PyType {
 
     #[pymethod(magic)]
     pub fn ror(zelf: PyObjectRef, other: PyObjectRef, vm: &VirtualMachine) -> PyObjectRef {
-        _or(other, zelf, vm)
+        or_(other, zelf, vm)
     }
 
     #[pymethod(magic)]
     pub fn or(zelf: PyObjectRef, other: PyObjectRef, vm: &VirtualMachine) -> PyObjectRef {
-        _or(zelf, other, vm)
+        or_(zelf, other, vm)
     }
 
     #[pyslot]
@@ -825,7 +825,7 @@ pub(crate) fn call_slot_new(
     unreachable!("Should be able to find a new slot somewhere in the mro")
 }
 
-pub(super) fn _or(zelf: PyObjectRef, other: PyObjectRef, vm: &VirtualMachine) -> PyObjectRef {
+pub(super) fn or_(zelf: PyObjectRef, other: PyObjectRef, vm: &VirtualMachine) -> PyObjectRef {
     if !union_::is_unionable(zelf.clone(), vm) || !union_::is_unionable(other.clone(), vm) {
         return vm.ctx.not_implemented();
     }

--- a/vm/src/builtins/union.rs
+++ b/vm/src/builtins/union.rs
@@ -104,7 +104,7 @@ impl PyUnion {
     #[pymethod(name = "__ror__")]
     #[pymethod(magic)]
     fn or(zelf: PyObjectRef, other: PyObjectRef, vm: &VirtualMachine) -> PyObjectRef {
-        type_::_or(zelf, other, vm)
+        type_::or_(zelf, other, vm)
     }
 }
 

--- a/vm/src/builtins/union.rs
+++ b/vm/src/builtins/union.rs
@@ -167,7 +167,7 @@ fn flatten_args(args: PyTupleRef, vm: &VirtualMachine) -> PyTupleRef {
     for arg in &args {
         if let Some(pyref) = arg.downcast_ref::<PyUnion>() {
             flattened_args.extend(pyref.args.iter().cloned());
-        } else if arg.payload_if_subclass::<PyNone>(vm).is_some() {
+        } else if vm.is_none(arg) {
             flattened_args.push(vm.ctx.types.none_type.as_ref().to_pyobject(vm).clone());
         } else {
             flattened_args.push(arg.clone());

--- a/vm/src/builtins/union.rs
+++ b/vm/src/builtins/union.rs
@@ -79,6 +79,23 @@ impl PyUnion {
             .join(" | "))
     }
 
+    // TODO: Add 'or' method(__or__, __ror__)
+    // #[pymethod(name = "__ror__")]
+    // #[pymethod(magic)]
+    // fn or(&self, other: PyObjectRef, vm: &VirtualMachine) -> PyObjectRef {
+
+    // }
+    #[pymethod(name = "__ror__")]
+    #[pymethod(magic)]
+    pub fn or(zelf: PyObjectRef, other: PyObjectRef, vm: &VirtualMachine) -> PyObjectRef {
+        if !is_unionable(zelf.clone(), vm) || !is_unionable(other.clone(), vm) {
+            return vm.ctx.not_implemented();
+        }
+
+        let tuple = PyTuple::new_ref(vec![zelf, other], &vm.ctx);
+        make_union(tuple, vm)
+    }
+
     #[pyproperty(magic)]
     fn parameters(&self) -> PyObjectRef {
         self.parameters.clone().into()

--- a/vm/src/builtins/union.rs
+++ b/vm/src/builtins/union.rs
@@ -1,4 +1,4 @@
-use super::genericalias;
+use super::{genericalias, PyNone};
 use crate::{
     builtins::{PyFrozenSet, PyStr, PyStrRef, PyTuple, PyTupleRef, PyType, PyTypeRef},
     class::PyClassImpl,
@@ -167,6 +167,8 @@ fn flatten_args(args: PyTupleRef, vm: &VirtualMachine) -> PyTupleRef {
     for arg in &args {
         if let Some(pyref) = arg.downcast_ref::<PyUnion>() {
             flattened_args.extend(pyref.args.iter().cloned());
+        } else if arg.payload_if_subclass::<PyNone>(vm).is_some() {
+            flattened_args.push(vm.ctx.types.none_type.as_ref().to_pyobject(vm).clone());
         } else {
             flattened_args.push(arg.clone());
         };

--- a/vm/src/builtins/union.rs
+++ b/vm/src/builtins/union.rs
@@ -100,6 +100,17 @@ impl PyUnion {
         Err(vm
             .new_type_error("issubclass() argument 2 cannot be a parameterized generic".to_owned()))
     }
+
+    #[pymethod(name = "__ror__")]
+    #[pymethod(magic)]
+    fn or(zelf: PyObjectRef, other: PyObjectRef, vm: &VirtualMachine) -> PyObjectRef {
+        if !is_unionable(zelf.clone(), vm) || !is_unionable(other.clone(), vm) {
+            return vm.ctx.not_implemented();
+        }
+
+        let tuple = PyTuple::new_ref(vec![zelf, other], &vm.ctx);
+        make_union(tuple, vm)
+    }
 }
 
 pub fn is_unionable(obj: PyObjectRef, vm: &VirtualMachine) -> bool {

--- a/vm/src/builtins/union.rs
+++ b/vm/src/builtins/union.rs
@@ -163,7 +163,7 @@ fn flatten_args(args: PyTupleRef, vm: &VirtualMachine) -> PyTupleRef {
         if let Some(pyref) = arg.downcast_ref::<PyUnion>() {
             flattened_args.extend(pyref.args.iter().cloned());
         } else if vm.is_none(arg) {
-            flattened_args.push(vm.ctx.types.none_type.as_ref().to_pyobject(vm).clone());
+            flattened_args.push(vm.ctx.types.none_type.to_owned().into());
         } else {
             flattened_args.push(arg.clone());
         };

--- a/vm/src/builtins/union.rs
+++ b/vm/src/builtins/union.rs
@@ -1,4 +1,4 @@
-use super::{genericalias, PyNone};
+use super::{genericalias, type_};
 use crate::{
     builtins::{PyFrozenSet, PyStr, PyStrRef, PyTuple, PyTupleRef, PyType, PyTypeRef},
     class::PyClassImpl,
@@ -104,12 +104,7 @@ impl PyUnion {
     #[pymethod(name = "__ror__")]
     #[pymethod(magic)]
     fn or(zelf: PyObjectRef, other: PyObjectRef, vm: &VirtualMachine) -> PyObjectRef {
-        if !is_unionable(zelf.clone(), vm) || !is_unionable(other.clone(), vm) {
-            return vm.ctx.not_implemented();
-        }
-
-        let tuple = PyTuple::new_ref(vec![zelf, other], &vm.ctx);
-        make_union(tuple, vm)
+        type_::_or(zelf, other, vm)
     }
 }
 

--- a/vm/src/builtins/union.rs
+++ b/vm/src/builtins/union.rs
@@ -79,23 +79,6 @@ impl PyUnion {
             .join(" | "))
     }
 
-    // TODO: Add 'or' method(__or__, __ror__)
-    // #[pymethod(name = "__ror__")]
-    // #[pymethod(magic)]
-    // fn or(&self, other: PyObjectRef, vm: &VirtualMachine) -> PyObjectRef {
-
-    // }
-    #[pymethod(name = "__ror__")]
-    #[pymethod(magic)]
-    pub fn or(zelf: PyObjectRef, other: PyObjectRef, vm: &VirtualMachine) -> PyObjectRef {
-        if !is_unionable(zelf.clone(), vm) || !is_unionable(other.clone(), vm) {
-            return vm.ctx.not_implemented();
-        }
-
-        let tuple = PyTuple::new_ref(vec![zelf, other], &vm.ctx);
-        make_union(tuple, vm)
-    }
-
     #[pyproperty(magic)]
     fn parameters(&self) -> PyObjectRef {
         self.parameters.clone().into()


### PR DESCRIPTION
I'm focusing on fixing `test_types::UnionTests::test_union_args`.
Modifying or Adding operator or(|) function for python's `Lib/typing.py`.

It fails, however, when the very last check procedures proceed.
The problem is `NoneType` has no `__args__` function.
I tried making that function, but I cannot guess how to do it
cuz I completely don't know how `PyNone` struct works.

Anyway I got pass at least for the previous check routines.
Thx.