### PR TITLE
Implement Number Protocol for `PyBool`

### DIFF
--- a/vm/src/builtins/bool.rs
+++ b/vm/src/builtins/bool.rs
@@ -1,11 +1,19 @@
 use super::{PyInt, PyStrRef, PyType, PyTypeRef};
 use crate::{
-    class::PyClassImpl, convert::ToPyObject, function::OptionalArg, identifier, types::Constructor,
+    atomic_func,
+    class::PyClassImpl,
+    convert::{ToPyObject, ToPyResult},
+    function::OptionalArg,
+    identifier,
+    protocol::PyNumberMethods,
+    types::{AsNumber, Constructor},
     AsObject, Context, Py, PyObject, PyObjectRef, PyPayload, PyResult, TryFromBorrowedObject,
     VirtualMachine,
 };
+use crossbeam_utils::atomic::AtomicCell;
 use num_bigint::Sign;
 use num_traits::Zero;
+use once_cell::sync::Lazy;
 use std::fmt::{Debug, Formatter};
 
 impl ToPyObject for bool {
@@ -102,7 +110,7 @@ impl Constructor for PyBool {
     }
 }
 
-#[pyclass(with(Constructor))]
+#[pyclass(with(Constructor, AsNumber))]
 impl PyBool {
     #[pymethod(magic)]
     fn repr(zelf: bool, vm: &VirtualMachine) -> PyStrRef {
@@ -163,6 +171,48 @@ impl PyBool {
         } else {
             get_py_int(&lhs).xor(rhs, vm).to_pyobject(vm)
         }
+    }
+}
+
+macro_rules! int_method {
+    ($method:ident) => {
+        AtomicCell::new(PyInt::as_number().$method.load().to_owned())
+    };
+}
+
+impl AsNumber for PyBool {
+    fn as_number() -> &'static PyNumberMethods {
+        static AS_NUMBER: Lazy<PyNumberMethods> = Lazy::new(|| PyNumberMethods {
+            add: int_method!(add),
+            subtract: int_method!(subtract),
+            multiply: int_method!(multiply),
+            remainder: int_method!(remainder),
+            divmod: int_method!(divmod),
+            power: int_method!(power),
+            negative: int_method!(negative),
+            positive: int_method!(positive),
+            absolute: int_method!(absolute),
+            boolean: int_method!(boolean),
+            invert: int_method!(invert),
+            lshift: int_method!(lshift),
+            rshift: int_method!(rshift),
+            and: atomic_func!(|number, other, vm| {
+                PyBool::and(number.obj.to_owned(), other.to_owned(), vm).to_pyresult(vm)
+            }),
+            xor: atomic_func!(|number, other, vm| {
+                PyBool::xor(number.obj.to_owned(), other.to_owned(), vm).to_pyresult(vm)
+            }),
+            or: atomic_func!(|number, other, vm| {
+                PyBool::or(number.obj.to_owned(), other.to_owned(), vm).to_pyresult(vm)
+            }),
+            int: int_method!(int),
+            float: int_method!(float),
+            floor_divide: int_method!(floor_divide),
+            true_divide: int_method!(true_divide),
+            index: int_method!(index),
+            ..PyNumberMethods::NOT_IMPLEMENTED
+        });
+        &AS_NUMBER
     }
 }
 


### PR DESCRIPTION
Closes https://github.com/RustPython/RustPython/issues/4638

In CPython, `bool` is a subclass of `int`, and its `as_number` method overrides `and`, `xor` and `or`.

In RustPython, ~as `PyBool` is not a subclass of `PyInt`~, the `as_number` "overriding" is done by including all other methods of `PyInt`.