### PR TITLE
Fix unicode decode bug on surrogate error mode

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -17,7 +17,6 @@ concurrency:
 env:
   CARGO_ARGS: --no-default-features --features stdlib,zlib,importlib,encodings,sqlite,ssl
   # Skip additional tests on Windows. They are checked on Linux and MacOS.
-  # test_argparse: UnicodeDecodeError
   # test_glob: many failing tests
   # test_io: many failing tests
   # test_os: many failing tests
@@ -26,7 +25,6 @@ env:
   # test_unicode: AttributeError: module '_winapi' has no attribute 'GetACP'
   # test_venv: couple of failing tests
   WINDOWS_SKIPS: >-
-    test_argparse
     test_glob
     test_io
     test_os

--- a/vm/src/codecs.rs
+++ b/vm/src/codecs.rs
@@ -619,11 +619,16 @@ fn surrogatepass_errors(err: PyObjectRef, vm: &VirtualMachine) -> PyResult<(PyOb
             // Not supported, fail with original exception
             return Err(err.downcast().unwrap());
         }
+
+        debug_assert!(range.start <= 0.max(s.len() - 1));
+        debug_assert!(range.end >= 1.min(s.len()));
+        debug_assert!(range.end <= s.len());
+
         let mut c: u32 = 0;
         // Try decoding a single surrogate character. If there are more,
         // let the codec call us again.
         let p = &s.as_bytes()[range.start..];
-        if p.len().saturating_sub(range.start) >= byte_length {
+        if p.len().overflowing_sub(range.start).0 >= byte_length {
             match standard_encoding {
                 StandardEncoding::Utf8 => {
                     if (p[0] as u32 & 0xf0) == 0xe0


### PR DESCRIPTION
Fixes #5542; error introduced by #5502. Adds some debug assertions that are also in cpython.
This will help allow test_argparse to work for windows.