### PR TITLE
Fix panic with high precision

### DIFF
--- a/compiler/literal/src/float.rs
+++ b/compiler/literal/src/float.rs
@@ -55,6 +55,7 @@ pub fn format_fixed(precision: usize, magnitude: f64, case: Case, alternate_form
     match magnitude {
         magnitude if magnitude.is_finite() => {
             let point = decimal_point_or_empty(precision, alternate_form);
+            let precision = std::cmp::min(precision, u16::MAX as usize);
             format!("{magnitude:.precision$}{point}")
         }
         magnitude if magnitude.is_nan() => format_nan(case),

--- a/vm/src/stdlib/io.rs
+++ b/vm/src/stdlib/io.rs
@@ -259,6 +259,9 @@ mod _io {
         }
 
         fn write(&mut self, data: &[u8]) -> Option<u64> {
+            if data.is_empty() {
+                return Some(0);
+            }
             let length = data.len();
             self.cursor.write_all(data).ok()?;
             Some(length as u64)


### PR DESCRIPTION
Rust 1.76 changed the internal format of precision values to be `u16` instead of `usize`.