### PR TITLE
Reorder PyNumberBinaryOp to match NB_* constants

### DIFF
--- a/crates/vm/src/protocol/number.rs
+++ b/crates/vm/src/protocol/number.rs
@@ -200,33 +200,34 @@ impl PyNumberMethods {
     }
 }
 
+/// Matches the NB_* constants ordering from opcode.h / BinaryOperator.
 #[derive(Copy, Clone)]
 pub enum PyNumberBinaryOp {
     Add,
-    Subtract,
+    And,
+    FloorDivide,
+    Lshift,
+    MatrixMultiply,
     Multiply,
     Remainder,
-    Divmod,
-    Lshift,
-    Rshift,
-    And,
-    Xor,
     Or,
+    Rshift,
+    Subtract,
+    TrueDivide,
+    Xor,
     InplaceAdd,
-    InplaceSubtract,
+    InplaceAnd,
+    InplaceFloorDivide,
+    InplaceLshift,
+    InplaceMatrixMultiply,
     InplaceMultiply,
     InplaceRemainder,
-    InplaceLshift,
-    InplaceRshift,
-    InplaceAnd,
-    InplaceXor,
     InplaceOr,
-    FloorDivide,
-    TrueDivide,
-    InplaceFloorDivide,
+    InplaceRshift,
+    InplaceSubtract,
     InplaceTrueDivide,
-    MatrixMultiply,
-    InplaceMatrixMultiply,
+    InplaceXor,
+    Divmod,
 }
 
 impl PyNumberBinaryOp {


### PR DESCRIPTION
Align variant ordering with BinaryOperator enum and CPython's NB_* constants from opcode.h. Divmod is placed last as it has no corresponding NB_* constant.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Internal code reorganization to align with Python conventions. No user-facing changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->