### PR TITLE
Add pyframe functions to c-api

### DIFF
--- a/.cspell.dict/cpython.txt
+++ b/.cspell.dict/cpython.txt
@@ -191,6 +191,7 @@ pycore
 pyinner
 pydecimal
 pyerrors
+pyframe
 Pyfunc
 pylifecycle
 pymain

--- a/crates/capi/src/lib.rs
+++ b/crates/capi/src/lib.rs
@@ -28,6 +28,7 @@ pub mod object;
 pub mod osmodule;
 pub mod pycapsule;
 pub mod pyerrors;
+pub mod pyframe;
 pub mod pylifecycle;
 pub mod pymem;
 pub mod pystate;

--- a/crates/capi/src/pyframe.rs
+++ b/crates/capi/src/pyframe.rs
@@ -1,0 +1,24 @@
+use crate::PyObject;
+use crate::pystate::with_vm;
+use rustpython_vm::frame::Frame;
+
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn PyFrame_GetCode(frame: *mut PyObject) -> *mut PyObject {
+    with_vm(|vm| {
+        let frame = unsafe { &*frame }.try_downcast_ref::<Frame>(vm)?;
+        Ok(frame.code.clone())
+    })
+}
+
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn PyFrame_GetLineNumber(frame: *mut PyObject) -> core::ffi::c_int {
+    with_vm(|vm| {
+        let frame = unsafe { &*frame }.try_downcast_ref::<Frame>(vm)?;
+        let lineno = if frame.lasti() == 0 {
+            frame.code.first_line_number.map_or(1, |n| n.get())
+        } else {
+            frame.current_location().line.get()
+        };
+        Ok(lineno as core::ffi::c_int)
+    })
+}

--- a/crates/capi/src/pyframe.rs
+++ b/crates/capi/src/pyframe.rs
@@ -6,7 +6,7 @@ use rustpython_vm::frame::Frame;
 pub unsafe extern "C" fn PyFrame_GetCode(frame: *mut PyObject) -> *mut PyObject {
     with_vm(|vm| {
         let frame = unsafe { &*frame }.try_downcast_ref::<Frame>(vm)?;
-        Ok(frame.code.clone())
+        Ok(frame.f_code())
     })
 }
 
@@ -14,11 +14,6 @@ pub unsafe extern "C" fn PyFrame_GetCode(frame: *mut PyObject) -> *mut PyObject 
 pub unsafe extern "C" fn PyFrame_GetLineNumber(frame: *mut PyObject) -> core::ffi::c_int {
     with_vm(|vm| {
         let frame = unsafe { &*frame }.try_downcast_ref::<Frame>(vm)?;
-        let lineno = if frame.lasti() == 0 {
-            frame.code.first_line_number.map_or(1, |n| n.get())
-        } else {
-            frame.current_location().line.get()
-        };
-        Ok(lineno as core::ffi::c_int)
+        Ok(frame.f_lineno() as core::ffi::c_int)
     })
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a new public API module for accessing runtime frame details from RustPython.
  * Added external entrypoints to retrieve a frame’s code object and its computed source line number.
* **Chores**
  * Updated spell-check dictionary with the new term.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->