### PR TITLE
Make mappingproxy's nb_or slot symmetric for dict | mp

### DIFF
--- a/Lib/test/test_types.py
+++ b/Lib/test/test_types.py
@@ -1362,7 +1362,6 @@ class MappingProxyTests(unittest.TestCase):
         self.assertEqual(view['key1'], 70)
         self.assertEqual(copy['key1'], 27)
 
-    @unittest.expectedFailure  # TODO: RUSTPYTHON; TypeError: unsupported operand type(s) for |: 'dict' and 'mappingproxy'
     def test_union(self):
         mapping = {'a': 0, 'b': 1, 'c': 2}
         view = self.mappingproxy(mapping)

--- a/Lib/test/test_userdict.py
+++ b/Lib/test/test_userdict.py
@@ -244,7 +244,6 @@ class UserDictTest(mapping_tests.TestHashMappingProtocol):
 
     test_repr_deep = mapping_tests.TestHashMappingProtocol.test_repr_deep
 
-    @unittest.expectedFailure  # TODO: RUSTPYTHON; TypeError: unsupported operand type(s) for |: 'UserDict' and 'mappingproxy'
     def test_mixed_or(self):
         for t in UserDict, dict, types.MappingProxyType:
             with self.subTest(t.__name__):

--- a/crates/vm/src/builtins/mappingproxy.rs
+++ b/crates/vm/src/builtins/mappingproxy.rs
@@ -258,11 +258,19 @@ impl AsNumber for PyMappingProxy {
     fn as_number() -> &'static PyNumberMethods {
         static AS_NUMBER: PyNumberMethods = PyNumberMethods {
             or: Some(|a, b, vm| {
-                if let Some(a) = a.downcast_ref::<PyMappingProxy>() {
-                    a.__or__(b.to_pyobject(vm), vm)
-                } else {
-                    Ok(vm.ctx.not_implemented())
-                }
+                // Mirror CPython's mappingproxy_or: when either side is a
+                // mappingproxy, unwrap to its underlying mapping and delegate
+                // to PyNumber_Or so `dict | mp`, `mp | dict`, and `mp | mp`
+                // all produce a `dict` result.
+                let a_obj = match a.downcast_ref::<PyMappingProxy>() {
+                    Some(mp) => mp.copy(vm)?,
+                    None => a.to_pyobject(vm),
+                };
+                let b_obj = match b.downcast_ref::<PyMappingProxy>() {
+                    Some(mp) => mp.copy(vm)?,
+                    None => b.to_pyobject(vm),
+                };
+                vm._or(a_obj.as_ref(), b_obj.as_ref())
             }),
             inplace_or: Some(|a, b, vm| {
                 if let Some(a) = a.downcast_ref::<PyMappingProxy>() {


### PR DESCRIPTION
## Background

CPython's `mappingproxy_or` (`Objects/descrobject.c`) unwraps a `mappingproxy` on either side of `|` to its underlying mapping and delegates back to `PyNumber_Or`. This makes `dict | mp`, `mp | dict`, and `mp | mp` all produce a plain `dict` result without dict's own `nb_or` having to know about `mappingproxy`.

RustPython's `or` slot in `AsNumber for PyMappingProxy` only handled the case where the *left* operand is a mappingproxy. When the slot fired with `a = dict, b = mp` (because `dict.nb_or` returned `NotImplemented`), it returned `NotImplemented` again — so `dict | mp` raised `TypeError`. This propagated to `UserDict | mappingproxy` (which calls `self.data | other`).

## Repro

```python
import types
from collections import UserDict
mp = types.MappingProxyType({1: 'c'})

{0: 'a'} | mp
# CPython 3.14: {0: 'a', 1: 'c'}
# RustPython:   TypeError: unsupported operand type(s) for |: 'dict' and 'mappingproxy'  (before this PR)

UserDict({0: 'a'}) | mp
# CPython 3.14: UserDict({0: 'a', 1: 'c'})
# RustPython:   TypeError: unsupported operand type(s) for |: 'UserDict' and 'mappingproxy'  (before this PR)
```

## Fix

Rewrite the `or` slot to unwrap a `mappingproxy` on either side (or both) before delegating to `vm._or` on the underlying mappings. Mirrors CPython's `mappingproxy_or`. The `inplace_or` slot is unchanged — `|=` is explicitly rejected on a mappingproxy.

## Tests unmasked

- `test_userdict.UserDictTest.test_mixed_or`

## Verification

- CPython 3.14.4 byte-identical for all 6 mixed cases (`dict | mp`, `mp | dict`, `mp | mp`, `UserDict | mp`, `mp | UserDict`, plus subclass propagation: `UserDict | Sub`, `Sub | UserDict`, `Sub | Sub2`)
- `mp |= dict` still raises `TypeError` (`inplace_or` slot unchanged)
- `mp | list` and `list | mp` still raise `TypeError` (non-mapping operands)
- Class-dict mappingproxy (`C.__dict__ | dict`) works for the other `MappingProxyInner` variant too
- No regressions across 9 modules (~2,147 tests): `test_userdict`, `test_dict`, `test_collections`, `test_descr`, `test_class`, `test_typing`, `test_userlist`, `test_ordered_dict`, `test_set`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes

* Fixed the `|` (or) operator behavior with mapping proxies. Operations combining dictionaries and mapping proxies (`dict | proxy`, `proxy | dict`, `proxy | proxy`) now consistently return dictionaries as expected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->