### PR TITLE
Fix sqlite Cursor initialization check

### DIFF
--- a/Lib/test/test_sqlite3/test_regression.py
+++ b/Lib/test/test_sqlite3/test_regression.py
@@ -195,8 +195,6 @@ class RegressionTests(unittest.TestCase):
                     con.isolation_level = value
                 self.assertEqual(con.isolation_level, "DEFERRED")
 
-    # TODO: RUSTPYTHON
-    @unittest.expectedFailure
     def test_cursor_constructor_call_check(self):
         """
         Verifies that cursor methods check whether base class __init__ was


### PR DESCRIPTION
Add proper __init__ validation for sqlite3.Cursor to ensure base class __init__ is called before using cursor methods. This fixes the test_cursor_constructor_call_check test case.

Changes:
- Modified Cursor to initialize with inner=None in py_new
- Added explicit __init__ method that sets up CursorInner
- Updated close() method to check for uninitialized state
- Changed error message to match CPython: 'Base Cursor.__init__ not called.'

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * SQLite Cursor now supports explicit initialization through `__init__` method.

* **Bug Fixes**
  * Improved error messages for invalid cursor operations, distinguishing between uninitialized and closed cursor states.
  * Enhanced cursor closing mechanism with better validation and state management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->