### PR TITLE
Bump rust-caseless to 0.2.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -207,11 +207,10 @@ dependencies = [
 
 [[package]]
 name = "caseless"
-version = "0.2.1"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "808dab3318747be122cb31d36de18d4d1c81277a76f8332a02b81a3d73463d7f"
+checksum = "8b6fd507454086c8edfd769ca6ada439193cdb209c7681712ef6275cccbfe5d8"
 dependencies = [
- "regex",
  "unicode-normalization",
 ]
 

--- a/vm/Cargo.toml
+++ b/vm/Cargo.toml
@@ -73,7 +73,7 @@ thiserror = { workspace = true }
 thread_local = { workspace = true }
 memchr = { workspace = true }
 
-caseless = "0.2.1"
+caseless = "0.2.2"
 flamer = { version = "0.4", optional = true }
 half = "2"
 memoffset = "0.9.1"


### PR DESCRIPTION
The latest version prebuilds the table (https://github.com/unicode-rs/rust-caseless/pull/21) thus removing the build step and dependency on regex. RustPython still has regex as a dev dependency but it's no longer part of normal builds, speeding them up.