### PR TITLE
Fill OSError attributes

### DIFF
--- a/Lib/test/test_exception_hierarchy.py
+++ b/Lib/test/test_exception_hierarchy.py
@@ -5,6 +5,7 @@ import socket
 import unittest
 import errno
 from errno import EEXIST
+import sys
 
 
 class SubOSError(OSError):
@@ -130,8 +131,8 @@ class AttributesTest(unittest.TestCase):
         else:
             self.assertNotIn('winerror', dir(OSError))
 
-    # TODO: RUSTPYTHON
-    @unittest.expectedFailure
+    @unittest.skip("TODO: RUSTPYTHON")
+    @unittest.skipIf(sys.platform == 'win32', 'winerror not filled yet')
     def test_posix_error(self):
         e = OSError(EEXIST, "File already exists", "foo.txt")
         self.assertEqual(e.errno, EEXIST)

--- a/Lib/test/test_fileio.py
+++ b/Lib/test/test_fileio.py
@@ -391,8 +391,6 @@ class PyAutoFileTests(AutoFileTests, unittest.TestCase):
     FileIO = _pyio.FileIO
     modulename = '_pyio'
 
-    # TODO: RUSTPYTHON
-    @unittest.expectedFailure
     def testOpendir(self):
         super().testOpendir()
 

--- a/Lib/test/test_subprocess.py
+++ b/Lib/test/test_subprocess.py
@@ -1547,8 +1547,6 @@ class ProcessTestCase(BaseTestCase):
         fds_after_exception = os.listdir(fd_directory)
         self.assertEqual(fds_before_popen, fds_after_exception)
 
-    # TODO: RUSTPYTHON
-    @unittest.expectedFailure
     @unittest.skipIf(mswindows, "behavior currently not supported on Windows")
     def test_file_not_found_includes_filename(self):
         with self.assertRaises(FileNotFoundError) as c:

--- a/extra_tests/snippets/builtin_exceptions.py
+++ b/extra_tests/snippets/builtin_exceptions.py
@@ -264,6 +264,40 @@ assert OSError.strerror
 assert OSError(1, 2).errno
 assert OSError(1, 2).strerror
 
+
+# OSError Unexpected number of arguments
+w = OSError()
+assert w.errno == None
+assert not sys.platform.startswith("win") or w.winerror == None
+assert w.strerror == None
+assert w.filename == None
+assert w.filename2 == None
+assert str(w) == ""
+
+w = OSError(0)
+assert w.errno == None
+assert not sys.platform.startswith("win") or w.winerror == None
+assert w.strerror == None
+assert w.filename == None
+assert w.filename2 == None
+assert str(w) == "0"
+
+w = OSError('foo')
+assert w.errno == None
+assert not sys.platform.startswith("win") or w.winerror == None
+assert w.strerror == None
+assert w.filename == None
+assert w.filename2 == None
+assert str(w) == "foo"
+
+w = OSError('a', 'b', 'c', 'd', 'e', 'f')
+assert w.errno == None
+assert not sys.platform.startswith("win") or w.winerror == None
+assert w.strerror == None
+assert w.filename == None
+assert w.filename2 == None
+assert str(w) == "('a', 'b', 'c', 'd', 'e', 'f')"
+
 # Custom `__new__` and `__init__`:
 assert ImportError.__init__.__qualname__ == 'ImportError.__init__'
 assert ImportError(name='a').name == 'a'


### PR DESCRIPTION
Tested by removing expected failure and commenting everything but OSError in Lib/test/test_exceptions.py::testAttributes::exceptionList, WindowsError and pickling part of the test.

fixes : #4193