### PR TITLE
Fix segfault on cyclic or deeply-nested AST in `compile()`

### DIFF
--- a/crates/vm/src/stdlib/_ast/node.rs
+++ b/crates/vm/src/stdlib/_ast/node.rs
@@ -31,7 +31,14 @@ impl<T: Node> Node for Vec<T> {
         source_file: &SourceFile,
         object: PyObjectRef,
     ) -> PyResult<Self> {
-        vm.extract_elements_with(&object, |obj| Node::ast_from_object(vm, source_file, obj))
+        // Recursion guard for each element: prevents stack overflow when a
+        // sequence element transitively references the sequence itself
+        // (e.g. `l = ast.List(...); l.elts = [l]`). See issue #4862.
+        vm.extract_elements_with(&object, |obj| {
+            vm.with_recursion("while traversing AST node", || {
+                Node::ast_from_object(vm, source_file, obj)
+            })
+        })
     }
 }
 
@@ -45,7 +52,13 @@ impl<T: Node> Node for Box<T> {
         source_file: &SourceFile,
         object: PyObjectRef,
     ) -> PyResult<Self> {
-        T::ast_from_object(vm, source_file, object).map(Self::new)
+        // Recursion guard: every descent through a Box<AstNode> increments the
+        // VM's recursion depth so cyclic or pathologically deep ASTs raise
+        // RecursionError instead of overflowing the native stack.
+        // See issue #4862.
+        vm.with_recursion("while traversing AST node", || {
+            T::ast_from_object(vm, source_file, object).map(Self::new)
+        })
     }
 
     fn is_none(&self) -> bool {

--- a/extra_tests/snippets/stdlib_ast.py
+++ b/extra_tests/snippets/stdlib_ast.py
@@ -37,3 +37,54 @@ assert i.level == 3
 assert i.module is None
 assert i.names[0].name == "a"
 assert i.names[0].asname is None
+
+
+# Regression test for issue #4862:
+# A cyclic AST fed to compile() used to overflow the Rust stack and SIGSEGV.
+# After the fix, the recursion guard in ast_from_object raises RecursionError,
+# matching CPython's behavior. Covers both Box<T> descents (UnaryOp, BinOp,
+# Call, Attribute) and Vec<T> descents (List, Tuple).
+import warnings
+
+
+def _cyclic_cases():
+    # Box<Expr> descents
+    u = ast.UnaryOp(op=ast.Not(), lineno=0, col_offset=0)
+    u.operand = u
+    yield "UnaryOp", u
+
+    b = ast.BinOp(
+        op=ast.Add(),
+        right=ast.Constant(value=0, lineno=0, col_offset=0),
+        lineno=0,
+        col_offset=0,
+    )
+    b.left = b
+    yield "BinOp", b
+
+    c = ast.Call(args=[], keywords=[], lineno=0, col_offset=0)
+    c.func = c
+    yield "Call", c
+
+    a = ast.Attribute(attr="x", ctx=ast.Load(), lineno=0, col_offset=0)
+    a.value = a
+    yield "Attribute", a
+
+    # Vec<Expr> descents
+    lst = ast.List(ctx=ast.Load(), lineno=0, col_offset=0)
+    lst.elts = [lst]
+    yield "List", lst
+
+    tup = ast.Tuple(ctx=ast.Load(), lineno=0, col_offset=0)
+    tup.elts = [tup]
+    yield "Tuple", tup
+
+
+with warnings.catch_warnings():
+    warnings.simplefilter("ignore")
+    for name, node in _cyclic_cases():
+        try:
+            compile(ast.Expression(node), "<cyclic>", "eval")
+            raise AssertionError(f"cyclic {name} should raise RecursionError")
+        except RecursionError:
+            pass  # expected; matches CPython


### PR DESCRIPTION
Closes #4862.

## Symptom

`compile()` with a cyclic or pathologically deep AST object (built via the `ast` module) overflows the native stack and crashes RustPython with `SIGSEGV`. CPython raises `RecursionError: maximum recursion depth exceeded while traversing <kind> node`.

### Reproduction

```python
import ast
d = ast.UnaryOp(op=ast.Not(), lineno=0, col_offset=0)
d.operand = d  # self-reference -> infinite traversal
compile(ast.Expression(d), '<t>', 'eval')
```

| | Before | After |
|---|---|---|
| RustPython | `SIGSEGV` | `RecursionError: maximum recursion depth exceeded while traversing AST node` |
| CPython 3.14 | `RecursionError: maximum recursion depth exceeded while traversing 'expr' node` | (unchanged) |

## Root cause

The `ast_from_object` conversion from a Python `ast` object tree to the internal `ruff_python_ast` types in `crates/vm/src/stdlib/_ast/node.rs` recursed unconditionally:

- `Box<T>::ast_from_object` called `T::ast_from_object` once per descent (no guard)
- `Vec<T>::ast_from_object` called `Node::ast_from_object` per element (no guard)

A cycle in the Python-level AST turns either call into unbounded recursion, which overflows the Rust native stack. Rust cannot recover from a stack overflow — the process is killed.

## Fix

Wrap both recursive descents in `vm.with_recursion(...)`, which is the existing machinery RustPython uses elsewhere to translate native recursion into a Python-level `RecursionError` at the configured limit (default 1000). No new infrastructure, no configuration changes.

```rust
// Box<T>::ast_from_object — single recursive descent
vm.with_recursion("while traversing AST node", || {
    T::ast_from_object(vm, source_file, object).map(Self::new)
})

// Vec<T>::ast_from_object — per-element descent
vm.extract_elements_with(&object, |obj| {
    vm.with_recursion("while traversing AST node", || {
        Node::ast_from_object(vm, source_file, obj)
    })
})
```

The `"while traversing AST node"` label matches CPython's `RecursionError` message style for this failure mode.

## Why both `Box<T>` and `Vec<T>` must be guarded

All recursive AST fields use one of these two containers:

- **Box<Expr>** etc. — direct single-child descent (most binary/unary expressions, attribute access, subscripts, etc.)
- **Vec<Expr>** etc. — multi-child descent (list/tuple/set literals, dict values, match patterns, call args, etc.)

An earlier iteration of this patch only guarded `Box<T>`. Testing showed that `List.elts = [self]` and `Tuple.elts = [self]` still crashed because they traverse via `Vec<T>`. Guarding both closes every cycle path I could construct.

## Verification

### Direct-cycle cases (were segfaulting; now raise `RecursionError`)

- `UnaryOp.operand = self`
- `BinOp.left = self`
- `Call.func = self`
- `Attribute.value = self`
- `Subscript.value = self`
- `IfExp.test = self`
- `List.elts = [self]`
- `Tuple.elts = [self]`
- `Set.elts = [self]`
- `Dict.values = [self]`
- `ListComp.elt = self`

### Indirect cycles

- `A.operand = B; B.operand = A` — caught on the same counter.

### Deep non-cyclic input

| Depth | Behavior |
|---|---|
| 500 | compiles OK |
| 900 | compiles OK |
| 999 | compiles OK |
| 1500 / 3000 / 5000 | `RecursionError` (safe; no crash) |

### Regression

```
$ ./target/release/rustpython -m test test_ast test_compile
All 2 tests OK.
Result: SUCCESS
```

A new regression test in `extra_tests/snippets/stdlib_ast.py` exercises 6 representative cycle patterns across both `Box` and `Vec` descent paths; it passes on both RustPython (with this patch) and CPython 3.14.

## Scope

- Targeted at the `ast_from_object` path, which is the only way a cyclic tree can enter RustPython's compilation pipeline (parsed source cannot be cyclic; ruff parser produces trees, not DAGs).
- `ast_to_object` (reverse direction) is only called on trees produced by `ruff_python_parser`, which does not emit cycles; no user-controlled path reaches it.
- `validate_mod` runs after `ast_from_object`. Since `ast_from_object` now caps depth via the VM's recursion counter, any AST reaching `validate_mod` is already depth-bounded; local testing at depth 999 confirms `validate_mod` handles it without crashing.

## Why this approach (vs. a dedicated counter in codegen)

The initial attempt placed a depth counter inside `Compiler::compile_expression` (`crates/codegen/src/compile.rs`). That turned out to be downstream of the crash site — the process is already dead before reaching codegen. The fix lives where the crash happens: the `ast_from_object` traversal. Using the VM's existing `with_recursion` keeps the mechanism consistent with how RustPython already converts native overflows to `RecursionError` elsewhere (e.g. during `__repr__` recursion, `__eq__` recursion).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of cyclic and pathologically deep AST structures to prevent stack overflow and raise proper recursion errors instead.

* **Tests**
  * Added comprehensive regression tests for cyclic AST nodes to ensure proper error handling across various node types.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->