### PR TITLE
Raise `ValueError` instead `OverflowError` when calling `chr()`

### DIFF
--- a/Lib/test/test_builtin.py
+++ b/Lib/test/test_builtin.py
@@ -367,7 +367,6 @@ class BuiltinTest(ComplexesAreIdenticalMixin, unittest.TestCase):
         c3 = C3()
         self.assertTrue(callable(c3))
 
-    @unittest.expectedFailure # TODO: RUSTPYTHON; OverflowError: Python int too large to convert to Rust isize
     def test_chr(self):
         self.assertEqual(chr(0), '\0')
         self.assertEqual(chr(32), ' ')

--- a/crates/vm/src/stdlib/builtins.rs
+++ b/crates/vm/src/stdlib/builtins.rs
@@ -88,7 +88,7 @@ mod builtins {
     #[pyfunction]
     fn chr(i: PyIntRef, vm: &VirtualMachine) -> PyResult<CodePoint> {
         let value = i
-            .try_to_primitive::<isize>(vm)?
+            .as_bigint()
             .to_u32()
             .and_then(CodePoint::from_u32)
             .ok_or_else(|| vm.new_value_error("chr() arg not in range(0x110000)"))?;


### PR DESCRIPTION
Historically, CPython raised OverflowError when calling `chr()` with out-of-range value (e.g., `chr(2**32)`).

<img width="1658" height="247" alt="image" src="https://github.com/user-attachments/assets/4a9c51ca-2d4e-41a0-92ff-59515029c1a1" />

But, since Python 3.13, it became to always raise `ValueError`.

## Links

- RustPython commit https://github.com/RustPython/RustPython/commit/d5b7f1ead1fffd5edef027530b96e400e461e38d
   > Clean up overflow cases.
- CPython commit https://github.com/python/cpython/commit/e2c403892400878707a20d4b7e183de505a64ca5
   > gh-76763: Make chr() always raising ValueError for out-of-range values (GH-114882)
   > Previously it raised OverflowError for very large or very small values.
- Python 3.13 changelog: https://docs.python.org/3.13/whatsnew/changelog.html
  > gh-76763: The chr() builtin function now always raises ValueError for values outside the valid range. Previously it raised OverflowError for very large or small values.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved the `chr()` built-in function to better handle numeric argument conversion to character code points. The function now ensures proper validation of input values and delivers consistent, clear error messages when conversion fails. This enhancement provides more reliable behavior, particularly for edge cases and inputs outside the supported range.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->