### PR TITLE
Chain reduce

### DIFF
--- a/Lib/test/test_itertools.py
+++ b/Lib/test/test_itertools.py
@@ -181,8 +181,6 @@ class TestBasicOps(unittest.TestCase):
         self.assertEqual(take(4, chain.from_iterable(['abc', 'def'])), list('abcd'))
         self.assertRaises(TypeError, list, chain.from_iterable([2, 3]))
 
-    # TODO: RUSTPYTHON
-    @unittest.expectedFailure
     def test_chain_reducible(self):
         for oper in [copy.deepcopy] + picklecopiers:
             it = chain('abc', 'def')
@@ -195,8 +193,7 @@ class TestBasicOps(unittest.TestCase):
             self.assertRaises(TypeError, list, oper(chain(2, 3)))
         for proto in range(pickle.HIGHEST_PROTOCOL + 1):
             self.pickletest(proto, chain('abc', 'def'), compare=list('abcdef'))
-    # TODO: RUSTPYTHON
-    @unittest.expectedFailure
+
     def test_chain_setstate(self):
         self.assertRaises(TypeError, chain().__setstate__, ())
         self.assertRaises(TypeError, chain().__setstate__, [])

--- a/vm/src/stdlib/itertools.rs
+++ b/vm/src/stdlib/itertools.rs
@@ -43,7 +43,7 @@ mod decl {
             .map(Into::into)
         }
 
-        #[pyclassmethod]    
+        #[pyclassmethod]
         fn from_iterable(
             cls: PyTypeRef,
             source: PyObjectRef,
@@ -63,19 +63,17 @@ mod decl {
 
         #[pymethod(magic)]
         fn reduce(zelf: PyRef<Self>, vm: &VirtualMachine) -> PyResult<PyTupleRef> {
-            let source =  zelf.source.read().clone();
+            let source = zelf.source.read().clone();
             let active = zelf.active.read().clone();
             let cls = zelf.class().to_owned();
             match source {
-                Some(source) => {
-                    match active {
-                        Some(active) => {
-                            Ok(vm.new_tuple((cls, vm.ctx.empty_tuple.clone(), (source, active))))
-                        },
-                        None => Ok(vm.new_tuple((cls, vm.ctx.empty_tuple.clone(), (source, ))))
+                Some(source) => match active {
+                    Some(active) => {
+                        Ok(vm.new_tuple((cls, vm.ctx.empty_tuple.clone(), (source, active))))
                     }
+                    None => Ok(vm.new_tuple((cls, vm.ctx.empty_tuple.clone(), (source,)))),
                 },
-                None => Ok(vm.new_tuple((cls, vm.ctx.empty_tuple.clone())))
+                None => Ok(vm.new_tuple((cls, vm.ctx.empty_tuple.clone()))),
             }
         }
     }

--- a/vm/src/stdlib/itertools.rs
+++ b/vm/src/stdlib/itertools.rs
@@ -65,7 +65,7 @@ mod decl {
         fn reduce(zelf: PyRef<Self>, vm: &VirtualMachine) -> PyResult<PyTupleRef> {
             let source =  zelf.source.read().clone();
             let active = zelf.active.read().clone();
-            let cls = zelf.class().clone();
+            let cls = zelf.class().to_owned();
             match source {
                 Some(source) => {
                     match active {
@@ -165,8 +165,8 @@ mod decl {
         #[pymethod(magic)]
         fn reduce(zelf: PyRef<Self>) -> (PyTypeRef, (PyIter, PyIter)) {
             (
-                zelf.class().clone(),
-                (zelf.data.clone(), zelf.selectors.clone()),
+                zelf.class().to_owned(),
+                (zelf.data.to_owned(), zelf.selectors.clone()),
             )
         }
     }
@@ -179,7 +179,7 @@ mod decl {
                     PyIterReturn::Return(obj) => obj,
                     PyIterReturn::StopIteration(v) => return Ok(PyIterReturn::StopIteration(v)),
                 };
-                let verdict = sel_obj.clone().try_to_bool(vm)?;
+                let verdict = sel_obj.to_owned().try_to_bool(vm)?;
                 let data_obj = zelf.data.next(vm)?;
 
                 if verdict {
@@ -236,7 +236,7 @@ mod decl {
         //      return Py_BuildValue("0(00)", Py_TYPE(lz), lz->long_cnt, lz->long_step);
         #[pymethod(magic)]
         fn reduce(zelf: PyRef<Self>) -> (PyTypeRef, (PyObjectRef,)) {
-            (zelf.class().clone(), (zelf.cur.read().clone(),))
+            (zelf.class().to_owned(), (zelf.cur.read().clone(),))
         }
 
         #[pymethod(magic)]
@@ -361,7 +361,7 @@ mod decl {
 
         #[pymethod(magic)]
         fn reduce(zelf: PyRef<Self>, vm: &VirtualMachine) -> PyResult<PyTupleRef> {
-            let cls = zelf.class().clone();
+            let cls = zelf.class().to_owned();
             Ok(match zelf.times {
                 Some(ref times) => vm.new_tuple((cls, (zelf.object.clone(), *times.read()))),
                 None => vm.new_tuple((cls, (zelf.object.clone(),))),
@@ -428,7 +428,7 @@ mod decl {
         #[pymethod(magic)]
         fn reduce(zelf: PyRef<Self>) -> (PyTypeRef, (PyObjectRef, PyIter)) {
             (
-                zelf.class().clone(),
+                zelf.class().to_owned(),
                 (zelf.function.clone(), zelf.iterable.clone()),
             )
         }
@@ -491,7 +491,7 @@ mod decl {
         #[pymethod(magic)]
         fn reduce(zelf: PyRef<Self>) -> (PyTypeRef, (PyObjectRef, PyIter), BigInt) {
             (
-                zelf.class().clone(),
+                zelf.class().to_owned(),
                 (zelf.predicate.clone(), zelf.iterable.clone()),
                 (if zelf.stop_flag.load() { 1 } else { 0 }).into(),
             )
@@ -572,7 +572,7 @@ mod decl {
         #[pymethod(magic)]
         fn reduce(zelf: PyRef<Self>) -> (PyTypeRef, (PyObjectRef, PyIter), BigInt) {
             (
-                zelf.class().clone(),
+                zelf.class().to_owned(),
                 (zelf.predicate.clone().into(), zelf.iterable.clone()),
                 (if zelf.start_flag.load() { 1 } else { 0 }).into(),
             )
@@ -967,7 +967,7 @@ mod decl {
         #[pymethod(magic)]
         fn reduce(zelf: PyRef<Self>) -> (PyTypeRef, (PyObjectRef, PyIter)) {
             (
-                zelf.class().clone(),
+                zelf.class().to_owned(),
                 (zelf.predicate.clone(), zelf.iterable.clone()),
             )
         }

--- a/vm/src/stdlib/itertools.rs
+++ b/vm/src/stdlib/itertools.rs
@@ -69,7 +69,7 @@ mod decl {
             match source {
                 Some(source) => match active {
                     Some(active) => {
-                        Ok(vm.new_tuple((cls, vm.ctx.empty_tuple.clone(), ((source, active)))))
+                        Ok(vm.new_tuple((cls, vm.ctx.empty_tuple.clone(), (source, active))))
                     }
                     None => Ok(vm.new_tuple((cls, vm.ctx.empty_tuple.clone(), (source,)))),
                 },

--- a/vm/src/stdlib/itertools.rs
+++ b/vm/src/stdlib/itertools.rs
@@ -76,26 +76,6 @@ mod decl {
                 None => Ok(vm.new_tuple((cls, vm.ctx.empty_tuple.clone()))),
             }
         }
-
-        #[pymethod(magic)]
-        fn reduce_ex(
-            zelf: PyRef<Self>,
-            _proto: usize,
-            vm: &VirtualMachine,
-        ) -> PyResult<PyTupleRef> {
-            let source = zelf.source.read().clone();
-            let active = zelf.active.read().clone();
-            let cls = zelf.class().to_owned();
-            match source {
-                Some(source) => match active {
-                    Some(active) => {
-                        Ok(vm.new_tuple((cls, vm.ctx.empty_tuple.clone(), ((source, active)))))
-                    }
-                    None => Ok(vm.new_tuple((cls, vm.ctx.empty_tuple.clone(), (source,)))),
-                },
-                None => Ok(vm.new_tuple((cls, vm.ctx.empty_tuple.clone()))),
-            }
-        }
     }
     impl IterNextIterable for PyItertoolsChain {}
     impl IterNext for PyItertoolsChain {

--- a/vm/src/stdlib/itertools.rs
+++ b/vm/src/stdlib/itertools.rs
@@ -78,7 +78,11 @@ mod decl {
         }
 
         #[pymethod(magic)]
-        fn reduce_ex(zelf: PyRef<Self>, _proto: usize, vm: &VirtualMachine) -> PyResult<PyTupleRef> {
+        fn reduce_ex(
+            zelf: PyRef<Self>,
+            _proto: usize,
+            vm: &VirtualMachine,
+        ) -> PyResult<PyTupleRef> {
             let source = zelf.source.read().clone();
             let active = zelf.active.read().clone();
             let cls = zelf.class().to_owned();

--- a/vm/src/stdlib/itertools.rs
+++ b/vm/src/stdlib/itertools.rs
@@ -60,6 +60,23 @@ mod decl {
         fn class_getitem(cls: PyTypeRef, args: PyObjectRef, vm: &VirtualMachine) -> PyGenericAlias {
             PyGenericAlias::new(cls, args, vm)
         }
+
+        #[pymethod(magic)]
+        fn reduce(zelf: PyRef<Self>, vm: &VirtualMachine) -> PyResult<PyTupleRef> {
+            let source =  zelf.source.read().clone();
+            let active = zelf.active.read().clone();
+            match source {
+                Some(source) => {
+                    match active {
+                        Some(active) => {
+                            Ok(vm.new_tuple((zelf.class().clone(), vm.ctx.empty_tuple.clone(), (source, active))))
+                        },
+                        None => Ok(vm.new_tuple((zelf.class().clone(), vm.ctx.empty_tuple.clone(), (source, ))))
+                    }
+                },
+                None => Ok(vm.new_tuple((zelf.class().clone(), vm.ctx.empty_tuple.clone())))
+            }
+        }
     }
     impl IterNextIterable for PyItertoolsChain {}
     impl IterNext for PyItertoolsChain {


### PR DESCRIPTION
Hello!

I tried to implement the `reduce` method for `PyItertoolsChain` (issue #3611) but got stuck. I used the [CPython implementation](https://github.com/python/cpython/blob/9608bef84afd797ba6d16ec97439909f2f0d1095/Modules/itertoolsmodule.c#L2276) as a reference. The implementation seems to work just fine with simple arrays etc. but fails the `test_chain_reducible` test. Any suggestions on why?

The error message:
```
ERROR: test_chain_reducible (test.test_itertools.TestBasicOps)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/home/dan/Projects/RustPython/pylib/Lib/test/test_itertools.py", line 187, in test_chain_reducible
    self.assertEqual(list(oper(it)), list('abcdef'))
  File "/home/dan/Projects/RustPython/pylib/Lib/copy.py", line 172, in deepcopy
    y = _reconstruct(x, memo, *rv)
  File "/home/dan/Projects/RustPython/pylib/Lib/copy.py", line 279, in _reconstruct
    y.__dict__.update(state)
AttributeError: 'chain' object has no attribute '__dict__'

----------------------------------------------------------------------

```