### PR TITLE
Remove unnecessary `uv run`in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -226,7 +226,7 @@ To enhance CPython compatibility, try to increase unittest coverage by checking 
 Another approach is to checkout the source code: builtin functions and object
 methods are often the simplest and easiest way to contribute.
 
-You can also simply run `uv run python -I whats_left.py` to assist in finding any unimplemented
+You can also simply run `python -I whats_left.py` to assist in finding any unimplemented
 method.
 
 ## Compiling to WebAssembly


### PR DESCRIPTION
Partial revert of #5771.
Two reasons for this:
1. There is no tangible benefit to using uv here, the script has no dependencies.
2. This breaks the run icons on the side of jetbrains editors for those don't use uv

/cc @rexledesma let me know if I've missed something