### PR TITLE
Preserve __dict__ and __slots__ state in deque.__reduce__

### DIFF
--- a/Lib/test/test_deque.py
+++ b/Lib/test/test_deque.py
@@ -817,7 +817,6 @@ class TestSubclass(unittest.TestCase):
         d.clear()
         self.assertEqual(len(d), 0)
 
-    @unittest.expectedFailure  # TODO: RUSTPYTHON; AttributeError: 'Deque' object has no attribute 'x'
     def test_copy_pickle(self):
         for cls in Deque, DequeWithSlots:
             for d in cls('abc'), cls('abcde', maxlen=4):

--- a/crates/vm/src/stdlib/_collections.rs
+++ b/crates/vm/src/stdlib/_collections.rs
@@ -388,7 +388,11 @@ mod _collections {
                 Some(v) => vm.new_pyobj((vm.ctx.empty_tuple.clone(), v)),
                 None => vm.ctx.empty_tuple.clone().into(),
             };
-            Ok(vm.new_pyobj((cls, value, vm.ctx.none(), PyDequeIterator::new(zelf))))
+            // Use __getstate__ to capture both __dict__ and __slots__ values so
+            // subclass attributes survive a pickle round-trip (matches CPython's
+            // deque___reduce___impl, which calls _PyObject_GetState).
+            let state = vm.call_method(zelf.as_object(), "__getstate__", ())?;
+            Ok(vm.new_pyobj((cls, value, state, PyDequeIterator::new(zelf))))
         }
 
         #[pyclassmethod]


### PR DESCRIPTION
## Background

`pickle.dumps(d)` calls `d.__reduce__()`, which returns a 5-tuple `(cls, args, state, listiter, dictiter)`. The `state` slot is meant to carry whatever `__setstate__` (or the default attribute-restore path) needs to reconstruct subclass-specific data: typically `__dict__`, or `(__dict__, slots_dict)` when `__slots__` is in play.

RustPython's `deque.__reduce__` passed `None` for `state`, so any attribute set on a deque subclass was lost across a pickle round-trip. CPython's `deque___reduce___impl` (`Modules/_collectionsmodule.c::deque___reduce___impl`) calls `_PyObject_GetState` to get the right value.

## Repro

```python
import pickle
from collections import deque

class D(deque): pass
class DS(deque):
    __slots__ = ('x', 'y', '__dict__')

for cls in D, DS:
    d = cls('abc')
    d.x = ['x']  # slot for DS, dict for D
    d.z = ['z']  # always dict
    e = pickle.loads(pickle.dumps(d))

# CPython 3.14 (and now RustPython): e.x and e.z preserved.
# RustPython before this PR: AttributeError on e.x.
```

## Fix

Replace the `vm.ctx.none()` placeholder with the result of `__getstate__()` on the instance. `object.__getstate__` already handles both `__dict__` and the dict/slots tuple form, matching CPython's `_PyObject_GetState`. No code duplication.

## Tests unmasked

- `test_deque.TestSubclass.test_copy_pickle`

`test_pickle_recursive` still expected-fails for an unrelated recursion issue and stays marked.

## Verification

- 10 modules pass with no regressions: `test_deque test_collections test_pickle test_copy test_dataclasses test_descr test_class test_typing test_inspect test_functools` (2,562 tests)
- CPython 3.14.4 byte-identical for the repro on both subclass shapes
- `copy.copy(d)` continues to drop attributes (matches CPython — the `__copy__` path doesn't go through `__reduce__`)
- `copy.deepcopy(d)` preserves attributes via the new `__reduce__`
- Plain `deque`, `deque(maxlen=...)`, and empty `deque` round-trip unchanged


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved serialization handling for collection data structures to properly preserve state during pickling and unpickling operations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->