### PR TITLE
Check operand types in bool or, and, xor to be PyInt

### DIFF
--- a/extra_tests/snippets/operator_arithmetic.py
+++ b/extra_tests/snippets/operator_arithmetic.py
@@ -32,3 +32,23 @@ assert_raises(ValueError, lambda: 1 << -1)
 
 # Right shift raises value error on negative
 assert_raises(ValueError, lambda: 1 >> -1)
+
+# Bitwise or, and, xor raises value error on incompatible types
+assert_raises(TypeError, lambda: "abc" | True)
+assert_raises(TypeError, lambda: "abc" & True)
+assert_raises(TypeError, lambda: "abc" ^ True)
+assert_raises(TypeError, lambda: True | "abc")
+assert_raises(TypeError, lambda: True & "abc")
+assert_raises(TypeError, lambda: True ^ "abc")
+assert_raises(TypeError, lambda: "abc" | 1.5)
+assert_raises(TypeError, lambda: "abc" & 1.5)
+assert_raises(TypeError, lambda: "abc" ^ 1.5)
+assert_raises(TypeError, lambda: 1.5 | "abc")
+assert_raises(TypeError, lambda: 1.5 & "abc")
+assert_raises(TypeError, lambda: 1.5 ^ "abc")
+assert_raises(TypeError, lambda: True | 1.5)
+assert_raises(TypeError, lambda: True & 1.5)
+assert_raises(TypeError, lambda: True ^ 1.5)
+assert_raises(TypeError, lambda: 1.5 | True)
+assert_raises(TypeError, lambda: 1.5 & True)
+assert_raises(TypeError, lambda: 1.5 ^ True)

--- a/vm/src/builtins/bool.rs
+++ b/vm/src/builtins/bool.rs
@@ -213,7 +213,3 @@ pub(crate) fn init(context: &Context) {
 pub(crate) fn get_value(obj: &PyObject) -> bool {
     !obj.payload::<PyInt>().unwrap().as_bigint().is_zero()
 }
-
-fn get_py_int(obj: &PyObject) -> &PyInt {
-    obj.payload::<PyInt>().unwrap()
-}

--- a/vm/src/builtins/bool.rs
+++ b/vm/src/builtins/bool.rs
@@ -127,8 +127,10 @@ impl PyBool {
             let lhs = get_value(&lhs);
             let rhs = get_value(&rhs);
             (lhs || rhs).to_pyobject(vm)
+        } else if let Some(lhs) = lhs.payload::<PyInt>() {
+            lhs.or(rhs, vm).to_pyobject(vm)
         } else {
-            get_py_int(&lhs).or(rhs, vm).to_pyobject(vm)
+            vm.ctx.not_implemented()
         }
     }
 
@@ -141,8 +143,10 @@ impl PyBool {
             let lhs = get_value(&lhs);
             let rhs = get_value(&rhs);
             (lhs && rhs).to_pyobject(vm)
+        } else if let Some(lhs) = lhs.payload::<PyInt>() {
+            lhs.and(rhs, vm).to_pyobject(vm)
         } else {
-            get_py_int(&lhs).and(rhs, vm).to_pyobject(vm)
+            vm.ctx.not_implemented()
         }
     }
 
@@ -155,8 +159,10 @@ impl PyBool {
             let lhs = get_value(&lhs);
             let rhs = get_value(&rhs);
             (lhs ^ rhs).to_pyobject(vm)
+        } else if let Some(lhs) = lhs.payload::<PyInt>() {
+            lhs.xor(rhs, vm).to_pyobject(vm)
         } else {
-            get_py_int(&lhs).xor(rhs, vm).to_pyobject(vm)
+            vm.ctx.not_implemented()
         }
     }
 }

--- a/vm/src/vm/vm_ops.rs
+++ b/vm/src/vm/vm_ops.rs
@@ -151,7 +151,7 @@ impl VirtualMachine {
     /// Calling scheme used for binary operations:
     ///
     /// Order operations are tried until either a valid result or error:
-    ///   b.rop(a,b)[*], a.op(a,b), b.rop(a,b)
+    ///   b.rop(b,a)[*], a.op(a,b), b.rop(b,a)
     ///
     /// [*] only when Py_TYPE(a) != Py_TYPE(b) && Py_TYPE(b) is a subclass of Py_TYPE(a)
     pub fn binary_op1(&self, a: &PyObject, b: &PyObject, op_slot: PyNumberBinaryOp) -> PyResult {

--- a/vm/src/vm/vm_ops.rs
+++ b/vm/src/vm/vm_ops.rs
@@ -151,7 +151,7 @@ impl VirtualMachine {
     /// Calling scheme used for binary operations:
     ///
     /// Order operations are tried until either a valid result or error:
-    ///   b.rop(b,a)[*], a.op(a,b), b.rop(b,a)
+    ///   b.rop(a,b)[*], a.op(a,b), b.rop(a,b)
     ///
     /// [*] only when Py_TYPE(a) != Py_TYPE(b) && Py_TYPE(b) is a subclass of Py_TYPE(a)
     pub fn binary_op1(&self, a: &PyObject, b: &PyObject, op_slot: PyNumberBinaryOp) -> PyResult {


### PR DESCRIPTION
PyNumber methods are expected to type check both arguments.

Dispatch is not done by inverting parameter order for __r<op>__ (example __ror__) when calls are handled via PyNumberMethods

Other changes:
- Add tests to assert a TypeError is raised when either of the parameter types boolean & other is not convertible to int (str or float for example)
- Sync binary operator order comment with actual implementation

Fixes: #5460