### PR TITLE
Improve unhashable set element errors

### DIFF
--- a/Lib/test/test_set.py
+++ b/Lib/test/test_set.py
@@ -657,7 +657,6 @@ class TestSet(TestJointOps, unittest.TestCase):
         self.assertRaises(KeyError, myset.remove, set(range(1)))
         self.assertRaises(KeyError, myset.remove, set(range(3)))
 
-    @unittest.expectedFailure  # TODO: RUSTPYTHON
     def test_unhashable_element(self):
         myset = {'a'}
         elem = [1, 2, 3]

--- a/crates/vm/src/builtins/set.rs
+++ b/crates/vm/src/builtins/set.rs
@@ -223,7 +223,9 @@ impl PySetInner {
     }
 
     fn contains(&self, needle: &PyObject, vm: &VirtualMachine) -> PyResult<bool> {
-        self.retry_op_with_frozenset(needle, vm, |needle, vm| self.content.contains(vm, needle))
+        let result = self
+            .retry_op_with_frozenset(needle, vm, |needle, vm| self.content.contains(vm, needle));
+        Self::wrap_unhashable_error(result, needle, vm)
     }
 
     fn compare(&self, other: &Self, op: PyComparisonOp, vm: &VirtualMachine) -> PyResult<bool> {
@@ -327,15 +329,20 @@ impl PySetInner {
     }
 
     fn add(&self, item: PyObjectRef, vm: &VirtualMachine) -> PyResult<()> {
-        self.content.insert(vm, &*item, ())
+        let result = self.content.insert(vm, &*item, ());
+        Self::wrap_unhashable_error(result, &item, vm)
     }
 
     fn remove(&self, item: PyObjectRef, vm: &VirtualMachine) -> PyResult<()> {
-        self.retry_op_with_frozenset(&item, vm, |item, vm| self.content.delete(vm, item))
+        let result =
+            self.retry_op_with_frozenset(&item, vm, |item, vm| self.content.delete(vm, item));
+        Self::wrap_unhashable_error(result, &item, vm)
     }
 
     fn discard(&self, item: &PyObject, vm: &VirtualMachine) -> PyResult<bool> {
-        self.retry_op_with_frozenset(item, vm, |item, vm| self.content.delete_if_exists(vm, item))
+        let result = self
+            .retry_op_with_frozenset(item, vm, |item, vm| self.content.delete_if_exists(vm, item));
+        Self::wrap_unhashable_error(result, item, vm)
     }
 
     fn clear(&self) {
@@ -487,6 +494,25 @@ impl PySetInner {
                     })
                 })
         })
+    }
+
+    fn wrap_unhashable_error<T>(
+        result: PyResult<T>,
+        item: &PyObject,
+        vm: &VirtualMachine,
+    ) -> PyResult<T> {
+        match result {
+            Err(cause) if cause.fast_isinstance(vm.ctx.exceptions.type_error) => {
+                let message = cause.as_object().str(vm)?;
+                let err = vm.new_type_error(format!(
+                    "cannot use '{}' as a set element ({message})",
+                    item.class().name()
+                ));
+                err.set___cause__(Some(cause));
+                Err(err)
+            }
+            result => result,
+        }
     }
 }
 


### PR DESCRIPTION
Assisted-by: Codex:gpt-5.4

<!--
Thanks for your contribution!
-->

- [ ] Closes #xxxx <!-- Replace xxxx with the GitHub issue number -->
- [x] This PR follows our [AI policy](https://github.com/RustPython/.github/blob/main/AI_POLICY.md)

## Summary
<!-- What's the purpose of the change? What does it do, and why? -->
- Improve unhashable element error messages for set `contains`, `add`, and `discard` operations while preserving non-TypeError exceptions.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved `TypeError` output for set operations involving unhashable elements (when checking membership and when adding/removing/discarding).
  - Set-related errors now clearly report the invalid element’s type and keep the original `TypeError` available as the underlying cause (`__cause__`).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->