### PR TITLE
Ctypes __mul__

### DIFF
--- a/crates/vm/src/stdlib/ctypes/base.rs
+++ b/crates/vm/src/stdlib/ctypes/base.rs
@@ -244,8 +244,18 @@ impl Constructor for PyCSimple {
         let attributes = cls.get_attributes();
         let _type_ = attributes
             .iter()
-            .find(|(k, _)| k.to_object().str(vm).unwrap().to_string() == *"_type_")
-            .unwrap()
+            .find(|(k, _)| {
+                k.to_object()
+                    .str(vm)
+                    .map(|s| s.to_string() == "_type_")
+                    .unwrap_or(false)
+            })
+            .ok_or_else(|| {
+                vm.new_type_error(format!(
+                    "cannot create '{}' instances: no _type_ attribute",
+                    cls.name()
+                ))
+            })?
             .1
             .str(vm)?
             .to_string();

--- a/crates/vm/src/stdlib/ctypes/pointer.rs
+++ b/crates/vm/src/stdlib/ctypes/pointer.rs
@@ -1,8 +1,13 @@
+use crossbeam_utils::atomic::AtomicCell;
+use num_traits::ToPrimitive;
 use rustpython_common::lock::PyRwLock;
 
-use crate::builtins::PyType;
+use crate::builtins::{PyType, PyTypeRef};
+use crate::convert::ToPyObject;
+use crate::protocol::PyNumberMethods;
 use crate::stdlib::ctypes::PyCData;
-use crate::{PyObjectRef, PyResult};
+use crate::types::AsNumber;
+use crate::{PyObjectRef, PyResult, VirtualMachine};
 
 #[pyclass(name = "PyCPointerType", base = PyType, module = "_ctypes")]
 #[derive(PyPayload, Debug)]
@@ -11,8 +16,44 @@ pub struct PyCPointerType {
     pub(crate) inner: PyCPointer,
 }
 
-#[pyclass]
-impl PyCPointerType {}
+#[pyclass(flags(IMMUTABLETYPE), with(AsNumber))]
+impl PyCPointerType {
+    #[pymethod]
+    fn __mul__(cls: PyTypeRef, n: isize, vm: &VirtualMachine) -> PyResult {
+        use super::array::{PyCArray, PyCArrayType};
+        if n < 0 {
+            return Err(vm.new_value_error(format!("Array length must be >= 0, not {n}")));
+        }
+        Ok(PyCArrayType {
+            inner: PyCArray {
+                typ: PyRwLock::new(cls),
+                length: AtomicCell::new(n as usize),
+                value: PyRwLock::new(vm.ctx.none()),
+            },
+        }
+        .to_pyobject(vm))
+    }
+}
+
+impl AsNumber for PyCPointerType {
+    fn as_number() -> &'static PyNumberMethods {
+        static AS_NUMBER: PyNumberMethods = PyNumberMethods {
+            multiply: Some(|a, b, vm| {
+                let cls = a
+                    .downcast_ref::<PyType>()
+                    .ok_or_else(|| vm.new_type_error("expected type".to_owned()))?;
+                let n = b
+                    .try_index(vm)?
+                    .as_bigint()
+                    .to_isize()
+                    .ok_or_else(|| vm.new_overflow_error("array size too large".to_owned()))?;
+                PyCPointerType::__mul__(cls.to_owned(), n, vm)
+            }),
+            ..PyNumberMethods::NOT_IMPLEMENTED
+        };
+        &AS_NUMBER
+    }
+}
 
 #[pyclass(
     name = "_Pointer",


### PR DESCRIPTION
Apply #6222 

cc @YashSuthar983 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enabled multiplication of ctypes simple and pointer types by integers to create repeated arrays (e.g., `c_int * 5` creates an array of 5 integers).

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->