### PR TITLE
Set python args to be like CPython in CI

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -296,6 +296,7 @@ jobs:
           extra_test_args:
             - '-u all'
             - '--timeout 600'
+            - '--dont-add-python-opts'
           env_polluting_tests:
             - test_set
           skips: []
@@ -304,6 +305,7 @@ jobs:
           extra_test_args:
             - '-u all'
             - '--timeout 600'
+            - '--dont-add-python-opts'
           env_polluting_tests:
             - test_set
           skips: []
@@ -312,6 +314,7 @@ jobs:
           extra_test_args:
             - '-u all'
             - '--timeout 600'
+            - '--dont-add-python-opts'
           env_polluting_tests:
             - test_set
           skips: []
@@ -399,7 +402,7 @@ jobs:
           for thing in "${target_array[@]}"; do
             for i in $(seq 1 10); do
               set +e
-              target/release/rustpython -u -m test --slow-ci -u all -j 1 --timeout 600 "${thing}"
+              target/release/rustpython -u -m test --slow-ci -u all -j 1 --timeout 600 --dont-add-python-opts "${thing}"
               exit_code=$?
               set -e
               if [ "${exit_code}" -eq 3 ]; then

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -295,6 +295,7 @@ jobs:
         - os: macos-latest
           extra_test_args:
             - '-u all'
+            - '--timeout 600'
           env_polluting_tests:
             - test_set
           skips: []
@@ -302,6 +303,7 @@ jobs:
         - os: ubuntu-latest
           extra_test_args:
             - '-u all'
+            - '--timeout 600'
           env_polluting_tests:
             - test_set
           skips: []
@@ -309,6 +311,7 @@ jobs:
         - os: windows-2025
           extra_test_args:
             - '-u all'
+            - '--timeout 600'
           env_polluting_tests:
             - test_set
           skips: []
@@ -360,7 +363,7 @@ jobs:
 
       - name: Run CPython tests
         run: |
-          target/release/rustpython -u -m test -j ${{ steps.cores.outputs.cores }} ${{ join(matrix.extra_test_args, ' ') }} --slowest --fail-env-changed --timeout 600 -x ${{ env.FLAKY_MP_TESTS }} ${{ join(matrix.skips, ' ') }}
+          target/release/rustpython -u -m test --slow-ci -j ${{ steps.cores.outputs.cores }} ${{ join(matrix.extra_test_args, ' ') }} -x ${{ env.FLAKY_MP_TESTS }} ${{ join(matrix.skips, ' ') }}
         timeout-minutes: ${{ matrix.timeout }}
         env:
           RUSTPYTHON_SKIP_ENV_POLLUTERS: true
@@ -371,7 +374,7 @@ jobs:
             echo "::group::Attempt ${attempt}"
 
             set +e
-            target/release/rustpython -u -m test -j 1 ${{ join(matrix.extra_test_args, ' ') }} --slowest --fail-env-changed --timeout 600 ${{ env.FLAKY_MP_TESTS }}
+            target/release/rustpython -u -m test --slow-ci -j 1 ${{ join(matrix.extra_test_args, ' ') }} ${{ env.FLAKY_MP_TESTS }}
             status=$?
             set -e
 
@@ -396,7 +399,7 @@ jobs:
           for thing in "${target_array[@]}"; do
             for i in $(seq 1 10); do
               set +e
-              target/release/rustpython -u -m test -j 1 --slowest --fail-env-changed --timeout 600 "${thing}"
+              target/release/rustpython -u -m test --slow-ci -u all -j 1 --timeout 600 "${thing}"
               exit_code=$?
               set -e
               if [ "${exit_code}" -eq 3 ]; then

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -34,6 +34,7 @@ env:
   CARGO_PROFILE_RELEASE_DEBUG: 0
   CARGO_TERM_COLOR: always
   CI: true
+  FORCE_COLOR: 1
 
 jobs:
   determine_changes:
@@ -359,7 +360,7 @@ jobs:
 
       - name: Run CPython tests
         run: |
-          target/release/rustpython -m test -j ${{ steps.cores.outputs.cores }} ${{ join(matrix.extra_test_args, ' ') }} --slowest --fail-env-changed --timeout 600 -v -x ${{ env.FLAKY_MP_TESTS }} ${{ join(matrix.skips, ' ') }}
+          target/release/rustpython -u -m test -j ${{ steps.cores.outputs.cores }} ${{ join(matrix.extra_test_args, ' ') }} --slowest --fail-env-changed --timeout 600 -x ${{ env.FLAKY_MP_TESTS }} ${{ join(matrix.skips, ' ') }}
         timeout-minutes: ${{ matrix.timeout }}
         env:
           RUSTPYTHON_SKIP_ENV_POLLUTERS: true
@@ -370,7 +371,7 @@ jobs:
             echo "::group::Attempt ${attempt}"
 
             set +e
-            target/release/rustpython -m test -j 1 ${{ join(matrix.extra_test_args, ' ') }} --slowest --fail-env-changed --timeout 600 -v ${{ env.FLAKY_MP_TESTS }}
+            target/release/rustpython -u -m test -j 1 ${{ join(matrix.extra_test_args, ' ') }} --slowest --fail-env-changed --timeout 600 ${{ env.FLAKY_MP_TESTS }}
             status=$?
             set -e
 
@@ -395,7 +396,7 @@ jobs:
           for thing in "${target_array[@]}"; do
             for i in $(seq 1 10); do
               set +e
-              target/release/rustpython -m test -j 1 --slowest --fail-env-changed --timeout 600 -v "${thing}"
+              target/release/rustpython -u -m test -j 1 --slowest --fail-env-changed --timeout 600 "${thing}"
               exit_code=$?
               set -e
               if [ "${exit_code}" -eq 3 ]; then

--- a/Lib/test/test_future_stmt/test_future.py
+++ b/Lib/test/test_future_stmt/test_future.py
@@ -177,7 +177,6 @@ class FutureTest(unittest.TestCase):
         exec("from __future__ import unicode_literals; x = ''", {}, scope)
         self.assertIsInstance(scope["x"], str)
 
-    @unittest.expectedFailure  # TODO: RUSTPYTHON; barry_as_FLUFL (<> operator) not supported
     def test_syntactical_future_repl(self):
         p = spawn_python('-i')
         p.stdin.write(b"from __future__ import barry_as_FLUFL\n")


### PR DESCRIPTION
<!--
Thanks for your contribution!
-->

- [ ] Closes #xxxx <!-- Replace xxxx with the GitHub issue number -->
- [ ] This PR follows our [AI policy](https://github.com/RustPython/.github/blob/main/AI_POLICY.md)

## Summary
<!-- What's the purpose of the change? What does it do, and why? -->

I've recently made some patches to CPython, and noticed that their CI output is less noisy. made it easier to find the failing tests

lmk what you think

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **Tests**
  * Updated CI CPython and flaky retry runs to use standardized test execution flags (`-m test --slow-ci`) for more consistent coverage.
  * Centralized timeout and related runtime settings in the job matrix to improve reliability and reduce command-level variance.
  * Adjusted the environment “polluters” verification loop to follow the same standardized test behavior.
* **Chores**
  * Enabled consistent colored output in CI logs via a workflow-level setting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->