### PR TITLE
Switch to const-initialized thread_local variables where appropriate

### DIFF
--- a/common/src/static_cell.rs
+++ b/common/src/static_cell.rs
@@ -56,7 +56,9 @@ mod non_threading {
             $($(#[$attr])*
             $vis static $name: $crate::static_cell::StaticCell<$t> = {
                 ::std::thread_local! {
-                     $vis static $name: $crate::lock::OnceCell<&'static $t> = $crate::lock::OnceCell::new();
+                     $vis static $name: $crate::lock::OnceCell<&'static $t> = const {
+                         $crate::lock::OnceCell::new()
+                     };
                 }
                 $crate::static_cell::StaticCell::_from_local_key(&$name)
             };)+

--- a/common/src/str.rs
+++ b/common/src/str.rs
@@ -486,7 +486,10 @@ pub mod levenshtein {
 
     pub fn levenshtein_distance(a: &str, b: &str, max_cost: usize) -> usize {
         thread_local! {
-            static BUFFER: RefCell<[usize; MAX_STRING_SIZE]> = const { RefCell::new([0usize; MAX_STRING_SIZE]) };
+            #[allow(clippy::declare_interior_mutable_const)]
+            static BUFFER: RefCell<[usize; MAX_STRING_SIZE]> = const {
+                RefCell::new([0usize; MAX_STRING_SIZE])
+            };
         }
 
         if a == b {

--- a/vm/src/stdlib/thread.rs
+++ b/vm/src/stdlib/thread.rs
@@ -355,7 +355,9 @@ pub(crate) mod _thread {
         Err(vm.new_exception_empty(vm.ctx.exceptions.system_exit.to_owned()))
     }
 
-    thread_local!(static SENTINELS: RefCell<Vec<PyRef<Lock>>> = RefCell::default());
+    thread_local! {
+        static SENTINELS: RefCell<Vec<PyRef<Lock>>> = const { RefCell::new(Vec::new()) };
+    }
 
     #[pyfunction]
     fn _set_sentinel(vm: &VirtualMachine) -> PyRef<Lock> {

--- a/wasm/lib/src/vm_class.rs
+++ b/wasm/lib/src/vm_class.rs
@@ -86,7 +86,9 @@ pub fn add_init_func(f: fn(&mut VirtualMachine)) {
 // https://rustwasm.github.io/2018/10/24/multithreading-rust-and-wasm.html#atomic-instructions
 thread_local! {
     static STORED_VMS: RefCell<HashMap<String, Rc<StoredVirtualMachine>>> = RefCell::default();
-    static VM_INIT_FUNCS: RefCell<Vec<fn(&mut VirtualMachine)>> = RefCell::default();
+    static VM_INIT_FUNCS: RefCell<Vec<fn(&mut VirtualMachine)>> = const {
+        RefCell::new(Vec::new())
+    };
 }
 
 pub fn get_vm_id(vm: &VirtualMachine) -> &str {


### PR DESCRIPTION
Apparently this was stabilized in 1.59 and I didn't even realize.
