### PR TITLE
Prefer crates.io install in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ NOTE: For windows users, please set `RUSTPYTHONPATH` environment variable as `Li
 You can also install and run RustPython with the following:
 
 ```bash
-$ cargo install --git https://github.com/RustPython/RustPython rustpython
+$ cargo install rustpython
 $ rustpython
 Welcome to the magnificent Rust Python interpreter
 >>>>>


### PR DESCRIPTION
## Summary

- Change the primary install command in the README from a git-based `cargo install` to `cargo install rustpython` from crates.io.
- Avoids Windows path-length failures and documents the supported install path for most users.

## Test plan

- [ ] README install section uses `cargo install rustpython`
- [ ] `cargo install rustpython` still installs a runnable binary on supported platforms

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the installation instructions to use a simpler Cargo command for installing RustPython directly.
  * No other usage steps or guidance were changed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->