### PR TITLE
Fix test_runpy

### DIFF
--- a/Lib/test/test_runpy.py
+++ b/Lib/test/test_runpy.py
@@ -801,11 +801,9 @@ class TestExit(unittest.TestCase):
         self.assertTrue(proc.stderr.endswith("\nKeyboardInterrupt\n"), proc.stderr)
         self.assertEqual(proc.returncode, self.EXPECTED_CODE)
 
-    @unittest.expectedFailureIfWindows("TODO: RUSTPYTHON; ")
     def test_pymain_run_file(self):
         self.assertSigInt([self.ham])
 
-    @unittest.expectedFailureIfWindows("TODO: RUSTPYTHON; ")
     def test_pymain_run_file_runpy_run_module(self):
         tmp = self.ham.parent
         run_module = tmp / "run_module.py"
@@ -819,7 +817,6 @@ class TestExit(unittest.TestCase):
         )
         self.assertSigInt([run_module], cwd=tmp)
 
-    @unittest.expectedFailureIfWindows("TODO: RUSTPYTHON; ")
     def test_pymain_run_file_runpy_run_module_as_main(self):
         tmp = self.ham.parent
         run_module_as_main = tmp / "run_module_as_main.py"
@@ -833,14 +830,12 @@ class TestExit(unittest.TestCase):
         )
         self.assertSigInt([run_module_as_main], cwd=tmp)
 
-    @unittest.expectedFailureIfWindows("TODO: RUSTPYTHON; ")
     def test_pymain_run_command_run_module(self):
         self.assertSigInt(
             ["-c", "import runpy; runpy.run_module('ham')"],
             cwd=self.ham.parent,
         )
 
-    @unittest.expectedFailureIfWindows("TODO: RUSTPYTHON; ")
     def test_pymain_run_command(self):
         self.assertSigInt(["-c", "import ham"], cwd=self.ham.parent)
 
@@ -848,7 +843,6 @@ class TestExit(unittest.TestCase):
     def test_pymain_run_stdin(self):
         self.assertSigInt([], input="import ham", cwd=self.ham.parent)
 
-    @unittest.expectedFailureIfWindows("TODO: RUSTPYTHON; ")
     def test_pymain_run_module(self):
         ham = self.ham
         self.assertSigInt(["-m", ham.stem], cwd=ham.parent)

--- a/Lib/test/test_signal.py
+++ b/Lib/test/test_signal.py
@@ -224,8 +224,6 @@ class WindowsSignalTests(unittest.TestCase):
         with self.assertRaises(ValueError):
             signal.signal(7, handler)
 
-    # TODO: RUSTPYTHON
-    @unittest.expectedFailure
     @unittest.skipUnless(sys.executable, "sys.executable required.")
     @support.requires_subprocess()
     def test_keyboard_interrupt_exit_code(self):

--- a/crates/vm/src/vm/interpreter.rs
+++ b/crates/vm/src/vm/interpreter.rs
@@ -96,7 +96,7 @@ impl Interpreter {
     ///
     /// See [`Interpreter::finalize`] for the finalization steps.
     /// See also [`Interpreter::enter`] for pure function call to obtain Python exception.
-    pub fn run<F>(self, f: F) -> u8
+    pub fn run<F>(self, f: F) -> u32
     where
         F: FnOnce(&VirtualMachine) -> PyResult<()>,
     {
@@ -113,7 +113,7 @@ impl Interpreter {
     /// 1. Mark vm as finalized.
     ///
     /// Note that calling `finalize` is not necessary by purpose though.
-    pub fn finalize(self, exc: Option<PyBaseExceptionRef>) -> u8 {
+    pub fn finalize(self, exc: Option<PyBaseExceptionRef>) -> u32 {
         self.enter(|vm| {
             vm.flush_std();
 

--- a/examples/generator.rs
+++ b/examples/generator.rs
@@ -46,5 +46,5 @@ fn main() -> ExitCode {
         vm.add_native_modules(rustpython_stdlib::get_module_inits());
     });
     let result = py_main(&interp);
-    ExitCode::from(interp.run(|_vm| result))
+    vm::common::os::exit_code(interp.run(|_vm| result))
 }

--- a/examples/package_embed.rs
+++ b/examples/package_embed.rs
@@ -26,5 +26,5 @@ fn main() -> ExitCode {
     let result = result.map(|result| {
         println!("name: {result}");
     });
-    ExitCode::from(interp.run(|_vm| result))
+    vm::common::os::exit_code(interp.run(|_vm| result))
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -111,7 +111,7 @@ pub fn run(init: impl FnOnce(&mut VirtualMachine) + 'static) -> ExitCode {
     let interp = config.interpreter();
     let exitcode = interp.run(move |vm| run_rustpython(vm, run_mode));
 
-    ExitCode::from(exitcode)
+    rustpython_vm::common::os::exit_code(exitcode)
 }
 
 fn setup_main_module(vm: &VirtualMachine) -> PyResult<Scope> {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Extended exit code support from 8-bit to 32-bit values, enabling larger exit codes.
  * Enhanced Windows-specific exit code handling for Ctrl+C scenarios to match standard behavior.

* **Refactor**
  * Improved exit code handling throughout the interpreter and VM modules.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->