### PR TITLE
Fix set in-place operators with self argument

### DIFF
--- a/extra_tests/snippets/builtin_set.py
+++ b/extra_tests/snippets/builtin_set.py
@@ -201,6 +201,18 @@ with assert_raises(TypeError):
     a &= [1, 2, 3]
 
 a = set([1, 2, 3])
+a &= a
+assert a == set([1, 2, 3])
+
+a = set([1, 2, 3])
+a -= a
+assert a == set()
+
+a = set([1, 2, 3])
+a ^= a
+assert a == set()
+
+a = set([1, 2, 3])
 a.difference_update([3, 4, 5])
 assert a == set([1, 2])
 assert_raises(TypeError, lambda: a.difference_update(1))


### PR DESCRIPTION
Fixes #3881
close #3912
close #4424
close #4708

  When a set performs in-place operations with itself (`s &= s`, `s -= s`, `s ^= s`), the operators now handle the self-reference case correctly:

  - `__iand__`: no-op (intersection with self is unchanged)
  - `__isub__`: clear (difference with self is empty)
  - `__ixor__`: clear (symmetric difference with self is empty)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected behavior of in-place set operations (&=, -=, ^=) when a set operates on itself, preventing unintended modifications.

* **Tests**
  * Added test cases validating in-place set operations when operating on the same set instance.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->