### PR TITLE
typing TypeAlias

### DIFF
--- a/Lib/test/test_typing.py
+++ b/Lib/test/test_typing.py
@@ -6649,8 +6649,6 @@ class OtherABCTests(BaseTestCase):
         self.assertIsInstance(cm, typing.ContextManager)
         self.assertNotIsInstance(42, typing.ContextManager)
 
-    # TODO: RUSTPYTHON
-    @unittest.expectedFailure
     def test_contextmanager_type_params(self):
         cm1 = typing.ContextManager[int]
         self.assertEqual(get_args(cm1), (int, bool | None))

--- a/compiler/core/src/bytecode.rs
+++ b/compiler/core/src/bytecode.rs
@@ -382,27 +382,13 @@ op_arg_enum!(
     #[derive(Copy, Clone, Debug, PartialEq, Eq)]
     #[repr(u8)]
     pub enum IntrinsicFunction1 {
-        /// Import * special case
-        // ImportStar = 0,
-        /// Set stop iteration value
-        // StopAsyncIteration = 1,
-        /// Unary operators
-        // UnaryPositive = 2,
-        // UnaryNegative = 3,
-        // UnaryNot = 4,
-        // UnaryInvert = 5,
-        /// Exit init subclass
-        // ExitInitCheck = 6,
-        /// Create a new list from an iterator
-        // ListToTupleForCall = 7,
         /// Type parameter related
-        // TypeVar = 8,
-        // TypeVarTuple = 9,
-        // ParamSpec = 10,
+        TypeVar = 7,
+        ParamSpec = 8,
+        TypeVarTuple = 9,
         /// Generic subscript for PEP 695
         SubscriptGeneric = 10,
-        // TypeAlias = 12,
-        // TypeParams = 13,
+        TypeAlias = 11,
     }
 );
 
@@ -412,8 +398,8 @@ op_arg_enum!(
     #[repr(u8)]
     pub enum IntrinsicFunction2 {
         // PrepReraiseS tar = 1,
-        // TypeVarWithBound = 2,
-        // TypeVarWithConstraints = 3,
+        TypeVarWithBound = 2,
+        TypeVarWithConstraint = 3,
         SetFunctionTypeParams = 4,
         /// Set default value for type parameter (PEP 695)
         SetTypeparamDefault = 5,
@@ -668,16 +654,10 @@ pub enum Instruction {
     MatchKeys,
     MatchClass(Arg<u32>),
     ExtendedArg,
-    TypeVar,
-    TypeVarWithBound,
-    TypeVarWithConstraint,
-    TypeAlias,
-    TypeVarTuple,
-    ParamSpec,
     // If you add a new instruction here, be sure to keep LAST_INSTRUCTION updated
 }
 // This must be kept up to date to avoid marshaling errors
-const LAST_INSTRUCTION: Instruction = Instruction::ParamSpec;
+const LAST_INSTRUCTION: Instruction = Instruction::ExtendedArg;
 const _: () = assert!(mem::size_of::<Instruction>() == 1);
 
 impl From<Instruction> for u8 {
@@ -1380,12 +1360,6 @@ impl Instruction {
             MatchKeys => -1,
             MatchClass(_) => -2,
             ExtendedArg => 0,
-            TypeVar => 0,
-            TypeVarWithBound => -1,
-            TypeVarWithConstraint => -1,
-            TypeAlias => -2,
-            ParamSpec => 0,
-            TypeVarTuple => 0,
         }
     }
 
@@ -1565,12 +1539,6 @@ impl Instruction {
             MatchKeys => w!(MatchKeys),
             MatchClass(arg) => w!(MatchClass, arg),
             ExtendedArg => w!(ExtendedArg, Arg::<u32>::marker()),
-            TypeVar => w!(TypeVar),
-            TypeVarWithBound => w!(TypeVarWithBound),
-            TypeVarWithConstraint => w!(TypeVarWithConstraint),
-            TypeAlias => w!(TypeAlias),
-            ParamSpec => w!(ParamSpec),
-            TypeVarTuple => w!(TypeVarTuple),
         }
     }
 }

--- a/vm/src/stdlib/typing.rs
+++ b/vm/src/stdlib/typing.rs
@@ -113,6 +113,27 @@ pub(crate) mod decl {
                 value,
             }
         }
+
+        #[pygetset]
+        fn __name__(&self) -> PyObjectRef {
+            self.name.clone()
+        }
+
+        #[pygetset]
+        fn __value__(&self) -> PyObjectRef {
+            self.value.clone()
+        }
+
+        #[pygetset]
+        fn __type_params__(&self) -> PyTupleRef {
+            self.type_params.clone()
+        }
+
+        #[pymethod(name = "__repr__")]
+        fn repr(&self, vm: &VirtualMachine) -> PyResult<String> {
+            let name = self.name.str(vm)?;
+            Ok(name.as_str().to_owned())
+        }
     }
 
     // impl AsMapping for Generic {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Python-accessible properties to type aliases: `__name__`, `__value__`, and `__type_params__`.
  * Implemented a custom string representation (`__repr__`) for type aliases.

* **Refactor**
  * Updated the handling of type aliases and type parameters to use intrinsic function calls, improving the internal consistency of typing operations.
  * Removed legacy bytecode instructions for typing constructs in favor of a unified intrinsic function approach.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->