### PR TITLE
Use proper locations for sub-expressions in constant matches

### DIFF
--- a/compiler/parser/python.lalrpop
+++ b/compiler/parser/python.lalrpop
@@ -576,6 +576,41 @@ StarPattern: ast::PatternKind = {
     },
 }
 
+ConstantAtom: ast::Expr = {
+    <location:@L> <value:Constant> <end_location:@R> => ast::Expr {
+        location,
+        end_location: Some(end_location),
+        custom: (),
+        node: ast::ExprKind::Constant { value, kind: None }
+    },
+}
+
+ConstantExpr: ast::Expr = {
+    ConstantAtom,
+    <location:@L> "-" <operand:ConstantAtom> <end_location:@R> => ast::Expr {
+        location,
+        end_location: Some(end_location),
+        custom: (),
+        node: ast::ExprKind::UnaryOp {
+            op: ast::Unaryop::USub,
+            operand: Box::new(operand)
+        }
+    },
+}
+
+AddOpExpr: ast::Expr = {
+    <location:@L> <left:ConstantExpr> <op:AddOp> <right:ConstantAtom> <end_location:@R> => ast::Expr {
+        location,
+        end_location: Some(end_location),
+        custom: (),
+        node: ast::ExprKind::BinOp {
+            left: Box::new(left),
+            op,
+            right: Box::new(right),
+        }
+    },
+}
+
 LiteralPattern: ast::PatternKind = {
     "None" => ast::PatternKind::MatchSingleton {
         value: ast::Constant::None
@@ -586,81 +621,11 @@ LiteralPattern: ast::PatternKind = {
     "False" => ast::PatternKind::MatchSingleton {
         value: false.into()
     },
-    <location:@L> <value:Constant> <end_location:@R> => ast::PatternKind::MatchValue {
-        value: Box::new(ast::Expr {
-            location,
-            end_location: Some(end_location),
-            custom: (),
-            node: ast::ExprKind::Constant { value, kind: None }
-        })
+    <location:@L> <value:ConstantExpr> <end_location:@R> => ast::PatternKind::MatchValue {
+        value: Box::new(value)
     },
-    <location:@L> "-" <value:Constant> <end_location:@R> => ast::PatternKind::MatchValue {
-        value: Box::new(ast::Expr {
-            location,
-            end_location: Some(end_location),
-            custom: (),
-            node: ast::ExprKind::UnaryOp {
-                op: ast::Unaryop::USub,
-                operand: Box::new(ast::Expr {
-                    location,
-                    end_location: Some(end_location),
-                    custom: (),
-                    node: ast::ExprKind::Constant { value, kind: None }
-                })
-            }
-        })
-    },
-    <location:@L> <left:Constant> <op:AddOp> <right:Constant> <end_location:@R> => ast::PatternKind::MatchValue {
-        value: Box::new(ast::Expr {
-            location,
-            end_location: Some(end_location),
-            custom: (),
-            node: ast::ExprKind::BinOp {
-                left: Box::new(ast::Expr {
-                    location,
-                    end_location: Some(end_location),
-                    custom: (),
-                    node: ast::ExprKind::Constant { value: left, kind: None }
-                }),
-                op,
-                right: Box::new(ast::Expr {
-                    location,
-                    end_location: Some(end_location),
-                    custom: (),
-                    node: ast::ExprKind::Constant { value: right, kind: None }
-                }),
-            }
-        })
-    },
-    <location:@L> "-" <left:Constant> <op:AddOp> <right:Constant> <end_location:@R> => ast::PatternKind::MatchValue {
-        value: Box::new(ast::Expr {
-            location,
-            end_location: Some(end_location),
-            custom: (),
-            node: ast::ExprKind::BinOp {
-                left: Box::new(ast::Expr {
-                    location,
-                    end_location: Some(end_location),
-                    custom: (),
-                    node: ast::ExprKind::UnaryOp {
-                        op: ast::Unaryop::USub,
-                        operand: Box::new(ast::Expr {
-                            location,
-                            end_location: Some(end_location),
-                            custom: (),
-                            node: ast::ExprKind::Constant { value: left, kind: None }
-                        })
-                    }
-                }),
-                op,
-                right: Box::new(ast::Expr {
-                    location,
-                    end_location: Some(end_location),
-                    custom: (),
-                    node: ast::ExprKind::Constant { value: right, kind: None }
-                }),
-            }
-        })
+    <location:@L> <value:AddOpExpr> => ast::PatternKind::MatchValue {
+        value: Box::new(value)
     },
     <location:@L> <s:(@L string @R)+> =>? Ok(ast::PatternKind::MatchValue {
         value: Box::new(parse_strings(s)?)
@@ -713,6 +678,9 @@ ValuePattern: ast::PatternKind = {
 }
 
 MappingKey: ast::Expr = {
+    ConstantExpr,
+    AddOpExpr,
+    MatchNameOrAttr,
     <location:@L> "None" <end_location:@R> => ast::Expr {
         location,
         end_location: Some(end_location),
@@ -740,76 +708,7 @@ MappingKey: ast::Expr = {
             kind: None,
         },
     },
-    <location:@L> <value:Constant> <end_location:@R> => ast::Expr {
-        location,
-        end_location: Some(end_location),
-        custom: (),
-        node: ast::ExprKind::Constant { value, kind: None }
-    },
-    <location:@L> "-" <value:Constant> <end_location:@R> => ast::Expr {
-        location,
-        end_location: Some(end_location),
-        custom: (),
-        node: ast::ExprKind::UnaryOp {
-            op: ast::Unaryop::USub,
-            operand: Box::new(ast::Expr {
-                location,
-                end_location: Some(end_location),
-                custom: (),
-                node: ast::ExprKind::Constant { value, kind: None }
-            })
-        }
-    },
-    <location:@L> <left:Constant> <op:AddOp> <right:Constant> <end_location:@R> => ast::Expr {
-        location,
-        end_location: Some(end_location),
-        custom: (),
-        node: ast::ExprKind::BinOp {
-            left: Box::new(ast::Expr {
-                location,
-                end_location: Some(end_location),
-                custom: (),
-                node: ast::ExprKind::Constant { value: left, kind: None }
-            }),
-            op,
-            right: Box::new(ast::Expr {
-                location,
-                end_location: Some(end_location),
-                custom: (),
-                node: ast::ExprKind::Constant { value: right, kind: None }
-            }),
-        }
-    },
-    <location:@L> "-" <left:Constant> <op:AddOp> <right:Constant> <end_location:@R> => ast::Expr {
-        location,
-        end_location: Some(end_location),
-        custom: (),
-        node: ast::ExprKind::BinOp {
-            left: Box::new(ast::Expr {
-                location,
-                end_location: Some(end_location),
-                custom: (),
-                node: ast::ExprKind::UnaryOp {
-                    op: ast::Unaryop::USub,
-                    operand: Box::new(ast::Expr {
-                        location,
-                        end_location: Some(end_location),
-                        custom: (),
-                        node: ast::ExprKind::Constant { value: left, kind: None }
-                    })
-                }
-            }),
-            op,
-            right: Box::new(ast::Expr {
-                location,
-                end_location: Some(end_location),
-                custom: (),
-                node: ast::ExprKind::Constant { value: right, kind: None }
-            }),
-        }
-    },
     <location:@L> <s:(@L string @R)+> =>? Ok(parse_strings(s)?),
-    MatchNameOrAttr,
 }
 
 MatchMappingEntry: (ast::Expr, ast::Pattern) = {

--- a/compiler/parser/src/snapshots/rustpython_parser__parser__tests__patma.snap
+++ b/compiler/parser/src/snapshots/rustpython_parser__parser__tests__patma.snap
@@ -65,7 +65,7 @@ expression: parse_ast
                                     operand: Located {
                                         location: Location {
                                             row: 5,
-                                            column: 9,
+                                            column: 10,
                                         },
                                         end_location: Some(
                                             Location {
@@ -2161,7 +2161,7 @@ expression: parse_ast
                                         end_location: Some(
                                             Location {
                                                 row: 41,
-                                                column: 21,
+                                                column: 13,
                                             },
                                         ),
                                         custom: (),
@@ -2176,7 +2176,7 @@ expression: parse_ast
                                     right: Located {
                                         location: Location {
                                             row: 41,
-                                            column: 9,
+                                            column: 16,
                                         },
                                         end_location: Some(
                                             Location {
@@ -2320,7 +2320,7 @@ expression: parse_ast
                                     operand: Located {
                                         location: Location {
                                             row: 45,
-                                            column: 9,
+                                            column: 10,
                                         },
                                         end_location: Some(
                                             Location {
@@ -4738,7 +4738,7 @@ expression: parse_ast
                                         end_location: Some(
                                             Location {
                                                 row: 95,
-                                                column: 22,
+                                                column: 14,
                                             },
                                         ),
                                         custom: (),
@@ -4747,12 +4747,12 @@ expression: parse_ast
                                             operand: Located {
                                                 location: Location {
                                                     row: 95,
-                                                    column: 9,
+                                                    column: 10,
                                                 },
                                                 end_location: Some(
                                                     Location {
                                                         row: 95,
-                                                        column: 22,
+                                                        column: 14,
                                                     },
                                                 ),
                                                 custom: (),
@@ -4769,7 +4769,7 @@ expression: parse_ast
                                     right: Located {
                                         location: Location {
                                             row: 95,
-                                            column: 9,
+                                            column: 17,
                                         },
                                         end_location: Some(
                                             Location {


### PR DESCRIPTION
This was an oversight in the initial implementation: I used the `MatchValue` location for _all_ sub-expressions (so, e.g., if you had `case -0j`, we used the range of `-0j` for the sub-expressions `0j`, which is incorrect). Now, we use the correct ranges for every sub-expression in the match.
