### PR TITLE
test_inplace_on_self now works in test_set and test_weakset

### DIFF
--- a/Lib/test/test_set.py
+++ b/Lib/test/test_set.py
@@ -582,8 +582,6 @@ class TestSet(TestJointOps, unittest.TestCase):
             else:
                 self.assertNotIn(c, self.s)
 
-    # TODO: RUSTPYTHON
-    @unittest.expectedFailure
     def test_inplace_on_self(self):
         t = self.s.copy()
         t |= t

--- a/Lib/test/test_weakset.py
+++ b/Lib/test/test_weakset.py
@@ -324,8 +324,6 @@ class TestWeakSet(unittest.TestCase):
             else:
                 self.assertNotIn(c, self.s)
 
-    # TODO: RUSTPYTHON
-    @unittest.expectedFailure
     def test_inplace_on_self(self):
         t = self.s.copy()
         t |= t


### PR DESCRIPTION
updated &= and -= so that it produces the right result when you do an operation on self:
s=set()
s &= s
s -= s