### PR TITLE
Use Unicode properties for alnum, alpha, etc.

### DIFF
--- a/Lib/test/test_str.py
+++ b/Lib/test/test_str.py
@@ -792,7 +792,6 @@ class StrTest(string_tests.StringLikeTest,
         for ch in ['\U0001D7F6', '\U00011066', '\U000104A0']:
             self.assertTrue(ch.isdecimal(), '{!a} is decimal.'.format(ch))
 
-    @unittest.expectedFailure  # TODO: RUSTPYTHON; AssertionError: False != True
     def test_isdigit(self):
         super().test_isdigit()
         self.checkequalnofix(True, '\u2460', 'isdigit')

--- a/crates/sre_engine/src/string.rs
+++ b/crates/sre_engine/src/string.rs
@@ -1,4 +1,4 @@
-use icu_properties::props::{CanonicalCombiningClass, EnumeratedProperty};
+use icu_properties::props::{EnumeratedProperty, GeneralCategory, GeneralCategoryGroup};
 use rustpython_wtf8::Wtf8;
 
 #[derive(Debug, Clone, Copy)]
@@ -444,9 +444,10 @@ pub(crate) const fn is_uni_linebreak(ch: u32) -> bool {
 pub(crate) fn is_uni_alnum(ch: u32) -> bool {
     // TODO: check with cpython
     char::try_from(ch)
-        .map(|x| {
-            x.is_alphanumeric()
-                && CanonicalCombiningClass::for_char(x) == CanonicalCombiningClass::NotReordered
+        .map(|c| {
+            GeneralCategoryGroup::Letter
+                .union(GeneralCategoryGroup::Number)
+                .contains(GeneralCategory::for_char(c))
         })
         .unwrap_or(false)
 }

--- a/crates/vm/src/builtins/str.rs
+++ b/crates/vm/src/builtins/str.rs
@@ -45,8 +45,8 @@ use rustpython_common::{
 };
 
 use icu_properties::props::{
-    BidiClass, BinaryProperty, CanonicalCombiningClass, EnumeratedProperty, GeneralCategory,
-    XidContinue, XidStart,
+    BidiClass, BinaryProperty, EnumeratedProperty, GeneralCategory, GeneralCategoryGroup,
+    NumericType, XidContinue, XidStart,
 };
 use unicode_casing::CharExt;
 
@@ -949,23 +949,30 @@ impl PyStr {
     fn isalnum(&self) -> bool {
         !self.data.is_empty()
             && self.char_all(|c| {
-                c.is_alphanumeric()
-                    && CanonicalCombiningClass::for_char(c) == CanonicalCombiningClass::NotReordered
+                GeneralCategoryGroup::Letter
+                    .union(GeneralCategoryGroup::Number)
+                    .contains(GeneralCategory::for_char(c))
             })
     }
 
     #[pymethod]
     fn isnumeric(&self) -> bool {
-        !self.data.is_empty() && self.char_all(char::is_numeric)
+        !self.data.is_empty()
+            && self.char_all(|c| {
+                [
+                    NumericType::Decimal,
+                    NumericType::Digit,
+                    NumericType::Numeric,
+                ]
+                .contains(&NumericType::for_char(c))
+            })
     }
 
     #[pymethod]
     fn isdigit(&self) -> bool {
-        // python's isdigit also checks if exponents are digits, these are the unicode codepoints for exponents
         !self.data.is_empty()
             && self.char_all(|c| {
-                c.is_ascii_digit()
-                    || matches!(c, '⁰' | '¹' | '²' | '³' | '⁴' | '⁵' | '⁶' | '⁷' | '⁸' | '⁹')
+                [NumericType::Digit, NumericType::Decimal].contains(&NumericType::for_char(c))
             })
     }
 
@@ -1064,7 +1071,9 @@ impl PyStr {
 
     #[pymethod]
     fn isalpha(&self) -> bool {
-        !self.data.is_empty() && self.char_all(char::is_alphabetic)
+        !self.data.is_empty()
+            && self
+                .char_all(|c| GeneralCategoryGroup::Letter.contains(GeneralCategory::for_char(c)))
     }
 
     #[pymethod]

--- a/extra_tests/snippets/builtin_str.py
+++ b/extra_tests/snippets/builtin_str.py
@@ -72,6 +72,7 @@ assert a.istitle()
 assert "\u1c89".istitle()
 # assert "Ǳ".title() == "ǲ"
 assert a.isalpha()
+assert not "\u093f".isalpha()
 
 # Combining characters differ slightly between Rust and Python
 assert "\u006e".isalnum()
@@ -79,8 +80,20 @@ assert not "\u0303".isalnum()
 assert not "\u006e\u0303".isalnum()
 assert "\u00f1".isalnum()
 assert not "\u0345".isalnum()
+assert not "\u093f".isalnum()
 for raw in range(0x0363, 0x036F):
     assert not chr(raw).isalnum()
+
+# isdigit is true for exponents
+assert "⁰".isdigit()
+assert "⁰".isnumeric()
+assert not "½".isdigit()
+assert "½".isnumeric()
+assert not "Ⅻ".isdigit()
+assert "Ⅻ".isnumeric()
+
+# isnumeric is broader than Rust's
+assert "\u3405".isnumeric()
 
 s = "1 2 3"
 assert s.split(" ", 1) == ["1", "2 3"]


### PR DESCRIPTION
Rust and Python differ in which properties they use for alphanumeric, numeric, et cetera. Both languages list which properties are used which makes it easy to mimic Python's behavior in Rust.

My previous patch was a bit shortsighted because I filtered out combining characters from is_alphanumeric. Using properties is exact and also much cleaner. It also covers edge cases that my initial approach missed.

Besides isalnum, I also fixed isnumeric and isdigit in the same way by using properties.

---

This contributes a bit to #7527. Unicode issues for isalnum etc. should be solved now (and permanently too!!). Title casing looks harder to fix, but the basic solution of using properties more should apply there too. Also, the RegEx engine can benefit from using properties more too, but I'm terrible at RegEx so I didn't really try to fix issues there. :laughing: 

For extra reading, here is [Python's docs](https://docs.python.org/3/library/stdtypes.html#str.isalnum) which lists the categories used. Look at `isalpha()`, for example.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Unicode classification for string methods (isalnum, isalpha, isdigit, isnumeric) for more accurate behavior across international characters and special Unicode categories.

* **Tests**
  * Added/expanded tests covering edge cases: superscript digits, fractions, Roman numerals, and additional non-Latin characters to validate classification behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->