### PR TITLE
Fix `freeze-stdlib` + `Interpreter::without_stdlib`

### DIFF
--- a/pylib/build.rs
+++ b/pylib/build.rs
@@ -1,11 +1,14 @@
 fn main() {
-    process_python_libs("../Lib/python_builtins/*");
+    process_python_libs("../vm/Lib/python_builtins/*");
 
     #[cfg(not(feature = "stdlib"))]
-    process_python_libs("../Lib/core_modules/*");
-
-    #[cfg(feature = "stdlib")]
-    process_python_libs("../../Lib/**/*");
+    process_python_libs("../vm/Lib/core_modules/*");
+    #[cfg(feature = "freeze-stdlib")]
+    if cfg!(windows) {
+        process_python_libs("../Lib/**/*");
+    } else {
+        process_python_libs("./Lib/**/*");
+    }
 
     if cfg!(windows) {
         if let Ok(real_path) = std::fs::read_to_string("Lib") {

--- a/vm/src/vm/mod.rs
+++ b/vm/src/vm/mod.rs
@@ -244,11 +244,13 @@ impl VirtualMachine {
 
     fn import_utf8_encodings(&mut self) -> PyResult<()> {
         import::import_frozen(self, "codecs")?;
-        let encoding_module_name = if cfg!(feature = "freeze-stdlib") {
-            "encodings.utf_8"
-        } else {
-            "encodings_utf_8"
-        };
+        // FIXME: See corresponding part of `core_frozen_inits`
+        // let encoding_module_name = if cfg!(feature = "freeze-stdlib") {
+        //     "encodings.utf_8"
+        // } else {
+        //     "encodings_utf_8"
+        // };
+        let encoding_module_name = "encodings_utf_8";
         let encoding_module = import::import_frozen(self, encoding_module_name)?;
         let getregentry = encoding_module.get_attr("getregentry", self)?;
         let codec_info = getregentry.call((), self)?;
@@ -875,7 +877,9 @@ fn core_frozen_inits() -> impl Iterator<Item = (&'static str, FrozenModule)> {
 
     // core stdlib Python modules that the vm calls into, but are still used in Python
     // application code, e.g. copyreg
-    #[cfg(not(feature = "freeze-stdlib"))]
+    // FIXME: Initializing core_modules here results duplicated frozen module generation for core_modules.
+    // We need a way to initialize this modules for both `Interpreter::without_stdlib()` and `InterpreterConfig::new().init_stdlib().interpreter()`
+    // #[cfg(not(feature = "freeze-stdlib"))]
     ext_modules!(
         iter,
         dir = "./Lib/core_modules",


### PR DESCRIPTION
Fix #5048