### PR TITLE
Honor sys.int_max_str_digits in native json.loads

### DIFF
--- a/crates/stdlib/src/json.rs
+++ b/crates/stdlib/src/json.rs
@@ -9,12 +9,11 @@ mod _json {
         builtins::{PyBaseExceptionRef, PyStrRef, PyType},
         convert::ToPyResult,
         function::{IntoFuncArgs, OptionalArg},
-        protocol::PyIterReturn,
+        protocol::{handle_bytes_to_int_err, PyIterReturn},
         types::{Callable, Constructor},
     };
     use core::str::FromStr;
-    use malachite_bigint::BigInt;
-    use rustpython_common::wtf8::Wtf8Buf;
+    use rustpython_common::{int::bytes_to_int, wtf8::Wtf8Buf};
     use std::collections::HashMap;
 
     /// Skip JSON whitespace characters (space, tab, newline, carriage return).
@@ -243,7 +242,12 @@ mod _json {
             } else if let Some(ref parse_int) = self.parse_int {
                 parse_int.call((buf,), vm)
             } else {
-                Ok(vm.new_pyobj(BigInt::from_str(buf).unwrap()))
+                let value = bytes_to_int(buf.as_bytes(), 10, vm.state.int_max_str_digits.load())
+                    .map_err(|e| {
+                        let obj = vm.ctx.new_str(buf);
+                        handle_bytes_to_int_err(e, obj.as_object(), vm)
+                    })?;
+                Ok(vm.new_pyobj(value))
             };
             Some((ret, buf.len()))
         }

--- a/crates/stdlib/src/json.rs
+++ b/crates/stdlib/src/json.rs
@@ -242,12 +242,12 @@ mod _json {
             } else if let Some(ref parse_int) = self.parse_int {
                 parse_int.call((buf,), vm)
             } else {
-                let value = bytes_to_int(buf.as_bytes(), 10, vm.state.int_max_str_digits.load())
+                bytes_to_int(buf.as_bytes(), 10, vm.state.int_max_str_digits.load())
+                    .map(|value| vm.new_pyobj(value))
                     .map_err(|e| {
                         let obj = vm.ctx.new_str(buf);
                         handle_bytes_to_int_err(e, obj.as_object(), vm)
-                    })?;
-                Ok(vm.new_pyobj(value))
+                    })
             };
             Some((ret, buf.len()))
         }

--- a/extra_tests/snippets/stdlib_json.py
+++ b/extra_tests/snippets/stdlib_json.py
@@ -261,3 +261,17 @@ except json.JSONDecodeError as e:
     assert e.pos == 5, f"expected pos=5, got {e.pos}"
 else:
     raise AssertionError("expected JSONDecodeError")
+
+# Test that json.loads honors sys.int_max_str_digits
+import sys
+
+_min_limit = sys.int_info.str_digits_check_threshold
+_orig_limit = sys.get_int_max_str_digits()
+try:
+    sys.set_int_max_str_digits(_min_limit)
+    with assert_raises(ValueError):
+        json.loads("1" * (_min_limit + 1))
+    assert json.loads("1" * _min_limit) == int("1" * _min_limit)
+    assert json.loads('42') == 42
+finally:
+    sys.set_int_max_str_digits(_orig_limit)

--- a/extra_tests/snippets/stdlib_json.py
+++ b/extra_tests/snippets/stdlib_json.py
@@ -1,4 +1,5 @@
 import json
+import sys
 from io import BytesIO, StringIO
 
 from testutils import assert_raises
@@ -263,8 +264,6 @@ else:
     raise AssertionError("expected JSONDecodeError")
 
 # Test that json.loads honors sys.int_max_str_digits
-import sys
-
 _min_limit = sys.int_info.str_digits_check_threshold
 _orig_limit = sys.get_int_max_str_digits()
 try:


### PR DESCRIPTION
- [x] This PR follows our [AI policy](https://github.com/RustPython/.github/blob/main/AI_POLICY.md)

Refs #8051.

Routes the native `_json` scanner integer path through `rustpython_common::int::bytes_to_int` with the live `vm.state.int_max_str_digits` value, matching the `int()` conversion path and the pure-Python JSON decoder. Adds snippet coverage for the boundary where an integer with exactly the configured digit limit parses, while one digit over the limit raises `ValueError`.

Local verification:
- `python3.14 -m py_compile extra_tests/snippets/stdlib_json.py`
- `python3.14 extra_tests/snippets/stdlib_json.py`

Could not run local Rust checks because `cargo` is not installed in this environment; CI will validate the Rust crate build and formatting.

AI assistance disclosure: OpenAI GPT-5 was used to inspect the issue and review feedback, draft the patch, and run local verification; the changes are disclosed in the commit with an `Assisted-by` trailer.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * JSON integer parsing now enforces the VM’s integer-string length limit, returning an error for overly long integer literals while preserving correct parsing for valid integers.
  * Error handling for integers exceeding the configured limit is now reported consistently.

* **Tests**
  * Added regression coverage confirming the limit is enforced and valid integer strings, including boundary-length values, continue to parse successfully.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->