### PR TITLE
RichCompare contains pymethod. No AtomicCell for slots

### DIFF
--- a/crates/stdlib/src/contextvars.rs
+++ b/crates/stdlib/src/contextvars.rs
@@ -264,7 +264,7 @@ mod _contextvars {
                         Err(vm.new_key_error(needle.to_owned().into()))
                     }
                 }),
-                ass_subscript: AtomicCell::new(None),
+                ass_subscript: None,
             };
             &AS_MAPPING
         }

--- a/crates/stdlib/src/sqlite.rs
+++ b/crates/stdlib/src/sqlite.rs
@@ -20,7 +20,6 @@ pub(crate) fn make_module(vm: &VirtualMachine) -> PyRef<PyModule> {
 
 #[pymodule]
 mod _sqlite {
-    use crossbeam_utils::atomic::AtomicCell;
     use libsqlite3_sys::{
         SQLITE_BLOB, SQLITE_DETERMINISTIC, SQLITE_FLOAT, SQLITE_INTEGER, SQLITE_NULL,
         SQLITE_OPEN_CREATE, SQLITE_OPEN_READWRITE, SQLITE_OPEN_URI, SQLITE_TEXT, SQLITE_TRACE_STMT,
@@ -2549,19 +2548,19 @@ mod _sqlite {
     impl AsSequence for Blob {
         fn as_sequence() -> &'static PySequenceMethods {
             static AS_SEQUENCE: PySequenceMethods = PySequenceMethods {
-                length: AtomicCell::new(None),
-                concat: AtomicCell::new(None),
-                repeat: AtomicCell::new(None),
-                item: AtomicCell::new(None),
-                ass_item: AtomicCell::new(None),
+                length: None,
+                concat: None,
+                repeat: None,
+                item: None,
+                ass_item: None,
                 contains: atomic_func!(|seq, _needle, vm| {
                     Err(vm.new_type_error(format!(
                         "argument of type '{}' is not iterable",
                         seq.obj.class().name(),
                     )))
                 }),
-                inplace_concat: AtomicCell::new(None),
-                inplace_repeat: AtomicCell::new(None),
+                inplace_concat: None,
+                inplace_repeat: None,
             };
             &AS_SEQUENCE
         }

--- a/crates/vm/src/protocol/mapping.rs
+++ b/crates/vm/src/protocol/mapping.rs
@@ -35,13 +35,13 @@ impl PyMappingSlots {
 
     /// Copy from static PyMappingMethods
     pub fn copy_from(&self, methods: &PyMappingMethods) {
-        if let Some(f) = methods.length.load() {
+        if let Some(f) = methods.length {
             self.length.store(Some(f));
         }
-        if let Some(f) = methods.subscript.load() {
+        if let Some(f) = methods.subscript {
             self.subscript.store(Some(f));
         }
-        if let Some(f) = methods.ass_subscript.load() {
+        if let Some(f) = methods.ass_subscript {
             self.ass_subscript.store(Some(f));
         }
     }
@@ -50,11 +50,10 @@ impl PyMappingSlots {
 #[allow(clippy::type_complexity)]
 #[derive(Default)]
 pub struct PyMappingMethods {
-    pub length: AtomicCell<Option<fn(PyMapping<'_>, &VirtualMachine) -> PyResult<usize>>>,
-    pub subscript: AtomicCell<Option<fn(PyMapping<'_>, &PyObject, &VirtualMachine) -> PyResult>>,
-    pub ass_subscript: AtomicCell<
+    pub length: Option<fn(PyMapping<'_>, &VirtualMachine) -> PyResult<usize>>,
+    pub subscript: Option<fn(PyMapping<'_>, &PyObject, &VirtualMachine) -> PyResult>,
+    pub ass_subscript:
         Option<fn(PyMapping<'_>, &PyObject, Option<PyObjectRef>, &VirtualMachine) -> PyResult<()>>,
-    >,
 }
 
 impl std::fmt::Debug for PyMappingMethods {
@@ -64,11 +63,10 @@ impl std::fmt::Debug for PyMappingMethods {
 }
 
 impl PyMappingMethods {
-    #[allow(clippy::declare_interior_mutable_const)]
     pub const NOT_IMPLEMENTED: Self = Self {
-        length: AtomicCell::new(None),
-        subscript: AtomicCell::new(None),
-        ass_subscript: AtomicCell::new(None),
+        length: None,
+        subscript: None,
+        ass_subscript: None,
     };
 }
 

--- a/crates/vm/src/protocol/sequence.rs
+++ b/crates/vm/src/protocol/sequence.rs
@@ -42,28 +42,28 @@ impl PySequenceSlots {
 
     /// Copy from static PySequenceMethods
     pub fn copy_from(&self, methods: &PySequenceMethods) {
-        if let Some(f) = methods.length.load() {
+        if let Some(f) = methods.length {
             self.length.store(Some(f));
         }
-        if let Some(f) = methods.concat.load() {
+        if let Some(f) = methods.concat {
             self.concat.store(Some(f));
         }
-        if let Some(f) = methods.repeat.load() {
+        if let Some(f) = methods.repeat {
             self.repeat.store(Some(f));
         }
-        if let Some(f) = methods.item.load() {
+        if let Some(f) = methods.item {
             self.item.store(Some(f));
         }
-        if let Some(f) = methods.ass_item.load() {
+        if let Some(f) = methods.ass_item {
             self.ass_item.store(Some(f));
         }
-        if let Some(f) = methods.contains.load() {
+        if let Some(f) = methods.contains {
             self.contains.store(Some(f));
         }
-        if let Some(f) = methods.inplace_concat.load() {
+        if let Some(f) = methods.inplace_concat {
             self.inplace_concat.store(Some(f));
         }
-        if let Some(f) = methods.inplace_repeat.load() {
+        if let Some(f) = methods.inplace_repeat {
             self.inplace_repeat.store(Some(f));
         }
     }
@@ -72,18 +72,15 @@ impl PySequenceSlots {
 #[allow(clippy::type_complexity)]
 #[derive(Default)]
 pub struct PySequenceMethods {
-    pub length: AtomicCell<Option<fn(PySequence<'_>, &VirtualMachine) -> PyResult<usize>>>,
-    pub concat: AtomicCell<Option<fn(PySequence<'_>, &PyObject, &VirtualMachine) -> PyResult>>,
-    pub repeat: AtomicCell<Option<fn(PySequence<'_>, isize, &VirtualMachine) -> PyResult>>,
-    pub item: AtomicCell<Option<fn(PySequence<'_>, isize, &VirtualMachine) -> PyResult>>,
-    pub ass_item: AtomicCell<
+    pub length: Option<fn(PySequence<'_>, &VirtualMachine) -> PyResult<usize>>,
+    pub concat: Option<fn(PySequence<'_>, &PyObject, &VirtualMachine) -> PyResult>,
+    pub repeat: Option<fn(PySequence<'_>, isize, &VirtualMachine) -> PyResult>,
+    pub item: Option<fn(PySequence<'_>, isize, &VirtualMachine) -> PyResult>,
+    pub ass_item:
         Option<fn(PySequence<'_>, isize, Option<PyObjectRef>, &VirtualMachine) -> PyResult<()>>,
-    >,
-    pub contains:
-        AtomicCell<Option<fn(PySequence<'_>, &PyObject, &VirtualMachine) -> PyResult<bool>>>,
-    pub inplace_concat:
-        AtomicCell<Option<fn(PySequence<'_>, &PyObject, &VirtualMachine) -> PyResult>>,
-    pub inplace_repeat: AtomicCell<Option<fn(PySequence<'_>, isize, &VirtualMachine) -> PyResult>>,
+    pub contains: Option<fn(PySequence<'_>, &PyObject, &VirtualMachine) -> PyResult<bool>>,
+    pub inplace_concat: Option<fn(PySequence<'_>, &PyObject, &VirtualMachine) -> PyResult>,
+    pub inplace_repeat: Option<fn(PySequence<'_>, isize, &VirtualMachine) -> PyResult>,
 }
 
 impl std::fmt::Debug for PySequenceMethods {
@@ -93,16 +90,15 @@ impl std::fmt::Debug for PySequenceMethods {
 }
 
 impl PySequenceMethods {
-    #[allow(clippy::declare_interior_mutable_const)]
     pub const NOT_IMPLEMENTED: Self = Self {
-        length: AtomicCell::new(None),
-        concat: AtomicCell::new(None),
-        repeat: AtomicCell::new(None),
-        item: AtomicCell::new(None),
-        ass_item: AtomicCell::new(None),
-        contains: AtomicCell::new(None),
-        inplace_concat: AtomicCell::new(None),
-        inplace_repeat: AtomicCell::new(None),
+        length: None,
+        concat: None,
+        repeat: None,
+        item: None,
+        ass_item: None,
+        contains: None,
+        inplace_concat: None,
+        inplace_repeat: None,
     };
 }
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Simplified internal storage and access mechanisms for protocol method handling in mappings and sequences, reducing runtime overhead.
  * Restructured and centralized comparison operation implementations for improved consistency and maintainability.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->