### PR TITLE
Add import support to c-api

### DIFF
--- a/crates/capi/src/import.rs
+++ b/crates/capi/src/import.rs
@@ -1,0 +1,22 @@
+use crate::{PyObject, pystate::with_vm};
+use rustpython_vm::builtins::PyStr;
+
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn PyImport_Import(name: *mut PyObject) -> *mut PyObject {
+    with_vm(|vm| {
+        let name = unsafe { (&*name).try_downcast_ref::<PyStr>(vm)? };
+        vm.import(name, 0)
+    })
+}
+
+#[cfg(false)]
+mod tests {
+    use pyo3::prelude::*;
+
+    #[test]
+    fn test_import() {
+        Python::attach(|py| {
+            let _module = py.import("sys").unwrap();
+        })
+    }
+}

--- a/crates/capi/src/lib.rs
+++ b/crates/capi/src/lib.rs
@@ -8,6 +8,7 @@ use std::sync::MutexGuard;
 
 extern crate alloc;
 
+pub mod import;
 pub mod object;
 pub mod pyerrors;
 pub mod pylifecycle;


### PR DESCRIPTION
Add import support to the c-api. The test is currently disabled until we have enough api exposed to make it compile.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Python module import functionality to the C API, allowing import operations through the external C interface.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/RustPython/RustPython/pull/7881?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->