### PR TITLE
changed int_max_str_digits from -1 to 4300 to be more cpython complient

### DIFF
--- a/Lib/test/test_cmd_line.py
+++ b/Lib/test/test_cmd_line.py
@@ -928,8 +928,6 @@ class CmdLineTest(unittest.TestCase):
         self.assertTrue(proc.stderr.startswith(err_msg), proc.stderr)
         self.assertNotEqual(proc.returncode, 0)
 
-    # TODO: RUSTPYTHON
-    @unittest.expectedFailure
     def test_int_max_str_digits(self):
         code = "import sys; print(sys.flags.int_max_str_digits, sys.get_int_max_str_digits())"
 

--- a/vm/src/vm/setting.rs
+++ b/vm/src/vm/setting.rs
@@ -151,7 +151,7 @@ impl Default for Settings {
             check_hash_pycs_mode: "default".to_owned(),
             allow_external_library: cfg!(feature = "importlib"),
             utf8_mode: 1,
-            int_max_str_digits: -1,
+            int_max_str_digits: 4300,
             #[cfg(feature = "flame-it")]
             profile_output: None,
             #[cfg(feature = "flame-it")]


### PR DESCRIPTION
A basic fix, which changes sys.flags.int_max_str_digits to `4300` instead of `-1` so it behaves the same as the cpython implementation. Fixes #5139

PS: this is my first issue and I am new here, do let me know if I missed anything.
