### PR TITLE
Increase threshold for zipfile test_many_opens 

### DIFF
--- a/Lib/test/test_os.py
+++ b/Lib/test/test_os.py
@@ -4248,9 +4248,8 @@ class TestScandir(unittest.TestCase):
         else:
             self.assertEqual(stat1, stat2)
 
-    # TODO: RUSTPPYTHON (AssertionError: TypeError not raised by ScandirIter)
-    # TODO: See https://github.com/RustPython/RustPython/issues/5190 for skip rationale 
-    @unittest.skip("TODO: RUSTPYTHON, avoid the unclosed scandir from squatting on file descriptors")
+    # TODO: RUSTPYTHON (AssertionError: TypeError not raised by ScandirIter)
+    @unittest.expectedFailure
     def test_uninstantiable(self):
         scandir_iter = os.scandir(self.path)
         self.assertRaises(TypeError, type(scandir_iter))

--- a/Lib/test/test_os.py
+++ b/Lib/test/test_os.py
@@ -4250,7 +4250,7 @@ class TestScandir(unittest.TestCase):
 
     # TODO: RUSTPPYTHON (AssertionError: TypeError not raised by ScandirIter)
     # TODO: See https://github.com/RustPython/RustPython/issues/5190 for skip rationale 
-    @unittest.skip("skipping to avoid the unclosed scandir from squatting on file descriptors")
+    @unittest.skip("TODO: RUSTPYTHON, avoid the unclosed scandir from squatting on file descriptors")
     def test_uninstantiable(self):
         scandir_iter = os.scandir(self.path)
         self.assertRaises(TypeError, type(scandir_iter))

--- a/Lib/test/test_zipfile.py
+++ b/Lib/test/test_zipfile.py
@@ -2561,17 +2561,22 @@ class TestsWithMultipleOpens(unittest.TestCase):
             self.assertEqual(data1, self.data1)
             self.assertEqual(data2, self.data2)
 
+    # TODO: RUSTPYTHON other tests can impact the file descriptor incrementor
+    # by leaving file handles unclosed. If there are more than 100 files in
+    # TESTFN and references to them are left unclosed and ungarbage collected
+    # in another test, then fileno() will always be too high for this test to
+    # pass. The solution is to increase the number of files from 100 to 200
     def test_many_opens(self):
         # Verify that read() and open() promptly close the file descriptor,
         # and don't rely on the garbage collector to free resources.
         self.make_test_archive(TESTFN2)
         with zipfile.ZipFile(TESTFN2, mode="r") as zipf:
-            for x in range(100):
+            for x in range(200):
                 zipf.read('ones')
                 with zipf.open('ones') as zopen1:
                     pass
         with open(os.devnull, "rb") as f:
-            self.assertLess(f.fileno(), 100)
+            self.assertLess(f.fileno(), 200)
 
     def test_write_while_reading(self):
         with zipfile.ZipFile(TESTFN2, 'w', zipfile.ZIP_DEFLATED) as zipf:


### PR DESCRIPTION
See https://github.com/RustPython/RustPython/pull/5204#discussion_r1534119326
Thanks @fanninpm , did not know that

I wound up finding at least three other tests that were also leaving unclosed file descriptors lying around and causing this test to fail. Rather than continue hunting them all down, I think it's easier to just increase the threshold so that they don't impact this test.

I suspect this is not an issue for CPython because it has a working garbage collector, and it has very few tests that are expected to fail.