### PR TITLE
Remove test_importlib from polluters

### DIFF
--- a/Lib/test/test_importlib/resources/test_resource.py
+++ b/Lib/test/test_importlib/resources/test_resource.py
@@ -153,7 +153,6 @@ class DeletingZipsTest(util.ZipSetup, unittest.TestCase):
     def test_as_file_does_not_keep_open(self):  # pragma: no cover
         resources.as_file(resources.files('data01') / 'binary.file')
 
-    @unittest.skipIf("RUSTPYTHON_SKIP_ENV_POLLUTERS" in os.environ, "TODO: RUSTPYTHON; environment pollution when running rustpython -m test --fail-env-changed due to tmpfile leak")
     def test_entered_path_does_not_keep_open(self):
         """
         Mimic what certifi does on import to make its bundle


### PR DESCRIPTION
This only removes the decorator from the offending test, as I don't think this test made it onto the list of polluters in the first place.

With this, it is possible to remove the logic for checking environment polluters from `.github/workflows/ci.yaml` altogether. (cc @ShaharNaveh)
