### PR TITLE
Prefix format with padding doesn't work correctly.

### DIFF
--- a/extra_tests/snippets/builtin_format.py
+++ b/extra_tests/snippets/builtin_format.py
@@ -33,3 +33,13 @@ assert f"{65:c}" == "A"
 assert f"{0x1f5a5:c}" == "🖥"
 assert_raises(ValueError, "{:+c}".format, 1, _msg="Sign not allowed with integer format specifier 'c'")
 assert_raises(ValueError, "{:#c}".format, 1, _msg="Alternate form (#) not allowed with integer format specifier 'c'")
+assert f"{256:#010x}" == "0x00000100"
+assert f"{256:0=#10x}" == "0x00000100"
+assert f"{256:0>#10x}" == "000000x100"
+assert f"{256:0^#10x}" == "000x100000"
+assert f"{256:0<#10x}" == "0x10000000"
+assert f"{512:+#010x}" == "+0x0000200"
+assert f"{512:0=+#10x}" == "+0x0000200"
+assert f"{512:0>+#10x}" == "0000+0x200"
+assert f"{512:0^+#10x}" == "00+0x20000"
+assert f"{512:0<+#10x}" == "+0x2000000"

--- a/vm/src/format.rs
+++ b/vm/src/format.rs
@@ -504,12 +504,7 @@ impl FormatSpec {
             },
             None => self.format_int_radix(magnitude, 10),
         };
-        let magnitude_string = format!(
-            "{}{}",
-            prefix,
-            self.add_magnitude_separators(raw_magnitude_string_result?)
-        );
-
+        let magnitude_string = self.add_magnitude_separators(raw_magnitude_string_result?);
         let format_sign = self.sign.unwrap_or(FormatSign::Minus);
         let sign_str = match num.sign() {
             Sign::Minus => "-",
@@ -519,8 +514,8 @@ impl FormatSpec {
                 FormatSign::MinusOrSpace => " ",
             },
         };
-
-        self.format_sign_and_align(&magnitude_string, sign_str, FormatAlign::Right)
+        let sign_prefix = format!("{}{}", sign_str, prefix);
+        self.format_sign_and_align(&magnitude_string, &sign_prefix, FormatAlign::Right)
     }
 
     pub(crate) fn format_string(&self, s: &str) -> Result<String, &'static str> {


### PR DESCRIPTION
Prefixed format with padding doesn't work correctly.

```
>>>>> f"{256:#010x}"
'000000x100'
```

the output should be `0x00000100`
I've fixed format function.
