### PR TITLE
Fixed UTF-8 encoding for `whats_left.py` and type mismatching in `stdlib/src/ssl.rs`

### DIFF
--- a/.cspell.json
+++ b/.cspell.json
@@ -80,11 +80,13 @@
     "rdiv",
     "idiv",
     "ndim",
+    "unionable",
     "varnames",
     "getweakrefs",
     "getweakrefcount",
     "stacklevel",
     "MemoryView",
+    "metatype",
     "warningregistry",
     "defaultaction",
     "unraisablehook",
@@ -129,7 +131,12 @@
     "posonlyargs",
     "kwonlyargs",
     "uninit",
-    "miri"
+    "miri",
+    // cpython
+    "linearise",
+    "dictoffset",
+    "heaptype",
+    "IMMUTABLETYPE"
   ],
   // flagWords - list of words to be always considered incorrect
   "flagWords": [

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -295,6 +295,8 @@ jobs:
         run: |
           mkdir site-packages
           target/release/rustpython --install-pip ensurepip --user
+      - name: Check whats_left is not broken
+        run: python -I whats_left.py
 
   lalrpop:
     if: ${{ !contains(github.event.pull_request.labels.*.name, 'skip:ci') }}
@@ -361,8 +363,6 @@ jobs:
         run: cd wasm && git ls-files -z | xargs -0 prettier --check -u
       - name: Check update_asdl.sh consistency
         run: bash scripts/update_asdl.sh && git diff --exit-code
-      - name: Check whats_left is not broken
-        run: python -I whats_left.py
 
   miri:
     if: ${{ !contains(github.event.pull_request.labels.*.name, 'skip:ci') }}

--- a/stdlib/src/ssl.rs
+++ b/stdlib/src/ssl.rs
@@ -121,7 +121,7 @@ mod _ssl {
     #[pyattr]
     const PROTO_MAXIMUM_SUPPORTED: i32 = ProtoVersion::MaxSupported as i32;
     #[pyattr]
-    const OP_ALL: libc::c_ulong = sys::SSL_OP_ALL & !sys::SSL_OP_DONT_INSERT_EMPTY_FRAGMENTS;
+    const OP_ALL: libc::c_ulong = (sys::SSL_OP_ALL & !sys::SSL_OP_DONT_INSERT_EMPTY_FRAGMENTS) as _;
     #[pyattr]
     const HAS_TLS_UNIQUE: bool = true;
     #[pyattr]

--- a/vm/src/builtins/type.rs
+++ b/vm/src/builtins/type.rs
@@ -868,11 +868,11 @@ impl PyType {
                 })?;
         }
 
-        if let Some(initter) = typ.get_super_attr(identifier!(vm, __init_subclass__)) {
-            let initter = vm
-                .call_get_descriptor_specific(initter.clone(), None, Some(typ.clone().into()))
-                .unwrap_or(Ok(initter))?;
-            vm.invoke(&initter, kwargs)?;
+        if let Some(init_subclass) = typ.get_super_attr(identifier!(vm, __init_subclass__)) {
+            let init_subclass = vm
+                .call_get_descriptor_specific(init_subclass.clone(), None, Some(typ.clone().into()))
+                .unwrap_or(Ok(init_subclass))?;
+            vm.invoke(&init_subclass, kwargs)?;
         };
 
         Ok(typ.into())
@@ -1156,14 +1156,14 @@ fn take_next_base(bases: &mut [Vec<PyTypeRef>]) -> Option<PyTypeRef> {
 }
 
 fn linearise_mro(mut bases: Vec<Vec<PyTypeRef>>) -> Result<Vec<PyTypeRef>, String> {
-    vm_trace!("Linearising MRO: {:?}", bases);
+    vm_trace!("Linearise MRO: {:?}", bases);
     // Python requires that the class direct bases are kept in the same order.
     // This is called local precedence ordering.
     // This means we must verify that for classes A(), B(A) we must reject C(A, B) even though this
     // algorithm will allow the mro ordering of [C, B, A, object].
     // To verify this, we make sure non of the direct bases are in the mro of bases after them.
     for (i, base_mro) in bases.iter().enumerate() {
-        let base = &base_mro[0]; // Mros cannot be empty.
+        let base = &base_mro[0]; // MROs cannot be empty.
         for later_mro in &bases[i + 1..] {
             // We start at index 1 to skip direct bases.
             // This will not catch duplicate bases, but such a thing is already tested for.

--- a/whats_left.py
+++ b/whats_left.py
@@ -441,7 +441,7 @@ def remove_one_indent(s):
 compare_src = inspect.getsourcelines(compare)[0][1:]
 output += "".join(remove_one_indent(line) for line in compare_src)
 
-with open(GENERATED_FILE, "w") as f:
+with open(GENERATED_FILE, "w", encoding='utf-8') as f:
     f.write(output + "\n")
 
 


### PR DESCRIPTION
This Pull Request is fixing the charmap error when running Python over the script whats_left.py as shown below:
```python
λ python.exe -I whats_left.py
test_sqlite3: testing with version '2.6.0', sqlite_version '3.39.4'
Traceback (most recent call last):
  File "[REDACTED]\IdeaProjects\RustPython\whats_left.py", line 445, in <module>
    f.write(output + "\n")
  File "[REDACTED]\AppData\Local\Programs\Python\Python311\Lib\encodings\cp1252.py", line 19, in encode
    return codecs.charmap_encode(input,self.errors,encoding_table)[0]
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
UnicodeEncodeError: 'charmap' codec can't encode character '\u03c0' in position 76582: character maps to <undefined>
```

The line responsible of this behaviour is:
```python
with open(GENERATED_FILE, "w") as f:
```

Hence, we just need to add the parameter `encoding` to the value UTF-8 to resolve this error.

The second fix resides in the ssl.rs file. Indeed, there are some type mismatching that cause errors while building with whats_left.py, where are listed below:
```rust
const OP_ALL: libc::c_ulong = sys::SSL_OP_ALL & !sys::SSL_OP_DONT_INSERT_EMPTY_FRAGMENTS;
[...]
fn set_options(&self, opts: libc::c_ulong) {
            self.builder()
                .set_options(SslOptions::from_bits_truncate(opts));
}
```

closes #4255