### PR TITLE
Raise UnicodeEncodeError for surrogates in sqlite.executescript

### DIFF
--- a/Lib/test/test_sqlite3/test_dbapi.py
+++ b/Lib/test/test_sqlite3/test_dbapi.py
@@ -1655,8 +1655,6 @@ class ExtensionTests(unittest.TestCase):
                 insert into a(i) values (5);
                 """)
 
-    # TODO: RUSTPYTHON
-    @unittest.expectedFailure
     def test_cursor_executescript_with_surrogates(self):
         con = sqlite.connect(":memory:")
         cur = con.cursor()

--- a/stdlib/src/sqlite.rs
+++ b/stdlib/src/sqlite.rs
@@ -1640,6 +1640,8 @@ mod _sqlite {
             script: PyStrRef,
             vm: &VirtualMachine,
         ) -> PyResult<PyRef<Self>> {
+            script.ensure_valid_utf8(vm)?;
+
             let db = zelf.connection.db_lock(vm)?;
 
             db.sql_limit(script.byte_len(), vm)?;


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved script execution reliability by validating that scripts are valid UTF-8 before execution. Users will now receive an error if an invalid UTF-8 script is provided.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->