### PR TITLE
remove labeled event from ci trigger to prevent re-run ci whenever label added

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -2,7 +2,7 @@ on:
   push:
     branches: [main, release]
   pull_request:
-    types: [labeled, unlabeled, opened, synchronize, reopened]
+    types: [unlabeled, opened, synchronize, reopened]
   merge_group:
 
 name: CI


### PR DESCRIPTION
need some hack to add new label and remove one will be required, but at least it will not run meaningless actions 