### PR TITLE
Fixed: `unused manifest key: dependencies.libz-sys.package`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -224,7 +224,7 @@ libloading = "0.9"
 liblzma = "0.4"
 liblzma-sys = "0.4"
 libsqlite3-sys = "0.37"
-libz-sys = { package = "libz-rs-sys", version = "0.5" }
+libz-rs-sys = "0.5"
 lock_api = "0.4"
 log = "0.4.29"
 nix = { version = "0.31", features = ["fs", "user", "process", "term", "time", "signal", "ioctl", "socket", "sched", "zerocopy", "dir", "hostname", "net", "poll"] }

--- a/crates/stdlib/Cargo.toml
+++ b/crates/stdlib/Cargo.toml
@@ -87,7 +87,7 @@ ucd = { workspace = true }
 adler32 = { workspace = true }
 crc32fast = { workspace = true }
 flate2 = { workspace = true, features = ["zlib-rs"] }
-libz-sys = { package = "libz-rs-sys", workspace = true }
+libz-sys = { workspace = true }
 bzip2 = { workspace = true }
 
 # tkinter

--- a/crates/stdlib/Cargo.toml
+++ b/crates/stdlib/Cargo.toml
@@ -87,7 +87,7 @@ ucd = { workspace = true }
 adler32 = { workspace = true }
 crc32fast = { workspace = true }
 flate2 = { workspace = true, features = ["zlib-rs"] }
-libz-sys = { workspace = true }
+libz-rs-sys = { workspace = true }
 bzip2 = { workspace = true }
 
 # tkinter

--- a/crates/stdlib/src/zlib.rs
+++ b/crates/stdlib/src/zlib.rs
@@ -25,7 +25,7 @@ mod zlib {
     use std::io::Write;
 
     #[pyattr]
-    use libz_sys::{
+    use libz_rs_sys::{
         Z_BEST_COMPRESSION, Z_BEST_SPEED, Z_BLOCK, Z_DEFAULT_COMPRESSION, Z_DEFAULT_STRATEGY,
         Z_DEFLATED as DEFLATED, Z_FILTERED, Z_FINISH, Z_FIXED, Z_FULL_FLUSH, Z_HUFFMAN_ONLY,
         Z_NO_COMPRESSION, Z_NO_FLUSH, Z_PARTIAL_FLUSH, Z_RLE, Z_SYNC_FLUSH, Z_TREES,
@@ -39,7 +39,7 @@ mod zlib {
     #[pyattr(name = "ZLIB_RUNTIME_VERSION")]
     #[pyattr]
     const ZLIB_VERSION: &str = unsafe {
-        match core::ffi::CStr::from_ptr(libz_sys::zlibVersion()).to_str() {
+        match core::ffi::CStr::from_ptr(libz_rs_sys::zlibVersion()).to_str() {
             Ok(s) => s,
             Err(_) => unreachable!(),
         }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated an internal dependency reference to use the workspace crate directly instead of an aliased entry; versioning and behavior remain unchanged. No functional or user-visible changes.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/RustPython/RustPython/pull/7792)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->