### PR TITLE
CI: Extract sandbox tests to their own job

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -43,6 +43,10 @@ jobs:
     outputs:
       # Flag that is raised when any rust code is changed.
       rust_code: ${{ steps.check_rust_code.outputs.changed }}
+      # Flag that is raised when any upstream lib code is changed.
+      upstream_lib: ${{ steps.check_upstream_lib.outputs.changed }}
+      # Flag that is raised when any extra test is changed.
+      extra_test: ${{ steps.check_extra_test.outputs.changed }}
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
@@ -67,6 +71,35 @@ jobs:
             ':.cargo/config.toml' \
             ':crates/**' \
             ':src/**' \
+            ':.github/workflows/ci.yaml' \
+          ; then
+              echo "changed=false" >> "$GITHUB_OUTPUT"
+          else
+              echo "changed=true" >> "$GITHUB_OUTPUT"
+          fi
+        env:
+          MERGE_BASE: ${{ steps.merge_base.outputs.sha }}
+
+      - name: Check if there was any upstream lib related change
+        id: check_upstream_lib
+        run: |
+          if git diff --quiet "${MERGE_BASE}...HEAD" -- \
+            ':Lib/**' \
+            ':(exclude)Lib/test/**' \
+            ':.github/workflows/ci.yaml' \
+          ; then
+              echo "changed=false" >> "$GITHUB_OUTPUT"
+          else
+              echo "changed=true" >> "$GITHUB_OUTPUT"
+          fi
+        env:
+          MERGE_BASE: ${{ steps.merge_base.outputs.sha }}
+
+      - name: Check if there was any extra test related change
+        id: check_extra_test
+        run: |
+          if git diff --quiet "${MERGE_BASE}...HEAD" -- \
+            ':extra_tests/**' \
             ':.github/workflows/ci.yaml' \
           ; then
               echo "changed=false" >> "$GITHUB_OUTPUT"
@@ -123,23 +156,6 @@ jobs:
         run: cargo test
         if: runner.os != 'Windows'  # Requires pyo3 0.29+ on Windows
 
-      - name: check compilation without host_env (sandbox mode)
-        run: |
-          cargo check -p rustpython-vm --no-default-features --features compiler
-          cargo check -p rustpython-stdlib --no-default-features --features compiler
-          cargo build --no-default-features --features stdlib,importlib,stdio,encodings,freeze-stdlib
-        if: runner.os == 'Linux'
-
-      - name: sandbox smoke test
-        run: |
-          target/debug/rustpython extra_tests/snippets/sandbox_smoke.py
-          target/debug/rustpython extra_tests/snippets/stdlib_re.py
-        if: runner.os == 'Linux'
-
-      - name: Test openssl build
-        run: cargo build --no-default-features --features ssl-openssl
-        if: runner.os == 'Linux'
-
       # - name: Install tk-dev for tkinter build
       #   run: sudo apt-get update && sudo apt-get install -y tk-dev
       #   if: runner.os == 'Linux'
@@ -159,6 +175,53 @@ jobs:
         env:
           PYTHONPATH: scripts
         if: runner.os == 'Linux'
+
+  sandbox_test:
+    runs-on: ubuntu-latest
+    needs:
+      - determine_changes
+    if: |
+      (
+        !contains(github.event.pull_request.labels.*.name, 'skip:ci') && (
+          needs.determine_changes.outputs.rust_code == 'true' ||
+          needs.determine_changes.outputs.upstream_lib == 'true' ||
+          needs.determine_changes.outputs.extra_tests == 'true'
+        )
+      ) || github.ref == 'refs/heads/main'
+    name: sandbox tests
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
+      - uses: dtolnay/rust-toolchain@stable
+
+      - name: Restore cache
+        uses: actions/cache/restore@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+        with:
+          path: |
+            ~/.cargo/bin/
+            ~/.cargo/registry/index/
+            ~/.cargo/registry/cache/
+            ~/.cargo/git/db/
+            target/
+          key: ${{ runner.os }}-${{ hashFiles('**/Cargo.toml') }}-
+          restore-keys: |
+            ${{ runner.os }}-stable--${{ hashFiles('**/Cargo.toml') }}-
+            ${{ runner.os }}-stable--
+
+      - name: check compilation without host_env
+        run: |
+          cargo check -p rustpython-vm --no-default-features --features compiler
+          cargo check -p rustpython-stdlib --no-default-features --features compiler
+
+      - name: cargo build
+        run: cargo build --no-default-features --features stdlib,importlib,stdio,encodings,freeze-stdlib
+
+      - name: sandbox smoke test
+        run: |
+          target/debug/rustpython extra_tests/snippets/sandbox_smoke.py
+          target/debug/rustpython extra_tests/snippets/stdlib_re.py
 
   cargo_check:
     name: cargo check

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -223,6 +223,9 @@ jobs:
           target/debug/rustpython extra_tests/snippets/sandbox_smoke.py
           target/debug/rustpython extra_tests/snippets/stdlib_re.py
 
+      - name: Test openssl build # NOTE: not really related to sandbox. but we don't have a better palce to put it
+        run: cargo build --no-default-features --features ssl-openssl
+
   cargo_check:
     name: cargo check
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -46,7 +46,7 @@ jobs:
       # Flag that is raised when any upstream lib code is changed.
       upstream_lib: ${{ steps.check_upstream_lib.outputs.changed }}
       # Flag that is raised when any extra test is changed.
-      extra_test: ${{ steps.check_extra_test.outputs.changed }}
+      extra_tests: ${{ steps.check_extra_tests.outputs.changed }}
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
@@ -96,7 +96,7 @@ jobs:
           MERGE_BASE: ${{ steps.merge_base.outputs.sha }}
 
       - name: Check if there was any extra test related change
-        id: check_extra_test
+        id: check_extra_tests
         run: |
           if git diff --quiet "${MERGE_BASE}...HEAD" -- \
             ':extra_tests/**' \


### PR DESCRIPTION
related to #7883.
I'll continue optimizing the CI so only necessary jobs trigger on their related changes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * CI adds a dedicated sandbox test job that performs Linux compilation checks, sandbox smoke tests, and a separate SSL build step.
  * Sandbox tests run when related code or test areas change and always run on the main branch.
  * Sandbox-related steps were moved out of the previous test flow for clearer, focused validation.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/RustPython/RustPython/pull/7888?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->