### PR TITLE
Fix metaclass check classcell

### DIFF
--- a/Lib/test/test_super.py
+++ b/Lib/test/test_super.py
@@ -143,8 +143,6 @@ class TestSuper(unittest.TestCase):
                 return __class__
         self.assertIs(X.f(), X)
 
-    # TODO: RUSTPYTHON
-    @unittest.expectedFailure
     def test___class___new(self):
         # See issue #23722
         # Ensure zero-arg super() works as soon as type.__new__() is completed
@@ -263,8 +261,6 @@ class TestSuper(unittest.TestCase):
                 def f(self):
                     return __class__
 
-    # TODO: RUSTPYTHON
-    @unittest.expectedFailure
     def test___classcell___overwrite(self):
         # See issue #23722
         # Overwriting __classcell__ with nonsense is explicitly prohibited
@@ -279,8 +275,6 @@ class TestSuper(unittest.TestCase):
                     class A(metaclass=Meta, cell=bad_cell):
                         pass
 
-    # TODO: RUSTPYTHON
-    @unittest.expectedFailure
     def test___classcell___wrong_cell(self):
         # See issue #23722
         # Pointing the cell reference at the wrong class is also prohibited

--- a/vm/src/stdlib/builtins.rs
+++ b/vm/src/stdlib/builtins.rs
@@ -913,7 +913,25 @@ mod builtins {
         )?;
 
         if let Some(ref classcell) = classcell {
-            classcell.set(Some(class.clone()));
+            let classcell = classcell.get();
+
+            match classcell {
+                Some(classcell) => {
+                    if !classcell.is(&class) {
+                        return Err(vm.new_type_error(format!(
+                            "__class__ set to {} defining {} as {}",
+                            classcell, meta_name, class
+                        )));
+                    }
+                }
+                None => {
+                    return Err(vm.new_type_error(format!(
+                        "__class__ not set defining {} as {}. 
+                        Was __classcell__ propagated to type.__new__?",
+                        meta_name, class
+                    )));
+                }
+            }
         }
 
         Ok(class)

--- a/vm/src/stdlib/builtins.rs
+++ b/vm/src/stdlib/builtins.rs
@@ -913,24 +913,18 @@ mod builtins {
         )?;
 
         if let Some(ref classcell) = classcell {
-            let classcell = classcell.get();
+            let classcell = classcell.get().ok_or_else(|| {
+                vm.new_type_error(format!(
+                    "__class__ not set defining {} as {}. Was __classcell__ propagated to type.__new__?",
+                    meta_name, class
+                ))
+            })?;
 
-            match classcell {
-                Some(classcell) => {
-                    if !classcell.is(&class) {
-                        return Err(vm.new_type_error(format!(
-                            "__class__ set to {} defining {} as {}",
-                            classcell, meta_name, class
-                        )));
-                    }
-                }
-                None => {
-                    return Err(vm.new_type_error(format!(
-                        "__class__ not set defining {} as {}. 
-                        Was __classcell__ propagated to type.__new__?",
-                        meta_name, class
-                    )));
-                }
+            if !classcell.is(&class) {
+                return Err(vm.new_type_error(format!(
+                    "__class__ set to {} defining {} as {}",
+                    classcell, meta_name, class
+                )));
             }
         }
 

--- a/vm/src/stdlib/builtins.rs
+++ b/vm/src/stdlib/builtins.rs
@@ -915,14 +915,14 @@ mod builtins {
         if let Some(ref classcell) = classcell {
             let classcell = classcell.get().ok_or_else(|| {
                 vm.new_type_error(format!(
-                    "__class__ not set defining {} as {}. Was __classcell__ propagated to type.__new__?",
+                    "__class__ not set defining {:?} as {:?}. Was __classcell__ propagated to type.__new__?",
                     meta_name, class
                 ))
             })?;
 
             if !classcell.is(&class) {
                 return Err(vm.new_type_error(format!(
-                    "__class__ set to {} defining {} as {}",
+                    "__class__ set to {:?} defining {:?} as {:?}",
                     classcell, meta_name, class
                 )));
             }

--- a/vm/src/vm/context.rs
+++ b/vm/src/vm/context.rs
@@ -87,6 +87,7 @@ declare_const_name! {
     __ceil__,
     __cformat__,
     __class__,
+    __classcell__,
     __class_getitem__,
     __complex__,
     __contains__,


### PR DESCRIPTION
- [x] Fix `__build_class__` check `__class__` cell
- [x] Fix `type.__new__` set classcell

When a class object is created with metaclass, the following operation is performed.
[https://docs.python.org/3/reference/datamodel.html?highlight=__classcell__#:~:text=CPython implementation detail%3A In,a RuntimeError in Python 3.8](https://docs.python.org/3/reference/datamodel.html?highlight=__classcell__#:~:text=CPython%20implementation%20detail%3A%20In,a%20RuntimeError%20in%20Python%203.8).

**CPython implementation detail:** In CPython 3.6 and later, the `__class__` cell is passed to the metaclass as a `__classcell__` entry in the class namespace. If present, this must be propagated up to the `type.__new__` call in order for the class to be initialised correctly. Failing to do so will result in a [RuntimeError] in Python 3.8.
1. Error handling when `__class__` (the class it belongs to) and metaclass are different ([bltinmodule.c](https://github.com/python/cpython/blob/3.10/Python/bltinmodule.c#L225-L242))
2. If the result in step 1 is the same, set class in `type.__new__` ([typeobject.c](https://github.com/python/cpython/blob/3.10/Objects/typeobject.c#L3030-L3056))

But in Rust Python it sets classcell without comparing `__class__`.
```rust
if let Some(ref classcell) = classcell {
	  classcell.set(Some(class.clone()));
}
```