### PR TITLE
interpreter: canonicalize when initializing search paths dynamically

### DIFF
--- a/Lib/test/test_unittest/test_program.py
+++ b/Lib/test/test_unittest/test_program.py
@@ -505,7 +505,6 @@ class TestCommandLineArgs(unittest.TestCase):
 
         self.assertEqual(program.testNamePatterns, ['*foo*', '*bar*', '*pat*'])
 
-    @unittest.expectedFailureIf(sys.platform != "win32", "TODO: RUSTPYTHON")
     def testSelectedTestNamesFunctionalTest(self):
         def run_unittest(args):
             # Use -E to ignore PYTHONSAFEPATH env var

--- a/src/interpreter.rs
+++ b/src/interpreter.rs
@@ -57,7 +57,23 @@ fn setup_dynamic_stdlib(vm: &mut crate::VirtualMachine) {
     use rustpython_vm::common::rc::PyRc;
 
     let state = PyRc::get_mut(&mut vm.state).unwrap();
-    let paths = collect_stdlib_paths();
+    let paths: Vec<String> = collect_stdlib_paths()
+        .into_iter()
+        .map(|p| {
+            std::fs::canonicalize(&p)
+                .map(|canonical| {
+                    let s = canonical.to_string_lossy();
+                    #[cfg(windows)]
+                    {
+                        if let Some(stripped) = s.strip_prefix(r"\\?\") {
+                            return stripped.to_owned();
+                        }
+                    }
+                    s.into_owned()
+                })
+                .unwrap_or(p)
+        })
+        .collect();
 
     // Set stdlib_dir to the first stdlib path if available
     if let Some(first_path) = paths.first() {


### PR DESCRIPTION
# RustPython Test Discovery Path Mismatch: Root Cause and Solution Comparison

This document provides a detailed analysis of the `AssertionError: Path must be within the project` failure during unittest discovery in RustPython, comparing two approaches to fix it.

## 1. Root Cause Analysis

### The Error Scenario
When executing the test suite with:
```bash
cargo run -- Lib/test/test_unittest/test_program.py
```
`unittest.loader` encounters an assertion failure during test discovery:
```python
AssertionError: Path must be within the project
```

### The Mechanism
1. **Unittest Loader Constraint**:
   CPython's `unittest` library asserts that any discovered test package (`start_dir`) must reside inside the project's top-level directory (`top_level_dir`).
   It checks this by computing the relative path and verifying it doesn't navigate upwards:
   ```python
   _relpath = os.path.relpath(path, self._top_level_dir)
   assert not _relpath.startswith('..'), "Path must be within the project"
   ```

2. **Dual-Root Mismatch in RustPython**:
   Unlike CPython, RustPython manages the standard library in two separate locations in the workspace:
   * **Workspace `Lib/`**: Contains the test suite (`Lib/test/...`) and standard library files.
   * **`crates/pylib/Lib/`**: A helper directory used for packaging. `crates/pylib/Lib` is a symlink pointing to the real workspace `../../Lib/`.

3. **Runtime Directory Discrepancy**:
   * `sys.path` contains `crates/pylib/Lib` (the path to the symlink).
   * Thus, when `test.support` is imported, its `__file__` is resolved relative to the symlink: `/home/lsahn/projects/oss/RustPython/crates/pylib/Lib/test/support/__init__.py`.
   * Consequently, `STDLIB_DIR` resolves to the symlink root: `/home/lsahn/projects/oss/RustPython/crates/pylib/Lib`.
   * However, since `test_program.py` is executed directly from the workspace, its `pkg_dir` is: `/home/lsahn/projects/oss/RustPython/Lib/test/test_unittest/testmock`.
   * When `os.path.relpath(pkg_dir, top_dir)` is called:
     ```python
     os.path.relpath(
         "/home/lsahn/projects/oss/RustPython/Lib/test/test_unittest/testmock",
         "/home/lsahn/projects/oss/RustPython/crates/pylib/Lib"
     )
     # Result: "../../../Lib/test/test_unittest/testmock"
     ```
     Because the relative path starts with `..`, the assertion fails.

## 2. Comparison of Solutions

### Solution 1: Python-Level Fix (Modifying `Lib/test/support/__init__.py`)
This approach intercepts the path discrepancy within the test framework itself.

* **Implementation**:
  Inside `load_package_tests` in `Lib/test/support/__init__.py`, check if `pkg_dir` falls outside `STDLIB_DIR` (using `.startswith('..')`). If so, trace up from `pkg_dir` to dynamically find the standard library root containing the test package.
* **Pros**:
  * Localized strictly to the test framework execution path.
* **Cons**:
  * **Violates Upstream Merging**: RustPython periodically syncs test files from upstream CPython in bulk. Modifying files under `Lib/test/` creates merge conflicts and complicates maintenance.
  * **Band-Aid Fix**: Solves the symptoms for unittest discovery but does not resolve the underlying path duplicate representation in `sys.path`.

### Solution 2: Rust-Level Fix (Modifying `src/interpreter.rs` - Recommended)
This approach resolves the symlink at the interpreter level when building standard library search paths.

* **Implementation**:
  When initializing search paths dynamically in `setup_dynamic_stdlib` using `collect_stdlib_paths()`, run `std::fs::canonicalize` on the paths. This resolves the `crates/pylib/Lib` symlink to its target `/home/lsahn/projects/oss/RustPython/Lib` before adding it to `sys.path`.
* **Pros**:
  * **Zero Changes to Standard Library**: Keeps `Lib/test` files pristine and 100% compatible with upstream CPython.
  * **Fixes the Root Cause**: Standardizes search paths so that `__file__` always refers to canonical paths, preventing path mismatches across the entire runtime environment.
  * **Robust**: Prevents other modules or user code from experiencing similar symlink-based path mismatches.
  * **No side effects on CPython standard library sync**.
* **Cons**:
  * Requires rebuilding the interpreter (though this is standard when changing Rust sources).

# Why Did Only This Specific Test Case Fail?

This document explains why the path resolution mismatch and subsequent `AssertionError` only affected a tiny subset of tests (specifically unittest discovery within `test_unittest`), while other tests involving symlinks ran successfully.

## 1. The Normal Case: Why Most Tests Succeed

Most standard library tests (e.g., `test_dict.py`, `test_bytes.py`) do not fail because they do not trigger path verification:
* **No Test Discovery**: They are single files imported and executed directly by the test runner. They never invoke `unittest.loader.discover()`.
* **Single Directory Root**: Even when standard `unittest discover` commands are run from the CLI (e.g., `rustpython -m unittest discover -s Lib/test`), both the start directory (`start_dir`) and top-level directory (`top_level_dir`) reside under the same folder (`Lib/`). Since there is no cross-referencing between different root directories, `os.path.relpath()` never returns a path starting with `..`.

## 2. The Failure Case: The Mismatch Scenario

The failure in `testSelectedTestNamesFunctionalTest` occurred because it met a highly specific set of conditions:

1. **Sub-package Hook (`testmock`)**:
   The `testmock` sub-package defines a custom `load_tests` hook that delegates to a shared helper in `test.support`:
   ```python
   def load_tests(*args):
       return load_package_tests(os.path.dirname(__file__), *args)
   ```

2. **Hardcoded `STDLIB_DIR` in `load_package_tests`**:
   The helper in `test.support` invokes discovery, hardcoding the project root to `STDLIB_DIR`:
   ```python
   # Inside test.support.load_package_tests
   top_dir = STDLIB_DIR
   package_tests = loader.discover(start_dir=pkg_dir, top_level_dir=top_dir, ...)
   ```

3. **Dual-Root Mismatch**:
   Because `test.support` is imported from the packaged stdlib directory, while the test file itself runs from the workspace directory:
   * **`pkg_dir` (start directory)** resolves to: `.../Lib/test/test_unittest/testmock` (workspace realpath).
   * **`top_dir` (top-level directory)** resolves to: `.../crates/pylib/Lib` (symlink path).

Because `loader.discover` was passed two paths belonging to different directories (one starting with `Lib/` and the other with `crates/pylib/Lib/`), `os.path.relpath` computed a relative path that navigated upwards (beginning with `..`). This directly triggered the assertion: `assert not _relpath.startswith('..')`.

## Summary

The error only surfaces when **a test package runs from the workspace `Lib` directory** but **delegates its sub-test discovery to `test.support` (imported from `crates/pylib/Lib`)**, forcing the unittest discoverer to compare paths across two different filesystem roots.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved standard library path resolution to make module discovery more reliable.
  * Enhanced Windows compatibility by removing extended (`\\?\`) path prefixes when present.
  * Kept existing fallback behavior when a standard library path can’t be canonicalized.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->