### PR TITLE
Reduce usage `JumpIfTrueOrPop` & `JumpIfFalseOrPop` opcdes. Refactor `compile_compare`

### DIFF
--- a/crates/codegen/src/compile.rs
+++ b/crates/codegen/src/compile.rs
@@ -4115,10 +4115,14 @@ impl Compiler {
             self.compile_addcompare(op);
 
             // if comparison result is false, we break with this value; if true, try the next one.
+            /*
             emit!(self, Instruction::CopyItem { index: 1 });
             // emit!(self, Instruction::ToBool); // TODO: Uncomment this
             emit!(self, Instruction::PopJumpIfFalse { target: cleanup });
             emit!(self, Instruction::PopTop);
+            */
+
+            emit!(self, Instruction::JumpIfFalseOrPop { target: cleanup });
         }
 
         self.compile_expression(last_comparator)?;


### PR DESCRIPTION
Implements https://github.com/python/cpython/pull/102870

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Optimized internal compilation logic for comparison operations and boolean expressions, improving code maintainability.

* **Documentation**
  * Enhanced compiler documentation with reference materials and detailed explanatory comments.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->