### PR TITLE
Update ruff to 0.11.12

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -388,20 +388,6 @@ checksum = "b05b61dc5112cbb17e4b6cd61790d9845d13888356391624cbe7e41efeac1e75"
 
 [[package]]
 name = "compact_str"
-version = "0.8.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b79c4069c6cad78e2e0cdfcbd26275770669fb39fd308a752dc110e83b9af32"
-dependencies = [
- "castaway",
- "cfg-if",
- "itoa",
- "rustversion",
- "ryu",
- "static_assertions",
-]
-
-[[package]]
-name = "compact_str"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3fdb1325a1cece981e8a296ab8f0f9b63ae357bd0784a9faaf548cc7b480707a"
@@ -2152,50 +2138,32 @@ dependencies = [
 [[package]]
 name = "ruff_python_ast"
 version = "0.0.0"
-source = "git+https://github.com/astral-sh/ruff.git?tag=0.11.0#2cd25ef6410fb5fca96af1578728a3d828d2d53a"
+source = "git+https://github.com/astral-sh/ruff.git?tag=0.11.12#aee3af0f7a018e9fcf921b746ad8ef76d3b84b83"
 dependencies = [
  "aho-corasick",
  "bitflags 2.9.4",
- "compact_str 0.8.1",
+ "compact_str",
  "is-macro",
  "itertools 0.14.0",
  "memchr",
- "ruff_python_trivia 0.0.0 (git+https://github.com/astral-sh/ruff.git?tag=0.11.0)",
- "ruff_source_file 0.0.0 (git+https://github.com/astral-sh/ruff.git?tag=0.11.0)",
- "ruff_text_size 0.0.0 (git+https://github.com/astral-sh/ruff.git?tag=0.11.0)",
+ "ruff_python_trivia",
+ "ruff_source_file",
+ "ruff_text_size",
  "rustc-hash",
-]
-
-[[package]]
-name = "ruff_python_ast"
-version = "0.0.0"
-source = "git+https://github.com/astral-sh/ruff.git?tag=0.13.1#706be0a6e7e09936511198f2ff8982915520d138"
-dependencies = [
- "aho-corasick",
- "bitflags 2.9.4",
- "compact_str 0.9.0",
- "is-macro",
- "itertools 0.14.0",
- "memchr",
- "ruff_python_trivia 0.0.0 (git+https://github.com/astral-sh/ruff.git?tag=0.13.1)",
- "ruff_source_file 0.0.0 (git+https://github.com/astral-sh/ruff.git?tag=0.13.1)",
- "ruff_text_size 0.0.0 (git+https://github.com/astral-sh/ruff.git?tag=0.13.1)",
- "rustc-hash",
- "thiserror 2.0.16",
 ]
 
 [[package]]
 name = "ruff_python_parser"
 version = "0.0.0"
-source = "git+https://github.com/astral-sh/ruff.git?tag=0.11.0#2cd25ef6410fb5fca96af1578728a3d828d2d53a"
+source = "git+https://github.com/astral-sh/ruff.git?tag=0.11.12#aee3af0f7a018e9fcf921b746ad8ef76d3b84b83"
 dependencies = [
  "bitflags 2.9.4",
  "bstr",
- "compact_str 0.8.1",
+ "compact_str",
  "memchr",
- "ruff_python_ast 0.0.0 (git+https://github.com/astral-sh/ruff.git?tag=0.11.0)",
- "ruff_python_trivia 0.0.0 (git+https://github.com/astral-sh/ruff.git?tag=0.11.0)",
- "ruff_text_size 0.0.0 (git+https://github.com/astral-sh/ruff.git?tag=0.11.0)",
+ "ruff_python_ast",
+ "ruff_python_trivia",
+ "ruff_text_size",
  "rustc-hash",
  "static_assertions",
  "unicode-ident",
@@ -2206,52 +2174,27 @@ dependencies = [
 [[package]]
 name = "ruff_python_trivia"
 version = "0.0.0"
-source = "git+https://github.com/astral-sh/ruff.git?tag=0.11.0#2cd25ef6410fb5fca96af1578728a3d828d2d53a"
+source = "git+https://github.com/astral-sh/ruff.git?tag=0.11.12#aee3af0f7a018e9fcf921b746ad8ef76d3b84b83"
 dependencies = [
  "itertools 0.14.0",
- "ruff_source_file 0.0.0 (git+https://github.com/astral-sh/ruff.git?tag=0.11.0)",
- "ruff_text_size 0.0.0 (git+https://github.com/astral-sh/ruff.git?tag=0.11.0)",
- "unicode-ident",
-]
-
-[[package]]
-name = "ruff_python_trivia"
-version = "0.0.0"
-source = "git+https://github.com/astral-sh/ruff.git?tag=0.13.1#706be0a6e7e09936511198f2ff8982915520d138"
-dependencies = [
- "itertools 0.14.0",
- "ruff_source_file 0.0.0 (git+https://github.com/astral-sh/ruff.git?tag=0.13.1)",
- "ruff_text_size 0.0.0 (git+https://github.com/astral-sh/ruff.git?tag=0.13.1)",
+ "ruff_source_file",
+ "ruff_text_size",
  "unicode-ident",
 ]
 
 [[package]]
 name = "ruff_source_file"
 version = "0.0.0"
-source = "git+https://github.com/astral-sh/ruff.git?tag=0.11.0#2cd25ef6410fb5fca96af1578728a3d828d2d53a"
+source = "git+https://github.com/astral-sh/ruff.git?tag=0.11.12#aee3af0f7a018e9fcf921b746ad8ef76d3b84b83"
 dependencies = [
  "memchr",
- "ruff_text_size 0.0.0 (git+https://github.com/astral-sh/ruff.git?tag=0.11.0)",
-]
-
-[[package]]
-name = "ruff_source_file"
-version = "0.0.0"
-source = "git+https://github.com/astral-sh/ruff.git?tag=0.13.1#706be0a6e7e09936511198f2ff8982915520d138"
-dependencies = [
- "memchr",
- "ruff_text_size 0.0.0 (git+https://github.com/astral-sh/ruff.git?tag=0.13.1)",
+ "ruff_text_size",
 ]
 
 [[package]]
 name = "ruff_text_size"
 version = "0.0.0"
-source = "git+https://github.com/astral-sh/ruff.git?tag=0.11.0#2cd25ef6410fb5fca96af1578728a3d828d2d53a"
-
-[[package]]
-name = "ruff_text_size"
-version = "0.0.0"
-source = "git+https://github.com/astral-sh/ruff.git?tag=0.13.1#706be0a6e7e09936511198f2ff8982915520d138"
+source = "git+https://github.com/astral-sh/ruff.git?tag=0.11.12#aee3af0f7a018e9fcf921b746ad8ef76d3b84b83"
 
 [[package]]
 name = "rustc-hash"
@@ -2309,9 +2252,10 @@ dependencies = [
  "memchr",
  "num-complex",
  "num-traits",
- "ruff_python_ast 0.0.0 (git+https://github.com/astral-sh/ruff.git?tag=0.13.1)",
+ "ruff_python_ast",
  "ruff_python_parser",
- "ruff_text_size 0.0.0 (git+https://github.com/astral-sh/ruff.git?tag=0.11.0)",
+ "ruff_source_file",
+ "ruff_text_size",
  "rustpython-compiler-core",
  "rustpython-literal",
  "rustpython-wtf8",
@@ -2350,10 +2294,10 @@ dependencies = [
 name = "rustpython-compiler"
 version = "0.4.0"
 dependencies = [
- "ruff_python_ast 0.0.0 (git+https://github.com/astral-sh/ruff.git?tag=0.13.1)",
+ "ruff_python_ast",
  "ruff_python_parser",
- "ruff_source_file 0.0.0 (git+https://github.com/astral-sh/ruff.git?tag=0.11.0)",
- "ruff_text_size 0.0.0 (git+https://github.com/astral-sh/ruff.git?tag=0.11.0)",
+ "ruff_source_file",
+ "ruff_text_size",
  "rustpython-codegen",
  "rustpython-compiler-core",
  "thiserror 2.0.16",
@@ -2368,7 +2312,7 @@ dependencies = [
  "lz4_flex",
  "malachite-bigint",
  "num-complex",
- "ruff_source_file 0.0.0 (git+https://github.com/astral-sh/ruff.git?tag=0.11.0)",
+ "ruff_source_file",
  "rustpython-wtf8",
 ]
 
@@ -2570,9 +2514,10 @@ dependencies = [
  "parking_lot",
  "paste",
  "result-like",
- "ruff_python_ast 0.0.0 (git+https://github.com/astral-sh/ruff.git?tag=0.13.1)",
+ "ruff_python_ast",
  "ruff_python_parser",
- "ruff_text_size 0.0.0 (git+https://github.com/astral-sh/ruff.git?tag=0.11.0)",
+ "ruff_source_file",
+ "ruff_text_size",
  "rustix",
  "rustpython-codegen",
  "rustpython-common",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -158,10 +158,10 @@ rustpython-sre_engine = { path = "vm/sre_engine", version = "0.4.0" }
 rustpython-wtf8 = { path = "wtf8", version = "0.4.0" }
 rustpython-doc = { git = "https://github.com/RustPython/__doc__", tag = "0.3.0", version = "0.3.0" }
 
-ruff_python_parser = { git = "https://github.com/astral-sh/ruff.git", tag = "0.11.0" }
-ruff_python_ast = { git = "https://github.com/astral-sh/ruff.git", tag = "0.11.0" }
-ruff_text_size = { git = "https://github.com/astral-sh/ruff.git", tag = "0.11.0" }
-ruff_source_file = { git = "https://github.com/astral-sh/ruff.git", tag = "0.11.0" }
+ruff_python_parser = { git = "https://github.com/astral-sh/ruff.git", tag = "0.11.12" }
+ruff_python_ast = { git = "https://github.com/astral-sh/ruff.git", tag = "0.11.12" }
+ruff_text_size = { git = "https://github.com/astral-sh/ruff.git", tag = "0.11.12" }
+ruff_source_file = { git = "https://github.com/astral-sh/ruff.git", tag = "0.11.12" }
 
 ahash = "0.8.12"
 ascii = "1.1"

--- a/compiler/codegen/Cargo.toml
+++ b/compiler/codegen/Cargo.toml
@@ -14,6 +14,7 @@ rustpython-literal = {workspace = true }
 rustpython-wtf8 = { workspace = true }
 ruff_python_ast = { workspace = true }
 ruff_text_size = { workspace = true }
+ruff_source_file = { workspace = true }
 
 ahash = { workspace = true }
 bitflags = { workspace = true }

--- a/compiler/codegen/src/ir.rs
+++ b/compiler/codegen/src/ir.rs
@@ -422,8 +422,8 @@ fn generate_linetable(locations: &[SourceLocation], first_line: i32) -> Box<[u8]
 
             // Get line and column information
             // SourceLocation always has row and column (both are OneIndexed)
-            let line = loc.row.get() as i32;
-            let col = (loc.column.get() as i32) - 1; // Convert 1-based to 0-based
+            let line = loc.line.get() as i32;
+            let col = (loc.character_offset.get() as i32) - 1; // Convert 1-based to 0-based
 
             let line_delta = line - prev_line;
 

--- a/compiler/codegen/src/symboltable.rs
+++ b/compiler/codegen/src/symboltable.rs
@@ -18,6 +18,7 @@ use ruff_python_ast::{
     PatternMatchMapping, PatternMatchOr, PatternMatchSequence, PatternMatchStar, PatternMatchValue,
     Stmt, TypeParam, TypeParamParamSpec, TypeParamTypeVar, TypeParamTypeVarTuple, TypeParams,
 };
+use ruff_source_file::PositionEncoding;
 use ruff_text_size::{Ranged, TextRange};
 use rustpython_compiler_core::{SourceFile, SourceLocation};
 use std::{borrow::Cow, fmt};
@@ -1046,7 +1047,7 @@ impl SymbolTableBuilder {
                 location: Some(
                     self.source_file
                         .to_source_code()
-                        .source_location(expression.range().start()),
+                        .source_location(expression.range().start(), PositionEncoding::Utf8),
                 ),
             });
         }
@@ -1282,7 +1283,7 @@ impl SymbolTableBuilder {
                 if let ExpressionContext::IterDefinitionExp = context {
                     return Err(SymbolTableError {
                           error: "assignment expression cannot be used in a comprehension iterable expression".to_string(),
-                          location: Some(self.source_file.to_source_code().source_location(target.range().start())),
+                          location: Some(self.source_file.to_source_code().source_location( target.range().start(), PositionEncoding::Utf8)),
                       });
                 }
 
@@ -1565,7 +1566,7 @@ impl SymbolTableBuilder {
         let location = self
             .source_file
             .to_source_code()
-            .source_location(range.start());
+            .source_location(range.start(), PositionEncoding::Utf8);
         let location = Some(location);
         let scope_depth = self.tables.len();
         let table = self.tables.last_mut().unwrap();

--- a/compiler/core/src/bytecode.rs
+++ b/compiler/core/src/bytecode.rs
@@ -1190,14 +1190,14 @@ impl<C: Constant> CodeObject<C> {
         level: usize,
     ) -> fmt::Result {
         let label_targets = self.label_targets();
-        let line_digits = (3).max(self.locations.last().unwrap().row.to_string().len());
+        let line_digits = (3).max(self.locations.last().unwrap().line.to_string().len());
         let offset_digits = (4).max(self.instructions.len().to_string().len());
         let mut last_line = OneIndexed::MAX;
         let mut arg_state = OpArgState::default();
         for (offset, &instruction) in self.instructions.iter().enumerate() {
             let (instruction, arg) = arg_state.get(instruction);
             // optional line number
-            let line = self.locations[offset].row;
+            let line = self.locations[offset].line;
             if line != last_line {
                 if last_line != OneIndexed::MAX {
                     writeln!(f)?;

--- a/compiler/core/src/marshal.rs
+++ b/compiler/core/src/marshal.rs
@@ -198,8 +198,8 @@ pub fn deserialize_code<R: Read, Bag: ConstantBag>(
     let locations = (0..len)
         .map(|_| {
             Ok(SourceLocation {
-                row: OneIndexed::new(rdr.read_u32()? as _).ok_or(MarshalError::InvalidLocation)?,
-                column: OneIndexed::from_zero_indexed(rdr.read_u32()? as _),
+                line: OneIndexed::new(rdr.read_u32()? as _).ok_or(MarshalError::InvalidLocation)?,
+                character_offset: OneIndexed::from_zero_indexed(rdr.read_u32()? as _),
             })
         })
         .collect::<Result<Box<[SourceLocation]>>>()?;
@@ -656,8 +656,8 @@ pub fn serialize_code<W: Write, C: Constant>(buf: &mut W, code: &CodeObject<C>) 
 
     write_len(buf, code.locations.len());
     for loc in &*code.locations {
-        buf.write_u32(loc.row.get() as _);
-        buf.write_u32(loc.column.to_zero_indexed() as _);
+        buf.write_u32(loc.line.get() as _);
+        buf.write_u32(loc.character_offset.to_zero_indexed() as _);
     }
 
     buf.write_u16(code.flags.bits());

--- a/compiler/src/lib.rs
+++ b/compiler/src/lib.rs
@@ -1,4 +1,4 @@
-use ruff_source_file::{SourceFile, SourceFileBuilder, SourceLocation};
+use ruff_source_file::{PositionEncoding, SourceFile, SourceFileBuilder, SourceLocation};
 use rustpython_codegen::{compile, symboltable};
 
 pub use rustpython_codegen::compile::CompileOpts;
@@ -46,7 +46,7 @@ impl CompileError {
     pub fn from_ruff_parse_error(error: parser::ParseError, source_file: &SourceFile) -> Self {
         let location = source_file
             .to_source_code()
-            .source_location(error.location.start());
+            .source_location(error.location.start(), PositionEncoding::Utf8);
         Self::Parse(ParseError {
             error: error.error,
             raw_location: error.location,
@@ -66,14 +66,14 @@ impl CompileError {
         match self {
             Self::Codegen(codegen_error) => {
                 if let Some(location) = &codegen_error.location {
-                    (location.row.get(), location.column.get())
+                    (location.line.get(), location.character_offset.get())
                 } else {
                     (0, 0)
                 }
             }
             Self::Parse(parse_error) => (
-                parse_error.location.row.get(),
-                parse_error.location.column.get(),
+                parse_error.location.line.get(),
+                parse_error.location.character_offset.get(),
             ),
         }
     }

--- a/stdlib/src/faulthandler.rs
+++ b/stdlib/src/faulthandler.rs
@@ -10,7 +10,7 @@ mod decl {
             stderr,
             "  File \"{}\", line {} in {}",
             frame.code.source_path,
-            frame.current_location().row,
+            frame.current_location().line,
             frame.code.obj_name
         )
     }

--- a/vm/Cargo.toml
+++ b/vm/Cargo.toml
@@ -20,7 +20,7 @@ freeze-stdlib = ["encodings"]
 jit = ["rustpython-jit"]
 threading = ["rustpython-common/threading"]
 compiler = ["parser", "codegen", "rustpython-compiler"]
-ast = ["ruff_python_ast", "ruff_text_size"]
+ast = ["ruff_python_ast", "ruff_text_size", "ruff_source_file"]
 codegen = ["rustpython-codegen", "ast"]
 parser = ["ast"]
 serde = ["dep:serde"]
@@ -35,6 +35,7 @@ rustpython-jit = { workspace = true, optional = true }
 
 ruff_python_ast = { workspace = true, optional = true }
 ruff_python_parser = { workspace = true }
+ruff_source_file = { workspace = true, optional = true }
 ruff_text_size = { workspace = true, optional = true }
 rustpython-compiler-core = { workspace = true }
 rustpython-literal = { workspace = true }

--- a/vm/src/builtins/frame.rs
+++ b/vm/src/builtins/frame.rs
@@ -60,7 +60,7 @@ impl Frame {
 
     #[pygetset]
     pub fn f_lineno(&self) -> usize {
-        self.current_location().row.get()
+        self.current_location().line.get()
     }
 
     #[pygetset]

--- a/vm/src/frame.rs
+++ b/vm/src/frame.rs
@@ -390,9 +390,13 @@ impl ExecutingFrame<'_> {
 
                         let loc = frame.code.locations[idx].clone();
                         let next = exception.__traceback__();
-                        let new_traceback =
-                            PyTraceback::new(next, frame.object.to_owned(), frame.lasti(), loc.row);
-                        vm_trace!("Adding to traceback: {:?} {:?}", new_traceback, loc.row);
+                        let new_traceback = PyTraceback::new(
+                            next,
+                            frame.object.to_owned(),
+                            frame.lasti(),
+                            loc.line,
+                        );
+                        vm_trace!("Adding to traceback: {:?} {:?}", new_traceback, loc.line);
                         exception.set_traceback_typed(Some(new_traceback.into_ref(&vm.ctx)));
 
                         vm.contextualize_exception(&exception);

--- a/vm/src/stdlib/ast.rs
+++ b/vm/src/stdlib/ast.rs
@@ -21,6 +21,7 @@ use crate::{
 };
 use node::Node;
 use ruff_python_ast as ruff;
+use ruff_source_file::PositionEncoding;
 use ruff_text_size::{Ranged, TextRange, TextSize};
 use rustpython_compiler_core::{
     LineIndex, OneIndexed, SourceFile, SourceFileBuilder, SourceLocation,
@@ -92,8 +93,8 @@ pub struct PySourceLocation {
 impl PySourceLocation {
     const fn to_source_location(&self) -> SourceLocation {
         SourceLocation {
-            row: self.row.get_one_indexed(),
-            column: self.column.get_one_indexed(),
+            line: self.row.get_one_indexed(),
+            character_offset: self.column.get_one_indexed(),
         }
     }
 }
@@ -194,14 +195,14 @@ fn source_range_to_text_range(source_file: &SourceFile, location: PySourceRange)
     }
 
     let start = index.offset(
-        location.start.row.get_one_indexed(),
-        location.start.column.get_one_indexed(),
+        location.start.to_source_location(),
         source,
+        PositionEncoding::Utf8,
     );
     let end = index.offset(
-        location.end.row.get_one_indexed(),
-        location.end.column.get_one_indexed(),
+        location.end.to_source_location(),
         source,
+        PositionEncoding::Utf8,
     );
 
     TextRange::new(start, end)

--- a/vm/src/vm/vm_new.rs
+++ b/vm/src/vm/vm_new.rs
@@ -412,7 +412,7 @@ impl VirtualMachine {
         fn get_statement(source: &str, loc: Option<SourceLocation>) -> Option<String> {
             let line = source
                 .split('\n')
-                .nth(loc?.row.to_zero_indexed())?
+                .nth(loc?.line.to_zero_indexed())?
                 .to_owned();
             Some(line + "\n")
         }


### PR DESCRIPTION
Not updating to the latest ruff version as the diff will be very large and hard to review. so I'm doing it in stages until we'll get to `>=0.13`