### PR TITLE
Set comparator start location to beginning of comparison

### DIFF
--- a/compiler/parser/python.lalrpop
+++ b/compiler/parser/python.lalrpop
@@ -800,7 +800,7 @@ NotTest: ast::Expr = {
 };
 
 Comparison: ast::Expr = {
-    <left:Expression> <location:@L> <comparisons:(CompOp Expression)+> <end_location:@R> => {
+    <location:@L> <left:Expression> <comparisons:(CompOp Expression)+> <end_location:@R> => {
         let (ops, comparators) = comparisons.into_iter().unzip();
         ast::Expr {
             location,

--- a/compiler/parser/src/snapshots/rustpython_parser__fstring__tests__parse_fstring_equals.snap
+++ b/compiler/parser/src/snapshots/rustpython_parser__fstring__tests__parse_fstring_equals.snap
@@ -19,7 +19,7 @@ expression: parse_ast
             value: Located {
                 location: Location {
                     row: 1,
-                    column: 4,
+                    column: 1,
                 },
                 end_location: Some(
                     Location {

--- a/compiler/parser/src/snapshots/rustpython_parser__fstring__tests__parse_fstring_not_equals.snap
+++ b/compiler/parser/src/snapshots/rustpython_parser__fstring__tests__parse_fstring_not_equals.snap
@@ -19,7 +19,7 @@ expression: parse_ast
             value: Located {
                 location: Location {
                     row: 1,
-                    column: 3,
+                    column: 1,
                 },
                 end_location: Some(
                     Location {

--- a/compiler/parser/src/snapshots/rustpython_parser__parser__tests__parse_double_list_comprehension.snap
+++ b/compiler/parser/src/snapshots/rustpython_parser__parser__tests__parse_double_list_comprehension.snap
@@ -145,7 +145,7 @@ Located {
                     Located {
                         location: Location {
                             row: 1,
-                            column: 34,
+                            column: 32,
                         },
                         end_location: Some(
                             Location {
@@ -201,7 +201,7 @@ Located {
                     Located {
                         location: Location {
                             row: 1,
-                            column: 43,
+                            column: 41,
                         },
                         end_location: Some(
                             Location {


### PR DESCRIPTION
Right now, `1 == 2` has a start location at the first `=`. This PR changes the parser such that start location is equivalent to the start of the `left` item (i.e., the `1`).
