### PR TITLE
Implement `del object.__dict__`

### DIFF
--- a/vm/src/builtins/object.rs
+++ b/vm/src/builtins/object.rs
@@ -496,9 +496,13 @@ pub fn object_get_dict(obj: PyObjectRef, vm: &VirtualMachine) -> PyResult<PyDict
         .ok_or_else(|| vm.new_attribute_error("This object has no __dict__".to_owned()))
 }
 
-pub fn object_set_dict(obj: PyObjectRef, dict: PySetterValue<PyDictRef>, vm: &VirtualMachine) -> PyResult<()> {
+pub fn object_set_dict(
+    obj: PyObjectRef,
+    dict: PySetterValue<PyDictRef>,
+    vm: &VirtualMachine,
+) -> PyResult<()> {
     obj.set_dict(dict)
-        .map_err(|_| vm.new_attribute_error("This object has no __dict__".to_owned()))
+        .map_err(|_| vm.new_attribute_error("This object has no __dict__ to delete".to_owned()))
 }
 
 pub fn init(ctx: &Context) {

--- a/vm/src/builtins/object.rs
+++ b/vm/src/builtins/object.rs
@@ -497,16 +497,8 @@ pub fn object_get_dict(obj: PyObjectRef, vm: &VirtualMachine) -> PyResult<PyDict
 }
 
 pub fn object_set_dict(obj: PyObjectRef, dict: PySetterValue<PyDictRef>, vm: &VirtualMachine) -> PyResult<()> {
-    match dict {
-        PySetterValue::Assign(dict) => {
-            obj.set_dict(dict)
-                .map_err(|_| vm.new_attribute_error("This object has no __dict__".to_owned()))
-        }
-        PySetterValue::Delete => {
-            obj.delete_dict()
-                .map_err(|_| vm.new_attribute_error("This object has no deletable __dict__".to_owned()))
-        }
-    }
+    obj.set_dict(dict)
+        .map_err(|_| vm.new_attribute_error("This object has no __dict__".to_owned()))
 }
 
 pub fn init(ctx: &Context) {

--- a/vm/src/builtins/object.rs
+++ b/vm/src/builtins/object.rs
@@ -495,9 +495,18 @@ pub fn object_get_dict(obj: PyObjectRef, vm: &VirtualMachine) -> PyResult<PyDict
     obj.dict()
         .ok_or_else(|| vm.new_attribute_error("This object has no __dict__".to_owned()))
 }
-pub fn object_set_dict(obj: PyObjectRef, dict: PyDictRef, vm: &VirtualMachine) -> PyResult<()> {
-    obj.set_dict(dict)
-        .map_err(|_| vm.new_attribute_error("This object has no __dict__".to_owned()))
+
+pub fn object_set_dict(obj: PyObjectRef, dict: PySetterValue<PyDictRef>, vm: &VirtualMachine) -> PyResult<()> {
+    match dict {
+        PySetterValue::Assign(dict) => {
+            obj.set_dict(dict)
+                .map_err(|_| vm.new_attribute_error("This object has no __dict__".to_owned()))
+        }
+        PySetterValue::Delete => {
+            obj.delete_dict()
+                .map_err(|_| vm.new_attribute_error("This object has no deletable __dict__".to_owned()))
+        }
+    }
 }
 
 pub fn init(ctx: &Context) {

--- a/vm/src/builtins/type.rs
+++ b/vm/src/builtins/type.rs
@@ -1288,7 +1288,7 @@ fn subtype_set_dict(obj: PyObjectRef, value: PyObjectRef, vm: &VirtualMachine) -
             descr_set(&descr, obj, PySetterValue::Assign(value), vm)
         }
         None => {
-            object::object_set_dict(obj, PySetterValue::Delete, vm)?;
+            object::object_set_dict(obj, PySetterValue::Assign(value.try_into_value(vm)?), vm)?;
             Ok(())
         }
     }

--- a/vm/src/builtins/type.rs
+++ b/vm/src/builtins/type.rs
@@ -1288,7 +1288,7 @@ fn subtype_set_dict(obj: PyObjectRef, value: PyObjectRef, vm: &VirtualMachine) -
             descr_set(&descr, obj, PySetterValue::Assign(value), vm)
         }
         None => {
-            object::object_set_dict(obj, value.try_into_value(vm)?, vm)?;
+            object::object_set_dict(obj, PySetterValue::Delete, vm)?;
             Ok(())
         }
     }

--- a/vm/src/function/getset.rs
+++ b/vm/src/function/getset.rs
@@ -36,8 +36,10 @@ where
 {
     #[inline]
     fn from_setter_value(vm: &VirtualMachine, obj: PySetterValue) -> PyResult<Self> {
-        let obj = obj.ok_or_else(|| vm.new_type_error("can't delete attribute".to_owned()))?;
-        T::try_from_object(vm, obj)
+        match obj {
+            PySetterValue::Assign(obj) => T::try_from_object(vm, obj),
+            PySetterValue::Delete => T::try_from_object(vm, vm.ctx.none()),
+        }
     }
 }
 

--- a/vm/src/object/core.rs
+++ b/vm/src/object/core.rs
@@ -717,6 +717,19 @@ impl PyObject {
         }
     }
 
+    pub fn delete_dict(&self) -> Result<(), ()> {
+        match self.instance_dict() {
+            Some(_) => {
+                unsafe {
+                    let ptr = self as *const _ as *mut PyObject;
+                    (*ptr).0.dict = None;
+                }
+                Ok(())
+            }
+            None => Err(()),
+        }
+    }
+
     #[inline(always)]
     pub fn payload_if_subclass<T: crate::PyPayload>(&self, vm: &VirtualMachine) -> Option<&T> {
         if self.class().fast_issubclass(T::class(&vm.ctx)) {

--- a/vm/src/object/core.rs
+++ b/vm/src/object/core.rs
@@ -708,13 +708,19 @@ impl PyObject {
 
     /// Set the dict field. Returns `Err(dict)` if this object does not have a dict field
     /// in the first place.
-    pub fn set_dict(&self, dict: PySetterValue<PyDictRef>) -> Result<(), PyDictRef> {
+    pub fn set_dict(&self, dict: PySetterValue<PyDictRef>) -> Result<(), PySetterValue<PyDictRef>> {
         match (self.instance_dict(), dict) {
             (Some(d), PySetterValue::Assign(dict)) => {
                 d.set(dict);
                 Ok(())
             }
-            (None, PySetterValue::Assign(dict)) => Err(dict),
+            (None, PySetterValue::Assign(dict)) => {
+                unsafe {
+                    let ptr = self as *const _ as *mut PyObject;
+                    (*ptr).0.dict = Some(InstanceDict::new(dict));
+                }
+                Ok(())
+            }
             (Some(_), PySetterValue::Delete) => {
                 unsafe {
                     let ptr = self as *const _ as *mut PyObject;
@@ -722,7 +728,7 @@ impl PyObject {
                 }
                 Ok(())
             }
-            (None, PySetterValue::Delete) => Ok(()),
+            (None, PySetterValue::Delete) => Err(PySetterValue::Delete),
         }
     }
 


### PR DESCRIPTION
I add `object::delete_dict()` which changes Object's dict to `None`, and add `PySetterValue::Delete` match case in `object::object_set_dict`. 
All things fine I think, but minor format issue remains. 

```rust
    pub fn delete_dict(&self) -> Result<(), ()> {
        match self.instance_dict() {
            Some(_) => {
                unsafe {
                    let ptr = self as *const _ as *mut PyObject;
                    (*ptr).0.dict = None;
                }
                Ok(())
            }
            None => Err(()),
        }
    }
```

In this code, since Err can be returned, we should define custom Error type.
I made several options for it.

1. Return `Ok(())` when it does not have __dict__ already
  - Can it satisfy normal convention? or I should raise error when the object to be deleted does not exist?
2. Make simple error type and return it. 
3. Return Option not Result
4. Add something to `delete_dict`'s parameter and return it. 

I cannot decide which one is better. Can you suggest about it?