### PR TITLE
Remove dependency on uuid-macro-internal

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3035,18 +3035,6 @@ dependencies = [
  "atomic",
  "getrandom",
  "rand",
- "uuid-macro-internal",
-]
-
-[[package]]
-name = "uuid-macro-internal"
-version = "1.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c1b300a878652a387d2a0de915bdae8f1a548f0c6d45e072fe2688794b656cc9"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 1.0.109",
 ]
 
 [[package]]

--- a/stdlib/Cargo.toml
+++ b/stdlib/Cargo.toml
@@ -88,7 +88,7 @@ bzip2 = { version = "0.4", optional = true }
 # uuid
 [target.'cfg(not(any(target_os = "ios", target_os = "android", target_os = "windows", target_arch = "wasm32", target_os = "redox")))'.dependencies]
 mac_address = "1.1.3"
-uuid = { version = "1.1.2", features = ["v1", "fast-rng", "macro-diagnostics"] }
+uuid = { version = "1.1.2", features = ["v1", "fast-rng"] }
 
 # mmap
 [target.'cfg(all(unix, not(target_arch = "wasm32")))'.dependencies]


### PR DESCRIPTION
`uuid-macro-internal` is only relevant when using `uuid!` macro to parse uuids at compile time. RustPython doesn't do that so it's unnecessary.