### PR TITLE
Update abc.py from Python 3.11

### DIFF
--- a/Lib/abc.py
+++ b/Lib/abc.py
@@ -106,7 +106,7 @@ else:
         implementations defined by the registering ABC be callable (not
         even via super()).
         """
-        def __new__(mcls, name, bases, namespace, **kwargs):
+        def __new__(mcls, name, bases, namespace, /, **kwargs):
             cls = super().__new__(mcls, name, bases, namespace, **kwargs)
             _abc_init(cls)
             return cls

--- a/Lib/test/test_abc.py
+++ b/Lib/test/test_abc.py
@@ -679,6 +679,19 @@ def test_factory(abc_ABCMeta, abc_get_cache_token):
             class Receiver(ReceivesClassKwargs, abc_ABC, x=1, y=2, z=3):
                 pass
             self.assertEqual(saved_kwargs, dict(x=1, y=2, z=3))
+
+        def test_positional_only_and_kwonlyargs_with_init_subclass(self):
+            saved_kwargs = {}
+
+            class A:
+                def __init_subclass__(cls, **kwargs):
+                    super().__init_subclass__()
+                    saved_kwargs.update(kwargs)
+
+            class B(A, metaclass=abc_ABCMeta, name="test"):
+                pass
+            self.assertEqual(saved_kwargs, dict(name="test"))
+
     return TestLegacyAPI, TestABC, TestABCWithInitSubclass
 
 TestLegacyAPI_Py, TestABC_Py, TestABCWithInitSubclass_Py = test_factory(abc.ABCMeta,


### PR DESCRIPTION
Was poking around abc and noticed it wasn't updated!

abc.py [from cpython](https://github.com/python/cpython/blob/3.11/Lib/abc.py)
test_abc.py [from cpython](https://github.com/python/cpython/blob/3.11/Lib/test/test_abc.py)

#4564 