### PR TITLE
Include Derive feature with optional Serde dependency

### DIFF
--- a/compiler/core/Cargo.toml
+++ b/compiler/core/Cargo.toml
@@ -13,6 +13,6 @@ bstr = { workspace = true }
 itertools = { workspace = true }
 num-bigint = { workspace = true }
 num-complex = { workspace = true }
-serde = { version = "1.0.133", optional = true, default-features = false }
+serde = { version = "1.0.133", optional = true, default-features = false, features = ["derive"] }
 
 lz4_flex = "0.9.2"

--- a/compiler/parser/Cargo.toml
+++ b/compiler/parser/Cargo.toml
@@ -34,7 +34,7 @@ unic-ucd-ident  = "0.9.0"
 lalrpop-util = "0.19.8"
 phf = "0.11.1"
 rustc-hash = "1.1.0"
-serde = { version = "1.0.133", optional = true, default-features = false }
+serde = { version = "1.0.133", optional = true, default-features = false, features = ["derive"] }
 
 [dev-dependencies]
 insta = { workspace = true }


### PR DESCRIPTION
## Summary

The Serde-enabled paths actually rely on this -- it was just missing. (Ruff was fine with this, since Ruff's Serde includes this feature, but attempting to compile outside of Ruff was causing an error.)

## Test Plan

From `compiler/parser`, run `cargo test --all-features`.

Before:

```
error: cannot find derive macro `Serialize` in this scope
 --> compiler/core/src/location.rs:6:38
  |
6 | #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
  |                                      ^^^^^^^^^
  |
note: `Serialize` is imported here, but it is only a trait, without a derive macro
 --> compiler/core/src/location.rs:2:26
  |
2 | use serde::{Deserialize, Serialize};
```

After: success.
