### PR TITLE
Fix issue with cformat converting bytes to string for bytesinner

### DIFF
--- a/Lib/test/test_bytes.py
+++ b/Lib/test/test_bytes.py
@@ -704,8 +704,6 @@ class BaseBytesTest:
         self.assertEqual(b.rindex(i, 3, 9), 7)
         self.assertRaises(ValueError, b.rindex, w, 1, 3)
 
-    # TODO: RUSTPYTHON
-    @unittest.expectedFailure
     def test_mod(self):
         b = self.type2test(b'hello, %b!')
         orig = b

--- a/Lib/test/test_bytes.py
+++ b/Lib/test/test_bytes.py
@@ -704,6 +704,8 @@ class BaseBytesTest:
         self.assertEqual(b.rindex(i, 3, 9), 7)
         self.assertRaises(ValueError, b.rindex, w, 1, 3)
 
+    # TODO: RUSTPYTHON
+    @unittest.expectedFailure
     def test_mod(self):
         b = self.type2test(b'hello, %b!')
         orig = b

--- a/vm/src/cformat.rs
+++ b/vm/src/cformat.rs
@@ -293,7 +293,10 @@ pub(crate) fn cformat_bytes(
                     CFormatPart::Literal(literal) => result.append(literal),
                     CFormatPart::Spec(spec) => {
                         let value = match &spec.mapping_key {
-                            Some(key) => values_obj.get_item(key.as_str(), vm)?,
+                            Some(key) => {
+                                let k = vm.ctx.new_bytes(key.as_str().as_bytes().to_vec());
+                                values_obj.get_item(k.as_object(), vm)?
+                            }
                             None => unreachable!(),
                         };
                         let mut part_result = spec_format_bytes(vm, spec, value)?;


### PR DESCRIPTION
This is a follow-up of the following PR
https://github.com/RustPython/RustPython/pull/4746

It addresses the failing test case for test_mod, where,

```
b'...%(foo)b...' % {b'foo':b"abc"}
```

caused invalid key error for 'foo'

The cause of this issue was that individual tokens in bytesinner were converted to string before being used for string formatting, but the token being addressed was expected to be in bytes.

It was addressed by making sure that it is treated as bytes.

