### PR TITLE
Fix invalid args count msg

### DIFF
--- a/Lib/test/test_str.py
+++ b/Lib/test/test_str.py
@@ -2701,6 +2701,8 @@ class StrTest(string_tests.StringLikeTest,
         proc = assert_python_failure('-X', 'dev', '-c', code)
         self.assertEqual(proc.rc, 10, proc)
 
+    # TODO: RUSTPYTHON
+    @unittest.expectedFailure
     def test_str_invalid_call(self):
         # too many args
         with self.assertRaisesRegex(TypeError, r"str expected at most 3 arguments, got 4"):

--- a/Lib/test/test_str.py
+++ b/Lib/test/test_str.py
@@ -2701,8 +2701,6 @@ class StrTest(string_tests.StringLikeTest,
         proc = assert_python_failure('-X', 'dev', '-c', code)
         self.assertEqual(proc.rc, 10, proc)
 
-    # TODO: RUSTPYTHON
-    @unittest.expectedFailure
     def test_str_invalid_call(self):
         # too many args
         with self.assertRaisesRegex(TypeError, r"str expected at most 3 arguments, got 4"):

--- a/derive-impl/src/from_args.rs
+++ b/derive-impl/src/from_args.rs
@@ -180,12 +180,16 @@ fn generate_field((i, field): (usize, &Field)) -> Result<TokenStream> {
 }
 
 pub fn impl_from_args(input: DeriveInput) -> Result<TokenStream> {
-    let fields = match input.data {
-        Data::Struct(syn::DataStruct { fields, .. }) => fields
-            .iter()
-            .enumerate()
-            .map(generate_field)
-            .collect::<Result<TokenStream>>()?,
+    // TODO: Set lower airty bound dynamicly
+    let (fields, arity) = match input.data {
+        Data::Struct(syn::DataStruct { fields, .. }) => (
+            fields
+                .iter()
+                .enumerate()
+                .map(generate_field)
+                .collect::<Result<TokenStream>>()?,
+            fields.len(),
+        ),
         _ => bail_span!(input, "FromArgs input must be a struct"),
     };
 
@@ -193,11 +197,15 @@ pub fn impl_from_args(input: DeriveInput) -> Result<TokenStream> {
     let (impl_generics, ty_generics, where_clause) = input.generics.split_for_impl();
     let output = quote! {
         impl #impl_generics ::rustpython_vm::function::FromArgs for #name #ty_generics #where_clause {
+            fn arity() -> ::std::ops::RangeInclusive<usize> {
+                0..=#arity
+            }
+
             fn from_args(
                 vm: &::rustpython_vm::VirtualMachine,
                 args: &mut ::rustpython_vm::function::FuncArgs
             ) -> ::std::result::Result<Self, ::rustpython_vm::function::ArgumentError> {
-                Ok(#name { #fields })
+                Ok(Self { #fields })
             }
         }
     };

--- a/derive-impl/src/from_args.rs
+++ b/derive-impl/src/from_args.rs
@@ -180,7 +180,7 @@ fn generate_field((i, field): (usize, &Field)) -> Result<TokenStream> {
 }
 
 pub fn impl_from_args(input: DeriveInput) -> Result<TokenStream> {
-    // TODO: Set lower airty bound dynamicly
+    // TODO: Set lower arity bound dynamicly
     let (fields, arity) = match input.data {
         Data::Struct(syn::DataStruct { fields, .. }) => (
             fields

--- a/vm/src/function/argument.rs
+++ b/vm/src/function/argument.rs
@@ -213,7 +213,7 @@ impl FuncArgs {
 
         if !self.args.is_empty() {
             Err(vm.new_type_error(format!(
-                "Expected at most {} arguments ({} given)",
+                "expected at most {} arguments, got {}",
                 T::arity().end(),
                 given_args,
             )))
@@ -263,12 +263,12 @@ impl ArgumentError {
     ) -> PyBaseExceptionRef {
         match self {
             Self::TooFewArgs => vm.new_type_error(format!(
-                "Expected at least {} arguments ({} given)",
+                "expected at least {} arguments, got {}",
                 arity.start(),
                 num_given
             )),
             Self::TooManyArgs => vm.new_type_error(format!(
-                "Expected at most {} arguments ({} given)",
+                "expected at most {} arguments, got {}",
                 arity.end(),
                 num_given
             )),


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an arity method to generated argument parsing implementations, allowing users to query the expected argument count range.

* **Style**
  * Updated error messages for argument count mismatches to use a consistent, lowercase format for improved readability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->