### PR TITLE
Fix stat module compilation for Redox OS

### DIFF
--- a/vm/src/stdlib/stat.rs
+++ b/vm/src/stdlib/stat.rs
@@ -132,10 +132,10 @@ mod stat {
     #[pyattr]
     pub const S_IWUSR: Mode = 0o0200;
 
-    #[cfg(all(unix, not(target_os = "android")))]
+    #[cfg(all(unix, not(target_os = "android"), not(target_os = "redox")))]
     #[pyattr]
     pub const S_IWRITE: Mode = libc::S_IWRITE;
-    #[cfg(any(not(unix), target_os = "android"))]
+    #[cfg(any(not(unix), target_os = "android", target_os = "redox"))]
     #[pyattr]
     pub const S_IWRITE: Mode = 0o0200;
 
@@ -146,10 +146,10 @@ mod stat {
     #[pyattr]
     pub const S_IXUSR: Mode = 0o0100;
 
-    #[cfg(all(unix, not(target_os = "android")))]
+    #[cfg(all(unix, not(target_os = "android"), not(target_os = "redox")))]
     #[pyattr]
     pub const S_IEXEC: Mode = libc::S_IEXEC;
-    #[cfg(any(not(unix), target_os = "android"))]
+    #[cfg(any(not(unix), target_os = "android", target_os = "redox"))]
     #[pyattr]
     pub const S_IEXEC: Mode = 0o0100;
 


### PR DESCRIPTION
Fixes #5856

The replacement constants is exist for redox and should be working: https://github.com/rust-lang/libc/blob/main/src/unix/redox/mod.rs