### PR TITLE
rustpython_vm::import::import_source

### DIFF
--- a/vm/src/import.rs
+++ b/vm/src/import.rs
@@ -106,17 +106,30 @@ pub fn import_file(
     vm: &VirtualMachine,
     module_name: &str,
     file_path: String,
-    content: String,
+    content: &str,
 ) -> PyResult {
     let code = vm
         .compile_with_opts(
-            &content,
+            content,
             crate::compiler::Mode::Exec,
             file_path,
             vm.compile_opts(),
         )
-        .map_err(|err| vm.new_syntax_error(&err, Some(&content)))?;
+        .map_err(|err| vm.new_syntax_error(&err, Some(content)))?;
     import_codeobj(vm, module_name, code, true)
+}
+
+#[cfg(feature = "rustpython-compiler")]
+pub fn import_source(vm: &VirtualMachine, module_name: &str, content: &str) -> PyResult {
+    let code = vm
+        .compile_with_opts(
+            content,
+            crate::compiler::Mode::Exec,
+            "<source>".to_owned(),
+            vm.compile_opts(),
+        )
+        .map_err(|err| vm.new_syntax_error(&err, Some(content)))?;
+    import_codeobj(vm, module_name, code, false)
 }
 
 pub fn import_codeobj(

--- a/vm/src/vm/mod.rs
+++ b/vm/src/vm/mod.rs
@@ -831,7 +831,7 @@ impl VirtualMachine {
                     );
                     let result = unsafe { sigaction(SIGINT, &action) };
                     if result.is_ok() {
-                        interpreter::flush_std(self);
+                        self.flush_std();
                         kill(getpid(), SIGINT).expect("Expect to be killed.");
                     }
 

--- a/vm/src/vm/mod.rs
+++ b/vm/src/vm/mod.rs
@@ -517,6 +517,7 @@ impl VirtualMachine {
     /// Roughly equivalent to `import module_name` or `import top.submodule`.
     ///
     /// See also [`import_from`] for more advanced import.
+    /// See also [`rustpython_vm::import::import_source`] and other primitive import functions.
     #[inline]
     pub fn import<'a>(&self, module_name: impl AsPyStr<'a>, level: usize) -> PyResult {
         let module_name = module_name.as_pystr(&self.ctx);

--- a/wasm/lib/src/browser_module.rs
+++ b/wasm/lib/src/browser_module.rs
@@ -11,7 +11,7 @@ mod _browser {
         class::PyClassImpl,
         convert::ToPyObject,
         function::{ArgCallable, OptionalArg},
-        import::import_file,
+        import::import_source,
         PyObjectRef, PyPayload, PyRef, PyResult, VirtualMachine,
     };
     use wasm_bindgen::{prelude::*, JsCast};

--- a/wasm/lib/src/browser_module.rs
+++ b/wasm/lib/src/browser_module.rs
@@ -245,7 +245,7 @@ mod _browser {
                 .expect("that the vm is valid when the promise resolves");
             stored_vm.interp.enter(move |vm| {
                 let resp_text = text.as_string().unwrap();
-                let res = import_file(vm, module.as_str(), "WEB".to_owned(), resp_text);
+                let res = import_source(vm, module.as_str(), &resp_text);
                 match res {
                     Ok(_) => Ok(JsValue::null()),
                     Err(err) => Err(convert::py_err_to_js_err(vm, &err)),


### PR DESCRIPTION
fix #5041 #5177

We already had almost same function `rustpython_vm::import::import_file`. This new function only skip to set `__file__` attribute of the new module.

