### PR TITLE
Fix not throwing the same error as CPython in test_pathlib.test_expanduser

### DIFF
--- a/extra_tests/snippets/stdlib_pwd.py
+++ b/extra_tests/snippets/stdlib_pwd.py
@@ -1,0 +1,7 @@
+from testutils import assert_raises
+import pwd
+
+with assert_raises(KeyError):
+    fake_name = 'fake_user'
+    while pwd.getpwnam(fake_name):
+        fake_name += '1'

--- a/extra_tests/snippets/stdlib_pwd.py
+++ b/extra_tests/snippets/stdlib_pwd.py
@@ -1,3 +1,8 @@
+import sys
+# windows doesn't support pwd
+if sys.platform.startswith("win"):
+    exit(0)
+
 from testutils import assert_raises
 import pwd
 

--- a/vm/src/stdlib/pwd.rs
+++ b/vm/src/stdlib/pwd.rs
@@ -57,7 +57,7 @@ mod pwd {
         if pw_name.contains('\0') {
             return Err(exceptions::cstring_error(vm));
         }
-        let user = User::from_name(name.as_str()).map_err(|err| err.into_pyexception(vm))?;
+        let user = User::from_name(name.as_str()).ok().flatten();
         let user = user.ok_or_else(|| {
             vm.new_key_error(
                 vm.ctx


### PR DESCRIPTION
Given,

```
hbina085@akarin-thinkpad ~/g/RustPython (main) [1]> cat ggg_nonexisten_user.py                                                                                                                                        (base) 
import pwd

fakename = 'fakeuser'
while pwd.getpwnam(fakename):
    fakename += '1'
```

Currently, in CPython,

```
hbina085@akarin-thinkpad ~/g/RustPython (main)> python ggg_nonexisten_user.py                                                                                                                                         (base) 
Traceback (most recent call last):
  File "/home/hbina085/git/RustPython/ggg_nonexisten_user.py", line 4, in <module>
    while pwd.getpwnam(fakename):
          ^^^^^^^^^^^^^^^^^^^^^^
KeyError: "getpwnam(): name not found: 'fakeuser'"
```

Whereas, in RustPython,

```
hbina085@akarin-thinkpad ~/g/RustPython (main) [1]> cargo run --release --quiet -- ggg_nonexisten_user.py                                                                                                             (base) 
Traceback (most recent call last):
  File "ggg_nonexisten_user.py", line 4, in <module>
    while pwd.getpwnam(fakename):
FileNotFoundError: (2, 'No such file or directory (os error 2)')
```
AFAIK, CPython doesn't care what kind of errors happen underneath.
See https://github.com/python/cpython/blob/a42168d316f0c9a4fc5658dab87682dc19054efb/Modules/pwdmodule.c#L270-L279