### PR TITLE
Enable TestMethodsMutating

### DIFF
--- a/Lib/test/test_set.py
+++ b/Lib/test/test_set.py
@@ -1898,7 +1898,6 @@ class TestBinaryOpsMutating_Subclass_Set(TestBinaryOpsMutating, unittest.TestCas
     constructor2 = set
 
 
-@unittest.skip("TODO: RUSTPYTHON; segfault")
 class TestMethodsMutating(TestOperationsMutating):
 
     def test_issubset_with_mutation(self):

--- a/Lib/test/test_set.py
+++ b/Lib/test/test_set.py
@@ -1809,7 +1809,6 @@ class TestOperationsMutating:
                 self.assertIn("changed size during iteration", str(e))
 
 
-@unittest.skip("TODO: RUSTPYTHON; segfault")
 class TestBinaryOpsMutating(TestOperationsMutating):
 
     def test_eq_with_mutation(self):

--- a/vm/src/dict_inner.rs
+++ b/vm/src/dict_inner.rs
@@ -582,12 +582,13 @@ impl<T: Clone> Dict<T> {
                 });
                 loop {
                     let index_index = idxs.next();
-                    let index_entry_ptr = inner.indices.get(index_index);
-                    if index_entry_ptr.is_none() {
-                        // Dictionary was modified under our hands, see TestMethodsMutating.
-                        continue 'outer;
-                    }
-                    let index_entry = *index_entry_ptr.unwrap();
+                    let index_entry = match inner.indices.get(index_index) {
+                        None => {
+                            // Dictionary was modified under our hands, see TestMethodsMutating.
+                            continue 'outer;
+                        }
+                        Some(v) => *v,
+                    };
                     match index_entry {
                         IndexEntry::DUMMY => {
                             if free_slot.is_none() {

--- a/vm/src/dict_inner.rs
+++ b/vm/src/dict_inner.rs
@@ -582,10 +582,12 @@ impl<T: Clone> Dict<T> {
                 });
                 loop {
                     let index_index = idxs.next();
-                    let index_entry = *unsafe {
-                        // Safety: index_index is generated
-                        inner.indices.get_unchecked(index_index)
-                    };
+                    let index_entry_ptr = inner.indices.get(index_index);
+                    if index_entry_ptr.is_none() {
+                        // Dictionary was modified under our hands, see TestMethodsMutating.
+                        continue 'outer;
+                    }
+                    let index_entry = *index_entry_ptr.unwrap();
                     match index_entry {
                         IndexEntry::DUMMY => {
                             if free_slot.is_none() {

--- a/vm/src/dict_inner.rs
+++ b/vm/src/dict_inner.rs
@@ -574,6 +574,7 @@ impl<T: Clone> Dict<T> {
     ) -> PyResult<LookupResult> {
         let mut idxs = None;
         let mut free_slot = None;
+        let original_size = self.size();
         let ret = 'outer: loop {
             let (entry_key, ret) = {
                 let inner = lock.take().unwrap_or_else(|| self.read());
@@ -585,7 +586,7 @@ impl<T: Clone> Dict<T> {
                     let index_entry = match inner.indices.get(index_index) {
                         None => {
                             // Dictionary was modified under our hands, see TestMethodsMutating.
-                            continue 'outer;
+                            return Err(vm.new_runtime_error("set changed size during iteration"));
                         }
                         Some(v) => *v,
                     };
@@ -600,6 +601,11 @@ impl<T: Clone> Dict<T> {
                                 Some(free) => (IndexEntry::DUMMY, free),
                                 None => (IndexEntry::FREE, index_index),
                             };
+                            if self.has_changed_size(&original_size) {
+                                return Err(
+                                    vm.new_runtime_error("set changed size during iteration")
+                                );
+                            }
                             return Ok(idxs);
                         }
                         idx => {
@@ -631,6 +637,9 @@ impl<T: Clone> Dict<T> {
 
             // warn!("Perturb value: {}", i);
         };
+        if self.has_changed_size(&original_size) {
+            return Err(vm.new_runtime_error("set changed size during iteration"));
+        }
         Ok(ret)
     }
 


### PR DESCRIPTION
Make Dict::lookup check if the dictionary has been modified. This is a workaround for a possible segfault. See bpo-46615 for the original discussion in CPython.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved dictionary iteration robustness: operations that modify a collection during iteration now produce a clear runtime error ("set changed size during iteration") instead of risking crashes, preventing silent corruption and improving stability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->