### PR TITLE
Require exact n_sequence_fields length in TryFromObject

### DIFF
--- a/Lib/test/test_time.py
+++ b/Lib/test/test_time.py
@@ -357,8 +357,6 @@ class TimeTestCase(unittest.TestCase):
                                    r'.*day of month without a year.*'):
             time.strptime('02-07 18:28', '%m-%d %H:%M')
 
-    # TODO: RUSTPYTHON; chrono on Windows cannot handle month=0/big years
-    @unittest.expectedFailureIf(sys.platform == "win32", "TODO: RUSTPYTHON")
     def test_asctime(self):
         time.asctime(time.gmtime(self.t))
 

--- a/crates/derive-impl/src/pystructseq.rs
+++ b/crates/derive-impl/src/pystructseq.rs
@@ -299,11 +299,12 @@ pub(crate) fn impl_pystruct_sequence_data(
                     obj: ::rustpython_vm::PyObjectRef,
                 ) -> ::rustpython_vm::PyResult<Self> {
                     let seq: Vec<::rustpython_vm::PyObjectRef> = obj.try_into_value(vm)?;
-                    if seq.len() < #n_required {
+                    if seq.len() != #n_required {
                         return Err(vm.new_type_error(format!(
-                            "{} requires at least {} elements",
+                            "{} requires a {}-sequence ({}-sequence given)",
                             stringify!(#data_ident),
-                            #n_required
+                            #n_required,
+                            seq.len()
                         )));
                     }
                     <Self as ::rustpython_vm::types::PyStructSequenceData>::try_from_elements(seq, vm)


### PR DESCRIPTION
Unmark test_asctime expectedFailure for Windows.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved struct sequence validation to enforce exact element count rather than minimum threshold, preventing invalid sequences from being accepted.
  * Enhanced error messages to display the actual number of elements provided, making validation failures more informative.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->