### PR TITLE
Fix __annotation__

### DIFF
--- a/compiler/codegen/src/compile.rs
+++ b/compiler/codegen/src/compile.rs
@@ -491,6 +491,10 @@ impl Compiler<'_> {
     ) -> CompileResult<()> {
         self.symbol_table_stack.push(symbol_table);
 
+        if Self::find_ann(body) {
+            emit!(self, Instruction::SetupAnnotation);
+        }
+
         if let Some((last, body)) = body.split_last() {
             for statement in body {
                 if let Stmt::Expr(StmtExpr { value, .. }) = &statement {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Ensured annotation setup is properly handled when compiling single-statement programs containing annotated assignments or nested annotations. This improves consistency with other compilation modes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->