### PR TITLE
Add expression context parsing

### DIFF
--- a/compiler/parser/python.lalrpop
+++ b/compiler/parser/python.lalrpop
@@ -8,6 +8,7 @@ use crate::{
     error::{LexicalError, LexicalErrorType},
     function::{ArgumentList, parse_args, parse_params},
     lexer,
+    context::set_context,
     string::parse_strings,
     token::StringKind
 };
@@ -82,7 +83,7 @@ DelStatement: ast::Stmt = {
             location,
             end_location: Some(end_location),
             custom: (),
-            node: ast::StmtKind::Delete { targets },
+            node: ast::StmtKind::Delete { targets: targets.into_iter().map(|expr| set_context(expr, ast::ExprContext::Del)).collect() },
         }
     },
 };
@@ -98,11 +99,11 @@ ExpressionStatement: ast::Stmt = {
                 node: ast::StmtKind::Expr { value: Box::new(expression) }
             }
         } else {
-            let mut targets = vec![expression];
+            let mut targets = vec![set_context(expression, ast::ExprContext::Store)];
             let mut values = suffix;
 
             while values.len() > 1 {
-                targets.push(values.remove(0));
+                targets.push(set_context(values.remove(0), ast::ExprContext::Store));
             }
 
             let value = Box::new(values.into_iter().next().unwrap());
@@ -121,7 +122,7 @@ ExpressionStatement: ast::Stmt = {
             location,
             end_location: Some(end_location),
             node: ast::StmtKind::AugAssign {
-                target: Box::new(target),
+                target: Box::new(set_context(target, ast::ExprContext::Store)),
                 op,
                 value: Box::new(rhs)
             },
@@ -134,7 +135,7 @@ ExpressionStatement: ast::Stmt = {
             location,
             end_location: Some(end_location),
             node: ast::StmtKind::AnnAssign {
-                target: Box::new(target),
+                target: Box::new(set_context(target, ast::ExprContext::Store)),
                 annotation: Box::new(annotation),
                 value: rhs.map(Box::new),
                 simple: if simple { 1 } else { 0 },
@@ -399,7 +400,7 @@ WhileStatement: ast::Stmt = {
 ForStatement: ast::Stmt = {
     <location:@L> <is_async:"async"?> "for" <target:ExpressionList> "in" <iter:TestList> ":" <body:Suite> <s2:("else" ":" Suite)?> <end_location:@R> => {
         let orelse = s2.map(|s| s.2).unwrap_or_default();
-        let target = Box::new(target);
+        let target = Box::new(set_context(target, ast::ExprContext::Store));
         let iter = Box::new(iter);
         let type_comment = None;
         let node = if is_async.is_some() {
@@ -484,7 +485,7 @@ WithStatement: ast::Stmt = {
 
 WithItem: ast::Withitem = {
     <context_expr:Test> <n:("as" Expression)?> => {
-        let optional_vars = n.map(|val| Box::new(val.1));
+        let optional_vars = n.map(|val| Box::new(set_context(val.1, ast::ExprContext::Store)));
         let context_expr = Box::new(context_expr);
         ast::Withitem { context_expr, optional_vars }
     },
@@ -1233,7 +1234,7 @@ SingleForComprehension: ast::Comprehension = {
     <location:@L> <is_async:"async"?> "for" <target:ExpressionList> "in" <iter:OrTest> <ifs:ComprehensionIf*> <end_location:@R> => {
         let is_async = is_async.is_some();
         ast::Comprehension {
-            target: Box::new(target),
+            target: Box::new(set_context(target, ast::ExprContext::Store)),
             iter: Box::new(iter),
             ifs,
             is_async: if is_async { 1 } else { 0 },

--- a/compiler/parser/src/context.rs
+++ b/compiler/parser/src/context.rs
@@ -1,0 +1,177 @@
+use rustpython_ast::{Expr, ExprContext, ExprKind};
+
+pub fn set_context(expr: Expr, ctx: ExprContext) -> Expr {
+    match expr.node {
+        ExprKind::Name { id, .. } => Expr {
+            node: ExprKind::Name { id, ctx },
+            ..expr
+        },
+        ExprKind::Tuple { elts, .. } => Expr {
+            node: ExprKind::Tuple {
+                elts: elts
+                    .into_iter()
+                    .map(|elt| set_context(elt, ctx.clone()))
+                    .collect(),
+                ctx,
+            },
+            ..expr
+        },
+        ExprKind::List { elts, .. } => Expr {
+            node: ExprKind::List {
+                elts: elts
+                    .into_iter()
+                    .map(|elt| set_context(elt, ctx.clone()))
+                    .collect(),
+                ctx,
+            },
+            ..expr
+        },
+        ExprKind::Attribute { value, attr, .. } => Expr {
+            node: ExprKind::Attribute { value, attr, ctx },
+            ..expr
+        },
+        ExprKind::Subscript { value, slice, .. } => Expr {
+            node: ExprKind::Subscript { value, slice, ctx },
+            ..expr
+        },
+        ExprKind::Starred { value, .. } => Expr {
+            node: ExprKind::Starred {
+                value: Box::new(set_context(*value, ctx.clone())),
+                ctx,
+            },
+            ..expr
+        },
+        _ => expr,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::parser::parse_program;
+
+    #[test]
+    fn test_assign_name() {
+        let source = String::from("x = (1, 2, 3)");
+        let parse_ast = parse_program(&source, "<test>").unwrap();
+        insta::assert_debug_snapshot!(parse_ast);
+    }
+
+    #[test]
+    fn test_assign_tuple() {
+        let source = String::from("(x, y) = (1, 2, 3)");
+        let parse_ast = parse_program(&source, "<test>").unwrap();
+        insta::assert_debug_snapshot!(parse_ast);
+    }
+
+    #[test]
+    fn test_assign_list() {
+        let source = String::from("[x, y] = (1, 2, 3)");
+        let parse_ast = parse_program(&source, "<test>").unwrap();
+        insta::assert_debug_snapshot!(parse_ast);
+    }
+
+    #[test]
+    fn test_assign_attribute() {
+        let source = String::from("x.y = (1, 2, 3)");
+        let parse_ast = parse_program(&source, "<test>").unwrap();
+        insta::assert_debug_snapshot!(parse_ast);
+    }
+
+    #[test]
+    fn test_assign_subscript() {
+        let source = String::from("x[y] = (1, 2, 3)");
+        let parse_ast = parse_program(&source, "<test>").unwrap();
+        insta::assert_debug_snapshot!(parse_ast);
+    }
+
+    #[test]
+    fn test_assign_starred() {
+        let source = String::from("(x, *y) = (1, 2, 3)");
+        let parse_ast = parse_program(&source, "<test>").unwrap();
+        insta::assert_debug_snapshot!(parse_ast);
+    }
+
+    #[test]
+    fn test_assign_for() {
+        let source = String::from("for x in (1, 2, 3): pass");
+        let parse_ast = parse_program(&source, "<test>").unwrap();
+        insta::assert_debug_snapshot!(parse_ast);
+    }
+
+    #[test]
+    fn test_assign_list_comp() {
+        let source = String::from("x = [y for y in (1, 2, 3)]");
+        let parse_ast = parse_program(&source, "<test>").unwrap();
+        insta::assert_debug_snapshot!(parse_ast);
+    }
+
+    #[test]
+    fn test_assign_set_comp() {
+        let source = String::from("x = {y for y in (1, 2, 3)}");
+        let parse_ast = parse_program(&source, "<test>").unwrap();
+        insta::assert_debug_snapshot!(parse_ast);
+    }
+
+    #[test]
+    fn test_assign_with() {
+        let source = String::from("with 1 as x: pass");
+        let parse_ast = parse_program(&source, "<test>").unwrap();
+        insta::assert_debug_snapshot!(parse_ast);
+    }
+
+    #[test]
+    fn test_assign_named_expr() {
+        let source = String::from("if x:= 1: pass");
+        let parse_ast = parse_program(&source, "<test>").unwrap();
+        insta::assert_debug_snapshot!(parse_ast);
+    }
+
+    #[test]
+    fn test_ann_assign_name() {
+        let source = String::from("x: int = 1");
+        let parse_ast = parse_program(&source, "<test>").unwrap();
+        insta::assert_debug_snapshot!(parse_ast);
+    }
+
+    #[test]
+    fn test_aug_assign_name() {
+        let source = String::from("x += 1");
+        let parse_ast = parse_program(&source, "<test>").unwrap();
+        insta::assert_debug_snapshot!(parse_ast);
+    }
+
+    #[test]
+    fn test_aug_assign_attribute() {
+        let source = String::from("x.y += (1, 2, 3)");
+        let parse_ast = parse_program(&source, "<test>").unwrap();
+        insta::assert_debug_snapshot!(parse_ast);
+    }
+
+    #[test]
+    fn test_aug_assign_subscript() {
+        let source = String::from("x[y] += (1, 2, 3)");
+        let parse_ast = parse_program(&source, "<test>").unwrap();
+        insta::assert_debug_snapshot!(parse_ast);
+    }
+
+    #[test]
+    fn test_del_name() {
+        let source = String::from("del x");
+        let parse_ast = parse_program(&source, "<test>").unwrap();
+        insta::assert_debug_snapshot!(parse_ast);
+    }
+
+    #[test]
+    fn test_del_attribute() {
+        let source = String::from("del x.y");
+        let parse_ast = parse_program(&source, "<test>").unwrap();
+        insta::assert_debug_snapshot!(parse_ast);
+    }
+
+    #[test]
+    fn test_del_subscript() {
+        let source = String::from("del x[y]");
+        let parse_ast = parse_program(&source, "<test>").unwrap();
+        insta::assert_debug_snapshot!(parse_ast);
+    }
+}

--- a/compiler/parser/src/lib.rs
+++ b/compiler/parser/src/lib.rs
@@ -30,5 +30,6 @@ pub mod mode;
 pub mod parser;
 #[rustfmt::skip]
 mod python;
+mod context;
 mod string;
 pub mod token;

--- a/compiler/parser/src/snapshots/rustpython_parser__context__tests__ann_assign_name.snap
+++ b/compiler/parser/src/snapshots/rustpython_parser__context__tests__ann_assign_name.snap
@@ -4,25 +4,29 @@ expression: parse_ast
 ---
 [
     Located {
-        start: Location {
+        location: Location {
             row: 1,
             column: 1,
         },
-        end: Location {
-            row: 1,
-            column: 11,
-        },
+        end_location: Some(
+            Location {
+                row: 1,
+                column: 11,
+            },
+        ),
         custom: (),
         node: AnnAssign {
             target: Located {
-                start: Location {
+                location: Location {
                     row: 1,
                     column: 1,
                 },
-                end: Location {
-                    row: 1,
-                    column: 2,
-                },
+                end_location: Some(
+                    Location {
+                        row: 1,
+                        column: 2,
+                    },
+                ),
                 custom: (),
                 node: Name {
                     id: "x",
@@ -30,14 +34,16 @@ expression: parse_ast
                 },
             },
             annotation: Located {
-                start: Location {
+                location: Location {
                     row: 1,
                     column: 4,
                 },
-                end: Location {
-                    row: 1,
-                    column: 7,
-                },
+                end_location: Some(
+                    Location {
+                        row: 1,
+                        column: 7,
+                    },
+                ),
                 custom: (),
                 node: Name {
                     id: "int",
@@ -46,14 +52,16 @@ expression: parse_ast
             },
             value: Some(
                 Located {
-                    start: Location {
+                    location: Location {
                         row: 1,
                         column: 10,
                     },
-                    end: Location {
-                        row: 1,
-                        column: 11,
-                    },
+                    end_location: Some(
+                        Location {
+                            row: 1,
+                            column: 11,
+                        },
+                    ),
                     custom: (),
                     node: Constant {
                         value: Int(

--- a/compiler/parser/src/snapshots/rustpython_parser__context__tests__assign.snap
+++ b/compiler/parser/src/snapshots/rustpython_parser__context__tests__assign.snap
@@ -8,33 +8,35 @@ expression: parse_ast
             row: 1,
             column: 1,
         },
-        end_location: Some(
-            Location {
-                row: 1,
-                column: 6,
-            },
-        ),
         custom: (),
-        node: Delete {
+        node: Assign {
             targets: [
                 Located {
                     location: Location {
                         row: 1,
-                        column: 5,
+                        column: 1,
                     },
-                    end_location: Some(
-                        Location {
-                            row: 1,
-                            column: 6,
-                        },
-                    ),
                     custom: (),
                     node: Name {
                         id: "x",
-                        ctx: Del,
+                        ctx: Store,
                     },
                 },
             ],
+            value: Located {
+                location: Location {
+                    row: 1,
+                    column: 5,
+                },
+                custom: (),
+                node: Constant {
+                    value: Int(
+                        1,
+                    ),
+                    kind: None,
+                },
+            },
+            type_comment: None,
         },
     },
 ]

--- a/compiler/parser/src/snapshots/rustpython_parser__context__tests__assign_attribute.snap
+++ b/compiler/parser/src/snapshots/rustpython_parser__context__tests__assign_attribute.snap
@@ -4,37 +4,43 @@ expression: parse_ast
 ---
 [
     Located {
-        start: Location {
+        location: Location {
             row: 1,
             column: 1,
         },
-        end: Location {
-            row: 1,
-            column: 16,
-        },
+        end_location: Some(
+            Location {
+                row: 1,
+                column: 16,
+            },
+        ),
         custom: (),
         node: Assign {
             targets: [
                 Located {
-                    start: Location {
+                    location: Location {
                         row: 1,
-                        column: 2,
+                        column: 1,
                     },
-                    end: Location {
-                        row: 1,
-                        column: 4,
-                    },
+                    end_location: Some(
+                        Location {
+                            row: 1,
+                            column: 4,
+                        },
+                    ),
                     custom: (),
                     node: Attribute {
                         value: Located {
-                            start: Location {
+                            location: Location {
                                 row: 1,
                                 column: 1,
                             },
-                            end: Location {
-                                row: 1,
-                                column: 2,
-                            },
+                            end_location: Some(
+                                Location {
+                                    row: 1,
+                                    column: 2,
+                                },
+                            ),
                             custom: (),
                             node: Name {
                                 id: "x",
@@ -47,26 +53,30 @@ expression: parse_ast
                 },
             ],
             value: Located {
-                start: Location {
+                location: Location {
                     row: 1,
                     column: 8,
                 },
-                end: Location {
-                    row: 1,
-                    column: 15,
-                },
+                end_location: Some(
+                    Location {
+                        row: 1,
+                        column: 15,
+                    },
+                ),
                 custom: (),
                 node: Tuple {
                     elts: [
                         Located {
-                            start: Location {
+                            location: Location {
                                 row: 1,
                                 column: 8,
                             },
-                            end: Location {
-                                row: 1,
-                                column: 9,
-                            },
+                            end_location: Some(
+                                Location {
+                                    row: 1,
+                                    column: 9,
+                                },
+                            ),
                             custom: (),
                             node: Constant {
                                 value: Int(
@@ -76,14 +86,16 @@ expression: parse_ast
                             },
                         },
                         Located {
-                            start: Location {
+                            location: Location {
                                 row: 1,
                                 column: 11,
                             },
-                            end: Location {
-                                row: 1,
-                                column: 12,
-                            },
+                            end_location: Some(
+                                Location {
+                                    row: 1,
+                                    column: 12,
+                                },
+                            ),
                             custom: (),
                             node: Constant {
                                 value: Int(
@@ -93,14 +105,16 @@ expression: parse_ast
                             },
                         },
                         Located {
-                            start: Location {
+                            location: Location {
                                 row: 1,
                                 column: 14,
                             },
-                            end: Location {
-                                row: 1,
-                                column: 15,
-                            },
+                            end_location: Some(
+                                Location {
+                                    row: 1,
+                                    column: 15,
+                                },
+                            ),
                             custom: (),
                             node: Constant {
                                 value: Int(

--- a/compiler/parser/src/snapshots/rustpython_parser__context__tests__assign_for.snap
+++ b/compiler/parser/src/snapshots/rustpython_parser__context__tests__assign_for.snap
@@ -4,25 +4,29 @@ expression: parse_ast
 ---
 [
     Located {
-        start: Location {
+        location: Location {
             row: 1,
             column: 1,
         },
-        end: Location {
-            row: 1,
-            column: 25,
-        },
+        end_location: Some(
+            Location {
+                row: 1,
+                column: 25,
+            },
+        ),
         custom: (),
         node: For {
             target: Located {
-                start: Location {
+                location: Location {
                     row: 1,
                     column: 5,
                 },
-                end: Location {
-                    row: 1,
-                    column: 6,
-                },
+                end_location: Some(
+                    Location {
+                        row: 1,
+                        column: 6,
+                    },
+                ),
                 custom: (),
                 node: Name {
                     id: "x",
@@ -30,26 +34,30 @@ expression: parse_ast
                 },
             },
             iter: Located {
-                start: Location {
+                location: Location {
                     row: 1,
                     column: 11,
                 },
-                end: Location {
-                    row: 1,
-                    column: 18,
-                },
+                end_location: Some(
+                    Location {
+                        row: 1,
+                        column: 18,
+                    },
+                ),
                 custom: (),
                 node: Tuple {
                     elts: [
                         Located {
-                            start: Location {
+                            location: Location {
                                 row: 1,
                                 column: 11,
                             },
-                            end: Location {
-                                row: 1,
-                                column: 12,
-                            },
+                            end_location: Some(
+                                Location {
+                                    row: 1,
+                                    column: 12,
+                                },
+                            ),
                             custom: (),
                             node: Constant {
                                 value: Int(
@@ -59,14 +67,16 @@ expression: parse_ast
                             },
                         },
                         Located {
-                            start: Location {
+                            location: Location {
                                 row: 1,
                                 column: 14,
                             },
-                            end: Location {
-                                row: 1,
-                                column: 15,
-                            },
+                            end_location: Some(
+                                Location {
+                                    row: 1,
+                                    column: 15,
+                                },
+                            ),
                             custom: (),
                             node: Constant {
                                 value: Int(
@@ -76,14 +86,16 @@ expression: parse_ast
                             },
                         },
                         Located {
-                            start: Location {
+                            location: Location {
                                 row: 1,
                                 column: 17,
                             },
-                            end: Location {
-                                row: 1,
-                                column: 18,
-                            },
+                            end_location: Some(
+                                Location {
+                                    row: 1,
+                                    column: 18,
+                                },
+                            ),
                             custom: (),
                             node: Constant {
                                 value: Int(
@@ -98,14 +110,16 @@ expression: parse_ast
             },
             body: [
                 Located {
-                    start: Location {
+                    location: Location {
                         row: 1,
                         column: 21,
                     },
-                    end: Location {
-                        row: 1,
-                        column: 25,
-                    },
+                    end_location: Some(
+                        Location {
+                            row: 1,
+                            column: 25,
+                        },
+                    ),
                     custom: (),
                     node: Pass,
                 },

--- a/compiler/parser/src/snapshots/rustpython_parser__context__tests__assign_list.snap
+++ b/compiler/parser/src/snapshots/rustpython_parser__context__tests__assign_list.snap
@@ -4,38 +4,44 @@ expression: parse_ast
 ---
 [
     Located {
-        start: Location {
+        location: Location {
             row: 1,
             column: 1,
         },
-        end: Location {
-            row: 1,
-            column: 19,
-        },
+        end_location: Some(
+            Location {
+                row: 1,
+                column: 19,
+            },
+        ),
         custom: (),
         node: Assign {
             targets: [
                 Located {
-                    start: Location {
+                    location: Location {
                         row: 1,
                         column: 1,
                     },
-                    end: Location {
-                        row: 1,
-                        column: 7,
-                    },
+                    end_location: Some(
+                        Location {
+                            row: 1,
+                            column: 7,
+                        },
+                    ),
                     custom: (),
                     node: List {
                         elts: [
                             Located {
-                                start: Location {
+                                location: Location {
                                     row: 1,
                                     column: 2,
                                 },
-                                end: Location {
-                                    row: 1,
-                                    column: 3,
-                                },
+                                end_location: Some(
+                                    Location {
+                                        row: 1,
+                                        column: 3,
+                                    },
+                                ),
                                 custom: (),
                                 node: Name {
                                     id: "x",
@@ -43,14 +49,16 @@ expression: parse_ast
                                 },
                             },
                             Located {
-                                start: Location {
+                                location: Location {
                                     row: 1,
                                     column: 5,
                                 },
-                                end: Location {
-                                    row: 1,
-                                    column: 6,
-                                },
+                                end_location: Some(
+                                    Location {
+                                        row: 1,
+                                        column: 6,
+                                    },
+                                ),
                                 custom: (),
                                 node: Name {
                                     id: "y",
@@ -63,26 +71,30 @@ expression: parse_ast
                 },
             ],
             value: Located {
-                start: Location {
+                location: Location {
                     row: 1,
                     column: 11,
                 },
-                end: Location {
-                    row: 1,
-                    column: 18,
-                },
+                end_location: Some(
+                    Location {
+                        row: 1,
+                        column: 18,
+                    },
+                ),
                 custom: (),
                 node: Tuple {
                     elts: [
                         Located {
-                            start: Location {
+                            location: Location {
                                 row: 1,
                                 column: 11,
                             },
-                            end: Location {
-                                row: 1,
-                                column: 12,
-                            },
+                            end_location: Some(
+                                Location {
+                                    row: 1,
+                                    column: 12,
+                                },
+                            ),
                             custom: (),
                             node: Constant {
                                 value: Int(
@@ -92,14 +104,16 @@ expression: parse_ast
                             },
                         },
                         Located {
-                            start: Location {
+                            location: Location {
                                 row: 1,
                                 column: 14,
                             },
-                            end: Location {
-                                row: 1,
-                                column: 15,
-                            },
+                            end_location: Some(
+                                Location {
+                                    row: 1,
+                                    column: 15,
+                                },
+                            ),
                             custom: (),
                             node: Constant {
                                 value: Int(
@@ -109,14 +123,16 @@ expression: parse_ast
                             },
                         },
                         Located {
-                            start: Location {
+                            location: Location {
                                 row: 1,
                                 column: 17,
                             },
-                            end: Location {
-                                row: 1,
-                                column: 18,
-                            },
+                            end_location: Some(
+                                Location {
+                                    row: 1,
+                                    column: 18,
+                                },
+                            ),
                             custom: (),
                             node: Constant {
                                 value: Int(

--- a/compiler/parser/src/snapshots/rustpython_parser__context__tests__assign_list_comp.snap
+++ b/compiler/parser/src/snapshots/rustpython_parser__context__tests__assign_list_comp.snap
@@ -4,26 +4,30 @@ expression: parse_ast
 ---
 [
     Located {
-        start: Location {
+        location: Location {
             row: 1,
             column: 1,
         },
-        end: Location {
-            row: 1,
-            column: 27,
-        },
+        end_location: Some(
+            Location {
+                row: 1,
+                column: 27,
+            },
+        ),
         custom: (),
         node: Assign {
             targets: [
                 Located {
-                    start: Location {
+                    location: Location {
                         row: 1,
                         column: 1,
                     },
-                    end: Location {
-                        row: 1,
-                        column: 2,
-                    },
+                    end_location: Some(
+                        Location {
+                            row: 1,
+                            column: 2,
+                        },
+                    ),
                     custom: (),
                     node: Name {
                         id: "x",
@@ -32,25 +36,29 @@ expression: parse_ast
                 },
             ],
             value: Located {
-                start: Location {
+                location: Location {
                     row: 1,
                     column: 5,
                 },
-                end: Location {
-                    row: 1,
-                    column: 27,
-                },
+                end_location: Some(
+                    Location {
+                        row: 1,
+                        column: 27,
+                    },
+                ),
                 custom: (),
                 node: ListComp {
                     elt: Located {
-                        start: Location {
+                        location: Location {
                             row: 1,
                             column: 6,
                         },
-                        end: Location {
-                            row: 1,
-                            column: 7,
-                        },
+                        end_location: Some(
+                            Location {
+                                row: 1,
+                                column: 7,
+                            },
+                        ),
                         custom: (),
                         node: Name {
                             id: "y",
@@ -60,14 +68,16 @@ expression: parse_ast
                     generators: [
                         Comprehension {
                             target: Located {
-                                start: Location {
+                                location: Location {
                                     row: 1,
                                     column: 12,
                                 },
-                                end: Location {
-                                    row: 1,
-                                    column: 13,
-                                },
+                                end_location: Some(
+                                    Location {
+                                        row: 1,
+                                        column: 13,
+                                    },
+                                ),
                                 custom: (),
                                 node: Name {
                                     id: "y",
@@ -75,26 +85,30 @@ expression: parse_ast
                                 },
                             },
                             iter: Located {
-                                start: Location {
+                                location: Location {
                                     row: 1,
                                     column: 18,
                                 },
-                                end: Location {
-                                    row: 1,
-                                    column: 25,
-                                },
+                                end_location: Some(
+                                    Location {
+                                        row: 1,
+                                        column: 25,
+                                    },
+                                ),
                                 custom: (),
                                 node: Tuple {
                                     elts: [
                                         Located {
-                                            start: Location {
+                                            location: Location {
                                                 row: 1,
                                                 column: 18,
                                             },
-                                            end: Location {
-                                                row: 1,
-                                                column: 19,
-                                            },
+                                            end_location: Some(
+                                                Location {
+                                                    row: 1,
+                                                    column: 19,
+                                                },
+                                            ),
                                             custom: (),
                                             node: Constant {
                                                 value: Int(
@@ -104,14 +118,16 @@ expression: parse_ast
                                             },
                                         },
                                         Located {
-                                            start: Location {
+                                            location: Location {
                                                 row: 1,
                                                 column: 21,
                                             },
-                                            end: Location {
-                                                row: 1,
-                                                column: 22,
-                                            },
+                                            end_location: Some(
+                                                Location {
+                                                    row: 1,
+                                                    column: 22,
+                                                },
+                                            ),
                                             custom: (),
                                             node: Constant {
                                                 value: Int(
@@ -121,14 +137,16 @@ expression: parse_ast
                                             },
                                         },
                                         Located {
-                                            start: Location {
+                                            location: Location {
                                                 row: 1,
                                                 column: 24,
                                             },
-                                            end: Location {
-                                                row: 1,
-                                                column: 25,
-                                            },
+                                            end_location: Some(
+                                                Location {
+                                                    row: 1,
+                                                    column: 25,
+                                                },
+                                            ),
                                             custom: (),
                                             node: Constant {
                                                 value: Int(

--- a/compiler/parser/src/snapshots/rustpython_parser__context__tests__assign_name.snap
+++ b/compiler/parser/src/snapshots/rustpython_parser__context__tests__assign_name.snap
@@ -4,26 +4,30 @@ expression: parse_ast
 ---
 [
     Located {
-        start: Location {
+        location: Location {
             row: 1,
             column: 1,
         },
-        end: Location {
-            row: 1,
-            column: 14,
-        },
+        end_location: Some(
+            Location {
+                row: 1,
+                column: 14,
+            },
+        ),
         custom: (),
         node: Assign {
             targets: [
                 Located {
-                    start: Location {
+                    location: Location {
                         row: 1,
                         column: 1,
                     },
-                    end: Location {
-                        row: 1,
-                        column: 2,
-                    },
+                    end_location: Some(
+                        Location {
+                            row: 1,
+                            column: 2,
+                        },
+                    ),
                     custom: (),
                     node: Name {
                         id: "x",
@@ -32,26 +36,30 @@ expression: parse_ast
                 },
             ],
             value: Located {
-                start: Location {
+                location: Location {
                     row: 1,
                     column: 6,
                 },
-                end: Location {
-                    row: 1,
-                    column: 13,
-                },
+                end_location: Some(
+                    Location {
+                        row: 1,
+                        column: 13,
+                    },
+                ),
                 custom: (),
                 node: Tuple {
                     elts: [
                         Located {
-                            start: Location {
+                            location: Location {
                                 row: 1,
                                 column: 6,
                             },
-                            end: Location {
-                                row: 1,
-                                column: 7,
-                            },
+                            end_location: Some(
+                                Location {
+                                    row: 1,
+                                    column: 7,
+                                },
+                            ),
                             custom: (),
                             node: Constant {
                                 value: Int(
@@ -61,14 +69,16 @@ expression: parse_ast
                             },
                         },
                         Located {
-                            start: Location {
+                            location: Location {
                                 row: 1,
                                 column: 9,
                             },
-                            end: Location {
-                                row: 1,
-                                column: 10,
-                            },
+                            end_location: Some(
+                                Location {
+                                    row: 1,
+                                    column: 10,
+                                },
+                            ),
                             custom: (),
                             node: Constant {
                                 value: Int(
@@ -78,14 +88,16 @@ expression: parse_ast
                             },
                         },
                         Located {
-                            start: Location {
+                            location: Location {
                                 row: 1,
                                 column: 12,
                             },
-                            end: Location {
-                                row: 1,
-                                column: 13,
-                            },
+                            end_location: Some(
+                                Location {
+                                    row: 1,
+                                    column: 13,
+                                },
+                            ),
                             custom: (),
                             node: Constant {
                                 value: Int(

--- a/compiler/parser/src/snapshots/rustpython_parser__context__tests__assign_named_expr.snap
+++ b/compiler/parser/src/snapshots/rustpython_parser__context__tests__assign_named_expr.snap
@@ -4,36 +4,42 @@ expression: parse_ast
 ---
 [
     Located {
-        start: Location {
+        location: Location {
             row: 1,
             column: 1,
         },
-        end: Location {
-            row: 1,
-            column: 15,
-        },
+        end_location: Some(
+            Location {
+                row: 1,
+                column: 15,
+            },
+        ),
         custom: (),
         node: If {
             test: Located {
-                start: Location {
+                location: Location {
                     row: 1,
                     column: 4,
                 },
-                end: Location {
-                    row: 1,
-                    column: 9,
-                },
+                end_location: Some(
+                    Location {
+                        row: 1,
+                        column: 9,
+                    },
+                ),
                 custom: (),
                 node: NamedExpr {
                     target: Located {
-                        start: Location {
+                        location: Location {
                             row: 1,
                             column: 4,
                         },
-                        end: Location {
-                            row: 1,
-                            column: 9,
-                        },
+                        end_location: Some(
+                            Location {
+                                row: 1,
+                                column: 9,
+                            },
+                        ),
                         custom: (),
                         node: Name {
                             id: "x",
@@ -41,14 +47,16 @@ expression: parse_ast
                         },
                     },
                     value: Located {
-                        start: Location {
+                        location: Location {
                             row: 1,
                             column: 8,
                         },
-                        end: Location {
-                            row: 1,
-                            column: 9,
-                        },
+                        end_location: Some(
+                            Location {
+                                row: 1,
+                                column: 9,
+                            },
+                        ),
                         custom: (),
                         node: Constant {
                             value: Int(
@@ -61,14 +69,16 @@ expression: parse_ast
             },
             body: [
                 Located {
-                    start: Location {
+                    location: Location {
                         row: 1,
                         column: 11,
                     },
-                    end: Location {
-                        row: 1,
-                        column: 15,
-                    },
+                    end_location: Some(
+                        Location {
+                            row: 1,
+                            column: 15,
+                        },
+                    ),
                     custom: (),
                     node: Pass,
                 },

--- a/compiler/parser/src/snapshots/rustpython_parser__context__tests__assign_set_comp.snap
+++ b/compiler/parser/src/snapshots/rustpython_parser__context__tests__assign_set_comp.snap
@@ -4,26 +4,30 @@ expression: parse_ast
 ---
 [
     Located {
-        start: Location {
+        location: Location {
             row: 1,
             column: 1,
         },
-        end: Location {
-            row: 1,
-            column: 27,
-        },
+        end_location: Some(
+            Location {
+                row: 1,
+                column: 27,
+            },
+        ),
         custom: (),
         node: Assign {
             targets: [
                 Located {
-                    start: Location {
+                    location: Location {
                         row: 1,
                         column: 1,
                     },
-                    end: Location {
-                        row: 1,
-                        column: 2,
-                    },
+                    end_location: Some(
+                        Location {
+                            row: 1,
+                            column: 2,
+                        },
+                    ),
                     custom: (),
                     node: Name {
                         id: "x",
@@ -32,25 +36,29 @@ expression: parse_ast
                 },
             ],
             value: Located {
-                start: Location {
+                location: Location {
                     row: 1,
                     column: 5,
                 },
-                end: Location {
-                    row: 1,
-                    column: 27,
-                },
+                end_location: Some(
+                    Location {
+                        row: 1,
+                        column: 27,
+                    },
+                ),
                 custom: (),
                 node: SetComp {
                     elt: Located {
-                        start: Location {
+                        location: Location {
                             row: 1,
                             column: 6,
                         },
-                        end: Location {
-                            row: 1,
-                            column: 7,
-                        },
+                        end_location: Some(
+                            Location {
+                                row: 1,
+                                column: 7,
+                            },
+                        ),
                         custom: (),
                         node: Name {
                             id: "y",
@@ -60,14 +68,16 @@ expression: parse_ast
                     generators: [
                         Comprehension {
                             target: Located {
-                                start: Location {
+                                location: Location {
                                     row: 1,
                                     column: 12,
                                 },
-                                end: Location {
-                                    row: 1,
-                                    column: 13,
-                                },
+                                end_location: Some(
+                                    Location {
+                                        row: 1,
+                                        column: 13,
+                                    },
+                                ),
                                 custom: (),
                                 node: Name {
                                     id: "y",
@@ -75,26 +85,30 @@ expression: parse_ast
                                 },
                             },
                             iter: Located {
-                                start: Location {
+                                location: Location {
                                     row: 1,
                                     column: 18,
                                 },
-                                end: Location {
-                                    row: 1,
-                                    column: 25,
-                                },
+                                end_location: Some(
+                                    Location {
+                                        row: 1,
+                                        column: 25,
+                                    },
+                                ),
                                 custom: (),
                                 node: Tuple {
                                     elts: [
                                         Located {
-                                            start: Location {
+                                            location: Location {
                                                 row: 1,
                                                 column: 18,
                                             },
-                                            end: Location {
-                                                row: 1,
-                                                column: 19,
-                                            },
+                                            end_location: Some(
+                                                Location {
+                                                    row: 1,
+                                                    column: 19,
+                                                },
+                                            ),
                                             custom: (),
                                             node: Constant {
                                                 value: Int(
@@ -104,14 +118,16 @@ expression: parse_ast
                                             },
                                         },
                                         Located {
-                                            start: Location {
+                                            location: Location {
                                                 row: 1,
                                                 column: 21,
                                             },
-                                            end: Location {
-                                                row: 1,
-                                                column: 22,
-                                            },
+                                            end_location: Some(
+                                                Location {
+                                                    row: 1,
+                                                    column: 22,
+                                                },
+                                            ),
                                             custom: (),
                                             node: Constant {
                                                 value: Int(
@@ -121,14 +137,16 @@ expression: parse_ast
                                             },
                                         },
                                         Located {
-                                            start: Location {
+                                            location: Location {
                                                 row: 1,
                                                 column: 24,
                                             },
-                                            end: Location {
-                                                row: 1,
-                                                column: 25,
-                                            },
+                                            end_location: Some(
+                                                Location {
+                                                    row: 1,
+                                                    column: 25,
+                                                },
+                                            ),
                                             custom: (),
                                             node: Constant {
                                                 value: Int(

--- a/compiler/parser/src/snapshots/rustpython_parser__context__tests__assign_starred.snap
+++ b/compiler/parser/src/snapshots/rustpython_parser__context__tests__assign_starred.snap
@@ -4,38 +4,44 @@ expression: parse_ast
 ---
 [
     Located {
-        start: Location {
+        location: Location {
             row: 1,
             column: 1,
         },
-        end: Location {
-            row: 1,
-            column: 20,
-        },
+        end_location: Some(
+            Location {
+                row: 1,
+                column: 20,
+            },
+        ),
         custom: (),
         node: Assign {
             targets: [
                 Located {
-                    start: Location {
+                    location: Location {
                         row: 1,
                         column: 2,
                     },
-                    end: Location {
-                        row: 1,
-                        column: 7,
-                    },
+                    end_location: Some(
+                        Location {
+                            row: 1,
+                            column: 7,
+                        },
+                    ),
                     custom: (),
                     node: Tuple {
                         elts: [
                             Located {
-                                start: Location {
+                                location: Location {
                                     row: 1,
                                     column: 2,
                                 },
-                                end: Location {
-                                    row: 1,
-                                    column: 3,
-                                },
+                                end_location: Some(
+                                    Location {
+                                        row: 1,
+                                        column: 3,
+                                    },
+                                ),
                                 custom: (),
                                 node: Name {
                                     id: "x",
@@ -43,25 +49,29 @@ expression: parse_ast
                                 },
                             },
                             Located {
-                                start: Location {
+                                location: Location {
                                     row: 1,
                                     column: 5,
                                 },
-                                end: Location {
-                                    row: 1,
-                                    column: 7,
-                                },
+                                end_location: Some(
+                                    Location {
+                                        row: 1,
+                                        column: 7,
+                                    },
+                                ),
                                 custom: (),
                                 node: Starred {
                                     value: Located {
-                                        start: Location {
+                                        location: Location {
                                             row: 1,
                                             column: 6,
                                         },
-                                        end: Location {
-                                            row: 1,
-                                            column: 7,
-                                        },
+                                        end_location: Some(
+                                            Location {
+                                                row: 1,
+                                                column: 7,
+                                            },
+                                        ),
                                         custom: (),
                                         node: Name {
                                             id: "y",
@@ -77,26 +87,30 @@ expression: parse_ast
                 },
             ],
             value: Located {
-                start: Location {
+                location: Location {
                     row: 1,
                     column: 12,
                 },
-                end: Location {
-                    row: 1,
-                    column: 19,
-                },
+                end_location: Some(
+                    Location {
+                        row: 1,
+                        column: 19,
+                    },
+                ),
                 custom: (),
                 node: Tuple {
                     elts: [
                         Located {
-                            start: Location {
+                            location: Location {
                                 row: 1,
                                 column: 12,
                             },
-                            end: Location {
-                                row: 1,
-                                column: 13,
-                            },
+                            end_location: Some(
+                                Location {
+                                    row: 1,
+                                    column: 13,
+                                },
+                            ),
                             custom: (),
                             node: Constant {
                                 value: Int(
@@ -106,14 +120,16 @@ expression: parse_ast
                             },
                         },
                         Located {
-                            start: Location {
+                            location: Location {
                                 row: 1,
                                 column: 15,
                             },
-                            end: Location {
-                                row: 1,
-                                column: 16,
-                            },
+                            end_location: Some(
+                                Location {
+                                    row: 1,
+                                    column: 16,
+                                },
+                            ),
                             custom: (),
                             node: Constant {
                                 value: Int(
@@ -123,14 +139,16 @@ expression: parse_ast
                             },
                         },
                         Located {
-                            start: Location {
+                            location: Location {
                                 row: 1,
                                 column: 18,
                             },
-                            end: Location {
-                                row: 1,
-                                column: 19,
-                            },
+                            end_location: Some(
+                                Location {
+                                    row: 1,
+                                    column: 19,
+                                },
+                            ),
                             custom: (),
                             node: Constant {
                                 value: Int(

--- a/compiler/parser/src/snapshots/rustpython_parser__context__tests__assign_subscript.snap
+++ b/compiler/parser/src/snapshots/rustpython_parser__context__tests__assign_subscript.snap
@@ -4,37 +4,43 @@ expression: parse_ast
 ---
 [
     Located {
-        start: Location {
+        location: Location {
             row: 1,
             column: 1,
         },
-        end: Location {
-            row: 1,
-            column: 17,
-        },
+        end_location: Some(
+            Location {
+                row: 1,
+                column: 17,
+            },
+        ),
         custom: (),
         node: Assign {
             targets: [
                 Located {
-                    start: Location {
+                    location: Location {
                         row: 1,
-                        column: 2,
+                        column: 1,
                     },
-                    end: Location {
-                        row: 1,
-                        column: 5,
-                    },
+                    end_location: Some(
+                        Location {
+                            row: 1,
+                            column: 5,
+                        },
+                    ),
                     custom: (),
                     node: Subscript {
                         value: Located {
-                            start: Location {
+                            location: Location {
                                 row: 1,
                                 column: 1,
                             },
-                            end: Location {
-                                row: 1,
-                                column: 2,
-                            },
+                            end_location: Some(
+                                Location {
+                                    row: 1,
+                                    column: 2,
+                                },
+                            ),
                             custom: (),
                             node: Name {
                                 id: "x",
@@ -42,14 +48,16 @@ expression: parse_ast
                             },
                         },
                         slice: Located {
-                            start: Location {
+                            location: Location {
                                 row: 1,
                                 column: 3,
                             },
-                            end: Location {
-                                row: 1,
-                                column: 4,
-                            },
+                            end_location: Some(
+                                Location {
+                                    row: 1,
+                                    column: 4,
+                                },
+                            ),
                             custom: (),
                             node: Name {
                                 id: "y",
@@ -61,26 +69,30 @@ expression: parse_ast
                 },
             ],
             value: Located {
-                start: Location {
+                location: Location {
                     row: 1,
                     column: 9,
                 },
-                end: Location {
-                    row: 1,
-                    column: 16,
-                },
+                end_location: Some(
+                    Location {
+                        row: 1,
+                        column: 16,
+                    },
+                ),
                 custom: (),
                 node: Tuple {
                     elts: [
                         Located {
-                            start: Location {
+                            location: Location {
                                 row: 1,
                                 column: 9,
                             },
-                            end: Location {
-                                row: 1,
-                                column: 10,
-                            },
+                            end_location: Some(
+                                Location {
+                                    row: 1,
+                                    column: 10,
+                                },
+                            ),
                             custom: (),
                             node: Constant {
                                 value: Int(
@@ -90,14 +102,16 @@ expression: parse_ast
                             },
                         },
                         Located {
-                            start: Location {
+                            location: Location {
                                 row: 1,
                                 column: 12,
                             },
-                            end: Location {
-                                row: 1,
-                                column: 13,
-                            },
+                            end_location: Some(
+                                Location {
+                                    row: 1,
+                                    column: 13,
+                                },
+                            ),
                             custom: (),
                             node: Constant {
                                 value: Int(
@@ -107,14 +121,16 @@ expression: parse_ast
                             },
                         },
                         Located {
-                            start: Location {
+                            location: Location {
                                 row: 1,
                                 column: 15,
                             },
-                            end: Location {
-                                row: 1,
-                                column: 16,
-                            },
+                            end_location: Some(
+                                Location {
+                                    row: 1,
+                                    column: 16,
+                                },
+                            ),
                             custom: (),
                             node: Constant {
                                 value: Int(

--- a/compiler/parser/src/snapshots/rustpython_parser__context__tests__assign_tuple.snap
+++ b/compiler/parser/src/snapshots/rustpython_parser__context__tests__assign_tuple.snap
@@ -4,38 +4,44 @@ expression: parse_ast
 ---
 [
     Located {
-        start: Location {
+        location: Location {
             row: 1,
             column: 1,
         },
-        end: Location {
-            row: 1,
-            column: 19,
-        },
+        end_location: Some(
+            Location {
+                row: 1,
+                column: 19,
+            },
+        ),
         custom: (),
         node: Assign {
             targets: [
                 Located {
-                    start: Location {
+                    location: Location {
                         row: 1,
                         column: 2,
                     },
-                    end: Location {
-                        row: 1,
-                        column: 6,
-                    },
+                    end_location: Some(
+                        Location {
+                            row: 1,
+                            column: 6,
+                        },
+                    ),
                     custom: (),
                     node: Tuple {
                         elts: [
                             Located {
-                                start: Location {
+                                location: Location {
                                     row: 1,
                                     column: 2,
                                 },
-                                end: Location {
-                                    row: 1,
-                                    column: 3,
-                                },
+                                end_location: Some(
+                                    Location {
+                                        row: 1,
+                                        column: 3,
+                                    },
+                                ),
                                 custom: (),
                                 node: Name {
                                     id: "x",
@@ -43,14 +49,16 @@ expression: parse_ast
                                 },
                             },
                             Located {
-                                start: Location {
+                                location: Location {
                                     row: 1,
                                     column: 5,
                                 },
-                                end: Location {
-                                    row: 1,
-                                    column: 6,
-                                },
+                                end_location: Some(
+                                    Location {
+                                        row: 1,
+                                        column: 6,
+                                    },
+                                ),
                                 custom: (),
                                 node: Name {
                                     id: "y",
@@ -63,26 +71,30 @@ expression: parse_ast
                 },
             ],
             value: Located {
-                start: Location {
+                location: Location {
                     row: 1,
                     column: 11,
                 },
-                end: Location {
-                    row: 1,
-                    column: 18,
-                },
+                end_location: Some(
+                    Location {
+                        row: 1,
+                        column: 18,
+                    },
+                ),
                 custom: (),
                 node: Tuple {
                     elts: [
                         Located {
-                            start: Location {
+                            location: Location {
                                 row: 1,
                                 column: 11,
                             },
-                            end: Location {
-                                row: 1,
-                                column: 12,
-                            },
+                            end_location: Some(
+                                Location {
+                                    row: 1,
+                                    column: 12,
+                                },
+                            ),
                             custom: (),
                             node: Constant {
                                 value: Int(
@@ -92,14 +104,16 @@ expression: parse_ast
                             },
                         },
                         Located {
-                            start: Location {
+                            location: Location {
                                 row: 1,
                                 column: 14,
                             },
-                            end: Location {
-                                row: 1,
-                                column: 15,
-                            },
+                            end_location: Some(
+                                Location {
+                                    row: 1,
+                                    column: 15,
+                                },
+                            ),
                             custom: (),
                             node: Constant {
                                 value: Int(
@@ -109,14 +123,16 @@ expression: parse_ast
                             },
                         },
                         Located {
-                            start: Location {
+                            location: Location {
                                 row: 1,
                                 column: 17,
                             },
-                            end: Location {
-                                row: 1,
-                                column: 18,
-                            },
+                            end_location: Some(
+                                Location {
+                                    row: 1,
+                                    column: 18,
+                                },
+                            ),
                             custom: (),
                             node: Constant {
                                 value: Int(

--- a/compiler/parser/src/snapshots/rustpython_parser__context__tests__assign_with.snap
+++ b/compiler/parser/src/snapshots/rustpython_parser__context__tests__assign_with.snap
@@ -4,27 +4,31 @@ expression: parse_ast
 ---
 [
     Located {
-        start: Location {
+        location: Location {
             row: 1,
             column: 1,
         },
-        end: Location {
-            row: 1,
-            column: 18,
-        },
+        end_location: Some(
+            Location {
+                row: 1,
+                column: 18,
+            },
+        ),
         custom: (),
         node: With {
             items: [
                 Withitem {
                     context_expr: Located {
-                        start: Location {
+                        location: Location {
                             row: 1,
                             column: 6,
                         },
-                        end: Location {
-                            row: 1,
-                            column: 7,
-                        },
+                        end_location: Some(
+                            Location {
+                                row: 1,
+                                column: 7,
+                            },
+                        ),
                         custom: (),
                         node: Constant {
                             value: Int(
@@ -35,14 +39,16 @@ expression: parse_ast
                     },
                     optional_vars: Some(
                         Located {
-                            start: Location {
+                            location: Location {
                                 row: 1,
                                 column: 11,
                             },
-                            end: Location {
-                                row: 1,
-                                column: 12,
-                            },
+                            end_location: Some(
+                                Location {
+                                    row: 1,
+                                    column: 12,
+                                },
+                            ),
                             custom: (),
                             node: Name {
                                 id: "x",
@@ -54,14 +60,16 @@ expression: parse_ast
             ],
             body: [
                 Located {
-                    start: Location {
+                    location: Location {
                         row: 1,
                         column: 14,
                     },
-                    end: Location {
-                        row: 1,
-                        column: 18,
-                    },
+                    end_location: Some(
+                        Location {
+                            row: 1,
+                            column: 18,
+                        },
+                    ),
                     custom: (),
                     node: Pass,
                 },

--- a/compiler/parser/src/snapshots/rustpython_parser__context__tests__aug_assign_attribute.snap
+++ b/compiler/parser/src/snapshots/rustpython_parser__context__tests__aug_assign_attribute.snap
@@ -4,36 +4,42 @@ expression: parse_ast
 ---
 [
     Located {
-        start: Location {
+        location: Location {
             row: 1,
             column: 1,
         },
-        end: Location {
-            row: 1,
-            column: 17,
-        },
+        end_location: Some(
+            Location {
+                row: 1,
+                column: 17,
+            },
+        ),
         custom: (),
         node: AugAssign {
             target: Located {
-                start: Location {
+                location: Location {
                     row: 1,
-                    column: 2,
+                    column: 1,
                 },
-                end: Location {
-                    row: 1,
-                    column: 4,
-                },
+                end_location: Some(
+                    Location {
+                        row: 1,
+                        column: 4,
+                    },
+                ),
                 custom: (),
                 node: Attribute {
                     value: Located {
-                        start: Location {
+                        location: Location {
                             row: 1,
                             column: 1,
                         },
-                        end: Location {
-                            row: 1,
-                            column: 2,
-                        },
+                        end_location: Some(
+                            Location {
+                                row: 1,
+                                column: 2,
+                            },
+                        ),
                         custom: (),
                         node: Name {
                             id: "x",
@@ -46,26 +52,30 @@ expression: parse_ast
             },
             op: Add,
             value: Located {
-                start: Location {
+                location: Location {
                     row: 1,
                     column: 9,
                 },
-                end: Location {
-                    row: 1,
-                    column: 16,
-                },
+                end_location: Some(
+                    Location {
+                        row: 1,
+                        column: 16,
+                    },
+                ),
                 custom: (),
                 node: Tuple {
                     elts: [
                         Located {
-                            start: Location {
+                            location: Location {
                                 row: 1,
                                 column: 9,
                             },
-                            end: Location {
-                                row: 1,
-                                column: 10,
-                            },
+                            end_location: Some(
+                                Location {
+                                    row: 1,
+                                    column: 10,
+                                },
+                            ),
                             custom: (),
                             node: Constant {
                                 value: Int(
@@ -75,14 +85,16 @@ expression: parse_ast
                             },
                         },
                         Located {
-                            start: Location {
+                            location: Location {
                                 row: 1,
                                 column: 12,
                             },
-                            end: Location {
-                                row: 1,
-                                column: 13,
-                            },
+                            end_location: Some(
+                                Location {
+                                    row: 1,
+                                    column: 13,
+                                },
+                            ),
                             custom: (),
                             node: Constant {
                                 value: Int(
@@ -92,14 +104,16 @@ expression: parse_ast
                             },
                         },
                         Located {
-                            start: Location {
+                            location: Location {
                                 row: 1,
                                 column: 15,
                             },
-                            end: Location {
-                                row: 1,
-                                column: 16,
-                            },
+                            end_location: Some(
+                                Location {
+                                    row: 1,
+                                    column: 16,
+                                },
+                            ),
                             custom: (),
                             node: Constant {
                                 value: Int(

--- a/compiler/parser/src/snapshots/rustpython_parser__context__tests__aug_assign_name.snap
+++ b/compiler/parser/src/snapshots/rustpython_parser__context__tests__aug_assign_name.snap
@@ -4,25 +4,29 @@ expression: parse_ast
 ---
 [
     Located {
-        start: Location {
+        location: Location {
             row: 1,
             column: 1,
         },
-        end: Location {
-            row: 1,
-            column: 7,
-        },
+        end_location: Some(
+            Location {
+                row: 1,
+                column: 7,
+            },
+        ),
         custom: (),
         node: AugAssign {
             target: Located {
-                start: Location {
+                location: Location {
                     row: 1,
                     column: 1,
                 },
-                end: Location {
-                    row: 1,
-                    column: 2,
-                },
+                end_location: Some(
+                    Location {
+                        row: 1,
+                        column: 2,
+                    },
+                ),
                 custom: (),
                 node: Name {
                     id: "x",
@@ -31,14 +35,16 @@ expression: parse_ast
             },
             op: Add,
             value: Located {
-                start: Location {
+                location: Location {
                     row: 1,
                     column: 6,
                 },
-                end: Location {
-                    row: 1,
-                    column: 7,
-                },
+                end_location: Some(
+                    Location {
+                        row: 1,
+                        column: 7,
+                    },
+                ),
                 custom: (),
                 node: Constant {
                     value: Int(

--- a/compiler/parser/src/snapshots/rustpython_parser__context__tests__aug_assign_subscript.snap
+++ b/compiler/parser/src/snapshots/rustpython_parser__context__tests__aug_assign_subscript.snap
@@ -4,36 +4,42 @@ expression: parse_ast
 ---
 [
     Located {
-        start: Location {
+        location: Location {
             row: 1,
             column: 1,
         },
-        end: Location {
-            row: 1,
-            column: 18,
-        },
+        end_location: Some(
+            Location {
+                row: 1,
+                column: 18,
+            },
+        ),
         custom: (),
         node: AugAssign {
             target: Located {
-                start: Location {
+                location: Location {
                     row: 1,
-                    column: 2,
+                    column: 1,
                 },
-                end: Location {
-                    row: 1,
-                    column: 5,
-                },
+                end_location: Some(
+                    Location {
+                        row: 1,
+                        column: 5,
+                    },
+                ),
                 custom: (),
                 node: Subscript {
                     value: Located {
-                        start: Location {
+                        location: Location {
                             row: 1,
                             column: 1,
                         },
-                        end: Location {
-                            row: 1,
-                            column: 2,
-                        },
+                        end_location: Some(
+                            Location {
+                                row: 1,
+                                column: 2,
+                            },
+                        ),
                         custom: (),
                         node: Name {
                             id: "x",
@@ -41,14 +47,16 @@ expression: parse_ast
                         },
                     },
                     slice: Located {
-                        start: Location {
+                        location: Location {
                             row: 1,
                             column: 3,
                         },
-                        end: Location {
-                            row: 1,
-                            column: 4,
-                        },
+                        end_location: Some(
+                            Location {
+                                row: 1,
+                                column: 4,
+                            },
+                        ),
                         custom: (),
                         node: Name {
                             id: "y",
@@ -60,26 +68,30 @@ expression: parse_ast
             },
             op: Add,
             value: Located {
-                start: Location {
+                location: Location {
                     row: 1,
                     column: 10,
                 },
-                end: Location {
-                    row: 1,
-                    column: 17,
-                },
+                end_location: Some(
+                    Location {
+                        row: 1,
+                        column: 17,
+                    },
+                ),
                 custom: (),
                 node: Tuple {
                     elts: [
                         Located {
-                            start: Location {
+                            location: Location {
                                 row: 1,
                                 column: 10,
                             },
-                            end: Location {
-                                row: 1,
-                                column: 11,
-                            },
+                            end_location: Some(
+                                Location {
+                                    row: 1,
+                                    column: 11,
+                                },
+                            ),
                             custom: (),
                             node: Constant {
                                 value: Int(
@@ -89,14 +101,16 @@ expression: parse_ast
                             },
                         },
                         Located {
-                            start: Location {
+                            location: Location {
                                 row: 1,
                                 column: 13,
                             },
-                            end: Location {
-                                row: 1,
-                                column: 14,
-                            },
+                            end_location: Some(
+                                Location {
+                                    row: 1,
+                                    column: 14,
+                                },
+                            ),
                             custom: (),
                             node: Constant {
                                 value: Int(
@@ -106,14 +120,16 @@ expression: parse_ast
                             },
                         },
                         Located {
-                            start: Location {
+                            location: Location {
                                 row: 1,
                                 column: 16,
                             },
-                            end: Location {
-                                row: 1,
-                                column: 17,
-                            },
+                            end_location: Some(
+                                Location {
+                                    row: 1,
+                                    column: 17,
+                                },
+                            ),
                             custom: (),
                             node: Constant {
                                 value: Int(

--- a/compiler/parser/src/snapshots/rustpython_parser__context__tests__del_attribute.snap
+++ b/compiler/parser/src/snapshots/rustpython_parser__context__tests__del_attribute.snap
@@ -4,37 +4,43 @@ expression: parse_ast
 ---
 [
     Located {
-        start: Location {
+        location: Location {
             row: 1,
             column: 1,
         },
-        end: Location {
-            row: 1,
-            column: 8,
-        },
+        end_location: Some(
+            Location {
+                row: 1,
+                column: 8,
+            },
+        ),
         custom: (),
         node: Delete {
             targets: [
                 Located {
-                    start: Location {
+                    location: Location {
                         row: 1,
-                        column: 6,
+                        column: 5,
                     },
-                    end: Location {
-                        row: 1,
-                        column: 8,
-                    },
+                    end_location: Some(
+                        Location {
+                            row: 1,
+                            column: 8,
+                        },
+                    ),
                     custom: (),
                     node: Attribute {
                         value: Located {
-                            start: Location {
+                            location: Location {
                                 row: 1,
                                 column: 5,
                             },
-                            end: Location {
-                                row: 1,
-                                column: 6,
-                            },
+                            end_location: Some(
+                                Location {
+                                    row: 1,
+                                    column: 6,
+                                },
+                            ),
                             custom: (),
                             node: Name {
                                 id: "x",

--- a/compiler/parser/src/snapshots/rustpython_parser__context__tests__del_subscript.snap
+++ b/compiler/parser/src/snapshots/rustpython_parser__context__tests__del_subscript.snap
@@ -4,37 +4,43 @@ expression: parse_ast
 ---
 [
     Located {
-        start: Location {
+        location: Location {
             row: 1,
             column: 1,
         },
-        end: Location {
-            row: 1,
-            column: 9,
-        },
+        end_location: Some(
+            Location {
+                row: 1,
+                column: 9,
+            },
+        ),
         custom: (),
         node: Delete {
             targets: [
                 Located {
-                    start: Location {
+                    location: Location {
                         row: 1,
-                        column: 6,
+                        column: 5,
                     },
-                    end: Location {
-                        row: 1,
-                        column: 9,
-                    },
+                    end_location: Some(
+                        Location {
+                            row: 1,
+                            column: 9,
+                        },
+                    ),
                     custom: (),
                     node: Subscript {
                         value: Located {
-                            start: Location {
+                            location: Location {
                                 row: 1,
                                 column: 5,
                             },
-                            end: Location {
-                                row: 1,
-                                column: 6,
-                            },
+                            end_location: Some(
+                                Location {
+                                    row: 1,
+                                    column: 6,
+                                },
+                            ),
                             custom: (),
                             node: Name {
                                 id: "x",
@@ -42,14 +48,16 @@ expression: parse_ast
                             },
                         },
                         slice: Located {
-                            start: Location {
+                            location: Location {
                                 row: 1,
                                 column: 7,
                             },
-                            end: Location {
-                                row: 1,
-                                column: 8,
-                            },
+                            end_location: Some(
+                                Location {
+                                    row: 1,
+                                    column: 8,
+                                },
+                            ),
                             custom: (),
                             node: Name {
                                 id: "y",

--- a/compiler/parser/src/snapshots/rustpython_parser__parser__tests__parse_dict_comprehension.snap
+++ b/compiler/parser/src/snapshots/rustpython_parser__parser__tests__parse_dict_comprehension.snap
@@ -65,7 +65,7 @@ Located {
                     custom: (),
                     node: Name {
                         id: "y",
-                        ctx: Load,
+                        ctx: Store,
                     },
                 },
                 iter: Located {

--- a/compiler/parser/src/snapshots/rustpython_parser__parser__tests__parse_double_list_comprehension.snap
+++ b/compiler/parser/src/snapshots/rustpython_parser__parser__tests__parse_double_list_comprehension.snap
@@ -62,7 +62,7 @@ Located {
                                 custom: (),
                                 node: Name {
                                     id: "y",
-                                    ctx: Load,
+                                    ctx: Store,
                                 },
                             },
                             Located {
@@ -79,11 +79,11 @@ Located {
                                 custom: (),
                                 node: Name {
                                     id: "y2",
-                                    ctx: Load,
+                                    ctx: Store,
                                 },
                             },
                         ],
-                        ctx: Load,
+                        ctx: Store,
                     },
                 },
                 iter: Located {
@@ -121,7 +121,7 @@ Located {
                     custom: (),
                     node: Name {
                         id: "a",
-                        ctx: Load,
+                        ctx: Store,
                     },
                 },
                 iter: Located {

--- a/compiler/parser/src/snapshots/rustpython_parser__parser__tests__parse_generator_comprehension.snap
+++ b/compiler/parser/src/snapshots/rustpython_parser__parser__tests__parse_generator_comprehension.snap
@@ -48,7 +48,7 @@ Located {
                     custom: (),
                     node: Name {
                         id: "y",
-                        ctx: Load,
+                        ctx: Store,
                     },
                 },
                 iter: Located {

--- a/compiler/parser/src/snapshots/rustpython_parser__parser__tests__parse_if_else_generator_comprehension.snap
+++ b/compiler/parser/src/snapshots/rustpython_parser__parser__tests__parse_if_else_generator_comprehension.snap
@@ -97,7 +97,7 @@ Located {
                     custom: (),
                     node: Name {
                         id: "y",
-                        ctx: Load,
+                        ctx: Store,
                     },
                 },
                 iter: Located {

--- a/compiler/parser/src/snapshots/rustpython_parser__parser__tests__parse_list_comprehension.snap
+++ b/compiler/parser/src/snapshots/rustpython_parser__parser__tests__parse_list_comprehension.snap
@@ -48,7 +48,7 @@ Located {
                     custom: (),
                     node: Name {
                         id: "y",
-                        ctx: Load,
+                        ctx: Store,
                     },
                 },
                 iter: Located {

--- a/compiler/parser/src/snapshots/rustpython_parser__parser__tests__parse_named_expression_generator_comprehension.snap
+++ b/compiler/parser/src/snapshots/rustpython_parser__parser__tests__parse_named_expression_generator_comprehension.snap
@@ -115,7 +115,7 @@ Located {
                     custom: (),
                     node: Name {
                         id: "y",
-                        ctx: Load,
+                        ctx: Store,
                     },
                 },
                 iter: Located {

--- a/compiler/parser/src/snapshots/rustpython_parser__parser__tests__parse_tuples.snap
+++ b/compiler/parser/src/snapshots/rustpython_parser__parser__tests__parse_tuples.snap
@@ -45,7 +45,7 @@ expression: "parse_program(source, \"<test>\").unwrap()"
                                 custom: (),
                                 node: Name {
                                     id: "a",
-                                    ctx: Load,
+                                    ctx: Store,
                                 },
                             },
                             Located {
@@ -62,11 +62,11 @@ expression: "parse_program(source, \"<test>\").unwrap()"
                                 custom: (),
                                 node: Name {
                                     id: "b",
-                                    ctx: Load,
+                                    ctx: Store,
                                 },
                             },
                         ],
-                        ctx: Load,
+                        ctx: Store,
                     },
                 },
             ],


### PR DESCRIPTION
# Summary

It looks like the parser is _almost_ always setting `ast::ExprContext::Load`. This PR attempts to set `ast::ExprContext::Store` and `ast::ExprContext::Del` in the right places, based on playing around with CPython's own behavior.

I'm not familiar enough with LALRPOP to know if there's a way to do this within the parser itself -- so, instead, I had to "rewrite" the expression tree in the right places.
