### PR TITLE
sqlite3: reject negative arraysize values

### DIFF
--- a/Lib/test/test_sqlite3/test_dbapi.py
+++ b/Lib/test/test_sqlite3/test_dbapi.py
@@ -1088,7 +1088,6 @@ class CursorTests(unittest.TestCase):
 
         self.assertEqual(len(res), 2)
 
-    @unittest.expectedFailure  # TODO: RUSTPYTHON arraysize validation not implemented
     def test_invalid_array_size(self):
         UINT32_MAX = (1 << 32) - 1
         setter = functools.partial(setattr, self.cu, 'arraysize')

--- a/crates/stdlib/src/_sqlite3.rs
+++ b/crates/stdlib/src/_sqlite3.rs
@@ -1955,9 +1955,16 @@ mod _sqlite3 {
         fn arraysize(&self) -> c_int {
             self.arraysize.load(Ordering::Relaxed)
         }
+
         #[pygetset(setter)]
-        fn set_arraysize(&self, val: c_int) {
+        fn set_arraysize(&self, val: c_int, vm: &VirtualMachine) -> PyResult<()> {
+            if val < 0 {
+                return Err(vm.new_value_error("arraysize may not be negative"));
+            }
+
             self.arraysize.store(val, Ordering::Relaxed);
+
+            Ok(())
         }
 
         fn build_row_cast_map(


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * SQLite Cursor.arraysize attribute now validates input and raises an error when negative values are set, improving error handling and preventing invalid states.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->