### PR TITLE
Allow named expressions in generator comprehensions

### DIFF
--- a/extra_tests/snippets/syntax_generator.py
+++ b/extra_tests/snippets/syntax_generator.py
@@ -17,6 +17,9 @@ assert r == [1, 2, 42, 3]
 r = list(x for x in [1, 2, 3])
 assert r == [1, 2, 3]
 
+r = list(y := x + 1 for x in [1, 2, 3])
+assert r == [2, 3, 4]
+
 def g2(x):
     x = yield x
     yield x + 5

--- a/parser/python.lalrpop
+++ b/parser/python.lalrpop
@@ -1012,7 +1012,7 @@ Atom: ast::Expr = {
         }
     },
     "(" <e:YieldExpr> ")" => e,
-    <location:@L> "(" <elt:Test> <generators:CompFor> ")" => {
+    <location:@L> "(" <elt:NamedExpressionTest> <generators:CompFor> ")" => {
         ast::Expr {
             location,
             custom: (),

--- a/parser/src/parser.rs
+++ b/parser/src/parser.rs
@@ -178,4 +178,25 @@ class Foo(A, B):
         let parse_ast = parse_expression(&source).unwrap();
         insta::assert_debug_snapshot!(parse_ast);
     }
+
+    #[test]
+    fn test_parse_generator_comprehension() {
+        let source = String::from("(x for y in z)");
+        let parse_ast = parse_expression(&source).unwrap();
+        insta::assert_debug_snapshot!(parse_ast);
+    }
+
+    #[test]
+    fn test_parse_named_expression_generator_comprehension() {
+        let source = String::from("(x := y + 1 for y in z)");
+        let parse_ast = parse_expression(&source).unwrap();
+        insta::assert_debug_snapshot!(parse_ast);
+    }
+
+    #[test]
+    fn test_parse_if_else_generator_comprehension() {
+        let source = String::from("(x if y else y for y in z)");
+        let parse_ast = parse_expression(&source).unwrap();
+        insta::assert_debug_snapshot!(parse_ast);
+    }
 }

--- a/parser/src/snapshots/rustpython_parser__parser__tests__parse_generator_comprehension.snap
+++ b/parser/src/snapshots/rustpython_parser__parser__tests__parse_generator_comprehension.snap
@@ -1,0 +1,52 @@
+---
+source: parser/src/parser.rs
+expression: parse_ast
+---
+Located {
+    location: Location {
+        row: 1,
+        column: 1,
+    },
+    custom: (),
+    node: GeneratorExp {
+        elt: Located {
+            location: Location {
+                row: 1,
+                column: 2,
+            },
+            custom: (),
+            node: Name {
+                id: "x",
+                ctx: Load,
+            },
+        },
+        generators: [
+            Comprehension {
+                target: Located {
+                    location: Location {
+                        row: 1,
+                        column: 8,
+                    },
+                    custom: (),
+                    node: Name {
+                        id: "y",
+                        ctx: Load,
+                    },
+                },
+                iter: Located {
+                    location: Location {
+                        row: 1,
+                        column: 13,
+                    },
+                    custom: (),
+                    node: Name {
+                        id: "z",
+                        ctx: Load,
+                    },
+                },
+                ifs: [],
+                is_async: 0,
+            },
+        ],
+    },
+}

--- a/parser/src/snapshots/rustpython_parser__parser__tests__parse_if_else_generator_comprehension.snap
+++ b/parser/src/snapshots/rustpython_parser__parser__tests__parse_if_else_generator_comprehension.snap
@@ -1,0 +1,83 @@
+---
+source: parser/src/parser.rs
+expression: parse_ast
+---
+Located {
+    location: Location {
+        row: 1,
+        column: 1,
+    },
+    custom: (),
+    node: GeneratorExp {
+        elt: Located {
+            location: Location {
+                row: 1,
+                column: 4,
+            },
+            custom: (),
+            node: IfExp {
+                test: Located {
+                    location: Location {
+                        row: 1,
+                        column: 7,
+                    },
+                    custom: (),
+                    node: Name {
+                        id: "y",
+                        ctx: Load,
+                    },
+                },
+                body: Located {
+                    location: Location {
+                        row: 1,
+                        column: 2,
+                    },
+                    custom: (),
+                    node: Name {
+                        id: "x",
+                        ctx: Load,
+                    },
+                },
+                orelse: Located {
+                    location: Location {
+                        row: 1,
+                        column: 14,
+                    },
+                    custom: (),
+                    node: Name {
+                        id: "y",
+                        ctx: Load,
+                    },
+                },
+            },
+        },
+        generators: [
+            Comprehension {
+                target: Located {
+                    location: Location {
+                        row: 1,
+                        column: 20,
+                    },
+                    custom: (),
+                    node: Name {
+                        id: "y",
+                        ctx: Load,
+                    },
+                },
+                iter: Located {
+                    location: Location {
+                        row: 1,
+                        column: 25,
+                    },
+                    custom: (),
+                    node: Name {
+                        id: "z",
+                        ctx: Load,
+                    },
+                },
+                ifs: [],
+                is_async: 0,
+            },
+        ],
+    },
+}

--- a/parser/src/snapshots/rustpython_parser__parser__tests__parse_named_expression_generator_comprehension.snap
+++ b/parser/src/snapshots/rustpython_parser__parser__tests__parse_named_expression_generator_comprehension.snap
@@ -1,0 +1,95 @@
+---
+source: parser/src/parser.rs
+expression: parse_ast
+---
+Located {
+    location: Location {
+        row: 1,
+        column: 1,
+    },
+    custom: (),
+    node: GeneratorExp {
+        elt: Located {
+            location: Location {
+                row: 1,
+                column: 2,
+            },
+            custom: (),
+            node: NamedExpr {
+                target: Located {
+                    location: Location {
+                        row: 1,
+                        column: 2,
+                    },
+                    custom: (),
+                    node: Name {
+                        id: "x",
+                        ctx: Store,
+                    },
+                },
+                value: Located {
+                    location: Location {
+                        row: 1,
+                        column: 9,
+                    },
+                    custom: (),
+                    node: BinOp {
+                        left: Located {
+                            location: Location {
+                                row: 1,
+                                column: 7,
+                            },
+                            custom: (),
+                            node: Name {
+                                id: "y",
+                                ctx: Load,
+                            },
+                        },
+                        op: Add,
+                        right: Located {
+                            location: Location {
+                                row: 1,
+                                column: 11,
+                            },
+                            custom: (),
+                            node: Constant {
+                                value: Int(
+                                    1,
+                                ),
+                                kind: None,
+                            },
+                        },
+                    },
+                },
+            },
+        },
+        generators: [
+            Comprehension {
+                target: Located {
+                    location: Location {
+                        row: 1,
+                        column: 17,
+                    },
+                    custom: (),
+                    node: Name {
+                        id: "y",
+                        ctx: Load,
+                    },
+                },
+                iter: Located {
+                    location: Location {
+                        row: 1,
+                        column: 22,
+                    },
+                    custom: (),
+                    node: Name {
+                        id: "z",
+                        ctx: Load,
+                    },
+                },
+                ifs: [],
+                is_async: 0,
+            },
+        ],
+    },
+}


### PR DESCRIPTION
# Summary

See: #4108.

I noticed this when trying to parse the CPython codebase itself, which has this test (on which `RustPython` throws a syntax error):

```
def test_named_expression_scope_in_genexp(self):
    a = 1
    b = [1, 2, 3, 4]
    genexp = (c := i + a for i in b)

    self.assertNotIn("c", locals())
    for idx, elem in enumerate(genexp):
        self.assertEqual(elem, b[idx] + a)
```
