### PR TITLE
Add macro for type check functions in c-api

### DIFF
--- a/crates/capi/src/object.rs
+++ b/crates/capi/src/object.rs
@@ -8,7 +8,7 @@ use rustpython_vm::{AsObject, Py};
 pub type PyTypeObject = Py<PyType>;
 
 macro_rules! define_py_check {
-    ($name:ident, $($ctx_path:ident).+) => {
+    (fn $name:ident, $($ctx_path:ident).+) => {
         #[unsafe(no_mangle)]
         pub unsafe extern "C" fn $name(obj: *mut crate::PyObject) -> core::ffi::c_int {
             crate::pystate::with_vm(|vm| unsafe {
@@ -19,7 +19,7 @@ macro_rules! define_py_check {
             })
         }
     };
-    (exact $name:ident, $($ctx_path:ident).+) => {
+    (exact fn $name:ident, $($ctx_path:ident).+) => {
         #[unsafe(no_mangle)]
         pub unsafe extern "C" fn $name(obj: *mut crate::PyObject) -> core::ffi::c_int {
             use rustpython_vm::AsObject;
@@ -33,8 +33,8 @@ macro_rules! define_py_check {
     };
 }
 
-define_py_check!(PyType_Check, types.type_type);
-define_py_check!(exact PyType_CheckExact, types.type_type);
+define_py_check!(fn PyType_Check, types.type_type);
+define_py_check!(exact fn PyType_CheckExact, types.type_type);
 
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn Py_TYPE(op: *mut PyObject) -> *const PyTypeObject {

--- a/crates/capi/src/object.rs
+++ b/crates/capi/src/object.rs
@@ -7,6 +7,35 @@ use rustpython_vm::{AsObject, Py};
 
 pub type PyTypeObject = Py<PyType>;
 
+macro_rules! define_py_check {
+    ($name:ident, $($ctx_path:ident).+) => {
+        #[unsafe(no_mangle)]
+        pub unsafe extern "C" fn $name(obj: *mut crate::PyObject) -> core::ffi::c_int {
+            crate::pystate::with_vm(|vm| unsafe {
+                obj
+                .as_ref()
+                .map(|obj| obj.class().is_subtype(vm.ctx.$($ctx_path).+))
+                .unwrap_or_default()
+            })
+        }
+    };
+    (exact $name:ident, $($ctx_path:ident).+) => {
+        #[unsafe(no_mangle)]
+        pub unsafe extern "C" fn $name(obj: *mut crate::PyObject) -> core::ffi::c_int {
+            use rustpython_vm::AsObject;
+            crate::pystate::with_vm(|vm| unsafe {
+                obj
+                .as_ref()
+                .map(|obj| obj.class().is(vm.ctx.$($ctx_path).+))
+                .unwrap_or_default()
+            })
+        }
+    };
+}
+
+define_py_check!(PyType_Check, types.type_type);
+define_py_check!(exact PyType_CheckExact, types.type_type);
+
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn Py_TYPE(op: *mut PyObject) -> *const PyTypeObject {
     unsafe { (*op).class() }
@@ -25,6 +54,15 @@ pub unsafe extern "C" fn Py_IS_TYPE(op: *mut PyObject, ty: *mut PyTypeObject) ->
 pub unsafe extern "C" fn PyType_GetFlags(ptr: *const PyTypeObject) -> c_ulong {
     let ty = unsafe { &*ptr };
     ty.slots.flags.bits() as u32 as c_ulong
+}
+
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn PyType_IsSubtype(a: *const PyTypeObject, b: *const PyTypeObject) -> c_int {
+    with_vm(move |_vm| {
+        let a = unsafe { &*a };
+        let b = unsafe { &*b };
+        Ok(a.is_subtype(b))
+    })
 }
 
 #[unsafe(no_mangle)]


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added exported C API functions providing runtime type checks (exact-type and subtype checks) for extension modules.
  * Introduced a C-accessible subtype query to inspect type relationships between runtime types.
  * Expanded interoperability surface for extensions performing type inspections and comparisons.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/RustPython/RustPython/pull/7871?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->