### PR TITLE
Return SyntaxError with null byte input in eval.

### DIFF
--- a/extra_tests/snippets/syntax_non_utf8.py
+++ b/extra_tests/snippets/syntax_non_utf8.py
@@ -5,6 +5,14 @@ from testutils import assert_raises
 
 dir_path = os.path.dirname(os.path.realpath(__file__))
 
-with assert_raises(SyntaxError):
+# TODO: RUSTPYTHON. At some point snippets will fail and it will look confusing
+# and out of the blue. This is going to be the cause and it's going to happen when
+# the github worker for MacOS starts using Python 3.11.4.
+if platform.python_implementation == "CPython" and platform.system() == 'Darwin':
+    expectedException = ValueError
+else:
+    expectedException = SyntaxError
+
+with assert_raises(expectedException):
     with open(os.path.join(dir_path , "non_utf8.txt")) as f:
         eval(f.read())

--- a/extra_tests/snippets/syntax_non_utf8.py
+++ b/extra_tests/snippets/syntax_non_utf8.py
@@ -5,6 +5,6 @@ from testutils import assert_raises
 
 dir_path = os.path.dirname(os.path.realpath(__file__))
 
-with assert_raises(ValueError):
+with assert_raises(SyntaxError):
     with open(os.path.join(dir_path , "non_utf8.txt")) as f:
         eval(f.read())

--- a/vm/src/stdlib/builtins.rs
+++ b/vm/src/stdlib/builtins.rs
@@ -257,7 +257,8 @@ mod builtins {
             Either::A(either) => {
                 let source: &[u8] = &either.borrow_bytes();
                 if source.contains(&0) {
-                    return Err(vm.new_value_error(
+                    return Err(vm.new_exception_msg(
+                        vm.ctx.exceptions.syntax_error.to_owned(),
                         "source code string cannot contain null bytes".to_owned(),
                     ));
                 }


### PR DESCRIPTION
Can't find anything in Python's changelogs but it appears eval now returns a SyntaxError in this case, lets see what the tests think.