### PR TITLE
Add Default derive to GroupByState and use default initialization

### DIFF
--- a/vm/src/stdlib/itertools.rs
+++ b/vm/src/stdlib/itertools.rs
@@ -666,6 +666,7 @@ mod decl {
         }
     }
 
+    #[derive(Default)]
     struct GroupByState {
         current_value: Option<PyObjectRef>,
         current_key: Option<PyObjectRef>,
@@ -729,12 +730,7 @@ mod decl {
             Self {
                 iterable,
                 key_func: key.flatten(),
-                state: PyMutex::new(GroupByState {
-                    current_key: None,
-                    current_value: None,
-                    next_group: false,
-                    grouper: None,
-                }),
+                state: PyMutex::new(GroupByState::default()),
             }
             .into_ref_with_type(vm, cls)
             .map(Into::into)


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved internal initialization of group-by functionality for better maintainability. No changes to user-facing behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->