### PR TITLE
Cleaner panic output for codegen errors

### DIFF
--- a/compiler/codegen/src/compile.rs
+++ b/compiler/codegen/src/compile.rs
@@ -212,7 +212,7 @@ macro_rules! emit {
     };
 }
 
-fn print_location(zelf: &Compiler<'_>) {
+fn eprint_location(zelf: &Compiler<'_>) {
     let start = zelf.source_code.source_location(zelf.current_source_range.start());
     let end = zelf.source_code.source_location(zelf.current_source_range.end());
     eprintln!("LOCATION: {} from {}:{} to {}:{}", zelf.source_code.path.to_owned(), start.row, start.column, end.row, end.column);

--- a/compiler/codegen/src/error.rs
+++ b/compiler/codegen/src/error.rs
@@ -36,6 +36,24 @@ impl fmt::Display for CodegenError {
 
 #[derive(Debug)]
 #[non_exhaustive]
+pub enum InternalError {
+    StackOverflow,
+    StackUnderflow,
+    MissingSymbol(String),
+}
+
+impl Display for InternalError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::StackOverflow => write!(f, "stack overflow"),
+            Self::StackUnderflow => write!(f, "stack underflow"),
+            Self::MissingSymbol(s) => write!(f, "The symbol '{s}' must be present in the symbol table, even when it is undefined in python.")
+        }
+    }
+}
+
+#[derive(Debug)]
+#[non_exhaustive]
 pub enum CodegenErrorType {
     /// Invalid assignment, cannot store value in target.
     Assign(&'static str),

--- a/compiler/codegen/src/error.rs
+++ b/compiler/codegen/src/error.rs
@@ -47,7 +47,10 @@ impl Display for InternalError {
         match self {
             Self::StackOverflow => write!(f, "stack overflow"),
             Self::StackUnderflow => write!(f, "stack underflow"),
-            Self::MissingSymbol(s) => write!(f, "The symbol '{s}' must be present in the symbol table, even when it is undefined in python.")
+            Self::MissingSymbol(s) => write!(
+                f,
+                "The symbol '{s}' must be present in the symbol table, even when it is undefined in python."
+            ),
         }
     }
 }

--- a/compiler/codegen/src/ir.rs
+++ b/compiler/codegen/src/ir.rs
@@ -155,7 +155,7 @@ impl CodeInfo {
             locations.clear()
         }
 
-        CodeObject {
+        Ok(CodeObject {
             flags,
             posonlyarg_count,
             arg_count,
@@ -173,7 +173,7 @@ impl CodeInfo {
             cellvars: cellvar_cache.into_iter().collect(),
             freevars: freevar_cache.into_iter().collect(),
             cell2arg,
-        }
+        })
     }
 
     fn cell2arg(&self) -> Option<Box<[i32]>> {

--- a/compiler/codegen/src/lib.rs
+++ b/compiler/codegen/src/lib.rs
@@ -18,6 +18,8 @@ mod unparse;
 pub use compile::CompileOpts;
 use ruff_python_ast::Expr;
 
+pub(crate) use compile::InternalResult;
+
 pub trait ToPythonName {
     /// Returns a short name for the node suitable for use in error messages.
     fn python_name(&self) -> &'static str;


### PR DESCRIPTION
Replacement of #5555. That attempted to just make it an error. But the main issue is that panicking leads to no source code or even file location. This simply outputs that before the panic (if the appropriate function is called). All the main places I have seen panics have been patched.