### PR TITLE
Raise `ValueError` if `\x00` character exists for `eval` argument

### DIFF
--- a/Lib/test/test_cmd_line.py
+++ b/Lib/test/test_cmd_line.py
@@ -75,8 +75,6 @@ class CmdLineTest(unittest.TestCase):
         rc, out, err = assert_python_ok('-vv')
         self.assertNotIn(b'stack overflow', err)
 
-    # TODO: RUSTPYTHON
-    @unittest.expectedFailure
     @unittest.skipIf(interpreter_requires_environment(),
                      'Cannot run -E tests when PYTHON env vars are required.')
     def test_xoptions(self):

--- a/Lib/test/test_subprocess.py
+++ b/Lib/test/test_subprocess.py
@@ -761,8 +761,6 @@ class ProcessTestCase(BaseTestCase):
             stdout, stderr = p.communicate()
             self.assertEqual(stdout, b"orange")
 
-    # TODO: RUSTPYTHON
-    @unittest.expectedFailure
     # Windows requires at least the SYSTEMROOT environment variable to start
     # Python
     @unittest.skipIf(sys.platform == 'win32',

--- a/extra_tests/snippets/syntax_non_utf8.py
+++ b/extra_tests/snippets/syntax_non_utf8.py
@@ -5,7 +5,6 @@ from testutils import assert_raises
 
 dir_path = os.path.dirname(os.path.realpath(__file__))
 
-error = ValueError
-with assert_raises(error):
+with assert_raises(ValueError):
     with open(os.path.join(dir_path , "non_utf8.txt")) as f:
         eval(f.read())

--- a/extra_tests/snippets/syntax_non_utf8.py
+++ b/extra_tests/snippets/syntax_non_utf8.py
@@ -5,8 +5,7 @@ from testutils import assert_raises
 
 dir_path = os.path.dirname(os.path.realpath(__file__))
 
-# TODO: RUSTPYTHON, RustPython raises a SyntaxError here, but cpython raise a ValueError
-error = SyntaxError if platform.python_implementation() == 'RustPython' else ValueError
+error = ValueError
 with assert_raises(error):
     with open(os.path.join(dir_path , "non_utf8.txt")) as f:
         eval(f.read())

--- a/vm/src/stdlib/builtins.rs
+++ b/vm/src/stdlib/builtins.rs
@@ -24,8 +24,8 @@ mod builtins {
         format::call_object_format,
         function::Either,
         function::{
-            ArgBytesLike, ArgCallable, ArgIntoBool, ArgIterable, ArgMapping, FuncArgs, KwArgs,
-            OptionalArg, OptionalOption, PosArgs, PyArithmeticValue,
+            ArgBytesLike, ArgCallable, ArgIntoBool, ArgIterable, ArgMapping, ArgStrOrBytesLike,
+            FuncArgs, KwArgs, OptionalArg, OptionalOption, PosArgs, PyArithmeticValue,
         },
         protocol::{PyIter, PyIterReturn},
         py_io,
@@ -248,20 +248,14 @@ mod builtins {
     #[cfg(feature = "rustpython-compiler")]
     #[pyfunction]
     fn eval(
-        source: Either<
-            Either<PyStrRef, crate::builtins::PyBytesRef>,
-            PyRef<crate::builtins::PyCode>,
-        >,
+        source: Either<ArgStrOrBytesLike, PyRef<crate::builtins::PyCode>>,
         scope: ScopeArgs,
         vm: &VirtualMachine,
     ) -> PyResult {
         // source as string
         let code = match source {
             Either::A(either) => {
-                let source: &[u8] = match either {
-                    Either::A(ref a) => a.as_str().as_bytes(),
-                    Either::B(ref b) => b.as_bytes(),
-                };
+                let source: &[u8] = &either.borrow_bytes();
                 for x in source {
                     if *x == 0 {
                         return Err(vm.new_value_error(

--- a/vm/src/stdlib/builtins.rs
+++ b/vm/src/stdlib/builtins.rs
@@ -262,17 +262,16 @@ mod builtins {
                     ));
                 }
 
-                match std::str::from_utf8(source) {
-                    Ok(s) => Ok(Either::A(vm.ctx.new_str(s))),
-                    Err(err) => {
-                        let msg = format!(
-                            "(unicode error) 'utf-8' codec can't decode byte 0x{:x?} in position {}: invalid start byte",
-                            source[err.valid_up_to()],
-                            err.valid_up_to()
-                        );
-                        Err(vm.new_exception_msg(vm.ctx.exceptions.syntax_error.to_owned(), msg))
-                    }
-                }
+                let source = std::str::from_utf8(source).map_err(|err| {
+                    let msg = format!(
+                        "(unicode error) 'utf-8' codec can't decode byte 0x{:x?} in position {}: invalid start byte",
+                        source[err.valid_up_to()],
+                        err.valid_up_to()
+                    );
+
+                    vm.new_exception_msg(vm.ctx.exceptions.syntax_error.to_owned(), msg)
+                })?;
+                Ok(Either::A(vm.ctx.new_str(source)))
             }
             Either::B(code) => Ok(Either::B(code)),
         }?;

--- a/vm/src/stdlib/builtins.rs
+++ b/vm/src/stdlib/builtins.rs
@@ -248,7 +248,10 @@ mod builtins {
     #[cfg(feature = "rustpython-compiler")]
     #[pyfunction]
     fn eval(
-        source: Either<Either<PyStrRef, crate::builtins::PyBytesRef>, PyRef<crate::builtins::PyCode>>,
+        source: Either<
+            Either<PyStrRef, crate::builtins::PyBytesRef>,
+            PyRef<crate::builtins::PyCode>,
+        >,
         scope: ScopeArgs,
         vm: &VirtualMachine,
     ) -> PyResult {
@@ -261,12 +264,16 @@ mod builtins {
                 };
                 for x in source {
                     if *x == 0 {
-                        return Err(vm.new_value_error("source code string cannot contain null bytes".to_owned()));
+                        return Err(vm.new_value_error(
+                            "source code string cannot contain null bytes".to_owned(),
+                        ));
                     }
                 }
 
-                Ok(Either::A(vm.ctx.new_str(std::str::from_utf8(source).unwrap())))
-            },
+                Ok(Either::A(
+                    vm.ctx.new_str(std::str::from_utf8(source).unwrap()),
+                ))
+            }
             Either::B(code) => Ok(Either::B(code)),
         }?;
         run_code(vm, code, scope, compile::Mode::Eval, "eval")

--- a/vm/src/stdlib/builtins.rs
+++ b/vm/src/stdlib/builtins.rs
@@ -264,9 +264,17 @@ mod builtins {
                     }
                 }
 
-                Ok(Either::A(
-                    vm.ctx.new_str(std::str::from_utf8(source).unwrap()),
-                ))
+                match std::str::from_utf8(source) {
+                    Ok(s) => Ok(Either::A(vm.ctx.new_str(s))),
+                    Err(err) => {
+                        let msg = format!(
+                            "(unicode error) 'utf-8' codec can't decode byte 0x{:x?} in position {}: invalid start byte",
+                            source[err.valid_up_to()],
+                            err.valid_up_to()
+                        );
+                        Err(vm.new_exception_msg(vm.ctx.exceptions.syntax_error.to_owned(), msg))
+                    }
+                }
             }
             Either::B(code) => Ok(Either::B(code)),
         }?;

--- a/vm/src/stdlib/builtins.rs
+++ b/vm/src/stdlib/builtins.rs
@@ -256,12 +256,10 @@ mod builtins {
         let code = match source {
             Either::A(either) => {
                 let source: &[u8] = &either.borrow_bytes();
-                for x in source {
-                    if *x == 0 {
-                        return Err(vm.new_value_error(
-                            "source code string cannot contain null bytes".to_owned(),
-                        ));
-                    }
+                if source.contains(&0) {
+                    return Err(vm.new_value_error(
+                        "source code string cannot contain null bytes".to_owned(),
+                    ));
                 }
 
                 match std::str::from_utf8(source) {

--- a/vm/src/stdlib/builtins.rs
+++ b/vm/src/stdlib/builtins.rs
@@ -259,6 +259,11 @@ mod builtins {
                     Either::A(ref a) => a.as_str().as_bytes(),
                     Either::B(ref b) => b.as_bytes(),
                 };
+                for x in source {
+                    if *x == 0 {
+                        return Err(vm.new_value_error("source code string cannot contain null bytes".to_owned()));
+                    }
+                }
 
                 Ok(Either::A(vm.ctx.new_str(std::str::from_utf8(source).unwrap())))
             },


### PR DESCRIPTION
It isn't a full perfect solution for `eval` implementation but it fixes:

- `eval` became to receive `bytes` also.
- `eval` raises `ValueError` when there is `null` (`\x00`) character before compiling.

You can see also:

- [`_Py_SourceAsString`](https://github.com/python/cpython/blob/b5e3ea286289fcad12be78480daf3756e350f69f/Python/pythonrun.c#L1820-L1867)
- https://github.com/python/cpython/blob/b5e3ea286289fcad12be78480daf3756e350f69f/Python/bltinmodule.c#L961
```
    str = _Py_SourceAsString(source, "eval", "string, bytes or code", &cf, &source_copy);
```

p.s. The message says like it should receive `string` or `bytes` or `code` but it also receives `bytearray` well. 🤔 