### PR TITLE
Fix integer format

### DIFF
--- a/common/src/format.rs
+++ b/common/src/format.rs
@@ -600,7 +600,7 @@ impl FormatSpec {
         let sign_prefix = format!("{}{}", sign_str, prefix);
         let magnitude_str = self.add_magnitude_separators(raw_magnitude_str?, &sign_prefix);
         self.format_sign_and_align(
-            unsafe { &BorrowedStr::from_ascii_unchecked(magnitude_str.as_bytes()) },
+            &BorrowedStr::from_bytes(magnitude_str.as_bytes()),
             &sign_prefix,
             FormatAlign::Right,
         )

--- a/common/src/str.rs
+++ b/common/src/str.rs
@@ -81,6 +81,20 @@ impl<'a> BorrowedStr<'a> {
     }
 
     #[inline]
+    pub fn from_bytes(s: &'a [u8]) -> Self {
+        let k = if s.is_ascii() {
+            PyStrKind::Ascii.new_data()
+        } else {
+            PyStrKind::Utf8.new_data()
+        };
+        Self {
+            bytes: s,
+            kind: k,
+            hash: PyAtomic::<PyHash>::new(0),
+        }
+    }
+
+    #[inline]
     pub fn as_str(&self) -> &str {
         unsafe {
             // SAFETY: Both PyStrKind::{Ascii, Utf8} are valid utf8 string


### PR DESCRIPTION
Panic occured when formatted from integer to multibyte characater.

```
>>>>> f"{0x1f5a5:c}"
thread 'main' panicked at 'assertion failed: s.is_ascii()', common/src/str.rs:75:9
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
```

I've implemented the check whether string contains multibyte character.