### PR TITLE
Correct `binascii.unhexlify` error type

### DIFF
--- a/Lib/test/test_base64.py
+++ b/Lib/test/test_base64.py
@@ -369,8 +369,6 @@ class BaseXYTestCase(unittest.TestCase):
                                b'0102ABCDEF')
         self.check_encode_type_errors(base64.b16encode)
 
-    # TODO: RUSTPYTHON
-    @unittest.expectedFailure
     def test_b16decode(self):
         eq = self.assertEqual
         eq(base64.b16decode(b'0102ABCDEF'), b'\x01\x02\xab\xcd\xef')

--- a/Lib/test/test_binascii.py
+++ b/Lib/test/test_binascii.py
@@ -234,8 +234,6 @@ class BinASCIITest(unittest.TestCase):
         decoded = binascii.rledecode_hqx(encoded)
         self.assertEqual(decoded, data)
 
-    # TODO: RUSTPYTHON
-    @unittest.expectedFailure
     def test_hex(self):
         # test hexlification
         s = b'{s\005\000\000\000worldi\002\000\000\000s\005\000\000\000helloi\001\000\000\0000'

--- a/stdlib/src/binascii.rs
+++ b/stdlib/src/binascii.rs
@@ -60,7 +60,7 @@ mod decl {
     fn unhexlify(data: ArgAsciiBuffer, vm: &VirtualMachine) -> PyResult<Vec<u8>> {
         data.with_ref(|hex_bytes| {
             if hex_bytes.len() % 2 != 0 {
-                return Err(new_binascii_error("Odd-length string".to_string(), vm));
+                return Err(new_binascii_error("Odd-length string".to_owned(), vm));
             }
 
             let mut unhex = Vec::<u8>::with_capacity(hex_bytes.len() / 2);
@@ -69,7 +69,7 @@ mod decl {
                     unhex.push(n1 << 4 | n2);
                 } else {
                     return Err(new_binascii_error(
-                        "Non-hexadecimal digit found".to_string(),
+                        "Non-hexadecimal digit found".to_owned(),
                         vm,
                     ));
                 }

--- a/stdlib/src/binascii.rs
+++ b/stdlib/src/binascii.rs
@@ -60,7 +60,7 @@ mod decl {
     fn unhexlify(data: ArgAsciiBuffer, vm: &VirtualMachine) -> PyResult<Vec<u8>> {
         data.with_ref(|hex_bytes| {
             if hex_bytes.len() % 2 != 0 {
-                return Err(vm.new_value_error("Odd-length string".to_owned()));
+                return Err(new_binascii_error("Odd-length string".to_string(), vm));
             }
 
             let mut unhex = Vec::<u8>::with_capacity(hex_bytes.len() / 2);
@@ -68,7 +68,10 @@ mod decl {
                 if let (Some(n1), Some(n2)) = (unhex_nibble(*n1), unhex_nibble(*n2)) {
                     unhex.push(n1 << 4 | n2);
                 } else {
-                    return Err(vm.new_value_error("Non-hexadecimal digit found".to_owned()));
+                    return Err(new_binascii_error(
+                        "Non-hexadecimal digit found".to_string(),
+                        vm,
+                    ));
                 }
             }
 


### PR DESCRIPTION
Originally, `binascii.unhexlify` raised `ValueError` when odd-length string came. But it should raise `binascii.Error` type error. This pull request does it.