### PR TITLE
Move dependency to workspace for example `rustpython-without-js`

### DIFF
--- a/example_projects/wasm32_without_js/rustpython-without-js/Cargo.toml
+++ b/example_projects/wasm32_without_js/rustpython-without-js/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2024"
 crate-type = ["cdylib"]
 
 [dependencies]
-getrandom = "0.3"
+getrandom = { workspace = true }
 rustpython-vm = { path = "../../../crates/vm", default-features = false, features = ["compiler"] }
 
 [workspace]


### PR DESCRIPTION
cc @ShaharNaveh


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal dependency management configuration to use workspace-managed versioning for consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->