### PR TITLE
Support xml.sax pyexpat setup APIs

### DIFF
--- a/Lib/test/test_pulldom.py
+++ b/Lib/test/test_pulldom.py
@@ -24,7 +24,6 @@ SMALL_SAMPLE = """<?xml version="1.0"?>
 
 class PullDOMTestCase(unittest.TestCase):
 
-    @unittest.expectedFailure  # TODO: RUSTPYTHON; FileNotFoundError: [Errno 2] No such file or directory (os error 2): 'xmltestdata/test.xml' -> 'None'
     def test_parse(self):
         """Minimal test of DOMEventStream.parse()"""
 

--- a/Lib/test/test_sax.py
+++ b/Lib/test/test_sax.py
@@ -190,7 +190,6 @@ class ParseTest(unittest.TestCase):
             with self.assertRaises(SAXException):
                 self.check_parse(f)
 
-    @unittest.expectedFailure  # TODO: RUSTPYTHON; AttributeError: 'xmlparser' object has no attribute 'SetParamEntityParsing'
     def test_parse_path_object(self):
         make_xml_file(self.data, 'utf-8', None)
         self.check_parse(FakePath(TESTFN))
@@ -1018,7 +1017,6 @@ class ExpatReaderTest(XmlTestBase):
             resolver.entities, [(None, 'unsupported://non-existing')]
         )
 
-    @unittest.expectedFailure  # TODO: RUSTPYTHON; AttributeError: 'xmlparser' object has no attribute 'SetParamEntityParsing'
     def test_expat_external_dtd_default(self):
         parser = create_parser()
         resolver = self.TestEntityRecorder()
@@ -1084,7 +1082,6 @@ class ExpatReaderTest(XmlTestBase):
         def startElementNS(self, name, qname, attrs):
             self._attrs = attrs
 
-    @unittest.expectedFailure  # TODO: RUSTPYTHON; AttributeError: 'xmlparser' object has no attribute 'SetParamEntityParsing'
     def test_expat_attrs_empty(self):
         parser = create_parser()
         gather = self.AttrGatherer()
@@ -1095,7 +1092,6 @@ class ExpatReaderTest(XmlTestBase):
 
         self.verify_empty_attrs(gather._attrs)
 
-    @unittest.expectedFailure  # TODO: RUSTPYTHON; AttributeError: 'xmlparser' object has no attribute 'SetParamEntityParsing'
     def test_expat_attrs_wattr(self):
         parser = create_parser()
         gather = self.AttrGatherer()
@@ -1106,7 +1102,6 @@ class ExpatReaderTest(XmlTestBase):
 
         self.verify_attrs_wattr(gather._attrs)
 
-    @unittest.expectedFailure  # TODO: RUSTPYTHON; AttributeError: 'xmlparser' object has no attribute 'SetParamEntityParsing'
     def test_expat_nsattrs_empty(self):
         parser = create_parser(1)
         gather = self.AttrGatherer()
@@ -1300,7 +1295,6 @@ class ExpatReaderTest(XmlTestBase):
 
     # ===== Locator support
 
-    @unittest.expectedFailure  # TODO: RUSTPYTHON; AttributeError: 'xmlparser' object has no attribute 'SetParamEntityParsing'
     def test_expat_locator_noinfo(self):
         result = BytesIO()
         xmlgen = XMLGenerator(result)
@@ -1315,7 +1309,6 @@ class ExpatReaderTest(XmlTestBase):
         self.assertEqual(parser.getPublicId(), None)
         self.assertEqual(parser.getLineNumber(), 1)
 
-    @unittest.expectedFailure  # TODO: RUSTPYTHON; AttributeError: 'xmlparser' object has no attribute 'SetParamEntityParsing'
     def test_expat_locator_withinfo(self):
         result = BytesIO()
         xmlgen = XMLGenerator(result)
@@ -1326,7 +1319,6 @@ class ExpatReaderTest(XmlTestBase):
         self.assertEqual(parser.getSystemId(), TEST_XMLFILE)
         self.assertEqual(parser.getPublicId(), None)
 
-    @unittest.expectedFailure  # TODO: RUSTPYTHON; AttributeError: 'xmlparser' object has no attribute 'SetParamEntityParsing'
     @requires_nonascii_filenames
     def test_expat_locator_withinfo_nonascii(self):
         fname = os_helper.TESTFN_UNICODE

--- a/crates/stdlib/src/pyexpat.rs
+++ b/crates/stdlib/src/pyexpat.rs
@@ -43,7 +43,7 @@ mod _pyexpat {
         Context, Py, PyObjectRef, PyPayload, PyRef, PyResult, TryFromObject, VirtualMachine,
         builtins::{PyBytesRef, PyException, PyModule, PyStr, PyStrRef, PyType, PyUtf8StrRef},
         extend_module,
-        function::{ArgBytesLike, Either, IntoFuncArgs, OptionalArg},
+        function::{ArgBytesLike, ArgPrimitiveIndex, Either, IntoFuncArgs, OptionalArg},
         types::Constructor,
     };
     use rustpython_common::lock::PyRwLock;
@@ -71,12 +71,21 @@ mod _pyexpat {
     pub(super) const VERSION_INFO: (u32, u32, u32) = (2, 7, 1);
 
     #[pyattr]
+    const XML_PARAM_ENTITY_PARSING_NEVER: i32 = 0;
+    #[pyattr]
+    const XML_PARAM_ENTITY_PARSING_UNLESS_STANDALONE: i32 = 1;
+    #[pyattr]
+    const XML_PARAM_ENTITY_PARSING_ALWAYS: i32 = 2;
+
+    #[pyattr]
     #[pyattr(name = "XMLParserType")]
     #[pyclass(name = "xmlparser", module = false, traverse)]
     #[derive(Debug, PyPayload)]
     pub(super) struct PyExpatLikeXmlParser {
         #[pytraverse(skip)]
         namespace_separator: Option<String>,
+        #[pytraverse(skip)]
+        base: PyRwLock<Option<String>>,
         start_element: MutableObject,
         end_element: MutableObject,
         character_data: MutableObject,
@@ -128,6 +137,7 @@ mod _pyexpat {
             let intern_dict = intern.unwrap_or_else(|| vm.ctx.new_dict().into());
             Self {
                 namespace_separator,
+                base: PyRwLock::new(None),
                 start_element: MutableObject::new(vm.ctx.none()),
                 end_element: MutableObject::new(vm.ctx.none()),
                 character_data: MutableObject::new(vm.ctx.none()),
@@ -295,6 +305,29 @@ mod _pyexpat {
                 .cdata_to_characters(true)
                 .coalesce_characters(false)
                 .whitespace_to_characters(true)
+        }
+
+        #[pymethod(name = "SetParamEntityParsing")]
+        fn set_param_entity_parsing(&self, _flag: ArgPrimitiveIndex<i32>) -> i32 {
+            // Compatibility shim: xml.sax requires this setup API, but xml-rs
+            // does not expose Expat parameter entity parsing configuration.
+            1
+        }
+
+        #[pymethod(name = "SetBase")]
+        fn set_base(&self, base: PyStrRef) {
+            // Store-only compatibility state for xml.sax locator APIs. The
+            // xml-rs backend still does not perform Expat-style base URI
+            // resolution for external entities.
+            *self.base.write() = Some(AsRef::<str>::as_ref(&base).to_owned());
+        }
+
+        #[pymethod(name = "GetBase")]
+        fn get_base(&self, vm: &VirtualMachine) -> PyObjectRef {
+            self.base.read().as_ref().map_or_else(
+                || vm.ctx.none(),
+                |base| vm.ctx.new_str(base.as_str()).into(),
+            )
         }
 
         /// Construct element name with namespace if separator is set

--- a/extra_tests/snippets/stdlib_xml.py
+++ b/extra_tests/snippets/stdlib_xml.py
@@ -1,0 +1,48 @@
+import xml.sax
+from xml.parsers import expat
+
+from testutils import assert_raises
+
+
+assert expat.XML_PARAM_ENTITY_PARSING_NEVER == 0
+assert expat.XML_PARAM_ENTITY_PARSING_UNLESS_STANDALONE == 1
+assert expat.XML_PARAM_ENTITY_PARSING_ALWAYS == 2
+
+parser = expat.ParserCreate()
+for value in (0, 1, 2, 3, -1, True):
+    assert parser.SetParamEntityParsing(value) == 1
+
+for value in ("x", None):
+    with assert_raises(TypeError):
+        parser.SetParamEntityParsing(value)
+
+with assert_raises(OverflowError):
+    parser.SetParamEntityParsing(2**100)
+
+assert parser.GetBase() is None
+assert parser.SetBase("example.xml") is None
+assert parser.GetBase() == "example.xml"
+for value in (b"example.xml", None, 123):
+    with assert_raises(TypeError):
+        parser.SetBase(value)
+
+
+class Handler(xml.sax.handler.ContentHandler):
+    def __init__(self):
+        self.events = []
+
+    def startElement(self, name, attrs):
+        self.events.append(("start", name))
+
+    def endElement(self, name):
+        self.events.append(("end", name))
+
+
+handler = Handler()
+xml.sax.parseString("<main><child /></main>", handler)
+assert handler.events == [
+    ("start", "main"),
+    ("start", "child"),
+    ("end", "child"),
+    ("end", "main"),
+]

--- a/extra_tests/snippets/stdlib_xml.py
+++ b/extra_tests/snippets/stdlib_xml.py
@@ -3,7 +3,6 @@ from xml.parsers import expat
 
 from testutils import assert_raises
 
-
 assert expat.XML_PARAM_ENTITY_PARSING_NEVER == 0
 assert expat.XML_PARAM_ENTITY_PARSING_UNLESS_STANDALONE == 1
 assert expat.XML_PARAM_ENTITY_PARSING_ALWAYS == 2


### PR DESCRIPTION
<!--
Thanks for your contribution!
-->

- [x] Closes #4983
- [x] Partially addresses #8083
- [x] This PR follows our [AI policy](https://github.com/RustPython/.github/blob/main/AI_POLICY.md)

## Summary

Adds the pyexpat setup APIs that `xml.sax` expects when initializing the Expat reader.

## Problem

`xml.sax.parseString()` and related SAX paths create a parser through `xml.parsers.expat`, then call setup methods such as `SetParamEntityParsing()`.

RustPython's native pyexpat parser did not expose those setup APIs, so normal SAX parsing could fail before it started parsing XML.

## Fixes

1. Expose the `XML_PARAM_ENTITY_PARSING_*` constants.
2. Add `SetParamEntityParsing()` as a compatibility shim for SAX setup.
3. Add `SetBase()` and `GetBase()` for parser base URI state used by locator-related SAX paths.
4. Add regression coverage in `extra_tests/snippets/stdlib_xml.py`.
5. Remove `expectedFailure` markers from the SAX tests that now pass.

This does not implement full Expat-style external entity parsing. The current backend still uses xml-rs, which does not expose that configuration.

## Testing

- `PATH=/tmp/pyshim:$PATH prek run --all-files`
- `cargo run --quiet -- extra_tests/snippets/stdlib_xml.py`
- `cargo run --release -- -m test test_sax`
- `cargo run --release -- -m test test_pyexpat`
- `cargo test --workspace --exclude rustpython-capi --exclude rustpython_wasm --exclude rustpython-compiler-source --exclude rustpython-venvlauncher --features threading --no-default-features --features stdlib,importlib,stdio,encodings,sqlite,ssl-rustls-aws-lc,host_env && (cd crates/capi && cargo test)`
- `PYO3_CONFIG_FILE=$PWD/crates/capi/pyo3-rustpython.config cargo test --workspace --exclude rustpython_wasm --exclude rustpython-venvlauncher`
- `cargo build --release --features sqlite && cd extra_tests && /tmp/rustpython-extra-tests-venv/bin/python -m pytest -v`
- `cargo clippy --workspace --exclude rustpython-capi --exclude rustpython_wasm --exclude rustpython-compiler-source --exclude rustpython-venvlauncher --features threading --no-default-features --features stdlib,importlib,stdio,encodings,sqlite,ssl-rustls-aws-lc,host_env`

## AI use

Assisted by Codex:gpt-5.5 for implementation, test drafting, and verification. I reviewed and verified the changes locally.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added new `xml.parsers.expat` XML parameter entity parsing constants and `SetParamEntityParsing()` compatibility behavior.
  * Added base URI support for the XML parser via `SetBase()` and `GetBase()`.
* **Tests**
  * Added coverage for constant values, accepted input types (including boolean), and error handling for invalid/overflow inputs.
  * Added tests for base URI initialization/update and for correct start/end element event sequencing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->