### PR TITLE
Make rustpython-vm compatible with non-js wasm32-unknown & add tests

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -377,7 +377,7 @@ jobs:
         with: { wabt-version: "1.0.30" }
       - name: check wasm32-unknown without js
         run: |
-          cargo build --release -p wasm-unknown-test --target wasm32-unknown-unknown --verbose
+          cargo build --release --manifest-path wasm/wasm-unknown-test/Cargo.toml --target wasm32-unknown-unknown --verbose
           if wasm-objdump -xj Import target/wasm32-unknown-unknown/release/wasm_unknown_test.wasm; then
             echo "ERROR: wasm32-unknown module expects imports from the host environment" >2
           fi

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -380,6 +380,14 @@ jobs:
         env:
           NODE_OPTIONS: "--openssl-legacy-provider"
         working-directory: ./wasm/demo
+      - uses: mwilliamson/setup-wabt-action@v1
+        with: { wabt-version: "1.0.30" }
+      - name: check wasm32-unknown without js
+        run: |
+          cargo build --release -p wasm-unknown-test --target wasm32-unknown-unknown --verbose
+          if wasm-objdump -xj Import target/wasm32-unknown-unknown/release/wasm_unknown_test.wasm; then
+            echo "ERROR: wasm32-unknown module expects imports from the host environment" >2
+          fi
       - name: build notebook demo
         if: github.ref == 'refs/heads/release'
         run: |

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -218,13 +218,6 @@ jobs:
 
       - uses: dtolnay/rust-toolchain@stable
         with:
-          target: wasm32-unknown-unknown
-
-      - name: Check compilation for wasm32
-        run: cargo check --target wasm32-unknown-unknown --no-default-features
-
-      - uses: dtolnay/rust-toolchain@stable
-        with:
           target: x86_64-unknown-freebsd
 
       - name: Check compilation for freeBSD

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3155,6 +3155,14 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "af190c94f2773fdb3729c55b007a722abb5384da03bc0986df4c289bf5567e96"
 
 [[package]]
+name = "wasm-unknown-test"
+version = "0.1.0"
+dependencies = [
+ "getrandom",
+ "rustpython-vm",
+]
+
+[[package]]
 name = "web-sys"
 version = "0.3.61"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3155,14 +3155,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "af190c94f2773fdb3729c55b007a722abb5384da03bc0986df4c289bf5567e96"
 
 [[package]]
-name = "wasm-unknown-test"
-version = "0.1.0"
-dependencies = [
- "getrandom",
- "rustpython-vm",
-]
-
-[[package]]
 name = "web-sys"
 version = "0.3.61"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -97,7 +97,7 @@ resolver = "2"
 members = [
     "compiler", "compiler/core", "compiler/codegen",
     ".", "common", "derive", "jit", "vm", "vm/sre_engine", "pylib", "stdlib", "derive-impl",
-    "wasm/lib", "wasm/wasm-unknown-test",
+    "wasm/lib",
 ]
 
 [workspace.package]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -96,7 +96,8 @@ x86_64-pc-windows-msvc = { triplet = "x64-windows-static-md", dev-dependencies =
 resolver = "2"
 members = [
     "compiler", "compiler/core", "compiler/codegen",
-    ".", "common", "derive", "jit", "vm", "vm/sre_engine", "pylib", "stdlib", "wasm/lib", "derive-impl",
+    ".", "common", "derive", "jit", "vm", "vm/sre_engine", "pylib", "stdlib", "derive-impl",
+    "wasm/lib", "wasm/wasm-unknown-test",
 ]
 
 [workspace.package]

--- a/stdlib/Cargo.toml
+++ b/stdlib/Cargo.toml
@@ -22,7 +22,7 @@ ssl-vendor = ["ssl", "openssl/vendored", "openssl-probe"]
 [dependencies]
 # rustpython crates
 rustpython-derive = { workspace = true }
-rustpython-vm = { workspace = true }
+rustpython-vm = { workspace = true, default-features = false }
 rustpython-common = { workspace = true }
 
 ahash = { workspace = true }

--- a/stdlib/Cargo.toml
+++ b/stdlib/Cargo.toml
@@ -12,12 +12,12 @@ license.workspace = true
 
 [features]
 default = ["compiler"]
-compiler = ["rustpython-vm/compiler"]
 threading = ["rustpython-common/threading", "rustpython-vm/threading"]
 zlib = ["libz-sys", "flate2/zlib"]
 bz2 = ["bzip2"]
 ssl = ["openssl", "openssl-sys", "foreign-types-shared"]
 ssl-vendor = ["ssl", "openssl/vendored", "openssl-probe"]
+compiler = ["rustpython-vm/compiler"]
 
 [dependencies]
 # rustpython crates

--- a/vm/Cargo.toml
+++ b/vm/Cargo.toml
@@ -10,7 +10,7 @@ repository.workspace = true
 license.workspace = true
 
 [features]
-default = ["compiler"]
+default = ["compiler", "js"]
 importlib = []
 encodings = ["importlib"]
 vm-tracing-logging = []
@@ -23,6 +23,8 @@ ast = ["rustpython-ast"]
 codegen = ["rustpython-codegen", "ast"]
 parser = ["rustpython-parser", "ast"]
 serde = ["dep:serde"]
+
+js = ["getrandom/js", "chrono/wasmbind", "wasm-bindgen"]
 
 [dependencies]
 rustpython-compiler = { workspace = true, optional = true }
@@ -71,7 +73,7 @@ thread_local = { workspace = true }
 memchr = { workspace = true }
 
 caseless = "0.2.1"
-getrandom = { version = "0.2.12", features = ["js"] }
+getrandom = { version = "0.2.12" }
 flamer = { version = "0.4", optional = true }
 half = "1.8.2"
 memoffset = "0.9.1"
@@ -140,8 +142,8 @@ features = [
   "Win32_UI_WindowsAndMessaging",
 ]
 
-[target.'cfg(target_arch = "wasm32")'.dependencies]
-wasm-bindgen = "0.2.92"
+[target.'cfg(all(target_arch = "wasm32", target_os = "unknown"))'.dependencies]
+wasm-bindgen = { version = "0.2.92", optional = true }
 
 [build-dependencies]
 glob = { workspace = true }

--- a/vm/src/stdlib/time.rs
+++ b/vm/src/stdlib/time.rs
@@ -102,7 +102,7 @@ mod decl {
         Ok(duration_since_system_now(vm)?.as_secs_f64())
     }
 
-    #[cfg(all(target_arch = "wasm32", not(target_os = "wasi")))]
+    #[cfg(all(target_arch = "wasm32", feature = "js", not(target_os = "wasi")))]
     fn _time(_vm: &VirtualMachine) -> PyResult<f64> {
         use wasm_bindgen::prelude::*;
         #[wasm_bindgen]
@@ -113,6 +113,11 @@ mod decl {
         }
         // Date.now returns unix time in milliseconds, we want it in seconds
         Ok(Date::now() / 1000.0)
+    }
+
+    #[cfg(all(target_arch = "wasm32", not(feature = "js"), not(target_os = "wasi")))]
+    fn _time(vm: &VirtualMachine) -> PyResult<f64> {
+        Err(vm.new_not_implemented_error("time.time".to_owned()))
     }
 
     #[pyfunction]

--- a/vm/src/vm/vm_object.rs
+++ b/vm/src/vm/vm_object.rs
@@ -19,7 +19,7 @@ impl VirtualMachine {
             self.flush_std();
             panic!("{msg}")
         }
-        #[cfg(all(target_arch = "wasm32", not(target_os = "wasi")))]
+        #[cfg(all(target_arch = "wasm32", feature = "js", not(target_os = "wasi")))]
         {
             use wasm_bindgen::prelude::*;
             #[wasm_bindgen]
@@ -31,6 +31,11 @@ impl VirtualMachine {
             self.write_exception(&mut s, &exc).unwrap();
             error(&s);
             panic!("{}; exception backtrace above", msg)
+        }
+        #[cfg(all(target_arch = "wasm32", not(feature = "js"), not(target_os = "wasi")))]
+        {
+            let _ = exc;
+            panic!("{}; python exception not available", msg)
         }
     }
 

--- a/wasm/lib/Cargo.toml
+++ b/wasm/lib/Cargo.toml
@@ -21,7 +21,7 @@ rustpython-common = { workspace = true }
 rustpython-pylib = { workspace = true, optional = true }
 rustpython-stdlib = { workspace = true, default-features = false, optional = true }
 # make sure no threading! otherwise wasm build will fail
-rustpython-vm = { workspace = true, features = ["compiler", "encodings", "serde"] }
+rustpython-vm = { workspace = true, features = ["compiler", "encodings", "serde", "js"] }
 
 rustpython-parser = { workspace = true }
 

--- a/wasm/wasm-unknown-test/Cargo.toml
+++ b/wasm/wasm-unknown-test/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "wasm-unknown-test"
+version = "0.1.0"
+edition = "2021"
+
+[lib]
+crate-type = ["cdylib"]
+
+[dependencies]
+getrandom = { version = "0.2.7", features = ["custom"] }
+rustpython-vm = { path = "../../vm", default-features = false, features = ["compiler"] }

--- a/wasm/wasm-unknown-test/Cargo.toml
+++ b/wasm/wasm-unknown-test/Cargo.toml
@@ -7,5 +7,7 @@ edition = "2021"
 crate-type = ["cdylib"]
 
 [dependencies]
-getrandom = { version = "0.2.7", features = ["custom"] }
+getrandom = { version = "0.2.12", features = ["custom"] }
 rustpython-vm = { path = "../../vm", default-features = false, features = ["compiler"] }
+
+[workspace]

--- a/wasm/wasm-unknown-test/README.md
+++ b/wasm/wasm-unknown-test/README.md
@@ -1,0 +1,1 @@
+A test crate to ensure that `rustpython-vm` compiles on `wasm32-unknown-unknown` without a JS host.

--- a/wasm/wasm-unknown-test/src/lib.rs
+++ b/wasm/wasm-unknown-test/src/lib.rs
@@ -1,0 +1,16 @@
+use rustpython_vm::{eval, Interpreter};
+
+pub unsafe extern "C" fn eval(s: *const u8, l: usize) -> u32 {
+    let src = std::slice::from_raw_parts(s, l);
+    let src = std::str::from_utf8(src).unwrap();
+    Interpreter::without_stdlib(Default::default()).enter(|vm| {
+        let res = eval::eval(vm, src, vm.new_scope_with_builtins(), "<string>").unwrap();
+        res.try_into_value(vm).unwrap()
+    })
+}
+
+fn getrandom_always_fail(_buf: &mut [u8]) -> Result<(), getrandom::Error> {
+    Err(getrandom::Error::UNSUPPORTED)
+}
+
+getrandom::register_custom_getrandom!(getrandom_always_fail);


### PR DESCRIPTION
Ideally the test crate shouldn't take long to compile, since it's the same target with only a few crates configured differently.
