### PR TITLE
Add type_check to _check()

### DIFF
--- a/vm/src/builtins/getset.rs
+++ b/vm/src/builtins/getset.rs
@@ -51,18 +51,19 @@ impl GetDescriptor for PyGetSet {
         _cls: Option<PyObjectRef>,
         vm: &VirtualMachine,
     ) -> PyResult {
-        let (zelf, obj) = match Self::_check(&zelf, obj, vm) {
-            Some(obj) => obj,
-            None => return Ok(zelf),
-        };
-        if let Some(ref f) = zelf.getter {
-            f(vm, obj)
+        if let Some(obj) = obj {
+            let (zelf, obj) = Self::_check(&zelf, obj, vm)?;
+            if let Some(ref f) = zelf.getter {
+                f(vm, obj)
+            } else {
+                Err(vm.new_attribute_error(format!(
+                    "attribute '{}' of '{}' objects is not readable",
+                    zelf.name,
+                    Self::class(&vm.ctx).name()
+                )))
+            }
         } else {
-            Err(vm.new_attribute_error(format!(
-                "attribute '{}' of '{}' objects is not readable",
-                zelf.name,
-                Self::class(&vm.ctx).name()
-            )))
+            Ok(zelf)
         }
     }
 }

--- a/vm/src/protocol/object.rs
+++ b/vm/src/protocol/object.rs
@@ -558,8 +558,8 @@ impl PyObject {
 
     // type protocol
     // PyObject *PyObject_Type(PyObject *o)
-    pub fn obj_type(&self) -> PyObjectRef {
-        self.class().to_owned().into()
+    pub fn obj_type(&self) -> PyTypeRef {
+        self.class().to_owned()
     }
 
     // int PyObject_TypeCheck(PyObject *o, PyTypeObject *type)


### PR DESCRIPTION
Hi!

After implementing `type_check` (#5091) I tried to add the `type_check` call in `_check` function by following the [CPython implementation](https://github.com/python/cpython/blob/cb1bf89c4066f30c80f7d1193b586a2ff8c40579/Objects/descrobject.c#L77). I also modified `descr_get` function of `PyGetSet` based on its [CPython counterpart](https://github.com/python/cpython/blob/cb1bf89c4066f30c80f7d1193b586a2ff8c40579/Objects/descrobject.c#L179). These modifications cause the code to panic and I am not quite sure why. Any thoughts?