### PR TITLE
Resolve `libc::RLIM_NLIMITS` warning on android

### DIFF
--- a/stdlib/src/resource.rs
+++ b/stdlib/src/resource.rs
@@ -14,7 +14,8 @@ mod resource {
 
     cfg_if::cfg_if! {
         if #[cfg(target_os = "android")] {
-            use libc::RLIM_NLIMITS;
+            #[expect(warnings)]
+            const RLIM_NLIMITS: i32 = libc::RLIM_NLIMITS;
         } else {
             // This constant isn't abi-stable across os versions, so we just
             // pick a high number so we don't get false positive ValueErrors and just bubble up the

--- a/stdlib/src/resource.rs
+++ b/stdlib/src/resource.rs
@@ -14,7 +14,7 @@ mod resource {
 
     cfg_if::cfg_if! {
         if #[cfg(target_os = "android")] {
-            #[expect(warnings)]
+            #[expect(deprecated)]
             const RLIM_NLIMITS: i32 = libc::RLIM_NLIMITS;
         } else {
             // This constant isn't abi-stable across os versions, so we just


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Improved internal handling of system constants for Android, with no impact on user-facing functionality.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->