### PR TITLE
remove most of old __doc__ remarks

### DIFF
--- a/stdlib/src/bisect.rs
+++ b/stdlib/src/bisect.rs
@@ -57,14 +57,6 @@ mod _bisect {
         Ok((lo, hi))
     }
 
-    /// Return the index where to insert item x in list a, assuming a is sorted.
-    ///
-    /// The return value i is such that all e in a[:i] have e < x, and all e in
-    /// a[i:] have e >= x.  So if x already appears in the list, a.insert(x) will
-    /// insert just before the leftmost x already there.
-    ///
-    /// Optional args lo (default 0) and hi (default len(a)) bound the
-    /// slice of a to be searched.
     #[inline]
     #[pyfunction]
     fn bisect_left(
@@ -91,14 +83,6 @@ mod _bisect {
         Ok(lo)
     }
 
-    /// Return the index where to insert item x in list a, assuming a is sorted.
-    ///
-    /// The return value i is such that all e in a[:i] have e <= x, and all e in
-    /// a[i:] have e > x.  So if x already appears in the list, a.insert(x) will
-    /// insert just after the rightmost x already there.
-    ///
-    /// Optional args lo (default 0) and hi (default len(a)) bound the
-    /// slice of a to be searched.
     #[inline]
     #[pyfunction]
     fn bisect_right(
@@ -125,12 +109,6 @@ mod _bisect {
         Ok(lo)
     }
 
-    /// Insert item x in list a, and keep it sorted assuming a is sorted.
-    ///
-    /// If x is already in a, insert it to the left of the leftmost x.
-    ///
-    /// Optional args lo (default 0) and hi (default len(a)) bound the
-    /// slice of a to be searched.
     #[pyfunction]
     fn insort_left(BisectArgs { a, x, lo, hi, key }: BisectArgs, vm: &VirtualMachine) -> PyResult {
         let x = if let Some(ref key) = key {
@@ -151,12 +129,6 @@ mod _bisect {
         vm.call_method(&a, "insert", (index, x))
     }
 
-    /// Insert item x in list a, and keep it sorted assuming a is sorted.
-    ///
-    /// If x is already in a, insert it to the right of the rightmost x.
-    ///
-    /// Optional args lo (default 0) and hi (default len(a)) bound the
-    /// slice of a to be searched
     #[pyfunction]
     fn insort_right(BisectArgs { a, x, lo, hi, key }: BisectArgs, vm: &VirtualMachine) -> PyResult {
         let x = if let Some(ref key) = key {

--- a/stdlib/src/cmath.rs
+++ b/stdlib/src/cmath.rs
@@ -1,8 +1,6 @@
 // TODO: Keep track of rust-num/num-complex/issues/2. A common trait could help with duplication
 //       that exists between cmath and math.
 pub(crate) use cmath::make_module;
-
-/// This module provides access to mathematical functions for complex numbers.
 #[pymodule]
 mod cmath {
     use crate::vm::{
@@ -21,57 +19,48 @@ mod cmath {
     #[pyattr(name = "nanj")]
     const NANJ: Complex64 = Complex64::new(0., std::f64::NAN);
 
-    /// Return argument, also known as the phase angle, of a complex.
     #[pyfunction]
     fn phase(z: ArgIntoComplex) -> f64 {
         z.arg()
     }
 
-    /// Convert a complex from rectangular coordinates to polar coordinates.
-    ///
-    /// r is the distance from 0 and phi the phase angle.
     #[pyfunction]
     fn polar(x: ArgIntoComplex) -> (f64, f64) {
         x.to_polar()
     }
 
-    /// Convert from polar coordinates to rectangular coordinates.
     #[pyfunction]
     fn rect(r: ArgIntoFloat, phi: ArgIntoFloat) -> Complex64 {
         Complex64::from_polar(*r, *phi)
     }
 
-    /// Checks if the real or imaginary part of z is infinite.
     #[pyfunction]
     fn isinf(z: ArgIntoComplex) -> bool {
         let Complex64 { re, im } = *z;
         re.is_infinite() || im.is_infinite()
     }
 
-    /// Return True if both the real and imaginary parts of z are finite, else False.
     #[pyfunction]
     fn isfinite(z: ArgIntoComplex) -> bool {
         z.is_finite()
     }
 
-    /// Checks if the real or imaginary part of z not a number (NaN)..
     #[pyfunction]
     fn isnan(z: ArgIntoComplex) -> bool {
         z.is_nan()
     }
 
-    /// Return the exponential value e**z.
     #[pyfunction]
     fn exp(z: ArgIntoComplex, vm: &VirtualMachine) -> PyResult<Complex64> {
         let z = *z;
         result_or_overflow(z, z.exp(), vm)
     }
-    /// Return the square root of z.
+
     #[pyfunction]
     fn sqrt(z: ArgIntoComplex) -> Complex64 {
         z.sqrt()
     }
-    /// Return the sine of z
+
     #[pyfunction]
     fn sin(z: ArgIntoComplex) -> Complex64 {
         z.sin()
@@ -82,7 +71,6 @@ mod cmath {
         z.asin()
     }
 
-    /// Return the cosine of z
     #[pyfunction]
     fn cos(z: ArgIntoComplex) -> Complex64 {
         z.cos()
@@ -93,9 +81,6 @@ mod cmath {
         z.acos()
     }
 
-    /// log(z[, base]) -> the logarithm of z to the given base.
-    ///
-    /// If the base not specified, returns the natural logarithm (base e) of z.
     #[pyfunction]
     fn log(z: ArgIntoComplex, base: OptionalArg<ArgIntoComplex>) -> Complex64 {
         // TODO: Complex64.log with a negative base yields wrong results.
@@ -110,55 +95,46 @@ mod cmath {
         )
     }
 
-    /// Return the base-10 logarithm of z.
     #[pyfunction]
     fn log10(z: ArgIntoComplex) -> Complex64 {
         z.log(10.0)
     }
 
-    /// Return the inverse hyperbolic cosine of z.
     #[pyfunction]
     fn acosh(z: ArgIntoComplex) -> Complex64 {
         z.acosh()
     }
 
-    /// Return the inverse tangent of z.
     #[pyfunction]
     fn atan(z: ArgIntoComplex) -> Complex64 {
         z.atan()
     }
 
-    /// Return the inverse hyperbolic tangent of z.
     #[pyfunction]
     fn atanh(z: ArgIntoComplex) -> Complex64 {
         z.atanh()
     }
 
-    /// Return the tangent of z.
     #[pyfunction]
     fn tan(z: ArgIntoComplex) -> Complex64 {
         z.tan()
     }
 
-    /// Return the hyperbolic tangent of z.
     #[pyfunction]
     fn tanh(z: ArgIntoComplex) -> Complex64 {
         z.tanh()
     }
 
-    /// Return the hyperbolic sin of z.
     #[pyfunction]
     fn sinh(z: ArgIntoComplex) -> Complex64 {
         z.sinh()
     }
 
-    /// Return the hyperbolic cosine of z.
     #[pyfunction]
     fn cosh(z: ArgIntoComplex) -> Complex64 {
         z.cosh()
     }
 
-    /// Return the inverse hyperbolic sine of z.
     #[pyfunction]
     fn asinh(z: ArgIntoComplex) -> Complex64 {
         z.asinh()
@@ -176,22 +152,6 @@ mod cmath {
         abs_tol: OptionalArg<ArgIntoFloat>,
     }
 
-    /// Determine whether two complex numbers are close in value.
-    ///
-    ///   rel_tol
-    ///     maximum difference for being considered "close", relative to the
-    ///     magnitude of the input values
-    ///   abs_tol
-    ///     maximum difference for being considered "close", regardless of the
-    ///     magnitude of the input values
-    ///
-    /// Return True if a is close in value to b, and False otherwise.
-    ///
-    /// For the values to be considered close, the difference between them must be
-    /// smaller than at least one of the tolerances.
-    ///
-    /// -inf, inf and NaN behave similarly to the IEEE 754 Standard. That is, NaN is
-    /// not close to anything, even itself. inf and -inf are only close to themselves.
     #[pyfunction]
     fn isclose(args: IsCloseArgs, vm: &VirtualMachine) -> PyResult<bool> {
         let a = *args.a;

--- a/stdlib/src/zlib.rs
+++ b/stdlib/src/zlib.rs
@@ -62,7 +62,6 @@ mod zlib {
         )
     }
 
-    /// Compute an Adler-32 checksum of data.
     #[pyfunction]
     fn adler32(data: ArgBytesLike, begin_state: OptionalArg<PyIntRef>) -> u32 {
         data.with_ref(|data| {
@@ -74,7 +73,6 @@ mod zlib {
         })
     }
 
-    /// Compute a CRC-32 checksum of data.
     #[pyfunction]
     fn crc32(data: ArgBytesLike, begin_state: OptionalArg<PyIntRef>) -> u32 {
         crate::binascii::crc32(data, begin_state)

--- a/vm/src/builtins/bool.rs
+++ b/vm/src/builtins/bool.rs
@@ -71,11 +71,6 @@ impl PyObjectRef {
     }
 }
 
-/// bool(x) -> bool
-///
-/// Returns True when the argument x is true, False otherwise.
-/// The builtins True and False are the only two instances of the class bool.
-/// The class bool is a subclass of the class int, and cannot be subclassed.
 #[pyclass(name = "bool", module = false, base = "PyInt")]
 pub struct PyBool;
 

--- a/vm/src/builtins/dict.rs
+++ b/vm/src/builtins/dict.rs
@@ -31,15 +31,6 @@ use std::fmt;
 
 pub type DictContentType = dictdatatype::Dict;
 
-/// dict() -> new empty dictionary
-/// dict(mapping) -> new dictionary initialized from a mapping object's
-///    (key, value) pairs
-/// dict(iterable) -> new dictionary initialized as if via:
-///    d = {}
-///    for k, v in iterable:
-///        d\[k\] = v
-/// dict(**kwargs) -> new dictionary initialized with the name=value pairs
-///    in the keyword argument list.  For example:  dict(one=1, two=2)
 #[pyclass(module = false, name = "dict")]
 #[derive(Default)]
 pub struct PyDict {

--- a/vm/src/builtins/filter.rs
+++ b/vm/src/builtins/filter.rs
@@ -6,10 +6,6 @@ use crate::{
     Context, Py, PyObjectRef, PyPayload, PyResult, VirtualMachine,
 };
 
-/// filter(function or None, iterable) --> filter object
-///
-/// Return an iterator yielding those items of iterable for which function(item)
-/// is true. If function is None, return the items that are true.
 #[pyclass(module = false, name = "filter")]
 #[derive(Debug)]
 pub struct PyFilter {

--- a/vm/src/builtins/float.rs
+++ b/vm/src/builtins/float.rs
@@ -22,7 +22,6 @@ use num_complex::Complex64;
 use num_rational::Ratio;
 use num_traits::{Signed, ToPrimitive, Zero};
 
-/// Convert a string or number to a floating point number, if possible.
 #[pyclass(module = false, name = "float")]
 #[derive(Debug, Copy, Clone, PartialEq)]
 pub struct PyFloat {

--- a/vm/src/builtins/int.rs
+++ b/vm/src/builtins/int.rs
@@ -23,20 +23,6 @@ use num_traits::{One, Pow, PrimInt, Signed, ToPrimitive, Zero};
 use std::ops::{Div, Neg};
 use std::{fmt, ops::Not};
 
-/// int(x=0) -> integer
-/// int(x, base=10) -> integer
-///
-/// Convert a number or string to an integer, or return 0 if no arguments
-/// are given.  If x is a number, return x.__int__().  For floating point
-/// numbers, this truncates towards zero.
-///
-/// If x is not a number or if base is given, then x must be a string,
-/// bytes, or bytearray instance representing an integer literal in the
-/// given base.  The literal can be preceded by '+' or '-' and be surrounded
-/// by whitespace.  The base defaults to 10.  Valid bases are 0 and 2-36.
-/// Base 0 means to interpret the base from the string as an integer literal.
-/// >>> int('0b100', base=0)
-/// 4
 #[pyclass(module = false, name = "int")]
 #[derive(Debug)]
 pub struct PyInt {

--- a/vm/src/builtins/list.rs
+++ b/vm/src/builtins/list.rs
@@ -22,10 +22,6 @@ use crate::{
 };
 use std::{fmt, ops::DerefMut};
 
-/// Built-in mutable sequence.
-///
-/// If no argument is given, the constructor creates a new empty list.
-/// The argument must be an iterable if specified.
 #[pyclass(module = false, name = "list")]
 #[derive(Default)]
 pub struct PyList {

--- a/vm/src/builtins/map.rs
+++ b/vm/src/builtins/map.rs
@@ -8,10 +8,6 @@ use crate::{
     Context, Py, PyObjectRef, PyPayload, PyResult, VirtualMachine,
 };
 
-/// map(func, *iterables) --> map object
-///
-/// Make an iterator that computes the function using arguments from
-/// each of the iterables. Stops when the shortest iterable is exhausted.
 #[pyclass(module = false, name = "map")]
 #[derive(Debug)]
 pub struct PyMap {

--- a/vm/src/builtins/property.rs
+++ b/vm/src/builtins/property.rs
@@ -10,38 +10,6 @@ use crate::{
     AsObject, Context, Py, PyObjectRef, PyPayload, PyRef, PyResult, TryFromObject, VirtualMachine,
 };
 
-/// Property attribute.
-///
-///   fget
-///     function to be used for getting an attribute value
-///   fset
-///     function to be used for setting an attribute value
-///   fdel
-///     function to be used for del'ing an attribute
-///   doc
-///     docstring
-///
-/// Typical use is to define a managed attribute x:
-///
-/// class C(object):
-///     def getx(self): return self._x
-///     def setx(self, value): self._x = value
-///     def delx(self): del self._x
-///     x = property(getx, setx, delx, "I'm the 'x' property.")
-///
-/// Decorators make defining new properties or modifying existing ones easy:
-///
-/// class C(object):
-///     @property
-///     def x(self):
-///         "I am the 'x' property."
-///         return self._x
-///     @x.setter
-///     def x(self, value):
-///         self._x = value
-///     @x.deleter
-///     def x(self):
-///         del self._x
 #[pyclass(module = false, name = "property")]
 #[derive(Debug)]
 pub struct PyProperty {

--- a/vm/src/builtins/range.rs
+++ b/vm/src/builtins/range.rs
@@ -59,14 +59,6 @@ fn iter_search(
     }
 }
 
-/// range(stop) -> range object
-/// range(start, stop[, step]) -> range object
-///
-/// Return an object that produces a sequence of integers from start (inclusive)
-/// to stop (exclusive) by step.  range(i, j) produces i, i+1, i+2, ..., j-1.
-/// start defaults to 0, and stop is omitted!  range(4) produces 0, 1, 2, 3.
-/// These are exactly the valid indices for a list of 4 elements.
-/// When step is given, it specifies the increment (or decrement).
 #[pyclass(module = false, name = "range")]
 #[derive(Debug, Clone)]
 pub struct PyRange {

--- a/vm/src/builtins/set.rs
+++ b/vm/src/builtins/set.rs
@@ -25,10 +25,6 @@ use std::{fmt, ops::Deref};
 
 pub type SetContentType = dictdatatype::Dict<()>;
 
-/// set() -> new empty set object
-/// set(iterable) -> new set object
-///
-/// Build an unordered collection of unique elements.
 #[pyclass(module = false, name = "set")]
 #[derive(Default)]
 pub struct PySet {
@@ -71,10 +67,6 @@ impl PySet {
     }
 }
 
-/// frozenset() -> empty frozenset object
-/// frozenset(iterable) -> frozenset object
-///
-/// Build an immutable unordered collection of unique elements.
 #[pyclass(module = false, name = "frozenset")]
 #[derive(Default)]
 pub struct PyFrozenSet {

--- a/vm/src/builtins/str.rs
+++ b/vm/src/builtins/str.rs
@@ -85,16 +85,6 @@ impl TryFromBorrowedObject for String {
     }
 }
 
-/// str(object='') -> str
-/// str(bytes_or_buffer[, encoding[, errors]]) -> str
-///
-/// Create a new string object from the given object. If encoding or
-/// errors is specified, then the object must expose a data buffer
-/// that will be decoded using the given encoding and error handler.
-/// Otherwise, returns the result of object.__str__() (if defined)
-/// or repr(object).
-/// encoding defaults to sys.getdefaultencoding().
-/// errors defaults to 'strict'."
 #[pyclass(module = false, name = "str")]
 pub struct PyStr {
     bytes: Box<[u8]>,

--- a/vm/src/builtins/tuple.rs
+++ b/vm/src/builtins/tuple.rs
@@ -20,10 +20,6 @@ use crate::{
 };
 use std::{fmt, marker::PhantomData};
 
-/// tuple() -> empty tuple
-/// tuple(iterable) -> tuple initialized from iterable's items
-///
-/// If the argument is a tuple, the return value is the same object.
 #[pyclass(module = false, name = "tuple")]
 pub struct PyTuple {
     elements: Box<[PyObjectRef]>,

--- a/vm/src/stdlib/builtins.rs
+++ b/vm/src/stdlib/builtins.rs
@@ -3,9 +3,6 @@
 //! Implements the list of [builtin Python functions](https://docs.python.org/3/library/builtins.html).
 use crate::{class::PyClassImpl, PyObjectRef, VirtualMachine};
 
-/// Built-in functions, exceptions, and other objects.
-///
-/// Noteworthy: None is the `nil' object; Ellipsis represents `...' in slices.
 #[pymodule]
 mod builtins {
     use crate::{
@@ -243,8 +240,6 @@ mod builtins {
         }
     }
 
-    /// Implements `eval`.
-    /// See also: https://docs.python.org/3/library/functions.html#eval
     #[pyfunction]
     fn eval(
         source: Either<ArgStrOrBytesLike, PyRef<crate::builtins::PyCode>>,
@@ -277,8 +272,6 @@ mod builtins {
         run_code(vm, code, scope, crate::compiler::Mode::Eval, "eval")
     }
 
-    /// Implements `exec`
-    /// https://docs.python.org/3/library/functions.html#exec
     #[pyfunction]
     fn exec(
         source: Either<PyStrRef, PyRef<crate::builtins::PyCode>>,

--- a/vm/src/stdlib/operator.rs
+++ b/vm/src/stdlib/operator.rs
@@ -1,12 +1,5 @@
 pub(crate) use _operator::make_module;
 
-/// Operator Interface
-///
-/// This module exports a set of functions corresponding to the intrinsic
-/// operators of Python.  For example, operator.add(x, y) is equivalent
-/// to the expression x+y.  The function names are those used for special
-/// methods; variants without leading and trailing '__' are also provided
-/// for convenience.
 #[pymodule]
 mod _operator {
     use crate::common::cmp;
@@ -21,85 +14,71 @@ mod _operator {
         AsObject, Py, PyObjectRef, PyPayload, PyRef, PyResult, VirtualMachine,
     };
 
-    /// Same as a < b.
     #[pyfunction]
     fn lt(a: PyObjectRef, b: PyObjectRef, vm: &VirtualMachine) -> PyResult {
         a.rich_compare(b, PyComparisonOp::Lt, vm)
     }
 
-    /// Same as a <= b.
     #[pyfunction]
     fn le(a: PyObjectRef, b: PyObjectRef, vm: &VirtualMachine) -> PyResult {
         a.rich_compare(b, PyComparisonOp::Le, vm)
     }
 
-    /// Same as a > b.
     #[pyfunction]
     fn gt(a: PyObjectRef, b: PyObjectRef, vm: &VirtualMachine) -> PyResult {
         a.rich_compare(b, PyComparisonOp::Gt, vm)
     }
 
-    /// Same as a >= b.
     #[pyfunction]
     fn ge(a: PyObjectRef, b: PyObjectRef, vm: &VirtualMachine) -> PyResult {
         a.rich_compare(b, PyComparisonOp::Ge, vm)
     }
 
-    /// Same as a == b.
     #[pyfunction]
     fn eq(a: PyObjectRef, b: PyObjectRef, vm: &VirtualMachine) -> PyResult {
         a.rich_compare(b, PyComparisonOp::Eq, vm)
     }
 
-    /// Same as a != b.
     #[pyfunction]
     fn ne(a: PyObjectRef, b: PyObjectRef, vm: &VirtualMachine) -> PyResult {
         a.rich_compare(b, PyComparisonOp::Ne, vm)
     }
 
-    /// Same as not a.
     #[pyfunction]
     fn not_(a: PyObjectRef, vm: &VirtualMachine) -> PyResult<bool> {
         a.try_to_bool(vm).map(|r| !r)
     }
 
-    /// Return True if a is true, False otherwise.
     #[pyfunction]
     fn truth(a: PyObjectRef, vm: &VirtualMachine) -> PyResult<bool> {
         a.try_to_bool(vm)
     }
 
-    /// Same as a is b.
     #[pyfunction]
     fn is_(a: PyObjectRef, b: PyObjectRef) -> PyResult<bool> {
         Ok(a.is(&b))
     }
 
-    /// Same as a is not b.
     #[pyfunction]
     fn is_not(a: PyObjectRef, b: PyObjectRef) -> PyResult<bool> {
         Ok(!a.is(&b))
     }
 
-    /// Return the absolute value of the argument.
     #[pyfunction]
     fn abs(a: PyObjectRef, vm: &VirtualMachine) -> PyResult {
         vm._abs(&a)
     }
 
-    /// Return a + b, for a and b numbers.
     #[pyfunction]
     fn add(a: PyObjectRef, b: PyObjectRef, vm: &VirtualMachine) -> PyResult {
         vm._add(&a, &b)
     }
 
-    /// Return the bitwise and of a and b.
     #[pyfunction]
     fn and_(a: PyObjectRef, b: PyObjectRef, vm: &VirtualMachine) -> PyResult {
         vm._and(&a, &b)
     }
 
-    /// Return a // b.
     #[pyfunction]
     fn floordiv(a: PyObjectRef, b: PyObjectRef, vm: &VirtualMachine) -> PyResult {
         vm._floordiv(&a, &b)
@@ -107,85 +86,71 @@ mod _operator {
 
     // Note: Keep track of issue17567. Will need changes in order to strictly match behavior of
     // a.__index__ as raised in the issue. Currently, we accept int subclasses.
-    /// Return a converted to an integer. Equivalent to a.__index__().
     #[pyfunction]
     fn index(a: PyObjectRef, vm: &VirtualMachine) -> PyResult<PyIntRef> {
         a.try_index(vm)
     }
 
-    /// Return the bitwise inverse of the number obj. This is equivalent to ~obj.
     #[pyfunction]
     fn invert(pos: PyObjectRef, vm: &VirtualMachine) -> PyResult {
         vm._invert(&pos)
     }
 
-    /// Return a shifted left by b.
     #[pyfunction]
     fn lshift(a: PyObjectRef, b: PyObjectRef, vm: &VirtualMachine) -> PyResult {
         vm._lshift(&a, &b)
     }
 
-    /// Return a % b
     #[pyfunction(name = "mod")]
     fn mod_(a: PyObjectRef, b: PyObjectRef, vm: &VirtualMachine) -> PyResult {
         vm._mod(&a, &b)
     }
 
-    /// Return a * b
     #[pyfunction]
     fn mul(a: PyObjectRef, b: PyObjectRef, vm: &VirtualMachine) -> PyResult {
         vm._mul(&a, &b)
     }
 
-    /// Return a @ b
     #[pyfunction]
     fn matmul(a: PyObjectRef, b: PyObjectRef, vm: &VirtualMachine) -> PyResult {
         vm._matmul(&a, &b)
     }
 
-    /// Return obj negated (-obj).
     #[pyfunction]
     fn neg(pos: PyObjectRef, vm: &VirtualMachine) -> PyResult {
         vm._neg(&pos)
     }
 
-    /// Return the bitwise or of a and b.
     #[pyfunction]
     fn or_(a: PyObjectRef, b: PyObjectRef, vm: &VirtualMachine) -> PyResult {
         vm._or(&a, &b)
     }
 
-    /// Return obj positive (+obj).
     #[pyfunction]
     fn pos(obj: PyObjectRef, vm: &VirtualMachine) -> PyResult {
         vm._pos(&obj)
     }
 
-    /// Return a ** b, for a and b numbers.
     #[pyfunction]
     fn pow(a: PyObjectRef, b: PyObjectRef, vm: &VirtualMachine) -> PyResult {
         vm._pow(&a, &b)
     }
 
-    /// Return a shifted right by b.
     #[pyfunction]
     fn rshift(a: PyObjectRef, b: PyObjectRef, vm: &VirtualMachine) -> PyResult {
         vm._rshift(&a, &b)
     }
 
-    /// Return a - b.
     #[pyfunction]
     fn sub(a: PyObjectRef, b: PyObjectRef, vm: &VirtualMachine) -> PyResult {
         vm._sub(&a, &b)
     }
 
-    /// Return a / b where 2/3 is .66 rather than 0. This is also known as "true" division.
     #[pyfunction]
     fn truediv(a: PyObjectRef, b: PyObjectRef, vm: &VirtualMachine) -> PyResult {
         vm._truediv(&a, &b)
     }
 
-    /// Return the bitwise exclusive or of a and b.
     #[pyfunction]
     fn xor(a: PyObjectRef, b: PyObjectRef, vm: &VirtualMachine) -> PyResult {
         vm._xor(&a, &b)
@@ -193,7 +158,6 @@ mod _operator {
 
     // Sequence based operators
 
-    /// Return a + b for a and b sequences.
     #[pyfunction]
     fn concat(a: PyObjectRef, b: PyObjectRef, vm: &VirtualMachine) -> PyResult {
         // Best attempt at checking that a is sequence-like.
@@ -207,13 +171,11 @@ mod _operator {
         vm._add(&a, &b)
     }
 
-    /// Return the outcome of the test b in a. Note the reversed operands.
     #[pyfunction]
     fn contains(a: PyObjectRef, b: PyObjectRef, vm: &VirtualMachine) -> PyResult {
         vm._contains(a, b)
     }
 
-    /// Return the number of occurrences of b in a.
     #[pyfunction(name = "countOf")]
     fn count_of(a: PyIter, b: PyObjectRef, vm: &VirtualMachine) -> PyResult<usize> {
         let mut count: usize = 0;
@@ -226,19 +188,16 @@ mod _operator {
         Ok(count)
     }
 
-    /// Remove the value of a at index b.
     #[pyfunction]
     fn delitem(a: PyObjectRef, b: PyObjectRef, vm: &VirtualMachine) -> PyResult<()> {
         a.del_item(&*b, vm)
     }
 
-    /// Return the value of a at index b.
     #[pyfunction]
     fn getitem(a: PyObjectRef, b: PyObjectRef, vm: &VirtualMachine) -> PyResult {
         a.get_item(&*b, vm)
     }
 
-    /// Return the number of occurrences of b in a.
     #[pyfunction(name = "indexOf")]
     fn index_of(a: PyIter, b: PyObjectRef, vm: &VirtualMachine) -> PyResult<usize> {
         for (index, element) in a.iter_without_hint::<PyObjectRef>(vm)?.enumerate() {
@@ -250,7 +209,6 @@ mod _operator {
         Err(vm.new_value_error("sequence.index(x): x not in sequence".to_owned()))
     }
 
-    /// Set the value of a at index b to c.
     #[pyfunction]
     fn setitem(
         a: PyObjectRef,
@@ -261,13 +219,6 @@ mod _operator {
         a.set_item(&*b, c, vm)
     }
 
-    /// Return an estimate of the number of items in obj.
-    ///
-    /// This is useful for presizing containers when building from an iterable.
-    ///
-    /// If the object supports len(), the result will be exact.
-    /// Otherwise, it may over- or under-estimate by an arbitrary amount.
-    /// The result will be an integer >= 0.
     #[pyfunction]
     fn length_hint(obj: PyObjectRef, default: OptionalArg, vm: &VirtualMachine) -> PyResult<usize> {
         let default: usize = default
@@ -286,19 +237,16 @@ mod _operator {
 
     // Inplace Operators
 
-    /// a = iadd(a, b) is equivalent to a += b.
     #[pyfunction]
     fn iadd(a: PyObjectRef, b: PyObjectRef, vm: &VirtualMachine) -> PyResult {
         vm._iadd(&a, &b)
     }
 
-    /// a = iand(a, b) is equivalent to a &= b.
     #[pyfunction]
     fn iand(a: PyObjectRef, b: PyObjectRef, vm: &VirtualMachine) -> PyResult {
         vm._iand(&a, &b)
     }
 
-    /// a = iconcat(a, b) is equivalent to a += b for a and b sequences.
     #[pyfunction]
     fn iconcat(a: PyObjectRef, b: PyObjectRef, vm: &VirtualMachine) -> PyResult {
         // Best attempt at checking that a is sequence-like.
@@ -312,83 +260,61 @@ mod _operator {
         vm._iadd(&a, &b)
     }
 
-    /// a = ifloordiv(a, b) is equivalent to a //= b.
     #[pyfunction]
     fn ifloordiv(a: PyObjectRef, b: PyObjectRef, vm: &VirtualMachine) -> PyResult {
         vm._ifloordiv(&a, &b)
     }
 
-    /// a = ilshift(a, b) is equivalent to a <<= b.
     #[pyfunction]
     fn ilshift(a: PyObjectRef, b: PyObjectRef, vm: &VirtualMachine) -> PyResult {
         vm._ilshift(&a, &b)
     }
 
-    /// a = imod(a, b) is equivalent to a %= b.
     #[pyfunction]
     fn imod(a: PyObjectRef, b: PyObjectRef, vm: &VirtualMachine) -> PyResult {
         vm._imod(&a, &b)
     }
 
-    /// a = imul(a, b) is equivalent to a *= b.
     #[pyfunction]
     fn imul(a: PyObjectRef, b: PyObjectRef, vm: &VirtualMachine) -> PyResult {
         vm._imul(&a, &b)
     }
 
-    /// a = imatmul(a, b) is equivalent to a @= b.
     #[pyfunction]
     fn imatmul(a: PyObjectRef, b: PyObjectRef, vm: &VirtualMachine) -> PyResult {
         vm._imatmul(&a, &b)
     }
 
-    /// a = ior(a, b) is equivalent to a |= b.
     #[pyfunction]
     fn ior(a: PyObjectRef, b: PyObjectRef, vm: &VirtualMachine) -> PyResult {
         vm._ior(&a, &b)
     }
 
-    /// a = ipow(a, b) is equivalent to a **= b.
     #[pyfunction]
     fn ipow(a: PyObjectRef, b: PyObjectRef, vm: &VirtualMachine) -> PyResult {
         vm._ipow(&a, &b)
     }
 
-    /// a = irshift(a, b) is equivalent to a >>= b.
     #[pyfunction]
     fn irshift(a: PyObjectRef, b: PyObjectRef, vm: &VirtualMachine) -> PyResult {
         vm._irshift(&a, &b)
     }
 
-    /// a = isub(a, b) is equivalent to a -= b.
     #[pyfunction]
     fn isub(a: PyObjectRef, b: PyObjectRef, vm: &VirtualMachine) -> PyResult {
         vm._isub(&a, &b)
     }
 
-    /// a = itruediv(a, b) is equivalent to a /= b.
     #[pyfunction]
     fn itruediv(a: PyObjectRef, b: PyObjectRef, vm: &VirtualMachine) -> PyResult {
         vm._itruediv(&a, &b)
     }
 
-    /// a = ixor(a, b) is equivalent to a ^= b.
     #[pyfunction]
     fn ixor(a: PyObjectRef, b: PyObjectRef, vm: &VirtualMachine) -> PyResult {
         vm._ixor(&a, &b)
     }
 
-    /// Return 'a == b'.
-    ///
-    /// This function uses an approach designed to prevent
-    /// timing analysis, making it appropriate for cryptography.
-    ///
-    /// a and b must both be of the same type: either str (ASCII only),
-    /// or any bytes-like object.
-    ///
-    /// Note: If a and b are of different lengths, or if an error occurs,
-    /// a timing attack could theoretically reveal information about the
-    /// types and lengths of a and b--but not their values.
     #[pyfunction]
     fn _compare_digest(
         a: Either<PyStrRef, ArgBytesLike>,

--- a/vm/src/stdlib/posix.rs
+++ b/vm/src/stdlib/posix.rs
@@ -1591,14 +1591,6 @@ pub mod module {
         ]
     }
 
-    /// Return a string containing the name of the user logged in on the
-    /// controlling terminal of the process.
-    ///
-    /// Exceptions:
-    ///
-    /// - `OSError`: Raised if login name could not be determined (`getlogin()`
-    ///   returned a null pointer).
-    /// - `UnicodeDecodeError`: Raised if login name contained invalid UTF-8 bytes.
     #[pyfunction]
     fn getlogin(vm: &VirtualMachine) -> PyResult<String> {
         // Get a pointer to the login name string. The string is statically

--- a/vm/src/stdlib/symtable.rs
+++ b/vm/src/stdlib/symtable.rs
@@ -8,8 +8,6 @@ mod symtable {
     use rustpython_codegen::symboltable::{Symbol, SymbolScope, SymbolTable, SymbolTableType};
     use std::fmt;
 
-    /// symtable. Return top level SymbolTable.
-    /// See docs: https://docs.python.org/3/library/symtable.html?highlight=symtable#symtable.symtable
     #[pyfunction]
     fn symtable(
         source: PyStrRef,


### PR DESCRIPTION
In this revision,
- Remove most of unnecessary remarks about `__doc__`, that already exist in [`Rustpython/__doc__/docs.inc.rs`](https://github.com/RustPython/__doc__/blob/main/docs.inc.rs)
- Not everything, like some remarks in `vm/src/builtins/str.rs` methods. They are not still added to docs.inc.rs.

--- 

Effected files are:
- [X] stdlib/src/bisect.rs
- [X] stdlib/src/cmath.rs
- [X] stdlib/src/zlib.rs
- [X] vm/src/builtins/bool.rs
- [X] vm/src/builtins/dict.rs
- [X] vm/src/builtins/filter.rs
- [X] vm/src/builtins/float.rs
- [X] vm/src/builtins/int.rs
- [X] vm/src/builtins/list.rs
- [X] vm/src/builtins/map.rs
- [X] vm/src/builtins/property.rs
- [X] vm/src/builtins/range.rs
- [X] vm/src/builtins/set.rs
- [X] vm/src/builtins/str.rs
- [X] vm/src/builtins/tuple.rs
- [X] vm/src/stdlib/builtins.rs
- [X]  vm/src/stdlib/operator.rs
- [X] vm/src/stdlib/posix.rs
- [X] vm/src/stdlib/symtable.rs
