### PR TITLE
Match float zero-division message with CPython

### DIFF
--- a/Lib/test/test_builtin.py
+++ b/Lib/test/test_builtin.py
@@ -728,7 +728,6 @@ class BuiltinTest(ComplexesAreIdenticalMixin, unittest.TestCase):
         self.assertIs(None.__ne__(0), NotImplemented)
         self.assertIs(None.__ne__("abc"), NotImplemented)
 
-    @unittest.expectedFailure # TODO: RUSTPYTHON; wrong error message
     def test_divmod(self):
         self.assertEqual(divmod(12, 7), (1, 5))
         self.assertEqual(divmod(-12, 7), (-2, 2))

--- a/crates/vm/src/builtins/float.rs
+++ b/crates/vm/src/builtins/float.rs
@@ -119,11 +119,11 @@ macro_rules! impl_try_from_object_float {
 impl_try_from_object_float!(f32, f64);
 
 fn inner_div(v1: f64, v2: f64, vm: &VirtualMachine) -> PyResult<f64> {
-    float_ops::div(v1, v2).ok_or_else(|| vm.new_zero_division_error("float division by zero"))
+    float_ops::div(v1, v2).ok_or_else(|| vm.new_zero_division_error("division by zero"))
 }
 
 fn inner_mod(v1: f64, v2: f64, vm: &VirtualMachine) -> PyResult<f64> {
-    float_ops::mod_(v1, v2).ok_or_else(|| vm.new_zero_division_error("float mod by zero"))
+    float_ops::mod_(v1, v2).ok_or_else(|| vm.new_zero_division_error("division by zero"))
 }
 
 pub fn try_to_bigint(value: f64, vm: &VirtualMachine) -> PyResult<BigInt> {
@@ -147,11 +147,11 @@ pub fn try_to_bigint(value: f64, vm: &VirtualMachine) -> PyResult<BigInt> {
 }
 
 fn inner_floordiv(v1: f64, v2: f64, vm: &VirtualMachine) -> PyResult<f64> {
-    float_ops::floordiv(v1, v2).ok_or_else(|| vm.new_zero_division_error("float floordiv by zero"))
+    float_ops::floordiv(v1, v2).ok_or_else(|| vm.new_zero_division_error("division by zero"))
 }
 
 fn inner_divmod(v1: f64, v2: f64, vm: &VirtualMachine) -> PyResult<(f64, f64)> {
-    float_ops::divmod(v1, v2).ok_or_else(|| vm.new_zero_division_error("float divmod()"))
+    float_ops::divmod(v1, v2).ok_or_else(|| vm.new_zero_division_error("division by zero"))
 }
 
 pub fn float_pow(v1: f64, v2: f64, vm: &VirtualMachine) -> PyResult {


### PR DESCRIPTION
This pull request lets RustPython raise zero-division error with same message with CPython.

```python
# testfile.py
for op in ("//", "/", "%"):
    try:
        eval(f"1.{op}0.")
        print(op, "No Error")
    except Exception as e:
        print(op, "Error", e)

# before this pull request (073adbd8d): cargo run --release -q -- testfile.py
// Error float floordiv by zero
/ Error float division by zero
% Error float mod by zero

# on this pull request: cargo run --release -q -- testfile.py
// Error division by zero
/ Error division by zero
% Error division by zero

# python 3.14.3: python3 -- testfile.py
// Error division by zero
/ Error division by zero
% Error division by zero
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Float division-by-zero error messages now display consistently across all division operations (division, modulo, floor division, and divmod).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->