### PR TITLE
Relocate generated file location in `whats_left.py`

### DIFF
--- a/whats_left.py
+++ b/whats_left.py
@@ -30,7 +30,7 @@ if not sys.flags.isolated:
     print("python -I whats_left.py")
     exit(1)
 
-GENERATED_FILE = "extra_tests/snippets/not_impl.py"
+GENERATED_FILE = "extra_tests/not_impl.py"
 
 implementation = platform.python_implementation()
 if implementation != "CPython":


### PR DESCRIPTION
With greeting #2448 patch, meta file's location for comparison is moved to `extra_tests/snippets`.
As we registered `extra_tests/not_impl.py` to `.gitignore`, need to relocate it.