### PR TITLE
Improve object traversal for heap types and mro

### DIFF
--- a/crates/vm/src/builtins/type.rs
+++ b/crates/vm/src/builtins/type.rs
@@ -49,8 +49,7 @@ unsafe impl crate::object::Traverse for PyType {
     fn traverse(&self, tracer_fn: &mut crate::object::TraverseFn<'_>) {
         self.base.traverse(tracer_fn);
         self.bases.traverse(tracer_fn);
-        // mro contains self as mro[0], so skip traversing to avoid circular reference
-        // self.mro.traverse(tracer_fn);
+        self.mro.traverse(tracer_fn);
         self.subclasses.traverse(tracer_fn);
         self.attributes
             .read_recursive()


### PR DESCRIPTION
- Fix heap type instance traversal to include type reference (enables correct cycle detection for instance ↔ type references)
- Enable mro traversal in PyType (was previously disabled)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved garbage collection traversal for type objects to ensure proper memory management of type hierarchies and heap-allocated types.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->