### PR TITLE
reject SemLock reduce

### DIFF
--- a/Lib/test/test_concurrent_futures/test_process_pool.py
+++ b/Lib/test/test_concurrent_futures/test_process_pool.py
@@ -228,13 +228,5 @@ create_executor_tests(globals(), ProcessPoolExecutorTest,
 def setUpModule():
     setup_module()
 
-class ProcessPoolSpawnProcessPoolExecutorTest(ProcessPoolSpawnProcessPoolExecutorTest):  # TODO: RUSTPYTHON
-    @unittest.skipIf(sys.platform == 'linux', "TODO: RUSTPYTHON flaky")
-    def test_saturation(self): super().test_saturation()  # TODO: RUSTPYTHON
-
-class ProcessPoolForkProcessPoolExecutorTest(ProcessPoolForkProcessPoolExecutorTest):  # TODO: RUSTPYTHON
-    @unittest.skipIf(sys.platform == 'linux', "TODO: RUSTPYTHON flaky")
-    def test_ressources_gced_in_workers(self): super().test_ressources_gced_in_workers()  # TODO: RUSTPYTHON
-
 if __name__ == "__main__":
     unittest.main()

--- a/crates/stdlib/src/multiprocessing.rs
+++ b/crates/stdlib/src/multiprocessing.rs
@@ -547,6 +547,13 @@ mod _multiprocessing {
             self.last_tid.store(0, Ordering::Release);
         }
 
+        /// SemLock objects cannot be pickled directly.
+        /// Use multiprocessing.synchronize.SemLock wrapper which handles pickling.
+        #[pymethod]
+        fn __reduce__(&self, vm: &VirtualMachine) -> PyResult {
+            Err(vm.new_type_error("cannot pickle 'SemLock' object".to_owned()))
+        }
+
         /// Num of `acquire()`s minus num of `release()`s for this process.
         // _multiprocessing_SemLock__count_impl
         #[pymethod]


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed pickling behavior for SemLock objects. Attempting to serialize a SemLock instance directly now properly raises an error. Users must utilize the `multiprocessing.SemLock` wrapper to enable serialization support for these objects.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->