### PR TITLE
Remove unnecessary string conversions in error message construction

### DIFF
--- a/stdlib/src/array.rs
+++ b/stdlib/src/array.rs
@@ -581,7 +581,7 @@ mod array {
                 .chars()
                 .exactly_one()
                 .map(|ch| Self(ch as _))
-                .map_err(|_| vm.new_type_error("array item must be unicode character".into()))
+                .map_err(|_| vm.new_type_error("array item must be unicode character"))
         }
         fn byteswap(self) -> Self {
             Self(self.0.swap_bytes())
@@ -832,9 +832,9 @@ mod array {
                 ))
             })?;
             if zelf.read().typecode() != 'u' {
-                return Err(vm.new_value_error(
-                    "fromunicode() may only be called on unicode type arrays".into(),
-                ));
+                return Err(
+                    vm.new_value_error("fromunicode() may only be called on unicode type arrays")
+                );
             }
             let mut w = zelf.try_resizable(vm)?;
             let bytes = Self::_unicode_to_wchar_bytes(wtf8, w.itemsize());
@@ -846,9 +846,9 @@ mod array {
         fn tounicode(&self, vm: &VirtualMachine) -> PyResult<Wtf8Buf> {
             let array = self.array.read();
             if array.typecode() != 'u' {
-                return Err(vm.new_value_error(
-                    "tounicode() may only be called on unicode type arrays".into(),
-                ));
+                return Err(
+                    vm.new_value_error("tounicode() may only be called on unicode type arrays")
+                );
             }
             let bytes = array.get_bytes();
             Self::_wchar_bytes_to_string(bytes, self.itemsize(), vm)
@@ -1500,7 +1500,7 @@ mod array {
                 .unwrap_or(u8::MAX)
                 .try_into()
                 .map_err(|_| {
-                    vm.new_value_error("third argument must be a valid machine format code.".into())
+                    vm.new_value_error("third argument must be a valid machine format code.")
                 })
         }
     }
@@ -1572,11 +1572,11 @@ mod array {
     fn check_type_code(spec: PyStrRef, vm: &VirtualMachine) -> PyResult<ArrayContentType> {
         let spec = spec.as_str().chars().exactly_one().map_err(|_| {
             vm.new_type_error(
-                "_array_reconstructor() argument 2 must be a unicode character, not str".into(),
+                "_array_reconstructor() argument 2 must be a unicode character, not str",
             )
         })?;
         ArrayContentType::from_char(spec)
-            .map_err(|_| vm.new_value_error("second argument must be a valid type code".into()))
+            .map_err(|_| vm.new_value_error("second argument must be a valid type code"))
     }
 
     macro_rules! chunk_to_obj {
@@ -1609,7 +1609,7 @@ mod array {
         let format = args.mformat_code;
         let bytes = args.items.as_bytes();
         if bytes.len() % format.item_size() != 0 {
-            return Err(vm.new_value_error("bytes length not a multiple of item size".into()));
+            return Err(vm.new_value_error("bytes length not a multiple of item size"));
         }
         if MachineFormatCode::from_typecode(array.typecode()) == Some(format) {
             array.frombytes(bytes);
@@ -1642,9 +1642,8 @@ mod array {
             })?,
             MachineFormatCode::Utf16 { big_endian } => {
                 let utf16: Vec<_> = chunks.map(|b| chunk_to_obj!(b, u16, big_endian)).collect();
-                let s = String::from_utf16(&utf16).map_err(|_| {
-                    vm.new_unicode_encode_error("items cannot decode as utf16".into())
-                })?;
+                let s = String::from_utf16(&utf16)
+                    .map_err(|_| vm.new_unicode_encode_error("items cannot decode as utf16"))?;
                 let bytes = PyArray::_unicode_to_wchar_bytes((*s).as_ref(), array.itemsize());
                 array.frombytes_move(bytes);
             }

--- a/stdlib/src/hashlib.rs
+++ b/stdlib/src/hashlib.rs
@@ -107,7 +107,7 @@ pub mod _hashlib {
 
         #[pyslot]
         fn slot_new(_cls: PyTypeRef, _args: FuncArgs, vm: &VirtualMachine) -> PyResult {
-            Err(vm.new_type_error("cannot create '_hashlib.HASH' instances".into()))
+            Err(vm.new_type_error("cannot create '_hashlib.HASH' instances"))
         }
 
         #[pygetset]
@@ -171,7 +171,7 @@ pub mod _hashlib {
 
         #[pyslot]
         fn slot_new(_cls: PyTypeRef, _args: FuncArgs, vm: &VirtualMachine) -> PyResult {
-            Err(vm.new_type_error("cannot create '_hashlib.HASHXOF' instances".into()))
+            Err(vm.new_type_error("cannot create '_hashlib.HASHXOF' instances"))
         }
 
         #[pygetset]
@@ -337,7 +337,7 @@ pub mod _hashlib {
 
     #[pyfunction]
     fn hmac_new(_args: NewHMACHashArgs, vm: &VirtualMachine) -> PyResult<PyObjectRef> {
-        Err(vm.new_type_error("cannot create 'hmac' instances".into())) // TODO: RUSTPYTHON support hmac
+        Err(vm.new_type_error("cannot create 'hmac' instances")) // TODO: RUSTPYTHON support hmac
     }
 
     pub trait ThreadSafeDynDigest: DynClone + DynDigest + Sync + Send {}

--- a/vm/src/buffer.rs
+++ b/vm/src/buffer.rs
@@ -549,7 +549,7 @@ impl Packable for f16 {
         // "from_f64 should be preferred in any non-`const` context" except it gives the wrong result :/
         let f_16 = f16::from_f64_const(f_64);
         if f_16.is_infinite() != f_64.is_infinite() {
-            return Err(vm.new_overflow_error("float too large to pack with e format".to_owned()));
+            return Err(vm.new_overflow_error("float too large to pack with e format"));
         }
         f_16.to_bits().pack_int::<E>(data);
         Ok(())

--- a/vm/src/buffer.rs
+++ b/vm/src/buffer.rs
@@ -646,5 +646,5 @@ pub fn struct_error_type(vm: &VirtualMachine) -> &'static PyTypeRef {
 pub fn new_struct_error(vm: &VirtualMachine, msg: impl Into<String>) -> PyBaseExceptionRef {
     // can't just STRUCT_ERROR.get().unwrap() cause this could be called before from buffer
     // machinery, independent of whether _struct was ever imported
-    vm.new_exception_msg(struct_error_type(vm).clone(), msg)
+    vm.new_exception_msg(struct_error_type(vm).clone(), msg.into())
 }

--- a/vm/src/builtins/classmethod.rs
+++ b/vm/src/builtins/classmethod.rs
@@ -169,7 +169,7 @@ impl Representable for PyClassMethod {
                 .map(|n| n.as_str()),
             class.module(vm).downcast_ref::<PyStr>().map(|m| m.as_str()),
         ) {
-            (None, _) => return Err(vm.new_type_error("Unknown qualified name".into())),
+            (None, _) => return Err(vm.new_type_error("Unknown qualified name")),
             (Some(qualname), Some(module)) if module != "builtins" => {
                 format!("<{module}.{qualname}({callable})>")
             }

--- a/vm/src/builtins/module.rs
+++ b/vm/src/builtins/module.rs
@@ -207,7 +207,7 @@ impl Representable for PyModule {
         let module_repr = importlib.get_attr("_module_repr", vm)?;
         let repr = module_repr.call((zelf.to_owned(),), vm)?;
         repr.downcast()
-            .map_err(|_| vm.new_type_error("_module_repr did not return a string".into()))
+            .map_err(|_| vm.new_type_error("_module_repr did not return a string"))
     }
 
     #[cold]

--- a/vm/src/builtins/object.rs
+++ b/vm/src/builtins/object.rs
@@ -350,7 +350,7 @@ impl PyBaseObject {
                 .map(|n| n.as_str()),
             class.module(vm).downcast_ref::<PyStr>().map(|m| m.as_str()),
         ) {
-            (None, _) => Err(vm.new_type_error("Unknown qualified name".into())),
+            (None, _) => Err(vm.new_type_error("Unknown qualified name")),
             (Some(qualname), Some(module)) if module != "builtins" => Ok(PyStr::from(format!(
                 "<{}.{} object at {:#x}>",
                 module,

--- a/vm/src/builtins/staticmethod.rs
+++ b/vm/src/builtins/staticmethod.rs
@@ -153,7 +153,7 @@ impl Representable for PyStaticMethod {
                 .map(|n| n.as_str()),
             class.module(vm).downcast_ref::<PyStr>().map(|m| m.as_str()),
         ) {
-            (None, _) => Err(vm.new_type_error("Unknown qualified name".into())),
+            (None, _) => Err(vm.new_type_error("Unknown qualified name")),
             (Some(qualname), Some(module)) if module != "builtins" => {
                 Ok(format!("<{module}.{qualname}({callable})>"))
             }

--- a/vm/src/exceptions.rs
+++ b/vm/src/exceptions.rs
@@ -427,8 +427,7 @@ impl ExceptionCtor {
         match (self, exc_inst) {
             // both are instances; which would we choose?
             (Self::Instance(_exc_a), Some(_exc_b)) => {
-                Err(vm
-                    .new_type_error("instance exception may not have a separate value".to_owned()))
+                Err(vm.new_type_error("instance exception may not have a separate value"))
             }
             // if the "type" is an instance and the value isn't, use the "type"
             (Self::Instance(exc), None) => Ok(exc),
@@ -653,7 +652,7 @@ impl PyRef<PyBaseException> {
         if !vm.is_none(&state) {
             let dict = state
                 .downcast::<crate::builtins::PyDict>()
-                .map_err(|_| vm.new_type_error("state is not a dictionary".to_owned()))?;
+                .map_err(|_| vm.new_type_error("state is not a dictionary"))?;
 
             for (key, value) in &dict {
                 let key_str = key.str(vm)?;
@@ -672,7 +671,7 @@ impl Constructor for PyBaseException {
 
     fn py_new(cls: PyTypeRef, args: FuncArgs, vm: &VirtualMachine) -> PyResult {
         if cls.is(PyBaseException::class(&vm.ctx)) && !args.kwargs.is_empty() {
-            return Err(vm.new_type_error("BaseException() takes no keyword arguments".to_owned()));
+            return Err(vm.new_type_error("BaseException() takes no keyword arguments"));
         }
         PyBaseException::new(args.args, vm)
             .into_ref_with_type(vm, cls)
@@ -1130,7 +1129,7 @@ impl serde::Serialize for SerializeException<'_, '_> {
 }
 
 pub fn cstring_error(vm: &VirtualMachine) -> PyBaseExceptionRef {
-    vm.new_value_error("embedded null character".to_owned())
+    vm.new_value_error("embedded null character")
 }
 
 impl ToPyException for std::ffi::NulError {
@@ -1334,8 +1333,7 @@ pub(super) mod types {
             // Check for any remaining invalid keyword arguments
             if let Some(invalid_key) = kwargs.keys().next() {
                 return Err(vm.new_type_error(format!(
-                    "'{}' is an invalid keyword argument for ImportError",
-                    invalid_key
+                    "'{invalid_key}' is an invalid keyword argument for ImportError"
                 )));
             }
 

--- a/vm/src/format.rs
+++ b/vm/src/format.rs
@@ -28,17 +28,17 @@ impl IntoPyException for FormatSpecError {
                 vm.new_value_error(msg)
             }
             FormatSpecError::PrecisionNotAllowed => {
-                vm.new_value_error("Precision not allowed in integer format specifier".to_owned())
+                vm.new_value_error("Precision not allowed in integer format specifier")
             }
             FormatSpecError::NotAllowed(s) => {
                 let msg = format!("{s} not allowed with integer format specifier 'c'");
                 vm.new_value_error(msg)
             }
             FormatSpecError::UnableToConvert => {
-                vm.new_value_error("Unable to convert int to float".to_owned())
+                vm.new_value_error("Unable to convert int to float")
             }
             FormatSpecError::CodeNotInRange => {
-                vm.new_overflow_error("%c arg not in range(0x110000)".to_owned())
+                vm.new_overflow_error("%c arg not in range(0x110000)")
             }
             FormatSpecError::NotImplemented(c, s) => {
                 let msg = format!("Format code '{c}' for object of type '{s}' not implemented yet");
@@ -52,9 +52,9 @@ impl ToPyException for FormatParseError {
     fn to_pyexception(&self, vm: &VirtualMachine) -> PyBaseExceptionRef {
         match self {
             FormatParseError::UnmatchedBracket => {
-                vm.new_value_error("expected '}' before end of string".to_owned())
+                vm.new_value_error("expected '}' before end of string")
             }
-            _ => vm.new_value_error("Unexpected error parsing format string".to_owned()),
+            _ => vm.new_value_error("Unexpected error parsing format string"),
         }
     }
 }
@@ -130,8 +130,7 @@ pub(crate) fn format(
         FieldType::Auto => {
             if seen_index {
                 return Err(vm.new_value_error(
-                    "cannot switch from manual field specification to automatic field numbering"
-                        .to_owned(),
+                    "cannot switch from manual field specification to automatic field numbering",
                 ));
             }
             auto_argument_index += 1;
@@ -139,13 +138,12 @@ pub(crate) fn format(
                 .args
                 .get(auto_argument_index - 1)
                 .cloned()
-                .ok_or_else(|| vm.new_index_error("tuple index out of range".to_owned()))
+                .ok_or_else(|| vm.new_index_error("tuple index out of range"))
         }
         FieldType::Index(index) => {
             if auto_argument_index != 0 {
                 return Err(vm.new_value_error(
-                    "cannot switch from automatic field numbering to manual field specification"
-                        .to_owned(),
+                    "cannot switch from automatic field numbering to manual field specification",
                 ));
             }
             seen_index = true;
@@ -153,7 +151,7 @@ pub(crate) fn format(
                 .args
                 .get(index)
                 .cloned()
-                .ok_or_else(|| vm.new_index_error("tuple index out of range".to_owned()))
+                .ok_or_else(|| vm.new_index_error("tuple index out of range"))
         }
         FieldType::Keyword(keyword) => keyword
             .as_str()
@@ -170,7 +168,7 @@ pub(crate) fn format_map(
 ) -> PyResult<Wtf8Buf> {
     format_internal(vm, format, &mut |field_type| match field_type {
         FieldType::Auto | FieldType::Index(_) => {
-            Err(vm.new_value_error("Format string contains positional fields".to_owned()))
+            Err(vm.new_value_error("Format string contains positional fields"))
         }
         FieldType::Keyword(keyword) => dict.get_item(&keyword, vm),
     })

--- a/vm/src/sequence.rs
+++ b/vm/src/sequence.rs
@@ -101,7 +101,7 @@ where
         let n = vm.check_repeat_or_overflow_error(self.as_ref().len(), n)?;
 
         if n > 1 && std::mem::size_of_val(self.as_ref()) >= MAX_MEMORY_SIZE / n {
-            return Err(vm.new_memory_error("".to_owned()));
+            return Err(vm.new_memory_error(""));
         }
 
         let mut v = Vec::with_capacity(n * self.as_ref().len());

--- a/vm/src/signal.rs
+++ b/vm/src/signal.rs
@@ -59,7 +59,7 @@ pub fn assert_in_range(signum: i32, vm: &VirtualMachine) -> PyResult<()> {
     if (1..NSIG as i32).contains(&signum) {
         Ok(())
     } else {
-        Err(vm.new_value_error("signal number out of range".to_owned()))
+        Err(vm.new_value_error("signal number out of range"))
     }
 }
 

--- a/vm/src/vm/vm_new.rs
+++ b/vm/src/vm/vm_new.rs
@@ -25,7 +25,7 @@ macro_rules! define_exception_fn {
         pub fn $fn_name(&self, msg: impl Into<String>) -> PyBaseExceptionRef
         {
             let err = self.ctx.exceptions.$attr.to_owned();
-            self.new_exception_msg(err, msg.into())
+            self.new_exception_msg(err, msg)
         }
     };
 }
@@ -117,8 +117,12 @@ impl VirtualMachine {
     /// type is passed in, it may not be fully initialized; try using
     /// [`vm.invoke_exception()`][Self::invoke_exception] or
     /// [`exceptions::ExceptionCtor`][crate::exceptions::ExceptionCtor] instead.
-    pub fn new_exception_msg(&self, exc_type: PyTypeRef, msg: String) -> PyBaseExceptionRef {
-        self.new_exception(exc_type, vec![self.ctx.new_str(msg).into()])
+    pub fn new_exception_msg(
+        &self,
+        exc_type: PyTypeRef,
+        msg: impl Into<String>,
+    ) -> PyBaseExceptionRef {
+        self.new_exception(exc_type, vec![self.ctx.new_str(msg.into()).into()])
     }
 
     /// Instantiate an exception with `msg` as the only argument and `dict` for object
@@ -129,14 +133,14 @@ impl VirtualMachine {
     pub fn new_exception_msg_dict(
         &self,
         exc_type: PyTypeRef,
-        msg: String,
+        msg: impl Into<String>,
         dict: PyDictRef,
     ) -> PyBaseExceptionRef {
         PyRef::new_ref(
             // TODO: this constructor might be invalid, because multiple
             // exception (even builtin ones) are using custom constructors,
             // see `OSError` as an example:
-            PyBaseException::new(vec![self.ctx.new_str(msg).into()], self),
+            PyBaseException::new(vec![self.ctx.new_str(msg.into()).into()], self),
             exc_type,
             Some(dict),
         )
@@ -156,7 +160,7 @@ impl VirtualMachine {
         attribute_error
     }
 
-    pub fn new_name_error(&self, msg: String, name: PyStrRef) -> PyBaseExceptionRef {
+    pub fn new_name_error(&self, msg: impl Into<String>, name: PyStrRef) -> PyBaseExceptionRef {
         let name_error_type = self.ctx.exceptions.name_error.to_owned();
         let name_error = self.new_exception_msg(name_error_type, msg);
         name_error.as_object().set_attr("name", name, self).unwrap();
@@ -201,13 +205,16 @@ impl VirtualMachine {
         ))
     }
 
-    pub fn new_errno_error(&self, errno: i32, msg: String) -> PyBaseExceptionRef {
+    pub fn new_errno_error(&self, errno: i32, msg: impl Into<String>) -> PyBaseExceptionRef {
         let vm = self;
         let exc_type =
             crate::exceptions::errno_to_exc_type(errno, vm).unwrap_or(vm.ctx.exceptions.os_error);
 
         let errno_obj = vm.new_pyobj(errno);
-        vm.new_exception(exc_type.to_owned(), vec![errno_obj, vm.new_pyobj(msg)])
+        vm.new_exception(
+            exc_type.to_owned(),
+            vec![errno_obj, vm.new_pyobj(msg.into())],
+        )
     }
 
     pub fn new_unicode_decode_error_real(
@@ -467,7 +474,7 @@ impl VirtualMachine {
         self.new_syntax_error_maybe_incomplete(error, source, false)
     }
 
-    pub fn new_import_error(&self, msg: String, name: PyStrRef) -> PyBaseExceptionRef {
+    pub fn new_import_error(&self, msg: impl Into<String>, name: PyStrRef) -> PyBaseExceptionRef {
         let import_error = self.ctx.exceptions.import_error.to_owned();
         let exc = self.new_exception_msg(import_error, msg);
         exc.as_object().set_attr("name", name, self).unwrap();

--- a/vm/src/vm/vm_new.rs
+++ b/vm/src/vm/vm_new.rs
@@ -25,7 +25,7 @@ macro_rules! define_exception_fn {
         pub fn $fn_name(&self, msg: impl Into<String>) -> PyBaseExceptionRef
         {
             let err = self.ctx.exceptions.$attr.to_owned();
-            self.new_exception_msg(err, msg)
+            self.new_exception_msg(err, msg.into())
         }
     };
 }
@@ -117,12 +117,8 @@ impl VirtualMachine {
     /// type is passed in, it may not be fully initialized; try using
     /// [`vm.invoke_exception()`][Self::invoke_exception] or
     /// [`exceptions::ExceptionCtor`][crate::exceptions::ExceptionCtor] instead.
-    pub fn new_exception_msg(
-        &self,
-        exc_type: PyTypeRef,
-        msg: impl Into<String>,
-    ) -> PyBaseExceptionRef {
-        self.new_exception(exc_type, vec![self.ctx.new_str(msg.into()).into()])
+    pub fn new_exception_msg(&self, exc_type: PyTypeRef, msg: String) -> PyBaseExceptionRef {
+        self.new_exception(exc_type, vec![self.ctx.new_str(msg).into()])
     }
 
     /// Instantiate an exception with `msg` as the only argument and `dict` for object
@@ -133,14 +129,14 @@ impl VirtualMachine {
     pub fn new_exception_msg_dict(
         &self,
         exc_type: PyTypeRef,
-        msg: impl Into<String>,
+        msg: String,
         dict: PyDictRef,
     ) -> PyBaseExceptionRef {
         PyRef::new_ref(
             // TODO: this constructor might be invalid, because multiple
             // exception (even builtin ones) are using custom constructors,
             // see `OSError` as an example:
-            PyBaseException::new(vec![self.ctx.new_str(msg.into()).into()], self),
+            PyBaseException::new(vec![self.ctx.new_str(msg).into()], self),
             exc_type,
             Some(dict),
         )
@@ -162,7 +158,7 @@ impl VirtualMachine {
 
     pub fn new_name_error(&self, msg: impl Into<String>, name: PyStrRef) -> PyBaseExceptionRef {
         let name_error_type = self.ctx.exceptions.name_error.to_owned();
-        let name_error = self.new_exception_msg(name_error_type, msg);
+        let name_error = self.new_exception_msg(name_error_type, msg.into());
         name_error.as_object().set_attr("name", name, self).unwrap();
         name_error
     }
@@ -476,7 +472,7 @@ impl VirtualMachine {
 
     pub fn new_import_error(&self, msg: impl Into<String>, name: PyStrRef) -> PyBaseExceptionRef {
         let import_error = self.ctx.exceptions.import_error.to_owned();
-        let exc = self.new_exception_msg(import_error, msg);
+        let exc = self.new_exception_msg(import_error, msg.into());
         exc.as_object().set_attr("name", name, self).unwrap();
         exc
     }

--- a/vm/src/vm/vm_new.rs
+++ b/vm/src/vm/vm_new.rs
@@ -22,9 +22,10 @@ macro_rules! define_exception_fn {
                     stringify!($python_repr),
                     " object.\nUseful for raising errors from python functions implemented in rust."
                 )]
-        pub fn $fn_name(&self, msg: String) -> PyBaseExceptionRef {
+        pub fn $fn_name(&self, msg: impl Into<String>) -> PyBaseExceptionRef
+        {
             let err = self.ctx.exceptions.$attr.to_owned();
-            self.new_exception_msg(err, msg)
+            self.new_exception_msg(err, msg.into())
         }
     };
 }

--- a/vm/src/vm/vm_ops.rs
+++ b/vm/src/vm/vm_ops.rs
@@ -128,7 +128,7 @@ impl VirtualMachine {
             })?
             .try_to_primitive::<isize>(self)?;
         if hint.is_negative() {
-            Err(self.new_value_error("__length_hint__() should return >= 0".to_owned()))
+            Err(self.new_value_error("__length_hint__() should return >= 0"))
         } else {
             Ok(Some(hint as usize))
         }
@@ -142,7 +142,7 @@ impl VirtualMachine {
         } else {
             let n = n as usize;
             if length > crate::stdlib::sys::MAXSIZE as usize / n {
-                Err(self.new_overflow_error("repeated value are too long".to_owned()))
+                Err(self.new_overflow_error("repeated value are too long"))
             } else {
                 Ok(n)
             }
@@ -407,16 +407,18 @@ impl VirtualMachine {
             return Ok(result);
         }
         if let Ok(seq_a) = PySequence::try_protocol(a, self) {
-            let n =
-                b.try_index(self)?.as_bigint().to_isize().ok_or_else(|| {
-                    self.new_overflow_error("repeated bytes are too long".to_owned())
-                })?;
+            let n = b
+                .try_index(self)?
+                .as_bigint()
+                .to_isize()
+                .ok_or_else(|| self.new_overflow_error("repeated bytes are too long"))?;
             return seq_a.repeat(n, self);
         } else if let Ok(seq_b) = PySequence::try_protocol(b, self) {
-            let n =
-                a.try_index(self)?.as_bigint().to_isize().ok_or_else(|| {
-                    self.new_overflow_error("repeated bytes are too long".to_owned())
-                })?;
+            let n = a
+                .try_index(self)?
+                .as_bigint()
+                .to_isize()
+                .ok_or_else(|| self.new_overflow_error("repeated bytes are too long"))?;
             return seq_b.repeat(n, self);
         }
         Err(self.new_unsupported_bin_op_error(a, b, "*"))
@@ -433,16 +435,18 @@ impl VirtualMachine {
             return Ok(result);
         }
         if let Ok(seq_a) = PySequence::try_protocol(a, self) {
-            let n =
-                b.try_index(self)?.as_bigint().to_isize().ok_or_else(|| {
-                    self.new_overflow_error("repeated bytes are too long".to_owned())
-                })?;
+            let n = b
+                .try_index(self)?
+                .as_bigint()
+                .to_isize()
+                .ok_or_else(|| self.new_overflow_error("repeated bytes are too long"))?;
             return seq_a.inplace_repeat(n, self);
         } else if let Ok(seq_b) = PySequence::try_protocol(b, self) {
-            let n =
-                a.try_index(self)?.as_bigint().to_isize().ok_or_else(|| {
-                    self.new_overflow_error("repeated bytes are too long".to_owned())
-                })?;
+            let n = a
+                .try_index(self)?
+                .as_bigint()
+                .to_isize()
+                .ok_or_else(|| self.new_overflow_error("repeated bytes are too long"))?;
             /* Note that the right hand operand should not be
              * mutated in this case so inplace_repeat is not
              * used. */

--- a/vm/src/warn.rs
+++ b/vm/src/warn.rs
@@ -109,7 +109,7 @@ fn get_filter(
 
     let filters: PyListRef = filters
         .try_into_value(vm)
-        .map_err(|_| vm.new_value_error("_warnings.filters must be a list".to_string()))?;
+        .map_err(|_| vm.new_value_error("_warnings.filters must be a list"))?;
 
     /* WarningsState.filters could change while we are iterating over it. */
     for i in 0..filters.borrow_vec().len() {
@@ -125,7 +125,7 @@ fn get_filter(
         let action = if let Some(action) = tmp_item.first() {
             action.str(vm).map(|action| action.into_object())
         } else {
-            Err(vm.new_type_error("action must be a string".to_string()))
+            Err(vm.new_type_error("action must be a string"))
         };
 
         let good_msg = if let Some(msg) = tmp_item.get(1) {
@@ -224,7 +224,7 @@ fn warn_explicit(
 ) -> PyResult<()> {
     let registry: PyObjectRef = registry
         .try_into_value(vm)
-        .map_err(|_| vm.new_type_error("'registry' must be a dict or None".to_owned()))?;
+        .map_err(|_| vm.new_type_error("'registry' must be a dict or None"))?;
 
     // Normalize module.
     let module = match module.or_else(|| normalize_module(&filename, vm)) {
@@ -314,13 +314,11 @@ fn call_show_warning(
         return show_warning(filename, lineno, message, category, source_line, vm);
     };
     if !show_fn.is_callable() {
-        return Err(
-            vm.new_type_error("warnings._showwarnmsg() must be set to a callable".to_owned())
-        );
+        return Err(vm.new_type_error("warnings._showwarnmsg() must be set to a callable"));
     }
     let Some(warnmsg_cls) = get_warnings_attr(vm, identifier!(&vm.ctx, WarningMessage), false)?
     else {
-        return Err(vm.new_type_error("unable to get warnings.WarningMessage".to_owned()));
+        return Err(vm.new_type_error("unable to get warnings.WarningMessage"));
     };
 
     let msg = warnmsg_cls.call(

--- a/wasm/lib/src/browser_module.rs
+++ b/wasm/lib/src/browser_module.rs
@@ -29,7 +29,7 @@ mod _browser {
                 "json" => Ok(FetchResponseFormat::Json),
                 "text" => Ok(FetchResponseFormat::Text),
                 "array_buffer" => Ok(FetchResponseFormat::ArrayBuffer),
-                _ => Err(vm.new_type_error("Unknown fetch response_format".into())),
+                _ => Err(vm.new_type_error("Unknown fetch response_format")),
             }
         }
         fn get_response(&self, response: &web_sys::Response) -> Result<Promise, JsValue> {

--- a/wasm/lib/src/convert.rs
+++ b/wasm/lib/src/convert.rs
@@ -57,7 +57,7 @@ pub fn py_err_to_js_err(vm: &VirtualMachine, py_err: &PyBaseExceptionRef) -> JsV
 
 pub fn js_py_typeerror(vm: &VirtualMachine, js_err: JsValue) -> PyBaseExceptionRef {
     let msg = js_err.unchecked_into::<js_sys::Error>().to_string();
-    vm.new_type_error(msg.into())
+    vm.new_type_error(msg)
 }
 
 pub fn js_err_to_py_err(vm: &VirtualMachine, js_err: &JsValue) -> PyBaseExceptionRef {

--- a/wasm/lib/src/convert.rs
+++ b/wasm/lib/src/convert.rs
@@ -70,7 +70,7 @@ pub fn js_err_to_py_err(vm: &VirtualMachine, js_err: &JsValue) -> PyBaseExceptio
                 _ => vm.ctx.exceptions.exception_type,
             }
             .to_owned();
-            vm.new_exception_msg(exc_type, err.message().into())
+            vm.new_exception_msg(exc_type, err.message())
         }
         None => vm.new_exception_msg(
             vm.ctx.exceptions.exception_type.to_owned(),

--- a/wasm/lib/src/convert.rs
+++ b/wasm/lib/src/convert.rs
@@ -70,7 +70,7 @@ pub fn js_err_to_py_err(vm: &VirtualMachine, js_err: &JsValue) -> PyBaseExceptio
                 _ => vm.ctx.exceptions.exception_type,
             }
             .to_owned();
-            vm.new_exception_msg(exc_type, err.message())
+            vm.new_exception_msg(exc_type, err.message().into())
         }
         None => vm.new_exception_msg(
             vm.ctx.exceptions.exception_type.to_owned(),

--- a/wasm/lib/src/js_module.rs
+++ b/wasm/lib/src/js_module.rs
@@ -136,9 +136,7 @@ mod _js {
                 } else if proto.value.is_null() {
                     Object::create(proto.value.unchecked_ref())
                 } else {
-                    return Err(
-                        vm.new_value_error("prototype must be an Object or null".to_owned())
-                    );
+                    return Err(vm.new_value_error("prototype must be an Object or null"));
                 }
             } else {
                 Object::new()
@@ -184,7 +182,7 @@ mod _js {
             let func = self
                 .value
                 .dyn_ref::<js_sys::Function>()
-                .ok_or_else(|| vm.new_type_error("JS value is not callable".to_owned()))?;
+                .ok_or_else(|| vm.new_type_error("JS value is not callable"))?;
             let js_args = args.iter().map(|x| -> &PyJsValue { x }).collect::<Array>();
             let res = match opts.this {
                 Some(this) => Reflect::apply(func, &this.value, &js_args),
@@ -216,7 +214,7 @@ mod _js {
             let ctor = self
                 .value
                 .dyn_ref::<js_sys::Function>()
-                .ok_or_else(|| vm.new_type_error("JS value is not callable".to_owned()))?;
+                .ok_or_else(|| vm.new_type_error("JS value is not callable"))?;
             let proto = opts
                 .prototype
                 .as_ref()
@@ -361,9 +359,7 @@ mod _js {
         #[pymethod]
         fn destroy(&self, vm: &VirtualMachine) -> PyResult<()> {
             let (closure, _) = self.closure.replace(None).ok_or_else(|| {
-                vm.new_value_error(
-                    "can't destroy closure has already been destroyed or detached".to_owned(),
-                )
+                vm.new_value_error("can't destroy closure has already been destroyed or detached")
             })?;
             drop(closure);
             self.destroyed.set(true);
@@ -372,9 +368,7 @@ mod _js {
         #[pymethod]
         fn detach(&self, vm: &VirtualMachine) -> PyResult<PyJsValueRef> {
             let (closure, js_val) = self.closure.replace(None).ok_or_else(|| {
-                vm.new_value_error(
-                    "can't detach closure has already been detached or destroyed".to_owned(),
-                )
+                vm.new_value_error("can't detach closure has already been detached or destroyed")
             })?;
             closure.forget();
             self.detached.set(true);
@@ -574,9 +568,7 @@ mod _js {
             match self.obj.take() {
                 Some(prom) => {
                     if val.is_some() {
-                        Err(vm.new_type_error(
-                            "can't send non-None value to an AwaitPromise".to_owned(),
-                        ))
+                        Err(vm.new_type_error("can't send non-None value to an AwaitPromise"))
                     } else {
                         Ok(PyIterReturn::Return(prom))
                     }


### PR DESCRIPTION
There are **a lot** more places where we can remove the call of `.to_owned()`, but this is just a start.

Did it here for a couple of files just to show how much code we can remove.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **Refactor**
  - Simplified error message creation across multiple modules by removing redundant string conversions.
  - Enhanced internal functions to accept more flexible string inputs for error messages.
  - Improved efficiency and clarity in error handling without changing user-facing behavior or messages.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->