### PR TITLE
Add TextIOWrapper.truncate, fix a few bugs

### DIFF
--- a/Lib/test/test_io.py
+++ b/Lib/test/test_io.py
@@ -4209,7 +4209,6 @@ class CTextIOWrapperTest(TextIOWrapperTest):
         self.assertEqual([b"abcdef", b"middle", b"g"*chunk_size],
                          buf._write_stack)
 
-    @unittest.expectedFailure # TODO: RUSTPYTHON
     def test_basic_io(self):
         return super().test_basic_io()
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added truncate() method to TextIOWrapper, enabling text I/O object truncation support.

* **Bug Fixes**
  * Improved decoder state handling in I/O operations for better accuracy.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->