### PR TITLE
Fix overflow handling for inplace sequence repetition

### DIFF
--- a/Lib/test/test_list.py
+++ b/Lib/test/test_list.py
@@ -106,7 +106,6 @@ class ListTest(list_tests.CommonTest):
         x[:] = x
         self.assertEqual(x, [])
 
-    @unittest.skip("TODO: RUSTPYTHON; crash")
     def test_list_resize_overflow(self):
         # gh-97616: test new_allocated * sizeof(PyObject*) overflow
         # check in list_resize()

--- a/crates/vm/src/sequence.rs
+++ b/crates/vm/src/sequence.rs
@@ -122,6 +122,11 @@ where
 
     fn imul(&mut self, vm: &VirtualMachine, n: isize) -> PyResult<()> {
         let n = vm.check_repeat_or_overflow_error(self.as_ref().len(), n)?;
+
+        if n > 1 && core::mem::size_of_val(self.as_ref()) >= MAX_MEMORY_SIZE / n {
+            return Err(vm.new_memory_error(""));
+        }
+
         if n == 0 {
             self.as_vec_mut().clear();
         } else if n != 1 {

--- a/crates/vm/src/sequence.rs
+++ b/crates/vm/src/sequence.rs
@@ -124,6 +124,7 @@ where
         let n = vm.check_repeat_or_overflow_error(self.as_ref().len(), n)?;
 
         if n > 1 && core::mem::size_of_val(self.as_ref()) >= MAX_MEMORY_SIZE / n {
+            // TODO: make a global static NoMemory shared exc object and return its reference. 
             return Err(vm.new_memory_error(""));
         }
 


### PR DESCRIPTION

- [ ] Closes #xxxx <!-- Replace xxxx with the GitHub issue number -->
- [x] This PR follows our [AI policy](https://github.com/RustPython/.github/blob/main/AI_POLICY.md)

## Summary
Fix a crash when repeating a list in place with an excessively large repeat count.

Previously, the resulting allocation can exceed the maximum supported memory size, causing list.__imul__ to attempt an invalid allocation.

This change adds the same memory-size check used by regular sequence multiplication. The operation now raises MemoryError
before mutating the original sequence.

The corresponding test_list_resize_overflow test is no longer skipped.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Added an extra memory overflow check for in-place sequence multiplication.
  * Operations that would exceed the allowed memory limit now fail gracefully with an error instead of risking a crash.
* **Tests**
  * Enabled the list resize overflow regression test so it runs as part of the standard test suite.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->