### PR TITLE
Raise TypeError when calling __new__ unsafely

### DIFF
--- a/vm/src/builtins/type.rs
+++ b/vm/src/builtins/type.rs
@@ -1120,6 +1120,24 @@ pub(crate) fn call_slot_new(
     args: FuncArgs,
     vm: &VirtualMachine,
 ) -> PyResult {
+    let mut staticbase = Some(subtype.clone());
+    while let Some(ref basetype) = staticbase {
+        if (basetype.flags() & PyTypeFlags::HEAPTYPE.bits()) != 0 {
+            staticbase = basetype.base().clone();
+        } else {
+            break;
+        }
+    }
+    if let Some(ref basetype) = staticbase {
+        if !PyType::subclasscheck(basetype.to_owned(), typ.to_owned()) {
+            return Err(vm.new_type_error(format!(
+                "{}.__new__({}) is not safe, use {}.__new__()",
+                typ.name(),
+                subtype.name(),
+                basetype.name()
+            )));
+        }
+    }
     for cls in typ.deref().iter_mro() {
         if let Some(slot_new) = cls.slots.new.load() {
             return slot_new(subtype, args, vm);


### PR DESCRIPTION
Related to #3692
This implementation is based on the following code from CPython.
https://github.com/python/cpython/blob/206f05a46b426eb374f724f8e7cd42f2f9643bb8/Objects/typeobject.c#L7685-L7700
![image](https://user-images.githubusercontent.com/88014292/212551057-cd5bcdfd-28c9-4a62-8faa-7997e36b8e2d.png)
