### PR TITLE
Update puruspe version from 0.1.5 to 0.2.0

### DIFF
--- a/stdlib/Cargo.toml
+++ b/stdlib/Cargo.toml
@@ -43,7 +43,7 @@ base64 = "0.13.0"
 csv-core = "0.1.10"
 dyn-clone = "1.0.10"
 libz-sys = { version = "1.1.5", optional = true }
-puruspe = "0.1.5"
+puruspe = "0.2.0"
 xml-rs = "0.8.14"
 
 # random


### PR DESCRIPTION
This pull request updates the `puruspe` library from version 0.1.5 to 0.2.0. The API syntax remains unchanged, ensuring full backward compatibility. The new version provides a critical bug fix in the gamma function, enhancing the library's reliability and accuracy.