### PR TITLE
Add metadata when uploading benchmark data

### DIFF
--- a/.github/workflows/cron-ci.yaml
+++ b/.github/workflows/cron-ci.yaml
@@ -180,7 +180,11 @@ jobs:
           cd website
           rm -rf ./assets/criterion
           cp -r ../target/criterion ./assets/criterion
-          git add ./assets/criterion
+          printf '{\n  "generated_at": "%s",\n  "rustpython_commit": "%s",\n  "rustpython_ref": "%s"\n}\n' \
+            "$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
+            "${{ github.sha }}" \
+            "${{ github.ref_name }}" > ./_data/criterion-metadata.json
+          git add ./assets/criterion ./_data/criterion-metadata.json
           if git -c user.name="Github Actions" -c user.email="actions@github.com" commit -m "Update benchmark results"; then
             git push
           fi


### PR DESCRIPTION
This is a minor issue, but when looking at the data on <https://rustpython.github.io/benchmarks>, it is difficult to tell which commit the results were generated from. To address this, I updated the process to include metadata and push it to the RustPython/rustpython.github.io repository. ~~I will also open a PR to the RustPython/rustpython.github.io repository.~~

See also https://github.com/RustPython/rustpython.github.io/pull/83.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Benchmark publishing workflow now generates and commits metadata JSON containing timestamp and commit information alongside benchmark results.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->