### PR TITLE
Update `test_types.py` to 3.14.5

### DIFF
--- a/Lib/test/test_types.py
+++ b/Lib/test/test_types.py
@@ -700,8 +700,7 @@ class TypesTests(unittest.TestCase):
         self.assertIsInstance(exc.__traceback__, types.TracebackType)
         self.assertIsInstance(exc.__traceback__.tb_frame, types.FrameType)
 
-    # XXX: RUSTPYTHON
-    @unittest.skipUnless(_datetime, "requires _datetime module")
+    @unittest.expectedFailure  # TODO: RUSTPYTHON; AttributeError: 'NoneType' object has no attribute 'datetime_CAPI'
     def test_capsule_type(self):
         self.assertIsInstance(_datetime.datetime_CAPI, types.CapsuleType)
 
@@ -2126,6 +2125,22 @@ class SimpleNamespaceTests(unittest.TestCase):
 
         self.assertIs(type(spam2), Spam)
         self.assertEqual(vars(spam2), {'ham': 5, 'eggs': 9})
+
+    @unittest.skip("TODO: RUSTPYTHON; called `Option::unwrap()` on a `None` value")
+    def test_replace_invalid_subtype(self):
+        # See https://github.com/python/cpython/issues/143636.
+        class MyNS(types.SimpleNamespace):
+            def __new__(cls, *args, **kwargs):
+                if created:
+                    return 12345
+                return super().__new__(cls)
+
+        created = False
+        ns = MyNS()
+        created = True
+        err = (r"^expect types\.SimpleNamespace type, "
+               r"but .+\.MyNS\(\) returned 'int' object")
+        self.assertRaisesRegex(TypeError, err, copy.replace, ns)
 
     def test_fake_namespace_compare(self):
         # Issue #24257: Incorrect use of PyObject_IsInstance() caused

--- a/Lib/test/test_types.py
+++ b/Lib/test/test_types.py
@@ -2126,7 +2126,6 @@ class SimpleNamespaceTests(unittest.TestCase):
         self.assertIs(type(spam2), Spam)
         self.assertEqual(vars(spam2), {'ham': 5, 'eggs': 9})
 
-    @unittest.skip("TODO: RUSTPYTHON; called `Option::unwrap()` on a `None` value")
     def test_replace_invalid_subtype(self):
         # See https://github.com/python/cpython/issues/143636.
         class MyNS(types.SimpleNamespace):

--- a/crates/vm/src/builtins/namespace.rs
+++ b/crates/vm/src/builtins/namespace.rs
@@ -61,8 +61,10 @@ impl PyNamespace {
                 zelf.class()
                     .__qualname__(vm)
                     .downcast_ref::<PyStr>()
-                    .map(|n| n.as_wtf8())
-                    .unwrap(),
+                    .map_or_else(
+                        || zelf.class().name().to_string(),
+                        |n| n.as_wtf8().to_string()
+                    ),
                 result.class().name(),
             )));
         }

--- a/crates/vm/src/builtins/namespace.rs
+++ b/crates/vm/src/builtins/namespace.rs
@@ -54,6 +54,19 @@ impl PyNamespace {
         let cls: PyObjectRef = zelf.class().to_owned().into();
         let result = cls.call((), vm)?;
 
+        if !zelf.class().is(result.class()) {
+            return Err(vm.new_type_error(format!(
+                "expect {} type, but {}() returned '{}' object",
+                Self::class(&vm.ctx).slot_name(),
+                zelf.class()
+                    .__qualname__(vm)
+                    .downcast_ref::<PyStr>()
+                    .map(|n| n.as_wtf8())
+                    .unwrap(),
+                result.class().name(),
+            )));
+        }
+
         // Copy the current namespace dict to the new instance
         let src_dict = zelf.dict().unwrap();
         let dst_dict = result.dict().unwrap();


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Namespace replacement now validates that the replacement object has the same runtime type as the original. If types differ, the operation raises a TypeError that indicates the expected SimpleNamespace-style type and the actual returned object type.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/RustPython/RustPython/pull/7912?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->