### PR TITLE
Fix `bool_eq` argument order of `_membership_iter_search` for compatibility with cpython

### DIFF
--- a/Lib/test/test_iter.py
+++ b/Lib/test/test_iter.py
@@ -648,8 +648,6 @@ class TestCase(unittest.TestCase):
             except OSError:
                 pass
 
-    # TODO: RUSTPYTHON
-    @unittest.expectedFailure
     # Test iterators with 'x in y' and 'x not in y'.
     def test_in_and_not_in(self):
         for sc5 in IteratingSequenceClass(5), SequenceClass(5):

--- a/vm/src/vm/vm_ops.rs
+++ b/vm/src/vm/vm_ops.rs
@@ -503,7 +503,7 @@ impl VirtualMachine {
         let iter = haystack.get_iter(self)?;
         loop {
             if let PyIterReturn::Return(element) = iter.next(self)? {
-                if self.bool_eq(&needle, &element)? {
+                if self.bool_eq(&element, &needle)? {
                     return Ok(self.ctx.new_bool(true));
                 } else {
                     continue;


### PR DESCRIPTION
## Related

- [Related CPython implementation](https://github.com/python/cpython/blob/main/Objects/abstract.c#L2173-L2254)