### PR TITLE
chore: upgrade to `ruff==0.11.8`

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -324,11 +324,11 @@ jobs:
         with:
           python-version: ${{ env.PYTHON_VERSION }}
       - name: install ruff
-        run: python -m pip install ruff==0.0.291 # astral-sh/ruff#7778
+        run: python -m pip install ruff==0.11.8
       - name: Ensure docs generate no warnings
         run: cargo doc
       - name: run python lint
-        run: ruff extra_tests wasm examples  --exclude='./.*',./Lib,./vm/Lib,./benches/ --select=E9,F63,F7,F82 --show-source
+        run: ruff check extra_tests wasm examples  --exclude='./.*',./Lib,./vm/Lib,./benches/ --select=E9,F63,F7,F82
       - name: install prettier
         run: yarn global add prettier && echo "$(yarn global bin)" >>$GITHUB_PATH
       - name: check wasm code with prettier


### PR DESCRIPTION
## Summary

The current version is pretty dated, so let's get back to being near latest.

## Test Plan

```
RustPython on  rl/upgrade-ruff [?] via 🐍 v3.13.2 via 🦀 v1.86.0 
❯ uvx --from "ruff==0.11.8" ruff check extra_tests wasm examples  --exclude='./.*',./Lib,./vm/Lib,./benches/ --select=E9,F63,F7,F82
All checks passed!
```