### PR TITLE
Add integer c-api support

### DIFF
--- a/crates/capi/src/lib.rs
+++ b/crates/capi/src/lib.rs
@@ -10,6 +10,7 @@ extern crate alloc;
 
 pub mod abstract_;
 pub mod import;
+pub mod longobject;
 pub mod object;
 pub mod pyerrors;
 pub mod pylifecycle;

--- a/crates/capi/src/longobject.rs
+++ b/crates/capi/src/longobject.rs
@@ -54,7 +54,9 @@ pub unsafe extern "C" fn PyLong_AsUnsignedLongLong(obj: *mut PyObject) -> c_ulon
             .try_downcast::<PyInt>(vm)?
             .as_bigint()
             .try_into()
-            .map_err(|_| vm.new_overflow_error("Python int too large to convert to C long long"))
+            .map_err(|_| {
+                vm.new_overflow_error("Python int too large to convert to C unsigned long long")
+            })
     })
 }
 

--- a/crates/capi/src/longobject.rs
+++ b/crates/capi/src/longobject.rs
@@ -1,0 +1,83 @@
+use crate::PyObject;
+use crate::pystate::with_vm;
+use core::ffi::{c_long, c_longlong, c_ulong, c_ulonglong};
+use rustpython_vm::PyResult;
+use rustpython_vm::builtins::PyInt;
+
+#[unsafe(no_mangle)]
+pub extern "C" fn PyLong_FromLong(value: c_long) -> *mut PyObject {
+    with_vm(|vm| vm.ctx.new_int(value))
+}
+
+#[unsafe(no_mangle)]
+pub extern "C" fn PyLong_FromLongLong(value: c_longlong) -> *mut PyObject {
+    with_vm(|vm| vm.ctx.new_int(value))
+}
+
+#[unsafe(no_mangle)]
+pub extern "C" fn PyLong_FromSsize_t(value: isize) -> *mut PyObject {
+    with_vm(|vm| vm.ctx.new_int(value))
+}
+
+#[unsafe(no_mangle)]
+pub extern "C" fn PyLong_FromSize_t(value: usize) -> *mut PyObject {
+    with_vm(|vm| vm.ctx.new_int(value))
+}
+
+#[unsafe(no_mangle)]
+pub extern "C" fn PyLong_FromUnsignedLong(value: c_ulong) -> *mut PyObject {
+    with_vm(|vm| vm.ctx.new_int(value))
+}
+
+#[unsafe(no_mangle)]
+pub extern "C" fn PyLong_FromUnsignedLongLong(value: c_ulonglong) -> *mut PyObject {
+    with_vm(|vm| vm.ctx.new_int(value))
+}
+
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn PyLong_AsLong(obj: *mut PyObject) -> c_long {
+    with_vm::<PyResult<c_long>, _>(|vm| {
+        unsafe { &*obj }
+            .to_owned()
+            .try_index(vm)?
+            .as_bigint()
+            .try_into()
+            .map_err(|_| vm.new_overflow_error("Python int too large to convert to C long"))
+    })
+}
+
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn PyLong_AsUnsignedLongLong(obj: *mut PyObject) -> c_longlong {
+    with_vm::<PyResult<c_longlong>, _>(|vm| {
+        unsafe { &*obj }
+            .to_owned()
+            .try_downcast::<PyInt>(vm)?
+            .as_bigint()
+            .try_into()
+            .map_err(|_| vm.new_overflow_error("Python int too large to convert to C long long"))
+    })
+}
+
+#[cfg(false)]
+mod tests {
+    use pyo3::prelude::*;
+    use pyo3::types::PyInt;
+
+    #[test]
+    fn test_py_int_u32() {
+        Python::attach(|py| {
+            let number = PyInt::new(py, 123);
+            assert!(number.is_instance_of::<PyInt>());
+            assert_eq!(number.extract::<i32>().unwrap(), 123);
+        })
+    }
+
+    #[test]
+    fn test_py_int_u64() {
+        Python::attach(|py| {
+            let number = PyInt::new(py, 123u64);
+            assert!(number.is_instance_of::<PyInt>());
+            assert_eq!(number.extract::<u64>().unwrap(), 123);
+        })
+    }
+}

--- a/crates/capi/src/longobject.rs
+++ b/crates/capi/src/longobject.rs
@@ -47,8 +47,8 @@ pub unsafe extern "C" fn PyLong_AsLong(obj: *mut PyObject) -> c_long {
 }
 
 #[unsafe(no_mangle)]
-pub unsafe extern "C" fn PyLong_AsUnsignedLongLong(obj: *mut PyObject) -> c_longlong {
-    with_vm::<PyResult<c_longlong>, _>(|vm| {
+pub unsafe extern "C" fn PyLong_AsUnsignedLongLong(obj: *mut PyObject) -> c_ulonglong {
+    with_vm::<PyResult<c_ulonglong>, _>(|vm| {
         unsafe { &*obj }
             .to_owned()
             .try_downcast::<PyInt>(vm)?

--- a/crates/capi/src/longobject.rs
+++ b/crates/capi/src/longobject.rs
@@ -1,8 +1,12 @@
 use crate::PyObject;
+use crate::object::define_py_check;
 use crate::pystate::with_vm;
 use core::ffi::{c_long, c_longlong, c_ulong, c_ulonglong};
 use rustpython_vm::PyResult;
 use rustpython_vm::builtins::PyInt;
+
+define_py_check!(fn PyLong_Check, types.int_type);
+define_py_check!(exact fn PyLong_CheckExact, types.int_type);
 
 #[unsafe(no_mangle)]
 pub extern "C" fn PyLong_FromLong(value: c_long) -> *mut PyObject {

--- a/crates/capi/src/object.rs
+++ b/crates/capi/src/object.rs
@@ -33,6 +33,7 @@ macro_rules! define_py_check {
     };
 }
 
+pub(crate) use define_py_check;
 define_py_check!(fn PyType_Check, types.type_type);
 define_py_check!(exact fn PyType_CheckExact, types.type_type);
 

--- a/crates/capi/src/util.rs
+++ b/crates/capi/src/util.rs
@@ -1,6 +1,6 @@
 use crate::PyObject;
 use core::convert::Infallible;
-use core::ffi::{c_char, c_double, c_int, c_long, c_void};
+use core::ffi::{c_char, c_double, c_int, c_long, c_ulonglong, c_void};
 use rustpython_vm::{PyObjectRef, PyRef, PyResult, VirtualMachine};
 
 pub(crate) trait FfiResult<Output = Self> {
@@ -87,6 +87,14 @@ impl FfiResult<isize> for usize {
 
 impl FfiResult for c_long {
     const ERR_VALUE: Self = -1;
+
+    fn into_output(self, _vm: &VirtualMachine) -> Self {
+        self
+    }
+}
+
+impl FfiResult for c_ulonglong {
+    const ERR_VALUE: Self = Self::MAX;
 
     fn into_output(self, _vm: &VirtualMachine) -> Self {
         self


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * C API support for creating Python integer objects from native signed and unsigned integer types, including large unsigned types.
  * Exposed runtime checks to detect Python integer types precisely.

* **Bug Fixes**
  * Consistent overflow errors when Python integers are too large to convert.
  * Defined sentinel/return behavior for FFI integer results to improve interoperability.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/RustPython/RustPython/pull/7905?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->