### PR TITLE
Handle reentrant detach in TextIOWrapper.close()

### DIFF
--- a/Lib/test/test_io.py
+++ b/Lib/test/test_io.py
@@ -4211,7 +4211,6 @@ class CTextIOWrapperTest(TextIOWrapperTest):
         self.assertEqual([b"abcdef", b"middle", b"g"*chunk_size],
                          buf._write_stack)
 
-    @unittest.expectedFailure  # TODO: RUSTPYTHON; AttributeError: 'NoneType' object has no attribute 'closed'
     def test_issue142594(self):
         wrapper = None
         detached = False

--- a/crates/vm/src/stdlib/io.rs
+++ b/crates/vm/src/stdlib/io.rs
@@ -3793,6 +3793,13 @@ mod _io {
             if file_closed(&buffer, vm)? {
                 return Ok(());
             }
+            // https://github.com/python/cpython/issues/142594
+            // The file_closed() check above may have triggered a reentrant
+            // call to detach() via a custom `closed` property.
+            // If so, the buffer is now detached and we should return early.
+            if vm.is_none(&zelf.lock(vm)?.buffer) {
+                return Ok(());
+            }
             if zelf.finalizing.load(Ordering::Relaxed) {
                 // _dealloc_warn: delegate to buffer._dealloc_warn(source)
                 let _ = vm.call_method(&buffer, "_dealloc_warn", (zelf.as_object().to_owned(),));


### PR DESCRIPTION
When a custom `closed` property on the underlying buffer calls `detach()` during the `file_closed()` check in `close()`, the wrapper's internal buffer becomes None. Subsequent flush/close operations then fail with AttributeError on NoneType.

Add a guard after the `file_closed()` check to detect if the buffer was detached reentrantly, and return early in that case (detach has already flushed the stream).

This mirrors the fix applied in CPython
(https://github.com/python/cpython/issues/142594\).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* Fixed a potential edge case during file closing operations that could cause issues when buffer detachment occurs reentrantly, improving the stability of file I/O operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->