### PR TITLE
Build wasm on release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -76,9 +76,31 @@ jobs:
           name: rustpython-release-${{ runner.os }}-${{ matrix.platform.target }}
           path: target/rustpython-release-${{ runner.os }}-${{ matrix.platform.target }}*
 
+  build-wasm:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+
+      - name: Set up Environment
+        shell: bash
+        run: rustup target add wasm32-wasi
+
+      - name: Build RustPython
+        run: cargo build --target wasm32-wasi --no-default-features --features freeze-stdlib,stdlib --release
+
+      - name: Rename Binary
+        run: cp target/wasm32-wasi/release/rustpython.wasm target/rustpython-release-wasm32-wasi.wasm
+
+      - name: Upload Binary Artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: rustpython-release-wasm32-wasi
+          path: target/rustpython-release-wasm32-wasi.wasm
+
   release:
     runs-on: ubuntu-latest
-    needs: build
+    needs: [build, build-wasm]
     steps:
       - name: Download Binary Artifacts
         uses: actions/download-artifact@v4


### PR DESCRIPTION
Self-explanatory: adds a job before releasing that builds and uploads the wasm artifact