### PR TITLE
Precision bug fix when `FormatType` is `None`

### DIFF
--- a/Lib/test/test_float.py
+++ b/Lib/test/test_float.py
@@ -777,8 +777,6 @@ class FormatTestCase(unittest.TestCase):
                 self.assertEqual(fmt % float(arg), rhs)
                 self.assertEqual(fmt % -float(arg), '-' + rhs)
 
-    # TODO: RUSTPYTHON
-    @unittest.expectedFailure
     def test_issue5864(self):
         self.assertEqual(format(123.456, '.4'), '123.5')
         self.assertEqual(format(1234.56, '.4'), '1.235e+03')

--- a/common/src/float_ops.rs
+++ b/common/src/float_ops.rs
@@ -188,6 +188,7 @@ pub fn format_general(
     magnitude: f64,
     case: Case,
     alternate_form: bool,
+    always_shows_fract: bool,
 ) -> String {
     match magnitude {
         magnitude if magnitude.is_finite() => {
@@ -195,7 +196,7 @@ pub fn format_general(
             let mut parts = r_exp.splitn(2, 'e');
             let base = parts.next().unwrap();
             let exponent = parts.next().unwrap().parse::<i64>().unwrap();
-            if exponent < -4 || exponent >= (precision as i64) {
+            if exponent < -4 || exponent + (always_shows_fract as i64) >= (precision as i64) {
                 let e = match case {
                     Case::Lower => 'e',
                     Case::Upper => 'E',

--- a/vm/src/cformat.rs
+++ b/vm/src/cformat.rs
@@ -348,6 +348,7 @@ impl CFormatSpec {
                     magnitude,
                     case,
                     self.flags.contains(CConversionFlags::ALTERNATE_FORM),
+                    false,
                 )
             }
             _ => unreachable!(),

--- a/vm/src/format.rs
+++ b/vm/src/format.rs
@@ -408,7 +408,18 @@ impl FormatSpec {
             None => match magnitude {
                 magnitude if magnitude.is_nan() => Ok("nan".to_owned()),
                 magnitude if magnitude.is_infinite() => Ok("inf".to_owned()),
-                _ => Ok(float_ops::to_string(magnitude)),
+                _ => match self.precision {
+                    Some(_) => {
+                        let precision = self.precision.unwrap_or(magnitude.to_string().len() - 1);
+                        Ok(float_ops::format_general(
+                            precision,
+                            magnitude,
+                            float_ops::Case::Lower,
+                            false,
+                        ))
+                    }
+                    None => Ok(float_ops::to_string(magnitude)),
+                },
             },
         };
 

--- a/vm/src/format.rs
+++ b/vm/src/format.rs
@@ -379,6 +379,7 @@ impl FormatSpec {
                     magnitude,
                     float_ops::Case::Upper,
                     false,
+                    false,
                 ))
             }
             Some(FormatType::GeneralFormatLower) => {
@@ -387,6 +388,7 @@ impl FormatSpec {
                     precision,
                     magnitude,
                     float_ops::Case::Lower,
+                    false,
                     false,
                 ))
             }
@@ -416,6 +418,7 @@ impl FormatSpec {
                             magnitude,
                             float_ops::Case::Lower,
                             false,
+                            true,
                         ))
                     }
                     None => Ok(float_ops::to_string(magnitude)),


### PR DESCRIPTION
In this revision, 
* Bugs about precision handling malfunction are fixed.

---
- [X] 1) Precision handing is not working when the `FormatType` is `None`.

Before:
```
>>>>> print('{:.2}'.format(math.pi))
3.141592653589793
```
After:
```
>>>>> print('{:.2}'.format(math.pi))
3.1
```

---
- [x] 2) Must includes at least one digit past the decimal point. 

RUSTPython:
```
print('{}'.format(60.0)) // 60 
print('{}'.format(120.0)) // 120 
```
CPython:
```
print('{}'.format(60.0)) // 60.0
print('{}'.format(120.0)) // 120.0
```

---
- [x] 3) `self.precision.unwrap_or(6);` should not apply when `FormatType` is `None`.

RUSTPython:
```
print('{}'.format(math.pi)) // 3.14159
```
CPython:
```
print('{}'.format(math.pi)) // 3.141592653589793
```

---
- [x] 4)  Must use scientific notation even if the rounded number does not have fractional part.

RUSTPython:
```
print('{:.2}'.format(math.pi)) // 3.1
print('{:.2}'.format(math.pi * 10)) // 31
print('{:.2}'.format(math.pi * 100)) // 3.1e+02
```
CPython:
```
print('{:.2}'.format(math.pi)) // 3.1
print('{:.2}'.format(math.pi * 10)) // 3.1e+01
print('{:.2}'.format(math.pi * 100)) // 3.1e+02
```