### PR TITLE
sqlite3: fix Connection.cursor() factory argument handling

### DIFF
--- a/Lib/test/test_sqlite3/test_factory.py
+++ b/Lib/test/test_sqlite3/test_factory.py
@@ -80,8 +80,6 @@ class CursorFactoryTests(unittest.TestCase):
     def tearDown(self):
         self.con.close()
 
-    # TODO: RUSTPYTHON
-    @unittest.expectedFailure
     def test_is_instance(self):
         cur = self.con.cursor()
         self.assertIsInstance(cur, sqlite.Cursor)


### PR DESCRIPTION
fixed #6782

## CPython Reference

- [`pysqlite_connection_cursor_impl`](https://github.com/python/cpython/blob/a6627638de9c48afdb1e8b8ced1794e6c6aff21c/Modules/_sqlite/connection.c#L477-L501)

```c
static PyObject *
pysqlite_connection_cursor_impl(pysqlite_Connection *self, PyObject *factory)
{
    if (factory == NULL) {
        factory = (PyObject *)self->state->CursorType;
    }
    cursor = PyObject_CallOneArg(factory, (PyObject *)self);
    if (!PyObject_TypeCheck(cursor, self->state->CursorType)) {
        PyErr_Format(PyExc_TypeError,
                     "factory must return a cursor, not %.100s",
                     Py_TYPE(cursor)->tp_name);
        ...
    }
    ...
}
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved SQLite cursor creation method to use a more structured argument approach
  * Enhanced validation to ensure custom factory functions return proper Cursor objects
  * Better alignment of row factory settings during cursor instantiation

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->