### PR TITLE
More accurate test dependencies

### DIFF
--- a/scripts/update_lib/cmd_todo.py
+++ b/scripts/update_lib/cmd_todo.py
@@ -146,7 +146,11 @@ def get_all_tests(cpython_prefix: str) -> list[str]:
     tests = set()
     for entry in test_dir.iterdir():
         # Skip non-test items
-        if not entry.name.startswith(("_test", "test_")):
+        if "test" not in entry.name:
+            continue
+
+        # Exclude special cases
+        if "regrtest" in entry.name:
             continue
 
         if entry.is_file() and entry.suffix == ".py":
@@ -333,8 +337,16 @@ def compute_test_todo_list(
             # Get order from DEPENDENCIES
             test_order = lib_test_order[lib_name].index(test_name)
         else:
-            # Extract lib name from test name (test_foo -> foo)
-            lib_name = test_name.removeprefix("test_").removeprefix("_test")
+            # Extract lib name from test name:
+            # - test_foo -> foo
+            # - datetimetester -> datetime
+            # - xmltests -> xml
+            lib_name = (
+                test_name.removeprefix("test_")
+                .removeprefix("_test")
+                .removesuffix("tester")
+                .removesuffix("tests")
+            )
             test_order = 0  # Default order for tests not in DEPENDENCIES
 
         # Check if corresponding lib is up-to-date


### PR DESCRIPTION
- [x] [no deps] `struct` (20 dependents) | 2026-01-21
  - [x] `test_struct` (7 TODO)
- [x] [no deps] `stat` (14 dependents) | 2026-02-14
  - [x] `test_stat`
- [x] [no deps] `keyword` (7 dependents) | 2024-06-21
  - [x] `test_keyword`
- [x] [no deps] `reprlib` (7 dependents) | 2026-01-21
  - [x] `test_reprlib` (2 TODO)
- [x] [no deps] `__future__` (6 dependents) | 2024-04-23
  - [x] `test_future_stmt` (8 TODO)
- [x] [no deps] `annotationlib` (6 dependents) | 2026-02-24
  - [x] `test_annotationlib`
- [x] [no deps] `token` (5 dependents) | 2026-01-22
- [x] [no deps] `bisect` (5 dependents) | 2023-12-24
  - [x] `test_bisect`
- [x] [no deps] `tty` (2 dependents) | 2026-01-05
  - [x] `test_tty` (2 TODO)
- [x] [no deps] `stringprep` (1 dependents) | 2019-12-21
  - [x] `test_stringprep`
- [x] [no deps] `__hello__` | 2023-02-25
- [x] [no deps] `__phello__` | 2023-02-25
- [x] [no deps] `colorsys` | 2025-04-21
  - [x] `test_colorsys`
- [x] [no deps] `this` | 2019-06-22
- [x] [0/8 deps] `os` (85 dependents) | 2026-02-03
  - [ ] `test_os` (2 TODO)
  - [x] `test_popen`
- [x] [0/4 deps] `re` (59 dependents) | 2026-01-20
  - [ ] `test_re` (14 TODO)
- [x] [0/2 deps] `types` (40 dependents) | 2026-02-18
  - [ ] `test_types` (10 TODO)
- [ ] [0/9 deps] `collections` (37 dependents) | 2026-02-14 Δ61
  - [x] `test_collections` (3 TODO)
  - [x] `test_deque` (3 TODO)
  - [x] `test_defaultdict` (1 TODO)
  - [x] `test_ordered_dict` (8 TODO)
- [x] [0/9 deps] `argparse` (29 dependents) | 2026-02-07
  - [x] `test_argparse`
- [x] [0/4 deps] `socket` (17 dependents) | 2026-02-01
  - [ ] `test_socket` (16 TODO)
- [x] [0/2 deps] `enum` (16 dependents) | 2026-02-15
  - [x] `test_enum` (4 TODO)
- [x] [0/4 deps] `weakref` (16 dependents) | 2026-01-30
  - [x] `test_weakref` (20 TODO)
  - [ ] `test_weakset`
- [x] [0/2 deps] `abc` (15 dependents) | 2025-06-29
  - [x] `test_abc` (1 TODO)
- [x] [0/3 deps] `copy` (14 dependents) | 2026-02-10
  - [x] `test_copy`
- [x] [0/1 deps] `operator` (14 dependents) | 2026-01-23
  - [x] `test_operator`
- [x] [0/2 deps] `getopt` (10 dependents) | 2026-02-08
  - [x] `test_getopt`
- [x] [0/3 deps] `base64` (10 dependents) | 2026-01-19
  - [ ] `test_base64`
- [x] [0/3 deps] `_colorize` (9 dependents) | 2026-01-17
  - [x] `test__colorize`
- [ ] [0/9 deps] `pickle` (9 dependents) | 2026-02-05 Δ8
  - [ ] `test_pickle` (21 TODO)
  - [ ] `test_picklebuffer` (12 TODO)
  - [ ] `test_pickletools` (8 TODO)
- [x] [0/4 deps] `posixpath` (9 dependents) | 2026-02-13
  - [x] `test_posixpath`
- [x] [0/1 deps] `textwrap` (8 dependents) | 2026-01-30
  - [x] `test_textwrap`
- [x] [0/4 deps] `fnmatch` (8 dependents) | 2026-02-13
  - [x] `test_fnmatch`
- [x] [0/2 deps] `codecs` (8 dependents) | 2026-01-31
  - [ ] `test_codecs` (12 TODO)
  - [ ] `test_codeccallbacks` (9 TODO)
  - [x] `test_codecencodings_cn` (4 TODO)
  - [x] `test_codecencodings_hk` (1 TODO)
  - [x] `test_codecencodings_iso2022` (5 TODO)
  - [x] `test_codecencodings_jp` (7 TODO)
  - [x] `test_codecencodings_kr` (3 TODO)
  - [x] `test_codecencodings_tw` (1 TODO)
  - [ ] `test_codecmaps_cn` (3 TODO)
  - [ ] `test_codecmaps_hk` (1 TODO)
  - [ ] `test_codecmaps_jp` (6 TODO)
  - [ ] `test_codecmaps_kr` (3 TODO)
  - [ ] `test_codecmaps_tw` (3 TODO)
  - [ ] `test_charmapcodec`
  - [ ] `test_multibytecodec` (untracked)
- [x] [0/12 deps] `pathlib` (8 dependents) | 2026-02-13
  - [x] `test_pathlib`
- [ ] [0/6 deps] `locale` (7 dependents) | 2025-08-20 Δ11
  - [ ] `test_locale`
  - [x] `test__locale`
- [ ] [0/8 deps] `random` (7 dependents) | 2024-11-11 Δ149
  - [ ] `test_random`
- [x] [0/2 deps] `copyreg` (6 dependents) | 2026-01-24
  - [x] `test_copyreg`
- [x] [0/1 deps] `signal` (6 dependents) | 2024-04-26
  - [x] `test_signal` (1 TODO)
- [x] [0/9 deps] `dataclasses` (6 dependents) | 2026-02-08
  - [x] `test_dataclasses` (10 TODO)
- [x] [0/2 deps] `bz2` (6 dependents) | 2026-01-19
  - [x] `test_bz2` (1 TODO)
- [x] [0/1 deps] `heapq` (5 dependents) | 2026-01-18
  - [x] `test_heapq`
- [ ] [0/4 deps] `json` (5 dependents) | 2026-01-18 Δ14
  - [ ] `test_json` (14 TODO)
- [ ] [0/9 deps] `webbrowser` (4 dependents) | 2025-04-21 Δ49
  - [ ] `test_webbrowser`
- [x] [0/8 deps] `glob` (4 dependents) | 2026-02-13
  - [x] `test_glob`
- [x] [0/6 deps] `socketserver` (4 dependents) | 2026-01-03
  - [ ] `test_socketserver` (1 TODO)
- [x] [0/3 deps] `code` (4 dependents) | 2026-02-01
  - [ ] `test_code` (11 TODO)
  - [x] `test_code_module` (3 TODO)
- [x] [0/2 deps] `hmac` (4 dependents) | 2026-02-15
  - [ ] `test_hmac` (14 TODO)
- [x] [0/2 deps] `lzma` (4 dependents) | 2026-01-19
  - [x] `test_lzma` (13 TODO)
- [x] [0/6 deps] `gzip` (4 dependents) | 2026-01-19
  - [x] `test_gzip`
- [x] [0/2 deps] `codeop` (3 dependents) | 2026-02-07
  - [x] `test_codeop` (4 TODO)
- [x] [0/1 deps] `numbers` (3 dependents) | 2025-09-11
  - [x] `test_abstract_numbers`
- [x] [0/1 deps] `contextvars` (3 dependents) | 2026-01-18
- [x] [0/3 deps] `ntpath` (3 dependents) | 2026-01-25
  - [x] `test_ntpath`
- [x] [0/4 deps] `rlcompleter` (3 dependents) | 2025-07-17
  - [ ] `test_rlcompleter` (1 TODO)
- [x] [0/6 deps] `compression` (3 dependents) | 2026-01-19
- [x] [0/17 deps] `zipfile` (3 dependents) | 2026-02-24
  - [ ] `test_zipfile` (15 TODO)
  - [x] `test_zipfile64`
- [x] [0/2 deps] `genericpath` (2 dependents) | 2025-08-04
  - [x] `test_genericpath`
- [x] [0/1 deps] `_ios_support` (2 dependents) | 2025-03-10
- [x] [0/2 deps] `html` (2 dependents) | 2026-02-15
  - [x] `test_html`
  - [x] `test_htmlparser`
- [x] [0/3 deps] `optparse` (2 dependents) | 2026-01-30
  - [x] `test_optparse`
- [ ] [0/10 deps] `bdb` (2 dependents) | 2025-12-30 Δ271
  - [ ] `test_bdb` (9 TODO)
- [x] [0/1 deps] `cmd` (2 dependents) | 2026-01-24
  - [x] `test_cmd`
- [x] [0/2 deps] `quopri` (2 dependents) | 2026-01-24
  - [x] `test_quopri`
- [ ] [0/2 deps] `site` (2 dependents) | 2026-01-17 Δ29
  - [ ] `test_site` (4 TODO)
- [ ] [0/7 deps] `plistlib` (2 dependents) | 2026-01-04 Δ2
  - [ ] `test_plistlib` (6 TODO)
- [x] [0/4 deps] `mimetypes` (2 dependents) | 2026-01-21
  - [x] `test_mimetypes`
- [ ] [0/6 deps] `pstats` (2 dependents)
  - [ ] `test_pstats` (untracked)
- [x] [0/4 deps] `py_compile` (2 dependents) | 2026-01-30
  - [x] `test_py_compile` (3 TODO)
- [x] [0/7 deps] `encodings` (2 dependents) | 2026-02-06
- [x] [0/2 deps] `ipaddress` (1 dependents) | 2026-01-18
  - [x] `test_ipaddress`
- [x] [0/3 deps] `csv` (1 dependents) | 2026-02-18
  - [x] `test_csv` (27 TODO)
- [x] [0/2 deps] `netrc` (1 dependents) | 2025-08-20
  - [x] `test_netrc`
- [x] [0/4 deps] `filecmp` (1 dependents) | 2026-01-03
  - [x] `test_filecmp`
- [x] [0/5 deps] `fractions` (1 dependents) | 2026-01-30
  - [x] `test_fractions` (2 TODO)
- [ ] [0/1 deps] `opcode` (1 dependents) | 2026-02-27 Δ382
  - [x] `test__opcode` (2 TODO)
  - [x] `test_opcodes`
- [x] [0/2 deps] `pyclbr` (1 dependents) | 2025-07-25
  - [ ] `test_pyclbr` (2 TODO)
- [x] [0/7 deps] `dbm` (1 dependents) | 2026-01-01
  - [ ] `test_dbm` (2 TODO)
  - [x] `test_dbm_dumb`
  - [ ] `test_dbm_gnu` (untracked)
  - [ ] `test_dbm_ndbm` (untracked)
  - [x] `test_dbm_sqlite3`
- [x] [0/4 deps] `getpass` (1 dependents) | 2026-02-08
  - [x] `test_getpass`
- [x] [0/5 deps] `sqlite3` (1 dependents) | 2026-01-19
  - [ ] `test_sqlite3` (78 TODO)
- [x] [0/13 deps] `tarfile` (1 dependents) | 2026-02-27
  - [ ] `test_tarfile`
- [x] [0/2 deps] `zipimport` (1 dependents) | 2026-01-24
  - [x] `test_zipimport` (2 TODO)
  - [ ] `test_zipimport_support` (untracked)
- [x] [0/1 deps] `graphlib` | 2026-01-18
  - [x] `test_graphlib`
- [x] [0/1 deps] `_apple_support` | 2025-03-10
- [x] [0/7 deps] `fileinput` | 2025-04-30
  - [ ] `test_fileinput`
- [x] [0/2 deps] `nturl2path` | 2026-01-25
  - [x] `test_nturl2path`
- [ ] [0/7 deps] `zipapp` | 2025-08-06 Δ14
  - [ ] `test_zipapp`
- [ ] [0/2 deps] `_android_support` | 2025-10-22 Δ7
- [x] [0/3 deps] `symtable` | 2026-01-30
  - [ ] `test_symtable` (17 TODO)
- [ ] [0/2 deps] `pty` | 2026-01-05 Δ51
  - [ ] `test_pty` (4 TODO)
- [ ] [0/4 deps] `modulefinder`
  - [ ] `test_modulefinder` (untracked)
- [x] [0/5 deps] `timeit` | 2026-02-01
  - [x] `test_timeit`
- [x] [0/7 deps] `tomllib` | 2026-02-08
  - [x] `test_tomllib`
- [ ] [0/1 deps] `curses`
  - [ ] `test_curses` (untracked)
- [x] [0/13 deps] `xmlrpc` | 2026-02-14
  - [x] `test_xmlrpc` (5 TODO)
  - [x] `test_docxmlrpc`
- [x] [1/8 deps] `warnings` (58 dependents) | 2026-01-18
  - [ ] `test_warnings` (12 TODO)
- [x] [1/7 deps] `io` (56 dependents) | 2026-02-13
  - [ ] `test_io` (21 TODO)
  - [x] `test_bufio`
  - [x] `test_fileio` (1 TODO)
  - [ ] `test_memoryio` (28 TODO)
- [x] [1/10 deps] `functools` (37 dependents) | 2026-01-20
  - [ ] `test_functools` (9 TODO)
- [x] [1/6 deps] `contextlib` (25 dependents) | 2025-08-01
  - [ ] `test_contextlib` (2 TODO)
  - [ ] `test_contextlib_async` (2 TODO)
- [x] [1/8 deps] `threading` (21 dependents) | 2026-01-18
  - [ ] `test_threading` (18 TODO)
  - [ ] `test_threadedtempfile`
  - [ ] `test_threading_local` (3 TODO)
- [x] [1/11 deps] `traceback` (20 dependents) | 2026-02-06
  - [ ] `test_traceback` (34 TODO)
- [x] [1/9 deps] `subprocess` (15 dependents) | 2026-02-28
  - [x] `test_subprocess` (4 TODO)
- [x] [1/10 deps] `shutil` (13 dependents) | 2026-02-15
  - [x] `test_shutil`
- [x] [1/2 deps] `linecache` (12 dependents) | 2026-02-09
  - [x] `test_linecache`
- [ ] [1/7 deps] `tokenize` (11 dependents) | 2022-08-09 Δ357
  - [ ] `test_tokenize` (2 TODO)
- [x] [1/8 deps] `datetime` (11 dependents) | 2026-02-24
  - [ ] `test_datetime`
  - [ ] `test_strptime` (untracked)
- [ ] [1/8 deps] `tempfile` (10 dependents) | 2026-01-04 Δ26
  - [ ] `test_tempfile` (1 TODO)
- [x] [1/11 deps] `typing` (10 dependents) | 2026-02-11
  - [ ] `test_typing` (4 TODO)
  - [x] `test_type_aliases`
  - [x] `test_type_annotations` (1 TODO)
  - [x] `test_type_params` (6 TODO)
  - [x] `test_genericalias`
- [ ] [1/7 deps] `ssl` (8 dependents) | 2025-10-28 Δ4
  - [ ] `test_ssl` (21 TODO)
- [x] [1/7 deps] `ast` (7 dependents) | 2026-02-02
  - [ ] `test_ast` (54 TODO)
  - [x] `test_unparse`
  - [x] `test_type_comments` (15 TODO)
- [x] [1/6 deps] `calendar` (7 dependents) | 2026-01-17
  - [x] `test_calendar`
- [x] [1/2 deps] `selectors` (6 dependents) | 2025-07-20
  - [x] `test_selectors`
- [x] [1/1 deps] `hashlib` (6 dependents) | 2026-02-14
  - [x] `test_hashlib` (7 TODO)
- [x] [1/2 deps] `string` (5 dependents) | 2026-01-17
  - [x] `test_string`
  - [x] `test_userstring`
- [x] [1/4 deps] `runpy` (5 dependents) | 2025-09-11
  - [x] `test_runpy` (2 TODO)
- [x] [1/4 deps] `difflib` (4 dependents) | 2026-02-08
  - [x] `test_difflib`
- [x] [1/5 deps] `pprint` (4 dependents) | 2026-02-06
  - [x] `test_pprint`
- [x] [1/4 deps] `queue` (4 dependents) | 2026-02-04
  - [x] `test_queue`
- [x] [1/2 deps] `shlex` (4 dependents) | 2026-02-02
  - [x] `test_shlex` (4 TODO)
- [ ] [1/7 deps] `pkgutil` (4 dependents) | 2026-01-04 Δ57
  - [ ] `test_pkgutil` (1 TODO)
- [x] [1/7 deps] `gettext` (3 dependents) | 2026-01-30
  - [x] `test_gettext` (7 TODO)
- [x] [1/6 deps] `configparser` (2 dependents) | 2026-02-07
  - [x] `test_configparser`
- [x] [1/3 deps] `secrets` (1 dependents) | 2025-07-17
  - [x] `test_secrets`
- [x] [1/4 deps] `ftplib` (1 dependents) | 2026-02-02
  - [x] `test_ftplib` (4 TODO)
- [x] [1/3 deps] `tabnanny` (1 dependents) | 2026-02-02
  - [ ] `test_tabnanny` (5 TODO)
- [ ] [1/4 deps] `tracemalloc` (1 dependents)
  - [ ] `test_tracemalloc` (untracked)
- [ ] [1/5 deps] `profile` (1 dependents)
  - [ ] `test_profile` (untracked)
  - [ ] `test_cprofile` (untracked)
- [ ] [1/8 deps] `smtplib` (1 dependents) | 2025-12-19 Δ11
  - [x] `test_smtplib`
  - [x] `test_smtpnet`
- [x] [1/2 deps] `antigravity` | 2023-02-28
- [x] [1/6 deps] `pickletools` | 2026-02-06
- [x] [1/3 deps] `shelve` | 2026-01-01
  - [x] `test_shelve`
- [ ] [1/4 deps] `poplib`
  - [ ] `test_poplib` (untracked)
- [x] [1/3 deps] `sched` | 2025-04-21
  - [x] `test_sched`
- [x] [1/4 deps] `wave` | 2026-02-13
  - [x] `test_wave`
- [x] [1/9 deps] `compileall` | 2026-02-25
  - [x] `test_compileall` (2 TODO)
- [x] [1/9 deps] `mailbox` | 2026-02-14
  - [x] `test_mailbox`
- [x] [1/10 deps] `xml` | 2026-02-27
  - [x] `test_xml_etree` (61 TODO)
  - [ ] `test_xml_etree_c`
  - [x] `test_minidom` (25 TODO)
  - [x] `test_pulldom` (4 TODO)
  - [x] `test_pyexpat` (29 TODO)
  - [x] `test_sax` (39 TODO)
  - [x] `test_xml_dom_minicompat`
  - [x] `test_xml_dom_xmlbuilder`
- [x] [2/18 deps] `inspect` (19 dependents) | 2026-02-07
  - [ ] `test_inspect` (46 TODO)
- [ ] [2/12 deps] `sysconfig` (6 dependents) | 2025-10-22 Δ265
  - [ ] `test_sysconfig` (8 TODO)
  - [ ] `test__osx_support`
- [x] [2/9 deps] `ctypes` (6 dependents) | 2026-02-18
  - [ ] `test_ctypes` (11 TODO)
  - [x] `test_stable_abi_ctypes`
- [x] [2/5 deps] `dis` (5 dependents) | 2026-01-26
  - [ ] `test_dis` (42 TODO)
- [ ] [2/12 deps] `platform` (5 dependents) | 2026-01-04 Δ124
  - [ ] `test_platform`
- [x] [2/6 deps] `decimal` (3 dependents) | 2026-01-30
  - [ ] `test_decimal` (1 TODO)
- [ ] [2/17 deps] `email` (3 dependents) | 2026-01-17 Δ238
  - [ ] `test_email` (12 TODO)
- [ ] [2/9 deps] `tkinter` (2 dependents) | 2025-04-06 Δ279
  - [ ] `test_tkinter` (untracked)
  - [ ] `test_ttk` (untracked)
  - [ ] `test_ttk_textonly` (untracked)
  - [ ] `test_tcl` (untracked)
  - [ ] `test_idle` (untracked)
- [x] [2/10 deps] `uuid` (1 dependents) | 2026-02-02
  - [x] `test_uuid`
- [x] [2/8 deps] `statistics` (1 dependents) | 2026-02-11
  - [ ] `test_statistics` (1 TODO)
- [x] [2/9 deps] `ensurepip` | 2026-01-17
  - [x] `test_ensurepip`
- [ ] [2/8 deps] `venv` | 2026-01-17 Δ29
  - [ ] `test_venv` (4 TODO)
- [x] [2/12 deps] `imaplib` | 2026-02-01
  - [x] `test_imaplib` (1 TODO)
- [ ] [2/6 deps] `cProfile`
- [ ] [2/12 deps] `turtle`
  - [ ] `test_turtle` (untracked)
- [ ] [2/10 deps] `wsgiref` | 2026-01-03 Δ7
  - [ ] `test_wsgiref` (1 TODO)
- [x] [2/24 deps] `http` | 2026-02-27
  - [x] `test_httplib` (2 TODO)
  - [x] `test_http_cookiejar`
  - [ ] `test_http_cookies`
  - [x] `test_httpservers` (1 TODO)
- [x] [3/14 deps] `doctest` (1 dependents) | 2026-02-11
  - [ ] `test_doctest` (9 TODO)
- [ ] [3/12 deps] `trace` (1 dependents) | 2025-07-25 Δ15
  - [ ] `test_trace` (14 TODO)
- [ ] [3/13 deps] `zoneinfo` | 2025-09-07 Δ24
  - [ ] `test_zoneinfo` (3 TODO)
- [ ] [4/21 deps] `logging` (7 dependents) | 2025-07-20 Δ77
  - [ ] `test_logging` (5 TODO)
- [ ] [4/23 deps] `unittest` (2 dependents) | 2026-01-18 Δ102
  - [ ] `test_unittest` (15 TODO)
- [x] [4/20 deps] `urllib` (1 dependents) | 2026-02-13
  - [x] `test_urllib`
  - [x] `test_urllib2`
  - [ ] `test_urllib2_localnet`
  - [x] `test_urllib2net`
  - [x] `test_urllibnet`
  - [x] `test_urlparse`
  - [x] `test_urllib_response`
  - [x] `test_robotparser`
- [ ] [4/11 deps] `concurrent` | 2026-01-09 Δ1012
  - [ ] `test_concurrent_futures` (18 TODO)
  - [ ] `test_interpreters` (untracked)
  - [ ] `test__interpreters` (untracked)
  - [ ] `test__interpchannels` (untracked)
  - [ ] `test_crossinterp` (untracked)
- [x] [5/23 deps] `importlib` (7 dependents) | 2026-02-05
  - [ ] `test_importlib` (16 TODO)
- [ ] [5/29 deps] `multiprocessing` (2 dependents) | 2026-02-04 Δ314
  - [ ] `test_multiprocessing_fork` (35 TODO)
  - [ ] `test_multiprocessing_forkserver` (10 TODO)
  - [ ] `test_multiprocessing_spawn` (13 TODO)
  - [x] `test_multiprocessing_main_handling`
- [ ] [5/35 deps] `pdb` (1 dependents) | 2026-02-11 Δ2601
  - [ ] `test_pdb` (untracked)
- [x] [6/20 deps] `pydoc` (4 dependents) | 2026-02-13
  - [ ] `test_pydoc` (36 TODO)
- [ ] [6/32 deps] `asyncio` (2 dependents) | 2026-02-02 Δ26
  - [ ] `test_asyncio` (38 TODO)
- [ ] [7/35 deps] `_pyrepl` | 2025-04-11 Δ2534
- [ ] [10/43 deps] `idlelib`

## Standalone Tests
- [x] `test_atexit` (1 TODO)
  - [x] `_test_atexit` (7 TODO)
- [x] `test_eintr`
  - [ ] `_test_eintr` (6 TODO)
- [ ] `_test_embed_structseq` (untracked)
- [ ] `_test_gc_fast_cycles` (untracked)
- [ ] `_test_monitoring_shutdown` (untracked)
- [ ] `_test_multiprocessing` (15 TODO)
- [x] `_test_venv_multiprocessing`
- [x] `test___all__`
- [ ] `test_android`
- [x] `test_apple`
- [ ] `test_array` (55 TODO)
- [ ] `test_asdl_parser` (untracked)
- [x] `test_asyncgen` (4 TODO)
- [ ] `test_audit`
- [x] `test_augassign`
- [x] `test_exceptions` (25 TODO)
  - [ ] `test_baseexception`
  - [x] `test_except_star` (1 TODO)
  - [x] `test_exception_group` (3 TODO)
  - [x] `test_exception_hierarchy` (2 TODO)
  - [x] `test_exception_variations`
- [x] `test_bigaddrspace`
- [ ] `test_bigmem` (4 TODO)
- [x] `test_binascii` (1 TODO)
- [x] `test_binop`
- [x] `test_bool`
- [x] `test_buffer` (11 TODO)
- [ ] `test_build_details` (untracked)
- [x] `test_builtin` (25 TODO)
- [ ] `test_bytes` (17 TODO)
- [ ] `test_c_locale_coercion`
- [ ] `test_call` (1 TODO)
- [ ] `test_capi` (untracked)
- [ ] `test_cext` (untracked)
- [ ] `test_class` (15 TODO)
  - [x] `test_genericclass`
  - [x] `test_subclassinit`
- [ ] `test_clinic` (untracked)
- [x] `test_cmath`
- [ ] `test_cmd_line` (24 TODO)
- [ ] `test_cmd_line_script` (15 TODO)
- [x] `test_compare`
- [x] `test_compile` (31 TODO)
  - [x] `test_compiler_assemble`
  - [x] `test_compiler_codegen`
  - [x] `test_peepholer` (31 TODO)
- [ ] `test_complex` (2 TODO)
- [x] `test_contains` (1 TODO)
- [ ] `test_context` (6 TODO)
- [x] `test_coroutines` (19 TODO)
- [ ] `test_cppext` (untracked)
- [ ] `test_decorators` (1 TODO)
- [ ] `test_descr` (47 TODO)
  - [ ] `test_descrtut` (3 TODO)
- [x] `test_devpoll`
- [x] `test_dict` (6 TODO)
  - [x] `test_dictcomps` (1 TODO)
  - [x] `test_dictviews` (2 TODO)
  - [x] `test_userdict`
- [ ] `test_dtrace` (8 TODO)
- [ ] `test_dynamic` (1 TODO)
- [ ] `test_dynamicclassattribute`
- [ ] `test_embed` (untracked)
- [x] `test_enumerate`
- [x] `test_eof` (6 TODO)
- [x] `test_epoll`
- [x] `test_errno`
- [ ] `test_extcall` (8 TODO)
- [ ] `test_external_inspection` (untracked)
- [x] `test_faulthandler` (4 TODO)
- [ ] `test_fcntl`
  - [ ] `test_ioctl`
- [ ] `test_file`
  - [ ] `test_largefile`
- [ ] `test_file_eintr` (1 TODO)
- [ ] `test_fileutils` (untracked)
- [ ] `test_finalization` (untracked)
- [x] `test_float` (6 TODO)
  - [ ] `test_strtod` (6 TODO)
- [x] `test_flufl` (4 TODO)
- [x] `test_fork1` (1 TODO)
- [ ] `test_format` (5 TODO)
- [ ] `test_frame` (untracked)
- [ ] `test_free_threading` (untracked)
- [x] `test_frozen`
- [ ] `test_str` (16 TODO)
  - [x] `test_fstring` (19 TODO)
  - [ ] `test_string_literals` (5 TODO)
- [x] `test_funcattrs` (6 TODO)
- [x] `test_gc`
- [ ] `test_gdb` (untracked)
- [ ] `test_generated_cases` (untracked)
- [ ] `test_generators` (12 TODO)
  - [ ] `test_genexps` (untracked)
  - [ ] `test_generator_stop` (untracked)
  - [ ] `test_yield_from` (6 TODO)
- [ ] `test_getpath` (untracked)
- [ ] `test_global` (3 TODO)
- [ ] `test_grammar` (18 TODO)
- [x] `test_grp`
- [ ] `test_hash` (4 TODO)
- [ ] `test_import` (3 TODO)
- [x] `test_index`
- [ ] `test_int` (7 TODO)
  - [x] `test_long` (4 TODO)
  - [x] `test_int_literal`
- [ ] `test_isinstance`
- [x] `test_iter` (1 TODO)
- [x] `test_iterlen`
- [x] `test_itertools` (6 TODO)
- [x] `test_keywordonlyarg`
- [x] `test_kqueue`
- [x] `test_launcher`
- [x] `test_list` (5 TODO)
  - [x] `test_listcomps` (1 TODO)
  - [ ] `test_userlist` (1 TODO)
- [ ] `test_lltrace` (untracked)
- [x] `test_longexp`
- [ ] `test_marshal` (21 TODO)
- [x] `test_math`
  - [x] `test_math_property`
- [ ] `test_memoryview` (9 TODO)
- [ ] `test_metaclass` (10 TODO)
- [ ] `test_mmap` (2 TODO)
- [ ] `test_module` (4 TODO)
- [ ] `test_monitoring` (13 TODO)
- [x] `test_msvcrt`
- [ ] `test_named_expressions` (12 TODO)
- [x] `test_numeric_tower`
- [ ] `test_opcache`
- [x] `test_openpty`
- [ ] `test_optimizer` (untracked)
- [x] `test_osx_env`
- [ ] `test_patma` (20 TODO)
- [ ] `test_peg_generator` (untracked)
- [ ] `test_pep646_syntax` (12 TODO)
- [ ] `test_perf_profiler` (untracked)
- [ ] `test_perfmaps` (untracked)
- [ ] `test_pkg`
- [x] `test_select` (3 TODO)
  - [ ] `test_poll` (1 TODO)
- [x] `test_positional_only_arg` (4 TODO)
- [ ] `test_posix` (4 TODO)
- [x] `test_pow`
- [x] `test_print` (6 TODO)
- [x] `test_property`
- [x] `test_pwd`
- [ ] `test_pyrepl` (untracked)
  - [ ] `test_repl`
- [ ] `test_raise`
- [ ] `test_range` (1 TODO)
- [ ] `test_readline` (untracked)
- [ ] `test_regrtest` (10 TODO)
- [ ] `test_remote_pdb` (untracked)
- [ ] `test_resource` (2 TODO)
- [x] `test_richcmp`
- [x] `test_scope` (1 TODO)
- [x] `test_support` (3 TODO)
  - [ ] `test_script_helper`
- [ ] `test_set` (5 TODO)
- [x] `test_setcomps`
- [x] `test_slice` (1 TODO)
- [ ] `test_sort` (2 TODO)
- [ ] `test_source_encoding` (untracked)
- [ ] `test_startfile` (untracked)
- [x] `test_time`
  - [x] `test_strftime`
- [ ] `test_structseq`
- [x] `test_sundry`
- [ ] `test_super` (4 TODO)
- [ ] `test_syntax` (25 TODO)
- [x] `test_sys` (8 TODO)
  - [ ] `test_syslog` (2 TODO)
  - [ ] `test_sys_setprofile` (14 TODO)
  - [ ] `test_sys_settrace` (52 TODO)
- [x] `test_termios` (15 TODO)
- [ ] `test_thread`
  - [ ] `test_thread_local_bytecode` (untracked)
  - [x] `test_threadsignals`
- [ ] `test_timeout`
- [ ] `test_tools`
- [x] `test_tstring` (4 TODO)
- [ ] `test_tuple` (1 TODO)
- [ ] `test_type_cache` (untracked)
- [x] `test_typechecks`
- [ ] `test_unicodedata` (9 TODO)
  - [x] `test_unicode_file`
  - [ ] `test_unicode_file_functions`
  - [ ] `test_unicode_identifiers` (1 TODO)
  - [x] `test_ucn` (3 TODO)
- [x] `test_unary`
- [x] `test_univnewlines`
- [ ] `test_unpack` (1 TODO)
  - [ ] `test_unpack_ex` (11 TODO)
- [ ] `test_utf8_mode` (6 TODO)
- [ ] `test_utf8source` (2 TODO)
- [x] `test_wait3`
- [x] `test_wait4`
- [x] `test_winapi`
- [x] `test_winconsoleio`
- [x] `test_winreg`
- [x] `test_winsound`
- [x] `test_with` (1 TODO)
- [x] `test_wmi`
- [ ] `test_xpickle` (untracked)
- [ ] `test_xxlimited` (untracked)
- [ ] `test_xxtestfuzz` (untracked)
- [x] `test_zlib` (2 TODO)
- [x] `test_zstd`

## Untracked Files
- site-packages/README.txt

## Original Files
- PSF-LICENSE
- README.md
- _dummy_os.py
- _dummy_thread.py
- _pycodecs.py
- dummy_threading.py

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Extended test detection to recognize more naming patterns beyond conventional prefixes
  * Improved library-to-test mapping for non-standard test module naming conventions

* **Refactoring**
  * Optimized internal utilities and updated type annotations for enhanced code clarity

<!-- end of auto-generated comment: release notes by coderabbit.ai -->