### PR TITLE
Add str compare functions to c-api

### DIFF
--- a/.cspell.dict/cpython.txt
+++ b/.cspell.dict/cpython.txt
@@ -198,6 +198,7 @@ pymain
 pymem
 pyrepl
 pystate
+pystrcmp
 PYTHONTRACEMALLOC
 PYTHONUTF8
 pythonw

--- a/.cspell.dict/cpython.txt
+++ b/.cspell.dict/cpython.txt
@@ -140,6 +140,8 @@ metavars
 miscompiles
 mult
 multibytecodec
+mystricmp
+mystrnicmp
 nameobj
 nameop
 nargsf

--- a/crates/capi/src/lib.rs
+++ b/crates/capi/src/lib.rs
@@ -34,6 +34,7 @@ pub mod pyframe;
 pub mod pylifecycle;
 pub mod pymem;
 pub mod pystate;
+pub mod pystrcmp;
 pub mod refcount;
 pub mod setobject;
 pub mod sliceobject;

--- a/crates/capi/src/pystrcmp.rs
+++ b/crates/capi/src/pystrcmp.rs
@@ -2,16 +2,7 @@ use core::ffi::c_char;
 
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn PyOS_mystricmp(str1: *const c_char, str2: *const c_char) -> i32 {
-    let mut index = 0usize;
-    loop {
-        let left = unsafe { *str1.add(index) } as u8;
-        let right = unsafe { *str2.add(index) } as u8;
-        let diff = left.to_ascii_lowercase() as i32 - right.to_ascii_lowercase() as i32;
-        if diff != 0 || left == 0 || right == 0 {
-            return diff;
-        }
-        index += 1;
-    }
+    unsafe { PyOS_mystrnicmp(str1, str2, isize::MAX) }
 }
 
 #[unsafe(no_mangle)]

--- a/crates/capi/src/pystrcmp.rs
+++ b/crates/capi/src/pystrcmp.rs
@@ -1,0 +1,37 @@
+use core::ffi::c_char;
+
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn PyOS_mystricmp(str1: *const c_char, str2: *const c_char) -> i32 {
+    let mut index = 0usize;
+    loop {
+        let left = unsafe { *str1.add(index) } as u8;
+        let right = unsafe { *str2.add(index) } as u8;
+        let diff = left.to_ascii_lowercase() as i32 - right.to_ascii_lowercase() as i32;
+        if diff != 0 || left == 0 || right == 0 {
+            return diff;
+        }
+        index += 1;
+    }
+}
+
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn PyOS_mystrnicmp(
+    str1: *const c_char,
+    str2: *const c_char,
+    size: isize,
+) -> i32 {
+    let Ok(limit) = usize::try_from(size) else {
+        return 0;
+    };
+    let mut index = 0usize;
+    while index < limit {
+        let left = unsafe { *str1.add(index) } as u8;
+        let right = unsafe { *str2.add(index) } as u8;
+        let diff = left.to_ascii_lowercase() as i32 - right.to_ascii_lowercase() as i32;
+        if diff != 0 || left == 0 || right == 0 {
+            return diff;
+        }
+        index += 1;
+    }
+    0
+}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added ASCII case-insensitive string comparison exports for native (C ABI) integrations.
  * Provides both NUL-terminated and length-limited variants, returning a signed result based on the first differing byte.
* **Chores**
  * Updated the spell-check dictionary with new comparison-related terms.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->