### PR TITLE
Emit deprecation warning for array typecode u

### DIFF
--- a/Lib/test/test_array.py
+++ b/Lib/test/test_array.py
@@ -1255,7 +1255,6 @@ class UnicodeTest(StringTest, unittest.TestCase):
         self.assertRaises(ValueError, a.tounicode)
         self.assertRaises(ValueError, str, a)
 
-    @unittest.expectedFailure  # TODO: RUSTPYTHON; AssertionError: DeprecationWarning not triggered
     def test_typecode_u_deprecation(self):
         with self.assertWarns(DeprecationWarning):
             array.array("u")

--- a/crates/stdlib/src/array.rs
+++ b/crates/stdlib/src/array.rs
@@ -35,6 +35,7 @@ mod array {
                 SaturatedSlice, SequenceIndex, SequenceIndexOp, SliceableSequenceMutOp,
                 SliceableSequenceOp,
             },
+            stdlib::warnings,
             types::{
                 AsBuffer, AsMapping, AsSequence, Comparable, Constructor, IterNext, Iterable,
                 PyComparisonOp, Representable, SelfIter,
@@ -643,6 +644,15 @@ mod array {
 
             if cls.is(Self::class(&vm.ctx)) && !kwargs.is_empty() {
                 return Err(vm.new_type_error("array.array() takes no keyword arguments"));
+            }
+
+            if spec == 'u' {
+                warnings::warn(
+                    vm.ctx.exceptions.deprecation_warning,
+                    "The 'u' type code is deprecated and will be removed in Python 3.16".to_owned(),
+                    1,
+                    vm,
+                )?;
             }
 
             let mut array =


### PR DESCRIPTION
### Background
`test.test_array.UnicodeTest.test_typecode_u_deprecation` was failing because RustPython did not emit a `DeprecationWarning` when creating `array.array("u")`. The failure text was `AssertionError: DeprecationWarning not triggered`, and the failing test code location is `/Users/moreal/github/RustPython/RustPython/Lib/test/test_array.py:1259`.

### CPython behavior
CPython expects `array.array("u")` to trigger a deprecation warning in this test method.

```python
    def test_typecode_u_deprecation(self):
        with self.assertWarns(DeprecationWarning):
            array.array("u")
```

Related CPython C implementation also emits the warning for typecode `'u'` in array construction.

```c
    if (c == 'u') {
        if (PyErr_WarnEx(PyExc_DeprecationWarning,
                         "The 'u' type code is deprecated and "
                         "will be removed in Python 3.16",
                         1)) {
            return NULL;
        }
    }
```

GitHub reference (test): https://github.com/python/cpython/blob/v3.14.3/Lib/test/test_array.py#L1255-L1257
GitHub reference (C impl): https://github.com/python/cpython/blob/v3.14.3/Modules/arraymodule.c#L2798-L2805

### Changes
RustPython now emits `DeprecationWarning` in `array` constructor when typecode is `'u'`, and the single `@unittest.expectedFailure` marker was removed after the test passed.

```diff
diff --git a/crates/stdlib/src/array.rs b/crates/stdlib/src/array.rs
@@
-            let mut array =
+            if spec == 'u' {
+                warnings::warn(
+                    vm.ctx.exceptions.deprecation_warning,
+                    "The 'u' type code is deprecated and will be removed in Python 3.16".to_owned(),
+                    1,
+                    vm,
+                )?;
+            }
+
+            let mut array =
                 ArrayContentType::from_char(spec).map_err(|err| vm.new_value_error(err))?;
diff --git a/Lib/test/test_array.py b/Lib/test/test_array.py
@@
-    @unittest.expectedFailure  # TODO: RUSTPYTHON; AssertionError: DeprecationWarning not triggered
     def test_typecode_u_deprecation(self):
         with self.assertWarns(DeprecationWarning):
             array.array("u")
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added deprecation warning when using the 'u' type code in array construction. This type code will be removed in Python 3.16.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->