### PR TITLE
Check `value` is `PyType` first

### DIFF
--- a/Lib/test/test_descr.py
+++ b/Lib/test/test_descr.py
@@ -1052,8 +1052,6 @@ order (MRO) for bases """
         self.assertEqual(x.foo, 1)
         self.assertEqual(x.__dict__, {'foo': 1})
 
-    # TODO: RUSTPYTHON
-    @unittest.expectedFailure
     def test_object_class_assignment_between_heaptypes_and_nonheaptypes(self):
         class SubType(types.ModuleType):
             a = 1

--- a/Lib/test/test_importlib/test_lazy.py
+++ b/Lib/test/test_importlib/test_lazy.py
@@ -75,8 +75,6 @@ class LazyLoaderTests(unittest.TestCase):
         self.assertIsNone(loader.loaded)
         return module
 
-    # TODO: RUSTPYTHON
-    @unittest.expectedFailure
     def test_e2e(self):
         # End-to-end test to verify the load is in fact lazy.
         importer = TestingImporter()
@@ -90,24 +88,18 @@ class LazyLoaderTests(unittest.TestCase):
         self.assertIsNotNone(importer.loaded)
         self.assertEqual(module, importer.loaded)
 
-    # TODO: RUSTPYTHON
-    @unittest.expectedFailure
     def test_attr_unchanged(self):
         # An attribute only mutated as a side-effect of import should not be
         # changed needlessly.
         module = self.new_module()
         self.assertEqual(TestingImporter.mutated_name, module.__name__)
 
-    # TODO: RUSTPYTHON
-    @unittest.expectedFailure
     def test_new_attr(self):
         # A new attribute should persist.
         module = self.new_module()
         module.new_attr = 42
         self.assertEqual(42, module.new_attr)
 
-    # TODO: RUSTPYTHON
-    @unittest.expectedFailure
     def test_mutated_preexisting_attr(self):
         # Changing an attribute that already existed on the module --
         # e.g. __name__ -- should persist.
@@ -115,8 +107,6 @@ class LazyLoaderTests(unittest.TestCase):
         module.__name__ = 'bogus'
         self.assertEqual('bogus', module.__name__)
 
-    # TODO: RUSTPYTHON
-    @unittest.expectedFailure
     def test_mutated_attr(self):
         # Changing an attribute that comes into existence after an import
         # should persist.
@@ -124,23 +114,17 @@ class LazyLoaderTests(unittest.TestCase):
         module.attr = 6
         self.assertEqual(6, module.attr)
 
-    # TODO: RUSTPYTHON
-    @unittest.expectedFailure
     def test_delete_eventual_attr(self):
         # Deleting an attribute should stay deleted.
         module = self.new_module()
         del module.attr
         self.assertFalse(hasattr(module, 'attr'))
 
-    # TODO: RUSTPYTHON
-    @unittest.expectedFailure
     def test_delete_preexisting_attr(self):
         module = self.new_module()
         del module.__name__
         self.assertFalse(hasattr(module, '__name__'))
 
-    # TODO: RUSTPYTHON
-    @unittest.expectedFailure
     def test_module_substitution_error(self):
         with test_util.uncache(TestingImporter.module_name):
             fresh_module = types.ModuleType(TestingImporter.module_name)
@@ -149,8 +133,6 @@ class LazyLoaderTests(unittest.TestCase):
             with self.assertRaisesRegex(ValueError, "substituted"):
                 module.__name__
 
-    # TODO: RUSTPYTHON
-    @unittest.expectedFailure
     def test_module_already_in_sys(self):
         with test_util.uncache(TestingImporter.module_name):
             module = self.new_module()


### PR DESCRIPTION
This pull request continues from #5225 PR. In that PR, I missed to downcast `value` to `PyType` type when evaluating `both_module` value. So `cargo run -- --install-pip get-pip` was still failed in the same reason.

This pull request downcasts `value` to `PyRef<PyType>` when `value` is module type. Also it checks `value` is `PyType` first, once.

This pull request doesn't resolve an issue, *get-pip doesn't work*, completely. After this pull request, it should bump `Lib/shutil` to Python 3.12 version's.