### PR TITLE
`eval` doesn't raise correct exception

### DIFF
--- a/Lib/test/test_builtin.py
+++ b/Lib/test/test_builtin.py
@@ -621,8 +621,6 @@ class BuiltinTest(unittest.TestCase):
 
         self.assertRaises(TypeError, divmod)
 
-    # TODO: RUSTPYTHON
-    @unittest.expectedFailure
     def test_eval(self):
         self.assertEqual(eval('1+1'), 2)
         self.assertEqual(eval(' 1+1\n'), 2)

--- a/vm/src/frame.rs
+++ b/vm/src/frame.rs
@@ -541,7 +541,7 @@ impl ExecutingFrame<'_> {
                 let result = self.locals.mapping().subscript(name, vm);
                 match result {
                     Ok(x) => self.push_value(x),
-                    Err(e) if e.class().is(vm.ctx.exceptions.key_error) => {
+                    Err(e) if e.fast_isinstance(vm.ctx.exceptions.key_error) => {
                         self.push_value(self.load_global_or_builtin(name, vm)?);
                     }
                     Err(e) => return Err(e),

--- a/vm/src/frame.rs
+++ b/vm/src/frame.rs
@@ -538,11 +538,14 @@ impl ExecutingFrame<'_> {
             }
             bytecode::Instruction::LoadNameAny(idx) => {
                 let name = self.code.names[*idx as usize];
-                let value = self.locals.mapping().subscript(name, vm).ok();
-                self.push_value(match value {
-                    Some(x) => x,
-                    None => self.load_global_or_builtin(name, vm)?,
-                });
+                let result = self.locals.mapping().subscript(name, vm);
+                match result {
+                    Ok(x) => self.push_value(x),
+                    Err(e) if e.class().is(vm.ctx.exceptions.key_error) => {
+                        self.push_value(self.load_global_or_builtin(name, vm)?);
+                    }
+                    Err(e) => return Err(e),
+                }
                 Ok(None)
             }
             bytecode::Instruction::LoadGlobal(idx) => {


### PR DESCRIPTION
#4375
I've fixed `LoadNameAny` opecode to return exception occured in local.
With this fix, following test now pass.
* test_eval