### PR TITLE
Add ability to initialize cwd from PWD when targeting WASI

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -63,6 +63,7 @@ pub use settings::{opts_with_clap, RunMode};
 pub fn run(init: impl FnOnce(&mut VirtualMachine) + 'static) -> ExitCode {
     env_logger::init();
 
+    // NOTE: This is not a WASI convention. But it will be convenient since POSIX shell always defines it.
     #[cfg(target_os = "wasi")]
     {
         if let Ok(pwd) = env::var("PWD") {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -63,6 +63,13 @@ pub use settings::{opts_with_clap, RunMode};
 pub fn run(init: impl FnOnce(&mut VirtualMachine) + 'static) -> ExitCode {
     env_logger::init();
 
+    #[cfg(target_os = "wasi")]
+    {
+        if let Ok(pwd) = env::var("PWD") {
+            let _ = env::set_current_dir(pwd);
+        };
+    }
+
     let (settings, run_mode) = opts_with_clap();
 
     // Be quiet if "quiet" arg is set OR stdin is not connected to a terminal


### PR DESCRIPTION
When compiling to WASI the the current directory is set to `/` on boot. That's a bit unfortunate and it means that if you'd list files in `.` it would read the root directory. This PR allows to initialize the current working directory from the `PWD` environment variable. I have added a `target` check to only do this for WASI.