### PR TITLE
Add built-in `breakpoint` function

### DIFF
--- a/Lib/test/test_builtin.py
+++ b/Lib/test/test_builtin.py
@@ -2004,6 +2004,10 @@ class TestBreakpoint(unittest.TestCase):
             breakpoint()
             mock.assert_not_called()
 
+    def test_runtime_error_when_hook_is_lost(self):
+        del sys.breakpointhook
+        with self.assertRaises(RuntimeError):
+            breakpoint()
 
 @unittest.skipUnless(pty, "the pty and signal modules must be available")
 class PtyTests(unittest.TestCase):

--- a/Lib/test/test_builtin.py
+++ b/Lib/test/test_builtin.py
@@ -1900,7 +1900,6 @@ class BuiltinTest(unittest.TestCase):
             self.assertFalse(not NotImplemented)
 
 
-@unittest.skip("TODO: RUSTPYTHON, AttributeError: module 'sys' has no attribute '__breakpointhook__'")
 class TestBreakpoint(unittest.TestCase):
     def setUp(self):
         # These tests require a clean slate environment.  For example, if the

--- a/vm/src/stdlib/builtins.rs
+++ b/vm/src/stdlib/builtins.rs
@@ -365,8 +365,8 @@ mod builtins {
         obj.hash(vm)
     }
 
-    #[pyfunction(name = "breakpoint")]
-    fn builtin_breakpoint(args: FuncArgs, vm: &VirtualMachine) -> PyResult {
+    #[pyfunction]
+    fn breakpoint(args: FuncArgs, vm: &VirtualMachine) -> PyResult {
         let hook =
             sys::get_object("breakpointhook".to_owned(), vm).expect("lost sys.breakpointhook");
 

--- a/vm/src/stdlib/builtins.rs
+++ b/vm/src/stdlib/builtins.rs
@@ -367,10 +367,13 @@ mod builtins {
 
     #[pyfunction]
     fn breakpoint(args: FuncArgs, vm: &VirtualMachine) -> PyResult {
-        let hook =
-            sys::get_object("breakpointhook".to_owned(), vm).expect("lost sys.breakpointhook");
-
-        vm.invoke(hook.as_ref(), args)
+        match vm
+            .sys_module
+            .get_attr(vm.ctx.intern_str("breakpointhook"), vm)
+        {
+            Ok(hook) => vm.invoke(hook.as_ref(), args),
+            Err(_) => Err(vm.new_runtime_error("lost sys.breakpointhook".to_owned())),
+        }
     }
 
     #[pyfunction]

--- a/vm/src/stdlib/builtins.rs
+++ b/vm/src/stdlib/builtins.rs
@@ -366,29 +366,11 @@ mod builtins {
     }
 
     #[pyfunction(name = "breakpoint")]
-    fn builtin_breakpoint(
-        args: OptionalArg<PyObjectRef>,
-        keywords: OptionalArg<PyObjectRef>,
-        vm: &VirtualMachine,
-    ) -> PyResult {
+    fn builtin_breakpoint(args: FuncArgs, vm: &VirtualMachine) -> PyResult {
         let hook =
             sys::get_object("breakpointhook".to_owned(), vm).expect("lost sys.breakpointhook");
 
-        match (args, keywords) {
-            (OptionalArg::Present(args), OptionalArg::Present(keywords)) => {
-                vm.invoke(hook.as_ref(), (args, keywords))
-            }
-            (OptionalArg::Missing, OptionalArg::Present(keywords)) => {
-                vm.invoke(hook.as_ref(), (Option::<PyObjectRef>::None, keywords))
-            }
-            (OptionalArg::Present(args), OptionalArg::Missing) => {
-                vm.invoke(hook.as_ref(), (args, Option::<PyObjectRef>::None))
-            }
-            (OptionalArg::Missing, OptionalArg::Missing) => vm.invoke(
-                hook.as_ref(),
-                (Option::<PyObjectRef>::None, Option::<PyObjectRef>::None),
-            ),
-        }
+        vm.invoke(hook.as_ref(), args)
     }
 
     #[pyfunction]

--- a/vm/src/stdlib/sys.rs
+++ b/vm/src/stdlib/sys.rs
@@ -326,7 +326,7 @@ mod sys {
     pub fn breakpointhook(args: FuncArgs, vm: &VirtualMachine) -> PyResult {
         let envar = std::env::var("PYTHONBREAKPOINT")
             .and_then(|envar| {
-                if envar.len() == 0 {
+                if envar.is_empty() {
                     Err(VarError::NotPresent)
                 } else {
                     Ok(envar)

--- a/vm/src/stdlib/sys.rs
+++ b/vm/src/stdlib/sys.rs
@@ -943,11 +943,6 @@ pub fn get_stderr(vm: &VirtualMachine) -> PyResult {
         .map_err(|_| vm.new_runtime_error("lost sys.stderr".to_owned()))
 }
 
-pub fn get_object(name: String, vm: &VirtualMachine) -> PyResult {
-    let dict = vm.sys_module.dict();
-    dict.get_item(&name, vm)
-}
-
 pub(crate) fn sysconfigdata_name() -> String {
     format!(
         "_sysconfigdata_{}_{}_{}",


### PR DESCRIPTION
## Outline

- Add built-in `breakpoint` function

## Result

```
>>>>> breakpoint()
--Return--
> /Users/igyubong/Desktop/RustPython/Lib/bdb.py(336)set_trace()->None
-> sys.settrace(self.trace_dispatch)
(Pdb) 
```

## References

- [Python breakpoint documentation](https://docs.python.org/3.7/library/functions.html#breakpoint)
- [cpython breakpoint implementation](https://github.com/python/cpython/blob/main/Python/sysmodule.c#L499-L582)