### PR TITLE
Fix lambda expression's  unexpected `UnboundLocalError`

### DIFF
--- a/compiler/codegen/src/compile.rs
+++ b/compiler/codegen/src/compile.rs
@@ -2118,14 +2118,15 @@ impl Compiler {
             Name { id, .. } => self.load_name(id)?,
             Lambda { args, body } => {
                 let prev_ctx = self.ctx;
+
+                let name = "<lambda>".to_owned();
+                let mut funcflags = self.enter_function(&name, args)?;
+
                 self.ctx = CompileContext {
                     loop_data: Option::None,
                     in_class: prev_ctx.in_class,
                     func: FunctionContext::Function,
                 };
-
-                let name = "<lambda>".to_owned();
-                let mut funcflags = self.enter_function(&name, args)?;
 
                 self.current_codeinfo()
                     .constants

--- a/extra_tests/snippets/scope_lambda.py
+++ b/extra_tests/snippets/scope_lambda.py
@@ -1,0 +1,3 @@
+class X:
+    v = 10
+    f = lambda x=v: x


### PR DESCRIPTION
This PR trying to fix #3934.

I think the compile context of the lambda expression should be resolved as `Function` after executing `enter_function` like in the `compile_function_def`.

The detailed explanations are in the above issue's comments.

## Result

Example code:

```
>>>>> class X:
.....   v = 999
.....   f = lambda x=v:x
..... 
>>>>> 
```

Example code's bytecodes:

```
  1           0 LoadGlobal           (0, __name__)
              1 StoreLocal           (1, __module__)
              2 LoadConst            ("X")
              3 StoreLocal           (2, __qualname__)
              4 LoadConst            (None)
              5 StoreLocal           (3, __doc__)

  2           6 LoadConst            (999)
              7 StoreLocal           (4, v)

  3           8 LoadNameAny          (4, v)
              9 BuildTuple           (1, false)
             10 LoadConst            (<code object <lambda> at ??? file "a.py", line 3>)
             11 LoadConst            ("<lambda>")
             12 MakeFunction         (DEFAULTS)
             13 StoreLocal           (5, f)
             14 LoadConst            (None)
             15 ReturnValue
```
