### PR TITLE
Integrate PyTupleTyped into PyTuple

### DIFF
--- a/derive-impl/src/pytraverse.rs
+++ b/derive-impl/src/pytraverse.rs
@@ -105,8 +105,19 @@ pub(crate) fn impl_pytraverse(mut item: DeriveInput) -> Result<TokenStream> {
 
     let ty = &item.ident;
 
+    // Add Traverse bound to all type parameters
+    for param in &mut item.generics.params {
+        if let syn::GenericParam::Type(type_param) = param {
+            type_param
+                .bounds
+                .push(syn::parse_quote!(::rustpython_vm::object::Traverse));
+        }
+    }
+
+    let (impl_generics, ty_generics, where_clause) = item.generics.split_for_impl();
+
     let ret = quote! {
-        unsafe impl ::rustpython_vm::object::Traverse for #ty {
+        unsafe impl #impl_generics ::rustpython_vm::object::Traverse for #ty #ty_generics #where_clause {
             fn traverse(&self, tracer_fn: &mut ::rustpython_vm::object::TraverseFn) {
                 #trace_code
             }

--- a/vm/src/builtins/function.rs
+++ b/vm/src/builtins/function.rs
@@ -2,8 +2,8 @@
 mod jit;
 
 use super::{
-    PyAsyncGen, PyCode, PyCoroutine, PyDictRef, PyGenerator, PyStr, PyStrRef, PyTupleRef, PyType,
-    PyTypeRef, tuple::PyTupleTyped,
+    PyAsyncGen, PyCode, PyCoroutine, PyDictRef, PyGenerator, PyStr, PyStrRef, PyTuple, PyTupleRef,
+    PyType, PyTypeRef,
 };
 #[cfg(feature = "jit")]
 use crate::common::lock::OnceCell;
@@ -31,7 +31,7 @@ pub struct PyFunction {
     code: PyRef<PyCode>,
     globals: PyDictRef,
     builtins: PyObjectRef,
-    closure: Option<PyRef<PyTupleTyped<PyCellRef>>>,
+    closure: Option<PyRef<PyTuple<PyCellRef>>>,
     defaults_and_kwdefaults: PyMutex<(Option<PyTupleRef>, Option<PyDictRef>)>,
     name: PyMutex<PyStrRef>,
     qualname: PyMutex<PyStrRef>,
@@ -59,7 +59,7 @@ impl PyFunction {
     pub(crate) fn new(
         code: PyRef<PyCode>,
         globals: PyDictRef,
-        closure: Option<PyRef<PyTupleTyped<PyCellRef>>>,
+        closure: Option<PyRef<PyTuple<PyCellRef>>>,
         defaults: Option<PyTupleRef>,
         kw_only_defaults: Option<PyDictRef>,
         qualname: PyStrRef,

--- a/vm/src/builtins/type.rs
+++ b/vm/src/builtins/type.rs
@@ -62,7 +62,7 @@ unsafe impl crate::object::Traverse for PyType {
 pub struct HeapTypeExt {
     pub name: PyRwLock<PyStrRef>,
     pub qualname: PyRwLock<PyStrRef>,
-    pub slots: Option<PyTupleTyped<PyStrRef>>,
+    pub slots: Option<PyRef<PyTupleTyped<PyStrRef>>>,
     pub sequence_methods: PySequenceMethods,
     pub mapping_methods: PyMappingMethods,
 }
@@ -1041,15 +1041,13 @@ impl Constructor for PyType {
         // TODO: Flags is currently initialized with HAS_DICT. Should be
         // updated when __slots__ are supported (toggling the flag off if
         // a class has __slots__ defined).
-        let heaptype_slots: Option<PyTupleTyped<PyStrRef>> =
+        let heaptype_slots: Option<PyRef<PyTupleTyped<PyStrRef>>> =
             if let Some(x) = attributes.get(identifier!(vm, __slots__)) {
-                Some(if x.to_owned().class().is(vm.ctx.types.str_type) {
-                    PyTupleTyped::<PyStrRef>::try_from_object(
-                        vm,
-                        vec![x.to_owned()].into_pytuple(vm).into(),
-                    )?
+                let slots = if x.class().is(vm.ctx.types.str_type) {
+                    let x = unsafe { x.downcast_unchecked_ref::<PyStr>() };
+                    PyTupleTyped::new_ref(vec![x.to_owned()], &vm.ctx)
                 } else {
-                    let iter = x.to_owned().get_iter(vm)?;
+                    let iter = x.get_iter(vm)?;
                     let elements = {
                         let mut elements = Vec::new();
                         while let PyIterReturn::Return(element) = iter.next(vm)? {
@@ -1057,8 +1055,10 @@ impl Constructor for PyType {
                         }
                         elements
                     };
-                    PyTupleTyped::<PyStrRef>::try_from_object(vm, elements.into_pytuple(vm).into())?
-                })
+                    let tuple = elements.into_pytuple(vm);
+                    tuple.try_into_typed(vm)?
+                };
+                Some(slots)
             } else {
                 None
             };
@@ -1082,7 +1082,7 @@ impl Constructor for PyType {
             let heaptype_ext = HeapTypeExt {
                 name: PyRwLock::new(name),
                 qualname: PyRwLock::new(qualname),
-                slots: heaptype_slots.to_owned(),
+                slots: heaptype_slots.clone(),
                 sequence_methods: PySequenceMethods::default(),
                 mapping_methods: PyMappingMethods::default(),
             };

--- a/vm/src/builtins/type.rs
+++ b/vm/src/builtins/type.rs
@@ -1,5 +1,5 @@
 use super::{
-    PyClassMethod, PyDictRef, PyList, PyStr, PyStrInterned, PyStrRef, PyTuple, PyTupleRef, PyWeak,
+    PyClassMethod, PyDictRef, PyList, PyStr, PyStrInterned, PyStrRef, PyTupleRef, PyWeak,
     mappingproxy::PyMappingProxy, object, union_,
 };
 use crate::{
@@ -12,7 +12,7 @@ use crate::{
             PyMemberDescriptor,
         },
         function::PyCellRef,
-        tuple::{IntoPyTuple, PyTupleTyped},
+        tuple::{IntoPyTuple, PyTuple},
     },
     class::{PyClassImpl, StaticType},
     common::{
@@ -62,7 +62,7 @@ unsafe impl crate::object::Traverse for PyType {
 pub struct HeapTypeExt {
     pub name: PyRwLock<PyStrRef>,
     pub qualname: PyRwLock<PyStrRef>,
-    pub slots: Option<PyRef<PyTupleTyped<PyStrRef>>>,
+    pub slots: Option<PyRef<PyTuple<PyStrRef>>>,
     pub sequence_methods: PySequenceMethods,
     pub mapping_methods: PyMappingMethods,
 }
@@ -1041,11 +1041,11 @@ impl Constructor for PyType {
         // TODO: Flags is currently initialized with HAS_DICT. Should be
         // updated when __slots__ are supported (toggling the flag off if
         // a class has __slots__ defined).
-        let heaptype_slots: Option<PyRef<PyTupleTyped<PyStrRef>>> =
+        let heaptype_slots: Option<PyRef<PyTuple<PyStrRef>>> =
             if let Some(x) = attributes.get(identifier!(vm, __slots__)) {
                 let slots = if x.class().is(vm.ctx.types.str_type) {
                     let x = unsafe { x.downcast_unchecked_ref::<PyStr>() };
-                    PyTupleTyped::new_ref(vec![x.to_owned()], &vm.ctx)
+                    PyTuple::new_ref_typed(vec![x.to_owned()], &vm.ctx)
                 } else {
                     let iter = x.get_iter(vm)?;
                     let elements = {

--- a/vm/src/convert/try_from.rs
+++ b/vm/src/convert/try_from.rs
@@ -78,12 +78,12 @@ where
     #[inline]
     fn try_from_object(vm: &VirtualMachine, obj: PyObjectRef) -> PyResult<Self> {
         let class = T::class(&vm.ctx);
-        if obj.fast_isinstance(class) {
+        let result = if obj.fast_isinstance(class) {
             obj.downcast()
-                .map_err(|obj| vm.new_downcast_runtime_error(class, &obj))
         } else {
-            Err(vm.new_downcast_type_error(class, &obj))
-        }
+            Err(obj)
+        };
+        result.map_err(|obj| vm.new_downcast_type_error(class, &obj))
     }
 }
 

--- a/vm/src/object/core.rs
+++ b/vm/src/object/core.rs
@@ -655,7 +655,7 @@ impl PyObject {
 
     #[inline(always)]
     pub fn payload_is<T: PyObjectPayload>(&self) -> bool {
-        self.0.typeid == TypeId::of::<T>()
+        self.0.typeid == T::payload_type_id()
     }
 
     /// Force to return payload as T.

--- a/vm/src/object/payload.rs
+++ b/vm/src/object/payload.rs
@@ -19,6 +19,10 @@ cfg_if::cfg_if! {
 pub trait PyPayload:
     std::fmt::Debug + MaybeTraverse + PyThreadingConstraint + Sized + 'static
 {
+    #[inline]
+    fn payload_type_id() -> std::any::TypeId {
+        std::any::TypeId::of::<Self>()
+    }
     fn class(ctx: &Context) -> &'static Py<PyType>;
 
     #[inline]
@@ -75,7 +79,7 @@ pub trait PyPayload:
 }
 
 pub trait PyObjectPayload:
-    std::any::Any + std::fmt::Debug + MaybeTraverse + PyThreadingConstraint + 'static
+    PyPayload + std::any::Any + std::fmt::Debug + MaybeTraverse + PyThreadingConstraint + 'static
 {
 }
 

--- a/vm/src/object/traverse_object.rs
+++ b/vm/src/object/traverse_object.rs
@@ -3,7 +3,8 @@ use std::fmt;
 use crate::{
     PyObject,
     object::{
-        Erased, InstanceDict, PyInner, PyObjectPayload, debug_obj, drop_dealloc_obj, try_trace_obj,
+        Erased, InstanceDict, MaybeTraverse, PyInner, PyObjectPayload, debug_obj, drop_dealloc_obj,
+        try_trace_obj,
     },
 };
 
@@ -56,7 +57,7 @@ unsafe impl Traverse for PyInner<Erased> {
     }
 }
 
-unsafe impl<T: PyObjectPayload> Traverse for PyInner<T> {
+unsafe impl<T: MaybeTraverse> Traverse for PyInner<T> {
     /// Type is known, so we can call `try_trace` directly instead of using erased type vtable
     fn traverse(&self, tracer_fn: &mut TraverseFn<'_>) {
         // 1. trace `dict` and `slots` field(`typ` can't trace for it's a AtomicRef while is leaked by design)

--- a/vm/src/vm/context.rs
+++ b/vm/src/vm/context.rs
@@ -11,6 +11,7 @@ use crate::{
         },
         getset::PyGetSet,
         object, pystr,
+        tuple::PyTupleTyped,
         type_::PyAttributes,
     },
     class::{PyClassImpl, StaticType},
@@ -371,6 +372,12 @@ impl Context {
     #[inline(always)]
     pub fn not_implemented(&self) -> PyObjectRef {
         self.not_implemented.clone().into()
+    }
+
+    #[inline]
+    pub fn empty_tuple_typed<T>(&self) -> &Py<PyTupleTyped<T>> {
+        let py: &Py<PyTuple> = &self.empty_tuple;
+        unsafe { std::mem::transmute(py) }
     }
 
     // universal pyref constructor

--- a/vm/src/vm/context.rs
+++ b/vm/src/vm/context.rs
@@ -11,7 +11,6 @@ use crate::{
         },
         getset::PyGetSet,
         object, pystr,
-        tuple::PyTupleTyped,
         type_::PyAttributes,
     },
     class::{PyClassImpl, StaticType},
@@ -375,7 +374,7 @@ impl Context {
     }
 
     #[inline]
-    pub fn empty_tuple_typed<T>(&self) -> &Py<PyTupleTyped<T>> {
+    pub fn empty_tuple_typed<T>(&self) -> &Py<PyTuple<T>> {
         let py: &Py<PyTuple> = &self.empty_tuple;
         unsafe { std::mem::transmute(py) }
     }

--- a/vm/src/vm/mod.rs
+++ b/vm/src/vm/mod.rs
@@ -599,7 +599,7 @@ impl VirtualMachine {
     #[inline]
     pub fn import<'a>(&self, module_name: impl AsPyStr<'a>, level: usize) -> PyResult {
         let module_name = module_name.as_pystr(&self.ctx);
-        let from_list = PyTupleTyped::empty(self);
+        let from_list = self.ctx.empty_tuple_typed();
         self.import_inner(module_name, from_list, level)
     }
 
@@ -609,7 +609,7 @@ impl VirtualMachine {
     pub fn import_from<'a>(
         &self,
         module_name: impl AsPyStr<'a>,
-        from_list: PyTupleTyped<PyStrRef>,
+        from_list: &Py<PyTupleTyped<PyStrRef>>,
         level: usize,
     ) -> PyResult {
         let module_name = module_name.as_pystr(&self.ctx);
@@ -619,7 +619,7 @@ impl VirtualMachine {
     fn import_inner(
         &self,
         module: &Py<PyStr>,
-        from_list: PyTupleTyped<PyStrRef>,
+        from_list: &Py<PyTupleTyped<PyStrRef>>,
         level: usize,
     ) -> PyResult {
         // if the import inputs seem weird, e.g a package import or something, rather than just
@@ -657,7 +657,7 @@ impl VirtualMachine {
                 } else {
                     (None, None)
                 };
-                let from_list = from_list.to_pyobject(self);
+                let from_list: PyObjectRef = from_list.to_owned().into();
                 import_func
                     .call((module.to_owned(), globals, locals, from_list, level), self)
                     .inspect_err(|exc| import::remove_importlib_frames(self, exc))

--- a/vm/src/vm/mod.rs
+++ b/vm/src/vm/mod.rs
@@ -20,10 +20,7 @@ use crate::{
     AsObject, Py, PyObject, PyObjectRef, PyPayload, PyRef, PyResult,
     builtins::{
         PyBaseExceptionRef, PyDictRef, PyInt, PyList, PyModule, PyStr, PyStrInterned, PyStrRef,
-        PyTypeRef,
-        code::PyCode,
-        pystr::AsPyStr,
-        tuple::{PyTuple, PyTupleTyped},
+        PyTypeRef, code::PyCode, pystr::AsPyStr, tuple::PyTuple,
     },
     codecs::CodecsRegistry,
     common::{hash::HashSecret, lock::PyMutex, rc::PyRc},
@@ -609,7 +606,7 @@ impl VirtualMachine {
     pub fn import_from<'a>(
         &self,
         module_name: impl AsPyStr<'a>,
-        from_list: &Py<PyTupleTyped<PyStrRef>>,
+        from_list: &Py<PyTuple<PyStrRef>>,
         level: usize,
     ) -> PyResult {
         let module_name = module_name.as_pystr(&self.ctx);
@@ -619,7 +616,7 @@ impl VirtualMachine {
     fn import_inner(
         &self,
         module: &Py<PyStr>,
-        from_list: &Py<PyTupleTyped<PyStrRef>>,
+        from_list: &Py<PyTuple<PyStrRef>>,
         level: usize,
     ) -> PyResult {
         // if the import inputs seem weird, e.g a package import or something, rather than just


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Improved internal consistency and type safety for tuple handling and closure representation in built-in functions and type objects.
  * Updated several public struct fields and method signatures to use reference-counted tuple types.
  * Enhanced payload type identification and trait requirements for object payloads.
  * Adjusted import-related methods to use references for tuple arguments, improving borrowing semantics.
  * Relaxed trait bounds on generic Python object wrappers for more flexible usage.
  * Simplified traversal trait bounds on internal object representations.
  * Refined error handling in type conversion for Python references.
  * Added utility method to obtain an empty typed tuple from the context.
  * Modified generic trait bounds for generated traversal implementations to include necessary constraints on type parameters.
  * Updated function closure handling to use reference-counted typed tuples with safe conversions.
  * Refined typed tuple abstractions to unify internal representations and conversions between typed and untyped tuples.
  * Adjusted import and function execution logic to use typed tuple references instead of owned tuples.

* **New Features**
  * Added a standardized method for retrieving payload type identifiers for Python objects.

* **Style**
  * Refined trait implementations and type parameterization for improved code clarity and maintainability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->