### PR TITLE
Preserve recursively-set value in defaultdict.__missing__

### DIFF
--- a/Lib/collections/_defaultdict.py
+++ b/Lib/collections/_defaultdict.py
@@ -17,6 +17,10 @@ class defaultdict(dict):
             val = self.default_factory()
         else:
             raise KeyError(key)
+        # CPython parity: a recursive __missing__ via factory() may have
+        # already populated key; preserve that value instead of overwriting.
+        if key in self:
+            return self[key]
         self[key] = val
         return val
 

--- a/Lib/test/test_defaultdict.py
+++ b/Lib/test/test_defaultdict.py
@@ -186,7 +186,6 @@ class TestDefaultDict(unittest.TestCase):
         with self.assertRaises(TypeError):
             i |= None
 
-    @unittest.expectedFailure  # TODO: RUSTPYTHON; AssertionError: 1 != 2
     def test_factory_conflict_with_set_value(self):
         key = "conflict_test"
         count = 0


### PR DESCRIPTION
## Background

CPython's `defaultdict.__missing__` (`Modules/_collectionsmodule.c::defdict_missing`) calls `default_factory()` first; if the factory's recursion populated `self[key]` while running, the existing value is preserved instead of being overwritten.

RustPython ships a Python fallback at `Lib/collections/_defaultdict.py` (the C-implemented `_collections.defaultdict` is not available — see the comment at `Lib/collections/__init__.py:60`). That fallback unconditionally executed `self[key] = val` after the factory returned, overwriting any value the recursive call had already stored.

## Repro

```python
from collections import defaultdict
key = 'k'
count = 0
def fac():
    global count
    count += 1
    local = count
    if count == 1:
        d[key]   # recursive lookup — inner factory stores d[key] = 2
    return local
d = defaultdict(fac)

d[key]
# CPython 3.14: 2  (outer factory's local=1 does NOT overwrite)
# RustPython:   1  (overwrote)   (before this PR)
```

## Fix

Add `if key in self: return self[key]` after the factory call, before the assignment. `dict.__contains__` does not invoke `__missing__`, so there's no recursion risk; in the common (non-reentrant) case the check is False and behavior is unchanged.

## Tests unmasked

- `test_defaultdict.TestDefaultDict.test_factory_conflict_with_set_value`

## Verification

- CPython 3.14.4 byte-identical for the test's repro (result=2, count=2)
- Normal cases unchanged: `defaultdict(int)` increment, `defaultdict()` with no factory still raises `KeyError`
- No regressions across `test_defaultdict`, `test_collections`, `test_dict`, `test_typing`, `test_descr` (~1,116 tests)