### PR TITLE
Make `OpArgType::from_op_arg` to return a `Result<Self, MarshalError>`

### DIFF
--- a/crates/compiler-core/src/bytecode/instruction.rs
+++ b/crates/compiler-core/src/bytecode/instruction.rs
@@ -1240,7 +1240,7 @@ impl<T: OpArgType> Arg<T> {
     }
 
     #[inline(always)]
-    pub fn try_get(self, arg: OpArg) -> Option<T> {
+    pub fn try_get(self, arg: OpArg) -> Result<T, MarshalError> {
         T::from_op_arg(arg.0)
     }
 


### PR DESCRIPTION
This will allow us to use `num_enum` crate with a custom error, I'll do it in a followup PR

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved internal error handling in the compiler's bytecode instruction processing to provide more detailed error information when invalid bytecode is encountered.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->