### PR TITLE
Store StopIteration.value in a struct field instead of the instance dict

### DIFF
--- a/Lib/test/test_pydoc/test_pydoc.py
+++ b/Lib/test/test_pydoc/test_pydoc.py
@@ -1797,7 +1797,6 @@ cm(x) class method of test.test_pydoc.test_pydoc.X
         self.assertEqual(self._get_summary_line(Exception.args), "args")
         self.assertEqual(self._get_summary_line(memoryview.obj), "obj")
 
-    @unittest.expectedFailure  # TODO: RUSTPYTHON
     @requires_docstrings
     def test_member_descriptor(self):
         # Currently these attributes are implemented as member descriptors

--- a/crates/vm/src/exceptions.rs
+++ b/crates/vm/src/exceptions.rs
@@ -965,9 +965,7 @@ impl ExceptionZoo {
 
         extend_exception!(PyException, ctx, excs.exception_type);
 
-        extend_exception!(PyStopIteration, ctx, excs.stop_iteration, {
-            "value" => ctx.none(),
-        });
+        extend_exception!(PyStopIteration, ctx, excs.stop_iteration);
         extend_exception!(PyStopAsyncIteration, ctx, excs.stop_async_iteration);
 
         extend_exception!(PyArithmeticError, ctx, excs.arithmetic_error);
@@ -1702,23 +1700,79 @@ pub(super) mod types {
     #[repr(transparent)]
     pub struct PyException(PyBaseException);
 
-    #[pyexception(name, base = PyException, ctx = "stop_iteration")]
-    #[derive(Debug)]
-    #[repr(transparent)]
-    pub struct PyStopIteration(PyException);
+    #[pyexception(name, base = PyException, ctx = "stop_iteration", traverse = "manual")]
+    #[repr(C)]
+    pub struct PyStopIteration {
+        base: PyException,
+        value: PyAtomicRef<Option<PyObject>>,
+    }
 
-    #[pyexception(with(Initializer))]
-    impl PyStopIteration {}
+    impl crate::class::PySubclass for PyStopIteration {
+        type Base = PyException;
+        fn as_base(&self) -> &Self::Base {
+            &self.base
+        }
+    }
+
+    impl core::fmt::Debug for PyStopIteration {
+        fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+            f.debug_struct("PyStopIteration").finish_non_exhaustive()
+        }
+    }
+
+    unsafe impl Traverse for PyStopIteration {
+        fn traverse(&self, tracer_fn: &mut TraverseFn<'_>) {
+            self.base.0.traverse(tracer_fn);
+            if let Some(obj) = self.value.deref() {
+                tracer_fn(obj);
+            }
+        }
+    }
+
+    impl Constructor for PyStopIteration {
+        type Args = FuncArgs;
+
+        fn py_new(_cls: &Py<PyType>, args: FuncArgs, vm: &VirtualMachine) -> PyResult<Self> {
+            let base_exception = PyBaseException::new(args.args, vm);
+            Ok(Self {
+                base: PyException(base_exception),
+                value: None.into(),
+            })
+        }
+    }
 
     impl Initializer for PyStopIteration {
         type Args = FuncArgs;
         fn slot_init(zelf: PyObjectRef, args: FuncArgs, vm: &VirtualMachine) -> PyResult<()> {
-            zelf.set_attr("value", vm.unwrap_or_none(args.args.first().cloned()), vm)?;
+            let value = match args.args.len() {
+                0 => vm.ctx.none(),
+                _ => args.args[0].clone(),
+            };
+            PyBaseException::slot_init(zelf.clone(), args, vm)?;
+            let exc: &Py<Self> = zelf.downcast_ref::<Self>().unwrap();
+            exc.value.swap_to_temporary_refs(Some(value), vm);
             Ok(())
         }
 
         fn init(_zelf: PyRef<Self>, _args: Self::Args, _vm: &VirtualMachine) -> PyResult<()> {
             unreachable!("slot_init is defined")
+        }
+    }
+
+    #[pyexception(with(Constructor, Initializer))]
+    impl PyStopIteration {
+        #[pygetset]
+        fn value(&self) -> Option<PyObjectRef> {
+            self.value.to_owned()
+        }
+
+        #[pygetset(setter)]
+        fn set_value(&self, setter_value: PySetterValue, vm: &VirtualMachine) {
+            let value = match setter_value {
+                PySetterValue::Assign(v) => Some(v),
+                PySetterValue::Delete => None,
+            };
+            self.value.swap_to_temporary_refs(value, vm);
         }
     }
 

--- a/crates/vm/src/vm/vm_new.rs
+++ b/crates/vm/src/vm/vm_new.rs
@@ -894,21 +894,15 @@ impl VirtualMachine {
     }
 
     pub fn new_stop_iteration(&self, value: Option<PyObjectRef>) -> PyBaseExceptionRef {
-        let dict = self.ctx.new_dict();
+        let stop_iteration_error = self.ctx.exceptions.stop_iteration.to_owned();
         let args = if let Some(value) = value {
-            // manually set `value` attribute like StopIteration.__init__
-            dict.set_item("value", value.clone(), self)
-                .expect("dict.__setitem__ never fails");
             vec![value]
         } else {
             Vec::new()
         };
+        let exc = self.invoke_exception(stop_iteration_error, args);
 
-        PyRef::new_ref(
-            PyBaseException::new(args, self),
-            self.ctx.exceptions.stop_iteration.to_owned(),
-            Some(dict),
-        )
+        exc.unwrap()
     }
 
     fn new_downcast_error(

--- a/crates/vm/src/vm/vm_new.rs
+++ b/crates/vm/src/vm/vm_new.rs
@@ -902,7 +902,7 @@ impl VirtualMachine {
         };
         let exc = self.invoke_exception(stop_iteration_error, args);
 
-        exc.unwrap()
+        exc.expect("StopIteration is a BaseException Subclass.")
     }
 
     fn new_downcast_error(


### PR DESCRIPTION
- [x] Closes #8290
- [x] This PR follows our [AI policy](https://github.com/RustPython/.github/blob/main/AI_POLICY.md)

## Summary

`StopIteration.value` was stored in the instance `__dict__`, so `StopIteration().__dict__` was non-empty and clearing the dict lost the value, unlike CPython. It's now a struct field on `PyStopIteration` (`#[repr(C)]` + base field, the same approach as `OSError` and `SystemExit` in #8282), exposed via `#[pygetset]` — writable, deletable, and independent from `args`, with an empty `__dict__` as in CPython.

`new_stop_iteration` is also routed through the full constructor path instead of building a `PyBaseException` with a manual dict. This fixes a crash caused by the added payload (the old path allocated a base-sized object) and removes the per-instance dict allocation on this hot path.

```python
e = StopIteration(5)
e.__dict__.clear()
print(e.value)
# before: None   after: 5   (matches CPython)
```

## Test plan

- Verified against CPython 3.14.6: `value` for `StopIteration()` / `(5)` / `(1, 2)`, write/delete, `dict.clear()`, `vars()`, empty `__dict__`, and generator `return` value delivery (incl. `yield from`).
- `test_generators`, `test_generator_stop`, `test_yield_from`: all pass. `test_exceptions` / `extra_tests/snippets/builtin_exceptions.py`: no regressions (the single `test_badisinstance` failure is pre-existing on `main`).
- `cargo fmt` / `cargo clippy`: clean (no new warnings).
- Unmarks test_pydoc's `test_member_descriptor`: it now passes because `StopIteration.value` is a real descriptor whose pydoc summary line renders as `value` (it was previously a plain `None` class attribute).
  Note this does not add `__doc__` support to getset descriptors — `StopIteration.value.__doc__` still differs from CPython, which is a separate pre-existing gap in `PyGetSet`.

Assisted-by: Claude Code:claude-fable-5

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved `StopIteration` exception handling and initialization to make the exception’s `value` reliably accessible and updatable.
  * Standardized how `StopIteration` is constructed, ensuring the return payload is consistently preserved whether a value is provided or not.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->