### PR TITLE
Refactor codecs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2355,6 +2355,7 @@ dependencies = [
  "rand 0.9.0",
  "rustpython-literal",
  "siphasher 0.3.11",
+ "unicode_names2",
  "volatile",
  "widestring",
  "windows-sys 0.59.0",

--- a/Lib/_pycodecs.py
+++ b/Lib/_pycodecs.py
@@ -1086,11 +1086,13 @@ def charmapencode_output(c, mapping):
     rep = mapping[c]
     if isinstance(rep, int) or isinstance(rep, int):
         if rep < 256:
-            return rep
+            return [rep]
         else:
             raise TypeError("character mapping must be in range(256)")
     elif isinstance(rep, str):
-        return ord(rep)
+        return [ord(rep)]
+    elif isinstance(rep, bytes):
+        return rep
     elif rep == None:
         raise KeyError("character maps to <undefined>")
     else:
@@ -1113,12 +1115,13 @@ def PyUnicode_EncodeCharmap(p, size, mapping='latin-1', errors='strict'):
         #/* try to encode it */
         try:
             x = charmapencode_output(ord(p[inpos]), mapping)
-            res += [x]
+            res += x
         except KeyError:
             x = unicode_call_errorhandler(errors, "charmap",
             "character maps to <undefined>", p, inpos, inpos+1, False)
             try:
-                res += [charmapencode_output(ord(y), mapping) for y in x[0]]
+                for y in x[0]:
+                    res += charmapencode_output(ord(y), mapping)
             except KeyError:
                 raise UnicodeEncodeError("charmap", p, inpos, inpos+1,
                                         "character maps to <undefined>")

--- a/Lib/test/test_charmapcodec.py
+++ b/Lib/test/test_charmapcodec.py
@@ -33,8 +33,6 @@ class CharmapCodecTest(unittest.TestCase):
         self.assertEqual(str(b'dxf', codecname), 'dabcf')
         self.assertEqual(str(b'dxfx', codecname), 'dabcfabc')
 
-    # TODO: RUSTPYTHON
-    @unittest.expectedFailure
     def test_encodex(self):
         self.assertEqual('abc'.encode(codecname), b'abc')
         self.assertEqual('xdef'.encode(codecname), b'abcdef')

--- a/Lib/test/test_codeccallbacks.py
+++ b/Lib/test/test_codeccallbacks.py
@@ -203,8 +203,6 @@ class CodecCallbackTest(unittest.TestCase):
         self.assertRaises(UnicodeDecodeError, sin.decode,
                           "utf-8", "test.relaxedutf8")
 
-    # TODO: RUSTPYTHON
-    @unittest.expectedFailure
     def test_charmapencode(self):
         # For charmap encodings the replacement string will be
         # mapped through the encoding again. This means, that
@@ -329,8 +327,6 @@ class CodecCallbackTest(unittest.TestCase):
         exc = exctype(*args)
         self.assertEqual(str(exc), msg)
 
-    # TODO: RUSTPYTHON
-    @unittest.expectedFailure
     def test_unicodeencodeerror(self):
         self.check_exceptionobjectargs(
             UnicodeEncodeError,
@@ -363,8 +359,6 @@ class CodecCallbackTest(unittest.TestCase):
             "'ascii' codec can't encode character '\\U00010000' in position 0: ouch"
         )
 
-    # TODO: RUSTPYTHON
-    @unittest.expectedFailure
     def test_unicodedecodeerror(self):
         self.check_exceptionobjectargs(
             UnicodeDecodeError,
@@ -377,8 +371,6 @@ class CodecCallbackTest(unittest.TestCase):
             "'ascii' codec can't decode bytes in position 1-2: ouch"
         )
 
-    # TODO: RUSTPYTHON
-    @unittest.expectedFailure
     def test_unicodetranslateerror(self):
         self.check_exceptionobjectargs(
             UnicodeTranslateError,
@@ -467,8 +459,6 @@ class CodecCallbackTest(unittest.TestCase):
             ("", 2)
         )
 
-    # TODO: RUSTPYTHON
-    @unittest.expectedFailure
     def test_badandgoodreplaceexceptions(self):
         # "replace" complains about a non-exception passed in
         self.assertRaises(
@@ -509,8 +499,6 @@ class CodecCallbackTest(unittest.TestCase):
             ("\ufffd", 2)
         )
 
-    # TODO: RUSTPYTHON
-    @unittest.expectedFailure
     def test_badandgoodxmlcharrefreplaceexceptions(self):
         # "xmlcharrefreplace" complains about a non-exception passed in
         self.assertRaises(
@@ -1017,8 +1005,6 @@ class CodecCallbackTest(unittest.TestCase):
         self.assertRaises(ValueError, codecs.charmap_decode, b"\xff", "strict", D())
         self.assertRaises(TypeError, codecs.charmap_decode, b"\xff", "strict", {0xff: sys.maxunicode+1})
 
-    # TODO: RUSTPYTHON
-    @unittest.expectedFailure
     def test_encodehelper(self):
         # enhance coverage of:
         # Objects/unicodeobject.c::unicode_encode_call_errorhandler()

--- a/Lib/test/test_logging.py
+++ b/Lib/test/test_logging.py
@@ -5525,8 +5525,6 @@ class BasicConfigTest(unittest.TestCase):
             self.assertEqual(data, r'\U0001f602: \u2603\ufe0f: The \xd8resund '
                                    r'Bridge joins Copenhagen to Malm\xf6')
 
-    # TODO: RustPython
-    @unittest.expectedFailure
     def test_encoding_errors_none(self):
         # Specifying None should behave as 'strict'
         try:

--- a/common/Cargo.toml
+++ b/common/Cargo.toml
@@ -29,6 +29,7 @@ num-traits = { workspace = true }
 once_cell = { workspace = true }
 parking_lot = { workspace = true, optional = true }
 rand = { workspace = true }
+unicode_names2 = { workspace = true }
 
 lock_api = "0.4"
 radium = "0.7"

--- a/common/src/encodings.rs
+++ b/common/src/encodings.rs
@@ -244,9 +244,6 @@ where
                 out.extend_from_slice(b.as_ref());
             }
         }
-        // data = crate::str::try_get_codepoints(full_data.as_ref(), char_restart..)
-        //     .ok_or_else(|| errors.error_oob_restart(char_restart))?;
-        // char_data_index = char_restart;
     }
     out.extend_from_slice(ctx.remaining_data().as_bytes());
     Ok(out)

--- a/common/src/str.rs
+++ b/common/src/str.rs
@@ -446,6 +446,21 @@ pub fn to_ascii(value: &str) -> AsciiString {
     unsafe { AsciiString::from_ascii_unchecked(ascii) }
 }
 
+pub struct UnicodeEscapeCodepoint(pub CodePoint);
+
+impl fmt::Display for UnicodeEscapeCodepoint {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let c = self.0.to_u32();
+        if c >= 0x10000 {
+            write!(f, "\\U{c:08x}")
+        } else if c >= 0x100 {
+            write!(f, "\\u{c:04x}")
+        } else {
+            write!(f, "\\x{c:02x}")
+        }
+    }
+}
+
 pub mod levenshtein {
     use std::{cell::RefCell, thread_local};
 

--- a/vm/src/function/buffer.rs
+++ b/vm/src/function/buffer.rs
@@ -70,6 +70,12 @@ impl From<ArgBytesLike> for PyBuffer {
     }
 }
 
+impl From<ArgBytesLike> for PyObjectRef {
+    fn from(buffer: ArgBytesLike) -> Self {
+        buffer.as_object().to_owned()
+    }
+}
+
 impl<'a> TryFromBorrowedObject<'a> for ArgBytesLike {
     fn try_from_borrowed_object(vm: &VirtualMachine, obj: &'a PyObject) -> PyResult<Self> {
         let buffer = PyBuffer::try_from_borrowed_object(vm, obj)?;

--- a/vm/src/stdlib/io.rs
+++ b/vm/src/stdlib/io.rs
@@ -2536,10 +2536,9 @@ mod _io {
                 *snapshot = Some((cookie.dec_flags, input_chunk.clone()));
                 let decoded = vm.call_method(decoder, "decode", (input_chunk, cookie.need_eof))?;
                 let decoded = check_decoded(decoded, vm)?;
-                let pos_is_valid = crate::common::wtf8::is_code_point_boundary(
-                    decoded.as_wtf8(),
-                    cookie.bytes_to_skip as usize,
-                );
+                let pos_is_valid = decoded
+                    .as_wtf8()
+                    .is_code_point_boundary(cookie.bytes_to_skip as usize);
                 textio.set_decoded_chars(Some(decoded));
                 if !pos_is_valid {
                     return Err(vm.new_os_error("can't restore logical file position".to_owned()));

--- a/vm/src/vm/vm_new.rs
+++ b/vm/src/vm/vm_new.rs
@@ -1,7 +1,8 @@
 use crate::{
     AsObject, Py, PyObject, PyObjectRef, PyRef,
     builtins::{
-        PyBaseException, PyBaseExceptionRef, PyDictRef, PyModule, PyStrRef, PyType, PyTypeRef,
+        PyBaseException, PyBaseExceptionRef, PyBytesRef, PyDictRef, PyModule, PyStrRef, PyType,
+        PyTypeRef,
         builtin_func::PyNativeFunction,
         descriptor::PyMethodDescriptor,
         tuple::{IntoPyTuple, PyTupleRef},
@@ -203,14 +204,76 @@ impl VirtualMachine {
         self.new_exception_msg(sys_error, msg)
     }
 
+    // TODO: remove & replace with new_unicode_decode_error_real
     pub fn new_unicode_decode_error(&self, msg: String) -> PyBaseExceptionRef {
         let unicode_decode_error = self.ctx.exceptions.unicode_decode_error.to_owned();
         self.new_exception_msg(unicode_decode_error, msg)
     }
 
+    pub fn new_unicode_decode_error_real(
+        &self,
+        encoding: PyStrRef,
+        object: PyBytesRef,
+        start: usize,
+        end: usize,
+        reason: PyStrRef,
+    ) -> PyBaseExceptionRef {
+        let start = self.ctx.new_int(start);
+        let end = self.ctx.new_int(end);
+        let exc = self.new_exception(
+            self.ctx.exceptions.unicode_decode_error.to_owned(),
+            vec![
+                encoding.clone().into(),
+                object.clone().into(),
+                start.clone().into(),
+                end.clone().into(),
+                reason.clone().into(),
+            ],
+        );
+        exc.as_object()
+            .set_attr("encoding", encoding, self)
+            .unwrap();
+        exc.as_object().set_attr("object", object, self).unwrap();
+        exc.as_object().set_attr("start", start, self).unwrap();
+        exc.as_object().set_attr("end", end, self).unwrap();
+        exc.as_object().set_attr("reason", reason, self).unwrap();
+        exc
+    }
+
+    // TODO: remove & replace with new_unicode_encode_error_real
     pub fn new_unicode_encode_error(&self, msg: String) -> PyBaseExceptionRef {
         let unicode_encode_error = self.ctx.exceptions.unicode_encode_error.to_owned();
         self.new_exception_msg(unicode_encode_error, msg)
+    }
+
+    pub fn new_unicode_encode_error_real(
+        &self,
+        encoding: PyStrRef,
+        object: PyStrRef,
+        start: usize,
+        end: usize,
+        reason: PyStrRef,
+    ) -> PyBaseExceptionRef {
+        let start = self.ctx.new_int(start);
+        let end = self.ctx.new_int(end);
+        let exc = self.new_exception(
+            self.ctx.exceptions.unicode_encode_error.to_owned(),
+            vec![
+                encoding.clone().into(),
+                object.clone().into(),
+                start.clone().into(),
+                end.clone().into(),
+                reason.clone().into(),
+            ],
+        );
+        exc.as_object()
+            .set_attr("encoding", encoding, self)
+            .unwrap();
+        exc.as_object().set_attr("object", object, self).unwrap();
+        exc.as_object().set_attr("start", start, self).unwrap();
+        exc.as_object().set_attr("end", end, self).unwrap();
+        exc.as_object().set_attr("reason", reason, self).unwrap();
+        exc
     }
 
     /// Create a new python ValueError object. Useful for raising errors from


### PR DESCRIPTION
This rejiggles some stuff around so that the situation is now:

* `{En,De}codeContext` owns the input data and defines the error type.
* `{En,De}codeErrorhandler` is passed the context and just encapsulates the error handling behavior.
* standard error handlers are now defined in the `rustpython_common::encodings::errors` module.