### PR TITLE
Accept __index__-conforming objects for compile() flags / optimize

### DIFF
--- a/Lib/test/test_call.py
+++ b/Lib/test/test_call.py
@@ -585,7 +585,6 @@ class FastCallTests(unittest.TestCase):
                 result = _testcapi.pyobject_vectorcall(func, args, kwnames)
                 self.check_result(result, expected)
 
-    @unittest.expectedFailure # TODO: RUSTPYTHON; TypeError: Expected type 'int' but 'IntWithDict' found.
     def test_fastcall_clearing_dict(self):
         # Test bpo-36907: the point of the test is just checking that this
         # does not crash.

--- a/crates/vm/src/stdlib/builtins.rs
+++ b/crates/vm/src/stdlib/builtins.rs
@@ -21,8 +21,8 @@ mod builtins {
         common::hash::PyHash,
         function::{
             ArgBytesLike, ArgCallable, ArgIndex, ArgIntoBool, ArgIterable, ArgMapping,
-            ArgStrOrBytesLike, Either, FsPath, FuncArgs, KwArgs, OptionalArg, OptionalOption,
-            PosArgs,
+            ArgPrimitiveIndex, ArgStrOrBytesLike, Either, FsPath, FuncArgs, KwArgs, OptionalArg,
+            OptionalOption, PosArgs,
         },
         protocol::{PyIter, PyIterReturn},
         py_io,
@@ -99,12 +99,15 @@ mod builtins {
         source: PyObjectRef,
         filename: FsPath,
         mode: PyUtf8StrRef,
+        // CPython parity: flags / optimize accept any object with __index__,
+        // not just exact int. Matches the behavior of `int(x)` arg conversion
+        // used by Python/Python-ast.c::compile.
         #[pyarg(any, optional)]
-        flags: OptionalArg<PyIntRef>,
+        flags: OptionalArg<ArgPrimitiveIndex<i32>>,
         #[pyarg(any, optional)]
         dont_inherit: OptionalArg<bool>,
         #[pyarg(any, optional)]
-        optimize: OptionalArg<PyIntRef>,
+        optimize: OptionalArg<ArgPrimitiveIndex<i32>>,
         #[pyarg(any, optional)]
         _feature_version: OptionalArg<i32>,
     }
@@ -264,7 +267,7 @@ mod builtins {
 
             let mode_str = args.mode.as_str();
 
-            let optimize: i32 = args.optimize.map_or(Ok(-1), |v| v.try_to_primitive(vm))?;
+            let optimize: i32 = args.optimize.map_or(-1, |v| v.value);
             let optimize: u8 = if optimize == -1 {
                 vm.state.config.settings.optimize
             } else {
@@ -277,7 +280,7 @@ mod builtins {
                 .source
                 .fast_isinstance(&_ast::NodeAst::make_static_type())
             {
-                let flags: i32 = args.flags.map_or(Ok(0), |v| v.try_to_primitive(vm))?;
+                let flags: i32 = args.flags.map_or(0, |v| v.value);
                 let is_ast_only = !(flags & _ast::PY_CF_ONLY_AST).is_zero();
 
                 // func_type mode requires PyCF_ONLY_AST
@@ -342,7 +345,7 @@ mod builtins {
                 let source = decode_source_bytes(&source, &args.filename.to_string_lossy(), vm)?;
                 let source = source.as_str();
 
-                let flags = args.flags.map_or(Ok(0), |v| v.try_to_primitive(vm))?;
+                let flags: i32 = args.flags.map_or(0, |v| v.value);
 
                 if !(flags & !_ast::PY_COMPILE_FLAGS_MASK).is_zero() {
                     return Err(vm.new_value_error("compile() unrecognized flags"));


### PR DESCRIPTION
## Background

CPython's `compile()` (`Python/Python-ast.c`) accepts any object with `__index__` for the `flags` and `optimize` arguments — not just exact `int`. RustPython's `CompileArgs` typed both fields as `OptionalArg<PyIntRef>`, so a class with only `__index__` raised `TypeError: Expected type 'int' but '<X>' found.` during arg binding.

bpo-36907's regression test (`test_call.test_fastcall_clearing_dict`) exercises exactly this: an `IntWithDict.__index__` that mutates `self.kwargs` mid-call. CPython parses both args via `__index__`, doesn't crash even when the kwargs dict is cleared between binding and use.

## Repro

```python
import gc
class IntWithDict:
    __slots__ = ['kwargs']
    def __init__(self, **kwargs): self.kwargs = kwargs
    def __index__(self):
        self.kwargs.clear()
        gc.collect()
        return 0

x = IntWithDict(optimize=IntWithDict())
compile("pass", "", "exec", x, **x.kwargs)
# CPython 3.14: succeeds
# RustPython:   TypeError: Expected type 'int' but 'IntWithDict' found.   (before this PR)
```

## Fix

Change `flags` and `optimize` in `CompileArgs` from `OptionalArg<PyIntRef>` to `OptionalArg<ArgPrimitiveIndex<i32>>`. `ArgPrimitiveIndex` (already used by `range`, `slice`, `bytes.__mul__`, `hex`, `oct`, ...) calls `__index__` then converts to the primitive in one step. Three call sites simplify from `.map_or(Ok(default), |v| v.try_to_primitive(vm))?` to `.map_or(default, |v| v.value)`.

## Tests unmasked

- `test_call.FastCallTests.test_fastcall_clearing_dict`

## Verification

- CPython 3.14.4 byte-identical for the bpo-36907 repro
- Normal cases unchanged: `compile("...", "<t>", "eval", 0)`, `compile(..., flags=0)`, `compile(..., optimize=1)`
- Non-int, non-`__index__` objects still raise `TypeError` (now from `try_index` instead of strict `PyIntRef` check)
- No regressions across `test_call`, `test_compile`, `test_int`, `test_index`, `test_descr`, `test_typing`, `test_ast` (~1,571 tests)
- Cross-module grep for the same TODO marker text — `test_termios.py` has 4 instances of `Expected type 'int' but 'FileIO' found.`, but those are a different fix path (file-descriptor protocol via `fileno()`, not `__index__`); out of scope.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved `compile()` function's argument handling to accept a broader range of numeric types, enhancing compatibility with Python conventions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->