### PR TITLE
Write message for `todo!` macro

### DIFF
--- a/compiler/codegen/src/compile.rs
+++ b/compiler/codegen/src/compile.rs
@@ -1095,8 +1095,12 @@ impl Compiler {
                         self.store_name(name.as_ref())?;
                     }
                 }
-                located_ast::TypeParam::ParamSpec(_) => todo!(),
-                located_ast::TypeParam::TypeVarTuple(_) => todo!(),
+                located_ast::TypeParam::ParamSpec(_) => {
+                    todo!("implement Compiler::compile_type_params for TypeParam::ParamSpec")
+                }
+                located_ast::TypeParam::TypeVarTuple(_) => {
+                    todo!("implement Compiler::compile_type_params for TypeParam::TypeVarTuple")
+                }
             };
         }
         emit!(

--- a/compiler/codegen/src/symboltable.rs
+++ b/compiler/codegen/src/symboltable.rs
@@ -1257,8 +1257,12 @@ impl SymbolTableBuilder {
                         self.scan_expression(binding, ExpressionContext::Load)?;
                     }
                 }
-                ast::located::TypeParam::ParamSpec(_) => todo!(),
-                ast::located::TypeParam::TypeVarTuple(_) => todo!(),
+                ast::located::TypeParam::ParamSpec(_) => {
+                    todo!("implement SymbolTableBuilder::scan_type_params TypeParam:::ParamSpec")
+                }
+                ast::located::TypeParam::TypeVarTuple(_) => {
+                    todo!("implement SymbolTableBuilder::scan_type_params TypeParam:::TypeVarTuple")
+                }
             }
         }
         Ok(())

--- a/stdlib/src/csv.rs
+++ b/stdlib/src/csv.rs
@@ -433,8 +433,12 @@ mod _csv {
                 QuoteStyle::All => csv_core::QuoteStyle::Always,
                 QuoteStyle::Nonnumeric => csv_core::QuoteStyle::NonNumeric,
                 QuoteStyle::None => csv_core::QuoteStyle::Never,
-                QuoteStyle::Strings => todo!(),
-                QuoteStyle::Notnull => todo!(),
+                QuoteStyle::Strings => {
+                    todo!("implement From<QuoteStyle> for csv_core::QuoteStyle::Strings")
+                }
+                QuoteStyle::Notnull => {
+                    todo!("implement From<QuoteStyle> for csv_core::QuoteStyle::Notnull")
+                }
             }
         }
     }

--- a/vm/src/builtins/bool.rs
+++ b/vm/src/builtins/bool.rs
@@ -88,7 +88,7 @@ impl PyPayload for PyBool {
 
 impl Debug for PyBool {
     fn fmt(&self, _f: &mut Formatter<'_>) -> std::fmt::Result {
-        todo!()
+        todo!("implement Debug::fmt for PyBool")
     }
 }
 


### PR DESCRIPTION
This pull request writes messages for `todo!` macros to help debugging.

For example, I met a situation that I cannot know lines where the build fails, when working on #5486.

```
error: proc macro panicked
  --> pylib/src/lib.rs:14:5
   |
14 |     rustpython_derive::py_freeze!(dir = "./Lib", crate_name = "rustpython_compiler_core");
   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
   |
   = help: message: not yet implemented
```

After this pull request, I met a helpful message:

```
error: proc macro panicked
  --> pylib/src/lib.rs:14:5
   |
14 |     rustpython_derive::py_freeze!(dir = "./Lib", crate_name = "rustpython_compiler_core");
   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
   |
   = help: message: not yet implemented: implement SymbolTableBuilder::scan_type_params TypeParam:::ParamSpec
```