### PR TITLE
Fix issues with flame-it.

### DIFF
--- a/vm/src/vm/setting.rs
+++ b/vm/src/vm/setting.rs
@@ -1,3 +1,6 @@
+#[cfg(feature = "flame-it")]
+use std::ffi::OsString;
+
 /// Struct containing all kind of settings for the python vm.
 #[non_exhaustive]
 pub struct Settings {
@@ -67,6 +70,11 @@ pub struct Settings {
 
     /// false for wasm. Not a command-line option
     pub allow_external_library: bool,
+
+    #[cfg(feature = "flame-it")]
+    pub profile_output: Option<OsString>,
+    #[cfg(feature = "flame-it")]
+    pub profile_format: Option<String>,
 }
 
 /// Sensible default settings.
@@ -95,6 +103,10 @@ impl Default for Settings {
             stdio_unbuffered: false,
             check_hash_based_pycs: "default".to_owned(),
             allow_external_library: cfg!(feature = "importlib"),
+            #[cfg(feature = "flame-it")]
+            profile_output: None,
+            #[cfg(feature = "flame-it")]
+            profile_format: None,
         }
     }
 }


### PR DESCRIPTION
Running flame it works now as described in the profiling section:

```bash
echo "print('hello!')" >> script.py
cargo run --release --features flame-it script.py
```

or:

```bash
cargo run --release --features flame-it -- -c "print('hello world')"
```

to generate the flamescope (by default) which can be uploaded to speedscope.

ref #4289 