### PR TITLE
Raise ValueError for None in Stmt lists to match CPython validator

### DIFF
--- a/Lib/test/test_ast/test_ast.py
+++ b/Lib/test/test_ast/test_ast.py
@@ -2108,7 +2108,6 @@ class ASTValidatorTests(unittest.TestCase):
         self.assertIsInstance(funcdef, ast.FunctionDef)
         self.assertTrue(matcher(funcdef))
 
-    @unittest.expectedFailure  # TODO: RUSTPYTHON; ValueError not raised
     def test_classdef(self):
         def cls(bases=None, keywords=None, body=None, decorator_list=None, type_params=None):
             if bases is None:

--- a/crates/vm/src/stdlib/_ast/statement.rs
+++ b/crates/vm/src/stdlib/_ast/statement.rs
@@ -135,6 +135,8 @@ impl Node for ast::Stmt {
                 source_file,
                 _object,
             )?)
+        } else if _vm.is_none(&_object) {
+            return Err(_vm.new_value_error("None disallowed in statement list"));
         } else {
             return Err(_vm.new_type_error(format!(
                 "expected some sort of stmt, but got {}",


### PR DESCRIPTION
Sibling fix to #7656 (which handled `Vec<Expr>`). The same catch-all `TypeError(\"expected some sort of stmt, but got {}\")` in `Stmt::ast_from_object` silently swallowed `None`, so `compile()` on an AST with `None` in a statement-list field (`ClassDef.body`, `Try.body`, `For.body`, etc.) raised `TypeError` where CPython raises `ValueError(\"None disallowed in statement list\")`.

## Fix

One check in `Stmt::ast_from_object` (`crates/vm/src/stdlib/_ast/statement.rs`) before the catch-all, matching the Expr-side shape from #7656:

```rust
} else if _vm.is_none(&_object) {
    return Err(_vm.new_value_error(\"None disallowed in statement list\"));
}
```

`Option<Stmt>` positions are unaffected — `node.rs` `Option<T>::ast_from_object` short-circuits `None` earlier.

## Verification

CPython 3.13.4 baseline message:

```
$ python3 -c \"import ast; compile(ast.Module([ast.ClassDef('X', [], [], [None], [], [])], []), '<t>', 'exec')\"
ValueError: None disallowed in statement list
```

After the fix, RustPython raises the byte-identical message for `ClassDef`, `For`, `While`, `Try`, and `FunctionDef` body positions.

Full `test.test_ast.test_ast` suite (227 tests):

```
Ran 227 tests in 18.951s
OK (skipped=10, expected failures=38)
```

0 failures, 0 unexpected successes. One less expected failure than upstream/main (was 39), corresponding to `test_classdef` unmasked.

## Unmasks

- `ASTValidatorTests.test_classdef` (was `@unittest.expectedFailure`; `body=[None]` sub-case now passes)

Part of the skip-test inventory in #7611.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling for invalid statement list inputs, providing a more specific error message when `None` values are encountered instead of generic type errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->