### PR TITLE
Implement some minor performance optimizations

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1721,6 +1721,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustc-hash"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
+
+[[package]]
 name = "rustc_version"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1876,7 +1882,6 @@ version = "0.1.2"
 dependencies = [
  "ahash",
  "anyhow",
- "fnv",
  "insta",
  "itertools",
  "lalrpop",
@@ -1886,6 +1891,7 @@ dependencies = [
  "num-traits",
  "phf",
  "phf_codegen",
+ "rustc-hash",
  "rustpython-ast",
  "rustpython-compiler-core",
  "thiserror",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1876,6 +1876,7 @@ version = "0.1.2"
 dependencies = [
  "ahash",
  "anyhow",
+ "fnv",
  "insta",
  "itertools",
  "lalrpop",

--- a/compiler/parser/Cargo.toml
+++ b/compiler/parser/Cargo.toml
@@ -28,11 +28,11 @@ log = "0.4.16"
 num-bigint = "0.4.3"
 num-traits = "0.2.14"
 phf = "0.10.1"
+rustc-hash = "1.1.0"
+thiserror = "1.0"
 unic-emoji-char = "0.9.0"
 unic-ucd-ident  = "0.9.0"
 unicode_names2 = "0.5.0"
-thiserror = "1.0"
-fnv = "1.0.7"
 
 [dev-dependencies]
 insta = "1.14.0"

--- a/compiler/parser/Cargo.toml
+++ b/compiler/parser/Cargo.toml
@@ -32,6 +32,7 @@ unic-emoji-char = "0.9.0"
 unic-ucd-ident  = "0.9.0"
 unicode_names2 = "0.5.0"
 thiserror = "1.0"
+fnv = "1.0.7"
 
 [dev-dependencies]
 insta = "1.14.0"

--- a/compiler/parser/src/function.rs
+++ b/compiler/parser/src/function.rs
@@ -1,7 +1,6 @@
 use crate::ast;
 use crate::error::{LexicalError, LexicalErrorType};
-use ahash::RandomState;
-use std::collections::HashSet;
+use fnv::FnvHashSet;
 
 pub struct ArgumentList {
     pub args: Vec<ast::Expr>,
@@ -54,7 +53,8 @@ pub fn parse_args(func_args: Vec<FunctionArgument>) -> Result<ArgumentList, Lexi
     let mut args = vec![];
     let mut keywords = vec![];
 
-    let mut keyword_names = HashSet::with_capacity_and_hasher(func_args.len(), RandomState::new());
+    let mut keyword_names =
+        FnvHashSet::with_capacity_and_hasher(func_args.len(), Default::default());
     for (name, value) in func_args {
         match name {
             Some((start, end, name)) => {

--- a/compiler/parser/src/function.rs
+++ b/compiler/parser/src/function.rs
@@ -1,6 +1,6 @@
 use crate::ast;
 use crate::error::{LexicalError, LexicalErrorType};
-use fnv::FnvHashSet;
+use rustc_hash::FxHashSet;
 
 pub struct ArgumentList {
     pub args: Vec<ast::Expr>,
@@ -54,7 +54,7 @@ pub fn parse_args(func_args: Vec<FunctionArgument>) -> Result<ArgumentList, Lexi
     let mut keywords = vec![];
 
     let mut keyword_names =
-        FnvHashSet::with_capacity_and_hasher(func_args.len(), Default::default());
+        FxHashSet::with_capacity_and_hasher(func_args.len(), Default::default());
     for (name, value) in func_args {
         match name {
             Some((start, end, name)) => {

--- a/compiler/parser/src/string.rs
+++ b/compiler/parser/src/string.rs
@@ -15,7 +15,7 @@ pub fn parse_strings(
     let initial_kind = (values[0].1 .1 == StringKind::U).then(|| "u".to_owned());
 
     // Optimization: fast-track the common case of a single string.
-    if values.len() == 1 && matches!(&values[0].1 .1, StringKind::Normal | StringKind::U) {
+    if matches!(&*values, [(_, (_, StringKind::Normal | StringKind::U), _)]) {
         let value = values.into_iter().last().unwrap().1 .0;
         return Ok(Expr::new(
             initial_start,

--- a/compiler/parser/src/string.rs
+++ b/compiler/parser/src/string.rs
@@ -14,6 +14,19 @@ pub fn parse_strings(
     let initial_end = values[0].2;
     let initial_kind = (values[0].1 .1 == StringKind::U).then(|| "u".to_owned());
 
+    // Optimization: fast-track the common case of a single string.
+    if values.len() == 1 && matches!(&values[0].1 .1, StringKind::Normal | StringKind::U) {
+        let value = values.into_iter().last().unwrap().1 .0;
+        return Ok(Expr::new(
+            initial_start,
+            initial_end,
+            ExprKind::Constant {
+                value: Constant::Str(value),
+                kind: initial_kind,
+            },
+        ));
+    }
+
     // Determine whether the list of values contains any f-strings. (If not, we can return a
     // single Constant at the end, rather than a JoinedStr.)
     let mut has_fstring = false;


### PR DESCRIPTION
I tend to benchmark the parser by parsing all of CPython in [Ruff](https://github.com/charliermarsh/ruff). This involves (1) disabling Ruff's linting pass, then (2) running `cargo build --release && hyperfine --warmup 10 --runs 50 -i "./target/release/ruff resources/test/cpython --no-cache"`.

Prior to this change:

```
Benchmark 1: ./target/release/ruff resources/test/cpython --no-cache
  Time (mean ± σ):     265.2 ms ±   4.6 ms    [User: 2260.7 ms, System: 83.1 ms]
  Range (min … max):   259.0 ms … 281.1 ms    50 runs

Benchmark 1: ./target/release/ruff resources/test/cpython --no-cache
  Time (mean ± σ):     268.4 ms ±   4.2 ms    [User: 2268.1 ms, System: 83.5 ms]
  Range (min … max):   262.5 ms … 283.6 ms    50 runs

Benchmark 1: ./target/release/ruff resources/test/cpython --no-cache
  Time (mean ± σ):     269.7 ms ±   5.5 ms    [User: 2277.9 ms, System: 83.5 ms]
  Range (min … max):   260.1 ms … 280.7 ms    50 runs
```

After this change:

```
Benchmark 1: ./target/release/ruff resources/test/cpython --no-cache
  Time (mean ± σ):     255.6 ms ±   5.1 ms    [User: 2156.0 ms, System: 83.4 ms]
  Range (min … max):   247.2 ms … 271.8 ms    50 runs

Benchmark 1: ./target/release/ruff resources/test/cpython --no-cache
  Time (mean ± σ):     255.4 ms ±   4.8 ms    [User: 2152.8 ms, System: 83.0 ms]
  Range (min … max):   246.9 ms … 269.7 ms    50 runs

Benchmark 1: ./target/release/ruff resources/test/cpython --no-cache
  Time (mean ± σ):     256.3 ms ±   4.8 ms    [User: 2156.3 ms, System: 82.8 ms]
  Range (min … max):   248.5 ms … 270.6 ms    50 runs
```

So it's a ~4.8% improvement, if you take the median results.

Note that there's about ~58ms of overhead associated with this benchmark (e.g., to locate all the Python files on-disk, read their contents, etc.), so that's really a lower-bound on improvement.
