### PR TITLE
Implement winapi.GetLongPathName

### DIFF
--- a/Lib/test/test_winapi.py
+++ b/Lib/test/test_winapi.py
@@ -110,8 +110,6 @@ class WinAPIBatchedWaitForMultipleObjectsTests(unittest.TestCase):
 
 
 class WinAPITests(unittest.TestCase):
-    # TODO: RUSTPYTHON
-    @unittest.expectedFailure
     def test_getlongpathname(self):
         testfn = pathlib.Path(os.getenv("ProgramFiles")).parents[-1] / "PROGRA~1"
         if not os.path.isdir(testfn):
@@ -128,8 +126,6 @@ class WinAPITests(unittest.TestCase):
         candidates = set(testfn.parent.glob("Progra*"))
         self.assertIn(pathlib.Path(actual), candidates)
 
-    # TODO: RUSTPYTHON
-    @unittest.expectedFailure
     def test_getshortpathname(self):
         testfn = pathlib.Path(os.getenv("ProgramFiles"))
         if not os.path.isdir(testfn):


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added two Windows path utilities to the winapi module: GetShortPathName and GetLongPathName, allowing conversion between short (DOS-style) and long path formats from Python.
  * Both functions provide robust handling of Windows path APIs and return properly encoded path strings on success.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->