### PR TITLE
Improve naming from proc macros

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -403,6 +403,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "convert_case"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "baaaa0ecca5b51987b9423ccdc971514dd8b0bb7b4060b983d3664dad3f1f89f"
+dependencies = [
+ "unicode-segmentation",
+]
+
+[[package]]
 name = "core-foundation"
 version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2391,6 +2400,7 @@ dependencies = [
 name = "rustpython-derive-impl"
 version = "0.4.0"
 dependencies = [
+ "convert_case",
  "itertools 0.14.0",
  "maplit",
  "proc-macro2",

--- a/derive-impl/Cargo.toml
+++ b/derive-impl/Cargo.toml
@@ -13,6 +13,7 @@ rustpython-compiler-core = { workspace = true }
 # rustpython-parser-core = { workspace = true }
 rustpython-doc = { workspace = true }
 
+convert_case = "0.8"
 itertools = { workspace = true }
 syn = { workspace = true, features = ["full", "extra-traits"] }
 

--- a/derive-impl/src/pyclass.rs
+++ b/derive-impl/src/pyclass.rs
@@ -1208,7 +1208,7 @@ impl ToTokens for MemberNursery {
 struct MethodItemMeta(ItemMetaInner);
 
 impl ItemMeta for MethodItemMeta {
-    const ALLOWED_NAMES: &'static [&'static str] = &["name", "magic", "private", "case", "raw"];
+    const ALLOWED_NAMES: &'static [&'static str] = &["name", "magic", "case"];
 
     fn from_inner(inner: ItemMetaInner) -> Self {
         Self(inner)
@@ -1231,7 +1231,7 @@ impl MethodItemMeta {
 struct GetSetItemMeta(ItemMetaInner);
 
 impl ItemMeta for GetSetItemMeta {
-    const ALLOWED_NAMES: &'static [&'static str] = &["name", "magic", "private", "case", "setter", "deleter"];
+    const ALLOWED_NAMES: &'static [&'static str] = &["name", "magic", "case", "setter", "deleter"];
 
     fn from_inner(inner: ItemMetaInner) -> Self {
         Self(inner)
@@ -1364,7 +1364,7 @@ impl SlotItemMeta {
 struct MemberItemMeta(ItemMetaInner);
 
 impl ItemMeta for MemberItemMeta {
-    const ALLOWED_NAMES: &'static [&'static str] = &["magic", "private", "case", "type", "setter"];
+    const ALLOWED_NAMES: &'static [&'static str] = &["name", "magic", "case", "type", "setter"];
 
     fn from_inner(inner: ItemMetaInner) -> Self {
         Self(inner)

--- a/stdlib/src/array.rs
+++ b/stdlib/src/array.rs
@@ -1096,7 +1096,7 @@ mod array {
             Ok(zelf)
         }
 
-        #[pymethod(name = "__rmul__")]
+        #[pymethod(magic, name = "rmul")]
         #[pymethod(magic)]
         fn mul(&self, value: isize, vm: &VirtualMachine) -> PyResult<PyRef<Self>> {
             self.read()

--- a/stdlib/src/cmath.rs
+++ b/stdlib/src/cmath.rs
@@ -12,13 +12,13 @@ mod cmath {
     // Constants
     #[pyattr]
     use std::f64::consts::{E as e, PI as pi, TAU as tau};
-    #[pyattr(name = "inf")]
+    #[pyattr(case = "lower")]
     const INF: f64 = f64::INFINITY;
-    #[pyattr(name = "nan")]
+    #[pyattr(case = "lower")]
     const NAN: f64 = f64::NAN;
-    #[pyattr(name = "infj")]
+    #[pyattr(case = "lower")]
     const INFJ: Complex64 = Complex64::new(0., f64::INFINITY);
-    #[pyattr(name = "nanj")]
+    #[pyattr(case = "lower")]
     const NANJ: Complex64 = Complex64::new(0., f64::NAN);
 
     #[pyfunction]

--- a/stdlib/src/math.rs
+++ b/stdlib/src/math.rs
@@ -17,9 +17,9 @@ mod math {
     // Constants
     #[pyattr]
     use std::f64::consts::{E as e, PI as pi, TAU as tau};
-    #[pyattr(name = "inf")]
+    #[pyattr(case = "lower")]
     const INF: f64 = f64::INFINITY;
-    #[pyattr(name = "nan")]
+    #[pyattr(case = "lower")]
     const NAN: f64 = f64::NAN;
 
     // Helper macro:

--- a/vm/src/stdlib/ctypes.rs
+++ b/vm/src/stdlib/ctypes.rs
@@ -219,7 +219,7 @@ pub(crate) mod _ctypes {
         Ok(())
     }
 
-    #[pyfunction(name = "POINTER")]
+    #[pyfunction(case = "upper")]
     pub fn pointer(_cls: PyTypeRef) {}
 
     #[pyfunction(name = "pointer")]
@@ -231,7 +231,7 @@ pub(crate) mod _ctypes {
     }
 
     #[cfg(target_os = "windows")]
-    #[pyfunction(name = "_check_HRESULT")]
+    #[pyfunction(private)]
     pub fn check_hresult(_self: PyObjectRef, hr: i32, _vm: &VirtualMachine) -> PyResult<i32> {
         // TODO: fixme
         if hr < 0 {

--- a/vm/src/stdlib/ctypes.rs
+++ b/vm/src/stdlib/ctypes.rs
@@ -219,7 +219,7 @@ pub(crate) mod _ctypes {
         Ok(())
     }
 
-    #[pyfunction(case = "upper")]
+    #[pyfunction(case = "uppercase")]
     pub fn pointer(_cls: PyTypeRef) {}
 
     #[pyfunction(name = "pointer")]
@@ -231,7 +231,7 @@ pub(crate) mod _ctypes {
     }
 
     #[cfg(target_os = "windows")]
-    #[pyfunction(private)]
+    #[pyfunction(case = "private")]
     pub fn check_hresult(_self: PyObjectRef, hr: i32, _vm: &VirtualMachine) -> PyResult<i32> {
         // TODO: fixme
         if hr < 0 {


### PR DESCRIPTION
Currently we have `magic` and `name`.

Initially, I was rather confused by `magic` and didn't understand that it just added underscores.
This pr will try to streamline the naming abilities by reducing the usage of `name`, removing `magic`, and adding a single attribute to handing naming modifiers.

This also makes `SimpleItem` allow these.

I try to imitate `serde` when possible.

## Modifiers
- magic` surround with double underscores
- private: prefix with underscore
- (snake|pascal|constant, etc) case: turn into that case
To my knowledge these are basically mutually exclusive.