### PR TITLE
unicodedata: One pass normalizer

### DIFF
--- a/crates/stdlib/src/unicodedata.rs
+++ b/crates/stdlib/src/unicodedata.rs
@@ -312,29 +312,22 @@ mod unicodedata {
 
         #[pymethod]
         fn normalize(&self, form: super::NormalizeForm, unistr: PyStrRef) -> Wtf8Buf {
-            let text = unistr.as_wtf8();
             match form {
                 NormalizeForm::Nfc => {
-                    let normalizer = ComposingNormalizerBorrowed::new_nfc();
-                    text.map_utf8(|s| normalizer.normalize_iter(s.chars()))
-                        .collect()
+                    ComposingNormalizerBorrowed::new_nfc().normalize_utf8(unistr.as_bytes())
                 }
                 NormalizeForm::Nfkc => {
-                    let normalizer = ComposingNormalizerBorrowed::new_nfkc();
-                    text.map_utf8(|s| normalizer.normalize_iter(s.chars()))
-                        .collect()
+                    ComposingNormalizerBorrowed::new_nfkc().normalize_utf8(unistr.as_bytes())
                 }
                 NormalizeForm::Nfd => {
-                    let normalizer = DecomposingNormalizerBorrowed::new_nfd();
-                    text.map_utf8(|s| normalizer.normalize_iter(s.chars()))
-                        .collect()
+                    DecomposingNormalizerBorrowed::new_nfd().normalize_utf8(unistr.as_bytes())
                 }
                 NormalizeForm::Nfkd => {
-                    let normalizer = DecomposingNormalizerBorrowed::new_nfkd();
-                    text.map_utf8(|s| normalizer.normalize_iter(s.chars()))
-                        .collect()
+                    DecomposingNormalizerBorrowed::new_nfkd().normalize_utf8(unistr.as_bytes())
                 }
             }
+            .to_string()
+            .into()
         }
 
         #[pymethod]


### PR DESCRIPTION
Currently, `normalize()` is a two pass operation. The string is chunked by surrogates, then each valid chunk is normalized. `icu4x` supports directly normalizing bytes without passing through the valid string slice twice.

<!--
Thanks for your contribution!
-->

- [ ] Closes #xxxx <!-- Replace xxxx with the GitHub issue number -->
- [x] This PR follows our [AI policy](https://github.com/RustPython/.github/blob/main/AI_POLICY.md)

## Summary
<!-- What's the purpose of the change? What does it do, and why? -->

* Clean up and simplify `unicodedata.normalize`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Unicode normalization handling for text input, with more direct processing of encoded data.
  * Normalization results are now returned more reliably across supported normalization modes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->