### PR TITLE
Add const methods for oparg enums

### DIFF
--- a/crates/compiler-core/src/bytecode/oparg.rs
+++ b/crates/compiler-core/src/bytecode/oparg.rs
@@ -124,10 +124,6 @@ impl OpArgState {
 /// - impl [`Into<u32>`]
 /// - impl [`OpArgType`]
 ///
-/// # Note
-/// If an enum variant has "alternative" values (i.e. `Foo = 0 | 1`), the first value will be the
-/// result of converting to a number.
-///
 /// # Examples
 ///
 /// ```ignore
@@ -138,8 +134,8 @@ impl OpArgState {
 ///         /// Some doc.
 ///         Foo = 4,
 ///         Bar = 8,
-///         Baz = 15 | 16,
-///         Qux = 23 | 42
+///         Baz = 15,
+///         Qux = 16
 ///     }
 /// );
 /// ```
@@ -149,7 +145,7 @@ macro_rules! oparg_enum {
         $vis:vis enum $name:ident {
             $(
                 $(#[$variant_meta:meta])*
-                $variant:ident = $value:literal $(| $alternatives:expr)*
+                $variant:ident = $value:literal
             ),* $(,)?
         }
     ) => {
@@ -162,9 +158,9 @@ macro_rules! oparg_enum {
         }
 
         impl_oparg_enum!(
-            enum $name {
+            $vis enum $name {
                 $(
-                    $variant = $value $(| $alternatives)*,
+                    $variant = $value,
                 )*
             }
         );
@@ -173,22 +169,53 @@ macro_rules! oparg_enum {
 
 macro_rules! impl_oparg_enum {
     (
-        enum $name:ident {
+        $vis:vis enum $name:ident {
             $(
-                $variant:ident = $value:literal $(| $alternatives:expr)*
+                $variant:ident = $value:literal
             ),* $(,)?
         }
     ) => {
+        impl $name {
+            /// Returns the oparg as a [`u8`] value.
+            #[must_use]
+            $vis const fn as_u8(self) -> u8 {
+                match self {
+                    $(
+                        Self::$variant => $value,
+                    )*
+                }
+            }
+
+            /// Returns the oparg as a [`u32`] value.
+            #[must_use]
+            $vis const fn as_u32(self) -> u32 {
+                self.as_u8() as u32
+            }
+
+            $vis const fn try_from_u8(value: u8) -> Result<Self, $crate::marshal::MarshalError> {
+                Ok(match value {
+                    $(
+                        $value => Self::$variant,
+                    )*
+                    _ => return Err($crate::marshal::MarshalError::InvalidBytecode),
+                })
+            }
+
+            $vis const fn try_from_u32(value: u32) -> Result<Self, $crate::marshal::MarshalError> {
+                if value > (u8::MAX as u32) {
+                    return Err($crate::marshal::MarshalError::InvalidBytecode);
+                }
+
+                // We already validated this is a lossles cast.
+                Self::try_from_u8(value as u8)
+            }
+        }
+
         impl TryFrom<u8> for $name {
             type Error = $crate::marshal::MarshalError;
 
             fn try_from(value: u8) -> Result<Self, Self::Error> {
-                Ok(match value {
-                    $(
-                        $value $(| $alternatives)* => Self::$variant,
-                    )*
-                    _ => return Err(Self::Error::InvalidBytecode),
-                })
+                Self::try_from_u8(value)
             }
         }
 
@@ -196,25 +223,19 @@ macro_rules! impl_oparg_enum {
             type Error = $crate::marshal::MarshalError;
 
             fn try_from(value: u32) -> Result<Self, Self::Error> {
-                u8::try_from(value)
-                    .map_err(|_| Self::Error::InvalidBytecode)
-                    .map(TryInto::try_into)?
+                Self::try_from_u32(value)
             }
         }
 
         impl From<$name> for u8 {
             fn from(value: $name) -> Self {
-                match value {
-                    $(
-                        $name::$variant => $value,
-                    )*
-                }
+                value.as_u8()
             }
         }
 
         impl From<$name> for u32 {
             fn from(value: $name) -> Self {
-                Self::from(u8::from(value))
+                value.as_u32()
             }
         }
 
@@ -236,8 +257,7 @@ oparg_enum!(
         /// f"{x}"
         /// f"{x:4}"
         /// ```
-        // Ruff `ConversionFlag::None` is `-1i8`, when its converted to `u8` its value is `u8::MAX`.
-        None = 0 | 255,
+        None = 0,
         /// Converts by calling `str(<value>)`.
         ///
         /// ```python
@@ -735,19 +755,19 @@ macro_rules! newtype_oparg {
         $vis struct $name(u32);
 
         impl $name {
-            /// Creates a new [`$name`] instance.
+            #[doc = concat!("Creates a new [`", stringify!($name), "`] instance.")]
             #[must_use]
             pub const fn from_u32(value: u32) -> Self {
                 Self(value)
             }
 
-            /// Returns the oparg as a `u32` value.
+            /// Returns the oparg as a [`u32`] value.
             #[must_use]
             pub const fn as_u32(self) -> u32 {
                 self.0
             }
 
-            /// Returns the oparg as a `usize` value.
+            /// Returns the oparg as a [`usize`] value.
             #[must_use]
             pub const fn as_usize(self) -> usize {
               self.0 as usize

--- a/crates/compiler-core/src/bytecode/oparg.rs
+++ b/crates/compiler-core/src/bytecode/oparg.rs
@@ -248,7 +248,7 @@ oparg_enum!(
     ///
     /// ## See also
     ///
-    /// - [CPython FVC_* flags](https://github.com/python/cpython/blob/8183fa5e3f78ca6ab862de7fb8b14f3d929421e0/Include/ceval.h#L129-L132)
+    /// - [CPython FVC_* flags](https://github.com/python/cpython/blob/v3.14.4/Include/ceval.h#L129-L132)
     #[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
     pub enum ConvertValueOparg {
         /// No conversion.


### PR DESCRIPTION
Until https://github.com/rust-lang/rust/issues/143874 is available for stable rust I believe there's a benefit for providing a `const` implementation of a trait where possible.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Streamlined value encoding/decoding logic in the compiler core to use explicit conversion helpers, improving consistency and reliability across enum-like bytecode values.
* **Bug Fixes**
  * Removed legacy alternative literal encodings; decoding is now strict to declared values and a default "None" value was normalized, preventing ambiguous interpretations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->