### PR TITLE
Use improved log2() implementation for log10()

### DIFF
--- a/Lib/test/test_long.py
+++ b/Lib/test/test_long.py
@@ -514,8 +514,6 @@ class LongTest(unittest.TestCase):
         self.assertNotEqual(float(shuge), int(shuge),
             "float(shuge) should not equal int(shuge)")
 
-    # TODO: RUSTPYTHON
-    @unittest.expectedFailure
     def test_logs(self):
         LOG10E = math.log10(math.e)
 

--- a/Lib/test/test_math.py
+++ b/Lib/test/test_math.py
@@ -1137,8 +1137,6 @@ class MathTests(unittest.TestCase):
             self.assertEqual(math.ldexp(NINF, n), NINF)
             self.assertTrue(math.isnan(math.ldexp(NAN, n)))
 
-    # TODO: RUSTPYTHON
-    @unittest.expectedFailure
     def testLog(self):
         self.assertRaises(TypeError, math.log)
         self.ftest('log(1/e)', math.log(1/math.e), -1)
@@ -1190,8 +1188,6 @@ class MathTests(unittest.TestCase):
         expected = [float(n) for n in range(-1074, 1024)]
         self.assertEqual(actual, expected)
 
-    # TODO: RUSTPYTHON
-    @unittest.expectedFailure
     def testLog10(self):
         self.assertRaises(TypeError, math.log10)
         self.ftest('log10(0.1)', math.log10(0.1), -1)

--- a/stdlib/src/math.rs
+++ b/stdlib/src/math.rs
@@ -171,7 +171,7 @@ mod math {
             Err(float_err) => {
                 if let Ok(x) = x.try_int(vm) {
                     let x = x.as_bigint();
-                    if x > &BigInt::zero() {
+                    if x.is_positive() {
                         Ok(int_log2(x))
                     } else {
                         Err(vm.new_value_error("math domain error".to_owned()))


### PR DESCRIPTION
This also fixes a bug in the `log2()` implementation, where very large negative integer arguments would not raise an exception (and instead would turn into NaNs).

Follow-up to #4241. Part of #1671.