### PR TITLE
Update `pprint` lib and tests from CPython v3.12.0a0

### DIFF
--- a/Lib/pprint.py
+++ b/Lib/pprint.py
@@ -149,8 +149,9 @@ class PrettyPrinter:
         self._underscore_numbers = underscore_numbers
 
     def pprint(self, object):
-        self._format(object, self._stream, 0, 0, {}, 0)
-        self._stream.write("\n")
+        if self._stream is not None:
+            self._format(object, self._stream, 0, 0, {}, 0)
+            self._stream.write("\n")
 
     def pformat(self, object):
         sio = _StringIO()
@@ -636,19 +637,6 @@ def _recursion(object):
             % (type(object).__name__, id(object)))
 
 
-def _perfcheck(object=None):
-    import time
-    if object is None:
-        object = [("string", (1, 2), [3, 4], {5: 6, 7: 8})] * 100000
-    p = PrettyPrinter()
-    t1 = time.perf_counter()
-    p._safe_repr(object, {}, None, 0, True)
-    t2 = time.perf_counter()
-    p.pformat(object)
-    t3 = time.perf_counter()
-    print("_safe_repr:", t2 - t1)
-    print("pformat:", t3 - t2)
-
 def _wrap_bytes_repr(object, width, allowance):
     current = b''
     last = len(object) // 4 * 4
@@ -665,6 +653,3 @@ def _wrap_bytes_repr(object, width, allowance):
             current = candidate
     if current:
         yield repr(current)
-
-if __name__ == "__main__":
-    _perfcheck()

--- a/Lib/test/test_pprint.py
+++ b/Lib/test/test_pprint.py
@@ -532,8 +532,6 @@ AdvancedNamespace(the=0,
         formatted = pprint.pformat(dc, width=20)
         self.assertEqual(formatted, "custom repr that doesn't fit within pprint width")
 
-    # TODO: RUSTPYTHON
-    @unittest.expectedFailure
     def test_dataclass_no_repr(self):
         dc = dataclass3()
         formatted = pprint.pformat(dc, width=10)

--- a/Lib/test/test_pprint.py
+++ b/Lib/test/test_pprint.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 
 import collections
+import contextlib
 import dataclasses
 import io
 import itertools
@@ -159,6 +160,13 @@ class QueryTestCase(unittest.TestCase):
             self.assertTrue(pp.isreadable(safe),
                             "expected isreadable for %r" % (safe,))
 
+    def test_stdout_is_None(self):
+        with contextlib.redirect_stdout(None):
+            # smoke test - there is no output to check
+            value = 'this should not fail'
+            pprint.pprint(value)
+            pprint.PrettyPrinter().pprint(value)
+
     def test_knotted(self):
         # Verify .isrecursive() and .isreadable() w/ recursion
         # Tie a knot.
@@ -195,7 +203,7 @@ class QueryTestCase(unittest.TestCase):
     def test_unreadable(self):
         # Not recursive but not readable anyway
         pp = pprint.PrettyPrinter()
-        for unreadable in type(3), pprint, pprint.isrecursive:
+        for unreadable in object(), int, pprint, pprint.isrecursive:
             # module-level convenience functions
             self.assertFalse(pprint.isrecursive(unreadable),
                              "expected not isrecursive for %r" % (unreadable,))
@@ -524,6 +532,8 @@ AdvancedNamespace(the=0,
         formatted = pprint.pformat(dc, width=20)
         self.assertEqual(formatted, "custom repr that doesn't fit within pprint width")
 
+    # TODO: RUSTPYTHON
+    @unittest.expectedFailure
     def test_dataclass_no_repr(self):
         dc = dataclass3()
         formatted = pprint.pformat(dc, width=10)


### PR DESCRIPTION
This is a change of cpython 3.10
Python codes are copy-pasted from CPython.

`pprint.pprint` function displays integer with underscores.

* https://github.com/python/cpython/pull/24864
