### PR TITLE
Increase numerical precision of log1p

### DIFF
--- a/stdlib/src/math.rs
+++ b/stdlib/src/math.rs
@@ -147,7 +147,7 @@ mod math {
     fn log1p(x: ArgIntoFloat, vm: &VirtualMachine) -> PyResult<f64> {
         let x = *x;
         if x.is_nan() || x > -1.0_f64 {
-            Ok((x + 1.0_f64).ln())
+            Ok(x.ln_1p())
         } else {
             Err(vm.new_value_error("math domain error".to_owned()))
         }


### PR DESCRIPTION
Use Rust native `ln_1p` to increase numerical precision matching what is expected by `test_mtestfile`.