### PR TITLE
Fix bz2 pickle

### DIFF
--- a/Lib/test/test_bz2.py
+++ b/Lib/test/test_bz2.py
@@ -676,8 +676,6 @@ class BZ2CompressorTest(BaseTest):
         finally:
             data = None
 
-    # TODO: RUSTPYTHON
-    @unittest.expectedFailure
     def testPickle(self):
         for proto in range(pickle.HIGHEST_PROTOCOL + 1):
             with self.assertRaises(TypeError):
@@ -736,8 +734,6 @@ class BZ2DecompressorTest(BaseTest):
             compressed = None
             decompressed = None
 
-    # TODO: RUSTPYTHON
-    @unittest.expectedFailure
     def testPickle(self):
         for proto in range(pickle.HIGHEST_PROTOCOL + 1):
             with self.assertRaises(TypeError):

--- a/stdlib/src/bz2.rs
+++ b/stdlib/src/bz2.rs
@@ -103,6 +103,11 @@ mod _bz2 {
             self.state.lock().needs_input()
         }
 
+        #[pymethod(name = "__reduce__")]
+        fn reduce(&self, vm: &VirtualMachine) -> PyResult<()> {
+            Err(vm.new_type_error("cannot pickle '_bz2.BZ2Decompressor' object".to_owned()))
+        }
+
         // TODO: mro()?
     }
 
@@ -184,6 +189,11 @@ mod _bz2 {
             let out = encoder.take().unwrap().finish().unwrap();
             state.flushed = true;
             Ok(vm.ctx.new_bytes(out.to_vec()))
+        }
+
+        #[pymethod(name = "__reduce__")]
+        fn reduce(&self, vm: &VirtualMachine) -> PyResult<()> {
+            Err(vm.new_type_error("cannot pickle '_bz2.BZ2Compressor' object".to_owned()))
         }
     }
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved handling of pickling for BZ2Compressor and BZ2Decompressor objects, ensuring that attempts to pickle these objects now raise a clear error message.
- **Tests**
  - Updated tests for BZ2Compressor and BZ2Decompressor to reflect the new pickling behavior and require these tests to pass.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->