### PR TITLE
Make stdio a feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,9 +10,10 @@ repository.workspace = true
 license.workspace = true
 
 [features]
-default = ["threading", "stdlib", "zlib", "importlib"]
+default = ["threading", "stdlib", "stdio", "zlib", "importlib"]
 importlib = ["rustpython-vm/importlib"]
 encodings = ["rustpython-vm/encodings"]
+stdio = ["rustpython-vm/stdio"]
 stdlib = ["rustpython-stdlib", "rustpython-pylib", "encodings"]
 flame-it = ["rustpython-vm/flame-it", "flame", "flamescope"]
 freeze-stdlib = ["stdlib", "rustpython-vm/freeze-stdlib", "rustpython-pylib?/freeze-stdlib"]

--- a/vm/Cargo.toml
+++ b/vm/Cargo.toml
@@ -10,7 +10,8 @@ repository.workspace = true
 license.workspace = true
 
 [features]
-default = ["compiler", "wasmbind"]
+default = ["compiler", "wasmbind", "stdio"]
+stdio = []
 importlib = []
 encodings = ["importlib"]
 vm-tracing-logging = []


### PR DESCRIPTION
When embedding RustPython into a graphical windows application (where windows_subsystem = "windows"), it fails to create the RustPython VM.

This happens because the VM will try to open stdin/stdout/stderr when initializing, but stdio isn't available for /SUBSYSTEM:WINDOWS apps.

This commit makes stdio a feature, so it can be disabled when needed.

https://doc.rust-lang.org/reference/runtime.html#the-windows_subsystem-attribute
https://learn.microsoft.com/en-us/cpp/build/reference/subsystem-specify-subsystem?view=msvc-170 https://asawicki.info/news_1768_ways_to_print_and_capture_text_output_of_a_process