### PR TITLE
Clean up deprecations

### DIFF
--- a/crates/host_env/src/resource.rs
+++ b/crates/host_env/src/resource.rs
@@ -7,9 +7,6 @@ pub use libc::{
     RLIMIT_NOFILE, RLIMIT_NPROC, RLIMIT_RSS, RLIMIT_STACK, c_long, rlim_t, rlimit, timeval,
 };
 
-#[cfg(target_os = "android")]
-pub use libc::RLIM_NLIMITS;
-
 #[cfg(any(target_os = "linux", target_os = "android", target_os = "emscripten"))]
 pub use libc::{RLIMIT_MSGQUEUE, RLIMIT_NICE, RLIMIT_RTPRIO, RLIMIT_SIGPENDING};
 
@@ -35,6 +32,9 @@ pub use libc::RUSAGE_THREAD;
 
 #[cfg(not(any(target_os = "windows", target_os = "redox")))]
 pub use libc::{RUSAGE_CHILDREN, RUSAGE_SELF};
+
+#[cfg(target_os = "android")]
+pub const RLIM_NLIMITS: libc::c_int = 16;
 
 #[derive(Debug, Clone, Copy)]
 pub struct RUsage {

--- a/crates/vm/src/builtins/function.rs
+++ b/crates/vm/src/builtins/function.rs
@@ -87,7 +87,7 @@ static FUNC_VERSION_COUNTER: AtomicU32 = AtomicU32::new(1);
 /// Once the counter wraps to 0, it stays at 0 permanently.
 fn next_func_version() -> u32 {
     FUNC_VERSION_COUNTER
-        .fetch_update(Relaxed, Relaxed, |v| (v != 0).then(|| v.wrapping_add(1)))
+        .try_update(Relaxed, Relaxed, |v| (v != 0).then(|| v.wrapping_add(1)))
         .unwrap_or(0)
 }
 

--- a/crates/vm/src/builtins/type.rs
+++ b/crates/vm/src/builtins/type.rs
@@ -680,7 +680,7 @@ impl PyType {
         let flags_bits = flags.bits();
         let _ = self
             .abc_tpflags
-            .fetch_update(Ordering::AcqRel, Ordering::Acquire, |old| {
+            .try_update(Ordering::AcqRel, Ordering::Acquire, |old| {
                 Some((old & !collection_bits) | flags_bits)
             });
         self.modified();


### PR DESCRIPTION
<!--
Thanks for your contribution!
-->

- [x] Closes #8297 <!-- Replace xxxx with the GitHub issue number -->
- [x] This PR follows our [AI policy](https://github.com/RustPython/.github/blob/main/AI_POLICY.md)

## Summary

This PR has two commits that replace the deprecated methods in libc with new APIs or define a new const value due to compatibility.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved stability when tracking function versions at runtime by adjusting how the internal version counter is atomically updated.
  * Improved reliability when updating collection-related type flags, including correct propagation through subclass hierarchies.
  * Ensured Android-specific resource limit constant availability by defining the exported constant explicitly for consistent cross-environment behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->