### PR TITLE
Add type name c-api functions

### DIFF
--- a/crates/capi/src/object.rs
+++ b/crates/capi/src/object.rs
@@ -67,6 +67,33 @@ pub unsafe extern "C" fn PyType_IsSubtype(a: *const PyTypeObject, b: *const PyTy
 }
 
 #[unsafe(no_mangle)]
+pub unsafe extern "C" fn PyType_GetName(ptr: *const PyTypeObject) -> *mut PyObject {
+    with_vm(|vm| unsafe { &*ptr }.__name__(vm))
+}
+
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn PyType_GetQualName(ptr: *const PyTypeObject) -> *mut PyObject {
+    with_vm(|vm| unsafe { &*ptr }.__qualname__(vm))
+}
+
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn PyType_GetFullyQualifiedName(ptr: *const PyTypeObject) -> *mut PyObject {
+    with_vm(|vm| {
+        let ty = unsafe { &*ptr };
+        let qualname = ty.__qualname__(vm).try_downcast::<PyStr>(vm)?;
+        let module = ty.__module__(vm);
+
+        if let Some(module) = module.downcast_ref::<PyStr>()
+            && module.as_wtf8() != "builtins"
+        {
+            Ok(vm.ctx.new_str(format!("{module}.{qualname}")))
+        } else {
+            Ok(qualname)
+        }
+    })
+}
+
+#[unsafe(no_mangle)]
 pub extern "C" fn Py_GetConstantBorrowed(constant_id: c_uint) -> *mut PyObject {
     with_vm(|vm| {
         let ctx = &vm.ctx;


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added three new C API functions for type objects (`PyType_GetName`, `PyType_GetQualName`, `PyType_GetFullyQualifiedName`) to retrieve type naming information for use in C extensions and external integrations.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/RustPython/RustPython/pull/7925?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->