### PR TITLE
Fix clippy warning

### DIFF
--- a/crates/codegen/src/compile.rs
+++ b/crates/codegen/src/compile.rs
@@ -1752,15 +1752,13 @@ impl<'warnings> Compiler<'warnings> {
 
                 // Check if __class__ is available as a cell/free variable
                 // The scope must be Free (from enclosing class) or have DEF_FREE_CLASS flag
-                if let Some(symbol) = table.lookup("__class__") {
+                {
+                    let symbol = table.lookup("__class__")?;
                     if symbol.scope != SymbolScope::Free
                         && !symbol.flags.contains(SymbolFlags::DEF_FREE_CLASS)
                     {
                         return None;
                     }
-                } else {
-                    // __class__ not in symbol table, optimization not possible
-                    return None;
                 }
 
                 Some(SuperCallType::ZeroArg)
@@ -8260,12 +8258,7 @@ impl<'warnings> Compiler<'warnings> {
                 self.compile_name(id, NameUsage::Load)?;
                 AugAssignKind::Name { id }
             }
-            ast::Expr::Subscript(ast::ExprSubscript {
-                value,
-                slice,
-                ctx: _,
-                ..
-            }) => {
+            ast::Expr::Subscript(ast::ExprSubscript { value, slice, .. }) => {
                 let use_slice_opt = self.should_apply_two_element_slice_optimization(slice);
                 self.compile_expression(value)?;
                 self.set_source_range(target_range);
@@ -9225,14 +9218,7 @@ impl<'warnings> Compiler<'warnings> {
         let ast::Expr::Name(ast::ExprName { id, .. }) = func else {
             return None;
         };
-        let [
-            ast::Expr::Generator(ast::ExprGenerator {
-                elt: _,
-                generators: _,
-                ..
-            }),
-        ] = &args.args[..]
-        else {
+        let [ast::Expr::Generator(ast::ExprGenerator { .. })] = &args.args[..] else {
             return None;
         };
         if !args.keywords.is_empty() || {

--- a/crates/codegen/src/symboltable.rs
+++ b/crates/codegen/src/symboltable.rs
@@ -1623,7 +1623,6 @@ impl SymbolTableBuilder {
                     decorator_list,
                     type_params,
                     range,
-                    node_index: _,
                     ..
                 }) => {
                     let prev_class = self.class_name.clone();
@@ -1819,7 +1818,6 @@ impl SymbolTableBuilder {
                     value,
                     simple,
                     range,
-                    node_index: _,
                     ..
                 }) => {
                     self.tables.last_mut().unwrap().annotations_used = true;
@@ -2141,35 +2139,20 @@ impl SymbolTableBuilder {
             }
 
             match expression {
-                Expr::BinOp(ExprBinOp {
-                    left,
-                    right,
-                    range: _,
-                    ..
-                }) => {
+                Expr::BinOp(ExprBinOp { left, right, .. }) => {
                     self.scan_expression(left, context)?;
                     self.scan_expression(right, context)?;
                 }
-                Expr::BoolOp(ExprBoolOp {
-                    values, range: _, ..
-                }) => {
+                Expr::BoolOp(ExprBoolOp { values, .. }) => {
                     self.scan_expressions(values, context)?;
                 }
                 Expr::Compare(ExprCompare {
-                    left,
-                    comparators,
-                    range: _,
-                    ..
+                    left, comparators, ..
                 }) => {
                     self.scan_expression(left, context)?;
                     self.scan_expressions(comparators, context)?;
                 }
-                Expr::Subscript(ExprSubscript {
-                    value,
-                    slice,
-                    range: _,
-                    ..
-                }) => {
+                Expr::Subscript(ExprSubscript { value, slice, .. }) => {
                     self.scan_expression(value, ExpressionContext::Load)?;
                     self.scan_expression(slice, ExpressionContext::Load)?;
                 }
@@ -2179,12 +2162,7 @@ impl SymbolTableBuilder {
                     self.check_name(attr.as_str(), context, *range)?;
                     self.scan_expression(value, ExpressionContext::Load)?;
                 }
-                Expr::Dict(ExprDict {
-                    items,
-                    node_index: _,
-                    range: _,
-                    ..
-                }) => {
+                Expr::Dict(ExprDict { items, .. }) => {
                     for item in items {
                         if let Some(key) = &item.key {
                             self.scan_expression(key, context)?;
@@ -2194,12 +2172,7 @@ impl SymbolTableBuilder {
                         self.scan_expression(&item.value, context)?;
                     }
                 }
-                Expr::Await(ExprAwait {
-                    value,
-                    node_index: _,
-                    range: _,
-                    ..
-                }) => {
+                Expr::Await(ExprAwait { value, .. }) => {
                     let current_scope = self.tables.last().unwrap().typ;
                     if !self.allows_top_level_await()
                         && !Self::is_function_like_scope(current_scope)
@@ -2227,12 +2200,7 @@ impl SymbolTableBuilder {
                     self.scan_expression(value, context)?;
                     self.tables.last_mut().unwrap().is_coroutine = true;
                 }
-                Expr::Yield(ExprYield {
-                    value,
-                    node_index: _,
-                    range: _,
-                    ..
-                }) => {
+                Expr::Yield(ExprYield { value, .. }) => {
                     if let Some(expression) = value {
                         self.scan_expression(expression, context)?;
                     }
@@ -2252,12 +2220,7 @@ impl SymbolTableBuilder {
                         });
                     }
                 }
-                Expr::YieldFrom(ExprYieldFrom {
-                    value,
-                    node_index: _,
-                    range: _,
-                    ..
-                }) => {
+                Expr::YieldFrom(ExprYieldFrom { value, .. }) => {
                     self.scan_expression(value, context)?;
                     self.tables.last_mut().unwrap().is_generator = true;
                     if let Some(context_name) = self.comprehension_yield_context
@@ -2275,28 +2238,19 @@ impl SymbolTableBuilder {
                         });
                     }
                 }
-                Expr::UnaryOp(ExprUnaryOp {
-                    operand, range: _, ..
-                }) => {
+                Expr::UnaryOp(ExprUnaryOp { operand, .. }) => {
                     self.scan_expression(operand, context)?;
                 }
-                Expr::Starred(ExprStarred {
-                    value, range: _, ..
-                }) => {
+                Expr::Starred(ExprStarred { value, .. }) => {
                     self.scan_expression(value, context)?;
                 }
-                Expr::Tuple(ExprTuple { elts, range: _, .. })
-                | Expr::Set(ExprSet { elts, range: _, .. })
-                | Expr::List(ExprList { elts, range: _, .. }) => {
+                Expr::Tuple(ExprTuple { elts, .. })
+                | Expr::Set(ExprSet { elts, .. })
+                | Expr::List(ExprList { elts, .. }) => {
                     self.scan_expressions(elts, context)?;
                 }
                 Expr::Slice(ExprSlice {
-                    lower,
-                    upper,
-                    step,
-                    node_index: _,
-                    range: _,
-                    ..
+                    lower, upper, step, ..
                 }) => {
                     if let Some(lower) = lower {
                         self.scan_expression(lower, context)?;
@@ -2326,7 +2280,6 @@ impl SymbolTableBuilder {
                     elt,
                     generators,
                     range,
-                    node_index: _,
                     ..
                 }) => {
                     let was_in_iter_def_exp = self.in_iter_def_exp;
@@ -2341,7 +2294,6 @@ impl SymbolTableBuilder {
                     elt,
                     generators,
                     range,
-                    node_index: _,
                     ..
                 }) => {
                     let was_in_iter_def_exp = self.in_iter_def_exp;
@@ -2357,7 +2309,6 @@ impl SymbolTableBuilder {
                     value,
                     generators,
                     range,
-                    node_index: _,
                     ..
                 }) => {
                     let was_in_iter_def_exp = self.in_iter_def_exp;
@@ -2377,11 +2328,7 @@ impl SymbolTableBuilder {
                     self.in_iter_def_exp = was_in_iter_def_exp;
                 }
                 Expr::Call(ExprCall {
-                    func,
-                    arguments,
-                    node_index: _,
-                    range: _,
-                    ..
+                    func, arguments, ..
                 }) => {
                     match context {
                         ExpressionContext::IterDefinitionExp => {
@@ -2438,11 +2385,7 @@ impl SymbolTableBuilder {
                     }
                 }
                 Expr::Lambda(ExprLambda {
-                    body,
-                    parameters,
-                    node_index: _,
-                    range: _,
-                    ..
+                    body, parameters, ..
                 }) => {
                     let was_in_iter_def_exp = self.in_iter_def_exp;
                     if let Some(parameters) = parameters {
@@ -2535,12 +2478,7 @@ impl SymbolTableBuilder {
                     });
                 }
                 Expr::If(ExprIf {
-                    test,
-                    body,
-                    orelse,
-                    node_index: _,
-                    range: _,
-                    ..
+                    test, body, orelse, ..
                 }) => {
                     self.scan_expression(test, ExpressionContext::Load)?;
                     self.scan_expression(body, ExpressionContext::Load)?;
@@ -2551,7 +2489,6 @@ impl SymbolTableBuilder {
                     target,
                     value,
                     range,
-                    node_index: _,
                     ..
                 }) => {
                     // named expressions are not allowed in the definition of
@@ -2777,7 +2714,6 @@ impl SymbolTableBuilder {
                         bound,
                         range: type_var_range,
                         default,
-                        node_index: _,
                         ..
                     }) => {
                         self.register_name(name.as_str(), SymbolUsage::TypeParam, *type_var_range)?;
@@ -2821,7 +2757,6 @@ impl SymbolTableBuilder {
                         name,
                         range: param_spec_range,
                         default,
-                        node_index: _,
                         ..
                     }) => {
                         self.register_name(name, SymbolUsage::TypeParam, *param_spec_range)?;
@@ -2850,7 +2785,6 @@ impl SymbolTableBuilder {
                         name,
                         range: type_var_tuple_range,
                         default,
-                        node_index: _,
                         ..
                     }) => {
                         self.register_name(name, SymbolUsage::TypeParam, *type_var_tuple_range)?;

--- a/crates/derive-impl/src/util.rs
+++ b/crates/derive-impl/src/util.rs
@@ -63,7 +63,7 @@ impl ItemNursery {
                 if !inserted {
                     return Err(syn::Error::new(
                         item.attr_name.span(),
-                        format!("Duplicated #[py*] attribute found for {:?}", &item.py_names),
+                        format!("Duplicated #[py*] attribute found for {:?}", item.py_names),
                     ));
                 }
             }

--- a/crates/host_env/src/fileutils.rs
+++ b/crates/host_env/src/fileutils.rs
@@ -457,6 +457,7 @@ pub unsafe fn fclose(fp: *mut CFile) -> core::ffi::c_int {
 // _Py_fopen_obj in cpython (Python/fileutils.c:1757-1835)
 // Open a file using std::fs::File and convert to FILE*
 // Automatically handles path encoding and EINTR retries
+#[expect(clippy::std_instead_of_core)] // false positive: core::io::ErrorKind is unstable (core_io)
 pub fn fopen(path: &std::path::Path, mode: &str) -> std::io::Result<*mut CFile> {
     use alloc::ffi::CString;
     use std::fs::File;

--- a/crates/host_env/src/fileutils.rs
+++ b/crates/host_env/src/fileutils.rs
@@ -457,7 +457,10 @@ pub unsafe fn fclose(fp: *mut CFile) -> core::ffi::c_int {
 // _Py_fopen_obj in cpython (Python/fileutils.c:1757-1835)
 // Open a file using std::fs::File and convert to FILE*
 // Automatically handles path encoding and EINTR retries
-#[expect(clippy::std_instead_of_core)] // false positive: core::io::ErrorKind is unstable (core_io)
+#[expect(
+    clippy::std_instead_of_core,
+    reason = "false positive: core::io::ErrorKind is unstable (core_io)"
+)]
 pub fn fopen(path: &std::path::Path, mode: &str) -> std::io::Result<*mut CFile> {
     use alloc::ffi::CString;
     use std::fs::File;

--- a/crates/host_env/src/posix.rs
+++ b/crates/host_env/src/posix.rs
@@ -305,7 +305,10 @@ pub fn fchown(fd: BorrowedFd<'_>, uid: Option<u32>, gid: Option<u32>) -> std::io
 }
 
 #[cfg(not(windows))]
-#[expect(clippy::std_instead_of_core)] // false positive: core::io::ErrorKind is unstable (core_io)
+#[expect(
+    clippy::std_instead_of_core,
+    reason = "false positive: core::io::ErrorKind is unstable (core_io)"
+)]
 pub fn stat_path(
     path: &OsStr,
     dir_fd: Option<i32>,
@@ -1432,9 +1435,10 @@ fn build_posix_spawn_attrs(
             target_os = "illumos",
             target_os = "hurd",
         )))]
-        // false positive: core::io::ErrorKind is unstable (core_io); expect is co-gated with
-        // the usage so it is not left unfulfilled on platforms where this block is compiled out
-        #[expect(clippy::std_instead_of_core)]
+        #[expect(
+            clippy::std_instead_of_core,
+            reason = "false positive: core::io::ErrorKind is unstable (core_io); expect is co-gated with the usage so it is not left unfulfilled on platforms where this block is compiled out"
+        )]
         {
             return Err(std::io::Error::new(
                 std::io::ErrorKind::Unsupported,

--- a/crates/host_env/src/posix.rs
+++ b/crates/host_env/src/posix.rs
@@ -305,6 +305,7 @@ pub fn fchown(fd: BorrowedFd<'_>, uid: Option<u32>, gid: Option<u32>) -> std::io
 }
 
 #[cfg(not(windows))]
+#[expect(clippy::std_instead_of_core)] // false positive: core::io::ErrorKind is unstable (core_io)
 pub fn stat_path(
     path: &OsStr,
     dir_fd: Option<i32>,
@@ -1431,6 +1432,9 @@ fn build_posix_spawn_attrs(
             target_os = "illumos",
             target_os = "hurd",
         )))]
+        // false positive: core::io::ErrorKind is unstable (core_io); expect is co-gated with
+        // the usage so it is not left unfulfilled on platforms where this block is compiled out
+        #[expect(clippy::std_instead_of_core)]
         {
             return Err(std::io::Error::new(
                 std::io::ErrorKind::Unsupported,

--- a/crates/stdlib/src/binascii.rs
+++ b/crates/stdlib/src/binascii.rs
@@ -392,7 +392,7 @@ mod decl {
         // there are a few uuencodes out there that use
         // '`' as zero instead of space.
         if !(b' '..=(b' ' + 64)).contains(&c) {
-            if [b'\r', b'\n'].contains(&c) {
+            if b"\r\n".contains(&c) {
                 return Ok(0);
             }
             return Err(super::new_binascii_error("Illegal char", vm));

--- a/crates/stdlib/src/pyexpat.rs
+++ b/crates/stdlib/src/pyexpat.rs
@@ -1,5 +1,8 @@
 //! Pyexpat builtin module
 
+// false positive: core::io::Cursor is unstable (core_io), unusable on stable
+#![expect(clippy::std_instead_of_core)]
+
 // spell-checker: ignore libexpat
 
 pub(crate) use _pyexpat::module_def;

--- a/crates/stdlib/src/ssl.rs
+++ b/crates/stdlib/src/ssl.rs
@@ -13,6 +13,9 @@
 //!
 //! Warning: This library contains AI-generated code and comments. Do not trust any code or comment without verification. Please have a qualified expert review the code and remove this notice after review.
 
+// false positive: core::io::{Cursor, ErrorKind} are unstable (core_io), unusable on stable
+#![expect(clippy::std_instead_of_core)]
+
 // OID (Object Identifier) management module
 mod oid;
 

--- a/crates/vm/src/builtins/builtin_func.rs
+++ b/crates/vm/src/builtins/builtin_func.rs
@@ -157,7 +157,7 @@ impl PyNativeFunction {
                 // m_self is an instance: use Py_TYPE(m_self).__qualname__
                 bound.class().name().to_string()
             };
-            vm.ctx.new_str(format!("{}.{}", prefix, &zelf.value.name))
+            vm.ctx.new_str(format!("{}.{}", prefix, zelf.value.name))
         } else {
             vm.ctx.intern_str(zelf.value.name).to_owned()
         };
@@ -220,7 +220,7 @@ impl fmt::Debug for PyNativeMethod {
             f,
             "builtin method of {:?} with {:?}",
             &*self.class.name(),
-            &self.func
+            self.func
         )
     }
 }

--- a/crates/vm/src/builtins/descriptor.rs
+++ b/crates/vm/src/builtins/descriptor.rs
@@ -127,7 +127,7 @@ impl PyMethodDescriptor {
 
     #[pygetset]
     fn __qualname__(&self) -> String {
-        format!("{}.{}", self.common.typ.name(), &self.common.name)
+        format!("{}.{}", self.common.typ.name(), self.common.name)
     }
 
     #[pygetset]
@@ -164,7 +164,7 @@ impl Representable for PyMethodDescriptor {
     fn repr_str(zelf: &Py<Self>, _vm: &VirtualMachine) -> PyResult<String> {
         Ok(format!(
             "<method '{}' of '{}' objects>",
-            &zelf.method.name,
+            zelf.method.name,
             zelf.common.typ.name()
         ))
     }

--- a/crates/vm/src/builtins/memory.rs
+++ b/crates/vm/src/builtins/memory.rs
@@ -198,7 +198,7 @@ impl PyMemoryView {
         let data = self.format_spec.pack(vec![value], vm).map_err(|_| {
             vm.new_type_error(format!(
                 "memoryview: invalid type for format '{}'",
-                &self.desc.format
+                self.desc.format
             ))
         })?;
         bytes[pos..pos + self.desc.itemsize].copy_from_slice(&data);

--- a/crates/vm/src/builtins/super.rs
+++ b/crates/vm/src/builtins/super.rs
@@ -237,7 +237,7 @@ impl Representable for PySuper {
         let obj = zelf.inner.read().obj.clone();
         let repr = match obj {
             Some((_, ref ty)) => {
-                format!("<super: <class '{}'>, <{} object>>", &type_name, ty.name())
+                format!("<super: <class '{}'>, <{} object>>", type_name, ty.name())
             }
             None => format!("<super: <class '{type_name}'>, NULL>"),
         };

--- a/crates/vm/src/builtins/type.rs
+++ b/crates/vm/src/builtins/type.rs
@@ -431,7 +431,7 @@ impl core::fmt::Display for PyType {
 
 impl core::fmt::Debug for PyType {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        write!(f, "[PyType {}]", &self.name())
+        write!(f, "[PyType {}]", self.name())
     }
 }
 
@@ -1906,13 +1906,7 @@ impl PyType {
             .get(identifier!(vm, __module__))
             .cloned()
             // We need to exclude this method from going into recursion:
-            .and_then(|found| {
-                if found.fast_isinstance(vm.ctx.types.getset_type) {
-                    None
-                } else {
-                    Some(found)
-                }
-            })
+            .filter(|found| !found.fast_isinstance(vm.ctx.types.getset_type))
             .unwrap_or_else(|| {
                 // For non-heap types, extract module from tp_name (e.g. "typing.TypeAliasType" -> "typing")
                 let slot_name = self.slot_name();

--- a/crates/vm/src/exceptions.rs
+++ b/crates/vm/src/exceptions.rs
@@ -2652,7 +2652,7 @@ pub(super) mod types {
             Ok(vm.ctx.new_str(if start < object.len() && end <= object.len() && end == start + 1 {
                 let b = object.borrow_buf()[start];
                 format!(
-                    "'{encoding}' codec can't decode byte {b:#02x} in position {start}: {reason}"
+                    "'{encoding}' codec can't decode byte {b:#04x} in position {start}: {reason}"
                 )
             } else {
                 format!(

--- a/crates/vm/src/frame.rs
+++ b/crates/vm/src/frame.rs
@@ -3801,16 +3801,15 @@ impl ExecutingFrame<'_> {
                             }
                             seen_keys.add(key.as_object().to_owned(), vm)?;
                             // value = map.get(key, dummy)
-                            match get_method.call((key.as_object(), dummy.clone()), vm) {
-                                Ok(value) => {
-                                    // if value == dummy: key not in map!
-                                    if value.is(&dummy) {
-                                        all_match = false;
-                                        break;
-                                    }
-                                    values.push(value);
+                            {
+                                let value =
+                                    get_method.call((key.as_object(), dummy.clone()), vm)?;
+                                // if value == dummy: key not in map!
+                                if value.is(&dummy) {
+                                    all_match = false;
+                                    break;
                                 }
-                                Err(e) => return Err(e),
+                                values.push(value);
                             }
                         }
                     } else {

--- a/crates/vm/src/object/core.rs
+++ b/crates/vm/src/object/core.rs
@@ -454,7 +454,7 @@ impl<T> PyInner<T> {
 
 impl<T: fmt::Debug> fmt::Debug for PyInner<T> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "[PyObject {:?}]", &self.payload)
+        write!(f, "[PyObject {:?}]", self.payload)
     }
 }
 

--- a/crates/vm/src/object/payload.rs
+++ b/crates/vm/src/object/payload.rs
@@ -198,7 +198,7 @@ pub trait PyPayload: MaybeTraverse + PyThreadingConstraint + Sized + 'static {
             ) -> PyBaseExceptionRef {
                 vm.new_type_error(format!(
                     "'{}' is not a subtype of '{}'",
-                    &cls.name(),
+                    cls.name(),
                     exact_class.name()
                 ))
             }

--- a/crates/vm/src/stdlib/_ast/argument.rs
+++ b/crates/vm/src/stdlib/_ast/argument.rs
@@ -151,7 +151,6 @@ pub(super) fn split_function_call_arguments(
         args,
         keywords,
         runtime_args,
-        runtime_bases: _,
         ..
     } = args;
 

--- a/crates/vm/src/stdlib/_ctypes/function.rs
+++ b/crates/vm/src/stdlib/_ctypes/function.rs
@@ -771,7 +771,7 @@ impl Constructor for PyCFuncPtr {
                     .as_bigint()
                     .clone(),
             };
-            let terminated = format!("{}\0", &name);
+            let terminated = format!("{name}\0");
             let ptr_val = match rustpython_host_env::ctypes::lookup_function_symbol_addr(
                 handle
                     .to_usize()

--- a/crates/vm/src/stdlib/_io.rs
+++ b/crates/vm/src/stdlib/_io.rs
@@ -3290,7 +3290,7 @@ mod _io {
             use crate::types::PyComparisonOp;
             if cookie.rich_compare_bool(vm.ctx.new_int(0).as_ref(), PyComparisonOp::Lt, vm)? {
                 return Err(
-                    vm.new_value_error(format!("negative seek position {}", &cookie.repr(vm)?))
+                    vm.new_value_error(format!("negative seek position {}", cookie.repr(vm)?))
                 );
             }
             drop(textio);

--- a/crates/vm/src/stdlib/_io.rs
+++ b/crates/vm/src/stdlib/_io.rs
@@ -112,7 +112,10 @@ impl std::os::fd::AsRawFd for Fildes {
 }
 
 #[pymodule]
-#[expect(clippy::std_instead_of_core)] // false positive: core::io items (Cursor, etc.) are unstable (core_io)
+#[expect(
+    clippy::std_instead_of_core,
+    reason = "false positive: core::io items (Cursor, etc.) are unstable (core_io)"
+)]
 mod _io {
     use super::*;
     use crate::{

--- a/crates/vm/src/stdlib/_io.rs
+++ b/crates/vm/src/stdlib/_io.rs
@@ -112,6 +112,7 @@ impl std::os::fd::AsRawFd for Fildes {
 }
 
 #[pymodule]
+#[expect(clippy::std_instead_of_core)] // false positive: core::io items (Cursor, etc.) are unstable (core_io)
 mod _io {
     use super::*;
     use crate::{

--- a/crates/vm/src/stdlib/_signal.rs
+++ b/crates/vm/src/stdlib/_signal.rs
@@ -335,6 +335,10 @@ pub(crate) mod _signal {
         }
 
         #[cfg(windows)]
+        #[expect(
+            clippy::std_instead_of_core,
+            reason = "false positive: core::io::ErrorKind is unstable (core_io)"
+        )]
         let is_socket = if fd != INVALID_WAKEUP {
             host_signal::wakeup_fd_is_socket(fd).map_err(|err| {
                 if err.kind() == std::io::ErrorKind::InvalidInput {

--- a/crates/vm/src/stdlib/_sysconfigdata.rs
+++ b/crates/vm/src/stdlib/_sysconfigdata.rs
@@ -19,7 +19,7 @@ mod _sysconfigdata {
         let paths = &vm.state.config.paths;
         build_time_vars.set_item("prefix", paths.prefix.clone().to_pyobject(vm), vm)?;
         build_time_vars.set_item("exec_prefix", paths.exec_prefix.clone().to_pyobject(vm), vm)?;
-        let bindir = format!("{}/bin", &paths.exec_prefix);
+        let bindir = format!("{}/bin", paths.exec_prefix);
         build_time_vars.set_item("BINDIR", bindir.to_pyobject(vm), vm)?;
 
         module.set_attr("build_time_vars", build_time_vars, vm)?;

--- a/crates/vm/src/vm/vm_ops.rs
+++ b/crates/vm/src/vm/vm_ops.rs
@@ -568,7 +568,7 @@ impl VirtualMachine {
         formatted.downcast().map_err(|result| {
             self.new_type_error(format!(
                 "__format__ must return a str, not {}",
-                &result.class().name()
+                result.class().name()
             ))
         })
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -303,7 +303,7 @@ fn run_rustpython(vm: &VirtualMachine, run_mode: RunMode) -> PyResult<()> {
         RunMode::InstallPip(installer) => install_pip(installer, scope.clone(), vm),
         RunMode::Script(script_path) => {
             // pymain_run_file_obj
-            debug!("Running script {}", &script_path);
+            debug!("Running script {}", script_path);
             run_file(vm, scope.clone(), &script_path)
         }
         RunMode::Repl => Ok(()),


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Simplified internal matching/argument-handling logic and minor control-flow expressions without changing behavior.
* **Bug Fixes**
  * Improved formatting for debug/repr/qualname and error messages (including wider hex for `UnicodeDecodeError`, and cleaner formatting arguments for various builtins/IO/type messages).
* **Chores**
  * Added/adjusted targeted Clippy lint suppressions for known false positives across runtime and stdlib code.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->