### PR TITLE
Dedent -c code argument

### DIFF
--- a/Lib/test/test_cmd_line.py
+++ b/Lib/test/test_cmd_line.py
@@ -1108,7 +1108,6 @@ class CmdLineTest(unittest.TestCase):
         )
         self.assertEqual(res2int(res), (6000, 6000))
 
-    @unittest.expectedFailure  # TODO: RUSTPYTHON
     def test_cmd_dedent(self):
         # test that -c auto-dedents its arguments
         test_cases = [

--- a/Lib/test/test_os.py
+++ b/Lib/test/test_os.py
@@ -2419,7 +2419,7 @@ class ExecTests(unittest.TestCase):
 
     # See https://github.com/python/cpython/issues/137934 and the other
     # related issues for the reason why we cannot test this on Windows.
-    @unittest.expectedFailure  # TODO: RUSTPYTHON; IndentationError: unexpected indentation
+    @unittest.expectedFailure  # TODO: RUSTPYTHON; TypeError: MyEnv.__getitem__() takes 1 positional argument but 2 were given
     @unittest.skipIf(os.name == "nt", "POSIX-specific test")
     @unittest.skipUnless(unix_shell and os.path.exists(unix_shell),
                         "requires a shell")

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -122,7 +122,11 @@ fn parse_args() -> Result<(CliArgs, RunMode, Vec<String>), lexopt::Error> {
             Short('B') => args.dont_write_bytecode = true,
             Short('c') => {
                 let cmd = parser.value()?.string()?;
-                return Ok((args, RunMode::Command(dedent(&cmd)), argv("-c".to_owned(), parser)?));
+                return Ok((
+                    args,
+                    RunMode::Command(dedent(&cmd)),
+                    argv("-c".to_owned(), parser)?,
+                ));
             }
             Short('d') => args.debug += 1,
             Short('E') => args.ignore_environment = true,

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -122,7 +122,7 @@ fn parse_args() -> Result<(CliArgs, RunMode, Vec<String>), lexopt::Error> {
             Short('B') => args.dont_write_bytecode = true,
             Short('c') => {
                 let cmd = parser.value()?.string()?;
-                return Ok((args, RunMode::Command(cmd), argv("-c".to_owned(), parser)?));
+                return Ok((args, RunMode::Command(dedent(&cmd)), argv("-c".to_owned(), parser)?));
             }
             Short('d') => args.debug += 1,
             Short('E') => args.ignore_environment = true,
@@ -464,4 +464,62 @@ pub(crate) fn split_paths<T: AsRef<std::ffi::OsStr> + ?Sized>(
             .to_owned()
             .into()
     })
+}
+
+///like textwrap.dedent; for processing -c argument
+fn dedent(input: &str) -> String {
+    let mut prefix: Option<String> = None;
+    let isspace = |c| c == ' ' || c == '\t';
+
+    //all-whitespace lines become empty
+    let deblanked: Vec<&str> = input
+        .lines()
+        .map(|line| if line.chars().all(isspace) { "" } else { line })
+        .collect();
+
+    //find maximum common whitespace prefix, if any
+    for line in deblanked.iter() {
+        if line.is_empty() {
+            continue;
+        }
+        if let Some(ref mut pstr) = prefix {
+            for (i, (c, pc)) in line.chars().zip(pstr.chars()).enumerate() {
+                if c != pc {
+                    pstr.truncate(i);
+                    break;
+                }
+            }
+        } else {
+            let mut pstr = String::new();
+            for c in line.chars() {
+                if isspace(c) {
+                    pstr.push(c);
+                } else {
+                    break;
+                }
+            }
+            prefix = Some(pstr);
+            continue;
+        }
+    }
+
+    if let Some(pstr) = prefix {
+        //strip prefix
+        deblanked
+            .iter()
+            .map(|line| {
+                if line.is_empty() {
+                    String::from("")
+                } else {
+                    //all non-empty lines start with pstr, must be at
+                    // least pstr.len() long
+                    String::from(line.get(pstr.len()..).unwrap())
+                }
+            })
+            .collect::<Vec<_>>()
+            .join("\n")
+    } else {
+        //no prefix: all lines blank
+        deblanked.join("\n")
+    }
 }

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -470,24 +470,33 @@ pub(crate) fn split_paths<T: AsRef<std::ffi::OsStr> + ?Sized>(
     })
 }
 
-///like textwrap.dedent; for processing -c argument
+/// Remove common whitespace prefix from all lines in a string.
+///
+/// This is like textwrap.dedent, and is used to process -c's code
+/// argument.  It's different from ruff's dedent, which does not
+/// distinguish between tab and space characters when dedenting.
 fn dedent(input: &str) -> String {
     let mut prefix: Option<String> = None;
     let isspace = |c| c == ' ' || c == '\t';
 
-    //all-whitespace lines become empty
+    // All-whitespace lines become empty.
     let deblanked: Vec<&str> = input
         .lines()
         .map(|line| if line.chars().all(isspace) { "" } else { line })
         .collect();
 
-    //find maximum common whitespace prefix, if any
+    // Find maximum common whitespace prefix, if any.
     for line in deblanked.iter() {
         if line.is_empty() {
             continue;
         }
         if let Some(ref mut pstr) = prefix {
             for (i, (c, pc)) in line.chars().zip(pstr.chars()).enumerate() {
+                // It's okay if `line` is shorter than `pstr`.  At
+                // least one char in `line` must be non-whitespace,
+                // and if `line` is shorter than `pstr`, this
+                // non-whitespace char will be compared to a
+                // whitespace char, and loop will terminate.
                 if c != pc {
                     pstr.truncate(i);
                     break;
@@ -508,22 +517,22 @@ fn dedent(input: &str) -> String {
     }
 
     if let Some(pstr) = prefix {
-        //strip prefix
+        // Strip common prefix.
         deblanked
             .iter()
             .map(|line| {
                 if line.is_empty() {
                     String::from("")
                 } else {
-                    //all non-empty lines start with pstr, must be at
-                    // least pstr.len() long
+                    // All non-empty lines start with pstr, must be at
+                    // least pstr.len() long.
                     String::from(line.get(pstr.len()..).unwrap())
                 }
             })
             .collect::<Vec<_>>()
             .join("\n")
     } else {
-        //no prefix: all lines blank
+        // No prefix found: all lines blank.
         deblanked.join("\n")
     }
 }


### PR DESCRIPTION
- [x] Closes #8055
- [x] This PR follows our [AI policy](https://github.com/RustPython/.github/blob/main/AI_POLICY.md)

I haven't used AI at all for this.  (I'm not sure if an "anti-disclaimer" is needed...)

## Summary

  - dedents -c code argument
  - removes expectedFailure marker from test.test_cmd_line.CmdLineTest.test_cmd_dedent
  - updated expectedFailure comment for test.test_os.ExecTests.test_execve_env_concurrent_mutation_with_fspath_posix, which used to fail with `IndentationError`, but now fails with a `TypeError`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved `-c` command-line argument handling by automatically stripping common leading indentation from multi-line commands, ensuring consistently normalized execution when commands are formatted with extra whitespace.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->