### PR TITLE
Fix csv.writer QUOTE_NONE with quotechar=None

### DIFF
--- a/Lib/test/test_csv.py
+++ b/Lib/test/test_csv.py
@@ -854,7 +854,6 @@ class EscapedExcel(csv.excel):
 class TestEscapedExcel(TestCsvBase):
     dialect = EscapedExcel()
 
-    @unittest.expectedFailure  # TODO: RUSTPYTHON
     def test_escape_fieldsep(self):
         self.writerAssertEqual([['abc,def']], 'abc\\,def\r\n')
 

--- a/crates/stdlib/src/csv.rs
+++ b/crates/stdlib/src/csv.rs
@@ -910,12 +910,8 @@ mod _csv {
                 writer = writer.delimiter(t);
             }
 
-            if let Some(t) = self.quotechar {
-                if let Some(u) = t {
-                    writer = writer.quote(u);
-                } else {
-                    todo!()
-                }
+            if let Some(Some(t)) = self.quotechar {
+                writer = writer.quote(t);
             }
 
             if let Some(t) = self.doublequote {
@@ -1148,6 +1144,24 @@ mod _csv {
         Ok(())
     }
 
+    fn write_unquoted_field(
+        output: &mut Vec<u8>,
+        data: &[u8],
+        dialect: PyDialect,
+        vm: &VirtualMachine,
+    ) -> PyResult<()> {
+        for &byte in data {
+            if field_needs_escape(byte, dialect) {
+                let escapechar = dialect
+                    .escapechar
+                    .ok_or_else(|| new_csv_error(vm, "need to escape, but no escapechar set"))?;
+                output.push(escapechar);
+            }
+            output.push(byte);
+        }
+        Ok(())
+    }
+
     fn field_needs_quotes(data: &[u8], dialect: PyDialect) -> bool {
         data.iter().any(|&byte| {
             byte == dialect.delimiter
@@ -1155,6 +1169,14 @@ mod _csv {
                 || matches!(byte, b'\r' | b'\n')
                 || matches!(dialect.lineterminator, Terminator::Any(t) if byte == t)
         })
+    }
+
+    fn field_needs_escape(byte: u8, dialect: PyDialect) -> bool {
+        byte == dialect.delimiter
+            || dialect.quotechar == Some(byte)
+            || dialect.escapechar == Some(byte)
+            || matches!(byte, b'\r' | b'\n')
+            || matches!(dialect.lineterminator, Terminator::Any(t) if byte == t)
     }
 
     fn write_lineterminator(output: &mut Vec<u8>, terminator: Terminator) {
@@ -1222,8 +1244,59 @@ mod _csv {
             self.write.call((s,), vm)
         }
 
+        fn writerow_quote_none(&self, row: PyObjectRef, vm: &VirtualMachine) -> PyResult {
+            let _state = self.state.lock();
+
+            let row: ArgIterable = ArgIterable::try_from_object(vm, row.clone()).map_err(|_e| {
+                new_csv_error(
+                    vm,
+                    format!("'{}' object is not iterable", row.class().name()),
+                )
+            })?;
+
+            let fields = row.iter(vm)?.collect::<PyResult<Vec<_>>>()?;
+            let single_field = fields.len() == 1;
+            let mut output = Vec::new();
+
+            for (index, field) in fields.into_iter().enumerate() {
+                if index > 0 {
+                    output.push(self.dialect.delimiter);
+                }
+
+                let stringified;
+                let data: &[u8] = match_class!(match field {
+                    ref s @ PyStr => s.as_bytes(),
+                    crate::builtins::PyNone => b"",
+                    ref obj => {
+                        stringified = obj.str(vm)?;
+                        stringified.as_bytes()
+                    }
+                });
+
+                if single_field && data.is_empty() {
+                    return Err(new_csv_error(
+                        vm,
+                        "single empty field record must be quoted",
+                    ));
+                }
+
+                write_unquoted_field(&mut output, data, self.dialect, vm)?;
+            }
+
+            write_lineterminator(&mut output, self.dialect.lineterminator);
+
+            let s = core::str::from_utf8(&output)
+                .map_err(|_| vm.new_unicode_decode_error("csv not utf8"))?;
+
+            self.write.call((s,), vm)
+        }
+
         #[pymethod]
         fn writerow(&self, row: PyObjectRef, vm: &VirtualMachine) -> PyResult {
+            if matches!(self.dialect.quoting, QuoteStyle::None) {
+                return self.writerow_quote_none(row, vm);
+            }
+
             if matches!(
                 self.dialect.quoting,
                 QuoteStyle::Strings | QuoteStyle::Notnull

--- a/crates/stdlib/src/csv.rs
+++ b/crates/stdlib/src/csv.rs
@@ -1293,15 +1293,12 @@ mod _csv {
 
         #[pymethod]
         fn writerow(&self, row: PyObjectRef, vm: &VirtualMachine) -> PyResult {
-            if matches!(self.dialect.quoting, QuoteStyle::None) {
-                return self.writerow_quote_none(row, vm);
-            }
-
-            if matches!(
-                self.dialect.quoting,
-                QuoteStyle::Strings | QuoteStyle::Notnull
-            ) {
-                return self.writerow_quoted_strings(row, vm);
+            match self.dialect.quoting {
+                QuoteStyle::None => return self.writerow_quote_none(row, vm),
+                QuoteStyle::Strings | QuoteStyle::Notnull => {
+                    return self.writerow_quoted_strings(row, vm);
+                }
+                _ => {}
             }
 
             let mut state = self.state.lock();

--- a/extra_tests/snippets/stdlib_csv.py
+++ b/extra_tests/snippets/stdlib_csv.py
@@ -72,3 +72,56 @@ def test_quote_strings_and_notnull_writer():
 
 
 test_quote_strings_and_notnull_writer()
+
+
+def test_quote_none_writer_without_quotechar():
+    no_quotechar_buf = io.StringIO()
+    csv.writer(
+        no_quotechar_buf,
+        quoting=csv.QUOTE_NONE,
+        quotechar=None,
+        escapechar="\\",
+    ).writerow(["a,b", 'x"y'])
+    assert no_quotechar_buf.getvalue() == 'a\\,b,x"y\r\n'
+
+    default_quotechar_buf = io.StringIO()
+    csv.writer(
+        default_quotechar_buf,
+        quoting=csv.QUOTE_NONE,
+        escapechar="\\",
+    ).writerow(["a,b", 'x"y'])
+    assert default_quotechar_buf.getvalue() == 'a\\,b,x\\"y\r\n'
+
+    escapechar_buf = io.StringIO()
+    csv.writer(
+        escapechar_buf,
+        quoting=csv.QUOTE_NONE,
+        quotechar=None,
+        escapechar="\\",
+    ).writerow(["a\\b"])
+    assert escapechar_buf.getvalue() == "a\\\\b\r\n"
+
+    with assert_raises(csv.Error):
+        csv.writer(io.StringIO(), quoting=csv.QUOTE_NONE, quotechar=None).writerow(
+            ["a,b"]
+        )
+
+    with assert_raises(csv.Error):
+        csv.writer(
+            io.StringIO(),
+            quoting=csv.QUOTE_NONE,
+            quotechar=None,
+            escapechar="\\",
+        ).writerow([None])
+
+    two_empty_buf = io.StringIO()
+    csv.writer(
+        two_empty_buf,
+        quoting=csv.QUOTE_NONE,
+        quotechar=None,
+        escapechar="\\",
+    ).writerow([None, ""])
+    assert two_empty_buf.getvalue() == ",\r\n"
+
+
+test_quote_none_writer_without_quotechar()

--- a/extra_tests/snippets/stdlib_csv.py
+++ b/extra_tests/snippets/stdlib_csv.py
@@ -101,6 +101,15 @@ def test_quote_none_writer_without_quotechar():
     ).writerow(["a\\b"])
     assert escapechar_buf.getvalue() == "a\\\\b\r\n"
 
+    linebreak_buf = io.StringIO()
+    csv.writer(
+        linebreak_buf,
+        quoting=csv.QUOTE_NONE,
+        quotechar=None,
+        escapechar="\\",
+    ).writerow(["a\rb", "c\nd"])
+    assert linebreak_buf.getvalue() == "a\\\rb,c\\\nd\r\n"
+
     with assert_raises(csv.Error):
         csv.writer(io.StringIO(), quoting=csv.QUOTE_NONE, quotechar=None).writerow(
             ["a,b"]


### PR DESCRIPTION
<!--
Thanks for your contribution!
-->

- [x] Closes #8200
- [x] This PR follows our [AI policy](https://github.com/RustPython/.github/blob/main/AI_POLICY.md)

## Summary

Fixes `csv.writer` with `quoting=csv.QUOTE_NONE` and `quotechar=None`.

## Problem

This case should match CPython:

```python
'a\\,b,x"y\r\n'
```

RustPython accepted the dialect, but reached an internal `todo!()` path and panicked while writing the row.

## Fixes

1. Skip csv-core quote character configuration when `quotechar=None`.
2. Add a `QUOTE_NONE` writer path that escapes fields without quoting them.
3. Match CPython behavior for missing `escapechar` and single empty fields.
4. Add regression coverage in `extra_tests/snippets/stdlib_csv.py`.

## Testing

- Verified the reproducer no longer panics.
- Verified `test_csv` behavior locally.
- Verified the new `stdlib_csv` regression.
- Verified formatting, lint, pre-commit hooks, and workspace tests before opening the PR.

## AI use

Assisted by Codex:gpt-5.5 for implementation, test drafting, verification. I reviewed and verified the changes locally.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved CSV writing when using `QUOTE_NONE` with no quote character, including correct escaping of commas, quotes, backslashes, and line breaks.
  * CSV output now handles empty fields more consistently and preserves expected validation errors for invalid writer settings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
