### PR TITLE
Remove PyStr::as_str

### DIFF
--- a/Lib/test/test_tstring.py
+++ b/Lib/test/test_tstring.py
@@ -4,7 +4,6 @@ from test.test_string._support import TStringBaseCase, fstring
 
 
 class TestTString(unittest.TestCase, TStringBaseCase):
-    @unittest.expectedFailure  # TODO: RUSTPYTHON; + Template(strings=('Hello',), interpolations=())
     def test_string_representation(self):
         # Test __repr__
         t = t"Hello"

--- a/crates/common/src/str.rs
+++ b/crates/common/src/str.rs
@@ -258,6 +258,7 @@ impl StrData {
         &self.data
     }
 
+    // TODO: rename to to_str
     #[inline]
     pub fn as_str(&self) -> Option<&str> {
         self.kind
@@ -429,13 +430,13 @@ pub fn zfill(bytes: &[u8], width: usize) -> Vec<u8> {
 
 /// Convert a string to ascii compatible, escaping unicode-s into escape
 /// sequences.
-pub fn to_ascii(value: &str) -> AsciiString {
+pub fn to_ascii(value: &Wtf8) -> AsciiString {
     let mut ascii = Vec::new();
-    for c in value.chars() {
-        if c.is_ascii() {
-            ascii.push(c as u8);
+    for cp in value.code_points() {
+        if cp.is_ascii() {
+            ascii.push(cp.to_u32() as u8);
         } else {
-            let c = c as i64;
+            let c = cp.to_u32();
             let hex = if c < 0x100 {
                 format!("\\x{c:02x}")
             } else if c < 0x10000 {

--- a/crates/stdlib/src/_sqlite3.rs
+++ b/crates/stdlib/src/_sqlite3.rs
@@ -89,7 +89,7 @@ mod _sqlite3 {
                 $(
                     #[allow(dead_code)]
                     fn [<new_ $x:snake>](vm: &VirtualMachine, msg: String) -> PyBaseExceptionRef {
-                        vm.new_exception_msg([<$x:snake _type>]().to_owned(), msg)
+                        vm.new_exception_msg([<$x:snake _type>]().to_owned(), msg.into())
                     }
                     fn [<$x:snake _type>]() -> &'static Py<PyType> {
                         [<$x:snake:upper>].get().expect("exception type not initialize")
@@ -723,7 +723,7 @@ mod _sqlite3 {
         converter: ArgCallable,
         vm: &VirtualMachine,
     ) -> PyResult<()> {
-        let name = typename.as_str().to_uppercase();
+        let name = typename.expect_str().to_uppercase();
         converters().set_item(&name, converter.into(), vm)
     }
 
@@ -2194,8 +2194,8 @@ mod _sqlite3 {
                     let Some(obj) = obj.downcast_ref::<PyStr>() else {
                         break;
                     };
-                    let a_iter = name.as_str().chars().flat_map(|x| x.to_uppercase());
-                    let b_iter = obj.as_str().chars().flat_map(|x| x.to_uppercase());
+                    let a_iter = name.expect_str().chars().flat_map(|x| x.to_uppercase());
+                    let b_iter = obj.expect_str().chars().flat_map(|x| x.to_uppercase());
 
                     if a_iter.eq(b_iter) {
                         return self.data.getitem_by_index(vm, i);
@@ -2918,7 +2918,7 @@ mod _sqlite3 {
             };
             let mut s = Vec::with_capacity(16);
             s.extend(b"BEGIN ");
-            s.extend(isolation_level.as_str().bytes());
+            s.extend(isolation_level.expect_str().bytes());
             s.push(b'\0');
             self._exec(&s, vm)
         }
@@ -3469,7 +3469,7 @@ mod _sqlite3 {
             return e;
         }
 
-        vm.new_exception_msg_dict(typ, msg, dict)
+        vm.new_exception_msg_dict(typ, msg.into(), dict)
     }
 
     static BEGIN_STATEMENTS: &[&[u8]] = &[

--- a/crates/stdlib/src/array.rs
+++ b/crates/stdlib/src/array.rs
@@ -19,7 +19,7 @@ mod array {
             builtins::{
                 PositionIterInternal, PyByteArray, PyBytes, PyBytesRef, PyDictRef, PyFloat,
                 PyGenericAlias, PyInt, PyList, PyListRef, PyStr, PyStrRef, PyTupleRef, PyType,
-                PyTypeRef, builtins_iter,
+                PyTypeRef, PyUtf8StrRef, builtins_iter,
             },
             class_or_notimplemented,
             convert::{ToPyObject, ToPyResult, TryFromBorrowedObject, TryFromObject},
@@ -559,7 +559,7 @@ mod array {
 
     impl ArrayElement for WideChar {
         fn try_into_from_object(vm: &VirtualMachine, obj: PyObjectRef) -> PyResult<Self> {
-            PyStrRef::try_from_object(vm, obj)?
+            PyUtf8StrRef::try_from_object(vm, obj)?
                 .as_str()
                 .chars()
                 .exactly_one()
@@ -625,7 +625,7 @@ mod array {
     #[derive(FromArgs)]
     pub struct ArrayNewArgs {
         #[pyarg(positional)]
-        spec: PyStrRef,
+        spec: PyUtf8StrRef,
         #[pyarg(positional, optional)]
         init: OptionalArg<PyObjectRef>,
     }
@@ -884,7 +884,7 @@ mod array {
             if not_enough_bytes {
                 Err(vm.new_exception_msg(
                     vm.ctx.exceptions.eof_error.to_owned(),
-                    "read() didn't return enough bytes".to_owned(),
+                    "read() didn't return enough bytes".into(),
                 ))
             } else {
                 Ok(())
@@ -1425,7 +1425,7 @@ mod array {
         #[pyarg(positional)]
         arraytype: PyTypeRef,
         #[pyarg(positional)]
-        typecode: PyStrRef,
+        typecode: PyUtf8StrRef,
         #[pyarg(positional)]
         mformat_code: MachineFormatCode,
         #[pyarg(positional)]
@@ -1568,7 +1568,7 @@ mod array {
         Ok(typ)
     }
 
-    fn check_type_code(spec: PyStrRef, vm: &VirtualMachine) -> PyResult<ArrayContentType> {
+    fn check_type_code(spec: PyUtf8StrRef, vm: &VirtualMachine) -> PyResult<ArrayContentType> {
         let spec = spec.as_str().chars().exactly_one().map_err(|_| {
             vm.new_type_error(
                 "_array_reconstructor() argument 2 must be a unicode character, not str",

--- a/crates/stdlib/src/binascii.rs
+++ b/crates/stdlib/src/binascii.rs
@@ -849,7 +849,7 @@ mod decl {
 struct Base64DecodeError(base64::DecodeError);
 
 fn new_binascii_error(msg: String, vm: &VirtualMachine) -> PyBaseExceptionRef {
-    vm.new_exception_msg(decl::error_type(vm), msg)
+    vm.new_exception_msg(decl::error_type(vm), msg.into())
 }
 
 impl ToPyException for Base64DecodeError {

--- a/crates/stdlib/src/grp.rs
+++ b/crates/stdlib/src/grp.rs
@@ -5,7 +5,7 @@ pub(crate) use grp::module_def;
 mod grp {
     use crate::vm::{
         PyObjectRef, PyResult, VirtualMachine,
-        builtins::{PyIntRef, PyListRef, PyStrRef},
+        builtins::{PyIntRef, PyListRef, PyUtf8StrRef},
         convert::{IntoPyException, ToPyObject},
         exceptions,
         types::PyStructSequence,
@@ -67,7 +67,7 @@ mod grp {
     }
 
     #[pyfunction]
-    fn getgrnam(name: PyStrRef, vm: &VirtualMachine) -> PyResult<GroupData> {
+    fn getgrnam(name: PyUtf8StrRef, vm: &VirtualMachine) -> PyResult<GroupData> {
         let gr_name = name.as_str();
         if gr_name.contains('\0') {
             return Err(exceptions::cstring_error(vm));

--- a/crates/stdlib/src/lzma.rs
+++ b/crates/stdlib/src/lzma.rs
@@ -82,7 +82,8 @@ mod _lzma {
     }
 
     fn new_lzma_error(message: impl Into<String>, vm: &VirtualMachine) -> PyBaseExceptionRef {
-        vm.new_exception_msg(vm.class("lzma", "LZMAError"), message.into())
+        let msg: String = message.into();
+        vm.new_exception_msg(vm.class("lzma", "LZMAError"), msg.into())
     }
 
     #[pyfunction]

--- a/crates/stdlib/src/multiprocessing.rs
+++ b/crates/stdlib/src/multiprocessing.rs
@@ -224,7 +224,7 @@ mod _multiprocessing {
                 if !ismine!(self) {
                     return Err(vm.new_exception_msg(
                         vm.ctx.exceptions.assertion_error.to_owned(),
-                        "attempt to release recursive lock not owned by thread".to_owned(),
+                        "attempt to release recursive lock not owned by thread".into(),
                     ));
                 }
                 if self.count.load(Ordering::Acquire) > 1 {
@@ -796,7 +796,7 @@ mod _multiprocessing {
                 if !ismine!(self) {
                     return Err(vm.new_exception_msg(
                         vm.ctx.exceptions.assertion_error.to_owned(),
-                        "attempt to release recursive lock not owned by thread".to_owned(),
+                        "attempt to release recursive lock not owned by thread".into(),
                     ));
                 }
                 // if (self->count > 1) { --self->count; Py_RETURN_NONE; }

--- a/crates/stdlib/src/overlapped.rs
+++ b/crates/stdlib/src/overlapped.rs
@@ -309,7 +309,7 @@ mod _overlapped {
                 let mut addr: SOCKADDR_IN = unsafe { core::mem::zeroed() };
                 addr.sin_family = AF_INET;
 
-                let host_wide: Vec<u16> = host.as_str().encode_utf16().chain([0]).collect();
+                let host_wide: Vec<u16> = host.as_wtf8().encode_wide().chain([0]).collect();
                 let mut addr_len = core::mem::size_of::<SOCKADDR_IN>() as i32;
 
                 let ret = unsafe {
@@ -348,7 +348,7 @@ mod _overlapped {
                 let mut addr: SOCKADDR_IN6 = unsafe { core::mem::zeroed() };
                 addr.sin6_family = AF_INET6;
 
-                let host_wide: Vec<u16> = host.as_str().encode_utf16().chain([0]).collect();
+                let host_wide: Vec<u16> = host.as_wtf8().encode_wide().chain([0]).collect();
                 let mut addr_len = core::mem::size_of::<SOCKADDR_IN6>() as i32;
 
                 let ret = unsafe {

--- a/crates/stdlib/src/posixshmem.rs
+++ b/crates/stdlib/src/posixshmem.rs
@@ -8,13 +8,15 @@ mod _posixshmem {
 
     use crate::{
         common::os::errno_io_error,
-        vm::{FromArgs, PyResult, VirtualMachine, builtins::PyStrRef, convert::IntoPyException},
+        vm::{
+            FromArgs, PyResult, VirtualMachine, builtins::PyUtf8StrRef, convert::IntoPyException,
+        },
     };
 
     #[derive(FromArgs)]
     struct ShmOpenArgs {
         #[pyarg(any)]
-        name: PyStrRef,
+        name: PyUtf8StrRef,
         #[pyarg(any)]
         flags: libc::c_int,
         #[pyarg(any, default = 0o600)]
@@ -37,7 +39,7 @@ mod _posixshmem {
     }
 
     #[pyfunction]
-    fn shm_unlink(name: PyStrRef, vm: &VirtualMachine) -> PyResult<()> {
+    fn shm_unlink(name: PyUtf8StrRef, vm: &VirtualMachine) -> PyResult<()> {
         let name = CString::new(name.as_str()).map_err(|e| e.into_pyexception(vm))?;
         // SAFETY: `name` is a valid NUL-terminated string and `shm_unlink` only reads it.
         let ret = unsafe { libc::shm_unlink(name.as_ptr()) };

--- a/crates/stdlib/src/pyexpat.rs
+++ b/crates/stdlib/src/pyexpat.rs
@@ -41,7 +41,7 @@ macro_rules! create_bool_property {
 mod _pyexpat {
     use crate::vm::{
         Context, Py, PyObjectRef, PyPayload, PyRef, PyResult, TryFromObject, VirtualMachine,
-        builtins::{PyBytesRef, PyException, PyModule, PyStr, PyStrRef, PyType},
+        builtins::{PyBytesRef, PyException, PyModule, PyStr, PyStrRef, PyType, PyUtf8StrRef},
         extend_module,
         function::{ArgBytesLike, Either, IntoFuncArgs, OptionalArg},
         types::Constructor,
@@ -390,7 +390,7 @@ mod _pyexpat {
         #[pyarg(any, optional)]
         encoding: Option<PyStrRef>,
         #[pyarg(any, optional)]
-        namespace_separator: Option<PyStrRef>,
+        namespace_separator: Option<PyUtf8StrRef>,
         #[pyarg(any, optional)]
         intern: Option<PyObjectRef>,
     }
@@ -403,11 +403,9 @@ mod _pyexpat {
         // Validate namespace_separator: must be at most one character
         let ns_sep = match args.namespace_separator {
             Some(ref s) => {
-                let chars: Vec<char> = s.as_str().chars().collect();
-                if chars.len() > 1 {
+                if s.as_str().chars().count() > 1 {
                     return Err(vm.new_value_error(
-                        "namespace_separator must be at most one character, omitted, or None"
-                            .to_owned(),
+                        "namespace_separator must be at most one character, omitted, or None",
                     ));
                 }
                 Some(s.as_str().to_owned())

--- a/crates/stdlib/src/pystruct.rs
+++ b/crates/stdlib/src/pystruct.rs
@@ -19,6 +19,7 @@ pub(crate) mod _struct {
         types::{Constructor, IterNext, Iterable, Representable, SelfIter},
     };
     use crossbeam_utils::atomic::AtomicCell;
+    use rustpython_common::wtf8::{Wtf8Buf, wtf8_concat};
 
     #[derive(Traverse)]
     struct IntoStructFormatBytes(PyStrRef);
@@ -305,8 +306,8 @@ pub(crate) mod _struct {
 
     impl Representable for PyStruct {
         #[inline]
-        fn repr_str(zelf: &Py<Self>, _vm: &VirtualMachine) -> PyResult<String> {
-            Ok(format!("Struct('{}')", zelf.format.as_str()))
+        fn repr_wtf8(zelf: &Py<Self>, _vm: &VirtualMachine) -> PyResult<Wtf8Buf> {
+            Ok(wtf8_concat!("Struct('", zelf.format.as_wtf8(), "')"))
         }
     }
 

--- a/crates/stdlib/src/zlib.rs
+++ b/crates/stdlib/src/zlib.rs
@@ -466,7 +466,8 @@ mod zlib {
     }
 
     fn new_zlib_error(message: impl Into<String>, vm: &VirtualMachine) -> PyBaseExceptionRef {
-        vm.new_exception_msg(vm.class("zlib", "error"), message.into())
+        let msg: String = message.into();
+        vm.new_exception_msg(vm.class("zlib", "error"), msg.into())
     }
 
     struct Level(Option<flate2::Compression>);

--- a/crates/vm/src/buffer.rs
+++ b/crates/vm/src/buffer.rs
@@ -725,5 +725,6 @@ pub fn struct_error_type(vm: &VirtualMachine) -> &'static PyTypeRef {
 pub fn new_struct_error(vm: &VirtualMachine, msg: impl Into<String>) -> PyBaseExceptionRef {
     // can't just STRUCT_ERROR.get().unwrap() cause this could be called before from buffer
     // machinery, independent of whether _struct was ever imported
+    let msg: String = msg.into();
     vm.new_exception_msg(struct_error_type(vm).clone(), msg.into())
 }

--- a/crates/vm/src/builtins/bool.rs
+++ b/crates/vm/src/builtins/bool.rs
@@ -1,4 +1,4 @@
-use super::{PyInt, PyStrRef, PyType, PyTypeRef};
+use super::{PyInt, PyStrRef, PyType, PyTypeRef, PyUtf8StrRef};
 use crate::common::format::FormatSpec;
 use crate::{
     AsObject, Context, Py, PyObject, PyObjectRef, PyResult, TryFromBorrowedObject, VirtualMachine,
@@ -101,7 +101,7 @@ impl Constructor for PyBool {
 #[pyclass(with(Constructor, AsNumber, Representable), flags(_MATCH_SELF))]
 impl PyBool {
     #[pymethod]
-    fn __format__(obj: PyObjectRef, spec: PyStrRef, vm: &VirtualMachine) -> PyResult<String> {
+    fn __format__(obj: PyObjectRef, spec: PyUtf8StrRef, vm: &VirtualMachine) -> PyResult<String> {
         let new_bool = obj.try_to_bool(vm)?;
         FormatSpec::parse(spec.as_str())
             .and_then(|format_spec| format_spec.format_bool(new_bool))

--- a/crates/vm/src/builtins/classmethod.rs
+++ b/crates/vm/src/builtins/classmethod.rs
@@ -211,11 +211,11 @@ impl Representable for PyClassMethod {
             class
                 .__qualname__(vm)
                 .downcast_ref::<PyStr>()
-                .map(|n| n.as_str()),
+                .map(|n| n.as_wtf8()),
             class
                 .__module__(vm)
                 .downcast_ref::<PyStr>()
-                .map(|m| m.as_str()),
+                .map(|m| m.as_wtf8()),
         ) {
             (None, _) => return Err(vm.new_type_error("Unknown qualified name")),
             (Some(qualname), Some(module)) if module != "builtins" => {

--- a/crates/vm/src/builtins/code.rs
+++ b/crates/vm/src/builtins/code.rs
@@ -459,7 +459,7 @@ impl Constructor for PyCode {
                 let s = obj.downcast_ref::<super::pystr::PyStr>().ok_or_else(|| {
                     vm.new_type_error("names must be tuple of strings".to_owned())
                 })?;
-                Ok(vm.ctx.intern_str(s.as_str()))
+                Ok(vm.ctx.intern_str(s.as_wtf8()))
             })
             .collect::<PyResult<Vec<_>>>()?
             .into_boxed_slice();
@@ -471,7 +471,7 @@ impl Constructor for PyCode {
                 let s = obj.downcast_ref::<super::pystr::PyStr>().ok_or_else(|| {
                     vm.new_type_error("varnames must be tuple of strings".to_owned())
                 })?;
-                Ok(vm.ctx.intern_str(s.as_str()))
+                Ok(vm.ctx.intern_str(s.as_wtf8()))
             })
             .collect::<PyResult<Vec<_>>>()?
             .into_boxed_slice();
@@ -483,7 +483,7 @@ impl Constructor for PyCode {
                 let s = obj.downcast_ref::<super::pystr::PyStr>().ok_or_else(|| {
                     vm.new_type_error("cellvars must be tuple of strings".to_owned())
                 })?;
-                Ok(vm.ctx.intern_str(s.as_str()))
+                Ok(vm.ctx.intern_str(s.as_wtf8()))
             })
             .collect::<PyResult<Vec<_>>>()?
             .into_boxed_slice();
@@ -495,7 +495,7 @@ impl Constructor for PyCode {
                 let s = obj.downcast_ref::<super::pystr::PyStr>().ok_or_else(|| {
                     vm.new_type_error("freevars must be tuple of strings".to_owned())
                 })?;
-                Ok(vm.ctx.intern_str(s.as_str()))
+                Ok(vm.ctx.intern_str(s.as_wtf8()))
             })
             .collect::<PyResult<Vec<_>>>()?
             .into_boxed_slice();
@@ -551,15 +551,15 @@ impl Constructor for PyCode {
             posonlyarg_count: args.posonlyargcount,
             arg_count: args.argcount,
             kwonlyarg_count: args.kwonlyargcount,
-            source_path: vm.ctx.intern_str(args.filename.as_str()),
+            source_path: vm.ctx.intern_str(args.filename.as_wtf8()),
             first_line_number: if args.firstlineno > 0 {
                 OneIndexed::new(args.firstlineno as usize)
             } else {
                 None
             },
             max_stackdepth: args.stacksize,
-            obj_name: vm.ctx.intern_str(args.name.as_str()),
-            qualname: vm.ctx.intern_str(args.qualname.as_str()),
+            obj_name: vm.ctx.intern_str(args.name.as_wtf8()),
+            qualname: vm.ctx.intern_str(args.qualname.as_wtf8()),
             cell2arg: None, // TODO: reuse `fn cell2arg`
             constants,
             names,

--- a/crates/vm/src/builtins/function/jit.rs
+++ b/crates/vm/src/builtins/function/jit.rs
@@ -41,7 +41,7 @@ impl ToPyObject for AbiValue {
 
 pub fn new_jit_error(msg: String, vm: &VirtualMachine) -> PyBaseExceptionRef {
     let jit_error = vm.ctx.exceptions.jit_error.to_owned();
-    vm.new_exception_msg(jit_error, msg)
+    vm.new_exception_msg(jit_error, msg.into())
 }
 
 fn get_jit_arg_type(dict: &Py<PyDict>, name: &str, vm: &VirtualMachine) -> PyResult<JitType> {

--- a/crates/vm/src/builtins/genericalias.rs
+++ b/crates/vm/src/builtins/genericalias.rs
@@ -635,14 +635,14 @@ impl Hashable for PyGenericAlias {
 
 impl GetAttr for PyGenericAlias {
     fn getattro(zelf: &Py<Self>, attr: &Py<PyStr>, vm: &VirtualMachine) -> PyResult {
-        let attr_str = attr.as_str();
+        let attr_str = attr.as_wtf8();
         for exc in &ATTR_EXCEPTIONS {
-            if *exc == attr_str {
+            if attr_str == *exc {
                 return zelf.as_object().generic_getattr(attr, vm);
             }
         }
         for blocked in &ATTR_BLOCKED {
-            if *blocked == attr_str {
+            if attr_str == *blocked {
                 return zelf.as_object().generic_getattr(attr, vm);
             }
         }

--- a/crates/vm/src/builtins/mappingproxy.rs
+++ b/crates/vm/src/builtins/mappingproxy.rs
@@ -1,10 +1,9 @@
 use super::{PyDict, PyDictRef, PyGenericAlias, PyList, PyTuple, PyType, PyTypeRef};
-use crate::common::lock::LazyLock;
 use crate::{
     AsObject, Context, Py, PyObject, PyObjectRef, PyPayload, PyRef, PyResult, VirtualMachine,
     atomic_func,
     class::PyClassImpl,
-    common::hash,
+    common::{hash, lock::LazyLock},
     convert::ToPyObject,
     function::{ArgMapping, OptionalArg, PyComparisonValue},
     object::{Traverse, TraverseFn},
@@ -14,6 +13,7 @@ use crate::{
         PyComparisonOp, Representable,
     },
 };
+use rustpython_common::wtf8::{Wtf8Buf, wtf8_concat};
 
 #[pyclass(module = false, name = "mappingproxy", traverse)]
 #[derive(Debug)]
@@ -287,9 +287,9 @@ impl Iterable for PyMappingProxy {
 
 impl Representable for PyMappingProxy {
     #[inline]
-    fn repr_str(zelf: &Py<Self>, vm: &VirtualMachine) -> PyResult<String> {
+    fn repr_wtf8(zelf: &Py<Self>, vm: &VirtualMachine) -> PyResult<Wtf8Buf> {
         let obj = zelf.to_object(vm)?;
-        Ok(format!("mappingproxy({})", obj.repr(vm)?))
+        Ok(wtf8_concat!("mappingproxy(", obj.repr(vm)?.as_wtf8(), ')'))
     }
 }
 

--- a/crates/vm/src/builtins/mod.rs
+++ b/crates/vm/src/builtins/mod.rs
@@ -63,7 +63,7 @@ pub(crate) mod bool_;
 pub use bool_::PyBool;
 #[path = "str.rs"]
 pub(crate) mod pystr;
-pub use pystr::{PyStr, PyStrInterned, PyStrRef, PyUtf8Str, PyUtf8StrRef};
+pub use pystr::{PyStr, PyStrInterned, PyStrRef, PyUtf8Str, PyUtf8StrInterned, PyUtf8StrRef};
 #[path = "super.rs"]
 pub(crate) mod super_;
 pub use super_::PySuper;

--- a/crates/vm/src/builtins/module.rs
+++ b/crates/vm/src/builtins/module.rs
@@ -160,9 +160,10 @@ impl Py<PyModule> {
             .get_item_opt(identifier!(vm, __name__), vm)
             .ok()
             .flatten();
-        let mod_name_str = mod_name_obj
-            .as_ref()
-            .and_then(|n| n.downcast_ref::<PyStr>().map(|s| s.as_str().to_owned()));
+        let mod_name_str = mod_name_obj.as_ref().and_then(|n| {
+            n.downcast_ref::<PyStr>()
+                .map(|s| s.to_string_lossy().into_owned())
+        });
 
         // If __name__ is not set or not a string, use a simpler error message
         let mod_display = match mod_name_str.as_deref() {
@@ -424,7 +425,7 @@ impl Initializer for PyModule {
                 .flags
                 .has_feature(crate::types::PyTypeFlags::HAS_DICT)
         );
-        zelf.init_dict(vm.ctx.intern_str(args.name.as_str()), args.doc, vm);
+        zelf.init_dict(vm.ctx.intern_str(args.name.as_wtf8()), args.doc, vm);
         Ok(())
     }
 }

--- a/crates/vm/src/builtins/range.rs
+++ b/crates/vm/src/builtins/range.rs
@@ -52,8 +52,9 @@ fn iter_search(
         SearchType::Index => Err(vm.new_value_error(format!(
             "{} not in range",
             item.repr(vm)
-                .map(|v| v.as_str().to_owned())
-                .unwrap_or_else(|_| "value".to_owned())
+                .as_ref()
+                .map_or("value".as_ref(), |s| s.as_wtf8())
+                .to_owned()
         ))),
     }
 }

--- a/crates/vm/src/builtins/slice.rs
+++ b/crates/vm/src/builtins/slice.rs
@@ -1,5 +1,7 @@
 // sliceobject.{h,c} in CPython
 // spell-checker:ignore sliceobject
+use rustpython_common::wtf8::{Wtf8Buf, wtf8_concat};
+
 use super::{PyGenericAlias, PyStrRef, PyTupleRef, PyType, PyTypeRef};
 use crate::{
     AsObject, Context, Py, PyObject, PyObjectRef, PyPayload, PyRef, PyResult, VirtualMachine,
@@ -291,12 +293,20 @@ impl Comparable for PySlice {
 
 impl Representable for PySlice {
     #[inline]
-    fn repr_str(zelf: &Py<Self>, vm: &VirtualMachine) -> PyResult<String> {
+    fn repr_wtf8(zelf: &Py<Self>, vm: &VirtualMachine) -> PyResult<Wtf8Buf> {
         let start_repr = zelf.start_ref(vm).repr(vm)?;
         let stop_repr = zelf.stop.repr(vm)?;
         let step_repr = zelf.step_ref(vm).repr(vm)?;
 
-        Ok(format!("slice({start_repr}, {stop_repr}, {step_repr})"))
+        Ok(wtf8_concat!(
+            "slice(",
+            start_repr.as_wtf8(),
+            ", ",
+            stop_repr.as_wtf8(),
+            ", ",
+            step_repr.as_wtf8(),
+            ")"
+        ))
     }
 }
 

--- a/crates/vm/src/builtins/staticmethod.rs
+++ b/crates/vm/src/builtins/staticmethod.rs
@@ -182,11 +182,11 @@ impl Representable for PyStaticMethod {
             class
                 .__qualname__(vm)
                 .downcast_ref::<PyStr>()
-                .map(|n| n.as_str()),
+                .map(|n| n.as_wtf8()),
             class
                 .__module__(vm)
                 .downcast_ref::<PyStr>()
-                .map(|m| m.as_str()),
+                .map(|m| m.as_wtf8()),
         ) {
             (None, _) => Err(vm.new_type_error("Unknown qualified name")),
             (Some(qualname), Some(module)) if module != "builtins" => {

--- a/crates/vm/src/builtins/tuple.rs
+++ b/crates/vm/src/builtins/tuple.rs
@@ -5,6 +5,7 @@ use crate::common::lock::LazyLock;
 use crate::common::{
     hash::{PyHash, PyUHash},
     lock::PyMutex,
+    wtf8::wtf8_concat,
 };
 use crate::object::{Traverse, TraverseFn};
 use crate::{
@@ -481,7 +482,7 @@ impl Representable for PyTuple {
             vm.ctx.intern_str("()").to_owned()
         } else if let Some(_guard) = ReprGuard::enter(vm, zelf.as_object()) {
             let s = if zelf.len() == 1 {
-                format!("({},)", zelf.elements[0].repr(vm)?)
+                wtf8_concat!("(", zelf.elements[0].repr(vm)?.as_wtf8(), ",)")
             } else {
                 collection_repr(None, "(", ")", zelf.elements.iter(), vm)?
             };

--- a/crates/vm/src/builtins/weakproxy.rs
+++ b/crates/vm/src/builtins/weakproxy.rs
@@ -142,7 +142,7 @@ impl IterNext for PyWeakProxy {
 fn new_reference_error(vm: &VirtualMachine) -> PyRef<super::PyBaseException> {
     vm.new_exception_msg(
         vm.ctx.exceptions.reference_error.to_owned(),
-        "weakly-referenced object no longer exists".to_owned(),
+        "weakly-referenced object no longer exists".into(),
     )
 }
 

--- a/crates/vm/src/coroutine.rs
+++ b/crates/vm/src/coroutine.rs
@@ -257,7 +257,7 @@ impl Coro {
         format!(
             "<{} object {} at {:#x}>",
             gen_name(jen, vm),
-            qualname.as_str(),
+            qualname.as_wtf8(),
             id
         )
     }

--- a/crates/vm/src/dict_inner.rs
+++ b/crates/vm/src/dict_inner.rs
@@ -5,7 +5,7 @@
 
 use crate::{
     AsObject, Py, PyExact, PyObject, PyObjectRef, PyRefExact, PyResult, VirtualMachine,
-    builtins::{PyBytes, PyInt, PyStr, PyStrInterned, PyStrRef},
+    builtins::{PyBytes, PyInt, PyStr, PyStrInterned, PyStrRef, PyUtf8Str, PyUtf8StrRef},
     convert::ToPyObject,
 };
 use crate::{
@@ -815,6 +815,33 @@ impl DictKey for Py<PyStr> {
     #[inline(always)]
     fn key_as_isize(&self, vm: &VirtualMachine) -> PyResult<isize> {
         self.as_object().key_as_isize(vm)
+    }
+}
+
+impl DictKey for Py<PyUtf8Str> {
+    type Owned = PyUtf8StrRef;
+    #[inline(always)]
+    fn _to_owned(&self, _vm: &VirtualMachine) -> Self::Owned {
+        self.to_owned()
+    }
+
+    #[inline]
+    fn key_hash(&self, vm: &VirtualMachine) -> PyResult<HashValue> {
+        self.as_pystr().key_hash(vm)
+    }
+
+    #[inline(always)]
+    fn key_is(&self, other: &PyObject) -> bool {
+        self.as_pystr().key_is(other)
+    }
+
+    fn key_eq(&self, vm: &VirtualMachine, other_key: &PyObject) -> PyResult<bool> {
+        self.as_pystr().key_eq(vm, other_key)
+    }
+
+    #[inline(always)]
+    fn key_as_isize(&self, vm: &VirtualMachine) -> PyResult<isize> {
+        self.as_pystr().key_as_isize(vm)
     }
 }
 

--- a/crates/vm/src/function/buffer.rs
+++ b/crates/vm/src/function/buffer.rs
@@ -172,7 +172,7 @@ impl TryFromObject for ArgAsciiBuffer {
     fn try_from_object(vm: &VirtualMachine, obj: PyObjectRef) -> PyResult<Self> {
         match obj.downcast::<PyStr>() {
             Ok(string) => {
-                if string.as_str().is_ascii() {
+                if string.as_wtf8().is_ascii() {
                     Ok(Self::String(string))
                 } else {
                     Err(vm.new_value_error("string argument should contain only ASCII characters"))
@@ -186,7 +186,7 @@ impl TryFromObject for ArgAsciiBuffer {
 impl ArgAsciiBuffer {
     pub fn len(&self) -> usize {
         match self {
-            Self::String(s) => s.as_str().len(),
+            Self::String(s) => s.as_wtf8().len(),
             Self::Buffer(buffer) => buffer.len(),
         }
     }

--- a/crates/vm/src/function/fspath.rs
+++ b/crates/vm/src/function/fspath.rs
@@ -106,7 +106,7 @@ impl FsPath {
 
     pub fn to_path_buf(&self, vm: &VirtualMachine) -> PyResult<PathBuf> {
         let path = match self {
-            Self::Str(s) => PathBuf::from(s.as_str()),
+            Self::Str(s) => PathBuf::from(vm.fsencode(s)?.as_ref() as &OsStr),
             Self::Bytes(b) => PathBuf::from(Self::bytes_as_os_str(b, vm)?),
         };
         Ok(path)

--- a/crates/vm/src/function/mod.rs
+++ b/crates/vm/src/function/mod.rs
@@ -36,9 +36,9 @@ pub enum ArgByteOrder {
 impl<'a> TryFromBorrowedObject<'a> for ArgByteOrder {
     fn try_from_borrowed_object(vm: &VirtualMachine, obj: &'a PyObject) -> PyResult<Self> {
         obj.try_value_with(
-            |s: &PyStr| match s.as_str() {
-                "big" => Ok(Self::Big),
-                "little" => Ok(Self::Little),
+            |s: &PyStr| match s.as_bytes() {
+                b"big" => Ok(Self::Big),
+                b"little" => Ok(Self::Little),
                 _ => Err(vm.new_value_error("byteorder must be either 'little' or 'big'")),
             },
             vm,

--- a/crates/vm/src/intern.rs
+++ b/crates/vm/src/intern.rs
@@ -152,8 +152,23 @@ impl CachedPyStrRef {
     }
 }
 
+#[repr(transparent)]
 pub struct PyInterned<T> {
     inner: Py<T>,
+}
+
+impl PyInterned<PyStr> {
+    /// Returns `&str` for interned strings.
+    ///
+    /// # Panics
+    /// Panics if the interned string contains unpaired surrogates (WTF-8 content).
+    /// Most interned strings are valid UTF-8, so this is an ergonomic default.
+    #[inline]
+    pub fn as_str(&self) -> &str {
+        self.inner
+            .to_str()
+            .unwrap_or_else(|| panic!("interned str is always valid UTF-8"))
+    }
 }
 
 impl<T: PyPayload> PyInterned<T> {

--- a/crates/vm/src/macros.rs
+++ b/crates/vm/src/macros.rs
@@ -188,11 +188,11 @@ macro_rules! identifier(
 
 #[macro_export]
 macro_rules! identifier_utf8(
-    ($as_ctx:expr, $name:ident) => {
+    ($as_ctx:expr, $name:ident) => {{
         // Safety: All known identifiers are ascii strings.
-        #[allow(clippy::macro_metavars_in_unsafe, reason = "known identifiers are ASCII and downcast target is fixed")]
-        unsafe { $as_ctx.as_ref().names.$name.as_object().downcast_unchecked_ref::<$crate::builtins::PyUtf8Str>() }
-    };
+        let interned = $as_ctx.as_ref().names.$name;
+        unsafe { $crate::builtins::PyUtf8StrInterned::from_str_interned_unchecked(interned) }
+    }};
 );
 
 /// Super detailed logging. Might soon overflow your log buffers

--- a/crates/vm/src/protocol/object.rs
+++ b/crates/vm/src/protocol/object.rs
@@ -362,8 +362,8 @@ impl PyObject {
     }
 
     pub fn ascii(&self, vm: &VirtualMachine) -> PyResult<ascii::AsciiString> {
-        let repr = self.repr_utf8(vm)?;
-        let ascii = to_ascii(repr.as_str());
+        let repr = self.repr(vm)?;
+        let ascii = to_ascii(repr.as_wtf8());
         Ok(ascii)
     }
 
@@ -658,7 +658,7 @@ impl PyObject {
 
         Err(vm.new_exception_msg(
             vm.ctx.exceptions.type_error.to_owned(),
-            format!("unhashable type: '{}'", self.class().name()),
+            format!("unhashable type: '{}'", self.class().name()).into(),
         ))
     }
 

--- a/crates/vm/src/stdlib/_abc.rs
+++ b/crates/vm/src/stdlib/_abc.rs
@@ -365,7 +365,7 @@ mod _abc {
         if !ok.is(&vm.ctx.not_implemented) {
             return Err(vm.new_exception_msg(
                 vm.ctx.exceptions.assertion_error.to_owned(),
-                "__subclasshook__ must return either False, True, or NotImplemented".to_owned(),
+                "__subclasshook__ must return either False, True, or NotImplemented".into(),
             ));
         }
 

--- a/crates/vm/src/stdlib/_wmi.rs
+++ b/crates/vm/src/stdlib/_wmi.rs
@@ -561,7 +561,7 @@ mod _wmi {
     /// by null characters.
     #[pyfunction]
     fn exec_query(query: PyStrRef, vm: &VirtualMachine) -> PyResult<String> {
-        let query_str = query.as_str();
+        let query_str = query.expect_str();
 
         if !query_str
             .get(..7)

--- a/crates/vm/src/stdlib/ast.rs
+++ b/crates/vm/src/stdlib/ast.rs
@@ -15,7 +15,7 @@ use crate::{
     AsObject, Context, Py, PyObject, PyObjectRef, PyPayload, PyRef, PyRefExact, PyResult,
     TryFromObject, VirtualMachine,
     builtins::PyIntRef,
-    builtins::{PyDict, PyModule, PyStrRef, PyType},
+    builtins::{PyDict, PyModule, PyType, PyUtf8StrRef},
     class::{PyClassImpl, StaticType},
     compiler::{CompileError, ParseError},
     convert::ToPyObject,

--- a/crates/vm/src/stdlib/ast/basic.rs
+++ b/crates/vm/src/stdlib/ast/basic.rs
@@ -13,7 +13,7 @@ impl Node for ast::Identifier {
         _source_file: &SourceFile,
         object: PyObjectRef,
     ) -> PyResult<Self> {
-        let py_str = PyStrRef::try_from_object(vm, object)?;
+        let py_str = PyUtf8StrRef::try_from_object(vm, object)?;
         Ok(Self::new(py_str.as_str(), TextRange::default()))
     }
 }

--- a/crates/vm/src/stdlib/ctypes.rs
+++ b/crates/vm/src/stdlib/ctypes.rs
@@ -78,7 +78,7 @@ impl PyType {
         {
             return Err(vm.new_exception_msg(
                 vm.ctx.exceptions.system_error.to_owned(),
-                format!("class \"{}\" already initialized", self.name()),
+                format!("class \"{}\" already initialized", self.name()).into(),
             ));
         }
         Ok(())
@@ -627,7 +627,7 @@ pub(crate) mod _ctypes {
     #[pyfunction]
     fn dlsym(
         handle: usize,
-        name: crate::builtins::PyStrRef,
+        name: crate::builtins::PyUtf8StrRef,
         vm: &VirtualMachine,
     ) -> PyResult<usize> {
         let symbol_name = alloc::ffi::CString::new(name.as_str())
@@ -689,7 +689,7 @@ pub(crate) mod _ctypes {
         // PyUnicode_CheckExact(cls) - string creates incomplete pointer type
         if let Some(s) = cls.downcast_ref::<PyStr>() {
             // Incomplete pointer type: _type_ not set, cache key is id(result)
-            let name = format!("LP_{}", s.as_str());
+            let name = format!("LP_{}", s.as_wtf8());
 
             let new_type = metaclass
                 .as_object()
@@ -1117,7 +1117,7 @@ pub(crate) mod _ctypes {
                 arg_values.push(ptr);
                 arg_types.push(Type::pointer());
             } else if let Some(s) = arg.downcast_ref::<crate::builtins::PyStr>() {
-                let ptr = s.as_str().as_ptr() as isize;
+                let ptr = s.as_bytes().as_ptr() as isize;
                 arg_values.push(ptr);
                 arg_types.push(Type::pointer());
             } else {

--- a/crates/vm/src/stdlib/ctypes/pointer.rs
+++ b/crates/vm/src/stdlib/ctypes/pointer.rs
@@ -639,7 +639,7 @@ impl PyCPointer {
             } else if type_code.as_deref() == Some("Z")
                 && let Some(s) = value.downcast_ref::<PyStr>()
             {
-                let (holder, ptr_val) = super::base::str_to_wchar_bytes(s.as_str(), vm);
+                let (holder, ptr_val) = super::base::str_to_wchar_bytes(s.as_wtf8(), vm);
                 unsafe {
                     *(addr as *mut usize) = ptr_val;
                 }

--- a/crates/vm/src/stdlib/marshal.rs
+++ b/crates/vm/src/stdlib/marshal.rs
@@ -226,7 +226,7 @@ mod decl {
         marshal::deserialize_value(&mut &buf[..], PyMarshalBag(vm)).map_err(|e| match e {
             marshal::MarshalError::Eof => vm.new_exception_msg(
                 vm.ctx.exceptions.eof_error.to_owned(),
-                "marshal data too short".to_owned(),
+                "marshal data too short".into(),
             ),
             marshal::MarshalError::InvalidBytecode => {
                 vm.new_value_error("Couldn't deserialize python bytecode")

--- a/crates/vm/src/stdlib/msvcrt.rs
+++ b/crates/vm/src/stdlib/msvcrt.rs
@@ -82,7 +82,7 @@ mod msvcrt {
     #[pyfunction]
     fn putwch(s: PyStrRef, vm: &VirtualMachine) -> PyResult<()> {
         let c = s
-            .as_str()
+            .expect_str()
             .chars()
             .exactly_one()
             .map_err(|_| vm.new_type_error("putch() argument must be a string of length 1"))?;
@@ -107,7 +107,7 @@ mod msvcrt {
     #[pyfunction]
     fn ungetwch(s: PyStrRef, vm: &VirtualMachine) -> PyResult<()> {
         let c =
-            s.as_str().chars().exactly_one().map_err(|_| {
+            s.expect_str().chars().exactly_one().map_err(|_| {
                 vm.new_type_error("ungetwch() argument must be a string of length 1")
             })?;
         let ret = unsafe { suppress_iph!(_ungetwch(c as u32)) };

--- a/crates/vm/src/stdlib/signal.rs
+++ b/crates/vm/src/stdlib/signal.rs
@@ -323,7 +323,7 @@ pub(crate) mod _signal {
         if ret != 0 {
             let err = std::io::Error::last_os_error();
             let itimer_error = itimer_error(vm);
-            return Err(vm.new_exception_msg(itimer_error, err.to_string()));
+            return Err(vm.new_exception_msg(itimer_error, err.to_string().into()));
         }
         let old = unsafe { old.assume_init() };
         Ok(itimerval_to_tuple(&old))
@@ -340,7 +340,7 @@ pub(crate) mod _signal {
         if ret != 0 {
             let err = std::io::Error::last_os_error();
             let itimer_error = itimer_error(vm);
-            return Err(vm.new_exception_msg(itimer_error, err.to_string()));
+            return Err(vm.new_exception_msg(itimer_error, err.to_string().into()));
         }
         let old = unsafe { old.assume_init() };
         Ok(itimerval_to_tuple(&old))

--- a/crates/vm/src/stdlib/symtable.rs
+++ b/crates/vm/src/stdlib/symtable.rs
@@ -4,7 +4,7 @@ pub(crate) use _symtable::module_def;
 mod _symtable {
     use crate::{
         Py, PyObjectRef, PyPayload, PyRef, PyResult, VirtualMachine,
-        builtins::{PyDictRef, PyStrRef},
+        builtins::{PyDictRef, PyUtf8StrRef},
         compiler,
         types::Representable,
     };
@@ -111,9 +111,9 @@ mod _symtable {
 
     #[pyfunction]
     fn symtable(
-        source: PyStrRef,
-        filename: PyStrRef,
-        mode: PyStrRef,
+        source: PyUtf8StrRef,
+        filename: PyUtf8StrRef,
+        mode: PyUtf8StrRef,
         vm: &VirtualMachine,
     ) -> PyResult<PyRef<PySymbolTable>> {
         let mode = mode

--- a/crates/vm/src/stdlib/sys.rs
+++ b/crates/vm/src/stdlib/sys.rs
@@ -34,7 +34,7 @@ mod sys {
         AsObject, PyObject, PyObjectRef, PyPayload, PyRef, PyRefExact, PyResult,
         builtins::{
             PyBaseExceptionRef, PyDictRef, PyFrozenSet, PyNamespace, PyStr, PyStrRef, PyTuple,
-            PyTupleRef, PyTypeRef,
+            PyTupleRef, PyTypeRef, PyUtf8StrRef,
         },
         common::{
             ascii,
@@ -974,7 +974,7 @@ mod sys {
     }
 
     #[pyfunction]
-    fn getfilesystemencodeerrors(vm: &VirtualMachine) -> PyStrRef {
+    fn getfilesystemencodeerrors(vm: &VirtualMachine) -> PyUtf8StrRef {
         vm.fs_encode_errors().to_owned()
     }
 
@@ -1250,7 +1250,7 @@ mod sys {
         // Print module name (if not builtins or __main__)
         let module_name = unraisable.exc_type.__module__(vm);
         if let Ok(module_str) = module_name.downcast::<PyStr>() {
-            let module = module_str.as_str();
+            let module = module_str.as_wtf8();
             if module != "builtins" && module != "__main__" {
                 write!(stderr, "{}.", module);
             }
@@ -1261,7 +1261,7 @@ mod sys {
         // Print qualname
         let qualname = unraisable.exc_type.__qualname__(vm);
         if let Ok(qualname_str) = qualname.downcast::<PyStr>() {
-            write!(stderr, "{}", qualname_str.as_str());
+            write!(stderr, "{}", qualname_str.as_wtf8());
         } else {
             write!(stderr, "{}", unraisable.exc_type.name());
         }
@@ -1270,7 +1270,7 @@ mod sys {
         if !vm.is_none(&unraisable.exc_value) {
             write!(stderr, ": ");
             if let Ok(str) = unraisable.exc_value.str(vm) {
-                write!(stderr, "{}", str.to_str().unwrap_or("<str with surrogate>"));
+                write!(stderr, "{}", str.as_wtf8());
             } else {
                 write!(stderr, "<exception str() failed>");
             }

--- a/crates/vm/src/stdlib/winreg.rs
+++ b/crates/vm/src/stdlib/winreg.rs
@@ -994,7 +994,7 @@ mod winreg {
                 let s = value
                     .downcast::<PyStr>()
                     .map_err(|_| vm.new_type_error("value must be a string".to_string()))?;
-                let wide = s.as_str().to_wide_with_nul();
+                let wide = s.as_wtf8().to_wide_with_nul();
                 // Convert Vec<u16> to Vec<u8>
                 let bytes: Vec<u8> = wide.iter().flat_map(|&c| c.to_le_bytes()).collect();
                 Ok(Some(bytes))
@@ -1013,7 +1013,7 @@ mod winreg {
                     let s = item.downcast_ref::<PyStr>().ok_or_else(|| {
                         vm.new_type_error("list items must be strings".to_string())
                     })?;
-                    let wide = s.as_str().to_wide_with_nul();
+                    let wide = s.as_wtf8().to_wide_with_nul();
                     bytes.extend(wide.iter().flat_map(|&c| c.to_le_bytes()));
                 }
                 // Add final null terminator (double null at end)

--- a/crates/vm/src/stdlib/winsound.rs
+++ b/crates/vm/src/stdlib/winsound.rs
@@ -118,7 +118,7 @@ mod winsound {
 
         // os.fspath(sound)
         let path = match sound.downcast_ref::<PyStr>() {
-            Some(s) => s.as_str().to_owned(),
+            Some(s) => s.as_wtf8().to_owned(),
             None => {
                 let fspath = vm.get_method_or_type_error(
                     sound.clone(),
@@ -151,12 +151,12 @@ mod winsound {
                     ))
                 })?;
 
-                s.as_str().to_owned()
+                s.as_wtf8().to_owned()
             }
         };
 
         // Check for embedded null characters
-        if path.contains('\0') {
+        if path.as_bytes().contains(&0) {
             return Err(vm.new_value_error("embedded null character".to_owned()));
         }
 

--- a/crates/vm/src/suggestion.rs
+++ b/crates/vm/src/suggestion.rs
@@ -89,7 +89,7 @@ pub fn offer_suggestions(exc: &Py<PyBaseException>, vm: &VirtualMachine) -> Opti
 
         // Look up the module in sys.modules
         let sys_modules = vm.sys_module.get_attr("modules", vm).ok()?;
-        let module = sys_modules.get_item(mod_name_str.as_str(), vm).ok()?;
+        let module = sys_modules.get_item(mod_name_str, vm).ok()?;
 
         calculate_suggestions(vm.dir(Some(module)).ok()?.borrow_vec().iter(), &wrong_name)
     } else {

--- a/crates/vm/src/types/structseq.rs
+++ b/crates/vm/src/types/structseq.rs
@@ -234,7 +234,7 @@ pub trait PyStructSequence: StaticType + PyClassImpl + Sized + 'static {
             match typ.get_attr(identifier!(vm.ctx, __module__)) {
                 Some(module) if module.downcastable::<PyStr>() => {
                     let module_str = module.downcast_ref::<PyStr>().unwrap();
-                    alloc::borrow::Cow::Owned(format!("{}.{}", module_str.as_str(), Self::NAME))
+                    alloc::borrow::Cow::Owned(format!("{}.{}", module_str.as_wtf8(), Self::NAME))
                 }
                 _ => alloc::borrow::Cow::Borrowed(Self::TP_NAME),
             }

--- a/crates/vm/src/vm/context.rs
+++ b/crates/vm/src/vm/context.rs
@@ -3,7 +3,7 @@ use crate::{
     builtins::{
         PyByteArray, PyBytes, PyComplex, PyDict, PyDictRef, PyEllipsis, PyFloat, PyFrozenSet,
         PyInt, PyIntRef, PyList, PyListRef, PyNone, PyNotImplemented, PyStr, PyStrInterned,
-        PyTuple, PyTupleRef, PyType, PyTypeRef,
+        PyTuple, PyTupleRef, PyType, PyTypeRef, PyUtf8Str,
         bool_::PyBool,
         code::{self, PyCode},
         descriptor::{
@@ -444,6 +444,11 @@ impl Context {
 
     #[inline]
     pub fn new_str(&self, s: impl Into<pystr::PyStr>) -> PyRef<PyStr> {
+        s.into().into_ref(self)
+    }
+
+    #[inline]
+    pub fn new_utf8_str(&self, s: impl Into<PyUtf8Str>) -> PyRef<PyUtf8Str> {
         s.into().into_ref(self)
     }
 

--- a/crates/vm/src/vm/interpreter.rs
+++ b/crates/vm/src/vm/interpreter.rs
@@ -562,7 +562,7 @@ mod tests {
             let b = vm.new_pyobj(4_i32);
             let res = vm._mul(&a, &b).unwrap();
             let value = res.downcast_ref::<PyStr>().unwrap();
-            assert_eq!(value.as_str(), "Hello Hello Hello Hello ")
+            assert_eq!(value.as_wtf8(), "Hello Hello Hello Hello ")
         })
     }
 }

--- a/crates/wasm/src/convert.rs
+++ b/crates/wasm/src/convert.rs
@@ -56,7 +56,7 @@ pub fn py_err_to_js_err(vm: &VirtualMachine, py_err: &Py<PyBaseException>) -> Js
 }
 
 pub fn js_py_typeerror(vm: &VirtualMachine, js_err: JsValue) -> PyBaseExceptionRef {
-    let msg = js_err.unchecked_into::<js_sys::Error>().to_string();
+    let msg: String = js_err.unchecked_into::<js_sys::Error>().to_string().into();
     vm.new_type_error(msg)
 }
 
@@ -70,11 +70,11 @@ pub fn js_err_to_py_err(vm: &VirtualMachine, js_err: &JsValue) -> PyBaseExceptio
                 _ => vm.ctx.exceptions.exception_type,
             }
             .to_owned();
-            vm.new_exception_msg(exc_type, err.message().into())
+            vm.new_exception_msg(exc_type, String::from(err.message()).into())
         }
         None => vm.new_exception_msg(
             vm.ctx.exceptions.exception_type.to_owned(),
-            format!("{js_err:?}"),
+            format!("{js_err:?}").into(),
         ),
     }
 }

--- a/crates/wasm/src/js_module.rs
+++ b/crates/wasm/src/js_module.rs
@@ -83,7 +83,7 @@ mod _js {
     impl JsProperty {
         fn into_js_value(self) -> JsValue {
             match self {
-                JsProperty::Str(s) => s.as_str().into(),
+                JsProperty::Str(s) => s.expect_str().into(),
                 JsProperty::Js(value) => value.value.clone(),
             }
         }
@@ -109,7 +109,7 @@ mod _js {
 
         #[pymethod]
         fn new_from_str(&self, s: PyStrRef) -> PyJsValue {
-            PyJsValue::new(s.as_str())
+            PyJsValue::new(s.expect_str())
         }
 
         #[pymethod]

--- a/crates/wasm/src/wasm_builtins.rs
+++ b/crates/wasm/src/wasm_builtins.rs
@@ -33,7 +33,7 @@ pub fn make_stdout_object(
         "write",
         cls,
         move |_self: PyObjectRef, data: PyStrRef, vm: &VirtualMachine| -> PyResult<()> {
-            write_f(data.as_str(), vm)
+            write_f(data.expect_str(), vm)
         },
     );
     let flush_method = vm.new_method("flush", cls, |_self: PyObjectRef| {});

--- a/crates/wtf8/src/concat.rs
+++ b/crates/wtf8/src/concat.rs
@@ -1,0 +1,143 @@
+use alloc::borrow::{Cow, ToOwned};
+use alloc::boxed::Box;
+use alloc::string::String;
+use core::fmt;
+use fmt::Write;
+
+use crate::{CodePoint, Wtf8, Wtf8Buf};
+
+impl fmt::Write for Wtf8Buf {
+    #[inline]
+    fn write_str(&mut self, s: &str) -> fmt::Result {
+        self.push_str(s);
+        Ok(())
+    }
+}
+
+/// Trait for types that can be appended to a [`Wtf8Buf`], preserving surrogates.
+pub trait Wtf8Concat {
+    fn fmt_wtf8(&self, buf: &mut Wtf8Buf);
+}
+
+impl Wtf8Concat for Wtf8 {
+    #[inline]
+    fn fmt_wtf8(&self, buf: &mut Wtf8Buf) {
+        buf.push_wtf8(self);
+    }
+}
+
+impl Wtf8Concat for Wtf8Buf {
+    #[inline]
+    fn fmt_wtf8(&self, buf: &mut Wtf8Buf) {
+        buf.push_wtf8(self);
+    }
+}
+
+impl Wtf8Concat for str {
+    #[inline]
+    fn fmt_wtf8(&self, buf: &mut Wtf8Buf) {
+        buf.push_str(self);
+    }
+}
+
+impl Wtf8Concat for String {
+    #[inline]
+    fn fmt_wtf8(&self, buf: &mut Wtf8Buf) {
+        buf.push_str(self);
+    }
+}
+
+impl Wtf8Concat for char {
+    #[inline]
+    fn fmt_wtf8(&self, buf: &mut Wtf8Buf) {
+        buf.push_char(*self);
+    }
+}
+
+impl Wtf8Concat for CodePoint {
+    #[inline]
+    fn fmt_wtf8(&self, buf: &mut Wtf8Buf) {
+        buf.push(*self);
+    }
+}
+
+/// Wrapper that appends a [`fmt::Display`] value to a [`Wtf8Buf`].
+///
+/// Note: This goes through UTF-8 formatting, so lone surrogates in the
+/// display output will be replaced with U+FFFD. Use direct [`Wtf8Concat`]
+/// impls for surrogate-preserving concatenation.
+#[allow(dead_code)]
+pub struct DisplayAsWtf8<T>(pub T);
+
+impl<T: fmt::Display> Wtf8Concat for DisplayAsWtf8<T> {
+    #[inline]
+    fn fmt_wtf8(&self, buf: &mut Wtf8Buf) {
+        write!(buf, "{}", self.0).unwrap();
+    }
+}
+
+macro_rules! impl_wtf8_concat_for_int {
+    ($($t:ty),*) => {
+        $(impl Wtf8Concat for $t {
+            #[inline]
+            fn fmt_wtf8(&self, buf: &mut Wtf8Buf) {
+                write!(buf, "{}", self).unwrap();
+            }
+        })*
+    };
+}
+
+impl_wtf8_concat_for_int!(
+    u8, u16, u32, u64, u128, usize, i8, i16, i32, i64, i128, isize, f32, f64
+);
+
+impl<T: Wtf8Concat + ?Sized> Wtf8Concat for &T {
+    #[inline]
+    fn fmt_wtf8(&self, buf: &mut Wtf8Buf) {
+        (**self).fmt_wtf8(buf);
+    }
+}
+
+impl<T: Wtf8Concat + ?Sized> Wtf8Concat for &mut T {
+    #[inline]
+    fn fmt_wtf8(&self, buf: &mut Wtf8Buf) {
+        (**self).fmt_wtf8(buf);
+    }
+}
+
+impl<T: Wtf8Concat + ?Sized> Wtf8Concat for Box<T> {
+    #[inline]
+    fn fmt_wtf8(&self, buf: &mut Wtf8Buf) {
+        (**self).fmt_wtf8(buf);
+    }
+}
+
+impl<T: Wtf8Concat + ?Sized> Wtf8Concat for Cow<'_, T>
+where
+    T: ToOwned,
+{
+    #[inline]
+    fn fmt_wtf8(&self, buf: &mut Wtf8Buf) {
+        (**self).fmt_wtf8(buf);
+    }
+}
+
+/// Concatenate values into a [`Wtf8Buf`], preserving surrogates.
+///
+/// Each argument must implement [`Wtf8Concat`]. String literals (`&str`),
+/// [`Wtf8`], [`Wtf8Buf`], [`char`], and [`CodePoint`] are all supported.
+///
+/// ```
+/// use rustpython_wtf8::Wtf8Buf;
+/// let name = "world";
+/// let result = rustpython_wtf8::wtf8_concat!("hello, ", name, "!");
+/// assert_eq!(result, Wtf8Buf::from("hello, world!"));
+/// ```
+#[macro_export]
+macro_rules! wtf8_concat {
+    ($($arg:expr),* $(,)?) => {{
+        let mut buf = $crate::Wtf8Buf::new();
+        $($crate::Wtf8Concat::fmt_wtf8(&$arg, &mut buf);)*
+        buf
+    }};
+}

--- a/example_projects/wasm32_without_js/rustpython-without-js/src/lib.rs
+++ b/example_projects/wasm32_without_js/rustpython-without-js/src/lib.rs
@@ -25,7 +25,7 @@ pub unsafe extern "C" fn eval(s: *const u8, l: usize) -> i32 {
             Err(_) => return Err(-1), // Python execution error
         };
         let repr_str = match res.repr(vm) {
-            Ok(repr) => repr.as_str().to_string(),
+            Ok(repr) => repr.to_string(),
             Err(_) => return Err(-1), // Failed to get string representation
         };
         Ok(repr_str)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -33,7 +33,7 @@
 //!     #[pyfunction]
 //!     fn other_thing(s: PyStrRef) -> (String, usize) {
 //!         let new_string = format!("hello from rust, {}!", s);
-//!         let prev_len = s.as_str().len();
+//!         let prev_len = s.byte_len();
 //!         (new_string, prev_len)
 //!     }
 //! }
@@ -135,7 +135,7 @@ __import__("io").TextIOWrapper(
         .downcast()
         .expect("TextIOWrapper.read() should return str");
     eprintln!("running get-pip.py...");
-    vm.run_string(scope, getpip_code.as_str(), "get-pip.py".to_owned())?;
+    vm.run_string(scope, getpip_code.expect_str(), "get-pip.py".to_owned())?;
     Ok(())
 }
 
@@ -143,7 +143,7 @@ fn install_pip(installer: InstallPipMode, scope: Scope, vm: &VirtualMachine) -> 
     if !cfg!(feature = "ssl") {
         return Err(vm.new_exception_msg(
             vm.ctx.exceptions.system_error.to_owned(),
-            "install-pip requires rustpython be build with '--features=ssl'".to_owned(),
+            "install-pip requires rustpython be build with '--features=ssl'".into(),
         ));
     }
 

--- a/src/shell.rs
+++ b/src/shell.rs
@@ -142,7 +142,7 @@ pub fn run_shell(vm: &VirtualMachine, scope: Scope) -> PyResult<()> {
             .get_attr(prompt_name, vm)
             .and_then(|prompt| prompt.str(vm));
         let prompt = match prompt {
-            Ok(ref s) => s.as_str(),
+            Ok(ref s) => s.expect_str(),
             Err(_) => "",
         };
 
@@ -211,8 +211,10 @@ pub fn run_shell(vm: &VirtualMachine, scope: Scope) -> PyResult<()> {
             }
             #[cfg(unix)]
             ReadlineResult::OsError(num) => {
-                let os_error =
-                    vm.new_exception_msg(vm.ctx.exceptions.os_error.to_owned(), format!("{num:?}"));
+                let os_error = vm.new_exception_msg(
+                    vm.ctx.exceptions.os_error.to_owned(),
+                    format!("{num:?}").into(),
+                );
                 vm.print_exception(os_error);
                 break;
             }

--- a/src/shell/helper.rs
+++ b/src/shell/helper.rs
@@ -108,7 +108,7 @@ impl<'vm> ShellHelper<'vm> {
             .filter(|res| {
                 res.as_ref()
                     .ok()
-                    .is_none_or(|s| s.as_str().starts_with(word_start))
+                    .is_none_or(|s| s.as_bytes().starts_with(word_start.as_bytes()))
             })
             .collect::<Result<Vec<_>, _>>()
             .ok()?;
@@ -120,7 +120,7 @@ impl<'vm> ShellHelper<'vm> {
             // only the completions that don't start with a '_'
             let no_underscore = all_completions
                 .iter()
-                .filter(|&s| !s.as_str().starts_with('_'))
+                .filter(|&s| !s.as_bytes().starts_with(b"_"))
                 .cloned()
                 .collect::<Vec<_>>();
 
@@ -134,13 +134,13 @@ impl<'vm> ShellHelper<'vm> {
         };
 
         // sort the completions alphabetically
-        completions.sort_by(|a, b| std::cmp::Ord::cmp(a.as_str(), b.as_str()));
+        completions.sort_by(|a, b| a.as_wtf8().cmp(b.as_wtf8()));
 
         Some((
             startpos,
             completions
                 .into_iter()
-                .map(|s| s.as_str().to_owned())
+                .map(|s| s.expect_str().to_owned())
                 .collect(),
         ))
     }


### PR DESCRIPTION
Fix #7196

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Wide rollout of UTF‑8/WTF‑8 handling across the VM and standard library for safer, binary‑preserving text processing and improved non‑ASCII rendering.
  * Many object reprs and I/O paths now correctly display surrogate and non‑ASCII content.

* **New Features**
  * UTF‑8 string types and VM helpers exposed to APIs for explicit UTF‑8 handling.

* **Bug Fixes**
  * Stricter string extraction yields earlier, clearer errors and reduces lossy conversions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->