### PR TITLE
Fix docs.rs build for rustpython-parser

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,5 +19,3 @@ flamescope.json
 
 extra_tests/snippets/resources
 extra_tests/not_impl.py
-
-compiler/parser/python.rs

--- a/compiler/parser/src/python.rs
+++ b/compiler/parser/src/python.rs
@@ -1,3 +1,3 @@
 #![allow(clippy::all)]
 #![allow(unused)]
-include!("../python.rs");
+include!(concat!(env!("OUT_DIR"), "/python.rs"));


### PR DESCRIPTION
docs.rs failed to build the documentation of the recently released rustpython-parser 0.2.0 because the build.rs script couldn't write the parser.rs file because docs.rs builds the documentation in a sandbox with a read-only filesystem.

This commit fixes this by writing the parser.rs file to the cargo output directory instead, as recommended by the docs.rs documentation.[1]

Fixes #4436.

[1]: https://docs.rs/about/builds#read-only-directories