### PR TITLE
Fix sqlite3 Cursor.fetchmany to not fetch rows when size=0

### DIFF
--- a/Lib/test/test_sqlite3/test_dbapi.py
+++ b/Lib/test/test_sqlite3/test_dbapi.py
@@ -1096,7 +1096,6 @@ class CursorTests(unittest.TestCase):
         self.assertRaises(ValueError, setter, -3)
         self.assertRaises(OverflowError, setter, UINT32_MAX + 1)
 
-    @unittest.expectedFailure  # TODO: RUSTPYTHON fetchmany behavior with exhausted cursor differs
     def test_fetchmany(self):
         # no active SQL statement
         res = self.cu.fetchmany()

--- a/crates/stdlib/src/_sqlite3.rs
+++ b/crates/stdlib/src/_sqlite3.rs
@@ -1900,10 +1900,14 @@ mod _sqlite3 {
             };
 
             let mut list = vec![];
-            while let PyIterReturn::Return(row) = Cursor::next(zelf, vm)? {
-                list.push(row);
-                if max_rows > 0 && list.len() as c_int >= max_rows {
-                    break;
+            let mut remaining = max_rows;
+            while remaining > 0 {
+                match Cursor::next(zelf, vm)? {
+                    PyIterReturn::Return(row) => {
+                        list.push(row);
+                        remaining -= 1;
+                    }
+                    PyIterReturn::StopIteration(_) => break,
                 }
             }
             Ok(list)


### PR DESCRIPTION
## CPython reference

https://github.com/python/cpython/blob/main/Modules/_sqlite/cursor.c#L1233-L1240

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved internal code structure for SQLite3 row collection logic with more explicit control flow handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->