### PR TITLE
feat: implement `zlib.__version__`

### DIFF
--- a/stdlib/src/zlib.rs
+++ b/stdlib/src/zlib.rs
@@ -31,6 +31,9 @@ mod zlib {
         Z_NO_COMPRESSION, Z_NO_FLUSH, Z_PARTIAL_FLUSH, Z_RLE, Z_SYNC_FLUSH, Z_TREES,
     };
 
+    #[pyattr(name = "__version__")]
+    const __VERSION__: &str = "1.0";
+
     // we're statically linking libz-rs, so the compile-time and runtime
     // versions will always be the same
     #[pyattr(name = "ZLIB_RUNTIME_VERSION")]


### PR DESCRIPTION
## Summary

After running `uv run python -I whats_left.py`, I saw `zlib.__version__` and thought it'd be easy to implement.

## Test Plan

```
RustPython on  rl/zlib-easy via 🐍 v3.13.2 via 🦀 v1.86.0 
❯ cargo run --release
   Compiling radium v1.1.0 (https://github.com/youknowone/ferrilab?branch=fix-nightly#4a301c3a)
   Compiling rustpython-common v0.4.0 (/Users/rexledesma/Documents/projects/RustPython/common)
   Compiling rustpython-vm v0.4.0 (/Users/rexledesma/Documents/projects/RustPython/vm)
   Compiling rustpython-stdlib v0.4.0 (/Users/rexledesma/Documents/projects/RustPython/stdlib)
   Compiling rustpython v0.4.0 (/Users/rexledesma/Documents/projects/RustPython)
    Finished `release` profile [optimized] target(s) in 22.71s
     Running `target/release/rustpython`
Welcome to the magnificent Rust Python 0.4.0 interpreter 😱 🖖
RustPython 3.13.0
Type "help", "copyright", "credits" or "license" for more information.
>>>>> import zlib
>>>>> zlib.__version__
'1.0'
```