### PR TITLE
Add sys.winver

### DIFF
--- a/vm/src/stdlib/sys.rs
+++ b/vm/src/stdlib/sys.rs
@@ -262,6 +262,13 @@ mod sys {
         version::get_version()
     }
 
+    #[cfg(windows)]
+    #[pyattr]
+    fn winver(_vm: &VirtualMachine) -> String {
+        // Note: This is Python DLL version in CPython, but we arbitrary fill it for compatibility
+        version::get_winver_number()
+    }
+
     #[pyattr]
     fn _xoptions(vm: &VirtualMachine) -> PyDictRef {
         let ctx = &vm.ctx;

--- a/vm/src/version.rs
+++ b/vm/src/version.rs
@@ -28,6 +28,10 @@ pub fn get_version_number() -> String {
     format!("{MAJOR}.{MINOR}.{MICRO}{RELEASELEVEL}")
 }
 
+pub fn get_winver_number() -> String {
+    format!("{MAJOR}.{MINOR}")
+}
+
 pub fn get_compiler() -> String {
     format!("rustc {}", env!("RUSTC_VERSION"))
 }


### PR DESCRIPTION
Resolve #4550

With this patch, I got the same string as with CPython's `sys.winver`.