### PR TITLE
fix(itertools): add re-entrancy guard to tee object

### DIFF
--- a/Lib/test/test_itertools.py
+++ b/Lib/test/test_itertools.py
@@ -1761,8 +1761,6 @@ class TestBasicOps(unittest.TestCase):
             del forward, backward
             raise
 
-    # TODO: RUSTPYTHON
-    @unittest.expectedFailure
     def test_tee_reenter(self):
         class I:
             first = True


### PR DESCRIPTION
Reference

- https://github.com/python/cpython/blob/f6650f9ad73359051f3e558c2431a109bc016664/Modules/itertoolsmodule.c#L948-L965
- https://github.com/python/cpython/blob/f6650f9ad73359051f3e558c2431a109bc016664/Modules/itertoolsmodule.c#L772-L797

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved stability of the tee iterator by preventing concurrent or recursive access, reducing the risk of runtime errors or inconsistent behavior. Users will now receive a clear error if re-entrancy is attempted.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->