### PR TITLE
Change error type for bad objects in "with" and "async with"

### DIFF
--- a/Lib/test/test_contextlib.py
+++ b/Lib/test/test_contextlib.py
@@ -545,8 +545,6 @@ class TestContextDecorator(unittest.TestCase):
         self.assertEqual(test.b, 2)
 
 
-    # TODO: RUSTPYTHON
-    @unittest.expectedFailure
     def test_typo_enter(self):
         class mycontext(ContextDecorator):
             def __unter__(self):
@@ -559,8 +557,6 @@ class TestContextDecorator(unittest.TestCase):
                 pass
 
 
-    # TODO: RUSTPYTHON
-    @unittest.expectedFailure
     def test_typo_exit(self):
         class mycontext(ContextDecorator):
             def __enter__(self):

--- a/Lib/test/test_with.py
+++ b/Lib/test/test_with.py
@@ -109,8 +109,6 @@ class FailureTestCase(unittest.TestCase):
             with foo: pass
         self.assertRaises(NameError, fooNotDeclared)
 
-    # TODO: RUSTPYTHON
-    @unittest.expectedFailure
     def testEnterAttributeError1(self):
         class LacksEnter(object):
             def __exit__(self, type, value, traceback):
@@ -121,8 +119,6 @@ class FailureTestCase(unittest.TestCase):
             with foo: pass
         self.assertRaisesRegex(TypeError, 'the context manager', fooLacksEnter)
 
-    # TODO: RUSTPYTHON
-    @unittest.expectedFailure
     def testEnterAttributeError2(self):
         class LacksEnterAndExit(object):
             pass
@@ -132,8 +128,6 @@ class FailureTestCase(unittest.TestCase):
             with foo: pass
         self.assertRaisesRegex(TypeError, 'the context manager', fooLacksEnterAndExit)
 
-    # TODO: RUSTPYTHON
-    @unittest.expectedFailure
     def testExitAttributeError(self):
         class LacksExit(object):
             def __enter__(self):


### PR DESCRIPTION
This patch does not cover all cases of `test_contextlib.py`

`bytecode::Instruction::SetupWith` and `BeforeAsyncWith` raise a TypeError instead of an AttributeError.

It relates to #4650 