### PR TITLE
Update `test_posix.py` from 3.14.3 and adjust android cfg

### DIFF
--- a/Lib/test/test_posix.py
+++ b/Lib/test/test_posix.py
@@ -1030,7 +1030,6 @@ class PosixTester(unittest.TestCase):
         target = self.tempdir()
         self.check_chmod(posix.chmod, target)
 
-    @unittest.expectedFailureIf(sys.platform in ("darwin", "linux", "android"), "TODO: RUSTPYTHON")
     @os_helper.skip_unless_working_chmod
     def test_fchmod_file(self):
         with open(os_helper.TESTFN, 'wb+') as f:

--- a/crates/vm/src/stdlib/posix.rs
+++ b/crates/vm/src/stdlib/posix.rs
@@ -1029,12 +1029,11 @@ pub mod module {
 
     #[cfg(not(target_os = "redox"))]
     fn _fchmod(fd: BorrowedFd<'_>, mode: u32, vm: &VirtualMachine) -> PyResult<()> {
-        let stat_mode = match nix::sys::stat::Mode::from_bits(mode as libc::mode_t) {
-            Some(v) => v,
-            None => return Ok(()), // Silent ignore errors like CPython
-        };
-
-        nix::sys::stat::fchmod(fd, stat_mode).map_err(|err| err.into_pyexception(vm))
+        nix::sys::stat::fchmod(
+            fd,
+            nix::sys::stat::Mode::from_bits_truncate(mode as libc::mode_t),
+        )
+        .map_err(|err| err.into_pyexception(vm))
     }
 
     #[cfg(not(target_os = "redox"))]


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  - File permission handling now ignores invalid mode bits, matching standard Python behavior.

* **Platform Support Changes**
  - `setresgid` and `initgroups` are no longer available on Android; they remain supported on FreeBSD, Linux, and OpenBSD.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->