### PR TITLE
Raise OverflowError in float pow when complex result overflows

### DIFF
--- a/crates/vm/src/builtins/complex.rs
+++ b/crates/vm/src/builtins/complex.rs
@@ -164,7 +164,7 @@ fn inner_pow(v1: Complex64, v2: Complex64, vm: &VirtualMachine) -> PyResult<Comp
 
     let ans = powc(v1, v2);
     if ans.is_infinite() && !(v1.is_infinite() || v2.is_infinite()) {
-        Err(vm.new_overflow_error("complex exponentiation overflow"))
+        Err(vm.new_overflow_error("complex exponentiation"))
     } else {
         Ok(ans)
     }

--- a/crates/vm/src/builtins/complex.rs
+++ b/crates/vm/src/builtins/complex.rs
@@ -150,7 +150,11 @@ fn inner_div(v1: Complex64, v2: Complex64, vm: &VirtualMachine) -> PyResult<Comp
     Ok(v1.fdiv(v2))
 }
 
-fn inner_pow(v1: Complex64, v2: Complex64, vm: &VirtualMachine) -> PyResult<Complex64> {
+pub(crate) fn complex_pow(
+    v1: Complex64,
+    v2: Complex64,
+    vm: &VirtualMachine,
+) -> PyResult<Complex64> {
     if v1.is_zero() {
         return if v2.re < 0.0 || v2.im != 0.0 {
             let msg = format!("{v1} cannot be raised to a negative or complex power");
@@ -471,7 +475,7 @@ impl AsNumber for PyComplex {
             multiply: Some(|a, b, vm| PyComplex::number_op(a, b, |a, b, _vm| a * b, vm)),
             power: Some(|a, b, c, vm| {
                 if vm.is_none(c) {
-                    PyComplex::number_op(a, b, inner_pow, vm)
+                    PyComplex::number_op(a, b, complex_pow, vm)
                 } else {
                     Err(vm.new_value_error(String::from("complex modulo")))
                 }

--- a/crates/vm/src/builtins/float.rs
+++ b/crates/vm/src/builtins/float.rs
@@ -161,7 +161,12 @@ pub fn float_pow(v1: f64, v2: f64, vm: &VirtualMachine) -> PyResult {
     } else if v1.is_sign_negative() && (v2.floor() - v2).abs() > f64::EPSILON {
         let v1 = Complex64::new(v1, 0.);
         let v2 = Complex64::new(v2, 0.);
-        Ok(v1.powc(v2).to_pyobject(vm))
+        let ans = v1.powc(v2);
+        if ans.is_infinite() && !(v1.is_infinite() || v2.is_infinite()) {
+            Err(vm.new_overflow_error("complex exponentiation"))
+        } else {
+            Ok(ans.to_pyobject(vm))
+        }
     } else {
         Ok(v1.powf(v2).to_pyobject(vm))
     }

--- a/crates/vm/src/builtins/float.rs
+++ b/crates/vm/src/builtins/float.rs
@@ -161,12 +161,7 @@ pub fn float_pow(v1: f64, v2: f64, vm: &VirtualMachine) -> PyResult {
     } else if v1.is_sign_negative() && (v2.floor() - v2).abs() > f64::EPSILON {
         let v1 = Complex64::new(v1, 0.);
         let v2 = Complex64::new(v2, 0.);
-        let ans = v1.powc(v2);
-        if ans.is_infinite() && !(v1.is_infinite() || v2.is_infinite()) {
-            Err(vm.new_overflow_error("complex exponentiation"))
-        } else {
-            Ok(ans.to_pyobject(vm))
-        }
+        Ok(super::complex::complex_pow(v1, v2, vm)?.to_pyobject(vm))
     } else {
         Ok(v1.powf(v2).to_pyobject(vm))
     }

--- a/extra_tests/snippets/builtin_pow.py
+++ b/extra_tests/snippets/builtin_pow.py
@@ -22,6 +22,10 @@ assert_raises(TypeError, pow, 2.0, 4, 5)
 assert pow(2, -1, 5) == 3
 assert_raises(ValueError, pow, 2, 2, 0)
 
+assert_raises(OverflowError, pow, -2, 2000.5)
+assert_raises(OverflowError, pow, -2.0, 2000.5)
+assert_raises(OverflowError, complex(-2).__pow__, complex(2000.5))
+
 
 assert_almost_equal = assert_equal
 


### PR DESCRIPTION
## Description

Fixes #7726 

`pow(negative, non_integer)` routes through `float_pow`'s complex branch (negative base × non-integer exponent) and silently returned an infinite complex value (e.g. `(-inf-infj)`) instead of raising `OverflowError`, diverging from CPython.

#### AS-IS
```
>>> pow(-316340, 8481.102091645396)
(-inf-infj)
```

#### TO-BE
```
>>> pow(-316340, 8481.102091645396)
OverflowError: complex exponentiation
```
(matching CPython)

## Changes

- Delegate `float_pow`'s negative-base × non-integer-exponent branch to `complex_pow` instead of calling `Complex64::powc` directly without any overflow check.
- Rename `complex.rs::inner_pow` to `pub(crate) complex_pow` so `float.rs` can reuse it.
- Align the overflow message with CPython: `"complex exponentiation overflow"` → `"complex exponentiation"`.
- Add regression tests for all three entry points (`int × float`, `float × float`, `complex × complex`).

## Alternatives Considered

1. **Inline the overflow check inside `float_pow`** (initial attempt). Rejected because the same check already exists in `complex.rs::inner_pow`. Duplicating the guard across two files is exactly the kind of inconsistency that produced this bug — `complex(-316340) ** complex(8481.10…)` already raised `OverflowError`, but `pow(-316340, 8481.10…)` did not.

2. **Expose the low-level `powc` helper and re-implement zero-base + overflow handling in `float_pow`.** Rejected for the same reason: `powc` is a pure formula; the semantics (zero-base `ZeroDivisionError`, overflow `OverflowError`) belong with the higher-level `complex_pow`. Splitting them across files re-introduces the original divergence risk.

3. **Delegate `float_pow` to `complex_pow`** *(chosen)*. Mirrors CPython's `Objects/floatobject.c:765`, where `float_pow` defers to `PyComplex_Type.tp_as_number->nb_power` (i.e. `complex_pow`). All complex-pow semantics now live in one function. As a side benefit, both paths (`pow(neg_float, float)` and `complex(neg_float) ** complex(float)`) use the same `powc` formula — previously the float path used `num-complex::Complex64::powc` (post-0.4.4 formula) while the complex path used the local `powc` helper (intentionally pinned to the pre-0.4.4 formula for regression-test compatibility), causing subtle numeric divergence between otherwise equivalent expressions.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved complex-number exponentiation for negative bases with non-integer exponents; overflow conditions now consistently raise OverflowError and present a shortened error message.
* **Tests**
  * Added overflow-focused tests verifying that large non-integer exponentiation of negative bases raises OverflowError across real and complex paths.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->