### PR TITLE
Fix `missing_transmute_annotations`, `legacy_numeric_constants` added in Rust 1.79.0 clippy

### DIFF
--- a/common/src/fileutils.rs
+++ b/common/src/fileutils.rs
@@ -327,7 +327,17 @@ pub mod windows {
                 if let Some(proc) =
                     unsafe { GetProcAddress(module, name.as_bytes_with_nul().as_ptr()) }
                 {
-                    Some(unsafe { std::mem::transmute(proc) })
+                    Some(unsafe {
+                        std::mem::transmute::<
+                            unsafe extern "system" fn() -> isize,
+                            unsafe extern "system" fn(
+                                *const u16,
+                                FILE_INFO_BY_NAME_CLASS,
+                                *mut libc::c_void,
+                                u32,
+                            ) -> i32,
+                        >(proc)
+                    })
                 } else {
                     unsafe { FreeLibrary(module) };
                     None

--- a/stdlib/src/ssl.rs
+++ b/stdlib/src/ssl.rs
@@ -379,7 +379,7 @@ mod _ssl {
     #[pyfunction(name = "RAND_add")]
     fn rand_add(string: ArgStrOrBytesLike, entropy: f64) {
         let f = |b: &[u8]| {
-            for buf in b.chunks(libc::c_int::max_value() as usize) {
+            for buf in b.chunks(libc::c_int::MAX as usize) {
                 unsafe { sys::RAND_add(buf.as_ptr() as *const _, buf.len() as _, entropy) }
             }
         };
@@ -1513,7 +1513,7 @@ mod bio {
         pub fn new(buf: &'a [u8]) -> Result<MemBioSlice<'a>, ErrorStack> {
             openssl::init();
 
-            assert!(buf.len() <= c_int::max_value() as usize);
+            assert!(buf.len() <= c_int::MAX as usize);
             let bio = unsafe { sys::BIO_new_mem_buf(buf.as_ptr() as *const _, buf.len() as c_int) };
             if bio.is_null() {
                 return Err(ErrorStack::get());

--- a/vm/src/function/method.rs
+++ b/vm/src/function/method.rs
@@ -236,7 +236,9 @@ impl std::fmt::Debug for PyMethodDef {
             .field("name", &self.name)
             .field(
                 "func",
-                &(unsafe { std::mem::transmute::<_, [usize; 2]>(self.func)[1] as *const u8 }),
+                &(unsafe {
+                    std::mem::transmute::<&dyn PyNativeFn, [usize; 2]>(self.func)[1] as *const u8
+                }),
             )
             .field("flags", &self.flags)
             .field("doc", &self.doc)

--- a/vm/src/intern.rs
+++ b/vm/src/intern.rs
@@ -286,7 +286,7 @@ impl MaybeInternedString for Py<PyStr> {
     #[inline(always)]
     fn as_interned(&self) -> Option<&'static PyStrInterned> {
         if self.as_object().is_interned() {
-            Some(unsafe { std::mem::transmute(self) })
+            Some(unsafe { std::mem::transmute::<&Py<PyStr>, &PyInterned<PyStr>>(self) })
         } else {
             None
         }

--- a/vm/src/stdlib/os.rs
+++ b/vm/src/stdlib/os.rs
@@ -999,7 +999,7 @@ pub(super) mod _os {
                 -1
             } else {
                 distance_to_move[0] = ret as _;
-                std::mem::transmute(distance_to_move)
+                std::mem::transmute::<[i32; 2], i64>(distance_to_move)
             }
         };
         if res < 0 {


### PR DESCRIPTION
Fix `missing_transmute_annotations`, `legacy_numeric_constants` added in Rust 1.79.0 clippy