### PR TITLE
Register `array.array` to `collections.abc.MutableSequence`

### DIFF
--- a/Lib/test/test_array.py
+++ b/Lib/test/test_array.py
@@ -30,8 +30,6 @@ typecodes = 'ubBhHiIlLfdqQ'
 
 class MiscTest(unittest.TestCase):
 
-    # TODO: RUSTPYTHON
-    @unittest.expectedFailure
     def test_array_is_sequence(self):
         self.assertIsInstance(array.array("B"), collections.abc.MutableSequence)
         self.assertIsInstance(array.array("B"), collections.abc.Reversible)

--- a/stdlib/src/array.rs
+++ b/stdlib/src/array.rs
@@ -1,4 +1,31 @@
-pub(crate) use array::make_module;
+use rustpython_vm::{PyObjectRef, VirtualMachine};
+
+pub(crate) fn make_module(vm: &VirtualMachine) -> PyObjectRef {
+    let module = array::make_module(vm);
+
+    let array = module
+        .get_attr("array", vm)
+        .expect("Expect array has arrat type.");
+
+    // TODO: RUSTPYTHON
+    // FIXME: it should import 'collections.abc' instead of '_collection_abc'
+    let collections_abc = vm
+        .import("_collections_abc", None, 0)
+        .expect("Expect collections.abc exist.");
+    let mutable_sequence = collections_abc
+        .get_attr("MutableSequence", vm)
+        .expect("Expect collections.abc has MutableSequence type.");
+
+    vm.invoke(
+        &mutable_sequence
+            .get_attr("register", vm)
+            .expect("Expect collections.abc.MutableSequence has register method."),
+        (array,),
+    )
+    .expect("Expect collections.abc.MutableSequence.register(array.array) not fail.");
+
+    module
+}
 
 #[pymodule(name = "array")]
 mod array {

--- a/stdlib/src/array.rs
+++ b/stdlib/src/array.rs
@@ -5,7 +5,7 @@ pub(crate) fn make_module(vm: &VirtualMachine) -> PyObjectRef {
 
     let array = module
         .get_attr("array", vm)
-        .expect("Expect array has arrat type.");
+        .expect("Expect array has array type.");
 
     // TODO: RUSTPYTHON
     // FIXME: it should import 'collections.abc' instead of '_collection_abc'

--- a/stdlib/src/array.rs
+++ b/stdlib/src/array.rs
@@ -7,12 +7,13 @@ pub(crate) fn make_module(vm: &VirtualMachine) -> PyObjectRef {
         .get_attr("array", vm)
         .expect("Expect array has array type.");
 
-    // TODO: RUSTPYTHON
-    // FIXME: it should import 'collections.abc' instead of '_collection_abc'
     let collections_abc = vm
-        .import("_collections_abc", None, 0)
-        .expect("Expect collections.abc exist.");
-    let mutable_sequence = collections_abc
+        .import("collections.abc", None, 0)
+        .expect("Expect collections exist.");
+    let abc = collections_abc
+        .get_attr("abc", vm)
+        .expect("Expect collections has abc submodule.");
+    let mutable_sequence = abc
         .get_attr("MutableSequence", vm)
         .expect("Expect collections.abc has MutableSequence type.");
 


### PR DESCRIPTION
This pull request registers `array.array` to `collections.abc.MutableSequence._abc_registry` and it makes `isinstance(array.array("<type>"), collections.abc.MutableSequence)` as `true`.

There is an issue that it cannot load `MutableSequence` from `collections.abc`, so I bypassed it by loading `MutableSequence` from `_collections_abc` directly. But it should be fixed or note comments about specific reason.

You can run the below code to test these changes:

```python
import array, collections.abc; print(isinstance(array.array('B'), collections.abc.MutableSequence))
```

### Related links

 - https://github.com/python/cpython/blob/bd7903967cd2a19ebc842dd1cce75f60a18aef02/Modules/arraymodule.c#L3075-L3088