### PR TITLE
Refactor fstrings

### DIFF
--- a/compiler/parser/src/snapshots/rustpython_parser__fstring__tests__parse_fstring_nested_spec.snap
+++ b/compiler/parser/src/snapshots/rustpython_parser__fstring__tests__parse_fstring_nested_spec.snap
@@ -41,7 +41,7 @@ expression: parse_ast
                                     value: Located {
                                         location: Location {
                                             row: 1,
-                                            column: 3,
+                                            column: 2,
                                         },
                                         custom: (),
                                         node: Name {


### PR DESCRIPTION
There's still a problem with this rework where 
```
arg_list = 'hits, misses, maxsize, currsize'
f'lambda _cls, {arg_list}: _tuple_new(_cls, ({arg_list}))
```
returns 
`lambda _cls, {'hits, misses, maxsize, currsize'}: _tuple_new(_cls, ({'hits, misses, maxsize, currsize'}))`
instead of 
`lambda _cls, hits, misses, maxsize, currsize: _tuple_new(_cls, (hits, misses, maxsize, currsize))`

closes: #4102