### PR TITLE
Satisfy safety conditions for std::slice::from_raw_parts. Fixes #4575.

### DIFF
--- a/stdlib/src/array.rs
+++ b/stdlib/src/array.rs
@@ -215,8 +215,10 @@ mod array {
                             // support are valid
                             let ptr = b.as_ptr() as *const $t;
                             let ptr_len = b.len() / std::mem::size_of::<$t>();
-                            let slice = unsafe { std::slice::from_raw_parts(ptr, ptr_len) };
-                            v.extend_from_slice(slice);
+                            if ptr_len > 0 {
+                                let slice = unsafe { std::slice::from_raw_parts(ptr, ptr_len) };
+                                v.extend_from_slice(slice);
+                            }
                         })*
                     }
                 }

--- a/stdlib/src/array.rs
+++ b/stdlib/src/array.rs
@@ -213,9 +213,9 @@ mod array {
                         $(ArrayContentType::$n(v) => {
                             // safe because every configuration of bytes for the types we
                             // support are valid
-                            let ptr = b.as_ptr() as *const $t;
-                            let ptr_len = b.len() / std::mem::size_of::<$t>();
-                            if ptr_len > 0 {
+                            if b.len() > 0 {
+                                let ptr = b.as_ptr() as *const $t;
+                                let ptr_len = b.len() / std::mem::size_of::<$t>();
                                 let slice = unsafe { std::slice::from_raw_parts(ptr, ptr_len) };
                                 v.extend_from_slice(slice);
                             }


### PR DESCRIPTION
Thanks to @youknowone 's suggestion, I was able to fix the bug I reported. Thank you so much!