### PR TITLE
Fix redox compilation in stdlib

### DIFF
--- a/crates/stdlib/src/posixsubprocess.rs
+++ b/crates/stdlib/src/posixsubprocess.rs
@@ -441,15 +441,14 @@ fn close_dir_fds(keep: KeepFds<'_>) -> nix::Result<()> {
 fn close_filetable_fds(keep: KeepFds<'_>) -> nix::Result<()> {
     use nix::fcntl;
     use std::os::fd::{FromRawFd, OwnedFd};
-    let fd = fcntl::open(
+    let filetable = fcntl::open(
         c"/scheme/thisproc/current/filetable",
         fcntl::OFlag::O_RDONLY,
         nix::sys::stat::Mode::empty(),
     )?;
-    let filetable = unsafe { OwnedFd::from_raw_fd(fd) };
     let read_one = || -> nix::Result<_> {
         let mut byte = 0;
-        let n = nix::unistd::read(filetable.as_raw_fd(), std::slice::from_mut(&mut byte))?;
+        let n = nix::unistd::read(&filetable, std::slice::from_mut(&mut byte))?;
         Ok((n > 0).then_some(byte))
     };
     while let Some(c) = read_one()? {


### PR DESCRIPTION
This fixes compilation on Redox due to cfg filter in this code, and `fcntl::open` here returns OwnedFd already.

This upstream version can't be compiled to Redox due to other reasons, so as a workaround this patch fix is verified in Redox build system using a [backported version](https://gitlab.redox-os.org/redox-os/redox/-/merge_requests/1715).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved internal file descriptor handling for enhanced code maintainability. No end-user facing changes.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->