### PR TITLE
unicodedata: No alloc is_normalized

### DIFF
--- a/crates/stdlib/src/unicodedata.rs
+++ b/crates/stdlib/src/unicodedata.rs
@@ -339,30 +339,20 @@ mod unicodedata {
 
         #[pymethod]
         fn is_normalized(&self, form: super::NormalizeForm, unistr: PyStrRef) -> bool {
-            let text = unistr.as_wtf8();
-            let normalized: Wtf8Buf = match form {
+            match form {
                 NormalizeForm::Nfc => {
-                    let normalizer = ComposingNormalizerBorrowed::new_nfc();
-                    text.map_utf8(|s| normalizer.normalize_iter(s.chars()))
-                        .collect()
+                    ComposingNormalizerBorrowed::new_nfc().is_normalized_utf8(unistr.as_bytes())
                 }
                 NormalizeForm::Nfkc => {
-                    let normalizer = ComposingNormalizerBorrowed::new_nfkc();
-                    text.map_utf8(|s| normalizer.normalize_iter(s.chars()))
-                        .collect()
+                    ComposingNormalizerBorrowed::new_nfkc().is_normalized_utf8(unistr.as_bytes())
                 }
                 NormalizeForm::Nfd => {
-                    let normalizer = DecomposingNormalizerBorrowed::new_nfd();
-                    text.map_utf8(|s| normalizer.normalize_iter(s.chars()))
-                        .collect()
+                    DecomposingNormalizerBorrowed::new_nfd().is_normalized_utf8(unistr.as_bytes())
                 }
                 NormalizeForm::Nfkd => {
-                    let normalizer = DecomposingNormalizerBorrowed::new_nfkd();
-                    text.map_utf8(|s| normalizer.normalize_iter(s.chars()))
-                        .collect()
+                    DecomposingNormalizerBorrowed::new_nfkd().is_normalized_utf8(unistr.as_bytes())
                 }
-            };
-            text == &*normalized
+            }
         }
 
         #[pymethod]


### PR DESCRIPTION
`icu4x` supports checking if a string is normalized without allocation.

<!--
Thanks for your contribution!
-->

- [ ] Closes #xxxx <!-- Replace xxxx with the GitHub issue number -->
- [x] This PR follows our [AI policy](https://github.com/RustPython/.github/blob/main/AI_POLICY.md)

## Summary
<!-- What's the purpose of the change? What does it do, and why? -->

* Remove a needless heap allocation
* Cleaner code

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Unicode normalization checks to use a direct normalized-state test, making `is_normalized` more efficient while preserving the same results for NFC, NFKC, NFD, and NFKD.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->