### PR TITLE
Add unicodedata.east_asian_width

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2174,6 +2174,7 @@ dependencies = [
  "socket2",
  "system-configuration",
  "termios",
+ "ucd",
  "unic-char-property",
  "unic-normal",
  "unic-ucd-age",
@@ -2752,6 +2753,12 @@ name = "typenum"
 version = "1.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "497961ef93d974e23eb6f433eb5fe1b7930b659f06d12dec6fc44a8f554c0bba"
+
+[[package]]
+name = "ucd"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fe4fa6e588762366f1eb4991ce59ad1b93651d0b769dfb4e4d1c5c4b943d1159"
 
 [[package]]
 name = "uname"

--- a/Lib/test/test_unicodedata.py
+++ b/Lib/test/test_unicodedata.py
@@ -243,8 +243,6 @@ class UnicodeFunctionsTest(UnicodeDatabaseTest):
     # For tests of unicodedata.is_normalized / self.db.is_normalized ,
     # see test_normalization.py .
 
-    # TODO: RUSTPYTHON
-    @unittest.expectedFailure
     def test_east_asian_width(self):
         eaw = self.db.east_asian_width
         self.assertRaises(TypeError, eaw, b'a')

--- a/extra_tests/snippets/builtin_str_unicode.py
+++ b/extra_tests/snippets/builtin_str_unicode.py
@@ -18,6 +18,7 @@ assert unicodedata.category('A') == 'Lu'
 assert unicodedata.name('a') == 'LATIN SMALL LETTER A'
 assert unicodedata.lookup('LATIN SMALL LETTER A') == 'a'
 assert unicodedata.bidirectional('a') == 'L'
+assert unicodedata.east_asian_width('\u231a') == 'W'
 assert unicodedata.normalize('NFC', 'bla') == 'bla'
 
 # testing unicodedata.ucd_3_2_0 for idna

--- a/stdlib/Cargo.toml
+++ b/stdlib/Cargo.toml
@@ -67,6 +67,7 @@ unic-ucd-bidi      = "0.9.0"
 unic-ucd-category  = "0.9.0"
 unic-ucd-age       = "0.9.0"
 unic-ucd-ident     = "0.9.0"
+ucd = "0.1.1"
 
 # compression
 adler32 = "1.2.0"

--- a/stdlib/src/unicodedata.rs
+++ b/stdlib/src/unicodedata.rs
@@ -18,8 +18,7 @@ pub fn make_module(vm: &VirtualMachine) -> PyObjectRef {
         "east_asian_width",
         "normalize",
     ]
-    .iter()
-    .copied()
+    .into_iter()
     {
         crate::vm::extend_module!(vm, &module, {
             attr => ucd.get_attr(attr, vm).unwrap(),


### PR DESCRIPTION
Closes https://github.com/RustPython/RustPython/issues/4522

~~This PR is a draft for further discussion.~~
Update: In this PR, we've adopted `ucd` crate to implement `unicodedata.east_asian_width` using database v9.0.0, while leaving `unicodedata.ucd_3_2_0.unidata_version` referring to `unicodedata.east_asian_width` as is for now.

# Python Document

https://docs.python.org/3/library/unicodedata.html#unicodedata.east_asian_width

# Expectation (as in CPython 3.11)
```
>>> import unicodedata
>>> unicodedata.unidata_version
'14.0.0'
>>> unicodedata.east_asian_width('\u231a')
'W'
>>> unicodedata.ucd_3_2_0.unidata_version
'3.2.0'
>>> unicodedata.ucd_3_2_0.east_asian_width('\u231a')
'N'
```

# Status
- `unicodedata.east_asian_width` is supported by using `ucd` crate
- `unicodedata.ucd_3_2_0.east_asian_width` is **not working** due to 9.0 change as in test https://github.com/RustPython/RustPython/blob/main/Lib/test/test_unicodedata.py#L264

# Reason
- `ucd` crate uses Unicode Character Database (v9.0.0)
- `self.assertEqual(self.db.ucd_3_2_0.east_asian_width('\u231a'), 'N')`
- https://github.com/sourtin/libucd/blob/master/src/tables/misc.rs#L768 => `W`

# Extra Information
- `unic` crate uses v10.0.0 https://github.com/open-i18n/rust-unic/blob/master/unic/ucd/age/tables/unicode_version.rsv#L3
- Thus existing functions `unicodedata.ucd_3_2_0.*` seem using v10.0.0 instead of v3.2.0 https://github.com/RustPython/RustPython/blob/main/stdlib/src/unicodedata.rs#L68

# Possible Solution
- We may (generate and) load Unicode Character Database according to `unidata_version`, including v3.2.0 and another major version (say, v14.0.0).
- `icu` crate may be a good option to load dynamic database https://github.com/unicode-org/icu4x/blob/main/components/properties/src/maps.rs#L376
- That means we may need to change all functions in `unicodedata` module to use database determined by `unidata_version`.

# Example Commits
- `ucd` crate: https://github.com/RustPython/RustPython/pull/4523/commits/420240c402e3cf4cc4baeec61a36659e2d1de8b1
- `icu` crate: https://github.com/RustPython/RustPython/pull/4523/commits/38eaa75c7e1fae44bc1a08add8a2d2ffee1f79c8

# Related Tests
- `cargo run --release -- -m test test_unicodedata -v`
- `cargo run --release -- extra_tests/snippets/builtin_str_unicode.py`