### PR TITLE
Align psuedo ops to CPython 3.14.2

### DIFF
--- a/Lib/_opcode_metadata.py
+++ b/Lib/_opcode_metadata.py
@@ -245,10 +245,6 @@ opmap = {
     'SETUP_FINALLY': 264,
     'SETUP_WITH': 265,
     'STORE_FAST_MAYBE_NULL': 266,
-    'LOAD_ATTR_METHOD': 267,
-    'LOAD_SUPER_METHOD': 268,
-    'LOAD_ZERO_SUPER_ATTR': 269,
-    'LOAD_ZERO_SUPER_METHOD': 270,
 }
 
 # CPython 3.13 compatible: opcodes < 44 have no argument

--- a/crates/compiler-core/src/bytecode/instruction.rs
+++ b/crates/compiler-core/src/bytecode/instruction.rs
@@ -474,7 +474,13 @@ impl InstructionMetadata for Instruction {
             Self::LoadFromDictOrDeref(_) => 1,
             Self::StoreSubscr => -3,
             Self::DeleteSubscr => -2,
-            Self::LoadAttr { .. } => 0,
+            Self::LoadAttr { idx } => {
+                // Stack effect depends on method flag in encoded oparg
+                // method=false: pop obj, push attr → effect = 0
+                // method=true: pop obj, push (method, self_or_null) → effect = +1
+                let (_, is_method) = decode_load_attr_arg(idx.get(arg));
+                if is_method { 1 } else { 0 }
+            }
             Self::StoreAttr { .. } => -2,
             Self::DeleteAttr { .. } => -1,
             Self::LoadCommonConstant { .. } => 1,
@@ -923,47 +929,22 @@ impl InstructionMetadata for Instruction {
 
 /// Instructions used by the compiler. They are not executed by the VM.
 ///
-/// CPython 3.14.2 aligned (256-266), RustPython-specific variants start at 267.
+/// CPython 3.14.2 aligned (256-266).
 #[derive(Clone, Copy, Debug)]
 #[repr(u16)]
 pub enum PseudoInstruction {
     // CPython 3.14.2 pseudo instructions (256-266)
     AnnotationsPlaceholder = 256,
-    Jump {
-        target: Arg<Label>,
-    } = 257,
-    JumpIfFalse {
-        target: Arg<Label>,
-    } = 258,
-    JumpIfTrue {
-        target: Arg<Label>,
-    } = 259,
-    JumpNoInterrupt {
-        target: Arg<Label>,
-    } = 260,
+    Jump { target: Arg<Label> } = 257,
+    JumpIfFalse { target: Arg<Label> } = 258,
+    JumpIfTrue { target: Arg<Label> } = 259,
+    JumpNoInterrupt { target: Arg<Label> } = 260,
     LoadClosure(Arg<NameIdx>) = 261,
     PopBlock = 262,
     SetupCleanup = 263,
     SetupFinally = 264,
     SetupWith = 265,
     StoreFastMaybeNull(Arg<NameIdx>) = 266,
-
-    // RustPython-specific pseudo instructions (267+)
-    LoadAttrMethod {
-        idx: Arg<NameIdx>,
-    } = 267,
-    // "Zero" variants are for 0-arg super() calls (has_class=false).
-    // Non-"Zero" variants are for 2-arg super(cls, self) calls (has_class=true).
-    /// 2-arg super(cls, self).method() - has_class=true, load_method=true
-    LoadSuperMethod {
-        idx: Arg<NameIdx>,
-    } = 268,
-    LoadZeroSuperAttr {
-        idx: Arg<NameIdx>,
-    } = 269,
-    LoadZeroSuperMethod {
-        idx: Arg<NameIdx>,
-    } = 270,
 }
 
 const _: () = assert!(mem::size_of::<PseudoInstruction>() == 2);
@@ -982,7 +963,7 @@ impl TryFrom<u16> for PseudoInstruction {
     #[inline]
     fn try_from(value: u16) -> Result<Self, MarshalError> {
         let start = u16::from(Self::AnnotationsPlaceholder);
-        let end = u16::from(Self::LoadZeroSuperMethod { idx: Arg::marker() });
+        let end = u16::from(Self::StoreFastMaybeNull(Arg::marker()));
 
         if (start..=end).contains(&value) {
             Ok(unsafe { mem::transmute::<u16, Self>(value) })
@@ -1024,10 +1005,6 @@ impl InstructionMetadata for PseudoInstruction {
             Self::SetupFinally => 0,
             Self::SetupWith => 0,
             Self::StoreFastMaybeNull(_) => -1,
-            Self::LoadAttrMethod { .. } => 1, // pop obj, push method + self_or_null
-            Self::LoadSuperMethod { .. } => -3 + 2, // pop 3, push [method, self_or_null]
-            Self::LoadZeroSuperAttr { .. } => -3 + 1, // pop 3, push [attr]
-            Self::LoadZeroSuperMethod { .. } => -3 + 2, // pop 3, push [method, self_or_null]
         }
     }
 

--- a/crates/stdlib/src/_opcode.rs
+++ b/crates/stdlib/src/_opcode.rs
@@ -92,7 +92,7 @@ mod _opcode {
                         | Instruction::StoreAttr { .. }
                         | Instruction::StoreGlobal(_)
                         | Instruction::StoreName(_)
-                ) | AnyInstruction::Pseudo(PseudoInstruction::LoadAttrMethod { .. }))
+                ))
             )
         }
 
@@ -148,8 +148,11 @@ mod _opcode {
         }
     }
 
+    // prepare specialization
     #[pyattr]
     const ENABLE_SPECIALIZATION: i8 = 1;
+    #[allow(dead_code)]
+    const ENABLE_SPECIALIZATION_FT: i8 = 1;
 
     #[derive(FromArgs)]
     struct StackEffectArgs {
@@ -303,6 +306,7 @@ mod _opcode {
             ("NB_INPLACE_SUBTRACT", "-="),
             ("NB_INPLACE_TRUE_DIVIDE", "/="),
             ("NB_INPLACE_XOR", "^="),
+            ("NB_SUBSCR", "[]"),
         ]
         .into_iter()
         .map(|(a, b)| {
@@ -314,8 +318,19 @@ mod _opcode {
     }
 
     #[pyfunction]
-    fn get_executor(_code: PyObjectRef, vm: &VirtualMachine) -> PyResult<PyObjectRef> {
-        // TODO
+    fn get_special_method_names(vm: &VirtualMachine) -> Vec<PyObjectRef> {
+        ["__enter__", "__exit__", "__aenter__", "__aexit__"]
+            .into_iter()
+            .map(|x| vm.ctx.new_str(x).into())
+            .collect()
+    }
+
+    #[pyfunction]
+    fn get_executor(
+        _code: PyObjectRef,
+        _offset: i32,
+        vm: &VirtualMachine,
+    ) -> PyResult<PyObjectRef> {
         Ok(vm.ctx.none())
     }
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added support for special method optimization and executor specialization.

* **Refactor**
  * Simplified internal attribute access compilation and bytecode emission.
  * Updated opcode support for Python 3.14.2 alignment.
  * Removed redundant instruction variants for streamlined bytecode generation.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->