### PR TITLE
Add BaseExceptionGroup

### DIFF
--- a/Lib/test/test_pickle.py
+++ b/Lib/test/test_pickle.py
@@ -632,7 +632,9 @@ class CompatPickleTests(unittest.TestCase):
                            ResourceWarning,
                            StopAsyncIteration,
                            RecursionError,
-                           EncodingWarning):
+                           EncodingWarning,
+                           BaseExceptionGroup,
+                           ExceptionGroup):
                     continue
                 if exc is not OSError and issubclass(exc, OSError):
                     self.assertEqual(reverse_mapping('builtins', name),

--- a/Lib/test/test_pickle.py
+++ b/Lib/test/test_pickle.py
@@ -633,8 +633,8 @@ class CompatPickleTests(unittest.TestCase):
                            StopAsyncIteration,
                            RecursionError,
                            EncodingWarning,
-                           BaseExceptionGroup,
-                           ExceptionGroup):
+                           #ExceptionGroup, # TODO: RUSTPYTHON
+                           BaseExceptionGroup):
                     continue
                 if exc is not OSError and issubclass(exc, OSError):
                     self.assertEqual(reverse_mapping('builtins', name),

--- a/vm/src/exceptions.rs
+++ b/vm/src/exceptions.rs
@@ -322,6 +322,7 @@ impl ExceptionCtor {
 #[derive(Debug, Clone)]
 pub struct ExceptionZoo {
     pub base_exception_type: &'static Py<PyType>,
+    pub base_exception_group: &'static Py<PyType>,
     pub system_exit: &'static Py<PyType>,
     pub keyboard_interrupt: &'static Py<PyType>,
     pub generator_exit: &'static Py<PyType>,
@@ -538,6 +539,7 @@ impl ExceptionZoo {
         let base_exception_type = PyBaseException::init_bare_type();
 
         // Sorted By Hierarchy then alphabetized.
+        let base_exception_group = PyBaseExceptionGroup::init_bare_type();
         let system_exit = PySystemExit::init_bare_type();
         let keyboard_interrupt = PyKeyboardInterrupt::init_bare_type();
         let generator_exit = PyGeneratorExit::init_bare_type();
@@ -623,6 +625,7 @@ impl ExceptionZoo {
 
         Self {
             base_exception_type,
+            base_exception_group,
             system_exit,
             keyboard_interrupt,
             generator_exit,
@@ -704,6 +707,10 @@ impl ExceptionZoo {
         PyBaseException::extend_class(ctx, excs.base_exception_type);
 
         // Sorted By Hierarchy then alphabetized.
+        extend_exception!(PyBaseExceptionGroup, ctx, excs.base_exception_group, {
+            "message" => ctx.new_readonly_getset("message", excs.base_exception_group, make_arg_getter(0)),
+            "exceptions" => ctx.new_readonly_getset("exceptions", excs.base_exception_group, make_arg_getter(1)),
+        });
         extend_exception!(PySystemExit, ctx, excs.system_exit, {
             "code" => ctx.new_readonly_getset("code", excs.system_exit, system_exit_code),
         });
@@ -1138,6 +1145,12 @@ pub(super) mod types {
         PyBaseException,
         system_exit,
         "Request to exit from the interpreter."
+    }
+    define_exception! {
+        PyBaseExceptionGroup,
+        PyBaseException,
+        base_exception_group,
+        "A combination of multiple unrelated exceptions."
     }
     define_exception! {
         PyGeneratorExit,

--- a/vm/src/stdlib/builtins.rs
+++ b/vm/src/stdlib/builtins.rs
@@ -994,6 +994,7 @@ pub fn make_module(vm: &VirtualMachine, module: PyObjectRef) {
         // ordered by exception_hierarchy.txt
         // Exceptions:
         "BaseException" => ctx.exceptions.base_exception_type.to_owned(),
+        "BaseExceptionGroup" => ctx.exceptions.base_exception_group.to_owned(),
         "SystemExit" => ctx.exceptions.system_exit.to_owned(),
         "KeyboardInterrupt" => ctx.exceptions.keyboard_interrupt.to_owned(),
         "GeneratorExit" => ctx.exceptions.generator_exit.to_owned(),


### PR DESCRIPTION
Add BaseExceptionGroup that is introduced in Python 3.11. ExceptionGroup still needs to be implemented.

#4628 

[1]: https://docs.python.org/3/library/exceptions.html#exception-groups