### PR TITLE
Fix f-string padding

### DIFF
--- a/Lib/test/test_tokenize.py
+++ b/Lib/test/test_tokenize.py
@@ -647,8 +647,6 @@ def"', """\
     DEDENT     ''            (4, 0) (4, 0)
     """)
 
-    # TODO: RUSTPYTHON
-    @unittest.expectedFailure
     def test_non_ascii_identifiers(self):
         # Non-ascii identifiers
         self.check_tokenize("Örter = 'places'\ngrün = 'green'", """\
@@ -661,8 +659,6 @@ def"', """\
     STRING     "'green'"     (2, 7) (2, 14)
     """)
 
-    # TODO: RUSTPYTHON
-    @unittest.expectedFailure
     def test_unicode(self):
         # Legacy unicode literals:
         self.check_tokenize("Örter = u'places'\ngrün = U'green'", """\

--- a/extra_tests/snippets/builtin_format.py
+++ b/extra_tests/snippets/builtin_format.py
@@ -66,6 +66,8 @@ assert f"{123.456:011,}" == "000,123.456"
 assert f"{123.456:+011,}" == "+00,123.456"
 assert f"{1234:.3g}" == "1.23e+03"
 assert f"{1234567:.6G}" == "1.23457E+06"
+assert f'{"🐍":4}' == "🐍   "
+
 assert_raises(ValueError, "{:,o}".format, 1, _msg="ValueError: Cannot specify ',' with 'o'.")
 assert_raises(ValueError, "{:_n}".format, 1, _msg="ValueError: Cannot specify '_' with 'n'.")
 assert_raises(ValueError, "{:,o}".format, 1.0, _msg="ValueError: Cannot specify ',' with 'o'.")


### PR DESCRIPTION
If multibyte character exists in string, f-string padding doesn't work correctly.
For example:
```py
f'{"🐍":4}'
```

On CPython, The result of this code is below.

```py
'🐍   '
```

But on RustPython, The Result is different.

```py
'🐍'
```

I've fixed the character counting method.
With this fix, the following tests now pass.

* `test_non_ascii_identifiers`
* `test_unicode`
