### PR TITLE
Update `_mut_iter_equal_skeleton` method

### DIFF
--- a/Lib/test/list_tests.py
+++ b/Lib/test/list_tests.py
@@ -304,8 +304,6 @@ class CommonTest(seq_tests.CommonTest):
         self.assertRaises(TypeError, a.pop, 42, 42)
         a = self.type2test([0, 10, 20, 30, 40])
 
-    # TODO: RUSTPYTHON
-    @unittest.expectedFailure
     def test_remove(self):
         a = self.type2test([0, 0, 1])
         a.remove(1)
@@ -365,8 +363,6 @@ class CommonTest(seq_tests.CommonTest):
             # verify that original order and values are retained.
             self.assertIs(x, y)
 
-    # TODO: RUSTPYTHON
-    @unittest.expectedFailure
     def test_index(self):
         super().test_index()
         a = self.type2test([-2, -1, 0, 0, 1, 2])

--- a/Lib/test/test_deque.py
+++ b/Lib/test/test_deque.py
@@ -929,21 +929,6 @@ class TestSequence(seq_tests.CommonTest):
         # For now, bypass tests that require slicing
         self.skipTest("Exhausted deque iterator doesn't free a deque")
 
-    # TODO: RUSTPYTHON
-    @unittest.expectedFailure
-    def test_contains_fake(self):  # XXX: RUSTPYTHON; the method also need to be removed when done
-        super().test_contains_fake()
-
-    # TODO: RUSTPYTHON
-    @unittest.expectedFailure
-    def test_count(self):  # XXX: RUSTPYTHON; the method also need to be removed when done
-        super().test_count()
-
-    # TODO: RUSTPYTHON
-    @unittest.expectedFailure
-    def test_index(self):  # XXX: RUSTPYTHON; the method also need to be removed when done
-        super().test_index()
-
 #==============================================================================
 
 libreftest = """

--- a/Lib/test/test_list.py
+++ b/Lib/test/test_list.py
@@ -231,15 +231,5 @@ class ListTest(list_tests.CommonTest):
         lst = [X(), X()]
         X() in lst
 
-    # TODO: RUSTPYTHON
-    @unittest.expectedFailure
-    def test_count(self):  # XXX: RUSTPYTHON; the method also need to be removed when done
-        super().test_count()
-
-    # TODO: RUSTPYTHON
-    @unittest.expectedFailure
-    def test_contains_fake(self):  # XXX: RUSTPYTHON; the method also need to be removed when done
-        super().test_contains_fake()
-
 if __name__ == "__main__":
     unittest.main()

--- a/Lib/test/test_userlist.py
+++ b/Lib/test/test_userlist.py
@@ -7,16 +7,6 @@ import unittest
 class UserListTest(list_tests.CommonTest):
     type2test = UserList
 
-    # TODO: RUSTPYTHON
-    @unittest.expectedFailure
-    def test_contains_fake(self):  # XXX: RUSTPYTHON; the method also need to be removed when done
-        super().test_contains_fake()
-
-    # TODO: RUSTPYTHON
-    @unittest.expectedFailure
-    def test_count(self):  # XXX: RUSTPYTHON; the method also need to be removed when done
-        super().test_count()
-
     import sys
     @unittest.skipIf(sys.platform == "win32", "TODO: RUSTPYTHON, unexpectedly panics somewhere")
     def test_repr_deep(self):  # XXX: RUSTPYTHON; remove this method when fixed


### PR DESCRIPTION
This code is tested based on `list_tests.py::CommonTest::test_remove`,
except for lines `352~358` that seem related to `str` test.