### PR TITLE
Unify CI caches (reduce total cache size by 75% ±)

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -209,18 +209,6 @@ jobs:
           AR_aarch64_linux_android: ${{ steps.setup-ndk.outputs.ndk-path }}/toolchains/llvm/prebuilt/linux-x86_64/bin/llvm-ar
           CARGO_TARGET_AARCH64_LINUX_ANDROID_LINKER: ${{ steps.setup-ndk.outputs.ndk-path }}/toolchains/llvm/prebuilt/linux-x86_64/bin/aarch64-linux-android24-clang
 
-      - name: Save cache
-        if: ${{ github.ref == 'refs/heads/main' }} # only save on main
-        uses: actions/cache/save@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5.0.4
-        with:
-          path: |
-            ~/.cargo/bin/
-            ~/.cargo/registry/index/
-            ~/.cargo/registry/cache/
-            ~/.cargo/git/db/
-            target/
-          key: cargo-check-${{ runner.os }}-${{ matrix.target }}-${{ hashFiles('**/Cargo.toml') }}-${{ hashFiles('Cargo.lock') }}-${{ github.sha }}
-
   snippets_cpython:
     if: ${{ !contains(github.event.pull_request.labels.*.name, 'skip:ci') }}
     env:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -29,6 +29,9 @@ env:
   X86_64_PC_WINDOWS_MSVC_OPENSSL_LIB_DIR: C:\Program Files\OpenSSL\lib\VC\x64\MD
   X86_64_PC_WINDOWS_MSVC_OPENSSL_INCLUDE_DIR: C:\Program Files\OpenSSL\include
   CARGO_INCREMENTAL: 0
+  CARGO_PROFILE_TEST_DEBUG: 0
+  CARGO_PROFILE_DEV_DEBUG: 0
+  CARGO_PROFILE_RELEASE_DEBUG: 0
   CARGO_TERM_COLOR: always
 
 jobs:
@@ -52,9 +55,19 @@ jobs:
         with:
           components: clippy
 
-      - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
+      - name: Restore cache
+        uses: actions/cache/restore@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5.0.4
         with:
-          save-if: ${{ github.ref == 'refs/heads/main' }}
+          path: |
+            ~/.cargo/bin/
+            ~/.cargo/registry/index/
+            ~/.cargo/registry/cache/
+            ~/.cargo/git/db/
+            target/
+          key: ${{ runner.os }}-${{ hashFiles('**/Cargo.toml') }}-
+          restore-keys: |
+            ${{ runner.os }}-stable--${{ hashFiles('**/Cargo.toml') }}-
+            ${{ runner.os }}-stable--
 
       - name: Install macOS dependencies
         uses: ./.github/actions/install-macos-deps
@@ -154,7 +167,6 @@ jobs:
 
       - name: Restore cache
         uses: actions/cache/restore@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5.0.4
-        if: ${{ github.ref != 'refs/heads/main' }} # Never restore on main
         with:
           path: |
             ~/.cargo/bin/
@@ -163,9 +175,12 @@ jobs:
             ~/.cargo/git/db/
             target/
           # key won't match, will rely on restore-keys
-          key: cargo-check-${{ runner.os }}-${{ matrix.target }}
+          key: ${{ runner.os }}-${{ matrix.target }}
           restore-keys: |
-            cargo-check-${{ runner.os }}-${{ matrix.target }}-
+            ${{ runner.os }}-stable-${{ matrix.target }}-${{ hashFiles('**/Cargo.toml') }}-
+            ${{ runner.os }}-stable-${{ matrix.target }}-
+            ${{ runner.os }}-stable--${{ hashFiles('**/Cargo.toml') }}-
+            ${{ runner.os }}-stable--
 
       - uses: dtolnay/rust-toolchain@stable
         with:
@@ -252,9 +267,19 @@ jobs:
 
       - uses: dtolnay/rust-toolchain@stable
 
-      - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
+      - name: Restore cache
+        uses: actions/cache/restore@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5.0.4
         with:
-          save-if: ${{ github.ref == 'refs/heads/main' }}
+          path: |
+            ~/.cargo/bin/
+            ~/.cargo/registry/index/
+            ~/.cargo/registry/cache/
+            ~/.cargo/git/db/
+            target/
+          key: ${{ runner.os }}-${{ hashFiles('**/Cargo.toml') }}-
+          restore-keys: |
+            ${{ runner.os }}-stable--${{ hashFiles('**/Cargo.toml') }}-
+            ${{ runner.os }}-stable--
 
       - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
 
@@ -377,7 +402,6 @@ jobs:
         uses: zizmorcore/zizmor-action@71321a20a9ded102f6e9ce5718a2fcec2c4f70d8 # v0.5.2
 
       - name: restore prek cache
-        if: ${{ github.ref != 'refs/heads/main' }} # never restore on main
         uses: actions/cache/restore@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5.0.4
         with:
           key: prek-${{ hashFiles('.pre-commit-config.yaml') }}
@@ -422,9 +446,18 @@ jobs:
           toolchain: ${{ env.NIGHTLY_CHANNEL }}
           components: miri
 
-      - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
+      - name: Restore cache
+        uses: actions/cache/restore@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5.0.4
         with:
-          save-if: ${{ github.ref == 'refs/heads/main' }}
+          path: |
+            ~/.cargo/bin/
+            ~/.cargo/registry/index/
+            ~/.cargo/registry/cache/
+            ~/.cargo/git/db/
+            target/
+          key: ${{ runner.os }}-${{ hashFiles('**/Cargo.toml') }}
+          restore-keys: |
+            ${{ runner.os }}-
 
       - name: Run tests under miri
         run: cargo +${{ env.NIGHTLY_CHANNEL }} miri test -p rustpython-vm -- miri_test
@@ -447,9 +480,20 @@ jobs:
         with:
           components: clippy
 
-      - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
+      - name: Restore cache
+        uses: actions/cache/restore@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5.0.4
         with:
-          save-if: ${{ github.ref == 'refs/heads/main' }}
+          path: |
+            ~/.cargo/bin/
+            ~/.cargo/registry/index/
+            ~/.cargo/registry/cache/
+            ~/.cargo/git/db/
+            target/
+          key: ${{ runner.os }}-${{ hashFiles('**/Cargo.toml') }}-
+          restore-keys: |
+            ${{ runner.os }}-stable--${{ hashFiles('**/Cargo.toml') }}-
+            ${{ runner.os }}-stable--
+            ${{ runner.os }}-
 
       - name: cargo clippy
         run: cargo clippy --manifest-path=crates/wasm/Cargo.toml -- -Dwarnings
@@ -522,9 +566,21 @@ jobs:
         with:
           target: wasm32-wasip1
 
-      - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
+      - name: Restore cache
+        uses: actions/cache/restore@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5.0.4
         with:
-          save-if: ${{ github.ref == 'refs/heads/main' }}
+          path: |
+            ~/.cargo/bin/
+            ~/.cargo/registry/index/
+            ~/.cargo/registry/cache/
+            ~/.cargo/git/db/
+            target/
+          key: ${{ runner.os }}-${{ hashFiles('**/Cargo.toml') }}-
+          restore-keys: |
+            ${{ runner.os }}-stable-wasm32-wasip1-${{ hashFiles('**/Cargo.toml') }}-
+            ${{ runner.os }}-stable-wasm32-wasip1-
+            ${{ runner.os }}-stable--${{ hashFiles('**/Cargo.toml') }}-
+            ${{ runner.os }}-stable--
 
       - name: Setup Wasmer
         uses: wasmerio/setup-wasmer@v3

--- a/.github/workflows/update-caches.yml
+++ b/.github/workflows/update-caches.yml
@@ -1,0 +1,73 @@
+name: Update Actions Caches
+
+permissions:
+  contents: read
+
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - main
+
+env:
+  CARGO_INCREMENTAL: 0
+  CARGO_TERM_COLOR: always
+  CARGO_PROFILE_TEST_DEBUG: 0
+  CARGO_PROFILE_DEV_DEBUG: 0
+  CARGO_PROFILE_RELEASE_DEBUG: 0
+  CARGO_ARGS: --no-default-features --features stdlib,importlib,stdio,encodings,sqlite,ssl-rustls,host_env,threading,jit
+
+jobs:
+  build-caches:
+    name: Build Caches
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        include:
+          - os: macos-latest
+            toolchain: stable
+            target: ""
+          - os: ubuntu-latest
+            toolchain: stable
+            target: ""
+          - os: windows-latest
+            toolchain: stable
+            target: ""
+    steps:
+      - name: Checkout RustPython main branch
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          repository: RustPython/RustPython
+          ref: main
+          persist-credentials: false
+
+      - name: Setup Rust
+        uses: dtolnay/rust-toolchain@3c5f7ea28cd621ae0bf5283f0e981fb97b8a7af9
+        with:
+          toolchain: ${{ matrix.toolchain }}
+          target: ${{ matrix.target }}
+
+      - name: Install macos dependencies
+        uses: ./.github/actions/install-macos-deps
+        with:
+          openssl: true
+
+      - name: Build dev cache # dev profile used by check & doc
+        run: cargo build --profile dev ${{ env.CARGO_ARGS }}
+
+      - name: Build test cache
+        run: cargo build --profile test ${{ env.CARGO_ARGS }}
+
+      - name: Build release cache
+        run: cargo build --profile release ${{ env.CARGO_ARGS }}
+
+      - name: Save cache
+        uses: actions/cache/save@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5.0.4
+        with:
+          path: |
+            ~/.cargo/bin/
+            ~/.cargo/registry/index/
+            ~/.cargo/registry/cache/
+            ~/.cargo/git/db/
+            target/
+          key: ${{ runner.os }}-${{ matrix.toolchain }}-${{ matrix.target }}-${{ hashFiles('**/Cargo.toml') }}-${{ hashFiles('Cargo.lock') }}-${{ github.sha }}


### PR DESCRIPTION
ATM we have separate cache for a matrix of `operating systems * job number` (the actual number is less, but not by that much). And the cache of all those jobs is 99% the same.

This PR makes it so we have a single cache for an `${{ runner.os }}-${{ matrix.target }}-${{ matrix.toolchain }}`, which is 3 in total for now. each of them weight 820-900MB.

The issue with the large number of cache size is that once we reach our limit GH starts to purge old caches, so sometimes some `cargo check` jobs didn't have a cache hit:/

Caches on main
![Screenshot_2026-04-14-17-24-19-02_e4424258c8b8649f6e67d283a50a2cbc](https://github.com/user-attachments/assets/8d1cb5fd-951e-4584-a61a-bbf32bd7f9cb)

Caches after change (there will be more entries with more invocations):

![Screenshot_2026-04-14-17-23-14-68_e4424258c8b8649f6e67d283a50a2cbc](https://github.com/user-attachments/assets/44a54138-0dc4-48ea-aaf2-f204d12ecdeb)


more targets & toolchains can be easily added if needed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Standardized and expanded CI caching to improve cache hit rates and build speed (broader restore fallbacks and unified keying).
  * Disabled debug-info generation for build profiles to reduce artifact size.
  * Removed restrictive cache-restore guards to allow more consistent cache usage.
  * Added an automated workflow to refresh and maintain build caches across supported OSes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->