### PR TITLE
Add get/set methods for function doc/module/annotations

### DIFF
--- a/vm/src/builtins/function.rs
+++ b/vm/src/builtins/function.rs
@@ -415,14 +415,19 @@ impl PyFunction {
         *self.name.lock() = name;
     }
 
-    #[pygetset(magic)]
-    fn doc(&self) -> PyObjectRef {
-        self.doc.lock().clone()
+    #[pymember(magic)]
+    fn doc(_vm: &VirtualMachine, zelf: PyObjectRef) -> PyResult {
+        let zelf: PyRef<PyFunction> = zelf.downcast().unwrap_or_else(|_| unreachable!());
+        let doc = zelf.doc.lock();
+        Ok(doc.clone())
     }
 
-    #[pygetset(magic, setter)]
-    fn set_doc(&self, doc: PyObjectRef) {
-        *self.doc.lock() = doc
+    #[pymember(magic, setter)]
+    fn set_doc(vm: &VirtualMachine, zelf: PyObjectRef, value: PySetterValue) -> PyResult<()> {
+        let zelf: PyRef<PyFunction> = zelf.downcast().unwrap_or_else(|_| unreachable!());
+        let value = value.unwrap_or_none(vm);
+        *zelf.doc.lock() = value;
+        Ok(())
     }
 
     #[pygetset(magic)]

--- a/vm/src/builtins/function.rs
+++ b/vm/src/builtins/function.rs
@@ -52,6 +52,7 @@ unsafe impl Traverse for PyFunction {
 }
 
 impl PyFunction {
+    #[allow(clippy::too_many_arguments)]
     pub(crate) fn new(
         code: PyRef<PyCode>,
         globals: PyDictRef,

--- a/vm/src/builtins/function.rs
+++ b/vm/src/builtins/function.rs
@@ -437,8 +437,8 @@ impl PyFunction {
     }
 
     #[pygetset(magic, setter)]
-    fn set_module(&self, module: PyObjectRef) {
-        *self.module.lock() = module
+    fn set_module(&self, module: PySetterValue<PyObjectRef>, vm: &VirtualMachine) {
+        *self.module.lock() = module.unwrap_or_none(vm);
     }
 
     #[pygetset(magic)]

--- a/vm/src/builtins/function.rs
+++ b/vm/src/builtins/function.rs
@@ -1,7 +1,10 @@
 #[cfg(feature = "jit")]
 mod jitfunc;
 
-use super::{tuple::PyTupleTyped, PyAsyncGen, PyCode, PyCoroutine, PyDictRef, PyGenerator, PyStr, PyStrRef, PyTupleRef, PyType, PyTypeRef};
+use super::{
+    tuple::PyTupleTyped, PyAsyncGen, PyCode, PyCoroutine, PyDictRef, PyGenerator, PyStr, PyStrRef,
+    PyTupleRef, PyType, PyTypeRef,
+};
 #[cfg(feature = "jit")]
 use crate::common::lock::OnceCell;
 use crate::common::lock::PyMutex;

--- a/vm/src/frame.rs
+++ b/vm/src/frame.rs
@@ -1731,6 +1731,8 @@ impl ExecutingFrame<'_> {
             None
         };
 
+        let module = vm.unwrap_or_none(self.globals.get_item_opt(identifier!(vm, __name__), vm)?);
+
         // pop argc arguments
         // argument: name, args, globals
         // let scope = self.scope.clone();
@@ -1742,17 +1744,15 @@ impl ExecutingFrame<'_> {
             kw_only_defaults,
             qualified_name.clone(),
             type_params,
+            annotations.downcast().unwrap(),
+            module,
+            vm.ctx.none(),
         )
         .into_pyobject(vm);
-
-        func_obj.set_attr(identifier!(vm, __doc__), vm.ctx.none(), vm)?;
 
         let name = qualified_name.as_str().split('.').next_back().unwrap();
         func_obj.set_attr(identifier!(vm, __name__), vm.new_pyobj(name), vm)?;
         func_obj.set_attr(identifier!(vm, __qualname__), qualified_name, vm)?;
-        let module = vm.unwrap_or_none(self.globals.get_item_opt(identifier!(vm, __name__), vm)?);
-        func_obj.set_attr(identifier!(vm, __module__), module, vm)?;
-        func_obj.set_attr(identifier!(vm, __annotations__), annotations, vm)?;
 
         self.push_value(func_obj);
         Ok(None)

--- a/vm/src/frame.rs
+++ b/vm/src/frame.rs
@@ -1753,6 +1753,7 @@ impl ExecutingFrame<'_> {
         let name = qualified_name.as_str().split('.').next_back().unwrap();
         func_obj.set_attr(identifier!(vm, __name__), vm.new_pyobj(name), vm)?;
         func_obj.set_attr(identifier!(vm, __qualname__), qualified_name, vm)?;
+        func_obj.set_attr(identifier!(vm, __doc__), vm.ctx.none(), vm)?;
 
         self.push_value(func_obj);
         Ok(None)


### PR DESCRIPTION
WIP

this adds getter and setter for the `doc`, `module` and `annotations` magic attributes for the python function objects.

`module` and `annotations` work without trouble. `doc` is different. The getter and setter were never called until i commented the line `class.set_attr(identifier!(ctx, __doc__), ctx.new_str(doc).into());` in `vm/src/class.rs`.

This will probably break other stuff. But it gets me closer to the goal.

Details

see this python code

```python
def foo():
    """doc string"""

print(foo.__dict__)
```

Output:

- CPython: `{}` - empty dict
- before PR: `{'__doc__': 'doc string', '__module__': '__main__', '__annotations__': {}}`
- without "fix" in `vm/src/class.rs`: `{'__doc__': 'doc string'}`
- with "fix": `{}` - empty dict

Any ideas how to fix this correctly?