### PR TITLE
Docs: add reference to `rustpython_derive` close to example

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -41,6 +41,8 @@
 //!
 //! The binary will have all the standard arguments of a python interpreter (including a REPL!) but
 //! it will have your modules loaded into the vm.
+//!
+//! See [`rustpython_derive`](../rustpython_derive/index.html) crate for documentation on macros used in the example above.
 
 #![cfg_attr(all(target_os = "wasi", target_env = "p2"), feature(wasip2))]
 #![allow(clippy::needless_doctest_main)]


### PR DESCRIPTION
Include a link for native module macros documentation, after an example where they are used. 

It's not obvious how find this documentation, when reading the example code for the native module.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated crate documentation to include reference to available macros and their usage.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->