### PR TITLE
Fix wasm build stdlib

### DIFF
--- a/wasm/lib/src/vm_class.rs
+++ b/wasm/lib/src/vm_class.rs
@@ -44,7 +44,7 @@ impl StoredVirtualMachine {
         let mut settings = Settings::default();
         settings.allow_external_library = false;
         let interp = Interpreter::with_init(settings, |vm| {
-            #[cfg(feature = "stdlib")]
+            #[cfg(feature = "freeze-stdlib")]
             vm.add_native_modules(rustpython_stdlib::get_module_inits());
 
             #[cfg(feature = "freeze-stdlib")]


### PR DESCRIPTION
Fix #4931

`rustpython-wasm` crate doesn't have `stdlib` feature