### PR TITLE
Prevent direct instantiation of `sqlite3.{Statement,Blob}`

### DIFF
--- a/Lib/test/test_sqlite3/test_dbapi.py
+++ b/Lib/test/test_sqlite3/test_dbapi.py
@@ -346,8 +346,6 @@ class ModuleTests(unittest.TestCase):
                              sqlite.SQLITE_CONSTRAINT_CHECK)
             self.assertEqual(exc.sqlite_errorname, "SQLITE_CONSTRAINT_CHECK")
 
-    # TODO: RUSTPYTHON
-    @unittest.expectedFailure
     def test_disallow_instantiation(self):
         cx = sqlite.connect(":memory:")
         check_disallow_instantiation(self, type(cx("select 1")))

--- a/stdlib/src/sqlite.rs
+++ b/stdlib/src/sqlite.rs
@@ -2036,12 +2036,20 @@ mod _sqlite {
     }
 
     #[pyattr]
-    #[pyclass(name, traverse)]
+    #[pyclass(module = "sqlite3", name = "Blob", traverse)]
     #[derive(Debug, PyPayload)]
     struct Blob {
         connection: PyRef<Connection>,
         #[pytraverse(skip)]
         inner: PyMutex<Option<BlobInner>>,
+    }
+
+    impl Constructor for Blob {
+        type Args = FuncArgs;
+
+        fn py_new(_cls: PyTypeRef, _args: Self::Args, vm: &VirtualMachine) -> PyResult {
+            Err(vm.new_type_error("cannot create 'sqlite3.Blob' instances"))
+        }
     }
 
     #[derive(Debug)]
@@ -2056,7 +2064,7 @@ mod _sqlite {
         }
     }
 
-    #[pyclass(with(AsMapping))]
+    #[pyclass(with(AsMapping, Constructor))]
     impl Blob {
         #[pymethod]
         fn close(&self) {
@@ -2356,7 +2364,7 @@ mod _sqlite {
     impl PrepareProtocol {}
 
     #[pyattr]
-    #[pyclass(name)]
+    #[pyclass(module = "sqlite3", name = "Statement")]
     #[derive(PyPayload)]
     struct Statement {
         st: PyMutex<SqliteStatement>,
@@ -2373,7 +2381,15 @@ mod _sqlite {
         }
     }
 
-    #[pyclass()]
+    impl Constructor for Statement {
+        type Args = FuncArgs;
+
+        fn py_new(_cls: PyTypeRef, _args: Self::Args, vm: &VirtualMachine) -> PyResult {
+            Err(vm.new_type_error("cannot create 'sqlite3.Statement' instances"))
+        }
+    }
+
+    #[pyclass(with(Constructor))]
     impl Statement {
         fn new(
             connection: &Connection,

--- a/stdlib/src/sqlite.rs
+++ b/stdlib/src/sqlite.rs
@@ -71,7 +71,7 @@ mod _sqlite {
         sliceable::{SaturatedSliceIter, SliceableSequenceOp},
         types::{
             AsMapping, AsSequence, Callable, Comparable, Constructor, Hashable, IterNext, Iterable,
-            PyComparisonOp, SelfIter,
+            PyComparisonOp, SelfIter, Unconstructible,
         },
         utils::ToCString,
     };
@@ -2044,13 +2044,7 @@ mod _sqlite {
         inner: PyMutex<Option<BlobInner>>,
     }
 
-    impl Constructor for Blob {
-        type Args = FuncArgs;
-
-        fn py_new(_cls: PyTypeRef, _args: Self::Args, vm: &VirtualMachine) -> PyResult {
-            Err(vm.new_type_error("cannot create 'sqlite3.Blob' instances"))
-        }
-    }
+    impl Unconstructible for Blob {}
 
     #[derive(Debug)]
     struct BlobInner {
@@ -2064,7 +2058,7 @@ mod _sqlite {
         }
     }
 
-    #[pyclass(with(AsMapping, Constructor))]
+    #[pyclass(with(AsMapping, Unconstructible))]
     impl Blob {
         #[pymethod]
         fn close(&self) {
@@ -2381,15 +2375,9 @@ mod _sqlite {
         }
     }
 
-    impl Constructor for Statement {
-        type Args = FuncArgs;
+    impl Unconstructible for Statement {}
 
-        fn py_new(_cls: PyTypeRef, _args: Self::Args, vm: &VirtualMachine) -> PyResult {
-            Err(vm.new_type_error("cannot create 'sqlite3.Statement' instances"))
-        }
-    }
-
-    #[pyclass(with(Constructor))]
+    #[pyclass(with(Unconstructible))]
     impl Statement {
         fn new(
             connection: &Connection,

--- a/vm/src/types/slot.rs
+++ b/vm/src/types/slot.rs
@@ -802,7 +802,7 @@ pub trait DefaultConstructor: PyPayload + Default {
 pub trait Unconstructible: PyPayload {
     #[pyslot]
     fn slot_new(cls: PyTypeRef, _args: FuncArgs, vm: &VirtualMachine) -> PyResult {
-        Err(vm.new_type_error(format!("cannot create {} instances", cls.slot_name())))
+        Err(vm.new_type_error(format!("cannot create '{}' instances", cls.slot_name())))
     }
 }
 


### PR DESCRIPTION
ref 

- https://github.com/python/cpython/blob/f66c75f11d3aeeb614600251fd5d3fe1a34b5ff1/Modules/_sqlite/statement.c#L191
- `Py_TPFLAGS_DISALLOW_INSTANTIATION`
- https://github.com/python/cpython/blob/f66c75f11d3aeeb614600251fd5d3fe1a34b5ff1/Objects/typeobject.c#L1661-L1665


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented direct creation of `Blob` and `Statement` objects in the sqlite3 module from Python, ensuring a clear error is raised if attempted.
  * Improved error messages by adding quotes around class names when instantiation is disallowed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->