### PR TITLE
doc: add greptimedb's use case to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,6 +154,7 @@ Checkout those talks on conferences:
 Although RustPython is a fairly young project, a few people have used it to
 make cool projects:
 
+- [GreptimeDB](https://github.com/GreptimeTeam/greptimedb): an open-source, cloud-native, distributed time-series database. Using RustPython for embedded scripting.
 - [pyckitup](https://github.com/pickitup247/pyckitup): a game engine written in
   rust.
 - [Robot Rumble](https://github.com/robot-rumble/logic/): an arena-based AI competition platform


### PR DESCRIPTION
GreptimeDB use RsutPython for simple embedded scripting, so I think we can add this use case here?: https://docs.greptime.com/developer-guide/datanode/python-coprocessor