### PR TITLE
Prohibit starred arguments after double-starred arguments

### DIFF
--- a/Lib/test/test_syntax.py
+++ b/Lib/test/test_syntax.py
@@ -1453,8 +1453,6 @@ class SyntaxTestCase(unittest.TestCase):
                           "positional argument follows "
                           "keyword argument unpacking")
 
-    # TODO: RUSTPYTHON
-    @unittest.expectedFailure
     def test_kwargs_last3(self):
         self._check_error("int(**{'base': 10}, *['2'])",
                           "iterable argument unpacking follows "

--- a/compiler/parser/src/error.rs
+++ b/compiler/parser/src/error.rs
@@ -22,6 +22,7 @@ pub enum LexicalErrorType {
     TabsAfterSpaces,
     DefaultArgumentError,
     PositionalArgumentError,
+    UnpackedArgumentError,
     DuplicateKeywordArgumentError,
     UnrecognizedToken { tok: char },
     FStringError(FStringErrorType),
@@ -54,6 +55,12 @@ impl fmt::Display for LexicalErrorType {
             }
             LexicalErrorType::PositionalArgumentError => {
                 write!(f, "positional argument follows keyword argument")
+            }
+            LexicalErrorType::UnpackedArgumentError => {
+                write!(
+                    f,
+                    "iterable argument unpacking follows keyword argument unpacking"
+                )
             }
             LexicalErrorType::UnrecognizedToken { tok } => {
                 write!(f, "Got unexpected token {tok}")


### PR DESCRIPTION
CPython prohibits `f(**kwargs, *args)`; we should too.