### PR TITLE
Preserve str subclass type returned by __str__ / __repr__

### DIFF
--- a/Lib/test/test_str.py
+++ b/Lib/test/test_str.py
@@ -2414,7 +2414,6 @@ class StrTest(string_tests.StringLikeTest,
         else:
             self.fail("Should have raised UnicodeDecodeError")
 
-    @unittest.expectedFailure  # TODO: RUSTPYTHON; AssertionError: <class 'str'> is not <class 'test.test_str.StrSubclass'>
     def test_conversion(self):
         # Make sure __str__() works properly
         class StrWithStr(str):

--- a/crates/vm/src/builtins/str.rs
+++ b/crates/vm/src/builtins/str.rs
@@ -406,6 +406,18 @@ impl Constructor for PyStr {
         }
 
         let args: Self::Args = func_args.bind(vm)?;
+
+        // CPython parity: when cls is exactly str, return the __str__ / __repr__
+        // result as-is so any str subclass type the user returned is preserved
+        // (matches unicode_new_impl which only invokes unicode_subtype_new when
+        // type != &PyUnicode_Type).
+        if cls.is(vm.ctx.types.str_type)
+            && args.encoding.is_missing()
+            && let OptionalArg::Present(input) = &args.object
+        {
+            return Ok(input.str(vm)?.into());
+        }
+
         let payload = Self::py_new(&cls, args, vm)?;
         payload.into_ref_with_type(vm, cls).map(Into::into)
     }


### PR DESCRIPTION
Closes #7450.

## Background

CPython's `unicode_new_impl` (`Objects/unicodeobject.c#L15575-L15596`) only invokes `unicode_subtype_new` when the requested type is a `str` subclass. When `type == &PyUnicode_Type`, it returns the result of `PyObject_Str(x)` as-is, preserving any `str` subclass type that `__str__` or `__repr__` returned.

RustPython's `PyStr::Constructor::py_new` extracted the raw bytes via `Self::from(s.as_wtf8().to_owned())`, then `slot_new` re-materialized through `into_ref_with_type(vm, cls)`. This stripped the subclass type even when `cls is str`.

## Repro

```python
class MyStr(str): pass
class Foo:
    def __repr__(self): return MyStr('hello')

print(type(str(Foo())))
# CPython 3.14:    <class '__main__.MyStr'>
# RustPython:      <class 'str'>     (before this PR)
```

## Fix

Add a branch in `slot_new` that returns `input.str(vm)?` directly when `cls is str_type` (no subtype conversion, no encoding). Subtype construction (`StrSubclass(...)`) and the `str(bytes, encoding)` decoding path are unchanged.

## Tests unmasked

- `test_str.StrTest.test_conversion` (11 `assertTypedEqual` cases covering `str(WithStr/StrWithStr/WithRepr(...))` × `StrSubclass` / `OtherStrSubclass` permutations)

## Verification

- CPython 3.14.4 byte-identical for 8 probed cases (plain `str()`, `str('hi')`, `str(MyStr('x'))`, `__str__`/`__repr__` returning subclass, `MyStr('z')`, `OtherStr(MyStr('w'))`, `str(b'abc', 'utf-8')`)
- No regressions across 14 modules (~3,349 tests): `test_str`, `test_descr`, `test_class`, `test_typing`, `test_userstring`, `test_format`, `test_pickle`, `test_io`, `test_collections`, `test_dict`, `test_set`, `test_exceptions`, `test_fstring`, `test_genericalias`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved string constructor to correctly preserve behavior when using user-defined string subclasses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->