### PR TITLE
Run scheduled CI jobs only on upstream repo

### DIFF
--- a/.github/workflows/cron-ci.yaml
+++ b/.github/workflows/cron-ci.yaml
@@ -18,6 +18,8 @@ jobs:
   codecov:
     name: Collect code coverage data
     runs-on: ubuntu-latest
+    # Disable this job when running on a fork.
+    if: github.repository == 'RustPython/RustPython'
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable
@@ -44,6 +46,8 @@ jobs:
   testdata:
     name: Collect regression test data
     runs-on: ubuntu-latest
+    # Disable this job when running on a fork.
+    if: github.repository == 'RustPython/RustPython'
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable
@@ -73,6 +77,8 @@ jobs:
   whatsleft:
     name: Collect what is left data
     runs-on: ubuntu-latest
+    # Disable this job when running on a fork.
+    if: github.repository == 'RustPython/RustPython'
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable
@@ -111,6 +117,8 @@ jobs:
   benchmark:
     name: Collect benchmark data
     runs-on: ubuntu-latest
+    # Disable this job when running on a fork.
+    if: github.repository == 'RustPython/RustPython'
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,6 +21,8 @@ env:
 jobs:
   build:
     runs-on: ${{ matrix.platform.runner }}
+    # Disable this job when running on a fork.
+    if: github.repository == 'RustPython/RustPython'
     strategy:
       matrix:
         platform:
@@ -88,6 +90,8 @@ jobs:
 
   build-wasm:
     runs-on: ubuntu-latest
+    # Disable this job when running on a fork.
+    if: github.repository == 'RustPython/RustPython'
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable
@@ -136,6 +140,8 @@ jobs:
 
   release:
     runs-on: ubuntu-latest
+    # Disable this job when running on a fork.
+    if: github.repository == 'RustPython/RustPython'
     needs: [build, build-wasm]
     steps:
       - name: Download Binary Artifacts


### PR DESCRIPTION
There's no point in running those tasks on forks anyway imo.
---
I wish Github Actions allowed top level `if`:/
https://docs.github.com/en/actions/reference/workflows-and-actions/workflow-syntax