### PR TITLE
Rework frozen modules and directly deserialize to CodeObject<Literal>

### DIFF
--- a/jit/tests/common.rs
+++ b/jit/tests/common.rs
@@ -165,6 +165,7 @@ macro_rules! jit_function {
                 crate_name = "rustpython_compiler_core",
                 source = $($t)*
             );
+            let code = code.decode(rustpython_compiler_core::BasicBag);
             let mut machine = $crate::common::StackMachine::new();
             machine.run(code);
             machine.get_function(stringify!($func_name)).compile()

--- a/pylib/src/lib.rs
+++ b/pylib/src/lib.rs
@@ -10,6 +10,5 @@ pub const LIB_PATH: &str = match option_env!("win_lib_path") {
 };
 
 #[cfg(feature = "freeze-stdlib")]
-pub fn frozen_stdlib() -> impl Iterator<Item = (String, rustpython_compiler_core::FrozenModule)> {
-    rustpython_derive::py_freeze!(dir = "./Lib", crate_name = "rustpython_compiler_core")
-}
+pub const FROZEN_STDLIB: &rustpython_compiler_core::frozen_lib::FrozenLib =
+    rustpython_derive::py_freeze!(dir = "./Lib", crate_name = "rustpython_compiler_core");

--- a/src/interpreter.rs
+++ b/src/interpreter.rs
@@ -41,7 +41,7 @@ pub fn init_stdlib(vm: &mut VirtualMachine) {
 
     // if we're on freeze-stdlib, the core stdlib modules will be included anyway
     #[cfg(feature = "freeze-stdlib")]
-    vm.add_frozen(rustpython_pylib::frozen_stdlib());
+    vm.add_frozen(rustpython_pylib::FROZEN_STDLIB);
 
     #[cfg(not(feature = "freeze-stdlib"))]
     {

--- a/vm/src/frozen.rs
+++ b/vm/src/frozen.rs
@@ -1,13 +1,10 @@
-use crate::bytecode::FrozenModule;
+use crate::bytecode::frozen_lib::FrozenModule;
 
-pub fn core_frozen_inits() -> impl Iterator<Item = (String, FrozenModule)> {
+pub fn core_frozen_inits() -> impl Iterator<Item = (&'static str, FrozenModule)> {
     let iter = std::iter::empty();
     macro_rules! ext_modules {
-        ($iter:ident, ($modules:expr)) => {
-            let $iter = $iter.chain($modules);
-        };
         ($iter:ident, $($t:tt)*) => {
-            ext_modules!($iter, (py_freeze!($($t)*)))
+            let $iter = $iter.chain(py_freeze!($($t)*));
         };
     }
 
@@ -23,10 +20,8 @@ pub fn core_frozen_inits() -> impl Iterator<Item = (String, FrozenModule)> {
     // Includes _importlib_bootstrap and _importlib_bootstrap_external
     ext_modules!(
         iter,
-        (rustpython_derive::py_freeze!(
-            dir = "./Lib/python_builtins",
-            crate_name = "rustpython_compiler_core"
-        ))
+        dir = "./Lib/python_builtins",
+        crate_name = "rustpython_compiler_core"
     );
 
     // core stdlib Python modules that the vm calls into, but are still used in Python
@@ -34,10 +29,8 @@ pub fn core_frozen_inits() -> impl Iterator<Item = (String, FrozenModule)> {
     #[cfg(not(feature = "freeze-stdlib"))]
     ext_modules!(
         iter,
-        (rustpython_derive::py_freeze!(
-            dir = "./Lib/core_modules",
-            crate_name = "rustpython_compiler_core"
-        ))
+        dir = "./Lib/core_modules",
+        crate_name = "rustpython_compiler_core"
     );
 
     iter

--- a/vm/src/import.rs
+++ b/vm/src/import.rs
@@ -77,7 +77,7 @@ pub fn make_frozen(vm: &VirtualMachine, name: &str) -> PyResult<PyRef<PyCode>> {
         vm.state.frozen.get(name).ok_or_else(|| {
             vm.new_import_error(format!("No such frozen object named {name}"), name)
         })?;
-    Ok(vm.ctx.new_code(frozen.code.clone()))
+    Ok(vm.ctx.new_code(frozen.code))
 }
 
 pub fn import_frozen(vm: &VirtualMachine, module_name: &str) -> PyResult {

--- a/vm/src/vm/mod.rs
+++ b/vm/src/vm/mod.rs
@@ -21,7 +21,7 @@ use crate::{
         tuple::{PyTuple, PyTupleTyped},
         PyBaseExceptionRef, PyDictRef, PyInt, PyList, PyModule, PyStrInterned, PyStrRef, PyTypeRef,
     },
-    bytecode,
+    bytecode::frozen_lib::FrozenModule,
     codecs::CodecsRegistry,
     common::{hash::HashSecret, lock::PyMutex, rc::PyRc},
     convert::ToPyObject,
@@ -88,7 +88,7 @@ struct ExceptionStack {
 pub struct PyGlobalState {
     pub settings: Settings,
     pub module_inits: stdlib::StdlibMap,
-    pub frozen: HashMap<String, bytecode::FrozenModule, ahash::RandomState>,
+    pub frozen: HashMap<&'static str, FrozenModule, ahash::RandomState>,
     pub stacksize: AtomicCell<usize>,
     pub thread_count: AtomicCell<usize>,
     pub hash_secret: HashSecret,
@@ -330,7 +330,7 @@ impl VirtualMachine {
     /// Can only be used in the initialization closure passed to [`Interpreter::with_init`]
     pub fn add_frozen<I>(&mut self, frozen: I)
     where
-        I: IntoIterator<Item = (String, bytecode::FrozenModule)>,
+        I: IntoIterator<Item = (&'static str, FrozenModule)>,
     {
         self.state_mut().frozen.extend(frozen);
     }

--- a/wasm/lib/src/vm_class.rs
+++ b/wasm/lib/src/vm_class.rs
@@ -46,7 +46,7 @@ impl StoredVirtualMachine {
             vm.add_native_modules(rustpython_stdlib::get_module_inits());
 
             #[cfg(feature = "freeze-stdlib")]
-            vm.add_frozen(rustpython_pylib::frozen_stdlib());
+            vm.add_frozen(rustpython_pylib::FROZEN_STDLIB);
 
             vm.wasm_id = Some(id);
 


### PR DESCRIPTION
Now frozen modules are stored as lz4-compressed in static memory until they are imported, which should help with memory usage in a freeze-stdlib environment (and the size increase from less efficient(?) compression due to potentially less dict-sharing(?? i have no clue how compression algorithms actually work) should hopefully not be too bad)
