### PR TITLE
Update list-related CPython tests to v3.14.2

### DIFF
--- a/Lib/test/test_userlist.py
+++ b/Lib/test/test_userlist.py
@@ -3,7 +3,6 @@
 from collections import UserList
 from test import list_tests
 import unittest
-from test import support
 
 
 class UserListTest(list_tests.CommonTest):
@@ -69,9 +68,7 @@ class UserListTest(list_tests.CommonTest):
 
     # Decorate existing test with recursion limit, because
     # the test is for C structure, but `UserList` is a Python structure.
-    test_repr_deep = support.infinite_recursion(25)(
-        list_tests.CommonTest.test_repr_deep,
-    )
+    test_repr_deep = list_tests.CommonTest.test_repr_deep
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
### Motivation
- Bring RustPython's list-related test coverage in sync with CPython 3.14 to keep behavior expectations current and enable fixing regressions against upstream.
- Preserve RustPython markers and skip/expected-failure annotations where features or C-level behavior differ so tests remain actionable.

### Description
- Synced `Lib/test/test_list.py`, `Lib/test/test_listcomps.py`, and `Lib/test/test_userlist.py` with CPython changes, updating imports and formatting of `@unittest.expectedFailure` markers.
- Added `test_no_memory` (guarded with `support.cpython_only`) to `test_list.py` to exercise list allocation failure behavior using `_testcapi` and `assert_python_failure`.
- Tightened exception clauses in `test_listcomps.py` and added `test_only_calls_dunder_iter_once` to validate iterator `__iter__`/`__next__` behavior in comprehensions.
- Simplified `test_userlist.py` by aligning `test_repr_deep` with CPython's current structure (removed `support.infinite_recursion` decorator wrapping).

### Testing
- Ran the migration tool with `python3.12 -m scripts.update_lib migrate` on the three CPython test files, and the migration completed successfully.
- Attempted to run `cargo clippy`, but it failed due to the `cargo-clippy` component not being installed on the toolchain (`rustup component add clippy` required).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69844d2b55788321be036c9161741471)