### PR TITLE
Add an architecture with libc::c_char == u8 build to CI

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -194,6 +194,13 @@ jobs:
 
       - uses: dtolnay/rust-toolchain@stable
         with:
+          target: aarch64-unknown-linux-gnu
+
+      - name: Check compilation for aarch64 linux gnu
+        run: cargo check --target aarch64-unknown-linux-gnu
+
+      - uses: dtolnay/rust-toolchain@stable
+        with:
           target: i686-unknown-linux-musl
 
       - name: Check compilation for musl

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -196,6 +196,8 @@ jobs:
         with:
           target: aarch64-unknown-linux-gnu
 
+      - name: Install gcc-aarch64-linux-gnu
+        run: sudo apt install gcc-aarch64-linux-gnu
       - name: Check compilation for aarch64 linux gnu
         run: cargo check --target aarch64-unknown-linux-gnu
 


### PR DESCRIPTION
Attempting to add #4665, but I don't know if this is right.

Needed to install `gcc-aarch64-linux-gnu` to get this to check locally.

