### PR TITLE
[boxvec] avoid 0-sized allocations

### DIFF
--- a/common/src/boxvec.rs
+++ b/common/src/boxvec.rs
@@ -39,6 +39,12 @@ macro_rules! panic_oob {
 
 impl<T> BoxVec<T> {
     pub fn new(n: usize) -> Self {
+        if n == 0 {
+            return Self {
+                xs: Box::new([]),
+                len: 0,
+            };
+        }
         Self {
             xs: Box::new_uninit_slice(n),
             len: 0,


### PR DESCRIPTION
## Description

Looks like there are occasionally cases where `code.max_stackdepth` is 0. That causes
`Frame::new` to call `BoxVec::new` with layout size 0, which calls the allocator with 0
size and non-zero-sized layout, which is undefined behavior.

The default Rust allocator returns a dangling pointer when called this way
(https://github.com/rust-lang/rust/blob/master/library/alloc/src/alloc.rs#L187 ), which
kind of sidesteps the issue. However, tikv-jemallocator has an `assume!` that causes it
to panic (in debug builds) instead, making it impossible for me to run debug builds
that combine RustPython and tikv-jemallocator
(https://github.com/tikv/jemallocator/blob/main/jemallocator/src/lib.rs#L96 )

## Test plan

```
cargo build ; cargo build --release
cargo clippy
cargo test --workspace --exclude rustpython_wasm
cd extra_tests ; pytest -v ; cd -

# back out change to confirm equivalent test results
git checkout HEAD^ common/src/boxvec.rs
cargo build ; cargo build --release
cargo clippy
cargo test --workspace --exclude rustpython_wasm
cd extra_tests ; pytest -v ; cd -
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved buffer initialization to properly construct empty buffers instead of leaving them uninitialized, ensuring correct behavior for edge cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->