### PR TITLE
Windows testing

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -60,7 +60,6 @@ env:
     test_dis
     test_enumerate
     test_exception_variations
-    test_exceptions
     test_float
     test_format
     test_fractions

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -18,6 +18,7 @@ env:
   CARGO_ARGS: --no-default-features --features stdlib,zlib,importlib,encodings,sqlite,ssl
   # Skip additional tests on Windows. They are checked on Linux and MacOS.
   WINDOWS_SKIPS: >-
+    test_argparse
     test_glob
     test_importlib
     test_io

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -44,7 +44,6 @@ env:
   # only run on Linux to speed up the CI.
   PLATFORM_INDEPENDENT_TESTS: >-
     test__colorize
-    test_argparse
     test_array
     test_asyncgen
     test_binop

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -17,6 +17,13 @@ concurrency:
 env:
   CARGO_ARGS: --no-default-features --features stdlib,zlib,importlib,encodings,sqlite,ssl
   # Skip additional tests on Windows. They are checked on Linux and MacOS.
+  # test_argparse: UnicodeDecodeError
+  # test_glob: many failing tests
+  # test_io: many failing tests
+  # test_os: many failing tests
+  # test_pathlib: support.rmtree() failing
+  # test_posixpath: OSError: (22, 'The filename, directory name, or volume label syntax is incorrect. (os error 123)')
+  # test_venv: couple of failing tests
   WINDOWS_SKIPS: >-
     test_argparse
     test_glob

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -20,7 +20,6 @@ env:
   WINDOWS_SKIPS: >-
     test_argparse
     test_glob
-    test_importlib
     test_io
     test_os
     test_pathlib

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -23,14 +23,17 @@ env:
   # test_os: many failing tests
   # test_pathlib: support.rmtree() failing
   # test_posixpath: OSError: (22, 'The filename, directory name, or volume label syntax is incorrect. (os error 123)')
+  # test_unicode: AttributeError: module '_winapi' has no attribute 'GetACP'
   # test_venv: couple of failing tests
   WINDOWS_SKIPS: >-
     test_argparse
     test_glob
     test_io
     test_os
+    test_rlcompleter
     test_pathlib
     test_posixpath
+    test_unicode
     test_venv
   # configparser: https://github.com/RustPython/RustPython/issues/4995#issuecomment-1582397417
   # socketserver: seems related to configparser crash.
@@ -106,7 +109,6 @@ env:
     test_tuple
     test_types
     test_unary
-    test_unicode
     test_unpack
     test_weakref
     test_yield_from

--- a/Lib/test/test_importlib/frozen/test_loader.py
+++ b/Lib/test/test_importlib/frozen/test_loader.py
@@ -77,6 +77,7 @@ class ExecModuleTests(abc.LoaderTests):
         self.assertTrue(hasattr(module, '__spec__'))
         self.assertEqual(module.__spec__.loader_state.origname, name)
 
+    @unittest.expectedFailureIfWindows("TODO: RUSTPYTHON")
     def test_package(self):
         name = '__phello__'
         module, output = self.exec_module(name)
@@ -90,6 +91,7 @@ class ExecModuleTests(abc.LoaderTests):
         self.assertEqual(output, 'Hello world!\n')
         self.assertEqual(module.__spec__.loader_state.origname, name)
 
+    @unittest.expectedFailureIfWindows("TODO: RUSTPYTHON")
     def test_lacking_parent(self):
         name = '__phello__.spam'
         with util.uncache('__phello__'):
@@ -147,6 +149,7 @@ class InspectLoaderTests:
             result = self.machinery.FrozenImporter.get_source('__hello__')
         self.assertIsNone(result)
 
+    @unittest.expectedFailureIfWindows("TODO: RUSTPYTHON")
     def test_is_package(self):
         # Should be able to tell what is a package.
         test_for = (('__hello__', False), ('__phello__', True),

--- a/Lib/test/test_importlib/frozen/test_loader.py
+++ b/Lib/test/test_importlib/frozen/test_loader.py
@@ -78,7 +78,7 @@ class ExecModuleTests(abc.LoaderTests):
         self.assertTrue(hasattr(module, '__spec__'))
         self.assertEqual(module.__spec__.loader_state.origname, name)
 
-    @unittest.expectedFailureIfWindows("TODO: RUSTPYTHON")
+    @unittest.skipIf(sys.platform == "win32", "TODO: RUSTPYTHON")
     def test_package(self):
         name = '__phello__'
         module, output = self.exec_module(name)
@@ -150,7 +150,7 @@ class InspectLoaderTests:
             result = self.machinery.FrozenImporter.get_source('__hello__')
         self.assertIsNone(result)
 
-    @unittest.expectedFailureIfWindows("TODO: RUSTPYTHON")
+    @unittest.skipIf(sys.platform == "win32", "TODO: RUSTPYTHON")
     def test_is_package(self):
         # Should be able to tell what is a package.
         test_for = (('__hello__', False), ('__phello__', True),

--- a/Lib/test/test_importlib/frozen/test_loader.py
+++ b/Lib/test/test_importlib/frozen/test_loader.py
@@ -7,6 +7,7 @@ import _imp
 import contextlib
 import marshal
 import os.path
+import sys
 import types
 import unittest
 import warnings
@@ -91,7 +92,7 @@ class ExecModuleTests(abc.LoaderTests):
         self.assertEqual(output, 'Hello world!\n')
         self.assertEqual(module.__spec__.loader_state.origname, name)
 
-    @unittest.expectedFailureIfWindows("TODO: RUSTPYTHON")
+    @unittest.skipIf(sys.platform == 'win32', "TODO:RUSTPYTHON Flaky on Windows")
     def test_lacking_parent(self):
         name = '__phello__.spam'
         with util.uncache('__phello__'):

--- a/Lib/test/test_importlib/resources/test_files.py
+++ b/Lib/test/test_importlib/resources/test_files.py
@@ -52,6 +52,10 @@ class OpenDiskTests(FilesTests, unittest.TestCase):
     def setUp(self):
         self.data = data01
 
+    @unittest.expectedFailureIfWindows("TODO: RUSTPYTHON")
+    def test_read_bytes(self):
+        super().test_read_bytes()
+
 
 class OpenZipTests(FilesTests, util.ZipSetup, unittest.TestCase):
     pass
@@ -63,6 +67,9 @@ class OpenNamespaceTests(FilesTests, unittest.TestCase):
 
         self.data = namespacedata01
 
+    @unittest.expectedFailureIfWindows("TODO: RUSTPYTHON")
+    def test_read_bytes(self):
+        super().test_read_bytes()
 
 class SiteDir:
     def setUp(self):

--- a/Lib/test/test_importlib/resources/test_open.py
+++ b/Lib/test/test_importlib/resources/test_open.py
@@ -69,6 +69,10 @@ class OpenDiskTests(OpenTests, unittest.TestCase):
     def setUp(self):
         self.data = data01
 
+    @unittest.expectedFailureIfWindows("TODO: RUSTPYTHON")
+    def test_read_bytes(self):
+        super().test_read_bytes()
+
 
 class OpenDiskNamespaceTests(OpenTests, unittest.TestCase):
     def setUp(self):

--- a/Lib/test/test_importlib/resources/test_open.py
+++ b/Lib/test/test_importlib/resources/test_open.py
@@ -69,10 +69,6 @@ class OpenDiskTests(OpenTests, unittest.TestCase):
     def setUp(self):
         self.data = data01
 
-    @unittest.expectedFailureIfWindows("TODO: RUSTPYTHON")
-    def test_read_bytes(self):
-        super().test_read_bytes()
-
 
 class OpenDiskNamespaceTests(OpenTests, unittest.TestCase):
     def setUp(self):

--- a/Lib/test/test_importlib/source/test_finder.py
+++ b/Lib/test/test_importlib/source/test_finder.py
@@ -168,7 +168,6 @@ class FinderTests(abc.FinderTests):
         found = self._find(finder, 'doesnotexist')
         self.assertEqual(found, self.NOT_FOUND)
 
-    @unittest.expectedFailureIfWindows("TODO: RUSTPYTHON")
     def test_ignore_file(self):
         # If a directory got changed to a file from underneath us, then don't
         # worry about looking for submodules.

--- a/vm/src/exceptions.rs
+++ b/vm/src/exceptions.rs
@@ -374,7 +374,7 @@ fn write_traceback_entry<W: Write>(
     writeln!(
         output,
         r##"  File "{}", line {}, in {}"##,
-        filename, tb_entry.lineno, tb_entry.frame.code.obj_name
+        filename.trim_start_matches(r"\\?\"), tb_entry.lineno, tb_entry.frame.code.obj_name
     )?;
     print_source_line(output, filename, tb_entry.lineno.to_usize())?;
 

--- a/vm/src/exceptions.rs
+++ b/vm/src/exceptions.rs
@@ -374,7 +374,9 @@ fn write_traceback_entry<W: Write>(
     writeln!(
         output,
         r##"  File "{}", line {}, in {}"##,
-        filename.trim_start_matches(r"\\?\"), tb_entry.lineno, tb_entry.frame.code.obj_name
+        filename.trim_start_matches(r"\\?\"),
+        tb_entry.lineno,
+        tb_entry.frame.code.obj_name
     )?;
     print_source_line(output, filename, tb_entry.lineno.to_usize())?;
 


### PR DESCRIPTION
This makes it so that failing tests on windows are explicitly marked on CI, and considered platform dependent, and non-failing ones are re-enabled. This also fixes a few bugs to unblock tests and fix broken ones.