### PR TITLE
Match CPython's "argument of type ... is not a container or iterable" wording

### DIFF
--- a/Lib/test/test_contains.py
+++ b/Lib/test/test_contains.py
@@ -16,7 +16,6 @@ class seq(base_set):
         return [self.el][n]
 
 class TestContains(unittest.TestCase):
-    @unittest.expectedFailure  # TODO: RUSTPYTHON; Wrong error message
     def test_common_tests(self):
         a = base_set(1)
         b = myset(1)

--- a/crates/vm/src/protocol/sequence.rs
+++ b/crates/vm/src/protocol/sequence.rs
@@ -1,5 +1,5 @@
 use crate::{
-    PyObject, PyObjectRef, PyPayload, PyResult, VirtualMachine,
+    AsObject, PyObject, PyObjectRef, PyPayload, PyResult, VirtualMachine,
     builtins::{PyList, PyListRef, PySlice, PyTuple, PyTupleRef},
     convert::ToPyObject,
     function::PyArithmeticValue,
@@ -398,7 +398,19 @@ impl PySequence<'_> {
             return f(self, target, vm);
         }
 
-        let iter = self.obj.to_owned().get_iter(vm)?;
+        // CPython parity: when neither __contains__ nor __iter__ is available,
+        // `PySequence_Contains` rewords the get_iter TypeError into the
+        // membership-test wording. Other exception types propagate unchanged.
+        let iter = self.obj.to_owned().get_iter(vm).map_err(|e| {
+            if e.fast_isinstance(vm.ctx.exceptions.type_error) {
+                vm.new_type_error(format!(
+                    "argument of type '{}' is not a container or iterable",
+                    self.obj.class().name()
+                ))
+            } else {
+                e
+            }
+        })?;
         let iter = iter.iter::<PyObjectRef>(vm)?;
 
         for elem in iter {


### PR DESCRIPTION
## Background

CPython's `PySequence_Contains` (`Objects/abstract.c::_PySequence_IterSearch`) catches the `TypeError` from `PyObject_GetIter` when neither `__contains__` nor `__iter__` is available, and re-raises with membership-test wording:

```
TypeError: argument of type 'X' is not a container or iterable
```

RustPython's `PySequence::contains` propagated the get_iter error verbatim, so `1 in obj` produced `'X' object is not iterable` — a literal but less specific message.

## Repro

```python
class X: pass
1 in X()
# CPython 3.14:    TypeError: argument of type 'X' is not a container or iterable
# RustPython:      TypeError: 'X' object is not iterable    (before this PR)
```

## Fix

Wrap the `get_iter(vm)` call inside `PySequence::contains` in `map_err`. When the failure is a `TypeError` (the "not iterable" case), re-raise with the byte-identical CPython membership-test wording. Other exception types (e.g. propagated from a user `__iter__`) pass through unchanged.

## Tests unmasked

- `test_contains.TestContains.test_common_tests`

## Verification

- CPython 3.14.4 byte-identical for the bare-class case
- Types with `__contains__` (str/tuple/dict/set/list/...): unchanged — they go through the `slots().contains` path before reaching this site
- Types with only `__iter__`: unchanged — `get_iter` succeeds
- No regressions across 8 modules (~1,349 tests): `test_contains`, `test_iter`, `test_dict`, `test_set`, `test_list`, `test_tuple`, `test_str`, `test_bytes`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes

* **Improved error messages for membership testing**: TypeError messages when testing membership on non-container or non-iterable objects now align with CPython's standard wording for better consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->