### PR TITLE
Remove redundant lints now that we're on edition2024

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -190,13 +190,6 @@ wasm-bindgen = "0.2.100"
 unsafe_code = "allow"
 unsafe_op_in_unsafe_fn = "deny"
 
-# rust_2024_compatibility
-missing_unsafe_on_extern = "deny"
-unsafe_attr_outside_unsafe = "deny"
-deprecated_safe_2024 = "deny"
-rust_2024_incompatible_pat = "deny"
-keyword_idents_2024 = "deny"
-
 [workspace.lints.clippy]
 perf = "warn"
 style = "warn"

--- a/vm/sre_engine/Cargo.toml
+++ b/vm/sre_engine/Cargo.toml
@@ -21,3 +21,6 @@ optional = "0.5"
 
 [dev-dependencies]
 criterion = { workspace = true }
+
+[lints]
+workspace = true


### PR DESCRIPTION
Follow-up to #5560. Also adds `lints.workspace = true` in `vm/sre_engine`