### PR TITLE
Cleanup `release.yml` a bit

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -136,6 +136,7 @@ jobs:
         working-directory: ./wasm/notebook
 
       - name: Deploy demo to Github Pages
+        if: ${{ github.repository == 'RustPython/RustPython' }}
         uses: peaceiris/actions-gh-pages@v4
         with:
           deploy_key: ${{ secrets.ACTIONS_DEMO_DEPLOY_KEY }}


### PR DESCRIPTION
### Behavior changes
- Enables jit on macos
- Enables `stdio`, `hoat_env` and `ssl-rustls` features on macos, windows, linux

### Other changes
- Don't use npm cache for release artifacts
- Pin actions to a commit hash
- Don't try to upload to gh-pages if running on forks

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Optimized build and release infrastructure for improved consistency and reliability across platforms.
  * Consolidated platform-specific build configuration and dependencies.
  * Pinned GitHub Actions to specific versions for enhanced security and stability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->