### PR TITLE
Fix `None.__ne__` bug

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -105,7 +105,7 @@ env:
     test_weakref
     test_yield_from
   # Python version targeted by the CI.
-  PYTHON_VERSION: "3.12.0"
+  PYTHON_VERSION: "3.12.3"
 
 jobs:
   rust_tests:
@@ -140,7 +140,7 @@ jobs:
 
       - name: run rust tests
         run: cargo test --workspace --exclude rustpython_wasm --verbose --features threading ${{ env.CARGO_ARGS }}
-        if: runner.os != 'macOS'  
+        if: runner.os != 'macOS'
       # temp skip ssl linking for Mac to avoid CI failure
       - name: run rust tests (MacOS no ssl)
         run: cargo test --workspace --exclude rustpython_wasm --verbose --no-default-features --features threading,stdlib,zlib,importlib,encodings,jit

--- a/Lib/test/test_builtin.py
+++ b/Lib/test/test_builtin.py
@@ -610,6 +610,11 @@ class BuiltinTest(unittest.TestCase):
         # test that object has a __dir__()
         self.assertEqual(sorted([].__dir__()), dir([]))
 
+    def test___ne__(self):
+        self.assertFalse(None.__ne__(None))
+        self.assertIs(None.__ne__(0), NotImplemented)
+        self.assertIs(None.__ne__("abc"), NotImplemented)
+
     def test_divmod(self):
         self.assertEqual(divmod(12, 7), (1, 5))
         self.assertEqual(divmod(-12, 7), (-2, 2))

--- a/extra_tests/snippets/builtin_none.py
+++ b/extra_tests/snippets/builtin_none.py
@@ -22,4 +22,4 @@ assert type(None)() is None
 assert None.__eq__(3) is NotImplemented
 assert None.__ne__(3) is NotImplemented
 assert None.__eq__(None) is True
-assert None.__ne__(None) is NotImplemented
+assert None.__ne__(None) is False

--- a/vm/src/builtins/singletons.rs
+++ b/vm/src/builtins/singletons.rs
@@ -2,10 +2,9 @@ use super::{PyStrRef, PyType, PyTypeRef};
 use crate::{
     class::PyClassImpl,
     convert::ToPyObject,
-    function::{PyArithmeticValue, PyComparisonValue},
     protocol::PyNumberMethods,
-    types::{AsNumber, Comparable, Constructor, PyComparisonOp, Representable},
-    Context, Py, PyObject, PyObjectRef, PyPayload, PyResult, VirtualMachine,
+    types::{AsNumber, Constructor, Representable},
+    Context, Py, PyObjectRef, PyPayload, PyResult, VirtualMachine,
 };
 
 #[pyclass(module = false, name = "NoneType")]
@@ -43,7 +42,7 @@ impl Constructor for PyNone {
     }
 }
 
-#[pyclass(with(Constructor, Comparable, AsNumber, Representable))]
+#[pyclass(with(Constructor, AsNumber, Representable))]
 impl PyNone {
     #[pymethod(magic)]
     fn bool(&self) -> bool {
@@ -70,28 +69,6 @@ impl AsNumber for PyNone {
             ..PyNumberMethods::NOT_IMPLEMENTED
         };
         &AS_NUMBER
-    }
-}
-
-impl Comparable for PyNone {
-    fn cmp(
-        _zelf: &Py<Self>,
-        other: &PyObject,
-        op: PyComparisonOp,
-        vm: &VirtualMachine,
-    ) -> PyResult<PyComparisonValue> {
-        let value = match op {
-            PyComparisonOp::Eq => {
-                if vm.is_none(other) {
-                    PyArithmeticValue::Implemented(true)
-                } else {
-                    PyArithmeticValue::NotImplemented
-                }
-            }
-            _ => PyComparisonValue::NotImplemented,
-        };
-
-        Ok(value)
     }
 }
 


### PR DESCRIPTION
## Description

This pull request is related with https://github.com/python/cpython/issues/112125, https://github.com/RustPython/RustPython/issues/5103, https://github.com/RustPython/RustPython/pull/5124.

In Python 3.12, `None.__ne__` behavior was changed but it was a bug. According to the GitHub issue, the bug was fixed in *3.12.1* version and deployed. When I run `None.__ne__(None)` in `3.12.2` CPython, it returns `False`.