### PR TITLE
Bump result-like to 0.5.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1566,13 +1566,13 @@ dependencies = [
 
 [[package]]
 name = "pmutil"
-version = "0.5.3"
+version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3894e5d549cccbe44afecf72922f277f603cd4bb0219c8342631ef18fffbe004"
+checksum = "52a40bc70c2c58040d2d8b167ba9a5ff59fc9dab7ad44771cfde3dcfde7a09c6"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 1.0.109",
+ "syn 2.0.77",
 ]
 
 [[package]]
@@ -1824,24 +1824,23 @@ dependencies = [
 
 [[package]]
 name = "result-like"
-version = "0.4.6"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ccc7ce6435c33898517a30e85578cd204cbb696875efb93dec19a2d31294f810"
+checksum = "abf7172fef6a7d056b5c26bf6c826570267562d51697f4982ff3ba4aec68a9df"
 dependencies = [
  "result-like-derive",
 ]
 
 [[package]]
 name = "result-like-derive"
-version = "0.4.6"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1fabf0a2e54f711c68c50d49f648a1a8a37adcb57353f518ac4df374f0788f42"
+checksum = "a8d6574c02e894d66370cfc681e5d68fedbc9a548fb55b30a96b3f0ae22d0fe5"
 dependencies = [
  "pmutil",
  "proc-macro2",
  "quote",
- "syn 1.0.109",
- "syn-ext",
+ "syn 2.0.77",
 ]
 
 [[package]]

--- a/vm/Cargo.toml
+++ b/vm/Cargo.toml
@@ -78,7 +78,7 @@ flamer = { version = "0.4", optional = true }
 half = "2"
 memoffset = "0.9.1"
 optional = "0.5.0"
-result-like = "0.4.6"
+result-like = "0.5.0"
 timsort = "0.1.2"
 
 ## unicode stuff


### PR DESCRIPTION
Removes one more reason to have `syn` 1.0 as a dependency. After this, the only dependency still using `syn` 1.0 is `syn-ext` used by `rustpython-derive-impl`.