### PR TITLE
Add basic number formatting

### DIFF
--- a/Lib/test/test_format.py
+++ b/Lib/test/test_format.py
@@ -396,8 +396,6 @@ class FormatTest(unittest.TestCase):
         testformat("a%sb", ('c\0d',), 'ac\0db')
         testcommon(b"a%sb", (b'c\0d',), b'ac\0db')
 
-    # TODO: RUSTPYTHON
-    @unittest.expectedFailure
     def test_non_ascii(self):
         testformat("\u20ac=%f", (1.0,), "\u20ac=1.000000")
 
@@ -419,8 +417,6 @@ class FormatTest(unittest.TestCase):
         self.assertEqual(format(1+2j, "\u2007^8"), "\u2007(1+2j)\u2007")
         self.assertEqual(format(0j, "\u2007^4"), "\u20070j\u2007")
 
-    # TODO: RUSTPYTHON
-    @unittest.expectedFailure
     def test_locale(self):
         try:
             oldloc = locale.setlocale(locale.LC_ALL)
@@ -466,8 +462,6 @@ class FormatTest(unittest.TestCase):
         self.assertIs(text % (), text)
         self.assertIs(text.format(), text)
 
-    # TODO: RUSTPYTHON
-    @unittest.expectedFailure
     def test_precision(self):
         f = 1.2
         self.assertEqual(format(f, ".0f"), "1")

--- a/Lib/test/test_format.py
+++ b/Lib/test/test_format.py
@@ -466,7 +466,7 @@ class FormatTest(unittest.TestCase):
         self.assertIs(text % (), text)
         self.assertIs(text.format(), text)
 
-    # TODO: RustPython missing complex.__format__ implementation
+    # TODO: RUSTPYTHON
     @unittest.expectedFailure
     def test_precision(self):
         f = 1.2

--- a/common/src/format.rs
+++ b/common/src/format.rs
@@ -3,10 +3,7 @@ use float_ops::Case;
 use itertools::{Itertools, PeekingNext};
 use num_bigint::{BigInt, Sign};
 use num_traits::{cast::ToPrimitive, Signed};
-use std::{
-    cmp::{self, Ordering},
-    str::FromStr,
-};
+use std::{cmp::Ordering, str::FromStr};
 
 trait FormatParse {
     fn parse(text: &str) -> (Option<Self>, &str)
@@ -109,6 +106,15 @@ impl FormatParse for FormatSign {
 pub enum FormatGrouping {
     Comma,
     Underscore,
+}
+
+impl FormatGrouping {
+    fn to_char(&self) -> char {
+        match self {
+            Self::Comma => ',',
+            Self::Underscore => '_',
+        }
+    }
 }
 
 impl FormatParse for FormatGrouping {
@@ -419,15 +425,12 @@ impl FormatSpec {
         padding: PaddingStyle,
     ) -> String {
         match &self.grouping_option {
-            Some(fg) => {
-                let sep = match fg {
-                    FormatGrouping::Comma => ',',
-                    FormatGrouping::Underscore => '_',
-                };
+            Some(grouping) => {
+                let sep = grouping.to_char();
                 let inter = self.get_separator_interval().try_into().unwrap();
                 let magnitude_len = magnitude_str.len();
                 let width = self.width.unwrap_or(magnitude_len) as i32 - prefix.len() as i32;
-                let disp_digit_cnt = cmp::max(width, magnitude_len as i32);
+                let disp_digit_cnt = std::cmp::max(width, magnitude_len as i32);
                 FormatSpec::add_magnitude_separators_for_char(
                     magnitude_str,
                     inter,
@@ -694,7 +697,7 @@ impl FormatSpec {
         let num_chars = magnitude_str.char_len();
         let fill_char = self.fill.unwrap_or(' ');
         let fill_chars_needed: i32 = self.width.map_or(0, |w| {
-            cmp::max(0, (w as i32) - (num_chars as i32) - (sign_str.len() as i32))
+            std::cmp::max(0, (w as i32) - (num_chars as i32) - (sign_str.len() as i32))
         });
         Ok(match align {
             FormatAlign::Left => format!(

--- a/extra_tests/snippets/builtin_str.py
+++ b/extra_tests/snippets/builtin_str.py
@@ -609,6 +609,39 @@ assert '{:.7g}'.format(1.020e-13) == '1.02e-13'
 assert '{:g}'.format(1.020e-13) == '1.02e-13'
 assert "{:g}".format(1.020e-4) == '0.000102'
 
+def test_number_formatting():
+    assert '{:n}'.format(0) == '0'
+    assert '{:2n}'.format(1) == ' 1'
+    assert '{:5n}'.format(10) == '   10'
+    assert '{:5n}'.format(100) == '  100'
+    assert '{:5n}'.format(1000) == ' 1000'
+    assert '{:5n}'.format(10000) == '10000'
+    #TODO: should remove trailing zero if the `magnitude` is given by exponential style
+    assert '{:n}'.format(123.123) == '123.123'
+    assert '{:2n}'.format(123.123) == '123.123'
+    assert '{:5n}'.format(123.123) == '123.123'
+    assert '{:.1n}'.format(1.12345) == '1'
+    assert '{:.2n}'.format(1.12345) == '1.1'
+    assert '{:.3n}'.format(1.12345) == '1.12'
+    assert '{:.4n}'.format(1.12345) == '1.123'
+    assert '{:.6n}'.format(1.12345) == '1.12345'
+    assert '{:.1n}'.format(12345.12345) == '1e+04'
+    assert '{:.2n}'.format(12345.12345) == '1.2e+04'
+    assert '{:.3n}'.format(12345.12345) == '1.23e+04'
+    assert '{:.4n}'.format(12345.12345) == '1.235e+04'
+    assert '{:5n}'.format(1234567.0) == '1.23457e+06'
+    assert '{:5n}'.format(1234567.1) == '1.23457e+06'
+    assert '{:.6n}'.format(12345.12345) == '12345.1'
+    assert '{:.7n}'.format(12345.12345) == '12345.12'
+    assert '{:.8n}'.format(12345.12345) == '12345.123'
+    assert '{:.9n}'.format(12345.12345) == '12345.1234'
+    assert '{:.10n}'.format(12345.12345) == '12345.12345'
+    assert '{:.11n}'.format(12345.12345) == '12345.12345'
+
+    ##TODO `nan` and `inf` are not fully supported yet
+    assert '{:n}'.format(float('nan')) == 'nan'
+    assert '{:n}'.format(float('-nan')) == 'nan'
+
 # remove*fix test
 def test_removeprefix():
     s = 'foobarfoo'


### PR DESCRIPTION
## Description
Only basic functionalities have been implemented so that formatting can be applied and output even when a 'float' type number comes in.

However, not all functions are fully functional(i.e, decimal rounding or `inf` value handling.), so it seems that additional functions will need to be supplemented in the future.

## Example
```python
## before
print('{:5n}'.format(1234567.1))
>>> Traceback (most recent call last):
    File "<wasm>", line 1, in <module>
    ValueError: Format code 'n' for object of type 'float' not implemented yet

## after
>>> 1.23457e+06
```
```python
a = '{:.8n}'.format(12345.12345)

type(a)
>>> <class 'str'>

print(a)
>>> 12345.123
```

## Related Issue
#1656
