### PR TITLE
Fix inconsistent behavior of Decimal.from_float

### DIFF
--- a/Lib/_pydecimal.py
+++ b/Lib/_pydecimal.py
@@ -734,18 +734,23 @@ class Decimal(object):
 
         """
         if isinstance(f, int):                # handle integer inputs
-            return cls(f)
-        if not isinstance(f, float):
-            raise TypeError("argument must be int or float.")
-        if _math.isinf(f) or _math.isnan(f):
-            return cls(repr(f))
-        if _math.copysign(1.0, f) == 1.0:
-            sign = 0
+            sign = 0 if f >= 0 else 1
+            k = 0
+            coeff = str(abs(f))
+        elif isinstance(f, float):
+            if _math.isinf(f) or _math.isnan(f):
+                return cls(repr(f))
+            if _math.copysign(1.0, f) == 1.0:
+                sign = 0
+            else:
+                sign = 1
+            n, d = abs(f).as_integer_ratio()
+            k = d.bit_length() - 1
+            coeff = str(n*5**k)
         else:
-            sign = 1
-        n, d = abs(f).as_integer_ratio()
-        k = d.bit_length() - 1
-        result = _dec_from_triple(sign, str(n*5**k), -k)
+            raise TypeError("argument must be int or float.")
+
+        result = _dec_from_triple(sign, coeff, -k)
         if cls is Decimal:
             return result
         else:

--- a/Lib/test/test_decimal.py
+++ b/Lib/test/test_decimal.py
@@ -1257,8 +1257,6 @@ class FormatTest:
         self.assertEqual(format(Decimal('100000000.123'), 'n'),
                          '100\u066c000\u066c000\u066b123')
 
-    # TODO: RUSTPYTHON
-    @unittest.expectedFailure
     def test_decimal_from_float_argument_type(self):
         class A(self.decimal.Decimal):
             def __init__(self, a):


### PR DESCRIPTION
Rustpython includes the test added in https://github.com/python/cpython/pull/65, but not the behavior, leading to the test being disabled. This patches RustPython with the above pr  to update `from_float` behavior when passed an int in order to pass the test.