### PR TITLE
Fix hex prefix

### DIFF
--- a/extra_tests/snippets/builtin_format.py
+++ b/extra_tests/snippets/builtin_format.py
@@ -28,3 +28,4 @@ assert f'{1024:_}' == '1_024'
 assert f'{65536:,}' == '65,536'
 assert f'{4294967296:,}' == '4,294,967,296'
 assert 'F' == "{0:{base}}".format(15, base="X")
+assert f'{255:#X}' == "0XFF"

--- a/vm/src/format.rs
+++ b/vm/src/format.rs
@@ -456,7 +456,7 @@ impl FormatSpec {
                 Some(FormatType::Binary) => "0b",
                 Some(FormatType::Octal) => "0o",
                 Some(FormatType::HexLower) => "0x",
-                Some(FormatType::HexUpper) => "0x",
+                Some(FormatType::HexUpper) => "0X",
                 _ => "",
             }
         } else {


### PR DESCRIPTION
Conversion from decimal to prefixed hex is incorrect.

```
>>>>> f"{255:#X}"
'0xFF'
```

The output should be `0XFF`.
I've fixed hex prefix.
