### PR TITLE
Custom marshal enc/decoding impl

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -127,15 +127,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9e1b586273c5702936fe7b7d6896644d8be71e6314cfe09d3167c95f712589e8"
 
 [[package]]
-name = "bincode"
-version = "1.3.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b1f45e9417d87227c7a56d22e471c6206462cba514c7590c09aff4cf6d1ddcad"
-dependencies = [
- "serde",
-]
-
-[[package]]
 name = "bit-set"
 version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1390,7 +1381,6 @@ dependencies = [
  "autocfg",
  "num-integer",
  "num-traits",
- "serde",
 ]
 
 [[package]]
@@ -1400,7 +1390,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "02e0d21255c828d6f128a1e41534206671e8c3ea0c62f32291e808dc82cff17d"
 dependencies = [
  "num-traits",
- "serde",
 ]
 
 [[package]]
@@ -1987,7 +1976,6 @@ dependencies = [
  "rustpython-ast",
  "rustpython-compiler-core",
  "rustpython-parser",
- "thiserror",
 ]
 
 [[package]]
@@ -2022,23 +2010,18 @@ dependencies = [
  "rustpython-codegen",
  "rustpython-compiler-core",
  "rustpython-parser",
- "thiserror",
 ]
 
 [[package]]
 name = "rustpython-compiler-core"
 version = "0.2.0"
 dependencies = [
- "bincode",
  "bitflags",
  "bstr",
  "itertools",
  "lz4_flex",
  "num-bigint",
  "num-complex",
- "num_enum",
- "serde",
- "thiserror",
 ]
 
 [[package]]
@@ -2108,7 +2091,6 @@ dependencies = [
  "rustc-hash",
  "rustpython-ast",
  "rustpython-compiler-core",
- "thiserror",
  "tiny-keccak",
  "unic-emoji-char",
  "unic-ucd-ident",

--- a/compiler/Cargo.toml
+++ b/compiler/Cargo.toml
@@ -9,5 +9,3 @@ edition = "2021"
 rustpython-compiler-core = { path = "core" }
 rustpython-codegen = { path = "codegen" }
 rustpython-parser = { path = "parser" }
-
-thiserror = { workspace = true }

--- a/compiler/codegen/Cargo.toml
+++ b/compiler/codegen/Cargo.toml
@@ -16,9 +16,8 @@ bitflags = { workspace = true }
 indexmap = { workspace = true }
 itertools = { workspace = true }
 log = { workspace = true }
-num-complex = { workspace = true, features = ["serde"] }
+num-complex = { workspace = true }
 num-traits = { workspace = true }
-thiserror = { workspace = true }
 
 [dev-dependencies]
 rustpython-parser = { path = "../parser" }

--- a/compiler/codegen/src/compile.rs
+++ b/compiler/codegen/src/compile.rs
@@ -249,9 +249,9 @@ impl Compiler {
     fn push_output(
         &mut self,
         flags: bytecode::CodeFlags,
-        posonlyarg_count: usize,
-        arg_count: usize,
-        kwonlyarg_count: usize,
+        posonlyarg_count: u32,
+        arg_count: u32,
+        kwonlyarg_count: u32,
         obj_name: String,
     ) {
         let source_path = self.source_path.clone();
@@ -936,9 +936,11 @@ impl Compiler {
 
         self.push_output(
             bytecode::CodeFlags::NEW_LOCALS | bytecode::CodeFlags::IS_OPTIMIZED,
-            args.posonlyargs.len(),
-            args.posonlyargs.len() + args.args.len(),
-            args.kwonlyargs.len(),
+            args.posonlyargs.len().try_into().unwrap(),
+            (args.posonlyargs.len() + args.args.len())
+                .try_into()
+                .unwrap(),
+            args.kwonlyargs.len().try_into().unwrap(),
             name.to_owned(),
         );
 
@@ -2750,8 +2752,8 @@ impl Compiler {
         self.current_source_location = location;
     }
 
-    fn get_source_line_number(&self) -> usize {
-        self.current_source_location.row()
+    fn get_source_line_number(&self) -> u32 {
+        self.current_source_location.row() as u32
     }
 
     fn push_qualified_path(&mut self, name: &str) {

--- a/compiler/codegen/src/error.rs
+++ b/compiler/codegen/src/error.rs
@@ -2,7 +2,7 @@ use std::fmt;
 
 pub type CodegenError = rustpython_compiler_core::BaseError<CodegenErrorType>;
 
-#[derive(Debug, thiserror::Error)]
+#[derive(Debug)]
 #[non_exhaustive]
 pub enum CodegenErrorType {
     /// Invalid assignment, cannot store value in target.
@@ -32,6 +32,8 @@ pub enum CodegenErrorType {
     EmptyWithBody,
     NotImplementedYet, // RustPython marker for unimplemented features
 }
+
+impl std::error::Error for CodegenErrorType {}
 
 impl fmt::Display for CodegenErrorType {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {

--- a/compiler/codegen/src/ir.rs
+++ b/compiler/codegen/src/ir.rs
@@ -63,11 +63,11 @@ impl Default for Block {
 
 pub struct CodeInfo {
     pub flags: CodeFlags,
-    pub posonlyarg_count: usize, // Number of positional-only arguments
-    pub arg_count: usize,
-    pub kwonlyarg_count: usize,
+    pub posonlyarg_count: u32, // Number of positional-only arguments
+    pub arg_count: u32,
+    pub kwonlyarg_count: u32,
     pub source_path: String,
-    pub first_line_number: usize,
+    pub first_line_number: u32,
     pub obj_name: String, // Name of the object that created this code object
 
     pub blocks: Vec<Block>,
@@ -172,15 +172,15 @@ impl CodeInfo {
         }
     }
 
-    fn cell2arg(&self) -> Option<Box<[isize]>> {
+    fn cell2arg(&self) -> Option<Box<[i32]>> {
         if self.cellvar_cache.is_empty() {
             return None;
         }
 
         let total_args = self.arg_count
             + self.kwonlyarg_count
-            + self.flags.contains(CodeFlags::HAS_VARARGS) as usize
-            + self.flags.contains(CodeFlags::HAS_VARKEYWORDS) as usize;
+            + self.flags.contains(CodeFlags::HAS_VARARGS) as u32
+            + self.flags.contains(CodeFlags::HAS_VARKEYWORDS) as u32;
 
         let mut found_cellarg = false;
         let cell2arg = self
@@ -190,10 +190,10 @@ impl CodeInfo {
                 self.varname_cache
                     .get_index_of(var)
                     // check that it's actually an arg
-                    .filter(|i| *i < total_args)
+                    .filter(|i| *i < total_args as usize)
                     .map_or(-1, |i| {
                         found_cellarg = true;
-                        i as isize
+                        i as i32
                     })
             })
             .collect::<Box<[_]>>();

--- a/compiler/core/Cargo.toml
+++ b/compiler/core/Cargo.toml
@@ -8,14 +8,10 @@ repository = "https://github.com/RustPython/RustPython"
 license = "MIT"
 
 [dependencies]
-bincode = { workspace = true }
 bitflags = { workspace = true }
 bstr = { workspace = true }
 itertools = { workspace = true }
-num-bigint = { workspace = true, features = ["serde"] }
-num-complex = { workspace = true, features = ["serde"] }
-num_enum = { workspace = true }
-serde = { workspace = true, features = ["derive"] }
-thiserror = { workspace = true }
+num-bigint = { workspace = true }
+num-complex = { workspace = true }
 
 lz4_flex = "0.9.2"

--- a/compiler/core/src/lib.rs
+++ b/compiler/core/src/lib.rs
@@ -4,6 +4,7 @@
 mod bytecode;
 mod error;
 mod location;
+pub mod marshal;
 mod mode;
 
 pub use bytecode::*;

--- a/compiler/core/src/location.rs
+++ b/compiler/core/src/location.rs
@@ -1,7 +1,5 @@
-use serde::{Deserialize, Serialize};
-
 /// Sourcecode location.
-#[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord)]
 pub struct Location {
     pub(super) row: u32,
     pub(super) column: u32,

--- a/compiler/core/src/marshal.rs
+++ b/compiler/core/src/marshal.rs
@@ -1,0 +1,615 @@
+use core::fmt;
+use std::convert::Infallible;
+
+use num_bigint::{BigInt, Sign};
+use num_complex::Complex64;
+
+use crate::{bytecode::*, Location};
+
+pub const FORMAT_VERSION: u32 = 4;
+
+#[derive(Debug)]
+pub enum MarshalError {
+    /// Unexpected End Of File
+    Eof,
+    /// Invalid Bytecode
+    InvalidBytecode,
+    /// Invalid utf8 in string
+    InvalidUtf8,
+    /// Bad type marker
+    BadType,
+}
+
+impl fmt::Display for MarshalError {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match self {
+            Self::Eof => f.write_str("unexpected end of data"),
+            Self::InvalidBytecode => f.write_str("invalid bytecode"),
+            Self::InvalidUtf8 => f.write_str("invalid utf8"),
+            Self::BadType => f.write_str("bad type marker"),
+        }
+    }
+}
+
+impl From<std::str::Utf8Error> for MarshalError {
+    fn from(_: std::str::Utf8Error) -> Self {
+        Self::InvalidUtf8
+    }
+}
+
+impl std::error::Error for MarshalError {}
+
+type Result<T, E = MarshalError> = std::result::Result<T, E>;
+
+#[repr(u8)]
+enum Type {
+    // Null = b'0',
+    None = b'N',
+    False = b'F',
+    True = b'T',
+    StopIter = b'S',
+    Ellipsis = b'.',
+    Int = b'i',
+    Float = b'g',
+    Complex = b'y',
+    // Long = b'l',  // i32
+    Bytes = b's', // = TYPE_STRING
+    // Interned = b't',
+    // Ref = b'r',
+    Tuple = b'(',
+    List = b'[',
+    Dict = b'{',
+    Code = b'c',
+    Unicode = b'u',
+    // Unknown = b'?',
+    Set = b'<',
+    FrozenSet = b'>',
+    Ascii = b'a',
+    // AsciiInterned = b'A',
+    // SmallTuple = b')',
+    // ShortAscii = b'z',
+    // ShortAsciiInterned = b'Z',
+}
+// const FLAG_REF: u8 = b'\x80';
+
+impl TryFrom<u8> for Type {
+    type Error = MarshalError;
+    fn try_from(value: u8) -> Result<Self> {
+        use Type::*;
+        Ok(match value {
+            // b'0' => Null,
+            b'N' => None,
+            b'F' => False,
+            b'T' => True,
+            b'S' => StopIter,
+            b'.' => Ellipsis,
+            b'i' => Int,
+            b'g' => Float,
+            b'y' => Complex,
+            // b'l' => Long,
+            b's' => Bytes,
+            // b't' => Interned,
+            // b'r' => Ref,
+            b'(' => Tuple,
+            b'[' => List,
+            b'{' => Dict,
+            b'c' => Code,
+            b'u' => Unicode,
+            // b'?' => Unknown,
+            b'<' => Set,
+            b'>' => FrozenSet,
+            b'a' => Ascii,
+            // b'A' => AsciiInterned,
+            // b')' => SmallTuple,
+            // b'z' => ShortAscii,
+            // b'Z' => ShortAsciiInterned,
+            _ => return Err(MarshalError::BadType),
+        })
+    }
+}
+
+pub trait Read {
+    fn read_slice(&mut self, n: u32) -> Result<&[u8]>;
+    fn read_array<const N: usize>(&mut self) -> Result<&[u8; N]> {
+        self.read_slice(N as u32).map(|s| s.try_into().unwrap())
+    }
+    fn read_str(&mut self, len: u32) -> Result<&str> {
+        Ok(std::str::from_utf8(self.read_slice(len)?)?)
+    }
+    fn read_u8(&mut self) -> Result<u8> {
+        Ok(u8::from_le_bytes(*self.read_array()?))
+    }
+    fn read_u16(&mut self) -> Result<u16> {
+        Ok(u16::from_le_bytes(*self.read_array()?))
+    }
+    fn read_u32(&mut self) -> Result<u32> {
+        Ok(u32::from_le_bytes(*self.read_array()?))
+    }
+    fn read_u64(&mut self) -> Result<u64> {
+        Ok(u64::from_le_bytes(*self.read_array()?))
+    }
+}
+
+impl Read for &[u8] {
+    fn read_slice(&mut self, n: u32) -> Result<&[u8]> {
+        let data = self.get(..n as usize).ok_or(MarshalError::Eof)?;
+        *self = &self[n as usize..];
+        Ok(data)
+    }
+}
+
+pub struct Cursor<B> {
+    pub data: B,
+    pub position: usize,
+}
+
+impl<B: AsRef<[u8]>> Read for Cursor<B> {
+    fn read_slice(&mut self, n: u32) -> Result<&[u8]> {
+        let data = &self.data.as_ref()[self.position..];
+        let slice = data.get(..n as usize).ok_or(MarshalError::Eof)?;
+        self.position += n as usize;
+        Ok(slice)
+    }
+}
+
+pub fn deserialize_code<R: Read, Bag: ConstantBag>(
+    rdr: &mut R,
+    bag: Bag,
+) -> Result<CodeObject<Bag::Constant>> {
+    let len = rdr.read_u32()?;
+    let instructions = rdr.read_slice(len * 2)?;
+    let instructions = instructions
+        .chunks_exact(2)
+        .map(|cu| {
+            let op = Instruction::try_from(cu[0])?;
+            let arg = OpArgByte(cu[1]);
+            Ok(CodeUnit { op, arg })
+        })
+        .collect::<Result<Box<[CodeUnit]>>>()?;
+
+    let len = rdr.read_u32()?;
+    let locations = (0..len)
+        .map(|_| {
+            Ok(Location {
+                row: rdr.read_u32()?,
+                column: rdr.read_u32()?,
+            })
+        })
+        .collect::<Result<Box<[Location]>>>()?;
+
+    let flags = CodeFlags::from_bits_truncate(rdr.read_u16()?);
+
+    let posonlyarg_count = rdr.read_u32()?;
+    let arg_count = rdr.read_u32()?;
+    let kwonlyarg_count = rdr.read_u32()?;
+
+    let len = rdr.read_u32()?;
+    let source_path = bag.make_name(rdr.read_str(len)?);
+
+    let first_line_number = rdr.read_u32()?;
+    let max_stackdepth = rdr.read_u32()?;
+
+    let len = rdr.read_u32()?;
+    let obj_name = bag.make_name(rdr.read_str(len)?);
+
+    let len = rdr.read_u32()?;
+    let cell2arg = (len != 0)
+        .then(|| {
+            (0..len)
+                .map(|_| Ok(rdr.read_u32()? as i32))
+                .collect::<Result<Box<[i32]>>>()
+        })
+        .transpose()?;
+
+    let len = rdr.read_u32()?;
+    let constants = (0..len)
+        .map(|_| deserialize_value(rdr, bag))
+        .collect::<Result<Box<[_]>>>()?;
+
+    let mut read_names = || {
+        let len = rdr.read_u32()?;
+        (0..len)
+            .map(|_| {
+                let len = rdr.read_u32()?;
+                Ok(bag.make_name(rdr.read_str(len)?))
+            })
+            .collect::<Result<Box<[_]>>>()
+    };
+
+    let names = read_names()?;
+    let varnames = read_names()?;
+    let cellvars = read_names()?;
+    let freevars = read_names()?;
+
+    Ok(CodeObject {
+        instructions,
+        locations,
+        flags,
+        posonlyarg_count,
+        arg_count,
+        kwonlyarg_count,
+        source_path,
+        first_line_number,
+        max_stackdepth,
+        obj_name,
+        cell2arg,
+        constants,
+        names,
+        varnames,
+        cellvars,
+        freevars,
+    })
+}
+
+pub trait MarshalBag: Copy {
+    type Value;
+    fn make_bool(&self, value: bool) -> Self::Value;
+    fn make_none(&self) -> Self::Value;
+    fn make_ellipsis(&self) -> Self::Value;
+    fn make_float(&self, value: f64) -> Self::Value;
+    fn make_complex(&self, value: Complex64) -> Self::Value;
+    fn make_str(&self, value: &str) -> Self::Value;
+    fn make_bytes(&self, value: &[u8]) -> Self::Value;
+    fn make_int(&self, value: BigInt) -> Self::Value;
+    fn make_tuple(&self, elements: impl Iterator<Item = Self::Value>) -> Self::Value;
+    fn make_code(
+        &self,
+        code: CodeObject<<Self::ConstantBag as ConstantBag>::Constant>,
+    ) -> Self::Value;
+    fn make_stop_iter(&self) -> Result<Self::Value>;
+    fn make_list(&self, it: impl Iterator<Item = Self::Value>) -> Result<Self::Value>;
+    fn make_set(&self, it: impl Iterator<Item = Self::Value>) -> Result<Self::Value>;
+    fn make_frozenset(&self, it: impl Iterator<Item = Self::Value>) -> Result<Self::Value>;
+    fn make_dict(
+        &self,
+        it: impl Iterator<Item = (Self::Value, Self::Value)>,
+    ) -> Result<Self::Value>;
+    type ConstantBag: ConstantBag;
+    fn constant_bag(self) -> Self::ConstantBag;
+}
+
+impl<Bag: ConstantBag> MarshalBag for Bag {
+    type Value = Bag::Constant;
+    fn make_bool(&self, value: bool) -> Self::Value {
+        self.make_constant::<Bag::Constant>(BorrowedConstant::Boolean { value })
+    }
+    fn make_none(&self) -> Self::Value {
+        self.make_constant::<Bag::Constant>(BorrowedConstant::None)
+    }
+    fn make_ellipsis(&self) -> Self::Value {
+        self.make_constant::<Bag::Constant>(BorrowedConstant::Ellipsis)
+    }
+    fn make_float(&self, value: f64) -> Self::Value {
+        self.make_constant::<Bag::Constant>(BorrowedConstant::Float { value })
+    }
+    fn make_complex(&self, value: Complex64) -> Self::Value {
+        self.make_constant::<Bag::Constant>(BorrowedConstant::Complex { value })
+    }
+    fn make_str(&self, value: &str) -> Self::Value {
+        self.make_constant::<Bag::Constant>(BorrowedConstant::Str { value })
+    }
+    fn make_bytes(&self, value: &[u8]) -> Self::Value {
+        self.make_constant::<Bag::Constant>(BorrowedConstant::Bytes { value })
+    }
+    fn make_int(&self, value: BigInt) -> Self::Value {
+        self.make_int(value)
+    }
+    fn make_tuple(&self, elements: impl Iterator<Item = Self::Value>) -> Self::Value {
+        self.make_tuple(elements)
+    }
+    fn make_code(
+        &self,
+        code: CodeObject<<Self::ConstantBag as ConstantBag>::Constant>,
+    ) -> Self::Value {
+        self.make_code(code)
+    }
+    fn make_stop_iter(&self) -> Result<Self::Value> {
+        Err(MarshalError::BadType)
+    }
+    fn make_list(&self, _: impl Iterator<Item = Self::Value>) -> Result<Self::Value> {
+        Err(MarshalError::BadType)
+    }
+    fn make_set(&self, _: impl Iterator<Item = Self::Value>) -> Result<Self::Value> {
+        Err(MarshalError::BadType)
+    }
+    fn make_frozenset(&self, _: impl Iterator<Item = Self::Value>) -> Result<Self::Value> {
+        Err(MarshalError::BadType)
+    }
+    fn make_dict(
+        &self,
+        _: impl Iterator<Item = (Self::Value, Self::Value)>,
+    ) -> Result<Self::Value> {
+        Err(MarshalError::BadType)
+    }
+    type ConstantBag = Self;
+    fn constant_bag(self) -> Self::ConstantBag {
+        self
+    }
+}
+
+pub fn deserialize_value<R: Read, Bag: MarshalBag>(rdr: &mut R, bag: Bag) -> Result<Bag::Value> {
+    let typ = Type::try_from(rdr.read_u8()?)?;
+    let value = match typ {
+        Type::True => bag.make_bool(true),
+        Type::False => bag.make_bool(false),
+        Type::None => bag.make_none(),
+        Type::StopIter => bag.make_stop_iter()?,
+        Type::Ellipsis => bag.make_ellipsis(),
+        Type::Int => {
+            let len = rdr.read_u32()? as i32;
+            let sign = if len < 0 { Sign::Minus } else { Sign::Plus };
+            let bytes = rdr.read_slice(len.unsigned_abs())?;
+            let int = BigInt::from_bytes_le(sign, bytes);
+            bag.make_int(int)
+        }
+        Type::Float => {
+            let value = f64::from_bits(rdr.read_u64()?);
+            bag.make_float(value)
+        }
+        Type::Complex => {
+            let re = f64::from_bits(rdr.read_u64()?);
+            let im = f64::from_bits(rdr.read_u64()?);
+            let value = Complex64 { re, im };
+            bag.make_complex(value)
+        }
+        Type::Ascii | Type::Unicode => {
+            let len = rdr.read_u32()?;
+            let value = rdr.read_str(len)?;
+            bag.make_str(value)
+        }
+        Type::Tuple => {
+            let len = rdr.read_u32()?;
+            let it = (0..len).map(|_| deserialize_value(rdr, bag));
+            itertools::process_results(it, |it| bag.make_tuple(it))?
+        }
+        Type::List => {
+            let len = rdr.read_u32()?;
+            let it = (0..len).map(|_| deserialize_value(rdr, bag));
+            itertools::process_results(it, |it| bag.make_list(it))??
+        }
+        Type::Set => {
+            let len = rdr.read_u32()?;
+            let it = (0..len).map(|_| deserialize_value(rdr, bag));
+            itertools::process_results(it, |it| bag.make_set(it))??
+        }
+        Type::FrozenSet => {
+            let len = rdr.read_u32()?;
+            let it = (0..len).map(|_| deserialize_value(rdr, bag));
+            itertools::process_results(it, |it| bag.make_frozenset(it))??
+        }
+        Type::Dict => {
+            let len = rdr.read_u32()?;
+            let it = (0..len).map(|_| {
+                let k = deserialize_value(rdr, bag)?;
+                let v = deserialize_value(rdr, bag)?;
+                Ok::<_, MarshalError>((k, v))
+            });
+            itertools::process_results(it, |it| bag.make_dict(it))??
+        }
+        Type::Bytes => {
+            // Following CPython, after marshaling, byte arrays are converted into bytes.
+            let len = rdr.read_u32()?;
+            let value = rdr.read_slice(len)?;
+            bag.make_bytes(value)
+        }
+        Type::Code => bag.make_code(deserialize_code(rdr, bag.constant_bag())?),
+    };
+    Ok(value)
+}
+
+pub trait Dumpable: Sized {
+    type Error;
+    type Constant: Constant;
+    fn with_dump<R>(&self, f: impl FnOnce(DumpableValue<'_, Self>) -> R) -> Result<R, Self::Error>;
+}
+
+pub enum DumpableValue<'a, D: Dumpable> {
+    Integer(&'a BigInt),
+    Float(f64),
+    Complex(Complex64),
+    Boolean(bool),
+    Str(&'a str),
+    Bytes(&'a [u8]),
+    Code(&'a CodeObject<D::Constant>),
+    Tuple(&'a [D]),
+    None,
+    Ellipsis,
+    StopIter,
+    List(&'a [D]),
+    Set(&'a [D]),
+    Frozenset(&'a [D]),
+    Dict(&'a [(D, D)]),
+}
+
+impl<'a, C: Constant> From<BorrowedConstant<'a, C>> for DumpableValue<'a, C> {
+    fn from(c: BorrowedConstant<'a, C>) -> Self {
+        match c {
+            BorrowedConstant::Integer { value } => Self::Integer(value),
+            BorrowedConstant::Float { value } => Self::Float(value),
+            BorrowedConstant::Complex { value } => Self::Complex(value),
+            BorrowedConstant::Boolean { value } => Self::Boolean(value),
+            BorrowedConstant::Str { value } => Self::Str(value),
+            BorrowedConstant::Bytes { value } => Self::Bytes(value),
+            BorrowedConstant::Code { code } => Self::Code(code),
+            BorrowedConstant::Tuple { elements } => Self::Tuple(elements),
+            BorrowedConstant::None => Self::None,
+            BorrowedConstant::Ellipsis => Self::Ellipsis,
+        }
+    }
+}
+
+impl<C: Constant> Dumpable for C {
+    type Error = Infallible;
+    type Constant = Self;
+    #[inline(always)]
+    fn with_dump<R>(&self, f: impl FnOnce(DumpableValue<'_, Self>) -> R) -> Result<R, Self::Error> {
+        Ok(f(self.borrow_constant().into()))
+    }
+}
+
+pub trait Write {
+    fn write_slice(&mut self, slice: &[u8]);
+    fn write_u8(&mut self, v: u8) {
+        self.write_slice(&v.to_le_bytes())
+    }
+    fn write_u16(&mut self, v: u16) {
+        self.write_slice(&v.to_le_bytes())
+    }
+    fn write_u32(&mut self, v: u32) {
+        self.write_slice(&v.to_le_bytes())
+    }
+    fn write_u64(&mut self, v: u64) {
+        self.write_slice(&v.to_le_bytes())
+    }
+}
+
+impl Write for Vec<u8> {
+    fn write_slice(&mut self, slice: &[u8]) {
+        self.extend_from_slice(slice)
+    }
+}
+
+pub(crate) fn write_len<W: Write>(buf: &mut W, len: usize) {
+    let Ok(len) = len.try_into() else { panic!("too long to serialize") };
+    buf.write_u32(len);
+}
+
+pub fn serialize_value<W: Write, D: Dumpable>(
+    buf: &mut W,
+    constant: DumpableValue<'_, D>,
+) -> Result<(), D::Error> {
+    match constant {
+        DumpableValue::Integer(int) => {
+            buf.write_u8(Type::Int as u8);
+            let (sign, bytes) = int.to_bytes_le();
+            let len: i32 = bytes.len().try_into().expect("too long to serialize");
+            let len = if sign == Sign::Minus { -len } else { len };
+            buf.write_u32(len as u32);
+            buf.write_slice(&bytes);
+        }
+        DumpableValue::Float(f) => {
+            buf.write_u8(Type::Float as u8);
+            buf.write_u64(f.to_bits());
+        }
+        DumpableValue::Complex(c) => {
+            buf.write_u8(Type::Complex as u8);
+            buf.write_u64(c.re.to_bits());
+            buf.write_u64(c.im.to_bits());
+        }
+        DumpableValue::Boolean(b) => {
+            buf.write_u8(if b { Type::True } else { Type::False } as u8);
+        }
+        DumpableValue::Str(s) => {
+            buf.write_u8(Type::Unicode as u8);
+            write_len(buf, s.len());
+            buf.write_slice(s.as_bytes());
+        }
+        DumpableValue::Bytes(b) => {
+            buf.write_u8(Type::Bytes as u8);
+            write_len(buf, b.len());
+            buf.write_slice(b);
+        }
+        DumpableValue::Code(c) => {
+            buf.write_u8(Type::Code as u8);
+            serialize_code(buf, c);
+        }
+        DumpableValue::Tuple(tup) => {
+            buf.write_u8(Type::Tuple as u8);
+            write_len(buf, tup.len());
+            for val in tup {
+                val.with_dump(|val| serialize_value(buf, val))??
+            }
+        }
+        DumpableValue::None => {
+            buf.write_u8(Type::None as u8);
+        }
+        DumpableValue::Ellipsis => {
+            buf.write_u8(Type::Ellipsis as u8);
+        }
+        DumpableValue::StopIter => {
+            buf.write_u8(Type::StopIter as u8);
+        }
+        DumpableValue::List(l) => {
+            buf.write_u8(Type::List as u8);
+            write_len(buf, l.len());
+            for val in l {
+                val.with_dump(|val| serialize_value(buf, val))??
+            }
+        }
+        DumpableValue::Set(set) => {
+            buf.write_u8(Type::Set as u8);
+            write_len(buf, set.len());
+            for val in set {
+                val.with_dump(|val| serialize_value(buf, val))??
+            }
+        }
+        DumpableValue::Frozenset(set) => {
+            buf.write_u8(Type::FrozenSet as u8);
+            write_len(buf, set.len());
+            for val in set {
+                val.with_dump(|val| serialize_value(buf, val))??
+            }
+        }
+        DumpableValue::Dict(d) => {
+            buf.write_u8(Type::Dict as u8);
+            write_len(buf, d.len());
+            for (k, v) in d {
+                k.with_dump(|val| serialize_value(buf, val))??;
+                v.with_dump(|val| serialize_value(buf, val))??;
+            }
+        }
+    }
+    Ok(())
+}
+
+pub fn serialize_code<W: Write, C: Constant>(buf: &mut W, code: &CodeObject<C>) {
+    write_len(buf, code.instructions.len());
+    // SAFETY: it's ok to transmute CodeUnit to [u8; 2]
+    let (_, instructions_bytes, _) = unsafe { code.instructions.align_to() };
+    buf.write_slice(instructions_bytes);
+
+    write_len(buf, code.locations.len());
+    for loc in &*code.locations {
+        buf.write_u32(loc.row);
+        buf.write_u32(loc.column);
+    }
+
+    buf.write_u16(code.flags.bits());
+
+    buf.write_u32(code.posonlyarg_count);
+    buf.write_u32(code.arg_count);
+    buf.write_u32(code.kwonlyarg_count);
+
+    write_len(buf, code.source_path.as_ref().len());
+    buf.write_slice(code.source_path.as_ref().as_bytes());
+
+    buf.write_u32(code.first_line_number);
+    buf.write_u32(code.max_stackdepth);
+
+    write_len(buf, code.obj_name.as_ref().len());
+    buf.write_slice(code.obj_name.as_ref().as_bytes());
+
+    let cell2arg = code.cell2arg.as_deref().unwrap_or(&[]);
+    write_len(buf, cell2arg.len());
+    for &i in cell2arg {
+        buf.write_u32(i as u32)
+    }
+
+    write_len(buf, code.constants.len());
+    for constant in &*code.constants {
+        serialize_value(buf, constant.borrow_constant().into()).unwrap_or_else(|x| match x {})
+    }
+
+    let mut write_names = |names: &[C::Name]| {
+        write_len(buf, names.len());
+        for name in names {
+            write_len(buf, name.as_ref().len());
+            buf.write_slice(name.as_ref().as_bytes());
+        }
+    };
+
+    write_names(&code.names);
+    write_names(&code.varnames);
+    write_names(&code.cellvars);
+    write_names(&code.freevars);
+}

--- a/compiler/parser/Cargo.toml
+++ b/compiler/parser/Cargo.toml
@@ -26,7 +26,6 @@ itertools = { workspace = true }
 log = { workspace = true }
 num-bigint = { workspace = true }
 num-traits = { workspace = true }
-thiserror = { workspace = true }
 unicode_names2 = { workspace = true }
 
 unic-emoji-char = "0.9.0"

--- a/compiler/parser/src/parser.rs
+++ b/compiler/parser/src/parser.rs
@@ -200,7 +200,7 @@ pub fn parse_tokens(
 pub type ParseError = rustpython_compiler_core::BaseError<ParseErrorType>;
 
 /// Represents the different types of errors that can occur during parsing.
-#[derive(Debug, PartialEq, thiserror::Error)]
+#[derive(Debug, PartialEq)]
 pub enum ParseErrorType {
     /// Parser encountered an unexpected end of input
     Eof,
@@ -214,6 +214,8 @@ pub enum ParseErrorType {
     /// Parser encountered an error during lexing.
     Lexical(LexicalErrorType),
 }
+
+impl std::error::Error for ParseErrorType {}
 
 // Convert `lalrpop_util::ParseError` to our internal type
 fn parse_error_from_lalrpop(

--- a/vm/Cargo.toml
+++ b/vm/Cargo.toml
@@ -21,6 +21,7 @@ compiler = ["parser", "codegen", "rustpython-compiler"]
 ast = ["rustpython-ast"]
 codegen = ["rustpython-codegen", "ast"]
 parser = ["rustpython-parser", "ast"]
+serde = ["dep:serde"]
 
 [dependencies]
 rustpython-compiler = { path = "../compiler", optional = true, version = "0.2.0" }
@@ -47,8 +48,8 @@ itertools = { workspace = true }
 libc = { workspace = true }
 log = { workspace = true }
 nix = { workspace = true }
-num-bigint = { workspace = true, features = ["serde"] }
-num-complex = { workspace = true, features = ["serde"] }
+num-bigint = { workspace = true }
+num-complex = { workspace = true }
 num-integer = { workspace = true }
 num-rational = { workspace = true }
 num-traits = { workspace = true }
@@ -57,7 +58,7 @@ once_cell = { workspace = true }
 parking_lot = { workspace = true }
 paste = { workspace = true }
 rand = { workspace = true }
-serde = { workspace = true, features = ["derive"] }
+serde = { workspace = true, optional = true }
 static_assertions = { workspace = true }
 thiserror = { workspace = true }
 thread_local = { workspace = true }

--- a/vm/src/builtins/code.rs
+++ b/vm/src/builtins/code.rs
@@ -79,6 +79,8 @@ fn borrow_obj_constant(obj: &PyObject) -> BorrowedConstant<Literal> {
         }
         ref t @ super::tuple::PyTuple => {
             let elements = t.as_slice();
+            // SAFETY: Literal is repr(transparent) over PyObjectRef, and a Literal tuple only ever
+            //         has other literals as elements
             let elements = unsafe { &*(elements as *const [PyObjectRef] as *const [Literal]) };
             BorrowedConstant::Tuple { elements }
         }

--- a/vm/src/builtins/code.rs
+++ b/vm/src/builtins/code.rs
@@ -17,15 +17,15 @@ use std::{borrow::Borrow, fmt, ops::Deref};
 #[derive(FromArgs)]
 pub struct ReplaceArgs {
     #[pyarg(named, optional)]
-    co_posonlyargcount: OptionalArg<usize>,
+    co_posonlyargcount: OptionalArg<u32>,
     #[pyarg(named, optional)]
-    co_argcount: OptionalArg<usize>,
+    co_argcount: OptionalArg<u32>,
     #[pyarg(named, optional)]
-    co_kwonlyargcount: OptionalArg<usize>,
+    co_kwonlyargcount: OptionalArg<u32>,
     #[pyarg(named, optional)]
     co_filename: OptionalArg<PyStrRef>,
     #[pyarg(named, optional)]
-    co_firstlineno: OptionalArg<usize>,
+    co_firstlineno: OptionalArg<u32>,
     #[pyarg(named, optional)]
     co_consts: OptionalArg<Vec<PyObjectRef>>,
     #[pyarg(named, optional)]
@@ -39,6 +39,7 @@ pub struct ReplaceArgs {
 }
 
 #[derive(Clone)]
+#[repr(transparent)]
 pub struct Literal(PyObjectRef);
 
 impl Borrow<PyObject> for Literal {
@@ -77,9 +78,9 @@ fn borrow_obj_constant(obj: &PyObject) -> BorrowedConstant<Literal> {
             BorrowedConstant::Code { code: &c.code }
         }
         ref t @ super::tuple::PyTuple => {
-            BorrowedConstant::Tuple {
-                elements: Box::new(t.iter().map(|o| borrow_obj_constant(o))),
-            }
+            let elements = t.as_slice();
+            let elements = unsafe { &*(elements as *const [PyObjectRef] as *const [Literal]) };
+            BorrowedConstant::Tuple { elements }
         }
         super::singletons::PyNone => BorrowedConstant::None,
         super::slice::PyEllipsis => BorrowedConstant::Ellipsis,
@@ -117,8 +118,8 @@ impl ConstantBag for PyObjBag<'_> {
             }
             bytecode::BorrowedConstant::Tuple { elements } => {
                 let elements = elements
-                    .into_iter()
-                    .map(|constant| self.make_constant(constant).0)
+                    .iter()
+                    .map(|constant| self.make_constant(constant.borrow_constant()).0)
                     .collect();
                 ctx.new_tuple(elements).into()
             }
@@ -130,6 +131,18 @@ impl ConstantBag for PyObjBag<'_> {
 
     fn make_name(&self, name: &str) -> &'static PyStrInterned {
         self.0.intern_str(name)
+    }
+
+    fn make_int(&self, value: num_bigint::BigInt) -> Self::Constant {
+        Literal(self.0.new_int(value).into())
+    }
+
+    fn make_tuple(&self, elements: impl Iterator<Item = Self::Constant>) -> Self::Constant {
+        Literal(self.0.new_tuple(elements.map(|lit| lit.0).collect()).into())
+    }
+
+    fn make_code(&self, code: CodeObject) -> Self::Constant {
+        Literal(self.0.new_code(code).into())
     }
 }
 
@@ -205,12 +218,12 @@ impl PyRef<PyCode> {
 
     #[pygetset]
     fn co_posonlyargcount(self) -> usize {
-        self.code.posonlyarg_count
+        self.code.posonlyarg_count as usize
     }
 
     #[pygetset]
     fn co_argcount(self) -> usize {
-        self.code.arg_count
+        self.code.arg_count as usize
     }
 
     #[pygetset]
@@ -237,12 +250,12 @@ impl PyRef<PyCode> {
 
     #[pygetset]
     fn co_firstlineno(self) -> usize {
-        self.code.first_line_number
+        self.code.first_line_number as usize
     }
 
     #[pygetset]
     fn co_kwonlyargcount(self) -> usize {
-        self.code.kwonlyarg_count
+        self.code.kwonlyarg_count as usize
     }
 
     #[pygetset]

--- a/vm/src/builtins/complex.rs
+++ b/vm/src/builtins/complex.rs
@@ -28,6 +28,12 @@ pub struct PyComplex {
     value: Complex64,
 }
 
+impl PyComplex {
+    pub fn to_complex64(self) -> Complex64 {
+        self.value
+    }
+}
+
 impl PyPayload for PyComplex {
     fn class(vm: &VirtualMachine) -> &'static Py<PyType> {
         vm.ctx.types.complex_type

--- a/vm/src/builtins/dict.rs
+++ b/vm/src/builtins/dict.rs
@@ -609,52 +609,52 @@ impl Py<PyDict> {
 // Implement IntoIterator so that we can easily iterate dictionaries from rust code.
 impl IntoIterator for PyDictRef {
     type Item = (PyObjectRef, PyObjectRef);
-    type IntoIter = DictIter;
+    type IntoIter = DictIntoIter;
+
+    fn into_iter(self) -> Self::IntoIter {
+        DictIntoIter::new(self)
+    }
+}
+
+impl<'a> IntoIterator for &'a PyDictRef {
+    type Item = (PyObjectRef, PyObjectRef);
+    type IntoIter = DictIter<'a>;
 
     fn into_iter(self) -> Self::IntoIter {
         DictIter::new(self)
     }
 }
 
-impl<'a> IntoIterator for &'a PyDictRef {
-    type Item = (PyObjectRef, PyObjectRef);
-    type IntoIter = DictIterRef<'a>;
-
-    fn into_iter(self) -> Self::IntoIter {
-        DictIterRef::new(self)
-    }
-}
-
 impl<'a> IntoIterator for &'a Py<PyDict> {
     type Item = (PyObjectRef, PyObjectRef);
-    type IntoIter = DictIterRef<'a>;
+    type IntoIter = DictIter<'a>;
 
     fn into_iter(self) -> Self::IntoIter {
-        DictIterRef::new(self)
+        DictIter::new(self)
     }
 }
 
 impl<'a> IntoIterator for &'a PyDict {
     type Item = (PyObjectRef, PyObjectRef);
-    type IntoIter = DictIterRef<'a>;
+    type IntoIter = DictIter<'a>;
 
     fn into_iter(self) -> Self::IntoIter {
-        DictIterRef::new(self)
+        DictIter::new(self)
     }
 }
 
-pub struct DictIter {
+pub struct DictIntoIter {
     dict: PyDictRef,
     position: usize,
 }
 
-impl DictIter {
-    pub fn new(dict: PyDictRef) -> DictIter {
-        DictIter { dict, position: 0 }
+impl DictIntoIter {
+    pub fn new(dict: PyDictRef) -> DictIntoIter {
+        DictIntoIter { dict, position: 0 }
     }
 }
 
-impl Iterator for DictIter {
+impl Iterator for DictIntoIter {
     type Item = (PyObjectRef, PyObjectRef);
 
     fn next(&mut self) -> Option<Self::Item> {
@@ -668,24 +668,24 @@ impl Iterator for DictIter {
         (l, Some(l))
     }
 }
-impl ExactSizeIterator for DictIter {
+impl ExactSizeIterator for DictIntoIter {
     fn len(&self) -> usize {
         self.dict.entries.len_from_entry_index(self.position)
     }
 }
 
-pub struct DictIterRef<'a> {
+pub struct DictIter<'a> {
     dict: &'a PyDict,
     position: usize,
 }
 
-impl<'a> DictIterRef<'a> {
+impl<'a> DictIter<'a> {
     pub fn new(dict: &'a PyDict) -> Self {
-        DictIterRef { dict, position: 0 }
+        DictIter { dict, position: 0 }
     }
 }
 
-impl Iterator for DictIterRef<'_> {
+impl Iterator for DictIter<'_> {
     type Item = (PyObjectRef, PyObjectRef);
 
     fn next(&mut self) -> Option<Self::Item> {
@@ -699,7 +699,7 @@ impl Iterator for DictIterRef<'_> {
         (l, Some(l))
     }
 }
-impl ExactSizeIterator for DictIterRef<'_> {
+impl ExactSizeIterator for DictIter<'_> {
     fn len(&self) -> usize {
         self.dict.entries.len_from_entry_index(self.position)
     }

--- a/vm/src/builtins/float.rs
+++ b/vm/src/builtins/float.rs
@@ -643,6 +643,7 @@ impl PyFloat {
 }
 
 // Retrieve inner float value:
+#[cfg(feature = "serde")]
 pub(crate) fn get_value(obj: &PyObject) -> f64 {
     obj.payload::<PyFloat>().unwrap().value
 }

--- a/vm/src/builtins/function.rs
+++ b/vm/src/builtins/function.rs
@@ -66,8 +66,8 @@ impl PyFunction {
     ) -> PyResult<()> {
         let code = &*self.code;
         let nargs = func_args.args.len();
-        let nexpected_args = code.arg_count;
-        let total_args = code.arg_count + code.kwonlyarg_count;
+        let nexpected_args = code.arg_count as usize;
+        let total_args = code.arg_count as usize + code.kwonlyarg_count as usize;
         // let arg_names = self.code.arg_names();
 
         // This parses the arguments from args and kwargs into
@@ -131,7 +131,7 @@ impl PyFunction {
         // Handle keyword arguments
         for (name, value) in func_args.kwargs {
             // Check if we have a parameter with this name:
-            if let Some(pos) = argpos(code.posonlyarg_count..total_args, &name) {
+            if let Some(pos) = argpos(code.posonlyarg_count as usize..total_args, &name) {
                 let slot = &mut fastlocals[pos];
                 if slot.is_some() {
                     return Err(vm.new_type_error(format!(
@@ -143,7 +143,7 @@ impl PyFunction {
                 *slot = Some(value);
             } else if let Some(kwargs) = kwargs.as_ref() {
                 kwargs.set_item(&name, value, vm)?;
-            } else if argpos(0..code.posonlyarg_count, &name).is_some() {
+            } else if argpos(0..code.posonlyarg_count as usize, &name).is_some() {
                 posonly_passed_as_kwarg.push(name);
             } else {
                 return Err(vm.new_type_error(format!(
@@ -176,7 +176,7 @@ impl PyFunction {
             let defaults = get_defaults!().0.as_ref().map(|tup| tup.as_slice());
             let ndefs = defaults.map_or(0, |d| d.len());
 
-            let nrequired = code.arg_count - ndefs;
+            let nrequired = code.arg_count as usize - ndefs;
 
             // Given the number of defaults available, check all the arguments for which we
             // _don't_ have defaults; if any are missing, raise an exception
@@ -244,8 +244,8 @@ impl PyFunction {
             for (slot, kwarg) in fastlocals
                 .iter_mut()
                 .zip(&*code.varnames)
-                .skip(code.arg_count)
-                .take(code.kwonlyarg_count)
+                .skip(code.arg_count as usize)
+                .take(code.kwonlyarg_count as usize)
                 .filter(|(slot, _)| slot.is_none())
             {
                 if let Some(defaults) = &get_defaults!().1 {

--- a/vm/src/builtins/traceback.rs
+++ b/vm/src/builtins/traceback.rs
@@ -67,6 +67,7 @@ pub fn init(context: &Context) {
     PyTraceback::extend_class(context, context.types.traceback_type);
 }
 
+#[cfg(feature = "serde")]
 impl serde::Serialize for PyTraceback {
     fn serialize<S: serde::Serializer>(&self, s: S) -> Result<S::Ok, S::Error> {
         use serde::ser::SerializeStruct;

--- a/vm/src/lib.rs
+++ b/vm/src/lib.rs
@@ -64,6 +64,7 @@ pub mod object;
 pub mod prelude;
 pub mod protocol;
 pub mod py_io;
+#[cfg(feature = "serde")]
 pub mod py_serde;
 pub mod readline;
 pub mod recursion;

--- a/vm/src/macros.rs
+++ b/vm/src/macros.rs
@@ -144,8 +144,8 @@ macro_rules! match_class {
     };
     (match ($obj:expr) { ref $binding:ident @ $class:ty => $expr:expr, $($rest:tt)* }) => {
         match $obj.payload::<$class>() {
-            Some($binding) => $expr,
-            None => $crate::match_class!(match ($obj) { $($rest)* }),
+            ::std::option::Option::Some($binding) => $expr,
+            ::std::option::Option::None => $crate::match_class!(match ($obj) { $($rest)* }),
         }
     };
 

--- a/vm/src/stdlib/marshal.rs
+++ b/vm/src/stdlib/marshal.rs
@@ -2,207 +2,90 @@ pub(crate) use decl::make_module;
 
 #[pymodule(name = "marshal")]
 mod decl {
+    use crate::builtins::code::{CodeObject, Literal, PyObjBag};
+    use crate::class::StaticType;
     use crate::{
         builtins::{
-            PyBaseExceptionRef, PyByteArray, PyBytes, PyCode, PyDict, PyFloat, PyFrozenSet, PyInt,
-            PyList, PySet, PyStr, PyTuple,
+            PyBool, PyByteArray, PyBytes, PyCode, PyComplex, PyDict, PyEllipsis, PyFloat,
+            PyFrozenSet, PyInt, PyList, PyNone, PySet, PyStopIteration, PyStr, PyTuple,
         },
-        bytecode,
         convert::ToPyObject,
         function::{ArgBytesLike, OptionalArg},
         object::AsObject,
         protocol::PyBuffer,
         PyObjectRef, PyResult, TryFromObject, VirtualMachine,
     };
-    use num_bigint::{BigInt, Sign};
+    use num_bigint::BigInt;
+    use num_complex::Complex64;
     use num_traits::Zero;
-
-    #[repr(u8)]
-    enum Type {
-        // Null = b'0',
-        None = b'N',
-        False = b'F',
-        True = b'T',
-        StopIter = b'S',
-        Ellipsis = b'.',
-        Int = b'i',
-        Float = b'g',
-        // Complex = b'y',
-        // Long = b'l',  // i32
-        Bytes = b's', // = TYPE_STRING
-        // Interned = b't',
-        // Ref = b'r',
-        Tuple = b'(',
-        List = b'[',
-        Dict = b'{',
-        Code = b'c',
-        Unicode = b'u',
-        // Unknown = b'?',
-        Set = b'<',
-        FrozenSet = b'>',
-        Ascii = b'a',
-        // AsciiInterned = b'A',
-        // SmallTuple = b')',
-        // ShortAscii = b'z',
-        // ShortAsciiInterned = b'Z',
-    }
-    // const FLAG_REF: u8 = b'\x80';
-
-    impl TryFrom<u8> for Type {
-        type Error = u8;
-        fn try_from(value: u8) -> Result<Self, u8> {
-            use Type::*;
-            Ok(match value {
-                // b'0' => Null,
-                b'N' => None,
-                b'F' => False,
-                b'T' => True,
-                b'S' => StopIter,
-                b'.' => Ellipsis,
-                b'i' => Int,
-                b'g' => Float,
-                // b'y' => Complex,
-                // b'l' => Long,
-                b's' => Bytes,
-                // b't' => Interned,
-                // b'r' => Ref,
-                b'(' => Tuple,
-                b'[' => List,
-                b'{' => Dict,
-                b'c' => Code,
-                b'u' => Unicode,
-                // b'?' => Unknown,
-                b'<' => Set,
-                b'>' => FrozenSet,
-                b'a' => Ascii,
-                // b'A' => AsciiInterned,
-                // b')' => SmallTuple,
-                // b'z' => ShortAscii,
-                // b'Z' => ShortAsciiInterned,
-                c => return Err(c),
-            })
-        }
-    }
+    use rustpython_compiler_core::marshal;
 
     #[pyattr(name = "version")]
-    const VERSION: u32 = 4;
+    use marshal::FORMAT_VERSION;
 
-    fn too_short_error(vm: &VirtualMachine) -> PyBaseExceptionRef {
-        vm.new_exception_msg(
-            vm.ctx.exceptions.eof_error.to_owned(),
-            "marshal data too short".to_owned(),
-        )
-    }
+    pub struct DumpError;
 
-    /// Dumps a sequence of objects into binary vector.
-    fn dump_seq(
-        buf: &mut Vec<u8>,
-        iter: std::slice::Iter<PyObjectRef>,
-        vm: &VirtualMachine,
-    ) -> PyResult<()> {
-        write_size(buf, iter.len(), vm)?;
-        // For each element, dump into binary, then add its length and value.
-        for element in iter {
-            dump_obj(buf, element.clone(), vm)?;
-        }
-        Ok(())
-    }
-
-    /// Dumping helper function to turn a value into bytes.
-    fn dump_obj(buf: &mut Vec<u8>, value: PyObjectRef, vm: &VirtualMachine) -> PyResult<()> {
-        if vm.is_none(&value) {
-            buf.push(Type::None as u8);
-        } else if value.is(vm.ctx.exceptions.stop_iteration) {
-            buf.push(Type::StopIter as u8);
-        } else if value.is(&vm.ctx.ellipsis) {
-            buf.push(Type::Ellipsis as u8);
-        } else {
-            match_class!(match value {
-                pyint @ PyInt => {
-                    if pyint.class().is(vm.ctx.types.bool_type) {
-                        let typ = if pyint.as_bigint().is_zero() {
-                            Type::False
-                        } else {
-                            Type::True
-                        };
-                        buf.push(typ as u8);
+    impl marshal::Dumpable for PyObjectRef {
+        type Error = DumpError;
+        type Constant = Literal;
+        fn with_dump<R>(
+            &self,
+            f: impl FnOnce(marshal::DumpableValue<'_, Self>) -> R,
+        ) -> Result<R, Self::Error> {
+            use marshal::DumpableValue::*;
+            if self.is(PyStopIteration::static_type()) {
+                return Ok(f(StopIter));
+            }
+            let ret = match_class!(match self {
+                PyNone => f(None),
+                PyEllipsis => f(Ellipsis),
+                ref pyint @ PyInt => {
+                    if self.class().is(PyBool::static_type()) {
+                        f(Boolean(!pyint.as_bigint().is_zero()))
                     } else {
-                        buf.push(Type::Int as u8);
-                        let (sign, int_bytes) = pyint.as_bigint().to_bytes_le();
-                        let mut len = int_bytes.len() as i32;
-                        if sign == Sign::Minus {
-                            len = -len;
-                        }
-                        buf.extend(len.to_le_bytes());
-                        buf.extend(int_bytes);
+                        f(Integer(pyint.as_bigint()))
                     }
                 }
-                pyfloat @ PyFloat => {
-                    buf.push(Type::Float as u8);
-                    buf.extend(pyfloat.to_f64().to_le_bytes());
+                ref pyfloat @ PyFloat => {
+                    f(Float(pyfloat.to_f64()))
                 }
-                pystr @ PyStr => {
-                    buf.push(if pystr.is_ascii() {
-                        Type::Ascii
-                    } else {
-                        Type::Unicode
-                    } as u8);
-                    write_size(buf, pystr.as_str().len(), vm)?;
-                    buf.extend(pystr.as_str().as_bytes());
+                ref pycomplex @ PyComplex => {
+                    f(Complex(pycomplex.to_complex64()))
                 }
-                pylist @ PyList => {
-                    buf.push(Type::List as u8);
-                    let pylist_items = pylist.borrow_vec();
-                    dump_seq(buf, pylist_items.iter(), vm)?;
+                ref pystr @ PyStr => {
+                    f(Str(pystr.as_str()))
                 }
-                pyset @ PySet => {
-                    buf.push(Type::Set as u8);
+                ref pylist @ PyList => {
+                    f(List(&pylist.borrow_vec()))
+                }
+                ref pyset @ PySet => {
                     let elements = pyset.elements();
-                    dump_seq(buf, elements.iter(), vm)?;
+                    f(Set(&elements))
                 }
-                pyfrozen @ PyFrozenSet => {
-                    buf.push(Type::FrozenSet as u8);
+                ref pyfrozen @ PyFrozenSet => {
                     let elements = pyfrozen.elements();
-                    dump_seq(buf, elements.iter(), vm)?;
+                    f(Frozenset(&elements))
                 }
-                pytuple @ PyTuple => {
-                    buf.push(Type::Tuple as u8);
-                    dump_seq(buf, pytuple.iter(), vm)?;
+                ref pytuple @ PyTuple => {
+                    f(Tuple(pytuple.as_slice()))
                 }
-                pydict @ PyDict => {
-                    buf.push(Type::Dict as u8);
-                    write_size(buf, pydict.len(), vm)?;
-                    for (key, value) in pydict {
-                        dump_obj(buf, key, vm)?;
-                        dump_obj(buf, value, vm)?;
-                    }
+                ref pydict @ PyDict => {
+                    let entries = pydict.into_iter().collect::<Vec<_>>();
+                    f(Dict(&entries))
                 }
-                bytes @ PyBytes => {
-                    buf.push(Type::Bytes as u8);
-                    let data = bytes.as_bytes();
-                    write_size(buf, data.len(), vm)?;
-                    buf.extend(data);
+                ref bytes @ PyBytes => {
+                    f(Bytes(bytes.as_bytes()))
                 }
-                bytes @ PyByteArray => {
-                    buf.push(Type::Bytes as u8);
-                    let data = bytes.borrow_buf();
-                    write_size(buf, data.len(), vm)?;
-                    buf.extend(&*data);
+                ref bytes @ PyByteArray => {
+                    f(Bytes(&bytes.borrow_buf()))
                 }
-                co @ PyCode => {
-                    buf.push(Type::Code as u8);
-                    let bytes = co.code.map_clone_bag(&bytecode::BasicBag).to_bytes();
-                    write_size(buf, bytes.len(), vm)?;
-                    buf.extend(bytes);
+                ref co @ PyCode => {
+                    f(Code(co))
                 }
-                _ => {
-                    return Err(vm.new_not_implemented_error(
-                        "TODO: not implemented yet or marshal unsupported type".to_owned(),
-                    ));
-                }
-            })
+                _ => return Err(DumpError),
+            });
+            Ok(ret)
         }
-        Ok(())
     }
 
     #[pyfunction]
@@ -211,8 +94,16 @@ mod decl {
         _version: OptionalArg<i32>,
         vm: &VirtualMachine,
     ) -> PyResult<PyBytes> {
+        use marshal::Dumpable;
         let mut buf = Vec::new();
-        dump_obj(&mut buf, value, vm)?;
+        value
+            .with_dump(|val| marshal::serialize_value(&mut buf, val))
+            .unwrap_or_else(Err)
+            .map_err(|DumpError| {
+                vm.new_not_implemented_error(
+                    "TODO: not implemented yet or marshal unsupported type".to_owned(),
+                )
+            })?;
         Ok(PyBytes::from(buf))
     }
 
@@ -228,38 +119,83 @@ mod decl {
         Ok(())
     }
 
-    /// Safely convert usize to 4 le bytes
-    fn write_size(buf: &mut Vec<u8>, x: usize, vm: &VirtualMachine) -> PyResult<()> {
-        // For marshalling we want to convert lengths to bytes. To save space
-        // we limit the size to u32 to keep marshalling smaller.
-        let n = u32::try_from(x).map_err(|_| {
-            vm.new_value_error("Size exceeds 2^32 capacity for marshaling.".to_owned())
-        })?;
-        buf.extend(n.to_le_bytes());
-        Ok(())
-    }
+    #[derive(Copy, Clone)]
+    struct PyMarshalBag<'a>(&'a VirtualMachine);
 
-    /// Read the next 4 bytes of a slice, read as u32, pass as usize.
-    /// Returns the rest of buffer with the value.
-    fn read_size<'a>(buf: &'a [u8], vm: &VirtualMachine) -> PyResult<(usize, &'a [u8])> {
-        if buf.len() < 4 {
-            return Err(too_short_error(vm));
+    impl<'a> marshal::MarshalBag for PyMarshalBag<'a> {
+        type Value = PyObjectRef;
+        fn make_bool(&self, value: bool) -> Self::Value {
+            self.0.ctx.new_bool(value).into()
         }
-        let (u32_bytes, rest) = buf.split_at(4);
-        let length = u32::from_le_bytes(u32_bytes.try_into().unwrap());
-        Ok((length as usize, rest))
-    }
-
-    /// Reads a list (or tuple) from a buffer.
-    fn load_seq<'b>(buf: &'b [u8], vm: &VirtualMachine) -> PyResult<(Vec<PyObjectRef>, &'b [u8])> {
-        let (len, mut buf) = read_size(buf, vm)?;
-        let mut elements: Vec<PyObjectRef> = Vec::new();
-        for _ in 0..len {
-            let (element, rest) = load_obj(buf, vm)?;
-            buf = rest;
-            elements.push(element);
+        fn make_none(&self) -> Self::Value {
+            self.0.ctx.none()
         }
-        Ok((elements, buf))
+        fn make_ellipsis(&self) -> Self::Value {
+            self.0.ctx.ellipsis()
+        }
+        fn make_float(&self, value: f64) -> Self::Value {
+            self.0.ctx.new_float(value).into()
+        }
+        fn make_complex(&self, value: Complex64) -> Self::Value {
+            self.0.ctx.new_complex(value).into()
+        }
+        fn make_str(&self, value: &str) -> Self::Value {
+            self.0.ctx.new_str(value).into()
+        }
+        fn make_bytes(&self, value: &[u8]) -> Self::Value {
+            self.0.ctx.new_bytes(value.to_vec()).into()
+        }
+        fn make_int(&self, value: BigInt) -> Self::Value {
+            self.0.ctx.new_int(value).into()
+        }
+        fn make_tuple(&self, elements: impl Iterator<Item = Self::Value>) -> Self::Value {
+            self.0.ctx.new_tuple(elements.collect()).into()
+        }
+        fn make_code(&self, code: CodeObject) -> Self::Value {
+            self.0.ctx.new_code(code).into()
+        }
+        fn make_stop_iter(&self) -> Result<Self::Value, marshal::MarshalError> {
+            Ok(self.0.ctx.exceptions.stop_iteration.to_owned().into())
+        }
+        fn make_list(
+            &self,
+            it: impl Iterator<Item = Self::Value>,
+        ) -> Result<Self::Value, marshal::MarshalError> {
+            Ok(self.0.ctx.new_list(it.collect()).into())
+        }
+        fn make_set(
+            &self,
+            it: impl Iterator<Item = Self::Value>,
+        ) -> Result<Self::Value, marshal::MarshalError> {
+            let vm = self.0;
+            let set = PySet::new_ref(&vm.ctx);
+            for elem in it {
+                set.add(elem, vm).unwrap()
+            }
+            Ok(set.into())
+        }
+        fn make_frozenset(
+            &self,
+            it: impl Iterator<Item = Self::Value>,
+        ) -> Result<Self::Value, marshal::MarshalError> {
+            let vm = self.0;
+            Ok(PyFrozenSet::from_iter(vm, it).unwrap().to_pyobject(vm))
+        }
+        fn make_dict(
+            &self,
+            it: impl Iterator<Item = (Self::Value, Self::Value)>,
+        ) -> Result<Self::Value, marshal::MarshalError> {
+            let vm = self.0;
+            let dict = vm.ctx.new_dict();
+            for (k, v) in it {
+                dict.set_item(&*k, v, vm).unwrap()
+            }
+            Ok(dict.into())
+        }
+        type ConstantBag = PyObjBag<'a>;
+        fn constant_bag(self) -> Self::ConstantBag {
+            PyObjBag(&self.0.ctx)
+        }
     }
 
     #[pyfunction]
@@ -267,128 +203,21 @@ mod decl {
         let buf = pybuffer.as_contiguous().ok_or_else(|| {
             vm.new_buffer_error("Buffer provided to marshal.loads() is not contiguous".to_owned())
         })?;
-        let (obj, _) = load_obj(&buf, vm)?;
-        Ok(obj)
-    }
-
-    fn load_obj<'b>(buf: &'b [u8], vm: &VirtualMachine) -> PyResult<(PyObjectRef, &'b [u8])> {
-        let (type_indicator, buf) = buf.split_first().ok_or_else(|| too_short_error(vm))?;
-        let typ = Type::try_from(*type_indicator)
-            .map_err(|_| vm.new_value_error("bad marshal data (unknown type code)".to_owned()))?;
-        let (obj, buf) = match typ {
-            Type::True => (true.to_pyobject(vm), buf),
-            Type::False => (false.to_pyobject(vm), buf),
-            Type::None => (vm.ctx.none(), buf),
-            Type::StopIter => (
-                vm.ctx.exceptions.stop_iteration.to_owned().to_pyobject(vm),
-                buf,
+        marshal::deserialize_value(&mut &buf[..], PyMarshalBag(vm)).map_err(|e| match e {
+            marshal::MarshalError::Eof => vm.new_exception_msg(
+                vm.ctx.exceptions.eof_error.to_owned(),
+                "marshal data too short".to_owned(),
             ),
-            Type::Ellipsis => (vm.ctx.ellipsis(), buf),
-            Type::Int => {
-                if buf.len() < 4 {
-                    return Err(too_short_error(vm));
-                }
-                let (len_bytes, buf) = buf.split_at(4);
-                let len = i32::from_le_bytes(len_bytes.try_into().unwrap());
-                let (sign, len) = if len < 0 {
-                    (Sign::Minus, (-len) as usize)
-                } else {
-                    (Sign::Plus, len as usize)
-                };
-                if buf.len() < len {
-                    return Err(too_short_error(vm));
-                }
-                let (bytes, buf) = buf.split_at(len);
-                let int = BigInt::from_bytes_le(sign, bytes);
-                (int.to_pyobject(vm), buf)
+            marshal::MarshalError::InvalidBytecode => {
+                vm.new_value_error("Couldn't deserialize python bytecode".to_owned())
             }
-            Type::Float => {
-                if buf.len() < 8 {
-                    return Err(too_short_error(vm));
-                }
-                let (bytes, buf) = buf.split_at(8);
-                let number = f64::from_le_bytes(bytes.try_into().unwrap());
-                (vm.ctx.new_float(number).into(), buf)
+            marshal::MarshalError::InvalidUtf8 => {
+                vm.new_value_error("invalid utf8 in marshalled string".to_owned())
             }
-            Type::Ascii => {
-                let (len, buf) = read_size(buf, vm)?;
-                if buf.len() < len {
-                    return Err(too_short_error(vm));
-                }
-                let (bytes, buf) = buf.split_at(len);
-                let s = String::from_utf8(bytes.to_vec())
-                    .map_err(|_| vm.new_value_error("invalid utf8 data".to_owned()))?;
-                (s.to_pyobject(vm), buf)
+            marshal::MarshalError::BadType => {
+                vm.new_value_error("bad marshal data (unknown type code)".to_owned())
             }
-            Type::Unicode => {
-                let (len, buf) = read_size(buf, vm)?;
-                if buf.len() < len {
-                    return Err(too_short_error(vm));
-                }
-                let (bytes, buf) = buf.split_at(len);
-                let s = String::from_utf8(bytes.to_vec())
-                    .map_err(|_| vm.new_value_error("invalid utf8 data".to_owned()))?;
-                (s.to_pyobject(vm), buf)
-            }
-            Type::List => {
-                let (elements, buf) = load_seq(buf, vm)?;
-                (vm.ctx.new_list(elements).into(), buf)
-            }
-            Type::Set => {
-                let (elements, buf) = load_seq(buf, vm)?;
-                let set = PySet::new_ref(&vm.ctx);
-                for element in elements {
-                    set.add(element, vm)?;
-                }
-                (set.to_pyobject(vm), buf)
-            }
-            Type::FrozenSet => {
-                let (elements, buf) = load_seq(buf, vm)?;
-                let set = PyFrozenSet::from_iter(vm, elements.into_iter())?;
-                (set.to_pyobject(vm), buf)
-            }
-            Type::Tuple => {
-                let (elements, buf) = load_seq(buf, vm)?;
-                (vm.ctx.new_tuple(elements).into(), buf)
-            }
-            Type::Dict => {
-                let (len, mut buf) = read_size(buf, vm)?;
-                let dict = vm.ctx.new_dict();
-                for _ in 0..len {
-                    let (key, rest) = load_obj(buf, vm)?;
-                    let (value, rest) = load_obj(rest, vm)?;
-                    buf = rest;
-                    dict.set_item(key.as_object(), value, vm)?;
-                }
-                (dict.into(), buf)
-            }
-            Type::Bytes => {
-                // Following CPython, after marshaling, byte arrays are converted into bytes.
-                let (len, buf) = read_size(buf, vm)?;
-                if buf.len() < len {
-                    return Err(too_short_error(vm));
-                }
-                let (bytes, buf) = buf.split_at(len);
-                (vm.ctx.new_bytes(bytes.to_vec()).into(), buf)
-            }
-            Type::Code => {
-                // If prefix is not identifiable, assume CodeObject, error out if it doesn't match.
-                let (len, buf) = read_size(buf, vm)?;
-                if buf.len() < len {
-                    return Err(too_short_error(vm));
-                }
-                let (bytes, buf) = buf.split_at(len);
-                let code = bytecode::CodeObject::from_bytes(bytes).map_err(|e| match e {
-                    bytecode::CodeDeserializeError::Eof => vm.new_exception_msg(
-                        vm.ctx.exceptions.eof_error.to_owned(),
-                        "End of file while deserializing bytecode".to_owned(),
-                    ),
-                    _ => vm.new_value_error("Couldn't deserialize python bytecode".to_owned()),
-                })?;
-                (vm.ctx.new_code(code).into(), buf)
-            }
-        };
-        Ok((obj, buf))
+        })
     }
 
     #[pyfunction]

--- a/wasm/lib/Cargo.toml
+++ b/wasm/lib/Cargo.toml
@@ -21,7 +21,7 @@ rustpython-parser = { path = "../../compiler/parser" }
 rustpython-pylib = { path = "../../pylib", default-features = false, optional = true }
 rustpython-stdlib = { path = "../../stdlib", default-features = false, optional = true }
 # make sure no threading! otherwise wasm build will fail
-rustpython-vm = { path = "../../vm", default-features = false, features = ["compiler", "encodings"] }
+rustpython-vm = { path = "../../vm", default-features = false, features = ["compiler", "encodings", "serde"] }
 
 serde = { workspace = true }
 


### PR DESCRIPTION
Switch from bincode to a custom marshal format. This totally removes `serde` as a dependency from the rustpython binary, improving compile times and also enabling a follow-up change I'm working on that deserializes from the marshal data straight into a `CodeObject<rustpython_vm::builtins::code::Literal>`, without the intermediary `CodeObject<bytecode::ConstantData>`.

Supersedes and
closes #4125 
closes #3563