### PR TITLE
Initialize ast when calling compile function

### DIFF
--- a/vm/src/stdlib/builtins.rs
+++ b/vm/src/stdlib/builtins.rs
@@ -117,6 +117,8 @@ mod builtins {
         {
             use crate::{class::PyClassImpl, stdlib::ast};
 
+            ast::make_module(vm);
+
             if args._feature_version.is_present() {
                 eprintln!("TODO: compile() got `_feature_version` but ignored");
             }

--- a/vm/src/stdlib/builtins.rs
+++ b/vm/src/stdlib/builtins.rs
@@ -117,8 +117,6 @@ mod builtins {
         {
             use crate::{class::PyClassImpl, stdlib::ast};
 
-            ast::make_module(vm);
-
             if args._feature_version.is_present() {
                 eprintln!("TODO: compile() got `_feature_version` but ignored");
             }

--- a/vm/src/vm/mod.rs
+++ b/vm/src/vm/mod.rs
@@ -242,6 +242,7 @@ impl VirtualMachine {
         let mut essential_init = || -> PyResult {
             #[cfg(not(target_arch = "wasm32"))]
             import::import_builtin(self, "_signal")?;
+            import::import_builtin(self, "_ast")?;
             #[cfg(not(feature = "threading"))]
             import::import_frozen(self, "_thread")?;
             let importlib = import::init_importlib_base(self)?;

--- a/vm/src/vm/mod.rs
+++ b/vm/src/vm/mod.rs
@@ -242,6 +242,7 @@ impl VirtualMachine {
         let mut essential_init = || -> PyResult {
             #[cfg(not(target_arch = "wasm32"))]
             import::import_builtin(self, "_signal")?;
+            #[cfg(any(feature = "parser", feature = "compiler"))]
             import::import_builtin(self, "_ast")?;
             #[cfg(not(feature = "threading"))]
             import::import_frozen(self, "_thread")?;


### PR DESCRIPTION
Related to #4316
This pull request allows the `compile` function to initialize the `ast` module before the compilation.
I am not sure if this is the correct way to initialize the module. But it seems to solve the problem.
