### PR TITLE
pin flate2 under 1.1.5

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4794,6 +4794,6 @@ dependencies = [
 
 [[package]]
 name = "zlib-rs"
-version = "0.5.2"
+version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f06ae92f42f5e5c42443fd094f245eb656abf56dd7cce9b8b263236565e00f2"
+checksum = "36134c44663532e6519d7a6dfdbbe06f6f8192bde8ae9ed076e9b213f0e31df7"

--- a/crates/stdlib/Cargo.toml
+++ b/crates/stdlib/Cargo.toml
@@ -83,7 +83,7 @@ unicode-bidi-mirroring = { workspace = true }
 # compression
 adler32 = "1.2.0"
 crc32fast = "1.3.2"
-flate2 = { version = "1.1", default-features = false, features = ["zlib-rs"] }
+flate2 = { version = "<=1.1.5", default-features = false, features = ["zlib-rs"] }
 libz-sys = { package = "libz-rs-sys", version = "0.5" }
 bzip2 = "0.6"
 


### PR DESCRIPTION
To prevent breaking change on 1.1.7 right now.

https://github.com/rust-lang/flate2-rs/issues/517


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated compression dependency version constraint for improved compatibility.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->