### PR TITLE
Match CPython parity for compile() str source, mode wording, and func_type

### DIFF
--- a/crates/vm/src/stdlib/builtins.rs
+++ b/crates/vm/src/stdlib/builtins.rs
@@ -315,9 +315,11 @@ mod builtins {
                 }
                 #[cfg(feature = "rustpython-codegen")]
                 {
-                    let mode = mode_str
-                        .parse::<crate::compiler::Mode>()
-                        .map_err(|err| vm.new_value_error(err.to_string()))?;
+                    use crate::compiler::Mode;
+
+                    let mode = mode_str.parse::<Mode>().map_err(|_| {
+                        vm.new_value_error("compile() mode must be 'exec', 'eval' or 'single'")
+                    })?;
                     return _ast::compile(
                         vm,
                         args.source,
@@ -339,11 +341,31 @@ mod builtins {
 
                 use ruff_python_parser as parser;
 
-                let source = ArgStrOrBytesLike::try_from_object(vm, args.source)?;
-                let source = source.borrow_bytes();
-
-                let source = decode_source_bytes(&source, &args.filename.to_string_lossy(), vm)?;
-                let source = source.as_str();
+                // CPython parity: encoding declarations (`# -*- coding: ... -*-`)
+                // only apply to bytes input. For `str` input the source is
+                // already decoded, so the declaration must be ignored —
+                // including the "unknown encoding" error path.
+                let source_string: String = match args.source.downcast_ref::<PyStr>() {
+                    Some(pystr) => match pystr.to_str() {
+                        Some(s) => s.to_owned(),
+                        // Surrogate-bearing str falls back to the bytes path,
+                        // which raises SyntaxError on the WTF-8 encoding.
+                        None => decode_source_bytes(
+                            pystr.as_wtf8().as_bytes(),
+                            &args.filename.to_string_lossy(),
+                            vm,
+                        )?,
+                    },
+                    None => {
+                        let bytes = ArgBytesLike::try_from_object(vm, args.source.clone())?;
+                        decode_source_bytes(
+                            &bytes.borrow_buf(),
+                            &args.filename.to_string_lossy(),
+                            vm,
+                        )?
+                    }
+                };
+                let source = source_string.as_str();
 
                 let flags: i32 = args.flags.map_or(0, |v| v.value);
 
@@ -363,10 +385,22 @@ mod builtins {
                     }
                     #[cfg(feature = "compiler")]
                     {
+                        use crate::compiler::Mode;
+
+                        // CPython parity: `func_type` is only valid when
+                        // PyCF_ONLY_AST is set (the `else` branch below).
+                        if mode_str == "func_type" {
+                            return Err(vm.new_value_error(
+                                "compile() mode 'func_type' requires flag PyCF_ONLY_AST",
+                            ));
+                        }
+
                         if let Some(feature_version) = feature_version {
-                            let mode = mode_str
-                                .parse::<parser::Mode>()
-                                .map_err(|err| vm.new_value_error(err.to_string()))?;
+                            let mode = mode_str.parse::<parser::Mode>().map_err(|_| {
+                                vm.new_value_error(
+                                    "compile() mode must be 'exec', 'eval' or 'single'",
+                                )
+                            })?;
                             let _ = _ast::parse(
                                 vm,
                                 source,
@@ -378,9 +412,9 @@ mod builtins {
                             .map_err(|e| (e, Some(source), allow_incomplete).to_pyexception(vm))?;
                         }
 
-                        let mode = mode_str
-                            .parse::<crate::compiler::Mode>()
-                            .map_err(|err| vm.new_value_error(err.to_string()))?;
+                        let mode = mode_str.parse::<Mode>().map_err(|_| {
+                            vm.new_value_error("compile() mode must be 'exec', 'eval' or 'single'")
+                        })?;
 
                         let mut opts = vm.compile_opts();
                         opts.optimize = optimize;
@@ -403,9 +437,9 @@ mod builtins {
                             .map_err(|e| (e, Some(source), allow_incomplete).to_pyexception(vm));
                     }
 
-                    let mode = mode_str
-                        .parse::<parser::Mode>()
-                        .map_err(|err| vm.new_value_error(err.to_string()))?;
+                    let mode = mode_str.parse::<parser::Mode>().map_err(|_| {
+                        vm.new_value_error("compile() mode must be 'exec', 'eval' or 'single'")
+                    })?;
                     let parsed = _ast::parse(
                         vm,
                         source,

--- a/extra_tests/snippets/builtin_compile.py
+++ b/extra_tests/snippets/builtin_compile.py
@@ -1,0 +1,44 @@
+from testutils import assert_raises
+
+
+# CPython parity: encoding declarations (`# -*- coding: ... -*-`) only apply
+# to bytes input. For `str` source the source is already decoded and the
+# declaration must be ignored, including the "unknown encoding" error path.
+compile("# -*- coding: badencoding -*-\nx = 1\n", "tmp", "exec")
+compile("# -*- coding: latin1 -*-\nx = 1\n", "tmp", "exec")
+compile("# -*- coding: utf-8 -*-\nx = 1\n", "tmp", "exec")
+
+# Bytes input keeps applying the declaration, so a bogus encoding still
+# raises SyntaxError.
+assert_raises(
+    SyntaxError, compile, b"# -*- coding: badencoding -*-\nx = 1\n", "tmp", "exec"
+)
+
+
+# CPython mode error wording. Both the missing `compile()` prefix and the
+# Oxford-comma / quote style come from the parser's generic error message;
+# `compile()` overrides it to match CPython exactly.
+def _check_mode_error(mode_str):
+    try:
+        compile("x = 1", "<test>", mode_str)
+    except ValueError as e:
+        assert str(e) == "compile() mode must be 'exec', 'eval' or 'single'", repr(e)
+    else:
+        raise AssertionError(f"expected ValueError for mode={mode_str!r}")
+
+
+for bad in ("bogus", "", "BAD", "__bogus__"):
+    _check_mode_error(bad)
+
+
+# `func_type` is only valid when PyCF_ONLY_AST (= 1024) is set. Plain text
+# source without the flag must raise the specific "requires flag" error,
+# not the generic "invalid mode" one.
+try:
+    compile("def f(x): pass", "<test>", "func_type")
+except ValueError as e:
+    assert (
+        str(e) == "compile() mode 'func_type' requires flag PyCF_ONLY_AST"
+    ), repr(e)
+else:
+    raise AssertionError("expected ValueError for func_type without PyCF_ONLY_AST")


### PR DESCRIPTION
## Summary

Three CPython parity gaps in `compile()` text-source handling, all in `crates/vm/src/stdlib/builtins.rs`.

### 1. str source path applies bytes-only encoding declaration validation

```python
>>> compile('# -*- coding: badencoding -*-\n"x"\n', 'tmp', 'exec')
# CPython 3.14.4: <code object>
# RustPython main: SyntaxError: unknown encoding for 'tmp': badencoding  ❌
```

Previously, `compile()` collapsed both `str` and bytes-like inputs to bytes via `ArgStrOrBytesLike::borrow_bytes()` and ran the same `decode_source_bytes()` over them, including the "unknown encoding" error path. CPython only applies `# -*- coding: ... -*-` validation when source is bytes — for `str` the source is already decoded and the declaration must be ignored.

Branch on `args.source` type early:
- pure `str` (no surrogates) → skip encoding-declaration validation
- surrogate-bearing `str` → fall back to bytes path (preserves existing SyntaxError)
- bytes-like → unchanged

### 2. `compile()` mode error wording

```python
>>> compile('x=1', '<x>', 'bogus')
# CPython 3.14.4: ValueError: compile() mode must be 'exec', 'eval' or 'single'
# RustPython main: ValueError: mode must be "exec", "eval", or "single"  ❌
```

The parser's `ModeParseError` Display produces a generic message used outside `compile()` too. Replace the `err.to_string()` wrapping at the four `mode_str.parse::<Mode>()` call sites in `builtins::compile` with the exact CPython wording.

### 3. Missing `func_type` validation on text-source path

```python
>>> compile('def f(x): pass', 'f', 'func_type')
# CPython 3.14.4: ValueError: compile() mode 'func_type' requires flag PyCF_ONLY_AST
# RustPython main: ValueError: mode must be "exec", "eval", or "single"  ❌
```

The AST-input path already had this check (lines 287-291); mirror it for text-source input so the user sees the actual cause (missing flag) rather than "invalid mode."

## Verification (CPython 3.14.4)

| Probe | Cases | Match |
|---|---|---|
| Source-input combinations: {str, bytes, bytearray, memoryview} × {no decl, valid utf-8, bad decl} | 9 | 9/9 |
| Mode strings (exec, eval, single, func_type, bogus, '', BAD) | 7 | 7/7 |

`cargo run --release -- -m test test_compile test_builtin test_compileall test_codeop test_ast` — 703 tests pass, 0 regressions. All 188 `extra_tests/snippets/*.py` pass under the CI feature set.

## Out of scope

`test_compile.test_encoding`'s `expectedFailure` marker is left in place: the test exercises non-UTF-8 encoding decoding (`# -*- coding: latin1 -*-`, `iso8859-15`) which is a separate pre-existing limitation in `decode_source_bytes` unaffected by this PR.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of source encodings for text vs. binary inputs when compiling code.
  * Enhanced compatibility with CPython compile behavior and error responses.
  * Stricter validation of compile "mode" values, with clearer error handling for invalid modes.
* **Tests**
  * Added tests to verify encoding rules, mode error messages, and special-mode flag requirements.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->