### PR TITLE
Fix convenient failing tests

### DIFF
--- a/Lib/test/test_cmd_line.py
+++ b/Lib/test/test_cmd_line.py
@@ -411,7 +411,8 @@ class CmdLineTest(unittest.TestCase):
             path = ":".join(sys.path)
             path = path.encode("ascii", "backslashreplace")
             sys.stdout.buffer.write(path)"""
-        rc1, out1, err1 = assert_python_ok('-c', code, PYTHONPATH="")
+        # TODO: RUSTPYTHON we must unset RUSTPYTHONPATH as well
+        rc1, out1, err1 = assert_python_ok('-c', code, PYTHONPATH="", RUSTPYTHONPATH="")
         rc2, out2, err2 = assert_python_ok('-c', code, __isolated=False)
         # regarding to Posix specification, outputs should be equal
         # for empty and unset PYTHONPATH

--- a/Lib/test/test_format.py
+++ b/Lib/test/test_format.py
@@ -420,6 +420,9 @@ class FormatTest(unittest.TestCase):
         self.assertEqual(format(1+2j, "\u2007^8"), "\u2007(1+2j)\u2007")
         self.assertEqual(format(0j, "\u2007^4"), "\u20070j\u2007")
 
+    # TODO: RUSTPYTHON formatting does not support locales
+    # See https://github.com/RustPython/RustPython/issues/5181
+    @unittest.skip("formatting does not support locales")
     def test_locale(self):
         try:
             oldloc = locale.setlocale(locale.LC_ALL)

--- a/Lib/test/test_format.py
+++ b/Lib/test/test_format.py
@@ -420,6 +420,9 @@ class FormatTest(unittest.TestCase):
         self.assertEqual(format(1+2j, "\u2007^8"), "\u2007(1+2j)\u2007")
         self.assertEqual(format(0j, "\u2007^4"), "\u20070j\u2007")
 
+    # TODO: RUSTPYTHON formatting does not support locales
+    # See https://github.com/RustPython/RustPython/issues/5181
+    @unittest.expectedFailure
     def test_locale(self):
         try:
             oldloc = locale.setlocale(locale.LC_ALL)

--- a/Lib/test/test_format.py
+++ b/Lib/test/test_format.py
@@ -420,9 +420,6 @@ class FormatTest(unittest.TestCase):
         self.assertEqual(format(1+2j, "\u2007^8"), "\u2007(1+2j)\u2007")
         self.assertEqual(format(0j, "\u2007^4"), "\u20070j\u2007")
 
-    # TODO: RUSTPYTHON formatting does not support locales
-    # See https://github.com/RustPython/RustPython/issues/5181
-    @unittest.expectedFailure
     def test_locale(self):
         try:
             oldloc = locale.setlocale(locale.LC_ALL)

--- a/Lib/test/test_socket.py
+++ b/Lib/test/test_socket.py
@@ -2161,12 +2161,16 @@ class ISOTPTest(unittest.TestCase):
         with socket.socket(socket.PF_CAN, socket.SOCK_DGRAM, socket.CAN_ISOTP) as s:
             pass
 
+    # TODO: RUSTPYTHON, OSError: bind(): bad family
+    @unittest.expectedFailure
     def testTooLongInterfaceName(self):
         # most systems limit IFNAMSIZ to 16, take 1024 to be sure
         with socket.socket(socket.PF_CAN, socket.SOCK_DGRAM, socket.CAN_ISOTP) as s:
             with self.assertRaisesRegex(OSError, 'interface name too long'):
                 s.bind(('x' * 1024, 1, 2))
 
+    # TODO: RUSTPYTHON, OSError: bind(): bad family
+    @unittest.expectedFailure
     def testBind(self):
         try:
             with socket.socket(socket.PF_CAN, socket.SOCK_DGRAM, socket.CAN_ISOTP) as s:


### PR DESCRIPTION
Fix some easy test failures.

There are more failing tests, but they don't fail when run individually, and so are much harder to debug. See #5190 