### PR TITLE
module: honor module-level __dir__ (PEP 562)

### DIFF
--- a/Lib/test/test_module/__init__.py
+++ b/Lib/test/test_module/__init__.py
@@ -151,13 +151,11 @@ a = A(destroyed)"""
         if 'test.test_module.bad_getattr2' in sys.modules:
             del sys.modules['test.test_module.bad_getattr2']
 
-    @unittest.expectedFailure  # TODO: RUSTPYTHON
     def test_module_dir(self):
         import test.test_module.good_getattr as gga
         self.assertEqual(dir(gga), ['a', 'b', 'c'])
         del sys.modules['test.test_module.good_getattr']
 
-    @unittest.expectedFailure  # TODO: RUSTPYTHON
     def test_module_dir_errors(self):
         import test.test_module.bad_getattr as bga
         from test.test_module import bad_getattr2

--- a/Lib/test/test_support.py
+++ b/Lib/test/test_support.py
@@ -458,7 +458,6 @@ class TestSupport(unittest.TestCase):
                 self.OtherClass, self.RefClass, ignore=ignore)
         self.assertEqual(set(), missing_items)
 
-    @unittest.expectedFailure  # TODO: RUSTPYTHON
     def test_check__all__(self):
         extra = {'tempdir'}
         not_exported = {'template'}

--- a/Lib/test/test_zoneinfo/test_zoneinfo.py
+++ b/Lib/test/test_zoneinfo/test_zoneinfo.py
@@ -1970,7 +1970,6 @@ class TestModule(ZoneInfoTestBase):
         with self.assertRaises(AttributeError):
             self.module.NOATTRIBUTE
 
-    @unittest.expectedFailure  # TODO: RUSTPYTHON; dir(self.module) should at least contain everything in __all__.
     def test_dir_contains_all(self):
         """dir(self.module) should at least contain everything in __all__."""
         module_all_set = set(self.module.__all__)

--- a/crates/vm/src/builtins/module.rs
+++ b/crates/vm/src/builtins/module.rs
@@ -303,6 +303,10 @@ impl PyModule {
         let dict = dict_attr
             .downcast::<PyDict>()
             .map_err(|_| vm.new_type_error("<module>.__dict__ is not a dictionary"))?;
+        // PEP 562: honor a module-level __dir__ if one is defined
+        if let Some(dir_func) = dict.get_item_opt(identifier!(vm, __dir__), vm)? {
+            return dir_func.call((), vm)?.try_to_value(vm);
+        }
         let attrs = dict.into_iter().map(|(k, _v)| k).collect();
         Ok(attrs)
     }


### PR DESCRIPTION


- [x] Closes #8231
- [x] This PR follows our [AI policy](https://github.com/RustPython/.github/blob/main/AI_POLICY.md)

## Summary

A module-level `__dir__` function (PEP 562) was ignored: `dir(module)` returned
the raw `__dict__` keys instead of calling the module's `__dir__`.

```python
# mod.py
def __dir__():
    return ['gamma', 'alpha', 'beta']
```
```text
# before: dir(mod) -> ['__builtins__', '__cached__', '__dir__', ...]
# after:  dir(mod) -> ['alpha', 'beta', 'gamma']   # matches CPython (dir() sorts)
```

## Cause

`PyModule::__dir__` (`crates/vm/src/builtins/module.rs`) unconditionally
returned the module dict's keys, with no check for a module-level `__dir__`.

## Fix

This ports the behavior of CPython's `module_dir()` in [`Objects/moduleobject.c`](https://github.com/python/cpython/blob/3.14/Objects/moduleobject.c#L1186-L1209), 
which is the reference implementation for this change: 

look up `__dir__` in the module's `__dict__` first and, if present, call it and return its result;
otherwise fall back to `list(__dict__)`. The lookup is a direct dict access,
so neither the module-level `__getattr__` nor the type's own `__dir__` slot is involved.
A non-callable or wrongly-signed `__dir__` raises `TypeError`, matching CPython.

The `@unittest.expectedFailure  # TODO: RUSTPYTHON` markers on `test_module_dir`
and `test_module_dir_errors` are removed since both now pass.

## Side effect

Honoring a module-level `__dir__` also fixes `dir()` for stdlib modules that
define one, which flips two previously-failing tests to passing. Their stale
`@unittest.expectedFailure  # TODO: RUSTPYTHON` markers are removed as well
(otherwise they would be reported as unexpected successes and fail CI):

- **`test_zoneinfo.test_dir_contains_all`** — `zoneinfo.__dir__` makes
  `dir(zoneinfo)` contain everything in `__all__`.
- **`test_support.test_check__all__`** — `support.check__all__` iterates
  `dir(module)`; `unittest.__dir__` now surfaces `IsolatedAsyncioTestCase`
  (declared in `unittest.__all__` but lazily loaded via PEP 562), so the check
  matches `__all__`.

## Test

Verified locally:

- `cargo run --release -- -m test test_module -v` → **SUCCESS** (run=39)
  (`test_module_dir` / `test_module_dir_errors` ... **ok**)
- `cargo run --release -- -m test test_zoneinfo` → **SUCCESS**
  (`test_dir_contains_all` now passes)
- `cargo run --release -- -m test test_support` → **SUCCESS**
  (`test_check__all__` now passes via `dir(unittest)`)
- `cargo run --release -- -m test test_unittest test_concurrent_futures` → **SUCCESS**
  (the other stdlib modules with a module-level `__dir__`; no regressions)

Assisted-by: Claude Code:claude-opus-4-8

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Modules can now define a custom `__dir__` function to control the names returned when inspecting available attributes.
  * Existing default behavior remains unchanged when no custom `__dir__` is provided.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->