### PR TITLE
Fix comment confusion bug in `update_lib`

### DIFF
--- a/Lib/test/test_descr.py
+++ b/Lib/test/test_descr.py
@@ -1860,8 +1860,8 @@ class ClassPropertiesAndMethods(unittest.TestCase):
         self.assertEqual(b.foo, 3)
         self.assertEqual(b.__class__, D)
 
-    # TODO: RUSTPYTHON; The `expectedFailure` here is from CPython, so this test must fail
-    # @unittest.expectedFailure
+    @unittest.expectedSuccess  # TODO: RUSTPYTHON; The `expectedFailure` here is from CPython, so this test must fail
+    @unittest.expectedFailure
     def test_bad_new(self):
         self.assertRaises(TypeError, object.__new__)
         self.assertRaises(TypeError, object.__new__, '')
@@ -1908,8 +1908,8 @@ class ClassPropertiesAndMethods(unittest.TestCase):
         object.__init__(A(3))
         self.assertRaises(TypeError, object.__init__, A(3), 5)
 
-    # TODO: RUSTPYTHON; The `expectedFailure` here is from CPython, so this test must fail
-    # @unittest.expectedFailure
+    @unittest.expectedSuccess  # TODO: RUSTPYTHON; The `expectedFailure` here is from CPython, so this test must fail
+    @unittest.expectedFailure
     def test_restored_object_new(self):
         class A(object):
             def __new__(cls, *args, **kwargs):

--- a/scripts/update_lib/patch_spec.py
+++ b/scripts/update_lib/patch_spec.py
@@ -190,13 +190,23 @@ class PatchEntry(typing.NamedTuple):
                     if ut_method.has_cond():
                         cond = ast.unparse(dec_node.args[0])
                 else:
-                    # Search first on decorator line, then in the line before
-                    for line in lines[dec_node.lineno - 1 : dec_node.lineno - 3 : -1]:
-                        if found := re.search(rf"{COMMENT}.?(.*)", line):
-                            reason = found.group()
-                            break
+                    pattern = re.compile(rf"{COMMENT}.?(.*)")
+                    dec_lineno = dec_node.lineno
+
+                    curr_line = lines[dec_lineno - 1]
+                    prev_line = lines[dec_lineno - 2]
+
+                    # If we see our comment at the decorator line, take it
+                    if found := pattern.search(curr_line):
+                        reason = found.group()
+                    elif prev_line.strip().startswith("#") and (
+                        found := pattern.search(prev_line)
+                    ):
+                        # Search the previous line of the decorator,
+                        # only take the comment if the line starts with a `#`
+                        reason = found.group()
                     else:
-                        # Didn't find our `COMMENT` :)
+                        # Didn't find our `COMMENT`, so the patch isn't ours :)
                         continue
 
                 reason = reason.removeprefix(COMMENT).strip(";:, ")

--- a/scripts/update_lib/tests/test_patch_spec.py
+++ b/scripts/update_lib/tests/test_patch_spec.py
@@ -149,6 +149,30 @@ class TestFoo(unittest.TestCase):
         specs = patches["TestFoo"]["test_one"]
         self.assertEqual(len(specs), 2)
 
+    def test_comment_confusion(self):
+        """
+        Test that we only extract our patches when CPython set one of the UT methods,
+        that we search for
+        """
+
+        code = f"""
+class TestFoo(unittest.TestCase):
+    @unittest.expectedSuccess # {COMMENT}; reason
+    @unittest.expectedFailure
+    def test_one(self):
+        pass
+        """
+
+        patches = extract_patches(code)
+        specs = patches["TestFoo"]["test_one"]
+        self.assertEqual(len(specs), 1)
+
+        spec = specs[0]
+        self.assertEqual(
+            spec,
+            PatchSpec(ut_method=UtMethod.ExpectedSuccess, cond=None, reason="reason"),
+        )
+
 
 class TestApplyPatches(unittest.TestCase):
     """Tests for apply_patches function."""


### PR DESCRIPTION
Before this fix. the script would do:

```py
@unittest.expectedSuccess  # TODO: RUSTPYTHON; The `expectedFailure` here is from CPython, so this test must fail
@unittest.expectedFailure  # TODO: RUSTPYTHON; The `expectedFailure` here is from CPython, so this test must fail
def test_bad_new(self):
  ...
```

Because the logic was: "search the current and the previous line for the comment, if you find it, take it".

Now we have a different logic 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved extraction of patch comments so the correct patch reason is identified when multiple decorators are present, preventing misattribution.

* **Tests**
  * Added a unit test that verifies patch extraction behavior with multiple decorators to prevent regressions.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/RustPython/RustPython/pull/7802)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->