### PR TITLE
match args without n_*_fields

### DIFF
--- a/Lib/test/test_structseq.py
+++ b/Lib/test/test_structseq.py
@@ -124,8 +124,6 @@ class StructSeqTest(unittest.TestCase):
                     self.assertEqual(list(t[start:stop:step]),
                                      L[start:stop:step])
 
-    # TODO: RUSTPYTHON
-    @unittest.expectedFailure
     def test_match_args(self):
         expected_args = ('tm_year', 'tm_mon', 'tm_mday', 'tm_hour', 'tm_min',
                          'tm_sec', 'tm_wday', 'tm_yday', 'tm_isdst')

--- a/vm/src/types/structseq.rs
+++ b/vm/src/types/structseq.rs
@@ -86,5 +86,16 @@ pub trait PyStructSequence: StaticType + PyClassImpl + Sized + 'static {
                 .into(),
             );
         }
+
+        class.set_attr(
+            identifier!(ctx, __match_args__),
+            ctx.new_tuple(
+                Self::FIELD_NAMES
+                    .iter()
+                    .map(|&name| ctx.new_str(name).into())
+                    .collect::<Vec<_>>(),
+            )
+            .into(),
+        );
     }
 }

--- a/vm/src/vm/context.rs
+++ b/vm/src/vm/context.rs
@@ -152,6 +152,7 @@ declare_const_name! {
     __lshift__,
     __lt__,
     __main__,
+    __match_args__,
     __matmul__,
     __missing__,
     __mod__,


### PR DESCRIPTION
This PR treat __match_args__ without n_*_fields

refs: #4063 