### PR TITLE
Bump rust version to 1.94.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -136,7 +136,7 @@ exclude = ["pymath"]
 version = "0.5.0"
 authors = ["RustPython Team"]
 edition = "2024"
-rust-version = "1.93.0"
+rust-version = "1.94.0"
 repository = "https://github.com/RustPython/RustPython"
 license = "MIT"
 


### PR DESCRIPTION
from refs: https://blog.rust-lang.org/2026/03/05/Rust-1.94.0/

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated minimum Rust version requirement to 1.94.0

<!-- end of auto-generated comment: release notes by coderabbit.ai -->