### PR TITLE
Support variable exchange (aka basic tuple support)

### DIFF
--- a/jit/tests/misc_tests.rs
+++ b/jit/tests/misc_tests.rs
@@ -101,3 +101,15 @@ fn test_while_loop() {
     assert_eq!(while_loop(1), Ok(1));
     assert_eq!(while_loop(10), Ok(10));
 }
+
+#[test]
+fn test_unpack_tuple() {
+    let unpack_tuple = jit_function! { unpack_tuple(a:i64, b:i64) -> i64 => r##"
+        def unpack_tuple(a: int, b: int):
+            a, b = b, a
+            return a
+    "## };
+
+    assert_eq!(unpack_tuple(0, 1), Ok(1));
+    assert_eq!(unpack_tuple(1, 2), Ok(2));
+}


### PR DESCRIPTION
I mostly just wrote this limited implementation to test out the performance of a simple iterative fibonacci implementation that I found. https://pythonistaplanet.com/fibonacci-sequence-iterative/

I modified the code to avoid calling print. For testing I also started at a higher number so the call overhead from python to the jitted code is reduced.

| no jit | jit |
| -------|-----|
| f(79) = 14472334024676221 | f(79) = 14472334024676221 |
| time: 0.0044 s |  time: 0.00048 s |

<details>
<summary>code</summary>

```python
import time

def f(n: int):
  a = 0
  b = 1
  c = 0
  while (n - 1):
    c = a + b
    a,b = b,c
    n = n - 1
  return c


start = time.time()
for i in range(50, 80):
  print(f"f({i}) = {f(i)}")
print("time: {:.2} s".format(time.time() - start))

print("__jit__()", f.__jit__())

start = time.time()
for i in range(50, 80):
  print(f"f({i}) = {f(i)}")
print("time: {:.2} s".format(time.time() - start))
```
</details>