### PR TITLE
DOC-DB: Get all builtin types dynamically

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,10 +1,13 @@
 Lib/**      linguist-vendored
 Cargo.lock  linguist-generated
 *.snap      linguist-generated -merge
-vm/src/stdlib/ast/gen.rs    linguist-generated -merge
 Lib/*.py    text working-tree-encoding=UTF-8 eol=LF
 **/*.rs     text working-tree-encoding=UTF-8 eol=LF
-crates/rustpython_doc_db/src/*.inc.rs   linguist-generated=true
+crates/vm/src/stdlib/ast/gen.rs    linguist-generated -merge
+crates/doc/src/data.inc.rs                              generated
+crates/compiler-core/src/bytecode/opcode_metadata.rs    generated
+
+.github/workflows/*.lock.yml linguist-generated=true merge=ours
 
 # Binary data types
 *.aif binary
@@ -45,10 +48,11 @@ Lib/venv/scripts/posix/* text eol=lf
 # Language aware diff headers
 # https://tekin.co.uk/2020/10/better-git-diff-output-for-ruby-python-elixir-and-more
 # https://gist.github.com/tekin/12500956bd56784728e490d8cef9cb81
-*.css   diff=css
-*.html  diff=html
-*.py    diff=python
-*.md    diff=markdown
+*.css       diff=css
+*.html      diff=html
+*.py        diff=python
+*.md        diff=markdown
+*.inc.rs    diff=rust
 
 # Generated files
 # https://github.com/github/linguist/blob/master/docs/overrides.md
@@ -66,6 +70,3 @@ Lib/test/certdata/*.0                                   generated
 Lib/test/levenshtein_examples.json                      generated
 Lib/test/test_stable_abi_ctypes.py                      generated
 Lib/token.py                                            generated
-crates/compiler-core/src/bytecode/opcode_metadata.rs    generated
-
-.github/workflows/*.lock.yml linguist-generated=true merge=ours

--- a/crates/doc/generate.py
+++ b/crates/doc/generate.py
@@ -185,23 +185,7 @@ def find_doc_entries() -> "Iterable[DocEntry]":
     )
     yield from (doc_entry for doc_entry in traverse(__builtins__, __builtins__))
 
-    builtin_types = [
-        type(None),
-        type(bytearray().__iter__()),
-        type(bytes().__iter__()),
-        type(dict().__iter__()),
-        type(dict().items()),
-        type(dict().items().__iter__()),
-        type(dict().values()),
-        type(dict().values().__iter__()),
-        type(lambda: ...),
-        type(list().__iter__()),
-        type(memoryview(b"").__iter__()),
-        type(range(0).__iter__()),
-        type(set().__iter__()),
-        type(str().__iter__()),
-        type(tuple().__iter__()),
-    ]
+    builtin_types = object.__subclasses__()
 
     # Add types from the types module (e.g., ModuleType, FunctionType, etc.)
     for name in dir(types):


### PR DESCRIPTION
<!--
Thanks for your contribution!
-->

- [ ] Closes #xxxx <!-- Replace xxxx with the GitHub issue number -->
- [ ] This PR follows our [AI policy](https://github.com/RustPython/.github/blob/main/AI_POLICY.md)

## Summary
<!-- What's the purpose of the change? What does it do, and why? -->

This will make it so we can detect every object, and won't need to manually do `type(iter([]))` and such

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated repository file classification and diff behavior configuration for improved handling of generated artifacts and workflow files.

* **Refactor**
  * Modified documentation generation to dynamically detect and enumerate built-in types based on the interpreter's current state rather than relying on a static predefined list.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->