### PR TITLE
Fix copysign behavior for NaNs

### DIFF
--- a/Lib/test/test_complex.py
+++ b/Lib/test/test_complex.py
@@ -568,8 +568,6 @@ class ComplexTest(unittest.TestCase):
                     self.assertFloatsAreIdentical(z.real, x)
                     self.assertFloatsAreIdentical(z.imag, y)
 
-    # TODO: RUSTPYTHON
-    @unittest.expectedFailure
     def test_constructor_negative_nans_from_string(self):
         self.assertEqual(copysign(1., complex("-nan").real), -1.)
         self.assertEqual(copysign(1., complex("-nanj").imag), -1.)

--- a/Lib/test/test_decimal.py
+++ b/Lib/test/test_decimal.py
@@ -2079,8 +2079,6 @@ class UsabilityTest:
         for d, n, r in test_triples:
             self.assertEqual(str(round(Decimal(d), n)), r)
 
-    # TODO: RUSTPYTHON
-    @unittest.expectedFailure
     def test_nan_to_float(self):
         # Test conversions of decimal NANs to float.
         # See http://bugs.python.org/issue15544

--- a/Lib/test/test_float.py
+++ b/Lib/test/test_float.py
@@ -1053,8 +1053,6 @@ class InfNanTest(unittest.TestCase):
         self.assertEqual(copysign(1.0, float('inf')), 1.0)
         self.assertEqual(copysign(1.0, float('-inf')), -1.0)
 
-    # TODO: RUSTPYTHON
-    @unittest.expectedFailure
     @unittest.skipUnless(getattr(sys, 'float_repr_style', '') == 'short',
                          "applies only when using short float repr style")
     def test_nan_signs(self):

--- a/stdlib/src/math.rs
+++ b/stdlib/src/math.rs
@@ -110,11 +110,7 @@ mod math {
 
     #[pyfunction]
     fn copysign(x: ArgIntoFloat, y: ArgIntoFloat) -> f64 {
-        if x.is_nan() || y.is_nan() {
-            x.into()
-        } else {
-            x.copysign(*y)
-        }
+        x.copysign(*y)
     }
 
     // Power and logarithmic functions:


### PR DESCRIPTION
This allows enabling test_constructor_negative_nans_from_string