### PR TITLE
Start simple string at quote mark

### DIFF
--- a/compiler/parser/src/lexer.rs
+++ b/compiler/parser/src/lexer.rs
@@ -492,9 +492,9 @@ where
         is_unicode: bool,
         is_fstring: bool,
     ) -> LexResult {
+        let start_pos = self.get_pos();
         let quote_char = self.next_char().unwrap();
         let mut string_content = String::new();
-        let start_pos = self.get_pos();
 
         // If the next two characters are also the quote character, then we have a triple-quoted
         // string; consume those two characters and ensure that we require a triple-quote to close

--- a/compiler/parser/src/snapshots/rustpython_parser__parser__tests__parse_class.snap
+++ b/compiler/parser/src/snapshots/rustpython_parser__parser__tests__parse_class.snap
@@ -1,6 +1,6 @@
 ---
-source: parser/src/parser.rs
-expression: parse_program(&source).unwrap()
+source: compiler/parser/src/parser.rs
+expression: "parse_program(source, \"<test>\").unwrap()"
 ---
 [
     Located {
@@ -126,7 +126,7 @@ expression: parse_program(&source).unwrap()
                                 Located {
                                     location: Location {
                                         row: 4,
-                                        column: 37,
+                                        column: 36,
                                     },
                                     custom: (),
                                     node: Constant {

--- a/compiler/parser/src/snapshots/rustpython_parser__parser__tests__parse_kwargs.snap
+++ b/compiler/parser/src/snapshots/rustpython_parser__parser__tests__parse_kwargs.snap
@@ -1,7 +1,6 @@
 ---
-source: parser/src/parser.rs
+source: compiler/parser/src/parser.rs
 expression: parse_ast
-
 ---
 [
     Located {
@@ -33,7 +32,7 @@ expression: parse_ast
                         Located {
                             location: Location {
                                 row: 1,
-                                column: 10,
+                                column: 9,
                             },
                             custom: (),
                             node: Constant {

--- a/compiler/parser/src/snapshots/rustpython_parser__parser__tests__parse_print_2.snap
+++ b/compiler/parser/src/snapshots/rustpython_parser__parser__tests__parse_print_2.snap
@@ -1,7 +1,6 @@
 ---
-source: parser/src/parser.rs
+source: compiler/parser/src/parser.rs
 expression: parse_ast
-
 ---
 [
     Located {
@@ -33,7 +32,7 @@ expression: parse_ast
                         Located {
                             location: Location {
                                 row: 1,
-                                column: 8,
+                                column: 7,
                             },
                             custom: (),
                             node: Constant {

--- a/compiler/parser/src/snapshots/rustpython_parser__parser__tests__parse_print_hello.snap
+++ b/compiler/parser/src/snapshots/rustpython_parser__parser__tests__parse_print_hello.snap
@@ -1,5 +1,5 @@
 ---
-source: parser/src/parser.rs
+source: compiler/parser/src/parser.rs
 expression: parse_ast
 ---
 [
@@ -32,7 +32,7 @@ expression: parse_ast
                         Located {
                             location: Location {
                                 row: 1,
-                                column: 8,
+                                column: 7,
                             },
                             custom: (),
                             node: Constant {

--- a/compiler/parser/src/snapshots/rustpython_parser__parser__tests__parse_string.snap
+++ b/compiler/parser/src/snapshots/rustpython_parser__parser__tests__parse_string.snap
@@ -1,19 +1,19 @@
 ---
-source: parser/src/parser.rs
+source: compiler/parser/src/parser.rs
 expression: parse_ast
 ---
 [
     Located {
         location: Location {
             row: 1,
-            column: 2,
+            column: 1,
         },
         custom: (),
         node: Expr {
             value: Located {
                 location: Location {
                     row: 1,
-                    column: 2,
+                    column: 1,
                 },
                 custom: (),
                 node: Constant {

--- a/compiler/parser/src/snapshots/rustpython_parser__string__tests__parse_f_string_concat_1.snap
+++ b/compiler/parser/src/snapshots/rustpython_parser__string__tests__parse_f_string_concat_1.snap
@@ -1,19 +1,19 @@
 ---
-source: parser/src/string.rs
+source: compiler/parser/src/string.rs
 expression: parse_ast
 ---
 [
     Located {
         location: Location {
             row: 1,
-            column: 2,
+            column: 1,
         },
         custom: (),
         node: Expr {
             value: Located {
                 location: Location {
                     row: 1,
-                    column: 2,
+                    column: 1,
                 },
                 custom: (),
                 node: JoinedStr {
@@ -21,7 +21,7 @@ expression: parse_ast
                         Located {
                             location: Location {
                                 row: 1,
-                                column: 2,
+                                column: 1,
                             },
                             custom: (),
                             node: Constant {

--- a/compiler/parser/src/snapshots/rustpython_parser__string__tests__parse_f_string_concat_2.snap
+++ b/compiler/parser/src/snapshots/rustpython_parser__string__tests__parse_f_string_concat_2.snap
@@ -1,19 +1,19 @@
 ---
-source: parser/src/string.rs
+source: compiler/parser/src/string.rs
 expression: parse_ast
 ---
 [
     Located {
         location: Location {
             row: 1,
-            column: 2,
+            column: 1,
         },
         custom: (),
         node: Expr {
             value: Located {
                 location: Location {
                     row: 1,
-                    column: 2,
+                    column: 1,
                 },
                 custom: (),
                 node: JoinedStr {
@@ -21,7 +21,7 @@ expression: parse_ast
                         Located {
                             location: Location {
                                 row: 1,
-                                column: 2,
+                                column: 1,
                             },
                             custom: (),
                             node: Constant {

--- a/compiler/parser/src/snapshots/rustpython_parser__string__tests__parse_f_string_concat_3.snap
+++ b/compiler/parser/src/snapshots/rustpython_parser__string__tests__parse_f_string_concat_3.snap
@@ -6,14 +6,14 @@ expression: parse_ast
     Located {
         location: Location {
             row: 1,
-            column: 2,
+            column: 1,
         },
         custom: (),
         node: Expr {
             value: Located {
                 location: Location {
                     row: 1,
-                    column: 2,
+                    column: 1,
                 },
                 custom: (),
                 node: JoinedStr {
@@ -21,7 +21,7 @@ expression: parse_ast
                         Located {
                             location: Location {
                                 row: 1,
-                                column: 2,
+                                column: 1,
                             },
                             custom: (),
                             node: Constant {
@@ -41,7 +41,7 @@ expression: parse_ast
                                 value: Located {
                                     location: Location {
                                         row: 1,
-                                        column: 3,
+                                        column: 2,
                                     },
                                     custom: (),
                                     node: Constant {

--- a/compiler/parser/src/snapshots/rustpython_parser__string__tests__parse_string_concat.snap
+++ b/compiler/parser/src/snapshots/rustpython_parser__string__tests__parse_string_concat.snap
@@ -1,19 +1,19 @@
 ---
-source: parser/src/string.rs
+source: compiler/parser/src/string.rs
 expression: parse_ast
 ---
 [
     Located {
         location: Location {
             row: 1,
-            column: 2,
+            column: 1,
         },
         custom: (),
         node: Expr {
             value: Located {
                 location: Location {
                     row: 1,
-                    column: 2,
+                    column: 1,
                 },
                 custom: (),
                 node: Constant {

--- a/compiler/parser/src/snapshots/rustpython_parser__string__tests__parse_u_string_concat_1.snap
+++ b/compiler/parser/src/snapshots/rustpython_parser__string__tests__parse_u_string_concat_1.snap
@@ -1,19 +1,19 @@
 ---
-source: parser/src/string.rs
+source: compiler/parser/src/string.rs
 expression: parse_ast
 ---
 [
     Located {
         location: Location {
             row: 1,
-            column: 2,
+            column: 1,
         },
         custom: (),
         node: Expr {
             value: Located {
                 location: Location {
                     row: 1,
-                    column: 2,
+                    column: 1,
                 },
                 custom: (),
                 node: Constant {


### PR DESCRIPTION
The same as #4220, but for simple strings. E.g., right now `"foo"` starts at column 2, instead of column 1.