### PR TITLE
Add monitoring lock reinit and use raw() accessor

### DIFF
--- a/crates/vm/src/stdlib/posix.rs
+++ b/crates/vm/src/stdlib/posix.rs
@@ -759,6 +759,7 @@ pub mod module {
             reinit_mutex_after_fork(&vm.state.atexit_funcs);
             reinit_mutex_after_fork(&vm.state.global_trace_func);
             reinit_mutex_after_fork(&vm.state.global_profile_func);
+            reinit_mutex_after_fork(&vm.state.monitoring);
 
             // PyGlobalState parking_lot::Mutex locks
             reinit_mutex_after_fork(&vm.state.thread_frames);

--- a/crates/vm/src/stdlib/thread.rs
+++ b/crates/vm/src/stdlib/thread.rs
@@ -987,8 +987,8 @@ pub(crate) mod _thread {
     #[cfg(unix)]
     fn reinit_parking_lot_mutex<T: ?Sized>(mutex: &parking_lot::Mutex<T>) {
         unsafe {
-            let ptr = mutex as *const parking_lot::Mutex<T> as *mut u8;
-            core::ptr::write_bytes(ptr, 0, core::mem::size_of::<parking_lot::RawMutex>());
+            let raw = mutex.raw() as *const parking_lot::RawMutex as *mut u8;
+            core::ptr::write_bytes(raw, 0, core::mem::size_of::<parking_lot::RawMutex>());
         }
     }
 


### PR DESCRIPTION
Add missing reinit_mutex_after_fork for vm.state.monitoring PyMutex in reinit_locks_after_fork.

Use Mutex::raw() accessor in reinit_parking_lot_mutex instead of pointer cast from struct start for layout safety.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved stability of thread synchronization mechanisms during process forking operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->