### PR TITLE
_ctypes pt. 3

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -62,9 +62,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.95"
+version = "1.0.96"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34ac096ce696dc2fcabef30516bb13c0a68a11d30131d3df6f04711467681b04"
+checksum = "6b964d184e89d9b6b67dd2715bc8e74cf3107fb2b529990c90cf517326150bf4"
 
 [[package]]
 name = "approx"
@@ -1757,7 +1757,7 @@ checksum = "3779b94aeb87e8bd4e834cee3650289ee9e0d5677f976ecdb6d219e5f4f6cd94"
 dependencies = [
  "rand_chacha 0.9.0",
  "rand_core 0.9.1",
- "zerocopy 0.8.18",
+ "zerocopy 0.8.20",
 ]
 
 [[package]]
@@ -1796,7 +1796,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a88e0da7a2c97baa202165137c158d0a2e824ac465d13d81046727b34cb247d3"
 dependencies = [
  "getrandom 0.3.1",
- "zerocopy 0.8.18",
+ "zerocopy 0.8.20",
 ]
 
 [[package]]
@@ -2421,9 +2421,9 @@ checksum = "f79dfe2d285b0488816f30e700a7438c5a73d816b5b7d3ac72fbc48b0d185e03"
 
 [[package]]
 name = "serde"
-version = "1.0.217"
+version = "1.0.218"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "02fc4265df13d6fa1d00ecff087228cc0a2b5f3c0e87e258d8b94a156e984c70"
+checksum = "e8dfc9d19bdbf6d17e22319da49161d5d0108e4188e8b680aef6299eed22df60"
 dependencies = [
  "serde_derive",
 ]
@@ -2452,9 +2452,9 @@ dependencies = [
 
 [[package]]
 name = "serde_derive"
-version = "1.0.217"
+version = "1.0.218"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a9bf7cf98d04a2b28aead066b7496853d4779c9cc183c440dbac457641e19a0"
+checksum = "f09503e191f4e797cb8aac08e9a4a4695c5edf6a2e70e376d961ddd5c969f82b"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2463,9 +2463,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.138"
+version = "1.0.139"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d434192e7da787e94a6ea7e9670b26a036d0ca41e0b7efb2676dd32bae872949"
+checksum = "44f86c3acccc9c65b153fe1b85a3be07fe5515274ec9f0653b4a0875731c72a6"
 dependencies = [
  "itoa",
  "memchr",
@@ -2937,9 +2937,9 @@ checksum = "623f59e6af2a98bdafeb93fa277ac8e1e40440973001ca15cf4ae1541cd16d56"
 
 [[package]]
 name = "unicode-ident"
-version = "1.0.16"
+version = "1.0.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a210d160f08b701c8721ba1c726c11662f877ea6b7094007e1ca9a1041945034"
+checksum = "00e2473a93778eb0bad35909dff6a10d28e63f792f16ed15e404fca9d5eeedbe"
 
 [[package]]
 name = "unicode-normalization"
@@ -3449,11 +3449,11 @@ dependencies = [
 
 [[package]]
 name = "zerocopy"
-version = "0.8.18"
+version = "0.8.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "79386d31a42a4996e3336b0919ddb90f81112af416270cff95b5f5af22b839c2"
+checksum = "dde3bb8c68a8f3f1ed4ac9221aad6b10cece3e60a8e2ea54a6a2dec806d0084c"
 dependencies = [
- "zerocopy-derive 0.8.18",
+ "zerocopy-derive 0.8.20",
 ]
 
 [[package]]
@@ -3469,9 +3469,9 @@ dependencies = [
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.8.18"
+version = "0.8.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "76331675d372f91bf8d17e13afbd5fe639200b73d01f0fc748bb059f9cca2db7"
+checksum = "eea57037071898bf96a6da35fd626f4f27e9cee3ead2a6c703cf09d472b2e700"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2282,6 +2282,7 @@ dependencies = [
  "itertools 0.14.0",
  "junction",
  "libc",
+ "libffi",
  "libloading",
  "log",
  "malachite-bigint",

--- a/extra_tests/snippets/builtins_ctypes.py
+++ b/extra_tests/snippets/builtins_ctypes.py
@@ -155,6 +155,8 @@ assert abs(f.value -  3.14) < 1e-06
 if _os.name == "nt":
     from _ctypes import LoadLibrary as _dlopen
     from _ctypes import FUNCFLAG_STDCALL as _FUNCFLAG_STDCALL
+elif _os.name == "posix":
+    from _ctypes import dlopen as _dlopen
 
 class CDLL(object):
     """An instance of this class represents a loaded dll/shared
@@ -258,7 +260,7 @@ class LibraryLoader(object):
 
 cdll = LibraryLoader(CDLL)
 
-if _os.name == "posix" and _sys.platform == "darwin":
+if _os.name == "posix" or _sys.platform == "darwin":
     pass
 else:
     libc = cdll.msvcrt

--- a/vm/Cargo.toml
+++ b/vm/Cargo.toml
@@ -100,6 +100,7 @@ uname = "0.1.1"
 rustyline = { workspace = true }
 which = "6"
 errno = "0.3"
+libffi = "3.2"
 libloading = "0.8"
 widestring = { workspace = true }
 

--- a/vm/Cargo.toml
+++ b/vm/Cargo.toml
@@ -100,9 +100,11 @@ uname = "0.1.1"
 rustyline = { workspace = true }
 which = "6"
 errno = "0.3"
+widestring = { workspace = true }
+
+[target.'cfg(all(any(target_os = "linux", target_os = "macos", target_os = "windows"), not(any(target_env = "musl", target_env = "sgx"))))'.dependencies]
 libffi = "3.2"
 libloading = "0.8"
-widestring = { workspace = true }
 
 [target.'cfg(any(not(target_arch = "wasm32"), target_os = "wasi"))'.dependencies]
 num_cpus = "1.13.1"

--- a/vm/src/stdlib/ctypes.rs
+++ b/vm/src/stdlib/ctypes.rs
@@ -180,7 +180,21 @@ pub(crate) mod _ctypes {
     }
 
     #[pyfunction(name = "LoadLibrary")]
-    fn load_library(
+    fn load_library_windows(
+        name: String,
+        _load_flags: OptionalArg<i32>,
+        vm: &VirtualMachine,
+    ) -> PyResult<usize> {
+        // TODO: audit functions first
+        // TODO: load_flags
+        let cache = library::libcache();
+        let mut cache_write = cache.write();
+        let (id, _) = cache_write.get_or_insert_lib(&name, vm).unwrap();
+        Ok(id)
+    }
+
+    #[pyfunction(name = "dlopen")]
+    fn load_library_unix(
         name: String,
         _load_flags: OptionalArg<i32>,
         vm: &VirtualMachine,

--- a/vm/src/stdlib/ctypes.rs
+++ b/vm/src/stdlib/ctypes.rs
@@ -189,8 +189,8 @@ pub(crate) mod _ctypes {
         // TODO: load_flags
         let cache = library::libcache();
         let mut cache_write = cache.write();
-        let lib_ref = cache_write.get_or_insert_lib(&name, vm).unwrap();
-        Ok(lib_ref.get_pointer())
+        let (id, _) = cache_write.get_or_insert_lib(&name, vm).unwrap();
+        Ok(id)
     }
 
     #[pyfunction(name = "FreeLibrary")]

--- a/vm/src/stdlib/ctypes.rs
+++ b/vm/src/stdlib/ctypes.rs
@@ -182,7 +182,7 @@ pub(crate) mod _ctypes {
     #[pyfunction(name = "LoadLibrary")]
     fn load_library(
         name: String,
-        load_flags: OptionalArg<i32>,
+        _load_flags: OptionalArg<i32>,
         vm: &VirtualMachine,
     ) -> PyResult<usize> {
         // TODO: audit functions first

--- a/vm/src/stdlib/ctypes.rs
+++ b/vm/src/stdlib/ctypes.rs
@@ -37,7 +37,7 @@ pub(crate) mod _ctypes {
     use super::base::PyCSimple;
     use crate::builtins::PyTypeRef;
     use crate::class::StaticType;
-    use crate::function::Either;
+    use crate::function::{Either, OptionalArg};
     use crate::stdlib::ctypes::library;
     use crate::{AsObject, PyObjectRef, PyResult, TryFromObject, VirtualMachine};
     use crossbeam_utils::atomic::AtomicCell;
@@ -180,8 +180,13 @@ pub(crate) mod _ctypes {
     }
 
     #[pyfunction(name = "LoadLibrary")]
-    fn load_library(name: String, vm: &VirtualMachine) -> PyResult<usize> {
+    fn load_library(
+        name: String,
+        load_flags: OptionalArg<i32>,
+        vm: &VirtualMachine,
+    ) -> PyResult<usize> {
         // TODO: audit functions first
+        // TODO: load_flags
         let cache = library::libcache();
         let mut cache_write = cache.write();
         let lib_ref = cache_write.get_or_insert_lib(&name, vm).unwrap();

--- a/vm/src/stdlib/ctypes/base.rs
+++ b/vm/src/stdlib/ctypes/base.rs
@@ -10,6 +10,31 @@ use num_traits::ToPrimitive;
 use rustpython_common::lock::PyRwLock;
 use std::fmt::Debug;
 
+pub fn ffi_type_from_str(_type_: &str) -> Option<libffi::middle::Type> {
+    match _type_ {
+        "c" => Some(libffi::middle::Type::u8()),
+        "u" => Some(libffi::middle::Type::u32()),
+        "b" => Some(libffi::middle::Type::i8()),
+        "B" => Some(libffi::middle::Type::u8()),
+        "h" => Some(libffi::middle::Type::i16()),
+        "H" => Some(libffi::middle::Type::u16()),
+        "i" => Some(libffi::middle::Type::i32()),
+        "I" => Some(libffi::middle::Type::u32()),
+        "l" => Some(libffi::middle::Type::i32()),
+        "L" => Some(libffi::middle::Type::u32()),
+        "q" => Some(libffi::middle::Type::i64()),
+        "Q" => Some(libffi::middle::Type::u64()),
+        "f" => Some(libffi::middle::Type::f32()),
+        "d" => Some(libffi::middle::Type::f64()),
+        "g" => Some(libffi::middle::Type::f64()),
+        "?" => Some(libffi::middle::Type::u8()),
+        "z" => Some(libffi::middle::Type::u64()),
+        "Z" => Some(libffi::middle::Type::u64()),
+        "P" => Some(libffi::middle::Type::u64()),
+        _ => None,
+    }
+}
+
 #[allow(dead_code)]
 fn set_primitive(_type_: &str, value: &PyObjectRef, vm: &VirtualMachine) -> PyResult {
     match _type_ {

--- a/vm/src/stdlib/ctypes/function.rs
+++ b/vm/src/stdlib/ctypes/function.rs
@@ -109,15 +109,9 @@ impl Debug for PyCFuncPtr {
 }
 
 impl Constructor for PyCFuncPtr {
-    type Args = FuncArgs;
+    type Args = (PyTupleRef, FuncArgs);
 
-    fn py_new(_cls: PyTypeRef, args: Self::Args, vm: &VirtualMachine) -> PyResult {
-        let tuple = args.args.first().ok_or_else(|| {
-            vm.new_type_error("CFuncPtr() takes exactly 1 argument (0 given)".to_string())
-        })?;
-        let tuple: &Py<PyTuple> = tuple
-            .downcast_ref()
-            .ok_or(vm.new_type_error("Expected a tuple".to_string()))?;
+    fn py_new(_cls: PyTypeRef, (tuple, _args): Self::Args, vm: &VirtualMachine) -> PyResult {
         let name = tuple
             .first()
             .ok_or(vm.new_type_error("Expected a tuple with at least 2 elements".to_string()))?

--- a/vm/src/stdlib/ctypes/function.rs
+++ b/vm/src/stdlib/ctypes/function.rs
@@ -1,4 +1,4 @@
-use crate::builtins::{PyStr, PyTuple, PyTypeRef};
+use crate::builtins::{PyStr, PyTupleRef, PyTypeRef};
 use crate::convert::ToPyObject;
 use crate::function::FuncArgs;
 use crate::stdlib::ctypes::PyCData;

--- a/vm/src/stdlib/ctypes/function.rs
+++ b/vm/src/stdlib/ctypes/function.rs
@@ -39,7 +39,7 @@ impl Function {
         let args = args.into_iter().map(|arg| {
             if arg.is_subclass(PyCSimple::static_type().as_object(), vm).unwrap() {
                 let arg_type = arg.get_attr("_type_", vm).unwrap().str(vm).unwrap().to_string();
-                let value = arg.get_attr("value", vm).unwrap();
+                let _value = arg.get_attr("value", vm).unwrap();
                 match &*arg_type {
                     _ => todo!("HANDLE ARG TYPE")
                 }
@@ -54,7 +54,7 @@ impl Function {
             .unwrap() };
         let code_ptr = CodePtr(*pointer as *mut _);
         let return_type = match ret_type {
-            Some(t) => todo!("HANDLE RETURN TYPE"),
+            Some(_t) => todo!("HANDLE RETURN TYPE"),
             None => Type::c_int(),
         };
         let cif = Cif::new(args.into_iter(), return_type);
@@ -64,7 +64,7 @@ impl Function {
         })
     }
 
-    pub unsafe fn call(&self, args: Vec<PyObjectRef>, vm: &VirtualMachine) -> PyObjectRef {
+    pub unsafe fn call(&self, _args: Vec<PyObjectRef>, vm: &VirtualMachine) -> PyObjectRef {
         let args: Vec<Arg> = vec![];
         // TODO: FIX return type
         let result: i32 = unsafe { self.cif.call(self.pointer, &args) };
@@ -94,7 +94,7 @@ impl Debug for PyCFuncPtr {
 impl Constructor for PyCFuncPtr {
     type Args = FuncArgs;
 
-    fn py_new(cls: PyTypeRef, args: Self::Args, vm: &VirtualMachine) -> PyResult {
+    fn py_new(_cls: PyTypeRef, args: Self::Args, vm: &VirtualMachine) -> PyResult {
         let tuple = args.args.first().unwrap();
         let tuple: &Py<PyTuple> = tuple.downcast_ref().unwrap();
         let name = tuple.first().unwrap().downcast_ref::<PyStr>().unwrap().to_string();

--- a/vm/src/stdlib/ctypes/function.rs
+++ b/vm/src/stdlib/ctypes/function.rs
@@ -1,17 +1,77 @@
-use crate::PyObjectRef;
+use crate::builtins::PyTypeRef;
 use crate::stdlib::ctypes::PyCData;
+use crate::types::{Callable, Constructor};
+use crate::{Py, PyObjectRef, PyResult, VirtualMachine};
 use crossbeam_utils::atomic::AtomicCell;
-use rustpython_common::lock::PyRwLock;
+use rustpython_common::lock::{PyMutex, PyRwLock};
 use std::ffi::c_void;
+use std::fmt::Debug;
+use std::sync::Arc;
+
+// https://github.com/python/cpython/blob/4f8bb3947cfbc20f970ff9d9531e1132a9e95396/Modules/_ctypes/callproc.c#L15
+
+#[derive(Debug)]
+pub enum FunctionArgument {
+    Float(std::ffi::c_float),
+    Double(std::ffi::c_double),
+    // TODO: Duplicate char stuff
+    UChar(std::ffi::c_uchar),
+    SChar(std::ffi::c_schar),
+    Char(std::ffi::c_char),
+    UShort(std::ffi::c_ushort),
+    Short(std::ffi::c_short),
+    UInt(std::ffi::c_uint),
+    Int(std::ffi::c_int),
+    ULong(std::ffi::c_ulong),
+    Long(std::ffi::c_long),
+    ULongLong(std::ffi::c_ulonglong),
+    LongLong(std::ffi::c_longlong),
+}
 
 #[derive(Debug)]
 pub struct Function {
-    _pointer: *mut c_void,
-    _arguments: Vec<()>,
-    _return_type: Box<()>,
+    // TODO: no protection from use-after-free
+    pointer: Arc<PyMutex<*mut c_void>>,
+    arguments: Vec<FunctionArgument>,
+    return_type: PyTypeRef,
+}
+
+unsafe impl Send for Function {}
+unsafe impl Sync for Function {}
+
+impl Function {
+    pub unsafe fn load(
+        library: &libloading::Library,
+        function: &str,
+        args: Vec<PyObjectRef>,
+        return_type: PyTypeRef,
+    ) -> PyResult<Self> {
+        let terminated = format!("{}\0", function);
+        let pointer = library
+            .get(terminated.as_bytes())
+            .map_err(|err| err.to_string())
+            .unwrap();
+        Ok(Function {
+            pointer: Arc::new(PyMutex::new(*pointer)),
+            arguments: args
+                .iter()
+                .map(|arg| todo!("convert PyObjectRef to FunctionArgument"))
+                .collect(),
+            return_type,
+        })
+    }
+
+    pub unsafe fn call(&self, vm: &VirtualMachine) -> PyObjectRef {
+        // assemble function type signature
+        let pointer = self.pointer.lock();
+        let f: extern "C" fn() = std::mem::transmute(*pointer);
+        f();
+        vm.ctx.none()
+    }
 }
 
 #[pyclass(module = "_ctypes", name = "CFuncPtr", base = "PyCData")]
+#[derive(PyPayload)]
 pub struct PyCFuncPtr {
     pub _name_: String,
     pub _argtypes_: AtomicCell<Vec<PyObjectRef>>,
@@ -20,5 +80,29 @@ pub struct PyCFuncPtr {
     _f: PyRwLock<Function>,
 }
 
-#[pyclass]
+impl Debug for PyCFuncPtr {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("PyCFuncPtr")
+            .field("_name_", &self._name_)
+            .finish()
+    }
+}
+
+impl Constructor for PyCFuncPtr {
+    type Args = ();
+
+    fn py_new(cls: PyTypeRef, args: Self::Args, vm: &VirtualMachine) -> PyResult {
+        todo!("PyCFuncPtr::py_new")
+    }
+}
+
+impl Callable for PyCFuncPtr {
+    type Args = Vec<PyObjectRef>;
+
+    fn call(zelf: &Py<Self>, _args: Self::Args, vm: &VirtualMachine) -> PyResult {
+        todo!()
+    }
+}
+
+#[pyclass(flags(BASETYPE), with(Callable, Constructor))]
 impl PyCFuncPtr {}

--- a/vm/src/stdlib/ctypes/function.rs
+++ b/vm/src/stdlib/ctypes/function.rs
@@ -1,16 +1,17 @@
-use crate::builtins::PyTypeRef;
+use crate::builtins::{PyStr, PyTuple, PyTypeRef};
 use crate::stdlib::ctypes::PyCData;
 use crate::types::{Callable, Constructor};
-use crate::{AsObject, Py, PyObjectRef, PyRef, PyResult, VirtualMachine};
+use crate::{AsObject, Py, PyObjectRef, PyResult, VirtualMachine};
 use crossbeam_utils::atomic::AtomicCell;
-use rustpython_common::lock::{PyMutex, PyRwLock};
-use std::ffi::c_void;
 use std::fmt::Debug;
-use std::sync::Arc;
 use crate::class::StaticType;
 use crate::stdlib::ctypes::base::PyCSimple;
 use libffi::middle::{Arg, Cif, CodePtr, Type};
 use libloading::Symbol;
+use num_traits::ToPrimitive;
+use rustpython_common::lock::PyRwLock;
+use crate::convert::ToPyObject;
+use crate::function::FuncArgs;
 // https://github.com/python/cpython/blob/4f8bb3947cfbc20f970ff9d9531e1132a9e95396/Modules/_ctypes/callproc.c#L15
 
 
@@ -31,7 +32,7 @@ impl Function {
         library: &libloading::Library,
         function: &str,
         args: &[PyObjectRef],
-        ret_type: Option<PyTypeRef>,
+        ret_type: &Option<PyTypeRef>,
         vm: &VirtualMachine,
     ) -> PyResult<Self> {
         // map each arg to a PyCSimple
@@ -47,10 +48,10 @@ impl Function {
             }
         }).collect::<Vec<Type>>();
         let terminated = format!("{}\0", function);
-        let pointer: Symbol<FP> = library
+        let pointer: Symbol<FP> = unsafe { library
             .get(terminated.as_bytes())
             .map_err(|err| err.to_string())
-            .unwrap();
+            .unwrap() };
         let code_ptr = CodePtr(*pointer as *mut _);
         let return_type = match ret_type {
             Some(t) => todo!("HANDLE RETURN TYPE"),
@@ -65,46 +66,74 @@ impl Function {
 
     pub unsafe fn call(&self, args: Vec<PyObjectRef>, vm: &VirtualMachine) -> PyObjectRef {
         let args: Vec<Arg> = vec![];
-        let result = self.cif.call(self.pointer, &args);
-        vm.ctx.none()
+        // TODO: FIX return type
+        let result: i32 = unsafe { self.cif.call(self.pointer, &args) };
+        vm.ctx.new_int(result).into()
     }
 }
 
 #[pyclass(module = "_ctypes", name = "CFuncPtr", base = "PyCData")]
 #[derive(PyPayload)]
 pub struct PyCFuncPtr {
-    pub _name_: String,
-    pub _argtypes_: AtomicCell<Vec<PyObjectRef>>,
-    pub _restype_: AtomicCell<PyObjectRef>,
-    _handle: PyObjectRef,
-    _f: PyRwLock<Function>,
+    pub name: PyRwLock<String>,
+    pub _flags_: AtomicCell<u32>,
+    // FIXME(arihant2math): This shouldn't be an option, setting the default as the none type should work
+    //  This is a workaround for now and I'll fix it later
+    pub _restype_: PyRwLock<Option<PyTypeRef>>,
+    pub handler: PyObjectRef
 }
 
 impl Debug for PyCFuncPtr {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("PyCFuncPtr")
-            .field("_name_", &self._name_)
+            .field("name", &self.name)
             .finish()
     }
 }
 
 impl Constructor for PyCFuncPtr {
-    type Args = ();
+    type Args = FuncArgs;
 
     fn py_new(cls: PyTypeRef, args: Self::Args, vm: &VirtualMachine) -> PyResult {
-        todo!("PyCFuncPtr::py_new")
+        let tuple = args.args.first().unwrap();
+        let tuple: &Py<PyTuple> = tuple.downcast_ref().unwrap();
+        let name = tuple.first().unwrap().downcast_ref::<PyStr>().unwrap().to_string();
+        let handler = tuple.into_iter().nth(1).unwrap().clone();
+        Ok(Self {
+            _flags_: AtomicCell::new(0),
+            name: PyRwLock::new(name),
+            _restype_: PyRwLock::new(None),
+            handler
+        }.to_pyobject(vm))
     }
 }
 
 impl Callable for PyCFuncPtr {
-    type Args = Vec<PyObjectRef>;
-
-    fn call(zelf: &Py<Self>, _args: Self::Args, vm: &VirtualMachine) -> PyResult {
-        todo!()
+    type Args = FuncArgs;
+    fn call(zelf: &Py<Self>, args: Self::Args, vm: &VirtualMachine) -> PyResult {
+        unsafe {
+            let handle = zelf.handler.get_attr("_handle", vm)?;
+            let handle = handle.try_int(vm)?.as_bigint().clone();
+            let library_cache = crate::stdlib::ctypes::library::libcache().read();
+            let library = library_cache.get_lib(handle.to_usize().unwrap()).unwrap();
+            let inner_lib = library.lib.lock();
+            let name = zelf.name.read();
+            let res_type = zelf._restype_.read();
+            let func = Function::load(inner_lib.as_ref().unwrap(), &name, &args.args, &res_type, vm)?;
+            Ok(func.call(args.args, vm))
+        }
     }
 }
 
 #[pyclass(flags(BASETYPE), with(Callable, Constructor))]
 impl PyCFuncPtr {
+    #[pygetset(magic)]
+    fn name(&self) -> String {
+        self.name.read().clone()
+    }
 
+    #[pygetset(setter, magic)]
+    fn set_name(&self, name: String) {
+        *self.name.write() = name;
+    }
 }

--- a/vm/src/stdlib/ctypes/library.rs
+++ b/vm/src/stdlib/ctypes/library.rs
@@ -1,20 +1,13 @@
 use crate::VirtualMachine;
-use crossbeam_utils::atomic::AtomicCell;
-#[cfg(not(target_os = "windows"))]
-use libloading::os::unix::{Library, Symbol};
-#[cfg(target_os = "windows")]
-use libloading::os::windows::{Library, Symbol};
-use rustpython_common::lock::PyRwLock;
+use libloading::Library;
+use rustpython_common::lock::{PyMutex, PyRwLock};
 use std::collections::HashMap;
 use std::ffi::c_void;
 use std::fmt;
 use std::ptr::null;
 
 pub struct SharedLibrary {
-    #[cfg(target_os = "windows")]
-    lib: AtomicCell<Option<Library>>,
-    #[cfg(not(target_os = "windows"))]
-    lib: AtomicCell<Option<Library>>,
+    pub(crate) lib: PyMutex<Option<Library>>,
 }
 
 impl fmt::Debug for SharedLibrary {
@@ -26,33 +19,13 @@ impl fmt::Debug for SharedLibrary {
 impl SharedLibrary {
     pub fn new(name: &str) -> Result<SharedLibrary, libloading::Error> {
         Ok(SharedLibrary {
-            lib: AtomicCell::new(Some(unsafe { Library::new(name)? })),
+            lib: PyMutex::new(unsafe { Some(Library::new(name)?) }),
         })
-    }
-
-    #[cfg(target_os = "windows")]
-    pub fn new_with_flags(name: &str, flags: u32) -> Result<SharedLibrary, libloading::Error> {
-        Ok(SharedLibrary {
-            lib: AtomicCell::new(Some(unsafe { Library::load_with_flags(name, flags)? })),
-        })
-    }
-
-    #[allow(dead_code)]
-    pub fn get_sym(&self, name: &str) -> Result<*mut c_void, String> {
-        if let Some(inner) = unsafe { &*self.lib.as_ptr() } {
-            unsafe {
-                inner
-                    .get(name.as_bytes())
-                    .map(|f: Symbol<'_, *mut c_void>| *f)
-                    .map_err(|err| err.to_string())
-            }
-        } else {
-            Err("The library has been closed".to_string())
-        }
     }
 
     pub fn get_pointer(&self) -> usize {
-        if let Some(l) = unsafe { &*self.lib.as_ptr() } {
+        let lib_lock = self.lib.lock();
+        if let Some(l) = &*lib_lock {
             l as *const Library as usize
         } else {
             null::<c_void>() as usize
@@ -60,13 +33,12 @@ impl SharedLibrary {
     }
 
     pub fn is_closed(&self) -> bool {
-        unsafe { &*self.lib.as_ptr() }.is_none()
+        let lib_lock = self.lib.lock();
+        &*lib_lock.is_none()
     }
 
     pub fn close(&self) {
-        let old = self.lib.take();
-        self.lib.store(None);
-        drop(old);
+        *self.lib.lock() = None;
     }
 }
 
@@ -96,7 +68,7 @@ impl ExternalLibs {
         &mut self,
         library_path: &str,
         _vm: &VirtualMachine,
-    ) -> Result<&SharedLibrary, libloading::Error> {
+    ) -> Result<(usize, &SharedLibrary), libloading::Error> {
         let nlib = SharedLibrary::new(library_path)?;
         let key = nlib.get_pointer();
 
@@ -111,7 +83,7 @@ impl ExternalLibs {
             }
         };
 
-        Ok(self.libraries.get(&key).unwrap())
+        Ok((key, self.libraries.get(&key).unwrap()))
     }
 
     pub fn drop_lib(&mut self, key: usize) {

--- a/vm/src/stdlib/ctypes/library.rs
+++ b/vm/src/stdlib/ctypes/library.rs
@@ -34,7 +34,7 @@ impl SharedLibrary {
 
     pub fn is_closed(&self) -> bool {
         let lib_lock = self.lib.lock();
-        &*lib_lock.is_none()
+        lib_lock.is_none()
     }
 
     pub fn close(&self) {

--- a/vm/src/stdlib/mod.rs
+++ b/vm/src/stdlib/mod.rs
@@ -76,65 +76,65 @@ pub fn get_module_inits() -> StdlibMap {
         }};
     }
     modules! {
-            #[cfg(all())]
-            {
-                "atexit" => atexit::make_module,
-                "_codecs" => codecs::make_module,
-                "_collections" => collections::make_module,
-                "errno" => errno::make_module,
-                "_functools" => functools::make_module,
-                "itertools" => itertools::make_module,
-                "_io" => io::make_module,
-                "marshal" => marshal::make_module,
-                "_operator" => operator::make_module,
-                "_signal" => signal::make_module,
-                "_sre" => sre::make_module,
-                "_string" => string::make_module,
-                "time" => time::make_module,
-                "_typing" => typing::make_module,
-                "_weakref" => weakref::make_module,
-                "_imp" => imp::make_module,
-                "_warnings" => warnings::make_module,
-                sys::sysconfigdata_name() => sysconfigdata::make_module,
-            }
-            // parser related modules:
-            #[cfg(feature = "rustpython-ast")]
-            {
-                "_ast" => ast::make_module,
-            }
-            // compiler related modules:
-            #[cfg(feature = "rustpython-compiler")]
-            {
-                "symtable" => symtable::make_module,
-            }
-            #[cfg(any(unix, target_os = "wasi"))]
-            {
-                "posix" => posix::make_module,
-                // "fcntl" => fcntl::make_module,
-            }
-            #[cfg(feature = "threading")]
-            {
-                "_thread" => thread::make_module,
-            }
-            // Unix-only
-            #[cfg(all(unix, not(any(target_os = "android", target_os = "redox"))))]
-            {
-                "pwd" => pwd::make_module,
-            }
-            // Windows-only
-            #[cfg(windows)]
-            {
-                "nt" => nt::make_module,
-                "msvcrt" => msvcrt::make_module,
-                "_winapi" => winapi::make_module,
-                "winreg" => winreg::make_module,
-            }
-            #[cfg(all(
-                any(target_os = "linux", target_os = "macos", target_os = "windows"),
-                not(any(target_env = "musl", target_env = "sgx"))
-            ))]
-            {
-                    "_ctypes" => ctypes::make_module,
-            }
+        #[cfg(all())]
+        {
+            "atexit" => atexit::make_module,
+            "_codecs" => codecs::make_module,
+            "_collections" => collections::make_module,
+            "errno" => errno::make_module,
+            "_functools" => functools::make_module,
+            "itertools" => itertools::make_module,
+            "_io" => io::make_module,
+            "marshal" => marshal::make_module,
+            "_operator" => operator::make_module,
+            "_signal" => signal::make_module,
+            "_sre" => sre::make_module,
+            "_string" => string::make_module,
+            "time" => time::make_module,
+            "_typing" => typing::make_module,
+            "_weakref" => weakref::make_module,
+            "_imp" => imp::make_module,
+            "_warnings" => warnings::make_module,
+            sys::sysconfigdata_name() => sysconfigdata::make_module,
+        }
+        // parser related modules:
+        #[cfg(feature = "rustpython-ast")]
+        {
+            "_ast" => ast::make_module,
+        }
+        // compiler related modules:
+        #[cfg(feature = "rustpython-compiler")]
+        {
+            "symtable" => symtable::make_module,
+        }
+        #[cfg(any(unix, target_os = "wasi"))]
+        {
+            "posix" => posix::make_module,
+            // "fcntl" => fcntl::make_module,
+        }
+        #[cfg(feature = "threading")]
+        {
+            "_thread" => thread::make_module,
+        }
+        // Unix-only
+        #[cfg(all(unix, not(any(target_os = "android", target_os = "redox"))))]
+        {
+            "pwd" => pwd::make_module,
+        }
+        // Windows-only
+        #[cfg(windows)]
+        {
+            "nt" => nt::make_module,
+            "msvcrt" => msvcrt::make_module,
+            "_winapi" => winapi::make_module,
+            "winreg" => winreg::make_module,
+        }
+        #[cfg(all(
+            any(target_os = "linux", target_os = "macos", target_os = "windows"),
+            not(any(target_env = "musl", target_env = "sgx"))
+        ))]
+        {
+                "_ctypes" => ctypes::make_module,
+        }
     }
 }

--- a/vm/src/stdlib/mod.rs
+++ b/vm/src/stdlib/mod.rs
@@ -37,7 +37,10 @@ pub mod posix;
 #[path = "posix_compat.rs"]
 pub mod posix;
 
-#[cfg(any(target_family = "unix", target_family = "windows"))]
+#[cfg(all(
+    any(target_os = "linux", target_os = "macos", target_os = "windows"),
+    not(any(target_env = "musl", target_env = "sgx"))
+))]
 mod ctypes;
 #[cfg(windows)]
 pub(crate) mod msvcrt;
@@ -73,62 +76,65 @@ pub fn get_module_inits() -> StdlibMap {
         }};
     }
     modules! {
-        #[cfg(all())]
-        {
-            "atexit" => atexit::make_module,
-            "_codecs" => codecs::make_module,
-            "_collections" => collections::make_module,
-            "errno" => errno::make_module,
-            "_functools" => functools::make_module,
-            "itertools" => itertools::make_module,
-            "_io" => io::make_module,
-            "marshal" => marshal::make_module,
-            "_operator" => operator::make_module,
-            "_signal" => signal::make_module,
-            "_sre" => sre::make_module,
-            "_string" => string::make_module,
-            "time" => time::make_module,
-            "_typing" => typing::make_module,
-            "_weakref" => weakref::make_module,
-            "_imp" => imp::make_module,
-            "_warnings" => warnings::make_module,
-            sys::sysconfigdata_name() => sysconfigdata::make_module,
-        }
-        // parser related modules:
-        #[cfg(feature = "rustpython-ast")]
-        {
-            "_ast" => ast::make_module,
-        }
-        // compiler related modules:
-        #[cfg(feature = "rustpython-compiler")]
-        {
-            "symtable" => symtable::make_module,
-        }
-        #[cfg(any(unix, target_os = "wasi"))]
-        {
-            "posix" => posix::make_module,
-            // "fcntl" => fcntl::make_module,
-        }
-        #[cfg(feature = "threading")]
-        {
-            "_thread" => thread::make_module,
-        }
-        // Unix-only
-        #[cfg(all(unix, not(any(target_os = "android", target_os = "redox"))))]
-        {
-            "pwd" => pwd::make_module,
-        }
-        // Windows-only
-        #[cfg(windows)]
-        {
-            "nt" => nt::make_module,
-            "msvcrt" => msvcrt::make_module,
-            "_winapi" => winapi::make_module,
-            "winreg" => winreg::make_module,
-        }
-        #[cfg(any(target_family = "unix", target_family = "windows"))]
-        {
-            "_ctypes" => ctypes::make_module,
-        }
+            #[cfg(all())]
+            {
+                "atexit" => atexit::make_module,
+                "_codecs" => codecs::make_module,
+                "_collections" => collections::make_module,
+                "errno" => errno::make_module,
+                "_functools" => functools::make_module,
+                "itertools" => itertools::make_module,
+                "_io" => io::make_module,
+                "marshal" => marshal::make_module,
+                "_operator" => operator::make_module,
+                "_signal" => signal::make_module,
+                "_sre" => sre::make_module,
+                "_string" => string::make_module,
+                "time" => time::make_module,
+                "_typing" => typing::make_module,
+                "_weakref" => weakref::make_module,
+                "_imp" => imp::make_module,
+                "_warnings" => warnings::make_module,
+                sys::sysconfigdata_name() => sysconfigdata::make_module,
+            }
+            // parser related modules:
+            #[cfg(feature = "rustpython-ast")]
+            {
+                "_ast" => ast::make_module,
+            }
+            // compiler related modules:
+            #[cfg(feature = "rustpython-compiler")]
+            {
+                "symtable" => symtable::make_module,
+            }
+            #[cfg(any(unix, target_os = "wasi"))]
+            {
+                "posix" => posix::make_module,
+                // "fcntl" => fcntl::make_module,
+            }
+            #[cfg(feature = "threading")]
+            {
+                "_thread" => thread::make_module,
+            }
+            // Unix-only
+            #[cfg(all(unix, not(any(target_os = "android", target_os = "redox"))))]
+            {
+                "pwd" => pwd::make_module,
+            }
+            // Windows-only
+            #[cfg(windows)]
+            {
+                "nt" => nt::make_module,
+                "msvcrt" => msvcrt::make_module,
+                "_winapi" => winapi::make_module,
+                "winreg" => winreg::make_module,
+            }
+            #[cfg(all(
+                any(target_os = "linux", target_os = "macos", target_os = "windows"),
+                not(any(target_env = "musl", target_env = "sgx"))
+            ))]
+            {
+                    "_ctypes" => ctypes::make_module,
+            }
     }
 }

--- a/vm/src/stdlib/mod.rs
+++ b/vm/src/stdlib/mod.rs
@@ -134,7 +134,7 @@ pub fn get_module_inits() -> StdlibMap {
             not(any(target_env = "musl", target_env = "sgx"))
         ))]
         {
-                "_ctypes" => ctypes::make_module,
+            "_ctypes" => ctypes::make_module,
         }
     }
 }


### PR DESCRIPTION
Here comes the meat of the code and the hardest part implementation-wise.
The main goal is to implement (atleast partially) `CFuncPtr`. By partially, I mean that not supporting arguments to functions is probably fine. At any rate the cpython implementation can be used as a reference since they use libffi. The main challenge is determining the return type of the loaded function from the `cvoid` it'll return (unless we don't have to do that for some reason).

- [x] Use libffi to manage functions (Can't pass in arbitrary arguments to functions through libloading)
- [x] Constructor for `CFuncPtr`
- [x] Give inner function class the ability to load functions
- [x] Give it the ability to call them and get the return
- [x] Cast the return properly
- [x] Callable for `CFuncPtr` that encapsulated the entire thing

The next pr can probably just do some cleanup on this and get the basics for struct and union return types working.

# Known issues
- Arguments cause errors to be thrown
- Return type of functions is `c_int` and cannot be changed
- Error handling isn't great.
- `import ctypes` fails
- creating string buffers is broken