### PR TITLE
Seperate between scope exit & unconditional jump opcodes

### DIFF
--- a/crates/codegen/src/ir.rs
+++ b/crates/codegen/src/ir.rs
@@ -439,7 +439,7 @@ impl CodeInfo {
         for block in &mut self.blocks {
             let mut last_instr = None;
             for (i, ins) in block.instructions.iter().enumerate() {
-                if ins.instr.unconditional_branch() {
+                if ins.instr.is_scope_exit() || ins.instr.is_unconditional_jump() {
                     last_instr = Some(i);
                     break;
                 }
@@ -545,7 +545,7 @@ impl CodeInfo {
                     );
                 }
                 depth = new_depth;
-                if instr.unconditional_branch() {
+                if instr.is_scope_exit() || instr.is_unconditional_jump() {
                     continue 'process_blocks;
                 }
             }


### PR DESCRIPTION
See: https://github.com/python/cpython/blob/1fa166888bd33538aab3f501174d512d6df22408/Include/internal/pycore_opcode_utils.h#L39-L44

and https://github.com/python/cpython/blob/1fa166888bd33538aab3f501174d512d6df22408/Include/internal/pycore_opcode_utils.h#L52-L55

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated compiler control flow analysis for improved accuracy in dead-code elimination and stack-depth tracking.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->