### PR TITLE
Skip TestScandir.test_uninstantiable

### DIFF
--- a/Lib/test/test_os.py
+++ b/Lib/test/test_os.py
@@ -4249,7 +4249,8 @@ class TestScandir(unittest.TestCase):
             self.assertEqual(stat1, stat2)
 
     # TODO: RUSTPPYTHON (AssertionError: TypeError not raised by ScandirIter)
-    @unittest.expectedFailure
+    # TODO: See https://github.com/RustPython/RustPython/issues/5190 for skip rationale 
+    @unittest.skip("skipping to avoid the unclosed scandir from squatting on file descriptors")
     def test_uninstantiable(self):
         scandir_iter = os.scandir(self.path)
         self.assertRaises(TypeError, type(scandir_iter))


### PR DESCRIPTION
This test was marked as an expected failure. Because the garbage collector is missing, that meant that the `os.scandir` object went unclosed. This object was squatting on the file descriptors of all the files contained in the test directory, which was breaking test_zipfile.