### PR TITLE
Partially fix `global` behavior on inner class

### DIFF
--- a/vm/src/frame.rs
+++ b/vm/src/frame.rs
@@ -559,6 +559,16 @@ impl ExecutingFrame<'_> {
             }
             bytecode::Instruction::StoreGlobal(idx) => {
                 let value = self.pop_value();
+                if value.class().is(vm.ctx.types.type_type) {
+                    let qualified_name = value
+                        .get_attr(identifier!(vm, __qualname__), vm)?
+                        .downcast::<PyStr>()
+                        .expect("qualified name to be a string");
+                    let name = qualified_name.as_str().split('.').next_back().unwrap();
+                    value.set_attr(identifier!(vm, __qualname__), vm.new_pyobj(name), vm)?;
+
+                    // TODO: qualname for type_type attrs needs to be set as well
+                }
                 self.globals
                     .set_item(self.code.names[*idx as usize], value, vm)?;
                 Ok(None)


### PR DESCRIPTION
Trying to fix #3993 
---
Using global on inner Subclass now have the same behavior.
![image](https://user-images.githubusercontent.com/11273319/184320366-32ab8eb3-4fb0-4aa2-bca6-66bf0fa53242.png)


but still not correct for the Nested class
![image](https://user-images.githubusercontent.com/11273319/184320415-f6c71954-9530-4c47-9b3d-d1ec47fbe923.png)

Seems that all nested classes need to be handled when applying `global`, need advise on how to fix this in a better way!
Thanks!
