### PR TITLE
Fix set___name__ and set___qualname__ deadlock

### DIFF
--- a/Lib/test/test_descr.py
+++ b/Lib/test/test_descr.py
@@ -4261,7 +4261,6 @@ order (MRO) for bases """
         C.__name__ = 'D.E'
         self.assertEqual((C.__module__, C.__name__), (mod, 'D.E'))
 
-    @unittest.skip("TODO: RUSTPYTHON, rustpython hang")
     def test_evil_type_name(self):
         # A badly placed Py_DECREF in type_set_name led to arbitrary code
         # execution while the type structure was not in a sane state, and a


### PR DESCRIPTION
close #5940 by different approach

cc @ShaharNaveh 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved the way type names are updated internally to enhance reliability and consistency. No changes to user-facing behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->