### PR TITLE
fix miri ci

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -508,7 +508,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 30
     env:
-      NIGHTLY_CHANNEL: nightly
+      NIGHTLY_CHANNEL: nightly-2026-02-11 # https://github.com/rust-lang/miri/issues/4855
     steps:
       - uses: actions/checkout@v6.0.2
 


### PR DESCRIPTION
makes https://github.com/RustPython/RustPython/pull/7092 to fail
 https://github.com/rust-lang/miri/issues/4855

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CI/CD configuration for build testing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->