### PR TITLE
Extract InterpreterFrame from Frame with Deref wrapper

### DIFF
--- a/crates/vm/src/frame.rs
+++ b/crates/vm/src/frame.rs
@@ -2324,7 +2324,8 @@ impl ExecutingFrame<'_> {
                 };
                 self.push_value(match value {
                     Some(v) => v,
-                    None => self.cell_ref(i)
+                    None => self
+                        .cell_ref(i)
                         .get()
                         .ok_or_else(|| self.unbound_cell_exception(i, vm))?,
                 });
@@ -2393,7 +2394,8 @@ impl ExecutingFrame<'_> {
             }
             Instruction::LoadDeref { i } => {
                 let idx = i.get(arg) as usize;
-                let x = self.cell_ref(idx)
+                let x = self
+                    .cell_ref(idx)
                     .get()
                     .ok_or_else(|| self.unbound_cell_exception(idx, vm))?;
                 self.push_value(x);
@@ -8686,23 +8688,25 @@ impl fmt::Debug for Frame {
         // SAFETY: Debug is best-effort; concurrent mutation is unlikely
         // and would only affect debug output.
         let iframe = unsafe { &*self.iframe.get() };
-        let stack_str = iframe.localsplus
-            .stack_as_slice()
-            .iter()
-            .fold(String::new(), |mut s, slot| {
-                match slot {
-                    Some(elem) if elem.downcastable::<Self>() => {
-                        s.push_str("\n  > {frame}");
+        let stack_str =
+            iframe
+                .localsplus
+                .stack_as_slice()
+                .iter()
+                .fold(String::new(), |mut s, slot| {
+                    match slot {
+                        Some(elem) if elem.downcastable::<Self>() => {
+                            s.push_str("\n  > {frame}");
+                        }
+                        Some(elem) => {
+                            core::fmt::write(&mut s, format_args!("\n  > {elem:?}")).unwrap();
+                        }
+                        None => {
+                            s.push_str("\n  > NULL");
+                        }
                     }
-                    Some(elem) => {
-                        core::fmt::write(&mut s, format_args!("\n  > {elem:?}")).unwrap();
-                    }
-                    None => {
-                        s.push_str("\n  > NULL");
-                    }
-                }
-                s
-            });
+                    s
+                });
         // TODO: fix this up
         write!(
             f,


### PR DESCRIPTION
close #7351

## Summary
- Introduce `InterpreterFrame` struct containing all execution state fields previously on `Frame`, analogous to CPython's `_PyInterpreterFrame`
- `Frame` (PyFrameObject) now wraps `InterpreterFrame` via `FrameUnsafeCell` and implements `Deref` for transparent field access
- `localsplus` and `prev_line` are plain fields on `InterpreterFrame` (no longer individually wrapped in `FrameUnsafeCell`) since the entire `InterpreterFrame` is wrapped at the `Frame` level
- Pure refactoring with no behavioral changes

This is a preparatory step toward removing PyObject allocation for normal function calls (future PR will allow `InterpreterFrame` to live on the Rust stack + DataStack without creating a `Frame` PyObject).

## Test plan
- [x] `cargo build` passes with no warnings
- [x] `cargo test` passes
- [x] `cargo run --release -- -m test test_scope test_generators test_coroutines test_sys test_traceback test_frame -v` — all 6 test suites pass (721 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Internal reorganization of VM frame storage and traversal: frame state now lives inside an embedded wrapper and is routed consistently through that wrapper across the runtime.
  * No user-visible behavior or API changes; this is an internal implementation cleanup.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->