### PR TITLE
Fix PyFunction doc behavior

### DIFF
--- a/Lib/test/test_funcattrs.py
+++ b/Lib/test/test_funcattrs.py
@@ -357,8 +357,6 @@ class FunctionDictsTest(FuncAttrsTest):
         else:
             self.fail("deleting function dictionary should raise TypeError")
 
-    # TODO: RUSTPYTHON
-    @unittest.expectedFailure
     def test_unassigned_dict(self):
         self.assertEqual(self.b.__dict__, {})
 
@@ -379,8 +377,6 @@ class FunctionDocstringTest(FuncAttrsTest):
         self.assertEqual(self.fi.a.__doc__, docstr)
         self.cannot_set_attr(self.fi.a, "__doc__", docstr, AttributeError)
 
-    # TODO: RUSTPYTHON
-    @unittest.expectedFailure
     def test_delete_docstring(self):
         self.b.__doc__ = "The docstring"
         del self.b.__doc__

--- a/extra_tests/snippets/syntax_function2.py
+++ b/extra_tests/snippets/syntax_function2.py
@@ -52,6 +52,8 @@ def f4():
 
 assert f4.__doc__ == "test4"
 
+assert type(lambda: None).__doc__.startswith("Create a function object."), type(f4).__doc__
+
 
 def revdocstr(f):
     d = f.__doc__

--- a/vm/src/builtins/function.rs
+++ b/vm/src/builtins/function.rs
@@ -417,10 +417,15 @@ impl PyFunction {
     }
 
     #[pymember(magic)]
-    fn doc(_vm: &VirtualMachine, zelf: PyObjectRef) -> PyResult {
-        let zelf: PyRef<PyFunction> = zelf.downcast().unwrap_or_else(|_| unreachable!());
-        let doc = zelf.doc.lock();
-        Ok(doc.clone())
+    fn doc(vm: &VirtualMachine, obj: PyObjectRef) -> PyResult {
+        // When accessed from instance, obj is the PyFunction instance
+        if let Ok(func) = obj.downcast::<PyFunction>() {
+            let doc = func.doc.lock();
+            Ok(doc.clone())
+        } else {
+            // When accessed from class, return None as there's no instance
+            Ok(vm.ctx.none())
+        }
     }
 
     #[pymember(magic, setter)]

--- a/vm/src/class.rs
+++ b/vm/src/class.rs
@@ -96,7 +96,12 @@ pub trait PyClassImpl: PyClassDef {
         }
         Self::impl_extend_class(ctx, class);
         if let Some(doc) = Self::DOC {
-            class.set_attr(identifier!(ctx, __doc__), ctx.new_str(doc).into());
+            // Only set __doc__ if it doesn't already exist (e.g., as a member descriptor)
+            // This matches CPython's behavior in type_dict_set_doc
+            let doc_attr_name = identifier!(ctx, __doc__);
+            if class.attributes.read().get(doc_attr_name).is_none() {
+                class.set_attr(doc_attr_name, ctx.new_str(doc).into());
+            }
         }
         if let Some(module_name) = Self::MODULE_NAME {
             class.set_attr(


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Improved handling and customization of class and function documentation strings (`__doc__`), including support for dynamic docstring retrieval and setting on classes and functions.
  - Enhanced compatibility with standard Python behavior when accessing or modifying `__doc__` attributes.

- **Bug Fixes**
  - Prevented overwriting of existing class `__doc__` attributes during class extension, ensuring correct documentation display.
  - Fixed behavior when accessing member descriptors and function docstrings from classes, returning appropriate values or `None` as expected.

- **Tests**
  - Added an assertion to verify the correct format of lambda function type documentation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->