### PR TITLE
Fix set intersection_update implementation

### DIFF
--- a/Lib/test/test_weakset.py
+++ b/Lib/test/test_weakset.py
@@ -322,8 +322,6 @@ class TestWeakSet(unittest.TestCase):
             else:
                 self.assertNotIn(c, self.s)
 
-    # TODO: RUSTPYTHON
-    @unittest.expectedFailure
     def test_inplace_on_self(self):
         t = self.s.copy()
         t |= t

--- a/vm/src/builtins/set.rs
+++ b/vm/src/builtins/set.rs
@@ -391,16 +391,10 @@ impl PySetInner {
         others: impl std::iter::Iterator<Item = ArgIterable>,
         vm: &VirtualMachine,
     ) -> PyResult<()> {
-        let mut temp_inner = self.copy();
+        let temp_inner = self.fold_op(others, PySetInner::intersection, vm)?;
         self.clear();
-        for iterable in others {
-            for item in iterable.iter(vm)? {
-                let obj = item?;
-                if temp_inner.contains(&obj, vm)? {
-                    self.add(obj, vm)?;
-                }
-            }
-            temp_inner = self.copy()
+        for obj in temp_inner.elements() {
+            self.add(obj, vm)?;
         }
         Ok(())
     }


### PR DESCRIPTION
The previous implementation had multiple bugs:

- self intersection would result in nil set (#3881, #3992 )
- Intersecting {1, 2, 3} in {1} and {2} would result in {1} instead of {}.

The new implementation uses the approach chosen by [cpython](https://github.com/python/cpython/blob/5f011115943933ff36adf997c886d73ea88003fb/Objects/setobject.c#L1481-L1495), i.e., create a normal intersection and then replace `self` with the result.

Allows turning on one test in `test_weakset`. The equivalent test in `test_set` still fails due to some of the other set operations also being buggy on self application.