### PR TITLE
Pin `youknowone/unicode_names2` to a specific revision

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2916,7 +2916,7 @@ checksum = "f962df74c8c05a667b5ee8bcf162993134c104e96440b663c8daa176dc772d8c"
 [[package]]
 name = "unicode_names2"
 version = "0.6.0"
-source = "git+https://github.com/youknowone/unicode_names2.git?tag=v0.6.0+character-alias#4ce16aa85cbcdd9cc830410f1a72ef9a235f2fde"
+source = "git+https://github.com/youknowone/unicode_names2.git?rev=4ce16aa85cbcdd9cc830410f1a72ef9a235f2fde#4ce16aa85cbcdd9cc830410f1a72ef9a235f2fde"
 dependencies = [
  "phf",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -55,7 +55,7 @@ static_assertions = "1.1"
 syn = "1.0.91"
 thiserror = "1.0"
 thread_local = "1.1.4"
-unicode_names2 = { version = "0.6.0", git = "https://github.com/youknowone/unicode_names2.git", tag = "v0.6.0+character-alias" }
+unicode_names2 = { version = "0.6.0", git = "https://github.com/youknowone/unicode_names2.git", rev = "4ce16aa85cbcdd9cc830410f1a72ef9a235f2fde" }
 widestring = "0.5.1"
 
 [features]


### PR DESCRIPTION
This avoids the `Updating git repository `https://github.com/youknowone/unicode_names2.git`` on every Cargo command.