### PR TITLE
Introduce Weekly Pre-Release + Manual Release for RustPython binaries

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -140,5 +140,6 @@ jobs:
               --repo="$GITHUB_REPOSITORY" \
               --title="RustPython $RELEASE_TYPE_NAME $today-$tag #$run" \
               --target="$tag" \
+              --generate-notes \
               $PRERELEASE_ARG \
               bin/rustpython-release-*

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,8 +1,13 @@
-on:
-  push:
-    branches: [main]
-
 name: Release
+
+on:
+  workflow_dispatch:
+    inputs:
+      pre-release:
+        type: boolean
+        description: Mark "Pre-Release"
+        required: false
+        default: true
 
 permissions:
   contents: write
@@ -119,9 +124,18 @@ jobs:
           tag: ${{ github.ref_name }}
           run: ${{ github.run_number }}
         run: |
+          if [[ "${{ github.event.inputs.pre-release }}" == "true" ]]; then
+            RELEASE_TYPE_NAME=Pre-Release
+            PRERELEASE_ARG=--prerelease
+          else
+            RELEASE_TYPE_NAME=Release
+            PRERELEASE_ARG=
+          fi
+          
           today=$(date '+%Y-%m-%d')
           gh release create "$today-$tag-$run" \
               --repo="$GITHUB_REPOSITORY" \
-              --title="RustPython Release $today-$tag #$run" \
+              --title="RustPython $RELEASE_TYPE_NAME $today-$tag #$run" \
               --target="$tag" \
+              $PRERELEASE_ARG \
               bin/rustpython-release-*

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,6 +1,9 @@
 name: Release
 
 on:
+  schedule:
+    # 9 AM UTC on every Monday
+    - cron: "0 9 * * Mon"
   workflow_dispatch:
     inputs:
       pre-release:


### PR DESCRIPTION
Introduce Weekly Pre-Release + Manual Release for RustPython binaries

Weekly Scheduled release @ Monday 9AM UTC defaults to Pre-Release. Regular Releases can be done using the same workflow by deselecting Mark "Pre-Release" checkbox.

Summary of Changes:
1. Support both Release & Pre-Release in Release Workflow
2. Schedule Pre-Release on Monday 9AM UTC
3. Re-enable Release Notes Generation

Workflow can be run manually. Pre-release of not can be selected at the time of run:
![image](https://github.com/user-attachments/assets/22caefe2-8b39-4e04-8a38-f720e6b0a3fc)

Sample Release: https://github.com/theshubhamp/RustPython/releases/tag/2025-01-03-gh-release-22
Sample Pre-Release: https://github.com/theshubhamp/RustPython/releases/tag/2025-01-03-gh-release-21