### PR TITLE
Add parser support for PEP 695

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1953,7 +1953,7 @@ dependencies = [
 [[package]]
 name = "ruff_source_location"
 version = "0.0.0"
-source = "git+https://github.com/RustPython/Parser.git?rev=69d27d924c877b6f2fa5dc75c9589ab505d5b3f1#69d27d924c877b6f2fa5dc75c9589ab505d5b3f1"
+source = "git+https://github.com/RustPython/Parser.git?rev=704eb40108239a8faf9bd1d4217e8dad0ac7edb3#704eb40108239a8faf9bd1d4217e8dad0ac7edb3"
 dependencies = [
  "memchr",
  "once_cell",
@@ -1963,7 +1963,7 @@ dependencies = [
 [[package]]
 name = "ruff_text_size"
 version = "0.0.0"
-source = "git+https://github.com/RustPython/Parser.git?rev=69d27d924c877b6f2fa5dc75c9589ab505d5b3f1#69d27d924c877b6f2fa5dc75c9589ab505d5b3f1"
+source = "git+https://github.com/RustPython/Parser.git?rev=704eb40108239a8faf9bd1d4217e8dad0ac7edb3#704eb40108239a8faf9bd1d4217e8dad0ac7edb3"
 
 [[package]]
 name = "rustc-hash"
@@ -2021,7 +2021,7 @@ dependencies = [
 [[package]]
 name = "rustpython-ast"
 version = "0.2.0"
-source = "git+https://github.com/RustPython/Parser.git?rev=69d27d924c877b6f2fa5dc75c9589ab505d5b3f1#69d27d924c877b6f2fa5dc75c9589ab505d5b3f1"
+source = "git+https://github.com/RustPython/Parser.git?rev=704eb40108239a8faf9bd1d4217e8dad0ac7edb3#704eb40108239a8faf9bd1d4217e8dad0ac7edb3"
 dependencies = [
  "is-macro",
  "malachite-bigint",
@@ -2133,7 +2133,7 @@ dependencies = [
 [[package]]
 name = "rustpython-format"
 version = "0.2.0"
-source = "git+https://github.com/RustPython/Parser.git?rev=69d27d924c877b6f2fa5dc75c9589ab505d5b3f1#69d27d924c877b6f2fa5dc75c9589ab505d5b3f1"
+source = "git+https://github.com/RustPython/Parser.git?rev=704eb40108239a8faf9bd1d4217e8dad0ac7edb3#704eb40108239a8faf9bd1d4217e8dad0ac7edb3"
 dependencies = [
  "bitflags 2.3.1",
  "itertools 0.10.5",
@@ -2160,7 +2160,7 @@ dependencies = [
 [[package]]
 name = "rustpython-literal"
 version = "0.2.0"
-source = "git+https://github.com/RustPython/Parser.git?rev=69d27d924c877b6f2fa5dc75c9589ab505d5b3f1#69d27d924c877b6f2fa5dc75c9589ab505d5b3f1"
+source = "git+https://github.com/RustPython/Parser.git?rev=704eb40108239a8faf9bd1d4217e8dad0ac7edb3#704eb40108239a8faf9bd1d4217e8dad0ac7edb3"
 dependencies = [
  "hexf-parse",
  "is-macro",
@@ -2172,7 +2172,7 @@ dependencies = [
 [[package]]
 name = "rustpython-parser"
 version = "0.2.0"
-source = "git+https://github.com/RustPython/Parser.git?rev=69d27d924c877b6f2fa5dc75c9589ab505d5b3f1#69d27d924c877b6f2fa5dc75c9589ab505d5b3f1"
+source = "git+https://github.com/RustPython/Parser.git?rev=704eb40108239a8faf9bd1d4217e8dad0ac7edb3#704eb40108239a8faf9bd1d4217e8dad0ac7edb3"
 dependencies = [
  "anyhow",
  "is-macro",
@@ -2195,7 +2195,7 @@ dependencies = [
 [[package]]
 name = "rustpython-parser-core"
 version = "0.2.0"
-source = "git+https://github.com/RustPython/Parser.git?rev=69d27d924c877b6f2fa5dc75c9589ab505d5b3f1#69d27d924c877b6f2fa5dc75c9589ab505d5b3f1"
+source = "git+https://github.com/RustPython/Parser.git?rev=704eb40108239a8faf9bd1d4217e8dad0ac7edb3#704eb40108239a8faf9bd1d4217e8dad0ac7edb3"
 dependencies = [
  "is-macro",
  "memchr",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,11 +29,11 @@ rustpython-pylib = { path = "pylib" }
 rustpython-stdlib = { path = "stdlib" }
 rustpython-doc = { git = "https://github.com/RustPython/__doc__", branch = "main" }
 
-rustpython-literal = { git = "https://github.com/RustPython/Parser.git", rev = "69d27d924c877b6f2fa5dc75c9589ab505d5b3f1" }
-rustpython-parser-core = { git = "https://github.com/RustPython/Parser.git", rev = "69d27d924c877b6f2fa5dc75c9589ab505d5b3f1" }
-rustpython-parser = { git = "https://github.com/RustPython/Parser.git", rev = "69d27d924c877b6f2fa5dc75c9589ab505d5b3f1" }
-rustpython-ast = { git = "https://github.com/RustPython/Parser.git", rev = "69d27d924c877b6f2fa5dc75c9589ab505d5b3f1" }
-rustpython-format = { git = "https://github.com/RustPython/Parser.git", rev = "69d27d924c877b6f2fa5dc75c9589ab505d5b3f1" }
+rustpython-literal = { git = "https://github.com/RustPython/Parser.git", rev = "704eb40108239a8faf9bd1d4217e8dad0ac7edb3" }
+rustpython-parser-core = { git = "https://github.com/RustPython/Parser.git", rev = "704eb40108239a8faf9bd1d4217e8dad0ac7edb3" }
+rustpython-parser = { git = "https://github.com/RustPython/Parser.git", rev = "704eb40108239a8faf9bd1d4217e8dad0ac7edb3" }
+rustpython-ast = { git = "https://github.com/RustPython/Parser.git", rev = "704eb40108239a8faf9bd1d4217e8dad0ac7edb3" }
+rustpython-format = { git = "https://github.com/RustPython/Parser.git", rev = "704eb40108239a8faf9bd1d4217e8dad0ac7edb3" }
 # rustpython-literal = { path = "../RustPython-parser/literal" }
 # rustpython-parser-core = { path = "../RustPython-parser/core" }
 # rustpython-parser = { path = "../RustPython-parser/parser" }

--- a/compiler/codegen/src/compile.rs
+++ b/compiler/codegen/src/compile.rs
@@ -888,6 +888,7 @@ impl Compiler {
             Stmt::Pass(_) => {
                 // No need to emit any code here :)
             }
+            Stmt::TypeAlias(_) => {}
         }
         Ok(())
     }

--- a/compiler/codegen/src/symboltable.rs
+++ b/compiler/codegen/src/symboltable.rs
@@ -686,6 +686,7 @@ impl SymbolTableBuilder {
                 bases,
                 keywords,
                 decorator_list,
+                type_params: _,
                 range,
             }) => {
                 self.enter_scope(name.as_str(), SymbolTableType::Class, range.start.row.get());
@@ -863,6 +864,7 @@ impl SymbolTableBuilder {
                     self.scan_expression(expression, ExpressionContext::Load)?;
                 }
             }
+            Stmt::TypeAlias(StmtTypeAlias { .. }) => {}
         }
         Ok(())
     }


### PR DESCRIPTION
Part of https://github.com/RustPython/RustPython/issues/4996

- Adds generated content using the latest Python ASDL
- Bumps RustPython/Parser to the latest version
- Adds stubs for handling generic type parameters and type alias statements

I know more will need to be done to actually _use_ PEP 695, I'd like to address these in separate pull requests if feasible.
