### PR TITLE
Fix panic about warlus operator inside mutiple comprehensions.

### DIFF
--- a/compiler/codegen/src/symboltable.rs
+++ b/compiler/codegen/src/symboltable.rs
@@ -483,7 +483,7 @@ impl SymbolTableAnalyzer {
                     };
                 } else {
                     let mut cloned_sym = symbol.clone();
-                    cloned_sym.scope = SymbolScope::Local;
+                    cloned_sym.scope = SymbolScope::Cell;
                     last.0.insert(cloned_sym.name.to_owned(), cloned_sym);
                 }
             }

--- a/extra_tests/snippets/syntax_comprehension.py
+++ b/extra_tests/snippets/syntax_comprehension.py
@@ -41,3 +41,8 @@ assert 'b' not in locals()
 assert 'c' not in locals()
 assert 'b' not in globals()
 assert 'c' not in globals()
+
+
+def f():
+    # Test no panic occured.
+    [[x := 1 for j in range(5)] for i in range(5)]


### PR DESCRIPTION
https://github.com/RustPython/RustPython/issues/4319#issuecomment-1356117387

What I have done are as follows.
* Replace symbol scope from Local to Cell.
* Add test in `syntax_comprehension.py`.