### PR TITLE
Move dependencies to workspace for `capi` crate

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -256,6 +256,7 @@ pkcs8 = "0.10"
 proc-macro2 = "1.0.105"
 psm = "0.1"
 pymath = { version = "0.2.0", features = ["mul_add", "malachite-bigint", "complex"] }
+pyo3 = "0.28"
 quote = "1.0.45"
 radium = "1.1.1"
 rand = "0.9"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -54,7 +54,7 @@ rustyline = { workspace = true }
 
 [dev-dependencies]
 criterion = { workspace = true }
-pyo3 = { version = "0.28.2", features = ["auto-initialize"] }
+pyo3 = { workspace = true, features = ["auto-initialize"] }
 rustpython-stdlib = { workspace = true }
 ruff_python_parser = { workspace = true }
 

--- a/crates/capi/Cargo.toml
+++ b/crates/capi/Cargo.toml
@@ -16,7 +16,7 @@ rustpython-vm = { workspace = true, features = ["threading"] }
 rustpython-stdlib = {workspace = true, features = ["threading"] }
 
 [dev-dependencies]
-pyo3 = { version = "0.28", features = ["auto-initialize", "abi3"] }
+pyo3 = { workspace = true, features = ["auto-initialize", "abi3"] }
 
 [lints]
 workspace = true


### PR DESCRIPTION
cc @ShaharNaveh @bschoenmaeckers


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Standardized Python interoperability dependency management across the workspace, switching dev-dependencies to the shared configuration and enabling automatic initialization. No public APIs or runtime behavior changes for end users.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->