### PR TITLE
handle panic if str is not defined in unraisablehook

### DIFF
--- a/extra_tests/snippets/syntax_del.py
+++ b/extra_tests/snippets/syntax_del.py
@@ -19,3 +19,13 @@ assert_raises(NameError, lambda: y)  # noqa: F821
 
 with assert_raises(NameError):
     del y  # noqa: F821
+
+# see https://github.com/RustPython/RustPython/issues/4863
+
+class MyTest:
+    def __del__(self):
+        type(self)()
+
+def test_del_panic():
+    mytest = MyTest()
+    del mytest

--- a/vm/src/stdlib/sys.rs
+++ b/vm/src/stdlib/sys.rs
@@ -590,7 +590,7 @@ mod sys {
     fn unraisablehook(unraisable: UnraisableHookArgs, vm: &VirtualMachine) {
         if let Err(e) = _unraisablehook(unraisable, vm) {
             let stderr = super::PyStderr(vm);
-            let default = vm.ctx.intern_str("{}").to_owned();
+            let default = vm.ctx.intern_str("").to_owned();
             writeln!(
                 stderr,
                 "{}",

--- a/vm/src/stdlib/sys.rs
+++ b/vm/src/stdlib/sys.rs
@@ -593,7 +593,10 @@ mod sys {
             writeln!(
                 stderr,
                 "{}",
-                e.as_object().repr(vm).unwrap_or_else(|_| vm.ctx.empty_str.to_owned()).as_str()
+                e.as_object()
+                    .repr(vm)
+                    .unwrap_or_else(|_| vm.ctx.empty_str.to_owned())
+                    .as_str()
             );
         }
     }

--- a/vm/src/stdlib/sys.rs
+++ b/vm/src/stdlib/sys.rs
@@ -594,7 +594,7 @@ mod sys {
             writeln!(
                 stderr,
                 "{}",
-                e.as_object().repr(vm).unwrap_or_else(|_| default).as_str()
+                e.as_object().repr(vm).unwrap_or(default).as_str()
             );
         }
     }

--- a/vm/src/stdlib/sys.rs
+++ b/vm/src/stdlib/sys.rs
@@ -593,7 +593,7 @@ mod sys {
             writeln!(
                 stderr,
                 "{}",
-                e.as_object().repr(vm).unwrap_or_else(|| vm.ctx.empty_str.to_owned()).as_str()
+                e.as_object().repr(vm).unwrap_or_else(|_| vm.ctx.empty_str.to_owned()).as_str()
             );
         }
     }

--- a/vm/src/stdlib/sys.rs
+++ b/vm/src/stdlib/sys.rs
@@ -594,7 +594,7 @@ mod sys {
             writeln!(
                 stderr,
                 "{}",
-                e.as_object().repr(vm).unwrap_or(default).as_str()
+                e.as_object().repr(vm).unwrap_or_else(|| vm.ctx.empty_str.to_owned()).as_str()
             );
         }
     }

--- a/vm/src/stdlib/sys.rs
+++ b/vm/src/stdlib/sys.rs
@@ -590,7 +590,6 @@ mod sys {
     fn unraisablehook(unraisable: UnraisableHookArgs, vm: &VirtualMachine) {
         if let Err(e) = _unraisablehook(unraisable, vm) {
             let stderr = super::PyStderr(vm);
-            let default = vm.ctx.intern_str("").to_owned();
             writeln!(
                 stderr,
                 "{}",

--- a/vm/src/stdlib/sys.rs
+++ b/vm/src/stdlib/sys.rs
@@ -590,7 +590,12 @@ mod sys {
     fn unraisablehook(unraisable: UnraisableHookArgs, vm: &VirtualMachine) {
         if let Err(e) = _unraisablehook(unraisable, vm) {
             let stderr = super::PyStderr(vm);
-            writeln!(stderr, "{}", e.as_object().repr(vm).unwrap().as_str());
+            let default = vm.ctx.intern_str("{}").to_owned();
+            writeln!(
+                stderr,
+                "{}",
+                e.as_object().repr(vm).unwrap_or_else(|_| default).as_str()
+            );
         }
     }
 


### PR DESCRIPTION
This PR aims to handle panic in `unraisablehook`
and thus fixes panic issue as mentioned in https://github.com/RustPython/RustPython/issues/4863
Note: It doesn't fixes underlying issue, as I am not sure what is expected in given scenario (cpython hangs if inputs as per as #4863 ).
Also, I am not sure what to put as default in unwrap_or_else.