### PR TITLE
Refactor cformat in prep for wtf8

### DIFF
--- a/common/src/format.rs
+++ b/common/src/format.rs
@@ -14,11 +14,12 @@ trait FormatParse {
 }
 
 #[derive(Debug, Copy, Clone, PartialEq)]
+#[repr(u8)]
 pub enum FormatConversion {
-    Str,
-    Repr,
-    Ascii,
-    Bytes,
+    Str = b's',
+    Repr = b'r',
+    Ascii = b'b',
+    Bytes = b'a',
 }
 
 impl FormatParse for FormatConversion {

--- a/vm/src/anystr.rs
+++ b/vm/src/anystr.rs
@@ -1,7 +1,6 @@
 use crate::{
     Py, PyObject, PyObjectRef, PyResult, TryFromObject, VirtualMachine,
     builtins::{PyIntRef, PyTuple},
-    cformat::cformat_string,
     convert::TryFromBorrowedObject,
     function::OptionalOption,
 };
@@ -155,7 +154,6 @@ pub trait AnyStr {
 
     fn to_container(&self) -> Self::Container;
     fn as_bytes(&self) -> &[u8];
-    fn as_utf8_str(&self) -> Result<&str, std::str::Utf8Error>;
     fn chars(&self) -> impl Iterator<Item = char>;
     fn elements(&self) -> impl Iterator<Item = Self::Char>;
     fn get_bytes(&self, range: std::ops::Range<usize>) -> &Self;
@@ -424,11 +422,6 @@ pub trait AnyStr {
             }
         }
         cased
-    }
-
-    fn py_cformat(&self, values: PyObjectRef, vm: &VirtualMachine) -> PyResult<String> {
-        let format_string = self.as_utf8_str().unwrap();
-        cformat_string(vm, format_string, values)
     }
 }
 

--- a/vm/src/builtins/str.rs
+++ b/vm/src/builtins/str.rs
@@ -8,6 +8,7 @@ use crate::{
     TryFromBorrowedObject, VirtualMachine,
     anystr::{self, AnyStr, AnyStrContainer, AnyStrWrapper, adjust_indices},
     atomic_func,
+    cformat::cformat_string,
     class::PyClassImpl,
     common::str::{BorrowedStr, PyStrKind, PyStrKindData},
     convert::{IntoPyException, ToPyException, ToPyObject, ToPyResult},
@@ -729,8 +730,7 @@ impl PyStr {
 
     #[pymethod(name = "__mod__")]
     fn modulo(&self, values: PyObjectRef, vm: &VirtualMachine) -> PyResult<String> {
-        let formatted = self.as_str().py_cformat(values, vm)?;
-        Ok(formatted)
+        cformat_string(vm, self.as_str(), values)
     }
 
     #[pymethod(magic)]
@@ -1596,10 +1596,6 @@ impl AnyStr for str {
 
     fn as_bytes(&self) -> &[u8] {
         self.as_bytes()
-    }
-
-    fn as_utf8_str(&self) -> Result<&str, std::str::Utf8Error> {
-        Ok(self)
     }
 
     fn chars(&self) -> impl Iterator<Item = char> {

--- a/vm/src/bytesinner.rs
+++ b/vm/src/bytesinner.rs
@@ -1037,10 +1037,6 @@ impl AnyStr for [u8] {
         self
     }
 
-    fn as_utf8_str(&self) -> Result<&str, std::str::Utf8Error> {
-        std::str::from_utf8(self)
-    }
-
     fn chars(&self) -> impl Iterator<Item = char> {
         bstr::ByteSlice::chars(self)
     }


### PR DESCRIPTION
Pulled from #5587. This makes the "Make cformat wtf8-compatible" commit there much smaller. The commit for str.format is already pretty find-and-replace str->wtf8, so I just pulled this out.