### PR TITLE
stdlib: remove unused warning on sock_wait()

### DIFF
--- a/crates/stdlib/src/socket.rs
+++ b/crates/stdlib/src/socket.rs
@@ -2444,6 +2444,7 @@ mod _socket {
     }
 
     /// returns Ok(true) on timeout
+    #[cfg(feature = "ssl")]
     pub(crate) fn sock_wait(
         sock: &Socket,
         wait_kind: SockWaitKind,


### PR DESCRIPTION
<!--
Thanks for your contribution!
-->

- [x] This PR follows our [AI policy](https://github.com/RustPython/.github/blob/main/AI_POLICY.md)

## Summary
The function is used in 'feature = ssl'. However, the current codebase defines it without a conditional compilation expression and always be compiled.

This commit removes the unused warning by adding a conditional compilation expression, '#[cfg(feature = "ssl")]'.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved builds for configurations without SSL support by limiting SSL-specific socket functionality to SSL-enabled builds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->