### PR TITLE
Edit dependency groups

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,9 +6,6 @@ updates:
     schedule:
       interval: weekly
     groups:
-      cranelift:
-        patterns:
-          - "cranelift*"
       criterion:
         patterns:
           - "criterion*"
@@ -113,6 +110,7 @@ updates:
           - "wasm-bindgen*"
       wasmtime:
         patterns:
+          - "cranelift*"
           - "wasmtime*"
       webpki-root:
         patterns:


### PR DESCRIPTION
So, as it turns out, in #7064 @dependabot didn't update all the random-related dependencies in a single PR.
Also, it might make more sense to fold the cranelift dependencies into the wasmtime group because cranelift is part of the wasmtime organization.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal dependency management configuration to reorganize how package updates are grouped and tracked. No impact to user-facing functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->