### PR TITLE
Upgrade typing to 3.13.5

### DIFF
--- a/Lib/test/test_typing.py
+++ b/Lib/test/test_typing.py
@@ -4091,8 +4091,6 @@ class GenericTests(BaseTestCase):
         self.assertIs(MyChain[int]().__class__, MyChain)
         self.assertEqual(MyChain[int]().__orig_class__, MyChain[int])
 
-    # TODO: RUSTPYTHON
-    @unittest.expectedFailure
     def test_all_repr_eq_any(self):
         objs = (getattr(typing, el) for el in typing.__all__)
         for obj in objs:
@@ -9591,8 +9589,6 @@ class AllTests(BaseTestCase):
         self.assertIn('SupportsBytes', a)
         self.assertIn('SupportsComplex', a)
 
-    # TODO: RUSTPYTHON
-    @unittest.expectedFailure
     def test_all_exported_names(self):
         # ensure all dynamically created objects are actualised
         for name in typing.__all__:

--- a/Lib/test/test_typing.py
+++ b/Lib/test/test_typing.py
@@ -3351,8 +3351,6 @@ class ProtocolTests(BaseTestCase):
         self.assertNotIsSubclass(C, Protocol)
         self.assertNotIsInstance(C(), Protocol)
 
-    # TODO: RUSTPYTHON
-    @unittest.expectedFailure
     def test_protocols_issubclass_non_callable(self):
         class C:
             x = 1
@@ -3412,8 +3410,6 @@ class ProtocolTests(BaseTestCase):
         ):
             issubclass(Eggs, Spam)
 
-    # TODO: RUSTPYTHON
-    @unittest.expectedFailure
     def test_no_weird_caching_with_issubclass_after_isinstance_2(self):
         @runtime_checkable
         class Spam(Protocol):
@@ -3434,8 +3430,6 @@ class ProtocolTests(BaseTestCase):
         ):
             issubclass(Eggs, Spam)
 
-    # TODO: RUSTPYTHON
-    @unittest.expectedFailure
     def test_no_weird_caching_with_issubclass_after_isinstance_3(self):
         @runtime_checkable
         class Spam(Protocol):

--- a/Lib/typing.py
+++ b/Lib/typing.py
@@ -1987,7 +1987,8 @@ def _allow_reckless_class_checks(depth=2):
     The abc and functools modules indiscriminately call isinstance() and
     issubclass() on the whole MRO of a user class, which may contain protocols.
     """
-    return _caller(depth) in {'abc', 'functools', None}
+    # XXX: RUSTPYTHON; https://github.com/python/cpython/pull/136115
+    return _caller(depth) in {'abc', '_py_abc', 'functools', None}
 
 
 _PROTO_ALLOWLIST = {

--- a/vm/src/stdlib/typing.rs
+++ b/vm/src/stdlib/typing.rs
@@ -48,7 +48,10 @@ pub(crate) mod decl {
     #[pyfunction(name = "override")]
     pub(crate) fn r#override(func: PyObjectRef, vm: &VirtualMachine) -> PyResult {
         // Set __override__ attribute to True
-        func.set_attr("__override__", vm.ctx.true_value.clone(), vm)?;
+        // Skip the attribute silently if it is not writable.
+        // AttributeError happens if the object has __slots__ or a
+        // read-only property, TypeError if it's a builtin class.
+        let _ = func.set_attr("__override__", vm.ctx.true_value.clone(), vm);
         Ok(func)
     }
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Introduced an `override` decorator to mark methods as overrides at runtime.
  * Improved error reporting for protocols with non-method members when using `issubclass()`.

* **Documentation**
  * Expanded docstrings for several typing utilities with new examples and usage guidance.

* **Refactor**
  * Refactored internal instance checking logic for better alignment with expected Python behavior.

* **Tests**
  * Updated test metadata by removing expected failure markers from certain typing tests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->