### PR TITLE
Forward pyexpat lexical events

### DIFF
--- a/Lib/test/test_minidom.py
+++ b/Lib/test/test_minidom.py
@@ -659,7 +659,6 @@ class MinidomTest(unittest.TestCase):
         self.assertIsNone(pi.localName)
         self.assertEqual(pi.namespaceURI, xml.dom.EMPTY_NAMESPACE)
 
-    @unittest.expectedFailure  # TODO: RUSTPYTHON
     def testProcessingInstructionRepr(self):
         dom = parseString('<e><?mypi \t\n data \t\n ?></e>')
         pi = dom.documentElement.firstChild
@@ -957,11 +956,9 @@ class MinidomTest(unittest.TestCase):
         self.confirm(clone.target == pi.target
                 and clone.data == pi.data)
 
-    @unittest.expectedFailure  # TODO: RUSTPYTHON
     def testClonePIShallow(self):
         self.check_clone_pi(0, "testClonePIShallow")
 
-    @unittest.expectedFailure  # TODO: RUSTPYTHON
     def testClonePIDeep(self):
         self.check_clone_pi(1, "testClonePIDeep")
 
@@ -1219,7 +1216,6 @@ class MinidomTest(unittest.TestCase):
         self.assertIsNone(node.childNodes[-1].nextSibling,
                      "Final child's .nextSibling should be None")
 
-    @unittest.expectedFailure  # TODO: RUSTPYTHON
     def testSiblings(self):
         doc = parseString("<doc><?pi?>text?<elm/></doc>")
         root = doc.documentElement
@@ -1792,7 +1788,6 @@ class MinidomTest(unittest.TestCase):
                          '<?xml version="1.0" ?>\n'
                          '<curriculum status="public" company="example"/>\n')
 
-    @unittest.expectedFailure  # TODO: RUSTPYTHON
     def test_toprettyxml_with_cdata(self):
         xml_str = '<?xml version="1.0" ?><root><node><![CDATA[</data>]]></node></root>'
         doc = parseString(xml_str)

--- a/Lib/test/test_pyexpat.py
+++ b/Lib/test/test_pyexpat.py
@@ -560,7 +560,6 @@ class BufferTextTest(unittest.TestCase):
             ["<a>", "1", "<b>", "</b>", "2", "<c>", "</c>", "345", "</a>"],
             "buffered text not properly split")
 
-    @unittest.expectedFailure  # TODO: RUSTPYTHON
     def test7(self):
         self.setHandlers(["CommentHandler", "EndElementHandler",
                     "StartElementHandler"])

--- a/Lib/test/test_xml_etree.py
+++ b/Lib/test/test_xml_etree.py
@@ -1800,7 +1800,6 @@ class XMLPullParserTest(unittest.TestCase):
         self._feed(parser, "<!-- text here -->\n")
         self.assert_events(parser, [('comment', (ET.Comment, ' text here '))])
 
-    @unittest.expectedFailure  # TODO: RUSTPYTHON
     def test_events_pi(self):
         parser = ET.XMLPullParser(events=('start', 'pi', 'end'))
         self._feed(parser, "<?pitarget?>\n")
@@ -3821,7 +3820,6 @@ class TreeBuilderTest(unittest.TestCase):
         a = parser.close()
         self.assertEqual(a.text, "texttail")
 
-    @unittest.expectedFailure  # TODO: RUSTPYTHON
     def test_late_tail_mix_pi_comments(self):
         # Issue #37399: The tail of an ignored comment could overwrite the text before it.
         # Test appending tails to comments/pis.

--- a/crates/stdlib/src/pyexpat.rs
+++ b/crates/stdlib/src/pyexpat.rs
@@ -351,10 +351,10 @@ mod _pyexpat {
             T: std::io::Read,
         {
             for e in parser {
-                match e {
-                    Ok(XmlEvent::StartElement {
+                match e? {
+                    XmlEvent::StartElement {
                         name, attributes, ..
-                    }) => {
+                    } => {
                         let dict = vm.ctx.new_dict();
                         for attribute in attributes {
                             let attr_name = self.make_name(&attribute.name);
@@ -369,30 +369,29 @@ mod _pyexpat {
                         let name_str = PyStr::from(self.make_name(&name)).into_ref(&vm.ctx);
                         invoke_handler(vm, &self.start_element, (name_str, dict));
                     }
-                    Ok(XmlEvent::EndElement { name, .. }) => {
+                    XmlEvent::EndElement { name, .. } => {
                         let name_str = PyStr::from(self.make_name(&name)).into_ref(&vm.ctx);
                         invoke_handler(vm, &self.end_element, (name_str,));
                     }
-                    Ok(XmlEvent::Characters(chars)) => {
+                    XmlEvent::Characters(chars) => {
                         let str = PyStr::from(chars).into_ref(&vm.ctx);
                         invoke_handler(vm, &self.character_data, (str,));
                     }
-                    Ok(XmlEvent::ProcessingInstruction { name, data }) => {
+                    XmlEvent::ProcessingInstruction { name, data } => {
                         let name = PyStr::from(name).into_ref(&vm.ctx);
                         let data = PyStr::from(data.unwrap_or_default()).into_ref(&vm.ctx);
                         invoke_handler(vm, &self.processing_instruction, (name, data));
                     }
-                    Ok(XmlEvent::Comment(comment)) => {
+                    XmlEvent::Comment(comment) => {
                         let comment = PyStr::from(comment).into_ref(&vm.ctx);
                         invoke_handler(vm, &self.comment, (comment,));
                     }
-                    Ok(XmlEvent::CData(chars)) => {
+                    XmlEvent::CData(chars) => {
                         invoke_handler(vm, &self.start_cdata_section, ());
                         let str = PyStr::from(chars).into_ref(&vm.ctx);
                         invoke_handler(vm, &self.character_data, (str,));
                         invoke_handler(vm, &self.end_cdata_section, ());
                     }
-                    Err(e) => return Err(e),
                     _ => {}
                 }
             }

--- a/crates/stdlib/src/pyexpat.rs
+++ b/crates/stdlib/src/pyexpat.rs
@@ -305,8 +305,9 @@ mod _pyexpat {
 
         fn create_config(&self) -> xml::ParserConfig {
             xml::ParserConfig::new()
-                .cdata_to_characters(true)
+                .cdata_to_characters(false)
                 .coalesce_characters(false)
+                .ignore_comments(false)
                 .whitespace_to_characters(true)
         }
 
@@ -375,6 +376,21 @@ mod _pyexpat {
                     Ok(XmlEvent::Characters(chars)) => {
                         let str = PyStr::from(chars).into_ref(&vm.ctx);
                         invoke_handler(vm, &self.character_data, (str,));
+                    }
+                    Ok(XmlEvent::ProcessingInstruction { name, data }) => {
+                        let name = PyStr::from(name).into_ref(&vm.ctx);
+                        let data = PyStr::from(data.unwrap_or_default()).into_ref(&vm.ctx);
+                        invoke_handler(vm, &self.processing_instruction, (name, data));
+                    }
+                    Ok(XmlEvent::Comment(comment)) => {
+                        let comment = PyStr::from(comment).into_ref(&vm.ctx);
+                        invoke_handler(vm, &self.comment, (comment,));
+                    }
+                    Ok(XmlEvent::CData(chars)) => {
+                        invoke_handler(vm, &self.start_cdata_section, ());
+                        let str = PyStr::from(chars).into_ref(&vm.ctx);
+                        invoke_handler(vm, &self.character_data, (str,));
+                        invoke_handler(vm, &self.end_cdata_section, ());
                     }
                     Err(e) => return Err(e),
                     _ => {}

--- a/extra_tests/snippets/stdlib_xml.py
+++ b/extra_tests/snippets/stdlib_xml.py
@@ -45,3 +45,24 @@ assert handler.events == [
     ("end", "child"),
     ("end", "main"),
 ]
+
+events = []
+parser = expat.ParserCreate()
+parser.ProcessingInstructionHandler = lambda target, data: events.append(
+    ("processing-instruction", target, data)
+)
+parser.CommentHandler = lambda data: events.append(("comment", data))
+parser.StartCdataSectionHandler = lambda: events.append(("start-cdata",))
+parser.CharacterDataHandler = lambda data: events.append(("characters", data))
+parser.EndCdataSectionHandler = lambda: events.append(("end-cdata",))
+parser.Parse(
+    "<?target data?><?empty?><root><!--comment--><![CDATA[text]]></root>", True
+)
+assert events == [
+    ("processing-instruction", "target", "data"),
+    ("processing-instruction", "empty", ""),
+    ("comment", "comment"),
+    ("start-cdata",),
+    ("characters", "text"),
+    ("end-cdata",),
+]


### PR DESCRIPTION
- [x] Partially addresses #8083
- [x] This PR follows our [AI policy](https://github.com/RustPython/.github/blob/main/AI_POLICY.md)

## Summary

Forward processing instructions, comments, and CDATA boundaries from `xml-rs` to the corresponding `pyexpat` handlers.

## Problem

RustPython exposed `ProcessingInstructionHandler`, `CommentHandler`, and the CDATA handlers, but the parser discarded those events. Code using the handlers received only character data.

## Fix

Preserve comment and CDATA events in the parser configuration, then dispatch them through the existing handler bridge. Processing instructions without data are passed as an empty string, matching CPython.

## Testing

- `cargo run -- extra_tests/snippets/stdlib_xml.py`
- `cargo run --release -- -m test test_pyexpat`
- `cargo run --release -- -m test test_sax`
- `prek run --all-files`
- Full `extra_tests`: 402 passed
- Workspace test suite
- Clippy

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved XML parsing compatibility by ensuring processing instructions, comments, and CDATA are correctly surfaced to configured callbacks.
  * Preserved CDATA section boundaries and content (rather than treating CDATA as regular character data).
  * Ensured parsing event dispatch continues to propagate errors correctly.

* **Tests**
  * Added coverage for ordered callback behavior across processing instructions, comments, CDATA boundaries, and character data.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->