### PR TITLE
Fix assertion error at unraisable exception

### DIFF
--- a/examples/atexit_example.py
+++ b/examples/atexit_example.py
@@ -1,0 +1,7 @@
+import atexit
+import sys
+
+def myexit():
+    sys.exit(2)
+
+atexit.register(myexit)

--- a/vm/src/stdlib/sys.rs
+++ b/vm/src/stdlib/sys.rs
@@ -549,12 +549,12 @@ mod sys {
         }
         assert!(unraisable
             .exc_type
-            .fast_issubclass(vm.ctx.exceptions.exception_type));
+            .fast_issubclass(vm.ctx.exceptions.base_exception_type));
 
         // TODO: print module name and qualname
 
         if !vm.is_none(&unraisable.exc_value) {
-            write!(stderr, ": ");
+            write!(stderr, "{}: ", unraisable.exc_type);
             if let Ok(str) = unraisable.exc_value.str(vm) {
                 write!(stderr, "{}", str.as_str());
             } else {


### PR DESCRIPTION
# What does this PR intend to do?

This PR aims to fix #4318. In order to do that,  I changed the exception type, of which the unraisable must be a subtype, to [`base_exception_type`](https://github.com/RustPython/RustPython/blob/d1811c72e72c51b849b0ad7b3f0efb2814a16bf2/vm/src/exceptions.rs#L324), because the [`SystemExit`](https://docs.python.org/3/library/exceptions.html#SystemExit) exception is not a subtype of  `Exception` (as [pointed out](https://github.com/RustPython/RustPython/issues/4318#issuecomment-1345354962) by @DimitrisJim). 

In addition,  I changed the error message printed  by the unraisable hook to print the exception type to match the behavior of CPython. The error message printed at `SystemExit` (generated by the `atexit_example.py` script included in this PR) does now look as follows:

```shell
cargo run --release examples/atexit_example.py
    Finished release [optimized] target(s) in 0.90s
     Running `target/release/rustpython examples/atexit_example.py`
Error in atexit._run_exitfuncs: <function myexit at 0x559d05956380>
  File "/home/jan/projects/RustPython/pylib/Lib/traceback.py", line 206, in print_stack
    print_list(extract_stack(f, limit=limit), file=file)
SystemExit: 2
```
In comparison, the error message generated by CPython 3.11.1 is this
```shell
python examples/atexit_example.py
Exception ignored in atexit callback: <function myexit at 0x7fe7575404a0>
Traceback (most recent call last):
  File "/home/jan/projects/RustPython/examples/atexit_example.py", line 5, in myexit
    sys.exit(2)
SystemExit: 2
```
As can be seen, the error message in the RustPython version is identical to CPython3.11.1 now, but the traceback is different. I'm not sure if this has to be fixed in this  PR, but I'm happy for suggestions on how to address that issue.

Interestingly, CPython3.9.1 (which @xiaxinmeng used in the original issue) does not generate an error for me. That is despite the `sys.unraisablehook()` function having been introduced in [3.8.0b1](https://github.com/python/cpython/commit/ef9d9b63129a2f243591db70e9a2dd53fab95d86). If someone has an idea on why that is, I would be happy to hear it :-).

# How has this been tested?

I ran the RustPython test suite as described in the [Development Guide](https://github.com/RustPython/RustPython/blob/main/DEVELOPMENT.md). The Rust unit tests all passed for me. However, three Python tests failed for me:

```shell
3 tests failed:
    test_cmd_line test_ioctl test_os
```

None of these tests seems related to the code I changed, and the error messages appear to indicate some faulty system configuration on my side.

# Notes
This is my first contribution to `RustPython`. I have read the [Code of Conduct](https://github.com/RustPython/RustPython/blob/main/code-of-conduct.md), and the development guide. However,  I'm sure I have overseen something, and the fix to the original issue might not be as simple as it seems. I am happy for any feedback and look forward to improving my understanding of the RustPython project and its code base.