### PR TITLE
Enforce integer digit limit in native JSON scanner

### DIFF
--- a/crates/stdlib/src/json.rs
+++ b/crates/stdlib/src/json.rs
@@ -243,6 +243,20 @@ mod _json {
             } else if let Some(ref parse_int) = self.parse_int {
                 parse_int.call((buf,), vm)
             } else {
+                // Honor sys.int_max_str_digits (PEP 651), matching CPython's
+                // PyLong_FromString path used by Modules/_json.c.
+                let digit_limit = vm.state.int_max_str_digits.load();
+                if digit_limit != 0 {
+                    let digits = buf.strip_prefix('-').unwrap_or(buf).len();
+                    if digits > digit_limit {
+                        return Some((
+                            Err(vm.new_value_error(format!(
+                                "Exceeds the limit ({digit_limit} digits) for integer string conversion: value has {digits} digits"
+                            ))),
+                            buf.len(),
+                        ));
+                    }
+                }
                 Ok(vm.new_pyobj(BigInt::from_str(buf).unwrap()))
             };
             Some((ret, buf.len()))


### PR DESCRIPTION
## Summary

- Make the native `_json` scanner respect `sys.get_int_max_str_digits()` / `sys.set_int_max_str_digits()` when decoding integer literals.
- Over-long integers now raise `ValueError` with the same style of message as other integer string conversions, aligning with CPython's accelerated JSON decoder.

## Test plan

- [ ] With `sys.set_int_max_str_digits(5000)`, `json.loads('1' * 5001)` raises `ValueError`
- [ ] With the limit at `0` (unlimited), large integers still decode
- [ ] Normal small integers and floats are unchanged
- [ ] CI passes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Integer parsing now respects the configured digit limit and raises an error when a number is too long.
  * Error messages now clearly report the digit limit and the size of the parsed number.
  * Floating-point number handling remains unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->