### PR TITLE
Bump libsqlite3-sys

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1149,9 +1149,9 @@ dependencies = [
 
 [[package]]
 name = "libsqlite3-sys"
-version = "0.25.2"
+version = "0.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "29f835d03d717946d28b1d1ed632eb6f0e24a299388ee623d0c23118d3e8a7fa"
+checksum = "0c10584274047cb335c23d3e61bcef8e323adae7c5c8c760540f73610177fc3f"
 dependencies = [
  "cc",
  "pkg-config",

--- a/stdlib/Cargo.toml
+++ b/stdlib/Cargo.toml
@@ -104,7 +104,7 @@ openssl-probe = { version = "0.1.5", optional = true }
 foreign-types-shared = { version = "0.1.1", optional = true }
 
 [target.'cfg(not(any(target_os = "android", target_arch = "wasm32")))'.dependencies]
-libsqlite3-sys = { version = "0.25", features = ["min_sqlite_version_3_7_16", "bundled"] }
+libsqlite3-sys = { version = "0.28", features = ["bundled"] }
 
 [target.'cfg(windows)'.dependencies]
 junction = { workspace = true }


### PR DESCRIPTION
This lets you define `LIBSQLITE3_SYS_USE_PKG_CONFIG=1` in your profile, which cuts out building `libsqlite` from source.