### PR TITLE
Use `raise_if_stop!` macro where possible

### DIFF
--- a/vm/src/builtins/enumerate.rs
+++ b/vm/src/builtins/enumerate.rs
@@ -8,6 +8,7 @@ use crate::{
     convert::ToPyObject,
     function::OptionalArg,
     protocol::{PyIter, PyIterReturn},
+    raise_if_stop,
     types::{Constructor, IterNext, Iterable, SelfIter},
 };
 use malachite_bigint::BigInt;
@@ -73,12 +74,10 @@ impl Py<PyEnumerate> {
 }
 
 impl SelfIter for PyEnumerate {}
+
 impl IterNext for PyEnumerate {
     fn next(zelf: &Py<Self>, vm: &VirtualMachine) -> PyResult<PyIterReturn> {
-        let next_obj = match zelf.iterator.next(vm)? {
-            PyIterReturn::StopIteration(v) => return Ok(PyIterReturn::StopIteration(v)),
-            PyIterReturn::Return(obj) => obj,
-        };
+        let next_obj = raise_if_stop!(zelf.iterator.next(vm)?);
         let mut counter = zelf.counter.write();
         let position = counter.clone();
         *counter += 1;

--- a/vm/src/builtins/map.rs
+++ b/vm/src/builtins/map.rs
@@ -5,6 +5,7 @@ use crate::{
     class::PyClassImpl,
     function::PosArgs,
     protocol::{PyIter, PyIterReturn},
+    raise_if_stop,
     types::{Constructor, IterNext, Iterable, SelfIter},
 };
 
@@ -53,14 +54,12 @@ impl PyMap {
 }
 
 impl SelfIter for PyMap {}
+
 impl IterNext for PyMap {
     fn next(zelf: &Py<Self>, vm: &VirtualMachine) -> PyResult<PyIterReturn> {
         let mut next_objs = Vec::new();
         for iterator in &zelf.iterators {
-            let item = match iterator.next(vm)? {
-                PyIterReturn::Return(obj) => obj,
-                PyIterReturn::StopIteration(v) => return Ok(PyIterReturn::StopIteration(v)),
-            };
+            let item = raise_if_stop!(iterator.next(vm)?);
             next_objs.push(item);
         }
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Streamlined internal error handling for built-in enumerate, filter, and map iterators, resulting in more concise and maintainable code. No changes to user-facing functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->