### PR TITLE
Remove packaging from release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -80,20 +80,6 @@ jobs:
         run: cp target/${{ matrix.platform.target }}/release/rustpython.exe target/rustpython-release-${{ runner.os }}-${{ matrix.platform.target }}.exe
         if: runner.os == 'Windows'
 
-      - name: Install cargo-packager
-        run: cargo binstall cargo-packager
-
-      - name: Generate MSI
-        if: runner.os == 'Windows'
-        run: cargo packager -f wix --release -o installer
-
-      - name: Upload MSI
-        if: runner.os == 'Windows'
-        uses: actions/upload-artifact@v4
-        with:
-          name: rustpython-installer-msi-${{ runner.os }}-${{ matrix.platform.target }}
-          path: installer/*.msi
-
       - name: Upload Binary Artifacts
         uses: actions/upload-artifact@v4
         with:


### PR DESCRIPTION
I can't seem to find a clean way to download the wix toolset and it's currently breaking CI. If I find a way to fix this in the future I'll submit another PR.