### PR TITLE
Mark RustPython as Python 3.11

### DIFF
--- a/vm/src/version.rs
+++ b/vm/src/version.rs
@@ -4,9 +4,9 @@
 use chrono::{prelude::DateTime, Local};
 use std::time::{Duration, UNIX_EPOCH};
 
-// = 3.10.0alpha
+// = 3.11.0alpha
 pub const MAJOR: usize = 3;
-pub const MINOR: usize = 10;
+pub const MINOR: usize = 11;
 pub const MICRO: usize = 0;
 pub const RELEASELEVEL: &str = "alpha";
 pub const RELEASELEVEL_N: usize = 0xA;


### PR DESCRIPTION
forgot to update when changing CI in #4517 