### PR TITLE
Remove trailing whitespace from sequence TODO

### DIFF
--- a/crates/vm/src/sequence.rs
+++ b/crates/vm/src/sequence.rs
@@ -124,7 +124,7 @@ where
         let n = vm.check_repeat_or_overflow_error(self.as_ref().len(), n)?;
 
         if n > 1 && core::mem::size_of_val(self.as_ref()) >= MAX_MEMORY_SIZE / n {
-            // TODO: make a global static NoMemory shared exc object and return its reference. 
+            // TODO: make a global static NoMemory shared exc object and return its reference.
             return Err(vm.new_memory_error(""));
         }
 


### PR DESCRIPTION
- [x] Follow-up to #8270; applies the maintainer suggestion in [discussion_r3590783360](https://github.com/RustPython/RustPython/pull/8270#discussion_r3590783360)
- [x] This PR follows our [AI policy](https://github.com/RustPython/.github/blob/main/AI_POLICY.md)

## Summary

This is a whitespace-only cleanup with no runtime behavior change.

This PR will get the build green on main.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Cleaned up internal code formatting without changing functionality or user-visible behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->