### PR TITLE
Fix `global` behavior on class

### DIFF
--- a/Lib/test/test_dataclasses.py
+++ b/Lib/test/test_dataclasses.py
@@ -1925,8 +1925,6 @@ class TestCase(unittest.TestCase):
         # Check MRO resolution.
         self.assertEqual(Child.__mro__, (Child, Parent, Generic, object))
 
-    # TODO: RUSTPYTHON
-    @unittest.expectedFailure
     def test_dataclasses_pickleable(self):
         global P, Q, R
         @dataclass

--- a/Lib/test/test_pickle.py
+++ b/Lib/test/test_pickle.py
@@ -110,10 +110,8 @@ class PyPicklerTests(AbstractPickleTests, unittest.TestCase):
     def test_in_band_buffers(self): # TODO: RUSTPYTHON, remove when this passes
         super().test_in_band_buffers() # TODO: RUSTPYTHON, remove when this passes
 
-    # TODO: RUSTPYTHON, pickle.PicklingError
-    @unittest.expectedFailure
-    def test_nested_names(self): # TODO: RUSTPYTHON, remove when this passes
-        super().test_nested_names() # TODO: RUSTPYTHON, remove when this passes
+    def test_nested_names(self):
+        super().test_nested_names()
 
     # TODO: RUSTPYTHON, AttributeError: module 'pickle' has no attribute 'PickleBuffer'
     @unittest.expectedFailure
@@ -201,10 +199,8 @@ class InMemoryPickleTests(AbstractPickleTests, AbstractUnpickleTests,
     def test_load_python2_str_as_bytes(self): # TODO: RUSTPYTHON, remove when this passes
         super().test_load_python2_str_as_bytes() # TODO: RUSTPYTHON, remove when this passes
 
-    # TODO: RUSTPYTHON, pickle.PicklingError
-    @unittest.expectedFailure
-    def test_nested_names(self): # TODO: RUSTPYTHON, remove when this passes
-        super().test_nested_names() # TODO: RUSTPYTHON, remove when this passes
+    def test_nested_names(self):
+        super().test_nested_names()
 
     # TODO: RUSTPYTHON, AttributeError: module 'pickle' has no attribute 'PickleBuffer'
     @unittest.expectedFailure

--- a/Lib/test/test_pickle.py
+++ b/Lib/test/test_pickle.py
@@ -110,9 +110,6 @@ class PyPicklerTests(AbstractPickleTests, unittest.TestCase):
     def test_in_band_buffers(self): # TODO: RUSTPYTHON, remove when this passes
         super().test_in_band_buffers() # TODO: RUSTPYTHON, remove when this passes
 
-    def test_nested_names(self):
-        super().test_nested_names()
-
     # TODO: RUSTPYTHON, AttributeError: module 'pickle' has no attribute 'PickleBuffer'
     @unittest.expectedFailure
     def test_oob_buffers(self): # TODO: RUSTPYTHON, remove when this passes
@@ -198,9 +195,6 @@ class InMemoryPickleTests(AbstractPickleTests, AbstractUnpickleTests,
     @unittest.expectedFailure
     def test_load_python2_str_as_bytes(self): # TODO: RUSTPYTHON, remove when this passes
         super().test_load_python2_str_as_bytes() # TODO: RUSTPYTHON, remove when this passes
-
-    def test_nested_names(self):
-        super().test_nested_names()
 
     # TODO: RUSTPYTHON, AttributeError: module 'pickle' has no attribute 'PickleBuffer'
     @unittest.expectedFailure

--- a/Lib/test/test_pickletools.py
+++ b/Lib/test/test_pickletools.py
@@ -35,9 +35,6 @@ class OptimizedPickleTests(AbstractPickleTests, unittest.TestCase):
     def test_in_band_buffers(self): # TODO: RUSTPYTHON, remove when this passes
         super().test_in_band_buffers()
 
-    def test_nested_names(self):
-        super().test_nested_names()
-
     def test_notimplemented(self): # TODO: RUSTPYTHON, remove when this passes
         super().test_notimplemented()
 

--- a/Lib/test/test_pickletools.py
+++ b/Lib/test/test_pickletools.py
@@ -35,9 +35,7 @@ class OptimizedPickleTests(AbstractPickleTests, unittest.TestCase):
     def test_in_band_buffers(self): # TODO: RUSTPYTHON, remove when this passes
         super().test_in_band_buffers()
 
-    # TODO: RUSTPYTHON, pickle.PicklingError
-    @unittest.expectedFailure
-    def test_nested_names(self): # TODO: RUSTPYTHON, remove when this passes
+    def test_nested_names(self):
         super().test_nested_names()
 
     def test_notimplemented(self): # TODO: RUSTPYTHON, remove when this passes

--- a/Lib/test/test_typing.py
+++ b/Lib/test/test_typing.py
@@ -1581,8 +1581,6 @@ class ProtocolTests(BaseTestCase):
         Alias2 = typing.Union[P, typing.Iterable]
         self.assertEqual(Alias, Alias2)
 
-    # TODO: RUSTPYTHON
-    @unittest.expectedFailure
     def test_protocols_pickleable(self):
         global P, CP  # pickle wants to reference the class by name
         T = TypeVar('T')
@@ -2186,8 +2184,6 @@ class GenericTests(BaseTestCase):
                     self.assertNotEqual(repr(base), '')
                     self.assertEqual(base, base)
 
-    # TODO: RUSTPYTHON
-    @unittest.expectedFailure
     def test_pickle(self):
         global C  # pickle wants to reference the class by name
         T = TypeVar('T')
@@ -4802,8 +4798,6 @@ class AnnotatedTests(BaseTestCase):
         with self.assertRaisesRegex(TypeError, 'at least two arguments'):
             Annotated[int]
 
-    # TODO: RUSTPYTHON
-    @unittest.expectedFailure
     def test_pickle(self):
         samples = [typing.Any, typing.Union[int, str],
                    typing.Optional[str], Tuple[int, ...],

--- a/compiler/codegen/src/compile.rs
+++ b/compiler/codegen/src/compile.rs
@@ -1282,8 +1282,8 @@ impl Compiler {
         );
         let mut prefix_path = vec![];
         if symbol.scope == SymbolScope::GlobalExplicit {
-            while let Some(val1) = self.qualified_path.pop() {
-                prefix_path.insert(0, val1);
+            while let Some(value) = self.qualified_path.pop() {
+                prefix_path.insert(0, value);
             }
         }
         self.push_qualified_path(name);

--- a/compiler/codegen/src/compile.rs
+++ b/compiler/codegen/src/compile.rs
@@ -1342,7 +1342,7 @@ impl Compiler {
         self.emit(Instruction::MakeFunction(funcflags));
 
         self.emit_constant(ConstantData::Str {
-            value: qualified_name,
+            value: name.to_owned(),
         });
 
         let call = self.compile_call_inner(2, bases, keywords)?;

--- a/compiler/codegen/src/compile.rs
+++ b/compiler/codegen/src/compile.rs
@@ -1298,7 +1298,7 @@ impl Compiler {
         let dunder_module = self.name("__module__");
         self.emit(Instruction::StoreLocal(dunder_module));
         self.emit_constant(ConstantData::Str {
-            value: qualified_name.clone(),
+            value: qualified_name,
         });
         let qualname = self.name("__qualname__");
         self.emit(Instruction::StoreLocal(qualname));

--- a/compiler/codegen/src/compile.rs
+++ b/compiler/codegen/src/compile.rs
@@ -1282,7 +1282,7 @@ impl Compiler {
         );
         let mut global_path_prefix = Vec::new();
         if symbol.scope == SymbolScope::GlobalExplicit {
-            global_path_prefix.extend(self.qualified_path.drain(..));
+            global_path_prefix.append(&mut self.qualified_path);
         }
         self.push_qualified_path(name);
         let qualified_name = self.qualified_path.join(".");

--- a/compiler/codegen/src/compile.rs
+++ b/compiler/codegen/src/compile.rs
@@ -1280,11 +1280,9 @@ impl Compiler {
         let symbol = symbol_table.lookup(name.as_ref()).expect(
             "The symbol must be present in the symbol table, even when it is undefined in python.",
         );
-        let mut prefix_path = vec![];
+        let mut global_path_prefix = Vec::new();
         if symbol.scope == SymbolScope::GlobalExplicit {
-            while let Some(value) = self.qualified_path.pop() {
-                prefix_path.insert(0, value);
-            }
+            global_path_prefix.extend(self.qualified_path.drain(..));
         }
         self.push_qualified_path(name);
         let qualified_name = self.qualified_path.join(".");
@@ -1334,7 +1332,7 @@ impl Compiler {
 
         self.class_name = prev_class_name;
         self.qualified_path.pop();
-        self.qualified_path.append(prefix_path.as_mut());
+        self.qualified_path.append(global_path_prefix.as_mut());
         self.ctx = prev_ctx;
 
         let mut funcflags = bytecode::MakeFunctionFlags::empty();


### PR DESCRIPTION
Fix #3993 

This pr tries to fix the compile time issue for `global` declaration.

Since lots of the tests under `Lib/test` used `global SomeClass` inside their test methods, this fix might help in the future.
e.g. Test `test_dataclasses_pickleable` has passed because the global classes are pickleable after this fix.

---

Take the following code snippet as example:
```python
def test_c_methods():
    global Subclass
    class Subclass(tuple):
        class Nested(str):
            pass

test_c_methods()
```
The result before this pr:

```
>>>>> Subclass.__qualname__
'test_c_methods.<locals>.Subclass'
>>>>>
>>>>> Subclass.Nested.__qualname__
'test_c_methods.<locals>.Subclass.Nested'
```

The result after fix:
```
>>> Subclass.__qualname__
'Subclass'
>>>
>>> Subclass.Nested.__qualname__
'Subclass.Nested'
```




