### PR TITLE
Allow multiple indented blocks in REPL

### DIFF
--- a/src/shell.rs
+++ b/src/shell.rs
@@ -86,11 +86,7 @@ fn shell_exec(
                             continuing_block
                         } // && p.location.is_some()
                         ParseErrorType::OtherError(msg) => {
-                            if msg.starts_with("Expected an indented block") {
-                                continuing_block
-                            } else {
-                                true
-                            }
+                            !msg.starts_with("Expected an indented block")
                         }
                         _ => true, // !matches!(p, ParseErrorType::UnrecognizedToken(Tok::Dedent, _))
                     }


### PR DESCRIPTION
# Description

Allow nested indented blocks in RustPython REPL.

## Additional comments

There aren't any tests but being able to do nested for loops seems like a pretty big win to me so I'm going to put up for review.

The original returned boolean clearly had **false positives** for detecting bad errors for things like nested `if` and `for` statements. What is less clear is if there are any **true positives** which I am no longer catching with the updated return value.

## Questions

I have seen reference to something called ctypes that if fixed would allow the use of `pyrepl` which is implemented in Python. Is there any way I could help with the ctypes work?

## Manual testing

**Before**
```python
>>>>> for i in range(2):
.....   for j in range(2):
  File "<stdin>", line 2
    for j in range(2):
                      ^
IndentationError: expected an indented block after `for` statement
```

**After**
```python
>>>>> for i in range(2):
.....   for j in range(2):
.....     print(i, j)
.....
0 0
0 1
1 0
1 1
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved REPL behavior when entering multi-line blocks: inputs that require an indented block now consistently prompt for continuation instead of throwing an error.
  * Reduced sporadic parse errors during block entry, resulting in smoother multi-line editing and fewer interruptions.
  * Ensured consistent handling of indentation-related messages so users can complete block constructs without unexpected failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->