### PR TITLE
Report invalid \uXXXX escape position at the u character

### DIFF
--- a/crates/stdlib/src/json/machinery.rs
+++ b/crates/stdlib/src/json/machinery.rs
@@ -231,17 +231,20 @@ pub fn scanstring<'a>(
                     'r' => "\r",
                     't' => "\t",
                     'u' => {
-                        let mut uni = decode_unicode(&mut chars, char_offset + char_i)?;
+                        // Error position for an invalid \uXXXX escape points at the
+                        // `u`, not the `\` -- matches CPython's json.decoder.
+                        let mut uni = decode_unicode(&mut chars, char_offset + next_char_i)?;
                         chunk_start = byte_i + 6;
                         if let Some(lead) = uni.to_lead_surrogate() {
                             // uni is a surrogate -- try to find its pair
                             let mut chars2 = chars.clone();
-                            if let Some(((_, (byte_pos2, _)), (_, _))) = chars2
+                            if let Some(((_, (byte_pos2, _)), (u2_char_i, (_, _)))) = chars2
                                 .next_tuple()
                                 .filter(|((_, (_, c1)), (_, (_, c2)))| *c1 == '\\' && *c2 == 'u')
                             {
-                                let uni2 =
-                                    decode_unicode(&mut chars2, char_offset + next_char_i + 1)?;
+                                // u2_char_i is the `u` of the second \uXXXX; same
+                                // position convention as the primary call above.
+                                let uni2 = decode_unicode(&mut chars2, char_offset + u2_char_i)?;
                                 if let Some(trail) = uni2.to_trail_surrogate() {
                                     // ok, we found what we were looking for -- \uXXXX\uXXXX, both surrogates
                                     uni = lead.merge(trail).into();

--- a/extra_tests/snippets/stdlib_json.py
+++ b/extra_tests/snippets/stdlib_json.py
@@ -247,11 +247,11 @@ try:
 except json.JSONDecodeError as e:
     assert e.pos == 2, f"expected pos=2, got {e.pos}"
 else:
-    assert False, "expected JSONDecodeError"
+    raise AssertionError("expected JSONDecodeError")
 
 try:
     json.loads('"abc\\uZZZZ"')
 except json.JSONDecodeError as e:
     assert e.pos == 5, f"expected pos=5, got {e.pos}"
 else:
-    assert False, "expected JSONDecodeError"
+    raise AssertionError("expected JSONDecodeError")

--- a/extra_tests/snippets/stdlib_json.py
+++ b/extra_tests/snippets/stdlib_json.py
@@ -239,3 +239,19 @@ assert_raises(
     RecursionError,
     lambda: json.loads(('[{"x":' * _deep) + "1" + ("}]" * _deep)),
 )
+
+
+# Invalid \uXXXX escape: error position points at the 'u', matching CPython.
+try:
+    json.loads('"\\uXYZW"')
+except json.JSONDecodeError as e:
+    assert e.pos == 2, f"expected pos=2, got {e.pos}"
+else:
+    assert False, "expected JSONDecodeError"
+
+try:
+    json.loads('"abc\\uZZZZ"')
+except json.JSONDecodeError as e:
+    assert e.pos == 5, f"expected pos=5, got {e.pos}"
+else:
+    assert False, "expected JSONDecodeError"


### PR DESCRIPTION
## Summary

`json.loads` of a string with an invalid `\uXXXX` escape reported a decode error position one character earlier than CPython: at the preceding `\` instead of at the `u` specifier. For surrogate-pair paths (`\uXXXX\uYYYY` where the second escape is invalid), the position was off by more — it landed on the first hex digit of the *first* escape rather than on the second `u`.

Examples (before / after):

| Input | CPython pos | Before | After |
|---|---|---|---|
| `json.loads('"\\uG000"')` | 2 | 1 | 2 |
| `json.loads('"abc\\uG000"')` | 5 | 4 | 5 |
| `json.loads('"\\u1234\\uG000"')` | 8 | 7 | 8 |
| `json.loads('"\\ud83d\\uG000"')` | 8 | 3 | 8 |
| `json.loads('"\\ud83d\\u"')` | 8 | 3 | 8 |
| `json.loads('"\\ud83d\\uDE0G"')` | 8 | 3 | 8 |

## Fix

In ``crates/stdlib/src/json/machinery.rs::scanstring``:

- Primary ``\uXXXX`` call: pass ``char_offset + next_char_i`` (position of the ``u``) instead of ``char_offset + char_i`` (position of the ``\``).
- Surrogate-pair second-escape call: capture the second ``u``'s char index from the ``next_tuple()`` peek and pass ``char_offset + u2_char_i``. The previous ``char_offset + next_char_i + 1`` referred to the *first* escape's position — unrelated to where the second escape fails.

No behavioural change on the success path, on non-``\u`` ``\escape`` errors, on unterminated strings, or on lone-surrogate preservation (pair filter unchanged). Decoded output bit-for-bit identical.

## Verification

### Targeted probes (13 cases)

Invalid hex digit at position 1/2/3/4, short escapes (``\u``, ``\u1``, ``\u12``, ``\u123``), escape preceded by ASCII, valid-then-invalid, and surrogate-pair error paths. All positions match CPython 3.13.4 after the fix.

### Test suite

```
$ ./target/release/rustpython -m unittest test.test_json
Ran 214 tests in 111s
OK (skipped=4, expected failures=12)
```

No regressions.

### Pre-push

- ``cargo fmt --all --check`` clean
- ``cargo clippy -p rustpython-stdlib --all-targets -- -D warnings`` clean
- ``prek run --all-files`` — all hooks pass

## Scope

Single file, +7/-4 lines (3 substantive + 4 comment lines). Independent from #7675 (decoder WTF-8 refactor) — this PR touches ``machinery::scanstring`` error-reporting path only; #7675 touches ``json.rs`` scanner frontend. Either order of merge is fine.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved JSON parsing error reporting for malformed Unicode escape sequences so error positions point precisely at the invalid escape, matching expected behavior and making debugging clearer.

* **Tests**
  * Added tests that validate invalid Unicode-escape handling and confirm reported error positions match the expected locations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->