### PR TITLE
Make paths in macro arguments relative to the source file, not MANIFEST_DIR

### DIFF
--- a/crates/pylib/src/lib.rs
+++ b/crates/pylib/src/lib.rs
@@ -11,4 +11,4 @@ pub const LIB_PATH: &str = match option_env!("win_lib_path") {
 
 #[cfg(feature = "freeze-stdlib")]
 pub const FROZEN_STDLIB: &rustpython_compiler_core::frozen::FrozenLib =
-    rustpython_derive::py_freeze!(dir = "./Lib", crate_name = "rustpython_compiler_core");
+    rustpython_derive::py_freeze!(dir = "../Lib", crate_name = "rustpython_compiler_core");

--- a/crates/vm/src/vm/interpreter.rs
+++ b/crates/vm/src/vm/interpreter.rs
@@ -452,7 +452,7 @@ fn core_frozen_inits() -> impl Iterator<Item = (&'static str, FrozenModule)> {
     // Includes _importlib_bootstrap and _importlib_bootstrap_external
     ext_modules!(
         iter,
-        dir = "./Lib/python_builtins",
+        dir = "../../Lib/python_builtins",
         crate_name = "rustpython_compiler_core"
     );
 
@@ -463,7 +463,7 @@ fn core_frozen_inits() -> impl Iterator<Item = (&'static str, FrozenModule)> {
     // #[cfg(not(feature = "freeze-stdlib"))]
     ext_modules!(
         iter,
-        dir = "./Lib/core_modules",
+        dir = "../../Lib/core_modules",
         crate_name = "rustpython_compiler_core"
     );
 

--- a/crates/vm/src/vm/mod.rs
+++ b/crates/vm/src/vm/mod.rs
@@ -1319,7 +1319,7 @@ fn test_nested_frozen() {
 
     vm::Interpreter::builder(Default::default())
         .add_frozen_modules(rustpython_vm::py_freeze!(
-            dir = "../../extra_tests/snippets"
+            dir = "../../../../extra_tests/snippets"
         ))
         .build()
         .enter(|vm| {

--- a/crates/wasm/src/vm_class.rs
+++ b/crates/wasm/src/vm_class.rs
@@ -59,7 +59,7 @@ impl StoredVirtualMachine {
             let browser_def = browser_module::module_def(&builder.ctx);
             builder = builder
                 .add_native_modules(&[window_def, browser_def])
-                .add_frozen_modules(rustpython_vm::py_freeze!(dir = "Lib"));
+                .add_frozen_modules(rustpython_vm::py_freeze!(dir = "../Lib"));
         }
 
         let interp = builder

--- a/examples/freeze/main.rs
+++ b/examples/freeze/main.rs
@@ -7,9 +7,8 @@ fn main() -> vm::PyResult<()> {
 fn run(vm: &vm::VirtualMachine) -> vm::PyResult<()> {
     let scope = vm.new_scope_with_builtins();
 
-    // the file parameter is relative to the directory where the crate's Cargo.toml is located, see $CARGO_MANIFEST_DIR:
-    // https://doc.rust-lang.org/cargo/reference/environment-variables.html#environment-variables-cargo-sets-for-crates
-    let module = vm::py_compile!(file = "examples/freeze/freeze.py");
+    // the file parameter is relative to the current file.
+    let module = vm::py_compile!(file = "freeze.py");
 
     let res = vm.run_code_obj(vm.ctx.new_code(module), scope);
 


### PR DESCRIPTION
Found this in my git stash. This is possible since rust 1.88, when `Span::local_file()` was added.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Path resolution for compilation and frozen module loading now correctly uses source-file–relative paths, fixing incorrect manifest-root assumptions.
  * Adjusted relative path references used when initializing frozen libraries so modules are located reliably.

* **Tests**
  * Updated test configurations to reference the new layout for frozen module loading.

* **Examples**
  * Example invocations updated to use source-relative file paths.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->