### PR TITLE
Fix _overlapped segfault and missing _winapi constants

### DIFF
--- a/crates/vm/src/stdlib/winapi.rs
+++ b/crates/vm/src/stdlib/winapi.rs
@@ -94,6 +94,7 @@ mod _winapi {
                 SEC_LARGE_PAGES, SEC_NOCACHE, SEC_RESERVE, SEC_WRITECOMBINE,
             },
             Pipes::{
+                NMPWAIT_NOWAIT, NMPWAIT_USE_DEFAULT_WAIT, NMPWAIT_WAIT_FOREVER,
                 PIPE_READMODE_MESSAGE, PIPE_TYPE_MESSAGE, PIPE_UNLIMITED_INSTANCES, PIPE_WAIT,
             },
             SystemServices::LOCALE_NAME_MAX_LENGTH,


### PR DESCRIPTION
- Fix from_windows_err using new_exception_empty on OSError subclasses (ConnectionRefusedError, ConnectionAbortedError), which caused segfault in release builds due to debug_assert on type size mismatch
- Move ConnectPipe from instance method to module-level function
- Add Destructor for Overlapped to cancel pending I/O on object cleanup
- Add NMPWAIT_NOWAIT, NMPWAIT_USE_DEFAULT_WAIT, NMPWAIT_WAIT_FOREVER constants to _winapi

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for connecting to named pipes on Windows.
  * Introduced new pipe wait mode constants for Windows pipe operations.
  * Enhanced cleanup and resource management for Windows I/O operations when objects are garbage-collected.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->