### PR TITLE
Fix member_descriptor to match CPython behavior

### DIFF
--- a/Lib/test/test_inspect/test_inspect.py
+++ b/Lib/test/test_inspect/test_inspect.py
@@ -672,7 +672,6 @@ class TestRetrievingSourceCode(GetSourceBase):
                                      ('lobbest', mod.lobbest),
                                      ('spam', mod.spam)])
 
-    @unittest.expectedFailure  # TODO: RUSTPYTHON
     @unittest.skipIf(sys.flags.optimize >= 2,
                      "Docstrings are omitted with -O2 and above")
     def test_getdoc(self):


### PR DESCRIPTION
descriptor.rs:
- Add __objclass__, __name__ (pymember) and __reduce__ (pymethod)
- Add type check (descr_check) in descr_get; simplify None branch
- Remove incorrect BASETYPE flag
- Add MemberKind::Object (_Py_T_OBJECT = 6)
- Prevent Bool slot deletion (TypeError)
- Raise AttributeError on ObjectEx deletion when already None

pyclass.rs (derive-impl):
- Remove duplicate MemberKind enum; use MemberKindStr (Option<String>)
- Simplify MemberNursery map key from (String, MemberKind) to String
- Support #[pymember(type="object")] for _Py_T_OBJECT semantics

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for Object member kind in the descriptor system
  * New descriptor introspection methods: __objclass__ and __name__
  * Enabled pickling support for descriptors via __reduce__ method

* **Improvements**
  * Enhanced validation and error handling for descriptor member access
  * Improved type checking when accessing descriptor members on instances

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->