### PR TITLE
Python ignores whitespace in format strings

### DIFF
--- a/.cspell.dict/cpython.txt
+++ b/.cspell.dict/cpython.txt
@@ -15,6 +15,7 @@ cellvar
 cellvars
 cmpop
 denom
+DICTFLAG
 dictoffset
 elts
 excepthandler
@@ -28,6 +29,7 @@ heaptype
 HIGHRES
 IMMUTABLETYPE
 Itertool
+keeped
 kwonlyarg
 kwonlyargs
 lasti
@@ -48,6 +50,7 @@ PYTHREAD_NAME
 SA_ONSTACK
 SOABI
 stackdepth
+stginfo
 stringlib
 structseq
 subparams

--- a/crates/vm/src/buffer.rs
+++ b/crates/vm/src/buffer.rs
@@ -238,10 +238,23 @@ impl FormatCode {
                 _ => 1,
             };
 
+            // Skip whitespace (Python ignores whitespace in format strings)
+            while let Some(b' ' | b'\t' | b'\n' | b'\r') = chars.peek() {
+                chars.next();
+            }
+
             // determine format char:
-            let c = chars
-                .next()
-                .ok_or_else(|| "repeat count given without format specifier".to_owned())?;
+            let c = match chars.next() {
+                Some(c) => c,
+                None => {
+                    // If we have a repeat count but only whitespace follows, error
+                    if repeat != 1 {
+                        return Err("repeat count given without format specifier".to_owned());
+                    }
+                    // Otherwise, we're done parsing
+                    break;
+                }
+            };
 
             // Check for embedded null character
             if c == 0 {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated spell-check dictionary with new entries.

* **Bug Fixes**
  * Improved format string parsing to gracefully handle whitespace characters after repeat counts, providing clearer error messaging when format specifiers are missing or malformed.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->