### PR TITLE
test_builtin.py test_compile unit test fix

### DIFF
--- a/Lib/test/test_builtin.py
+++ b/Lib/test/test_builtin.py
@@ -338,11 +338,10 @@ class BuiltinTest(unittest.TestCase):
         self.assertRaises(TypeError, compile)
         self.assertRaises(ValueError, compile, 'print(42)\n', '<string>', 'badmode')
         self.assertRaises(ValueError, compile, 'print(42)\n', '<string>', 'single', 0xff)
-        self.assertRaises(ValueError, compile, chr(0), 'f', 'exec')
         self.assertRaises(TypeError, compile, 'pass', '?', 'exec',
                           mode='eval', source='0', filename='tmp')
         compile('print("\xe5")\n', '', 'exec')
-        self.assertRaises(ValueError, compile, chr(0), 'f', 'exec')
+        self.assertRaises(SyntaxError, compile, chr(0), 'f', 'exec')
         self.assertRaises(ValueError, compile, str('a = 1'), 'f', 'bad')
 
         # test the optimize argument

--- a/Lib/test/test_builtin.py
+++ b/Lib/test/test_builtin.py
@@ -327,8 +327,6 @@ class BuiltinTest(unittest.TestCase):
     def test_cmp(self):
         self.assertTrue(not hasattr(builtins, "cmp"))
 
-    # TODO: RUSTPYTHON
-    @unittest.expectedFailure
     def test_compile(self):
         compile('print(1)\n', '', 'exec')
         bom = b'\xef\xbb\xbf'

--- a/Lib/test/test_builtin.py
+++ b/Lib/test/test_builtin.py
@@ -373,7 +373,7 @@ class BuiltinTest(unittest.TestCase):
                 ns = {}
                 exec(code, ns)
                 rv = ns['f']()
-                self.assertEqual(rv, tuple(expected))
+                self.assertEqual(rv, tuple(expected), msg=f'optval={optval}')
 
     # TODO: RUSTPYTHON
     @unittest.expectedFailure

--- a/Lib/test/test_builtin.py
+++ b/Lib/test/test_builtin.py
@@ -327,6 +327,8 @@ class BuiltinTest(unittest.TestCase):
     def test_cmp(self):
         self.assertTrue(not hasattr(builtins, "cmp"))
 
+    # TODO: RUSTPYTHON optval=2 does not remove docstrings
+    @unittest.expectedFailure
     def test_compile(self):
         compile('print(1)\n', '', 'exec')
         bom = b'\xef\xbb\xbf'
@@ -373,7 +375,7 @@ class BuiltinTest(unittest.TestCase):
                 ns = {}
                 exec(code, ns)
                 rv = ns['f']()
-                self.assertEqual(rv, tuple(expected), msg=f'optval={optval}')
+                self.assertEqual(rv, tuple(expected))
 
     # TODO: RUSTPYTHON
     @unittest.expectedFailure

--- a/vm/src/stdlib/ast.rs
+++ b/vm/src/stdlib/ast.rs
@@ -358,8 +358,16 @@ pub(crate) fn compile(
 pub(crate) use _ast::NodeAst;
 // Used by builtins::compile()
 pub const PY_COMPILE_FLAG_AST_ONLY: i32 = 0x0400;
+
+// The following flags match the values from Include/cpython/compile.h
+// Caveat emptor: These flags are undocumented on purpose and depending
+// on their effect outside the standard library is **unsupported**.
+const PY_CF_DONT_IMPLY_DEDENT: i32 = 0x200;
+const PY_CF_ALLOW_INCOMPLETE_INPUT: i32 = 0x4000;
+
 // Used by builtins::compile() - the summary of all flags
-pub const PY_COMPILE_FLAGS_MASK: i32 = PY_COMPILE_FLAG_AST_ONLY;
+pub const PY_COMPILE_FLAGS_MASK: i32 =
+    PY_COMPILE_FLAG_AST_ONLY | PY_CF_DONT_IMPLY_DEDENT | PY_CF_ALLOW_INCOMPLETE_INPUT;
 
 pub fn make_module(vm: &VirtualMachine) -> PyRef<PyModule> {
     let module = _ast::make_module(vm);

--- a/vm/src/stdlib/ast.rs
+++ b/vm/src/stdlib/ast.rs
@@ -365,9 +365,36 @@ pub const PY_COMPILE_FLAG_AST_ONLY: i32 = 0x0400;
 const PY_CF_DONT_IMPLY_DEDENT: i32 = 0x200;
 const PY_CF_ALLOW_INCOMPLETE_INPUT: i32 = 0x4000;
 
+// __future__ flags - sync with Lib/__future__.py
+// TODO: These flags aren't being used in rust code
+//       CO_FUTURE_ANNOTATIONS does make a difference in the codegen,
+//       so it should be used in compile().
+//       see compiler/codegen/src/compile.rs
+const CO_NESTED: i32 = 0x0010;
+const CO_GENERATOR_ALLOWED: i32 = 0;
+const CO_FUTURE_DIVISION: i32 = 0x20000;
+const CO_FUTURE_ABSOLUTE_IMPORT: i32 = 0x40000;
+const CO_FUTURE_WITH_STATEMENT: i32 = 0x80000;
+const CO_FUTURE_PRINT_FUNCTION: i32 = 0x100000;
+const CO_FUTURE_UNICODE_LITERALS: i32 = 0x200000;
+const CO_FUTURE_BARRY_AS_BDFL: i32 = 0x400000;
+const CO_FUTURE_GENERATOR_STOP: i32 = 0x800000;
+const CO_FUTURE_ANNOTATIONS: i32 = 0x1000000;
+
 // Used by builtins::compile() - the summary of all flags
-pub const PY_COMPILE_FLAGS_MASK: i32 =
-    PY_COMPILE_FLAG_AST_ONLY | PY_CF_DONT_IMPLY_DEDENT | PY_CF_ALLOW_INCOMPLETE_INPUT;
+pub const PY_COMPILE_FLAGS_MASK: i32 = PY_COMPILE_FLAG_AST_ONLY
+    | PY_CF_DONT_IMPLY_DEDENT
+    | PY_CF_ALLOW_INCOMPLETE_INPUT
+    | CO_NESTED
+    | CO_GENERATOR_ALLOWED
+    | CO_FUTURE_DIVISION
+    | CO_FUTURE_ABSOLUTE_IMPORT
+    | CO_FUTURE_WITH_STATEMENT
+    | CO_FUTURE_PRINT_FUNCTION
+    | CO_FUTURE_UNICODE_LITERALS
+    | CO_FUTURE_BARRY_AS_BDFL
+    | CO_FUTURE_GENERATOR_STOP
+    | CO_FUTURE_ANNOTATIONS;
 
 pub fn make_module(vm: &VirtualMachine) -> PyRef<PyModule> {
     let module = _ast::make_module(vm);

--- a/vm/src/stdlib/ast.rs
+++ b/vm/src/stdlib/ast.rs
@@ -353,6 +353,8 @@ pub(crate) fn compile(
 pub(crate) use _ast::NodeAst;
 // Used by builtins::compile()
 pub const PY_COMPILE_FLAG_AST_ONLY: i32 = 0x0400;
+// Used by builtins::compile() - the summary of all flags
+pub const PY_COMPILE_FLAGS_MASK: i32 = PY_COMPILE_FLAG_AST_ONLY;
 
 pub fn make_module(vm: &VirtualMachine) -> PyRef<PyModule> {
     let module = _ast::make_module(vm);

--- a/vm/src/stdlib/ast.rs
+++ b/vm/src/stdlib/ast.rs
@@ -341,8 +341,13 @@ pub(crate) fn compile(
     object: PyObjectRef,
     filename: &str,
     mode: crate::compiler::Mode,
+    optimize: Option<u8>,
 ) -> PyResult {
-    let opts = vm.compile_opts();
+    let mut opts = vm.compile_opts();
+    if let Some(optimize) = optimize {
+        opts.optimize = optimize;
+    }
+
     let ast = Node::ast_from_object(vm, object)?;
     let code = codegen::compile::compile_top(&ast, filename.to_owned(), mode, opts)
         .map_err(|err| (CompileError::from(err), None).to_pyexception(vm))?; // FIXME source

--- a/vm/src/stdlib/builtins.rs
+++ b/vm/src/stdlib/builtins.rs
@@ -179,6 +179,10 @@ mod builtins {
 
                 let flags = args.flags.map_or(Ok(0), |v| v.try_to_primitive(vm))?;
 
+                if !(flags & !ast::PY_COMPILE_FLAGS_MASK).is_zero() {
+                    return Err(vm.new_value_error("compile() unrecognized flags".to_owned()));
+                }
+
                 if (flags & ast::PY_COMPILE_FLAG_AST_ONLY).is_zero() {
                     #[cfg(not(feature = "rustpython-compiler"))]
                     {

--- a/vm/src/stdlib/builtins.rs
+++ b/vm/src/stdlib/builtins.rs
@@ -146,16 +146,35 @@ mod builtins {
             }
             #[cfg(feature = "rustpython-parser")]
             {
+                use crate::builtins::PyMemoryView;
+                use crate::common::borrow::BorrowedValue;
+                use crate::protocol::PyBuffer;
+                use crate::types::AsBuffer;
                 use crate::{builtins::PyBytesRef, convert::ToPyException};
                 use num_traits::Zero;
                 use rustpython_parser as parser;
 
-                let source = Either::<PyStrRef, PyBytesRef>::try_from_object(vm, args.source)?;
+                //
+                let source =
+                    Either::<PyStrRef, Either<PyBytesRef, PyRef<PyMemoryView>>>::try_from_object(
+                        vm,
+                        args.source,
+                    )?;
+
+                let memory_view_holder: PyBuffer;
+                let memory_view_borrow_holder: BorrowedValue<[u8]>;
+
                 // TODO: compiler::compile should probably get bytes
                 let source = match &source {
                     Either::A(string) => string.as_str(),
-                    Either::B(bytes) => std::str::from_utf8(bytes)
+                    Either::B(Either::A(bytes)) => std::str::from_utf8(bytes)
                         .map_err(|e| vm.new_unicode_decode_error(e.to_string()))?,
+                    Either::B(Either::B(memory_view)) => {
+                        memory_view_holder = AsBuffer::as_buffer(memory_view, vm)?;
+                        memory_view_borrow_holder = memory_view_holder.obj_bytes();
+                        std::str::from_utf8(memory_view_borrow_holder.as_ref())
+                            .map_err(|e| vm.new_unicode_decode_error(e.to_string()))?
+                    }
                 };
 
                 let flags = args.flags.map_or(Ok(0), |v| v.try_to_primitive(vm))?;


### PR DESCRIPTION
Code changes to make the test `BuiltinTest.test_compile` in `test_builtin.py` work.

I've made a draft PR as this unit test has multiple different incompatibility issues that all need to be fixed for this to fully work, and so feedback can be given on the first issues while I work on the latter ones. 

Issues:
- [x] Accept memoryview as source code in `compile()`
- [x] Update unit test from what was in CPython3.8 to CPython3.12, as one error changed from `ValueError` to `SyntaxError`
- [x] Raise `ValueError` when given invalid flags
- [x] Pass optimize argument to inner code
- [ ] Remove function doc strings on `optimize=2` -> future PR
