### PR TITLE
Fixes evaluation order in expression lists

### DIFF
--- a/compiler/core/src/bytecode.rs
+++ b/compiler/core/src/bytecode.rs
@@ -542,19 +542,20 @@ pub enum Instruction {
     BuildTuple {
         size: Arg<u32>,
     },
-    BuildTupleUnpack {
+    BuildTupleFromTuples {
         size: Arg<u32>,
     },
+    BuildTupleFromIter,
     BuildList {
         size: Arg<u32>,
     },
-    BuildListUnpack {
+    BuildListFromTuples {
         size: Arg<u32>,
     },
     BuildSet {
         size: Arg<u32>,
     },
-    BuildSetUnpack {
+    BuildSetFromTuples {
         size: Arg<u32>,
     },
     BuildMap {
@@ -1260,11 +1261,12 @@ impl Instruction {
             Raise { kind } => -(kind.get(arg) as u8 as i32),
             BuildString { size }
             | BuildTuple { size, .. }
-            | BuildTupleUnpack { size, .. }
+            | BuildTupleFromTuples { size, .. }
             | BuildList { size, .. }
-            | BuildListUnpack { size, .. }
+            | BuildListFromTuples { size, .. }
             | BuildSet { size, .. }
-            | BuildSetUnpack { size, .. } => -(size.get(arg) as i32) + 1,
+            | BuildSetFromTuples { size, .. } => -(size.get(arg) as i32) + 1,
+            BuildTupleFromIter => 0,
             BuildMap { size } => {
                 let nargs = size.get(arg) * 2;
                 -(nargs as i32) + 1
@@ -1447,13 +1449,14 @@ impl Instruction {
             Raise { kind } => w!(Raise, ?kind),
             BuildString { size } => w!(BuildString, size),
             BuildTuple { size } => w!(BuildTuple, size),
-            BuildTupleUnpack { size } => w!(BuildTupleUnpack, size),
+            BuildTupleFromTuples { size } => w!(BuildTupleFromTuples, size),
+            BuildTupleFromIter => w!(BuildTupleFromIter),
             BuildList { size } => w!(BuildList, size),
-            BuildListUnpack { size } => w!(BuildListUnpack, size),
+            BuildListFromTuples { size } => w!(BuildListFromTuples, size),
             BuildSet { size } => w!(BuildSet, size),
-            BuildSetUnpack { size } => w!(BuildSetUnpack, size),
+            BuildSetFromTuples { size } => w!(BuildSetFromTuples, size),
             BuildMap { size } => w!(BuildMap, size),
-            BuildMapForCall { size } => w!(BuildMap, size),
+            BuildMapForCall { size } => w!(BuildMapForCall, size),
             DictUpdate => w!(DictUpdate),
             BuildSlice { step } => w!(BuildSlice, step),
             ListAppend { i } => w!(ListAppend, i),

--- a/extra_tests/snippets/builtin_list.py
+++ b/extra_tests/snippets/builtin_list.py
@@ -636,6 +636,27 @@ assert it.__length_hint__() == 0
 a = [*[1, 2], 3, *[4, 5]]
 assert a == [1, 2, 3, 4, 5]
 
+# Test for list unpacking evaluation order (https://github.com/RustPython/RustPython/issues/5566)
+a = [1, 2]
+b = [a.append(3), *a, a.append(4), *a]
+assert a == [1, 2, 3, 4]
+assert b == [None, 1, 2, 3, None, 1, 2, 3, 4]
+
+for base in object, list, tuple:
+    # do not assume that a type inherited from some sequence type behaves like
+    # that sequence type
+    class C(base):
+        def __iter__(self):
+            a.append(2)
+            def inner():
+                yield 3
+                a.append(4)
+            return inner()
+
+    a = [1]
+    b = [*a, *C(), *a.copy()]
+    assert b == [1, 3, 1, 2, 4]
+
 # Test for list entering daedlock or not (https://github.com/RustPython/RustPython/pull/2933)
 class MutatingCompare:
     def __eq__(self, other):


### PR DESCRIPTION
Enforce left-to-right evaluation with list/tuple/set expressions and positional arguments in calls.

We cannot iterate through the `*`-unpacked iterables after evaluating all given expressions. This PR fixes the problem by temporarily collecting the unpacked iterable into a tuple before moving on to the next element.

Fixes #5566 

(`**`-unpacking with `dict`s and keyword arguments seem to be more buggy; working on a fix.)