### PR TITLE
Add comment about 6 params

### DIFF
--- a/vm/src/function/argument.rs
+++ b/vm/src/function/argument.rs
@@ -55,6 +55,10 @@ into_func_args_from_tuple!((v1, T1), (v2, T2), (v3, T3));
 into_func_args_from_tuple!((v1, T1), (v2, T2), (v3, T3), (v4, T4));
 into_func_args_from_tuple!((v1, T1), (v2, T2), (v3, T3), (v4, T4), (v5, T5));
 into_func_args_from_tuple!((v1, T1), (v2, T2), (v3, T3), (v4, T4), (v5, T5), (v6, T6));
+// We currently allows only 6 unnamed positional arguments.
+// Please use `#[derive(FromArgs)]` and a struct for more complex argument parsing.
+// The number of limitation came from:
+// https://rust-lang.github.io/rust-clippy/master/index.html#too_many_arguments
 
 /// The `FuncArgs` struct is one of the most used structs then creating
 /// a rust function that can be called from python. It holds both positional


### PR DESCRIPTION
close #6098 
close #6101 

Technically #6101 can be a solution of #6098, but we have to set a limitation.
Practically 6 is a good point due to harmony of other Rust ecosystem like clippy

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified limitations on passing function arguments via tuples, noting support for up to six unnamed positional arguments.
  * Recommended using a struct with a derive-based argument parser for more complex argument parsing.
  * Added references to guidance for choosing the appropriate approach.
  * No functional or API changes; behavior remains the same.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->