### PR TITLE
Revert "Only run `cargo check` when rust code is changed"

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -32,42 +32,6 @@ env:
   CARGO_TERM_COLOR: always
 
 jobs:
-  determine_changes:
-    name: Determine changes
-    runs-on: ubuntu-latest
-    outputs:
-      # Flag that is raised when any rust code is changed.
-      rust_code: ${{ steps.check_rust_code.outputs.changed }}
-    steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-        with:
-          fetch-depth: 0
-          persist-credentials: false
-
-      - name: Determine merge base
-        id: merge_base
-        run: |
-          sha=$(git merge-base HEAD "origin/${BASE_REF}")
-          echo "sha=${sha}" >> "$GITHUB_OUTPUT"
-        env:
-          BASE_REF: ${{ github.event.pull_request.base.ref || 'main' }}
-
-      - name: Check if there was any code related change
-        id: check_rust_code
-        run: |
-          if git diff --quiet "${MERGE_BASE}...HEAD" -- \
-            ':!Lib/**' \
-            ':!scripts/**' \
-            ':!extra_tests/**' \
-            ':.github/workflows/ci.yaml' \
-          ; then
-              echo "changed=false" >> "$GITHUB_OUTPUT"
-          else
-              echo "changed=true" >> "$GITHUB_OUTPUT"
-          fi
-        env:
-          MERGE_BASE: ${{ steps.merge_base.outputs.sha }}
-
   rust_tests:
     if: ${{ !contains(github.event.pull_request.labels.*.name, 'skip:ci') }}
     env:
@@ -145,13 +109,9 @@ jobs:
         if: runner.os == 'Linux'
 
   cargo_check:
+    if: ${{ !contains(github.event.pull_request.labels.*.name, 'skip:ci') }}
     name: cargo check
     runs-on: ${{ matrix.os }}
-    needs:
-      - determine_changes
-    if: |
-      !contains(github.event.pull_request.labels.*.name, 'skip:ci') &&
-      needs.determine_changes.outputs.rust_code == 'true'
     strategy:
       matrix:
         include: 


### PR DESCRIPTION
Reverts RustPython/RustPython#7572

This always skips, I'll test it a bit more. for now restore it to the way it was

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Simplified CI workflow configuration by streamlining job dependencies and condition checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->