### PR TITLE
Make validate_downcastable_from unsafe

### DIFF
--- a/crates/derive-impl/src/pyclass.rs
+++ b/crates/derive-impl/src/pyclass.rs
@@ -667,7 +667,7 @@ pub(crate) fn impl_pyclass(attr: PunctuatedNestedMeta, item: Item) -> Result<Tok
                 const PAYLOAD_TYPE_ID: ::core::any::TypeId = <#base_type as ::rustpython_vm::PyPayload>::PAYLOAD_TYPE_ID;
 
                 #[inline]
-                fn validate_downcastable_from(obj: &::rustpython_vm::PyObject) -> bool {
+                unsafe fn validate_downcastable_from(obj: &::rustpython_vm::PyObject) -> bool {
                     <Self as ::rustpython_vm::class::PyClassDef>::BASICSIZE <= obj.class().slots.basicsize && obj.class().fast_issubclass(<Self as ::rustpython_vm::class::StaticType>::static_type())
                 }
 

--- a/crates/derive-impl/src/pystructseq.rs
+++ b/crates/derive-impl/src/pystructseq.rs
@@ -595,7 +595,7 @@ pub(crate) fn impl_pystruct_sequence(
             const PAYLOAD_TYPE_ID: ::core::any::TypeId = <::rustpython_vm::builtins::PyTuple as ::rustpython_vm::PyPayload>::PAYLOAD_TYPE_ID;
 
             #[inline]
-            fn validate_downcastable_from(obj: &::rustpython_vm::PyObject) -> bool {
+            unsafe fn validate_downcastable_from(obj: &::rustpython_vm::PyObject) -> bool {
                 obj.class().fast_issubclass(<Self as ::rustpython_vm::class::StaticType>::static_type())
             }
 

--- a/crates/vm/src/builtins/str.rs
+++ b/crates/vm/src/builtins/str.rs
@@ -1944,7 +1944,7 @@ impl PyPayload for PyUtf8Str {
 
     const PAYLOAD_TYPE_ID: core::any::TypeId = core::any::TypeId::of::<PyStr>();
 
-    fn validate_downcastable_from(obj: &PyObject) -> bool {
+    unsafe fn validate_downcastable_from(obj: &PyObject) -> bool {
         // SAFETY: we know the object is a PyStr in this context
         let wtf8 = unsafe { obj.downcast_unchecked_ref::<PyStr>() };
         wtf8.is_utf8()

--- a/crates/vm/src/object/core.rs
+++ b/crates/vm/src/object/core.rs
@@ -753,7 +753,7 @@ impl PyObject {
     /// Check if this object can be downcast to T.
     #[inline(always)]
     pub fn downcastable<T: PyPayload>(&self) -> bool {
-        T::downcastable_from(self)
+        self.typeid() == T::PAYLOAD_TYPE_ID && unsafe { T::validate_downcastable_from(self) }
     }
 
     /// Attempt to downcast this reference to a subclass.

--- a/crates/vm/src/object/payload.rs
+++ b/crates/vm/src/object/payload.rs
@@ -28,19 +28,15 @@ pub(crate) fn cold_downcast_type_error(
 pub trait PyPayload: MaybeTraverse + PyThreadingConstraint + Sized + 'static {
     const PAYLOAD_TYPE_ID: core::any::TypeId = core::any::TypeId::of::<Self>();
 
-    /// # Safety: this function should only be called if `payload_type_id` matches the type of `obj`.
+    /// # Safety
+    /// This function should only be called if `payload_type_id` matches the type of `obj`.
     #[inline]
-    fn downcastable_from(obj: &PyObject) -> bool {
-        obj.typeid() == Self::PAYLOAD_TYPE_ID && Self::validate_downcastable_from(obj)
-    }
-
-    #[inline]
-    fn validate_downcastable_from(_obj: &PyObject) -> bool {
+    unsafe fn validate_downcastable_from(_obj: &PyObject) -> bool {
         true
     }
 
     fn try_downcast_from(obj: &PyObject, vm: &VirtualMachine) -> PyResult<()> {
-        if Self::downcastable_from(obj) {
+        if obj.downcastable::<Self>() {
             return Ok(());
         }
 


### PR DESCRIPTION
Meant to put this as part of #6231


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Improved type validation safety mechanisms within the object system to enforce explicit unsafe boundaries around type downcast operations, ensuring more secure type checking during runtime.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->