### PR TITLE
Initial _ctypes implementation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1265,9 +1265,9 @@ checksum = "78ca9ab1a0babb1e7d5695e3530886289c18cf2f87ec19a575a0abdce112e3a3"
 
 [[package]]
 name = "memmap2"
-version = "0.9.5"
+version = "0.5.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fd3f7eed9d3848f8b98834af67102b720745c4ec028fcd0aa0239277e7de374f"
+checksum = "83faa42c0a078c393f6b29d5db232d8be22776a891f8f56e5284faee4a20b327"
 dependencies = [
  "libc",
 ]
@@ -2205,6 +2205,7 @@ dependencies = [
  "cfg-if",
  "chrono",
  "crossbeam-utils",
+ "errno",
  "exitcode",
  "flame",
  "flamer",

--- a/vm/Cargo.toml
+++ b/vm/Cargo.toml
@@ -99,6 +99,7 @@ uname = "0.1.1"
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 rustyline = { workspace = true }
 which = "6"
+errno = "0.3"
 
 [target.'cfg(any(not(target_arch = "wasm32"), target_os = "wasi"))'.dependencies]
 num_cpus = "1.13.1"

--- a/vm/src/stdlib/ctypes.rs
+++ b/vm/src/stdlib/ctypes.rs
@@ -1,0 +1,34 @@
+pub(crate) use _ctypes::make_module;
+
+#[pymodule]
+mod _ctypes {
+    use crate::{common::lock::PyRwLock, PyObjectRef};
+    use crossbeam_utils::atomic::AtomicCell;
+
+    pub struct RawBuffer {
+        #[allow(dead_code)]
+        pub inner: Box<[u8]>,
+        #[allow(dead_code)]
+        pub size: usize,
+    }
+
+    #[pyattr]
+    #[pyclass(name = "_CData")]
+    pub struct PyCData {
+        _objects: AtomicCell<Vec<PyObjectRef>>,
+        _buffer: PyRwLock<RawBuffer>,
+    }
+
+    #[pyclass]
+    impl PyCData {}
+
+    #[pyfunction]
+    fn get_errno() -> i32 {
+        errno::errno().0
+    }
+
+    #[pyfunction]
+    fn set_errno(value: i32) {
+        errno::set_errno(errno::Errno(value));
+    }
+}

--- a/vm/src/stdlib/mod.rs
+++ b/vm/src/stdlib/mod.rs
@@ -37,6 +37,8 @@ pub mod posix;
 #[path = "posix_compat.rs"]
 pub mod posix;
 
+#[cfg(any(target_family = "unix", target_family = "windows"))]
+mod ctypes;
 #[cfg(windows)]
 pub(crate) mod msvcrt;
 #[cfg(all(unix, not(any(target_os = "android", target_os = "redox"))))]
@@ -123,6 +125,10 @@ pub fn get_module_inits() -> StdlibMap {
             "msvcrt" => msvcrt::make_module,
             "_winapi" => winapi::make_module,
             "winreg" => winreg::make_module,
+        }
+        #[cfg(any(target_family = "unix", target_family = "windows"))]
+        {
+            "_ctypes" => ctypes::make_module,
         }
     }
 }


### PR DESCRIPTION
In order to make this merge-able, I've highly reduced the scope of this. This will not make the `ctypes` module anywhere close to usable, but will atleast expose a few useful APIs with regards to `errno`.

- [x] get_errno (tested)
- [x] set_errno (tested)
- [x] _CData
