### PR TITLE
Add dependency groups to dependabot.yml

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,14 +1,131 @@
+# cspell:ignore manyhow tinyvec zeroize
 version: 2
 updates:
   - package-ecosystem: cargo
     directory: /
     schedule:
       interval: weekly
+    groups:
+      cranelift:
+        patterns:
+          - "cranelift*"
+      criterion:
+        patterns:
+          - "criterion*"
+      futures:
+        patterns:
+          - "futures*"
+      get-size2:
+        patterns:
+          - "get-size*2"
+      iana-time-zone:
+        patterns:
+          - "iana-time-zone*"
+      jiff:
+        patterns:
+          - "jiff*"
+      lexical:
+        patterns:
+          - "lexical*"
+      libffi:
+        patterns:
+          - "libffi*"
+      malachite:
+        patterns:
+          - "malachite*"
+      manyhow:
+        patterns:
+          - "manyhow*"
+      num:
+        patterns:
+          - "num-bigint"
+          - "num-complex"
+          - "num-integer"
+          - "num-iter"
+          - "num-rational"
+          - "num-traits"
+      num_enum:
+        patterns:
+          - "num_enum*"
+      openssl:
+        patterns:
+          - "openssl*"
+      parking_lot:
+        patterns:
+          - "parking_lot*"
+      phf:
+        patterns:
+          - "phf*"
+      plotters:
+        patterns:
+          - "plotters*"
+      portable-atomic:
+        patterns:
+          - "portable-atomic*"
+      pyo3:
+        patterns:
+          - "pyo3*"
+      quote-use:
+        patterns:
+          - "quote-use*"
+      rayon:
+        patterns:
+          - "rayon*"
+      regex:
+        patterns:
+          - "regex*"
+      result-like:
+        patterns:
+          - "result-like*"
+      security-framework:
+        patterns:
+          - "security-framework*"
+      serde:
+        patterns:
+          - "serde"
+          - "serde_core"
+          - "serde_derive"
+      system-configuration:
+        patterns:
+          - "system-configuration*"
+      thiserror:
+        patterns:
+          - "thiserror*"
+      time:
+        patterns:
+          - "time*"
+      tinyvec:
+        patterns:
+          - "tinyvec*"
+      tls_codec:
+        patterns:
+          - "tls_codec*"
+      toml:
+        patterns:
+          - "toml*"
+      wasm-bindgen:
+        patterns:
+          - "wasm-bindgen*"
+      wasmtime:
+        patterns:
+          - "wasmtime*"
+      webpki-root:
+        patterns:
+          - "webpki-root*"
+      windows:
+        patterns:
+          - "windows*"
+      zerocopy:
+        patterns:
+          - "zerocopy*"
+      zeroize:
+        patterns:
+          - "zeroize*"
     ignore:
       # TODO: Remove when we use ruff from crates.io
       # for some reason dependabot only updates the Cargo.lock file when dealing
       # with git dependencies. i.e. not updating the version in Cargo.toml
-      - dependency-name: "ruff_*" 
+      - dependency-name: "ruff_*"
   - package-ecosystem: github-actions
     directory: /
     schedule:


### PR DESCRIPTION
This is so that Dependabot can automatically update, e.g., all of the `malachite` dependencies in a single PR, rather than having to depend on opening multiple PRs.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated dependency management configuration to establish organized grouping across multiple package categories, including cranelift, criterion, futures, serde, TLS, wasm-bindgen, wasmtime, and various num-related packages. This strategic reorganization enables more precise, coordinated, and targeted dependency updates across the entire dependency ecosystem, significantly improving overall efficiency and coordination of dependency maintenance operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->