### PR TITLE
Fix pow() raising ValueError instead of TypeError for non-int exponent

### DIFF
--- a/crates/vm/src/builtins/int.rs
+++ b/crates/vm/src/builtins/int.rs
@@ -395,6 +395,9 @@ impl PyInt {
     }
 
     fn modpow(&self, other: PyObjectRef, modulus: PyObjectRef, vm: &VirtualMachine) -> PyResult {
+        if other.downcast_ref::<Self>().is_none() {
+            return Ok(vm.ctx.not_implemented());
+        }
         let modulus = match modulus.downcast_ref::<Self>() {
             Some(val) => val.as_bigint(),
             None => return Ok(vm.ctx.not_implemented()),

--- a/extra_tests/snippets/builtin_pow.py
+++ b/extra_tests/snippets/builtin_pow.py
@@ -22,6 +22,9 @@ assert_raises(TypeError, pow, 2.0, 4, 5)
 assert pow(2, -1, 5) == 3
 assert_raises(ValueError, pow, 2, 2, 0)
 
+assert_raises(TypeError, pow, 1, None, 0)
+assert_raises(TypeError, pow, True, 1.5, False)
+
 
 assert_almost_equal = assert_equal
 


### PR DESCRIPTION
## Description

Fixes #7724

`pow(x, y, z)` raised `ValueError` when the modulus was zero even if the exponent was a non-integer such as `None` or `float`, instead of falling through to the `TypeError` that CPython raises.

#### AS-IS
```
>>> pow(1, None, 0)
ValueError: pow() 3rd argument cannot be 0
```

#### TO-BE
```
>>> pow(1, None, 0)
TypeError: unsupported operand type(s) for ** or pow(): 'int', 'NoneType', 'int'
```
(matching CPython)

## Changes

- Downcast `other` to `PyInt` first in `PyInt::modpow` and return `NotImplemented` when the cast fails, so `ternary_op` falls through to the proper `TypeError` — either the formatted "unsupported operand type(s)" message or `PyFloat`'s "pow() 3rd argument not allowed unless all arguments are integers".
- Add regression tests in `extra_tests/snippets/builtin_pow.py` covering `pow(1, None, 0)` and `pow(True, 1.5, False)`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Enhanced type validation in the `pow()` function's 3-argument form to properly handle and reject incompatible argument types.

* **Tests**
  * Added test cases verifying `pow()` raises `TypeError` for incompatible argument types.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->