### PR TITLE
Align SQL comment parsing with CPython

### DIFF
--- a/Lib/test/test_sqlite3/test_dbapi.py
+++ b/Lib/test/test_sqlite3/test_dbapi.py
@@ -769,8 +769,6 @@ class CursorTests(unittest.TestCase):
         with self.assertRaises(sqlite.OperationalError):
             self.cu.execute("select asdf")
 
-    # TODO: RUSTPYTHON
-    @unittest.expectedFailure
     def test_execute_multiple_statements(self):
         msg = "You can only execute one statement at a time"
         dataset = (
@@ -793,8 +791,6 @@ class CursorTests(unittest.TestCase):
                 with self.assertRaisesRegex(sqlite.ProgrammingError, msg):
                     self.cu.execute(query)
 
-    # TODO: RUSTPYTHON
-    @unittest.expectedFailure
     def test_execute_with_appended_comments(self):
         dataset = (
             "select 1; -- foo bar",
@@ -963,8 +959,6 @@ class CursorTests(unittest.TestCase):
         self.assertEqual(self.cu.fetchone()[0], 1)
         self.assertEqual(self.cu.rowcount, 1)
 
-    # TODO: RUSTPYTHON
-    @unittest.expectedFailure
     def test_rowcount_prefixed_with_comment(self):
         # gh-79579: rowcount is updated even if query is prefixed with comments
         self.cu.execute("""

--- a/stdlib/src/sqlite.rs
+++ b/stdlib/src/sqlite.rs
@@ -3068,36 +3068,52 @@ mod _sqlite {
     }
 
     fn lstrip_sql(sql: &[u8]) -> Option<&[u8]> {
-        let mut pos = sql;
-        loop {
-            match pos.first()? {
+        let mut pos = 0;
+
+        // This loop is borrowed from the SQLite source code.
+        while let Some(t_char) = sql.get(pos) {
+            match t_char {
                 b' ' | b'\t' | b'\x0c' | b'\n' | b'\r' => {
-                    pos = &pos[1..];
+                    // Skip whitespace.
+                    pos += 1;
                 }
                 b'-' => {
-                    if *pos.get(1)? == b'-' {
-                        // line comments
-                        pos = &pos[2..];
-                        while *pos.first()? != b'\n' {
-                            pos = &pos[1..];
+                    // Skip line comments.
+                    if sql.get(pos + 1) == Some(&b'-') {
+                        pos += 2;
+                        while let Some(&ch) = sql.get(pos) {
+                            if ch == b'\n' {
+                                break;
+                            }
+                            pos += 1;
                         }
+                        let _ = sql.get(pos)?;
                     } else {
-                        return Some(pos);
+                        return Some(&sql[pos..]);
                     }
                 }
                 b'/' => {
-                    if *pos.get(1)? == b'*' {
-                        // c style comments
-                        pos = &pos[2..];
-                        while *pos.first()? != b'*' || *pos.get(1)? != b'/' {
-                            pos = &pos[1..];
+                    // Skip C style comments.
+                    if sql.get(pos + 1) == Some(&b'*') {
+                        pos += 2;
+                        while let Some(&ch) = sql.get(pos) {
+                            if ch == b'*' && sql.get(pos + 1) == Some(&b'/') {
+                                break;
+                            }
+                            pos += 1;
                         }
+                        let _ = sql.get(pos)?;
+                        pos += 2;
                     } else {
-                        return Some(pos);
+                        return Some(&sql[pos..]);
                     }
                 }
-                _ => return Some(pos),
+                _ => {
+                    return Some(&sql[pos..]);
+                }
             }
         }
+
+        None
     }
 }


### PR DESCRIPTION
Reference

- <https://github.com/python/cpython/blob/ef053a92d5552bb082bbe1fe7fcaab020cbe6f99/Modules/_sqlite/statement.c#L133-L179>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved the internal handling of whitespace and comment skipping for SQL input, resulting in more robust and maintainable processing. No changes to user-facing features or interfaces.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->