### PR TITLE
fix: add `readinto` and `write` methods to `RawIOBase`

### DIFF
--- a/crates/vm/src/stdlib/io.rs
+++ b/crates/vm/src/stdlib/io.rs
@@ -699,6 +699,16 @@ mod _io {
             }
             Ok(Some(ret))
         }
+
+        #[pymethod]
+        fn readinto(_instance: PyObjectRef, _args: FuncArgs, vm: &VirtualMachine) -> PyResult {
+            Err(vm.new_not_implemented_error(String::new()))
+        }
+
+        #[pymethod]
+        fn write(_instance: PyObjectRef, _args: FuncArgs, vm: &VirtualMachine) -> PyResult {
+            Err(vm.new_not_implemented_error(String::new()))
+        }
     }
 
     #[pyattr]


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling for I/O operations with explicit NotImplementedError behavior for unsupported I/O methods, providing clearer error messages when attempting to use unimplemented operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->