### PR TITLE
Match CPython unsigned socket conversion errors

### DIFF
--- a/Lib/test/test_lzma.py
+++ b/Lib/test/test_lzma.py
@@ -656,7 +656,6 @@ class FileTestCase(unittest.TestCase):
         with self.assertRaises(ValueError):
             LZMAFile(BytesIO(COMPRESSED_XZ), check=lzma.CHECK_UNKNOWN)
 
-    @unittest.expectedFailure  # TODO: RUSTPYTHON; OverflowError: Python int too large to convert to Rust u32
     def test_init_bad_preset(self):
         with self.assertRaises(TypeError):
             LZMAFile(BytesIO(), "w", preset=4.39)

--- a/Lib/test/test_memoryio.py
+++ b/Lib/test/test_memoryio.py
@@ -934,10 +934,6 @@ class CBytesIOTest(PyBytesIOTest):
     def test_write(self):
         return super().test_write()
 
-    @unittest.expectedFailure  # TODO: RUSTPYTHON; OverflowError: Python int too large to convert to Rust u64
-    def test_seek(self):
-        return super().test_seek()
-
 class CStringIOTest(PyStringIOTest):
     ioclass = io.StringIO
     UnsupportedOperation = io.UnsupportedOperation
@@ -1029,10 +1025,6 @@ class CStringIOTest(PyStringIOTest):
     @unittest.expectedFailure  # TODO: RUSTPYTHON; AttributeError: 'StringIO' object has no attribute 'newlines'. Did you mean: 'readlines'?
     def test_newlines_property(self):
         return super().test_newlines_property()
-
-    @unittest.expectedFailure  # TODO: RUSTPYTHON; OverflowError: Python int too large to convert to Rust u64
-    def test_seek(self):
-        return super().test_seek()
 
     @unittest.expectedFailure  # TODO: RUSTPYTHON; d
     def test_newline_cr(self):

--- a/Lib/test/test_resource.py
+++ b/Lib/test/test_resource.py
@@ -151,7 +151,6 @@ class ResourceTest(unittest.TestCase):
                 resource.setrlimit(resource.RLIMIT_FSIZE, (2**64-5, max))
                 self.assertIn(resource.getrlimit(resource.RLIMIT_FSIZE), expected(2**64-5))
 
-    @unittest.expectedFailure  # TODO: RUSTPYTHON; OverflowError: Python int too large to convert to Rust u64
     @unittest.skipIf(sys.platform == "vxworks",
                      "setting RLIMIT_FSIZE is not supported on VxWorks")
     @unittest.skipUnless(hasattr(resource, 'RLIMIT_FSIZE'), 'requires resource.RLIMIT_FSIZE')

--- a/Lib/test/test_socket.py
+++ b/Lib/test/test_socket.py
@@ -1181,7 +1181,6 @@ class GeneralModuleTests(unittest.TestCase):
             self.assertIsInstance(_name, str)
             self.assertEqual(name, _name)
 
-    @unittest.expectedFailure  # TODO: RUSTPYTHON; OverflowError: Python int too large to convert to Rust u32
     @unittest.skipUnless(hasattr(socket, 'if_indextoname'),
                          'socket.if_indextoname() not available.')
     @support.skip_android_selinux('if_indextoname')
@@ -1249,7 +1248,6 @@ class GeneralModuleTests(unittest.TestCase):
             self.assertEqual(swapped & mask, mask)
             self.assertRaises(OverflowError, func, 1<<34)
 
-    @unittest.expectedFailure  # TODO: RUSTPYTHON; OverflowError: Python int too large to convert to Rust u16
     def testNtoHErrors(self):
         s_good_values = [0, 1, 2, 0xffff]
         l_good_values = s_good_values + [0xffffffff]

--- a/crates/stdlib/src/array.rs
+++ b/crates/stdlib/src/array.rs
@@ -498,7 +498,7 @@ pub mod array {
         ($($t:ty,)*) => {$(
             impl ArrayElement for $t {
                 fn try_into_from_object(vm: &VirtualMachine, obj: PyObjectRef) -> PyResult<Self> {
-                    obj.try_index(vm)?.try_to_primitive(vm)
+                    obj.try_index(vm)?.try_to_primitive_raw(vm)
                 }
                 fn byteswap(self) -> Self {
                     <$t>::swap_bytes(self)

--- a/crates/stdlib/src/socket.rs
+++ b/crates/stdlib/src/socket.rs
@@ -2230,7 +2230,7 @@ mod _socket {
             let addr = Self::from_tuple(tuple, vm)?;
             let flowinfo = tuple
                 .get(2)
-                .map(|obj| u32::try_from_borrowed_object(vm, obj))
+                .map(|obj| obj.clone().try_index(vm)?.try_to_primitive_raw(vm))
                 .transpose()?
                 .unwrap_or(0);
             let scopeid = tuple
@@ -3141,14 +3141,16 @@ mod _socket {
 
     #[cfg(all(unix, not(target_os = "redox")))]
     #[pyfunction(name = "CMSG_LEN")]
-    fn cmsg_len(length: usize, vm: &VirtualMachine) -> PyResult<usize> {
+    fn cmsg_len(length: PyObjectRef, vm: &VirtualMachine) -> PyResult<usize> {
+        let length = length.try_index(vm)?.try_to_primitive_raw(vm)?;
         host_socket::checked_cmsg_len(length)
             .ok_or_else(|| vm.new_overflow_error("CMSG_LEN() argument out of range"))
     }
 
     #[cfg(all(unix, not(target_os = "redox")))]
     #[pyfunction(name = "CMSG_SPACE")]
-    fn cmsg_space(length: usize, vm: &VirtualMachine) -> PyResult<usize> {
+    fn cmsg_space(length: PyObjectRef, vm: &VirtualMachine) -> PyResult<usize> {
+        let length = length.try_index(vm)?.try_to_primitive_raw(vm)?;
         host_socket::checked_cmsg_space(length)
             .ok_or_else(|| vm.new_overflow_error("CMSG_SPACE() argument out of range"))
     }

--- a/crates/vm/src/builtins/int.rs
+++ b/crates/vm/src/builtins/int.rs
@@ -343,13 +343,17 @@ impl PyInt {
     where
         I: PrimInt + TryFrom<&'a BigInt>,
     {
-        // TODO: Python 3.14+: ValueError for negative int to unsigned type
-        // See stdlib_socket.py socket.htonl(-1)
-        //
-        // if I::min_value() == I::zero() && self.as_bigint().sign() == Sign::Minus {
-        //     return Err(vm.new_value_error("Cannot convert negative int".to_owned()));
-        // }
+        if I::min_value() == I::zero() && self.as_bigint().sign() == Sign::Minus {
+            return Err(vm.new_value_error("can't convert negative number to unsigned"));
+        }
 
+        self.try_to_primitive_raw(vm)
+    }
+
+    pub fn try_to_primitive_raw<'a, I>(&'a self, vm: &VirtualMachine) -> PyResult<I>
+    where
+        I: PrimInt + TryFrom<&'a BigInt>,
+    {
         I::try_from(self.as_bigint()).map_err(|_| {
             vm.new_overflow_error(format!(
                 "Python int too large to convert to Rust {}",

--- a/crates/vm/src/stdlib/os.rs
+++ b/crates/vm/src/stdlib/os.rs
@@ -1870,7 +1870,8 @@ pub(super) mod _os {
 
     #[cfg(windows)]
     #[pyfunction]
-    fn waitstatus_to_exitcode(status: u64, vm: &VirtualMachine) -> PyResult<u32> {
+    fn waitstatus_to_exitcode(status: PyObjectRef, vm: &VirtualMachine) -> PyResult<u32> {
+        let status = status.try_index(vm)?.try_to_primitive_raw::<u64>(vm)?;
         let exitcode = status >> 8;
         // ExitProcess() accepts an UINT type:
         // reject exit code which doesn't fit in an UINT


### PR DESCRIPTION
Assisted-by: Codex:gpt-5.4

<!--
Thanks for your contribution!
-->

- [ ] Closes #xxxx <!-- Replace xxxx with the GitHub issue number -->
- [x] This PR follows our [AI policy](https://github.com/RustPython/.github/blob/main/AI_POLICY.md)

## Summary
<!-- What's the purpose of the change? What does it do, and why? -->
- Fixed `test_socket.GeneralModuleTests.testNtoHErrors` by aligning RustPython’s `socket.htons()`, `socket.htonl()`, `socket.ntohs()`, and `socket.ntohl()` error handling with CPython.
- This change makes the socket byte-order conversion helpers accept indexable Python objects, route conversion through the shared unsigned integer path, and raise `ValueError` for negative inputs instead of incorrectly surfacing `OverflowError`. It also updates the shared integer conversion helper so unsigned primitive conversions report the CPython-style negative-number error, which lets the expected-failure marker be removed from `Lib/test/test_socket.py`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Updated socket ancillary-data helpers to accept Python integer-like inputs and correctly raise overflow/out-of-range errors.
  * Improved IPv6 address tuple parsing for the optional `flowinfo` value.
  * Prevented negative integers from converting to unsigned integer types, raising a clear `ValueError`.
  * Aligned integer array element conversion with the same unsigned/primitive conversion rules.
  * Improved Windows `waitstatus_to_exitcode` input handling to accept Python integer-like values consistently.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->