### PR TITLE
sqlite: Fix missing ProgrammingError for parameter mismatch

### DIFF
--- a/Lib/test/test_sqlite3/test_dbapi.py
+++ b/Lib/test/test_sqlite3/test_dbapi.py
@@ -836,15 +836,11 @@ class CursorTests(unittest.TestCase):
         with self.assertRaises(sqlite.ProgrammingError):
             self.cu.execute("insert into test(id) values (?)", (17, "Egon"))
 
-    # TODO: RUSTPYTHON
-    @unittest.expectedFailure
     def test_execute_wrong_no_of_args2(self):
         # too little parameters
         with self.assertRaises(sqlite.ProgrammingError):
             self.cu.execute("insert into test(id) values (?)")
 
-    # TODO: RUSTPYTHON
-    @unittest.expectedFailure
     def test_execute_wrong_no_of_args3(self):
         # no parameters, parameters are needed
         with self.assertRaises(sqlite.ProgrammingError):
@@ -911,8 +907,6 @@ class CursorTests(unittest.TestCase):
         with self.assertRaises(sqlite.ProgrammingError):
             self.cu.execute("select name from test where name=:name and id=:id", {"name": "foo"})
 
-    # TODO: RUSTPYTHON
-    @unittest.expectedFailure
     def test_execute_dict_mapping_no_args(self):
         self.cu.execute("insert into test(name) values ('foo')")
         with self.assertRaises(sqlite.ProgrammingError):


### PR DESCRIPTION
ref 

- https://github.com/python/cpython/blob/d22a7456443415961b93169b851ab7e550be8791/Modules/_sqlite/cursor.c#L640-L683

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Validates the number of parameters required by prepared SQLite statements before execution to prevent missing or extra bindings.
  * Emits clearer ProgrammingError messages indicating how many bindings are required versus supplied, including when none are provided.
  * Improves reliability of parameterized queries by rejecting mismatched bindings early without changing the public API.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->