### PR TITLE
Fix bug in `binascii` `uu` encoding. Pass more related unit tests.

### DIFF
--- a/Lib/test/test_binascii.py
+++ b/Lib/test/test_binascii.py
@@ -38,8 +38,6 @@ class BinASCIITest(unittest.TestCase):
             self.assertTrue(hasattr(getattr(binascii, name), '__call__'))
             self.assertRaises(TypeError, getattr(binascii, name))
 
-    # TODO: RUSTPYTHON
-    @unittest.expectedFailure
     def test_returned_value(self):
         # Limit to the minimum of all limits (b2a_uu)
         MAX_ALL = 45
@@ -186,8 +184,6 @@ class BinASCIITest(unittest.TestCase):
         assertInvalidLength(b'a' * (4 * 87 + 1))
         assertInvalidLength(b'A\tB\nC ??DE')  # only 5 valid characters
 
-    # TODO: RUSTPYTHON
-    @unittest.expectedFailure
     def test_uu(self):
         MAX_UU = 45
         for backtick in (True, False):
@@ -404,8 +400,6 @@ class BinASCIITest(unittest.TestCase):
         # crc_hqx needs 2 arguments
         self.assertRaises(TypeError, binascii.crc_hqx, "test", 0)
 
-    # TODO: RUSTPYTHON
-    @unittest.expectedFailure
     def test_unicode_a2b(self):
         # Unicode strings are accepted by a2b_* functions.
         MAX_ALL = 45

--- a/Lib/test/test_codecs.py
+++ b/Lib/test/test_codecs.py
@@ -2946,8 +2946,6 @@ else:
 
 class TransformCodecTest(unittest.TestCase):
 
-    # TODO: RUSTPYTHON
-    @unittest.expectedFailure
     def test_basics(self):
         binput = bytes(range(256))
         for encoding in bytes_transform_encodings:
@@ -2959,8 +2957,6 @@ class TransformCodecTest(unittest.TestCase):
                 self.assertEqual(size, len(o))
                 self.assertEqual(i, binput)
 
-    # TODO: RUSTPYTHON
-    @unittest.expectedFailure
     def test_read(self):
         for encoding in bytes_transform_encodings:
             with self.subTest(encoding=encoding):
@@ -2969,8 +2965,6 @@ class TransformCodecTest(unittest.TestCase):
                 sout = reader.read()
                 self.assertEqual(sout, b"\x80")
 
-    # TODO: RUSTPYTHON
-    @unittest.expectedFailure
     def test_readline(self):
         for encoding in bytes_transform_encodings:
             with self.subTest(encoding=encoding):

--- a/Lib/test/test_uu.py
+++ b/Lib/test/test_uu.py
@@ -75,8 +75,6 @@ class UUTest(unittest.TestCase):
         with self.assertRaises(TypeError):
             uu.encode(inp, out, "t1", 0o644, True)
 
-    # TODO: RUSTPYTHON
-    @unittest.expectedFailure
     def test_decode(self):
         for backtick in True, False:
             inp = io.BytesIO(encodedtextwrapped(0o666, "t1", backtick=backtick))
@@ -110,8 +108,6 @@ class UUTest(unittest.TestCase):
         except uu.Error as e:
             self.assertEqual(str(e), "No valid begin line found in input file")
 
-    # TODO: RUSTPYTHON
-    @unittest.expectedFailure
     def test_garbage_padding(self):
         # Issue #22406
         encodedtext1 = (
@@ -163,8 +159,6 @@ class UUStdIOTest(unittest.TestCase):
         sys.stdin = self.stdin
         sys.stdout = self.stdout
 
-    # TODO: RUSTPYTHON
-    @unittest.expectedFailure
     def test_encode(self):
         sys.stdin = FakeIO(plaintext.decode("ascii"))
         sys.stdout = FakeIO()
@@ -172,8 +166,6 @@ class UUStdIOTest(unittest.TestCase):
         self.assertEqual(sys.stdout.getvalue(),
                          encodedtextwrapped(0o666, "t1").decode("ascii"))
 
-    # TODO: RUSTPYTHON
-    @unittest.expectedFailure
     def test_decode(self):
         sys.stdin = FakeIO(encodedtextwrapped(0o666, "t1").decode("ascii"))
         sys.stdout = FakeIO()
@@ -192,8 +184,6 @@ class UUFileTest(unittest.TestCase):
         self.addCleanup(os_helper.unlink, self.tmpin)
         self.addCleanup(os_helper.unlink, self.tmpout)
 
-    # TODO: RUSTPYTHON
-    @unittest.expectedFailure
     def test_encode(self):
         with open(self.tmpin, 'wb') as fin:
             fin.write(plaintext)
@@ -212,8 +202,6 @@ class UUFileTest(unittest.TestCase):
             s = fout.read()
         self.assertEqual(s, encodedtextwrapped(0o644, self.tmpin))
 
-    # TODO: RUSTPYTHON
-    @unittest.expectedFailure
     def test_decode(self):
         with open(self.tmpin, 'wb') as f:
             f.write(encodedtextwrapped(0o644, self.tmpout))
@@ -226,8 +214,6 @@ class UUFileTest(unittest.TestCase):
         self.assertEqual(s, plaintext)
         # XXX is there an xp way to verify the mode?
 
-    # TODO: RUSTPYTHON
-    @unittest.expectedFailure
     def test_decode_filename(self):
         with open(self.tmpin, 'wb') as f:
             f.write(encodedtextwrapped(0o644, self.tmpout))


### PR DESCRIPTION
- Fix logic bug in both `binascii.a2b_uu` and `binascii.b2a_uu`.
- Use correct error type by `new_binascii_error` instead of `new_value_error`.
- Pass three more unit tests: `test_uu`, `test_returned_value` and `test_unicode_a2b`.

[Edit]
- Pass more related unit tests in `test_uu` and `test_codecs`.
