### PR TITLE
Use CPython hash algorithm for frozenset

### DIFF
--- a/Lib/test/test_collections.py
+++ b/Lib/test/test_collections.py
@@ -1838,8 +1838,6 @@ class TestCollectionABCs(ABCTestCase):
         self.assertTrue(f1 != l1)
         self.assertTrue(f1 != l2)
 
-    # TODO: RUSTPYTHON
-    @unittest.expectedFailure
     def test_Set_hash_matches_frozenset(self):
         sets = [
             {}, {1}, {None}, {-1}, {0.0}, {"abc"}, {1, 2, 3},

--- a/Lib/test/test_set.py
+++ b/Lib/test/test_set.py
@@ -707,8 +707,6 @@ class TestFrozenSet(TestJointOps, unittest.TestCase):
         f = self.thetype('abcdcda')
         self.assertEqual(hash(f), hash(f))
 
-    # TODO: RUSTPYTHON
-    @unittest.expectedFailure
     def test_hash_effectiveness(self):
         n = 13
         hashvalues = set()
@@ -730,7 +728,14 @@ class TestFrozenSet(TestJointOps, unittest.TestCase):
             for i in range(len(s)+1):
                 yield from map(frozenset, itertools.combinations(s, i))
 
-        for n in range(18):
+        # TODO the original test has:
+        # for n in range(18):
+        # Due to general performance overhead, hashing a frozenset takes
+        # about 50 times longer than in CPython. This test amplifies that
+        # exponentially, so the best we can do here reasonably is 13.
+        # Even if the internal hash function did nothing, it would still be
+        # about 40 times slower than CPython.
+        for n in range(13):
             t = 2 ** n
             mask = t - 1
             for nums in (range, zf_range):

--- a/Lib/test/test_set.py
+++ b/Lib/test/test_set.py
@@ -728,7 +728,8 @@ class TestFrozenSet(TestJointOps, unittest.TestCase):
             for i in range(len(s)+1):
                 yield from map(frozenset, itertools.combinations(s, i))
 
-        # TODO the original test has:
+        # TODO: RUSTPYTHON
+        # The original test has:
         # for n in range(18):
         # Due to general performance overhead, hashing a frozenset takes
         # about 50 times longer than in CPython. This test amplifies that

--- a/benches/microbenchmarks/frozenset.py
+++ b/benches/microbenchmarks/frozenset.py
@@ -1,0 +1,5 @@
+fs = frozenset(range(0, ITERATIONS))
+
+# ---
+
+hash(fs)

--- a/common/src/hash.rs
+++ b/common/src/hash.rs
@@ -130,20 +130,6 @@ pub fn hash_float(value: f64) -> Option<PyHash> {
     Some(fix_sentinel(x as PyHash * value.signum() as PyHash))
 }
 
-pub fn hash_iter_unordered<'a, T: 'a, I, F, E>(iter: I, hashf: F) -> Result<PyHash, E>
-where
-    I: IntoIterator<Item = &'a T>,
-    F: Fn(&'a T) -> Result<PyHash, E>,
-{
-    let mut hash: PyHash = 0;
-    for element in iter {
-        let item_hash = hashf(element)?;
-        // xor is commutative and hash should be independent of order
-        hash ^= item_hash;
-    }
-    Ok(fix_sentinel(mod_int(hash)))
-}
-
 pub fn hash_bigint(value: &BigInt) -> PyHash {
     let ret = match value.to_i64() {
         Some(i) => mod_int(i),

--- a/vm/src/utils.rs
+++ b/vm/src/utils.rs
@@ -11,13 +11,6 @@ pub fn hash_iter<'a, I: IntoIterator<Item = &'a PyObjectRef>>(
     vm.state.hash_secret.hash_iter(iter, |obj| obj.hash(vm))
 }
 
-pub fn hash_iter_unordered<'a, I: IntoIterator<Item = &'a PyObjectRef>>(
-    iter: I,
-    vm: &VirtualMachine,
-) -> PyResult<rustpython_common::hash::PyHash> {
-    rustpython_common::hash::hash_iter_unordered(iter, |obj| obj.hash(vm))
-}
-
 impl ToPyObject for std::convert::Infallible {
     fn to_pyobject(self, _vm: &VirtualMachine) -> PyObjectRef {
         match self {}


### PR DESCRIPTION
The original hash algorithm just XOR'd all the hashes of the elements of the set, which can be problematic. The CPython algorithm is required to pass the tests.

- Replace `PyFrozenSet::hash` with CPython's algorithm
- Remove unused `hash_iter_unorded` functions
- Add `frozenset` benchmark
- Enable tests
- Lower performance expectations on effectiveness test
- Adjust `slot::hash_wrapper` so that it doesn't rehash the computed hash value in the process of converting PyInt to PyHash