### PR TITLE
Cargo check features on all os

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -79,9 +79,6 @@ jobs:
       - name: run rust tests
         run: cargo test --workspace ${{ env.WORKSPACE_EXCLUDES }} --verbose --features threading ${{ env.CARGO_ARGS }}
 
-      - name: check compilation without threading
-        run: cargo check ${{ env.CARGO_ARGS }}
-
       - run: cargo doc --locked
         if: runner.os == 'Linux'
 
@@ -151,6 +148,8 @@ jobs:
           target: aarch64-apple-ios
         - os: macos-latest
           target: x86_64-apple-darwin
+        - os: windows-latest
+          target: x86_64-pc-windows-msvc
       fail-fast: false
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -204,7 +203,14 @@ jobs:
       #     args: --ignore-rust-version
 
       - name: Check compilation
-        run: cargo check --target "${{ matrix.target }}" ${{ env.CARGO_ARGS_NO_SSL }}
+        run: |
+          echo "::group::no ssl"
+          cargo check --target "${{ matrix.target }}" ${{ env.CARGO_ARGS_NO_SSL }}
+          echo "::endgroup::"
+
+          echo "::group::no threading"
+          cargo check --target "${{ matrix.target }}" ${{ env.CARGO_ARGS }}
+          echo "::endgroup::"
         env:
           CC_aarch64_linux_android: ${{ steps.setup-ndk.outputs.ndk-path }}/toolchains/llvm/prebuilt/linux-x86_64/bin/aarch64-linux-android24-clang
           AR_aarch64_linux_android: ${{ steps.setup-ndk.outputs.ndk-path }}/toolchains/llvm/prebuilt/linux-x86_64/bin/llvm-ar

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -203,11 +203,11 @@ jobs:
         run: |
           {
             echo "[env]"
-            echo "CC_aarch64_linux_android = \"${{ env.NDK_PATH }}/toolchains/llvm/prebuilt/linux-x86_64/bin/aarch64-linux-android24-clang\""
+            echo "CC_aarch64_linux_android = \"${NDK_PATH}/toolchains/llvm/prebuilt/linux-x86_64/bin/aarch64-linux-android24-clang\""
 
-            echo "AR_aarch64_linux_android = \"${{ env.NDK_PATH }}/toolchains/llvm/prebuilt/linux-x86_64/bin/llvm-ar\""
+            echo "AR_aarch64_linux_android = \"${NDK_PATH}/toolchains/llvm/prebuilt/linux-x86_64/bin/llvm-ar\""
 
-          echo "CARGO_TARGET_AARCH64_LINUX_ANDROID_LINKER = \"${{ env.NDK_PATH }}/toolchains/llvm/prebuilt/linux-x86_64/bin/aarch64-linux-android24-clang\""
+          echo "CARGO_TARGET_AARCH64_LINUX_ANDROID_LINKER = \"${NDK_PATH}/toolchains/llvm/prebuilt/linux-x86_64/bin/aarch64-linux-android24-clang\""
           } >> .cargo/config.toml
 
       # - name: Prepare repository for redox compilation

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -136,10 +136,12 @@ jobs:
           target: i686-unknown-linux-musl
           dependencies:
             musl-tools: true
+          skip_ssl: true
         - os: ubuntu-latest
           target: wasm32-wasip2
         - os: ubuntu-latest
           target: x86_64-unknown-freebsd
+          skip_ssl: true
         - os: ubuntu-latest
           target: aarch64-unknown-linux-gnu
           dependencies:
@@ -216,10 +218,11 @@ jobs:
       #     command: check
       #     args: --ignore-rust-version
 
-      - name: Check compilation without ssl
-        run: cargo check --target "${{ matrix.target }}" ${{ env.CARGO_ARGS_NO_SSL }}
+      - name: Check compilation with threading
+        run: cargo check --target "${{ matrix.target }}" ${{ env.CARGO_ARGS_NO_SSL }} --features threading
 
-      - name: Check compilation with
+      - name: Check compilation with ssl
+        if: ${{ !matrix.skip_ssl }}
         run: cargo check --target "${{ matrix.target }}" ${{ env.CARGO_ARGS }}
 
   snippets_cpython:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -194,6 +194,20 @@ jobs:
           ndk-version: r27
           add-to-path: true
 
+      - name: Append env conf to cargo
+        if: ${{ matrix.target == 'aarch64-linux-android' }}
+        env:
+          NDK_PATH: ${{ steps.setup-ndk.outputs.ndk-path }}
+        run: |
+          {
+            echo "[env]"
+            echo "CC_aarch64_linux_android = \"${{ env.NDK_PATH }}/toolchains/llvm/prebuilt/linux-x86_64/bin/aarch64-linux-android24-clang\""
+
+            echo "AR_aarch64_linux_android = \"${{ env.NDK_PATH }}/toolchains/llvm/prebuilt/linux-x86_64/bin/llvm-ar\""
+
+          echo "CARGO_TARGET_AARCH64_LINUX_ANDROID_LINKER = \"${{ env.NDK_PATH }}/toolchains/llvm/prebuilt/linux-x86_64/bin/aarch64-linux-android24-clang\""
+          } >> .cargo/config.toml
+
       # - name: Prepare repository for redox compilation
       #   run: bash scripts/redox/uncomment-cargo.sh
       # - name: Check compilation for Redox
@@ -202,19 +216,11 @@ jobs:
       #     command: check
       #     args: --ignore-rust-version
 
-      - name: Check compilation
-        run: |
-          echo "::group::no ssl"
-          cargo check --target "${{ matrix.target }}" ${{ env.CARGO_ARGS_NO_SSL }}
-          echo "::endgroup::"
+      - name: Check compilation without ssl
+        run: cargo check --target "${{ matrix.target }}" ${{ env.CARGO_ARGS_NO_SSL }}
 
-          echo "::group::no threading"
-          cargo check --target "${{ matrix.target }}" ${{ env.CARGO_ARGS }}
-          echo "::endgroup::"
-        env:
-          CC_aarch64_linux_android: ${{ steps.setup-ndk.outputs.ndk-path }}/toolchains/llvm/prebuilt/linux-x86_64/bin/aarch64-linux-android24-clang
-          AR_aarch64_linux_android: ${{ steps.setup-ndk.outputs.ndk-path }}/toolchains/llvm/prebuilt/linux-x86_64/bin/llvm-ar
-          CARGO_TARGET_AARCH64_LINUX_ANDROID_LINKER: ${{ steps.setup-ndk.outputs.ndk-path }}/toolchains/llvm/prebuilt/linux-x86_64/bin/aarch64-linux-android24-clang
+      - name: Check compilation with
+        run: cargo check --target "${{ matrix.target }}" ${{ env.CARGO_ARGS }}
 
   snippets_cpython:
     if: ${{ !contains(github.event.pull_request.labels.*.name, 'skip:ci') }}

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -150,8 +150,6 @@ jobs:
           target: aarch64-apple-ios
         - os: macos-latest
           target: x86_64-apple-darwin
-        - os: windows-latest
-          target: x86_64-pc-windows-msvc
       fail-fast: false
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * CI now runs a two-pass compilation check: threading-enabled always, plus an SSL-enabled check unless skipped.
  * Per-target flag added to skip SSL-enabled builds for specific platforms (e.g., musl, FreeBSD).
  * Android NDK toolchain settings moved into the build configuration for consistent toolchain setup.
  * Removed the redundant standalone "check without threading" step from the Rust test job.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->