### PR TITLE
Make a shared run function in ThreadedVirtualMachine

### DIFF
--- a/vm/src/vm/thread.rs
+++ b/vm/src/vm/thread.rs
@@ -93,9 +93,9 @@ impl ThreadedVirtualMachine {
     /// to the parent thread and then `join()` on the `JoinHandle` (or similar), there is a possibility that
     /// the current thread will panic as `PyObjectRef`'s `Drop` implementation tries to run the `__del__`
     /// destructor of a python object but finds that it's not in the context of any vm.
-    pub fn run<F, R>(&self, f: F) -> R
+    pub fn run<F, R>(&self, mut f: F) -> R
     where
-        F: Fn(&VirtualMachine) -> R,
+        F: FnMut(&VirtualMachine) -> R,
     {
         let vm = &self.vm;
         enter_vm(vm, || f(vm))

--- a/vm/src/vm/thread.rs
+++ b/vm/src/vm/thread.rs
@@ -82,7 +82,7 @@ impl ThreadedVirtualMachine {
     where
         F: FnOnce(&VirtualMachine) -> R,
     {
-        move || enter_vm(&self.vm, || f(&self.vm))
+        move || self.run(f)
     }
 
     /// Run a function in this thread context

--- a/vm/src/vm/thread.rs
+++ b/vm/src/vm/thread.rs
@@ -93,9 +93,9 @@ impl ThreadedVirtualMachine {
     /// to the parent thread and then `join()` on the `JoinHandle` (or similar), there is a possibility that
     /// the current thread will panic as `PyObjectRef`'s `Drop` implementation tries to run the `__del__`
     /// destructor of a python object but finds that it's not in the context of any vm.
-    pub fn run<F, R>(&self, mut f: F) -> R
+    pub fn run<F, R>(&self, f: F) -> R
     where
-        F: FnMut(&VirtualMachine) -> R,
+        F: FnOnce(&VirtualMachine) -> R,
     {
         let vm = &self.vm;
         enter_vm(vm, || f(vm))


### PR DESCRIPTION
This makes it much easier to store a `ThreadedVirtualMachine` somewhere and run it as many times as we want in another thread.

After looking at the code, I see the way things are set up with the current `run` it's not best to change it from taking `self`. However I might suggest renaming it into `into_run` or similar (along with `into_spawn_func`) as it makes the fact it takes ownership clearer. That'd leave us with being able to name the shared run function simply `run`. However these would be breaking changes, so I left the core implementations the same.

For now I've just made a simple `shared_run` instead which accomplishes this without breaking changes.

I am sure this might require quite a bit of discussion about how we really want it and some refactoring, so let me know your thoughts!