### PR TITLE
Drop int() delegation to __trunc__

### DIFF
--- a/Lib/test/test_int.py
+++ b/Lib/test/test_int.py
@@ -380,7 +380,6 @@ class IntTestCases(unittest.TestCase):
     def test_string_float(self):
         self.assertRaises(ValueError, int, '1.2')
 
-    @unittest.expectedFailure  # TODO: RUSTPYTHON; AssertionError: TypeError not raised
     def test_intconversion(self):
         # Test __int__()
         class ClassicMissingMethods:

--- a/crates/vm/src/protocol/number.rs
+++ b/crates/vm/src/protocol/number.rs
@@ -58,20 +58,6 @@ impl PyObject {
             Ok(i.to_owned())
         } else if let Some(i) = self.number().int(vm).or_else(|| self.try_index_opt(vm)) {
             i
-        } else if let Ok(Some(f)) = vm.get_special_method(self, identifier!(vm, __trunc__)) {
-            _warnings::warn(
-                vm.ctx.exceptions.deprecation_warning,
-                "The delegation of int() to __trunc__ is deprecated.".to_owned(),
-                1,
-                vm,
-            )?;
-            let ret = f.invoke((), vm)?;
-            ret.try_index(vm).map_err(|_| {
-                vm.new_type_error(format!(
-                    "__trunc__ returned non-Integral (type {})",
-                    ret.class()
-                ))
-            })
         } else if let Some(s) = self.downcast_ref::<PyStr>() {
             try_convert(self, s.as_wtf8().trim().as_bytes(), vm)
         } else if let Some(bytes) = self.downcast_ref::<PyBytes>() {


### PR DESCRIPTION
## Background

CPython 3.14 fully removed the long-deprecated delegation from `int()` to `__trunc__`. Classes that want to support `int(x)` must implement `__int__` or `__index__`; `math.trunc(x)` continues to use `__trunc__`.

RustPython still delegated to `__trunc__` (with a `DeprecationWarning`) inside `PyObject::try_int`, so `int(JustTrunc())` returned the truncated value instead of raising `TypeError`.

## Repro

```python
class JustTrunc:
    def __trunc__(self): return 42

int(JustTrunc())
# CPython 3.14:    TypeError: int() argument must be a string, a bytes-like object or a real number, not 'JustTrunc'
# RustPython:      42 (with DeprecationWarning)   (before this PR)
```

## Fix

Delete the `__trunc__` branch in `PyObject::try_int` (`crates/vm/src/protocol/number.rs`). The fall-through reaches the existing `TypeError` arm.

`math.trunc()` is unaffected — it goes through the `__trunc__` method directly, not through `try_int`.

## Tests unmasked

- `test_int.IntTestCases.test_intconversion` (covers `int(JustTrunc())` raising `TypeError`)

## Verification

- CPython 3.14.4 byte-identical for `int(JustTrunc())` (TypeError), `int(IntOverridesTrunc())` (uses `__int__` → 42), `math.trunc(T())` (still uses `__trunc__` → 100)
- No regressions across 8 modules (~2,022 tests): `test_int`, `test_math`, `test_decimal`, `test_descr`, `test_class`, `test_inspect`, `test_typing`, `test_unittest.testmock.testmagicmethods`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Changes**
  * Removed `__trunc__` method delegation from integer conversion. The `int()` function will no longer attempt to use the `__trunc__` method on objects.
  * Removed associated deprecation warnings previously issued during integer conversion.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->