### PR TITLE
test_class.py: testTypeAttributeAccessErrorMessages fix

### DIFF
--- a/Lib/test/test_class.py
+++ b/Lib/test/test_class.py
@@ -629,8 +629,6 @@ class ClassTests(unittest.TestCase):
         with self.assertRaises(TypeError):
             type.__setattr__(A, b'x', None)
 
-    # TODO: RUSTPYTHON
-    @unittest.expectedFailure
     def testTypeAttributeAccessErrorMessages(self):
         class A:
             pass

--- a/vm/src/builtins/type.rs
+++ b/vm/src/builtins/type.rs
@@ -1073,10 +1073,11 @@ impl SetAttr for PyType {
         } else {
             let prev_value = zelf.attributes.write().shift_remove(attr_name); // TODO: swap_remove applicable?
             if prev_value.is_none() {
-                return Err(vm.new_exception(
-                    vm.ctx.exceptions.attribute_error.to_owned(),
-                    vec![attr_name.to_object()],
-                ));
+                return Err(vm.new_attribute_error(format!(
+                    "type object '{}' has no attribute '{}'",
+                    zelf.name(),
+                    attr_name.as_str(),
+                )));
             }
         }
         if attr_name.as_str().starts_with("__") && attr_name.as_str().ends_with("__") {


### PR DESCRIPTION
adjusted error message to match expectation when deleting non-existant attributes, e.g. `del A.x` where A has no attr x.