### PR TITLE
`sys.platform` android & ios

### DIFF
--- a/vm/src/stdlib/sys.rs
+++ b/vm/src/stdlib/sys.rs
@@ -73,6 +73,8 @@ mod sys {
                 "android"
             } else if #[cfg(target_os = "macos")] {
                 "darwin"
+            } else if #[cfg(target_os = "ios")] {
+                "ios"
             } else if #[cfg(windows)] {
                 "win32"
             } else if #[cfg(target_os = "wasi")] {

--- a/vm/src/stdlib/sys.rs
+++ b/vm/src/stdlib/sys.rs
@@ -67,9 +67,10 @@ mod sys {
     #[pyattr(name = "platform")]
     pub(crate) const PLATFORM: &str = {
         cfg_if::cfg_if! {
-            if #[cfg(any(target_os = "linux", target_os = "android"))] {
-                // Android is linux as well. see https://bugs.python.org/issue32637
+            if #[cfg(target_os = "linux")] {
                 "linux"
+            } else if #[cfg(target_os = "android")] {
+                "android"
             } else if #[cfg(target_os = "macos")] {
                 "darwin"
             } else if #[cfg(windows)] {


### PR DESCRIPTION
Starting from 3.13, `sys.platform` now returns 'android' if running on an android device. See notes at https://docs.python.org/3/library/sys.html#sys.platform

Added "ios" support as well

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved platform detection to distinguish between Linux, Android, macOS, and iOS systems.
  * Platform string now accurately identifies Android and iOS separately from Linux and macOS.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->