### PR TITLE
pyproperty -> pygetset

### DIFF
--- a/derive/src/pyclass.rs
+++ b/derive/src/pyclass.rs
@@ -33,7 +33,7 @@ impl std::fmt::Display for AttrName {
             Self::Method => "pymethod",
             Self::ClassMethod => "pyclassmethod",
             Self::StaticMethod => "pystaticmethod",
-            Self::GetSet => "pyproperty",
+            Self::GetSet => "pygetset",
             Self::Slot => "pyslot",
             Self::Attr => "pyattr",
             Self::ExtendClass => "extend_class",
@@ -50,7 +50,7 @@ impl FromStr for AttrName {
             "pymethod" => Self::Method,
             "pyclassmethod" => Self::ClassMethod,
             "pystaticmethod" => Self::StaticMethod,
-            "pyproperty" => Self::GetSet,
+            "pygetset" => Self::GetSet,
             "pyslot" => Self::Slot,
             "pyattr" => Self::Attr,
             "extend_class" => Self::ExtendClass,
@@ -406,7 +406,7 @@ struct MethodItem {
     inner: ContentItemInner<AttrName>,
 }
 
-/// #[pyproperty]
+/// #[pygetset]
 struct GetSetItem {
     inner: ContentItemInner<AttrName>,
 }

--- a/derive/src/util.rs
+++ b/derive/src/util.rs
@@ -15,7 +15,7 @@ pub(crate) const ALL_ALLOWED_NAMES: &[&str] = &[
     "pymethod",
     "pyclassmethod",
     "pystaticmethod",
-    "pyproperty",
+    "pygetset",
     "pyfunction",
     "pyclass",
     "pyexception",

--- a/stdlib/src/array.rs
+++ b/stdlib/src/array.rs
@@ -686,14 +686,14 @@ mod array {
             self.array.write()
         }
 
-        #[pyproperty]
+        #[pygetset]
         fn typecode(&self, vm: &VirtualMachine) -> PyStrRef {
             vm.ctx
                 .intern_str(self.read().typecode().to_string())
                 .to_owned()
         }
 
-        #[pyproperty]
+        #[pygetset]
         fn itemsize(&self) -> usize {
             self.read().itemsize()
         }

--- a/stdlib/src/bz2.rs
+++ b/stdlib/src/bz2.rs
@@ -126,13 +126,13 @@ mod _bz2 {
             Ok(vm.ctx.new_bytes(buf.to_vec()))
         }
 
-        #[pyproperty]
+        #[pygetset]
         fn eof(&self) -> bool {
             let state = self.state.lock();
             state.eof
         }
 
-        #[pyproperty]
+        #[pygetset]
         fn unused_data(&self, vm: &VirtualMachine) -> PyBytesRef {
             // Data found after the end of the compressed stream.
             // If this attribute is accessed before the end of the stream
@@ -152,7 +152,7 @@ mod _bz2 {
             // }
         }
 
-        #[pyproperty]
+        #[pygetset]
         fn needs_input(&self) -> bool {
             // False if the decompress() method can provide more
             // decompressed data before requiring new uncompressed input.

--- a/stdlib/src/contextvars.rs
+++ b/stdlib/src/contextvars.rs
@@ -101,7 +101,7 @@ mod _contextvars {
 
     #[pyclass(with(Initializer))]
     impl ContextVar {
-        #[pyproperty]
+        #[pygetset]
         fn name(&self) -> String {
             self.name.clone()
         }
@@ -174,12 +174,12 @@ mod _contextvars {
 
     #[pyclass(with(Initializer))]
     impl ContextToken {
-        #[pyproperty]
+        #[pygetset]
         fn var(&self, _vm: &VirtualMachine) -> PyObjectRef {
             unimplemented!("Token.var() is currently under construction")
         }
 
-        #[pyproperty]
+        #[pygetset]
         fn old_value(&self, _vm: &VirtualMachine) -> PyObjectRef {
             unimplemented!("Token.old_value() is currently under construction")
         }

--- a/stdlib/src/hashlib.rs
+++ b/stdlib/src/hashlib.rs
@@ -80,12 +80,12 @@ mod hashlib {
             Ok(PyHasher::new("md5", HashWrapper::md5()).into_pyobject(vm))
         }
 
-        #[pyproperty]
+        #[pygetset]
         fn name(&self) -> String {
             self.name.clone()
         }
 
-        #[pyproperty]
+        #[pygetset]
         fn digest_size(&self) -> usize {
             self.read().digest_size()
         }

--- a/stdlib/src/mmap.rs
+++ b/stdlib/src/mmap.rs
@@ -541,7 +541,7 @@ mod mmap {
             ))
         }
 
-        #[pyproperty]
+        #[pygetset]
         fn closed(&self) -> bool {
             self.closed.load()
         }

--- a/stdlib/src/pystruct.rs
+++ b/stdlib/src/pystruct.rs
@@ -258,12 +258,12 @@ pub(crate) mod _struct {
 
     #[pyclass(with(Constructor))]
     impl PyStruct {
-        #[pyproperty]
+        #[pygetset]
         fn format(&self) -> PyStrRef {
             self.format.clone()
         }
 
-        #[pyproperty]
+        #[pygetset]
         #[inline]
         fn size(&self) -> usize {
             self.spec.size

--- a/stdlib/src/re.rs
+++ b/stdlib/src/re.rs
@@ -343,7 +343,7 @@ mod re {
             self.sub(repl, text, vm)
         }
 
-        #[pyproperty]
+        #[pygetset]
         fn pattern(&self, vm: &VirtualMachine) -> PyResult<PyStrRef> {
             Ok(vm.ctx.new_str(self.pattern.clone()))
         }

--- a/stdlib/src/socket.rs
+++ b/stdlib/src/socket.rs
@@ -1504,15 +1504,15 @@ mod _socket {
             Ok(self.sock()?.shutdown(how)?)
         }
 
-        #[pyproperty(name = "type")]
+        #[pygetset(name = "type")]
         fn kind(&self) -> i32 {
             self.kind.load()
         }
-        #[pyproperty]
+        #[pygetset]
         fn family(&self) -> i32 {
             self.family.load()
         }
-        #[pyproperty]
+        #[pygetset]
         fn proto(&self) -> i32 {
             self.proto.load()
         }

--- a/stdlib/src/ssl.rs
+++ b/stdlib/src/ssl.rs
@@ -512,11 +512,11 @@ mod _ssl {
             func(builder_as_ctx(&c))
         }
 
-        #[pyproperty]
+        #[pygetset]
         fn post_handshake_auth(&self) -> bool {
             *self.post_handshake_auth.lock()
         }
-        #[pyproperty(setter)]
+        #[pygetset(setter)]
         fn set_post_handshake_auth(
             &self,
             value: Option<PyObjectRef>,
@@ -539,20 +539,20 @@ mod _ssl {
             })
         }
 
-        #[pyproperty]
+        #[pygetset]
         fn options(&self) -> libc::c_ulong {
             self.ctx.read().options().bits()
         }
-        #[pyproperty(setter)]
+        #[pygetset(setter)]
         fn set_options(&self, opts: libc::c_ulong) {
             self.builder()
                 .set_options(SslOptions::from_bits_truncate(opts));
         }
-        #[pyproperty]
+        #[pygetset]
         fn protocol(&self) -> i32 {
             self.protocol as i32
         }
-        #[pyproperty]
+        #[pygetset]
         fn verify_mode(&self) -> i32 {
             let mode = self.exec_ctx(|ctx| ctx.verify_mode());
             if mode == SslVerifyMode::NONE {
@@ -565,7 +565,7 @@ mod _ssl {
                 unreachable!()
             }
         }
-        #[pyproperty(setter)]
+        #[pygetset(setter)]
         fn set_verify_mode(&self, cert: i32, vm: &VirtualMachine) -> PyResult<()> {
             let mut ctx = self.builder();
             let cert_req = CertRequirements::try_from(cert)
@@ -586,11 +586,11 @@ mod _ssl {
             ctx.set_verify(mode);
             Ok(())
         }
-        #[pyproperty]
+        #[pygetset]
         fn check_hostname(&self) -> bool {
             self.check_hostname.load()
         }
-        #[pyproperty(setter)]
+        #[pygetset(setter)]
         fn set_check_hostname(&self, ch: bool) {
             let mut ctx = self.builder();
             if ch && builder_as_ctx(&ctx).verify_mode() == SslVerifyMode::NONE {
@@ -923,26 +923,26 @@ mod _ssl {
 
     #[pyclass]
     impl PySslSocket {
-        #[pyproperty]
+        #[pygetset]
         fn owner(&self) -> Option<PyObjectRef> {
             self.owner.read().as_ref().and_then(|weak| weak.upgrade())
         }
-        #[pyproperty(setter)]
+        #[pygetset(setter)]
         fn set_owner(&self, owner: PyObjectRef, vm: &VirtualMachine) -> PyResult<()> {
             let mut lock = self.owner.write();
             lock.take();
             *lock = Some(owner.downgrade(None, vm)?);
             Ok(())
         }
-        #[pyproperty]
+        #[pygetset]
         fn server_side(&self) -> bool {
             self.socket_type == SslServerOrClient::Server
         }
-        #[pyproperty]
+        #[pygetset]
         fn context(&self) -> PyRef<PySslContext> {
             self.ctx.clone()
         }
-        #[pyproperty]
+        #[pygetset]
         fn server_hostname(&self) -> Option<PyStrRef> {
             self.server_hostname.clone()
         }

--- a/stdlib/src/unicodedata.rs
+++ b/stdlib/src/unicodedata.rs
@@ -132,7 +132,7 @@ mod unicodedata {
             Ok(normalized_text)
         }
 
-        #[pyproperty]
+        #[pygetset]
         fn unidata_version(&self) -> String {
             self.unic_version.to_string()
         }

--- a/stdlib/src/zlib.rs
+++ b/stdlib/src/zlib.rs
@@ -290,15 +290,15 @@ mod zlib {
     }
     #[pyclass]
     impl PyDecompress {
-        #[pyproperty]
+        #[pygetset]
         fn eof(&self) -> bool {
             self.eof.load()
         }
-        #[pyproperty]
+        #[pygetset]
         fn unused_data(&self) -> PyBytesRef {
             self.unused_data.lock().clone()
         }
-        #[pyproperty]
+        #[pygetset]
         fn unconsumed_tail(&self) -> PyBytesRef {
             self.unconsumed_tail.lock().clone()
         }

--- a/vm/src/builtins/asyncgenerator.rs
+++ b/vm/src/builtins/asyncgenerator.rs
@@ -39,12 +39,12 @@ impl PyAsyncGen {
         }
     }
 
-    #[pyproperty(magic)]
+    #[pygetset(magic)]
     fn name(&self) -> PyStrRef {
         self.inner.name()
     }
 
-    #[pyproperty(magic, setter)]
+    #[pygetset(magic, setter)]
     fn set_name(&self, name: PyStrRef) {
         self.inner.set_name(name)
     }
@@ -107,19 +107,19 @@ impl PyAsyncGen {
         }
     }
 
-    #[pyproperty]
+    #[pygetset]
     fn ag_await(&self, _vm: &VirtualMachine) -> Option<PyObjectRef> {
         self.inner.frame().yield_from_target()
     }
-    #[pyproperty]
+    #[pygetset]
     fn ag_frame(&self, _vm: &VirtualMachine) -> FrameRef {
         self.inner.frame()
     }
-    #[pyproperty]
+    #[pygetset]
     fn ag_running(&self, _vm: &VirtualMachine) -> bool {
         self.inner.running()
     }
-    #[pyproperty]
+    #[pygetset]
     fn ag_code(&self, _vm: &VirtualMachine) -> PyRef<PyCode> {
         self.inner.frame().code.clone()
     }

--- a/vm/src/builtins/builtinfunc.rs
+++ b/vm/src/builtins/builtinfunc.rs
@@ -116,23 +116,23 @@ impl Callable for PyBuiltinFunction {
 
 #[pyclass(with(Callable, Constructor), flags(HAS_DICT))]
 impl PyBuiltinFunction {
-    #[pyproperty(magic)]
+    #[pygetset(magic)]
     fn module(&self, vm: &VirtualMachine) -> PyObjectRef {
         vm.unwrap_or_none(self.module.clone())
     }
-    #[pyproperty(magic)]
+    #[pygetset(magic)]
     fn name(&self) -> PyStrRef {
         self.value.name.clone()
     }
-    #[pyproperty(magic)]
+    #[pygetset(magic)]
     fn qualname(&self) -> PyStrRef {
         self.name()
     }
-    #[pyproperty(magic)]
+    #[pygetset(magic)]
     fn doc(&self) -> Option<PyStrRef> {
         self.value.doc.clone()
     }
-    #[pyproperty(name = "__self__")]
+    #[pygetset(name = "__self__")]
     fn get_self(&self, vm: &VirtualMachine) -> PyObjectRef {
         vm.ctx.none()
     }
@@ -149,7 +149,7 @@ impl PyBuiltinFunction {
     fn repr(&self) -> String {
         format!("<built-in function {}>", self.value.name)
     }
-    #[pyproperty(magic)]
+    #[pygetset(magic)]
     fn text_signature(&self) -> Option<String> {
         self.value.doc.as_ref().and_then(|doc| {
             type_::get_text_signature_from_internal_doc(self.value.name.as_str(), doc.as_str())
@@ -227,19 +227,19 @@ impl PyBuiltinMethod {
 
 #[pyclass(with(GetDescriptor, Callable, Constructor), flags(METHOD_DESCR))]
 impl PyBuiltinMethod {
-    #[pyproperty(magic)]
+    #[pygetset(magic)]
     fn name(&self) -> PyStrRef {
         self.value.name.clone()
     }
-    #[pyproperty(magic)]
+    #[pygetset(magic)]
     fn qualname(&self) -> String {
         format!("{}.{}", self.class.name(), &self.value.name)
     }
-    #[pyproperty(magic)]
+    #[pygetset(magic)]
     fn doc(&self) -> Option<PyStrRef> {
         self.value.doc.clone()
     }
-    #[pyproperty(magic)]
+    #[pygetset(magic)]
     fn text_signature(&self) -> Option<String> {
         self.value.doc.as_ref().and_then(|doc| {
             type_::get_text_signature_from_internal_doc(self.value.name.as_str(), doc.as_str())

--- a/vm/src/builtins/bytearray.rs
+++ b/vm/src/builtins/bytearray.rs
@@ -107,7 +107,7 @@ pub(crate) fn init(context: &Context) {
 )]
 impl PyByteArray {
     #[cfg(debug_assertions)]
-    #[pyproperty]
+    #[pygetset]
     fn exports(&self) -> usize {
         self.exports.load(Ordering::Relaxed)
     }

--- a/vm/src/builtins/classmethod.rs
+++ b/vm/src/builtins/classmethod.rs
@@ -106,32 +106,32 @@ impl PyClassMethod {
 
 #[pyclass(with(GetDescriptor, Constructor), flags(BASETYPE, HAS_DICT))]
 impl PyClassMethod {
-    #[pyproperty(magic)]
+    #[pygetset(magic)]
     fn func(&self) -> PyObjectRef {
         self.callable.lock().clone()
     }
 
-    #[pyproperty(magic)]
+    #[pygetset(magic)]
     fn wrapped(&self) -> PyObjectRef {
         self.callable.lock().clone()
     }
 
-    #[pyproperty(magic)]
+    #[pygetset(magic)]
     fn module(&self, vm: &VirtualMachine) -> PyResult {
         self.callable.lock().get_attr("__module__", vm)
     }
 
-    #[pyproperty(magic)]
+    #[pygetset(magic)]
     fn qualname(&self, vm: &VirtualMachine) -> PyResult {
         self.callable.lock().get_attr("__qualname__", vm)
     }
 
-    #[pyproperty(magic)]
+    #[pygetset(magic)]
     fn name(&self, vm: &VirtualMachine) -> PyResult {
         self.callable.lock().get_attr("__name__", vm)
     }
 
-    #[pyproperty(magic)]
+    #[pygetset(magic)]
     fn annotations(&self, vm: &VirtualMachine) -> PyResult {
         self.callable.lock().get_attr("__annotations__", vm)
     }
@@ -156,7 +156,7 @@ impl PyClassMethod {
         }
     }
 
-    #[pyproperty(magic)]
+    #[pygetset(magic)]
     fn isabstractmethod(&self, vm: &VirtualMachine) -> PyObjectRef {
         match vm.get_attribute_opt(self.callable.lock().clone(), "__isabstractmethod__") {
             Ok(Some(is_abstract)) => is_abstract,
@@ -164,7 +164,7 @@ impl PyClassMethod {
         }
     }
 
-    #[pyproperty(magic, setter)]
+    #[pygetset(magic, setter)]
     fn set_isabstractmethod(&self, value: PyObjectRef, vm: &VirtualMachine) -> PyResult<()> {
         self.callable
             .lock()

--- a/vm/src/builtins/code.rs
+++ b/vm/src/builtins/code.rs
@@ -179,48 +179,48 @@ impl PyRef<PyCode> {
         )
     }
 
-    #[pyproperty]
+    #[pygetset]
     fn co_posonlyargcount(self) -> usize {
         self.code.posonlyarg_count
     }
 
-    #[pyproperty]
+    #[pygetset]
     fn co_argcount(self) -> usize {
         self.code.arg_count
     }
 
-    #[pyproperty]
+    #[pygetset]
     pub fn co_filename(self) -> PyStrRef {
         self.code.source_path.to_owned()
     }
 
-    #[pyproperty]
+    #[pygetset]
     fn co_firstlineno(self) -> usize {
         self.code.first_line_number
     }
 
-    #[pyproperty]
+    #[pygetset]
     fn co_kwonlyargcount(self) -> usize {
         self.code.kwonlyarg_count
     }
 
-    #[pyproperty]
+    #[pygetset]
     fn co_consts(self, vm: &VirtualMachine) -> PyTupleRef {
         let consts = self.code.constants.iter().map(|x| x.0.clone()).collect();
         vm.ctx.new_tuple(consts)
     }
 
-    #[pyproperty]
+    #[pygetset]
     fn co_name(self) -> PyStrRef {
         self.code.obj_name.to_owned()
     }
 
-    #[pyproperty]
+    #[pygetset]
     fn co_flags(self) -> u16 {
         self.code.flags.bits()
     }
 
-    #[pyproperty]
+    #[pygetset]
     pub fn co_varnames(self, vm: &VirtualMachine) -> PyTupleRef {
         let varnames = self.code.varnames.iter().map(|s| s.to_object()).collect();
         vm.ctx.new_tuple(varnames)

--- a/vm/src/builtins/complex.rs
+++ b/vm/src/builtins/complex.rs
@@ -217,12 +217,12 @@ impl PyComplex {
         }
     }
 
-    #[pyproperty]
+    #[pygetset]
     fn real(&self) -> f64 {
         self.value.re
     }
 
-    #[pyproperty]
+    #[pygetset]
     fn imag(&self) -> f64 {
         self.value.im
     }

--- a/vm/src/builtins/coroutine.rs
+++ b/vm/src/builtins/coroutine.rs
@@ -34,12 +34,12 @@ impl PyCoroutine {
         }
     }
 
-    #[pyproperty(magic)]
+    #[pygetset(magic)]
     fn name(&self) -> PyStrRef {
         self.inner.name()
     }
 
-    #[pyproperty(magic, setter)]
+    #[pygetset(magic, setter)]
     fn set_name(&self, name: PyStrRef) {
         self.inner.set_name(name)
     }
@@ -81,25 +81,25 @@ impl PyCoroutine {
         PyCoroutineWrapper { coro: zelf }
     }
 
-    #[pyproperty]
+    #[pygetset]
     fn cr_await(&self, _vm: &VirtualMachine) -> Option<PyObjectRef> {
         self.inner.frame().yield_from_target()
     }
-    #[pyproperty]
+    #[pygetset]
     fn cr_frame(&self, _vm: &VirtualMachine) -> FrameRef {
         self.inner.frame()
     }
-    #[pyproperty]
+    #[pygetset]
     fn cr_running(&self, _vm: &VirtualMachine) -> bool {
         self.inner.running()
     }
-    #[pyproperty]
+    #[pygetset]
     fn cr_code(&self, _vm: &VirtualMachine) -> PyRef<PyCode> {
         self.inner.frame().code.clone()
     }
     // TODO: coroutine origin tracking:
     // https://docs.python.org/3/library/sys.html#sys.set_coroutine_origin_tracking_depth
-    #[pyproperty]
+    #[pygetset]
     fn cr_origin(&self, _vm: &VirtualMachine) -> Option<(PyStrRef, usize, PyStrRef)> {
         None
     }

--- a/vm/src/builtins/descriptor.rs
+++ b/vm/src/builtins/descriptor.rs
@@ -110,12 +110,12 @@ impl MemberDescrObject {
         )
     }
 
-    #[pyproperty(magic)]
+    #[pygetset(magic)]
     fn doc(zelf: PyRef<Self>) -> Option<String> {
         zelf.member.doc.to_owned()
     }
 
-    #[pyproperty(magic)]
+    #[pygetset(magic)]
     fn qualname(&self, vm: &VirtualMachine) -> PyResult<Option<String>> {
         let qualname = self.common.qualname.read();
         Ok(if qualname.is_none() {

--- a/vm/src/builtins/dict.rs
+++ b/vm/src/builtins/dict.rs
@@ -1032,7 +1032,7 @@ impl PyDictKeys {
         zelf.dict().contains(key, vm)
     }
 
-    #[pyproperty]
+    #[pygetset]
     fn mapping(zelf: PyRef<Self>) -> PyMappingProxy {
         PyMappingProxy::from(zelf.dict().clone())
     }
@@ -1085,7 +1085,7 @@ impl PyDictItems {
         let found = PyDict::getitem(zelf.dict().clone(), key, vm)?;
         vm.identical_or_equal(&found, &value)
     }
-    #[pyproperty]
+    #[pygetset]
     fn mapping(zelf: PyRef<Self>) -> PyMappingProxy {
         PyMappingProxy::from(zelf.dict().clone())
     }
@@ -1118,7 +1118,7 @@ impl AsSequence for PyDictItems {
 
 #[pyclass(with(DictView, Constructor, Iterable, AsSequence))]
 impl PyDictValues {
-    #[pyproperty]
+    #[pygetset]
     fn mapping(zelf: PyRef<Self>) -> PyMappingProxy {
         PyMappingProxy::from(zelf.dict().clone())
     }

--- a/vm/src/builtins/float.rs
+++ b/vm/src/builtins/float.rs
@@ -442,12 +442,12 @@ impl PyFloat {
         zelf
     }
 
-    #[pyproperty]
+    #[pygetset]
     fn real(zelf: PyRef<Self>) -> PyRef<Self> {
         zelf
     }
 
-    #[pyproperty]
+    #[pygetset]
     fn imag(&self) -> f64 {
         0.0f64
     }

--- a/vm/src/builtins/frame.rs
+++ b/vm/src/builtins/frame.rs
@@ -31,22 +31,22 @@ impl FrameRef {
         // TODO
     }
 
-    #[pyproperty]
+    #[pygetset]
     fn f_globals(self) -> PyDictRef {
         self.globals.clone()
     }
 
-    #[pyproperty]
+    #[pygetset]
     fn f_locals(self, vm: &VirtualMachine) -> PyResult {
         self.locals(vm).map(Into::into)
     }
 
-    #[pyproperty]
+    #[pygetset]
     pub fn f_code(self) -> PyRef<PyCode> {
         self.code.clone()
     }
 
-    #[pyproperty]
+    #[pygetset]
     pub fn f_back(self, vm: &VirtualMachine) -> Option<Self> {
         // TODO: actually store f_back inside Frame struct
 
@@ -61,23 +61,23 @@ impl FrameRef {
             .cloned()
     }
 
-    #[pyproperty]
+    #[pygetset]
     fn f_lasti(self) -> u32 {
         self.lasti()
     }
 
-    #[pyproperty]
+    #[pygetset]
     pub fn f_lineno(self) -> usize {
         self.current_location().row()
     }
 
-    #[pyproperty]
+    #[pygetset]
     fn f_trace(self) -> PyObjectRef {
         let boxed = self.trace.lock();
         boxed.clone()
     }
 
-    #[pyproperty(setter)]
+    #[pygetset(setter)]
     fn set_f_trace(self, value: PySetterValue, vm: &VirtualMachine) {
         let mut storage = self.trace.lock();
         *storage = value.unwrap_or_none(vm);

--- a/vm/src/builtins/function.rs
+++ b/vm/src/builtins/function.rs
@@ -330,25 +330,25 @@ impl PyPayload for PyFunction {
 
 #[pyclass(with(GetDescriptor, Callable), flags(HAS_DICT, METHOD_DESCR))]
 impl PyFunction {
-    #[pyproperty(magic)]
+    #[pygetset(magic)]
     fn code(&self) -> PyRef<PyCode> {
         self.code.clone()
     }
 
-    #[pyproperty(magic)]
+    #[pygetset(magic)]
     fn defaults(&self) -> Option<PyTupleRef> {
         self.defaults_and_kwdefaults.lock().0.clone()
     }
-    #[pyproperty(magic, setter)]
+    #[pygetset(magic, setter)]
     fn set_defaults(&self, defaults: Option<PyTupleRef>) {
         self.defaults_and_kwdefaults.lock().0 = defaults
     }
 
-    #[pyproperty(magic)]
+    #[pygetset(magic)]
     fn kwdefaults(&self) -> Option<PyDictRef> {
         self.defaults_and_kwdefaults.lock().1.clone()
     }
-    #[pyproperty(magic, setter)]
+    #[pygetset(magic, setter)]
     fn set_kwdefaults(&self, kwdefaults: Option<PyDictRef>) {
         self.defaults_and_kwdefaults.lock().1 = kwdefaults
     }
@@ -370,12 +370,12 @@ impl PyFunction {
         Ok(vm.unwrap_or_none(zelf.closure.clone().map(|x| x.to_pyobject(vm))))
     }
 
-    #[pyproperty(magic)]
+    #[pygetset(magic)]
     fn name(&self) -> PyStrRef {
         self.name.lock().clone()
     }
 
-    #[pyproperty(magic, setter)]
+    #[pygetset(magic, setter)]
     fn set_name(&self, name: PyStrRef) {
         *self.name.lock() = name;
     }
@@ -532,27 +532,27 @@ impl PyBoundMethod {
         ))
     }
 
-    #[pyproperty(magic)]
+    #[pygetset(magic)]
     fn doc(&self, vm: &VirtualMachine) -> PyResult {
         self.function.get_attr("__doc__", vm)
     }
 
-    #[pyproperty(magic)]
+    #[pygetset(magic)]
     fn func(&self) -> PyObjectRef {
         self.function.clone()
     }
 
-    #[pyproperty(name = "__self__")]
+    #[pygetset(name = "__self__")]
     fn get_self(&self) -> PyObjectRef {
         self.object.clone()
     }
 
-    #[pyproperty(magic)]
+    #[pygetset(magic)]
     fn module(&self, vm: &VirtualMachine) -> Option<PyObjectRef> {
         self.function.get_attr("__module__", vm).ok()
     }
 
-    #[pyproperty(magic)]
+    #[pygetset(magic)]
     fn qualname(&self, vm: &VirtualMachine) -> PyResult {
         if self
             .function
@@ -619,12 +619,12 @@ impl PyCell {
         *self.contents.lock() = x;
     }
 
-    #[pyproperty]
+    #[pygetset]
     fn cell_contents(&self, vm: &VirtualMachine) -> PyResult {
         self.get()
             .ok_or_else(|| vm.new_value_error("Cell is empty".to_owned()))
     }
-    #[pyproperty(setter)]
+    #[pygetset(setter)]
     fn set_cell_contents(&self, x: PyObjectRef) {
         self.set(Some(x))
     }

--- a/vm/src/builtins/generator.rs
+++ b/vm/src/builtins/generator.rs
@@ -37,12 +37,12 @@ impl PyGenerator {
         }
     }
 
-    #[pyproperty(magic)]
+    #[pygetset(magic)]
     fn name(&self) -> PyStrRef {
         self.inner.name()
     }
 
-    #[pyproperty(magic, setter)]
+    #[pygetset(magic, setter)]
     fn set_name(&self, name: PyStrRef) {
         self.inner.set_name(name)
     }
@@ -79,19 +79,19 @@ impl PyGenerator {
         zelf.inner.close(zelf.as_object(), vm)
     }
 
-    #[pyproperty]
+    #[pygetset]
     fn gi_frame(&self, _vm: &VirtualMachine) -> FrameRef {
         self.inner.frame()
     }
-    #[pyproperty]
+    #[pygetset]
     fn gi_running(&self, _vm: &VirtualMachine) -> bool {
         self.inner.running()
     }
-    #[pyproperty]
+    #[pygetset]
     fn gi_code(&self, _vm: &VirtualMachine) -> PyRef<PyCode> {
         self.inner.frame().code.clone()
     }
-    #[pyproperty]
+    #[pygetset]
     fn gi_yieldfrom(&self, _vm: &VirtualMachine) -> Option<PyObjectRef> {
         self.inner.frame().yield_from_target()
     }

--- a/vm/src/builtins/genericalias.rs
+++ b/vm/src/builtins/genericalias.rs
@@ -123,17 +123,17 @@ impl PyGenericAlias {
         ))
     }
 
-    #[pyproperty(magic)]
+    #[pygetset(magic)]
     fn parameters(&self) -> PyObjectRef {
         self.parameters.clone().into()
     }
 
-    #[pyproperty(magic)]
+    #[pygetset(magic)]
     fn args(&self) -> PyObjectRef {
         self.args.clone().into()
     }
 
-    #[pyproperty(magic)]
+    #[pygetset(magic)]
     fn origin(&self) -> PyObjectRef {
         self.origin.clone().into()
     }

--- a/vm/src/builtins/getset.rs
+++ b/vm/src/builtins/getset.rs
@@ -130,12 +130,12 @@ impl PyGetSet {
         Self::descr_set(zelf, obj, PySetterValue::Delete, vm)
     }
 
-    #[pyproperty(magic)]
+    #[pygetset(magic)]
     fn name(&self) -> String {
         self.name.clone()
     }
 
-    #[pyproperty(magic)]
+    #[pygetset(magic)]
     fn qualname(&self) -> String {
         format!("{}.{}", self.class.slot_name(), self.name.clone())
     }

--- a/vm/src/builtins/int.rs
+++ b/vm/src/builtins/int.rs
@@ -700,22 +700,22 @@ impl PyInt {
         vm.ctx.new_bigint(&zelf.value)
     }
 
-    #[pyproperty]
+    #[pygetset]
     fn real(zelf: PyRef<Self>, vm: &VirtualMachine) -> PyRef<Self> {
         Self::clone_if_subclass(zelf, vm)
     }
 
-    #[pyproperty]
+    #[pygetset]
     fn imag(&self) -> usize {
         0
     }
 
-    #[pyproperty]
+    #[pygetset]
     fn numerator(zelf: PyRef<Self>, vm: &VirtualMachine) -> PyRef<Self> {
         Self::clone_if_subclass(zelf, vm)
     }
 
-    #[pyproperty]
+    #[pygetset]
     fn denominator(&self) -> usize {
         1
     }

--- a/vm/src/builtins/memory.rs
+++ b/vm/src/builtins/memory.rs
@@ -155,32 +155,32 @@ impl PyMemoryView {
         }
     }
 
-    #[pyproperty]
+    #[pygetset]
     fn obj(&self, vm: &VirtualMachine) -> PyResult<PyObjectRef> {
         self.try_not_released(vm).map(|_| self.buffer.obj.clone())
     }
 
-    #[pyproperty]
+    #[pygetset]
     fn nbytes(&self, vm: &VirtualMachine) -> PyResult<usize> {
         self.try_not_released(vm).map(|_| self.desc.len)
     }
 
-    #[pyproperty]
+    #[pygetset]
     fn readonly(&self, vm: &VirtualMachine) -> PyResult<bool> {
         self.try_not_released(vm).map(|_| self.desc.readonly)
     }
 
-    #[pyproperty]
+    #[pygetset]
     fn itemsize(&self, vm: &VirtualMachine) -> PyResult<usize> {
         self.try_not_released(vm).map(|_| self.desc.itemsize)
     }
 
-    #[pyproperty]
+    #[pygetset]
     fn ndim(&self, vm: &VirtualMachine) -> PyResult<usize> {
         self.try_not_released(vm).map(|_| self.desc.ndim())
     }
 
-    #[pyproperty]
+    #[pygetset]
     fn shape(&self, vm: &VirtualMachine) -> PyResult<PyTupleRef> {
         self.try_not_released(vm)?;
         Ok(vm.ctx.new_tuple(
@@ -192,7 +192,7 @@ impl PyMemoryView {
         ))
     }
 
-    #[pyproperty]
+    #[pygetset]
     fn strides(&self, vm: &VirtualMachine) -> PyResult<PyTupleRef> {
         self.try_not_released(vm)?;
         Ok(vm.ctx.new_tuple(
@@ -204,7 +204,7 @@ impl PyMemoryView {
         ))
     }
 
-    #[pyproperty]
+    #[pygetset]
     fn suboffsets(&self, vm: &VirtualMachine) -> PyResult<PyTupleRef> {
         self.try_not_released(vm)?;
         Ok(vm.ctx.new_tuple(
@@ -216,23 +216,23 @@ impl PyMemoryView {
         ))
     }
 
-    #[pyproperty]
+    #[pygetset]
     fn format(&self, vm: &VirtualMachine) -> PyResult<PyStr> {
         self.try_not_released(vm)
             .map(|_| PyStr::from(self.desc.format.clone()))
     }
 
-    #[pyproperty]
+    #[pygetset]
     fn contiguous(&self, vm: &VirtualMachine) -> PyResult<bool> {
         self.try_not_released(vm).map(|_| self.desc.is_contiguous())
     }
 
-    #[pyproperty]
+    #[pygetset]
     fn c_contiguous(&self, vm: &VirtualMachine) -> PyResult<bool> {
         self.try_not_released(vm).map(|_| self.desc.is_contiguous())
     }
 
-    #[pyproperty]
+    #[pygetset]
     fn f_contiguous(&self, vm: &VirtualMachine) -> PyResult<bool> {
         // TODO: fortain order
         self.try_not_released(vm)

--- a/vm/src/builtins/object.rs
+++ b/vm/src/builtins/object.rs
@@ -259,12 +259,12 @@ impl PyBaseObject {
         Ok(())
     }
 
-    #[pyproperty(name = "__class__")]
+    #[pygetset(name = "__class__")]
     fn get_class(obj: PyObjectRef) -> PyTypeRef {
         obj.class().clone()
     }
 
-    #[pyproperty(name = "__class__", setter)]
+    #[pygetset(name = "__class__", setter)]
     fn set_class(instance: PyObjectRef, value: PyObjectRef, vm: &VirtualMachine) -> PyResult<()> {
         if instance.payload_is::<PyBaseObject>() {
             match value.downcast::<PyType>() {

--- a/vm/src/builtins/property.rs
+++ b/vm/src/builtins/property.rs
@@ -132,17 +132,17 @@ impl PyProperty {
 
     // Access functions
 
-    #[pyproperty]
+    #[pygetset]
     fn fget(&self) -> Option<PyObjectRef> {
         self.getter.read().clone()
     }
 
-    #[pyproperty]
+    #[pygetset]
     fn fset(&self) -> Option<PyObjectRef> {
         self.setter.read().clone()
     }
 
-    #[pyproperty]
+    #[pygetset]
     fn fdel(&self) -> Option<PyObjectRef> {
         self.deleter.read().clone()
     }
@@ -201,7 +201,7 @@ impl PyProperty {
         .into_ref_with_type(vm, zelf.class().clone())
     }
 
-    #[pyproperty(magic)]
+    #[pygetset(magic)]
     fn isabstractmethod(&self, vm: &VirtualMachine) -> PyObjectRef {
         let getter_abstract = match self.getter.read().to_owned() {
             Some(getter) => getter
@@ -219,7 +219,7 @@ impl PyProperty {
             .unwrap_or_else(|_| vm.ctx.new_bool(false).into())
     }
 
-    #[pyproperty(magic, setter)]
+    #[pygetset(magic, setter)]
     fn set_isabstractmethod(&self, value: PyObjectRef, vm: &VirtualMachine) -> PyResult<()> {
         if let Some(getter) = self.getter.read().to_owned() {
             getter.set_attr("__isabstractmethod__", value, vm)?;

--- a/vm/src/builtins/range.rs
+++ b/vm/src/builtins/range.rs
@@ -209,17 +209,17 @@ impl PyRange {
         .into_ref_with_type(vm, cls)
     }
 
-    #[pyproperty]
+    #[pygetset]
     fn start(&self) -> PyIntRef {
         self.start.clone()
     }
 
-    #[pyproperty]
+    #[pygetset]
     fn stop(&self) -> PyIntRef {
         self.stop.clone()
     }
 
-    #[pyproperty]
+    #[pygetset]
     fn step(&self) -> PyIntRef {
         self.step.clone()
     }

--- a/vm/src/builtins/slice.rs
+++ b/vm/src/builtins/slice.rs
@@ -27,7 +27,7 @@ impl PyPayload for PySlice {
 
 #[pyclass(with(Hashable, Comparable))]
 impl PySlice {
-    #[pyproperty]
+    #[pygetset]
     fn start(&self, vm: &VirtualMachine) -> PyObjectRef {
         self.start.clone().to_pyobject(vm)
     }
@@ -39,12 +39,12 @@ impl PySlice {
         }
     }
 
-    #[pyproperty]
+    #[pygetset]
     pub(crate) fn stop(&self, _vm: &VirtualMachine) -> PyObjectRef {
         self.stop.clone()
     }
 
-    #[pyproperty]
+    #[pygetset]
     fn step(&self, vm: &VirtualMachine) -> PyObjectRef {
         self.step.clone().to_pyobject(vm)
     }

--- a/vm/src/builtins/staticmethod.rs
+++ b/vm/src/builtins/staticmethod.rs
@@ -108,32 +108,32 @@ impl Initializer for PyStaticMethod {
     flags(BASETYPE, HAS_DICT)
 )]
 impl PyStaticMethod {
-    #[pyproperty(magic)]
+    #[pygetset(magic)]
     fn func(&self) -> PyObjectRef {
         self.callable.lock().clone()
     }
 
-    #[pyproperty(magic)]
+    #[pygetset(magic)]
     fn wrapped(&self) -> PyObjectRef {
         self.callable.lock().clone()
     }
 
-    #[pyproperty(magic)]
+    #[pygetset(magic)]
     fn module(&self, vm: &VirtualMachine) -> PyResult {
         self.callable.lock().get_attr("__module__", vm)
     }
 
-    #[pyproperty(magic)]
+    #[pygetset(magic)]
     fn qualname(&self, vm: &VirtualMachine) -> PyResult {
         self.callable.lock().get_attr("__qualname__", vm)
     }
 
-    #[pyproperty(magic)]
+    #[pygetset(magic)]
     fn name(&self, vm: &VirtualMachine) -> PyResult {
         self.callable.lock().get_attr("__name__", vm)
     }
 
-    #[pyproperty(magic)]
+    #[pygetset(magic)]
     fn annotations(&self, vm: &VirtualMachine) -> PyResult {
         self.callable.lock().get_attr("__annotations__", vm)
     }
@@ -158,7 +158,7 @@ impl PyStaticMethod {
         }
     }
 
-    #[pyproperty(magic)]
+    #[pygetset(magic)]
     fn isabstractmethod(&self, vm: &VirtualMachine) -> PyObjectRef {
         match vm.get_attribute_opt(self.callable.lock().clone(), "__isabstractmethod__") {
             Ok(Some(is_abstract)) => is_abstract,
@@ -166,7 +166,7 @@ impl PyStaticMethod {
         }
     }
 
-    #[pyproperty(magic, setter)]
+    #[pygetset(magic, setter)]
     fn set_isabstractmethod(&self, value: PyObjectRef, vm: &VirtualMachine) -> PyResult<()> {
         self.callable
             .lock()

--- a/vm/src/builtins/super.rs
+++ b/vm/src/builtins/super.rs
@@ -109,17 +109,17 @@ impl PySuper {
         Ok(Self { typ, obj })
     }
 
-    #[pyproperty(magic)]
+    #[pygetset(magic)]
     fn thisclass(&self) -> PyTypeRef {
         self.typ.clone()
     }
 
-    #[pyproperty(magic)]
+    #[pygetset(magic)]
     fn self_class(&self) -> Option<PyTypeRef> {
         Some(self.obj.as_ref()?.1.clone())
     }
 
-    #[pyproperty]
+    #[pygetset]
     fn __self__(&self) -> Option<PyObjectRef> {
         Some(self.obj.as_ref()?.0.clone())
     }

--- a/vm/src/builtins/traceback.rs
+++ b/vm/src/builtins/traceback.rs
@@ -31,27 +31,27 @@ impl PyTraceback {
         }
     }
 
-    #[pyproperty]
+    #[pygetset]
     fn tb_frame(&self) -> FrameRef {
         self.frame.clone()
     }
 
-    #[pyproperty]
+    #[pygetset]
     fn tb_lasti(&self) -> u32 {
         self.lasti
     }
 
-    #[pyproperty]
+    #[pygetset]
     fn tb_lineno(&self) -> usize {
         self.lineno
     }
 
-    #[pyproperty]
+    #[pygetset]
     fn tb_next(&self) -> Option<PyRef<Self>> {
         self.next.lock().as_ref().cloned()
     }
 
-    #[pyproperty(setter)]
+    #[pygetset(setter)]
     fn set_tb_next(&self, value: Option<PyRef<Self>>) {
         *self.next.lock() = value;
     }

--- a/vm/src/builtins/type.rs
+++ b/vm/src/builtins/type.rs
@@ -321,14 +321,14 @@ impl PyType {
         call_slot_new(zelf, subtype, args, vm)
     }
 
-    #[pyproperty(name = "__mro__")]
+    #[pygetset(name = "__mro__")]
     fn get_mro(zelf: PyRef<Self>) -> PyTuple {
         let elements: Vec<PyObjectRef> =
             zelf.iter_mro().map(|x| x.as_object().to_owned()).collect();
         PyTuple::new_unchecked(elements.into_boxed_slice())
     }
 
-    #[pyproperty(magic)]
+    #[pygetset(magic)]
     fn bases(&self, vm: &VirtualMachine) -> PyTupleRef {
         vm.ctx.new_tuple(
             self.bases
@@ -338,12 +338,12 @@ impl PyType {
         )
     }
 
-    #[pyproperty(magic)]
+    #[pygetset(magic)]
     fn base(&self) -> Option<PyTypeRef> {
         self.base.clone()
     }
 
-    #[pyproperty(magic)]
+    #[pygetset(magic)]
     fn flags(&self) -> u64 {
         self.slots.flags.bits()
     }
@@ -373,7 +373,7 @@ impl PyType {
         vm.ctx.not_implemented()
     }
 
-    #[pyproperty]
+    #[pygetset]
     fn __name__(&self) -> String {
         self.name().to_string()
     }
@@ -411,7 +411,7 @@ impl PyType {
         }
     }
 
-    #[pyproperty(magic)]
+    #[pygetset(magic)]
     pub fn qualname(&self, vm: &VirtualMachine) -> PyObjectRef {
         self.attributes
             .read()
@@ -428,7 +428,7 @@ impl PyType {
             .unwrap_or_else(|| vm.ctx.new_str(self.name().deref()).into())
     }
 
-    #[pyproperty(magic, setter)]
+    #[pygetset(magic, setter)]
     fn set_qualname(&self, value: PySetterValue, vm: &VirtualMachine) -> PyResult<()> {
         // TODO: we should replace heaptype flag check to immutable flag check
         if !self.slots.flags.has_feature(PyTypeFlags::HEAPTYPE) {
@@ -456,7 +456,7 @@ impl PyType {
         Ok(())
     }
 
-    #[pyproperty(magic)]
+    #[pygetset(magic)]
     pub fn module(&self, vm: &VirtualMachine) -> PyObjectRef {
         self.attributes
             .read()
@@ -473,7 +473,7 @@ impl PyType {
             .unwrap_or_else(|| vm.ctx.new_str(ascii!("builtins")).into())
     }
 
-    #[pyproperty(magic, setter)]
+    #[pygetset(magic, setter)]
     fn set_module(&self, value: PyObjectRef, vm: &VirtualMachine) {
         self.attributes
             .write()
@@ -758,19 +758,19 @@ impl PyType {
         Ok(typ.into())
     }
 
-    #[pyproperty(magic)]
+    #[pygetset(magic)]
     fn dict(zelf: PyRef<Self>) -> PyMappingProxy {
         PyMappingProxy::from(zelf)
     }
 
-    #[pyproperty(magic, setter)]
+    #[pygetset(magic, setter)]
     fn set_dict(&self, _value: PyObjectRef, vm: &VirtualMachine) -> PyResult<()> {
         Err(vm.new_not_implemented_error(
             "Setting __dict__ attribute on a type isn't yet implemented".to_owned(),
         ))
     }
 
-    #[pyproperty(magic, setter)]
+    #[pygetset(magic, setter)]
     fn set_name(&self, value: PyObjectRef, vm: &VirtualMachine) -> PyResult<()> {
         if !self.slots.flags.has_feature(PyTypeFlags::HEAPTYPE) {
             return Err(vm.new_type_error(format!(
@@ -793,7 +793,7 @@ impl PyType {
         Ok(())
     }
 
-    #[pyproperty(magic)]
+    #[pygetset(magic)]
     fn text_signature(&self) -> Option<String> {
         self.slots
             .doc

--- a/vm/src/builtins/union.rs
+++ b/vm/src/builtins/union.rs
@@ -79,12 +79,12 @@ impl PyUnion {
             .join(" | "))
     }
 
-    #[pyproperty(magic)]
+    #[pygetset(magic)]
     fn parameters(&self) -> PyObjectRef {
         self.parameters.clone().into()
     }
 
-    #[pyproperty(magic)]
+    #[pygetset(magic)]
     fn args(&self) -> PyObjectRef {
         self.args.clone().into()
     }

--- a/vm/src/exceptions.rs
+++ b/vm/src/exceptions.rs
@@ -443,56 +443,56 @@ impl PyBaseException {
         self.args.read().get(idx).cloned()
     }
 
-    #[pyproperty]
+    #[pygetset]
     pub fn args(&self) -> PyTupleRef {
         self.args.read().clone()
     }
 
-    #[pyproperty(setter)]
+    #[pygetset(setter)]
     fn set_args(&self, args: ArgIterable, vm: &VirtualMachine) -> PyResult<()> {
         let args = args.iter(vm)?.collect::<PyResult<Vec<_>>>()?;
         *self.args.write() = PyTuple::new_ref(args, &vm.ctx);
         Ok(())
     }
 
-    #[pyproperty(magic)]
+    #[pygetset(magic)]
     pub fn traceback(&self) -> Option<PyTracebackRef> {
         self.traceback.read().clone()
     }
 
-    #[pyproperty(magic, setter)]
+    #[pygetset(magic, setter)]
     pub fn set_traceback(&self, traceback: Option<PyTracebackRef>) {
         *self.traceback.write() = traceback;
     }
 
-    #[pyproperty(magic)]
+    #[pygetset(magic)]
     pub fn cause(&self) -> Option<PyRef<Self>> {
         self.cause.read().clone()
     }
 
-    #[pyproperty(magic, setter)]
+    #[pygetset(magic, setter)]
     pub fn set_cause(&self, cause: Option<PyRef<Self>>) {
         let mut c = self.cause.write();
         self.set_suppress_context(true);
         *c = cause;
     }
 
-    #[pyproperty(magic)]
+    #[pygetset(magic)]
     pub fn context(&self) -> Option<PyRef<Self>> {
         self.context.read().clone()
     }
 
-    #[pyproperty(magic, setter)]
+    #[pygetset(magic, setter)]
     pub fn set_context(&self, context: Option<PyRef<Self>>) {
         *self.context.write() = context;
     }
 
-    #[pyproperty(name = "__suppress_context__")]
+    #[pygetset(name = "__suppress_context__")]
     pub(super) fn get_suppress_context(&self) -> bool {
         self.suppress_context.load()
     }
 
-    #[pyproperty(name = "__suppress_context__", setter)]
+    #[pygetset(name = "__suppress_context__", setter)]
     fn set_suppress_context(&self, suppress_context: bool) {
         self.suppress_context.store(suppress_context);
     }

--- a/vm/src/stdlib/collections.rs
+++ b/vm/src/stdlib/collections.rs
@@ -264,7 +264,7 @@ mod _collections {
             }
         }
 
-        #[pyproperty]
+        #[pygetset]
         fn maxlen(&self) -> Option<usize> {
             self.maxlen
         }

--- a/vm/src/stdlib/io.rs
+++ b/vm/src/stdlib/io.rs
@@ -444,7 +444,7 @@ mod _io {
             false
         }
 
-        #[pyproperty]
+        #[pygetset]
         fn closed(instance: PyObjectRef, vm: &VirtualMachine) -> PyResult {
             instance.get_attr("__closed", vm)
         }
@@ -706,7 +706,7 @@ mod _io {
 
     #[pyclass(flags(BASETYPE))]
     impl _TextIOBase {
-        #[pyproperty]
+        #[pygetset]
         fn encoding(_zelf: PyObjectRef, vm: &VirtualMachine) -> PyObjectRef {
             vm.ctx.none()
         }
@@ -1496,25 +1496,25 @@ mod _io {
         fn seekable(&self, vm: &VirtualMachine) -> PyResult {
             vm.call_method(self.lock(vm)?.check_init(vm)?, "seekable", ())
         }
-        #[pyproperty]
+        #[pygetset]
         fn raw(&self, vm: &VirtualMachine) -> PyResult<Option<PyObjectRef>> {
             Ok(self.lock(vm)?.raw.clone())
         }
-        #[pyproperty]
+        #[pygetset]
         fn closed(&self, vm: &VirtualMachine) -> PyResult {
             self.lock(vm)?
                 .check_init(vm)?
                 .to_owned()
                 .get_attr("closed", vm)
         }
-        #[pyproperty]
+        #[pygetset]
         fn name(&self, vm: &VirtualMachine) -> PyResult {
             self.lock(vm)?
                 .check_init(vm)?
                 .to_owned()
                 .get_attr("name", vm)
         }
-        #[pyproperty]
+        #[pygetset]
         fn mode(&self, vm: &VirtualMachine) -> PyResult {
             self.lock(vm)?
                 .check_init(vm)?
@@ -1837,7 +1837,7 @@ mod _io {
             true
         }
 
-        #[pyproperty]
+        #[pygetset]
         fn closed(&self, vm: &VirtualMachine) -> PyResult {
             self.write.closed(vm)
         }
@@ -2312,12 +2312,12 @@ mod _io {
             vm.call_method(&textio.buffer, "writable", ())
         }
 
-        #[pyproperty(name = "_CHUNK_SIZE")]
+        #[pygetset(name = "_CHUNK_SIZE")]
         fn chunksize(&self, vm: &VirtualMachine) -> PyResult<usize> {
             Ok(self.lock(vm)?.chunk_size)
         }
 
-        #[pyproperty(setter, name = "_CHUNK_SIZE")]
+        #[pygetset(setter, name = "_CHUNK_SIZE")]
         fn set_chunksize(
             &self,
             chunk_size: PySetterValue<usize>,
@@ -2571,16 +2571,16 @@ mod _io {
             Ok(cookie.build().to_pyobject(vm))
         }
 
-        #[pyproperty]
+        #[pygetset]
         fn name(&self, vm: &VirtualMachine) -> PyResult {
             let buffer = self.lock(vm)?.buffer.clone();
             buffer.get_attr("name", vm)
         }
-        #[pyproperty]
+        #[pygetset]
         fn encoding(&self, vm: &VirtualMachine) -> PyResult<PyStrRef> {
             Ok(self.lock(vm)?.encoding.clone())
         }
-        #[pyproperty]
+        #[pygetset]
         fn errors(&self, vm: &VirtualMachine) -> PyResult<PyStrRef> {
             Ok(self.lock(vm)?.errors.clone())
         }
@@ -2897,12 +2897,12 @@ mod _io {
             let close_res = vm.call_method(&buffer, "close", ()).map(drop);
             exeption_chain(flush_res, close_res)
         }
-        #[pyproperty]
+        #[pygetset]
         fn closed(&self, vm: &VirtualMachine) -> PyResult {
             let buffer = self.lock(vm)?.buffer.clone();
             buffer.get_attr("closed", vm)
         }
-        #[pyproperty]
+        #[pygetset]
         fn buffer(&self, vm: &VirtualMachine) -> PyResult {
             Ok(self.lock(vm)?.buffer.clone())
         }
@@ -3129,7 +3129,7 @@ mod _io {
             true
         }
 
-        #[pyproperty]
+        #[pygetset]
         fn closed(&self) -> bool {
             self.closed.load()
         }
@@ -3342,7 +3342,7 @@ mod _io {
             Ok(buffer.truncate(pos))
         }
 
-        #[pyproperty]
+        #[pygetset]
         fn closed(self) -> bool {
             self.closed.load()
         }
@@ -3919,12 +3919,12 @@ mod fileio {
 
     #[pyclass(with(DefaultConstructor, Initializer), flags(BASETYPE, HAS_DICT))]
     impl FileIO {
-        #[pyproperty]
+        #[pygetset]
         fn closed(&self) -> bool {
             self.fd.load() < 0
         }
 
-        #[pyproperty]
+        #[pygetset]
         fn closefd(&self) -> bool {
             self.closefd.load()
         }
@@ -3951,7 +3951,7 @@ mod fileio {
         fn writable(&self) -> bool {
             self.mode.load().contains(Mode::WRITABLE)
         }
-        #[pyproperty]
+        #[pygetset]
         fn mode(&self) -> &'static str {
             let mode = self.mode.load();
             if mode.contains(Mode::CREATED) {

--- a/vm/src/stdlib/os.rs
+++ b/vm/src/stdlib/os.rs
@@ -703,12 +703,12 @@ pub(super) mod _os {
 
     #[pyclass]
     impl DirEntry {
-        #[pyproperty]
+        #[pygetset]
         fn name(&self, vm: &VirtualMachine) -> PyResult {
             self.mode.process_path(self.entry.file_name(), vm)
         }
 
-        #[pyproperty]
+        #[pygetset]
         fn path(&self, vm: &VirtualMachine) -> PyResult {
             self.mode.process_path(self.entry.path(), vm)
         }

--- a/vm/src/stdlib/posix.rs
+++ b/vm/src/stdlib/posix.rs
@@ -536,7 +536,7 @@ pub mod module {
 
     #[pyclass(with(Constructor))]
     impl SchedParam {
-        #[pyproperty]
+        #[pygetset]
         fn sched_priority(&self, vm: &VirtualMachine) -> PyObjectRef {
             self.sched_priority.clone().to_pyobject(vm)
         }

--- a/vm/src/stdlib/sre.rs
+++ b/vm/src/stdlib/sre.rs
@@ -380,19 +380,19 @@ mod _sre {
             }
         }
 
-        #[pyproperty]
+        #[pygetset]
         fn flags(&self) -> u16 {
             self.flags.bits()
         }
-        #[pyproperty]
+        #[pygetset]
         fn groupindex(&self) -> PyDictRef {
             self.groupindex.clone()
         }
-        #[pyproperty]
+        #[pygetset]
         fn groups(&self) -> usize {
             self.groups
         }
-        #[pyproperty]
+        #[pygetset]
         fn pattern(&self) -> PyObjectRef {
             self.pattern.clone()
         }
@@ -553,15 +553,15 @@ mod _sre {
             }
         }
 
-        #[pyproperty]
+        #[pygetset]
         fn pos(&self) -> usize {
             self.pos
         }
-        #[pyproperty]
+        #[pygetset]
         fn endpos(&self) -> usize {
             self.endpos
         }
-        #[pyproperty]
+        #[pygetset]
         fn lastindex(&self) -> Option<isize> {
             if self.lastindex >= 0 {
                 Some(self.lastindex)
@@ -569,21 +569,21 @@ mod _sre {
                 None
             }
         }
-        #[pyproperty]
+        #[pygetset]
         fn lastgroup(&self) -> Option<PyStrRef> {
             self.lastindex
                 .to_usize()
                 .and_then(|i| self.pattern.indexgroup.get(i).cloned().flatten())
         }
-        #[pyproperty]
+        #[pygetset]
         fn re(&self) -> PyRef<Pattern> {
             self.pattern.clone()
         }
-        #[pyproperty]
+        #[pygetset]
         fn string(&self) -> PyObjectRef {
             self.string.clone()
         }
-        #[pyproperty]
+        #[pygetset]
         fn regs(&self, vm: &VirtualMachine) -> PyTupleRef {
             PyTuple::new_ref(
                 self.regs.iter().map(|&x| x.to_pyobject(vm)).collect(),
@@ -778,7 +778,7 @@ mod _sre {
 
     #[pyclass]
     impl SreScanner {
-        #[pyproperty]
+        #[pygetset]
         fn pattern(&self) -> PyRef<Pattern> {
             self.pattern.clone()
         }

--- a/wasm/lib/src/js_module.rs
+++ b/wasm/lib/src/js_module.rs
@@ -341,18 +341,18 @@ mod _js {
             })
         }
 
-        #[pyproperty]
+        #[pygetset]
         fn value(&self) -> Option<PyJsValueRef> {
             self.closure
                 .borrow()
                 .as_ref()
                 .map(|(_, jsval)| jsval.clone())
         }
-        #[pyproperty]
+        #[pygetset]
         fn destroyed(&self) -> bool {
             self.destroyed.get()
         }
-        #[pyproperty]
+        #[pygetset]
         fn detached(&self) -> bool {
             self.detached.get()
         }


### PR DESCRIPTION
Though it actually create a getset descriptor, we didn't change the name because its concept was a property for users. Now we have `pymember`, another property-like descriptor. So naming them under same level would be less confusing instead of telling everybody "it is a getset but we call it pyproperty"

cc @moreal 