### PR TITLE
Implement `array.array.__contains__`

### DIFF
--- a/extra_tests/snippets/stdlib_array.py
+++ b/extra_tests/snippets/stdlib_array.py
@@ -112,3 +112,8 @@ assert str(a.__class__.__name__) == "array"
 # test arrayiterator name
 i = iter(a)
 assert str(i.__class__.__name__) == "arrayiterator"
+
+# teset array.__contains__
+a = array('B', [0])
+assert a.__contains__(0)
+assert not a.__contains__(1)

--- a/stdlib/src/array.rs
+++ b/stdlib/src/array.rs
@@ -1160,6 +1160,23 @@ mod array {
                 zelf.as_object().dict(),
             ))
         }
+
+        #[pymethod(magic)]
+        fn contains(&self, value: PyObjectRef, vm: &VirtualMachine) -> bool {
+            let array = self.array.read();
+            for element in array
+                .iter(vm)
+                .map(|x| x.expect("Expected to be checked by array.len() and read lock."))
+            {
+                if let Ok(true) =
+                    element.rich_compare_bool(value.as_object(), PyComparisonOp::Eq, vm)
+                {
+                    return true;
+                }
+            }
+
+            false
+        }
     }
 
     impl Comparable for PyArray {


### PR DESCRIPTION


CPython implements `array.__contains__` but RustPython doesn't implement it yet. This pull request implements it.

## CPython

```python
Python 3.10.9 (main, Dec 15 2022, 17:11:09) [Clang 14.0.0 (clang-1400.0.29.202)] on darwin
Type "help", "copyright", "credits" or "license" for more information.
>>> import array
>>> array.array('B').__contains__
<method-wrapper '__contains__' of array.array object at 0x1051ce700>
```

## RustPython (before)

```python
Welcome to the magnificent Rust Python 0.2.0 interpreter 😱 🖖
>>>>> import array
>>>>> array.array('B').__contains__
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
AttributeError: 'array' object has no attribute '__contains__'
```

## RustPython (after)

```python
Welcome to the magnificent Rust Python 0.2.0 interpreter 😱 🖖
>>>>> import array
>>>>> array.array('B').__contains__
<bound method array.__contains__ of array('B')>
```

### Related links

 - https://github.com/python/cpython/blob/5f08fe4a2c055880c23c6f9b57ff03005d193bfc/Modules/arraymodule.c#L1176-L1190