### PR TITLE
Fix for test future.py  test annotations

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2011,7 +2011,7 @@ dependencies = [
 [[package]]
 name = "rustpython-ast"
 version = "0.3.1"
-source = "git+https://github.com/RustPython/Parser.git?rev=a95045bc627b2fbf84caf4f010e521846be7b37f#a95045bc627b2fbf84caf4f010e521846be7b37f"
+source = "git+https://github.com/RustPython/Parser.git?rev=51b5f80ae3080dfec2db815a299a69873fb9ca65#51b5f80ae3080dfec2db815a299a69873fb9ca65"
 dependencies = [
  "is-macro",
  "malachite-bigint",
@@ -2124,7 +2124,7 @@ dependencies = [
 [[package]]
 name = "rustpython-format"
 version = "0.3.1"
-source = "git+https://github.com/RustPython/Parser.git?rev=a95045bc627b2fbf84caf4f010e521846be7b37f#a95045bc627b2fbf84caf4f010e521846be7b37f"
+source = "git+https://github.com/RustPython/Parser.git?rev=51b5f80ae3080dfec2db815a299a69873fb9ca65#51b5f80ae3080dfec2db815a299a69873fb9ca65"
 dependencies = [
  "bitflags 2.5.0",
  "itertools 0.11.0",
@@ -2151,7 +2151,7 @@ dependencies = [
 [[package]]
 name = "rustpython-literal"
 version = "0.3.1"
-source = "git+https://github.com/RustPython/Parser.git?rev=a95045bc627b2fbf84caf4f010e521846be7b37f#a95045bc627b2fbf84caf4f010e521846be7b37f"
+source = "git+https://github.com/RustPython/Parser.git?rev=51b5f80ae3080dfec2db815a299a69873fb9ca65#51b5f80ae3080dfec2db815a299a69873fb9ca65"
 dependencies = [
  "hexf-parse",
  "is-macro",
@@ -2163,7 +2163,7 @@ dependencies = [
 [[package]]
 name = "rustpython-parser"
 version = "0.3.1"
-source = "git+https://github.com/RustPython/Parser.git?rev=a95045bc627b2fbf84caf4f010e521846be7b37f#a95045bc627b2fbf84caf4f010e521846be7b37f"
+source = "git+https://github.com/RustPython/Parser.git?rev=51b5f80ae3080dfec2db815a299a69873fb9ca65#51b5f80ae3080dfec2db815a299a69873fb9ca65"
 dependencies = [
  "anyhow",
  "is-macro",
@@ -2186,7 +2186,7 @@ dependencies = [
 [[package]]
 name = "rustpython-parser-core"
 version = "0.3.1"
-source = "git+https://github.com/RustPython/Parser.git?rev=a95045bc627b2fbf84caf4f010e521846be7b37f#a95045bc627b2fbf84caf4f010e521846be7b37f"
+source = "git+https://github.com/RustPython/Parser.git?rev=51b5f80ae3080dfec2db815a299a69873fb9ca65#51b5f80ae3080dfec2db815a299a69873fb9ca65"
 dependencies = [
  "is-macro",
  "memchr",
@@ -2196,7 +2196,7 @@ dependencies = [
 [[package]]
 name = "rustpython-parser-vendored"
 version = "0.3.1"
-source = "git+https://github.com/RustPython/Parser.git?rev=a95045bc627b2fbf84caf4f010e521846be7b37f#a95045bc627b2fbf84caf4f010e521846be7b37f"
+source = "git+https://github.com/RustPython/Parser.git?rev=51b5f80ae3080dfec2db815a299a69873fb9ca65#51b5f80ae3080dfec2db815a299a69873fb9ca65"
 dependencies = [
  "memchr",
  "once_cell",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,11 +30,11 @@ rustpython-stdlib = { path = "stdlib", default-features = false, version = "0.3.
 rustpython-sre_engine = { path = "vm/sre_engine", version = "0.3.1" }
 rustpython-doc = { git = "https://github.com/RustPython/__doc__", tag = "0.3.0", version = "0.3.0" }
 
-rustpython-literal = { git = "https://github.com/RustPython/Parser.git", version = "0.3.1", rev = "a95045bc627b2fbf84caf4f010e521846be7b37f" }
-rustpython-parser-core = { git = "https://github.com/RustPython/Parser.git", version = "0.3.1", rev = "a95045bc627b2fbf84caf4f010e521846be7b37f" }
-rustpython-parser = { git = "https://github.com/RustPython/Parser.git", version = "0.3.1", rev = "a95045bc627b2fbf84caf4f010e521846be7b37f" }
-rustpython-ast = { git = "https://github.com/RustPython/Parser.git", version = "0.3.1", rev = "a95045bc627b2fbf84caf4f010e521846be7b37f" }
-rustpython-format = { git = "https://github.com/RustPython/Parser.git", version = "0.3.1", rev = "a95045bc627b2fbf84caf4f010e521846be7b37f" }
+rustpython-literal = { git = "https://github.com/RustPython/Parser.git", version = "0.3.1", rev = "51b5f80ae3080dfec2db815a299a69873fb9ca65" }
+rustpython-parser-core = { git = "https://github.com/RustPython/Parser.git", version = "0.3.1", rev = "51b5f80ae3080dfec2db815a299a69873fb9ca65" }
+rustpython-parser = { git = "https://github.com/RustPython/Parser.git", version = "0.3.1", rev = "51b5f80ae3080dfec2db815a299a69873fb9ca65" }
+rustpython-ast = { git = "https://github.com/RustPython/Parser.git", version = "0.3.1", rev = "51b5f80ae3080dfec2db815a299a69873fb9ca65" }
+rustpython-format = { git = "https://github.com/RustPython/Parser.git", version = "0.3.1", rev = "51b5f80ae3080dfec2db815a299a69873fb9ca65" }
 # rustpython-literal = { path = "../RustPython-parser/literal" }
 # rustpython-parser-core = { path = "../RustPython-parser/core" }
 # rustpython-parser = { path = "../RustPython-parser/parser" }

--- a/Lib/test/test_future_stmt/test_future.py
+++ b/Lib/test/test_future_stmt/test_future.py
@@ -198,8 +198,6 @@ class AnnotationsFutureTestCase(unittest.TestCase):
         )
         return scope
 
-    # TODO: RUSTPYTHON
-    @unittest.expectedFailure
     def test_annotations(self):
         eq = self.assertAnnotationEqual
         eq('...')


### PR DESCRIPTION
Enabled test from PR https://github.com/RustPython/Parser/pull/121 and bumped version of the parser used forward by 4 commits to include the PR.

close #5317 