### PR TITLE
class-doc-fixed

### DIFF
--- a/vm/src/builtins/type.rs
+++ b/vm/src/builtins/type.rs
@@ -28,9 +28,6 @@ use indexmap::{map::Entry, IndexMap};
 use itertools::Itertools;
 use std::{borrow::Borrow, collections::HashSet, fmt, ops::Deref, pin::Pin, ptr::NonNull};
 
-/// type(object_or_name, bases, dict)
-/// type(object) -> the object's type
-/// type(name, bases, dict) -> a new type
 #[pyclass(module = false, name = "type")]
 pub struct PyType {
     pub base: Option<PyTypeRef>,


### PR DESCRIPTION
In this revision,
- #4085 has been fixed by removing remark and
- [Updating `docs.inc.rs` file in `RustPython/__doc__`](https://github.com/RustPython/__doc__/pull/1/files)


close: #4085 