### PR TITLE
Use `stable` toolchain when updating caches

### DIFF
--- a/.github/workflows/update-caches.yml
+++ b/.github/workflows/update-caches.yml
@@ -46,7 +46,7 @@ jobs:
           persist-credentials: false
 
       - name: Setup Rust
-        uses: dtolnay/rust-toolchain@3c5f7ea28cd621ae0bf5283f0e981fb97b8a7af9
+        uses: dtolnay/rust-toolchain@stable
         with:
           toolchain: ${{ matrix.toolchain }}
           target: ${{ matrix.target }}


### PR DESCRIPTION
<!--
Thanks for your contribution!
-->

- [x] Closes  #8148 <!-- Replace xxxx with the GitHub issue number -->
- [x] This PR follows our [AI policy](https://github.com/RustPython/.github/blob/main/AI_POLICY.md)

## Summary
<!-- What's the purpose of the change? What does it do, and why? -->

It should match what we use in our main CI workflow

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CI/CD workflow toolchain configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->