### PR TITLE
Align ellipsis type name with CPython

### DIFF
--- a/crates/vm/src/builtins/slice.rs
+++ b/crates/vm/src/builtins/slice.rs
@@ -369,7 +369,7 @@ impl Representable for PySlice {
     }
 }
 
-#[pyclass(module = false, name = "EllipsisType")]
+#[pyclass(module = false, name = "ellipsis")]
 #[derive(Debug)]
 pub struct PyEllipsis;
 


### PR DESCRIPTION
## Summary

- Rename the `PyEllipsis` type's `tp_name` from `EllipsisType` to `ellipsis` so `type(...).__name__` and `repr(type(...))` match CPython.
- `types.EllipsisType is type(...)` continues to hold; only the visible type name changes.

## Test plan

- [ ] `type(...).__name__` prints `ellipsis`
- [ ] `repr(type(...))` is `<class 'ellipsis'>`
- [ ] `types.EllipsisType is type(...)` is `True`
- [ ] CI passes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the displayed Python class name for `Ellipsis` from `EllipsisType` to `ellipsis`, improving consistency with expected Python-side naming.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->