### PR TITLE
Add `_lzma.CHECK_ID_MAX` and remove duplicate `_os.{SEEK_CUR,SEEK_END}`

### DIFF
--- a/Lib/test/test___all__.py
+++ b/Lib/test/test___all__.py
@@ -97,7 +97,6 @@ class AllTest(unittest.TestCase):
                 continue
             yield path, modpath + modname
 
-    @unittest.expectedFailure  # TODO: RUSTPYTHON
     def test_all(self):
         # List of denied modules and packages
         denylist = set([

--- a/Lib/test/test_lzma.py
+++ b/Lib/test/test_lzma.py
@@ -1553,7 +1553,6 @@ class OpenTestCase(unittest.TestCase):
 
 class MiscellaneousTestCase(unittest.TestCase):
 
-    @unittest.expectedFailure  # TODO: RUSTPYTHON; AttributeError: module 'lzma' has no attribute 'CHECK_ID_MAX'
     def test_is_check_supported(self):
         # CHECK_NONE and CHECK_CRC32 should always be supported,
         # regardless of the options liblzma was compiled with.

--- a/crates/stdlib/src/lzma.rs
+++ b/crates/stdlib/src/lzma.rs
@@ -51,7 +51,9 @@ mod _lzma {
     #[pyattr]
     const FILTER_DELTA: i32 = 3;
     #[pyattr]
-    const CHECK_UNKNOWN: i32 = 16;
+    const CHECK_ID_MAX: i32 = 15;
+    #[pyattr]
+    const CHECK_UNKNOWN: i32 = CHECK_ID_MAX + 1;
 
     // the variant ids are hardcoded to be equivalent to the C enum values
     enum Format {

--- a/crates/vm/src/stdlib/os.rs
+++ b/crates/vm/src/stdlib/os.rs
@@ -188,10 +188,7 @@ pub(super) mod _os {
     pub(crate) const SYMLINK_DIR_FD: bool = cfg!(not(any(windows, target_os = "redox")));
 
     #[pyattr]
-    use libc::{
-        O_APPEND, O_CREAT, O_EXCL, O_RDONLY, O_RDWR, O_TRUNC, O_WRONLY, SEEK_CUR, SEEK_END,
-        SEEK_SET,
-    };
+    use libc::{O_APPEND, O_CREAT, O_EXCL, O_RDONLY, O_RDWR, O_TRUNC, O_WRONLY};
 
     #[pyattr]
     pub(crate) const F_OK: u8 = 0;


### PR DESCRIPTION
This pull request ensures that the tests checking whether each module correctly defines `__all__` now pass.

First, I resolved an issue in the `Lib/os.py` module where `SEEK_CUR` and `SEEK_END` were being defined and used while also being provided by `_os`.

Additionally, I defined `CHECK_ID_MAX`, which was previously undefined in `_lzma`. I also updated `CHECK_UNKNOWN` to use the value `CHECK_ID_MAX + 1`, consistent with the CPython implementation.

``` c
#define LZMA_CHECK_UNKNOWN (LZMA_CHECK_ID_MAX + 1)
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Reorganized constant definitions for improved code maintainability.
  * Optimized standard library imports to streamline internal dependencies.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->