### PR TITLE
Use rustix for uname; drop uname crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3567,7 +3567,6 @@ dependencies = [
  "strum_macros",
  "thiserror 2.0.18",
  "timsort",
- "uname",
  "unicode-casing",
  "wasm-bindgen",
  "which",
@@ -4254,15 +4253,6 @@ name = "ucd"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fe4fa6e588762366f1eb4991ce59ad1b93651d0b769dfb4e4d1c5c4b943d1159"
-
-[[package]]
-name = "uname"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b72f89f0ca32e4db1c04e2a72f5345d59796d4866a1ee0609084569f73683dc8"
-dependencies = [
- "libc",
-]
 
 [[package]]
 name = "unic-char-property"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -187,7 +187,7 @@ bitflagset = "0.0.3"
 bstr = "1"
 bzip2 = "0.6"
 caseless = "0.2.2"
-chrono = { version = "0.4.44", default-features = false, features = ["clock", "oldtime", "std"] }
+chrono = { version = "0.4.44", default-features = false, features = ["clock", "std"] }
 constant_time_eq = "0.4"
 cranelift = "0.131.0"
 cranelift-jit = "0.131.1"
@@ -261,7 +261,7 @@ radium = "1.1.1"
 rand = "0.9"
 rand_core = { version = "0.9", features = ["os_rng"] }
 result-like = "0.5.0"
-rustix = { version = "1.1", features = ["event"] }
+rustix = { version = "1.1", features = ["event", "system"] }
 rustls = { version = "0.23.39", default-features = false }
 rustls-native-certs = "0.8"
 rustls-pemfile = "2.2"
@@ -291,7 +291,6 @@ icu_properties = "2"
 icu_normalizer = "2"
 uuid = "1.23.1"
 ucd = "0.1.1"
-uname = "0.1.1"
 unicode-casing = "0.1.1"
 unic-ucd-age = "0.9.0"
 unicode_names2 = "2.0.0"

--- a/crates/vm/Cargo.toml
+++ b/crates/vm/Cargo.toml
@@ -91,7 +91,6 @@ icu_properties = { workspace = true }
 rustix = { workspace = true }
 nix = { workspace = true }
 exitcode = { workspace = true }
-uname = { workspace = true }
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 rustyline = { workspace = true }

--- a/crates/vm/src/stdlib/posix.rs
+++ b/crates/vm/src/stdlib/posix.rs
@@ -1475,15 +1475,15 @@ pub mod module {
     }
 
     #[pyfunction]
-    fn uname(vm: &VirtualMachine) -> PyResult<_os::UnameResultData> {
-        let info = uname::uname().map_err(|err| err.into_pyexception(vm))?;
-        Ok(_os::UnameResultData {
-            sysname: info.sysname,
-            nodename: info.nodename,
-            release: info.release,
-            version: info.version,
-            machine: info.machine,
-        })
+    fn uname() -> _os::UnameResultData {
+        let info = rustix::system::uname();
+        _os::UnameResultData {
+            sysname: info.sysname().to_string_lossy().into(),
+            nodename: info.nodename().to_string_lossy().into(),
+            release: info.release().to_string_lossy().into(),
+            version: info.version().to_string_lossy().into(),
+            machine: info.machine().to_string_lossy().into(),
+        }
     }
 
     #[pyfunction]


### PR DESCRIPTION
---

Nothing fancy here. `uname` is a small crate that hasn't been touched in ten years. It doesn't do anything spectacular. [Here](https://github.com/icorderi/rust-uname/blob/master/src/lib.rs) is its source. `rustix`, which is already being used by RustPython, provides a `uname()` wrapper that we can use instead.

I also dropped the `oldtime` feature from `chrono`. According to the `chrono` docs, that feature doesn't do anything anymore.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated time library configuration for improved compatibility
  * Refactored system information retrieval with streamlined dependency management
  * Internal code organization improvements with no functional changes to user-facing features

<!-- end of auto-generated comment: release notes by coderabbit.ai -->