### PR TITLE
Fix stack overflow on deeply-nested JSON in json.loads()

### DIFF
--- a/Lib/test/test_json/test_recursion.py
+++ b/Lib/test/test_json/test_recursion.py
@@ -70,7 +70,6 @@ class TestRecursion:
             self.fail("didn't raise ValueError on default recursion")
 
 
-    @unittest.skip("TODO: RUSTPYTHON; crashes")
     @support.skip_if_unlimited_stack_size
     @support.skip_emscripten_stack_overflow()
     @support.skip_wasi_stack_overflow()

--- a/crates/stdlib/src/json.rs
+++ b/crates/stdlib/src/json.rs
@@ -513,107 +513,116 @@ mod _json {
             memo: &mut HashMap<String, PyStrRef>,
             vm: &VirtualMachine,
         ) -> PyResult<(PyObjectRef, usize, usize)> {
-            let bytes = pystr.as_bytes();
-            let wtf8 = pystr.as_wtf8();
-            let s = pystr.as_str();
+            // Recursion guard: parse_object/parse_array recurse into call_scan_once
+            // for each child value. Without this, a deeply-nested input like
+            // `'[' * 50000 + ']' * 50000` overflows the native Rust stack and
+            // crashes the process with SIGSEGV. Matches CPython's
+            // _Py_EnterRecursiveCall in Modules/_json.c.
+            vm.with_recursion("while decoding a JSON object from a string", || {
+                let bytes = pystr.as_bytes();
+                let wtf8 = pystr.as_wtf8();
+                let s = pystr.as_str();
 
-            let first_byte = match bytes.get(byte_idx) {
-                Some(&b) => b,
-                None => return Err(self.make_decode_error("Expecting value", pystr, char_idx, vm)),
-            };
+                let first_byte = match bytes.get(byte_idx) {
+                    Some(&b) => b,
+                    None => {
+                        return Err(self.make_decode_error("Expecting value", pystr, char_idx, vm));
+                    }
+                };
 
-            match first_byte {
-                b'"' => {
-                    // String - pass slice starting after the quote
-                    let (wtf8_result, chars_consumed, bytes_consumed) =
-                        machinery::scanstring(&wtf8[byte_idx + 1..], char_idx + 1, self.strict)
-                            .map_err(|e| py_decode_error(e, pystr.clone().into_wtf8(), vm))?;
-                    let py_str = vm.ctx.new_str(wtf8_result.to_string());
-                    Ok((
-                        py_str.into(),
-                        char_idx + 1 + chars_consumed,
-                        byte_idx + 1 + bytes_consumed,
-                    ))
-                }
-                b'{' => {
-                    // Object
-                    self.parse_object(pystr, char_idx + 1, byte_idx + 1, scan_once, memo, vm)
-                }
-                b'[' => {
-                    // Array
-                    self.parse_array(pystr, char_idx + 1, byte_idx + 1, scan_once, memo, vm)
-                }
-                b'n' if starts_with_bytes(&bytes[byte_idx..], b"null") => {
-                    // null
-                    Ok((vm.ctx.none(), char_idx + 4, byte_idx + 4))
-                }
-                b't' if starts_with_bytes(&bytes[byte_idx..], b"true") => {
-                    // true
-                    Ok((vm.ctx.new_bool(true).into(), char_idx + 4, byte_idx + 4))
-                }
-                b'f' if starts_with_bytes(&bytes[byte_idx..], b"false") => {
-                    // false
-                    Ok((vm.ctx.new_bool(false).into(), char_idx + 5, byte_idx + 5))
-                }
-                b'N' if starts_with_bytes(&bytes[byte_idx..], b"NaN") => {
-                    // NaN
-                    let result = self.parse_constant.call(("NaN",), vm)?;
-                    Ok((result, char_idx + 3, byte_idx + 3))
-                }
-                b'I' if starts_with_bytes(&bytes[byte_idx..], b"Infinity") => {
-                    // Infinity
-                    let result = self.parse_constant.call(("Infinity",), vm)?;
-                    Ok((result, char_idx + 8, byte_idx + 8))
-                }
-                b'-' => {
-                    // -Infinity or negative number
-                    if starts_with_bytes(&bytes[byte_idx..], b"-Infinity") {
-                        let result = self.parse_constant.call(("-Infinity",), vm)?;
-                        return Ok((result, char_idx + 9, byte_idx + 9));
+                match first_byte {
+                    b'"' => {
+                        // String - pass slice starting after the quote
+                        let (wtf8_result, chars_consumed, bytes_consumed) =
+                            machinery::scanstring(&wtf8[byte_idx + 1..], char_idx + 1, self.strict)
+                                .map_err(|e| py_decode_error(e, pystr.clone().into_wtf8(), vm))?;
+                        let py_str = vm.ctx.new_str(wtf8_result.to_string());
+                        Ok((
+                            py_str.into(),
+                            char_idx + 1 + chars_consumed,
+                            byte_idx + 1 + bytes_consumed,
+                        ))
                     }
-                    // Negative number - numbers are ASCII so len == bytes
-                    if let Some((result, len)) = self.parse_number(&s[byte_idx..], vm) {
-                        return Ok((result?, char_idx + len, byte_idx + len));
+                    b'{' => {
+                        // Object
+                        self.parse_object(pystr, char_idx + 1, byte_idx + 1, scan_once, memo, vm)
                     }
-                    Err(self.make_decode_error("Expecting value", pystr, char_idx, vm))
-                }
-                b'0'..=b'9' => {
-                    // Positive number - numbers are ASCII so len == bytes
-                    if let Some((result, len)) = self.parse_number(&s[byte_idx..], vm) {
-                        return Ok((result?, char_idx + len, byte_idx + len));
+                    b'[' => {
+                        // Array
+                        self.parse_array(pystr, char_idx + 1, byte_idx + 1, scan_once, memo, vm)
                     }
-                    Err(self.make_decode_error("Expecting value", pystr, char_idx, vm))
-                }
-                _ => {
-                    // Fall back to scan_once for unrecognized input
-                    // Note: This path requires char_idx for Python compatibility
-                    let result = scan_once.call((pystr.clone(), char_idx as isize), vm);
+                    b'n' if starts_with_bytes(&bytes[byte_idx..], b"null") => {
+                        // null
+                        Ok((vm.ctx.none(), char_idx + 4, byte_idx + 4))
+                    }
+                    b't' if starts_with_bytes(&bytes[byte_idx..], b"true") => {
+                        // true
+                        Ok((vm.ctx.new_bool(true).into(), char_idx + 4, byte_idx + 4))
+                    }
+                    b'f' if starts_with_bytes(&bytes[byte_idx..], b"false") => {
+                        // false
+                        Ok((vm.ctx.new_bool(false).into(), char_idx + 5, byte_idx + 5))
+                    }
+                    b'N' if starts_with_bytes(&bytes[byte_idx..], b"NaN") => {
+                        // NaN
+                        let result = self.parse_constant.call(("NaN",), vm)?;
+                        Ok((result, char_idx + 3, byte_idx + 3))
+                    }
+                    b'I' if starts_with_bytes(&bytes[byte_idx..], b"Infinity") => {
+                        // Infinity
+                        let result = self.parse_constant.call(("Infinity",), vm)?;
+                        Ok((result, char_idx + 8, byte_idx + 8))
+                    }
+                    b'-' => {
+                        // -Infinity or negative number
+                        if starts_with_bytes(&bytes[byte_idx..], b"-Infinity") {
+                            let result = self.parse_constant.call(("-Infinity",), vm)?;
+                            return Ok((result, char_idx + 9, byte_idx + 9));
+                        }
+                        // Negative number - numbers are ASCII so len == bytes
+                        if let Some((result, len)) = self.parse_number(&s[byte_idx..], vm) {
+                            return Ok((result?, char_idx + len, byte_idx + len));
+                        }
+                        Err(self.make_decode_error("Expecting value", pystr, char_idx, vm))
+                    }
+                    b'0'..=b'9' => {
+                        // Positive number - numbers are ASCII so len == bytes
+                        if let Some((result, len)) = self.parse_number(&s[byte_idx..], vm) {
+                            return Ok((result?, char_idx + len, byte_idx + len));
+                        }
+                        Err(self.make_decode_error("Expecting value", pystr, char_idx, vm))
+                    }
+                    _ => {
+                        // Fall back to scan_once for unrecognized input
+                        // Note: This path requires char_idx for Python compatibility
+                        let result = scan_once.call((pystr.clone(), char_idx as isize), vm);
 
-                    match result {
-                        Ok(tuple) => {
-                            use crate::vm::builtins::PyTupleRef;
-                            let tuple: PyTupleRef = tuple.try_into_value(vm)?;
-                            if tuple.len() != 2 {
-                                return Err(vm.new_value_error("scan_once must return 2-tuple"));
+                        match result {
+                            Ok(tuple) => {
+                                use crate::vm::builtins::PyTupleRef;
+                                let tuple: PyTupleRef = tuple.try_into_value(vm)?;
+                                if tuple.len() != 2 {
+                                    return Err(vm.new_value_error("scan_once must return 2-tuple"));
+                                }
+                                let value = tuple.as_slice()[0].clone();
+                                let end_char_idx: isize = tuple.as_slice()[1].try_to_value(vm)?;
+                                // For fallback, we need to calculate byte_idx from char_idx
+                                // This is expensive but fallback should be rare
+                                let end_byte_idx = s
+                                    .char_indices()
+                                    .nth(end_char_idx as usize)
+                                    .map(|(i, _)| i)
+                                    .unwrap_or(s.len());
+                                Ok((value, end_char_idx as usize, end_byte_idx))
                             }
-                            let value = tuple.as_slice()[0].clone();
-                            let end_char_idx: isize = tuple.as_slice()[1].try_to_value(vm)?;
-                            // For fallback, we need to calculate byte_idx from char_idx
-                            // This is expensive but fallback should be rare
-                            let end_byte_idx = s
-                                .char_indices()
-                                .nth(end_char_idx as usize)
-                                .map(|(i, _)| i)
-                                .unwrap_or(s.len());
-                            Ok((value, end_char_idx as usize, end_byte_idx))
+                            Err(err) if err.fast_isinstance(vm.ctx.exceptions.stop_iteration) => {
+                                Err(self.make_decode_error("Expecting value", pystr, char_idx, vm))
+                            }
+                            Err(err) => Err(err),
                         }
-                        Err(err) if err.fast_isinstance(vm.ctx.exceptions.stop_iteration) => {
-                            Err(self.make_decode_error("Expecting value", pystr, char_idx, vm))
-                        }
-                        Err(err) => Err(err),
                     }
                 }
-            }
+            })
         }
 
         /// Create a decode error.

--- a/extra_tests/snippets/stdlib_json.py
+++ b/extra_tests/snippets/stdlib_json.py
@@ -217,3 +217,25 @@ i = 7**500
 assert json.dumps(i) == str(i)
 
 assert json.decoder.scanstring('✨x"', 1) == ("x", 3)
+
+
+# Recursion guard: deeply-nested input must raise RecursionError instead of
+# overflowing the native stack (SIGSEGV). Matches CPython's
+# _Py_EnterRecursiveCall in Modules/_json.c.
+
+_deep = 100_000  # well above the ~45k native-stack crash threshold
+
+# Array nesting
+assert_raises(RecursionError, lambda: json.loads("[" * _deep + "]" * _deep))
+
+# Object nesting
+assert_raises(
+    RecursionError,
+    lambda: json.loads('{"a":' * _deep + "1" + "}" * _deep),
+)
+
+# Alternating array/object nesting
+assert_raises(
+    RecursionError,
+    lambda: json.loads(('[{"x":' * _deep) + "1" + ("}]" * _deep)),
+)


### PR DESCRIPTION
## Summary

`json.loads()` on a deeply-nested array or object overflows the native Rust stack and crashes the interpreter process with `SIGSEGV`. CPython raises `RecursionError` on the same input.

```python
import json
json.loads('[' * 50000 + ']' * 50000)
# RustPython (before): SIGSEGV (exit 139)
# CPython:             RecursionError: maximum recursion depth exceeded
# RustPython (after):  RecursionError: maximum recursion depth exceeded while
#                         decoding a JSON object from a string
```

## Root cause

The scanner has a mutual-recursion chain in `crates/stdlib/src/json.rs`:

```
JsonScanner::parse_object / parse_array
  -> JsonScanner::call_scan_once
    -> JsonScanner::parse_object / parse_array  (recurse)
```

`call_scan_once` is the single choke point every descent passes through, but
it wasn't wrapped in a recursion guard. Each nesting level consumes a pair
of Rust stack frames (`parse_X` + `call_scan_once`), so input depth ~45k
exhausts the 8 MB main thread stack on macOS and the OS kills the process
with `SIGSEGV`.

CPython's `Modules/_json.c` handles this with `_Py_EnterRecursiveCall(\" while decoding a JSON object from a string\")`, which translates native recursion into `RecursionError` at `sys.getrecursionlimit()`.

## Fix

Wrap the body of `call_scan_once` with `vm.with_recursion(\"while decoding a JSON object from a string\", || { ... })`. Same machinery RustPython already uses for comparison, `__repr__`, `__subclasscheck__`, and AST traversal (see `protocol/object.rs` and `stdlib/_ast/node.rs`).

The guard is placed at `call_scan_once` rather than on `parse_object` / `parse_array` individually because every recursive descent funnels through `call_scan_once` — one wrap covers array, object, and alternating nesting with a single point of maintenance.

## Verification

```console
$ cargo +1.94.0 build --release
   Finished \`release\` profile [optimized] target(s) in 41s

$ ./target/release/rustpython -c \"import json; json.loads('[' * 50000 + ']' * 50000)\"
Traceback (most recent call last):
  File \"<stdin>\", line 1, in <module>
RecursionError: maximum recursion depth exceeded while decoding a JSON object from a string

$ ./target/release/rustpython extra_tests/snippets/stdlib_json.py
(passes silently — includes 3 new regression cases)

$ ./target/release/rustpython -m test test_json
Ran 214 tests in 6.700s
OK (skipped=9, expected failures=13)
Result: SUCCESS
```

### Tested surfaces

| Input | Before | After |
|---|---|---|
| `'[' * 50000 + ']' * 50000` | SIGSEGV | RecursionError |
| `'[' * 500000 + ']' * 500000` | SIGSEGV | RecursionError |
| `'{\"a\":' * 100000 + '1' + '}' * 100000` | SIGSEGV | RecursionError |
| `('[{\"x\":' * 100000) + '1' + ('}]' * 100000)` | SIGSEGV | RecursionError |
| `'[1, 2, [3, [4, [5]]]]'` | OK | OK (no regression) |
| `'{\"a\": {\"b\": {\"c\": 1}}}'` | OK | OK (no regression) |

### CPython parity note

After the fix, RustPython raises `RecursionError` at JSON depth >= ~1000 (VM default `recursion_limit`). CPython raises it at depth >= ~10000 due to a different stack-headroom heuristic in `_Py_EnterRecursiveCall`. Both refuse to crash; exact threshold is tunable via `sys.setrecursionlimit()`. Real-world JSON is rarely deeper than 50 levels, so the difference is not user-visible in practice.

## Scope

- **In:** recursion guard on `call_scan_once` — covers all three nesting patterns above
- **Out:** encoder side (iterative, already safe), string/number parsing (non-recursive), `scan_once` Python-callback fallback path (already counted by VM frame machinery)

## Related

- Prior security fix using the same `vm.with_recursion` pattern: #7630 (cyclic AST in `compile()`)
- CPython reference: `Modules/_json.c` `scanner_call` / `_scan_once` uses `_Py_EnterRecursiveCall`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * JSON parser now raises `RecursionError` when decoding extremely deeply nested JSON structures (arrays, objects exceeding ~100,000 nesting levels) instead of causing potential stack overflow crashes.

* **Tests**
  * Added regression tests for JSON parsing with extremely deeply nested arrays, objects, and alternating nesting patterns.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->