### PR TITLE
Raise ValueError for None in required AST scalar fields

### DIFF
--- a/Lib/test/test_ast/test_ast.py
+++ b/Lib/test/test_ast/test_ast.py
@@ -604,7 +604,6 @@ class AST_Tests(unittest.TestCase):
             ):
                 compile(e, "<test>", "eval")
 
-    @unittest.expectedFailure  # TODO: RUSTPYTHON; TypeError: expected some sort of expr, but got None
     def test_empty_yield_from(self):
         # Issue 16546: yield from value is not optional.
         empty_yield_from = ast.parse("def f():\n yield from g()")
@@ -1039,7 +1038,6 @@ class AST_Tests(unittest.TestCase):
             with self.assertRaisesRegex(ValueError, f"^{e}$"):
                 compile(tree, "<test>", "exec")
 
-    @unittest.expectedFailure  # TODO: RUSTPYTHON; TypeError: expected some sort of expr, but got None
     def test_none_checks(self) -> None:
         tests = [
             (ast.alias, "name", "import spam as SPAM"),

--- a/crates/vm/src/stdlib/_ast.rs
+++ b/crates/vm/src/stdlib/_ast.rs
@@ -73,6 +73,33 @@ fn get_node_field(vm: &VirtualMachine, obj: &PyObject, field: &'static str, typ:
         .ok_or_else(|| vm.new_type_error(format!(r#"required field "{field}" missing from {typ}"#)))
 }
 
+/// Read a required scalar field, rejecting both attribute absence and `None` value
+/// with CPython-compatible error messages. Pairs with `get_node_field_opt` (which
+/// returns `Option::None` for the same conditions): both filter `None`, but diverge
+/// on whether to raise or return `None`.
+///
+/// Errors:
+/// - Attribute absent: `TypeError("required field \"X\" missing from Y")` (via `get_node_field`).
+/// - Attribute present but `None`: `ValueError("field 'X' is required for Y")`,
+///   matching CPython's `Python/ast.c` validator output.
+///
+/// Use for required scalar fields where `None` is invalid (e.g. `comprehension.target`,
+/// `keyword.value`, `match_case.pattern`). Do NOT use for fields where `None` is
+/// legitimate (e.g. `Constant.value` representing the `None` literal — use plain
+/// `get_node_field`); or for optional fields (use `get_node_field_opt`).
+fn get_node_field_required(
+    vm: &VirtualMachine,
+    obj: &PyObject,
+    field: &'static str,
+    typ: &str,
+) -> PyResult {
+    let value = get_node_field(vm, obj, field, typ)?;
+    if vm.is_none(&value) {
+        return Err(vm.new_value_error(format!("field '{field}' is required for {typ}")));
+    }
+    Ok(value)
+}
+
 fn get_node_field_opt(
     vm: &VirtualMachine,
     obj: &PyObject,

--- a/crates/vm/src/stdlib/_ast/expression.rs
+++ b/crates/vm/src/stdlib/_ast/expression.rs
@@ -802,7 +802,7 @@ impl Node for ast::ExprYieldFrom {
             value: Node::ast_from_object(
                 vm,
                 source_file,
-                get_node_field(vm, &object, "value", "YieldFrom")?,
+                get_node_field_required(vm, &object, "value", "YieldFrom")?,
             )?,
             range: range_from_object(vm, source_file, object, "YieldFrom")?,
         })
@@ -1316,12 +1316,12 @@ impl Node for ast::Comprehension {
             target: Node::ast_from_object(
                 vm,
                 source_file,
-                get_node_field(vm, &object, "target", "comprehension")?,
+                get_node_field_required(vm, &object, "target", "comprehension")?,
             )?,
             iter: Node::ast_from_object(
                 vm,
                 source_file,
-                get_node_field(vm, &object, "iter", "comprehension")?,
+                get_node_field_required(vm, &object, "iter", "comprehension")?,
             )?,
             ifs: Node::ast_from_object(
                 vm,

--- a/crates/vm/src/stdlib/_ast/other.rs
+++ b/crates/vm/src/stdlib/_ast/other.rs
@@ -92,7 +92,7 @@ impl Node for ast::Alias {
             name: Node::ast_from_object(
                 vm,
                 source_file,
-                get_node_field(vm, &object, "name", "alias")?,
+                get_node_field_required(vm, &object, "name", "alias")?,
             )?,
             asname: get_node_field_opt(vm, &object, "asname")?
                 .map(|obj| Node::ast_from_object(vm, source_file, obj))
@@ -140,7 +140,7 @@ impl Node for ast::WithItem {
             context_expr: Node::ast_from_object(
                 vm,
                 source_file,
-                get_node_field(vm, &object, "context_expr", "withitem")?,
+                get_node_field_required(vm, &object, "context_expr", "withitem")?,
             )?,
             optional_vars: get_node_field_opt(vm, &object, "optional_vars")?
                 .map(|obj| Node::ast_from_object(vm, source_file, obj))

--- a/crates/vm/src/stdlib/_ast/parameter.rs
+++ b/crates/vm/src/stdlib/_ast/parameter.rs
@@ -143,7 +143,7 @@ impl Node for ast::Parameter {
             name: Node::ast_from_object(
                 _vm,
                 source_file,
-                get_node_field(_vm, &_object, "arg", "arg")?,
+                get_node_field_required(_vm, &_object, "arg", "arg")?,
             )?,
             annotation: get_node_field_opt(_vm, &_object, "annotation")?
                 .map(|obj| Node::ast_from_object(_vm, source_file, obj))
@@ -189,7 +189,7 @@ impl Node for ast::Keyword {
             value: Node::ast_from_object(
                 _vm,
                 source_file,
-                get_node_field(_vm, &_object, "value", "keyword")?,
+                get_node_field_required(_vm, &_object, "value", "keyword")?,
             )?,
             range: range_from_object(_vm, source_file, _object, "keyword")?,
         })

--- a/crates/vm/src/stdlib/_ast/pattern.rs
+++ b/crates/vm/src/stdlib/_ast/pattern.rs
@@ -34,7 +34,7 @@ impl Node for ast::MatchCase {
             pattern: Node::ast_from_object(
                 vm,
                 source_file,
-                get_node_field(vm, &object, "pattern", "match_case")?,
+                get_node_field_required(vm, &object, "pattern", "match_case")?,
             )?,
             guard: get_node_field_opt(vm, &object, "guard")?
                 .map(|obj| Node::ast_from_object(vm, source_file, obj))


### PR DESCRIPTION
## Summary

When required scalar AST fields receive ``None`` (e.g. ``comprehension.target = None`` after manually constructing an AST), ``compile()`` raises mismatched errors compared to CPython:

| Field | Current RustPython | CPython 3.14 |
|---|---|---|
| ``alias.name`` | ``TypeError: Expected type 'str' but 'NoneType' found.`` | ``ValueError: field 'name' is required for alias`` |
| ``arg.arg`` | same TypeError | ``ValueError: field 'arg' is required for arg`` |
| ``comprehension.target`` / ``iter`` | ``ValueError: None disallowed in expression list`` | ``ValueError: field '<target/iter>' is required for comprehension`` |
| ``keyword.value`` | same generic ValueError | ``ValueError: field 'value' is required for keyword`` |
| ``match_case.pattern`` | ``TypeError: expected some sort of pattern, but got None`` | ``ValueError: field 'pattern' is required for match_case`` |
| ``withitem.context_expr`` | same generic ValueError | ``ValueError: field 'context_expr' is required for withitem`` |
| ``YieldFrom.value`` | same generic ValueError | ``ValueError: field 'value' is required for YieldFrom`` |

These slip past the existing ``validate.rs`` semantic validator because Rust's non-``Option`` field types (e.g. ``Alias.name: Identifier``, ``Comprehension.target: Expr``, ``MatchCase.pattern: Pattern``) force ``Node::ast_from_object`` to fail at conversion time, before the validator pass can run. CPython's single-pass ``PyAST_Validate`` works because every AST attribute is a ``PyObject*`` and tolerates ``None`` until the validator decides; RustPython's strong typing forces this work to happen at conversion.

## Fix

Add ``get_node_field_required`` next to the existing ``get_node_field`` / ``get_node_field_opt`` in ``crates/vm/src/stdlib/_ast.rs``:

```rust
fn get_node_field_required(vm, obj, field, typ) -> PyResult {
    let value = get_node_field(vm, obj, field, typ)?;
    if vm.is_none(&value) {
        return Err(vm.new_value_error(format!("field '{field}' is required for {typ}")));
    }
    Ok(value)
}
```

Switch the eight call sites that read required scalar fields:

- ``alias.name``, ``withitem.context_expr`` (``other.rs``)
- ``arg.arg``, ``keyword.value`` (``parameter.rs``)
- ``comprehension.target``, ``comprehension.iter``, ``YieldFrom.value`` (``expression.rs``)
- ``match_case.pattern`` (``pattern.rs``)

Optional fields (read via ``get_node_field_opt``: ``alias.asname``, ``arg.annotation``, ``Yield.value``, ``Return.value``, ``WithItem.optional_vars``, ``ExceptHandler.type``, etc.) and fields where ``None`` is legitimate (``Constant.value`` representing the ``None`` literal) are unchanged.

## Verification

### Targeted probes (CPython 3.14.4 byte-identical)

```
$ ./target/release/rustpython /tmp/probe_none_checks.py
  alias.name: ValueError: field 'name' is required for alias
  arg.arg: ValueError: field 'arg' is required for arg
  comprehension.target: ValueError: field 'target' is required for comprehension
  comprehension.iter: ValueError: field 'iter' is required for comprehension
  keyword.value: ValueError: field 'value' is required for keyword
  match_case.pattern: ValueError: field 'pattern' is required for match_case
  withitem.context_expr: ValueError: field 'context_expr' is required for withitem
```

Identical to CPython 3.14.4 output for every case.

### Test suites

```
$ ./target/release/rustpython -m unittest test.test_ast.test_ast
Ran 227 tests in 19s
OK (skipped=10, expected failures=36)
```

Was 38 expected failures; this PR unmasks ``test_none_checks`` and ``test_empty_yield_from``.

```
$ ./target/release/rustpython -m unittest test.test_compile
Ran 185 tests in 4s
OK (skipped=50, expected failures=18)
```

No regressions.

### Optional ``None`` paths still compile

Verified that legitimate ``None`` AST positions are unaffected:

- ``import x`` (``alias.asname=None``)
- ``def f(x): pass`` (``arg.annotation=None``, ``returns=None``)
- ``def f(): yield`` (``Yield.value=None``)
- ``def f(): return`` (``Return.value=None``)
- ``with x: pass`` (``WithItem.optional_vars=None``)
- ``try: pass\nexcept: pass`` (``ExceptHandler.type=None``)
- ``Constant(value=None)`` (``None`` literal)

All compile cleanly.

### Pre-push

- ``cargo fmt --all --check`` clean
- ``cargo clippy -p rustpython-vm --all-targets -- -D warnings`` clean
- ``prek run --all-files`` — all 8 hooks pass

## Scope

6 files, +35/-10 lines. Additive in spirit — no behaviour change on success paths.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced AST field validation to enforce required fields during deserialization with improved CPython-compatible error messages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->