### PR TITLE
raise TypeError when `__iter__` method is `None`

### DIFF
--- a/Lib/test/test_typing.py
+++ b/Lib/test/test_typing.py
@@ -10916,7 +10916,6 @@ class TypeIterationTests(BaseTestCase):
         Annotated[T, ''],
     )
 
-    @unittest.expectedFailure  # TODO: RUSTPYTHON
     def test_cannot_iterate(self):
         expected_error_regex = "object is not iterable"
         for test_type in self._UNITERABLE_TYPES:


### PR DESCRIPTION
Setting special `__iter__` method to `None` is used to mark objects as non-iterable.

https://docs.python.org/3/reference/datamodel.html#special-method-names

Check if `__iter__` is set to `None` and raise TypeError exception.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced error reporting for iteration operations with clearer, more precise error messages when attempting to iterate over non-iterable objects
  * Improved exception handling to distinguish between different iteration failure scenarios

<!-- end of auto-generated comment: release notes by coderabbit.ai -->