### PR TITLE
Correct exitcode of KeyboardInterrupt

### DIFF
--- a/vm/src/vm/mod.rs
+++ b/vm/src/vm/mod.rs
@@ -757,6 +757,19 @@ impl VirtualMachine {
                 writeln!(stderr, "{msg}");
             }
             1
+        } else if exc.fast_isinstance(self.ctx.exceptions.keyboard_interrupt) {
+            #[allow(clippy::if_same_then_else)]
+            {
+                self.print_exception(exc);
+                #[cfg(unix)]
+                {
+                    (libc::SIGINT as u8) + 128u8
+                }
+                #[cfg(not(unix))]
+                {
+                    1
+                }
+            }
         } else {
             self.print_exception(exc);
             1


### PR DESCRIPTION
This pull requests fixes exitcode of `KeyboardInterrupt`. You can run the below code with CPython and RustPython(before/after). (in unix target os)

```
# RUSTPYTHON
cargo run -- -c "raise KeyboardInterrupt"
echo $?  # before = 1 / after = 130

# CPYTHON
python3 -c "raise KeyboardInterrupt"
echo $?  # 130
```

## Tasks

- [x] macOS
- [x] ubuntu
- ~~windows~~
  - https://docs.rs/winapi/latest/winapi/um/winnt/constant.STATUS_CONTROL_C_EXIT.html
- ~~wasm~~

## Related links

 - https://github.com/python/cpython/blob/8b1f1251215651c4ef988622345c5cb134e54d69/Modules/main.c#L666