### PR TITLE
Implement lone-dot semantics for %-style format strings

### DIFF
--- a/Lib/test/test_locale.py
+++ b/Lib/test/test_locale.py
@@ -170,8 +170,6 @@ class EnUSNumberFormatting(BaseFormattingTest):
         self._test_format("%f", -42, grouping=1, out='-42.000000')
         self._test_format("%+f", -42, grouping=1, out='-42.000000')
 
-    # TODO: RUSTPYTHON
-    @unittest.expectedFailure
     def test_grouping_and_padding(self):
         self._test_format("%20.f", -42, grouping=1, out='-42'.rjust(20))
         if self.sep:
@@ -197,8 +195,6 @@ class EnUSNumberFormatting(BaseFormattingTest):
         self._test_format("%f", -42, grouping=0, out='-42.000000')
         self._test_format("%+f", -42, grouping=0, out='-42.000000')
 
-    # TODO: RUSTPYTHON
-    @unittest.expectedFailure
     def test_padding(self):
         self._test_format("%20.f", -42, grouping=0, out='-42'.rjust(20))
         self._test_format("%+10.f", -4200, grouping=0, out='-4200'.rjust(10))

--- a/common/src/cformat.rs
+++ b/common/src/cformat.rs
@@ -551,11 +551,9 @@ where
     if let Some(&(_, c)) = iter.peek() {
         if c.into() == '.' {
             iter.next().unwrap();
-            return Ok(Some(
-                parse_quantity(iter)?
-                    .map(CFormatPrecision::Quantity)
-                    .unwrap_or(CFormatPrecision::Dot),
-            ));
+            let quantity = parse_quantity(iter)?;
+            let precision = quantity.map_or(CFormatPrecision::Dot, CFormatPrecision::Quantity);
+            return Ok(Some(precision));
         }
     }
     Ok(None)


### PR DESCRIPTION
This PR extends `cformat.rs` to handle lone-dot cases, like `"%.f" % 123.456`. Previously, RustPython used six decimal places for this case, treating it equivalently to `"%f" % 123.456`. This differs from CPython, which treats `"%.f"` as "remove the decimal point". Similarly, CPython treats `"%.s"` as a full string truncation.