### PR TITLE
Unpin nightly channel for miri tests

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -514,7 +514,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 30
     env:
-      NIGHTLY_CHANNEL: nightly-2026-02-11 # https://github.com/rust-lang/miri/issues/4855
+      NIGHTLY_CHANNEL: nightly
     steps:
       - uses: actions/checkout@v6.0.2
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated continuous integration testing configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->