### PR TITLE
Implement float format validation

### DIFF
--- a/common/src/format.rs
+++ b/common/src/format.rs
@@ -580,7 +580,7 @@ impl FormatSpec {
             | Some(FormatType::ExponentUpper)
             | Some(FormatType::ExponentLower)
             | Some(FormatType::Percentage) => match num.to_f64() {
-                Some(float) => return self.format_float(float).map_err(|msg| msg.to_owned()),
+                Some(float) => return self.format_float(float),
                 _ => Err("Unable to convert int to float".to_owned()),
             },
             None => self.format_int_radix(magnitude, 10),

--- a/extra_tests/snippets/builtin_format.py
+++ b/extra_tests/snippets/builtin_format.py
@@ -68,3 +68,5 @@ assert f"{1234:.3g}" == "1.23e+03"
 assert f"{1234567:.6G}" == "1.23457E+06"
 assert_raises(ValueError, "{:,o}".format, 1, _msg="ValueError: Cannot specify ',' with 'o'.")
 assert_raises(ValueError, "{:_n}".format, 1, _msg="ValueError: Cannot specify '_' with 'n'.")
+assert_raises(ValueError, "{:,o}".format, 1.0, _msg="ValueError: Cannot specify ',' with 'o'.")
+assert_raises(ValueError, "{:_n}".format, 1.0, _msg="ValueError: Cannot specify '_' with 'n'.")

--- a/vm/src/builtins/float.rs
+++ b/vm/src/builtins/float.rs
@@ -189,12 +189,11 @@ fn float_from_string(val: PyObjectRef, vm: &VirtualMachine) -> PyResult<f64> {
 impl PyFloat {
     #[pymethod(magic)]
     fn format(&self, spec: PyStrRef, vm: &VirtualMachine) -> PyResult<String> {
-        match FormatSpec::parse(spec.as_str())
-            .and_then(|format_spec| format_spec.format_float(self.value))
-        {
-            Ok(string) => Ok(string),
-            Err(err) => Err(vm.new_value_error(err.to_string())),
-        }
+        let format_spec =
+            FormatSpec::parse(spec.as_str()).map_err(|msg| vm.new_value_error(msg.to_owned()))?;
+        format_spec
+            .format_float(self.value)
+            .map_err(|msg| vm.new_value_error(msg))
     }
 
     #[pystaticmethod(magic)]


### PR DESCRIPTION
Float Format validation is not implemented.

```
>>>>> f"{1.0:,o}"
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
ValueError: Unknown format code 'o' for object of type 'float'
```
The output should be raised `ValueError: Cannot specify ',' with 'o'.`
I've implemented format validation.