### PR TITLE
Update code.py and test_code.py from CPython v3.12 

### DIFF
--- a/Lib/code.py
+++ b/Lib/code.py
@@ -106,6 +106,7 @@ class InteractiveInterpreter:
 
         """
         type, value, tb = sys.exc_info()
+        sys.last_exc = value
         sys.last_type = type
         sys.last_value = value
         sys.last_traceback = tb
@@ -119,7 +120,7 @@ class InteractiveInterpreter:
             else:
                 # Stuff in the right filename
                 value = SyntaxError(msg, (filename, lineno, offset, line))
-                sys.last_value = value
+                sys.last_exc = sys.last_value = value
         if sys.excepthook is sys.__excepthook__:
             lines = traceback.format_exception_only(type, value)
             self.write(''.join(lines))
@@ -138,6 +139,7 @@ class InteractiveInterpreter:
         """
         sys.last_type, sys.last_value, last_tb = ei = sys.exc_info()
         sys.last_traceback = last_tb
+        sys.last_exc = ei[1]
         try:
             lines = traceback.format_exception(ei[0], ei[1], last_tb.tb_next)
             if sys.excepthook is sys.__excepthook__:

--- a/Lib/test/test_code.py
+++ b/Lib/test/test_code.py
@@ -357,6 +357,8 @@ class CodeTest(unittest.TestCase):
         new_code = code = func.__code__.replace(co_linetable=b'')
         self.assertEqual(list(new_code.co_lines()), [])
 
+    # TODO: RUSTPYTHON
+    @unittest.expectedFailure
     def test_co_lnotab_is_deprecated(self):  # TODO: remove in 3.14
         def func():
             pass
@@ -364,6 +366,8 @@ class CodeTest(unittest.TestCase):
         with self.assertWarns(DeprecationWarning):
             func.__code__.co_lnotab
 
+    # TODO: RUSTPYTHON
+    @unittest.expectedFailure
     def test_invalid_bytecode(self):
         def foo():
             pass
@@ -520,6 +524,8 @@ class CodeTest(unittest.TestCase):
         self.assertNotEqual(c, swapped)
         self.assertNotEqual(hash(c), hash(swapped))
 
+    # TODO: RUSTPYTHON
+    @unittest.expectedFailure
     def test_code_hash_uses_bytecode(self):
         c = (lambda x, y: x + y).__code__
         d = (lambda x, y: x * y).__code__

--- a/Lib/test/test_code.py
+++ b/Lib/test/test_code.py
@@ -150,7 +150,7 @@ from test.support import (cpython_only,
                           gc_collect)
 from test.support.script_helper import assert_python_ok
 from test.support import threading_helper
-from opcode import opmap
+from opcode import opmap, opname
 COPY_FREE_VARS = opmap['COPY_FREE_VARS']
 
 
@@ -357,6 +357,28 @@ class CodeTest(unittest.TestCase):
         new_code = code = func.__code__.replace(co_linetable=b'')
         self.assertEqual(list(new_code.co_lines()), [])
 
+    def test_co_lnotab_is_deprecated(self):  # TODO: remove in 3.14
+        def func():
+            pass
+
+        with self.assertWarns(DeprecationWarning):
+            func.__code__.co_lnotab
+
+    def test_invalid_bytecode(self):
+        def foo():
+            pass
+
+        # assert that opcode 229 is invalid
+        self.assertEqual(opname[229], '<229>')
+
+        # change first opcode to 0xeb (=229)
+        foo.__code__ = foo.__code__.replace(
+            co_code=b'\xe5' + foo.__code__.co_code[1:])
+
+        msg = "unknown opcode 229"
+        with self.assertRaisesRegex(SystemError, msg):
+            foo()
+
     # TODO: RUSTPYTHON
     @unittest.expectedFailure
     # @requires_debug_ranges()
@@ -478,6 +500,32 @@ class CodeTest(unittest.TestCase):
         self.assertNotEqual(code_b, code_c)
         self.assertNotEqual(code_b, code_d)
         self.assertNotEqual(code_c, code_d)
+
+    def test_code_hash_uses_firstlineno(self):
+        c1 = (lambda: 1).__code__
+        c2 = (lambda: 1).__code__
+        self.assertNotEqual(c1, c2)
+        self.assertNotEqual(hash(c1), hash(c2))
+        c3 = c1.replace(co_firstlineno=17)
+        self.assertNotEqual(c1, c3)
+        self.assertNotEqual(hash(c1), hash(c3))
+
+    def test_code_hash_uses_order(self):
+        # Swapping posonlyargcount and kwonlyargcount should change the hash.
+        c = (lambda x, y, *, z=1, w=1: 1).__code__
+        self.assertEqual(c.co_argcount, 2)
+        self.assertEqual(c.co_posonlyargcount, 0)
+        self.assertEqual(c.co_kwonlyargcount, 2)
+        swapped = c.replace(co_posonlyargcount=2, co_kwonlyargcount=0)
+        self.assertNotEqual(c, swapped)
+        self.assertNotEqual(hash(c), hash(swapped))
+
+    def test_code_hash_uses_bytecode(self):
+        c = (lambda x, y: x + y).__code__
+        d = (lambda x, y: x * y).__code__
+        c1 = c.replace(co_code=d.co_code)
+        self.assertNotEqual(c, c1)
+        self.assertNotEqual(hash(c), hash(c1))
 
 
 def isinterned(s):
@@ -692,7 +740,8 @@ class CodeLocationTest(unittest.TestCase):
 
     def check_lines(self, func):
         co = func.__code__
-        lines1 = list(dedup(l for (_, _, l) in co.co_lines()))
+        lines1 = [line for _, _, line in co.co_lines()]
+        self.assertEqual(lines1, list(dedup(lines1)))
         lines2 = list(lines_from_postions(positions_from_location_table(co)))
         for l1, l2 in zip(lines1, lines2):
             self.assertEqual(l1, l2)
@@ -714,6 +763,7 @@ class CodeLocationTest(unittest.TestCase):
             pass
         PY_CODE_LOCATION_INFO_NO_COLUMNS = 13
         f.__code__ = f.__code__.replace(
+            co_stacksize=1,
             co_firstlineno=42,
             co_code=bytes(
                 [
@@ -742,15 +792,15 @@ if check_impl_detail(cpython=True) and ctypes is not None:
     py = ctypes.pythonapi
     freefunc = ctypes.CFUNCTYPE(None,ctypes.c_voidp)
 
-    RequestCodeExtraIndex = py._PyEval_RequestCodeExtraIndex
+    RequestCodeExtraIndex = py.PyUnstable_Eval_RequestCodeExtraIndex
     RequestCodeExtraIndex.argtypes = (freefunc,)
     RequestCodeExtraIndex.restype = ctypes.c_ssize_t
 
-    SetExtra = py._PyCode_SetExtra
+    SetExtra = py.PyUnstable_Code_SetExtra
     SetExtra.argtypes = (ctypes.py_object, ctypes.c_ssize_t, ctypes.c_voidp)
     SetExtra.restype = ctypes.c_int
 
-    GetExtra = py._PyCode_GetExtra
+    GetExtra = py.PyUnstable_Code_GetExtra
     GetExtra.argtypes = (ctypes.py_object, ctypes.c_ssize_t,
                          ctypes.POINTER(ctypes.c_voidp))
     GetExtra.restype = ctypes.c_int


### PR DESCRIPTION
```log
ssssssxxsxxxxx..xxxxxsxxxx..
----------------------------------------------------------------------
Ran 28 tests in 0.958s

OK (skipped=8, expected failures=16)
```
The current tests have passed, and the new version has added several test functions, among which three functions have failed. I have marked them as TODO. For details,
please check commit 572053df82a6ad1b09e00be3d4cb130eb8eba762.

#5104 