### PR TITLE
feature: Double drop check in debug mode

### DIFF
--- a/vm/src/object/core.rs
+++ b/vm/src/object/core.rs
@@ -806,6 +806,8 @@ impl PyObject {
             // abort drop for whatever reason
             return;
         }
+
+        *ptr.as_ref().0.is_drop.lock() = true;
         let drop_dealloc = ptr.as_ref().0.vtable.drop_dealloc;
         // call drop only when there are no references in scope - stacked borrows stuff
         drop_dealloc(ptr.as_ptr())
@@ -858,10 +860,10 @@ impl<'a, T: PyObjectPayload> From<&'a Py<T>> for &'a PyObject {
     }
 }
 
+#[cfg(debug_assertions)]
 impl Drop for PyObjectRef {
     #[inline]
     fn drop(&mut self) {
-        #[cfg(debug_assertions)]
         if *self.0.is_drop.lock() {
             error!(
                 "Double drop on PyObjectRef with typeid={:?}(Type={:?})",
@@ -874,10 +876,16 @@ impl Drop for PyObjectRef {
             return;
         }
         if self.0.ref_count.dec() {
-            #[cfg(debug_assertions)]
-            {
-                *self.0.is_drop.lock() = true;
-            }
+            unsafe { PyObject::drop_slow(self.ptr) }
+        }
+    }
+}
+
+#[cfg(not(debug_assertions))]
+impl Drop for PyObjectRef {
+    #[inline]
+    fn drop(&mut self) {
+        if self.0.ref_count.dec() {
             unsafe { PyObject::drop_slow(self.ptr) }
         }
     }
@@ -978,31 +986,35 @@ impl<T: PyObjectPayload> fmt::Debug for PyRef<T> {
     }
 }
 
+#[cfg(debug_assertions)]
 impl<T: PyObjectPayload> Drop for PyRef<T> {
     #[inline]
     fn drop(&mut self) {
-        #[cfg(debug_assertions)]
-        {
-            if *self.0.is_drop.lock() {
-                error!(
-                    "Double drop on PyRef<{}>",
-                    std::any::type_name::<T>().to_string()
-                );
-                return;
-            }
-            let tid = TypeId::of::<T>();
-            ID2TYPE
-                .lock()
-                .expect("can't insert into ID2TYPE")
-                .entry(tid)
-                .or_insert_with(|| std::any::type_name::<T>().to_string());
+        if *self.0.is_drop.lock() {
+            error!(
+                "Double drop on PyRef<{}>",
+                std::any::type_name::<T>().to_string()
+            );
+            return;
         }
+        let tid = TypeId::of::<T>();
+        ID2TYPE
+            .lock()
+            .expect("can't insert into ID2TYPE")
+            .entry(tid)
+            .or_insert_with(|| std::any::type_name::<T>().to_string());
 
         if self.0.ref_count.dec() {
-            #[cfg(debug_assertions)]
-            {
-                *self.0.is_drop.lock() = true;
-            }
+            unsafe { PyObject::drop_slow(self.ptr.cast::<PyObject>()) }
+        }
+    }
+}
+
+#[cfg(not(debug_assertions))]
+impl<T: PyObjectPayload> Drop for PyRef<T> {
+    #[inline]
+    fn drop(&mut self) {
+        if self.0.ref_count.dec() {
             unsafe { PyObject::drop_slow(self.ptr.cast::<PyObject>()) }
         }
     }

--- a/vm/src/object/core.rs
+++ b/vm/src/object/core.rs
@@ -1081,21 +1081,26 @@ impl<T: PyObjectPayload> PyWeakRef<T> {
 /// either given values or explicitly left uninitialized
 macro_rules! partially_init {
     (
-        $ty:path {$($init_field:ident: $init_value:expr),*$(,)?},
+        $ty:path {$($(#[$attr:meta])? $init_field:ident: $init_value:expr),*$(,)?},
         Uninit { $($uninit_field:ident),*$(,)? }$(,)?
     ) => {{
         // check all the fields are there but *don't* actually run it
         if false {
             #[allow(invalid_value, dead_code, unreachable_code)]
             let _ = {$ty {
-                $($init_field: $init_value,)*
+                $(
+                    $(#[$attr])? 
+                    $init_field: $init_value,
+                )*
                 $($uninit_field: unreachable!(),)*
             }};
         }
         let mut m = ::std::mem::MaybeUninit::<$ty>::uninit();
         #[allow(unused_unsafe)]
         unsafe {
-            $(::std::ptr::write(&mut (*m.as_mut_ptr()).$init_field, $init_value);)*
+            $(
+                $(#[$attr])?
+                ::std::ptr::write(&mut (*m.as_mut_ptr()).$init_field, $init_value);)*
         }
         m
     }};


### PR DESCRIPTION
Add a double drop check field for PyInner, which:
- guaranteed not to have False positives，but might have false negative because after drop other things might alter `is_drop` field back to false, also might cause seg fault if others write even more exotic data in it after drop
- only print `[ERROR]` message, but doesn't panic
- only activate in debug mode
- print type name of corrsponding typeid(assuming `TypeId`'s SipHash impl doesn't collide with so few types)