### PR TITLE
compat fix for test_field_metadata_custom_mapping in test_dataclasses.py

### DIFF
--- a/Lib/test/test_dataclasses.py
+++ b/Lib/test/test_dataclasses.py
@@ -1843,8 +1843,6 @@ class TestCase(unittest.TestCase):
                                     'does not support item assignment'):
             fields(C)[0].metadata['test'] = 3
 
-    # TODO: RUSTPYTHON
-    @unittest.expectedFailure
     def test_field_metadata_custom_mapping(self):
         # Try a custom mapping.
         class SimpleNameSpace:

--- a/vm/src/builtins/mappingproxy.rs
+++ b/vm/src/builtins/mappingproxy.rs
@@ -93,13 +93,12 @@ impl Constructor for PyMappingProxy {
 ))]
 impl PyMappingProxy {
     fn get_inner(&self, key: PyObjectRef, vm: &VirtualMachine) -> PyResult<Option<PyObjectRef>> {
-        let opt = match &self.mapping {
-            MappingProxyInner::Class(class) => key
+        match &self.mapping {
+            MappingProxyInner::Class(class) => Ok(key
                 .as_interned_str(vm)
-                .and_then(|key| class.attributes.read().get(key).cloned()),
-            MappingProxyInner::Mapping(mapping) => mapping.mapping().subscript(&*key, vm).ok(),
-        };
-        Ok(opt)
+                .and_then(|key| class.attributes.read().get(key).cloned())),
+            MappingProxyInner::Mapping(mapping) => mapping.mapping().subscript(&*key, vm).map(Some),
+        }
     }
 
     #[pymethod]


### PR DESCRIPTION
Makes the test `test_field_metadata_custom_mapping` in `test_dataclasses.py` work. 
Closes #5232

The documentation states that MappingProxyType throws a KeyError if the key is not found, but in reality, the Cpython source just forwards the `__getitem__` call, so the error thrown by the underlying object is what is really thrown. So I address this by allowing the error from `mapping().subscript` to propagate instead of replacing it with a KeyError as before.

CPython source:
https://github.com/python/cpython/blob/5f4c7cf3f49629bcf890c305e0a90ffd708110a2/Objects/descrobject.c#L1042-L1046