### PR TITLE
Remove completed TODO

### DIFF
--- a/extra_tests/snippets/syntax_fstring.py
+++ b/extra_tests/snippets/syntax_fstring.py
@@ -54,12 +54,6 @@ assert f"{16:{spec}}{foo}" == '00000+0x10bar'
 part_spec = ">+#10x"
 assert f"{16:0{part_spec}}{foo}" == '00000+0x10bar'
 
-# TODO: RUSTPYTHON, delete the next block once `test_fstring.py` can successfully parse
-assert f'{10:#{1}0x}' == '       0xa'
-assert f'{10:{"#"}1{0}{"x"}}' == '       0xa'
-assert f'{-10:-{"#"}1{0}x}' == '      -0xa'
-assert f'{-10:{"-"}#{1}0{"x"}}' == '      -0xa'
-
 spec = "bla"
 assert_raises(ValueError, lambda: f"{16:{spec}}")
 


### PR DESCRIPTION
I'm not sure about the context when the TODO comment was written, but according to the comment, these lines can be removed because `cargo run -- Lib/test/test_fstring.py` runs successfully.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Streamlined complex formatting scenario tests into a simpler, representative case to improve readability and reduce fragility.
  * Preserved coverage to ensure invalid formatting specifications still raise appropriate errors.
  * Improved stability and maintainability of the test suite; potential reduction in false positives/negatives.
  * No changes to application behavior or features; end users should see no impact.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->