### PR TITLE
gitignore, folder fix, like __pycache__ 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,11 +2,11 @@
 /*/target
 **/*.rs.bk
 **/*.bytecode
-__pycache__
+__pycache__/
 **/*.pytest_cache
 .*sw*
 .repl_history.txt
-.vscode
+.vscode/
 wasm-pack.log
 .idea/
 .envrc


### PR DESCRIPTION
~Fix the path for better usability.~ We can clean the `__pycache__` directory instead of using the downloaded one. It can sometimes cause errors