### PR TITLE
Implement `__slots__` with `member_descriptor`

### DIFF
--- a/Lib/test/test_rlcompleter.py
+++ b/Lib/test/test_rlcompleter.py
@@ -93,8 +93,6 @@ class TestRlcompleter(unittest.TestCase):
         self.assertEqual(completer.complete('f.b', 0), 'f.bar')
         self.assertEqual(f.calls, 1)
 
-    # TODO: RUSTPYTHON
-    @unittest.expectedFailure
     def test_uncreated_attr(self):
         # Attributes like properties and slots should be completed even when
         # they haven't been created on an instance

--- a/derive/src/util.rs
+++ b/derive/src/util.rs
@@ -23,6 +23,7 @@ pub(crate) const ALL_ALLOWED_NAMES: &[&str] = &[
     "pyattr",
     "pyslot",
     "extend_class",
+    "pymember",
 ];
 
 #[derive(Clone)]

--- a/vm/src/builtins/descriptor.rs
+++ b/vm/src/builtins/descriptor.rs
@@ -1,6 +1,6 @@
 use rustpython_common::lock::PyRwLock;
 
-use crate::types::GetDescriptor;
+use crate::types::{Constructor, GetDescriptor, Unconstructible};
 use crate::{Context, Py, PyObjectRef, PyRef, PyResult, VirtualMachine};
 
 use super::{PyStr, PyType, PyTypeRef};
@@ -62,7 +62,7 @@ fn calculate_qualname(descr: &DescrObject, vm: &VirtualMachine) -> PyResult<Opti
     }
 }
 
-#[pyclass(with(GetDescriptor), flags(BASETYPE))]
+#[pyclass(with(GetDescriptor, Constructor), flags(BASETYPE))]
 impl MemberDescrObject {
     #[pymethod(magic)]
     fn repr(zelf: PyRef<Self>) -> String {
@@ -87,6 +87,8 @@ impl MemberDescrObject {
         Ok(self.common.qualname.read().to_owned())
     }
 }
+
+impl Unconstructible for MemberDescrObject {}
 
 impl GetDescriptor for MemberDescrObject {
     fn descr_get(

--- a/vm/src/builtins/descriptor.rs
+++ b/vm/src/builtins/descriptor.rs
@@ -17,7 +17,7 @@ pub enum MemberKind {
 }
 
 pub enum MemberGetter {
-    Getter(fn(PyObjectRef, &VirtualMachine) -> PyResult),
+    Getter(fn(&VirtualMachine, PyObjectRef) -> PyResult),
     Offset(usize),
 }
 
@@ -124,7 +124,7 @@ impl GetDescriptor for MemberDescrObject {
             Some(x) => {
                 let zelf = Self::_zelf(zelf, vm)?;
                 match zelf.member.getter {
-                    MemberGetter::Getter(getter) => (getter)(x, vm),
+                    MemberGetter::Getter(getter) => (getter)(vm, x),
                     MemberGetter::Offset(offset) => get_slot_from_object(x, offset, &zelf.member, vm),
                 }
             }

--- a/vm/src/builtins/descriptor.rs
+++ b/vm/src/builtins/descriptor.rs
@@ -1,8 +1,8 @@
-use rustpython_common::lock::PyRwLock;
 use super::{PyStr, PyType, PyTypeRef};
 use crate::class::PyClassImpl;
 use crate::types::{Constructor, GetDescriptor, Unconstructible};
 use crate::{AsObject, Context, Py, PyObjectRef, PyPayload, PyRef, PyResult, VirtualMachine};
+use rustpython_common::lock::PyRwLock;
 
 #[derive(Debug)]
 pub struct DescrObject {
@@ -53,9 +53,11 @@ impl PyPayload for MemberDescrObject {
 
 fn calculate_qualname(descr: &DescrObject, vm: &VirtualMachine) -> PyResult<Option<String>> {
     if let Some(qualname) = vm.get_attribute_opt(descr.typ.to_owned().into(), "__qualname__")? {
-        let str = qualname.downcast::<PyStr>().map_err(|_| vm.new_type_error(
-            "<descriptor>.__objclass__.__qualname__ is not a unicode object".to_owned(),
-        ))?;
+        let str = qualname.downcast::<PyStr>().map_err(|_| {
+            vm.new_type_error(
+                "<descriptor>.__objclass__.__qualname__ is not a unicode object".to_owned(),
+            )
+        })?;
         Ok(Some(format!("{}.{}", str, descr.name)))
     } else {
         return Ok(None);
@@ -125,7 +127,9 @@ impl GetDescriptor for MemberDescrObject {
                 let zelf = Self::_zelf(zelf, vm)?;
                 match zelf.member.getter {
                     MemberGetter::Getter(getter) => (getter)(vm, x),
-                    MemberGetter::Offset(offset) => get_slot_from_object(x, offset, &zelf.member, vm),
+                    MemberGetter::Offset(offset) => {
+                        get_slot_from_object(x, offset, &zelf.member, vm)
+                    }
                 }
             }
             None => Ok(zelf),

--- a/vm/src/builtins/descriptor.rs
+++ b/vm/src/builtins/descriptor.rs
@@ -1,5 +1,4 @@
 use rustpython_common::lock::PyRwLock;
-
 use super::{PyStr, PyType, PyTypeRef};
 use crate::class::PyClassImpl;
 use crate::function::Either;
@@ -52,12 +51,12 @@ fn calculate_qualname(descr: &DescrObject, vm: &VirtualMachine) -> PyResult<Opti
     let type_qualname = vm.get_attribute_opt(descr.typ.to_owned().into(), "__qualname__")?;
     match type_qualname {
         None => Ok(None),
-        Some(obj) => match obj.downcast::<PyStr>() {
-            Ok(str) => Ok(Some(format!("{}.{}", str, descr.name))),
-            Err(_) => Err(vm.new_type_error(
+        Some(obj) => {
+            let str = obj.downcast::<PyStr>().map_err(|_| vm.new_type_error(
                 "<descriptor>.__objclass__.__qualname__ is not a unicode object".to_owned(),
-            )),
-        },
+            ))?;
+            Ok(Some(format!("{}.{}", str, descr.name)))
+        }
     }
 }
 

--- a/vm/src/builtins/descriptor.rs
+++ b/vm/src/builtins/descriptor.rs
@@ -60,7 +60,7 @@ fn calculate_qualname(descr: &DescrObject, vm: &VirtualMachine) -> PyResult<Opti
         })?;
         Ok(Some(format!("{}.{}", str, descr.name)))
     } else {
-        return Ok(None);
+        Ok(None)
     }
 }
 

--- a/vm/src/builtins/descriptor.rs
+++ b/vm/src/builtins/descriptor.rs
@@ -48,15 +48,13 @@ impl PyPayload for MemberDescrObject {
 }
 
 fn calculate_qualname(descr: &DescrObject, vm: &VirtualMachine) -> PyResult<Option<String>> {
-    let type_qualname = vm.get_attribute_opt(descr.typ.to_owned().into(), "__qualname__")?;
-    match type_qualname {
-        None => Ok(None),
-        Some(obj) => {
-            let str = obj.downcast::<PyStr>().map_err(|_| vm.new_type_error(
-                "<descriptor>.__objclass__.__qualname__ is not a unicode object".to_owned(),
-            ))?;
-            Ok(Some(format!("{}.{}", str, descr.name)))
-        }
+    if let Some(qualname) = vm.get_attribute_opt(descr.typ.to_owned().into(), "__qualname__")? {
+        let str = qualname.downcast::<PyStr>().map_err(|_| vm.new_type_error(
+            "<descriptor>.__objclass__.__qualname__ is not a unicode object".to_owned(),
+        ))?;
+        Ok(Some(format!("{}.{}", str, descr.name)))
+    } else {
+        return Ok(None);
     }
 }
 

--- a/vm/src/builtins/descriptor.rs
+++ b/vm/src/builtins/descriptor.rs
@@ -78,11 +78,15 @@ impl MemberDescrObject {
 
     #[pyproperty(magic)]
     fn qualname(&self, vm: &VirtualMachine) -> PyResult<Option<String>> {
-        if self.common.qualname.read().is_none() {
-            *self.common.qualname.write() = calculate_qualname(&self.common, vm)?;
-        }
-
-        Ok(self.common.qualname.read().to_owned())
+        let qualname = self.common.qualname.read();
+        Ok(if qualname.is_none() {
+            drop(qualname);
+            let calculated = calculate_qualname(&self.common, vm)?;
+            *self.common.qualname.write() = calculated.to_owned();
+            calculated
+        } else {
+            qualname.to_owned()
+        })
     }
 }
 

--- a/vm/src/builtins/descriptor.rs
+++ b/vm/src/builtins/descriptor.rs
@@ -1,0 +1,83 @@
+use rustpython_common::lock::PyRwLock;
+
+use crate::{Context, Py, PyRef, PyResult, VirtualMachine};
+
+use super::{PyStr, PyType, PyTypeRef};
+use crate::class::PyClassImpl;
+use crate::object::PyPayload;
+
+#[derive(Debug)]
+pub struct DescrObject {
+    pub typ: PyTypeRef,
+    pub name: String,
+    pub qualname: PyRwLock<Option<String>>,
+}
+
+#[derive(Debug)]
+pub enum MemberKind {
+    ObjectEx = 16,
+}
+
+#[derive(Debug)]
+pub struct MemberDef {
+    pub name: String,
+    pub kind: MemberKind,
+    pub doc: Option<String>,
+}
+
+#[pyclass(name = "member_descriptor", module = false)]
+#[derive(Debug)]
+pub struct MemberDescrObject {
+    pub common: DescrObject,
+    pub member: MemberDef,
+}
+
+impl PyPayload for MemberDescrObject {
+    fn class(vm: &VirtualMachine) -> &'static Py<PyType> {
+        vm.ctx.types.member_descriptor_type
+    }
+}
+
+fn calculate_qualname(descr: &DescrObject, vm: &VirtualMachine) -> PyResult<Option<String>> {
+    let type_qualname = vm.get_attribute_opt(descr.typ.to_owned().into(), "__qualname__")?;
+    match type_qualname {
+        None => Ok(None),
+        Some(obj) => match obj.downcast::<PyStr>() {
+            Ok(str) => Ok(Some(format!("{}.{}", str, descr.name))),
+            Err(_) => Err(vm.new_type_error(
+                "<descriptor>.__objclass__.__qualname__ is not a unicode object".to_owned(),
+            )),
+        },
+    }
+}
+
+#[pyclass(flags(BASETYPE))]
+impl MemberDescrObject {
+    #[pymethod(magic)]
+    fn repr(zelf: PyRef<Self>) -> String {
+        format!(
+            "<member '{}' of '{}' objects>",
+            zelf.common.name,
+            zelf.common.typ.name(),
+        )
+    }
+
+    #[pyproperty(magic)]
+    fn doc(zelf: PyRef<Self>) -> Option<String> {
+        zelf.member.doc.to_owned()
+    }
+
+    #[pyproperty(magic)]
+    fn qualname(&self, vm: &VirtualMachine) -> PyResult<Option<String>> {
+        if self.common.qualname.read().is_none() {
+            *self.common.qualname.write() = calculate_qualname(&self.common, vm)?;
+        }
+
+        Ok(self.common.qualname.read().to_owned())
+    }
+}
+
+pub fn init(context: &Context) {
+    let member_descriptor_type = &context.types.member_descriptor_type;
+    MemberDescrObject::extend_class(context, member_descriptor_type);
+}

--- a/vm/src/builtins/function.rs
+++ b/vm/src/builtins/function.rs
@@ -5,7 +5,10 @@ use super::{
     tuple::PyTupleTyped, PyAsyncGen, PyCode, PyCoroutine, PyDictRef, PyGenerator, PyStr, PyStrRef,
     PyTupleRef, PyType, PyTypeRef,
 };
+#[cfg(feature = "jit")]
+use crate::common::lock::OnceCell;
 use crate::common::lock::PyMutex;
+use crate::convert::ToPyObject;
 use crate::function::ArgMapping;
 use crate::{
     bytecode,
@@ -16,8 +19,6 @@ use crate::{
     types::{Callable, Comparable, Constructor, GetAttr, GetDescriptor, PyComparisonOp},
     AsObject, Context, Py, PyObject, PyObjectRef, PyPayload, PyRef, PyResult, VirtualMachine,
 };
-#[cfg(feature = "jit")]
-use crate::{common::lock::OnceCell, convert::ToPyObject};
 use itertools::Itertools;
 #[cfg(feature = "jit")]
 use rustpython_jit::CompiledCode;
@@ -352,14 +353,21 @@ impl PyFunction {
         self.defaults_and_kwdefaults.lock().1 = kwdefaults
     }
 
-    #[pyproperty(magic)]
-    fn globals(&self) -> PyDictRef {
-        self.globals.clone()
+    // {"__closure__",   T_OBJECT,     OFF(func_closure), READONLY},
+    // {"__doc__",       T_OBJECT,     OFF(func_doc), 0},
+    // {"__globals__",   T_OBJECT,     OFF(func_globals), READONLY},
+    // {"__module__",    T_OBJECT,     OFF(func_module), 0},
+    // {"__builtins__",  T_OBJECT,     OFF(func_builtins), READONLY},
+    #[pymember(magic)]
+    fn globals(zelf: PyObjectRef, vm: &VirtualMachine) -> PyResult {
+        let zelf = Self::_zelf(zelf, vm)?;
+        Ok(zelf.globals.clone().into())
     }
 
-    #[pyproperty(magic)]
-    fn closure(&self) -> Option<PyTupleTyped<PyCellRef>> {
-        self.closure.clone()
+    #[pymember(magic)]
+    fn closure(zelf: PyObjectRef, vm: &VirtualMachine) -> PyResult {
+        let zelf = Self::_zelf(zelf, vm)?;
+        Ok(vm.unwrap_or_none(zelf.closure.clone().map(|x| x.to_pyobject(vm))))
     }
 
     #[pyproperty(magic)]

--- a/vm/src/builtins/function.rs
+++ b/vm/src/builtins/function.rs
@@ -359,13 +359,13 @@ impl PyFunction {
     // {"__module__",    T_OBJECT,     OFF(func_module), 0},
     // {"__builtins__",  T_OBJECT,     OFF(func_builtins), READONLY},
     #[pymember(magic)]
-    fn globals(zelf: PyObjectRef, vm: &VirtualMachine) -> PyResult {
+    fn globals(vm: &VirtualMachine, zelf: PyObjectRef) -> PyResult {
         let zelf = Self::_zelf(zelf, vm)?;
         Ok(zelf.globals.clone().into())
     }
 
     #[pymember(magic)]
-    fn closure(zelf: PyObjectRef, vm: &VirtualMachine) -> PyResult {
+    fn closure(vm: &VirtualMachine, zelf: PyObjectRef) -> PyResult {
         let zelf = Self::_zelf(zelf, vm)?;
         Ok(vm.unwrap_or_none(zelf.closure.clone().map(|x| x.to_pyobject(vm))))
     }

--- a/vm/src/builtins/mod.rs
+++ b/vm/src/builtins/mod.rs
@@ -89,6 +89,7 @@ pub use zip::PyZip;
 #[path = "union.rs"]
 pub(crate) mod union_;
 pub use union_::PyUnion;
+pub(crate) mod descriptor;
 
 pub use float::try_to_bigint as try_f64_to_bigint;
 pub use int::try_to_float as try_bigint_to_f64;

--- a/vm/src/builtins/type.rs
+++ b/vm/src/builtins/type.rs
@@ -678,6 +678,7 @@ impl PyType {
                 let member_def = MemberDef {
                     name: member.to_string(),
                     kind: MemberKind::ObjectEx,
+                    getter: |x, _vmm| Ok(x),
                     doc: None,
                 };
                 let member_descriptor: PyRef<MemberDescrObject> = vm.new_pyref(MemberDescrObject {

--- a/vm/src/builtins/type.rs
+++ b/vm/src/builtins/type.rs
@@ -4,7 +4,7 @@ use super::{
 };
 use crate::{
     builtins::PyBaseExceptionRef,
-    builtins::{function::PyCellRef, tuple::PyTupleTyped, descriptor::MemberGetter},
+    builtins::{descriptor::MemberGetter, function::PyCellRef, tuple::PyTupleTyped},
     class::{PyClassImpl, StaticType},
     convert::ToPyObject,
     function::{FuncArgs, KwArgs, OptionalArg, PySetterValue},

--- a/vm/src/builtins/type.rs
+++ b/vm/src/builtins/type.rs
@@ -4,10 +4,10 @@ use super::{
 };
 use crate::{
     builtins::PyBaseExceptionRef,
-    builtins::{function::PyCellRef, tuple::PyTupleTyped},
+    builtins::{function::PyCellRef, tuple::PyTupleTyped, descriptor::MemberGetter},
     class::{PyClassImpl, StaticType},
     convert::ToPyObject,
-    function::{Either, FuncArgs, KwArgs, OptionalArg, PySetterValue},
+    function::{FuncArgs, KwArgs, OptionalArg, PySetterValue},
     identifier,
     protocol::PyNumberMethods,
     types::{Callable, GetAttr, PyTypeFlags, PyTypeSlots, SetAttr},
@@ -686,7 +686,7 @@ impl PyType {
                 let member_def = MemberDef {
                     name: member.to_string(),
                     kind: MemberKind::ObjectEx,
-                    getter_or_offset: Either::B(offset),
+                    getter: MemberGetter::Offset(offset),
                     doc: None,
                 };
                 let member_descriptor: PyRef<MemberDescrObject> = vm.new_pyref(MemberDescrObject {

--- a/vm/src/builtins/type.rs
+++ b/vm/src/builtins/type.rs
@@ -636,19 +636,21 @@ impl PyType {
         // updated when __slots__ are supported (toggling the flag off if
         // a class has __slots__ defined).
         let heaptype_slots: Option<PyTupleTyped<PyStrRef>> =
-            if let Some(x) = attributes.get(vm.ctx.intern_str("__slots__")) {
+            if let Some(x) = attributes.get(identifier!(vm, __slots__)) {
                 Some(if x.to_owned().class().is(vm.ctx.types.str_type) {
                     PyTupleTyped::<PyStrRef>::try_from_object(
                         vm,
                         vec![x.to_owned()].into_pytuple(vm).into(),
                     )?
                 } else {
-                    let mut elements = Vec::new();
                     let iter = x.to_owned().get_iter(vm)?;
-                    while let PyIterReturn::Return(element) = iter.next(vm)? {
-                        elements.push(element);
-                    }
-
+                    let elements = {
+                        let mut elements = Vec::new();
+                        while let PyIterReturn::Return(element) = iter.next(vm)? {
+                            elements.push(element);
+                        }
+                        elements
+                    };
                     PyTupleTyped::<PyStrRef>::try_from_object(vm, elements.into_pytuple(vm).into())?
                 })
             } else {

--- a/vm/src/types/slot.rs
+++ b/vm/src/types/slot.rs
@@ -81,6 +81,9 @@ pub struct PyTypeSlots {
     // tp_subclasses
     // tp_weaklist
     pub del: AtomicCell<Option<DelFunc>>,
+
+    // The count of tp_members.
+    pub member_count: usize,
 }
 
 impl PyTypeSlots {

--- a/vm/src/types/zoo.rs
+++ b/vm/src/types/zoo.rs
@@ -1,9 +1,10 @@
 use crate::{
     builtins::{
         asyncgenerator, bool_, builtinfunc, bytearray, bytes, classmethod, code, complex,
-        coroutine, dict, enumerate, filter, float, frame, function, generator, genericalias,
-        getset, int, iter, list, map, mappingproxy, memory, module, namespace, object, property,
-        pystr, range, set, singletons, slice, staticmethod, super_, traceback, tuple,
+        coroutine, descriptor, dict, enumerate, filter, float, frame, function, generator,
+        genericalias, getset, int, iter, list, map, mappingproxy, memory, module, namespace,
+        object, property, pystr, range, set, singletons, slice, staticmethod, super_, traceback,
+        tuple,
         type_::{self, PyType},
         union_, weakproxy, weakref, zip,
     },
@@ -88,6 +89,7 @@ pub struct TypeZoo {
     pub not_implemented_type: &'static Py<PyType>,
     pub generic_alias_type: &'static Py<PyType>,
     pub union_type: &'static Py<PyType>,
+    pub member_descriptor_type: &'static Py<PyType>,
 }
 
 impl TypeZoo {
@@ -172,6 +174,7 @@ impl TypeZoo {
             not_implemented_type: singletons::PyNotImplemented::init_bare_type(),
             generic_alias_type: genericalias::PyGenericAlias::init_bare_type(),
             union_type: union_::PyUnion::init_bare_type(),
+            member_descriptor_type: descriptor::MemberDescrObject::init_bare_type(),
         }
     }
 
@@ -220,5 +223,6 @@ impl TypeZoo {
         traceback::init(context);
         genericalias::init(context);
         union_::init(context);
+        descriptor::init(context);
     }
 }

--- a/vm/src/vm/context.rs
+++ b/vm/src/vm/context.rs
@@ -194,6 +194,7 @@ declare_const_name! {
     __set_name__,
     __setattr__,
     __setitem__,
+    __slots__,
     __str__,
     __sub__,
     __subclasscheck__,

--- a/vm/src/vm/context.rs
+++ b/vm/src/vm/context.rs
@@ -3,7 +3,7 @@ use crate::{
         builtinfunc::{PyBuiltinFunction, PyBuiltinMethod, PyNativeFuncDef},
         bytes,
         code::{self, PyCode},
-        descriptor::{DescrObject, MemberDef, MemberDescrObject, MemberKind, MemberGetter},
+        descriptor::{DescrObject, MemberDef, MemberDescrObject, MemberGetter, MemberKind},
         getset::PyGetSet,
         object, pystr,
         type_::PyAttributes,

--- a/vm/src/vm/context.rs
+++ b/vm/src/vm/context.rs
@@ -14,7 +14,7 @@ use crate::{
     class::{PyClassImpl, StaticType},
     common::rc::PyRc,
     exceptions,
-    function::{IntoPyGetterFunc, IntoPyNativeFunc, IntoPySetterFunc},
+    function::{Either, IntoPyGetterFunc, IntoPyNativeFunc, IntoPySetterFunc},
     intern::{Internable, MaybeInterned, StringPool},
     object::{Py, PyObjectPayload, PyObjectRef, PyPayload, PyRef},
     types::{PyTypeFlags, PyTypeSlots, TypeZoo},
@@ -462,7 +462,7 @@ impl Context {
         let member_def = MemberDef {
             name: name.to_owned(),
             kind: MemberKind::ObjectEx,
-            getter,
+            getter_or_offset: Either::A(getter),
             doc: None,
         };
         let member_descriptor = MemberDescrObject {

--- a/vm/src/vm/context.rs
+++ b/vm/src/vm/context.rs
@@ -456,7 +456,7 @@ impl Context {
     pub fn new_member(
         &self,
         name: &str,
-        getter: fn(PyObjectRef, &VirtualMachine) -> PyResult,
+        getter: fn(&VirtualMachine, PyObjectRef) -> PyResult,
         class: &'static Py<PyType>,
     ) -> PyRef<MemberDescrObject> {
         let member_def = MemberDef {

--- a/vm/src/vm/context.rs
+++ b/vm/src/vm/context.rs
@@ -3,7 +3,7 @@ use crate::{
         builtinfunc::{PyBuiltinFunction, PyBuiltinMethod, PyNativeFuncDef},
         bytes,
         code::{self, PyCode},
-        descriptor::{DescrObject, MemberDef, MemberDescrObject, MemberKind},
+        descriptor::{DescrObject, MemberDef, MemberDescrObject, MemberKind, MemberGetter},
         getset::PyGetSet,
         object, pystr,
         type_::PyAttributes,
@@ -14,7 +14,7 @@ use crate::{
     class::{PyClassImpl, StaticType},
     common::rc::PyRc,
     exceptions,
-    function::{Either, IntoPyGetterFunc, IntoPyNativeFunc, IntoPySetterFunc},
+    function::{IntoPyGetterFunc, IntoPyNativeFunc, IntoPySetterFunc},
     intern::{Internable, MaybeInterned, StringPool},
     object::{Py, PyObjectPayload, PyObjectRef, PyPayload, PyRef},
     types::{PyTypeFlags, PyTypeSlots, TypeZoo},
@@ -462,7 +462,7 @@ impl Context {
         let member_def = MemberDef {
             name: name.to_owned(),
             kind: MemberKind::ObjectEx,
-            getter_or_offset: Either::A(getter),
+            getter: MemberGetter::Getter(getter),
             doc: None,
         };
         let member_descriptor = MemberDescrObject {


### PR DESCRIPTION
This pull request tries to implement `__slots__` feature with `member_descriptor`.

This pull request doesn't contain `mebmer_descriptor.slots.descr_get` yet and it'll be implemented in the next pull request because I worried that this pull request becomes too big to review.