### PR TITLE
use socket2 accept_raw

### DIFF
--- a/Lib/test/test_socket.py
+++ b/Lib/test/test_socket.py
@@ -4832,13 +4832,11 @@ class SendrecvmsgUnixStreamTestBase(SendrecvmsgConnectedBase,
 
 @requireAttrs(socket.socket, "sendmsg")
 @requireAttrs(socket, "AF_UNIX")
-@unittest.skip("TODO: RUSTPYTHON; accept() on Unix sockets returns EINVAL")
 class SendmsgUnixStreamTest(SendmsgStreamTests, SendrecvmsgUnixStreamTestBase):
     pass
 
 @requireAttrs(socket.socket, "recvmsg")
 @requireAttrs(socket, "AF_UNIX")
-@unittest.skip("TODO: RUSTPYTHON; intermittent accept() EINVAL on Unix sockets")
 class RecvmsgUnixStreamTest(RecvmsgTests, RecvmsgGenericStreamTests,
                             SendrecvmsgUnixStreamTestBase):
     pass
@@ -4851,7 +4849,6 @@ class RecvmsgIntoUnixStreamTest(RecvmsgIntoTests, RecvmsgGenericStreamTests,
 
 @requireAttrs(socket.socket, "sendmsg", "recvmsg")
 @requireAttrs(socket, "AF_UNIX", "SOL_SOCKET", "SCM_RIGHTS")
-@unittest.skip("TODO: RUSTPYTHON; intermittent accept() EINVAL on Unix sockets")
 class RecvmsgSCMRightsStreamTest(SCMRightsTest, SendrecvmsgUnixStreamTestBase):
     pass
 

--- a/crates/stdlib/src/socket.rs
+++ b/crates/stdlib/src/socket.rs
@@ -1570,7 +1570,9 @@ mod _socket {
             &self,
             vm: &VirtualMachine,
         ) -> Result<(RawSocket, PyObjectRef), IoOrPyException> {
-            let (sock, addr) = self.sock_op(vm, SelectKind::Read, || self.sock()?.accept())?;
+            // Use accept_raw() instead of accept() to avoid socket2's set_common_flags()
+            // which tries to set SO_NOSIGPIPE and fails with EINVAL on Unix domain sockets on macOS
+            let (sock, addr) = self.sock_op(vm, SelectKind::Read, || self.sock()?.accept_raw())?;
             let fd = into_sock_fileno(sock);
             Ok((fd, get_addr_tuple(&addr, vm)))
         }


### PR DESCRIPTION
also reported to socket2 https://github.com/rust-lang/socket2/issues/631

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed connection acceptance failures on Unix domain sockets on macOS systems, improving compatibility and stability.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->