### PR TITLE
Remove getrandom 0.2 from dependencies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -987,10 +987,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "335ff9f135e4384c8150d6f27c6daed433577f86b4750418338c01a1a2528592"
 dependencies = [
  "cfg-if",
- "js-sys",
  "libc",
  "wasi 0.11.0+wasi-snapshot-preview1",
- "wasm-bindgen",
 ]
 
 [[package]]
@@ -2602,7 +2600,6 @@ name = "rustpython_wasm"
 version = "0.4.0"
 dependencies = [
  "console_error_panic_hook",
- "getrandom 0.2.16",
  "js-sys",
  "ruff_python_parser",
  "rustpython-common",

--- a/wasm/lib/Cargo.toml
+++ b/wasm/lib/Cargo.toml
@@ -28,9 +28,6 @@ ruff_python_parser = { workspace = true }
 serde = { workspace = true }
 wasm-bindgen = { workspace = true }
 
-# remove once getrandom 0.2 is no longer otherwise in the dependency tree
-getrandom = { version = "0.2", features = ["js"] }
-
 console_error_panic_hook = "0.1"
 js-sys = "0.3"
 serde-wasm-bindgen = "0.3.1"

--- a/wasm/wasm-unknown-test/Cargo.toml
+++ b/wasm/wasm-unknown-test/Cargo.toml
@@ -7,8 +7,7 @@ edition = "2021"
 crate-type = ["cdylib"]
 
 [dependencies]
-getrandom = { version = "0.2.12", features = ["custom"] }
-getrandom_03 = { package = "getrandom", version = "0.3" }
+getrandom = "0.3"
 rustpython-vm = { path = "../../vm", default-features = false, features = ["compiler"] }
 
 [workspace]

--- a/wasm/wasm-unknown-test/src/lib.rs
+++ b/wasm/wasm-unknown-test/src/lib.rs
@@ -1,4 +1,4 @@
-use rustpython_vm::{eval, Interpreter};
+use rustpython_vm::{Interpreter, eval};
 
 pub unsafe extern "C" fn eval(s: *const u8, l: usize) -> u32 {
     let src = std::slice::from_raw_parts(s, l);
@@ -9,16 +9,10 @@ pub unsafe extern "C" fn eval(s: *const u8, l: usize) -> u32 {
     })
 }
 
-fn getrandom_always_fail(_buf: &mut [u8]) -> Result<(), getrandom::Error> {
-    Err(getrandom::Error::UNSUPPORTED)
-}
-
-getrandom::register_custom_getrandom!(getrandom_always_fail);
-
 #[unsafe(no_mangle)]
 unsafe extern "Rust" fn __getrandom_v03_custom(
     _dest: *mut u8,
     _len: usize,
-) -> Result<(), getrandom_03::Error> {
-    Err(getrandom_03::Error::UNSUPPORTED)
+) -> Result<(), getrandom::Error> {
+    Err(getrandom::Error::UNSUPPORTED)
 }


### PR DESCRIPTION
Now that no transitive non-build deps depend on getrandom 0.2, we can remove it from our deps.