### PR TITLE
Fix f-string conversion flag ValueError when compiling AST

### DIFF
--- a/crates/vm/src/stdlib/ast.rs
+++ b/crates/vm/src/stdlib/ast.rs
@@ -15,7 +15,6 @@ use crate::{
     builtins::PyIntRef,
     builtins::{PyDict, PyModule, PyStrRef, PyType},
     class::{PyClassImpl, StaticType},
-    compiler::core::bytecode::OpArgType,
     compiler::{CompileError, ParseError},
     convert::ToPyObject,
 };


### PR DESCRIPTION
The ast_from_object for ConversionFlag was using bytecode::ConvertValueOparg::from_op_arg() which only accepts internal oparg values (0, 1, 2, 3, 255), but Python's AST uses ASCII codes ('s'=115, 'r'=114, 'a'=97, -1=None).

This caused compile() on parsed AST with conversion flags to fail with "invalid conversion flag".

@ShaharNaveh You probably knows better about ConvertValueOparg. Will this be okay? Do we need to handle ConvertValueOparg differently?

Fix #6533




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved internal deserialization logic for better code maintainability.

* **Chores**
  * Removed unused import dependencies.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->