### PR TITLE
Update README.md: compile error in stable 

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,8 +39,8 @@ Or use the interactive shell:
     >>>>> 2+2
     4
     
-NOTE: For windows users, please set `RUSTPYTHONPATH` environment variable as `Lib` path in project directory.
-(e.g. When RustPython directory is `C:\RustPython`, set `RUSTPYTHONPATH` as `C:\RustPython\Lib`)
+> Note: For windows users, please set `RUSTPYTHONPATH` environment variable as `Lib` path in project directory.
+(e.g. When RustPython directory is `C:\RustPython`, set `RUSTPYTHONPATH` as `C:\RustPython\Lib`). If the compile error E0658("use of unstable library feature") happend, please set your Rust version into beta/nightly(e.g. `rustup override set beta`).
 
 You can also install and run RustPython with the following:
 


### PR DESCRIPTION
I have found a compile error in my windows serve 2020. This is it's details:

error[E0658]: use of unstable library feature 'bool_to_option'
  --> common\src\refcount.rs:47:63
   |
47 |             .fetch_update(AcqRel, Acquire, |prev| (prev != 0).then_some(prev + 1))
   |                                                               ^^^^^^^^^
   |
   = note: see issue #80967 <https://github.com/rust-lang/rust/issues/80967> for more information

For more information about this error, try `rustc --explain E0658`.
error: could not compile `rustpython-common` due to previous error
warning: build failed, waiting for other jobs to finish...
error: build failed