### PR TITLE
Break after annotation future found

### DIFF
--- a/crates/codegen/src/symboltable.rs
+++ b/crates/codegen/src/symboltable.rs
@@ -736,7 +736,8 @@ impl SymbolTableBuilder {
         if let Stmt::ImportFrom(StmtImportFrom { module, names, .. }) = &statement
             && module.as_ref().map(|id| id.as_str()) == Some("__future__")
         {
-            self.future_annotations = names.iter().any(|future| &future.name == "annotations");
+            self.future_annotations =
+                self.future_annotations || names.iter().any(|future| &future.name == "annotations");
         }
 
         match &statement {


### PR DESCRIPTION
ATM we keep iterating over all imports regardless if we found `from __future__ import annotations` already.

It was either to add `break` after the `self.future_annotations = true;` assignment, or to use `.iter().any()` instead (I went with the later)