### PR TITLE
fix for test test_bool.BoolTest.test_subclass

### DIFF
--- a/Lib/test/test_bool.py
+++ b/Lib/test/test_bool.py
@@ -7,8 +7,6 @@ import os
 
 class BoolTest(unittest.TestCase):
 
-    # TODO: RUSTPYTHON
-    @unittest.expectedFailure
     def test_subclass(self):
         try:
             class C(bool):

--- a/vm/src/builtins/int.rs
+++ b/vm/src/builtins/int.rs
@@ -212,6 +212,12 @@ impl Constructor for PyInt {
     type Args = IntOptions;
 
     fn py_new(cls: PyTypeRef, options: Self::Args, vm: &VirtualMachine) -> PyResult {
+        if cls.is(vm.ctx.types.bool_type) {
+            return Err(
+                vm.new_type_error("int.__new__(bool) is not safe, use bool.__new__()".to_owned())
+            );
+        }
+
         let value = if let OptionalArg::Present(val) = options.val_options {
             if let OptionalArg::Present(base) = options.base {
                 let base = base


### PR DESCRIPTION
added a check that `int.__new__` cannot be used to construct `bool`