### PR TITLE
Fix `test_infinite_recursion_via_bases_tuple`, `test_infinite_cycle_in_bases`

### DIFF
--- a/Lib/test/test_isinstance.py
+++ b/Lib/test/test_isinstance.py
@@ -316,7 +316,6 @@ class TestIsInstanceIsSubclass(unittest.TestCase):
             self.assertRaises(RecursionError, issubclass, int, X())
             self.assertRaises(RecursionError, isinstance, 1, X())
 
-    @unittest.skip("TODO: RUSTPYTHON")
     def test_infinite_recursion_via_bases_tuple(self):
         """Regression test for bpo-30570."""
         class Failure(object):
@@ -326,7 +325,6 @@ class TestIsInstanceIsSubclass(unittest.TestCase):
             with self.assertRaises(RecursionError):
                 issubclass(Failure(), int)
 
-    @unittest.skip("TODO: RUSTPYTHON")
     def test_infinite_cycle_in_bases(self):
         """Regression test for bpo-30570."""
         class X:

--- a/vm/src/protocol/object.rs
+++ b/vm/src/protocol/object.rs
@@ -382,9 +382,17 @@ impl PyObject {
                     continue;
                 }
                 _ => {
-                    for i in 0..n {
-                        if let Ok(true) = tuple.fast_getitem(i).abstract_issubclass(cls, vm) {
-                            return Ok(true);
+                    if let Some(i) = (0..n).next() {
+                        match vm.with_recursion("in abstract_issubclass", || {
+                            tuple.fast_getitem(i).abstract_issubclass(cls, vm)
+                        }) {
+                            Ok(true) => {
+                                return Ok(true);
+                            }
+                            Err(err) => {
+                                return Err(err);
+                            }
+                            _ => continue,
                         }
                     }
                 }

--- a/vm/src/protocol/object.rs
+++ b/vm/src/protocol/object.rs
@@ -383,16 +383,11 @@ impl PyObject {
                 }
                 _ => {
                     if let Some(i) = (0..n).next() {
-                        match vm.with_recursion("in abstract_issubclass", || {
+                        let check = vm.with_recursion("in abstract_issubclass", || {
                             tuple.fast_getitem(i).abstract_issubclass(cls, vm)
-                        }) {
-                            Ok(true) => {
-                                return Ok(true);
-                            }
-                            Err(err) => {
-                                return Err(err);
-                            }
-                            _ => continue,
+                        })?;
+                        if check {
+                            return Ok(true);
                         }
                     }
                 }


### PR DESCRIPTION
This PR resolves 2 tests by applying `with_recursion` in `abstract_issubclass`

* `test_infinite_recursion_via_bases_tuple`
* `test_infinite_cycle_in_bases`