### PR TITLE
Rename method/member types

### DIFF
--- a/vm/src/builtins/descriptor.rs
+++ b/vm/src/builtins/descriptor.rs
@@ -32,7 +32,7 @@ pub enum MemberSetter {
     Offset(usize),
 }
 
-pub struct MemberDef {
+pub struct PyMemberDef {
     pub name: String,
     pub kind: MemberKind,
     pub getter: MemberGetter,
@@ -40,7 +40,7 @@ pub struct MemberDef {
     pub doc: Option<String>,
 }
 
-impl MemberDef {
+impl PyMemberDef {
     fn get(&self, obj: PyObjectRef, vm: &VirtualMachine) -> PyResult {
         match self.getter {
             MemberGetter::Getter(getter) => (getter)(vm, obj),
@@ -64,9 +64,9 @@ impl MemberDef {
     }
 }
 
-impl std::fmt::Debug for MemberDef {
+impl std::fmt::Debug for PyMemberDef {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        f.debug_struct("MemberDef")
+        f.debug_struct("PyMemberDef")
             .field("name", &self.name)
             .field("kind", &self.kind)
             .field("doc", &self.doc)
@@ -78,7 +78,7 @@ impl std::fmt::Debug for MemberDef {
 #[derive(Debug)]
 pub struct MemberDescrObject {
     pub common: DescrObject,
-    pub member: MemberDef,
+    pub member: PyMemberDef,
 }
 
 impl PyPayload for MemberDescrObject {
@@ -136,7 +136,7 @@ impl MemberDescrObject {
 fn get_slot_from_object(
     obj: PyObjectRef,
     offset: usize,
-    member: &MemberDef,
+    member: &PyMemberDef,
     vm: &VirtualMachine,
 ) -> PyResult {
     let slot = match member.kind {
@@ -158,7 +158,7 @@ fn get_slot_from_object(
 fn set_slot_at_object(
     obj: PyObjectRef,
     offset: usize,
-    member: &MemberDef,
+    member: &PyMemberDef,
     value: PySetterValue,
     vm: &VirtualMachine,
 ) -> PyResult<()> {

--- a/vm/src/builtins/descriptor.rs
+++ b/vm/src/builtins/descriptor.rs
@@ -74,14 +74,15 @@ impl std::fmt::Debug for PyMemberDef {
     }
 }
 
+// PyMemberDescrObject in CPython
 #[pyclass(name = "member_descriptor", module = false)]
 #[derive(Debug)]
-pub struct MemberDescrObject {
+pub struct PyMemberDescriptor {
     pub common: DescrObject,
     pub member: PyMemberDef,
 }
 
-impl PyPayload for MemberDescrObject {
+impl PyPayload for PyMemberDescriptor {
     fn class(ctx: &Context) -> &'static Py<PyType> {
         ctx.types.member_descriptor_type
     }
@@ -101,7 +102,7 @@ fn calculate_qualname(descr: &DescrObject, vm: &VirtualMachine) -> PyResult<Opti
 }
 
 #[pyclass(with(GetDescriptor, Constructor, Representable), flags(BASETYPE))]
-impl MemberDescrObject {
+impl PyMemberDescriptor {
     #[pygetset(magic)]
     fn doc(&self) -> Option<String> {
         self.member.doc.to_owned()
@@ -186,9 +187,9 @@ fn set_slot_at_object(
     Ok(())
 }
 
-impl Unconstructible for MemberDescrObject {}
+impl Unconstructible for PyMemberDescriptor {}
 
-impl Representable for MemberDescrObject {
+impl Representable for PyMemberDescriptor {
     #[inline]
     fn repr_str(zelf: &Py<Self>, _vm: &VirtualMachine) -> PyResult<String> {
         Ok(format!(
@@ -199,7 +200,7 @@ impl Representable for MemberDescrObject {
     }
 }
 
-impl GetDescriptor for MemberDescrObject {
+impl GetDescriptor for PyMemberDescriptor {
     fn descr_get(
         zelf: PyObjectRef,
         obj: Option<PyObjectRef>,
@@ -218,5 +219,5 @@ impl GetDescriptor for MemberDescrObject {
 
 pub fn init(context: &Context) {
     let member_descriptor_type = &context.types.member_descriptor_type;
-    MemberDescrObject::extend_class(context, member_descriptor_type);
+    PyMemberDescriptor::extend_class(context, member_descriptor_type);
 }

--- a/vm/src/builtins/type.rs
+++ b/vm/src/builtins/type.rs
@@ -5,7 +5,7 @@ use super::{
 use crate::{
     builtins::{
         descriptor::{
-            DescrObject, MemberDescrObject, MemberGetter, MemberKind, MemberSetter, PyMemberDef,
+            DescrObject, MemberGetter, MemberKind, MemberSetter, PyMemberDef, PyMemberDescriptor,
         },
         function::PyCellRef,
         tuple::{IntoPyTuple, PyTupleTyped},
@@ -811,8 +811,8 @@ impl PyType {
                     setter: MemberSetter::Offset(offset),
                     doc: None,
                 };
-                let member_descriptor: PyRef<MemberDescrObject> =
-                    vm.ctx.new_pyref(MemberDescrObject {
+                let member_descriptor: PyRef<PyMemberDescriptor> =
+                    vm.ctx.new_pyref(PyMemberDescriptor {
                         common: DescrObject {
                             typ: typ.clone(),
                             name: vm.ctx.intern_str(member.as_str()),

--- a/vm/src/builtins/type.rs
+++ b/vm/src/builtins/type.rs
@@ -5,7 +5,7 @@ use super::{
 use crate::{
     builtins::{
         descriptor::{
-            DescrObject, MemberDef, MemberDescrObject, MemberGetter, MemberKind, MemberSetter,
+            DescrObject, MemberDescrObject, MemberGetter, MemberKind, MemberSetter, PyMemberDef,
         },
         function::PyCellRef,
         tuple::{IntoPyTuple, PyTupleTyped},
@@ -804,7 +804,7 @@ impl PyType {
         if let Some(ref slots) = heaptype_slots {
             let mut offset = base_member_count;
             for member in slots.as_slice() {
-                let member_def = MemberDef {
+                let member_def = PyMemberDef {
                     name: member.to_string(),
                     kind: MemberKind::ObjectEx,
                     getter: MemberGetter::Offset(offset),

--- a/vm/src/types/zoo.rs
+++ b/vm/src/types/zoo.rs
@@ -177,7 +177,7 @@ impl TypeZoo {
             not_implemented_type: singletons::PyNotImplemented::init_builtin_type(),
             generic_alias_type: genericalias::PyGenericAlias::init_builtin_type(),
             union_type: union_::PyUnion::init_builtin_type(),
-            member_descriptor_type: descriptor::MemberDescrObject::init_builtin_type(),
+            member_descriptor_type: descriptor::PyMemberDescriptor::init_builtin_type(),
         }
     }
 

--- a/vm/src/vm/context.rs
+++ b/vm/src/vm/context.rs
@@ -4,8 +4,8 @@ use crate::{
         bytes,
         code::{self, PyCode},
         descriptor::{
-            DescrObject, MemberDef, MemberDescrObject, MemberGetter, MemberKind, MemberSetter,
-            MemberSetterFunc,
+            DescrObject, MemberDescrObject, MemberGetter, MemberKind, MemberSetter,
+            MemberSetterFunc, PyMemberDef,
         },
         getset::PyGetSet,
         object, pystr,
@@ -501,7 +501,7 @@ impl Context {
         setter: MemberSetterFunc,
         class: &'static Py<PyType>,
     ) -> PyRef<MemberDescrObject> {
-        let member_def = MemberDef {
+        let member_def = PyMemberDef {
             name: name.to_owned(),
             kind: member_kind,
             getter: MemberGetter::Getter(getter),

--- a/vm/src/vm/context.rs
+++ b/vm/src/vm/context.rs
@@ -4,8 +4,8 @@ use crate::{
         bytes,
         code::{self, PyCode},
         descriptor::{
-            DescrObject, MemberDescrObject, MemberGetter, MemberKind, MemberSetter,
-            MemberSetterFunc, PyMemberDef,
+            DescrObject, MemberGetter, MemberKind, MemberSetter, MemberSetterFunc, PyMemberDef,
+            PyMemberDescriptor,
         },
         getset::PyGetSet,
         object, pystr,
@@ -500,7 +500,7 @@ impl Context {
         getter: fn(&VirtualMachine, PyObjectRef) -> PyResult,
         setter: MemberSetterFunc,
         class: &'static Py<PyType>,
-    ) -> PyRef<MemberDescrObject> {
+    ) -> PyRef<PyMemberDescriptor> {
         let member_def = PyMemberDef {
             name: name.to_owned(),
             kind: member_kind,
@@ -508,7 +508,7 @@ impl Context {
             setter: MemberSetter::Setter(setter),
             doc: None,
         };
-        let member_descriptor = MemberDescrObject {
+        let member_descriptor = PyMemberDescriptor {
             common: DescrObject {
                 typ: class.to_owned(),
                 name: self.intern_str(name),


### PR DESCRIPTION
- PyMemberDef: Matches to CPython name and similar naming as `PyMethodDef`. `PyMehtodDef` is a python object in CPython
- PyMemberDescrObject -> PyMemberDescriptor
   - we don't use -Object suffix
   - we avoid abbr as much as possible