### PR TITLE
Implement Hashable for PyBoundMethod

### DIFF
--- a/crates/vm/src/builtins/function.rs
+++ b/crates/vm/src/builtins/function.rs
@@ -5,6 +5,7 @@ use super::{
     PyAsyncGen, PyCode, PyCoroutine, PyDictRef, PyGenerator, PyModule, PyStr, PyStrRef, PyTuple,
     PyTupleRef, PyType,
 };
+use crate::common::hash::PyHash;
 use crate::common::lock::PyMutex;
 use crate::function::ArgMapping;
 use crate::object::{PyAtomicRef, Traverse, TraverseFn};
@@ -17,7 +18,8 @@ use crate::{
     function::{FuncArgs, OptionalArg, PyComparisonValue, PySetterValue},
     scope::Scope,
     types::{
-        Callable, Comparable, Constructor, GetAttr, GetDescriptor, PyComparisonOp, Representable,
+        Callable, Comparable, Constructor, GetAttr, GetDescriptor, Hashable, PyComparisonOp,
+        Representable,
     },
 };
 use core::sync::atomic::{AtomicU32, Ordering::Relaxed};
@@ -1193,6 +1195,14 @@ impl Comparable for PyBoundMethod {
     }
 }
 
+impl Hashable for PyBoundMethod {
+    fn hash(zelf: &Py<Self>, vm: &VirtualMachine) -> PyResult<PyHash> {
+        let self_hash = crate::common::hash::hash_object_id_raw(zelf.object.get_id());
+        let func_hash = zelf.function.hash(vm)?;
+        Ok(crate::common::hash::fix_sentinel(self_hash ^ func_hash))
+    }
+}
+
 impl GetAttr for PyBoundMethod {
     fn getattro(zelf: &Py<Self>, name: &Py<PyStr>, vm: &VirtualMachine) -> PyResult {
         let class_attr = vm
@@ -1248,7 +1258,7 @@ impl PyBoundMethod {
 }
 
 #[pyclass(
-    with(Callable, Comparable, GetAttr, Constructor, Representable),
+    with(Callable, Comparable, Hashable, GetAttr, Constructor, Representable),
     flags(IMMUTABLETYPE, HAS_WEAKREF)
 )]
 impl PyBoundMethod {


### PR DESCRIPTION
This pull request implements `Hashable` trait for `PyBoundMethod`. It will make `PyBoundMethod`'s hash consistent.

## Behavior changes

### Before

``` python
>>>>> class A:
.....   def f(): ...
.....
>>>>> a=A()
>>>>> hash(a.f)
38671770224
>>>>> hash(a.f)
38671770224
>>>>> a.f
<bound method A.f of <__main__.A object at 0x901164508>>
>>>>> hash(a.f)
38671770704
>>>>> hash(a.f)
38671770224
```

### After

``` python
>>>>> class A:
.....   def f(): ...
.....
>>>>> a=A()
>>>>> hash(a.f)
13456784
>>>>> hash(a.f)
13456784
>>>>> a.f
<bound method A.f of <__main__.A object at 0x84d00d3e8>>
>>>>> hash(a.f)
13456784
>>>>> hash(a.f)
13456784
```

## Links

- ~~Flaky CI failure: https://github.com/RustPython/RustPython/actions/runs/23328161711/job/67853734611?pr=7457~~
- CPython reference: https://github.com/python/cpython/blob/v3.14.3/Objects/classobject.c#L312-L327

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## New Features

* Bound methods can now be used as dictionary keys and in set operations, providing enhanced compatibility with hash-based collections.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->