### PR TITLE
Forward pyexpat lexical events

### DIFF
--- a/Lib/test/test_pyexpat.py
+++ b/Lib/test/test_pyexpat.py
@@ -560,7 +560,6 @@ class BufferTextTest(unittest.TestCase):
             ["<a>", "1", "<b>", "</b>", "2", "<c>", "</c>", "345", "</a>"],
             "buffered text not properly split")
 
-    @unittest.expectedFailure  # TODO: RUSTPYTHON
     def test7(self):
         self.setHandlers(["CommentHandler", "EndElementHandler",
                     "StartElementHandler"])

--- a/crates/stdlib/src/pyexpat.rs
+++ b/crates/stdlib/src/pyexpat.rs
@@ -305,8 +305,9 @@ mod _pyexpat {
 
         fn create_config(&self) -> xml::ParserConfig {
             xml::ParserConfig::new()
-                .cdata_to_characters(true)
+                .cdata_to_characters(false)
                 .coalesce_characters(false)
+                .ignore_comments(false)
                 .whitespace_to_characters(true)
         }
 
@@ -375,6 +376,21 @@ mod _pyexpat {
                     Ok(XmlEvent::Characters(chars)) => {
                         let str = PyStr::from(chars).into_ref(&vm.ctx);
                         invoke_handler(vm, &self.character_data, (str,));
+                    }
+                    Ok(XmlEvent::ProcessingInstruction { name, data }) => {
+                        let name = PyStr::from(name).into_ref(&vm.ctx);
+                        let data = PyStr::from(data.unwrap_or_default()).into_ref(&vm.ctx);
+                        invoke_handler(vm, &self.processing_instruction, (name, data));
+                    }
+                    Ok(XmlEvent::Comment(comment)) => {
+                        let comment = PyStr::from(comment).into_ref(&vm.ctx);
+                        invoke_handler(vm, &self.comment, (comment,));
+                    }
+                    Ok(XmlEvent::CData(chars)) => {
+                        invoke_handler(vm, &self.start_cdata_section, ());
+                        let str = PyStr::from(chars).into_ref(&vm.ctx);
+                        invoke_handler(vm, &self.character_data, (str,));
+                        invoke_handler(vm, &self.end_cdata_section, ());
                     }
                     Err(e) => return Err(e),
                     _ => {}

--- a/extra_tests/snippets/stdlib_xml.py
+++ b/extra_tests/snippets/stdlib_xml.py
@@ -45,3 +45,24 @@ assert handler.events == [
     ("end", "child"),
     ("end", "main"),
 ]
+
+events = []
+parser = expat.ParserCreate()
+parser.ProcessingInstructionHandler = lambda target, data: events.append(
+    ("processing-instruction", target, data)
+)
+parser.CommentHandler = lambda data: events.append(("comment", data))
+parser.StartCdataSectionHandler = lambda: events.append(("start-cdata",))
+parser.CharacterDataHandler = lambda data: events.append(("characters", data))
+parser.EndCdataSectionHandler = lambda: events.append(("end-cdata",))
+parser.Parse(
+    "<?target data?><?empty?><root><!--comment--><![CDATA[text]]></root>", True
+)
+assert events == [
+    ("processing-instruction", "target", "data"),
+    ("processing-instruction", "empty", ""),
+    ("comment", "comment"),
+    ("start-cdata",),
+    ("characters", "text"),
+    ("end-cdata",),
+]


### PR DESCRIPTION
- [x] Partially addresses #8083
- [x] This PR follows our [AI policy](https://github.com/RustPython/.github/blob/main/AI_POLICY.md)

## Summary

Forward processing instructions, comments, and CDATA boundaries from `xml-rs` to the corresponding `pyexpat` handlers.

## Problem

RustPython exposed `ProcessingInstructionHandler`, `CommentHandler`, and the CDATA handlers, but the parser discarded those events. Code using the handlers received only character data.

## Fix

Preserve comment and CDATA events in the parser configuration, then dispatch them through the existing handler bridge. Processing instructions without data are passed as an empty string, matching CPython.

## Testing

- `cargo run -- extra_tests/snippets/stdlib_xml.py`
- `cargo run --release -- -m test test_pyexpat`
- `cargo run --release -- -m test test_sax`
- `prek run --all-files`
- Full `extra_tests`: 402 passed
- Workspace test suite
- Clippy

Codex:gpt-5.6-sol assisted with investigation, implementation, review, testing, and drafting this PR.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * XML parsing now correctly reports processing instructions, comments, and CDATA sections.
  * CDATA content is delivered as character data with proper section start and end notifications.

* **Tests**
  * Added coverage validating event ordering and callback behavior for these XML constructs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->