### PR TITLE
Match CPython error type for non-ASCII struct format arguments

### DIFF
--- a/crates/stdlib/src/pystruct.rs
+++ b/crates/stdlib/src/pystruct.rs
@@ -26,20 +26,42 @@ pub(crate) mod _struct {
 
     impl TryFromObject for IntoStructFormatBytes {
         fn try_from_object(vm: &VirtualMachine, obj: PyObjectRef) -> PyResult<Self> {
-            // CPython turns str to bytes but we do reversed way here
-            // The only performance difference is this transition cost
+            // CPython turns str to bytes (via str.encode('ascii')) but we keep str.
+            // The error reporting for non-ASCII input still matches CPython:
+            // - str input with non-ASCII char: UnicodeEncodeError, the same exception
+            //   str.encode('ascii') would produce.
+            // - bytes input with non-ASCII byte: struct.error("bad char in struct format"),
+            //   matching CPython where bytes are passed through to the format parser.
             let fmt = match_class!(match obj {
-                s @ PyStr => s.isascii().then_some(s),
-                b @ PyBytes => ascii::AsciiStr::from_ascii(&b)
-                    .ok()
-                    .map(|s| vm.ctx.new_str(s)),
+                s @ PyStr => {
+                    if !s.isascii() {
+                        let start = s
+                            .as_wtf8()
+                            .code_points()
+                            .position(|cp| !cp.to_char().is_some_and(|c| c.is_ascii()))
+                            .unwrap_or(0);
+                        return Err(vm.new_unicode_encode_error_real(
+                            vm.ctx.new_str("ascii"),
+                            s,
+                            start,
+                            start + 1,
+                            vm.ctx.new_str("ordinal not in range(128)"),
+                        ));
+                    }
+                    s
+                }
+                b @ PyBytes => {
+                    let ascii_str = ascii::AsciiStr::from_ascii(&b).map_err(|_| {
+                        new_struct_error(vm, "bad char in struct format".to_owned())
+                    })?;
+                    vm.ctx.new_str(ascii_str)
+                }
                 other =>
                     return Err(vm.new_type_error(format!(
                         "Struct() argument 1 must be a str or bytes object, not {}",
                         other.class().name()
                     ))),
-            })
-            .ok_or_else(|| vm.new_unicode_decode_error("Struct format must be a ascii string"))?;
+            });
             Ok(Self(fmt))
         }
     }

--- a/extra_tests/snippets/stdlib_struct.py
+++ b/extra_tests/snippets/stdlib_struct.py
@@ -85,7 +85,7 @@ try:
 except UnicodeEncodeError as e:
     assert e.encoding == "ascii"
 else:
-    assert False, "expected UnicodeEncodeError"
+    raise AssertionError("expected UnicodeEncodeError")
 
 with assert_raises(UnicodeEncodeError):
     struct.Struct("한")

--- a/extra_tests/snippets/stdlib_struct.py
+++ b/extra_tests/snippets/stdlib_struct.py
@@ -76,3 +76,19 @@ assert data == b"\0"
 
 assert struct.error.__module__ == "struct"
 assert struct.error.__name__ == "error"
+
+# Non-ASCII format string: error type matches CPython.
+# str → UnicodeEncodeError (encoding='ascii')
+# bytes → struct.error
+try:
+    struct.Struct("\udc00")
+except UnicodeEncodeError as e:
+    assert e.encoding == "ascii"
+else:
+    assert False, "expected UnicodeEncodeError"
+
+with assert_raises(UnicodeEncodeError):
+    struct.Struct("한")
+
+with assert_raises(struct.error):
+    struct.Struct(b"\xff")


### PR DESCRIPTION
## Summary

``Struct()`` (and the module-level ``struct.pack`` / ``unpack`` / ``calcsize``) raised the wrong exception type when the format argument contained non-ASCII characters:

| Input | Before (RustPython) | CPython 3.14.4 |
|---|---|---|
| ``struct.pack('é', 42)`` | ``UnicodeDecodeError:`` (empty message) | ``UnicodeEncodeError: 'ascii' codec can't encode character '\xe9' in position 0: ordinal not in range(128)`` |
| ``struct.pack(b'\xe9', 42)`` | ``UnicodeDecodeError:`` (empty message) | ``struct.error: bad char in struct format`` |

Both error type and message diverge from CPython.

## Fix

Restructure ``IntoStructFormatBytes::try_from_object`` in ``crates/stdlib/src/pystruct.rs``:

- **str input with non-ASCII char** → raise ``UnicodeEncodeError("ascii", s, start, start+1, "ordinal not in range(128)")``. The position is the first non-ASCII code point, matching what ``format.encode('ascii')`` would naturally produce in CPython.
- **bytes input with non-ASCII byte** → raise ``struct.error("bad char in struct format")`` via the existing ``new_struct_error`` helper. CPython gets here because it passes the bytes through to the format parser, which then errors on the bad char; we emit the equivalent error directly without the indirection.

Other paths (str ASCII, bytes ASCII, non-str/bytes argument) are unchanged.

## Verification

### Targeted probes (CPython 3.14.4 byte-identical)

```
$ rustpython -c 'import struct; struct.pack("é", 42)'
UnicodeEncodeError: 'ascii' codec can't encode character '\xe9' in position 0: ordinal not in range(128)

$ rustpython -c 'import struct; struct.pack(b"\xe9", 42)'
struct.error: bad char in struct format
```

Identical to CPython 3.14.4 output for both.

### Test suite

```
$ rustpython -m unittest test.test_struct
Ran 43 tests in 0.6s
OK (skipped=6, expected failures=8)
```

No regressions; expected-failures unchanged (none of the 8 expected failures cover this code path).

### Sanity check on valid usage

Verified that standard ``struct.pack`` / ``unpack`` / ``calcsize`` with valid str or bytes format strings, and the ``'s'`` / ``'p'`` byte-string formats, all behave as before. No behaviour change on success paths.

### Pre-push

- ``cargo fmt --all --check`` clean
- ``cargo clippy -p rustpython-stdlib --all-targets -- -D warnings`` clean
- ``prek run --all-files`` — all 8 hooks pass

## Scope

1 file, +30/−8 lines. Single function. The only behaviour change is the exception type and message for non-ASCII format input, which previously produced an incorrect ``UnicodeDecodeError`` with an empty message.

## Out of scope (separate PRs)

While probing this fix, two further ``struct`` divergences were observed:

- ``struct.pack('5s', 'hello')`` raises ``TypeError`` in RustPython but ``struct.error`` in CPython. This is a separate code path in the format-spec packer.
- ``struct.pack('Q@', 42)`` is silently accepted in RustPython but raises ``struct.error: bad char in struct format`` in CPython. The shared ``FormatSpec::parse`` (also used by ``memoryview``) silently skips endianness markers mid-format; addressing this requires deciding a parser-mode strategy.

Both deferred to follow-up PRs.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * struct format parsing now yields more accurate errors: string format inputs raise a UnicodeEncodeError with CPython-like message/position; bytes format inputs raise a clearer struct.error for invalid characters.

* **Tests**
  * Added tests verifying non-ASCII behavior for both string and bytes struct format inputs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->