### PR TITLE
Match SymbolTable repr with CPython format

### DIFF
--- a/Lib/test/test_symtable.py
+++ b/Lib/test/test_symtable.py
@@ -543,7 +543,6 @@ class SymtableTest(unittest.TestCase):
         self.assertEqual(repr(class_A.lookup('x')),
                          "<symbol 'x': LOCAL, DEF_LOCAL|DEF_FREE_CLASS>")
 
-    @unittest.expectedFailure  # TODO: RUSTPYTHON
     def test_symtable_entry_repr(self):
         expected = f"<symtable entry top({self.top.get_id()}), line {self.top.get_lineno()}>"
         self.assertEqual(repr(self.top._table), expected)

--- a/crates/vm/src/stdlib/symtable.rs
+++ b/crates/vm/src/stdlib/symtable.rs
@@ -3,9 +3,10 @@ pub(crate) use _symtable::module_def;
 #[pymodule]
 mod _symtable {
     use crate::{
-        PyObjectRef, PyPayload, PyRef, PyResult, VirtualMachine,
+        Py, PyObjectRef, PyPayload, PyRef, PyResult, VirtualMachine,
         builtins::{PyDictRef, PyStrRef},
         compiler,
+        types::Representable,
     };
     use alloc::fmt;
     use rustpython_codegen::symboltable::{
@@ -132,7 +133,7 @@ mod _symtable {
     }
 
     #[pyattr]
-    #[pyclass(name = "SymbolTable")]
+    #[pyclass(name = "symtable entry")]
     #[derive(PyPayload)]
     struct PySymbolTable {
         symtable: SymbolTable,
@@ -144,7 +145,7 @@ mod _symtable {
         }
     }
 
-    #[pyclass]
+    #[pyclass(with(Representable))]
     impl PySymbolTable {
         #[pygetset]
         fn name(&self) -> String {
@@ -207,6 +208,19 @@ mod _symtable {
         #[pygetset]
         const fn nested(&self) -> bool {
             self.symtable.is_nested
+        }
+    }
+
+    impl Representable for PySymbolTable {
+        #[inline]
+        fn repr_str(zelf: &Py<Self>, vm: &VirtualMachine) -> PyResult<String> {
+            Ok(format!(
+                "<{} {}({}), line {}>",
+                Self::class(&vm.ctx).name(),
+                zelf.symtable.name,
+                zelf.id(),
+                zelf.symtable.line_number
+            ))
         }
     }
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Symbol table objects now display with detailed information (table name, object ID, and line number) when printed in the Python REPL or error messages.
  * Updated symbol table class identifier for clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->