### PR TITLE
Always load __debug__ as a const.

### DIFF
--- a/Lib/test/test_compile.py
+++ b/Lib/test/test_compile.py
@@ -31,8 +31,6 @@ class TestSpecifics(unittest.TestCase):
         compile("hi\r\nstuff\r\ndef f():\n    pass\r", "<test>", "exec")
         compile("this_is\rreally_old_mac\rdef f():\n    pass", "<test>", "exec")
 
-    # TODO: RUSTPYTHON
-    @unittest.expectedFailure
     def test_debug_assignment(self):
         # catch assignments to __debug__
         self.assertRaises(SyntaxError, compile, '__debug__ = 1', '?', 'single')

--- a/compiler/codegen/src/compile.rs
+++ b/compiler/codegen/src/compile.rs
@@ -500,6 +500,14 @@ impl Compiler {
             // // TODO: is this right?
             // SymbolScope::Unknown => NameOpType::Global,
         };
+
+        if NameUsage::Load == usage && name == "__debug__" {
+            self.emit_constant(ConstantData::Boolean {
+                value: self.opts.optimize == 0,
+            });
+            return Ok(());
+        }
+
         let mut idx = cache
             .get_index_of(name.as_ref())
             .unwrap_or_else(|| cache.insert_full(name.into_owned()).0);


### PR DESCRIPTION
The final case from #2979 that wasn't handled.