### PR TITLE
Enable bad bytecode tests for PEP451 loaders

### DIFF
--- a/Lib/test/test_importlib/source/test_file_loader.py
+++ b/Lib/test/test_importlib/source/test_file_loader.py
@@ -672,10 +672,9 @@ class SourceLoaderBadBytecodeTest:
                 os.chmod(bytecode_path, stat.S_IWUSR)
 
 
-# TODO: RUSTPYTHON
-# class SourceLoaderBadBytecodeTestPEP451(
-#         SourceLoaderBadBytecodeTest, BadBytecodeTestPEP451):
-#     pass
+class SourceLoaderBadBytecodeTestPEP451(
+        SourceLoaderBadBytecodeTest, BadBytecodeTestPEP451):
+    pass
 
 
 # (Frozen_SourceBadBytecodePEP451,
@@ -772,10 +771,9 @@ class SourcelessLoaderBadBytecodeTest:
         self._test_non_code_marshal(del_source=True)
 
 
-# TODO: RUSTPYTHON
-# class SourcelessLoaderBadBytecodeTestPEP451(SourcelessLoaderBadBytecodeTest,
-#         BadBytecodeTestPEP451):
-#     pass
+class SourcelessLoaderBadBytecodeTestPEP451(SourcelessLoaderBadBytecodeTest,
+        BadBytecodeTestPEP451):
+    pass
 
 
 # (Frozen_SourcelessBadBytecodePEP451,


### PR DESCRIPTION
reference

- pep451: https://peps.python.org/pep-0451/#attributes
- magic number: https://github.com/ever0de/RustPython/blob/b25fcefe75a826846ef64879ceac87de31e5ec64/vm/src/import.rs#L46-L56

