### PR TITLE
Fix README demo script reference

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ needed to prevent stack overflow on Windows):
 
 ```bash
 $ cd RustPython
-$ cargo run --release demo_closures.py
+$ cargo run --release demo_hello.py
 Hello, RustPython!
 ```
 

--- a/demo_hello.py
+++ b/demo_hello.py
@@ -1,0 +1,1 @@
+print("Hello, RustPython!")


### PR DESCRIPTION
## Summary

- Add a minimal `demo_hello.py` that prints the greeting shown in the README.
- Update the usage section to run that script instead of a missing demo file.

## Test plan

- [ ] `cargo run --release demo_hello.py` prints `Hello, RustPython!`
- [ ] README no longer references a non-existent demo script

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a simple demo script that prints `Hello, RustPython!` when run.

* **Documentation**
  * Updated the local demo instructions to use the new hello-world example instead of the previous demo command.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->