### PR TITLE
Fix type_params lifetime in symboltable

### DIFF
--- a/Lib/test/test_typing.py
+++ b/Lib/test/test_typing.py
@@ -2924,13 +2924,10 @@ class ProtocolTests(BaseTestCase):
             @runtime_checkable
             class Foo[T]: ...
 
-    # TODO: RUSTPYTHON
-    @unittest.expectedFailure
     def test_runtime_checkable_generic(self):
-        # @runtime_checkable
-        # class Foo[T](Protocol):
-        #     def meth(self) -> T: ...
-        # pass
+        @runtime_checkable
+        class Foo[T](Protocol):
+            def meth(self) -> T: ...
 
         class Impl:
             def meth(self) -> int: ...
@@ -2945,9 +2942,9 @@ class ProtocolTests(BaseTestCase):
     # TODO: RUSTPYTHON
     @unittest.expectedFailure
     def test_pep695_generics_can_be_runtime_checkable(self):
-        # @runtime_checkable
-        # class HasX(Protocol):
-        #     x: int
+        @runtime_checkable
+        class HasX(Protocol):
+            x: int
 
         class Bar[T]:
             x: T
@@ -2987,22 +2984,20 @@ class ProtocolTests(BaseTestCase):
 
         self.assertIsInstance(f, HasCallProtocol)
 
-    # TODO: RUSTPYTHON
-    @unittest.expectedFailure
     def test_no_inheritance_from_nominal(self):
         class C: pass
 
-        # class BP(Protocol): pass
+        class BP(Protocol): pass
 
-        # with self.assertRaises(TypeError):
-        #     class P(C, Protocol):
-        #         pass
-        # with self.assertRaises(TypeError):
-        #     class Q(Protocol, C):
-        #         pass
-        # with self.assertRaises(TypeError):
-        #     class R(BP, C, Protocol):
-        #         pass
+        with self.assertRaises(TypeError):
+            class P(C, Protocol):
+                pass
+        with self.assertRaises(TypeError):
+            class Q(Protocol, C):
+                pass
+        with self.assertRaises(TypeError):
+            class R(BP, C, Protocol):
+                pass
 
         class D(BP, C): pass
 
@@ -3014,7 +3009,7 @@ class ProtocolTests(BaseTestCase):
     # TODO: RUSTPYTHON
     @unittest.expectedFailure
     def test_no_instantiation(self):
-        # class P(Protocol): pass
+        class P(Protocol): pass
 
         with self.assertRaises(TypeError):
             P()
@@ -3042,16 +3037,14 @@ class ProtocolTests(BaseTestCase):
         with self.assertRaises(TypeError):
             CG[int](42)
 
-    # TODO: RUSTPYTHON
-    @unittest.expectedFailure
     def test_protocol_defining_init_does_not_get_overridden(self):
         # check that P.__init__ doesn't get clobbered
         # see https://bugs.python.org/issue44807
 
-        # class P(Protocol):
-        #     x: int
-        #     def __init__(self, x: int) -> None:
-        #         self.x = x
+        class P(Protocol):
+            x: int
+            def __init__(self, x: int) -> None:
+                self.x = x
         class C: pass
 
         c = C()
@@ -3478,9 +3471,9 @@ class ProtocolTests(BaseTestCase):
     # TODO: RUSTPYTHON
     @unittest.expectedFailure
     def test_no_weird_caching_with_issubclass_after_isinstance_pep695(self):
-        # @runtime_checkable
-        # class Spam[T](Protocol):
-            # x: T
+        @runtime_checkable
+        class Spam[T](Protocol):
+            x: T
 
         class Eggs[T]:
             def __init__(self, x: T) -> None:

--- a/compiler/codegen/src/compile.rs
+++ b/compiler/codegen/src/compile.rs
@@ -230,6 +230,7 @@ fn eprint_location(zelf: &Compiler<'_>) {
 }
 
 /// Better traceback for internal error
+#[track_caller]
 fn unwrap_internal<T>(zelf: &Compiler<'_>, r: InternalResult<T>) -> T {
     if let Err(ref r_err) = r {
         eprintln!("=== CODEGEN PANIC INFO ===");
@@ -1705,11 +1706,6 @@ impl Compiler<'_> {
             func_flags |= bytecode::MakeFunctionFlags::CLOSURE;
         }
 
-        // Pop the special type params symbol table
-        if type_params.is_some() {
-            self.pop_symbol_table();
-        }
-
         self.emit_load_const(ConstantData::Code {
             code: Box::new(code),
         });
@@ -1727,6 +1723,11 @@ impl Compiler<'_> {
             CallType::Positional { nargs: 2 }
         };
         self.compile_normal_call(call);
+
+        // Pop the special type params symbol table
+        if type_params.is_some() {
+            self.pop_symbol_table();
+        }
 
         self.apply_decorators(decorator_list);
 

--- a/vm/src/builtins/memory.rs
+++ b/vm/src/builtins/memory.rs
@@ -636,7 +636,7 @@ impl PyMemoryView {
 
     #[pygetset]
     fn f_contiguous(&self, vm: &VirtualMachine) -> PyResult<bool> {
-        // TODO: fortain order
+        // TODO: column-major order
         self.try_not_released(vm)
             .map(|_| self.desc.ndim() <= 1 && self.desc.is_contiguous())
     }

--- a/vm/src/protocol/buffer.rs
+++ b/vm/src/protocol/buffer.rs
@@ -381,7 +381,7 @@ impl BufferDescriptor {
         self.dim_desc.iter().any(|(shape, _, _)| *shape == 0)
     }
 
-    // TODO: support fortain order
+    // TODO: support column-major order
 }
 
 pub trait BufferResizeGuard {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enabled several protocol-related typing tests by removing expected failure markers and uncommenting test code, improving coverage for runtime checkable generic protocols and related behaviors.

* **Style**
  * Updated comments to clarify terminology, replacing "fortain order" with "column-major order" in memory handling components.

* **Chores**
  * Enhanced error tracking for internal panics, improving debugging information for developers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->