### PR TITLE
Add callable validation to `codecs.register_error`

### DIFF
--- a/Lib/test/test_codeccallbacks.py
+++ b/Lib/test/test_codeccallbacks.py
@@ -909,8 +909,6 @@ class CodecCallbackTest(unittest.TestCase):
                 self.assertEqual(exc.object, input)
                 self.assertEqual(exc.reason, "surrogates not allowed")
 
-    # TODO: RUSTPYTHON
-    @unittest.expectedFailure
     def test_badregistercall(self):
         # enhance coverage of:
         # Modules/_codecsmodule.c::register_error()

--- a/vm/src/stdlib/codecs.rs
+++ b/vm/src/stdlib/codecs.rs
@@ -67,10 +67,14 @@ mod _codecs {
     }
 
     #[pyfunction]
-    fn register_error(name: PyStrRef, handler: PyObjectRef, vm: &VirtualMachine) {
+    fn register_error(name: PyStrRef, handler: PyObjectRef, vm: &VirtualMachine) -> PyResult<()> {
+        if !handler.is_callable() {
+            return Err(vm.new_type_error("handler must be callable".to_owned()));
+        }
         vm.state
             .codec_registry
             .register_error(name.as_str().to_owned(), handler);
+        Ok(())
     }
 
     #[pyfunction]


### PR DESCRIPTION
Validate that the handler argument passed to codecs.register_error is callable, raising TypeError with message 'handler must be callable' if it is not.

This fix enables test_badregistercall in test_codeccallbacks.py to pass.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handler registration with enhanced validation to ensure handlers are callable, returning appropriate error messages when validation fails.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->