### PR TITLE
4982 - Implement tm_gmtoff and tm_zone

### DIFF
--- a/Lib/test/test_time.py
+++ b/Lib/test/test_time.py
@@ -718,9 +718,10 @@ class TestAsctime4dyear(_TestAsctimeYear, _Test4dYear, unittest.TestCase):
 
 
 class TestPytime(unittest.TestCase):
+    # TODO: RUSTPYTHON
+    @unittest.expectedFailure
     @skip_if_buggy_ucrt_strfptime
-    @unittest.skip("TODO: RUSTPYTHON, AttributeError: module 'time' has no attribute '_STRUCT_TM_ITEMS'")
-    # @unittest.skipUnless(time._STRUCT_TM_ITEMS == 11, "needs tm_zone support")
+    @unittest.skipUnless(time._STRUCT_TM_ITEMS == 11, "needs tm_zone support")
     def test_localtime_timezone(self):
 
         # Get the localtime and examine it for the offset and zone.
@@ -755,16 +756,18 @@ class TestPytime(unittest.TestCase):
         self.assertEqual(new_lt.tm_gmtoff, lt.tm_gmtoff)
         self.assertEqual(new_lt9.tm_zone, lt.tm_zone)
     
-    @unittest.skip("TODO: RUSTPYTHON, AttributeError: module 'time' has no attribute '_STRUCT_TM_ITEMS'")
-    # @unittest.skipUnless(time._STRUCT_TM_ITEMS == 11, "needs tm_zone support")
+    # TODO: RUSTPYTHON
+    @unittest.expectedFailure
+    @unittest.skipUnless(time._STRUCT_TM_ITEMS == 11, "needs tm_zone support")
     def test_strptime_timezone(self):
         t = time.strptime("UTC", "%Z")
         self.assertEqual(t.tm_zone, 'UTC')
         t = time.strptime("+0500", "%z")
         self.assertEqual(t.tm_gmtoff, 5 * 3600)
     
-    @unittest.skip("TODO: RUSTPYTHON, AttributeError: module 'time' has no attribute '_STRUCT_TM_ITEMS'")
-    # @unittest.skipUnless(time._STRUCT_TM_ITEMS == 11, "needs tm_zone support")
+    # TODO: RUSTPYTHON
+    @unittest.expectedFailure
+    @unittest.skipUnless(time._STRUCT_TM_ITEMS == 11, "needs tm_zone support")
     def test_short_times(self):
 
         import pickle

--- a/vm/src/stdlib/time.rs
+++ b/vm/src/stdlib/time.rs
@@ -451,7 +451,9 @@ mod decl {
         tm_wday: PyObjectRef,
         tm_yday: PyObjectRef,
         tm_isdst: PyObjectRef,
+        #[pystruct(skip)]
         tm_gmtoff: PyObjectRef,
+        #[pystruct(skip)]
         tm_zone: PyObjectRef,
     }
 

--- a/vm/src/stdlib/time.rs
+++ b/vm/src/stdlib/time.rs
@@ -72,6 +72,9 @@ mod decl {
             .map_err(|e| vm.new_value_error(format!("Time error: {e:?}")))
     }
 
+    #[pyattr]
+    pub const _STRUCT_TM_ITEMS: usize = 11;
+
     // TODO: implement proper monotonic time for wasm/wasi.
     #[cfg(not(any(unix, windows)))]
     fn get_monotonic_time(vm: &VirtualMachine) -> PyResult<Duration> {


### PR DESCRIPTION
Fixes #4982 

Implements the missing`tm_gmtoff` and `tm_zone` fields in PyStructTime struct. 

The original issue's code example does not work in python 3.12. I used this instead for testing:

```py
import datetime
sgtTimeDelta = datetime.timedelta(hours=5)
sgtTZObject = datetime.timezone(sgtTimeDelta,
                                name="EST")
print(datetime.datetime(3001, 1, 19, 7, 59, 59, 999999, sgtTZObject).astimezone())
```