### PR TITLE
Remove -merge from Cargo.lock gitattributes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,5 +1,5 @@
 Lib/**      linguist-vendored
-Cargo.lock  linguist-generated -merge
+Cargo.lock  linguist-generated
 *.snap      linguist-generated -merge
 vm/src/stdlib/ast/gen.rs    linguist-generated -merge
 Lib/*.py    text working-tree-encoding=UTF-8 eol=LF


### PR DESCRIPTION
This was causing git to refuse to even attempt to merge Cargo.lock, leading to oftentimes changes to Cargo.lock being completely overwritten in a merge. 