### PR TITLE
Feature: _thread.interrupt_main

### DIFF
--- a/Lib/test/test_threading.py
+++ b/Lib/test/test_threading.py
@@ -1382,8 +1382,6 @@ class MiscTestCase(unittest.TestCase):
 
 
 class InterruptMainTests(unittest.TestCase):
-    # TODO: RUSTPYTHON
-    @unittest.expectedFailure
     def test_interrupt_main_subthread(self):
         # Calling start_new_thread with a function that executes interrupt_main
         # should raise KeyboardInterrupt upon completion.
@@ -1395,16 +1393,12 @@ class InterruptMainTests(unittest.TestCase):
             t.join()
         t.join()
 
-    # TODO: RUSTPYTHON
-    @unittest.expectedFailure
     def test_interrupt_main_mainthread(self):
         # Make sure that if interrupt_main is called in main thread that
         # KeyboardInterrupt is raised instantly.
         with self.assertRaises(KeyboardInterrupt):
             _thread.interrupt_main()
 
-    # TODO: RUSTPYTHON
-    @unittest.expectedFailure
     def test_interrupt_main_noerror(self):
         handler = signal.getsignal(signal.SIGINT)
         try:

--- a/vm/src/signal.rs
+++ b/vm/src/signal.rs
@@ -67,6 +67,7 @@ pub fn assert_in_range(signum: i32, vm: &VirtualMachine) -> PyResult<()> {
 ///
 /// Missing signal handler for the given signal number is silently ignored.
 #[allow(dead_code)]
+#[cfg(not(target_arch = "wasm32"))]
 pub fn set_interrupt_ex(signum: i32, vm: &VirtualMachine) -> PyResult<()> {
     use crate::stdlib::signal::_signal::{run_signal, SIG_DFL, SIG_IGN};
     assert_in_range(signum, vm)?;

--- a/vm/src/stdlib/signal.rs
+++ b/vm/src/stdlib/signal.rs
@@ -279,4 +279,20 @@ pub(crate) mod _signal {
             Err(vm.new_value_error("signal number out of range".to_owned()))
         }
     }
+
+    /// Similar to `PyErr_SetInterruptEx` in CPython
+    ///
+    /// Missing signal handler for the given signal number is silently ignored.
+    pub fn set_interrupt_ex(signum: i32, vm: &VirtualMachine) -> PyResult<()> {
+        assert_in_range(signum, vm)?;
+
+        match signum as usize {
+            SIG_DFL | SIG_IGN => Ok(()),
+            _ => {
+                // interrupt the main thread with given signal number
+                run_signal(signum);
+                Ok(())
+            }
+        }
+    }
 }

--- a/vm/src/stdlib/signal.rs
+++ b/vm/src/stdlib/signal.rs
@@ -283,6 +283,7 @@ pub(crate) mod _signal {
     /// Similar to `PyErr_SetInterruptEx` in CPython
     ///
     /// Missing signal handler for the given signal number is silently ignored.
+    #[allow(dead_code)]
     pub fn set_interrupt_ex(signum: i32, vm: &VirtualMachine) -> PyResult<()> {
         assert_in_range(signum, vm)?;
 

--- a/vm/src/stdlib/thread.rs
+++ b/vm/src/stdlib/thread.rs
@@ -304,6 +304,7 @@ pub(crate) mod _thread {
         vm.state.thread_count.fetch_sub(1);
     }
 
+    #[cfg(not(target_arch = "wasm32"))]
     #[pyfunction]
     fn interrupt_main(signum: OptionalArg<i32>, vm: &VirtualMachine) -> PyResult<()> {
         crate::stdlib::signal::_signal::set_interrupt_ex(signum.unwrap_or(libc::SIGINT), vm)

--- a/vm/src/stdlib/thread.rs
+++ b/vm/src/stdlib/thread.rs
@@ -305,6 +305,11 @@ pub(crate) mod _thread {
     }
 
     #[pyfunction]
+    fn interrupt_main(signum: OptionalArg<i32>, vm: &VirtualMachine) -> PyResult<()> {
+        crate::stdlib::signal::_signal::set_interrupt_ex(signum.unwrap_or(libc::SIGINT), vm)
+    }
+
+    #[pyfunction]
     fn exit(vm: &VirtualMachine) -> PyResult {
         Err(vm.new_exception_empty(vm.ctx.exceptions.system_exit.to_owned()))
     }

--- a/vm/src/stdlib/thread.rs
+++ b/vm/src/stdlib/thread.rs
@@ -307,7 +307,7 @@ pub(crate) mod _thread {
     #[cfg(not(target_arch = "wasm32"))]
     #[pyfunction]
     fn interrupt_main(signum: OptionalArg<i32>, vm: &VirtualMachine) -> PyResult<()> {
-        crate::stdlib::signal::_signal::set_interrupt_ex(signum.unwrap_or(libc::SIGINT), vm)
+        crate::signal::set_interrupt_ex(signum.unwrap_or(libc::SIGINT), vm)
     }
 
     #[pyfunction]


### PR DESCRIPTION
Additionally I ran the test below, and it was successful.

```py
# SuperFastPython.com
# example of main thread cannot be interrupting while sleeping
from time import sleep
from threading import Thread
from _thread import interrupt_main
import sys

# task executed in a new thread
def task():
    # block for a moment
    sleep(3)
    # interrupt the main thread
    print('Interrupting main thread now')
    interrupt_main()

# start the new thread
thread = Thread(target=task)
thread.start()
# handle being interrupted
try:
    # block for a long time
    print('Main thread waiting...')
    sleep(7)
except KeyboardInterrupt:
    # terminate main thread
    print('Main interrupted! Exiting.')
    sys.exit()
``` 

Close: #3922