### PR TITLE
Switch `eprintln!` to `TODO` when handling `feature_version`

### DIFF
--- a/vm/src/stdlib/builtins.rs
+++ b/vm/src/stdlib/builtins.rs
@@ -118,7 +118,7 @@ mod builtins {
             use crate::{class::PyClassImpl, stdlib::ast};
 
             if args._feature_version.is_present() {
-                eprintln!("TODO: compile() got `_feature_version` but ignored");
+                // TODO: add support for _feature_version
             }
 
             let mode_str = args.mode.as_str();


### PR DESCRIPTION
Switch `eprintln!` to `TODO` when handling `feature_version` in `builtins.rs`. Solves issue #4515.