### PR TITLE
chore: allow `uv run python -I whats_left.py`

### DIFF
--- a/README.md
+++ b/README.md
@@ -221,7 +221,7 @@ To enhance CPython compatibility, try to increase unittest coverage by checking 
 Another approach is to checkout the source code: builtin functions and object
 methods are often the simplest and easiest way to contribute.
 
-You can also simply run `./whats_left.py` to assist in finding any unimplemented
+You can also simply run `uv run python -I whats_left.py` to assist in finding any unimplemented
 method.
 
 ## Compiling to WebAssembly

--- a/whats_left.py
+++ b/whats_left.py
@@ -1,4 +1,7 @@
 #!/usr/bin/env -S python3 -I
+# /// script
+# requires-python = ">=3.13"
+# ///
 
 # This script generates Lib/snippets/whats_left_data.py with these variables defined:
 # expected_methods - a dictionary mapping builtin objects to their methods


### PR DESCRIPTION
## Summary
I was looking to contribute to the project and saw this script as the starting point for contributors. However, when running it locally, I realized it required Python 3.13.

[`uv` allows scripts with Python dependencies](https://docs.astral.sh/uv/guides/scripts/#running-a-script-without-dependencies), so this should be taken care by users who already have `uv` installed.

## Test Plan

Ran `./whats_left.py` and `uv run python -I whats_left.py`. Got the same result.