### PR TITLE
Fix edge case of `math.pow(0.0, -inf)`, `math.pow(-0.0, -inf)`

### DIFF
--- a/Lib/test/test_math.py
+++ b/Lib/test/test_math.py
@@ -1227,8 +1227,6 @@ class MathTests(unittest.TestCase):
         self.assertTrue(math.isnan(modf_nan[0]))
         self.assertTrue(math.isnan(modf_nan[1]))
 
-    # TODO: RUSTPYTHON
-    @unittest.expectedFailure
     def testPow(self):
         self.assertRaises(TypeError, math.pow)
         self.ftest('pow(0,1)', math.pow(0,1), 0)

--- a/stdlib/src/math.rs
+++ b/stdlib/src/math.rs
@@ -184,7 +184,7 @@ mod math {
             return Err(vm.new_value_error("math domain error".to_owned()));
         }
 
-        if x == 0.0 && y < 0.0 {
+        if x == 0.0 && y < 0.0 && y != f64::NEG_INFINITY {
             return Err(vm.new_value_error("math domain error".to_owned()));
         }
 


### PR DESCRIPTION
Python documentation says `The special cases pow(0.0, -inf) and pow(-0.0, -inf) were changed to return inf instead of raising ValueError, for consistency with IEEE 754`

## Related links

- [Python documentation](https://docs.python.org/ko/3.11/library/math.html#math.pow)

- [Python 3.11 change log](https://github.com/python/cpython/blob/main/Doc/whatsnew/3.11.rst#math)

- https://github.com/python/cpython/pull/26606