### PR TITLE
Introduce `ImplicitConcat`

### DIFF
--- a/compiler/ast/Cargo.toml
+++ b/compiler/ast/Cargo.toml
@@ -8,7 +8,7 @@ edition = "2021"
 default = ["constant-optimization", "fold"]
 constant-optimization = ["fold"]
 fold = []
-implicit-concatenation = []
+implicit-concat = []
 unparse = ["rustpython-common"]
 
 [dependencies]

--- a/compiler/ast/Cargo.toml
+++ b/compiler/ast/Cargo.toml
@@ -8,6 +8,7 @@ edition = "2021"
 default = ["constant-optimization", "fold"]
 constant-optimization = ["fold"]
 fold = []
+implicit-concatenation = []
 unparse = ["rustpython-common"]
 
 [dependencies]

--- a/compiler/ast/src/ast_gen.rs
+++ b/compiler/ast/src/ast_gen.rs
@@ -245,8 +245,8 @@ pub enum ExprKind<U = ()> {
     JoinedStr {
         values: Vec<Expr<U>>,
     },
-    #[cfg(feature = "implicit-concatenation")]
-    ImplicitConcatenation {
+    #[cfg(feature = "implicit-concat")]
+    ImplicitConcat {
         values: Vec<Expr<U>>,
     },
     Constant {
@@ -867,8 +867,8 @@ pub mod fold {
             ExprKind::JoinedStr { values } => Ok(ExprKind::JoinedStr {
                 values: Foldable::fold(values, folder)?,
             }),
-            #[cfg(feature = "implicit-concatenation")]
-            ExprKind::ImplicitConcatenation { values } => Ok(ExprKind::JoinedStr {
+            #[cfg(feature = "implicit-concat")]
+            ExprKind::ImplicitConcat { values } => Ok(ExprKind::JoinedStr {
                 values: Foldable::fold(values, folder)?,
             }),
             ExprKind::Constant { value, kind } => Ok(ExprKind::Constant {

--- a/compiler/ast/src/ast_gen.rs
+++ b/compiler/ast/src/ast_gen.rs
@@ -245,6 +245,10 @@ pub enum ExprKind<U = ()> {
     JoinedStr {
         values: Vec<Expr<U>>,
     },
+    #[cfg(feature = "implicit-concatenation")]
+    ImplicitConcatenation {
+        values: Vec<Expr<U>>,
+    },
     Constant {
         value: Constant,
         kind: Option<String>,
@@ -861,6 +865,10 @@ pub mod fold {
                 format_spec: Foldable::fold(format_spec, folder)?,
             }),
             ExprKind::JoinedStr { values } => Ok(ExprKind::JoinedStr {
+                values: Foldable::fold(values, folder)?,
+            }),
+            #[cfg(feature = "implicit-concatenation")]
+            ExprKind::ImplicitConcatenation { values } => Ok(ExprKind::JoinedStr {
                 values: Foldable::fold(values, folder)?,
             }),
             ExprKind::Constant { value, kind } => Ok(ExprKind::Constant {

--- a/compiler/ast/src/impls.rs
+++ b/compiler/ast/src/impls.rs
@@ -50,6 +50,8 @@ impl<U> ExprKind<U> {
                     "literal"
                 }
             }
+            #[cfg(feature = "implicit-concatenation")]
+            ExprKind::ImplicitConcatenation { .. } => "implicit concatenation",
             ExprKind::FormattedValue { .. } => "f-string expression",
             ExprKind::Name { .. } => "name",
             ExprKind::Lambda { .. } => "lambda",

--- a/compiler/ast/src/impls.rs
+++ b/compiler/ast/src/impls.rs
@@ -50,8 +50,8 @@ impl<U> ExprKind<U> {
                     "literal"
                 }
             }
-            #[cfg(feature = "implicit-concatenation")]
-            ExprKind::ImplicitConcatenation { .. } => "implicit concatenation",
+            #[cfg(feature = "implicit-concat")]
+            ExprKind::ImplicitConcat { .. } => "implicit concatenation",
             ExprKind::FormattedValue { .. } => "f-string expression",
             ExprKind::Name { .. } => "name",
             ExprKind::Lambda { .. } => "lambda",

--- a/compiler/ast/src/unparse.rs
+++ b/compiler/ast/src/unparse.rs
@@ -284,6 +284,12 @@ impl<'a> Unparser<'a> {
                 format_spec,
             } => self.unparse_formatted(value, *conversion, format_spec.as_deref())?,
             ExprKind::JoinedStr { values } => self.unparse_joinedstr(values, false)?,
+            #[cfg(feature = "implicit-concat")]
+            ExprKind::ImplicitConcat { values } => {
+                for value in values {
+                    self.unparse_expr(value, precedence::ATOM)?;
+                }
+            }
             ExprKind::Constant { value, kind } => {
                 if let Some(kind) = kind {
                     self.p(kind)?;

--- a/compiler/parser/Cargo.toml
+++ b/compiler/parser/Cargo.toml
@@ -10,7 +10,7 @@ edition = "2021"
 
 [features]
 default = ["lalrpop"]  # removing this causes potential build failure
-implicit-concatenation = ["rustpython-ast/implicit-concatenation"]
+implicit-concat = ["rustpython-ast/implicit-concat"]
 
 [build-dependencies]
 anyhow = "1.0.45"

--- a/compiler/parser/Cargo.toml
+++ b/compiler/parser/Cargo.toml
@@ -10,6 +10,7 @@ edition = "2021"
 
 [features]
 default = ["lalrpop"]  # removing this causes potential build failure
+implicit-concatenation = ["rustpython-ast/implicit-concatenation"]
 
 [build-dependencies]
 anyhow = "1.0.45"

--- a/compiler/parser/src/string.rs
+++ b/compiler/parser/src/string.rs
@@ -10,7 +10,7 @@ pub fn parse_strings(
     values: Vec<(Location, (String, StringKind, bool), Location)>,
 ) -> Result<Expr, LexicalError> {
     // Preserve the initial location and kind.
-    let is_implicit_concatenation = cfg!(feature = "implicit-concatenation") && values.len() > 1;
+    let is_implicit_concat = cfg!(feature = "implicit-concat") && values.len() > 1;
     let initial_start = values[0].0;
     let last_end = values.last().unwrap().2;
     let initial_kind = (values[0].1 .1 == StringKind::Unicode).then(|| "u".to_owned());
@@ -30,8 +30,8 @@ pub fn parse_strings(
         });
     }
 
-    #[cfg(feature = "implicit-concatenation")]
-    if is_implicit_concatenation {
+    #[cfg(feature = "implicit-concat")]
+    if is_implicit_concat {
         let mut exprs: Vec<Expr> = vec![];
         for (start, (source, kind, triple_quoted), end) in values {
             let expr = parse_string(&source, kind, triple_quoted, start, end)?;
@@ -40,7 +40,7 @@ pub fn parse_strings(
         return Ok(Expr::new(
             initial_start,
             last_end,
-            ExprKind::ImplicitConcatenation { values: exprs },
+            ExprKind::ImplicitConcat { values: exprs },
         ));
     }
 

--- a/compiler/parser/src/string_parser.rs
+++ b/compiler/parser/src/string_parser.rs
@@ -502,13 +502,14 @@ impl<'a> StringParser<'a> {
         }))
     }
 
-    pub fn parse(&mut self) -> Result<Vec<Expr>, LexicalError> {
+    pub fn parse(&mut self) -> Result<Expr, LexicalError> {
         if self.kind.is_fstring() {
             self.parse_fstring(0)
+                .map(|values| self.expr(ExprKind::JoinedStr { values }))
         } else if self.kind.is_bytes() {
-            self.parse_bytes().map(|expr| vec![expr])
+            self.parse_bytes()
         } else {
-            self.parse_string().map(|expr| vec![expr])
+            self.parse_string()
         }
     }
 }
@@ -528,7 +529,7 @@ pub fn parse_string(
     triple_quoted: bool,
     start: Location,
     end: Location,
-) -> Result<Vec<Expr>, LexicalError> {
+) -> Result<Expr, LexicalError> {
     StringParser::new(source, kind, triple_quoted, start, end).parse()
 }
 
@@ -536,7 +537,7 @@ pub fn parse_string(
 mod tests {
     use super::*;
 
-    fn parse_fstring(source: &str) -> Result<Vec<Expr>, FStringErrorType> {
+    fn parse_fstring(source: &str) -> Result<Expr, FStringErrorType> {
         StringParser::new(
             source,
             StringKind::FString,

--- a/rust-toolchain
+++ b/rust-toolchain
@@ -1,1 +1,2 @@
-stable
+[toolchain]
+channel = "nightly"


### PR DESCRIPTION
**I don't think this proposal is acceptable** because the proposed node doesn't exist in Python. I just wanted to hear thoughts on it. This PR adds a new AST node `ImplicitConcat` that represents implicit concatenation (e.g. `"a" "b"`). Currently, implicitly-concatenated strings are merged into a single `Constant` or `JoinedStr` node. This makes it difficult to analyze each string component. Here's an example:

```python
(
  f"a"    # useless f-string
  ""      # useless empty string
  f"{x}"
)
```

This code is parsed as:

```
JoinedStr {
  values: [
    Constant,
    FormattedValue
  ]
}
```

This is is equivalent to `f"a{x}"`, which is a valid f-string.


If the python code above was parsed as:

```
ImplicitConcat {
  values: [
    JoinedStr { values: [Constant] },
    Constnat,
    JoinedStr { values: [FormattedValue] },
  ]
}
```

that would allow a linter such as Ruff to analyze each token and provide more helpful errors.

The following video is a quick demo that utilizes `ImplicitConcat`:

https://user-images.githubusercontent.com/17039389/210311906-3043c61d-b562-44aa-b88f-e752df1f2925.mov