### PR TITLE
Implement a few more ops in the JIT

### DIFF
--- a/jit/tests/int_tests.rs
+++ b/jit/tests/int_tests.rs
@@ -24,6 +24,111 @@ fn test_sub() {
 }
 
 #[test]
+fn test_floor_div() {
+    let floor_div = jit_function! { floor_div(a:i64, b:i64) -> i64 => r##"
+        def floor_div(a: int, b: int):
+            return a // b
+    "## };
+
+    assert_eq!(floor_div(5, 10), Ok(0));
+    assert_eq!(floor_div(5, 2), Ok(2));
+    assert_eq!(floor_div(12, 10), Ok(1));
+    assert_eq!(floor_div(7, 10), Ok(0));
+    assert_eq!(floor_div(-3, -1), Ok(3));
+    assert_eq!(floor_div(-3, 1), Ok(-3));
+}
+
+#[test]
+fn test_mod() {
+    let modulo = jit_function! { modulo(a:i64, b:i64) -> i64 => r##"
+        def modulo(a: int, b: int):
+            return a % b
+    "## };
+
+    assert_eq!(modulo(5, 10), Ok(5));
+    assert_eq!(modulo(5, 2), Ok(1));
+    assert_eq!(modulo(12, 10), Ok(2));
+    assert_eq!(modulo(7, 10), Ok(7));
+    assert_eq!(modulo(-3, 1), Ok(0));
+    assert_eq!(modulo(-5, 10), Ok(-5));
+}
+
+#[test]
+fn test_lshift() {
+    let lshift = jit_function! { lshift(a:i64, b:i64) -> i64 => r##"
+        def lshift(a: int, b: int):
+            return a << b
+    "## };
+
+    assert_eq!(lshift(5, 10), Ok(5120));
+    assert_eq!(lshift(5, 2), Ok(20));
+    assert_eq!(lshift(12, 10), Ok(12288));
+    assert_eq!(lshift(7, 10), Ok(7168));
+    assert_eq!(lshift(-3, 1), Ok(-6));
+    assert_eq!(lshift(-10, 2), Ok(-40));
+}
+
+#[test]
+fn test_rshift() {
+    let rshift = jit_function! { rshift(a:i64, b:i64) -> i64 => r##"
+        def rshift(a: int, b: int):
+            return a >> b
+    "## };
+
+    assert_eq!(rshift(5120, 10), Ok(5));
+    assert_eq!(rshift(20, 2), Ok(5));
+    assert_eq!(rshift(12288, 10), Ok(12));
+    assert_eq!(rshift(7168, 10), Ok(7));
+    assert_eq!(rshift(-3, 1), Ok(-2));
+    assert_eq!(rshift(-10, 2), Ok(-3));
+}
+
+#[test]
+fn test_and() {
+    let bitand = jit_function! { bitand(a:i64, b:i64) -> i64 => r##"
+        def bitand(a: int, b: int):
+            return a & b
+    "## };
+
+    assert_eq!(bitand(5120, 10), Ok(0));
+    assert_eq!(bitand(20, 16), Ok(16));
+    assert_eq!(bitand(12488, 4249), Ok(4232));
+    assert_eq!(bitand(7168, 2), Ok(0));
+    assert_eq!(bitand(-3, 1), Ok(1));
+    assert_eq!(bitand(-10, 2), Ok(2));
+}
+
+#[test]
+fn test_or() {
+    let bitor = jit_function! { bitor(a:i64, b:i64) -> i64 => r##"
+        def bitor(a: int, b: int):
+            return a | b
+    "## };
+
+    assert_eq!(bitor(5120, 10), Ok(5130));
+    assert_eq!(bitor(20, 16), Ok(20));
+    assert_eq!(bitor(12488, 4249), Ok(12505));
+    assert_eq!(bitor(7168, 2), Ok(7170));
+    assert_eq!(bitor(-3, 1), Ok(-3));
+    assert_eq!(bitor(-10, 2), Ok(-10));
+}
+
+#[test]
+fn test_xor() {
+    let bitxor = jit_function! { bitxor(a:i64, b:i64) -> i64 => r##"
+        def bitxor(a: int, b: int):
+            return a ^ b
+    "## };
+
+    assert_eq!(bitxor(5120, 10), Ok(5130));
+    assert_eq!(bitxor(20, 16), Ok(4));
+    assert_eq!(bitxor(12488, 4249), Ok(8273));
+    assert_eq!(bitxor(7168, 2), Ok(7170));
+    assert_eq!(bitxor(-3, 1), Ok(-4));
+    assert_eq!(bitxor(-10, 2), Ok(-12));
+}
+
+#[test]
 fn test_eq() {
     let eq = jit_function! { eq(a:i64, b:i64) -> i64 => r##"
         def eq(a: int, b: int):


### PR DESCRIPTION
👋 Hey,

This PR implements a few more ops in the JIT.

I noticed that shifting by negative numbers raises an exception, I've modeled this as a trap, with the hopes that some day we'll catch that custom trap code and do proper exception handling.

Are there any other cases of special values in these ops that python treats differently? 