### PR TITLE
Upgrade libffi 5

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1687,9 +1687,9 @@ checksum = "37c93d8daa9d8a012fd8ab92f088405fb202ea0b6ab73ee2482ae66af4f42091"
 
 [[package]]
 name = "libffi"
-version = "4.1.2"
+version = "5.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b0feebbe0ccd382a2790f78d380540500d7b78ed7a3498b68fcfbc1593749a94"
+checksum = "0444124f3ffd67e1b0b0c661a7f81a278a135eb54aaad4078e79fbc8be50c8a5"
 dependencies = [
  "libc",
  "libffi-sys",
@@ -1697,9 +1697,9 @@ dependencies = [
 
 [[package]]
 name = "libffi-sys"
-version = "3.3.3"
+version = "4.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "90c6c6e17136d4bc439d43a2f3c6ccf0731cccc016d897473a29791d3c2160c3"
+checksum = "3d722da8817ea580d0669da6babe2262d7b86a1af1103da24102b8bb9c101ce7"
 dependencies = [
  "cc",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -178,7 +178,7 @@ itertools = "0.14.0"
 is-macro = "0.3.7"
 junction = "1.3.0"
 libc = "0.2.178"
-libffi = "4.1"
+libffi = "5"
 log = "0.4.29"
 nix = { version = "0.30", features = ["fs", "user", "process", "term", "time", "signal", "ioctl", "socket", "sched", "zerocopy", "dir", "hostname", "net", "poll"] }
 malachite-bigint = "0.8"

--- a/crates/vm/src/stdlib/ctypes.rs
+++ b/crates/vm/src/stdlib/ctypes.rs
@@ -1102,7 +1102,7 @@ pub(crate) mod _ctypes {
             return Err(vm.new_value_error("NULL function pointer"));
         }
 
-        let mut ffi_args: Vec<Arg> = Vec::with_capacity(args.len());
+        let mut ffi_args: Vec<Arg<'_>> = Vec::with_capacity(args.len());
         let mut arg_values: Vec<isize> = Vec::with_capacity(args.len());
         let mut arg_types: Vec<Type> = Vec::with_capacity(args.len());
 

--- a/crates/vm/src/stdlib/ctypes/array.rs
+++ b/crates/vm/src/stdlib/ctypes/array.rs
@@ -1058,14 +1058,6 @@ impl PyCArray {
     }
 }
 
-impl PyCArray {
-    #[allow(unused)]
-    pub fn to_arg(&self, _vm: &VirtualMachine) -> PyResult<libffi::middle::Arg> {
-        let buffer = self.0.buffer.read();
-        Ok(libffi::middle::Arg::new(&*buffer))
-    }
-}
-
 impl AsBuffer for PyCArray {
     fn as_buffer(zelf: &Py<Self>, _vm: &VirtualMachine) -> PyResult<PyBuffer> {
         let buffer_len = zelf.0.buffer.read().len();

--- a/crates/vm/src/stdlib/ctypes/base.rs
+++ b/crates/vm/src/stdlib/ctypes/base.rs
@@ -1821,7 +1821,7 @@ pub enum FfiArgValue {
 
 impl FfiArgValue {
     /// Create an Arg reference to this owned value
-    pub fn as_arg(&self) -> libffi::middle::Arg {
+    pub fn as_arg(&self) -> libffi::middle::Arg<'_> {
         match self {
             FfiArgValue::U8(v) => libffi::middle::Arg::new(v),
             FfiArgValue::I8(v) => libffi::middle::Arg::new(v),

--- a/crates/vm/src/stdlib/ctypes/function.rs
+++ b/crates/vm/src/stdlib/ctypes/function.rs
@@ -1449,7 +1449,7 @@ enum RawResult {
 fn ctypes_callproc(code_ptr: CodePtr, arguments: &[Argument], call_info: &CallInfo) -> RawResult {
     let ffi_arg_types: Vec<Type> = arguments.iter().map(|a| a.ffi_type.clone()).collect();
     let cif = Cif::new(ffi_arg_types, call_info.ffi_return_type.clone());
-    let ffi_args: Vec<Arg> = arguments.iter().map(|a| a.value.as_arg()).collect();
+    let ffi_args: Vec<Arg<'_>> = arguments.iter().map(|a| a.value.as_arg()).collect();
 
     if call_info.restype_is_none {
         unsafe { cif.call::<()>(code_ptr, &ffi_args) };


### PR DESCRIPTION
close #6397

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Dependency Updates**
  * Updated libffi dependency from version 4.1 to 5.

* **Breaking Changes**
  * Removed the `PyCArray.to_arg()` method, which previously allowed conversion of array objects to FFI-compatible arguments.

* **Internal Improvements**
  * Enhanced FFI subsystem with improved argument handling, stronger type safety guarantees, and better lifetime management for more robust foreign function interface operations.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->