### PR TITLE
Removed unused __bool__ methods

### DIFF
--- a/Lib/test/test_collections.py
+++ b/Lib/test/test_collections.py
@@ -52,18 +52,12 @@ class TestUserObjects(unittest.TestCase):
         self.assertEqual(obj.data, obj_copy.data)
         self.assertIs(obj.test, obj_copy.test)
 
-    # TODO: RUSTPYTHON
-    @unittest.expectedFailure
     def test_str_protocol(self):
         self._superset_test(UserString, str)
 
-    # TODO: RUSTPYTHON
-    @unittest.expectedFailure
     def test_list_protocol(self):
         self._superset_test(UserList, list)
 
-    # TODO: RUSTPYTHON
-    @unittest.expectedFailure
     def test_dict_protocol(self):
         self._superset_test(UserDict, dict)
 

--- a/vm/src/builtins/dict.rs
+++ b/vm/src/builtins/dict.rs
@@ -243,11 +243,6 @@ impl PyDict {
     }
 
     #[pymethod(magic)]
-    fn bool(&self) -> bool {
-        !self.entries.is_empty()
-    }
-
-    #[pymethod(magic)]
     pub fn len(&self) -> usize {
         self.entries.len()
     }

--- a/vm/src/builtins/list.rs
+++ b/vm/src/builtins/list.rs
@@ -164,11 +164,6 @@ impl PyList {
         Ok(zelf)
     }
 
-    #[pymethod(magic)]
-    fn bool(&self) -> bool {
-        !self.borrow_vec().is_empty()
-    }
-
     #[pymethod]
     fn clear(&self) {
         let _removed = std::mem::take(self.borrow_vec_mut().deref_mut());

--- a/vm/src/builtins/str.rs
+++ b/vm/src/builtins/str.rs
@@ -411,11 +411,6 @@ impl PyStr {
         }
     }
 
-    #[pymethod(magic)]
-    fn bool(&self) -> bool {
-        !self.bytes.is_empty()
-    }
-
     fn _contains(&self, needle: &PyObject, vm: &VirtualMachine) -> PyResult<bool> {
         if let Some(needle) = needle.payload::<Self>() {
             Ok(self.as_str().contains(needle.as_str()))

--- a/vm/src/dictdatatype.rs
+++ b/vm/src/dictdatatype.rs
@@ -486,10 +486,6 @@ impl<T: Clone> Dict<T> {
         self.read().used
     }
 
-    pub fn is_empty(&self) -> bool {
-        self.len() == 0
-    }
-
     pub fn size(&self) -> DictSize {
         self.read().size()
     }


### PR DESCRIPTION
Python does not define `list().__bool__`, `dict().__bool__`, and `str().__bool__`, and some tests were failing because they were defined.
I could not find any references to them and deleting them doesn't seem to break anything.