### PR TITLE
Move `clippy`and `cargo-shear` to separated jobs

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -92,8 +92,6 @@ jobs:
           persist-credentials: false
 
       - uses: dtolnay/rust-toolchain@stable
-        with:
-          components: clippy
 
       - name: Restore cache
         uses: actions/cache/restore@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
@@ -111,9 +109,6 @@ jobs:
 
       - name: Install macOS dependencies
         uses: ./.github/actions/install-macos-deps
-
-      - name: run clippy
-        run: cargo clippy --keep-going ${{ env.CARGO_ARGS }} --workspace --all-targets ${{ env.WORKSPACE_EXCLUDES }} -- -Dwarnings
 
       - name: run rust tests
         run: cargo test --workspace ${{ env.WORKSPACE_EXCLUDES }} --verbose --features threading ${{ env.CARGO_ARGS }}
@@ -432,6 +427,73 @@ jobs:
         shell: bash
         run: python -I scripts/whats_left.py ${{ env.CARGO_ARGS }} --features jit
 
+  clippy:
+    name: clippy
+    runs-on: ${{ matrix.os }}
+    needs:
+      - determine_changes
+    permissions:
+      contents: read
+    if: |
+      needs.determine_changes.outputs.rust_code == 'true' ||
+      github.ref == 'refs/heads/main'
+    strategy:
+      fail-fast: false
+      matrix:
+        os:
+          - macos-latest
+          - ubuntu-latest
+          - windows-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          components: clippy
+
+      - name: Restore cache
+        uses: actions/cache/restore@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+        with:
+          path: |
+            ~/.cargo/bin/
+            ~/.cargo/registry/index/
+            ~/.cargo/registry/cache/
+            ~/.cargo/git/db/
+            target/
+          key: ${{ runner.os }}-${{ hashFiles('**/Cargo.toml') }}-
+          restore-keys: |
+            ${{ runner.os }}-stable--${{ hashFiles('**/Cargo.toml') }}-
+            ${{ runner.os }}-stable--
+
+      - name: Clippy
+        run: cargo clippy --keep-going ${{ env.CARGO_ARGS }} --workspace --all-targets ${{ env.WORKSPACE_EXCLUDES }} -- -Dwarnings
+
+  cargo_shear:
+    name: cargo shear
+    runs-on: ubuntu-latest
+    needs:
+      - determine_changes
+    permissions:
+      contents: read
+    if: |
+      needs.determine_changes.outputs.rust_code == 'true' ||
+      github.ref == 'refs/heads/main'
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
+      - uses: dtolnay/rust-toolchain@stable
+
+      - uses: cargo-bins/cargo-binstall@dc19f1e48450eefe5a29b8da6c6b00a87d730b37 # v1.18.1
+
+      - name: cargo shear
+        run: |
+          cargo binstall --no-confirm cargo-shear
+          cargo shear
+
   lint:
     name: Lint
     runs-on: ubuntu-latest
@@ -449,13 +511,6 @@ jobs:
       - uses: dtolnay/rust-toolchain@stable
         with:
           components: rustfmt
-
-      - uses: cargo-bins/cargo-binstall@dc19f1e48450eefe5a29b8da6c6b00a87d730b37 # v1.18.1
-
-      - name: cargo shear
-        run: |
-          cargo binstall --no-confirm cargo-shear
-          cargo shear
 
       - name: actionlint
         uses: reviewdog/action-actionlint@6fb7acc99f4a1008869fa8a0f09cfca740837d9d # v1.72.0


### PR DESCRIPTION
~~ATM we are running clippy 3 times (on Linux, macOS and Windows), it's better to run it once on Linux and give it the `--all-targets --all-features` flags~~

Move to a separate step so we will trigger it when rust related code changes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Restructured the continuous integration pipeline to isolate code quality checks and dependency validation into dedicated, independent jobs. These checks now run across macOS, Ubuntu, and Windows platforms in parallel, improving workflow efficiency and making it easier to identify build-related issues.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->