### PR TITLE
Chain __context__ alongside __cause__ when wrapping StopIteration (PEP 479)

### DIFF
--- a/Lib/test/test_generator_stop.py
+++ b/Lib/test/test_generator_stop.py
@@ -13,7 +13,6 @@ class TestPEP479(unittest.TestCase):
                                     "generator raised StopIteration"):
             next(g())
 
-    @unittest.expectedFailure  # TODO: RUSTPYTHON; AssertionError: <class 'NoneType'> is not <class 'StopIteration'>
     def test_stopiteration_wrapping_context(self):
         def f():
             raise StopIteration

--- a/Lib/test/test_yield_from.py
+++ b/Lib/test/test_yield_from.py
@@ -1069,7 +1069,6 @@ class TestInterestingEdgeCases(unittest.TestCase):
     def assert_generator_ignored_generator_exit(self):
         return self.assertRaisesRegex(RuntimeError, r"^generator ignored GeneratorExit$")
 
-    @unittest.expectedFailure  # TODO: RUSTPYTHON
     def test_close_and_throw_work(self):
 
         yielded_first = object()
@@ -1207,7 +1206,6 @@ class TestInterestingEdgeCases(unittest.TestCase):
             self.assertIsNone(caught.exception.__context__.__context__)
             self.assert_stop_iteration(g)
 
-    @unittest.expectedFailure  # TODO: RUSTPYTHON; AssertionError: RuntimeError not raised
     def test_close_and_throw_raise_stop_iteration(self):
 
         yielded_first = object()
@@ -1447,7 +1445,6 @@ class TestInterestingEdgeCases(unittest.TestCase):
             self.assertIsNone(caught.exception.__context__.__context__)
             self.assert_stop_iteration(g)
 
-    @unittest.expectedFailure  # TODO: RUSTPYTHON; AssertionError: None is not StopIteration()
     def test_close_and_throw_yield(self):
 
         yielded_first = object()

--- a/crates/vm/src/coroutine.rs
+++ b/crates/vm/src/coroutine.rs
@@ -138,12 +138,16 @@ impl Coro {
                 if e.fast_isinstance(vm.ctx.exceptions.stop_iteration) {
                     let err =
                         vm.new_runtime_error(format!("{} raised StopIteration", gen_name(jen, vm)));
+                    // PEP 479: chain __context__ as well as __cause__ to match
+                    // CPython, which sets both to the original StopIteration.
+                    err.set___context__(Some(e.clone()));
                     err.set___cause__(Some(e));
                     Err(err)
                 } else if jen.class().is(vm.ctx.types.async_generator)
                     && e.fast_isinstance(vm.ctx.exceptions.stop_async_iteration)
                 {
                     let err = vm.new_runtime_error("async generator raised StopAsyncIteration");
+                    err.set___context__(Some(e.clone()));
                     err.set___cause__(Some(e));
                     Err(err)
                 } else {

--- a/crates/vm/src/frame.rs
+++ b/crates/vm/src/frame.rs
@@ -9551,7 +9551,13 @@ impl ExecutingFrame<'_> {
                         "generator raised StopIteration"
                     };
                     let err = vm.new_runtime_error(msg);
-                    err.set___cause__(arg.downcast().ok());
+                    // PEP 479 chains both __cause__ and __context__ to the
+                    // original StopIteration; the explicit cause is what users
+                    // see in tracebacks (suppress_context becomes true), but
+                    // assertions that inspect __context__ also expect it set.
+                    let cause: Option<PyBaseExceptionRef> = arg.downcast().ok();
+                    err.set___context__(cause.clone());
+                    err.set___cause__(cause);
                     Ok(err.into())
                 } else {
                     // Not StopIteration, pass through for RERAISE


### PR DESCRIPTION
## Background

PEP 479 wraps a `StopIteration` raised from a generator/coroutine into a `RuntimeError`. CPython sets both `__cause__` and `__context__` of the new `RuntimeError` to the original `StopIteration` (the same object). RustPython's wrapping sites set `__cause__` only, leaving `__context__` as `None`.

`set___cause__` already toggles `__suppress_context__` to true, so the user-facing traceback is unchanged — only assertions that inspect `__context__` directly observe the gap.

## Repro

```python
def f(): raise StopIteration
def g(): yield f()
try: next(g())
except RuntimeError as exc:
    type(exc.__context__)
# CPython 3.14: <class 'StopIteration'>
# RustPython:   <class 'NoneType'>     (before this PR)
```

## Fix

Three sites all wrap `StopIteration` / `StopAsyncIteration` into `RuntimeError` for PEP 479. Set `__context__` to the same exception instance before setting `__cause__`:

- `crates/vm/src/frame.rs::StopIterationError` intrinsic (generator yield-expression path)
- `crates/vm/src/coroutine.rs` generator `__next__` StopIteration branch
- `crates/vm/src/coroutine.rs` async-generator `__anext__` StopAsyncIteration branch

`PyBaseExceptionRef` is `Arc`-backed, so `e.clone()` is a refcount bump; `cause is context` holds, matching CPython.

## Tests unmasked

- `test_generator_stop.TestPEP479.test_stopiteration_wrapping_context`
- `test_yield_from.TestInterestingEdgeCases.test_close_and_throw_work`
- `test_yield_from.TestInterestingEdgeCases.test_close_and_throw_raise_stop_iteration`
- `test_yield_from.TestInterestingEdgeCases.test_close_and_throw_yield`

(test_yield_from cases discovered via cross-module grep on `__context__` / `StopIteration()` TODO markers; same root cause.)

## Verification

- CPython 3.14.4 byte-identical for the PEP 479 chain — `cause is context`, `suppress_context == True`
- Async-generator path probed (StopIteration leaking through `async for` triggers same wrapping with `__context__` now set)
- Other PEP 479 traceback assertions (`assertIs(type(exc.__cause__), StopIteration)`, `assertTrue(exc.__suppress_context__)`) unchanged
- No regressions across `test_generator_stop`, `test_generators`, `test_yield_from`, `test_coroutines`, `test_asyncgen`, `test_typing`, `test_descr` (~1,156 tests)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected exception chaining behavior for stop iteration cases to align with CPython. Exception context is now properly maintained in error chains and displayed in tracebacks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->