### PR TITLE
fix type_check

### DIFF
--- a/vm/src/protocol/object.rs
+++ b/vm/src/protocol/object.rs
@@ -565,7 +565,7 @@ impl PyObject {
 
     // int PyObject_TypeCheck(PyObject *o, PyTypeObject *type)
     pub fn type_check(&self, typ: PyTypeRef) -> bool {
-        self.class().fast_isinstance(&typ)
+        self.fast_isinstance(&typ)
     }
 
     pub fn length_opt(&self, vm: &VirtualMachine) -> Option<PyResult<usize>> {


### PR DESCRIPTION
Hi!

I noticed that there was an error in my earlier pull request (#5091 ). `fast_isinstance()` should be called by `self` instead of `self.class()` in `type_check`. Sorry for the inconvenience.