### PR TITLE
Avoid creating unused JoinedStr in FStringParser

### DIFF
--- a/compiler/parser/src/snapshots/rustpython_parser__fstring__tests__fstring_parse_selfdocumenting_base.snap
+++ b/compiler/parser/src/snapshots/rustpython_parser__fstring__tests__fstring_parse_selfdocumenting_base.snap
@@ -1,5 +1,5 @@
 ---
-source: parser/src/fstring.rs
+source: compiler/parser/src/fstring.rs
 expression: parse_ast
 ---
 [

--- a/compiler/parser/src/snapshots/rustpython_parser__fstring__tests__fstring_parse_selfdocumenting_base.snap
+++ b/compiler/parser/src/snapshots/rustpython_parser__fstring__tests__fstring_parse_selfdocumenting_base.snap
@@ -2,62 +2,53 @@
 source: parser/src/fstring.rs
 expression: parse_ast
 ---
-Located {
-    location: Location {
-        row: 0,
-        column: 0,
+[
+    Located {
+        location: Location {
+            row: 0,
+            column: 0,
+        },
+        custom: (),
+        node: Constant {
+            value: Str(
+                "user=",
+            ),
+            kind: None,
+        },
     },
-    custom: (),
-    node: JoinedStr {
-        values: [
-            Located {
-                location: Location {
-                    row: 0,
-                    column: 0,
-                },
-                custom: (),
-                node: Constant {
-                    value: Str(
-                        "user=",
-                    ),
-                    kind: None,
-                },
-            },
-            Located {
-                location: Location {
-                    row: 0,
-                    column: 0,
-                },
-                custom: (),
-                node: Constant {
-                    value: Str(
-                        "",
-                    ),
-                    kind: None,
-                },
-            },
-            Located {
-                location: Location {
-                    row: 0,
-                    column: 0,
-                },
-                custom: (),
-                node: FormattedValue {
-                    value: Located {
-                        location: Location {
-                            row: 1,
-                            column: 2,
-                        },
-                        custom: (),
-                        node: Name {
-                            id: "user",
-                            ctx: Load,
-                        },
-                    },
-                    conversion: 114,
-                    format_spec: None,
-                },
-            },
-        ],
+    Located {
+        location: Location {
+            row: 0,
+            column: 0,
+        },
+        custom: (),
+        node: Constant {
+            value: Str(
+                "",
+            ),
+            kind: None,
+        },
     },
-}
+    Located {
+        location: Location {
+            row: 0,
+            column: 0,
+        },
+        custom: (),
+        node: FormattedValue {
+            value: Located {
+                location: Location {
+                    row: 1,
+                    column: 2,
+                },
+                custom: (),
+                node: Name {
+                    id: "user",
+                    ctx: Load,
+                },
+            },
+            conversion: 114,
+            format_spec: None,
+        },
+    },
+]

--- a/compiler/parser/src/snapshots/rustpython_parser__fstring__tests__fstring_parse_selfdocumenting_base_more.snap
+++ b/compiler/parser/src/snapshots/rustpython_parser__fstring__tests__fstring_parse_selfdocumenting_base_more.snap
@@ -1,5 +1,5 @@
 ---
-source: parser/src/fstring.rs
+source: compiler/parser/src/fstring.rs
 expression: parse_ast
 ---
 [

--- a/compiler/parser/src/snapshots/rustpython_parser__fstring__tests__fstring_parse_selfdocumenting_base_more.snap
+++ b/compiler/parser/src/snapshots/rustpython_parser__fstring__tests__fstring_parse_selfdocumenting_base_more.snap
@@ -2,136 +2,127 @@
 source: parser/src/fstring.rs
 expression: parse_ast
 ---
-Located {
-    location: Location {
-        row: 0,
-        column: 0,
+[
+    Located {
+        location: Location {
+            row: 0,
+            column: 0,
+        },
+        custom: (),
+        node: Constant {
+            value: Str(
+                "mix ",
+            ),
+            kind: None,
+        },
     },
-    custom: (),
-    node: JoinedStr {
-        values: [
-            Located {
-                location: Location {
-                    row: 0,
-                    column: 0,
-                },
-                custom: (),
-                node: Constant {
-                    value: Str(
-                        "mix ",
-                    ),
-                    kind: None,
-                },
-            },
-            Located {
-                location: Location {
-                    row: 0,
-                    column: 0,
-                },
-                custom: (),
-                node: Constant {
-                    value: Str(
-                        "user=",
-                    ),
-                    kind: None,
-                },
-            },
-            Located {
-                location: Location {
-                    row: 0,
-                    column: 0,
-                },
-                custom: (),
-                node: Constant {
-                    value: Str(
-                        "",
-                    ),
-                    kind: None,
-                },
-            },
-            Located {
-                location: Location {
-                    row: 0,
-                    column: 0,
-                },
-                custom: (),
-                node: FormattedValue {
-                    value: Located {
-                        location: Location {
-                            row: 1,
-                            column: 2,
-                        },
-                        custom: (),
-                        node: Name {
-                            id: "user",
-                            ctx: Load,
-                        },
-                    },
-                    conversion: 114,
-                    format_spec: None,
-                },
-            },
-            Located {
-                location: Location {
-                    row: 0,
-                    column: 0,
-                },
-                custom: (),
-                node: Constant {
-                    value: Str(
-                        " with text and ",
-                    ),
-                    kind: None,
-                },
-            },
-            Located {
-                location: Location {
-                    row: 0,
-                    column: 0,
-                },
-                custom: (),
-                node: Constant {
-                    value: Str(
-                        "second=",
-                    ),
-                    kind: None,
-                },
-            },
-            Located {
-                location: Location {
-                    row: 0,
-                    column: 0,
-                },
-                custom: (),
-                node: Constant {
-                    value: Str(
-                        "",
-                    ),
-                    kind: None,
-                },
-            },
-            Located {
-                location: Location {
-                    row: 0,
-                    column: 0,
-                },
-                custom: (),
-                node: FormattedValue {
-                    value: Located {
-                        location: Location {
-                            row: 1,
-                            column: 2,
-                        },
-                        custom: (),
-                        node: Name {
-                            id: "second",
-                            ctx: Load,
-                        },
-                    },
-                    conversion: 114,
-                    format_spec: None,
-                },
-            },
-        ],
+    Located {
+        location: Location {
+            row: 0,
+            column: 0,
+        },
+        custom: (),
+        node: Constant {
+            value: Str(
+                "user=",
+            ),
+            kind: None,
+        },
     },
-}
+    Located {
+        location: Location {
+            row: 0,
+            column: 0,
+        },
+        custom: (),
+        node: Constant {
+            value: Str(
+                "",
+            ),
+            kind: None,
+        },
+    },
+    Located {
+        location: Location {
+            row: 0,
+            column: 0,
+        },
+        custom: (),
+        node: FormattedValue {
+            value: Located {
+                location: Location {
+                    row: 1,
+                    column: 2,
+                },
+                custom: (),
+                node: Name {
+                    id: "user",
+                    ctx: Load,
+                },
+            },
+            conversion: 114,
+            format_spec: None,
+        },
+    },
+    Located {
+        location: Location {
+            row: 0,
+            column: 0,
+        },
+        custom: (),
+        node: Constant {
+            value: Str(
+                " with text and ",
+            ),
+            kind: None,
+        },
+    },
+    Located {
+        location: Location {
+            row: 0,
+            column: 0,
+        },
+        custom: (),
+        node: Constant {
+            value: Str(
+                "second=",
+            ),
+            kind: None,
+        },
+    },
+    Located {
+        location: Location {
+            row: 0,
+            column: 0,
+        },
+        custom: (),
+        node: Constant {
+            value: Str(
+                "",
+            ),
+            kind: None,
+        },
+    },
+    Located {
+        location: Location {
+            row: 0,
+            column: 0,
+        },
+        custom: (),
+        node: FormattedValue {
+            value: Located {
+                location: Location {
+                    row: 1,
+                    column: 2,
+                },
+                custom: (),
+                node: Name {
+                    id: "second",
+                    ctx: Load,
+                },
+            },
+            conversion: 114,
+            format_spec: None,
+        },
+    },
+]

--- a/compiler/parser/src/snapshots/rustpython_parser__fstring__tests__fstring_parse_selfdocumenting_format.snap
+++ b/compiler/parser/src/snapshots/rustpython_parser__fstring__tests__fstring_parse_selfdocumenting_format.snap
@@ -2,87 +2,78 @@
 source: parser/src/fstring.rs
 expression: parse_ast
 ---
-Located {
-    location: Location {
-        row: 0,
-        column: 0,
+[
+    Located {
+        location: Location {
+            row: 0,
+            column: 0,
+        },
+        custom: (),
+        node: Constant {
+            value: Str(
+                "user=",
+            ),
+            kind: None,
+        },
     },
-    custom: (),
-    node: JoinedStr {
-        values: [
-            Located {
+    Located {
+        location: Location {
+            row: 0,
+            column: 0,
+        },
+        custom: (),
+        node: Constant {
+            value: Str(
+                "",
+            ),
+            kind: None,
+        },
+    },
+    Located {
+        location: Location {
+            row: 0,
+            column: 0,
+        },
+        custom: (),
+        node: FormattedValue {
+            value: Located {
                 location: Location {
-                    row: 0,
-                    column: 0,
+                    row: 1,
+                    column: 2,
                 },
                 custom: (),
-                node: Constant {
-                    value: Str(
-                        "user=",
-                    ),
-                    kind: None,
+                node: Name {
+                    id: "user",
+                    ctx: Load,
                 },
             },
-            Located {
-                location: Location {
-                    row: 0,
-                    column: 0,
-                },
-                custom: (),
-                node: Constant {
-                    value: Str(
-                        "",
-                    ),
-                    kind: None,
-                },
-            },
-            Located {
-                location: Location {
-                    row: 0,
-                    column: 0,
-                },
-                custom: (),
-                node: FormattedValue {
-                    value: Located {
-                        location: Location {
-                            row: 1,
-                            column: 2,
-                        },
-                        custom: (),
-                        node: Name {
-                            id: "user",
-                            ctx: Load,
-                        },
+            conversion: 0,
+            format_spec: Some(
+                Located {
+                    location: Location {
+                        row: 0,
+                        column: 0,
                     },
-                    conversion: 0,
-                    format_spec: Some(
-                        Located {
-                            location: Location {
-                                row: 0,
-                                column: 0,
+                    custom: (),
+                    node: JoinedStr {
+                        values: [
+                            Located {
+                                location: Location {
+                                    row: 0,
+                                    column: 0,
+                                },
+                                custom: (),
+                                node: Constant {
+                                    value: Str(
+                                        ">10",
+                                    ),
+                                    kind: None,
+                                },
                             },
-                            custom: (),
-                            node: JoinedStr {
-                                values: [
-                                    Located {
-                                        location: Location {
-                                            row: 0,
-                                            column: 0,
-                                        },
-                                        custom: (),
-                                        node: Constant {
-                                            value: Str(
-                                                ">10",
-                                            ),
-                                            kind: None,
-                                        },
-                                    },
-                                ],
-                            },
-                        },
-                    ),
+                        ],
+                    },
                 },
-            },
-        ],
+            ),
+        },
     },
-}
+]

--- a/compiler/parser/src/snapshots/rustpython_parser__fstring__tests__fstring_parse_selfdocumenting_format.snap
+++ b/compiler/parser/src/snapshots/rustpython_parser__fstring__tests__fstring_parse_selfdocumenting_format.snap
@@ -1,5 +1,5 @@
 ---
-source: parser/src/fstring.rs
+source: compiler/parser/src/fstring.rs
 expression: parse_ast
 ---
 [

--- a/compiler/parser/src/snapshots/rustpython_parser__fstring__tests__parse_empty_fstring.snap
+++ b/compiler/parser/src/snapshots/rustpython_parser__fstring__tests__parse_empty_fstring.snap
@@ -1,5 +1,5 @@
 ---
-source: parser/src/fstring.rs
+source: compiler/parser/src/fstring.rs
 expression: "parse_fstring(\"\").unwrap()"
 ---
 []

--- a/compiler/parser/src/snapshots/rustpython_parser__fstring__tests__parse_empty_fstring.snap
+++ b/compiler/parser/src/snapshots/rustpython_parser__fstring__tests__parse_empty_fstring.snap
@@ -1,15 +1,5 @@
 ---
 source: parser/src/fstring.rs
 expression: "parse_fstring(\"\").unwrap()"
-
 ---
-Located {
-    location: Location {
-        row: 0,
-        column: 0,
-    },
-    custom: (),
-    node: JoinedStr {
-        values: [],
-    },
-}
+[]

--- a/compiler/parser/src/snapshots/rustpython_parser__fstring__tests__parse_fstring.snap
+++ b/compiler/parser/src/snapshots/rustpython_parser__fstring__tests__parse_fstring.snap
@@ -1,5 +1,5 @@
 ---
-source: parser/src/fstring.rs
+source: compiler/parser/src/fstring.rs
 expression: parse_ast
 ---
 [

--- a/compiler/parser/src/snapshots/rustpython_parser__fstring__tests__parse_fstring.snap
+++ b/compiler/parser/src/snapshots/rustpython_parser__fstring__tests__parse_fstring.snap
@@ -2,71 +2,62 @@
 source: parser/src/fstring.rs
 expression: parse_ast
 ---
-Located {
-    location: Location {
-        row: 0,
-        column: 0,
+[
+    Located {
+        location: Location {
+            row: 0,
+            column: 0,
+        },
+        custom: (),
+        node: FormattedValue {
+            value: Located {
+                location: Location {
+                    row: 1,
+                    column: 2,
+                },
+                custom: (),
+                node: Name {
+                    id: "a",
+                    ctx: Load,
+                },
+            },
+            conversion: 0,
+            format_spec: None,
+        },
     },
-    custom: (),
-    node: JoinedStr {
-        values: [
-            Located {
+    Located {
+        location: Location {
+            row: 0,
+            column: 0,
+        },
+        custom: (),
+        node: FormattedValue {
+            value: Located {
                 location: Location {
-                    row: 0,
-                    column: 0,
+                    row: 1,
+                    column: 3,
                 },
                 custom: (),
-                node: FormattedValue {
-                    value: Located {
-                        location: Location {
-                            row: 1,
-                            column: 2,
-                        },
-                        custom: (),
-                        node: Name {
-                            id: "a",
-                            ctx: Load,
-                        },
-                    },
-                    conversion: 0,
-                    format_spec: None,
+                node: Name {
+                    id: "b",
+                    ctx: Load,
                 },
             },
-            Located {
-                location: Location {
-                    row: 0,
-                    column: 0,
-                },
-                custom: (),
-                node: FormattedValue {
-                    value: Located {
-                        location: Location {
-                            row: 1,
-                            column: 3,
-                        },
-                        custom: (),
-                        node: Name {
-                            id: "b",
-                            ctx: Load,
-                        },
-                    },
-                    conversion: 0,
-                    format_spec: None,
-                },
-            },
-            Located {
-                location: Location {
-                    row: 0,
-                    column: 0,
-                },
-                custom: (),
-                node: Constant {
-                    value: Str(
-                        "{foo}",
-                    ),
-                    kind: None,
-                },
-            },
-        ],
+            conversion: 0,
+            format_spec: None,
+        },
     },
-}
+    Located {
+        location: Location {
+            row: 0,
+            column: 0,
+        },
+        custom: (),
+        node: Constant {
+            value: Str(
+                "{foo}",
+            ),
+            kind: None,
+        },
+    },
+]

--- a/compiler/parser/src/snapshots/rustpython_parser__fstring__tests__parse_fstring_equals.snap
+++ b/compiler/parser/src/snapshots/rustpython_parser__fstring__tests__parse_fstring_equals.snap
@@ -1,5 +1,5 @@
 ---
-source: parser/src/fstring.rs
+source: compiler/parser/src/fstring.rs
 expression: parse_ast
 ---
 [

--- a/compiler/parser/src/snapshots/rustpython_parser__fstring__tests__parse_fstring_equals.snap
+++ b/compiler/parser/src/snapshots/rustpython_parser__fstring__tests__parse_fstring_equals.snap
@@ -2,65 +2,56 @@
 source: parser/src/fstring.rs
 expression: parse_ast
 ---
-Located {
-    location: Location {
-        row: 0,
-        column: 0,
-    },
-    custom: (),
-    node: JoinedStr {
-        values: [
-            Located {
+[
+    Located {
+        location: Location {
+            row: 0,
+            column: 0,
+        },
+        custom: (),
+        node: FormattedValue {
+            value: Located {
                 location: Location {
-                    row: 0,
-                    column: 0,
+                    row: 1,
+                    column: 5,
                 },
                 custom: (),
-                node: FormattedValue {
-                    value: Located {
+                node: Compare {
+                    left: Located {
                         location: Location {
                             row: 1,
-                            column: 5,
+                            column: 2,
                         },
                         custom: (),
-                        node: Compare {
-                            left: Located {
-                                location: Location {
-                                    row: 1,
-                                    column: 2,
-                                },
-                                custom: (),
-                                node: Constant {
-                                    value: Int(
-                                        42,
-                                    ),
-                                    kind: None,
-                                },
-                            },
-                            ops: [
-                                Eq,
-                            ],
-                            comparators: [
-                                Located {
-                                    location: Location {
-                                        row: 1,
-                                        column: 8,
-                                    },
-                                    custom: (),
-                                    node: Constant {
-                                        value: Int(
-                                            42,
-                                        ),
-                                        kind: None,
-                                    },
-                                },
-                            ],
+                        node: Constant {
+                            value: Int(
+                                42,
+                            ),
+                            kind: None,
                         },
                     },
-                    conversion: 0,
-                    format_spec: None,
+                    ops: [
+                        Eq,
+                    ],
+                    comparators: [
+                        Located {
+                            location: Location {
+                                row: 1,
+                                column: 8,
+                            },
+                            custom: (),
+                            node: Constant {
+                                value: Int(
+                                    42,
+                                ),
+                                kind: None,
+                            },
+                        },
+                    ],
                 },
             },
-        ],
+            conversion: 0,
+            format_spec: None,
+        },
     },
-}
+]

--- a/compiler/parser/src/snapshots/rustpython_parser__fstring__tests__parse_fstring_nested_spec.snap
+++ b/compiler/parser/src/snapshots/rustpython_parser__fstring__tests__parse_fstring_nested_spec.snap
@@ -2,118 +2,52 @@
 source: parser/src/fstring.rs
 expression: parse_ast
 ---
-Located {
-    location: Location {
-        row: 0,
-        column: 0,
-    },
-    custom: (),
-    node: JoinedStr {
-        values: [
-            Located {
+[
+    Located {
+        location: Location {
+            row: 0,
+            column: 0,
+        },
+        custom: (),
+        node: FormattedValue {
+            value: Located {
                 location: Location {
-                    row: 0,
-                    column: 0,
+                    row: 1,
+                    column: 2,
                 },
                 custom: (),
-                node: FormattedValue {
-                    value: Located {
-                        location: Location {
-                            row: 1,
-                            column: 2,
-                        },
-                        custom: (),
-                        node: Name {
-                            id: "foo",
-                            ctx: Load,
-                        },
-                    },
-                    conversion: 0,
-                    format_spec: Some(
-                        Located {
-                            location: Location {
-                                row: 0,
-                                column: 0,
-                            },
-                            custom: (),
-                            node: JoinedStr {
-                                values: [
-                                    Located {
-                                        location: Location {
-                                            row: 0,
-                                            column: 0,
-                                        },
-                                        custom: (),
-                                        node: Constant {
-                                            value: Str(
-                                                "",
-                                            ),
-                                            kind: None,
-                                        },
-                                    },
-                                    Located {
-                                        location: Location {
-                                            row: 0,
-                                            column: 0,
-                                        },
-                                        custom: (),
-                                        node: FormattedValue {
-                                            value: Located {
-                                                location: Location {
-                                                    row: 0,
-                                                    column: 0,
-                                                },
-                                                custom: (),
-                                                node: JoinedStr {
-                                                    values: [
-                                                        Located {
-                                                            location: Location {
-                                                                row: 0,
-                                                                column: 0,
-                                                            },
-                                                            custom: (),
-                                                            node: FormattedValue {
-                                                                value: Located {
-                                                                    location: Location {
-                                                                        row: 1,
-                                                                        column: 3,
-                                                                    },
-                                                                    custom: (),
-                                                                    node: Name {
-                                                                        id: "spec",
-                                                                        ctx: Load,
-                                                                    },
-                                                                },
-                                                                conversion: 0,
-                                                                format_spec: None,
-                                                            },
-                                                        },
-                                                    ],
-                                                },
-                                            },
-                                            conversion: 0,
-                                            format_spec: None,
-                                        },
-                                    },
-                                    Located {
-                                        location: Location {
-                                            row: 0,
-                                            column: 0,
-                                        },
-                                        custom: (),
-                                        node: Constant {
-                                            value: Str(
-                                                "",
-                                            ),
-                                            kind: None,
-                                        },
-                                    },
-                                ],
-                            },
-                        },
-                    ),
+                node: Name {
+                    id: "foo",
+                    ctx: Load,
                 },
             },
-        ],
+            conversion: 0,
+            format_spec: Some(
+                Located {
+                    location: Location {
+                        row: 0,
+                        column: 0,
+                    },
+                    custom: (),
+                    node: JoinedStr {
+                        values: [
+                            Located {
+                                location: Location {
+                                    row: 0,
+                                    column: 0,
+                                },
+                                custom: (),
+                                node: Constant {
+                                    value: Str(
+                                        "{ spec}",
+                                    ),
+                                    kind: None,
+                                },
+                            },
+                        ],
+                    },
+                },
+            ),
+        },
     },
-}
+]

--- a/compiler/parser/src/snapshots/rustpython_parser__fstring__tests__parse_fstring_nested_spec.snap
+++ b/compiler/parser/src/snapshots/rustpython_parser__fstring__tests__parse_fstring_nested_spec.snap
@@ -1,5 +1,5 @@
 ---
-source: parser/src/fstring.rs
+source: compiler/parser/src/fstring.rs
 expression: parse_ast
 ---
 [
@@ -37,11 +37,20 @@ expression: parse_ast
                                     column: 0,
                                 },
                                 custom: (),
-                                node: Constant {
-                                    value: Str(
-                                        "{ spec}",
-                                    ),
-                                    kind: None,
+                                node: FormattedValue {
+                                    value: Located {
+                                        location: Location {
+                                            row: 1,
+                                            column: 3,
+                                        },
+                                        custom: (),
+                                        node: Name {
+                                            id: "spec",
+                                            ctx: Load,
+                                        },
+                                    },
+                                    conversion: 0,
+                                    format_spec: None,
                                 },
                             },
                         ],

--- a/compiler/parser/src/snapshots/rustpython_parser__fstring__tests__parse_fstring_not_equals.snap
+++ b/compiler/parser/src/snapshots/rustpython_parser__fstring__tests__parse_fstring_not_equals.snap
@@ -1,5 +1,5 @@
 ---
-source: parser/src/fstring.rs
+source: compiler/parser/src/fstring.rs
 expression: parse_ast
 ---
 [

--- a/compiler/parser/src/snapshots/rustpython_parser__fstring__tests__parse_fstring_not_equals.snap
+++ b/compiler/parser/src/snapshots/rustpython_parser__fstring__tests__parse_fstring_not_equals.snap
@@ -2,65 +2,56 @@
 source: parser/src/fstring.rs
 expression: parse_ast
 ---
-Located {
-    location: Location {
-        row: 0,
-        column: 0,
-    },
-    custom: (),
-    node: JoinedStr {
-        values: [
-            Located {
+[
+    Located {
+        location: Location {
+            row: 0,
+            column: 0,
+        },
+        custom: (),
+        node: FormattedValue {
+            value: Located {
                 location: Location {
-                    row: 0,
-                    column: 0,
+                    row: 1,
+                    column: 4,
                 },
                 custom: (),
-                node: FormattedValue {
-                    value: Located {
+                node: Compare {
+                    left: Located {
                         location: Location {
                             row: 1,
-                            column: 4,
+                            column: 2,
                         },
                         custom: (),
-                        node: Compare {
-                            left: Located {
-                                location: Location {
-                                    row: 1,
-                                    column: 2,
-                                },
-                                custom: (),
-                                node: Constant {
-                                    value: Int(
-                                        1,
-                                    ),
-                                    kind: None,
-                                },
-                            },
-                            ops: [
-                                NotEq,
-                            ],
-                            comparators: [
-                                Located {
-                                    location: Location {
-                                        row: 1,
-                                        column: 7,
-                                    },
-                                    custom: (),
-                                    node: Constant {
-                                        value: Int(
-                                            2,
-                                        ),
-                                        kind: None,
-                                    },
-                                },
-                            ],
+                        node: Constant {
+                            value: Int(
+                                1,
+                            ),
+                            kind: None,
                         },
                     },
-                    conversion: 0,
-                    format_spec: None,
+                    ops: [
+                        NotEq,
+                    ],
+                    comparators: [
+                        Located {
+                            location: Location {
+                                row: 1,
+                                column: 7,
+                            },
+                            custom: (),
+                            node: Constant {
+                                value: Int(
+                                    2,
+                                ),
+                                kind: None,
+                            },
+                        },
+                    ],
                 },
             },
-        ],
+            conversion: 0,
+            format_spec: None,
+        },
     },
-}
+]

--- a/compiler/parser/src/snapshots/rustpython_parser__fstring__tests__parse_fstring_not_nested_spec.snap
+++ b/compiler/parser/src/snapshots/rustpython_parser__fstring__tests__parse_fstring_not_nested_spec.snap
@@ -1,5 +1,5 @@
 ---
-source: parser/src/fstring.rs
+source: compiler/parser/src/fstring.rs
 expression: parse_ast
 ---
 [

--- a/compiler/parser/src/snapshots/rustpython_parser__fstring__tests__parse_fstring_not_nested_spec.snap
+++ b/compiler/parser/src/snapshots/rustpython_parser__fstring__tests__parse_fstring_not_nested_spec.snap
@@ -2,61 +2,52 @@
 source: parser/src/fstring.rs
 expression: parse_ast
 ---
-Located {
-    location: Location {
-        row: 0,
-        column: 0,
-    },
-    custom: (),
-    node: JoinedStr {
-        values: [
-            Located {
+[
+    Located {
+        location: Location {
+            row: 0,
+            column: 0,
+        },
+        custom: (),
+        node: FormattedValue {
+            value: Located {
                 location: Location {
-                    row: 0,
-                    column: 0,
+                    row: 1,
+                    column: 2,
                 },
                 custom: (),
-                node: FormattedValue {
-                    value: Located {
-                        location: Location {
-                            row: 1,
-                            column: 2,
-                        },
-                        custom: (),
-                        node: Name {
-                            id: "foo",
-                            ctx: Load,
-                        },
-                    },
-                    conversion: 0,
-                    format_spec: Some(
-                        Located {
-                            location: Location {
-                                row: 0,
-                                column: 0,
-                            },
-                            custom: (),
-                            node: JoinedStr {
-                                values: [
-                                    Located {
-                                        location: Location {
-                                            row: 0,
-                                            column: 0,
-                                        },
-                                        custom: (),
-                                        node: Constant {
-                                            value: Str(
-                                                "spec",
-                                            ),
-                                            kind: None,
-                                        },
-                                    },
-                                ],
-                            },
-                        },
-                    ),
+                node: Name {
+                    id: "foo",
+                    ctx: Load,
                 },
             },
-        ],
+            conversion: 0,
+            format_spec: Some(
+                Located {
+                    location: Location {
+                        row: 0,
+                        column: 0,
+                    },
+                    custom: (),
+                    node: JoinedStr {
+                        values: [
+                            Located {
+                                location: Location {
+                                    row: 0,
+                                    column: 0,
+                                },
+                                custom: (),
+                                node: Constant {
+                                    value: Str(
+                                        "spec",
+                                    ),
+                                    kind: None,
+                                },
+                            },
+                        ],
+                    },
+                },
+            ),
+        },
     },
-}
+]

--- a/compiler/parser/src/snapshots/rustpython_parser__fstring__tests__parse_fstring_selfdoc_prec_space.snap
+++ b/compiler/parser/src/snapshots/rustpython_parser__fstring__tests__parse_fstring_selfdoc_prec_space.snap
@@ -2,62 +2,53 @@
 source: parser/src/fstring.rs
 expression: parse_ast
 ---
-Located {
-    location: Location {
-        row: 0,
-        column: 0,
+[
+    Located {
+        location: Location {
+            row: 0,
+            column: 0,
+        },
+        custom: (),
+        node: Constant {
+            value: Str(
+                "x   =",
+            ),
+            kind: None,
+        },
     },
-    custom: (),
-    node: JoinedStr {
-        values: [
-            Located {
-                location: Location {
-                    row: 0,
-                    column: 0,
-                },
-                custom: (),
-                node: Constant {
-                    value: Str(
-                        "x   =",
-                    ),
-                    kind: None,
-                },
-            },
-            Located {
-                location: Location {
-                    row: 0,
-                    column: 0,
-                },
-                custom: (),
-                node: Constant {
-                    value: Str(
-                        "",
-                    ),
-                    kind: None,
-                },
-            },
-            Located {
-                location: Location {
-                    row: 0,
-                    column: 0,
-                },
-                custom: (),
-                node: FormattedValue {
-                    value: Located {
-                        location: Location {
-                            row: 1,
-                            column: 2,
-                        },
-                        custom: (),
-                        node: Name {
-                            id: "x",
-                            ctx: Load,
-                        },
-                    },
-                    conversion: 114,
-                    format_spec: None,
-                },
-            },
-        ],
+    Located {
+        location: Location {
+            row: 0,
+            column: 0,
+        },
+        custom: (),
+        node: Constant {
+            value: Str(
+                "",
+            ),
+            kind: None,
+        },
     },
-}
+    Located {
+        location: Location {
+            row: 0,
+            column: 0,
+        },
+        custom: (),
+        node: FormattedValue {
+            value: Located {
+                location: Location {
+                    row: 1,
+                    column: 2,
+                },
+                custom: (),
+                node: Name {
+                    id: "x",
+                    ctx: Load,
+                },
+            },
+            conversion: 114,
+            format_spec: None,
+        },
+    },
+]

--- a/compiler/parser/src/snapshots/rustpython_parser__fstring__tests__parse_fstring_selfdoc_prec_space.snap
+++ b/compiler/parser/src/snapshots/rustpython_parser__fstring__tests__parse_fstring_selfdoc_prec_space.snap
@@ -1,5 +1,5 @@
 ---
-source: parser/src/fstring.rs
+source: compiler/parser/src/fstring.rs
 expression: parse_ast
 ---
 [

--- a/compiler/parser/src/snapshots/rustpython_parser__fstring__tests__parse_fstring_selfdoc_trailing_space.snap
+++ b/compiler/parser/src/snapshots/rustpython_parser__fstring__tests__parse_fstring_selfdoc_trailing_space.snap
@@ -2,62 +2,53 @@
 source: parser/src/fstring.rs
 expression: parse_ast
 ---
-Located {
-    location: Location {
-        row: 0,
-        column: 0,
+[
+    Located {
+        location: Location {
+            row: 0,
+            column: 0,
+        },
+        custom: (),
+        node: Constant {
+            value: Str(
+                "x=",
+            ),
+            kind: None,
+        },
     },
-    custom: (),
-    node: JoinedStr {
-        values: [
-            Located {
-                location: Location {
-                    row: 0,
-                    column: 0,
-                },
-                custom: (),
-                node: Constant {
-                    value: Str(
-                        "x=",
-                    ),
-                    kind: None,
-                },
-            },
-            Located {
-                location: Location {
-                    row: 0,
-                    column: 0,
-                },
-                custom: (),
-                node: Constant {
-                    value: Str(
-                        "   ",
-                    ),
-                    kind: None,
-                },
-            },
-            Located {
-                location: Location {
-                    row: 0,
-                    column: 0,
-                },
-                custom: (),
-                node: FormattedValue {
-                    value: Located {
-                        location: Location {
-                            row: 1,
-                            column: 2,
-                        },
-                        custom: (),
-                        node: Name {
-                            id: "x",
-                            ctx: Load,
-                        },
-                    },
-                    conversion: 114,
-                    format_spec: None,
-                },
-            },
-        ],
+    Located {
+        location: Location {
+            row: 0,
+            column: 0,
+        },
+        custom: (),
+        node: Constant {
+            value: Str(
+                "   ",
+            ),
+            kind: None,
+        },
     },
-}
+    Located {
+        location: Location {
+            row: 0,
+            column: 0,
+        },
+        custom: (),
+        node: FormattedValue {
+            value: Located {
+                location: Location {
+                    row: 1,
+                    column: 2,
+                },
+                custom: (),
+                node: Name {
+                    id: "x",
+                    ctx: Load,
+                },
+            },
+            conversion: 114,
+            format_spec: None,
+        },
+    },
+]

--- a/compiler/parser/src/snapshots/rustpython_parser__fstring__tests__parse_fstring_selfdoc_trailing_space.snap
+++ b/compiler/parser/src/snapshots/rustpython_parser__fstring__tests__parse_fstring_selfdoc_trailing_space.snap
@@ -1,5 +1,5 @@
 ---
-source: parser/src/fstring.rs
+source: compiler/parser/src/fstring.rs
 expression: parse_ast
 ---
 [

--- a/compiler/parser/src/snapshots/rustpython_parser__fstring__tests__parse_fstring_yield_expr.snap
+++ b/compiler/parser/src/snapshots/rustpython_parser__fstring__tests__parse_fstring_yield_expr.snap
@@ -1,5 +1,5 @@
 ---
-source: parser/src/fstring.rs
+source: compiler/parser/src/fstring.rs
 expression: parse_ast
 ---
 [

--- a/compiler/parser/src/snapshots/rustpython_parser__fstring__tests__parse_fstring_yield_expr.snap
+++ b/compiler/parser/src/snapshots/rustpython_parser__fstring__tests__parse_fstring_yield_expr.snap
@@ -2,35 +2,26 @@
 source: parser/src/fstring.rs
 expression: parse_ast
 ---
-Located {
-    location: Location {
-        row: 0,
-        column: 0,
-    },
-    custom: (),
-    node: JoinedStr {
-        values: [
-            Located {
+[
+    Located {
+        location: Location {
+            row: 0,
+            column: 0,
+        },
+        custom: (),
+        node: FormattedValue {
+            value: Located {
                 location: Location {
-                    row: 0,
-                    column: 0,
+                    row: 1,
+                    column: 2,
                 },
                 custom: (),
-                node: FormattedValue {
-                    value: Located {
-                        location: Location {
-                            row: 1,
-                            column: 2,
-                        },
-                        custom: (),
-                        node: Yield {
-                            value: None,
-                        },
-                    },
-                    conversion: 0,
-                    format_spec: None,
+                node: Yield {
+                    value: None,
                 },
             },
-        ],
+            conversion: 0,
+            format_spec: None,
+        },
     },
-}
+]

--- a/compiler/parser/src/string.rs
+++ b/compiler/parser/src/string.rs
@@ -34,19 +34,10 @@ pub fn parse_strings(values: Vec<(Location, (String, StringKind))>) -> Result<Ex
             StringKind::Normal | StringKind::U => current.push(string),
             StringKind::F => {
                 has_fstring = true;
-                let values = if let ExprKind::JoinedStr { values } =
-                    parse_located_fstring(&string, location)
-                        .map_err(|e| LexicalError {
-                            location,
-                            error: LexicalErrorType::FStringError(e.error),
-                        })?
-                        .node
-                {
-                    values
-                } else {
-                    unreachable!("parse_located_fstring returned a non-JoinedStr.")
-                };
-                for value in values {
+                for value in parse_located_fstring(&string, location).map_err(|e| LexicalError {
+                    location,
+                    error: LexicalErrorType::FStringError(e.error),
+                })? {
                     match value.node {
                         ExprKind::FormattedValue { .. } => {
                             if !current.is_empty() {

--- a/demo.py
+++ b/demo.py
@@ -1,2 +1,0 @@
-
-print("Hello, RustPython!")


### PR DESCRIPTION
# Summary

Per discussion in #4097, we can now avoid creating a `JoinedStr` entirely when parsing f-strings, and instead return the vector of values.
