### PR TITLE
Add missing test for select.select()

### DIFF
--- a/extra_tests/snippets/stdlib_select.py
+++ b/extra_tests/snippets/stdlib_select.py
@@ -62,6 +62,16 @@ if sys.platform != "win32":
         resource.setrlimit(resource.RLIMIT_NOFILE, (soft_max_fds, hard_max_fds))
 sockets = [s for _ in range(TOO_MANY_SELECT_FDS // 2) for s in socket.socketpair()]
 assert_raises(ValueError, select.select, sockets, [], [], 0)
+if sys.platform != "win32":
+    # Try to overflow descriptor bit mask on *nix with a single item
+    max_fd = -1
+    max_fd_sock = None
+    sockets.reverse()
+    for sock in sockets:
+        if sock.fileno() > max_fd:
+            max_fd = sock.fileno()
+            max_fd_sock = sock
+    assert_raises(ValueError, select.select, [max_fd_sock], [], [], 0)
 del sockets
 a, b = socket.socketpair()
 # CPython disallows this on *nix systems too.


### PR DESCRIPTION
This is a follow up for https://github.com/RustPython/RustPython/pull/7948

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Expanded test coverage for `select` validation with additional edge case scenarios on UNIX-like systems.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/RustPython/RustPython/pull/7953?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->