### PR TITLE
Update `test_cmath.py` from 3.14.4

### DIFF
--- a/Lib/test/test_cmath.py
+++ b/Lib/test/test_cmath.py
@@ -406,6 +406,8 @@ class CMathTests(ComplexesAreIdenticalMixin, unittest.TestCase):
                 _testcapi.set_errno(0)
         self.check_polar(polar_with_errno_set)
 
+    @unittest.skipIf(sys.platform.startswith("sunos"),
+                     "skipping, see gh-138573")
     def test_phase(self):
         self.assertAlmostEqual(phase(0), 0.)
         self.assertAlmostEqual(phase(1.), 0.)


### PR DESCRIPTION
Syncs `Lib/test/test_cmath.py` with CPython 3.14.4.

Adds the SunOS skip decorator on `test_phase` introduced in CPython ([gh-138573](https://github.com/python/cpython/issues/138573)).

Follows the same pattern as #7607, #7609, #7614, #7618.