### PR TITLE
Add __replace__ and fix __reduce__ for structseq

### DIFF
--- a/crates/vm/src/types/structseq.rs
+++ b/crates/vm/src/types/structseq.rs
@@ -247,8 +247,8 @@ pub trait PyStructSequence: StaticType + PyClassImpl + Sized + 'static {
             )));
         }
 
-        let n_fields = Self::Data::REQUIRED_FIELD_NAMES.len()
-            + Self::Data::OPTIONAL_FIELD_NAMES.len();
+        let n_fields =
+            Self::Data::REQUIRED_FIELD_NAMES.len() + Self::Data::OPTIONAL_FIELD_NAMES.len();
         let mut items: Vec<PyObjectRef> = zelf.as_slice()[..n_fields].to_vec();
 
         let mut kwargs = args.kwargs.clone();
@@ -268,10 +268,7 @@ pub trait PyStructSequence: StaticType + PyClassImpl + Sized + 'static {
         // Check for unexpected keyword arguments
         if !kwargs.is_empty() {
             let names: Vec<&str> = kwargs.keys().map(|k| k.as_str()).collect();
-            return Err(vm.new_type_error(format!(
-                "Got unexpected field name(s): {:?}",
-                names
-            )));
+            return Err(vm.new_type_error(format!("Got unexpected field name(s): {:?}", names)));
         }
 
         PyTuple::new_unchecked(items.into_boxed_slice())


### PR DESCRIPTION
- Add `__replace__` method to PyStructSequence trait
- Move `__reduce__` from #[pymethod] to extend_pyclass with contains_key guard, allowing per-type overrides
- Fix repr: remove trailing comma for single-field sequences

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `__replace__` method for struct sequences, enabling creation of modified copies by replacing selected fields via keyword arguments.
  * Improved default serialization support for struct sequences with automatic `__reduce__` method handling.

* **Bug Fixes**
  * Enhanced field representation logic for improved consistency in struct sequence formatting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->