### PR TITLE
Don't skip `test_glob` on windows

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -29,7 +29,6 @@ env:
   # test_posixpath: OSError: (22, 'The filename, directory name, or volume label syntax is incorrect. (os error 123)')
   # test_venv: couple of failing tests
   WINDOWS_SKIPS: >-
-    test_glob
     test_rlcompleter
     test_pathlib
     test_posixpath


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Windows CI test configuration to run test_glob tests instead of skipping them.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->