### PR TITLE
Stop non-main threads during interpreter finalization

### DIFF
--- a/crates/vm/src/vm/mod.rs
+++ b/crates/vm/src/vm/mod.rs
@@ -1479,6 +1479,13 @@ impl VirtualMachine {
     /// Checks for triggered signals and calls the appropriate handlers. A no-op on
     /// platforms where signals are not supported.
     pub fn check_signals(&self) -> PyResult<()> {
+        #[cfg(feature = "threading")]
+        if self.state.finalizing.load(Ordering::Acquire) && !self.is_main_thread() {
+            // once finalization starts,
+            // non-main Python threads should stop running bytecode.
+            return Err(self.new_exception(self.ctx.exceptions.system_exit.to_owned(), vec![]));
+        }
+
         #[cfg(not(target_arch = "wasm32"))]
         {
             crate::signal::check_signals(self)


### PR DESCRIPTION
Raise SystemExit in check_signals() for non-main threads once the finalizing flag is set. Without GIL, this serves as the checkpoint where daemon threads detect shutdown, analogous to CPython's _PyThreadState_MustExit in take_gil.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced error handling in multi-threaded configurations to properly manage edge cases during application shutdown.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->