### PR TITLE
Update faulthandler to 3.14.2

### DIFF
--- a/Lib/test/test_faulthandler.py
+++ b/Lib/test/test_faulthandler.py
@@ -533,7 +533,6 @@ class FaultHandlerTests(unittest.TestCase):
     def test_dump_traceback(self):
         self.check_dump_traceback()
 
-    @unittest.expectedFailure  # TODO: RUSTPYTHON; - binary file write needs different handling
     def test_dump_traceback_file(self):
         with temporary_filename() as filename:
             self.check_dump_traceback(filename=filename)
@@ -629,11 +628,9 @@ class FaultHandlerTests(unittest.TestCase):
         self.assertRegex(output, regex)
         self.assertEqual(exitcode, 0)
 
-    @unittest.expectedFailure  # TODO: RUSTPYTHON; AssertionError: Regex didn't match: '^Thread 0x[0-9a-f]+( \\[.*\\])? \\(most recent call first\\):\n(?:  File ".*threading.py", line [0-9]+ in [_a-z]+\n){1,3}  File "<string>", line (?:22|23) in run\n  File ".*threading.py", line [0-9]+ in _bootstrap_inner\n  File ".*threading.py", line [0-9]+ in _bootstrap\n\nCurrent thread 0x[0-9a-f]+( \\[.*\\])? \\(most recent call first\\):\n  File "<string>", line 10 in dump\n  File "<string>", line 28 in <module>$' not found in 'Stack (most recent call first):\n  File "<string>", line 10 in dump\n  File "<string>", line 28 in <module>'
     def test_dump_traceback_threads(self):
         self.check_dump_traceback_threads(None)
 
-    @unittest.expectedFailure  # TODO: RUSTPYTHON; - TypeError: a bytes-like object is required, not 'str'
     def test_dump_traceback_threads_file(self):
         with temporary_filename() as filename:
             self.check_dump_traceback_threads(filename)
@@ -701,19 +698,15 @@ class FaultHandlerTests(unittest.TestCase):
             self.assertEqual(trace, '')
         self.assertEqual(exitcode, 0)
 
-    @unittest.expectedFailure  # TODO: RUSTPYTHON; AssertionError: Regex didn't match: '^Timeout \\(0:00:00.500000\\)!\\nThread 0x[0-9a-f]+( \\[.*\\])? \\(most recent call first\\):\\n  File "<string>", line 17 in func\n  File "<string>", line 26 in <module>$' not found in 'Traceback (most recent call last):\n  File "<string>", line 26, in <module>\n  File "<string>", line 14, in func\nAttributeError: \'NoneType\' object has no attribute \'fileno\''
     def test_dump_traceback_later(self):
         self.check_dump_traceback_later()
 
-    @unittest.expectedFailure  # TODO: RUSTPYTHON; AssertionError: Regex didn't match: '^Timeout \\(0:00:00.500000\\)!\\nThread 0x[0-9a-f]+( \\[.*\\])? \\(most recent call first\\):\\n  File "<string>", line 17 in func\n  File "<string>", line 26 in <module>\nTimeout \\(0:00:00.500000\\)!\\nThread 0x[0-9a-f]+( \\[.*\\])? \\(most recent call first\\):\\n  File "<string>", line 17 in func\n  File "<string>", line 26 in <module>' not found in 'Traceback (most recent call last):\n  File "<string>", line 26, in <module>\n  File "<string>", line 14, in func\nAttributeError: \'NoneType\' object has no attribute \'fileno\''
     def test_dump_traceback_later_repeat(self):
         self.check_dump_traceback_later(repeat=True)
 
-    @unittest.expectedFailure  # TODO: RUSTPYTHON; - AttributeError: 'NoneType' object has no attribute 'fileno'
     def test_dump_traceback_later_cancel(self):
         self.check_dump_traceback_later(cancel=True)
 
-    @unittest.expectedFailure  # TODO: RUSTPYTHON; AssertionError: Regex didn't match: '^Timeout \\(0:00:00.500000\\)!\\nThread 0x[0-9a-f]+( \\[.*\\])? \\(most recent call first\\):\\n  File "<string>", line 17 in func\n  File "<string>", line 26 in <module>$' not found in 'Timeout (00:00:00.500000)!\n<timeout: cannot dump traceback from watchdog thread>'
     def test_dump_traceback_later_file(self):
         with temporary_filename() as filename:
             self.check_dump_traceback_later(filename=filename)
@@ -724,7 +717,6 @@ class FaultHandlerTests(unittest.TestCase):
         with tempfile.TemporaryFile('wb+') as fp:
             self.check_dump_traceback_later(fd=fp.fileno())
 
-    @unittest.expectedFailure  # TODO: RUSTPYTHON; AssertionError: Regex didn't match: '^Timeout \\(0:00:00.500000\\)!\\nThread 0x[0-9a-f]+( \\[.*\\])? \\(most recent call first\\):\\n  File "<string>", line 17 in func\n  File "<string>", line 26 in <module>\nTimeout \\(0:00:00.500000\\)!\\nThread 0x[0-9a-f]+( \\[.*\\])? \\(most recent call first\\):\\n  File "<string>", line 17 in func\n  File "<string>", line 26 in <module>' not found in 'Traceback (most recent call last):\n  File "<string>", line 26, in <module>\n  File "<string>", line 14, in func\nAttributeError: \'NoneType\' object has no attribute \'fileno\''
     @support.requires_resource('walltime')
     def test_dump_traceback_later_twice(self):
         self.check_dump_traceback_later(loops=2)

--- a/Lib/test/test_inspect/test_inspect.py
+++ b/Lib/test/test_inspect/test_inspect.py
@@ -540,7 +540,6 @@ class TestInterpreterStack(IsTestBase):
         self.istest(inspect.istraceback, 'git.ex.__traceback__')
         self.istest(inspect.isframe, 'mod.fr')
 
-    @unittest.expectedFailure  # TODO: RUSTPYTHON
     def test_stack(self):
         self.assertTrue(len(mod.st) >= 5)
         frame1, frame2, frame3, frame4, *_ = mod.st

--- a/Lib/test/test_listcomps.py
+++ b/Lib/test/test_listcomps.py
@@ -716,8 +716,6 @@ class ListComprehensionTest(unittest.TestCase):
         self._check_in_scopes(code, {"x": 2, "y": [3]}, ns={"x": 3}, scopes=["class"])
         self._check_in_scopes(code, {"x": 2, "y": [2]}, ns={"x": 3}, scopes=["function", "module"])
 
-    # TODO: RUSTPYTHON
-    @unittest.expectedFailure
     def test_exception_locations(self):
         # The location of an exception raised from __init__ or
         # __next__ should should be the iterator expression

--- a/Lib/test/test_setcomps.py
+++ b/Lib/test/test_setcomps.py
@@ -152,7 +152,6 @@ We also repeat each of the above scoping tests inside a function
 """
 
 class SetComprehensionTest(unittest.TestCase):
-    @unittest.expectedFailure # TODO: RUSTPYTHON; AttributeError: 'FrameSummary' object has no attribute 'end_lineno'
     def test_exception_locations(self):
         # The location of an exception raised from __init__ or
         # __next__ should should be the iterator expression

--- a/Lib/test/test_traceback.py
+++ b/Lib/test/test_traceback.py
@@ -3423,8 +3423,6 @@ class TestStack(unittest.TestCase):
         s = traceback.StackSummary.extract(iter([(f, 6)]))
         self.assertEqual(s[0].locals, None)
 
-    # TODO: RUSTPYTHON
-    @unittest.expectedFailure
     def test_format_locals(self):
         def some_inner(k, v):
             a = 1
@@ -3441,8 +3439,6 @@ class TestStack(unittest.TestCase):
              '    v = 4\n' % (__file__, some_inner.__code__.co_firstlineno + 3)
             ], s.format())
 
-    # TODO: RUSTPYTHON
-    @unittest.expectedFailure
     def test_custom_format_frame(self):
         class CustomStackSummary(traceback.StackSummary):
             def format_frame_summary(self, frame_summary, colorize=False):

--- a/crates/vm/src/stdlib/thread.rs
+++ b/crates/vm/src/stdlib/thread.rs
@@ -1,9 +1,10 @@
 //! Implementation of the _thread module
 #[cfg(unix)]
 pub(crate) use _thread::after_fork_child;
+pub use _thread::get_ident;
 #[cfg_attr(target_arch = "wasm32", allow(unused_imports))]
 pub(crate) use _thread::{
-    CurrentFrameSlot, HandleEntry, RawRMutex, ShutdownEntry, get_all_current_frames, get_ident,
+    CurrentFrameSlot, HandleEntry, RawRMutex, ShutdownEntry, get_all_current_frames,
     init_main_thread_ident, module_def,
 };
 
@@ -873,12 +874,12 @@ pub(crate) mod _thread {
     // Re-export type from vm::thread for PyGlobalState
     pub use crate::vm::thread::CurrentFrameSlot;
 
-    /// Get all threads' current frames. Used by sys._current_frames().
+    /// Get all threads' current (top) frames. Used by sys._current_frames().
     pub fn get_all_current_frames(vm: &VirtualMachine) -> Vec<(u64, FrameRef)> {
         let registry = vm.state.thread_frames.lock();
         registry
             .iter()
-            .filter_map(|(id, slot)| slot.lock().clone().map(|f| (*id, f)))
+            .filter_map(|(id, slot)| slot.lock().last().cloned().map(|f| (*id, f)))
             .collect()
     }
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Call-site line numbers for calls now reflect the call start for more accurate tracebacks.
  * Crash dumps traverse live frames and emit per-thread tracebacks for clearer diagnostics.
  * Signal-handler reentrancy now defers nested handling to avoid unsafe recursion.
  * Improved cross-platform fatal-signal/exception handling and cleaner traceback formatting.

* **New Features**
  * Full per-thread current-frame tracking and signal-safe frame chains for more reliable diagnostics.
  * Thread identifier now directly available from the threading API.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->