### PR TITLE
Add call functions to c-api

### DIFF
--- a/.cspell.dict/cpython.txt
+++ b/.cspell.dict/cpython.txt
@@ -133,6 +133,7 @@ mult
 multibytecodec
 nameobj
 nameop
+nargsf
 ncells
 nconsts
 newargs

--- a/crates/capi/src/abstract_.rs
+++ b/crates/capi/src/abstract_.rs
@@ -1,5 +1,96 @@
 use crate::{PyObject, pystate::with_vm};
+use alloc::slice;
 use core::ffi::c_int;
+use rustpython_vm::builtins::{PyDict, PyStr, PyTuple};
+use rustpython_vm::function::{FuncArgs, KwArgs};
+use rustpython_vm::{AsObject, PyObjectRef};
+
+const PY_VECTORCALL_ARGUMENTS_OFFSET: usize = 1usize << (usize::BITS as usize - 1);
+
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn PyObject_Call(
+    callable: *mut PyObject,
+    args: *mut PyObject,
+    kwargs: *mut PyObject,
+) -> *mut PyObject {
+    with_vm(|vm| {
+        let callable = unsafe { &*callable };
+        let args = unsafe { &*args }.try_downcast_ref::<PyTuple>(vm)?;
+
+        let kwargs: Option<KwArgs> = unsafe { kwargs.as_ref() }
+            .map(|kwargs| kwargs.try_downcast_ref::<PyDict>(vm)?.try_into())
+            .transpose()?;
+
+        callable.call_with_args(FuncArgs::new(args, kwargs.unwrap_or_default()), vm)
+    })
+}
+
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn PyObject_CallNoArgs(callable: *mut PyObject) -> *mut PyObject {
+    with_vm(|vm| unsafe { &*callable }.call((), vm))
+}
+
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn PyObject_Vectorcall(
+    callable: *mut PyObject,
+    args: *const *mut PyObject,
+    nargsf: usize,
+    kwnames: *mut PyObject,
+) -> *mut PyObject {
+    with_vm(|vm| {
+        let num_positional_args = nargsf & !PY_VECTORCALL_ARGUMENTS_OFFSET;
+
+        let kwnames: Option<&[PyObjectRef]> = unsafe {
+            kwnames
+                .as_ref()
+                .map(|tuple| Ok(&***tuple.try_downcast_ref::<PyTuple>(vm)?))
+                .transpose()?
+        };
+
+        let args_len = num_positional_args + kwnames.map_or(0, <[PyObjectRef]>::len);
+        let args = unsafe { slice::from_raw_parts(args, args_len) }
+            .iter()
+            .map(|arg| unsafe { &**arg }.to_owned())
+            .collect::<Vec<_>>();
+
+        let callable = unsafe { &*callable };
+        callable.vectorcall(args, num_positional_args, kwnames, vm)
+    })
+}
+
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn PyObject_VectorcallMethod(
+    name: *mut PyObject,
+    args: *const *mut PyObject,
+    nargsf: usize,
+    kwnames: *mut PyObject,
+) -> *mut PyObject {
+    with_vm(|vm| {
+        let args_len = nargsf & !PY_VECTORCALL_ARGUMENTS_OFFSET;
+
+        if args_len == 0 {
+            return Err(
+                vm.new_system_error("PyObject_VectorcallMethod called with no receiver".to_owned())
+            );
+        }
+
+        let (receiver, args) = unsafe { slice::from_raw_parts(args, args_len) }
+            .split_first()
+            .expect("args_len > 0 should guarantee a receiver");
+
+        let method_name = unsafe { (&*name).try_downcast_ref::<PyStr>(vm)? };
+        let callable = unsafe { (&**receiver).get_attr(method_name, vm)? };
+
+        Ok(unsafe {
+            PyObject_Vectorcall(
+                callable.as_object().as_raw().cast_mut(),
+                args.as_ptr(),
+                nargsf - 1,
+                kwnames,
+            )
+        })
+    })
+}
 
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn PyObject_GetItem(obj: *mut PyObject, key: *mut PyObject) -> *mut PyObject {

--- a/crates/capi/src/abstract_.rs
+++ b/crates/capi/src/abstract_.rs
@@ -48,10 +48,14 @@ pub unsafe extern "C" fn PyObject_Vectorcall(
         };
 
         let args_len = num_positional_args + kwnames.map_or(0, <[PyObjectRef]>::len);
-        let args = unsafe { slice::from_raw_parts(args, args_len) }
-            .iter()
-            .map(|arg| unsafe { &**arg }.to_owned())
-            .collect::<Vec<_>>();
+        let args = if args_len == 0 {
+            Vec::new()
+        } else {
+            unsafe { slice::from_raw_parts(args, args_len) }
+                .iter()
+                .map(|arg| unsafe { &**arg }.to_owned())
+                .collect::<Vec<_>>()
+        };
 
         let callable = unsafe { &*callable };
         callable.vectorcall(args, num_positional_args, kwnames, vm)

--- a/crates/capi/src/abstract_.rs
+++ b/crates/capi/src/abstract_.rs
@@ -2,10 +2,28 @@ use crate::{PyObject, pystate::with_vm};
 use alloc::slice;
 use core::ffi::c_int;
 use rustpython_vm::builtins::{PyDict, PyStr, PyTuple};
-use rustpython_vm::function::{FuncArgs, KwArgs};
-use rustpython_vm::{AsObject, PyObjectRef};
+use rustpython_vm::function::{FuncArgs, KwArgs, PosArgs};
+use rustpython_vm::{AsObject, Py, PyObjectRef, PyResult, VirtualMachine};
 
 const PY_VECTORCALL_ARGUMENTS_OFFSET: usize = 1usize << (usize::BITS as usize - 1);
+
+fn tuple_to_args(tuple: &Py<PyTuple>) -> PosArgs {
+    tuple.iter().cloned().collect::<Vec<_>>().into()
+}
+
+fn dict_to_kwargs(vm: &VirtualMachine, dict: &Py<PyDict>) -> PyResult<KwArgs> {
+    dict.items_vec()
+        .into_iter()
+        .map(|(key, value)| {
+            let key = key
+                .downcast_ref::<PyStr>()
+                .map(|s| s.to_string())
+                .ok_or_else(|| vm.new_type_error("keywords must be strings"))?;
+            Ok((key, value))
+        })
+        .collect::<PyResult<_>>()
+        .map(KwArgs::new)
+}
 
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn PyObject_Call(
@@ -15,10 +33,10 @@ pub unsafe extern "C" fn PyObject_Call(
 ) -> *mut PyObject {
     with_vm(|vm| {
         let callable = unsafe { &*callable };
-        let args = unsafe { &*args }.try_downcast_ref::<PyTuple>(vm)?;
+        let args = tuple_to_args(unsafe { &*args }.try_downcast_ref::<PyTuple>(vm)?);
 
         let kwargs: Option<KwArgs> = unsafe { kwargs.as_ref() }
-            .map(|kwargs| kwargs.try_downcast_ref::<PyDict>(vm)?.try_into())
+            .map(|kwargs| dict_to_kwargs(vm, kwargs.try_downcast_ref::<PyDict>(vm)?))
             .transpose()?;
 
         callable.call_with_args(FuncArgs::new(args, kwargs.unwrap_or_default()), vm)

--- a/crates/vm/src/function/argument.rs
+++ b/crates/vm/src/function/argument.rs
@@ -1,4 +1,9 @@
-use crate::{AsObject, PyObjectRef, PyPayload, PyRef, PyResult, TryFromObject, VirtualMachine, builtins::{PyBaseExceptionRef, PyDict, PyStr, PyTuple, PyTupleRef, PyTypeRef}, convert::ToPyObject, object::{Traverse, TraverseFn}, Py};
+use crate::{
+    AsObject, Py, PyObjectRef, PyPayload, PyRef, PyResult, TryFromObject, VirtualMachine,
+    builtins::{PyBaseExceptionRef, PyDict, PyStr, PyTuple, PyTupleRef, PyTypeRef},
+    convert::ToPyObject,
+    object::{Traverse, TraverseFn},
+};
 use core::ops::RangeInclusive;
 use indexmap::IndexMap;
 use itertools::Itertools;

--- a/crates/vm/src/function/argument.rs
+++ b/crates/vm/src/function/argument.rs
@@ -1,9 +1,4 @@
-use crate::{
-    AsObject, PyObjectRef, PyPayload, PyRef, PyResult, TryFromObject, VirtualMachine,
-    builtins::{PyBaseExceptionRef, PyTupleRef, PyTypeRef},
-    convert::ToPyObject,
-    object::{Traverse, TraverseFn},
-};
+use crate::{AsObject, PyObjectRef, PyPayload, PyRef, PyResult, TryFromObject, VirtualMachine, builtins::{PyBaseExceptionRef, PyDict, PyStr, PyTuple, PyTupleRef, PyTypeRef}, convert::ToPyObject, object::{Traverse, TraverseFn}, Py};
 use core::ops::RangeInclusive;
 use indexmap::IndexMap;
 use itertools::Itertools;
@@ -438,6 +433,29 @@ impl<T> FromIterator<(String, T)> for KwArgs<T> {
     }
 }
 
+impl TryFrom<&Py<PyDict>> for KwArgs<PyObjectRef> {
+    type Error = PyBaseExceptionRef;
+
+    fn try_from(kwargs: &Py<PyDict>) -> Result<Self, Self::Error> {
+        kwargs
+            .items_vec()
+            .into_iter()
+            .map(|(key, value)| {
+                let key = key
+                    .downcast_ref::<PyStr>()
+                    .map(|s| s.to_string())
+                    .ok_or_else(|| {
+                        crate::vm::thread::with_current_vm(|vm| {
+                            vm.new_type_error("keywords must be strings")
+                        })
+                    })?;
+                Ok((key, value))
+            })
+            .collect::<Result<IndexMap<_, _>, _>>()
+            .map(Self)
+    }
+}
+
 impl<T> Default for KwArgs<T> {
     fn default() -> Self {
         Self(IndexMap::new())
@@ -505,6 +523,12 @@ impl<T> PosArgs<T> {
 impl<T> From<Vec<T>> for PosArgs<T> {
     fn from(v: Vec<T>) -> Self {
         Self(v)
+    }
+}
+
+impl From<&Py<PyTuple>> for PosArgs<PyObjectRef> {
+    fn from(args: &Py<PyTuple>) -> Self {
+        Self(args.iter().cloned().collect())
     }
 }
 

--- a/crates/vm/src/function/argument.rs
+++ b/crates/vm/src/function/argument.rs
@@ -1,6 +1,6 @@
 use crate::{
-    AsObject, Py, PyObjectRef, PyPayload, PyRef, PyResult, TryFromObject, VirtualMachine,
-    builtins::{PyBaseExceptionRef, PyDict, PyStr, PyTuple, PyTupleRef, PyTypeRef},
+    AsObject, PyObjectRef, PyPayload, PyRef, PyResult, TryFromObject, VirtualMachine,
+    builtins::{PyBaseExceptionRef, PyTupleRef, PyTypeRef},
     convert::ToPyObject,
     object::{Traverse, TraverseFn},
 };
@@ -438,29 +438,6 @@ impl<T> FromIterator<(String, T)> for KwArgs<T> {
     }
 }
 
-impl TryFrom<&Py<PyDict>> for KwArgs<PyObjectRef> {
-    type Error = PyBaseExceptionRef;
-
-    fn try_from(kwargs: &Py<PyDict>) -> Result<Self, Self::Error> {
-        kwargs
-            .items_vec()
-            .into_iter()
-            .map(|(key, value)| {
-                let key = key
-                    .downcast_ref::<PyStr>()
-                    .map(|s| s.to_string())
-                    .ok_or_else(|| {
-                        crate::vm::thread::with_current_vm(|vm| {
-                            vm.new_type_error("keywords must be strings")
-                        })
-                    })?;
-                Ok((key, value))
-            })
-            .collect::<Result<IndexMap<_, _>, _>>()
-            .map(Self)
-    }
-}
-
 impl<T> Default for KwArgs<T> {
     fn default() -> Self {
         Self(IndexMap::new())
@@ -528,12 +505,6 @@ impl<T> PosArgs<T> {
 impl<T> From<Vec<T>> for PosArgs<T> {
     fn from(v: Vec<T>) -> Self {
         Self(v)
-    }
-}
-
-impl From<&Py<PyTuple>> for PosArgs<PyObjectRef> {
-    fn from(args: &Py<PyTuple>) -> Self {
-        Self(args.iter().cloned().collect())
     }
 }
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Expanded C API object calling interface with new functions supporting multiple invocation patterns. These include standard calls with arguments and keyword arguments, efficient no-argument calls, and optimized vectorcall variants. These additions enable improved performance, better compatibility, and provide developers with flexible mechanisms for object invocation in C-based code.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/RustPython/RustPython/pull/7937?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->