### PR TITLE
Fix select.select list construction

### DIFF
--- a/Lib/test/test_select.py
+++ b/Lib/test/test_select.py
@@ -40,7 +40,6 @@ class SelectTestCase(unittest.TestCase):
             else:
                 self.fail("exception not raised")
 
-    @unittest.expectedFailure  # TODO: RUSTPYTHON; AssertionError: unexpectedly identical: []
     def test_returned_list_identity(self):
         # See issue #8329
         r, w, x = select.select([], [], [], 1)

--- a/crates/stdlib/src/select.rs
+++ b/crates/stdlib/src/select.rs
@@ -107,8 +107,11 @@ mod decl {
         let (xlist, mut x) = seq2set(&xlist)?;
 
         if rlist.is_empty() && wlist.is_empty() && xlist.is_empty() {
-            let empty = vm.ctx.new_list(vec![]);
-            return Ok((empty.clone(), empty.clone(), empty));
+            return Ok((
+                vm.ctx.new_list(vec![]),
+                vm.ctx.new_list(vec![]),
+                vm.ctx.new_list(vec![]),
+            ));
         }
 
         let nfds = cfg_select! {


### PR DESCRIPTION
<!--
Thanks for your contribution!
-->

- [x] This PR follows our [AI policy](https://github.com/RustPython/.github/blob/main/AI_POLICY.md)

## Summary

This pull request just complement CPython compatibility by correcting `select.select` function's logic.

