### PR TITLE
Add `_heapq` module

### DIFF
--- a/crates/stdlib/src/_heapq.rs
+++ b/crates/stdlib/src/_heapq.rs
@@ -331,6 +331,7 @@ mod _heapq {
         heapify_internal(&lst, siftup, vm)
     }
 
+    /// [CPython's siftdown_max](https://github.com/python/cpython/blob/v3.14.5/Modules/_heapqmodule.c#L407-L449)
     fn siftdown_max(
         heap: &PyListRef,
         startpos: usize,
@@ -374,6 +375,7 @@ mod _heapq {
         Ok(())
     }
 
+    /// [CPython's siftup_max](https://github.com/python/cpython/blob/v3.14.5/Modules/_heapqmodule.c#L451-L499)
     fn siftup_max(heap: &PyListRef, mut pos: usize, vm: &VirtualMachine) -> PyResult<()> {
         let endpos = heap.__len__();
         let startpos = pos;

--- a/crates/stdlib/src/_heapq.rs
+++ b/crates/stdlib/src/_heapq.rs
@@ -114,7 +114,7 @@ mod _heapq {
 
         let size = heap.__len__();
 
-        siftdown_func(&heap, 0, size - 1, vm)
+        siftdown_func(heap, 0, size - 1, vm)
     }
 
     #[pyfunction]
@@ -152,7 +152,7 @@ mod _heapq {
             root
         };
 
-        siftup_func(&heap, 0, vm)?;
+        siftup_func(heap, 0, vm)?;
         Ok(returnitem)
     }
 
@@ -188,7 +188,7 @@ mod _heapq {
             root
         };
 
-        siftup_func(&heap, 0, vm)?;
+        siftup_func(heap, 0, vm)?;
         Ok(returnitem)
     }
 

--- a/crates/stdlib/src/_heapq.rs
+++ b/crates/stdlib/src/_heapq.rs
@@ -22,6 +22,8 @@ mod _heapq {
             None => return Err(vm.new_index_error("index out of range")),
         };
 
+        // Follow the path to the root, moving parents down until finding
+        // a place newitem fits.
         while pos > startpos {
             let parentpos = (pos - 1) >> 1;
             let parent = {
@@ -30,6 +32,49 @@ mod _heapq {
             };
 
             let cmp = newitem.rich_compare_bool(&parent, PyComparisonOp::Lt, vm)?;
+
+            if size != heap.__len__() {
+                return Err(vm.new_runtime_error("list changed size during iteration"));
+            }
+
+            if !cmp {
+                break;
+            }
+
+            {
+                let mut vec = heap.borrow_vec_mut();
+                vec.swap(pos, parentpos);
+            }
+
+            pos = parentpos;
+        }
+
+        Ok(())
+    }
+
+    fn siftdown_max(
+        heap: &PyListRef,
+        startpos: usize,
+        mut pos: usize,
+        vm: &VirtualMachine,
+    ) -> PyResult<()> {
+        let size = heap.__len__();
+
+        let newitem = match heap.borrow_vec().get(pos) {
+            Some(v) => v.clone(),
+            None => return Err(vm.new_index_error("index out of range")),
+        };
+
+        // Follow the path to the root, moving parents down until finding
+        // a place newitem fits.
+        while pos > startpos {
+            let parentpos = (pos - 1) >> 1;
+            let parent = {
+                let vec = heap.borrow_vec();
+                vec[parentpos].clone()
+            };
+
+            let cmp = parent.rich_compare_bool(&newitem, PyComparisonOp::Lt, vm)?;
 
             if size != heap.__len__() {
                 return Err(vm.new_runtime_error("list changed size during iteration"));
@@ -60,17 +105,18 @@ mod _heapq {
 
         let limit = endpos >> 1; // smallest pos that has no child
 
+        // Bubble up the smaller child until hitting a leaf.
         while pos < limit {
             // Set childpos to index of smaller child.
             let mut childpos = 2 * pos + 1; // leftmost child position
 
             if childpos + 1 < endpos {
-                let (left, right) = {
+                let (a, b) = {
                     let vec = heap.borrow_vec();
                     (vec[childpos].clone(), vec[childpos + 1].clone())
                 };
 
-                let cmp = left.rich_compare_bool(&right, PyComparisonOp::Lt, vm)?;
+                let cmp = a.rich_compare_bool(&b, PyComparisonOp::Lt, vm)?;
 
                 if endpos != heap.__len__() {
                     return Err(vm.new_runtime_error("list changed size during iteration"));
@@ -92,6 +138,51 @@ mod _heapq {
 
         // Bubble it up to its final resting place (by sifting its parents down)
         siftdown(heap, startpos, pos, vm)
+    }
+
+    fn siftup_max(heap: &PyListRef, mut pos: usize, vm: &VirtualMachine) -> PyResult<()> {
+        let endpos = heap.__len__();
+        let startpos = pos;
+
+        if pos >= endpos {
+            return Err(vm.new_index_error("index out of range"));
+        };
+
+        let limit = endpos >> 1; // smallest pos that has no child
+
+        // Bubble up the larger child until hitting a leaf.
+        while pos < limit {
+            // Set childpos to index of larger child.
+            let mut childpos = 2 * pos + 1; // leftmost child position
+
+            if childpos + 1 < endpos {
+                let (a, b) = {
+                    let vec = heap.borrow_vec();
+                    (vec[childpos + 1].clone(), vec[childpos].clone())
+                };
+
+                let cmp = a.rich_compare_bool(&b, PyComparisonOp::Lt, vm)?;
+
+                if endpos != heap.__len__() {
+                    return Err(vm.new_runtime_error("list changed size during iteration"));
+                }
+
+                if !cmp {
+                    childpos += 1;
+                }
+            }
+
+            {
+                // Move the larger child up
+                let mut vec = heap.borrow_vec_mut();
+                vec.swap(pos, childpos);
+            }
+
+            pos = childpos;
+        }
+
+        // Bubble it up to its final resting place (by sifting its parents down)
+        siftdown_max(heap, startpos, pos, vm)
     }
 
     const fn keep_top_bit(mut n: usize) -> usize {
@@ -216,6 +307,25 @@ mod _heapq {
         Ok(returnitem)
     }
 
+    fn heappush_internal<F>(
+        heap: &PyListRef,
+        item: PyObjectRef,
+        siftdown_func: F,
+        vm: &VirtualMachine,
+    ) -> PyResult<()>
+    where
+        F: Fn(&PyListRef, usize, usize, &VirtualMachine) -> PyResult<()>,
+    {
+        {
+            let mut vec = heap.borrow_vec_mut();
+            vec.push(item);
+        }
+
+        let size = heap.__len__();
+
+        siftdown_func(&heap, 0, size - 1, vm)
+    }
+
     #[pyfunction]
     fn heappush(heap: PyObjectRef, item: PyObjectRef, vm: &VirtualMachine) -> PyResult<()> {
         let lst = heap.downcast::<PyList>().map_err(|obj| {
@@ -225,14 +335,19 @@ mod _heapq {
             ))
         })?;
 
-        {
-            let mut vec = lst.borrow_vec_mut();
-            vec.push(item);
-        }
+        heappush_internal(&lst, item, siftdown, vm)
+    }
 
-        let size = lst.__len__();
+    #[pyfunction]
+    fn heappush_max(heap: PyObjectRef, item: PyObjectRef, vm: &VirtualMachine) -> PyResult<()> {
+        let lst = heap.downcast::<PyList>().map_err(|obj| {
+            vm.new_type_error(format!(
+                "heappush_max() argument 1 must be list, not {}",
+                obj.class().name()
+            ))
+        })?;
 
-        siftdown(&lst, 0, size - 1, vm)
+        heappush_internal(&lst, item, siftdown_max, vm)
     }
 
     #[pyfunction]
@@ -248,6 +363,18 @@ mod _heapq {
     }
 
     #[pyfunction]
+    fn heappop_max(heap: PyObjectRef, vm: &VirtualMachine) -> PyResult<PyObjectRef> {
+        let lst = heap.downcast::<PyList>().map_err(|obj| {
+            vm.new_type_error(format!(
+                "heappop_max() argument 1 must be list, not {}",
+                obj.class().name()
+            ))
+        })?;
+
+        heappop_internal(&lst, siftup_max, vm)
+    }
+
+    #[pyfunction]
     fn heapify(heap: PyObjectRef, vm: &VirtualMachine) -> PyResult<()> {
         let lst = heap.downcast::<PyList>().map_err(|obj| {
             vm.new_type_error(format!(
@@ -257,6 +384,18 @@ mod _heapq {
         })?;
 
         heapify_internal(&lst, siftup, vm)
+    }
+
+    #[pyfunction]
+    fn heapify_max(heap: PyObjectRef, vm: &VirtualMachine) -> PyResult<()> {
+        let lst = heap.downcast::<PyList>().map_err(|obj| {
+            vm.new_type_error(format!(
+                "heapify_max() argument 1 must be list, not {}",
+                obj.class().name()
+            ))
+        })?;
+
+        heapify_internal(&lst, siftup_max, vm)
     }
 
     #[pyfunction]
@@ -301,6 +440,47 @@ mod _heapq {
     }
 
     #[pyfunction]
+    fn heappushpop_max(
+        heap: PyObjectRef,
+        item: PyObjectRef,
+        vm: &VirtualMachine,
+    ) -> PyResult<PyObjectRef> {
+        let lst = heap.downcast::<PyList>().map_err(|obj| {
+            vm.new_type_error(format!(
+                "heappushpop_max() argument 1 must be list, not {}",
+                obj.class().name()
+            ))
+        })?;
+
+        let top = {
+            let vec = lst.borrow_vec();
+            match vec.first() {
+                Some(v) => v.clone(),
+                None => return Ok(item),
+            }
+        };
+
+        let cmp = item.rich_compare_bool(&top, PyComparisonOp::Lt, vm)?;
+        if !cmp {
+            return Ok(item);
+        }
+
+        let returnitem = {
+            let mut vec = lst.borrow_vec_mut();
+            let root = match vec.first() {
+                Some(v) => v.clone(),
+                None => return Err(vm.new_index_error("index out of range")),
+            };
+
+            vec[0] = item;
+            root
+        };
+
+        siftup_max(&lst, 0, vm)?;
+        Ok(returnitem)
+    }
+
+    #[pyfunction]
     fn heapreplace(
         heap: PyObjectRef,
         item: PyObjectRef,
@@ -314,5 +494,21 @@ mod _heapq {
         })?;
 
         heapreplace_internal(&lst, item, siftup, vm)
+    }
+
+    #[pyfunction]
+    fn heapreplace_max(
+        heap: PyObjectRef,
+        item: PyObjectRef,
+        vm: &VirtualMachine,
+    ) -> PyResult<PyObjectRef> {
+        let lst = heap.downcast::<PyList>().map_err(|obj| {
+            vm.new_type_error(format!(
+                "heapreplace_max() argument 1 must be list, not {}",
+                obj.class().name()
+            ))
+        })?;
+
+        heapreplace_internal(&lst, item, siftup_max, vm)
     }
 }

--- a/crates/stdlib/src/_heapq.rs
+++ b/crates/stdlib/src/_heapq.rs
@@ -1,3 +1,4 @@
+// cspell:ignore siftup siftdown
 pub(crate) use _heapq::module_def;
 
 #[pymodule]

--- a/crates/stdlib/src/_heapq.rs
+++ b/crates/stdlib/src/_heapq.rs
@@ -10,6 +10,7 @@ mod _heapq {
         types::PyComparisonOp,
     };
 
+    /// [CPython's siftdown](https://github.com/python/cpython/blob/v3.14.5/Modules/_heapqmodule.c#L25-L68)
     fn siftdown(
         heap: &PyListRef,
         startpos: usize,
@@ -53,6 +54,7 @@ mod _heapq {
         Ok(())
     }
 
+    /// [CPython's siftup](https://github.com/python/cpython/blob/v3.14.5/Modules/_heapqmodule.c#L70-L118)
     fn siftup(heap: &PyListRef, mut pos: usize, vm: &VirtualMachine) -> PyResult<()> {
         let endpos = heap.__len__();
         let startpos = pos;
@@ -98,6 +100,11 @@ mod _heapq {
         siftdown(heap, startpos, pos, vm)
     }
 
+    /// configurable `sift_func` for doing heappush operation.
+    ///
+    /// A generic implementation of:
+    /// - [CPython's _heapq_heappush_impl](https://github.com/python/cpython/blob/v3.14.5/Modules/_heapqmodule.c#L131-L150)
+    /// - [CPython's _heapq_heappush_max_impl](https://github.com/python/cpython/blob/v3.14.5/Modules/_heapqmodule.c#L512-L532)
     fn heappush_internal<F>(
         heap: &PyListRef,
         item: PyObjectRef,
@@ -129,6 +136,7 @@ mod _heapq {
         heappush_internal(&lst, item, siftdown, vm)
     }
 
+    /// [CPython's heappop_internal](https://github.com/python/cpython/blob/v3.14.5/Modules/_heapqmodule.c#L152-L183)
     fn heappop_internal<F>(
         heap: &PyListRef,
         siftup_func: F,
@@ -168,6 +176,7 @@ mod _heapq {
         heappop_internal(&lst, siftup, vm)
     }
 
+    /// [CPython's heapreplace_internal](https://github.com/python/cpython/blob/v3.14.5/Modules/_heapqmodule.c#L202-L220)
     fn heapreplace_internal<F>(
         heap: &PyListRef,
         item: PyObjectRef,
@@ -249,6 +258,7 @@ mod _heapq {
         Ok(returnitem)
     }
 
+    /// [CPython's keep_top_bit](https://github.com/python/cpython/blob/v3.14.5/Modules/_heapqmodule.c#L299-L309)
     const fn keep_top_bit(mut n: usize) -> usize {
         let mut i = 0;
 
@@ -260,6 +270,7 @@ mod _heapq {
         n << i
     }
 
+    /// [CPython's cache_friendly_heapify](https://github.com/python/cpython/blob/v3.14.5/Modules/_heapqmodule.c#L311-L362)
     fn cache_friendly_heapify<F>(
         heap: &PyListRef,
         siftup_func: F,
@@ -303,6 +314,7 @@ mod _heapq {
         Ok(())
     }
 
+    /// [CPython's heapify_internal](https://github.com/python/cpython/blob/v3.14.5/Modules/_heapqmodule.c#L364-L388)
     fn heapify_internal<F>(heap: &PyListRef, siftup_func: F, vm: &VirtualMachine) -> PyResult<()>
     where
         F: Fn(&PyListRef, usize, &VirtualMachine) -> PyResult<()>,

--- a/crates/stdlib/src/_heapq.rs
+++ b/crates/stdlib/src/_heapq.rs
@@ -52,49 +52,6 @@ mod _heapq {
         Ok(())
     }
 
-    fn siftdown_max(
-        heap: &PyListRef,
-        startpos: usize,
-        mut pos: usize,
-        vm: &VirtualMachine,
-    ) -> PyResult<()> {
-        let size = heap.__len__();
-
-        let newitem = match heap.borrow_vec().get(pos) {
-            Some(v) => v.clone(),
-            None => return Err(vm.new_index_error("index out of range")),
-        };
-
-        // Follow the path to the root, moving parents down until finding
-        // a place newitem fits.
-        while pos > startpos {
-            let parentpos = (pos - 1) >> 1;
-            let parent = {
-                let vec = heap.borrow_vec();
-                vec[parentpos].clone()
-            };
-
-            let cmp = parent.rich_compare_bool(&newitem, PyComparisonOp::Lt, vm)?;
-
-            if size != heap.__len__() {
-                return Err(vm.new_runtime_error("list changed size during iteration"));
-            }
-
-            if !cmp {
-                break;
-            }
-
-            {
-                let mut vec = heap.borrow_vec_mut();
-                vec.swap(pos, parentpos);
-            }
-
-            pos = parentpos;
-        }
-
-        Ok(())
-    }
-
     fn siftup(heap: &PyListRef, mut pos: usize, vm: &VirtualMachine) -> PyResult<()> {
         let endpos = heap.__len__();
         let startpos = pos;
@@ -140,49 +97,155 @@ mod _heapq {
         siftdown(heap, startpos, pos, vm)
     }
 
-    fn siftup_max(heap: &PyListRef, mut pos: usize, vm: &VirtualMachine) -> PyResult<()> {
-        let endpos = heap.__len__();
-        let startpos = pos;
+    fn heappush_internal<F>(
+        heap: &PyListRef,
+        item: PyObjectRef,
+        siftdown_func: F,
+        vm: &VirtualMachine,
+    ) -> PyResult<()>
+    where
+        F: Fn(&PyListRef, usize, usize, &VirtualMachine) -> PyResult<()>,
+    {
+        {
+            let mut vec = heap.borrow_vec_mut();
+            vec.push(item);
+        }
 
-        if pos >= endpos {
+        let size = heap.__len__();
+
+        siftdown_func(&heap, 0, size - 1, vm)
+    }
+
+    #[pyfunction]
+    fn heappush(heap: PyObjectRef, item: PyObjectRef, vm: &VirtualMachine) -> PyResult<()> {
+        let lst = heap.downcast::<PyList>().map_err(|obj| {
+            vm.new_type_error(format!(
+                "heappush() argument 1 must be list, not {}",
+                obj.class().name()
+            ))
+        })?;
+
+        heappush_internal(&lst, item, siftdown, vm)
+    }
+
+    fn heappop_internal<F>(
+        heap: &PyListRef,
+        siftup_func: F,
+        vm: &VirtualMachine,
+    ) -> PyResult<PyObjectRef>
+    where
+        F: Fn(&PyListRef, usize, &VirtualMachine) -> PyResult<()>,
+    {
+        let Some(lastelt) = heap.borrow_vec_mut().pop() else {
             return Err(vm.new_index_error("index out of range"));
         };
 
-        let limit = endpos >> 1; // smallest pos that has no child
+        if heap.borrow_vec().is_empty() {
+            return Ok(lastelt);
+        };
 
-        // Bubble up the larger child until hitting a leaf.
-        while pos < limit {
-            // Set childpos to index of larger child.
-            let mut childpos = 2 * pos + 1; // leftmost child position
+        let returnitem = {
+            let mut vec = heap.borrow_vec_mut();
+            let root = vec[0].clone();
+            vec[0] = lastelt;
+            root
+        };
 
-            if childpos + 1 < endpos {
-                let (a, b) = {
-                    let vec = heap.borrow_vec();
-                    (vec[childpos + 1].clone(), vec[childpos].clone())
-                };
+        siftup_func(&heap, 0, vm)?;
+        Ok(returnitem)
+    }
 
-                let cmp = a.rich_compare_bool(&b, PyComparisonOp::Lt, vm)?;
+    #[pyfunction]
+    fn heappop(heap: PyObjectRef, vm: &VirtualMachine) -> PyResult<PyObjectRef> {
+        let lst = heap.downcast::<PyList>().map_err(|obj| {
+            vm.new_type_error(format!(
+                "heappop() argument 1 must be list, not {}",
+                obj.class().name()
+            ))
+        })?;
 
-                if endpos != heap.__len__() {
-                    return Err(vm.new_runtime_error("list changed size during iteration"));
-                }
+        heappop_internal(&lst, siftup, vm)
+    }
 
-                if !cmp {
-                    childpos += 1;
-                }
+    fn heapreplace_internal<F>(
+        heap: &PyListRef,
+        item: PyObjectRef,
+        siftup_func: F,
+        vm: &VirtualMachine,
+    ) -> PyResult<PyObjectRef>
+    where
+        F: Fn(&PyListRef, usize, &VirtualMachine) -> PyResult<()>,
+    {
+        let returnitem = {
+            let mut vec = heap.borrow_vec_mut();
+            let root = match vec.first() {
+                Some(v) => v.clone(),
+                None => return Err(vm.new_index_error("index out of range")),
+            };
+
+            vec[0] = item;
+            root
+        };
+
+        siftup_func(&heap, 0, vm)?;
+        Ok(returnitem)
+    }
+
+    #[pyfunction]
+    fn heapreplace(
+        heap: PyObjectRef,
+        item: PyObjectRef,
+        vm: &VirtualMachine,
+    ) -> PyResult<PyObjectRef> {
+        let lst = heap.downcast::<PyList>().map_err(|obj| {
+            vm.new_type_error(format!(
+                "heapreplace() argument 1 must be list, not {}",
+                obj.class().name()
+            ))
+        })?;
+
+        heapreplace_internal(&lst, item, siftup, vm)
+    }
+
+    #[pyfunction]
+    fn heappushpop(
+        heap: PyObjectRef,
+        item: PyObjectRef,
+        vm: &VirtualMachine,
+    ) -> PyResult<PyObjectRef> {
+        let lst = heap.downcast::<PyList>().map_err(|obj| {
+            vm.new_type_error(format!(
+                "heappushpop() argument 1 must be list, not {}",
+                obj.class().name()
+            ))
+        })?;
+
+        let top = {
+            let vec = lst.borrow_vec();
+            match vec.first() {
+                Some(v) => v.clone(),
+                None => return Ok(item),
             }
+        };
 
-            {
-                // Move the larger child up
-                let mut vec = heap.borrow_vec_mut();
-                vec.swap(pos, childpos);
-            }
-
-            pos = childpos;
+        let cmp = top.rich_compare_bool(&item, PyComparisonOp::Lt, vm)?;
+        if !cmp {
+            return Ok(item);
         }
 
-        // Bubble it up to its final resting place (by sifting its parents down)
-        siftdown_max(heap, startpos, pos, vm)
+        let returnitem = {
+            let mut vec = lst.borrow_vec_mut();
+            let root = match vec.first() {
+                Some(v) => v.clone(),
+                None => return Err(vm.new_index_error("index out of range")),
+            };
+
+            vec[0] = item;
+            root
+        };
+
+        siftup(&lst, 0, vm)?;
+        Ok(returnitem)
     }
 
     const fn keep_top_bit(mut n: usize) -> usize {
@@ -256,86 +319,104 @@ mod _heapq {
         Ok(())
     }
 
-    fn heappop_internal<F>(
-        heap: &PyListRef,
-        siftup_func: F,
-        vm: &VirtualMachine,
-    ) -> PyResult<PyObjectRef>
-    where
-        F: Fn(&PyListRef, usize, &VirtualMachine) -> PyResult<()>,
-    {
-        let Some(lastelt) = heap.borrow_vec_mut().pop() else {
-            return Err(vm.new_index_error("index out of range"));
-        };
-
-        if heap.borrow_vec().is_empty() {
-            return Ok(lastelt);
-        };
-
-        let returnitem = {
-            let mut vec = heap.borrow_vec_mut();
-            let root = vec[0].clone();
-            vec[0] = lastelt;
-            root
-        };
-
-        siftup_func(&heap, 0, vm)?;
-        Ok(returnitem)
-    }
-
-    fn heapreplace_internal<F>(
-        heap: &PyListRef,
-        item: PyObjectRef,
-        siftup_func: F,
-        vm: &VirtualMachine,
-    ) -> PyResult<PyObjectRef>
-    where
-        F: Fn(&PyListRef, usize, &VirtualMachine) -> PyResult<()>,
-    {
-        let returnitem = {
-            let mut vec = heap.borrow_vec_mut();
-            let root = match vec.first() {
-                Some(v) => v.clone(),
-                None => return Err(vm.new_index_error("index out of range")),
-            };
-
-            vec[0] = item;
-            root
-        };
-
-        siftup_func(&heap, 0, vm)?;
-        Ok(returnitem)
-    }
-
-    fn heappush_internal<F>(
-        heap: &PyListRef,
-        item: PyObjectRef,
-        siftdown_func: F,
-        vm: &VirtualMachine,
-    ) -> PyResult<()>
-    where
-        F: Fn(&PyListRef, usize, usize, &VirtualMachine) -> PyResult<()>,
-    {
-        {
-            let mut vec = heap.borrow_vec_mut();
-            vec.push(item);
-        }
-
-        let size = heap.__len__();
-
-        siftdown_func(&heap, 0, size - 1, vm)
-    }
-
     #[pyfunction]
-    fn heappush(heap: PyObjectRef, item: PyObjectRef, vm: &VirtualMachine) -> PyResult<()> {
+    fn heapify(heap: PyObjectRef, vm: &VirtualMachine) -> PyResult<()> {
         let lst = heap.downcast::<PyList>().map_err(|obj| {
             vm.new_type_error(format!(
-                "heappush() argument 1 must be list, not {}",
+                "heapify() argument 1 must be list, not {}",
                 obj.class().name()
             ))
         })?;
 
-        heappush_internal(&lst, item, siftdown, vm)
+        heapify_internal(&lst, siftup, vm)
+    }
+
+    fn siftdown_max(
+        heap: &PyListRef,
+        startpos: usize,
+        mut pos: usize,
+        vm: &VirtualMachine,
+    ) -> PyResult<()> {
+        let size = heap.__len__();
+
+        let newitem = match heap.borrow_vec().get(pos) {
+            Some(v) => v.clone(),
+            None => return Err(vm.new_index_error("index out of range")),
+        };
+
+        // Follow the path to the root, moving parents down until finding
+        // a place newitem fits.
+        while pos > startpos {
+            let parentpos = (pos - 1) >> 1;
+            let parent = {
+                let vec = heap.borrow_vec();
+                vec[parentpos].clone()
+            };
+
+            let cmp = parent.rich_compare_bool(&newitem, PyComparisonOp::Lt, vm)?;
+
+            if size != heap.__len__() {
+                return Err(vm.new_runtime_error("list changed size during iteration"));
+            }
+
+            if !cmp {
+                break;
+            }
+
+            {
+                let mut vec = heap.borrow_vec_mut();
+                vec.swap(pos, parentpos);
+            }
+
+            pos = parentpos;
+        }
+
+        Ok(())
+    }
+
+    fn siftup_max(heap: &PyListRef, mut pos: usize, vm: &VirtualMachine) -> PyResult<()> {
+        let endpos = heap.__len__();
+        let startpos = pos;
+
+        if pos >= endpos {
+            return Err(vm.new_index_error("index out of range"));
+        };
+
+        let limit = endpos >> 1; // smallest pos that has no child
+
+        // Bubble up the larger child until hitting a leaf.
+        while pos < limit {
+            // Set childpos to index of larger child.
+            let mut childpos = 2 * pos + 1; // leftmost child position
+
+            if childpos + 1 < endpos {
+                let (a, b) = {
+                    let vec = heap.borrow_vec();
+                    (vec[childpos + 1].clone(), vec[childpos].clone())
+                };
+
+                let cmp = a.rich_compare_bool(&b, PyComparisonOp::Lt, vm)?;
+
+                if endpos != heap.__len__() {
+                    return Err(vm.new_runtime_error("list changed size during iteration"));
+                }
+
+                if !cmp {
+                    childpos += 1;
+                }
+            }
+
+            {
+                // Move the larger child up
+                let mut vec = heap.borrow_vec_mut();
+                vec.swap(pos, childpos);
+            }
+
+            pos = childpos;
+        }
+
+        // Bubble it up to its final resting place (by sifting its parents down)
+        siftdown_max(heap, startpos, pos, vm)
     }
 
     #[pyfunction]
@@ -351,18 +432,6 @@ mod _heapq {
     }
 
     #[pyfunction]
-    fn heappop(heap: PyObjectRef, vm: &VirtualMachine) -> PyResult<PyObjectRef> {
-        let lst = heap.downcast::<PyList>().map_err(|obj| {
-            vm.new_type_error(format!(
-                "heappop() argument 1 must be list, not {}",
-                obj.class().name()
-            ))
-        })?;
-
-        heappop_internal(&lst, siftup, vm)
-    }
-
-    #[pyfunction]
     fn heappop_max(heap: PyObjectRef, vm: &VirtualMachine) -> PyResult<PyObjectRef> {
         let lst = heap.downcast::<PyList>().map_err(|obj| {
             vm.new_type_error(format!(
@@ -375,15 +444,19 @@ mod _heapq {
     }
 
     #[pyfunction]
-    fn heapify(heap: PyObjectRef, vm: &VirtualMachine) -> PyResult<()> {
+    fn heapreplace_max(
+        heap: PyObjectRef,
+        item: PyObjectRef,
+        vm: &VirtualMachine,
+    ) -> PyResult<PyObjectRef> {
         let lst = heap.downcast::<PyList>().map_err(|obj| {
             vm.new_type_error(format!(
-                "heapify() argument 1 must be list, not {}",
+                "heapreplace_max() argument 1 must be list, not {}",
                 obj.class().name()
             ))
         })?;
 
-        heapify_internal(&lst, siftup, vm)
+        heapreplace_internal(&lst, item, siftup_max, vm)
     }
 
     #[pyfunction]
@@ -396,47 +469,6 @@ mod _heapq {
         })?;
 
         heapify_internal(&lst, siftup_max, vm)
-    }
-
-    #[pyfunction]
-    fn heappushpop(
-        heap: PyObjectRef,
-        item: PyObjectRef,
-        vm: &VirtualMachine,
-    ) -> PyResult<PyObjectRef> {
-        let lst = heap.downcast::<PyList>().map_err(|obj| {
-            vm.new_type_error(format!(
-                "heappushpop() argument 1 must be list, not {}",
-                obj.class().name()
-            ))
-        })?;
-
-        let top = {
-            let vec = lst.borrow_vec();
-            match vec.first() {
-                Some(v) => v.clone(),
-                None => return Ok(item),
-            }
-        };
-
-        let cmp = top.rich_compare_bool(&item, PyComparisonOp::Lt, vm)?;
-        if !cmp {
-            return Ok(item);
-        }
-
-        let returnitem = {
-            let mut vec = lst.borrow_vec_mut();
-            let root = match vec.first() {
-                Some(v) => v.clone(),
-                None => return Err(vm.new_index_error("index out of range")),
-            };
-
-            vec[0] = item;
-            root
-        };
-
-        siftup(&lst, 0, vm)?;
-        Ok(returnitem)
     }
 
     #[pyfunction]
@@ -478,37 +510,5 @@ mod _heapq {
 
         siftup_max(&lst, 0, vm)?;
         Ok(returnitem)
-    }
-
-    #[pyfunction]
-    fn heapreplace(
-        heap: PyObjectRef,
-        item: PyObjectRef,
-        vm: &VirtualMachine,
-    ) -> PyResult<PyObjectRef> {
-        let lst = heap.downcast::<PyList>().map_err(|obj| {
-            vm.new_type_error(format!(
-                "heapreplace() argument 1 must be list, not {}",
-                obj.class().name()
-            ))
-        })?;
-
-        heapreplace_internal(&lst, item, siftup, vm)
-    }
-
-    #[pyfunction]
-    fn heapreplace_max(
-        heap: PyObjectRef,
-        item: PyObjectRef,
-        vm: &VirtualMachine,
-    ) -> PyResult<PyObjectRef> {
-        let lst = heap.downcast::<PyList>().map_err(|obj| {
-            vm.new_type_error(format!(
-                "heapreplace_max() argument 1 must be list, not {}",
-                obj.class().name()
-            ))
-        })?;
-
-        heapreplace_internal(&lst, item, siftup_max, vm)
     }
 }

--- a/crates/stdlib/src/_heapq.rs
+++ b/crates/stdlib/src/_heapq.rs
@@ -1,4 +1,4 @@
-// cspell:ignore siftup siftdown
+// cspell:ignore siftup siftdown mhalf
 pub(crate) use _heapq::module_def;
 
 #[pymodule]

--- a/crates/stdlib/src/_heapq.rs
+++ b/crates/stdlib/src/_heapq.rs
@@ -1,0 +1,285 @@
+pub(crate) use _heapq::module_def;
+
+#[pymodule]
+mod _heapq {
+
+    use crate::vm::{
+        AsObject, PyObjectRef, PyResult, VirtualMachine,
+        builtins::{PyList, PyListRef},
+        types::PyComparisonOp,
+    };
+
+    fn siftdown(
+        heap: &PyListRef,
+        startpos: usize,
+        mut pos: usize,
+        vm: &VirtualMachine,
+    ) -> PyResult<()> {
+        let size = heap.__len__();
+
+        let newitem = match heap.borrow_vec().get(pos) {
+            Some(v) => v.clone(),
+            None => return Err(vm.new_index_error("index out of range")),
+        };
+
+        while pos > startpos {
+            let parentpos = (pos - 1) >> 1;
+            let parent = {
+                let vec = heap.borrow_vec();
+                vec[parentpos].clone()
+            };
+
+            let cmp = newitem.rich_compare_bool(&parent, PyComparisonOp::Lt, vm)?;
+
+            if size != heap.__len__() {
+                return Err(vm.new_runtime_error("list changed size during iteration"));
+            }
+
+            if !cmp {
+                break;
+            }
+
+            {
+                let mut vec = heap.borrow_vec_mut();
+                vec.swap(pos, parentpos);
+            }
+
+            pos = parentpos;
+        }
+
+        Ok(())
+    }
+
+    fn siftup(heap: &PyListRef, mut pos: usize, vm: &VirtualMachine) -> PyResult<()> {
+        let endpos = heap.__len__();
+        let startpos = pos;
+
+        if pos >= endpos {
+            return Err(vm.new_index_error("index out of range"));
+        };
+
+        let limit = endpos >> 1; // smallest pos that has no child
+
+        while pos < limit {
+            // Set childpos to index of smaller child.
+            let mut childpos = 2 * pos + 1; // leftmost child position
+
+            if childpos + 1 < endpos {
+                let (left, right) = {
+                    let vec = heap.borrow_vec();
+                    (vec[childpos].clone(), vec[childpos + 1].clone())
+                };
+
+                let cmp = left.rich_compare_bool(&right, PyComparisonOp::Lt, vm)?;
+
+                if endpos != heap.__len__() {
+                    return Err(vm.new_runtime_error("list changed size during iteration"));
+                }
+
+                if !cmp {
+                    childpos += 1;
+                }
+            }
+
+            {
+                // Move the smaller child up
+                let mut vec = heap.borrow_vec_mut();
+                vec.swap(pos, childpos);
+            }
+
+            pos = childpos;
+        }
+
+        // Bubble it up to its final resting place (by sifting its parents down)
+        siftdown(heap, startpos, pos, vm)
+    }
+
+    const fn keep_top_bit(mut n: usize) -> usize {
+        let mut i = 0;
+
+        while n > 1 {
+            n >>= 1;
+            i += 1;
+        }
+
+        n << i
+    }
+
+    fn cache_friendly_heapify(heap: &PyListRef, vm: &VirtualMachine) -> PyResult<()> {
+        let m = heap.__len__() >> 1; // index of first childless node
+        let leftmost = keep_top_bit(m + 1) - 1; // leftmost node in row of m 
+        let mhalf = m >> 1; // parent of first childless node
+
+        for i in (mhalf..leftmost).rev() {
+            let mut j = i;
+
+            loop {
+                siftup(heap, j, vm)?;
+
+                if j & 1 == 0 {
+                    break;
+                }
+
+                j >>= 1;
+            }
+        }
+
+        for i in (leftmost..m).rev() {
+            let mut j = i;
+
+            loop {
+                siftup(heap, j, vm)?;
+
+                if j & 1 == 0 {
+                    break;
+                }
+
+                j >>= 1;
+            }
+        }
+
+        Ok(())
+    }
+
+    fn heapify_internal(heap: &PyListRef, vm: &VirtualMachine) -> PyResult<()> {
+        let n = heap.__len__();
+
+        if n > 2500 {
+            return cache_friendly_heapify(heap, vm);
+        }
+
+        for i in (0..(n >> 1)).rev() {
+            siftup(heap, i, vm)?;
+        }
+
+        Ok(())
+    }
+
+    #[pyfunction]
+    fn heappush(heap: PyObjectRef, item: PyObjectRef, vm: &VirtualMachine) -> PyResult<()> {
+        let lst = heap.downcast::<PyList>().map_err(|obj| {
+            vm.new_type_error(format!(
+                "heappush() argument 1 must be list, not {}",
+                obj.class().name()
+            ))
+        })?;
+
+        {
+            let mut vec = lst.borrow_vec_mut();
+            vec.push(item);
+        }
+
+        let size = lst.__len__();
+
+        siftdown(&lst, 0, size - 1, vm)
+    }
+
+    #[pyfunction]
+    fn heappop(heap: PyObjectRef, vm: &VirtualMachine) -> PyResult<PyObjectRef> {
+        let lst = heap.downcast::<PyList>().map_err(|obj| {
+            vm.new_type_error(format!(
+                "heappop() argument 1 must be list, not {}",
+                obj.class().name()
+            ))
+        })?;
+
+        let Some(lastelt) = lst.borrow_vec_mut().pop() else {
+            return Err(vm.new_index_error("index out of range"));
+        };
+
+        if lst.borrow_vec().is_empty() {
+            return Ok(lastelt);
+        };
+
+        let returnitem = {
+            let mut vec = lst.borrow_vec_mut();
+            let root = vec[0].clone();
+            vec[0] = lastelt;
+            root
+        };
+
+        siftup(&lst, 0, vm)?;
+        Ok(returnitem)
+    }
+
+    #[pyfunction]
+    fn heapify(heap: PyObjectRef, vm: &VirtualMachine) -> PyResult<()> {
+        let lst = heap.downcast::<PyList>().map_err(|obj| {
+            vm.new_type_error(format!(
+                "heapify() argument 1 must be list, not {}",
+                obj.class().name()
+            ))
+        })?;
+
+        heapify_internal(&lst, vm)
+    }
+
+    #[pyfunction]
+    fn heappushpop(
+        heap: PyObjectRef,
+        item: PyObjectRef,
+        vm: &VirtualMachine,
+    ) -> PyResult<PyObjectRef> {
+        let lst = heap.downcast::<PyList>().map_err(|obj| {
+            vm.new_type_error(format!(
+                "heappushpop() argument 1 must be list, not {}",
+                obj.class().name()
+            ))
+        })?;
+
+        let top = {
+            let vec = lst.borrow_vec();
+            match vec.first() {
+                Some(v) => v.clone(),
+                None => return Ok(item),
+            }
+        };
+
+        let cmp = top.rich_compare_bool(&item, PyComparisonOp::Lt, vm)?;
+        if !cmp {
+            return Ok(item);
+        }
+
+        let returnitem = {
+            let mut vec = lst.borrow_vec_mut();
+            let root = match vec.first() {
+                Some(v) => v.clone(),
+                None => return Err(vm.new_index_error("index out of range")),
+            };
+
+            vec[0] = item;
+            root
+        };
+
+        siftup(&lst, 0, vm)?;
+        Ok(returnitem)
+    }
+
+    #[pyfunction]
+    fn heapreplace(
+        heap: PyObjectRef,
+        item: PyObjectRef,
+        vm: &VirtualMachine,
+    ) -> PyResult<PyObjectRef> {
+        let lst = heap.downcast::<PyList>().map_err(|obj| {
+            vm.new_type_error(format!(
+                "heapreplace() argument 1 must be list, not {}",
+                obj.class().name()
+            ))
+        })?;
+
+        let returnitem = {
+            let mut vec = lst.borrow_vec_mut();
+            let root = match vec.first() {
+                Some(v) => v.clone(),
+                None => return Err(vm.new_index_error("index out of range")),
+            };
+
+            vec[0] = item;
+            root
+        };
+
+        siftup(&lst, 0, vm)?;
+        Ok(returnitem)
+    }
+}

--- a/crates/stdlib/src/_heapq.rs
+++ b/crates/stdlib/src/_heapq.rs
@@ -105,7 +105,14 @@ mod _heapq {
         n << i
     }
 
-    fn cache_friendly_heapify(heap: &PyListRef, vm: &VirtualMachine) -> PyResult<()> {
+    fn cache_friendly_heapify<F>(
+        heap: &PyListRef,
+        siftup_func: F,
+        vm: &VirtualMachine,
+    ) -> PyResult<()>
+    where
+        F: Fn(&PyListRef, usize, &VirtualMachine) -> PyResult<()>,
+    {
         let m = heap.__len__() >> 1; // index of first childless node
         let leftmost = keep_top_bit(m + 1) - 1; // leftmost node in row of m 
         let mhalf = m >> 1; // parent of first childless node
@@ -114,7 +121,7 @@ mod _heapq {
             let mut j = i;
 
             loop {
-                siftup(heap, j, vm)?;
+                siftup_func(heap, j, vm)?;
 
                 if j & 1 == 0 {
                     break;
@@ -128,7 +135,7 @@ mod _heapq {
             let mut j = i;
 
             loop {
-                siftup(heap, j, vm)?;
+                siftup_func(heap, j, vm)?;
 
                 if j & 1 == 0 {
                     break;
@@ -141,18 +148,72 @@ mod _heapq {
         Ok(())
     }
 
-    fn heapify_internal(heap: &PyListRef, vm: &VirtualMachine) -> PyResult<()> {
+    fn heapify_internal<F>(heap: &PyListRef, siftup_func: F, vm: &VirtualMachine) -> PyResult<()>
+    where
+        F: Fn(&PyListRef, usize, &VirtualMachine) -> PyResult<()>,
+    {
         let n = heap.__len__();
 
         if n > 2500 {
-            return cache_friendly_heapify(heap, vm);
+            return cache_friendly_heapify(heap, siftup_func, vm);
         }
 
         for i in (0..(n >> 1)).rev() {
-            siftup(heap, i, vm)?;
+            siftup_func(heap, i, vm)?;
         }
 
         Ok(())
+    }
+
+    fn heappop_internal<F>(
+        heap: &PyListRef,
+        siftup_func: F,
+        vm: &VirtualMachine,
+    ) -> PyResult<PyObjectRef>
+    where
+        F: Fn(&PyListRef, usize, &VirtualMachine) -> PyResult<()>,
+    {
+        let Some(lastelt) = heap.borrow_vec_mut().pop() else {
+            return Err(vm.new_index_error("index out of range"));
+        };
+
+        if heap.borrow_vec().is_empty() {
+            return Ok(lastelt);
+        };
+
+        let returnitem = {
+            let mut vec = heap.borrow_vec_mut();
+            let root = vec[0].clone();
+            vec[0] = lastelt;
+            root
+        };
+
+        siftup_func(&heap, 0, vm)?;
+        Ok(returnitem)
+    }
+
+    fn heapreplace_internal<F>(
+        heap: &PyListRef,
+        item: PyObjectRef,
+        siftup_func: F,
+        vm: &VirtualMachine,
+    ) -> PyResult<PyObjectRef>
+    where
+        F: Fn(&PyListRef, usize, &VirtualMachine) -> PyResult<()>,
+    {
+        let returnitem = {
+            let mut vec = heap.borrow_vec_mut();
+            let root = match vec.first() {
+                Some(v) => v.clone(),
+                None => return Err(vm.new_index_error("index out of range")),
+            };
+
+            vec[0] = item;
+            root
+        };
+
+        siftup_func(&heap, 0, vm)?;
+        Ok(returnitem)
     }
 
     #[pyfunction]
@@ -183,23 +244,7 @@ mod _heapq {
             ))
         })?;
 
-        let Some(lastelt) = lst.borrow_vec_mut().pop() else {
-            return Err(vm.new_index_error("index out of range"));
-        };
-
-        if lst.borrow_vec().is_empty() {
-            return Ok(lastelt);
-        };
-
-        let returnitem = {
-            let mut vec = lst.borrow_vec_mut();
-            let root = vec[0].clone();
-            vec[0] = lastelt;
-            root
-        };
-
-        siftup(&lst, 0, vm)?;
-        Ok(returnitem)
+        heappop_internal(&lst, siftup, vm)
     }
 
     #[pyfunction]
@@ -211,7 +256,7 @@ mod _heapq {
             ))
         })?;
 
-        heapify_internal(&lst, vm)
+        heapify_internal(&lst, siftup, vm)
     }
 
     #[pyfunction]
@@ -268,18 +313,6 @@ mod _heapq {
             ))
         })?;
 
-        let returnitem = {
-            let mut vec = lst.borrow_vec_mut();
-            let root = match vec.first() {
-                Some(v) => v.clone(),
-                None => return Err(vm.new_index_error("index out of range")),
-            };
-
-            vec[0] = item;
-            root
-        };
-
-        siftup(&lst, 0, vm)?;
-        Ok(returnitem)
+        heapreplace_internal(&lst, item, siftup, vm)
     }
 }

--- a/crates/stdlib/src/lib.rs
+++ b/crates/stdlib/src/lib.rs
@@ -53,6 +53,7 @@ mod math;
 #[cfg(all(feature = "host_env", any(unix, windows)))]
 mod mmap;
 
+mod _heapq;
 mod _queue;
 mod pyexpat;
 mod pystruct;
@@ -226,6 +227,7 @@ pub fn stdlib_module_defs(ctx: &Context) -> Vec<&'static builtins::PyModuleDef> 
         posixshmem::module_def(ctx),
         pyexpat::module_def(ctx),
         pystruct::module_def(ctx),
+        _heapq::module_def(ctx),
         _queue::module_def(ctx),
         random::module_def(ctx),
         #[cfg(all(feature = "host_env", unix, not(target_os = "redox")))]


### PR DESCRIPTION
<!--
Thanks for your contribution!
-->

- [ ] Closes #xxxx <!-- Replace xxxx with the GitHub issue number -->
- [ ] This PR follows our [AI policy](https://github.com/RustPython/.github/blob/main/AI_POLICY.md)

## Summary
<!-- What's the purpose of the change? What does it do, and why? -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a heap queue module to the standard library providing priority-queue operations (push, pop, replace, push-pop, heapify) for both min-heap and max-heap variants. Exposed as a standard-library module for direct use; heapify uses an optimized path for very large lists.

* **Bug Fixes**
  * Improved robustness: operations now detect and raise clear errors when lists change during operations or when invalid indices are encountered.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->