### PR TITLE
csv: apply dialect quoting and lineterminator in writer

### DIFF
--- a/Lib/test/test_csv.py
+++ b/Lib/test/test_csv.py
@@ -213,7 +213,6 @@ class Test_Csv(unittest.TestCase):
         self._write_test([bigstring,bigstring], '%s,%s' % \
                          (bigstring, bigstring))
 
-    @unittest.expectedFailure  # TODO: RUSTPYTHON
     def test_write_quoting(self):
         self._write_test(['a',1,'p,q'], 'a,1,"p,q"')
         self._write_error_test(csv.Error, ['a',1,'p,q'],

--- a/Lib/test/test_csv.py
+++ b/Lib/test/test_csv.py
@@ -862,7 +862,6 @@ class TestEscapedExcel(TestCsvBase):
 class TestDialectUnix(TestCsvBase):
     dialect = 'unix'
 
-    @unittest.expectedFailure  # TODO: RUSTPYTHON
     def test_simple_writer(self):
         self.writerAssertEqual([[1, 'abc def', 'abc']], '"1","abc def","abc"\n')
 

--- a/crates/stdlib/src/csv.rs
+++ b/crates/stdlib/src/csv.rs
@@ -796,6 +796,48 @@ mod _csv {
             delimiter
         }
 
+        fn get_lineterminator(&self) -> csv_core::Terminator {
+            let mut lineterminator = match &self.dialect {
+                DialectItem::Str(name) => {
+                    let g = GLOBAL_HASHMAP.lock();
+                    if let Some(dialect) = g.get(name) {
+                        dialect.lineterminator
+                    } else {
+                        Terminator::CRLF
+                    }
+                }
+                DialectItem::Obj(obj) => obj.lineterminator,
+                _ => Terminator::CRLF,
+            };
+
+            if let Some(attr) = self.lineterminator {
+                lineterminator = attr
+            }
+
+            lineterminator
+        }
+
+        fn get_quoting(&self) -> QuoteStyle {
+            let mut quoting = match &self.dialect {
+                DialectItem::Str(name) => {
+                    let g = GLOBAL_HASHMAP.lock();
+                    if let Some(dialect) = g.get(name) {
+                        dialect.quoting
+                    } else {
+                        QuoteStyle::Minimal
+                    }
+                }
+                DialectItem::Obj(obj) => obj.quoting,
+                _ => QuoteStyle::Minimal,
+            };
+
+            if let Some(attr) = self.quoting {
+                quoting = attr
+            }
+
+            quoting
+        }
+
         fn to_reader(&self) -> csv_core::Reader {
             let dialect = match &self.dialect {
                 DialectItem::Str(name) => GLOBAL_HASHMAP.lock().get(name).copied(),
@@ -900,15 +942,13 @@ mod _csv {
                 writer = writer.double_quote(t);
             }
 
-            writer = writer.terminator(self.lineterminator.unwrap_or(Terminator::CRLF));
+            writer = writer.terminator(self.get_lineterminator());
 
             if let Some(e) = self.escapechar {
                 writer = writer.escape(e);
             }
 
-            if let Some(e) = self.quoting {
-                writer = writer.quote_style(e.into());
-            }
+            writer = writer.quote_style(self.get_quoting().into());
 
             writer.build()
         }

--- a/crates/stdlib/src/csv.rs
+++ b/crates/stdlib/src/csv.rs
@@ -462,7 +462,7 @@ mod _csv {
     impl From<QuoteStyle> for csv_core::QuoteStyle {
         fn from(val: QuoteStyle) -> Self {
             match val {
-                QuoteStyle::Minimal => Self::Always,
+                QuoteStyle::Minimal => Self::Necessary,
                 QuoteStyle::All => Self::Always,
                 QuoteStyle::Nonnumeric => Self::NonNumeric,
                 QuoteStyle::None => Self::Never,


### PR DESCRIPTION
- [x] Closes #8253
- [x] This PR follows our [AI policy](https://github.com/RustPython/.github/blob/main/AI_POLICY.md)

## Summary

`csv.writer` ignored the `quoting` and `lineterminator` defined by a dialect (passed by name like `dialect='unix'` or as a dialect object), so writing with a built-in dialect diverged from CPython. Only explicit keyword arguments took effect. `to_writer` now resolves both from the dialect (via `get_quoting()` / `get_lineterminator()`, mirroring the existing `get_delimiter()`), while an explicit keyword argument still overrides it.

While fixing this I also found the `QuoteStyle::Minimal` → csv_core mapping was `Always` (quoting every field under `QUOTE_MINIMAL`); it is now `Necessary`. This was dormant because the quote style was only applied for an explicit `quoting=` argument, so it had to be fixed before applying the dialect's quoting.

```python
import csv, io
sio = io.StringIO()
csv.writer(sio, dialect='unix').writerow([1, 'abc def', 'abc'])
# before: '1,abc def,abc\r\n'
# after:  '"1","abc def","abc"\n'   (matches CPython)
```

## Test plan

- Unmarks `TestDialectUnix.test_simple_writer` and `Test_Csv.test_write_quoting` (both `@unittest.expectedFailure` before). `cargo run --release -- -m test test_csv`: 128 run, 7 skipped, SUCCESS.
- `extra_tests/snippets/stdlib_csv.py`: passes.
- `cargo fmt --check` / `cargo clippy`: clean (no new warnings).
- Compared against real CPython 3.14.6 on the same machine; the outputs for the `dialect='unix'` and `QUOTE_MINIMAL` cases match.

Assisted-by: Claude Code:claude-opus-4-8


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected minimal CSV quoting so values are quoted only when necessary.
  * Improved CSV formatting to consistently respect the selected dialect’s line terminator and quoting settings.
  * Ensured explicitly configured formatting options take precedence over dialect defaults.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->