### PR TITLE
Remove `PyGetSet.deleter`

### DIFF
--- a/vm/src/builtins/function.rs
+++ b/vm/src/builtins/function.rs
@@ -620,10 +620,6 @@ impl PyCell {
     fn set_cell_contents(&self, x: PyObjectRef) {
         self.set(Some(x))
     }
-    #[pyproperty(deleter)]
-    fn del_cell_contents(&self) {
-        self.set(None)
-    }
 }
 
 pub fn init(context: &Context) {

--- a/vm/src/stdlib/io.rs
+++ b/vm/src/stdlib/io.rs
@@ -2312,9 +2312,15 @@ mod _io {
         }
 
         #[pyproperty(setter, name = "_CHUNK_SIZE")]
-        fn set_chunksize(&self, chunk_size: usize, vm: &VirtualMachine) -> PyResult<()> {
+        fn set_chunksize(&self, chunk_size: Option<usize>, vm: &VirtualMachine) -> PyResult<()> {
             let mut textio = self.lock(vm)?;
-            textio.chunk_size = chunk_size;
+            match chunk_size {
+                Some(chunk_size) => textio.chunk_size = chunk_size,
+                None => Err(vm.new_attribute_error("cannot delete attribute".to_owned()))?,
+            };
+            // TODO: RUSTPYTHON
+            // Change chunk_size type, validate it manually and throws ValueError if invalid.
+            // https://github.com/python/cpython/blob/2e9da8e3522764d09f1d6054a2be567e91a30812/Modules/_io/textio.c#L3124-L3143
             Ok(())
         }
 


### PR DESCRIPTION
This pull request tries to resolve #3897, #3899. You can run the below code in the main branch (before this pull request) and you'll see the result message like below:

```
>>>>> import sys
>>>>> frame = sys._getframe()
>>>>> del frame.f_trace
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
AttributeError: attribute 'f_trace' of 'frame' objects is not writable
```

But after this pull request, it became deletable.

```
>>>>> import sys
>>>>> frame = sys._getframe()
>>>>> del frame.f_trace
>>>>> frame.f_trace = "a"
>>>>> frame.f_trace
'a'
>>>>> del frame.f_trace
>>>>> frame.f_trace
```