### PR TITLE
lookup slot in hash()

### DIFF
--- a/vm/src/protocol/object.rs
+++ b/vm/src/protocol/object.rs
@@ -642,6 +642,11 @@ impl PyObject {
     }
 
     pub fn hash(&self, vm: &VirtualMachine) -> PyResult<PyHash> {
+        // __hash__ function in str cannot be overwritten
+        if let Some(pystr) = self.downcast_ref_if_exact::<PyStr>(vm) {
+            return Ok(pystr.hash(vm));
+        }
+
         let hash = self.get_class_attr(identifier!(vm, __hash__)).unwrap();
         if vm.is_none(&hash) {
             return Err(vm.new_exception_msg(

--- a/vm/src/protocol/object.rs
+++ b/vm/src/protocol/object.rs
@@ -646,10 +646,10 @@ impl PyObject {
             return hash(self, vm);
         }
 
-        return Err(vm.new_exception_msg(
+        Err(vm.new_exception_msg(
             vm.ctx.exceptions.type_error.to_owned(),
             format!("unhashable type: '{}'", self.class().name()),
-        ));
+        ))
     }
 
     // type protocol


### PR DESCRIPTION
# Description

`str.__hash__` can’t be overwritten, so for exact `PyStr` instances we skip the attribute lookup and MRO walk and call the string hash directly. This reduces overhead on hot paths (e.g., dict/set key hashing) while keeping subclass semantics unchanged.

```
>>> str.__hash__ = None
Traceback (most recent call last):
  File "<python-input-0>", line 1, in <module>
    str.__hash__ = None
    ^^^^^^^^^^^^
TypeError: cannot set '__hash__' attribute of immutable type 'str'
```
in Python 3.13.5.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Object hashing now uses type-defined hash behavior via inheritance lookup, ensuring consistent dispatch for custom types.
  * If a type provides no hash slot, an explicit TypeError ("unhashable type: '<TypeName>'") is raised.
  * No public API or signature changes; behavior for most built-in types is preserved.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->