### PR TITLE
Fix `best_base` to select proper base class

### DIFF
--- a/Lib/test/test_builtin.py
+++ b/Lib/test/test_builtin.py
@@ -2368,8 +2368,6 @@ class ShutdownTest(unittest.TestCase):
 
 
 class TestType(unittest.TestCase):
-    # TODO: RUSTPYTHON
-    @unittest.expectedFailure
     def test_new_type(self):
         A = type('A', (), {})
         self.assertEqual(A.__name__, 'A')
@@ -2472,8 +2470,6 @@ class TestType(unittest.TestCase):
             A.__doc__ = doc
             self.assertEqual(A.__doc__, doc)
 
-    # TODO: RUSTPYTHON
-    @unittest.expectedFailure
     def test_bad_args(self):
         with self.assertRaises(TypeError):
             type()

--- a/Lib/test/test_descr.py
+++ b/Lib/test/test_descr.py
@@ -823,8 +823,6 @@ class ClassPropertiesAndMethods(unittest.TestCase):
             class X(int(), C):
                 pass
 
-    # TODO: RUSTPYTHON
-    @unittest.expectedFailure
     def test_module_subclasses(self):
         # Testing Python subclass of module...
         log = []
@@ -1500,8 +1498,6 @@ order (MRO) for bases """
             pass
         self.assertNotEqual(someclass, object)
 
-    # TODO: RUSTPYTHON
-    @unittest.expectedFailure
     def test_errors(self):
         # Testing errors...
         try:

--- a/Lib/test/test_posix.py
+++ b/Lib/test/test_posix.py
@@ -1680,8 +1680,6 @@ class PosixGroupsTester(unittest.TestCase):
         posix.initgroups(name, g)
         self.assertIn(g, posix.getgroups())
 
-    # TODO: RUSTPYTHON: TypeError: Unexpected keyword argument setpgroup
-    @unittest.expectedFailure
     @unittest.skipUnless(hasattr(posix, 'setgroups'),
                          "test needs posix.setgroups()")
     def test_setgroups(self):

--- a/vm/src/builtins/type.rs
+++ b/vm/src/builtins/type.rs
@@ -1324,7 +1324,6 @@ fn calculate_meta_class(
     Ok(winner)
 }
 
-
 fn solid_base(typ: &PyTypeRef, vm: &VirtualMachine) -> PyTypeRef {
     let base = if let Some(base) = &typ.base {
         solid_base(base, vm)
@@ -1341,7 +1340,6 @@ fn solid_base(typ: &PyTypeRef, vm: &VirtualMachine) -> PyTypeRef {
 }
 
 fn best_base(bases: &[PyTypeRef], vm: &VirtualMachine) -> PyResult<PyTypeRef> {
-   
     let mut base: Option<PyTypeRef> = None;
     let mut winner: Option<PyTypeRef> = None;
 
@@ -1368,9 +1366,9 @@ fn best_base(bases: &[PyTypeRef], vm: &VirtualMachine) -> PyResult<PyTypeRef> {
             winner = Some(candidate.clone());
             base = Some(base_i.clone());
         } else {
-            return Err(vm.new_type_error(
-                "multiple bases have instance layout conflict".to_string(),
-            ));
+            return Err(
+                vm.new_type_error("multiple bases have instance layout conflict".to_string())
+            );
         }
     }
 

--- a/vm/src/builtins/type.rs
+++ b/vm/src/builtins/type.rs
@@ -1320,21 +1320,34 @@ fn calculate_meta_class(
 
 fn solid_base(typ: &PyTypeRef, vm: &VirtualMachine) -> Option<PyTypeRef> {
     let result = if let Some(base) = &typ.base {
-        solid_base(&base, vm)
+        solid_base(&base, vm).unwrap()
     } else {
-        Some(vm.ctx.types.object_type.to_owned())
+        vm.ctx.types.object_type.to_owned()
     };
 
-    result
+    if result.slots.basicsize != typ.slots.basicsize {
+        Some(typ)
+    } else {
+        Some(result)
+    }
 }
 
 fn best_base(bases: &[PyTypeRef], vm: &VirtualMachine) -> PyResult<PyTypeRef> {
-    let mut base: Option<PyTypeRef> = None;
-    let mut winner: Option<PyTypeRef> = None;
+    // let mut base = None;
+    // let mut winner = None;
 
     for base_i in bases {
-        // if !base_i.fast_issubclass(vm.ctx.types.type_type) {
-        //     return Err(vm.new_type_error("best must be types".into()));
+        // base_proto = PyTuple_GET_ITEM(bases, i);
+        // if (!PyType_Check(base_proto)) {
+        //     PyErr_SetString(
+        //         PyExc_TypeError,
+        //         "bases must be types");
+        //     return NULL;
+        // }
+        // base_i = (PyTypeObject *)base_proto;
+        // if (base_i->slot_dict == NULL) {
+        //     if (PyType_Ready(base_i) < 0)
+        //         return NULL;
         // }
 
         if !base_i.slots.flags.has_feature(PyTypeFlags::BASETYPE) {
@@ -1343,14 +1356,51 @@ fn best_base(bases: &[PyTypeRef], vm: &VirtualMachine) -> PyResult<PyTypeRef> {
                 base_i.name()
             )));
         }
-
-        let candidate = solid_base(&base_i, vm);
-        println!("candidate type : {}", candidate.unwrap().name());
+        // candidate = solid_base(base_i);
+        // if (winner == NULL) {
+        //     winner = candidate;
+        //     base = base_i;
+        // }
+        // else if (PyType_IsSubtype(winner, candidate))
+        //     ;
+        // else if (PyType_IsSubtype(candidate, winner)) {
+        //     winner = candidate;
+        //     base = base_i;
+        // }
+        // else {
+        //     PyErr_SetString(
+        //         PyExc_TypeError,
+        //         "multiple bases have "
+        //         "instance lay-out conflict");
+        //     return NULL;
+        // }
     }
 
-    // Ok(base.unwrap())
-
+    // FIXME: Ok(base.unwrap()) is expected
     Ok(bases[0].clone())
+
+    // let mut base: Option<PyTypeRef> = None;
+    // let mut winner: Option<PyTypeRef> = None;
+
+    // for base_i in bases {
+    //     // if !base_i.fast_issubclass(vm.ctx.types.type_type) {
+    //     //     return Err(vm.new_type_error("best must be types".into()));
+    //     // }
+
+    //     if !base_i.slots.flags.has_feature(PyTypeFlags::BASETYPE) {
+    //         return Err(vm.new_type_error(format!(
+    //             "type '{}' is not an acceptable base type",
+    //             base_i.name()
+    //         )));
+    //     }
+
+    //     let candidate = solid_base(&base_i, vm);
+    //     println!("candidate type : {}", candidate.unwrap().name());
+    // }
+
+    // // Ok(base.unwrap())
+
+    // Ok(bases[0].clone())
 }
 
 #[cfg(test)]

--- a/vm/src/builtins/type.rs
+++ b/vm/src/builtins/type.rs
@@ -205,6 +205,9 @@ impl PyType {
         if base.slots.flags.has_feature(PyTypeFlags::HAS_DICT) {
             slots.flags |= PyTypeFlags::HAS_DICT
         }
+        if slots.basicsize == 0 {
+            slots.basicsize = base.slots.basicsize;
+        }
 
         if let Some(qualname) = attrs.get(identifier!(ctx, __qualname__)) {
             if !qualname.fast_isinstance(ctx.types.str_type) {
@@ -252,6 +255,9 @@ impl PyType {
     ) -> Result<PyRef<Self>, String> {
         if base.slots.flags.has_feature(PyTypeFlags::HAS_DICT) {
             slots.flags |= PyTypeFlags::HAS_DICT
+        }
+        if slots.basicsize == 0 {
+            slots.basicsize = base.slots.basicsize;
         }
 
         let bases = vec![base.clone()];

--- a/vm/src/builtins/type.rs
+++ b/vm/src/builtins/type.rs
@@ -1321,7 +1321,7 @@ fn calculate_meta_class(
 
 fn solid_base(typ: &PyTypeRef, vm: &VirtualMachine) -> PyTypeRef {
     let base = if let Some(base) = &typ.base {
-        solid_base(&base, vm)
+        solid_base(base, vm)
     } else {
         vm.ctx.types.object_type.to_owned()
     };
@@ -1352,7 +1352,7 @@ fn best_base(bases: &[PyTypeRef], vm: &VirtualMachine) -> PyResult<PyTypeRef> {
             )));
         }
 
-        let candidate = solid_base(&base_i, vm);
+        let candidate = solid_base(base_i, vm);
         if winner.is_none() {
             winner = Some(candidate.clone());
             base = Some(base_i.clone());


### PR DESCRIPTION
This revision implements `itemsize` slots and fix `best_base` implementation to select proper base class when generating class.