### PR TITLE
Fix atexit unraisable exception message format

### DIFF
--- a/Lib/test/_test_atexit.py
+++ b/Lib/test/_test_atexit.py
@@ -135,7 +135,6 @@ class GeneralTest(unittest.TestCase):
         finally:
             atexit.unregister(func)
 
-    @unittest.skip("TODO: RUSTPYTHON; Hangs")
     def test_eq_unregister_clear(self):
         # Issue #112127: callback's __eq__ may call unregister or _clear
         class Evil:
@@ -149,7 +148,6 @@ class GeneralTest(unittest.TestCase):
                 atexit.unregister(Evil())
                 atexit._clear()
 
-    @unittest.skip("TODO: RUSTPYTHON; Hangs")
     def test_eq_unregister(self):
         # Issue #112127: callback's __eq__ may call unregister
         def f1():

--- a/crates/vm/src/stdlib/atexit.rs
+++ b/crates/vm/src/stdlib/atexit.rs
@@ -7,7 +7,11 @@ mod atexit {
 
     #[pyfunction]
     fn register(func: PyObjectRef, args: FuncArgs, vm: &VirtualMachine) -> PyObjectRef {
-        vm.state.atexit_funcs.lock().push((func.clone(), args));
+        // Callbacks go in LIFO order (insert at front)
+        vm.state
+            .atexit_funcs
+            .lock()
+            .insert(0, Box::new((func.clone(), args)));
         func
     }
 
@@ -18,35 +22,62 @@ mod atexit {
 
     #[pyfunction]
     fn unregister(func: PyObjectRef, vm: &VirtualMachine) -> PyResult<()> {
-        let mut funcs = vm.state.atexit_funcs.lock();
-
-        let mut i = 0;
-        while i < funcs.len() {
-            if vm.bool_eq(&funcs[i].0, &func)? {
-                funcs.remove(i);
-            } else {
-                i += 1;
+        // Iterate backward (oldest to newest in LIFO list).
+        // Release the lock during comparison so __eq__ can call atexit functions.
+        let mut i = {
+            let funcs = vm.state.atexit_funcs.lock();
+            funcs.len() as isize - 1
+        };
+        while i >= 0 {
+            let (cb, entry_ptr) = {
+                let funcs = vm.state.atexit_funcs.lock();
+                if i as usize >= funcs.len() {
+                    i = funcs.len() as isize;
+                    i -= 1;
+                    continue;
+                }
+                let entry = &funcs[i as usize];
+                (entry.0.clone(), &**entry as *const (PyObjectRef, FuncArgs))
+            };
+            // Lock released: __eq__ can safely call atexit functions
+            let eq = vm.bool_eq(&func, &cb)?;
+            if eq {
+                // The entry may have moved during __eq__. Search backward by identity.
+                let mut funcs = vm.state.atexit_funcs.lock();
+                let mut j = (funcs.len() as isize - 1).min(i);
+                while j >= 0 {
+                    if core::ptr::eq(&**funcs.get(j as usize).unwrap(), entry_ptr) {
+                        funcs.remove(j as usize);
+                        i = j;
+                        break;
+                    }
+                    j -= 1;
+                }
             }
+            {
+                let funcs = vm.state.atexit_funcs.lock();
+                if i as usize >= funcs.len() {
+                    i = funcs.len() as isize;
+                }
+            }
+            i -= 1;
         }
-
         Ok(())
     }
 
     #[pyfunction]
     pub fn _run_exitfuncs(vm: &VirtualMachine) {
         let funcs: Vec<_> = core::mem::take(&mut *vm.state.atexit_funcs.lock());
-        for (func, args) in funcs.into_iter().rev() {
+        // Callbacks stored in LIFO order, iterate forward
+        for entry in funcs.into_iter() {
+            let (func, args) = *entry;
             if let Err(e) = func.call(args, vm) {
                 let exit = e.fast_isinstance(vm.ctx.exceptions.system_exit);
                 let msg = func
                     .repr(vm)
-                    .map(|r| {
-                        format!("Exception ignored in atexit callback {}", r.as_wtf8())
-                    })
-                    .unwrap_or_else(|_| {
-                        "Exception ignored in atexit callback".to_owned()
-                    });
-                vm.run_unraisable(e, Some(msg), vm.ctx.none());
+                    .ok()
+                    .map(|r| format!("Exception ignored in atexit callback {}", r.as_wtf8()));
+                vm.run_unraisable(e, msg, vm.ctx.none());
                 if exit {
                     break;
                 }

--- a/crates/vm/src/vm/mod.rs
+++ b/crates/vm/src/vm/mod.rs
@@ -585,7 +585,7 @@ pub struct PyGlobalState {
     pub stacksize: AtomicCell<usize>,
     pub thread_count: AtomicCell<usize>,
     pub hash_secret: HashSecret,
-    pub atexit_funcs: PyMutex<Vec<(PyObjectRef, FuncArgs)>>,
+    pub atexit_funcs: PyMutex<Vec<Box<(PyObjectRef, FuncArgs)>>>,
     pub codec_registry: CodecsRegistry,
     pub finalizing: AtomicBool,
     pub warnings: WarningsState,


### PR DESCRIPTION
Match PyErr_FormatUnraisable behavior: use
"Exception ignored in atexit callback {func!r}" as err_msg and pass None as object instead of the callback function.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Behavior Changes**
  * Exit callbacks now run in last-registered, first-run order (LIFO), preserving expected unwind ordering.

* **Bug Fixes**
  * Improved error reports when an exit callback raises, showing a more informative callback representation when possible.
  * Added a safe fallback to a generic error message if rendering the callback for the report fails.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->