### PR TITLE
Support del __dict__

### DIFF
--- a/extra_tests/snippets/classes.py
+++ b/extra_tests/snippets/classes.py
@@ -1,0 +1,17 @@
+from testutils import assert_raises
+
+
+class Thing:
+    def __init__(self):
+        self.x = 1
+
+
+t = Thing()
+assert t.x == 1
+
+del t.__dict__
+
+with assert_raises(AttributeError):
+    _ = t.x
+
+assert t.__dict__ == {}

--- a/vm/src/builtins/object.rs
+++ b/vm/src/builtins/object.rs
@@ -500,12 +500,9 @@ pub fn object_set_dict(
     dict: PySetterValue<PyDictRef>,
     vm: &VirtualMachine,
 ) -> PyResult<()> {
-    let new_dict = match dict {
-        PySetterValue::Delete => PyDict::new_ref(&vm.ctx),
-        PySetterValue::Assign(dict) => dict,
-    };
+    let dict = dict.unwrap_or_else(|| PyDict::new_ref(&vm.ctx));
 
-    obj.set_dict(new_dict)
+    obj.set_dict(dict)
         .map_err(|_| vm.new_attribute_error("This object has no __dict__".to_owned()))
 }
 

--- a/vm/src/builtins/object.rs
+++ b/vm/src/builtins/object.rs
@@ -1,4 +1,4 @@
-use super::{PyDictRef, PyList, PyStr, PyStrRef, PyType, PyTypeRef};
+use super::{PyDict, PyDictRef, PyList, PyStr, PyStrRef, PyType, PyTypeRef};
 use crate::common::hash::PyHash;
 use crate::types::PyTypeFlags;
 use crate::{
@@ -495,8 +495,17 @@ pub fn object_get_dict(obj: PyObjectRef, vm: &VirtualMachine) -> PyResult<PyDict
     obj.dict()
         .ok_or_else(|| vm.new_attribute_error("This object has no __dict__".to_owned()))
 }
-pub fn object_set_dict(obj: PyObjectRef, dict: PyDictRef, vm: &VirtualMachine) -> PyResult<()> {
-    obj.set_dict(dict)
+pub fn object_set_dict(
+    obj: PyObjectRef,
+    dict: PySetterValue<PyDictRef>,
+    vm: &VirtualMachine,
+) -> PyResult<()> {
+    let new_dict = match dict {
+        PySetterValue::Delete => PyDict::new_ref(&vm.ctx),
+        PySetterValue::Assign(dict) => dict,
+    };
+
+    obj.set_dict(new_dict)
         .map_err(|_| vm.new_attribute_error("This object has no __dict__".to_owned()))
 }
 

--- a/vm/src/builtins/type.rs
+++ b/vm/src/builtins/type.rs
@@ -1267,7 +1267,11 @@ fn subtype_get_dict(obj: PyObjectRef, vm: &VirtualMachine) -> PyResult {
     Ok(ret)
 }
 
-fn subtype_set_dict(obj: PyObjectRef, value: PyObjectRef, vm: &VirtualMachine) -> PyResult<()> {
+fn subtype_set_dict(
+    obj: PyObjectRef,
+    value: PySetterValue<PyObjectRef>,
+    vm: &VirtualMachine,
+) -> PyResult<()> {
     let cls = obj.class();
     match find_base_dict_descr(cls, vm) {
         Some(descr) => {
@@ -1280,10 +1284,16 @@ fn subtype_set_dict(obj: PyObjectRef, value: PyObjectRef, vm: &VirtualMachine) -
                         cls.name()
                     ))
                 })?;
-            descr_set(&descr, obj, PySetterValue::Assign(value), vm)
+            descr_set(&descr, obj, value, vm)
         }
         None => {
-            object::object_set_dict(obj, value.try_into_value(vm)?, vm)?;
+            let value = match value {
+                PySetterValue::Assign(value) => {
+                    PySetterValue::Assign(PyDictRef::try_from_object(vm, value)?)
+                }
+                PySetterValue::Delete => PySetterValue::Delete,
+            };
+            object::object_set_dict(obj, value, vm)?;
             Ok(())
         }
     }

--- a/vm/src/builtins/type.rs
+++ b/vm/src/builtins/type.rs
@@ -1287,12 +1287,10 @@ fn subtype_set_dict(
             descr_set(&descr, obj, value, vm)
         }
         None => {
-            let value = match value {
-                PySetterValue::Assign(value) => {
-                    PySetterValue::Assign(PyDictRef::try_from_object(vm, value)?)
-                }
-                PySetterValue::Delete => PySetterValue::Delete,
-            };
+            let value = value
+                .map(|assign| PyDictRef::try_from_object(vm, assign))
+                .transpose()?;
+
             object::object_set_dict(obj, value, vm)?;
             Ok(())
         }


### PR DESCRIPTION
I would like to take over this good first issue: #5355 

It brings the interpreter in line with the cpython behaviour when deleting `__dict__` attributes.

```python
class Thing:
    def __init__(self):
        self.x = 1


t = Thing()

del t.__dict__  # no error

t.x  # this is now an AttributeError
```

Basically this replaces the instance dict with an empty dictionary. This seems to duplicate the cpython behaviour.

Things to improve

- I'm not sure if there is a better place for the test
- ~~I don't like the `let new_dict = match dict` where i take the given dict or and empty one. I could add a `unwrap_or_default` for the `PySetterValue`?~~ (found it)
- ~~I also don't like the `let value = match value {` where i convert the `Assign` from a `PyObjectRef` into a `PyDictRef`. But i could not find a `map*` variant that let's  me pass a function that returns a PyResult~~ (i guess i found it)

I'd love to hear your suggestions