### PR TITLE
[RFC] Add Github Codespaces configuration (devcontainer.json)

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,6 @@
+{
+  "image": "mcr.microsoft.com/devcontainers/universal:2",
+  "features": {
+    "ghcr.io/devcontainers/features/rust:1": {}
+  }
+}


### PR DESCRIPTION
Github has recently a new feature called [Codespaces](https://github.com/features/codespaces). A codespace is basically a development VM that can be preconfigured to support certain environment. I've found this feature while working on my first contribution to RustPython, so I would like to suggest to add this configuration to the main repo. This PR adds an official Rust feature image supported by Github team, currently it has Rust 1.66.0.

Codespaces in forks are paid by the fork owner, so RustPython org won't be billed for anything.

# Relevant links
- Docs: https://docs.github.com/en/codespaces/overview