### PR TITLE
Feature/add staticmethod init

### DIFF
--- a/vm/src/builtins/builtinfunc.rs
+++ b/vm/src/builtins/builtinfunc.rs
@@ -55,7 +55,6 @@ impl PyNativeFuncDef {
         ctx: &Context,
         class: &'static Py<PyType>,
     ) -> PyRef<PyStaticMethod> {
-        // TODO: classmethod_descriptor
         let callable = self.build_method(ctx, class).into();
         PyStaticMethod::new_ref(callable, ctx)
     }

--- a/vm/src/builtins/builtinfunc.rs
+++ b/vm/src/builtins/builtinfunc.rs
@@ -55,12 +55,9 @@ impl PyNativeFuncDef {
         ctx: &Context,
         class: &'static Py<PyType>,
     ) -> PyRef<PyStaticMethod> {
+        // TODO: classmethod_descriptor
         let callable = self.build_method(ctx, class).into();
-        PyRef::new_ref(
-            PyStaticMethod { callable },
-            ctx.types.staticmethod_type.to_owned(),
-            None,
-        )
+        PyStaticMethod::new_ref(callable, ctx)
     }
 }
 

--- a/vm/src/builtins/staticmethod.rs
+++ b/vm/src/builtins/staticmethod.rs
@@ -179,7 +179,8 @@ impl Callable for PyStaticMethod {
     type Args = FuncArgs;
     #[inline]
     fn call(zelf: &crate::Py<Self>, args: FuncArgs, vm: &VirtualMachine) -> PyResult {
-        vm.invoke(&zelf.callable.lock().clone(), args)
+        let callable = zelf.callable.lock().clone();
+        vm.invoke(&callable, args)
     }
 }
 

--- a/vm/src/builtins/staticmethod.rs
+++ b/vm/src/builtins/staticmethod.rs
@@ -1,16 +1,17 @@
-use super::{PyStr, PyType, PyTypeRef};
+use super::{PyBoundMethod, PyStr, PyType, PyTypeRef};
 use crate::{
     builtins::builtinfunc::PyBuiltinMethod,
     class::PyClassImpl,
+    common::lock::PyMutex,
     function::{FuncArgs, IntoPyNativeFunc},
     types::{Callable, Constructor, GetDescriptor, Initializer},
-    Context, Py, PyObjectRef, PyPayload, PyRef, PyResult, VirtualMachine,
+    AsObject, Context, Py, PyObjectRef, PyPayload, PyRef, PyResult, VirtualMachine,
 };
 
 #[pyclass(module = false, name = "staticmethod")]
-#[derive(Clone, Debug)]
+#[derive(Debug)]
 pub struct PyStaticMethod {
-    pub callable: PyObjectRef,
+    pub callable: PyMutex<PyObjectRef>,
 }
 
 impl PyPayload for PyStaticMethod {
@@ -22,18 +23,25 @@ impl PyPayload for PyStaticMethod {
 impl GetDescriptor for PyStaticMethod {
     fn descr_get(
         zelf: PyObjectRef,
-        _obj: Option<PyObjectRef>,
-        _cls: Option<PyObjectRef>,
+        obj: Option<PyObjectRef>,
+        cls: Option<PyObjectRef>,
         vm: &VirtualMachine,
     ) -> PyResult {
-        let zelf = Self::_zelf(zelf, vm)?;
-        Ok(zelf.callable.clone())
+        let (zelf, _obj) = Self::_unwrap(zelf, obj, vm)?;
+        let cls = cls.unwrap_or_else(|| _obj.class().clone().into());
+        let call_descr_get: PyResult<PyObjectRef> = zelf.callable.lock().get_attr("__get__", vm);
+        match call_descr_get {
+            Err(_) => Ok(PyBoundMethod::new_ref(cls, zelf.callable.lock().clone(), &vm.ctx).into()),
+            Ok(call_descr_get) => vm.invoke(&call_descr_get, (cls.clone(), cls)),
+        }
     }
 }
 
 impl From<PyObjectRef> for PyStaticMethod {
     fn from(callable: PyObjectRef) -> Self {
-        Self { callable }
+        Self {
+            callable: PyMutex::new(callable),
+        }
     }
 }
 
@@ -43,7 +51,10 @@ impl Constructor for PyStaticMethod {
     fn py_new(cls: PyTypeRef, callable: Self::Args, vm: &VirtualMachine) -> PyResult {
         let doc = callable.get_attr("__doc__", vm);
 
-        let result = PyStaticMethod { callable }.into_ref_with_type(vm, cls)?;
+        let result = PyStaticMethod {
+            callable: PyMutex::new(callable),
+        }
+        .into_ref_with_type(vm, cls)?;
         let obj = PyObjectRef::from(result);
 
         if let Ok(doc) = doc {
@@ -51,6 +62,18 @@ impl Constructor for PyStaticMethod {
         }
 
         Ok(obj)
+    }
+}
+
+impl PyStaticMethod {
+    pub fn new_ref(callable: PyObjectRef, ctx: &Context) -> PyRef<Self> {
+        PyRef::new_ref(
+            Self {
+                callable: PyMutex::new(callable),
+            },
+            ctx.types.staticmethod_type.to_owned(),
+            None,
+        )
     }
 }
 
@@ -66,7 +89,9 @@ impl PyStaticMethod {
     {
         let callable = PyBuiltinMethod::new_ref(name, class, f, ctx).into();
         PyRef::new_ref(
-            Self { callable },
+            Self {
+                callable: PyMutex::new(callable),
+            },
             ctx.types.staticmethod_type.to_owned(),
             None,
         )
@@ -76,49 +101,47 @@ impl PyStaticMethod {
 impl Initializer for PyStaticMethod {
     type Args = PyObjectRef;
 
-    fn init(_zelf: PyRef<Self>, _func: Self::Args, _vm: &VirtualMachine) -> PyResult<()> {
+    fn init(zelf: PyRef<Self>, callable: Self::Args, _vm: &VirtualMachine) -> PyResult<()> {
+        *zelf.callable.lock() = callable;
         Ok(())
     }
 }
 
-#[pyclass(
-    with(Callable, GetDescriptor, Constructor, Initializer),
-    flags(BASETYPE, HAS_DICT)
-)]
+#[pyclass(with(Callable, Constructor, Initializer), flags(BASETYPE, HAS_DICT))]
 impl PyStaticMethod {
     #[pyproperty(magic)]
     fn func(&self) -> PyObjectRef {
-        self.callable.clone()
+        self.callable.lock().clone()
     }
 
     #[pyproperty(magic)]
     fn wrapped(&self) -> PyObjectRef {
-        self.callable.clone()
+        self.callable.lock().clone()
     }
 
     #[pyproperty(magic)]
     fn module(&self, vm: &VirtualMachine) -> PyResult {
-        self.callable.get_attr("__module__", vm)
+        self.callable.lock().get_attr("__module__", vm)
     }
 
     #[pyproperty(magic)]
     fn qualname(&self, vm: &VirtualMachine) -> PyResult {
-        self.callable.get_attr("__qualname__", vm)
+        self.callable.lock().get_attr("__qualname__", vm)
     }
 
     #[pyproperty(magic)]
     fn name(&self, vm: &VirtualMachine) -> PyResult {
-        self.callable.get_attr("__name__", vm)
+        self.callable.lock().get_attr("__name__", vm)
     }
 
     #[pyproperty(magic)]
     fn annotations(&self, vm: &VirtualMachine) -> PyResult {
-        self.callable.get_attr("__annotations__", vm)
+        self.callable.lock().get_attr("__annotations__", vm)
     }
 
     #[pymethod(magic)]
     fn repr(&self, vm: &VirtualMachine) -> Option<String> {
-        let callable = self.callable.repr(vm).unwrap();
+        let callable = self.callable.lock().repr(vm).unwrap();
         let class = Self::class(vm);
 
         match (
@@ -138,7 +161,7 @@ impl PyStaticMethod {
 
     #[pyproperty(magic)]
     fn isabstractmethod(&self, vm: &VirtualMachine) -> PyObjectRef {
-        match vm.get_attribute_opt(self.callable.clone(), "__isabstractmethod__") {
+        match vm.get_attribute_opt(self.callable.lock().clone(), "__isabstractmethod__") {
             Ok(Some(is_abstract)) => is_abstract,
             _ => vm.ctx.new_bool(false).into(),
         }
@@ -146,7 +169,9 @@ impl PyStaticMethod {
 
     #[pyproperty(magic, setter)]
     fn set_isabstractmethod(&self, value: PyObjectRef, vm: &VirtualMachine) -> PyResult<()> {
-        self.callable.set_attr("__isabstractmethod__", value, vm)?;
+        self.callable
+            .lock()
+            .set_attr("__isabstractmethod__", value, vm)?;
         Ok(())
     }
 }
@@ -155,7 +180,7 @@ impl Callable for PyStaticMethod {
     type Args = FuncArgs;
     #[inline]
     fn call(zelf: &crate::Py<Self>, args: FuncArgs, vm: &VirtualMachine) -> PyResult {
-        vm.invoke(&zelf.callable, args)
+        vm.invoke(&zelf.callable.lock().clone(), args)
     }
 }
 


### PR DESCRIPTION
- PyStaticMethod struct field type change to PyMutex<PyObjectRef>
- Adding a .lock() due to adding a lock method
- builtinfunc.rs file change due to type change