### PR TITLE
Add `operator.call`

### DIFF
--- a/Lib/operator.py
+++ b/Lib/operator.py
@@ -10,7 +10,7 @@ for convenience.
 This is the pure Python implementation of the module.
 """
 
-__all__ = ['abs', 'add', 'and_', 'attrgetter', 'concat', 'contains', 'countOf',
+__all__ = ['abs', 'add', 'and_', 'attrgetter', 'call', 'concat', 'contains', 'countOf',
            'delitem', 'eq', 'floordiv', 'ge', 'getitem', 'gt', 'iadd', 'iand',
            'iconcat', 'ifloordiv', 'ilshift', 'imatmul', 'imod', 'imul',
            'index', 'indexOf', 'inv', 'invert', 'ior', 'ipow', 'irshift',

--- a/Lib/operator.py
+++ b/Lib/operator.py
@@ -221,6 +221,12 @@ def length_hint(obj, default=0):
         raise ValueError(msg)
     return val
 
+# Other Operations ************************************************************#
+
+def call(obj, /, *args, **kwargs):
+    """Same as obj(*args, **kwargs)."""
+    return obj(*args, **kwargs)
+
 # Generalized Lookup Objects **************************************************#
 
 class attrgetter:
@@ -423,6 +429,7 @@ __not__ = not_
 __abs__ = abs
 __add__ = add
 __and__ = and_
+__call__ = call
 __floordiv__ = floordiv
 __index__ = index
 __inv__ = inv

--- a/Lib/test/test_operator.py
+++ b/Lib/test/test_operator.py
@@ -45,6 +45,18 @@ class BadIterable:
 
 
 class OperatorTestCase:
+    def test___all__(self):
+        operator = self.module
+        actual_all = set(operator.__all__)
+        computed_all = set()
+        for name in vars(operator):
+            if name.startswith('__'):
+                continue
+            value = getattr(operator, name)
+            if value.__module__ in ('operator', '_operator'):
+                computed_all.add(name)
+        self.assertSetEqual(computed_all, actual_all)
+
     def test_lt(self):
         operator = self.module
         self.assertRaises(TypeError, operator.lt)

--- a/Lib/test/test_operator.py
+++ b/Lib/test/test_operator.py
@@ -518,6 +518,18 @@ class OperatorTestCase:
         with self.assertRaises(LookupError):
             operator.length_hint(X(LookupError))
 
+    def test_call(self):
+        operator = self.module
+
+        def func(*args, **kwargs): return args, kwargs
+
+        self.assertEqual(operator.call(func), ((), {}))
+        self.assertEqual(operator.call(func, 0, 1), ((0, 1), {}))
+        self.assertEqual(operator.call(func, a=2, obj=3),
+                         ((), {"a": 2, "obj": 3}))
+        self.assertEqual(operator.call(func, 0, 1, a=2, obj=3),
+                         ((0, 1), {"a": 2, "obj": 3}))
+
     def test_dunder_is_original(self):
         operator = self.module
 

--- a/vm/src/stdlib/operator.rs
+++ b/vm/src/stdlib/operator.rs
@@ -139,7 +139,7 @@ mod _operator {
 
     /// Return a @ b
     #[pyfunction]
-    fn mat_mul(a: PyObjectRef, b: PyObjectRef, vm: &VirtualMachine) -> PyResult {
+    fn matmul(a: PyObjectRef, b: PyObjectRef, vm: &VirtualMachine) -> PyResult {
         vm._matmul(&a, &b)
     }
 


### PR DESCRIPTION
Add `operator.call` implemented in cpython 3.11

# Related links

* Python codes are copy-pasted from CPython.

- [Cpython change log](https://github.com/python/cpython/blob/main/Doc/whatsnew/3.11.rst#operator)

## Related PRs

-  https://github.com/python/cpython/pull/27888

- https://github.com/python/cpython/pull/29110
