### PR TITLE
WindowsError

### DIFF
--- a/Lib/test/test_exception_hierarchy.py
+++ b/Lib/test/test_exception_hierarchy.py
@@ -136,8 +136,6 @@ class AttributesTest(unittest.TestCase):
         if os.name == "nt":
             self.assertEqual(e.winerror, None)
 
-    # TODO: RUSTPYTHON
-    @unittest.expectedFailure
     @unittest.skipUnless(os.name == "nt", "Windows-specific test")
     def test_errno_translation(self):
         # ERROR_ALREADY_EXISTS (183) -> EEXIST

--- a/crates/vm/src/stdlib/builtins.rs
+++ b/crates/vm/src/stdlib/builtins.rs
@@ -1187,4 +1187,10 @@ pub fn init_module(vm: &VirtualMachine, module: &Py<PyModule>) {
     extend_module!(vm, module, {
         "JitError" => ctx.exceptions.jit_error.to_owned(),
     });
+
+    #[cfg(windows)]
+    extend_module!(vm, module, {
+        // OSError alias for Windows
+        "WindowsError" => ctx.exceptions.os_error.to_owned(),
+    });
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * OSError string output on Windows now shows Windows error codes as "[WinError {code}]" when appropriate, matching CPython formatting.

* **New Features**
  * A Windows-specific WindowsError alias for OSError is now available on Windows.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->