### PR TITLE
Fix `FormatSpec::parse`.

### DIFF
--- a/common/src/format.rs
+++ b/common/src/format.rs
@@ -271,7 +271,7 @@ fn parse_precision(text: &str) -> Result<(Option<usize>, &str), &'static str> {
 }
 
 impl FormatSpec {
-    pub fn parse(text: &str) -> Result<Self, &'static str> {
+    pub fn parse(text: &str) -> Result<Self, String> {
         // get_integer in CPython
         let (preconversor, text) = FormatPreconversor::parse(text);
         let (mut fill, mut align, text) = parse_fill_and_align(text);
@@ -283,7 +283,7 @@ impl FormatSpec {
         let (precision, text) = parse_precision(text)?;
         let (format_type, text) = FormatType::parse(text);
         if !text.is_empty() {
-            return Err("Invalid format specifier");
+            return Err("Invalid format specifier".to_owned());
         }
 
         if zero && fill.is_none() {
@@ -685,7 +685,7 @@ pub enum FormatParseError {
 }
 
 impl FromStr for FormatSpec {
-    type Err = &'static str;
+    type Err = String;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         FormatSpec::parse(s)
     }

--- a/common/src/format.rs
+++ b/common/src/format.rs
@@ -1104,13 +1104,34 @@ mod tests {
 
     #[test]
     fn test_format_invalid_specification() {
-        assert_eq!(FormatSpec::parse("%3"), Err("Invalid format specifier"));
-        assert_eq!(FormatSpec::parse(".2fa"), Err("Invalid format specifier"));
-        assert_eq!(FormatSpec::parse("ds"), Err("Invalid format specifier"));
-        assert_eq!(FormatSpec::parse("x+"), Err("Invalid format specifier"));
-        assert_eq!(FormatSpec::parse("b4"), Err("Invalid format specifier"));
-        assert_eq!(FormatSpec::parse("o!"), Err("Invalid format specifier"));
-        assert_eq!(FormatSpec::parse("d "), Err("Invalid format specifier"));
+        assert_eq!(
+            FormatSpec::parse("%3"),
+            Err("Invalid format specifier".to_owned())
+        );
+        assert_eq!(
+            FormatSpec::parse(".2fa"),
+            Err("Invalid format specifier".to_owned())
+        );
+        assert_eq!(
+            FormatSpec::parse("ds"),
+            Err("Invalid format specifier".to_owned())
+        );
+        assert_eq!(
+            FormatSpec::parse("x+"),
+            Err("Invalid format specifier".to_owned())
+        );
+        assert_eq!(
+            FormatSpec::parse("b4"),
+            Err("Invalid format specifier".to_owned())
+        );
+        assert_eq!(
+            FormatSpec::parse("o!"),
+            Err("Invalid format specifier".to_owned())
+        );
+        assert_eq!(
+            FormatSpec::parse("d "),
+            Err("Invalid format specifier".to_owned())
+        );
     }
 
     #[test]

--- a/vm/src/builtins/float.rs
+++ b/vm/src/builtins/float.rs
@@ -189,10 +189,8 @@ fn float_from_string(val: PyObjectRef, vm: &VirtualMachine) -> PyResult<f64> {
 impl PyFloat {
     #[pymethod(magic)]
     fn format(&self, spec: PyStrRef, vm: &VirtualMachine) -> PyResult<String> {
-        let format_spec =
-            FormatSpec::parse(spec.as_str()).map_err(|msg| vm.new_value_error(msg.to_owned()))?;
-        format_spec
-            .format_float(self.value)
+        FormatSpec::parse(spec.as_str())
+            .and_then(|format_spec| format_spec.format_float(self.value))
             .map_err(|msg| vm.new_value_error(msg))
     }
 

--- a/vm/src/builtins/int.rs
+++ b/vm/src/builtins/int.rs
@@ -568,10 +568,8 @@ impl PyInt {
 
     #[pymethod(magic)]
     fn format(&self, spec: PyStrRef, vm: &VirtualMachine) -> PyResult<String> {
-        let format_spec =
-            FormatSpec::parse(spec.as_str()).map_err(|msg| vm.new_value_error(msg.to_owned()))?;
-        format_spec
-            .format_int(&self.value)
+        FormatSpec::parse(spec.as_str())
+            .and_then(|format_spec| format_spec.format_int(&self.value))
             .map_err(|msg| vm.new_value_error(msg))
     }
 

--- a/vm/src/builtins/str.rs
+++ b/vm/src/builtins/str.rs
@@ -730,10 +730,8 @@ impl PyStr {
 
     #[pymethod(name = "__format__")]
     fn format_str(&self, spec: PyStrRef, vm: &VirtualMachine) -> PyResult<String> {
-        let format_spec =
-            FormatSpec::parse(spec.as_str()).map_err(|err| vm.new_value_error(err.to_string()))?;
-        format_spec
-            .format_string(self.borrow())
+        FormatSpec::parse(spec.as_str())
+            .and_then(|format_spec| format_spec.format_string(self.borrow()))
             .map_err(|msg| vm.new_value_error(msg))
     }
 


### PR DESCRIPTION
Fix return type of `FormatSpec::parse`.
With this fix, Method chain can be used.