### PR TITLE
get &= -= working for sets

### DIFF
--- a/Lib/test/test_set.py
+++ b/Lib/test/test_set.py
@@ -582,8 +582,6 @@ class TestSet(TestJointOps, unittest.TestCase):
             else:
                 self.assertNotIn(c, self.s)
 
-    # TODO: RUSTPYTHON
-    @unittest.expectedFailure
     def test_inplace_on_self(self):
         t = self.s.copy()
         t |= t


### PR DESCRIPTION
current set implementation of &= and -= does not work correctly for the following test cases:
s=set([1,2,3])
s &= s
s -= s

This new implementation solves these issues and the test_inplace_on_self test passes.