### PR TITLE
Allow update `__class__` for mutable types or module subclasses

### DIFF
--- a/Lib/test/test_opcache.py
+++ b/Lib/test/test_opcache.py
@@ -152,8 +152,6 @@ class TestLoadAttrCache(unittest.TestCase):
         for _ in range(1025):
             self.assertTrue(f())
 
-    # TODO: RUSTPYTHON
-    @unittest.expectedFailure
     def test_metaclass_swap(self):
         class OldMetaclass(type):
             @property
@@ -411,8 +409,6 @@ class TestLoadMethodCache(unittest.TestCase):
         for _ in range(1025):
             self.assertTrue(f())
 
-    # TODO: RUSTPYTHON
-    @unittest.expectedFailure
     def test_metaclass_swap(self):
         class OldMetaclass(type):
             @property

--- a/derive-impl/src/pyclass.rs
+++ b/derive-impl/src/pyclass.rs
@@ -1497,6 +1497,9 @@ fn extract_impl_attrs(attr: AttributeArgs, item: &Ident) -> Result<ExtractedImpl
                              .union(::rustpython_vm::types::PyTypeFlags::#ident)
                         });
                     }
+                    flags.push(quote! {
+                        .union(::rustpython_vm::types::PyTypeFlags::IMMUTABLETYPE)
+                    });
                 } else {
                     bail_span!(path, "Unknown pyimpl attribute")
                 }


### PR DESCRIPTION
## Description

This pull request is related with https://github.com/RustPython/RustPython/issues/5105. The error was raised when executing the below lines:

```python

if not six.PY2:

    class RequestModule(sys.modules[__name__].__class__):
        def __call__(self, *args, **kwargs):
            """
            If user tries to call this module directly urllib3 v2.x style raise an error to the user
            suggesting they may need urllib3 v2
            """
            raise TypeError(
                "'module' object is not callable\n"
                "urllib3.request() method is not supported in this release, "
                "upgrade to urllib3 v2 to use it\n"
                "see https://urllib3.readthedocs.io/en/stable/v2-migration-guide.html"
            )

    sys.modules[__name__].__class__ = RequestModule  # HERE.
```

I thought it is because RustPython doesn't allow update even if the `value` is module's subclass. This pull request just updates it.

## CPython implementation

- https://github.com/python/cpython/blob/c50cb6dd09d5a1bfdd1b896cc31ccdc96c72e561/Objects/typeobject.c#L6172-L6180
- https://github.com/python/cpython/blob/c50cb6dd09d5a1bfdd1b896cc31ccdc96c72e561/Objects/typeobject.c#L7953-L7958