### PR TITLE
Use _print_exception_bltin in excepthook, register source in linecache

### DIFF
--- a/.cspell.dict/cpython.txt
+++ b/.cspell.dict/cpython.txt
@@ -11,6 +11,7 @@ badsyntax
 baseinfo
 basetype
 binop
+bltin
 boolop
 BUFMAX
 BUILDSTDLIB

--- a/Lib/test/test_sys.py
+++ b/Lib/test/test_sys.py
@@ -1232,7 +1232,6 @@ class SysModuleTest(unittest.TestCase):
         self.assertIsInstance(level, int)
         self.assertGreater(level, 0)
 
-    @unittest.expectedFailure # TODO: RUSTPYTHON
     @force_not_colorized
     @support.requires_subprocess()
     def test_sys_tracebacklimit(self):

--- a/Lib/test/test_warnings/__init__.py
+++ b/Lib/test/test_warnings/__init__.py
@@ -1478,7 +1478,6 @@ class EnvironmentVariableTests(BaseTest):
         self.assertEqual(stdout,
             b"['ignore::DeprecationWarning', 'ignore::UnicodeWarning']")
 
-    @unittest.expectedFailure  # TODO: RUSTPYTHON; AssertionError: b"['error::DeprecationWarning']" != b"['default::DeprecationWarning', 'error::DeprecationWarning']"
     @force_not_colorized
     def test_conflicting_envvar_and_command_line(self):
         rc, stdout, stderr = assert_python_failure("-Werror::DeprecationWarning", "-c",

--- a/crates/vm/src/stdlib/sys.rs
+++ b/crates/vm/src/stdlib/sys.rs
@@ -825,11 +825,13 @@ mod sys {
         let stderr = super::get_stderr(vm)?;
         match vm.normalize_exception(exc_type.clone(), exc_val.clone(), exc_tb) {
             Ok(exc) => {
-                // Try Python traceback module first for richer output
-                // (enables features like keyword typo suggestions in SyntaxError)
+                // PyErr_Display: try traceback._print_exception_bltin first
                 if let Ok(tb_mod) = vm.import("traceback", 0)
-                    && let Ok(print_exc) = tb_mod.get_attr("print_exception", vm)
-                    && print_exc.call((exc.as_object().to_owned(),), vm).is_ok()
+                    && let Ok(print_exc_builtin) =
+                        tb_mod.get_attr("_print_exception_bltin", vm)
+                    && print_exc_builtin
+                        .call((exc.as_object().to_owned(),), vm)
+                        .is_ok()
                 {
                     return Ok(());
                 }


### PR DESCRIPTION
- excepthook: call traceback._print_exception_bltin instead of traceback.print_exception to match PyErr_Display behavior
- run_string: register compiled code in linecache._interactive_cache so traceback can display source lines and caret indicators
- Remove test_sys_tracebacklimit expectedFailure

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved exception traceback output for clearer error messages.
  * Enhanced debugging by registering executed source so stack traces show more accurate line information.

* **Chores**
  * Updated spell-check dictionary with an additional symbol.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->