### PR TITLE
Renewd DictUpdate instruction

### DIFF
--- a/compiler/codegen/src/compile.rs
+++ b/compiler/codegen/src/compile.rs
@@ -4398,7 +4398,7 @@ impl Compiler {
 
         for item in unpacked {
             self.compile_expression(&item.value)?;
-            emit!(self, Instruction::DictUpdate);
+            emit!(self, Instruction::DictUpdate { index: 1 });
         }
 
         Ok(())

--- a/compiler/core/src/bytecode.rs
+++ b/compiler/core/src/bytecode.rs
@@ -667,7 +667,9 @@ pub enum Instruction {
     BuildMapForCall {
         size: Arg<u32>,
     },
-    DictUpdate,
+    DictUpdate {
+        index: Arg<u32>,
+    },
     BuildSlice {
         /// whether build a slice with a third step argument
         step: Arg<bool>,
@@ -1397,7 +1399,7 @@ impl Instruction {
                 let nargs = size.get(arg);
                 -(nargs as i32) + 1
             }
-            DictUpdate => -1,
+            DictUpdate { .. } => -1,
             BuildSlice { step } => -2 - (step.get(arg) as i32) + 1,
             ListAppend { .. } | SetAdd { .. } => -1,
             MapAdd { .. } => -2,
@@ -1586,7 +1588,7 @@ impl Instruction {
             BuildSetFromTuples { size } => w!(BuildSetFromTuples, size),
             BuildMap { size } => w!(BuildMap, size),
             BuildMapForCall { size } => w!(BuildMapForCall, size),
-            DictUpdate => w!(DictUpdate),
+            DictUpdate { index } => w!(DictUpdate, index),
             BuildSlice { step } => w!(BuildSlice, step),
             ListAppend { i } => w!(ListAppend, i),
             SetAdd { i } => w!(SetAdd, i),


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * The dictionary update operation now supports specifying which dictionary on the stack to update using an index argument, enabling more flexible updates.

* **Bug Fixes**
  * Improved handling of dictionary updates to ensure correct merging of mappings based on the provided index.

* **Refactor**
  * Updated the internal structure of the dictionary update instruction to include an index parameter for consistency and clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->