### PR TITLE
Fake PEP-0695 with empty __type_params__

### DIFF
--- a/vm/src/frame.rs
+++ b/vm/src/frame.rs
@@ -1642,7 +1642,8 @@ impl ExecutingFrame<'_> {
             closure,
             defaults,
             kw_only_defaults,
-            PyMutex::new(qualified_name.clone()),
+            qualified_name.clone(),
+            vm.ctx.empty_tuple.clone(), // FIXME: fake implementation
         )
         .into_pyobject(vm);
 


### PR DESCRIPTION
We need this fake one to make Python 3.12 functools work