### PR TITLE
stdlib(sqlite3): Raise ProgrammingError for missing named parameter

### DIFF
--- a/Lib/test/test_sqlite3/test_dbapi.py
+++ b/Lib/test/test_sqlite3/test_dbapi.py
@@ -908,8 +908,6 @@ class CursorTests(unittest.TestCase):
         row = self.cu.fetchone()
         self.assertEqual(row[0], "foo")
 
-    # TODO: RUSTPYTHON
-    @unittest.expectedFailure
     def test_execute_dict_mapping_too_little_args(self):
         self.cu.execute("insert into test(name) values ('foo')")
         with self.assertRaises(sqlite.ProgrammingError):

--- a/stdlib/src/sqlite.rs
+++ b/stdlib/src/sqlite.rs
@@ -2725,7 +2725,18 @@ mod _sqlite {
                 let name = unsafe { name.add(1) };
                 let name = ptr_to_str(name, vm)?;
 
-                let val = dict.get_item(name, vm)?;
+                let val = match dict.get_item_opt(name, vm)? {
+                    Some(val) => val,
+                    None => {
+                        return Err(new_programming_error(
+                            vm,
+                            format!(
+                                "You did not supply a value for binding parameter :{}.",
+                                name
+                            ),
+                        ));
+                    }
+                };
 
                 self.bind_parameter(i, &val, vm)?;
             }


### PR DESCRIPTION
ref 

- https://github.com/python/cpython/blob/f66c75f11d3aeeb614600251fd5d3fe1a34b5ff1/Modules/_sqlite/cursor.c#L741-L748