### PR TITLE
import ruff_python_ast only and don't imort its subitems

### DIFF
--- a/crates/codegen/src/lib.rs
+++ b/crates/codegen/src/lib.rs
@@ -18,7 +18,7 @@ pub mod symboltable;
 mod unparse;
 
 pub use compile::CompileOpts;
-use ruff_python_ast::Expr;
+use ruff_python_ast as ast;
 
 pub(crate) use compile::InternalResult;
 
@@ -27,7 +27,7 @@ pub trait ToPythonName {
     fn python_name(&self) -> &'static str;
 }
 
-impl ToPythonName for Expr {
+impl ToPythonName for ast::Expr {
     fn python_name(&self) -> &'static str {
         match self {
             Self::BoolOp { .. } | Self::BinOp { .. } | Self::UnaryOp { .. } => "operator",

--- a/crates/codegen/src/string_parser.rs
+++ b/crates/codegen/src/string_parser.rs
@@ -7,7 +7,7 @@
 
 use core::convert::Infallible;
 
-use ruff_python_ast::{AnyStringFlags, StringFlags};
+use ruff_python_ast::{self as ast, StringFlags as _};
 use rustpython_wtf8::{CodePoint, Wtf8, Wtf8Buf};
 
 // use ruff_python_parser::{LexicalError, LexicalErrorType};
@@ -24,11 +24,11 @@ struct StringParser {
     /// Current position of the parser in the source.
     cursor: usize,
     /// Flags that can be used to query information about the string.
-    flags: AnyStringFlags,
+    flags: ast::AnyStringFlags,
 }
 
 impl StringParser {
-    const fn new(source: Box<str>, flags: AnyStringFlags) -> Self {
+    const fn new(source: Box<str>, flags: ast::AnyStringFlags) -> Self {
         Self {
             source,
             cursor: 0,
@@ -272,7 +272,7 @@ impl StringParser {
     }
 }
 
-pub(crate) fn parse_string_literal(source: &str, flags: AnyStringFlags) -> Box<Wtf8> {
+pub(crate) fn parse_string_literal(source: &str, flags: ast::AnyStringFlags) -> Box<Wtf8> {
     let source = &source[flags.opener_len().to_usize()..];
     let source = &source[..source.len() - flags.quote_len().to_usize()];
     StringParser::new(source.into(), flags)
@@ -280,7 +280,10 @@ pub(crate) fn parse_string_literal(source: &str, flags: AnyStringFlags) -> Box<W
         .unwrap_or_else(|x| match x {})
 }
 
-pub(crate) fn parse_fstring_literal_element(source: Box<str>, flags: AnyStringFlags) -> Box<Wtf8> {
+pub(crate) fn parse_fstring_literal_element(
+    source: Box<str>,
+    flags: ast::AnyStringFlags,
+) -> Box<Wtf8> {
     StringParser::new(source, flags)
         .parse_fstring_middle()
         .unwrap_or_else(|x| match x {})

--- a/crates/vm/src/stdlib/ast.rs
+++ b/crates/vm/src/stdlib/ast.rs
@@ -19,7 +19,7 @@ use crate::{
     convert::ToPyObject,
 };
 use node::Node;
-use ruff_python_ast as ruff;
+use ruff_python_ast as ast;
 use ruff_text_size::{Ranged, TextRange, TextSize};
 use rustpython_compiler_core::{
     LineIndex, OneIndexed, PositionEncoding, SourceFile, SourceFileBuilder, SourceLocation,
@@ -283,8 +283,8 @@ pub(crate) fn parse(
         })?
         .into_syntax();
     let top = match top {
-        ruff::Mod::Module(m) => Mod::Module(m),
-        ruff::Mod::Expression(e) => Mod::Expression(e),
+        ast::Mod::Module(m) => Mod::Module(m),
+        ast::Mod::Expression(e) => Mod::Expression(e),
     };
     Ok(top.ast_to_object(vm, &source_file))
 }
@@ -305,13 +305,13 @@ pub(crate) fn compile(
     let source_file = SourceFileBuilder::new(filename.to_owned(), "".to_owned()).finish();
     let ast: Mod = Node::ast_from_object(vm, &source_file, object)?;
     let ast = match ast {
-        Mod::Module(m) => ruff::Mod::Module(m),
-        Mod::Interactive(ModInteractive { range, body }) => ruff::Mod::Module(ruff::ModModule {
+        Mod::Module(m) => ast::Mod::Module(m),
+        Mod::Interactive(ModInteractive { range, body }) => ast::Mod::Module(ast::ModModule {
             node_index: Default::default(),
             range,
             body,
         }),
-        Mod::Expression(e) => ruff::Mod::Expression(e),
+        Mod::Expression(e) => ast::Mod::Expression(e),
         Mod::FunctionType(_) => todo!(),
     };
     // TODO: create a textual representation of the ast

--- a/crates/vm/src/stdlib/ast/argument.rs
+++ b/crates/vm/src/stdlib/ast/argument.rs
@@ -3,7 +3,7 @@ use rustpython_compiler_core::SourceFile;
 
 pub(super) struct PositionalArguments {
     pub range: TextRange,
-    pub args: Box<[ruff::Expr]>,
+    pub args: Box<[ast::Expr]>,
 }
 
 impl Node for PositionalArguments {
@@ -27,7 +27,7 @@ impl Node for PositionalArguments {
 
 pub(super) struct KeywordArguments {
     pub range: TextRange,
-    pub keywords: Box<[ruff::Keyword]>,
+    pub keywords: Box<[ast::Keyword]>,
 }
 
 impl Node for KeywordArguments {
@@ -53,10 +53,10 @@ impl Node for KeywordArguments {
 pub(super) fn merge_function_call_arguments(
     pos_args: PositionalArguments,
     key_args: KeywordArguments,
-) -> ruff::Arguments {
+) -> ast::Arguments {
     let range = pos_args.range.cover(key_args.range);
 
-    ruff::Arguments {
+    ast::Arguments {
         node_index: Default::default(),
         range,
         args: pos_args.args,
@@ -65,9 +65,9 @@ pub(super) fn merge_function_call_arguments(
 }
 
 pub(super) fn split_function_call_arguments(
-    args: ruff::Arguments,
+    args: ast::Arguments,
 ) -> (PositionalArguments, KeywordArguments) {
-    let ruff::Arguments {
+    let ast::Arguments {
         node_index: _,
         range: _,
         args,
@@ -100,13 +100,13 @@ pub(super) fn split_function_call_arguments(
 }
 
 pub(super) fn split_class_def_args(
-    args: Option<Box<ruff::Arguments>>,
+    args: Option<Box<ast::Arguments>>,
 ) -> (Option<PositionalArguments>, Option<KeywordArguments>) {
     let args = match args {
         None => return (None, None),
         Some(args) => *args,
     };
-    let ruff::Arguments {
+    let ast::Arguments {
         node_index: _,
         range: _,
         args,
@@ -141,7 +141,7 @@ pub(super) fn split_class_def_args(
 pub(super) fn merge_class_def_args(
     positional_arguments: Option<PositionalArguments>,
     keyword_arguments: Option<KeywordArguments>,
-) -> Option<Box<ruff::Arguments>> {
+) -> Option<Box<ast::Arguments>> {
     if positional_arguments.is_none() && keyword_arguments.is_none() {
         return None;
     }
@@ -157,7 +157,7 @@ pub(super) fn merge_class_def_args(
         vec![].into_boxed_slice()
     };
 
-    Some(Box::new(ruff::Arguments {
+    Some(Box::new(ast::Arguments {
         node_index: Default::default(),
         range: Default::default(), // TODO
         args,

--- a/crates/vm/src/stdlib/ast/basic.rs
+++ b/crates/vm/src/stdlib/ast/basic.rs
@@ -2,7 +2,7 @@ use super::*;
 use rustpython_codegen::compile::ruff_int_to_bigint;
 use rustpython_compiler_core::SourceFile;
 
-impl Node for ruff::Identifier {
+impl Node for ast::Identifier {
     fn ast_to_object(self, vm: &VirtualMachine, _source_file: &SourceFile) -> PyObjectRef {
         let id = self.as_str();
         vm.ctx.new_str(id).into()
@@ -18,7 +18,7 @@ impl Node for ruff::Identifier {
     }
 }
 
-impl Node for ruff::Int {
+impl Node for ast::Int {
     fn ast_to_object(self, vm: &VirtualMachine, _source_file: &SourceFile) -> PyObjectRef {
         vm.ctx.new_int(ruff_int_to_bigint(&self).unwrap()).into()
     }

--- a/crates/vm/src/stdlib/ast/elif_else_clause.rs
+++ b/crates/vm/src/stdlib/ast/elif_else_clause.rs
@@ -2,12 +2,12 @@ use super::*;
 use rustpython_compiler_core::SourceFile;
 
 pub(super) fn ast_to_object(
-    clause: ruff::ElifElseClause,
-    mut rest: alloc::vec::IntoIter<ruff::ElifElseClause>,
+    clause: ast::ElifElseClause,
+    mut rest: alloc::vec::IntoIter<ast::ElifElseClause>,
     vm: &VirtualMachine,
     source_file: &SourceFile,
 ) -> PyObjectRef {
-    let ruff::ElifElseClause {
+    let ast::ElifElseClause {
         node_index: _,
         range,
         test,
@@ -48,18 +48,18 @@ pub(super) fn ast_from_object(
     vm: &VirtualMachine,
     source_file: &SourceFile,
     object: PyObjectRef,
-) -> PyResult<ruff::StmtIf> {
+) -> PyResult<ast::StmtIf> {
     let test = Node::ast_from_object(vm, source_file, get_node_field(vm, &object, "test", "If")?)?;
     let body = Node::ast_from_object(vm, source_file, get_node_field(vm, &object, "body", "If")?)?;
-    let orelse: Vec<ruff::Stmt> = Node::ast_from_object(
+    let orelse: Vec<ast::Stmt> = Node::ast_from_object(
         vm,
         source_file,
         get_node_field(vm, &object, "orelse", "If")?,
     )?;
     let range = range_from_object(vm, source_file, object, "If")?;
 
-    let elif_else_clauses = if let [ruff::Stmt::If(_)] = &*orelse {
-        let Some(ruff::Stmt::If(ruff::StmtIf {
+    let elif_else_clauses = if let [ast::Stmt::If(_)] = &*orelse {
+        let Some(ast::Stmt::If(ast::StmtIf {
             node_index: _,
             range,
             test,
@@ -71,7 +71,7 @@ pub(super) fn ast_from_object(
         };
         elif_else_clauses.insert(
             0,
-            ruff::ElifElseClause {
+            ast::ElifElseClause {
                 node_index: Default::default(),
                 range,
                 test: Some(*test),
@@ -80,7 +80,7 @@ pub(super) fn ast_from_object(
         );
         elif_else_clauses
     } else {
-        vec![ruff::ElifElseClause {
+        vec![ast::ElifElseClause {
             node_index: Default::default(),
             range,
             test: None,
@@ -88,7 +88,7 @@ pub(super) fn ast_from_object(
         }]
     };
 
-    Ok(ruff::StmtIf {
+    Ok(ast::StmtIf {
         node_index: Default::default(),
         test,
         body,

--- a/crates/vm/src/stdlib/ast/exception.rs
+++ b/crates/vm/src/stdlib/ast/exception.rs
@@ -2,7 +2,7 @@ use super::*;
 use rustpython_compiler_core::SourceFile;
 
 // sum
-impl Node for ruff::ExceptHandler {
+impl Node for ast::ExceptHandler {
     fn ast_to_object(self, vm: &VirtualMachine, source_file: &SourceFile) -> PyObjectRef {
         match self {
             Self::ExceptHandler(cons) => cons.ast_to_object(vm, source_file),
@@ -16,7 +16,7 @@ impl Node for ruff::ExceptHandler {
         let _cls = _object.class();
         Ok(
             if _cls.is(pyast::NodeExceptHandlerExceptHandler::static_type()) {
-                Self::ExceptHandler(ruff::ExceptHandlerExceptHandler::ast_from_object(
+                Self::ExceptHandler(ast::ExceptHandlerExceptHandler::ast_from_object(
                     _vm,
                     source_file,
                     _object,
@@ -32,7 +32,7 @@ impl Node for ruff::ExceptHandler {
 }
 
 // constructor
-impl Node for ruff::ExceptHandlerExceptHandler {
+impl Node for ast::ExceptHandlerExceptHandler {
     fn ast_to_object(self, _vm: &VirtualMachine, source_file: &SourceFile) -> PyObjectRef {
         let Self {
             node_index: _,

--- a/crates/vm/src/stdlib/ast/expression.rs
+++ b/crates/vm/src/stdlib/ast/expression.rs
@@ -7,7 +7,7 @@ use crate::stdlib::ast::{
 use rustpython_compiler_core::SourceFile;
 
 // sum
-impl Node for ruff::Expr {
+impl Node for ast::Expr {
     fn ast_to_object(self, vm: &VirtualMachine, source_file: &SourceFile) -> PyObjectRef {
         match self {
             Self::BoolOp(cons) => cons.ast_to_object(vm, source_file),
@@ -59,77 +59,69 @@ impl Node for ruff::Expr {
     ) -> PyResult<Self> {
         let cls = object.class();
         Ok(if cls.is(pyast::NodeExprBoolOp::static_type()) {
-            Self::BoolOp(ruff::ExprBoolOp::ast_from_object(vm, source_file, object)?)
+            Self::BoolOp(ast::ExprBoolOp::ast_from_object(vm, source_file, object)?)
         } else if cls.is(pyast::NodeExprNamedExpr::static_type()) {
-            Self::Named(ruff::ExprNamed::ast_from_object(vm, source_file, object)?)
+            Self::Named(ast::ExprNamed::ast_from_object(vm, source_file, object)?)
         } else if cls.is(pyast::NodeExprBinOp::static_type()) {
-            Self::BinOp(ruff::ExprBinOp::ast_from_object(vm, source_file, object)?)
+            Self::BinOp(ast::ExprBinOp::ast_from_object(vm, source_file, object)?)
         } else if cls.is(pyast::NodeExprUnaryOp::static_type()) {
-            Self::UnaryOp(ruff::ExprUnaryOp::ast_from_object(vm, source_file, object)?)
+            Self::UnaryOp(ast::ExprUnaryOp::ast_from_object(vm, source_file, object)?)
         } else if cls.is(pyast::NodeExprLambda::static_type()) {
-            Self::Lambda(ruff::ExprLambda::ast_from_object(vm, source_file, object)?)
+            Self::Lambda(ast::ExprLambda::ast_from_object(vm, source_file, object)?)
         } else if cls.is(pyast::NodeExprIfExp::static_type()) {
-            Self::If(ruff::ExprIf::ast_from_object(vm, source_file, object)?)
+            Self::If(ast::ExprIf::ast_from_object(vm, source_file, object)?)
         } else if cls.is(pyast::NodeExprDict::static_type()) {
-            Self::Dict(ruff::ExprDict::ast_from_object(vm, source_file, object)?)
+            Self::Dict(ast::ExprDict::ast_from_object(vm, source_file, object)?)
         } else if cls.is(pyast::NodeExprSet::static_type()) {
-            Self::Set(ruff::ExprSet::ast_from_object(vm, source_file, object)?)
+            Self::Set(ast::ExprSet::ast_from_object(vm, source_file, object)?)
         } else if cls.is(pyast::NodeExprListComp::static_type()) {
-            Self::ListComp(ruff::ExprListComp::ast_from_object(
-                vm,
-                source_file,
-                object,
-            )?)
+            Self::ListComp(ast::ExprListComp::ast_from_object(vm, source_file, object)?)
         } else if cls.is(pyast::NodeExprSetComp::static_type()) {
-            Self::SetComp(ruff::ExprSetComp::ast_from_object(vm, source_file, object)?)
+            Self::SetComp(ast::ExprSetComp::ast_from_object(vm, source_file, object)?)
         } else if cls.is(pyast::NodeExprDictComp::static_type()) {
-            Self::DictComp(ruff::ExprDictComp::ast_from_object(
-                vm,
-                source_file,
-                object,
-            )?)
+            Self::DictComp(ast::ExprDictComp::ast_from_object(vm, source_file, object)?)
         } else if cls.is(pyast::NodeExprGeneratorExp::static_type()) {
-            Self::Generator(ruff::ExprGenerator::ast_from_object(
+            Self::Generator(ast::ExprGenerator::ast_from_object(
                 vm,
                 source_file,
                 object,
             )?)
         } else if cls.is(pyast::NodeExprAwait::static_type()) {
-            Self::Await(ruff::ExprAwait::ast_from_object(vm, source_file, object)?)
+            Self::Await(ast::ExprAwait::ast_from_object(vm, source_file, object)?)
         } else if cls.is(pyast::NodeExprYield::static_type()) {
-            Self::Yield(ruff::ExprYield::ast_from_object(vm, source_file, object)?)
+            Self::Yield(ast::ExprYield::ast_from_object(vm, source_file, object)?)
         } else if cls.is(pyast::NodeExprYieldFrom::static_type()) {
-            Self::YieldFrom(ruff::ExprYieldFrom::ast_from_object(
+            Self::YieldFrom(ast::ExprYieldFrom::ast_from_object(
                 vm,
                 source_file,
                 object,
             )?)
         } else if cls.is(pyast::NodeExprCompare::static_type()) {
-            Self::Compare(ruff::ExprCompare::ast_from_object(vm, source_file, object)?)
+            Self::Compare(ast::ExprCompare::ast_from_object(vm, source_file, object)?)
         } else if cls.is(pyast::NodeExprCall::static_type()) {
-            Self::Call(ruff::ExprCall::ast_from_object(vm, source_file, object)?)
+            Self::Call(ast::ExprCall::ast_from_object(vm, source_file, object)?)
         } else if cls.is(pyast::NodeExprAttribute::static_type()) {
-            Self::Attribute(ruff::ExprAttribute::ast_from_object(
+            Self::Attribute(ast::ExprAttribute::ast_from_object(
                 vm,
                 source_file,
                 object,
             )?)
         } else if cls.is(pyast::NodeExprSubscript::static_type()) {
-            Self::Subscript(ruff::ExprSubscript::ast_from_object(
+            Self::Subscript(ast::ExprSubscript::ast_from_object(
                 vm,
                 source_file,
                 object,
             )?)
         } else if cls.is(pyast::NodeExprStarred::static_type()) {
-            Self::Starred(ruff::ExprStarred::ast_from_object(vm, source_file, object)?)
+            Self::Starred(ast::ExprStarred::ast_from_object(vm, source_file, object)?)
         } else if cls.is(pyast::NodeExprName::static_type()) {
-            Self::Name(ruff::ExprName::ast_from_object(vm, source_file, object)?)
+            Self::Name(ast::ExprName::ast_from_object(vm, source_file, object)?)
         } else if cls.is(pyast::NodeExprList::static_type()) {
-            Self::List(ruff::ExprList::ast_from_object(vm, source_file, object)?)
+            Self::List(ast::ExprList::ast_from_object(vm, source_file, object)?)
         } else if cls.is(pyast::NodeExprTuple::static_type()) {
-            Self::Tuple(ruff::ExprTuple::ast_from_object(vm, source_file, object)?)
+            Self::Tuple(ast::ExprTuple::ast_from_object(vm, source_file, object)?)
         } else if cls.is(pyast::NodeExprSlice::static_type()) {
-            Self::Slice(ruff::ExprSlice::ast_from_object(vm, source_file, object)?)
+            Self::Slice(ast::ExprSlice::ast_from_object(vm, source_file, object)?)
         } else if cls.is(pyast::NodeExprConstant::static_type()) {
             Constant::ast_from_object(vm, source_file, object)?.into_expr()
         } else if cls.is(pyast::NodeExprJoinedStr::static_type()) {
@@ -144,7 +136,7 @@ impl Node for ruff::Expr {
 }
 
 // constructor
-impl Node for ruff::ExprBoolOp {
+impl Node for ast::ExprBoolOp {
     fn ast_to_object(self, vm: &VirtualMachine, source_file: &SourceFile) -> PyObjectRef {
         let Self {
             node_index: _,
@@ -187,7 +179,7 @@ impl Node for ruff::ExprBoolOp {
 }
 
 // constructor
-impl Node for ruff::ExprNamed {
+impl Node for ast::ExprNamed {
     fn ast_to_object(self, vm: &VirtualMachine, source_file: &SourceFile) -> PyObjectRef {
         let Self {
             node_index: _,
@@ -230,7 +222,7 @@ impl Node for ruff::ExprNamed {
 }
 
 // constructor
-impl Node for ruff::ExprBinOp {
+impl Node for ast::ExprBinOp {
     fn ast_to_object(self, vm: &VirtualMachine, source_file: &SourceFile) -> PyObjectRef {
         let Self {
             node_index: _,
@@ -281,7 +273,7 @@ impl Node for ruff::ExprBinOp {
 }
 
 // constructor
-impl Node for ruff::ExprUnaryOp {
+impl Node for ast::ExprUnaryOp {
     fn ast_to_object(self, vm: &VirtualMachine, source_file: &SourceFile) -> PyObjectRef {
         let Self {
             node_index: _,
@@ -323,7 +315,7 @@ impl Node for ruff::ExprUnaryOp {
 }
 
 // constructor
-impl Node for ruff::ExprLambda {
+impl Node for ast::ExprLambda {
     fn ast_to_object(self, vm: &VirtualMachine, source_file: &SourceFile) -> PyObjectRef {
         let Self {
             node_index: _,
@@ -366,7 +358,7 @@ impl Node for ruff::ExprLambda {
 }
 
 // constructor
-impl Node for ruff::ExprIf {
+impl Node for ast::ExprIf {
     fn ast_to_object(self, vm: &VirtualMachine, source_file: &SourceFile) -> PyObjectRef {
         let Self {
             node_index: _,
@@ -417,7 +409,7 @@ impl Node for ruff::ExprIf {
 }
 
 // constructor
-impl Node for ruff::ExprDict {
+impl Node for ast::ExprDict {
     fn ast_to_object(self, vm: &VirtualMachine, source_file: &SourceFile) -> PyObjectRef {
         let Self {
             node_index: _,
@@ -449,7 +441,7 @@ impl Node for ruff::ExprDict {
         source_file: &SourceFile,
         object: PyObjectRef,
     ) -> PyResult<Self> {
-        let keys: Vec<Option<ruff::Expr>> = Node::ast_from_object(
+        let keys: Vec<Option<ast::Expr>> = Node::ast_from_object(
             vm,
             source_file,
             get_node_field(vm, &object, "keys", "Dict")?,
@@ -462,7 +454,7 @@ impl Node for ruff::ExprDict {
         let items = keys
             .into_iter()
             .zip(values)
-            .map(|(key, value)| ruff::DictItem { key, value })
+            .map(|(key, value)| ast::DictItem { key, value })
             .collect();
         Ok(Self {
             node_index: Default::default(),
@@ -473,7 +465,7 @@ impl Node for ruff::ExprDict {
 }
 
 // constructor
-impl Node for ruff::ExprSet {
+impl Node for ast::ExprSet {
     fn ast_to_object(self, vm: &VirtualMachine, source_file: &SourceFile) -> PyObjectRef {
         let Self {
             node_index: _,
@@ -507,7 +499,7 @@ impl Node for ruff::ExprSet {
 }
 
 // constructor
-impl Node for ruff::ExprListComp {
+impl Node for ast::ExprListComp {
     fn ast_to_object(self, vm: &VirtualMachine, source_file: &SourceFile) -> PyObjectRef {
         let Self {
             node_index: _,
@@ -550,7 +542,7 @@ impl Node for ruff::ExprListComp {
 }
 
 // constructor
-impl Node for ruff::ExprSetComp {
+impl Node for ast::ExprSetComp {
     fn ast_to_object(self, vm: &VirtualMachine, source_file: &SourceFile) -> PyObjectRef {
         let Self {
             node_index: _,
@@ -593,7 +585,7 @@ impl Node for ruff::ExprSetComp {
 }
 
 // constructor
-impl Node for ruff::ExprDictComp {
+impl Node for ast::ExprDictComp {
     fn ast_to_object(self, vm: &VirtualMachine, source_file: &SourceFile) -> PyObjectRef {
         let Self {
             node_index: _,
@@ -644,7 +636,7 @@ impl Node for ruff::ExprDictComp {
 }
 
 // constructor
-impl Node for ruff::ExprGenerator {
+impl Node for ast::ExprGenerator {
     fn ast_to_object(self, vm: &VirtualMachine, source_file: &SourceFile) -> PyObjectRef {
         let Self {
             node_index: _,
@@ -690,7 +682,7 @@ impl Node for ruff::ExprGenerator {
 }
 
 // constructor
-impl Node for ruff::ExprAwait {
+impl Node for ast::ExprAwait {
     fn ast_to_object(self, vm: &VirtualMachine, source_file: &SourceFile) -> PyObjectRef {
         let Self {
             node_index: _,
@@ -724,7 +716,7 @@ impl Node for ruff::ExprAwait {
 }
 
 // constructor
-impl Node for ruff::ExprYield {
+impl Node for ast::ExprYield {
     fn ast_to_object(self, vm: &VirtualMachine, source_file: &SourceFile) -> PyObjectRef {
         let Self {
             node_index: _,
@@ -757,7 +749,7 @@ impl Node for ruff::ExprYield {
 }
 
 // constructor
-impl Node for ruff::ExprYieldFrom {
+impl Node for ast::ExprYieldFrom {
     fn ast_to_object(self, vm: &VirtualMachine, source_file: &SourceFile) -> PyObjectRef {
         let Self {
             node_index: _,
@@ -792,7 +784,7 @@ impl Node for ruff::ExprYieldFrom {
 }
 
 // constructor
-impl Node for ruff::ExprCompare {
+impl Node for ast::ExprCompare {
     fn ast_to_object(self, vm: &VirtualMachine, source_file: &SourceFile) -> PyObjectRef {
         let Self {
             node_index: _,
@@ -853,7 +845,7 @@ impl Node for ruff::ExprCompare {
 }
 
 // constructor
-impl Node for ruff::ExprCall {
+impl Node for ast::ExprCall {
     fn ast_to_object(self, vm: &VirtualMachine, source_file: &SourceFile) -> PyObjectRef {
         let Self {
             node_index: _,
@@ -914,7 +906,7 @@ impl Node for ruff::ExprCall {
 }
 
 // constructor
-impl Node for ruff::ExprAttribute {
+impl Node for ast::ExprAttribute {
     fn ast_to_object(self, vm: &VirtualMachine, source_file: &SourceFile) -> PyObjectRef {
         let Self {
             node_index: _,
@@ -965,7 +957,7 @@ impl Node for ruff::ExprAttribute {
 }
 
 // constructor
-impl Node for ruff::ExprSubscript {
+impl Node for ast::ExprSubscript {
     fn ast_to_object(self, vm: &VirtualMachine, source_file: &SourceFile) -> PyObjectRef {
         let Self {
             node_index: _,
@@ -1015,7 +1007,7 @@ impl Node for ruff::ExprSubscript {
 }
 
 // constructor
-impl Node for ruff::ExprStarred {
+impl Node for ast::ExprStarred {
     fn ast_to_object(self, vm: &VirtualMachine, source_file: &SourceFile) -> PyObjectRef {
         let Self {
             node_index: _,
@@ -1057,7 +1049,7 @@ impl Node for ruff::ExprStarred {
 }
 
 // constructor
-impl Node for ruff::ExprName {
+impl Node for ast::ExprName {
     fn ast_to_object(self, vm: &VirtualMachine, source_file: &SourceFile) -> PyObjectRef {
         let Self {
             node_index: _,
@@ -1095,7 +1087,7 @@ impl Node for ruff::ExprName {
 }
 
 // constructor
-impl Node for ruff::ExprList {
+impl Node for ast::ExprList {
     fn ast_to_object(self, vm: &VirtualMachine, source_file: &SourceFile) -> PyObjectRef {
         let Self {
             node_index: _,
@@ -1138,7 +1130,7 @@ impl Node for ruff::ExprList {
 }
 
 // constructor
-impl Node for ruff::ExprTuple {
+impl Node for ast::ExprTuple {
     fn ast_to_object(self, vm: &VirtualMachine, source_file: &SourceFile) -> PyObjectRef {
         let Self {
             node_index: _,
@@ -1183,7 +1175,7 @@ impl Node for ruff::ExprTuple {
 }
 
 // constructor
-impl Node for ruff::ExprSlice {
+impl Node for ast::ExprSlice {
     fn ast_to_object(self, vm: &VirtualMachine, source_file: &SourceFile) -> PyObjectRef {
         let Self {
             node_index: _,
@@ -1228,7 +1220,7 @@ impl Node for ruff::ExprSlice {
 }
 
 // sum
-impl Node for ruff::ExprContext {
+impl Node for ast::ExprContext {
     fn ast_to_object(self, vm: &VirtualMachine, _source_file: &SourceFile) -> PyObjectRef {
         let node_type = match self {
             Self::Load => pyast::NodeExprContextLoad::static_type(),
@@ -1266,7 +1258,7 @@ impl Node for ruff::ExprContext {
 }
 
 // product
-impl Node for ruff::Comprehension {
+impl Node for ast::Comprehension {
     fn ast_to_object(self, vm: &VirtualMachine, source_file: &SourceFile) -> PyObjectRef {
         let Self {
             node_index: _,

--- a/crates/vm/src/stdlib/ast/module.rs
+++ b/crates/vm/src/stdlib/ast/module.rs
@@ -18,9 +18,9 @@ use rustpython_compiler_core::SourceFile;
 /// - `FunctionType`: A function signature with argument and return type
 ///   annotations, representing the type hints of a function (e.g., `def add(x: int, y: int) -> int`).
 pub(super) enum Mod {
-    Module(ruff::ModModule),
+    Module(ast::ModModule),
     Interactive(ModInteractive),
-    Expression(ruff::ModExpression),
+    Expression(ast::ModExpression),
     FunctionType(ModFunctionType),
 }
 
@@ -42,11 +42,11 @@ impl Node for Mod {
     ) -> PyResult<Self> {
         let cls = object.class();
         Ok(if cls.is(pyast::NodeModModule::static_type()) {
-            Self::Module(ruff::ModModule::ast_from_object(vm, source_file, object)?)
+            Self::Module(ast::ModModule::ast_from_object(vm, source_file, object)?)
         } else if cls.is(pyast::NodeModInteractive::static_type()) {
             Self::Interactive(ModInteractive::ast_from_object(vm, source_file, object)?)
         } else if cls.is(pyast::NodeModExpression::static_type()) {
-            Self::Expression(ruff::ModExpression::ast_from_object(
+            Self::Expression(ast::ModExpression::ast_from_object(
                 vm,
                 source_file,
                 object,
@@ -63,7 +63,7 @@ impl Node for Mod {
 }
 
 // constructor
-impl Node for ruff::ModModule {
+impl Node for ast::ModModule {
     fn ast_to_object(self, vm: &VirtualMachine, source_file: &SourceFile) -> PyObjectRef {
         let Self {
             node_index: _,
@@ -113,7 +113,7 @@ impl Node for ruff::ModModule {
 
 pub(super) struct ModInteractive {
     pub(crate) range: TextRange,
-    pub(crate) body: Vec<ruff::Stmt>,
+    pub(crate) body: Vec<ast::Stmt>,
 }
 
 // constructor
@@ -147,7 +147,7 @@ impl Node for ModInteractive {
 }
 
 // constructor
-impl Node for ruff::ModExpression {
+impl Node for ast::ModExpression {
     fn ast_to_object(self, vm: &VirtualMachine, source_file: &SourceFile) -> PyObjectRef {
         let Self {
             node_index: _,
@@ -182,8 +182,8 @@ impl Node for ruff::ModExpression {
 }
 
 pub(super) struct ModFunctionType {
-    pub(crate) argtypes: Box<[ruff::Expr]>,
-    pub(crate) returns: ruff::Expr,
+    pub(crate) argtypes: Box<[ast::Expr]>,
+    pub(crate) returns: ast::Expr,
     pub(crate) range: TextRange,
 }
 

--- a/crates/vm/src/stdlib/ast/operator.rs
+++ b/crates/vm/src/stdlib/ast/operator.rs
@@ -2,7 +2,7 @@ use super::*;
 use rustpython_compiler_core::SourceFile;
 
 // sum
-impl Node for ruff::BoolOp {
+impl Node for ast::BoolOp {
     fn ast_to_object(self, vm: &VirtualMachine, _source_file: &SourceFile) -> PyObjectRef {
         let node_type = match self {
             Self::And => pyast::NodeBoolOpAnd::static_type(),
@@ -34,7 +34,7 @@ impl Node for ruff::BoolOp {
 }
 
 // sum
-impl Node for ruff::Operator {
+impl Node for ast::Operator {
     fn ast_to_object(self, vm: &VirtualMachine, _source_file: &SourceFile) -> PyObjectRef {
         let node_type = match self {
             Self::Add => pyast::NodeOperatorAdd::static_type(),
@@ -99,7 +99,7 @@ impl Node for ruff::Operator {
 }
 
 // sum
-impl Node for ruff::UnaryOp {
+impl Node for ast::UnaryOp {
     fn ast_to_object(self, vm: &VirtualMachine, _source_file: &SourceFile) -> PyObjectRef {
         let node_type = match self {
             Self::Invert => pyast::NodeUnaryOpInvert::static_type(),
@@ -137,7 +137,7 @@ impl Node for ruff::UnaryOp {
 }
 
 // sum
-impl Node for ruff::CmpOp {
+impl Node for ast::CmpOp {
     fn ast_to_object(self, vm: &VirtualMachine, _source_file: &SourceFile) -> PyObjectRef {
         let node_type = match self {
             Self::Eq => pyast::NodeCmpOpEq::static_type(),

--- a/crates/vm/src/stdlib/ast/other.rs
+++ b/crates/vm/src/stdlib/ast/other.rs
@@ -1,7 +1,7 @@
 use super::*;
 use rustpython_compiler_core::SourceFile;
 
-impl Node for ruff::ConversionFlag {
+impl Node for ast::ConversionFlag {
     fn ast_to_object(self, vm: &VirtualMachine, _source_file: &SourceFile) -> PyObjectRef {
         vm.ctx.new_int(self as u8).into()
     }
@@ -24,7 +24,7 @@ impl Node for ruff::ConversionFlag {
 }
 
 // /// This is just a string, not strictly an AST node. But it makes AST conversions easier.
-impl Node for ruff::name::Name {
+impl Node for ast::name::Name {
     fn ast_to_object(self, vm: &VirtualMachine, _source_file: &SourceFile) -> PyObjectRef {
         vm.ctx.new_str(self.as_str()).to_pyobject(vm)
     }
@@ -41,9 +41,9 @@ impl Node for ruff::name::Name {
     }
 }
 
-impl Node for ruff::Decorator {
+impl Node for ast::Decorator {
     fn ast_to_object(self, vm: &VirtualMachine, source_file: &SourceFile) -> PyObjectRef {
-        ruff::Expr::ast_to_object(self.expression, vm, source_file)
+        ast::Expr::ast_to_object(self.expression, vm, source_file)
     }
 
     fn ast_from_object(
@@ -51,7 +51,7 @@ impl Node for ruff::Decorator {
         source_file: &SourceFile,
         object: PyObjectRef,
     ) -> PyResult<Self> {
-        let expression = ruff::Expr::ast_from_object(vm, source_file, object)?;
+        let expression = ast::Expr::ast_from_object(vm, source_file, object)?;
         let range = expression.range();
         Ok(Self {
             node_index: Default::default(),
@@ -62,7 +62,7 @@ impl Node for ruff::Decorator {
 }
 
 // product
-impl Node for ruff::Alias {
+impl Node for ast::Alias {
     fn ast_to_object(self, vm: &VirtualMachine, source_file: &SourceFile) -> PyObjectRef {
         let Self {
             node_index: _,
@@ -103,7 +103,7 @@ impl Node for ruff::Alias {
 }
 
 // product
-impl Node for ruff::WithItem {
+impl Node for ast::WithItem {
     fn ast_to_object(self, vm: &VirtualMachine, source_file: &SourceFile) -> PyObjectRef {
         let Self {
             node_index: _,

--- a/crates/vm/src/stdlib/ast/parameter.rs
+++ b/crates/vm/src/stdlib/ast/parameter.rs
@@ -2,7 +2,7 @@ use super::*;
 use rustpython_compiler_core::SourceFile;
 
 // product
-impl Node for ruff::Parameters {
+impl Node for ast::Parameters {
     fn ast_to_object(self, vm: &VirtualMachine, source_file: &SourceFile) -> PyObjectRef {
         let Self {
             node_index: _,
@@ -101,7 +101,7 @@ impl Node for ruff::Parameters {
 }
 
 // product
-impl Node for ruff::Parameter {
+impl Node for ast::Parameter {
     fn ast_to_object(self, _vm: &VirtualMachine, source_file: &SourceFile) -> PyObjectRef {
         let Self {
             node_index: _,
@@ -156,7 +156,7 @@ impl Node for ruff::Parameter {
 }
 
 // product
-impl Node for ruff::Keyword {
+impl Node for ast::Keyword {
     fn ast_to_object(self, _vm: &VirtualMachine, source_file: &SourceFile) -> PyObjectRef {
         let Self {
             node_index: _,
@@ -197,7 +197,7 @@ impl Node for ruff::Keyword {
 
 struct PositionalParameters {
     pub _range: TextRange, // TODO: Use this
-    pub args: Box<[ruff::Parameter]>,
+    pub args: Box<[ast::Parameter]>,
 }
 
 impl Node for PositionalParameters {
@@ -220,7 +220,7 @@ impl Node for PositionalParameters {
 
 struct KeywordParameters {
     pub _range: TextRange, // TODO: Use this
-    pub keywords: Box<[ruff::Parameter]>,
+    pub keywords: Box<[ast::Parameter]>,
 }
 
 impl Node for KeywordParameters {
@@ -243,7 +243,7 @@ impl Node for KeywordParameters {
 
 struct ParameterDefaults {
     pub _range: TextRange, // TODO: Use this
-    defaults: Box<[Option<Box<ruff::Expr>>]>,
+    defaults: Box<[Option<Box<ast::Expr>>]>,
 }
 
 impl Node for ParameterDefaults {
@@ -265,8 +265,8 @@ impl Node for ParameterDefaults {
 }
 
 fn extract_positional_parameter_defaults(
-    pos_only_args: Vec<ruff::ParameterWithDefault>,
-    args: Vec<ruff::ParameterWithDefault>,
+    pos_only_args: Vec<ast::ParameterWithDefault>,
+    args: Vec<ast::ParameterWithDefault>,
 ) -> (
     PositionalParameters,
     PositionalParameters,
@@ -325,15 +325,15 @@ fn merge_positional_parameter_defaults(
     args: PositionalParameters,
     defaults: ParameterDefaults,
 ) -> (
-    Vec<ruff::ParameterWithDefault>,
-    Vec<ruff::ParameterWithDefault>,
+    Vec<ast::ParameterWithDefault>,
+    Vec<ast::ParameterWithDefault>,
 ) {
     let posonlyargs = posonlyargs.args;
     let args = args.args;
     let defaults = defaults.defaults;
 
     let mut posonlyargs: Vec<_> = <Box<[_]> as IntoIterator>::into_iter(posonlyargs)
-        .map(|parameter| ruff::ParameterWithDefault {
+        .map(|parameter| ast::ParameterWithDefault {
             node_index: Default::default(),
             range: Default::default(),
             parameter,
@@ -341,7 +341,7 @@ fn merge_positional_parameter_defaults(
         })
         .collect();
     let mut args: Vec<_> = <Box<[_]> as IntoIterator>::into_iter(args)
-        .map(|parameter| ruff::ParameterWithDefault {
+        .map(|parameter| ast::ParameterWithDefault {
             node_index: Default::default(),
             range: Default::default(),
             parameter,
@@ -366,7 +366,7 @@ fn merge_positional_parameter_defaults(
 }
 
 fn extract_keyword_parameter_defaults(
-    kw_only_args: Vec<ruff::ParameterWithDefault>,
+    kw_only_args: Vec<ast::ParameterWithDefault>,
 ) -> (KeywordParameters, ParameterDefaults) {
     let mut defaults = vec![];
     defaults.extend(kw_only_args.iter().map(|item| item.default.clone()));
@@ -402,9 +402,9 @@ fn extract_keyword_parameter_defaults(
 fn merge_keyword_parameter_defaults(
     kw_only_args: KeywordParameters,
     defaults: ParameterDefaults,
-) -> Vec<ruff::ParameterWithDefault> {
+) -> Vec<ast::ParameterWithDefault> {
     core::iter::zip(kw_only_args.keywords, defaults.defaults)
-        .map(|(parameter, default)| ruff::ParameterWithDefault {
+        .map(|(parameter, default)| ast::ParameterWithDefault {
             node_index: Default::default(),
             parameter,
             default,

--- a/crates/vm/src/stdlib/ast/pattern.rs
+++ b/crates/vm/src/stdlib/ast/pattern.rs
@@ -2,7 +2,7 @@ use super::*;
 use rustpython_compiler_core::SourceFile;
 
 // product
-impl Node for ruff::MatchCase {
+impl Node for ast::MatchCase {
     fn ast_to_object(self, _vm: &VirtualMachine, source_file: &SourceFile) -> PyObjectRef {
         let Self {
             node_index: _,
@@ -50,7 +50,7 @@ impl Node for ruff::MatchCase {
 }
 
 // sum
-impl Node for ruff::Pattern {
+impl Node for ast::Pattern {
     fn ast_to_object(self, vm: &VirtualMachine, source_file: &SourceFile) -> PyObjectRef {
         match self {
             Self::MatchValue(cons) => cons.ast_to_object(vm, source_file),
@@ -70,49 +70,49 @@ impl Node for ruff::Pattern {
     ) -> PyResult<Self> {
         let _cls = _object.class();
         Ok(if _cls.is(pyast::NodePatternMatchValue::static_type()) {
-            Self::MatchValue(ruff::PatternMatchValue::ast_from_object(
+            Self::MatchValue(ast::PatternMatchValue::ast_from_object(
                 _vm,
                 source_file,
                 _object,
             )?)
         } else if _cls.is(pyast::NodePatternMatchSingleton::static_type()) {
-            Self::MatchSingleton(ruff::PatternMatchSingleton::ast_from_object(
+            Self::MatchSingleton(ast::PatternMatchSingleton::ast_from_object(
                 _vm,
                 source_file,
                 _object,
             )?)
         } else if _cls.is(pyast::NodePatternMatchSequence::static_type()) {
-            Self::MatchSequence(ruff::PatternMatchSequence::ast_from_object(
+            Self::MatchSequence(ast::PatternMatchSequence::ast_from_object(
                 _vm,
                 source_file,
                 _object,
             )?)
         } else if _cls.is(pyast::NodePatternMatchMapping::static_type()) {
-            Self::MatchMapping(ruff::PatternMatchMapping::ast_from_object(
+            Self::MatchMapping(ast::PatternMatchMapping::ast_from_object(
                 _vm,
                 source_file,
                 _object,
             )?)
         } else if _cls.is(pyast::NodePatternMatchClass::static_type()) {
-            Self::MatchClass(ruff::PatternMatchClass::ast_from_object(
+            Self::MatchClass(ast::PatternMatchClass::ast_from_object(
                 _vm,
                 source_file,
                 _object,
             )?)
         } else if _cls.is(pyast::NodePatternMatchStar::static_type()) {
-            Self::MatchStar(ruff::PatternMatchStar::ast_from_object(
+            Self::MatchStar(ast::PatternMatchStar::ast_from_object(
                 _vm,
                 source_file,
                 _object,
             )?)
         } else if _cls.is(pyast::NodePatternMatchAs::static_type()) {
-            Self::MatchAs(ruff::PatternMatchAs::ast_from_object(
+            Self::MatchAs(ast::PatternMatchAs::ast_from_object(
                 _vm,
                 source_file,
                 _object,
             )?)
         } else if _cls.is(pyast::NodePatternMatchOr::static_type()) {
-            Self::MatchOr(ruff::PatternMatchOr::ast_from_object(
+            Self::MatchOr(ast::PatternMatchOr::ast_from_object(
                 _vm,
                 source_file,
                 _object,
@@ -126,7 +126,7 @@ impl Node for ruff::Pattern {
     }
 }
 // constructor
-impl Node for ruff::PatternMatchValue {
+impl Node for ast::PatternMatchValue {
     fn ast_to_object(self, _vm: &VirtualMachine, source_file: &SourceFile) -> PyObjectRef {
         let Self {
             node_index: _,
@@ -161,7 +161,7 @@ impl Node for ruff::PatternMatchValue {
 }
 
 // constructor
-impl Node for ruff::PatternMatchSingleton {
+impl Node for ast::PatternMatchSingleton {
     fn ast_to_object(self, _vm: &VirtualMachine, source_file: &SourceFile) -> PyObjectRef {
         let Self {
             node_index: _,
@@ -198,12 +198,12 @@ impl Node for ruff::PatternMatchSingleton {
     }
 }
 
-impl Node for ruff::Singleton {
+impl Node for ast::Singleton {
     fn ast_to_object(self, vm: &VirtualMachine, _source_file: &SourceFile) -> PyObjectRef {
         match self {
-            ruff::Singleton::None => vm.ctx.none(),
-            ruff::Singleton::True => vm.ctx.new_bool(true).into(),
-            ruff::Singleton::False => vm.ctx.new_bool(false).into(),
+            ast::Singleton::None => vm.ctx.none(),
+            ast::Singleton::True => vm.ctx.new_bool(true).into(),
+            ast::Singleton::False => vm.ctx.new_bool(false).into(),
         }
     }
 
@@ -213,11 +213,11 @@ impl Node for ruff::Singleton {
         object: PyObjectRef,
     ) -> PyResult<Self> {
         if vm.is_none(&object) {
-            Ok(ruff::Singleton::None)
+            Ok(ast::Singleton::None)
         } else if object.is(&vm.ctx.true_value) {
-            Ok(ruff::Singleton::True)
+            Ok(ast::Singleton::True)
         } else if object.is(&vm.ctx.false_value) {
-            Ok(ruff::Singleton::False)
+            Ok(ast::Singleton::False)
         } else {
             Err(vm.new_value_error(format!(
                 "Expected None, True, or False, got {:?}",
@@ -228,7 +228,7 @@ impl Node for ruff::Singleton {
 }
 
 // constructor
-impl Node for ruff::PatternMatchSequence {
+impl Node for ast::PatternMatchSequence {
     fn ast_to_object(self, _vm: &VirtualMachine, source_file: &SourceFile) -> PyObjectRef {
         let Self {
             node_index: _,
@@ -266,7 +266,7 @@ impl Node for ruff::PatternMatchSequence {
 }
 
 // constructor
-impl Node for ruff::PatternMatchMapping {
+impl Node for ast::PatternMatchMapping {
     fn ast_to_object(self, _vm: &VirtualMachine, source_file: &SourceFile) -> PyObjectRef {
         let Self {
             node_index: _,
@@ -318,7 +318,7 @@ impl Node for ruff::PatternMatchMapping {
 }
 
 // constructor
-impl Node for ruff::PatternMatchClass {
+impl Node for ast::PatternMatchClass {
     fn ast_to_object(self, vm: &VirtualMachine, source_file: &SourceFile) -> PyObjectRef {
         let Self {
             node_index: _,
@@ -377,7 +377,7 @@ impl Node for ruff::PatternMatchClass {
                 get_node_field(vm, &object, "cls", "MatchClass")?,
             )?,
             range: range_from_object(vm, source_file, object, "MatchClass")?,
-            arguments: ruff::PatternArguments {
+            arguments: ast::PatternArguments {
                 node_index: Default::default(),
                 range: Default::default(),
                 patterns,
@@ -387,7 +387,7 @@ impl Node for ruff::PatternMatchClass {
     }
 }
 
-struct PatternMatchClassPatterns(Vec<ruff::Pattern>);
+struct PatternMatchClassPatterns(Vec<ast::Pattern>);
 
 impl Node for PatternMatchClassPatterns {
     fn ast_to_object(self, vm: &VirtualMachine, source_file: &SourceFile) -> PyObjectRef {
@@ -403,7 +403,7 @@ impl Node for PatternMatchClassPatterns {
     }
 }
 
-struct PatternMatchClassKeywordAttributes(Vec<ruff::Identifier>);
+struct PatternMatchClassKeywordAttributes(Vec<ast::Identifier>);
 
 impl Node for PatternMatchClassKeywordAttributes {
     fn ast_to_object(self, vm: &VirtualMachine, source_file: &SourceFile) -> PyObjectRef {
@@ -419,7 +419,7 @@ impl Node for PatternMatchClassKeywordAttributes {
     }
 }
 
-struct PatternMatchClassKeywordPatterns(Vec<ruff::Pattern>);
+struct PatternMatchClassKeywordPatterns(Vec<ast::Pattern>);
 
 impl Node for PatternMatchClassKeywordPatterns {
     fn ast_to_object(self, vm: &VirtualMachine, source_file: &SourceFile) -> PyObjectRef {
@@ -435,7 +435,7 @@ impl Node for PatternMatchClassKeywordPatterns {
     }
 }
 // constructor
-impl Node for ruff::PatternMatchStar {
+impl Node for ast::PatternMatchStar {
     fn ast_to_object(self, _vm: &VirtualMachine, source_file: &SourceFile) -> PyObjectRef {
         let Self {
             node_index: _,
@@ -468,7 +468,7 @@ impl Node for ruff::PatternMatchStar {
 }
 
 // constructor
-impl Node for ruff::PatternMatchAs {
+impl Node for ast::PatternMatchAs {
     fn ast_to_object(self, _vm: &VirtualMachine, source_file: &SourceFile) -> PyObjectRef {
         let Self {
             node_index: _,
@@ -507,7 +507,7 @@ impl Node for ruff::PatternMatchAs {
 }
 
 // constructor
-impl Node for ruff::PatternMatchOr {
+impl Node for ast::PatternMatchOr {
     fn ast_to_object(self, _vm: &VirtualMachine, source_file: &SourceFile) -> PyObjectRef {
         let Self {
             node_index: _,
@@ -541,7 +541,7 @@ impl Node for ruff::PatternMatchOr {
 }
 
 fn split_pattern_match_class(
-    arguments: ruff::PatternArguments,
+    arguments: ast::PatternArguments,
 ) -> (
     PatternMatchClassPatterns,
     PatternMatchClassKeywordAttributes,
@@ -562,12 +562,12 @@ fn merge_pattern_match_class(
     patterns: PatternMatchClassPatterns,
     kwd_attrs: PatternMatchClassKeywordAttributes,
     kwd_patterns: PatternMatchClassKeywordPatterns,
-) -> (Vec<ruff::Pattern>, Vec<ruff::PatternKeyword>) {
+) -> (Vec<ast::Pattern>, Vec<ast::PatternKeyword>) {
     let keywords = kwd_attrs
         .0
         .into_iter()
         .zip(kwd_patterns.0)
-        .map(|(attr, pattern)| ruff::PatternKeyword {
+        .map(|(attr, pattern)| ast::PatternKeyword {
             range: Default::default(),
             node_index: Default::default(),
             attr,

--- a/crates/vm/src/stdlib/ast/statement.rs
+++ b/crates/vm/src/stdlib/ast/statement.rs
@@ -3,7 +3,7 @@ use crate::stdlib::ast::argument::{merge_class_def_args, split_class_def_args};
 use rustpython_compiler_core::SourceFile;
 
 // sum
-impl Node for ruff::Stmt {
+impl Node for ast::Stmt {
     fn ast_to_object(self, vm: &VirtualMachine, source_file: &SourceFile) -> PyObjectRef {
         match self {
             Self::FunctionDef(cons) => cons.ast_to_object(vm, source_file),
@@ -44,117 +44,93 @@ impl Node for ruff::Stmt {
     ) -> PyResult<Self> {
         let _cls = _object.class();
         Ok(if _cls.is(pyast::NodeStmtFunctionDef::static_type()) {
-            Self::FunctionDef(ruff::StmtFunctionDef::ast_from_object(
+            Self::FunctionDef(ast::StmtFunctionDef::ast_from_object(
                 _vm,
                 source_file,
                 _object,
             )?)
         } else if _cls.is(pyast::NodeStmtAsyncFunctionDef::static_type()) {
-            Self::FunctionDef(ruff::StmtFunctionDef::ast_from_object(
+            Self::FunctionDef(ast::StmtFunctionDef::ast_from_object(
                 _vm,
                 source_file,
                 _object,
             )?)
         } else if _cls.is(pyast::NodeStmtClassDef::static_type()) {
-            Self::ClassDef(ruff::StmtClassDef::ast_from_object(
+            Self::ClassDef(ast::StmtClassDef::ast_from_object(
                 _vm,
                 source_file,
                 _object,
             )?)
         } else if _cls.is(pyast::NodeStmtReturn::static_type()) {
-            Self::Return(ruff::StmtReturn::ast_from_object(
-                _vm,
-                source_file,
-                _object,
-            )?)
+            Self::Return(ast::StmtReturn::ast_from_object(_vm, source_file, _object)?)
         } else if _cls.is(pyast::NodeStmtDelete::static_type()) {
-            Self::Delete(ruff::StmtDelete::ast_from_object(
-                _vm,
-                source_file,
-                _object,
-            )?)
+            Self::Delete(ast::StmtDelete::ast_from_object(_vm, source_file, _object)?)
         } else if _cls.is(pyast::NodeStmtAssign::static_type()) {
-            Self::Assign(ruff::StmtAssign::ast_from_object(
-                _vm,
-                source_file,
-                _object,
-            )?)
+            Self::Assign(ast::StmtAssign::ast_from_object(_vm, source_file, _object)?)
         } else if _cls.is(pyast::NodeStmtTypeAlias::static_type()) {
-            Self::TypeAlias(ruff::StmtTypeAlias::ast_from_object(
+            Self::TypeAlias(ast::StmtTypeAlias::ast_from_object(
                 _vm,
                 source_file,
                 _object,
             )?)
         } else if _cls.is(pyast::NodeStmtAugAssign::static_type()) {
-            Self::AugAssign(ruff::StmtAugAssign::ast_from_object(
+            Self::AugAssign(ast::StmtAugAssign::ast_from_object(
                 _vm,
                 source_file,
                 _object,
             )?)
         } else if _cls.is(pyast::NodeStmtAnnAssign::static_type()) {
-            Self::AnnAssign(ruff::StmtAnnAssign::ast_from_object(
+            Self::AnnAssign(ast::StmtAnnAssign::ast_from_object(
                 _vm,
                 source_file,
                 _object,
             )?)
         } else if _cls.is(pyast::NodeStmtFor::static_type()) {
-            Self::For(ruff::StmtFor::ast_from_object(_vm, source_file, _object)?)
+            Self::For(ast::StmtFor::ast_from_object(_vm, source_file, _object)?)
         } else if _cls.is(pyast::NodeStmtAsyncFor::static_type()) {
-            Self::For(ruff::StmtFor::ast_from_object(_vm, source_file, _object)?)
+            Self::For(ast::StmtFor::ast_from_object(_vm, source_file, _object)?)
         } else if _cls.is(pyast::NodeStmtWhile::static_type()) {
-            Self::While(ruff::StmtWhile::ast_from_object(_vm, source_file, _object)?)
+            Self::While(ast::StmtWhile::ast_from_object(_vm, source_file, _object)?)
         } else if _cls.is(pyast::NodeStmtIf::static_type()) {
-            Self::If(ruff::StmtIf::ast_from_object(_vm, source_file, _object)?)
+            Self::If(ast::StmtIf::ast_from_object(_vm, source_file, _object)?)
         } else if _cls.is(pyast::NodeStmtWith::static_type()) {
-            Self::With(ruff::StmtWith::ast_from_object(_vm, source_file, _object)?)
+            Self::With(ast::StmtWith::ast_from_object(_vm, source_file, _object)?)
         } else if _cls.is(pyast::NodeStmtAsyncWith::static_type()) {
-            Self::With(ruff::StmtWith::ast_from_object(_vm, source_file, _object)?)
+            Self::With(ast::StmtWith::ast_from_object(_vm, source_file, _object)?)
         } else if _cls.is(pyast::NodeStmtMatch::static_type()) {
-            Self::Match(ruff::StmtMatch::ast_from_object(_vm, source_file, _object)?)
+            Self::Match(ast::StmtMatch::ast_from_object(_vm, source_file, _object)?)
         } else if _cls.is(pyast::NodeStmtRaise::static_type()) {
-            Self::Raise(ruff::StmtRaise::ast_from_object(_vm, source_file, _object)?)
+            Self::Raise(ast::StmtRaise::ast_from_object(_vm, source_file, _object)?)
         } else if _cls.is(pyast::NodeStmtTry::static_type()) {
-            Self::Try(ruff::StmtTry::ast_from_object(_vm, source_file, _object)?)
+            Self::Try(ast::StmtTry::ast_from_object(_vm, source_file, _object)?)
         } else if _cls.is(pyast::NodeStmtTryStar::static_type()) {
-            Self::Try(ruff::StmtTry::ast_from_object(_vm, source_file, _object)?)
+            Self::Try(ast::StmtTry::ast_from_object(_vm, source_file, _object)?)
         } else if _cls.is(pyast::NodeStmtAssert::static_type()) {
-            Self::Assert(ruff::StmtAssert::ast_from_object(
-                _vm,
-                source_file,
-                _object,
-            )?)
+            Self::Assert(ast::StmtAssert::ast_from_object(_vm, source_file, _object)?)
         } else if _cls.is(pyast::NodeStmtImport::static_type()) {
-            Self::Import(ruff::StmtImport::ast_from_object(
-                _vm,
-                source_file,
-                _object,
-            )?)
+            Self::Import(ast::StmtImport::ast_from_object(_vm, source_file, _object)?)
         } else if _cls.is(pyast::NodeStmtImportFrom::static_type()) {
-            Self::ImportFrom(ruff::StmtImportFrom::ast_from_object(
+            Self::ImportFrom(ast::StmtImportFrom::ast_from_object(
                 _vm,
                 source_file,
                 _object,
             )?)
         } else if _cls.is(pyast::NodeStmtGlobal::static_type()) {
-            Self::Global(ruff::StmtGlobal::ast_from_object(
-                _vm,
-                source_file,
-                _object,
-            )?)
+            Self::Global(ast::StmtGlobal::ast_from_object(_vm, source_file, _object)?)
         } else if _cls.is(pyast::NodeStmtNonlocal::static_type()) {
-            Self::Nonlocal(ruff::StmtNonlocal::ast_from_object(
+            Self::Nonlocal(ast::StmtNonlocal::ast_from_object(
                 _vm,
                 source_file,
                 _object,
             )?)
         } else if _cls.is(pyast::NodeStmtExpr::static_type()) {
-            Self::Expr(ruff::StmtExpr::ast_from_object(_vm, source_file, _object)?)
+            Self::Expr(ast::StmtExpr::ast_from_object(_vm, source_file, _object)?)
         } else if _cls.is(pyast::NodeStmtPass::static_type()) {
-            Self::Pass(ruff::StmtPass::ast_from_object(_vm, source_file, _object)?)
+            Self::Pass(ast::StmtPass::ast_from_object(_vm, source_file, _object)?)
         } else if _cls.is(pyast::NodeStmtBreak::static_type()) {
-            Self::Break(ruff::StmtBreak::ast_from_object(_vm, source_file, _object)?)
+            Self::Break(ast::StmtBreak::ast_from_object(_vm, source_file, _object)?)
         } else if _cls.is(pyast::NodeStmtContinue::static_type()) {
-            Self::Continue(ruff::StmtContinue::ast_from_object(
+            Self::Continue(ast::StmtContinue::ast_from_object(
                 _vm,
                 source_file,
                 _object,
@@ -169,7 +145,7 @@ impl Node for ruff::Stmt {
 }
 
 // constructor
-impl Node for ruff::StmtFunctionDef {
+impl Node for ast::StmtFunctionDef {
     fn ast_to_object(self, vm: &VirtualMachine, source_file: &SourceFile) -> PyObjectRef {
         let Self {
             node_index: _,
@@ -266,7 +242,7 @@ impl Node for ruff::StmtFunctionDef {
 }
 
 // constructor
-impl Node for ruff::StmtClassDef {
+impl Node for ast::StmtClassDef {
     fn ast_to_object(self, _vm: &VirtualMachine, source_file: &SourceFile) -> PyObjectRef {
         let Self {
             node_index: _,
@@ -348,7 +324,7 @@ impl Node for ruff::StmtClassDef {
     }
 }
 // constructor
-impl Node for ruff::StmtReturn {
+impl Node for ast::StmtReturn {
     fn ast_to_object(self, _vm: &VirtualMachine, source_file: &SourceFile) -> PyObjectRef {
         let Self {
             node_index: _,
@@ -379,7 +355,7 @@ impl Node for ruff::StmtReturn {
     }
 }
 // constructor
-impl Node for ruff::StmtDelete {
+impl Node for ast::StmtDelete {
     fn ast_to_object(self, _vm: &VirtualMachine, source_file: &SourceFile) -> PyObjectRef {
         let Self {
             node_index: _,
@@ -413,7 +389,7 @@ impl Node for ruff::StmtDelete {
 }
 
 // constructor
-impl Node for ruff::StmtAssign {
+impl Node for ast::StmtAssign {
     fn ast_to_object(self, vm: &VirtualMachine, source_file: &SourceFile) -> PyObjectRef {
         let Self {
             node_index: _,
@@ -461,7 +437,7 @@ impl Node for ruff::StmtAssign {
 }
 
 // constructor
-impl Node for ruff::StmtTypeAlias {
+impl Node for ast::StmtTypeAlias {
     fn ast_to_object(self, _vm: &VirtualMachine, source_file: &SourceFile) -> PyObjectRef {
         let Self {
             node_index: _,
@@ -516,7 +492,7 @@ impl Node for ruff::StmtTypeAlias {
 }
 
 // constructor
-impl Node for ruff::StmtAugAssign {
+impl Node for ast::StmtAugAssign {
     fn ast_to_object(self, _vm: &VirtualMachine, source_file: &SourceFile) -> PyObjectRef {
         let Self {
             node_index: _,
@@ -566,7 +542,7 @@ impl Node for ruff::StmtAugAssign {
 }
 
 // constructor
-impl Node for ruff::StmtAnnAssign {
+impl Node for ast::StmtAnnAssign {
     fn ast_to_object(self, _vm: &VirtualMachine, source_file: &SourceFile) -> PyObjectRef {
         let Self {
             node_index: _,
@@ -626,7 +602,7 @@ impl Node for ruff::StmtAnnAssign {
 }
 
 // constructor
-impl Node for ruff::StmtFor {
+impl Node for ast::StmtFor {
     fn ast_to_object(self, _vm: &VirtualMachine, source_file: &SourceFile) -> PyObjectRef {
         let Self {
             node_index: _,
@@ -704,7 +680,7 @@ impl Node for ruff::StmtFor {
 }
 
 // constructor
-impl Node for ruff::StmtWhile {
+impl Node for ast::StmtWhile {
     fn ast_to_object(self, _vm: &VirtualMachine, source_file: &SourceFile) -> PyObjectRef {
         let Self {
             node_index: _,
@@ -754,7 +730,7 @@ impl Node for ruff::StmtWhile {
     }
 }
 // constructor
-impl Node for ruff::StmtIf {
+impl Node for ast::StmtIf {
     fn ast_to_object(self, _vm: &VirtualMachine, source_file: &SourceFile) -> PyObjectRef {
         let Self {
             node_index: _,
@@ -764,7 +740,7 @@ impl Node for ruff::StmtIf {
             elif_else_clauses,
         } = self;
         elif_else_clause::ast_to_object(
-            ruff::ElifElseClause {
+            ast::ElifElseClause {
                 node_index: Default::default(),
                 range,
                 test: Some(*test),
@@ -784,7 +760,7 @@ impl Node for ruff::StmtIf {
     }
 }
 // constructor
-impl Node for ruff::StmtWith {
+impl Node for ast::StmtWith {
     fn ast_to_object(self, _vm: &VirtualMachine, source_file: &SourceFile) -> PyObjectRef {
         let Self {
             node_index: _,
@@ -844,7 +820,7 @@ impl Node for ruff::StmtWith {
     }
 }
 // constructor
-impl Node for ruff::StmtMatch {
+impl Node for ast::StmtMatch {
     fn ast_to_object(self, _vm: &VirtualMachine, source_file: &SourceFile) -> PyObjectRef {
         let Self {
             node_index: _,
@@ -885,7 +861,7 @@ impl Node for ruff::StmtMatch {
     }
 }
 // constructor
-impl Node for ruff::StmtRaise {
+impl Node for ast::StmtRaise {
     fn ast_to_object(self, _vm: &VirtualMachine, source_file: &SourceFile) -> PyObjectRef {
         let Self {
             node_index: _,
@@ -922,7 +898,7 @@ impl Node for ruff::StmtRaise {
     }
 }
 // constructor
-impl Node for ruff::StmtTry {
+impl Node for ast::StmtTry {
     fn ast_to_object(self, _vm: &VirtualMachine, source_file: &SourceFile) -> PyObjectRef {
         let Self {
             node_index: _,
@@ -996,7 +972,7 @@ impl Node for ruff::StmtTry {
     }
 }
 // constructor
-impl Node for ruff::StmtAssert {
+impl Node for ast::StmtAssert {
     fn ast_to_object(self, _vm: &VirtualMachine, source_file: &SourceFile) -> PyObjectRef {
         let Self {
             node_index: _,
@@ -1035,7 +1011,7 @@ impl Node for ruff::StmtAssert {
     }
 }
 // constructor
-impl Node for ruff::StmtImport {
+impl Node for ast::StmtImport {
     fn ast_to_object(self, _vm: &VirtualMachine, source_file: &SourceFile) -> PyObjectRef {
         let Self {
             node_index: _,
@@ -1068,7 +1044,7 @@ impl Node for ruff::StmtImport {
     }
 }
 // constructor
-impl Node for ruff::StmtImportFrom {
+impl Node for ast::StmtImportFrom {
     fn ast_to_object(self, vm: &VirtualMachine, source_file: &SourceFile) -> PyObjectRef {
         let Self {
             node_index: _,
@@ -1117,7 +1093,7 @@ impl Node for ruff::StmtImportFrom {
     }
 }
 // constructor
-impl Node for ruff::StmtGlobal {
+impl Node for ast::StmtGlobal {
     fn ast_to_object(self, _vm: &VirtualMachine, source_file: &SourceFile) -> PyObjectRef {
         let Self {
             node_index: _,
@@ -1150,7 +1126,7 @@ impl Node for ruff::StmtGlobal {
     }
 }
 // constructor
-impl Node for ruff::StmtNonlocal {
+impl Node for ast::StmtNonlocal {
     fn ast_to_object(self, _vm: &VirtualMachine, source_file: &SourceFile) -> PyObjectRef {
         let Self {
             node_index: _,
@@ -1183,7 +1159,7 @@ impl Node for ruff::StmtNonlocal {
     }
 }
 // constructor
-impl Node for ruff::StmtExpr {
+impl Node for ast::StmtExpr {
     fn ast_to_object(self, _vm: &VirtualMachine, source_file: &SourceFile) -> PyObjectRef {
         let Self {
             node_index: _,
@@ -1216,7 +1192,7 @@ impl Node for ruff::StmtExpr {
     }
 }
 // constructor
-impl Node for ruff::StmtPass {
+impl Node for ast::StmtPass {
     fn ast_to_object(self, _vm: &VirtualMachine, source_file: &SourceFile) -> PyObjectRef {
         let Self {
             node_index: _,
@@ -1241,7 +1217,7 @@ impl Node for ruff::StmtPass {
     }
 }
 // constructor
-impl Node for ruff::StmtBreak {
+impl Node for ast::StmtBreak {
     fn ast_to_object(self, _vm: &VirtualMachine, source_file: &SourceFile) -> PyObjectRef {
         let Self {
             node_index: _,
@@ -1268,7 +1244,7 @@ impl Node for ruff::StmtBreak {
 }
 
 // constructor
-impl Node for ruff::StmtContinue {
+impl Node for ast::StmtContinue {
     fn ast_to_object(self, _vm: &VirtualMachine, source_file: &SourceFile) -> PyObjectRef {
         let Self {
             node_index: _,

--- a/crates/vm/src/stdlib/ast/type_parameters.rs
+++ b/crates/vm/src/stdlib/ast/type_parameters.rs
@@ -1,7 +1,7 @@
 use super::*;
 use rustpython_compiler_core::SourceFile;
 
-impl Node for ruff::TypeParams {
+impl Node for ast::TypeParams {
     fn ast_to_object(self, vm: &VirtualMachine, source_file: &SourceFile) -> PyObjectRef {
         self.type_params.ast_to_object(vm, source_file)
     }
@@ -11,7 +11,7 @@ impl Node for ruff::TypeParams {
         _source_file: &SourceFile,
         _object: PyObjectRef,
     ) -> PyResult<Self> {
-        let type_params: Vec<ruff::TypeParam> = Node::ast_from_object(_vm, _source_file, _object)?;
+        let type_params: Vec<ast::TypeParam> = Node::ast_from_object(_vm, _source_file, _object)?;
         let range = Option::zip(type_params.first(), type_params.last())
             .map(|(first, last)| first.range().cover(last.range()))
             .unwrap_or_default();
@@ -28,7 +28,7 @@ impl Node for ruff::TypeParams {
 }
 
 // sum
-impl Node for ruff::TypeParam {
+impl Node for ast::TypeParam {
     fn ast_to_object(self, vm: &VirtualMachine, source_file: &SourceFile) -> PyObjectRef {
         match self {
             Self::TypeVar(cons) => cons.ast_to_object(vm, source_file),
@@ -44,19 +44,19 @@ impl Node for ruff::TypeParam {
     ) -> PyResult<Self> {
         let _cls = _object.class();
         Ok(if _cls.is(pyast::NodeTypeParamTypeVar::static_type()) {
-            Self::TypeVar(ruff::TypeParamTypeVar::ast_from_object(
+            Self::TypeVar(ast::TypeParamTypeVar::ast_from_object(
                 _vm,
                 source_file,
                 _object,
             )?)
         } else if _cls.is(pyast::NodeTypeParamParamSpec::static_type()) {
-            Self::ParamSpec(ruff::TypeParamParamSpec::ast_from_object(
+            Self::ParamSpec(ast::TypeParamParamSpec::ast_from_object(
                 _vm,
                 source_file,
                 _object,
             )?)
         } else if _cls.is(pyast::NodeTypeParamTypeVarTuple::static_type()) {
-            Self::TypeVarTuple(ruff::TypeParamTypeVarTuple::ast_from_object(
+            Self::TypeVarTuple(ast::TypeParamTypeVarTuple::ast_from_object(
                 _vm,
                 source_file,
                 _object,
@@ -71,7 +71,7 @@ impl Node for ruff::TypeParam {
 }
 
 // constructor
-impl Node for ruff::TypeParamTypeVar {
+impl Node for ast::TypeParamTypeVar {
     fn ast_to_object(self, _vm: &VirtualMachine, source_file: &SourceFile) -> PyObjectRef {
         let Self {
             node_index: _,
@@ -118,7 +118,7 @@ impl Node for ruff::TypeParamTypeVar {
 }
 
 // constructor
-impl Node for ruff::TypeParamParamSpec {
+impl Node for ast::TypeParamParamSpec {
     fn ast_to_object(self, _vm: &VirtualMachine, source_file: &SourceFile) -> PyObjectRef {
         let Self {
             node_index: _,
@@ -165,7 +165,7 @@ impl Node for ruff::TypeParamParamSpec {
 }
 
 // constructor
-impl Node for ruff::TypeParamTypeVarTuple {
+impl Node for ast::TypeParamTypeVarTuple {
     fn ast_to_object(self, _vm: &VirtualMachine, source_file: &SourceFile) -> PyObjectRef {
         let Self {
             node_index: _,


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Standardized internal AST type references across the codebase to improve consistency and maintainability.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->