### PR TITLE
rename ssl-vendor to ssl-openssl-vendor

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -141,7 +141,7 @@ jobs:
         if: runner.os == 'Linux'
 
       - name: Test vendored OpenSSL build
-        run: cargo build --no-default-features --features ssl-vendor
+        run: cargo build --no-default-features --features ssl-openssl-vendor
         if: runner.os == 'Linux'
 
       # - name: Install tk-dev for tkinter build

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,7 @@ ssl-rustls = ["ssl", "rustpython-stdlib/ssl-rustls"]
 ssl-rustls-aws-lc = ["ssl-rustls", "dep:rustls", "rustls/aws_lc_rs"]
 ssl-rustls-aws-lc-fips = ["ssl-rustls-aws-lc", "rustls/fips"]
 ssl-openssl = ["ssl", "rustpython-stdlib/ssl-openssl"]
-ssl-vendor = ["ssl-openssl", "rustpython-stdlib/ssl-vendor"]
+ssl-openssl-vendor = ["ssl-openssl", "rustpython-stdlib/ssl-openssl-vendor"]
 tkinter = ["rustpython-stdlib/tkinter"]
 
 [build-dependencies]

--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ $ python # now `python` is the alias of the RustPython for the new env
 
 If you'd like to make https requests, you can enable the `ssl` feature, which
 also lets you install the `pip` package manager. Note that on Windows, you may
-need to install OpenSSL, or you can enable the `ssl-vendor` feature instead,
+need to install OpenSSL, or you can enable the `ssl-openssl-vendor` feature instead,
 which compiles OpenSSL for you but requires a C compiler, perl, and `make`.
 OpenSSL version 3 is expected and tested in CI. Older versions may not work.
 
@@ -103,7 +103,7 @@ rustpython
 ### SSL provider
 
 For HTTPS requests, `ssl-rustls-aws-lc` is enabled by default for the RustPython binary. Embedders can use `rustpython-stdlib`'s provider-agnostic `ssl-rustls` feature and install their own rustls crypto provider, or replace rustls with `ssl-openssl` if their environment requires OpenSSL.
-Note that to use OpenSSL on Windows, you may need to install OpenSSL, or you can enable the `ssl-vendor` feature instead,
+Note that to use OpenSSL on Windows, you may need to install OpenSSL, or you can enable the `ssl-openssl-vendor` feature instead,
 which compiles OpenSSL for you but requires a C compiler, perl, and `make`.
 OpenSSL version 3 is expected and tested in CI. Older versions may not work.
 

--- a/crates/stdlib/Cargo.toml
+++ b/crates/stdlib/Cargo.toml
@@ -20,7 +20,7 @@ sqlite = ["dep:libsqlite3-sys"]
 ssl = ["host_env"]
 ssl-rustls = ["__ssl-rustls", "rustls/custom-provider"]
 ssl-openssl = ["ssl", "openssl", "openssl-sys", "foreign-types-shared", "openssl-probe"]
-ssl-vendor = ["ssl-openssl", "openssl/vendored"]
+ssl-openssl-vendor = ["ssl-openssl", "openssl/vendored"]
 tkinter = ["dep:tk-sys", "dep:tcl-sys", "dep:widestring"]
 flame-it = ["flame"]
 


### PR DESCRIPTION
see also #7985

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Renamed OpenSSL vendored build feature from `ssl-vendor` to `ssl-openssl-vendor` across all project configurations for consistency.

* **Documentation**
  * Updated Windows SSL setup instructions to reflect the renamed build feature.

* **Tests**
  * Updated CI test configurations to use the renamed OpenSSL build feature.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/RustPython/RustPython/pull/7989?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->