### PR TITLE
Add `sha1` to `crypto` dependency group

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -19,6 +19,7 @@ updates:
           - "digest"
           - "md-5"
           - "sha-1"
+          - "sha1"
           - "sha2"
           - "sha3"
           - "blake2"


### PR DESCRIPTION
See #7642


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated dependency management configuration to improve handling of security-related packages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->