### PR TITLE
Implemented tp_repr slots for more types

### DIFF
--- a/stdlib/src/contextvars.rs
+++ b/stdlib/src/contextvars.rs
@@ -5,8 +5,8 @@ mod _contextvars {
     use crate::vm::{
         builtins::{PyFunction, PyStrRef, PyTypeRef},
         function::{ArgCallable, FuncArgs, OptionalArg},
-        types::Initializer,
-        PyObjectRef, PyPayload, PyRef, PyResult, VirtualMachine,
+        types::{Initializer, Representable},
+        Py, PyObjectRef, PyPayload, PyRef, PyResult, VirtualMachine,
     };
 
     #[pyattr]
@@ -99,7 +99,7 @@ mod _contextvars {
         default: OptionalArg<PyObjectRef>,
     }
 
-    #[pyclass(with(Initializer))]
+    #[pyclass(with(Initializer, Representable))]
     impl ContextVar {
         #[pygetset]
         fn name(&self) -> String {
@@ -133,17 +133,6 @@ mod _contextvars {
         fn class_getitem(_cls: PyTypeRef, _key: PyStrRef, _vm: &VirtualMachine) -> PyResult<()> {
             unimplemented!("ContextVar.__class_getitem__() is currently under construction")
         }
-
-        #[pymethod(magic)]
-        fn repr(_zelf: PyRef<Self>, _vm: &VirtualMachine) -> String {
-            unimplemented!("<ContextVar name={{}} default={{}} at {{}}")
-            // format!(
-            //     "<ContextVar name={} default={:?} at {:#x}>",
-            //     zelf.name.as_str(),
-            //     zelf.default.map_or("", |x| PyStr::from(*x).as_str()),
-            //     zelf.get_id()
-            // )
-        }
     }
 
     impl Initializer for ContextVar {
@@ -151,6 +140,19 @@ mod _contextvars {
 
         fn init(_obj: PyRef<Self>, _args: Self::Args, _vm: &VirtualMachine) -> PyResult<()> {
             unimplemented!("ContextVar.__init__() is currently under construction")
+        }
+    }
+
+    impl Representable for ContextVar {
+        #[inline]
+        fn repr_str(_zelf: &Py<Self>, _vm: &VirtualMachine) -> PyResult<String> {
+            unimplemented!("<ContextVar name={{}} default={{}} at {{}}")
+            // format!(
+            //     "<ContextVar name={} default={:?} at {:#x}>",
+            //     zelf.name.as_str(),
+            //     zelf.default.map_or("", |x| PyStr::from(*x).as_str()),
+            //     zelf.get_id()
+            // )
         }
     }
 
@@ -172,7 +174,7 @@ mod _contextvars {
         old_value: PyObjectRef,
     }
 
-    #[pyclass(with(Initializer))]
+    #[pyclass(with(Initializer, Representable))]
     impl ContextToken {
         #[pygetset]
         fn var(&self, _vm: &VirtualMachine) -> PyObjectRef {
@@ -183,11 +185,6 @@ mod _contextvars {
         fn old_value(&self, _vm: &VirtualMachine) -> PyObjectRef {
             unimplemented!("Token.old_value() is currently under construction")
         }
-
-        #[pymethod(magic)]
-        fn repr(_zelf: PyRef<Self>, _vm: &VirtualMachine) -> String {
-            unimplemented!("<Token {{}}var={{}} at {{}}>")
-        }
     }
 
     impl Initializer for ContextToken {
@@ -195,6 +192,13 @@ mod _contextvars {
 
         fn init(_obj: PyRef<Self>, _args: Self::Args, _vm: &VirtualMachine) -> PyResult<()> {
             unimplemented!("Token.__init__() is currently under construction")
+        }
+    }
+
+    impl Representable for ContextToken {
+        #[inline]
+        fn repr_str(_zelf: &Py<Self>, _vm: &VirtualMachine) -> PyResult<String> {
+            unimplemented!("<Token {{}}var={{}} at {{}}>")
         }
     }
 

--- a/stdlib/src/socket.rs
+++ b/stdlib/src/socket.rs
@@ -15,9 +15,9 @@ mod _socket {
         builtins::{PyBaseExceptionRef, PyListRef, PyStrRef, PyTupleRef, PyTypeRef},
         convert::{IntoPyException, ToPyObject, TryFromBorrowedObject, TryFromObject},
         function::{ArgBytesLike, ArgMemoryBuffer, Either, FsPath, OptionalArg, OptionalOption},
-        types::{DefaultConstructor, Initializer},
+        types::{DefaultConstructor, Initializer, Representable},
         utils::ToCString,
-        AsObject, PyObjectRef, PyPayload, PyRef, PyResult, VirtualMachine,
+        AsObject, Py, PyObjectRef, PyPayload, PyRef, PyResult, VirtualMachine,
     };
     use crossbeam_utils::atomic::AtomicCell;
     use num_traits::ToPrimitive;
@@ -1015,7 +1015,21 @@ mod _socket {
         }
     }
 
-    #[pyclass(with(DefaultConstructor, Initializer), flags(BASETYPE))]
+    impl Representable for PySocket {
+        #[inline]
+        fn repr_str(zelf: &Py<Self>, _vm: &VirtualMachine) -> PyResult<String> {
+            Ok(format!(
+                "<socket object, fd={}, family={}, type={}, proto={}>",
+                // cast because INVALID_SOCKET is unsigned, so would show usize::MAX instead of -1
+                zelf.fileno() as i64,
+                zelf.family.load(),
+                zelf.kind.load(),
+                zelf.proto.load(),
+            ))
+        }
+    }
+
+    #[pyclass(with(DefaultConstructor, Initializer, Representable), flags(BASETYPE))]
     impl PySocket {
         fn _init(
             zelf: PyRef<Self>,
@@ -1462,18 +1476,6 @@ mod _socket {
         #[pygetset]
         fn proto(&self) -> i32 {
             self.proto.load()
-        }
-
-        #[pymethod(magic)]
-        fn repr(&self) -> String {
-            format!(
-                "<socket object, fd={}, family={}, type={}, proto={}>",
-                // cast because INVALID_SOCKET is unsigned, so would show usize::MAX instead of -1
-                self.fileno() as i64,
-                self.family.load(),
-                self.kind.load(),
-                self.proto.load(),
-            )
         }
     }
 

--- a/vm/src/builtins/code.rs
+++ b/vm/src/builtins/code.rs
@@ -230,7 +230,7 @@ impl Representable for PyCode {
     }
 }
 
-#[pyclass(with(Py, Representable))]
+#[pyclass(with(Representable))]
 impl PyCode {
     #[pyslot]
     fn slot_new(_cls: PyTypeRef, _args: FuncArgs, vm: &VirtualMachine) -> PyResult {
@@ -415,29 +415,6 @@ impl PyCode {
                 cell2arg: self.code.cell2arg.clone(),
             },
         })
-    }
-}
-
-#[pyclass(with(Representable))]
-impl Py<PyCode> {}
-
-impl PyPayload for Py<PyCode> {
-    fn class(ctx: &Context) -> &'static Py<PyType> {
-        ctx.types.code_type
-    }
-}
-
-impl Representable for Py<PyCode> {
-    #[inline]
-    fn repr_str(zelf: &Py<Self>, _vm: &VirtualMachine) -> PyResult<String> {
-        let code = &zelf.code;
-        Ok(format!(
-            "<code object {} at {:#x} file {:?}, line {}>",
-            code.obj_name,
-            zelf.get_id(),
-            code.source_path.as_str(),
-            code.first_line_number
-        ))
     }
 }
 

--- a/vm/src/builtins/code.rs
+++ b/vm/src/builtins/code.rs
@@ -230,7 +230,7 @@ impl Representable for PyCode {
     }
 }
 
-#[pyclass(with(Py))]
+#[pyclass(with(Py, Representable))]
 impl PyCode {
     #[pyslot]
     fn slot_new(_cls: PyTypeRef, _args: FuncArgs, vm: &VirtualMachine) -> PyResult {
@@ -418,18 +418,26 @@ impl PyCode {
     }
 }
 
-#[pyclass]
-impl Py<PyCode> {
-    #[pymethod(magic)]
-    fn repr(&self) -> String {
-        let code = &self.code;
-        format!(
+#[pyclass(with(Representable))]
+impl Py<PyCode> {}
+
+impl PyPayload for Py<PyCode> {
+    fn class(ctx: &Context) -> &'static Py<PyType> {
+        ctx.types.code_type
+    }
+}
+
+impl Representable for Py<PyCode> {
+    #[inline]
+    fn repr_str(zelf: &Py<Self>, _vm: &VirtualMachine) -> PyResult<String> {
+        let code = &zelf.code;
+        Ok(format!(
             "<code object {} at {:#x} file {:?}, line {}>",
             code.obj_name,
-            self.get_id(),
+            zelf.get_id(),
             code.source_path.as_str(),
             code.first_line_number
-        )
+        ))
     }
 }
 

--- a/vm/src/builtins/slice.rs
+++ b/vm/src/builtins/slice.rs
@@ -244,6 +244,7 @@ impl Comparable for PySlice {
         Ok(PyComparisonValue::Implemented(ret))
     }
 }
+
 impl Representable for PySlice {
     #[inline]
     fn repr_str(zelf: &Py<Self>, vm: &VirtualMachine) -> PyResult<String> {

--- a/vm/src/stdlib/operator.rs
+++ b/vm/src/stdlib/operator.rs
@@ -10,7 +10,7 @@ mod _operator {
         identifier,
         protocol::PyIter,
         recursion::ReprGuard,
-        types::{Callable, Constructor, PyComparisonOp},
+        types::{Callable, Constructor, PyComparisonOp, Representable},
         AsObject, Py, PyObjectRef, PyPayload, PyRef, PyResult, VirtualMachine,
     };
 
@@ -356,22 +356,8 @@ mod _operator {
         attrs: Vec<PyStrRef>,
     }
 
-    #[pyclass(with(Callable, Constructor))]
+    #[pyclass(with(Callable, Constructor, Representable))]
     impl PyAttrGetter {
-        #[pymethod(magic)]
-        fn repr(zelf: PyRef<Self>, vm: &VirtualMachine) -> PyResult<String> {
-            let fmt = if let Some(_guard) = ReprGuard::enter(vm, zelf.as_object()) {
-                let mut parts = Vec::with_capacity(zelf.attrs.len());
-                for part in &zelf.attrs {
-                    parts.push(part.as_object().repr(vm)?.as_str().to_owned());
-                }
-                parts.join(", ")
-            } else {
-                "...".to_owned()
-            };
-            Ok(format!("operator.attrgetter({fmt})"))
-        }
-
         #[pymethod(magic)]
         fn reduce(zelf: PyRef<Self>, vm: &VirtualMachine) -> PyResult<(PyTypeRef, PyTupleRef)> {
             let attrs = vm
@@ -441,6 +427,22 @@ mod _operator {
         }
     }
 
+    impl Representable for PyAttrGetter {
+        #[inline]
+        fn repr_str(zelf: &Py<Self>, vm: &VirtualMachine) -> PyResult<String> {
+            let fmt = if let Some(_guard) = ReprGuard::enter(vm, zelf.as_object()) {
+                let mut parts = Vec::with_capacity(zelf.attrs.len());
+                for part in &zelf.attrs {
+                    parts.push(part.as_object().repr(vm)?.as_str().to_owned());
+                }
+                parts.join(", ")
+            } else {
+                "...".to_owned()
+            };
+            Ok(format!("operator.attrgetter({fmt})"))
+        }
+    }
+
     /// itemgetter(item, ...) --> itemgetter object
     ///
     /// Return a callable object that fetches the given item(s) from its operand.
@@ -453,22 +455,8 @@ mod _operator {
         items: Vec<PyObjectRef>,
     }
 
-    #[pyclass(with(Callable, Constructor))]
+    #[pyclass(with(Callable, Constructor, Representable))]
     impl PyItemGetter {
-        #[pymethod(magic)]
-        fn repr(zelf: PyRef<Self>, vm: &VirtualMachine) -> PyResult<String> {
-            let fmt = if let Some(_guard) = ReprGuard::enter(vm, zelf.as_object()) {
-                let mut items = Vec::with_capacity(zelf.items.len());
-                for item in &zelf.items {
-                    items.push(item.repr(vm)?.as_str().to_owned());
-                }
-                items.join(", ")
-            } else {
-                "...".to_owned()
-            };
-            Ok(format!("operator.itemgetter({fmt})"))
-        }
-
         #[pymethod(magic)]
         fn reduce(zelf: PyRef<Self>, vm: &VirtualMachine) -> PyObjectRef {
             let items = vm.ctx.new_tuple(zelf.items.to_vec());
@@ -508,6 +496,22 @@ mod _operator {
         }
     }
 
+    impl Representable for PyItemGetter {
+        #[inline]
+        fn repr_str(zelf: &Py<Self>, vm: &VirtualMachine) -> PyResult<String> {
+            let fmt = if let Some(_guard) = ReprGuard::enter(vm, zelf.as_object()) {
+                let mut items = Vec::with_capacity(zelf.items.len());
+                for item in &zelf.items {
+                    items.push(item.repr(vm)?.as_str().to_owned());
+                }
+                items.join(", ")
+            } else {
+                "...".to_owned()
+            };
+            Ok(format!("operator.itemgetter({fmt})"))
+        }
+    }
+
     /// methodcaller(name, ...) --> methodcaller object
     ///
     /// Return a callable object that calls the given method on its operand.
@@ -522,37 +526,8 @@ mod _operator {
         args: FuncArgs,
     }
 
-    #[pyclass(with(Callable, Constructor))]
+    #[pyclass(with(Callable, Constructor, Representable))]
     impl PyMethodCaller {
-        #[pymethod(magic)]
-        fn repr(zelf: PyRef<Self>, vm: &VirtualMachine) -> PyResult<String> {
-            let fmt = if let Some(_guard) = ReprGuard::enter(vm, zelf.as_object()) {
-                let args = &zelf.args.args;
-                let kwargs = &zelf.args.kwargs;
-                let mut fmt = vec![zelf.name.as_object().repr(vm)?.as_str().to_owned()];
-                if !args.is_empty() {
-                    let mut parts = Vec::with_capacity(args.len());
-                    for v in args {
-                        parts.push(v.repr(vm)?.as_str().to_owned());
-                    }
-                    fmt.push(parts.join(", "));
-                }
-                // build name=value pairs from KwArgs.
-                if !kwargs.is_empty() {
-                    let mut parts = Vec::with_capacity(kwargs.len());
-                    for (key, value) in kwargs {
-                        let value_repr = value.repr(vm)?;
-                        parts.push(format!("{key}={value_repr}"));
-                    }
-                    fmt.push(parts.join(", "));
-                }
-                fmt.join(", ")
-            } else {
-                "...".to_owned()
-            };
-            Ok(format!("operator.methodcaller({fmt})"))
-        }
-
         #[pymethod(magic)]
         fn reduce(zelf: PyRef<Self>, vm: &VirtualMachine) -> PyResult<PyTupleRef> {
             // With no kwargs, return (type(obj), (name, *args)) tuple.
@@ -594,6 +569,37 @@ mod _operator {
         #[inline]
         fn call(zelf: &Py<Self>, obj: Self::Args, vm: &VirtualMachine) -> PyResult {
             vm.call_method(&obj, zelf.name.as_str(), zelf.args.clone())
+        }
+    }
+
+    impl Representable for PyMethodCaller {
+        #[inline]
+        fn repr_str(zelf: &Py<Self>, vm: &VirtualMachine) -> PyResult<String> {
+            let fmt = if let Some(_guard) = ReprGuard::enter(vm, zelf.as_object()) {
+                let args = &zelf.args.args;
+                let kwargs = &zelf.args.kwargs;
+                let mut fmt = vec![zelf.name.as_object().repr(vm)?.as_str().to_owned()];
+                if !args.is_empty() {
+                    let mut parts = Vec::with_capacity(args.len());
+                    for v in args {
+                        parts.push(v.repr(vm)?.as_str().to_owned());
+                    }
+                    fmt.push(parts.join(", "));
+                }
+                // build name=value pairs from KwArgs.
+                if !kwargs.is_empty() {
+                    let mut parts = Vec::with_capacity(kwargs.len());
+                    for (key, value) in kwargs {
+                        let value_repr = value.repr(vm)?;
+                        parts.push(format!("{key}={value_repr}"));
+                    }
+                    fmt.push(parts.join(", "));
+                }
+                fmt.join(", ")
+            } else {
+                "...".to_owned()
+            };
+            Ok(format!("operator.methodcaller({fmt})"))
         }
     }
 }

--- a/vm/src/stdlib/posix.rs
+++ b/vm/src/stdlib/posix.rs
@@ -28,9 +28,9 @@ pub mod module {
             errno_err, DirFd, FollowSymlinks, OsPath, OsPathOrFd, SupportFunc, TargetIsDirectory,
             _os, fs_metadata, IOErrorBuilder,
         },
-        types::Constructor,
+        types::{Constructor, Representable},
         utils::ToCString,
-        AsObject, PyObjectRef, PyPayload, PyResult, VirtualMachine,
+        AsObject, Py, PyObjectRef, PyPayload, PyResult, VirtualMachine,
     };
     use bitflags::bitflags;
     use nix::{
@@ -540,20 +540,11 @@ pub mod module {
         }
     }
 
-    #[pyclass(with(Constructor))]
+    #[pyclass(with(Constructor, Representable))]
     impl SchedParam {
         #[pygetset]
         fn sched_priority(&self, vm: &VirtualMachine) -> PyObjectRef {
             self.sched_priority.clone().to_pyobject(vm)
-        }
-
-        #[pymethod(magic)]
-        fn repr(&self, vm: &VirtualMachine) -> PyResult<String> {
-            let sched_priority_repr = self.sched_priority.repr(vm)?;
-            Ok(format!(
-                "posix.sched_param(sched_priority = {})",
-                sched_priority_repr.as_str()
-            ))
         }
 
         #[cfg(any(
@@ -588,6 +579,17 @@ pub mod module {
             }
             .into_ref_with_type(vm, cls)
             .map(Into::into)
+        }
+    }
+
+    impl Representable for SchedParam {
+        #[inline]
+        fn repr_str(zelf: &Py<Self>, vm: &VirtualMachine) -> PyResult<String> {
+            let sched_priority_repr = zelf.sched_priority.repr(vm)?;
+            Ok(format!(
+                "posix.sched_param(sched_priority = {})",
+                sched_priority_repr.as_str()
+            ))
         }
     }
 

--- a/wasm/lib/src/js_module.rs
+++ b/wasm/lib/src/js_module.rs
@@ -14,7 +14,7 @@ mod _js {
         convert::{IntoObject, ToPyObject},
         function::{ArgCallable, OptionalArg, OptionalOption, PosArgs},
         protocol::PyIterReturn,
-        types::{IterNext, IterNextIterable},
+        types::{IterNext, IterNextIterable, Representable},
         Py, PyObjectRef, PyPayload, PyRef, PyResult, TryFromObject, VirtualMachine,
     };
     use std::{cell, fmt, future};
@@ -90,7 +90,7 @@ mod _js {
         }
     }
 
-    #[pyclass]
+    #[pyclass(with(Representable))]
     impl PyJsValue {
         #[inline]
         pub fn new(value: impl Into<JsValue>) -> PyJsValue {
@@ -265,10 +265,12 @@ mod _js {
         fn instanceof(&self, rhs: PyJsValueRef, vm: &VirtualMachine) -> PyResult<bool> {
             instance_of(&self.value, &rhs.value).map_err(|err| new_js_error(vm, err))
         }
+    }
 
-        #[pymethod(magic)]
-        fn repr(&self) -> String {
-            format!("{:?}", self.value)
+    impl Representable for PyJsValue {
+        #[inline]
+        fn repr_str(zelf: &Py<Self>, _vm: &VirtualMachine) -> PyResult<String> {
+            Ok(format!("{:?}", zelf.value))
         }
     }
 


### PR DESCRIPTION
I implemented the tp_repr slot for most types except tuples (c.f. #4653).
Implementing it for tuples turns out to be quite tricky and will probably require quite some refactoring.