### PR TITLE
Feature: sys.thread_info

### DIFF
--- a/Lib/test/test_sys.py
+++ b/Lib/test/test_sys.py
@@ -573,8 +573,6 @@ class SysModuleTest(unittest.TestCase):
         if not sys.platform.startswith('win'):
             self.assertIsInstance(sys.abiflags, str)
 
-    # TODO: RUSTPYTHON, AttributeError: module 'sys' has no attribute 'thread_info'
-    @unittest.expectedFailure
     def test_thread_info(self):
         info = sys.thread_info
         self.assertEqual(len(info), 3)

--- a/vm/src/stdlib/thread.rs
+++ b/vm/src/stdlib/thread.rs
@@ -18,6 +18,21 @@ pub(crate) mod _thread {
     use std::{cell::RefCell, fmt, thread, time::Duration};
     use thread_local::ThreadLocal;
 
+    // PYTHREAD_NAME: show current thread name
+    pub const PYTHREAD_NAME: Option<&str> = {
+        cfg_if::cfg_if! {
+            if #[cfg(windows)] {
+                Some("nt")
+            } else if #[cfg(unix)] {
+                Some("pthread")
+            } else if #[cfg(any(target_os = "solaris", target_os = "illumos"))] {
+                Some("solaris")
+            } else {
+                None
+            }
+        }
+    };
+
     // TIMEOUT_MAX_IN_MICROSECONDS is a value in microseconds
     #[cfg(not(target_os = "windows"))]
     const TIMEOUT_MAX_IN_MICROSECONDS: i64 = i64::MAX / 1_000;


### PR DESCRIPTION
Implementation - `sys.thread_info` 

close: #4014 