### PR TITLE
Move log message to the debug level

### DIFF
--- a/vm/src/frame.rs
+++ b/vm/src/frame.rs
@@ -1534,7 +1534,7 @@ impl ExecutingFrame<'_> {
                 .topmost_exception()
                 .ok_or_else(|| vm.new_runtime_error("No active exception to reraise".to_owned()))?,
         };
-        info!("Exception raised: {:?} with cause: {:?}", exception, cause);
+        debug!("Exception raised: {:?} with cause: {:?}", exception, cause);
         if let Some(cause) = cause {
             exception.set_cause(cause);
         }


### PR DESCRIPTION
When embedding and using logging facility, this log message interferes and pollutes the log with useless information. Specifically, this happens on `vm.run_code_obj(obj, scope)`. Example:

```text
[26/11/2024 21:15:47] - INFO: Exception raised: PyBaseException with cause: None
[26/11/2024 21:15:47] - INFO: Exception raised: PyBaseException with cause: None
[26/11/2024 21:15:47] - INFO: Exception raised: PyBaseException with cause: None
[26/11/2024 21:15:47] - INFO: Exception raised: PyBaseException with cause: None
[26/11/2024 21:15:47] - INFO: Exception raised: PyBaseException with cause: None
[26/11/2024 21:15:47] - INFO: Exception raised: PyBaseException with cause: None
[26/11/2024 21:15:47] - INFO: Exception raised: PyBaseException with cause: None
[26/11/2024 21:15:47] - INFO: Exception raised: PyBaseException with cause: None
[26/11/2024 21:15:47] - INFO: Exception raised: PyBaseException with cause: None
```

While there _probably_ is a reason for it, it still should be moved to either ERROR/WARNING level with a clear indication what's wrong, or moved to the debug level.