### PR TITLE
Remove incorrect `EmptyExpression` in `StringParser.parse_formatted_value`

### DIFF
--- a/compiler/parser/src/error.rs
+++ b/compiler/parser/src/error.rs
@@ -42,7 +42,7 @@ impl fmt::Display for LexicalErrorType {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match self {
             LexicalErrorType::StringError => write!(f, "Got unexpected string"),
-            LexicalErrorType::FStringError(error) => write!(f, "Got error in f-string: {error}"),
+            LexicalErrorType::FStringError(error) => write!(f, "f-string: {error}"),
             LexicalErrorType::UnicodeError => write!(f, "Got unexpected unicode"),
             LexicalErrorType::NestingError => write!(f, "Got unexpected nesting"),
             LexicalErrorType::IndentationError => {

--- a/compiler/parser/src/string_parser.rs
+++ b/compiler/parser/src/string_parser.rs
@@ -358,11 +358,7 @@ impl<'a> StringParser<'a> {
                 }
             }
         }
-        Err(if expression.trim().is_empty() {
-            FStringError::new(EmptyExpression, self.get_pos()).into()
-        } else {
-            FStringError::new(UnclosedLbrace, self.get_pos()).into()
-        })
+        Err(FStringError::new(UnclosedLbrace, self.get_pos()).into())
     }
 
     fn parse_spec(&mut self, nested: u8) -> Result<Vec<Expr>, LexicalError> {


### PR DESCRIPTION
Removes incorrect `EmptyExpression` in `StringParser.parse_formatted_value`.