### PR TITLE
Fix `object.__init__` excess-arg checks for heap types

### DIFF
--- a/Lib/test/test_class.py
+++ b/Lib/test/test_class.py
@@ -741,7 +741,6 @@ class ClassTests(unittest.TestCase):
         with self.assertRaisesRegex(AttributeError, error_msg):
             del B().z
 
-    @unittest.expectedFailure  # TODO: RUSTPYTHON
     def testConstructorErrorMessages(self):
         # bpo-31506: Improves the error message logic for object_new & object_init
 

--- a/Lib/test/test_descr.py
+++ b/Lib/test/test_descr.py
@@ -1853,7 +1853,6 @@ class ClassPropertiesAndMethods(unittest.TestCase):
             __new__ = object.__new__
         self.assertRaises(TypeError, C)
 
-    @unittest.expectedFailure  # TODO: RUSTPYTHON
     def test_object_new(self):
         class A(object):
             pass

--- a/crates/vm/src/builtins/object.rs
+++ b/crates/vm/src/builtins/object.rs
@@ -138,11 +138,12 @@ impl Initializer for PyBaseObject {
             ));
         }
 
-        let typ_new = typ.slots.new.load().map(|f| f as usize);
-        let object_new = object_type.slots.new.load().map(|f| f as usize);
-
         // if (type->tp_new == object_new) → second error
-        if typ_new == object_new {
+        if let (Some(typ_new), Some(object_new)) = (
+            typ.get_attr(identifier!(vm, __new__)),
+            object_type.get_attr(identifier!(vm, __new__)),
+        ) && typ_new.is(&object_new)
+        {
             return Err(vm.new_type_error(format!(
                 "{}.__init__() takes exactly one argument (the instance to initialize)",
                 typ.name()


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Internal improvements to how object type initialization is evaluated. No user-visible changes or behavioral impact.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->