### PR TITLE
Add errno.EHWPOISON

### DIFF
--- a/crates/vm/src/stdlib/errno.rs
+++ b/crates/vm/src/stdlib/errno.rs
@@ -733,6 +733,18 @@ const ERROR_CODES: &[(&str, i32)] = &[
         ERPCMISMATCH
     ),
     e!(cfg(target_vendor = "apple"), ESHLIBVERS),
+    e!(
+        cfg(all(
+            unix,
+            any(target_os = "linux", target_os = "fuchsia"),
+            not(any(
+                target_os = "freebsd",
+                target_os = "android",
+                target_vendor = "apple",
+            ))
+        )),
+        EHWPOISON
+    ),
 ];
 
 #[cfg(not(any(unix, windows, target_os = "wasi")))]


### PR DESCRIPTION
<!--
Thanks for your contribution!
-->

- [ ] Closes #xxxx <!-- Replace xxxx with the GitHub issue number -->
- [ ] This PR follows our [AI policy](https://github.com/RustPython/.github/blob/main/AI_POLICY.md)

## Summary
<!-- What's the purpose of the change? What does it do, and why? -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Added support for hardware poison error (EHWPOISON) recognition and reporting on select Unix-based systems, including Linux and Fuchsia.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/RustPython/RustPython/pull/7996?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->