### PR TITLE
Make HASH/HASHXOF types immutable

### DIFF
--- a/Lib/test/test_hashlib.py
+++ b/Lib/test/test_hashlib.py
@@ -994,8 +994,6 @@ class HashLibTestCase(unittest.TestCase):
         support.check_disallow_instantiation(self, HASH)
         support.check_disallow_instantiation(self, HASHXOF)
 
-    # TODO: RUSTPYTHON
-    @unittest.expectedFailure
     def test_readonly_types(self):
         for algorithm, constructors in self.constructors_to_test.items():
             # all other types have DISALLOW_INSTANTIATION

--- a/crates/stdlib/src/hashlib.rs
+++ b/crates/stdlib/src/hashlib.rs
@@ -103,7 +103,7 @@ pub mod _hashlib {
         }
     }
 
-    #[pyclass(with(Representable))]
+    #[pyclass(with(Representable), flags(IMMUTABLETYPE))]
     impl PyHasher {
         fn new(name: &str, d: HashWrapper) -> Self {
             Self {
@@ -176,7 +176,7 @@ pub mod _hashlib {
         }
     }
 
-    #[pyclass]
+    #[pyclass(flags(IMMUTABLETYPE))]
     impl PyHasherXof {
         fn new(name: &str, d: HashXofWrapper) -> Self {
             Self {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved type safety for hash operations by marking core hash-related types as immutable, ensuring data integrity and preventing unintended modifications.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->