### PR TITLE
Initialize warnings module during interpreter startup to process

### DIFF
--- a/Lib/test/test_warnings/__init__.py
+++ b/Lib/test/test_warnings/__init__.py
@@ -841,8 +841,6 @@ class PyWCmdLineTests(WCmdLineTests, unittest.TestCase):
         rc, out, err = assert_python_ok("-Wxxx", "-c", "pass")
         self.assertIn(b"Invalid -W option ignored: invalid action: 'xxx'", err)
 
-    # TODO: RUSTPYTHON
-    @unittest.expectedFailure
     def test_warnings_bootstrap(self):
         # Check that the warnings module does get loaded when -W<some option>
         # is used (see issue #10372 for an example of silent bootstrap failure).

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -219,6 +219,12 @@ fn run_rustpython(vm: &VirtualMachine, run_mode: RunMode) -> PyResult<()> {
         );
     }
 
+    // Initialize warnings module to process sys.warnoptions
+    // _PyWarnings_Init()
+    if vm.import("warnings", 0).is_err() {
+        warn!("Failed to import warnings module");
+    }
+
     // _PyPathConfig_ComputeSysPath0 - set sys.path[0] after site import
     if !vm.state.config.settings.safe_path {
         let path0: Option<String> = match &run_mode {


### PR DESCRIPTION
probably related to #6762 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved warnings module initialization on RustPython CLI startup with robust error handling.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->