### PR TITLE
Support custom `rustls` providers

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -19,7 +19,7 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  CARGO_ARGS: --no-default-features --features stdlib,importlib,stdio,encodings,sqlite,ssl-rustls,host_env
+  CARGO_ARGS: --no-default-features --features stdlib,importlib,stdio,encodings,sqlite,ssl-rustls-aws-lc,host_env
   CARGO_ARGS_NO_SSL: --no-default-features --features stdlib,importlib,stdio,encodings,sqlite,host_env
   # Crates excluded from workspace builds:
   # - rustpython_wasm: requires wasm target

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -186,6 +186,7 @@ jobs:
           skip_ssl: true
         - os: ubuntu-latest
           target: wasm32-wasip2
+          skip_ssl: true
         - os: ubuntu-latest
           target: x86_64-unknown-freebsd
           skip_ssl: true
@@ -760,7 +761,7 @@ jobs:
           clang: true
 
       - name: build rustpython
-        run: cargo build --release --target wasm32-wasip1 --features freeze-stdlib,stdlib --verbose
+        run: cargo build --release --target wasm32-wasip1 --no-default-features --features freeze-stdlib,stdlib,stdio,importlib,host_env --verbose
       - name: run snippets
         run: wasmer run --dir "$(pwd)" target/wasm32-wasip1/release/rustpython.wasm -- "$(pwd)/extra_tests/snippets/stdlib_random.py"
       - name: run cpython unittest

--- a/.github/workflows/cron-ci.yaml
+++ b/.github/workflows/cron-ci.yaml
@@ -14,7 +14,7 @@ on:
       - .github/workflows/cron-ci.yaml
 
 env:
-  CARGO_ARGS: --no-default-features --features stdlib,importlib,stdio,encodings,ssl-rustls,jit,host_env
+  CARGO_ARGS: --no-default-features --features stdlib,importlib,stdio,encodings,ssl-rustls-aws-lc,jit,host_env
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: 'true' # TODO: Remove on 2026/06/02
 
 jobs:
@@ -41,7 +41,7 @@ jobs:
       - run: sudo apt-get update && sudo apt-get -y install lcov
 
       - name: Run cargo-llvm-cov with Rust tests.
-        run: cargo llvm-cov --no-report --workspace --exclude rustpython_wasm --exclude rustpython-compiler-source --exclude rustpython-venvlauncher --verbose --no-default-features --features stdlib,importlib,stdio,encodings,ssl-rustls,jit,host_env
+        run: cargo llvm-cov --no-report --workspace --exclude rustpython_wasm --exclude rustpython-compiler-source --exclude rustpython-venvlauncher --verbose --no-default-features --features stdlib,importlib,stdio,encodings,ssl-rustls-aws-lc,jit,host_env
 
       - name: Run cargo-llvm-cov with Python snippets.
         run: python scripts/cargo-llvm-cov.py

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -68,7 +68,7 @@ jobs:
           libtool: true
 
       - name: Build RustPython
-        run: cargo build --release --target=${{ matrix.target }} --verbose --no-default-features --features stdlib,stdio,importlib,encodings,sqlite,host_env,ssl-rustls,threading,jit
+        run: cargo build --release --target=${{ matrix.target }} --verbose --no-default-features --features stdlib,stdio,importlib,encodings,sqlite,host_env,ssl-rustls-aws-lc,threading,jit
 
       - name: Rename Binary
         run: cp target/${{ matrix.target }}/release/rustpython target/rustpython-release-${{ runner.os }}-${{ matrix.target }}

--- a/.github/workflows/update-caches.yml
+++ b/.github/workflows/update-caches.yml
@@ -19,7 +19,7 @@ env:
   CARGO_PROFILE_TEST_DEBUG: 0
   CARGO_PROFILE_DEV_DEBUG: 0
   CARGO_PROFILE_RELEASE_DEBUG: 0
-  CARGO_ARGS: --workspace --no-default-features --features stdlib,importlib,stdio,encodings,sqlite,ssl-rustls,host_env,threading,jit --exclude rustpython_wasm --exclude rustpython-compiler-source --exclude rustpython-venvlauncher
+  CARGO_ARGS: --workspace --no-default-features --features stdlib,importlib,stdio,encodings,sqlite,ssl-rustls-aws-lc,host_env,threading,jit --exclude rustpython_wasm --exclude rustpython-compiler-source --exclude rustpython-venvlauncher
 
 jobs:
   build-caches:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -256,7 +256,6 @@ checksum = "0ec6fb3fe69024a75fa7e1bfb48aa6cf59706a101658ea01bfd33b2b248a038f"
 dependencies = [
  "aws-lc-fips-sys",
  "aws-lc-sys",
- "untrusted 0.7.1",
  "zeroize",
 ]
 
@@ -3327,7 +3326,7 @@ dependencies = [
  "cfg-if",
  "getrandom 0.2.17",
  "libc",
- "untrusted 0.9.0",
+ "untrusted",
  "windows-sys 0.52.0",
 ]
 
@@ -3459,7 +3458,7 @@ dependencies = [
  "aws-lc-rs",
  "ring",
  "rustls-pki-types",
- "untrusted 0.9.0",
+ "untrusted",
 ]
 
 [[package]]
@@ -3759,7 +3758,6 @@ version = "0.5.0"
 dependencies = [
  "adler32",
  "ascii",
- "aws-lc-rs",
  "base64",
  "blake2",
  "bzip2",
@@ -4705,12 +4703,6 @@ dependencies = [
  "phf_codegen",
  "rand 0.8.5",
 ]
-
-[[package]]
-name = "untrusted"
-version = "0.7.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a156c684c91ea7d62626509bce3cb4e1d9ed5c4d978f7b4352658f96a4c26b4a"
 
 [[package]]
 name = "untrusted"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -81,9 +81,9 @@ dependencies = [
 
 [[package]]
 name = "anstyle"
-version = "1.0.13"
+version = "1.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5192cca8006f1fd4f7237516f40fa183bb07f8fbdfedaa0036de5ea9b0b45e78"
+checksum = "940b3a0ca603d1eade50a4846a2afffd5ef57a9feac2c0e2ec2e14f9ead76000"
 
 [[package]]
 name = "anstyle-parse"
@@ -116,9 +116,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.100"
+version = "1.0.102"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a23eb6b1614318a8071c9b2521f36b424b2c83db5eb3a0fead4a6c0809af6e61"
+checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
 name = "approx"
@@ -236,9 +236,9 @@ checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
 name = "aws-lc-fips-sys"
-version = "0.13.13"
+version = "0.13.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8bce4948d2520386c6d92a6ea2d472300257702242e5a1d01d6add52bd2e7c1"
+checksum = "d3d619165468401dec3caa3366ebffbcb83f2f31883e5b3932f8e2dec2ddc568"
 dependencies = [
  "bindgen 0.72.1",
  "cc",
@@ -289,7 +289,7 @@ version = "0.71.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5f58bf3d7db68cfbac37cfc485a8d711e87e064c3d0fe0435b92f7a407f9d6b3"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.11.1",
  "cexpr",
  "clang-sys",
  "itertools 0.13.0",
@@ -309,7 +309,7 @@ version = "0.72.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "993776b509cfb49c750f11b8f07a46fa23e0a1386ffc01fb1e7d343efc387895"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.11.1",
  "cexpr",
  "clang-sys",
  "itertools 0.13.0",
@@ -331,9 +331,9 @@ checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bitflags"
-version = "2.11.0"
+version = "2.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "843867be96c8daad0d758b57df9392b6d8d271134fce549de6ce169ff98a92af"
+checksum = "c4512299f36f043ab09a583e57bceb5a5aab7a73db1805848e8fef3c9e8c78b3"
 
 [[package]]
 name = "bitflagset"
@@ -405,9 +405,9 @@ dependencies = [
 
 [[package]]
 name = "bytemuck"
-version = "1.24.0"
+version = "1.25.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1fbdf580320f38b612e485521afda1ee26d10cc9884efaaa750d383e13e3c5f4"
+checksum = "c8efb64bd706a16a1bdde310ae86b351e4d21550d98d056f22f8a7f7a2183fec"
 
 [[package]]
 name = "bytes"
@@ -450,9 +450,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.2.54"
+version = "1.2.61"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6354c81bbfd62d9cfa9cb3c773c2b7b2a3a482d569de977fd0e961f6e7c00583"
+checksum = "d16d90359e986641506914ba71350897565610e87ce0ad9e6f28569db3dd5c6d"
 dependencies = [
  "find-msvc-tools",
  "jobserver",
@@ -545,18 +545,18 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.5.54"
+version = "4.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c6e6ff9dcd79cff5cd969a17a545d79e84ab086e444102a591e288a8aa3ce394"
+checksum = "1ddb117e43bbf7dacf0a4190fef4d345b9bad68dfc649cb349e7d17d28428e51"
 dependencies = [
  "clap_builder",
 ]
 
 [[package]]
 name = "clap_builder"
-version = "4.5.54"
+version = "4.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa42cf4d2b7a41bc8f663a7cab4031ebafa1bf3875705bfaf8466dc60ab52c00"
+checksum = "714a53001bf66416adb0e2ef5ac857140e7dc3a0c48fb28b2f10762fc4b5069f"
 dependencies = [
  "anstyle",
  "clap_lex",
@@ -564,9 +564,9 @@ dependencies = [
 
 [[package]]
 name = "clap_lex"
-version = "0.7.7"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c3e64b0cc0439b12df2fa678eae89a1c56a529fd067a9115f7827f1fffd22b32"
+checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "clipboard-win"
@@ -579,9 +579,9 @@ dependencies = [
 
 [[package]]
 name = "cmake"
-version = "0.1.57"
+version = "0.1.58"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75443c44cd6b379beb8c5b45d85d0773baf31cce901fe7bb252f4eff3008ef7d"
+checksum = "c0f78a02292a74a88ac736019ab962ece0bc380e3f977bf72e376c5d78ff0678"
 dependencies = [
  "cc",
 ]
@@ -600,9 +600,9 @@ checksum = "2550f75b8cfac212855f6b1885455df8eaee8fe8e246b647d69146142e016084"
 
 [[package]]
 name = "colorchoice"
-version = "1.0.4"
+version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b05b61dc5112cbb17e4b6cd61790d9845d13888356391624cbe7e41efeac1e75"
+checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
 
 [[package]]
 name = "combine"
@@ -1020,9 +1020,9 @@ dependencies = [
 
 [[package]]
 name = "data-encoding"
-version = "2.10.0"
+version = "2.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7a1e2f27636f116493b8b860f5546edb47c8d8f8ea73e1d2a20be88e28d1fea"
+checksum = "a4ae5f15dda3c708c0ade84bfee31ccab44a3da4f88015ed22f63732abe300c8"
 
 [[package]]
 name = "der"
@@ -1075,18 +1075,18 @@ dependencies = [
 
 [[package]]
 name = "deranged"
-version = "0.5.5"
+version = "0.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ececcb659e7ba858fb4f10388c250a7252eb0a27373f1a72b8748afdd248e587"
+checksum = "7cd812cc2bc1d69d4764bd80df88b4317eaef9e773c75226407d9bc0876b211c"
 dependencies = [
  "powerfmt",
 ]
 
 [[package]]
 name = "derive-where"
-version = "1.6.0"
+version = "1.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ef941ded77d15ca19b40374869ac6000af1c9f2a4c0f3d4c70926287e6364a8f"
+checksum = "d08b3a0bcc0d079199cd476b2cae8435016ec11d1c0986c6901c5ac223041534"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1191,9 +1191,9 @@ checksum = "869b0adbda23651a9c5c0c3d270aac9fcb52e8622a8f2b17e57802d7791962f2"
 
 [[package]]
 name = "env_filter"
-version = "1.0.0"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a1c3cc8e57274ec99de65301228b537f1e4eedc1b8e0f9411c6caac8ae7308f"
+checksum = "32e90c2accc4b07a8456ea0debdc2e7587bdd890680d71173a15d4ae604f6eef"
 dependencies = [
  "log",
  "regex",
@@ -1242,15 +1242,15 @@ checksum = "de853764b47027c2e862a995c34978ffa63c1501f2e15f987ba11bd4f9bba193"
 
 [[package]]
 name = "fastrand"
-version = "2.3.0"
+version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
+checksum = "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
 
 [[package]]
 name = "find-msvc-tools"
-version = "0.1.8"
+version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8591b0bcc8a98a64310a2fae1bb3e9b8564dd10e381e6e28010fde8e8e8568db"
+checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
 
 [[package]]
 name = "flagset"
@@ -1328,7 +1328,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f6f339eb8adc052cd2ca78910fda869aefa38d22d5cb648e6485e4d3fc06f3b1"
 dependencies = [
- "foreign-types-shared 0.1.1",
+ "foreign-types-shared",
 ]
 
 [[package]]
@@ -1338,12 +1338,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
 
 [[package]]
-name = "foreign-types-shared"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aa9a19cbb55df58761df49b23516a86d432839add4af60fc256da840f66ed35b"
-
-[[package]]
 name = "fs_extra"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1351,26 +1345,25 @@ checksum = "42703706b716c37f96a77aea830392ad231f44c9e9a67872fa5548707e11b11c"
 
 [[package]]
 name = "futures-core"
-version = "0.3.31"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "05f29059c0c2090612e8d742178b0580d2dc940c837851ad723096f87af6663e"
+checksum = "7e3450815272ef58cec6d564423f6e755e25379b217b0bc688e295ba24df6b1d"
 
 [[package]]
 name = "futures-task"
-version = "0.3.31"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f90f7dce0722e95104fcb095585910c0977252f286e354b5e3bd38902cd99988"
+checksum = "037711b3d59c33004d3856fbdc83b99d4ff37a24768fa1be9ce3538a1cde4393"
 
 [[package]]
 name = "futures-util"
-version = "0.3.31"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9fa08315bb612088cc391249efdc3bc77536f16c91f6cf495e6fbe85b20a4a81"
+checksum = "389ca41296e6190b48053de0321d02a77f32f8a5d2461dd38762c0593805c6d6"
 dependencies = [
  "futures-core",
  "futures-task",
  "pin-project-lite",
- "pin-utils",
  "slab",
 ]
 
@@ -1627,9 +1620,9 @@ dependencies = [
 
 [[package]]
 name = "iana-time-zone"
-version = "0.1.64"
+version = "0.1.65"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "33e57f83510bb73707521ebaffa789ec8caf86f9657cad665b092b581d40e9fb"
+checksum = "e31bc9ad994ba00e440a8aa5c9ef0ec67d5cb5e5cb0cc7f8b744a35b389cc470"
 dependencies = [
  "android_system_properties",
  "core-foundation-sys",
@@ -1865,15 +1858,15 @@ dependencies = [
 
 [[package]]
 name = "itoa"
-version = "1.0.17"
+version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "92ecc6618181def0457392ccd0ee51198e065e016d1d527a7ac1b6dc7c1f09d2"
+checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
 name = "jiff"
-version = "0.2.23"
+version = "0.2.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a3546dc96b6d42c5f24902af9e2538e82e39ad350b0c766eb3fbf2d8f3d8359"
+checksum = "f00b5dbd620d61dfdcb6007c9c1f6054ebd75319f163d886a9055cec1155073d"
 dependencies = [
  "jiff-static",
  "log",
@@ -1884,9 +1877,9 @@ dependencies = [
 
 [[package]]
 name = "jiff-static"
-version = "0.2.23"
+version = "0.2.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a8c8b344124222efd714b73bb41f8b5120b27a7cc1c75593a6ff768d9d05aa4"
+checksum = "e000de030ff8022ea1da3f466fbb0f3a809f5e51ed31f6dd931c35181ad8e6d7"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1954,10 +1947,12 @@ dependencies = [
 
 [[package]]
 name = "js-sys"
-version = "0.3.85"
+version = "0.3.97"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8c942ebf8e95485ca0d52d97da7c5a2c387d0e7f0ba4c35e93bfcaee045955b3"
+checksum = "a1840c94c045fbcf8ba2812c95db44499f7c64910a912551aaaa541decebcacf"
 dependencies = [
+ "cfg-if",
+ "futures-util",
  "once_cell",
  "wasm-bindgen",
 ]
@@ -2032,9 +2027,9 @@ checksum = "803ec87c9cfb29b9d2633f20cba1f488db3fd53f2158b1024cbefb47ba05d413"
 
 [[package]]
 name = "libbz2-rs-sys"
-version = "0.2.2"
+version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2c4a545a15244c7d945065b5d392b2d2d7f21526fba56ce51467b06ed445e8f7"
+checksum = "b3a6a8c165077efc8f3a971534c50ea6a1a18b329ef4a66e897a7e3a1494565f"
 
 [[package]]
 name = "libc"
@@ -2173,11 +2168,10 @@ checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
 
 [[package]]
 name = "libredox"
-version = "0.1.12"
+version = "0.1.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d0b95e02c851351f877147b7deea7b1afb1df71b63aa5f8270716e0c5720616"
+checksum = "e02f3bb43d335493c96bf3fd3a321600bf6bd07ed34bc64118e9293bdffea46c"
 dependencies = [
- "bitflags 2.11.0",
  "libc",
 ]
 
@@ -2209,9 +2203,9 @@ checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
 
 [[package]]
 name = "litemap"
-version = "0.8.1"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6373607a59f0be73a39b6fe456b8192fcc3585f602af20751600e974dd455e77"
+checksum = "92daf443525c4cce67b150400bc2316076100ce0b3686209eb8cf3c31612e6f0"
 
 [[package]]
 name = "lock_api"
@@ -2401,7 +2395,7 @@ version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "71e2746dc3a24dd78b3cfcb7be93368c6de9963d30f43a6a73998a9cf4b17b46"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.11.1",
  "cfg-if",
  "cfg_aliases",
  "libc",
@@ -2410,11 +2404,11 @@ dependencies = [
 
 [[package]]
 name = "nix"
-version = "0.31.2"
+version = "0.31.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d6d0705320c1e6ba1d912b5e37cf18071b6c2e9b7fa8215a1e8a7651966f5d3"
+checksum = "cf20d2fde8ff38632c426f1165ed7436270b44f199fc55284c38276f9db47c3d"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.11.1",
  "cfg-if",
  "cfg_aliases",
  "libc",
@@ -2452,9 +2446,9 @@ dependencies = [
 
 [[package]]
 name = "num-conv"
-version = "0.2.0"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf97ec579c3c42f953ef76dbf8d55ac91fb219dde70e49aa4a6b7d74e9919050"
+checksum = "c6673768db2d862beb9b39a78fdcb1a69439615d5794a1be50caa9bc92c81967"
 
 [[package]]
 name = "num-integer"
@@ -2525,9 +2519,9 @@ dependencies = [
 
 [[package]]
 name = "once_cell"
-version = "1.21.3"
+version = "1.21.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
+checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
 
 [[package]]
 name = "once_cell_polyfill"
@@ -2547,7 +2541,7 @@ version = "0.10.80"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a45fa2aa886c42762255da344f0a0d313e254066c46aad76f300c3d3da62d967"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.11.1",
  "cfg-if",
  "foreign-types",
  "libc",
@@ -2574,9 +2568,9 @@ checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
 
 [[package]]
 name = "openssl-src"
-version = "300.5.4+3.5.4"
+version = "300.6.0+3.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a507b3792995dae9b0df8a1c1e3771e8418b7c2d9f0baeba32e6fe8b06c7cb72"
+checksum = "a8e8cbfd3a4a8c8f089147fd7aaa33cf8c7450c4d09f8f80698a0cf093abeff4"
 dependencies = [
  "cc",
 ]
@@ -2608,9 +2602,9 @@ checksum = "978aa494585d3ca4ad74929863093e87cac9790d81fe7aba2b3dc2890643a0fc"
 
 [[package]]
 name = "ordermap"
-version = "1.1.0"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cfa78c92071bbd3628c22b1a964f7e0eb201dc1456555db072beb1662ecd6715"
+checksum = "7f7476a5b122ff1fce7208e7ee9dccd0a516e835f5b8b19b8f3c98a34cf757c1"
 dependencies = [
  "indexmap",
 ]
@@ -2655,9 +2649,9 @@ checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
 
 [[package]]
 name = "pastey"
-version = "0.2.2"
+version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c5a797f0e07bdf071d15742978fc3128ec6c22891c31a3a931513263904c982a"
+checksum = "2ee67f1008b1ba2321834326597b8e186293b049a023cdef258527550b9935b4"
 
 [[package]]
 name = "pbkdf2"
@@ -2734,7 +2728,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3c80231409c20246a13fddb31776fb942c38553c51e871f8cbd687a4cfb5843d"
 dependencies = [
  "phf_shared 0.11.3",
- "rand 0.8.5",
+ "rand 0.8.6",
 ]
 
 [[package]]
@@ -2780,15 +2774,9 @@ dependencies = [
 
 [[package]]
 name = "pin-project-lite"
-version = "0.2.16"
+version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b3cff922bd51709b605d9ead9aa71031d81447142d828eb4a6eba76fe619f9b"
-
-[[package]]
-name = "pin-utils"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
+checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
 
 [[package]]
 name = "pkcs5"
@@ -2820,9 +2808,9 @@ dependencies = [
 
 [[package]]
 name = "pkg-config"
-version = "0.3.32"
+version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
+checksum = "19f132c84eca552bf34cab8ec81f1c1dcc229b811638f9d283dceabe58c5569e"
 
 [[package]]
 name = "plotters"
@@ -2865,24 +2853,24 @@ dependencies = [
 
 [[package]]
 name = "portable-atomic"
-version = "1.13.0"
+version = "1.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f89776e4d69bb58bc6993e99ffa1d11f228b839984854c7daeb5d37f87cbe950"
+checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
 
 [[package]]
 name = "portable-atomic-util"
-version = "0.2.4"
+version = "0.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d8a2f0d8d040d7848a709caf78912debcc3f33ee4b3cac47d73d1e1069e83507"
+checksum = "c2a106d1259c23fac8e543272398ae0e3c0b8d33c88ed73d0cc71b0f1d902618"
 dependencies = [
  "portable-atomic",
 ]
 
 [[package]]
 name = "potential_utf"
-version = "0.1.4"
+version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b73949432f5e2a09657003c25bca5e19a0e9c84f8058ca374f49e0ebe605af77"
+checksum = "0103b1cef7ec0cf76490e969665504990193874ea05c85ff9bab8b911d0a0564"
 dependencies = [
  "serde_core",
  "writeable",
@@ -3102,9 +3090,9 @@ dependencies = [
 
 [[package]]
 name = "rand"
-version = "0.8.5"
+version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
+checksum = "5ca0ecfa931c29007047d1bc58e623ab12e5590e8c7cc53200d5202b69266d8a"
 dependencies = [
  "libc",
  "rand_chacha 0.3.1",
@@ -3176,9 +3164,9 @@ dependencies = [
 
 [[package]]
 name = "rayon"
-version = "1.11.0"
+version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "368f01d005bf8fd9b1206fb6fa653e6c4a81ceb1466406b81792d87c5677a58f"
+checksum = "fb39b166781f92d482534ef4b4b1b2568f42613b53e5b6c160e24cfbfa30926d"
 dependencies = [
  "either",
  "rayon-core",
@@ -3206,7 +3194,7 @@ version = "0.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.11.1",
 ]
 
 [[package]]
@@ -3242,13 +3230,13 @@ dependencies = [
 
 [[package]]
 name = "regalloc2"
-version = "0.15.0"
+version = "0.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "952ddbfc6f9f64d006c3efd8c9851a6ba2f2b944ba94730db255d55006e0ffda"
+checksum = "de2c52737737f8609e94f975dee22854a2d5c125772d4b1cf292120f4d45c186"
 dependencies = [
  "allocator-api2",
  "bumpalo",
- "hashbrown 0.15.5",
+ "hashbrown 0.17.0",
  "log",
  "rustc-hash",
  "smallvec",
@@ -3256,9 +3244,9 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.12.2"
+version = "1.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "843bc0191f75f3e22651ae5f1e72939ab2f72a4bc30fa80a066bd66edefc24d4"
+checksum = "e10754a14b9137dd7b1e3e5b0493cc9171fdd105e0ab477f51b72e7f3ac0e276"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -3268,9 +3256,9 @@ dependencies = [
 
 [[package]]
 name = "regex-automata"
-version = "0.4.13"
+version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5276caf25ac86c8d810222b3dbb938e512c55c6831a10f3e6ed1c93b84041f1c"
+checksum = "6e1dd4122fc1595e8162618945476892eefca7b88c52820e74af6262213cae8f"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -3279,9 +3267,9 @@ dependencies = [
 
 [[package]]
 name = "regex-syntax"
-version = "0.8.8"
+version = "0.8.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a2d987857b319362043e95f5353c0535c1f58eec5336fdfcf626430af7def58"
+checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
 
 [[package]]
 name = "region"
@@ -3332,9 +3320,9 @@ dependencies = [
 
 [[package]]
 name = "rustc-hash"
-version = "2.1.1"
+version = "2.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "357703d41365b4b27c590e3ed91eabb1b663f07c4c084095e60cbed4362dff0d"
+checksum = "94300abf3f1ae2e2b8ffb7b58043de3d399c73fa6f4b73826402a5c457614dbe"
 
 [[package]]
 name = "rustc_version"
@@ -3360,7 +3348,7 @@ version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.11.1",
  "errno",
  "libc",
  "linux-raw-sys",
@@ -3369,9 +3357,9 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.23.39"
+version = "0.23.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7c2c118cb077cca2822033836dfb1b975355dfb784b5e8da48f7b6c5db74e60e"
+checksum = "ef86cd5876211988985292b91c96a8f2d298df24e75989a43a3c73f2d4d8168b"
 dependencies = [
  "aws-lc-rs",
  "once_cell",
@@ -3415,9 +3403,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-pki-types"
-version = "1.14.0"
+version = "1.14.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be040f8b0a225e40375822a563fa9524378b9d63112f53e19ffff34df5d33fdd"
+checksum = "30a7197ae7eb376e574fe940d068c30fe0462554a3ddbe4eca7838e049c937a9"
 dependencies = [
  "zeroize",
 ]
@@ -3500,7 +3488,7 @@ dependencies = [
 name = "rustpython-codegen"
 version = "0.5.0"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.11.1",
  "indexmap",
  "itertools 0.14.0",
  "log",
@@ -3524,7 +3512,7 @@ name = "rustpython-common"
 version = "0.5.0"
 dependencies = [
  "ascii",
- "bitflags 2.11.0",
+ "bitflags 2.11.1",
  "getrandom 0.3.4",
  "itertools 0.14.0",
  "libc",
@@ -3559,7 +3547,7 @@ dependencies = [
 name = "rustpython-compiler-core"
 version = "0.5.0"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.11.1",
  "bitflagset",
  "itertools 0.14.0",
  "lz4_flex",
@@ -3611,14 +3599,14 @@ dependencies = [
 name = "rustpython-host_env"
 version = "0.5.0"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.11.1",
  "getrandom 0.3.4",
  "junction",
  "libc",
  "libffi",
  "libloading 0.9.0",
  "memmap2",
- "nix 0.31.2",
+ "nix 0.31.3",
  "num-traits",
  "num_cpus",
  "parking_lot",
@@ -3676,7 +3664,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f021ff72cabf5e2cd6d8ec8813d376a8445a228dc610ab56c27bd9054cda70d4"
 dependencies = [
  "aho-corasick",
- "bitflags 2.11.0",
+ "bitflags 2.11.1",
  "compact_str",
  "get-size2",
  "is-macro",
@@ -3694,7 +3682,7 @@ version = "0.15.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "01e6ee78bd9671fb5766664b2695fe1f2a92a961f4d9101646c570d8acdb1e0b"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.11.1",
  "bstr",
  "compact_str",
  "get-size2",
@@ -3744,7 +3732,7 @@ dependencies = [
 name = "rustpython-sre_engine"
 version = "0.5.0"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.11.1",
  "criterion",
  "icu_properties",
  "num_enum",
@@ -3772,7 +3760,7 @@ dependencies = [
  "dyn-clone",
  "flame",
  "flate2",
- "foreign-types-shared 0.3.1",
+ "foreign-types-shared",
  "gethostname",
  "hex",
  "hmac 0.12.1",
@@ -3847,7 +3835,7 @@ name = "rustpython-vm"
 version = "0.5.0"
 dependencies = [
  "ascii",
- "bitflags 2.11.0",
+ "bitflags 2.11.1",
  "bstr",
  "chrono",
  "constant_time_eq",
@@ -3943,14 +3931,14 @@ version = "18.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4a990b25f351b25139ddc7f21ee3f6f56f86d6846b74ac8fad3a719a287cd4a0"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.11.1",
  "cfg-if",
  "clipboard-win",
  "home",
  "libc",
  "log",
  "memchr",
- "nix 0.31.2",
+ "nix 0.31.3",
  "radix_trie",
  "unicode-segmentation",
  "unicode-width",
@@ -3960,9 +3948,9 @@ dependencies = [
 
 [[package]]
 name = "ryu"
-version = "1.0.22"
+version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a50f4cf475b65d88e057964e0e9bb1f0aa9bbb2036dc65c64596b42932536984"
+checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
 
 [[package]]
 name = "safe_arch"
@@ -4021,11 +4009,11 @@ dependencies = [
 
 [[package]]
 name = "security-framework"
-version = "3.5.1"
+version = "3.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b3297343eaf830f66ede390ea39da1d462b6b0c1b000f420d0a83f898bbbe6ef"
+checksum = "b7f4bc775c73d9a02cde8bf7b2ec4c9d12743edf609006c7facc23998404cd1d"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.11.1",
  "core-foundation 0.10.1",
  "core-foundation-sys",
  "libc",
@@ -4034,9 +4022,9 @@ dependencies = [
 
 [[package]]
 name = "security-framework-sys"
-version = "2.15.0"
+version = "2.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc1f0cbffaac4852523ce30d8bd3c5cdc873501d96ff467ca09b6767bb8cd5c0"
+checksum = "6ce2691df843ecc5d231c0b14ece2acc3efb62c0a398c7e1d875f3983ce020e3"
 dependencies = [
  "core-foundation-sys",
  "libc",
@@ -4104,9 +4092,9 @@ dependencies = [
 
 [[package]]
 name = "serde_spanned"
-version = "1.1.0"
+version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "876ac351060d4f882bb1032b6369eb0aef79ad9df1ea8bc404874d8cc3d0cd98"
+checksum = "6662b5879511e06e8999a8a235d848113e942c9124f211511b16466ee2995f26"
 dependencies = [
  "serde_core",
 ]
@@ -4157,9 +4145,9 @@ dependencies = [
 
 [[package]]
 name = "sha3"
-version = "0.10.8"
+version = "0.10.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75872d278a8f37ef87fa0ddbda7802605cb18344497949862c0d4dcb291eba60"
+checksum = "77fd7028345d415a4034cf8777cd4f8ab1851274233b45f84e3d955502d93874"
 dependencies = [
  "digest 0.10.7",
  "keccak",
@@ -4190,9 +4178,9 @@ dependencies = [
 
 [[package]]
 name = "simd-adler32"
-version = "0.3.8"
+version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e320a6c5ad31d271ad523dcf3ad13e2767ad8b1cb8f047f75a8aeaf8da139da2"
+checksum = "703d5c7ef118737c72f1af64ad2f6f8c5e1921f818cdcb97b8fe6fc69bf66214"
 
 [[package]]
 name = "simd_cesu8"
@@ -4218,15 +4206,15 @@ checksum = "bbbb5d9659141646ae647b42fe094daf6c6192d1620870b449d9557f748b2daa"
 
 [[package]]
 name = "siphasher"
-version = "1.0.2"
+version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b2aa850e253778c88a04c3d7323b043aeda9d3e30d5971937c1855769763678e"
+checksum = "8ee5873ec9cce0195efcb7a4e9507a04cd49aec9c83d0389df45b1ef7ba2e649"
 
 [[package]]
 name = "slab"
-version = "0.4.11"
+version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a2ae44ef20feb57a68b23d846850f861394c2e02dc425a50098ae8c90267589"
+checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
 
 [[package]]
 name = "smallvec"
@@ -4339,7 +4327,7 @@ version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a13f3d0daba03132c0aa9767f98351b3488edc2c100cda2d2ec2b04f3d8d3c8b"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.11.1",
  "core-foundation 0.9.4",
  "system-configuration-sys",
 ]
@@ -4356,9 +4344,9 @@ dependencies = [
 
 [[package]]
 name = "target-lexicon"
-version = "0.13.4"
+version = "0.13.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b1dd07eb858a2067e2f3c7155d54e929265c264e6f37efe3ee7a8d1b5a1dd0ba"
+checksum = "adb6935a6f5c20170eeceb1a3835a49e12e19d792f6dd344ccc76a985ca5a6ca"
 
 [[package]]
 name = "tcl-sys"
@@ -4371,12 +4359,12 @@ dependencies = [
 
 [[package]]
 name = "tempfile"
-version = "3.24.0"
+version = "3.27.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "655da9c7eb6305c55742045d5a8d2037996d61d8de95806335c7c86ce0f82e9c"
+checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
 dependencies = [
  "fastrand",
- "getrandom 0.3.4",
+ "getrandom 0.4.2",
  "once_cell",
  "rustix",
  "windows-sys 0.61.2",
@@ -4488,9 +4476,9 @@ dependencies = [
 
 [[package]]
 name = "tinyvec"
-version = "1.10.0"
+version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bfa5fdc3bce6191a1dbc8c02d5c8bffcf557bafa17c124c5264a458f1b0613fa"
+checksum = "3e61e67053d25a4e82c844e8424039d9745781b3fc4f32b8d55ed50f5f667ef3"
 dependencies = [
  "tinyvec_macros",
 ]
@@ -4533,9 +4521,9 @@ dependencies = [
 
 [[package]]
 name = "toml"
-version = "1.1.0+spec-1.1.0"
+version = "1.1.2+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8195ca05e4eb728f4ba94f3e3291661320af739c4e43779cbdfae82ab239fcc"
+checksum = "81f3d15e84cbcd896376e6730314d59fb5a87f31e4b038454184435cd57defee"
 dependencies = [
  "indexmap",
  "serde_core",
@@ -4548,27 +4536,27 @@ dependencies = [
 
 [[package]]
 name = "toml_datetime"
-version = "1.1.0+spec-1.1.0"
+version = "1.1.1+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97251a7c317e03ad83774a8752a7e81fb6067740609f75ea2b585b569a59198f"
+checksum = "3165f65f62e28e0115a00b2ebdd37eb6f3b641855f9d636d3cd4103767159ad7"
 dependencies = [
  "serde_core",
 ]
 
 [[package]]
 name = "toml_parser"
-version = "1.1.0+spec-1.1.0"
+version = "1.1.2+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2334f11ee363607eb04df9b8fc8a13ca1715a72ba8662a26ac285c98aabb4011"
+checksum = "a2abe9b86193656635d2411dc43050282ca48aa31c2451210f4202550afb7526"
 dependencies = [
  "winnow",
 ]
 
 [[package]]
 name = "toml_writer"
-version = "1.1.0+spec-1.1.0"
+version = "1.1.1+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d282ade6016312faf3e41e57ebbba0c073e4056dab1232ab1cb624199648f8ed"
+checksum = "756daf9b1013ebe47a8776667b466417e2d4c5679d441c26230efd9ef78692db"
 
 [[package]]
 name = "twox-hash"
@@ -4631,9 +4619,9 @@ dependencies = [
 
 [[package]]
 name = "unicode-ident"
-version = "1.0.22"
+version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9312f7c4f6ff9069b165498234ce8be658059c6728633667c526e27dc2cf1df5"
+checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
 
 [[package]]
 name = "unicode-normalization"
@@ -4646,9 +4634,9 @@ dependencies = [
 
 [[package]]
 name = "unicode-segmentation"
-version = "1.12.0"
+version = "1.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f6ccf251212114b54433ec949fd6a7841275f9ada20dddd2f29e9ceea4501493"
+checksum = "9629274872b2bfaf8d66f5f15725007f635594914870f65218920345aa11aa8c"
 
 [[package]]
 name = "unicode-width"
@@ -4691,7 +4679,7 @@ dependencies = [
  "getopts",
  "log",
  "phf_codegen",
- "rand 0.8.5",
+ "rand 0.8.6",
 ]
 
 [[package]]
@@ -4701,7 +4689,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1262662dc96937c71115228ce2e1d30f41db71a7a45d3459e98783ef94052214"
 dependencies = [
  "phf_codegen",
- "rand 0.8.5",
+ "rand 0.8.6",
 ]
 
 [[package]]
@@ -4770,11 +4758,11 @@ checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
 
 [[package]]
 name = "wasip2"
-version = "1.0.2+wasi-0.2.9"
+version = "1.0.3+wasi-0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9517f9239f02c069db75e65f174b3da828fe5f5b945c4dd26bd25d89c03ebcf5"
+checksum = "20064672db26d7cdc89c7798c48a0fdfac8213434a1186e5ef29fd560ae223d6"
 dependencies = [
- "wit-bindgen",
+ "wit-bindgen 0.57.1",
 ]
 
 [[package]]
@@ -4783,14 +4771,14 @@ version = "0.4.0+wasi-0.3.0-rc-2026-01-06"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5428f8bf88ea5ddc08faddef2ac4a67e390b88186c703ce6dbd955e1c145aca5"
 dependencies = [
- "wit-bindgen",
+ "wit-bindgen 0.51.0",
 ]
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.108"
+version = "0.2.120"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "64024a30ec1e37399cf85a7ffefebdb72205ca1c972291c51512360d90bd8566"
+checksum = "df52b6d9b87e0c74c9edfa1eb2d9bf85e5d63515474513aa50fa181b3c4f5db1"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -4801,23 +4789,19 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.58"
+version = "0.4.70"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70a6e77fd0ae8029c9ea0063f87c46fde723e7d887703d74ad2616d792e51e6f"
+checksum = "af934872acec734c2d80e6617bbb5ff4f12b052dd8e6332b0817bce889516084"
 dependencies = [
- "cfg-if",
- "futures-util",
  "js-sys",
- "once_cell",
  "wasm-bindgen",
- "web-sys",
 ]
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.108"
+version = "0.2.120"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "008b239d9c740232e71bd39e8ef6429d27097518b6b30bdf9086833bd5b6d608"
+checksum = "78b1041f495fb322e64aca85f5756b2172e35cd459376e67f2a6c9dffcedb103"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -4825,9 +4809,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.108"
+version = "0.2.120"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5256bae2d58f54820e6490f9839c49780dff84c65aeab9e772f15d5f0e913a55"
+checksum = "9dcd0ff20416988a18ac686d4d4d0f6aae9ebf08a389ff5d29012b05af2a1b41"
 dependencies = [
  "bumpalo",
  "proc-macro2",
@@ -4838,9 +4822,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.108"
+version = "0.2.120"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1f01b580c9ac74c8d8f0c0e4afb04eeef2acf145458e52c03845ee9cd23e3d12"
+checksum = "49757b3c82ebf16c57d69365a142940b384176c24df52a087fb748e2085359ea"
 dependencies = [
  "unicode-ident",
 ]
@@ -4873,7 +4857,7 @@ version = "0.244.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.11.1",
  "hashbrown 0.15.5",
  "indexmap",
  "semver",
@@ -4903,9 +4887,9 @@ dependencies = [
 
 [[package]]
 name = "web-sys"
-version = "0.3.85"
+version = "0.3.97"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "312e32e551d92129218ea9a2452120f4aabc03529ef03e4d0d82fb2780608598"
+checksum = "2eadbac71025cd7b0834f20d1fe8472e8495821b4e9801eb0a60bd1f19827602"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -4913,9 +4897,9 @@ dependencies = [
 
 [[package]]
 name = "webpki-root-certs"
-version = "1.0.5"
+version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "36a29fc0408b113f68cf32637857ab740edfafdf460c326cd2afaa2d84cc05dc"
+checksum = "f31141ce3fc3e300ae89b78c0dd67f9708061d1d2eda54b8209346fd6be9a92c"
 dependencies = [
  "rustls-pki-types",
 ]
@@ -4940,9 +4924,9 @@ dependencies = [
 
 [[package]]
 name = "wide"
-version = "1.1.1"
+version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ac11b009ebeae802ed758530b6496784ebfee7a87b9abfbcaf3bbe25b814eb25"
+checksum = "c9479f84a757f819cfab37295955906479181395de83add28f74975fde083141"
 dependencies = [
  "bytemuck",
  "safe_arch",
@@ -5202,9 +5186,9 @@ checksum = "d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650"
 
 [[package]]
 name = "winnow"
-version = "1.0.0"
+version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a90e88e4667264a994d34e6d1ab2d26d398dcdca8b7f52bec8668957517fc7d8"
+checksum = "2ee1708bef14716a11bae175f579062d4554d95be2c6829f518df847b7b3fdd0"
 
 [[package]]
 name = "winresource"
@@ -5224,6 +5208,12 @@ checksum = "d7249219f66ced02969388cf2bb044a09756a083d0fab1e566056b04d9fbcaa5"
 dependencies = [
  "wit-bindgen-rust-macro",
 ]
+
+[[package]]
+name = "wit-bindgen"
+version = "0.57.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ebf944e87a7c253233ad6766e082e3cd714b5d03812acc24c318f549614536e"
 
 [[package]]
 name = "wit-bindgen-core"
@@ -5274,7 +5264,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9d66ea20e9553b30172b5e831994e35fbde2d165325bec84fc43dbf6f4eb9cb2"
 dependencies = [
  "anyhow",
- "bitflags 2.11.0",
+ "bitflags 2.11.1",
  "indexmap",
  "log",
  "serde",
@@ -5312,9 +5302,9 @@ checksum = "d1890f4022759daae28ed4fe62859b1236caebfc61ede2f63ed4e695f3f6d936"
 
 [[package]]
 name = "writeable"
-version = "0.6.2"
+version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9edde0db4769d2dc68579893f2306b26c6ecfbe0ef499b013d731b7b9247e0b9"
+checksum = "1ffae5123b2d3fc086436f8834ae3ab053a283cfac8fe0a0b8eaae044768a4c4"
 
 [[package]]
 name = "x509-cert"
@@ -5378,18 +5368,18 @@ dependencies = [
 
 [[package]]
 name = "zerocopy"
-version = "0.8.34"
+version = "0.8.48"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "71ddd76bcebeed25db614f82bf31a9f4222d3fbba300e6fb6c00afa26cbd4d9d"
+checksum = "eed437bf9d6692032087e337407a86f04cd8d6a16a37199ed57949d415bd68e9"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.8.34"
+version = "0.8.48"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d8187381b52e32220d50b255276aa16a084ec0a9017a0ca2152a1f55c539758d"
+checksum = "70e3cd084b1788766f53af483dd21f93881ff30d7320490ec3ef7526d203bad4"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -5398,18 +5388,18 @@ dependencies = [
 
 [[package]]
 name = "zerofrom"
-version = "0.1.6"
+version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "50cc42e0333e05660c3587f3bf9d0478688e15d870fab3346451ce7f8c9fbea5"
+checksum = "69faa1f2a1ea75661980b013019ed6687ed0e83d069bc1114e2cc74c6c04c4df"
 dependencies = [
  "zerofrom-derive",
 ]
 
 [[package]]
 name = "zerofrom-derive"
-version = "0.1.6"
+version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d71e5d6e06ab090c67b5e44993ec16b72dcbaabc526db883a360057678b48502"
+checksum = "11532158c46691caf0f2593ea8358fed6bbf68a0315e80aae9bd41fbade684a1"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -5480,6 +5470,6 @@ checksum = "3be3d40e40a133f9c916ee3f9f4fa2d9d63435b5fbe1bfc6d9dae0aa0ada1513"
 
 [[package]]
 name = "zmij"
-version = "1.0.17"
+version = "1.0.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "02aae0f83f69aafc94776e879363e9771d7ecbffe2c7fbb6c14c5e00dfe88439"
+checksum = "b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -81,9 +81,9 @@ dependencies = [
 
 [[package]]
 name = "anstyle"
-version = "1.0.14"
+version = "1.0.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "940b3a0ca603d1eade50a4846a2afffd5ef57a9feac2c0e2ec2e14f9ead76000"
+checksum = "5192cca8006f1fd4f7237516f40fa183bb07f8fbdfedaa0036de5ea9b0b45e78"
 
 [[package]]
 name = "anstyle-parse"
@@ -116,9 +116,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.102"
+version = "1.0.100"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
+checksum = "a23eb6b1614318a8071c9b2521f36b424b2c83db5eb3a0fead4a6c0809af6e61"
 
 [[package]]
 name = "approx"
@@ -236,9 +236,9 @@ checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
 name = "aws-lc-fips-sys"
-version = "0.13.14"
+version = "0.13.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d3d619165468401dec3caa3366ebffbcb83f2f31883e5b3932f8e2dec2ddc568"
+checksum = "f8bce4948d2520386c6d92a6ea2d472300257702242e5a1d01d6add52bd2e7c1"
 dependencies = [
  "bindgen 0.72.1",
  "cc",
@@ -290,7 +290,7 @@ version = "0.71.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5f58bf3d7db68cfbac37cfc485a8d711e87e064c3d0fe0435b92f7a407f9d6b3"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.11.0",
  "cexpr",
  "clang-sys",
  "itertools 0.13.0",
@@ -310,7 +310,7 @@ version = "0.72.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "993776b509cfb49c750f11b8f07a46fa23e0a1386ffc01fb1e7d343efc387895"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.11.0",
  "cexpr",
  "clang-sys",
  "itertools 0.13.0",
@@ -332,9 +332,9 @@ checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bitflags"
-version = "2.11.1"
+version = "2.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c4512299f36f043ab09a583e57bceb5a5aab7a73db1805848e8fef3c9e8c78b3"
+checksum = "843867be96c8daad0d758b57df9392b6d8d271134fce549de6ce169ff98a92af"
 
 [[package]]
 name = "bitflagset"
@@ -406,9 +406,9 @@ dependencies = [
 
 [[package]]
 name = "bytemuck"
-version = "1.25.0"
+version = "1.24.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c8efb64bd706a16a1bdde310ae86b351e4d21550d98d056f22f8a7f7a2183fec"
+checksum = "1fbdf580320f38b612e485521afda1ee26d10cc9884efaaa750d383e13e3c5f4"
 
 [[package]]
 name = "bytes"
@@ -451,9 +451,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.2.61"
+version = "1.2.54"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d16d90359e986641506914ba71350897565610e87ce0ad9e6f28569db3dd5c6d"
+checksum = "6354c81bbfd62d9cfa9cb3c773c2b7b2a3a482d569de977fd0e961f6e7c00583"
 dependencies = [
  "find-msvc-tools",
  "jobserver",
@@ -546,18 +546,18 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.6.1"
+version = "4.5.54"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ddb117e43bbf7dacf0a4190fef4d345b9bad68dfc649cb349e7d17d28428e51"
+checksum = "c6e6ff9dcd79cff5cd969a17a545d79e84ab086e444102a591e288a8aa3ce394"
 dependencies = [
  "clap_builder",
 ]
 
 [[package]]
 name = "clap_builder"
-version = "4.6.0"
+version = "4.5.54"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "714a53001bf66416adb0e2ef5ac857140e7dc3a0c48fb28b2f10762fc4b5069f"
+checksum = "fa42cf4d2b7a41bc8f663a7cab4031ebafa1bf3875705bfaf8466dc60ab52c00"
 dependencies = [
  "anstyle",
  "clap_lex",
@@ -565,9 +565,9 @@ dependencies = [
 
 [[package]]
 name = "clap_lex"
-version = "1.1.0"
+version = "0.7.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
+checksum = "c3e64b0cc0439b12df2fa678eae89a1c56a529fd067a9115f7827f1fffd22b32"
 
 [[package]]
 name = "clipboard-win"
@@ -580,9 +580,9 @@ dependencies = [
 
 [[package]]
 name = "cmake"
-version = "0.1.58"
+version = "0.1.57"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c0f78a02292a74a88ac736019ab962ece0bc380e3f977bf72e376c5d78ff0678"
+checksum = "75443c44cd6b379beb8c5b45d85d0773baf31cce901fe7bb252f4eff3008ef7d"
 dependencies = [
  "cc",
 ]
@@ -601,9 +601,9 @@ checksum = "2550f75b8cfac212855f6b1885455df8eaee8fe8e246b647d69146142e016084"
 
 [[package]]
 name = "colorchoice"
-version = "1.0.5"
+version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
+checksum = "b05b61dc5112cbb17e4b6cd61790d9845d13888356391624cbe7e41efeac1e75"
 
 [[package]]
 name = "combine"
@@ -693,6 +693,17 @@ name = "core-foundation-sys"
 version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
+
+[[package]]
+name = "core-models"
+version = "0.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "657f625ff361906f779745d08375ae3cc9fef87a35fba5f22874cf773010daf4"
+dependencies = [
+ "hax-lib",
+ "pastey",
+ "rand 0.9.4",
+]
 
 [[package]]
 name = "cpubits"
@@ -1010,9 +1021,9 @@ dependencies = [
 
 [[package]]
 name = "data-encoding"
-version = "2.11.0"
+version = "2.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4ae5f15dda3c708c0ade84bfee31ccab44a3da4f88015ed22f63732abe300c8"
+checksum = "d7a1e2f27636f116493b8b860f5546edb47c8d8f8ea73e1d2a20be88e28d1fea"
 
 [[package]]
 name = "der"
@@ -1065,18 +1076,18 @@ dependencies = [
 
 [[package]]
 name = "deranged"
-version = "0.5.8"
+version = "0.5.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7cd812cc2bc1d69d4764bd80df88b4317eaef9e773c75226407d9bc0876b211c"
+checksum = "ececcb659e7ba858fb4f10388c250a7252eb0a27373f1a72b8748afdd248e587"
 dependencies = [
  "powerfmt",
 ]
 
 [[package]]
 name = "derive-where"
-version = "1.6.1"
+version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d08b3a0bcc0d079199cd476b2cae8435016ec11d1c0986c6901c5ac223041534"
+checksum = "ef941ded77d15ca19b40374869ac6000af1c9f2a4c0f3d4c70926287e6364a8f"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1181,9 +1192,9 @@ checksum = "869b0adbda23651a9c5c0c3d270aac9fcb52e8622a8f2b17e57802d7791962f2"
 
 [[package]]
 name = "env_filter"
-version = "1.0.1"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32e90c2accc4b07a8456ea0debdc2e7587bdd890680d71173a15d4ae604f6eef"
+checksum = "7a1c3cc8e57274ec99de65301228b537f1e4eedc1b8e0f9411c6caac8ae7308f"
 dependencies = [
  "log",
  "regex",
@@ -1232,15 +1243,15 @@ checksum = "de853764b47027c2e862a995c34978ffa63c1501f2e15f987ba11bd4f9bba193"
 
 [[package]]
 name = "fastrand"
-version = "2.4.1"
+version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
+checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
 
 [[package]]
 name = "find-msvc-tools"
-version = "0.1.9"
+version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
+checksum = "8591b0bcc8a98a64310a2fae1bb3e9b8564dd10e381e6e28010fde8e8e8568db"
 
 [[package]]
 name = "flagset"
@@ -1341,25 +1352,26 @@ checksum = "42703706b716c37f96a77aea830392ad231f44c9e9a67872fa5548707e11b11c"
 
 [[package]]
 name = "futures-core"
-version = "0.3.32"
+version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e3450815272ef58cec6d564423f6e755e25379b217b0bc688e295ba24df6b1d"
+checksum = "05f29059c0c2090612e8d742178b0580d2dc940c837851ad723096f87af6663e"
 
 [[package]]
 name = "futures-task"
-version = "0.3.32"
+version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "037711b3d59c33004d3856fbdc83b99d4ff37a24768fa1be9ce3538a1cde4393"
+checksum = "f90f7dce0722e95104fcb095585910c0977252f286e354b5e3bd38902cd99988"
 
 [[package]]
 name = "futures-util"
-version = "0.3.32"
+version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "389ca41296e6190b48053de0321d02a77f32f8a5d2461dd38762c0593805c6d6"
+checksum = "9fa08315bb612088cc391249efdc3bc77536f16c91f6cf495e6fbe85b20a4a81"
 dependencies = [
  "futures-core",
  "futures-task",
  "pin-project-lite",
+ "pin-utils",
  "slab",
 ]
 
@@ -1473,6 +1485,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0cc23270f6e1808e30a928bdc84dea0b9b4136a8bc82338574f23baf47bbd280"
 
 [[package]]
+name = "graviola"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4387e0458389da24c6fe732531e65595c7c4a32b027f98f4789e512e28224465"
+dependencies = [
+ "cfg-if",
+ "getrandom 0.3.4",
+]
+
+[[package]]
 name = "half"
 version = "2.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1506,6 +1528,43 @@ name = "hashbrown"
 version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4f467dd6dccf739c208452f8014c75c18bb8301b050ad1cfb27153803edb0f51"
+
+[[package]]
+name = "hax-lib"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "543f93241d32b3f00569201bfce9d7a93c92c6421b23c77864ac929dc947b9fc"
+dependencies = [
+ "hax-lib-macros",
+ "num-bigint",
+ "num-traits",
+]
+
+[[package]]
+name = "hax-lib-macros"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8755751e760b11021765bb04cb4a6c4e24742688d9f3aa14c2079638f537b0f"
+dependencies = [
+ "hax-lib-macros-types",
+ "proc-macro-error2",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "hax-lib-macros-types"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f177c9ae8ea456e2f71ff3c1ea47bf4464f772a05133fcbba56cd5ba169035a2"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "serde",
+ "serde_json",
+ "uuid",
+]
 
 [[package]]
 name = "heck"
@@ -1569,9 +1628,9 @@ dependencies = [
 
 [[package]]
 name = "iana-time-zone"
-version = "0.1.65"
+version = "0.1.64"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e31bc9ad994ba00e440a8aa5c9ef0ec67d5cb5e5cb0cc7f8b744a35b389cc470"
+checksum = "33e57f83510bb73707521ebaffa789ec8caf86f9657cad665b092b581d40e9fb"
 dependencies = [
  "android_system_properties",
  "core-foundation-sys",
@@ -1807,15 +1866,15 @@ dependencies = [
 
 [[package]]
 name = "itoa"
-version = "1.0.18"
+version = "1.0.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
+checksum = "92ecc6618181def0457392ccd0ee51198e065e016d1d527a7ac1b6dc7c1f09d2"
 
 [[package]]
 name = "jiff"
-version = "0.2.24"
+version = "0.2.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f00b5dbd620d61dfdcb6007c9c1f6054ebd75319f163d886a9055cec1155073d"
+checksum = "1a3546dc96b6d42c5f24902af9e2538e82e39ad350b0c766eb3fbf2d8f3d8359"
 dependencies = [
  "jiff-static",
  "log",
@@ -1826,9 +1885,9 @@ dependencies = [
 
 [[package]]
 name = "jiff-static"
-version = "0.2.24"
+version = "0.2.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e000de030ff8022ea1da3f466fbb0f3a809f5e51ed31f6dd931c35181ad8e6d7"
+checksum = "2a8c8b344124222efd714b73bb41f8b5120b27a7cc1c75593a6ff768d9d05aa4"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1896,12 +1955,10 @@ dependencies = [
 
 [[package]]
 name = "js-sys"
-version = "0.3.97"
+version = "0.3.85"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1840c94c045fbcf8ba2812c95db44499f7c64910a912551aaaa541decebcacf"
+checksum = "8c942ebf8e95485ca0d52d97da7c5a2c387d0e7f0ba4c35e93bfcaee045955b3"
 dependencies = [
- "cfg-if",
- "futures-util",
  "once_cell",
  "wasm-bindgen",
 ]
@@ -1976,15 +2033,79 @@ checksum = "803ec87c9cfb29b9d2633f20cba1f488db3fd53f2158b1024cbefb47ba05d413"
 
 [[package]]
 name = "libbz2-rs-sys"
-version = "0.2.3"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b3a6a8c165077efc8f3a971534c50ea6a1a18b329ef4a66e897a7e3a1494565f"
+checksum = "2c4a545a15244c7d945065b5d392b2d2d7f21526fba56ce51467b06ed445e8f7"
 
 [[package]]
 name = "libc"
 version = "0.2.186"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
+
+[[package]]
+name = "libcrux-intrinsics"
+version = "0.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b1b5db005ff8001e026b73a6842ee81bbef8ec5ff0e1915a67ae65fd2a9fafa5"
+dependencies = [
+ "core-models",
+ "hax-lib",
+]
+
+[[package]]
+name = "libcrux-ml-kem"
+version = "0.0.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a14ab3e477de9df6ee1273a114018ff62c4996ca9220070c4e5cb1743f94a67d"
+dependencies = [
+ "hax-lib",
+ "libcrux-intrinsics",
+ "libcrux-platform",
+ "libcrux-secrets",
+ "libcrux-sha3",
+ "libcrux-traits",
+]
+
+[[package]]
+name = "libcrux-platform"
+version = "0.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d9e21d7ed31a92ac539bd69a8c970b183ee883872d2d19ce27036e24cb8ecc4"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "libcrux-secrets"
+version = "0.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ce650f3041b44ba40d4263852347d007cd2cd9d1cc856a6f6c8b2e10c3fd40b"
+dependencies = [
+ "hax-lib",
+]
+
+[[package]]
+name = "libcrux-sha3"
+version = "0.0.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b1ae0b7d0e1cc4793a609fd0ff2ca3b3a3fabae523770c619a3d4bc86417b0d7"
+dependencies = [
+ "hax-lib",
+ "libcrux-intrinsics",
+ "libcrux-platform",
+ "libcrux-traits",
+]
+
+[[package]]
+name = "libcrux-traits"
+version = "0.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "812e4fa89f3f5e34b47f928b22b1b78395a0d4ec23b1f583db635f128159d65f"
+dependencies = [
+ "libcrux-secrets",
+ "rand 0.9.4",
+]
 
 [[package]]
 name = "libffi"
@@ -2053,10 +2174,11 @@ checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
 
 [[package]]
 name = "libredox"
-version = "0.1.16"
+version = "0.1.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e02f3bb43d335493c96bf3fd3a321600bf6bd07ed34bc64118e9293bdffea46c"
+checksum = "3d0b95e02c851351f877147b7deea7b1afb1df71b63aa5f8270716e0c5720616"
 dependencies = [
+ "bitflags 2.11.0",
  "libc",
 ]
 
@@ -2088,9 +2210,9 @@ checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
 
 [[package]]
 name = "litemap"
-version = "0.8.2"
+version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "92daf443525c4cce67b150400bc2316076100ce0b3686209eb8cf3c31612e6f0"
+checksum = "6373607a59f0be73a39b6fe456b8192fcc3585f602af20751600e974dd455e77"
 
 [[package]]
 name = "lock_api"
@@ -2280,7 +2402,7 @@ version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "71e2746dc3a24dd78b3cfcb7be93368c6de9963d30f43a6a73998a9cf4b17b46"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.11.0",
  "cfg-if",
  "cfg_aliases",
  "libc",
@@ -2289,11 +2411,11 @@ dependencies = [
 
 [[package]]
 name = "nix"
-version = "0.31.3"
+version = "0.31.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf20d2fde8ff38632c426f1165ed7436270b44f199fc55284c38276f9db47c3d"
+checksum = "5d6d0705320c1e6ba1d912b5e37cf18071b6c2e9b7fa8215a1e8a7651966f5d3"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.11.0",
  "cfg-if",
  "cfg_aliases",
  "libc",
@@ -2331,9 +2453,9 @@ dependencies = [
 
 [[package]]
 name = "num-conv"
-version = "0.2.1"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c6673768db2d862beb9b39a78fdcb1a69439615d5794a1be50caa9bc92c81967"
+checksum = "cf97ec579c3c42f953ef76dbf8d55ac91fb219dde70e49aa4a6b7d74e9919050"
 
 [[package]]
 name = "num-integer"
@@ -2404,9 +2526,9 @@ dependencies = [
 
 [[package]]
 name = "once_cell"
-version = "1.21.4"
+version = "1.21.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
+checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
 
 [[package]]
 name = "once_cell_polyfill"
@@ -2426,7 +2548,7 @@ version = "0.10.80"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a45fa2aa886c42762255da344f0a0d313e254066c46aad76f300c3d3da62d967"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.11.0",
  "cfg-if",
  "foreign-types",
  "libc",
@@ -2453,9 +2575,9 @@ checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
 
 [[package]]
 name = "openssl-src"
-version = "300.6.0+3.6.2"
+version = "300.5.4+3.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a8e8cbfd3a4a8c8f089147fd7aaa33cf8c7450c4d09f8f80698a0cf093abeff4"
+checksum = "a507b3792995dae9b0df8a1c1e3771e8418b7c2d9f0baeba32e6fe8b06c7cb72"
 dependencies = [
  "cc",
 ]
@@ -2487,9 +2609,9 @@ checksum = "978aa494585d3ca4ad74929863093e87cac9790d81fe7aba2b3dc2890643a0fc"
 
 [[package]]
 name = "ordermap"
-version = "1.2.0"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f7476a5b122ff1fce7208e7ee9dccd0a516e835f5b8b19b8f3c98a34cf757c1"
+checksum = "cfa78c92071bbd3628c22b1a964f7e0eb201dc1456555db072beb1662ecd6715"
 dependencies = [
  "indexmap",
 ]
@@ -2531,6 +2653,12 @@ name = "paste"
 version = "1.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
+
+[[package]]
+name = "pastey"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c5a797f0e07bdf071d15742978fc3128ec6c22891c31a3a931513263904c982a"
 
 [[package]]
 name = "pbkdf2"
@@ -2607,7 +2735,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3c80231409c20246a13fddb31776fb942c38553c51e871f8cbd687a4cfb5843d"
 dependencies = [
  "phf_shared 0.11.3",
- "rand 0.8.6",
+ "rand 0.8.5",
 ]
 
 [[package]]
@@ -2653,9 +2781,15 @@ dependencies = [
 
 [[package]]
 name = "pin-project-lite"
-version = "0.2.17"
+version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
+checksum = "3b3cff922bd51709b605d9ead9aa71031d81447142d828eb4a6eba76fe619f9b"
+
+[[package]]
+name = "pin-utils"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
 name = "pkcs5"
@@ -2687,9 +2821,9 @@ dependencies = [
 
 [[package]]
 name = "pkg-config"
-version = "0.3.33"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "19f132c84eca552bf34cab8ec81f1c1dcc229b811638f9d283dceabe58c5569e"
+checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
 
 [[package]]
 name = "plotters"
@@ -2732,24 +2866,24 @@ dependencies = [
 
 [[package]]
 name = "portable-atomic"
-version = "1.13.1"
+version = "1.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
+checksum = "f89776e4d69bb58bc6993e99ffa1d11f228b839984854c7daeb5d37f87cbe950"
 
 [[package]]
 name = "portable-atomic-util"
-version = "0.2.7"
+version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c2a106d1259c23fac8e543272398ae0e3c0b8d33c88ed73d0cc71b0f1d902618"
+checksum = "d8a2f0d8d040d7848a709caf78912debcc3f33ee4b3cac47d73d1e1069e83507"
 dependencies = [
  "portable-atomic",
 ]
 
 [[package]]
 name = "potential_utf"
-version = "0.1.5"
+version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0103b1cef7ec0cf76490e969665504990193874ea05c85ff9bab8b911d0a0564"
+checksum = "b73949432f5e2a09657003c25bca5e19a0e9c84f8058ca374f49e0ebe605af77"
 dependencies = [
  "serde_core",
  "writeable",
@@ -2778,6 +2912,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
 dependencies = [
  "proc-macro2",
+ "syn",
+]
+
+[[package]]
+name = "proc-macro-error-attr2"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96de42df36bb9bba5542fe9f1a054b8cc87e172759a1868aa05c1f3acc89dfc5"
+dependencies = [
+ "proc-macro2",
+ "quote",
+]
+
+[[package]]
+name = "proc-macro-error2"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11ec05c52be0a07b08061f7dd003e7d7092e0472bc731b4af7bb1ef876109802"
+dependencies = [
+ "proc-macro-error-attr2",
+ "proc-macro2",
+ "quote",
  "syn",
 ]
 
@@ -2947,9 +3103,9 @@ dependencies = [
 
 [[package]]
 name = "rand"
-version = "0.8.6"
+version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ca0ecfa931c29007047d1bc58e623ab12e5590e8c7cc53200d5202b69266d8a"
+checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
 dependencies = [
  "libc",
  "rand_chacha 0.3.1",
@@ -3021,9 +3177,9 @@ dependencies = [
 
 [[package]]
 name = "rayon"
-version = "1.12.0"
+version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fb39b166781f92d482534ef4b4b1b2568f42613b53e5b6c160e24cfbfa30926d"
+checksum = "368f01d005bf8fd9b1206fb6fa653e6c4a81ceb1466406b81792d87c5677a58f"
 dependencies = [
  "either",
  "rayon-core",
@@ -3051,7 +3207,7 @@ version = "0.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.11.0",
 ]
 
 [[package]]
@@ -3087,13 +3243,13 @@ dependencies = [
 
 [[package]]
 name = "regalloc2"
-version = "0.15.1"
+version = "0.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "de2c52737737f8609e94f975dee22854a2d5c125772d4b1cf292120f4d45c186"
+checksum = "952ddbfc6f9f64d006c3efd8c9851a6ba2f2b944ba94730db255d55006e0ffda"
 dependencies = [
  "allocator-api2",
  "bumpalo",
- "hashbrown 0.17.0",
+ "hashbrown 0.15.5",
  "log",
  "rustc-hash",
  "smallvec",
@@ -3101,9 +3257,9 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.12.3"
+version = "1.12.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e10754a14b9137dd7b1e3e5b0493cc9171fdd105e0ab477f51b72e7f3ac0e276"
+checksum = "843bc0191f75f3e22651ae5f1e72939ab2f72a4bc30fa80a066bd66edefc24d4"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -3113,9 +3269,9 @@ dependencies = [
 
 [[package]]
 name = "regex-automata"
-version = "0.4.14"
+version = "0.4.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e1dd4122fc1595e8162618945476892eefca7b88c52820e74af6262213cae8f"
+checksum = "5276caf25ac86c8d810222b3dbb938e512c55c6831a10f3e6ed1c93b84041f1c"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -3124,9 +3280,9 @@ dependencies = [
 
 [[package]]
 name = "regex-syntax"
-version = "0.8.10"
+version = "0.8.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
+checksum = "7a2d987857b319362043e95f5353c0535c1f58eec5336fdfcf626430af7def58"
 
 [[package]]
 name = "region"
@@ -3177,9 +3333,9 @@ dependencies = [
 
 [[package]]
 name = "rustc-hash"
-version = "2.1.2"
+version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94300abf3f1ae2e2b8ffb7b58043de3d399c73fa6f4b73826402a5c457614dbe"
+checksum = "357703d41365b4b27c590e3ed91eabb1b663f07c4c084095e60cbed4362dff0d"
 
 [[package]]
 name = "rustc_version"
@@ -3205,7 +3361,7 @@ version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.11.0",
  "errno",
  "libc",
  "linux-raw-sys",
@@ -3214,9 +3370,9 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.23.40"
+version = "0.23.39"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ef86cd5876211988985292b91c96a8f2d298df24e75989a43a3c73f2d4d8168b"
+checksum = "7c2c118cb077cca2822033836dfb1b975355dfb784b5e8da48f7b6c5db74e60e"
 dependencies = [
  "aws-lc-rs",
  "once_cell",
@@ -3224,6 +3380,17 @@ dependencies = [
  "rustls-webpki",
  "subtle",
  "zeroize",
+]
+
+[[package]]
+name = "rustls-graviola"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "323c712e50c59ceb2ba9ad4d79dcfd3e0046a082d61efa87fcdf8f59af04473c"
+dependencies = [
+ "graviola",
+ "libcrux-ml-kem",
+ "rustls",
 ]
 
 [[package]]
@@ -3249,9 +3416,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-pki-types"
-version = "1.14.1"
+version = "1.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "30a7197ae7eb376e574fe940d068c30fe0462554a3ddbe4eca7838e049c937a9"
+checksum = "be040f8b0a225e40375822a563fa9524378b9d63112f53e19ffff34df5d33fdd"
 dependencies = [
  "zeroize",
 ]
@@ -3308,6 +3475,8 @@ dependencies = [
  "libc",
  "log",
  "pyo3",
+ "rustls",
+ "rustls-graviola",
  "rustpython-capi",
  "rustpython-compiler",
  "rustpython-pylib",
@@ -3332,7 +3501,7 @@ dependencies = [
 name = "rustpython-codegen"
 version = "0.5.0"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.11.0",
  "indexmap",
  "itertools 0.14.0",
  "log",
@@ -3356,7 +3525,7 @@ name = "rustpython-common"
 version = "0.5.0"
 dependencies = [
  "ascii",
- "bitflags 2.11.1",
+ "bitflags 2.11.0",
  "getrandom 0.3.4",
  "itertools 0.14.0",
  "libc",
@@ -3391,7 +3560,7 @@ dependencies = [
 name = "rustpython-compiler-core"
 version = "0.5.0"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.11.0",
  "bitflagset",
  "itertools 0.14.0",
  "lz4_flex",
@@ -3443,14 +3612,14 @@ dependencies = [
 name = "rustpython-host_env"
 version = "0.5.0"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.11.0",
  "getrandom 0.3.4",
  "junction",
  "libc",
  "libffi",
  "libloading 0.9.0",
  "memmap2",
- "nix 0.31.3",
+ "nix 0.31.2",
  "num-traits",
  "num_cpus",
  "parking_lot",
@@ -3508,7 +3677,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f021ff72cabf5e2cd6d8ec8813d376a8445a228dc610ab56c27bd9054cda70d4"
 dependencies = [
  "aho-corasick",
- "bitflags 2.11.1",
+ "bitflags 2.11.0",
  "compact_str",
  "get-size2",
  "is-macro",
@@ -3526,7 +3695,7 @@ version = "0.15.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "01e6ee78bd9671fb5766664b2695fe1f2a92a961f4d9101646c570d8acdb1e0b"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.11.0",
  "bstr",
  "compact_str",
  "get-size2",
@@ -3576,7 +3745,7 @@ dependencies = [
 name = "rustpython-sre_engine"
 version = "0.5.0"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.11.0",
  "criterion",
  "icu_properties",
  "num_enum",
@@ -3680,7 +3849,7 @@ name = "rustpython-vm"
 version = "0.5.0"
 dependencies = [
  "ascii",
- "bitflags 2.11.1",
+ "bitflags 2.11.0",
  "bstr",
  "chrono",
  "constant_time_eq",
@@ -3776,14 +3945,14 @@ version = "18.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4a990b25f351b25139ddc7f21ee3f6f56f86d6846b74ac8fad3a719a287cd4a0"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.11.0",
  "cfg-if",
  "clipboard-win",
  "home",
  "libc",
  "log",
  "memchr",
- "nix 0.31.3",
+ "nix 0.31.2",
  "radix_trie",
  "unicode-segmentation",
  "unicode-width",
@@ -3793,9 +3962,9 @@ dependencies = [
 
 [[package]]
 name = "ryu"
-version = "1.0.23"
+version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
+checksum = "a50f4cf475b65d88e057964e0e9bb1f0aa9bbb2036dc65c64596b42932536984"
 
 [[package]]
 name = "safe_arch"
@@ -3854,11 +4023,11 @@ dependencies = [
 
 [[package]]
 name = "security-framework"
-version = "3.7.0"
+version = "3.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7f4bc775c73d9a02cde8bf7b2ec4c9d12743edf609006c7facc23998404cd1d"
+checksum = "b3297343eaf830f66ede390ea39da1d462b6b0c1b000f420d0a83f898bbbe6ef"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.11.0",
  "core-foundation 0.10.1",
  "core-foundation-sys",
  "libc",
@@ -3867,9 +4036,9 @@ dependencies = [
 
 [[package]]
 name = "security-framework-sys"
-version = "2.17.0"
+version = "2.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ce2691df843ecc5d231c0b14ece2acc3efb62c0a398c7e1d875f3983ce020e3"
+checksum = "cc1f0cbffaac4852523ce30d8bd3c5cdc873501d96ff467ca09b6767bb8cd5c0"
 dependencies = [
  "core-foundation-sys",
  "libc",
@@ -3937,9 +4106,9 @@ dependencies = [
 
 [[package]]
 name = "serde_spanned"
-version = "1.1.1"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6662b5879511e06e8999a8a235d848113e942c9124f211511b16466ee2995f26"
+checksum = "876ac351060d4f882bb1032b6369eb0aef79ad9df1ea8bc404874d8cc3d0cd98"
 dependencies = [
  "serde_core",
 ]
@@ -3990,9 +4159,9 @@ dependencies = [
 
 [[package]]
 name = "sha3"
-version = "0.10.9"
+version = "0.10.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77fd7028345d415a4034cf8777cd4f8ab1851274233b45f84e3d955502d93874"
+checksum = "75872d278a8f37ef87fa0ddbda7802605cb18344497949862c0d4dcb291eba60"
 dependencies = [
  "digest 0.10.7",
  "keccak",
@@ -4023,9 +4192,9 @@ dependencies = [
 
 [[package]]
 name = "simd-adler32"
-version = "0.3.9"
+version = "0.3.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "703d5c7ef118737c72f1af64ad2f6f8c5e1921f818cdcb97b8fe6fc69bf66214"
+checksum = "e320a6c5ad31d271ad523dcf3ad13e2767ad8b1cb8f047f75a8aeaf8da139da2"
 
 [[package]]
 name = "simd_cesu8"
@@ -4051,15 +4220,15 @@ checksum = "bbbb5d9659141646ae647b42fe094daf6c6192d1620870b449d9557f748b2daa"
 
 [[package]]
 name = "siphasher"
-version = "1.0.3"
+version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ee5873ec9cce0195efcb7a4e9507a04cd49aec9c83d0389df45b1ef7ba2e649"
+checksum = "b2aa850e253778c88a04c3d7323b043aeda9d3e30d5971937c1855769763678e"
 
 [[package]]
 name = "slab"
-version = "0.4.12"
+version = "0.4.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
+checksum = "7a2ae44ef20feb57a68b23d846850f861394c2e02dc425a50098ae8c90267589"
 
 [[package]]
 name = "smallvec"
@@ -4172,7 +4341,7 @@ version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a13f3d0daba03132c0aa9767f98351b3488edc2c100cda2d2ec2b04f3d8d3c8b"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.11.0",
  "core-foundation 0.9.4",
  "system-configuration-sys",
 ]
@@ -4189,9 +4358,9 @@ dependencies = [
 
 [[package]]
 name = "target-lexicon"
-version = "0.13.5"
+version = "0.13.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "adb6935a6f5c20170eeceb1a3835a49e12e19d792f6dd344ccc76a985ca5a6ca"
+checksum = "b1dd07eb858a2067e2f3c7155d54e929265c264e6f37efe3ee7a8d1b5a1dd0ba"
 
 [[package]]
 name = "tcl-sys"
@@ -4204,12 +4373,12 @@ dependencies = [
 
 [[package]]
 name = "tempfile"
-version = "3.27.0"
+version = "3.24.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
+checksum = "655da9c7eb6305c55742045d5a8d2037996d61d8de95806335c7c86ce0f82e9c"
 dependencies = [
  "fastrand",
- "getrandom 0.4.2",
+ "getrandom 0.3.4",
  "once_cell",
  "rustix",
  "windows-sys 0.61.2",
@@ -4321,9 +4490,9 @@ dependencies = [
 
 [[package]]
 name = "tinyvec"
-version = "1.11.0"
+version = "1.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3e61e67053d25a4e82c844e8424039d9745781b3fc4f32b8d55ed50f5f667ef3"
+checksum = "bfa5fdc3bce6191a1dbc8c02d5c8bffcf557bafa17c124c5264a458f1b0613fa"
 dependencies = [
  "tinyvec_macros",
 ]
@@ -4366,9 +4535,9 @@ dependencies = [
 
 [[package]]
 name = "toml"
-version = "1.1.2+spec-1.1.0"
+version = "1.1.0+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "81f3d15e84cbcd896376e6730314d59fb5a87f31e4b038454184435cd57defee"
+checksum = "f8195ca05e4eb728f4ba94f3e3291661320af739c4e43779cbdfae82ab239fcc"
 dependencies = [
  "indexmap",
  "serde_core",
@@ -4381,27 +4550,27 @@ dependencies = [
 
 [[package]]
 name = "toml_datetime"
-version = "1.1.1+spec-1.1.0"
+version = "1.1.0+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3165f65f62e28e0115a00b2ebdd37eb6f3b641855f9d636d3cd4103767159ad7"
+checksum = "97251a7c317e03ad83774a8752a7e81fb6067740609f75ea2b585b569a59198f"
 dependencies = [
  "serde_core",
 ]
 
 [[package]]
 name = "toml_parser"
-version = "1.1.2+spec-1.1.0"
+version = "1.1.0+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a2abe9b86193656635d2411dc43050282ca48aa31c2451210f4202550afb7526"
+checksum = "2334f11ee363607eb04df9b8fc8a13ca1715a72ba8662a26ac285c98aabb4011"
 dependencies = [
  "winnow",
 ]
 
 [[package]]
 name = "toml_writer"
-version = "1.1.1+spec-1.1.0"
+version = "1.1.0+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "756daf9b1013ebe47a8776667b466417e2d4c5679d441c26230efd9ef78692db"
+checksum = "d282ade6016312faf3e41e57ebbba0c073e4056dab1232ab1cb624199648f8ed"
 
 [[package]]
 name = "twox-hash"
@@ -4464,9 +4633,9 @@ dependencies = [
 
 [[package]]
 name = "unicode-ident"
-version = "1.0.24"
+version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
+checksum = "9312f7c4f6ff9069b165498234ce8be658059c6728633667c526e27dc2cf1df5"
 
 [[package]]
 name = "unicode-normalization"
@@ -4479,9 +4648,9 @@ dependencies = [
 
 [[package]]
 name = "unicode-segmentation"
-version = "1.13.2"
+version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9629274872b2bfaf8d66f5f15725007f635594914870f65218920345aa11aa8c"
+checksum = "f6ccf251212114b54433ec949fd6a7841275f9ada20dddd2f29e9ceea4501493"
 
 [[package]]
 name = "unicode-width"
@@ -4524,7 +4693,7 @@ dependencies = [
  "getopts",
  "log",
  "phf_codegen",
- "rand 0.8.6",
+ "rand 0.8.5",
 ]
 
 [[package]]
@@ -4534,7 +4703,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1262662dc96937c71115228ce2e1d30f41db71a7a45d3459e98783ef94052214"
 dependencies = [
  "phf_codegen",
- "rand 0.8.6",
+ "rand 0.8.5",
 ]
 
 [[package]]
@@ -4574,6 +4743,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ddd74a9687298c6858e9b88ec8935ec45d22e8fd5e6394fa1bd4e99a87789c76"
 dependencies = [
  "atomic",
+ "getrandom 0.4.2",
  "js-sys",
  "wasm-bindgen",
 ]
@@ -4608,11 +4778,11 @@ checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
 
 [[package]]
 name = "wasip2"
-version = "1.0.3+wasi-0.2.9"
+version = "1.0.2+wasi-0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "20064672db26d7cdc89c7798c48a0fdfac8213434a1186e5ef29fd560ae223d6"
+checksum = "9517f9239f02c069db75e65f174b3da828fe5f5b945c4dd26bd25d89c03ebcf5"
 dependencies = [
- "wit-bindgen 0.57.1",
+ "wit-bindgen",
 ]
 
 [[package]]
@@ -4621,14 +4791,14 @@ version = "0.4.0+wasi-0.3.0-rc-2026-01-06"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5428f8bf88ea5ddc08faddef2ac4a67e390b88186c703ce6dbd955e1c145aca5"
 dependencies = [
- "wit-bindgen 0.51.0",
+ "wit-bindgen",
 ]
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.120"
+version = "0.2.108"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df52b6d9b87e0c74c9edfa1eb2d9bf85e5d63515474513aa50fa181b3c4f5db1"
+checksum = "64024a30ec1e37399cf85a7ffefebdb72205ca1c972291c51512360d90bd8566"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -4639,19 +4809,23 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.70"
+version = "0.4.58"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af934872acec734c2d80e6617bbb5ff4f12b052dd8e6332b0817bce889516084"
+checksum = "70a6e77fd0ae8029c9ea0063f87c46fde723e7d887703d74ad2616d792e51e6f"
 dependencies = [
+ "cfg-if",
+ "futures-util",
  "js-sys",
+ "once_cell",
  "wasm-bindgen",
+ "web-sys",
 ]
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.120"
+version = "0.2.108"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78b1041f495fb322e64aca85f5756b2172e35cd459376e67f2a6c9dffcedb103"
+checksum = "008b239d9c740232e71bd39e8ef6429d27097518b6b30bdf9086833bd5b6d608"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -4659,9 +4833,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.120"
+version = "0.2.108"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9dcd0ff20416988a18ac686d4d4d0f6aae9ebf08a389ff5d29012b05af2a1b41"
+checksum = "5256bae2d58f54820e6490f9839c49780dff84c65aeab9e772f15d5f0e913a55"
 dependencies = [
  "bumpalo",
  "proc-macro2",
@@ -4672,9 +4846,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.120"
+version = "0.2.108"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "49757b3c82ebf16c57d69365a142940b384176c24df52a087fb748e2085359ea"
+checksum = "1f01b580c9ac74c8d8f0c0e4afb04eeef2acf145458e52c03845ee9cd23e3d12"
 dependencies = [
  "unicode-ident",
 ]
@@ -4707,7 +4881,7 @@ version = "0.244.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.11.0",
  "hashbrown 0.15.5",
  "indexmap",
  "semver",
@@ -4737,9 +4911,9 @@ dependencies = [
 
 [[package]]
 name = "web-sys"
-version = "0.3.97"
+version = "0.3.85"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2eadbac71025cd7b0834f20d1fe8472e8495821b4e9801eb0a60bd1f19827602"
+checksum = "312e32e551d92129218ea9a2452120f4aabc03529ef03e4d0d82fb2780608598"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -4747,9 +4921,9 @@ dependencies = [
 
 [[package]]
 name = "webpki-root-certs"
-version = "1.0.7"
+version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f31141ce3fc3e300ae89b78c0dd67f9708061d1d2eda54b8209346fd6be9a92c"
+checksum = "36a29fc0408b113f68cf32637857ab740edfafdf460c326cd2afaa2d84cc05dc"
 dependencies = [
  "rustls-pki-types",
 ]
@@ -4774,9 +4948,9 @@ dependencies = [
 
 [[package]]
 name = "wide"
-version = "1.3.0"
+version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c9479f84a757f819cfab37295955906479181395de83add28f74975fde083141"
+checksum = "ac11b009ebeae802ed758530b6496784ebfee7a87b9abfbcaf3bbe25b814eb25"
 dependencies = [
  "bytemuck",
  "safe_arch",
@@ -5036,9 +5210,9 @@ checksum = "d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650"
 
 [[package]]
 name = "winnow"
-version = "1.0.2"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2ee1708bef14716a11bae175f579062d4554d95be2c6829f518df847b7b3fdd0"
+checksum = "a90e88e4667264a994d34e6d1ab2d26d398dcdca8b7f52bec8668957517fc7d8"
 
 [[package]]
 name = "winresource"
@@ -5058,12 +5232,6 @@ checksum = "d7249219f66ced02969388cf2bb044a09756a083d0fab1e566056b04d9fbcaa5"
 dependencies = [
  "wit-bindgen-rust-macro",
 ]
-
-[[package]]
-name = "wit-bindgen"
-version = "0.57.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ebf944e87a7c253233ad6766e082e3cd714b5d03812acc24c318f549614536e"
 
 [[package]]
 name = "wit-bindgen-core"
@@ -5114,7 +5282,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9d66ea20e9553b30172b5e831994e35fbde2d165325bec84fc43dbf6f4eb9cb2"
 dependencies = [
  "anyhow",
- "bitflags 2.11.1",
+ "bitflags 2.11.0",
  "indexmap",
  "log",
  "serde",
@@ -5152,9 +5320,9 @@ checksum = "d1890f4022759daae28ed4fe62859b1236caebfc61ede2f63ed4e695f3f6d936"
 
 [[package]]
 name = "writeable"
-version = "0.6.3"
+version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ffae5123b2d3fc086436f8834ae3ab053a283cfac8fe0a0b8eaae044768a4c4"
+checksum = "9edde0db4769d2dc68579893f2306b26c6ecfbe0ef499b013d731b7b9247e0b9"
 
 [[package]]
 name = "x509-cert"
@@ -5218,18 +5386,18 @@ dependencies = [
 
 [[package]]
 name = "zerocopy"
-version = "0.8.48"
+version = "0.8.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eed437bf9d6692032087e337407a86f04cd8d6a16a37199ed57949d415bd68e9"
+checksum = "71ddd76bcebeed25db614f82bf31a9f4222d3fbba300e6fb6c00afa26cbd4d9d"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.8.48"
+version = "0.8.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70e3cd084b1788766f53af483dd21f93881ff30d7320490ec3ef7526d203bad4"
+checksum = "d8187381b52e32220d50b255276aa16a084ec0a9017a0ca2152a1f55c539758d"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -5238,18 +5406,18 @@ dependencies = [
 
 [[package]]
 name = "zerofrom"
-version = "0.1.7"
+version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "69faa1f2a1ea75661980b013019ed6687ed0e83d069bc1114e2cc74c6c04c4df"
+checksum = "50cc42e0333e05660c3587f3bf9d0478688e15d870fab3346451ce7f8c9fbea5"
 dependencies = [
  "zerofrom-derive",
 ]
 
 [[package]]
 name = "zerofrom-derive"
-version = "0.1.7"
+version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "11532158c46691caf0f2593ea8358fed6bbf68a0315e80aae9bd41fbade684a1"
+checksum = "d71e5d6e06ab090c67b5e44993ec16b72dcbaabc526db883a360057678b48502"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -5320,6 +5488,6 @@ checksum = "3be3d40e40a133f9c916ee3f9f4fa2d9d63435b5fbe1bfc6d9dae0aa0ada1513"
 
 [[package]]
 name = "zmij"
-version = "1.0.21"
+version = "1.0.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa"
+checksum = "02aae0f83f69aafc94776e879363e9771d7ecbffe2c7fbb6c14c5e00dfe88439"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -194,7 +194,6 @@ phf = { version = "0.13.1", default-features = false, features = ["macros"]}
 adler32 = "1.2.0"
 approx = "0.5.1"
 ascii = "1.1"
-aws-lc-rs = "1.16.3"
 base64 = "0.22"
 blake2 = "0.10.4"
 bitflags = "2.11.0"
@@ -218,7 +217,7 @@ exitcode = "1.1.2"
 flame = "0.2.2"
 flamer = "0.5"
 flate2 = { version = "1.1.9", default-features = false }
-foreign-types-shared = "0.3.1"
+foreign-types-shared = "0.1"
 gethostname = "1.0.2"
 getrandom = { version = "0.3", features = ["std"] }
 glob = "0.3"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ license.workspace = true
 
 [features]
 capi = ["dep:rustpython-capi", "threading"]
-default = ["threading", "stdlib", "stdio", "importlib", "ssl-rustls", "host_env"]
+default = ["threading", "stdlib", "stdio", "importlib", "ssl-rustls-aws-lc", "host_env"]
 host_env = ["rustpython-vm/host_env", "rustpython-stdlib?/host_env"]
 importlib = ["rustpython-vm/importlib"]
 encodings = ["rustpython-vm/encodings"]
@@ -23,7 +23,8 @@ jit = ["rustpython-vm/jit"]
 threading = ["rustpython-vm/threading", "rustpython-stdlib/threading"]
 sqlite = ["rustpython-stdlib/sqlite"]
 ssl = []
-ssl-rustls = ["ssl", "rustpython-stdlib/ssl-rustls"]
+ssl-rustls-aws-lc = ["ssl", "rustpython-stdlib/ssl-rustls-aws-lc"]
+ssl-rustls-no-provider = ["ssl", "rustpython-stdlib/ssl-rustls-no-provider"]
 ssl-openssl = ["ssl", "rustpython-stdlib/ssl-openssl"]
 ssl-vendor = ["ssl-openssl", "rustpython-stdlib/ssl-vendor"]
 tkinter = ["rustpython-stdlib/tkinter"]
@@ -45,6 +46,9 @@ lexopt = "0.3"
 dirs = "6"
 env_logger = "0.11"
 flamescope = { version = "0.1.2", optional = true }
+
+rustls = { workspace = true, optional = true }
+rustls-graviola = { workspace = true, optional = true }
 
 [target.'cfg(windows)'.dependencies]
 libc = { workspace = true }
@@ -69,6 +73,17 @@ harness = false
 [[bin]]
 name = "rustpython"
 path = "src/main.rs"
+
+[[example]]
+name = "custom_tls_providers"
+path = "examples/custom_tls_providers.rs"
+required-features = [
+    "rustls-graviola",
+    "rustls/ring",
+    "rustpython-pylib/freeze-stdlib",
+    "rustpython-stdlib/ssl-rustls-no-provider",
+    "rustpython-vm/freeze-stdlib",
+]
 
 [profile.dev.package."*"]
 opt-level = 3
@@ -263,6 +278,7 @@ rapidhash = "4.4.1"
 result-like = "0.5.0"
 rustix = { version = "1.1", features = ["event", "param", "system"] }
 rustls = { version = "0.23.39", default-features = false }
+rustls-graviola = "0.3"
 rustls-native-certs = "0.8"
 rustls-pemfile = "2.2"
 rustls-platform-verifier = "0.7"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,9 +22,10 @@ freeze-stdlib = ["stdlib", "rustpython-vm/freeze-stdlib", "rustpython-pylib?/fre
 jit = ["rustpython-vm/jit"]
 threading = ["rustpython-vm/threading", "rustpython-stdlib/threading"]
 sqlite = ["rustpython-stdlib/sqlite"]
-ssl = []
-ssl-rustls-aws-lc = ["ssl", "rustpython-stdlib/ssl-rustls-aws-lc"]
-ssl-rustls-no-provider = ["ssl", "rustpython-stdlib/ssl-rustls-no-provider"]
+ssl = ["host_env"]
+ssl-rustls = ["ssl", "rustpython-stdlib/ssl-rustls"]
+ssl-rustls-aws-lc = ["ssl-rustls", "dep:rustls", "rustls/aws_lc_rs"]
+ssl-rustls-aws-lc-fips = ["ssl-rustls-aws-lc", "rustls/fips"]
 ssl-openssl = ["ssl", "rustpython-stdlib/ssl-openssl"]
 ssl-vendor = ["ssl-openssl", "rustpython-stdlib/ssl-vendor"]
 tkinter = ["rustpython-stdlib/tkinter"]
@@ -81,7 +82,7 @@ required-features = [
     "rustls-graviola",
     "rustls/ring",
     "rustpython-pylib/freeze-stdlib",
-    "rustpython-stdlib/ssl-rustls-no-provider",
+    "rustpython-stdlib/ssl-rustls",
     "rustpython-vm/freeze-stdlib",
 ]
 

--- a/README.md
+++ b/README.md
@@ -102,7 +102,7 @@ rustpython
 
 ### SSL provider
 
-For HTTPS requests, `ssl-rustls` feature is enabled by default. You can replace it with `ssl-openssl` feature if your environment requires OpenSSL.
+For HTTPS requests, `ssl-rustls-aws-lc` is enabled by default for the RustPython binary. Embedders can use `rustpython-stdlib`'s provider-agnostic `ssl-rustls` feature and install their own rustls crypto provider, or replace rustls with `ssl-openssl` if their environment requires OpenSSL.
 Note that to use OpenSSL on Windows, you may need to install OpenSSL, or you can enable the `ssl-vendor` feature instead,
 which compiles OpenSSL for you but requires a C compiler, perl, and `make`.
 OpenSSL version 3 is expected and tested in CI. Older versions may not work.

--- a/crates/stdlib/Cargo.toml
+++ b/crates/stdlib/Cargo.toml
@@ -18,12 +18,14 @@ threading = ["rustpython-common/threading", "rustpython-vm/threading"]
 sqlite = ["dep:libsqlite3-sys"]
 # SSL backends - default to rustls
 ssl = []
-ssl-rustls = ["ssl", "rustls", "rustls-native-certs", "rustls-pemfile", "rustls-platform-verifier", "x509-cert", "x509-parser", "der", "pem-rfc7468", "webpki-roots", "aws-lc-rs", "oid-registry", "pkcs8"]
-ssl-rustls-fips = ["ssl-rustls", "aws-lc-rs/fips"]
+ssl-rustls = ["__ssl-rustls", "rustls/aws_lc_rs", "aws-lc-rs"]
+ssl-rustls-fips = ["__ssl-rustls", "rustls/aws_lc_rs", "aws-lc-rs", "aws-lc-rs/fips"]
 ssl-openssl = ["ssl", "openssl", "openssl-sys", "foreign-types-shared", "openssl-probe"]
 ssl-vendor = ["ssl-openssl", "openssl/vendored"]
 tkinter = ["dep:tk-sys", "dep:tcl-sys", "dep:widestring"]
 flame-it = ["flame"]
+
+__ssl-rustls = ["ssl", "rustls", "rustls-native-certs", "rustls-pemfile", "rustls-platform-verifier", "x509-cert", "x509-parser", "der", "pem-rfc7468", "webpki-roots", "oid-registry", "pkcs8"]
 
 [dependencies]
 # rustpython crates
@@ -113,7 +115,7 @@ openssl-probe = { workspace = true, optional = true }
 foreign-types-shared = { workspace = true, optional = true }
 
 # Rustls dependencies (optional, for ssl-rustls feature)
-rustls = { workspace = true, default-features = false, features = ["std", "tls12", "aws_lc_rs"], optional = true }
+rustls = { workspace = true, default-features = false, features = ["std", "tls12", ], optional = true }
 rustls-native-certs = { workspace = true, optional = true }
 rustls-pemfile = { workspace = true, optional = true }
 rustls-platform-verifier = { workspace = true, optional = true }

--- a/crates/stdlib/Cargo.toml
+++ b/crates/stdlib/Cargo.toml
@@ -16,11 +16,9 @@ host_env = ["rustpython-vm/host_env"]
 compiler = ["rustpython-vm/compiler"]
 threading = ["rustpython-common/threading", "rustpython-vm/threading"]
 sqlite = ["dep:libsqlite3-sys"]
-# SSL backends - default to rustls
-ssl = []
-ssl-rustls-aws-lc = ["__ssl-rustls", "rustls/aws_lc_rs"]
-ssl-rustls-aws-lc-fips = ["ssl-rustls-aws-lc", "aws-lc-rs", "aws-lc-rs/fips"]
-ssl-rustls-no-provider = ["__ssl-rustls", "rustls/custom-provider"]
+# SSL backends
+ssl = ["host_env"]
+ssl-rustls = ["__ssl-rustls", "rustls/custom-provider"]
 ssl-openssl = ["ssl", "openssl", "openssl-sys", "foreign-types-shared", "openssl-probe"]
 ssl-vendor = ["ssl-openssl", "openssl/vendored"]
 tkinter = ["dep:tk-sys", "dep:tcl-sys", "dep:widestring"]
@@ -125,7 +123,6 @@ x509-parser = { workspace = true, optional = true }
 der = { workspace = true, optional = true }
 pem-rfc7468 = { workspace = true, features = ["alloc"], optional = true }
 webpki-roots = { workspace = true, optional = true }
-aws-lc-rs = { workspace = true, optional = true }
 oid-registry = { workspace = true, features = ["x509", "pkcs1", "nist_algs"], optional = true }
 pkcs8 = { workspace = true, features = ["encryption", "pkcs5", "pem"], optional = true }
 

--- a/crates/stdlib/Cargo.toml
+++ b/crates/stdlib/Cargo.toml
@@ -18,8 +18,9 @@ threading = ["rustpython-common/threading", "rustpython-vm/threading"]
 sqlite = ["dep:libsqlite3-sys"]
 # SSL backends - default to rustls
 ssl = []
-ssl-rustls = ["__ssl-rustls", "rustls/aws_lc_rs", "aws-lc-rs"]
-ssl-rustls-fips = ["__ssl-rustls", "rustls/aws_lc_rs", "aws-lc-rs", "aws-lc-rs/fips"]
+ssl-rustls-aws-lc = ["__ssl-rustls", "rustls/aws_lc_rs"]
+ssl-rustls-aws-lc-fips = ["ssl-rustls-aws-lc", "aws-lc-rs", "aws-lc-rs/fips"]
+ssl-rustls-no-provider = ["__ssl-rustls", "rustls/custom-provider"]
 ssl-openssl = ["ssl", "openssl", "openssl-sys", "foreign-types-shared", "openssl-probe"]
 ssl-vendor = ["ssl-openssl", "openssl/vendored"]
 tkinter = ["dep:tk-sys", "dep:tcl-sys", "dep:widestring"]
@@ -115,7 +116,7 @@ openssl-probe = { workspace = true, optional = true }
 foreign-types-shared = { workspace = true, optional = true }
 
 # Rustls dependencies (optional, for ssl-rustls feature)
-rustls = { workspace = true, default-features = false, features = ["std", "tls12", ], optional = true }
+rustls = { workspace = true, default-features = false, features = ["std", "tls12"], optional = true }
 rustls-native-certs = { workspace = true, optional = true }
 rustls-pemfile = { workspace = true, optional = true }
 rustls-platform-verifier = { workspace = true, optional = true }

--- a/crates/stdlib/src/lib.rs
+++ b/crates/stdlib/src/lib.rs
@@ -130,14 +130,10 @@ mod openssl;
     not(target_arch = "wasm32"),
     feature = "__ssl-rustls"
 ))]
-mod ssl;
+pub mod ssl;
 
-#[cfg(all(feature = "ssl-openssl", feature = "ssl-rustls", not(clippy)))]
-compile_error!(r#"features "ssl-openssl" and "ssl-rustls" are mutually exclusive"#);
-#[cfg(all(feature = "ssl-rustls-aws-lc-rs", feature = "ssl-rustls-ring"))]
-compile_error!(
-    "features \"ssl-rustls-aws-lc-rs\" (also enabled transitively by \"ssl-rustls-fips\") and \"ssl-rustls-ring\" are mutually exclusive; pick exactly one rustls crypto backend"
-);
+#[cfg(all(feature = "ssl-openssl", feature = "__ssl-rustls", not(clippy)))]
+compile_error!(r#"features "ssl-openssl" and "ssl-rustls-*" are mutually exclusive"#);
 
 #[cfg(all(
     feature = "host_env",

--- a/crates/stdlib/src/lib.rs
+++ b/crates/stdlib/src/lib.rs
@@ -128,12 +128,16 @@ mod openssl;
 #[cfg(all(
     feature = "host_env",
     not(target_arch = "wasm32"),
-    feature = "ssl-rustls"
+    feature = "__ssl-rustls"
 ))]
 mod ssl;
 
 #[cfg(all(feature = "ssl-openssl", feature = "ssl-rustls", not(clippy)))]
 compile_error!(r#"features "ssl-openssl" and "ssl-rustls" are mutually exclusive"#);
+#[cfg(all(feature = "ssl-rustls-aws-lc-rs", feature = "ssl-rustls-ring"))]
+compile_error!(
+    "features \"ssl-rustls-aws-lc-rs\" (also enabled transitively by \"ssl-rustls-fips\") and \"ssl-rustls-ring\" are mutually exclusive; pick exactly one rustls crypto backend"
+);
 
 #[cfg(all(
     feature = "host_env",
@@ -246,7 +250,7 @@ pub fn stdlib_module_defs(ctx: &Context) -> Vec<&'static builtins::PyModuleDef> 
         #[cfg(all(
             feature = "host_env",
             not(target_arch = "wasm32"),
-            feature = "ssl-rustls"
+            feature = "__ssl-rustls"
         ))]
         ssl::module_def(ctx),
         statistics::module_def(ctx),

--- a/crates/stdlib/src/lib.rs
+++ b/crates/stdlib/src/lib.rs
@@ -133,7 +133,7 @@ mod openssl;
 pub mod ssl;
 
 #[cfg(all(feature = "ssl-openssl", feature = "__ssl-rustls", not(clippy)))]
-compile_error!(r#"features "ssl-openssl" and "ssl-rustls-*" are mutually exclusive"#);
+compile_error!(r#"features "ssl-openssl" and "ssl-rustls" are mutually exclusive"#);
 
 #[cfg(all(
     feature = "host_env",

--- a/crates/stdlib/src/openssl.rs
+++ b/crates/stdlib/src/openssl.rs
@@ -2292,12 +2292,17 @@ mod _ssl {
             self.0.get_timeout().map(|d| Instant::now() + d)
         }
 
-        fn select(&self, needs: SslNeeds, deadline: &SocketDeadline) -> SelectRet {
+        fn select(
+            &self,
+            needs: SslNeeds,
+            deadline: &SocketDeadline,
+            vm: &VirtualMachine,
+        ) -> SelectRet {
             let sock = match self.0.sock_opt() {
                 Some(s) => s,
                 None => return SelectRet::Closed,
             };
-            // For blocking sockets without timeout, call sock_select with None timeout
+            // For blocking sockets without timeout, call sock_wait with None timeout
             // to actually block waiting for data instead of busy-looping
             let timeout = match &deadline {
                 Ok(deadline) => match deadline.checked_duration_since(Instant::now()) {
@@ -2307,13 +2312,14 @@ mod _ssl {
                 Err(true) => None, // Blocking: no timeout, wait indefinitely
                 Err(false) => return SelectRet::Nonblocking,
             };
-            let res = socket::sock_select(
+            let res = socket::sock_wait(
                 &sock,
                 match needs {
-                    SslNeeds::Read => socket::SelectKind::Read,
-                    SslNeeds::Write => socket::SelectKind::Write,
+                    SslNeeds::Read => socket::SockWaitKind::Read,
+                    SslNeeds::Write => socket::SockWaitKind::Write,
                 },
                 timeout,
+                vm,
             );
             match res {
                 Ok(true) => SelectRet::TimedOut,
@@ -2325,13 +2331,14 @@ mod _ssl {
             &self,
             err: &ssl::Error,
             deadline: &SocketDeadline,
+            vm: &VirtualMachine,
         ) -> (Option<SslNeeds>, SelectRet) {
             let needs = match err.code() {
                 ssl::ErrorCode::WANT_READ => Some(SslNeeds::Read),
                 ssl::ErrorCode::WANT_WRITE => Some(SslNeeds::Write),
                 _ => None,
             };
-            let state = needs.map_or(SelectRet::Ok, |needs| self.select(needs, deadline));
+            let state = needs.map_or(SelectRet::Ok, |needs| self.select(needs, deadline, vm));
             (needs, state)
         }
     }
@@ -2850,7 +2857,7 @@ mod _ssl {
                         break;
                     }
                     // Wait briefly for peer's close_notify before retrying
-                    match socket_stream.select(SslNeeds::Read, &deadline) {
+                    match socket_stream.select(SslNeeds::Read, &deadline, vm) {
                         SelectRet::TimedOut => {
                             return Err(socket::timeout_error_msg(
                                 vm,
@@ -2888,7 +2895,7 @@ mod _ssl {
                 };
 
                 // Wait on the socket
-                match socket_stream.select(needs, &deadline) {
+                match socket_stream.select(needs, &deadline, vm) {
                     SelectRet::TimedOut => {
                         let msg = if err == sys::SSL_ERROR_WANT_READ {
                             "The read operation timed out"
@@ -2984,7 +2991,7 @@ mod _ssl {
                 let (needs, state) = stream
                     .get_ref()
                     .expect("handshake called in bio mode; should only be called in socket mode")
-                    .socket_needs(&err, &timeout);
+                    .socket_needs(&err, &timeout, vm);
                 match state {
                     SelectRet::TimedOut => {
                         // Clean up SNI ex_data before returning error
@@ -3038,7 +3045,7 @@ mod _ssl {
                 .get_ref()
                 .expect("write called in bio mode; should only be called in socket mode");
             let timeout = socket_ref.timeout_deadline();
-            let state = socket_ref.select(SslNeeds::Write, &timeout);
+            let state = socket_ref.select(SslNeeds::Write, &timeout, vm);
             match state {
                 SelectRet::TimedOut => {
                     return Err(socket::timeout_error_msg(
@@ -3058,7 +3065,7 @@ mod _ssl {
                 let (needs, state) = stream
                     .get_ref()
                     .expect("write called in bio mode; should only be called in socket mode")
-                    .socket_needs(&err, &timeout);
+                    .socket_needs(&err, &timeout, vm);
                 match state {
                     SelectRet::TimedOut => {
                         return Err(socket::timeout_error_msg(
@@ -3229,7 +3236,7 @@ mod _ssl {
                     let (needs, state) = stream
                         .get_ref()
                         .expect("read called in bio mode; should only be called in socket mode")
-                        .socket_needs(&err, &timeout);
+                        .socket_needs(&err, &timeout, vm);
                     match state {
                         SelectRet::TimedOut => {
                             return Err(socket::timeout_error_msg(

--- a/crates/stdlib/src/ssl.rs
+++ b/crates/stdlib/src/ssl.rs
@@ -85,14 +85,8 @@ mod _ssl {
     };
     use sha2::{Digest, Sha256};
 
-    #[cfg(all(feature = "ssl-rustls-aws-lc-rs", feature = "ssl-rustls-ring"))]
-    compile_error!("Enable only one rustls provider: ssl-rustls-aws-lc-rs or ssl-rustls-ring");
-
-    #[cfg(feature = "ssl-rustls-aws-lc-rs")]
+    #[cfg(feature = "ssl-rustls")]
     use rustls::crypto::aws_lc_rs::{ALL_CIPHER_SUITES, Ticketer, sign};
-
-    #[cfg(feature = "ssl-rustls-ring")]
-    use rustls::crypto::ring::{ALL_CIPHER_SUITES, Ticketer, sign};
 
     // Import certificate operations module
     use super::cert;

--- a/crates/stdlib/src/ssl.rs
+++ b/crates/stdlib/src/ssl.rs
@@ -25,6 +25,9 @@ mod compat;
 // SSL exception types (shared with openssl backend)
 mod error;
 
+// Utilities for setting a Rustls cryptography provider.
+pub mod providers;
+
 pub(crate) use _ssl::module_def;
 
 #[allow(non_snake_case)]
@@ -85,9 +88,6 @@ mod _ssl {
     };
     use sha2::{Digest, Sha256};
 
-    #[cfg(feature = "ssl-rustls")]
-    use rustls::crypto::aws_lc_rs::{ALL_CIPHER_SUITES, Ticketer, sign};
-
     // Import certificate operations module
     use super::cert;
 
@@ -100,6 +100,8 @@ mod _ssl {
         create_client_config, create_server_config, curve_name_to_kx_group, extract_cipher_info,
         get_cipher_encryption_desc, is_blocking_io_error, normalize_cipher_name, ssl_do_handshake,
     };
+
+    use super::providers::CryptoExt;
 
     // Type aliases for better readability
     // Additional type alias for certificate/key pairs (SessionCache and SniCertName defined below)
@@ -638,7 +640,7 @@ mod _ssl {
             return Err("No cipher can be selected".to_string());
         }
 
-        let all_suites = ALL_CIPHER_SUITES;
+        let all_suites = CryptoExt::get_ext().all_ciphers_or_default();
         let mut selected = Vec::new();
 
         for part in cipher_str.split(':') {
@@ -1061,6 +1063,8 @@ mod _ssl {
 
         #[pymethod]
         fn load_cert_chain(&self, args: LoadCertChainArgs, vm: &VirtualMachine) -> PyResult<()> {
+            let crypto_ext = CryptoExt::get_ext();
+
             // Parse certfile argument (str or bytes) to path
             let cert_path = Self::parse_path_arg(&args.certfile, vm)?;
 
@@ -1203,7 +1207,7 @@ mod _ssl {
             }
 
             // Additional validation: Create CertifiedKey to ensure rustls accepts it
-            let signing_key = sign::any_supported_type(&key).map_err(|_| {
+            let signing_key = crypto_ext.any_supported_key(&key).map_err(|_| {
                 vm.new_os_subtype_error(
                     PySSLError::class(&vm.ctx).to_owned(),
                     None,
@@ -1525,7 +1529,8 @@ mod _ssl {
             // Dynamically generate cipher list from rustls ALL_CIPHER_SUITES
             // This automatically includes all cipher suites supported by the current rustls version
 
-            let cipher_list = ALL_CIPHER_SUITES
+            let cipher_list = CryptoExt::get_ext()
+                .all_ciphers_or_default()
                 .iter()
                 .map(|suite| {
                     // Extract cipher information using unified helper
@@ -2219,6 +2224,8 @@ mod _ssl {
             (protocol,): Self::Args,
             vm: &VirtualMachine,
         ) -> PyResult<Self> {
+            let crypto_ext = CryptoExt::get_ext();
+
             // Validate protocol
             match protocol {
                 PROTOCOL_TLS | PROTOCOL_TLS_CLIENT | PROTOCOL_TLS_SERVER | PROTOCOL_TLSv1_2
@@ -2311,7 +2318,7 @@ mod _ssl {
                 rustls_server_session_store: rustls::server::ServerSessionMemoryCache::new(
                     SSL_SESSION_CACHE_SIZE,
                 ),
-                server_ticketer: Ticketer::new()
+                server_ticketer: (crypto_ext.ticketer)()
                     .expect("Failed to create shared ticketer for TLS 1.2 session resumption"),
                 accept_count: AtomicUsize::new(0),
                 session_hits: AtomicUsize::new(0),
@@ -4877,10 +4884,6 @@ mod _ssl {
 
     #[pyfunction]
     fn RAND_bytes(n: i64, vm: &VirtualMachine) -> PyResult<PyBytesRef> {
-        compat::ensure_default_provider();
-        let default_provider =
-            CryptoProvider::get_default().expect("A CryptoProvider should have been set earlier");
-
         // Validate n is not negative
         if n < 0 {
             return Err(vm.new_value_error("num must be positive"));
@@ -4888,7 +4891,7 @@ mod _ssl {
 
         let n_usize = n as usize;
         let mut buf = vec![0u8; n_usize];
-        default_provider
+        CryptoExt::get_provider()
             .secure_random
             .fill(&mut buf)
             .map_err(|_| vm.new_os_error("Failed to generate random bytes"))?;

--- a/crates/stdlib/src/ssl.rs
+++ b/crates/stdlib/src/ssl.rs
@@ -40,7 +40,6 @@ mod _ssl {
             lock::{PyMutex, PyRwLock},
         },
         socket::{PySocket, SockWaitKind, sock_wait, timeout_error_msg},
-        ssl::compat,
         vm::{
             AsObject, Py, PyObject, PyObjectRef, PyPayload, PyRef, PyResult, TryFromObject,
             VirtualMachine,
@@ -80,7 +79,7 @@ mod _ssl {
     use rustls::{
         ClientConnection, Connection, HandshakeKind, RootCertStore, ServerConfig, ServerConnection,
         client::{ClientSessionMemoryCache, ClientSessionStore},
-        crypto::{CryptoProvider, SupportedKxGroup},
+        crypto::SupportedKxGroup,
         pki_types::{CertificateDer, CertificateRevocationListDer, PrivateKeyDer, ServerName},
         server::{ClientHello, ResolvesServerCert},
         sign::CertifiedKey,
@@ -4873,12 +4872,12 @@ mod _ssl {
 
     #[pyfunction]
     fn RAND_status() -> i32 {
-        1 // Always have good randomness with aws-lc-rs
+        1 // The configured rustls provider supplies cryptographic randomness.
     }
 
     #[pyfunction]
     fn RAND_add(_string: PyObjectRef, _entropy: f64) {
-        // No-op: aws-lc-rs handles its own entropy
+        // No-op: the configured rustls provider handles its own entropy.
         // Accept any type (str, bytes, bytearray)
     }
 
@@ -4900,7 +4899,7 @@ mod _ssl {
 
     #[pyfunction]
     fn RAND_pseudo_bytes(n: i64, vm: &VirtualMachine) -> PyResult<(PyBytesRef, bool)> {
-        // In rustls/aws-lc-rs, all random bytes are cryptographically strong
+        // Rustls providers expose cryptographically strong random bytes.
         let bytes = RAND_bytes(n, vm)?;
         Ok((bytes, true))
     }

--- a/crates/stdlib/src/ssl.rs
+++ b/crates/stdlib/src/ssl.rs
@@ -37,6 +37,7 @@ mod _ssl {
             lock::{PyMutex, PyRwLock},
         },
         socket::{PySocket, SockWaitKind, sock_wait, timeout_error_msg},
+        ssl::compat,
         vm::{
             AsObject, Py, PyObject, PyObjectRef, PyPayload, PyRef, PyResult, TryFromObject,
             VirtualMachine,
@@ -64,7 +65,6 @@ mod _ssl {
         sync::atomic::{AtomicUsize, Ordering},
         time::Duration,
     };
-    use rustls::crypto::aws_lc_rs::ALL_CIPHER_SUITES;
     use std::{
         collections::{HashMap, hash_map::DefaultHasher},
         io::BufRead,
@@ -77,13 +77,22 @@ mod _ssl {
     use rustls::{
         ClientConnection, Connection, HandshakeKind, RootCertStore, ServerConfig, ServerConnection,
         client::{ClientSessionMemoryCache, ClientSessionStore},
-        crypto::SupportedKxGroup,
+        crypto::{CryptoProvider, SupportedKxGroup},
         pki_types::{CertificateDer, CertificateRevocationListDer, PrivateKeyDer, ServerName},
         server::{ClientHello, ResolvesServerCert},
         sign::CertifiedKey,
         version::{TLS12, TLS13},
     };
     use sha2::{Digest, Sha256};
+
+    #[cfg(all(feature = "ssl-rustls-aws-lc-rs", feature = "ssl-rustls-ring"))]
+    compile_error!("Enable only one rustls provider: ssl-rustls-aws-lc-rs or ssl-rustls-ring");
+
+    #[cfg(feature = "ssl-rustls-aws-lc-rs")]
+    use rustls::crypto::aws_lc_rs::{ALL_CIPHER_SUITES, Ticketer, sign};
+
+    #[cfg(feature = "ssl-rustls-ring")]
+    use rustls::crypto::ring::{ALL_CIPHER_SUITES, Ticketer, sign};
 
     // Import certificate operations module
     use super::cert;
@@ -1200,15 +1209,14 @@ mod _ssl {
             }
 
             // Additional validation: Create CertifiedKey to ensure rustls accepts it
-            let signing_key =
-                rustls::crypto::aws_lc_rs::sign::any_supported_type(&key).map_err(|_| {
-                    vm.new_os_subtype_error(
-                        PySSLError::class(&vm.ctx).to_owned(),
-                        None,
-                        "[SSL: KEY_VALUES_MISMATCH] key values mismatch",
-                    )
-                    .upcast()
-                })?;
+            let signing_key = sign::any_supported_type(&key).map_err(|_| {
+                vm.new_os_subtype_error(
+                    PySSLError::class(&vm.ctx).to_owned(),
+                    None,
+                    "[SSL: KEY_VALUES_MISMATCH] key values mismatch",
+                )
+                .upcast()
+            })?;
 
             let certified_key = CertifiedKey::new(full_chain.clone(), signing_key);
             if certified_key.keys_match().is_err() {
@@ -2309,7 +2317,7 @@ mod _ssl {
                 rustls_server_session_store: rustls::server::ServerSessionMemoryCache::new(
                     SSL_SESSION_CACHE_SIZE,
                 ),
-                server_ticketer: rustls::crypto::aws_lc_rs::Ticketer::new()
+                server_ticketer: Ticketer::new()
                     .expect("Failed to create shared ticketer for TLS 1.2 session resumption"),
                 accept_count: AtomicUsize::new(0),
                 session_hits: AtomicUsize::new(0),
@@ -4875,7 +4883,9 @@ mod _ssl {
 
     #[pyfunction]
     fn RAND_bytes(n: i64, vm: &VirtualMachine) -> PyResult<PyBytesRef> {
-        use aws_lc_rs::rand::{SecureRandom, SystemRandom};
+        compat::ensure_default_provider();
+        let default_provider =
+            CryptoProvider::get_default().expect("A CryptoProvider should have been set earlier");
 
         // Validate n is not negative
         if n < 0 {
@@ -4883,9 +4893,10 @@ mod _ssl {
         }
 
         let n_usize = n as usize;
-        let rng = SystemRandom::new();
         let mut buf = vec![0u8; n_usize];
-        rng.fill(&mut buf)
+        default_provider
+            .secure_random
+            .fill(&mut buf)
             .map_err(|_| vm.new_os_error("Failed to generate random bytes"))?;
         Ok(PyBytesRef::from(vm.ctx.new_bytes(buf)))
     }

--- a/crates/stdlib/src/ssl/cert.rs
+++ b/crates/stdlib/src/ssl/cert.rs
@@ -24,6 +24,12 @@ use x509_parser::prelude::*;
 
 use super::_ssl::{VERIFY_X509_PARTIAL_CHAIN, VERIFY_X509_STRICT};
 
+#[cfg(feature = "ssl-rustls-aws-lc-rs")]
+use rustls::crypto::aws_lc_rs::sign;
+
+#[cfg(feature = "ssl-rustls-ring")]
+use rustls::crypto::ring::sign;
+
 // Certificate Verification Constants
 
 /// All supported signature schemes for certificate verification
@@ -1268,9 +1274,7 @@ pub(super) fn validate_cert_key_match(
 
     // For rustls, the actual validation happens when creating CertifiedKey
     // We can attempt to create a signing key to verify the key is valid
-    use rustls::crypto::aws_lc_rs::sign::any_supported_type;
-
-    match any_supported_type(private_key) {
+    match sign::any_supported_type(private_key) {
         Ok(_signing_key) => {
             // If we can create a signing key, the private key is valid
             // Rustls will validate the cert-key match when building config

--- a/crates/stdlib/src/ssl/cert.rs
+++ b/crates/stdlib/src/ssl/cert.rs
@@ -24,11 +24,8 @@ use x509_parser::prelude::*;
 
 use super::_ssl::{VERIFY_X509_PARTIAL_CHAIN, VERIFY_X509_STRICT};
 
-#[cfg(feature = "ssl-rustls-aws-lc-rs")]
+#[cfg(feature = "ssl-rustls")]
 use rustls::crypto::aws_lc_rs::sign;
-
-#[cfg(feature = "ssl-rustls-ring")]
-use rustls::crypto::ring::sign;
 
 // Certificate Verification Constants
 

--- a/crates/stdlib/src/ssl/cert.rs
+++ b/crates/stdlib/src/ssl/cert.rs
@@ -22,10 +22,10 @@ use rustpython_vm::{PyObjectRef, PyResult, VirtualMachine};
 use std::collections::HashSet;
 use x509_parser::prelude::*;
 
-use super::_ssl::{VERIFY_X509_PARTIAL_CHAIN, VERIFY_X509_STRICT};
-
-#[cfg(feature = "ssl-rustls")]
-use rustls::crypto::aws_lc_rs::sign;
+use super::{
+    compat::{VERIFY_X509_PARTIAL_CHAIN, VERIFY_X509_STRICT},
+    providers::CryptoExt,
+};
 
 // Certificate Verification Constants
 
@@ -1271,7 +1271,7 @@ pub(super) fn validate_cert_key_match(
 
     // For rustls, the actual validation happens when creating CertifiedKey
     // We can attempt to create a signing key to verify the key is valid
-    match sign::any_supported_type(private_key) {
+    match CryptoExt::get_ext().any_supported_key(private_key) {
         Ok(_signing_key) => {
             // If we can create a signing key, the private key is valid
             // Rustls will validate the cert-key match when building config

--- a/crates/stdlib/src/ssl/cert.rs
+++ b/crates/stdlib/src/ssl/cert.rs
@@ -23,7 +23,7 @@ use std::collections::HashSet;
 use x509_parser::prelude::*;
 
 use super::{
-    compat::{VERIFY_X509_PARTIAL_CHAIN, VERIFY_X509_STRICT},
+    _ssl::{VERIFY_X509_PARTIAL_CHAIN, VERIFY_X509_STRICT},
     providers::CryptoExt,
 };
 

--- a/crates/stdlib/src/ssl/compat.rs
+++ b/crates/stdlib/src/ssl/compat.rs
@@ -54,14 +54,8 @@ static INIT_PROVIDER: Once = Once::new();
 
 pub(super) fn ensure_default_provider() {
     INIT_PROVIDER.call_once(|| {
-        #[cfg(feature = "ssl-rustls-aws-lc-rs")]
         let _ = rustls::crypto::CryptoProvider::install_default(
             rustls::crypto::aws_lc_rs::default_provider(),
-        );
-
-        #[cfg(feature = "ssl-rustls-ring")]
-        let _ = rustls::crypto::CryptoProvider::install_default(
-            rustls::crypto::ring::default_provider(),
         );
     });
 }

--- a/crates/stdlib/src/ssl/compat.rs
+++ b/crates/stdlib/src/ssl/compat.rs
@@ -730,7 +730,6 @@ pub(super) fn create_client_config(options: ClientConfigOptions) -> Result<Clien
                 };
 
                 // Wrap with PartialChainVerifier if VERIFY_X509_PARTIAL_CHAIN is set
-                const VERIFY_X509_PARTIAL_CHAIN: i32 = 0x80000;
                 let verifier = if options.verify_flags & VERIFY_X509_PARTIAL_CHAIN != 0 {
                     use crate::ssl::cert::PartialChainVerifier;
                     Arc::new(PartialChainVerifier::new(

--- a/crates/stdlib/src/ssl/compat.rs
+++ b/crates/stdlib/src/ssl/compat.rs
@@ -20,19 +20,21 @@ use crate::vm::VirtualMachine;
 use alloc::sync::Arc;
 use parking_lot::RwLock as ParkingRwLock;
 use rustls::Connection;
-use rustls::RootCertStore;
-use rustls::client::ClientConfig;
-use rustls::crypto::SupportedKxGroup;
+use rustls::client::{ClientConfig, ClientConnection};
+use rustls::crypto::{CryptoProvider, SupportedKxGroup};
 use rustls::pki_types::{CertificateDer, CertificateRevocationListDer, PrivateKeyDer};
-use rustls::server::ResolvesServerCert;
-use rustls::server::ServerConfig;
+use rustls::server::{
+    ProducesTickets, ResolvesServerCert, ServerConfig, ServerConnection, WebPkiClientVerifier,
+};
 use rustls::sign::CertifiedKey;
+use rustls::{RootCertStore, SupportedCipherSuite};
 use rustpython_vm::builtins::{PyBaseException, PyBaseExceptionRef};
 use rustpython_vm::convert::IntoPyException;
 use rustpython_vm::function::ArgBytesLike;
 use rustpython_vm::{AsObject, Py, PyObjectRef, PyPayload, PyResult, TryFromObject};
 use std::io::Read;
-use std::sync::Once;
+
+use super::providers::CryptoExt;
 
 // Import PySSLSocket from parent module
 use super::_ssl::{PySSLSocket, SSL3_RT_MAX_PACKET_SIZE, VERIFY_X509_STRICT};
@@ -43,22 +45,15 @@ use super::error::{
     create_ssl_want_read_error, create_ssl_want_write_error, create_ssl_zero_return_error,
 };
 
-// CryptoProvider Initialization:
+// SSL Verification Flags
+/// VERIFY_X509_STRICT flag for RFC 5280 strict compliance
+/// When set, performs additional validation including AKI extension checks
+pub(super) const VERIFY_X509_STRICT: i32 = 0x20;
 
-/// Ensure the default CryptoProvider is installed (thread-safe, runs once)
-///
-/// This is necessary because rustls 0.23+ requires a process-level CryptoProvider
-/// to be installed before using default_provider(). We use Once to ensure this
-/// happens exactly once, even if called from multiple threads.
-static INIT_PROVIDER: Once = Once::new();
-
-pub(super) fn ensure_default_provider() {
-    INIT_PROVIDER.call_once(|| {
-        let _ = rustls::crypto::CryptoProvider::install_default(
-            rustls::crypto::aws_lc_rs::default_provider(),
-        );
-    });
-}
+/// VERIFY_X509_PARTIAL_CHAIN flag for partial chain validation
+/// When set, accept certificates if any certificate in the chain is in the trust store
+/// (not just root CAs). This matches OpenSSL's X509_V_FLAG_PARTIAL_CHAIN behavior.
+pub(super) const VERIFY_X509_PARTIAL_CHAIN: i32 = 0x80000;
 
 // OpenSSL Constants:
 
@@ -449,7 +444,7 @@ pub(super) struct ServerConfigOptions {
     /// Session storage for server-side session resumption
     pub session_storage: Option<Arc<rustls::server::ServerSessionMemoryCache>>,
     /// Shared ticketer for TLS 1.2 session tickets (stateless resumption)
-    pub ticketer: Option<Arc<dyn rustls::server::ProducesTickets>>,
+    pub ticketer: Option<Arc<dyn ProducesTickets>>,
 }
 
 /// Options for creating a client TLS configuration
@@ -482,13 +477,12 @@ pub(super) struct ClientConfigOptions {
 /// This helper function consolidates the duplicated CryptoProvider creation logic
 /// for both server and client configurations.
 fn create_custom_crypto_provider(
-    cipher_suites: Option<Vec<rustls::SupportedCipherSuite>>,
-    kx_groups: Option<Vec<&'static dyn rustls::crypto::SupportedKxGroup>>,
-) -> Arc<rustls::crypto::CryptoProvider> {
-    let default_provider = rustls::crypto::CryptoProvider::get_default()
-        .expect("A CryptoProvider should have been set earlier");
+    cipher_suites: Option<Vec<SupportedCipherSuite>>,
+    kx_groups: Option<Vec<&'static dyn SupportedKxGroup>>,
+) -> Arc<CryptoProvider> {
+    let default_provider = CryptoExt::get_provider();
 
-    Arc::new(rustls::crypto::CryptoProvider {
+    Arc::new(CryptoProvider {
         cipher_suites: cipher_suites.unwrap_or_else(|| default_provider.cipher_suites.clone()),
         kx_groups: kx_groups.unwrap_or_else(|| default_provider.kx_groups.clone()),
         signature_verification_algorithms: default_provider.signature_verification_algorithms,
@@ -502,11 +496,6 @@ fn create_custom_crypto_provider(
 /// This abstracts the complex rustls ServerConfig building logic,
 /// matching SSL_CTX initialization for server sockets.
 pub(super) fn create_server_config(options: ServerConfigOptions) -> Result<ServerConfig, String> {
-    use rustls::server::WebPkiClientVerifier;
-
-    // Ensure default CryptoProvider is installed
-    ensure_default_provider();
-
     // Create custom crypto provider using helper function
     let custom_provider = create_custom_crypto_provider(
         options.protocol_settings.cipher_suites.clone(),
@@ -684,9 +673,6 @@ fn apply_alpn_with_fallback(config_alpn: &mut Vec<Vec<u8>>, alpn_protocols: &[Ve
 /// This abstracts the complex rustls ClientConfig building logic,
 /// matching SSL_CTX initialization for client sockets.
 pub(super) fn create_client_config(options: ClientConfigOptions) -> Result<ClientConfig, String> {
-    // Ensure default CryptoProvider is installed
-    ensure_default_provider();
-
     // Create custom crypto provider using helper function
     let custom_provider = create_custom_crypto_provider(
         options.protocol_settings.cipher_suites.clone(),
@@ -2123,9 +2109,7 @@ pub(super) fn curve_name_to_kx_group(
     curve: &str,
 ) -> Result<Vec<&'static dyn SupportedKxGroup>, String> {
     // Get the default crypto provider's key exchange groups
-    let provider = rustls::crypto::CryptoProvider::get_default()
-        .expect("A CryptoProvider should have been set earlier");
-    let all_groups = &provider.kx_groups;
+    let all_groups = CryptoExt::get_ext().all_kx_or_default();
 
     match curve {
         // P-256 (also known as secp256r1 or prime256v1)

--- a/crates/stdlib/src/ssl/compat.rs
+++ b/crates/stdlib/src/ssl/compat.rs
@@ -20,12 +20,10 @@ use crate::vm::VirtualMachine;
 use alloc::sync::Arc;
 use parking_lot::RwLock as ParkingRwLock;
 use rustls::Connection;
-use rustls::client::{ClientConfig, ClientConnection};
+use rustls::client::ClientConfig;
 use rustls::crypto::{CryptoProvider, SupportedKxGroup};
 use rustls::pki_types::{CertificateDer, CertificateRevocationListDer, PrivateKeyDer};
-use rustls::server::{
-    ProducesTickets, ResolvesServerCert, ServerConfig, ServerConnection, WebPkiClientVerifier,
-};
+use rustls::server::{ProducesTickets, ResolvesServerCert, ServerConfig, WebPkiClientVerifier};
 use rustls::sign::CertifiedKey;
 use rustls::{RootCertStore, SupportedCipherSuite};
 use rustpython_vm::builtins::{PyBaseException, PyBaseExceptionRef};
@@ -37,23 +35,15 @@ use std::io::Read;
 use super::providers::CryptoExt;
 
 // Import PySSLSocket from parent module
-use super::_ssl::{PySSLSocket, SSL3_RT_MAX_PACKET_SIZE, VERIFY_X509_STRICT};
+use super::_ssl::{
+    PySSLSocket, SSL3_RT_MAX_PACKET_SIZE, VERIFY_X509_PARTIAL_CHAIN, VERIFY_X509_STRICT,
+};
 
 // Import error types and helper functions from error module
 use super::error::{
     PySSLCertVerificationError, PySSLError, create_ssl_eof_error, create_ssl_syscall_error,
     create_ssl_want_read_error, create_ssl_want_write_error, create_ssl_zero_return_error,
 };
-
-// SSL Verification Flags
-/// VERIFY_X509_STRICT flag for RFC 5280 strict compliance
-/// When set, performs additional validation including AKI extension checks
-pub(super) const VERIFY_X509_STRICT: i32 = 0x20;
-
-/// VERIFY_X509_PARTIAL_CHAIN flag for partial chain validation
-/// When set, accept certificates if any certificate in the chain is in the trust store
-/// (not just root CAs). This matches OpenSSL's X509_V_FLAG_PARTIAL_CHAIN behavior.
-pub(super) const VERIFY_X509_PARTIAL_CHAIN: i32 = 0x80000;
 
 // OpenSSL Constants:
 
@@ -2134,14 +2124,12 @@ pub(super) fn curve_name_to_kx_group(
             .map(|g| vec![*g])
             .ok_or_else(|| "X25519 not supported by crypto provider".to_owned()),
         // P-521 (also known as secp521r1 or prime521v1)
-        // Now supported with aws-lc-rs crypto provider
         "prime521v1" | "secp521r1" => all_groups
             .iter()
             .find(|g| g.name() == rustls::NamedGroup::secp521r1)
             .map(|g| vec![*g])
             .ok_or_else(|| "secp521r1 not supported by crypto provider".to_owned()),
         // X448
-        // Now supported with aws-lc-rs crypto provider
         "X448" | "x448" => all_groups
             .iter()
             .find(|g| g.name() == rustls::NamedGroup::X448)

--- a/crates/stdlib/src/ssl/compat.rs
+++ b/crates/stdlib/src/ssl/compat.rs
@@ -52,10 +52,16 @@ use super::error::{
 /// happens exactly once, even if called from multiple threads.
 static INIT_PROVIDER: Once = Once::new();
 
-fn ensure_default_provider() {
+pub(super) fn ensure_default_provider() {
     INIT_PROVIDER.call_once(|| {
+        #[cfg(feature = "ssl-rustls-aws-lc-rs")]
         let _ = rustls::crypto::CryptoProvider::install_default(
             rustls::crypto::aws_lc_rs::default_provider(),
+        );
+
+        #[cfg(feature = "ssl-rustls-ring")]
+        let _ = rustls::crypto::CryptoProvider::install_default(
+            rustls::crypto::ring::default_provider(),
         );
     });
 }
@@ -485,12 +491,12 @@ fn create_custom_crypto_provider(
     cipher_suites: Option<Vec<rustls::SupportedCipherSuite>>,
     kx_groups: Option<Vec<&'static dyn rustls::crypto::SupportedKxGroup>>,
 ) -> Arc<rustls::crypto::CryptoProvider> {
-    use rustls::crypto::aws_lc_rs::{ALL_CIPHER_SUITES, ALL_KX_GROUPS};
-    let default_provider = rustls::crypto::aws_lc_rs::default_provider();
+    let default_provider = rustls::crypto::CryptoProvider::get_default()
+        .expect("A CryptoProvider should have been set earlier");
 
     Arc::new(rustls::crypto::CryptoProvider {
-        cipher_suites: cipher_suites.unwrap_or_else(|| ALL_CIPHER_SUITES.to_vec()),
-        kx_groups: kx_groups.unwrap_or_else(|| ALL_KX_GROUPS.to_vec()),
+        cipher_suites: cipher_suites.unwrap_or_else(|| default_provider.cipher_suites.clone()),
+        kx_groups: kx_groups.unwrap_or_else(|| default_provider.kx_groups.clone()),
         signature_verification_algorithms: default_provider.signature_verification_algorithms,
         secure_random: default_provider.secure_random,
         key_provider: default_provider.key_provider,
@@ -2123,7 +2129,8 @@ pub(super) fn curve_name_to_kx_group(
     curve: &str,
 ) -> Result<Vec<&'static dyn SupportedKxGroup>, String> {
     // Get the default crypto provider's key exchange groups
-    let provider = rustls::crypto::aws_lc_rs::default_provider();
+    let provider = rustls::crypto::CryptoProvider::get_default()
+        .expect("A CryptoProvider should have been set earlier");
     let all_groups = &provider.kx_groups;
 
     match curve {

--- a/crates/stdlib/src/ssl/providers.rs
+++ b/crates/stdlib/src/ssl/providers.rs
@@ -1,0 +1,150 @@
+//! Utilities for user-settable cryptography providers.
+//!
+//! This has two main moving parts: [`CryptoProvider`] and [`CryptoExt`]. [`CryptoProvider`]
+//! is always implemented by the cryptography crate because it's a trait from Rustls. RustPython
+//! needs some extra data such as all of the cipher suites supported by an implementation.
+//! The [`CryptoExt`] table stores that extra data if it exists and provides convenience methods
+//! as a fallback.
+//!
+//! Both the [`CryptoProvider`] and [`CryptoExt`] are process-level structs that need to be
+//! set before any TLS operations. [`CryptoExt::set_provider`] is thread-safe and runs once. It
+//! sets both once per process.
+
+use alloc::sync::Arc;
+use std::sync::OnceLock;
+
+use rustls::{
+    Error, SignatureScheme, SupportedCipherSuite,
+    crypto::{CryptoProvider, SupportedKxGroup},
+    pki_types::PrivateKeyDer,
+    server::ProducesTickets,
+    sign::SigningKey,
+};
+
+static CRYPTO_EXT: OnceLock<CryptoExt> = OnceLock::new();
+
+#[derive(Clone, Copy)]
+pub struct CryptoExt {
+    pub all_cipher_suites: Option<&'static [SupportedCipherSuite]>,
+    pub all_kx_groups: Option<&'static [&'static dyn SupportedKxGroup]>,
+    #[allow(clippy::type_complexity)]
+    pub any_supported_key: Option<fn(&PrivateKeyDer<'_>) -> Result<Arc<dyn SigningKey>, Error>>,
+    pub ticketer: fn() -> Result<Arc<dyn ProducesTickets>, Error>,
+}
+
+impl CryptoExt {
+    #[inline]
+    #[must_use]
+    pub fn get_ext() -> &'static Self {
+        #[cfg(feature = "ssl-rustls-aws-lc")]
+        let _ = Self::set_aws_lc_provider();
+        CRYPTO_EXT
+            .get()
+            .expect("A CryptoProvider must be set before TLS")
+    }
+
+    #[inline]
+    #[must_use]
+    pub fn get_provider() -> &'static CryptoProvider {
+        #[cfg(feature = "ssl-rustls-aws-lc")]
+        let _ = Self::set_aws_lc_provider();
+        CryptoProvider::get_default().expect("A CryptoProvider must be set before TLS")
+    }
+
+    /// Returns all [`SupportedCipherSuite`] or the provider's defaults.
+    ///
+    /// # Panics
+    /// Panics if a [`CryptoProvider`] hasn't been set.
+    #[must_use]
+    pub fn all_ciphers_or_default(&self) -> &'static [SupportedCipherSuite] {
+        self.all_cipher_suites.unwrap_or_else(|| {
+            CryptoProvider::get_default()
+                .expect("A CryptoProvider has been set if CryptoExt is set")
+                .cipher_suites
+                .as_slice()
+        })
+    }
+
+    /// Returns all [`SupportedKxGroup`] or the provider's defaults.
+    ///
+    /// # Panics
+    /// Panics if a [`CryptoProvider`] hasn't been set.
+    #[must_use]
+    pub fn all_kx_or_default(&self) -> &'static [&'static dyn SupportedKxGroup] {
+        self.all_kx_groups.unwrap_or_else(|| {
+            CryptoProvider::get_default()
+                .expect("A CryptoProvider has been set if CryptoExt is set")
+                .kx_groups
+                .as_slice()
+        })
+    }
+
+    /// Return the first supported [`SigningKey`] for a [`PrivateKeyDer`].
+    ///
+    /// Ideally, this function should be provided by the backend implementation or
+    /// the user. This fallback filters out insecure algorithms then picks the first available key
+    /// if it exists.
+    ///
+    /// # Panics
+    /// Panics if a [`CryptoProvider`] hasn't been set.
+    pub fn any_supported_key(&self, der: &PrivateKeyDer<'_>) -> Result<Arc<dyn SigningKey>, Error> {
+        self.any_supported_key.map_or_else(
+            || {
+                let provider = CryptoProvider::get_default()
+                    .expect("A CryptoProvider has been set if CryptoExt is set");
+                let key = provider.key_provider.load_private_key(der.clone_key())?;
+
+                for scheme in provider
+                    .signature_verification_algorithms
+                    .mapping
+                    .iter()
+                    .filter_map(|(scheme, _)| {
+                        (!matches!(
+                            scheme,
+                            SignatureScheme::RSA_PKCS1_SHA1
+                                | SignatureScheme::ECDSA_SHA1_Legacy
+                                | SignatureScheme::Unknown(_),
+                        ))
+                        .then_some(*scheme)
+                    })
+                {
+                    if key.choose_scheme(&[scheme]).is_some() {
+                        return Ok(key);
+                    }
+                }
+
+                Err(Error::General(
+                    "failed to parse private key as RSA, ECDSA, or EdDSA".into(),
+                ))
+            },
+            |f| f(der),
+        )
+    }
+
+    /// Set a process-level [`CryptoProvider`] and [`CryptoExt`].
+    ///
+    /// A provider must be set before any cryptographic operations. All crypto ops panic if a provider
+    /// is unset. See [`Self::set_aws_lc_provider`] for the default provider.
+    pub fn set_provider(provider: CryptoProvider, extension: CryptoExt) -> Result<(), Error> {
+        provider
+            .install_default()
+            .map_err(|_| Error::General("A default CryptoProvider is already set".into()))?;
+        CRYPTO_EXT
+            .set(extension)
+            .map_err(|_| Error::General("A CryptoExt is already set".into()))
+    }
+
+    /// Use AWS-LC as the default cryptography provider.
+    #[cfg(feature = "ssl-rustls-aws-lc")]
+    pub fn set_aws_lc_provider() -> Result<(), Error> {
+        use rustls::crypto::aws_lc_rs;
+        let provider = aws_lc_rs::default_provider();
+        let ext = CryptoExt {
+            all_cipher_suites: Some(aws_lc_rs::ALL_CIPHER_SUITES),
+            all_kx_groups: Some(aws_lc_rs::ALL_KX_GROUPS),
+            any_supported_key: Some(aws_lc_rs::sign::any_supported_type),
+            ticketer: aws_lc_rs::Ticketer::new,
+        };
+        Self::set_provider(provider, ext)
+    }
+}

--- a/crates/stdlib/src/ssl/providers.rs
+++ b/crates/stdlib/src/ssl/providers.rs
@@ -7,8 +7,8 @@
 //! as a fallback.
 //!
 //! Both the [`CryptoProvider`] and [`CryptoExt`] are process-level structs that need to be
-//! set before any TLS operations. [`CryptoExt::set_provider`] is thread-safe and runs once. It
-//! sets both once per process.
+//! set before any TLS operations. [`CryptoExt::set_provider`] is thread-safe and runs once.
+//! It sets both once per process.
 
 use alloc::sync::Arc;
 use std::sync::OnceLock;
@@ -36,8 +36,6 @@ impl CryptoExt {
     #[inline]
     #[must_use]
     pub fn get_ext() -> &'static Self {
-        #[cfg(feature = "ssl-rustls-aws-lc")]
-        let _ = Self::set_aws_lc_provider();
         CRYPTO_EXT
             .get()
             .expect("A CryptoProvider must be set before TLS")
@@ -46,8 +44,6 @@ impl CryptoExt {
     #[inline]
     #[must_use]
     pub fn get_provider() -> &'static CryptoProvider {
-        #[cfg(feature = "ssl-rustls-aws-lc")]
-        let _ = Self::set_aws_lc_provider();
         CryptoProvider::get_default().expect("A CryptoProvider must be set before TLS")
     }
 
@@ -124,27 +120,13 @@ impl CryptoExt {
     /// Set a process-level [`CryptoProvider`] and [`CryptoExt`].
     ///
     /// A provider must be set before any cryptographic operations. All crypto ops panic if a provider
-    /// is unset. See [`Self::set_aws_lc_provider`] for the default provider.
-    pub fn set_provider(provider: CryptoProvider, extension: CryptoExt) -> Result<(), Error> {
+    /// is unset.
+    pub fn set_provider(provider: CryptoProvider, extension: Self) -> Result<(), Error> {
         provider
             .install_default()
             .map_err(|_| Error::General("A default CryptoProvider is already set".into()))?;
         CRYPTO_EXT
             .set(extension)
             .map_err(|_| Error::General("A CryptoExt is already set".into()))
-    }
-
-    /// Use AWS-LC as the default cryptography provider.
-    #[cfg(feature = "ssl-rustls-aws-lc")]
-    pub fn set_aws_lc_provider() -> Result<(), Error> {
-        use rustls::crypto::aws_lc_rs;
-        let provider = aws_lc_rs::default_provider();
-        let ext = CryptoExt {
-            all_cipher_suites: Some(aws_lc_rs::ALL_CIPHER_SUITES),
-            all_kx_groups: Some(aws_lc_rs::ALL_KX_GROUPS),
-            any_supported_key: Some(aws_lc_rs::sign::any_supported_type),
-            ticketer: aws_lc_rs::Ticketer::new,
-        };
-        Self::set_provider(provider, ext)
     }
 }

--- a/examples/custom_tls_providers.rs
+++ b/examples/custom_tls_providers.rs
@@ -1,0 +1,65 @@
+//! Example project to demonstrate how to set a custom rustls provider for RustPython.
+
+// spell-checker: ignore graviola
+
+use std::env;
+
+use rustls::crypto::ring;
+use rustpython_pylib::FROZEN_STDLIB;
+use rustpython_stdlib::{ssl::providers::CryptoExt, stdlib_module_defs};
+use rustpython_vm::Interpreter;
+
+const SCRIPT: &str = r#"
+import urllib.request
+
+with urllib.request.urlopen("https://python.org") as response:
+    assert response.status == 200
+"#;
+
+fn main() {
+    let provider = env::args()
+        .skip(1)
+        .find_map(|arg| match &*arg {
+            "--ring" => Some("ring"),
+            "--graviola" => Some("graviola"),
+            _ => None,
+        })
+        .unwrap_or("ring");
+
+    match provider {
+        "ring" => {
+            let ext = CryptoExt {
+                all_cipher_suites: Some(ring::ALL_CIPHER_SUITES),
+                all_kx_groups: Some(ring::ALL_KX_GROUPS),
+                any_supported_key: Some(ring::sign::any_supported_type),
+                ticketer: ring::Ticketer::new,
+            };
+            CryptoExt::set_provider(ring::default_provider(), ext).unwrap();
+            println!("Using ring for cryptography");
+        }
+        "graviola" => {
+            let ext = CryptoExt {
+                all_cipher_suites: Some(rustls_graviola::suites::ALL_CIPHER_SUITES),
+                all_kx_groups: Some(rustls_graviola::kx::ALL_KX_GROUPS),
+                any_supported_key: None,
+                ticketer: rustls_graviola::Ticketer::new,
+            };
+            CryptoExt::set_provider(rustls_graviola::default_provider(), ext).unwrap();
+            println!("Using Graviola for cryptography");
+        }
+        unsupported => panic!("Unsupported provider: {unsupported}"),
+    }
+
+    let builder = Interpreter::builder(Default::default());
+    let defs = stdlib_module_defs(&builder.ctx);
+    let result = builder
+        .add_native_modules(&defs)
+        .add_frozen_modules(FROZEN_STDLIB)
+        .build()
+        .run(|vm| {
+            let scope = vm.new_scope_with_builtins();
+            vm.run_block_expr(scope, SCRIPT).map(|_| ())
+        });
+
+    assert_eq!(0, result);
+}

--- a/src/interpreter.rs
+++ b/src/interpreter.rs
@@ -14,6 +14,8 @@ impl InterpreterBuilderExt for InterpreterBuilder {
     fn init_stdlib(self) -> Self {
         let defs = rustpython_stdlib::stdlib_module_defs(&self.ctx);
         let builder = self.add_native_modules(&defs);
+        #[cfg(all(feature = "ssl-rustls-aws-lc", not(target_arch = "wasm32")))]
+        let builder = builder.init_hook(install_default_tls_provider);
 
         cfg_select! {
             feature = "freeze-stdlib" => {
@@ -24,6 +26,20 @@ impl InterpreterBuilderExt for InterpreterBuilder {
             _ => builder.init_hook(setup_dynamic_stdlib),
         }
     }
+}
+
+#[cfg(all(feature = "ssl-rustls-aws-lc", not(target_arch = "wasm32")))]
+fn install_default_tls_provider(_vm: &mut crate::VirtualMachine) {
+    use rustls::crypto::aws_lc_rs;
+    use rustpython_stdlib::ssl::providers::CryptoExt;
+
+    let ext = CryptoExt {
+        all_cipher_suites: Some(aws_lc_rs::ALL_CIPHER_SUITES),
+        all_kx_groups: Some(aws_lc_rs::ALL_KX_GROUPS),
+        any_supported_key: Some(aws_lc_rs::sign::any_supported_type),
+        ticketer: aws_lc_rs::Ticketer::new,
+    };
+    let _ = CryptoExt::set_provider(aws_lc_rs::default_provider(), ext);
 }
 
 /// Set stdlib_dir for frozen standard library

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -71,7 +71,11 @@ pub use shell::run_shell;
 
 #[cfg(all(
     feature = "ssl",
-    not(any(feature = "ssl-rustls", feature = "ssl-openssl"))
+    not(any(
+        feature = "ssl-rustls",
+        feature = "ssl-rustls-ring",
+        feature = "ssl-openssl"
+    ))
 ))]
 compile_error!(
     "Feature \"ssl\" is now enabled by either \"ssl-rustls\" or \"ssl-openssl\" to be enabled. Do not manually pass \"ssl\" feature. To enable ssl-openssl, use --no-default-features to disable ssl-rustls"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -71,10 +71,14 @@ pub use shell::run_shell;
 
 #[cfg(all(
     feature = "ssl",
-    not(any(feature = "ssl-rustls", feature = "ssl-openssl"))
+    not(any(
+        feature = "ssl-rustls-aws-lc",
+        feature = "ssl-rustls-no-provider",
+        feature = "ssl-openssl"
+    ))
 ))]
 compile_error!(
-    "Feature \"ssl\" is now enabled by either \"ssl-rustls\" or \"ssl-openssl\" to be enabled. Do not manually pass \"ssl\" feature. To enable ssl-openssl, use --no-default-features to disable ssl-rustls"
+    "Feature \"ssl\" is now enabled by either \"ssl-rustls-{aws-lc, no-provider}\" or \"ssl-openssl\" to be enabled. Do not manually pass \"ssl\" feature. To enable ssl-openssl, use --no-default-features to disable ssl-rustls-*"
 );
 
 /// The main cli of the `rustpython` interpreter. This function will return `std::process::ExitCode`

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -71,11 +71,7 @@ pub use shell::run_shell;
 
 #[cfg(all(
     feature = "ssl",
-    not(any(
-        feature = "ssl-rustls",
-        feature = "ssl-rustls-ring",
-        feature = "ssl-openssl"
-    ))
+    not(any(feature = "ssl-rustls", feature = "ssl-openssl"))
 ))]
 compile_error!(
     "Feature \"ssl\" is now enabled by either \"ssl-rustls\" or \"ssl-openssl\" to be enabled. Do not manually pass \"ssl\" feature. To enable ssl-openssl, use --no-default-features to disable ssl-rustls"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -71,14 +71,10 @@ pub use shell::run_shell;
 
 #[cfg(all(
     feature = "ssl",
-    not(any(
-        feature = "ssl-rustls-aws-lc",
-        feature = "ssl-rustls-no-provider",
-        feature = "ssl-openssl"
-    ))
+    not(any(feature = "ssl-rustls", feature = "ssl-openssl"))
 ))]
 compile_error!(
-    "Feature \"ssl\" is now enabled by either \"ssl-rustls-{aws-lc, no-provider}\" or \"ssl-openssl\" to be enabled. Do not manually pass \"ssl\" feature. To enable ssl-openssl, use --no-default-features to disable ssl-rustls-*"
+    "Feature \"ssl\" is now enabled by either \"ssl-rustls\" or \"ssl-openssl\". Do not manually pass \"ssl\" feature. To enable ssl-openssl, use --no-default-features to disable ssl-rustls*"
 );
 
 /// The main cli of the `rustpython` interpreter. This function will return `std::process::ExitCode`


### PR DESCRIPTION
`rustls`'s architecture is very clean and trait-driven. There are many providers for `rustls` including the built-in `aws-lc-rs` and `ring` as well as backends for `boringssl`, `graviola`, `openssl`, `mbedtls`, etc.

The new feature, `ssl-rustls-no-provider`, enables custom rustls providers. By default, `aws-lc-rs` is enabled which matches the old behavior and keeps backward compatibility.

I wrote a new type that abstracts what we need from crypto providers. CryptoExt encapsulates the ticketer as well as cipher suites and KX groups. I wrote fallbacks to help select a reasonable default if a provider is missing features (they all seem to support the same things though).

I also wrote an example to show how to actually use custom providers.

Closes: #7059

---

`aws-lc-rs` is still the default, so this patch should be transparent to all users.

I tested with:

```sh
cargo build
target/debug/rustpython Lib/test/test_ssl.py
```

And:

(todo, test with example!)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Pluggable SSL/TLS crypto providers so users can choose custom cryptographic backends.
  * New feature option to run Rustls without a bundled provider.
  * Added an example showing how to select and run with different TLS providers.

* **Chores**
  * Updated feature defaults to favor the aws-lc-backed Rustls option.
  * Adjusted build/test workflows and feature wiring to support the new provider options.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/RustPython/RustPython/pull/7657)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->