### PR TITLE
Bump openssl

### DIFF
--- a/stdlib/Cargo.toml
+++ b/stdlib/Cargo.toml
@@ -92,7 +92,7 @@ termios = "0.3.3"
 gethostname = "0.2.3"
 socket2 = { version = "0.4.4", features = ["all"] }
 dns-lookup = "1.0.8"
-openssl = { version = "0.10.38", optional = true }
+openssl = { version = "0.10.43", optional = true }
 openssl-sys = { version = "0.9.72", optional = true }
 openssl-probe = { version = "0.1.5", optional = true }
 foreign-types-shared = { version = "0.1.1", optional = true }


### PR DESCRIPTION
The test runner for ubuntu was recently bumped from 20.04 to 22.04, this appears to have caused some linking errors in openssl. Bumping it to the most recent version appears to clear things up.