### PR TITLE
Add object protocol methods to c-api

### DIFF
--- a/crates/capi/src/abstract_.rs
+++ b/crates/capi/src/abstract_.rs
@@ -1,0 +1,52 @@
+use crate::{PyObject, pystate::with_vm};
+use core::ffi::c_int;
+
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn PyObject_GetItem(obj: *mut PyObject, key: *mut PyObject) -> *mut PyObject {
+    with_vm(|vm| {
+        let obj = unsafe { &*obj };
+        let key = unsafe { &*key };
+        obj.get_item(key, vm)
+    })
+}
+
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn PyObject_SetItem(
+    obj: *mut PyObject,
+    key: *mut PyObject,
+    value: *mut PyObject,
+) -> c_int {
+    with_vm(|vm| {
+        let obj = unsafe { &*obj };
+        let key = unsafe { &*key };
+        let value = unsafe { &*value }.to_owned();
+        obj.set_item(key, value, vm)
+    })
+}
+
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn PyObject_DelItem(obj: *mut PyObject, key: *mut PyObject) -> c_int {
+    with_vm(|vm| {
+        let obj = unsafe { &*obj };
+        let key = unsafe { &*key };
+        obj.del_item(key, vm)
+    })
+}
+
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn PyObject_IsSubclass(derived: *mut PyObject, cls: *mut PyObject) -> c_int {
+    with_vm(|vm| {
+        let derived = unsafe { &*derived };
+        let cls = unsafe { &*cls };
+        derived.is_subclass(cls, vm)
+    })
+}
+
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn PyObject_IsInstance(inst: *mut PyObject, cls: *mut PyObject) -> c_int {
+    with_vm(|vm| {
+        let inst = unsafe { &*inst };
+        let cls = unsafe { &*cls };
+        inst.is_instance(cls, vm)
+    })
+}

--- a/crates/capi/src/lib.rs
+++ b/crates/capi/src/lib.rs
@@ -8,6 +8,7 @@ use std::sync::MutexGuard;
 
 extern crate alloc;
 
+pub mod abstract_;
 pub mod import;
 pub mod object;
 pub mod pyerrors;


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Extended the C API surface with new object operations for getting, setting, and deleting items, and added subclass/instance checks—improving compatibility with C extensions and interoperability with code relying on these fundamental object behaviors.
  * Exposed the new API group at crate/module level so it’s available to C consumers.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/RustPython/RustPython/pull/7882?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->