### PR TITLE
Fix error messages in binary/ternary ops to match CPython format

### DIFF
--- a/Lib/test/test_fractions.py
+++ b/Lib/test/test_fractions.py
@@ -1696,7 +1696,6 @@ class FractionTest(unittest.TestCase):
                                  message % ("divmod()", "complex", "Fraction"),
                                  divmod, b, a)
 
-    @unittest.expectedFailure # TODO: RUSTPYTHON; Wrong error message
     def test_three_argument_pow(self):
         message = "unsupported operand type(s) for ** or pow(): '%s', '%s', '%s'"
         self.assertRaisesMessage(TypeError,

--- a/Lib/test/test_fractions.py
+++ b/Lib/test/test_fractions.py
@@ -1669,7 +1669,6 @@ class FractionTest(unittest.TestCase):
                     self.assertEqual(float(format(f, fmt2)), float(rhs))
                     self.assertEqual(float(format(-f, fmt2)), float('-' + rhs))
 
-    @unittest.expectedFailure # TODO: RUSTPYTHON; TypeError: '%' not supported between instances of 'Fraction' and 'complex'
     def test_complex_handling(self):
         # See issue gh-102840 for more details.
 

--- a/crates/vm/src/vm/vm_ops.rs
+++ b/crates/vm/src/vm/vm_ops.rs
@@ -401,7 +401,7 @@ impl VirtualMachine {
 
     binary_func!(_sub, Subtract, "-");
     binary_func!(_mod, Remainder, "%");
-    binary_func!(_divmod, Divmod, "divmod");
+    binary_func!(_divmod, Divmod, "divmod()");
     binary_func!(_lshift, Lshift, "<<");
     binary_func!(_rshift, Rshift, ">>");
     binary_func!(_and, And, "&");

--- a/crates/vm/src/vm/vm_ops.rs
+++ b/crates/vm/src/vm/vm_ops.rs
@@ -372,7 +372,7 @@ impl VirtualMachine {
         } else {
             self.new_type_error(format!(
                 "unsupported operand type(s) for {}: \
-                '{}' and '{}', '{}'",
+                '{}', '{}', '{}'",
                 op_str,
                 a.class(),
                 b.class(),


### PR DESCRIPTION
Fixes two closely-related error-message divergences in `crates/vm/src/vm/vm_ops.rs`. Both affect `TypeError` text for arithmetic ops with unsupported operand types. Each unmasks one `@unittest.expectedFailure` in `test_fractions.py`.

## Fix 1 — `divmod` missing parentheses

**Symptom.** `divmod(x, y)` with unsupported types emits `"... for divmod: ..."`. CPython emits `"... for divmod(): ..."` (the function-call form, consistent with how `pow()` is named).

```python
>>> divmod(1.5, 1j)
# CPython:    TypeError: unsupported operand type(s) for divmod(): 'float' and 'complex'
# RustPython: TypeError: unsupported operand type(s) for divmod:   'float' and 'complex'
```

**Fix.** `vm_ops.rs:404` — `"divmod"` → `"divmod()"`.

**Source.** CPython's `Objects/abstract.c` uses `"divmod()"` as the op_name for the divmod dispatch.

**Unmasks:** `test_fractions.py::FractionTest::test_complex_handling`.

## Fix 2 — ternary op error uses " and " instead of ", "

**Symptom.** 3-argument error (e.g. `pow(a, b, c)` with unsupported types) emits `"'X' and 'Y', 'Z'"`. CPython emits `"'X', 'Y', 'Z'"` — all commas.

```python
>>> pow(Fraction(3), 4, 5)
# CPython:    TypeError: unsupported operand type(s) for ** or pow(): 'Fraction', 'int', 'int'
# RustPython: TypeError: unsupported operand type(s) for ** or pow(): 'Fraction' and 'int', 'int'
```

**Fix.** `vm_ops.rs:375` — the format string's `'{}' and '{}', '{}'` → `'{}', '{}', '{}'`.

The 2-argument case (line 367) correctly keeps `'X' and 'Y'` (CPython matches this).

**Unmasks:** `test_fractions.py::FractionTest::test_three_argument_pow`.

## Verification

```
$ ./target/release/rustpython -m test test_fractions -v
test_complex_handling     ... ok     # was: expected failure
test_three_argument_pow   ... ok     # was: expected failure
Ran 50 tests in 0.060s
OK                                    # was: OK (expected failures=2)
```