### PR TITLE
Add optional serde dependency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2022,6 +2022,7 @@ dependencies = [
  "lz4_flex",
  "num-bigint",
  "num-complex",
+ "serde",
 ]
 
 [[package]]
@@ -2091,6 +2092,7 @@ dependencies = [
  "rustc-hash",
  "rustpython-ast",
  "rustpython-compiler-core",
+ "serde",
  "tiny-keccak",
  "unic-emoji-char",
  "unic-ucd-ident",

--- a/compiler/core/Cargo.toml
+++ b/compiler/core/Cargo.toml
@@ -13,5 +13,6 @@ bstr = { workspace = true }
 itertools = { workspace = true }
 num-bigint = { workspace = true }
 num-complex = { workspace = true }
+serde = { version = "1.0.133", optional = true, default-features = false }
 
 lz4_flex = "0.9.2"

--- a/compiler/core/src/location.rs
+++ b/compiler/core/src/location.rs
@@ -1,5 +1,9 @@
+#[cfg(feature = "serde")]
+use serde::{Deserialize, Serialize};
+
 /// Sourcecode location.
 #[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct Location {
     pub(super) row: u32,
     pub(super) column: u32,

--- a/compiler/parser/Cargo.toml
+++ b/compiler/parser/Cargo.toml
@@ -10,6 +10,7 @@ edition = "2021"
 
 [features]
 default = ["lalrpop"]  # removing this causes potential build failure
+serde = ["dep:serde", "rustpython-compiler-core/serde"]
 
 [build-dependencies]
 anyhow = { workspace = true }
@@ -33,6 +34,7 @@ unic-ucd-ident  = "0.9.0"
 lalrpop-util = "0.19.8"
 phf = "0.11.1"
 rustc-hash = "1.1.0"
+serde = { version = "1.0.133", optional = true, default-features = false }
 
 [dev-dependencies]
 insta = { workspace = true }


### PR DESCRIPTION
I mostly followed the way that Rome does this in [`rome_rowan`](https://github.com/rome/tools/blob/main/crates/rome_rowan/Cargo.toml), which presumedly comes from Rowan initially.