### PR TITLE
Resolve shellcheck warning on `ci.yaml`

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -270,7 +270,9 @@ jobs:
       - name: run cpython tests to check if env polluters have stopped polluting
         shell: bash
         run: |
-          for thing in "${{ matrix.env_polluting_tests }}"; do
+          IFS=' ' read -r -a target_array <<< "$TARGETS"
+
+          for thing in "${target_array[@]}"; do
             for i in $(seq 1 10); do
               set +e
               target/release/rustpython -m test -j 1 --slowest --fail-env-changed --timeout 600 -v "${thing}"
@@ -292,6 +294,8 @@ jobs:
               exit 1
             fi
           done
+        env:
+          TARGETS: ${{ join(matrix.env_polluting_tests, ' ') }}
         timeout-minutes: 15
 
       - if: runner.os != 'Windows'


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Improved CI reliability by making shell argument handling and exit-code checks more robust.
  * Made test-loop invocation safer to ensure selected tests are respected and avoid shell-parsing issues.
  * Ensured WASM test runner uses a quoted working directory to prevent path-related failures and improve cross-platform stability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->