### PR TITLE
Fix test_poll::test_poll3

### DIFF
--- a/Lib/test/test_poll.py
+++ b/Lib/test/test_poll.py
@@ -152,8 +152,6 @@ class PollTests(unittest.TestCase):
             else:
                 self.fail('Unexpected return value from select.poll: %s' % fdlist)
 
-    # TODO: RUSTPYTHON int overflow
-    @unittest.expectedFailure
     def test_poll3(self):
         # test int overflow
         pollster = select.poll()


### PR DESCRIPTION
I asked github copilot chat to find one of easy to fix `TODO: RUSTPYTHON` in the test files and try to fix one of them.

The result with minor edits is the first commit.

Next, I asked to refactor them with:
```
By looking current changes, I found the eventmask parsing is repeated in both functions. Rather than that, please add `PyEventMask` type as `pub struct PyEventMask(u16)` to retrieve the pattern.

How `Fildes` is doing with `impl TryFromObject for Fildes`  will be helpful to understand how to handle the pattern.
```

The result with minor edits is the second commit.