### PR TITLE
Refactor: sys.rs CI problem

### DIFF
--- a/vm/src/stdlib/sys.rs
+++ b/vm/src/stdlib/sys.rs
@@ -12,7 +12,7 @@ mod sys {
         },
         frame::FrameRef,
         function::{FuncArgs, OptionalArg, PosArgs},
-        stdlib::{self, builtins},
+        stdlib::builtins,
         types::PyStructSequence,
         version,
         vm::{Settings, VirtualMachine},
@@ -661,7 +661,7 @@ mod sys {
     #[pyclass(with(PyStructSequence))]
     impl PyThreadInfo {
         const INFO: Self = PyThreadInfo {
-            name: stdlib::thread::_thread::PYTHREAD_NAME,
+            name: crate::stdlib::thread::_thread::PYTHREAD_NAME,
             /// As I know, there's only way to use lock as "Mutex" in Rust
             /// with satisfying python document spec.
             lock: Some("mutex+cond"),


### PR DESCRIPTION
Remove `stdlib::self` in `sys.rs` and refactoring.

```
warning: unused import: `self`
[151](https://github.com/RustPython/RustPython/runs/7802998224?check_suite_focus=true#step:5:152)
  --> vm/src/stdlib/sys.rs:15:18
[152](https://github.com/RustPython/RustPython/runs/7802998224?check_suite_focus=true#step:5:153)
   |
[153](https://github.com/RustPython/RustPython/runs/7802998224?check_suite_focus=true#step:5:154)
15 |         stdlib::{self, builtins},
[154](https://github.com/RustPython/RustPython/runs/7802998224?check_suite_focus=true#step:5:155)
   |                  ^^^^
[155](https://github.com/RustPython/RustPython/runs/7802998224?check_suite_focus=true#step:5:156)
   |
[156](https://github.com/RustPython/RustPython/runs/7802998224?check_suite_focus=true#step:5:157)
   = note: `#[warn(unused_imports)]` on by default
```