### PR TITLE
docs(readme): fix installation command for cargo

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ NOTE: For windows users, please set `RUSTPYTHONPATH` environment variable as `Li
 You can also install and run RustPython with the following:
 
 ```bash
-$ cargo install --git https://github.com/RustPython/RustPython
+$ cargo install --git https://github.com/RustPython/RustPython rustpython
 $ rustpython
 Welcome to the magnificent Rust Python interpreter
 >>>>>


### PR DESCRIPTION
![图片](https://github.com/user-attachments/assets/1669eb27-fa32-4fbd-a157-33fd3ae0f223)

This repo is monorepo so we should use `cargo install --git https://github.com/RustPython/RustPython rustpython` instead