### PR TITLE
Remove Traverse from FromArgs

### DIFF
--- a/stdlib/src/array.rs
+++ b/stdlib/src/array.rs
@@ -1434,13 +1434,12 @@ mod array {
         }
     }
 
-    #[derive(FromArgs, Traverse)]
+    #[derive(FromArgs)]
     struct ReconstructorArgs {
         #[pyarg(positional)]
         arraytype: PyTypeRef,
         #[pyarg(positional)]
         typecode: PyStrRef,
-        #[pytraverse(skip)]
         #[pyarg(positional)]
         mformat_code: MachineFormatCode,
         #[pyarg(positional)]

--- a/stdlib/src/bisect.rs
+++ b/stdlib/src/bisect.rs
@@ -8,7 +8,7 @@ mod _bisect {
         PyObjectRef, PyResult, VirtualMachine,
     };
 
-    #[derive(FromArgs, Traverse)]
+    #[derive(FromArgs)]
     struct BisectArgs {
         a: PyObjectRef,
         x: PyObjectRef,

--- a/stdlib/src/contextvars.rs
+++ b/stdlib/src/contextvars.rs
@@ -162,7 +162,7 @@ mod _contextvars {
     #[derive(Debug, PyPayload)]
     struct ContextToken {}
 
-    #[derive(FromArgs, Traverse)]
+    #[derive(FromArgs)]
     struct ContextTokenOptions {
         #[pyarg(positional)]
         #[allow(dead_code)] // TODO: RUSTPYTHON

--- a/stdlib/src/math.rs
+++ b/stdlib/src/math.rs
@@ -885,7 +885,7 @@ mod math {
         }
     }
 
-    #[derive(FromArgs, Traverse)]
+    #[derive(FromArgs)]
     struct ProdArgs {
         #[pyarg(positional)]
         iterable: ArgIterable<PyObjectRef>,

--- a/stdlib/src/mmap.rs
+++ b/stdlib/src/mmap.rs
@@ -244,9 +244,8 @@ mod mmap {
     }
 
     #[cfg(not(target_os = "redox"))]
-    #[derive(FromArgs, Traverse)]
+    #[derive(FromArgs)]
     pub struct AdviseOptions {
-        #[pytraverse(skip)]
         #[pyarg(positional)]
         option: libc::c_int,
         #[pyarg(positional, default)]

--- a/stdlib/src/pyexpat.rs
+++ b/stdlib/src/pyexpat.rs
@@ -156,7 +156,7 @@ mod _pyexpat {
         }
     }
 
-    #[derive(FromArgs, Traverse)]
+    #[derive(FromArgs)]
     #[allow(dead_code)]
     struct ParserCreateArgs {
         #[pyarg(any, optional)]

--- a/stdlib/src/pystruct.rs
+++ b/stdlib/src/pystruct.rs
@@ -134,10 +134,9 @@ pub(crate) mod _struct {
         buffer.with_ref(|buf| format_spec.unpack(buf, vm))
     }
 
-    #[derive(FromArgs, Traverse)]
+    #[derive(FromArgs)]
     struct UpdateFromArgs {
         buffer: ArgBytesLike,
-        #[pytraverse(skip)]
         #[pyarg(any, default = "0")]
         offset: isize,
     }

--- a/stdlib/src/sqlite.rs
+++ b/stdlib/src/sqlite.rs
@@ -340,41 +340,36 @@ mod _sqlite {
         }
     }
 
-    #[derive(FromArgs, Traverse)]
+    #[derive(FromArgs)]
     struct CreateFunctionArgs {
         #[pyarg(any)]
         name: PyStrRef,
-        #[pytraverse(skip)]
         #[pyarg(any)]
         narg: c_int,
         #[pyarg(any)]
         func: PyObjectRef,
-        #[pytraverse(skip)]
         #[pyarg(named, default)]
         deterministic: bool,
     }
 
-    #[derive(FromArgs, Traverse)]
+    #[derive(FromArgs)]
     struct CreateAggregateArgs {
         #[pyarg(any)]
         name: PyStrRef,
-        #[pytraverse(skip)]
         #[pyarg(positional)]
         narg: c_int,
         #[pyarg(positional)]
         aggregate_class: PyObjectRef,
     }
 
-    #[derive(FromArgs, Traverse)]
+    #[derive(FromArgs)]
     struct BlobOpenArgs {
         #[pyarg(positional)]
         table: PyStrRef,
         #[pyarg(positional)]
         column: PyStrRef,
-        #[pytraverse(skip)]
         #[pyarg(positional)]
         row: i64,
-        #[pytraverse(skip)]
         #[pyarg(named, default)]
         readonly: bool,
         #[pyarg(named, default = "vm.ctx.new_str(stringify!(main))")]

--- a/stdlib/src/ssl.rs
+++ b/stdlib/src/ssl.rs
@@ -788,10 +788,9 @@ mod _ssl {
         }
     }
 
-    #[derive(FromArgs, Traverse)]
+    #[derive(FromArgs)]
     struct WrapSocketArgs {
         sock: PyRef<PySocket>,
-        #[pytraverse(skip)]
         server_side: bool,
         #[pyarg(any, default)]
         server_hostname: Option<PyStrRef>,
@@ -811,11 +810,9 @@ mod _ssl {
         cadata: Option<Either<PyStrRef, ArgBytesLike>>,
     }
 
-    #[derive(FromArgs, Traverse)]
+    #[derive(FromArgs)]
     struct LoadCertChainArgs {
-        #[pytraverse(skip)]
         certfile: FsPath,
-        #[pytraverse(skip)]
         #[pyarg(any, optional)]
         keyfile: Option<FsPath>,
         #[pyarg(any, optional)]

--- a/stdlib/src/syslog.rs
+++ b/stdlib/src/syslog.rs
@@ -95,7 +95,7 @@ mod syslog {
         Ok(())
     }
 
-    #[derive(FromArgs, Traverse)]
+    #[derive(FromArgs)]
     struct SysLogArgs {
         #[pyarg(positional)]
         priority: PyObjectRef,

--- a/vm/src/builtins/function.rs
+++ b/vm/src/builtins/function.rs
@@ -522,7 +522,7 @@ impl GetAttr for PyBoundMethod {
     }
 }
 
-#[derive(FromArgs, Traverse)]
+#[derive(FromArgs)]
 pub struct PyBoundMethodNewArgs {
     #[pyarg(positional)]
     function: PyObjectRef,

--- a/vm/src/builtins/memory.rs
+++ b/vm/src/builtins/memory.rs
@@ -33,7 +33,7 @@ use once_cell::sync::Lazy;
 use rustpython_common::lock::PyMutex;
 use std::{cmp::Ordering, fmt::Debug, mem::ManuallyDrop, ops::Range};
 
-#[derive(FromArgs, Traverse)]
+#[derive(FromArgs)]
 pub struct PyMemoryViewNewArgs {
     object: PyObjectRef,
 }
@@ -896,7 +896,7 @@ impl Py<PyMemoryView> {
     }
 }
 
-#[derive(FromArgs, Traverse)]
+#[derive(FromArgs)]
 struct CastArgs {
     #[pyarg(any)]
     format: PyStrRef,

--- a/vm/src/builtins/str.rs
+++ b/vm/src/builtins/str.rs
@@ -259,7 +259,7 @@ impl IterNext for PyStrIterator {
     }
 }
 
-#[derive(FromArgs, Traverse)]
+#[derive(FromArgs)]
 pub struct StrArgs {
     #[pyarg(any, optional)]
     object: OptionalArg<PyObjectRef>,
@@ -1401,7 +1401,7 @@ impl AsSequence for PyStr {
     }
 }
 
-#[derive(FromArgs, Traverse)]
+#[derive(FromArgs)]
 struct EncodeArgs {
     #[pyarg(any, default)]
     encoding: Option<PyStrRef>,
@@ -1465,7 +1465,7 @@ impl ToPyObject for AsciiString {
 
 type SplitArgs = anystr::SplitArgs<PyStrRef>;
 
-#[derive(FromArgs, Traverse)]
+#[derive(FromArgs)]
 pub struct FindArgs {
     #[pyarg(positional)]
     sub: PyStrRef,

--- a/vm/src/builtins/weakref.rs
+++ b/vm/src/builtins/weakref.rs
@@ -12,7 +12,7 @@ use crate::{
 
 pub use crate::object::PyWeak;
 
-#[derive(FromArgs, Traverse)]
+#[derive(FromArgs)]
 pub struct WeakNewArgs {
     #[pyarg(positional)]
     referent: PyObjectRef,


### PR DESCRIPTION
@discord9 could you check this is safe?

In my opinion, *Args object never be referenced by any object but they instantly removed after a function call.
They will not have chance to be called by traverse.