### PR TITLE
Remove incorrect `@expectedFailure`s from `test_cmd_line`

### DIFF
--- a/Lib/test/test_cmd_line.py
+++ b/Lib/test/test_cmd_line.py
@@ -278,13 +278,11 @@ class CmdLineTest(unittest.TestCase):
         code = 'import sys, os; s=os.fsencode(sys.argv[1]); print(ascii(s))'
 
         # TODO: RUSTPYTHON
-        @unittest.expectedFailure
         def run_default(arg):
             cmd = [sys.executable, '-c', code, arg]
             return subprocess.run(cmd, stdout=subprocess.PIPE, text=True)
 
         # TODO: RUSTPYTHON
-        @unittest.expectedFailure
         def run_c_locale(arg):
             cmd = [sys.executable, '-c', code, arg]
             env = dict(os.environ)
@@ -293,7 +291,6 @@ class CmdLineTest(unittest.TestCase):
                                   text=True, env=env)
 
         # TODO: RUSTPYTHON
-        @unittest.expectedFailure
         def run_utf8_mode(arg):
             cmd = [sys.executable, '-X', 'utf8', '-c', code, arg]
             return subprocess.run(cmd, stdout=subprocess.PIPE, text=True)


### PR DESCRIPTION
After you suggestion in https://github.com/python/cpython/issues/116504#issuecomment-1999239012 I went to take a look at `test_cmd_line` in RustPython (it was so long ago I contributed to this amazing project, so may thing had changed!), and I've noticed this.

This is a problem, here' the simplest demo:

```python
import unittest

class TestMe(unittest.TestCase):
    @unittest.expectedFailure
    def test_me(self):
        def run():
            raise ValueError

        with self.subTest(run=run):
            run()

if __name__ == '__main__':
    unittest.main()
```

This works as expected:

```
» ./python.exe ex.py
x
----------------------------------------------------------------------
Ran 1 test in 0.001s

OK (expected failures=1)
```

This does not:

```python
import unittest

class TestMe(unittest.TestCase):
    def test_me(self):
        @unittest.expectedFailure
        def run():
            raise ValueError

        with self.subTest(run=run):
            run()

if __name__ == '__main__':
    unittest.main()
```

Produces:

```
» ./python.exe ex.py
E
======================================================================
ERROR: test_me (__main__.TestMe.test_me) (run=<function TestMe.test_me.<locals>.run at 0x1057a2150>)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/Users/sobolev/Desktop/cpython2/ex.py", line 10, in test_me
    run()
    ~~~^^
  File "/Users/sobolev/Desktop/cpython2/ex.py", line 7, in run
    raise ValueError
ValueError

----------------------------------------------------------------------
Ran 1 test in 0.001s

FAILED (errors=1)
```

So, I propose to remove these decorators, let's only keep `TODO` comments to indicate separate failures.