### PR TITLE
Correctly implement `isolation_level` setter to handle deletion

### DIFF
--- a/Lib/test/test_sqlite3/test_regression.py
+++ b/Lib/test/test_sqlite3/test_regression.py
@@ -413,8 +413,6 @@ class RegressionTests(unittest.TestCase):
         del ref
         support.gc_collect()
 
-    # TODO: RUSTPYTHON
-    @unittest.expectedFailure
     def test_del_isolation_level_segfault(self):
         with self.assertRaises(AttributeError):
             del self.con.isolation_level

--- a/stdlib/src/sqlite.rs
+++ b/stdlib/src/sqlite.rs
@@ -61,6 +61,7 @@ mod _sqlite {
             PyInt, PyIntRef, PySlice, PyStr, PyStrRef, PyTuple, PyTupleRef, PyType, PyTypeRef,
         },
         convert::IntoObject,
+        function::PySetterValue,
         function::{ArgCallable, ArgIterable, FsPath, FuncArgs, OptionalArg, PyComparisonValue},
         object::{Traverse, TraverseFn},
         protocol::{PyBuffer, PyIterReturn, PyMappingMethods, PySequence, PySequenceMethods},
@@ -1350,22 +1351,34 @@ mod _sqlite {
             self.isolation_level.deref().map(|x| x.to_owned())
         }
         #[pygetset(setter)]
-        fn set_isolation_level(&self, val: Option<PyStrRef>, vm: &VirtualMachine) -> PyResult<()> {
-            if let Some(val) = &val {
-                begin_statement_ptr_from_isolation_level(val, vm)?;
-            }
+        fn set_isolation_level(&self, value: PySetterValue, vm: &VirtualMachine) -> PyResult<()> {
+            match value {
+                PySetterValue::Assign(new_value) => {
+                    let val = if vm.is_none(&new_value) {
+                        None
+                    } else {
+                        Some(new_value.try_into_value::<PyStrRef>(vm)?)
+                    };
 
-            // If setting isolation_level to None (auto-commit mode), commit any pending transaction
-            if val.is_none() {
-                let db = self.db_lock(vm)?;
-                if !db.is_autocommit() {
-                    // Keep the lock and call implicit_commit directly to avoid race conditions
-                    db.implicit_commit(vm)?;
+                    if let Some(val_str) = &val {
+                        begin_statement_ptr_from_isolation_level(val_str, vm)?;
+                    }
+
+                    // If setting isolation_level to None (auto-commit mode), commit any pending transaction
+                    if val.is_none() {
+                        let db = self.db_lock(vm)?;
+                        if !db.is_autocommit() {
+                            // Keep the lock and call implicit_commit directly to avoid race conditions
+                            db.implicit_commit(vm)?;
+                        }
+                    }
+                    let _ = unsafe { self.isolation_level.swap(val) };
+                    Ok(())
                 }
+                PySetterValue::Delete => Err(vm.new_attribute_error(
+                    "'isolation_level' attribute cannot be deleted".to_owned(),
+                )),
             }
-
-            let _ = unsafe { self.isolation_level.swap(val) };
-            Ok(())
         }
 
         #[pygetset]


### PR DESCRIPTION
ref

- https://github.com/python/cpython/blob/7689407fa4406ab79d7e9e02363f50be4ec35b5e/Modules/_sqlite/connection.c#L1781-L1806

I noticed CPython's error message is just "cannot delete attribute". I made mine more informative (...'isolation_level' attribute...). Should I change it to match CPython for exact compatibility?