### PR TITLE
Hmac working without generics, and test not working yet

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -990,6 +990,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dfa686283ad6dd069f105e5ab091b04c62850d3e4cf5d67debad1933f55023df"
 
 [[package]]
+name = "hmac"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
+dependencies = [
+ "digest",
+]
+
+[[package]]
 name = "home"
 version = "0.5.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2365,6 +2374,7 @@ dependencies = [
  "foreign-types-shared",
  "gethostname",
  "hex",
+ "hmac",
  "indexmap",
  "itertools 0.14.0",
  "junction",

--- a/stdlib/Cargo.toml
+++ b/stdlib/Cargo.toml
@@ -54,6 +54,7 @@ rand_core = { workspace = true }
 mt19937 = "3.1"
 
 # Crypto:
+hmac = "0.12.1"
 digest = "0.10.3"
 md-5 = "0.10.1"
 sha-1 = "0.10.0"

--- a/stdlib/src/hashlib.rs
+++ b/stdlib/src/hashlib.rs
@@ -326,44 +326,38 @@ pub mod _hashlib {
         Ok((a_hash == b_hash).to_pyobject(vm))
     }
 
-
-
     #[derive(FromArgs, Debug)]
     #[allow(unused)]
     pub struct NewHmacHashArgs {
         #[pyarg(positional)]
         key: PyBuffer,
-        #[pyarg(named, optional)]
+        #[pyarg(any, optional)]
         msg: OptionalArg<ArgBytesLike>,
         #[pyarg(any)]
-        digestmod: PyStrRef, // TODO: RUSTPYTHON support functions & name functions
+        digestmod: PyStrRef, // TODO: RUSTPYTHON support functions
     }
 
     #[pyattr]
-    #[pyclass(module="_hmac", name="HMAC")]
+    #[pyclass(module = "_hmac", name = "HMAC")]
     #[derive(PyPayload)]
-    pub struct PyHmac 
-    {
+    pub struct PyHmac {
         pub name: String,
         pub ctx: PyRwLock<HmacWrapper>,
     }
 
-    impl std::fmt::Debug for PyHmac
-    {
+    impl std::fmt::Debug for PyHmac {
         fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
             write!(f, "HASH {}", self.name)
         }
     }
 
     #[pyclass]
-    impl PyHmac
-    {
-        fn new(name: &str, d: HmacWrapper) -> Self
-        {
+    impl PyHmac {
+        fn new(name: &str, d: HmacWrapper) -> Self {
             PyHmac {
                 name: name.to_owned(),
                 ctx: PyRwLock::new(d),
-            }        
+            }
         }
 
         #[pyslot]
@@ -388,7 +382,7 @@ pub mod _hashlib {
 
         #[pygetset]
         fn digest_size(&self) -> usize {
-            self.ctx.read().digest_size() 
+            self.ctx.read().digest_size()
         }
 
         #[pymethod]
@@ -398,7 +392,14 @@ pub mod _hashlib {
 
         #[pymethod]
         fn hexdigest(&self) -> String {
-            self.ctx.read().digest().iter().map(|d| format!("{:02x}", d)).collect()
+            self.ctx
+                .read()
+                .digest()
+                .iter()
+                .fold(String::new(), |mut acc, d| {
+                    acc.push_str(&format!("{:02x}", d));
+                    acc
+                })
         }
 
         #[pymethod]
@@ -410,34 +411,34 @@ pub mod _hashlib {
     #[pyfunction]
     fn hmac_new(args: NewHmacHashArgs, vm: &VirtualMachine) -> PyResult<PyObjectRef> {
         match args.digestmod.as_str().to_lowercase().as_str() {
-            "md5" => Ok(hmac_md5(args.into()).into_pyobject(vm)),
-            "sha1" => Ok(hmac_sha1(args.into()).into_pyobject(vm)),
-            "sha224" => Ok(hmac_sha224(args.into()).into_pyobject(vm)),
-            "sha256" => Ok(hmac_sha256(args.into()).into_pyobject(vm)),
-            "sha384" => Ok(hmac_sha384(args.into()).into_pyobject(vm)),
-            "sha512" => Ok(hmac_sha512(args.into()).into_pyobject(vm)),
-            "sha3_224" => Ok(hmac_sha3_224(args.into()).into_pyobject(vm)),
-            "sha3_256" => Ok(hmac_sha3_256(args.into()).into_pyobject(vm)),
-            "sha3_384" => Ok(hmac_sha3_384(args.into()).into_pyobject(vm)),
-            "sha3_512" => Ok(hmac_sha3_512(args.into()).into_pyobject(vm)),
-            other => Err(vm.new_value_error(format!("Unown hashing algorithm: {other}"))),            
+            "md5" => Ok(hmac_md5(args).into_pyobject(vm)),
+            "sha1" => Ok(hmac_sha1(args).into_pyobject(vm)),
+            "sha224" => Ok(hmac_sha224(args).into_pyobject(vm)),
+            "sha256" => Ok(hmac_sha256(args).into_pyobject(vm)),
+            "sha384" => Ok(hmac_sha384(args).into_pyobject(vm)),
+            "sha512" => Ok(hmac_sha512(args).into_pyobject(vm)),
+            "sha3_224" => Ok(hmac_sha3_224(args).into_pyobject(vm)),
+            "sha3_256" => Ok(hmac_sha3_256(args).into_pyobject(vm)),
+            "sha3_384" => Ok(hmac_sha3_384(args).into_pyobject(vm)),
+            "sha3_512" => Ok(hmac_sha3_512(args).into_pyobject(vm)),
+            other => Err(vm.new_value_error(format!("Unown hashing algorithm: {other}"))),
         }
     }
 
     #[pyfunction]
     fn hmac_digest(args: NewHmacHashArgs, vm: &VirtualMachine) -> PyResult<PyBytes> {
         match args.digestmod.as_str().to_lowercase().as_str() {
-            "md5" => Ok(hmac_md5(args.into()).digest()),
-            "sha1" => Ok(hmac_sha1(args.into()).digest()),
-            "sha224" => Ok(hmac_sha224(args.into()).digest()),
-            "sha256" => Ok(hmac_sha256(args.into()).digest()),
-            "sha384" => Ok(hmac_sha384(args.into()).digest()),
-            "sha512" => Ok(hmac_sha512(args.into()).digest()),
-            "sha3_224" => Ok(hmac_sha3_224(args.into()).digest()),
-            "sha3_256" => Ok(hmac_sha3_256(args.into()).digest()),
-            "sha3_384" => Ok(hmac_sha3_384(args.into()).digest()),
-            "sha3_512" => Ok(hmac_sha3_512(args.into()).digest()),
-            other => Err(vm.new_value_error(format!("Unown hashing algorithm: {other}"))),            
+            "md5" => Ok(hmac_md5(args).digest()),
+            "sha1" => Ok(hmac_sha1(args).digest()),
+            "sha224" => Ok(hmac_sha224(args).digest()),
+            "sha256" => Ok(hmac_sha256(args).digest()),
+            "sha384" => Ok(hmac_sha384(args).digest()),
+            "sha512" => Ok(hmac_sha512(args).digest()),
+            "sha3_224" => Ok(hmac_sha3_224(args).digest()),
+            "sha3_256" => Ok(hmac_sha3_256(args).digest()),
+            "sha3_384" => Ok(hmac_sha3_384(args).digest()),
+            "sha3_512" => Ok(hmac_sha3_512(args).digest()),
+            other => Err(vm.new_value_error(format!("Unown hashing algorithm: {other}"))),
         }
     }
 
@@ -453,42 +454,66 @@ pub mod _hashlib {
 
     #[pyfunction(name = "hmac_sha224")]
     pub fn hmac_sha224(args: NewHmacHashArgs) -> PyHmac {
-        PyHmac::new("hmac-sha224", HmacWrapper::new_sha224_hmac(args.key, args.msg))
+        PyHmac::new(
+            "hmac-sha224",
+            HmacWrapper::new_sha224_hmac(args.key, args.msg),
+        )
     }
 
     #[pyfunction(name = "hmac_sha256")]
     pub fn hmac_sha256(args: NewHmacHashArgs) -> PyHmac {
-        PyHmac::new("hmac-sha256", HmacWrapper::new_sha256_hmac(args.key, args.msg))
+        PyHmac::new(
+            "hmac-sha256",
+            HmacWrapper::new_sha256_hmac(args.key, args.msg),
+        )
     }
 
     #[pyfunction(name = "hmac_sha384")]
     pub fn hmac_sha384(args: NewHmacHashArgs) -> PyHmac {
-        PyHmac::new("hmac-sha384", HmacWrapper::new_sha384_hmac(args.key, args.msg))
+        PyHmac::new(
+            "hmac-sha384",
+            HmacWrapper::new_sha384_hmac(args.key, args.msg),
+        )
     }
 
     #[pyfunction(name = "hmac_sha512")]
     pub fn hmac_sha512(args: NewHmacHashArgs) -> PyHmac {
-        PyHmac::new("hmac-sha512", HmacWrapper::new_sha512_hmac(args.key, args.msg))
+        PyHmac::new(
+            "hmac-sha512",
+            HmacWrapper::new_sha512_hmac(args.key, args.msg),
+        )
     }
 
     #[pyfunction(name = "hmac_sha3_224")]
     pub fn hmac_sha3_224(args: NewHmacHashArgs) -> PyHmac {
-        PyHmac::new("hmac-sha3_224", HmacWrapper::new_sha3_224_hmac(args.key, args.msg))
+        PyHmac::new(
+            "hmac-sha3_224",
+            HmacWrapper::new_sha3_224_hmac(args.key, args.msg),
+        )
     }
 
     #[pyfunction(name = "hmac_sha3_256")]
     pub fn hmac_sha3_256(args: NewHmacHashArgs) -> PyHmac {
-        PyHmac::new("hmac-sha3_256", HmacWrapper::new_sha3_256_hmac(args.key, args.msg))
+        PyHmac::new(
+            "hmac-sha3_256",
+            HmacWrapper::new_sha3_256_hmac(args.key, args.msg),
+        )
     }
 
     #[pyfunction(name = "hmac_sha3_384")]
     pub fn hmac_sha3_384(args: NewHmacHashArgs) -> PyHmac {
-        PyHmac::new("hmac-sha3_384", HmacWrapper::new_sha3_384_hmac(args.key, args.msg))
+        PyHmac::new(
+            "hmac-sha3_384",
+            HmacWrapper::new_sha3_384_hmac(args.key, args.msg),
+        )
     }
 
     #[pyfunction(name = "hmac_sha3_512")]
     pub fn hmac_sha3_512(args: NewHmacHashArgs) -> PyHmac {
-        PyHmac::new("hmac-sha3_512", HmacWrapper::new_sha3_512_hmac(args.key, args.msg))
+        PyHmac::new(
+            "hmac-sha3_512",
+            HmacWrapper::new_sha3_512_hmac(args.key, args.msg),
+        )
     }
 
     pub trait ThreadSafeDynDigest: DynClone + DynDigest + Sync + Send {}
@@ -537,8 +562,7 @@ pub mod _hashlib {
     }
 
     #[derive(Clone)]
-    pub enum HmacWrapper
-    {
+    pub enum HmacWrapper {
         HmacMd5(Hmac<Md5>),
         HmacSha1(Hmac<Sha1>),
         HmacSha224(Hmac<Sha224>),
@@ -551,120 +575,118 @@ pub mod _hashlib {
         HmacSha3_512(Hmac<Sha3_512>),
     }
 
-    impl HmacWrapper
-    {
-        pub fn new_md5_hmac(key: PyBuffer, data: OptionalArg<ArgBytesLike>) -> Self 
-        {
-            let mut h = HmacWrapper::HmacMd5(<Hmac<Md5> as KeyInit>::new_from_slice(&key.obj_bytes()).unwrap());
+    impl HmacWrapper {
+        pub fn new_md5_hmac(key: PyBuffer, data: OptionalArg<ArgBytesLike>) -> Self {
+            let mut h = HmacWrapper::HmacMd5(
+                <Hmac<Md5> as KeyInit>::new_from_slice(&key.obj_bytes()).unwrap(),
+            );
 
-            if let OptionalArg::Present(d) = data 
-            {
+            if let OptionalArg::Present(d) = data {
                 d.with_ref(|bytes| h.update(bytes));
             }
             h
         }
 
-        pub fn new_sha1_hmac(key: PyBuffer, data: OptionalArg<ArgBytesLike>) -> Self 
-        {
-            let mut h = HmacWrapper::HmacSha1(<Hmac<Sha1> as KeyInit>::new_from_slice(&key.obj_bytes()).unwrap());
+        pub fn new_sha1_hmac(key: PyBuffer, data: OptionalArg<ArgBytesLike>) -> Self {
+            let mut h = HmacWrapper::HmacSha1(
+                <Hmac<Sha1> as KeyInit>::new_from_slice(&key.obj_bytes()).unwrap(),
+            );
 
-            if let OptionalArg::Present(d) = data 
-            {
+            if let OptionalArg::Present(d) = data {
                 d.with_ref(|bytes| h.update(bytes));
             }
             h
         }
 
-        pub fn new_sha224_hmac(key: PyBuffer, data: OptionalArg<ArgBytesLike>) -> Self 
-        {
-            let mut h = HmacWrapper::HmacSha224(<Hmac<Sha224> as KeyInit>::new_from_slice(&key.obj_bytes()).unwrap());
+        pub fn new_sha224_hmac(key: PyBuffer, data: OptionalArg<ArgBytesLike>) -> Self {
+            let mut h = HmacWrapper::HmacSha224(
+                <Hmac<Sha224> as KeyInit>::new_from_slice(&key.obj_bytes()).unwrap(),
+            );
 
-            if let OptionalArg::Present(d) = data 
-            {
+            if let OptionalArg::Present(d) = data {
                 d.with_ref(|bytes| h.update(bytes));
             }
             h
         }
 
-        pub fn new_sha256_hmac(key: PyBuffer, data: OptionalArg<ArgBytesLike>) -> Self 
-        {
-            let mut h = HmacWrapper::HmacSha256(<Hmac<Sha256> as KeyInit>::new_from_slice(&key.obj_bytes()).unwrap());
+        pub fn new_sha256_hmac(key: PyBuffer, data: OptionalArg<ArgBytesLike>) -> Self {
+            let mut h = HmacWrapper::HmacSha256(
+                <Hmac<Sha256> as KeyInit>::new_from_slice(&key.obj_bytes()).unwrap(),
+            );
 
-            if let OptionalArg::Present(d) = data 
-            {
+            if let OptionalArg::Present(d) = data {
                 d.with_ref(|bytes| h.update(bytes));
             }
             h
         }
 
-        pub fn new_sha384_hmac(key: PyBuffer, data: OptionalArg<ArgBytesLike>) -> Self 
-        {
-            let mut h = HmacWrapper::HmacSha384(<Hmac<Sha384> as KeyInit>::new_from_slice(&key.obj_bytes()).unwrap());
+        pub fn new_sha384_hmac(key: PyBuffer, data: OptionalArg<ArgBytesLike>) -> Self {
+            let mut h = HmacWrapper::HmacSha384(
+                <Hmac<Sha384> as KeyInit>::new_from_slice(&key.obj_bytes()).unwrap(),
+            );
 
-            if let OptionalArg::Present(d) = data 
-            {
+            if let OptionalArg::Present(d) = data {
                 d.with_ref(|bytes| h.update(bytes));
             }
             h
         }
 
-        pub fn new_sha512_hmac(key: PyBuffer, data: OptionalArg<ArgBytesLike>) -> Self 
-        {
-            let mut h = HmacWrapper::HmacSha512(<Hmac<Sha512> as KeyInit>::new_from_slice(&key.obj_bytes()).unwrap());
+        pub fn new_sha512_hmac(key: PyBuffer, data: OptionalArg<ArgBytesLike>) -> Self {
+            let mut h = HmacWrapper::HmacSha512(
+                <Hmac<Sha512> as KeyInit>::new_from_slice(&key.obj_bytes()).unwrap(),
+            );
 
-            if let OptionalArg::Present(d) = data 
-            {
+            if let OptionalArg::Present(d) = data {
                 d.with_ref(|bytes| h.update(bytes));
             }
             h
         }
 
-        pub fn new_sha3_224_hmac(key: PyBuffer, data: OptionalArg<ArgBytesLike>) -> Self 
-        {
-            let mut h = HmacWrapper::HmacSha3_224(<Hmac<Sha3_224> as KeyInit>::new_from_slice(&key.obj_bytes()).unwrap());
+        pub fn new_sha3_224_hmac(key: PyBuffer, data: OptionalArg<ArgBytesLike>) -> Self {
+            let mut h = HmacWrapper::HmacSha3_224(
+                <Hmac<Sha3_224> as KeyInit>::new_from_slice(&key.obj_bytes()).unwrap(),
+            );
 
-            if let OptionalArg::Present(d) = data 
-            {
+            if let OptionalArg::Present(d) = data {
                 d.with_ref(|bytes| h.update(bytes));
             }
             h
         }
 
-        pub fn new_sha3_256_hmac(key: PyBuffer, data: OptionalArg<ArgBytesLike>) -> Self 
-        {
-            let mut h = HmacWrapper::HmacSha3_256(<Hmac<Sha3_256> as KeyInit>::new_from_slice(&key.obj_bytes()).unwrap());
+        pub fn new_sha3_256_hmac(key: PyBuffer, data: OptionalArg<ArgBytesLike>) -> Self {
+            let mut h = HmacWrapper::HmacSha3_256(
+                <Hmac<Sha3_256> as KeyInit>::new_from_slice(&key.obj_bytes()).unwrap(),
+            );
 
-            if let OptionalArg::Present(d) = data 
-            {
+            if let OptionalArg::Present(d) = data {
                 d.with_ref(|bytes| h.update(bytes));
             }
             h
         }
 
-        pub fn new_sha3_384_hmac(key: PyBuffer, data: OptionalArg<ArgBytesLike>) -> Self 
-        {
-            let mut h = HmacWrapper::HmacSha3_384(<Hmac<Sha3_384> as KeyInit>::new_from_slice(&key.obj_bytes()).unwrap());
+        pub fn new_sha3_384_hmac(key: PyBuffer, data: OptionalArg<ArgBytesLike>) -> Self {
+            let mut h = HmacWrapper::HmacSha3_384(
+                <Hmac<Sha3_384> as KeyInit>::new_from_slice(&key.obj_bytes()).unwrap(),
+            );
 
-            if let OptionalArg::Present(d) = data 
-            {
+            if let OptionalArg::Present(d) = data {
                 d.with_ref(|bytes| h.update(bytes));
             }
             h
         }
 
-        pub fn new_sha3_512_hmac(key: PyBuffer, data: OptionalArg<ArgBytesLike>) -> Self 
-        {
-            let mut h = HmacWrapper::HmacSha3_512(<Hmac<Sha3_512> as KeyInit>::new_from_slice(&key.obj_bytes()).unwrap());
+        pub fn new_sha3_512_hmac(key: PyBuffer, data: OptionalArg<ArgBytesLike>) -> Self {
+            let mut h = HmacWrapper::HmacSha3_512(
+                <Hmac<Sha3_512> as KeyInit>::new_from_slice(&key.obj_bytes()).unwrap(),
+            );
 
-            if let OptionalArg::Present(d) = data 
-            {
+            if let OptionalArg::Present(d) = data {
                 d.with_ref(|bytes| h.update(bytes));
             }
             h
         }
 
-        fn update(&mut self, data: &[u8]) 
-        {
+        fn update(&mut self, data: &[u8]) {
             match self {
                 HmacWrapper::HmacMd5(h) => digest::Update::update(h, data),
                 HmacWrapper::HmacSha1(h) => digest::Update::update(h, data),
@@ -708,7 +730,7 @@ pub mod _hashlib {
                 HmacWrapper::HmacSha3_512(_) => Hmac::<Sha3_512>::output_size(),
             }
         }
-        
+
         fn digest(&self) -> Vec<u8> {
             match self {
                 HmacWrapper::HmacMd5(h) => h.clone().finalize().into_bytes().to_vec(),


### PR DESCRIPTION
This is a draft PR just to show what I have so far, the things I want to do before pulling in the PR are: 

1. Get the unit tests of test_hmac.py working
2. make a generic function to use within the new_hash_hmac() functions for initialization, I just tried very hard to have it work like the hashlib stuff using generics, but I think because CoreProxy needs a type at compile time I can't initialize an hmac<x> dynamically like it's being done for the HashWrapper. Might still play around with that a little, and if anyone know's a way I can use generics I would appreciate the advice, but I couldn't find a way to do it without having to pass a generic to HmacWrapper (as in it would have to be HmacWrapper<T> which then I don't think I can use in PyHmac because I'm guessing it needs to be generic free for the front end). 
3. Play around with NewHmacHashArgs since I get an error when trying to initialize hmac without msg, and digestmod should be able to take a function. I have a feeling the msg thing might be something deeper because it complains about the function in hmac.py expecting 0 arguments. 

Other than that, playing with what I have vs the cpython version they output the same bytes when digesting. 