### PR TITLE
Fix compatibility bug for min/max builtins

### DIFF
--- a/Lib/test/test_builtin.py
+++ b/Lib/test/test_builtin.py
@@ -1027,8 +1027,6 @@ class BuiltinTest(unittest.TestCase):
             m2 = map(map_char, "Is this the real life?")
             self.check_iter_pickle(m1, list(m2), proto)
 
-    # TODO: RUSTPYTHON
-    @unittest.expectedFailure
     def test_max(self):
         self.assertEqual(max('123123'), '3')
         self.assertEqual(max(1, 2, 3), 3)
@@ -1088,8 +1086,6 @@ class BuiltinTest(unittest.TestCase):
         self.assertEqual(max(data, key=f),
                          sorted(reversed(data), key=f)[-1])
 
-    # TODO: RUSTPYTHON
-    @unittest.expectedFailure
     def test_min(self):
         self.assertEqual(min('123123'), '1')
         self.assertEqual(min(1, 2, 3), 1)

--- a/vm/src/stdlib/builtins.rs
+++ b/vm/src/stdlib/builtins.rs
@@ -478,7 +478,7 @@ mod builtins {
             std::cmp::Ordering::Greater => {
                 if default.is_some() {
                     return Err(vm.new_type_error(format!(
-                        "Cannot specify a default for {} with multiple positional arguments",
+                        "Cannot specify a default for {}() with multiple positional arguments",
                         func_name
                     )));
                 }
@@ -487,7 +487,9 @@ mod builtins {
             std::cmp::Ordering::Equal => args.args[0].try_to_value(vm)?,
             std::cmp::Ordering::Less => {
                 // zero arguments means type error:
-                return Err(vm.new_type_error("Expected 1 or more arguments".to_owned()));
+                return Err(
+                    vm.new_type_error(format!("{} expected at least 1 argument, got 0", func_name))
+                );
             }
         };
 
@@ -496,7 +498,7 @@ mod builtins {
             Some(x) => x,
             None => {
                 return default.ok_or_else(|| {
-                    vm.new_value_error(format!("{} arg is an empty sequence", func_name))
+                    vm.new_value_error(format!("{}() arg is an empty sequence", func_name))
                 })
             }
         };
@@ -524,12 +526,12 @@ mod builtins {
 
     #[pyfunction]
     fn max(args: FuncArgs, vm: &VirtualMachine) -> PyResult {
-        min_or_max(args, vm, "max()", PyComparisonOp::Gt)
+        min_or_max(args, vm, "max", PyComparisonOp::Gt)
     }
 
     #[pyfunction]
     fn min(args: FuncArgs, vm: &VirtualMachine) -> PyResult {
-        min_or_max(args, vm, "min()", PyComparisonOp::Lt)
+        min_or_max(args, vm, "min", PyComparisonOp::Lt)
     }
 
     #[pyfunction]


### PR DESCRIPTION
This was as simple as fixing the error messages produced when zero arguments are passed.

Part of #1671. It was a great first issue to work on!