### PR TITLE
Temporarily disable release notes generation

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -102,5 +102,4 @@ jobs:
               --repo="$GITHUB_REPOSITORY" \
               --title="RustPython Release $today-$tag #$run" \
               --target="$tag" \
-              --generate-notes \
               bin/rustpython-release-*


### PR DESCRIPTION
Release creation fails with this error:
```
HTTP 422: Validation Failed (https://api.github.com/repos/RustPython/RustPython/releases)
body is too long (maximum is 125000 characters)
Error: Process completed with exit code 1.
```

Most likely because there's no previous release to diff of from.

Disabling, getting a green release & enabling back might fix this.