### PR TITLE
Add `PyDictProxy_New` to the c-api

### DIFF
--- a/crates/capi/src/descrobject.rs
+++ b/crates/capi/src/descrobject.rs
@@ -1,0 +1,31 @@
+use crate::PyObject;
+use crate::pystate::with_vm;
+use rustpython_vm::PyPayload;
+use rustpython_vm::builtins::PyMappingProxy;
+
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn PyDictProxy_New(mapping: *mut PyObject) -> *mut PyObject {
+    with_vm(|vm| {
+        let mapping = unsafe { &*mapping }.to_owned();
+        Ok(PyMappingProxy::from_object(mapping, vm)?.into_ref(&vm.ctx))
+    })
+}
+
+#[cfg(false)]
+mod tests {
+    use pyo3::prelude::*;
+    use pyo3::types::{PyDict, PyInt, PyMappingProxy};
+
+    #[test]
+    fn proxy_reads_items() {
+        Python::attach(|py| {
+            let dict = PyDict::new(py);
+            dict.set_item("x", 7).unwrap();
+
+            let mapping = dict.as_mapping();
+            let proxy = PyMappingProxy::new(py, &mapping);
+            let value = proxy.get_item("x").unwrap().cast_into::<PyInt>().unwrap();
+            assert_eq!(value, 7);
+        })
+    }
+}

--- a/crates/capi/src/lib.rs
+++ b/crates/capi/src/lib.rs
@@ -14,6 +14,7 @@ pub mod bytearrayobject;
 pub mod bytesobject;
 pub mod ceval;
 pub mod complexobject;
+pub mod descrobject;
 pub mod dictobject;
 pub mod floatobject;
 pub mod import;

--- a/crates/vm/src/builtins/mappingproxy.rs
+++ b/crates/vm/src/builtins/mappingproxy.rs
@@ -63,18 +63,7 @@ impl Constructor for PyMappingProxy {
     type Args = PyObjectRef;
 
     fn py_new(_cls: &Py<PyType>, mapping: Self::Args, vm: &VirtualMachine) -> PyResult<Self> {
-        if mapping.mapping_unchecked().check()
-            && !mapping.downcastable::<PyList>()
-            && !mapping.downcastable::<PyTuple>()
-        {
-            return Ok(Self {
-                mapping: MappingProxyInner::Mapping(ArgMapping::new(mapping)),
-            });
-        }
-        Err(vm.new_type_error(format!(
-            "mappingproxy() argument must be a mapping, not {}",
-            mapping.class()
-        )))
+        Self::from_object(mapping, vm)
     }
 }
 
@@ -89,6 +78,21 @@ impl Constructor for PyMappingProxy {
     Representable
 ))]
 impl PyMappingProxy {
+    pub fn from_object(mapping: PyObjectRef, vm: &VirtualMachine) -> PyResult<Self> {
+        if mapping.mapping_unchecked().check()
+            && !mapping.downcastable::<PyList>()
+            && !mapping.downcastable::<PyTuple>()
+        {
+            return Ok(Self {
+                mapping: MappingProxyInner::Mapping(ArgMapping::new(mapping)),
+            });
+        }
+        Err(vm.new_type_error(format!(
+            "mappingproxy() argument must be a mapping, not {}",
+            mapping.class()
+        )))
+    }
+
     fn get_inner(&self, key: PyObjectRef, vm: &VirtualMachine) -> PyResult<Option<PyObjectRef>> {
         match &self.mapping {
             MappingProxyInner::Class(class) => Ok(key


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * C-API support to create mapping proxy objects, allowing C extensions to construct read-only mapping views of dictionaries.

* **Refactor**
  * Reorganized mapping proxy construction for clearer validation and consistent behavior, improving reliability when creating proxy objects from arbitrary mappings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->