### PR TITLE
Match CPython error wording for __slots__ conflict and __doc__ delete

### DIFF
--- a/Lib/test/test_descr.py
+++ b/Lib/test/test_descr.py
@@ -4952,7 +4952,6 @@ class ClassPropertiesAndMethods(unittest.TestCase):
         with self.assertRaises(TypeError):
             a + a
 
-    @unittest.expectedFailure  # TODO: RUSTPYTHON
     def test_slot_shadows_class_variable(self):
         with self.assertRaises(ValueError) as cm:
             class X:
@@ -4961,7 +4960,6 @@ class ClassPropertiesAndMethods(unittest.TestCase):
         m = str(cm.exception)
         self.assertEqual("'foo' in __slots__ conflicts with class variable", m)
 
-    @unittest.expectedFailure  # TODO: RUSTPYTHON
     def test_set_doc(self):
         class X:
             "elephant"

--- a/crates/vm/src/builtins/type.rs
+++ b/crates/vm/src/builtins/type.rs
@@ -2004,7 +2004,7 @@ impl Constructor for PyType {
                 // Check if slot name conflicts with class attributes
                 if attributes.contains_key(vm.ctx.intern_str(slot.as_wtf8())) {
                     return Err(vm.new_value_error(format!(
-                        "'{}' in __slots__ conflicts with a class variable",
+                        "'{}' in __slots__ conflicts with class variable",
                         slot.as_wtf8()
                     )));
                 }
@@ -2404,7 +2404,7 @@ impl Py<PyType> {
         // Similar to CPython's type_set_doc
         let value = value.ok_or_else(|| {
             vm.new_type_error(format!(
-                "cannot delete '__doc__' attribute of type '{}'",
+                "cannot delete '__doc__' attribute of immutable type '{}'",
                 self.name()
             ))
         })?;


### PR DESCRIPTION
Two small wording differences from CPython's type-attribute error messages, both flagged by `test_descr.ClassPropertiesAndMethods`:

| Site | RustPython | CPython 3.14 |
|---|---|---|
| `__slots__` conflicts with class attr (`type.rs:2007`) | `"...conflicts with a class variable"` | `"...conflicts with class variable"` |
| `del cls.__doc__` (`type.rs:2407`) | `"cannot delete '__doc__' attribute of type 'X'"` | `"cannot delete '__doc__' attribute of immutable type 'X'"` |

The behavior in both cases already matched CPython (the conflict is detected, the delete is rejected); only the message text drifted. CPython surfaces the "immutable" phrase even for user-defined classes because the `__doc__` descriptor refuses the delete unconditionally.

## Tests unmasked

- `test_descr.ClassPropertiesAndMethods.test_slot_shadows_class_variable`
- `test_descr.ClassPropertiesAndMethods.test_set_doc`

## Verification

- 11 modules pass with no regressions: `test_descr test_class test_super test_abc test_property test_metaclass test_call test_module test_typing test_inspect test_decorators` (1,645 tests)
- CPython 3.14.4 byte-identical wording for both messages
- No other test or RustPython source references the old wording (grep'd `Lib/test/` and `crates/`)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Refined error messages for improved clarity when encountering class attribute conflicts and immutable type modifications.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->