### PR TITLE
Warn on elided_lifetimes_in_paths

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -189,6 +189,7 @@ wasm-bindgen = "0.2.100"
 [workspace.lints.rust]
 unsafe_code = "allow"
 unsafe_op_in_unsafe_fn = "deny"
+elided_lifetimes_in_paths = "warn"
 
 [workspace.lints.clippy]
 perf = "warn"

--- a/common/src/borrow.rs
+++ b/common/src/borrow.rs
@@ -68,7 +68,7 @@ impl<T: ?Sized> Deref for BorrowedValue<'_, T> {
 }
 
 impl fmt::Display for BorrowedValue<'_, str> {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         fmt::Display::fmt(self.deref(), f)
     }
 }

--- a/common/src/boxvec.rs
+++ b/common/src/boxvec.rs
@@ -262,7 +262,7 @@ impl<T> BoxVec<T> {
     ///
     /// **Panics** if the starting point is greater than the end point or if
     /// the end point is greater than the length of the vector.
-    pub fn drain<R>(&mut self, range: R) -> Drain<T>
+    pub fn drain<R>(&mut self, range: R) -> Drain<'_, T>
     where
         R: RangeBounds<usize>,
     {
@@ -290,7 +290,7 @@ impl<T> BoxVec<T> {
         self.drain_range(start, end)
     }
 
-    fn drain_range(&mut self, start: usize, end: usize) -> Drain<T> {
+    fn drain_range(&mut self, start: usize, end: usize) -> Drain<'_, T> {
         let len = self.len();
 
         // bounds check happens here (before length is changed!)
@@ -438,7 +438,7 @@ impl<T> fmt::Debug for IntoIter<T>
 where
     T: fmt::Debug,
 {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_list().entries(&self.v[self.index..]).finish()
     }
 }
@@ -658,7 +658,7 @@ impl<T> fmt::Debug for BoxVec<T>
 where
     T: fmt::Debug,
 {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         (**self).fmt(f)
     }
 }
@@ -691,13 +691,13 @@ const CAPERROR: &str = "insufficient capacity";
 impl<T> std::error::Error for CapacityError<T> {}
 
 impl<T> fmt::Display for CapacityError<T> {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "{CAPERROR}")
     }
 }
 
 impl<T> fmt::Debug for CapacityError<T> {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "capacity error: {CAPERROR}")
     }
 }

--- a/common/src/lock/thread_mutex.rs
+++ b/common/src/lock/thread_mutex.rs
@@ -100,7 +100,7 @@ impl<R: RawMutex, G: GetThreadId, T> From<T> for ThreadMutex<R, G, T> {
     }
 }
 impl<R: RawMutex, G: GetThreadId, T: ?Sized> ThreadMutex<R, G, T> {
-    pub fn lock(&self) -> Option<ThreadMutexGuard<R, G, T>> {
+    pub fn lock(&self) -> Option<ThreadMutexGuard<'_, R, G, T>> {
         if self.raw.lock() {
             Some(ThreadMutexGuard {
                 mu: self,
@@ -110,7 +110,7 @@ impl<R: RawMutex, G: GetThreadId, T: ?Sized> ThreadMutex<R, G, T> {
             None
         }
     }
-    pub fn try_lock(&self) -> Result<ThreadMutexGuard<R, G, T>, TryLockThreadError> {
+    pub fn try_lock(&self) -> Result<ThreadMutexGuard<'_, R, G, T>, TryLockThreadError> {
         match self.raw.try_lock() {
             Some(true) => Ok(ThreadMutexGuard {
                 mu: self,
@@ -218,14 +218,14 @@ impl<R: RawMutex, G: GetThreadId, T: ?Sized> Drop for ThreadMutexGuard<'_, R, G,
 impl<R: RawMutex, G: GetThreadId, T: ?Sized + fmt::Display> fmt::Display
     for ThreadMutexGuard<'_, R, G, T>
 {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         fmt::Display::fmt(&**self, f)
     }
 }
 impl<R: RawMutex, G: GetThreadId, T: ?Sized + fmt::Debug> fmt::Debug
     for ThreadMutexGuard<'_, R, G, T>
 {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         fmt::Debug::fmt(&**self, f)
     }
 }
@@ -285,14 +285,14 @@ impl<R: RawMutex, G: GetThreadId, T: ?Sized> Drop for MappedThreadMutexGuard<'_,
 impl<R: RawMutex, G: GetThreadId, T: ?Sized + fmt::Display> fmt::Display
     for MappedThreadMutexGuard<'_, R, G, T>
 {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         fmt::Display::fmt(&**self, f)
     }
 }
 impl<R: RawMutex, G: GetThreadId, T: ?Sized + fmt::Debug> fmt::Debug
     for MappedThreadMutexGuard<'_, R, G, T>
 {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         fmt::Debug::fmt(&**self, f)
     }
 }

--- a/compiler/codegen/src/compile.rs
+++ b/compiler/codegen/src/compile.rs
@@ -3484,7 +3484,7 @@ mod tests {
     use rustpython_parser_core::source_code::LinearLocator;
 
     fn compile_exec(source: &str) -> CodeObject {
-        let mut locator: LinearLocator = LinearLocator::new(source);
+        let mut locator: LinearLocator<'_> = LinearLocator::new(source);
         use rustpython_parser::ast::fold::Fold;
         let mut compiler: Compiler = Compiler::new(
             CompileOpts::default(),

--- a/compiler/codegen/src/error.rs
+++ b/compiler/codegen/src/error.rs
@@ -38,7 +38,7 @@ pub enum CodegenErrorType {
 impl std::error::Error for CodegenErrorType {}
 
 impl fmt::Display for CodegenErrorType {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         use CodegenErrorType::*;
         match self {
             Assign(target) => write!(f, "cannot assign to {target}"),

--- a/compiler/codegen/src/symboltable.rs
+++ b/compiler/codegen/src/symboltable.rs
@@ -74,7 +74,7 @@ pub enum SymbolTableType {
 }
 
 impl fmt::Display for SymbolTableType {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
             SymbolTableType::Module => write!(f, "module"),
             SymbolTableType::Class => write!(f, "class"),
@@ -195,7 +195,7 @@ impl SymbolTable {
 }
 
 impl std::fmt::Debug for SymbolTable {
-    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(
             f,
             "SymbolTable({:?} symbols, {:?} sub scopes)",

--- a/compiler/core/src/marshal.rs
+++ b/compiler/core/src/marshal.rs
@@ -21,7 +21,7 @@ pub enum MarshalError {
 }
 
 impl std::fmt::Display for MarshalError {
-    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
             Self::Eof => f.write_str("unexpected end of data"),
             Self::InvalidBytecode => f.write_str("invalid bytecode"),

--- a/compiler/src/lib.rs
+++ b/compiler/src/lib.rs
@@ -25,7 +25,7 @@ impl std::error::Error for CompileErrorType {
     }
 }
 impl std::fmt::Display for CompileErrorType {
-    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
             CompileErrorType::Codegen(e) => e.fmt(f),
             CompileErrorType::Parse(e) => e.fmt(f),

--- a/derive-impl/src/compile_bytecode.rs
+++ b/derive-impl/src/compile_bytecode.rs
@@ -316,7 +316,7 @@ impl PyCompileArgs {
     }
 }
 
-fn parse_str(input: ParseStream) -> ParseResult<LitStr> {
+fn parse_str(input: ParseStream<'_>) -> ParseResult<LitStr> {
     let span = input.span();
     if input.peek(LitStr) {
         input.parse()

--- a/derive-impl/src/pyclass.rs
+++ b/derive-impl/src/pyclass.rs
@@ -25,7 +25,7 @@ enum AttrName {
 }
 
 impl std::fmt::Display for AttrName {
-    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let s = match self {
             Self::Method => "pymethod",
             Self::ClassMethod => "pyclassmethod",

--- a/derive-impl/src/pymodule.rs
+++ b/derive-impl/src/pymodule.rs
@@ -19,7 +19,7 @@ enum AttrName {
 }
 
 impl std::fmt::Display for AttrName {
-    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let s = match self {
             Self::Function => "pyfunction",
             Self::Attr => "pyattr",

--- a/jit/src/instructions.rs
+++ b/jit/src/instructions.rs
@@ -188,7 +188,7 @@ impl<'a, 'b> FunctionCompiler<'a, 'b> {
 
     fn prepare_const<C: bytecode::Constant>(
         &mut self,
-        constant: BorrowedConstant<C>,
+        constant: BorrowedConstant<'_, C>,
     ) -> Result<JitValue, JitCompileError> {
         let value = match constant {
             BorrowedConstant::Integer { value } => {

--- a/stdlib/src/contextvars.rs
+++ b/stdlib/src/contextvars.rs
@@ -301,7 +301,7 @@ mod _contextvars {
     }
 
     impl std::fmt::Debug for ContextVar {
-        fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
             f.debug_struct("ContextVar").finish()
         }
     }

--- a/stdlib/src/csv.rs
+++ b/stdlib/src/csv.rs
@@ -910,7 +910,7 @@ mod _csv {
     }
 
     impl fmt::Debug for Reader {
-        fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
             write!(f, "_csv.reader")
         }
     }
@@ -1064,7 +1064,7 @@ mod _csv {
     }
 
     impl fmt::Debug for Writer {
-        fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
             write!(f, "_csv.writer")
         }
     }

--- a/stdlib/src/hashlib.rs
+++ b/stdlib/src/hashlib.rs
@@ -91,7 +91,7 @@ pub mod _hashlib {
     }
 
     impl std::fmt::Debug for PyHasher {
-        fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
             write!(f, "HASH {}", self.name)
         }
     }
@@ -155,7 +155,7 @@ pub mod _hashlib {
     }
 
     impl std::fmt::Debug for PyHasherXof {
-        fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
             write!(f, "HASHXOF {}", self.name)
         }
     }

--- a/stdlib/src/mmap.rs
+++ b/stdlib/src/mmap.rs
@@ -483,7 +483,7 @@ mod mmap {
         flags(BASETYPE)
     )]
     impl PyMmap {
-        fn as_bytes_mut(&self) -> BorrowedValueMut<[u8]> {
+        fn as_bytes_mut(&self) -> BorrowedValueMut<'_, [u8]> {
             PyMutexGuard::map(self.mmap.lock(), |m| {
                 match m.as_mut().expect("mmap closed or invalid") {
                     MmapObj::Read(_) => panic!("mmap can't modify a readonly memory map."),
@@ -493,7 +493,7 @@ mod mmap {
             .into()
         }
 
-        fn as_bytes(&self) -> BorrowedValue<[u8]> {
+        fn as_bytes(&self) -> BorrowedValue<'_, [u8]> {
             PyMutexGuard::map_immutable(self.mmap.lock(), |m| {
                 match m.as_ref().expect("mmap closed or invalid") {
                     MmapObj::Read(mmap) => &mmap[..],
@@ -536,7 +536,7 @@ mod mmap {
             }
         }
 
-        fn check_valid(&self, vm: &VirtualMachine) -> PyResult<PyMutexGuard<Option<MmapObj>>> {
+        fn check_valid(&self, vm: &VirtualMachine) -> PyResult<PyMutexGuard<'_, Option<MmapObj>>> {
             let m = self.mmap.lock();
 
             if m.is_none() {

--- a/stdlib/src/overlapped.rs
+++ b/stdlib/src/overlapped.rs
@@ -52,7 +52,7 @@ mod _overlapped {
     unsafe impl Send for OverlappedInner {}
 
     impl std::fmt::Debug for Overlapped {
-        fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
             let zelf = self.inner.lock();
             f.debug_struct("Overlapped")
                 // .field("overlapped", &(self.overlapped as *const _ as usize))
@@ -93,7 +93,7 @@ mod _overlapped {
     }
 
     impl std::fmt::Debug for OverlappedReadFrom {
-        fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
             f.debug_struct("OverlappedReadFrom")
                 .field("result", &self.result)
                 .field("allocated_buffer", &self.allocated_buffer)
@@ -114,7 +114,7 @@ mod _overlapped {
     }
 
     impl std::fmt::Debug for OverlappedReadFromInto {
-        fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
             f.debug_struct("OverlappedReadFromInto")
                 .field("result", &self.result)
                 .field("user_buffer", &self.user_buffer)

--- a/stdlib/src/posixsubprocess.rs
+++ b/stdlib/src/posixsubprocess.rs
@@ -152,7 +152,7 @@ struct ProcArgs<'a> {
     extra_groups: Option<&'a [Gid]>,
 }
 
-fn exec(args: &ForkExecArgs, procargs: ProcArgs) -> ! {
+fn exec(args: &ForkExecArgs, procargs: ProcArgs<'_>) -> ! {
     let mut ctx = ExecErrorContext::NoExec;
     match exec_inner(args, procargs, &mut ctx) {
         Ok(x) => match x {},
@@ -183,7 +183,7 @@ impl ExecErrorContext {
 
 fn exec_inner(
     args: &ForkExecArgs,
-    procargs: ProcArgs,
+    procargs: ProcArgs<'_>,
     ctx: &mut ExecErrorContext,
 ) -> nix::Result<Never> {
     for &fd in args.fds_to_keep.as_slice() {

--- a/stdlib/src/scproxy.rs
+++ b/stdlib/src/scproxy.rs
@@ -56,10 +56,7 @@ mod _scproxy {
                 .map(|s| {
                     unsafe { CFType::from_void(*s) }
                         .downcast::<CFString>()
-                        .map(|s| {
-                            let a_string: std::borrow::Cow<str> = (&s).into();
-                            PyStr::from(a_string.into_owned())
-                        })
+                        .map(|s| PyStr::from(s.to_string()))
                         .to_pyobject(vm)
                 })
                 .collect();

--- a/stdlib/src/socket.rs
+++ b/stdlib/src/socket.rs
@@ -1920,7 +1920,7 @@ mod _socket {
         };
 
         let host = opts.host.as_ref().map(|s| s.as_str());
-        let port = opts.port.as_ref().map(|p| -> std::borrow::Cow<str> {
+        let port = opts.port.as_ref().map(|p| -> std::borrow::Cow<'_, str> {
             match p {
                 Either::A(s) => s.as_str().into(),
                 Either::B(i) => i.to_string().into(),

--- a/vm/src/builtins/code.rs
+++ b/vm/src/builtins/code.rs
@@ -58,7 +58,7 @@ impl From<Literal> for PyObjectRef {
     }
 }
 
-fn borrow_obj_constant(obj: &PyObject) -> BorrowedConstant<Literal> {
+fn borrow_obj_constant(obj: &PyObject) -> BorrowedConstant<'_, Literal> {
     match_class!(match obj {
         ref i @ super::int::PyInt => {
             let value = i.as_bigint();
@@ -96,7 +96,7 @@ fn borrow_obj_constant(obj: &PyObject) -> BorrowedConstant<Literal> {
 
 impl Constant for Literal {
     type Name = &'static PyStrInterned;
-    fn borrow_constant(&self) -> BorrowedConstant<Self> {
+    fn borrow_constant(&self) -> BorrowedConstant<'_, Self> {
         borrow_obj_constant(&self.0)
     }
 }
@@ -120,7 +120,7 @@ pub struct PyObjBag<'a>(pub &'a Context);
 impl ConstantBag for PyObjBag<'_> {
     type Constant = Literal;
 
-    fn make_constant<C: Constant>(&self, constant: BorrowedConstant<C>) -> Self::Constant {
+    fn make_constant<C: Constant>(&self, constant: BorrowedConstant<'_, C>) -> Self::Constant {
         let ctx = self.0;
         let obj = match constant {
             bytecode::BorrowedConstant::Integer { value } => ctx.new_bigint(value).into(),
@@ -208,7 +208,7 @@ impl PyCode {
 }
 
 impl fmt::Debug for PyCode {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "code: {:?}", self.code)
     }
 }

--- a/vm/src/builtins/dict.rs
+++ b/vm/src/builtins/dict.rs
@@ -37,7 +37,7 @@ pub struct PyDict {
 pub type PyDictRef = PyRef<PyDict>;
 
 impl fmt::Debug for PyDict {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         // TODO: implement more detailed, non-recursive Debug formatter
         f.write_str("dict")
     }

--- a/vm/src/builtins/function.rs
+++ b/vm/src/builtins/function.rs
@@ -44,7 +44,7 @@ pub struct PyFunction {
 }
 
 unsafe impl Traverse for PyFunction {
-    fn traverse(&self, tracer_fn: &mut TraverseFn) {
+    fn traverse(&self, tracer_fn: &mut TraverseFn<'_>) {
         self.globals.traverse(tracer_fn);
         self.closure.traverse(tracer_fn);
         self.defaults_and_kwdefaults.traverse(tracer_fn);

--- a/vm/src/builtins/genericalias.rs
+++ b/vm/src/builtins/genericalias.rs
@@ -36,7 +36,7 @@ pub struct PyGenericAlias {
 }
 
 impl fmt::Debug for PyGenericAlias {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.write_str("GenericAlias")
     }
 }

--- a/vm/src/builtins/iter.rs
+++ b/vm/src/builtins/iter.rs
@@ -26,7 +26,7 @@ pub enum IterStatus<T> {
 }
 
 unsafe impl<T: Traverse> Traverse for IterStatus<T> {
-    fn traverse(&self, tracer_fn: &mut TraverseFn) {
+    fn traverse(&self, tracer_fn: &mut TraverseFn<'_>) {
         match self {
             IterStatus::Active(r) => r.traverse(tracer_fn),
             IterStatus::Exhausted => (),
@@ -41,7 +41,7 @@ pub struct PositionIterInternal<T> {
 }
 
 unsafe impl<T: Traverse> Traverse for PositionIterInternal<T> {
-    fn traverse(&self, tracer_fn: &mut TraverseFn) {
+    fn traverse(&self, tracer_fn: &mut TraverseFn<'_>) {
         self.status.traverse(tracer_fn)
     }
 }

--- a/vm/src/builtins/list.rs
+++ b/vm/src/builtins/list.rs
@@ -29,7 +29,7 @@ pub struct PyList {
 }
 
 impl fmt::Debug for PyList {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         // TODO: implement more detailed, non-recursive Debug formatter
         f.write_str("list")
     }

--- a/vm/src/builtins/mappingproxy.rs
+++ b/vm/src/builtins/mappingproxy.rs
@@ -27,7 +27,7 @@ enum MappingProxyInner {
 }
 
 unsafe impl Traverse for MappingProxyInner {
-    fn traverse(&self, tracer_fn: &mut TraverseFn) {
+    fn traverse(&self, tracer_fn: &mut TraverseFn<'_>) {
         match self {
             MappingProxyInner::Class(r) => r.traverse(tracer_fn),
             MappingProxyInner::Mapping(arg) => arg.traverse(tracer_fn),

--- a/vm/src/builtins/memory.rs
+++ b/vm/src/builtins/memory.rs
@@ -386,7 +386,7 @@ impl PyMemoryView {
         ret
     }
 
-    fn obj_bytes(&self) -> BorrowedValue<[u8]> {
+    fn obj_bytes(&self) -> BorrowedValue<'_, [u8]> {
         if self.desc.is_contiguous() {
             BorrowedValue::map(self.buffer.obj_bytes(), |x| {
                 &x[self.start..self.start + self.desc.len]
@@ -396,7 +396,7 @@ impl PyMemoryView {
         }
     }
 
-    fn obj_bytes_mut(&self) -> BorrowedValueMut<[u8]> {
+    fn obj_bytes_mut(&self) -> BorrowedValueMut<'_, [u8]> {
         if self.desc.is_contiguous() {
             BorrowedValueMut::map(self.buffer.obj_bytes_mut(), |x| {
                 &mut x[self.start..self.start + self.desc.len]
@@ -406,7 +406,7 @@ impl PyMemoryView {
         }
     }
 
-    fn as_contiguous(&self) -> Option<BorrowedValue<[u8]>> {
+    fn as_contiguous(&self) -> Option<BorrowedValue<'_, [u8]>> {
         self.desc.is_contiguous().then(|| {
             BorrowedValue::map(self.buffer.obj_bytes(), |x| {
                 &x[self.start..self.start + self.desc.len]
@@ -414,7 +414,7 @@ impl PyMemoryView {
         })
     }
 
-    fn _as_contiguous_mut(&self) -> Option<BorrowedValueMut<[u8]>> {
+    fn _as_contiguous_mut(&self) -> Option<BorrowedValueMut<'_, [u8]>> {
         self.desc.is_contiguous().then(|| {
             BorrowedValueMut::map(self.buffer.obj_bytes_mut(), |x| {
                 &mut x[self.start..self.start + self.desc.len]

--- a/vm/src/builtins/set.rs
+++ b/vm/src/builtins/set.rs
@@ -138,14 +138,14 @@ impl PyFrozenSet {
 }
 
 impl fmt::Debug for PySet {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         // TODO: implement more detailed, non-recursive Debug formatter
         f.write_str("set")
     }
 }
 
 impl fmt::Debug for PyFrozenSet {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         // TODO: implement more detailed, non-recursive Debug formatter
         f.write_str("PyFrozenSet ")?;
         f.debug_set().entries(self.elements().iter()).finish()
@@ -170,7 +170,7 @@ pub(super) struct PySetInner {
 }
 
 unsafe impl crate::object::Traverse for PySetInner {
-    fn traverse(&self, tracer_fn: &mut crate::object::TraverseFn) {
+    fn traverse(&self, tracer_fn: &mut crate::object::TraverseFn<'_>) {
         // FIXME(discord9): Rc means shared ref, so should it be traced?
         self.content.traverse(tracer_fn)
     }
@@ -1266,7 +1266,7 @@ pub(crate) struct PySetIterator {
 }
 
 impl fmt::Debug for PySetIterator {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         // TODO: implement more detailed, non-recursive Debug formatter
         f.write_str("set_iterator")
     }

--- a/vm/src/builtins/str.rs
+++ b/vm/src/builtins/str.rs
@@ -62,7 +62,7 @@ pub struct PyStr {
 }
 
 impl fmt::Debug for PyStr {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("PyStr")
             .field("value", &self.as_str())
             .field("kind", &self.kind)
@@ -192,7 +192,7 @@ pub struct PyStrIterator {
 }
 
 unsafe impl Traverse for PyStrIterator {
-    fn traverse(&self, tracer: &mut TraverseFn) {
+    fn traverse(&self, tracer: &mut TraverseFn<'_>) {
         // No need to worry about deadlock, for inner is a PyStr and can't make ref cycle
         self.internal.lock().0.traverse(tracer);
     }
@@ -351,7 +351,7 @@ impl PyStr {
         }
     }
 
-    fn borrow(&self) -> &BorrowedStr {
+    fn borrow(&self) -> &BorrowedStr<'_> {
         unsafe { std::mem::transmute(self) }
     }
 

--- a/vm/src/builtins/tuple.rs
+++ b/vm/src/builtins/tuple.rs
@@ -28,7 +28,7 @@ pub struct PyTuple {
 }
 
 impl fmt::Debug for PyTuple {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         // TODO: implement more informational, non-recursive Debug formatter
         f.write_str("tuple")
     }
@@ -513,7 +513,7 @@ unsafe impl<T> Traverse for PyTupleTyped<T>
 where
     T: TransmuteFromObject + Traverse,
 {
-    fn traverse(&self, tracer_fn: &mut TraverseFn) {
+    fn traverse(&self, tracer_fn: &mut TraverseFn<'_>) {
         self.tuple.traverse(tracer_fn);
     }
 }

--- a/vm/src/builtins/type.rs
+++ b/vm/src/builtins/type.rs
@@ -45,7 +45,7 @@ pub struct PyType {
 }
 
 unsafe impl crate::object::Traverse for PyType {
-    fn traverse(&self, tracer_fn: &mut crate::object::TraverseFn) {
+    fn traverse(&self, tracer_fn: &mut crate::object::TraverseFn<'_>) {
         self.base.traverse(tracer_fn);
         self.bases.traverse(tracer_fn);
         self.mro.traverse(tracer_fn);
@@ -119,7 +119,7 @@ cfg_if::cfg_if! {
 pub type PyAttributes = IndexMap<&'static PyStrInterned, PyObjectRef, ahash::RandomState>;
 
 unsafe impl Traverse for PyAttributes {
-    fn traverse(&self, tracer_fn: &mut TraverseFn) {
+    fn traverse(&self, tracer_fn: &mut TraverseFn<'_>) {
         self.values().for_each(|v| v.traverse(tracer_fn));
     }
 }
@@ -131,7 +131,7 @@ impl fmt::Display for PyType {
 }
 
 impl fmt::Debug for PyType {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "[PyType {}]", &self.name())
     }
 }
@@ -406,14 +406,14 @@ impl PyType {
         }
     }
 
-    pub fn slot_name(&self) -> BorrowedValue<str> {
+    pub fn slot_name(&self) -> BorrowedValue<'_, str> {
         self.name_inner(
             |name| name.into(),
             |ext| PyRwLockReadGuard::map(ext.name.read(), |name| name.as_str()).into(),
         )
     }
 
-    pub fn name(&self) -> BorrowedValue<str> {
+    pub fn name(&self) -> BorrowedValue<'_, str> {
         self.name_inner(
             |name| name.rsplit_once('.').map_or(name, |(_, name)| name).into(),
             |ext| PyRwLockReadGuard::map(ext.name.read(), |name| name.as_str()).into(),

--- a/vm/src/builtins/union.rs
+++ b/vm/src/builtins/union.rs
@@ -22,7 +22,7 @@ pub struct PyUnion {
 }
 
 impl fmt::Debug for PyUnion {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.write_str("UnionObject")
     }
 }

--- a/vm/src/dictdatatype.rs
+++ b/vm/src/dictdatatype.rs
@@ -35,7 +35,7 @@ pub struct Dict<T = PyObjectRef> {
 }
 
 unsafe impl<T: Traverse> Traverse for Dict<T> {
-    fn traverse(&self, tracer_fn: &mut TraverseFn) {
+    fn traverse(&self, tracer_fn: &mut TraverseFn<'_>) {
         self.inner.traverse(tracer_fn);
     }
 }
@@ -79,7 +79,7 @@ struct DictInner<T> {
 }
 
 unsafe impl<T: Traverse> Traverse for DictInner<T> {
-    fn traverse(&self, tracer_fn: &mut TraverseFn) {
+    fn traverse(&self, tracer_fn: &mut TraverseFn<'_>) {
         self.entries
             .iter()
             .map(|v| {
@@ -548,7 +548,7 @@ impl<T: Clone> Dict<T> {
         vm: &VirtualMachine,
         key: &K,
         hash_value: HashValue,
-        mut lock: Option<PyRwLockReadGuard<DictInner<T>>>,
+        mut lock: Option<PyRwLockReadGuard<'_, DictInner<T>>>,
     ) -> PyResult<LookupResult> {
         let mut idxs = None;
         let mut free_slot = None;

--- a/vm/src/exceptions.rs
+++ b/vm/src/exceptions.rs
@@ -22,7 +22,7 @@ use std::{
 };
 
 unsafe impl Traverse for PyBaseException {
-    fn traverse(&self, tracer_fn: &mut TraverseFn) {
+    fn traverse(&self, tracer_fn: &mut TraverseFn<'_>) {
         self.traceback.traverse(tracer_fn);
         self.cause.traverse(tracer_fn);
         self.context.traverse(tracer_fn);
@@ -31,7 +31,7 @@ unsafe impl Traverse for PyBaseException {
 }
 
 impl std::fmt::Debug for PyBaseException {
-    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         // TODO: implement more detailed, non-recursive Debug formatter
         f.write_str("PyBaseException")
     }

--- a/vm/src/frame.rs
+++ b/vm/src/frame.rs
@@ -221,7 +221,7 @@ impl Frame {
 
 impl Py<Frame> {
     #[inline(always)]
-    fn with_exec<R>(&self, f: impl FnOnce(ExecutingFrame) -> R) -> R {
+    fn with_exec<R>(&self, f: impl FnOnce(ExecutingFrame<'_>) -> R) -> R {
         let mut state = self.state.lock();
         let exec = ExecutingFrame {
             code: &self.code,
@@ -308,7 +308,7 @@ struct ExecutingFrame<'a> {
 }
 
 impl fmt::Debug for ExecutingFrame<'_> {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("ExecutingFrame")
             .field("code", self.code)
             // .field("scope", self.scope)
@@ -371,7 +371,7 @@ impl ExecutingFrame<'_> {
                 Err(exception) => {
                     #[cold]
                     fn handle_exception(
-                        frame: &mut ExecutingFrame,
+                        frame: &mut ExecutingFrame<'_>,
                         exception: PyBaseExceptionRef,
                         idx: usize,
                         vm: &VirtualMachine,
@@ -2081,7 +2081,7 @@ impl ExecutingFrame<'_> {
         }
     }
 
-    fn pop_multiple(&mut self, count: usize) -> crate::common::boxvec::Drain<PyObjectRef> {
+    fn pop_multiple(&mut self, count: usize) -> crate::common::boxvec::Drain<'_, PyObjectRef> {
         let stack_len = self.state.stack.len();
         self.state.stack.drain(stack_len - count..)
     }
@@ -2119,7 +2119,7 @@ impl ExecutingFrame<'_> {
 }
 
 impl fmt::Debug for Frame {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         let state = self.state.lock();
         let stack_str = state.stack.iter().fold(String::new(), |mut s, elem| {
             if elem.payload_is::<Frame>() {

--- a/vm/src/function/argument.rs
+++ b/vm/src/function/argument.rs
@@ -67,7 +67,7 @@ pub struct FuncArgs {
 }
 
 unsafe impl Traverse for IndexMap<String, PyObjectRef> {
-    fn traverse(&self, tracer_fn: &mut TraverseFn) {
+    fn traverse(&self, tracer_fn: &mut TraverseFn<'_>) {
         self.values().for_each(|v| v.traverse(tracer_fn));
     }
 }
@@ -336,7 +336,7 @@ unsafe impl<T> Traverse for KwArgs<T>
 where
     T: Traverse,
 {
-    fn traverse(&self, tracer_fn: &mut TraverseFn) {
+    fn traverse(&self, tracer_fn: &mut TraverseFn<'_>) {
         self.0.iter().map(|(_, v)| v.traverse(tracer_fn)).count();
     }
 }
@@ -402,7 +402,7 @@ unsafe impl<T> Traverse for PosArgs<T>
 where
     T: Traverse,
 {
-    fn traverse(&self, tracer_fn: &mut TraverseFn) {
+    fn traverse(&self, tracer_fn: &mut TraverseFn<'_>) {
         self.0.traverse(tracer_fn)
     }
 }
@@ -416,7 +416,7 @@ impl<T> PosArgs<T> {
         self.0
     }
 
-    pub fn iter(&self) -> std::slice::Iter<T> {
+    pub fn iter(&self) -> std::slice::Iter<'_, T> {
         self.0.iter()
     }
 }
@@ -495,7 +495,7 @@ unsafe impl<T> Traverse for OptionalArg<T>
 where
     T: Traverse,
 {
-    fn traverse(&self, tracer_fn: &mut TraverseFn) {
+    fn traverse(&self, tracer_fn: &mut TraverseFn<'_>) {
         match self {
             OptionalArg::Present(o) => o.traverse(tracer_fn),
             OptionalArg::Missing => (),

--- a/vm/src/function/protocol.rs
+++ b/vm/src/function/protocol.rs
@@ -81,7 +81,7 @@ pub struct ArgIterable<T = PyObjectRef> {
 }
 
 unsafe impl<T: Traverse> Traverse for ArgIterable<T> {
-    fn traverse(&self, tracer_fn: &mut TraverseFn) {
+    fn traverse(&self, tracer_fn: &mut TraverseFn<'_>) {
         self.iterable.traverse(tracer_fn)
     }
 }
@@ -143,7 +143,7 @@ impl ArgMapping {
     }
 
     #[inline(always)]
-    pub fn mapping(&self) -> PyMapping {
+    pub fn mapping(&self) -> PyMapping<'_> {
         PyMapping {
             obj: &self.obj,
             methods: self.methods,
@@ -200,7 +200,7 @@ impl TryFromObject for ArgMapping {
 pub struct ArgSequence<T = PyObjectRef>(Vec<T>);
 
 unsafe impl<T: Traverse> Traverse for ArgSequence<T> {
-    fn traverse(&self, tracer_fn: &mut TraverseFn) {
+    fn traverse(&self, tracer_fn: &mut TraverseFn<'_>) {
         self.0.traverse(tracer_fn);
     }
 }

--- a/vm/src/object/core.rs
+++ b/vm/src/object/core.rs
@@ -81,14 +81,17 @@ pub(super) unsafe fn drop_dealloc_obj<T: PyObjectPayload>(x: *mut PyObject) {
 }
 pub(super) unsafe fn debug_obj<T: PyObjectPayload>(
     x: &PyObject,
-    f: &mut fmt::Formatter,
+    f: &mut fmt::Formatter<'_>,
 ) -> fmt::Result {
     let x = unsafe { &*(x as *const PyObject as *const PyInner<T>) };
     fmt::Debug::fmt(x, f)
 }
 
 /// Call `try_trace` on payload
-pub(super) unsafe fn try_trace_obj<T: PyObjectPayload>(x: &PyObject, tracer_fn: &mut TraverseFn) {
+pub(super) unsafe fn try_trace_obj<T: PyObjectPayload>(
+    x: &PyObject,
+    tracer_fn: &mut TraverseFn<'_>,
+) {
     let x = unsafe { &*(x as *const PyObject as *const PyInner<T>) };
     let payload = &x.payload;
     payload.try_traverse(tracer_fn)
@@ -113,7 +116,7 @@ pub(super) struct PyInner<T> {
 }
 
 impl<T: fmt::Debug> fmt::Debug for PyInner<T> {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "[PyObject {:?}]", &self.payload)
     }
 }
@@ -121,7 +124,7 @@ impl<T: fmt::Debug> fmt::Debug for PyInner<T> {
 unsafe impl<T: PyObjectPayload> Traverse for Py<T> {
     /// DO notice that call `trace` on `Py<T>` means apply `tracer_fn` on `Py<T>`'s children,
     /// not like call `trace` on `PyRef<T>` which apply `tracer_fn` on `PyRef<T>` itself
-    fn traverse(&self, tracer_fn: &mut TraverseFn) {
+    fn traverse(&self, tracer_fn: &mut TraverseFn<'_>) {
         self.0.traverse(tracer_fn)
     }
 }
@@ -129,7 +132,7 @@ unsafe impl<T: PyObjectPayload> Traverse for Py<T> {
 unsafe impl Traverse for PyObject {
     /// DO notice that call `trace` on `PyObject` means apply `tracer_fn` on `PyObject`'s children,
     /// not like call `trace` on `PyObjectRef` which apply `tracer_fn` on `PyObjectRef` itself
-    fn traverse(&self, tracer_fn: &mut TraverseFn) {
+    fn traverse(&self, tracer_fn: &mut TraverseFn<'_>) {
         self.0.traverse(tracer_fn)
     }
 }
@@ -139,7 +142,7 @@ pub(super) struct WeakRefList {
 }
 
 impl fmt::Debug for WeakRefList {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("WeakRefList").finish_non_exhaustive()
     }
 }
@@ -972,7 +975,7 @@ where
 }
 
 impl<T: PyObjectPayload> fmt::Debug for Py<T> {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         (**self).fmt(f)
     }
 }
@@ -999,7 +1002,7 @@ cfg_if::cfg_if! {
 }
 
 impl<T: PyObjectPayload> fmt::Debug for PyRef<T> {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         (**self).fmt(f)
     }
 }

--- a/vm/src/object/ext.rs
+++ b/vm/src/object/ext.rs
@@ -43,7 +43,7 @@ impl<T: fmt::Display> fmt::Display for PyRef<T>
 where
     T: PyObjectPayload + fmt::Display,
 {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         fmt::Display::fmt(&**self, f)
     }
 }
@@ -51,7 +51,7 @@ impl<T: fmt::Display> fmt::Display for Py<T>
 where
     T: PyObjectPayload + fmt::Display,
 {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         fmt::Display::fmt(&**self, f)
     }
 }
@@ -534,7 +534,7 @@ impl<T> fmt::Display for PyLease<'_, T>
 where
     T: PyPayload + fmt::Display,
 {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         fmt::Display::fmt(&**self, f)
     }
 }

--- a/vm/src/object/traverse.rs
+++ b/vm/src/object/traverse.rs
@@ -14,7 +14,7 @@ pub trait MaybeTraverse {
     /// if is traceable, will be used by vtable to determine
     const IS_TRACE: bool = false;
     // if this type is traceable, then call with tracer_fn, default to do nothing
-    fn try_traverse(&self, traverse_fn: &mut TraverseFn);
+    fn try_traverse(&self, traverse_fn: &mut TraverseFn<'_>);
 }
 
 /// Type that need traverse it's children should impl `Traverse`(Not `MaybeTraverse`)
@@ -27,28 +27,28 @@ pub unsafe trait Traverse {
     ///   but if some field is called repeatedly, panic and deadlock can happen.
     ///
     /// - _**DO NOT**_ clone a `PyObjectRef` or `Pyef<T>` in `traverse()`
-    fn traverse(&self, traverse_fn: &mut TraverseFn);
+    fn traverse(&self, traverse_fn: &mut TraverseFn<'_>);
 }
 
 unsafe impl Traverse for PyObjectRef {
-    fn traverse(&self, traverse_fn: &mut TraverseFn) {
+    fn traverse(&self, traverse_fn: &mut TraverseFn<'_>) {
         traverse_fn(self)
     }
 }
 
 unsafe impl<T: PyObjectPayload> Traverse for PyRef<T> {
-    fn traverse(&self, traverse_fn: &mut TraverseFn) {
+    fn traverse(&self, traverse_fn: &mut TraverseFn<'_>) {
         traverse_fn(self.as_object())
     }
 }
 
 unsafe impl Traverse for () {
-    fn traverse(&self, _traverse_fn: &mut TraverseFn) {}
+    fn traverse(&self, _traverse_fn: &mut TraverseFn<'_>) {}
 }
 
 unsafe impl<T: Traverse> Traverse for Option<T> {
     #[inline]
-    fn traverse(&self, traverse_fn: &mut TraverseFn) {
+    fn traverse(&self, traverse_fn: &mut TraverseFn<'_>) {
         if let Some(v) = self {
             v.traverse(traverse_fn);
         }
@@ -60,7 +60,7 @@ where
     T: Traverse,
 {
     #[inline]
-    fn traverse(&self, traverse_fn: &mut TraverseFn) {
+    fn traverse(&self, traverse_fn: &mut TraverseFn<'_>) {
         for elem in self {
             elem.traverse(traverse_fn);
         }
@@ -72,7 +72,7 @@ where
     T: Traverse,
 {
     #[inline]
-    fn traverse(&self, traverse_fn: &mut TraverseFn) {
+    fn traverse(&self, traverse_fn: &mut TraverseFn<'_>) {
         for elem in &**self {
             elem.traverse(traverse_fn);
         }
@@ -84,7 +84,7 @@ where
     T: Traverse,
 {
     #[inline]
-    fn traverse(&self, traverse_fn: &mut TraverseFn) {
+    fn traverse(&self, traverse_fn: &mut TraverseFn<'_>) {
         for elem in self {
             elem.traverse(traverse_fn);
         }
@@ -93,7 +93,7 @@ where
 
 unsafe impl<T: Traverse> Traverse for PyRwLock<T> {
     #[inline]
-    fn traverse(&self, traverse_fn: &mut TraverseFn) {
+    fn traverse(&self, traverse_fn: &mut TraverseFn<'_>) {
         // if can't get a lock, this means something else is holding the lock,
         // but since gc stopped the world, during gc the lock is always held
         // so it is safe to ignore those in gc
@@ -109,7 +109,7 @@ unsafe impl<T: Traverse> Traverse for PyRwLock<T> {
 /// and refcnt is atomic, so it should be fine?)
 unsafe impl<T: Traverse> Traverse for PyMutex<T> {
     #[inline]
-    fn traverse(&self, traverse_fn: &mut TraverseFn) {
+    fn traverse(&self, traverse_fn: &mut TraverseFn<'_>) {
         let mut chs: Vec<NonNull<PyObject>> = Vec::new();
         if let Some(obj) = self.try_lock() {
             obj.traverse(&mut |ch| {
@@ -130,7 +130,7 @@ macro_rules! trace_tuple {
     ($(($NAME: ident, $NUM: tt)),*) => {
         unsafe impl<$($NAME: Traverse),*> Traverse for ($($NAME),*) {
             #[inline]
-            fn traverse(&self, traverse_fn: &mut TraverseFn) {
+            fn traverse(&self, traverse_fn: &mut TraverseFn<'_>) {
                 $(
                     self.$NUM.traverse(traverse_fn);
                 )*
@@ -142,7 +142,7 @@ macro_rules! trace_tuple {
 
 unsafe impl<A: Traverse, B: Traverse> Traverse for Either<A, B> {
     #[inline]
-    fn traverse(&self, tracer_fn: &mut TraverseFn) {
+    fn traverse(&self, tracer_fn: &mut TraverseFn<'_>) {
         match self {
             Either::A(a) => a.traverse(tracer_fn),
             Either::B(b) => b.traverse(tracer_fn),
@@ -154,7 +154,7 @@ unsafe impl<A: Traverse, B: Traverse> Traverse for Either<A, B> {
 // because long tuple is extremely rare in almost every case
 unsafe impl<A: Traverse> Traverse for (A,) {
     #[inline]
-    fn traverse(&self, tracer_fn: &mut TraverseFn) {
+    fn traverse(&self, tracer_fn: &mut TraverseFn<'_>) {
         self.0.traverse(tracer_fn);
     }
 }

--- a/vm/src/object/traverse_object.rs
+++ b/vm/src/object/traverse_object.rs
@@ -11,8 +11,8 @@ use super::{Traverse, TraverseFn};
 
 pub(in crate::object) struct PyObjVTable {
     pub(in crate::object) drop_dealloc: unsafe fn(*mut PyObject),
-    pub(in crate::object) debug: unsafe fn(&PyObject, &mut fmt::Formatter) -> fmt::Result,
-    pub(in crate::object) trace: Option<unsafe fn(&PyObject, &mut TraverseFn)>,
+    pub(in crate::object) debug: unsafe fn(&PyObject, &mut fmt::Formatter<'_>) -> fmt::Result,
+    pub(in crate::object) trace: Option<unsafe fn(&PyObject, &mut TraverseFn<'_>)>,
 }
 
 impl PyObjVTable {
@@ -32,14 +32,14 @@ impl PyObjVTable {
 }
 
 unsafe impl Traverse for InstanceDict {
-    fn traverse(&self, tracer_fn: &mut TraverseFn) {
+    fn traverse(&self, tracer_fn: &mut TraverseFn<'_>) {
         self.d.traverse(tracer_fn)
     }
 }
 
 unsafe impl Traverse for PyInner<Erased> {
     /// Because PyObject hold a `PyInner<Erased>`, so we need to trace it
-    fn traverse(&self, tracer_fn: &mut TraverseFn) {
+    fn traverse(&self, tracer_fn: &mut TraverseFn<'_>) {
         // 1. trace `dict` and `slots` field(`typ` can't trace for it's a AtomicRef while is leaked by design)
         // 2. call vtable's trace function to trace payload
         // self.typ.trace(tracer_fn);
@@ -58,7 +58,7 @@ unsafe impl Traverse for PyInner<Erased> {
 
 unsafe impl<T: PyObjectPayload> Traverse for PyInner<T> {
     /// Type is known, so we can call `try_trace` directly instead of using erased type vtable
-    fn traverse(&self, tracer_fn: &mut TraverseFn) {
+    fn traverse(&self, tracer_fn: &mut TraverseFn<'_>) {
         // 1. trace `dict` and `slots` field(`typ` can't trace for it's a AtomicRef while is leaked by design)
         // 2. call corresponding `try_trace` function to trace payload
         // (No need to call vtable's trace function because we already know the type)

--- a/vm/src/protocol/buffer.rs
+++ b/vm/src/protocol/buffer.rs
@@ -15,8 +15,8 @@ use itertools::Itertools;
 use std::{borrow::Cow, fmt::Debug, ops::Range};
 
 pub struct BufferMethods {
-    pub obj_bytes: fn(&PyBuffer) -> BorrowedValue<[u8]>,
-    pub obj_bytes_mut: fn(&PyBuffer) -> BorrowedValueMut<[u8]>,
+    pub obj_bytes: fn(&PyBuffer) -> BorrowedValue<'_, [u8]>,
+    pub obj_bytes_mut: fn(&PyBuffer) -> BorrowedValueMut<'_, [u8]>,
     pub release: fn(&PyBuffer),
     pub retain: fn(&PyBuffer),
 }
@@ -52,13 +52,13 @@ impl PyBuffer {
         zelf
     }
 
-    pub fn as_contiguous(&self) -> Option<BorrowedValue<[u8]>> {
+    pub fn as_contiguous(&self) -> Option<BorrowedValue<'_, [u8]>> {
         self.desc
             .is_contiguous()
             .then(|| unsafe { self.contiguous_unchecked() })
     }
 
-    pub fn as_contiguous_mut(&self) -> Option<BorrowedValueMut<[u8]>> {
+    pub fn as_contiguous_mut(&self) -> Option<BorrowedValueMut<'_, [u8]>> {
         (!self.desc.readonly && self.desc.is_contiguous())
             .then(|| unsafe { self.contiguous_mut_unchecked() })
     }
@@ -74,13 +74,13 @@ impl PyBuffer {
 
     /// # Safety
     /// assume the buffer is contiguous
-    pub unsafe fn contiguous_unchecked(&self) -> BorrowedValue<[u8]> {
+    pub unsafe fn contiguous_unchecked(&self) -> BorrowedValue<'_, [u8]> {
         self.obj_bytes()
     }
 
     /// # Safety
     /// assume the buffer is contiguous and writable
-    pub unsafe fn contiguous_mut_unchecked(&self) -> BorrowedValueMut<[u8]> {
+    pub unsafe fn contiguous_mut_unchecked(&self) -> BorrowedValueMut<'_, [u8]> {
         self.obj_bytes_mut()
     }
 
@@ -113,11 +113,11 @@ impl PyBuffer {
         unsafe { self.obj.downcast_unchecked_ref() }
     }
 
-    pub fn obj_bytes(&self) -> BorrowedValue<[u8]> {
+    pub fn obj_bytes(&self) -> BorrowedValue<'_, [u8]> {
         (self.methods.obj_bytes)(self)
     }
 
-    pub fn obj_bytes_mut(&self) -> BorrowedValueMut<[u8]> {
+    pub fn obj_bytes_mut(&self) -> BorrowedValueMut<'_, [u8]> {
         (self.methods.obj_bytes_mut)(self)
     }
 

--- a/vm/src/protocol/callable.rs
+++ b/vm/src/protocol/callable.rs
@@ -62,7 +62,7 @@ enum TraceEvent {
 }
 
 impl std::fmt::Display for TraceEvent {
-    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         use TraceEvent::*;
         match self {
             Call => write!(f, "call"),

--- a/vm/src/protocol/iter.rs
+++ b/vm/src/protocol/iter.rs
@@ -16,7 +16,7 @@ where
     O: Borrow<PyObject>;
 
 unsafe impl<O: Borrow<PyObject>> Traverse for PyIter<O> {
-    fn traverse(&self, tracer_fn: &mut TraverseFn) {
+    fn traverse(&self, tracer_fn: &mut TraverseFn<'_>) {
         self.0.borrow().traverse(tracer_fn);
     }
 }
@@ -70,7 +70,7 @@ where
 
 impl PyIter<PyObjectRef> {
     /// Returns an iterator over this sequence of objects.
-    pub fn into_iter<U>(self, vm: &VirtualMachine) -> PyResult<PyIterIter<U, PyObjectRef>> {
+    pub fn into_iter<U>(self, vm: &VirtualMachine) -> PyResult<PyIterIter<'_, U, PyObjectRef>> {
         let length_hint = vm.length_hint_opt(self.as_object().to_owned())?;
         Ok(PyIterIter::new(vm, self.0, length_hint))
     }
@@ -157,7 +157,7 @@ pub enum PyIterReturn<T = PyObjectRef> {
 }
 
 unsafe impl<T: Traverse> Traverse for PyIterReturn<T> {
-    fn traverse(&self, tracer_fn: &mut TraverseFn) {
+    fn traverse(&self, tracer_fn: &mut TraverseFn<'_>) {
         match self {
             PyIterReturn::Return(r) => r.traverse(tracer_fn),
             PyIterReturn::StopIteration(Some(obj)) => obj.traverse(tracer_fn),
@@ -233,7 +233,7 @@ unsafe impl<T, O> Traverse for PyIterIter<'_, T, O>
 where
     O: Traverse + Borrow<PyObject>,
 {
-    fn traverse(&self, tracer_fn: &mut TraverseFn) {
+    fn traverse(&self, tracer_fn: &mut TraverseFn<'_>) {
         self.obj.traverse(tracer_fn)
     }
 }

--- a/vm/src/protocol/mapping.rs
+++ b/vm/src/protocol/mapping.rs
@@ -22,15 +22,15 @@ impl PyObject {
 #[allow(clippy::type_complexity)]
 #[derive(Default)]
 pub struct PyMappingMethods {
-    pub length: AtomicCell<Option<fn(PyMapping, &VirtualMachine) -> PyResult<usize>>>,
-    pub subscript: AtomicCell<Option<fn(PyMapping, &PyObject, &VirtualMachine) -> PyResult>>,
+    pub length: AtomicCell<Option<fn(PyMapping<'_>, &VirtualMachine) -> PyResult<usize>>>,
+    pub subscript: AtomicCell<Option<fn(PyMapping<'_>, &PyObject, &VirtualMachine) -> PyResult>>,
     pub ass_subscript: AtomicCell<
-        Option<fn(PyMapping, &PyObject, Option<PyObjectRef>, &VirtualMachine) -> PyResult<()>>,
+        Option<fn(PyMapping<'_>, &PyObject, Option<PyObjectRef>, &VirtualMachine) -> PyResult<()>>,
     >,
 }
 
 impl std::fmt::Debug for PyMappingMethods {
-    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "mapping methods")
     }
 }
@@ -64,7 +64,7 @@ pub struct PyMapping<'a> {
 }
 
 unsafe impl Traverse for PyMapping<'_> {
-    fn traverse(&self, tracer_fn: &mut TraverseFn) {
+    fn traverse(&self, tracer_fn: &mut TraverseFn<'_>) {
         self.obj.traverse(tracer_fn)
     }
 }

--- a/vm/src/protocol/number.rs
+++ b/vm/src/protocol/number.rs
@@ -12,13 +12,13 @@ use crate::{
     stdlib::warnings,
 };
 
-pub type PyNumberUnaryFunc<R = PyObjectRef> = fn(PyNumber, &VirtualMachine) -> PyResult<R>;
+pub type PyNumberUnaryFunc<R = PyObjectRef> = fn(PyNumber<'_>, &VirtualMachine) -> PyResult<R>;
 pub type PyNumberBinaryFunc = fn(&PyObject, &PyObject, &VirtualMachine) -> PyResult;
 pub type PyNumberTernaryFunc = fn(&PyObject, &PyObject, &PyObject, &VirtualMachine) -> PyResult;
 
 impl PyObject {
     #[inline]
-    pub fn to_number(&self) -> PyNumber {
+    pub fn to_number(&self) -> PyNumber<'_> {
         PyNumber(self)
     }
 
@@ -427,7 +427,7 @@ impl PyNumberSlots {
 pub struct PyNumber<'a>(&'a PyObject);
 
 unsafe impl Traverse for PyNumber<'_> {
-    fn traverse(&self, tracer_fn: &mut TraverseFn) {
+    fn traverse(&self, tracer_fn: &mut TraverseFn<'_>) {
         self.0.traverse(tracer_fn)
     }
 }

--- a/vm/src/protocol/sequence.rs
+++ b/vm/src/protocol/sequence.rs
@@ -28,16 +28,18 @@ impl PyObject {
 #[allow(clippy::type_complexity)]
 #[derive(Default)]
 pub struct PySequenceMethods {
-    pub length: AtomicCell<Option<fn(PySequence, &VirtualMachine) -> PyResult<usize>>>,
-    pub concat: AtomicCell<Option<fn(PySequence, &PyObject, &VirtualMachine) -> PyResult>>,
-    pub repeat: AtomicCell<Option<fn(PySequence, isize, &VirtualMachine) -> PyResult>>,
-    pub item: AtomicCell<Option<fn(PySequence, isize, &VirtualMachine) -> PyResult>>,
+    pub length: AtomicCell<Option<fn(PySequence<'_>, &VirtualMachine) -> PyResult<usize>>>,
+    pub concat: AtomicCell<Option<fn(PySequence<'_>, &PyObject, &VirtualMachine) -> PyResult>>,
+    pub repeat: AtomicCell<Option<fn(PySequence<'_>, isize, &VirtualMachine) -> PyResult>>,
+    pub item: AtomicCell<Option<fn(PySequence<'_>, isize, &VirtualMachine) -> PyResult>>,
     pub ass_item: AtomicCell<
-        Option<fn(PySequence, isize, Option<PyObjectRef>, &VirtualMachine) -> PyResult<()>>,
+        Option<fn(PySequence<'_>, isize, Option<PyObjectRef>, &VirtualMachine) -> PyResult<()>>,
     >,
-    pub contains: AtomicCell<Option<fn(PySequence, &PyObject, &VirtualMachine) -> PyResult<bool>>>,
-    pub inplace_concat: AtomicCell<Option<fn(PySequence, &PyObject, &VirtualMachine) -> PyResult>>,
-    pub inplace_repeat: AtomicCell<Option<fn(PySequence, isize, &VirtualMachine) -> PyResult>>,
+    pub contains:
+        AtomicCell<Option<fn(PySequence<'_>, &PyObject, &VirtualMachine) -> PyResult<bool>>>,
+    pub inplace_concat:
+        AtomicCell<Option<fn(PySequence<'_>, &PyObject, &VirtualMachine) -> PyResult>>,
+    pub inplace_repeat: AtomicCell<Option<fn(PySequence<'_>, isize, &VirtualMachine) -> PyResult>>,
 }
 
 impl Debug for PySequenceMethods {
@@ -67,7 +69,7 @@ pub struct PySequence<'a> {
 }
 
 unsafe impl Traverse for PySequence<'_> {
-    fn traverse(&self, tracer_fn: &mut TraverseFn) {
+    fn traverse(&self, tracer_fn: &mut TraverseFn<'_>) {
         self.obj.traverse(tracer_fn)
     }
 }

--- a/vm/src/py_io.rs
+++ b/vm/src/py_io.rs
@@ -7,7 +7,7 @@ use std::{fmt, io, ops};
 
 pub trait Write {
     type Error;
-    fn write_fmt(&mut self, args: fmt::Arguments) -> Result<(), Self::Error>;
+    fn write_fmt(&mut self, args: fmt::Arguments<'_>) -> Result<(), Self::Error>;
 }
 
 #[repr(transparent)]
@@ -37,14 +37,14 @@ where
     W: io::Write,
 {
     type Error = io::Error;
-    fn write_fmt(&mut self, args: fmt::Arguments) -> io::Result<()> {
+    fn write_fmt(&mut self, args: fmt::Arguments<'_>) -> io::Result<()> {
         <W as io::Write>::write_fmt(&mut self.0, args)
     }
 }
 
 impl Write for String {
     type Error = fmt::Error;
-    fn write_fmt(&mut self, args: fmt::Arguments) -> fmt::Result {
+    fn write_fmt(&mut self, args: fmt::Arguments<'_>) -> fmt::Result {
         <String as fmt::Write>::write_fmt(self, args)
     }
 }
@@ -53,7 +53,7 @@ pub struct PyWriter<'vm>(pub PyObjectRef, pub &'vm VirtualMachine);
 
 impl Write for PyWriter<'_> {
     type Error = PyBaseExceptionRef;
-    fn write_fmt(&mut self, args: fmt::Arguments) -> Result<(), Self::Error> {
+    fn write_fmt(&mut self, args: fmt::Arguments<'_>) -> Result<(), Self::Error> {
         let PyWriter(obj, vm) = self;
         vm.call_method(obj, "write", (args.to_string(),)).map(drop)
     }

--- a/vm/src/py_serde.rs
+++ b/vm/src/py_serde.rs
@@ -41,7 +41,7 @@ impl<'s> PyObjectSerializer<'s> {
         PyObjectSerializer { pyobject, vm }
     }
 
-    fn clone_with_object(&self, pyobject: &'s PyObjectRef) -> PyObjectSerializer {
+    fn clone_with_object(&self, pyobject: &'s PyObjectRef) -> PyObjectSerializer<'_> {
         PyObjectSerializer {
             pyobject,
             vm: self.vm,
@@ -130,7 +130,7 @@ impl<'de> DeserializeSeed<'de> for PyObjectDeserializer<'de> {
 impl<'de> Visitor<'de> for PyObjectDeserializer<'de> {
     type Value = PyObjectRef;
 
-    fn expecting(&self, formatter: &mut std::fmt::Formatter) -> std::fmt::Result {
+    fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         formatter.write_str("a type that can deserialize in Python")
     }
 

--- a/vm/src/scope.rs
+++ b/vm/src/scope.rs
@@ -8,7 +8,7 @@ pub struct Scope {
 }
 
 impl fmt::Debug for Scope {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         // TODO: have a more informative Debug impl that DOESN'T recurse and cause a stack overflow
         f.write_str("Scope")
     }

--- a/vm/src/signal.rs
+++ b/vm/src/signal.rs
@@ -107,14 +107,14 @@ impl UserSignalSender {
 pub struct UserSignalSendError(pub UserSignal);
 
 impl fmt::Debug for UserSignalSendError {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("UserSignalSendError")
             .finish_non_exhaustive()
     }
 }
 
 impl fmt::Display for UserSignalSendError {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.write_str("sending a signal to a exited vm")
     }
 }

--- a/vm/src/stdlib/ctypes/library.rs
+++ b/vm/src/stdlib/ctypes/library.rs
@@ -12,7 +12,7 @@ pub struct SharedLibrary {
 }
 
 impl fmt::Debug for SharedLibrary {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "SharedLibrary")
     }
 }
@@ -30,7 +30,7 @@ impl SharedLibrary {
             unsafe {
                 inner
                     .get(name.as_bytes())
-                    .map(|f: libloading::Symbol<*mut c_void>| *f)
+                    .map(|f: libloading::Symbol<'_, *mut c_void>| *f)
                     .map_err(|err| err.to_string())
             }
         } else {

--- a/vm/src/stdlib/io.rs
+++ b/vm/src/stdlib/io.rs
@@ -1392,7 +1392,7 @@ mod _io {
         const WRITABLE: bool;
         const SEEKABLE: bool = false;
         fn data(&self) -> &PyThreadMutex<BufferedData>;
-        fn lock(&self, vm: &VirtualMachine) -> PyResult<PyThreadMutexGuard<BufferedData>> {
+        fn lock(&self, vm: &VirtualMachine) -> PyResult<PyThreadMutexGuard<'_, BufferedData>> {
             self.data()
                 .lock()
                 .ok_or_else(|| vm.new_runtime_error("reentrant call inside buffered io".to_owned()))
@@ -2273,13 +2273,13 @@ mod _io {
         fn lock_opt(
             &self,
             vm: &VirtualMachine,
-        ) -> PyResult<PyThreadMutexGuard<Option<TextIOData>>> {
+        ) -> PyResult<PyThreadMutexGuard<'_, Option<TextIOData>>> {
             self.data
                 .lock()
                 .ok_or_else(|| vm.new_runtime_error("reentrant call inside textio".to_owned()))
         }
 
-        fn lock(&self, vm: &VirtualMachine) -> PyResult<PyMappedThreadMutexGuard<TextIOData>> {
+        fn lock(&self, vm: &VirtualMachine) -> PyResult<PyMappedThreadMutexGuard<'_, TextIOData>> {
             let lock = self.lock_opt(vm)?;
             PyThreadMutexGuard::try_map(lock, |x| x.as_mut())
                 .map_err(|_| vm.new_value_error("I/O operation on uninitialized object".to_owned()))
@@ -3210,7 +3210,7 @@ mod _io {
         fn lock_opt(
             &self,
             vm: &VirtualMachine,
-        ) -> PyResult<PyThreadMutexGuard<Option<IncrementalNewlineDecoderData>>> {
+        ) -> PyResult<PyThreadMutexGuard<'_, Option<IncrementalNewlineDecoderData>>> {
             self.data
                 .lock()
                 .ok_or_else(|| vm.new_runtime_error("reentrant call inside nldecoder".to_owned()))
@@ -3219,7 +3219,7 @@ mod _io {
         fn lock(
             &self,
             vm: &VirtualMachine,
-        ) -> PyResult<PyMappedThreadMutexGuard<IncrementalNewlineDecoderData>> {
+        ) -> PyResult<PyMappedThreadMutexGuard<'_, IncrementalNewlineDecoderData>> {
             let lock = self.lock_opt(vm)?;
             PyThreadMutexGuard::try_map(lock, |x| x.as_mut()).map_err(|_| {
                 vm.new_value_error("I/O operation on uninitialized nldecoder".to_owned())

--- a/vm/src/stdlib/sre.rs
+++ b/vm/src/stdlib/sre.rs
@@ -53,7 +53,7 @@ mod _sre {
     trait SreStr: StrDrive {
         fn slice(&self, start: usize, end: usize, vm: &VirtualMachine) -> PyObjectRef;
 
-        fn create_request(self, pattern: &Pattern, start: usize, end: usize) -> Request<Self> {
+        fn create_request(self, pattern: &Pattern, start: usize, end: usize) -> Request<'_, Self> {
             Request::new(self, start, end, &pattern.code, false)
         }
     }

--- a/vm/src/stdlib/symtable.rs
+++ b/vm/src/stdlib/symtable.rs
@@ -41,7 +41,7 @@ mod symtable {
     }
 
     impl fmt::Debug for PySymbolTable {
-        fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
             write!(f, "SymbolTable()")
         }
     }
@@ -157,7 +157,7 @@ mod symtable {
     }
 
     impl fmt::Debug for PySymbol {
-        fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
             write!(f, "Symbol()")
         }
     }

--- a/vm/src/stdlib/thread.rs
+++ b/vm/src/stdlib/thread.rs
@@ -115,7 +115,7 @@ pub(crate) mod _thread {
     }
 
     impl fmt::Debug for Lock {
-        fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
             f.pad("Lock")
         }
     }
@@ -192,7 +192,7 @@ pub(crate) mod _thread {
     }
 
     impl fmt::Debug for RLock {
-        fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
             f.pad("RLock")
         }
     }

--- a/vm/src/stdlib/time.rs
+++ b/vm/src/stdlib/time.rs
@@ -450,7 +450,7 @@ mod decl {
     }
 
     impl std::fmt::Debug for PyStructTime {
-        fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
             write!(f, "struct_time()")
         }
     }

--- a/vm/src/types/slot.rs
+++ b/vm/src/types/slot.rs
@@ -1232,7 +1232,7 @@ pub trait AsMapping: PyPayload {
     fn as_mapping() -> &'static PyMappingMethods;
 
     #[inline]
-    fn mapping_downcast(mapping: PyMapping) -> &Py<Self> {
+    fn mapping_downcast(mapping: PyMapping<'_>) -> &Py<Self> {
         unsafe { mapping.obj.downcast_unchecked_ref() }
     }
 }
@@ -1243,7 +1243,7 @@ pub trait AsSequence: PyPayload {
     fn as_sequence() -> &'static PySequenceMethods;
 
     #[inline]
-    fn sequence_downcast(seq: PySequence) -> &Py<Self> {
+    fn sequence_downcast(seq: PySequence<'_>) -> &Py<Self> {
         unsafe { seq.obj.downcast_unchecked_ref() }
     }
 }
@@ -1259,12 +1259,12 @@ pub trait AsNumber: PyPayload {
     }
 
     #[inline]
-    fn number_downcast(num: PyNumber) -> &Py<Self> {
+    fn number_downcast(num: PyNumber<'_>) -> &Py<Self> {
         unsafe { num.obj().downcast_unchecked_ref() }
     }
 
     #[inline]
-    fn number_downcast_exact(num: PyNumber, vm: &VirtualMachine) -> PyRef<Self> {
+    fn number_downcast_exact(num: PyNumber<'_>, vm: &VirtualMachine) -> PyRef<Self> {
         if let Some(zelf) = num.downcast_ref_if_exact::<Self>(vm) {
             zelf.to_owned()
         } else {

--- a/vm/src/vm/mod.rs
+++ b/vm/src/vm/mod.rs
@@ -497,7 +497,7 @@ impl VirtualMachine {
         }
     }
 
-    pub fn current_frame(&self) -> Option<Ref<FrameRef>> {
+    pub fn current_frame(&self) -> Option<Ref<'_, FrameRef>> {
         let frames = self.frames.borrow();
         if frames.is_empty() {
             None
@@ -514,7 +514,7 @@ impl VirtualMachine {
             .locals(self)
     }
 
-    pub fn current_globals(&self) -> Ref<PyDictRef> {
+    pub fn current_globals(&self) -> Ref<'_, PyDictRef> {
         let frame = self
             .current_frame()
             .expect("called current_globals but no frames on the stack");

--- a/vm/sre_engine/src/engine.rs
+++ b/vm/sre_engine/src/engine.rs
@@ -122,14 +122,14 @@ pub struct State {
 }
 
 impl State {
-    pub fn reset<S: StrDrive>(&mut self, req: &Request<S>, start: usize) {
+    pub fn reset<S: StrDrive>(&mut self, req: &Request<'_, S>, start: usize) {
         self.marks.clear();
         self.repeat_stack.clear();
         self.start = start;
         req.string.adjust_cursor(&mut self.cursor, start);
     }
 
-    pub fn pymatch<S: StrDrive>(&mut self, req: &Request<S>) -> bool {
+    pub fn pymatch<S: StrDrive>(&mut self, req: &Request<'_, S>) -> bool {
         self.start = req.start;
         req.string.adjust_cursor(&mut self.cursor, self.start);
 
@@ -144,7 +144,7 @@ impl State {
         _match(req, self, ctx)
     }
 
-    pub fn search<S: StrDrive>(&mut self, mut req: Request<S>) -> bool {
+    pub fn search<S: StrDrive>(&mut self, mut req: Request<'_, S>) -> bool {
         self.start = req.start;
         req.string.adjust_cursor(&mut self.cursor, self.start);
 
@@ -279,7 +279,7 @@ enum Jump {
     PossessiveRepeat4,
 }
 
-fn _match<S: StrDrive>(req: &Request<S>, state: &mut State, mut ctx: MatchContext) -> bool {
+fn _match<S: StrDrive>(req: &Request<'_, S>, state: &mut State, mut ctx: MatchContext) -> bool {
     let mut context_stack = vec![];
     let mut popped_result = false;
 
@@ -882,7 +882,7 @@ fn _match<S: StrDrive>(req: &Request<S>, state: &mut State, mut ctx: MatchContex
 }
 
 fn search_info_literal<const LITERAL: bool, S: StrDrive>(
-    req: &mut Request<S>,
+    req: &mut Request<'_, S>,
     state: &mut State,
     mut ctx: MatchContext,
 ) -> bool {
@@ -998,7 +998,7 @@ fn search_info_literal<const LITERAL: bool, S: StrDrive>(
 }
 
 fn search_info_charset<S: StrDrive>(
-    req: &mut Request<S>,
+    req: &mut Request<'_, S>,
     state: &mut State,
     mut ctx: MatchContext,
 ) -> bool {
@@ -1054,11 +1054,11 @@ impl MatchContext {
         &req.pattern_codes[self.code_position..]
     }
 
-    fn remaining_codes<S>(&self, req: &Request<S>) -> usize {
+    fn remaining_codes<S>(&self, req: &Request<'_, S>) -> usize {
         req.pattern_codes.len() - self.code_position
     }
 
-    fn remaining_chars<S>(&self, req: &Request<S>) -> usize {
+    fn remaining_chars<S>(&self, req: &Request<'_, S>) -> usize {
         req.end - self.cursor.position
     }
 
@@ -1086,11 +1086,11 @@ impl MatchContext {
         S::back_advance(&mut self.cursor)
     }
 
-    fn peek_code<S>(&self, req: &Request<S>, peek: usize) -> u32 {
+    fn peek_code<S>(&self, req: &Request<'_, S>, peek: usize) -> u32 {
         req.pattern_codes[self.code_position + peek]
     }
 
-    fn try_peek_code_as<T, S>(&self, req: &Request<S>, peek: usize) -> Result<T, T::Error>
+    fn try_peek_code_as<T, S>(&self, req: &Request<'_, S>, peek: usize) -> Result<T, T::Error>
     where
         T: TryFrom<u32>,
     {
@@ -1101,7 +1101,7 @@ impl MatchContext {
         self.code_position += skip;
     }
 
-    fn skip_code_from<S>(&mut self, req: &Request<S>, peek: usize) {
+    fn skip_code_from<S>(&mut self, req: &Request<'_, S>, peek: usize) {
         self.skip_code(self.peek_code(req, peek) as usize + 1);
     }
 
@@ -1110,17 +1110,17 @@ impl MatchContext {
         self.cursor.position == 0
     }
 
-    fn at_end<S>(&self, req: &Request<S>) -> bool {
+    fn at_end<S>(&self, req: &Request<'_, S>) -> bool {
         self.cursor.position == req.end
     }
 
-    fn at_linebreak<S: StrDrive>(&self, req: &Request<S>) -> bool {
+    fn at_linebreak<S: StrDrive>(&self, req: &Request<'_, S>) -> bool {
         !self.at_end(req) && is_linebreak(self.peek_char::<S>())
     }
 
     fn at_boundary<S: StrDrive, F: FnMut(u32) -> bool>(
         &self,
-        req: &Request<S>,
+        req: &Request<'_, S>,
         mut word_checker: F,
     ) -> bool {
         if self.at_beginning() && self.at_end(req) {
@@ -1133,7 +1133,7 @@ impl MatchContext {
 
     fn at_non_boundary<S: StrDrive, F: FnMut(u32) -> bool>(
         &self,
-        req: &Request<S>,
+        req: &Request<'_, S>,
         mut word_checker: F,
     ) -> bool {
         if self.at_beginning() && self.at_end(req) {
@@ -1144,7 +1144,7 @@ impl MatchContext {
         this == that
     }
 
-    fn can_success<S>(&self, req: &Request<S>) -> bool {
+    fn can_success<S>(&self, req: &Request<'_, S>) -> bool {
         if !self.toplevel {
             return true;
         }
@@ -1158,7 +1158,7 @@ impl MatchContext {
     }
 
     #[must_use]
-    fn next_peek_from<S>(&mut self, peek: usize, req: &Request<S>, jump: Jump) -> Self {
+    fn next_peek_from<S>(&mut self, peek: usize, req: &Request<'_, S>, jump: Jump) -> Self {
         self.next_offset(self.peek_code(req, peek) as usize + 1, jump)
     }
 
@@ -1179,7 +1179,7 @@ impl MatchContext {
     }
 }
 
-fn at<S: StrDrive>(req: &Request<S>, ctx: &MatchContext, atcode: SreAtCode) -> bool {
+fn at<S: StrDrive>(req: &Request<'_, S>, ctx: &MatchContext, atcode: SreAtCode) -> bool {
     match atcode {
         SreAtCode::BEGINNING | SreAtCode::BEGINNING_STRING => ctx.at_beginning(),
         SreAtCode::BEGINNING_LINE => ctx.at_beginning() || is_linebreak(ctx.back_peek_char::<S>()),
@@ -1327,7 +1327,7 @@ fn charset(set: &[u32], ch: u32) -> bool {
 }
 
 fn _count<S: StrDrive>(
-    req: &Request<S>,
+    req: &Request<'_, S>,
     state: &mut State,
     ctx: &mut MatchContext,
     max_count: usize,
@@ -1399,7 +1399,7 @@ fn _count<S: StrDrive>(
 }
 
 fn general_count_literal<S: StrDrive, F: FnMut(u32, u32) -> bool>(
-    req: &Request<S>,
+    req: &Request<'_, S>,
     ctx: &mut MatchContext,
     end: usize,
     mut f: F,

--- a/wasm/lib/src/js_module.rs
+++ b/wasm/lib/src/js_module.rs
@@ -297,7 +297,7 @@ mod _js {
     }
 
     impl fmt::Debug for JsClosure {
-        fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
             f.pad("JsClosure")
         }
     }

--- a/wasm/lib/src/lib.rs
+++ b/wasm/lib/src/lib.rs
@@ -14,7 +14,7 @@ pub(crate) use vm_class::weak_vm;
 use wasm_bindgen::prelude::*;
 
 /// Sets error info on the window object, and prints the backtrace to console
-pub fn panic_hook(info: &panic::PanicHookInfo) {
+pub fn panic_hook(info: &panic::PanicHookInfo<'_>) {
     // If something errors, just ignore it; we don't want to panic in the panic hook
     let try_set_info = || {
         let msg = &info.to_string();


### PR DESCRIPTION
Not totally sure about this, but this sometimes trips me up because I forget that this elision is allowed, since rust-analyzer and co will usually add `<'_>` in code that they generate, so it's confusing to see a type I know has a lifetime parameter not have one.

From the [lint description](https://doc.rust-lang.org/rustc/lints/listing/allowed-by-default.html#elided-lifetimes-in-paths):

> Elided lifetime parameters can make it difficult to see at a glance that borrowing is occurring. This lint ensures that lifetime parameters are always explicitly stated, even if it is the `'_` [placeholder lifetime](https://doc.rust-lang.org/reference/lifetime-elision.html#lifetime-elision-in-functions).