### PR TITLE
Add missing `@` for the "take" comment command

### DIFF
--- a/.github/workflows/comment-commands.yml
+++ b/.github/workflows/comment-commands.yml
@@ -16,7 +16,7 @@ jobs:
       issues: write    
 
     steps:
-      - run: gh issue edit "${{ env.ISSUE_NUMBER }}" --add-assignee "${{ env.USER_LOGIN }}"
+      - run: gh issue edit "${{ env.ISSUE_NUMBER }}" --add-assignee "@${{ env.USER_LOGIN }}"
         env:
           ISSUE_NUMBER: ${{ github.event.issue.number }}
           USER_LOGIN: ${{ github.event.comment.user.login }}


### PR DESCRIPTION
Very odd, I have tested this in a private repo and it worked. maybe it needs the `@` sign :shrug: 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the GitHub Actions workflow to adjust how issue assignments are handled.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->