### PR TITLE
Make updating actions cache synchronous

### DIFF
--- a/.github/workflows/update-caches.yml
+++ b/.github/workflows/update-caches.yml
@@ -9,6 +9,10 @@ on:
     branches:
       - main
 
+concurrency:
+    group: ${{ github.workflow }}
+    cancel-in-progress: false
+
 env:
   CARGO_INCREMENTAL: 0
   CARGO_TERM_COLOR: always


### PR DESCRIPTION
If multiple PRs are being merged in a short period of time multiple runs of the workflow can trigger, and cause a little race condition regarding what is considered the latest cache. This PR makes it so no more than 1 run of updating the cache can run at any given time