### PR TITLE
resolve unittest error in test_sort.py

### DIFF
--- a/Lib/test/test_sort.py
+++ b/Lib/test/test_sort.py
@@ -383,8 +383,6 @@ class TestOptimizedCompares(unittest.TestCase):
         self.assertRaises(TypeError, [('a', 1), (1, 'a')].sort)
         self.assertRaises(TypeError, [(1, 'a'), ('a', 1)].sort)
 
-    # TODO: RUSTPYTHON
-    @unittest.expectedFailure
     def test_none_in_tuples(self):
         expected = [(None, 1), (None, 2)]
         actual = sorted([(None, 2), (None, 1)])

--- a/vm/src/iter.rs
+++ b/vm/src/iter.rs
@@ -34,6 +34,9 @@ pub trait PyExactSizeIterator<'a>: ExactSizeIterator<Item = &'a PyObjectRef> + S
         let lhs_len = lhs.len();
         let rhs_len = rhs.len();
         for (a, b) in lhs.zip(rhs) {
+            if vm.bool_eq(a, b)? {
+                continue;
+            }
             let ret = if less {
                 vm.bool_seq_lt(a, b)?
             } else {


### PR DESCRIPTION
modified `richcompare` fn in `iter.rs` to #4564 resolve unittest error in `test_sort.py`

removed TODO mark in `test_sort.py`