### PR TITLE
add isatty() method in BytesIO

### DIFF
--- a/crates/vm/src/stdlib/io.rs
+++ b/crates/vm/src/stdlib/io.rs
@@ -4757,6 +4757,15 @@ mod _io {
 
             Ok(())
         }
+
+        #[pymethod]
+        fn isatty(&self, vm: &VirtualMachine) -> PyResult<bool> {
+            if self.closed() {
+                return Err(io_closed_error(vm));
+            }
+
+            Ok(false)
+        }
     }
 
     #[pyclass]


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for querying TTY device status on BytesIO streams. In-memory buffers now properly report as non-TTY devices when checked, consistent with CPython behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->