### PR TITLE
Fix off-by-one error in SQL length limit check

### DIFF
--- a/Lib/test/test_sqlite3/test_regression.py
+++ b/Lib/test/test_sqlite3/test_regression.py
@@ -351,8 +351,6 @@ class RegressionTests(unittest.TestCase):
         self.assertRaises(UnicodeEncodeError, cur.execute, "select '\ud8ff'")
         self.assertRaises(UnicodeEncodeError, cur.execute, "select '\udcff'")
 
-    # TODO: RUSTPYTHON
-    @unittest.expectedFailure
     def test_large_sql(self):
         msg = "query string is too large"
         with memory_database() as cx, cx_limit(cx) as lim:

--- a/stdlib/src/sqlite.rs
+++ b/stdlib/src/sqlite.rs
@@ -2296,11 +2296,10 @@ mod _sqlite {
         ) -> PyResult<Option<Self>> {
             let sql = sql.try_into_utf8(vm)?;
             let sql_cstr = sql.to_cstring(vm)?;
-            let sql_len = sql.byte_len() + 1;
 
             let db = connection.db_lock(vm)?;
 
-            db.sql_limit(sql_len, vm)?;
+            db.sql_limit(sql.byte_len(), vm)?;
 
             let mut tail = null();
             let st = db.prepare(sql_cstr.as_ptr(), &mut tail, vm)?;


### PR DESCRIPTION
ref

- https://github.com/python/cpython/blob/be02e68158aee4d70f15baa1d8329df2c35a57f2/Modules/_sqlite/statement.c#L45-L50
- https://github.com/ever0de/RustPython/blob/cb61d5a5eddab33761a457e865c8aa7e8ad4d564/stdlib/src/sqlite.rs#L2460-L2467

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved accuracy of SQL query length validation when preparing statements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->