### PR TITLE
Fix byte indices must be integers or slices, error message

### DIFF
--- a/Lib/test/test_bytes.py
+++ b/Lib/test/test_bytes.py
@@ -989,8 +989,6 @@ class BaseBytesTest:
 class BytesTest(BaseBytesTest, unittest.TestCase):
     type2test = bytes
 
-    # TODO: RUSTPYTHON
-    @unittest.expectedFailure
     def test_getitem_error(self):
         b = b'python'
         msg = "byte indices must be integers or slices"

--- a/vm/src/builtins/bytes.rs
+++ b/vm/src/builtins/bytes.rs
@@ -167,7 +167,7 @@ impl PyBytes {
     }
 
     fn _getitem(&self, needle: &PyObject, vm: &VirtualMachine) -> PyResult {
-        match SequenceIndex::try_from_borrowed_object(vm, needle, "bytes")? {
+        match SequenceIndex::try_from_borrowed_object(vm, needle, "byte")? {
             SequenceIndex::Int(i) => self
                 .inner
                 .elements


### PR DESCRIPTION
`b = b'python'`
`b['a']`

TypeError: bytes indices must be integers or slices or classes that override __index__ operator, not 'str'
=> TypeError: byte indices must be integers or slices or classes that override __index__ operator, not 'str'