### PR TITLE
sqlite3: add Cursor.row_factory pygetset and fix Connection.cursor() …

### DIFF
--- a/Lib/test/test_sqlite3/test_factory.py
+++ b/Lib/test/test_sqlite3/test_factory.py
@@ -112,7 +112,6 @@ class CursorFactoryTests(MemoryDatabaseMixin, unittest.TestCase):
 
 class RowFactoryTestsBackwardsCompat(MemoryDatabaseMixin, unittest.TestCase):
 
-    @unittest.expectedFailure # TODO: RUSTPYTHON
     def test_is_produced_by_factory(self):
         cur = self.con.cursor(factory=MyCursor)
         cur.execute("select 4+5 as foo")

--- a/crates/stdlib/src/_sqlite3.rs
+++ b/crates/stdlib/src/_sqlite3.rs
@@ -1043,8 +1043,10 @@ mod _sqlite3 {
                 )));
             }
 
-            if let Some(cursor_ref) = cursor.downcast_ref::<Cursor>() {
-                let _ = unsafe { cursor_ref.row_factory.swap(zelf.row_factory.to_owned()) };
+            if let Some(cursor_ref) = cursor.downcast_ref::<Cursor>()
+                && let Some(factory) = zelf.row_factory.to_owned()
+            {
+                let _ = unsafe { cursor_ref.row_factory.swap(Some(factory)) };
             }
 
             Ok(cursor)
@@ -1975,6 +1977,16 @@ mod _sqlite3 {
             self.arraysize.store(val, Ordering::Relaxed);
 
             Ok(())
+        }
+
+        #[pygetset]
+        fn row_factory(&self) -> Option<PyObjectRef> {
+            self.row_factory.to_owned()
+        }
+
+        #[pygetset(setter)]
+        fn set_row_factory(&self, val: Option<PyObjectRef>) {
+            let _ = unsafe { self.row_factory.swap(val) };
         }
 
         fn build_row_cast_map(


### PR DESCRIPTION
…propagation

Add #[pygetset] getter/setter for Cursor.row_factory so that Python-level attribute access reads/writes the Rust struct field instead of the instance dict.

Fix Connection.cursor() to only propagate the connection's row_factory to the cursor when the connection's row_factory is not None, matching CPython behavior. Previously it unconditionally overwrote the cursor's row_factory, discarding any factory set by a cursor subclass __init__.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Cursor objects now provide public methods to get and set row factory configurations.

* **Bug Fixes**
  * Improved row factory handling during cursor initialization for increased reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->