### PR TITLE
Pin CI image to `windows-2025`

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -116,7 +116,10 @@ jobs:
     timeout-minutes: ${{ contains(matrix.os, 'windows') && 45 || 30 }}
     strategy:
       matrix:
-        os: [macos-latest, ubuntu-latest, windows-latest]
+        os:
+          - macos-latest
+          - ubuntu-latest
+          - windows-2025 # TODO: Switch to `windows-latest` on 2025/09/30
       fail-fast: false
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
For more info see see:
https://github.blog/changelog/2025-07-31-github-actions-new-apis-and-windows-latest-migration-notice/