### PR TITLE
Fix IOBase.fileno() incorrect error message

### DIFF
--- a/crates/vm/src/stdlib/io.rs
+++ b/crates/vm/src/stdlib/io.rs
@@ -435,7 +435,7 @@ mod _io {
 
         #[pymethod]
         fn fileno(zelf: PyObjectRef, vm: &VirtualMachine) -> PyResult {
-            _unsupported(vm, &zelf, "truncate")
+            _unsupported(vm, &zelf, "fileno")
         }
 
         #[pyattr]


### PR DESCRIPTION
fileno() was calling _unsupported with "truncate" instead of "fileno", causing UnsupportedOperation('truncate') to be raised instead of UnsupportedOperation('fileno').

CPython 3.14 reference: Modules/_io/iobase.c calls iobase_unsupported(state, "fileno")

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed error message for unsupported file operations to display the correct operation name instead of an incorrect reference.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->