### PR TITLE
simplify rustfmt invocation in CI

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -308,7 +308,7 @@ jobs:
         with:
             components: rustfmt, clippy
       - name: run rustfmt
-        run: cargo fmt --all -- --check
+        run: cargo fmt --check
       - name: run clippy on wasm
         run: cargo clippy --manifest-path=wasm/lib/Cargo.toml -- -Dwarnings
       - uses: actions/setup-python@v4


### PR DESCRIPTION
We added the `--check` flag directly to cargo fmt some time back, so when I stumble across cases of the older more verbose versions I open these types of PRs to increase awareness.

Additionally, when `cargo fmt` is invoked in the root of a workspace it will automatically format all the workspace members (you can see that `cargo fmt --all --check -- --verbose` will enumerate the same files as `cargo fmt --check -- --verbose`).

Our `--all` flag is a bit dated compared to other tools, and is only necessary with `cargo fmt` in some more edge type cases (e.g. wanting to format packages that aren't explicit workspace members, or when invoking from certain subdirectories)