### PR TITLE
enable std feature in indexmap

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -983,9 +983,9 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "1.9.2"
+version = "1.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1885e79c1fc4b10f0e172c475f458b7f7b93061064d98c3293e98c5ba0c8b399"
+checksum = "bd070e393353796e801d209ad339e89596eb4c8d430d18ede6a1cced8fafbd99"
 dependencies = [
  "autocfg",
  "hashbrown",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -52,7 +52,7 @@ crossbeam-utils = "0.8.16"
 flame = "0.2.2"
 glob = "0.3"
 hex = "0.4.3"
-indexmap = "1.8.1"
+indexmap = { version = "1.9.3", features = ["std"] }
 insta = "1.33.0"
 itertools = "0.11.0"
 is-macro = "0.3.0"


### PR DESCRIPTION
Without 'std' I can't compile for 'wasi'. It seems that random state has to be supplied when 'has_std' is false and somehow indexmap thinks there is no 'std' in 'wasi'.

Also bumped indexmap to match lock file.

```
error[E0107]: struct takes 3 generic arguments but 2 generic arguments were supplied
  --> /workspaces/aici/RustPython/vm/src/function/argument.rs:65:17
   |
65 |     pub kwargs: IndexMap<String, PyObjectRef>,
   |                 ^^^^^^^^ ------  ----------- supplied 2 generic arguments
   |                 |
   |                 expected 3 generic arguments
   |
note: struct defined here, with 3 generic parameters: `K`, `V`, `S`
  --> /root/.cargo/registry/src/index.crates.io-6f17d22bba15001f/indexmap-1.9.3/src/map.rs:76:12
   |
76 | pub struct IndexMap<K, V, S> {
   |            ^^^^^^^^ -  -  -
help: add missing generic argument
   |
65 |     pub kwargs: IndexMap<String, PyObjectRef, S>,
   |                                             +++

error[E0107]: struct takes 3 generic arguments but 2 generic arguments were supplied
```
