### PR TITLE
sys.setswitchinterval

### DIFF
--- a/Lib/test/test_functools.py
+++ b/Lib/test/test_functools.py
@@ -1691,8 +1691,6 @@ class TestLRU:
         for attr in self.module.WRAPPER_ASSIGNMENTS:
             self.assertEqual(getattr(g, attr), getattr(f, attr))
 
-    # TODO: RUSTPYTHON
-    @unittest.expectedFailure
     @threading_helper.requires_working_threading()
     def test_lru_cache_threaded(self):
         n, m = 5, 11

--- a/Lib/test/test_sys.py
+++ b/Lib/test/test_sys.py
@@ -260,8 +260,6 @@ class SysModuleTest(unittest.TestCase):
     # testing sys.settrace() is done in test_sys_settrace.py
     # testing sys.setprofile() is done in test_sys_setprofile.py
 
-    # TODO: RUSTPYTHON, AttributeError: module 'sys' has no attribute 'setswitchinterval'
-    @unittest.expectedFailure
     def test_switchinterval(self):
         self.assertRaises(TypeError, sys.setswitchinterval)
         self.assertRaises(TypeError, sys.setswitchinterval, "a")

--- a/Lib/test/test_syslog.py
+++ b/Lib/test/test_syslog.py
@@ -55,8 +55,6 @@ class Test(unittest.TestCase):
         syslog.openlog()
         syslog.syslog('test message from python test_syslog')
 
-    # TODO: RUSTPYTHON; AttributeError: module 'sys' has no attribute 'getswitchinterval'
-    @unittest.expectedFailure
     @threading_helper.requires_working_threading()
     def test_syslog_threaded(self):
         start = threading.Event()

--- a/Lib/test/test_threading.py
+++ b/Lib/test/test_threading.py
@@ -412,8 +412,6 @@ class ThreadTests(BaseTestCase):
             b"Woke up, sleep function is: <built-in function sleep>")
         self.assertEqual(err, b"")
 
-    # TODO: RUSTPYTHON
-    @unittest.expectedFailure
     def test_enumerate_after_join(self):
         # Try hard to trigger #1703448: a thread is still returned in
         # threading.enumerate() after it has been join()ed.

--- a/vm/src/stdlib/sys.rs
+++ b/vm/src/stdlib/sys.rs
@@ -799,6 +799,25 @@ mod sys {
         crate::vm::thread::COROUTINE_ORIGIN_TRACKING_DEPTH.with(|cell| cell.get()) as _
     }
 
+    #[pyfunction]
+    fn getswitchinterval(vm: &VirtualMachine) -> f64 {
+        // Return the stored switch interval
+        vm.state.switch_interval.load()
+    }
+
+    // TODO: vm.state.switch_interval is currently not used anywhere in the VM
+    #[pyfunction]
+    fn setswitchinterval(interval: f64, vm: &VirtualMachine) -> PyResult<()> {
+        // Validate the interval parameter like CPython does
+        if interval <= 0.0 {
+            return Err(vm.new_value_error("switch interval must be strictly positive".to_owned()));
+        }
+
+        // Store the switch interval value
+        vm.state.switch_interval.store(interval);
+        Ok(())
+    }
+
     #[derive(FromArgs)]
     struct SetAsyncgenHooksArgs {
         #[pyarg(any, optional)]

--- a/vm/src/vm/mod.rs
+++ b/vm/src/vm/mod.rs
@@ -106,6 +106,7 @@ pub struct PyGlobalState {
     pub after_forkers_child: PyMutex<Vec<PyObjectRef>>,
     pub after_forkers_parent: PyMutex<Vec<PyObjectRef>>,
     pub int_max_str_digits: AtomicCell<usize>,
+    pub switch_interval: AtomicCell<f64>,
 }
 
 pub fn process_hash_secret_seed() -> u32 {
@@ -189,6 +190,7 @@ impl VirtualMachine {
                 after_forkers_child: PyMutex::default(),
                 after_forkers_parent: PyMutex::default(),
                 int_max_str_digits,
+                switch_interval: AtomicCell::new(0.005),
             }),
             initialized: false,
             recursion_depth: Cell::new(0),


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added functions to get and set the interpreter's thread switch interval via the system module.

- **Bug Fixes**
  - Updated tests so that checks for thread switch interval settings are now treated as normal tests, not expected failures.
  - Removed expected failure markers from several threading and functools tests, improving test reliability and coverage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->