### PR TITLE
Fix `ctypes.py_object` handling

### DIFF
--- a/crates/vm/src/stdlib/_ctypes/base.rs
+++ b/crates/vm/src/stdlib/_ctypes/base.rs
@@ -2342,6 +2342,20 @@ pub(super) fn bytes_to_pyobject(
                 }
                 Ok(vm.ctx.new_int(val).into())
             }
+            "O" => {
+                // py_object: return Python object from pointer
+                let ptr = read_ptr_from_buffer(bytes);
+                if ptr == 0 {
+                    return Err(vm.new_value_error("PyObject is NULL"));
+                }
+                let raw_ptr = ptr as *mut crate::object::PyObject;
+                unsafe {
+                    let obj =
+                        crate::PyObjectRef::from_raw(core::ptr::NonNull::new_unchecked(raw_ptr));
+                    let obj = core::mem::ManuallyDrop::new(obj);
+                    Ok((*obj).clone())
+                }
+            }
             "u" => {
                 let val = if bytes.len() >= mem::size_of::<WideChar>() {
                     let wc = if mem::size_of::<WideChar>() == 2 {

--- a/crates/vm/src/stdlib/_ctypes/base.rs
+++ b/crates/vm/src/stdlib/_ctypes/base.rs
@@ -2348,12 +2348,10 @@ pub(super) fn bytes_to_pyobject(
                 if ptr == 0 {
                     return Err(vm.new_value_error("PyObject is NULL"));
                 }
-                let raw_ptr = ptr as *mut crate::object::PyObject;
                 unsafe {
                     let obj =
-                        crate::PyObjectRef::from_raw(core::ptr::NonNull::new_unchecked(raw_ptr));
-                    let obj = core::mem::ManuallyDrop::new(obj);
-                    Ok((*obj).clone())
+                        PyObjectRef::from_raw(core::ptr::NonNull::new_unchecked(ptr as *mut _));
+                    Ok(obj)
                 }
             }
             "u" => {

--- a/crates/vm/src/stdlib/_ctypes/simple.rs
+++ b/crates/vm/src/stdlib/_ctypes/simple.rs
@@ -466,6 +466,17 @@ impl PyCSimpleType {
                     }
                 }
             }
+            // py_object: pass any Python object as PyObject*
+            Some("O") => {
+                return Ok(CArgObject {
+                    tag: b'O',
+                    value: FfiArgValue::Pointer(value.get_id()),
+                    obj: value,
+                    size: 0,
+                    offset: 0,
+                }
+                .to_pyobject(vm));
+            }
             // c_bool
             Some("?") => {
                 let bool_val = value.is_true(vm)?;


### PR DESCRIPTION
While testing the python c-api using `ctypes` in https://github.com/RustPython/RustPython/pull/7562, I stumbled on this bug. Previously all `ctypes.py_object` values were returned as `None`. After this fix the `PythonAPITestCase.test_PyBytes_FromStringAndSize` test case succeeds when `PyBytes_FromStringAndSize` is present in the c-api crate.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Enhanced ctypes `py_object` type support with improved Python object marshalling and NULL pointer validation during type conversions.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/RustPython/RustPython/pull/7836)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->