### PR TITLE
Don't run whats_left with older CPython versions

### DIFF
--- a/whats_left.py
+++ b/whats_left.py
@@ -490,7 +490,7 @@ if args.signature:
             if rustpy_value is None or rustpy_value.startswith("ValueError("):
                 rustpy_value = f" {rustpy_value}"
             print(f"{item}{rustpy_value}")
-            if cpython_value is None or cpython_value.startswith("ValueError("):
+            if cpython_value is None:
                 cpython_value = f" {cpython_value}"
             print(f"{' ' * len(item)}{cpython_value}")
             if i < len(mismatched) - 1:


### PR DESCRIPTION
I added a check that whats_left is being run with CPython 3.11 or newer, as suggested here https://github.com/RustPython/RustPython/pull/4255#issuecomment-1298014225 and also put one signature under the other to make them easier to compare