### PR TITLE
Add itertools.batched Support

### DIFF
--- a/vm/src/stdlib/itertools.rs
+++ b/vm/src/stdlib/itertools.rs
@@ -1986,10 +1986,7 @@ mod decl {
                 return Err(vm.new_value_error("n must be at least one".to_owned()));
             }
             let n = n.to_usize().unwrap();
-            let iterable = match iterable_ref.get_iter(vm) {
-                Ok(it) => it,
-                Err(e) => return Err(e),
-            };
+            let iterable = iterable_ref.get_iter(vm)?;
 
             Self {
                 iterable,

--- a/vm/src/stdlib/itertools.rs
+++ b/vm/src/stdlib/itertools.rs
@@ -1985,9 +1985,9 @@ mod decl {
             if n.lt(&BigInt::one()) {
                 return Err(vm.new_value_error("n must be at least one".to_owned()));
             }
-            let n = n
-                .to_usize()
-                .ok_or(vm.new_value_error("Python int too large to convert to usize".to_owned()))?;
+            let n = n.to_usize().ok_or(
+                vm.new_overflow_error("Python int too large to convert to usize".to_owned()),
+            )?;
             let iterable = iterable_ref.get_iter(vm)?;
 
             Self {

--- a/vm/src/stdlib/itertools.rs
+++ b/vm/src/stdlib/itertools.rs
@@ -1985,7 +1985,9 @@ mod decl {
             if n.lt(&BigInt::one()) {
                 return Err(vm.new_value_error("n must be at least one".to_owned()));
             }
-            let n = n.to_usize().unwrap();
+            let n = n
+                .to_usize()
+                .ok_or(vm.new_value_error("Python int too large to convert to usize".to_owned()))?;
             let iterable = iterable_ref.get_iter(vm)?;
 
             Self {

--- a/vm/src/stdlib/sre.rs
+++ b/vm/src/stdlib/sre.rs
@@ -471,7 +471,6 @@ mod _sre {
                         }
                     };
 
-
                     last_pos = iter.state.cursor.position;
                     n += 1;
                 }


### PR DESCRIPTION
Adds the itertools.batched function new in python 3.12

https://docs.python.org/3/library/itertools.html#itertools.batched