### PR TITLE
Add `math.cbrt` implemented in cpython 3.11

### DIFF
--- a/Lib/test/test_math.py
+++ b/Lib/test/test_math.py
@@ -377,8 +377,6 @@ class MathTests(unittest.TestCase):
         self.assertTrue(math.isnan(math.atan2(NAN, INF)))
         self.assertTrue(math.isnan(math.atan2(NAN, NAN)))
 
-    # TODO: RUSTPYTHON
-    @unittest.expectedFailure
     def testCbrt(self):
         self.assertRaises(TypeError, math.cbrt)
         self.ftest('cbrt(0)', math.cbrt(0), 0)

--- a/stdlib/src/math.rs
+++ b/stdlib/src/math.rs
@@ -542,6 +542,11 @@ mod math {
     }
 
     #[pyfunction]
+    fn cbrt(x: ArgIntoFloat) -> f64 {
+        x.cbrt()
+    }
+
+    #[pyfunction]
     fn fsum(seq: ArgIterable<ArgIntoFloat>, vm: &VirtualMachine) -> PyResult<f64> {
         let mut partials = vec![];
         let mut special_sum = 0.0;


### PR DESCRIPTION
`math.cbrt` returns the cube root of x

## Related links

* Python codes are copy-pasted from CPython.

- https://github.com/python/cpython/pull/26622

- [Python documentation](https://docs.python.org/ko/3.11/library/math.html#math.cbrt)