### PR TITLE
(nit) Align concurrency CI groups names

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -12,7 +12,7 @@ name: CI
 # with the same event (push/pull_request) even they are in progress.
 # This setting will help reduce the number of duplicated workflows.
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}-${{ github.event_name }}
+  group: ${{ github.workflow }}-${{ github.ref_name }}-${{ github.event.pull_request.number || github.sha }}
   cancel-in-progress: true
 
 env:

--- a/.github/workflows/lib-deps-check.yaml
+++ b/.github/workflows/lib-deps-check.yaml
@@ -7,7 +7,7 @@ on:
       - "Lib/**"
 
 concurrency:
-  group: lib-deps-${{ github.event.pull_request.number }}
+  group: ${{ github.workflow }}-${{ github.ref_name }}-${{ github.event.pull_request.number }}
   cancel-in-progress: true
 
 env:

--- a/.github/workflows/pr-format.yaml
+++ b/.github/workflows/pr-format.yaml
@@ -10,7 +10,7 @@ on:
       - release
 
 concurrency:
-  group: format-check-${{ github.event.pull_request.number }}
+  group: ${{ github.workflow }}-${{ github.ref_name }}-${{ github.event.pull_request.number }}
   cancel-in-progress: true
 
 env:


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved GitHub Actions workflow concurrency configuration across multiple CI/CD pipelines (continuous integration, dependency verification, and pull request validation) to better manage how concurrent runs are grouped and cancelled when multiple development activities occur simultaneously, enhancing workflow efficiency and responsiveness.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->