### PR TITLE
Remove duplicate `cargo check --target x86_64-unknown-freebsd`

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -265,13 +265,6 @@ jobs:
 
       - uses: dtolnay/rust-toolchain@stable
         with:
-          target: x86_64-unknown-freebsd
-
-      - name: Check compilation for freeBSD
-        run: cargo check --target x86_64-unknown-freebsd ${{ env.CARGO_ARGS_NO_SSL }}
-
-      - uses: dtolnay/rust-toolchain@stable
-        with:
           target: wasm32-wasip2
 
       - name: Check compilation for wasip2


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Streamlined continuous integration workflow by removing duplicate build configurations and toolchain setup steps, reducing configuration complexity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->