### PR TITLE
5539 - CTRL+Z then Enter will now close shell on Windows.

### DIFF
--- a/vm/src/readline.rs
+++ b/vm/src/readline.rs
@@ -76,6 +76,7 @@ mod rustyline_readline {
         repl: rustyline::Editor<H, rustyline::history::DefaultHistory>,
     }
 
+    #[cfg(windows)]
     const EOF_CHAR: &str = "\u{001A}";
 
     impl<H: Helper> Readline<H> {


### PR DESCRIPTION
Fixes #5539 

Sending CTRL+Z will now cause the shell to close on Windows. 

The EOF will still be stored in the history. This is how it works when running python on CMD and Powershell so I figured I'd leave it alone. Not sure if that's a python feature or a feature of those particular shells 😄

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * CTRL+Z on Windows now correctly signals end-of-file in the interactive REPL. Trailing carriage returns/newlines are trimmed so an explicit EOF input is recognized when running in a terminal. Non-Windows platforms and other input paths retain previous behavior; public interfaces remain unchanged.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->