### PR TITLE
Fix pyclass memory layout to prevent silent UB in inherited getter dispatch

### DIFF
--- a/crates/derive-impl/src/pyclass.rs
+++ b/crates/derive-impl/src/pyclass.rs
@@ -387,8 +387,7 @@ fn ensure_repr_c(mut item: Item) -> Item {
     };
     let has_repr = s.attrs.iter().any(|attr| attr.path().is_ident("repr"));
     if !has_repr {
-        let repr_c: syn::Attribute = parse_quote!(#[repr(C)]);
-        s.attrs.push(repr_c);
+        s.attrs.push(parse_quote!(#[repr(C)]));
     }
     item
 }

--- a/crates/derive-impl/src/pyclass.rs
+++ b/crates/derive-impl/src/pyclass.rs
@@ -573,14 +573,20 @@ pub(crate) fn impl_pyclass(attr: PunctuatedNestedMeta, item: Item) -> Result<Tok
     let fake_ident = Ident::new("pyclass", item.span());
     let (class_meta, class_name, module_name, base, metaclass, unhashable) = {
         let (ident, _) = pyclass_ident_and_attrs(&item)?;
-        let class_meta =
-            ClassItemMeta::from_nested(ident.clone(), fake_ident, attr.into_iter())?;
+        let class_meta = ClassItemMeta::from_nested(ident.clone(), fake_ident, attr.into_iter())?;
         let class_name = class_meta.class_name()?;
         let module_name = class_meta.module()?;
         let base = class_meta.base()?;
         let metaclass = class_meta.metaclass()?;
         let unhashable = class_meta.unhashable()?;
-        (class_meta, class_name, module_name, base, metaclass, unhashable)
+        (
+            class_meta,
+            class_name,
+            module_name,
+            base,
+            metaclass,
+            unhashable,
+        )
     };
 
     // When a base is specified:

--- a/crates/derive-impl/src/pyclass.rs
+++ b/crates/derive-impl/src/pyclass.rs
@@ -318,12 +318,13 @@ pub(crate) fn impl_pyclass_impl(attr: PunctuatedNestedMeta, item: Item) -> Resul
     Ok(tokens)
 }
 
-/// Validates that when a base class is specified, the struct has the base type as its first field.
-/// This ensures proper memory layout for subclassing (required for #[repr(transparent)] to work correctly).
-fn validate_base_field(item: &Item, base_path: &syn::Path) -> Result<()> {
+/// Validates that when a base class is specified, the struct has the base type as its first
+/// *declared* field.  Returns a token naming that field (e.g. `_base` or `0` for tuple structs)
+/// so the caller can emit a compile-time `offset_of!` assertion, or `None` for non-structs.
+fn validate_base_field(item: &Item, base_path: &syn::Path) -> Result<Option<TokenStream>> {
     let Item::Struct(item_struct) = item else {
         // Only validate structs - enums with base are already an error elsewhere
-        return Ok(());
+        return Ok(None);
     };
 
     // Get the base type name for error messages
@@ -347,6 +348,8 @@ fn validate_base_field(item: &Item, base_path: &syn::Path) -> Result<()> {
                     "#[pyclass] with base = {base_name} requires the first field to be of type {base_name}"
                 );
             }
+            let ident = first_field.ident.as_ref().map(|id| quote! { #id });
+            Ok(ident)
         }
         syn::Fields::Unnamed(fields) => {
             let Some(first_field) = fields.unnamed.first() else {
@@ -361,6 +364,7 @@ fn validate_base_field(item: &Item, base_path: &syn::Path) -> Result<()> {
                     "#[pyclass] with base = {base_name} requires the first field to be of type {base_name}"
                 );
             }
+            Ok(Some(quote! { 0 }))
         }
         syn::Fields::Unit => {
             bail_span!(
@@ -369,8 +373,24 @@ fn validate_base_field(item: &Item, base_path: &syn::Path) -> Result<()> {
             );
         }
     }
+}
 
-    Ok(())
+/// Adds `#[repr(C)]` to a derived pyclass struct when no explicit `#[repr(…)]` is present.
+///
+/// The inherited getter dispatcher reinterprets the derived object pointer as `*Base`, which
+/// is only valid when the base field is at offset 0.  Under `#[repr(Rust)]` the compiler may
+/// reorder fields to minimise padding, silently displacing the base field.  `#[repr(C)]`
+/// preserves declaration order, guaranteeing offset 0 for the first field.
+fn ensure_repr_c(mut item: Item) -> Item {
+    let Item::Struct(ref mut s) = item else {
+        return item;
+    };
+    let has_repr = s.attrs.iter().any(|attr| attr.path().is_ident("repr"));
+    if !has_repr {
+        let repr_c: syn::Attribute = parse_quote!(#[repr(C)]);
+        s.attrs.push(repr_c);
+    }
+    item
 }
 
 /// Check if a type matches a given path (handles simple cases like `Foo` or `path::to::Foo`)
@@ -549,19 +569,54 @@ pub(crate) fn impl_pyclass(attr: PunctuatedNestedMeta, item: Item) -> Result<Tok
     if matches!(item, syn::Item::Use(_)) {
         return Ok(quote!(#item));
     }
-    let (ident, attrs) = pyclass_ident_and_attrs(&item)?;
-    let fake_ident = Ident::new("pyclass", item.span());
-    let class_meta = ClassItemMeta::from_nested(ident.clone(), fake_ident, attr.into_iter())?;
-    let class_name = class_meta.class_name()?;
-    let module_name = class_meta.module()?;
-    let base = class_meta.base()?;
-    let metaclass = class_meta.metaclass()?;
-    let unhashable = class_meta.unhashable()?;
 
-    // Validate that if base is specified, the first field must be of the base type
-    if let Some(ref base_path) = base {
-        validate_base_field(&item, base_path)?;
-    }
+    let fake_ident = Ident::new("pyclass", item.span());
+    let (class_meta, class_name, module_name, base, metaclass, unhashable) = {
+        let (ident, _) = pyclass_ident_and_attrs(&item)?;
+        let class_meta =
+            ClassItemMeta::from_nested(ident.clone(), fake_ident, attr.into_iter())?;
+        let class_name = class_meta.class_name()?;
+        let module_name = class_meta.module()?;
+        let base = class_meta.base()?;
+        let metaclass = class_meta.metaclass()?;
+        let unhashable = class_meta.unhashable()?;
+        (class_meta, class_name, module_name, base, metaclass, unhashable)
+    };
+
+    // When a base is specified:
+    //   1. Validate that the first *declared* field has the base type.
+    //   2. Auto-insert #[repr(C)] so the compiler preserves declaration order,
+    //      keeping the base field at offset 0 as the inherited getter dispatcher requires.
+    //   3. Emit a compile-time offset_of! assertion as a safety net for structs that
+    //      already carry an explicit repr that does not guarantee offset 0.
+    let base_field_token = if let Some(ref base_path) = base {
+        validate_base_field(&item, base_path)?
+    } else {
+        None
+    };
+
+    let item = if base.is_some() {
+        ensure_repr_c(item)
+    } else {
+        item
+    };
+
+    let (ident, attrs) = pyclass_ident_and_attrs(&item)?;
+
+    let offset_assert = match (&base, &base_field_token) {
+        (Some(_), Some(field)) => quote! {
+            const _: () = ::core::assert!(
+                ::core::mem::offset_of!(#ident, #field) == 0,
+                concat!(
+                    "The base field of `", stringify!(#ident), "` is not at offset 0. \
+                     Add `#[repr(C)]` (or `#[repr(transparent)]`) to the struct so the \
+                     compiler preserves declaration order and inherited getter dispatch \
+                     reads the correct memory."
+                )
+            );
+        },
+        _ => quote! {},
+    };
 
     let class_def = generate_class_def(
         ident,
@@ -704,6 +759,7 @@ pub(crate) fn impl_pyclass(attr: PunctuatedNestedMeta, item: Item) -> Result<Tok
     let ret = quote! {
         #derive_trace
         #item
+        #offset_assert
         #maybe_traverse_code
         #class_def
         #impl_payload

--- a/crates/stdlib/src/_asyncio.rs
+++ b/crates/stdlib/src/_asyncio.rs
@@ -114,7 +114,6 @@ pub(crate) mod _asyncio {
     #[pyattr]
     #[pyclass(name = "Future", module = "_asyncio", traverse)]
     #[derive(Debug, PyPayload)]
-    #[repr(C)] // Required for inheritance - ensures base field is at offset 0 in subclasses
     struct PyFuture {
         fut_loop: PyRwLock<Option<PyObjectRef>>,
         fut_callback0: PyRwLock<Option<PyObjectRef>>,
@@ -1098,9 +1097,7 @@ pub(crate) mod _asyncio {
     #[pyattr]
     #[pyclass(name = "Task", module = "_asyncio", base = PyFuture, traverse)]
     #[derive(Debug)]
-    #[repr(C)]
     struct PyTask {
-        // Base class (must be first field for inheritance)
         base: PyFuture,
         // Task-specific fields
         task_coro: PyRwLock<Option<PyObjectRef>>,

--- a/crates/vm/src/builtins/builtin_func.rs
+++ b/crates/vm/src/builtins/builtin_func.rs
@@ -201,8 +201,6 @@ impl PyNativeFunction {
 }
 
 // PyCMethodObject in CPython
-// repr(C) ensures `func` is at offset 0, allowing safe cast from PyNativeMethod to PyNativeFunction
-#[repr(C)]
 #[pyclass(name = "builtin_function_or_method", module = false, base = PyNativeFunction, ctx = "builtin_function_or_method_type")]
 pub struct PyNativeMethod {
     pub(crate) func: PyNativeFunction,
@@ -211,7 +209,6 @@ pub struct PyNativeMethod {
 
 // All Python-visible behavior (getters, slots) is registered by PyNativeFunction::extend_class.
 // PyNativeMethod only extends the Rust-side struct with the defining class reference.
-// The func field at offset 0 (#[repr(C)]) allows NativeFunctionOrMethod to read it safely.
 #[pyclass(flags(HAS_DICT, HAS_WEAKREF, DISALLOW_INSTANTIATION))]
 impl PyNativeMethod {}
 


### PR DESCRIPTION
Derived `#[pyclass]` structs that mix pointer-sized and non-pointer-sized fields are silently miscompiled: Rust's default `#[repr(Rust)]` layout algorithm places the base field at a **non-zero offset**, while the inherited getter dispatcher unconditionally assumes it is at offset 0.

The result is undefined behaviour that manifests as a SIGSEGV at runtime.

This PR fixes the root cause by:
1. Auto-inserting `#[repr(C)]` on derived structs that carry no explicit repr (guarantees declaration-order layout, keeping the base field at offset 0).
2. Emitting a `const_assert` via `offset_of!` as belt-and-suspenders: catches the remaining case where a user supplies an explicit repr that does not guarantee offset 0.

Here is my minimal code that causes SIGSEGV/ACCESS_VIOLATION on Windows/Linux:
```rust
use rustpython_vm::Interpreter;
use rustpython_vm::PyObjectRef;
use rustpython_vm::pyclass;
use rustpython_vm::class::PyClassImpl;
use rustpython_vm::PyPayload;

fn main() {

    #[pyclass(module = false, name = "Base")]
    #[derive(Debug, PyPayload)]
    struct Base {
        field: PyObjectRef,
    }

    #[pyclass]
    impl Base {
        #[pygetset]
        fn field(&self) -> PyObjectRef {
            self.field.clone()
        }
    }

    #[pyclass(module = false, name = "Derived", base = Base)]
    #[derive(Debug)]
    struct Derived { // No #[repr(C)] — triggers the bug
        _base: Base,
        extra: Option<u64>,  // displaces _base in memory under #[repr(Rust)]
    }

    #[pyclass]
    impl Derived {
        #[pygetset]
        fn extra(&self) -> Option<u64> {
            self.extra
        }

        // No `field` getter — relies on inherited Base getter -> crash
    }

    let interp = Interpreter::without_stdlib(Default::default());
    interp.enter(|vm| {
        Base::make_static_type();
        Derived::make_static_type();

        let obj = vm.new_pyobj(Derived {
            _base: Base { field: vm.ctx.new_int(42).into() },
            extra: Some(99),
        });

        // Accessing `extra` (own getter) is fine.
        let _extra = obj.get_attr("extra", vm).expect("extra getter ok");

        // Accessing `field` (inherited getter) -> SIGSEGV without the fix
        let _field = obj.get_attr("field", vm).expect("field getter ok");
    });
}
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Strengthened compile-time validation of struct memory layout for base classes, now detecting and validating the primary base field and asserting correct offsets.
  * Automatically enforce a compatible memory representation when a base is declared so derived types meet layout expectations.
  * Removed several explicit memory-layout annotations from internal types to streamline layout handling and reduce redundant declarations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->