### PR TITLE
test(str): add regression test for isprintable() unicode 15 chars,

### DIFF
--- a/crates/vm/src/builtins/str.rs
+++ b/crates/vm/src/builtins/str.rs
@@ -2723,4 +2723,24 @@ mod tests {
             assert_eq!("TypeError", &*translated.unwrap_err().class().name(),);
         })
     }
+
+    #[test]
+    fn str_isprintable_unicode15() {
+        // Regression test for https://github.com/RustPython/RustPython/issues/7525
+        // At the time of the issue, RustPython used unic_ucd_category which had
+        // outdated Unicode data, causing U+0B55 to be misclassified as Unassigned.
+        // Now fixed by migrating to icu_properties with up-to-date Unicode data.
+
+        // Characters that should be printable
+        assert!(PyStr::from("\u{0B55}").isprintable());
+        assert!(PyStr::from("A").isprintable());
+        assert!(PyStr::from(" ").isprintable());
+        assert!(PyStr::from("").isprintable());
+
+        // Characters that should NOT be printable
+        assert!(!PyStr::from("\x00").isprintable());
+        assert!(!PyStr::from("\u{200B}").isprintable());
+        assert!(!PyStr::from("\u{E000}").isprintable());
+        assert!(!PyStr::from("\u{00A0}").isprintable());
+    }
 }


### PR DESCRIPTION
Fixes #7525

This PR adds a regression test for #7525.
At the time the issue was reported (commit 1a9b10e), str.isprintable() was returning False for '\u0b55' while CPython returns True.
The root cause was that rustpython_literal::char::is_printable() was using unic-ucd-category 0.9.0, which is based on Unicode 10.0 data. U+0B55 was unassigned (Cn) in Unicode 10.0, so it was incorrectly treated as non-printable.
This has since been fixed by migrating to icu_properties 2.2.0, which uses up-to-date Unicode data and correctly classifies U+0B55 as Mn (Nonspacing Mark), making it printable.

```
RustPython on  HEAD (1a9b10e) [$?] is 📦 v0.5.0 via 🦀 v1.95.0
❯ cargo run -- -c "print('\u0b55'.isprintable())"

False

RustPython on  main (c2910c0) [$?⇡] is 📦 v0.5.0 via 🐍 v3.11.6 via 🦀 v1.95.0
❯ cargo run -- -c "print('\u0b55'.isprintable())"

True
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enhanced test coverage for Unicode character validation and classification.
  * Added comprehensive tests to ensure accurate handling of printable and non-printable Unicode characters across updated Unicode standards.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->