### PR TITLE
Use correct dirs crate; drop uname for rustix

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -175,7 +175,7 @@ dependencies = [
  "nom",
  "num-traits",
  "rusticata-macros",
- "thiserror 2.0.18",
+ "thiserror",
  "time",
 ]
 
@@ -1059,24 +1059,24 @@ dependencies = [
 ]
 
 [[package]]
-name = "dirs-next"
-version = "2.0.0"
+name = "dirs"
+version = "6.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b98cf8ebf19c3d1b223e151f99a4f9f0690dca41414773390fc824184ac833e1"
+checksum = "c3e8aa94d75141228480295a7d0e7feb620b1a5ad9f12bc40be62411e38cce4e"
 dependencies = [
- "cfg-if",
- "dirs-sys-next",
+ "dirs-sys",
 ]
 
 [[package]]
-name = "dirs-sys-next"
-version = "0.1.2"
+name = "dirs-sys"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ebda144c4fe02d1f7ea1a7d9641b6fc6b580adcfa024ae48797ecdeb6825b4d"
+checksum = "e01a3366d27ee9890022452ee61b2b63a67e6f13f58900b651ff5665f0bb1fab"
 dependencies = [
  "libc",
+ "option-ext",
  "redox_users",
- "winapi",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1782,7 +1782,7 @@ dependencies = [
  "jni-sys",
  "log",
  "simd_cesu8",
- "thiserror 2.0.18",
+ "thiserror",
  "walkdir",
  "windows-link",
 ]
@@ -2409,6 +2409,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "option-ext"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
+
+[[package]]
 name = "optional"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2959,13 +2965,13 @@ dependencies = [
 
 [[package]]
 name = "redox_users"
-version = "0.4.6"
+version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba009ff324d1fc1b900bd1fdb31564febe58a8ccc8a6fdbb93b543d33b13ca43"
+checksum = "a4e608c6638b9c18977b00b475ac1f28d14e84b27d8d42f70e0bf1e3dec127ac"
 dependencies = [
  "getrandom 0.2.17",
  "libredox",
- "thiserror 1.0.69",
+ "thiserror",
 ]
 
 [[package]]
@@ -3203,7 +3209,7 @@ name = "rustpython"
 version = "0.5.0"
 dependencies = [
  "criterion",
- "dirs-next",
+ "dirs",
  "env_logger",
  "flame",
  "flamescope",
@@ -3249,7 +3255,7 @@ dependencies = [
  "rustpython-ruff_python_parser",
  "rustpython-ruff_text_size",
  "rustpython-wtf8",
- "thiserror 2.0.18",
+ "thiserror",
  "unicode_names2 2.0.0",
 ]
 
@@ -3286,7 +3292,7 @@ dependencies = [
  "rustpython-ruff_python_parser",
  "rustpython-ruff_source_file",
  "rustpython-ruff_text_size",
- "thiserror 2.0.18",
+ "thiserror",
 ]
 
 [[package]]
@@ -3360,7 +3366,6 @@ dependencies = [
  "rustpython-wtf8",
  "schannel",
  "termios",
- "uname",
  "widestring",
  "windows-sys 0.61.2",
 ]
@@ -3378,7 +3383,7 @@ dependencies = [
  "rustpython-compiler-core",
  "rustpython-derive",
  "rustpython-wtf8",
- "thiserror 2.0.18",
+ "thiserror",
 ]
 
 [[package]]
@@ -3419,7 +3424,7 @@ dependencies = [
  "rustpython-ruff_python_trivia",
  "rustpython-ruff_source_file",
  "rustpython-ruff_text_size",
- "thiserror 2.0.18",
+ "thiserror",
 ]
 
 [[package]]
@@ -3633,7 +3638,7 @@ dependencies = [
  "static_assertions",
  "strum",
  "strum_macros",
- "thiserror 2.0.18",
+ "thiserror",
  "timsort",
  "wasm-bindgen",
  "which",
@@ -4113,31 +4118,11 @@ checksum = "c13547615a44dc9c452a8a534638acdf07120d4b6847c8178705da06306a3057"
 
 [[package]]
 name = "thiserror"
-version = "1.0.69"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b6aaf5339b578ea85b50e080feb250a3e8ae8cfcdff9a461c9ec2904bc923f52"
-dependencies = [
- "thiserror-impl 1.0.69",
-]
-
-[[package]]
-name = "thiserror"
 version = "2.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4288b5bcbc7920c07a1149a35cf9590a2aa808e0bc1eafaade0b80947865fbc4"
 dependencies = [
- "thiserror-impl 2.0.18",
-]
-
-[[package]]
-name = "thiserror-impl"
-version = "1.0.69"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
+ "thiserror-impl",
 ]
 
 [[package]]
@@ -4321,15 +4306,6 @@ name = "ucd"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fe4fa6e588762366f1eb4991ce59ad1b93651d0b769dfb4e4d1c5c4b943d1159"
-
-[[package]]
-name = "uname"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b72f89f0ca32e4db1c04e2a72f5345d59796d4866a1ee0609084569f73683dc8"
-dependencies = [
- "libc",
-]
 
 [[package]]
 name = "unic-char-property"
@@ -5093,7 +5069,7 @@ dependencies = [
  "nom",
  "oid-registry",
  "rusticata-macros",
- "thiserror 2.0.18",
+ "thiserror",
  "time",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,7 +42,7 @@ log = { workspace = true }
 flame = { workspace = true, optional = true }
 
 lexopt = "0.3"
-dirs = { package = "dirs-next", version = "2.0" }
+dirs = "6"
 env_logger = "0.11"
 flamescope = { version = "0.1.2", optional = true }
 

--- a/crates/host_env/Cargo.toml
+++ b/crates/host_env/Cargo.toml
@@ -20,7 +20,6 @@ paste = { workspace = true }
 [target.'cfg(unix)'.dependencies]
 nix = { workspace = true }
 rustix = { workspace = true }
-uname = "0.1.1"
 
 [target.'cfg(any(not(target_arch = "wasm32"), target_os = "wasi"))'.dependencies]
 num_cpus = "1.17.0"

--- a/crates/host_env/src/posix.rs
+++ b/crates/host_env/src/posix.rs
@@ -380,14 +380,14 @@ pub fn fchownat(
     .map_err(std::io::Error::from)
 }
 
-pub fn uname_info() -> std::io::Result<UnameInfo> {
-    let info = uname::uname()?;
+pub fn uname_info() -> Result<UnameInfo, core::str::Utf8Error> {
+    let info = rustix::system::uname();
     Ok(UnameInfo {
-        sysname: info.sysname,
-        nodename: info.nodename,
-        release: info.release,
-        version: info.version,
-        machine: info.machine,
+        sysname: info.sysname().to_str()?.into(),
+        nodename: info.nodename().to_str()?.into(),
+        release: info.release().to_str()?.into(),
+        version: info.version().to_str()?.into(),
+        machine: info.machine().to_str()?.into(),
     })
 }
 

--- a/crates/vm/src/stdlib/posix.rs
+++ b/crates/vm/src/stdlib/posix.rs
@@ -1279,8 +1279,8 @@ pub mod module {
 
     #[pyfunction]
     fn uname(vm: &VirtualMachine) -> PyResult<_os::UnameResultData> {
-        let info =
-            rustpython_host_env::posix::uname_info().map_err(|err| err.into_pyexception(vm))?;
+        let info = rustpython_host_env::posix::uname_info()
+            .map_err(|err| vm.new_unicode_decode_error(err.to_string()))?;
         Ok(_os::UnameResultData {
             sysname: info.sysname,
             nodename: info.nodename,


### PR DESCRIPTION
RustPython used an ancient, unmaintained version of the `dirs` crate. This pulled in `winapi-rs` on Windows, which is an old crate that has been deprecated in favor of `windows-rs`. `windows-rs` is maintained by Microsoft. Bumping `dirs` to the latest version removes more `winapi-rs` from Cargo.lock.

As for `uname`, `rustix` handles it safely so the additional crate isn't needed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated the directory-handling library dependency to a newer implementation.
  * Removed an unused system utility dependency.

* **Refactor**
  * Improved system information retrieval to surface explicit UTF-8 decode errors.
  * POSIX bindings now map failures to Unicode decode errors for clearer diagnostics.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/RustPython/RustPython/pull/7906?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->