### PR TITLE
Add SymbolUsage::TypeParams

### DIFF
--- a/Lib/test/test_typing.py
+++ b/Lib/test/test_typing.py
@@ -3888,8 +3888,6 @@ class GenericTests(BaseTestCase):
         # should not have changed as a result of the get_type_hints() calls!
         self.assertEqual(ann_module695.__dict__, original_globals)
 
-    # TODO: RUSTPYTHON
-    @unittest.expectedFailure
     def test_pep695_generic_class_with_future_annotations_and_local_shadowing(self):
         hints_for_B = get_type_hints(ann_module695.B)
         self.assertEqual(hints_for_B, {"x": int, "y": str, "z": bytes})
@@ -3935,8 +3933,6 @@ class GenericTests(BaseTestCase):
             set(ann_module695.D.generic_method_2.__type_params__)
         )
 
-    # TODO: RUSTPYTHON
-    @unittest.expectedFailure
     def test_pep_695_generics_with_future_annotations_nested_in_function(self):
         results = ann_module695.nested()
 

--- a/compiler/codegen/src/compile.rs
+++ b/compiler/codegen/src/compile.rs
@@ -638,7 +638,11 @@ impl Compiler<'_> {
                 cache = &mut info.cellvar_cache;
                 NameOpType::Deref
             } // TODO: is this right?
-              // SymbolScope::Unknown => NameOpType::Global,
+            SymbolScope::TypeParams => {
+                // Type parameters are always cell variables
+                cache = &mut info.cellvar_cache;
+                NameOpType::Deref
+            } // SymbolScope::Unknown => NameOpType::Global,
         };
 
         if NameUsage::Load == usage && name == "__debug__" {
@@ -1630,6 +1634,7 @@ impl Compiler<'_> {
             let vars = match symbol.scope {
                 SymbolScope::Free => &parent_code.freevar_cache,
                 SymbolScope::Cell => &parent_code.cellvar_cache,
+                SymbolScope::TypeParams => &parent_code.cellvar_cache,
                 _ if symbol.flags.contains(SymbolFlags::FREE_CLASS) => &parent_code.freevar_cache,
                 x => unreachable!(
                     "var {} in a {:?} should be free or cell but it's {:?}",

--- a/vm/src/frame.rs
+++ b/vm/src/frame.rs
@@ -596,7 +596,11 @@ impl ExecutingFrame<'_> {
             }
             bytecode::Instruction::LoadClassDeref(i) => {
                 let i = i.get(arg) as usize;
-                let name = self.code.freevars[i - self.code.cellvars.len()];
+                let name = if i < self.code.cellvars.len() {
+                    self.code.cellvars[i]
+                } else {
+                    self.code.freevars[i - self.code.cellvars.len()]
+                };
                 let value = self.locals.mapping().subscript(name, vm).ok();
                 self.push_value(match value {
                     Some(v) => v,


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved handling of classes declared as global in parent scopes, ensuring correct naming in generated code.
  * Added support for type parameters in symbol table analysis and code generation, treating them as cell variables for better closure and scope management.

* **Bug Fixes**
  * Ensured emitted function and class names use the correct qualified name from the code object, improving consistency.
  * Corrected variable name resolution logic for closures involving both cell and free variables, enhancing execution accuracy.

* **Refactor**
  * Centralized logic for global class qualification names and unified symbol scope handling for type parameters.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->