### PR TITLE
Pin `marocchino/sticky-pull-request-comment` action to a hash

### DIFF
--- a/.github/workflows/lib-deps-check.yaml
+++ b/.github/workflows/lib-deps-check.yaml
@@ -98,7 +98,7 @@ jobs:
 
       - name: Post comment
         if: steps.deps-check.outputs.deps_output != ''
-        uses: marocchino/sticky-pull-request-comment@v3
+        uses: marocchino/sticky-pull-request-comment@0ea0beb66eb9baf113663a64ec522f60e49231c0 # v3.0.4
         with:
           header: lib-deps-check
           number: ${{ github.event.pull_request.number }}
@@ -115,7 +115,7 @@ jobs:
 
       - name: Remove comment if no Lib changes
         if: steps.changed-files.outputs.modules == ''
-        uses: marocchino/sticky-pull-request-comment@v3
+        uses: marocchino/sticky-pull-request-comment@0ea0beb66eb9baf113663a64ec522f60e49231c0 # v3.0.4
         with:
           header: lib-deps-check
           number: ${{ github.event.pull_request.number }}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal CI/CD workflow to use pinned dependency versions for improved stability and reproducibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->