### PR TITLE
Uncomment codegen crashing tests

### DIFF
--- a/Lib/test/test_grammar.py
+++ b/Lib/test/test_grammar.py
@@ -1723,8 +1723,7 @@ class GrammarTests(unittest.TestCase):
         class H: pass
         @d := class_decorator
         class I: pass
-        # TODO: RUSTPYTHON; SyntaxError: the symbol 'class_decorator' must be present in the symbol table
-        # @lambda c: class_decorator(c)
+        @lambda c: class_decorator(c)
         class J: pass
         @[..., class_decorator, ...][1]
         class K: pass

--- a/Lib/test/test_listcomps.py
+++ b/Lib/test/test_listcomps.py
@@ -206,11 +206,9 @@ class ListComprehensionTest(unittest.TestCase):
         """
         self._check_in_scopes(code, raises=NameError)
 
-    @unittest.expectedFailure  # TODO: RUSTPYTHON; SyntaxError: compiler_make_closure: cannot find '__classdict__' in parent vars
     def test_references___classdict___nested(self):
         class _C:
-            # res = [(lambda: __classdict__)() for _ in [1]]  # TODO: RUSTPYTHON
-            pass  # TODO: RUSTPYTHON
+            res = [(lambda: __classdict__)() for _ in [1]]
         self.assertIn("res", _C.res[0])
 
     def test_references___conditional_annotations__(self):

--- a/Lib/test/test_patma.py
+++ b/Lib/test/test_patma.py
@@ -6,6 +6,7 @@ import enum
 import inspect
 import sys
 import unittest
+from test import support
 
 
 @dataclasses.dataclass
@@ -2563,15 +2564,14 @@ class TestPatma(unittest.TestCase):
         self.assertEqual(y, 0)
         self.assertEqual(z, {0: 1})
 
-    # TODO: RUSTPYTHON
-    # def test_patma_241(self):
-    #     x = [[{0: 0}]]
-    #     match x:
-    #         case list([({-0-0j: int(real=0+0j, imag=0-0j) | (1) as z},)]):
-    #             y = 0
-    #     self.assertEqual(x, [[{0: 0}]])
-    #     self.assertEqual(y, 0)
-    #     self.assertEqual(z, 0)
+    def test_patma_241(self):
+        x = [[{0: 0}]]
+        match x:
+            case list([({-0-0j: int(real=0+0j, imag=0-0j) | (1) as z},)]):
+                y = 0
+        self.assertEqual(x, [[{0: 0}]])
+        self.assertEqual(y, 0)
+        self.assertEqual(z, 0)
 
     def test_patma_242(self):
         x = range(3)
@@ -3013,6 +3013,13 @@ class TestSyntaxErrors(unittest.TestCase):
         self.assert_syntax_error("""
         match ...:
             case a as a:
+                pass
+        """)
+
+    def test_multiple_assignments_to_name_in_pattern_6(self):
+        self.assert_syntax_error("""
+        match ...:
+            case a as a + 1:  # NAME and expression with no ()
                 pass
         """)
 
@@ -3492,6 +3499,7 @@ class TestTracing(unittest.TestCase):
         self.assertListEqual(self._trace(f, 1), [1, 2, 3])
         self.assertListEqual(self._trace(f, 0), [1, 2, 5, 6])
 
+    @support.skip_wasi_stack_overflow()
     def test_parser_deeply_nested_patterns(self):
         # Deeply nested patterns can cause exponential backtracking when parsing.
         # See gh-93671 for more information.

--- a/Lib/test/test_pep646_syntax.py
+++ b/Lib/test/test_pep646_syntax.py
@@ -321,8 +321,7 @@ is *not* valid syntax.)
 __test__ = {'doctests' : doctests}
 
 def load_tests(loader, tests, pattern):
-    from test.support.rustpython import DocTestChecker  # TODO: RUSTPYTHON
-    tests.addTest(doctest.DocTestSuite(checker=DocTestChecker())) # TODO: RUSTPYTHON
+    tests.addTest(doctest.DocTestSuite())
     return tests
 
 

--- a/Lib/test/test_super.py
+++ b/Lib/test/test_super.py
@@ -112,7 +112,7 @@ class TestSuper(unittest.TestCase):
                     __class__""", globals(), {})
         self.assertIs(type(e.exception), NameError) # Not UnboundLocalError
         class X:
-            # global __class__  # TODO: RUSTPYTHON; SyntaxError: name '__class__' is assigned to before global declaration
+            global __class__
             __class__ = 42
             def f():
                 __class__
@@ -120,7 +120,7 @@ class TestSuper(unittest.TestCase):
         del globals()["__class__"]
         self.assertNotIn("__class__", X.__dict__)
         class X:
-            # nonlocal __class__  # TODO: RUSTPYTHON; SyntaxError: name '__class__' is assigned to before nonlocal declaration
+            nonlocal __class__
             __class__ = 42
             def f():
                 __class__


### PR DESCRIPTION
<!--
Thanks for your contribution!
-->

- [ ] Closes #xxxx <!-- Replace xxxx with the GitHub issue number -->
- [ ] This PR follows our [AI policy](https://github.com/RustPython/.github/blob/main/AI_POLICY.md)

## Summary
<!-- What's the purpose of the change? What does it do, and why? -->

These tests were causing RustPython to crash during the codegen phase, which is no longer the case

These no longer crash RustPython after https://github.com/RustPython/RustPython/pull/8138 (most likely)