### PR TITLE
Remove cfg_attr features for redox

### DIFF
--- a/common/src/lib.rs
+++ b/common/src/lib.rs
@@ -1,7 +1,6 @@
 //! A crate to hold types and functions common to all rustpython components.
 
 #![cfg_attr(all(target_os = "wasi", target_env = "p2"), feature(wasip2))]
-#![cfg_attr(target_os = "redox", feature(byte_slice_trim_ascii, new_uninit))]
 
 #[macro_use]
 mod macros;

--- a/stdlib/src/lib.rs
+++ b/stdlib/src/lib.rs
@@ -3,7 +3,6 @@
 
 #![allow(clippy::module_inception)]
 #![cfg_attr(all(target_os = "wasi", target_env = "p2"), feature(wasip2))]
-#![cfg_attr(target_os = "redox", feature(raw_ref_op))]
 
 #[macro_use]
 extern crate rustpython_derive;

--- a/vm/src/lib.rs
+++ b/vm/src/lib.rs
@@ -14,7 +14,6 @@
 #![allow(clippy::upper_case_acronyms)]
 #![doc(html_logo_url = "https://raw.githubusercontent.com/RustPython/RustPython/main/logo.png")]
 #![doc(html_root_url = "https://docs.rs/rustpython-vm/")]
-#![cfg_attr(target_os = "redox", feature(raw_ref_op))]
 
 #[cfg(feature = "flame-it")]
 #[macro_use]


### PR DESCRIPTION
No longer needed; redoxer has a recent enough version of rustc.
