### PR TITLE
Add more error functions to the c-api

### DIFF
--- a/crates/capi/src/pyerrors.rs
+++ b/crates/capi/src/pyerrors.rs
@@ -417,32 +417,30 @@ pub unsafe extern "C" fn PyErr_Fetch(
     ptraceback: *mut *mut PyObject,
 ) {
     with_vm(|vm| {
-        let (ty, value, tb) = vm.take_raised_exception().map_or_else(
-            || {
-                (
-                    core::ptr::null_mut(),
-                    core::ptr::null_mut(),
-                    core::ptr::null_mut(),
-                )
-            },
+        let (mut ty, mut value, mut tb) = vm.take_raised_exception().map_or_else(
+            || (None, None, None),
             |exc| {
                 let (ty, value, tb) = vm.split_exception(exc);
-                let tb = if vm.is_none(&tb) {
-                    core::ptr::null_mut()
-                } else {
-                    tb.into_raw().as_ptr()
-                };
-                (ty.into_raw().as_ptr(), value.into_raw().as_ptr(), tb)
+                (Some(ty), Some(value), vm.option_if_none(tb))
             },
         );
 
         if let Some(ptype) = NonNull::new(ptype) {
+            let ty = ty
+                .take()
+                .map_or(core::ptr::null_mut(), |value| value.into_raw().as_ptr());
             unsafe { ptype.write(ty) };
         }
         if let Some(pvalue) = NonNull::new(pvalue) {
+            let value = value
+                .take()
+                .map_or(core::ptr::null_mut(), |value| value.into_raw().as_ptr());
             unsafe { pvalue.write(value) };
         }
         if let Some(ptraceback) = NonNull::new(ptraceback) {
+            let tb = tb
+                .take()
+                .map_or(core::ptr::null_mut(), |tb| tb.into_raw().as_ptr());
             unsafe { ptraceback.write(tb) };
         }
     })
@@ -477,7 +475,7 @@ pub unsafe extern "C" fn PyErr_Restore(
 #[unsafe(no_mangle)]
 pub extern "C" fn PyErr_GetHandledException() -> *mut PyObject {
     with_vm(|vm| {
-        vm.current_exception()
+        vm.topmost_exception()
             .map(|exc| exc.into_object().into_raw().as_ptr())
             .unwrap_or_default()
     })
@@ -486,11 +484,11 @@ pub extern "C" fn PyErr_GetHandledException() -> *mut PyObject {
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn PyErr_SetHandledException(exc: *mut PyObject) {
     with_vm(|vm| {
-        if let Some(exc) = NonNull::new(exc) {
-            let exception = unsafe { PyObjectRef::from_raw(exc).downcast_unchecked() };
-            vm.set_exception(Some(exception));
-        } else {
+        if exc.is_null() || vm.is_none(unsafe { &*exc }) {
             vm.set_exception(None);
+        } else {
+            let exception = unsafe { (&*exc).to_owned().downcast_unchecked() };
+            vm.set_exception(Some(exception));
         }
     })
 }
@@ -502,32 +500,30 @@ pub unsafe extern "C" fn PyErr_GetExcInfo(
     ptraceback: *mut *mut PyObject,
 ) {
     with_vm(|vm| {
-        let (ty, value, tb) = vm.current_exception().map_or_else(
-            || {
-                (
-                    core::ptr::null_mut(),
-                    core::ptr::null_mut(),
-                    core::ptr::null_mut(),
-                )
-            },
+        let (mut ty, mut value, mut tb) = vm.topmost_exception().map_or_else(
+            || (None, None, None),
             |exc| {
                 let (ty, value, tb) = vm.split_exception(exc);
-                let tb = if vm.is_none(&tb) {
-                    core::ptr::null_mut()
-                } else {
-                    tb.into_raw().as_ptr()
-                };
-                (ty.into_raw().as_ptr(), value.into_raw().as_ptr(), tb)
+                (Some(ty), Some(value), vm.option_if_none(tb))
             },
         );
 
         if let Some(ptype) = NonNull::new(ptype) {
+            let ty = ty
+                .take()
+                .map_or(core::ptr::null_mut(), |ty| ty.into_raw().as_ptr());
             unsafe { ptype.write(ty) };
         }
         if let Some(pvalue) = NonNull::new(pvalue) {
+            let value = value
+                .take()
+                .map_or(core::ptr::null_mut(), |value| value.into_raw().as_ptr());
             unsafe { pvalue.write(value) };
         }
         if let Some(ptraceback) = NonNull::new(ptraceback) {
+            let tb = tb
+                .take()
+                .map_or(core::ptr::null_mut(), |tb| tb.into_raw().as_ptr());
             unsafe { ptraceback.write(tb) };
         }
     })
@@ -542,13 +538,14 @@ pub unsafe extern "C" fn PyErr_SetExcInfo(
     with_vm(|vm| {
         let _exc_type = NonNull::new(exc_type).map(|ptr| unsafe { PyObjectRef::from_raw(ptr) });
         let _exc_tb = NonNull::new(exc_tb).map(|ptr| unsafe { PyObjectRef::from_raw(ptr) });
-        let exc_val = NonNull::new(exc_val).map(|ptr| unsafe { PyObjectRef::from_raw(ptr) });
-        let exc = exc_val
-            .map(|obj| {
-                obj.downcast::<PyBaseException>()
-                    .map_err(|_| vm.new_type_error("exception value must be an exception instance"))
-            })
-            .transpose()?;
+        let exc =
+            match NonNull::new(exc_val).map(|ptr| unsafe { PyObjectRef::from_raw(ptr) }) {
+                None => None,
+                Some(obj) if vm.is_none(&obj) => None,
+                Some(obj) => Some(obj.downcast::<PyBaseException>().map_err(|_| {
+                    vm.new_type_error("exception value must be an exception instance")
+                })?),
+            };
         vm.set_exception(exc);
         Ok(())
     })

--- a/crates/capi/src/pyerrors.rs
+++ b/crates/capi/src/pyerrors.rs
@@ -2,13 +2,23 @@ use crate::object::define_py_check;
 use crate::util::CStrExt;
 use crate::{PyObject, pystate::with_vm};
 use core::convert::Infallible;
-use core::ffi::{c_char, c_int};
+use core::ffi::{CStr, c_char, c_int};
 use core::ptr::NonNull;
-use core::slice;
+pub use errno::*;
 use rustpython_vm::builtins::{PyBaseException, PyTuple, PyType};
 use rustpython_vm::convert::IntoObject;
 use rustpython_vm::exceptions::ExceptionZoo;
+use rustpython_vm::signal::set_interrupt_ex;
 use rustpython_vm::{AsObject, PyObjectRef, PyResult};
+use std::process::abort;
+pub use unicode::*;
+#[cfg(windows)]
+pub use windows::*;
+
+mod errno;
+mod unicode;
+#[cfg(windows)]
+mod windows;
 
 macro_rules! define_exception_statics {
     ($( $(#[$meta:meta])* $export:ident => $exc:ident ),* $(,)?) => {
@@ -315,55 +325,249 @@ pub unsafe extern "C" fn PyException_SetContext(exc: *mut PyObject, context: *mu
 }
 
 #[unsafe(no_mangle)]
-pub unsafe extern "C" fn PyUnicodeDecodeError_Create(
-    encoding: *const c_char,
-    object: *const c_char,
-    length: isize,
-    start: isize,
-    end: isize,
-    reason: *const c_char,
-) -> *mut PyObject {
-    with_vm(|vm| {
-        let encoding = unsafe { encoding.try_as_str(vm) }?;
-        let reason = unsafe { reason.try_as_str(vm) }?;
-        let length: usize = length
-            .try_into()
-            .map_err(|_| vm.new_system_error("length must be non-negative"))?;
-        let start: usize = start
-            .try_into()
-            .map_err(|_| vm.new_system_error("start must be non-negative"))?;
-        let end: usize = end
-            .try_into()
-            .map_err(|_| vm.new_system_error("end must be non-negative"))?;
-
-        let bytes = if object.is_null() {
-            if length != 0 {
-                return Err(vm.new_system_error(
-                    "PyUnicodeDecodeError_Create called with null object and non-zero length",
-                ));
-            }
-            Vec::new()
-        } else {
-            unsafe { slice::from_raw_parts(object.cast::<u8>(), length) }.to_vec()
-        };
-
-        let exc = vm.new_unicode_decode_error_real(
-            vm.ctx.new_str(encoding),
-            vm.ctx.new_bytes(bytes),
-            start,
-            end,
-            vm.ctx.new_str(reason),
-        );
-        Ok(exc)
-    })
-}
-
-#[unsafe(no_mangle)]
 pub unsafe extern "C" fn PyException_SetTraceback(exc: *mut PyObject, tb: *mut PyObject) -> c_int {
     with_vm(|vm| {
         let exc = unsafe { &*exc }.try_downcast_ref::<PyBaseException>(vm)?;
         let traceback = unsafe { tb.as_ref() }.map(|obj| obj.to_owned());
         exc.set___traceback__(vm.unwrap_or_none(traceback), vm)
+    })
+}
+
+#[unsafe(no_mangle)]
+pub extern "C" fn PyErr_Clear() {
+    with_vm(|vm| vm.set_exception(None))
+}
+
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn PyErr_ExceptionMatches(exc: *mut PyObject) -> c_int {
+    with_vm(|vm| {
+        if let Some(current) = vm.current_exception() {
+            current
+                .class()
+                .as_object()
+                .is_subclass(unsafe { &*exc }, vm)
+        } else {
+            Ok(false)
+        }
+    })
+}
+
+#[unsafe(no_mangle)]
+pub extern "C" fn PyErr_BadArgument() -> c_int {
+    with_vm::<PyResult<Infallible>, ()>(|vm| {
+        Err(vm.new_type_error("bad argument type for built-in operation"))
+    });
+    0
+}
+
+#[unsafe(no_mangle)]
+pub extern "C" fn PyErr_BadInternalCall() {
+    with_vm::<PyResult<Infallible>, _>(|vm| {
+        Err(vm.new_system_error("bad argument to internal function"))
+    })
+}
+
+#[unsafe(no_mangle)]
+pub extern "C" fn PyErr_CheckSignals() -> c_int {
+    with_vm(|vm| vm.check_signals())
+}
+
+#[unsafe(no_mangle)]
+pub extern "C" fn PyErr_SetInterrupt() {
+    PyErr_SetInterruptEx(libc::SIGINT);
+}
+
+#[unsafe(no_mangle)]
+pub extern "C" fn PyErr_SetInterruptEx(signum: c_int) -> c_int {
+    let Ok(signum) = signum.try_into() else {
+        return -1;
+    };
+    set_interrupt_ex(signum).map_or(-1, |_| 0)
+}
+
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn Py_FatalError(message: *const c_char) -> ! {
+    let message = if message.is_null() {
+        c"(null)"
+    } else {
+        unsafe { CStr::from_ptr(message) }
+    };
+    eprintln!("Fatal Python error: {message:?}");
+    abort()
+}
+
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn PyErr_SetNone(exception: *mut PyObject) {
+    with_vm::<PyResult<Infallible>, _>(|vm| {
+        let exc_type = unsafe { (&*exception).to_owned() };
+        let normalized = vm.normalize_exception(exc_type, vm.ctx.none(), vm.ctx.none())?;
+        Err(normalized)
+    })
+}
+
+#[unsafe(no_mangle)]
+pub extern "C" fn PyErr_NoMemory() -> *mut PyObject {
+    with_vm::<PyResult<*mut PyObject>, _>(|vm| Err(vm.new_memory_error("")))
+}
+
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn PyErr_Fetch(
+    ptype: *mut *mut PyObject,
+    pvalue: *mut *mut PyObject,
+    ptraceback: *mut *mut PyObject,
+) {
+    with_vm(|vm| {
+        let (ty, value, tb) = vm.take_raised_exception().map_or_else(
+            || {
+                (
+                    core::ptr::null_mut(),
+                    core::ptr::null_mut(),
+                    core::ptr::null_mut(),
+                )
+            },
+            |exc| {
+                let (ty, value, tb) = vm.split_exception(exc);
+                let tb = if vm.is_none(&tb) {
+                    core::ptr::null_mut()
+                } else {
+                    tb.into_raw().as_ptr()
+                };
+                (ty.into_raw().as_ptr(), value.into_raw().as_ptr(), tb)
+            },
+        );
+
+        if let Some(ptype) = NonNull::new(ptype) {
+            unsafe { ptype.write(ty) };
+        }
+        if let Some(pvalue) = NonNull::new(pvalue) {
+            unsafe { pvalue.write(value) };
+        }
+        if let Some(ptraceback) = NonNull::new(ptraceback) {
+            unsafe { ptraceback.write(tb) };
+        }
+    })
+}
+
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn PyErr_Restore(
+    exc_type: *mut PyObject,
+    exc_val: *mut PyObject,
+    exc_tb: *mut PyObject,
+) {
+    with_vm(|vm| {
+        let exc_type = NonNull::new(exc_type).map(|ptr| unsafe { PyObjectRef::from_raw(ptr) });
+        let exc_val = NonNull::new(exc_val).map(|ptr| unsafe { PyObjectRef::from_raw(ptr) });
+        let exc_tb = NonNull::new(exc_tb).map(|ptr| unsafe { PyObjectRef::from_raw(ptr) });
+
+        if let Some(exc_type) = exc_type {
+            let normalized = vm.normalize_exception(
+                exc_type,
+                vm.unwrap_or_none(exc_val),
+                vm.unwrap_or_none(exc_tb),
+            )?;
+            vm.set_exception(Some(normalized));
+        } else {
+            vm.set_exception(None);
+        };
+
+        Ok(())
+    })
+}
+
+#[unsafe(no_mangle)]
+pub extern "C" fn PyErr_GetHandledException() -> *mut PyObject {
+    with_vm(|vm| {
+        vm.current_exception()
+            .map(|exc| exc.into_object().into_raw().as_ptr())
+            .unwrap_or_default()
+    })
+}
+
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn PyErr_SetHandledException(exc: *mut PyObject) {
+    with_vm(|vm| {
+        if let Some(exc) = NonNull::new(exc) {
+            let exception = unsafe { PyObjectRef::from_raw(exc).downcast_unchecked() };
+            vm.set_exception(Some(exception));
+        } else {
+            vm.set_exception(None);
+        }
+    })
+}
+
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn PyErr_GetExcInfo(
+    ptype: *mut *mut PyObject,
+    pvalue: *mut *mut PyObject,
+    ptraceback: *mut *mut PyObject,
+) {
+    with_vm(|vm| {
+        let (ty, value, tb) = vm.current_exception().map_or_else(
+            || {
+                (
+                    core::ptr::null_mut(),
+                    core::ptr::null_mut(),
+                    core::ptr::null_mut(),
+                )
+            },
+            |exc| {
+                let (ty, value, tb) = vm.split_exception(exc);
+                let tb = if vm.is_none(&tb) {
+                    core::ptr::null_mut()
+                } else {
+                    tb.into_raw().as_ptr()
+                };
+                (ty.into_raw().as_ptr(), value.into_raw().as_ptr(), tb)
+            },
+        );
+
+        if let Some(ptype) = NonNull::new(ptype) {
+            unsafe { ptype.write(ty) };
+        }
+        if let Some(pvalue) = NonNull::new(pvalue) {
+            unsafe { pvalue.write(value) };
+        }
+        if let Some(ptraceback) = NonNull::new(ptraceback) {
+            unsafe { ptraceback.write(tb) };
+        }
+    })
+}
+
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn PyErr_SetExcInfo(
+    exc_type: *mut PyObject,
+    exc_val: *mut PyObject,
+    exc_tb: *mut PyObject,
+) {
+    with_vm(|vm| {
+        let _exc_type = NonNull::new(exc_type).map(|ptr| unsafe { PyObjectRef::from_raw(ptr) });
+        let _exc_tb = NonNull::new(exc_tb).map(|ptr| unsafe { PyObjectRef::from_raw(ptr) });
+        let exc_val = NonNull::new(exc_val).map(|ptr| unsafe { PyObjectRef::from_raw(ptr) });
+        let exc = exc_val
+            .map(|obj| {
+                obj.downcast::<PyBaseException>()
+                    .map_err(|_| vm.new_type_error("exception value must be an exception instance"))
+            })
+            .transpose()?;
+        vm.set_exception(exc);
+        Ok(())
+    })
+}
+
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn PyException_GetArgs(exc: *mut PyObject) -> *mut PyObject {
+    with_vm(|vm| {
+        let exc = unsafe { &*exc }.try_downcast_ref::<PyBaseException>(vm)?;
+        Ok(exc.args())
+    })
+}
+
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn PyException_SetArgs(exc: *mut PyObject, args: *mut PyObject) {
+    with_vm(|vm| {
+        let exc = unsafe { &*exc }.try_downcast_ref::<PyBaseException>(vm)?;
+        let args = unsafe { &*args }.to_owned();
+        exc.as_object().set_attr("args", args, vm)
     })
 }
 

--- a/crates/capi/src/pyerrors/errno.rs
+++ b/crates/capi/src/pyerrors/errno.rs
@@ -1,0 +1,117 @@
+use crate::unicodeobject::decode_fsdefault_and_size;
+use crate::{PyObject, pystate::with_vm};
+use core::convert::Infallible;
+use core::ffi::{CStr, c_char};
+use core::ptr::NonNull;
+use rustpython_vm::builtins::PyType;
+use rustpython_vm::convert::ToPyObject;
+use rustpython_vm::{AsObject, PyResult};
+
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn PyErr_SetFromErrno(exc: *mut PyObject) -> *mut PyObject {
+    unsafe {
+        PyErr_SetFromErrnoWithFilenameObjects(exc, core::ptr::null_mut(), core::ptr::null_mut())
+    }
+}
+
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn PyErr_SetFromErrnoWithFilename(
+    exc: *mut PyObject,
+    filename: *const c_char,
+) -> *mut PyObject {
+    with_vm::<PyResult<Infallible>, _>(|vm| {
+        let errno = rustpython_vm::host_env::os::get_errno();
+        if errno == libc::EINTR {
+            vm.check_signals()?;
+        }
+
+        let filename = if filename.is_null() {
+            None
+        } else {
+            let filename_len = unsafe { CStr::from_ptr(filename) }.count_bytes();
+            let filename = decode_fsdefault_and_size(vm, filename, filename_len)?;
+            Some(filename.into())
+        };
+
+        let exc_type = unsafe { &*exc }.try_downcast_ref::<PyType>(vm)?;
+        let msg = if errno == 0 {
+            vm.ctx.new_str("Error").into()
+        } else {
+            let msg = rustpython_vm::host_env::errno::strerror_string(errno)
+                .unwrap_or_else(|| "Error".to_owned());
+            vm.ctx.new_str(msg).into()
+        };
+
+        let args = if let Some(filename) = filename {
+            vec![errno.to_pyobject(vm), msg, filename]
+        } else {
+            vec![errno.to_pyobject(vm), msg]
+        };
+        let err = exc_type.as_object().call(args, vm)?;
+        let err = err
+            .downcast()
+            .map_err(|_| vm.new_type_error("errno helper expected an exception instance"))?;
+        Err(err)
+    })
+}
+
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn PyErr_SetFromErrnoWithFilenameObject(
+    exc: *mut PyObject,
+    filename: *mut PyObject,
+) -> *mut PyObject {
+    unsafe { PyErr_SetFromErrnoWithFilenameObjects(exc, filename, core::ptr::null_mut()) }
+}
+
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn PyErr_SetFromErrnoWithFilenameObjects(
+    exc: *mut PyObject,
+    filename: *mut PyObject,
+    filename2: *mut PyObject,
+) -> *mut PyObject {
+    with_vm::<PyResult<Infallible>, _>(|vm| {
+        let errno = rustpython_vm::host_env::os::get_errno();
+        if errno == libc::EINTR {
+            vm.check_signals()?;
+        }
+
+        let exc_type = unsafe { &*exc }.try_downcast_ref::<PyType>(vm)?;
+        let msg = if errno == 0 {
+            vm.ctx.new_str("Error").into()
+        } else {
+            let msg = rustpython_vm::host_env::errno::strerror_string(errno)
+                .unwrap_or_else(|| "Error".to_owned());
+            vm.ctx.new_str(msg).into()
+        };
+
+        let filename = NonNull::new(filename).map_or_else(
+            || vm.ctx.none(),
+            |filename| unsafe { filename.as_ref().to_owned() },
+        );
+        let filename2 = NonNull::new(filename2).map_or_else(
+            || vm.ctx.none(),
+            |filename| unsafe { filename.as_ref().to_owned() },
+        );
+
+        let args = if !vm.is_none(&filename2) {
+            vec![
+                errno.to_pyobject(vm),
+                msg,
+                filename,
+                0.to_pyobject(vm),
+                filename2,
+            ]
+        } else if !vm.is_none(&filename) {
+            vec![errno.to_pyobject(vm), msg, filename]
+        } else {
+            vec![errno.to_pyobject(vm), msg]
+        };
+
+        let err = exc_type.as_object().call(args, vm)?;
+        let err = err
+            .downcast()
+            .map_err(|_| vm.new_type_error("errno helper expected an exception instance"))?;
+
+        Err(err)
+    })
+}

--- a/crates/capi/src/pyerrors/errno.rs
+++ b/crates/capi/src/pyerrors/errno.rs
@@ -3,9 +3,8 @@ use crate::{PyObject, pystate::with_vm};
 use core::convert::Infallible;
 use core::ffi::{CStr, c_char};
 use core::ptr::NonNull;
+use rustpython_vm::PyResult;
 use rustpython_vm::builtins::PyType;
-use rustpython_vm::convert::ToPyObject;
-use rustpython_vm::{AsObject, PyResult};
 
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn PyErr_SetFromErrno(exc: *mut PyObject) -> *mut PyObject {
@@ -21,9 +20,6 @@ pub unsafe extern "C" fn PyErr_SetFromErrnoWithFilename(
 ) -> *mut PyObject {
     with_vm::<PyResult<Infallible>, _>(|vm| {
         let errno = rustpython_vm::host_env::os::get_errno();
-        if errno == libc::EINTR {
-            vm.check_signals()?;
-        }
 
         let filename = if filename.is_null() {
             None
@@ -34,23 +30,7 @@ pub unsafe extern "C" fn PyErr_SetFromErrnoWithFilename(
         };
 
         let exc_type = unsafe { &*exc }.try_downcast_ref::<PyType>(vm)?;
-        let msg = if errno == 0 {
-            vm.ctx.new_str("Error").into()
-        } else {
-            let msg = rustpython_vm::host_env::errno::strerror_string(errno)
-                .unwrap_or_else(|| "Error".to_owned());
-            vm.ctx.new_str(msg).into()
-        };
-
-        let args = if let Some(filename) = filename {
-            vec![errno.to_pyobject(vm), msg, filename]
-        } else {
-            vec![errno.to_pyobject(vm), msg]
-        };
-        let err = exc_type.as_object().call(args, vm)?;
-        let err = err
-            .downcast()
-            .map_err(|_| vm.new_type_error("errno helper expected an exception instance"))?;
+        let err = vm.new_errno_error_with_filenames(exc_type.to_owned(), errno, filename, None)?;
         Err(err)
     })
 }
@@ -71,46 +51,14 @@ pub unsafe extern "C" fn PyErr_SetFromErrnoWithFilenameObjects(
 ) -> *mut PyObject {
     with_vm::<PyResult<Infallible>, _>(|vm| {
         let errno = rustpython_vm::host_env::os::get_errno();
-        if errno == libc::EINTR {
-            vm.check_signals()?;
-        }
 
         let exc_type = unsafe { &*exc }.try_downcast_ref::<PyType>(vm)?;
-        let msg = if errno == 0 {
-            vm.ctx.new_str("Error").into()
-        } else {
-            let msg = rustpython_vm::host_env::errno::strerror_string(errno)
-                .unwrap_or_else(|| "Error".to_owned());
-            vm.ctx.new_str(msg).into()
-        };
-
-        let filename = NonNull::new(filename).map_or_else(
-            || vm.ctx.none(),
-            |filename| unsafe { filename.as_ref().to_owned() },
-        );
-        let filename2 = NonNull::new(filename2).map_or_else(
-            || vm.ctx.none(),
-            |filename| unsafe { filename.as_ref().to_owned() },
-        );
-
-        let args = if !vm.is_none(&filename2) {
-            vec![
-                errno.to_pyobject(vm),
-                msg,
-                filename,
-                0.to_pyobject(vm),
-                filename2,
-            ]
-        } else if !vm.is_none(&filename) {
-            vec![errno.to_pyobject(vm), msg, filename]
-        } else {
-            vec![errno.to_pyobject(vm), msg]
-        };
-
-        let err = exc_type.as_object().call(args, vm)?;
-        let err = err
-            .downcast()
-            .map_err(|_| vm.new_type_error("errno helper expected an exception instance"))?;
+        let filename =
+            NonNull::new(filename).map(|filename| unsafe { filename.as_ref().to_owned() });
+        let filename2 =
+            NonNull::new(filename2).map(|filename| unsafe { filename.as_ref().to_owned() });
+        let err =
+            vm.new_errno_error_with_filenames(exc_type.to_owned(), errno, filename, filename2)?;
 
         Err(err)
     })

--- a/crates/capi/src/pyerrors/unicode.rs
+++ b/crates/capi/src/pyerrors/unicode.rs
@@ -69,11 +69,12 @@ pub unsafe extern "C" fn PyUnicodeDecodeError_GetStart(
     start: *mut isize,
 ) -> c_int {
     with_vm(|vm| {
+        let exc = unsafe { &*exc };
         let start =
             NonNull::new(start).ok_or_else(|| vm.new_system_error("start must not be null"))?;
-        let value = unsafe { &*exc }.get_attr("start", vm)?;
+        let value = exc.get_attr("start", vm)?;
         let value = value.try_index(vm)?.try_to_primitive::<isize>(vm)?;
-        let object_len = unsafe { &*exc }.get_attr("object", vm)?.length(vm)?;
+        let object_len = exc.get_attr("object", vm)?.length(vm)?;
         let value = if object_len == 0 {
             0
         } else {

--- a/crates/capi/src/pyerrors/unicode.rs
+++ b/crates/capi/src/pyerrors/unicode.rs
@@ -1,0 +1,272 @@
+use crate::util::CStrExt;
+use crate::{PyObject, pystate::with_vm};
+use core::ffi::{c_char, c_int};
+use core::ptr::NonNull;
+use core::slice;
+
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn PyUnicodeDecodeError_Create(
+    encoding: *const c_char,
+    object: *const c_char,
+    length: isize,
+    start: isize,
+    end: isize,
+    reason: *const c_char,
+) -> *mut PyObject {
+    with_vm(|vm| {
+        let encoding = unsafe { encoding.try_as_str(vm) }?;
+        let reason = unsafe { reason.try_as_str(vm) }?;
+        let length: usize = length
+            .try_into()
+            .map_err(|_| vm.new_system_error("length must be non-negative"))?;
+        let start: usize = start
+            .try_into()
+            .map_err(|_| vm.new_system_error("start must be non-negative"))?;
+        let end: usize = end
+            .try_into()
+            .map_err(|_| vm.new_system_error("end must be non-negative"))?;
+
+        let bytes = if object.is_null() {
+            if length != 0 {
+                return Err(vm.new_system_error(
+                    "PyUnicodeDecodeError_Create called with null object and non-zero length",
+                ));
+            }
+            Vec::new()
+        } else {
+            unsafe { slice::from_raw_parts(object.cast::<u8>(), length) }.to_vec()
+        };
+
+        let exc = vm.new_unicode_decode_error_real(
+            vm.ctx.new_str(encoding),
+            vm.ctx.new_bytes(bytes),
+            start,
+            end,
+            vm.ctx.new_str(reason),
+        );
+        Ok(exc)
+    })
+}
+
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn PyUnicodeDecodeError_GetEncoding(exc: *mut PyObject) -> *mut PyObject {
+    with_vm(|vm| unsafe { &*exc }.get_attr("encoding", vm))
+}
+
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn PyUnicodeDecodeError_GetObject(exc: *mut PyObject) -> *mut PyObject {
+    with_vm(|vm| unsafe { &*exc }.get_attr("object", vm))
+}
+
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn PyUnicodeDecodeError_GetReason(exc: *mut PyObject) -> *mut PyObject {
+    with_vm(|vm| unsafe { &*exc }.get_attr("reason", vm))
+}
+
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn PyUnicodeDecodeError_GetStart(
+    exc: *mut PyObject,
+    start: *mut isize,
+) -> c_int {
+    with_vm(|vm| {
+        let start =
+            NonNull::new(start).ok_or_else(|| vm.new_system_error("start must not be null"))?;
+        let value = unsafe { &*exc }.get_attr("start", vm)?;
+        let value = value.try_index(vm)?.try_to_primitive::<isize>(vm)?;
+        let object_len = unsafe { &*exc }.get_attr("object", vm)?.length(vm)?;
+        let value = if object_len == 0 {
+            0
+        } else {
+            value.clamp(0, object_len.saturating_sub(1) as isize)
+        };
+        unsafe { start.write(value) };
+        Ok(())
+    })
+}
+
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn PyUnicodeDecodeError_GetEnd(exc: *mut PyObject, end: *mut isize) -> c_int {
+    with_vm(|vm| {
+        let end = NonNull::new(end).ok_or_else(|| vm.new_system_error("end must not be null"))?;
+        let value = unsafe { &*exc }.get_attr("end", vm)?;
+        let value = value.try_index(vm)?.try_to_primitive::<isize>(vm)?;
+        let object_len = unsafe { &*exc }.get_attr("object", vm)?.length(vm)?;
+        let value = if object_len == 0 {
+            0
+        } else {
+            value.clamp(1, object_len as isize)
+        };
+        unsafe { end.write(value) };
+        Ok(())
+    })
+}
+
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn PyUnicodeDecodeError_SetStart(exc: *mut PyObject, start: isize) -> c_int {
+    with_vm(|vm| unsafe { &*exc }.set_attr("start", vm.ctx.new_int(start), vm))
+}
+
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn PyUnicodeDecodeError_SetEnd(exc: *mut PyObject, end: isize) -> c_int {
+    with_vm(|vm| unsafe { &*exc }.set_attr("end", vm.ctx.new_int(end), vm))
+}
+
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn PyUnicodeDecodeError_SetReason(
+    exc: *mut PyObject,
+    reason: *const c_char,
+) -> c_int {
+    with_vm(|vm| {
+        let reason = unsafe { reason.try_as_str(vm)? };
+        unsafe { &*exc }.set_attr("reason", vm.ctx.new_str(reason), vm)
+    })
+}
+
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn PyUnicodeEncodeError_GetEncoding(exc: *mut PyObject) -> *mut PyObject {
+    with_vm(|vm| unsafe { &*exc }.get_attr("encoding", vm))
+}
+
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn PyUnicodeEncodeError_GetObject(exc: *mut PyObject) -> *mut PyObject {
+    with_vm(|vm| unsafe { &*exc }.get_attr("object", vm))
+}
+
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn PyUnicodeEncodeError_GetReason(exc: *mut PyObject) -> *mut PyObject {
+    with_vm(|vm| unsafe { &*exc }.get_attr("reason", vm))
+}
+
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn PyUnicodeEncodeError_GetStart(
+    exc: *mut PyObject,
+    start: *mut isize,
+) -> c_int {
+    with_vm(|vm| {
+        let start =
+            NonNull::new(start).ok_or_else(|| vm.new_system_error("start must not be null"))?;
+        let value = unsafe { &*exc }.get_attr("start", vm)?;
+        let value = value.try_index(vm)?.try_to_primitive::<isize>(vm)?;
+        let object_len = unsafe { &*exc }.get_attr("object", vm)?.length(vm)?;
+        let value = if object_len == 0 {
+            0
+        } else {
+            value.clamp(0, object_len.saturating_sub(1) as isize)
+        };
+        unsafe { start.write(value) };
+        Ok(())
+    })
+}
+
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn PyUnicodeEncodeError_GetEnd(exc: *mut PyObject, end: *mut isize) -> c_int {
+    with_vm(|vm| {
+        let end = NonNull::new(end).ok_or_else(|| vm.new_system_error("end must not be null"))?;
+        let value = unsafe { &*exc }.get_attr("end", vm)?;
+        let value = value.try_index(vm)?.try_to_primitive::<isize>(vm)?;
+        let object_len = unsafe { &*exc }.get_attr("object", vm)?.length(vm)?;
+        let value = if object_len == 0 {
+            0
+        } else {
+            value.clamp(1, object_len as isize)
+        };
+        unsafe { end.write(value) };
+        Ok(())
+    })
+}
+
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn PyUnicodeEncodeError_SetStart(exc: *mut PyObject, start: isize) -> c_int {
+    with_vm(|vm| unsafe { &*exc }.set_attr("start", vm.ctx.new_int(start), vm))
+}
+
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn PyUnicodeEncodeError_SetEnd(exc: *mut PyObject, end: isize) -> c_int {
+    with_vm(|vm| unsafe { &*exc }.set_attr("end", vm.ctx.new_int(end), vm))
+}
+
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn PyUnicodeEncodeError_SetReason(
+    exc: *mut PyObject,
+    reason: *const c_char,
+) -> c_int {
+    with_vm(|vm| {
+        let reason = unsafe { reason.try_as_str(vm)? };
+        unsafe { &*exc }.set_attr("reason", vm.ctx.new_str(reason), vm)
+    })
+}
+
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn PyUnicodeTranslateError_GetObject(exc: *mut PyObject) -> *mut PyObject {
+    with_vm(|vm| unsafe { &*exc }.get_attr("object", vm))
+}
+
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn PyUnicodeTranslateError_GetReason(exc: *mut PyObject) -> *mut PyObject {
+    with_vm(|vm| unsafe { &*exc }.get_attr("reason", vm))
+}
+
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn PyUnicodeTranslateError_GetStart(
+    exc: *mut PyObject,
+    start: *mut isize,
+) -> c_int {
+    with_vm(|vm| {
+        let start =
+            NonNull::new(start).ok_or_else(|| vm.new_system_error("start must not be null"))?;
+        let value = unsafe { &*exc }.get_attr("start", vm)?;
+        let value = value.try_index(vm)?.try_to_primitive::<isize>(vm)?;
+        let object_len = unsafe { &*exc }.get_attr("object", vm)?.length(vm)?;
+        let value = if object_len == 0 {
+            0
+        } else {
+            value.clamp(0, object_len.saturating_sub(1) as isize)
+        };
+        unsafe { start.write(value) };
+        Ok(())
+    })
+}
+
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn PyUnicodeTranslateError_GetEnd(
+    exc: *mut PyObject,
+    end: *mut isize,
+) -> c_int {
+    with_vm(|vm| {
+        let end = NonNull::new(end).ok_or_else(|| vm.new_system_error("end must not be null"))?;
+        let value = unsafe { &*exc }.get_attr("end", vm)?;
+        let value = value.try_index(vm)?.try_to_primitive::<isize>(vm)?;
+        let object_len = unsafe { &*exc }.get_attr("object", vm)?.length(vm)?;
+        let value = if object_len == 0 {
+            0
+        } else {
+            value.clamp(1, object_len as isize)
+        };
+        unsafe { end.write(value) };
+        Ok(())
+    })
+}
+
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn PyUnicodeTranslateError_SetStart(
+    exc: *mut PyObject,
+    start: isize,
+) -> c_int {
+    with_vm(|vm| unsafe { &*exc }.set_attr("start", vm.ctx.new_int(start), vm))
+}
+
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn PyUnicodeTranslateError_SetEnd(exc: *mut PyObject, end: isize) -> c_int {
+    with_vm(|vm| unsafe { &*exc }.set_attr("end", vm.ctx.new_int(end), vm))
+}
+
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn PyUnicodeTranslateError_SetReason(
+    exc: *mut PyObject,
+    reason: *const c_char,
+) -> c_int {
+    with_vm(|vm| {
+        let reason = unsafe { reason.try_as_str(vm)? };
+        unsafe { &*exc }.set_attr("reason", vm.ctx.new_str(reason), vm)
+    })
+}

--- a/crates/capi/src/pyerrors/windows.rs
+++ b/crates/capi/src/pyerrors/windows.rs
@@ -1,0 +1,124 @@
+use crate::unicodeobject::decode_fsdefault_and_size;
+use crate::{PyObject, pyerrors::PyExc_OSError, pystate::with_vm};
+use core::convert::Infallible;
+use core::ffi::{CStr, c_char, c_int};
+use core::ptr::NonNull;
+use rustpython_vm::builtins::PyType;
+use rustpython_vm::convert::{IntoObject, ToPyObject};
+use rustpython_vm::host_env::windows::get_last_error;
+use rustpython_vm::{AsObject, PyObjectRef, PyResult};
+use std::io::Error;
+
+fn set_windows_error(
+    exc: &PyObject,
+    winerror: c_int,
+    filename: Option<PyObjectRef>,
+    filename2: Option<PyObjectRef>,
+) -> *mut PyObject {
+    with_vm::<PyResult<Infallible>, _>(|vm| {
+        let exc_type = exc.try_downcast_ref::<PyType>(vm)?;
+        let message = Error::from_raw_os_error(winerror).to_string();
+
+        let args = vec![
+            0.to_pyobject(vm),
+            vm.ctx.new_str(message).into(),
+            vm.unwrap_or_none(filename),
+            winerror.to_pyobject(vm),
+            vm.unwrap_or_none(filename2),
+        ];
+        let os_err = exc_type.as_object().call(args, vm)?.try_downcast(vm)?;
+        Err(os_err)
+    })
+}
+
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn PyErr_SetExcFromWindowsErr(
+    exc: *mut PyObject,
+    err: c_int,
+) -> *mut PyObject {
+    let winerror = if err != 0 {
+        err
+    } else {
+        get_last_error() as c_int
+    };
+    set_windows_error(unsafe { &*exc }, winerror, None, None)
+}
+
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn PyErr_SetExcFromWindowsErrWithFilename(
+    exc: *mut PyObject,
+    err: c_int,
+    filename: *const c_char,
+) -> *mut PyObject {
+    with_vm(|vm| {
+        let winerror = if err != 0 {
+            err
+        } else {
+            get_last_error() as c_int
+        };
+        let filename = NonNull::new(filename.cast_mut())
+            .map(|filename| {
+                let filename_len = unsafe { CStr::from_ptr(filename.as_ptr()) }.count_bytes();
+                decode_fsdefault_and_size(vm, filename.as_ptr(), filename_len)
+            })
+            .transpose()?
+            .map(|filename| filename.into_object());
+
+        Ok(set_windows_error(
+            unsafe { &*exc },
+            winerror,
+            filename,
+            None,
+        ))
+    })
+}
+
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn PyErr_SetExcFromWindowsErrWithFilenameObject(
+    exc: *mut PyObject,
+    err: c_int,
+    filename: *mut PyObject,
+) -> *mut PyObject {
+    let winerror = if err != 0 {
+        err
+    } else {
+        get_last_error() as c_int
+    };
+    let filename = NonNull::new(filename).map(|filename| unsafe { filename.as_ref().to_owned() });
+    set_windows_error(unsafe { &*exc }, winerror, filename, None)
+}
+
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn PyErr_SetExcFromWindowsErrWithFilenameObjects(
+    exc: *mut PyObject,
+    err: c_int,
+    filename: *mut PyObject,
+    filename2: *mut PyObject,
+) -> *mut PyObject {
+    let winerror = if err != 0 {
+        err
+    } else {
+        get_last_error() as c_int
+    };
+    let filename = NonNull::new(filename).map(|filename| unsafe { filename.as_ref().to_owned() });
+    let filename2 = NonNull::new(filename2).map(|filename| unsafe { filename.as_ref().to_owned() });
+    set_windows_error(unsafe { &*exc }, winerror, filename, filename2)
+}
+
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn PyErr_SetFromWindowsErr(err: c_int) -> *mut PyObject {
+    let winerror = if err != 0 {
+        err
+    } else {
+        get_last_error() as c_int
+    };
+    set_windows_error(unsafe { &*PyExc_OSError }, winerror, None, None)
+}
+
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn PyErr_SetFromWindowsErrWithFilename(
+    err: c_int,
+    filename: *const c_char,
+) -> *mut PyObject {
+    unsafe { PyErr_SetExcFromWindowsErrWithFilename(PyExc_OSError, err, filename) }
+}

--- a/crates/capi/src/util.rs
+++ b/crates/capi/src/util.rs
@@ -206,6 +206,19 @@ impl FfiResult<()> for PyResult<Infallible> {
     }
 }
 
+impl FfiResult<*mut PyObject> for PyResult<Infallible> {
+    const ERR_VALUE: *mut PyObject = core::ptr::null_mut();
+
+    fn into_output(self, vm: &VirtualMachine) -> *mut PyObject {
+        match self {
+            Err(err) => {
+                vm.set_exception(Some(err));
+                Self::ERR_VALUE
+            }
+        }
+    }
+}
+
 impl<Output, T> FfiResult<Output> for PyResult<T>
 where
     T: FfiResult<Output>,

--- a/crates/vm/src/vm/mod.rs
+++ b/crates/vm/src/vm/mod.rs
@@ -2302,7 +2302,7 @@ impl VirtualMachine {
         }
     }
 
-    pub(crate) fn topmost_exception(&self) -> Option<PyBaseExceptionRef> {
+    pub fn topmost_exception(&self) -> Option<PyBaseExceptionRef> {
         let excs = self.exceptions.borrow();
         excs.stack.iter().rev().find_map(|e| e.clone())
     }

--- a/crates/vm/src/vm/vm_new.rs
+++ b/crates/vm/src/vm/vm_new.rs
@@ -496,6 +496,44 @@ impl VirtualMachine {
         self.new_os_subtype_error(exc_type.to_owned(), Some(errno), msg)
     }
 
+    pub fn new_errno_error_with_filenames(
+        &self,
+        exc_type: PyTypeRef,
+        errno: i32,
+        filename: Option<PyObjectRef>,
+        filename2: Option<PyObjectRef>,
+    ) -> PyResult<PyBaseExceptionRef> {
+        if errno == libc::EINTR {
+            self.check_signals()?;
+        }
+
+        let msg = if errno == 0 {
+            self.ctx.new_str("Error").into()
+        } else {
+            let msg = crate::host_env::errno::strerror_string(errno)
+                .unwrap_or_else(|| "Error".to_owned());
+            self.ctx.new_str(msg).into()
+        };
+
+        let args = if let Some(filename2) = filename2 {
+            vec![
+                errno.to_pyobject(self),
+                msg,
+                filename.unwrap_or_else(|| self.ctx.none()),
+                0.to_pyobject(self),
+                filename2,
+            ]
+        } else if let Some(filename) = filename {
+            vec![errno.to_pyobject(self), msg, filename]
+        } else {
+            vec![errno.to_pyobject(self), msg]
+        };
+
+        let err = exc_type.as_object().call(args, self)?;
+        err.downcast()
+            .map_err(|_| self.new_type_error("errno helper expected an exception instance"))
+    }
+
     pub fn new_unicode_decode_error_real(
         &self,
         encoding: PyStrRef,

--- a/crates/vm/src/vm/vm_new.rs
+++ b/crates/vm/src/vm/vm_new.rs
@@ -503,16 +503,22 @@ impl VirtualMachine {
         filename: Option<PyObjectRef>,
         filename2: Option<PyObjectRef>,
     ) -> PyResult<PyBaseExceptionRef> {
+        #[cfg(not(target_arch = "wasm32"))]
         if errno == libc::EINTR {
             self.check_signals()?;
         }
 
-        let msg = if errno == 0 {
-            self.ctx.new_str("Error").into()
-        } else {
-            let msg = crate::host_env::errno::strerror_string(errno)
-                .unwrap_or_else(|| "Error".to_owned());
-            self.ctx.new_str(msg).into()
+        let msg = cfg_select! {
+            any(unix, windows) => {
+                if errno == 0 {
+                    self.ctx.new_str("Error").into()
+                } else {
+                    let msg = crate::host_env::errno::strerror_string(errno)
+                        .unwrap_or_else(|| "Error".to_owned());
+                    self.ctx.new_str(msg).into()
+                }
+            },
+            _ => self.ctx.new_str("Error").into()
         };
 
         let args = if let Some(filename2) = filename2 {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Expanded native C-API for exception management, including setting/clearing errors, handled exceptions, `exc_info`, signal/interrupt helpers, and fatal-error support.
  * Added OS-error helpers to construct exceptions from `errno` and Windows error codes, with optional filename context.
  * Introduced Unicode error constructors and attribute getters/setters for decode/encode/translate errors; also added exception `.args` getters/setters.
* **Bug Fixes**
  * Improved validation and normalization for traceback handling and Unicode error fields (including bounds/signaling checks).
* **Chores**
  * Improved infallible native error propagation when setting exceptions fails.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->