### PR TITLE
Add `crates/*` directories to Dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -2,7 +2,9 @@
 version: 2
 updates:
   - package-ecosystem: cargo
-    directory: /
+    directories:
+      - "/"
+      - "crates/*"
     schedule:
       interval: weekly
     cooldown:


### PR DESCRIPTION
This allows dependabot to bump versions in all places we have `Cargo.toml`, not just the root directory.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced dependency update automation configuration to cover multiple project directories, improving the efficiency of dependency management across the codebase.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->