### PR TITLE
sqlite3: handle int type in Connection.timeout parameter

### DIFF
--- a/Lib/test/test_sqlite3/test_dbapi.py
+++ b/Lib/test/test_sqlite3/test_dbapi.py
@@ -1930,7 +1930,6 @@ class MultiprocessTests(unittest.TestCase):
     def tearDown(self):
         unlink(TESTFN)
 
-    @unittest.expectedFailure  # TODO: RUSTPYTHON multiprocess test fails
     def test_ctx_mgr_rollback_if_commit_failed(self):
         # bpo-27334: ctx manager does not rollback if commit fails
         SCRIPT = f"""if 1:

--- a/Lib/test/test_sqlite3/test_transactions.py
+++ b/Lib/test/test_sqlite3/test_transactions.py
@@ -31,7 +31,6 @@ from .util import memory_database
 from .util import MemoryDatabaseMixin
 
 
-@unittest.skip("TODO: RUSTPYTHON timeout parameter does not accept int type")
 class TransactionTests(unittest.TestCase):
     def setUp(self):
         # We can disable the busy handlers, since we control


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * SQLite connection timeout now accepts both floating‑point and integer values, making it easier to supply timeouts in seconds or as whole numbers. The change is backward compatible: existing defaults and behavior are preserved while allowing mixed input types for more flexible configuration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->