### PR TITLE
filter out doc strings with opt level 2 as final step to enable test_builtin.py test_compile

### DIFF
--- a/Lib/test/test_builtin.py
+++ b/Lib/test/test_builtin.py
@@ -327,8 +327,6 @@ class BuiltinTest(unittest.TestCase):
     def test_cmp(self):
         self.assertTrue(not hasattr(builtins, "cmp"))
 
-    # TODO: RUSTPYTHON optval=2 does not remove docstrings
-    @unittest.expectedFailure
     def test_compile(self):
         compile('print(1)\n', '', 'exec')
         bom = b'\xef\xbb\xbf'


### PR DESCRIPTION
Addresses the last todo item of #5251

Optimize=2 removes doc strings, so I added code to do that. 

The unit tests will most likely fail as the main branch commit this branch is based on doesn't pass all the tests. 