### PR TITLE
Remove useless `String::from` in tests

### DIFF
--- a/compiler/parser/src/context.rs
+++ b/compiler/parser/src/context.rs
@@ -51,127 +51,127 @@ mod tests {
 
     #[test]
     fn test_assign_name() {
-        let source = String::from("x = (1, 2, 3)");
-        let parse_ast = parse_program(&source, "<test>").unwrap();
+        let source = "x = (1, 2, 3)";
+        let parse_ast = parse_program(source, "<test>").unwrap();
         insta::assert_debug_snapshot!(parse_ast);
     }
 
     #[test]
     fn test_assign_tuple() {
-        let source = String::from("(x, y) = (1, 2, 3)");
-        let parse_ast = parse_program(&source, "<test>").unwrap();
+        let source = "(x, y) = (1, 2, 3)";
+        let parse_ast = parse_program(source, "<test>").unwrap();
         insta::assert_debug_snapshot!(parse_ast);
     }
 
     #[test]
     fn test_assign_list() {
-        let source = String::from("[x, y] = (1, 2, 3)");
-        let parse_ast = parse_program(&source, "<test>").unwrap();
+        let source = "[x, y] = (1, 2, 3)";
+        let parse_ast = parse_program(source, "<test>").unwrap();
         insta::assert_debug_snapshot!(parse_ast);
     }
 
     #[test]
     fn test_assign_attribute() {
-        let source = String::from("x.y = (1, 2, 3)");
-        let parse_ast = parse_program(&source, "<test>").unwrap();
+        let source = "x.y = (1, 2, 3)";
+        let parse_ast = parse_program(source, "<test>").unwrap();
         insta::assert_debug_snapshot!(parse_ast);
     }
 
     #[test]
     fn test_assign_subscript() {
-        let source = String::from("x[y] = (1, 2, 3)");
-        let parse_ast = parse_program(&source, "<test>").unwrap();
+        let source = "x[y] = (1, 2, 3)";
+        let parse_ast = parse_program(source, "<test>").unwrap();
         insta::assert_debug_snapshot!(parse_ast);
     }
 
     #[test]
     fn test_assign_starred() {
-        let source = String::from("(x, *y) = (1, 2, 3)");
-        let parse_ast = parse_program(&source, "<test>").unwrap();
+        let source = "(x, *y) = (1, 2, 3)";
+        let parse_ast = parse_program(source, "<test>").unwrap();
         insta::assert_debug_snapshot!(parse_ast);
     }
 
     #[test]
     fn test_assign_for() {
-        let source = String::from("for x in (1, 2, 3): pass");
-        let parse_ast = parse_program(&source, "<test>").unwrap();
+        let source = "for x in (1, 2, 3): pass";
+        let parse_ast = parse_program(source, "<test>").unwrap();
         insta::assert_debug_snapshot!(parse_ast);
     }
 
     #[test]
     fn test_assign_list_comp() {
-        let source = String::from("x = [y for y in (1, 2, 3)]");
-        let parse_ast = parse_program(&source, "<test>").unwrap();
+        let source = "x = [y for y in (1, 2, 3)]";
+        let parse_ast = parse_program(source, "<test>").unwrap();
         insta::assert_debug_snapshot!(parse_ast);
     }
 
     #[test]
     fn test_assign_set_comp() {
-        let source = String::from("x = {y for y in (1, 2, 3)}");
-        let parse_ast = parse_program(&source, "<test>").unwrap();
+        let source = "x = {y for y in (1, 2, 3)}";
+        let parse_ast = parse_program(source, "<test>").unwrap();
         insta::assert_debug_snapshot!(parse_ast);
     }
 
     #[test]
     fn test_assign_with() {
-        let source = String::from("with 1 as x: pass");
-        let parse_ast = parse_program(&source, "<test>").unwrap();
+        let source = "with 1 as x: pass";
+        let parse_ast = parse_program(source, "<test>").unwrap();
         insta::assert_debug_snapshot!(parse_ast);
     }
 
     #[test]
     fn test_assign_named_expr() {
-        let source = String::from("if x:= 1: pass");
-        let parse_ast = parse_program(&source, "<test>").unwrap();
+        let source = "if x:= 1: pass";
+        let parse_ast = parse_program(source, "<test>").unwrap();
         insta::assert_debug_snapshot!(parse_ast);
     }
 
     #[test]
     fn test_ann_assign_name() {
-        let source = String::from("x: int = 1");
-        let parse_ast = parse_program(&source, "<test>").unwrap();
+        let source = "x: int = 1";
+        let parse_ast = parse_program(source, "<test>").unwrap();
         insta::assert_debug_snapshot!(parse_ast);
     }
 
     #[test]
     fn test_aug_assign_name() {
-        let source = String::from("x += 1");
-        let parse_ast = parse_program(&source, "<test>").unwrap();
+        let source = "x += 1";
+        let parse_ast = parse_program(source, "<test>").unwrap();
         insta::assert_debug_snapshot!(parse_ast);
     }
 
     #[test]
     fn test_aug_assign_attribute() {
-        let source = String::from("x.y += (1, 2, 3)");
-        let parse_ast = parse_program(&source, "<test>").unwrap();
+        let source = "x.y += (1, 2, 3)";
+        let parse_ast = parse_program(source, "<test>").unwrap();
         insta::assert_debug_snapshot!(parse_ast);
     }
 
     #[test]
     fn test_aug_assign_subscript() {
-        let source = String::from("x[y] += (1, 2, 3)");
-        let parse_ast = parse_program(&source, "<test>").unwrap();
+        let source = "x[y] += (1, 2, 3)";
+        let parse_ast = parse_program(source, "<test>").unwrap();
         insta::assert_debug_snapshot!(parse_ast);
     }
 
     #[test]
     fn test_del_name() {
-        let source = String::from("del x");
-        let parse_ast = parse_program(&source, "<test>").unwrap();
+        let source = "del x";
+        let parse_ast = parse_program(source, "<test>").unwrap();
         insta::assert_debug_snapshot!(parse_ast);
     }
 
     #[test]
     fn test_del_attribute() {
-        let source = String::from("del x.y");
-        let parse_ast = parse_program(&source, "<test>").unwrap();
+        let source = "del x.y";
+        let parse_ast = parse_program(source, "<test>").unwrap();
         insta::assert_debug_snapshot!(parse_ast);
     }
 
     #[test]
     fn test_del_subscript() {
-        let source = String::from("del x[y]");
-        let parse_ast = parse_program(&source, "<test>").unwrap();
+        let source = "del x[y]";
+        let parse_ast = parse_program(source, "<test>").unwrap();
         insta::assert_debug_snapshot!(parse_ast);
     }
 }

--- a/compiler/parser/src/parser.rs
+++ b/compiler/parser/src/parser.rs
@@ -124,43 +124,43 @@ mod tests {
 
     #[test]
     fn test_parse_string() {
-        let source = String::from("'Hello world'");
-        let parse_ast = parse_program(&source, "<test>").unwrap();
+        let source = "'Hello world'";
+        let parse_ast = parse_program(source, "<test>").unwrap();
         insta::assert_debug_snapshot!(parse_ast);
     }
 
     #[test]
     fn test_parse_f_string() {
-        let source = String::from("f'Hello world'");
-        let parse_ast = parse_program(&source, "<test>").unwrap();
+        let source = "f'Hello world'";
+        let parse_ast = parse_program(source, "<test>").unwrap();
         insta::assert_debug_snapshot!(parse_ast);
     }
 
     #[test]
     fn test_parse_print_hello() {
-        let source = String::from("print('Hello world')");
-        let parse_ast = parse_program(&source, "<test>").unwrap();
+        let source = "print('Hello world')";
+        let parse_ast = parse_program(source, "<test>").unwrap();
         insta::assert_debug_snapshot!(parse_ast);
     }
 
     #[test]
     fn test_parse_print_2() {
-        let source = String::from("print('Hello world', 2)");
-        let parse_ast = parse_program(&source, "<test>").unwrap();
+        let source = "print('Hello world', 2)";
+        let parse_ast = parse_program(source, "<test>").unwrap();
         insta::assert_debug_snapshot!(parse_ast);
     }
 
     #[test]
     fn test_parse_kwargs() {
-        let source = String::from("my_func('positional', keyword=2)");
-        let parse_ast = parse_program(&source, "<test>").unwrap();
+        let source = "my_func('positional', keyword=2)";
+        let parse_ast = parse_program(source, "<test>").unwrap();
         insta::assert_debug_snapshot!(parse_ast);
     }
 
     #[test]
     fn test_parse_if_elif_else() {
-        let source = String::from("if 1: 10\nelif 2: 20\nelse: 30");
-        let parse_ast = parse_program(&source, "<test>").unwrap();
+        let source = "if 1: 10\nelif 2: 20\nelse: 30";
+        let parse_ast = parse_program(source, "<test>").unwrap();
         insta::assert_debug_snapshot!(parse_ast);
     }
 
@@ -192,64 +192,64 @@ class Foo(A, B):
 
     #[test]
     fn test_parse_dict_comprehension() {
-        let source = String::from("{x1: x2 for y in z}");
-        let parse_ast = parse_expression(&source, "<test>").unwrap();
+        let source = "{x1: x2 for y in z}";
+        let parse_ast = parse_expression(source, "<test>").unwrap();
         insta::assert_debug_snapshot!(parse_ast);
     }
 
     #[test]
     fn test_parse_list_comprehension() {
-        let source = String::from("[x for y in z]");
-        let parse_ast = parse_expression(&source, "<test>").unwrap();
+        let source = "[x for y in z]";
+        let parse_ast = parse_expression(source, "<test>").unwrap();
         insta::assert_debug_snapshot!(parse_ast);
     }
 
     #[test]
     fn test_parse_double_list_comprehension() {
-        let source = String::from("[x for y, y2 in z for a in b if a < 5 if a > 10]");
-        let parse_ast = parse_expression(&source, "<test>").unwrap();
+        let source = "[x for y, y2 in z for a in b if a < 5 if a > 10]";
+        let parse_ast = parse_expression(source, "<test>").unwrap();
         insta::assert_debug_snapshot!(parse_ast);
     }
 
     #[test]
     fn test_parse_generator_comprehension() {
-        let source = String::from("(x for y in z)");
-        let parse_ast = parse_expression(&source, "<test>").unwrap();
+        let source = "(x for y in z)";
+        let parse_ast = parse_expression(source, "<test>").unwrap();
         insta::assert_debug_snapshot!(parse_ast);
     }
 
     #[test]
     fn test_parse_named_expression_generator_comprehension() {
-        let source = String::from("(x := y + 1 for y in z)");
-        let parse_ast = parse_expression(&source, "<test>").unwrap();
+        let source = "(x := y + 1 for y in z)";
+        let parse_ast = parse_expression(source, "<test>").unwrap();
         insta::assert_debug_snapshot!(parse_ast);
     }
 
     #[test]
     fn test_parse_if_else_generator_comprehension() {
-        let source = String::from("(x if y else y for y in z)");
-        let parse_ast = parse_expression(&source, "<test>").unwrap();
+        let source = "(x if y else y for y in z)";
+        let parse_ast = parse_expression(source, "<test>").unwrap();
         insta::assert_debug_snapshot!(parse_ast);
     }
 
     #[test]
     fn test_parse_boolop_or() {
-        let source = String::from("x or y");
-        let parse_ast = parse_expression(&source, "<test>").unwrap();
+        let source = "x or y";
+        let parse_ast = parse_expression(source, "<test>").unwrap();
         insta::assert_debug_snapshot!(parse_ast);
     }
 
     #[test]
     fn test_parse_boolop_and() {
-        let source = String::from("x and y");
-        let parse_ast = parse_expression(&source, "<test>").unwrap();
+        let source = "x and y";
+        let parse_ast = parse_expression(source, "<test>").unwrap();
         insta::assert_debug_snapshot!(parse_ast);
     }
 
     #[test]
     fn test_slice() {
-        let source = String::from("x[1:2:3]");
-        let parse_ast = parse_expression(&source, "<test>").unwrap();
+        let source = "x[1:2:3]";
+        let parse_ast = parse_expression(source, "<test>").unwrap();
         insta::assert_debug_snapshot!(parse_ast);
     }
 


### PR DESCRIPTION
This PR removes useless `String::from` in tests