### PR TITLE
Fix complex repr to use scientific notation for large integer-valued components

### DIFF
--- a/crates/literal/src/complex.rs
+++ b/crates/literal/src/complex.rs
@@ -2,14 +2,39 @@ use crate::float;
 use alloc::borrow::ToOwned;
 use alloc::string::{String, ToString};
 
+/// Format a single complex component (real or imag) for `repr`.
+/// Uses scientific notation when `|value| < 1e-4` or `|value| >= 1e16`
+/// (matching CPython's `PyOS_double_to_string(format='r')`), otherwise
+/// Rust's default `Display`, which drops the trailing `.0` for
+/// integer-valued floats.
+///
+/// This differs from `float::to_string` only in that integer values in
+/// the normal range render as `"1"` rather than `"1.0"` — complex repr
+/// formats `1+2j` as `"(1+2j)"`, not `"(1.0+2.0j)"`.
+fn component_to_string(value: f64) -> String {
+    let lit = alloc::format!("{value:e}");
+    if let Some(position) = lit.find('e') {
+        let significand = &lit[..position];
+        let exponent = lit[position + 1..].parse::<i32>().unwrap();
+        if exponent < 16 && exponent > -5 {
+            // Normal magnitude — Rust's default Display emits "1" for 1.0,
+            // "1.5" for 1.5, "1000000000000000" for 1e15, etc.
+            value.to_string()
+        } else {
+            alloc::format!("{significand}e{exponent:+#03}")
+        }
+    } else {
+        // nan / inf / -inf — `format!("{x:e}")` produces e.g. "NaN" with no
+        // exponent marker; lowercase to match Python.
+        let mut s = value.to_string();
+        s.make_ascii_lowercase();
+        s
+    }
+}
+
 /// Convert a complex number to a string.
 pub fn to_string(re: f64, im: f64) -> String {
-    // integer => drop ., fractional => float_ops
-    let mut im_part = if im.fract() == 0.0 {
-        im.to_string()
-    } else {
-        float::to_string(im)
-    };
+    let mut im_part = component_to_string(im);
     im_part.push('j');
 
     // positive empty => return im_part, integer => drop ., fractional => float_ops
@@ -19,10 +44,8 @@ pub fn to_string(re: f64, im: f64) -> String {
         } else {
             "-0".to_owned()
         }
-    } else if re.fract() == 0.0 {
-        re.to_string()
     } else {
-        float::to_string(re)
+        component_to_string(re)
     };
     let mut result =
         String::with_capacity(re_part.len() + im_part.len() + 2 + im.is_sign_positive() as usize);

--- a/extra_tests/snippets/builtin_complex.py
+++ b/extra_tests/snippets/builtin_complex.py
@@ -236,3 +236,33 @@ class complex_subclass(complex):
 z = complex_subclass(3 + 4j)
 assert z.__complex__() == 3 + 4j
 assert type(z.__complex__()) == complex
+
+
+# repr must use scientific notation for |value| >= 1e16 or < 1e-4, matching
+# CPython. Previously integer-valued large magnitudes (e.g. 1e16, 1e100) hit
+# a `fract() == 0.0` branch in rustpython_literal::complex::to_string that
+# used Rust's default Display — which emits the full decimal expansion
+# (`10000...000`) instead of `1e+16`.
+assert repr(1e16 + 1j) == "(1e+16+1j)"
+assert repr(1e17 + 1j) == "(1e+17+1j)"
+assert repr(1e100 + 1e100j) == "(1e+100+1e+100j)"
+assert repr(-1e100 - 1e100j) == "(-1e+100-1e+100j)"
+assert repr(1e-100 + 1e100j) == "(1e-100+1e+100j)"
+assert repr(1 + 1e100j) == "(1+1e+100j)"
+assert repr(1e100 + 1j) == "(1e+100+1j)"
+
+# Values at the threshold boundaries must stay in non-scientific form.
+assert repr(1e15 + 1j) == "(1000000000000000+1j)"
+assert repr(1e-4 + 1j) == "(0.0001+1j)"
+assert repr(1e-5 + 1j) == "(1e-05+1j)"
+
+# Integer-valued components render without trailing ".0".
+assert repr(1 + 2j) == "(1+2j)"
+assert repr(1.0 + 2.0j) == "(1+2j)"
+
+# Special values still round-trip correctly.
+assert repr(float("nan") + 1j) == "(nan+1j)"
+assert repr(float("inf") + 1j) == "(inf+1j)"
+assert repr(float("-inf") + 1j) == "(-inf+1j)"
+assert repr(complex(1, float("nan"))) == "(1+nanj)"
+assert repr(complex(1, float("inf"))) == "(1+infj)"

--- a/extra_tests/snippets/builtin_complex.py
+++ b/extra_tests/snippets/builtin_complex.py
@@ -251,10 +251,12 @@ assert repr(1e-100 + 1e100j) == "(1e-100+1e+100j)"
 assert repr(1 + 1e100j) == "(1+1e+100j)"
 assert repr(1e100 + 1j) == "(1e+100+1j)"
 
-# Values at the threshold boundaries must stay in non-scientific form.
-assert repr(1e15 + 1j) == "(1000000000000000+1j)"
-assert repr(1e-4 + 1j) == "(0.0001+1j)"
-assert repr(1e-5 + 1j) == "(1e-05+1j)"
+# Threshold boundary: |x| in [1e-4, 1e16) renders in decimal form; values
+# outside that range use scientific notation. These three assertions pin
+# the exact transition points.
+assert repr(1e15 + 1j) == "(1000000000000000+1j)"  # below 1e16 -> decimal
+assert repr(1e-4 + 1j) == "(0.0001+1j)"  # at 1e-4 (inclusive) -> decimal
+assert repr(1e-5 + 1j) == "(1e-05+1j)"  # below 1e-4 -> scientific
 
 # Integer-valued components render without trailing ".0".
 assert repr(1 + 2j) == "(1+2j)"


### PR DESCRIPTION
## Summary

`repr()` on a complex number whose real or imaginary part is an integer-valued float with `|x| >= 1e16` emitted the full decimal expansion instead of scientific notation. CPython uses scientific on the same input.

```python
# Before
>>> repr(1e100 + 1e100j)
'(1000000000000000015902891109759918046836080856394528138978132755774...<100 zeros>+1000000000000000015902891109759918046836080856394528138978132755774...<100 zeros>j)'

# CPython / After
>>> repr(1e100 + 1e100j)
'(1e+100+1e+100j)'
```

## Root cause

`crates/literal/src/complex.rs::to_string` bifurcated each component by `.fract() == 0.0`:

```rust
let mut im_part = if im.fract() == 0.0 {
    im.to_string()          // Rust's default Display — never scientific
} else {
    float::to_string(im)    // Python-style: scientific for |x| < 1e-4 or |x| >= 1e16
};
```

Integer-valued f64 values — including `1e16`, `1e17`, `1e100` which are all exactly representable as integers — took the `im.to_string()` branch and rendered as full decimal expansion. Non-integer magnitudes took `float::to_string` and rendered correctly. The bifurcation didn't capture CPython's actual rule ("scientific iff `|x| < 1e-4` or `|x| >= 1e16`"); it happened to be correct only when the two conditions coincidentally aligned.

## Fix

Replace the two-branch logic with one helper that implements CPython's actual `PyOS_double_to_string(format='r')` rule:

```rust
fn component_to_string(value: f64) -> String {
    let lit = alloc::format!(\"{value:e}\");
    if let Some(position) = lit.find('e') {
        let significand = &lit[..position];
        let exponent = lit[position + 1..].parse::<i32>().unwrap();
        if exponent < 16 && exponent > -5 {
            value.to_string()                       // normal range
        } else {
            alloc::format!(\"{significand}e{exponent:+#03}\")  // scientific
        }
    } else {
        // nan / inf / -inf
        let mut s = value.to_string();
        s.make_ascii_lowercase();
        s
    }
}
```

The threshold matches `float::to_string`; the only behavioral difference is that complex components render `1.0` as `\"1\"` rather than `\"1.0\"` — matching CPython's `(1+2j)` convention rather than `(1.0+2.0j)`.

## Verification

### Byte-identical CPython parity

| Probe | Cases | Result |
|---|---|---|
| Primary regression set (normal / boundary / mixed magnitudes / special) | 29 | ✅ 29/29 |
| Edge cases (subnormal 5e-324, f64::MAX, MIN_POSITIVE, DBL_EPSILON, threshold-straddling) | 18 | ✅ 18/18 |

### Test suites

```console
$ cargo run -- -m test test_complex
Ran 37 tests — all pass

$ cargo run -- -m test test_float test_long
Ran 101 tests (9 skipped) — all pass

$ cargo run -- -m unittest test.test_complex.ComplexTest.test_repr_str \\
      test.test_complex.ComplexTest.test_negative_zero_repr_str \\
      test.test_complex.ComplexTest.test_repr_roundtrip
Ran 3 tests in 0.004s — OK
```

### ast unparse

The other caller of `literal::complex::to_string` is `codegen::unparse.rs`, which generates Python source from an AST. Round-trip of source containing complex literals:

```console
$ rustpython -c 'import ast; print(ast.unparse(ast.parse(\"x = 1e100 + 1e-100j; y = 1e17 + 1j\")))'
x = 1e+100 + 1e-100j
y = 1e+17 + 1j
$ python3 -c 'import ast; print(ast.unparse(ast.parse(\"x = 1e100 + 1e-100j; y = 1e17 + 1j\")))'
x = 1e+100 + 1e-100j
y = 1e+17 + 1j
```

### Regression snippet

`extra_tests/snippets/builtin_complex.py` now pins expected output at the threshold boundaries, at extremes (`1e100`, `-1e100`), with mixed magnitudes, and at the integer-vs-float rendering boundary (`1+2j`, `1.0+2.0j` → both `(1+2j)`).

## Scope

- **In:** `crates/literal/src/complex.rs::to_string` (the single function that renders complex `repr`/`str`/AST constants). Both callers (`PyComplex::Representable` and `codegen::unparse`) receive the fix transitively.
- **Out:** `crates/common/src/format.rs::format_complex` — this handles format-spec types (`'{:.5e}'.format(c)`) and is an independent code path. Its current output already matches CPython byte-identically across boundary precisions (verified in a separate audit). Not touched here.

## Related

- The pre-existing TODO comment at the top of `PyComplex::repr_str` noted the intent to consolidate complex formatting; keeping the helper in `rustpython_literal::complex` matches where existing callers already look for it.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Refined complex-number string formatting to match CPython rules: use scientific notation at very large/small magnitudes, omit trailing .0 for integer-valued components, and normalize NaN/Infinity rendering and signs.

* **Tests**
  * Added tests covering boundary transitions and comprehensive edge cases for complex number repr formatting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->