### PR TITLE
Replace `ahash` with `rapidhash`

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -85,7 +85,6 @@ updates:
           - "quote-use*"
       random:
         patterns:
-          - "ahash"
           - "getrandom"
           - "mt19937"
           - "rand*"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2929,6 +2929,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "rapidhash"
+version = "4.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b5e48930979c155e2f33aa36ab3119b5ee81332beb6482199a8ecd6029b80b59"
+dependencies = [
+ "rustversion",
+]
+
+[[package]]
 name = "rayon"
 version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3241,7 +3250,6 @@ dependencies = [
 name = "rustpython-codegen"
 version = "0.5.0"
 dependencies = [
- "ahash",
  "bitflags 2.11.1",
  "indexmap",
  "itertools 0.14.0",
@@ -3250,6 +3258,7 @@ dependencies = [
  "memchr",
  "num-complex",
  "num-traits",
+ "rapidhash",
  "rustpython-compiler-core",
  "rustpython-literal",
  "rustpython-ruff_python_ast",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -26,19 +26,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "ahash"
-version = "0.8.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a15f179cd60c4584b8a8c596927aadc462e27f2ca70c04e0071964a73ba7a75"
-dependencies = [
- "cfg-if",
- "getrandom 0.3.4",
- "once_cell",
- "version_check",
- "zerocopy",
-]
-
-[[package]]
 name = "aho-corasick"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3597,7 +3584,6 @@ version = "0.5.0"
 name = "rustpython-vm"
 version = "0.5.0"
 dependencies = [
- "ahash",
  "ascii",
  "bitflags 2.11.1",
  "bstr",
@@ -3628,6 +3614,7 @@ dependencies = [
  "parking_lot",
  "paste",
  "psm",
+ "rapidhash",
  "result-like",
  "rustpython-codegen",
  "rustpython-common",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3507,7 +3507,6 @@ name = "rustpython-stdlib"
 version = "0.5.0"
 dependencies = [
  "adler32",
- "ahash",
  "ascii",
  "aws-lc-rs",
  "base64",
@@ -3558,6 +3557,7 @@ dependencies = [
  "pkcs8",
  "pymath",
  "rand_core 0.9.5",
+ "rapidhash",
  "rustls",
  "rustls-native-certs",
  "rustls-pemfile",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -176,7 +176,6 @@ ruff_source_file = { package = "rustpython-ruff_source_file", version = "0.15.8"
 der = { version = "0.8", features = ["alloc", "oid", "pem", "zeroize"] }
 phf = { version = "0.13.1", default-features = false, features = ["macros"]}
 adler32 = "1.2.0"
-ahash = "0.8.12"
 approx = "0.5.1"
 ascii = "1.1"
 aws-lc-rs = "1.16.3"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -260,6 +260,7 @@ quote = "1.0.45"
 radium = "1.1.1"
 rand = "0.9"
 rand_core = { version = "0.9", features = ["os_rng"] }
+rapidhash = "4.4.1"
 result-like = "0.5.0"
 rustix = { version = "1.1", features = ["event", "param", "system"] }
 rustls = { version = "0.23.39", default-features = false }

--- a/crates/codegen/Cargo.toml
+++ b/crates/codegen/Cargo.toml
@@ -19,7 +19,6 @@ rustpython-wtf8 = { workspace = true }
 ruff_python_ast = { workspace = true }
 ruff_text_size = { workspace = true }
 
-ahash = { workspace = true }
 bitflags = { workspace = true }
 indexmap = { workspace = true }
 itertools = { workspace = true }
@@ -29,6 +28,7 @@ num-traits = { workspace = true }
 thiserror = { workspace = true }
 malachite-bigint = { workspace = true }
 memchr = { workspace = true }
+rapidhash = { workspace = true }
 unicode_names2 = { workspace = true }
 
 [dev-dependencies]

--- a/crates/codegen/src/lib.rs
+++ b/crates/codegen/src/lib.rs
@@ -8,8 +8,8 @@ extern crate log;
 
 extern crate alloc;
 
-type IndexMap<K, V> = indexmap::IndexMap<K, V, ahash::RandomState>;
-type IndexSet<T> = indexmap::IndexSet<T, ahash::RandomState>;
+type IndexMap<K, V> = indexmap::IndexMap<K, V, rapidhash::quality::RandomState>;
+type IndexSet<T> = indexmap::IndexSet<T, rapidhash::quality::RandomState>;
 
 pub mod compile;
 pub mod error;

--- a/crates/stdlib/Cargo.toml
+++ b/crates/stdlib/Cargo.toml
@@ -37,7 +37,6 @@ ruff_python_ast = { workspace = true }
 ruff_text_size = { workspace = true }
 ruff_source_file = { workspace = true }
 
-ahash = { workspace = true }
 ascii = { workspace = true }
 crossbeam-utils = { workspace = true }
 flame = { workspace = true, optional = true }
@@ -51,6 +50,7 @@ num-traits = { workspace = true }
 num_enum = { workspace = true }
 parking_lot = { workspace = true }
 phf = { workspace = true, default-features = true, features = ["macros"] }
+rapidhash = { workspace = true }
 
 memchr = { workspace = true }
 base64 = { workspace = true }

--- a/crates/stdlib/src/contextvars.rs
+++ b/crates/stdlib/src/contextvars.rs
@@ -28,7 +28,7 @@ mod _contextvars {
     use indexmap::IndexMap;
 
     // TODO: Real hamt implementation
-    type Hamt = IndexMap<PyRef<ContextVar>, PyObjectRef, ahash::RandomState>;
+    type Hamt = IndexMap<PyRef<ContextVar>, PyObjectRef, rapidhash::quality::RandomState>;
 
     #[pyclass(no_attr, name = "Hamt", module = "contextvars")]
     #[derive(Debug, PyPayload)]

--- a/crates/vm/Cargo.toml
+++ b/crates/vm/Cargo.toml
@@ -44,7 +44,6 @@ rustpython-literal = { workspace = true }
 rustpython-sre_engine = { workspace = true }
 
 ascii = { workspace = true }
-ahash = { workspace = true }
 bitflags = { workspace = true }
 bstr = { workspace = true }
 crossbeam-utils = { workspace = true }
@@ -64,6 +63,7 @@ num-traits = { workspace = true }
 num_enum = { workspace = true }
 parking_lot = { workspace = true }
 paste = { workspace = true }
+rapidhash = { workspace = true }
 scopeguard = { workspace = true }
 serde = { workspace = true, optional = true }
 static_assertions = { workspace = true }

--- a/crates/vm/src/builtins/type.rs
+++ b/crates/vm/src/builtins/type.rs
@@ -408,7 +408,8 @@ cfg_select! {
 /// For attributes we do not use a dict, but an IndexMap, which is an Hash Table
 /// that maintains order and is compatible with the standard HashMap  This is probably
 /// faster and only supports strings as keys.
-pub(crate) type PyAttributes = IndexMap<&'static PyStrInterned, PyObjectRef, ahash::RandomState>;
+pub(crate) type PyAttributes =
+    IndexMap<&'static PyStrInterned, PyObjectRef, rapidhash::quality::RandomState>;
 
 unsafe impl Traverse for PyAttributes {
     fn traverse(&self, tracer_fn: &mut TraverseFn<'_>) {

--- a/crates/vm/src/intern.rs
+++ b/crates/vm/src/intern.rs
@@ -11,7 +11,7 @@ use core::{borrow::Borrow, ops::Deref};
 
 #[derive(Debug)]
 pub(crate) struct StringPool {
-    inner: PyRwLock<std::collections::HashSet<CachedPyStrRef, ahash::RandomState>>,
+    inner: PyRwLock<std::collections::HashSet<CachedPyStrRef, rapidhash::quality::RandomState>>,
 }
 
 impl Default for StringPool {

--- a/crates/vm/src/vm/interpreter.rs
+++ b/crates/vm/src/vm/interpreter.rs
@@ -95,8 +95,11 @@ where
     } as usize);
 
     // Initialize frozen modules (core + user-provided)
-    let mut frozen: std::collections::HashMap<&'static str, FrozenModule, ahash::RandomState> =
-        core_frozen_inits().collect();
+    let mut frozen: std::collections::HashMap<
+        &'static str,
+        FrozenModule,
+        rapidhash::quality::RandomState,
+    > = core_frozen_inits().collect();
     frozen.extend(frozen_modules);
 
     // Create PyGlobalState

--- a/crates/vm/src/vm/mod.rs
+++ b/crates/vm/src/vm/mod.rs
@@ -589,7 +589,7 @@ pub(crate) struct CallableCache {
 pub struct PyGlobalState {
     pub config: PyConfig,
     pub module_defs: BTreeMap<&'static str, &'static builtins::PyModuleDef>,
-    pub frozen: HashMap<&'static str, FrozenModule, ahash::RandomState>,
+    pub frozen: HashMap<&'static str, FrozenModule, rapidhash::quality::RandomState>,
     pub stacksize: AtomicCell<usize>,
     pub thread_count: AtomicCell<usize>,
     pub hash_secret: HashSecret,


### PR DESCRIPTION
Follow-up to #7800.

Back in 2021, `ahash` was added to RustPython in #2397 because it was faster than the Rust standard library hash/`RandomState`. 
Since then, hashing technology has evolved to the point where `rapidhash` beats `ahash` in both the `SMHasher` and `SMHasher3` test suites. 
Additionally, `rapidhash` has very minimal direct dependencies and is portable across CPU architectures.

cc @coolreader18 @joshuamegnauth54


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Replaced the workspace hashing dependency with an alternative implementation and updated usages across crates for consistent hashing behavior.
  * Adjusted dependency grouping so the previous hash crate is no longer included in the automated grouping/configuration.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/RustPython/RustPython/pull/7954?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->