### PR TITLE
Make singleton builtin types immutable

### DIFF
--- a/Lib/test/test_builtin.py
+++ b/Lib/test/test_builtin.py
@@ -2434,7 +2434,6 @@ class BuiltinTest(ComplexesAreIdenticalMixin, unittest.TestCase):
         with self.assertRaisesRegex(TypeError, msg):
             not NotImplemented
 
-    @unittest.expectedFailure # TODO: RUSTPYTHON; AssertionError: TypeError not raised
     def test_singleton_attribute_access(self):
         for singleton in (NotImplemented, Ellipsis):
             with self.subTest(singleton):

--- a/crates/vm/src/builtins/singletons.rs
+++ b/crates/vm/src/builtins/singletons.rs
@@ -98,7 +98,7 @@ impl Constructor for PyNotImplemented {
     }
 }
 
-#[pyclass(with(Constructor, AsNumber, Representable))]
+#[pyclass(with(Constructor, AsNumber, Representable), flags(IMMUTABLETYPE))]
 impl PyNotImplemented {
     #[pymethod]
     fn __reduce__(&self, vm: &VirtualMachine) -> PyStrRef {

--- a/crates/vm/src/builtins/slice.rs
+++ b/crates/vm/src/builtins/slice.rs
@@ -393,7 +393,7 @@ impl Constructor for PyEllipsis {
     }
 }
 
-#[pyclass(with(Constructor, Representable))]
+#[pyclass(with(Constructor, Representable), flags(IMMUTABLETYPE))]
 impl PyEllipsis {
     #[pymethod]
     fn __reduce__(&self, vm: &VirtualMachine) -> PyStrRef {


### PR DESCRIPTION
This pull request just marks `NotImplemented` and `Ellipsis` as immutable type (`IMMUTABLETYPE` flag).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Internal improvements to built-in singleton types for enhanced type safety and immutability enforcement.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->