### PR TITLE
fix 'import encodings' error message

### DIFF
--- a/vm/src/vm/mod.rs
+++ b/vm/src/vm/mod.rs
@@ -218,8 +218,8 @@ impl VirtualMachine {
     fn import_encodings(&mut self) -> PyResult<()> {
         self.import("encodings", None, 0).map_err(|import_err| {
             let err = self.new_runtime_error(
-                "Could not import encodings. Is your RUSTPYTHONPATH set? If you don't have \
-                    access to a consistent external environment (e.g. if you're embedding \
+                "Could not import encodings. Try adding path to settings.pathlist (ie. by setting RUSTPYTHONPATH) \
+                    If you don't have access to a consistent external environment (e.g. if you're embedding \
                     rustpython in another application), try enabling the freeze-stdlib feature"
                     .to_owned(),
             );


### PR DESCRIPTION
new error message : 
```
encodings initialization failed. Only utf-8 encoding will be supported.
ModuleNotFoundError: No module named 'encodings'

The above exception was the direct cause of the following exception:

RuntimeError: Could not import encodings. Try adding path to settings.pathlist (ie. by setting RUSTPYTHONPATH) If you don't have access to a consistent external environment (e.g. if you're embedding rustpython in another application), try enabling the freeze-stdlib feature
```
fixes issue #4988 