### PR TITLE
Implement `complex.from_number`

### DIFF
--- a/Lib/test/test_complex.py
+++ b/Lib/test/test_complex.py
@@ -744,7 +744,6 @@ class ComplexTest(ComplexesAreIdenticalMixin, unittest.TestCase):
             if not any(ch in lit for ch in 'xXoObB'):
                 self.assertRaises(ValueError, complex, lit)
 
-    @unittest.expectedFailure  # TODO: RUSTPYTHON; AttributeError: type object 'complex' has no attribute 'from_number'
     def test_from_number(self, cls=complex):
         def eq(actual, expected):
             self.assertEqual(actual, expected)
@@ -771,7 +770,6 @@ class ComplexTest(ComplexesAreIdenticalMixin, unittest.TestCase):
         self.assertRaises(TypeError, cls.from_number, {})
         self.assertRaises(TypeError, cls.from_number)
 
-    @unittest.expectedFailure  # TODO: RUSTPYTHON; AttributeError: type object 'ComplexSubclass' has no attribute 'from_number'
     def test_from_number_subclass(self):
         self.test_from_number(ComplexSubclass)
 

--- a/crates/vm/src/builtins/complex.rs
+++ b/crates/vm/src/builtins/complex.rs
@@ -416,15 +416,7 @@ impl Comparable for PyComplex {
     ) -> PyResult<PyComparisonValue> {
         op.eq_only(|| {
             let result = if let Some(other) = other.downcast_ref::<Self>() {
-                if zelf.value.re.is_nan()
-                    && zelf.value.im.is_nan()
-                    && other.value.re.is_nan()
-                    && other.value.im.is_nan()
-                {
-                    true
-                } else {
-                    zelf.value == other.value
-                }
+                zelf.value == other.value
             } else {
                 match float::to_op_float(other, vm) {
                     Ok(Some(other)) => zelf.value == other.into(),


### PR DESCRIPTION
This pull request does things:

- Upgrade `test.test_complex` to CPython 3.14.3
- Implement `complex.from_number`
- Correct `complex.__eq__` behavior where `complex(float('nan'), float('nan')) == complex(float('nan'), float('nan'))` was `True`.

As a note, `test_truediv` and `test_mul` fail because `complex(float('inf'), float('inf')) * 1` returns `nan+nanj`. It is num-complex's bug and I'll see it later.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new class method to construct complex numbers from numeric inputs, with proper subclassing support and preservation of existing behavior for complex and real number inputs.

* **Bug Fixes**
  * Simplified complex number equality comparison by removing special NaN handling, resulting in more consistent equality semantics.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->