### PR TITLE
Make `determine_changes` step run on `ubuntu-slim`

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -39,7 +39,7 @@ env:
 jobs:
   determine_changes:
     name: Determine changes
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-slim
     outputs:
       # Flag that is raised when any rust code is changed.
       rust_code: ${{ steps.check_rust_code.outputs.changed }}
@@ -168,7 +168,7 @@ jobs:
       ) || github.ref == 'refs/heads/main'
     strategy:
       matrix:
-        include: 
+        include:
         - os: ubuntu-latest
           target: aarch64-linux-android
         - os: ubuntu-latest


### PR DESCRIPTION
Since the `ubuntu-slim` image contains the `git` executable by default, we can use this image and thus improve our actions parallelism.

Ideally, we should consider extracting the `cargo_check` step into a separate GitHub Actions `.yaml` file, possibly obviating the need for the `determine_changes` step.

cc @ShaharNaveh


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Optimized CI workflow configuration for improved build efficiency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->