### PR TITLE
more typing

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -183,6 +183,27 @@ cargo run --features jit
 cargo run --features ssl
 ```
 
+## Test Code Modification Rules
+
+**CRITICAL: Test code modification restrictions**
+- NEVER comment out or delete any test code lines except for removing `@unittest.expectedFailure` decorators and upper TODO comments
+- NEVER modify test assertions, test logic, or test data
+- When a test cannot pass due to missing language features, keep it as expectedFailure and document the reason
+- The only acceptable modifications to test files are:
+  1. Removing `@unittest.expectedFailure` decorators and the upper TODO comments when tests actually pass
+  2. Adding `@unittest.expectedFailure` decorators when tests cannot be fixed
+
+**Examples of FORBIDDEN modifications:**
+- Commenting out test lines
+- Changing test assertions
+- Modifying test data or expected results
+- Removing test logic
+
+**Correct approach when tests fail due to unsupported syntax:**
+- Keep the test as `@unittest.expectedFailure`
+- Document that it requires PEP 695 support
+- Focus on tests that can be fixed through Rust code changes only
+
 ## Documentation
 
 - Check the [architecture document](architecture/architecture.md) for a high-level overview

--- a/Lib/test/test_typing.py
+++ b/Lib/test/test_typing.py
@@ -387,8 +387,6 @@ class TypeVarTests(BaseTestCase):
         self.assertIs(T.__infer_variance__, False)
         self.assertEqual(T.__module__, __name__)
 
-    # TODO: RUSTPYTHON
-    @unittest.expectedFailure
     def test_basic_with_exec(self):
         ns = {}
         exec('from typing import TypeVar; T = TypeVar("T", bound=float)', ns, ns)
@@ -1286,8 +1284,6 @@ class TypeVarTupleTests(BaseTestCase):
         Ts = TypeVarTuple('Ts')
         self.assertEqual(Ts.__module__, __name__)
 
-    # TODO: RUSTPYTHON
-    @unittest.expectedFailure
     def test_exec(self):
         ns = {}
         exec('from typing import TypeVarTuple; Ts = TypeVarTuple("Ts")', ns)
@@ -8788,8 +8784,6 @@ class ParamSpecTests(BaseTestCase):
         self.assertEqual(P.__name__, 'P')
         self.assertEqual(P.__module__, __name__)
 
-    # TODO: RUSTPYTHON
-    @unittest.expectedFailure
     def test_basic_with_exec(self):
         ns = {}
         exec('from typing import ParamSpec; P = ParamSpec("P")', ns, ns)
@@ -9177,8 +9171,6 @@ class ParamSpecTests(BaseTestCase):
         self.assertEqual(C2[Concatenate[str, P2]].__parameters__, (P2,))
         self.assertEqual(C2[Concatenate[T, P2]].__parameters__, (T, P2))
 
-    # TODO: RUSTPYTHON
-    @unittest.expectedFailure
     def test_cannot_subclass(self):
         with self.assertRaisesRegex(TypeError, NOT_A_BASE_TYPE % 'ParamSpec'):
             class C(ParamSpec): pass

--- a/Lib/test/test_typing.py
+++ b/Lib/test/test_typing.py
@@ -373,7 +373,6 @@ class LiteralStringTests(BaseTestCase):
         self.assertEqual(get_args(alias_3), (LiteralString,))
 
 class TypeVarTests(BaseTestCase):
-    # TODO: RUSTPYTHON
     def test_basic_plain(self):
         T = TypeVar('T')
         # T equals itself.
@@ -403,7 +402,6 @@ class TypeVarTests(BaseTestCase):
         self.assertIs(T.__infer_variance__, False)
         self.assertIs(T.__module__, None)
 
-    # TODO: RUSTPYTHON
     def test_attributes(self):
         T_bound = TypeVar('T_bound', bound=int)
         self.assertEqual(T_bound.__name__, 'T_bound')
@@ -445,7 +443,6 @@ class TypeVarTests(BaseTestCase):
         with self.assertRaises(TypeError):
             issubclass(T, int)
 
-    # TODO: RUSTPYTHON
     def test_constrained_error(self):
         with self.assertRaises(TypeError):
             X = TypeVar('X', int)
@@ -478,7 +475,6 @@ class TypeVarTests(BaseTestCase):
         A = TypeVar('A', str, bytes)
         self.assertNotEqual(Union[A, str], Union[A])
 
-    # TODO: RUSTPYTHON
     def test_repr(self):
         self.assertEqual(repr(T), '~T')
         self.assertEqual(repr(KT), '~KT')
@@ -493,7 +489,6 @@ class TypeVarTests(BaseTestCase):
         self.assertNotEqual(TypeVar('T'), TypeVar('T'))
         self.assertNotEqual(TypeVar('T', int, str), TypeVar('T', int, str))
 
-    # TODO: RUSTPYTHON
     def test_cannot_subclass(self):
         with self.assertRaisesRegex(TypeError, NOT_A_BASE_TYPE % 'TypeVar'):
             class V(TypeVar): pass
@@ -573,7 +568,6 @@ class TypeVarTests(BaseTestCase):
                     vals[x] = cls(str(x))
                 del vals
 
-    # TODO: RUSTPYTHON
     def test_constructor(self):
         T = TypeVar(name="T")
         self.assertEqual(T.__name__, "T")
@@ -654,7 +648,6 @@ class TypeParameterDefaultsTests(BaseTestCase):
         self.assertIs(T.__default__, NoDefault)
         self.assertFalse(T.has_default())
 
-    # TODO: RUSTPYTHON
     def test_paramspec(self):
         P = ParamSpec('P', default=(str, int))
         self.assertEqual(P.__default__, (str, int))
@@ -682,7 +675,6 @@ class TypeParameterDefaultsTests(BaseTestCase):
         self.assertIs(P.__default__, NoDefault)
         self.assertFalse(P.has_default())
 
-    # TODO: RUSTPYTHON
     def test_typevartuple(self):
         Ts = TypeVarTuple('Ts', default=Unpack[Tuple[str, int]])
         self.assertEqual(Ts.__default__, Unpack[Tuple[str, int]])
@@ -1284,14 +1276,12 @@ class UnpackTests(BaseTestCase):
 
 class TypeVarTupleTests(BaseTestCase):
 
-    # TODO: RUSTPYTHON
     def test_name(self):
         Ts = TypeVarTuple('Ts')
         self.assertEqual(Ts.__name__, 'Ts')
         Ts2 = TypeVarTuple('Ts2')
         self.assertEqual(Ts2.__name__, 'Ts2')
 
-    # TODO: RUSTPYTHON
     def test_module(self):
         Ts = TypeVarTuple('Ts')
         self.assertEqual(Ts.__module__, __name__)
@@ -4270,7 +4260,6 @@ class GenericTests(BaseTestCase):
             self.assertEqual(t, copy(t))
             self.assertEqual(t, deepcopy(t))
 
-    # TODO: RUSTPYTHON
     def test_immutability_by_copy_and_pickle(self):
         # Special forms like Union, Any, etc., generic aliases to containers like List,
         # Mapping, etc., and type variabcles are considered immutable by copy and pickle.
@@ -8792,7 +8781,6 @@ class TypeAliasTests(BaseTestCase):
 
 class ParamSpecTests(BaseTestCase):
 
-    # TODO: RUSTPYTHON
     def test_basic_plain(self):
         P = ParamSpec('P')
         self.assertEqual(P, P)
@@ -9000,7 +8988,6 @@ class ParamSpecTests(BaseTestCase):
         B = A[[int, str], bytes, float]
         self.assertEqual(B.__args__, ((int, str,), Tuple[bytes, float]))
 
-    # TODO: RUSTPYTHON
     def test_var_substitution(self):
         P = ParamSpec("P")
         subst = P.__typing_subst__
@@ -9011,7 +8998,6 @@ class ParamSpecTests(BaseTestCase):
         self.assertIs(subst(P), P)
         self.assertEqual(subst(Concatenate[int, P]), Concatenate[int, P])
 
-    # TODO: RUSTPYTHON
     def test_bad_var_substitution(self):
         T = TypeVar('T')
         P = ParamSpec('P')
@@ -9229,7 +9215,6 @@ class ConcatenateTests(BaseTestCase):
             with self.subTest(required_item=required_item):
                 self.assertIn(required_item, dir_items)
 
-    # TODO: RUSTPYTHON
     def test_valid_uses(self):
         P = ParamSpec('P')
         T = TypeVar('T')

--- a/vm/src/frame.rs
+++ b/vm/src/frame.rs
@@ -17,7 +17,7 @@ use crate::{
     protocol::{PyIter, PyIterReturn},
     scope::Scope,
     source::SourceLocation,
-    stdlib::{builtins, typing::_typing},
+    stdlib::{builtins, typing},
     vm::{Context, PyMethod},
 };
 use indexmap::IndexMap;
@@ -1234,7 +1234,7 @@ impl ExecutingFrame<'_> {
             bytecode::Instruction::TypeVar => {
                 let type_name = self.pop_value();
                 let type_var: PyObjectRef =
-                    _typing::make_typevar(vm, type_name.clone(), vm.ctx.none(), vm.ctx.none())
+                    typing::make_typevar(vm, type_name.clone(), vm.ctx.none(), vm.ctx.none())
                         .into_ref(&vm.ctx)
                         .into();
                 self.push_value(type_var);
@@ -1244,7 +1244,7 @@ impl ExecutingFrame<'_> {
                 let type_name = self.pop_value();
                 let bound = self.pop_value();
                 let type_var: PyObjectRef =
-                    _typing::make_typevar(vm, type_name.clone(), bound, vm.ctx.none())
+                    typing::make_typevar(vm, type_name.clone(), bound, vm.ctx.none())
                         .into_ref(&vm.ctx)
                         .into();
                 self.push_value(type_var);
@@ -1254,7 +1254,7 @@ impl ExecutingFrame<'_> {
                 let type_name = self.pop_value();
                 let constraint = self.pop_value();
                 let type_var: PyObjectRef =
-                    _typing::make_typevar(vm, type_name.clone(), vm.ctx.none(), constraint)
+                    typing::make_typevar(vm, type_name.clone(), vm.ctx.none(), constraint)
                         .into_ref(&vm.ctx)
                         .into();
                 self.push_value(type_var);
@@ -1267,13 +1267,13 @@ impl ExecutingFrame<'_> {
                     .downcast()
                     .map_err(|_| vm.new_type_error("Type params must be a tuple."))?;
                 let value = self.pop_value();
-                let type_alias = _typing::TypeAliasType::new(name, type_params, value);
+                let type_alias = typing::TypeAliasType::new(name, type_params, value);
                 self.push_value(type_alias.into_ref(&vm.ctx).into());
                 Ok(None)
             }
             bytecode::Instruction::ParamSpec => {
                 let param_spec_name = self.pop_value();
-                let param_spec: PyObjectRef = _typing::make_paramspec(param_spec_name.clone())
+                let param_spec: PyObjectRef = typing::make_paramspec(param_spec_name.clone())
                     .into_ref(&vm.ctx)
                     .into();
                 self.push_value(param_spec);
@@ -1282,7 +1282,7 @@ impl ExecutingFrame<'_> {
             bytecode::Instruction::TypeVarTuple => {
                 let type_var_tuple_name = self.pop_value();
                 let type_var_tuple: PyObjectRef =
-                    _typing::make_typevartuple(type_var_tuple_name.clone(), vm)
+                    typing::make_typevartuple(type_var_tuple_name.clone(), vm)
                         .into_ref(&vm.ctx)
                         .into();
                 self.push_value(type_var_tuple);

--- a/vm/src/stdlib/typing.rs
+++ b/vm/src/stdlib/typing.rs
@@ -337,6 +337,11 @@ pub(crate) mod decl {
 
     #[pyclass(flags(HAS_DICT), with(AsNumber, Constructor))]
     impl ParamSpec {
+        #[pymethod(magic)]
+        fn mro_entries(&self, _bases: PyObjectRef, vm: &VirtualMachine) -> PyResult {
+            Err(vm.new_type_error("Cannot subclass an instance of ParamSpec".to_owned()))
+        }
+
         #[pygetset(magic)]
         fn name(&self) -> PyObjectRef {
             self.name.clone()
@@ -720,6 +725,11 @@ pub(crate) mod decl {
     }
     #[pyclass(flags(BASETYPE), with(Constructor, Representable))]
     impl ParamSpecArgs {
+        #[pymethod(magic)]
+        fn mro_entries(&self, _bases: PyObjectRef, vm: &VirtualMachine) -> PyResult {
+            Err(vm.new_type_error("Cannot subclass an instance of ParamSpecArgs".to_owned()))
+        }
+
         #[pygetset(magic)]
         fn origin(&self) -> PyObjectRef {
             self.__origin__.clone()
@@ -765,6 +775,11 @@ pub(crate) mod decl {
     }
     #[pyclass(flags(BASETYPE), with(Constructor, Representable))]
     impl ParamSpecKwargs {
+        #[pymethod(magic)]
+        fn mro_entries(&self, _bases: PyObjectRef, vm: &VirtualMachine) -> PyResult {
+            Err(vm.new_type_error("Cannot subclass an instance of ParamSpecKwargs".to_owned()))
+        }
+
         #[pygetset(magic)]
         fn origin(&self) -> PyObjectRef {
             self.__origin__.clone()

--- a/vm/src/stdlib/typing.rs
+++ b/vm/src/stdlib/typing.rs
@@ -643,6 +643,27 @@ pub(crate) mod decl {
         fn reduce(&self) -> PyObjectRef {
             self.name.clone()
         }
+
+        #[pymethod(magic)]
+        fn mro_entries(&self, _bases: PyObjectRef, vm: &VirtualMachine) -> PyResult {
+            Err(vm.new_type_error("Cannot subclass an instance of TypeVarTuple".to_owned()))
+        }
+
+        #[pymethod(magic)]
+        fn typing_subst(&self, _arg: PyObjectRef, vm: &VirtualMachine) -> PyResult {
+            Err(vm.new_type_error("Substitution of bare TypeVarTuple is not supported".to_owned()))
+        }
+
+        #[pymethod(magic)]
+        fn typing_prepare_subst(
+            zelf: crate::PyRef<Self>,
+            alias: PyObjectRef,
+            args: PyObjectRef,
+            vm: &VirtualMachine,
+        ) -> PyResult {
+            let self_obj: PyObjectRef = zelf.into();
+            _call_typing_func_object(vm, "_typevartuple_prepare_subst", (self_obj, alias, args))
+        }
     }
 
     impl Constructor for TypeVarTuple {

--- a/vm/src/stdlib/typing.rs
+++ b/vm/src/stdlib/typing.rs
@@ -717,7 +717,7 @@ pub(crate) mod decl {
     }
 
     #[pyattr]
-    #[pyclass(name = "ParamSpecArgs")]
+    #[pyclass(name = "ParamSpecArgs", module = "typing")]
     #[derive(Debug, PyPayload)]
     #[allow(dead_code)]
     pub(crate) struct ParamSpecArgs {
@@ -767,7 +767,7 @@ pub(crate) mod decl {
     }
 
     #[pyattr]
-    #[pyclass(name = "ParamSpecKwargs")]
+    #[pyclass(name = "ParamSpecKwargs", module = "typing")]
     #[derive(Debug, PyPayload)]
     #[allow(dead_code)]
     pub(crate) struct ParamSpecKwargs {

--- a/vm/src/stdlib/typing.rs
+++ b/vm/src/stdlib/typing.rs
@@ -1,17 +1,17 @@
 use crate::{PyRef, VirtualMachine, stdlib::PyModule};
 
-pub(crate) use _typing::NoDefault;
+pub(crate) use decl::*;
 
 pub(crate) fn make_module(vm: &VirtualMachine) -> PyRef<PyModule> {
-    let module = _typing::make_module(vm);
+    let module = decl::make_module(vm);
     extend_module!(vm, &module, {
         "NoDefault" => vm.ctx.typing_no_default.clone(),
     });
     module
 }
 
-#[pymodule]
-pub(crate) mod _typing {
+#[pymodule(name = "_typing")]
+pub(crate) mod decl {
     use crate::{
         AsObject, PyObjectRef, PyPayload, PyResult, VirtualMachine,
         builtins::{PyGenericAlias, PyTupleRef, PyTypeRef, pystr::AsPyStr},

--- a/vm/src/stdlib/typing.rs
+++ b/vm/src/stdlib/typing.rs
@@ -346,7 +346,7 @@ pub(crate) mod decl {
     impl ParamSpec {
         #[pymethod(magic)]
         fn mro_entries(&self, _bases: PyObjectRef, vm: &VirtualMachine) -> PyResult {
-            Err(vm.new_type_error("Cannot subclass an instance of ParamSpec".to_owned()))
+            Err(vm.new_type_error("Cannot subclass an instance of ParamSpec"))
         }
 
         #[pygetset(magic)]
@@ -483,16 +483,14 @@ pub(crate) mod decl {
                 if let Some(name) = kwargs.swap_remove("name") {
                     name
                 } else {
-                    return Err(vm.new_type_error(
-                        "ParamSpec() missing required argument: 'name' (pos 1)".to_owned(),
-                    ));
+                    return Err(
+                        vm.new_type_error("ParamSpec() missing required argument: 'name' (pos 1)")
+                    );
                 }
             } else if args.args.len() == 1 {
                 args.args[0].clone()
             } else {
-                return Err(
-                    vm.new_type_error("ParamSpec() takes at most 1 positional argument".to_owned())
-                );
+                return Err(vm.new_type_error("ParamSpec() takes at most 1 positional argument"));
             };
 
             let bound = kwargs.swap_remove("bound");
@@ -524,15 +522,11 @@ pub(crate) mod decl {
 
             // Check for invalid combinations
             if covariant && contravariant {
-                return Err(
-                    vm.new_value_error("Bivariant type variables are not supported.".to_owned())
-                );
+                return Err(vm.new_value_error("Bivariant type variables are not supported."));
             }
 
             if infer_variance && (covariant || contravariant) {
-                return Err(vm.new_value_error(
-                    "Variance cannot be specified with infer_variance".to_owned(),
-                ));
+                return Err(vm.new_value_error("Variance cannot be specified with infer_variance"));
             }
 
             // Handle default value
@@ -653,12 +647,12 @@ pub(crate) mod decl {
 
         #[pymethod(magic)]
         fn mro_entries(&self, _bases: PyObjectRef, vm: &VirtualMachine) -> PyResult {
-            Err(vm.new_type_error("Cannot subclass an instance of TypeVarTuple".to_owned()))
+            Err(vm.new_type_error("Cannot subclass an instance of TypeVarTuple"))
         }
 
         #[pymethod(magic)]
         fn typing_subst(&self, _arg: PyObjectRef, vm: &VirtualMachine) -> PyResult {
-            Err(vm.new_type_error("Substitution of bare TypeVarTuple is not supported".to_owned()))
+            Err(vm.new_type_error("Substitution of bare TypeVarTuple is not supported"))
         }
 
         #[pymethod(magic)]
@@ -685,15 +679,13 @@ pub(crate) mod decl {
                     name
                 } else {
                     return Err(vm.new_type_error(
-                        "TypeVarTuple() missing required argument: 'name' (pos 1)".to_owned(),
+                        "TypeVarTuple() missing required argument: 'name' (pos 1)",
                     ));
                 }
             } else if args.args.len() == 1 {
                 args.args[0].clone()
             } else {
-                return Err(vm.new_type_error(
-                    "TypeVarTuple() takes at most 1 positional argument".to_owned(),
-                ));
+                return Err(vm.new_type_error("TypeVarTuple() takes at most 1 positional argument"));
             };
 
             let default = kwargs.swap_remove("default");
@@ -755,7 +747,7 @@ pub(crate) mod decl {
     impl ParamSpecArgs {
         #[pymethod(magic)]
         fn mro_entries(&self, _bases: PyObjectRef, vm: &VirtualMachine) -> PyResult {
-            Err(vm.new_type_error("Cannot subclass an instance of ParamSpecArgs".to_owned()))
+            Err(vm.new_type_error("Cannot subclass an instance of ParamSpecArgs"))
         }
 
         #[pygetset(magic)]
@@ -834,7 +826,7 @@ pub(crate) mod decl {
     impl ParamSpecKwargs {
         #[pymethod(magic)]
         fn mro_entries(&self, _bases: PyObjectRef, vm: &VirtualMachine) -> PyResult {
-            Err(vm.new_type_error("Cannot subclass an instance of ParamSpecKwargs".to_owned()))
+            Err(vm.new_type_error("Cannot subclass an instance of ParamSpecKwargs"))
         }
 
         #[pygetset(magic)]

--- a/vm/src/stdlib/typing.rs
+++ b/vm/src/stdlib/typing.rs
@@ -44,6 +44,13 @@ pub(crate) mod decl {
         args.args[0].clone()
     }
 
+    #[pyfunction(name = "override")]
+    pub(crate) fn r#override(func: PyObjectRef, vm: &VirtualMachine) -> PyResult {
+        // Set __override__ attribute to True
+        func.set_attr("__override__", vm.ctx.true_value.clone(), vm)?;
+        Ok(func)
+    }
+
     #[pyattr]
     #[pyclass(name = "TypeVar", module = "typing")]
     #[derive(Debug, PyPayload)]


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an `override` decorator for marking functions as overrides.
  * Enhanced typing classes (`ParamSpec`, `TypeVarTuple`, `ParamSpecArgs`, `ParamSpecKwargs`) with new behaviors to prevent subclassing and unsupported operations.
  * Improved comparison logic for `ParamSpecArgs` and `ParamSpecKwargs`.
  * Refined module attribution for objects created in dynamic execution contexts.

* **Documentation**
  * Updated documentation to clarify strict rules for modifying test code, including allowed and forbidden changes.

* **Chores**
  * Removed outdated `@unittest.expectedFailure` decorators and related TODO comments from typing-related tests.
  * Refactored internal module naming and import paths for typing constructs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->