### PR TITLE
Fix __set_name__ error handling to match Python 3.12+

### DIFF
--- a/Lib/test/test_enum.py
+++ b/Lib/test/test_enum.py
@@ -445,7 +445,6 @@ class _EnumTests:
         with self.assertRaises(AttributeError):
             del Season.SPRING.name
 
-    @unittest.expectedFailure  # TODO: RUSTPYTHON; RuntimeError: Error calling __set_name__ on '_proto_member' instance failed in 'BadSuper'
     def test_bad_new_super(self):
         with self.assertRaisesRegex(
                 TypeError,
@@ -1903,7 +1902,6 @@ class TestSpecial(unittest.TestCase):
             class Wrong(Enum, str):
                 NotHere = 'error before this point'
 
-    @unittest.expectedFailure  # TODO: RUSTPYTHON; RuntimeError: Error calling __set_name__ on '_proto_member' instance INVALID in 'RgbColor'
     def test_raise_custom_error_on_creation(self):
         class InvalidRgbColorError(ValueError):
             def __init__(self, r, g, b):
@@ -2591,7 +2589,6 @@ class TestSpecial(unittest.TestCase):
         self.assertEqual(Test.flash.flash, 'flashy dynamic')
         self.assertEqual(Test.flash.value, 1)
 
-    @unittest.expectedFailure  # TODO: RUSTPYTHON; RuntimeError: Error calling __set_name__ on '_proto_member' instance grene in 'Color'
     def test_no_duplicates(self):
         class UniqueEnum(Enum):
             def __init__(self, *args):
@@ -2977,7 +2974,6 @@ class TestSpecial(unittest.TestCase):
         local_ls = {}
         exec(code, global_ns, local_ls)
 
-    @unittest.expectedFailure  # TODO: RUSTPYTHON; RuntimeError: Error calling __set_name__ on '_proto_member' instance one in 'FirstFailedStrEnum'
     def test_strenum(self):
         class GoodStrEnum(StrEnum):
             one = '1'
@@ -3102,7 +3098,6 @@ class TestSpecial(unittest.TestCase):
                 one = '1'
                 two = b'2', 'ascii', 9
 
-    @unittest.expectedFailure  # TODO: RUSTPYTHON; RuntimeError: Error calling __set_name__ on '_proto_member' instance key_type in 'Combined'
     def test_missing_value_error(self):
         with self.assertRaisesRegex(TypeError, "_value_ not set in __new__"):
             class Combined(str, Enum):
@@ -3389,7 +3384,6 @@ class TestSpecial(unittest.TestCase):
         self.assertEqual(FlagFromChar.a, 158456325028528675187087900672)
         self.assertEqual(FlagFromChar.a|1, 158456325028528675187087900673)
 
-    @unittest.expectedFailure  # TODO: RUSTPYTHON; RuntimeError: Error calling __set_name__ on '_proto_member' instance A in 'MyEnum'
     def test_init_exception(self):
         class Base:
             def __new__(cls, *args):

--- a/Lib/test/test_functools.py
+++ b/Lib/test/test_functools.py
@@ -1192,37 +1192,45 @@ class TestCmpToKeyC(TestCmpToKey, unittest.TestCase):
             self, type(c_functools.cmp_to_key(None))
         )
 
-    @unittest.expectedFailure  # TODO: RUSTPYTHON
-    def test_bad_cmp(self):
-        return super().test_bad_cmp()
-
-    @unittest.expectedFailure  # TODO: RUSTPYTHON
-    def test_cmp_to_key(self):
-        return super().test_cmp_to_key()
-
-    @unittest.expectedFailure  # TODO: RUSTPYTHON
-    def test_cmp_to_key_arguments(self):
-        return super().test_cmp_to_key_arguments()
-
-    @unittest.expectedFailure  # TODO: RUSTPYTHON
+    @unittest.expectedFailure  # TODO: RUSTPYTHON; + (mycmp)
     def test_cmp_to_signature(self):
         return super().test_cmp_to_signature()
 
-    @unittest.expectedFailure  # TODO: RUSTPYTHON
-    def test_hash(self):
-        return super().test_hash()
+    @unittest.expectedFailure  # TODO: RUSTPYTHON; TypeError: cmp_to_key() got multiple values for argument 'mycmp'
+    def test_cmp_to_key_arguments(self):
+        return super().test_cmp_to_key_arguments()
 
-    @unittest.expectedFailure  # TODO: RUSTPYTHON
+    @unittest.expectedFailure  # TODO: RUSTPYTHON; TypeError: cmp_to_key() got multiple values for argument 'mycmp'
     def test_obj_field(self):
         return super().test_obj_field()
 
-    @unittest.expectedFailure  # TODO: RUSTPYTHON
+    @unittest.expectedFailure  # TODO: RUSTPYTHON; TypeError: cmp_to_key() takes 1 positional argument but 2 were given
+    def test_bad_cmp(self):
+        return super().test_bad_cmp()
+
+    @unittest.expectedFailure  # TODO: RUSTPYTHON; TypeError: cmp_to_key() takes 1 positional argument but 2 were given
+    def test_cmp_to_key(self):
+        return super().test_cmp_to_key()
+
+    @unittest.expectedFailure  # TODO: RUSTPYTHON; TypeError: cmp_to_key() takes 1 positional argument but 2 were given
+    def test_hash(self):
+        return super().test_hash()
+
+    @unittest.expectedFailure  # TODO: RUSTPYTHON; TypeError: cmp_to_key() takes 1 positional argument but 2 were given
     def test_sort_int(self):
         return super().test_sort_int()
 
-    @unittest.expectedFailure  # TODO: RUSTPYTHON
+    @unittest.expectedFailure  # TODO: RUSTPYTHON; TypeError: cmp_to_key() takes 1 positional argument but 2 were given
     def test_sort_int_str(self):
         return super().test_sort_int_str()
+
+
+
+
+
+
+
+
 
 
 class TestCmpToKeyPy(TestCmpToKey, unittest.TestCase):
@@ -3592,7 +3600,6 @@ class TestCachedProperty(unittest.TestCase):
         ):
             MyClass.prop
 
-    @unittest.expectedFailure  # TODO: RUSTPYTHON
     def test_reuse_different_names(self):
         """Disallow this case because decorated function a would not be cached."""
         with self.assertRaises(TypeError) as ctx:

--- a/Lib/test/test_subclassinit.py
+++ b/Lib/test/test_subclassinit.py
@@ -129,7 +129,6 @@ class Test(unittest.TestCase):
             d = Descriptor()
         self.assertEqual(A, 0)
 
-    @unittest.expectedFailure # TODO: RUSTPYTHON; ZeroDivisionError: division by zero
     def test_set_name_error(self):
         class Descriptor:
             def __set_name__(self, owner, name):
@@ -144,7 +143,6 @@ class Test(unittest.TestCase):
         self.assertRegex(str(notes), r'\battr\b')
         self.assertRegex(str(notes), r'\bDescriptor\b')
 
-    @unittest.expectedFailure # TODO: RUSTPYTHON; RuntimeError: Error calling __set_name__ on 'Descriptor' instance attr in 'NotGoingToWork'
     def test_set_name_wrong(self):
         class Descriptor:
             def __set_name__(self):


### PR DESCRIPTION
Changed type.rs to add notes to original exceptions instead of wrapping them in RuntimeError, following PEP 678 (gh-77757).

This allows enum.py's exception handling to work correctly when super().__new__() is misused in Enum subclasses, enabling the proper TypeError to propagate instead of being hidden behind a RuntimeError wrapper.

Fixes test_bad_new_super test case.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

**Bug Fixes**
* Improved error reporting in type initialization by adding contextual annotations to error messages, providing better debugging information when errors occur.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->