### PR TITLE
Deprecate delegating int() to __trunc__

### DIFF
--- a/Lib/test/test_long.py
+++ b/Lib/test/test_long.py
@@ -378,8 +378,6 @@ class LongTest(unittest.TestCase):
         self.assertRaises(ValueError, int, '\u3053\u3093\u306b\u3061\u306f')
 
 
-    # TODO: RUSTPYTHON
-    @unittest.expectedFailure
     def test_conversion(self):
 
         class JustLong:

--- a/vm/src/protocol/number.rs
+++ b/vm/src/protocol/number.rs
@@ -63,13 +63,12 @@ impl PyObject {
         } else if let Some(i) = self.to_number().int(vm).or_else(|| self.try_index_opt(vm)) {
             i
         } else if let Ok(Some(f)) = vm.get_special_method(self, identifier!(vm, __trunc__)) {
-            // TODO: Deprecate in 3.11
-            // warnings::warn(
-            //     vm.ctx.exceptions.deprecation_warning.clone(),
-            //     "The delegation of int() to __trunc__ is deprecated.".to_owned(),
-            //     1,
-            //     vm,
-            // )?;
+            warnings::warn(
+                vm.ctx.exceptions.deprecation_warning,
+                "The delegation of int() to __trunc__ is deprecated.".to_owned(),
+                1,
+                vm,
+            )?;
             let ret = f.invoke((), vm)?;
             ret.try_index(vm).map_err(|_| {
                 vm.new_type_error(format!(


### PR DESCRIPTION
Looking at the to-do, it was supposed to be uncommented when switching the target to python 3.11 but was missed.