### PR TITLE
Enable rust2024-incompatible pat and keyword-ident lints

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -190,9 +190,13 @@ wasm-bindgen = "0.2.100"
 [workspace.lints.rust]
 unsafe_code = "allow"
 unsafe_op_in_unsafe_fn = "deny"
+
+# rust_2024_compatibility
 missing_unsafe_on_extern = "deny"
 unsafe_attr_outside_unsafe = "deny"
 deprecated_safe_2024 = "deny"
+rust_2024_incompatible_pat = "deny"
+keyword_idents_2024 = "deny"
 
 [workspace.lints.clippy]
 perf = "warn"

--- a/common/src/int.rs
+++ b/common/src/int.rs
@@ -50,7 +50,7 @@ pub fn bytes_to_int(lit: &[u8], mut base: u32) -> Option<BigInt> {
                     base = parsed;
                     true
                 } else {
-                    if let [_first, ref others @ .., last] = lit {
+                    if let [_first, others @ .., last] = lit {
                         let is_zero =
                             others.iter().all(|&c| c == b'0' || c == b'_') && *last == b'0';
                         if !is_zero {

--- a/compiler/codegen/src/compile.rs
+++ b/compiler/codegen/src/compile.rs
@@ -3302,13 +3302,13 @@ impl Compiler {
                 elt, generators, ..
             }) => {
                 Self::contains_await(elt)
-                    || generators.iter().any(|gen| Self::contains_await(&gen.iter))
+                    || generators.iter().any(|jen| Self::contains_await(&jen.iter))
             }
             Expr::SetComp(located_ast::ExprSetComp {
                 elt, generators, ..
             }) => {
                 Self::contains_await(elt)
-                    || generators.iter().any(|gen| Self::contains_await(&gen.iter))
+                    || generators.iter().any(|jen| Self::contains_await(&jen.iter))
             }
             Expr::DictComp(located_ast::ExprDictComp {
                 key,
@@ -3318,13 +3318,13 @@ impl Compiler {
             }) => {
                 Self::contains_await(key)
                     || Self::contains_await(value)
-                    || generators.iter().any(|gen| Self::contains_await(&gen.iter))
+                    || generators.iter().any(|jen| Self::contains_await(&jen.iter))
             }
             Expr::GeneratorExp(located_ast::ExprGeneratorExp {
                 elt, generators, ..
             }) => {
                 Self::contains_await(elt)
-                    || generators.iter().any(|gen| Self::contains_await(&gen.iter))
+                    || generators.iter().any(|jen| Self::contains_await(&jen.iter))
             }
             Expr::Starred(expr) => Self::contains_await(&expr.value),
             Expr::IfExp(located_ast::ExprIfExp {

--- a/derive-impl/src/pytraverse.rs
+++ b/derive-impl/src/pytraverse.rs
@@ -70,7 +70,7 @@ fn gen_trace_code(item: &mut DeriveInput) -> Result<TokenStream> {
         syn::Data::Struct(s) => {
             let fields = &mut s.fields;
             match fields {
-                syn::Fields::Named(ref mut fields) => {
+                syn::Fields::Named(fields) => {
                     let res: Vec<TokenStream> = fields
                         .named
                         .iter_mut()

--- a/derive-impl/src/util.rs
+++ b/derive-impl/src/util.rs
@@ -529,7 +529,7 @@ impl AttributeExt for Attribute {
     fn try_remove_name(&mut self, item_name: &str) -> Result<Option<NestedMeta>> {
         self.try_meta_mut(|meta| {
             let nested = match meta {
-                Meta::List(MetaList { ref mut nested, .. }) => Ok(nested),
+                Meta::List(MetaList { nested, .. }) => Ok(nested),
                 other => Err(syn::Error::new(
                     other.span(),
                     format!(

--- a/jit/src/lib.rs
+++ b/jit/src/lib.rs
@@ -215,9 +215,9 @@ pub enum AbiValue {
 impl AbiValue {
     fn to_libffi_arg(&self) -> libffi::middle::Arg {
         match self {
-            AbiValue::Int(ref i) => libffi::middle::Arg::new(i),
-            AbiValue::Float(ref f) => libffi::middle::Arg::new(f),
-            AbiValue::Bool(ref b) => libffi::middle::Arg::new(b),
+            AbiValue::Int(i) => libffi::middle::Arg::new(i),
+            AbiValue::Float(f) => libffi::middle::Arg::new(f),
+            AbiValue::Bool(b) => libffi::middle::Arg::new(b),
         }
     }
 }

--- a/stdlib/src/json/machinery.rs
+++ b/stdlib/src/json/machinery.rs
@@ -135,7 +135,7 @@ pub fn scanstring<'a>(
     };
     let unterminated_err = || DecodeError::new("Unterminated string starting at", end - 1);
     let mut chars = s.char_indices().enumerate().skip(end).peekable();
-    let (_, (mut chunk_start, _)) = chars.peek().ok_or_else(unterminated_err)?;
+    let &(_, (mut chunk_start, _)) = chars.peek().ok_or_else(unterminated_err)?;
     while let Some((char_i, (byte_i, c))) = chars.next() {
         match c {
             '"' => {

--- a/stdlib/src/mmap.rs
+++ b/stdlib/src/mmap.rs
@@ -497,8 +497,8 @@ mod mmap {
         fn as_bytes(&self) -> BorrowedValue<[u8]> {
             PyMutexGuard::map_immutable(self.mmap.lock(), |m| {
                 match m.as_ref().expect("mmap closed or invalid") {
-                    MmapObj::Read(ref mmap) => &mmap[..],
-                    MmapObj::Write(ref mmap) => &mmap[..],
+                    MmapObj::Read(mmap) => &mmap[..],
+                    MmapObj::Write(mmap) => &mmap[..],
                 }
             })
             .into()

--- a/stdlib/src/socket.rs
+++ b/stdlib/src/socket.rs
@@ -1924,7 +1924,7 @@ mod _socket {
         let host = opts.host.as_ref().map(|s| s.as_str());
         let port = opts.port.as_ref().map(|p| -> std::borrow::Cow<str> {
             match p {
-                Either::A(ref s) => s.as_str().into(),
+                Either::A(s) => s.as_str().into(),
                 Either::B(i) => i.to_string().into(),
             }
         });

--- a/stdlib/src/syslog.rs
+++ b/stdlib/src/syslog.rs
@@ -49,7 +49,7 @@ mod syslog {
     impl GlobalIdent {
         fn as_ptr(&self) -> *const c_char {
             match self {
-                GlobalIdent::Explicit(ref cstr) => cstr.as_ptr(),
+                GlobalIdent::Explicit(cstr) => cstr.as_ptr(),
                 GlobalIdent::Implicit => std::ptr::null(),
             }
         }

--- a/vm/src/builtins/iter.rs
+++ b/vm/src/builtins/iter.rs
@@ -28,7 +28,7 @@ pub enum IterStatus<T> {
 unsafe impl<T: Traverse> Traverse for IterStatus<T> {
     fn traverse(&self, tracer_fn: &mut TraverseFn) {
         match self {
-            IterStatus::Active(ref r) => r.traverse(tracer_fn),
+            IterStatus::Active(r) => r.traverse(tracer_fn),
             IterStatus::Exhausted => (),
         }
     }

--- a/vm/src/builtins/mappingproxy.rs
+++ b/vm/src/builtins/mappingproxy.rs
@@ -29,8 +29,8 @@ enum MappingProxyInner {
 unsafe impl Traverse for MappingProxyInner {
     fn traverse(&self, tracer_fn: &mut TraverseFn) {
         match self {
-            MappingProxyInner::Class(ref r) => r.traverse(tracer_fn),
-            MappingProxyInner::Mapping(ref arg) => arg.traverse(tracer_fn),
+            MappingProxyInner::Class(r) => r.traverse(tracer_fn),
+            MappingProxyInner::Mapping(arg) => arg.traverse(tracer_fn),
         }
     }
 }

--- a/vm/src/function/argument.rs
+++ b/vm/src/function/argument.rs
@@ -497,7 +497,7 @@ where
 {
     fn traverse(&self, tracer_fn: &mut TraverseFn) {
         match self {
-            OptionalArg::Present(ref o) => o.traverse(tracer_fn),
+            OptionalArg::Present(o) => o.traverse(tracer_fn),
             OptionalArg::Missing => (),
         }
     }

--- a/vm/src/stdlib/ast.rs
+++ b/vm/src/stdlib/ast.rs
@@ -3,7 +3,7 @@
 //! This module makes use of the parser logic, and translates all ast nodes
 //! into python ast.AST objects.
 
-mod gen;
+mod r#gen;
 
 use crate::{
     builtins::{self, PyDict, PyModule, PyStrRef, PyType},
@@ -398,6 +398,6 @@ pub const PY_COMPILE_FLAGS_MASK: i32 = PY_COMPILE_FLAG_AST_ONLY
 
 pub fn make_module(vm: &VirtualMachine) -> PyRef<PyModule> {
     let module = _ast::make_module(vm);
-    gen::extend_module_nodes(vm, &module);
+    r#gen::extend_module_nodes(vm, &module);
     module
 }

--- a/vm/src/stdlib/ctypes/base.rs
+++ b/vm/src/stdlib/ctypes/base.rs
@@ -176,7 +176,7 @@ impl Constructor for PyCSimple {
         let attributes = cls.get_attributes();
         let _type_ = attributes
             .iter()
-            .find(|(&k, _)| k.to_object().str(vm).unwrap().to_string() == *"_type_")
+            .find(|(k, _)| k.to_object().str(vm).unwrap().to_string() == *"_type_")
             .unwrap()
             .1
             .str(vm)?

--- a/vm/src/stdlib/os.rs
+++ b/vm/src/stdlib/os.rs
@@ -380,8 +380,8 @@ pub(super) mod _os {
 
     fn env_bytes_as_bytes(obj: &Either<PyStrRef, PyBytesRef>) -> &[u8] {
         match obj {
-            Either::A(ref s) => s.as_str().as_bytes(),
-            Either::B(ref b) => b.as_bytes(),
+            Either::A(s) => s.as_str().as_bytes(),
+            Either::B(b) => b.as_bytes(),
         }
     }
 

--- a/wasm/lib/src/vm_class.rs
+++ b/wasm/lib/src/vm_class.rs
@@ -233,7 +233,7 @@ impl WASMVirtualMachine {
 
     #[wasm_bindgen(js_name = addToScope)]
     pub fn add_to_scope(&self, name: String, value: JsValue) -> Result<(), JsValue> {
-        self.with_vm(move |vm, StoredVirtualMachine { ref scope, .. }| {
+        self.with_vm(move |vm, StoredVirtualMachine { scope, .. }| {
             let value = convert::js_to_py(vm, value);
             scope.globals.set_item(&name, value, vm).into_js(vm)
         })?
@@ -335,7 +335,7 @@ impl WASMVirtualMachine {
         mode: Mode,
         source_path: Option<String>,
     ) -> Result<JsValue, JsValue> {
-        self.with_vm(|vm, StoredVirtualMachine { ref scope, .. }| {
+        self.with_vm(|vm, StoredVirtualMachine { scope, .. }| {
             let source_path = source_path.unwrap_or_else(|| "<wasm>".to_owned());
             let code = vm.compile(source, mode, source_path);
             let code = code.map_err(convert::syntax_err)?;


### PR DESCRIPTION
Open to suggestions for a better "euphemism" for `gen` - could always just go with `gen_` or even `r#gen`, but `jen` felt like it fit in the tradition of `klass` and `zelf`.