### PR TITLE
implement TextIOBase encoding attribute

### DIFF
--- a/vm/src/stdlib/io.rs
+++ b/vm/src/stdlib/io.rs
@@ -704,7 +704,12 @@ mod _io {
     struct _TextIOBase;
 
     #[pyimpl(flags(BASETYPE))]
-    impl _TextIOBase {}
+    impl _TextIOBase {
+        #[pyattr]
+        fn encoding(vm: &VirtualMachine) -> PyObjectRef {
+            vm.ctx.none()
+        }
+    }
 
     #[derive(FromArgs, Clone)]
     struct BufferSize {

--- a/vm/src/stdlib/io.rs
+++ b/vm/src/stdlib/io.rs
@@ -701,12 +701,13 @@ mod _io {
     // TextIO Base has no public constructor
     #[pyattr]
     #[pyclass(name = "_TextIOBase", base = "_IOBase")]
+    #[derive(Debug, PyPayload)]
     struct _TextIOBase;
 
     #[pyimpl(flags(BASETYPE))]
     impl _TextIOBase {
-        #[pyattr]
-        fn encoding(vm: &VirtualMachine) -> PyObjectRef {
+        #[pyproperty]
+        fn encoding(&self, vm: &VirtualMachine) -> PyObjectRef {
             vm.ctx.none()
         }
     }


### PR DESCRIPTION
fix #3896 

- python3
```
>>> import io
>>> io.TextIOBase.encoding
<attribute 'encoding' of '_io._TextIOBase' objects>
```
- RustPython
```
>>>>> import io
>>>>> io.TextIOBase.encoding
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
AttributeError: 'TextIOBase' object has no attribute 'encoding'
```