### PR TITLE
Add Ruff as a use-case in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,6 +157,7 @@ make cool projects:
 - [pyckitup](https://github.com/pickitup247/pyckitup): a game engine written in
   rust.
 - [Robot Rumble](https://github.com/robot-rumble/logic/): an arena-based AI competition platform
+- [Ruff](https://github.com/charliermarsh/ruff/): an extremely fast Python linter, written in Rust
 
 ## Goals
 


### PR DESCRIPTION
I hate to be self-promotional but RustPython powers Ruff's AST parser. If you want to include in the README, feel free! But also fine if not :)
