### PR TITLE
Fix builtin class names not being interned

### DIFF
--- a/Lib/test/test_dataclasses/__init__.py
+++ b/Lib/test/test_dataclasses/__init__.py
@@ -3977,7 +3977,6 @@ class TestSlots(unittest.TestCase):
         # that we create internally.
         self.assertEqual(CorrectSuper.args, ["default", "default"])
 
-    @unittest.skip("TODO: RUSTPYTHON; Crash - static type name must be already interned but async_generator_wrapped_value is not")
     def test_original_class_is_gced(self):
         # gh-135228: Make sure when we replace the class with slots=True, the original class
         # gets garbage collected.

--- a/Lib/test/test_pydoc/test_pydoc.py
+++ b/Lib/test/test_pydoc/test_pydoc.py
@@ -556,7 +556,6 @@ class PydocDocTest(unittest.TestCase):
         self.assertEqual(stripid("<type 'exceptions.Exception'>"),
                          "<type 'exceptions.Exception'>")
 
-    @unittest.skip("TODO: RUSTPYTHON; Panic")
     def test_builtin_with_more_than_four_children(self):
         """Tests help on builtin object which have more than four child classes.
 

--- a/crates/vm/src/builtins/asyncgenerator.rs
+++ b/crates/vm/src/builtins/asyncgenerator.rs
@@ -818,4 +818,5 @@ pub(crate) fn init(ctx: &'static Context) {
     PyAsyncGenASend::extend_class(ctx, ctx.types.async_generator_asend);
     PyAsyncGenAThrow::extend_class(ctx, ctx.types.async_generator_athrow);
     PyAnextAwaitable::extend_class(ctx, ctx.types.anext_awaitable);
+    PyAsyncGenWrappedValue::extend_class(ctx, ctx.types.async_generator_wrapped_value);
 }

--- a/crates/vm/src/function/method.rs
+++ b/crates/vm/src/function/method.rs
@@ -5,6 +5,7 @@ use crate::{
         builtin_func::{PyNativeFunction, PyNativeMethod},
         descriptor::PyMethodDescriptor,
     },
+    class::PyClassDef,
     function::{IntoPyNativeFn, PyNativeFn},
 };
 
@@ -331,3 +332,10 @@ impl Py<HeapMethodDef> {
 
 #[pyclass]
 impl HeapMethodDef {}
+
+pub(crate) fn init(ctx: &'static Context) {
+    // TODO: Should we extend the class instead of interning only the name?
+    // HeapMethodDef::extend_class(ctx, ctx.types.method_def);
+
+    let _ = ctx.intern_str(HeapMethodDef::NAME);
+}

--- a/crates/vm/src/function/mod.rs
+++ b/crates/vm/src/function/mod.rs
@@ -5,7 +5,7 @@ mod builtin;
 mod either;
 mod fspath;
 mod getset;
-mod method;
+pub(crate) mod method;
 mod number;
 mod protocol;
 mod time;

--- a/crates/vm/src/types/zoo.rs
+++ b/crates/vm/src/types/zoo.rs
@@ -266,5 +266,8 @@ impl TypeZoo {
         template::init(context);
         descriptor::init(context);
         crate::stdlib::_typing::init(context);
+
+        // RustPython specific
+        crate::function::method::init(context);
     }
 }


### PR DESCRIPTION
<!--
Thanks for your contribution!
-->

- [x] ref #7611 <!-- Replace xxxx with the GitHub issue number -->
- [x] This PR follows our [AI policy](https://github.com/RustPython/.github/blob/main/AI_POLICY.md)

## Summary
<!-- What's the purpose of the change? What does it do, and why? -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced virtual machine startup by improving class and method definition registration mechanisms.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->