### PR TITLE
feat: allow not to set SIGINT handler

### DIFF
--- a/src/settings.rs
+++ b/src/settings.rs
@@ -245,6 +245,9 @@ fn settings_from(matches: &ArgMatches) -> (Settings, RunMode) {
             if name == "warn_default_encoding" {
                 warn_default_encoding = true
             }
+            if name == "no_sig_int" {
+                settings.no_sig_int = true;
+            }
             let value = parts.next().map(ToOwned::to_owned);
             (name, value)
         }));

--- a/vm/src/stdlib/signal.rs
+++ b/vm/src/stdlib/signal.rs
@@ -103,7 +103,9 @@ pub(crate) mod _signal {
             .clone()
             .get_attr("default_int_handler", vm)
             .expect("_signal does not have this attr?");
-        signal(libc::SIGINT, int_handler, vm).expect("Failed to set sigint handler");
+        if !vm.state.settings.no_sig_int {
+            signal(libc::SIGINT, int_handler, vm).expect("Failed to set sigint handler");
+        }
     }
 
     #[pyfunction]

--- a/vm/src/vm/setting.rs
+++ b/vm/src/vm/setting.rs
@@ -16,6 +16,9 @@ pub struct Settings {
     /// -O optimization switch counter
     pub optimize: u8,
 
+    /// Not set SIGINT handler(i.e. for embedded mode)
+    pub no_sig_int: bool,
+
     /// -s
     pub no_user_site: bool,
 
@@ -85,6 +88,7 @@ impl Default for Settings {
             inspect: false,
             interactive: false,
             optimize: 0,
+            no_sig_int: false,
             no_user_site: false,
             no_site: false,
             ignore_environment: false,


### PR DESCRIPTION
# Allow not to set SIGINT handler
which is similiar to pyo3's `prepare_freethreaded_python()`, will not raise the `KeyboardInterrupt` exception, this will be benefit when embedding RustPython in other application(Which might want to set their own Interrupt)