### PR TITLE
Add `or`, `ror` and`ior` to `defaultdict`

### DIFF
--- a/Lib/collections/_defaultdict.py
+++ b/Lib/collections/_defaultdict.py
@@ -41,7 +41,7 @@ class defaultdict(dict):
 
     def __or__(self, other):
         if not isinstance(other, dict):
-            raise TypeError(f'unsupported operand type(s) for |: \'collections.{self.__class__.__qualname__}\' and \'{type(other).__qualname__}\'')
+            return NotImplemented
 
         new = defaultdict(self.default_factory, self)
         new.update(other)
@@ -49,14 +49,10 @@ class defaultdict(dict):
 
     def __ror__(self, other):
         if not isinstance(other, dict):
-            raise TypeError(f'unsupported operand type(s) for |: \'collections.{self.__class__.__qualname__}\' and \'{type(other).__qualname__}\'')
+            return NotImplemented
 
         new = defaultdict(self.default_factory, other)
         new.update(self)
         return new
-
-    def __ior__(self, other):
-        self.update(other)
-        return self
 
 defaultdict.__module__ = 'collections'

--- a/Lib/collections/_defaultdict.py
+++ b/Lib/collections/_defaultdict.py
@@ -39,4 +39,24 @@ class defaultdict(dict):
             args = ()
         return type(self), args, None, None, iter(self.items())
 
+    def __or__(self, other):
+        if not isinstance(other, dict):
+            raise TypeError(f'unsupported operand type(s) for |: \'collections.{self.__class__.__qualname__}\' and \'{type(other).__qualname__}\'')
+
+        new = defaultdict(self.default_factory, self)
+        new.update(other)
+        return new
+
+    def __ror__(self, other):
+        if not isinstance(other, dict):
+            raise TypeError(f'unsupported operand type(s) for |: \'collections.{self.__class__.__qualname__}\' and \'{type(other).__qualname__}\'')
+
+        new = defaultdict(self.default_factory, other)
+        new.update(self)
+        return new
+
+    def __ior__(self, other):
+        self.update(other)
+        return self
+
 defaultdict.__module__ = 'collections'

--- a/Lib/test/test_defaultdict.py
+++ b/Lib/test/test_defaultdict.py
@@ -150,8 +150,6 @@ class TestDefaultDict(unittest.TestCase):
             o = pickle.loads(s)
             self.assertEqual(d, o)
 
-    # TODO: RUSTPYTHON
-    @unittest.expectedFailure
     def test_union(self):
         i = defaultdict(int, {1: 1, 2: 2})
         s = defaultdict(str, {0: "zero", 1: "one"})


### PR DESCRIPTION
Fixes #3933.

## Reference

cpython's `defaultdict` implementation: https://github.com/python/cpython/blob/3.10/Modules/_collectionsmodule.c#L2160-L2190