### PR TITLE
Fix compile error when using `vm-tracing-logging`

### DIFF
--- a/vm/src/frame.rs
+++ b/vm/src/frame.rs
@@ -382,7 +382,7 @@ impl ExecutingFrame<'_> {
                         let next = exception.traceback();
                         let new_traceback =
                             PyTraceback::new(next, frame.object.to_owned(), frame.lasti(), loc.row);
-                        vm_trace!("Adding to traceback: {:?} {:?}", new_traceback, loc.row());
+                        vm_trace!("Adding to traceback: {:?} {:?}", new_traceback, loc.row);
                         exception.set_traceback(Some(new_traceback.into_ref(&vm.ctx)));
 
                         vm.contextualize_exception(&exception);

--- a/vm/src/protocol/callable.rs
+++ b/vm/src/protocol/callable.rs
@@ -24,16 +24,17 @@ impl PyObject {
 
     /// PyObject_Call
     pub fn call_with_args(&self, args: FuncArgs, vm: &VirtualMachine) -> PyResult {
-        vm_trace!("Invoke: {:?} {:?}", callable, args);
         let Some(callable) = self.to_callable() else {
             return Err(
                 vm.new_type_error(format!("'{}' object is not callable", self.class().name()))
             );
         };
+        vm_trace!("Invoke: {:?} {:?}", callable, args);
         callable.invoke(args, vm)
     }
 }
 
+#[derive(Debug)]
 pub struct PyCallable<'a> {
     pub obj: &'a PyObject,
     pub call: GenericMethod,


### PR DESCRIPTION
While trying to fix https://github.com/RustPython/RustPython/issues/5355, I stumbled upon a compile error when the `vm-tracing-logging` feature is enabled.

This PR fixes the above mentioned compile error.

One other thing that came up, is that [/vm/src/protocol/object.rs#L172 ](https://github.com/RustPython/RustPython/blob/98d09e781623ccec64643cf5412453cc78ba4f18/vm/src/protocol/object.rs#L172) generates very long traces and I think that it would be a good idea to use another format since it prints all the data of `self` and `value`.