### PR TITLE
Fix deque module name for test_repr

### DIFF
--- a/Lib/test/test_dataclasses.py
+++ b/Lib/test/test_dataclasses.py
@@ -2088,8 +2088,6 @@ class TestDocString(unittest.TestCase):
 
         self.assertDocStrEqual(C.__doc__, "C(x:List[int]=<factory>)")
 
-    # TODO: RUSTPYTHON
-    @unittest.expectedFailure
     def test_docstring_deque_field(self):
         @dataclass
         class C:
@@ -2097,8 +2095,6 @@ class TestDocString(unittest.TestCase):
 
         self.assertDocStrEqual(C.__doc__, "C(x:collections.deque)")
 
-    # TODO: RUSTPYTHON
-    @unittest.expectedFailure
     def test_docstring_deque_field_with_default_factory(self):
         @dataclass
         class C:

--- a/Lib/test/test_httplib.py
+++ b/Lib/test/test_httplib.py
@@ -1,3 +1,4 @@
+import sys
 import errno
 from http import client, HTTPStatus
 import io
@@ -1781,6 +1782,7 @@ class HTTPSTest(TestCase):
 
     # TODO: RUSTPYTHON
     @unittest.expectedFailure
+    @unittest.skipIf(sys.platform == 'darwin', 'Occasionally success on macOS')
     def test_local_unknown_cert(self):
         # The custom cert isn't known to the default trust bundle
         import ssl

--- a/Lib/test/test_reprlib.py
+++ b/Lib/test/test_reprlib.py
@@ -82,8 +82,6 @@ class ReprTests(unittest.TestCase):
         expected = repr(t3)[:-2] + "+++)"
         eq(r3.repr(t3), expected)
 
-    # TODO: RUSTPYTHON
-    @unittest.expectedFailure
     def test_container(self):
         from array import array
         from collections import deque

--- a/vm/src/stdlib/collections.rs
+++ b/vm/src/stdlib/collections.rs
@@ -27,7 +27,7 @@ mod _collections {
     use std::collections::VecDeque;
 
     #[pyattr]
-    #[pyclass(name = "deque", unhashable = true)]
+    #[pyclass(module = "collections", name = "deque", unhashable = true)]
     #[derive(Debug, Default, PyPayload)]
     struct PyDeque {
         deque: PyRwLock<VecDeque<PyObjectRef>>,


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Tests that previously were expected to fail now run as normal tests, improving reliability of test results.
  - A specific test is now skipped on macOS to avoid inconsistent test outcomes on that platform.

- **Refactor**
  - Improved internal association of certain classes with their respective modules, enhancing consistency within the Python environment.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->