### PR TITLE
Reduce parser size and Avoid copying elements when parsing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1795,7 +1795,7 @@ dependencies = [
 [[package]]
 name = "ruff_source_location"
 version = "0.0.0"
-source = "git+https://github.com/youknowone/RustPython-Parser.git?rev=718354673eb2cc9645d63fc0c50b4ad08e5595c2#718354673eb2cc9645d63fc0c50b4ad08e5595c2"
+source = "git+https://github.com/youknowone/RustPython-Parser.git?rev=dd4cc25227452178cce357b49677842efe533711#dd4cc25227452178cce357b49677842efe533711"
 dependencies = [
  "memchr",
  "once_cell",
@@ -1805,7 +1805,7 @@ dependencies = [
 [[package]]
 name = "ruff_text_size"
 version = "0.0.0"
-source = "git+https://github.com/youknowone/RustPython-Parser.git?rev=718354673eb2cc9645d63fc0c50b4ad08e5595c2#718354673eb2cc9645d63fc0c50b4ad08e5595c2"
+source = "git+https://github.com/youknowone/RustPython-Parser.git?rev=dd4cc25227452178cce357b49677842efe533711#dd4cc25227452178cce357b49677842efe533711"
 
 [[package]]
 name = "rustc-hash"
@@ -1863,7 +1863,7 @@ dependencies = [
 [[package]]
 name = "rustpython-ast"
 version = "0.2.0"
-source = "git+https://github.com/youknowone/RustPython-Parser.git?rev=718354673eb2cc9645d63fc0c50b4ad08e5595c2#718354673eb2cc9645d63fc0c50b4ad08e5595c2"
+source = "git+https://github.com/youknowone/RustPython-Parser.git?rev=dd4cc25227452178cce357b49677842efe533711#dd4cc25227452178cce357b49677842efe533711"
 dependencies = [
  "is-macro",
  "num-bigint",
@@ -1972,7 +1972,7 @@ dependencies = [
 [[package]]
 name = "rustpython-format"
 version = "0.2.0"
-source = "git+https://github.com/youknowone/RustPython-Parser.git?rev=718354673eb2cc9645d63fc0c50b4ad08e5595c2#718354673eb2cc9645d63fc0c50b4ad08e5595c2"
+source = "git+https://github.com/youknowone/RustPython-Parser.git?rev=dd4cc25227452178cce357b49677842efe533711#dd4cc25227452178cce357b49677842efe533711"
 dependencies = [
  "bitflags 2.2.1",
  "itertools",
@@ -1999,7 +1999,7 @@ dependencies = [
 [[package]]
 name = "rustpython-literal"
 version = "0.2.0"
-source = "git+https://github.com/youknowone/RustPython-Parser.git?rev=718354673eb2cc9645d63fc0c50b4ad08e5595c2#718354673eb2cc9645d63fc0c50b4ad08e5595c2"
+source = "git+https://github.com/youknowone/RustPython-Parser.git?rev=dd4cc25227452178cce357b49677842efe533711#dd4cc25227452178cce357b49677842efe533711"
 dependencies = [
  "hexf-parse",
  "lexical-parse-float",
@@ -2010,7 +2010,7 @@ dependencies = [
 [[package]]
 name = "rustpython-parser"
 version = "0.2.0"
-source = "git+https://github.com/youknowone/RustPython-Parser.git?rev=718354673eb2cc9645d63fc0c50b4ad08e5595c2#718354673eb2cc9645d63fc0c50b4ad08e5595c2"
+source = "git+https://github.com/youknowone/RustPython-Parser.git?rev=dd4cc25227452178cce357b49677842efe533711#dd4cc25227452178cce357b49677842efe533711"
 dependencies = [
  "anyhow",
  "itertools",
@@ -2032,7 +2032,7 @@ dependencies = [
 [[package]]
 name = "rustpython-parser-core"
 version = "0.2.0"
-source = "git+https://github.com/youknowone/RustPython-Parser.git?rev=718354673eb2cc9645d63fc0c50b4ad08e5595c2#718354673eb2cc9645d63fc0c50b4ad08e5595c2"
+source = "git+https://github.com/youknowone/RustPython-Parser.git?rev=dd4cc25227452178cce357b49677842efe533711#dd4cc25227452178cce357b49677842efe533711"
 dependencies = [
  "ruff_source_location",
  "ruff_text_size",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,11 +29,11 @@ rustpython-pylib = { path = "pylib" }
 rustpython-stdlib = { path = "stdlib" }
 rustpython-doc = { git = "https://github.com/RustPython/__doc__", branch = "main" }
 
-rustpython-literal = { git = "https://github.com/youknowone/RustPython-Parser.git", rev = "718354673eb2cc9645d63fc0c50b4ad08e5595c2" }
-rustpython-parser-core = { git = "https://github.com/youknowone/RustPython-Parser.git", rev = "718354673eb2cc9645d63fc0c50b4ad08e5595c2" }
-rustpython-parser = { git = "https://github.com/youknowone/RustPython-Parser.git", rev = "718354673eb2cc9645d63fc0c50b4ad08e5595c2" }
-rustpython-ast = { git = "https://github.com/youknowone/RustPython-Parser.git", rev = "718354673eb2cc9645d63fc0c50b4ad08e5595c2" }
-rustpython-format = { git = "https://github.com/youknowone/RustPython-Parser.git", rev = "718354673eb2cc9645d63fc0c50b4ad08e5595c2" }
+rustpython-literal = { git = "https://github.com/youknowone/RustPython-Parser.git", rev = "dd4cc25227452178cce357b49677842efe533711" }
+rustpython-parser-core = { git = "https://github.com/youknowone/RustPython-Parser.git", rev = "dd4cc25227452178cce357b49677842efe533711" }
+rustpython-parser = { git = "https://github.com/youknowone/RustPython-Parser.git", rev = "dd4cc25227452178cce357b49677842efe533711" }
+rustpython-ast = { git = "https://github.com/youknowone/RustPython-Parser.git", rev = "dd4cc25227452178cce357b49677842efe533711" }
+rustpython-format = { git = "https://github.com/youknowone/RustPython-Parser.git", rev = "dd4cc25227452178cce357b49677842efe533711" }
 # rustpython-literal = { path = "../RustPython-parser/literal" }
 # rustpython-parser-core = { path = "../RustPython-parser/core" }
 # rustpython-parser = { path = "../RustPython-parser/parser" }


### PR DESCRIPTION
https://github.com/RustPython/Parser/pull/35 


cc @lastmjs The binary size goes 100k smaller and hopefully function `__reduce` can be smaller.