### PR TITLE
Remove Windows skip from test_configparser test_parse_errors

### DIFF
--- a/Lib/test/test_configparser.py
+++ b/Lib/test/test_configparser.py
@@ -526,7 +526,6 @@ boolean {0[0]} NO
             cf.get(self.default_section, "Foo"), "Bar",
             "could not locate option, expecting case-insensitive defaults")
 
-    @unittest.skipIf(os.name == "nt", "TODO: RUSTPYTHON; universal newlines")
     def test_parse_errors(self):
         cf = self.newconfig()
         self.parse_error(cf, configparser.ParsingError,


### PR DESCRIPTION
The universal newlines issue has been resolved.
All 13 test_parse_errors variants now pass on Windows.