### PR TITLE
Add `datetime.UTC` alias for `datetime.timezone.utc`

### DIFF
--- a/Lib/datetime.py
+++ b/Lib/datetime.py
@@ -5,7 +5,7 @@ time zone and DST data sources.
 """
 
 __all__ = ("date", "datetime", "time", "timedelta", "timezone", "tzinfo",
-           "MINYEAR", "MAXYEAR")
+           "MINYEAR", "MAXYEAR", "UTC")
 
 
 import time as _time
@@ -2298,7 +2298,7 @@ class timezone(tzinfo):
             return f'UTC{sign}{hours:02d}:{minutes:02d}:{seconds:02d}'
         return f'UTC{sign}{hours:02d}:{minutes:02d}'
 
-timezone.utc = timezone._create(timedelta(0))
+UTC = timezone.utc = timezone._create(timedelta(0))
 # bpo-37642: These attributes are rounded to the nearest minute for backwards
 # compatibility, even though the constructor will accept a wider range of
 # values. This may change in the future.


### PR DESCRIPTION
Added `UTC` alias added in cpython 3.11

By the way, It seems maybe the `Lib/test/datetimetester.py` tests are missing, I'm wondering if this is intended.

## Manual test 

```
>>>>> datetime.UTC
datetime.timezone.utc
```

## Related links

* Python codes are copy-pasted from CPython.

- https://github.com/python/cpython/pull/91973

- [Python change log](https://github.com/python/cpython/blob/main/Doc/whatsnew/3.11.rst#datetime)