### PR TITLE
unit test fix - only allow catching exceptions - test_catch_non_BaseException

### DIFF
--- a/Lib/test/test_baseexception.py
+++ b/Lib/test/test_baseexception.py
@@ -196,8 +196,6 @@ class UsageTests(unittest.TestCase):
         # Raising a string raises TypeError.
         self.raise_fails("spam")
 
-    # TODO: RUSTPYTHON
-    @unittest.expectedFailure
     def test_catch_non_BaseException(self):
         # Trying to catch an object that does not inherit from BaseException
         # is not allowed.

--- a/Lib/test/test_exceptions.py
+++ b/Lib/test/test_exceptions.py
@@ -2613,8 +2613,6 @@ class SyntaxErrorTests(unittest.TestCase):
 
 
 class TestInvalidExceptionMatcher(unittest.TestCase):
-    # TODO: RUSTPYTHON
-    @unittest.expectedFailure
     def test_except_star_invalid_exception_type(self):
         with self.assertRaises(TypeError):
             try:

--- a/vm/src/frame.rs
+++ b/vm/src/frame.rs
@@ -1848,13 +1848,11 @@ impl ExecutingFrame<'_> {
                             ));
                         }
                     }
-                } else {
-                    if !b.is_subclass(vm.ctx.exceptions.base_exception_type.into(), vm)? {
-                        return Err(vm.new_type_error(
-                            "catching classes that do not inherit from BaseException is not allowed"
-                                .to_owned(),
-                        ));
-                    }
+                } else if !b.is_subclass(vm.ctx.exceptions.base_exception_type.into(), vm)? {
+                    return Err(vm.new_type_error(
+                        "catching classes that do not inherit from BaseException is not allowed"
+                            .to_owned(),
+                    ));
                 }
 
                 a.is_instance(&b, vm)?


### PR DESCRIPTION
Added logic to ensure only BaseExceptions or its subclasses can be used in an except block. Checks and handles tuples of Exceptions too. 

Fix for `test_catch_non_BaseException` in `pylib/Lib/test/test_baseexception.py`