### PR TITLE
Fix _hashlib.compare_digest to reject non-ASCII strings

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3238,6 +3238,7 @@ dependencies = [
  "bzip2",
  "cfg-if",
  "chrono",
+ "constant_time_eq",
  "crc32fast",
  "crossbeam-utils",
  "csv-core",

--- a/Lib/test/test_hmac.py
+++ b/Lib/test/test_hmac.py
@@ -1484,18 +1484,10 @@ class HMACCompareDigestTestCase(CompareDigestMixin, unittest.TestCase):
         else:
             self.assertIs(self.compare_digest, operator_compare_digest)
 
-    @unittest.expectedFailure  # TODO: RUSTPYTHON; AssertionError: TypeError not raised by compare_digest
-    def test_exceptions(self):
-        return super().test_exceptions()
-
 
 @hashlib_helper.requires_hashlib()
 class OpenSSLCompareDigestTestCase(CompareDigestMixin, unittest.TestCase):
     compare_digest = openssl_compare_digest
-
-    @unittest.expectedFailure  # TODO: RUSTPYTHON; AssertionError: TypeError not raised by compare_digest
-    def test_exceptions(self):
-        return super().test_exceptions()
 
 
 class OperatorCompareDigestTestCase(CompareDigestMixin, unittest.TestCase):

--- a/crates/stdlib/Cargo.toml
+++ b/crates/stdlib/Cargo.toml
@@ -69,6 +69,7 @@ sha3 = "0.10.1"
 blake2 = "0.10.4"
 hmac = "0.12"
 pbkdf2 = { version = "0.12", features = ["hmac"] }
+constant_time_eq = { workspace = true }
 
 ## unicode stuff
 unicode_names2 = { workspace = true }


### PR DESCRIPTION
Add non-ASCII string check to _hashlib.compare_digest, matching the behavior of _operator._compare_digest. When both arguments are strings, non-ASCII characters now correctly raise TypeError.

Also replace the non-constant-time == comparison with constant_time_eq for proper timing-attack resistance, and return PyResult<bool> instead of PyResult<PyObjectRef>.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added a dependency to support constant-time cryptographic comparisons.
* **Bug Fixes**
  * Digest comparison now yields a direct boolean result and uses constant-time comparison under the hood.
  * Stricter input validation with clearer errors for non-ASCII strings and incompatible/bytes-like inputs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->