### PR TITLE
Mark RustPython 0.5.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3070,7 +3070,7 @@ dependencies = [
 
 [[package]]
 name = "rustpython"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "cfg-if",
  "criterion",
@@ -3093,7 +3093,7 @@ dependencies = [
 
 [[package]]
 name = "rustpython-codegen"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "ahash",
  "bitflags 2.11.0",
@@ -3117,7 +3117,7 @@ dependencies = [
 
 [[package]]
 name = "rustpython-common"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "ascii",
  "bitflags 2.11.0",
@@ -3144,7 +3144,7 @@ dependencies = [
 
 [[package]]
 name = "rustpython-compiler"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "ruff_python_ast",
  "ruff_python_parser",
@@ -3157,7 +3157,7 @@ dependencies = [
 
 [[package]]
 name = "rustpython-compiler-core"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "bitflags 2.11.0",
  "bitflagset",
@@ -3179,7 +3179,7 @@ dependencies = [
 
 [[package]]
 name = "rustpython-derive"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "rustpython-compiler",
  "rustpython-derive-impl",
@@ -3188,7 +3188,7 @@ dependencies = [
 
 [[package]]
 name = "rustpython-derive-impl"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "itertools 0.14.0",
  "maplit",
@@ -3203,14 +3203,14 @@ dependencies = [
 
 [[package]]
 name = "rustpython-doc"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "phf 0.13.1",
 ]
 
 [[package]]
 name = "rustpython-jit"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "approx",
  "cranelift",
@@ -3226,7 +3226,7 @@ dependencies = [
 
 [[package]]
 name = "rustpython-literal"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "hexf-parse",
  "is-macro",
@@ -3239,7 +3239,7 @@ dependencies = [
 
 [[package]]
 name = "rustpython-pylib"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "glob",
  "rustpython-compiler-core",
@@ -3248,7 +3248,7 @@ dependencies = [
 
 [[package]]
 name = "rustpython-sre_engine"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "bitflags 2.11.0",
  "criterion",
@@ -3259,7 +3259,7 @@ dependencies = [
 
 [[package]]
 name = "rustpython-stdlib"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "adler32",
  "ahash",
@@ -3357,14 +3357,14 @@ dependencies = [
 
 [[package]]
 name = "rustpython-venvlauncher"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "windows-sys 0.61.2",
 ]
 
 [[package]]
 name = "rustpython-vm"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "ahash",
  "ascii",
@@ -3439,7 +3439,7 @@ dependencies = [
 
 [[package]]
 name = "rustpython-wtf8"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "ascii",
  "bstr",
@@ -3449,7 +3449,7 @@ dependencies = [
 
 [[package]]
 name = "rustpython_wasm"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "console_error_panic_hook",
  "js-sys",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -133,7 +133,7 @@ members = [
 exclude = ["pymath"]
 
 [workspace.package]
-version = "0.4.0"
+version = "0.5.0"
 authors = ["RustPython Team"]
 edition = "2024"
 rust-version = "1.93.0"
@@ -141,20 +141,20 @@ repository = "https://github.com/RustPython/RustPython"
 license = "MIT"
 
 [workspace.dependencies]
-rustpython-compiler-core = { path = "crates/compiler-core", version = "0.4.0" }
-rustpython-compiler = { path = "crates/compiler", version = "0.4.0" }
-rustpython-codegen = { path = "crates/codegen", version = "0.4.0" }
-rustpython-common = { path = "crates/common", version = "0.4.0" }
-rustpython-derive = { path = "crates/derive", version = "0.4.0" }
-rustpython-derive-impl = { path = "crates/derive-impl", version = "0.4.0" }
-rustpython-jit = { path = "crates/jit", version = "0.4.0" }
-rustpython-literal = { path = "crates/literal", version = "0.4.0" }
-rustpython-vm = { path = "crates/vm", default-features = false, version = "0.4.0" }
-rustpython-pylib = { path = "crates/pylib", version = "0.4.0" }
-rustpython-stdlib = { path = "crates/stdlib", default-features = false, version = "0.4.0" }
-rustpython-sre_engine = { path = "crates/sre_engine", version = "0.4.0" }
-rustpython-wtf8 = { path = "crates/wtf8", version = "0.4.0" }
-rustpython-doc = { path = "crates/doc", version = "0.4.0" }
+rustpython-compiler-core = { path = "crates/compiler-core", version = "0.5.0" }
+rustpython-compiler = { path = "crates/compiler", version = "0.5.0" }
+rustpython-codegen = { path = "crates/codegen", version = "0.5.0" }
+rustpython-common = { path = "crates/common", version = "0.5.0" }
+rustpython-derive = { path = "crates/derive", version = "0.5.0" }
+rustpython-derive-impl = { path = "crates/derive-impl", version = "0.5.0" }
+rustpython-jit = { path = "crates/jit", version = "0.5.0" }
+rustpython-literal = { path = "crates/literal", version = "0.5.0" }
+rustpython-vm = { path = "crates/vm", default-features = false, version = "0.5.0" }
+rustpython-pylib = { path = "crates/pylib", version = "0.5.0" }
+rustpython-stdlib = { path = "crates/stdlib", default-features = false, version = "0.5.0" }
+rustpython-sre_engine = { path = "crates/sre_engine", version = "0.5.0" }
+rustpython-wtf8 = { path = "crates/wtf8", version = "0.5.0" }
+rustpython-doc = { path = "crates/doc", version = "0.5.0" }
 
 # Ruff tag 0.15.6 is based on commit e4c7f357777a2fdd34dbe6a98b1b7d3e7488f675
 # at the time of this capture. We use the commit hash to ensure reproducible builds.

--- a/wapm.toml
+++ b/wapm.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rustpython"
-version = "0.4.0"
+version = "0.5.0"
 description = "A Python-3 (CPython >= 3.5.0) Interpreter written in Rust 🐍 😱 🤘"
 license-file = "LICENSE"
 readme = "README.md"


### PR DESCRIPTION
for next release 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Version bumped to 0.5.0 across the project

<!-- end of auto-generated comment: release notes by coderabbit.ai -->