### PR TITLE
Allow named expression in subscript and set comprehension

### DIFF
--- a/Lib/test/test_named_expressions.py
+++ b/Lib/test/test_named_expressions.py
@@ -340,27 +340,25 @@ class NamedExpressionAssignmentTest(unittest.TestCase):
         fib = {(c := a): (a := b) + (b := a + c) - b for __ in range(6)}
         self.assertEqual(fib, {1: 2, 2: 3, 3: 5, 5: 8, 8: 13, 13: 21})
 
-    # TODO: RUSTPYTHON, SyntaxError
-    # def test_named_expression_assignment_17(self):
-    #     a = [1]
-    #     element = a[b:=0]
-    #     self.assertEqual(b, 0)
-    #     self.assertEqual(element, a[0])
+    def test_named_expression_assignment_17(self):
+        a = [1]
+        element = a[b:=0]
+        self.assertEqual(b, 0)
+        self.assertEqual(element, a[0])
 
-    # TODO: RUSTPYTHON, SyntaxError
-    # def test_named_expression_assignment_18(self):
-    #     class TwoDimensionalList:
-    #         def __init__(self, two_dimensional_list):
-    #             self.two_dimensional_list = two_dimensional_list
+    def test_named_expression_assignment_18(self):
+        class TwoDimensionalList:
+            def __init__(self, two_dimensional_list):
+                self.two_dimensional_list = two_dimensional_list
 
-    #         def __getitem__(self, index):
-    #             return self.two_dimensional_list[index[0]][index[1]]
+            def __getitem__(self, index):
+                return self.two_dimensional_list[index[0]][index[1]]
 
-    #     a = TwoDimensionalList([[1], [2]])
-    #     element = a[b:=0, c:=0]
-    #     self.assertEqual(b, 0)
-    #     self.assertEqual(c, 0)
-    #     self.assertEqual(element, a.two_dimensional_list[b][c])
+        a = TwoDimensionalList([[1], [2]])
+        element = a[b:=0, c:=0]
+        self.assertEqual(b, 0)
+        self.assertEqual(c, 0)
+        self.assertEqual(element, a.two_dimensional_list[b][c])
 
 
 

--- a/compiler/parser/python.lalrpop
+++ b/compiler/parser/python.lalrpop
@@ -1023,7 +1023,7 @@ SubscriptList: ast::Expr = {
 };
 
 Subscript: ast::Expr = {
-    Test<"all">,
+    NamedExpressionTest,
     <location:@L> <e1:Test<"all">?> ":" <e2:Test<"all">?> <e3:SliceOp?> <end_location:@R> => {
         let lower = e1.map(Box::new);
         let upper = e2.map(Box::new);

--- a/compiler/parser/python.lalrpop
+++ b/compiler/parser/python.lalrpop
@@ -1185,7 +1185,7 @@ Atom<Goal>: ast::Expr = {
         custom: (),
         node: ast::ExprKind::Set { elts }
     },
-    <location:@L> "{" <elt:Test<"all">> <generators:CompFor> "}" <end_location:@R> => {
+    <location:@L> "{" <elt:NamedExpressionTest> <generators:CompFor> "}" <end_location:@R> => {
         ast::Expr {
             location,
             end_location: Some(end_location),


### PR DESCRIPTION
`a[b := c]` and `{a := b for c in d}` are valid Python.