### PR TITLE
arg name to be written upon duplicate kwargs error #4381

### DIFF
--- a/compiler/parser/src/error.rs
+++ b/compiler/parser/src/error.rs
@@ -55,7 +55,7 @@ impl fmt::Display for LexicalErrorType {
                 write!(f, "duplicate argument '{arg_name}' in function definition")
             }
             LexicalErrorType::DuplicateKeywordArgumentError(arg_name) => {
-                write!(f, "keyword argument '{arg_name}' repeated")
+                write!(f, "keyword argument repeated: {arg_name}")
             }
             LexicalErrorType::PositionalArgumentError => {
                 write!(f, "positional argument follows keyword argument")

--- a/compiler/parser/src/error.rs
+++ b/compiler/parser/src/error.rs
@@ -24,7 +24,7 @@ pub enum LexicalErrorType {
     DuplicateArgumentError(String),
     PositionalArgumentError,
     UnpackedArgumentError,
-    DuplicateKeywordArgumentError,
+    DuplicateKeywordArgumentError(String),
     UnrecognizedToken { tok: char },
     FStringError(FStringErrorType),
     LineContinuationError,
@@ -54,8 +54,8 @@ impl fmt::Display for LexicalErrorType {
             LexicalErrorType::DuplicateArgumentError(arg_name) => {
                 write!(f, "duplicate argument '{arg_name}' in function definition")
             }
-            LexicalErrorType::DuplicateKeywordArgumentError => {
-                write!(f, "keyword argument repeated")
+            LexicalErrorType::DuplicateKeywordArgumentError(arg_name) => {
+                write!(f, "keyword argument '{arg_name}' repeated")
             }
             LexicalErrorType::PositionalArgumentError => {
                 write!(f, "positional argument follows keyword argument")

--- a/compiler/parser/src/function.rs
+++ b/compiler/parser/src/function.rs
@@ -92,7 +92,7 @@ pub fn parse_args(func_args: Vec<FunctionArgument>) -> Result<ArgumentList, Lexi
                 if let Some(keyword_name) = &name {
                     if keyword_names.contains(keyword_name) {
                         return Err(LexicalError {
-                            error: LexicalErrorType::DuplicateKeywordArgumentError,
+                            error: LexicalErrorType::DuplicateKeywordArgumentError(keyword_name.to_string()),
                             location: start,
                         });
                     }

--- a/compiler/parser/src/function.rs
+++ b/compiler/parser/src/function.rs
@@ -92,7 +92,9 @@ pub fn parse_args(func_args: Vec<FunctionArgument>) -> Result<ArgumentList, Lexi
                 if let Some(keyword_name) = &name {
                     if keyword_names.contains(keyword_name) {
                         return Err(LexicalError {
-                            error: LexicalErrorType::DuplicateKeywordArgumentError(keyword_name.to_string()),
+                            error: LexicalErrorType::DuplicateKeywordArgumentError(
+                                keyword_name.to_string(),
+                            ),
                             location: start,
                         });
                     }


### PR DESCRIPTION
Output before:

```
>>>>> def foo(**kwargs): pass
>>>>> foo(k=10, k=20)
SyntaxError: keyword argument repeated at line 1 column 10
foo(k=10, k=20)
         ^
```

Output after:

```
>>>>> def foo(**kwargs): pass
>>>>> foo(k=10, k=20)
SyntaxError: keyword argument 'k' repeated at line 1 column 10
foo(k=10, k=20)
         ^
```