### PR TITLE
Fix frozenset subclass keyword arguments

### DIFF
--- a/Lib/test/test_set.py
+++ b/Lib/test/test_set.py
@@ -828,7 +828,6 @@ class TestFrozenSetSubclass(TestFrozenSet):
     thetype = FrozenSetSubclass
     basetype = frozenset
 
-    @unittest.expectedFailure  # TODO: RUSTPYTHON
     def test_keywords_in_subclass(self):
         class subclass(frozenset):
             pass

--- a/crates/vm/src/builtins/set.rs
+++ b/crates/vm/src/builtins/set.rs
@@ -958,31 +958,54 @@ impl Constructor for PyFrozenSet {
     type Args = Vec<PyObjectRef>;
 
     fn slot_new(cls: PyTypeRef, args: FuncArgs, vm: &VirtualMachine) -> PyResult {
-        let iterable: OptionalArg<PyObjectRef> = args.bind(vm)?;
+        let is_exact_frozenset = cls.is(vm.ctx.types.frozenset_type);
+        let is_frozenset_init = {
+            let cls_init = cls.slots.init.load().map(|init| init as usize);
+            let frozenset_init = vm
+                .ctx
+                .types
+                .frozenset_type
+                .slots
+                .init
+                .load()
+                .map(|init| init as usize);
+            cls_init == frozenset_init
+        };
 
         // Optimizations for exact frozenset type
-        if cls.is(vm.ctx.types.frozenset_type) {
+        let iterable_opt = if is_exact_frozenset || is_frozenset_init {
+            let iterable: OptionalArg<PyObjectRef> = args.bind(vm)?;
+
             // Return exact frozenset as-is
-            if let OptionalArg::Present(ref input) = iterable
-                && let Ok(fs) = input.clone().downcast_exact::<Self>(vm)
+            if is_exact_frozenset
+                && let OptionalArg::Present(input) = &iterable
+                && input.class().is(vm.ctx.types.frozenset_type)
             {
-                return Ok(fs.into_pyref().into());
+                return Ok(input.clone());
             }
 
-            // Return empty frozenset singleton
-            if iterable.is_missing() {
-                return Ok(vm.ctx.empty_frozenset.clone().into());
+            iterable.into_option()
+        } else {
+            match &args.args[..] {
+                [] => None,
+                [iterable] => Some(iterable.clone()),
+                slice => {
+                    return Err(vm.new_type_error(format!(
+                        "frozenset expected at most 1 argument, got {}",
+                        slice.len()
+                    )));
+                }
             }
-        }
+        };
 
-        let elements: Vec<PyObjectRef> = if let OptionalArg::Present(iterable) = iterable {
+        let elements = if let Some(iterable) = iterable_opt {
             iterable.try_to_value(vm)?
         } else {
             vec![]
         };
 
-        // Return empty frozenset singleton for exact frozenset types (when iterable was empty)
-        if elements.is_empty() && cls.is(vm.ctx.types.frozenset_type) {
+        // Return empty frozenset singleton
+        if is_exact_frozenset && elements.is_empty() {
             return Ok(vm.ctx.empty_frozenset.clone().into());
         }
 


### PR DESCRIPTION
Assisted-by: Codex:gpt-5.6

<!--
Thanks for your contribution!
-->

- [ ] Closes #xxxx <!-- Replace xxxx with the GitHub issue number -->
- [x] This PR follows our [AI policy](https://github.com/RustPython/.github/blob/main/AI_POLICY.md)

## Summary

- Fix `frozenset` subclass construction to match CPython’s keyword-argument behavior.
- Allow subclasses with a custom `__init__` to receive keyword arguments while `frozenset.__new__` consumes the positional iterable.
- Preserve strict argument validation for exact `frozenset` and subclasses inheriting `frozenset.__init__`.
- Keep exact-type reuse and empty-singleton optimizations limited to exact `frozenset` instances.
- Re-enable `TestFrozenSetSubclass.test_keywords_in_subclass` by removing its `expectedFailure` marker.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved `frozenset` construction by detecting the exact builtin type for a faster initialization path.
  * Returns existing builtin `frozenset` inputs directly when appropriate.
  * For `frozenset` subclasses, enforces “at most 1 argument” and raises `TypeError` when more than one positional argument is provided.
  * Optimized empty `frozenset` creation to reuse the existing empty singleton instead of allocating a new one.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->