### PR TITLE
Set `codegen-untis = 1` for some crates in release mode

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -77,8 +77,19 @@ opt-level = 3
 # https://github.com/rust-lang/rust/issues/92869
 # lto = "thin"
 
-# Doesn't change often
+# Some crates don't change as much but benefit more from
+# more expensive optimization passes, so we selectively
+# decrease codegen-units in some cases.
 [profile.release.package.rustpython-doc]
+codegen-units = 1
+
+[profile.release.package.rustpython-literal]
+codegen-units = 1
+
+[profile.release.package.rustpython-common]
+codegen-units = 1
+
+[profile.release.package.rustpython-wtf8]
 codegen-units = 1
 
 [profile.bench]


### PR DESCRIPTION
From my testings this adds around 12 seconds to the compile time. Haven't ran the benchmarks, this can't affect performance in a negative way

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Optimized release build profiles for select packages to improve compilation efficiency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->