### PR TITLE
Allow try_update_quantity_from_tuple to set left alignment when needed

### DIFF
--- a/Lib/test/test_bytes.py
+++ b/Lib/test/test_bytes.py
@@ -704,8 +704,6 @@ class BaseBytesTest:
         self.assertEqual(b.rindex(i, 3, 9), 7)
         self.assertRaises(ValueError, b.rindex, w, 1, 3)
 
-    # TODO: RUSTPYTHON
-    @unittest.expectedFailure
     def test_mod(self):
         b = self.type2test(b'hello, %b!')
         orig = b

--- a/common/src/cformat.rs
+++ b/common/src/cformat.rs
@@ -754,6 +754,12 @@ impl CFormatString {
     }
 }
 
+#[derive(Debug, Copy, Clone, PartialEq)]
+pub enum CFormatAlign {
+    Left,
+    Right,
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/common/src/cformat.rs
+++ b/common/src/cformat.rs
@@ -754,12 +754,6 @@ impl CFormatString {
     }
 }
 
-#[derive(Debug, Copy, Clone, PartialEq)]
-pub enum CFormatAlign {
-    Left,
-    Right,
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/vm/src/cformat.rs
+++ b/vm/src/cformat.rs
@@ -218,19 +218,20 @@ fn try_update_quantity_from_element(
     }
 }
 
-fn try_update_adjust_from_tuple(
+fn try_conversion_flag_from_tuple(
     vm: &VirtualMachine,
     element: Option<&PyObjectRef>,
-    f: &mut CConversionFlags,
-) -> PyResult<()> {
+) -> PyResult<CConversionFlags> {
     match element {
         Some(width_obj) => {
             if let Some(i) = width_obj.payload::<PyInt>() {
                 let i = i.try_to_primitive::<i32>(vm)?;
-                if i < 0 {
-                    f.insert(CConversionFlags::LEFT_ADJUST)
-                }
-                Ok(())
+                let flags = if i < 0 {
+                    CConversionFlags::LEFT_ADJUST
+                } else {
+                    CConversionFlags::from_bits(0).unwrap()
+                };
+                Ok(flags)
             } else {
                 Err(vm.new_type_error("* wants int".to_owned()))
             }
@@ -249,7 +250,7 @@ fn try_update_quantity_from_tuple<'a, I: Iterator<Item = &'a PyObjectRef>>(
         return Ok(());
     };
     let element = elements.next();
-    try_update_adjust_from_tuple(vm, element, f)?;
+    f.insert(try_conversion_flag_from_tuple(vm, element)?);
     let quantity = try_update_quantity_from_element(vm, element)?;
     *q = Some(quantity);
     Ok(())

--- a/vm/src/cformat.rs
+++ b/vm/src/cformat.rs
@@ -209,12 +209,11 @@ fn try_update_quantity_from_element(
         Some(width_obj) => {
             if let Some(i) = width_obj.payload::<PyInt>() {
                 let i = i.try_to_primitive::<i32>(vm)?;
-                let align: CFormatAlign;
-                if i < 0 {
-                    align = CFormatAlign::Left;
+                let align = if i < 0 {
+                    CFormatAlign::Left
                 } else {
-                    align = CFormatAlign::Right;
-                }
+                    CFormatAlign::Right
+                };
                 let i = i.unsigned_abs();
                 Ok((CFormatQuantity::Amount(i as usize), align))
             } else {
@@ -333,7 +332,12 @@ pub(crate) fn cformat_bytes(
         match part {
             CFormatPart::Literal(literal) => result.append(literal),
             CFormatPart::Spec(spec) => {
-                try_update_quantity_from_tuple(vm, &mut value_iter, &mut spec.min_field_width, &mut spec.flags)?;
+                try_update_quantity_from_tuple(
+                    vm,
+                    &mut value_iter,
+                    &mut spec.min_field_width,
+                    &mut spec.flags,
+                )?;
                 try_update_precision_from_tuple(vm, &mut value_iter, &mut spec.precision)?;
 
                 let value = match value_iter.next() {
@@ -427,7 +431,12 @@ pub(crate) fn cformat_string(
         match part {
             CFormatPart::Literal(literal) => result.push_str(literal),
             CFormatPart::Spec(spec) => {
-                try_update_quantity_from_tuple(vm, &mut value_iter, &mut spec.min_field_width, &mut spec.flags)?;
+                try_update_quantity_from_tuple(
+                    vm,
+                    &mut value_iter,
+                    &mut spec.min_field_width,
+                    &mut spec.flags,
+                )?;
                 try_update_precision_from_tuple(vm, &mut value_iter, &mut spec.precision)?;
 
                 let value = match value_iter.next() {


### PR DESCRIPTION
More details can be found here
https://github.com/RustPython/RustPython/issues/4762

It was the last issue that made test_mod to fail, so I also removed the expectedFailure flag from that test.