### PR TITLE
Fix SQLite large integer overflow error handling

### DIFF
--- a/Lib/test/test_sqlite3/test_userfunctions.py
+++ b/Lib/test/test_sqlite3/test_userfunctions.py
@@ -337,8 +337,6 @@ class FunctionTests(unittest.TestCase):
         # SQLite has no concept of nan; it is converted to NULL
         self.assertTrue(cur.fetchone()[0])
 
-    # TODO: RUSTPYTHON
-    @unittest.expectedFailure
     def test_too_large_int(self):
         err = "Python int too large to convert to SQLite INTEGER"
         self.assertRaisesRegex(OverflowError, err, self.con.execute,

--- a/stdlib/src/sqlite.rs
+++ b/stdlib/src/sqlite.rs
@@ -2609,7 +2609,9 @@ mod _sqlite {
             let ret = if vm.is_none(obj) {
                 unsafe { sqlite3_bind_null(self.st, pos) }
             } else if let Some(val) = obj.payload::<PyInt>() {
-                let val = val.try_to_primitive::<i64>(vm)?;
+                let val = val.try_to_primitive::<i64>(vm).map_err(|_| {
+                    vm.new_overflow_error("Python int too large to convert to SQLite INTEGER")
+                })?;
                 unsafe { sqlite3_bind_int64(self.st, pos, val) }
             } else if let Some(val) = obj.payload::<PyFloat>() {
                 let val = val.to_f64();


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error messages when attempting to store very large Python integers in SQLite, providing clearer feedback if the value is too large to convert.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->