### PR TITLE
Fix future clippy warnings

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -138,7 +138,7 @@ members = [
 version = "0.4.0"
 authors = ["RustPython Team"]
 edition = "2024"
-rust-version = "1.85.0"
+rust-version = "1.87.0"
 repository = "https://github.com/RustPython/RustPython"
 license = "MIT"
 

--- a/stdlib/src/array.rs
+++ b/stdlib/src/array.rs
@@ -851,7 +851,7 @@ mod array {
         }
 
         fn _from_bytes(&self, b: &[u8], itemsize: usize, vm: &VirtualMachine) -> PyResult<()> {
-            if b.len() % itemsize != 0 {
+            if !b.len().is_multiple_of(itemsize) {
                 return Err(vm.new_value_error("bytes length not a multiple of item size"));
             }
             if b.len() / itemsize > 0 {
@@ -1473,7 +1473,7 @@ mod array {
         type Error = u8;
 
         fn try_from(code: u8) -> Result<Self, Self::Error> {
-            let big_endian = code % 2 != 0;
+            let big_endian = !code.is_multiple_of(2);
             let signed = match code {
                 0 | 1 => code != 0,
                 2..=13 => (code - 2) % 4 >= 2,
@@ -1615,7 +1615,7 @@ mod array {
         let mut array = check_type_code(args.typecode, vm)?;
         let format = args.mformat_code;
         let bytes = args.items.as_bytes();
-        if bytes.len() % format.item_size() != 0 {
+        if !bytes.len().is_multiple_of(format.item_size()) {
             return Err(vm.new_value_error("bytes length not a multiple of item size"));
         }
         if MachineFormatCode::from_typecode(array.typecode()) == Some(format) {

--- a/stdlib/src/pystruct.rs
+++ b/stdlib/src/pystruct.rs
@@ -171,7 +171,7 @@ pub(crate) mod _struct {
                     vm,
                     "cannot iteratively unpack with a struct of length 0".to_owned(),
                 ))
-            } else if buffer.len() % format_spec.size != 0 {
+            } else if !buffer.len().is_multiple_of(format_spec.size) {
                 Err(new_struct_error(
                     vm,
                     format!(

--- a/vm/src/builtins/memory.rs
+++ b/vm/src/builtins/memory.rs
@@ -743,7 +743,7 @@ impl PyMemoryView {
     fn cast_to_1d(&self, format: PyStrRef, vm: &VirtualMachine) -> PyResult<Self> {
         let format_spec = Self::parse_format(format.as_str(), vm)?;
         let itemsize = format_spec.size();
-        if self.desc.len % itemsize != 0 {
+        if !self.desc.len.is_multiple_of(itemsize) {
             return Err(vm.new_type_error("memoryview: length is not a multiple of itemsize"));
         }
 

--- a/wtf8/src/core_str_count.rs
+++ b/wtf8/src/core_str_count.rs
@@ -35,7 +35,7 @@ fn do_count_chars(s: &Wtf8) -> usize {
     // Check the properties of `CHUNK_SIZE` and `UNROLL_INNER` that are required
     // for correctness.
     const _: () = assert!(CHUNK_SIZE < 256);
-    const _: () = assert!(CHUNK_SIZE % UNROLL_INNER == 0);
+    const _: () = assert!(CHUNK_SIZE.is_multiple_of(UNROLL_INNER));
 
     // SAFETY: transmuting `[u8]` to `[usize]` is safe except for size
     // differences which are handled by `align_to`.


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated minimum Rust toolchain requirement to 1.87.0.

* **Refactor**
  * Replaced modulo-based divisibility checks with is_multiple_of across various components for clearer intent and consistency. No functional behavior changes.

* **Style**
  * Minor condition style improvements in internal logic to enhance readability without altering outcomes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->