### PR TITLE
Update os constant to libc `0.2.180` & target cpython 3.14

### DIFF
--- a/crates/vm/src/stdlib/posix.rs
+++ b/crates/vm/src/stdlib/posix.rs
@@ -41,6 +41,10 @@ pub mod module {
     };
     use strum_macros::{EnumIter, EnumString};
 
+    #[cfg(target_os = "android")]
+    #[pyattr]
+    use libc::{SCHED_DEADLINE, SCHED_NORMAL};
+
     #[cfg(target_os = "freebsd")]
     #[pyattr]
     use libc::{MFD_HUGE_MASK, SF_MNOWAIT, SF_NOCACHE, SF_NODISKIO, SF_SYNC};

--- a/scripts/libc_posix.py
+++ b/scripts/libc_posix.py
@@ -13,7 +13,7 @@ OS_CONSTS_PAT = re.compile(
 )  # TODO: Exclude matches if they have `(` after (those are functions)
 
 
-LIBC_VERSION = "0.2.177"
+LIBC_VERSION = "0.2.180"
 
 EXCLUDE = frozenset(
     {
@@ -96,7 +96,7 @@ def format_groups(groups: dict) -> "Iterator[tuple[str, str]]":
 
 def main():
     wanted_consts = get_consts(
-        "https://docs.python.org/3.13/library/os.html",  # Should we read from https://github.com/python/cpython/blob/bcee1c322115c581da27600f2ae55e5439c027eb/Modules/posixmodule.c#L17023 instead?
+        "https://docs.python.org/3.14/library/os.html",  # Should we read from https://github.com/python/cpython/blob/bcee1c322115c581da27600f2ae55e5439c027eb/Modules/posixmodule.c#L17023 instead?
         pattern=OS_CONSTS_PAT,
     )
     available = {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Android platform now supports SCHED_DEADLINE and SCHED_NORMAL scheduling constants for process scheduling operations.

* **Updates**
  * Updated libc library to version 0.2.180.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->