### PR TITLE
fix sys path

### DIFF
--- a/Lib/test/test_cmd_line_script.py
+++ b/Lib/test/test_cmd_line_script.py
@@ -411,8 +411,6 @@ class CmdLineTest(unittest.TestCase):
                                    script_name, script_name, script_dir, 'test_pkg',
                                    importlib.machinery.SourceFileLoader)
 
-    # TODO: RUSTPYTHON
-    @unittest.expectedFailure
     def test_issue8202_dash_c_file_ignored(self):
         # Make sure a "-c" file in the current directory
         # does not alter the value of sys.path[0]
@@ -713,8 +711,6 @@ class CmdLineTest(unittest.TestCase):
                     ]
                 )
 
-    # TODO: RUSTPYTHON
-    @unittest.expectedFailure
     def test_consistent_sys_path_for_direct_execution(self):
         # This test case ensures that the following all give the same
         # sys.path configuration:

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -339,6 +339,7 @@ pub fn parse_opts() -> Result<(Settings, RunMode), lexopt::Error> {
 /// Helper function to retrieve a sequence of paths from an environment variable.
 fn get_paths(env_variable_name: &str) -> impl Iterator<Item = String> + '_ {
     env::var_os(env_variable_name)
+        .filter(|v| !v.is_empty())
         .into_iter()
         .flat_map(move |paths| {
             split_paths(&paths)


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved environment variable path processing by filtering empty values to prevent empty strings from propagating through path lists.

* **Refactor**
  * Adjusted initialization sequence to import site modules before configuring sys.path[0], aligning with standard Python behavior. Path handling now includes run-mode-specific configurations.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->