### PR TITLE
Add dropwhile.__reduce__

### DIFF
--- a/extra_tests/snippets/stdlib_itertools.py
+++ b/extra_tests/snippets/stdlib_itertools.py
@@ -2,6 +2,7 @@ import itertools
 
 from testutils import assert_raises
 
+import pickle
 
 # itertools.chain tests
 chain = itertools.chain
@@ -278,6 +279,17 @@ assert 4 == next(it)
 assert 1 == next(it)
 with assert_raises(StopIteration):
     next(it)
+
+def underten(x):
+    return x<10
+
+it = itertools.dropwhile(underten, [1, 3, 5, 20, 2, 4, 6, 8])
+assert pickle.dumps(it, 0) == b'citertools\ndropwhile\np0\n(c__main__\nunderten\np1\nc__builtin__\niter\np2\n((lp3\nI1\naI3\naI5\naI20\naI2\naI4\naI6\naI8\natp4\nRp5\nI0\nbtp6\nRp7\nI0\nb.'
+assert pickle.dumps(it, 1) == b'citertools\ndropwhile\nq\x00(c__main__\nunderten\nq\x01c__builtin__\niter\nq\x02(]q\x03(K\x01K\x03K\x05K\x14K\x02K\x04K\x06K\x08etq\x04Rq\x05K\x00btq\x06Rq\x07K\x00b.'
+assert pickle.dumps(it, 2) == b'\x80\x02citertools\ndropwhile\nq\x00c__main__\nunderten\nq\x01c__builtin__\niter\nq\x02]q\x03(K\x01K\x03K\x05K\x14K\x02K\x04K\x06K\x08e\x85q\x04Rq\x05K\x00b\x86q\x06Rq\x07K\x00b.'
+assert pickle.dumps(it, 3) == b'\x80\x03citertools\ndropwhile\nq\x00c__main__\nunderten\nq\x01cbuiltins\niter\nq\x02]q\x03(K\x01K\x03K\x05K\x14K\x02K\x04K\x06K\x08e\x85q\x04Rq\x05K\x00b\x86q\x06Rq\x07K\x00b.'
+assert pickle.dumps(it, 4) == b'\x80\x04\x95i\x00\x00\x00\x00\x00\x00\x00\x8c\titertools\x94\x8c\tdropwhile\x94\x93\x94\x8c\x08__main__\x94\x8c\x08underten\x94\x93\x94\x8c\x08builtins\x94\x8c\x04iter\x94\x93\x94]\x94(K\x01K\x03K\x05K\x14K\x02K\x04K\x06K\x08e\x85\x94R\x94K\x00b\x86\x94R\x94K\x00b.'
+assert pickle.dumps(it, 5) == b'\x80\x05\x95i\x00\x00\x00\x00\x00\x00\x00\x8c\titertools\x94\x8c\tdropwhile\x94\x93\x94\x8c\x08__main__\x94\x8c\x08underten\x94\x93\x94\x8c\x08builtins\x94\x8c\x04iter\x94\x93\x94]\x94(K\x01K\x03K\x05K\x14K\x02K\x04K\x06K\x08e\x85\x94R\x94K\x00b\x86\x94R\x94K\x00b.'
 
 
 # itertools.accumulate


### PR DESCRIPTION
The test `def test_dropwhile(self):` of Lib/test/test_itertools.py is not activated because the line `self.assertRaises(TypeError, next, dropwhile(10, [(4,5)]))` fails.

The bytes against which the pickling is compared in stdlib_itertools.py are generated with CPython

This is part of #3611 