### PR TITLE
Fix broken CI (rustc 1.96)

### DIFF
--- a/crates/vm/src/builtins/weakref.rs
+++ b/crates/vm/src/builtins/weakref.rs
@@ -131,7 +131,7 @@ impl Comparable for PyWeak {
     ) -> PyResult<PyComparisonValue> {
         op.eq_only(|| {
             let other = class_or_notimplemented!(Self, other);
-            let both = zelf.upgrade().and_then(|s| other.upgrade().map(|o| (s, o)));
+            let both = zelf.upgrade().zip(other.upgrade());
             match both {
                 // CPython parity (Objects/weakref.c::weakref_richcompare): use
                 // PyObject_RichCompare on the referents, not the bool variant,

--- a/crates/vm/src/stdlib/builtins.rs
+++ b/crates/vm/src/stdlib/builtins.rs
@@ -1006,10 +1006,6 @@ mod builtins {
             exp: y,
             modulus,
         } = args;
-        #[expect(
-            clippy::unnecessary_option_map_or_else,
-            reason = "changing this won't compile"
-        )]
         let modulus = modulus
             .as_ref()
             .map_or_else(|| vm.ctx.none.as_object(), |m| m);

--- a/example_projects/wasm32_without_js/rustpython-without-js/src/lib.rs
+++ b/example_projects/wasm32_without_js/rustpython-without-js/src/lib.rs
@@ -1,12 +1,12 @@
 use rustpython_vm::Interpreter;
 
+#[link(wasm_import_module = "env")]
 unsafe extern "C" {
     fn kv_get(kp: i32, kl: i32, vp: i32, vl: i32) -> i32;
 
     /// kp and kl are the key pointer and length in wasm memory, vp and vl are for the value
     fn kv_put(kp: i32, kl: i32, vp: i32, vl: i32) -> i32;
 
-    #[link(wasm_import_module = "env")]
     fn print(p: i32, l: i32) -> i32;
 }
 

--- a/example_projects/wasm32_without_js/rustpython-without-js/src/lib.rs
+++ b/example_projects/wasm32_without_js/rustpython-without-js/src/lib.rs
@@ -6,6 +6,7 @@ unsafe extern "C" {
     /// kp and kl are the key pointer and length in wasm memory, vp and vl are for the value
     fn kv_put(kp: i32, kl: i32, vp: i32, vl: i32) -> i32;
 
+    #[link(wasm_import_module = "env")]
     fn print(p: i32, l: i32) -> i32;
 }
 


### PR DESCRIPTION
Wasm issues seems to be related to https://github.com/rust-lang/rust/pull/149868
<!--
Thanks for your contribution!
-->

- [ ] Closes #xxxx <!-- Replace xxxx with the GitHub issue number -->
- [ ] This PR follows our [AI policy](https://github.com/RustPython/.github/blob/main/AI_POLICY.md)

## Summary
<!-- What's the purpose of the change? What does it do, and why? -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary

* **Refactor**
  * Simplified weak reference comparison to ensure referent-equality is handled correctly when both targets are alive.
* **Chores**
  * Removed a now-unnecessary lint suppression around modular exponentiation handling.
* **Build**
  * Made a WASM import declaration explicit for the JS-free build to ensure correct linkage.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/RustPython/RustPython/pull/7992?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->