### PR TITLE
`ast.NodeVisitor` for import tracking

### DIFF
--- a/scripts/update_lib/cmd_todo.py
+++ b/scripts/update_lib/cmd_todo.py
@@ -334,7 +334,7 @@ def compute_test_todo_list(
             test_order = lib_test_order[lib_name].index(test_name)
         else:
             # Extract lib name from test name (test_foo -> foo)
-            lib_name = test_name.removeprefix("test_")
+            lib_name = test_name.removeprefix("test_").removeprefix("_test")
             test_order = 0  # Default order for tests not in DEPENDENCIES
 
         # Check if corresponding lib is up-to-date

--- a/scripts/update_lib/deps.py
+++ b/scripts/update_lib/deps.py
@@ -11,7 +11,6 @@ import ast
 import difflib
 import functools
 import pathlib
-import re
 import shelve
 import subprocess
 
@@ -32,62 +31,98 @@ from update_lib.file_utils import (
 # === Import parsing utilities ===
 
 
-def _extract_top_level_code(content: str) -> str:
-    """Extract only top-level code from Python content for faster parsing."""
-    def_idx = content.find("\ndef ")
-    class_idx = content.find("\nclass ")
+class ImportVisitor(ast.NodeVisitor):
+    def __init__(self) -> None:
+        self.test_imports = set()
+        self.lib_imports = set()
 
-    indices = [i for i in (def_idx, class_idx) if i != -1]
-    if indices:
-        content = content[: min(indices)]
-    return content.rstrip("\n")
+    def add_import(self, name: str) -> None:
+        """
+        Add an `import` to its correct slot (`test_imports` or `lib_imports`).
 
+        Parameters
+        ----------
+        name : str
+            Module name.
+        """
+        if name.startswith("test.support"):
+            return
 
-_FROM_TEST_IMPORT_RE = re.compile(r"^from test import (.+)", re.MULTILINE)
-_FROM_TEST_DOT_RE = re.compile(r"^from test\.(\w+)", re.MULTILINE)
-_IMPORT_TEST_DOT_RE = re.compile(r"^import test\.(\w+)", re.MULTILINE)
+        real_name = name.split(".", 1)[-1]
+        if name.startswith("test."):
+            self.test_imports.add(real_name)
+        else:
+            self.lib_imports.add(real_name)
+
+    def visit_Import(self, node):
+        for alias in node.names:
+            self.add_import(alias.name)
+
+    def visit_ImportFrom(self, node):
+        try:
+            module = node.module
+        except AttributeError:
+            # Ignore `from . import my_internal_module`
+            return
+
+        for name in node.names:
+            self.add_import(f"{module}.{name}")
+
+    def visit_Call(self, node) -> None:
+        """
+        In test files, there's sometimes use of:
+
+        ```python
+        import test.support
+        from test.support import script_helper
+
+        script = support.findfile("_test_atexit.py")
+        script_helper.run_test_script(script)
+        ```
+
+        This imports "_test_atexit.py" but does not show as an import node.
+        """
+        func = node.func
+        if not isinstance(func, ast.Attribute):
+            return
+
+        value = func.value
+        if not isinstance(value, ast.Name):
+            return
+
+        if (value.id != "support") or (func.attr != "findfile"):
+            return
+
+        arg = node.args[0]
+        if not isinstance(arg, ast.Constant):
+            return
+
+        target = arg.value
+        if not target.endswith(".py"):
+            return
+
+        target = target.removesuffix(".py")
+        self.add_import(f"test.{target}")
 
 
 def parse_test_imports(content: str) -> set[str]:
     """Parse test file content and extract test package dependencies."""
-    content = _extract_top_level_code(content)
-    imports = set()
+    if not (tree := safe_parse_ast(content)):
+        return set()
 
-    for match in _FROM_TEST_IMPORT_RE.finditer(content):
-        import_list = match.group(1)
-        for part in import_list.split(","):
-            name = part.split()[0].strip()
-            if name and name not in ("support", "__init__"):
-                imports.add(name)
-
-    for match in _FROM_TEST_DOT_RE.finditer(content):
-        dep = match.group(1)
-        if dep not in ("support", "__init__"):
-            imports.add(dep)
-
-    for match in _IMPORT_TEST_DOT_RE.finditer(content):
-        dep = match.group(1)
-        if dep not in ("support", "__init__"):
-            imports.add(dep)
-
-    return imports
-
-
-_IMPORT_RE = re.compile(r"^import\s+(\w[\w.]*)", re.MULTILINE)
-_FROM_IMPORT_RE = re.compile(r"^from\s+(\w[\w.]*)\s+import", re.MULTILINE)
+    visitor = ImportVisitor()
+    visitor.visit(tree)
+    return visitor.test_imports
 
 
 def parse_lib_imports(content: str) -> set[str]:
     """Parse library file and extract all imported module names."""
-    imports = set()
+    if not (tree := safe_parse_ast(content)):
+        return set()
 
-    for match in _IMPORT_RE.finditer(content):
-        imports.add(match.group(1))
-
-    for match in _FROM_IMPORT_RE.finditer(content):
-        imports.add(match.group(1))
-
-    return imports
+    visitor = ImportVisitor()
+    visitor.visit(tree)
+    return visitor.lib_imports
 
 
 # === TODO marker utilities ===
@@ -104,7 +139,7 @@ def filter_rustpython_todo(content: str) -> str:
 
 def count_rustpython_todo(content: str) -> int:
     """Count lines containing RustPython TODO markers."""
-    return sum(1 for line in content.splitlines() if TODO_MARKER in line)
+    return content.count(TODO_MARKER)
 
 
 def count_todo_in_path(path: pathlib.Path) -> int:
@@ -113,10 +148,7 @@ def count_todo_in_path(path: pathlib.Path) -> int:
         content = safe_read_text(path)
         return count_rustpython_todo(content) if content else 0
 
-    total = 0
-    for _, content in read_python_files(path):
-        total += count_rustpython_todo(content)
-    return total
+    return sum(count_rustpython_todo(content) for _, content in read_python_files(path))
 
 
 # === Test utilities ===


### PR DESCRIPTION
New output:
- [x] [no deps] `abc` (18 dependents) | 2025-06-29
  - [x] `test_abc` (1 TODO)
- [x] [no deps] `struct` (17 dependents) | 2026-01-21
  - [x] `test_struct` (7 TODO)
- [x] [no deps] `stat` (13 dependents) | 2026-02-14
  - [x] `test_stat`
- [x] [no deps] `operator` (7 dependents) | 2026-01-23
  - [x] `test_operator`
- [x] [no deps] `enum` (7 dependents) | 2026-02-15
  - [x] `test_enum` (4 TODO)
- [x] [no deps] `signal` (6 dependents) | 2024-04-26
  - [x] `test_signal` (1 TODO)
- [x] [no deps] `selectors` (6 dependents) | 2025-07-20
  - [x] `test_selectors`
- [x] [no deps] `keyword` (5 dependents) | 2024-06-21
  - [x] `test_keyword`
- [x] [no deps] `token` (5 dependents) | 2026-01-22
- [x] [no deps] `shlex` (4 dependents) | 2026-02-02
  - [x] `test_shlex` (4 TODO)
- [x] [no deps] `__future__` (3 dependents) | 2024-04-23
  - [x] `test_future_stmt` (8 TODO)
- [x] [no deps] `bisect` (3 dependents) | 2023-12-24
  - [x] `test_bisect`
- [x] [no deps] `numbers` (3 dependents) | 2025-09-11
  - [x] `test_abstract_numbers`
- [x] [no deps] `reprlib` (3 dependents) | 2026-01-21
  - [x] `test_reprlib` (2 TODO)
- [x] [no deps] `annotationlib` (2 dependents) | 2026-02-24
  - [x] `test_annotationlib`
- [x] [no deps] `tty` (2 dependents) | 2026-01-05
  - [x] `test_tty` (2 TODO)
- [x] [no deps] `cmd` (2 dependents) | 2026-01-24
  - [x] `test_cmd`
- [x] [no deps] `stringprep` (1 dependents) | 2019-12-21
  - [x] `test_stringprep`
- [x] [no deps] `_ios_support` (1 dependents) | 2025-03-10
- [x] [no deps] `__hello__` | 2023-02-25
- [x] [no deps] `__phello__` | 2023-02-25
- [x] [no deps] `colorsys` | 2025-04-21
  - [x] `test_colorsys`
- [x] [no deps] `this` | 2019-06-22
- [x] [no deps] `graphlib` | 2026-01-18
  - [x] `test_graphlib`
- [ ] [no deps] `opcode` | 2026-01-26 Δ313
  - [x] `test__opcode` (2 TODO)
  - [x] `test_opcodes`
- [x] [0/4 deps] `re` (59 dependents) | 2026-01-20
  - [ ] `test_re` (14 TODO)
- [x] [0/7 deps] `argparse` (26 dependents) | 2026-02-07
  - [x] `test_argparse`
- [x] [0/3 deps] `functools` (26 dependents) | 2026-01-20
  - [ ] `test_functools` (9 TODO)
- [x] [0/2 deps] `types` (25 dependents) | 2026-02-18
  - [ ] `test_types` (10 TODO)
- [x] [0/2 deps] `threading` (20 dependents) | 2026-01-18
  - [ ] `test_threading` (18 TODO)
  - [ ] `test_threadedtempfile`
  - [ ] `test_threading_local` (3 TODO)
- [x] [0/3 deps] `socket` (17 dependents) | 2026-02-01
  - [ ] `test_socket` (16 TODO)
- [x] [0/3 deps] `contextlib` (16 dependents) | 2025-08-01
  - [ ] `test_contextlib` (2 TODO)
  - [ ] `test_contextlib_async` (2 TODO)
- [ ] [0/4 deps] `collections` (15 dependents) | 2026-02-14 Δ61
  - [x] `test_collections` (3 TODO)
  - [x] `test_deque` (3 TODO)
  - [x] `test_defaultdict` (1 TODO)
  - [x] `test_ordered_dict` (8 TODO)
- [x] [0/1 deps] `weakref` (14 dependents) | 2026-01-30
  - [x] `test_weakref` (20 TODO)
  - [ ] `test_weakset`
- [x] [0/2 deps] `copy` (11 dependents) | 2026-02-10
  - [x] `test_copy`
- [x] [0/3 deps] `base64` (10 dependents) | 2026-01-19
  - [ ] `test_base64`
- [x] [0/1 deps] `getopt` (10 dependents) | 2026-02-08
  - [x] `test_getopt`
- [ ] [0/7 deps] `tempfile` (10 dependents) | 2026-01-04 Δ26
  - [ ] `test_tempfile` (1 TODO)
- [x] [0/4 deps] `posixpath` (9 dependents) | 2026-02-13
  - [x] `test_posixpath`
- [ ] [0/5 deps] `pickle` (8 dependents) | 2026-02-05 Δ8
  - [ ] `test_pickle` (21 TODO)
  - [ ] `test_picklebuffer` (12 TODO)
  - [ ] `test_pickletools` (8 TODO)
- [ ] [0/4 deps] `ssl` (8 dependents) | 2025-10-28 Δ4
  - [ ] `test_ssl` (21 TODO)
- [x] [0/1 deps] `textwrap` (7 dependents) | 2026-01-30
  - [x] `test_textwrap`
- [x] [0/2 deps] `codecs` (7 dependents) | 2026-01-31
  - [ ] `test_codecs` (12 TODO)
  - [ ] `test_codeccallbacks` (9 TODO)
  - [x] `test_codecencodings_cn` (4 TODO)
  - [x] `test_codecencodings_hk` (1 TODO)
  - [x] `test_codecencodings_iso2022` (5 TODO)
  - [x] `test_codecencodings_jp` (7 TODO)
  - [x] `test_codecencodings_kr` (3 TODO)
  - [x] `test_codecencodings_tw` (1 TODO)
  - [ ] `test_codecmaps_cn` (3 TODO)
  - [ ] `test_codecmaps_hk` (1 TODO)
  - [ ] `test_codecmaps_jp` (6 TODO)
  - [ ] `test_codecmaps_kr` (3 TODO)
  - [ ] `test_codecmaps_tw` (3 TODO)
  - [ ] `test_charmapcodec`
  - [ ] `test_multibytecodec` (untracked)
- [ ] [0/6 deps] `locale` (7 dependents) | 2025-08-20 Δ11
  - [ ] `test_locale`
  - [x] `test__locale`
- [x] [0/3 deps] `ast` (7 dependents) | 2026-02-02
  - [ ] `test_ast` (54 TODO)
  - [x] `test_unparse`
  - [x] `test_type_comments` (15 TODO)
- [x] [0/4 deps] `fnmatch` (6 dependents) | 2026-02-13
  - [x] `test_fnmatch`
- [x] [0/2 deps] `bz2` (6 dependents) | 2026-01-19
  - [x] `test_bz2` (1 TODO)
- [x] [0/2 deps] `runpy` (5 dependents) | 2025-09-11
  - [x] `test_runpy` (2 TODO)
- [ ] [0/3 deps] `json` (5 dependents) | 2026-01-18 Δ14
  - [ ] `test_json` (14 TODO)
- [ ] [0/2 deps] `random` (5 dependents) | 2024-11-11 Δ149
  - [ ] `test_random`
- [x] [0/2 deps] `copyreg` (4 dependents) | 2026-01-24
  - [x] `test_copyreg`
- [x] [0/1 deps] `difflib` (4 dependents) | 2026-02-08
  - [x] `test_difflib`
- [x] [0/2 deps] `lzma` (4 dependents) | 2026-01-19
  - [x] `test_lzma` (49 TODO)
- [x] [0/2 deps] `queue` (4 dependents) | 2026-02-04
  - [x] `test_queue`
- [x] [0/1 deps] `_colorize` (4 dependents) | 2026-01-17
  - [x] `test__colorize`
- [x] [0/1 deps] `heapq` (3 dependents) | 2026-01-18
  - [x] `test_heapq`
- [x] [0/2 deps] `hmac` (3 dependents) | 2026-02-15
  - [ ] `test_hmac` (14 TODO)
- [x] [0/1 deps] `string` (3 dependents) | 2026-01-17
  - [x] `test_string`
  - [x] `test_userstring`
- [x] [0/1 deps] `contextvars` (3 dependents) | 2026-01-18
- [x] [0/5 deps] `socketserver` (3 dependents) | 2026-01-03
  - [ ] `test_socketserver` (1 TODO)
- [x] [0/5 deps] `gzip` (3 dependents) | 2026-01-19
  - [x] `test_gzip`
- [ ] [0/5 deps] `pkgutil` (3 dependents) | 2026-01-04 Δ57
  - [ ] `test_pkgutil` (1 TODO)
- [x] [0/15 deps] `zipfile` (3 dependents) | 2026-02-24
  - [ ] `test_zipfile` (15 TODO)
  - [x] `test_zipfile64`
- [x] [0/3 deps] `ntpath` (3 dependents) | 2026-01-25
  - [x] `test_ntpath`
- [x] [0/7 deps] `pathlib` (3 dependents) | 2026-02-13
  - [x] `test_pathlib`
- [x] [0/2 deps] `codeop` (2 dependents) | 2026-02-07
  - [x] `test_codeop` (4 TODO)
- [x] [0/2 deps] `genericpath` (2 dependents) | 2025-08-04
  - [x] `test_genericpath`
- [x] [0/8 deps] `glob` (2 dependents) | 2026-02-13
  - [x] `test_glob`
- [x] [0/2 deps] `html` (2 dependents) | 2026-02-15
  - [x] `test_html`
  - [x] `test_htmlparser`
- [ ] [0/6 deps] `plistlib` (2 dependents) | 2026-01-04 Δ2
  - [ ] `test_plistlib` (6 TODO)
- [x] [0/2 deps] `code` (2 dependents) | 2026-02-01
  - [ ] `test_code` (11 TODO)
  - [x] `test_code_module` (3 TODO)
- [x] [0/4 deps] `py_compile` (2 dependents) | 2026-01-30
  - [x] `test_py_compile` (3 TODO)
- [x] [0/1 deps] `quopri` (2 dependents) | 2026-01-24
  - [x] `test_quopri`
- [ ] [0/8 deps] `bdb` (2 dependents) | 2025-12-30 Δ271
  - [ ] `test_bdb` (33 TODO)
- [x] [0/2 deps] `mimetypes` (2 dependents) | 2026-01-21
  - [x] `test_mimetypes`
- [ ] [0/3 deps] `pstats` (2 dependents)
  - [ ] `test_pstats` (untracked)
- [x] [0/6 deps] `encodings` (2 dependents) | 2026-02-06
- [x] [0/2 deps] `ipaddress` (1 dependents) | 2026-01-18
  - [x] `test_ipaddress`
- [x] [0/2 deps] `netrc` (1 dependents) | 2025-08-20
  - [x] `test_netrc`
- [x] [0/2 deps] `pyclbr` (1 dependents) | 2025-07-25
  - [ ] `test_pyclbr` (2 TODO)
- [x] [0/1 deps] `secrets` (1 dependents) | 2025-07-17
  - [x] `test_secrets`
- [ ] [0/2 deps] `site` (1 dependents) | 2026-01-17 Δ29
  - [ ] `test_site` (4 TODO)
- [x] [0/3 deps] `filecmp` (1 dependents) | 2026-01-03
  - [x] `test_filecmp`
- [x] [0/7 deps] `dataclasses` (1 dependents) | 2026-02-08
  - [x] `test_dataclasses` (10 TODO)
- [x] [0/4 deps] `getpass` (1 dependents) | 2026-02-08
  - [x] `test_getpass`
- [x] [0/4 deps] `rlcompleter` (1 dependents) | 2025-07-17
  - [ ] `test_rlcompleter` (1 TODO)
- [x] [0/5 deps] `configparser` (1 dependents) | 2026-02-07
  - [x] `test_configparser`
- [x] [0/6 deps] `dbm` (1 dependents) | 2026-01-01
  - [ ] `test_dbm` (2 TODO)
  - [x] `test_dbm_dumb`
  - [ ] `test_dbm_gnu` (untracked)
  - [ ] `test_dbm_ndbm` (untracked)
  - [x] `test_dbm_sqlite3`
- [x] [0/2 deps] `sqlite3` (1 dependents) | 2026-01-19
  - [ ] `test_sqlite3` (82 TODO)
- [x] [0/2 deps] `zipimport` (1 dependents) | 2026-01-24
  - [x] `test_zipimport` (2 TODO)
  - [ ] `test_zipimport_support` (untracked)
- [ ] [0/11 deps] `tarfile` (1 dependents) | 2025-05-07 Δ527
  - [ ] `test_tarfile` (3 TODO)
- [x] [0/2 deps] `csv` (1 dependents) | 2026-02-18
  - [x] `test_csv` (27 TODO)
- [x] [0/1 deps] `_apple_support` | 2025-03-10
- [x] [0/2 deps] `nturl2path` | 2026-01-25
  - [x] `test_nturl2path`
- [ ] [0/7 deps] `zipapp` | 2025-08-06 Δ14
  - [ ] `test_zipapp`
- [x] [0/6 deps] `fileinput` | 2025-04-30
  - [ ] `test_fileinput`
- [x] [0/4 deps] `fractions` | 2026-01-30
  - [x] `test_fractions` (2 TODO)
- [x] [0/2 deps] `optparse` | 2026-01-30
  - [x] `test_optparse`
- [x] [0/3 deps] `wave` | 2026-02-13
  - [x] `test_wave`
- [ ] [0/1 deps] `_android_support` | 2025-10-22 Δ7
- [ ] [0/4 deps] `modulefinder`
  - [ ] `test_modulefinder` (untracked)
- [x] [0/2 deps] `sched` | 2025-04-21
  - [x] `test_sched`
- [x] [0/2 deps] `shelve` | 2026-01-01
  - [x] `test_shelve`
- [x] [0/5 deps] `timeit` | 2026-02-01
  - [x] `test_timeit`
- [ ] [0/1 deps] `curses`
  - [ ] `test_curses` (untracked)
- [ ] [0/2 deps] `pty` | 2026-01-05 Δ51
  - [ ] `test_pty` (4 TODO)
- [x] [0/9 deps] `xmlrpc` | 2026-02-14
  - [x] `test_xmlrpc` (5 TODO)
  - [x] `test_docxmlrpc`
- [x] [0/5 deps] `compression` | 2026-01-19
- [x] [0/2 deps] `symtable` | 2026-01-30
  - [ ] `test_symtable` (17 TODO)
- [x] [0/2 deps] `tomllib` | 2026-02-08
  - [x] `test_tomllib`
- [x] [1/7 deps] `os` (84 dependents) | 2026-02-03
  - [ ] `test_os` (3 TODO)
  - [x] `test_popen`
- [x] [1/6 deps] `warnings` (53 dependents) | 2026-01-18
  - [ ] `test_warnings` (12 TODO)
- [x] [1/6 deps] `io` (42 dependents) | 2026-02-13
  - [ ] `test_io` (21 TODO)
  - [x] `test_bufio`
  - [x] `test_fileio` (1 TODO)
  - [ ] `test_memoryio` (28 TODO)
- [x] [1/11 deps] `traceback` (17 dependents) | 2026-02-06
  - [ ] `test_traceback` (34 TODO)
- [x] [1/13 deps] `inspect` (14 dependents) | 2026-02-07
  - [ ] `test_inspect` (46 TODO)
- [ ] [1/9 deps] `subprocess` (14 dependents) | 2026-02-04 Δ2
  - [x] `test_subprocess` (4 TODO)
- [x] [1/2 deps] `linecache` (12 dependents) | 2026-02-09
  - [x] `test_linecache`
- [ ] [1/5 deps] `tokenize` (11 dependents) | 2022-08-09 Δ357
  - [ ] `test_tokenize` (2 TODO)
- [x] [1/6 deps] `datetime` (7 dependents) | 2026-02-24
  - [ ] `test_datetime`
  - [ ] `test_strptime` (untracked)
- [x] [1/4 deps] `calendar` (5 dependents) | 2026-01-17
  - [x] `test_calendar`
- [x] [1/1 deps] `hashlib` (5 dependents) | 2026-02-14
  - [x] `test_hashlib` (7 TODO)
- [x] [1/4 deps] `dis` (5 dependents) | 2026-01-26
  - [ ] `test_dis` (43 TODO)
- [ ] [1/7 deps] `webbrowser` (4 dependents) | 2025-04-21 Δ49
  - [ ] `test_webbrowser`
- [x] [1/3 deps] `pprint` (3 dependents) | 2026-02-06
  - [x] `test_pprint`
- [ ] [1/11 deps] `email` (3 dependents) | 2026-01-17 Δ238
  - [ ] `test_email` (12 TODO)
- [x] [1/10 deps] `typing` (2 dependents) | 2026-02-11
  - [ ] `test_typing` (4 TODO)
  - [x] `test_type_aliases`
  - [x] `test_type_annotations` (1 TODO)
  - [x] `test_type_params` (6 TODO)
  - [x] `test_genericalias`
- [x] [1/3 deps] `tabnanny` (1 dependents) | 2026-02-02
  - [ ] `test_tabnanny` (5 TODO)
- [x] [1/4 deps] `ftplib` (1 dependents) | 2026-02-02
  - [x] `test_ftplib` (4 TODO)
- [ ] [1/8 deps] `smtplib` (1 dependents) | 2025-12-19 Δ11
  - [x] `test_smtplib`
  - [x] `test_smtpnet`
- [ ] [1/4 deps] `profile` (1 dependents)
  - [ ] `test_profile` (untracked)
  - [ ] `test_cprofile` (untracked)
- [ ] [1/3 deps] `tracemalloc` (1 dependents)
  - [ ] `test_tracemalloc` (untracked)
- [x] [1/2 deps] `antigravity` | 2023-02-28
- [ ] [1/4 deps] `poplib`
  - [ ] `test_poplib` (untracked)
- [x] [1/5 deps] `pickletools` | 2026-02-06
- [x] [1/6 deps] `gettext` | 2026-01-30
  - [x] `test_gettext` (7 TODO)
- [x] [1/7 deps] `compileall` | 2026-02-25
  - [x] `test_compileall` (2 TODO)
- [x] [1/8 deps] `mailbox` | 2026-02-14
  - [x] `test_mailbox`
- [x] [1/5 deps] `decimal` | 2026-01-30
  - [ ] `test_decimal` (1 TODO)
- [ ] [1/5 deps] `wsgiref` | 2026-01-03 Δ7
  - [ ] `test_wsgiref` (1 TODO)
- [x] [1/2 deps] `statistics` | 2026-02-11
  - [ ] `test_statistics` (1 TODO)
- [ ] [1/11 deps] `xml` | 2025-08-21 Δ35
  - [ ] `test_xml_etree` (55 TODO)
  - [ ] `test_xml_etree_c`
  - [ ] `test_minidom` (untracked)
  - [ ] `test_pulldom` (4 TODO)
  - [ ] `test_pyexpat` (28 TODO)
  - [ ] `test_sax` (untracked)
  - [x] `test_xml_dom_minicompat`
  - [x] `test_xml_dom_xmlbuilder`
- [x] [2/9 deps] `shutil` (12 dependents) | 2026-02-15
  - [x] `test_shutil`
- [ ] [2/9 deps] `tkinter` (2 dependents) | 2025-04-06 Δ279
  - [ ] `test_tkinter` (untracked)
  - [ ] `test_ttk` (untracked)
  - [ ] `test_ttk_textonly` (untracked)
  - [ ] `test_tcl` (untracked)
  - [ ] `test_idle` (untracked)
- [x] [2/12 deps] `doctest` (1 dependents) | 2026-02-11
  - [ ] `test_doctest` (9 TODO)
- [ ] [2/5 deps] `cProfile`
- [ ] [3/11 deps] `sysconfig` (6 dependents) | 2025-10-22 Δ265
  - [ ] `test_sysconfig` (8 TODO)
  - [ ] `test__osx_support`
- [ ] [3/11 deps] `platform` (4 dependents) | 2026-01-04 Δ124
  - [ ] `test_platform`
- [x] [3/9 deps] `ctypes` (3 dependents) | 2026-02-18
  - [ ] `test_ctypes` (11 TODO)
  - [x] `test_stable_abi_ctypes`
- [x] [3/9 deps] `uuid` (1 dependents) | 2026-02-02
  - [x] `test_uuid`
- [ ] [3/8 deps] `venv` | 2026-01-17 Δ29
  - [ ] `test_venv` (4 TODO)
- [ ] [3/12 deps] `trace` | 2025-07-25 Δ15
  - [ ] `test_trace` (14 TODO)
- [x] [3/5 deps] `ensurepip` | 2026-01-17
  - [x] `test_ensurepip`
- [x] [3/10 deps] `imaplib` | 2026-02-01
  - [x] `test_imaplib` (1 TODO)
- [ ] [3/11 deps] `zoneinfo` | 2025-09-07 Δ24
  - [ ] `test_zoneinfo` (3 TODO)
- [ ] [3/23 deps] `http` | 2026-01-16 Δ198
  - [ ] `test_httplib`
  - [ ] `test_http_cookiejar`
  - [ ] `test_http_cookies`
  - [ ] `test_httpservers` (1 TODO)
- [ ] [3/7 deps] `turtle`
  - [ ] `test_turtle` (untracked)
- [ ] [4/19 deps] `logging` (7 dependents) | 2025-07-20 Δ77
  - [ ] `test_logging` (5 TODO)
- [ ] [4/20 deps] `unittest` (2 dependents) | 2026-01-18 Δ102
  - [ ] `test_unittest` (15 TODO)
- [x] [4/19 deps] `urllib` (1 dependents) | 2026-02-13
  - [x] `test_urllib`
  - [x] `test_urllib2`
  - [ ] `test_urllib2_localnet`
  - [x] `test_urllib2net`
  - [x] `test_urllibnet`
  - [x] `test_urlparse`
  - [x] `test_urllib_response`
  - [x] `test_robotparser`
- [ ] [4/10 deps] `concurrent` | 2026-01-09 Δ1012
  - [ ] `test_concurrent_futures` (18 TODO)
  - [ ] `test_interpreters` (untracked)
  - [ ] `test__interpreters` (untracked)
  - [ ] `test__interpchannels` (untracked)
  - [ ] `test_crossinterp` (untracked)
- [x] [5/15 deps] `pydoc` (4 dependents) | 2026-02-13
  - [ ] `test_pydoc` (36 TODO)
- [x] [5/21 deps] `importlib` (4 dependents) | 2026-02-05
  - [ ] `test_importlib` (16 TODO)
- [ ] [5/27 deps] `multiprocessing` (2 dependents) | 2026-02-04 Δ314
  - [ ] `test_multiprocessing_fork` (35 TODO)
  - [ ] `test_multiprocessing_forkserver` (10 TODO)
  - [ ] `test_multiprocessing_spawn` (13 TODO)
  - [x] `test_multiprocessing_main_handling`
- [ ] [5/32 deps] `pdb` (1 dependents) | 2026-02-11 Δ2601
  - [ ] `test_pdb` (untracked)
- [ ] [5/25 deps] `_pyrepl` | 2025-04-11 Δ2534
- [ ] [7/32 deps] `asyncio` (2 dependents) | 2026-02-02 Δ26
  - [ ] `test_asyncio` (38 TODO)
- [ ] [10/39 deps] `idlelib`

## Standalone Tests
- [ ] `test_atexit`
  - [ ] `_test_atexit`
- [x] `test_eintr`
  - [ ] `_test_eintr` (6 TODO)
- [ ] `_test_embed_structseq` (untracked)
- [ ] `_test_gc_fast_cycles` (untracked)
- [ ] `_test_monitoring_shutdown` (untracked)
- [ ] `_test_multiprocessing` (15 TODO)
- [x] `_test_venv_multiprocessing`
- [x] `test___all__`
- [ ] `test_android`
- [x] `test_apple`
- [ ] `test_array` (55 TODO)
- [ ] `test_asdl_parser` (untracked)
- [x] `test_asyncgen` (4 TODO)
- [ ] `test_audit`
- [x] `test_augassign`
- [x] `test_exceptions` (25 TODO)
  - [ ] `test_baseexception`
  - [x] `test_except_star` (1 TODO)
  - [x] `test_exception_group` (3 TODO)
  - [x] `test_exception_hierarchy` (2 TODO)
  - [x] `test_exception_variations`
- [x] `test_bigaddrspace`
- [ ] `test_bigmem` (4 TODO)
- [x] `test_binascii` (1 TODO)
- [x] `test_binop`
- [x] `test_bool`
- [x] `test_buffer` (11 TODO)
- [ ] `test_build_details` (untracked)
- [x] `test_builtin` (25 TODO)
- [ ] `test_bytes` (17 TODO)
- [ ] `test_c_locale_coercion`
- [ ] `test_call` (1 TODO)
- [ ] `test_capi` (untracked)
- [ ] `test_cext` (untracked)
- [ ] `test_class` (15 TODO)
  - [x] `test_genericclass`
  - [x] `test_subclassinit`
- [ ] `test_clinic` (untracked)
- [x] `test_cmath`
- [ ] `test_cmd_line` (24 TODO)
- [ ] `test_cmd_line_script` (15 TODO)
- [x] `test_compare`
- [ ] `test_compile` (24 TODO)
  - [x] `test_compiler_assemble`
  - [x] `test_compiler_codegen`
  - [x] `test_peepholer` (31 TODO)
- [ ] `test_complex` (2 TODO)
- [x] `test_contains` (1 TODO)
- [ ] `test_context` (6 TODO)
- [x] `test_coroutines` (19 TODO)
- [ ] `test_cppext` (untracked)
- [ ] `test_decorators` (1 TODO)
- [ ] `test_descr` (47 TODO)
  - [ ] `test_descrtut` (3 TODO)
- [x] `test_devpoll`
- [x] `test_dict` (6 TODO)
  - [x] `test_dictcomps` (1 TODO)
  - [x] `test_dictviews` (2 TODO)
  - [x] `test_userdict`
- [ ] `test_dtrace` (8 TODO)
- [ ] `test_dynamic` (1 TODO)
- [ ] `test_dynamicclassattribute`
- [ ] `test_embed` (untracked)
- [x] `test_enumerate`
- [x] `test_eof` (6 TODO)
- [x] `test_epoll`
- [x] `test_errno`
- [ ] `test_extcall` (8 TODO)
- [ ] `test_external_inspection` (untracked)
- [x] `test_faulthandler` (4 TODO)
- [ ] `test_fcntl`
  - [ ] `test_ioctl`
- [ ] `test_file`
  - [ ] `test_largefile`
- [ ] `test_file_eintr` (1 TODO)
- [ ] `test_fileutils` (untracked)
- [ ] `test_finalization` (untracked)
- [x] `test_float` (6 TODO)
  - [ ] `test_strtod` (6 TODO)
- [x] `test_flufl` (4 TODO)
- [x] `test_fork1` (1 TODO)
- [ ] `test_format` (5 TODO)
- [ ] `test_frame` (untracked)
- [ ] `test_free_threading` (untracked)
- [x] `test_frozen`
- [ ] `test_str` (16 TODO)
  - [x] `test_fstring` (19 TODO)
  - [ ] `test_string_literals` (5 TODO)
- [x] `test_funcattrs` (6 TODO)
- [x] `test_gc`
- [ ] `test_gdb` (untracked)
- [ ] `test_generated_cases` (untracked)
- [ ] `test_generators` (12 TODO)
  - [ ] `test_genexps` (untracked)
  - [ ] `test_generator_stop` (untracked)
  - [ ] `test_yield_from` (6 TODO)
- [ ] `test_getpath` (untracked)
- [ ] `test_global` (3 TODO)
- [ ] `test_grammar` (18 TODO)
- [x] `test_grp`
- [ ] `test_hash` (4 TODO)
- [ ] `test_import` (3 TODO)
- [x] `test_index`
- [ ] `test_int` (7 TODO)
  - [x] `test_long` (4 TODO)
  - [x] `test_int_literal`
- [ ] `test_isinstance`
- [x] `test_iter` (1 TODO)
- [x] `test_iterlen`
- [x] `test_itertools` (6 TODO)
- [x] `test_keywordonlyarg`
- [x] `test_kqueue`
- [x] `test_launcher`
- [x] `test_list` (5 TODO)
  - [x] `test_listcomps` (1 TODO)
  - [ ] `test_userlist` (1 TODO)
- [ ] `test_lltrace` (untracked)
- [x] `test_longexp`
- [ ] `test_marshal` (21 TODO)
- [x] `test_math`
  - [x] `test_math_property`
- [ ] `test_memoryview` (9 TODO)
- [ ] `test_metaclass` (10 TODO)
- [ ] `test_mmap` (2 TODO)
- [ ] `test_module` (4 TODO)
- [ ] `test_monitoring` (untracked)
- [x] `test_msvcrt`
- [ ] `test_named_expressions` (12 TODO)
- [x] `test_numeric_tower`
- [ ] `test_opcache`
- [x] `test_openpty`
- [ ] `test_optimizer` (untracked)
- [x] `test_osx_env`
- [ ] `test_patma` (20 TODO)
- [ ] `test_peg_generator` (untracked)
- [ ] `test_pep646_syntax` (12 TODO)
- [ ] `test_perf_profiler` (untracked)
- [ ] `test_perfmaps` (untracked)
- [ ] `test_pkg`
- [x] `test_select` (3 TODO)
  - [ ] `test_poll` (1 TODO)
- [x] `test_positional_only_arg` (4 TODO)
- [ ] `test_posix` (4 TODO)
- [x] `test_pow`
- [x] `test_print` (6 TODO)
- [x] `test_property`
- [x] `test_pwd`
- [ ] `test_pyrepl` (untracked)
  - [ ] `test_repl`
- [ ] `test_raise`
- [ ] `test_range` (1 TODO)
- [ ] `test_readline` (untracked)
- [ ] `test_regrtest` (10 TODO)
- [ ] `test_remote_pdb` (untracked)
- [ ] `test_resource` (2 TODO)
- [x] `test_richcmp`
- [x] `test_scope` (1 TODO)
- [x] `test_support` (3 TODO)
  - [ ] `test_script_helper`
- [ ] `test_set` (5 TODO)
- [x] `test_setcomps`
- [x] `test_slice` (1 TODO)
- [ ] `test_sort` (2 TODO)
- [ ] `test_source_encoding` (untracked)
- [ ] `test_startfile` (untracked)
- [x] `test_time`
  - [x] `test_strftime`
- [ ] `test_structseq`
- [x] `test_sundry`
- [ ] `test_super` (4 TODO)
- [ ] `test_syntax` (26 TODO)
- [x] `test_sys` (8 TODO)
  - [ ] `test_syslog` (2 TODO)
  - [ ] `test_sys_setprofile` (14 TODO)
  - [ ] `test_sys_settrace` (85 TODO)
- [x] `test_termios` (15 TODO)
- [ ] `test_thread`
  - [ ] `test_thread_local_bytecode` (untracked)
  - [x] `test_threadsignals`
- [ ] `test_timeout`
- [ ] `test_tools`
- [x] `test_tstring` (5 TODO)
- [ ] `test_tuple` (1 TODO)
- [ ] `test_type_cache` (untracked)
- [x] `test_typechecks`
- [ ] `test_unicodedata` (9 TODO)
  - [x] `test_unicode_file`
  - [ ] `test_unicode_file_functions`
  - [ ] `test_unicode_identifiers` (1 TODO)
  - [x] `test_ucn` (3 TODO)
- [x] `test_unary`
- [x] `test_univnewlines`
- [ ] `test_unpack` (1 TODO)
  - [ ] `test_unpack_ex` (11 TODO)
- [ ] `test_utf8_mode` (6 TODO)
- [ ] `test_utf8source` (2 TODO)
- [x] `test_wait3`
- [x] `test_wait4`
- [x] `test_winapi`
- [x] `test_winconsoleio`
- [x] `test_winreg`
- [x] `test_winsound`
- [x] `test_with` (1 TODO)
- [x] `test_wmi`
- [ ] `test_xpickle` (untracked)
- [ ] `test_xxlimited` (untracked)
- [ ] `test_xxtestfuzz` (untracked)
- [x] `test_zlib` (2 TODO)
- [x] `test_zstd`

## Untracked Files
- site-packages/README.txt

## Original Files
- PSF-LICENSE
- README.md
- _dummy_os.py
- _dummy_thread.py
- _pycodecs.py
- dummy_threading.py

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved test dependency mapping to accurately handle edge-case naming conventions, ensuring correct library associations and proper test execution ordering.
  * Enhanced import detection mechanism for more reliable identification of library and test dependencies.
  * Optimized TODO marker tracking system for simplified maintenance workflows and clearer project status visibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->