### PR TITLE
Add SHA3 private attribute parity to hashlib hash objects

### DIFF
--- a/Lib/test/test_hashlib.py
+++ b/Lib/test/test_hashlib.py
@@ -487,8 +487,6 @@ class HashLibTestCase(unittest.TestCase):
             self.assertEqual(m._rate_bits, rate)
             self.assertEqual(m._suffix, suffix)
 
-    # TODO: RUSTPYTHON
-    @unittest.expectedFailure
     @requires_sha3
     def test_extra_sha3(self):
         self.check_sha3('sha3_224', 448, 1152, b'\x06')


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * HASH and HASHXOF objects now expose additional metadata properties: capacity bits, rate bits, and suffix information for Keccak-based hash algorithms.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->