### PR TITLE
Remove  redundant `to_owned()` calls

### DIFF
--- a/crates/capi/src/abstract_.rs
+++ b/crates/capi/src/abstract_.rs
@@ -100,9 +100,7 @@ pub unsafe extern "C" fn PyObject_VectorcallMethod(
         let args_len = nargsf & !PY_VECTORCALL_ARGUMENTS_OFFSET;
 
         if args_len == 0 {
-            return Err(
-                vm.new_system_error("PyObject_VectorcallMethod called with no receiver".to_owned())
-            );
+            return Err(vm.new_system_error("PyObject_VectorcallMethod called with no receiver"));
         }
 
         let (receiver, args) = unsafe { slice::from_raw_parts(args, args_len) }

--- a/crates/capi/src/unicodeobject.rs
+++ b/crates/capi/src/unicodeobject.rs
@@ -158,7 +158,7 @@ pub unsafe extern "C" fn PyUnicode_FromEncodedObject(
         let obj = unsafe { &*obj };
 
         if obj.downcast_ref::<PyStr>().is_some() {
-            return Err(vm.new_type_error("decoding str is not supported".to_owned()));
+            return Err(vm.new_type_error("decoding str is not supported"));
         }
 
         let encoding = if encoding.is_null() {

--- a/crates/stdlib/src/multiprocessing.rs
+++ b/crates/stdlib/src/multiprocessing.rs
@@ -496,7 +496,7 @@ mod _multiprocessing {
                 let timeout: f64 = timeout_obj.try_float(vm)?.to_f64();
                 Some(
                     host_multiprocessing::deadline_from_timeout(timeout)
-                        .map_err(|_| vm.new_os_error("gettimeofday failed".to_string()))?,
+                        .map_err(|_| vm.new_os_error("gettimeofday failed"))?,
                 )
             } else {
                 None

--- a/crates/stdlib/src/select.rs
+++ b/crates/stdlib/src/select.rs
@@ -393,7 +393,7 @@ mod decl {
                     return Err(vm.new_value_error("negative sizehint"));
                 }
                 if !matches!(args.flags, 0 | libc::EPOLL_CLOEXEC) {
-                    return Err(vm.new_os_error("invalid flags".to_owned()));
+                    return Err(vm.new_os_error("invalid flags"));
                 }
                 Self::new().map_err(|e| e.into_pyexception(vm))
             }

--- a/crates/stdlib/src/socket.rs
+++ b/crates/stdlib/src/socket.rs
@@ -1123,7 +1123,7 @@ mod _socket {
                         ArgStrOrBytesLike::Str(s) => vm.fsencode(s)?,
                     };
                     socket2::SockAddr::unix(path)
-                        .map_err(|_| vm.new_os_error("AF_UNIX path too long".to_owned()).into())
+                        .map_err(|_| vm.new_os_error("AF_UNIX path too long").into())
                 }
                 c::AF_INET => {
                     let tuple: PyTupleRef = addr.downcast().map_err(|obj| {
@@ -1206,12 +1206,10 @@ mod _socket {
                     } else {
                         // Check interface name length (IFNAMSIZ is typically 16)
                         if ifname.len() >= 16 {
-                            return Err(vm
-                                .new_os_error("interface name too long".to_owned())
-                                .into());
+                            return Err(vm.new_os_error("interface name too long").into());
                         }
                         let cstr = alloc::ffi::CString::new(ifname)
-                            .map_err(|_| vm.new_os_error("invalid interface name".to_owned()))?;
+                            .map_err(|_| vm.new_os_error("invalid interface name"))?;
                         host_socket::if_nametoindex_checked(cstr.as_c_str())? as i32
                     };
 
@@ -2052,9 +2050,7 @@ mod _socket {
                 Ok(vm.ctx.new_int(flag).into())
             } else {
                 if buflen <= 0 || buflen > 1024 {
-                    return Err(vm
-                        .new_os_error("getsockopt buflen out of range".to_owned())
-                        .into());
+                    return Err(vm.new_os_error("getsockopt buflen out of range").into());
                 }
                 let buf = host_socket::getsockopt_bytes(fd as _, level, name, buflen as usize)?;
                 Ok(vm.ctx.new_bytes(buf).into())
@@ -2341,16 +2337,14 @@ mod _socket {
             .as_str()
             .parse::<Ipv4Addr>()
             .map(|ip_addr| Vec::<u8>::from(ip_addr.octets()))
-            .map_err(|_| {
-                vm.new_os_error("illegal IP address string passed to inet_aton".to_owned())
-            })
+            .map_err(|_| vm.new_os_error("illegal IP address string passed to inet_aton"))
     }
 
     #[pyfunction]
     fn inet_ntoa(packed_ip: ArgBytesLike, vm: &VirtualMachine) -> PyResult<PyStrRef> {
         let packed_ip = packed_ip.borrow_buf();
         let packed_ip = <&[u8; 4]>::try_from(&*packed_ip)
-            .map_err(|_| vm.new_os_error("packed IP wrong length for inet_ntoa".to_owned()))?;
+            .map_err(|_| vm.new_os_error("packed IP wrong length for inet_ntoa"))?;
         Ok(vm.ctx.new_str(Ipv4Addr::from(*packed_ip).to_string()))
     }
 
@@ -2372,7 +2366,7 @@ mod _socket {
         let cstr_proto = cstr_opt_as_ptr(&cstr_proto);
         let serv = unsafe { c::getservbyname(cstr_name.as_ptr() as _, cstr_proto as _) };
         if serv.is_null() {
-            return Err(vm.new_os_error("service/proto not found".to_owned()));
+            return Err(vm.new_os_error("service/proto not found"));
         }
         let port = unsafe { (*serv).s_port };
         Ok(u16::from_be(port as u16))
@@ -2394,7 +2388,7 @@ mod _socket {
         let cstr_proto = cstr_opt_as_ptr(&cstr_proto);
         let serv = unsafe { c::getservbyport(port.to_be() as _, cstr_proto as _) };
         if serv.is_null() {
-            return Err(vm.new_os_error("port/proto not found".to_owned()));
+            return Err(vm.new_os_error("port/proto not found"));
         }
         let s = unsafe { ffi::CStr::from_ptr((*serv).s_name as _) };
         Ok(s.to_string_lossy().into_owned())
@@ -2729,7 +2723,7 @@ mod _socket {
                 .map_err(|_| vm.new_os_error(ERROR_MSG.to_owned()))?
                 .octets()
                 .to_vec(),
-            _ => return Err(vm.new_os_error("Address family not supported by protocol".to_owned())),
+            _ => return Err(vm.new_os_error("Address family not supported by protocol")),
         };
         Ok(ip_addr)
     }
@@ -2759,7 +2753,7 @@ mod _socket {
         let cstr = name.to_cstring(vm)?;
         let proto = unsafe { c::getprotobyname(cstr.as_ptr() as _) };
         if proto.is_null() {
-            return Err(vm.new_os_error("protocol not found".to_owned()));
+            return Err(vm.new_os_error("protocol not found"));
         }
         let num = unsafe { (*proto).p_proto };
         Ok(vm.ctx.new_int(num).into())
@@ -2792,15 +2786,13 @@ mod _socket {
         let mut ainfo = res.next().unwrap();
         if res.next().is_some() {
             return Err(vm
-                .new_os_error("sockaddr resolved to multiple addresses".to_owned())
+                .new_os_error("sockaddr resolved to multiple addresses")
                 .into());
         }
         match &mut ainfo.sockaddr {
             SocketAddr::V4(_) => {
                 if address.len() != 2 {
-                    return Err(vm
-                        .new_os_error("IPv4 sockaddr must be 2 tuple".to_owned())
-                        .into());
+                    return Err(vm.new_os_error("IPv4 sockaddr must be 2 tuple").into());
                 }
             }
             SocketAddr::V6(addr) => {
@@ -2931,7 +2923,7 @@ mod _socket {
             let ainfo = res.next().unwrap()?;
             if res.next().is_some() {
                 return Err(vm
-                    .new_os_error("wildcard resolved to multiple address".to_owned())
+                    .new_os_error("wildcard resolved to multiple address")
                     .into());
             }
             return Ok(ainfo.sockaddr);
@@ -2940,9 +2932,7 @@ mod _socket {
             match af {
                 c::AF_INET | c::AF_UNSPEC => {}
                 _ => {
-                    return Err(vm
-                        .new_os_error("address family mismatched".to_owned())
-                        .into());
+                    return Err(vm.new_os_error("address family mismatched").into());
                 }
             }
             return Ok(SocketAddr::V4(net::SocketAddrV4::new(

--- a/crates/stdlib/src/ssl.rs
+++ b/crates/stdlib/src/ssl.rs
@@ -2824,7 +2824,7 @@ mod _ssl {
         ) -> PyResult<PyBytesRef> {
             let obj_to_bytes = |bytes_obj| {
                 PyBytesRef::try_from_object(vm, bytes_obj)
-                    .map_err(|_| vm.new_os_error("Expected bytes from recv".to_string()))
+                    .map_err(|_| vm.new_os_error("Expected bytes from recv"))
             };
 
             let tls_record_header_buf = self

--- a/crates/vm/src/builtins/code.rs
+++ b/crates/vm/src/builtins/code.rs
@@ -536,7 +536,7 @@ impl PyCode {
     }
     #[cfg(not(feature = "host_env"))]
     pub fn from_pyc_path(_path: &std::path::Path, vm: &VirtualMachine) -> PyResult<PyRef<Self>> {
-        Err(vm.new_runtime_error("loading a pyc file requires the `host_env` feature".to_owned()))
+        Err(vm.new_runtime_error("loading a pyc file requires the `host_env` feature"))
     }
     pub fn from_pyc(
         pyc_bytes: &[u8],

--- a/crates/vm/src/builtins/function.rs
+++ b/crates/vm/src/builtins/function.rs
@@ -1253,10 +1253,10 @@ impl Constructor for PyBoundMethod {
         vm: &VirtualMachine,
     ) -> PyResult<Self> {
         if !function.is_callable() {
-            return Err(vm.new_type_error("first argument must be callable".to_owned()));
+            return Err(vm.new_type_error("first argument must be callable"));
         }
         if vm.is_none(&object) {
-            return Err(vm.new_type_error("instance must not be None".to_owned()));
+            return Err(vm.new_type_error("instance must not be None"));
         }
         Ok(Self::new(object, function))
     }

--- a/crates/vm/src/builtins/list.rs
+++ b/crates/vm/src/builtins/list.rs
@@ -295,7 +295,7 @@ impl PyList {
                 .setitem_by_index(vm, index, value)
                 .map_err(|e| {
                     if e.class().is(vm.ctx.exceptions.index_error) {
-                        vm.new_index_error("list assignment index out of range".to_owned())
+                        vm.new_index_error("list assignment index out of range")
                     } else {
                         e
                     }

--- a/crates/vm/src/exceptions.rs
+++ b/crates/vm/src/exceptions.rs
@@ -2536,7 +2536,7 @@ pub(super) mod types {
                     4 | 6 => {}
                     5 => {
                         return Err(vm.new_type_error(
-                            "end_offset must be provided when end_lineno is provided".to_owned(),
+                            "end_offset must be provided when end_lineno is provided",
                         ));
                     }
                     _ => {

--- a/crates/vm/src/function/time.rs
+++ b/crates/vm/src/function/time.rs
@@ -29,7 +29,7 @@ impl TryFromObject for TimeoutSeconds {
             super::Either::B(i) => i as f64,
         };
         if value.is_nan() {
-            return Err(vm.new_value_error("Invalid value NaN (not a number)".to_owned()));
+            return Err(vm.new_value_error("Invalid value NaN (not a number)"));
         }
         Ok(Self { value })
     }

--- a/crates/vm/src/stdlib/_signal.rs
+++ b/crates/vm/src/stdlib/_signal.rs
@@ -222,7 +222,7 @@ pub(crate) mod _signal {
         let _old = match old {
             Ok(old) => old,
             Err(_) => {
-                return Err(vm.new_os_error("Failed to set signal".to_owned()));
+                return Err(vm.new_os_error("Failed to set signal"));
             }
         };
 
@@ -440,7 +440,7 @@ pub(crate) mod _signal {
         let set = PySet::default().into_ref(&vm.ctx);
         #[cfg(any(unix, windows))]
         for signum in host_signal::valid_signals(signal::NSIG)
-            .map_err(|_| vm.new_os_error("sigfillset failed".to_owned()))?
+            .map_err(|_| vm.new_os_error("sigfillset failed"))?
         {
             set.add(vm.ctx.new_int(signum).into(), vm)?;
         }

--- a/crates/vm/src/stdlib/marshal.rs
+++ b/crates/vm/src/stdlib/marshal.rs
@@ -187,7 +187,7 @@ mod decl {
     ) -> PyResult<()> {
         use marshal::Write;
         if depth == 0 {
-            return Err(vm.new_value_error("object too deeply nested to marshal".to_string()));
+            return Err(vm.new_value_error("object too deeply nested to marshal"));
         }
 
         // Singletons: no FLAG_REF needed
@@ -325,7 +325,7 @@ mod decl {
             marshal::serialize_code(buf, &co.code);
         } else if let Some(sl) = obj.downcast_ref::<crate::builtins::PySlice>() {
             if version < 5 {
-                return Err(vm.new_value_error("unmarshallable object".to_string()));
+                return Err(vm.new_value_error("unmarshallable object"));
             }
             buf.write_u8(b':');
             let none: PyObjectRef = vm.ctx.none();
@@ -352,7 +352,7 @@ mod decl {
             buf.write_u32(data.len() as u32);
             buf.write_slice(&data);
         } else {
-            return Err(vm.new_value_error("unmarshallable object".to_string()));
+            return Err(vm.new_value_error("unmarshallable object"));
         }
 
         if use_ref {
@@ -558,7 +558,7 @@ mod decl {
     /// Recursively check that no code objects are present.
     fn check_no_code(obj: &PyObjectRef, vm: &VirtualMachine) -> PyResult<()> {
         if obj.downcast_ref::<PyCode>().is_some() {
-            return Err(vm.new_value_error("unmarshalling code objects is disallowed".to_string()));
+            return Err(vm.new_value_error("unmarshalling code objects is disallowed"));
         }
         if let Some(tup) = obj.downcast_ref::<PyTuple>() {
             for elem in tup.as_slice() {
@@ -602,7 +602,7 @@ mod decl {
             PyFrozenSet::static_type(),
         ] {
             if cls.fast_issubclass(base) && !cls.is(base) {
-                return Err(vm.new_value_error("unmarshallable object".to_string()));
+                return Err(vm.new_value_error("unmarshallable object"));
             }
         }
         Ok(())

--- a/crates/vm/src/stdlib/nt.rs
+++ b/crates/vm/src/stdlib/nt.rs
@@ -963,7 +963,7 @@ pub(crate) mod module {
 
     #[pyfunction]
     fn getlogin(vm: &VirtualMachine) -> PyResult<String> {
-        host_nt::getlogin().map_err(|_| vm.new_os_error("Error code: 0".to_owned()))
+        host_nt::getlogin().map_err(|_| vm.new_os_error("Error code: 0"))
     }
 
     pub fn raw_set_handle_inheritable(handle: intptr_t, inheritable: bool) -> std::io::Result<()> {

--- a/crates/vm/src/stdlib/os.rs
+++ b/crates/vm/src/stdlib/os.rs
@@ -1678,7 +1678,7 @@ pub(super) mod _os {
         #[cfg(unix)]
         {
             let times = crate::host_env::time::process_times()
-                .map_err(|_| vm.new_os_error("Fail to get times".to_string()))?;
+                .map_err(|_| vm.new_os_error("Fail to get times"))?;
 
             let times_result = TimesResultData {
                 user: times.user,
@@ -1767,7 +1767,7 @@ pub(super) mod _os {
     #[pyfunction]
     fn getloadavg(vm: &VirtualMachine) -> PyResult<(f64, f64, f64)> {
         let loadavg = crate::host_env::time::getloadavg()
-            .map_err(|_| vm.new_os_error("Load averages are unobtainable".to_string()))?;
+            .map_err(|_| vm.new_os_error("Load averages are unobtainable"))?;
         Ok((loadavg[0], loadavg[1], loadavg[2]))
     }
 

--- a/crates/vm/src/stdlib/sys.rs
+++ b/crates/vm/src/stdlib/sys.rs
@@ -103,7 +103,7 @@ pub mod sys {
         #[pymethod]
         fn write(&self, s: PyStrRef, vm: &VirtualMachine) -> PyResult<usize> {
             if self.fd == 0 {
-                return Err(vm.new_os_error("not writable".to_owned()));
+                return Err(vm.new_os_error("not writable"));
             }
             let bytes = s.as_bytes();
             if self.fd == 2 {
@@ -121,7 +121,7 @@ pub mod sys {
         #[pymethod]
         fn readline(&self, size: OptionalArg<isize>, vm: &VirtualMachine) -> PyResult<String> {
             if self.fd != 0 {
-                return Err(vm.new_os_error("not readable".to_owned()));
+                return Err(vm.new_os_error("not readable"));
             }
             let size = size.unwrap_or(-1);
             if size == 0 {

--- a/crates/vm/src/stdlib/time.rs
+++ b/crates/vm/src/stdlib/time.rs
@@ -685,8 +685,8 @@ mod decl {
 
     #[cfg(all(target_arch = "wasm32", target_os = "emscripten"))]
     fn get_process_time(vm: &VirtualMachine) -> PyResult<Duration> {
-        let times = host_time::process_times()
-            .map_err(|_| vm.new_os_error("Failed to get clock time".to_owned()))?;
+        let times =
+            host_time::process_times().map_err(|_| vm.new_os_error("Failed to get clock time"))?;
         Ok(Duration::from_secs_f64(times.user + times.system))
     }
 
@@ -1336,13 +1336,13 @@ mod platform {
 
     pub(super) fn get_thread_time(vm: &VirtualMachine) -> PyResult<Duration> {
         let total = host_time::get_thread_time_100ns()
-            .ok_or_else(|| vm.new_os_error("Failed to get clock time".to_owned()))?;
+            .ok_or_else(|| vm.new_os_error("Failed to get clock time"))?;
         Ok(Duration::from_nanos(total * 100))
     }
 
     pub(super) fn get_process_time(vm: &VirtualMachine) -> PyResult<Duration> {
         let total = host_time::get_process_time_100ns()
-            .ok_or_else(|| vm.new_os_error("Failed to get clock time".to_owned()))?;
+            .ok_or_else(|| vm.new_os_error("Failed to get clock time"))?;
         Ok(Duration::from_nanos(total * 100))
     }
 }

--- a/crates/vm/src/vm/mod.rs
+++ b/crates/vm/src/vm/mod.rs
@@ -647,7 +647,7 @@ impl VirtualMachine {
             .types
             .list_type
             .get_attr(self.ctx.intern_str("append"))
-            .ok_or_else(|| self.new_runtime_error("failed to cache list.append".to_owned()))?;
+            .ok_or_else(|| self.new_runtime_error("failed to cache list.append"))?;
         self.callable_cache.list_append = Some(list_append);
         self.callable_cache.builtin_all = Some(self.builtins.get_attr("all", self)?);
         self.callable_cache.builtin_any = Some(self.builtins.get_attr("any", self)?);


### PR DESCRIPTION
<!--
Thanks for your contribution!
-->

- [ ] Closes #xxxx <!-- Replace xxxx with the GitHub issue number -->
- [ ] This PR follows our [AI policy](https://github.com/RustPython/.github/blob/main/AI_POLICY.md)

## Summary
<!-- What's the purpose of the change? What does it do, and why? -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Simplified internal error-message construction across many modules to reduce unnecessary allocations and improve efficiency; no changes to error text, behavior, or public APIs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->