### PR TITLE
Fix IndentationError works differently with cpython in interective shell

### DIFF
--- a/compiler/parser/src/error.rs
+++ b/compiler/parser/src/error.rs
@@ -221,7 +221,7 @@ pub(crate) fn parse_error_from_lalrpop(
                     source_path,
                 }
             }
-        },
+        }
     }
 }
 

--- a/compiler/parser/src/error.rs
+++ b/compiler/parser/src/error.rs
@@ -205,10 +205,22 @@ pub(crate) fn parse_error_from_lalrpop(
                 source_path,
             }
         }
-        LalrpopError::UnrecognizedEOF { location, .. } => ParseError {
-            error: ParseErrorType::Eof,
-            location,
-            source_path,
+        LalrpopError::UnrecognizedEOF { location, expected } => {
+            // This could be an initial indentation error that we should ignore
+            let indent_error = expected == ["Indent"];
+            if indent_error {
+                ParseError {
+                    error: ParseErrorType::Lexical(LexicalErrorType::IndentationError),
+                    location,
+                    source_path,
+                }
+            } else {
+                ParseError {
+                    error: ParseErrorType::Eof,
+                    location,
+                    source_path,
+                }
+            }
         },
     }
 }

--- a/src/shell.rs
+++ b/src/shell.rs
@@ -15,11 +15,20 @@ enum ShellExecResult {
     Continue,
 }
 
-fn shell_exec(vm: &VirtualMachine, source: &str, scope: Scope) -> ShellExecResult {
+fn shell_exec(vm: &VirtualMachine, source: &str, scope: Scope, last_row: &mut usize, empty_line_given: bool, continuing: bool) -> ShellExecResult {
     match vm.compile(source, compiler::Mode::Single, "<stdin>".to_owned()) {
-        Ok(code) => match vm.run_code_obj(code, scope) {
-            Ok(_val) => ShellExecResult::Ok,
-            Err(err) => ShellExecResult::PyErr(err),
+        Ok(code) => {
+            if empty_line_given || !continuing {
+                // We want to execute the full code
+                *last_row = 0;
+                match vm.run_code_obj(code, scope) {
+                    Ok(_val) => ShellExecResult::Ok,
+                    Err(err) => ShellExecResult::PyErr(err),
+                }
+            } else {
+                // We can just return an ok result
+                ShellExecResult::Ok
+            }
         },
         Err(CompileError {
             body:
@@ -37,7 +46,31 @@ fn shell_exec(vm: &VirtualMachine, source: &str, scope: Scope) -> ShellExecResul
                 },
             ..
         }) => ShellExecResult::Continue,
-        Err(err) => ShellExecResult::PyErr(vm.new_syntax_error(&err)),
+        Err(err) => {
+            // Indent error or something else?
+            let indent_error = match err.body.error {
+                CompileErrorType::Parse(ref p) => p.is_indentation_error(),
+                _ => false
+            };
+
+            if indent_error && !empty_line_given {
+                // The input line is not empty and it threw an indentation error
+                let l = err.body.location;
+
+                // This is how we can mask unnecesary errors
+                if l.row() > *last_row {
+                    *last_row = l.row();
+                    ShellExecResult::Continue
+                } else {
+                    *last_row = 0;
+                    ShellExecResult::PyErr(vm.new_syntax_error(&err))
+                }
+            } else {
+                // Throw the error for all other cases
+                *last_row = 0;
+                ShellExecResult::PyErr(vm.new_syntax_error(&err))
+            }
+        }  
     }
 }
 
@@ -60,6 +93,7 @@ pub fn run_shell(vm: &VirtualMachine, scope: Scope) -> PyResult<()> {
     }
 
     let mut continuing = false;
+    let mut last_row: usize = 0;
 
     loop {
         let prompt_name = if continuing { "ps2" } else { "ps1" };
@@ -78,7 +112,7 @@ pub fn run_shell(vm: &VirtualMachine, scope: Scope) -> PyResult<()> {
 
                 repl.add_history_entry(line.trim_end()).unwrap();
 
-                let stop_continuing = line.is_empty();
+                let empty_line_given = line.is_empty();
 
                 if full_input.is_empty() {
                     full_input = line;
@@ -87,30 +121,45 @@ pub fn run_shell(vm: &VirtualMachine, scope: Scope) -> PyResult<()> {
                 }
                 full_input.push('\n');
 
-                if continuing {
-                    if stop_continuing {
-                        continuing = false;
-                    } else {
-                        continue;
-                    }
-                }
 
-                match shell_exec(vm, &full_input, scope.clone()) {
+                match shell_exec(vm, &full_input, scope.clone(), &mut last_row, empty_line_given, continuing) {
                     ShellExecResult::Ok => {
-                        full_input.clear();
-                        Ok(())
+                        if continuing {
+
+                            if empty_line_given {
+                                // We should be exiting continue mode
+                                continuing = false;
+                                full_input.clear();
+                                Ok(())
+                            } else {
+                                // We should stay in continue mode
+                                continuing = true;
+                                Ok(())
+                            }
+
+                        } else {
+
+                            // We aren't in continue mode so proceed normally
+                            last_row = 0;
+                            continuing = false;
+                            full_input.clear();
+                            Ok(())
+                            
+                        }
                     }
                     ShellExecResult::Continue => {
                         continuing = true;
                         Ok(())
                     }
                     ShellExecResult::PyErr(err) => {
+                        continuing = false;
                         full_input.clear();
                         Err(err)
                     }
                 }
             }
             ReadlineResult::Interrupt => {
+                last_row = 0;
                 continuing = false;
                 full_input.clear();
                 let keyboard_interrupt =

--- a/src/shell.rs
+++ b/src/shell.rs
@@ -122,7 +122,14 @@ pub fn run_shell(vm: &VirtualMachine, scope: Scope) -> PyResult<()> {
                 full_input.push('\n');
 
 
-                match shell_exec(vm, &full_input, scope.clone(), &mut last_row, empty_line_given, continuing) {
+                match shell_exec(
+                    vm,
+                    &full_input,
+                    scope.clone(),
+                    &mut last_row,
+                    empty_line_given,
+                    continuing,
+                ) {
                     ShellExecResult::Ok => {
                         if continuing {
 

--- a/src/shell.rs
+++ b/src/shell.rs
@@ -15,7 +15,14 @@ enum ShellExecResult {
     Continue,
 }
 
-fn shell_exec(vm: &VirtualMachine, source: &str, scope: Scope, last_row: &mut usize, empty_line_given: bool, continuing: bool) -> ShellExecResult {
+fn shell_exec(
+    vm: &VirtualMachine,
+    source: &str,
+    scope: Scope,
+    last_row: &mut usize,
+    empty_line_given: bool,
+    continuing: bool,
+) -> ShellExecResult {
     match vm.compile(source, compiler::Mode::Single, "<stdin>".to_owned()) {
         Ok(code) => {
             if empty_line_given || !continuing {
@@ -29,7 +36,7 @@ fn shell_exec(vm: &VirtualMachine, source: &str, scope: Scope, last_row: &mut us
                 // We can just return an ok result
                 ShellExecResult::Ok
             }
-        },
+        }
         Err(CompileError {
             body:
                 CompileErrorBody {
@@ -50,7 +57,7 @@ fn shell_exec(vm: &VirtualMachine, source: &str, scope: Scope, last_row: &mut us
             // Indent error or something else?
             let indent_error = match err.body.error {
                 CompileErrorType::Parse(ref p) => p.is_indentation_error(),
-                _ => false
+                _ => false,
             };
 
             if indent_error && !empty_line_given {
@@ -70,7 +77,7 @@ fn shell_exec(vm: &VirtualMachine, source: &str, scope: Scope, last_row: &mut us
                 *last_row = 0;
                 ShellExecResult::PyErr(vm.new_syntax_error(&err))
             }
-        }  
+        }
     }
 }
 
@@ -121,7 +128,6 @@ pub fn run_shell(vm: &VirtualMachine, scope: Scope) -> PyResult<()> {
                 }
                 full_input.push('\n');
 
-
                 match shell_exec(
                     vm,
                     &full_input,
@@ -132,7 +138,6 @@ pub fn run_shell(vm: &VirtualMachine, scope: Scope) -> PyResult<()> {
                 ) {
                     ShellExecResult::Ok => {
                         if continuing {
-
                             if empty_line_given {
                                 // We should be exiting continue mode
                                 continuing = false;
@@ -143,15 +148,12 @@ pub fn run_shell(vm: &VirtualMachine, scope: Scope) -> PyResult<()> {
                                 continuing = true;
                                 Ok(())
                             }
-
                         } else {
-
                             // We aren't in continue mode so proceed normally
                             last_row = 0;
                             continuing = false;
                             full_input.clear();
                             Ok(())
-                            
                         }
                     }
                     ShellExecResult::Continue => {


### PR DESCRIPTION
Fixes #3892  #4400 

Removed the automatic continuing logic that was in place for code that needs multiple lines in the shell to parse correctly. Now we check if full_code can be parsed after each line of input given, but ignoring specific EOF and IndentationLevel errors.

I am working on a way to do this without modifying errors.rs, if I should not be modifying that.

Edit: I think my edits to errors.rs may have improved EOF error handling.