### PR TITLE
Update GH Actions to use Node 16

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -113,7 +113,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - name: Cache generated parser
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: compiler/parser/python.rs
           key: lalrpop-${{ hashFiles('compiler/parser/python.lalrpop') }}
@@ -171,7 +171,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - name: Cache generated parser
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: compiler/parser/python.rs
           key: lalrpop-${{ hashFiles('compiler/parser/python.lalrpop') }}
@@ -250,7 +250,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - name: Cache generated parser
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: compiler/parser/python.rs
           key: lalrpop-${{ hashFiles('compiler/parser/python.lalrpop') }}
@@ -321,7 +321,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - name: Cache generated parser
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: compiler/parser/python.rs
           key: lalrpop-${{ hashFiles('compiler/parser/python.lalrpop') }}
@@ -351,7 +351,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - name: Cache generated parser
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: compiler/parser/python.rs
           key: lalrpop-${{ hashFiles('compiler/parser/python.lalrpop') }}
@@ -385,7 +385,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - name: Cache generated parser
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: compiler/parser/python.rs
           key: lalrpop-${{ hashFiles('compiler/parser/python.lalrpop') }}
@@ -408,7 +408,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - name: Cache generated parser
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: compiler/parser/python.rs
           key: lalrpop-${{ hashFiles('compiler/parser/python.lalrpop') }}
@@ -458,7 +458,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - name: Cache generated parser
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: compiler/parser/python.rs
           key: lalrpop-${{ hashFiles('compiler/parser/python.lalrpop') }}

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -327,7 +327,7 @@ jobs:
           key: lalrpop-${{ hashFiles('compiler/parser/python.lalrpop') }}
       - name: Check if cached generated parser exists
         id: generated_parser
-        uses: andstor/file-existence-action@v1
+        uses: andstor/file-existence-action@v2
         with:
           files: "compiler/parser/python.rs"
       - if: runner.os == 'Windows'

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -427,7 +427,7 @@ jobs:
           python-version: "3.11"
       - run: python -m pip install -r requirements.txt
         working-directory: ./wasm/tests
-      - uses: actions/setup-node@v1
+      - uses: actions/setup-node@v3
       - name: run test
         run: |
           export PATH=$PATH:`pwd`/../../geckodriver

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -256,7 +256,7 @@ jobs:
           key: lalrpop-${{ hashFiles('compiler/parser/python.lalrpop') }}
 
       - uses: dtolnay/rust-toolchain@stable
-      - uses: actions/setup-python@v2
+      - uses: actions/setup-python@v4
         with:
           python-version: "3.11"
       - name: Set up the Windows environment
@@ -272,7 +272,7 @@ jobs:
       - uses: Swatinem/rust-cache@v2
       - name: build rustpython
         run: cargo build --release --verbose --features=threading ${{ env.CARGO_ARGS }}
-      - uses: actions/setup-python@v2
+      - uses: actions/setup-python@v4
         with:
           python-version: "3.11"
       - name: run snippets
@@ -362,7 +362,7 @@ jobs:
         run: cargo fmt --all -- --check
       - name: run clippy on wasm
         run: cargo clippy --manifest-path=wasm/lib/Cargo.toml -- -Dwarnings
-      - uses: actions/setup-python@v2
+      - uses: actions/setup-python@v4
         with:
           python-version: "3.11"
       - name: install flake8
@@ -422,7 +422,7 @@ jobs:
           wget https://github.com/mozilla/geckodriver/releases/download/v0.30.0/geckodriver-v0.30.0-linux64.tar.gz
           mkdir geckodriver
           tar -xzf geckodriver-v0.30.0-linux64.tar.gz -C geckodriver
-      - uses: actions/setup-python@v2
+      - uses: actions/setup-python@v4
         with:
           python-version: "3.11"
       - run: python -m pip install -r requirements.txt

--- a/.github/workflows/cron-ci.yaml
+++ b/.github/workflows/cron-ci.yaml
@@ -27,7 +27,7 @@ jobs:
       - run: cargo build --release --verbose ${{ env.CARGO_ARGS }}
         env:
           RUSTC_WRAPPER: './scripts/codecoverage-rustc-wrapper.sh'
-      - uses: actions/setup-python@v2
+      - uses: actions/setup-python@v4
         with:
           python-version: "3.11"
       - run: python -m pip install pytest
@@ -145,7 +145,7 @@ jobs:
           path: compiler/parser/python.rs
           key: lalrpop-${{ hashFiles('compiler/parser/python.lalrpop') }}
       - uses: dtolnay/rust-toolchain@stable
-      - uses: actions/setup-python@v2
+      - uses: actions/setup-python@v4
         with:
           python-version: 3.9
       - run: cargo install cargo-criterion

--- a/.github/workflows/cron-ci.yaml
+++ b/.github/workflows/cron-ci.yaml
@@ -199,7 +199,7 @@ jobs:
           key: lalrpop-${{ hashFiles('compiler/parser/python.lalrpop') }}
       - name: Check if cached generated parser exists
         id: generated_parser
-        uses: andstor/file-existence-action@v1
+        uses: andstor/file-existence-action@v2
         with:
           files: "compiler/parser/python.rs"
       - if: runner.os == 'Windows'

--- a/.github/workflows/cron-ci.yaml
+++ b/.github/workflows/cron-ci.yaml
@@ -16,7 +16,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - name: Cache generated parser
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: compiler/parser/python.rs
           key: lalrpop-${{ hashFiles('compiler/parser/python.lalrpop') }}
@@ -67,7 +67,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - name: Cache generated parser
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: compiler/parser/python.rs
           key: lalrpop-${{ hashFiles('compiler/parser/python.lalrpop') }}
@@ -102,7 +102,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - name: Cache generated parser
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: compiler/parser/python.rs
           key: lalrpop-${{ hashFiles('compiler/parser/python.lalrpop') }}
@@ -140,7 +140,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - name: Cache generated parser
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: compiler/parser/python.rs
           key: lalrpop-${{ hashFiles('compiler/parser/python.lalrpop') }}
@@ -193,7 +193,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - name: Cache generated parser
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: compiler/parser/python.rs
           key: lalrpop-${{ hashFiles('compiler/parser/python.lalrpop') }}


### PR DESCRIPTION
This updates most of our old actions to use Node 16, as [GitHub Actions is deprecating Node 12 actions to Node 16.](https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/)

- Update actions/cache@v2 to v3
- Update andstor/file-existence-action@v1 to v2
- Update actions/setup-python@v2 to v4
- Update actions/setup-node@v1 to v3
