### PR TITLE
Only run `cargo check` when rust code is changed

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -64,6 +64,7 @@ jobs:
             ':Cargo.lock' \
             ':crates/**' \
             ':src/**' \
+            ':.github/workflows/ci.yaml' \
           ; then
               echo "changed=false" >> "$GITHUB_OUTPUT"
           else

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -62,6 +62,8 @@ jobs:
           if git diff --quiet "${MERGE_BASE}...HEAD" -- \
             ':Cargo.toml' \
             ':Cargo.lock' \
+            ':rust-toolchain.toml' \
+            ':.cargo/config.toml' \
             ':crates/**' \
             ':src/**' \
             ':.github/workflows/ci.yaml' \

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -64,7 +64,6 @@ jobs:
             ':Cargo.lock' \
             ':crates/**' \
             ':src/**' \
-            ':.github/workflows/ci.yaml' \
           ; then
               echo "changed=false" >> "$GITHUB_OUTPUT"
           else

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -36,6 +36,43 @@ env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true # TODO: Remove on 2026/06/02
 
 jobs:
+  determine_changes:
+    name: Determine changes
+    runs-on: ubuntu-latest
+    outputs:
+      # Flag that is raised when any rust code is changed.
+      rust_code: ${{ steps.check_rust_code.outputs.changed }}
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Determine merge base
+        id: merge_base
+        run: |
+          sha=$(git merge-base HEAD "origin/${BASE_REF}")
+          echo "sha=${sha}" >> "$GITHUB_OUTPUT"
+        env:
+          BASE_REF: ${{ github.event.pull_request.base.ref || 'main' }}
+
+      - name: Check if there was any code related change
+        id: check_rust_code
+        run: |
+          if git diff --quiet "${MERGE_BASE}...HEAD" -- \
+            ':Cargo.toml' \
+            ':Cargo.lock' \
+            ':crates/**' \
+            ':src/**' \
+            ':.github/workflows/ci.yaml' \
+          ; then
+              echo "changed=false" >> "$GITHUB_OUTPUT"
+          else
+              echo "changed=true" >> "$GITHUB_OUTPUT"
+          fi
+        env:
+          MERGE_BASE: ${{ steps.merge_base.outputs.sha }}
+
   rust_tests:
     if: ${{ !contains(github.event.pull_request.labels.*.name, 'skip:ci') }}
     env:
@@ -120,9 +157,15 @@ jobs:
         if: runner.os == 'Linux'
 
   cargo_check:
-    if: ${{ !contains(github.event.pull_request.labels.*.name, 'skip:ci') }}
     name: cargo check
     runs-on: ${{ matrix.os }}
+    needs:
+      - determine_changes
+    if: |
+      (
+        !contains(github.event.pull_request.labels.*.name, 'skip:ci') &&
+        needs.determine_changes.outputs.rust_code == 'true'
+      ) || github.ref == 'refs/heads/main'
     strategy:
       matrix:
         include: 

--- a/src/interpreter.rs
+++ b/src/interpreter.rs
@@ -13,6 +13,7 @@ impl InterpreterBuilderExt for InterpreterBuilder {
     #[cfg(feature = "stdlib")]
     fn init_stdlib(self) -> Self {
         let defs = rustpython_stdlib::stdlib_module_defs(&self.ctx);
+
         let builder = self.add_native_modules(&defs);
 
         #[cfg(feature = "freeze-stdlib")]

--- a/src/interpreter.rs
+++ b/src/interpreter.rs
@@ -13,7 +13,6 @@ impl InterpreterBuilderExt for InterpreterBuilder {
     #[cfg(feature = "stdlib")]
     fn init_stdlib(self) -> Self {
         let defs = rustpython_stdlib::stdlib_module_defs(&self.ctx);
-
         let builder = self.add_native_modules(&defs);
 
         #[cfg(feature = "freeze-stdlib")]


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * CI now detects whether Rust-related or workflow changes are present and runs Rust checks only when needed, reducing unnecessary runs.
  * A new detection step ensures the skip label is respected so Rust checks can be skipped when requested.
  * Rust checks still run unconditionally on the main branch to maintain baseline validation and prevent regressions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->