### PR TITLE
Remove unnecessary to_vec() in bytes.rs

### DIFF
--- a/vm/src/builtins/bytes.rs
+++ b/vm/src/builtins/bytes.rs
@@ -382,7 +382,7 @@ impl PyBytes {
         vm: &VirtualMachine,
     ) -> PyRef<Self> {
         let stripped = zelf.inner.rstrip(chars);
-        if stripped == zelf.as_bytes().to_vec() {
+        if stripped == zelf.as_bytes() {
             zelf
         } else {
             vm.ctx.new_bytes(stripped.to_vec())


### PR DESCRIPTION
One unnecessary `to_vec()` was not removed in #4500.