### PR TITLE
`_queue`: check for pending signals during blocking `get()`

### DIFF
--- a/crates/stdlib/src/_queue.rs
+++ b/crates/stdlib/src/_queue.rs
@@ -31,6 +31,11 @@ mod _queue {
 
     const INITIAL_RING_BUF_CAPACITY: usize = 8;
 
+    /// Wait chunk size so blocking waits stay responsive to signals, mirroring
+    /// CPython's `PyThread_acquire_lock_timed`.
+    #[cfg(feature = "threading")]
+    const SIGNAL_CHECK_INTERVAL: Duration = Duration::from_millis(50);
+
     #[pyattr]
     #[pyclass(module = "_queue", name = "Empty", base = PyException)]
     #[repr(transparent)]
@@ -72,31 +77,50 @@ mod _queue {
             self.cond.notify_one();
         }
 
-        /// Returns `true` if the semaphore was acquired, `false` on timeout.
-        #[must_use]
-        fn acquire(&self, block: bool, deadline: Option<Instant>, vm: &VirtualMachine) -> bool {
-            let mut count = self.mutex.lock();
+        /// `Ok(true)` if acquired, `Ok(false)` on timeout, `Err` if a signal
+        /// handler raised (e.g. `KeyboardInterrupt`) while we were waiting.
+        fn acquire(
+            &self,
+            block: bool,
+            deadline: Option<Instant>,
+            vm: &VirtualMachine,
+        ) -> PyResult<bool> {
             loop {
-                if *count > 0 {
-                    *count -= 1;
-                    return true;
+                // Guard must be dropped before check_signals() below, since a
+                // signal handler may call back into this same queue.
+                {
+                    let mut count = self.mutex.lock();
+
+                    if *count > 0 {
+                        *count -= 1;
+                        return Ok(true);
+                    }
+
+                    if !block {
+                        return Ok(false);
+                    }
+
+                    let now = Instant::now();
+                    let chunk_deadline = deadline.map_or_else(
+                        || now + SIGNAL_CHECK_INTERVAL,
+                        |dl| dl.min(now + SIGNAL_CHECK_INTERVAL),
+                    );
+
+                    vm.allow_threads(|| self.cond.wait_until(&mut count, chunk_deadline));
+
+                    if *count > 0 {
+                        *count -= 1;
+                        return Ok(true);
+                    }
+
+                    if let Some(dl) = deadline
+                        && Instant::now() >= dl
+                    {
+                        return Ok(false);
+                    }
                 }
 
-                if !block {
-                    return false;
-                }
-
-                match deadline {
-                    Some(dl) => {
-                        let result = vm.allow_threads(|| self.cond.wait_until(&mut count, dl));
-                        if result.timed_out() && *count == 0 {
-                            return false;
-                        }
-                    }
-                    None => {
-                        vm.allow_threads(|| self.cond.wait(&mut count));
-                    }
-                }
+                vm.check_signals()?;
             }
         }
     }
@@ -227,7 +251,7 @@ mod _queue {
 
             #[cfg(feature = "threading")]
             {
-                if !self.sem.acquire(block, deadline, vm) {
+                if !self.sem.acquire(block, deadline, vm)? {
                     return Err(empty_error(vm));
                 }
             }
@@ -239,7 +263,7 @@ mod _queue {
         fn get_nowait(&self, vm: &VirtualMachine) -> PyResult<PyObjectRef> {
             #[cfg(feature = "threading")]
             {
-                if !self.sem.acquire(false, None, vm) {
+                if !self.sem.acquire(false, None, vm)? {
                     return Err(empty_error(vm));
                 }
             }

--- a/crates/stdlib/src/_queue.rs
+++ b/crates/stdlib/src/_queue.rs
@@ -37,7 +37,7 @@ mod _queue {
     // (SA_RESTART cleared via `siginterrupt`), but `parking_lot::Condvar` swallows
     // it and re-parks, forcing this poll. Replace with a shared interruptible
     // timed-wait that surfaces EINTR (`poll`/wakeup-fd, portable incl. macOS; or
-   // `sem_timedwait` where available) -- `_thread` lock and `Thread.join` share
+    // `sem_timedwait` where available) -- `_thread` lock and `Thread.join` share
     // this defect. Then this constant and the chunking loop go away.
     #[cfg(feature = "threading")]
     const SIGNAL_CHECK_INTERVAL: Duration = Duration::from_millis(50);

--- a/crates/stdlib/src/_queue.rs
+++ b/crates/stdlib/src/_queue.rs
@@ -33,6 +33,12 @@ mod _queue {
 
     /// `parking_lot`'s `Condvar` doesn't expose a mid-wait signal to us (unlike
     /// CPython's raw `sem_timedwait`, which reports `EINTR`), so we poll instead.
+    // FIXME: interim stopgap. The signal already interrupts the wait with EINTR
+    // (SA_RESTART cleared via `siginterrupt`), but `parking_lot::Condvar` swallows
+    // it and re-parks, forcing this poll. Replace with a shared interruptible
+    // timed-wait that surfaces EINTR (`poll`/wakeup-fd, portable incl. macOS; or
+   // `sem_timedwait` where available) -- `_thread` lock and `Thread.join` share
+    // this defect. Then this constant and the chunking loop go away.
     #[cfg(feature = "threading")]
     const SIGNAL_CHECK_INTERVAL: Duration = Duration::from_millis(50);
 

--- a/crates/stdlib/src/_queue.rs
+++ b/crates/stdlib/src/_queue.rs
@@ -31,8 +31,8 @@ mod _queue {
 
     const INITIAL_RING_BUF_CAPACITY: usize = 8;
 
-    /// Wait chunk size so blocking waits stay responsive to signals, mirroring
-    /// CPython's `PyThread_acquire_lock_timed`.
+    /// `parking_lot`'s `Condvar` doesn't expose a mid-wait signal to us (unlike
+    /// CPython's raw `sem_timedwait`, which reports `EINTR`), so we poll instead.
     #[cfg(feature = "threading")]
     const SIGNAL_CHECK_INTERVAL: Duration = Duration::from_millis(50);
 

--- a/extra_tests/snippets/stdlib_queue_signal.py
+++ b/extra_tests/snippets/stdlib_queue_signal.py
@@ -1,0 +1,52 @@
+"""A blocking queue.SimpleQueue.get() must stay responsive to signals.
+
+SimpleQueue.get() waits on a Condvar. A single uninterrupted wait blocks
+Python-level signal handlers (including the default KeyboardInterrupt) until
+the wait itself returns, since signals are only delivered at bytecode
+safepoints. A regression shows up as the handler firing only once get()
+unblocks, instead of promptly when the signal actually arrives.
+"""
+
+import queue
+import signal
+import sys
+import threading
+import time
+
+if sys.platform.startswith("win"):
+    print("skipped (no SIGALRM)")
+    raise SystemExit(0)
+
+q = queue.SimpleQueue()
+start = time.time()
+handled_at = []
+
+
+def handler(signum, frame):
+    handled_at.append(time.time() - start)
+
+
+signal.signal(signal.SIGALRM, handler)
+signal.setitimer(signal.ITIMER_REAL, 0.3)
+
+
+def unblock_later():
+    time.sleep(1.5)
+    q.put("unblock")
+
+
+threading.Thread(target=unblock_later, daemon=True).start()
+
+item = q.get()  # blocks until unblock_later() wakes us up
+elapsed = time.time() - start
+
+assert item == "unblock", item
+assert handled_at, "signal handler never ran"
+# The handler should fire around t=0.3s, when the timer was started, not t=1.5s
+# (when get() finally unblocked).
+assert handled_at[0] < elapsed - 0.5, (
+    f"signal handled at {handled_at[0]:.2f}s but get() only returned at "
+    f"{elapsed:.2f}s -- signal was not processed while blocked"
+)
+
+print("ok")


### PR DESCRIPTION
- [x] Closes #8250
- [x] This PR follows our [AI policy](https://github.com/RustPython/.github/blob/main/AI_POLICY.md)

## Summary

`queue.SimpleQueue.get()` blocked via a single uninterrupted `parking_lot::Condvar` wait, so a Python-level signal handler never ran until the wait itself returned -- `check_signals()` is only invoked from the bytecode dispatch loop, and this native wait never passed through it. CPython avoids this because its blocking wait (`sem_timedwait` pre-3.13, `_PyParkingLot_Park`/`_PySemaphore_Wait` in 3.13+) is backed by a real OS semaphore and gets `EINTR` directly from the kernel when a signal arrives -- no chunking, in either era.

This PR caps each wait at a short interval and calls `check_signals()` between chunks, only giving up once the caller's real deadline has actually elapsed. The mutex guard is dropped before `check_signals()` runs, since a signal handler that calls back into the same queue on the same thread would otherwise deadlock trying to relock a mutex it's still
holding (a self-deadlock I hit and fixed while developing this).

True parity with CPython would mean replacing the mutex+condvar primitive backing `Semaphore` (from the `parking_lot` Rust crate) with a real OS semaphore called directly via FFI (`sem_timedwait` on POSIX, `CreateSemaphore` on Windows) -- the same kind of primitive CPython's own parking-lot implementation (`Python/parking_lot.c`) uses internally. `parking_lot::Condvar` can't give us that: it swallows `EINTR` internally on every platform and never surfaces it to the caller. Given the low severity here (a handler delayed by up to `SIGNAL_CHECK_INTERVAL` instead of running instantly) against the cost of unsafe, per-platform code we'd have to write and maintain, polling is the pragmatic tradeoff.

[Before]
<img width="1654" height="442" alt="image" src="https://github.com/user-attachments/assets/2de7a20f-5e8e-49df-97cb-5a0c8adcd361" />


[After]
<img width="1586" height="512" alt="image" src="https://github.com/user-attachments/assets/0ccec282-c3bd-4542-94c0-21e781c3021f" />


## Test plan

- Added `extra_tests/snippets/stdlib_queue_signal.py`: arms a `SIGALRM`  well before a helper thread unblocks the queue, and asserts the handler  ran near the alarm instead of only once `get()` returned. Verified it fails with an `AssertionError` against the pre-fix code and passes after the fix.
- `cargo run -- -m test test_queue -j 1`: 162 passed, 6 skipped (unrelated, memory-gated).
- `cargo clippy` / `cargo fmt --check`: clean.
- Manually compared against real CPython on the same machine to confirm the expected (responsive) behavior.

## AI disclosure

This change was developed with assistance from Claude Code(claude-sonnet-5): investigating the root cause, drafting the fix andregression test, and iterating after I found a self-deadlock in an early
version of the fix. I reviewed the diff, ran the build/lints/tests myself, and verified the fix and regression test against both RustPython and real CPython before opening this PR.

Assisted-by: Claude Code:claude-sonnet-5

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved responsiveness of `queue.SimpleQueue.get()` / `get_nowait()` to OS signals while waiting for items.
  * Waiting behavior now checks for pending signals periodically, ensuring signal handlers run promptly and related errors are handled correctly.

* **Tests**
  * Added a regression test that sends an OS signal during a blocked `get()` call, confirms it unblocks via the intended path, and verifies the signal handler executes on time (skips on platforms without the needed signal).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->



