### PR TITLE
Handle pre-release flag being empty for schedule triggers in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -127,12 +127,12 @@ jobs:
           tag: ${{ github.ref_name }}
           run: ${{ github.run_number }}
         run: |
-          if [[ "${{ github.event.inputs.pre-release }}" == "true" ]]; then
-            RELEASE_TYPE_NAME=Pre-Release
-            PRERELEASE_ARG=--prerelease
-          else
+          if [[ "${{ github.event.inputs.pre-release }}" == "false" ]]; then
             RELEASE_TYPE_NAME=Release
             PRERELEASE_ARG=
+          else
+            RELEASE_TYPE_NAME=Pre-Release
+            PRERELEASE_ARG=--prerelease
           fi
           
           today=$(date '+%Y-%m-%d')


### PR DESCRIPTION
Handle pre-release flag being empty for schedule triggers in release workflow

GitHub workflow_dispatch input variables are always empty for other triggers