### PR TITLE
fix(sqlite): autocommit mode transaction handling to match CPython

### DIFF
--- a/Lib/test/test_sqlite3/test_transactions.py
+++ b/Lib/test/test_sqlite3/test_transactions.py
@@ -94,8 +94,6 @@ class TransactionTests(unittest.TestCase):
         self.assertEqual(len(res), 1)
         self.assertEqual(res[0][0], 5)
 
-    # TODO: RUSTPYTHON
-    @unittest.expectedFailure
     def test_toggle_auto_commit(self):
         self.cur1.execute("create table test(i)")
         self.cur1.execute("insert into test(i) values (5)")


### PR DESCRIPTION
## References

### CPython Implementation
- **Connection.c**
  - https://github.com/python/cpython/blob/6ea425828540d7a19296183c3410283897767d9a/Modules/_sqlite/connection.c#L1781-L1806
  - cpython 3.13: https://github.com/python/cpython/blob/c44070b2d51d59f608577b1f6c55c0168d8e416b/Modules/_sqlite/connection.c#L1749-L1771
- **Cursor.c**
  - https://github.com/python/cpython/blob/6ea425828540d7a19296183c3410283897767d9a/Modules/_sqlite/cursor.c#L866-L874

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved transaction management when switching to auto-commit mode by ensuring pending transactions are properly committed.
  * Refined when transactions are started during statement execution, so transactions only begin if an isolation level is explicitly set.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->