### PR TITLE
itertools: fix count() repr to show float step 1.0

### DIFF
--- a/Lib/test/test_itertools.py
+++ b/Lib/test/test_itertools.py
@@ -538,7 +538,6 @@ class TestBasicOps(unittest.TestCase):
         #check proper internal error handling for large "step' sizes
         count(1, maxsize+5); sys.exc_info()
 
-    @unittest.expectedFailure  # TODO: RUSTPYTHON; 'count(10.5)' != 'count(10.5, 1.0)'
     def test_count_with_step(self):
         self.assertEqual(lzip('abc',count(2,3)), [('a', 2), ('b', 5), ('c', 8)])
         self.assertEqual(lzip('abc',count(start=2,step=3)),

--- a/crates/vm/src/stdlib/itertools.rs
+++ b/crates/vm/src/stdlib/itertools.rs
@@ -225,7 +225,9 @@ mod decl {
             let step = &zelf.step;
             let mut result = Wtf8Buf::from("count(");
             result.push_wtf8(cur_repr.as_wtf8());
-            if !vm.bool_eq(step, vm.ctx.new_int(1).as_object())? {
+            let step_is_int_one = step.fast_isinstance(vm.ctx.types.int_type)
+                && vm.bool_eq(step, vm.ctx.new_int(1).as_object())?;
+            if !step_is_int_one {
                 result.push_str(", ");
                 result.push_wtf8(step.repr(vm)?.as_wtf8());
             }


### PR DESCRIPTION
- [x] This PR follows our AI policy.

## Summary

`itertools.count()`'s `__repr__` omitted the step when it equalled `1`, but
CPython omits the step only for the **integer** `1` — a float step of `1.0`
should still be shown.

```python
from itertools import count
repr(count(10.5))
# before: 'count(10.5)'
# after:  'count(10.5, 1.0)'   # matches CPython
```

CPython's `count_repr` skips the step only when it is a `PyLong` equal to `1`,
so a float such as `1.0` is still shown. The repr now omits the step only when it
is exactly the integer `1` (checked via both the `int` type and value). Also
unmarks `test_count_with_step`, which now passes.

Verified locally:

- `cargo run --release -- -m unittest -v test.test_itertools.TestBasicOps.test_count_with_step` -> `ok`
- `cargo run --release -- -m test test_itertools` -> SUCCESS (run=137, skipped=22)

Assisted-by: Claude Code:claude-opus-4-8

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the display of iterator count expressions.
  * The `step` value is now omitted only when it is exactly the integer `1`; other values and types remain explicitly shown for accurate representations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->