### PR TITLE
Only run lalrpop generation on ubuntu-latest

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -104,7 +104,6 @@ jobs:
     env:
       RUST_BACKTRACE: full
     name: Run rust tests
-    needs: lalrpop
     runs-on:  ${{ matrix.os }}
     strategy:
       matrix:
@@ -114,11 +113,9 @@ jobs:
       # for windows, always checkout files with their original lf line endings
       - run: git config --global core.autocrlf false; git config --global core.eol lf
       - uses: actions/checkout@v2
-      - name: Cache generated parser
-        uses: actions/cache@v3
-        with:
-          path: compiler/parser/python.rs
-          key: lalrpop-${{ hashFiles('compiler/parser/python.lalrpop') }}
+      - uses: actions/cache@v3
+        with: { path: "~/.cargo/bin/lalrpop\n~/.cargo/.crates.toml", key: "lalrpop-${{ runner.os }}" }
+      - run: cargo install lalrpop@0.19.8
       - uses: dtolnay/rust-toolchain@stable
       - name: Set up the Windows environment
         shell: bash
@@ -155,15 +152,12 @@ jobs:
   exotic_targets:
     if: ${{ !contains(github.event.pull_request.labels.*.name, 'skip:ci') }}
     name: Ensure compilation on various targets
-    needs: lalrpop
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - name: Cache generated parser
-        uses: actions/cache@v3
-        with:
-          path: compiler/parser/python.rs
-          key: lalrpop-${{ hashFiles('compiler/parser/python.lalrpop') }}
+      - uses: actions/cache@v3
+        with: { path: "~/.cargo/bin/lalrpop\n~/.cargo/.crates.toml", key: "lalrpop-${{ runner.os }}" }
+      - run: cargo install lalrpop@0.19.8
 
       - uses: dtolnay/rust-toolchain@stable
         with:
@@ -219,7 +213,6 @@ jobs:
 
   snippets_cpython:
     if: ${{ !contains(github.event.pull_request.labels.*.name, 'skip:ci') }}
-    needs: lalrpop
     env:
       RUST_BACKTRACE: full
     name: Run snippets and cpython tests
@@ -231,11 +224,9 @@ jobs:
     steps:
       - run: git config --global core.autocrlf false; git config --global core.eol lf
       - uses: actions/checkout@v2
-      - name: Cache generated parser
-        uses: actions/cache@v3
-        with:
-          path: compiler/parser/python.rs
-          key: lalrpop-${{ hashFiles('compiler/parser/python.lalrpop') }}
+      - uses: actions/cache@v3
+        with: { path: "~/.cargo/bin/lalrpop\n~/.cargo/.crates.toml", key: "lalrpop-${{ runner.os }}" }
+      - run: cargo install lalrpop@0.19.8
 
       - uses: dtolnay/rust-toolchain@stable
       - uses: actions/setup-python@v2
@@ -284,44 +275,14 @@ jobs:
         run: |
           mkdir site-packages
           target/release/rustpython --install-pip ensurepip --user
-
-  lalrpop:
-    if: ${{ !contains(github.event.pull_request.labels.*.name, 'skip:ci') }}
-    name: Generate parser with lalrpop
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v2
-      - name: Cache generated parser
-        uses: actions/cache@v3
-        with:
-          path: compiler/parser/python.rs
-          key: lalrpop-${{ hashFiles('compiler/parser/python.lalrpop') }}
-      - name: Check if cached generated parser exists
-        id: generated_parser
-        uses: andstor/file-existence-action@v1
-        with:
-          files: "compiler/parser/python.rs"
-      - name: Install lalrpop
-        if: steps.generated_parser.outputs.files_exists == 'false'
-        uses: actions-rs/install@v0.1
-        with:
-          crate: lalrpop
-          version: "0.19.8"
-      - name: Run lalrpop
-        if: steps.generated_parser.outputs.files_exists == 'false'
-        run: lalrpop compiler/parser/python.lalrpop
-
   lint:
     name: Check Rust code with rustfmt and clippy
-    needs: lalrpop
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - name: Cache generated parser
-        uses: actions/cache@v3
-        with:
-          path: compiler/parser/python.rs
-          key: lalrpop-${{ hashFiles('compiler/parser/python.lalrpop') }}
+      - uses: actions/cache@v3
+        with: { path: "~/.cargo/bin/lalrpop\n~/.cargo/.crates.toml", key: "lalrpop-${{ runner.os }}" }
+      - run: cargo install lalrpop@0.19.8
       - uses: dtolnay/rust-toolchain@stable
         with:
             components: rustfmt, clippy
@@ -351,15 +312,12 @@ jobs:
   miri:
     if: ${{ !contains(github.event.pull_request.labels.*.name, 'skip:ci') }}
     name: Run tests under miri
-    needs: lalrpop
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - name: Cache generated parser
-        uses: actions/cache@v3
-        with:
-          path: compiler/parser/python.rs
-          key: lalrpop-${{ hashFiles('compiler/parser/python.lalrpop') }}
+      - uses: actions/cache@v3
+        with: { path: "~/.cargo/bin/lalrpop\n~/.cargo/.crates.toml", key: "lalrpop-${{ runner.os }}" }
+      - run: cargo install lalrpop@0.19.8
       - uses: dtolnay/rust-toolchain@master
         with:
             toolchain: nightly
@@ -373,15 +331,12 @@ jobs:
   wasm:
     if: ${{ !contains(github.event.pull_request.labels.*.name, 'skip:ci') }}
     name: Check the WASM package and demo
-    needs: lalrpop
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - name: Cache generated parser
-        uses: actions/cache@v3
-        with:
-          path: compiler/parser/python.rs
-          key: lalrpop-${{ hashFiles('compiler/parser/python.lalrpop') }}
+      - uses: actions/cache@v3
+        with: { path: "~/.cargo/bin/lalrpop\n~/.cargo/.crates.toml", key: "lalrpop-${{ runner.os }}" }
+      - run: cargo install lalrpop@0.19.8
       - uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v1
       - name: install wasm-pack
@@ -422,15 +377,12 @@ jobs:
   wasm-wasi:
     if: ${{ !contains(github.event.pull_request.labels.*.name, 'skip:ci') }}
     name: Run snippets and cpython tests on wasm-wasi
-    needs: lalrpop
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - name: Cache generated parser
-        uses: actions/cache@v3
-        with:
-          path: compiler/parser/python.rs
-          key: lalrpop-${{ hashFiles('compiler/parser/python.lalrpop') }}
+      - uses: actions/cache@v3
+        with: { path: "~/.cargo/bin/lalrpop\n~/.cargo/.crates.toml", key: "lalrpop-${{ runner.os }}" }
+      - run: cargo install lalrpop@0.19.8
       - uses: dtolnay/rust-toolchain@stable
         with:
           target: wasm32-wasi

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -111,6 +111,8 @@ jobs:
         os: [macos-latest, ubuntu-latest, windows-latest]
       fail-fast: false
     steps:
+      # for windows, always checkout files with their original lf line endings
+      - run: git config --global core.autocrlf false; git config --global core.eol lf
       - uses: actions/checkout@v2
       - name: Cache generated parser
         uses: actions/cache@v2
@@ -227,6 +229,7 @@ jobs:
         os: [macos-latest, ubuntu-latest, windows-latest]
       fail-fast: false
     steps:
+      - run: git config --global core.autocrlf false; git config --global core.eol lf
       - uses: actions/checkout@v2
       - name: Cache generated parser
         uses: actions/cache@v2

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -285,10 +285,7 @@ jobs:
   lalrpop:
     if: ${{ !contains(github.event.pull_request.labels.*.name, 'skip:ci') }}
     name: Generate parser with lalrpop
-    strategy:
-      matrix:
-        os: [ubuntu-latest, windows-latest]
-    runs-on:  ${{ matrix.os }}
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
       - name: Cache generated parser
@@ -301,13 +298,9 @@ jobs:
         uses: andstor/file-existence-action@v1
         with:
           files: "compiler/parser/python.rs"
-      - if: runner.os == 'Windows'
-        name: Force python.lalrpop to be lf  # actions@checkout ignore .gitattributes
-        run: |
-          set file compiler/parser/python.lalrpop; ((Get-Content $file) -join "`n") + "`n" | Set-Content -NoNewline $file
       - name: Install lalrpop
         if: steps.generated_parser.outputs.files_exists == 'false'
-        uses: baptiste0928/cargo-install@v1
+        uses: actions-rs/install@v0.1
         with:
           crate: lalrpop
           version: "0.19.8"

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -115,7 +115,7 @@ jobs:
       - run: git config --global core.autocrlf false; git config --global core.eol lf
       - uses: actions/checkout@v2
       - name: Cache generated parser
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: compiler/parser/python.rs
           key: lalrpop-${{ hashFiles('compiler/parser/python.lalrpop') }}
@@ -160,7 +160,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - name: Cache generated parser
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: compiler/parser/python.rs
           key: lalrpop-${{ hashFiles('compiler/parser/python.lalrpop') }}
@@ -232,7 +232,7 @@ jobs:
       - run: git config --global core.autocrlf false; git config --global core.eol lf
       - uses: actions/checkout@v2
       - name: Cache generated parser
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: compiler/parser/python.rs
           key: lalrpop-${{ hashFiles('compiler/parser/python.lalrpop') }}
@@ -292,7 +292,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - name: Cache generated parser
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: compiler/parser/python.rs
           key: lalrpop-${{ hashFiles('compiler/parser/python.lalrpop') }}
@@ -318,7 +318,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - name: Cache generated parser
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: compiler/parser/python.rs
           key: lalrpop-${{ hashFiles('compiler/parser/python.lalrpop') }}
@@ -356,7 +356,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - name: Cache generated parser
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: compiler/parser/python.rs
           key: lalrpop-${{ hashFiles('compiler/parser/python.lalrpop') }}
@@ -378,7 +378,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - name: Cache generated parser
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: compiler/parser/python.rs
           key: lalrpop-${{ hashFiles('compiler/parser/python.lalrpop') }}
@@ -427,7 +427,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - name: Cache generated parser
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: compiler/parser/python.rs
           key: lalrpop-${{ hashFiles('compiler/parser/python.lalrpop') }}

--- a/.github/workflows/cron-ci.yaml
+++ b/.github/workflows/cron-ci.yaml
@@ -16,7 +16,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - name: Cache generated parser
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: compiler/parser/python.rs
           key: lalrpop-${{ hashFiles('compiler/parser/python.lalrpop') }}
@@ -67,7 +67,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - name: Cache generated parser
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: compiler/parser/python.rs
           key: lalrpop-${{ hashFiles('compiler/parser/python.lalrpop') }}
@@ -102,7 +102,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - name: Cache generated parser
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: compiler/parser/python.rs
           key: lalrpop-${{ hashFiles('compiler/parser/python.lalrpop') }}
@@ -140,7 +140,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - name: Cache generated parser
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: compiler/parser/python.rs
           key: lalrpop-${{ hashFiles('compiler/parser/python.lalrpop') }}
@@ -190,7 +190,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - name: Cache generated parser
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: compiler/parser/python.rs
           key: lalrpop-${{ hashFiles('compiler/parser/python.lalrpop') }}

--- a/.github/workflows/cron-ci.yaml
+++ b/.github/workflows/cron-ci.yaml
@@ -11,15 +11,12 @@ env:
 jobs:
   codecov:
     name: Collect code coverage data
-    needs: lalrpop
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - name: Cache generated parser
-        uses: actions/cache@v3
-        with:
-          path: compiler/parser/python.rs
-          key: lalrpop-${{ hashFiles('compiler/parser/python.lalrpop') }}
+      - uses: actions/cache@v3
+        with: { path: "~/.cargo/bin/lalrpop\n~/.cargo/.crates.toml", key: "lalrpop-${{ runner.os }}" }
+      - run: cargo install lalrpop@0.19.8
       - uses: dtolnay/rust-toolchain@stable
         with:
           components: llvm-tools-preview
@@ -62,15 +59,12 @@ jobs:
 
   testdata:
     name: Collect regression test data
-    needs: lalrpop
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - name: Cache generated parser
-        uses: actions/cache@v3
-        with:
-          path: compiler/parser/python.rs
-          key: lalrpop-${{ hashFiles('compiler/parser/python.lalrpop') }}
+      - uses: actions/cache@v3
+        with: { path: "~/.cargo/bin/lalrpop\n~/.cargo/.crates.toml", key: "lalrpop-${{ runner.os }}" }
+      - run: cargo install lalrpop@0.19.8
       - uses: dtolnay/rust-toolchain@stable
       - name: build rustpython
         run: cargo build --release --verbose
@@ -97,15 +91,12 @@ jobs:
 
   whatsleft:
     name: Collect what is left data
-    needs: lalrpop
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - name: Cache generated parser
-        uses: actions/cache@v3
-        with:
-          path: compiler/parser/python.rs
-          key: lalrpop-${{ hashFiles('compiler/parser/python.lalrpop') }}
+      - uses: actions/cache@v3
+        with: { path: "~/.cargo/bin/lalrpop\n~/.cargo/.crates.toml", key: "lalrpop-${{ runner.os }}" }
+      - run: cargo install lalrpop@0.19.8
       - uses: dtolnay/rust-toolchain@stable
       - name: build rustpython
         run: cargo build --release --verbose
@@ -135,15 +126,12 @@ jobs:
 
   benchmark:
     name: Collect benchmark data
-    needs: lalrpop
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - name: Cache generated parser
-        uses: actions/cache@v3
-        with:
-          path: compiler/parser/python.rs
-          key: lalrpop-${{ hashFiles('compiler/parser/python.lalrpop') }}
+      - uses: actions/cache@v3
+        with: { path: "~/.cargo/bin/lalrpop\n~/.cargo/.crates.toml", key: "lalrpop-${{ runner.os }}" }
+      - run: cargo install lalrpop@0.19.8
       - uses: dtolnay/rust-toolchain@stable
       - uses: actions/setup-python@v2
         with:
@@ -183,28 +171,3 @@ jobs:
           if git -c user.name="Github Actions" -c user.email="actions@github.com" commit -m "Update benchmark results"; then
             git push
           fi
-
-  lalrpop:
-    name: Generate parser with lalrpop
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v2
-      - name: Cache generated parser
-        uses: actions/cache@v3
-        with:
-          path: compiler/parser/python.rs
-          key: lalrpop-${{ hashFiles('compiler/parser/python.lalrpop') }}
-      - name: Check if cached generated parser exists
-        id: generated_parser
-        uses: andstor/file-existence-action@v1
-        with:
-          files: "compiler/parser/python.rs"
-      - name: Install lalrpop
-        if: steps.generated_parser.outputs.files_exists == 'false'
-        uses: actions-rs/install@v0.1
-        with:
-          crate: lalrpop
-          version: "0.19.8"
-      - name: Run lalrpop
-        if: steps.generated_parser.outputs.files_exists == 'false'
-        run: lalrpop compiler/parser/python.lalrpop

--- a/.github/workflows/cron-ci.yaml
+++ b/.github/workflows/cron-ci.yaml
@@ -186,10 +186,7 @@ jobs:
 
   lalrpop:
     name: Generate parser with lalrpop
-    strategy:
-      matrix:
-        os: [ubuntu-latest, windows-latest]
-    runs-on:  ${{ matrix.os }}
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
       - name: Cache generated parser
@@ -202,13 +199,9 @@ jobs:
         uses: andstor/file-existence-action@v1
         with:
           files: "compiler/parser/python.rs"
-      - if: runner.os == 'Windows'
-        name: Force python.lalrpop to be lf  # actions@checkout ignore .gitattributes
-        run: |
-          set file compiler/parser/python.lalrpop; ((Get-Content $file) -join "`n") + "`n" | Set-Content -NoNewline $file
       - name: Install lalrpop
         if: steps.generated_parser.outputs.files_exists == 'false'
-        uses: baptiste0928/cargo-install@v1
+        uses: actions-rs/install@v0.1
         with:
           crate: lalrpop
           version: "0.19.8"

--- a/Lib/test/test_difflib.py
+++ b/Lib/test/test_difflib.py
@@ -244,10 +244,6 @@ class TestSFpatches(unittest.TestCase):
         with open(findfile('test_difflib_expect.html')) as fp:
             self.assertEqual(actual, fp.read())
 
-    # TODO: RUSTPYTHON
-    if sys.platform == "win32":
-        test_html_diff = unittest.expectedFailure(test_html_diff)
-
     def test_recursion_limit(self):
         # Check if the problem described in patch #1413711 exists.
         limit = sys.getrecursionlimit()

--- a/Lib/test/test_imp.py
+++ b/Lib/test/test_imp.py
@@ -100,10 +100,6 @@ class ImportTests(unittest.TestCase):
             self.assertEqual(fp.readline(),
                              '"""Tokenization help for Python programs.\n')
 
-    # TODO: RUSTPYTHON
-    if sys.platform == 'win32':
-        test_issue1267 = unittest.expectedFailure(test_issue1267)
-
     def test_issue3594(self):
         temp_mod_name = 'test_imp_helper'
         sys.path.insert(0, '.')

--- a/compiler/parser/python.lalrpop
+++ b/compiler/parser/python.lalrpop
@@ -51,7 +51,7 @@ SimpleStatement: ast::Suite = {
         let mut statements = vec![s1];
         statements.extend(s2.into_iter().map(|e| e.1));
         statements
-    }
+    },
 };
 
 SmallStatement: ast::Stmt = {
@@ -138,7 +138,7 @@ ExpressionStatement: ast::Stmt = {
 };
 
 AssignSuffix: ast::Expr = {
-    "=" <e:TestListOrYieldExpr> => e
+    "=" <e:TestListOrYieldExpr> => e,
 };
 
 TestListOrYieldExpr: ast::Expr = {


### PR DESCRIPTION
Unless I'm misunderstanding something in the gh actions config, running lalrpop on windows and linux doesn't actually do anything - the cache key doesn't have the os in it, so it'll just overwrite each other and it's doing more work than it needs to.
