### PR TITLE
Add `float.from_number` classmethod

### DIFF
--- a/Lib/test/test_float.py
+++ b/Lib/test/test_float.py
@@ -287,7 +287,6 @@ class GeneralFloatCases(unittest.TestCase):
         self.assertEqual(actual, expected_value)
         self.assertIs(type(actual), expected_type)
 
-    @unittest.expectedFailure  # TODO: RUSTPYTHON; AttributeError: type object 'float' has no attribute 'from_number'
     def test_from_number(self, cls=float):
         def eq(actual, expected):
             self.assertEqual(actual, expected)
@@ -312,7 +311,6 @@ class GeneralFloatCases(unittest.TestCase):
         self.assertRaises(TypeError, cls.from_number, {})
         self.assertRaises(TypeError, cls.from_number)
 
-    @unittest.expectedFailure  # TODO: RUSTPYTHON; AttributeError: type object 'FloatSubclass' has no attribute 'from_number'
     def test_from_number_subclass(self):
         self.test_from_number(FloatSubclass)
 

--- a/crates/vm/src/builtins/float.rs
+++ b/crates/vm/src/builtins/float.rs
@@ -325,6 +325,21 @@ impl PyFloat {
     }
 
     #[pyclassmethod]
+    fn from_number(cls: PyTypeRef, number: PyObjectRef, vm: &VirtualMachine) -> PyResult {
+        if number.class().is(vm.ctx.types.float_type) && cls.is(vm.ctx.types.float_type) {
+            return Ok(number);
+        }
+
+        let value = number.try_float(vm)?.to_f64();
+        let result = vm.ctx.new_float(value);
+        if cls.is(vm.ctx.types.float_type) {
+            Ok(result.into())
+        } else {
+            PyType::call(&cls, vec![result.into()].into(), vm)
+        }
+    }
+
+    #[pyclassmethod]
     fn fromhex(cls: PyTypeRef, string: PyStrRef, vm: &VirtualMachine) -> PyResult {
         let result = crate::literal::float::from_hex(string.as_str().trim())
             .ok_or_else(|| vm.new_value_error("invalid hexadecimal floating-point string"))?;


### PR DESCRIPTION
~~#7106 PR should be merged first.~~

The `float.from_number` was added in v3.14

https://docs.python.org/ko/3/library/stdtypes.html#float.from_number

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced float instantiation capabilities with improved numeric object conversion and better support for float subclass operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->