### PR TITLE
Support slice hash

### DIFF
--- a/Lib/test/test_slice.py
+++ b/Lib/test/test_slice.py
@@ -5,6 +5,7 @@ import operator
 import sys
 import unittest
 import weakref
+import copy
 
 from pickle import loads, dumps
 from test import support
@@ -79,10 +80,16 @@ class SliceTest(unittest.TestCase):
         self.assertEqual(repr(slice(1, 2, 3)), "slice(1, 2, 3)")
 
     def test_hash(self):
-        # Verify clearing of SF bug #800796
-        self.assertRaises(TypeError, hash, slice(5))
+        self.assertEqual(hash(slice(5)), slice(5).__hash__())
+        self.assertEqual(hash(slice(1, 2)), slice(1, 2).__hash__())
+        self.assertEqual(hash(slice(1, 2, 3)), slice(1, 2, 3).__hash__())
+        self.assertNotEqual(slice(5), slice(6))
+
         with self.assertRaises(TypeError):
-            slice(5).__hash__()
+            hash(slice(1, 2, []))
+
+        with self.assertRaises(TypeError):
+            hash(slice(4, {}))
 
     def test_cmp(self):
         s1 = slice(1, 2, 3)
@@ -235,12 +242,49 @@ class SliceTest(unittest.TestCase):
         self.assertEqual(tmp, [(slice(1, 2), 42)])
 
     def test_pickle(self):
+        import pickle
+
         s = slice(10, 20, 3)
-        for protocol in (0,1,2):
+        for protocol in range(pickle.HIGHEST_PROTOCOL + 1):
             t = loads(dumps(s, protocol))
             self.assertEqual(s, t)
             self.assertEqual(s.indices(15), t.indices(15))
             self.assertNotEqual(id(s), id(t))
+
+    def test_copy(self):
+        s = slice(1, 10)
+        c = copy.copy(s)
+        self.assertIs(s, c)
+
+        s = slice(1, 10, 2)
+        c = copy.copy(s)
+        self.assertIs(s, c)
+
+        # Corner case for mutable indices:
+        s = slice([1, 2], [3, 4], [5, 6])
+        c = copy.copy(s)
+        self.assertIs(s, c)
+        self.assertIs(s.start, c.start)
+        self.assertIs(s.stop, c.stop)
+        self.assertIs(s.step, c.step)
+
+    def test_deepcopy(self):
+        s = slice(1, 10)
+        c = copy.deepcopy(s)
+        self.assertEqual(s, c)
+
+        s = slice(1, 10, 2)
+        c = copy.deepcopy(s)
+        self.assertEqual(s, c)
+
+        # Corner case for mutable indices:
+        s = slice([1, 2], [3, 4], [5, 6])
+        c = copy.deepcopy(s)
+        self.assertIsNot(s, c)
+        self.assertEqual(s, c)
+        self.assertIsNot(s.start, c.start)
+        self.assertIsNot(s.stop, c.stop)
+        self.assertIsNot(s.step, c.step)
 
     # TODO: RUSTPYTHON
     @unittest.expectedFailure

--- a/extra_tests/snippets/builtin_slice.py
+++ b/extra_tests/snippets/builtin_slice.py
@@ -82,7 +82,7 @@ assert_raises(TypeError, lambda: slice(0) > 3)
 assert_raises(TypeError, lambda: slice(0) <= 3)
 assert_raises(TypeError, lambda: slice(0) >= 3)
 
-# TODO: slice is hashable in CPython 3.12
+# slice is hashable in CPython 3.12
 # assert_raises(TypeError, hash, slice(0))
 # assert_raises(TypeError, hash, slice(None))
 #

--- a/extra_tests/snippets/builtin_slice.py
+++ b/extra_tests/snippets/builtin_slice.py
@@ -82,16 +82,6 @@ assert_raises(TypeError, lambda: slice(0) > 3)
 assert_raises(TypeError, lambda: slice(0) <= 3)
 assert_raises(TypeError, lambda: slice(0) >= 3)
 
-# slice is hashable in CPython 3.12
-# assert_raises(TypeError, hash, slice(0))
-# assert_raises(TypeError, hash, slice(None))
-#
-# def dict_slice():
-#     d = {}
-#     d[slice(0)] = 3
-#
-# assert_raises(TypeError, dict_slice)
-
 assert slice(None           ).indices(10) == (0, 10,  1)
 assert slice(None,  None,  2).indices(10) == (0, 10,  2)
 assert slice(1,     None,  2).indices(10) == (1, 10,  2)


### PR DESCRIPTION
related to #5101.
This PR implemented slice hash based on [sliceobject.c](https://github.com/python/cpython/blob/main/Objects/sliceobject.c#L653) and updated cooresponding tests.

It seems that the hash results for many objects are different from CPython's, e.g. `hash(None)`.