### PR TITLE
Replace unsafe pointer cast with PyMutex in PyCode

### DIFF
--- a/crates/stdlib/src/faulthandler.rs
+++ b/crates/stdlib/src/faulthandler.rs
@@ -252,7 +252,7 @@ mod decl {
     /// Dump a single frame's info to fd (signal-safe), reading live data.
     #[cfg(any(unix, windows))]
     fn dump_frame_from_raw(fd: i32, frame: &Frame) {
-        let filename = frame.code.source_path.as_str();
+        let filename = frame.code.source_path().as_str();
         let funcname = frame.code.obj_name.as_str();
         let lasti = frame.lasti();
         let lineno = if lasti == 0 {
@@ -328,7 +328,7 @@ mod decl {
     #[cfg(any(unix, windows))]
     fn dump_frame_from_ref(fd: i32, frame: &crate::vm::PyRef<Frame>) {
         let funcname = frame.code.obj_name.as_str();
-        let filename = frame.code.source_path.as_str();
+        let filename = frame.code.source_path().as_str();
         let lineno = if frame.lasti() == 0 {
             frame.code.first_line_number.map(|n| n.get()).unwrap_or(1) as u32
         } else {

--- a/crates/vm/src/builtins/traceback.rs
+++ b/crates/vm/src/builtins/traceback.rs
@@ -131,7 +131,7 @@ impl serde::Serialize for PyTraceback {
         let mut struc = s.serialize_struct("PyTraceback", 3)?;
         struc.serialize_field("name", self.frame.code.obj_name.as_str())?;
         struc.serialize_field("lineno", &self.lineno.get())?;
-        struc.serialize_field("filename", self.frame.code.source_path.as_str())?;
+        struc.serialize_field("filename", self.frame.code.source_path().as_str())?;
         struc.end()
     }
 }

--- a/crates/vm/src/exceptions.rs
+++ b/crates/vm/src/exceptions.rs
@@ -383,7 +383,7 @@ fn write_traceback_entry<W: Write>(
     output: &mut W,
     tb_entry: &Py<PyTraceback>,
 ) -> Result<(), W::Error> {
-    let filename = tb_entry.frame.code.source_path.as_str();
+    let filename = tb_entry.frame.code.source_path().as_str();
     writeln!(
         output,
         r##"  File "{}", line {}, in {}"##,

--- a/crates/vm/src/frame.rs
+++ b/crates/vm/src/frame.rs
@@ -3223,7 +3223,7 @@ impl ExecutingFrame<'_> {
                 self.lasti(),
                 self.code.obj_name,
                 op_name,
-                self.code.source_path
+                self.code.source_path()
             );
         }
         self.state.stack.drain(stack_len - count..).map(|obj| {

--- a/crates/vm/src/import.rs
+++ b/crates/vm/src/import.rs
@@ -168,7 +168,7 @@ pub fn import_code_obj(
     if set_file_attr {
         attrs.set_item(
             identifier!(vm, __file__),
-            code_obj.source_path.to_object(),
+            code_obj.source_path().to_object(),
             vm,
         )?;
     }
@@ -195,7 +195,7 @@ fn remove_importlib_frames_inner(
         return (None, false);
     };
 
-    let file_name = traceback.frame.code.source_path.as_str();
+    let file_name = traceback.frame.code.source_path().as_str();
 
     let (inner_tb, mut now_in_importlib) =
         remove_importlib_frames_inner(vm, traceback.next.lock().clone(), always_trim);

--- a/crates/vm/src/stdlib/io.rs
+++ b/crates/vm/src/stdlib/io.rs
@@ -4971,7 +4971,7 @@ mod _io {
                     && let Some(frame) = vm.current_frame()
                     && let Some(stdlib_dir) = vm.state.config.paths.stdlib_dir.as_deref()
                 {
-                    let path = frame.code.source_path.as_str();
+                    let path = frame.code.source_path().as_str();
                     if !path.starts_with(stdlib_dir) {
                         stacklevel = stacklevel.saturating_sub(1);
                     }

--- a/crates/vm/src/vm/context.rs
+++ b/crates/vm/src/vm/context.rs
@@ -658,7 +658,7 @@ impl Context {
 
     pub fn new_code(&self, code: impl code::IntoCodeObject) -> PyRef<PyCode> {
         let code = code.into_code_object(self);
-        PyRef::new_ref(PyCode { code }, self.types.code_type.to_owned(), None)
+        PyRef::new_ref(PyCode::new(code), self.types.code_type.to_owned(), None)
     }
 }
 

--- a/crates/vm/src/warn.rs
+++ b/crates/vm/src/warn.rs
@@ -578,7 +578,7 @@ fn setup_context(
     }
 
     let (globals, filename, lineno) = if let Some(f) = f {
-        (f.globals.clone(), f.code.source_path, f.f_lineno())
+        (f.globals.clone(), f.code.source_path(), f.f_lineno())
     } else if let Some(frame) = vm.current_frame() {
         // We have a frame but it wasn't found during stack walking
         (frame.globals.clone(), vm.ctx.intern_str("<sys>"), 1)


### PR DESCRIPTION
Add `source_path: PyMutex<&'static PyStrInterned>` field to `PyCode` for interior mutability, replacing the UB-inducing `#[allow(invalid_reference_casting)]` + `write_volatile` pattern in `update_code_filenames`. Update all 12 read sites across the codebase to use the new `source_path()` method.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Improved thread-safety and safer handling of code object source paths across the runtime by replacing direct internal field access and in-place mutations with controlled accessors and setters, reducing unsafe mutations and standardizing path retrieval in traceback, import, and warning/reporting flows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->