### PR TITLE
Update CI toolchain to stable

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -263,7 +263,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - uses: dtolnay/rust-toolchain@1.62.1
+      - uses: dtolnay/rust-toolchain@stable
         with:
             components: rustfmt, clippy
       - name: run rustfmt


### PR DESCRIPTION
Currently, the `cargo clippy` or the CI `Check Rust code with rustfmt and clippy` job failed.
It warns `clippy::derive_partial_eq_without_eq` as unknown lints but it exists in 1.63.0 release. You can see it through https://rust-lang.github.io/rust-clippy/master/.

At the #4046, it updated the toolchain's version to `1.62.1` from `stable` and the `stable` version was `1.63.0`.

But I see the pull request description while writing this pull request's description:

> I need time to check if the failure is our bug or rust regression.

I don't know its context so it may be intended and if then, this pull request should be closed.