### PR TITLE
Fix #[pyclass(base=...)] notation

### DIFF
--- a/derive-impl/src/pyclass.rs
+++ b/derive-impl/src/pyclass.rs
@@ -308,7 +308,7 @@ fn generate_class_def(
     ident: &Ident,
     name: &str,
     module_name: Option<&str>,
-    base: Option<String>,
+    base: Option<syn::Path>,
     metaclass: Option<String>,
     unhashable: bool,
     attrs: &[Attribute],
@@ -358,7 +358,6 @@ fn generate_class_def(
         Some(quote! { rustpython_vm::builtins::PyTuple })
     } else {
         base.as_ref().map(|typ| {
-            let typ = Ident::new(typ, ident.span());
             quote_spanned! { ident.span() => #typ }
         })
     }
@@ -382,7 +381,6 @@ fn generate_class_def(
     });
 
     let base_or_object = if let Some(base) = base {
-        let base = Ident::new(&base, ident.span());
         quote! { #base }
     } else {
         quote! { ::rustpython_vm::builtins::PyBaseObject }

--- a/derive/src/lib.rs
+++ b/derive/src/lib.rs
@@ -34,7 +34,7 @@ pub fn derive_from_args(input: TokenStream) -> TokenStream {
 ///     - `IMMUTABLETYPE`: class attributes are immutable.
 /// - `with`: which trait implementations are to be included in the python class.
 /// ```rust, ignore
-/// #[pyclass(module = "my_module", name = "MyClass", base = "BaseClass")]
+/// #[pyclass(module = "my_module", name = "MyClass", base = BaseClass)]
 /// struct MyStruct {
 ///    x: i32,
 /// }

--- a/stdlib/src/ssl.rs
+++ b/stdlib/src/ssl.rs
@@ -246,7 +246,7 @@ mod _ssl {
 
     /// An error occurred in the SSL implementation.
     #[pyattr]
-    #[pyexception(name = "SSLError", base = "PyOSError")]
+    #[pyexception(name = "SSLError", base = PyOSError)]
     #[derive(Debug)]
     pub struct PySslError {}
 
@@ -269,7 +269,7 @@ mod _ssl {
 
     /// A certificate could not be verified.
     #[pyattr]
-    #[pyexception(name = "SSLCertVerificationError", base = "PySslError")]
+    #[pyexception(name = "SSLCertVerificationError", base = PySslError)]
     #[derive(Debug)]
     pub struct PySslCertVerificationError {}
 
@@ -278,7 +278,7 @@ mod _ssl {
 
     /// SSL/TLS session closed cleanly.
     #[pyattr]
-    #[pyexception(name = "SSLZeroReturnError", base = "PySslError")]
+    #[pyexception(name = "SSLZeroReturnError", base = PySslError)]
     #[derive(Debug)]
     pub struct PySslZeroReturnError {}
 
@@ -287,7 +287,7 @@ mod _ssl {
 
     /// Non-blocking SSL socket needs to read more data.
     #[pyattr]
-    #[pyexception(name = "SSLWantReadError", base = "PySslError")]
+    #[pyexception(name = "SSLWantReadError", base = PySslError)]
     #[derive(Debug)]
     pub struct PySslWantReadError {}
 
@@ -296,7 +296,7 @@ mod _ssl {
 
     /// Non-blocking SSL socket needs to write more data.
     #[pyattr]
-    #[pyexception(name = "SSLWantWriteError", base = "PySslError")]
+    #[pyexception(name = "SSLWantWriteError", base = PySslError)]
     #[derive(Debug)]
     pub struct PySslWantWriteError {}
 
@@ -305,7 +305,7 @@ mod _ssl {
 
     /// System error when attempting SSL operation.
     #[pyattr]
-    #[pyexception(name = "SSLSyscallError", base = "PySslError")]
+    #[pyexception(name = "SSLSyscallError", base = PySslError)]
     #[derive(Debug)]
     pub struct PySslSyscallError {}
 
@@ -314,7 +314,7 @@ mod _ssl {
 
     /// SSL/TLS connection terminated abruptly.
     #[pyattr]
-    #[pyexception(name = "SSLEOFError", base = "PySslError")]
+    #[pyexception(name = "SSLEOFError", base = PySslError)]
     #[derive(Debug)]
     pub struct PySslEOFError {}
 

--- a/vm/src/builtins/bool.rs
+++ b/vm/src/builtins/bool.rs
@@ -77,7 +77,7 @@ impl PyObjectRef {
     }
 }
 
-#[pyclass(name = "bool", module = false, base = "PyInt")]
+#[pyclass(name = "bool", module = false, base = PyInt)]
 pub struct PyBool;
 
 impl PyPayload for PyBool {

--- a/vm/src/builtins/builtin_func.rs
+++ b/vm/src/builtins/builtin_func.rs
@@ -148,7 +148,7 @@ impl Representable for PyNativeFunction {
 impl Unconstructible for PyNativeFunction {}
 
 // `PyCMethodObject` in CPython
-#[pyclass(name = "builtin_method", module = false, base = "PyNativeFunction")]
+#[pyclass(name = "builtin_method", module = false, base = PyNativeFunction)]
 pub struct PyNativeMethod {
     pub(crate) func: PyNativeFunction,
     pub(crate) class: &'static Py<PyType>, // TODO: the actual life is &'self

--- a/vm/src/exceptions.rs
+++ b/vm/src/exceptions.rs
@@ -1225,11 +1225,11 @@ pub(super) mod types {
         pub(super) args: PyRwLock<PyTupleRef>,
     }
 
-    #[pyexception(name, base = "PyBaseException", ctx = "system_exit", impl)]
+    #[pyexception(name, base = PyBaseException, ctx = "system_exit", impl)]
     #[derive(Debug)]
     pub struct PySystemExit {}
 
-    #[pyexception(name, base = "PyBaseException", ctx = "base_exception_group")]
+    #[pyexception(name, base = PyBaseException, ctx = "base_exception_group")]
     #[derive(Debug)]
     pub struct PyBaseExceptionGroup {}
 
@@ -1245,23 +1245,23 @@ pub(super) mod types {
         }
     }
 
-    #[pyexception(name, base = "PyBaseExceptionGroup", ctx = "exception_group", impl)]
+    #[pyexception(name, base = PyBaseExceptionGroup, ctx = "exception_group", impl)]
     #[derive(Debug)]
     pub struct PyExceptionGroup {}
 
-    #[pyexception(name, base = "PyBaseException", ctx = "generator_exit", impl)]
+    #[pyexception(name, base = PyBaseException, ctx = "generator_exit", impl)]
     #[derive(Debug)]
     pub struct PyGeneratorExit {}
 
-    #[pyexception(name, base = "PyBaseException", ctx = "keyboard_interrupt", impl)]
+    #[pyexception(name, base = PyBaseException, ctx = "keyboard_interrupt", impl)]
     #[derive(Debug)]
     pub struct PyKeyboardInterrupt {}
 
-    #[pyexception(name, base = "PyBaseException", ctx = "exception_type", impl)]
+    #[pyexception(name, base = PyBaseException, ctx = "exception_type", impl)]
     #[derive(Debug)]
     pub struct PyException {}
 
-    #[pyexception(name, base = "PyException", ctx = "stop_iteration")]
+    #[pyexception(name, base = PyException, ctx = "stop_iteration")]
     #[derive(Debug)]
     pub struct PyStopIteration {}
 
@@ -1279,31 +1279,31 @@ pub(super) mod types {
         }
     }
 
-    #[pyexception(name, base = "PyException", ctx = "stop_async_iteration", impl)]
+    #[pyexception(name, base = PyException, ctx = "stop_async_iteration", impl)]
     #[derive(Debug)]
     pub struct PyStopAsyncIteration {}
 
-    #[pyexception(name, base = "PyException", ctx = "arithmetic_error", impl)]
+    #[pyexception(name, base = PyException, ctx = "arithmetic_error", impl)]
     #[derive(Debug)]
     pub struct PyArithmeticError {}
 
-    #[pyexception(name, base = "PyArithmeticError", ctx = "floating_point_error", impl)]
+    #[pyexception(name, base = PyArithmeticError, ctx = "floating_point_error", impl)]
     #[derive(Debug)]
     pub struct PyFloatingPointError {}
 
-    #[pyexception(name, base = "PyArithmeticError", ctx = "overflow_error", impl)]
+    #[pyexception(name, base = PyArithmeticError, ctx = "overflow_error", impl)]
     #[derive(Debug)]
     pub struct PyOverflowError {}
 
-    #[pyexception(name, base = "PyArithmeticError", ctx = "zero_division_error", impl)]
+    #[pyexception(name, base = PyArithmeticError, ctx = "zero_division_error", impl)]
     #[derive(Debug)]
     pub struct PyZeroDivisionError {}
 
-    #[pyexception(name, base = "PyException", ctx = "assertion_error", impl)]
+    #[pyexception(name, base = PyException, ctx = "assertion_error", impl)]
     #[derive(Debug)]
     pub struct PyAssertionError {}
 
-    #[pyexception(name, base = "PyException", ctx = "attribute_error")]
+    #[pyexception(name, base = PyException, ctx = "attribute_error")]
     #[derive(Debug)]
     pub struct PyAttributeError {}
 
@@ -1330,15 +1330,15 @@ pub(super) mod types {
         }
     }
 
-    #[pyexception(name, base = "PyException", ctx = "buffer_error", impl)]
+    #[pyexception(name, base = PyException, ctx = "buffer_error", impl)]
     #[derive(Debug)]
     pub struct PyBufferError {}
 
-    #[pyexception(name, base = "PyException", ctx = "eof_error", impl)]
+    #[pyexception(name, base = PyException, ctx = "eof_error", impl)]
     #[derive(Debug)]
     pub struct PyEOFError {}
 
-    #[pyexception(name, base = "PyException", ctx = "import_error")]
+    #[pyexception(name, base = PyException, ctx = "import_error")]
     #[derive(Debug)]
     pub struct PyImportError {}
 
@@ -1383,19 +1383,19 @@ pub(super) mod types {
         }
     }
 
-    #[pyexception(name, base = "PyImportError", ctx = "module_not_found_error", impl)]
+    #[pyexception(name, base = PyImportError, ctx = "module_not_found_error", impl)]
     #[derive(Debug)]
     pub struct PyModuleNotFoundError {}
 
-    #[pyexception(name, base = "PyException", ctx = "lookup_error", impl)]
+    #[pyexception(name, base = PyException, ctx = "lookup_error", impl)]
     #[derive(Debug)]
     pub struct PyLookupError {}
 
-    #[pyexception(name, base = "PyLookupError", ctx = "index_error", impl)]
+    #[pyexception(name, base = PyLookupError, ctx = "index_error", impl)]
     #[derive(Debug)]
     pub struct PyIndexError {}
 
-    #[pyexception(name, base = "PyLookupError", ctx = "key_error")]
+    #[pyexception(name, base = PyLookupError, ctx = "key_error")]
     #[derive(Debug)]
     pub struct PyKeyError {}
 
@@ -1415,19 +1415,19 @@ pub(super) mod types {
         }
     }
 
-    #[pyexception(name, base = "PyException", ctx = "memory_error", impl)]
+    #[pyexception(name, base = PyException, ctx = "memory_error", impl)]
     #[derive(Debug)]
     pub struct PyMemoryError {}
 
-    #[pyexception(name, base = "PyException", ctx = "name_error", impl)]
+    #[pyexception(name, base = PyException, ctx = "name_error", impl)]
     #[derive(Debug)]
     pub struct PyNameError {}
 
-    #[pyexception(name, base = "PyNameError", ctx = "unbound_local_error", impl)]
+    #[pyexception(name, base = PyNameError, ctx = "unbound_local_error", impl)]
     #[derive(Debug)]
     pub struct PyUnboundLocalError {}
 
-    #[pyexception(name, base = "PyException", ctx = "os_error")]
+    #[pyexception(name, base = PyException, ctx = "os_error")]
     #[derive(Debug)]
     pub struct PyOSError {}
 
@@ -1558,25 +1558,25 @@ pub(super) mod types {
         }
     }
 
-    #[pyexception(name, base = "PyOSError", ctx = "blocking_io_error", impl)]
+    #[pyexception(name, base = PyOSError, ctx = "blocking_io_error", impl)]
     #[derive(Debug)]
     pub struct PyBlockingIOError {}
 
-    #[pyexception(name, base = "PyOSError", ctx = "child_process_error", impl)]
+    #[pyexception(name, base = PyOSError, ctx = "child_process_error", impl)]
     #[derive(Debug)]
     pub struct PyChildProcessError {}
 
-    #[pyexception(name, base = "PyOSError", ctx = "connection_error", impl)]
+    #[pyexception(name, base = PyOSError, ctx = "connection_error", impl)]
     #[derive(Debug)]
     pub struct PyConnectionError {}
 
-    #[pyexception(name, base = "PyConnectionError", ctx = "broken_pipe_error", impl)]
+    #[pyexception(name, base = PyConnectionError, ctx = "broken_pipe_error", impl)]
     #[derive(Debug)]
     pub struct PyBrokenPipeError {}
 
     #[pyexception(
         name,
-        base = "PyConnectionError",
+        base = PyConnectionError,
         ctx = "connection_aborted_error",
         impl
     )]
@@ -1585,66 +1585,66 @@ pub(super) mod types {
 
     #[pyexception(
         name,
-        base = "PyConnectionError",
+        base = PyConnectionError,
         ctx = "connection_refused_error",
         impl
     )]
     #[derive(Debug)]
     pub struct PyConnectionRefusedError {}
 
-    #[pyexception(name, base = "PyConnectionError", ctx = "connection_reset_error", impl)]
+    #[pyexception(name, base = PyConnectionError, ctx = "connection_reset_error", impl)]
     #[derive(Debug)]
     pub struct PyConnectionResetError {}
 
-    #[pyexception(name, base = "PyOSError", ctx = "file_exists_error", impl)]
+    #[pyexception(name, base = PyOSError, ctx = "file_exists_error", impl)]
     #[derive(Debug)]
     pub struct PyFileExistsError {}
 
-    #[pyexception(name, base = "PyOSError", ctx = "file_not_found_error", impl)]
+    #[pyexception(name, base = PyOSError, ctx = "file_not_found_error", impl)]
     #[derive(Debug)]
     pub struct PyFileNotFoundError {}
 
-    #[pyexception(name, base = "PyOSError", ctx = "interrupted_error", impl)]
+    #[pyexception(name, base = PyOSError, ctx = "interrupted_error", impl)]
     #[derive(Debug)]
     pub struct PyInterruptedError {}
 
-    #[pyexception(name, base = "PyOSError", ctx = "is_a_directory_error", impl)]
+    #[pyexception(name, base = PyOSError, ctx = "is_a_directory_error", impl)]
     #[derive(Debug)]
     pub struct PyIsADirectoryError {}
 
-    #[pyexception(name, base = "PyOSError", ctx = "not_a_directory_error", impl)]
+    #[pyexception(name, base = PyOSError, ctx = "not_a_directory_error", impl)]
     #[derive(Debug)]
     pub struct PyNotADirectoryError {}
 
-    #[pyexception(name, base = "PyOSError", ctx = "permission_error", impl)]
+    #[pyexception(name, base = PyOSError, ctx = "permission_error", impl)]
     #[derive(Debug)]
     pub struct PyPermissionError {}
 
-    #[pyexception(name, base = "PyOSError", ctx = "process_lookup_error", impl)]
+    #[pyexception(name, base = PyOSError, ctx = "process_lookup_error", impl)]
     #[derive(Debug)]
     pub struct PyProcessLookupError {}
 
-    #[pyexception(name, base = "PyOSError", ctx = "timeout_error", impl)]
+    #[pyexception(name, base = PyOSError, ctx = "timeout_error", impl)]
     #[derive(Debug)]
     pub struct PyTimeoutError {}
 
-    #[pyexception(name, base = "PyException", ctx = "reference_error", impl)]
+    #[pyexception(name, base = PyException, ctx = "reference_error", impl)]
     #[derive(Debug)]
     pub struct PyReferenceError {}
 
-    #[pyexception(name, base = "PyException", ctx = "runtime_error", impl)]
+    #[pyexception(name, base = PyException, ctx = "runtime_error", impl)]
     #[derive(Debug)]
     pub struct PyRuntimeError {}
 
-    #[pyexception(name, base = "PyRuntimeError", ctx = "not_implemented_error", impl)]
+    #[pyexception(name, base = PyRuntimeError, ctx = "not_implemented_error", impl)]
     #[derive(Debug)]
     pub struct PyNotImplementedError {}
 
-    #[pyexception(name, base = "PyRuntimeError", ctx = "recursion_error", impl)]
+    #[pyexception(name, base = PyRuntimeError, ctx = "recursion_error", impl)]
     #[derive(Debug)]
     pub struct PyRecursionError {}
 
-    #[pyexception(name, base = "PyException", ctx = "syntax_error")]
+    #[pyexception(name, base = PyException, ctx = "syntax_error")]
     #[derive(Debug)]
     pub struct PySyntaxError {}
 
@@ -1736,7 +1736,7 @@ pub(super) mod types {
 
     #[pyexception(
         name = "_IncompleteInputError",
-        base = "PySyntaxError",
+        base = PySyntaxError,
         ctx = "incomplete_input_error"
     )]
     #[derive(Debug)]
@@ -1756,31 +1756,31 @@ pub(super) mod types {
         }
     }
 
-    #[pyexception(name, base = "PySyntaxError", ctx = "indentation_error", impl)]
+    #[pyexception(name, base = PySyntaxError, ctx = "indentation_error", impl)]
     #[derive(Debug)]
     pub struct PyIndentationError {}
 
-    #[pyexception(name, base = "PyIndentationError", ctx = "tab_error", impl)]
+    #[pyexception(name, base = PyIndentationError, ctx = "tab_error", impl)]
     #[derive(Debug)]
     pub struct PyTabError {}
 
-    #[pyexception(name, base = "PyException", ctx = "system_error", impl)]
+    #[pyexception(name, base = PyException, ctx = "system_error", impl)]
     #[derive(Debug)]
     pub struct PySystemError {}
 
-    #[pyexception(name, base = "PyException", ctx = "type_error", impl)]
+    #[pyexception(name, base = PyException, ctx = "type_error", impl)]
     #[derive(Debug)]
     pub struct PyTypeError {}
 
-    #[pyexception(name, base = "PyException", ctx = "value_error", impl)]
+    #[pyexception(name, base = PyException, ctx = "value_error", impl)]
     #[derive(Debug)]
     pub struct PyValueError {}
 
-    #[pyexception(name, base = "PyValueError", ctx = "unicode_error", impl)]
+    #[pyexception(name, base = PyValueError, ctx = "unicode_error", impl)]
     #[derive(Debug)]
     pub struct PyUnicodeError {}
 
-    #[pyexception(name, base = "PyUnicodeError", ctx = "unicode_decode_error")]
+    #[pyexception(name, base = PyUnicodeError, ctx = "unicode_decode_error")]
     #[derive(Debug)]
     pub struct PyUnicodeDecodeError {}
 
@@ -1831,7 +1831,7 @@ pub(super) mod types {
         }
     }
 
-    #[pyexception(name, base = "PyUnicodeError", ctx = "unicode_encode_error")]
+    #[pyexception(name, base = PyUnicodeError, ctx = "unicode_encode_error")]
     #[derive(Debug)]
     pub struct PyUnicodeEncodeError {}
 
@@ -1882,7 +1882,7 @@ pub(super) mod types {
         }
     }
 
-    #[pyexception(name, base = "PyUnicodeError", ctx = "unicode_translate_error")]
+    #[pyexception(name, base = PyUnicodeError, ctx = "unicode_translate_error")]
     #[derive(Debug)]
     pub struct PyUnicodeTranslateError {}
 
@@ -1930,56 +1930,56 @@ pub(super) mod types {
 
     /// JIT error.
     #[cfg(feature = "jit")]
-    #[pyexception(name, base = "PyException", ctx = "jit_error", impl)]
+    #[pyexception(name, base = PyException, ctx = "jit_error", impl)]
     #[derive(Debug)]
     pub struct PyJitError {}
 
     // Warnings
-    #[pyexception(name, base = "PyException", ctx = "warning", impl)]
+    #[pyexception(name, base = PyException, ctx = "warning", impl)]
     #[derive(Debug)]
     pub struct PyWarning {}
 
-    #[pyexception(name, base = "PyWarning", ctx = "deprecation_warning", impl)]
+    #[pyexception(name, base = PyWarning, ctx = "deprecation_warning", impl)]
     #[derive(Debug)]
     pub struct PyDeprecationWarning {}
 
-    #[pyexception(name, base = "PyWarning", ctx = "pending_deprecation_warning", impl)]
+    #[pyexception(name, base = PyWarning, ctx = "pending_deprecation_warning", impl)]
     #[derive(Debug)]
     pub struct PyPendingDeprecationWarning {}
 
-    #[pyexception(name, base = "PyWarning", ctx = "runtime_warning", impl)]
+    #[pyexception(name, base = PyWarning, ctx = "runtime_warning", impl)]
     #[derive(Debug)]
     pub struct PyRuntimeWarning {}
 
-    #[pyexception(name, base = "PyWarning", ctx = "syntax_warning", impl)]
+    #[pyexception(name, base = PyWarning, ctx = "syntax_warning", impl)]
     #[derive(Debug)]
     pub struct PySyntaxWarning {}
 
-    #[pyexception(name, base = "PyWarning", ctx = "user_warning", impl)]
+    #[pyexception(name, base = PyWarning, ctx = "user_warning", impl)]
     #[derive(Debug)]
     pub struct PyUserWarning {}
 
-    #[pyexception(name, base = "PyWarning", ctx = "future_warning", impl)]
+    #[pyexception(name, base = PyWarning, ctx = "future_warning", impl)]
     #[derive(Debug)]
     pub struct PyFutureWarning {}
 
-    #[pyexception(name, base = "PyWarning", ctx = "import_warning", impl)]
+    #[pyexception(name, base = PyWarning, ctx = "import_warning", impl)]
     #[derive(Debug)]
     pub struct PyImportWarning {}
 
-    #[pyexception(name, base = "PyWarning", ctx = "unicode_warning", impl)]
+    #[pyexception(name, base = PyWarning, ctx = "unicode_warning", impl)]
     #[derive(Debug)]
     pub struct PyUnicodeWarning {}
 
-    #[pyexception(name, base = "PyWarning", ctx = "bytes_warning", impl)]
+    #[pyexception(name, base = PyWarning, ctx = "bytes_warning", impl)]
     #[derive(Debug)]
     pub struct PyBytesWarning {}
 
-    #[pyexception(name, base = "PyWarning", ctx = "resource_warning", impl)]
+    #[pyexception(name, base = PyWarning, ctx = "resource_warning", impl)]
     #[derive(Debug)]
     pub struct PyResourceWarning {}
 
-    #[pyexception(name, base = "PyWarning", ctx = "encoding_warning", impl)]
+    #[pyexception(name, base = PyWarning, ctx = "encoding_warning", impl)]
     #[derive(Debug)]
     pub struct PyEncodingWarning {}
 }

--- a/vm/src/stdlib/ast/pyast.rs
+++ b/vm/src/stdlib/ast/pyast.rs
@@ -77,774 +77,774 @@ macro_rules! impl_node {
     };
 }
 
-#[pyclass(module = "_ast", name = "mod", base = "NodeAst")]
+#[pyclass(module = "_ast", name = "mod", base = NodeAst)]
 pub(crate) struct NodeMod;
 
 #[pyclass(flags(HAS_DICT, BASETYPE))]
 impl NodeMod {}
 
 impl_node!(
-    #[pyclass(module = "_ast", name = "Module", base = "NodeMod")]
+    #[pyclass(module = "_ast", name = "Module", base = NodeMod)]
     pub(crate) struct NodeModModule,
     fields: ["body", "type_ignores"],
 );
 
 impl_node!(
-    #[pyclass(module = "_ast", name = "Interactive", base = "NodeMod")]
+    #[pyclass(module = "_ast", name = "Interactive", base = NodeMod)]
     pub(crate) struct NodeModInteractive,
     fields: ["body"],
 );
 
 impl_node!(
-    #[pyclass(module = "_ast", name = "Expression", base = "NodeMod")]
+    #[pyclass(module = "_ast", name = "Expression", base = NodeMod)]
     pub(crate) struct NodeModExpression,
     fields: ["body"],
 );
 
-#[pyclass(module = "_ast", name = "stmt", base = "NodeAst")]
+#[pyclass(module = "_ast", name = "stmt", base = NodeAst)]
 pub(crate) struct NodeStmt;
 
 #[pyclass(flags(HAS_DICT, BASETYPE))]
 impl NodeStmt {}
 
 impl_node!(
-    #[pyclass(module = "_ast", name = "FunctionType", base = "NodeMod")]
+    #[pyclass(module = "_ast", name = "FunctionType", base = NodeMod)]
     pub(crate) struct NodeModFunctionType,
     fields: ["argtypes", "returns"],
 );
 
 impl_node!(
-    #[pyclass(module = "_ast", name = "FunctionDef", base = "NodeStmt")]
+    #[pyclass(module = "_ast", name = "FunctionDef", base = NodeStmt)]
     pub(crate) struct NodeStmtFunctionDef,
     fields: ["name", "args", "body", "decorator_list", "returns", "type_comment", "type_params"],
     attributes: ["lineno", "col_offset", "end_lineno", "end_col_offset"],
 );
 
 impl_node!(
-    #[pyclass(module = "_ast", name = "AsyncFunctionDef", base = "NodeStmt")]
+    #[pyclass(module = "_ast", name = "AsyncFunctionDef", base = NodeStmt)]
     pub(crate) struct NodeStmtAsyncFunctionDef,
     fields: ["name", "args", "body", "decorator_list", "returns", "type_comment", "type_params"],
     attributes: ["lineno", "col_offset", "end_lineno", "end_col_offset"],
 );
 
 impl_node!(
-    #[pyclass(module = "_ast", name = "ClassDef", base = "NodeStmt")]
+    #[pyclass(module = "_ast", name = "ClassDef", base = NodeStmt)]
     pub(crate) struct NodeStmtClassDef,
     fields: ["name", "bases", "keywords", "body", "decorator_list", "type_params"],
     attributes: ["lineno", "col_offset", "end_lineno", "end_col_offset"],
 );
 
 impl_node!(
-    #[pyclass(module = "_ast", name = "Return", base = "NodeStmt")]
+    #[pyclass(module = "_ast", name = "Return", base = NodeStmt)]
     pub(crate) struct NodeStmtReturn,
     fields: ["value"],
     attributes: ["lineno", "col_offset", "end_lineno", "end_col_offset"],
 );
 
 impl_node!(
-    #[pyclass(module = "_ast", name = "Delete", base = "NodeStmt")]
+    #[pyclass(module = "_ast", name = "Delete", base = NodeStmt)]
     pub(crate) struct NodeStmtDelete,
     fields: ["targets"],
     attributes: ["lineno", "col_offset", "end_lineno", "end_col_offset"],
 );
 
 impl_node!(
-    #[pyclass(module = "_ast", name = "Assign", base = "NodeStmt")]
+    #[pyclass(module = "_ast", name = "Assign", base = NodeStmt)]
     pub(crate) struct NodeStmtAssign,
     fields: ["targets", "value", "type_comment"],
     attributes: ["lineno", "col_offset", "end_lineno", "end_col_offset"],
 );
 
 impl_node!(
-    #[pyclass(module = "_ast", name = "TypeAlias", base = "NodeStmt")]
+    #[pyclass(module = "_ast", name = "TypeAlias", base = NodeStmt)]
     pub(crate) struct NodeStmtTypeAlias,
     fields: ["name", "type_params", "value"],
     attributes: ["lineno", "col_offset", "end_lineno", "end_col_offset"],
 );
 
 impl_node!(
-    #[pyclass(module = "_ast", name = "AugAssign", base = "NodeStmt")]
+    #[pyclass(module = "_ast", name = "AugAssign", base = NodeStmt)]
     pub(crate) struct NodeStmtAugAssign,
     fields: ["target", "op", "value"],
     attributes: ["lineno", "col_offset", "end_lineno", "end_col_offset"],
 );
 
 impl_node!(
-    #[pyclass(module = "_ast", name = "AnnAssign", base = "NodeStmt")]
+    #[pyclass(module = "_ast", name = "AnnAssign", base = NodeStmt)]
     pub(crate) struct NodeStmtAnnAssign,
     fields: ["target", "annotation", "value", "simple"],
     attributes: ["lineno", "col_offset", "end_lineno", "end_col_offset"],
 );
 
 impl_node!(
-    #[pyclass(module = "_ast", name = "For", base = "NodeStmt")]
+    #[pyclass(module = "_ast", name = "For", base = NodeStmt)]
     pub(crate) struct NodeStmtFor,
     fields: ["target", "iter", "body", "orelse", "type_comment"],
     attributes: ["lineno", "col_offset", "end_lineno", "end_col_offset"],
 );
 
 impl_node!(
-    #[pyclass(module = "_ast", name = "AsyncFor", base = "NodeStmt")]
+    #[pyclass(module = "_ast", name = "AsyncFor", base = NodeStmt)]
     pub(crate) struct NodeStmtAsyncFor,
     fields: ["target", "iter", "body", "orelse", "type_comment"],
     attributes: ["lineno", "col_offset", "end_lineno", "end_col_offset"],
 );
 
 impl_node!(
-    #[pyclass(module = "_ast", name = "While", base = "NodeStmt")]
+    #[pyclass(module = "_ast", name = "While", base = NodeStmt)]
     pub(crate) struct NodeStmtWhile,
     fields: ["test", "body", "orelse"],
     attributes: ["lineno", "col_offset", "end_lineno", "end_col_offset"],
 );
 
 impl_node!(
-    #[pyclass(module = "_ast", name = "If", base = "NodeStmt")]
+    #[pyclass(module = "_ast", name = "If", base = NodeStmt)]
     pub(crate) struct NodeStmtIf,
     fields: ["test", "body", "orelse"],
     attributes: ["lineno", "col_offset", "end_lineno", "end_col_offset"],
 );
 
 impl_node!(
-    #[pyclass(module = "_ast", name = "With", base = "NodeStmt")]
+    #[pyclass(module = "_ast", name = "With", base = NodeStmt)]
     pub(crate) struct NodeStmtWith,
     fields: ["items", "body", "type_comment"],
     attributes: ["lineno", "col_offset", "end_lineno", "end_col_offset"],
 );
 
 impl_node!(
-    #[pyclass(module = "_ast", name = "AsyncWith", base = "NodeStmt")]
+    #[pyclass(module = "_ast", name = "AsyncWith", base = NodeStmt)]
     pub(crate) struct NodeStmtAsyncWith,
     fields: ["items", "body", "type_comment"],
     attributes: ["lineno", "col_offset", "end_lineno", "end_col_offset"],
 );
 
 impl_node!(
-    #[pyclass(module = "_ast", name = "Match", base = "NodeStmt")]
+    #[pyclass(module = "_ast", name = "Match", base = NodeStmt)]
     pub(crate) struct NodeStmtMatch,
     fields: ["subject", "cases"],
     attributes: ["lineno", "col_offset", "end_lineno", "end_col_offset"],
 );
 
 impl_node!(
-    #[pyclass(module = "_ast", name = "Raise", base = "NodeStmt")]
+    #[pyclass(module = "_ast", name = "Raise", base = NodeStmt)]
     pub(crate) struct NodeStmtRaise,
     fields: ["exc", "cause"],
     attributes: ["lineno", "col_offset", "end_lineno", "end_col_offset"],
 );
 
 impl_node!(
-    #[pyclass(module = "_ast", name = "Try", base = "NodeStmt")]
+    #[pyclass(module = "_ast", name = "Try", base = NodeStmt)]
     pub(crate) struct NodeStmtTry,
     fields: ["body", "handlers", "orelse", "finalbody"],
     attributes: ["lineno", "col_offset", "end_lineno", "end_col_offset"],
 );
 
 impl_node!(
-    #[pyclass(module = "_ast", name = "TryStar", base = "NodeStmt")]
+    #[pyclass(module = "_ast", name = "TryStar", base = NodeStmt)]
     pub(crate) struct NodeStmtTryStar,
     fields: ["body", "handlers", "orelse", "finalbody"],
     attributes: ["lineno", "col_offset", "end_lineno", "end_col_offset"],
 );
 
 impl_node!(
-    #[pyclass(module = "_ast", name = "Assert", base = "NodeStmt")]
+    #[pyclass(module = "_ast", name = "Assert", base = NodeStmt)]
     pub(crate) struct NodeStmtAssert,
     fields: ["test", "msg"],
     attributes: ["lineno", "col_offset", "end_lineno", "end_col_offset"],
 );
 
 impl_node!(
-    #[pyclass(module = "_ast", name = "Import", base = "NodeStmt")]
+    #[pyclass(module = "_ast", name = "Import", base = NodeStmt)]
     pub(crate) struct NodeStmtImport,
     fields: ["names"],
     attributes: ["lineno", "col_offset", "end_lineno", "end_col_offset"],
 );
 
 impl_node!(
-    #[pyclass(module = "_ast", name = "ImportFrom", base = "NodeStmt")]
+    #[pyclass(module = "_ast", name = "ImportFrom", base = NodeStmt)]
     pub(crate) struct NodeStmtImportFrom,
     fields: ["module", "names", "level"],
     attributes: ["lineno", "col_offset", "end_lineno", "end_col_offset"],
 );
 
 impl_node!(
-    #[pyclass(module = "_ast", name = "Global", base = "NodeStmt")]
+    #[pyclass(module = "_ast", name = "Global", base = NodeStmt)]
     pub(crate) struct NodeStmtGlobal,
     fields: ["names"],
     attributes: ["lineno", "col_offset", "end_lineno", "end_col_offset"],
 );
 
 impl_node!(
-    #[pyclass(module = "_ast", name = "Nonlocal", base = "NodeStmt")]
+    #[pyclass(module = "_ast", name = "Nonlocal", base = NodeStmt)]
     pub(crate) struct NodeStmtNonlocal,
     fields: ["names"],
     attributes: ["lineno", "col_offset", "end_lineno", "end_col_offset"],
 );
 
 impl_node!(
-    #[pyclass(module = "_ast", name = "Expr", base = "NodeStmt")]
+    #[pyclass(module = "_ast", name = "Expr", base = NodeStmt)]
     pub(crate) struct NodeStmtExpr,
     fields: ["value"],
     attributes: ["lineno", "col_offset", "end_lineno", "end_col_offset"],
 );
 
 impl_node!(
-    #[pyclass(module = "_ast", name = "Pass", base = "NodeStmt")]
+    #[pyclass(module = "_ast", name = "Pass", base = NodeStmt)]
     pub(crate) struct NodeStmtPass,
     attributes: ["lineno", "col_offset", "end_lineno", "end_col_offset"],
 );
 
 impl_node!(
-    #[pyclass(module = "_ast", name = "Break", base = "NodeStmt")]
+    #[pyclass(module = "_ast", name = "Break", base = NodeStmt)]
     pub(crate) struct NodeStmtBreak,
     attributes: ["lineno", "col_offset", "end_lineno", "end_col_offset"],
 );
 
-#[pyclass(module = "_ast", name = "expr", base = "NodeAst")]
+#[pyclass(module = "_ast", name = "expr", base = NodeAst)]
 pub(crate) struct NodeExpr;
 
 #[pyclass(flags(HAS_DICT, BASETYPE))]
 impl NodeExpr {}
 
 impl_node!(
-    #[pyclass(module = "_ast", name = "Continue", base = "NodeStmt")]
+    #[pyclass(module = "_ast", name = "Continue", base = NodeStmt)]
     pub(crate) struct NodeStmtContinue,
     attributes: ["lineno", "col_offset", "end_lineno", "end_col_offset"],
 );
 
 impl_node!(
-    #[pyclass(module = "_ast", name = "BoolOp", base = "NodeExpr")]
+    #[pyclass(module = "_ast", name = "BoolOp", base = NodeExpr)]
     pub(crate) struct NodeExprBoolOp,
     fields: ["op", "values"],
     attributes: ["lineno", "col_offset", "end_lineno", "end_col_offset"],
 );
 
 impl_node!(
-    #[pyclass(module = "_ast", name = "NamedExpr", base = "NodeExpr")]
+    #[pyclass(module = "_ast", name = "NamedExpr", base = NodeExpr)]
     pub(crate) struct NodeExprNamedExpr,
     fields: ["target", "value"],
     attributes: ["lineno", "col_offset", "end_lineno", "end_col_offset"],
 );
 
 impl_node!(
-    #[pyclass(module = "_ast", name = "BinOp", base = "NodeExpr")]
+    #[pyclass(module = "_ast", name = "BinOp", base = NodeExpr)]
     pub(crate) struct NodeExprBinOp,
     fields: ["left", "op", "right"],
     attributes: ["lineno", "col_offset", "end_lineno", "end_col_offset"],
 );
 
 impl_node!(
-    #[pyclass(module = "_ast", name = "UnaryOp", base = "NodeExpr")]
+    #[pyclass(module = "_ast", name = "UnaryOp", base = NodeExpr)]
     pub(crate) struct NodeExprUnaryOp,
     fields: ["op", "operand"],
     attributes: ["lineno", "col_offset", "end_lineno", "end_col_offset"],
 );
 
 impl_node!(
-    #[pyclass(module = "_ast", name = "Lambda", base = "NodeExpr")]
+    #[pyclass(module = "_ast", name = "Lambda", base = NodeExpr)]
     pub(crate) struct NodeExprLambda,
     fields: ["args", "body"],
     attributes: ["lineno", "col_offset", "end_lineno", "end_col_offset"],
 );
 
 impl_node!(
-    #[pyclass(module = "_ast", name = "IfExp", base = "NodeExpr")]
+    #[pyclass(module = "_ast", name = "IfExp", base = NodeExpr)]
     pub(crate) struct NodeExprIfExp,
     fields: ["test", "body", "orelse"],
     attributes: ["lineno", "col_offset", "end_lineno", "end_col_offset"],
 );
 
 impl_node!(
-    #[pyclass(module = "_ast", name = "Dict", base = "NodeExpr")]
+    #[pyclass(module = "_ast", name = "Dict", base = NodeExpr)]
     pub(crate) struct NodeExprDict,
     fields: ["keys", "values"],
     attributes: ["lineno", "col_offset", "end_lineno", "end_col_offset"],
 );
 
 impl_node!(
-    #[pyclass(module = "_ast", name = "Set", base = "NodeExpr")]
+    #[pyclass(module = "_ast", name = "Set", base = NodeExpr)]
     pub(crate) struct NodeExprSet,
     fields: ["elts"],
     attributes: ["lineno", "col_offset", "end_lineno", "end_col_offset"],
 );
 
 impl_node!(
-    #[pyclass(module = "_ast", name = "ListComp", base = "NodeExpr")]
+    #[pyclass(module = "_ast", name = "ListComp", base = NodeExpr)]
     pub(crate) struct NodeExprListComp,
     fields: ["elt", "generators"],
     attributes: ["lineno", "col_offset", "end_lineno", "end_col_offset"],
 );
 
 impl_node!(
-    #[pyclass(module = "_ast", name = "SetComp", base = "NodeExpr")]
+    #[pyclass(module = "_ast", name = "SetComp", base = NodeExpr)]
     pub(crate) struct NodeExprSetComp,
     fields: ["elt", "generators"],
     attributes: ["lineno", "col_offset", "end_lineno", "end_col_offset"],
 );
 
 impl_node!(
-    #[pyclass(module = "_ast", name = "DictComp", base = "NodeExpr")]
+    #[pyclass(module = "_ast", name = "DictComp", base = NodeExpr)]
     pub(crate) struct NodeExprDictComp,
     fields: ["key", "value", "generators"],
     attributes: ["lineno", "col_offset", "end_lineno", "end_col_offset"],
 );
 
 impl_node!(
-    #[pyclass(module = "_ast", name = "GeneratorExp", base = "NodeExpr")]
+    #[pyclass(module = "_ast", name = "GeneratorExp", base = NodeExpr)]
     pub(crate) struct NodeExprGeneratorExp,
     fields: ["elt", "generators"],
     attributes: ["lineno", "col_offset", "end_lineno", "end_col_offset"],
 );
 
 impl_node!(
-    #[pyclass(module = "_ast", name = "Await", base = "NodeExpr")]
+    #[pyclass(module = "_ast", name = "Await", base = NodeExpr)]
     pub(crate) struct NodeExprAwait,
     fields: ["value"],
     attributes: ["lineno", "col_offset", "end_lineno", "end_col_offset"],
 );
 
 impl_node!(
-    #[pyclass(module = "_ast", name = "Yield", base = "NodeExpr")]
+    #[pyclass(module = "_ast", name = "Yield", base = NodeExpr)]
     pub(crate) struct NodeExprYield,
     fields: ["value"],
     attributes: ["lineno", "col_offset", "end_lineno", "end_col_offset"],
 );
 
 impl_node!(
-    #[pyclass(module = "_ast", name = "YieldFrom", base = "NodeExpr")]
+    #[pyclass(module = "_ast", name = "YieldFrom", base = NodeExpr)]
     pub(crate) struct NodeExprYieldFrom,
     fields: ["value"],
     attributes: ["lineno", "col_offset", "end_lineno", "end_col_offset"],
 );
 
 impl_node!(
-    #[pyclass(module = "_ast", name = "Compare", base = "NodeExpr")]
+    #[pyclass(module = "_ast", name = "Compare", base = NodeExpr)]
     pub(crate) struct NodeExprCompare,
     fields: ["left", "ops", "comparators"],
     attributes: ["lineno", "col_offset", "end_lineno", "end_col_offset"],
 );
 
 impl_node!(
-    #[pyclass(module = "_ast", name = "Call", base = "NodeExpr")]
+    #[pyclass(module = "_ast", name = "Call", base = NodeExpr)]
     pub(crate) struct NodeExprCall,
     fields: ["func", "args", "keywords"],
     attributes: ["lineno", "col_offset", "end_lineno", "end_col_offset"],
 );
 
 impl_node!(
-    #[pyclass(module = "_ast", name = "FormattedValue", base = "NodeExpr")]
+    #[pyclass(module = "_ast", name = "FormattedValue", base = NodeExpr)]
     pub(crate) struct NodeExprFormattedValue,
     fields: ["value", "conversion", "format_spec"],
     attributes: ["lineno", "col_offset", "end_lineno", "end_col_offset"],
 );
 
 impl_node!(
-    #[pyclass(module = "_ast", name = "JoinedStr", base = "NodeExpr")]
+    #[pyclass(module = "_ast", name = "JoinedStr", base = NodeExpr)]
     pub(crate) struct NodeExprJoinedStr,
     fields: ["values"],
     attributes: ["lineno", "col_offset", "end_lineno", "end_col_offset"],
 );
 
 impl_node!(
-    #[pyclass(module = "_ast", name = "Constant", base = "NodeExpr")]
+    #[pyclass(module = "_ast", name = "Constant", base = NodeExpr)]
     pub(crate) struct NodeExprConstant,
     fields: ["value", "kind"],
     attributes: ["lineno", "col_offset", "end_lineno", "end_col_offset"],
 );
 
 impl_node!(
-    #[pyclass(module = "_ast", name = "Attribute", base = "NodeExpr")]
+    #[pyclass(module = "_ast", name = "Attribute", base = NodeExpr)]
     pub(crate) struct NodeExprAttribute,
     fields: ["value", "attr", "ctx"],
     attributes: ["lineno", "col_offset", "end_lineno", "end_col_offset"],
 );
 
 impl_node!(
-    #[pyclass(module = "_ast", name = "Subscript", base = "NodeExpr")]
+    #[pyclass(module = "_ast", name = "Subscript", base = NodeExpr)]
     pub(crate) struct NodeExprSubscript,
     fields: ["value", "slice", "ctx"],
     attributes: ["lineno", "col_offset", "end_lineno", "end_col_offset"],
 );
 
 impl_node!(
-    #[pyclass(module = "_ast", name = "Starred", base = "NodeExpr")]
+    #[pyclass(module = "_ast", name = "Starred", base = NodeExpr)]
     pub(crate) struct NodeExprStarred,
     fields: ["value", "ctx"],
     attributes: ["lineno", "col_offset", "end_lineno", "end_col_offset"],
 );
 
 impl_node!(
-    #[pyclass(module = "_ast", name = "Name", base = "NodeExpr")]
+    #[pyclass(module = "_ast", name = "Name", base = NodeExpr)]
     pub(crate) struct NodeExprName,
     fields: ["id", "ctx"],
     attributes: ["lineno", "col_offset", "end_lineno", "end_col_offset"],
 );
 
 impl_node!(
-    #[pyclass(module = "_ast", name = "List", base = "NodeExpr")]
+    #[pyclass(module = "_ast", name = "List", base = NodeExpr)]
     pub(crate) struct NodeExprList,
     fields: ["elts", "ctx"],
     attributes: ["lineno", "col_offset", "end_lineno", "end_col_offset"],
 );
 
 impl_node!(
-    #[pyclass(module = "_ast", name = "Tuple", base = "NodeExpr")]
+    #[pyclass(module = "_ast", name = "Tuple", base = NodeExpr)]
     pub(crate) struct NodeExprTuple,
     fields: ["elts", "ctx"],
     attributes: ["lineno", "col_offset", "end_lineno", "end_col_offset"],
 );
 
-#[pyclass(module = "_ast", name = "expr_context", base = "NodeAst")]
+#[pyclass(module = "_ast", name = "expr_context", base = NodeAst)]
 pub(crate) struct NodeExprContext;
 
 #[pyclass(flags(HAS_DICT, BASETYPE))]
 impl NodeExprContext {}
 
 impl_node!(
-    #[pyclass(module = "_ast", name = "Slice", base = "NodeExpr")]
+    #[pyclass(module = "_ast", name = "Slice", base = NodeExpr)]
     pub(crate) struct NodeExprSlice,
     fields: ["lower", "upper", "step"],
     attributes: ["lineno", "col_offset", "end_lineno", "end_col_offset"],
 );
 
 impl_node!(
-    #[pyclass(module = "_ast", name = "Load", base = "NodeExprContext")]
+    #[pyclass(module = "_ast", name = "Load", base = NodeExprContext)]
     pub(crate) struct NodeExprContextLoad,
 );
 
 impl_node!(
-    #[pyclass(module = "_ast", name = "Store", base = "NodeExprContext")]
+    #[pyclass(module = "_ast", name = "Store", base = NodeExprContext)]
     pub(crate) struct NodeExprContextStore,
 );
 
-#[pyclass(module = "_ast", name = "boolop", base = "NodeAst")]
+#[pyclass(module = "_ast", name = "boolop", base = NodeAst)]
 pub(crate) struct NodeBoolOp;
 
 #[pyclass(flags(HAS_DICT, BASETYPE))]
 impl NodeBoolOp {}
 
 impl_node!(
-    #[pyclass(module = "_ast", name = "Del", base = "NodeExprContext")]
+    #[pyclass(module = "_ast", name = "Del", base = NodeExprContext)]
     pub(crate) struct NodeExprContextDel,
 );
 
 impl_node!(
-    #[pyclass(module = "_ast", name = "And", base = "NodeBoolOp")]
+    #[pyclass(module = "_ast", name = "And", base = NodeBoolOp)]
     pub(crate) struct NodeBoolOpAnd,
 );
 
-#[pyclass(module = "_ast", name = "operator", base = "NodeAst")]
+#[pyclass(module = "_ast", name = "operator", base = NodeAst)]
 pub(crate) struct NodeOperator;
 
 #[pyclass(flags(HAS_DICT, BASETYPE))]
 impl NodeOperator {}
 
 impl_node!(
-    #[pyclass(module = "_ast", name = "Or", base = "NodeBoolOp")]
+    #[pyclass(module = "_ast", name = "Or", base = NodeBoolOp)]
     pub(crate) struct NodeBoolOpOr,
 );
 
 impl_node!(
-    #[pyclass(module = "_ast", name = "Add", base = "NodeOperator")]
+    #[pyclass(module = "_ast", name = "Add", base = NodeOperator)]
     pub(crate) struct NodeOperatorAdd,
 );
 
 impl_node!(
-    #[pyclass(module = "_ast", name = "Sub", base = "NodeOperator")]
+    #[pyclass(module = "_ast", name = "Sub", base = NodeOperator)]
     pub(crate) struct NodeOperatorSub,
 );
 
 impl_node!(
-    #[pyclass(module = "_ast", name = "Mult", base = "NodeOperator")]
+    #[pyclass(module = "_ast", name = "Mult", base = NodeOperator)]
     pub(crate) struct NodeOperatorMult,
 );
 
 impl_node!(
-    #[pyclass(module = "_ast", name = "MatMult", base = "NodeOperator")]
+    #[pyclass(module = "_ast", name = "MatMult", base = NodeOperator)]
     pub(crate) struct NodeOperatorMatMult,
 );
 
 impl_node!(
-    #[pyclass(module = "_ast", name = "Div", base = "NodeOperator")]
+    #[pyclass(module = "_ast", name = "Div", base = NodeOperator)]
     pub(crate) struct NodeOperatorDiv,
 );
 
 impl_node!(
-    #[pyclass(module = "_ast", name = "Mod", base = "NodeOperator")]
+    #[pyclass(module = "_ast", name = "Mod", base = NodeOperator)]
     pub(crate) struct NodeOperatorMod,
 );
 
 impl_node!(
-    #[pyclass(module = "_ast", name = "Pow", base = "NodeOperator")]
+    #[pyclass(module = "_ast", name = "Pow", base = NodeOperator)]
     pub(crate) struct NodeOperatorPow,
 );
 
 impl_node!(
-    #[pyclass(module = "_ast", name = "LShift", base = "NodeOperator")]
+    #[pyclass(module = "_ast", name = "LShift", base = NodeOperator)]
     pub(crate) struct NodeOperatorLShift,
 );
 
 impl_node!(
-    #[pyclass(module = "_ast", name = "RShift", base = "NodeOperator")]
+    #[pyclass(module = "_ast", name = "RShift", base = NodeOperator)]
     pub(crate) struct NodeOperatorRShift,
 );
 
 impl_node!(
-    #[pyclass(module = "_ast", name = "BitOr", base = "NodeOperator")]
+    #[pyclass(module = "_ast", name = "BitOr", base = NodeOperator)]
     pub(crate) struct NodeOperatorBitOr,
 );
 
 impl_node!(
-    #[pyclass(module = "_ast", name = "BitXor", base = "NodeOperator")]
+    #[pyclass(module = "_ast", name = "BitXor", base = NodeOperator)]
     pub(crate) struct NodeOperatorBitXor,
 );
 
 impl_node!(
-    #[pyclass(module = "_ast", name = "BitAnd", base = "NodeOperator")]
+    #[pyclass(module = "_ast", name = "BitAnd", base = NodeOperator)]
     pub(crate) struct NodeOperatorBitAnd,
 );
 
-#[pyclass(module = "_ast", name = "unaryop", base = "NodeAst")]
+#[pyclass(module = "_ast", name = "unaryop", base = NodeAst)]
 pub(crate) struct NodeUnaryOp;
 
 #[pyclass(flags(HAS_DICT, BASETYPE))]
 impl NodeUnaryOp {}
 
 impl_node!(
-    #[pyclass(module = "_ast", name = "FloorDiv", base = "NodeOperator")]
+    #[pyclass(module = "_ast", name = "FloorDiv", base = NodeOperator)]
     pub(crate) struct NodeOperatorFloorDiv,
 );
 
 impl_node!(
-    #[pyclass(module = "_ast", name = "Invert", base = "NodeUnaryOp")]
+    #[pyclass(module = "_ast", name = "Invert", base = NodeUnaryOp)]
     pub(crate) struct NodeUnaryOpInvert,
 );
 
 impl_node!(
-    #[pyclass(module = "_ast", name = "Not", base = "NodeUnaryOp")]
+    #[pyclass(module = "_ast", name = "Not", base = NodeUnaryOp)]
     pub(crate) struct NodeUnaryOpNot,
 );
 
 impl_node!(
-    #[pyclass(module = "_ast", name = "UAdd", base = "NodeUnaryOp")]
+    #[pyclass(module = "_ast", name = "UAdd", base = NodeUnaryOp)]
     pub(crate) struct NodeUnaryOpUAdd,
 );
 
-#[pyclass(module = "_ast", name = "cmpop", base = "NodeAst")]
+#[pyclass(module = "_ast", name = "cmpop", base = NodeAst)]
 pub(crate) struct NodeCmpOp;
 
 #[pyclass(flags(HAS_DICT, BASETYPE))]
 impl NodeCmpOp {}
 
 impl_node!(
-    #[pyclass(module = "_ast", name = "USub", base = "NodeUnaryOp")]
+    #[pyclass(module = "_ast", name = "USub", base = NodeUnaryOp)]
     pub(crate) struct NodeUnaryOpUSub,
 );
 
 impl_node!(
-    #[pyclass(module = "_ast", name = "Eq", base = "NodeCmpOp")]
+    #[pyclass(module = "_ast", name = "Eq", base = NodeCmpOp)]
     pub(crate) struct NodeCmpOpEq,
 );
 
 impl_node!(
-    #[pyclass(module = "_ast", name = "NotEq", base = "NodeCmpOp")]
+    #[pyclass(module = "_ast", name = "NotEq", base = NodeCmpOp)]
     pub(crate) struct NodeCmpOpNotEq,
 );
 
 impl_node!(
-    #[pyclass(module = "_ast", name = "Lt", base = "NodeCmpOp")]
+    #[pyclass(module = "_ast", name = "Lt", base = NodeCmpOp)]
     pub(crate) struct NodeCmpOpLt,
 );
 
 impl_node!(
-    #[pyclass(module = "_ast", name = "LtE", base = "NodeCmpOp")]
+    #[pyclass(module = "_ast", name = "LtE", base = NodeCmpOp)]
     pub(crate) struct NodeCmpOpLtE,
 );
 
 impl_node!(
-    #[pyclass(module = "_ast", name = "Gt", base = "NodeCmpOp")]
+    #[pyclass(module = "_ast", name = "Gt", base = NodeCmpOp)]
     pub(crate) struct NodeCmpOpGt,
 );
 
 impl_node!(
-    #[pyclass(module = "_ast", name = "GtE", base = "NodeCmpOp")]
+    #[pyclass(module = "_ast", name = "GtE", base = NodeCmpOp)]
     pub(crate) struct NodeCmpOpGtE,
 );
 
 impl_node!(
-    #[pyclass(module = "_ast", name = "Is", base = "NodeCmpOp")]
+    #[pyclass(module = "_ast", name = "Is", base = NodeCmpOp)]
     pub(crate) struct NodeCmpOpIs,
 );
 
 impl_node!(
-    #[pyclass(module = "_ast", name = "IsNot", base = "NodeCmpOp")]
+    #[pyclass(module = "_ast", name = "IsNot", base = NodeCmpOp)]
     pub(crate) struct NodeCmpOpIsNot,
 );
 
 impl_node!(
-    #[pyclass(module = "_ast", name = "In", base = "NodeCmpOp")]
+    #[pyclass(module = "_ast", name = "In", base = NodeCmpOp)]
     pub(crate) struct NodeCmpOpIn,
 );
 
 impl_node!(
-    #[pyclass(module = "_ast", name = "NotIn", base = "NodeCmpOp")]
+    #[pyclass(module = "_ast", name = "NotIn", base = NodeCmpOp)]
     pub(crate) struct NodeCmpOpNotIn,
 );
 
-#[pyclass(module = "_ast", name = "excepthandler", base = "NodeAst")]
+#[pyclass(module = "_ast", name = "excepthandler", base = NodeAst)]
 pub(crate) struct NodeExceptHandler;
 
 #[pyclass(flags(HAS_DICT, BASETYPE))]
 impl NodeExceptHandler {}
 
 impl_node!(
-    #[pyclass(module = "_ast", name = "comprehension", base = "NodeAst")]
+    #[pyclass(module = "_ast", name = "comprehension", base = NodeAst)]
     pub(crate) struct NodeComprehension,
     fields: ["target", "iter", "ifs", "is_async"],
 );
 
 impl_node!(
-    #[pyclass(module = "_ast", name = "ExceptHandler", base = "NodeExceptHandler")]
+    #[pyclass(module = "_ast", name = "ExceptHandler", base = NodeExceptHandler)]
     pub(crate) struct NodeExceptHandlerExceptHandler,
     fields: ["type", "name", "body"],
     attributes: ["lineno", "col_offset", "end_lineno", "end_col_offset"],
 );
 
 impl_node!(
-    #[pyclass(module = "_ast", name = "arguments", base = "NodeAst")]
+    #[pyclass(module = "_ast", name = "arguments", base = NodeAst)]
     pub(crate) struct NodeArguments,
     fields: ["posonlyargs", "args", "vararg", "kwonlyargs", "kw_defaults", "kwarg", "defaults"],
 );
 
 impl_node!(
-    #[pyclass(module = "_ast", name = "arg", base = "NodeAst")]
+    #[pyclass(module = "_ast", name = "arg", base = NodeAst)]
     pub(crate) struct NodeArg,
     fields: ["arg", "annotation", "type_comment"],
     attributes: ["lineno", "col_offset", "end_lineno", "end_col_offset"],
 );
 
 impl_node!(
-    #[pyclass(module = "_ast", name = "keyword", base = "NodeAst")]
+    #[pyclass(module = "_ast", name = "keyword", base = NodeAst)]
     pub(crate) struct NodeKeyword,
     fields: ["arg", "value"],
     attributes: ["lineno", "col_offset", "end_lineno", "end_col_offset"],
 );
 
 impl_node!(
-    #[pyclass(module = "_ast", name = "alias", base = "NodeAst")]
+    #[pyclass(module = "_ast", name = "alias", base = NodeAst)]
     pub(crate) struct NodeAlias,
     fields: ["name", "asname"],
     attributes: ["lineno", "col_offset", "end_lineno", "end_col_offset"],
 );
 
 impl_node!(
-    #[pyclass(module = "_ast", name = "withitem", base = "NodeAst")]
+    #[pyclass(module = "_ast", name = "withitem", base = NodeAst)]
     pub(crate) struct NodeWithItem,
     fields: ["context_expr", "optional_vars"],
 );
 
-#[pyclass(module = "_ast", name = "pattern", base = "NodeAst")]
+#[pyclass(module = "_ast", name = "pattern", base = NodeAst)]
 pub(crate) struct NodePattern;
 
 #[pyclass(flags(HAS_DICT, BASETYPE))]
 impl NodePattern {}
 
 impl_node!(
-    #[pyclass(module = "_ast", name = "match_case", base = "NodeAst")]
+    #[pyclass(module = "_ast", name = "match_case", base = NodeAst)]
     pub(crate) struct NodeMatchCase,
     fields: ["pattern", "guard", "body"],
 );
 
 impl_node!(
-    #[pyclass(module = "_ast", name = "MatchValue", base = "NodePattern")]
+    #[pyclass(module = "_ast", name = "MatchValue", base = NodePattern)]
     pub(crate) struct NodePatternMatchValue,
     fields: ["value"],
     attributes: ["lineno", "col_offset", "end_lineno", "end_col_offset"],
 );
 
 impl_node!(
-    #[pyclass(module = "_ast", name = "MatchSingleton", base = "NodePattern")]
+    #[pyclass(module = "_ast", name = "MatchSingleton", base = NodePattern)]
     pub(crate) struct NodePatternMatchSingleton,
     fields: ["value"],
     attributes: ["lineno", "col_offset", "end_lineno", "end_col_offset"],
 );
 
 impl_node!(
-    #[pyclass(module = "_ast", name = "MatchSequence", base = "NodePattern")]
+    #[pyclass(module = "_ast", name = "MatchSequence", base = NodePattern)]
     pub(crate) struct NodePatternMatchSequence,
     fields: ["patterns"],
     attributes: ["lineno", "col_offset", "end_lineno", "end_col_offset"],
 );
 
 impl_node!(
-    #[pyclass(module = "_ast", name = "MatchMapping", base = "NodePattern")]
+    #[pyclass(module = "_ast", name = "MatchMapping", base = NodePattern)]
     pub(crate) struct NodePatternMatchMapping,
     fields: ["keys", "patterns", "rest"],
     attributes: ["lineno", "col_offset", "end_lineno", "end_col_offset"],
 );
 
 impl_node!(
-    #[pyclass(module = "_ast", name = "MatchClass", base = "NodePattern")]
+    #[pyclass(module = "_ast", name = "MatchClass", base = NodePattern)]
     pub(crate) struct NodePatternMatchClass,
     fields: ["cls", "patterns", "kwd_attrs", "kwd_patterns"],
     attributes: ["lineno", "col_offset", "end_lineno", "end_col_offset"],
 );
 
 impl_node!(
-    #[pyclass(module = "_ast", name = "MatchStar", base = "NodePattern")]
+    #[pyclass(module = "_ast", name = "MatchStar", base = NodePattern)]
     pub(crate) struct NodePatternMatchStar,
     fields: ["name"],
     attributes: ["lineno", "col_offset", "end_lineno", "end_col_offset"],
 );
 
 impl_node!(
-    #[pyclass(module = "_ast", name = "MatchAs", base = "NodePattern")]
+    #[pyclass(module = "_ast", name = "MatchAs", base = NodePattern)]
     pub(crate) struct NodePatternMatchAs,
     fields: ["pattern", "name"],
     attributes: ["lineno", "col_offset", "end_lineno", "end_col_offset"],
 );
 
-#[pyclass(module = "_ast", name = "type_ignore", base = "NodeAst")]
+#[pyclass(module = "_ast", name = "type_ignore", base = NodeAst)]
 pub(crate) struct NodeTypeIgnore;
 
 #[pyclass(flags(HAS_DICT, BASETYPE))]
 impl NodeTypeIgnore {}
 
 impl_node!(
-    #[pyclass(module = "_ast", name = "MatchOr", base = "NodePattern")]
+    #[pyclass(module = "_ast", name = "MatchOr", base = NodePattern)]
     pub(crate) struct NodePatternMatchOr,
     fields: ["patterns"],
     attributes: ["lineno", "col_offset", "end_lineno", "end_col_offset"],
 );
 
-#[pyclass(module = "_ast", name = "type_param", base = "NodeAst")]
+#[pyclass(module = "_ast", name = "type_param", base = NodeAst)]
 pub(crate) struct NodeTypeParam;
 
 #[pyclass(flags(HAS_DICT, BASETYPE))]
 impl NodeTypeParam {}
 
 impl_node!(
-    #[pyclass(module = "_ast", name = "TypeIgnore", base = "NodeTypeIgnore")]
+    #[pyclass(module = "_ast", name = "TypeIgnore", base = NodeTypeIgnore)]
     pub(crate) struct NodeTypeIgnoreTypeIgnore,
     fields: ["lineno", "tag"],
 );
 
 impl_node!(
-    #[pyclass(module = "_ast", name = "TypeVar", base = "NodeTypeParam")]
+    #[pyclass(module = "_ast", name = "TypeVar", base = NodeTypeParam)]
     pub(crate) struct NodeTypeParamTypeVar,
     fields: ["name", "bound"],
     attributes: ["lineno", "col_offset", "end_lineno", "end_col_offset"],
 );
 
 impl_node!(
-    #[pyclass(module = "_ast", name = "ParamSpec", base = "NodeTypeParam")]
+    #[pyclass(module = "_ast", name = "ParamSpec", base = NodeTypeParam)]
     pub(crate) struct NodeTypeParamParamSpec,
     fields: ["name"],
     attributes: ["lineno", "col_offset", "end_lineno", "end_col_offset"],
 );
 
 impl_node!(
-    #[pyclass(module = "_ast", name = "TypeVarTuple", base = "NodeTypeParam")]
+    #[pyclass(module = "_ast", name = "TypeVarTuple", base = NodeTypeParam)]
     pub(crate) struct NodeTypeParamTypeVarTuple,
     fields: ["name"],
     attributes: ["lineno", "col_offset", "end_lineno", "end_col_offset"],

--- a/vm/src/stdlib/ctypes/array.rs
+++ b/vm/src/stdlib/ctypes/array.rs
@@ -10,7 +10,7 @@ use crossbeam_utils::atomic::AtomicCell;
 use rustpython_common::lock::PyRwLock;
 use rustpython_vm::stdlib::ctypes::base::PyCData;
 
-#[pyclass(name = "PyCArrayType", base = "PyType", module = "_ctypes")]
+#[pyclass(name = "PyCArrayType", base = PyType, module = "_ctypes")]
 #[derive(PyPayload)]
 pub struct PyCArrayType {
     pub(super) inner: PyCArray,
@@ -49,7 +49,7 @@ impl PyCArrayType {}
 
 #[pyclass(
     name = "Array",
-    base = "PyCData",
+    base = PyCData,
     metaclass = "PyCArrayType",
     module = "_ctypes"
 )]

--- a/vm/src/stdlib/ctypes/base.rs
+++ b/vm/src/stdlib/ctypes/base.rs
@@ -157,7 +157,7 @@ pub struct PyCData {
 #[pyclass]
 impl PyCData {}
 
-#[pyclass(module = "_ctypes", name = "PyCSimpleType", base = "PyType")]
+#[pyclass(module = "_ctypes", name = "PyCSimpleType", base = PyType)]
 pub struct PyCSimpleType {}
 
 #[pyclass(flags(BASETYPE))]
@@ -176,7 +176,7 @@ impl PyCSimpleType {
 #[pyclass(
     module = "_ctypes",
     name = "_SimpleCData",
-    base = "PyCData",
+    base = PyCData,
     metaclass = "PyCSimpleType"
 )]
 #[derive(PyPayload)]

--- a/vm/src/stdlib/ctypes/function.rs
+++ b/vm/src/stdlib/ctypes/function.rs
@@ -122,7 +122,7 @@ impl Function {
     }
 }
 
-#[pyclass(module = "_ctypes", name = "CFuncPtr", base = "PyCData")]
+#[pyclass(module = "_ctypes", name = "CFuncPtr", base = PyCData)]
 #[derive(PyPayload)]
 pub struct PyCFuncPtr {
     pub name: PyRwLock<String>,

--- a/vm/src/stdlib/ctypes/structure.rs
+++ b/vm/src/stdlib/ctypes/structure.rs
@@ -8,7 +8,7 @@ use rustpython_vm::types::Constructor;
 use std::collections::HashMap;
 use std::fmt::Debug;
 
-#[pyclass(module = "_ctypes", name = "Structure", base = "PyCData")]
+#[pyclass(module = "_ctypes", name = "Structure", base = PyCData)]
 #[derive(PyPayload, Debug)]
 pub struct PyCStructure {
     #[allow(dead_code)]

--- a/vm/src/stdlib/ctypes/union.rs
+++ b/vm/src/stdlib/ctypes/union.rs
@@ -1,7 +1,7 @@
 use super::base::PyCData;
 
 // TODO: metaclass = "UnionType"
-#[pyclass(module = "_ctypes", name = "Union", base = "PyCData")]
+#[pyclass(module = "_ctypes", name = "Union", base = PyCData)]
 pub struct PyCUnion {}
 
 #[pyclass(flags(BASETYPE, IMMUTABLETYPE))]

--- a/vm/src/stdlib/io.rs
+++ b/vm/src/stdlib/io.rs
@@ -607,7 +607,7 @@ mod _io {
     }
 
     #[pyattr]
-    #[pyclass(name = "_RawIOBase", base = "_IOBase")]
+    #[pyclass(name = "_RawIOBase", base = _IOBase)]
     pub(super) struct _RawIOBase;
 
     #[pyclass(flags(BASETYPE, HAS_DICT))]
@@ -665,7 +665,7 @@ mod _io {
     }
 
     #[pyattr]
-    #[pyclass(name = "_BufferedIOBase", base = "_IOBase")]
+    #[pyclass(name = "_BufferedIOBase", base = _IOBase)]
     struct _BufferedIOBase;
 
     #[pyclass(flags(BASETYPE))]
@@ -728,7 +728,7 @@ mod _io {
 
     // TextIO Base has no public constructor
     #[pyattr]
-    #[pyclass(name = "_TextIOBase", base = "_IOBase")]
+    #[pyclass(name = "_TextIOBase", base = _IOBase)]
     #[derive(Debug, PyPayload)]
     struct _TextIOBase;
 
@@ -1728,7 +1728,7 @@ mod _io {
     }
 
     #[pyattr]
-    #[pyclass(name = "BufferedReader", base = "_BufferedIOBase")]
+    #[pyclass(name = "BufferedReader", base = _BufferedIOBase)]
     #[derive(Debug, Default, PyPayload)]
     struct BufferedReader {
         data: PyThreadMutex<BufferedData>,
@@ -1785,7 +1785,7 @@ mod _io {
     }
 
     #[pyattr]
-    #[pyclass(name = "BufferedWriter", base = "_BufferedIOBase")]
+    #[pyclass(name = "BufferedWriter", base = _BufferedIOBase)]
     #[derive(Debug, Default, PyPayload)]
     struct BufferedWriter {
         data: PyThreadMutex<BufferedData>,
@@ -1818,7 +1818,7 @@ mod _io {
     impl DefaultConstructor for BufferedWriter {}
 
     #[pyattr]
-    #[pyclass(name = "BufferedRandom", base = "_BufferedIOBase")]
+    #[pyclass(name = "BufferedRandom", base = _BufferedIOBase)]
     #[derive(Debug, Default, PyPayload)]
     struct BufferedRandom {
         data: PyThreadMutex<BufferedData>,
@@ -1860,7 +1860,7 @@ mod _io {
     impl DefaultConstructor for BufferedRandom {}
 
     #[pyattr]
-    #[pyclass(name = "BufferedRWPair", base = "_BufferedIOBase")]
+    #[pyclass(name = "BufferedRWPair", base = _BufferedIOBase)]
     #[derive(Debug, Default, PyPayload)]
     struct BufferedRWPair {
         read: BufferedReader,
@@ -2274,7 +2274,7 @@ mod _io {
     }
 
     #[pyattr]
-    #[pyclass(name = "TextIOWrapper", base = "_TextIOBase")]
+    #[pyclass(name = "TextIOWrapper", base = _TextIOBase)]
     #[derive(Debug, Default, PyPayload)]
     struct TextIOWrapper {
         data: PyThreadMutex<Option<TextIOData>>,
@@ -3460,7 +3460,7 @@ mod _io {
     }
 
     #[pyattr]
-    #[pyclass(name = "StringIO", base = "_TextIOBase")]
+    #[pyclass(name = "StringIO", base = _TextIOBase)]
     #[derive(Debug, PyPayload)]
     struct StringIO {
         buffer: PyRwLock<BufferedIO>,
@@ -3605,7 +3605,7 @@ mod _io {
     }
 
     #[pyattr]
-    #[pyclass(name = "BytesIO", base = "_BufferedIOBase")]
+    #[pyclass(name = "BytesIO", base = _BufferedIOBase)]
     #[derive(Debug, PyPayload)]
     struct BytesIO {
         buffer: PyRwLock<BufferedIO>,
@@ -4241,7 +4241,7 @@ mod fileio {
     }
 
     #[pyattr]
-    #[pyclass(module = "io", name, base = "_RawIOBase")]
+    #[pyclass(module = "io", name, base = _RawIOBase)]
     #[derive(Debug, PyPayload)]
     pub(super) struct FileIO {
         fd: AtomicCell<i32>,


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated internal code to use direct type references instead of string literals for base class specifications across class and exception declarations, improving type safety and consistency in the codebase without affecting user-facing functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->