### PR TITLE
Fix `test_tty.py` tests

### DIFF
--- a/Lib/test/test_termios.py
+++ b/Lib/test/test_termios.py
@@ -51,7 +51,7 @@ class TestFunctions(unittest.TestCase):
                 self.assertEqual(len(x), 1)
         self.assertEqual(termios.tcgetattr(self.stream), attrs)
 
-    @unittest.skip("TODO: RUSTPYTHON segfault")
+    @unittest.skip("TODO: RUSTPYTHON; segfault")
     def test_tcgetattr_errors(self):
         self.assertRaisesTermiosError(errno.ENOTTY, termios.tcgetattr, self.bad_fd)
         self.assertRaises(ValueError, termios.tcgetattr, -1)
@@ -67,7 +67,7 @@ class TestFunctions(unittest.TestCase):
         termios.tcsetattr(self.fd, termios.TCSAFLUSH, attrs)
         termios.tcsetattr(self.stream, termios.TCSANOW, attrs)
 
-    @unittest.skip("TODO: RUSTPYTHON segfault")
+    @unittest.skip("TODO: RUSTPYTHON; segfault")
     def test_tcsetattr_errors(self):
         attrs = termios.tcgetattr(self.fd)
         self.assertRaises(TypeError, termios.tcsetattr, self.fd, termios.TCSANOW, tuple(attrs))
@@ -115,7 +115,7 @@ class TestFunctions(unittest.TestCase):
             raise
         termios.tcsendbreak(self.stream, 1)
 
-    @unittest.skip("TODO: RUSTPYTHON segfault")
+    @unittest.skip("TODO: RUSTPYTHON; segfault")
     @support.skip_android_selinux('tcsendbreak')
     def test_tcsendbreak_errors(self):
         self.assertRaises(OverflowError, termios.tcsendbreak, self.fd, 2**1000)
@@ -133,7 +133,7 @@ class TestFunctions(unittest.TestCase):
         termios.tcdrain(self.fd)
         termios.tcdrain(self.stream)
 
-    @unittest.skip("TODO: RUSTPYTHON segfault")
+    @unittest.skip("TODO: RUSTPYTHON; segfault")
     @support.skip_android_selinux('tcdrain')
     def test_tcdrain_errors(self):
         self.assertRaisesTermiosError(errno.ENOTTY, termios.tcdrain, self.bad_fd)
@@ -147,7 +147,7 @@ class TestFunctions(unittest.TestCase):
         termios.tcflush(self.fd, termios.TCOFLUSH)
         termios.tcflush(self.fd, termios.TCIOFLUSH)
 
-    @unittest.skip("TODO: RUSTPYTHON segfault")
+    @unittest.skip("TODO: RUSTPYTHON; segfault")
     def test_tcflush_errors(self):
         self.assertRaisesTermiosError(errno.EINVAL, termios.tcflush, self.fd, -1)
         self.assertRaises(OverflowError, termios.tcflush, self.fd, 2**1000)
@@ -190,7 +190,7 @@ class TestFunctions(unittest.TestCase):
         termios.tcflow(self.fd, termios.TCIOFF)
         termios.tcflow(self.fd, termios.TCION)
 
-    @unittest.skip("TODO: RUSTPYTHON segfault")
+    @unittest.skip("TODO: RUSTPYTHON; segfault")
     @support.skip_android_selinux('tcflow')
     def test_tcflow_errors(self):
         self.assertRaisesTermiosError(errno.EINVAL, termios.tcflow, self.fd, -1)

--- a/Lib/test/test_termios.py
+++ b/Lib/test/test_termios.py
@@ -181,7 +181,6 @@ class TestFunctions(unittest.TestCase):
         termios.tcflow(self.fd, termios.TCIOFF)
         termios.tcflow(self.fd, termios.TCION)
 
-    @unittest.skip("TODO: RUSTPYTHON; segfault")
     @support.skip_android_selinux('tcflow')
     def test_tcflow_errors(self):
         self.assertRaisesTermiosError(errno.EINVAL, termios.tcflow, self.fd, -1)

--- a/Lib/test/test_termios.py
+++ b/Lib/test/test_termios.py
@@ -32,7 +32,6 @@ class TestFunctions(unittest.TestCase):
             callable(*args)
         self.assertIn(cm.exception.args[0], errs)
 
-    @unittest.expectedFailure  # TODO: RUSTPYTHON; TypeError: Expected type 'int' but 'FileIO' found.
     def test_tcgetattr(self):
         attrs = termios.tcgetattr(self.fd)
         self.assertIsInstance(attrs, list)
@@ -51,7 +50,6 @@ class TestFunctions(unittest.TestCase):
                 self.assertEqual(len(x), 1)
         self.assertEqual(termios.tcgetattr(self.stream), attrs)
 
-    @unittest.skip("TODO: RUSTPYTHON; segfault")
     def test_tcgetattr_errors(self):
         self.assertRaisesTermiosError(errno.ENOTTY, termios.tcgetattr, self.bad_fd)
         self.assertRaises(ValueError, termios.tcgetattr, -1)
@@ -59,7 +57,6 @@ class TestFunctions(unittest.TestCase):
         self.assertRaises(TypeError, termios.tcgetattr, object())
         self.assertRaises(TypeError, termios.tcgetattr)
 
-    @unittest.expectedFailure  # TODO: RUSTPYTHON; TypeError: Expected type 'int' but 'FileIO' found.
     def test_tcsetattr(self):
         attrs = termios.tcgetattr(self.fd)
         termios.tcsetattr(self.fd, termios.TCSANOW, attrs)
@@ -67,7 +64,6 @@ class TestFunctions(unittest.TestCase):
         termios.tcsetattr(self.fd, termios.TCSAFLUSH, attrs)
         termios.tcsetattr(self.stream, termios.TCSANOW, attrs)
 
-    @unittest.skip("TODO: RUSTPYTHON; segfault")
     def test_tcsetattr_errors(self):
         attrs = termios.tcgetattr(self.fd)
         self.assertRaises(TypeError, termios.tcsetattr, self.fd, termios.TCSANOW, tuple(attrs))
@@ -103,7 +99,6 @@ class TestFunctions(unittest.TestCase):
         self.assertRaises(TypeError, termios.tcsetattr, object(), termios.TCSANOW, attrs)
         self.assertRaises(TypeError, termios.tcsetattr, self.fd, termios.TCSANOW)
 
-    @unittest.expectedFailure  # TODO: RUSTPYTHON; TypeError: Expected type 'int' but 'FileIO' found.
     @support.skip_android_selinux('tcsendbreak')
     def test_tcsendbreak(self):
         try:
@@ -115,7 +110,6 @@ class TestFunctions(unittest.TestCase):
             raise
         termios.tcsendbreak(self.stream, 1)
 
-    @unittest.skip("TODO: RUSTPYTHON; segfault")
     @support.skip_android_selinux('tcsendbreak')
     def test_tcsendbreak_errors(self):
         self.assertRaises(OverflowError, termios.tcsendbreak, self.fd, 2**1000)
@@ -127,13 +121,11 @@ class TestFunctions(unittest.TestCase):
         self.assertRaises(TypeError, termios.tcsendbreak, object(), 0)
         self.assertRaises(TypeError, termios.tcsendbreak, self.fd)
 
-    @unittest.expectedFailure  # TODO: RUSTPYTHON; TypeError: Expected type 'int' but 'FileIO' found.
     @support.skip_android_selinux('tcdrain')
     def test_tcdrain(self):
         termios.tcdrain(self.fd)
         termios.tcdrain(self.stream)
 
-    @unittest.skip("TODO: RUSTPYTHON; segfault")
     @support.skip_android_selinux('tcdrain')
     def test_tcdrain_errors(self):
         self.assertRaisesTermiosError(errno.ENOTTY, termios.tcdrain, self.bad_fd)
@@ -147,7 +139,6 @@ class TestFunctions(unittest.TestCase):
         termios.tcflush(self.fd, termios.TCOFLUSH)
         termios.tcflush(self.fd, termios.TCIOFLUSH)
 
-    @unittest.skip("TODO: RUSTPYTHON; segfault")
     def test_tcflush_errors(self):
         self.assertRaisesTermiosError(errno.EINVAL, termios.tcflush, self.fd, -1)
         self.assertRaises(OverflowError, termios.tcflush, self.fd, 2**1000)

--- a/Lib/test/test_tty.py
+++ b/Lib/test/test_tty.py
@@ -64,7 +64,6 @@ class TestTty(unittest.TestCase):
         self.assertEqual(mode[tty.IFLAG] & termios.ICRNL, 0,
                          msg="ICRNL should not be set by cbreak")
 
-    @unittest.expectedFailure  # TODO: RUSTPYTHON; TypeError: Expected type "int" but "FileIO" found.
     def test_setraw(self):
         mode0 = termios.tcgetattr(self.fd)
         mode1 = tty.setraw(self.fd)
@@ -76,7 +75,6 @@ class TestTty(unittest.TestCase):
         tty.setraw(self.stream)
         tty.setraw(fd=self.fd, when=termios.TCSANOW)
 
-    @unittest.expectedFailure  # TODO: RUSTPYTHON; TypeError: Expected type "int" but "FileIO" found.
     def test_setcbreak(self):
         mode0 = termios.tcgetattr(self.fd)
         mode1 = tty.setcbreak(self.fd)

--- a/Lib/test/test_tty.py
+++ b/Lib/test/test_tty.py
@@ -64,7 +64,7 @@ class TestTty(unittest.TestCase):
         self.assertEqual(mode[tty.IFLAG] & termios.ICRNL, 0,
                          msg="ICRNL should not be set by cbreak")
 
-    @unittest.expectedFailure # TODO: RUSTPYTHON TypeError: Expected type "int" but "FileIO" found.
+    @unittest.expectedFailure  # TODO: RUSTPYTHON; TypeError: Expected type "int" but "FileIO" found.
     def test_setraw(self):
         mode0 = termios.tcgetattr(self.fd)
         mode1 = tty.setraw(self.fd)
@@ -76,7 +76,7 @@ class TestTty(unittest.TestCase):
         tty.setraw(self.stream)
         tty.setraw(fd=self.fd, when=termios.TCSANOW)
 
-    @unittest.expectedFailure # TODO: RUSTPYTHON TypeError: Expected type "int" but "FileIO" found.
+    @unittest.expectedFailure  # TODO: RUSTPYTHON; TypeError: Expected type "int" but "FileIO" found.
     def test_setcbreak(self):
         mode0 = termios.tcgetattr(self.fd)
         mode1 = tty.setcbreak(self.fd)

--- a/crates/stdlib/src/termios.rs
+++ b/crates/stdlib/src/termios.rs
@@ -8,6 +8,7 @@ mod termios {
         PyObjectRef, PyResult, TryFromObject, VirtualMachine,
         builtins::{PyBaseExceptionRef, PyBytes, PyInt, PyListRef, PyTypeRef},
         convert::ToPyObject,
+        stdlib::_io::Fildes,
     };
     use rustpython_host_env::{os::ErrorExt, termios as host_termios};
 
@@ -166,7 +167,8 @@ mod termios {
     };
 
     #[pyfunction]
-    fn tcgetattr(fd: i32, vm: &VirtualMachine) -> PyResult<Vec<PyObjectRef>> {
+    fn tcgetattr(fd: PyObjectRef, vm: &VirtualMachine) -> PyResult<Vec<PyObjectRef>> {
+        let fd = Fildes::try_from_object(vm, fd).map(Into::into)?;
         let termios = host_termios::tcgetattr(fd).map_err(|e| termios_error(e, vm))?;
         let noncanon = (termios.c_lflag & host_termios::ICANON) == 0;
         let cc = termios
@@ -191,7 +193,13 @@ mod termios {
     }
 
     #[pyfunction]
-    fn tcsetattr(fd: i32, when: i32, attributes: PyListRef, vm: &VirtualMachine) -> PyResult<()> {
+    fn tcsetattr(
+        fd: PyObjectRef,
+        when: i32,
+        attributes: PyListRef,
+        vm: &VirtualMachine,
+    ) -> PyResult<()> {
+        let fd = Fildes::try_from_object(vm, fd).map(Into::into)?;
         let [iflag, oflag, cflag, lflag, ispeed, ospeed, cc] =
             <&[PyObjectRef; 7]>::try_from(&*attributes.borrow_vec())
                 .map_err(|_| vm.new_type_error("tcsetattr, arg 3: must be 7 element list"))?
@@ -233,25 +241,29 @@ mod termios {
     }
 
     #[pyfunction]
-    fn tcsendbreak(fd: i32, duration: i32, vm: &VirtualMachine) -> PyResult<()> {
+    fn tcsendbreak(fd: PyObjectRef, duration: i32, vm: &VirtualMachine) -> PyResult<()> {
+        let fd = Fildes::try_from_object(vm, fd).map(Into::into)?;
         host_termios::tcsendbreak(fd, duration).map_err(|e| termios_error(e, vm))?;
         Ok(())
     }
 
     #[pyfunction]
-    fn tcdrain(fd: i32, vm: &VirtualMachine) -> PyResult<()> {
+    fn tcdrain(fd: PyObjectRef, vm: &VirtualMachine) -> PyResult<()> {
+        let fd = Fildes::try_from_object(vm, fd).map(Into::into)?;
         host_termios::tcdrain(fd).map_err(|e| termios_error(e, vm))?;
         Ok(())
     }
 
     #[pyfunction]
-    fn tcflush(fd: i32, queue: i32, vm: &VirtualMachine) -> PyResult<()> {
+    fn tcflush(fd: PyObjectRef, queue: i32, vm: &VirtualMachine) -> PyResult<()> {
+        let fd = Fildes::try_from_object(vm, fd).map(Into::into)?;
         host_termios::tcflush(fd, queue).map_err(|e| termios_error(e, vm))?;
         Ok(())
     }
 
     #[pyfunction]
-    fn tcflow(fd: i32, action: i32, vm: &VirtualMachine) -> PyResult<()> {
+    fn tcflow(fd: PyObjectRef, action: i32, vm: &VirtualMachine) -> PyResult<()> {
+        let fd = Fildes::try_from_object(vm, fd).map(Into::into)?;
         host_termios::tcflow(fd, action).map_err(|e| termios_error(e, vm))?;
         Ok(())
     }

--- a/crates/vm/src/stdlib/_io.rs
+++ b/crates/vm/src/stdlib/_io.rs
@@ -89,6 +89,12 @@ impl TryFromObject for Fildes {
     }
 }
 
+impl From<Fildes> for i32 {
+    fn from(fildes: Fildes) -> Self {
+        fildes.0
+    }
+}
+
 #[cfg(unix)]
 impl std::os::fd::AsFd for Fildes {
     fn as_fd(&self) -> std::os::fd::BorrowedFd<'_> {
@@ -97,6 +103,7 @@ impl std::os::fd::AsFd for Fildes {
         unsafe { std::os::fd::BorrowedFd::borrow_raw(self.0) }
     }
 }
+
 #[cfg(unix)]
 impl std::os::fd::AsRawFd for Fildes {
     fn as_raw_fd(&self) -> std::os::fd::RawFd {


### PR DESCRIPTION
<!--
Thanks for your contribution!
-->

- [ ] Closes #xxxx <!-- Replace xxxx with the GitHub issue number -->
- [ ] This PR follows our [AI policy](https://github.com/RustPython/.github/blob/main/AI_POLICY.md)

## Summary
<!-- What's the purpose of the change? What does it do, and why? -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Enhanced file descriptor handling in the termios module's core functions (tcgetattr, tcsetattr, tcsendbreak, tcdrain, tcflush, tcflow) for improved robustness.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->