### PR TITLE
Use of deprecated function `itertools::zip` use `std::iter::zip` instead

### DIFF
--- a/vm/src/frame.rs
+++ b/vm/src/frame.rs
@@ -187,7 +187,7 @@ impl FrameRef {
         let j = std::cmp::min(map.len(), code.varnames.len());
         if !code.varnames.is_empty() {
             let fastlocals = self.fastlocals.lock();
-            for (&k, v) in itertools::zip(&map[..j], &**fastlocals) {
+            for (&k, v) in std::iter::zip(&map[..j], &**fastlocals) {
                 match locals.mapping().ass_subscript(k, v.clone(), vm) {
                     Ok(()) => {}
                     Err(e) if e.fast_isinstance(vm.ctx.exceptions.key_error) => {}
@@ -197,7 +197,7 @@ impl FrameRef {
         }
         if !code.cellvars.is_empty() || !code.freevars.is_empty() {
             let map_to_dict = |keys: &[&PyStrInterned], values: &[PyCellRef]| {
-                for (&k, v) in itertools::zip(keys, values) {
+                for (&k, v) in std::iter::zip(keys, values) {
                     if let Some(value) = v.get() {
                         locals.mapping().ass_subscript(k, Some(value), vm)?;
                     } else {


### PR DESCRIPTION
When I built RustPython, I got the following warning:
```
warning: use of deprecated function `itertools::zip`: Use [std::iter::zip](https://doc.rust-lang.org/std/iter/fn.zip.html) instead
   --> vm/src/frame.rs:190:39
    |
190 |             for (&k, v) in itertools::zip(&map[..j], &**fastlocals) {
    |                                       ^^^
    |
    = note: `#[warn(deprecated)]` on by default

warning: use of deprecated function `itertools::zip`: Use [std::iter::zip](https://doc.rust-lang.org/std/iter/fn.zip.html) instead
   --> vm/src/frame.rs:200:43
    |
200 |                 for (&k, v) in itertools::zip(keys, values) {
    |     
```
And I edited it to fit the warning.