### PR TITLE
Handle OsError in REPL

### DIFF
--- a/src/shell.rs
+++ b/src/shell.rs
@@ -209,6 +209,13 @@ pub fn run_shell(vm: &VirtualMachine, scope: Scope) -> PyResult<()> {
             ReadlineResult::Eof => {
                 break;
             }
+            #[cfg(unix)]
+            ReadlineResult::OsError(num) => {
+                let os_error =
+                    vm.new_exception_msg(vm.ctx.exceptions.os_error.to_owned(), format!("{num:?}"));
+                vm.print_exception(os_error);
+                break;
+            }
             ReadlineResult::Other(err) => {
                 eprintln!("Readline error: {err:?}");
                 break;

--- a/vm/src/readline.rs
+++ b/vm/src/readline.rs
@@ -13,6 +13,8 @@ pub enum ReadlineResult {
     Eof,
     Interrupt,
     Io(std::io::Error),
+    #[cfg(unix)]
+    OsError(nix::Error),
     Other(OtherError),
 }
 
@@ -118,6 +120,8 @@ mod rustyline_readline {
                     Err(ReadlineError::Eof) => ReadlineResult::Eof,
                     Err(ReadlineError::Io(e)) => ReadlineResult::Io(e),
                     Err(ReadlineError::Signal(_)) => continue,
+                    #[cfg(unix)]
+                    Err(ReadlineError::Errno(num)) => ReadlineResult::OsError(num),
                     Err(e) => ReadlineResult::Other(e.into()),
                 };
             }

--- a/vm/src/stdlib/builtins.rs
+++ b/vm/src/stdlib/builtins.rs
@@ -489,6 +489,8 @@ mod builtins {
                     Err(vm.new_exception_empty(vm.ctx.exceptions.keyboard_interrupt.to_owned()))
                 }
                 ReadlineResult::Io(e) => Err(vm.new_os_error(e.to_string())),
+                #[cfg(unix)]
+                ReadlineResult::OsError(num) => Err(vm.new_os_error(num.to_string())),
                 ReadlineResult::Other(e) => Err(vm.new_runtime_error(e.to_string())),
             }
         } else {


### PR DESCRIPTION
Closes #6146


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Bug Fixes
  - Improved handling of OS-level read errors on Unix when reading input, providing clearer error messages and exiting the prompt loop safely.
  - The built-in input function now surfaces OS errors as proper exceptions on Unix instead of ambiguous failures.
  - Enhances stability and diagnostics during terminal I/O failures on Unix systems; existing behavior on other platforms remains unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->