### PR TITLE
Correctly handle `None` for protocol in `adapt(..)`

### DIFF
--- a/Lib/test/test_sqlite3/test_types.py
+++ b/Lib/test/test_sqlite3/test_types.py
@@ -433,8 +433,6 @@ class ObjectAdaptationTests(unittest.TestCase):
         with self.assertRaises(sqlite.ProgrammingError):
             sqlite.adapt(1.)  # No float adapter registered
 
-    # TODO: RUSTPYTHON
-    @unittest.expectedFailure
     def test_missing_protocol(self):
         with self.assertRaises(sqlite.ProgrammingError):
             sqlite.adapt(1, None)

--- a/stdlib/src/sqlite.rs
+++ b/stdlib/src/sqlite.rs
@@ -732,7 +732,14 @@ mod _sqlite {
         alt: OptionalArg<PyObjectRef>,
         vm: &VirtualMachine,
     ) -> PyResult {
-        // TODO: None proto
+        if matches!(proto, OptionalArg::Present(None)) {
+            return if let OptionalArg::Present(alt) = alt {
+                Ok(alt)
+            } else {
+                Err(new_programming_error(vm, "can't adapt".to_owned()))
+            };
+        }
+
         let proto = proto
             .flatten()
             .unwrap_or_else(|| PrepareProtocol::class(&vm.ctx).to_owned());


### PR DESCRIPTION
ref

- https://github.com/python/cpython/blob/be02e68158aee4d70f15baa1d8329df2c35a57f2/Modules/_sqlite/microprotocols.c#L73-L143