### PR TITLE
Refactor _ast module for clarity

### DIFF
--- a/crates/vm/src/stdlib/ast/exception.rs
+++ b/crates/vm/src/stdlib/ast/exception.rs
@@ -9,22 +9,22 @@ impl Node for ast::ExceptHandler {
         }
     }
     fn ast_from_object(
-        _vm: &VirtualMachine,
+        vm: &VirtualMachine,
         source_file: &SourceFile,
-        _object: PyObjectRef,
+        object: PyObjectRef,
     ) -> PyResult<Self> {
-        let _cls = _object.class();
+        let cls = object.class();
         Ok(
-            if _cls.is(pyast::NodeExceptHandlerExceptHandler::static_type()) {
+            if cls.is(pyast::NodeExceptHandlerExceptHandler::static_type()) {
                 Self::ExceptHandler(ast::ExceptHandlerExceptHandler::ast_from_object(
-                    _vm,
+                    vm,
                     source_file,
-                    _object,
+                    object,
                 )?)
             } else {
-                return Err(_vm.new_type_error(format!(
+                return Err(vm.new_type_error(format!(
                     "expected some sort of excepthandler, but got {}",
-                    _object.repr(_vm)?
+                    object.repr(vm)?
                 )));
             },
         )
@@ -33,50 +33,50 @@ impl Node for ast::ExceptHandler {
 
 // constructor
 impl Node for ast::ExceptHandlerExceptHandler {
-    fn ast_to_object(self, _vm: &VirtualMachine, source_file: &SourceFile) -> PyObjectRef {
+    fn ast_to_object(self, vm: &VirtualMachine, source_file: &SourceFile) -> PyObjectRef {
         let Self {
             node_index: _,
             type_,
             name,
             body,
-            range: _range,
+            range,
         } = self;
         let node = NodeAst
             .into_ref_with_type(
-                _vm,
+                vm,
                 pyast::NodeExceptHandlerExceptHandler::static_type().to_owned(),
             )
             .unwrap();
         let dict = node.as_object().dict().unwrap();
-        dict.set_item("type", type_.ast_to_object(_vm, source_file), _vm)
+        dict.set_item("type", type_.ast_to_object(vm, source_file), vm)
             .unwrap();
-        dict.set_item("name", name.ast_to_object(_vm, source_file), _vm)
+        dict.set_item("name", name.ast_to_object(vm, source_file), vm)
             .unwrap();
-        dict.set_item("body", body.ast_to_object(_vm, source_file), _vm)
+        dict.set_item("body", body.ast_to_object(vm, source_file), vm)
             .unwrap();
-        node_add_location(&dict, _range, _vm, source_file);
+        node_add_location(&dict, range, vm, source_file);
         node.into()
     }
 
     fn ast_from_object(
-        _vm: &VirtualMachine,
+        vm: &VirtualMachine,
         source_file: &SourceFile,
-        _object: PyObjectRef,
+        object: PyObjectRef,
     ) -> PyResult<Self> {
         Ok(Self {
             node_index: Default::default(),
-            type_: get_node_field_opt(_vm, &_object, "type")?
-                .map(|obj| Node::ast_from_object(_vm, source_file, obj))
+            type_: get_node_field_opt(vm, &object, "type")?
+                .map(|obj| Node::ast_from_object(vm, source_file, obj))
                 .transpose()?,
-            name: get_node_field_opt(_vm, &_object, "name")?
-                .map(|obj| Node::ast_from_object(_vm, source_file, obj))
+            name: get_node_field_opt(vm, &object, "name")?
+                .map(|obj| Node::ast_from_object(vm, source_file, obj))
                 .transpose()?,
             body: Node::ast_from_object(
-                _vm,
+                vm,
                 source_file,
-                get_node_field(_vm, &_object, "body", "ExceptHandler")?,
+                get_node_field(vm, &object, "body", "ExceptHandler")?,
             )?,
-            range: range_from_object(_vm, source_file, _object, "ExceptHandler")?,
+            range: range_from_object(vm, source_file, object, "ExceptHandler")?,
         })
     }
 }

--- a/crates/vm/src/stdlib/ast/expression.rs
+++ b/crates/vm/src/stdlib/ast/expression.rs
@@ -1256,13 +1256,7 @@ impl Node for ast::ExprContext {
                 unimplemented!("Invalid expression context is not allowed in Python AST")
             }
         };
-        if let Some(instance) = node_type.get_attr(vm.ctx.intern_str("_instance")) {
-            return instance;
-        }
-        NodeAst
-            .into_ref_with_type(vm, node_type.to_owned())
-            .unwrap()
-            .into()
+        singleton_node_to_object(vm, node_type)
     }
 
     fn ast_from_object(
@@ -1270,12 +1264,12 @@ impl Node for ast::ExprContext {
         _source_file: &SourceFile,
         object: PyObjectRef,
     ) -> PyResult<Self> {
-        let _cls = object.class();
-        Ok(if _cls.is(pyast::NodeExprContextLoad::static_type()) {
+        let cls = object.class();
+        Ok(if cls.is(pyast::NodeExprContextLoad::static_type()) {
             Self::Load
-        } else if _cls.is(pyast::NodeExprContextStore::static_type()) {
+        } else if cls.is(pyast::NodeExprContextStore::static_type()) {
             Self::Store
-        } else if _cls.is(pyast::NodeExprContextDel::static_type()) {
+        } else if cls.is(pyast::NodeExprContextDel::static_type()) {
             Self::Del
         } else {
             return Err(vm.new_type_error(format!(

--- a/crates/vm/src/stdlib/ast/operator.rs
+++ b/crates/vm/src/stdlib/ast/operator.rs
@@ -8,29 +8,23 @@ impl Node for ast::BoolOp {
             Self::And => pyast::NodeBoolOpAnd::static_type(),
             Self::Or => pyast::NodeBoolOpOr::static_type(),
         };
-        if let Some(instance) = node_type.get_attr(vm.ctx.intern_str("_instance")) {
-            return instance;
-        }
-        NodeAst
-            .into_ref_with_type(vm, node_type.to_owned())
-            .unwrap()
-            .into()
+        singleton_node_to_object(vm, node_type)
     }
 
     fn ast_from_object(
-        _vm: &VirtualMachine,
+        vm: &VirtualMachine,
         _source_file: &SourceFile,
-        _object: PyObjectRef,
+        object: PyObjectRef,
     ) -> PyResult<Self> {
-        let _cls = _object.class();
-        Ok(if _cls.is(pyast::NodeBoolOpAnd::static_type()) {
+        let cls = object.class();
+        Ok(if cls.is(pyast::NodeBoolOpAnd::static_type()) {
             Self::And
-        } else if _cls.is(pyast::NodeBoolOpOr::static_type()) {
+        } else if cls.is(pyast::NodeBoolOpOr::static_type()) {
             Self::Or
         } else {
-            return Err(_vm.new_type_error(format!(
+            return Err(vm.new_type_error(format!(
                 "expected some sort of boolop, but got {}",
-                _object.repr(_vm)?
+                object.repr(vm)?
             )));
         })
     }
@@ -54,51 +48,45 @@ impl Node for ast::Operator {
             Self::BitAnd => pyast::NodeOperatorBitAnd::static_type(),
             Self::FloorDiv => pyast::NodeOperatorFloorDiv::static_type(),
         };
-        if let Some(instance) = node_type.get_attr(vm.ctx.intern_str("_instance")) {
-            return instance;
-        }
-        NodeAst
-            .into_ref_with_type(vm, node_type.to_owned())
-            .unwrap()
-            .into()
+        singleton_node_to_object(vm, node_type)
     }
 
     fn ast_from_object(
-        _vm: &VirtualMachine,
+        vm: &VirtualMachine,
         _source_file: &SourceFile,
-        _object: PyObjectRef,
+        object: PyObjectRef,
     ) -> PyResult<Self> {
-        let _cls = _object.class();
-        Ok(if _cls.is(pyast::NodeOperatorAdd::static_type()) {
+        let cls = object.class();
+        Ok(if cls.is(pyast::NodeOperatorAdd::static_type()) {
             Self::Add
-        } else if _cls.is(pyast::NodeOperatorSub::static_type()) {
+        } else if cls.is(pyast::NodeOperatorSub::static_type()) {
             Self::Sub
-        } else if _cls.is(pyast::NodeOperatorMult::static_type()) {
+        } else if cls.is(pyast::NodeOperatorMult::static_type()) {
             Self::Mult
-        } else if _cls.is(pyast::NodeOperatorMatMult::static_type()) {
+        } else if cls.is(pyast::NodeOperatorMatMult::static_type()) {
             Self::MatMult
-        } else if _cls.is(pyast::NodeOperatorDiv::static_type()) {
+        } else if cls.is(pyast::NodeOperatorDiv::static_type()) {
             Self::Div
-        } else if _cls.is(pyast::NodeOperatorMod::static_type()) {
+        } else if cls.is(pyast::NodeOperatorMod::static_type()) {
             Self::Mod
-        } else if _cls.is(pyast::NodeOperatorPow::static_type()) {
+        } else if cls.is(pyast::NodeOperatorPow::static_type()) {
             Self::Pow
-        } else if _cls.is(pyast::NodeOperatorLShift::static_type()) {
+        } else if cls.is(pyast::NodeOperatorLShift::static_type()) {
             Self::LShift
-        } else if _cls.is(pyast::NodeOperatorRShift::static_type()) {
+        } else if cls.is(pyast::NodeOperatorRShift::static_type()) {
             Self::RShift
-        } else if _cls.is(pyast::NodeOperatorBitOr::static_type()) {
+        } else if cls.is(pyast::NodeOperatorBitOr::static_type()) {
             Self::BitOr
-        } else if _cls.is(pyast::NodeOperatorBitXor::static_type()) {
+        } else if cls.is(pyast::NodeOperatorBitXor::static_type()) {
             Self::BitXor
-        } else if _cls.is(pyast::NodeOperatorBitAnd::static_type()) {
+        } else if cls.is(pyast::NodeOperatorBitAnd::static_type()) {
             Self::BitAnd
-        } else if _cls.is(pyast::NodeOperatorFloorDiv::static_type()) {
+        } else if cls.is(pyast::NodeOperatorFloorDiv::static_type()) {
             Self::FloorDiv
         } else {
-            return Err(_vm.new_type_error(format!(
+            return Err(vm.new_type_error(format!(
                 "expected some sort of operator, but got {}",
-                _object.repr(_vm)?
+                object.repr(vm)?
             )));
         })
     }
@@ -113,33 +101,27 @@ impl Node for ast::UnaryOp {
             Self::UAdd => pyast::NodeUnaryOpUAdd::static_type(),
             Self::USub => pyast::NodeUnaryOpUSub::static_type(),
         };
-        if let Some(instance) = node_type.get_attr(vm.ctx.intern_str("_instance")) {
-            return instance;
-        }
-        NodeAst
-            .into_ref_with_type(vm, node_type.to_owned())
-            .unwrap()
-            .into()
+        singleton_node_to_object(vm, node_type)
     }
 
     fn ast_from_object(
-        _vm: &VirtualMachine,
+        vm: &VirtualMachine,
         _source_file: &SourceFile,
-        _object: PyObjectRef,
+        object: PyObjectRef,
     ) -> PyResult<Self> {
-        let _cls = _object.class();
-        Ok(if _cls.is(pyast::NodeUnaryOpInvert::static_type()) {
+        let cls = object.class();
+        Ok(if cls.is(pyast::NodeUnaryOpInvert::static_type()) {
             Self::Invert
-        } else if _cls.is(pyast::NodeUnaryOpNot::static_type()) {
+        } else if cls.is(pyast::NodeUnaryOpNot::static_type()) {
             Self::Not
-        } else if _cls.is(pyast::NodeUnaryOpUAdd::static_type()) {
+        } else if cls.is(pyast::NodeUnaryOpUAdd::static_type()) {
             Self::UAdd
-        } else if _cls.is(pyast::NodeUnaryOpUSub::static_type()) {
+        } else if cls.is(pyast::NodeUnaryOpUSub::static_type()) {
             Self::USub
         } else {
-            return Err(_vm.new_type_error(format!(
+            return Err(vm.new_type_error(format!(
                 "expected some sort of unaryop, but got {}",
-                _object.repr(_vm)?
+                object.repr(vm)?
             )));
         })
     }
@@ -160,45 +142,39 @@ impl Node for ast::CmpOp {
             Self::In => pyast::NodeCmpOpIn::static_type(),
             Self::NotIn => pyast::NodeCmpOpNotIn::static_type(),
         };
-        if let Some(instance) = node_type.get_attr(vm.ctx.intern_str("_instance")) {
-            return instance;
-        }
-        NodeAst
-            .into_ref_with_type(vm, node_type.to_owned())
-            .unwrap()
-            .into()
+        singleton_node_to_object(vm, node_type)
     }
 
     fn ast_from_object(
-        _vm: &VirtualMachine,
+        vm: &VirtualMachine,
         _source_file: &SourceFile,
-        _object: PyObjectRef,
+        object: PyObjectRef,
     ) -> PyResult<Self> {
-        let _cls = _object.class();
-        Ok(if _cls.is(pyast::NodeCmpOpEq::static_type()) {
+        let cls = object.class();
+        Ok(if cls.is(pyast::NodeCmpOpEq::static_type()) {
             Self::Eq
-        } else if _cls.is(pyast::NodeCmpOpNotEq::static_type()) {
+        } else if cls.is(pyast::NodeCmpOpNotEq::static_type()) {
             Self::NotEq
-        } else if _cls.is(pyast::NodeCmpOpLt::static_type()) {
+        } else if cls.is(pyast::NodeCmpOpLt::static_type()) {
             Self::Lt
-        } else if _cls.is(pyast::NodeCmpOpLtE::static_type()) {
+        } else if cls.is(pyast::NodeCmpOpLtE::static_type()) {
             Self::LtE
-        } else if _cls.is(pyast::NodeCmpOpGt::static_type()) {
+        } else if cls.is(pyast::NodeCmpOpGt::static_type()) {
             Self::Gt
-        } else if _cls.is(pyast::NodeCmpOpGtE::static_type()) {
+        } else if cls.is(pyast::NodeCmpOpGtE::static_type()) {
             Self::GtE
-        } else if _cls.is(pyast::NodeCmpOpIs::static_type()) {
+        } else if cls.is(pyast::NodeCmpOpIs::static_type()) {
             Self::Is
-        } else if _cls.is(pyast::NodeCmpOpIsNot::static_type()) {
+        } else if cls.is(pyast::NodeCmpOpIsNot::static_type()) {
             Self::IsNot
-        } else if _cls.is(pyast::NodeCmpOpIn::static_type()) {
+        } else if cls.is(pyast::NodeCmpOpIn::static_type()) {
             Self::In
-        } else if _cls.is(pyast::NodeCmpOpNotIn::static_type()) {
+        } else if cls.is(pyast::NodeCmpOpNotIn::static_type()) {
             Self::NotIn
         } else {
-            return Err(_vm.new_type_error(format!(
+            return Err(vm.new_type_error(format!(
                 "expected some sort of cmpop, but got {}",
-                _object.repr(_vm)?
+                object.repr(vm)?
             )));
         })
     }

--- a/crates/vm/src/stdlib/ast/pattern.rs
+++ b/crates/vm/src/stdlib/ast/pattern.rs
@@ -3,46 +3,46 @@ use rustpython_compiler_core::SourceFile;
 
 // product
 impl Node for ast::MatchCase {
-    fn ast_to_object(self, _vm: &VirtualMachine, source_file: &SourceFile) -> PyObjectRef {
+    fn ast_to_object(self, vm: &VirtualMachine, source_file: &SourceFile) -> PyObjectRef {
         let Self {
             node_index: _,
             pattern,
             guard,
             body,
-            range: _range,
+            range: _,
         } = self;
         let node = NodeAst
-            .into_ref_with_type(_vm, pyast::NodeMatchCase::static_type().to_owned())
+            .into_ref_with_type(vm, pyast::NodeMatchCase::static_type().to_owned())
             .unwrap();
         let dict = node.as_object().dict().unwrap();
-        dict.set_item("pattern", pattern.ast_to_object(_vm, source_file), _vm)
+        dict.set_item("pattern", pattern.ast_to_object(vm, source_file), vm)
             .unwrap();
-        dict.set_item("guard", guard.ast_to_object(_vm, source_file), _vm)
+        dict.set_item("guard", guard.ast_to_object(vm, source_file), vm)
             .unwrap();
-        dict.set_item("body", body.ast_to_object(_vm, source_file), _vm)
+        dict.set_item("body", body.ast_to_object(vm, source_file), vm)
             .unwrap();
         node.into()
     }
 
     fn ast_from_object(
-        _vm: &VirtualMachine,
+        vm: &VirtualMachine,
         source_file: &SourceFile,
-        _object: PyObjectRef,
+        object: PyObjectRef,
     ) -> PyResult<Self> {
         Ok(Self {
             node_index: Default::default(),
             pattern: Node::ast_from_object(
-                _vm,
+                vm,
                 source_file,
-                get_node_field(_vm, &_object, "pattern", "match_case")?,
+                get_node_field(vm, &object, "pattern", "match_case")?,
             )?,
-            guard: get_node_field_opt(_vm, &_object, "guard")?
-                .map(|obj| Node::ast_from_object(_vm, source_file, obj))
+            guard: get_node_field_opt(vm, &object, "guard")?
+                .map(|obj| Node::ast_from_object(vm, source_file, obj))
                 .transpose()?,
             body: Node::ast_from_object(
-                _vm,
+                vm,
                 source_file,
-                get_node_field(_vm, &_object, "body", "match_case")?,
+                get_node_field(vm, &object, "body", "match_case")?,
             )?,
             range: Default::default(),
         })
@@ -64,136 +64,136 @@ impl Node for ast::Pattern {
         }
     }
     fn ast_from_object(
-        _vm: &VirtualMachine,
+        vm: &VirtualMachine,
         source_file: &SourceFile,
-        _object: PyObjectRef,
+        object: PyObjectRef,
     ) -> PyResult<Self> {
-        let _cls = _object.class();
-        Ok(if _cls.is(pyast::NodePatternMatchValue::static_type()) {
+        let cls = object.class();
+        Ok(if cls.is(pyast::NodePatternMatchValue::static_type()) {
             Self::MatchValue(ast::PatternMatchValue::ast_from_object(
-                _vm,
+                vm,
                 source_file,
-                _object,
+                object,
             )?)
-        } else if _cls.is(pyast::NodePatternMatchSingleton::static_type()) {
+        } else if cls.is(pyast::NodePatternMatchSingleton::static_type()) {
             Self::MatchSingleton(ast::PatternMatchSingleton::ast_from_object(
-                _vm,
+                vm,
                 source_file,
-                _object,
+                object,
             )?)
-        } else if _cls.is(pyast::NodePatternMatchSequence::static_type()) {
+        } else if cls.is(pyast::NodePatternMatchSequence::static_type()) {
             Self::MatchSequence(ast::PatternMatchSequence::ast_from_object(
-                _vm,
+                vm,
                 source_file,
-                _object,
+                object,
             )?)
-        } else if _cls.is(pyast::NodePatternMatchMapping::static_type()) {
+        } else if cls.is(pyast::NodePatternMatchMapping::static_type()) {
             Self::MatchMapping(ast::PatternMatchMapping::ast_from_object(
-                _vm,
+                vm,
                 source_file,
-                _object,
+                object,
             )?)
-        } else if _cls.is(pyast::NodePatternMatchClass::static_type()) {
+        } else if cls.is(pyast::NodePatternMatchClass::static_type()) {
             Self::MatchClass(ast::PatternMatchClass::ast_from_object(
-                _vm,
+                vm,
                 source_file,
-                _object,
+                object,
             )?)
-        } else if _cls.is(pyast::NodePatternMatchStar::static_type()) {
+        } else if cls.is(pyast::NodePatternMatchStar::static_type()) {
             Self::MatchStar(ast::PatternMatchStar::ast_from_object(
-                _vm,
+                vm,
                 source_file,
-                _object,
+                object,
             )?)
-        } else if _cls.is(pyast::NodePatternMatchAs::static_type()) {
+        } else if cls.is(pyast::NodePatternMatchAs::static_type()) {
             Self::MatchAs(ast::PatternMatchAs::ast_from_object(
-                _vm,
+                vm,
                 source_file,
-                _object,
+                object,
             )?)
-        } else if _cls.is(pyast::NodePatternMatchOr::static_type()) {
+        } else if cls.is(pyast::NodePatternMatchOr::static_type()) {
             Self::MatchOr(ast::PatternMatchOr::ast_from_object(
-                _vm,
+                vm,
                 source_file,
-                _object,
+                object,
             )?)
         } else {
-            return Err(_vm.new_type_error(format!(
+            return Err(vm.new_type_error(format!(
                 "expected some sort of pattern, but got {}",
-                _object.repr(_vm)?
+                object.repr(vm)?
             )));
         })
     }
 }
 // constructor
 impl Node for ast::PatternMatchValue {
-    fn ast_to_object(self, _vm: &VirtualMachine, source_file: &SourceFile) -> PyObjectRef {
+    fn ast_to_object(self, vm: &VirtualMachine, source_file: &SourceFile) -> PyObjectRef {
         let Self {
             node_index: _,
             value,
-            range: _range,
+            range,
         } = self;
         let node = NodeAst
-            .into_ref_with_type(_vm, pyast::NodePatternMatchValue::static_type().to_owned())
+            .into_ref_with_type(vm, pyast::NodePatternMatchValue::static_type().to_owned())
             .unwrap();
         let dict = node.as_object().dict().unwrap();
-        dict.set_item("value", value.ast_to_object(_vm, source_file), _vm)
+        dict.set_item("value", value.ast_to_object(vm, source_file), vm)
             .unwrap();
-        node_add_location(&dict, _range, _vm, source_file);
+        node_add_location(&dict, range, vm, source_file);
         node.into()
     }
 
     fn ast_from_object(
-        _vm: &VirtualMachine,
+        vm: &VirtualMachine,
         source_file: &SourceFile,
-        _object: PyObjectRef,
+        object: PyObjectRef,
     ) -> PyResult<Self> {
         Ok(Self {
             node_index: Default::default(),
             value: Node::ast_from_object(
-                _vm,
+                vm,
                 source_file,
-                get_node_field(_vm, &_object, "value", "MatchValue")?,
+                get_node_field(vm, &object, "value", "MatchValue")?,
             )?,
-            range: range_from_object(_vm, source_file, _object, "MatchValue")?,
+            range: range_from_object(vm, source_file, object, "MatchValue")?,
         })
     }
 }
 
 // constructor
 impl Node for ast::PatternMatchSingleton {
-    fn ast_to_object(self, _vm: &VirtualMachine, source_file: &SourceFile) -> PyObjectRef {
+    fn ast_to_object(self, vm: &VirtualMachine, source_file: &SourceFile) -> PyObjectRef {
         let Self {
             node_index: _,
             value,
-            range: _range,
+            range,
         } = self;
         let node = NodeAst
             .into_ref_with_type(
-                _vm,
+                vm,
                 pyast::NodePatternMatchSingleton::static_type().to_owned(),
             )
             .unwrap();
         let dict = node.as_object().dict().unwrap();
-        dict.set_item("value", value.ast_to_object(_vm, source_file), _vm)
+        dict.set_item("value", value.ast_to_object(vm, source_file), vm)
             .unwrap();
-        node_add_location(&dict, _range, _vm, source_file);
+        node_add_location(&dict, range, vm, source_file);
         node.into()
     }
 
     fn ast_from_object(
-        _vm: &VirtualMachine,
+        vm: &VirtualMachine,
         source_file: &SourceFile,
-        _object: PyObjectRef,
+        object: PyObjectRef,
     ) -> PyResult<Self> {
         Ok(Self {
             node_index: Default::default(),
             value: Node::ast_from_object(
-                _vm,
+                vm,
                 source_file,
-                get_node_field(_vm, &_object, "value", "MatchSingleton")?,
+                get_node_field(vm, &object, "value", "MatchSingleton")?,
             )?,
-            range: range_from_object(_vm, source_file, _object, "MatchSingleton")?,
+            range: range_from_object(vm, source_file, object, "MatchSingleton")?,
         })
     }
 }
@@ -229,90 +229,87 @@ impl Node for ast::Singleton {
 
 // constructor
 impl Node for ast::PatternMatchSequence {
-    fn ast_to_object(self, _vm: &VirtualMachine, source_file: &SourceFile) -> PyObjectRef {
+    fn ast_to_object(self, vm: &VirtualMachine, source_file: &SourceFile) -> PyObjectRef {
         let Self {
             node_index: _,
             patterns,
-            range: _range,
+            range,
         } = self;
         let node = NodeAst
             .into_ref_with_type(
-                _vm,
+                vm,
                 pyast::NodePatternMatchSequence::static_type().to_owned(),
             )
             .unwrap();
         let dict = node.as_object().dict().unwrap();
-        dict.set_item("patterns", patterns.ast_to_object(_vm, source_file), _vm)
+        dict.set_item("patterns", patterns.ast_to_object(vm, source_file), vm)
             .unwrap();
-        node_add_location(&dict, _range, _vm, source_file);
+        node_add_location(&dict, range, vm, source_file);
         node.into()
     }
 
     fn ast_from_object(
-        _vm: &VirtualMachine,
+        vm: &VirtualMachine,
         source_file: &SourceFile,
-        _object: PyObjectRef,
+        object: PyObjectRef,
     ) -> PyResult<Self> {
         Ok(Self {
             node_index: Default::default(),
             patterns: Node::ast_from_object(
-                _vm,
+                vm,
                 source_file,
-                get_node_field(_vm, &_object, "patterns", "MatchSequence")?,
+                get_node_field(vm, &object, "patterns", "MatchSequence")?,
             )?,
-            range: range_from_object(_vm, source_file, _object, "MatchSequence")?,
+            range: range_from_object(vm, source_file, object, "MatchSequence")?,
         })
     }
 }
 
 // constructor
 impl Node for ast::PatternMatchMapping {
-    fn ast_to_object(self, _vm: &VirtualMachine, source_file: &SourceFile) -> PyObjectRef {
+    fn ast_to_object(self, vm: &VirtualMachine, source_file: &SourceFile) -> PyObjectRef {
         let Self {
             node_index: _,
             keys,
             patterns,
             rest,
-            range: _range,
+            range,
         } = self;
         let node = NodeAst
-            .into_ref_with_type(
-                _vm,
-                pyast::NodePatternMatchMapping::static_type().to_owned(),
-            )
+            .into_ref_with_type(vm, pyast::NodePatternMatchMapping::static_type().to_owned())
             .unwrap();
         let dict = node.as_object().dict().unwrap();
-        dict.set_item("keys", keys.ast_to_object(_vm, source_file), _vm)
+        dict.set_item("keys", keys.ast_to_object(vm, source_file), vm)
             .unwrap();
-        dict.set_item("patterns", patterns.ast_to_object(_vm, source_file), _vm)
+        dict.set_item("patterns", patterns.ast_to_object(vm, source_file), vm)
             .unwrap();
-        dict.set_item("rest", rest.ast_to_object(_vm, source_file), _vm)
+        dict.set_item("rest", rest.ast_to_object(vm, source_file), vm)
             .unwrap();
-        node_add_location(&dict, _range, _vm, source_file);
+        node_add_location(&dict, range, vm, source_file);
         node.into()
     }
 
     fn ast_from_object(
-        _vm: &VirtualMachine,
+        vm: &VirtualMachine,
         source_file: &SourceFile,
-        _object: PyObjectRef,
+        object: PyObjectRef,
     ) -> PyResult<Self> {
         Ok(Self {
             node_index: Default::default(),
             keys: Node::ast_from_object(
-                _vm,
+                vm,
                 source_file,
-                get_node_field(_vm, &_object, "keys", "MatchMapping")?,
+                get_node_field(vm, &object, "keys", "MatchMapping")?,
             )?,
             patterns: Node::ast_from_object(
-                _vm,
+                vm,
                 source_file,
-                get_node_field(_vm, &_object, "patterns", "MatchMapping")?,
+                get_node_field(vm, &object, "patterns", "MatchMapping")?,
             )?,
-            rest: get_node_field_opt(_vm, &_object, "rest")?
-                .map(|obj| Node::ast_from_object(_vm, source_file, obj))
+            rest: get_node_field_opt(vm, &object, "rest")?
+                .map(|obj| Node::ast_from_object(vm, source_file, obj))
                 .transpose()?,
-            range: range_from_object(_vm, source_file, _object, "MatchMapping")?,
+            range: range_from_object(vm, source_file, object, "MatchMapping")?,
         })
     }
 }
@@ -324,7 +321,7 @@ impl Node for ast::PatternMatchClass {
             node_index: _,
             cls,
             arguments,
-            range: _range,
+            range,
         } = self;
         let (patterns, kwd_attrs, kwd_patterns) = split_pattern_match_class(arguments);
         let node = NodeAst
@@ -343,7 +340,7 @@ impl Node for ast::PatternMatchClass {
             vm,
         )
         .unwrap();
-        node_add_location(&dict, _range, vm, source_file);
+        node_add_location(&dict, range, vm, source_file);
         node.into()
     }
 
@@ -441,106 +438,106 @@ impl Node for PatternMatchClassKeywordPatterns {
 }
 // constructor
 impl Node for ast::PatternMatchStar {
-    fn ast_to_object(self, _vm: &VirtualMachine, source_file: &SourceFile) -> PyObjectRef {
+    fn ast_to_object(self, vm: &VirtualMachine, source_file: &SourceFile) -> PyObjectRef {
         let Self {
             node_index: _,
             name,
-            range: _range,
+            range,
         } = self;
         let node = NodeAst
-            .into_ref_with_type(_vm, pyast::NodePatternMatchStar::static_type().to_owned())
+            .into_ref_with_type(vm, pyast::NodePatternMatchStar::static_type().to_owned())
             .unwrap();
         let dict = node.as_object().dict().unwrap();
-        dict.set_item("name", name.ast_to_object(_vm, source_file), _vm)
+        dict.set_item("name", name.ast_to_object(vm, source_file), vm)
             .unwrap();
-        node_add_location(&dict, _range, _vm, source_file);
+        node_add_location(&dict, range, vm, source_file);
         node.into()
     }
 
     fn ast_from_object(
-        _vm: &VirtualMachine,
+        vm: &VirtualMachine,
         source_file: &SourceFile,
-        _object: PyObjectRef,
+        object: PyObjectRef,
     ) -> PyResult<Self> {
         Ok(Self {
             node_index: Default::default(),
-            name: get_node_field_opt(_vm, &_object, "name")?
-                .map(|obj| Node::ast_from_object(_vm, source_file, obj))
+            name: get_node_field_opt(vm, &object, "name")?
+                .map(|obj| Node::ast_from_object(vm, source_file, obj))
                 .transpose()?,
-            range: range_from_object(_vm, source_file, _object, "MatchStar")?,
+            range: range_from_object(vm, source_file, object, "MatchStar")?,
         })
     }
 }
 
 // constructor
 impl Node for ast::PatternMatchAs {
-    fn ast_to_object(self, _vm: &VirtualMachine, source_file: &SourceFile) -> PyObjectRef {
+    fn ast_to_object(self, vm: &VirtualMachine, source_file: &SourceFile) -> PyObjectRef {
         let Self {
             node_index: _,
             pattern,
             name,
-            range: _range,
+            range,
         } = self;
         let node = NodeAst
-            .into_ref_with_type(_vm, pyast::NodePatternMatchAs::static_type().to_owned())
+            .into_ref_with_type(vm, pyast::NodePatternMatchAs::static_type().to_owned())
             .unwrap();
         let dict = node.as_object().dict().unwrap();
-        dict.set_item("pattern", pattern.ast_to_object(_vm, source_file), _vm)
+        dict.set_item("pattern", pattern.ast_to_object(vm, source_file), vm)
             .unwrap();
-        dict.set_item("name", name.ast_to_object(_vm, source_file), _vm)
+        dict.set_item("name", name.ast_to_object(vm, source_file), vm)
             .unwrap();
-        node_add_location(&dict, _range, _vm, source_file);
+        node_add_location(&dict, range, vm, source_file);
         node.into()
     }
 
     fn ast_from_object(
-        _vm: &VirtualMachine,
+        vm: &VirtualMachine,
         source_file: &SourceFile,
-        _object: PyObjectRef,
+        object: PyObjectRef,
     ) -> PyResult<Self> {
         Ok(Self {
             node_index: Default::default(),
-            pattern: get_node_field_opt(_vm, &_object, "pattern")?
-                .map(|obj| Node::ast_from_object(_vm, source_file, obj))
+            pattern: get_node_field_opt(vm, &object, "pattern")?
+                .map(|obj| Node::ast_from_object(vm, source_file, obj))
                 .transpose()?,
-            name: get_node_field_opt(_vm, &_object, "name")?
-                .map(|obj| Node::ast_from_object(_vm, source_file, obj))
+            name: get_node_field_opt(vm, &object, "name")?
+                .map(|obj| Node::ast_from_object(vm, source_file, obj))
                 .transpose()?,
-            range: range_from_object(_vm, source_file, _object, "MatchAs")?,
+            range: range_from_object(vm, source_file, object, "MatchAs")?,
         })
     }
 }
 
 // constructor
 impl Node for ast::PatternMatchOr {
-    fn ast_to_object(self, _vm: &VirtualMachine, source_file: &SourceFile) -> PyObjectRef {
+    fn ast_to_object(self, vm: &VirtualMachine, source_file: &SourceFile) -> PyObjectRef {
         let Self {
             node_index: _,
             patterns,
-            range: _range,
+            range,
         } = self;
         let node = NodeAst
-            .into_ref_with_type(_vm, pyast::NodePatternMatchOr::static_type().to_owned())
+            .into_ref_with_type(vm, pyast::NodePatternMatchOr::static_type().to_owned())
             .unwrap();
         let dict = node.as_object().dict().unwrap();
-        dict.set_item("patterns", patterns.ast_to_object(_vm, source_file), _vm)
+        dict.set_item("patterns", patterns.ast_to_object(vm, source_file), vm)
             .unwrap();
-        node_add_location(&dict, _range, _vm, source_file);
+        node_add_location(&dict, range, vm, source_file);
         node.into()
     }
     fn ast_from_object(
-        _vm: &VirtualMachine,
+        vm: &VirtualMachine,
         source_file: &SourceFile,
-        _object: PyObjectRef,
+        object: PyObjectRef,
     ) -> PyResult<Self> {
         Ok(Self {
             node_index: Default::default(),
             patterns: Node::ast_from_object(
-                _vm,
+                vm,
                 source_file,
-                get_node_field(_vm, &_object, "patterns", "MatchOr")?,
+                get_node_field(vm, &object, "patterns", "MatchOr")?,
             )?,
-            range: range_from_object(_vm, source_file, _object, "MatchOr")?,
+            range: range_from_object(vm, source_file, object, "MatchOr")?,
         })
     }
 }

--- a/crates/vm/src/stdlib/ast/type_ignore.rs
+++ b/crates/vm/src/stdlib/ast/type_ignore.rs
@@ -13,21 +13,21 @@ impl Node for TypeIgnore {
         }
     }
     fn ast_from_object(
-        _vm: &VirtualMachine,
+        vm: &VirtualMachine,
         source_file: &SourceFile,
-        _object: PyObjectRef,
+        object: PyObjectRef,
     ) -> PyResult<Self> {
-        let _cls = _object.class();
-        Ok(if _cls.is(pyast::NodeTypeIgnoreTypeIgnore::static_type()) {
+        let cls = object.class();
+        Ok(if cls.is(pyast::NodeTypeIgnoreTypeIgnore::static_type()) {
             Self::TypeIgnore(TypeIgnoreTypeIgnore::ast_from_object(
-                _vm,
+                vm,
                 source_file,
-                _object,
+                object,
             )?)
         } else {
-            return Err(_vm.new_type_error(format!(
+            return Err(vm.new_type_error(format!(
                 "expected some sort of type_ignore, but got {}",
-                _object.repr(_vm)?
+                object.repr(vm)?
             )));
         })
     }

--- a/crates/vm/src/stdlib/ast/type_parameters.rs
+++ b/crates/vm/src/stdlib/ast/type_parameters.rs
@@ -7,11 +7,11 @@ impl Node for ast::TypeParams {
     }
 
     fn ast_from_object(
-        _vm: &VirtualMachine,
-        _source_file: &SourceFile,
-        _object: PyObjectRef,
+        vm: &VirtualMachine,
+        source_file: &SourceFile,
+        object: PyObjectRef,
     ) -> PyResult<Self> {
-        let type_params: Vec<ast::TypeParam> = Node::ast_from_object(_vm, _source_file, _object)?;
+        let type_params: Vec<ast::TypeParam> = Node::ast_from_object(vm, source_file, object)?;
         let range = Option::zip(type_params.first(), type_params.last())
             .map(|(first, last)| first.range().cover(last.range()))
             .unwrap_or_default();
@@ -38,33 +38,33 @@ impl Node for ast::TypeParam {
     }
 
     fn ast_from_object(
-        _vm: &VirtualMachine,
+        vm: &VirtualMachine,
         source_file: &SourceFile,
-        _object: PyObjectRef,
+        object: PyObjectRef,
     ) -> PyResult<Self> {
-        let _cls = _object.class();
-        Ok(if _cls.is(pyast::NodeTypeParamTypeVar::static_type()) {
+        let cls = object.class();
+        Ok(if cls.is(pyast::NodeTypeParamTypeVar::static_type()) {
             Self::TypeVar(ast::TypeParamTypeVar::ast_from_object(
-                _vm,
+                vm,
                 source_file,
-                _object,
+                object,
             )?)
-        } else if _cls.is(pyast::NodeTypeParamParamSpec::static_type()) {
+        } else if cls.is(pyast::NodeTypeParamParamSpec::static_type()) {
             Self::ParamSpec(ast::TypeParamParamSpec::ast_from_object(
-                _vm,
+                vm,
                 source_file,
-                _object,
+                object,
             )?)
-        } else if _cls.is(pyast::NodeTypeParamTypeVarTuple::static_type()) {
+        } else if cls.is(pyast::NodeTypeParamTypeVarTuple::static_type()) {
             Self::TypeVarTuple(ast::TypeParamTypeVarTuple::ast_from_object(
-                _vm,
+                vm,
                 source_file,
-                _object,
+                object,
             )?)
         } else {
-            return Err(_vm.new_type_error(format!(
+            return Err(vm.new_type_error(format!(
                 "expected some sort of type_param, but got {}",
-                _object.repr(_vm)?
+                object.repr(vm)?
             )));
         })
     }
@@ -72,150 +72,138 @@ impl Node for ast::TypeParam {
 
 // constructor
 impl Node for ast::TypeParamTypeVar {
-    fn ast_to_object(self, _vm: &VirtualMachine, source_file: &SourceFile) -> PyObjectRef {
+    fn ast_to_object(self, vm: &VirtualMachine, source_file: &SourceFile) -> PyObjectRef {
         let Self {
             node_index: _,
             name,
             bound,
-            range: _range,
+            range,
             default,
         } = self;
         let node = NodeAst
-            .into_ref_with_type(_vm, pyast::NodeTypeParamTypeVar::static_type().to_owned())
+            .into_ref_with_type(vm, pyast::NodeTypeParamTypeVar::static_type().to_owned())
             .unwrap();
         let dict = node.as_object().dict().unwrap();
-        dict.set_item("name", name.ast_to_object(_vm, source_file), _vm)
+        dict.set_item("name", name.ast_to_object(vm, source_file), vm)
             .unwrap();
-        dict.set_item("bound", bound.ast_to_object(_vm, source_file), _vm)
+        dict.set_item("bound", bound.ast_to_object(vm, source_file), vm)
             .unwrap();
-        dict.set_item(
-            "default_value",
-            default.ast_to_object(_vm, source_file),
-            _vm,
-        )
-        .unwrap();
-        node_add_location(&dict, _range, _vm, source_file);
+        dict.set_item("default_value", default.ast_to_object(vm, source_file), vm)
+            .unwrap();
+        node_add_location(&dict, range, vm, source_file);
         node.into()
     }
 
     fn ast_from_object(
-        _vm: &VirtualMachine,
+        vm: &VirtualMachine,
         source_file: &SourceFile,
-        _object: PyObjectRef,
+        object: PyObjectRef,
     ) -> PyResult<Self> {
         Ok(Self {
             node_index: Default::default(),
             name: Node::ast_from_object(
-                _vm,
+                vm,
                 source_file,
-                get_node_field(_vm, &_object, "name", "TypeVar")?,
+                get_node_field(vm, &object, "name", "TypeVar")?,
             )?,
-            bound: get_node_field_opt(_vm, &_object, "bound")?
-                .map(|obj| Node::ast_from_object(_vm, source_file, obj))
+            bound: get_node_field_opt(vm, &object, "bound")?
+                .map(|obj| Node::ast_from_object(vm, source_file, obj))
                 .transpose()?,
             default: Node::ast_from_object(
-                _vm,
+                vm,
                 source_file,
-                get_node_field(_vm, &_object, "default_value", "TypeVar")?,
+                get_node_field(vm, &object, "default_value", "TypeVar")?,
             )?,
-            range: range_from_object(_vm, source_file, _object, "TypeVar")?,
+            range: range_from_object(vm, source_file, object, "TypeVar")?,
         })
     }
 }
 
 // constructor
 impl Node for ast::TypeParamParamSpec {
-    fn ast_to_object(self, _vm: &VirtualMachine, source_file: &SourceFile) -> PyObjectRef {
+    fn ast_to_object(self, vm: &VirtualMachine, source_file: &SourceFile) -> PyObjectRef {
         let Self {
             node_index: _,
             name,
-            range: _range,
+            range,
             default,
         } = self;
         let node = NodeAst
-            .into_ref_with_type(_vm, pyast::NodeTypeParamParamSpec::static_type().to_owned())
+            .into_ref_with_type(vm, pyast::NodeTypeParamParamSpec::static_type().to_owned())
             .unwrap();
         let dict = node.as_object().dict().unwrap();
-        dict.set_item("name", name.ast_to_object(_vm, source_file), _vm)
+        dict.set_item("name", name.ast_to_object(vm, source_file), vm)
             .unwrap();
-        dict.set_item(
-            "default_value",
-            default.ast_to_object(_vm, source_file),
-            _vm,
-        )
-        .unwrap();
-        node_add_location(&dict, _range, _vm, source_file);
+        dict.set_item("default_value", default.ast_to_object(vm, source_file), vm)
+            .unwrap();
+        node_add_location(&dict, range, vm, source_file);
         node.into()
     }
 
     fn ast_from_object(
-        _vm: &VirtualMachine,
+        vm: &VirtualMachine,
         source_file: &SourceFile,
-        _object: PyObjectRef,
+        object: PyObjectRef,
     ) -> PyResult<Self> {
         Ok(Self {
             node_index: Default::default(),
             name: Node::ast_from_object(
-                _vm,
+                vm,
                 source_file,
-                get_node_field(_vm, &_object, "name", "ParamSpec")?,
+                get_node_field(vm, &object, "name", "ParamSpec")?,
             )?,
             default: Node::ast_from_object(
-                _vm,
+                vm,
                 source_file,
-                get_node_field(_vm, &_object, "default_value", "ParamSpec")?,
+                get_node_field(vm, &object, "default_value", "ParamSpec")?,
             )?,
-            range: range_from_object(_vm, source_file, _object, "ParamSpec")?,
+            range: range_from_object(vm, source_file, object, "ParamSpec")?,
         })
     }
 }
 
 // constructor
 impl Node for ast::TypeParamTypeVarTuple {
-    fn ast_to_object(self, _vm: &VirtualMachine, source_file: &SourceFile) -> PyObjectRef {
+    fn ast_to_object(self, vm: &VirtualMachine, source_file: &SourceFile) -> PyObjectRef {
         let Self {
             node_index: _,
             name,
-            range: _range,
+            range,
             default,
         } = self;
         let node = NodeAst
             .into_ref_with_type(
-                _vm,
+                vm,
                 pyast::NodeTypeParamTypeVarTuple::static_type().to_owned(),
             )
             .unwrap();
         let dict = node.as_object().dict().unwrap();
-        dict.set_item("name", name.ast_to_object(_vm, source_file), _vm)
+        dict.set_item("name", name.ast_to_object(vm, source_file), vm)
             .unwrap();
-        dict.set_item(
-            "default_value",
-            default.ast_to_object(_vm, source_file),
-            _vm,
-        )
-        .unwrap();
-        node_add_location(&dict, _range, _vm, source_file);
+        dict.set_item("default_value", default.ast_to_object(vm, source_file), vm)
+            .unwrap();
+        node_add_location(&dict, range, vm, source_file);
         node.into()
     }
 
     fn ast_from_object(
-        _vm: &VirtualMachine,
+        vm: &VirtualMachine,
         source_file: &SourceFile,
-        _object: PyObjectRef,
+        object: PyObjectRef,
     ) -> PyResult<Self> {
         Ok(Self {
             node_index: Default::default(),
             name: Node::ast_from_object(
-                _vm,
+                vm,
                 source_file,
-                get_node_field(_vm, &_object, "name", "TypeVarTuple")?,
+                get_node_field(vm, &object, "name", "TypeVarTuple")?,
             )?,
             default: Node::ast_from_object(
-                _vm,
+                vm,
                 source_file,
-                get_node_field(_vm, &_object, "default_value", "TypeVarTuple")?,
+                get_node_field(vm, &object, "default_value", "TypeVarTuple")?,
             )?,
-            range: range_from_object(_vm, source_file, _object, "TypeVarTuple")?,
+            range: range_from_object(vm, source_file, object, "TypeVarTuple")?,
         })
     }
 }

--- a/crates/vm/src/stdlib/builtins.rs
+++ b/crates/vm/src/stdlib/builtins.rs
@@ -141,7 +141,7 @@ mod builtins {
             {
                 use num_traits::Zero;
                 let flags: i32 = args.flags.map_or(Ok(0), |v| v.try_to_primitive(vm))?;
-                let is_ast_only = !(flags & ast::PY_COMPILE_FLAG_AST_ONLY).is_zero();
+                let is_ast_only = !(flags & ast::PY_CF_ONLY_AST).is_zero();
 
                 // func_type mode requires PyCF_ONLY_AST
                 if mode_str == "func_type" && !is_ast_only {
@@ -218,7 +218,7 @@ mod builtins {
 
                 let optimize_level = optimize;
 
-                if (flags & ast::PY_COMPILE_FLAG_AST_ONLY).is_zero() {
+                if (flags & ast::PY_CF_ONLY_AST).is_zero() {
                     #[cfg(not(feature = "compiler"))]
                     {
                         Err(vm.new_value_error(CODEGEN_NOT_SUPPORTED.to_owned()))


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Performance Improvements**
  * Improved AST node object caching for faster repeated access.

* **Refactor**
  * Consolidated AST node object creation and serialization across implementations for maintainability.
  * Simplified how node metadata is populated: switched to a representation-focused population and removed some automatic attribute/match-args population.

* **Chores**
  * Renamed the compile-time AST-only flag (public API name updated).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->