### PR TITLE
sqlite3: Support 'size' keyword argument in `Cursor::fetchmany`

### DIFF
--- a/Lib/test/test_sqlite3/test_dbapi.py
+++ b/Lib/test/test_sqlite3/test_dbapi.py
@@ -1069,8 +1069,6 @@ class CursorTests(unittest.TestCase):
         res = self.cu.fetchmany(100)
         self.assertEqual(res, [])
 
-    # TODO: RUSTPYTHON
-    @unittest.expectedFailure
     def test_fetchmany_kw_arg(self):
         """Checks if fetchmany works with keyword arguments"""
         self.cu.execute("select name from test")


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Cursor.fetchmany now accepts a size keyword argument (via an argument bag) and uses arraysize when omitted.
* **Bug Fixes**
  * Clearer handling of invalid argument combinations (too many positional args, unexpected keywords, or duplicate size).
  * Behavior: non‑positive size fetches all remaining rows; positive size limits returned rows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->