### PR TITLE
Fix end location for elif blocks

### DIFF
--- a/compiler/parser/python.lalrpop
+++ b/compiler/parser/python.lalrpop
@@ -372,7 +372,7 @@ IfStatement: ast::Stmt = {
             let x = ast::Stmt {
                 custom: (),
                 location: i.0,
-                end_location: i.4.last().unwrap().end_location,
+                end_location,
                 node: ast::StmtKind::If { test: Box::new(i.2), body: i.4, orelse: last },
             };
             last = vec![x];

--- a/compiler/parser/src/snapshots/rustpython_parser__parser__tests__parse_if_elif_else.snap
+++ b/compiler/parser/src/snapshots/rustpython_parser__parser__tests__parse_if_elif_else.snap
@@ -79,8 +79,8 @@ expression: parse_ast
                     },
                     end_location: Some(
                         Location {
-                            row: 2,
-                            column: 10,
+                            row: 3,
+                            column: 8,
                         },
                     ),
                     custom: (),


### PR DESCRIPTION
Since we parse an `elif:` block as an `If` node, its location should include its `orelse` node like it would for an `if:` block.