### PR TITLE
Reject __abc_tpflags__ with both SEQUENCE and MAPPING bits

### DIFF
--- a/Lib/test/test_collections.py
+++ b/Lib/test/test_collections.py
@@ -2028,7 +2028,6 @@ class TestCollectionABCs(ABCTestCase):
         self.assertEqual(len(mss), len(mss2))
         self.assertEqual(list(mss), list(mss2))
 
-    @unittest.expectedFailure  # TODO: RUSTPYTHON; AssertionError: TypeError not raised
     def test_illegal_patma_flags(self):
         with self.assertRaises(TypeError):
             class Both(Collection):

--- a/crates/vm/src/builtins/type.rs
+++ b/crates/vm/src/builtins/type.rs
@@ -604,38 +604,60 @@ impl PyType {
         attrs: &PyAttributes,
         bases: &[PyRef<Self>],
         ctx: &Context,
-    ) {
+    ) -> Result<(), String> {
         const COLLECTION_FLAGS: PyTypeFlags = PyTypeFlags::from_bits_truncate(
             PyTypeFlags::SEQUENCE.bits() | PyTypeFlags::MAPPING.bits(),
         );
 
-        // Don't override if flags are already set
-        if slots.flags.intersects(COLLECTION_FLAGS) {
-            return;
-        }
-
-        // First check in our own attributes
+        // Always validate this class's own __abc_tpflags__ even when slot
+        // flags were already inherited, otherwise a child setting both
+        // Py_TPFLAGS_SEQUENCE and Py_TPFLAGS_MAPPING would slip through.
         let abc_tpflags_name = ctx.intern_str("__abc_tpflags__");
         if let Some(abc_tpflags_obj) = attrs.get(abc_tpflags_name)
             && let Some(int_obj) = abc_tpflags_obj.downcast_ref::<crate::builtins::int::PyInt>()
         {
             let flags_val = int_obj.as_bigint().to_i64().unwrap_or(0);
             let abc_flags = PyTypeFlags::from_bits_truncate(flags_val as u64);
-            slots.flags |= abc_flags & COLLECTION_FLAGS;
-            return;
+            let masked = abc_flags & COLLECTION_FLAGS;
+            if masked == COLLECTION_FLAGS {
+                return Err(
+                    "__abc_tpflags__ cannot be both Py_TPFLAGS_SEQUENCE and Py_TPFLAGS_MAPPING"
+                        .to_owned(),
+                );
+            }
+            // Don't override flags already inherited from a base class.
+            if !slots.flags.intersects(COLLECTION_FLAGS) {
+                slots.flags |= masked;
+            }
+            return Ok(());
         }
 
-        // Then check in base classes
+        // No __abc_tpflags__ on this class — inheritance already happened
+        // in inherit_patma_flags, so nothing more to do if those bits are set.
+        if slots.flags.intersects(COLLECTION_FLAGS) {
+            return Ok(());
+        }
+
+        // Then check in base classes (legacy path for cases that bypass
+        // inherit_patma_flags).
         for base in bases {
             if let Some(abc_tpflags_obj) = base.find_name_in_mro(abc_tpflags_name)
                 && let Some(int_obj) = abc_tpflags_obj.downcast_ref::<crate::builtins::int::PyInt>()
             {
                 let flags_val = int_obj.as_bigint().to_i64().unwrap_or(0);
                 let abc_flags = PyTypeFlags::from_bits_truncate(flags_val as u64);
-                slots.flags |= abc_flags & COLLECTION_FLAGS;
-                return;
+                let masked = abc_flags & COLLECTION_FLAGS;
+                if masked == COLLECTION_FLAGS {
+                    return Err(
+                        "__abc_tpflags__ cannot be both Py_TPFLAGS_SEQUENCE and Py_TPFLAGS_MAPPING"
+                            .to_owned(),
+                    );
+                }
+                slots.flags |= masked;
+                return Ok(());
             }
         }
+        Ok(())
     }
 
     #[allow(clippy::too_many_arguments)]
@@ -671,7 +693,7 @@ impl PyType {
         Self::inherit_patma_flags(&mut slots, &bases);
 
         // Check for __abc_tpflags__ from ABCMeta (for collections.abc.Sequence, Mapping, etc.)
-        Self::check_abc_tpflags(&mut slots, &attrs, &bases, ctx);
+        Self::check_abc_tpflags(&mut slots, &attrs, &bases, ctx)?;
 
         if slots.basicsize == 0 {
             slots.basicsize = base.slots.basicsize;


### PR DESCRIPTION
## Background

`__abc_tpflags__` is the integer ABC pattern-matching flag set on a class so `match` statements can short-circuit `Sequence` vs `Mapping` dispatch. Setting both bits is meaningless for pattern matching and CPython rejects it in `Modules/_abc.c::_abc_init`:

```
TypeError: __abc_tpflags__ cannot be both Py_TPFLAGS_SEQUENCE and Py_TPFLAGS_MAPPING
```

RustPython's `check_abc_tpflags` (`crates/vm/src/builtins/type.rs`) copied the bits onto `slots.flags` without validating the conflict, silently producing an inconsistent type.

## Repro

```python
from collections.abc import Collection, Sequence, Mapping

class Both(Collection):
    __abc_tpflags__ = Sequence.__flags__ | Mapping.__flags__

# CPython 3.14: TypeError
# RustPython before this PR: class created without complaint

# Also: child overriding a valid parent
class Parent(Collection):
    __abc_tpflags__ = Sequence.__flags__

class Child(Parent):
    __abc_tpflags__ = Sequence.__flags__ | Mapping.__flags__

# CPython 3.14: TypeError
# RustPython before this PR: class created (parent's SEQUENCE bit
# triggered an early return that skipped Child's validation)
```

## Fix

Two changes inside `check_abc_tpflags`:

1. Mask `abc_flags` with `COLLECTION_FLAGS` (the `SEQUENCE | MAPPING` bits). If the masked value equals `COLLECTION_FLAGS`, return a `String` error — `new_heap_inner` already converts that to `TypeError` for the user.
2. Move the "flags already inherited, skip" early return below the self-attrs branch. The previous order let a child class's conflicting `__abc_tpflags__` slip through whenever the parent had already set one of the bits.

## Tests unmasked

- `test_collections.TestCollectionABCs.test_illegal_patma_flags`

## Verification

- 10 modules pass with no regressions: `test_collections test_descr test_class test_typing test_abc test_dataclasses test_super test_call test_module test_patma` (1,951 tests)
- CPython 3.14.4 byte-identical wording for both conflict shapes (direct and child-override)
- Edge cases probed: 3-level inheritance conflict (caught), diamond inheritance with no self flags (matches CPython — created OK), Sequence-only / Mapping-only / plain Collection subclasses (all OK), non-int `__abc_tpflags__` value (silently ignored, matches CPython)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Internal type validation function refactored to return explicit error results, enabling better error propagation and more robust inheritance handling.

* **Bug Fixes**
  * Type validation now properly detects and rejects invalid configurations where both sequence and mapping collection behaviors are declared simultaneously, preventing runtime issues from contradictory type metadata.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->