### PR TITLE
Fix classmethod descr_get to match CPython behavior

### DIFF
--- a/Lib/test/test_decorators.py
+++ b/Lib/test/test_decorators.py
@@ -291,7 +291,6 @@ class TestDecorators(unittest.TestCase):
         self.assertEqual(bar(), 42)
         self.assertEqual(actions, expected_actions)
 
-    @unittest.expectedFailure # TODO: RUSTPYTHON
     def test_bound_function_inside_classmethod(self):
         class A:
             def foo(self, cls):

--- a/crates/vm/src/builtins/classmethod.rs
+++ b/crates/vm/src/builtins/classmethod.rs
@@ -57,13 +57,8 @@ impl GetDescriptor for PyClassMethod {
     ) -> PyResult {
         let (zelf, _obj) = Self::_unwrap(&zelf, obj, vm)?;
         let cls = cls.unwrap_or_else(|| _obj.class().to_owned().into());
-        // Clone and release lock before calling Python code to prevent deadlock
         let callable = zelf.callable.lock().clone();
-        let call_descr_get: PyResult<PyObjectRef> = callable.get_attr("__get__", vm);
-        match call_descr_get {
-            Err(_) => Ok(PyBoundMethod::new(cls, callable).into_ref(&vm.ctx).into()),
-            Ok(call_descr_get) => call_descr_get.call((cls.clone(), cls), vm),
-        }
+        Ok(PyBoundMethod::new(cls, callable).into_ref(&vm.ctx).into())
     }
 }
 


### PR DESCRIPTION
Simplify classmethod.__get__ to always create a PyBoundMethod binding the callable to the class, matching CPython's cm_descr_get which simply calls PyMethod_New(cm->cm_callable, type).

The previous implementation incorrectly tried to call __get__ on the wrapped callable, which broke when a bound method was passed to classmethod() (e.g. classmethod(A().foo)).

## CPython reference

https://github.com/python/cpython/blob/d9c26676b26ab09d8db7265dc22a733d3c358d4b/Objects/funcobject.c#L1458-L1471

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Simplified classmethod descriptor behavior so classmethods consistently resolve to bound methods and avoid unexpected errors from unnecessary attribute lookups.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->