### PR TITLE
sqlite3: fix Blob.__setitem__ value range validation

### DIFF
--- a/Lib/test/test_sqlite3/test_dbapi.py
+++ b/Lib/test/test_sqlite3/test_dbapi.py
@@ -1444,7 +1444,6 @@ class BlobTests(unittest.TestCase):
         with self.assertRaisesRegex(IndexError, "cannot fit 'int'"):
             self.blob[_testcapi.ULLONG_MAX]
 
-    @unittest.expectedFailure # TODO: RUSTPYTHON
     def test_blob_set_item_error(self):
         with self.assertRaisesRegex(TypeError, "cannot be interpreted"):
             self.blob[0] = b"multiple"

--- a/crates/stdlib/src/_sqlite3.rs
+++ b/crates/stdlib/src/_sqlite3.rs
@@ -2571,7 +2571,7 @@ mod _sqlite3 {
                 // Mirror CPython ass_subscript_index: use PyLong_AsLong, treat any
                 // overflow (e.g. 2**65) as -1, then validate the [0, 255] range.
                 let val = int_val.as_bigint().to_i64().unwrap_or(-1);
-                if val < 0 || val > 255 {
+                if !(0..=255).contains(&val) {
                     return Err(vm.new_value_error("byte must be in range(0, 256)"));
                 }
                 let ret = inner.blob.write_single(val as u8, index);
@@ -2612,25 +2612,25 @@ mod _sqlite3 {
                     self.check(ret, vm)
                 } else {
                     let span_len = range.end - range.start;
+                    let range_start = range.start;
                     let mut temp_buf = vec![0u8; span_len];
 
                     let ret = inner.blob.read(
                         temp_buf.as_mut_ptr().cast(),
                         span_len as c_int,
-                        range.start as c_int,
+                        range_start as c_int,
                     );
                     self.check(ret, vm)?;
 
-                    let mut i_in_temp: usize = 0;
-                    for i_in_src in 0..slice_len {
-                        temp_buf[i_in_temp] = buf[i_in_src];
-                        i_in_temp += step as usize;
+                    let iter = SaturatedSliceIter::from_adjust_indices(range, step, slice_len);
+                    for (i_in_src, abs_idx) in iter.enumerate() {
+                        temp_buf[abs_idx - range_start] = buf[i_in_src];
                     }
 
                     let ret = inner.blob.write(
                         temp_buf.as_ptr().cast(),
                         span_len as c_int,
-                        range.start as c_int,
+                        range_start as c_int,
                     );
                     self.check(ret, vm)
                 }

--- a/crates/stdlib/src/_sqlite3.rs
+++ b/crates/stdlib/src/_sqlite3.rs
@@ -44,6 +44,7 @@ mod _sqlite3 {
         sqlite3_value_text, sqlite3_value_type,
     };
     use malachite_bigint::Sign;
+    use num_traits::ToPrimitive;
     use rustpython_common::{
         atomic::{Ordering, PyAtomic, Radium},
         hash::PyHash,
@@ -2551,28 +2552,35 @@ mod _sqlite3 {
             value: Option<PyObjectRef>,
             vm: &VirtualMachine,
         ) -> PyResult<()> {
-            let Some(value) = value else {
-                return Err(vm.new_type_error("Blob doesn't support slice deletion"));
-            };
             self.ensure_connection_open(vm)?;
             let inner = self.inner(vm)?;
 
             if let Some(index) = needle.try_index_opt(vm) {
                 // Handle single item assignment: blob[i] = b
-                let Some(value) = value.downcast_ref::<PyInt>() else {
+                let Some(value) = value else {
+                    return Err(vm.new_type_error("Blob doesn't support item deletion"));
+                };
+                let Some(int_val) = value.downcast_ref::<PyInt>() else {
                     return Err(vm.new_type_error(format!(
                         "'{}' object cannot be interpreted as an integer",
                         value.class()
                     )));
                 };
-                let value = value.try_to_primitive::<u8>(vm)?;
                 let blob_len = inner.blob.bytes();
                 let index = Self::wrapped_index(index?, blob_len, vm)?;
-                Self::expect_write(blob_len, 1, index, vm)?;
-                let ret = inner.blob.write_single(value, index);
+                // Mirror CPython ass_subscript_index: use PyLong_AsLong, treat any
+                // overflow (e.g. 2**65) as -1, then validate the [0, 255] range.
+                let val = int_val.as_bigint().to_i64().unwrap_or(-1);
+                if val < 0 || val > 255 {
+                    return Err(vm.new_value_error("byte must be in range(0, 256)"));
+                }
+                let ret = inner.blob.write_single(val as u8, index);
                 self.check(ret, vm)
             } else if let Some(slice) = needle.downcast_ref::<PySlice>() {
                 // Handle slice assignment: blob[a:b:c] = b"..."
+                let Some(value) = value else {
+                    return Err(vm.new_type_error("Blob doesn't support slice deletion"));
+                };
                 let value_buf = PyBuffer::try_from_borrowed_object(vm, &value)?;
 
                 let buf = value_buf

--- a/extra_tests/snippets/stdlib_sqlite.py
+++ b/extra_tests/snippets/stdlib_sqlite.py
@@ -53,3 +53,14 @@ class AggrText:
 cx.create_aggregate("aggtxt", 1, AggrText)
 cur.execute("select aggtxt(key) from foo")
 assert cur.fetchone()[0] == "341011"
+
+# Blob extended-slice assignment with negative step
+cx.execute("CREATE TABLE blobtest(b BLOB)")
+data = b"this blob data string is exactly fifty bytes long!"
+cx.execute("INSERT INTO blobtest(b) VALUES (?)", (data,))
+blob = cx.blobopen("blobtest", "b", 1)
+blob[9:0:-2] = b"12345"  # writes to indices 9, 7, 5, 3, 1
+actual = cx.execute("select b from blobtest").fetchone()[0]
+expected = b"t5i4 3l2b1" + data[10:]
+assert actual == expected, f"got {actual!r}, expected {expected!r}"
+blob.close()

--- a/extra_tests/snippets/stdlib_sqlite.py
+++ b/extra_tests/snippets/stdlib_sqlite.py
@@ -58,6 +58,7 @@ assert cur.fetchone()[0] == "341011"
 # Guard: CPython 3.11 has a SystemError bug with negative-step Blob slicing;
 # this test only runs on RustPython where the fix is being validated.
 import sys
+
 if sys.implementation.name == "rustpython":
     cx.execute("CREATE TABLE blobtest(b BLOB)")
     data = b"this blob data string is exactly fifty bytes long!"

--- a/extra_tests/snippets/stdlib_sqlite.py
+++ b/extra_tests/snippets/stdlib_sqlite.py
@@ -57,6 +57,7 @@ assert cur.fetchone()[0] == "341011"
 # Blob extended-slice assignment with negative step
 # Guard: CPython 3.11 has a SystemError bug with negative-step Blob slicing;
 # this test only runs on RustPython where the fix is being validated.
+# TODO: remove this once https://github.com/python/cpython/pull/150450 is released and RustPython CI uses it.
 import sys
 
 if sys.implementation.name == "rustpython":

--- a/extra_tests/snippets/stdlib_sqlite.py
+++ b/extra_tests/snippets/stdlib_sqlite.py
@@ -55,12 +55,16 @@ cur.execute("select aggtxt(key) from foo")
 assert cur.fetchone()[0] == "341011"
 
 # Blob extended-slice assignment with negative step
-cx.execute("CREATE TABLE blobtest(b BLOB)")
-data = b"this blob data string is exactly fifty bytes long!"
-cx.execute("INSERT INTO blobtest(b) VALUES (?)", (data,))
-blob = cx.blobopen("blobtest", "b", 1)
-blob[9:0:-2] = b"12345"  # writes to indices 9, 7, 5, 3, 1
-actual = cx.execute("select b from blobtest").fetchone()[0]
-expected = b"t5i4 3l2b1" + data[10:]
-assert actual == expected, f"got {actual!r}, expected {expected!r}"
-blob.close()
+# Guard: CPython 3.11 has a SystemError bug with negative-step Blob slicing;
+# this test only runs on RustPython where the fix is being validated.
+import sys
+if sys.implementation.name == "rustpython":
+    cx.execute("CREATE TABLE blobtest(b BLOB)")
+    data = b"this blob data string is exactly fifty bytes long!"
+    cx.execute("INSERT INTO blobtest(b) VALUES (?)", (data,))
+    blob = cx.blobopen("blobtest", "b", 1)
+    blob[9:0:-2] = b"12345"  # writes to indices 9, 7, 5, 3, 1
+    actual = cx.execute("select b from blobtest").fetchone()[0]
+    expected = b"t5i4 3l2b1" + data[10:]
+    assert actual == expected, f"got {actual!r}, expected {expected!r}"
+    blob.close()


### PR DESCRIPTION
Previously, assigning an out-of-range integer (negative or > 255) or an integer too large for i64 (e.g. 2**65) to a Blob index raised OverflowError instead of ValueError.

Mirror CPython's ass_subscript_index logic:
- Convert the value via to_i64(), treating any overflow as -1
- Validate the result is in [0, 255], raising ValueError("byte must be in range(0, 256)") otherwise
- Separate deletion error messages: "item deletion" for index, "slice deletion" for slice

Ref: https://github.com/python/cpython/blob/main/Modules/_sqlite/blob.c

----
### Problem

When assigning an out-of-range integer to a `Blob` index, RustPython raised `OverflowError` instead of `ValueError`:

```python
blob[0] = -1      # OverflowError: Python int too large to convert to Rust u8
blob[0] = 256     # OverflowError
blob[0] = 2**65   # OverflowError
```

CPython raises `ValueError: byte must be in range(0, 256)` for all three cases.

### Root Cause

The previous implementation used `try_to_primitive::<u8>(vm)?` to convert the assigned value, which calls Rust's type conversion and raises a generic `OverflowError` for any value that doesn't fit in `u8` — including negative numbers.

### Fix

Mirrors CPython's `ass_subscript_index` logic:

```c
// CPython blob.c
long val = PyLong_AsLong(value);
if (val == -1 && PyErr_Occurred()) {
    PyErr_Clear();
    val = -1;  // treat overflow as out-of-range
}
if (val < 0 || val > 255) {
    PyErr_SetString(PyExc_ValueError, "byte must be in range(0, 256)");
    return -1;
}
```

In Rust:
- Replace `try_to_primitive::<u8>()` with `as_bigint().to_i64().unwrap_or(-1)`
- Values that overflow `i64` (e.g. `2**65`) are treated as `-1`, which then fails the range check
- Raises `ValueError("byte must be in range(0, 256)")` for any value outside `[0, 255]`

Additionally, aligned the deletion error messages with CPython:
- `del blob[0]` → `"Blob doesn't support item deletion"`
- `del blob[5:10]` → `"Blob doesn't support slice deletion"`

### Changes
- _sqlite3.rs: Fix `Blob::ass_subscript` index branch
- test_dbapi.py: Remove `@unittest.expectedFailure` from `test_blob_set_item_error`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed single-byte BLOB assignment to properly validate byte values and handle integer overflow.
  * Improved BLOB slice assignment so unaffected bytes are preserved for complex slices, including negative-step writes.

* **Tests**
  * Added a regression test for extended-slice BLOB assignments to prevent future regressions.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/RustPython/RustPython/pull/7981?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->