### PR TITLE
Refactor warn.rs and _warnings module

### DIFF
--- a/Lib/test/test_warnings/__init__.py
+++ b/Lib/test/test_warnings/__init__.py
@@ -929,7 +929,6 @@ class _WarningsTests(BaseTest, unittest.TestCase):
             self.assertRaises(UserWarning, self.module.warn,
                                 'convert to error')
 
-    @unittest.expectedFailure  # TODO: RUSTPYTHON; AttributeError: module 'warnings' has no attribute 'onceregistry'
     def test_onceregistry(self):
         # Replacing or removing the onceregistry should be okay.
         global __warningregistry__
@@ -959,7 +958,6 @@ class _WarningsTests(BaseTest, unittest.TestCase):
         finally:
             self.module.onceregistry = original_registry
 
-    @unittest.expectedFailure  # TODO: RUSTPYTHON; AttributeError: module 'warnings' has no attribute 'defaultaction'
     def test_default_action(self):
         # Replacing or removing defaultaction should be okay.
         message = UserWarning("defaultaction test")
@@ -1631,7 +1629,6 @@ a=A()
         self.assertEqual(err.decode().rstrip(),
                          '<string>:7: UserWarning: test')
 
-    @unittest.expectedFailure  # TODO: RUSTPYTHON; AssertionError: b'' doesn't start with b'<sys>:0: ResourceWarning: unclosed file '
     def test_late_resource_warning(self):
         # Issue #21925: Emitting a ResourceWarning late during the Python
         # shutdown must be logged.

--- a/crates/vm/src/stdlib/io.rs
+++ b/crates/vm/src/stdlib/io.rs
@@ -2808,14 +2808,10 @@ mod _io {
             encoding: Option<PyUtf8StrRef>,
             vm: &VirtualMachine,
         ) -> PyResult<PyUtf8StrRef> {
-            if encoding.is_none() && vm.state.config.settings.warn_default_encoding {
-                crate::stdlib::warnings::warn(
-                    vm.ctx.exceptions.encoding_warning,
-                    "'encoding' argument not specified".to_owned(),
-                    1,
-                    vm,
-                )?;
-            }
+            // Note: Do not issue EncodingWarning here. The warning should only
+            // be issued by io.text_encoding(), the public API. This function
+            // is used internally (e.g., for stdin/stdout/stderr initialization)
+            // where no warning should be emitted.
             let encoding = match encoding {
                 None if vm.state.config.settings.utf8_mode > 0 => {
                     identifier_utf8!(vm, utf_8).to_owned()

--- a/crates/vm/src/vm/context.rs
+++ b/crates/vm/src/vm/context.rs
@@ -247,6 +247,8 @@ declare_const_name! {
     _defaultaction,
     _onceregistry,
     _showwarnmsg,
+    defaultaction,
+    onceregistry,
     filters,
     backslashreplace,
     close,


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Stop emitting redundant encoding warnings during stdin/stdout/stderr initialization; warnings now appear only via the explicit public encoding API.

* **Refactor**
  * Reworked the warnings system for more reliable filter matching, registry handling, and frame context resolution to improve warning delivery and tracking.
  * Public warning API updated to a more structured flow (may affect integrations relying on previous behavior).

* **New Features**
  * Added two additional common names as public constants.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->