### PR TITLE
Resolve PathLike via os.fspath in io.open

### DIFF
--- a/Lib/test/test_bz2.py
+++ b/Lib/test/test_bz2.py
@@ -740,7 +740,6 @@ class BZ2FileTest(BaseTest):
             self.assertEqual(f.read(), self.DATA)
             self.assertEqual(f.name, str_filename)
 
-    @unittest.expectedFailure  # TODO: RUSTPYTHON; AssertionError: <FakePath 'Z:\\TEMP\\tmphoipjcen'> != 'Z:\\TEMP\\tmphoipjcen'
     def testOpenPathLikeFilename(self):
         filename = FakePath(self.filename)
         with BZ2File(filename, "wb") as f:

--- a/Lib/test/test_lzma.py
+++ b/Lib/test/test_lzma.py
@@ -555,7 +555,6 @@ class FileTestCase(unittest.TestCase):
             self.assertIsInstance(f, LZMAFile)
             self.assertEqual(f.mode, "wb")
 
-    @unittest.expectedFailure  # TODO: RUSTPYTHON; AssertionError: <FakePath '@test_23396_tmp챈'> != '@test_23396_tmp챈'
     def test_init_with_PathLike_filename(self):
         filename = FakePath(TESTFN)
         with TempFile(filename, COMPRESSED_XZ):
@@ -1438,7 +1437,6 @@ class OpenTestCase(unittest.TestCase):
             with lzma.open(TESTFN, "rb") as f:
                 self.assertEqual(f.read(), INPUT * 2)
 
-    @unittest.expectedFailure  # TODO: RUSTPYTHON; AssertionError: <FakePath '@test_23396_tmp챈'> != '@test_23396_tmp챈'
     def test_with_pathlike_filename(self):
         filename = FakePath(TESTFN)
         with TempFile(filename):

--- a/crates/vm/src/stdlib/_io.rs
+++ b/crates/vm/src/stdlib/_io.rs
@@ -121,8 +121,8 @@ mod _io {
         convert::ToPyObject,
         exceptions::cstring_error,
         function::{
-            ArgBytesLike, ArgIterable, ArgMemoryBuffer, ArgSize, Either, FuncArgs, IntoFuncArgs,
-            OptionalArg, OptionalOption, PySetterValue,
+            ArgBytesLike, ArgIterable, ArgMemoryBuffer, ArgSize, Either, FsPath, FuncArgs,
+            IntoFuncArgs, OptionalArg, OptionalOption, PySetterValue,
         },
         protocol::{
             BufferDescriptor, BufferMethods, BufferResizeGuard, PyBuffer, PyIterReturn, VecBuffer,
@@ -5068,6 +5068,15 @@ mod _io {
                 return Err(vm.new_value_error(msg));
             }
         }
+
+        // Match CPython's _pyio.open (Lib/_pyio.py): resolve PathLike here so
+        // _io.FileIO still receives (and preserves on .name) the raw argument
+        // when called directly.
+        let file = if file.fast_isinstance(vm.ctx.types.int_type) {
+            file
+        } else {
+            FsPath::try_from_path_like(file, true, vm)?.to_pyobject(vm)
+        };
 
         // check file descriptor validity
         #[cfg(all(unix, feature = "host_env"))]


### PR DESCRIPTION
## Background

CPython splits PathLike resolution across two layers:

| Call | `.name` type (CPython) |
|---|---|
| `_io.FileIO(PathLike)` | the original PathLike (preserved) |
| `builtins.open(PathLike)` | str / bytes (resolved via `os.fspath`) |
| `bz2.BZ2File(PathLike)` / `lzma.LZMAFile(PathLike)` | str / bytes (inherits from `open`) |

`_io.FileIO` is the low-level primitive — its contract preserves the original
argument on `.name`. `builtins.open` is the high-level wrapper that normalizes
the path first, per `Lib/_pyio.py:193-194`:

```python
if not isinstance(file, int):
    file = os.fspath(file)
```

RustPython's `_io.FileIO` already matched CPython on the low-level contract,
but `io_open` skipped the `os.fspath` step. Result: `builtins.open(PathLike).name`
returned the raw PathLike, and the divergence cascaded to `bz2.BZ2File` and
`lzma.LZMAFile` (which both wrap `builtins.open` and expose `_fp.name`).

## Repro (CPython 3.14.4 vs RustPython main)

```python
import builtins, _io, bz2, pathlib, tempfile

with tempfile.NamedTemporaryFile(delete=False) as t:
    p = pathlib.Path(t.name)

# Layer 1 — _io.FileIO direct (already correct on both)
type(_io.FileIO(p, "rb").name)   # CPython: PosixPath  RP main: PosixPath  OK

# Layer 2 — builtins.open (the gap)
type(builtins.open(p, "rb").name)   # CPython: str       RP main: PosixPath  BUG

# Layer 3 — bz2.BZ2File (inherits from Layer 2)
with bz2.BZ2File(p, "wb") as f:
    type(f.name)                    # CPython: str       RP main: PosixPath  BUG
```

User code such as `f.name.upper()`, `f.name.endswith('.bz2')`, or
`assertEqual(f.name, str_path)` silently breaks in the Layer 2 / 3 cases.

## Fix

Insert `os.fspath`-style resolution at the `io_open` boundary, between mode
validation and FileIO construction. Reuses the existing
`FsPath::try_from_path_like` helper (`crates/vm/src/function/fspath.rs`) which
implements the full `os.fspath` semantics (str/bytes pass-through, `__fspath__`
dispatch, TypeError on invalid types, `__fspath__ = None` rejection).

```rust
let file = if file.fast_isinstance(vm.ctx.types.int_type) {
    file
} else {
    FsPath::try_from_path_like(file, true, vm)?.to_pyobject(vm)
};
```

`_io.FileIO::__init__` is unchanged. Direct `_io.FileIO(PathLike)` calls bypass
`io_open` entirely, so Layer 1's CPython parity is preserved.

The integer fast-path matches `_pyio.open`'s `if not isinstance(file, int)`
check — file descriptors are not subject to `os.fspath`, and `int` has no
`__fspath__`, so without the check fd inputs would raise.

## Tests unmasked

Three `expectedFailure` markers, all sharing the same `<FakePath ...> != '...'`
root cause:

- `test_bz2.BZ2FileTest.testOpenPathLikeFilename`
- `test_lzma.FileTestCase.test_init_with_PathLike_filename`
- `test_lzma.OpenTestCase.test_with_pathlike_filename`

`grep -rn "FakePath" Lib/test/` confirms no other markers tied to this root
cause across the test suite.

## Verification

CPython 3.14.4 byte-identical for 12 input shapes:

| Input | CPython behavior | RustPython after fix |
|---|---|---|
| `_io.FileIO(FakePath)` | FakePath (identity preserved) | FakePath (identity preserved) |
| `_io.FileIO(pathlib.Path)` | PosixPath (identity preserved) | PosixPath (identity preserved) |
| `builtins.open(FakePath(str))` | str | str |
| `builtins.open(FakePath(bytes))` | bytes | bytes |
| `builtins.open(pathlib.Path)` | str | str |
| `builtins.open(int_fd)` | int (unchanged) | int (unchanged) |
| `builtins.open(99999, closefd=False)` | OSError [Errno 9] Bad file descriptor | OSError [Errno 9] Bad file descriptor |
| `bz2.BZ2File(FakePath)` | str | str |
| `__fspath__` raises | RuntimeError propagated | RuntimeError propagated |
| `__fspath__` returns int | TypeError "expected ... to return str or bytes, not int" | identical |
| `__fspath__ = None` | TypeError "expected str, bytes or os.PathLike object, not X" | identical |
| no `__fspath__` / `None` | TypeError "expected str, bytes or os.PathLike object, not X" | identical |

No regressions across `test_io` (667), `test_fileio` (99), `test_bz2` (101),
`test_lzma` (121), `test_gzip` (75), `test_tempfile` (118), `test_pathlib`
(1369), `test_os` (373) — 2,923 tests.

## Note

Follows up on #7736 (closed), which placed the same fix one layer too low
(inside `FileIO::__init__`), causing `_io.FileIO(PathLike).name` to diverge
from CPython. This PR keeps the fix at the correct layer.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of path-like arguments in file operations. File objects now correctly preserve the original path representation in the `.name` attribute when opened with various path input types.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->