### PR TITLE
fix wrong directory name for openssl setup

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -125,7 +125,7 @@ jobs:
         shell: bash
         run: |
           choco install llvm openssl --no-progress
-          echo "OPENSSL_DIR=C:\Program Files\OpenSSL-Win64" >>$GITHUB_ENV
+          echo "OPENSSL_DIR=C:\Program Files\OpenSSL" >>$GITHUB_ENV
         if: runner.os == 'Windows'
       - name: Set up the Mac environment
         run: brew install autoconf automake libtool
@@ -263,8 +263,8 @@ jobs:
       - name: Set up the Windows environment
         shell: bash
         run: |
-          choco install llvm openssl
-          echo "OPENSSL_DIR=C:\Program Files\OpenSSL-Win64" >>$GITHUB_ENV
+          choco install llvm openssl --no-progress
+          echo "OPENSSL_DIR=C:\Program Files\OpenSSL" >>$GITHUB_ENV
         if: runner.os == 'Windows'
       - name: Set up the Mac environment
         run: brew install autoconf automake libtool openssl@3


### PR DESCRIPTION
Fixes https://github.com/RustPython/RustPython/issues/4915 by setting correct dir path