### PR TITLE
Fix `PyFloat::py_new` always returning new float object issue

### DIFF
--- a/extra_tests/snippets/builtin_float.py
+++ b/extra_tests/snippets/builtin_float.py
@@ -441,6 +441,8 @@ assert float('inf').hex() == 'inf'
 assert float('-inf').hex() == '-inf'
 assert float('nan').hex() == 'nan'
 
+assert float(math.nan) is float(math.nan)
+
 # Test float exponent:
 assert 1 if 1else 0 == 1
 

--- a/vm/src/builtins/float.rs
+++ b/vm/src/builtins/float.rs
@@ -142,8 +142,7 @@ impl Constructor for PyFloat {
         let float_val = match arg {
             OptionalArg::Missing => 0.0,
             OptionalArg::Present(val) => {
-                if cls.is(vm.ctx.types.float_type) && val.payload_if_exact::<PyFloat>(vm).is_some()
-                {
+                if cls.is(vm.ctx.types.float_type) && val.class().is(vm.ctx.types.float_type) {
                     return Ok(val);
                 }
 

--- a/vm/src/builtins/float.rs
+++ b/vm/src/builtins/float.rs
@@ -142,7 +142,7 @@ impl Constructor for PyFloat {
         let float_val = match arg {
             OptionalArg::Missing => 0.0,
             OptionalArg::Present(val) => {
-                if let Some(_) = val.payload_if_exact::<PyFloat>(vm) {
+                if val.payload_if_exact::<PyFloat>(vm).is_some() {
                     return Ok(val);
                 } else if let Some(f) = val.try_float_opt(vm)? {
                     f.value

--- a/vm/src/builtins/float.rs
+++ b/vm/src/builtins/float.rs
@@ -142,9 +142,14 @@ impl Constructor for PyFloat {
         let float_val = match arg {
             OptionalArg::Missing => 0.0,
             OptionalArg::Present(val) => {
-                if val.payload_if_exact::<PyFloat>(vm).is_some() {
-                    return Ok(val);
-                } else if let Some(f) = val.try_float_opt(vm)? {
+                if cls.is(vm.ctx.types.float_type) {
+                    return match val.downcast_exact::<PyFloat>(vm) {
+                        Ok(f) => Ok(f.to_pyobject(vm)),
+                        Err(val) => Ok(val),
+                    };
+                }
+
+                if let Some(f) = val.try_float_opt(vm)? {
                     f.value
                 } else {
                     float_from_string(val, vm)?

--- a/vm/src/builtins/float.rs
+++ b/vm/src/builtins/float.rs
@@ -142,7 +142,9 @@ impl Constructor for PyFloat {
         let float_val = match arg {
             OptionalArg::Missing => 0.0,
             OptionalArg::Present(val) => {
-                if let Some(f) = val.try_float_opt(vm)? {
+                if let Some(_) = val.payload_if_exact::<PyFloat>(vm) {
+                    return Ok(val);
+                } else if let Some(f) = val.try_float_opt(vm)? {
                     f.value
                 } else {
                     float_from_string(val, vm)?

--- a/vm/src/builtins/float.rs
+++ b/vm/src/builtins/float.rs
@@ -142,11 +142,9 @@ impl Constructor for PyFloat {
         let float_val = match arg {
             OptionalArg::Missing => 0.0,
             OptionalArg::Present(val) => {
-                if cls.is(vm.ctx.types.float_type) {
-                    return match val.downcast_exact::<PyFloat>(vm) {
-                        Ok(f) => Ok(f.to_pyobject(vm)),
-                        Err(val) => Ok(val),
-                    };
+                if cls.is(vm.ctx.types.float_type) && val.payload_if_exact::<PyFloat>(vm).is_some()
+                {
+                    return Ok(val);
                 }
 
                 if let Some(f) = val.try_float_opt(vm)? {


### PR DESCRIPTION
Fixes #3978.

```
>>>>> import math
>>>>> a = float(math.nan)
>>>>> b = float(math.nan)
>>>>> a is b
>>>>> true
```

## Reference

- https://github.com/python/cpython/blob/main/Objects/abstract.c#L1633-L1635

- https://github.com/RustPython/RustPython/blob/main/vm/src/builtins/int.rs#L258-L264