### PR TITLE
Fix: `range` beyond the isize range

### DIFF
--- a/Lib/test/test_range.py
+++ b/Lib/test/test_range.py
@@ -375,8 +375,6 @@ class RangeTest(unittest.TestCase):
                     self.assertEqual(list(pickle.loads(pickle.dumps(r, proto))),
                                      list(r))
 
-    # TODO: RUSTPYTHON
-    @unittest.expectedFailure
     def test_iterator_pickling(self):
         testcases = [(13,), (0, 11), (-22, 10), (20, 3, -1), (13, 21, 3),
                      (-2, 2, 2)]

--- a/vm/src/builtins/range.rs
+++ b/vm/src/builtins/range.rs
@@ -476,8 +476,8 @@ impl Iterable for PyRange {
             zelf.step.as_bigint(),
             zelf.len(),
         );
-        if let (Some(start), Some(step), Some(_)) =
-            (start.to_isize(), step.to_isize(), stop.to_isize())
+        if let (Some(start), Some(step), Some(_), Some(_)) =
+            (start.to_isize(), step.to_isize(), stop.to_isize(), (start + step).to_isize())
         {
             Ok(PyRangeIterator {
                 index: AtomicCell::new(0),

--- a/vm/src/builtins/range.rs
+++ b/vm/src/builtins/range.rs
@@ -476,9 +476,12 @@ impl Iterable for PyRange {
             zelf.step.as_bigint(),
             zelf.len(),
         );
-        if let (Some(start), Some(step), Some(_), Some(_)) =
-            (start.to_isize(), step.to_isize(), stop.to_isize(), (start + step).to_isize())
-        {
+        if let (Some(start), Some(step), Some(_), Some(_)) = (
+            start.to_isize(),
+            step.to_isize(),
+            stop.to_isize(),
+            (start + step).to_isize(),
+        ) {
             Ok(PyRangeIterator {
                 index: AtomicCell::new(0),
                 start,


### PR DESCRIPTION
* Check if start + step is greater than sys.maxsize

Close #3936 
An attempt was made to implement the pickle-related function of the range iter, but the implementation was already completed.
The real problem is the difference in behavior with cpython.
In cpython, even if only start + step of range exceeds the range of int, longrange_iter is returned, but in rustpython, only start, stop, and step exceed the range of int.