### PR TITLE
Ensure correct site packages are visible to rustpython

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -308,6 +308,11 @@ jobs:
         run: |
           target/release/rustpython -m ensurepip
           target/release/rustpython -c "import pip"
+      - if: runner.os != 'Windows'
+        name: Check if pip inside venv is functional
+        run: |
+          target/release/rustpython -m venv testvenv
+          testvenv/bin/rustpython -m pip install wheel
       - name: Check whats_left is not broken
         run: python -I whats_left.py
 

--- a/Lib/site.py
+++ b/Lib/site.py
@@ -275,6 +275,7 @@ def _getuserbase():
 
     if os.name == "nt":
         base = os.environ.get("APPDATA") or "~"
+        # XXX: RUSTPYTHON; please keep this change for site-packages
         return joinuser(base, "RustPython")
 
     if sys.platform == "darwin" and sys._framework:
@@ -368,6 +369,7 @@ def getsitepackages(prefixes=None):
 
             for libdir in libdirs:
                 path = os.path.join(prefix, libdir,
+                                    # XXX: RUSTPYTHON; please keep this change for site-packages
                                     "rustpython%d.%d" % sys.version_info[:2],
                                     "site-packages")
                 sitepackages.append(path)

--- a/Lib/site.py
+++ b/Lib/site.py
@@ -275,7 +275,7 @@ def _getuserbase():
 
     if os.name == "nt":
         base = os.environ.get("APPDATA") or "~"
-        return joinuser(base, "Python")
+        return joinuser(base, "RustPython")
 
     if sys.platform == "darwin" and sys._framework:
         return joinuser("~", "Library", sys._framework,
@@ -368,7 +368,7 @@ def getsitepackages(prefixes=None):
 
             for libdir in libdirs:
                 path = os.path.join(prefix, libdir,
-                                    "python%d.%d" % sys.version_info[:2],
+                                    "rustpython%d.%d" % sys.version_info[:2],
                                     "site-packages")
                 sitepackages.append(path)
         else:

--- a/Lib/sysconfig.py
+++ b/Lib/sysconfig.py
@@ -1,3 +1,5 @@
+# XXX: RUSTPYTHON; Trick to make sysconfig work as RustPython
+exec(r'''
 """Access to Python's configuration information."""
 
 import os
@@ -851,10 +853,6 @@ def _main():
     print()
     _print_dict('Variables', get_config_vars())
 
-# XXX RUSTPYTHON: replace python with rustpython in all these paths
-for group in _INSTALL_SCHEMES.values():
-    for key in group.keys():
-        group[key] = group[key].replace("Python", "RustPython").replace("python", "rustpython")
-
 if __name__ == '__main__':
     _main()
+'''.replace("Python", "RustPython").replace("/python", "/rustpython"))

--- a/Lib/test/test_site.py
+++ b/Lib/test/test_site.py
@@ -288,12 +288,14 @@ class HelperFunctionsTests(unittest.TestCase):
             if sys.platlibdir != "lib":
                 self.assertEqual(len(dirs), 2)
                 wanted = os.path.join('xoxo', sys.platlibdir,
+                                      # XXX: RUSTPYTHON
                                       'rustpython%d.%d' % sys.version_info[:2],
                                       'site-packages')
                 self.assertEqual(dirs[0], wanted)
             else:
                 self.assertEqual(len(dirs), 1)
             wanted = os.path.join('xoxo', 'lib',
+                                  # XXX: RUSTPYTHON
                                   'rustpython%d.%d' % sys.version_info[:2],
                                   'site-packages')
             self.assertEqual(dirs[-1], wanted)

--- a/Lib/test/test_site.py
+++ b/Lib/test/test_site.py
@@ -288,13 +288,13 @@ class HelperFunctionsTests(unittest.TestCase):
             if sys.platlibdir != "lib":
                 self.assertEqual(len(dirs), 2)
                 wanted = os.path.join('xoxo', sys.platlibdir,
-                                      'python%d.%d' % sys.version_info[:2],
+                                      'rustpython%d.%d' % sys.version_info[:2],
                                       'site-packages')
                 self.assertEqual(dirs[0], wanted)
             else:
                 self.assertEqual(len(dirs), 1)
             wanted = os.path.join('xoxo', 'lib',
-                                  'python%d.%d' % sys.version_info[:2],
+                                  'rustpython%d.%d' % sys.version_info[:2],
                                   'site-packages')
             self.assertEqual(dirs[-1], wanted)
         else:


### PR DESCRIPTION
This work should resolves https://github.com/RustPython/RustPython/issues/4911

Aim

- [x] 1. Add rustpython's lib to sys.path
- [x] 2. Fix typo in rustpython's lib name
- [x] 3. Add test in CI for setting up venv and pip

Note: Instead of having both python and rustpython, I am including only one as venv/lib/rustpython3.11/site-packages, as venv/lib/python3.11/ severs no purpose and create confusion.