### PR TITLE
Fix the markdown URL in the sample notebook

### DIFF
--- a/wasm/notebook/snippets/python-markdown-math.txt
+++ b/wasm/notebook/snippets/python-markdown-math.txt
@@ -20,7 +20,7 @@ In the notebook, you can write markdown, math and python. use %% then:
 
 
 I **can** bold things and _italicize_ them. You got the gist, this is standard
-markdown syntax that you can [google](google.com).
+markdown syntax that you can [google](https://google.com).
 
 <br>
 


### PR DESCRIPTION
`[google](google.com)` → `[google](https://google.com)`

URLs without `https://` are relative.

If you run it in [the demo notebook](https://rustpython.github.io/demo/notebook/), then `google.com` becomes `https://rustpython.github.io/demo/notebook/google.com`.