### PR TITLE
fix(sqlite): raise `ProgrammingError` when operating on a blob with a…

### DIFF
--- a/Lib/test/test_sqlite3/test_dbapi.py
+++ b/Lib/test/test_sqlite3/test_dbapi.py
@@ -1469,8 +1469,6 @@ class BlobTests(unittest.TestCase):
             with self.assertRaisesRegex(sqlite.ProgrammingError, msg):
                 blob[0] = b""
 
-    # TODO: RUSTPYTHON
-    @unittest.expectedFailure
     def test_blob_closed_db_read(self):
         with memory_database() as cx:
             cx.execute("create table test(b blob)")


### PR DESCRIPTION
… closed connection,

Fixed #6285


reference:
- https://github.com/python/cpython/blob/a8733cbc7328dbeeed50e82ef13abb197d511c46/Modules/_sqlite/connection.c#L699-L701
- https://github.com/python/cpython/blob/a8733cbc7328dbeeed50e82ef13abb197d511c46/Modules/_sqlite/blob.c#L70-L73
- https://github.com/python/cpython/blob/a8733cbc7328dbeeed50e82ef13abb197d511c46/Modules/_sqlite/blob.c#L183-L189

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added ability to check if a database connection is closed

* **Bug Fixes**
  * Database read operations now fail gracefully with error messaging when the connection is closed

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->