### PR TITLE
Reject format-string field index above Py_ssize_t::MAX

### DIFF
--- a/Lib/test/test_str.py
+++ b/Lib/test/test_str.py
@@ -1469,7 +1469,6 @@ class StrTest(string_tests.StringLikeTest,
         with self.assertRaises(ValueError):
             result = format(2.34, format_string)
 
-    @unittest.expectedFailure  # TODO: RUSTPYTHON; IndexError: tuple index out of range
     def test_format_huge_item_number(self):
         format_string = "{{{}:.6f}}".format(sys.maxsize + 1)
         with self.assertRaises(ValueError):

--- a/crates/common/src/format.rs
+++ b/crates/common/src/format.rs
@@ -1102,6 +1102,7 @@ pub enum FormatParseError {
     EmptyAttribute,
     MissingRightBracket,
     InvalidCharacterAfterRightBracket,
+    TooManyDecimalDigits,
 }
 
 impl FromStr for FormatSpec {
@@ -1185,7 +1186,19 @@ impl FieldName {
         let field_type = if first.is_empty() {
             FieldType::Auto
         } else if let Some(index) = parse_usize(&first) {
+            // Match CPython's get_integer: digits-only segment must fit in
+            // Py_ssize_t. Above that, raise ValueError at parse time.
+            if index > isize::MAX as usize {
+                return Err(FormatParseError::TooManyDecimalDigits);
+            }
             FieldType::Index(index)
+        } else if first
+            .as_str()
+            .ok()
+            .is_some_and(|s| s.bytes().all(|b| b.is_ascii_digit()))
+        {
+            // All-digit segment whose value overflows usize itself.
+            return Err(FormatParseError::TooManyDecimalDigits);
         } else {
             FieldType::Keyword(first)
         };

--- a/crates/vm/src/format.rs
+++ b/crates/vm/src/format.rs
@@ -114,6 +114,9 @@ impl ToPyException for FormatParseError {
     fn to_pyexception(&self, vm: &VirtualMachine) -> PyBaseExceptionRef {
         match self {
             Self::UnmatchedBracket => vm.new_value_error("expected '}' before end of string"),
+            Self::TooManyDecimalDigits => {
+                vm.new_value_error("Too many decimal digits in format string")
+            }
             _ => vm.new_value_error("Unexpected error parsing format string"),
         }
     }


### PR DESCRIPTION
## Background

CPython rejects digit-only format-string field names that overflow `Py_ssize_t` at parse time with `ValueError: Too many decimal digits in format string` (`Python/string_parser.c::get_integer`). RustPython's `FieldName::parse` accepted any digit string `usize::from_str` could parse:
- Values within `usize` but above `isize::MAX` → wrong exception at lookup (`IndexError: tuple index out of range`)
- Values above `usize::MAX` → fell through to `Keyword`, then `KeyError`

## Repro

```python
import sys
fs = '{{{}:.6f}}'.format(sys.maxsize + 1)  # '{9223372036854775808:.6f}'

fs.format(2.34)
# CPython 3.14:    ValueError: Too many decimal digits in format string
# RustPython:      IndexError: tuple index out of range  (before this PR)
```

## Fix

In `FieldName::parse`, after `parse_usize` returns the digit-only index, reject values above `isize::MAX` (matching CPython's `Py_ssize_t::MAX`). When `parse_usize` itself fails on a digits-only string (overflowing `usize`), raise the same error. A new `FormatParseError::TooManyDecimalDigits` maps to the byte-identical CPython wording.

The cap is `isize::MAX as usize`, which equals `Py_ssize_t::MAX` on every platform (i64 on 64-bit, i32 on 32-bit). Values up to `isize::MAX` parse successfully and only fail at lookup, matching CPython.

Nested `[index]` field-name parts (`'{0[huge]}'`) have the same shape but no upstream regression test; left for a follow-up.

## Tests unmasked

- `test_str.StrTest.test_format_huge_item_number`

## Verification

CPython 3.14.4 byte-identical for boundary cases:
- `{2147483647}` (i32::MAX): IndexError (parse OK)
- `{2147483648}` (i32::MAX+1): IndexError (parse OK — not band-aid)
- `{9223372036854775807}` (isize::MAX): IndexError (parse OK)
- `{9223372036854775808}` (isize::MAX+1): ValueError
- `{99999999999999999999...}` (usize overflow): ValueError

Normal field names unchanged: `{0}`, `{abc}`, `{0[1]}`, `{abc1}` (digit in keyword), `{007}` (leading zeros), `{0.attr}`, dynamic `'{0:{1}}'.format('x', 5)`.

No regressions across `test_str`, `test_format`, `test_fstring`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced validation for numeric field names in format strings to detect values exceeding parsing limits and provide more precise error messaging when invalid format specifications are encountered.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->