### PR TITLE
[DRAFT] Use Rust's `sort_by` instead of `timsort::try_sort_by_gt`

### DIFF
--- a/vm/src/builtins/list.rs
+++ b/vm/src/builtins/list.rs
@@ -504,8 +504,8 @@ impl Representable for PyList {
     }
 }
 
-use std::cmp::Ordering;
 use crate::exceptions::types::PyBaseExceptionRef;
+use std::cmp::Ordering;
 fn do_sort(
     vm: &VirtualMachine,
     values: &mut Vec<PyObjectRef>,
@@ -520,13 +520,17 @@ fn do_sort(
 
     // If a PyException is encountered stop swapping elements and store the error.
     let mut error_slot: Option<PyBaseExceptionRef> = None;
-    let mut cmp = |a: &PyObjectRef, b: &PyObjectRef| {
-        match a.rich_compare_bool(b, op, vm) {
-            Ok(res) => if res { Ordering::Greater } else { Ordering::Less },
-            Err(e) => {
-                error_slot = Some(e);
-                Ordering::Equal
-            },
+    let mut cmp = |a: &PyObjectRef, b: &PyObjectRef| match a.rich_compare_bool(b, op, vm) {
+        Ok(res) => {
+            if res {
+                Ordering::Greater
+            } else {
+                Ordering::Less
+            }
+        }
+        Err(e) => {
+            error_slot = Some(e);
+            Ordering::Equal
         }
     };
 

--- a/vm/src/builtins/list.rs
+++ b/vm/src/builtins/list.rs
@@ -543,7 +543,7 @@ fn do_sort(
         items.sort_unstable_by(|a, b| cmp(&a.1, &b.1));
         *values = items.into_iter().map(|(val, _)| val).collect();
     } else {
-        values.sort_unstable_by(cmp(a, b));
+        values.sort_unstable_by(cmp);
     }
 
     // After the sort is done, check if an error was captured.

--- a/vm/src/builtins/list.rs
+++ b/vm/src/builtins/list.rs
@@ -517,11 +517,9 @@ fn do_sort(
         PyComparisonOp::Gt
     };
     let cmp = |a: &PyObjectRef, b: &PyObjectRef| {
-        let res = a.rich_compare_bool(b, op, vm).unwrap();
-        if res {
-            Ordering::Greater
-        } else {
-            Ordering::Less
+        match a.rich_compare_bool(b, op, vm) {
+            Ok(res) => if res { Ordering::Greater } else { Ordering::Less },
+            Err(_) => Ordering::Equal,
         }
     };
 

--- a/vm/src/builtins/list.rs
+++ b/vm/src/builtins/list.rs
@@ -543,7 +543,7 @@ fn do_sort(
         items.sort_unstable_by(|a, b| cmp(&a.1, &b.1));
         *values = items.into_iter().map(|(val, _)| val).collect();
     } else {
-        values.sort_unstable_by(|a, b| cmp(a, b));
+        values.sort_unstable_by(cmp(a, b));
     }
 
     // After the sort is done, check if an error was captured.


### PR DESCRIPTION
Relates #6093 

## Time improvements
**rust-timsort**
(Timing from Linux laptop - I didn't repeat this experiment on my Mac as it is 16 mins long)
```sh
✦ ❯ time cargo run --release -- -c "from random import random;
sorted([random() for i in range(1_000_000)]); print('DONE');"
    Finished `release` profile [optimized] target(s) in 0.16s
     Running `target/release/rustpython -c 'from random import random;
sorted([random() for i in range(1_000_000)]); print('\''DONE'\'');'`
DONE

real    16m52.217s
user    16m51.926s
sys     0m0.174s
```

**Built-in**
(Timing from MacOS laptop)
```sh
❯ time cargo run --release -- -c "from random import random;
sorted([random() for i in range(1_000_000)]); print('DONE');"
    Finished `release` profile [optimized] target(s) in 0.89s
     Running `target/release/rustpython -c 'from random import random;
sorted([random() for i in range(1_000_000)]); print('\''DONE'\'');'`
DONE
cargo run --release -- -c   0.96s user 0.23s system 54% cpu 2.196 total

```

## Verify list is sorted
```sh
❯ cargo run --release -- -c "from random import random; l =
sorted([random() for i in range(1_000_000)]); print(all(l[i] <= l[i+1]
for i in range(len(l) - 1))               ─╯
);"
TRUE
```

## TODO
- This uses `.unwrap` because I don't know how to handle the error case
- This doesn't use Ordering::Equal so it needs to either be confirmed that this is a stable sorting algorithm, or else make it stable