### PR TITLE
csv: fix csv escape fieldsep

### DIFF
--- a/Lib/test/test_csv.py
+++ b/Lib/test/test_csv.py
@@ -857,7 +857,6 @@ class TestEscapedExcel(TestCsvBase):
     def test_escape_fieldsep(self):
         self.writerAssertEqual([['abc,def']], 'abc\\,def\r\n')
 
-    @unittest.expectedFailure  # TODO: RUSTPYTHON
     def test_read_escape_fieldsep(self):
         self.readerAssertEqual('abc\\,def\r\n', [['abc,def']])
 

--- a/Lib/test/test_csv.py
+++ b/Lib/test/test_csv.py
@@ -881,7 +881,6 @@ class TestQuotedEscapedExcel(TestCsvBase):
     def test_write_escape_fieldsep(self):
         self.writerAssertEqual([['abc,def']], '"abc,def"\r\n')
 
-    @unittest.expectedFailure  # TODO: RUSTPYTHON
     def test_read_escape_fieldsep(self):
         self.readerAssertEqual('"abc\\,def"\r\n', [['abc,def']])
 

--- a/crates/stdlib/src/csv.rs
+++ b/crates/stdlib/src/csv.rs
@@ -797,48 +797,27 @@ mod _csv {
         }
 
         fn to_reader(&self) -> csv_core::Reader {
+            let dialect = match &self.dialect {
+                DialectItem::Str(name) => GLOBAL_HASHMAP.lock().get(name).copied(),
+                DialectItem::Obj(obj) => Some(*obj),
+                DialectItem::None => {
+                    let g = GLOBAL_HASHMAP.lock();
+                    Some(*g.get("excel").unwrap())
+                }
+            };
+
             let mut builder = csv_core::ReaderBuilder::new();
-            let mut reader = match &self.dialect {
-                DialectItem::Str(name) => {
-                    let g = GLOBAL_HASHMAP.lock();
-                    if let Some(dialect) = g.get(name) {
-                        let mut builder = builder
-                            .delimiter(dialect.delimiter)
-                            .double_quote(dialect.doublequote)
-                            .escape(dialect.escapechar);
-                        if let Some(t) = dialect.quotechar {
-                            builder = builder.quote(t);
-                        }
-                        builder
-                        // RustPython todo
-                        // todo! Perfecting the remaining attributes.
-                    } else {
-                        &mut builder
-                    }
+            let mut reader = if let Some(dialect) = dialect {
+                let mut builder = builder
+                    .delimiter(dialect.delimiter)
+                    .double_quote(dialect.doublequote)
+                    .escape(dialect.escapechar);
+                if let Some(quotechar) = dialect.quotechar {
+                    builder = builder.quote(quotechar);
                 }
-                DialectItem::Obj(obj) => {
-                    let mut builder = builder
-                        .delimiter(obj.delimiter)
-                        .double_quote(obj.doublequote)
-                        .escape(obj.escapechar);
-                    if let Some(t) = obj.quotechar {
-                        builder = builder.quote(t);
-                    }
-                    builder
-                }
-                _ => {
-                    let name = "excel";
-                    let g = GLOBAL_HASHMAP.lock();
-                    let dialect = g.get(name).unwrap();
-                    let mut builder = builder
-                        .delimiter(dialect.delimiter)
-                        .double_quote(dialect.doublequote)
-                        .escape(dialect.escapechar);
-                    if let Some(quotechar) = dialect.quotechar {
-                        builder = builder.quote(quotechar);
-                    }
-                    builder
-                }
+                builder
+            } else {
+                &mut builder
             };
 
             if let Some(t) = self.delimiter {

--- a/crates/stdlib/src/csv.rs
+++ b/crates/stdlib/src/csv.rs
@@ -983,15 +983,20 @@ mod _csv {
     ) -> PyResult<Vec<PyObjectRef>> {
         let mut fields = vec![Vec::new()];
         let mut escaped = false;
+        let mut after_delimiter = false;
 
         for (index, &byte) in input.iter().enumerate() {
             if escaped {
                 fields.last_mut().unwrap().push(byte);
                 escaped = false;
+                after_delimiter = false;
+            } else if dialect.skipinitialspace && after_delimiter && byte == b' ' {
+                continue;
             } else if dialect.escapechar == Some(byte) {
                 escaped = true;
             } else if byte == dialect.delimiter {
                 fields.push(Vec::new());
+                after_delimiter = true;
             } else if matches!(byte, b'\r' | b'\n') {
                 if !input[index..]
                     .iter()
@@ -1008,6 +1013,7 @@ mod _csv {
                 break;
             } else {
                 fields.last_mut().unwrap().push(byte);
+                after_delimiter = false;
             }
         }
 

--- a/crates/stdlib/src/csv.rs
+++ b/crates/stdlib/src/csv.rs
@@ -804,7 +804,8 @@ mod _csv {
                     if let Some(dialect) = g.get(name) {
                         let mut builder = builder
                             .delimiter(dialect.delimiter)
-                            .double_quote(dialect.doublequote);
+                            .double_quote(dialect.doublequote)
+                            .escape(dialect.escapechar);
                         if let Some(t) = dialect.quotechar {
                             builder = builder.quote(t);
                         }
@@ -818,7 +819,8 @@ mod _csv {
                 DialectItem::Obj(obj) => {
                     let mut builder = builder
                         .delimiter(obj.delimiter)
-                        .double_quote(obj.doublequote);
+                        .double_quote(obj.doublequote)
+                        .escape(obj.escapechar);
                     if let Some(t) = obj.quotechar {
                         builder = builder.quote(t);
                     }
@@ -830,7 +832,8 @@ mod _csv {
                     let dialect = g.get(name).unwrap();
                     let mut builder = builder
                         .delimiter(dialect.delimiter)
-                        .double_quote(dialect.doublequote);
+                        .double_quote(dialect.doublequote)
+                        .escape(dialect.escapechar);
                     if let Some(quotechar) = dialect.quotechar {
                         builder = builder.quote(quotechar);
                     }

--- a/crates/stdlib/src/csv.rs
+++ b/crates/stdlib/src/csv.rs
@@ -975,6 +975,61 @@ mod _csv {
 
     impl SelfIter for Reader {}
 
+    fn read_quote_none_record(
+        input: &[u8],
+        dialect: PyDialect,
+        field_limit: isize,
+        vm: &VirtualMachine,
+    ) -> PyResult<Vec<PyObjectRef>> {
+        let mut fields = vec![Vec::new()];
+        let mut escaped = false;
+
+        for (index, &byte) in input.iter().enumerate() {
+            if escaped {
+                fields.last_mut().unwrap().push(byte);
+                escaped = false;
+            } else if dialect.escapechar == Some(byte) {
+                escaped = true;
+            } else if byte == dialect.delimiter {
+                fields.push(Vec::new());
+            } else if matches!(byte, b'\r' | b'\n') {
+                if !input[index..]
+                    .iter()
+                    .all(|&byte| matches!(byte, b'\r' | b'\n'))
+                {
+                    return Err(new_csv_error(
+                        vm,
+                        concat!(
+                            "new-line character seen in unquoted field",
+                            " - do you need to open the file in universal-newline mode?"
+                        ),
+                    ));
+                }
+                break;
+            } else {
+                fields.last_mut().unwrap().push(byte);
+            }
+        }
+
+        // CPython treats an escape character at the end of an iterator item
+        // as escaping the implicit newline at the end of that item.
+        if escaped {
+            fields.last_mut().unwrap().push(b'\n');
+        }
+
+        fields
+            .into_iter()
+            .map(|field| {
+                if field.len() > field_limit as usize {
+                    return Err(new_csv_error(vm, "filed too long to read"));
+                }
+                let field = core::str::from_utf8(&field)
+                    .map_err(|_| vm.new_unicode_decode_error("csv not utf8"))?;
+                Ok(vm.ctx.new_str(field).into())
+            })
+            .collect()
+    }
+
     impl IterNext for Reader {
         fn next(zelf: &Py<Self>, vm: &VirtualMachine) -> PyResult<PyIterReturn> {
             let string = raise_if_stop!(zelf.iter.next(vm)?);
@@ -1005,6 +1060,12 @@ mod _csv {
             let mut output_offset = 0;
             let mut output_ends_offset = 0;
             let field_limit = GLOBAL_FIELD_LIMIT.lock().to_owned();
+
+            if zelf.dialect.quoting == QuoteStyle::None && zelf.dialect.escapechar.is_some() {
+                let out = read_quote_none_record(input, zelf.dialect, field_limit, vm)?;
+                *line_num += 1;
+                return Ok(PyIterReturn::Return(vm.ctx.new_list(out).into()));
+            }
 
             #[inline]
             fn trim_spaces(input: &[u8]) -> &[u8] {

--- a/extra_tests/snippets/stdlib_csv.py
+++ b/extra_tests/snippets/stdlib_csv.py
@@ -134,3 +134,16 @@ def test_quote_none_writer_without_quotechar():
 
 
 test_quote_none_writer_without_quotechar()
+
+
+def test_quote_none_reader_skipinitialspace_escapechar():
+    reader = csv.reader(
+        ["a,  b,\\ c,d"],
+        quoting=csv.QUOTE_NONE,
+        escapechar="\\",
+        skipinitialspace=True,
+    )
+    assert list(reader) == [["a", "b", " c", "d"]]
+
+
+test_quote_none_reader_skipinitialspace_escapechar()


### PR DESCRIPTION
- [x] This PR follows our AI policy.

## Summary

`csv.reader` did not pass a dialect's `escapechar` into `csv_core`, so an
escape character worked only when supplied as an explicit keyword argument.
The first commit passes the dialect value through to `csv_core`, fixing escaped
delimiters inside quoted fields.

`csv_core` does not apply its escape setting to unquoted fields. The second
commit adds a small RustPython `QUOTE_NONE` parser path: an escape character
makes the following byte data, so an escaped delimiter does not split a field.

```python
import csv

class EscapedExcel(csv.excel):
    quoting = csv.QUOTE_NONE
    escapechar = "\\"

list(csv.reader(["abc\\,def\\r\\n"], dialect=EscapedExcel()))
# before: [["abc\\", "def"]]
# after:  [["abc,def"]]  # matches CPython
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved CSV parsing for dialects and defaults with custom `escapechar`, ensuring consistent behavior across dialect resolution paths.
  * Enhanced `QUOTE_NONE` handling with `escapechar` and `skipinitialspace`, including correct escaped separators and whitespace processing.
  * Added stricter input validation (record termination, field size limits, and UTF-8 decoding) and ensured trailing escapes are handled gracefully.
* **Tests**
  * Added a regression test for `QUOTE_NONE` with `escapechar` and `skipinitialspace` to verify correct field parsing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->