### PR TITLE
Add more build-info functions to c-api

### DIFF
--- a/crates/capi/src/pylifecycle.rs
+++ b/crates/capi/src/pylifecycle.rs
@@ -91,26 +91,17 @@ pub extern "C" fn Py_GetBuildInfo() -> *const c_char {
 
 #[unsafe(no_mangle)]
 pub extern "C" fn Py_GetCompiler() -> *const c_char {
-    static COMPILER: LazyLock<CString> = LazyLock::new(|| {
-        CString::new(sys::COMPILER).expect("compiler must not contain interior NULs")
-    });
-    COMPILER.as_ptr()
+    sys::COMPILER.as_ptr()
 }
 
 #[unsafe(no_mangle)]
 pub extern "C" fn Py_GetCopyright() -> *const c_char {
-    static COPYRIGHT: LazyLock<CString> = LazyLock::new(|| {
-        CString::new(sys::COPYRIGHT).expect("copyright must not contain interior NULs")
-    });
-    COPYRIGHT.as_ptr()
+    sys::COPYRIGHT.as_ptr()
 }
 
 #[unsafe(no_mangle)]
 pub extern "C" fn Py_GetPlatform() -> *const c_char {
-    static PLATFORM: LazyLock<CString> = LazyLock::new(|| {
-        CString::new(sys::PLATFORM).expect("platform must not contain interior NULs")
-    });
-    PLATFORM.as_ptr()
+    sys::PLATFORM.as_ptr()
 }
 
 #[cfg(test)]

--- a/crates/capi/src/pylifecycle.rs
+++ b/crates/capi/src/pylifecycle.rs
@@ -5,7 +5,7 @@ use alloc::ffi::CString;
 use core::ffi::{c_char, c_int, c_ulong};
 use rustpython_vm::common::rc::PyRc;
 use rustpython_vm::stdlib::sys;
-use rustpython_vm::version::{MAJOR, MICRO, MINOR, VERSION_HEX};
+use rustpython_vm::version::{MAJOR, MICRO, MINOR, RUSTPYTHON_BUILD_INFO, VERSION_HEX};
 use rustpython_vm::vm::thread::ThreadedVirtualMachine;
 use rustpython_vm::{Context, Interpreter};
 use std::sync::{LazyLock, Mutex};
@@ -84,14 +84,14 @@ pub extern "C" fn Py_GetVersion() -> *const c_char {
 #[unsafe(no_mangle)]
 pub extern "C" fn Py_GetBuildInfo() -> *const c_char {
     static BUILD_INFO: LazyLock<CString> = LazyLock::new(|| {
-        CString::new(sys::BUILD_INFO).expect("build info must not contain interior NULs")
+        CString::new(RUSTPYTHON_BUILD_INFO).expect("build info must not contain interior NULs")
     });
     BUILD_INFO.as_ptr()
 }
 
 #[unsafe(no_mangle)]
 pub extern "C" fn Py_GetCompiler() -> *const c_char {
-    sys::COMPILER.as_ptr()
+    c"[RUST]".as_ptr()
 }
 
 #[unsafe(no_mangle)]

--- a/crates/capi/src/pylifecycle.rs
+++ b/crates/capi/src/pylifecycle.rs
@@ -4,6 +4,7 @@ use crate::pystate::ensure_thread_has_vm_attached;
 use alloc::ffi::CString;
 use core::ffi::{c_char, c_int, c_ulong};
 use rustpython_vm::common::rc::PyRc;
+use rustpython_vm::stdlib::sys;
 use rustpython_vm::version::{MAJOR, MICRO, MINOR, VERSION_HEX};
 use rustpython_vm::vm::thread::ThreadedVirtualMachine;
 use rustpython_vm::{Context, Interpreter};
@@ -78,6 +79,38 @@ pub extern "C" fn Py_GetVersion() -> *const c_char {
             .expect("version string must not contain interior NULs")
     });
     VERSION.as_ptr()
+}
+
+#[unsafe(no_mangle)]
+pub extern "C" fn Py_GetBuildInfo() -> *const c_char {
+    static BUILD_INFO: LazyLock<CString> = LazyLock::new(|| {
+        CString::new(sys::BUILD_INFO).expect("build info must not contain interior NULs")
+    });
+    BUILD_INFO.as_ptr()
+}
+
+#[unsafe(no_mangle)]
+pub extern "C" fn Py_GetCompiler() -> *const c_char {
+    static COMPILER: LazyLock<CString> = LazyLock::new(|| {
+        CString::new(sys::COMPILER).expect("compiler must not contain interior NULs")
+    });
+    COMPILER.as_ptr()
+}
+
+#[unsafe(no_mangle)]
+pub extern "C" fn Py_GetCopyright() -> *const c_char {
+    static COPYRIGHT: LazyLock<CString> = LazyLock::new(|| {
+        CString::new(sys::COPYRIGHT).expect("copyright must not contain interior NULs")
+    });
+    COPYRIGHT.as_ptr()
+}
+
+#[unsafe(no_mangle)]
+pub extern "C" fn Py_GetPlatform() -> *const c_char {
+    static PLATFORM: LazyLock<CString> = LazyLock::new(|| {
+        CString::new(sys::PLATFORM).expect("platform must not contain interior NULs")
+    });
+    PLATFORM.as_ptr()
 }
 
 #[cfg(test)]

--- a/crates/vm/src/builtins/str.rs
+++ b/crates/vm/src/builtins/str.rs
@@ -1871,7 +1871,8 @@ impl ToPyObject for &String {
 
 impl ToPyObject for &CStr {
     fn to_pyobject(self, vm: &VirtualMachine) -> PyObjectRef {
-        vm.ctx.new_str(self.to_string_lossy()).into()
+        let s = self.to_str().expect("ToPyObject expects utf-8 CStr");
+        vm.ctx.new_str(s).into()
     }
 }
 

--- a/crates/vm/src/builtins/str.rs
+++ b/crates/vm/src/builtins/str.rs
@@ -35,6 +35,7 @@ use crate::{
 use alloc::{borrow::Cow, fmt};
 use ascii::{AsciiChar, AsciiStr, AsciiString};
 use bstr::ByteSlice;
+use core::ffi::CStr;
 use core::{char, mem, ops::Range};
 use itertools::Itertools;
 use num_traits::ToPrimitive;
@@ -1865,6 +1866,12 @@ impl ToPyObject for &str {
 impl ToPyObject for &String {
     fn to_pyobject(self, vm: &VirtualMachine) -> PyObjectRef {
         vm.ctx.new_str(self.clone()).into()
+    }
+}
+
+impl ToPyObject for &CStr {
+    fn to_pyobject(self, vm: &VirtualMachine) -> PyObjectRef {
+        vm.ctx.new_str(self.to_string_lossy()).into()
     }
 }
 

--- a/crates/vm/src/stdlib/sys.rs
+++ b/crates/vm/src/stdlib/sys.rs
@@ -51,6 +51,7 @@ pub mod sys {
         version,
         vm::{Settings, VirtualMachine},
     };
+    use core::ffi::CStr;
     use core::sync::atomic::Ordering;
     use num_traits::ToPrimitive;
     use std::{
@@ -223,7 +224,7 @@ pub mod sys {
     #[pyattr(name = "api_version")]
     const API_VERSION: u32 = 0x0; // what C api?
     #[pyattr(name = "copyright")]
-    pub const COPYRIGHT: &str = "Copyright (c) 2019 RustPython Team";
+    pub const COPYRIGHT: &CStr = c"Copyright (c) 2019 RustPython Team";
     #[pyattr(name = "float_repr_style")]
     const FLOAT_REPR_STYLE: &str = "short";
     #[pyattr(name = "_framework")]
@@ -236,14 +237,14 @@ pub mod sys {
     const MAXUNICODE: u32 = core::char::MAX as u32;
 
     #[pyattr(name = "platform")]
-    pub const PLATFORM: &str = cfg_select! {
-        target_os = "linux" => "linux",
-        target_os = "android" => "android",
-        target_os = "macos" => "darwin",
-        target_os = "ios" => "ios",
-        windows => "win32",
-        target_os = "wasi" => "wasi",
-        _ => "unknown"
+    pub const PLATFORM: &CStr = cfg_select! {
+        target_os = "linux" => c"linux",
+        target_os = "android" => c"android",
+        target_os = "macos" => c"darwin",
+        target_os = "ios" => c"ios",
+        windows => c"win32",
+        target_os = "wasi" => c"wasi",
+        _ => c"unknown"
     };
 
     #[pyattr(name = "ps1")]
@@ -713,7 +714,7 @@ pub mod sys {
 
     pub const BUILD_INFO: &str = version::RUSTPYTHON_BUILD_INFO;
 
-    pub const COMPILER: &str = "[Rust]";
+    pub const COMPILER: &CStr = c"[Rust]";
 
     // Note: This is Python DLL version in CPython, but we arbitrary fill it for compatibility
     #[cfg(windows)]
@@ -1916,7 +1917,7 @@ pub(crate) fn sysconfigdata_name() -> String {
     format!(
         "_sysconfigdata_{}_{}_{}",
         sys::ABIFLAGS,
-        sys::PLATFORM,
+        sys::PLATFORM.to_string_lossy(),
         sys::multiarch()
     )
 }

--- a/crates/vm/src/stdlib/sys.rs
+++ b/crates/vm/src/stdlib/sys.rs
@@ -4,6 +4,7 @@ use crate::{Py, PyPayload, PyResult, VirtualMachine, builtins::PyModule, convert
 
 #[cfg(all(not(feature = "host_env"), feature = "stdio"))]
 pub(crate) use sys::SandboxStdio;
+pub use sys::{BUILD_INFO, COMPILER, COPYRIGHT, PLATFORM, VERSION};
 pub(crate) use sys::{DOC, MAXSIZE, RUST_MULTIARCH, UnraisableHookArgsData, module_def, multiarch};
 
 #[pymodule(name = "_jit")]
@@ -222,7 +223,7 @@ pub mod sys {
     #[pyattr(name = "api_version")]
     const API_VERSION: u32 = 0x0; // what C api?
     #[pyattr(name = "copyright")]
-    const COPYRIGHT: &str = "Copyright (c) 2019 RustPython Team";
+    pub const COPYRIGHT: &str = "Copyright (c) 2019 RustPython Team";
     #[pyattr(name = "float_repr_style")]
     const FLOAT_REPR_STYLE: &str = "short";
     #[pyattr(name = "_framework")]
@@ -708,7 +709,11 @@ pub mod sys {
     }
 
     #[pyattr(name = "version")]
-    const VERSION: &str = version::RUSTPYTHON_VERSION;
+    pub const VERSION: &str = version::RUSTPYTHON_VERSION;
+
+    pub const BUILD_INFO: &str = version::RUSTPYTHON_BUILD_INFO;
+
+    pub const COMPILER: &str = "[Rust]";
 
     // Note: This is Python DLL version in CPython, but we arbitrary fill it for compatibility
     #[cfg(windows)]

--- a/crates/vm/src/stdlib/sys.rs
+++ b/crates/vm/src/stdlib/sys.rs
@@ -4,7 +4,7 @@ use crate::{Py, PyPayload, PyResult, VirtualMachine, builtins::PyModule, convert
 
 #[cfg(all(not(feature = "host_env"), feature = "stdio"))]
 pub(crate) use sys::SandboxStdio;
-pub use sys::{BUILD_INFO, COMPILER, COPYRIGHT, PLATFORM, VERSION};
+pub use sys::{COPYRIGHT, PLATFORM};
 pub(crate) use sys::{DOC, MAXSIZE, RUST_MULTIARCH, UnraisableHookArgsData, module_def, multiarch};
 
 #[pymodule(name = "_jit")]
@@ -710,11 +710,7 @@ pub mod sys {
     }
 
     #[pyattr(name = "version")]
-    pub const VERSION: &str = version::RUSTPYTHON_VERSION;
-
-    pub const BUILD_INFO: &str = version::RUSTPYTHON_BUILD_INFO;
-
-    pub const COMPILER: &CStr = c"[Rust]";
+    const VERSION: &str = version::RUSTPYTHON_VERSION;
 
     // Note: This is Python DLL version in CPython, but we arbitrary fill it for compatibility
     #[cfg(windows)]


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added runtime access to system metadata (build, compiler, copyright, platform) via standard C-ABI entry points.
  * Exposed additional `sys` metadata constants with consistent string handling.
* **Bug Fixes**
  * Improved conversion of C strings into Python `str` to better represent system metadata reliably.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->