### PR TITLE
Fix location of parenthesized expression

### DIFF
--- a/compiler/parser/python.lalrpop
+++ b/compiler/parser/python.lalrpop
@@ -1088,7 +1088,11 @@ Atom<Goal>: ast::Expr = {
     },
     <location:@L> "(" <elts:OneOrMore<Test<"all">>> <trailing_comma:","?> ")" <end_location:@R> if Goal != "no-withitems" => {
         if elts.len() == 1 && trailing_comma.is_none() {
-            elts.into_iter().next().unwrap()
+            ast::Expr::new(
+                location,
+                end_location,
+                elts.into_iter().next().unwrap().node,
+            )
         } else {
             ast::Expr::new(
                 location,

--- a/compiler/parser/python.lalrpop
+++ b/compiler/parser/python.lalrpop
@@ -22,7 +22,7 @@ grammar;
 pub Top: ast::Mod = {
     StartModule <body:Program> => ast::Mod::Module { body, type_ignores: vec![] },
     StartInteractive <body:Program> => ast::Mod::Interactive { body },
-    StartExpression <body:TestList> ("\n")* => ast::Mod::Expression { body: Box::new(body) },
+    StartExpression <body:TestListOrYieldExpr> ("\n")* => ast::Mod::Expression { body: Box::new(body) },
 };
 
 Program: ast::Suite = {

--- a/compiler/parser/src/parser.rs
+++ b/compiler/parser/src/parser.rs
@@ -316,4 +316,11 @@ with (0 as a, 1 as b,): pass
             assert!(parse_program(source, "<test>").is_err());
         }
     }
+
+    #[test]
+    fn test_parenthesized_expression() {
+        let source = String::from("( 1 )");
+        let parse_ast = parse_expression(&source, "<test>").unwrap();
+        insta::assert_debug_snapshot!(parse_ast);
+    }
 }

--- a/compiler/parser/src/snapshots/rustpython_parser__parser__tests__parenthesized_expression.snap
+++ b/compiler/parser/src/snapshots/rustpython_parser__parser__tests__parenthesized_expression.snap
@@ -1,0 +1,23 @@
+---
+source: compiler/parser/src/parser.rs
+expression: parse_ast
+---
+Located {
+    location: Location {
+        row: 1,
+        column: 0,
+    },
+    end_location: Some(
+        Location {
+            row: 1,
+            column: 5,
+        },
+    ),
+    custom: (),
+    node: Constant {
+        value: Int(
+            1,
+        ),
+        kind: None,
+    },
+}

--- a/compiler/parser/src/snapshots/rustpython_parser__parser__tests__with_statement.snap
+++ b/compiler/parser/src/snapshots/rustpython_parser__parser__tests__with_statement.snap
@@ -761,12 +761,12 @@ expression: "parse_program(source, \"<test>\").unwrap()"
                     context_expr: Located {
                         location: Location {
                             row: 10,
-                            column: 6,
+                            column: 5,
                         },
                         end_location: Some(
                             Location {
                                 row: 10,
-                                column: 7,
+                                column: 8,
                             },
                         ),
                         custom: (),

--- a/compiler/parser/src/string_parser.rs
+++ b/compiler/parser/src/string_parser.rs
@@ -533,7 +533,7 @@ fn parse_fstring_expr(source: &str, location: Location) -> Result<Expr, ParseErr
     );
     let mut tokens: Vec<LexResult> = iter::once(Ok(marker_token))
         .chain(lxr)
-        .filter_ok(|(_, tok, _)| !matches!(tok, Tok::Comment { .. }))
+        .filter_ok(|(_, tok, _)| !matches!(tok, Tok::Comment { .. } | Tok::NonLogicalNewline))
         .collect();
     // Remove the first `Lpar` token
     let lpar_index = tokens

--- a/compiler/parser/src/string_parser.rs
+++ b/compiler/parser/src/string_parser.rs
@@ -518,8 +518,12 @@ impl<'a> StringParser<'a> {
 }
 
 fn parse_fstring_expr(source: &str, location: Location) -> Result<Expr, ParseError> {
-    let fstring_body = format!("({source})");
-    parse_expression_located(&fstring_body, "<fstring>", location.with_col_offset(-1))
+    let trimmed = source.trim_start();
+    parse_expression_located(
+        trimmed,
+        "<fstring>",
+        location.with_col_offset(source.chars().count() - trimmed.chars().count()),
+    )
 }
 
 pub fn parse_string(
@@ -669,7 +673,6 @@ mod tests {
     #[test]
     fn test_parse_fstring_yield_expr() {
         let source = "{yield}";
-        let parse_ast = parse_fstring(source).unwrap();
-        insta::assert_debug_snapshot!(parse_ast);
+        assert!(parse_fstring(source).is_err());
     }
 }

--- a/compiler/parser/src/string_parser.rs
+++ b/compiler/parser/src/string_parser.rs
@@ -711,6 +711,7 @@ mod tests {
     #[test]
     fn test_parse_fstring_yield_expr() {
         let source = "{yield}";
-        assert!(parse_fstring(source).is_err());
+        let parse_ast = parse_fstring(source).unwrap();
+        insta::assert_debug_snapshot!(parse_ast);
     }
 }


### PR DESCRIPTION
This PR fixes the location of a parenthesized expression like this:

```python
(     1   )
```

## Cpython

```python
import ast

print(ast.dump(ast.parse("(     1   )"), include_attributes=True, indent=2))
```

gives:

```
Module(
  body=[
    Expr(
      value=Constant(
        value=1,
        lineno=1,
        col_offset=6,
        end_lineno=1,
        end_col_offset=7),
      lineno=1,
      col_offset=0,
      end_lineno=1,
      end_col_offset=11)],
  type_ignores=[])
```