### PR TITLE
fix: add `flush` method to `BytesIO`

### DIFF
--- a/crates/vm/src/stdlib/io.rs
+++ b/crates/vm/src/stdlib/io.rs
@@ -4596,6 +4596,15 @@ mod _io {
         }
 
         #[pymethod]
+        fn flush(&self, vm: &VirtualMachine) -> PyResult<()> {
+            if self.closed.load() {
+                Err(io_closed_error(vm))
+            } else {
+                Ok(())
+            }
+        }
+
+        #[pymethod]
         fn write(&self, data: ArgBytesLike, vm: &VirtualMachine) -> PyResult<u64> {
             let mut buffer = self.try_resizable(vm)?;
             data.with_ref(|b| buffer.write(b))

--- a/extra_tests/snippets/stdlib_io_bytesio.py
+++ b/extra_tests/snippets/stdlib_io_bytesio.py
@@ -74,6 +74,30 @@ def test_06():
     assert f.readline() == b""
 
 
+def test_07():
+    """
+    Tests that flush() returns None when the file is open,
+    and raises ValueError when the file is closed.
+    CPython reference: Modules/_io/bytesio.c:325-335
+    """
+    f = BytesIO(b"Test String 7")
+
+    # flush() on an open BytesIO returns None
+    assert f.flush() is None
+
+    # flush() is defined directly on BytesIO (not just inherited)
+    assert "flush" in BytesIO.__dict__
+
+    f.close()
+
+    # flush() on a closed BytesIO raises ValueError
+    try:
+        f.flush()
+        assert False, "Expected ValueError not raised"
+    except ValueError:
+        pass
+
+
 if __name__ == "__main__":
     test_01()
     test_02()
@@ -81,3 +105,4 @@ if __name__ == "__main__":
     test_04()
     test_05()
     test_06()
+    test_07()


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * BytesIO class now includes a flush() method for improved stream management, providing proper error handling for closed streams.

* **Tests**
  * Added test coverage for the new BytesIO.flush() method, validating behavior on both open and closed streams.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->