### PR TITLE
Revert class lookup

### DIFF
--- a/crates/vm/src/protocol/object.rs
+++ b/crates/vm/src/protocol/object.rs
@@ -580,14 +580,13 @@ impl PyObject {
         if let Ok(cls) = cls.try_to_ref::<PyType>(vm) {
             // PyType_Check(cls) - cls is a type object
             let mut retval = self.class().is_subtype(cls);
-            if !retval {
-                if let Some(i_cls) =
+            if !retval
+                && let Some(i_cls) =
                     vm.get_attribute_opt(self.to_owned(), identifier!(vm, __class__))?
-                    && let Ok(i_cls_type) = PyTypeRef::try_from_object(vm, i_cls)
-                    && !i_cls_type.is(self.class())
-                {
-                    retval = i_cls_type.is_subtype(cls);
-                }
+                && let Ok(i_cls_type) = PyTypeRef::try_from_object(vm, i_cls)
+                && !i_cls_type.is(self.class())
+            {
+                retval = i_cls_type.is_subtype(cls);
             }
             Ok(retval)
         } else {


### PR DESCRIPTION
wrong optimization

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Made isinstance/issubclass checks more consistent by always resolving an object’s class via attribute lookup. This reduces edge-case inconsistencies for objects with custom attribute access or modified class mechanisms, improving reliability and predictability when checking types across dynamic or altered class hierarchies.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->