### PR TITLE
Update `test_{binop,contains}.py` from 3.14.3

### DIFF
--- a/Lib/test/test_binop.py
+++ b/Lib/test/test_binop.py
@@ -383,7 +383,7 @@ class OperationOrderTests(unittest.TestCase):
         self.assertEqual(op_sequence(le, B, C), ['C.__ge__', 'B.__le__'])
         self.assertEqual(op_sequence(le, C, B), ['C.__le__', 'B.__ge__'])
 
-        self.assertTrue(issubclass(V, B))
+        self.assertIsSubclass(V, B)
         self.assertEqual(op_sequence(eq, B, V), ['B.__eq__', 'V.__eq__'])
         self.assertEqual(op_sequence(le, B, V), ['B.__le__', 'V.__ge__'])
 

--- a/Lib/test/test_contains.py
+++ b/Lib/test/test_contains.py
@@ -16,6 +16,7 @@ class seq(base_set):
         return [self.el][n]
 
 class TestContains(unittest.TestCase):
+    @unittest.expectedFailure  # TODO: RUSTPYTHON; Wrong error message
     def test_common_tests(self):
         a = base_set(1)
         b = myset(1)
@@ -24,8 +25,11 @@ class TestContains(unittest.TestCase):
         self.assertNotIn(0, b)
         self.assertIn(1, c)
         self.assertNotIn(0, c)
-        self.assertRaises(TypeError, lambda: 1 in a)
-        self.assertRaises(TypeError, lambda: 1 not in a)
+        msg = "argument of type 'base_set' is not a container or iterable"
+        with self.assertRaisesRegex(TypeError, msg):
+            1 in a
+        with self.assertRaisesRegex(TypeError, msg):
+            1 not in a
 
         # test char in string
         self.assertIn('c', 'abc')


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced error messages when attempting to iterate over non-iterable objects to provide clearer feedback on what types of values can be iterated.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->