### PR TITLE
stdlib(sqlite): Raise ProgrammingError in closed Blob context manager

### DIFF
--- a/Lib/test/test_sqlite3/test_dbapi.py
+++ b/Lib/test/test_sqlite3/test_dbapi.py
@@ -1452,8 +1452,6 @@ class BlobTests(unittest.TestCase):
                 raise DummyException("reraised")
 
 
-    # TODO: RUSTPYTHON
-    @unittest.expectedFailure
     def test_blob_closed(self):
         with memory_database() as cx:
             cx.execute("create table test(b blob)")

--- a/stdlib/src/sqlite.rs
+++ b/stdlib/src/sqlite.rs
@@ -2145,13 +2145,16 @@ mod _sqlite {
         }
 
         #[pymethod]
-        fn __enter__(zelf: PyRef<Self>) -> PyRef<Self> {
-            zelf
+        fn __enter__(zelf: PyRef<Self>, vm: &VirtualMachine) -> PyResult<PyRef<Self>> {
+            let _ = zelf.inner(vm)?;
+            Ok(zelf)
         }
 
         #[pymethod]
-        fn __exit__(&self, _args: FuncArgs) {
-            self.close()
+        fn __exit__(&self, _args: FuncArgs, vm: &VirtualMachine) -> PyResult<()> {
+            let _ = self.inner(vm)?;
+            self.close();
+            Ok(())
         }
 
         fn inner(&self, vm: &VirtualMachine) -> PyResult<PyMappedMutexGuard<'_, BlobInner>> {


### PR DESCRIPTION
ref

- https://github.com/python/cpython/blob/ae8b7d710020dfd336edd399fa35525dfe8fc049/Modules/_sqlite/blob.c#L367-L377
- https://github.com/python/cpython/blob/ae8b7d710020dfd336edd399fa35525dfe8fc049/Modules/_sqlite/blob.c#L345-L353
- https://github.com/python/cpython/blob/ae8b7d710020dfd336edd399fa35525dfe8fc049/Modules/_sqlite/blob.c#L67-L81

Right now I'm discarding the return value of inner(). Should I extract this check into a separate helper function, like ensure_inner(), that just validates the state?

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling when using blobs as context managers, ensuring proper resource management and error reporting during entry and exit.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->