### PR TITLE
Drop redundant exception type prefix from float-to-int error messages

### DIFF
--- a/crates/vm/src/builtins/float.rs
+++ b/crates/vm/src/builtins/float.rs
@@ -131,10 +131,9 @@ pub fn try_to_bigint(value: f64, vm: &VirtualMachine) -> PyResult<BigInt> {
         Some(int) => Ok(int),
         None => {
             if value.is_infinite() {
-                Err(vm
-                    .new_overflow_error("OverflowError: cannot convert float infinity to integer"))
+                Err(vm.new_overflow_error("cannot convert float infinity to integer"))
             } else if value.is_nan() {
-                Err(vm.new_value_error("ValueError: cannot convert float NaN to integer"))
+                Err(vm.new_value_error("cannot convert float NaN to integer"))
             } else {
                 // unreachable unless BigInt has a bug
                 unreachable!(

--- a/extra_tests/snippets/builtin_float.py
+++ b/extra_tests/snippets/builtin_float.py
@@ -517,3 +517,35 @@ assert_raises(ValueError, lambda: float("._0"))
 
 assert 3.0 % -2.0 == -1.0
 assert -3.0 % 2.0 == 1.0
+
+
+# Float-to-int conversion error wording matches CPython exactly. The
+# error class name is added by Python's exception display layer; the
+# message itself must not duplicate it.
+def _check_msg(call, exc_type, expected_msg):
+    try:
+        call()
+    except exc_type as e:
+        assert str(e) == expected_msg, repr(e)
+    else:
+        raise AssertionError(f"expected {exc_type.__name__}")
+
+
+_check_msg(lambda: int(INF), OverflowError, "cannot convert float infinity to integer")
+_check_msg(lambda: int(NINF), OverflowError, "cannot convert float infinity to integer")
+_check_msg(lambda: int(NAN), ValueError, "cannot convert float NaN to integer")
+_check_msg(
+    lambda: round(INF), OverflowError, "cannot convert float infinity to integer"
+)
+_check_msg(lambda: round(NAN), ValueError, "cannot convert float NaN to integer")
+_check_msg(
+    lambda: math.floor(INF), OverflowError, "cannot convert float infinity to integer"
+)
+_check_msg(lambda: math.ceil(NAN), ValueError, "cannot convert float NaN to integer")
+_check_msg(
+    lambda: math.trunc(INF), OverflowError, "cannot convert float infinity to integer"
+)
+_check_msg(
+    lambda: INF.__int__(), OverflowError, "cannot convert float infinity to integer"
+)
+_check_msg(lambda: NAN.__floor__(), ValueError, "cannot convert float NaN to integer")


### PR DESCRIPTION
## Summary

CPython raises `OverflowError("cannot convert float infinity to integer")` and `ValueError("cannot convert float NaN to integer")` (`Objects/floatobject.c`). The exception type name is added by Python's traceback display layer; the message itself should not duplicate it.

`try_to_bigint` was producing the duplicated form:

```python
>>> int(float("inf"))
# CPython 3.14.4: OverflowError('cannot convert float infinity to integer')
# RustPython main: OverflowError('OverflowError: cannot convert float infinity to integer')  ❌
```

This makes `repr(e)` and any code path that inspects `str(e)` diverge from CPython.

## Affected sites

All five callers of `try_to_bigint` share the message:

| Operation | Caller |
|---|---|
| `int(x)` | `float.__int__` |
| `math.floor(x)` | `float.__floor__` |
| `math.ceil(x)` | `float.__ceil__` |
| `math.trunc(x)` | `float.__trunc__` |
| `round(x)` (no ndigits) | `float.__round__` |

## Verification

- Byte-identical with CPython 3.14.4 across 14 probe sites: 14/14 match.
- `cargo run --release -- -m test test_float test_builtin test_math test_int test_long test_complex test_decimal test_fractions test_statistics test_format test_re` — 1,627 tests pass, 0 regressions.
- All 188 `extra_tests/snippets/*.py` pass under the CI feature set.

A regression block is added to `extra_tests/snippets/builtin_float.py` checking the exact message text via a small `_check_msg(call, exc_type, expected_msg)` helper across all five callers.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved error messages when converting float infinity and NaN values to integers with standardized wording for consistency.

* **Tests**
  * Added comprehensive test coverage for float-to-integer conversion error messages across multiple conversion methods.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->