### PR TITLE
Allow fcntl functions to accept objects with fileno() function

### DIFF
--- a/Lib/test/test_fcntl.py
+++ b/Lib/test/test_fcntl.py
@@ -141,8 +141,6 @@ class TestFcntl(unittest.TestCase):
         finally:
             os.close(fd)
 
-    # TODO: RUSTPYTHON, TypeError: 'BufferedRandom' object cannot be interpreted as an integer
-    @unittest.expectedFailure
     def test_flock(self):
         # Solaris needs readable file for shared lock
         self.f = open(TESTFN, 'wb+')
@@ -157,7 +155,7 @@ class TestFcntl(unittest.TestCase):
         self.assertRaises(ValueError, fcntl.flock, -1, fcntl.LOCK_SH)
         self.assertRaises(TypeError, fcntl.flock, 'spam', fcntl.LOCK_SH)
 
-    # TODO: RUSTPYTHON, TypeError: 'BufferedRandom' object cannot be interpreted as an integer
+    # TODO: RUSTPYTHON, AttributeError: module 'os' has no attribute 'fork'
     @unittest.expectedFailure
     @unittest.skipIf(platform.system() == "AIX", "AIX returns PermissionError")
     def test_lockf_exclusive(self):
@@ -170,7 +168,7 @@ class TestFcntl(unittest.TestCase):
         fcntl.lockf(self.f, fcntl.LOCK_UN)
         self.assertEqual(p.exitcode, 0)
 
-    # TODO: RUSTPYTHON, TypeError: 'BufferedRandom' object cannot be interpreted as an integer
+    # TODO: RUSTPYTHON, AttributeError: module 'os' has no attribute 'fork'
     @unittest.expectedFailure
     @unittest.skipIf(platform.system() == "AIX", "AIX returns PermissionError")
     def test_lockf_share(self):


### PR DESCRIPTION
As specified in Python official documentation
(https://docs.python.org/3.10/library/fcntl.html)

> All functions in this module take a file descriptor fd as their first
> argument. This can be an integer file descriptor, such as returned by
> sys.stdin.fileno(), or an io.IOBase object, such as sys.stdin itself,
> which provides a fileno() that returns a genuine file descriptor.

And clarified more in fcntl.fcntl function:

> Perform the operation cmd on file descriptor fd (file objects
> providing a fileno() method are accepted as well).

All function in fcntl modules should accept either int fd or object with
fileno() function which returns int fd.

This was already implemented with for `fcntl.fcntl` function with
`io::Fildes` newtype helper which extracted either int fd or called
fileno() function, and it was also implemented with duplicated ad-hoc
code for `fcntl.ioctl`.

This commit replaces the ad-hoc implementation with `io::Fildes` and
adds it to missing functions: `fcntl.flock` and `fcntl.lockf`.

For more information that this is implemented in the same way as
CPython, you can check the corresponding CPython module:
https://github.com/python/cpython/blob/3.10/Modules/clinic/fcntlmodule.c.h

The functions are: `fcntl_fcntl`, `fcntl_ioctl`, `fcntl_flock` and
`fcntl_lockf`, all of these functions use
`_PyLong_FileDescriptor_Converter` which does the same thing as
RustPython's `io::Fildes`, meaning it either extracts the argument as
int fd or calls fileno() function on passed object that returns the int
fd.

Here is the implementation for `_PyLong_FileDescriptor_Converter`:
https://github.com/python/cpython/blob/3.10/Objects/fileobject.c#L227
which in turns calls `PyObject_AsFileDescriptor` which is located here
https://github.com/python/cpython/blob/3.10/Objects/fileobject.c#L180 in
the same file and we can see that it tries to convert it to int or call
fileno() function.