### PR TITLE
Allow retry if `as_mut` fail when insert Dict

### DIFF
--- a/vm/src/dictdatatype.rs
+++ b/vm/src/dictdatatype.rs
@@ -253,10 +253,8 @@ impl<T: Clone> Dict<T> {
                     } else {
                         // The dict was changed since we did lookup. Let's try again.
                         // this is very rare to happen
-                        // (and seems only happen with very high freq gc, and about three to four time in 200000 iters)
+                        // (and seems only happen with very high freq gc, and about one time in 10000 iters)
                         // but still possible
-                        // so logging a warn is acceptable in here
-                        warn!("The dict was changed since we did lookup. Let's try again.");
                         continue;
                     };
                     if entry.index == index_index {

--- a/vm/src/dictdatatype.rs
+++ b/vm/src/dictdatatype.rs
@@ -248,9 +248,7 @@ impl<T: Clone> Dict<T> {
             if let Some(index) = entry_index.index() {
                 // Update existing key
                 if let Some(entry) = inner.entries.get_mut(index) {
-                    let entry = if let Some(entry) = entry.as_mut() {
-                        entry
-                    } else {
+                    let Some(entry) = entry.as_mut() else {
                         // The dict was changed since we did lookup. Let's try again.
                         // this is very rare to happen
                         // (and seems only happen with very high freq gc, and about one time in 10000 iters)


### PR DESCRIPTION
This as_mut doesn't fail in most condition, although if you actually impl a garbage collect, there is a very small chances(three in 200,000, edited: more like 20 in 200000) that this following as_mut can fail due to change in dict:
https://github.com/RustPython/RustPython/blob/1a92399349704d2a49ae57539f308c5f91a1d436/vm/src/dictdatatype.rs#L252
```rust
/// Store a key
pub fn insert<K>(&self, vm: &VirtualMachine, key: &K, value: T) -> PyResult<()>
where K: DictKey + ?Sized,
{
    let hash = key.key_hash(vm)?;
    let _removed = loop {
        let (entry_index, index_index) = self.lookup(vm, key, hash, None)?;
        let mut inner = self.write();
        if let Some(index) = entry_index.index() {
            // Update existing key
            if let Some(entry) = inner.entries.get_mut(index) {
                // this `as_mut` might fail
                let entry = entry
                    .as_mut()
                    .expect("The dict was changed since we did lookup.");
                if entry.index == index_index {
                    let removed = std::mem::replace(&mut entry.value, value);
                    // defer dec RC
                    break Some(removed);
                } else {
                    // stuff shifted around, let's try again
                }
            } else {
                // The dict was changed since we did lookup. Let's try again.
            }
        } else {
            // New key:
            inner.unchecked_push(index_index, hash, key.to_pyobject(vm), value, entry_index);
            break None;
        }
    };
    Ok(())
}
```
so change to allow continue to loop and try to acquire a mut ref:
```rust
let entry = if let Some(entry) = entry.as_mut() {
    entry
} else {
    // The dict was changed since we did lookup. Let's try again.
    // this is very rare to happen
    // (and seems only happen with very high freq gc, and about three to four time in 200000 iters)
    // but still possible
    // so logging a warn is acceptable in here
    warn!("The dict was changed since we did lookup. Let's try again.");
    continue;
};
```