### PR TITLE
Reject format spec with width above i32::MAX

### DIFF
--- a/Lib/test/test_str.py
+++ b/Lib/test/test_str.py
@@ -1463,7 +1463,6 @@ class StrTest(string_tests.StringLikeTest,
         with self.assertRaises(ValueError):
             result = format(2.34, format_string)
 
-    @unittest.expectedFailure  # TODO: RUSTPYTHON; AssertionError: ValueError not raised
     def test_format_huge_width(self):
         format_string = "{}f".format(sys.maxsize + 1)
         with self.assertRaises(ValueError):

--- a/crates/common/src/format.rs
+++ b/crates/common/src/format.rs
@@ -315,6 +315,11 @@ impl FormatSpec {
         let (alternate_form, text) = parse_alternate_form(text);
         let (zero, text) = parse_zero(text);
         let (width, text) = parse_number(text)?;
+        if let Some(w) = width
+            && w > i32::MAX as usize
+        {
+            return Err(FormatSpecError::DecimalDigitsTooMany);
+        }
         let (grouping_option, text) = FormatGrouping::parse(text);
         if let Some(grouping) = &grouping_option {
             Self::validate_separator(grouping, text)?;


### PR DESCRIPTION
## Background

CPython rejects format-spec widths that exceed `Py_ssize_t::MAX` with `ValueError: Too many decimal digits in format string`. RustPython's `FormatSpec::_parse` only capped **precision** (via `parse_precision`); width digits were accepted up to `usize::MAX`, so values like `sys.maxsize + 1` silently produced an effectively-ignored width.

## Repro

```python
import sys
fs = '{}f'.format(sys.maxsize + 1)  # '9223372036854775808f'

format(2.34, fs)
# CPython 3.14:    ValueError: Too many decimal digits in format string
# RustPython:      '2.340000'        (silently dropped huge width, before this PR)
```

## Fix

After `parse_number` returns the width in `FormatSpec::_parse`, reject any value above `i32::MAX` with `FormatSpecError::DecimalDigitsTooMany`. This matches the cap precision already uses and produces the byte-identical CPython `"Too many decimal digits in format string"` ValueError.

## Tests unmasked

- `test_str.StrTest.test_format_huge_width`

## Verification

- CPython 3.14.4 byte-identical wording for the huge-width case
- Precision path unchanged (`test_format_huge_precision` still passes with its existing `"Precision too big"` message)
- Normal widths (e.g. `format(2.34, '100.3f')`) still pad correctly
- No regressions across 7 modules: `test_str`, `test_format`, `test_unicode_identifiers`, `test_fstring`, `test_int`, `test_float`, `test_decimal`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved validation for format specifications to properly reject overly large width values with appropriate error handling during parsing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->