### PR TITLE
Fix dict unpack

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -102,6 +102,7 @@ Run `./whats_left.py` to get a list of unimplemented methods, which is helpful w
 
 ### Python Code
 
+- **IMPORTANT**: In most cases, Python code should not be edited. Bug fixes should be made through Rust code modifications only
 - Follow PEP 8 style for custom Python code
 - Use ruff for linting Python code
 - Minimize modifications to CPython standard library files

--- a/Lib/test/test_call.py
+++ b/Lib/test/test_call.py
@@ -13,8 +13,6 @@ import gc
 
 class FunctionCalls(unittest.TestCase):
 
-    # TODO: RUSTPYTHON
-    @unittest.expectedFailure
     def test_kwargs_order(self):
         # bpo-34320:  **kwargs should preserve order of passed OrderedDict
         od = collections.OrderedDict([('a', 1), ('b', 2)])

--- a/extra_tests/snippets/builtin_dict.py
+++ b/extra_tests/snippets/builtin_dict.py
@@ -358,3 +358,53 @@ next(it)
 assert it.__length_hint__() == 0
 assert_raises(StopIteration, next, it)
 assert it.__length_hint__() == 0
+
+# Test dictionary unpacking with non-mapping objects
+# This should raise TypeError for non-mapping objects
+with assert_raises(TypeError) as cm:
+    {**[1, 2]}
+assert "'list' object is not a mapping" in str(cm.exception)
+
+with assert_raises(TypeError) as cm:
+    {**[[1, 2], [3, 4]]}
+assert "'list' object is not a mapping" in str(cm.exception)
+
+with assert_raises(TypeError) as cm:
+    {**"string"}
+assert "'str' object is not a mapping" in str(cm.exception)
+
+with assert_raises(TypeError) as cm:
+    {**(1, 2, 3)}
+assert "'tuple' object is not a mapping" in str(cm.exception)
+
+# Test that valid mappings still work
+assert {**{"a": 1}, **{"b": 2}} == {"a": 1, "b": 2}
+
+# Test OrderedDict unpacking preserves order
+import collections
+
+od = collections.OrderedDict([("a", 1), ("b", 2)])
+od.move_to_end("a")  # Move 'a' to end: ['b', 'a']
+expected_order = list(od.items())  # [('b', 2), ('a', 1)]
+
+
+def test_func(**kwargs):
+    return kwargs
+
+
+result = test_func(**od)
+assert list(result.items()) == expected_order, (
+    f"Expected {expected_order}, got {list(result.items())}"
+)
+
+# Test multiple OrderedDict unpacking
+od1 = collections.OrderedDict([("x", 10), ("y", 20)])
+od2 = collections.OrderedDict([("z", 30), ("w", 40)])
+od2.move_to_end("z")  # Move 'z' to end: ['w', 'z']
+
+result = test_func(**od1, **od2)
+# Should preserve order: x, y, w, z
+expected_keys = ["x", "y", "w", "z"]
+assert list(result.keys()) == expected_keys, (
+    f"Expected {expected_keys}, got {list(result.keys())}"
+)

--- a/vm/src/frame.rs
+++ b/vm/src/frame.rs
@@ -796,6 +796,19 @@ impl ExecutingFrame<'_> {
                     .top_value()
                     .downcast_ref::<PyDict>()
                     .expect("exact dict expected");
+
+                // For dictionary unpacking {**x}, x must be a mapping
+                // Check if the object has the mapping protocol (keys method)
+                if vm
+                    .get_method(other.clone(), vm.ctx.intern_str("keys"))
+                    .is_none()
+                {
+                    return Err(vm.new_type_error(format!(
+                        "'{}' object is not a mapping",
+                        other.class().name()
+                    )));
+                }
+
                 dict.merge_object(other, vm)?;
                 Ok(None)
             }


### PR DESCRIPTION
fix #5645 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
	- Improved handling of dictionary unpacking and keyword arguments to support any mapping-like object, with clearer error messages for non-mapping objects and non-string keys.
	- Updated tests to ensure correct behavior when unpacking various types into dictionaries, including proper error handling and order preservation with OrderedDict.

- **Documentation**
	- Clarified coding guidelines regarding where Python code should be edited versus Rust code.

- **Tests**
	- Added new tests for dictionary unpacking and keyword argument order preservation.
	- Updated an existing test to reflect that keyword argument order is now correctly handled and expected to pass.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->