### PR TITLE
Validate TextIOWrapper chunk size

### DIFF
--- a/crates/vm/src/stdlib/_io.rs
+++ b/crates/vm/src/stdlib/_io.rs
@@ -3219,9 +3219,15 @@ mod _io {
                     let integer = object_value.try_index(vm)?;
 
                     integer.try_to_primitive::<isize>(vm).map_err(|_| {
+                        let class = object_value.class();
+                        let type_name = class.name();
+                        let mut end = type_name.len().min(200);
+                        while !type_name.is_char_boundary(end) {
+                            end -= 1;
+                        }
                         vm.new_value_error(format!(
-                            "cannot fit '{:.200}' into an index-sized integer",
-                            object_value.class().name()
+                            "cannot fit '{}' into an index-sized integer",
+                            &type_name[..end]
                         ))
                     })?
                 }

--- a/crates/vm/src/stdlib/_io.rs
+++ b/crates/vm/src/stdlib/_io.rs
@@ -3206,19 +3206,27 @@ mod _io {
         }
 
         #[pygetset(setter, name = "_CHUNK_SIZE")]
-        fn set_chunksize(
-            &self,
-            chunk_size: PySetterValue<usize>,
-            vm: &VirtualMachine,
-        ) -> PyResult<()> {
-            let mut textio = self.lock(vm)?;
-            match chunk_size {
-                PySetterValue::Assign(chunk_size) => textio.chunk_size = chunk_size,
+        fn set_chunksize(&self, value: PySetterValue, vm: &VirtualMachine) -> PyResult<()> {
+            let chunk_size: isize = match value {
+                PySetterValue::Assign(object_value) => {
+                    let integer = object_value.try_index(vm)?;
+
+                    integer.try_to_primitive::<isize>(vm).map_err(|_| {
+                        vm.new_value_error("cannot fit 'int' into an index-sized integer")
+                    })?
+                }
                 PySetterValue::Delete => Err(vm.new_attribute_error("cannot delete attribute"))?,
             };
-            // TODO: RUSTPYTHON
-            // Change chunk_size type, validate it manually and throws ValueError if invalid.
-            // https://github.com/python/cpython/blob/2e9da8e3522764d09f1d6054a2be567e91a30812/Modules/_io/textio.c#L3124-L3143
+
+            if chunk_size <= 0 {
+                return Err(vm.new_value_error("a strictly positive integer is required"));
+            }
+
+            let chunk_size = usize::try_from(chunk_size)
+                .map_err(|_| vm.new_value_error("a strictly positive integer is required"))?;
+
+            let mut textio = self.lock(vm)?;
+            textio.chunk_size = chunk_size;
             Ok(())
         }
 

--- a/crates/vm/src/stdlib/_io.rs
+++ b/crates/vm/src/stdlib/_io.rs
@@ -3207,18 +3207,27 @@ mod _io {
 
         #[pygetset(setter, name = "_CHUNK_SIZE")]
         fn set_chunksize(&self, value: PySetterValue, vm: &VirtualMachine) -> PyResult<()> {
+            {
+                let textio = self.lock(vm)?;
+                if vm.is_none(&textio.buffer) {
+                    return Err(vm.new_value_error("underlying buffer has been detached"));
+                }
+            }
+
             let chunk_size: isize = match value {
                 PySetterValue::Assign(object_value) => {
-                    let type_name = object_value.class().name().to_owned();
                     let integer = object_value.try_index(vm)?;
 
                     integer.try_to_primitive::<isize>(vm).map_err(|_| {
                         vm.new_value_error(format!(
-                            "cannot fit '{type_name}' into an index-sized integer"
+                            "cannot fit '{:.200}' into an index-sized integer",
+                            object_value.class().name()
                         ))
                     })?
                 }
-                PySetterValue::Delete => Err(vm.new_attribute_error("cannot delete attribute"))?,
+                PySetterValue::Delete => {
+                    return Err(vm.new_attribute_error("cannot delete attribute"));
+                }
             };
 
             if chunk_size <= 0 {

--- a/crates/vm/src/stdlib/_io.rs
+++ b/crates/vm/src/stdlib/_io.rs
@@ -3209,10 +3209,13 @@ mod _io {
         fn set_chunksize(&self, value: PySetterValue, vm: &VirtualMachine) -> PyResult<()> {
             let chunk_size: isize = match value {
                 PySetterValue::Assign(object_value) => {
+                    let type_name = object_value.class().name().to_owned();
                     let integer = object_value.try_index(vm)?;
 
                     integer.try_to_primitive::<isize>(vm).map_err(|_| {
-                        vm.new_value_error("cannot fit 'int' into an index-sized integer")
+                        vm.new_value_error(format!(
+                            "cannot fit '{type_name}' into an index-sized integer"
+                        ))
                     })?
                 }
                 PySetterValue::Delete => Err(vm.new_attribute_error("cannot delete attribute"))?,

--- a/extra_tests/snippets/stdlib_io.py
+++ b/extra_tests/snippets/stdlib_io.py
@@ -93,7 +93,7 @@ for invalid_chunk_size in (0, -1, 2**100):
     except ValueError:
         pass
     else:
-        assert False, f"expected ValueError for {invalid_chunk_size!r}"
+        raise AssertionError(f"expected ValueError for {invalid_chunk_size!r}")
 
 for invalid_chunk_size in (1.5, "4"):
     try:
@@ -101,7 +101,7 @@ for invalid_chunk_size in (1.5, "4"):
     except TypeError:
         pass
     else:
-        assert False, f"expected TypeError for {invalid_chunk_size!r}"
+        raise AssertionError(f"expected TypeError for {invalid_chunk_size!r}")
 
 
 class ChunkSize:

--- a/extra_tests/snippets/stdlib_io.py
+++ b/extra_tests/snippets/stdlib_io.py
@@ -123,6 +123,6 @@ try:
 except ValueError as error:
     expected = "cannot fit 'OversizedChunkSize' into an index-sized integer"
     if str(error) != expected:
-        raise AssertionError(f"unexpected error message: {error}")
+        raise AssertionError(f"unexpected error message: {error}") from error
 else:
     raise AssertionError("expected ValueError for oversized indexable object")

--- a/extra_tests/snippets/stdlib_io.py
+++ b/extra_tests/snippets/stdlib_io.py
@@ -155,7 +155,9 @@ expect_value_error(
 )
 
 if uninitialized_chunk_size.called:
-    raise AssertionError("__index__ should not be called for uninitialized TextIOWrapper")
+    raise AssertionError(
+        "__index__ should not be called for uninitialized TextIOWrapper"
+    )
 
 
 detached_textio = TextIOWrapper(BytesIO())

--- a/extra_tests/snippets/stdlib_io.py
+++ b/extra_tests/snippets/stdlib_io.py
@@ -182,3 +182,18 @@ expect_value_error(
     f"cannot fit '{long_type_name[:200]}' into an index-sized integer",
     lambda: setattr(textio, "_CHUNK_SIZE", LongNamedChunkSize()),
 )
+
+
+non_ascii_type_name = "é" * 250
+NonAsciiNamedChunkSize = type(
+    non_ascii_type_name,
+    (),
+    {"__index__": lambda self: 2**100},
+)
+truncated_non_ascii_type_name = (
+    non_ascii_type_name.encode("utf-8")[:200].decode("utf-8")
+)
+expect_value_error(
+    f"cannot fit '{truncated_non_ascii_type_name}' into an index-sized integer",
+    lambda: setattr(textio, "_CHUNK_SIZE", NonAsciiNamedChunkSize()),
+)

--- a/extra_tests/snippets/stdlib_io.py
+++ b/extra_tests/snippets/stdlib_io.py
@@ -190,8 +190,8 @@ NonAsciiNamedChunkSize = type(
     (),
     {"__index__": lambda self: 2**100},
 )
-truncated_non_ascii_type_name = (
-    non_ascii_type_name.encode("utf-8")[:200].decode("utf-8")
+truncated_non_ascii_type_name = non_ascii_type_name.encode("utf-8")[:200].decode(
+    "utf-8"
 )
 expect_value_error(
     f"cannot fit '{truncated_non_ascii_type_name}' into an index-sized integer",

--- a/extra_tests/snippets/stdlib_io.py
+++ b/extra_tests/snippets/stdlib_io.py
@@ -126,3 +126,57 @@ except ValueError as error:
         raise AssertionError(f"unexpected error message: {error}") from error
 else:
     raise AssertionError("expected ValueError for oversized indexable object")
+
+
+def expect_value_error(expected, operation):
+    try:
+        operation()
+    except ValueError as error:
+        if str(error) != expected:
+            raise AssertionError(f"unexpected error message: {error}") from error
+    else:
+        raise AssertionError(f"expected ValueError: {expected}")
+
+
+class UninitializedChunkSize:
+    def __init__(self):
+        self.called = False
+
+    def __index__(self):
+        self.called = True
+        return 16
+
+
+uninitialized_textio = TextIOWrapper.__new__(TextIOWrapper)
+uninitialized_chunk_size = UninitializedChunkSize()
+expect_value_error(
+    "I/O operation on uninitialized object",
+    lambda: setattr(uninitialized_textio, "_CHUNK_SIZE", uninitialized_chunk_size),
+)
+
+if uninitialized_chunk_size.called:
+    raise AssertionError("__index__ should not be called for uninitialized TextIOWrapper")
+
+
+detached_textio = TextIOWrapper(BytesIO())
+detached_textio.detach()
+expect_value_error(
+    "underlying buffer has been detached",
+    lambda: setattr(detached_textio, "_CHUNK_SIZE", 16),
+)
+expect_value_error(
+    "underlying buffer has been detached",
+    lambda: delattr(detached_textio, "_CHUNK_SIZE"),
+)
+
+
+long_type_name = "X" * 250
+LongNamedChunkSize = type(
+    long_type_name,
+    (),
+    {"__index__": lambda self: 2**100},
+)
+expect_value_error(
+    f"cannot fit '{long_type_name[:200]}' into an index-sized integer",
+    lambda: setattr(textio, "_CHUNK_SIZE", LongNamedChunkSize()),
+)

--- a/extra_tests/snippets/stdlib_io.py
+++ b/extra_tests/snippets/stdlib_io.py
@@ -111,3 +111,18 @@ class ChunkSize:
 
 textio._CHUNK_SIZE = ChunkSize()
 assert textio._CHUNK_SIZE == 16
+
+
+class OversizedChunkSize:
+    def __index__(self):
+        return 2**100
+
+
+try:
+    textio._CHUNK_SIZE = OversizedChunkSize()
+except ValueError as error:
+    expected = "cannot fit 'OversizedChunkSize' into an index-sized integer"
+    if str(error) != expected:
+        raise AssertionError(f"unexpected error message: {error}")
+else:
+    raise AssertionError("expected ValueError for oversized indexable object")

--- a/extra_tests/snippets/stdlib_io.py
+++ b/extra_tests/snippets/stdlib_io.py
@@ -84,3 +84,30 @@ textio = TextIOWrapper(raw, encoding="utf-8", write_through=True)
 raw.textio = textio
 with assert_raises(AttributeError):
     textio.writelines(["x"])
+
+textio = TextIOWrapper(BytesIO())
+
+for invalid_chunk_size in (0, -1, 2**100):
+    try:
+        textio._CHUNK_SIZE = invalid_chunk_size
+    except ValueError:
+        pass
+    else:
+        assert False, f"expected ValueError for {invalid_chunk_size!r}"
+
+for invalid_chunk_size in (1.5, "4"):
+    try:
+        textio._CHUNK_SIZE = invalid_chunk_size
+    except TypeError:
+        pass
+    else:
+        assert False, f"expected TypeError for {invalid_chunk_size!r}"
+
+
+class ChunkSize:
+    def __index__(self):
+        return 16
+
+
+textio._CHUNK_SIZE = ChunkSize()
+assert textio._CHUNK_SIZE == 16


### PR DESCRIPTION
<!--
Thanks for your contribution!
-->

- [x] This PR follows our [AI policy](https://github.com/RustPython/.github/blob/main/AI_POLICY.md)

## Summary

Makes the `TextIOWrapper._CHUNK_SIZE` setter match CPython's validation behavior.

The setter now:

- accepts integers and objects implementing `__index__()`
- rejects values less than or equal to zero with `ValueError`
- rejects non-indexable values with `TypeError`
- rejects values outside the platform `isize` range with `ValueError`
- reports the original object's type name for oversized indexable values
- checks uninitialized and detached wrappers before conversion
- preserves the existing deletion error behavior

The regression snippet covers boundary values, indexable objects, oversized results, uninitialized and detached wrappers, deletion, and error-message truncation.

## Tests

```shell
.git/pre-push-venv/bin/prek run --files extra_tests/snippets/stdlib_io.py

cd extra_tests
RUSTPYTHON=../target/debug/rustpython ../.git/pre-push-venv/bin/pytest -v test_snippets.py -k stdlib_io
```

Result: `6 passed, 392 deselected`.

The snippet was also run directly with CPython and RustPython, both normally and with `-O`.

## AI assistance

Codex (GPT-5) was used to compare RustPython with CPython, help draft the Rust implementation and regression tests, and help address review feedback. I reviewed the final diff and verified the behavior locally.
