### PR TITLE
Implemented the block_size attribute for PyHasher

### DIFF
--- a/Lib/test/test_hmac.py
+++ b/Lib/test/test_hmac.py
@@ -331,14 +331,10 @@ class TestVectorsTestCase(unittest.TestCase):
     def test_sha256_rfc4231(self):
         self._rfc4231_test_cases(hashlib.sha256, 'sha256', 32, 64)
 
-    # TODO: RUSTPYTHON
-    @unittest.expectedFailure
     @hashlib_helper.requires_hashdigest('sha384', openssl=True)
     def test_sha384_rfc4231(self):
         self._rfc4231_test_cases(hashlib.sha384, 'sha384', 48, 128)
 
-    # TODO: RUSTPYTHON
-    @unittest.expectedFailure
     @hashlib_helper.requires_hashdigest('sha512', openssl=True)
     def test_sha512_rfc4231(self):
         self._rfc4231_test_cases(hashlib.sha512, 'sha512', 64, 128)


### PR DESCRIPTION
Following PR #4526, I decided to investigate the two failing tests.

The `PyHasher` implementation was missing the `block_size` attribute which is used by the `hmac.py` code. This code was generating a warning and defaulting to an arbitrary block size: https://github.com/RustPython/RustPython/blob/ef873b4b606f0a58e3640b6186416631fdeead26/Lib/hmac.py#L84-L95
This caused the `sha2_384` and `sha2_512` HMAC to use  an incorrect block size and generate incorrect outputs.

In the process of implementing the block size property, I also simplified the `HashWrapper` constructor to use a generic type parameter.