### PR TITLE
weakref: treat explicit None callback as no callback

### DIFF
--- a/Lib/test/test_weakref.py
+++ b/Lib/test/test_weakref.py
@@ -380,7 +380,6 @@ class ReferencesTestCase(TestBase):
     # was not honored, and was broken in different ways for
     # PyWeakref_NewRef() and PyWeakref_NewProxy().  (Two tests.)
 
-    @unittest.expectedFailure  # TODO: RUSTPYTHON
     def test_shared_ref_without_callback(self):
         self.check_shared_without_callback(weakref.ref)
 

--- a/crates/vm/src/builtins/weakref.rs
+++ b/crates/vm/src/builtins/weakref.rs
@@ -49,7 +49,7 @@ impl Constructor for PyWeak {
         let referent = positional
             .next()
             .ok_or_else(|| vm.new_type_error("__new__ expected at least 1 argument, got 0"))?;
-        let callback = positional.next();
+        let callback = positional.next().filter(|callback| !vm.is_none(callback));
         if let Some(_extra) = positional.next() {
             let got = positional.count() + 3;
             return Err(


### PR DESCRIPTION
<!--
Thanks for your contribution!
-->

- [ ] Closes #xxxx <!-- Replace xxxx with the GitHub issue number -->
- [ ] This PR follows our [AI policy](https://github.com/RustPython/.github/blob/main/AI_POLICY.md)

## Summary
<!-- What's the purpose of the change? What does it do, and why? -->

- Fix `weakref.ref(obj, None)` being treated as having a callback instead of no callback.
- Re-enable `test_shared_ref_without_callback`, which was previously marked `@unittest.expectedFailure` due to this bug.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved weak reference creation by consistently treating an explicitly provided `None` callback as no callback.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->