### PR TITLE
dependabot check daily

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,7 +6,7 @@ updates:
       - "/"
       - "crates/*"
     schedule:
-      interval: weekly
+      interval: daily
     cooldown:
       default-days: 7
       semver-major-days: 30
@@ -157,13 +157,13 @@ updates:
   - package-ecosystem: github-actions
     directory: /
     schedule:
-      interval: weekly
+      interval: daily
     cooldown:
       default-days: 7
   - package-ecosystem: npm
     directory: /
     schedule:
-      interval: weekly
+      interval: daily
     cooldown:
       default-days: 7
       semver-major-days: 30
@@ -172,6 +172,6 @@ updates:
   - package-ecosystem: pre-commit
     directory: /
     schedule:
-      interval: weekly
+      interval: daily
     cooldown:
       default-days: 7


### PR DESCRIPTION
<!--
Thanks for your contribution!
-->

- [ ] Closes #xxxx <!-- Replace xxxx with the GitHub issue number -->
- [ ] This PR follows our [AI policy](https://github.com/RustPython/.github/blob/main/AI_POLICY.md)

## Summary
<!-- What's the purpose of the change? What does it do, and why? -->

Since we introduced a wait cooldown at https://github.com/RustPython/RustPython/pull/7490 dependabot is "storing" updates and not opening the PRs when the cooldown expires since it runs once a week.

By switching to `daily`I hope dependabot will open PRs sporadically throughout the week and not in bulk, and reduce the number of times the CI chokes