### PR TITLE
Raise ValueError for None in Expr lists to match CPython validator

### DIFF
--- a/Lib/test/test_ast/test_ast.py
+++ b/Lib/test/test_ast/test_ast.py
@@ -2132,14 +2132,12 @@ class ASTValidatorTests(unittest.TestCase):
         self.stmt(cls(decorator_list=[ast.Name("x", ast.Store())]),
                   "must have Load context")
 
-    @unittest.expectedFailure  # TODO: RUSTPYTHON; ValueError not raised
     def test_delete(self):
         self.stmt(ast.Delete([]), "empty targets on Delete")
         self.stmt(ast.Delete([None]), "None disallowed")
         self.stmt(ast.Delete([ast.Name("x", ast.Load())]),
                   "must have Del context")
 
-    @unittest.expectedFailure  # TODO: RUSTPYTHON; ValueError not raised
     def test_assign(self):
         self.stmt(ast.Assign([], ast.Constant(3)), "empty targets on Assign")
         self.stmt(ast.Assign([None], ast.Constant(3)), "None disallowed")
@@ -2271,7 +2269,6 @@ class ASTValidatorTests(unittest.TestCase):
         e = ast.Expr(ast.Name("x", ast.Store()))
         self.stmt(e, "must have Load context")
 
-    @unittest.skip("TODO: RUSTPYTHON; called `Option::unwrap()` on a `None` value")
     def test_boolop(self):
         b = ast.BoolOp(ast.And(), [])
         self.expr(b, "less than 2 values")
@@ -2301,14 +2298,12 @@ class ASTValidatorTests(unittest.TestCase):
         for args in (s, l, l), (l, s, l), (l, l, s):
             self.expr(ast.IfExp(*args), "must have Load context")
 
-    @unittest.expectedFailure  # TODO: RUSTPYTHON; ValueError not raised
     def test_dict(self):
         d = ast.Dict([], [ast.Name("x", ast.Load())])
         self.expr(d, "same number of keys as values")
         d = ast.Dict([ast.Name("x", ast.Load())], [None])
         self.expr(d, "None disallowed")
 
-    @unittest.expectedFailure  # TODO: RUSTPYTHON; TypeError: expected some sort of expr, but got None
     def test_set(self):
         self.expr(ast.Set([None]), "None disallowed")
         s = ast.Set([ast.Name("x", ast.Store())])
@@ -2338,19 +2333,15 @@ class ASTValidatorTests(unittest.TestCase):
             return fac(ast.Name("x", ast.Store()), gens)
         self._check_comprehension(wrap)
 
-    @unittest.expectedFailure  # TODO: RUSTPYTHON; ValueError not raised
     def test_listcomp(self):
         self._simple_comp(ast.ListComp)
 
-    @unittest.expectedFailure  # TODO: RUSTPYTHON; ValueError not raised
     def test_setcomp(self):
         self._simple_comp(ast.SetComp)
 
-    @unittest.expectedFailure  # TODO: RUSTPYTHON; ValueError not raised
     def test_generatorexp(self):
         self._simple_comp(ast.GeneratorExp)
 
-    @unittest.expectedFailure  # TODO: RUSTPYTHON; ValueError not raised
     def test_dictcomp(self):
         g = ast.comprehension(ast.Name("y", ast.Store()),
                               ast.Name("p", ast.Load()), [], 0)
@@ -2382,7 +2373,6 @@ class ASTValidatorTests(unittest.TestCase):
         comp = ast.Compare(left, [ast.In()], [ast.Constant("blah")])
         self.expr(comp)
 
-    @unittest.expectedFailure  # TODO: RUSTPYTHON; ValueError not raised
     def test_call(self):
         func = ast.Name("x", ast.Load())
         args = [ast.Name("y", ast.Load())]
@@ -2428,11 +2418,9 @@ class ASTValidatorTests(unittest.TestCase):
         self.expr(fac([ast.Name("x", ast.Store())], ast.Load()),
                   "must have Load context")
 
-    @unittest.expectedFailure  # TODO: RUSTPYTHON; TypeError: expected some sort of expr, but got None
     def test_list(self):
         self._sequence(ast.List)
 
-    @unittest.expectedFailure  # TODO: RUSTPYTHON; TypeError: expected some sort of expr, but got None
     def test_tuple(self):
         self._sequence(ast.Tuple)
 

--- a/crates/vm/src/stdlib/_ast/expression.rs
+++ b/crates/vm/src/stdlib/_ast/expression.rs
@@ -133,6 +133,8 @@ impl Node for ast::Expr {
             let interpolation =
                 string::TStringInterpolation::ast_from_object(vm, source_file, object)?;
             return string::interpolation_to_expr(vm, interpolation);
+        } else if vm.is_none(&object) {
+            return Err(vm.new_value_error("None disallowed in expression list".to_owned()));
         } else {
             return Err(vm.new_type_error(format!(
                 "expected some sort of expr, but got {}",

--- a/crates/vm/src/stdlib/_ast/expression.rs
+++ b/crates/vm/src/stdlib/_ast/expression.rs
@@ -134,7 +134,7 @@ impl Node for ast::Expr {
                 string::TStringInterpolation::ast_from_object(vm, source_file, object)?;
             return string::interpolation_to_expr(vm, interpolation);
         } else if vm.is_none(&object) {
-            return Err(vm.new_value_error("None disallowed in expression list".to_owned()));
+            return Err(vm.new_value_error("None disallowed in expression list"));
         } else {
             return Err(vm.new_type_error(format!(
                 "expected some sort of expr, but got {}",


### PR DESCRIPTION
## Summary

CPython raises `ValueError(\"None disallowed in expression list\")` when `compile()` encounters `None` as an element in an `Expr` list position (`Set/List/Tuple.elts`, `BoolOp.values`, `Call.args`, comprehension generators, etc.). RustPython reached the catch-all `TypeError(\"expected some sort of expr, but got {}\")` branch instead, failing a dozen `test_ast` validator tests.

## Fix

One check in `Expr::ast_from_object` (`crates/vm/src/stdlib/_ast/expression.rs`) before the catch-all:

```rust
} else if vm.is_none(&object) {
    return Err(vm.new_value_error("None disallowed in expression list".to_owned()));
}
```

`Option<Expr>` positions (e.g. `Dict.keys` for `**unpack`) are unaffected — `node.rs` `Option<T>::ast_from_object` already short-circuits `None` there, so this change only fires when `None` reaches the non-optional `Vec<Expr>` iteration path.

## Verification

CPython 3.13.4 baseline message:

```
$ python3 -c "import ast; compile(ast.Expression(ast.Set([None])), '<t>', 'eval')"
ValueError: None disallowed in expression list
```

After the fix, `rustpython -c "import ast; compile(ast.Expression(ast.Set([None])), '<t>', 'eval')"` raises the same message.

Full `test.test_ast.test_ast` suite (227 tests):

```
Ran 227 tests in 18.144s
OK (skipped=10, expected failures=39)
```

0 failures, 0 unexpected successes.

## Unmasked tests (12)

In `Lib/test/test_ast/test_ast.py`:

- `test_boolop` — was `@unittest.skip` with stale ``Option::unwrap()`` message
- `test_set`, `test_list`, `test_tuple` — were `@unittest.expectedFailure` / TypeError
- `test_call`, `test_delete`, `test_assign`, `test_dict`, `test_dictcomp`, `test_generatorexp`, `test_listcomp`, `test_setcomp` — were `@unittest.expectedFailure` / \"ValueError not raised\"

Addresses part of the skip-test inventory in #7611.

## Scope notes

The Stmt-level analog — `body=[None]` raising `\"None disallowed in statement list\"`, used by `test_classdef` — needs a sibling change in `statement.rs`. Out of scope here; can be a follow-up PR with the identical pattern.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling when a missing/empty (None) value is encountered in an expression list. Users will now see a clearer, specific error indicating None is disallowed in expression lists instead of a generic type mismatch, making invalid-expression diagnostics more actionable.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->