### PR TITLE
Update locale from v3.14.3

### DIFF
--- a/Lib/locale.py
+++ b/Lib/locale.py
@@ -13,7 +13,6 @@ also includes default encodings for all supported locale names.
 import sys
 import encodings
 import encodings.aliases
-import re
 import _collections_abc
 from builtins import str as _builtin_str
 import functools
@@ -177,8 +176,7 @@ def _strip_padding(s, amount):
         amount -= 1
     return s[lpos:rpos+1]
 
-_percent_re = re.compile(r'%(?:\((?P<key>.*?)\))?'
-                         r'(?P<modifiers>[-#0-9 +*.hlL]*?)[eEfFgGdiouxXcrs%]')
+_percent_re = None
 
 def _format(percent, value, grouping=False, monetary=False, *additional):
     if additional:
@@ -217,6 +215,13 @@ def format_string(f, val, grouping=False, monetary=False):
     Grouping is applied if the third parameter is true.
     Conversion uses monetary thousands separator and grouping strings if
     forth parameter monetary is true."""
+    global _percent_re
+    if _percent_re is None:
+        import re
+
+        _percent_re = re.compile(r'%(?:\((?P<key>.*?)\))?(?P<modifiers'
+                                 r'>[-#0-9 +*.hlL]*?)[eEfFgGdiouxXcrs%]')
+
     percents = list(_percent_re.finditer(f))
     new_f = _percent_re.sub('%s', f)
 

--- a/Lib/test/test_locale.py
+++ b/Lib/test/test_locale.py
@@ -1,13 +1,18 @@
 from decimal import Decimal
-from test.support import verbose, is_android, is_emscripten, is_wasi
+from test.support import cpython_only, verbose, is_android, linked_to_musl, os_helper
 from test.support.warnings_helper import check_warnings
-from test.support.import_helper import import_fresh_module
+from test.support.import_helper import ensure_lazy_imports, import_fresh_module
 from unittest import mock
 import unittest
 import locale
 import os
 import sys
 import codecs
+
+class LazyImportTest(unittest.TestCase):
+    @cpython_only
+    def test_lazy_import(self):
+        ensure_lazy_imports("locale", {"re", "warnings"})
 
 
 class BaseLocalizedTest(unittest.TestCase):
@@ -351,10 +356,7 @@ class TestEnUSCollation(BaseLocalizedTest, TestCollation):
 
     @unittest.skipIf(sys.platform.startswith('aix'),
                      'bpo-29972: broken test on AIX')
-    @unittest.skipIf(
-        is_emscripten or is_wasi,
-        "musl libc issue on Emscripten/WASI, bpo-46390"
-    )
+    @unittest.skipIf(linked_to_musl(), "musl libc issue, bpo-46390")
     @unittest.skipIf(sys.platform.startswith("netbsd"),
                      "gh-124108: NetBSD doesn't support UTF-8 for LC_COLLATE")
     def test_strcoll_with_diacritic(self):
@@ -362,10 +364,7 @@ class TestEnUSCollation(BaseLocalizedTest, TestCollation):
 
     @unittest.skipIf(sys.platform.startswith('aix'),
                      'bpo-29972: broken test on AIX')
-    @unittest.skipIf(
-        is_emscripten or is_wasi,
-        "musl libc issue on Emscripten/WASI, bpo-46390"
-    )
+    @unittest.skipIf(linked_to_musl(), "musl libc issue, bpo-46390")
     @unittest.skipIf(sys.platform.startswith("netbsd"),
                      "gh-124108: NetBSD doesn't support UTF-8 for LC_COLLATE")
     def test_strxfrm_with_diacritic(self):
@@ -541,7 +540,6 @@ class TestMiscellaneous(unittest.TestCase):
         # valid. Furthermore LC_CTYPE=UTF is used by the UTF-8 locale coercing
         # during interpreter startup (on macOS).
         import _locale
-        import os
 
         self.assertEqual(locale._parse_localename('UTF-8'), (None, 'UTF-8'))
 
@@ -551,25 +549,14 @@ class TestMiscellaneous(unittest.TestCase):
         else:
             orig_getlocale = None
 
-        orig_env = {}
         try:
-            for key in ('LC_ALL', 'LC_CTYPE', 'LANG', 'LANGUAGE'):
-                if key in os.environ:
-                    orig_env[key] = os.environ[key]
-                    del os.environ[key]
+            with os_helper.EnvironmentVarGuard() as env:
+                env.unset('LC_ALL', 'LC_CTYPE', 'LANG', 'LANGUAGE')
+                env.set('LC_CTYPE', 'UTF-8')
 
-            os.environ['LC_CTYPE'] = 'UTF-8'
-
-            with check_warnings(('', DeprecationWarning)):
-                self.assertEqual(locale.getdefaultlocale(), (None, 'UTF-8'))
-
+                with check_warnings(('', DeprecationWarning)):
+                    self.assertEqual(locale.getdefaultlocale(), (None, 'UTF-8'))
         finally:
-            for k in orig_env:
-                os.environ[k] = orig_env[k]
-
-            if 'LC_CTYPE' not in orig_env:
-                del os.environ['LC_CTYPE']
-
             if orig_getlocale is not None:
                 _locale._getdefaultlocale = orig_getlocale
 


### PR DESCRIPTION
## Summary
- Updated `Lib/locale.py` from CPython v3.14.3
  - Lazy `re` module import for faster startup (moved `re` import from module-level to `format_string()`)
- Updated `Lib/test/test_locale.py` from CPython v3.14.3
  - Added `LazyImportTest` (cpython_only, skipped in RustPython)
  - Replaced `is_emscripten or is_wasi` checks with `linked_to_musl()`
  - Modernized `test_defaults_UTF8` to use `EnvironmentVarGuard`
- Removed `@expectedFailure` from 2 tests in `test_types.py` that now pass thanks to the lazy `re` import fix:
  - `test_float__format__locale`
  - `test_int__format__locale`

## Test plan
- [x] `test_locale` and `test__locale` pass
- [x] `test_types` passes (2 previously failing tests now pass)
- [x] Direct dependent tests pass: `test_builtin`, `test_calendar`, `test_decimal`, `test_float`, `test_format`, `test_inspect`, `test_io`, `test_re`, `test_strftime`, `test_sys`, `test_types`, `test_gettext`, `test_argparse`, `test_getopt`, `test_optparse`, `test_site`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for locale-aware number formatting that respects your system's locale settings for thousands separators and decimal points.
  * Numbers (integers, floating-point, and complex) can now be formatted using locale-specific grouping patterns.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->