### PR TITLE
Ensure socket.gethostbyname_ex only returns IPv4 addresses

### DIFF
--- a/Lib/test/test_urllib2.py
+++ b/Lib/test/test_urllib2.py
@@ -782,8 +782,6 @@ class HandlerTests(unittest.TestCase):
             self.assertEqual(headers.get("Content-type"), mimetype)
             self.assertEqual(int(headers["Content-length"]), len(data))
 
-    # TODO: RUSTPYTHON
-    @unittest.expectedFailure
     def test_file(self):
         import email.utils
         h = urllib.request.FileHandler()

--- a/stdlib/src/socket.rs
+++ b/stdlib/src/socket.rs
@@ -1835,7 +1835,7 @@ mod _socket {
         name: PyStrRef,
         vm: &VirtualMachine,
     ) -> Result<(String, PyListRef, PyListRef), IoOrPyException> {
-        let addr = get_addr(vm, name, c::AF_UNSPEC)?;
+        let addr = get_addr(vm, name, c::AF_INET)?;
         let (hostname, _) = dns_lookup::getnameinfo(&addr, 0)
             .map_err(|e| convert_socket_error(vm, e, SocketError::HError))?;
         Ok((


### PR DESCRIPTION
The `gethostbyname_ex` function of the `socket` module is only supposed to return IPv4 address as per the documentation: https://docs.python.org/3/library/socket.html#socket.gethostbyname_ex

This can also be seen in the CPython code: https://github.com/python/cpython/blob/c00faf79438cc7f0d98af2679c695f747e4369a3/Modules/socketmodule.c#L5882

This commit replace `AF_UNSPEC` with `AF_INET` so that only IPv4 are returned. This also fixes the test issue I had in PR #4526 .

I don't know if the test will pass on other platforms so I'm opening this PR to see the test results 🙂 