### PR TITLE
Ensure pymethod cannot be both magic and named simultaneously + macro documentation

### DIFF
--- a/derive-impl/src/pyclass.rs
+++ b/derive-impl/src/pyclass.rs
@@ -1229,6 +1229,13 @@ impl MethodItemMeta {
         let inner = self.inner();
         let name = inner._optional_str("name")?;
         let magic = inner._bool("magic")?;
+        if magic && name.is_some() {
+            bail_span!(
+                &inner.meta_ident,
+                "A #[{}] method cannot be magic and have a specified name, choose one.",
+                inner.meta_name()
+            );
+        }
         Ok(if let Some(name) = name {
             name
         } else {

--- a/derive/src/lib.rs
+++ b/derive/src/lib.rs
@@ -152,6 +152,61 @@ pub fn pyexception(attr: TokenStream, item: TokenStream) -> TokenStream {
     derive_impl::pyexception(attr, item).into()
 }
 
+/// This attribute must be applied to an inline module.
+/// It defines a Python module in the form a `make_module` function in the module;
+/// this has to be used in a `get_module_inits` to properly register the module.
+/// Additionally, this macro defines 'MODULE_NAME' and 'DOC' in the module.
+/// # Arguments
+/// - `name`: the name of the python module,
+/// by default, it is the name of the module, but this can be configured.
+/// ```no_run
+/// // This will create a module named `mymodule`
+/// #[pymodule(name = "mymodule")]
+/// mod module {
+/// }
+/// ```
+/// - `sub`: declare the module as a submodule of another module.
+/// ```no_run
+/// #[pymodule(sub)]
+/// mod submodule {
+/// }
+///
+/// #[pymodule(with(submodule))]
+/// mod mymodule {
+/// }
+/// ```
+/// - `with`: declare the list of submodules that this module contains (see `sub` for example).
+/// ## pyattr
+/// `pyattr` is a multipurpose marker that can be used in a pymodule.
+/// The most common use is to mark a function or class as a part of the module.
+/// This can be done by applying it to a function or struct prior to the `#[pyfunction]` or `#[pyclass]` macro.
+/// If applied to a constant, it will be added to the module as an attribute.
+/// If applied to a function not marked with `pyfunction`,
+/// it will also be added to the module as an attribute but the value is the result of the function.
+/// If `#[pyattr(once)]` is used in this case, the function will be called once
+/// and the result will be stored using a `static_cell`.
+/// ### Examples
+/// ```no_run
+/// #[pymodule]
+/// mod mymodule {
+///     #[pyattr]
+///     const MY_CONSTANT: i32 = 42;
+///     #[pyattr]
+///    fn another_constant() -> PyResult<i32> {
+///       Ok(42)
+///    }
+///   #[pyattr(once)]
+///   fn once() -> PyResult<i32> {
+///     // This will only be called once and the result will be stored.
+///     Ok(2 ** 24)
+///  }
+///
+///     #[pyattr]
+///     #[pyfunction]
+///     fn my_function(vm: &VirtualMachine) -> PyResult<()> {
+///         ...
+///     }
+/// }
 #[proc_macro_attribute]
 pub fn pymodule(attr: TokenStream, item: TokenStream) -> TokenStream {
     let attr = parse_macro_input!(attr);

--- a/derive/src/lib.rs
+++ b/derive/src/lib.rs
@@ -32,7 +32,7 @@ pub fn derive_from_args(input: TokenStream) -> TokenStream {
 ///     - `BASETYPE`: allows the class to be inheritable.
 ///     - `IMMUTABLETYPE`: class attributes are immutable.
 /// - `with`: which trait implementations are to be included in the python class.
-/// ```no_run
+/// ```rust, ignore
 /// #[pyclass(module = "mymodule", name = "MyClass", base = "BaseClass")]
 /// struct MyStruct {
 ///    x: i32,
@@ -64,7 +64,7 @@ pub fn derive_from_args(input: TokenStream) -> TokenStream {
 /// Consider using `OptionalArg` for optional arguments.
 /// #### Arguments
 /// - `magic`: marks the method as a magic method: the method name is surrounded with double underscores.
-/// ```no_run
+/// ```rust, ignore
 /// #[pyclass]
 /// impl MyStruct {
 ///     // This will be called as the `__add__` method in Python.
@@ -88,7 +88,7 @@ pub fn derive_from_args(input: TokenStream) -> TokenStream {
 ///
 /// Ensure both the getter and setter are marked with `name` and `magic` in the same manner.
 /// #### Examples
-/// ```no_run
+/// ```rust, ignore
 /// #[pyclass]
 /// impl MyStruct {
 ///    #[pygetset]
@@ -111,7 +111,7 @@ pub fn derive_from_args(input: TokenStream) -> TokenStream {
 /// This helps inherit attributes from a parent class.
 /// The method this is applied on should be called `extend_class_with_fields`.
 /// #### Examples
-/// ```no_run
+/// ```rust, ignore
 /// #[extend_class]
 /// fn extend_class_with_fields(ctx: &Context, class: &'static Py<PyType>) {
 ///     class.set_attr(
@@ -159,14 +159,14 @@ pub fn pyexception(attr: TokenStream, item: TokenStream) -> TokenStream {
 /// # Arguments
 /// - `name`: the name of the python module,
 ///   by default, it is the name of the module, but this can be configured.
-/// ```no_run
+/// ```rust, ignore
 /// // This will create a module named `mymodule`
 /// #[pymodule(name = "mymodule")]
 /// mod module {
 /// }
 /// ```
 /// - `sub`: declare the module as a submodule of another module.
-/// ```no_run
+/// ```rust, ignore
 /// #[pymodule(sub)]
 /// mod submodule {
 /// }
@@ -187,7 +187,7 @@ pub fn pyexception(attr: TokenStream, item: TokenStream) -> TokenStream {
 /// If `#[pyattr(once)]` is used in this case, the function will be called once
 /// and the result will be stored using a `static_cell`.
 /// #### Examples
-/// ```no_run
+/// ```rust, ignore
 /// #[pymodule]
 /// mod mymodule {
 ///     #[pyattr]

--- a/derive/src/lib.rs
+++ b/derive/src/lib.rs
@@ -176,7 +176,8 @@ pub fn pyexception(attr: TokenStream, item: TokenStream) -> TokenStream {
 /// }
 /// ```
 /// - `with`: declare the list of submodules that this module contains (see `sub` for example).
-/// ## pyattr
+/// ## Inner markers
+/// ### pyattr
 /// `pyattr` is a multipurpose marker that can be used in a pymodule.
 /// The most common use is to mark a function or class as a part of the module.
 /// This can be done by applying it to a function or struct prior to the `#[pyfunction]` or `#[pyclass]` macro.
@@ -185,7 +186,7 @@ pub fn pyexception(attr: TokenStream, item: TokenStream) -> TokenStream {
 /// it will also be added to the module as an attribute but the value is the result of the function.
 /// If `#[pyattr(once)]` is used in this case, the function will be called once
 /// and the result will be stored using a `static_cell`.
-/// ### Examples
+/// #### Examples
 /// ```no_run
 /// #[pymodule]
 /// mod mymodule {
@@ -207,6 +208,15 @@ pub fn pyexception(attr: TokenStream, item: TokenStream) -> TokenStream {
 ///         ...
 ///     }
 /// }
+/// ```
+/// ### pyfunction
+/// This is used to create a python function.
+/// #### Function signature
+/// The last argument can optionally be of the type `&VirtualMachine` to access the VM.
+/// Refer to the `pymethod` documentation (located in the `pyclass` macro documentation)
+/// for more information on what regular argument types are permitted.
+/// #### Arguments
+/// - `name`: the name of the function in Python, by default it is the same as the associated Rust function.
 #[proc_macro_attribute]
 pub fn pymodule(attr: TokenStream, item: TokenStream) -> TokenStream {
     let attr = parse_macro_input!(attr);

--- a/derive/src/lib.rs
+++ b/derive/src/lib.rs
@@ -20,7 +20,7 @@ pub fn derive_from_args(input: TokenStream) -> TokenStream {
 /// - `module`: the module which contains the class --  can be omitted if in a `#[pymodule]`.
 /// - `name`: the name of the Python class, by default it is the name of the struct.
 /// - `base`: the base class of the Python class.
-/// This does not cause inheritance of functions or attributes that must be done by a separate trait.
+///   This does not cause inheritance of functions or attributes that must be done by a separate trait.
 /// # Impl
 /// This part implements `PyClassImpl` for the struct.
 /// This includes methods, getters/setters, etc.; only annotated methods will be included.
@@ -75,16 +75,16 @@ pub fn derive_from_args(input: TokenStream) -> TokenStream {
 /// }
 /// ```
 /// - `name`: the name of the method in Python,
-/// by default it is the same as the Rust method, or surrounded by double underscores if magic is present.
-/// This overrides `magic` and the default name and cannot be used with `magic` to prevent ambiguity.
+///   by default it is the same as the Rust method, or surrounded by double underscores if magic is present.
+///   This overrides `magic` and the default name and cannot be used with `magic` to prevent ambiguity.
 /// ### pygetset
 /// This is used to mark a getter/setter pair.
 /// #### Arguments
 /// - `setter`: marks the method as a setter, it acts as a getter by default.
-/// Setter method names should be prefixed with `set_`.
+///   Setter method names should be prefixed with `set_`.
 /// - `name`: the name of the attribute in Python, by default it is the same as the Rust method.
 /// - `magic`: marks the method as a magic method: the method name is surrounded with double underscores.
-/// This cannot be used with `name` to prevent ambiguity.
+///   This cannot be used with `name` to prevent ambiguity.
 ///
 /// Ensure both the getter and setter are marked with `name` and `magic` in the same manner.
 /// #### Examples
@@ -158,7 +158,7 @@ pub fn pyexception(attr: TokenStream, item: TokenStream) -> TokenStream {
 /// Additionally, this macro defines 'MODULE_NAME' and 'DOC' in the module.
 /// # Arguments
 /// - `name`: the name of the python module,
-/// by default, it is the name of the module, but this can be configured.
+///   by default, it is the name of the module, but this can be configured.
 /// ```no_run
 /// // This will create a module named `mymodule`
 /// #[pymodule(name = "mymodule")]


### PR DESCRIPTION
Originally, this would ignore the `magic`, which is counterintuitive, so it now just throws an error (nothing relies on this, so I think a hard error should be fine). I also documented `pyclass` and `pymodule` with API docs which cover almost everything.
The docs here are mostly just highly specific documentation for every argument and use case. https://github.com/RustPython/RustPython/wiki/Python-Attributes is currently a high level overview and can now be more geared towards that.

It would be nice if the docs for the main branch could be deployed using github pages to display them for users, since the current docs.rs content is highly out of date.