### PR TITLE
Avoid set changed size during iteration

### DIFF
--- a/Lib/test/test_set.py
+++ b/Lib/test/test_set.py
@@ -582,8 +582,6 @@ class TestSet(TestJointOps, unittest.TestCase):
             else:
                 self.assertNotIn(c, self.s)
 
-    # TODO: RUSTPYTHON
-    @unittest.expectedFailure
     def test_inplace_on_self(self):
         t = self.s.copy()
         t |= t

--- a/vm/src/builtins/set.rs
+++ b/vm/src/builtins/set.rs
@@ -425,8 +425,9 @@ impl PySetInner {
         vm: &VirtualMachine,
     ) -> PyResult<()> {
         for iterable in others {
-            for item in iterable.iter(vm)? {
-                self.content.delete_if_exists(vm, &*item?)?;
+            let items = iterable.iter(vm)?.collect::<Result<Vec<_>, _>>()?;
+            for item in items {
+                self.content.delete_if_exists(vm, &*item)?;
             }
         }
         Ok(())


### PR DESCRIPTION
This pull request fixes #3992 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated set operation tests to remove an expected failure marker, allowing the test to run and report results as usual.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->