### PR TITLE
Use rust idioms for accessing a `Vec` in `codegen/src/compile.rs`

### DIFF
--- a/crates/codegen/src/compile.rs
+++ b/crates/codegen/src/compile.rs
@@ -625,8 +625,7 @@ impl Compiler {
 
         // Push the next table onto the stack
         self.symbol_table_stack.push(table);
-        // SAFETY: We just pushed, so it can't be empty
-        unsafe { self.symbol_table_stack.last().unwrap_unchecked() }
+        self.current_symbol_table()
     }
 
     /// Pop the current symbol table off the stack


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Improved compiler internals for safer symbol-table handling to reduce crashes and make lookup behavior explicit.
* **Bug Fixes**
  * Replaced fragile index-based lookups with guarded checks that return clear syntax errors when state is inconsistent.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->