### PR TITLE
Refactor `FormatType`

### DIFF
--- a/common/src/float_ops.rs
+++ b/common/src/float_ops.rs
@@ -100,7 +100,7 @@ pub fn is_integer(v: f64) -> bool {
     (v - v.round()).abs() < f64::EPSILON
 }
 
-#[derive(Debug)]
+#[derive(Debug, PartialEq, Clone, Copy)]
 pub enum Case {
     Lower,
     Upper,


### PR DESCRIPTION
I've fxied to hold `float_ops::Case` in the following `FormatType` value.
* Hex
* Exponent
* GeneralFormat
* FixedPoint
