### PR TITLE
Upgrade radium to 1.1.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1958,8 +1958,9 @@ checksum = "74765f6d916ee2faa39bc8e68e4f3ed8949b48cccdac59983d287a7cb71ce9c5"
 
 [[package]]
 name = "radium"
-version = "1.1.0"
-source = "git+https://github.com/youknowone/ferrilab?branch=fix-nightly#4a301c3a223e096626a2773d1a1eed1fc4e21140"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1775bc532a9bfde46e26eba441ca1171b91608d14a3bae71fea371f18a00cffe"
 dependencies = [
  "cfg-if",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -82,7 +82,6 @@ opt-level = 3
 lto = "thin"
 
 [patch.crates-io]
-radium = { version = "1.1.0", git = "https://github.com/youknowone/ferrilab", branch = "fix-nightly" }
 # REDOX START, Uncomment when you want to compile/check with redoxer
 # REDOX END
 
@@ -190,7 +189,7 @@ paste = "1.0.15"
 proc-macro2 = "1.0.93"
 pymath = "0.0.2"
 quote = "1.0.38"
-radium = "1.1"
+radium = "1.1.1"
 rand = "0.9"
 rand_core = { version = "0.9", features = ["os_rng"] }
 rustix = { version = "1.0", features = ["event"] }

--- a/example_projects/barebone/Cargo.toml
+++ b/example_projects/barebone/Cargo.toml
@@ -9,4 +9,3 @@ rustpython-vm = { path = "../../vm", default-features = false }
 [workspace]
 
 [patch.crates-io]
-radium = { version = "1.1.0", git = "https://github.com/youknowone/ferrilab", branch = "fix-nightly" }

--- a/example_projects/frozen_stdlib/Cargo.toml
+++ b/example_projects/frozen_stdlib/Cargo.toml
@@ -11,4 +11,3 @@ rustpython-pylib = { path = "../../pylib", default-features = false, features = 
 [workspace]
 
 [patch.crates-io]
-radium = { version = "1.1.0", git = "https://github.com/youknowone/ferrilab", branch = "fix-nightly" }

--- a/vm/src/vm/mod.rs
+++ b/vm/src/vm/mod.rs
@@ -14,8 +14,6 @@ mod vm_new;
 mod vm_object;
 mod vm_ops;
 
-#[cfg(not(feature = "stdio"))]
-use crate::builtins::PyNone;
 use crate::{
     AsObject, Py, PyObject, PyObjectRef, PyPayload, PyRef, PyResult,
     builtins::{
@@ -337,7 +335,8 @@ impl VirtualMachine {
                     Ok(stdio)
                 };
                 #[cfg(not(feature = "stdio"))]
-                let make_stdio = |_name, _fd, _write| Ok(PyNone.into_pyobject(self));
+                let make_stdio =
+                    |_name, _fd, _write| Ok(crate::builtins::PyNone.into_pyobject(self));
 
                 let set_stdio = |name, fd, write| {
                     let stdio = make_stdio(name, fd, write)?;

--- a/wasm/wasm-unknown-test/Cargo.toml
+++ b/wasm/wasm-unknown-test/Cargo.toml
@@ -13,4 +13,3 @@ rustpython-vm = { path = "../../vm", default-features = false, features = ["comp
 [workspace]
 
 [patch.crates-io]
-radium = { version = "1.1.0", git = "https://github.com/youknowone/ferrilab", branch = "fix-nightly" }


### PR DESCRIPTION
Fix #5768

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated the `radium` dependency to version 1.1.1 from the official source.
  * Removed custom overrides for the `radium` crate in multiple project configurations, ensuring all projects now use the standard published version.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->