### PR TITLE
Match CPython wording for compile() optimize and flags validation

### DIFF
--- a/crates/vm/src/stdlib/builtins.rs
+++ b/crates/vm/src/stdlib/builtins.rs
@@ -268,12 +268,10 @@ mod builtins {
             let mode_str = args.mode.as_str();
 
             let optimize: i32 = args.optimize.map_or(-1, |v| v.value);
-            let optimize: u8 = if optimize == -1 {
-                vm.state.config.settings.optimize
-            } else {
-                optimize
-                    .try_into()
-                    .map_err(|_| vm.new_value_error("compile() optimize value invalid"))?
+            let optimize: u8 = match optimize {
+                -1 => vm.state.config.settings.optimize,
+                0..=2 => optimize as u8,
+                _ => return Err(vm.new_value_error("compile(): invalid optimize value")),
             };
 
             if args
@@ -348,7 +346,7 @@ mod builtins {
                 let flags: i32 = args.flags.map_or(0, |v| v.value);
 
                 if !(flags & !_ast::PY_COMPILE_FLAGS_MASK).is_zero() {
-                    return Err(vm.new_value_error("compile() unrecognized flags"));
+                    return Err(vm.new_value_error("compile(): unrecognised flags"));
                 }
 
                 let allow_incomplete = !(flags & _ast::PY_CF_ALLOW_INCOMPLETE_INPUT).is_zero();

--- a/extra_tests/snippets/builtin_compile.py
+++ b/extra_tests/snippets/builtin_compile.py
@@ -1,0 +1,46 @@
+from testutils import assert_raises
+
+# compile() basic mode acceptance
+assert isinstance(
+    compile("x = 1", "<test>", "exec"), type(compile("", "<test>", "exec"))
+)
+assert compile("1 + 1", "<test>", "eval") is not None
+assert compile("1", "<test>", "single") is not None
+
+# `optimize` accepts -1 (use config default), 0, 1, 2 only.
+# Anything else raises ValueError with CPython's exact wording.
+for ok in (-1, 0, 1, 2):
+    compile("x = 1", "<test>", "exec", optimize=ok)
+
+
+def _check_optimize_error(value):
+    try:
+        compile("x = 1", "<test>", "exec", optimize=value)
+    except ValueError as e:
+        assert str(e) == "compile(): invalid optimize value", repr(e)
+    else:
+        raise AssertionError(f"expected ValueError for optimize={value!r}")
+
+
+for bad in (3, 4, 99, 255, 256, 1000, -2, -99, -128):
+    _check_optimize_error(bad)
+
+# Huge `optimize` values raise OverflowError during argument conversion,
+# not ValueError. The exact wording differs from CPython here (Rust i32
+# vs C int) — checking the type only, matching test_compile.py.
+assert_raises(OverflowError, compile, "x = 1", "<test>", "exec", optimize=1 << 1000)
+
+
+# Unrecognised `flags` bits raise ValueError. CPython uses British spelling
+# ("unrecognised") so the message must match exactly.
+def _check_flags_error(flags):
+    try:
+        compile("x = 1", "<test>", "exec", flags=flags)
+    except ValueError as e:
+        assert str(e) == "compile(): unrecognised flags", repr(e)
+    else:
+        raise AssertionError(f"expected ValueError for flags={flags!r}")
+
+
+_check_flags_error(99999)
+_check_flags_error(0x10000)


### PR DESCRIPTION
## Summary

Two CPython parity gaps in `compile()` argument validation, both in `crates/vm/src/stdlib/builtins.rs`.

### 1. `optimize` validation gap (real bug)

CPython accepts `optimize ∈ {-1, 0, 1, 2}` only; anything else raises `ValueError("compile(): invalid optimize value")` (`Python/bltinmodule.c::builtin_compile_impl`).

The previous logic only validated through `i32::try_into::<u8>()`, which silently accepts every value in `[0, 255]`. So `optimize=3`, `optimize=99`, etc. were silently truncated to a u8 instead of being rejected.

```python
>>> compile('x = 1', '<x>', 'exec', optimize=3)
# CPython 3.14.4: ValueError: compile(): invalid optimize value
# RustPython main: <code object ...>  ❌
```

### 2. `flags` error wording (wording-only)

CPython uses British "unrecognised" with a colon separator: `compile(): unrecognised flags`. The previous wording was American "unrecognized" without the colon.

## Fix

Replace the cast-based optimize validation with a range pattern, and align the flags wording with CPython's.

```rust
let optimize: u8 = match optimize {
    -1 => vm.state.config.settings.optimize,
    0..=2 => optimize as u8,
    _ => return Err(vm.new_value_error("compile(): invalid optimize value")),
};
```

The `optimize=1 << 1000` boundary still raises `OverflowError` via the `ArgPrimitiveIndex<i32>` conversion layer before this check (preserves `Lib/test/test_compile.py:668`).

## Verification (CPython 3.14.4)

| Probe | Cases | Match |
|---|---|---|
| optimize boundary (-1, 0..2, 3, 4, 99, 255, 256, 1000, -2, -99) | 12 | 12/12 |
| flags invalid bits (99999, 0x10000) | 2 | 2/2 |
| flags valid bits (0x20000, 0x40000) | 2 | 2/2 |

`cargo run --release -- -m test test_compile test_builtin test_compileall test_codeop test_ast` — 703 tests pass, 0 regressions. All 189 `extra_tests/snippets/*.py` pass under the CI feature set. A new `builtin_compile.py` adds regression coverage for both wordings.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced the compile() function's parameter validation with clearer error messages for invalid optimize values and unrecognized compile flags.

* **Tests**
  * Added comprehensive test coverage for the compile() function, validating accepted parameter values and ensuring proper error handling across different scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->