### PR TITLE
Update `ruff` to 0.15.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2839,7 +2839,7 @@ dependencies = [
 [[package]]
 name = "ruff_python_ast"
 version = "0.0.0"
-source = "git+https://github.com/astral-sh/ruff.git?rev=ce5f7b6127a5d684e96fd0f8e387f73c41c7a1b0#ce5f7b6127a5d684e96fd0f8e387f73c41c7a1b0"
+source = "git+https://github.com/astral-sh/ruff.git?rev=a2f11d239f91cf8daedb0764ec15fcfe29c5ae6d#a2f11d239f91cf8daedb0764ec15fcfe29c5ae6d"
 dependencies = [
  "aho-corasick",
  "bitflags 2.10.0",
@@ -2857,7 +2857,7 @@ dependencies = [
 [[package]]
 name = "ruff_python_parser"
 version = "0.0.0"
-source = "git+https://github.com/astral-sh/ruff.git?rev=ce5f7b6127a5d684e96fd0f8e387f73c41c7a1b0#ce5f7b6127a5d684e96fd0f8e387f73c41c7a1b0"
+source = "git+https://github.com/astral-sh/ruff.git?rev=a2f11d239f91cf8daedb0764ec15fcfe29c5ae6d#a2f11d239f91cf8daedb0764ec15fcfe29c5ae6d"
 dependencies = [
  "bitflags 2.10.0",
  "bstr",
@@ -2877,7 +2877,7 @@ dependencies = [
 [[package]]
 name = "ruff_python_trivia"
 version = "0.0.0"
-source = "git+https://github.com/astral-sh/ruff.git?rev=ce5f7b6127a5d684e96fd0f8e387f73c41c7a1b0#ce5f7b6127a5d684e96fd0f8e387f73c41c7a1b0"
+source = "git+https://github.com/astral-sh/ruff.git?rev=a2f11d239f91cf8daedb0764ec15fcfe29c5ae6d#a2f11d239f91cf8daedb0764ec15fcfe29c5ae6d"
 dependencies = [
  "itertools 0.14.0",
  "ruff_source_file",
@@ -2888,7 +2888,7 @@ dependencies = [
 [[package]]
 name = "ruff_source_file"
 version = "0.0.0"
-source = "git+https://github.com/astral-sh/ruff.git?rev=ce5f7b6127a5d684e96fd0f8e387f73c41c7a1b0#ce5f7b6127a5d684e96fd0f8e387f73c41c7a1b0"
+source = "git+https://github.com/astral-sh/ruff.git?rev=a2f11d239f91cf8daedb0764ec15fcfe29c5ae6d#a2f11d239f91cf8daedb0764ec15fcfe29c5ae6d"
 dependencies = [
  "memchr",
  "ruff_text_size",
@@ -2897,7 +2897,7 @@ dependencies = [
 [[package]]
 name = "ruff_text_size"
 version = "0.0.0"
-source = "git+https://github.com/astral-sh/ruff.git?rev=ce5f7b6127a5d684e96fd0f8e387f73c41c7a1b0#ce5f7b6127a5d684e96fd0f8e387f73c41c7a1b0"
+source = "git+https://github.com/astral-sh/ruff.git?rev=a2f11d239f91cf8daedb0764ec15fcfe29c5ae6d#a2f11d239f91cf8daedb0764ec15fcfe29c5ae6d"
 dependencies = [
  "get-size2",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -144,12 +144,12 @@ rustpython-sre_engine = { path = "crates/sre_engine", version = "0.4.0" }
 rustpython-wtf8 = { path = "crates/wtf8", version = "0.4.0" }
 rustpython-doc = { path = "crates/doc", version = "0.4.0" }
 
-# Ruff tag 0.15.0 is based on commit ce5f7b6127a5d684e96fd0f8e387f73c41c7a1b0
+# Ruff tag 0.15.1 is based on commit a2f11d239f91cf8daedb0764ec15fcfe29c5ae6d
 # at the time of this capture. We use the commit hash to ensure reproducible builds.
-ruff_python_parser = { git = "https://github.com/astral-sh/ruff.git", rev = "ce5f7b6127a5d684e96fd0f8e387f73c41c7a1b0" }
-ruff_python_ast = { git = "https://github.com/astral-sh/ruff.git", rev = "ce5f7b6127a5d684e96fd0f8e387f73c41c7a1b0" }
-ruff_text_size = { git = "https://github.com/astral-sh/ruff.git", rev = "ce5f7b6127a5d684e96fd0f8e387f73c41c7a1b0" }
-ruff_source_file = { git = "https://github.com/astral-sh/ruff.git", rev = "ce5f7b6127a5d684e96fd0f8e387f73c41c7a1b0" }
+ruff_python_parser = { git = "https://github.com/astral-sh/ruff.git", rev = "a2f11d239f91cf8daedb0764ec15fcfe29c5ae6d" }
+ruff_python_ast = { git = "https://github.com/astral-sh/ruff.git", rev = "a2f11d239f91cf8daedb0764ec15fcfe29c5ae6d" }
+ruff_text_size = { git = "https://github.com/astral-sh/ruff.git", rev = "a2f11d239f91cf8daedb0764ec15fcfe29c5ae6d" }
+ruff_source_file = { git = "https://github.com/astral-sh/ruff.git", rev = "a2f11d239f91cf8daedb0764ec15fcfe29c5ae6d" }
 
 phf = { version = "0.13.1", default-features = false, features = ["macros"]}
 ahash = "0.8.12"


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated parsing-related dependencies to version 0.15.1 for improved stability and performance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->