### PR TITLE
Implement properties on `_TextIOBase` and `StringIO`

### DIFF
--- a/Lib/test/test_memoryio.py
+++ b/Lib/test/test_memoryio.py
@@ -940,8 +940,6 @@ class CStringIOTest(PyStringIOTest):
     def test_seek(self):
         super().test_seek()
 
-    # TODO: RUSTPYTHON
-    @unittest.expectedFailure
     def test_textio_properties(self):
         super().test_textio_properties()
 
@@ -1046,8 +1044,6 @@ class CStringIOPickleTest(PyStringIOPickleTest):
     def test_relative_seek(self):
         super().test_relative_seek()
 
-    # TODO: RUSTPYTHON
-    @unittest.expectedFailure
     def test_textio_properties(self):
         super().test_textio_properties()
 

--- a/vm/src/stdlib/io.rs
+++ b/vm/src/stdlib/io.rs
@@ -743,11 +743,6 @@ mod _io {
         fn errors(_zelf: PyObjectRef, vm: &VirtualMachine) -> PyObjectRef {
             vm.ctx.none()
         }
-
-        #[pygetset]
-        fn line_buffering(_zelf: PyObjectRef) -> bool {
-            false
-        }
     }
 
     #[derive(FromArgs, Clone)]
@@ -3603,6 +3598,11 @@ mod _io {
             let mut buffer = self.buffer(vm)?;
             let pos = pos.try_usize(vm)?;
             Ok(buffer.truncate(pos))
+        }
+
+        #[pygetset]
+        fn line_buffering(&self) -> bool {
+            false
         }
     }
 

--- a/vm/src/stdlib/io.rs
+++ b/vm/src/stdlib/io.rs
@@ -738,6 +738,16 @@ mod _io {
         fn encoding(_zelf: PyObjectRef, vm: &VirtualMachine) -> PyObjectRef {
             vm.ctx.none()
         }
+
+        #[pygetset]
+        fn errors(_zelf: PyObjectRef, vm: &VirtualMachine) -> PyObjectRef {
+            vm.ctx.none()
+        }
+
+        #[pygetset]
+        fn line_buffering(_zelf: PyObjectRef) -> bool {
+            false
+        }
     }
 
     #[derive(FromArgs, Clone)]


### PR DESCRIPTION

ref
- https://github.com/python/cpython/blob/ef053a92d5552bb082bbe1fe7fcaab020cbe6f99/Modules/_io/stringio.c#L959-L965
- https://github.com/python/cpython/blob/ef053a92d5552bb082bbe1fe7fcaab020cbe6f99/Modules/_io/textio.c#L164-L168

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `errors` and `line_buffering` properties to text I/O objects, providing default attribute access for improved compatibility.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->