### PR TITLE
`no_std` for doc, replace HashSet in codegen

### DIFF
--- a/crates/codegen/src/compile.rs
+++ b/crates/codegen/src/compile.rs
@@ -23,8 +23,6 @@ use num_complex::Complex;
 use num_traits::{Num, ToPrimitive};
 use ruff_python_ast as ast;
 use ruff_text_size::{Ranged, TextRange, TextSize};
-use std::collections::HashSet;
-
 use rustpython_compiler_core::{
     Mode, OneIndexed, PositionEncoding, SourceFile, SourceLocation,
     bytecode::{
@@ -211,7 +209,7 @@ enum ComprehensionType {
 }
 
 fn validate_duplicate_params(params: &ast::Parameters) -> Result<(), CodegenErrorType> {
-    let mut seen_params = HashSet::new();
+    let mut seen_params = IndexSet::default();
     for param in params {
         let param_name = param.name().as_str();
         if !seen_params.insert(param_name) {
@@ -5530,7 +5528,7 @@ impl Compiler {
         // Step 2: If we have keys to match
         if size > 0 {
             // Validate and compile keys
-            let mut seen = HashSet::new();
+            let mut seen = IndexSet::default();
             for key in keys {
                 let is_attribute = matches!(key, ast::Expr::Attribute(_));
                 let is_literal = matches!(

--- a/crates/codegen/src/symboltable.rs
+++ b/crates/codegen/src/symboltable.rs
@@ -8,7 +8,7 @@ Inspirational file: https://github.com/python/cpython/blob/main/Python/symtable.
 */
 
 use crate::{
-    IndexMap,
+    IndexMap, IndexSet,
     error::{CodegenError, CodegenErrorType},
 };
 use alloc::{borrow::Cow, fmt};
@@ -16,7 +16,6 @@ use bitflags::bitflags;
 use ruff_python_ast as ast;
 use ruff_text_size::{Ranged, TextRange};
 use rustpython_compiler_core::{PositionEncoding, SourceFile, SourceLocation};
-use std::collections::HashSet;
 
 /// Captures all symbols in the current scope, and has a list of sub-scopes in this scope.
 #[derive(Clone)]
@@ -275,21 +274,21 @@ fn analyze_symbol_table(symbol_table: &mut SymbolTable) -> SymbolTableResult {
    `newfree` set (which contains free variables collected from all child scopes)
    and sets the corresponding flags on the class's symbol table entry.
 */
-fn drop_class_free(symbol_table: &mut SymbolTable, newfree: &mut HashSet<String>) {
+fn drop_class_free(symbol_table: &mut SymbolTable, newfree: &mut IndexSet<String>) {
     // Check if __class__ is in the free variables collected from children
     // If found, it means a child scope (method) references __class__
-    if newfree.remove("__class__") {
+    if newfree.shift_remove("__class__") {
         symbol_table.needs_class_closure = true;
     }
 
     // Check if __classdict__ is in the free variables collected from children
-    if newfree.remove("__classdict__") {
+    if newfree.shift_remove("__classdict__") {
         symbol_table.needs_classdict = true;
     }
 
     // Check if __conditional_annotations__ is in the free variables collected from children
     // Remove it from free set - it's handled specially in class scope
-    if newfree.remove("__conditional_annotations__") {
+    if newfree.shift_remove("__conditional_annotations__") {
         symbol_table.has_conditional_annotations = true;
     }
 }
@@ -367,12 +366,12 @@ impl SymbolTableAnalyzer {
         &mut self,
         symbol_table: &mut SymbolTable,
         class_entry: Option<&SymbolMap>,
-    ) -> SymbolTableResult<HashSet<String>> {
+    ) -> SymbolTableResult<IndexSet<String>> {
         let symbols = core::mem::take(&mut symbol_table.symbols);
         let sub_tables = &mut *symbol_table.sub_tables;
 
         // Collect free variables from all child scopes
-        let mut newfree = HashSet::new();
+        let mut newfree = IndexSet::default();
 
         let annotation_block = &mut symbol_table.annotation_block;
 
@@ -1947,7 +1946,7 @@ impl SymbolTableBuilder {
 
     fn scan_type_params(&mut self, type_params: &ast::TypeParams) -> SymbolTableResult {
         // Check for duplicate type parameter names
-        let mut seen_names: std::collections::HashSet<&str> = std::collections::HashSet::new();
+        let mut seen_names: IndexSet<&str> = IndexSet::default();
         for type_param in &type_params.type_params {
             let (name, range) = match type_param {
                 ast::TypeParam::TypeVar(tv) => (tv.name.as_str(), tv.range),

--- a/crates/doc/src/lib.rs
+++ b/crates/doc/src/lib.rs
@@ -1,3 +1,5 @@
+#![no_std]
+
 include!("./data.inc.rs");
 
 #[cfg(test)]


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Improved internal collection handling in code generation and symbol table analysis to preserve insertion order.

* **Chores**
  * Added no_std support for improved compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->