### PR TITLE
Make `__bases__` mutable

### DIFF
--- a/Lib/test/test_descr.py
+++ b/Lib/test/test_descr.py
@@ -4036,8 +4036,6 @@ order (MRO) for bases """
             y = x ** 2
         self.assertIn('unsupported operand type(s) for **', str(cm.exception))
 
-    # TODO: RUSTPYTHON
-    @unittest.expectedFailure
     def test_mutable_bases(self):
         # Testing mutable bases...
 
@@ -4239,8 +4237,6 @@ order (MRO) for bases """
         else:
             self.fail("exception not propagated")
 
-    # TODO: RUSTPYTHON
-    @unittest.expectedFailure
     def test_mutable_bases_catch_mro_conflict(self):
         # Testing mutable bases catch mro conflict...
         class A(object):
@@ -5763,8 +5759,6 @@ class MroTest(unittest.TestCase):
         class A(metaclass=M):
             pass
 
-    # TODO: RUSTPYTHON
-    @unittest.expectedFailure
     def test_reent_set_bases_on_base(self):
         """
         Deep reentrancy must not over-decref old_mro.

--- a/vm/src/builtins/super.rs
+++ b/vm/src/builtins/super.rs
@@ -166,12 +166,13 @@ impl GetAttr for PySuper {
 
         if let Some(name) = vm.ctx.interned_str(name) {
             // skip the classes in start_type.mro up to and including zelf.typ
-            let mro: Vec<_> = start_type
-                .iter_mro()
+            let mro: Vec<PyRef<PyType>> = start_type.mro_map_collect(|x| x.to_owned());
+            let mro: Vec<_> = mro
+                .iter()
                 .skip_while(|cls| !cls.is(&zelf.inner.read().typ))
                 .skip(1) // skip su->type (if any)
                 .collect();
-            for cls in mro {
+            for cls in mro.iter() {
                 if let Some(descr) = cls.get_direct_attr(name) {
                     return vm
                         .call_get_descriptor_specific(

--- a/vm/src/builtins/type.rs
+++ b/vm/src/builtins/type.rs
@@ -312,16 +312,6 @@ impl PyType {
         }
     }
 
-    pub fn mro_map_collect<F, R>(&self, f: F) -> Vec<R>
-    where
-        F: Fn(&Self) -> R,
-    {
-        std::iter::once(self)
-            .chain(self.mro.read().iter().map(|cls| -> &PyType { cls }))
-            .map(f)
-            .collect()
-    }
-
     // This is used for class initialisation where the vm is not yet available.
     pub fn set_str_attr<V: Into<PyObjectRef>>(
         &self,

--- a/vm/src/object/core.rs
+++ b/vm/src/object/core.rs
@@ -1190,8 +1190,8 @@ pub(crate) fn init_type_hierarchy() -> (PyTypeRef, PyTypeRef, PyTypeRef) {
 
         let type_payload = PyType {
             base: None,
-            bases: vec![],
-            mro: vec![],
+            bases: PyRwLock::default(),
+            mro: PyRwLock::default(),
             subclasses: PyRwLock::default(),
             attributes: PyRwLock::new(Default::default()),
             slots: PyType::make_slots(),
@@ -1199,8 +1199,8 @@ pub(crate) fn init_type_hierarchy() -> (PyTypeRef, PyTypeRef, PyTypeRef) {
         };
         let object_payload = PyType {
             base: None,
-            bases: vec![],
-            mro: vec![],
+            bases: PyRwLock::default(),
+            mro: PyRwLock::default(),
             subclasses: PyRwLock::default(),
             attributes: PyRwLock::new(Default::default()),
             slots: object::PyBaseObject::make_slots(),
@@ -1244,8 +1244,8 @@ pub(crate) fn init_type_hierarchy() -> (PyTypeRef, PyTypeRef, PyTypeRef) {
 
             let object_type = PyTypeRef::from_raw(object_type_ptr.cast());
 
-            (*type_type_ptr).payload.mro = vec![object_type.clone()];
-            (*type_type_ptr).payload.bases = vec![object_type.clone()];
+            (*type_type_ptr).payload.mro = PyRwLock::new(vec![object_type.clone()]);
+            (*type_type_ptr).payload.bases = PyRwLock::new(vec![object_type.clone()]);
             (*type_type_ptr).payload.base = Some(object_type.clone());
 
             let type_type = PyTypeRef::from_raw(type_type_ptr.cast());
@@ -1256,8 +1256,8 @@ pub(crate) fn init_type_hierarchy() -> (PyTypeRef, PyTypeRef, PyTypeRef) {
 
     let weakref_type = PyType {
         base: Some(object_type.clone()),
-        bases: vec![object_type.clone()],
-        mro: vec![object_type.clone()],
+        bases: PyRwLock::new(vec![object_type.clone()]),
+        mro: PyRwLock::new(vec![object_type.clone()]),
         subclasses: PyRwLock::default(),
         attributes: PyRwLock::default(),
         slots: PyWeak::make_slots(),


### PR DESCRIPTION
Assigning `__bases__` allows you to alter the class inheritance tree at any point. The updated `typing.py` uses this feature when constructing `NamedTuples`, for reasons unknown to me.

I had to make `PyType.bases` and `PyType.mro` mutable behind a `PyRwLock` in order to enable this feature.

Assigning `__bases__` has several features I wasn't sure how to implement. I left TODOs for these:
* Making sure the new method resolution order is actually a tree, i.e. it contains no cycles
* Removing the modified class from any `__subclass__` lists it used to belong to
* Removing any slots that no longer apply (not sure if this is required?)