### PR TITLE
Add example for calling between rust and python

### DIFF
--- a/examples/call_between_rust_and_python.py
+++ b/examples/call_between_rust_and_python.py
@@ -1,0 +1,13 @@
+from rust_py_module import RustStruct, rust_function
+
+class PythonPerson:
+    def __init__(self, name):
+        self.name = name
+
+def python_callback():
+    python_person = PythonPerson("Peter Python")
+    rust_object = rust_function(42, "This is a python string", python_person)
+    rust_object.print_in_rust_from_python()
+
+def take_string(string):
+    print("Calling python function from rust with string: " + string)

--- a/examples/call_between_rust_and_python.py
+++ b/examples/call_between_rust_and_python.py
@@ -7,6 +7,7 @@ class PythonPerson:
 def python_callback():
     python_person = PythonPerson("Peter Python")
     rust_object = rust_function(42, "This is a python string", python_person)
+    print("Printing member 'numbers' from rust struct: ", rust_object.numbers)
     rust_object.print_in_rust_from_python()
 
 def take_string(string):

--- a/examples/call_between_rust_and_python.rs
+++ b/examples/call_between_rust_and_python.rs
@@ -1,6 +1,5 @@
 use rustpython_vm::{
-    pyclass, pymodule, PyObject, PyPayload, PyResult, TryFromBorrowedObject,
-    VirtualMachine,
+    pyclass, pymodule, PyObject, PyPayload, PyResult, TryFromBorrowedObject, VirtualMachine,
 };
 
 pub(crate) use rust_py_module::make_module;
@@ -20,7 +19,11 @@ pub fn main() {
         vm.invoke(&init_fn, ()).unwrap();
 
         let take_string_fn = module.get_attr("take_string", vm).unwrap();
-        vm.invoke(&take_string_fn, (String::from("Rust string sent to python"),)).unwrap();
+        vm.invoke(
+            &take_string_fn,
+            (String::from("Rust string sent to python"),),
+        )
+        .unwrap();
     })
 }
 
@@ -40,9 +43,7 @@ mod rust_py_module {
 num: {},
 string: {},
 python_person.name: {}",
-            num,
-            s,
-            python_person.name
+            num, s, python_person.name
         );
         Ok(RustStruct)
     }
@@ -66,9 +67,7 @@ python_person.name: {}",
 
     impl TryFromBorrowedObject for PythonPerson {
         fn try_from_borrowed_object(vm: &VirtualMachine, obj: &PyObject) -> PyResult<Self> {
-            let name = obj
-                .get_attr("name", vm)?
-                .try_into_value::<String>(vm)?;
+            let name = obj.get_attr("name", vm)?.try_into_value::<String>(vm)?;
             Ok(PythonPerson { name })
         }
     }

--- a/examples/call_between_rust_and_python.rs
+++ b/examples/call_between_rust_and_python.rs
@@ -1,0 +1,88 @@
+use rustpython_vm::{
+    builtins::PyStr,
+    function::{FuncArgs, KwArgs, PosArgs},
+    pyclass, pymodule, PyObject, PyObjectRef, PyPayload, PyResult, TryFromBorrowedObject,
+    VirtualMachine,
+};
+
+pub(crate) use rust_py_module::make_module;
+
+pub fn main() {
+    let interp = rustpython_vm::Interpreter::with_init(Default::default(), |vm| {
+        vm.add_native_modules(rustpython_stdlib::get_module_inits());
+        vm.add_native_module("rust_py_module".to_owned(), Box::new(make_module));
+    });
+
+    interp.enter(|vm| {
+        vm.insert_sys_path(vm.new_pyobj("examples"))
+            .expect("add path");
+
+        let module = vm.import("call_between_rust_and_python", None, 0).unwrap();
+        let init_fn = module.get_attr("python_callback", vm).unwrap();
+
+        vm.invoke(&init_fn, ()).unwrap();
+
+        let pystr = PyObjectRef::from(PyStr::new_ref(
+            unsafe {
+                PyStr::new_ascii_unchecked(String::from("Rust string sent to python").into_bytes())
+            },
+            vm.as_ref(),
+        ));
+        let take_string_args = FuncArgs::new(PosArgs::new(vec![pystr]), KwArgs::default());
+        let take_string_fn = module.get_attr("take_string", vm).unwrap();
+
+        vm.invoke(&take_string_fn, take_string_args).unwrap();
+    })
+}
+
+#[pymodule]
+mod rust_py_module {
+    use super::*;
+
+    #[pyfunction]
+    fn rust_function(
+        num: i32,
+        s: String,
+        python_person: PyObjectRef,
+        vm: &VirtualMachine,
+    ) -> PyResult<RustStruct> {
+        println!(
+            "Calling standalone rust function from python passing args:
+num: {},
+string: {},
+python_person.name: {}",
+            num,
+            s,
+            python_person.try_into_value::<PythonPerson>(vm).unwrap().name
+        );
+        Ok(RustStruct)
+    }
+
+    #[pyattr]
+    #[pyclass(module = "rust_py_module", name = "RustStruct")]
+    #[derive(Debug, PyPayload)]
+    struct RustStruct;
+
+    #[pyclass]
+    impl RustStruct {
+        #[pymethod]
+        fn print_in_rust_from_python(&self) {
+            println!("Calling a rust method from python");
+        }
+    }
+
+    struct PythonPerson {
+        name: String,
+    }
+
+    impl TryFromBorrowedObject for PythonPerson {
+        fn try_from_borrowed_object(vm: &VirtualMachine, obj: &PyObject) -> PyResult<Self> {
+            let name = obj
+                .get_attr("name", vm)
+                .unwrap()
+                .try_into_value::<String>(vm)
+                .unwrap();
+            Ok(PythonPerson { name })
+        }
+    }
+}


### PR DESCRIPTION
Add an example which illustrates how to call between rust and python. Most importantly there no examples which illustrate how to call rust from python and it is not obvious how to do this.

I never figured out if there was a way to nicely call a constructor of a rust struct since all methods in python require the self parameter I assumed that this was not possible and that construction should be done via a standalone function.
If it is encouraged or idiomatic to use a python constructor from rust for some reason then perhaps that should be added to the example.

Previous opened issue: https://github.com/RustPython/RustPython/issues/4124