### PR TITLE
Fix `hash`'s error message when `hash` method is `None`

### DIFF
--- a/Lib/test/test_dataclasses.py
+++ b/Lib/test/test_dataclasses.py
@@ -2536,8 +2536,6 @@ class TestHash(unittest.TestCase):
         self.assertEqual(hash(C(4)), hash((4,)))
         self.assertEqual(hash(C(42)), hash((42,)))
 
-    # TODO: RUSTPYTHON
-    @unittest.expectedFailure
     def test_hash_no_args(self):
         # Test dataclasses with no hash= argument.  This exists to
         #  make sure that if the @dataclass parameter name is changed

--- a/vm/src/protocol/object.rs
+++ b/vm/src/protocol/object.rs
@@ -514,9 +514,8 @@ impl PyObject {
     }
 
     pub fn hash(&self, vm: &VirtualMachine) -> PyResult<PyHash> {
-        // hash always exist
         let hash = self.get_class_attr(identifier!(vm, __hash__)).unwrap();
-        if hash.is(&vm.ctx.none()) {
+        if vm.is_none(&hash) {
             return Err(vm.new_exception_msg(
                 vm.ctx.exceptions.type_error.to_owned(),
                 format!("unhashable type: '{}'", self.class().name()),

--- a/vm/src/protocol/object.rs
+++ b/vm/src/protocol/object.rs
@@ -514,10 +514,20 @@ impl PyObject {
     }
 
     pub fn hash(&self, vm: &VirtualMachine) -> PyResult<PyHash> {
+        // hash always exist
+        let hash = self.get_class_attr(identifier!(vm, __hash__)).unwrap();
+        if hash.is(&vm.ctx.none()) {
+            return Err(vm.new_exception_msg(
+                vm.ctx.exceptions.type_error.to_owned(),
+                format!("unhashable type: '{}'", self.class().name()),
+            ));
+        }
+
         let hash = self
             .class()
             .mro_find_map(|cls| cls.slots.hash.load())
-            .unwrap(); // hash always exist
+            .unwrap();
+
         hash(self, vm)
     }
 


### PR DESCRIPTION
## CPython (Expected result)

```
>>> class NoHash(object):
...   __hash__ = None
... 
>>> hash(NoHash())
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
TypeError: unhashable type: 'NoHash'
```

## RustPython (Actual result)

```
>>>>> class NoHash(object):
.....   __hash__ = None
..... 
>>>>> hash(NoHash())
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
TypeError: 'NoneType' object is not callable
```

## Result

This PR fixes RustPython's error message when `hash` method is `None`

```
>>>>> class NoHash(object):
.....   __hash__ = None
..... 
>>>>> hash(None)
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
TypeError: unhashable type: 'NoHash'
>>>>> 