### PR TITLE
Add more c-api error functions

### DIFF
--- a/crates/capi/src/lib.rs
+++ b/crates/capi/src/lib.rs
@@ -17,6 +17,7 @@ pub mod pyerrors;
 pub mod pylifecycle;
 pub mod pystate;
 pub mod refcount;
+pub mod traceback;
 pub mod tupleobject;
 pub mod unicodeobject;
 mod util;

--- a/crates/capi/src/pyerrors.rs
+++ b/crates/capi/src/pyerrors.rs
@@ -1,5 +1,5 @@
-use crate::PyObject;
-use crate::pystate::with_vm;
+use crate::object::define_py_check;
+use crate::{PyObject, pystate::with_vm};
 use core::convert::Infallible;
 use core::ffi::{CStr, c_char, c_int};
 use core::ptr::NonNull;
@@ -95,6 +95,8 @@ define_exception_statics! {
     PyExc_ResourceWarning => resource_warning,
     PyExc_EncodingWarning => encoding_warning,
 }
+
+define_py_check!(fn PyExceptionInstance_Check, exceptions.base_exception_type);
 
 #[unsafe(no_mangle)]
 pub extern "C" fn PyErr_Occurred() -> *mut PyObject {
@@ -192,6 +194,15 @@ pub unsafe extern "C" fn PyErr_WriteUnraisable(obj: *mut PyObject) {
 }
 
 #[unsafe(no_mangle)]
+pub unsafe extern "C" fn PyExceptionClass_Check(obj: *mut PyObject) -> c_int {
+    with_vm(|vm| unsafe {
+        obj.as_ref()
+            .and_then(|obj| obj.downcast_ref::<PyType>())
+            .is_some_and(|ty| ty.is_subtype(vm.ctx.exceptions.base_exception_type))
+    })
+}
+
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn PyErr_NewException(
     name: *const c_char,
     base: *mut PyObject,
@@ -249,6 +260,39 @@ pub unsafe extern "C" fn PyErr_GivenExceptionMatches(
         let exc = unsafe { &*exc };
 
         given.is_subclass(exc, vm)
+    })
+}
+
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn PyException_GetTraceback(exc: *mut PyObject) -> *mut PyObject {
+    with_vm(|vm| {
+        let exc = unsafe { &*exc }.try_downcast_ref::<PyBaseException>(vm)?;
+        let tb = exc
+            .__traceback__()
+            .map(|tb| tb.into_object().into_raw().as_ptr())
+            .unwrap_or_default();
+        Ok(tb)
+    })
+}
+
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn PyException_GetCause(exc: *mut PyObject) -> *mut PyObject {
+    with_vm(|vm| {
+        let exc = unsafe { &*exc }.try_downcast_ref::<PyBaseException>(vm)?;
+        let context = exc.__cause__().map(|context| context.into_object());
+        Ok(vm.unwrap_or_none(context))
+    })
+}
+
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn PyException_GetContext(exc: *mut PyObject) -> *mut PyObject {
+    with_vm(|vm| {
+        let exc = unsafe { &*exc }.try_downcast_ref::<PyBaseException>(vm)?;
+        let context = exc
+            .__context__()
+            .map(|context| context.into_object().into_raw().as_ptr())
+            .unwrap_or_default();
+        Ok(context)
     })
 }
 

--- a/crates/capi/src/pyerrors.rs
+++ b/crates/capi/src/pyerrors.rs
@@ -279,8 +279,11 @@ pub unsafe extern "C" fn PyException_GetTraceback(exc: *mut PyObject) -> *mut Py
 pub unsafe extern "C" fn PyException_GetCause(exc: *mut PyObject) -> *mut PyObject {
     with_vm(|vm| {
         let exc = unsafe { &*exc }.try_downcast_ref::<PyBaseException>(vm)?;
-        let context = exc.__cause__().map(|context| context.into_object());
-        Ok(vm.unwrap_or_none(context))
+        let cause = exc
+            .__cause__()
+            .map(|cause| cause.into_object().into_raw().as_ptr())
+            .unwrap_or_default();
+        Ok(cause)
     })
 }
 

--- a/crates/capi/src/traceback.rs
+++ b/crates/capi/src/traceback.rs
@@ -1,0 +1,24 @@
+use crate::PyObject;
+use crate::object::define_py_check;
+use crate::pystate::with_vm;
+use core::ffi::c_int;
+use rustpython_vm::function::{FuncArgs, KwArgs};
+
+define_py_check!(exact fn PyTraceBack_Check, types.traceback_type);
+
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn PyTraceBack_Print(tb: *mut PyObject, file: *mut PyObject) -> c_int {
+    with_vm(|vm| {
+        let tb = unsafe { &*tb };
+        let file = unsafe { &*file };
+        let tb_module = vm.import("traceback", 0)?;
+        let print_tb = tb_module.get_attr("print_tb", vm)?;
+
+        let kwargs: KwArgs = [("file".to_string(), file.to_owned())]
+            .into_iter()
+            .collect();
+        print_tb.call(FuncArgs::new(vec![tb.to_owned()], kwargs), vm)?;
+
+        Ok(())
+    })
+}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * C API to inspect exceptions: check exception classes and access an exception's traceback, cause, and context.
  * C API support for traceback handling: type checking and printing formatted tracebacks to a file-like object.
  * Traceback module made publicly available to C API consumers.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/RustPython/RustPython/pull/7915?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->