### PR TITLE
Switch to newer thread::LocalKey convenience methods

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2558,6 +2558,8 @@ dependencies = [
  "rustpython-sre_engine",
  "rustyline",
  "schannel",
+ "scoped-tls",
+ "scopeguard",
  "serde",
  "static_assertions",
  "strum",
@@ -2667,6 +2669,12 @@ checksum = "1f29ebaa345f945cec9fbbc532eb307f0fdad8161f281b6369539c8d84876b3d"
 dependencies = [
  "windows-sys 0.59.0",
 ]
+
+[[package]]
+name = "scoped-tls"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e1cf6437eb19a8f4a6cc0f7dca544973b0b78843adbfeb3683d1a94a0024a294"
 
 [[package]]
 name = "scopeguard"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -207,6 +207,8 @@ rustix = { version = "1.0", features = ["event"] }
 rustyline = "17.0.0"
 serde = { version = "1.0.133", default-features = false }
 schannel = "0.1.27"
+scoped-tls = "1"
+scopeguard = "1"
 static_assertions = "1.1"
 strum = "0.27"
 strum_macros = "0.27"

--- a/common/src/str.rs
+++ b/common/src/str.rs
@@ -533,10 +533,9 @@ pub mod levenshtein {
             return max_cost + 1;
         }
 
-        BUFFER.with(|buffer| {
-            let mut buffer = buffer.borrow_mut();
-            for i in 0..a_end {
-                buffer[i] = (i + 1) * MOVE_COST;
+        BUFFER.with_borrow_mut(|buffer| {
+            for (i, x) in buffer.iter_mut().take(a_end).enumerate() {
+                *x = (i + 1) * MOVE_COST;
             }
 
             let mut result = 0usize;

--- a/vm/Cargo.toml
+++ b/vm/Cargo.toml
@@ -65,6 +65,8 @@ num_enum = { workspace = true }
 once_cell = { workspace = true }
 parking_lot = { workspace = true }
 paste = { workspace = true }
+scoped-tls = { workspace = true }
+scopeguard = { workspace = true }
 serde = { workspace = true, optional = true }
 static_assertions = { workspace = true }
 strum = { workspace = true }

--- a/vm/src/stdlib/sys.rs
+++ b/vm/src/stdlib/sys.rs
@@ -830,13 +830,13 @@ mod sys {
         if depth < 0 {
             return Err(vm.new_value_error("depth must be >= 0"));
         }
-        crate::vm::thread::COROUTINE_ORIGIN_TRACKING_DEPTH.with(|cell| cell.set(depth as _));
+        crate::vm::thread::COROUTINE_ORIGIN_TRACKING_DEPTH.set(depth as u32);
         Ok(())
     }
 
     #[pyfunction]
     fn get_coroutine_origin_tracking_depth() -> i32 {
-        crate::vm::thread::COROUTINE_ORIGIN_TRACKING_DEPTH.with(|cell| cell.get()) as _
+        crate::vm::thread::COROUTINE_ORIGIN_TRACKING_DEPTH.get() as i32
     }
 
     #[pyfunction]
@@ -887,14 +887,10 @@ mod sys {
         }
 
         if let Some(finalizer) = args.finalizer.into_option() {
-            crate::vm::thread::ASYNC_GEN_FINALIZER.with(|cell| {
-                cell.replace(finalizer);
-            });
+            crate::vm::thread::ASYNC_GEN_FINALIZER.set(finalizer);
         }
         if let Some(firstiter) = args.firstiter.into_option() {
-            crate::vm::thread::ASYNC_GEN_FIRSTITER.with(|cell| {
-                cell.replace(firstiter);
-            });
+            crate::vm::thread::ASYNC_GEN_FIRSTITER.set(firstiter);
         }
 
         Ok(())
@@ -914,9 +910,11 @@ mod sys {
     fn get_asyncgen_hooks(vm: &VirtualMachine) -> PyAsyncgenHooks {
         PyAsyncgenHooks {
             firstiter: crate::vm::thread::ASYNC_GEN_FIRSTITER
-                .with(|cell| cell.borrow().clone().to_pyobject(vm)),
+                .with_borrow(Clone::clone)
+                .to_pyobject(vm),
             finalizer: crate::vm::thread::ASYNC_GEN_FINALIZER
-                .with(|cell| cell.borrow().clone().to_pyobject(vm)),
+                .with_borrow(Clone::clone)
+                .to_pyobject(vm),
         }
     }
 


### PR DESCRIPTION
This branch has been sitting around in my local checkout for a while, and I was finally reminded of it today.

`THREAD_LOCAL.with(|x: &RefCell<_>| x.borrow_mut().foo())` -> `THREAD_LOCAL.with_borrow_mut(|x: &mut _| x.foo())`, since Rust 1.73.