### PR TITLE
Print version and info text when executing the shell

### DIFF
--- a/src/shell.rs
+++ b/src/shell.rs
@@ -6,7 +6,7 @@ use rustpython_vm::{
     compiler::{self, CompileError, CompileErrorType},
     readline::{Readline, ReadlineResult},
     scope::Scope,
-    AsObject, PyResult, VirtualMachine,
+    version, AsObject, PyResult, VirtualMachine,
 };
 
 enum ShellExecResult {
@@ -92,6 +92,15 @@ pub fn run_shell(vm: &VirtualMachine, scope: Scope) -> PyResult<()> {
     }
 
     let mut continuing = false;
+
+    println!(
+        "RustPython {}.{}.{}",
+        version::MAJOR,
+        version::MINOR,
+        version::MICRO,
+    );
+
+    println!("Type \"help\", \"copyright\", \"credits\" or \"license\" for more information.");
 
     loop {
         let prompt_name = if continuing { "ps2" } else { "ps1" };


### PR DESCRIPTION
This PR prints the same initial messages that you'd expect in the CPython shell, at least to some extend.

<img width="650" alt="image" src="https://github.com/RustPython/RustPython/assets/12571019/6975a4e2-e2b0-40f4-b107-efc68f5e7b8f">
