### PR TITLE
Pin Python version to 3.11.4 in CI runs.

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -105,7 +105,7 @@ env:
     test_weakref
     test_yield_from
   # Python version targeted by the CI.
-  PYTHON_VERSION: 3.11.4
+  PYTHON_VERSION: "3.11.4"
 
 jobs:
   rust_tests:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -104,6 +104,8 @@ env:
     test_unpack
     test_weakref
     test_yield_from
+  # Python version targeted by the CI.
+  PYTHON_VERSION: 3.11.4
 
 jobs:
   rust_tests:
@@ -245,7 +247,7 @@ jobs:
       - uses: dtolnay/rust-toolchain@stable
       - uses: actions/setup-python@v4
         with:
-          python-version: "3.11.4"
+          python-version: ${{ env.PYTHON_VERSION }}
       - name: Set up the Windows environment
         shell: bash
         run: |
@@ -261,7 +263,7 @@ jobs:
         run: cargo build --release --verbose --features=threading ${{ env.CARGO_ARGS }}
       - uses: actions/setup-python@v4
         with:
-          python-version: "3.11"
+          python-version: ${{ env.PYTHON_VERSION }}
       - name: run snippets
         run: python -m pip install -r requirements.txt && pytest -v
         working-directory: ./extra_tests
@@ -311,7 +313,7 @@ jobs:
         run: cargo clippy --manifest-path=wasm/lib/Cargo.toml -- -Dwarnings
       - uses: actions/setup-python@v4
         with:
-          python-version: "3.11"
+          python-version: ${{ env.PYTHON_VERSION }}
       - name: install ruff
         run: python -m pip install ruff
       - name: run python lint
@@ -359,7 +361,7 @@ jobs:
           tar -xzf geckodriver-v0.30.0-linux64.tar.gz -C geckodriver
       - uses: actions/setup-python@v4
         with:
-          python-version: "3.11"
+          python-version: ${{ env.PYTHON_VERSION }}
       - run: python -m pip install -r requirements.txt
         working-directory: ./wasm/tests
       - uses: actions/setup-node@v3

--- a/.github/workflows/cron-ci.yaml
+++ b/.github/workflows/cron-ci.yaml
@@ -7,6 +7,7 @@ name: Periodic checks/tasks
 
 env:
   CARGO_ARGS: --no-default-features --features stdlib,zlib,importlib,encodings,ssl,jit
+  PYTHON_VERSION: 3.11.4
 
 jobs:
   # codecov collects code coverage data from the rust tests, python snippets and python test suite.
@@ -20,7 +21,7 @@ jobs:
       - uses: taiki-e/install-action@cargo-llvm-cov
       - uses: actions/setup-python@v4
         with:
-          python-version: "3.11"
+          python-version: ${{ env.PYTHON_VERSION }}
       - run: sudo apt-get update && sudo apt-get -y install lcov
       - name: Run cargo-llvm-cov with Rust tests.
         run: cargo llvm-cov --no-report --workspace --exclude rustpython_wasm --verbose --no-default-features --features stdlib,zlib,importlib,encodings,ssl,jit
@@ -74,7 +75,7 @@ jobs:
       - uses: dtolnay/rust-toolchain@stable
       - uses: actions/setup-python@v4
         with:
-          python-version: "3.11"
+          python-version: ${{ env.PYTHON_VERSION }}
       - name: build rustpython
         run: cargo build --release --verbose
       - name: Collect what is left data

--- a/.github/workflows/cron-ci.yaml
+++ b/.github/workflows/cron-ci.yaml
@@ -7,7 +7,7 @@ name: Periodic checks/tasks
 
 env:
   CARGO_ARGS: --no-default-features --features stdlib,zlib,importlib,encodings,ssl,jit
-  PYTHON_VERSION: 3.11.4
+  PYTHON_VERSION: "3.11.4"
 
 jobs:
   # codecov collects code coverage data from the rust tests, python snippets and python test suite.


### PR DESCRIPTION
It seems that the Mac CI sometimes targets 3.11.3, sometimes 3.11.4 and this is becoming very annoying. Pin the Python version to a specific major.minor.micro. Ideally, we'd like to target major.minor in the future.