### PR TITLE
Raise error on power with negative number

### DIFF
--- a/Lib/test/test_complex.py
+++ b/Lib/test/test_complex.py
@@ -236,8 +236,6 @@ class ComplexTest(unittest.TestCase):
         for a, b in ZERO_DIVISION:
             self.assertRaises(TypeError, divmod, a, b)
 
-    # TODO: RUSTPYTHON
-    @unittest.expectedFailure
     def test_pow(self):
         self.assertAlmostEqual(pow(1+1j, 0+0j), 1.0)
         self.assertAlmostEqual(pow(0+0j, 2+0j), 0.0)

--- a/vm/src/builtins/complex.rs
+++ b/vm/src/builtins/complex.rs
@@ -103,7 +103,7 @@ fn inner_div(v1: Complex64, v2: Complex64, vm: &VirtualMachine) -> PyResult<Comp
 
 fn inner_pow(v1: Complex64, v2: Complex64, vm: &VirtualMachine) -> PyResult<Complex64> {
     if v1.is_zero() {
-        return if v2.re < 0.0 || v2.im != 0.0{
+        return if v2.re < 0.0 || v2.im != 0.0 {
             let msg = format!("{v1} cannot be raised to a negative or complex power");
             Err(vm.new_zero_division_error(msg))
         } else if v2.is_zero() {

--- a/vm/src/builtins/complex.rs
+++ b/vm/src/builtins/complex.rs
@@ -103,7 +103,7 @@ fn inner_div(v1: Complex64, v2: Complex64, vm: &VirtualMachine) -> PyResult<Comp
 
 fn inner_pow(v1: Complex64, v2: Complex64, vm: &VirtualMachine) -> PyResult<Complex64> {
     if v1.is_zero() {
-        return if v2.im != 0.0 {
+        return if v2.re < 0.0 || v2.im != 0.0{
             let msg = format!("{v1} cannot be raised to a negative or complex power");
             Err(vm.new_zero_division_error(msg))
         } else if v2.is_zero() {


### PR DESCRIPTION
Addressing issue #5138, this PR adds another check on the `inner_pow` function to raise error when the real number part of power number is negative