### PR TITLE
sqlite: Throw `TypeError` when `callable` is not callable

### DIFF
--- a/Lib/test/test_sqlite3/test_hooks.py
+++ b/Lib/test/test_sqlite3/test_hooks.py
@@ -36,8 +36,6 @@ class CollationTests(unittest.TestCase):
         with self.assertRaises(TypeError):
             con.create_collation(None, lambda x, y: (x > y) - (x < y))
 
-    # TODO: RUSTPYTHON
-    @unittest.expectedFailure
     def test_create_collation_not_callable(self):
         con = sqlite.connect(":memory:")
         with self.assertRaises(TypeError) as cm:

--- a/stdlib/src/sqlite.rs
+++ b/stdlib/src/sqlite.rs
@@ -1107,13 +1107,17 @@ mod _sqlite {
         ) -> PyResult<()> {
             let name = name.to_cstring(vm)?;
             let db = self.db_lock(vm)?;
-            let Some(data )= CallbackData::new(callable, vm) else {
+            let Some(data )= CallbackData::new(callable.to_owned(), vm) else {
                 unsafe {
                     sqlite3_create_collation_v2(db.db, name.as_ptr(), SQLITE_UTF8, null_mut(), None, None);
                 }
                 return Ok(());
             };
             let data = Box::into_raw(Box::new(data));
+
+            if !callable.is_callable() {
+                return Err(vm.new_type_error("parameter must be callable".to_owned()));
+            }
 
             let ret = unsafe {
                 sqlite3_create_collation_v2(

--- a/stdlib/src/sqlite.rs
+++ b/stdlib/src/sqlite.rs
@@ -1107,7 +1107,7 @@ mod _sqlite {
         ) -> PyResult<()> {
             let name = name.to_cstring(vm)?;
             let db = self.db_lock(vm)?;
-            let Some(data )= CallbackData::new(callable.to_owned(), vm) else {
+            let Some(data) = CallbackData::new(callable.clone(), vm) else {
                 unsafe {
                     sqlite3_create_collation_v2(db.db, name.as_ptr(), SQLITE_UTF8, null_mut(), None, None);
                 }


### PR DESCRIPTION
## RustPython (Before this pull request, main)

```python
>>>>> import sqlite3; sqlite3.connect(':memory:').create_collation('X', 42)
```

(no output)

## CPython (3.11.3)

```python
>>> import sqlite3; sqlite3.connect(':memory:').create_collation('X', 42)
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
TypeError: parameter must be callable
```

## RustPython (After this pull request)

```python
>>>>> import sqlite3; sqlite3.connect(':memory:').create_collation('X', 42)
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
TypeError: parameter must be callable
```

## Links

 - https://github.com/python/cpython/blob/dc328d398d8f65ec6d2fa493e16ceee75f6d774a/Modules/_sqlite/connection.c#L2078-L2081