### PR TITLE
Fix openssl error reasons

### DIFF
--- a/Lib/test/test_httplib.py
+++ b/Lib/test/test_httplib.py
@@ -1695,8 +1695,6 @@ class HTTPSTest(TestCase):
         h = client.HTTPSConnection(HOST, TimeoutTest.PORT, timeout=30)
         self.assertEqual(h.timeout, 30)
 
-    # TODO: RUSTPYTHON
-    @unittest.expectedFailure
     def test_networked(self):
         # Default settings: requires a valid cert from a trusted CA
         import ssl
@@ -1769,8 +1767,6 @@ class HTTPSTest(TestCase):
             h.close()
             self.assertIn('nginx', server_string)
 
-    # TODO: RUSTPYTHON
-    @unittest.expectedFailure
     def test_networked_bad_cert(self):
         # We feed a "CA" cert that is unrelated to the server's cert
         import ssl

--- a/stdlib/src/ssl.rs
+++ b/stdlib/src/ssl.rs
@@ -1183,8 +1183,12 @@ mod _ssl {
                 let file = file
                     .rsplit_once(&['/', '\\'][..])
                     .map_or(file, |(_, basename)| basename);
-                // TODO: map the error codes to code names, e.g. "CERTIFICATE_VERIFY_FAILED", just requires a big hashmap/dict
-                let errstr = e.reason().unwrap_or("unknown error");
+                // TODO: finish map
+                let default_errstr = e.reason().unwrap_or("unknown error");
+                let errstr = match default_errstr {
+                    "certificate verify failed" => "CERTIFICATE_VERIFY_FAILED",
+                    _ => default_errstr,
+                };
                 let msg = if let Some(lib) = e.library() {
                     // add `library` attribute
                     let attr_name = vm.ctx.as_ref().intern_str("library");


### PR DESCRIPTION
This isn't how cpython does it, but it should work just fine.
It can be updated/expanded as needed for tests.