### PR TITLE
Make inner oparg values private

### DIFF
--- a/crates/codegen/src/compile.rs
+++ b/crates/codegen/src/compile.rs
@@ -1165,7 +1165,7 @@ impl Compiler {
                 arg: OpArgMarker::marker(),
             }
             .into(),
-            arg: OpArg(u32::from(bytecode::ResumeType::AtFuncStart)),
+            arg: OpArg::new(u32::from(bytecode::ResumeType::AtFuncStart)),
             target: BlockIdx::NULL,
             location,
             end_location,
@@ -7397,7 +7397,7 @@ impl Compiler {
         let return_none = init_collection.is_none();
         // Create empty object of proper type:
         if let Some(init_collection) = init_collection {
-            self._emit(init_collection, OpArg(0), BlockIdx::NULL)
+            self._emit(init_collection, OpArg::new(0), BlockIdx::NULL)
         }
 
         let mut loop_labels = vec![];
@@ -7593,7 +7593,7 @@ impl Compiler {
         // Step 4: Create the collection (list/set/dict)
         // For generator expressions, init_collection is None
         if let Some(init_collection) = init_collection {
-            self._emit(init_collection, OpArg(0), BlockIdx::NULL);
+            self._emit(init_collection, OpArg::new(0), BlockIdx::NULL);
             // SWAP to get iterator on top
             emit!(self, Instruction::Swap { index: 2 });
         }
@@ -7767,7 +7767,7 @@ impl Compiler {
     }
 
     fn emit_no_arg<I: Into<AnyInstruction>>(&mut self, ins: I) {
-        self._emit(ins, OpArg::null(), BlockIdx::NULL)
+        self._emit(ins, OpArg::NULL, BlockIdx::NULL)
     }
 
     fn emit_arg<A: OpArgType, T: EmitArg<A>, I: Into<AnyInstruction>>(
@@ -8455,7 +8455,7 @@ impl EmitArg<bytecode::Label> for BlockIdx {
         self,
         f: impl FnOnce(OpArgMarker<bytecode::Label>) -> I,
     ) -> (AnyInstruction, OpArg, BlockIdx) {
-        (f(OpArgMarker::marker()).into(), OpArg::null(), self)
+        (f(OpArgMarker::marker()).into(), OpArg::NULL, self)
     }
 }
 

--- a/crates/compiler-core/src/bytecode/instruction.rs
+++ b/crates/compiler-core/src/bytecode/instruction.rs
@@ -1249,7 +1249,7 @@ impl<T: OpArgType> Arg<T> {
 
     #[inline]
     pub fn new(arg: T) -> (Self, OpArg) {
-        (Self(PhantomData), OpArg(arg.into()))
+        (Self(PhantomData), OpArg::new(arg.into()))
     }
 
     #[inline]
@@ -1257,7 +1257,7 @@ impl<T: OpArgType> Arg<T> {
     where
         T: Into<u8>,
     {
-        (Self(PhantomData), OpArgByte(arg.into()))
+        (Self(PhantomData), OpArgByte::new(arg.into()))
     }
 
     #[inline(always)]
@@ -1267,7 +1267,7 @@ impl<T: OpArgType> Arg<T> {
 
     #[inline(always)]
     pub fn try_get(self, arg: OpArg) -> Result<T, MarshalError> {
-        T::try_from(arg.0).map_err(|_| MarshalError::InvalidBytecode)
+        T::try_from(u32::from(arg)).map_err(|_| MarshalError::InvalidBytecode)
     }
 
     /// # Safety
@@ -1275,7 +1275,7 @@ impl<T: OpArgType> Arg<T> {
     #[inline(always)]
     pub unsafe fn get_unchecked(self, arg: OpArg) -> T {
         // SAFETY: requirements forwarded from caller
-        unsafe { T::try_from(arg.0).unwrap_unchecked() }
+        unsafe { T::try_from(u32::from(arg)).unwrap_unchecked() }
     }
 }
 

--- a/crates/compiler-core/src/bytecode/oparg.rs
+++ b/crates/compiler-core/src/bytecode/oparg.rs
@@ -12,17 +12,26 @@ pub trait OpArgType: Copy + Into<u32> + TryFrom<u32> {}
 /// Opcode argument that may be extended by a prior ExtendedArg.
 #[derive(Copy, Clone, PartialEq, Eq)]
 #[repr(transparent)]
-pub struct OpArgByte(pub u8);
+pub struct OpArgByte(u8);
 
 impl OpArgByte {
-    pub const fn null() -> Self {
-        Self(0)
+    pub const NULL: Self = Self::new(0);
+
+    #[must_use]
+    pub const fn new(value: u8) -> Self {
+        Self(value)
     }
 }
 
 impl From<u8> for OpArgByte {
     fn from(raw: u8) -> Self {
-        Self(raw)
+        Self::new(raw)
+    }
+}
+
+impl From<OpArgByte> for u8 {
+    fn from(value: OpArgByte) -> Self {
+        value.0
     }
 }
 
@@ -35,11 +44,14 @@ impl fmt::Debug for OpArgByte {
 /// Full 32-bit op_arg, including any possible ExtendedArg extension.
 #[derive(Copy, Clone, Debug)]
 #[repr(transparent)]
-pub struct OpArg(pub u32);
+pub struct OpArg(u32);
 
 impl OpArg {
-    pub const fn null() -> Self {
-        Self(0)
+    pub const NULL: Self = Self::new(0);
+
+    #[must_use]
+    pub const fn new(value: u32) -> Self {
+        Self(value)
     }
 
     /// Returns how many CodeUnits a instruction with this op_arg will be encoded as
@@ -65,7 +77,7 @@ impl OpArg {
 
 impl From<u32> for OpArg {
     fn from(raw: u32) -> Self {
-        Self(raw)
+        Self::new(raw)
     }
 }
 
@@ -94,7 +106,7 @@ impl OpArgState {
     #[inline(always)]
     pub fn extend(&mut self, arg: OpArgByte) -> OpArg {
         self.state = (self.state << 8) | u32::from(arg.0);
-        OpArg(self.state)
+        self.state.into()
     }
 
     #[inline(always)]

--- a/crates/vm/src/frame.rs
+++ b/crates/vm/src/frame.rs
@@ -577,7 +577,7 @@ impl ExecutingFrame<'_> {
                     {
                         // YIELD_VALUE arg: 0 = direct yield, >= 1 = yield-from/await
                         // OpArgByte.0 is the raw byte value
-                        if prev_unit.arg.0 >= 1 {
+                        if u8::from(prev_unit.arg) >= 1 {
                             // In yield-from/await context, delegate is on top of stack
                             return Some(self.top_value());
                         }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Refactor
- Standardized bytecode instruction argument handling and conversion patterns for improved code consistency and maintainability across the compiler's internal architecture.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->