### PR TITLE
Add sorted.py to microbenchmarks

### DIFF
--- a/benches/README.md
+++ b/benches/README.md
@@ -18,7 +18,7 @@ To view Python tracebacks during benchmarks, run `RUST_BACKTRACE=1 cargo bench`.
 specific installed Python version by running:
 
 ```shell
-PYTHON_SYS_EXECUTABLE=python3.7 cargo bench
+PYTHON_SYS_EXECUTABLE=python3.13 cargo bench
 ```
 
 ### Adding a benchmark

--- a/benches/README.md
+++ b/benches/README.md
@@ -4,19 +4,26 @@ These are some files to determine performance of rustpython.
 
 ## Usage
 
-Running `cargo bench` from the root of the repository will start the benchmarks. Once done there will be a graphical 
+Running `cargo bench` from the root of the repository will start the benchmarks. Once done there will be a graphical
 report under `target/criterion/report/index.html` that you can use use to view the results.
 
-To view Python tracebacks during benchmarks, run `RUST_BACKTRACE=1 cargo bench`. You can also bench against a 
+`cargo bench` supports name matching to run a subset of the benchmarks. To
+run only the sorted microbenchmark, you can run:
+
+```shell
+cargo bench sorted
+```
+
+To view Python tracebacks during benchmarks, run `RUST_BACKTRACE=1 cargo bench`. You can also bench against a
 specific installed Python version by running:
 
 ```shell
-$ PYTHON_SYS_EXECUTABLE=python3.7 cargo bench
+PYTHON_SYS_EXECUTABLE=python3.7 cargo bench
 ```
 
 ### Adding a benchmark
 
-Simply adding a file to the `benchmarks/` directory will add it to the set of files benchmarked. Each file is tested 
+Simply adding a file to the `benchmarks/` directory will add it to the set of files benchmarked. Each file is tested
 in two ways:
 
 1. The time to parse the file to AST
@@ -24,8 +31,9 @@ in two ways:
 
 ### Adding a micro benchmark
 
-Micro benchmarks are small snippets of code added under the `microbenchmarks/` directory. A microbenchmark file has 
+Micro benchmarks are small snippets of code added under the `microbenchmarks/` directory. A microbenchmark file has
 two sections:
+
 1. Optional setup code
 2. The code to be benchmarked
 
@@ -39,8 +47,8 @@ a_list = [1,2,3]
 len(a_list)
 ```
 
-Only `len(a_list)` will be timed. Setup or benchmarked code can optionally reference a variable called `ITERATIONS`. If 
-present then the benchmark code will be invoked 5 times with `ITERATIONS` set to a value between 100 and 1,000. For 
+Only `len(a_list)` will be timed. Setup or benchmarked code can optionally reference a variable called `ITERATIONS`. If
+present then the benchmark code will be invoked 5 times with `ITERATIONS` set to a value between 100 and 1,000. For
 example:
 
 ```python
@@ -49,7 +57,7 @@ obj = [i for i in range(ITERATIONS)]
 
 `ITERATIONS` can appear in both the setup code and the benchmark code.
 
-## MacOS setup 
+## MacOS setup
 
 On MacOS you will need to add the following to a `.cargo/config` file:
 
@@ -63,4 +71,4 @@ rustflags = [
 
 ## Benchmark source
 
-- https://benchmarksgame-team.pages.debian.net/benchmarksgame/program/nbody-python3-2.html
+- <https://benchmarksgame-team.pages.debian.net/benchmarksgame/program/nbody-python3-2.html>

--- a/benches/microbenchmarks/sorted.py
+++ b/benches/microbenchmarks/sorted.py
@@ -1,0 +1,9 @@
+from random import random, seed
+seed(0)
+
+unsorted_list = [random() for _ in range(5 * ITERATIONS)]
+
+# ---
+
+# Setup code only runs once so do not modify in-place
+sorted(unsorted_list)


### PR DESCRIPTION
# Description

- Adds a new microbenchmark for `sorted` (and by extension `sort`) builtin functions
- Documents how to run individual benchmarks to the relevant README.

I chose `5 * ITERATIONS` to better show the divergence between the sort implementations, while trying to avoid individual microbenchmark runs timing out.

## Sample benchmark results

**Violin plot**
<img width="1058" height="467" alt="image" src="https://github.com/user-attachments/assets/66a65dff-208a-431d-b458-b148fe784e98" />


**Line Chart**
<img width="1058" height="601" alt="image" src="https://github.com/user-attachments/assets/730a1713-fa13-4f22-baa5-6ef9c007ee51" />

## Manually benchmark

Using larger list sizes really shows the difference. Sorting 1_000_000 random numbers:
- CPython => 0.3 seconds
- RustPython => ~17 minutes

```shell
✦ ❯ time python -c "from random import random; sorted([random() for i in range(1_000_000)]); print('DONE');"
DONE

real    0m0.309s
user    0m0.274s
sys    0m0.036s

✦ ❯ time cargo run --release -- -c "from random import random; sorted([random() for i in range(1_000_000)]); print('DONE');"
    Finished `release` profile [optimized] target(s) in 0.16s
     Running `target/release/rustpython -c 'from random import random; sorted([random() for i in range(1_000_000)]); print('\''DONE'\'');'`
DONE

real    16m52.217s
user    16m51.926s
sys    0m0.174s
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Tests**
  - Added a deterministic Python microbenchmark for sorting to the benchmark suite.

- **Documentation**
  - Documented running benchmark subsets by name (e.g., run specific benchmarks).
  - Noted that a graphical benchmark report is generated after runs.
  - Updated Python invocation example to use python3.13.
  - Minor wording, header, and formatting refinements in the benchmark README.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->