### PR TITLE
Fix character format

### DIFF
--- a/extra_tests/snippets/builtin_format.py
+++ b/extra_tests/snippets/builtin_format.py
@@ -33,5 +33,3 @@ assert f"{65:c}" == "A"
 assert f"{0x1f5a5:c}" == "🖥"
 assert_raises(ValueError, "{:+c}".format, 1, _msg="Sign not allowed with integer format specifier 'c'")
 assert_raises(ValueError, "{:#c}".format, 1, _msg="Alternate form (#) not allowed with integer format specifier 'c'")
-# TODO: raise OverflowError
-assert_raises(ValueError, "{:c}".format, -1, _msg="%c arg not in range(0x110000)")

--- a/extra_tests/snippets/builtin_format.py
+++ b/extra_tests/snippets/builtin_format.py
@@ -29,3 +29,9 @@ assert f'{65536:,}' == '65,536'
 assert f'{4294967296:,}' == '4,294,967,296'
 assert 'F' == "{0:{base}}".format(15, base="X")
 assert f'{255:#X}' == "0XFF"
+assert f"{65:c}" == "A"
+assert f"{0x1f5a5:c}" == "🖥"
+assert_raises(ValueError, "{:+c}".format, 1, _msg="Sign not allowed with integer format specifier 'c'")
+assert_raises(ValueError, "{:#c}".format, 1, _msg="Alternate form (#) not allowed with integer format specifier 'c'")
+# TODO: raise OverflowError
+assert_raises(ValueError, "{:c}".format, -1, _msg="%c arg not in range(0x110000)")


### PR DESCRIPTION
In CPython, integer can be converted to character.

```
>>> f"{65:c}"
'A'
```

But in RustPython, ValueError is raised.

```
>>>>> f"{65:c}"
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
ValueError: Unknown format code 'c' for object of type 'int'
```

I've fixed to convert an integer to character.
I referenced the following source code.
https://github.com/python/cpython/blob/79c10b7da84f52999dc483fc62c8e758ad3eff23/Python/formatter_unicode.c#L864
