### PR TITLE
make `test_globals` pass

### DIFF
--- a/Lib/test/test_symtable.py
+++ b/Lib/test/test_symtable.py
@@ -106,8 +106,6 @@ class SymtableTest(unittest.TestCase):
         self.assertEqual(sorted(func.get_globals()), ["bar", "glob", "some_assigned_global_var"])
         self.assertEqual(self.internal.get_frees(), ("x",))
 
-    # TODO: RUSTPYTHON
-    @unittest.expectedFailure
     def test_globals(self):
         self.assertTrue(self.spam.lookup("glob").is_global())
         self.assertFalse(self.spam.lookup("glob").is_declared_global())

--- a/vm/src/stdlib/symtable.rs
+++ b/vm/src/stdlib/symtable.rs
@@ -174,7 +174,12 @@ mod symtable {
 
         #[pymethod]
         fn is_global(&self) -> bool {
-            self.symbol.is_global()
+            self.symbol.is_global() || (self.is_top_scope && self.symbol.is_bound())
+        }
+
+        #[pymethod]
+        fn is_declared_global(&self) -> bool {
+            matches!(self.symbol.scope, SymbolScope::GlobalExplicit)
         }
 
         #[pymethod]


### PR DESCRIPTION
To make `test_globals` in `test_symtable.py` pass, I've done following fix about `PySymbol`.

### Fix `is_global` function
I referenced the following CPython code.
https://github.com/python/cpython/blob/main/Lib/symtable.py#L247-L251

### Add `is_decleared_global` function
I referenced the following CPython code.
https://github.com/python/cpython/blob/main/Lib/symtable.py#L257-L260
