### PR TITLE
Add GitHub Binary Release Pipeline for RustPython

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -57,10 +57,10 @@ jobs:
         if: runner.os == 'macOS'
 
       - name: Build RustPython
-        run: cargo build --release --verbose --features=threading ${{ env.CARGO_ARGS }}
+        run: cargo build --release --target=${{ matrix.platform.target }} --verbose --features=threading ${{ env.CARGO_ARGS }}
         if: runner.os == 'macOS'
       - name: Build RustPython
-        run: cargo build --release --verbose --features=threading ${{ env.CARGO_ARGS }},jit
+        run: cargo build --release --target=${{ matrix.platform.target }} --verbose --features=threading ${{ env.CARGO_ARGS }},jit
         if: runner.os != 'macOS'
 
       - name: Rename Binary

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,6 +1,6 @@
 on:
   push:
-    branches: [gh-rel-rustpython]
+    branches: [main]
 
 name: Release
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,26 +18,26 @@ jobs:
         platform:
           - runner: ubuntu-latest
             target: x86_64-unknown-linux-gnu
-          - runner: ubuntu-latest
-            target: i686-unknown-linux-gnu
-          - runner: ubuntu-latest
-            target: aarch64-unknown-linux-gnu
-          - runner: ubuntu-latest
-            target: armv7-unknown-linux-gnueabi
-          - runner: ubuntu-latest
-            target: s390x-unknown-linux-gnu
-          - runner: ubuntu-latest
-            target: powerpc64le-unknown-linux-gnu
+#          - runner: ubuntu-latest
+#            target: i686-unknown-linux-gnu
+#          - runner: ubuntu-latest
+#            target: aarch64-unknown-linux-gnu
+#          - runner: ubuntu-latest
+#            target: armv7-unknown-linux-gnueabi
+#          - runner: ubuntu-latest
+#            target: s390x-unknown-linux-gnu
+#          - runner: ubuntu-latest
+#            target: powerpc64le-unknown-linux-gnu
           - runner: macos-latest
             target: aarch64-apple-darwin
-          - runner: macos-latest
-            target: x86_64-apple-darwin
+#          - runner: macos-latest
+#            target: x86_64-apple-darwin
           - runner: windows-latest
             target: x86_64-pc-windows-msvc
-          - runner: windows-latest
-            target: i686-pc-windows-msvc
-          - runner: windows-latest
-            target: aarch64-pc-windows-msvc
+#          - runner: windows-latest
+#            target: i686-pc-windows-msvc
+#          - runner: windows-latest
+#            target: aarch64-pc-windows-msvc
       fail-fast: false
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,6 +1,6 @@
 on:
   push:
-    branches: [main]
+    branches: [gh-rel-rustpython]
 
 name: Release
 
@@ -101,5 +101,6 @@ jobs:
           gh release create "$today-$tag-$run" \
               --repo="$GITHUB_REPOSITORY" \
               --title="RustPython Release $today-$tag #$run" \
+              --target="$tag" \
               --generate-notes \
               bin/rustpython-release-*

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,6 +1,6 @@
 on:
   push:
-    branches: [main]
+    branches: [gh-rel-rustpython]
 
 name: Release
 
@@ -67,14 +67,14 @@ jobs:
         run: cp target/${{ matrix.platform.target }}/release/rustpython target/rustpython-release-${{ runner.os }}-${{ matrix.platform.target }}
         if: runner.os != 'Windows'
       - name: Rename Binary
-        run: cp target/${{ matrix.platform.target }}/release/rustpython.exe target/rustpython-release-${{ runner.os }}-${{ matrix.platform.target }}
+        run: cp target/${{ matrix.platform.target }}/release/rustpython.exe target/rustpython-release-${{ runner.os }}-${{ matrix.platform.target }}.exe
         if: runner.os == 'Windows'
 
       - name: Upload Binary Artifacts
         uses: actions/upload-artifact@v4
         with:
           name: rustpython-release-${{ runner.os }}-${{ matrix.platform.target }}
-          path: target/rustpython-release-${{ runner.os }}-${{ matrix.platform.target }}
+          path: target/rustpython-release-${{ runner.os }}-${{ matrix.platform.target }}*
 
   release:
     runs-on: ubuntu-latest

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,78 @@
+on:
+  push:
+    branches: [main]
+
+name: Release
+
+permissions:
+  contents: write
+
+env:
+  CARGO_ARGS: --no-default-features --features stdlib,zlib,importlib,encodings,sqlite,ssl
+
+jobs:
+  build:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ macos-latest, ubuntu-latest, windows-latest ]
+      fail-fast: false
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+
+      - name: Set up Windows Environment
+        shell: bash
+        run: |
+          cargo install --target-dir=target -v cargo-vcpkg
+          cargo vcpkg -v build
+        if: runner.os == 'Windows'
+      - name: Set up MacOS Environment
+        run: brew install autoconf automake libtool
+        if: runner.os == 'macOS'
+
+      - name: Build RustPython
+        run: cargo build --release --verbose --features=threading ${{ env.CARGO_ARGS }}
+        if: runner.os == 'macOS'
+      - name: Build RustPython
+        run: cargo build --release --verbose --features=threading ${{ env.CARGO_ARGS }},jit
+        if: runner.os != 'macOS'
+
+      - name: Rename Binary
+        run: cp target/release/rustpython target/release/rustpython-release-${{ matrix.os }}
+        if: runner.os != 'Windows'
+      - name: Rename Binary
+        run: cp target/release/rustpython.exe target/release/rustpython-release-${{ matrix.os }}
+        if: runner.os == 'Windows'
+
+      - name: Upload Binary Artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: rustpython-release-${{ matrix.os }}
+          path: target/release/rustpython-release-${{ matrix.os }}
+
+  release:
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
+      - name: Download Binary Artifacts
+        uses: actions/download-artifact@v4
+        with:
+          path: bin
+          pattern: rustpython-release-*
+          merge-multiple: true
+
+      - name: List Binaries
+        run: ls -R bin
+      - name: Create Release
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          tag: ${{ github.ref_name }}
+          run: ${{ github.run_number }}
+        run: |
+          today=$(date '+%Y-%m-%d')
+          gh release create "$today-$tag-$run" \
+              --repo="$GITHUB_REPOSITORY" \
+              --title="RustPython Release $today-$tag #$run" \
+              --generate-notes \
+              bin/rustpython-release-*

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,6 +1,6 @@
 on:
   push:
-    branches: [main]
+    branches: [gh-rel-rustpython]
 
 name: Release
 
@@ -12,15 +12,40 @@ env:
 
 jobs:
   build:
-    runs-on: ${{ matrix.os }}
+    runs-on: ${{ matrix.platform.runner }}
     strategy:
       matrix:
-        os: [ macos-latest, ubuntu-latest, windows-latest ]
+        platform:
+          - runner: ubuntu-latest
+            target: x86_64-unknown-linux-gnu
+          - runner: ubuntu-latest
+            target: i686-unknown-linux-gnu
+          - runner: ubuntu-latest
+            target: aarch64-unknown-linux-gnu
+          - runner: ubuntu-latest
+            target: armv7-unknown-linux-gnueabi
+          - runner: ubuntu-latest
+            target: s390x-unknown-linux-gnu
+          - runner: ubuntu-latest
+            target: powerpc64le-unknown-linux-gnu
+          - runner: macos-latest
+            target: aarch64-apple-darwin
+          - runner: macos-latest
+            target: x86_64-apple-darwin
+          - runner: windows-latest
+            target: x86_64-pc-windows-msvc
+          - runner: windows-latest
+            target: i686-pc-windows-msvc
+          - runner: windows-latest
+            target: aarch64-pc-windows-msvc
       fail-fast: false
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable
 
+      - name: Set up Environment
+        shell: bash
+        run: rustup target add ${{ matrix.platform.target }}
       - name: Set up Windows Environment
         shell: bash
         run: |
@@ -39,17 +64,17 @@ jobs:
         if: runner.os != 'macOS'
 
       - name: Rename Binary
-        run: cp target/release/rustpython target/release/rustpython-release-${{ matrix.os }}
+        run: cp target/release/rustpython target/release/rustpython-release-${{ runner.os }}-${{ matrix.platform.target }}
         if: runner.os != 'Windows'
       - name: Rename Binary
-        run: cp target/release/rustpython.exe target/release/rustpython-release-${{ matrix.os }}
+        run: cp target/release/rustpython.exe target/release/rustpython-release-${{ runner.os }}-${{ matrix.platform.target }}
         if: runner.os == 'Windows'
 
       - name: Upload Binary Artifacts
         uses: actions/upload-artifact@v4
         with:
-          name: rustpython-release-${{ matrix.os }}
-          path: target/release/rustpython-release-${{ matrix.os }}
+          name: rustpython-release-${{ runner.os }}-${{ matrix.platform.target }}
+          path: target/release/rustpython-release-${{ runner.os }}-${{ matrix.platform.target }}
 
   release:
     runs-on: ubuntu-latest
@@ -63,7 +88,9 @@ jobs:
           merge-multiple: true
 
       - name: List Binaries
-        run: ls -R bin
+        run: |
+          ls -lah bin/
+          file bin/*
       - name: Create Release
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -64,17 +64,17 @@ jobs:
         if: runner.os != 'macOS'
 
       - name: Rename Binary
-        run: cp target/release/rustpython target/release/rustpython-release-${{ runner.os }}-${{ matrix.platform.target }}
+        run: cp target/${{ matrix.platform.target }}/release/rustpython target/rustpython-release-${{ runner.os }}-${{ matrix.platform.target }}
         if: runner.os != 'Windows'
       - name: Rename Binary
-        run: cp target/release/rustpython.exe target/release/rustpython-release-${{ runner.os }}-${{ matrix.platform.target }}
+        run: cp target/${{ matrix.platform.target }}/release/rustpython.exe target/rustpython-release-${{ runner.os }}-${{ matrix.platform.target }}
         if: runner.os == 'Windows'
 
       - name: Upload Binary Artifacts
         uses: actions/upload-artifact@v4
         with:
           name: rustpython-release-${{ runner.os }}-${{ matrix.platform.target }}
-          path: target/release/rustpython-release-${{ runner.os }}-${{ matrix.platform.target }}
+          path: target/rustpython-release-${{ runner.os }}-${{ matrix.platform.target }}
 
   release:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Add Release Pipeline for RustPython. Pipeline is currently configured to cut a new release on every merge to main.

Sample Release: https://github.com/theshubhamp/RustPython/releases/tag/2024-12-07-gh-rel-rustpython-11
![image](https://github.com/user-attachments/assets/1e71f3c3-947b-4771-b0c9-af81cae35fab)

Sample Build: https://github.com/theshubhamp/RustPython/actions/runs/12212320619
![image](https://github.com/user-attachments/assets/970d7464-3f40-4466-9540-90afe3ca03c4)

Validated to run on Linux / Fedora:
![image](https://github.com/user-attachments/assets/366a5719-e021-439c-9ace-20ee737341c2)

Issue #5440 