### PR TITLE
Support incomplete parsing

### DIFF
--- a/Lib/codeop.py
+++ b/Lib/codeop.py
@@ -65,12 +65,10 @@ def _maybe_compile(compiler, source, filename, symbol):
             try:
                 compiler(source + "\n", filename, symbol)
                 return None
+            except _IncompleteInputError as e:
+                return None
             except SyntaxError as e:
-                # XXX: RustPython; support multiline definitions in REPL
-                # See also: https://github.com/RustPython/RustPython/pull/5743
-                strerr = str(e)
-                if isinstance(e, _IncompleteInputError):
-                    return None
+                pass
                 # fallthrough
 
     return compiler(source, filename, symbol, incomplete_input=False)

--- a/Lib/codeop.py
+++ b/Lib/codeop.py
@@ -69,6 +69,8 @@ def _maybe_compile(compiler, source, filename, symbol):
                 # XXX: RustPython; support multiline definitions in REPL
                 # See also: https://github.com/RustPython/RustPython/pull/5743
                 strerr = str(e)
+                if isinstance(e, _IncompleteInputError):
+                    return None
                 if source.endswith(":") and "expected an indented block" in strerr:
                     return None
                 elif "incomplete input" in str(e):

--- a/Lib/codeop.py
+++ b/Lib/codeop.py
@@ -71,10 +71,6 @@ def _maybe_compile(compiler, source, filename, symbol):
                 strerr = str(e)
                 if isinstance(e, _IncompleteInputError):
                     return None
-                if source.endswith(":") and "expected an indented block" in strerr:
-                    return None
-                elif "incomplete input" in str(e):
-                    return None
                 # fallthrough
 
     return compiler(source, filename, symbol, incomplete_input=False)

--- a/Lib/test/test_baseexception.py
+++ b/Lib/test/test_baseexception.py
@@ -83,7 +83,7 @@ class ExceptionClassTests(unittest.TestCase):
         exc_set = set(e for e in exc_set if not e.startswith('_'))
         # RUSTPYTHON specific
         exc_set.discard("JitError")
-        # RUSTPYTHON specific
+        # TODO: RUSTPYTHON; this will be officially introduced in Python 3.15
         exc_set.discard("IncompleteInputError")
         self.assertEqual(len(exc_set), 0, "%s not accounted for" % exc_set)
 

--- a/Lib/test/test_baseexception.py
+++ b/Lib/test/test_baseexception.py
@@ -83,6 +83,8 @@ class ExceptionClassTests(unittest.TestCase):
         exc_set = set(e for e in exc_set if not e.startswith('_'))
         # RUSTPYTHON specific
         exc_set.discard("JitError")
+        # RUSTPYTHON specific
+        exc_set.discard("IncompleteInputError")
         self.assertEqual(len(exc_set), 0, "%s not accounted for" % exc_set)
 
     interface_tests = ("length", "args", "str", "repr")

--- a/Lib/test/test_pickle.py
+++ b/Lib/test/test_pickle.py
@@ -664,6 +664,9 @@ class CompatPickleTests(unittest.TestCase):
                            BaseExceptionGroup,
                            ExceptionGroup):
                     continue
+                # TODO: RUSTPYTHON: fix name mapping for _IncompleteInputError
+                if exc is _IncompleteInputError:
+                    continue
                 if exc is not OSError and issubclass(exc, OSError):
                     self.assertEqual(reverse_mapping('builtins', name),
                                      ('exceptions', 'OSError'))

--- a/compiler/src/lib.rs
+++ b/compiler/src/lib.rs
@@ -25,6 +25,7 @@ pub enum CompileErrorType {
 pub struct ParseError {
     #[source]
     pub error: parser::ParseErrorType,
+    pub raw_location: ruff_text_size::TextRange,
     pub location: SourceLocation,
     pub source_path: String,
 }
@@ -48,6 +49,7 @@ impl CompileError {
         let location = source_code.source_location(error.location.start());
         Self::Parse(ParseError {
             error: error.error,
+            raw_location: error.location,
             location,
             source_path: source_code.path.to_owned(),
         })

--- a/src/shell.rs
+++ b/src/shell.rs
@@ -15,7 +15,8 @@ use rustpython_vm::{
 enum ShellExecResult {
     Ok,
     PyErr(PyBaseExceptionRef),
-    Continue,
+    ContinueBlock,
+    ContinueLine,
 }
 
 fn shell_exec(
@@ -23,7 +24,7 @@ fn shell_exec(
     source: &str,
     scope: Scope,
     empty_line_given: bool,
-    continuing: bool,
+    continuing_block: bool,
 ) -> ShellExecResult {
     // compiling expects only UNIX style line endings, and will replace windows line endings
     // internally. Since we might need to analyze the source to determine if an error could be
@@ -33,7 +34,7 @@ fn shell_exec(
     let source = &source.replace("\r\n", "\n");
     match vm.compile(source, compiler::Mode::Single, "<stdin>".to_owned()) {
         Ok(code) => {
-            if empty_line_given || !continuing {
+            if empty_line_given || !continuing_block {
                 // We want to execute the full code
                 match vm.run_code_obj(code, scope) {
                     Ok(_val) => ShellExecResult::Ok,
@@ -47,14 +48,14 @@ fn shell_exec(
         Err(CompileError::Parse(ParseError {
             error: ParseErrorType::Lexical(LexicalErrorType::Eof),
             ..
-        })) => ShellExecResult::Continue,
+        })) => ShellExecResult::ContinueLine,
         Err(CompileError::Parse(ParseError {
             error:
                 ParseErrorType::Lexical(LexicalErrorType::FStringError(
                     FStringErrorType::UnterminatedTripleQuotedString,
                 )),
             ..
-        })) => ShellExecResult::Continue,
+        })) => ShellExecResult::ContinueLine,
         Err(err) => {
             // Check if the error is from an unclosed triple quoted string (which should always
             // continue)
@@ -68,7 +69,7 @@ fn shell_exec(
                     let mut iter = source.chars();
                     if let Some(quote) = iter.nth(loc) {
                         if iter.next() == Some(quote) && iter.next() == Some(quote) {
-                            return ShellExecResult::Continue;
+                            return ShellExecResult::ContinueLine;
                         }
                     }
                 }
@@ -83,10 +84,12 @@ fn shell_exec(
             let bad_error = match err {
                 CompileError::Parse(ref p) => {
                     match &p.error {
-                        ParseErrorType::Lexical(LexicalErrorType::IndentationError) => continuing, // && p.location.is_some()
+                        ParseErrorType::Lexical(LexicalErrorType::IndentationError) => {
+                            continuing_block
+                        } // && p.location.is_some()
                         ParseErrorType::OtherError(msg) => {
                             if msg.starts_with("Expected an indented block") {
-                                continuing
+                                continuing_block
                             } else {
                                 true
                             }
@@ -101,7 +104,7 @@ fn shell_exec(
             if empty_line_given || bad_error {
                 ShellExecResult::PyErr(vm.new_syntax_error(&err, Some(source)))
             } else {
-                ShellExecResult::Continue
+                ShellExecResult::ContinueBlock
             }
         }
     }
@@ -126,10 +129,19 @@ pub fn run_shell(vm: &VirtualMachine, scope: Scope) -> PyResult<()> {
         println!("No previous history.");
     }
 
-    let mut continuing = false;
+    // We might either be waiting to know if a block is complete, or waiting to know if a multiline
+    // statement is complete. In the former case, we need to ensure that we read one extra new line
+    // to know that the block is complete. In the latter, we can execute as soon as the statement is
+    // valid.
+    let mut continuing_block = false;
+    let mut continuing_line = false;
 
     loop {
-        let prompt_name = if continuing { "ps2" } else { "ps1" };
+        let prompt_name = if continuing_block || continuing_line {
+            "ps2"
+        } else {
+            "ps1"
+        };
         let prompt = vm
             .sys_module
             .get_attr(prompt_name, vm)
@@ -138,6 +150,8 @@ pub fn run_shell(vm: &VirtualMachine, scope: Scope) -> PyResult<()> {
             Ok(ref s) => s.as_str(),
             Err(_) => "",
         };
+
+        continuing_line = false;
         let result = match repl.readline(prompt) {
             ReadlineResult::Line(line) => {
                 debug!("You entered {:?}", line);
@@ -153,39 +167,44 @@ pub fn run_shell(vm: &VirtualMachine, scope: Scope) -> PyResult<()> {
                 }
                 full_input.push('\n');
 
-                match shell_exec(vm, &full_input, scope.clone(), empty_line_given, continuing) {
+                match shell_exec(
+                    vm,
+                    &full_input,
+                    scope.clone(),
+                    empty_line_given,
+                    continuing_block,
+                ) {
                     ShellExecResult::Ok => {
-                        if continuing {
+                        if continuing_block {
                             if empty_line_given {
-                                // We should be exiting continue mode
-                                continuing = false;
+                                // We should exit continue mode since the block succesfully executed
+                                continuing_block = false;
                                 full_input.clear();
-                                Ok(())
-                            } else {
-                                // We should stay in continue mode
-                                continuing = true;
-                                Ok(())
                             }
                         } else {
                             // We aren't in continue mode so proceed normally
-                            continuing = false;
                             full_input.clear();
-                            Ok(())
                         }
+                        Ok(())
                     }
-                    ShellExecResult::Continue => {
-                        continuing = true;
+                    // Continue, but don't change the mode
+                    ShellExecResult::ContinueLine => {
+                        continuing_line = true;
+                        Ok(())
+                    }
+                    ShellExecResult::ContinueBlock => {
+                        continuing_block = true;
                         Ok(())
                     }
                     ShellExecResult::PyErr(err) => {
-                        continuing = false;
+                        continuing_block = false;
                         full_input.clear();
                         Err(err)
                     }
                 }
             }
             ReadlineResult::Interrupt => {
-                continuing = false;
+                continuing_block = false;
                 full_input.clear();
                 let keyboard_interrupt =
                     vm.new_exception_empty(vm.ctx.exceptions.keyboard_interrupt.to_owned());

--- a/src/shell.rs
+++ b/src/shell.rs
@@ -175,7 +175,7 @@ pub fn run_shell(vm: &VirtualMachine, scope: Scope) -> PyResult<()> {
                     ShellExecResult::Ok => {
                         if continuing_block {
                             if empty_line_given {
-                                // We should exit continue mode since the block succesfully executed
+                                // We should exit continue mode since the block successfully executed
                                 continuing_block = false;
                                 full_input.clear();
                             }

--- a/src/shell.rs
+++ b/src/shell.rs
@@ -59,21 +59,19 @@ fn shell_exec(
         Err(err) => {
             // Check if the error is from an unclosed triple quoted string (which should always
             // continue)
-            match err {
-                CompileError::Parse(ParseError {
-                    error: ParseErrorType::Lexical(LexicalErrorType::UnclosedStringError),
-                    raw_location,
-                    ..
-                }) => {
-                    let loc = raw_location.start().to_usize();
-                    let mut iter = source.chars();
-                    if let Some(quote) = iter.nth(loc) {
-                        if iter.next() == Some(quote) && iter.next() == Some(quote) {
-                            return ShellExecResult::ContinueLine;
-                        }
+            if let CompileError::Parse(ParseError {
+                error: ParseErrorType::Lexical(LexicalErrorType::UnclosedStringError),
+                raw_location,
+                ..
+            }) = err
+            {
+                let loc = raw_location.start().to_usize();
+                let mut iter = source.chars();
+                if let Some(quote) = iter.nth(loc) {
+                    if iter.next() == Some(quote) && iter.next() == Some(quote) {
+                        return ShellExecResult::ContinueLine;
                     }
                 }
-                _ => (),
             };
 
             // bad_error == true if we are handling an error that should be thrown even if we are continuing

--- a/vm/src/compiler.rs
+++ b/vm/src/compiler.rs
@@ -49,3 +49,10 @@ impl crate::convert::ToPyException for (CompileError, Option<&str>) {
         vm.new_syntax_error(&self.0, self.1)
     }
 }
+
+#[cfg(any(feature = "parser", feature = "codegen"))]
+impl crate::convert::ToPyException for (CompileError, Option<&str>, bool) {
+    fn to_pyexception(&self, vm: &crate::VirtualMachine) -> crate::builtins::PyBaseExceptionRef {
+        vm.new_syntax_error_maybe_incomplete(&self.0, self.1, self.2)
+    }
+}

--- a/vm/src/exceptions.rs
+++ b/vm/src/exceptions.rs
@@ -1646,11 +1646,11 @@ pub(super) mod types {
 
     }
 
-    #[pyexception(name, base = "PyIncompleteInputError", ctx = "indentation_error", impl)]
+    #[pyexception(name, base = "PySyntaxError", ctx = "indentation_error", impl)]
     #[derive(Debug)]
     pub struct PyIndentationError {}
 
-    #[pyexception(name, base = "PyIncompleteInputError", ctx = "tab_error", impl)]
+    #[pyexception(name, base = "PySyntaxError", ctx = "tab_error", impl)]
     #[derive(Debug)]
     pub struct PyTabError {}
 

--- a/vm/src/exceptions.rs
+++ b/vm/src/exceptions.rs
@@ -1627,7 +1627,11 @@ pub(super) mod types {
         }
     }
 
-    #[pyexception(name, base = "PySyntaxError", ctx = "incomplete_input_error")]
+    #[pyexception(
+        name = "_IncompleteInputError",
+        base = "PySyntaxError",
+        ctx = "incomplete_input_error"
+    )]
     #[derive(Debug)]
     pub struct PyIncompleteInputError {}
 

--- a/vm/src/exceptions.rs
+++ b/vm/src/exceptions.rs
@@ -1643,7 +1643,6 @@ pub(super) mod types {
             zelf.set_attr("name", vm.ctx.new_str("SyntaxError"), vm)?;
             Ok(())
         }
-
     }
 
     #[pyexception(name, base = "PySyntaxError", ctx = "indentation_error", impl)]

--- a/vm/src/exceptions.rs
+++ b/vm/src/exceptions.rs
@@ -495,6 +495,7 @@ pub struct ExceptionZoo {
     pub not_implemented_error: &'static Py<PyType>,
     pub recursion_error: &'static Py<PyType>,
     pub syntax_error: &'static Py<PyType>,
+    pub incomplete_input_error: &'static Py<PyType>,
     pub indentation_error: &'static Py<PyType>,
     pub tab_error: &'static Py<PyType>,
     pub system_error: &'static Py<PyType>,
@@ -743,6 +744,7 @@ impl ExceptionZoo {
         let recursion_error = PyRecursionError::init_builtin_type();
 
         let syntax_error = PySyntaxError::init_builtin_type();
+        let incomplete_input_error = PyIncompleteInputError::init_builtin_type();
         let indentation_error = PyIndentationError::init_builtin_type();
         let tab_error = PyTabError::init_builtin_type();
 
@@ -817,6 +819,7 @@ impl ExceptionZoo {
             not_implemented_error,
             recursion_error,
             syntax_error,
+            incomplete_input_error,
             indentation_error,
             tab_error,
             system_error,
@@ -965,6 +968,7 @@ impl ExceptionZoo {
             "end_offset" => ctx.none(),
             "text" => ctx.none(),
         });
+        extend_exception!(PyIncompleteInputError, ctx, excs.incomplete_input_error);
         extend_exception!(PyIndentationError, ctx, excs.indentation_error);
         extend_exception!(PyTabError, ctx, excs.tab_error);
 
@@ -1623,11 +1627,30 @@ pub(super) mod types {
         }
     }
 
-    #[pyexception(name, base = "PySyntaxError", ctx = "indentation_error", impl)]
+    #[pyexception(name, base = "PySyntaxError", ctx = "incomplete_input_error")]
+    #[derive(Debug)]
+    pub struct PyIncompleteInputError {}
+
+    #[pyexception]
+    impl PyIncompleteInputError {
+        #[pyslot]
+        #[pymethod(name = "__init__")]
+        pub(crate) fn slot_init(
+            zelf: PyObjectRef,
+            _args: FuncArgs,
+            vm: &VirtualMachine,
+        ) -> PyResult<()> {
+            zelf.set_attr("name", vm.ctx.new_str("SyntaxError"), vm)?;
+            Ok(())
+        }
+
+    }
+
+    #[pyexception(name, base = "PyIncompleteInputError", ctx = "indentation_error", impl)]
     #[derive(Debug)]
     pub struct PyIndentationError {}
 
-    #[pyexception(name, base = "PyIndentationError", ctx = "tab_error", impl)]
+    #[pyexception(name, base = "PyIncompleteInputError", ctx = "tab_error", impl)]
     #[derive(Debug)]
     pub struct PyTabError {}
 

--- a/vm/src/exceptions.rs
+++ b/vm/src/exceptions.rs
@@ -1649,7 +1649,7 @@ pub(super) mod types {
     #[derive(Debug)]
     pub struct PyIndentationError {}
 
-    #[pyexception(name, base = "PySyntaxError", ctx = "tab_error", impl)]
+    #[pyexception(name, base = "PyIndentationError", ctx = "tab_error", impl)]
     #[derive(Debug)]
     pub struct PyTabError {}
 

--- a/vm/src/stdlib/ast.rs
+++ b/vm/src/stdlib/ast.rs
@@ -245,6 +245,7 @@ pub(crate) fn parse(
     let top = parser::parse(source, mode.into())
         .map_err(|parse_error| ParseError {
             error: parse_error.error,
+            raw_location: parse_error.location,
             location: text_range_to_source_range(&source_code, parse_error.location)
                 .start
                 .to_source_location(),

--- a/vm/src/stdlib/ast.rs
+++ b/vm/src/stdlib/ast.rs
@@ -296,8 +296,8 @@ pub const PY_COMPILE_FLAG_AST_ONLY: i32 = 0x0400;
 // The following flags match the values from Include/cpython/compile.h
 // Caveat emptor: These flags are undocumented on purpose and depending
 // on their effect outside the standard library is **unsupported**.
-const PY_CF_DONT_IMPLY_DEDENT: i32 = 0x200;
-const PY_CF_ALLOW_INCOMPLETE_INPUT: i32 = 0x4000;
+pub const PY_CF_DONT_IMPLY_DEDENT: i32 = 0x200;
+pub const PY_CF_ALLOW_INCOMPLETE_INPUT: i32 = 0x4000;
 
 // __future__ flags - sync with Lib/__future__.py
 // TODO: These flags aren't being used in rust code

--- a/vm/src/vm/vm_new.rs
+++ b/vm/src/vm/vm_new.rs
@@ -363,7 +363,11 @@ impl VirtualMachine {
                 ..
             }) => {
                 if s.starts_with("Expected an indented block after") {
-                    self.ctx.exceptions.indentation_error
+                    if allow_incomplete {
+                        self.ctx.exceptions.incomplete_input_error
+                    } else {
+                        self.ctx.exceptions.indentation_error
+                    }
                 } else {
                     self.ctx.exceptions.syntax_error
                 }


### PR DESCRIPTION
This PR adds support for incomplete parsing both in the native REPL and in the stdin REPL (in particular multiline input support is expanded for to allow more cases such as multiline strings). The implementation adds compatibility for cpython's `PY_CF_ALLOW_INCOMPLETE_INPUT` compile flag and adds a new exception type similar to python 3.14.