### PR TITLE
Add allocator functions to c-api

### DIFF
--- a/.cspell.dict/cpython.txt
+++ b/.cspell.dict/cpython.txt
@@ -192,6 +192,7 @@ pyerrors
 Pyfunc
 pylifecycle
 pymain
+pymem
 pyrepl
 pystate
 PYTHONTRACEMALLOC

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3447,6 +3447,7 @@ version = "0.5.0"
 dependencies = [
  "bitflags 2.13.0",
  "itertools 0.14.0",
+ "libc",
  "num-complex",
  "pyo3",
  "rustpython-pylib",

--- a/crates/capi/Cargo.toml
+++ b/crates/capi/Cargo.toml
@@ -14,6 +14,7 @@ crate-type = ["cdylib", "rlib"]
 [dependencies]
 bitflags = { workspace = true }
 itertools = { workspace = true }
+libc = { workspace = true }
 num-complex = { workspace = true }
 rustpython-vm = { workspace = true, features = ["threading", "compiler", "importlib", "host_env"] }
 rustpython-stdlib = {workspace = true, features = ["threading"] }

--- a/crates/capi/src/lib.rs
+++ b/crates/capi/src/lib.rs
@@ -26,6 +26,7 @@ pub mod object;
 pub mod pycapsule;
 pub mod pyerrors;
 pub mod pylifecycle;
+pub mod pymem;
 pub mod pystate;
 pub mod refcount;
 pub mod setobject;

--- a/crates/capi/src/pymem.rs
+++ b/crates/capi/src/pymem.rs
@@ -1,0 +1,46 @@
+use core::ffi::c_void;
+
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn PyMem_Malloc(n: usize) -> *mut c_void {
+    unsafe { libc::malloc(if n == 0 { 1 } else { n }) }
+}
+
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn PyMem_Calloc(nelem: usize, elsize: usize) -> *mut c_void {
+    unsafe {
+        libc::calloc(
+            if nelem == 0 || elsize == 0 { 1 } else { nelem },
+            if nelem == 0 || elsize == 0 { 1 } else { elsize },
+        )
+    }
+}
+
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn PyMem_Realloc(ptr: *mut c_void, new_size: usize) -> *mut c_void {
+    unsafe { libc::realloc(ptr, if new_size == 0 { 1 } else { new_size }) }
+}
+
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn PyMem_Free(ptr: *mut c_void) {
+    unsafe { libc::free(ptr) }
+}
+
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn PyMem_RawMalloc(n: usize) -> *mut c_void {
+    unsafe { libc::malloc(n) }
+}
+
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn PyMem_RawCalloc(nelem: usize, elsize: usize) -> *mut c_void {
+    unsafe { libc::calloc(nelem, elsize) }
+}
+
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn PyMem_RawRealloc(ptr: *mut c_void, new_size: usize) -> *mut c_void {
+    unsafe { libc::realloc(ptr, new_size) }
+}
+
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn PyMem_RawFree(ptr: *mut c_void) {
+    unsafe { libc::free(ptr) }
+}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Python-compatible C API memory allocation/free entry points, including both standard and “raw” variants.
  * Standard variants normalize zero-size allocation requests, while raw variants pass sizes through directly.

* **Chores**
  * Updated the spelling dictionary to recognize the new term introduced by these changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->