### PR TITLE
Re-organizing lexer struct

### DIFF
--- a/compiler/parser/src/lexer.rs
+++ b/compiler/parser/src/lexer.rs
@@ -147,11 +147,13 @@ where
 
 pub struct Lexer<T: Iterator<Item = char>> {
     chars: T,
+    window: CharWindow<3>,
+
     at_begin_of_line: bool,
     nesting: usize, // Amount of parenthesis
     indentations: Indentations,
+
     pending: Vec<Spanned>,
-    window: CharWindow<3>,
     location: Location,
 }
 

--- a/compiler/parser/src/lexer.rs
+++ b/compiler/parser/src/lexer.rs
@@ -426,7 +426,7 @@ where
         loop {
             if let Some(c) = self.take_number(radix) {
                 value_text.push(c);
-            } else if self.window[1] == Some('_')
+            } else if self.window[0] == Some('_')
                 && Lexer::<T>::is_digit_of_radix(self.window[1], radix)
             {
                 self.next_char();
@@ -1392,7 +1392,7 @@ mod tests {
 
     #[test]
     fn test_numbers() {
-        let source = "0x2f 0b1101 0 123 0.2 2j 2.2j";
+        let source = "0x2f 0b1101 0 123 123_45_67_890 0.2 2j 2.2j";
         let tokens = lex_source(source);
         assert_eq!(
             tokens,
@@ -1408,6 +1408,9 @@ mod tests {
                 },
                 Tok::Int {
                     value: BigInt::from(123),
+                },
+                Tok::Int {
+                    value: BigInt::from(1234567890),
                 },
                 Tok::Float { value: 0.2 },
                 Tok::Complex {

--- a/compiler/parser/src/lexer.rs
+++ b/compiler/parser/src/lexer.rs
@@ -111,11 +111,8 @@ struct CharWindow<const N: usize>([Option<char>; N]);
 
 impl<const N: usize> CharWindow<N> {
     fn slide(&mut self, next_char: Option<char>) {
-        let len = self.0.len();
-        for i in 0..(len - 1) {
-            self[i] = self[i + 1];
-        }
-        self[len - 1] = next_char;
+        self.0.rotate_left(1);
+        *self.0.last_mut().expect("never empty") = next_char;
     }
 }
 

--- a/compiler/parser/src/lexer.rs
+++ b/compiler/parser/src/lexer.rs
@@ -110,14 +110,18 @@ where
         }
     }
 
-    fn slide(&mut self) {
+    fn slide(&mut self) -> Option<char> {
         self.window.rotate_left(1);
-        *self.window.last_mut().expect("never empty") = self.source.next();
+        let next = self.source.next();
+        *self.window.last_mut().expect("never empty") = next;
+        next
     }
 
     fn fill(&mut self) {
         while self.window[0] == None {
-            self.slide();
+            if self.slide() == None {
+                return;
+            }
         }
     }
 

--- a/compiler/parser/src/lexer.rs
+++ b/compiler/parser/src/lexer.rs
@@ -117,14 +117,6 @@ where
         next
     }
 
-    fn fill(&mut self) {
-        while self.window[0].is_none() {
-            if self.slide().is_none() {
-                return;
-            }
-        }
-    }
-
     fn change_first(&mut self, ch: char) {
         *self.window.first_mut().expect("never empty") = Some(ch);
     }
@@ -241,7 +233,9 @@ where
             location: start,
             window: CharWindow::new(input),
         };
-        lxr.window.fill();
+        lxr.window.slide();
+        lxr.window.slide();
+        lxr.window.slide();
         // Start at top row (=1) left column (=1)
         lxr.location.reset();
         lxr

--- a/compiler/parser/src/lexer.rs
+++ b/compiler/parser/src/lexer.rs
@@ -118,8 +118,8 @@ where
     }
 
     fn fill(&mut self) {
-        while self.window[0] == None {
-            if self.slide() == None {
+        while self.window[0].is_none() {
+            if self.slide().is_none() {
                 return;
             }
         }

--- a/compiler/parser/src/lexer.rs
+++ b/compiler/parser/src/lexer.rs
@@ -102,7 +102,7 @@ impl<const N: usize> CharWindow<N> {
         *self.0.last_mut().expect("never empty") = next_char;
     }
 
-    fn swap(&mut self, ch: char) {
+    fn swap_first(&mut self, ch: char) {
         *self.0.first_mut().expect("never empty") = Some(ch);
     }
 }
@@ -200,7 +200,7 @@ where
                 }
                 (Some('\r'), _) => {
                     // MAC EOL into \n
-                    self.window.swap('\n');
+                    self.window.swap_first('\n');
                 }
                 _ => break,
             }

--- a/compiler/parser/src/lexer.rs
+++ b/compiler/parser/src/lexer.rs
@@ -77,22 +77,22 @@ struct Indentations {
 }
 
 impl Indentations {
-    pub fn is_empty(&self) -> bool {
+    fn is_empty(&self) -> bool {
         self.indent_stack.len() == 1
     }
 
-    pub fn push(&mut self, indent: IndentationLevel) {
+    fn push(&mut self, indent: IndentationLevel) {
         self.indent_stack.push(indent);
     }
 
-    pub fn pop(&mut self) -> Option<IndentationLevel> {
+    fn pop(&mut self) -> Option<IndentationLevel> {
         if self.is_empty() {
             return None;
         }
         self.indent_stack.pop()
     }
 
-    pub fn current(&self) -> &IndentationLevel {
+    fn current(&self) -> &IndentationLevel {
         self.indent_stack
             .last()
             .expect("Indetations must have at least one level")
@@ -107,7 +107,7 @@ impl Default for Indentations {
     }
 }
 
-struct CharWindow<const N: usize>(pub [Option<char>; N]);
+struct CharWindow<const N: usize>([Option<char>; N]);
 
 impl<const N: usize> CharWindow<N> {
     fn slide(&mut self, next_char: Option<char>) {

--- a/compiler/parser/src/lexer.rs
+++ b/compiler/parser/src/lexer.rs
@@ -17,19 +17,6 @@ use std::str::FromStr;
 use unic_emoji_char::is_emoji_presentation;
 use unic_ucd_ident::{is_xid_continue, is_xid_start};
 
-#[inline]
-pub fn make_tokenizer(source: &str) -> impl Iterator<Item = LexResult> + '_ {
-    make_tokenizer_located(source, Location::new(0, 0))
-}
-
-pub fn make_tokenizer_located(
-    source: &str,
-    start_location: Location,
-) -> impl Iterator<Item = LexResult> + '_ {
-    let nlh = NewlineHandler::new(source.chars());
-    Lexer::new(nlh, start_location)
-}
-
 #[derive(Clone, Copy, PartialEq, Debug, Default)]
 struct IndentationLevel {
     tabs: usize,
@@ -160,6 +147,19 @@ pub static KEYWORDS: phf::Map<&'static str, Tok> =
 
 pub type Spanned = (Location, Tok, Location);
 pub type LexResult = Result<Spanned, LexicalError>;
+
+#[inline]
+pub fn make_tokenizer(source: &str) -> impl Iterator<Item = LexResult> + '_ {
+    make_tokenizer_located(source, Location::new(0, 0))
+}
+
+pub fn make_tokenizer_located(
+    source: &str,
+    start_location: Location,
+) -> impl Iterator<Item = LexResult> + '_ {
+    let nlh = NewlineHandler::new(source.chars());
+    Lexer::new(nlh, start_location)
+}
 
 // The newline handler is an iterator which collapses different newline
 // types into \n always.

--- a/compiler/parser/src/lexer.rs
+++ b/compiler/parser/src/lexer.rs
@@ -352,7 +352,7 @@ where
             }
 
             // 1e6 for example:
-            if matches!(self.window[0], Some('e' | 'E')) {
+            if let Some('e' | 'E') = self.window[0] {
                 if self.window[1] == Some('_') {
                     return Err(LexicalError {
                         error: LexicalErrorType::OtherError("Invalid Syntax".to_owned()),
@@ -1256,10 +1256,7 @@ where
             ' ' | '\t' | '\x0C' => {
                 // Skip whitespaces
                 self.next_char();
-                while self.window[0] == Some(' ')
-                    || self.window[0] == Some('\t')
-                    || self.window[0] == Some('\x0C')
-                {
+                while let Some(' ' | '\t' | '\x0C') = self.window[0] {
                     self.next_char();
                 }
             }

--- a/compiler/parser/src/lexer.rs
+++ b/compiler/parser/src/lexer.rs
@@ -11,7 +11,7 @@ use num_traits::identities::Zero;
 use num_traits::Num;
 use std::char;
 use std::cmp::Ordering;
-use std::ops::{Index, IndexMut};
+use std::ops::Index;
 use std::slice::SliceIndex;
 use std::str::FromStr;
 use unic_emoji_char::is_emoji_presentation;
@@ -101,6 +101,10 @@ impl<const N: usize> CharWindow<N> {
         self.0.rotate_left(1);
         *self.0.last_mut().expect("never empty") = next_char;
     }
+
+    fn swap(&mut self, ch: char) {
+        *self.0.first_mut().expect("never empty") = Some(ch);
+    }
 }
 
 impl<const N: usize> Default for CharWindow<N> {
@@ -117,15 +121,6 @@ where
 
     fn index(&self, index: Idx) -> &Self::Output {
         self.0.index(index)
-    }
-}
-
-impl<const N: usize, Idx> IndexMut<Idx> for CharWindow<N>
-where
-    Idx: SliceIndex<[Option<char>], Output = Option<char>>,
-{
-    fn index_mut(&mut self, index: Idx) -> &mut Self::Output {
-        self.0.index_mut(index)
     }
 }
 
@@ -205,7 +200,7 @@ where
                 }
                 (Some('\r'), _) => {
                     // MAC EOL into \n
-                    self.window[0] = Some('\n');
+                    self.window.swap('\n');
                 }
                 _ => break,
             }


### PR DESCRIPTION
I slightly made some changes to the lexer for better organization of the struct

- Changed `Vec<IndentationLevel>` into a new struct `Indentations` and limited its methods just for `pop`, `push`, `is_empty`, and `current`: Checking empty semantics is different from normal vectors in that `is_empty()` should return when the length is one, rather than zero because of the default indentation level.
- Made a struct for `chr0, chr1, chr2`, which is `CharWindow<const N: usize>`
- Changed condition expression in if statements. For example `if x == Some(1) || x == Some(2) { ... }` changed into `if matches!(x, Some(1 | 2))`
- Shortcircuited an if statement to reduce indentation level.
- Add a new test for `123_45_67_890` which was missing in `lexer.rs` tests module