### PR TITLE
feat: Sync code.py + test_code_module.py from CPython v3.13.1

### DIFF
--- a/Lib/code.py
+++ b/Lib/code.py
@@ -5,12 +5,14 @@
 # Inspired by similar code by Jeff Epler and Fredrik Lundh.
 
 
+import builtins
 import sys
 import traceback
 from codeop import CommandCompiler, compile_command
 
 __all__ = ["InteractiveInterpreter", "InteractiveConsole", "interact",
            "compile_command"]
+
 
 class InteractiveInterpreter:
     """Base class for InteractiveConsole.
@@ -24,10 +26,10 @@ class InteractiveInterpreter:
     def __init__(self, locals=None):
         """Constructor.
 
-        The optional 'locals' argument specifies the dictionary in
-        which code will be executed; it defaults to a newly created
-        dictionary with key "__name__" set to "__console__" and key
-        "__doc__" set to None.
+        The optional 'locals' argument specifies a mapping to use as the
+        namespace in which code will be executed; it defaults to a newly
+        created dictionary with key "__name__" set to "__console__" and
+        key "__doc__" set to None.
 
         """
         if locals is None:
@@ -63,7 +65,7 @@ class InteractiveInterpreter:
             code = self.compile(source, filename, symbol)
         except (OverflowError, SyntaxError, ValueError):
             # Case 1
-            self.showsyntaxerror(filename)
+            self.showsyntaxerror(filename, source=source)
             return False
 
         if code is None:
@@ -93,7 +95,7 @@ class InteractiveInterpreter:
         except:
             self.showtraceback()
 
-    def showsyntaxerror(self, filename=None):
+    def showsyntaxerror(self, filename=None, **kwargs):
         """Display the syntax error that just occurred.
 
         This doesn't display a stack trace because there isn't one.
@@ -105,29 +107,14 @@ class InteractiveInterpreter:
         The output is written by self.write(), below.
 
         """
-        type, value, tb = sys.exc_info()
-        sys.last_exc = value
-        sys.last_type = type
-        sys.last_value = value
-        sys.last_traceback = tb
-        if filename and type is SyntaxError:
-            # Work hard to stuff the correct filename in the exception
-            try:
-                msg, (dummy_filename, lineno, offset, line) = value.args
-            except ValueError:
-                # Not the format we expect; leave it alone
-                pass
-            else:
-                # Stuff in the right filename
-                value = SyntaxError(msg, (filename, lineno, offset, line))
-                sys.last_exc = sys.last_value = value
-        if sys.excepthook is sys.__excepthook__:
-            lines = traceback.format_exception_only(type, value)
-            self.write(''.join(lines))
-        else:
-            # If someone has set sys.excepthook, we let that take precedence
-            # over self.write
-            sys.excepthook(type, value, tb)
+        try:
+            typ, value, tb = sys.exc_info()
+            if filename and issubclass(typ, SyntaxError):
+                value.filename = filename
+            source = kwargs.pop('source', "")
+            self._showtraceback(typ, value, None, source)
+        finally:
+            typ = value = tb = None
 
     def showtraceback(self):
         """Display the exception that just occurred.
@@ -137,19 +124,46 @@ class InteractiveInterpreter:
         The output is written by self.write(), below.
 
         """
-        sys.last_type, sys.last_value, last_tb = ei = sys.exc_info()
-        sys.last_traceback = last_tb
-        sys.last_exc = ei[1]
         try:
-            lines = traceback.format_exception(ei[0], ei[1], last_tb.tb_next)
-            if sys.excepthook is sys.__excepthook__:
-                self.write(''.join(lines))
-            else:
-                # If someone has set sys.excepthook, we let that take precedence
-                # over self.write
-                sys.excepthook(ei[0], ei[1], last_tb)
+            typ, value, tb = sys.exc_info()
+            self._showtraceback(typ, value, tb.tb_next, '')
         finally:
-            last_tb = ei = None
+            typ = value = tb = None
+
+    def _showtraceback(self, typ, value, tb, source):
+        sys.last_type = typ
+        sys.last_traceback = tb
+        value = value.with_traceback(tb)
+        # Set the line of text that the exception refers to
+        lines = source.splitlines()
+        if (source and typ is SyntaxError
+                and not value.text and value.lineno is not None
+                and len(lines) >= value.lineno):
+            value.text = lines[value.lineno - 1]
+        sys.last_exc = sys.last_value = value = value.with_traceback(tb)
+        if sys.excepthook is sys.__excepthook__:
+            self._excepthook(typ, value, tb)
+        else:
+            # If someone has set sys.excepthook, we let that take precedence
+            # over self.write
+            try:
+                sys.excepthook(typ, value, tb)
+            except SystemExit:
+                raise
+            except BaseException as e:
+                e.__context__ = None
+                e = e.with_traceback(e.__traceback__.tb_next)
+                print('Error in sys.excepthook:', file=sys.stderr)
+                sys.__excepthook__(type(e), e, e.__traceback__)
+                print(file=sys.stderr)
+                print('Original exception was:', file=sys.stderr)
+                sys.__excepthook__(typ, value, tb)
+
+    def _excepthook(self, typ, value, tb):
+        # This method is being overwritten in
+        # _pyrepl.console.InteractiveColoredConsole
+        lines = traceback.format_exception(typ, value, tb)
+        self.write(''.join(lines))
 
     def write(self, data):
         """Write a string.
@@ -169,7 +183,7 @@ class InteractiveConsole(InteractiveInterpreter):
 
     """
 
-    def __init__(self, locals=None, filename="<console>"):
+    def __init__(self, locals=None, filename="<console>", *, local_exit=False):
         """Constructor.
 
         The optional locals argument will be passed to the
@@ -181,6 +195,7 @@ class InteractiveConsole(InteractiveInterpreter):
         """
         InteractiveInterpreter.__init__(self, locals)
         self.filename = filename
+        self.local_exit = local_exit
         self.resetbuffer()
 
     def resetbuffer(self):
@@ -219,29 +234,66 @@ class InteractiveConsole(InteractiveInterpreter):
         elif banner:
             self.write("%s\n" % str(banner))
         more = 0
-        while 1:
-            try:
-                if more:
-                    prompt = sys.ps2
-                else:
-                    prompt = sys.ps1
-                try:
-                    line = self.raw_input(prompt)
-                except EOFError:
-                    self.write("\n")
-                    break
-                else:
-                    more = self.push(line)
-            except KeyboardInterrupt:
-                self.write("\nKeyboardInterrupt\n")
-                self.resetbuffer()
-                more = 0
-        if exitmsg is None:
-            self.write('now exiting %s...\n' % self.__class__.__name__)
-        elif exitmsg != '':
-            self.write('%s\n' % exitmsg)
 
-    def push(self, line):
+        # When the user uses exit() or quit() in their interactive shell
+        # they probably just want to exit the created shell, not the whole
+        # process. exit and quit in builtins closes sys.stdin which makes
+        # it super difficult to restore
+        #
+        # When self.local_exit is True, we overwrite the builtins so
+        # exit() and quit() only raises SystemExit and we can catch that
+        # to only exit the interactive shell
+
+        _exit = None
+        _quit = None
+
+        if self.local_exit:
+            if hasattr(builtins, "exit"):
+                _exit = builtins.exit
+                builtins.exit = Quitter("exit")
+
+            if hasattr(builtins, "quit"):
+                _quit = builtins.quit
+                builtins.quit = Quitter("quit")
+
+        try:
+            while True:
+                try:
+                    if more:
+                        prompt = sys.ps2
+                    else:
+                        prompt = sys.ps1
+                    try:
+                        line = self.raw_input(prompt)
+                    except EOFError:
+                        self.write("\n")
+                        break
+                    else:
+                        more = self.push(line)
+                except KeyboardInterrupt:
+                    self.write("\nKeyboardInterrupt\n")
+                    self.resetbuffer()
+                    more = 0
+                except SystemExit as e:
+                    if self.local_exit:
+                        self.write("\n")
+                        break
+                    else:
+                        raise e
+        finally:
+            # restore exit and quit in builtins if they were modified
+            if _exit is not None:
+                builtins.exit = _exit
+
+            if _quit is not None:
+                builtins.quit = _quit
+
+            if exitmsg is None:
+                self.write('now exiting %s...\n' % self.__class__.__name__)
+            elif exitmsg != '':
+                self.write('%s\n' % exitmsg)
+
+    def push(self, line, filename=None, _symbol="single"):
         """Push a line to the interpreter.
 
         The line should not have a trailing newline; it may have
@@ -257,7 +309,9 @@ class InteractiveConsole(InteractiveInterpreter):
         """
         self.buffer.append(line)
         source = "\n".join(self.buffer)
-        more = self.runsource(source, self.filename)
+        if filename is None:
+            filename = self.filename
+        more = self.runsource(source, filename, symbol=_symbol)
         if not more:
             self.resetbuffer()
         return more
@@ -276,8 +330,22 @@ class InteractiveConsole(InteractiveInterpreter):
         return input(prompt)
 
 
+class Quitter:
+    def __init__(self, name):
+        self.name = name
+        if sys.platform == "win32":
+            self.eof = 'Ctrl-Z plus Return'
+        else:
+            self.eof = 'Ctrl-D (i.e. EOF)'
 
-def interact(banner=None, readfunc=None, local=None, exitmsg=None):
+    def __repr__(self):
+        return f'Use {self.name} or {self.eof} to exit'
+
+    def __call__(self, code=None):
+        raise SystemExit(code)
+
+
+def interact(banner=None, readfunc=None, local=None, exitmsg=None, local_exit=False):
     """Closely emulate the interactive Python interpreter.
 
     This is a backwards compatible interface to the InteractiveConsole
@@ -290,9 +358,10 @@ def interact(banner=None, readfunc=None, local=None, exitmsg=None):
     readfunc -- if not None, replaces InteractiveConsole.raw_input()
     local -- passed to InteractiveInterpreter.__init__()
     exitmsg -- passed to InteractiveConsole.interact()
+    local_exit -- passed to InteractiveConsole.__init__()
 
     """
-    console = InteractiveConsole(local)
+    console = InteractiveConsole(local, local_exit=local_exit)
     if readfunc is not None:
         console.raw_input = readfunc
     else:
@@ -308,7 +377,7 @@ if __name__ == "__main__":
 
     parser = argparse.ArgumentParser()
     parser.add_argument('-q', action='store_true',
-                       help="don't print version and copyright messages")
+                        help="don't print version and copyright messages")
     args = parser.parse_args()
     if args.q or sys.flags.quiet:
         banner = ''

--- a/Lib/test/test_code_module.py
+++ b/Lib/test/test_code_module.py
@@ -1,5 +1,6 @@
 "Test InteractiveConsole and InteractiveInterpreter from code module"
 import sys
+import traceback
 import unittest
 from textwrap import dedent
 from contextlib import ExitStack
@@ -10,11 +11,7 @@ from test.support import import_helper
 code = import_helper.import_module('code')
 
 
-class TestInteractiveConsole(unittest.TestCase):
-
-    def setUp(self):
-        self.console = code.InteractiveConsole()
-        self.mock_sys()
+class MockSys:
 
     def mock_sys(self):
         "Mock system environment for InteractiveConsole"
@@ -31,6 +28,14 @@ class TestInteractiveConsole(unittest.TestCase):
             self.sysmod.excepthook = self.sysmod.__excepthook__
         del self.sysmod.ps1
         del self.sysmod.ps2
+
+
+class TestInteractiveConsole(unittest.TestCase, MockSys):
+    maxDiff = None
+
+    def setUp(self):
+        self.console = code.InteractiveConsole()
+        self.mock_sys()
 
     def test_ps1(self):
         self.infunc.side_effect = EOFError('Finished')
@@ -58,21 +63,151 @@ class TestInteractiveConsole(unittest.TestCase):
             raise AssertionError("no console stdout")
 
     def test_syntax_error(self):
-        self.infunc.side_effect = ["undefined", EOFError('Finished')]
+        self.infunc.side_effect = ["def f():",
+                                   "    x = ?",
+                                   "",
+                                    EOFError('Finished')]
         self.console.interact()
-        for call in self.stderr.method_calls:
-            if 'NameError' in ''.join(call[1]):
-                break
-        else:
-            raise AssertionError("No syntax error from console")
+        output = ''.join(''.join(call[1]) for call in self.stderr.method_calls)
+        output = output[output.index('(InteractiveConsole)'):]
+        output = output[:output.index('\nnow exiting')]
+        self.assertEqual(output.splitlines()[1:], [
+            '  File "<console>", line 2',
+            '    x = ?',
+            '        ^',
+            'SyntaxError: invalid syntax'])
+        self.assertIs(self.sysmod.last_type, SyntaxError)
+        self.assertIs(type(self.sysmod.last_value), SyntaxError)
+        self.assertIsNone(self.sysmod.last_traceback)
+        self.assertIsNone(self.sysmod.last_value.__traceback__)
+        self.assertIs(self.sysmod.last_exc, self.sysmod.last_value)
+
+    def test_indentation_error(self):
+        self.infunc.side_effect = ["  1", EOFError('Finished')]
+        self.console.interact()
+        output = ''.join(''.join(call[1]) for call in self.stderr.method_calls)
+        output = output[output.index('(InteractiveConsole)'):]
+        output = output[:output.index('\nnow exiting')]
+        self.assertEqual(output.splitlines()[1:], [
+            '  File "<console>", line 1',
+            '    1',
+            'IndentationError: unexpected indent'])
+        self.assertIs(self.sysmod.last_type, IndentationError)
+        self.assertIs(type(self.sysmod.last_value), IndentationError)
+        self.assertIsNone(self.sysmod.last_traceback)
+        self.assertIsNone(self.sysmod.last_value.__traceback__)
+        self.assertIs(self.sysmod.last_exc, self.sysmod.last_value)
+
+    def test_unicode_error(self):
+        self.infunc.side_effect = ["'\ud800'", EOFError('Finished')]
+        self.console.interact()
+        output = ''.join(''.join(call[1]) for call in self.stderr.method_calls)
+        output = output[output.index('(InteractiveConsole)'):]
+        output = output[output.index('\n') + 1:]
+        self.assertTrue(output.startswith('UnicodeEncodeError: '), output)
+        self.assertIs(self.sysmod.last_type, UnicodeEncodeError)
+        self.assertIs(type(self.sysmod.last_value), UnicodeEncodeError)
+        self.assertIsNone(self.sysmod.last_traceback)
+        self.assertIsNone(self.sysmod.last_value.__traceback__)
+        self.assertIs(self.sysmod.last_exc, self.sysmod.last_value)
 
     def test_sysexcepthook(self):
-        self.infunc.side_effect = ["raise ValueError('')",
+        self.infunc.side_effect = ["def f():",
+                                   "    raise ValueError('BOOM!')",
+                                   "",
+                                   "f()",
                                     EOFError('Finished')]
         hook = mock.Mock()
         self.sysmod.excepthook = hook
         self.console.interact()
-        self.assertTrue(hook.called)
+        hook.assert_called()
+        hook.assert_called_with(self.sysmod.last_type,
+                                self.sysmod.last_value,
+                                self.sysmod.last_traceback)
+        self.assertIs(self.sysmod.last_type, ValueError)
+        self.assertIs(type(self.sysmod.last_value), ValueError)
+        self.assertIs(self.sysmod.last_traceback, self.sysmod.last_value.__traceback__)
+        self.assertIs(self.sysmod.last_exc, self.sysmod.last_value)
+        self.assertEqual(traceback.format_exception(self.sysmod.last_exc), [
+            'Traceback (most recent call last):\n',
+            '  File "<console>", line 1, in <module>\n',
+            '  File "<console>", line 2, in f\n',
+            'ValueError: BOOM!\n'])
+
+    def test_sysexcepthook_syntax_error(self):
+        self.infunc.side_effect = ["def f():",
+                                   "    x = ?",
+                                   "",
+                                    EOFError('Finished')]
+        hook = mock.Mock()
+        self.sysmod.excepthook = hook
+        self.console.interact()
+        hook.assert_called()
+        hook.assert_called_with(self.sysmod.last_type,
+                                self.sysmod.last_value,
+                                self.sysmod.last_traceback)
+        self.assertIs(self.sysmod.last_type, SyntaxError)
+        self.assertIs(type(self.sysmod.last_value), SyntaxError)
+        self.assertIsNone(self.sysmod.last_traceback)
+        self.assertIsNone(self.sysmod.last_value.__traceback__)
+        self.assertIs(self.sysmod.last_exc, self.sysmod.last_value)
+        self.assertEqual(traceback.format_exception(self.sysmod.last_exc), [
+            '  File "<console>", line 2\n',
+            '    x = ?\n',
+            '        ^\n',
+            'SyntaxError: invalid syntax\n'])
+
+    def test_sysexcepthook_indentation_error(self):
+        self.infunc.side_effect = ["  1", EOFError('Finished')]
+        hook = mock.Mock()
+        self.sysmod.excepthook = hook
+        self.console.interact()
+        hook.assert_called()
+        hook.assert_called_with(self.sysmod.last_type,
+                                self.sysmod.last_value,
+                                self.sysmod.last_traceback)
+        self.assertIs(self.sysmod.last_type, IndentationError)
+        self.assertIs(type(self.sysmod.last_value), IndentationError)
+        self.assertIsNone(self.sysmod.last_traceback)
+        self.assertIsNone(self.sysmod.last_value.__traceback__)
+        self.assertIs(self.sysmod.last_exc, self.sysmod.last_value)
+        self.assertEqual(traceback.format_exception(self.sysmod.last_exc), [
+            '  File "<console>", line 1\n',
+            '    1\n',
+            'IndentationError: unexpected indent\n'])
+
+    def test_sysexcepthook_crashing_doesnt_close_repl(self):
+        self.infunc.side_effect = ["1/0", "a = 123", "print(a)", EOFError('Finished')]
+        self.sysmod.excepthook = 1
+        self.console.interact()
+        self.assertEqual(['write', ('123', ), {}], self.stdout.method_calls[0])
+        error = "".join(call.args[0] for call in self.stderr.method_calls if call[0] == 'write')
+        self.assertIn("Error in sys.excepthook:", error)
+        self.assertEqual(error.count("'int' object is not callable"), 1)
+        self.assertIn("Original exception was:", error)
+        self.assertIn("division by zero", error)
+
+    def test_sysexcepthook_raising_BaseException(self):
+        self.infunc.side_effect = ["1/0", "a = 123", "print(a)", EOFError('Finished')]
+        s = "not so fast"
+        def raise_base(*args, **kwargs):
+            raise BaseException(s)
+        self.sysmod.excepthook = raise_base
+        self.console.interact()
+        self.assertEqual(['write', ('123', ), {}], self.stdout.method_calls[0])
+        error = "".join(call.args[0] for call in self.stderr.method_calls if call[0] == 'write')
+        self.assertIn("Error in sys.excepthook:", error)
+        self.assertEqual(error.count("not so fast"), 1)
+        self.assertIn("Original exception was:", error)
+        self.assertIn("division by zero", error)
+
+    def test_sysexcepthook_raising_SystemExit_gets_through(self):
+        self.infunc.side_effect = ["1/0"]
+        def raise_base(*args, **kwargs):
+            raise SystemExit
+        self.sysmod.excepthook = raise_base
+        with self.assertRaises(SystemExit):
+            self.console.interact()
 
     def test_banner(self):
         # with banner
@@ -115,8 +250,7 @@ class TestInteractiveConsole(unittest.TestCase):
         expected = message + '\n'
         self.assertEqual(err_msg, ['write', (expected,), {}])
 
-    # TODO: RUSTPYTHON
-    @unittest.expectedFailure
+
     def test_cause_tb(self):
         self.infunc.side_effect = ["raise ValueError('') from AttributeError",
                                     EOFError('Finished')]
@@ -132,9 +266,12 @@ class TestInteractiveConsole(unittest.TestCase):
         ValueError
         """)
         self.assertIn(expected, output)
+        self.assertIs(self.sysmod.last_type, ValueError)
+        self.assertIs(type(self.sysmod.last_value), ValueError)
+        self.assertIs(self.sysmod.last_traceback, self.sysmod.last_value.__traceback__)
+        self.assertIsNotNone(self.sysmod.last_traceback)
+        self.assertIs(self.sysmod.last_exc, self.sysmod.last_value)
 
-    # TODO: RUSTPYTHON
-    @unittest.expectedFailure
     def test_context_tb(self):
         self.infunc.side_effect = ["try: ham\nexcept: eggs\n",
                                     EOFError('Finished')]
@@ -152,6 +289,28 @@ class TestInteractiveConsole(unittest.TestCase):
         NameError: name 'eggs' is not defined
         """)
         self.assertIn(expected, output)
+        self.assertIs(self.sysmod.last_type, NameError)
+        self.assertIs(type(self.sysmod.last_value), NameError)
+        self.assertIs(self.sysmod.last_traceback, self.sysmod.last_value.__traceback__)
+        self.assertIsNotNone(self.sysmod.last_traceback)
+        self.assertIs(self.sysmod.last_exc, self.sysmod.last_value)
+
+
+class TestInteractiveConsoleLocalExit(unittest.TestCase, MockSys):
+
+    def setUp(self):
+        self.console = code.InteractiveConsole(local_exit=True)
+        self.mock_sys()
+
+    @unittest.skipIf(sys.flags.no_site, "exit() isn't defined unless there's a site module")
+    def test_exit(self):
+        # default exit message
+        self.infunc.side_effect = ["exit()"]
+        self.console.interact(banner='')
+        self.assertEqual(len(self.stderr.method_calls), 2)
+        err_msg = self.stderr.method_calls[1]
+        expected = 'now exiting InteractiveConsole...\n'
+        self.assertEqual(err_msg, ['write', (expected,), {}])
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
This PR updates RustPython’s stdlib `code.py` and its associated tests 
`test_code_module.py` to match CPython v3.13.1.

- Copied from CPython tag v3.13.1
- Ran with:
  cargo run -- -m test -v test_code_module
- 17 tests run, 11 passed, 6 failed
- Failures are expected due to known VM differences:
  • SyntaxError wording
  • IndentationError wording
  • Unicode error mismatch
  • Traceback formatting difference

As per #5529, I’m submitting the updated files as-is. Follow-up issues can be filed for the failing cases.