### PR TITLE
feat(vm/slot): implement `Py_TPFLAGS_MANAGED_DICT` for class objects

### DIFF
--- a/Lib/test/test_array.py
+++ b/Lib/test/test_array.py
@@ -1285,8 +1285,6 @@ class NumberTest(BaseTest):
         self.assertRaises(OverflowError, array.array, self.typecode, [upper+1])
         self.assertRaises(OverflowError, a.__setitem__, 0, upper+1)
 
-    # TODO: RUSTPYTHON
-    @unittest.expectedFailure
     def test_subclassing(self):
         typecode = self.typecode
         class ExaggeratingArray(array.array):

--- a/Lib/test/test_class.py
+++ b/Lib/test/test_class.py
@@ -851,11 +851,7 @@ try:
 except ImportError:
     has_inline_values = None
 
-
-Py_TPFLAGS_MANAGED_DICT = (1 << 4)
-
-class NoManagedDict:
-    __slots__ = ('a',)
+Py_TPFLAGS_MANAGED_DICT = (1 << 2)
 
 class Plain:
     pass
@@ -869,18 +865,11 @@ class WithAttrs:
         self.c = 3
         self.d = 4
 
-class TestNoManagedValues(unittest.TestCase):
-    def test_flags(self):
-        self.assertEqual(NoManagedDict.__flags__ & Py_TPFLAGS_MANAGED_DICT, 0)
-
-    # TODO: RUSTPYTHON
-    @unittest.expectedFailure
-    def test_no_inline_values_for_slots_class(self):
-        c = NoManagedDict()
-        self.assertFalse(has_inline_values(c))
 
 class TestInlineValues(unittest.TestCase):
 
+    # TODO: RUSTPYTHON
+    @unittest.expectedFailure
     def test_flags(self):
         self.assertEqual(Plain.__flags__ & Py_TPFLAGS_MANAGED_DICT, Py_TPFLAGS_MANAGED_DICT)
         self.assertEqual(WithAttrs.__flags__ & Py_TPFLAGS_MANAGED_DICT, Py_TPFLAGS_MANAGED_DICT)

--- a/Lib/test/test_class.py
+++ b/Lib/test/test_class.py
@@ -851,7 +851,11 @@ try:
 except ImportError:
     has_inline_values = None
 
-Py_TPFLAGS_MANAGED_DICT = (1 << 2)
+
+Py_TPFLAGS_MANAGED_DICT = (1 << 4)
+
+class NoManagedDict:
+    __slots__ = ('a',)
 
 class Plain:
     pass
@@ -865,11 +869,18 @@ class WithAttrs:
         self.c = 3
         self.d = 4
 
-
-class TestInlineValues(unittest.TestCase):
+class TestNoManagedValues(unittest.TestCase):
+    def test_flags(self):
+        self.assertEqual(NoManagedDict.__flags__ & Py_TPFLAGS_MANAGED_DICT, 0)
 
     # TODO: RUSTPYTHON
     @unittest.expectedFailure
+    def test_no_inline_values_for_slots_class(self):
+        c = NoManagedDict()
+        self.assertFalse(has_inline_values(c))
+
+class TestInlineValues(unittest.TestCase):
+
     def test_flags(self):
         self.assertEqual(Plain.__flags__ & Py_TPFLAGS_MANAGED_DICT, Py_TPFLAGS_MANAGED_DICT)
         self.assertEqual(WithAttrs.__flags__ & Py_TPFLAGS_MANAGED_DICT, Py_TPFLAGS_MANAGED_DICT)

--- a/Lib/test/test_importlib/test_metadata_api.py
+++ b/Lib/test/test_importlib/test_metadata_api.py
@@ -139,8 +139,6 @@ class APITests(
     def test_entry_points_missing_group(self):
         assert entry_points(group='missing') == ()
 
-    # TODO: RUSTPYTHON
-    @unittest.expectedFailure
     def test_entry_points_allows_no_attributes(self):
         ep = entry_points().select(group='entries', name='main')
         with self.assertRaises(AttributeError):

--- a/Lib/test/test_property.py
+++ b/Lib/test/test_property.py
@@ -242,8 +242,6 @@ class PropertySubSlots(property):
 
 class PropertySubclassTests(unittest.TestCase):
 
-    # TODO: RUSTPYTHON
-    @unittest.expectedFailure
     def test_slots_docstring_copy_exception(self):
         try:
             class Foo(object):

--- a/Lib/test/test_weakref.py
+++ b/Lib/test/test_weakref.py
@@ -1132,8 +1132,6 @@ class SubclassableWeakrefTestCase(TestBase):
         self.assertIn(r1, refs)
         self.assertIn(r2, refs)
 
-    # TODO: RUSTPYTHON
-    @unittest.expectedFailure
     def test_subclass_refs_with_slots(self):
         class MyRef(weakref.ref):
             __slots__ = "slot1", "slot2"

--- a/vm/src/types/slot.rs
+++ b/vm/src/types/slot.rs
@@ -122,6 +122,7 @@ bitflags! {
     #[derive(Copy, Clone, Debug, PartialEq)]
     #[non_exhaustive]
     pub struct PyTypeFlags: u64 {
+        const MANAGED_DICT = 1 << 4;
         const IMMUTABLETYPE = 1 << 8;
         const HEAPTYPE = 1 << 9;
         const BASETYPE = 1 << 10;


### PR DESCRIPTION
Reference

- <https://github.com/python/cpython/blob/cba2974a545c9d35f15f25575c214fbda601a47a/Objects/typeobject.c#L4264-L4310>
- <https://github.com/python/cpython/blob/cba2974a545c9d35f15f25575c214fbda601a47a/Objects/typeobject.c#L3658-L3683>
- <https://github.com/python/cpython/blob/cba2974a545c9d35f15f25575c214fbda601a47a/Objects/typeobject.c#L3906-L3946>
- MANAGED_DICT: https://github.com/python/cpython/blob/49365bd110a254a6a304d2f880482bfeb2e4490d/Include/object.h#L532-L535

~~Waiting for CPython Issue(PR)~~
~~<https://github.com/python/cpython/issues/136535>~~
> https://github.com/RustPython/RustPython/pull/5949#discussion_r2217527161


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved handling of type attributes for custom classes, ensuring correct support for types with and without `__slots__`.

* **Bug Fixes**
  * Fixed an issue where types with `__slots__` were incorrectly assigned dictionary-related flags.

* **Chores**
  * Updated internal flags to better represent type characteristics.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->