### PR TITLE
Fix weakref richcompare

### DIFF
--- a/Lib/test/test_weakref.py
+++ b/Lib/test/test_weakref.py
@@ -2138,12 +2138,12 @@ __test__ = {'libreftest' : libreftest}
 def test_main():
     support.run_unittest(
         ReferencesTestCase,
-        # WeakMethodTestCase,
-        # MappingTestCase,
-        # WeakValueDictionaryTestCase,
-        # WeakKeyDictionaryTestCase,
-        # SubclassableWeakrefTestCase,
-        # FinalizeTestCase,
+        WeakMethodTestCase,
+        MappingTestCase,
+        WeakValueDictionaryTestCase,
+        WeakKeyDictionaryTestCase,
+        SubclassableWeakrefTestCase,
+        FinalizeTestCase,
         )
     # TODO: RUSTPYTHON
     # support.run_doctest(sys.modules[__name__])

--- a/Lib/test/test_weakref.py
+++ b/Lib/test/test_weakref.py
@@ -228,8 +228,6 @@ class ReferencesTestCase(TestBase):
         self.assertIs(proxy1, proxy2,
                      "proxy object w/out callback should have been re-used")
 
-    # TODO: RUSTPYTHON
-    @unittest.expectedFailure
     def test_basic_proxy(self):
         o = C()
         self.check_proxy(o, weakref.proxy(o))
@@ -250,7 +248,7 @@ class ReferencesTestCase(TestBase):
         L2 = collections.UserList(L)
         p2 = weakref.proxy(L2)
         self.assertEqual(p, p2)
-        ## self.assertEqual(repr(L2), repr(p2))
+        self.assertEqual(repr(L2), repr(p2))
         L3 = collections.UserList(range(10))
         p3 = weakref.proxy(L3)
         self.assertEqual(L3[:], p3[:])
@@ -2140,12 +2138,12 @@ __test__ = {'libreftest' : libreftest}
 def test_main():
     support.run_unittest(
         ReferencesTestCase,
-        WeakMethodTestCase,
-        MappingTestCase,
-        WeakValueDictionaryTestCase,
-        WeakKeyDictionaryTestCase,
-        SubclassableWeakrefTestCase,
-        FinalizeTestCase,
+        # WeakMethodTestCase,
+        # MappingTestCase,
+        # WeakValueDictionaryTestCase,
+        # WeakKeyDictionaryTestCase,
+        # SubclassableWeakrefTestCase,
+        # FinalizeTestCase,
         )
     # TODO: RUSTPYTHON
     # support.run_doctest(sys.modules[__name__])

--- a/Lib/test/test_weakref.py
+++ b/Lib/test/test_weakref.py
@@ -248,7 +248,7 @@ class ReferencesTestCase(TestBase):
         L2 = collections.UserList(L)
         p2 = weakref.proxy(L2)
         self.assertEqual(p, p2)
-        self.assertEqual(repr(L2), repr(p2))
+        ## self.assertEqual(repr(L2), repr(p2))
         L3 = collections.UserList(range(10))
         p3 = weakref.proxy(L3)
         self.assertEqual(L3[:], p3[:])

--- a/vm/src/builtins/weakproxy.rs
+++ b/vm/src/builtins/weakproxy.rs
@@ -58,7 +58,7 @@ crate::common::static_cell! {
     static WEAK_SUBCLASS: PyTypeRef;
 }
 
-#[pyimpl(with(GetAttr, SetAttr, Constructor, AsSequence, AsMapping))]
+#[pyimpl(with(GetAttr, SetAttr, Constructor, Comparable, AsSequence, AsMapping))]
 impl PyWeakProxy {
     fn try_upgrade(&self, vm: &VirtualMachine) -> PyResult {
         self.weak.upgrade().ok_or_else(|| new_reference_error(vm))
@@ -88,6 +88,7 @@ impl PyWeakProxy {
         self.try_upgrade(vm)?.repr(vm)
     }
 
+    #[pymethod(magic)]
     fn contains(&self, needle: PyObjectRef, vm: &VirtualMachine) -> PyResult<bool> {
         let obj = self.try_upgrade(vm)?;
         PySequence::contains(&obj, &needle, vm)


### PR DESCRIPTION
Resolve `test_weakref::ReferencesTestCase::test_basic_proxy`

fix: #3909 