### PR TITLE
Pin actions version to commit; force runner to use node 24

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -33,6 +33,7 @@ env:
   CARGO_PROFILE_DEV_DEBUG: 0
   CARGO_PROFILE_RELEASE_DEBUG: 0
   CARGO_TERM_COLOR: always
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: 'true' # TODO: Remove on 2026/06/02
 
 jobs:
   rust_tests:
@@ -426,7 +427,7 @@ jobs:
 
       - name: reviewdog
         if: ${{ !cancelled() }}
-        uses: reviewdog/action-suggester@aa38384ceb608d00f84b4690cacc83a5aba307ff # 1.24.0
+        uses: reviewdog/action-suggester@aa38384ceb608d00f84b4690cacc83a5aba307ff # v1.24.0
         with:
           level: warning
           fail_level: error
@@ -512,10 +513,12 @@ jobs:
 
       - run: python -m pip install -r requirements.txt
         working-directory: ./wasm/tests
+
       - uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
         with:
           cache: "npm"
           cache-dependency-path: "wasm/demo/package-lock.json"
+
       - name: run test
         run: |
           driver_path="$(pwd)/../../geckodriver"
@@ -525,8 +528,11 @@ jobs:
         env:
           NODE_OPTIONS: "--openssl-legacy-provider"
         working-directory: ./wasm/demo
-      - uses: mwilliamson/setup-wabt-action@v3
-        with: { wabt-version: "1.0.36" }
+
+      - uses: mwilliamson/setup-wabt-action@427f2fdd70bc4dbc2e53c2eb4f19f66162d71bd2 # v4.0.0
+        with:
+          wabt-version: "1.0.36"
+
       - name: check wasm32-unknown without js
         run: |
           cd example_projects/wasm32_without_js/rustpython-without-js
@@ -536,6 +542,7 @@ jobs:
             echo "ERROR: wasm32-unknown module expects imports from the host environment" >&2
           fi
           cargo run --release --manifest-path wasm-runtime/Cargo.toml rustpython-without-js/target/wasm32-unknown-unknown/debug/rustpython_without_js.wasm
+
       - name: build notebook demo
         if: github.ref == 'refs/heads/release'
         run: |
@@ -545,9 +552,10 @@ jobs:
         env:
           NODE_OPTIONS: "--openssl-legacy-provider"
         working-directory: ./wasm/notebook
+
       - name: Deploy demo to Github Pages
         if: success() && github.ref == 'refs/heads/release'
-        uses: peaceiris/actions-gh-pages@v4
+        uses: peaceiris/actions-gh-pages@4f9cc6602d3f66b9c108549d475ec49e8ef4d45e # v4.0.0
         env:
           ACTIONS_DEPLOY_KEY: ${{ secrets.ACTIONS_DEMO_DEPLOY_KEY }}
           PUBLISH_DIR: ./wasm/demo/dist

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -190,7 +190,7 @@ jobs:
       - name: Setup Android NDK
         if: ${{ matrix.target == 'aarch64-linux-android' }}
         id: setup-ndk
-        uses: nttld/setup-ndk@v1
+        uses: nttld/setup-ndk@ed92fe6cadad69be94a966a7ee3271275e62f779 # v1.6.0
         with:
           ndk-version: r27
           add-to-path: true
@@ -593,7 +593,7 @@ jobs:
             ${{ runner.os }}-stable--
 
       - name: Setup Wasmer
-        uses: wasmerio/setup-wasmer@v3
+        uses: wasmerio/setup-wasmer@24b15c95293d23f89c68bd40dac76338f773e924 # v3.1
 
       - name: Install clang
         uses: ./.github/actions/install-linux-deps


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated CI workflow settings, including a top-level environment flag and several action versions pinned to specific commits for more predictable builds.
  * Minor workflow formatting and comment adjustments to improve clarity and maintainability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->