### PR TITLE
Run benchmarks with stdlib native modules

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -54,6 +54,7 @@ rustyline = { workspace = true }
 [dev-dependencies]
 criterion = { workspace = true }
 pyo3 = { version = "0.27", features = ["auto-initialize"] }
+rustpython-stdlib = { workspace = true }
 
 [[bench]]
 name = "execution"

--- a/benches/execution.rs
+++ b/benches/execution.rs
@@ -24,7 +24,10 @@ fn bench_rustpython_code(b: &mut Bencher, name: &str, source: &str) {
     settings.path_list.push("Lib/".to_string());
     settings.write_bytecode = false;
     settings.user_site_directory = false;
-    Interpreter::without_stdlib(settings).enter(|vm| {
+    Interpreter::with_init(settings, |vm| {
+        vm.add_native_modules(rustpython_stdlib::get_module_inits());
+    })
+    .enter(|vm| {
         // Note: bench_cpython is both compiling and executing the code.
         // As such we compile the code in the benchmark loop as well.
         b.iter(|| {


### PR DESCRIPTION
Personally, I was checking https://rustpython.github.io/benchmarks to see if benchmarks improved after the `json.loads` enhancement, but there was actually no performance improvement. Upon reviewing this again, I suspect it was running with a Pure Python implementation using an interpreter without stdlib. So if there are no particular issues, how about running the benchmark with a version that includes stdlib?

I'm not very familiar with whether the presence of a standard library has a significant impact on performance benchmarks, so I would be really happy if you could share your opinion!

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added standard library support to development dependencies to enable richer test environments.
  * Updated development benchmarks to initialize with the standard library, yielding more realistic performance measurements.
  * No changes to public/external APIs or exported signatures.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->