### PR TITLE
chore: test testcases with `@unittest.skip` decorator

### DIFF
--- a/Lib/test/test_ast.py
+++ b/Lib/test/test_ast.py
@@ -340,7 +340,8 @@ class AST_Tests(unittest.TestCase):
         support.gc_collect()
         self.assertIsNone(ref())
 
-    @unittest.skip("TODO: RUSTPYTHON, thread 'main' panicked at 'not implemented: async for comprehensions'")
+    # TODO: RUSTPYTHON
+    @unittest.expectedFailure
     def test_snippets(self):
         for input, output, kind in ((exec_tests, exec_results, "exec"),
                                     (single_tests, single_results, "single"),
@@ -353,7 +354,8 @@ class AST_Tests(unittest.TestCase):
                 with self.subTest(action="compiling", input=i, kind=kind):
                     compile(ast_tree, "?", kind)
 
-    @unittest.skip("TODO: RUSTPYTHON, thread 'main' panicked at 'not implemented: async for comprehensions'")
+    # TODO: RUSTPYTHON
+    @unittest.expectedFailure
     def test_ast_validation(self):
         # compile() is the only function that calls PyAST_Validate
         snippets_to_validate = exec_tests + single_tests + eval_tests
@@ -361,7 +363,8 @@ class AST_Tests(unittest.TestCase):
             tree = ast.parse(snippet)
             compile(tree, '<string>', 'exec')
 
-    @unittest.skip("TODO: RUSTPYTHON, OverflowError: Python int too large to convert to Rust u32")
+    # TODO: RUSTPYTHON
+    @unittest.expectedFailure
     def test_invalid_position_information(self):
         invalid_linenos = [
             (10, 1), (-10, -11), (10, -11), (-5, -2), (-5, 1)

--- a/Lib/test/test_cmd_line.py
+++ b/Lib/test/test_cmd_line.py
@@ -259,7 +259,8 @@ class CmdLineTest(unittest.TestCase):
         if not stdout.startswith(pattern):
             raise AssertionError("%a doesn't start with %a" % (stdout, pattern))
 
-    @unittest.skip("TODO: RUSTPYTHON, thread 'main' panicked at 'unexpected invalid UTF-8 code point'")
+    # TODO: RUSTPYTHON
+    @unittest.expectedFailure
     @unittest.skipIf(sys.platform == 'win32',
                      'Windows has a native unicode API')
     def test_invalid_utf8_arg(self):

--- a/Lib/test/test_float.py
+++ b/Lib/test/test_float.py
@@ -153,8 +153,6 @@ class GeneralFloatCases(unittest.TestCase):
         # non-UTF-8 byte string
         check(b'123\xa0')
 
-    # TODO: RUSTPYTHON
-    @unittest.skip("RustPython panics on this")
     @support.run_with_locale('LC_NUMERIC', 'fr_FR', 'de_DE', '')
     def test_float_with_comma(self):
         # set locale to something that doesn't use '.' for the decimal point

--- a/Lib/test/test_io.py
+++ b/Lib/test/test_io.py
@@ -5098,13 +5098,15 @@ class SignalsTest(unittest.TestCase):
                 if e.errno != errno.EBADF:
                     raise
 
-    @unittest.skip("TODO: RUSTPYTHON, thread 'main' panicked at 'already borrowed: BorrowMutError'")
+    # TODO: RUSTPYTHON
+    @unittest.expectedFailure
     @requires_alarm
     @support.requires_resource('walltime')
     def test_interrupted_write_retry_buffered(self):
         self.check_interrupted_write_retry(b"x", mode="wb")
 
-    @unittest.skip("TODO: RUSTPYTHON, thread 'main' panicked at 'already borrowed: BorrowMutError'")
+    # TODO: RUSTPYTHON
+    @unittest.expectedFailure
     @requires_alarm
     @support.requires_resource('walltime')
     def test_interrupted_write_retry_text(self):

--- a/Lib/test/test_strftime.py
+++ b/Lib/test/test_strftime.py
@@ -63,7 +63,6 @@ class StrftimeTest(unittest.TestCase):
             setlocale(LC_TIME, 'C')
             self.addCleanup(setlocale, LC_TIME, saved_locale)
 
-    @unittest.skip("TODO: RUSTPYTHON, thread 'main' panicked at 'a Display implementation returned an error unexpectedly: Error'")
     def test_strftime(self):
         now = time.time()
         self._update_variables(now)

--- a/Lib/test/test_time.py
+++ b/Lib/test/test_time.py
@@ -236,7 +236,6 @@ class TimeTestCase(unittest.TestCase):
     def test_strftime_bounding_check(self):
         self._bounds_checking(lambda tup: time.strftime('', tup))
 
-    @unittest.skip("TODO: RUSTPYTHON, thread 'main' panicked at 'a Display implementation returned an error unexpectedly: Error'")
     def test_strftime_format_check(self):
         # Test that strftime does not crash on invalid format strings
         # that may trigger a buffer overread. When not triggered,
@@ -459,7 +458,6 @@ class TimeTestCase(unittest.TestCase):
 
     # Issue #13309: passing extreme values to mktime() or localtime()
     # borks the glibc's internal timezone data.
-    @unittest.skip("TODO: RUSTPYTHON, thread 'main' panicked at 'a Display implementation returned an error unexpectedly: Error'")
     @unittest.skipUnless(platform.libc_ver()[0] != 'glibc',
                          "disabled because of a bug in glibc. Issue #13309")
     def test_mktime_error(self):


### PR DESCRIPTION
This pull request replaces the `@unittest.skip` decorator with `@unittest.expectedFailure` for test cases that are no longer failing due to panic. And, if the test case is no longer failing, their `@unittest.skip` decorators are just unmarked.

<details>
<summary>Claude Code prompt (Korean)</summary>
@Lib/test 하위에 있는 테스트들중 `@unittest.skip` 으로 마킹되어 있고 메시지로 'panicked'를 포함하고 있는 것들을 골라 마킹을 하나씩 해제해보고 실제로 패닉이 발생하는지 확인하려고 합니다. 만약 패닉이 발생하지 않고 그저 실패한다면 `# TODO: RUSTPYTHON\n@unittest.expectedFailure`로 교체해야 합니다. `cargo run -q -- -m test --list-cases test.test_ast` 꼴로 전체 테스트 목록을 가져올 수 있고, `cargo run -q -- -m unittest <qualified_testcase_name>` 꼴로 특정 테스트를 실행해볼 수 있습니다. 우선 확인 해볼 테스트 케이스를 조사하여 PLAN.md에 체크리스트로 기록하여 주십시오.
</details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated several previously skipped tests to be marked as expected failures, improving test reporting and visibility of known issues.
  * Enabled multiple tests that were previously skipped, allowing them to run during test execution.
  * Added comments to highlight areas with known issues for future reference.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->