### PR TITLE
compat fix for testHashStuff in test_class.py

### DIFF
--- a/Lib/test/test_class.py
+++ b/Lib/test/test_class.py
@@ -489,8 +489,6 @@ class ClassTests(unittest.TestCase):
         for f in [float, complex, str, repr, bytes, bin, oct, hex, bool, index]:
             self.assertRaises(TypeError, f, BadTypeClass())
 
-    # TODO: RUSTPYTHON
-    @unittest.expectedFailure
     def testHashStuff(self):
         # Test correct errors from hash() on objects with comparisons but
         #  no __hash__

--- a/Lib/test/test_hash.py
+++ b/Lib/test/test_hash.py
@@ -132,8 +132,6 @@ class HashInheritanceTestCase(unittest.TestCase):
         for obj in self.fixed_expected:
             self.assertEqual(hash(obj), _FIXED_HASH_VALUE)
 
-    # TODO: RUSTPYTHON
-    @unittest.expectedFailure
     def test_error_hash(self):
         for obj in self.error_expected:
             self.assertRaises(TypeError, hash, obj)
@@ -144,8 +142,6 @@ class HashInheritanceTestCase(unittest.TestCase):
         for obj in objects:
             self.assertIsInstance(obj, Hashable)
 
-    # TODO: RUSTPYTHON
-    @unittest.expectedFailure
     def test_not_hashable(self):
         for obj in self.error_expected:
             self.assertNotIsInstance(obj, Hashable)

--- a/Lib/test/test_weakset.py
+++ b/Lib/test/test_weakset.py
@@ -203,8 +203,6 @@ class TestWeakSet(unittest.TestCase):
         t = WeakSet(s)
         self.assertNotEqual(id(s), id(t))
 
-    # TODO: RUSTPYTHON
-    @unittest.expectedFailure
     def test_hash(self):
         self.assertRaises(TypeError, hash, self.s)
 

--- a/vm/src/builtins/type.rs
+++ b/vm/src/builtins/type.rs
@@ -733,6 +733,14 @@ impl PyType {
             .entry(identifier!(vm, __qualname__))
             .or_insert_with(|| vm.ctx.new_str(name.as_str()).into());
 
+        if attributes.get(identifier!(vm, __eq__)).is_some()
+            && attributes.get(identifier!(vm, __hash__)).is_none()
+        {
+            // if __eq__ exists but __hash__ doesn't, overwrite it with None so it doesn't inherit the default hash
+            // https://docs.python.org/3/reference/datamodel.html#object.__hash__
+            attributes.insert(identifier!(vm, __hash__), vm.ctx.none.clone().into());
+        }
+
         // All *classes* should have a dict. Exceptions are *instances* of
         // classes that define __slots__ and instances of built-in classes
         // (with exceptions, e.g function)


### PR DESCRIPTION
enables the test: testHashStuff in test_class.py

If a class defines its own `__eq__` but not `__hash__`, then CPython sets `__hash__` to None for that class (otherwise it inherits hash from `object`). So this PR re-creates that behavior.

[https://docs.python.org/3/reference/datamodel.html#object.\_\_hash\_\_](https://docs.python.org/3/reference/datamodel.html#object.__hash__)

