### PR TITLE
Make `take` issue comment to use curl

### DIFF
--- a/.github/workflows/comment-commands.yml
+++ b/.github/workflows/comment-commands.yml
@@ -13,12 +13,11 @@ jobs:
       group: ${{ github.actor }}-issue-assign
 
     permissions:
-      issues: write    
+      issues: write
 
     steps:
-      - run: gh issue edit "${{ env.ISSUE_NUMBER }}" --add-assignee "${{ env.USER_LOGIN }}"
-        env:
-          ISSUE_NUMBER: ${{ github.event.issue.number }}
-          USER_LOGIN: ${{ github.event.comment.user.login }}
-          GH_TOKEN: ${{ github.token }}
-          GH_REPO: ${{ github.repository }}
+      # Using REST API and not `gh issue edit`. https://github.com/cli/cli/issues/6235#issuecomment-1243487651
+      - run: curl \
+          -H "Authorization: token ${{ github.token }}" \
+          -d '{"assignees": ["${{ github.event.comment.user.login }}"]}' \
+          https://api.github.com/repos/${{ github.repository }}/issues/${{ github.event.issue.number }}/assignees

--- a/.github/workflows/comment-commands.yml
+++ b/.github/workflows/comment-commands.yml
@@ -16,7 +16,7 @@ jobs:
       issues: write    
 
     steps:
-      - run: gh issue edit "${{ env.ISSUE_NUMBER }}" --add-assignee "@${{ env.USER_LOGIN }}"
+      - run: gh issue edit "${{ env.ISSUE_NUMBER }}" --add-assignee "${{ env.USER_LOGIN }}"
         env:
           ISSUE_NUMBER: ${{ github.event.issue.number }}
           USER_LOGIN: ${{ github.event.comment.user.login }}


### PR DESCRIPTION
After some debugging I got to https://github.com/scikit-learn/scikit-learn/issues/29395#issuecomment-2206776963

Which, after running:
```shell
gh api graphql -f query='query($endCursor:String){repository(owner:"RustPython",name:"RustPython"){assignableUsers(first:100,after:$endCursor){nodes{login}pageInfo{endCursor,hasNextPage}}}}' --paginate --jq '.data.repository.assignableUsers.nodes[].login'
```

Returned:
```
arihant2math
BenLewis-Seequent
charliermarsh
coolreader18
cthulahoops
DimitrisJim
fanninpm
MichaReiser
mireille-raad
OddBloke
palaviv
qingshi163
shinglyu
windelbouwman
youknowone
``` 
---

So, I've switched it to use curl. now it should work for non maintainers as well

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the workflow for assigning issues based on comment commands to use a direct API call for improved reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->