### PR TITLE
Fix the end location of an implicitly-concatenated string

### DIFF
--- a/Lib/test/test_ast.py
+++ b/Lib/test/test_ast.py
@@ -1978,8 +1978,6 @@ class EndPositionTests(unittest.TestCase):
         self._check_end_pos(assign, 3, 40)
         self._check_end_pos(assign.value, 3, 40)
 
-    # TODO: RUSTPYTHON
-    @unittest.expectedFailure
     def test_continued_str(self):
         s = dedent('''
             x = "first part" \\

--- a/compiler/parser/src/snapshots/rustpython_parser__string__tests__parse_f_string_concat_1.snap
+++ b/compiler/parser/src/snapshots/rustpython_parser__string__tests__parse_f_string_concat_1.snap
@@ -38,7 +38,7 @@ expression: parse_ast
                             end_location: Some(
                                 Location {
                                     row: 1,
-                                    column: 8,
+                                    column: 17,
                                 },
                             ),
                             custom: (),

--- a/compiler/parser/src/snapshots/rustpython_parser__string__tests__parse_f_string_concat_1.snap
+++ b/compiler/parser/src/snapshots/rustpython_parser__string__tests__parse_f_string_concat_1.snap
@@ -24,7 +24,7 @@ expression: parse_ast
                 end_location: Some(
                     Location {
                         row: 1,
-                        column: 8,
+                        column: 17,
                     },
                 ),
                 custom: (),

--- a/compiler/parser/src/snapshots/rustpython_parser__string__tests__parse_f_string_concat_2.snap
+++ b/compiler/parser/src/snapshots/rustpython_parser__string__tests__parse_f_string_concat_2.snap
@@ -38,7 +38,7 @@ expression: parse_ast
                             end_location: Some(
                                 Location {
                                     row: 1,
-                                    column: 8,
+                                    column: 17,
                                 },
                             ),
                             custom: (),

--- a/compiler/parser/src/snapshots/rustpython_parser__string__tests__parse_f_string_concat_2.snap
+++ b/compiler/parser/src/snapshots/rustpython_parser__string__tests__parse_f_string_concat_2.snap
@@ -24,7 +24,7 @@ expression: parse_ast
                 end_location: Some(
                     Location {
                         row: 1,
-                        column: 8,
+                        column: 17,
                     },
                 ),
                 custom: (),

--- a/compiler/parser/src/snapshots/rustpython_parser__string__tests__parse_f_string_concat_3.snap
+++ b/compiler/parser/src/snapshots/rustpython_parser__string__tests__parse_f_string_concat_3.snap
@@ -24,7 +24,7 @@ expression: parse_ast
                 end_location: Some(
                     Location {
                         row: 1,
-                        column: 8,
+                        column: 22,
                     },
                 ),
                 custom: (),

--- a/compiler/parser/src/snapshots/rustpython_parser__string__tests__parse_f_string_concat_3.snap
+++ b/compiler/parser/src/snapshots/rustpython_parser__string__tests__parse_f_string_concat_3.snap
@@ -38,7 +38,7 @@ expression: parse_ast
                             end_location: Some(
                                 Location {
                                     row: 1,
-                                    column: 8,
+                                    column: 22,
                                 },
                             ),
                             custom: (),

--- a/compiler/parser/src/snapshots/rustpython_parser__string__tests__parse_string_concat.snap
+++ b/compiler/parser/src/snapshots/rustpython_parser__string__tests__parse_string_concat.snap
@@ -24,7 +24,7 @@ expression: parse_ast
                 end_location: Some(
                     Location {
                         row: 1,
-                        column: 8,
+                        column: 16,
                     },
                 ),
                 custom: (),

--- a/compiler/parser/src/snapshots/rustpython_parser__string__tests__parse_u_f_string_concat_1.snap
+++ b/compiler/parser/src/snapshots/rustpython_parser__string__tests__parse_u_f_string_concat_1.snap
@@ -38,7 +38,7 @@ expression: parse_ast
                             end_location: Some(
                                 Location {
                                     row: 1,
-                                    column: 9,
+                                    column: 18,
                                 },
                             ),
                             custom: (),

--- a/compiler/parser/src/snapshots/rustpython_parser__string__tests__parse_u_f_string_concat_1.snap
+++ b/compiler/parser/src/snapshots/rustpython_parser__string__tests__parse_u_f_string_concat_1.snap
@@ -24,7 +24,7 @@ expression: parse_ast
                 end_location: Some(
                     Location {
                         row: 1,
-                        column: 9,
+                        column: 18,
                     },
                 ),
                 custom: (),

--- a/compiler/parser/src/snapshots/rustpython_parser__string__tests__parse_u_f_string_concat_2.snap
+++ b/compiler/parser/src/snapshots/rustpython_parser__string__tests__parse_u_f_string_concat_2.snap
@@ -24,7 +24,7 @@ expression: parse_ast
                 end_location: Some(
                     Location {
                         row: 1,
-                        column: 9,
+                        column: 22,
                     },
                 ),
                 custom: (),

--- a/compiler/parser/src/snapshots/rustpython_parser__string__tests__parse_u_f_string_concat_2.snap
+++ b/compiler/parser/src/snapshots/rustpython_parser__string__tests__parse_u_f_string_concat_2.snap
@@ -38,7 +38,7 @@ expression: parse_ast
                             end_location: Some(
                                 Location {
                                     row: 1,
-                                    column: 9,
+                                    column: 22,
                                 },
                             ),
                             custom: (),

--- a/compiler/parser/src/snapshots/rustpython_parser__string__tests__parse_u_string_concat_1.snap
+++ b/compiler/parser/src/snapshots/rustpython_parser__string__tests__parse_u_string_concat_1.snap
@@ -24,7 +24,7 @@ expression: parse_ast
                 end_location: Some(
                     Location {
                         row: 1,
-                        column: 8,
+                        column: 17,
                     },
                 ),
                 custom: (),

--- a/compiler/parser/src/snapshots/rustpython_parser__string__tests__parse_u_string_concat_2.snap
+++ b/compiler/parser/src/snapshots/rustpython_parser__string__tests__parse_u_string_concat_2.snap
@@ -24,7 +24,7 @@ expression: parse_ast
                 end_location: Some(
                     Location {
                         row: 1,
-                        column: 9,
+                        column: 17,
                     },
                 ),
                 custom: (),

--- a/compiler/parser/src/string.rs
+++ b/compiler/parser/src/string.rs
@@ -12,6 +12,7 @@ pub fn parse_strings(
     // Preserve the initial location and kind.
     let initial_start = values[0].0;
     let initial_end = values[0].2;
+    let last_end = values.last().unwrap().2;
     let initial_kind = (values[0].1 .1 == StringKind::U).then(|| "u".to_owned());
 
     // Optimization: fast-track the common case of a single string.
@@ -84,7 +85,7 @@ pub fn parse_strings(
     Ok(if has_fstring {
         Expr::new(
             initial_start,
-            initial_end,
+            last_end,
             ExprKind::JoinedStr { values: deduped },
         )
     } else {

--- a/compiler/parser/src/string.rs
+++ b/compiler/parser/src/string.rs
@@ -82,18 +82,16 @@ pub fn parse_strings(
         deduped.push(take_current(&mut current));
     }
 
-    Ok(if has_fstring {
-        Expr::new(
-            initial_start,
-            last_end,
-            ExprKind::JoinedStr { values: deduped },
-        )
+    let node = if has_fstring {
+        ExprKind::JoinedStr { values: deduped }
     } else {
         deduped
             .into_iter()
             .exactly_one()
             .expect("String must be concatenated to a single element.")
-    })
+            .node
+    };
+    Ok(Expr::new(initial_start, last_end, node))
 }
 
 #[cfg(test)]

--- a/compiler/parser/src/string.rs
+++ b/compiler/parser/src/string.rs
@@ -11,7 +11,6 @@ pub fn parse_strings(
 ) -> Result<Expr, LexicalError> {
     // Preserve the initial location and kind.
     let initial_start = values[0].0;
-    let initial_end = values[0].2;
     let last_end = values.last().unwrap().2;
     let initial_kind = (values[0].1 .1 == StringKind::U).then(|| "u".to_owned());
 
@@ -20,7 +19,7 @@ pub fn parse_strings(
         let value = values.into_iter().last().unwrap().1 .0;
         return Ok(Expr::new(
             initial_start,
-            initial_end,
+            last_end,
             ExprKind::Constant {
                 value: Constant::Str(value),
                 kind: initial_kind,
@@ -39,7 +38,7 @@ pub fn parse_strings(
     let take_current = |current: &mut Vec<String>| -> Expr {
         Expr::new(
             initial_start,
-            initial_end,
+            last_end,
             ExprKind::Constant {
                 value: Constant::Str(current.drain(..).join("")),
                 kind: initial_kind.clone(),


### PR DESCRIPTION
## Before the fix:

```
"hello" "world"
      ^
      end_location
```

## After the fix:

```
"hello" "world"
              ^
              end_location
```