### PR TITLE
Relax `rustyline` version constraint

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -211,7 +211,7 @@ radium = "1.1.1"
 rand = "0.9"
 rand_core = { version = "0.9", features = ["os_rng"] }
 rustix = { version = "1.1", features = ["event"] }
-rustyline = "17.0.1"
+rustyline = "17"
 serde = { package = "serde_core", version = "1.0.225", default-features = false, features = ["alloc"] }
 schannel = "0.1.29"
 scoped-tls = "1"


### PR DESCRIPTION
ref https://github.com/RustPython/RustPython/pull/7468#issuecomment-4313755301

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated dependency version constraints to allow resolution of newer compatible releases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->