### PR TITLE
CodeInfo::private

### DIFF
--- a/compiler/codegen/src/ir.rs
+++ b/compiler/codegen/src/ir.rs
@@ -74,6 +74,7 @@ pub struct CodeInfo {
     pub first_line_number: OneIndexed,
     pub obj_name: String, // Name of the object that created this code object
     pub qualname: Option<String>, // Qualified name of the object
+    pub private: Option<String>, // For private name mangling, mostly for class
 
     pub blocks: Vec<Block>,
     pub current_block: BlockIdx,
@@ -101,6 +102,7 @@ impl CodeInfo {
             first_line_number,
             obj_name,
             qualname,
+            private: _, // private is only used during compilation
 
             mut blocks,
             current_block: _,


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved handling of private name mangling by moving the private name context from a global compiler field to a per-code-object context.
  * Streamlined internal management of class and private names for better alignment with code object scopes.

No user-facing features or visible changes; these updates improve internal consistency and maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->