### PR TITLE
fix(sqlite): Raise ProgrammingError when operating on a closed cursor

### DIFF
--- a/Lib/test/test_sqlite3/test_dbapi.py
+++ b/Lib/test/test_sqlite3/test_dbapi.py
@@ -1735,8 +1735,6 @@ class ClosedConTests(unittest.TestCase):
             con()
 
 class ClosedCurTests(unittest.TestCase):
-    # TODO: RUSTPYTHON
-    @unittest.expectedFailure
     def test_closed(self):
         con = sqlite.connect(":memory:")
         cur = con.cursor()


### PR DESCRIPTION
fixed #6336

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved SQLite cursor handling and script execution initialization to ensure more reliable state management and proper resource cleanup.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->