### PR TITLE
Write profile even if failed

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -276,11 +276,11 @@ fn run_rustpython(vm: &VirtualMachine, run_mode: RunMode) -> PyResult<()> {
         }
         RunMode::Repl => Ok(()),
     };
-    if is_repl || vm.state.config.settings.inspect {
-        shell::run_shell(vm, scope)?;
+    let result = if is_repl || vm.state.config.settings.inspect {
+        shell::run_shell(vm, scope)
     } else {
-        res?;
-    }
+        res
+    };
 
     #[cfg(feature = "flame-it")]
     {
@@ -289,7 +289,8 @@ fn run_rustpython(vm: &VirtualMachine, run_mode: RunMode) -> PyResult<()> {
             error!("Error writing profile information: {}", e);
         }
     }
-    Ok(())
+
+    result
 }
 
 #[cfg(feature = "flame-it")]


### PR DESCRIPTION
Currently, when an error occurs, the `?` operator causes an early return, which may result in the profile not being recorded properly even when built with the `flame-it` feature. This change makes a minor modification to the code to ensure that `write_profile` is always reached.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved error handling consistency for interactive shell operations by unifying the control flow for result collection and error propagation.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->