### PR TITLE
Improve frozenset debug representation

### DIFF
--- a/vm/src/builtins/set.rs
+++ b/vm/src/builtins/set.rs
@@ -66,7 +66,8 @@ impl fmt::Debug for PySet {
 impl fmt::Debug for PyFrozenSet {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         // TODO: implement more detailed, non-recursive Debug formatter
-        f.write_str("frozenset")
+        f.write_str("PyFrozenSet ")?;
+        f.debug_set().entries(self.elements().iter()).finish()
     }
 }
 


### PR DESCRIPTION
This pull request tries to improve `frozenset`'s debug representation. But there is a comment *"implement more detailed, non-recursive Debug formatter`"* 🤔. So if this pull request's change can occur errors, please let me know it 🙏🏻 

For `frozenset([1, 2, "str"])` object, it is represented as `PyFrozenSet {[PyObject PyInt { value: 1 }], [PyObject PyInt { value: 2 }], [PyObject PyStr { value: "str", kind: Ascii, hash: -845154580267954013 }]}`

For `frozenset(['a', frozenset(['a'])])`, it is represented as `PyFrozenSet {[PyObject PyStr { value: "a", kind: Ascii, hash: -1579463412027138821 }], [PyObject PyFrozenSet {[PyObject PyStr { value: "a", kind: Ascii, hash: -1579463412027138821 }]}]}`.