### PR TITLE
Update test/test_with.py from CPython 3.11.2

### DIFF
--- a/Lib/test/test_with.py
+++ b/Lib/test/test_with.py
@@ -117,7 +117,7 @@ class FailureTestCase(unittest.TestCase):
         def fooLacksEnter():
             foo = LacksEnter()
             with foo: pass
-        self.assertRaisesRegex(AttributeError, '__enter__', fooLacksEnter)
+        self.assertRaisesRegex(TypeError, 'the context manager', fooLacksEnter)
 
     def testEnterAttributeError2(self):
         class LacksEnterAndExit(object):
@@ -126,7 +126,7 @@ class FailureTestCase(unittest.TestCase):
         def fooLacksEnterAndExit():
             foo = LacksEnterAndExit()
             with foo: pass
-        self.assertRaisesRegex(AttributeError, '__enter__', fooLacksEnterAndExit)
+        self.assertRaisesRegex(TypeError, 'the context manager', fooLacksEnterAndExit)
 
     def testExitAttributeError(self):
         class LacksExit(object):
@@ -136,7 +136,7 @@ class FailureTestCase(unittest.TestCase):
         def fooLacksExit():
             foo = LacksExit()
             with foo: pass
-        self.assertRaisesRegex(AttributeError, '__exit__', fooLacksExit)
+        self.assertRaisesRegex(TypeError, 'the context manager.*__exit__', fooLacksExit)
 
     def assertRaisesSyntaxError(self, codestr):
         def shouldRaiseSyntaxError(s):

--- a/Lib/test/test_with.py
+++ b/Lib/test/test_with.py
@@ -109,6 +109,8 @@ class FailureTestCase(unittest.TestCase):
             with foo: pass
         self.assertRaises(NameError, fooNotDeclared)
 
+    # TODO: RUSTPYTHON
+    @unittest.expectedFailure
     def testEnterAttributeError1(self):
         class LacksEnter(object):
             def __exit__(self, type, value, traceback):
@@ -119,6 +121,8 @@ class FailureTestCase(unittest.TestCase):
             with foo: pass
         self.assertRaisesRegex(TypeError, 'the context manager', fooLacksEnter)
 
+    # TODO: RUSTPYTHON
+    @unittest.expectedFailure
     def testEnterAttributeError2(self):
         class LacksEnterAndExit(object):
             pass
@@ -128,6 +132,8 @@ class FailureTestCase(unittest.TestCase):
             with foo: pass
         self.assertRaisesRegex(TypeError, 'the context manager', fooLacksEnterAndExit)
 
+    # TODO: RUSTPYTHON
+    @unittest.expectedFailure
     def testExitAttributeError(self):
         class LacksExit(object):
             def __enter__(self):


### PR DESCRIPTION
#4564
Tests related to python/cpython#26809 have been marked as failing tests.