### PR TITLE
Fix PyNumber::boolean

### DIFF
--- a/vm/src/builtins/complex.rs
+++ b/vm/src/builtins/complex.rs
@@ -492,7 +492,7 @@ impl AsNumber for PyComplex {
                 let value = PyComplex::number_downcast(number).value;
                 value.norm().to_pyresult(vm)
             }),
-            boolean: Some(|number, _vm| Ok(PyComplex::number_downcast(number).value.is_zero())),
+            boolean: Some(|number, _vm| Ok(!PyComplex::number_downcast(number).value.is_zero())),
             true_divide: Some(|a, b, vm| PyComplex::number_op(a, b, inner_div, vm)),
             ..PyNumberMethods::NOT_IMPLEMENTED
         };

--- a/vm/src/builtins/float.rs
+++ b/vm/src/builtins/float.rs
@@ -590,7 +590,7 @@ impl AsNumber for PyFloat {
                 let value = PyFloat::number_downcast(num).value;
                 value.abs().to_pyresult(vm)
             }),
-            boolean: Some(|num, _vm| Ok(PyFloat::number_downcast(num).value.is_zero())),
+            boolean: Some(|num, _vm| Ok(!PyFloat::number_downcast(num).value.is_zero())),
             int: Some(|num, vm| {
                 let value = PyFloat::number_downcast(num).value;
                 try_to_bigint(value, vm).map(|x| PyInt::from(x).into_pyobject(vm))

--- a/vm/src/builtins/int.rs
+++ b/vm/src/builtins/int.rs
@@ -773,7 +773,7 @@ impl PyInt {
         negative: Some(|num, vm| (&Self::number_downcast(num).value).neg().to_pyresult(vm)),
         positive: Some(|num, vm| Ok(Self::number_downcast_exact(num, vm).into())),
         absolute: Some(|num, vm| Self::number_downcast(num).value.abs().to_pyresult(vm)),
-        boolean: Some(|num, _vm| Ok(Self::number_downcast(num).value.is_zero())),
+        boolean: Some(|num, _vm| Ok(!Self::number_downcast(num).value.is_zero())),
         invert: Some(|num, vm| (&Self::number_downcast(num).value).not().to_pyresult(vm)),
         lshift: Some(|a, b, vm| Self::number_op(a, b, inner_lshift, vm)),
         rshift: Some(|a, b, vm| Self::number_op(a, b, inner_rshift, vm)),


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected boolean evaluation for integers, floats, and complex numbers: non‑zero values now evaluate to True and zero to False.
  * Ensures conditionals, loops, and truthiness checks behave consistently with Python’s expectations across numeric types.
  * Prevents unexpected True results for zero values, improving reliability in control flow and filtering.
  * No user-facing API changes; only behavior of numeric truthiness was corrected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->