### PR TITLE
Use new_buffer_error

### DIFF
--- a/Lib/test/test_binascii.py
+++ b/Lib/test/test_binascii.py
@@ -490,7 +490,6 @@ class BinASCIITest(unittest.TestCase):
         restored = binascii.a2b_base64(self.type2test(converted))
         self.assertConversion(binary, converted, restored, newline=newline)
 
-    @unittest.expectedFailure # TODO: RUSTPYTHON
     def test_c_contiguity(self):
         m = memoryview(bytearray(b'noncontig'))
         noncontig_writable = m[::-2]

--- a/Lib/test/test_ssl.py
+++ b/Lib/test/test_ssl.py
@@ -1811,7 +1811,6 @@ class MemoryBIOTests(unittest.TestCase):
         bio.read()
         self.assertEqual(bio.pending, 0)
 
-    @unittest.expectedFailure  # TODO: RUSTPYTHON
     def test_buffer_types(self):
         bio = ssl.MemoryBIO()
         bio.write(b'foo')

--- a/vm/src/function/buffer.rs
+++ b/vm/src/function/buffer.rs
@@ -22,7 +22,7 @@ impl PyObject {
         buffer
             .as_contiguous()
             .map(|x| f(&x))
-            .ok_or_else(|| vm.new_type_error("non-contiguous buffer is not a bytes-like object"))
+            .ok_or_else(|| vm.new_buffer_error("non-contiguous buffer is not a bytes-like object"))
     }
 
     pub fn try_rw_bytes_like<R>(
@@ -81,7 +81,7 @@ impl<'a> TryFromBorrowedObject<'a> for ArgBytesLike {
         if buffer.desc.is_contiguous() {
             Ok(Self(buffer))
         } else {
-            Err(vm.new_type_error("non-contiguous buffer is not a bytes-like object"))
+            Err(vm.new_buffer_error("non-contiguous buffer is not a bytes-like object"))
         }
     }
 }
@@ -121,7 +121,7 @@ impl<'a> TryFromBorrowedObject<'a> for ArgMemoryBuffer {
     fn try_from_borrowed_object(vm: &VirtualMachine, obj: &'a PyObject) -> PyResult<Self> {
         let buffer = PyBuffer::try_from_borrowed_object(vm, obj)?;
         if !buffer.desc.is_contiguous() {
-            Err(vm.new_type_error("non-contiguous buffer is not a bytes-like object"))
+            Err(vm.new_buffer_error("non-contiguous buffer is not a bytes-like object"))
         } else if buffer.desc.readonly {
             Err(vm.new_type_error("buffer is not a read-write bytes-like object"))
         } else {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error reporting for buffer operations: the system now returns a clearer buffer-related error when encountering non-contiguous buffers (and maintains existing behavior for other buffer constraints), so users receive more accurate, actionable feedback when supplying incompatible buffer data.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->