### PR TITLE
Remove some unncessary dependencies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1336,7 +1336,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc2f4eb4bc735547cfed7c0a4922cbd04a4655978c09b54f1f7b228750664c34"
 dependencies = [
  "cfg-if",
- "windows-targets 0.52.6",
+ "windows-targets 0.48.5",
 ]
 
 [[package]]
@@ -1546,7 +1546,7 @@ version = "3.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df7151a832e54d2d6b2c827a20e5bcdd80359281cd2c354e725d4b82e7c471de"
 dependencies = [
- "rand_core 0.9.1",
+ "rand_core 0.9.3",
 ]
 
 [[package]]
@@ -1797,7 +1797,7 @@ version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "67eabc2ef2a60eb7faa00097bd1ffdb5bd28e62bf39990626a582201b7a754e5"
 dependencies = [
- "siphasher 1.0.1",
+ "siphasher",
 ]
 
 [[package]]
@@ -2014,7 +2014,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3779b94aeb87e8bd4e834cee3650289ee9e0d5677f976ecdb6d219e5f4f6cd94"
 dependencies = [
  "rand_chacha 0.9.0",
- "rand_core 0.9.1",
+ "rand_core 0.9.3",
  "zerocopy 0.8.20",
 ]
 
@@ -2035,7 +2035,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
 dependencies = [
  "ppv-lite86",
- "rand_core 0.9.1",
+ "rand_core 0.9.3",
 ]
 
 [[package]]
@@ -2049,12 +2049,11 @@ dependencies = [
 
 [[package]]
 name = "rand_core"
-version = "0.9.1"
+version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a88e0da7a2c97baa202165137c158d0a2e824ac465d13d81046727b34cb247d3"
+checksum = "99d9a13982dcf210057a8a78572b2217b667c3beacbf3a0d8b454f6f82837d38"
 dependencies = [
  "getrandom 0.3.1",
- "zerocopy 0.8.20",
 ]
 
 [[package]]
@@ -2253,15 +2252,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "357703d41365b4b27c590e3ed91eabb1b663f07c4c084095e60cbed4362dff0d"
 
 [[package]]
-name = "rustc_version"
-version = "0.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cfcb3a22ef46e85b45de6ee7e79d063319ebb6594faafcf1c225ea92ab6e9b92"
-dependencies = [
- "semver",
-]
-
-[[package]]
 name = "rustix"
 version = "0.38.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2329,6 +2319,7 @@ dependencies = [
  "bitflags 2.8.0",
  "bstr",
  "cfg-if",
+ "getrandom 0.3.1",
  "itertools 0.14.0",
  "libc",
  "lock_api",
@@ -2340,10 +2331,9 @@ dependencies = [
  "once_cell",
  "parking_lot",
  "radium",
- "rand 0.9.0",
  "rustpython-literal",
  "rustpython-wtf8",
- "siphasher 0.3.11",
+ "siphasher",
  "unicode_names2",
  "volatile",
  "widestring",
@@ -2354,6 +2344,7 @@ dependencies = [
 name = "rustpython-compiler"
 version = "0.4.0"
 dependencies = [
+ "rand 0.9.0",
  "ruff_python_ast",
  "ruff_python_parser",
  "ruff_source_file",
@@ -2511,7 +2502,7 @@ dependencies = [
  "parking_lot",
  "paste",
  "puruspe",
- "rand 0.9.0",
+ "rand_core 0.9.3",
  "rustix",
  "rustpython-common",
  "rustpython-derive",
@@ -2581,13 +2572,11 @@ dependencies = [
  "optional",
  "parking_lot",
  "paste",
- "rand 0.9.0",
  "result-like",
  "ruff_python_ast",
  "ruff_python_parser",
  "ruff_source_file",
  "ruff_text_size",
- "rustc_version",
  "rustix",
  "rustpython-codegen",
  "rustpython-common",
@@ -2709,12 +2698,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
-name = "semver"
-version = "1.0.25"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f79dfe2d285b0488816f30e700a7438c5a73d816b5b7d3ac72fbc48b0d185e03"
-
-[[package]]
 name = "serde"
 version = "1.0.218"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2820,12 +2803,6 @@ name = "similar"
 version = "2.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbbb5d9659141646ae647b42fe094daf6c6192d1620870b449d9557f748b2daa"
-
-[[package]]
-name = "siphasher"
-version = "0.3.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38b58827f4464d87d377d175e90bf58eb00fd8716ff0a62f80356b5e61555d0d"
 
 [[package]]
 name = "siphasher"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -158,7 +158,7 @@ chrono = "0.4.39"
 criterion = { version = "0.3.5", features = ["html_reports"] }
 crossbeam-utils = "0.8.21"
 flame = "0.2.2"
-getrandom = "0.3"
+getrandom = { version = "0.3", features = ["std"] }
 glob = "0.3"
 hex = "0.4.3"
 indexmap = { version = "2.2.6", features = ["std"] }
@@ -185,6 +185,7 @@ paste = "1.0.15"
 proc-macro2 = "1.0.93"
 quote = "1.0.38"
 rand = "0.9"
+rand_core = { version = "0.9", features = ["os_rng"] }
 rustix = { version = "0.38", features = ["event"] }
 rustyline = "15.0.0"
 serde = { version = "1.0.133", default-features = false }

--- a/common/Cargo.toml
+++ b/common/Cargo.toml
@@ -19,6 +19,7 @@ ascii = { workspace = true }
 bitflags = { workspace = true }
 bstr = { workspace = true }
 cfg-if = { workspace = true }
+getrandom = { workspace = true }
 itertools = { workspace = true }
 libc = { workspace = true }
 malachite-bigint = { workspace = true }
@@ -28,12 +29,11 @@ memchr = { workspace = true }
 num-traits = { workspace = true }
 once_cell = { workspace = true }
 parking_lot = { workspace = true, optional = true }
-rand = { workspace = true }
 unicode_names2 = { workspace = true }
 
 lock_api = "0.4"
 radium = "0.7"
-siphasher = "0.3"
+siphasher = "1"
 volatile = "0.3"
 
 [target.'cfg(windows)'.dependencies]

--- a/common/src/hash.rs
+++ b/common/src/hash.rs
@@ -37,15 +37,6 @@ impl BuildHasher for HashSecret {
     }
 }
 
-impl rand::distr::Distribution<HashSecret> for rand::distr::StandardUniform {
-    fn sample<R: rand::Rng + ?Sized>(&self, rng: &mut R) -> HashSecret {
-        HashSecret {
-            k0: rng.random(),
-            k1: rng.random(),
-        }
-    }
-}
-
 impl HashSecret {
     pub fn new(seed: u32) -> Self {
         let mut buf = [0u8; 16];

--- a/common/src/lib.rs
+++ b/common/src/lib.rs
@@ -23,6 +23,7 @@ pub mod int;
 pub mod linked_list;
 pub mod lock;
 pub mod os;
+pub mod rand;
 pub mod rc;
 pub mod refcount;
 pub mod static_cell;

--- a/common/src/rand.rs
+++ b/common/src/rand.rs
@@ -1,0 +1,13 @@
+/// Get `N` bytes of random data.
+///
+/// This function is mildly expensive to call, as it fetches random data
+/// directly from the OS entropy source.
+///
+/// # Panics
+///
+/// Panics if the OS entropy source returns an error.
+pub fn os_random<const N: usize>() -> [u8; N] {
+    let mut buf = [0u8; N];
+    getrandom::fill(&mut buf).unwrap();
+    buf
+}

--- a/compiler/Cargo.toml
+++ b/compiler/Cargo.toml
@@ -19,5 +19,8 @@ ruff_source_file = { workspace = true }
 ruff_text_size = { workspace = true }
 thiserror = { workspace = true }
 
+[dev-dependencies]
+rand = { workspace = true }
+
 [lints]
 workspace = true

--- a/stdlib/Cargo.toml
+++ b/stdlib/Cargo.toml
@@ -50,7 +50,7 @@ puruspe = "0.4.0"
 xml-rs = "0.8.14"
 
 # random
-rand = { workspace = true }
+rand_core = { workspace = true }
 mt19937 = "3.1"
 
 # Crypto:

--- a/stdlib/src/random.rs
+++ b/stdlib/src/random.rs
@@ -16,7 +16,7 @@ mod _random {
     use malachite_bigint::{BigInt, BigUint, Sign};
     use mt19937::MT19937;
     use num_traits::{Signed, Zero};
-    use rand::{RngCore, SeedableRng};
+    use rand_core::{RngCore, SeedableRng};
     use rustpython_vm::types::DefaultConstructor;
 
     #[pyattr]

--- a/stdlib/src/uuid.rs
+++ b/stdlib/src/uuid.rs
@@ -10,7 +10,8 @@ mod _uuid {
     fn get_node_id() -> [u8; 6] {
         match get_mac_address() {
             Ok(Some(_ma)) => get_mac_address().unwrap().unwrap().bytes(),
-            _ => rand::random::<[u8; 6]>(),
+            // os_random is expensive, but this is only ever called once
+            _ => rustpython_common::rand::os_random::<6>(),
         }
     }
 

--- a/vm/Cargo.toml
+++ b/vm/Cargo.toml
@@ -68,7 +68,6 @@ num_enum = { workspace = true }
 once_cell = { workspace = true }
 parking_lot = { workspace = true }
 paste = { workspace = true }
-rand = { workspace = true }
 serde = { workspace = true, optional = true }
 static_assertions = { workspace = true }
 strum = { workspace = true }
@@ -160,7 +159,6 @@ getrandom = { workspace = true }
 [build-dependencies]
 glob = { workspace = true }
 itertools = { workspace = true }
-rustc_version = "0.4.0"
 
 [lints]
 workspace = true

--- a/vm/build.rs
+++ b/vm/build.rs
@@ -20,10 +20,7 @@ fn main() {
     );
     println!("cargo:rustc-env=RUSTPYTHON_GIT_TAG={}", git_tag());
     println!("cargo:rustc-env=RUSTPYTHON_GIT_BRANCH={}", git_branch());
-    println!(
-        "cargo:rustc-env=RUSTC_VERSION={}",
-        rustc_version::version().unwrap()
-    );
+    println!("cargo:rustc-env=RUSTC_VERSION={}", rustc_version());
 
     println!(
         "cargo:rustc-env=RUSTPYTHON_TARGET_TRIPLE={}",
@@ -61,7 +58,12 @@ fn git(args: &[&str]) -> String {
     command("git", args)
 }
 
-fn command(cmd: &str, args: &[&str]) -> String {
+fn rustc_version() -> String {
+    let rustc = env::var_os("RUSTC").unwrap_or_else(|| "rustc".into());
+    command(rustc, &["-V"])
+}
+
+fn command(cmd: impl AsRef<std::ffi::OsStr>, args: &[&str]) -> String {
     match Command::new(cmd).args(args).output() {
         Ok(output) => match String::from_utf8(output.stdout) {
             Ok(s) => s,

--- a/vm/src/import.rs
+++ b/vm/src/import.rs
@@ -49,7 +49,8 @@ pub(crate) fn init_importlib_package(vm: &VirtualMachine, importlib: PyObjectRef
         let mut magic = get_git_revision().into_bytes();
         magic.truncate(4);
         if magic.len() != 4 {
-            magic = rand::random::<[u8; 4]>().to_vec();
+            // os_random is expensive, but this is only ever called once
+            magic = rustpython_common::rand::os_random::<4>().to_vec();
         }
         let magic: PyObjectRef = vm.ctx.new_bytes(magic).into();
         importlib_external.set_attr("MAGIC_NUMBER", magic, vm)?;

--- a/vm/src/version.rs
+++ b/vm/src/version.rs
@@ -21,7 +21,7 @@ pub fn get_version() -> String {
         get_version_number(),
         get_build_info(),
         env!("CARGO_PKG_VERSION"),
-        get_compiler()
+        COMPILER,
     )
 }
 
@@ -33,9 +33,7 @@ pub fn get_winver_number() -> String {
     format!("{MAJOR}.{MINOR}")
 }
 
-pub fn get_compiler() -> String {
-    format!("rustc {}", env!("RUSTC_VERSION"))
-}
+const COMPILER: &str = env!("RUSTC_VERSION");
 
 pub fn get_build_info() -> String {
     // See: https://reproducible-builds.org/docs/timestamps/

--- a/vm/src/vm/mod.rs
+++ b/vm/src/vm/mod.rs
@@ -109,7 +109,8 @@ pub struct PyGlobalState {
 pub fn process_hash_secret_seed() -> u32 {
     use std::sync::OnceLock;
     static SEED: OnceLock<u32> = OnceLock::new();
-    *SEED.get_or_init(rand::random)
+    // os_random is expensive, but this is only ever called once
+    *SEED.get_or_init(|| u32::from_ne_bytes(rustpython_common::rand::os_random()))
 }
 
 impl VirtualMachine {


### PR DESCRIPTION
Specifically, `rand` and `rustc_version` - we actually use very little of these dependencies' capabilities, and it's quite simple to swap them out with a 2-3 line function.