### PR TITLE
Resolve lint fails w rust 1.83 clippy

### DIFF
--- a/common/src/boxvec.rs
+++ b/common/src/boxvec.rs
@@ -468,8 +468,8 @@ pub struct Drain<'a, T> {
     vec: ptr::NonNull<BoxVec<T>>,
 }
 
-unsafe impl<'a, T: Sync> Sync for Drain<'a, T> {}
-unsafe impl<'a, T: Sync> Send for Drain<'a, T> {}
+unsafe impl<T: Sync> Sync for Drain<'_, T> {}
+unsafe impl<T: Sync> Send for Drain<'_, T> {}
 
 impl<T> Iterator for Drain<'_, T> {
     type Item = T;

--- a/common/src/linked_list.rs
+++ b/common/src/linked_list.rs
@@ -293,7 +293,7 @@ impl<T: Link> LinkedList<T, T::Target> {
     }
 }
 
-impl<'a, T, F> Iterator for DrainFilter<'a, T, F>
+impl<T, F> Iterator for DrainFilter<'_, T, F>
 where
     T: Link,
     F: FnMut(&mut T::Target) -> bool,

--- a/common/src/lock/immutable_mutex.rs
+++ b/common/src/lock/immutable_mutex.rs
@@ -45,7 +45,7 @@ impl<'a, R: RawMutex, T: ?Sized> ImmutableMappedMutexGuard<'a, R, T> {
     }
 }
 
-impl<'a, R: RawMutex, T: ?Sized> Deref for ImmutableMappedMutexGuard<'a, R, T> {
+impl<R: RawMutex, T: ?Sized> Deref for ImmutableMappedMutexGuard<'_, R, T> {
     type Target = T;
     fn deref(&self) -> &Self::Target {
         // SAFETY: self.data is valid for the lifetime of the guard
@@ -53,22 +53,20 @@ impl<'a, R: RawMutex, T: ?Sized> Deref for ImmutableMappedMutexGuard<'a, R, T> {
     }
 }
 
-impl<'a, R: RawMutex, T: ?Sized> Drop for ImmutableMappedMutexGuard<'a, R, T> {
+impl<R: RawMutex, T: ?Sized> Drop for ImmutableMappedMutexGuard<'_, R, T> {
     fn drop(&mut self) {
         // SAFETY: An ImmutableMappedMutexGuard always holds the lock
         unsafe { self.raw.unlock() }
     }
 }
 
-impl<'a, R: RawMutex, T: fmt::Debug + ?Sized> fmt::Debug for ImmutableMappedMutexGuard<'a, R, T> {
+impl<R: RawMutex, T: fmt::Debug + ?Sized> fmt::Debug for ImmutableMappedMutexGuard<'_, R, T> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         fmt::Debug::fmt(&**self, f)
     }
 }
 
-impl<'a, R: RawMutex, T: fmt::Display + ?Sized> fmt::Display
-    for ImmutableMappedMutexGuard<'a, R, T>
-{
+impl<R: RawMutex, T: fmt::Display + ?Sized> fmt::Display for ImmutableMappedMutexGuard<'_, R, T> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         fmt::Display::fmt(&**self, f)
     }

--- a/common/src/lock/thread_mutex.rs
+++ b/common/src/lock/thread_mutex.rs
@@ -192,31 +192,31 @@ impl<'a, R: RawMutex, G: GetThreadId, T: ?Sized> ThreadMutexGuard<'a, R, G, T> {
         }
     }
 }
-impl<'a, R: RawMutex, G: GetThreadId, T: ?Sized> Deref for ThreadMutexGuard<'a, R, G, T> {
+impl<R: RawMutex, G: GetThreadId, T: ?Sized> Deref for ThreadMutexGuard<'_, R, G, T> {
     type Target = T;
     fn deref(&self) -> &T {
         unsafe { &*self.mu.data.get() }
     }
 }
-impl<'a, R: RawMutex, G: GetThreadId, T: ?Sized> DerefMut for ThreadMutexGuard<'a, R, G, T> {
+impl<R: RawMutex, G: GetThreadId, T: ?Sized> DerefMut for ThreadMutexGuard<'_, R, G, T> {
     fn deref_mut(&mut self) -> &mut T {
         unsafe { &mut *self.mu.data.get() }
     }
 }
-impl<'a, R: RawMutex, G: GetThreadId, T: ?Sized> Drop for ThreadMutexGuard<'a, R, G, T> {
+impl<R: RawMutex, G: GetThreadId, T: ?Sized> Drop for ThreadMutexGuard<'_, R, G, T> {
     fn drop(&mut self) {
         unsafe { self.mu.raw.unlock() }
     }
 }
-impl<'a, R: RawMutex, G: GetThreadId, T: ?Sized + fmt::Display> fmt::Display
-    for ThreadMutexGuard<'a, R, G, T>
+impl<R: RawMutex, G: GetThreadId, T: ?Sized + fmt::Display> fmt::Display
+    for ThreadMutexGuard<'_, R, G, T>
 {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         fmt::Display::fmt(&**self, f)
     }
 }
-impl<'a, R: RawMutex, G: GetThreadId, T: ?Sized + fmt::Debug> fmt::Debug
-    for ThreadMutexGuard<'a, R, G, T>
+impl<R: RawMutex, G: GetThreadId, T: ?Sized + fmt::Debug> fmt::Debug
+    for ThreadMutexGuard<'_, R, G, T>
 {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         fmt::Debug::fmt(&**self, f)
@@ -259,31 +259,31 @@ impl<'a, R: RawMutex, G: GetThreadId, T: ?Sized> MappedThreadMutexGuard<'a, R, G
         }
     }
 }
-impl<'a, R: RawMutex, G: GetThreadId, T: ?Sized> Deref for MappedThreadMutexGuard<'a, R, G, T> {
+impl<R: RawMutex, G: GetThreadId, T: ?Sized> Deref for MappedThreadMutexGuard<'_, R, G, T> {
     type Target = T;
     fn deref(&self) -> &T {
         unsafe { self.data.as_ref() }
     }
 }
-impl<'a, R: RawMutex, G: GetThreadId, T: ?Sized> DerefMut for MappedThreadMutexGuard<'a, R, G, T> {
+impl<R: RawMutex, G: GetThreadId, T: ?Sized> DerefMut for MappedThreadMutexGuard<'_, R, G, T> {
     fn deref_mut(&mut self) -> &mut T {
         unsafe { self.data.as_mut() }
     }
 }
-impl<'a, R: RawMutex, G: GetThreadId, T: ?Sized> Drop for MappedThreadMutexGuard<'a, R, G, T> {
+impl<R: RawMutex, G: GetThreadId, T: ?Sized> Drop for MappedThreadMutexGuard<'_, R, G, T> {
     fn drop(&mut self) {
         unsafe { self.mu.unlock() }
     }
 }
-impl<'a, R: RawMutex, G: GetThreadId, T: ?Sized + fmt::Display> fmt::Display
-    for MappedThreadMutexGuard<'a, R, G, T>
+impl<R: RawMutex, G: GetThreadId, T: ?Sized + fmt::Display> fmt::Display
+    for MappedThreadMutexGuard<'_, R, G, T>
 {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         fmt::Display::fmt(&**self, f)
     }
 }
-impl<'a, R: RawMutex, G: GetThreadId, T: ?Sized + fmt::Debug> fmt::Debug
-    for MappedThreadMutexGuard<'a, R, G, T>
+impl<R: RawMutex, G: GetThreadId, T: ?Sized + fmt::Debug> fmt::Debug
+    for MappedThreadMutexGuard<'_, R, G, T>
 {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         fmt::Debug::fmt(&**self, f)

--- a/jit/src/lib.rs
+++ b/jit/src/lib.rs
@@ -341,7 +341,7 @@ pub struct Args<'a> {
     code: &'a CompiledCode,
 }
 
-impl<'a> Args<'a> {
+impl Args<'_> {
     pub fn invoke(&self) -> Option<AbiValue> {
         unsafe { self.code.invoke_raw(&self.cif_args) }
     }

--- a/stdlib/src/posixsubprocess.rs
+++ b/stdlib/src/posixsubprocess.rs
@@ -113,7 +113,7 @@ struct CharPtrSlice<'a> {
     slice: [*const libc::c_char],
 }
 
-impl<'a> CharPtrSlice<'a> {
+impl CharPtrSlice<'_> {
     fn as_ptr(&self) -> *const *const libc::c_char {
         self.slice.as_ptr()
     }

--- a/stdlib/src/sqlite.rs
+++ b/stdlib/src/sqlite.rs
@@ -1026,7 +1026,7 @@ mod _sqlite {
                 name_cstring = name.to_cstring(vm)?;
                 name_cstring.as_ptr()
             } else {
-                b"main\0".as_ptr().cast()
+                c"main".as_ptr().cast()
             };
 
             let sleep_ms = (sleep * 1000.0) as c_int;
@@ -1035,7 +1035,7 @@ mod _sqlite {
             let target_db = target.db_lock(vm)?;
 
             let handle = unsafe {
-                sqlite3_backup_init(target_db.db, b"main\0".as_ptr().cast(), db.db, name_ptr)
+                sqlite3_backup_init(target_db.db, c"main".as_ptr().cast(), db.db, name_ptr)
             };
 
             if handle.is_null() {

--- a/stdlib/src/sqlite.rs
+++ b/stdlib/src/sqlite.rs
@@ -1004,7 +1004,9 @@ mod _sqlite {
             )
         }
 
+        // TODO: Make it build without clippy::manual_c_str_literals
         #[pymethod]
+        #[allow(clippy::manual_c_str_literals)]
         fn backup(zelf: &Py<Self>, args: BackupArgs, vm: &VirtualMachine) -> PyResult<()> {
             let BackupArgs {
                 target,
@@ -1026,7 +1028,7 @@ mod _sqlite {
                 name_cstring = name.to_cstring(vm)?;
                 name_cstring.as_ptr()
             } else {
-                c"main".as_ptr().cast()
+                b"main\0".as_ptr().cast()
             };
 
             let sleep_ms = (sleep * 1000.0) as c_int;
@@ -1035,7 +1037,7 @@ mod _sqlite {
             let target_db = target.db_lock(vm)?;
 
             let handle = unsafe {
-                sqlite3_backup_init(target_db.db, c"main".as_ptr().cast(), db.db, name_ptr)
+                sqlite3_backup_init(target_db.db, b"main\0".as_ptr().cast(), db.db, name_ptr)
             };
 
             if handle.is_null() {

--- a/stdlib/src/ssl.rs
+++ b/stdlib/src/ssl.rs
@@ -1503,7 +1503,7 @@ mod bio {
 
     pub struct MemBioSlice<'a>(*mut sys::BIO, PhantomData<&'a [u8]>);
 
-    impl<'a> Drop for MemBioSlice<'a> {
+    impl Drop for MemBioSlice<'_> {
         fn drop(&mut self) {
             unsafe {
                 sys::BIO_free_all(self.0);

--- a/vm/src/object/ext.rs
+++ b/vm/src/object/ext.rs
@@ -500,21 +500,21 @@ pub struct PyLease<'a, T: PyObjectPayload> {
     inner: PyRwLockReadGuard<'a, PyRef<T>>,
 }
 
-impl<'a, T: PyObjectPayload + PyPayload> PyLease<'a, T> {
+impl<T: PyObjectPayload + PyPayload> PyLease<'_, T> {
     #[inline(always)]
     pub fn into_owned(self) -> PyRef<T> {
         self.inner.clone()
     }
 }
 
-impl<'a, T: PyObjectPayload + PyPayload> Borrow<PyObject> for PyLease<'a, T> {
+impl<T: PyObjectPayload + PyPayload> Borrow<PyObject> for PyLease<'_, T> {
     #[inline(always)]
     fn borrow(&self) -> &PyObject {
         self.inner.as_ref()
     }
 }
 
-impl<'a, T: PyObjectPayload + PyPayload> Deref for PyLease<'a, T> {
+impl<T: PyObjectPayload + PyPayload> Deref for PyLease<'_, T> {
     type Target = PyRef<T>;
     #[inline(always)]
     fn deref(&self) -> &Self::Target {
@@ -522,7 +522,7 @@ impl<'a, T: PyObjectPayload + PyPayload> Deref for PyLease<'a, T> {
     }
 }
 
-impl<'a, T> fmt::Display for PyLease<'a, T>
+impl<T> fmt::Display for PyLease<'_, T>
 where
     T: PyPayload + fmt::Display,
 {

--- a/vm/src/ospath.rs
+++ b/vm/src/ospath.rs
@@ -179,7 +179,7 @@ impl<'a> IOErrorBuilder<'a> {
     }
 }
 
-impl<'a> ToPyException for IOErrorBuilder<'a> {
+impl ToPyException for IOErrorBuilder<'_> {
     fn to_pyexception(&self, vm: &VirtualMachine) -> PyBaseExceptionRef {
         let excp = self.error.to_pyexception(vm);
 

--- a/vm/src/protocol/iter.rs
+++ b/vm/src/protocol/iter.rs
@@ -229,7 +229,7 @@ where
     _phantom: std::marker::PhantomData<T>,
 }
 
-unsafe impl<'a, T, O> Traverse for PyIterIter<'a, T, O>
+unsafe impl<T, O> Traverse for PyIterIter<'_, T, O>
 where
     O: Traverse + Borrow<PyObject>,
 {
@@ -252,7 +252,7 @@ where
     }
 }
 
-impl<'a, T, O> Iterator for PyIterIter<'a, T, O>
+impl<T, O> Iterator for PyIterIter<'_, T, O>
 where
     T: TryFromObject,
     O: Borrow<PyObject>,

--- a/vm/src/protocol/number.rs
+++ b/vm/src/protocol/number.rs
@@ -432,7 +432,7 @@ unsafe impl Traverse for PyNumber<'_> {
     }
 }
 
-impl<'a> Deref for PyNumber<'a> {
+impl Deref for PyNumber<'_> {
     type Target = PyObject;
 
     fn deref(&self) -> &Self::Target {

--- a/vm/src/py_serde.rs
+++ b/vm/src/py_serde.rs
@@ -22,7 +22,7 @@ where
 pub fn deserialize<'de, D>(
     vm: &'de VirtualMachine,
     deserializer: D,
-) -> Result<<PyObjectDeserializer as DeserializeSeed>::Value, D::Error>
+) -> Result<<PyObjectDeserializer<'de> as DeserializeSeed<'de>>::Value, D::Error>
 where
     D: serde::Deserializer<'de>,
 {
@@ -49,7 +49,7 @@ impl<'s> PyObjectSerializer<'s> {
     }
 }
 
-impl<'s> serde::Serialize for PyObjectSerializer<'s> {
+impl serde::Serialize for PyObjectSerializer<'_> {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
     where
         S: serde::Serializer,

--- a/vm/src/recursion.rs
+++ b/vm/src/recursion.rs
@@ -23,7 +23,7 @@ impl<'vm> ReprGuard<'vm> {
     }
 }
 
-impl<'vm> Drop for ReprGuard<'vm> {
+impl Drop for ReprGuard<'_> {
     fn drop(&mut self) {
         self.vm.repr_guards.borrow_mut().remove(&self.id);
     }

--- a/vm/src/stdlib/codecs.rs
+++ b/vm/src/stdlib/codecs.rs
@@ -107,7 +107,7 @@ mod _codecs {
             PyStr::is_ascii(self)
         }
     }
-    impl<'vm> encodings::ErrorHandler for ErrorsHandler<'vm> {
+    impl encodings::ErrorHandler for ErrorsHandler<'_> {
         type Error = PyBaseExceptionRef;
         type StrBuf = PyStrRef;
         type BytesBuf = PyBytesRef;

--- a/vm/sre_engine/src/engine.rs
+++ b/vm/sre_engine/src/engine.rs
@@ -236,7 +236,7 @@ pub struct SearchIter<'a, S: StrDrive> {
     pub state: State,
 }
 
-impl<'a, S: StrDrive> Iterator for SearchIter<'a, S> {
+impl<S: StrDrive> Iterator for SearchIter<'_, S> {
     type Item = ();
 
     fn next(&mut self) -> Option<Self::Item> {

--- a/vm/sre_engine/src/string.rs
+++ b/vm/sre_engine/src/string.rs
@@ -25,7 +25,7 @@ pub trait StrDrive: Copy {
     fn back_skip(cursor: &mut StringCursor, n: usize);
 }
 
-impl<'a> StrDrive for &'a [u8] {
+impl StrDrive for &[u8] {
     #[inline]
     fn count(&self) -> usize {
         self.len()


### PR DESCRIPTION
Since new version of rust 1.83 released, clippy lint rules are also updated. 
It makes CI broen. 
Most of them is related to 
1. Some lifetimes are newly elided.
2. c str literal is recommended. 

I think there are various change of result in test, I will try them later. 
This PR is only for lint problem. 