### PR TITLE
Correct exitcode when running through `subprocess.run`

### DIFF
--- a/Lib/test/test_runpy.py
+++ b/Lib/test/test_runpy.py
@@ -790,13 +790,9 @@ class TestExit(unittest.TestCase):
         self.assertTrue(proc.stderr.endswith("\nKeyboardInterrupt\n"))
         self.assertEqual(proc.returncode, self.EXPECTED_CODE)
 
-    # TODO: RUSTPYTHON
-    @unittest.expectedFailure
     def test_pymain_run_file(self):
         self.assertSigInt([sys.executable, self.ham])
 
-    # TODO: RUSTPYTHON
-    @unittest.expectedFailure
     def test_pymain_run_file_runpy_run_module(self):
         tmp = self.ham.parent
         run_module = tmp / "run_module.py"
@@ -810,8 +806,6 @@ class TestExit(unittest.TestCase):
         )
         self.assertSigInt([sys.executable, run_module], cwd=tmp)
 
-    # TODO: RUSTPYTHON
-    @unittest.expectedFailure
     def test_pymain_run_file_runpy_run_module_as_main(self):
         tmp = self.ham.parent
         run_module_as_main = tmp / "run_module_as_main.py"
@@ -825,16 +819,12 @@ class TestExit(unittest.TestCase):
         )
         self.assertSigInt([sys.executable, run_module_as_main], cwd=tmp)
 
-    # TODO: RUSTPYTHON
-    @unittest.expectedFailure
     def test_pymain_run_command_run_module(self):
         self.assertSigInt(
             [sys.executable, "-c", "import runpy; runpy.run_module('ham')"],
             cwd=self.ham.parent,
         )
 
-    # TODO: RUSTPYTHON
-    @unittest.expectedFailure
     def test_pymain_run_command(self):
         self.assertSigInt([sys.executable, "-c", "import ham"], cwd=self.ham.parent)
 
@@ -843,11 +833,22 @@ class TestExit(unittest.TestCase):
     def test_pymain_run_stdin(self):
         self.assertSigInt([sys.executable], input="import ham", cwd=self.ham.parent)
 
-    # TODO: RUSTPYTHON
-    @unittest.expectedFailure
     def test_pymain_run_module(self):
         ham = self.ham
         self.assertSigInt([sys.executable, "-m", ham.stem], cwd=ham.parent)
+
+    # TODO: RUSTPYTHON
+    if sys.platform == "win32":
+        windows_only_failed_tests = [
+            test_pymain_run_file,
+            test_pymain_run_file_runpy_run_module,
+            test_pymain_run_file_runpy_run_module_as_main,
+            test_pymain_run_command_run_module,
+            test_pymain_run_command,
+            test_pymain_run_module
+        ]
+        for t in windows_only_failed_tests:
+            unittest.expectedFailure(t)
 
 
 if __name__ == "__main__":

--- a/Lib/test/test_signal.py
+++ b/Lib/test/test_signal.py
@@ -96,8 +96,6 @@ class PosixTests(unittest.TestCase):
         self.assertNotIn(signal.NSIG, s)
         self.assertLess(len(s), signal.NSIG)
 
-    # TODO: RUSTPYTHON
-    @unittest.expectedFailure
     @unittest.skipUnless(sys.executable, "sys.executable required.")
     def test_keyboard_interrupt_exit_code(self):
         """KeyboardInterrupt triggers exit via SIGINT."""

--- a/vm/src/vm/interpreter.rs
+++ b/vm/src/vm/interpreter.rs
@@ -84,7 +84,7 @@ impl Interpreter {
     }
 }
 
-fn flush_std(vm: &VirtualMachine) {
+pub(crate) fn flush_std(vm: &VirtualMachine) {
     if let Ok(stdout) = sys::get_stdout(vm) {
         let _ = vm.call_method(&stdout, identifier!(vm, flush).as_str(), ());
     }

--- a/vm/src/vm/mod.rs
+++ b/vm/src/vm/mod.rs
@@ -779,22 +779,7 @@ impl VirtualMachine {
                         )
                         .is_ok()
                         {
-                            // FIXME: flush sys.stdout and sys.stderr before killing process.
-                            if let Ok(stdout) = stdlib::sys::get_stdout(self) {
-                                let _ = self.call_method(
-                                    &stdout,
-                                    identifier!(self, flush).as_str(),
-                                    (),
-                                );
-                            }
-                            if let Ok(stderr) = stdlib::sys::get_stderr(self) {
-                                let _ = self.call_method(
-                                    &stderr,
-                                    identifier!(self, flush).as_str(),
-                                    (),
-                                );
-                            }
-
+                            interpreter::flush_std(self);
                             kill(getpid(), SIGINT).expect("Expect to be killed.");
                         }
                     }


### PR DESCRIPTION
This pull request fixes exitcode of `SIGINT` (i.e., `KeyboardInterrupt`) when running through `subprocess.run`.

You can run the below script.

```python
import sys, subprocess; subprocess.run([sys.executable, "-c", "raise KeyboardInterrupt"])
```

## CPython

```python
Python 3.10.9 (main, Dec 15 2022, 17:11:09) [Clang 14.0.0 (clang-1400.0.29.202)] on darwin
Type "help", "copyright", "credits" or "license" for more information.
>>> import sys, subprocess; subprocess.run([sys.executable, "-c", "raise KeyboardInterrupt"])
Traceback (most recent call last):
  File "<string>", line 1, in <module>
KeyboardInterrupt
CompletedProcess(args=['/opt/homebrew/opt/python@3.10/bin/python3.10', '-c', 'raise KeyboardInterrupt'], returncode=-2)
```

## Before (RustPython main)

```python
>>>>> import sys, subprocess; subprocess.run([sys.executable, "-c", "raise KeyboardInterrupt"])
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
KeyboardInterrupt
CompletedProcess(args=['/path/to/RustPython/RustPython/target/debug/rustpython', '-c', 'raise KeyboardInterrupt'], returncode=130)
```

## After (RustPython)

```python
Welcome to the magnificent Rust Python 0.2.0 interpreter 😱 🖖
>>>>> import sys, subprocess; subprocess.run([sys.executable, "-c", "raise KeyboardInterrupt"])
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
KeyboardInterrupt
CompletedProcess(args=['/path/to/RustPython/RustPython/target/debug/rustpython', '-c', 'raise KeyboardInterrupt'], returncode=-2)
```

## Related links

 - #4414 
 - https://github.com/python/cpython/blob/8b1f1251215651c4ef988622345c5cb134e54d69/Modules/main.c#L652-L657
