### PR TITLE
Opcode descs not hardcoded

### DIFF
--- a/crates/compiler-core/src/bytecode/oparg.rs
+++ b/crates/compiler-core/src/bytecode/oparg.rs
@@ -242,6 +242,12 @@ macro_rules! impl_oparg_enum {
                 // We already validated this is a lossles cast.
                 Self::try_from_u8(value as u8)
             }
+
+            /// Iterate over the variants.
+            #[must_use]
+            $vis fn iterator() -> impl Iterator<Item = Self> {
+                [$(Self::$variant),*].iter().copied()
+            }
         }
 
         impl TryFrom<u8> for $name {

--- a/crates/compiler-core/src/bytecode/oparg.rs
+++ b/crates/compiler-core/src/bytecode/oparg.rs
@@ -669,6 +669,40 @@ impl BinaryOperator {
             _ => self,
         }
     }
+
+    /// https://github.com/python/cpython/blob/v3.14.4/Include/opcode.h#L10-L36
+    #[must_use]
+    pub const fn desc(&self) -> &str {
+        match self {
+            Self::Add => "NB_ADD",
+            Self::And => "NB_AND",
+            Self::FloorDivide => "NB_FLOOR_DIVIDE",
+            Self::Lshift => "NB_LSHIFT",
+            Self::MatrixMultiply => "NB_MATRIX_MULTIPLY",
+            Self::Multiply => "NB_MULTIPLY",
+            Self::Remainder => "NB_REMAINDER",
+            Self::Or => "NB_OR",
+            Self::Power => "NB_POWER",
+            Self::Rshift => "NB_RSHIFT",
+            Self::Subtract => "NB_SUBTRACT",
+            Self::TrueDivide => "NB_TRUE_DIVIDE",
+            Self::Xor => "NB_XOR",
+            Self::InplaceAdd => "NB_INPLACE_ADD",
+            Self::InplaceAnd => "NB_INPLACE_AND",
+            Self::InplaceFloorDivide => "NB_INPLACE_FLOOR_DIVIDE",
+            Self::InplaceLshift => "NB_INPLACE_LSHIFT",
+            Self::InplaceMatrixMultiply => "NB_INPLACE_MATRIX_MULTIPLY",
+            Self::InplaceMultiply => "NB_INPLACE_MULTIPLY",
+            Self::InplaceRemainder => "NB_INPLACE_REMAINDER",
+            Self::InplaceOr => "NB_INPLACE_OR",
+            Self::InplacePower => "NB_INPLACE_POWER",
+            Self::InplaceRshift => "NB_INPLACE_RSHIFT",
+            Self::InplaceSubtract => "NB_INPLACE_SUBTRACT",
+            Self::InplaceTrueDivide => "NB_INPLACE_TRUE_DIVIDE",
+            Self::InplaceXor => "NB_INPLACE_XOR",
+            Self::Subscr => "NB_SUBSCR",
+        }
+    }
 }
 
 oparg_enum!(

--- a/crates/compiler-core/src/bytecode/oparg.rs
+++ b/crates/compiler-core/src/bytecode/oparg.rs
@@ -244,7 +244,6 @@ macro_rules! impl_oparg_enum {
             }
 
             /// Iterate over the variants.
-            #[must_use]
             $vis fn iterator() -> impl Iterator<Item = Self> {
                 [$(Self::$variant),*].iter().copied()
             }

--- a/crates/compiler-core/src/bytecode/oparg.rs
+++ b/crates/compiler-core/src/bytecode/oparg.rs
@@ -372,7 +372,7 @@ oparg_enum!(
     /// Intrinsic function for CALL_INTRINSIC_1
     #[derive(Copy, Clone, Debug, PartialEq, Eq)]
     pub enum IntrinsicFunction1 {
-        // Invalid = 0,
+        Invalid = 0,
         Print = 1,
         /// Import * operation
         ImportStar = 2,
@@ -391,6 +391,27 @@ oparg_enum!(
         TypeAlias = 11,
     }
 );
+
+impl IntrinsicFunction1 {
+    /// https://github.com/python/cpython/blob/v3.14.4/Include/internal/pycore_intrinsics.h#L9-L20
+    #[must_use]
+    pub const fn desc(&self) -> &str {
+        match self {
+            Self::Invalid => "INTRINSIC_1_INVALID",
+            Self::Print => "INTRINSIC_PRINT",
+            Self::ImportStar => "INTRINSIC_IMPORT_STAR",
+            Self::StopIterationError => "INTRINSIC_STOPITERATION_ERROR",
+            Self::AsyncGenWrap => "INTRINSIC_ASYNC_GEN_WRAP",
+            Self::UnaryPositive => "INTRINSIC_UNARY_POSITIVE",
+            Self::ListToTuple => "INTRINSIC_LIST_TO_TUPLE",
+            Self::TypeVar => "INTRINSIC_TYPEVAR",
+            Self::ParamSpec => "INTRINSIC_PARAMSPEC",
+            Self::TypeVarTuple => "INTRINSIC_TYPEVARTUPLE",
+            Self::SubscriptGeneric => "INTRINSIC_SUBSCRIPT_GENERIC",
+            Self::TypeAlias => "INTRINSIC_TYPEALIAS",
+        }
+    }
+}
 
 oparg_enum!(
     /// Intrinsic function for CALL_INTRINSIC_2

--- a/crates/compiler-core/src/bytecode/oparg.rs
+++ b/crates/compiler-core/src/bytecode/oparg.rs
@@ -244,7 +244,7 @@ macro_rules! impl_oparg_enum {
             }
 
             /// Iterate over the variants.
-            $vis fn iterator() -> impl Iterator<Item = Self> {
+            $vis fn iter() -> impl Iterator<Item = Self> {
                 [$(Self::$variant),*].iter().copied()
             }
         }

--- a/crates/compiler-core/src/bytecode/oparg.rs
+++ b/crates/compiler-core/src/bytecode/oparg.rs
@@ -396,6 +396,7 @@ oparg_enum!(
     /// Intrinsic function for CALL_INTRINSIC_2
     #[derive(Copy, Clone, Debug, PartialEq, Eq)]
     pub enum IntrinsicFunction2 {
+        Invalid = 0,
         PrepReraiseStar = 1,
         TypeVarWithBound = 2,
         TypeVarWithConstraint = 3,
@@ -404,6 +405,21 @@ oparg_enum!(
         SetTypeparamDefault = 5,
     }
 );
+
+impl IntrinsicFunction2 {
+    /// https://github.com/python/cpython/blob/v3.14.4/Include/internal/pycore_intrinsics.h#L26-L31
+    #[must_use]
+    pub const fn desc(&self) -> &str {
+        match self {
+            Self::Invalid => "INTRINSIC_2_INVALID",
+            Self::PrepReraiseStar => "INTRINSIC_PREP_RERAISE_STAR",
+            Self::TypeVarWithBound => "INTRINSIC_TYPEVAR_WITH_BOUND",
+            Self::TypeVarWithConstraint => "INTRINSIC_TYPEVAR_WITH_CONSTRAINTS",
+            Self::SetFunctionTypeParams => "INTRINSIC_SET_FUNCTION_TYPE_PARAMS",
+            Self::SetTypeparamDefault => "INTRINSIC_SET_TYPEPARAM_DEFAULT",
+        }
+    }
+}
 
 bitflagset::bitflag! {
     /// `SET_FUNCTION_ATTRIBUTE` flags.

--- a/crates/stdlib/src/_opcode.rs
+++ b/crates/stdlib/src/_opcode.rs
@@ -177,23 +177,9 @@ mod _opcode {
 
     #[pyfunction]
     fn get_intrinsic1_descs(vm: &VirtualMachine) -> Vec<PyObjectRef> {
-        [
-            "INTRINSIC_1_INVALID",
-            "INTRINSIC_PRINT",
-            "INTRINSIC_IMPORT_STAR",
-            "INTRINSIC_STOPITERATION_ERROR",
-            "INTRINSIC_ASYNC_GEN_WRAP",
-            "INTRINSIC_UNARY_POSITIVE",
-            "INTRINSIC_LIST_TO_TUPLE",
-            "INTRINSIC_TYPEVAR",
-            "INTRINSIC_PARAMSPEC",
-            "INTRINSIC_TYPEVARTUPLE",
-            "INTRINSIC_SUBSCRIPT_GENERIC",
-            "INTRINSIC_TYPEALIAS",
-        ]
-        .into_iter()
-        .map(|x| vm.ctx.new_str(x).into())
-        .collect()
+        oparg::IntrinsicFunction1::iterator()
+            .map(|x| vm.ctx.new_str(x.desc()).into())
+            .collect()
     }
 
     #[pyfunction]

--- a/crates/stdlib/src/_opcode.rs
+++ b/crates/stdlib/src/_opcode.rs
@@ -5,7 +5,7 @@ mod _opcode {
     use crate::vm::{
         AsObject, PyObjectRef, PyResult, VirtualMachine,
         builtins::{PyInt, PyIntRef},
-        bytecode::{AnyInstruction, AnyOpcode, InstructionMetadata, Opcode, PseudoOpcode},
+        bytecode::{AnyInstruction, AnyOpcode, InstructionMetadata, Opcode, PseudoOpcode, oparg},
     };
 
     fn try_from_i32(raw: i32) -> Result<AnyOpcode, ()> {
@@ -253,9 +253,8 @@ mod _opcode {
 
     #[pyfunction]
     fn get_special_method_names(vm: &VirtualMachine) -> Vec<PyObjectRef> {
-        ["__enter__", "__exit__", "__aenter__", "__aexit__"]
-            .into_iter()
-            .map(|x| vm.ctx.new_str(x).into())
+        oparg::SpecialMethod::iterator()
+            .map(|x| vm.ctx.new_str(x.to_string()).into())
             .collect()
     }
 

--- a/crates/stdlib/src/_opcode.rs
+++ b/crates/stdlib/src/_opcode.rs
@@ -191,42 +191,16 @@ mod _opcode {
 
     #[pyfunction]
     fn get_nb_ops(vm: &VirtualMachine) -> Vec<PyObjectRef> {
-        [
-            ("NB_ADD", "+"),
-            ("NB_AND", "&"),
-            ("NB_FLOOR_DIVIDE", "//"),
-            ("NB_LSHIFT", "<<"),
-            ("NB_MATRIX_MULTIPLY", "@"),
-            ("NB_MULTIPLY", "*"),
-            ("NB_REMAINDER", "%"),
-            ("NB_OR", "|"),
-            ("NB_POWER", "**"),
-            ("NB_RSHIFT", ">>"),
-            ("NB_SUBTRACT", "-"),
-            ("NB_TRUE_DIVIDE", "/"),
-            ("NB_XOR", "^"),
-            ("NB_INPLACE_ADD", "+="),
-            ("NB_INPLACE_AND", "&="),
-            ("NB_INPLACE_FLOOR_DIVIDE", "//="),
-            ("NB_INPLACE_LSHIFT", "<<="),
-            ("NB_INPLACE_MATRIX_MULTIPLY", "@="),
-            ("NB_INPLACE_MULTIPLY", "*="),
-            ("NB_INPLACE_REMAINDER", "%="),
-            ("NB_INPLACE_OR", "|="),
-            ("NB_INPLACE_POWER", "**="),
-            ("NB_INPLACE_RSHIFT", ">>="),
-            ("NB_INPLACE_SUBTRACT", "-="),
-            ("NB_INPLACE_TRUE_DIVIDE", "/="),
-            ("NB_INPLACE_XOR", "^="),
-            ("NB_SUBSCR", "[]"),
-        ]
-        .into_iter()
-        .map(|(a, b)| {
-            vm.ctx
-                .new_tuple(vec![vm.ctx.new_str(a).into(), vm.ctx.new_str(b).into()])
-                .into()
-        })
-        .collect()
+        oparg::BinaryOperator::iterator()
+            .map(|x| {
+                vm.ctx
+                    .new_tuple(vec![
+                        vm.ctx.new_str(x.desc()).into(),
+                        vm.ctx.new_str(x.to_string()).into(),
+                    ])
+                    .into()
+            })
+            .collect()
     }
 
     #[pyfunction]

--- a/crates/stdlib/src/_opcode.rs
+++ b/crates/stdlib/src/_opcode.rs
@@ -177,21 +177,21 @@ mod _opcode {
 
     #[pyfunction]
     fn get_intrinsic1_descs(vm: &VirtualMachine) -> Vec<PyObjectRef> {
-        oparg::IntrinsicFunction1::iterator()
+        oparg::IntrinsicFunction1::iter()
             .map(|x| vm.ctx.new_str(x.desc()).into())
             .collect()
     }
 
     #[pyfunction]
     fn get_intrinsic2_descs(vm: &VirtualMachine) -> Vec<PyObjectRef> {
-        oparg::IntrinsicFunction2::iterator()
+        oparg::IntrinsicFunction2::iter()
             .map(|x| vm.ctx.new_str(x.desc()).into())
             .collect()
     }
 
     #[pyfunction]
     fn get_nb_ops(vm: &VirtualMachine) -> Vec<PyObjectRef> {
-        oparg::BinaryOperator::iterator()
+        oparg::BinaryOperator::iter()
             .map(|x| {
                 vm.ctx
                     .new_tuple(vec![
@@ -205,7 +205,7 @@ mod _opcode {
 
     #[pyfunction]
     fn get_special_method_names(vm: &VirtualMachine) -> Vec<PyObjectRef> {
-        oparg::SpecialMethod::iterator()
+        oparg::SpecialMethod::iter()
             .map(|x| vm.ctx.new_str(x.to_string()).into())
             .collect()
     }

--- a/crates/stdlib/src/_opcode.rs
+++ b/crates/stdlib/src/_opcode.rs
@@ -198,17 +198,9 @@ mod _opcode {
 
     #[pyfunction]
     fn get_intrinsic2_descs(vm: &VirtualMachine) -> Vec<PyObjectRef> {
-        [
-            "INTRINSIC_2_INVALID",
-            "INTRINSIC_PREP_RERAISE_STAR",
-            "INTRINSIC_TYPEVAR_WITH_BOUND",
-            "INTRINSIC_TYPEVAR_WITH_CONSTRAINTS",
-            "INTRINSIC_SET_FUNCTION_TYPE_PARAMS",
-            "INTRINSIC_SET_TYPEPARAM_DEFAULT",
-        ]
-        .into_iter()
-        .map(|x| vm.ctx.new_str(x).into())
-        .collect()
+        oparg::IntrinsicFunction2::iterator()
+            .map(|x| vm.ctx.new_str(x.desc()).into())
+            .collect()
     }
 
     #[pyfunction]

--- a/crates/vm/src/frame.rs
+++ b/crates/vm/src/frame.rs
@@ -9573,6 +9573,9 @@ impl ExecutingFrame<'_> {
         vm: &VirtualMachine,
     ) -> PyResult {
         match func {
+            bytecode::IntrinsicFunction2::Invalid => {
+                unreachable!("This is a bug in RustPython compiler")
+            }
             bytecode::IntrinsicFunction2::SetTypeparamDefault => {
                 crate::stdlib::_typing::set_typeparam_default(arg1, arg2, vm)
             }

--- a/crates/vm/src/frame.rs
+++ b/crates/vm/src/frame.rs
@@ -9458,6 +9458,9 @@ impl ExecutingFrame<'_> {
         vm: &VirtualMachine,
     ) -> PyResult {
         match func {
+            bytecode::IntrinsicFunction1::Invalid => {
+                unreachable!("This is a bug in RustPython compiler")
+            }
             bytecode::IntrinsicFunction1::Print => {
                 let displayhook = vm
                     .sys_module


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Enhanced internal opcode/enumeration utilities with iteration and descriptive helpers; several helpers now derive intrinsic/operator metadata from those enums.
* **Bug Fixes**
  * Added explicit handling for invalid intrinsic variants in VM dispatch to prevent unexpected or undefined behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->