### PR TITLE
Update to pass test for unhashable collections

### DIFF
--- a/Lib/test/test_collections.py
+++ b/Lib/test/test_collections.py
@@ -892,8 +892,6 @@ class TestOneTrickPonyABCs(ABCTestCase):
         self.assertFalse(isinstance(CoroLike(), Coroutine))
         self.assertFalse(issubclass(CoroLike, Coroutine))
 
-    # TODO: RUSTPYTHON
-    @unittest.expectedFailure
     def test_Hashable(self):
         # Check some non-hashables
         non_samples = [bytearray(), list(), set(), dict()]

--- a/Lib/test/test_typing.py
+++ b/Lib/test/test_typing.py
@@ -3516,8 +3516,6 @@ class GetUtilitiesTestCase(TestCase):
 
 class CollectionsAbcTests(BaseTestCase):
 
-    # TODO: RUSTPYTHON
-    @unittest.expectedFailure
     def test_hashable(self):
         self.assertIsInstance(42, typing.Hashable)
         self.assertNotIsInstance([], typing.Hashable)

--- a/derive-impl/src/util.rs
+++ b/derive-impl/src/util.rs
@@ -263,7 +263,8 @@ impl ItemMeta for AttrItemMeta {
 pub(crate) struct ClassItemMeta(ItemMetaInner);
 
 impl ItemMeta for ClassItemMeta {
-    const ALLOWED_NAMES: &'static [&'static str] = &["module", "name", "base", "metaclass"];
+    const ALLOWED_NAMES: &'static [&'static str] =
+        &["module", "name", "base", "metaclass", "unhashable"];
 
     fn from_inner(inner: ItemMetaInner) -> Self {
         Self(inner)
@@ -297,6 +298,10 @@ impl ClassItemMeta {
 
     pub fn base(&self) -> Result<Option<String>> {
         self.inner()._optional_str("base")
+    }
+
+    pub fn unhashable(&self) -> Result<bool> {
+        self.inner()._bool("unhashable")
     }
 
     pub fn metaclass(&self) -> Result<Option<String>> {

--- a/vm/src/builtins/bytearray.rs
+++ b/vm/src/builtins/bytearray.rs
@@ -30,9 +30,8 @@ use crate::{
     },
     sliceable::{SequenceIndex, SliceableSequenceMutOp, SliceableSequenceOp},
     types::{
-        hash_not_implemented, AsBuffer, AsMapping, AsNumber, AsSequence, Callable, Comparable,
-        Constructor, Initializer, IterNext, IterNextIterable, Iterable, PyComparisonOp,
-        Unconstructible,
+        AsBuffer, AsMapping, AsNumber, AsSequence, Callable, Comparable, Constructor, Initializer,
+        IterNext, IterNextIterable, Iterable, PyComparisonOp, Unconstructible,
     },
     AsObject, Context, Py, PyObject, PyObjectRef, PyPayload, PyRef, PyResult, TryFromObject,
     VirtualMachine,

--- a/vm/src/builtins/bytearray.rs
+++ b/vm/src/builtins/bytearray.rs
@@ -41,7 +41,7 @@ use bstr::ByteSlice;
 use once_cell::sync::Lazy;
 use std::mem::size_of;
 
-#[pyclass(module = false, name = "bytearray")]
+#[pyclass(module = false, name = "bytearray", unhashable = true)]
 #[derive(Debug, Default)]
 pub struct PyByteArray {
     inner: PyRwLock<PyBytesInner>,
@@ -91,13 +91,6 @@ impl PyPayload for PyByteArray {
 
 /// Fill bytearray class methods dictionary.
 pub(crate) fn init(context: &Context) {
-    context
-        .types
-        .bytearray_type
-        .slots
-        .hash
-        .store(Some(unhashable_wrapper));
-
     PyByteArray::extend_class(context, context.types.bytearray_type);
     PyByteArrayIterator::extend_class(context, context.types.bytearray_iterator_type);
 }

--- a/vm/src/builtins/bytearray.rs
+++ b/vm/src/builtins/bytearray.rs
@@ -30,7 +30,7 @@ use crate::{
     },
     sliceable::{SequenceIndex, SliceableSequenceMutOp, SliceableSequenceOp},
     types::{
-        unhashable_wrapper, AsBuffer, AsMapping, AsNumber, AsSequence, Callable, Comparable,
+        hash_not_implemented, AsBuffer, AsMapping, AsNumber, AsSequence, Callable, Comparable,
         Constructor, Initializer, IterNext, IterNextIterable, Iterable, PyComparisonOp,
         Unconstructible,
     },

--- a/vm/src/builtins/bytearray.rs
+++ b/vm/src/builtins/bytearray.rs
@@ -30,9 +30,9 @@ use crate::{
     },
     sliceable::{SequenceIndex, SliceableSequenceMutOp, SliceableSequenceOp},
     types::{
-        AsBuffer, AsMapping, AsNumber, AsSequence, Callable, Comparable, Constructor, Hashable,
-        Initializer, IterNext, IterNextIterable, Iterable, PyComparisonOp, Unconstructible,
-        Unhashable,
+        unhashable_wrapper, AsBuffer, AsMapping, AsNumber, AsSequence, Callable, Comparable,
+        Constructor, Initializer, IterNext, IterNextIterable, Iterable, PyComparisonOp,
+        Unconstructible,
     },
     AsObject, Context, Py, PyObject, PyObjectRef, PyPayload, PyRef, PyResult, TryFromObject,
     VirtualMachine,
@@ -91,6 +91,13 @@ impl PyPayload for PyByteArray {
 
 /// Fill bytearray class methods dictionary.
 pub(crate) fn init(context: &Context) {
+    context
+        .types
+        .bytearray_type
+        .slots
+        .hash
+        .store(Some(unhashable_wrapper));
+
     PyByteArray::extend_class(context, context.types.bytearray_type);
     PyByteArrayIterator::extend_class(context, context.types.bytearray_iterator_type);
 }
@@ -100,7 +107,6 @@ pub(crate) fn init(context: &Context) {
     with(
         Constructor,
         Initializer,
-        Hashable,
         Comparable,
         AsBuffer,
         AsMapping,
@@ -872,8 +878,6 @@ impl AsNumber for PyByteArray {
         &AS_NUMBER
     }
 }
-
-impl Unhashable for PyByteArray {}
 
 impl Iterable for PyByteArray {
     fn iter(zelf: PyRef<Self>, vm: &VirtualMachine) -> PyResult {

--- a/vm/src/builtins/dict.rs
+++ b/vm/src/builtins/dict.rs
@@ -33,7 +33,7 @@ use std::fmt;
 
 pub type DictContentType = dictdatatype::Dict;
 
-#[pyclass(module = false, name = "dict")]
+#[pyclass(module = false, name = "dict", unhashable = true)]
 #[derive(Default)]
 pub struct PyDict {
     entries: DictContentType,
@@ -1207,13 +1207,6 @@ impl AsSequence for PyDictValues {
 }
 
 pub(crate) fn init(context: &Context) {
-    context
-        .types
-        .dict_type
-        .slots
-        .hash
-        .store(Some(unhashable_wrapper));
-
     PyDict::extend_class(context, context.types.dict_type);
     PyDictKeys::extend_class(context, context.types.dict_keys_type);
     PyDictKeyIterator::extend_class(context, context.types.dict_keyiterator_type);

--- a/vm/src/builtins/dict.rs
+++ b/vm/src/builtins/dict.rs
@@ -19,7 +19,7 @@ use crate::{
     protocol::{PyIterIter, PyIterReturn, PyMappingMethods, PyNumberMethods, PySequenceMethods},
     recursion::ReprGuard,
     types::{
-        unhashable_wrapper, AsMapping, AsNumber, AsSequence, Callable, Comparable, Constructor,
+        hash_not_implemented, AsMapping, AsNumber, AsSequence, Callable, Comparable, Constructor,
         Hashable, Initializer, IterNext, IterNextIterable, Iterable, PyComparisonOp,
         Unconstructible,
     },

--- a/vm/src/builtins/dict.rs
+++ b/vm/src/builtins/dict.rs
@@ -19,9 +19,8 @@ use crate::{
     protocol::{PyIterIter, PyIterReturn, PyMappingMethods, PyNumberMethods, PySequenceMethods},
     recursion::ReprGuard,
     types::{
-        hash_not_implemented, AsMapping, AsNumber, AsSequence, Callable, Comparable, Constructor,
-        Hashable, Initializer, IterNext, IterNextIterable, Iterable, PyComparisonOp,
-        Unconstructible,
+        AsMapping, AsNumber, AsSequence, Callable, Comparable, Constructor, Initializer, IterNext,
+        IterNextIterable, Iterable, PyComparisonOp, Unconstructible,
     },
     vm::VirtualMachine,
     AsObject, Context, Py, PyObject, PyObjectRef, PyPayload, PyRef, PyRefExact, PyResult,

--- a/vm/src/builtins/dict.rs
+++ b/vm/src/builtins/dict.rs
@@ -19,8 +19,9 @@ use crate::{
     protocol::{PyIterIter, PyIterReturn, PyMappingMethods, PyNumberMethods, PySequenceMethods},
     recursion::ReprGuard,
     types::{
-        AsMapping, AsNumber, AsSequence, Callable, Comparable, Constructor, Hashable, Initializer,
-        IterNext, IterNextIterable, Iterable, PyComparisonOp, Unconstructible, Unhashable,
+        unhashable_wrapper, AsMapping, AsNumber, AsSequence, Callable, Comparable, Constructor,
+        Hashable, Initializer, IterNext, IterNextIterable, Iterable, PyComparisonOp,
+        Unconstructible,
     },
     vm::VirtualMachine,
     AsObject, Context, Py, PyObject, PyObjectRef, PyPayload, PyRef, PyRefExact, PyResult,
@@ -206,7 +207,6 @@ impl PyDict {
         Constructor,
         Initializer,
         AsMapping,
-        Hashable,
         Comparable,
         Iterable,
         AsSequence,
@@ -511,8 +511,6 @@ impl Comparable for PyDict {
         })
     }
 }
-
-impl Unhashable for PyDict {}
 
 impl Iterable for PyDict {
     fn iter(zelf: PyRef<Self>, vm: &VirtualMachine) -> PyResult {
@@ -1209,6 +1207,13 @@ impl AsSequence for PyDictValues {
 }
 
 pub(crate) fn init(context: &Context) {
+    context
+        .types
+        .dict_type
+        .slots
+        .hash
+        .store(Some(unhashable_wrapper));
+
     PyDict::extend_class(context, context.types.dict_type);
     PyDictKeys::extend_class(context, context.types.dict_keys_type);
     PyDictKeyIterator::extend_class(context, context.types.dict_keyiterator_type);

--- a/vm/src/builtins/list.rs
+++ b/vm/src/builtins/list.rs
@@ -13,8 +13,8 @@ use crate::{
     sequence::{MutObjectSequenceOp, OptionalRangeArgs, SequenceExt, SequenceMutExt},
     sliceable::{SequenceIndex, SliceableSequenceMutOp, SliceableSequenceOp},
     types::{
-        unhashable_wrapper, AsMapping, AsSequence, Comparable, Constructor, Initializer, IterNext,
-        IterNextIterable, Iterable, PyComparisonOp, Unconstructible,
+        hash_not_implemented, AsMapping, AsSequence, Comparable, Constructor, Initializer,
+        IterNext, IterNextIterable, Iterable, PyComparisonOp, Unconstructible,
     },
     utils::collection_repr,
     vm::VirtualMachine,

--- a/vm/src/builtins/list.rs
+++ b/vm/src/builtins/list.rs
@@ -13,8 +13,8 @@ use crate::{
     sequence::{MutObjectSequenceOp, OptionalRangeArgs, SequenceExt, SequenceMutExt},
     sliceable::{SequenceIndex, SliceableSequenceMutOp, SliceableSequenceOp},
     types::{
-        hash_not_implemented, AsMapping, AsSequence, Comparable, Constructor, Initializer,
-        IterNext, IterNextIterable, Iterable, PyComparisonOp, Unconstructible,
+        AsMapping, AsSequence, Comparable, Constructor, Initializer, IterNext, IterNextIterable,
+        Iterable, PyComparisonOp, Unconstructible,
     },
     utils::collection_repr,
     vm::VirtualMachine,

--- a/vm/src/builtins/list.rs
+++ b/vm/src/builtins/list.rs
@@ -22,7 +22,7 @@ use crate::{
 };
 use std::{fmt, ops::DerefMut};
 
-#[pyclass(module = false, name = "list")]
+#[pyclass(module = false, name = "list", unhashable = true)]
 #[derive(Default)]
 pub struct PyList {
     elements: PyRwLock<Vec<PyObjectRef>>,
@@ -602,13 +602,6 @@ impl IterNext for PyListReverseIterator {
 }
 
 pub fn init(context: &Context) {
-    context
-        .types
-        .list_type
-        .slots
-        .hash
-        .store(Some(unhashable_wrapper));
-
     let list_type = &context.types.list_type;
     PyList::extend_class(context, list_type);
 

--- a/vm/src/builtins/list.rs
+++ b/vm/src/builtins/list.rs
@@ -13,8 +13,8 @@ use crate::{
     sequence::{MutObjectSequenceOp, OptionalRangeArgs, SequenceExt, SequenceMutExt},
     sliceable::{SequenceIndex, SliceableSequenceMutOp, SliceableSequenceOp},
     types::{
-        AsMapping, AsSequence, Comparable, Constructor, Hashable, Initializer, IterNext,
-        IterNextIterable, Iterable, PyComparisonOp, Unconstructible, Unhashable,
+        unhashable_wrapper, AsMapping, AsSequence, Comparable, Constructor, Initializer, IterNext,
+        IterNextIterable, Iterable, PyComparisonOp, Unconstructible,
     },
     utils::collection_repr,
     vm::VirtualMachine,
@@ -86,15 +86,7 @@ pub(crate) struct SortOptions {
 pub type PyListRef = PyRef<PyList>;
 
 #[pyclass(
-    with(
-        Constructor,
-        Initializer,
-        AsMapping,
-        Iterable,
-        Hashable,
-        Comparable,
-        AsSequence
-    ),
+    with(Constructor, Initializer, AsMapping, Iterable, Comparable, AsSequence),
     flags(BASETYPE)
 )]
 impl PyList {
@@ -492,8 +484,6 @@ impl Comparable for PyList {
     }
 }
 
-impl Unhashable for PyList {}
-
 fn do_sort(
     vm: &VirtualMachine,
     values: &mut Vec<PyObjectRef>,
@@ -612,6 +602,13 @@ impl IterNext for PyListReverseIterator {
 }
 
 pub fn init(context: &Context) {
+    context
+        .types
+        .list_type
+        .slots
+        .hash
+        .store(Some(unhashable_wrapper));
+
     let list_type = &context.types.list_type;
     PyList::extend_class(context, list_type);
 

--- a/vm/src/builtins/set.rs
+++ b/vm/src/builtins/set.rs
@@ -16,8 +16,8 @@ use crate::{
     recursion::ReprGuard,
     types::AsNumber,
     types::{
-        AsSequence, Comparable, Constructor, Hashable, Initializer, IterNext, IterNextIterable,
-        Iterable, PyComparisonOp, Unconstructible, Unhashable,
+        unhashable_wrapper, AsSequence, Comparable, Constructor, Hashable, Initializer, IterNext,
+        IterNextIterable, Iterable, PyComparisonOp, Unconstructible,
     },
     utils::collection_repr,
     vm::VirtualMachine,
@@ -489,15 +489,7 @@ fn reduce_set(
 }
 
 #[pyclass(
-    with(
-        Constructor,
-        Initializer,
-        AsSequence,
-        Hashable,
-        Comparable,
-        Iterable,
-        AsNumber
-    ),
+    with(Constructor, Initializer, AsSequence, Comparable, Iterable, AsNumber),
     flags(BASETYPE)
 )]
 impl PySet {
@@ -804,8 +796,6 @@ impl Comparable for PySet {
         })
     }
 }
-
-impl Unhashable for PySet {}
 
 impl Iterable for PySet {
     fn iter(zelf: PyRef<Self>, vm: &VirtualMachine) -> PyResult {
@@ -1251,6 +1241,13 @@ impl IterNext for PySetIterator {
 }
 
 pub fn init(context: &Context) {
+    context
+        .types
+        .set_type
+        .slots
+        .hash
+        .store(Some(unhashable_wrapper));
+
     PySet::extend_class(context, context.types.set_type);
     PyFrozenSet::extend_class(context, context.types.frozenset_type);
     PySetIterator::extend_class(context, context.types.set_iterator_type);

--- a/vm/src/builtins/set.rs
+++ b/vm/src/builtins/set.rs
@@ -16,7 +16,7 @@ use crate::{
     recursion::ReprGuard,
     types::AsNumber,
     types::{
-        unhashable_wrapper, AsSequence, Comparable, Constructor, Hashable, Initializer, IterNext,
+        hash_not_implemented, AsSequence, Comparable, Constructor, Hashable, Initializer, IterNext,
         IterNextIterable, Iterable, PyComparisonOp, Unconstructible,
     },
     utils::collection_repr,

--- a/vm/src/builtins/set.rs
+++ b/vm/src/builtins/set.rs
@@ -16,8 +16,8 @@ use crate::{
     recursion::ReprGuard,
     types::AsNumber,
     types::{
-        hash_not_implemented, AsSequence, Comparable, Constructor, Hashable, Initializer, IterNext,
-        IterNextIterable, Iterable, PyComparisonOp, Unconstructible,
+        AsSequence, Comparable, Constructor, Hashable, Initializer, IterNext, IterNextIterable,
+        Iterable, PyComparisonOp, Unconstructible,
     },
     utils::collection_repr,
     vm::VirtualMachine,

--- a/vm/src/builtins/set.rs
+++ b/vm/src/builtins/set.rs
@@ -28,7 +28,7 @@ use std::{fmt, ops::Deref};
 
 pub type SetContentType = dictdatatype::Dict<()>;
 
-#[pyclass(module = false, name = "set")]
+#[pyclass(module = false, name = "set", unhashable = true)]
 #[derive(Default)]
 pub struct PySet {
     pub(super) inner: PySetInner,
@@ -70,7 +70,7 @@ impl PySet {
     }
 }
 
-#[pyclass(module = false, name = "frozenset")]
+#[pyclass(module = false, name = "frozenset", unhashable = true)]
 #[derive(Default)]
 pub struct PyFrozenSet {
     inner: PySetInner,
@@ -1241,13 +1241,6 @@ impl IterNext for PySetIterator {
 }
 
 pub fn init(context: &Context) {
-    context
-        .types
-        .set_type
-        .slots
-        .hash
-        .store(Some(unhashable_wrapper));
-
     PySet::extend_class(context, context.types.set_type);
     PyFrozenSet::extend_class(context, context.types.frozenset_type);
     PySetIterator::extend_class(context, context.types.set_iterator_type);

--- a/vm/src/builtins/slice.rs
+++ b/vm/src/builtins/slice.rs
@@ -25,7 +25,6 @@ impl PyPayload for PySlice {
     }
 }
 
-// #[pyclass(with(Hashable, Comparable))]
 #[pyclass(with(Comparable))]
 impl PySlice {
     #[pygetset]

--- a/vm/src/builtins/slice.rs
+++ b/vm/src/builtins/slice.rs
@@ -1,6 +1,5 @@
 // sliceobject.{h,c} in CPython
 use super::{PyInt, PyIntRef, PyTupleRef, PyType, PyTypeRef};
-use crate::types::hash_not_implemented;
 use crate::{
     class::PyClassImpl,
     convert::ToPyObject,

--- a/vm/src/builtins/slice.rs
+++ b/vm/src/builtins/slice.rs
@@ -1,6 +1,6 @@
 // sliceobject.{h,c} in CPython
 use super::{PyInt, PyIntRef, PyTupleRef, PyType, PyTypeRef};
-use crate::types::unhashable_wrapper;
+use crate::types::hash_not_implemented;
 use crate::{
     class::PyClassImpl,
     convert::ToPyObject,

--- a/vm/src/builtins/slice.rs
+++ b/vm/src/builtins/slice.rs
@@ -12,7 +12,7 @@ use crate::{
 use num_bigint::{BigInt, ToBigInt};
 use num_traits::{One, Signed, Zero};
 
-#[pyclass(module = false, name = "slice")]
+#[pyclass(module = false, name = "slice", unhashable = true)]
 #[derive(Debug)]
 pub struct PySlice {
     pub start: Option<PyObjectRef>,
@@ -292,12 +292,6 @@ impl PyEllipsis {
 }
 
 pub fn init(ctx: &Context) {
-    ctx.types
-        .slice_type
-        .slots
-        .hash
-        .store(Some(unhashable_wrapper));
-
     PySlice::extend_class(ctx, ctx.types.slice_type);
     PyEllipsis::extend_class(ctx, ctx.types.ellipsis_type);
 }

--- a/vm/src/builtins/slice.rs
+++ b/vm/src/builtins/slice.rs
@@ -1,11 +1,12 @@
 // sliceobject.{h,c} in CPython
 use super::{PyInt, PyIntRef, PyTupleRef, PyType, PyTypeRef};
+use crate::types::unhashable_wrapper;
 use crate::{
     class::PyClassImpl,
     convert::ToPyObject,
     function::{FuncArgs, OptionalArg, PyComparisonValue},
     sliceable::SaturatedSlice,
-    types::{Comparable, Constructor, Hashable, PyComparisonOp, Unhashable},
+    types::{Comparable, Constructor, PyComparisonOp},
     AsObject, Context, Py, PyObject, PyObjectRef, PyPayload, PyRef, PyResult, VirtualMachine,
 };
 use num_bigint::{BigInt, ToBigInt};
@@ -25,7 +26,8 @@ impl PyPayload for PySlice {
     }
 }
 
-#[pyclass(with(Hashable, Comparable))]
+// #[pyclass(with(Hashable, Comparable))]
+#[pyclass(with(Comparable))]
 impl PySlice {
     #[pygetset]
     fn start(&self, vm: &VirtualMachine) -> PyObjectRef {
@@ -258,8 +260,6 @@ impl Comparable for PySlice {
     }
 }
 
-impl Unhashable for PySlice {}
-
 #[pyclass(module = false, name = "EllipsisType")]
 #[derive(Debug)]
 pub struct PyEllipsis;
@@ -292,6 +292,12 @@ impl PyEllipsis {
 }
 
 pub fn init(ctx: &Context) {
+    ctx.types
+        .slice_type
+        .slots
+        .hash
+        .store(Some(unhashable_wrapper));
+
     PySlice::extend_class(ctx, ctx.types.slice_type);
     PyEllipsis::extend_class(ctx, ctx.types.ellipsis_type);
 }

--- a/vm/src/builtins/type.rs
+++ b/vm/src/builtins/type.rs
@@ -1019,11 +1019,10 @@ impl SetAttr for PyType {
         }
         let assign = value.is_assign();
 
-        let mut attributes = zelf.attributes.write();
         if let PySetterValue::Assign(value) = value {
-            attributes.insert(attr_name, value);
+            zelf.attributes.write().insert(attr_name, value);
         } else {
-            let prev_value = attributes.remove(attr_name);
+            let prev_value = zelf.attributes.write().remove(attr_name);
             if prev_value.is_none() {
                 return Err(vm.new_exception(
                     vm.ctx.exceptions.attribute_error.to_owned(),

--- a/vm/src/class.rs
+++ b/vm/src/class.rs
@@ -115,13 +115,7 @@ pub trait PyClassImpl: PyClassDef {
             class.set_attr(identifier!(ctx, __new__), bound);
         }
 
-        if class
-            .slots
-            .hash
-            .load()
-            .map(|h| h as usize == unhashable_wrapper as usize)
-            .unwrap_or(false)
-        {
+        if class.slots.hash.load().map_or(0, |h| h as usize) == unhashable_wrapper as usize {
             class.set_attr(ctx.names.__hash__, ctx.none.clone().into());
         }
     }

--- a/vm/src/class.rs
+++ b/vm/src/class.rs
@@ -117,7 +117,7 @@ pub trait PyClassImpl: PyClassDef {
             .slots
             .hash
             .load()
-            .map(|h| h as u64 == unhashable_wrapper as u64)
+            .map(|h| h as usize == unhashable_wrapper as usize)
             .unwrap_or(false)
         {
             class.set_attr(ctx.names.__hash__, ctx.none.clone().into());

--- a/vm/src/class.rs
+++ b/vm/src/class.rs
@@ -4,7 +4,7 @@ use crate::{
     builtins::{PyBaseObject, PyBoundMethod, PyType, PyTypeRef},
     identifier,
     object::{Py, PyObjectPayload, PyObjectRef, PyRef},
-    types::{unhashable_wrapper, PyTypeFlags, PyTypeSlots},
+    types::{hash_not_implemented, PyTypeFlags, PyTypeSlots},
     vm::Context,
 };
 use rustpython_common::{lock::PyRwLock, static_cell};
@@ -115,7 +115,7 @@ pub trait PyClassImpl: PyClassDef {
             class.set_attr(identifier!(ctx, __new__), bound);
         }
 
-        if class.slots.hash.load().map_or(0, |h| h as usize) == unhashable_wrapper as usize {
+        if class.slots.hash.load().map_or(0, |h| h as usize) == hash_not_implemented as usize {
             class.set_attr(ctx.names.__hash__, ctx.none.clone().into());
         }
     }
@@ -148,7 +148,7 @@ pub trait PyClassImpl: PyClassDef {
         };
 
         if Self::UNHASHABLE {
-            slots.hash.store(Some(unhashable_wrapper));
+            slots.hash.store(Some(hash_not_implemented));
         }
 
         Self::extend_slots(&mut slots);

--- a/vm/src/class.rs
+++ b/vm/src/class.rs
@@ -60,6 +60,7 @@ pub trait PyClassDef {
     const TP_NAME: &'static str;
     const DOC: Option<&'static str> = None;
     const BASICSIZE: usize;
+    const UNHASHABLE: bool;
 }
 
 impl<T> PyClassDef for PyRef<T>
@@ -71,6 +72,7 @@ where
     const TP_NAME: &'static str = T::TP_NAME;
     const DOC: Option<&'static str> = T::DOC;
     const BASICSIZE: usize = T::BASICSIZE;
+    const UNHASHABLE: bool = false;
 }
 
 pub trait PyClassImpl: PyClassDef {
@@ -150,6 +152,11 @@ pub trait PyClassImpl: PyClassDef {
             doc: Self::DOC,
             ..Default::default()
         };
+
+        if Self::UNHASHABLE {
+            slots.hash.store(Some(unhashable_wrapper));
+        }
+
         Self::extend_slots(&mut slots);
         slots
     }

--- a/vm/src/class.rs
+++ b/vm/src/class.rs
@@ -60,7 +60,7 @@ pub trait PyClassDef {
     const TP_NAME: &'static str;
     const DOC: Option<&'static str> = None;
     const BASICSIZE: usize;
-    const UNHASHABLE: bool;
+    const UNHASHABLE: bool = false;
 }
 
 impl<T> PyClassDef for PyRef<T>
@@ -72,7 +72,7 @@ where
     const TP_NAME: &'static str = T::TP_NAME;
     const DOC: Option<&'static str> = T::DOC;
     const BASICSIZE: usize = T::BASICSIZE;
-    const UNHASHABLE: bool = false;
+    const UNHASHABLE: bool = T::UNHASHABLE;
 }
 
 pub trait PyClassImpl: PyClassDef {

--- a/vm/src/stdlib/collections.rs
+++ b/vm/src/stdlib/collections.rs
@@ -27,7 +27,7 @@ mod _collections {
     use std::collections::VecDeque;
 
     #[pyattr]
-    #[pyclass(name = "deque")]
+    #[pyclass(name = "deque", unhashable = true)]
     #[derive(Debug, Default, PyPayload)]
     struct PyDeque {
         deque: PyRwLock<VecDeque<PyObjectRef>>,

--- a/vm/src/stdlib/collections.rs
+++ b/vm/src/stdlib/collections.rs
@@ -16,8 +16,8 @@ mod _collections {
         sequence::{MutObjectSequenceOp, OptionalRangeArgs},
         sliceable::SequenceIndexOp,
         types::{
-            AsSequence, Comparable, Constructor, Hashable, Initializer, IterNext, IterNextIterable,
-            Iterable, PyComparisonOp, Unhashable,
+            AsSequence, Comparable, Constructor, Initializer, IterNext, IterNextIterable, Iterable,
+            PyComparisonOp,
         },
         utils::collection_repr,
         AsObject, PyObject, PyObjectRef, PyPayload, PyRef, PyResult, VirtualMachine,
@@ -57,7 +57,7 @@ mod _collections {
 
     #[pyclass(
         flags(BASETYPE),
-        with(Constructor, Initializer, AsSequence, Comparable, Hashable, Iterable)
+        with(Constructor, Initializer, AsSequence, Comparable, Iterable)
     )]
     impl PyDeque {
         #[pymethod]
@@ -573,8 +573,6 @@ mod _collections {
                 .map(PyComparisonValue::Implemented)
         }
     }
-
-    impl Unhashable for PyDeque {}
 
     impl Iterable for PyDeque {
         fn iter(zelf: PyRef<Self>, vm: &VirtualMachine) -> PyResult {

--- a/vm/src/types/slot.rs
+++ b/vm/src/types/slot.rs
@@ -423,7 +423,7 @@ impl PyType {
                     .attributes
                     .read()
                     .get(identifier!(ctx, __hash__))
-                    .map_or(false, |a| a.is(&ctx.none()));
+                    .map_or(false, |a| a.is(&ctx.none));
                 if is_unhashable {
                     toggle_slot!(hash, unhashable_wrapper);
                 } else {

--- a/vm/src/types/slot.rs
+++ b/vm/src/types/slot.rs
@@ -424,11 +424,12 @@ impl PyType {
                     .read()
                     .get(identifier!(ctx, __hash__))
                     .map_or(false, |a| a.is(&ctx.none));
-                if is_unhashable {
-                    toggle_slot!(hash, unhashable_wrapper);
+                let wrapper = if is_unhashable {
+                    unhashable_wrapper
                 } else {
-                    toggle_slot!(hash, hash_wrapper);
-                }
+                    hash_wrapper
+                };
+                toggle_slot!(hash, wrapper);
             }
             _ if name == identifier!(ctx, __call__) => {
                 toggle_slot!(call, call_wrapper);

--- a/vm/src/types/slot.rs
+++ b/vm/src/types/slot.rs
@@ -423,8 +423,7 @@ impl PyType {
                     .attributes
                     .read()
                     .get(identifier!(ctx, __hash__))
-                    .map(|a| a.is(&ctx.none()))
-                    .unwrap_or(false);
+                    .map_or(false, |a| a.is(&ctx.none()));
                 if is_unhashable {
                     toggle_slot!(hash, unhashable_wrapper);
                 } else {

--- a/vm/src/types/slot.rs
+++ b/vm/src/types/slot.rs
@@ -244,7 +244,7 @@ fn hash_wrapper(zelf: &PyObject, vm: &VirtualMachine) -> PyResult<PyHash> {
 }
 
 /// Marks a type as unhashable. Similar to PyObject_HashNotImplemented in CPython
-pub fn unhashable_wrapper(zelf: &PyObject, vm: &VirtualMachine) -> PyResult<PyHash> {
+pub fn hash_not_implemented(zelf: &PyObject, vm: &VirtualMachine) -> PyResult<PyHash> {
     Err(vm.new_type_error(format!("unhashable type: {}", zelf.class().name())))
 }
 
@@ -425,7 +425,7 @@ impl PyType {
                     .get(identifier!(ctx, __hash__))
                     .map_or(false, |a| a.is(&ctx.none));
                 let wrapper = if is_unhashable {
-                    unhashable_wrapper
+                    hash_not_implemented
                 } else {
                     hash_wrapper
                 };

--- a/vm/src/types/slot.rs
+++ b/vm/src/types/slot.rs
@@ -243,6 +243,11 @@ fn hash_wrapper(zelf: &PyObject, vm: &VirtualMachine) -> PyResult<PyHash> {
     }
 }
 
+/// Marks a type as unhashable. Similar to PyObject_HashNotImplemented in CPython
+pub fn unhashable_wrapper(zelf: &PyObject, vm: &VirtualMachine) -> PyResult<PyHash> {
+    Err(vm.new_type_error(format!("unhashable type: {}", zelf.class().name())))
+}
+
 fn call_wrapper(zelf: &PyObject, args: FuncArgs, vm: &VirtualMachine) -> PyResult {
     vm.call_special_method(zelf.to_owned(), identifier!(vm, __call__), args)
 }
@@ -414,7 +419,17 @@ impl PyType {
                 update_pointer_slot!(as_mapping, mapping_methods);
             }
             _ if name == identifier!(ctx, __hash__) => {
-                toggle_slot!(hash, hash_wrapper);
+                let is_unhashable = self
+                    .attributes
+                    .read()
+                    .get(identifier!(ctx, __hash__))
+                    .map(|a| a.is(&ctx.none()))
+                    .unwrap_or(false);
+                if is_unhashable {
+                    toggle_slot!(hash, unhashable_wrapper);
+                } else {
+                    toggle_slot!(hash, hash_wrapper);
+                }
             }
             _ if name == identifier!(ctx, __call__) => {
                 toggle_slot!(call, call_wrapper);
@@ -661,22 +676,6 @@ pub trait Hashable: PyPayload {
     }
 
     fn hash(zelf: &Py<Self>, vm: &VirtualMachine) -> PyResult<PyHash>;
-}
-
-pub trait Unhashable: PyPayload {}
-
-impl<T> Hashable for T
-where
-    T: Unhashable,
-{
-    fn slot_hash(zelf: &PyObject, vm: &VirtualMachine) -> PyResult<PyHash> {
-        Err(vm.new_type_error(format!("unhashable type: '{}'", zelf.class().name())))
-    }
-
-    #[cold]
-    fn hash(_zelf: &Py<Self>, _vm: &VirtualMachine) -> PyResult<PyHash> {
-        unreachable!("slot_hash is implemented for unhashable types");
-    }
 }
 
 #[pyclass]


### PR DESCRIPTION
In CPython:

- If a type is marked as unhashable on the native side (i.e. `PyObject_HashNotImplemented` is assigned to hash slot), then `__hash__` attribute of the type dict is set to None so that the type is considered as unhashable on Python side too.
- If a type is created at runtime and `"__hash__": None` is given as the type dict (like `type('C', (object,), {'__hash__': None})`), then the hash slot is filled with PyObject_HashNotImplemented.

In RustPython, Unhashable trait exists to mark a type as unhashble. But there is no way to check if a type implements Unhashable trait at runtime, so it is hard to follow the CPython's mechanism.

So I've added `unhashable_wrapper` function similar to PyObject_HashNotImplemented, and used that as a marker for unhashable on the native side.

---

Thanks for the advice from @youknowone !