### PR TITLE
Add separator validation

### DIFF
--- a/Lib/test/test_format.py
+++ b/Lib/test/test_format.py
@@ -502,29 +502,21 @@ class FormatTest(unittest.TestCase):
         self.assertEqual(format(12300050.0, ".6g"), "1.23e+07")
         self.assertEqual(format(12300050.0, "#.6g"), "1.23000e+07")
 
-    # TODO: RUSTPYTHON
-    @unittest.expectedFailure
     def test_with_two_commas_in_format_specifier(self):
         error_msg = re.escape("Cannot specify ',' with ','.")
         with self.assertRaisesRegex(ValueError, error_msg):
             '{:,,}'.format(1)
 
-    # TODO: RUSTPYTHON
-    @unittest.expectedFailure
     def test_with_two_underscore_in_format_specifier(self):
         error_msg = re.escape("Cannot specify '_' with '_'.")
         with self.assertRaisesRegex(ValueError, error_msg):
             '{:__}'.format(1)
 
-    # TODO: RUSTPYTHON
-    @unittest.expectedFailure
     def test_with_a_commas_and_an_underscore_in_format_specifier(self):
         error_msg = re.escape("Cannot specify both ',' and '_'.")
         with self.assertRaisesRegex(ValueError, error_msg):
             '{:,_}'.format(1)
 
-    # TODO: RUSTPYTHON
-    @unittest.expectedFailure
     def test_with_an_underscore_and_a_comma_in_format_specifier(self):
         error_msg = re.escape("Cannot specify both ',' and '_'.")
         with self.assertRaisesRegex(ValueError, error_msg):

--- a/Lib/test/test_fstring.py
+++ b/Lib/test/test_fstring.py
@@ -1838,29 +1838,21 @@ x = (
         ):
             compile("f'{a $ b}'", "?", "exec")
 
-    # TODO: RUSTPYTHON
-    @unittest.expectedFailure
     def test_with_two_commas_in_format_specifier(self):
         error_msg = re.escape("Cannot specify ',' with ','.")
         with self.assertRaisesRegex(ValueError, error_msg):
             f"{1:,,}"
 
-    # TODO: RUSTPYTHON
-    @unittest.expectedFailure
     def test_with_two_underscore_in_format_specifier(self):
         error_msg = re.escape("Cannot specify '_' with '_'.")
         with self.assertRaisesRegex(ValueError, error_msg):
             f"{1:__}"
 
-    # TODO: RUSTPYTHON
-    @unittest.expectedFailure
     def test_with_a_commas_and_an_underscore_in_format_specifier(self):
         error_msg = re.escape("Cannot specify both ',' and '_'.")
         with self.assertRaisesRegex(ValueError, error_msg):
             f"{1:,_}"
 
-    # TODO: RUSTPYTHON
-    @unittest.expectedFailure
     def test_with_an_underscore_and_a_comma_in_format_specifier(self):
         error_msg = re.escape("Cannot specify both ',' and '_'.")
         with self.assertRaisesRegex(ValueError, error_msg):

--- a/Lib/test/test_long.py
+++ b/Lib/test/test_long.py
@@ -625,8 +625,6 @@ class LongTest(unittest.TestCase):
                     eq(x > y, Rcmp > 0)
                     eq(x >= y, Rcmp >= 0)
 
-    # TODO: RUSTPYTHON
-    @unittest.expectedFailure
     def test__format__(self):
         self.assertEqual(format(123456789, 'd'), '123456789')
         self.assertEqual(format(123456789, 'd'), '123456789')

--- a/vm/src/format.rs
+++ b/vm/src/format.rs
@@ -21,6 +21,10 @@ impl IntoPyException for FormatSpecError {
                 let msg = format!("Cannot specify '{c1}' with '{c2}'.");
                 vm.new_value_error(msg)
             }
+            Self::ExclusiveFormat(c1, c2) => {
+                let msg = format!("Cannot specify both '{c1}' and '{c2}'.");
+                vm.new_value_error(msg)
+            }
             Self::UnknownFormatCode(c, s) => {
                 let msg = format!("Unknown format code '{c}' for object of type '{s}'");
                 vm.new_value_error(msg)


### PR DESCRIPTION
## Summary

I've added format separator validation.

```
>>>>> f"{1:,,}"
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
ValueError: Cannot specify ',' with ','.
>>>>> f"{1:,_}"
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
ValueError: Cannot specify both ',' and '_'.
```

With this fix, following tests now pass.
- test_format.py
    - test_with_two_commas_in_format_specifier
    - test_with_two_underscore_in_format_specifier
    - test_with_a_commas_and_an_underscore_in_format_specifier
    - test_with_an_underscore_and_a_comma_in_format_specifier
- test_fstring.py
    - test_with_two_commas_in_format_specifier
    - test_with_two_underscore_in_format_specifier
    - test_with_a_commas_and_an_underscore_in_format_specifier
    - test_with_an_underscore_and_a_comma_in_format_specifier
- test_long.py
    - test\_\_format\_\_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved validation of grouping separators in format specifications, providing immediate feedback on invalid combinations.
  * Added clearer error messages when conflicting grouping separators are specified.

* **Bug Fixes**
  * Prevented the use of both comma and underscore as grouping separators in the same format specifier.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->