### PR TITLE
Fix trace/profile events for generators and exceptions

### DIFF
--- a/.cspell.dict/cpython.txt
+++ b/.cspell.dict/cpython.txt
@@ -28,6 +28,7 @@ carg
 cellarg
 cellvar
 cellvars
+ceval
 cfield
 CLASSDEREF
 classdict

--- a/Lib/test/test_bdb.py
+++ b/Lib/test/test_bdb.py
@@ -614,7 +614,6 @@ class StateTestCase(BaseTestCase):
                 with TracerRun(self) as tracer:
                     tracer.runcall(tfunc_main)
 
-    @unittest.expectedFailure  # TODO: RUSTPYTHON; AssertionError: All paired tuples have not been processed, the last one was number 1 [('next',), ('quit',)]
     def test_stepinstr(self):
         self.expect_set = [
             ('line',   2, 'tfunc_main'),  ('stepinstr', ),
@@ -1084,7 +1083,6 @@ class IssuesTestCase(BaseTestCase):
             with TracerRun(self) as tracer:
                 tracer.runcall(tfunc_import)
 
-    @unittest.expectedFailure  # TODO: RUSTPYTHON; Error in atexit._run_exitfuncs
     def test_next_until_return_in_generator(self):
         # Issue #16596.
         # Check that set_next(), set_until() and set_return() do not treat the
@@ -1126,7 +1124,6 @@ class IssuesTestCase(BaseTestCase):
                     with TracerRun(self) as tracer:
                         tracer.runcall(tfunc_import)
 
-    @unittest.expectedFailure  # TODO: RUSTPYTHON; Error in atexit._run_exitfuncs
     def test_next_command_in_generator_for_loop(self):
         # Issue #16596.
         code = """
@@ -1158,7 +1155,6 @@ class IssuesTestCase(BaseTestCase):
             with TracerRun(self) as tracer:
                 tracer.runcall(tfunc_import)
 
-    @unittest.expectedFailure  # TODO: RUSTPYTHON; Error in atexit._run_exitfuncs
     def test_next_command_in_generator_with_subiterator(self):
         # Issue #16596.
         code = """
@@ -1190,7 +1186,6 @@ class IssuesTestCase(BaseTestCase):
             with TracerRun(self) as tracer:
                 tracer.runcall(tfunc_import)
 
-    @unittest.expectedFailure  # TODO: RUSTPYTHON; Error in atexit._run_exitfuncs
     def test_return_command_in_generator_with_subiterator(self):
         # Issue #16596.
         code = """

--- a/Lib/test/test_sys_setprofile.py
+++ b/Lib/test/test_sys_setprofile.py
@@ -108,7 +108,6 @@ class ProfileHookTestCase(TestCaseBase):
                               (1, 'return', f_ident),
                               ])
 
-    @unittest.expectedFailure  # TODO: RUSTPYTHON; [(1, 'call', (112, 'f'))]
     def test_exception(self):
         def f(p):
             1/0
@@ -135,7 +134,6 @@ class ProfileHookTestCase(TestCaseBase):
                               (1, 'return', f_ident),
                               ])
 
-    @unittest.expectedFailure  # TODO: RUSTPYTHON; [(1, 'call', (138, 'f'))]
     def test_nested_exception(self):
         def f(p):
             1/0
@@ -147,7 +145,6 @@ class ProfileHookTestCase(TestCaseBase):
                               (1, 'return', f_ident),
                               ])
 
-    @unittest.expectedFailure  # TODO: RUSTPYTHON; (1, 'return', (151, 'g'))]
     def test_exception_in_except_clause(self):
         def f(p):
             1/0
@@ -167,7 +164,6 @@ class ProfileHookTestCase(TestCaseBase):
                               (1, 'return', g_ident),
                               ])
 
-    @unittest.expectedFailure  # TODO: RUSTPYTHON; (1, 'falling through', (170, 'g'))]
     def test_exception_propagation(self):
         def f(p):
             1/0
@@ -183,7 +179,6 @@ class ProfileHookTestCase(TestCaseBase):
                               (1, 'return', g_ident),
                               ])
 
-    @unittest.expectedFailure  # TODO: RUSTPYTHON; [(1, 'call', (183, 'f'))]
     def test_raise_twice(self):
         def f(p):
             try: 1/0
@@ -193,7 +188,6 @@ class ProfileHookTestCase(TestCaseBase):
                               (1, 'return', f_ident),
                               ])
 
-    @unittest.expectedFailure  # TODO: RUSTPYTHON; [(1, 'call', (192, 'f'))]
     def test_raise_reraise(self):
         def f(p):
             try: 1/0
@@ -203,7 +197,6 @@ class ProfileHookTestCase(TestCaseBase):
                               (1, 'return', f_ident),
                               ])
 
-    @unittest.expectedFailure  # TODO: RUSTPYTHON; [(1, 'call', (201, 'f'))]
     def test_raise(self):
         def f(p):
             raise Exception()
@@ -212,7 +205,6 @@ class ProfileHookTestCase(TestCaseBase):
                               (1, 'return', f_ident),
                               ])
 
-    @unittest.expectedFailure  # TODO: RUSTPYTHON; (5, 'call', (209, 'f'))]
     def test_distant_exception(self):
         def f():
             1/0
@@ -297,7 +289,6 @@ class ProfileSimulatorTestCase(TestCaseBase):
                               (1, 'return', f_ident),
                               ])
 
-    @unittest.expectedFailure  # TODO: RUSTPYTHON; [(1, 'call', (293, 'f'))]
     def test_basic_exception(self):
         def f(p):
             1/0
@@ -315,7 +306,6 @@ class ProfileSimulatorTestCase(TestCaseBase):
                               (1, 'return', f_ident),
                               ])
 
-    @unittest.expectedFailure  # TODO: RUSTPYTHON; (5, 'call', (310, 'f'))]
     def test_distant_exception(self):
         def f():
             1/0
@@ -354,7 +344,6 @@ class ProfileSimulatorTestCase(TestCaseBase):
                               (1, 'return', f_ident)])
 
     # Test an invalid call (bpo-34126)
-    @unittest.expectedFailure  # TODO: RUSTPYTHON; [(1, 'call', (348, 'f'))]
     def test_unbound_method_no_args(self):
         def f(p):
             dict.get()
@@ -363,7 +352,6 @@ class ProfileSimulatorTestCase(TestCaseBase):
                               (1, 'return', f_ident)])
 
     # Test an invalid call (bpo-34126)
-    @unittest.expectedFailure  # TODO: RUSTPYTHON; [(1, 'call', (356, 'f'))]
     def test_unbound_method_invalid_args(self):
         def f(p):
             dict.get(print, 42)
@@ -372,7 +360,6 @@ class ProfileSimulatorTestCase(TestCaseBase):
                               (1, 'return', f_ident)])
 
     # Test an invalid call (bpo-34125)
-    @unittest.expectedFailure  # TODO: RUSTPYTHON; [(1, 'call', (365, 'f'))]
     def test_unbound_method_no_keyword_args(self):
         kwargs = {}
         def f(p):
@@ -382,7 +369,6 @@ class ProfileSimulatorTestCase(TestCaseBase):
                               (1, 'return', f_ident)])
 
     # Test an invalid call (bpo-34125)
-    @unittest.expectedFailure  # TODO: RUSTPYTHON; [(1, 'call', (374, 'f'))]
     def test_unbound_method_invalid_keyword_args(self):
         kwargs = {}
         def f(p):


### PR DESCRIPTION
- Move prev_line from ExecutingFrame to FrameState so it persists across generator/coroutine suspend and resume
- Add TraceEvent::Exception and fire_exception_trace helper for sys.settrace exception events in execution loop, FOR_ITER, and SEND
- Add is_profile_event filter so sys.setprofile skips line/exception
- Fire return trace event on both normal return and exception unwind (PY_UNWIND → PyTrace_RETURN) and propagate trace function errors
- Extract dispatch_traced_frame helper from with_frame/resume_gen_frame
- Remove 4 expectedFailure markers in test_bdb (generator tests)
- Remove 14 expectedFailure markers in test_sys_setprofile

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added exception and opcode trace events to improve debugging and profiling.

* **Improvements / Bug Fixes**
  * Per-code event masking to prevent cross-code event leakage.
  * More accurate line-number tracking across suspended/resumed frames.
  * Exception trace events now fire when exceptions are raised or resume points produce new exceptions.

* **Refactor**
  * Centralized tracing dispatch to unify Call/Return tracing behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->