### PR TITLE
relocate Generic under typevar.rs

### DIFF
--- a/vm/src/stdlib/typing.rs
+++ b/vm/src/stdlib/typing.rs
@@ -2,7 +2,7 @@
 use crate::{PyPayload, PyRef, VirtualMachine, class::PyClassImpl, stdlib::PyModule};
 
 pub use crate::stdlib::typevar::{
-    ParamSpec, ParamSpecArgs, ParamSpecKwargs, TypeVar, TypeVarTuple,
+    Generic, ParamSpec, ParamSpecArgs, ParamSpecKwargs, TypeVar, TypeVarTuple,
 };
 pub use decl::*;
 
@@ -13,6 +13,7 @@ pub(crate) fn make_module(vm: &VirtualMachine) -> PyRef<PyModule> {
     TypeVarTuple::make_class(&vm.ctx);
     ParamSpecArgs::make_class(&vm.ctx);
     ParamSpecKwargs::make_class(&vm.ctx);
+    Generic::make_class(&vm.ctx);
     extend_module!(vm, &module, {
         "NoDefault" => vm.ctx.typing_no_default.clone(),
         "TypeVar" => TypeVar::class(&vm.ctx).to_owned(),
@@ -20,6 +21,7 @@ pub(crate) fn make_module(vm: &VirtualMachine) -> PyRef<PyModule> {
         "TypeVarTuple" => TypeVarTuple::class(&vm.ctx).to_owned(),
         "ParamSpecArgs" => ParamSpecArgs::class(&vm.ctx).to_owned(),
         "ParamSpecKwargs" => ParamSpecKwargs::class(&vm.ctx).to_owned(),
+        "Generic" => Generic::class(&vm.ctx).to_owned(),
     });
     module
 }
@@ -113,55 +115,6 @@ pub(crate) mod decl {
                 type_params,
                 value,
             }
-        }
-    }
-
-    /// Helper function to call typing module functions with cls as first argument
-    /// Similar to CPython's call_typing_args_kwargs
-    fn call_typing_args_kwargs(
-        name: &'static str,
-        cls: PyTypeRef,
-        args: FuncArgs,
-        vm: &VirtualMachine,
-    ) -> PyResult {
-        let typing = vm.import("typing", 0)?;
-        let func = typing.get_attr(name, vm)?;
-
-        // Prepare arguments: (cls, *args)
-        let mut call_args = vec![cls.into()];
-        call_args.extend(args.args);
-
-        // Call with prepared args and original kwargs
-        let func_args = FuncArgs {
-            args: call_args,
-            kwargs: args.kwargs,
-        };
-
-        func.call(func_args, vm)
-    }
-
-    #[pyattr]
-    #[pyclass(name = "Generic", module = "typing")]
-    #[derive(Debug, PyPayload)]
-    #[allow(dead_code)]
-    pub(crate) struct Generic {}
-
-    // #[pyclass(with(AsMapping), flags(BASETYPE))]
-    #[pyclass(flags(BASETYPE))]
-    impl Generic {
-        #[pyclassmethod]
-        fn __class_getitem__(cls: PyTypeRef, args: PyObjectRef, vm: &VirtualMachine) -> PyResult {
-            // Convert single arg to FuncArgs
-            let func_args = FuncArgs {
-                args: vec![args],
-                kwargs: Default::default(),
-            };
-            call_typing_args_kwargs("_generic_class_getitem", cls, func_args, vm)
-        }
-
-        #[pyclassmethod]
-        fn __init_subclass__(cls: PyTypeRef, args: FuncArgs, vm: &VirtualMachine) -> PyResult {
-            call_typing_args_kwargs("_generic_init_subclass", cls, args, vm)
         }
     }
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced a new `Generic` class in the typing module, providing class methods for generic type handling.

* **Refactor**
  * Internal implementation of the `Generic` class has been reorganized for improved maintainability, with no impact on existing user functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->