### PR TITLE
Set trace_func / profile_func to none on error

### DIFF
--- a/Lib/test/test_trace.py
+++ b/Lib/test/test_trace.py
@@ -298,8 +298,6 @@ class TestFuncs(unittest.TestCase):
         }
         self.assertEqual(self.tracer.results().calledfuncs, expected)
 
-    # TODO: RUSTPYTHON, gc
-    @unittest.expectedFailure
     def test_arg_errors(self):
         res = self.tracer.runfunc(traced_capturer, 1, 2, self=3, func=4)
         self.assertEqual(res, ((1, 2), {'self': 3, 'func': 4}))
@@ -552,8 +550,6 @@ class TestCommandLine(unittest.TestCase):
             expected = f'filename: {filename}, modulename: {modulename}, funcname: <module>'
             self.assertIn(expected.encode(), stdout)
 
-    # TODO: RUSTPYTHON
-    @unittest.expectedFailure
     def test_sys_argv_list(self):
         with open(TESTFN, 'w', encoding='utf-8') as fd:
             self.addCleanup(unlink, TESTFN)
@@ -591,8 +587,6 @@ class TestCommandLine(unittest.TestCase):
         self.assertIn('lines   cov%   module   (path)', stdout)
         self.assertIn(f'6   100%   {modulename}   ({filename})', stdout)
 
-    # TODO: RUSTPYTHON
-    @unittest.expectedFailure
     def test_run_as_module(self):
         assert_python_ok('-m', 'trace', '-l', '--module', 'timeit', '-n', '1')
         assert_python_failure('-m', 'trace', '-l', '--module', 'not_a_module_zzz')

--- a/vm/src/protocol/callable.rs
+++ b/vm/src/protocol/callable.rs
@@ -103,14 +103,18 @@ impl VirtualMachine {
             self.use_tracing.set(false);
             let res = trace_func.call(args.clone(), self);
             self.use_tracing.set(true);
-            res?;
+            if res.is_err() {
+                *self.trace_func.borrow_mut() = self.ctx.none();
+            }
         }
 
         if !self.is_none(&profile_func) {
             self.use_tracing.set(false);
             let res = profile_func.call(args, self);
             self.use_tracing.set(true);
-            res?;
+            if res.is_err() {
+                *self.profile_func.borrow_mut() = self.ctx.none();
+            }
         }
         Ok(())
     }


### PR DESCRIPTION
#4906

trace_func and profile_func now set to none if errors are encountered

Working with the example code:
```
import sys
def trace(frame, event, arg):
    raise NameError
    return trace

sys.settrace(trace)
print("fail here")
try:
    a = 1/0
except:
    print("not allowed")
```
RustPython now correctly will print:
fail here
not allowed

