### PR TITLE
Added num/malachite-bigint features

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -15,7 +15,7 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  CARGO_ARGS: --no-default-features --features stdlib,zlib,importlib,encodings,ssl
+  CARGO_ARGS: --no-default-features --features malachite-bigint,stdlib,zlib,importlib,encodings,ssl
   # Skip additional tests on Windows. They are checked on Linux and MacOS.
   WINDOWS_SKIPS: >-
     test_datetime
@@ -142,7 +142,8 @@ jobs:
         run: cargo test --workspace --exclude rustpython_wasm --verbose --features threading ${{ env.CARGO_ARGS }}
         if: runner.os != 'macOS'
       - name: run rust tests
-        run: cargo test --workspace --exclude rustpython_wasm --exclude rustpython-jit --verbose --features threading  ${{ env.CARGO_ARGS }}
+        run: cargo test --workspace --exclude rustpython_wasm --exclude rustpython-jit --verbose --no-default-features --features malachite-bigint,threading,stdlib,zlib,importlib,encodings,jit  ${{ env.CARGO_ARGS }}
+
         if: runner.os == 'macOS'
 
       - name: check compilation without threading
@@ -215,7 +216,7 @@ jobs:
           target: wasm32-unknown-unknown
 
       - name: Check compilation for wasm32
-        run: cargo check --target wasm32-unknown-unknown --no-default-features
+        run: cargo check --target wasm32-unknown-unknown --no-default-features --features malachite-bigint
 
       - uses: dtolnay/rust-toolchain@stable
         with:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -142,7 +142,7 @@ jobs:
         run: cargo test --workspace --exclude rustpython_wasm --verbose --features threading ${{ env.CARGO_ARGS }}
         if: runner.os != 'macOS'
       - name: run rust tests
-        run: cargo test --workspace --exclude rustpython_wasm --exclude rustpython-jit --verbose --no-default-features --features malachite-bigint,threading,stdlib,zlib,importlib,encodings,jit  ${{ env.CARGO_ARGS }}
+        run: cargo test --workspace --exclude rustpython_wasm --exclude rustpython-jit --verbose --no-default-features --features malachite-bigint,threading,stdlib,zlib,importlib,encodings,jit,ssl  ${{ env.CARGO_ARGS }}
 
         if: runner.os == 'macOS'
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1429,6 +1429,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "num-bigint"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "608e7659b5c3d7cba262d894801b9ec9d00de989e8a82bd4bef91d08da45cdc0"
+dependencies = [
+ "autocfg",
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
 name = "num-complex"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1448,10 +1459,21 @@ dependencies = [
 ]
 
 [[package]]
-name = "num-traits"
-version = "0.2.15"
+name = "num-rational"
+version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "578ede34cf02f8924ab9447f50c28075b4d3e5b269972345e7e0372b38c6cdcd"
+checksum = "f83d14da390562dca69fc84082e73e548e1ad308d24accdedd2720017cb37824"
+dependencies = [
+ "num-bigint",
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
+name = "num-traits"
+version = "0.2.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
 dependencies = [
  "autocfg",
 ]
@@ -2014,6 +2036,7 @@ source = "git+https://github.com/RustPython/Parser.git?rev=51b5f80ae3080dfec2db8
 dependencies = [
  "is-macro",
  "malachite-bigint",
+ "num-bigint",
  "rustpython-literal",
  "rustpython-parser-core",
  "static_assertions",
@@ -2051,6 +2074,7 @@ dependencies = [
  "malachite-base",
  "malachite-bigint",
  "malachite-q",
+ "num-bigint",
  "num-complex",
  "num-traits",
  "once_cell",
@@ -2081,6 +2105,7 @@ dependencies = [
  "itertools 0.11.0",
  "lz4_flex",
  "malachite-bigint",
+ "num-bigint",
  "num-complex",
  "rustpython-parser-core",
  "serde",
@@ -2128,6 +2153,7 @@ dependencies = [
  "bitflags 2.5.0",
  "itertools 0.11.0",
  "malachite-bigint",
+ "num-bigint",
  "num-traits",
  "rustpython-literal",
 ]
@@ -2170,6 +2196,7 @@ dependencies = [
  "lalrpop-util",
  "log",
  "malachite-bigint",
+ "num-bigint",
  "num-traits",
  "phf",
  "phf_codegen",
@@ -2253,8 +2280,10 @@ dependencies = [
  "memmap2",
  "mt19937",
  "nix 0.27.1",
+ "num-bigint",
  "num-complex",
  "num-integer",
+ "num-rational",
  "num-traits",
  "num_enum",
  "once_cell",
@@ -2324,8 +2353,10 @@ dependencies = [
  "memchr",
  "memoffset 0.9.1",
  "nix 0.27.1",
+ "num-bigint",
  "num-complex",
  "num-integer",
+ "num-rational",
  "num-traits",
  "num_cpus",
  "num_enum",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,23 +18,23 @@ members = [
 
 [workspace.dependencies]
 rustpython-compiler-core = { path = "compiler/core", version = "0.3.1" }
-rustpython-compiler = { path = "compiler", version = "0.3.1" }
+rustpython-compiler = { path = "compiler", default-features = false, version = "0.3.1" }
 rustpython-codegen = { path = "compiler/codegen", version = "0.3.1" }
 rustpython-common = { path = "common", version = "0.3.1" }
-rustpython-derive = { path = "derive", version = "0.3.1" }
-rustpython-derive-impl = { path = "derive-impl", version = "0.3.1" }
+rustpython-derive = { path = "derive", default-features = false, version = "0.3.1" }
+rustpython-derive-impl = { path = "derive-impl", default-features = false, version = "0.3.1" }
 rustpython-jit = { path = "jit", version = "0.3.1" }
 rustpython-vm = { path = "vm", default-features = false, version = "0.3.1" }
-rustpython-pylib = { path = "pylib", version = "0.3.1" }
+rustpython-pylib = { path = "pylib", default-features = false, version = "0.3.1" }
 rustpython-stdlib = { path = "stdlib", default-features = false, version = "0.3.1" }
 rustpython-sre_engine = { path = "vm/sre_engine", version = "0.3.1" }
 rustpython-doc = { git = "https://github.com/RustPython/__doc__", tag = "0.3.0", version = "0.3.0" }
 
 rustpython-literal = { git = "https://github.com/RustPython/Parser.git", version = "0.3.1", rev = "51b5f80ae3080dfec2db815a299a69873fb9ca65" }
 rustpython-parser-core = { git = "https://github.com/RustPython/Parser.git", version = "0.3.1", rev = "51b5f80ae3080dfec2db815a299a69873fb9ca65" }
-rustpython-parser = { git = "https://github.com/RustPython/Parser.git", version = "0.3.1", rev = "51b5f80ae3080dfec2db815a299a69873fb9ca65" }
-rustpython-ast = { git = "https://github.com/RustPython/Parser.git", version = "0.3.1", rev = "51b5f80ae3080dfec2db815a299a69873fb9ca65" }
-rustpython-format = { git = "https://github.com/RustPython/Parser.git", version = "0.3.1", rev = "51b5f80ae3080dfec2db815a299a69873fb9ca65" }
+rustpython-parser = { git = "https://github.com/RustPython/Parser.git", version = "0.3.1", rev = "51b5f80ae3080dfec2db815a299a69873fb9ca65", default-features = false, features = ["location"] }
+rustpython-ast = { git = "https://github.com/RustPython/Parser.git", version = "0.3.1", rev = "51b5f80ae3080dfec2db815a299a69873fb9ca65", default-features = false, features = ["location"] }
+rustpython-format = { git = "https://github.com/RustPython/Parser.git", version = "0.3.1", rev = "51b5f80ae3080dfec2db815a299a69873fb9ca65", default-features = false, features = ["location"] }
 # rustpython-literal = { path = "../RustPython-parser/literal" }
 # rustpython-parser-core = { path = "../RustPython-parser/core" }
 # rustpython-parser = { path = "../RustPython-parser/parser" }
@@ -64,8 +64,10 @@ malachite-bigint = "0.2.0"
 malachite-q = "0.4.4"
 malachite-base = "0.4.4"
 memchr = "2.7.2"
+num-bigint = "0.4.4"
 num-complex = "0.4.0"
 num-integer = "0.1.44"
+num-rational = "0.4.0"
 num-traits = "0.2"
 num_enum = "0.7"
 once_cell = "1.19.0"
@@ -84,7 +86,7 @@ widestring = "1.1.0"
 windows-sys = "0.52.0"
 
 [features]
-default = ["threading", "stdlib", "zlib", "importlib"]
+default = ["threading", "stdlib", "zlib", "importlib", "malachite-bigint"]
 importlib = ["rustpython-vm/importlib"]
 encodings = ["rustpython-vm/encodings"]
 stdlib = ["rustpython-stdlib", "rustpython-pylib", "encodings"]
@@ -96,13 +98,27 @@ zlib = ["stdlib", "rustpython-stdlib/zlib"]
 bz2 = ["stdlib", "rustpython-stdlib/bz2"]
 ssl = ["rustpython-stdlib/ssl"]
 ssl-vendor = ["ssl", "rustpython-stdlib/ssl-vendor"]
+malachite-bigint = [
+    "rustpython-compiler/malachite-bigint",
+    "rustpython-pylib?/malachite-bigint",
+    "rustpython-stdlib?/malachite-bigint",
+    "rustpython-vm/malachite-bigint",
+    "rustpython-parser/malachite-bigint",
+]
+num-bigint = [
+    "rustpython-compiler/num-bigint",
+    "rustpython-pylib?/num-bigint",
+    "rustpython-stdlib?/num-bigint",
+    "rustpython-vm/num-bigint",
+    "rustpython-parser/num-bigint",
+]
 
 [dependencies]
-rustpython-compiler = { workspace = true }
-rustpython-pylib = { workspace = true, optional = true }
-rustpython-stdlib = { workspace = true, optional = true }
-rustpython-vm = { workspace = true, features = ["compiler"] }
-rustpython-parser = { workspace = true }
+rustpython-compiler = { workspace = true, default-features = false }
+rustpython-pylib = { workspace = true, default-features = false, optional = true }
+rustpython-stdlib = { workspace = true, default-features = false, optional = true }
+rustpython-vm = { workspace = true, default-features = false, features = ["compiler"] }
+rustpython-parser = { workspace = true, default-features = false }
 
 atty = { workspace = true }
 cfg-if = { workspace = true }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,7 +34,7 @@ rustpython-literal = { git = "https://github.com/RustPython/Parser.git", version
 rustpython-parser-core = { git = "https://github.com/RustPython/Parser.git", version = "0.3.1", rev = "51b5f80ae3080dfec2db815a299a69873fb9ca65" }
 rustpython-parser = { git = "https://github.com/RustPython/Parser.git", version = "0.3.1", rev = "51b5f80ae3080dfec2db815a299a69873fb9ca65", default-features = false, features = ["location"] }
 rustpython-ast = { git = "https://github.com/RustPython/Parser.git", version = "0.3.1", rev = "51b5f80ae3080dfec2db815a299a69873fb9ca65", default-features = false, features = ["location"] }
-rustpython-format = { git = "https://github.com/RustPython/Parser.git", version = "0.3.1", rev = "51b5f80ae3080dfec2db815a299a69873fb9ca65", default-features = false, features = ["location"] }
+rustpython-format = { git = "https://github.com/RustPython/Parser.git", version = "0.3.1", rev = "51b5f80ae3080dfec2db815a299a69873fb9ca65", default-features = false }
 # rustpython-literal = { path = "../RustPython-parser/literal" }
 # rustpython-parser-core = { path = "../RustPython-parser/core" }
 # rustpython-parser = { path = "../RustPython-parser/parser" }

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -68,6 +68,12 @@ Rust unit tests can be run with `cargo`:
 $ cargo test --workspace --exclude rustpython_wasm
 ```
 
+To enable 'num-bigint' feature (For context refer to the issue [License clarification](https://github.com/RustPython/RustPython/issues/5130)).
+```shell
+cargo test --workspace --exclude rustpython_wasm --no-default-features --features num-bigint,stdlib,threading
+
+```
+
 Python unit tests can be run by compiling RustPython and running the test module:
 
 ```shell

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -70,7 +70,7 @@ $ cargo test --workspace --exclude rustpython_wasm
 
 To enable 'num-bigint' feature (For context refer to the issue [License clarification](https://github.com/RustPython/RustPython/issues/5130)).
 ```shell
-cargo test --workspace --exclude rustpython_wasm --no-default-features --features num-bigint,stdlib,threading
+cargo test --workspace --exclude rustpython_wasm --exclude rustpython-jit --no-default-features --features num-bigint,stdlib,threading
 
 ```
 

--- a/common/Cargo.toml
+++ b/common/Cargo.toml
@@ -9,9 +9,11 @@ license = "MIT"
 
 [features]
 threading = ["parking_lot"]
+malachite-bigint = ["dep:malachite-base", "dep:malachite-bigint", "dep:malachite-q", "rustpython-format/malachite-bigint"]
+num-bigint = ["dep:num-bigint", "rustpython-format/num-bigint"]
 
 [dependencies]
-rustpython-format = { workspace = true }
+rustpython-format = { workspace = true, default-features = false }
 
 ascii = { workspace = true }
 bitflags = { workspace = true }
@@ -19,9 +21,10 @@ bstr = { workspace = true }
 cfg-if = { workspace = true }
 itertools = { workspace = true }
 libc = { workspace = true }
-malachite-bigint = { workspace = true }
-malachite-q = { workspace = true }
-malachite-base = { workspace = true }
+malachite-base = { workspace = true, optional = true }
+malachite-bigint = { workspace = true, optional = true }
+malachite-q = { workspace = true, optional = true }
+num-bigint = { workspace = true, optional = true }
 num-complex = { workspace = true }
 num-traits = { workspace = true }
 once_cell = { workspace = true }

--- a/common/src/float_ops.rs
+++ b/common/src/float_ops.rs
@@ -1,4 +1,7 @@
+#[cfg(feature = "malachite-bigint")]
 use malachite_bigint::{BigInt, ToBigInt};
+#[cfg(feature = "num-bigint")]
+use num_bigint::{BigInt, ToBigInt};
 use num_traits::{Float, Signed, ToPrimitive, Zero};
 use std::f64;
 
@@ -20,7 +23,10 @@ pub fn ufrexp(value: f64) -> (f64, i32) {
 /// # Examples
 ///
 /// ```
+/// #[cfg(feature = "malachite-bigint")]
 /// use malachite_bigint::BigInt;
+/// #[cfg(feature = "num-bigint")]
+/// use num_bigint::BigInt;
 /// use rustpython_common::float_ops::eq_int;
 /// let a = 1.0f64;
 /// let b = BigInt::from(1);

--- a/common/src/hash.rs
+++ b/common/src/hash.rs
@@ -1,4 +1,7 @@
+#[cfg(feature = "malachite-bigint")]
 use malachite_bigint::BigInt;
+#[cfg(feature = "num-bigint")]
+use num_bigint::BigInt;
 use num_traits::ToPrimitive;
 use siphasher::sip::SipHasher24;
 use std::hash::{BuildHasher, Hash, Hasher};

--- a/common/src/int.rs
+++ b/common/src/int.rs
@@ -1,9 +1,18 @@
 use bstr::ByteSlice;
+#[cfg(feature = "malachite-bigint")]
 use malachite_base::{num::conversion::traits::RoundingInto, rounding_modes::RoundingMode};
+#[cfg(feature = "malachite-bigint")]
 use malachite_bigint::{BigInt, BigUint, Sign};
+#[cfg(feature = "malachite-bigint")]
 use malachite_q::Rational;
+#[cfg(feature = "num-bigint")]
+use num_bigint::{BigInt, BigUint, Sign};
+#[cfg(feature = "malachite-bigint")]
 use num_traits::{One, ToPrimitive, Zero};
+#[cfg(feature = "num-bigint")]
+use num_traits::{ToPrimitive, Zero};
 
+#[cfg(feature = "malachite-bigint")]
 pub fn true_div(numerator: &BigInt, denominator: &BigInt) -> f64 {
     let rational = Rational::from_integers_ref(numerator.into(), denominator.into());
     match rational.rounding_into(RoundingMode::Nearest) {
@@ -15,6 +24,7 @@ pub fn true_div(numerator: &BigInt, denominator: &BigInt) -> f64 {
     }
 }
 
+#[cfg(feature = "malachite-bigint")]
 pub fn float_to_ratio(value: f64) -> Option<(BigInt, BigInt)> {
     let sign = match std::cmp::PartialOrd::partial_cmp(&value, &0.0)? {
         std::cmp::Ordering::Less => Sign::Minus,

--- a/compiler/Cargo.toml
+++ b/compiler/Cargo.toml
@@ -7,10 +7,15 @@ repository = "https://github.com/RustPython/RustPython"
 license = "MIT"
 edition = "2021"
 
+[features]
+default = ["malachite-bigint"]
+malachite-bigint = ["rustpython-codegen/malachite-bigint", "rustpython-compiler-core/malachite-bigint", "rustpython-parser/malachite-bigint"]
+num-bigint = ["rustpython-codegen/num-bigint", "rustpython-compiler-core/num-bigint", "rustpython-parser/num-bigint"]
+
 [dependencies]
 rustpython-codegen = { workspace = true }
 rustpython-compiler-core = { workspace = true }
-rustpython-parser = { workspace = true }
+rustpython-parser = { workspace = true, default-features = false }
 
 [lints]
 workspace = true

--- a/compiler/codegen/Cargo.toml
+++ b/compiler/codegen/Cargo.toml
@@ -7,8 +7,12 @@ repository = "https://github.com/RustPython/RustPython"
 license = "MIT"
 edition = "2021"
 
+[features]
+malachite-bigint = ["rustpython-ast/malachite-bigint", "rustpython-compiler-core/malachite-bigint", "rustpython-parser/malachite-bigint"]
+num-bigint = ["rustpython-ast/num-bigint", "rustpython-compiler-core/num-bigint", "rustpython-parser/num-bigint"]
+
 [dependencies]
-rustpython-ast = { workspace = true, features=["unparse", "constant-optimization"] }
+rustpython-ast = { workspace = true, default-features = false, features=["location", "unparse", "constant-optimization"] }
 rustpython-parser-core = { workspace = true }
 rustpython-compiler-core = { workspace = true }
 

--- a/compiler/codegen/Cargo.toml
+++ b/compiler/codegen/Cargo.toml
@@ -25,7 +25,7 @@ num-complex = { workspace = true }
 num-traits = { workspace = true }
 
 [dev-dependencies]
-rustpython-parser = { workspace = true }
+rustpython-parser = { workspace = true, default-features = false }
 
 insta = { workspace = true }
 

--- a/compiler/core/Cargo.toml
+++ b/compiler/core/Cargo.toml
@@ -7,12 +7,17 @@ edition = "2021"
 repository = "https://github.com/RustPython/RustPython"
 license = "MIT"
 
+[features]
+malachite-bigint = ["dep:malachite-bigint"]
+num-bigint = ["dep:num-bigint"]
+
 [dependencies]
 rustpython-parser-core = { workspace = true, features=["location"] }
 
 bitflags = { workspace = true }
 itertools = { workspace = true }
-malachite-bigint = { workspace = true }
+malachite-bigint = { workspace = true, optional = true }
+num-bigint = { workspace = true, optional = true }
 num-complex = { workspace = true }
 serde = { version = "1.0.133", optional = true, default-features = false, features = ["derive"] }
 

--- a/compiler/core/src/bytecode.rs
+++ b/compiler/core/src/bytecode.rs
@@ -3,7 +3,10 @@
 
 use bitflags::bitflags;
 use itertools::Itertools;
+#[cfg(feature = "malachite-bigint")]
 use malachite_bigint::BigInt;
+#[cfg(feature = "num-bigint")]
+use num_bigint::BigInt;
 use num_complex::Complex64;
 use rustpython_parser_core::source_code::{OneIndexed, SourceLocation};
 use std::marker::PhantomData;

--- a/compiler/core/src/marshal.rs
+++ b/compiler/core/src/marshal.rs
@@ -1,5 +1,8 @@
 use crate::bytecode::*;
+#[cfg(feature = "malachite-bigint")]
 use malachite_bigint::{BigInt, Sign};
+#[cfg(feature = "num-bigint")]
+use num_bigint::{BigInt, Sign};
 use num_complex::Complex64;
 use rustpython_parser_core::source_code::{OneIndexed, SourceLocation};
 use std::convert::Infallible;

--- a/derive-impl/Cargo.toml
+++ b/derive-impl/Cargo.toml
@@ -7,6 +7,11 @@ repository = "https://github.com/RustPython/RustPython"
 license = "MIT"
 edition = "2021"
 
+[features]
+default = ["malachite-bigint"]
+malachite-bigint = ["rustpython-compiler-core/malachite-bigint"]
+num-bigint = ["rustpython-compiler-core/num-bigint"]
+
 [dependencies]
 rustpython-compiler-core = { workspace = true }
 rustpython-parser-core = { workspace = true }

--- a/derive/Cargo.toml
+++ b/derive/Cargo.toml
@@ -10,9 +10,14 @@ edition = "2021"
 [lib]
 proc-macro = true
 
+[features]
+default = ["malachite-bigint"]
+malachite-bigint = ["rustpython-compiler/malachite-bigint", "rustpython-derive-impl/malachite-bigint"]
+num-bigint = ["rustpython-compiler/num-bigint", "rustpython-derive-impl/num-bigint"]
+
 [dependencies]
-rustpython-compiler = { workspace = true }
-rustpython-derive-impl = { workspace = true }
+rustpython-compiler = { workspace = true, default-features = false }
+rustpython-derive-impl = { workspace = true, default-features = false }
 syn = { workspace = true }
 
 [lints]

--- a/jit/Cargo.toml
+++ b/jit/Cargo.toml
@@ -24,7 +24,7 @@ version = "3.1.0"
 features = ["system"]
 
 [dev-dependencies]
-rustpython-derive = { path = "../derive", version = "0.3.1" }
+rustpython-derive = { path = "../derive", default-features = false, version = "0.3.1" }
 
 approx = "0.5.1"
 

--- a/pylib/Cargo.toml
+++ b/pylib/Cargo.toml
@@ -9,11 +9,18 @@ edition = "2021"
 include = ["Cargo.toml", "src/**/*.rs", "Lib/", "!Lib/**/test/", "!Lib/**/*.pyc"]
 
 [features]
+default = ["malachite-bigint"]
 freeze-stdlib = []
+malachite-bigint = [
+    "rustpython-derive/malachite-bigint",
+]
+num-bigint = [
+    "rustpython-derive/num-bigint",
+]
 
 [dependencies]
 rustpython-compiler-core = { workspace = true }
-rustpython-derive = { version = "0.3.1", path = "../derive" }
+rustpython-derive = { version = "0.3.1", default-features = false, path = "../derive" }
 
 [build-dependencies]
 glob = { workspace = true }

--- a/stdlib/Cargo.toml
+++ b/stdlib/Cargo.toml
@@ -10,16 +10,30 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [features]
+default = ["malachite-bigint"]
 threading = ["rustpython-common/threading", "rustpython-vm/threading"]
 zlib = ["libz-sys", "flate2/zlib"]
 bz2 = ["bzip2"]
 ssl = ["openssl", "openssl-sys", "foreign-types-shared"]
 ssl-vendor = ["ssl", "openssl/vendored", "openssl-probe"]
+malachite-bigint = [
+  "dep:malachite-bigint",
+  "rustpython-derive/malachite-bigint",
+  "rustpython-vm/malachite-bigint",
+  "rustpython-common/malachite-bigint"
+]
+num-bigint = [
+  "dep:num-bigint",
+  "dep:num-rational",
+  "rustpython-derive/num-bigint",
+  "rustpython-vm/num-bigint",
+  "rustpython-common/num-bigint",
+]
 
 [dependencies]
 # rustpython crates
-rustpython-derive = { workspace = true }
-rustpython-vm = { workspace = true }
+rustpython-derive = { workspace = true, default-features = false }
+rustpython-vm = { workspace = true, default-features = false }
 rustpython-common = { workspace = true }
 
 ahash = { workspace = true }
@@ -32,8 +46,10 @@ indexmap = { workspace = true }
 libc = { workspace = true }
 nix = { workspace = true }
 num-complex = { workspace = true }
-malachite-bigint = { workspace = true }
+malachite-bigint = { workspace = true, optional = true }
+num-bigint = { workspace = true, optional = true }
 num-integer = { workspace = true }
+num-rational = { workspace = true, optional = true }
 num-traits = { workspace = true }
 num_enum = { workspace = true }
 once_cell = { workspace = true }

--- a/stdlib/src/json.rs
+++ b/stdlib/src/json.rs
@@ -12,7 +12,10 @@ mod _json {
         types::{Callable, Constructor},
         AsObject, Py, PyObjectRef, PyPayload, PyResult, VirtualMachine,
     };
+    #[cfg(feature = "malachite-bigint")]
     use malachite_bigint::BigInt;
+    #[cfg(feature = "num-bigint")]
+    use num_bigint::BigInt;
     use std::str::FromStr;
 
     #[pyattr(name = "make_scanner")]

--- a/stdlib/src/math.rs
+++ b/stdlib/src/math.rs
@@ -14,9 +14,9 @@ mod math {
     use num_bigint::BigInt;
     #[cfg(feature = "num-bigint")]
     use num_rational::Ratio;
-    use num_traits::{One, Signed, Zero};
     #[cfg(feature = "num-bigint")]
     use num_traits::ToPrimitive;
+    use num_traits::{One, Signed, Zero};
     use rustpython_common::float_ops;
     #[cfg(feature = "malachite-bigint")]
     use rustpython_common::int::true_div;

--- a/stdlib/src/random.rs
+++ b/stdlib/src/random.rs
@@ -11,7 +11,10 @@ mod _random {
         types::Constructor,
         PyObjectRef, PyPayload, PyResult, VirtualMachine,
     };
+    #[cfg(feature = "malachite-bigint")]
     use malachite_bigint::{BigInt, BigUint, Sign};
+    #[cfg(feature = "num-bigint")]
+    use num_bigint::{BigInt, BigUint, Sign};
     use num_traits::{Signed, Zero};
     use rand::{rngs::StdRng, RngCore, SeedableRng};
 

--- a/stdlib/src/sqlite.rs
+++ b/stdlib/src/sqlite.rs
@@ -45,7 +45,10 @@ mod _sqlite {
         SQLITE_NULL, SQLITE_OPEN_CREATE, SQLITE_OPEN_READWRITE, SQLITE_OPEN_URI, SQLITE_TEXT,
         SQLITE_TRACE_STMT, SQLITE_TRANSIENT, SQLITE_UTF8,
     };
+    #[cfg(feature = "malachite-bigint")]
     use malachite_bigint::Sign;
+    #[cfg(feature = "num-bigint")]
+    use num_bigint::Sign;
     use rustpython_common::{
         atomic::{Ordering, PyAtomic, Radium},
         hash::PyHash,

--- a/vm/Cargo.toml
+++ b/vm/Cargo.toml
@@ -9,7 +9,7 @@ edition = "2021"
 include = ["src/**/*.rs", "Cargo.toml", "build.rs", "Lib/**/*.py"]
 
 [features]
-default = ["compiler"]
+default = ["compiler", "malachite-bigint"]
 importlib = []
 encodings = ["importlib"]
 vm-tracing-logging = []
@@ -22,20 +22,42 @@ ast = ["rustpython-ast"]
 codegen = ["rustpython-codegen", "ast"]
 parser = ["rustpython-parser", "ast"]
 serde = ["dep:serde"]
+malachite-bigint = [
+    "dep:malachite-bigint",
+    "rustpython-compiler?/malachite-bigint",
+    "rustpython-codegen/malachite-bigint",
+    "rustpython-common/malachite-bigint",
+    "rustpython-derive/malachite-bigint",
+    "rustpython-ast?/malachite-bigint",
+    "rustpython-parser?/malachite-bigint",
+    "rustpython-compiler-core/malachite-bigint",
+    "rustpython-format/malachite-bigint"
+]
+num-bigint = [
+    "dep:num-bigint",
+    "rustpython-compiler?/num-bigint",
+    "rustpython-codegen/num-bigint",
+    "rustpython-common/num-bigint",
+    "rustpython-derive/num-bigint",
+    "rustpython-ast?/num-bigint",
+    "rustpython-parser?/num-bigint",
+    "rustpython-compiler-core/num-bigint",
+    "rustpython-format/num-bigint"
+]
 
 [dependencies]
-rustpython-compiler = { workspace = true, optional = true }
+rustpython-compiler = { workspace = true, default-features = false, optional = true }
 rustpython-codegen = { workspace = true, optional = true }
 rustpython-common = { workspace = true }
-rustpython-derive = { workspace = true }
+rustpython-derive = { workspace = true, default-features = false }
 rustpython-jit = { workspace = true, optional = true }
 
-rustpython-ast = { workspace = true, optional = true }
-rustpython-parser = { workspace = true, optional = true }
+rustpython-ast = { workspace = true, default-features = false, optional = true }
+rustpython-parser = { workspace = true, default-features = false, optional = true }
 rustpython-compiler-core = { workspace = true }
 rustpython-parser-core = { workspace = true }
 rustpython-literal = { workspace = true }
-rustpython-format = { workspace = true }
+rustpython-format = { workspace = true, default-features = false }
 rustpython-sre_engine = { workspace = true }
 
 ascii = { workspace = true }
@@ -54,9 +76,11 @@ is-macro = { workspace = true }
 libc = { workspace = true }
 log = { workspace = true }
 nix = { workspace = true }
-malachite-bigint = { workspace = true }
+malachite-bigint = { workspace = true, optional = true }
+num-bigint = { workspace = true, optional = true }
 num-complex = { workspace = true }
 num-integer = { workspace = true }
+num-rational = { workspace = true }
 num-traits = { workspace = true }
 num_enum = { workspace = true }
 once_cell = { workspace = true }

--- a/vm/src/buffer.rs
+++ b/vm/src/buffer.rs
@@ -7,7 +7,10 @@ use crate::{
 };
 use half::f16;
 use itertools::Itertools;
+#[cfg(feature = "malachite-bigint")]
 use malachite_bigint::BigInt;
+#[cfg(feature = "num-bigint")]
+use num_bigint::BigInt;
 use num_traits::{PrimInt, ToPrimitive};
 use std::{fmt, iter::Peekable, mem, os::raw};
 

--- a/vm/src/builtins/bool.rs
+++ b/vm/src/builtins/bool.rs
@@ -9,7 +9,10 @@ use crate::{
     AsObject, Context, Py, PyObject, PyObjectRef, PyPayload, PyResult, TryFromBorrowedObject,
     VirtualMachine,
 };
+#[cfg(feature = "malachite-bigint")]
 use malachite_bigint::Sign;
+#[cfg(feature = "num-bigint")]
+use num_bigint::Sign;
 use num_traits::Zero;
 use rustpython_format::FormatSpec;
 use std::fmt::{Debug, Formatter};

--- a/vm/src/builtins/code.rs
+++ b/vm/src/builtins/code.rs
@@ -14,7 +14,10 @@ use crate::{
     types::Representable,
     AsObject, Context, Py, PyObject, PyObjectRef, PyPayload, PyResult, VirtualMachine,
 };
+#[cfg(feature = "malachite-bigint")]
 use malachite_bigint::BigInt;
+#[cfg(feature = "num-bigint")]
+use num_bigint::BigInt;
 use num_traits::Zero;
 use std::{borrow::Borrow, fmt, ops::Deref};
 

--- a/vm/src/builtins/enumerate.rs
+++ b/vm/src/builtins/enumerate.rs
@@ -10,7 +10,10 @@ use crate::{
     types::{Constructor, IterNext, Iterable, SelfIter},
     AsObject, Context, Py, PyObjectRef, PyPayload, PyResult, VirtualMachine,
 };
+#[cfg(feature = "malachite-bigint")]
 use malachite_bigint::BigInt;
+#[cfg(feature = "num-bigint")]
+use num_bigint::BigInt;
 use num_traits::Zero;
 
 #[pyclass(module = false, name = "enumerate", traverse)]

--- a/vm/src/builtins/int.rs
+++ b/vm/src/builtins/int.rs
@@ -1,4 +1,6 @@
 use super::{float, PyByteArray, PyBytes, PyStr, PyType, PyTypeRef};
+#[cfg(feature = "malachite-bigint")]
+use crate::common::int::true_div;
 use crate::{
     builtins::PyStrRef,
     bytesinner::PyBytesInner,
@@ -18,8 +20,6 @@ use crate::{
     TryFromBorrowedObject, VirtualMachine,
 };
 #[cfg(feature = "malachite-bigint")]
-use crate::common::int::true_div;
-#[cfg(feature = "malachite-bigint")]
 use malachite_bigint::{BigInt, Sign};
 #[cfg(feature = "num-bigint")]
 use num_bigint::{BigInt, Sign};
@@ -29,10 +29,10 @@ use num_rational::Ratio;
 use num_traits::{One, Pow, PrimInt, Signed, ToPrimitive, Zero};
 use rustpython_format::FormatSpec;
 use std::fmt;
-#[cfg(feature = "malachite-bigint")]
-use std::ops::{Neg, Not};
 #[cfg(feature = "num-bigint")]
 use std::ops::{Div, Neg, Not};
+#[cfg(feature = "malachite-bigint")]
+use std::ops::{Neg, Not};
 
 #[pyclass(module = false, name = "int")]
 #[derive(Debug)]

--- a/vm/src/builtins/range.rs
+++ b/vm/src/builtins/range.rs
@@ -15,7 +15,10 @@ use crate::{
     VirtualMachine,
 };
 use crossbeam_utils::atomic::AtomicCell;
+#[cfg(feature = "malachite-bigint")]
 use malachite_bigint::{BigInt, Sign};
+#[cfg(feature = "num-bigint")]
+use num_bigint::{BigInt, Sign};
 use num_integer::Integer;
 use num_traits::{One, Signed, ToPrimitive, Zero};
 use once_cell::sync::Lazy;

--- a/vm/src/builtins/slice.rs
+++ b/vm/src/builtins/slice.rs
@@ -10,7 +10,10 @@ use crate::{
     types::{Comparable, Constructor, Hashable, PyComparisonOp, Representable},
     AsObject, Context, Py, PyObject, PyObjectRef, PyPayload, PyRef, PyResult, VirtualMachine,
 };
+#[cfg(feature = "malachite-bigint")]
 use malachite_bigint::{BigInt, ToBigInt};
+#[cfg(feature = "num-bigint")]
+use num_bigint::{BigInt, ToBigInt};
 use num_traits::{One, Signed, Zero};
 
 #[pyclass(module = false, name = "slice", unhashable = true, traverse)]

--- a/vm/src/bytesinner.rs
+++ b/vm/src/bytesinner.rs
@@ -17,7 +17,10 @@ use crate::{
 };
 use bstr::ByteSlice;
 use itertools::Itertools;
+#[cfg(feature = "malachite-bigint")]
 use malachite_bigint::BigInt;
+#[cfg(feature = "num-bigint")]
+use num_bigint::BigInt;
 use num_traits::ToPrimitive;
 
 #[derive(Debug, Default, Clone)]

--- a/vm/src/function/number.rs
+++ b/vm/src/function/number.rs
@@ -1,6 +1,9 @@
 use super::argument::OptionalArg;
 use crate::{builtins::PyIntRef, AsObject, PyObjectRef, PyResult, TryFromObject, VirtualMachine};
+#[cfg(feature = "malachite-bigint")]
 use malachite_bigint::BigInt;
+#[cfg(feature = "num-bigint")]
+use num_bigint::BigInt;
 use num_complex::Complex64;
 use num_traits::PrimInt;
 use std::ops::Deref;

--- a/vm/src/macros.rs
+++ b/vm/src/macros.rs
@@ -64,7 +64,10 @@ macro_rules! py_namespace {
 /// # Examples
 ///
 /// ```
+/// #[cfg(feature = "malachite-bigint")]
 /// use malachite_bigint::ToBigInt;
+/// #[cfg(feature = "num-bigint")]
+/// use num_bigint::ToBigInt;
 /// use num_traits::Zero;
 ///
 /// use rustpython_vm::match_class;
@@ -88,7 +91,10 @@ macro_rules! py_namespace {
 /// With a binding to the downcasted type:
 ///
 /// ```
+/// #[cfg(feature = "malachite-bigint")]
 /// use malachite_bigint::ToBigInt;
+/// #[cfg(feature = "num-bigint")]
+/// use num_bigint::ToBigInt;
 /// use num_traits::Zero;
 ///
 /// use rustpython_vm::match_class;

--- a/vm/src/sliceable.rs
+++ b/vm/src/sliceable.rs
@@ -3,7 +3,10 @@ use crate::{
     builtins::{int::PyInt, slice::PySlice},
     PyObject, PyResult, VirtualMachine,
 };
+#[cfg(feature = "malachite-bigint")]
 use malachite_bigint::BigInt;
+#[cfg(feature = "num-bigint")]
+use num_bigint::BigInt;
 use num_traits::{Signed, ToPrimitive};
 use std::ops::Range;
 

--- a/vm/src/stdlib/io.rs
+++ b/vm/src/stdlib/io.rs
@@ -131,7 +131,10 @@ mod _io {
     };
     use bstr::ByteSlice;
     use crossbeam_utils::atomic::AtomicCell;
+    #[cfg(feature = "malachite-bigint")]
     use malachite_bigint::{BigInt, BigUint};
+    #[cfg(feature = "num-bigint")]
+    use num_bigint::{BigInt, BigUint};
     use num_traits::ToPrimitive;
     use std::{
         io::{self, prelude::*, Cursor, SeekFrom},

--- a/vm/src/stdlib/itertools.rs
+++ b/vm/src/stdlib/itertools.rs
@@ -22,7 +22,10 @@ mod decl {
         VirtualMachine,
     };
     use crossbeam_utils::atomic::AtomicCell;
+    #[cfg(feature = "malachite-bigint")]
     use malachite_bigint::BigInt;
+    #[cfg(feature = "num-bigint")]
+    use num_bigint::BigInt;
     use num_traits::One;
 
     use num_traits::{Signed, ToPrimitive};

--- a/vm/src/stdlib/marshal.rs
+++ b/vm/src/stdlib/marshal.rs
@@ -15,7 +15,10 @@ mod decl {
         protocol::PyBuffer,
         PyObjectRef, PyResult, TryFromObject, VirtualMachine,
     };
+    #[cfg(feature = "malachite-bigint")]
     use malachite_bigint::BigInt;
+    #[cfg(feature = "num-bigint")]
+    use num_bigint::BigInt;
     use num_complex::Complex64;
     use num_traits::Zero;
     use rustpython_compiler_core::marshal;

--- a/vm/src/types/slot.rs
+++ b/vm/src/types/slot.rs
@@ -15,7 +15,10 @@ use crate::{
     AsObject, Py, PyObject, PyObjectRef, PyPayload, PyRef, PyResult, VirtualMachine,
 };
 use crossbeam_utils::atomic::AtomicCell;
+#[cfg(feature = "malachite-bigint")]
 use malachite_bigint::BigInt;
+#[cfg(feature = "num-bigint")]
+use num_bigint::BigInt;
 use num_traits::{Signed, ToPrimitive};
 use std::{borrow::Borrow, cmp::Ordering, ops::Deref};
 

--- a/vm/src/vm/context.rs
+++ b/vm/src/vm/context.rs
@@ -25,7 +25,10 @@ use crate::{
     types::{PyTypeFlags, PyTypeSlots, TypeZoo},
     PyResult, VirtualMachine,
 };
+#[cfg(feature = "malachite-bigint")]
 use malachite_bigint::BigInt;
+#[cfg(feature = "num-bigint")]
+use num_bigint::BigInt;
 use num_complex::Complex64;
 use num_traits::ToPrimitive;
 use rustpython_common::lock::PyRwLock;

--- a/vm/src/vm/interpreter.rs
+++ b/vm/src/vm/interpreter.rs
@@ -143,7 +143,10 @@ mod tests {
         builtins::{int, PyStr},
         PyObjectRef,
     };
+    #[cfg(feature = "malachite-bigint")]
     use malachite_bigint::ToBigInt;
+    #[cfg(feature = "num-bigint")]
+    use num_bigint::ToBigInt;
 
     #[test]
     fn test_add_py_integers() {

--- a/wasm/lib/Cargo.toml
+++ b/wasm/lib/Cargo.toml
@@ -11,18 +11,32 @@ edition = "2021"
 crate-type = ["cdylib", "rlib"]
 
 [features]
-default = ["freeze-stdlib"]
+default = ["freeze-stdlib", "malachite-bigint"]
 freeze-stdlib = ["rustpython-vm/freeze-stdlib", "rustpython-pylib/freeze-stdlib", "rustpython-stdlib"]
 no-start-func = []
+malachite-bigint = [
+    "rustpython-common/malachite-bigint",
+    "rustpython-pylib/malachite-bigint",
+    "rustpython-stdlib/malachite-bigint",
+    "rustpython-vm/malachite-bigint",
+    "rustpython-parser/malachite-bigint"
+]
+num-bigint = [
+    "rustpython-common/num-bigint",
+    "rustpython-pylib/num-bigint",
+    "rustpython-stdlib/num-bigint",
+    "rustpython-vm/num-bigint",
+    "rustpython-parser/num-bigint"
+]
 
 [dependencies]
 rustpython-common = { workspace = true }
-rustpython-pylib = { workspace = true, optional = true }
+rustpython-pylib = { workspace = true, default-features = false, optional = true }
 rustpython-stdlib = { workspace = true, default-features = false, optional = true }
 # make sure no threading! otherwise wasm build will fail
-rustpython-vm = { workspace = true, features = ["compiler", "encodings", "serde"] }
+rustpython-vm = { workspace = true, default-features = false, features = ["compiler", "encodings", "serde"] }
 
-rustpython-parser = { workspace = true }
+rustpython-parser = { workspace = true, default-features = false }
 
 serde = { workspace = true }
 


### PR DESCRIPTION
As per the comment, https://github.com/RustPython/RustPython/issues/5130#issuecomment-1853251581 added support for both `num-bigint` and `malachite-bigint` to fix https://github.com/RustPython/RustPython/issues/5130

Changes are tested on Mac and Ubuntu. 
Some tests fail, but they also fail without these changes. So I assume these are flaky.

**Note**: 

As the `num-bigint` and `malachite-bigint` are mutually exclusive features, care should be taken when changing things(deps) around. Most likely, adding 'default-features = false' will suffice.
This should be worthwhile as the malachite dependency is LGPL and it complicates licensing of any projects that embed RustPython.

Example usage:

```
rustpython-vm = { git = "https://github.com/h7kanna/rustpython", branch = "num-malachite-bigint-features", default-features = false, features = ["compiler", "serde", "num-bigint"]  }
rustpython = { git = "https://github.com/h7kanna/rustpython", branch = "num-malachite-bigint-features", default-features = false, features = ["num-bigint", "stdlib","threading"]}
```

Tests when `num-bigint` enabled
```
cargo test --workspace --exclude rustpython_wasm --no-default-features --features num-bigint,stdlib,threading
```

About CI:

Again as the features are mutually exclusive, CI workflow should be run with both enabled separately potentially doubling the run time. I added the 'malachite-bigint' in the workflow as it is the default and the default tests are successful

6 tests are failing when the 'num-bigint' is enabled, they need to be checked/fixed. That can be done in a separate PR if these changes are okay.

Also, we can refactor the code to use a separate crate 'rustpython-bigint' similar to https://github.com/RustPython/Parser/blob/main/format/src/bigint.rs

