### PR TITLE
Minor lexer optimizations

### DIFF
--- a/compiler/parser/src/lexer.rs
+++ b/compiler/parser/src/lexer.rs
@@ -534,12 +534,15 @@ where
     }
 
     fn is_identifier_start(&self, c: char) -> bool {
-        c == '_' || is_xid_start(c)
+        match c {
+            'a'..='z' | 'A'..='Z' | '_' => true,
+            _ => is_xid_start(c),
+        }
     }
 
     fn is_identifier_continuation(&self) -> bool {
         match self.window[0] {
-            Some('_' | '0'..='9') => true,
+            Some('a'..='z' | 'A'..='Z' | '_' | '0'..='9') => true,
             Some(c) => is_xid_continue(c),
             _ => false,
         }

--- a/compiler/parser/src/lexer.rs
+++ b/compiler/parser/src/lexer.rs
@@ -690,12 +690,12 @@ where
     fn consume_normal(&mut self) -> Result<(), LexicalError> {
         // Check if we have some character:
         if let Some(c) = self.window[0] {
-               if self.is_identifier_start(c) {
-                    let identifier = self.lex_identifier()?;
-                    self.emit(identifier);
-               } else {
-                    self.consume_character(c)?;
-               }
+            if self.is_identifier_start(c) {
+                let identifier = self.lex_identifier()?;
+                self.emit(identifier);
+            } else {
+                self.consume_character(c)?;
+            }
         } else {
             // We reached end of file.
             let tok_pos = self.get_pos();
@@ -1039,10 +1039,7 @@ where
                 }
             }
             ',' => {
-                let tok_start = self.get_pos();
-                self.next_char();
-                let tok_end = self.get_pos();
-                self.emit((tok_start, Tok::Comma, tok_end));
+                self.eat_single_char(Tok::Comma);
             }
             '.' => {
                 if let Some('0'..='9') = self.window[1] {
@@ -1102,7 +1099,7 @@ where
                 }
             }
             _ => {
-                 if is_emoji_presentation(c) {
+                if is_emoji_presentation(c) {
                     let tok_start = self.get_pos();
                     self.next_char();
                     let tok_end = self.get_pos();

--- a/compiler/parser/src/lexer.rs
+++ b/compiler/parser/src/lexer.rs
@@ -1125,7 +1125,11 @@ where
 
     fn eat_single_char(&mut self, ty: Tok) {
         let tok_start = self.get_pos();
-        self.next_char();
+        self.next_char().unwrap_or_else(|| unsafe {
+            // SAFETY: eat_single_char has been called only after a character has been read
+            // from the window, so the window is guaranteed to be non-empty.
+            std::hint::unreachable_unchecked()
+        });
         let tok_end = self.get_pos();
         self.emit((tok_start, ty, tok_end));
     }


### PR DESCRIPTION
Mainly by matching on `'a'..='z'` and `'A'..='Z'` which are the most common identifier characters (avoiding the calls to `is_xid_start` and `is_xid_continue`). Apart from that makes `IndentationLevel` slightly smaller and adds some sensible capacities.

Testing locally, this results in tokenizing the stdlib around ~20% faster (mainly, the `match` change yields that), I'll probably add that benchmark and one for the parser since its nice to have lying around).