### PR TITLE
Always insert `None` at `code_stack.constants`

### DIFF
--- a/compiler/codegen/src/compile.rs
+++ b/compiler/codegen/src/compile.rs
@@ -1107,6 +1107,10 @@ impl Compiler {
 
         let (doc_str, body) = split_doc(body);
 
+        self.current_codeinfo()
+            .constants
+            .insert_full(ConstantData::None);
+
         self.compile_statements(body)?;
 
         // Emit None at end:

--- a/compiler/codegen/src/compile.rs
+++ b/compiler/codegen/src/compile.rs
@@ -2126,6 +2126,11 @@ impl Compiler {
 
                 let name = "<lambda>".to_owned();
                 let mut funcflags = self.enter_function(&name, args)?;
+
+                self.current_codeinfo()
+                    .constants
+                    .insert_full(ConstantData::None);
+
                 self.compile_expression(body)?;
                 self.emit(Instruction::ReturnValue);
                 let code = self.pop_code_object();

--- a/extra_tests/snippets/code_co_consts.py
+++ b/extra_tests/snippets/code_co_consts.py
@@ -1,0 +1,31 @@
+from asyncio import sleep
+
+def f():
+    def g():
+        return 1
+
+    assert g.__code__.co_consts[0] == None
+    return 2
+
+assert f.__code__.co_consts[0] == None
+
+def generator():
+  yield 1
+  yield 2
+
+assert generator().gi_code.co_consts[0] == None
+
+async def async_f():
+  await sleep(1)
+  return 1
+
+assert async_f.__code__.co_consts[0] == None
+
+lambda_f = lambda: 0
+assert lambda_f.__code__.co_consts[0] == None
+
+class cls:
+    def f():
+        return 1
+
+assert cls().f.__code__.co_consts[0] == None


### PR DESCRIPTION
# Outline

Always insert `None` at `code_stack.constants`

## Expected Result (cpython)

```py
Python 3.10.6 (main, Aug 30 2022, 04:58:14) [Clang 13.1.6 (clang-1316.0.21.2.5)] on darwin
Type "help", "copyright", "credits" or "license" for more information.
>>> import dis
>>> def g():
...     return 1
... 
>>> dis.dis(g)
  2           0 LOAD_CONST               1 (1)
              2 RETURN_VALUE
>>> g.__code__.co_consts
(None, 1)
```

## Actual Result (RustPython)

```py
>>>>> import dis
>>>>> def g():
.....     return 1
..... 
>>>>> dis.dis(g)
  2           0 LoadConst            (1)
              1 ReturnValue
>>>>> g.__code__.co_consts
(1,)
```

## This PR's result

```py
>>>>> import dis
>>>>> def g():
.....     return 1
..... 
>>>>> dis.dis(g)
  2           0 LoadConst            (1)
              1 ReturnValue
>>>>> g.__code__.co_consts
(None, 1)
```

# Reference

- [What is none doing in the code objects co consts attribute](https://stackoverflow.com/questions/27667747/what-is-none-doing-in-the-code-objects-co-consts-attribute)
