### PR TITLE
CI: Increase windows timeout from 40 -> 45

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -113,7 +113,7 @@ jobs:
       RUST_BACKTRACE: full
     name: Run rust tests
     runs-on:  ${{ matrix.os }}
-    timeout-minutes: ${{ contains(matrix.os, 'windows') && 40 || 30 }}
+    timeout-minutes: ${{ contains(matrix.os, 'windows') && 45 || 30 }}
     strategy:
       matrix:
         os: [macos-latest, ubuntu-latest, windows-latest]
@@ -239,7 +239,7 @@ jobs:
       RUST_BACKTRACE: full
     name: Run snippets and cpython tests
     runs-on:  ${{ matrix.os }}
-    timeout-minutes: ${{ contains(matrix.os, 'windows') && 40 || 30 }}
+    timeout-minutes: ${{ contains(matrix.os, 'windows') && 45 || 30 }}
     strategy:
       matrix:
         os: [macos-latest, ubuntu-latest, windows-latest]


### PR DESCRIPTION
Motivation: https://github.com/RustPython/RustPython/actions/runs/16317658934/job/46087349628?pr=5988 failed during the `checking that whatsleft.py is not broken` stage (due to timeout) and was running normally

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Increased timeout for Windows test jobs in the CI workflow to improve reliability during longer test runs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->