### PR TITLE
Add GC infrastructure: tracking bits, tp_clear

### DIFF
--- a/crates/vm/src/builtins/type.rs
+++ b/crates/vm/src/builtins/type.rs
@@ -57,6 +57,33 @@ unsafe impl crate::object::Traverse for PyType {
             .map(|(_, v)| v.traverse(tracer_fn))
             .count();
     }
+
+    /// type_clear: break reference cycles in type objects
+    fn clear(&mut self, out: &mut Vec<crate::PyObjectRef>) {
+        if let Some(base) = self.base.take() {
+            out.push(base.into());
+        }
+        if let Some(mut guard) = self.bases.try_write() {
+            for base in guard.drain(..) {
+                out.push(base.into());
+            }
+        }
+        if let Some(mut guard) = self.mro.try_write() {
+            for typ in guard.drain(..) {
+                out.push(typ.into());
+            }
+        }
+        if let Some(mut guard) = self.subclasses.try_write() {
+            for weak in guard.drain(..) {
+                out.push(weak.into());
+            }
+        }
+        if let Some(mut guard) = self.attributes.try_write() {
+            for (_, val) in guard.drain(..) {
+                out.push(val);
+            }
+        }
+    }
 }
 
 // PyHeapTypeObject in CPython
@@ -393,6 +420,11 @@ impl PyType {
             metaclass,
             None,
         );
+
+        // Static types are not tracked by GC.
+        // They are immortal and never participate in collectable cycles.
+        new_type.as_object().clear_gc_tracked();
+
         new_type.mro.write().insert(0, new_type.clone());
 
         // Note: inherit_slots is called in PyClassImpl::init_class after

--- a/crates/vm/src/gc_state.rs
+++ b/crates/vm/src/gc_state.rs
@@ -236,6 +236,10 @@ impl GcState {
     pub unsafe fn track_object(&self, obj: NonNull<PyObject>) {
         let gc_ptr = GcObjectPtr(obj);
 
+        // _PyObject_GC_TRACK
+        let obj_ref = unsafe { obj.as_ref() };
+        obj_ref.set_gc_tracked();
+
         // Add to generation 0 tracking first (for correct gc_refs algorithm)
         // Only increment count if we successfully add to the set
         if let Ok(mut gen0) = self.generation_objects[0].write()


### PR DESCRIPTION
GC bit operations (_PyObject_GC_TRACK/UNTRACK equivalent):
- Add set_gc_bit() helper for atomic GC bit manipulation
- Add set_gc_tracked() / clear_gc_tracked() methods
- Update is_gc_tracked() to use GcBits::TRACKED flag
- Call set_gc_tracked() in track_object()
- Call clear_gc_tracked() for static types (they are immortal)

tp_clear infrastructure (for breaking reference cycles):
- Add try_clear_obj() function to call payload's try_clear
- Add clear field to PyObjVTable
- Add clear() method to PyType's Traverse impl

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced garbage collection system to more effectively detect and break circular references, improving memory management and reducing potential memory leaks.
  * Improved object deallocation process to ensure proper cleanup of child references before memory is freed.
  * Strengthened object tracking mechanisms to better identify objects requiring garbage collection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->