### PR TITLE
Expose rustpython_pylib in rustpython

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -56,6 +56,9 @@ mod interpreter;
 mod settings;
 mod shell;
 
+#[cfg(feature = "rustpython-pylib")]
+pub use rustpython_pylib as pylib;
+
 use rustpython_vm::{AsObject, PyObjectRef, PyResult, VirtualMachine, scope::Scope};
 use std::env;
 use std::io::IsTerminal;


### PR DESCRIPTION
No need to `cargo add rustpython-pylib` anymore; `rustpython_pylib::FROZEN_STDLIB` is now accessible as `rustpython::pylib::FROZEN_STDLIB`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added `pylib` module for Python runtime functionality when the `rustpython-pylib` feature is enabled.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->