### PR TITLE
Fix time.strptime

### DIFF
--- a/Lib/test/test_time.py
+++ b/Lib/test/test_time.py
@@ -284,8 +284,6 @@ class TimeTestCase(unittest.TestCase):
         self.assertRaises(TypeError, time.strptime, b'2009', "%Y")
         self.assertRaises(TypeError, time.strptime, '2009', b'%Y')
 
-    # TODO: RUSTPYTHON
-    @unittest.expectedFailure
     def test_strptime_exception_context(self):
         # check that this doesn't chain exceptions needlessly (see #17572)
         with self.assertRaises(ValueError) as e:

--- a/Lib/test/test_zipfile.py
+++ b/Lib/test/test_zipfile.py
@@ -123,8 +123,6 @@ class AbstractTestsWithSourceFile:
             # Check that testzip doesn't raise an exception
             zipfp.testzip()
 
-    # TODO: RUSTPYTHON
-    @unittest.expectedFailure
     def test_basic(self):
         for f in get_files(self):
             self.zip_test(f, self.compression)
@@ -394,8 +392,6 @@ class AbstractTestsWithSourceFile:
                 self.assertIn('[closed]', repr(zipopen))
             self.assertIn('[closed]', repr(zipfp))
 
-    # TODO: RUSTPYTHON
-    @unittest.expectedFailure
     def test_compresslevel_basic(self):
         for f in get_files(self):
             self.zip_test(f, self.compression, compresslevel=9)
@@ -751,8 +747,6 @@ class AbstractTestZip64InSmallFiles:
             # Check that testzip doesn't raise an exception
             zipfp.testzip()
 
-    # TODO: RUSTPYTHON
-    @unittest.expectedFailure
     def test_basic(self):
         for f in get_files(self):
             self.zip_test(f, self.compression)


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Updated time.strptime() to use the standard CPython parsing behavior — error responses and returned time representations now match CPython for improved compatibility and more consistent parsing results.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->