### PR TITLE
relocate FsPath from stdlib::os and rename PyPathLike to OsPath

### DIFF
--- a/common/src/os.rs
+++ b/common/src/os.rs
@@ -1,6 +1,6 @@
 // TODO: we can move more os-specific bindings/interfaces from stdlib::{os, posix, nt} to here
 
-use std::io;
+use std::{io, str::Utf8Error};
 
 #[cfg(windows)]
 pub fn errno() -> io::Error {
@@ -20,4 +20,15 @@ pub fn errno() -> io::Error {
 #[cfg(not(windows))]
 pub fn errno() -> io::Error {
     io::Error::last_os_error()
+}
+
+#[cfg(unix)]
+pub fn bytes_as_osstr(b: &[u8]) -> Result<&std::ffi::OsStr, Utf8Error> {
+    use std::os::unix::ffi::OsStrExt;
+    Ok(std::ffi::OsStr::from_bytes(b))
+}
+
+#[cfg(not(unix))]
+pub fn bytes_as_osstr(b: &[u8]) -> Result<&std::ffi::OsStr, Utf8Error> {
+    Ok(std::str::from_utf8(b)?.as_ref())
 }

--- a/common/src/os.rs
+++ b/common/src/os.rs
@@ -32,3 +32,8 @@ pub fn bytes_as_osstr(b: &[u8]) -> Result<&std::ffi::OsStr, Utf8Error> {
 pub fn bytes_as_osstr(b: &[u8]) -> Result<&std::ffi::OsStr, Utf8Error> {
     Ok(std::str::from_utf8(b)?.as_ref())
 }
+
+#[cfg(unix)]
+pub use std::os::unix::ffi;
+#[cfg(target_os = "wasi")]
+pub use std::os::wasi::ffi;

--- a/stdlib/src/posixsubprocess.rs
+++ b/stdlib/src/posixsubprocess.rs
@@ -1,7 +1,7 @@
 use crate::vm::{
     builtins::PyListRef,
     function::ArgSequence,
-    stdlib::{os::PyPathLike, posix},
+    stdlib::{os::OsPath, posix},
     {PyObjectRef, PyResult, TryFromObject, VirtualMachine},
 };
 use nix::{errno::Errno, unistd};
@@ -60,7 +60,7 @@ struct CStrPathLike {
 }
 impl TryFromObject for CStrPathLike {
     fn try_from_object(vm: &VirtualMachine, obj: PyObjectRef) -> PyResult<Self> {
-        let s = PyPathLike::try_from_object(vm, obj)?.into_cstring(vm)?;
+        let s = OsPath::try_from_object(vm, obj)?.into_cstring(vm)?;
         Ok(CStrPathLike { s })
     }
 }

--- a/stdlib/src/socket.rs
+++ b/stdlib/src/socket.rs
@@ -14,7 +14,7 @@ mod _socket {
     use crate::vm::{
         builtins::{PyBaseExceptionRef, PyListRef, PyStrRef, PyTupleRef, PyTypeRef},
         convert::{IntoPyException, ToPyObject, TryFromBorrowedObject, TryFromObject},
-        function::{ArgBytesLike, ArgMemoryBuffer, Either, OptionalArg, OptionalOption},
+        function::{ArgBytesLike, ArgMemoryBuffer, Either, FsPath, OptionalArg, OptionalOption},
         types::{DefaultConstructor, Initializer},
         utils::ToCString,
         AsObject, PyObjectRef, PyPayload, PyRef, PyResult, VirtualMachine,
@@ -1977,12 +1977,10 @@ mod _socket {
 
     #[cfg(not(target_os = "redox"))]
     #[pyfunction]
-    fn if_nametoindex(name: PyObjectRef, vm: &VirtualMachine) -> PyResult<IfIndex> {
-        let name = crate::vm::stdlib::os::FsPath::try_from(name, true, vm)?;
-        let name = ffi::CString::new(name.as_bytes()).map_err(|err| err.into_pyexception(vm))?;
+    fn if_nametoindex(name: FsPath, vm: &VirtualMachine) -> PyResult<IfIndex> {
+        let name = name.to_cstring(vm)?;
 
         let ret = unsafe { c::if_nametoindex(name.as_ptr()) };
-
         if ret == 0 {
             Err(vm.new_os_error("no interface with this name".to_owned()))
         } else {

--- a/stdlib/src/sqlite.rs
+++ b/stdlib/src/sqlite.rs
@@ -58,10 +58,9 @@ mod _sqlite {
             PyInt, PyIntRef, PySlice, PyStr, PyStrRef, PyTuple, PyTupleRef, PyType, PyTypeRef,
         },
         convert::IntoObject,
-        function::{ArgCallable, ArgIterable, FuncArgs, OptionalArg, PyComparisonValue},
+        function::{ArgCallable, ArgIterable, FsPath, FuncArgs, OptionalArg, PyComparisonValue},
         protocol::{PyBuffer, PyIterReturn, PyMappingMethods, PySequence, PySequenceMethods},
         sliceable::{SaturatedSliceIter, SliceableSequenceOp},
-        stdlib::os::PyPathLike,
         types::{
             AsMapping, AsSequence, Callable, Comparable, Constructor, Hashable, IterNext,
             IterNextIterable, Iterable, PyComparisonOp,
@@ -293,7 +292,7 @@ mod _sqlite {
     #[derive(FromArgs)]
     struct ConnectArgs {
         #[pyarg(any)]
-        database: PyPathLike,
+        database: FsPath,
         #[pyarg(any, default = "5.0")]
         timeout: f64,
         #[pyarg(any, default = "0")]
@@ -828,7 +827,7 @@ mod _sqlite {
     #[pyclass(with(Constructor, Callable), flags(BASETYPE))]
     impl Connection {
         fn new(args: ConnectArgs, vm: &VirtualMachine) -> PyResult<Self> {
-            let path = args.database.into_cstring(vm)?;
+            let path = args.database.to_cstring(vm)?;
             let db = Sqlite::from(SqliteRaw::open(path.as_ptr(), args.uri, vm)?);
             let timeout = (args.timeout * 1000.0) as c_int;
             db.busy_timeout(timeout);

--- a/vm/src/function/fspath.rs
+++ b/vm/src/function/fspath.rs
@@ -1,0 +1,130 @@
+use crate::{
+    builtins::{PyBytes, PyBytesRef, PyStrRef},
+    convert::{IntoPyException, ToPyObject},
+    function::PyStr,
+    protocol::PyBuffer,
+    PyObjectRef, PyResult, TryFromObject, VirtualMachine,
+};
+use std::{ffi::OsStr, path::PathBuf};
+
+#[derive(Clone)]
+pub enum FsPath {
+    Str(PyStrRef),
+    Bytes(PyBytesRef),
+}
+
+impl FsPath {
+    // PyOS_FSPath in CPython
+    pub fn try_from(obj: PyObjectRef, check_for_nul: bool, vm: &VirtualMachine) -> PyResult<Self> {
+        let check_nul = |b: &[u8]| {
+            if !check_for_nul || memchr::memchr(b'\0', b).is_none() {
+                Ok(())
+            } else {
+                Err(crate::exceptions::cstring_error(vm))
+            }
+        };
+        let match1 = |obj: PyObjectRef| {
+            let pathlike = match_class!(match obj {
+                s @ PyStr => {
+                    check_nul(s.as_str().as_bytes())?;
+                    FsPath::Str(s)
+                }
+                b @ PyBytes => {
+                    check_nul(&b)?;
+                    FsPath::Bytes(b)
+                }
+                obj => return Ok(Err(obj)),
+            });
+            Ok(Ok(pathlike))
+        };
+        let obj = match match1(obj)? {
+            Ok(pathlike) => return Ok(pathlike),
+            Err(obj) => obj,
+        };
+        let method =
+            vm.get_method_or_type_error(obj.clone(), identifier!(vm, __fspath__), || {
+                format!(
+                    "should be string, bytes, os.PathLike or integer, not {}",
+                    obj.class().name()
+                )
+            })?;
+        let result = method.call((), vm)?;
+        match1(result)?.map_err(|result| {
+            vm.new_type_error(format!(
+                "expected {}.__fspath__() to return str or bytes, not {}",
+                obj.class().name(),
+                result.class().name(),
+            ))
+        })
+    }
+
+    pub fn as_os_str(&self, vm: &VirtualMachine) -> PyResult<&OsStr> {
+        // TODO: FS encodings
+        match self {
+            FsPath::Str(s) => Ok(s.as_str().as_ref()),
+            FsPath::Bytes(b) => Self::bytes_as_osstr(b.as_bytes(), vm),
+        }
+    }
+
+    pub fn as_bytes(&self) -> &[u8] {
+        // TODO: FS encodings
+        match self {
+            FsPath::Str(s) => s.as_str().as_bytes(),
+            FsPath::Bytes(b) => b.as_bytes(),
+        }
+    }
+
+    pub fn as_str(&self) -> &str {
+        match self {
+            FsPath::Bytes(b) => std::str::from_utf8(b).unwrap(),
+            FsPath::Str(s) => s.as_str(),
+        }
+    }
+
+    pub fn to_path_buf(&self, vm: &VirtualMachine) -> PyResult<PathBuf> {
+        let path = match self {
+            FsPath::Str(s) => PathBuf::from(s.as_str()),
+            FsPath::Bytes(b) => PathBuf::from(Self::bytes_as_osstr(b, vm)?),
+        };
+        Ok(path)
+    }
+
+    pub fn to_cstring(&self, vm: &VirtualMachine) -> PyResult<std::ffi::CString> {
+        std::ffi::CString::new(self.as_bytes()).map_err(|e| e.into_pyexception(vm))
+    }
+
+    #[cfg(windows)]
+    pub fn to_widecstring(&self, vm: &VirtualMachine) -> PyResult<widestring::WideCString> {
+        widestring::WideCString::from_os_str(self.as_os_str(vm)?)
+            .map_err(|err| err.into_pyexception(vm))
+    }
+
+    pub fn bytes_as_osstr<'a>(b: &'a [u8], vm: &VirtualMachine) -> PyResult<&'a std::ffi::OsStr> {
+        rustpython_common::os::bytes_as_osstr(b)
+            .map_err(|_| vm.new_unicode_decode_error("can't decode path for utf-8".to_owned()))
+    }
+}
+
+impl ToPyObject for FsPath {
+    fn to_pyobject(self, _vm: &VirtualMachine) -> PyObjectRef {
+        match self {
+            Self::Str(s) => s.into(),
+            Self::Bytes(b) => b.into(),
+        }
+    }
+}
+
+impl TryFromObject for FsPath {
+    // PyUnicode_FSDecoder in CPython
+    fn try_from_object(vm: &VirtualMachine, obj: PyObjectRef) -> PyResult<Self> {
+        let obj = match obj.try_to_value::<PyBuffer>(vm) {
+            Ok(buffer) => {
+                let mut bytes = vec![];
+                buffer.append_to(&mut bytes);
+                vm.ctx.new_bytes(bytes).into()
+            }
+            Err(_) => obj,
+        };
+        Self::try_from(obj, true, vm)
+    }
+}

--- a/vm/src/function/mod.rs
+++ b/vm/src/function/mod.rs
@@ -3,6 +3,7 @@ mod arithmetic;
 mod buffer;
 mod builtin;
 mod either;
+mod fspath;
 mod getset;
 mod number;
 mod protocol;
@@ -16,6 +17,7 @@ pub use buffer::{ArgAsciiBuffer, ArgBytesLike, ArgMemoryBuffer, ArgStrOrBytesLik
 pub(self) use builtin::{BorrowedParam, OwnedParam, RefParam};
 pub use builtin::{IntoPyNativeFunc, PyNativeFunc};
 pub use either::Either;
+pub use fspath::FsPath;
 pub use getset::PySetterValue;
 pub(super) use getset::{IntoPyGetterFunc, IntoPySetterFunc, PyGetterFunc, PySetterFunc};
 pub use number::{ArgIndex, ArgIntoBool, ArgIntoComplex, ArgIntoFloat, ArgPrimitiveIndex, ArgSize};

--- a/vm/src/stdlib/io.rs
+++ b/vm/src/stdlib/io.rs
@@ -3541,7 +3541,7 @@ mod _io {
 
         // check file descriptor validity
         #[cfg(unix)]
-        if let Ok(crate::stdlib::os::PathOrFd::Fd(fd)) = file.clone().try_into_value(vm) {
+        if let Ok(crate::stdlib::os::OsPathOrFd::Fd(fd)) = file.clone().try_into_value(vm) {
             nix::fcntl::fcntl(fd, nix::fcntl::F_GETFD)
                 .map_err(|_| crate::stdlib::os::errno_err(vm))?;
         }

--- a/vm/src/stdlib/io.rs
+++ b/vm/src/stdlib/io.rs
@@ -3703,7 +3703,7 @@ mod fileio {
         builtins::{PyStr, PyStrRef},
         common::crt_fd::Fd,
         convert::ToPyException,
-        function::{ArgBytesLike, ArgMemoryBuffer, FsPath, OptionalArg, OptionalOption},
+        function::{ArgBytesLike, ArgMemoryBuffer, OptionalArg, OptionalOption},
         stdlib::os,
         types::{DefaultConstructor, Initializer},
         AsObject, PyObjectRef, PyPayload, PyRef, PyResult, TryFromObject, VirtualMachine,
@@ -3870,19 +3870,13 @@ mod fileio {
             } else if let Some(i) = name.payload::<crate::builtins::PyInt>() {
                 i.try_to_primitive(vm)?
             } else {
-                let path = FsPath::try_from_object(vm, name.clone())?;
+                let path = os::OsPath::try_from_object(vm, name.clone())?;
                 if !args.closefd {
                     return Err(
                         vm.new_value_error("Cannot use closefd=False with file name".to_owned())
                     );
                 }
-                os::open(
-                    path.to_pathlike(vm)?,
-                    flags as _,
-                    None,
-                    Default::default(),
-                    vm,
-                )?
+                os::open(path, flags as _, None, Default::default(), vm)?
             };
 
             if mode.contains(Mode::APPENDING) {

--- a/vm/src/stdlib/nt.rs
+++ b/vm/src/stdlib/nt.rs
@@ -60,7 +60,7 @@ pub(crate) mod module {
         let dir = args.target_is_directory.target_is_directory
             || args
                 .dst
-                .path
+                .as_path()
                 .parent()
                 .and_then(|dst_parent| dst_parent.join(&args.src).symlink_metadata().ok())
                 .map_or(false, |meta| meta.is_dir());
@@ -297,7 +297,7 @@ pub(crate) mod module {
 
     #[pyfunction]
     fn _path_splitroot(path: OsPath, vm: &VirtualMachine) -> PyResult<(String, String)> {
-        let orig: Vec<_> = path.path.into_os_string().encode_wide().collect();
+        let orig: Vec<_> = path.path.encode_wide().collect();
         if orig.is_empty() {
             return Ok(("".to_owned(), "".to_owned()));
         }

--- a/vm/src/stdlib/nt.rs
+++ b/vm/src/stdlib/nt.rs
@@ -17,7 +17,7 @@ pub(crate) mod module {
         function::Either,
         function::OptionalArg,
         stdlib::os::{
-            errno_err, DirFd, FollowSymlinks, PyPathLike, SupportFunc, TargetIsDirectory, _os,
+            errno_err, DirFd, FollowSymlinks, OsPath, SupportFunc, TargetIsDirectory, _os,
         },
         PyResult, TryFromObject, VirtualMachine,
     };
@@ -35,7 +35,7 @@ pub(crate) mod module {
     use libc::{O_BINARY, O_TEMPORARY};
 
     #[pyfunction]
-    pub(super) fn access(path: PyPathLike, mode: u8, vm: &VirtualMachine) -> PyResult<bool> {
+    pub(super) fn access(path: OsPath, mode: u8, vm: &VirtualMachine) -> PyResult<bool> {
         use um::{fileapi, winnt};
         let attr = unsafe { fileapi::GetFileAttributesW(path.to_widecstring(vm)?.as_ptr()) };
         Ok(attr != fileapi::INVALID_FILE_ATTRIBUTES
@@ -46,8 +46,8 @@ pub(crate) mod module {
 
     #[derive(FromArgs)]
     pub(super) struct SymlinkArgs {
-        src: PyPathLike,
-        dst: PyPathLike,
+        src: OsPath,
+        dst: OsPath,
         #[pyarg(flatten)]
         target_is_directory: TargetIsDirectory,
         #[pyarg(flatten)]
@@ -90,7 +90,7 @@ pub(crate) mod module {
 
     #[pyfunction]
     fn chmod(
-        path: PyPathLike,
+        path: OsPath,
         dir_fd: DirFd<0>,
         mode: u32,
         follow_symlinks: FollowSymlinks,
@@ -239,7 +239,7 @@ pub(crate) mod module {
     }
 
     #[pyfunction]
-    fn _getfinalpathname(path: PyPathLike, vm: &VirtualMachine) -> PyResult {
+    fn _getfinalpathname(path: OsPath, vm: &VirtualMachine) -> PyResult {
         let real = path
             .as_ref()
             .canonicalize()
@@ -248,7 +248,7 @@ pub(crate) mod module {
     }
 
     #[pyfunction]
-    fn _getfullpathname(path: PyPathLike, vm: &VirtualMachine) -> PyResult {
+    fn _getfullpathname(path: OsPath, vm: &VirtualMachine) -> PyResult {
         let wpath = path.to_widecstring(vm)?;
         let mut buffer = vec![0u16; winapi::shared::minwindef::MAX_PATH];
         let ret = unsafe {
@@ -281,7 +281,7 @@ pub(crate) mod module {
     }
 
     #[pyfunction]
-    fn _getvolumepathname(path: PyPathLike, vm: &VirtualMachine) -> PyResult {
+    fn _getvolumepathname(path: OsPath, vm: &VirtualMachine) -> PyResult {
         let wide = path.to_widecstring(vm)?;
         let buflen = std::cmp::max(wide.len(), winapi::shared::minwindef::MAX_PATH);
         let mut buffer = vec![0u16; buflen];
@@ -296,7 +296,7 @@ pub(crate) mod module {
     }
 
     #[pyfunction]
-    fn _path_splitroot(path: PyPathLike, vm: &VirtualMachine) -> PyResult<(String, String)> {
+    fn _path_splitroot(path: OsPath, vm: &VirtualMachine) -> PyResult<(String, String)> {
         let orig: Vec<_> = path.path.into_os_string().encode_wide().collect();
         if orig.is_empty() {
             return Ok(("".to_owned(), "".to_owned()));
@@ -334,7 +334,7 @@ pub(crate) mod module {
     }
 
     #[pyfunction]
-    fn _getdiskusage(path: PyPathLike, vm: &VirtualMachine) -> PyResult<(u64, u64)> {
+    fn _getdiskusage(path: OsPath, vm: &VirtualMachine) -> PyResult<(u64, u64)> {
         use um::fileapi::GetDiskFreeSpaceExW;
         use winapi::shared::{ntdef::ULARGE_INTEGER, winerror};
 
@@ -399,7 +399,7 @@ pub(crate) mod module {
 
     #[pyfunction]
     fn mkdir(
-        path: PyPathLike,
+        path: OsPath,
         mode: OptionalArg<i32>,
         dir_fd: DirFd<{ _os::MKDIR_DIR_FD as usize }>,
         vm: &VirtualMachine,

--- a/vm/src/stdlib/os.rs
+++ b/vm/src/stdlib/os.rs
@@ -378,13 +378,8 @@ pub(super) struct FollowSymlinks(
     #[pyarg(named, name = "follow_symlinks", default = "true")] pub bool,
 );
 
-#[cfg(unix)]
-use platform::bytes_as_osstr;
-
-#[cfg(not(unix))]
 fn bytes_as_osstr<'a>(b: &'a [u8], vm: &VirtualMachine) -> PyResult<&'a ffi::OsStr> {
-    std::str::from_utf8(b)
-        .map(|s| s.as_ref())
+    rustpython_common::os::bytes_as_osstr(b)
         .map_err(|_| vm.new_unicode_decode_error("can't decode path for utf-8".to_owned()))
 }
 

--- a/vm/src/stdlib/os.rs
+++ b/vm/src/stdlib/os.rs
@@ -130,9 +130,9 @@ pub(crate) enum OsPathOrFd {
 
 impl TryFromObject for OsPathOrFd {
     fn try_from_object(vm: &VirtualMachine, obj: PyObjectRef) -> PyResult<Self> {
-        let r = match obj.downcast::<PyInt>() {
-            Ok(int) => Self::Fd(int.try_to_primitive(vm)?),
-            Err(obj) => Self::Path(obj.try_into_value(vm)?),
+        let r = match obj.try_index_opt(vm) {
+            Some(int) => Self::Fd(int?.try_to_primitive(vm)?),
+            None => Self::Path(obj.try_into_value(vm)?),
         };
         Ok(r)
     }

--- a/vm/src/stdlib/os.rs
+++ b/vm/src/stdlib/os.rs
@@ -10,11 +10,6 @@ use std::{
     path::{Path, PathBuf},
 };
 
-#[cfg(unix)]
-use std::os::unix::ffi as ffi_ext;
-#[cfg(target_os = "wasi")]
-use std::os::wasi::ffi as ffi_ext;
-
 #[derive(Debug, Copy, Clone)]
 pub(super) enum OutputMode {
     String,
@@ -36,7 +31,7 @@ impl OutputMode {
                 OutputMode::Bytes => {
                     #[cfg(any(unix, target_os = "wasi"))]
                     {
-                        use ffi_ext::OsStringExt;
+                        use rustpython_common::os::ffi::OsStringExt;
                         Ok(vm.ctx.new_bytes(path.into_os_string().into_vec()).into())
                     }
                     #[cfg(windows)]
@@ -66,7 +61,7 @@ impl PyPathLike {
 
     #[cfg(any(unix, target_os = "wasi"))]
     pub fn into_bytes(self) -> Vec<u8> {
-        use ffi_ext::OsStringExt;
+        use rustpython_common::os::ffi::OsStringExt;
         self.path.into_os_string().into_vec()
     }
 
@@ -524,7 +519,7 @@ pub(super) mod _os {
                 }
                 #[cfg(all(unix, not(target_os = "redox")))]
                 {
-                    use super::ffi_ext::OsStrExt;
+                    use rustpython_common::os::ffi::OsStrExt;
                     let new_fd = nix::unistd::dup(fno).map_err(|e| e.into_pyexception(vm))?;
                     let mut dir =
                         nix::dir::Dir::from_fd(new_fd).map_err(|e| e.into_pyexception(vm))?;
@@ -1060,7 +1055,7 @@ pub(super) mod _os {
         let mut stat = std::mem::MaybeUninit::uninit();
         let ret = match file {
             PathOrFd::Path(path) => {
-                use super::ffi_ext::OsStrExt;
+                use rustpython_common::os::ffi::OsStrExt;
                 let path = path.as_ref().as_os_str().as_bytes();
                 let path = match ffi::CString::new(path) {
                     Ok(x) => x,

--- a/vm/src/stdlib/posix.rs
+++ b/vm/src/stdlib/posix.rs
@@ -1,4 +1,4 @@
-use crate::{PyObjectRef, PyResult, VirtualMachine};
+use crate::{PyObjectRef, VirtualMachine};
 use std::os::unix::io::RawFd;
 
 pub fn raw_set_inheritable(fd: RawFd, inheritable: bool) -> nix::Result<()> {
@@ -10,14 +10,6 @@ pub fn raw_set_inheritable(fd: RawFd, inheritable: bool) -> nix::Result<()> {
         fcntl::fcntl(fd, fcntl::FcntlArg::F_SETFD(new_flags))?;
     }
     Ok(())
-}
-
-pub(super) fn bytes_as_osstr<'a>(
-    b: &'a [u8],
-    _vm: &VirtualMachine,
-) -> PyResult<&'a std::ffi::OsStr> {
-    use std::os::unix::ffi::OsStrExt;
-    Ok(std::ffi::OsStr::from_bytes(b))
 }
 
 pub(crate) fn make_module(vm: &VirtualMachine) -> PyObjectRef {

--- a/vm/src/stdlib/posix.rs
+++ b/vm/src/stdlib/posix.rs
@@ -41,7 +41,7 @@ pub mod module {
         env,
         ffi::{CStr, CString},
         fs, io,
-        os::unix::{ffi as ffi_ext, io::RawFd},
+        os::unix::io::RawFd,
     };
     use strum_macros::{EnumIter, EnumString};
 
@@ -285,7 +285,7 @@ pub mod module {
 
     #[pyattr]
     fn environ(vm: &VirtualMachine) -> PyDictRef {
-        use ffi_ext::OsStringExt;
+        use rustpython_common::os::ffi::OsStringExt;
 
         let environ = vm.ctx.new_dict();
         for (key, value) in env::vars_os() {

--- a/vm/src/stdlib/posix_compat.rs
+++ b/vm/src/stdlib/posix_compat.rs
@@ -12,7 +12,7 @@ pub(crate) fn make_module(vm: &VirtualMachine) -> PyObjectRef {
 pub(crate) mod module {
     use crate::{
         builtins::PyStrRef,
-        stdlib::os::{DirFd, PyPathLike, SupportFunc, TargetIsDirectory, _os},
+        stdlib::os::{DirFd, OsPath, SupportFunc, TargetIsDirectory, _os},
         PyObjectRef, PyResult, VirtualMachine,
     };
     use std::env;
@@ -25,8 +25,8 @@ pub(crate) mod module {
     #[derive(FromArgs)]
     #[allow(unused)]
     pub(super) struct SymlinkArgs {
-        src: PyPathLike,
-        dst: PyPathLike,
+        src: OsPath,
+        dst: OsPath,
         #[pyarg(flatten)]
         _target_is_directory: TargetIsDirectory,
         #[pyarg(flatten)]

--- a/vm/src/stdlib/posix_compat.rs
+++ b/vm/src/stdlib/posix_compat.rs
@@ -16,10 +16,6 @@ pub(crate) mod module {
         PyObjectRef, PyResult, VirtualMachine,
     };
     use std::env;
-    #[cfg(unix)]
-    use std::os::unix::ffi as ffi_ext;
-    #[cfg(target_os = "wasi")]
-    use std::os::wasi::ffi as ffi_ext;
 
     #[pyfunction]
     pub(super) fn access(_path: PyStrRef, _mode: u8, vm: &VirtualMachine) -> PyResult<bool> {
@@ -45,7 +41,7 @@ pub(crate) mod module {
     #[cfg(target_os = "wasi")]
     #[pyattr]
     fn environ(vm: &VirtualMachine) -> crate::builtins::PyDictRef {
-        use ffi_ext::OsStringExt;
+        use rustpython_common::os::ffi::OsStringExt;
 
         let environ = vm.ctx.new_dict();
         for (key, value) in env::vars_os() {


### PR DESCRIPTION
FsPath work to support #4773 

cc @ilp-sys 

`PyPathLike` is defined in `posixmodule` as `path_t`.
But FsPath is more common concept.

`PyPathLike` also is not a python object. We don't prefix non-python object with `Py` anymore without good reasons