### PR TITLE
Optimize bytes-like (l|r)strip

### DIFF
--- a/vm/src/builtins/bytearray.rs
+++ b/vm/src/builtins/bytearray.rs
@@ -507,13 +507,37 @@ impl PyByteArray {
     }
 
     #[pymethod]
-    fn lstrip(&self, chars: OptionalOption<PyBytesInner>) -> Self {
-        self.inner().lstrip(chars).into()
+    fn lstrip(
+        zelf: PyRef<Self>,
+        chars: OptionalOption<PyBytesInner>,
+        vm: &VirtualMachine,
+    ) -> PyRef<Self> {
+        let inner = zelf.inner();
+        let stripped = inner.lstrip(chars);
+        let elements = &inner.elements;
+        if stripped == elements {
+            drop(inner);
+            zelf
+        } else {
+            vm.new_pyref(PyByteArray::from(stripped.to_vec()))
+        }
     }
 
     #[pymethod]
-    fn rstrip(&self, chars: OptionalOption<PyBytesInner>) -> Self {
-        self.inner().rstrip(chars).into()
+    fn rstrip(
+        zelf: PyRef<Self>,
+        chars: OptionalOption<PyBytesInner>,
+        vm: &VirtualMachine,
+    ) -> PyRef<Self> {
+        let inner = zelf.inner();
+        let stripped = inner.rstrip(chars);
+        let elements = &inner.elements;
+        if stripped == elements {
+            drop(inner);
+            zelf
+        } else {
+            vm.new_pyref(PyByteArray::from(stripped.to_vec()))
+        }
     }
 
     /// removeprefix($self, prefix, /)

--- a/vm/src/builtins/bytes.rs
+++ b/vm/src/builtins/bytes.rs
@@ -372,10 +372,10 @@ impl PyBytes {
         vm: &VirtualMachine,
     ) -> PyRef<Self> {
         let stripped = zelf.inner.lstrip(chars);
-        if stripped == zelf.as_bytes().to_vec() {
+        if stripped == zelf.as_bytes() {
             zelf
         } else {
-            vm.ctx.new_bytes(stripped)
+            vm.ctx.new_bytes(stripped.to_vec())
         }
     }
 
@@ -389,7 +389,7 @@ impl PyBytes {
         if stripped == zelf.as_bytes().to_vec() {
             zelf
         } else {
-            vm.ctx.new_bytes(stripped)
+            vm.ctx.new_bytes(stripped.to_vec())
         }
     }
 

--- a/vm/src/builtins/bytes.rs
+++ b/vm/src/builtins/bytes.rs
@@ -366,7 +366,11 @@ impl PyBytes {
     }
 
     #[pymethod]
-    fn lstrip(zelf: PyRef<Self>, chars: OptionalOption<PyBytesInner>, vm: &VirtualMachine) -> PyRef<Self> {
+    fn lstrip(
+        zelf: PyRef<Self>,
+        chars: OptionalOption<PyBytesInner>,
+        vm: &VirtualMachine,
+    ) -> PyRef<Self> {
         let stripped = zelf.inner.lstrip(chars);
         if stripped == zelf.as_bytes().to_vec() {
             zelf
@@ -376,7 +380,11 @@ impl PyBytes {
     }
 
     #[pymethod]
-    fn rstrip(zelf: PyRef<Self>, chars: OptionalOption<PyBytesInner>, vm: &VirtualMachine) -> PyRef<Self> {
+    fn rstrip(
+        zelf: PyRef<Self>,
+        chars: OptionalOption<PyBytesInner>,
+        vm: &VirtualMachine,
+    ) -> PyRef<Self> {
         let stripped = zelf.inner.rstrip(chars);
         if stripped == zelf.as_bytes().to_vec() {
             zelf

--- a/vm/src/builtins/bytes.rs
+++ b/vm/src/builtins/bytes.rs
@@ -366,13 +366,23 @@ impl PyBytes {
     }
 
     #[pymethod]
-    fn lstrip(&self, chars: OptionalOption<PyBytesInner>) -> Self {
-        self.inner.lstrip(chars).into()
+    fn lstrip(zelf: PyRef<Self>, chars: OptionalOption<PyBytesInner>, vm: &VirtualMachine) -> PyRef<Self> {
+        let stripped = zelf.inner.lstrip(chars);
+        if stripped == zelf.as_bytes().to_vec() {
+            zelf
+        } else {
+            vm.ctx.new_bytes(stripped)
+        }
     }
 
     #[pymethod]
-    fn rstrip(&self, chars: OptionalOption<PyBytesInner>) -> Self {
-        self.inner.rstrip(chars).into()
+    fn rstrip(zelf: PyRef<Self>, chars: OptionalOption<PyBytesInner>, vm: &VirtualMachine) -> PyRef<Self> {
+        let stripped = zelf.inner.rstrip(chars);
+        if stripped == zelf.as_bytes().to_vec() {
+            zelf
+        } else {
+            vm.ctx.new_bytes(stripped)
+        }
     }
 
     /// removeprefix($self, prefix, /)

--- a/vm/src/bytesinner.rs
+++ b/vm/src/bytesinner.rs
@@ -578,24 +578,20 @@ impl PyBytesInner {
             .to_vec()
     }
 
-    pub fn lstrip(&self, chars: OptionalOption<PyBytesInner>) -> Vec<u8> {
-        self.elements
-            .py_strip(
-                chars,
-                |s, chars| s.trim_start_with(|c| chars.contains(&(c as u8))),
-                |s| s.trim_start(),
-            )
-            .to_vec()
+    pub fn lstrip(&self, chars: OptionalOption<PyBytesInner>) -> &[u8] {
+        self.elements.py_strip(
+            chars,
+            |s, chars| s.trim_start_with(|c| chars.contains(&(c as u8))),
+            |s| s.trim_start(),
+        )
     }
 
-    pub fn rstrip(&self, chars: OptionalOption<PyBytesInner>) -> Vec<u8> {
-        self.elements
-            .py_strip(
-                chars,
-                |s, chars| s.trim_end_with(|c| chars.contains(&(c as u8))),
-                |s| s.trim_end(),
-            )
-            .to_vec()
+    pub fn rstrip(&self, chars: OptionalOption<PyBytesInner>) -> &[u8] {
+        self.elements.py_strip(
+            chars,
+            |s, chars| s.trim_end_with(|c| chars.contains(&(c as u8))),
+            |s| s.trim_end(),
+        )
     }
 
     // new in Python 3.9


### PR DESCRIPTION
Hi!

Here is a solution proposal to #4497. I was not quite sure what the optimization part of #4496 was (I assumed it was the if-else part).