### PR TITLE
Handle `KeyboardInterrupt` exception in also Windows

### DIFF
--- a/examples/generator.rs
+++ b/examples/generator.rs
@@ -46,5 +46,5 @@ fn main() -> ExitCode {
         vm.add_native_modules(rustpython_stdlib::get_module_inits());
     });
     let result = py_main(&interp);
-    ExitCode::from(interp.run(|_vm| result))
+    interp.run(|_vm| result)
 }

--- a/examples/package_embed.rs
+++ b/examples/package_embed.rs
@@ -22,5 +22,5 @@ fn main() -> ExitCode {
     let result = result.map(|result| {
         println!("name: {result}");
     });
-    ExitCode::from(interp.run(|_vm| result))
+    interp.run(|_vm| result)
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -89,9 +89,8 @@ pub fn run(init: impl FnOnce(&mut VirtualMachine) + 'static) -> ExitCode {
     config = config.init_hook(Box::new(init));
 
     let interp = config.interpreter();
-    let exitcode = interp.run(move |vm| run_rustpython(vm, run_mode, quiet_var));
 
-    ExitCode::from(exitcode)
+    interp.run(move |vm| run_rustpython(vm, run_mode, quiet_var))
 }
 
 fn setup_main_module(vm: &VirtualMachine) -> PyResult<Scope> {

--- a/vm/src/vm/interpreter.rs
+++ b/vm/src/vm/interpreter.rs
@@ -3,7 +3,7 @@ use crate::{
     stdlib::{atexit, sys},
     PyResult,
 };
-use std::sync::atomic::Ordering;
+use std::{process::ExitCode, sync::atomic::Ordering};
 
 /// The general interface for the VM
 ///
@@ -59,7 +59,7 @@ impl Interpreter {
         thread::enter_vm(&self.vm, || f(&self.vm))
     }
 
-    pub fn run<F, R>(self, f: F) -> u8
+    pub fn run<F, R>(self, f: F) -> ExitCode
     where
         F: FnOnce(&VirtualMachine) -> PyResult<R>,
     {
@@ -69,7 +69,7 @@ impl Interpreter {
 
             // See if any exception leaked out:
             let exit_code = res
-                .map(|_| 0)
+                .map(|_| ExitCode::from(0))
                 .map_err(|exc| vm.handle_exit_exception(exc))
                 .unwrap_or_else(|code| code);
 

--- a/vm/src/vm/mod.rs
+++ b/vm/src/vm/mod.rs
@@ -36,12 +36,12 @@ use crate::{
     AsObject, PyObject, PyObjectRef, PyPayload, PyRef, PyResult,
 };
 use crossbeam_utils::atomic::AtomicCell;
-use std::sync::atomic::AtomicBool;
 use std::{
     borrow::Cow,
     cell::{Cell, Ref, RefCell},
     collections::{HashMap, HashSet},
 };
+use std::{process::ExitCode, sync::atomic::AtomicBool};
 
 pub use context::Context;
 pub use interpreter::Interpreter;
@@ -732,19 +732,19 @@ impl VirtualMachine {
         }
     }
 
-    pub fn handle_exit_exception(&self, exc: PyBaseExceptionRef) -> u8 {
+    pub fn handle_exit_exception(&self, exc: PyBaseExceptionRef) -> ExitCode {
         if exc.fast_isinstance(self.ctx.exceptions.system_exit) {
             let args = exc.args();
             let msg = match args.as_slice() {
-                [] => return 0,
+                [] => return ExitCode::from(0),
                 [arg] => match_class!(match arg {
                     ref i @ PyInt => {
                         use num_traits::cast::ToPrimitive;
-                        return i.as_bigint().to_u8().unwrap_or(0);
+                        return ExitCode::from(i.as_bigint().to_u8().unwrap_or(0));
                     }
                     arg => {
                         if self.is_none(arg) {
-                            return 0;
+                            return ExitCode::from(0);
                         } else {
                             arg.str(self).ok()
                         }
@@ -756,23 +756,23 @@ impl VirtualMachine {
                 let stderr = stdlib::sys::PyStderr(self);
                 writeln!(stderr, "{msg}");
             }
-            1
+            ExitCode::from(1)
         } else if exc.fast_isinstance(self.ctx.exceptions.keyboard_interrupt) {
             #[allow(clippy::if_same_then_else)]
             {
                 self.print_exception(exc);
                 #[cfg(unix)]
                 {
-                    (libc::SIGINT as u8) + 128u8
+                    ExitCode::from((libc::SIGINT as u8) + 128u8)
                 }
-                #[cfg(not(unix))]
+                #[cfg(not(any(unix, windows)))]
                 {
-                    1
+                    ExitCode::from(1)
                 }
             }
         } else {
             self.print_exception(exc);
-            1
+            ExitCode::from(1)
         }
     }
 

--- a/vm/src/vm/mod.rs
+++ b/vm/src/vm/mod.rs
@@ -36,6 +36,8 @@ use crate::{
     AsObject, PyObject, PyObjectRef, PyPayload, PyRef, PyResult,
 };
 use crossbeam_utils::atomic::AtomicCell;
+#[cfg(windows)]
+use std::os::windows::process::ExitCodeExt;
 use std::{
     borrow::Cow,
     cell::{Cell, Ref, RefCell},
@@ -764,6 +766,10 @@ impl VirtualMachine {
                 #[cfg(unix)]
                 {
                     ExitCode::from((libc::SIGINT as u8) + 128u8)
+                }
+                #[cfg(windows)]
+                {
+                    ExitCode::from_raw(winapi::um::winnt::STATUS_CONTROL_C_EXIT)
                 }
                 #[cfg(not(any(unix, windows)))]
                 {


### PR DESCRIPTION
This pull request is a follow-up of #4414 pull request.

But the `ExitCodeExt` is available only in nightly version.[^1] Maybe it is related with https://github.com/rust-lang/libs-team/issues/48. (updated: https://github.com/rust-lang/rust/issues/111688)

> This is a nightly-only experimental API. (windows_process_exit_code_from)

I will make this pull request stay on draft state but maintainers can close when cleaning up stale pull requests.

[^1]: https://doc.rust-lang.org/std/os/windows/process/trait.ExitCodeExt.html