### PR TITLE
Cache hash value for FrozenSets

### DIFF
--- a/Lib/test/test_set.py
+++ b/Lib/test/test_set.py
@@ -728,15 +728,7 @@ class TestFrozenSet(TestJointOps, unittest.TestCase):
             for i in range(len(s)+1):
                 yield from map(frozenset, itertools.combinations(s, i))
 
-        # TODO: RUSTPYTHON
-        # The original test has:
-        # for n in range(18):
-        # Due to general performance overhead, hashing a frozenset takes
-        # about 50 times longer than in CPython. This test amplifies that
-        # exponentially, so the best we can do here reasonably is 13.
-        # Even if the internal hash function did nothing, it would still be
-        # about 40 times slower than CPython.
-        for n in range(13):
+        for n in range(18):
             t = 2 ** n
             mask = t - 1
             for nums in (range, zf_range):


### PR DESCRIPTION
Adds a hash field to the `PyFrozenSet` data type in order to avoid recomputing the hash of an immutable object.

Similar to the way it's done in [cpython](https://github.com/python/cpython/blob/5f011115943933ff36adf997c886d73ea88003fb/Objects/setobject.c#L761-L774) but the hash value is stored in the PyFrozenSet struct instead of the inner Set datatype.

Massively speeds up the `test_hash_effectiveness` test and allows using the same limit of 2**18 elements on the test as cpython.

RustPython is still about 5x slower than python at running this test (0.5s vs 2.5s on my machine).

Of course, in practical use cases repeatedly hashing the same frozenset is not common so I doubt this is a performance win in general. Just adding this to be consistent with cpython.

Fixes #5167 