### PR TITLE
Handle negative time.sleep values

### DIFF
--- a/vm/src/stdlib/time.rs
+++ b/vm/src/stdlib/time.rs
@@ -93,18 +93,13 @@ mod decl {
     fn sleep(seconds: PyObjectRef, vm: &VirtualMachine) -> PyResult<()> {
         let dur = seconds.try_into_value::<Duration>(vm).map_err(|e| {
             if e.class().is(vm.ctx.exceptions.value_error) {
-                // Check if this is a "negative duration" error by examining the args
-                if let Some(args) = e.args().first() {
-                    if let Ok(s) = args.str(vm) {
-                        if s.as_str() == "negative duration" {
-                            return vm.new_value_error("sleep length must be non-negative");
-                        }
+                if let Some(s) = e.args().first().and_then(|arg| arg.str(vm).ok()) {
+                    if s.as_str() == "negative duration" {
+                        return vm.new_value_error("sleep length must be non-negative");
                     }
                 }
-                e
-            } else {
-                e
             }
+            e
         })?;
 
         std::thread::sleep(dur);
@@ -711,18 +706,13 @@ mod platform {
     fn sleep(seconds: PyObjectRef, vm: &VirtualMachine) -> PyResult<()> {
         let dur = seconds.try_into_value::<Duration>(vm).map_err(|e| {
             if e.class().is(vm.ctx.exceptions.value_error) {
-                // Check if this is a "negative duration" error by examining the args
-                if let Some(args) = e.args().first() {
-                    if let Ok(s) = args.str(vm) {
-                        if s.as_str() == "negative duration" {
-                            return vm.new_value_error("sleep length must be non-negative");
-                        }
+                if let Some(s) = e.args().first().and_then(|arg| arg.str(vm).ok()) {
+                    if s.as_str() == "negative duration" {
+                        return vm.new_value_error("sleep length must be non-negative");
                     }
                 }
-                e
-            } else {
-                e
             }
+            e
         })?;
 
         let ts = TimeSpec::from(dur);

--- a/vm/src/stdlib/time.rs
+++ b/vm/src/stdlib/time.rs
@@ -34,7 +34,7 @@ unsafe extern "C" {
 #[pymodule(name = "time", with(platform))]
 mod decl {
     use crate::{
-        PyObjectRef, PyResult, TryFromObject, VirtualMachine,
+        PyObjectRef, PyResult, TryFromObject, VirtualMachine, AsObject,
         builtins::{PyStrRef, PyTypeRef},
         function::{Either, FuncArgs, OptionalArg},
         types::PyStructSequence,
@@ -88,7 +88,6 @@ mod decl {
         duration_since_system_now(vm)
     }
 
-    #[cfg(not(unix))]
     #[pyfunction]
     fn sleep(seconds: PyObjectRef, vm: &VirtualMachine) -> PyResult<()> {
         let dur = seconds.try_into_value::<Duration>(vm).map_err(|e| {
@@ -102,7 +101,23 @@ mod decl {
             e
         })?;
 
-        std::thread::sleep(dur);
+        #[cfg(unix)]
+        {
+            // this is basically std::thread::sleep, but that catches interrupts and we don't want to;
+            let ts = nix::sys::time::TimeSpec::from(dur);
+            let res = unsafe { libc::nanosleep(ts.as_ref(), std::ptr::null_mut()) };
+            let interrupted = res == -1 && nix::Error::last_raw() == libc::EINTR;
+
+            if interrupted {
+                vm.check_signals()?;
+            }
+        }
+
+        #[cfg(not(unix))]
+        {
+            std::thread::sleep(dur);
+        }
+
         Ok(())
     }
 
@@ -700,30 +715,6 @@ mod platform {
 
     pub(super) fn get_perf_time(vm: &VirtualMachine) -> PyResult<Duration> {
         get_clock_time(ClockId::CLOCK_MONOTONIC, vm)
-    }
-
-    #[pyfunction]
-    fn sleep(seconds: PyObjectRef, vm: &VirtualMachine) -> PyResult<()> {
-        let dur = seconds.try_into_value::<Duration>(vm).map_err(|e| {
-            if e.class().is(vm.ctx.exceptions.value_error) {
-                if let Some(s) = e.args().first().and_then(|arg| arg.str(vm).ok()) {
-                    if s.as_str() == "negative duration" {
-                        return vm.new_value_error("sleep length must be non-negative");
-                    }
-                }
-            }
-            e
-        })?;
-
-        let ts = TimeSpec::from(dur);
-        let res = unsafe { libc::nanosleep(ts.as_ref(), std::ptr::null_mut()) };
-        let interrupted = res == -1 && nix::Error::last_raw() == libc::EINTR;
-
-        if interrupted {
-            vm.check_signals()?;
-        }
-
-        Ok(())
     }
 
     #[cfg(not(any(

--- a/vm/src/stdlib/time.rs
+++ b/vm/src/stdlib/time.rs
@@ -34,7 +34,7 @@ unsafe extern "C" {
 #[pymodule(name = "time", with(platform))]
 mod decl {
     use crate::{
-        PyObjectRef, PyResult, TryFromObject, VirtualMachine, AsObject,
+        AsObject, PyObjectRef, PyResult, TryFromObject, VirtualMachine,
         builtins::{PyStrRef, PyTypeRef},
         function::{Either, FuncArgs, OptionalArg},
         types::PyStructSequence,
@@ -552,7 +552,7 @@ mod platform {
     use super::decl::{SEC_TO_NS, US_TO_NS};
     #[cfg_attr(target_os = "macos", allow(unused_imports))]
     use crate::{
-        AsObject, PyObject, PyObjectRef, PyRef, PyResult, TryFromBorrowedObject, VirtualMachine,
+        PyObject, PyRef, PyResult, TryFromBorrowedObject, VirtualMachine,
         builtins::{PyNamespace, PyStrRef},
         convert::IntoPyException,
     };


### PR DESCRIPTION
resolved #5895

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved validation to prevent negative durations when converting from Python objects, ensuring that negative values now raise clear errors.

* **New Features**
  * Enhanced error messaging for invalid sleep durations, providing a more user-friendly message when a negative duration is specified.

* **Refactor**
  * Updated the `sleep` function to accept a wider range of Python objects for specifying sleep duration, increasing flexibility in usage.
  * Unified and simplified platform-specific sleep handling for better consistency across environments.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->