### PR TITLE
Fix the start and end locations of `Tuple`

### DIFF
--- a/Lib/test/test_ast.py
+++ b/Lib/test/test_ast.py
@@ -2107,8 +2107,6 @@ class EndPositionTests(unittest.TestCase):
         self._check_content(s, bop.values[1],
                             'other_condition or yet_another_one')
 
-    # TODO: RUSTPYTHON
-    @unittest.expectedFailure
     def test_tuples(self):
         s1 = 'x = () ;'
         s2 = 'x = 1 , ;'
@@ -2190,8 +2188,6 @@ class EndPositionTests(unittest.TestCase):
         self._check_content(s, fdef.body[0].value, 'yield x')
         self._check_content(s, fdef.body[1].value, 'await y')
 
-    # TODO: RUSTPYTHON
-    @unittest.expectedFailure
     def test_source_segment_multi(self):
         s_orig = dedent('''
             x = (

--- a/compiler/parser/python.lalrpop
+++ b/compiler/parser/python.lalrpop
@@ -1090,7 +1090,7 @@ AtomAs<Goal>: Goal = {
             node: ast::ExprKind::ListComp { elt: Box::new(elt), generators }
         }.into()
     },
-    "(" <location:@L> <items:OneOrMore<TestOrStarNamedExprOrWithitem>> <trailing_comma:","?> <end_location:@R> ")" =>? {
+    <location:@L> "(" <items:OneOrMore<TestOrStarNamedExprOrWithitem>> <trailing_comma:","?> ")" <end_location:@R> =>? {
         if items.len() == 1 && items[0].1.is_none() && trailing_comma.is_none() {
             match items[0].0.node {
                 ast::ExprKind::Starred { .. } => {

--- a/compiler/parser/src/snapshots/rustpython_parser__context__tests__assign_attribute.snap
+++ b/compiler/parser/src/snapshots/rustpython_parser__context__tests__assign_attribute.snap
@@ -55,12 +55,12 @@ expression: parse_ast
             value: Located {
                 location: Location {
                     row: 1,
-                    column: 7,
+                    column: 6,
                 },
                 end_location: Some(
                     Location {
                         row: 1,
-                        column: 14,
+                        column: 15,
                     },
                 ),
                 custom: (),

--- a/compiler/parser/src/snapshots/rustpython_parser__context__tests__assign_for.snap
+++ b/compiler/parser/src/snapshots/rustpython_parser__context__tests__assign_for.snap
@@ -36,12 +36,12 @@ expression: parse_ast
             iter: Located {
                 location: Location {
                     row: 1,
-                    column: 10,
+                    column: 9,
                 },
                 end_location: Some(
                     Location {
                         row: 1,
-                        column: 17,
+                        column: 18,
                     },
                 ),
                 custom: (),

--- a/compiler/parser/src/snapshots/rustpython_parser__context__tests__assign_list.snap
+++ b/compiler/parser/src/snapshots/rustpython_parser__context__tests__assign_list.snap
@@ -73,12 +73,12 @@ expression: parse_ast
             value: Located {
                 location: Location {
                     row: 1,
-                    column: 10,
+                    column: 9,
                 },
                 end_location: Some(
                     Location {
                         row: 1,
-                        column: 17,
+                        column: 18,
                     },
                 ),
                 custom: (),

--- a/compiler/parser/src/snapshots/rustpython_parser__context__tests__assign_list_comp.snap
+++ b/compiler/parser/src/snapshots/rustpython_parser__context__tests__assign_list_comp.snap
@@ -87,12 +87,12 @@ expression: parse_ast
                             iter: Located {
                                 location: Location {
                                     row: 1,
-                                    column: 17,
+                                    column: 16,
                                 },
                                 end_location: Some(
                                     Location {
                                         row: 1,
-                                        column: 24,
+                                        column: 25,
                                     },
                                 ),
                                 custom: (),

--- a/compiler/parser/src/snapshots/rustpython_parser__context__tests__assign_name.snap
+++ b/compiler/parser/src/snapshots/rustpython_parser__context__tests__assign_name.snap
@@ -38,12 +38,12 @@ expression: parse_ast
             value: Located {
                 location: Location {
                     row: 1,
-                    column: 5,
+                    column: 4,
                 },
                 end_location: Some(
                     Location {
                         row: 1,
-                        column: 12,
+                        column: 13,
                     },
                 ),
                 custom: (),

--- a/compiler/parser/src/snapshots/rustpython_parser__context__tests__assign_set_comp.snap
+++ b/compiler/parser/src/snapshots/rustpython_parser__context__tests__assign_set_comp.snap
@@ -87,12 +87,12 @@ expression: parse_ast
                             iter: Located {
                                 location: Location {
                                     row: 1,
-                                    column: 17,
+                                    column: 16,
                                 },
                                 end_location: Some(
                                     Location {
                                         row: 1,
-                                        column: 24,
+                                        column: 25,
                                     },
                                 ),
                                 custom: (),

--- a/compiler/parser/src/snapshots/rustpython_parser__context__tests__assign_starred.snap
+++ b/compiler/parser/src/snapshots/rustpython_parser__context__tests__assign_starred.snap
@@ -20,12 +20,12 @@ expression: parse_ast
                 Located {
                     location: Location {
                         row: 1,
-                        column: 1,
+                        column: 0,
                     },
                     end_location: Some(
                         Location {
                             row: 1,
-                            column: 6,
+                            column: 7,
                         },
                     ),
                     custom: (),
@@ -89,12 +89,12 @@ expression: parse_ast
             value: Located {
                 location: Location {
                     row: 1,
-                    column: 11,
+                    column: 10,
                 },
                 end_location: Some(
                     Location {
                         row: 1,
-                        column: 18,
+                        column: 19,
                     },
                 ),
                 custom: (),

--- a/compiler/parser/src/snapshots/rustpython_parser__context__tests__assign_subscript.snap
+++ b/compiler/parser/src/snapshots/rustpython_parser__context__tests__assign_subscript.snap
@@ -71,12 +71,12 @@ expression: parse_ast
             value: Located {
                 location: Location {
                     row: 1,
-                    column: 8,
+                    column: 7,
                 },
                 end_location: Some(
                     Location {
                         row: 1,
-                        column: 15,
+                        column: 16,
                     },
                 ),
                 custom: (),

--- a/compiler/parser/src/snapshots/rustpython_parser__context__tests__assign_tuple.snap
+++ b/compiler/parser/src/snapshots/rustpython_parser__context__tests__assign_tuple.snap
@@ -20,12 +20,12 @@ expression: parse_ast
                 Located {
                     location: Location {
                         row: 1,
-                        column: 1,
+                        column: 0,
                     },
                     end_location: Some(
                         Location {
                             row: 1,
-                            column: 5,
+                            column: 6,
                         },
                     ),
                     custom: (),
@@ -73,12 +73,12 @@ expression: parse_ast
             value: Located {
                 location: Location {
                     row: 1,
-                    column: 10,
+                    column: 9,
                 },
                 end_location: Some(
                     Location {
                         row: 1,
-                        column: 17,
+                        column: 18,
                     },
                 ),
                 custom: (),

--- a/compiler/parser/src/snapshots/rustpython_parser__context__tests__aug_assign_attribute.snap
+++ b/compiler/parser/src/snapshots/rustpython_parser__context__tests__aug_assign_attribute.snap
@@ -54,12 +54,12 @@ expression: parse_ast
             value: Located {
                 location: Location {
                     row: 1,
-                    column: 8,
+                    column: 7,
                 },
                 end_location: Some(
                     Location {
                         row: 1,
-                        column: 15,
+                        column: 16,
                     },
                 ),
                 custom: (),

--- a/compiler/parser/src/snapshots/rustpython_parser__context__tests__aug_assign_subscript.snap
+++ b/compiler/parser/src/snapshots/rustpython_parser__context__tests__aug_assign_subscript.snap
@@ -70,12 +70,12 @@ expression: parse_ast
             value: Located {
                 location: Location {
                     row: 1,
-                    column: 9,
+                    column: 8,
                 },
                 end_location: Some(
                     Location {
                         row: 1,
-                        column: 16,
+                        column: 17,
                     },
                 ),
                 custom: (),

--- a/compiler/parser/src/snapshots/rustpython_parser__with__tests__with_statement.snap
+++ b/compiler/parser/src/snapshots/rustpython_parser__with__tests__with_statement.snap
@@ -891,12 +891,12 @@ expression: "parse_program(source, \"<test>\").unwrap()"
                     context_expr: Located {
                         location: Location {
                             row: 12,
-                            column: 6,
+                            column: 5,
                         },
                         end_location: Some(
                             Location {
                                 row: 12,
-                                column: 8,
+                                column: 9,
                             },
                         ),
                         custom: (),
@@ -1061,12 +1061,12 @@ expression: "parse_program(source, \"<test>\").unwrap()"
                     context_expr: Located {
                         location: Location {
                             row: 14,
-                            column: 6,
+                            column: 5,
                         },
                         end_location: Some(
                             Location {
                                 row: 14,
-                                column: 10,
+                                column: 11,
                             },
                         ),
                         custom: (),
@@ -1172,12 +1172,12 @@ expression: "parse_program(source, \"<test>\").unwrap()"
                     context_expr: Located {
                         location: Location {
                             row: 15,
-                            column: 6,
+                            column: 5,
                         },
                         end_location: Some(
                             Location {
                                 row: 15,
-                                column: 9,
+                                column: 10,
                             },
                         ),
                         custom: (),
@@ -1260,12 +1260,12 @@ expression: "parse_program(source, \"<test>\").unwrap()"
                     context_expr: Located {
                         location: Location {
                             row: 16,
-                            column: 6,
+                            column: 5,
                         },
                         end_location: Some(
                             Location {
                                 row: 16,
-                                column: 9,
+                                column: 10,
                             },
                         ),
                         custom: (),
@@ -1366,12 +1366,12 @@ expression: "parse_program(source, \"<test>\").unwrap()"
                     context_expr: Located {
                         location: Location {
                             row: 17,
-                            column: 6,
+                            column: 5,
                         },
                         end_location: Some(
                             Location {
                                 row: 17,
-                                column: 11,
+                                column: 12,
                             },
                         ),
                         custom: (),
@@ -1473,12 +1473,12 @@ expression: "parse_program(source, \"<test>\").unwrap()"
                     context_expr: Located {
                         location: Location {
                             row: 18,
-                            column: 6,
+                            column: 5,
                         },
                         end_location: Some(
                             Location {
                                 row: 18,
-                                column: 11,
+                                column: 12,
                             },
                         ),
                         custom: (),
@@ -1934,12 +1934,12 @@ expression: "parse_program(source, \"<test>\").unwrap()"
                     context_expr: Located {
                         location: Location {
                             row: 22,
-                            column: 6,
+                            column: 5,
                         },
                         end_location: Some(
                             Location {
                                 row: 22,
-                                column: 20,
+                                column: 21,
                             },
                         ),
                         custom: (),


### PR DESCRIPTION
This PR fixes the start and end locations of `Tuple`.

### Current:

```
(1, 2, 3)
 ^-----^
 doesn't include ()
```

### Fixed:

```
(1, 2, 3)
^-------^
includes ()
```
