### PR TITLE
Use CRT functions for time module on Windows

### DIFF
--- a/Lib/test/datetimetester.py
+++ b/Lib/test/datetimetester.py
@@ -1519,7 +1519,6 @@ class TestDate(HarmlessMixedComparison, unittest.TestCase):
         # bpo-41260: The parameter was named "fmt" in the pure python impl.
         t.strftime(format="%f")
 
-    @unittest.expectedFailureIf(sys.platform == "win32", "TODO: RUSTPYTHON; chrono fallback on Windows")
     def test_strftime_trailing_percent(self):
         # bpo-35066: Make sure trailing '%' doesn't cause datetime's strftime to
         # complain. Different libcs have different handling of trailing

--- a/Lib/test/test_strftime.py
+++ b/Lib/test/test_strftime.py
@@ -39,7 +39,21 @@ class StrftimeTest(unittest.TestCase):
         if now[3] < 12: self.ampm='(AM|am)'
         else: self.ampm='(PM|pm)'
 
-        self.jan1 = time.localtime(time.mktime((now[0], 1, 1, 0, 0, 0, 0, 1, 0)))
+        jan1 = time.struct_time(
+            (
+                now.tm_year,  # Year
+                1,  # Month (January)
+                1,  # Day (1st)
+                0,  # Hour (0)
+                0,  # Minute (0)
+                0,  # Second (0)
+                -1,  # tm_wday (will be determined)
+                1,  # tm_yday (day 1 of the year)
+                -1,  # tm_isdst (let the system determine)
+            )
+        )
+        # use mktime to get the correct tm_wday and tm_isdst values
+        self.jan1 = time.localtime(time.mktime(jan1))
 
         try:
             if now[8]: self.tz = time.tzname[1]
@@ -54,14 +68,10 @@ class StrftimeTest(unittest.TestCase):
         self.now = now
 
     def setUp(self):
-        try:
-            import java
-            java.util.Locale.setDefault(java.util.Locale.US)
-        except ImportError:
-            from locale import setlocale, LC_TIME
-            saved_locale = setlocale(LC_TIME)
-            setlocale(LC_TIME, 'C')
-            self.addCleanup(setlocale, LC_TIME, saved_locale)
+        from locale import setlocale, LC_TIME
+        saved_locale = setlocale(LC_TIME)
+        setlocale(LC_TIME, 'C')
+        self.addCleanup(setlocale, LC_TIME, saved_locale)
 
     def test_strftime(self):
         now = time.time()
@@ -187,8 +197,7 @@ class Y1900Tests(unittest.TestCase):
     def test_y_before_1900(self):
         # Issue #13674, #19634
         t = (1899, 1, 1, 0, 0, 0, 0, 0, 0)
-        if (sys.platform == "win32"
-        or sys.platform.startswith(("aix", "sunos", "solaris"))):
+        if sys.platform.startswith(("aix", "sunos", "solaris")):
             with self.assertRaises(ValueError):
                 time.strftime("%y", t)
         else:

--- a/Lib/test/test_time.py
+++ b/Lib/test/test_time.py
@@ -208,8 +208,6 @@ class TimeTestCase(unittest.TestCase):
                     except ValueError as exc:
                         self.assertEqual(str(exc), 'Invalid format string')
 
-    # TODO: RUSTPYTHON; chrono fallback on Windows does not preserve surrogates
-    @unittest.expectedFailureIf(sys.platform == "win32", "TODO: RUSTPYTHON")
     def test_strftime_special(self):
         tt = time.gmtime(self.t)
         s1 = time.strftime('%c', tt)
@@ -294,8 +292,6 @@ class TimeTestCase(unittest.TestCase):
         self.assertRaises(ValueError, func,
                             (1900, 1, 1, 0, 0, 0, 0, 367, -1))
 
-    # TODO: RUSTPYTHON; chrono on Windows rejects month=0/day=0 and raises wrong error type
-    @unittest.expectedFailureIf(sys.platform == "win32", "TODO: RUSTPYTHON")
     def test_strftime_bounding_check(self):
         self._bounds_checking(lambda tup: time.strftime('', tup))
 
@@ -312,8 +308,6 @@ class TimeTestCase(unittest.TestCase):
                     except ValueError:
                         pass
 
-    # TODO: RUSTPYTHON; chrono on Windows does not handle month=0/day=0 in struct_time
-    @unittest.expectedFailureIf(sys.platform == "win32", "TODO: RUSTPYTHON")
     def test_default_values_for_zero(self):
         # Make sure that using all zeros uses the proper default
         # values.  No test for daylight savings since strftime() does
@@ -324,8 +318,6 @@ class TimeTestCase(unittest.TestCase):
             result = time.strftime("%Y %m %d %H %M %S %w %j", (2000,)+(0,)*8)
         self.assertEqual(expected, result)
 
-    # TODO: RUSTPYTHON; chrono %Z on Windows not compatible with strptime
-    @unittest.expectedFailureIf(sys.platform == "win32", "TODO: RUSTPYTHON")
     @skip_if_buggy_ucrt_strfptime
     def test_strptime(self):
         # Should be able to go round-trip from strftime to strptime without
@@ -382,13 +374,9 @@ class TimeTestCase(unittest.TestCase):
         self.assertRaises(TypeError, time.asctime, ())
         self.assertRaises(TypeError, time.asctime, (0,) * 10)
 
-    # TODO: RUSTPYTHON; chrono on Windows rejects month=0/day=0
-    @unittest.expectedFailureIf(sys.platform == "win32", "TODO: RUSTPYTHON")
     def test_asctime_bounding_check(self):
         self._bounds_checking(time.asctime)
 
-    # TODO: RUSTPYTHON; chrono on Windows formats negative years differently
-    @unittest.expectedFailureIf(sys.platform == "win32", "TODO: RUSTPYTHON")
     def test_ctime(self):
         t = time.mktime((1973, 9, 16, 1, 3, 52, 0, 0, -1))
         self.assertEqual(time.ctime(t), 'Sun Sep 16 01:03:52 1973')
@@ -761,37 +749,13 @@ class _Test4dYear:
 
 
 class TestAsctime4dyear(_TestAsctimeYear, _Test4dYear, unittest.TestCase):
-    # TODO: RUSTPYTHON; chrono on Windows cannot handle month=0/day=0 in struct_time
-    @unittest.expectedFailureIf(sys.platform == "win32", "TODO: RUSTPYTHON")
-    def test_year(self, *args, **kwargs):
-        return super().test_year(*args, **kwargs)
-
-    @unittest.expectedFailureIf(sys.platform == "win32", "TODO: RUSTPYTHON")
-    def test_large_year(self):
-        return super().test_large_year()
-
-    @unittest.expectedFailureIf(sys.platform == "win32", "TODO: RUSTPYTHON")
-    def test_negative(self):
-        return super().test_negative()
+    pass
 
 class TestStrftime4dyear(_TestStrftimeYear, _Test4dYear, unittest.TestCase):
-    # TODO: RUSTPYTHON; chrono on Windows cannot handle month=0/day=0 in struct_time
-    @unittest.expectedFailureIf(sys.platform == "win32", "TODO: RUSTPYTHON")
-    def test_year(self, *args, **kwargs):
-        return super().test_year(*args, **kwargs)
-
-    @unittest.expectedFailureIf(sys.platform == "win32", "TODO: RUSTPYTHON")
-    def test_large_year(self):
-        return super().test_large_year()
-
-    @unittest.expectedFailureIf(sys.platform == "win32", "TODO: RUSTPYTHON")
-    def test_negative(self):
-        return super().test_negative()
+    pass
 
 
 class TestPytime(unittest.TestCase):
-    # TODO: RUSTPYTHON; chrono %Z on Windows gives offset instead of timezone name
-    @unittest.expectedFailureIf(sys.platform == "win32", "TODO: RUSTPYTHON")
     @skip_if_buggy_ucrt_strfptime
     @unittest.skipUnless(time._STRUCT_TM_ITEMS == 11, "needs tm_zone support")
     def test_localtime_timezone(self):


### PR DESCRIPTION
- Replace chrono with CRT functions (wcsftime, _gmtime64_s, _localtime64_s, _mktime64) on Windows for correct behavior
- Fix timezone name corruption: use take_while instead of filter for null-terminated wide strings in TIME_ZONE_INFORMATION
- Fix wcsftime symbol name (_wcsftime -> wcsftime)
- Fix CString import cfg to unix-only
- Remove 13 expectedFailure markers from test_time for Windows

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Unified time/timezone handling across Unix, Windows, and other targets; centralized mktime/gmtime/localtime/struct_time conversion and formatting for consistent cross-platform behavior.

* **Bug Fixes**
  * More robust timezone name extraction and safer local/UTC conversions.
  * Improved strftime/strptime with OS-specific validation, proper wide/ASCII handling on Windows, and preserved non-Unix/non-Windows fallbacks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->