### PR TITLE
Add bool support to c-api

### DIFF
--- a/crates/capi/src/boolobject.rs
+++ b/crates/capi/src/boolobject.rs
@@ -1,0 +1,28 @@
+use crate::object::define_py_check;
+use crate::{PyObject, pystate::with_vm};
+use core::ffi::{c_int, c_long};
+use rustpython_vm::AsObject;
+
+define_py_check!(fn PyBool_Check, types.bool_type);
+
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn Py_IsTrue(obj: *mut PyObject) -> c_int {
+    with_vm(|vm| unsafe { obj.as_ref().is_some_and(|obj| obj.is(&vm.ctx.true_value)) })
+}
+
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn Py_IsFalse(obj: *mut PyObject) -> c_int {
+    with_vm(|vm| unsafe { obj.as_ref().is_some_and(|obj| obj.is(&vm.ctx.false_value)) })
+}
+
+#[unsafe(no_mangle)]
+pub extern "C" fn PyBool_FromLong(value: c_long) -> *mut PyObject {
+    with_vm(|vm| {
+        if value == 0 {
+            &vm.ctx.false_value
+        } else {
+            &vm.ctx.true_value
+        }
+        .to_owned()
+    })
+}

--- a/crates/capi/src/lib.rs
+++ b/crates/capi/src/lib.rs
@@ -9,6 +9,7 @@ use std::sync::MutexGuard;
 extern crate alloc;
 
 pub mod abstract_;
+pub mod boolobject;
 pub mod bytesobject;
 pub mod ceval;
 pub mod import;


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Extended the C API with new boolean type operations. Added functions for boolean type validation, testing whether values evaluate to true or false, and converting numeric values to boolean singletons. These additions improve compatibility for C-based extensions and third-party modules using boolean types.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/RustPython/RustPython/pull/7938?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->