### PR TITLE
Remove `ImportNameless` bytecode

### DIFF
--- a/crates/codegen/src/compile.rs
+++ b/crates/codegen/src/compile.rs
@@ -1351,8 +1351,6 @@ impl Compiler {
                         .collect()
                 };
 
-                let module_idx = module.as_ref().map(|s| self.name(s.as_str()));
-
                 // from .... import (*fromlist)
                 self.emit_load_const(ConstantData::Integer {
                     value: (*level).into(),
@@ -1360,11 +1358,10 @@ impl Compiler {
                 self.emit_load_const(ConstantData::Tuple {
                     elements: from_list,
                 });
-                if let Some(idx) = module_idx {
-                    emit!(self, Instruction::ImportName { idx });
-                } else {
-                    emit!(self, Instruction::ImportNameless);
-                }
+
+                let module_name = module.as_ref().map_or("", |s| s.as_str());
+                let module_idx = self.name(module_name);
+                emit!(self, Instruction::ImportName { idx: module_idx });
 
                 if import_star {
                     // from .... import *

--- a/crates/compiler-core/src/bytecode.rs
+++ b/crates/compiler-core/src/bytecode.rs
@@ -662,8 +662,6 @@ pub enum Instruction {
     ImportFrom {
         idx: Arg<NameIdx>,
     },
-    /// Importing without name
-    ImportNameless,
     /// Importing by name
     ImportName {
         idx: Arg<NameIdx>,
@@ -1607,7 +1605,7 @@ impl Instruction {
     pub fn stack_effect(&self, arg: OpArg, jump: bool) -> i32 {
         match self {
             Nop => 0,
-            ImportName { .. } | ImportNameless => -1,
+            ImportName { .. } => -1,
             ImportFrom { .. } => 1,
             LoadFast(_) | LoadNameAny(_) | LoadGlobal(_) | LoadDeref(_) | LoadClassDeref(_) => 1,
             StoreFast(_) | StoreLocal(_) | StoreGlobal(_) | StoreDeref(_) => -1,
@@ -1844,7 +1842,6 @@ impl Instruction {
             GetIter => w!(GetIter),
             GetLen => w!(GetLen),
             ImportFrom { idx } => w!(ImportFrom, name = idx),
-            ImportNameless => w!(ImportNameless),
             ImportName { idx } => w!(ImportName, name = idx),
             IsOp(inv) => w!(IS_OP, ?inv),
             JumpIfFalseOrPop { target } => w!(JumpIfFalseOrPop, target),

--- a/crates/vm/src/frame.rs
+++ b/crates/vm/src/frame.rs
@@ -939,10 +939,6 @@ impl ExecutingFrame<'_> {
                 self.push_value(obj);
                 Ok(None)
             }
-            bytecode::Instruction::ImportNameless => {
-                self.import(vm, None)?;
-                Ok(None)
-            }
             bytecode::Instruction::ImportName { idx } => {
                 self.import(vm, Some(self.code.names[idx.get(arg) as usize]))?;
                 Ok(None)


### PR DESCRIPTION
This is CPython does it:
https://github.com/python/cpython/blob/8183fa5e3f78ca6ab862de7fb8b14f3d929421e0/Python/compile.c#L3960-L3961

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Simplified import handling by consolidating the import instruction implementation. Import operations now use a unified approach across all scenarios, reducing code complexity and maintenance overhead.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->