### PR TITLE
Fix panic when parsing a format spec with multi-byte character

### DIFF
--- a/common/src/format.rs
+++ b/common/src/format.rs
@@ -869,7 +869,7 @@ impl FormatString {
         let mut left = String::new();
 
         // There may be one layer nesting brackets in spec
-        for (idx, c) in text.chars().enumerate() {
+        for (idx, c) in text.char_indices() {
             if idx == 0 {
                 if c != '{' {
                     return Err(FormatParseError::MissingStartBracket);
@@ -1074,6 +1074,11 @@ mod tests {
         });
 
         assert_eq!(FormatString::from_str("abcd{1}:{key}"), expected);
+    }
+
+    #[test]
+    fn test_format_parse_multi_byte_char() {
+        assert!(FormatString::from_str("{a:%ЫйЯЧ}").is_ok());
     }
 
     #[test]


### PR DESCRIPTION
[String::split_at](https://doc.rust-lang.org/std/string/struct.String.html#method.split_at) panics if `mid` is not on a UTF-8 code point boundary, changed to use [`String::char_indices`](https://doc.rust-lang.org/std/string/struct.String.html#method.char_indices) instead of `String::chars().enumerate()` to fix it.

See also https://github.com/charliermarsh/ruff/issues/1845