### PR TITLE
Always wrap token streams in `SoftKeywordTransformer`

### DIFF
--- a/compiler/parser/src/lib.rs
+++ b/compiler/parser/src/lib.rs
@@ -131,5 +131,5 @@ mod string;
 #[rustfmt::skip]
 mod python;
 mod context;
-mod soft_keywords;
+pub mod soft_keywords;
 pub mod token;

--- a/compiler/parser/src/lib.rs
+++ b/compiler/parser/src/lib.rs
@@ -66,27 +66,29 @@
 //! For example, to get a stream of tokens from a given string, one could do this:
 //!
 //! ```
+//! use rustpython_parser::mode::Mode;
 //! use rustpython_parser::lexer::make_tokenizer;
 //!
 //! let python_source = r#"
 //! def is_odd(i):
 //!     return bool(i & 1)
 //! "#;
-//! let mut tokens = make_tokenizer(python_source);
+//! let mut tokens = make_tokenizer(python_source, Mode::Module);
 //! assert!(tokens.all(|t| t.is_ok()));
 //! ```
 //!
 //! These tokens can be directly fed into the parser to generate an AST:
 //!
 //! ```
-//! use rustpython_parser::parser::{parse_tokens, Mode};
 //! use rustpython_parser::lexer::make_tokenizer;
+//! use rustpython_parser::mode::Mode;
+//! use rustpython_parser::parser::parse_tokens;
 //!
 //! let python_source = r#"
 //! def is_odd(i):
 //!    return bool(i & 1)
 //! "#;
-//! let tokens = make_tokenizer(python_source);
+//! let tokens = make_tokenizer(python_source, Mode::Module);
 //! let ast = parse_tokens(tokens, Mode::Module, "<embedded>");
 //!
 //! assert!(ast.is_ok());
@@ -131,5 +133,5 @@ mod string;
 #[rustfmt::skip]
 mod python;
 mod context;
-pub mod soft_keywords;
+mod soft_keywords;
 pub mod token;

--- a/compiler/parser/src/soft_keywords.rs
+++ b/compiler/parser/src/soft_keywords.rs
@@ -19,8 +19,8 @@ pub struct SoftKeywordTransformer<I>
 where
     I: Iterator<Item = LexResult>,
 {
-    pub underlying: MultiPeek<I>,
-    pub start_of_line: bool,
+    underlying: MultiPeek<I>,
+    start_of_line: bool,
 }
 
 impl<I> SoftKeywordTransformer<I>
@@ -84,14 +84,18 @@ where
 
         self.start_of_line = next.as_ref().map_or(false, |lex_result| {
             lex_result.as_ref().map_or(false, |(_, tok, _)| {
-                matches!(
-                    tok,
-                    Tok::StartModule
-                        | Tok::StartInteractive
-                        | Tok::Newline
-                        | Tok::Indent
-                        | Tok::Dedent
-                )
+                if matches!(tok, Tok::NonLogicalNewline | Tok::Comment { .. }) {
+                    self.start_of_line
+                } else {
+                    matches!(
+                        tok,
+                        Tok::StartModule
+                            | Tok::StartInteractive
+                            | Tok::Newline
+                            | Tok::Indent
+                            | Tok::Dedent
+                    )
+                }
             })
         });
 


### PR DESCRIPTION
In Ruff, we often generate token streams outside of the parse step. Right now, that's causing failures for lint rules in certain cases that rely on the token stream rather than the AST. This PR always wraps the lexer in the soft keyword transformer. The primary downside is that we now have to thread through the `Mode` to all lexer calls.