### PR TITLE
csv: handle empty fields with skipinitialspace

### DIFF
--- a/Lib/test/test_csv.py
+++ b/Lib/test/test_csv.py
@@ -471,7 +471,6 @@ class Test_Csv(unittest.TestCase):
         self._read_test(['1\\.5,\\.5,"\\.5"'], [[1.5, 0.5, ".5"]],
                         quoting=csv.QUOTE_STRINGS, escapechar='\\')
 
-    @unittest.skip("TODO: RUSTPYTHON; slice index starts at 1 but ends at 0")
     def test_read_skipinitialspace(self):
         self._read_test(['no space, space,  spaces,\ttab'],
                         [['no space', 'space', 'spaces', '\ttab']],

--- a/crates/stdlib/src/csv.rs
+++ b/crates/stdlib/src/csv.rs
@@ -994,28 +994,68 @@ mod _csv {
 
     impl SelfIter for Reader {}
 
-    fn read_quote_none_record(
+    fn read_quote_record(
         input: &[u8],
         dialect: PyDialect,
         field_limit: isize,
         vm: &VirtualMachine,
     ) -> PyResult<Vec<PyObjectRef>> {
-        let mut fields = vec![Vec::new()];
+        // QUOTE_NOTNULL and QUOTE_STRINGS map empty unquoted fields to None,
+        // but preserve quoted empty fields as strings, so retain quote provenance.
+        let mut fields = vec![(Vec::new(), false)];
+        let mut at_field_start = true;
+        let mut in_quoted_field = false;
         let mut escaped = false;
-        let mut after_delimiter = false;
+        let mut index = 0;
 
-        for (index, &byte) in input.iter().enumerate() {
+        while index < input.len() {
+            let byte = input[index];
+
             if escaped {
-                fields.last_mut().unwrap().push(byte);
+                fields.last_mut().unwrap().0.push(byte);
                 escaped = false;
-                after_delimiter = false;
-            } else if dialect.skipinitialspace && after_delimiter && byte == b' ' {
+                at_field_start = false;
+                index += 1;
                 continue;
-            } else if dialect.escapechar == Some(byte) {
+            }
+
+            if dialect.escapechar == Some(byte) {
                 escaped = true;
+                at_field_start = false;
+                index += 1;
+                continue;
+            }
+
+            if in_quoted_field {
+                if dialect.quotechar == Some(byte) {
+                    if dialect.doublequote && input.get(index + 1) == Some(&byte) {
+                        fields.last_mut().unwrap().0.push(byte);
+                        index += 2;
+                    } else {
+                        in_quoted_field = false;
+                        index += 1;
+                    }
+                } else {
+                    fields.last_mut().unwrap().0.push(byte);
+                    index += 1;
+                }
+                continue;
+            }
+
+            if at_field_start && dialect.skipinitialspace && byte == b' ' {
+                index += 1;
+            } else if at_field_start
+                && dialect.quoting != QuoteStyle::None
+                && dialect.quotechar == Some(byte)
+            {
+                fields.last_mut().unwrap().1 = true;
+                at_field_start = false;
+                in_quoted_field = true;
+                index += 1;
             } else if byte == dialect.delimiter {
-                fields.push(Vec::new());
-                after_delimiter = true;
+                fields.push((Vec::new(), false));
+                at_field_start = true;
+                index += 1;
             } else if matches!(byte, b'\r' | b'\n') {
                 if !input[index..]
                     .iter()
@@ -1031,22 +1071,29 @@ mod _csv {
                 }
                 break;
             } else {
-                fields.last_mut().unwrap().push(byte);
-                after_delimiter = false;
+                fields.last_mut().unwrap().0.push(byte);
+                at_field_start = false;
+                index += 1;
             }
         }
 
         // CPython treats an escape character at the end of an iterator item
         // as escaping the implicit newline at the end of that item.
         if escaped {
-            fields.last_mut().unwrap().push(b'\n');
+            fields.last_mut().unwrap().0.push(b'\n');
         }
 
         fields
             .into_iter()
-            .map(|field| {
+            .map(|(field, was_quoted)| {
                 if field.len() > field_limit as usize {
                     return Err(new_csv_error(vm, "filed too long to read"));
+                }
+                if matches!(dialect.quoting, QuoteStyle::Notnull | QuoteStyle::Strings)
+                    && !was_quoted
+                    && field.is_empty()
+                {
+                    return Ok(vm.ctx.none());
                 }
                 let field = core::str::from_utf8(&field)
                     .map_err(|_| vm.new_unicode_decode_error("csv not utf8"))?;
@@ -1086,23 +1133,38 @@ mod _csv {
             let mut output_ends_offset = 0;
             let field_limit = GLOBAL_FIELD_LIMIT.lock().to_owned();
 
-            if zelf.dialect.quoting == QuoteStyle::None && zelf.dialect.escapechar.is_some() {
-                let out = read_quote_none_record(input, zelf.dialect, field_limit, vm)?;
+            let use_quote_record = matches!(
+                zelf.dialect.quoting,
+                QuoteStyle::Notnull | QuoteStyle::Strings
+            ) || (zelf.dialect.quoting == QuoteStyle::None
+                && zelf.dialect.escapechar.is_some());
+            if use_quote_record {
+                let out = read_quote_record(input, zelf.dialect, field_limit, vm)?;
                 *line_num += 1;
                 return Ok(PyIterReturn::Return(vm.ctx.new_list(out).into()));
+            }
+
+            #[inline]
+            fn trim_initial_spaces(input: &[u8]) -> &[u8] {
+                let trimmed_start = input.iter().position(|&x| x != b' ').unwrap_or(input.len());
+                &input[trimmed_start..]
             }
 
             #[inline]
             fn trim_spaces(input: &[u8]) -> &[u8] {
                 let trimmed_start = input.iter().position(|&x| x != b' ').unwrap_or(input.len());
                 let trimmed_end = input.iter().rposition(|&x| x != b' ').map_or(0, |i| i + 1);
-                &input[trimmed_start..trimmed_end]
+                if trimmed_start >= trimmed_end {
+                    &input[input.len()..]
+                } else {
+                    &input[trimmed_start..trimmed_end]
+                }
             }
 
             let input = if *skipinitialspace {
                 let t = input.split(|x| x == delimiter);
                 t.map(|x| {
-                    let trimmed = trim_spaces(x);
+                    let trimmed = trim_initial_spaces(x);
                     String::from_utf8(trimmed.to_vec()).unwrap()
                 })
                 .join(format!("{}", *delimiter as char).as_str())

--- a/crates/stdlib/src/csv.rs
+++ b/crates/stdlib/src/csv.rs
@@ -14,7 +14,7 @@ mod _csv {
     };
     use alloc::fmt;
     use csv_core::Terminator;
-    use itertools::{self, Itertools};
+    use itertools::Itertools;
     use parking_lot::Mutex;
     use rustpython_common::{lock::LazyLock, wtf8::Wtf8Buf};
     use rustpython_vm::{match_class, sliceable::SliceableSequenceOp};
@@ -409,7 +409,6 @@ mod _csv {
                 output_ends: vec![0; 16],
                 reader: options.to_reader(),
                 skipinitialspace: options.get_skipinitialspace(),
-                delimiter: options.get_delimiter(),
                 line_num: 0,
             }),
             dialect: options.result(vm)?,
@@ -773,29 +772,6 @@ mod _csv {
             skipinitialspace
         }
 
-        fn get_delimiter(&self) -> u8 {
-            let mut delimiter = match &self.dialect {
-                DialectItem::Str(name) => {
-                    let g = GLOBAL_HASHMAP.lock();
-                    if let Some(dialect) = g.get(name) {
-                        dialect.delimiter
-                        // RustPython todo
-                        // todo! Perfecting the remaining attributes.
-                    } else {
-                        b','
-                    }
-                }
-                DialectItem::Obj(obj) => obj.delimiter,
-                _ => b',',
-            };
-
-            if let Some(attr) = self.delimiter {
-                delimiter = attr
-            }
-
-            delimiter
-        }
-
         fn get_lineterminator(&self) -> csv_core::Terminator {
             let mut lineterminator = match &self.dialect {
                 DialectItem::Str(name) => {
@@ -959,7 +935,6 @@ mod _csv {
         output_ends: Vec<usize>,
         reader: csv_core::Reader,
         skipinitialspace: bool,
-        delimiter: u8,
         line_num: u64,
     }
 
@@ -994,6 +969,85 @@ mod _csv {
 
     impl SelfIter for Reader {}
 
+    enum QuoteScanEvent {
+        InitialSpace,
+        StartQuotedField,
+        EndQuotedField,
+        Escaped(Option<u8>),
+        DoubleQuote(u8),
+        Delimiter,
+        RecordTerminator,
+        Data(u8),
+    }
+
+    struct QuoteScanState {
+        at_field_start: bool,
+        in_quoted_field: bool,
+    }
+
+    impl QuoteScanState {
+        const fn new() -> Self {
+            Self {
+                at_field_start: true,
+                in_quoted_field: false,
+            }
+        }
+
+        fn scan(
+            &mut self,
+            input: &[u8],
+            index: usize,
+            dialect: PyDialect,
+            unquoted_escape: bool,
+        ) -> (QuoteScanEvent, usize) {
+            let byte = input[index];
+
+            if (self.in_quoted_field || unquoted_escape) && dialect.escapechar == Some(byte) {
+                self.at_field_start = false;
+                return match input.get(index + 1).copied() {
+                    Some(escaped) => (QuoteScanEvent::Escaped(Some(escaped)), 2),
+                    None => (QuoteScanEvent::Escaped(None), 1),
+                };
+            }
+
+            if self.in_quoted_field {
+                if dialect.quotechar == Some(byte) {
+                    if dialect.doublequote && input.get(index + 1) == Some(&byte) {
+                        return (QuoteScanEvent::DoubleQuote(byte), 2);
+                    }
+                    self.in_quoted_field = false;
+                    return (QuoteScanEvent::EndQuotedField, 1);
+                }
+                return (QuoteScanEvent::Data(byte), 1);
+            }
+
+            if self.at_field_start && dialect.skipinitialspace && byte == b' ' {
+                return (QuoteScanEvent::InitialSpace, 1);
+            }
+
+            if self.at_field_start
+                && dialect.quoting != QuoteStyle::None
+                && dialect.quotechar == Some(byte)
+            {
+                self.at_field_start = false;
+                self.in_quoted_field = true;
+                return (QuoteScanEvent::StartQuotedField, 1);
+            }
+
+            if byte == dialect.delimiter {
+                self.at_field_start = true;
+                return (QuoteScanEvent::Delimiter, 1);
+            }
+
+            self.at_field_start = false;
+            if matches!(byte, b'\r' | b'\n') {
+                (QuoteScanEvent::RecordTerminator, 1)
+            } else {
+                (QuoteScanEvent::Data(byte), 1)
+            }
+        }
+    }
+
     fn read_quote_record(
         input: &[u8],
         dialect: PyDialect,
@@ -1003,83 +1057,43 @@ mod _csv {
         // QUOTE_NOTNULL and QUOTE_STRINGS map empty unquoted fields to None,
         // but preserve quoted empty fields as strings, so retain quote provenance.
         let mut fields = vec![(Vec::new(), false)];
-        let mut at_field_start = true;
-        let mut in_quoted_field = false;
-        let mut escaped = false;
+        let mut scan_state = QuoteScanState::new();
+        let mut dangling_escape = false;
         let mut index = 0;
 
         while index < input.len() {
-            let byte = input[index];
-
-            if escaped {
-                fields.last_mut().unwrap().0.push(byte);
-                escaped = false;
-                at_field_start = false;
-                index += 1;
-                continue;
-            }
-
-            if dialect.escapechar == Some(byte) {
-                escaped = true;
-                at_field_start = false;
-                index += 1;
-                continue;
-            }
-
-            if in_quoted_field {
-                if dialect.quotechar == Some(byte) {
-                    if dialect.doublequote && input.get(index + 1) == Some(&byte) {
-                        fields.last_mut().unwrap().0.push(byte);
-                        index += 2;
-                    } else {
-                        in_quoted_field = false;
-                        index += 1;
-                    }
-                } else {
+            let (event, consumed) = scan_state.scan(input, index, dialect, true);
+            match event {
+                QuoteScanEvent::InitialSpace | QuoteScanEvent::EndQuotedField => {}
+                QuoteScanEvent::StartQuotedField => fields.last_mut().unwrap().1 = true,
+                QuoteScanEvent::Escaped(Some(byte)) | QuoteScanEvent::DoubleQuote(byte) => {
                     fields.last_mut().unwrap().0.push(byte);
-                    index += 1;
                 }
-                continue;
-            }
-
-            if at_field_start && dialect.skipinitialspace && byte == b' ' {
-                index += 1;
-            } else if at_field_start
-                && dialect.quoting != QuoteStyle::None
-                && dialect.quotechar == Some(byte)
-            {
-                fields.last_mut().unwrap().1 = true;
-                at_field_start = false;
-                in_quoted_field = true;
-                index += 1;
-            } else if byte == dialect.delimiter {
-                fields.push((Vec::new(), false));
-                at_field_start = true;
-                index += 1;
-            } else if matches!(byte, b'\r' | b'\n') {
-                if !input[index..]
-                    .iter()
-                    .all(|&byte| matches!(byte, b'\r' | b'\n'))
-                {
-                    return Err(new_csv_error(
-                        vm,
-                        concat!(
-                            "new-line character seen in unquoted field",
-                            " - do you need to open the file in universal-newline mode?"
-                        ),
-                    ));
+                QuoteScanEvent::Escaped(None) => dangling_escape = true,
+                QuoteScanEvent::Delimiter => fields.push((Vec::new(), false)),
+                QuoteScanEvent::RecordTerminator => {
+                    if !input[index..]
+                        .iter()
+                        .all(|&byte| matches!(byte, b'\r' | b'\n'))
+                    {
+                        return Err(new_csv_error(
+                            vm,
+                            concat!(
+                                "new-line character seen in unquoted field",
+                                " - do you need to open the file in universal-newline mode?"
+                            ),
+                        ));
+                    }
+                    break;
                 }
-                break;
-            } else {
-                fields.last_mut().unwrap().0.push(byte);
-                at_field_start = false;
-                index += 1;
+                QuoteScanEvent::Data(byte) => fields.last_mut().unwrap().0.push(byte),
             }
+            index += consumed;
         }
 
         // CPython treats an escape character at the end of an iterator item
         // as escaping the implicit newline at the end of that item.
-        if escaped {
+        if dangling_escape {
             fields.last_mut().unwrap().0.push(b'\n');
         }
 
@@ -1124,7 +1138,6 @@ mod _csv {
                 output_ends,
                 reader,
                 skipinitialspace,
-                delimiter,
                 line_num,
             } = &mut *state;
 
@@ -1145,9 +1158,22 @@ mod _csv {
             }
 
             #[inline]
-            fn trim_initial_spaces(input: &[u8]) -> &[u8] {
-                let trimmed_start = input.iter().position(|&x| x != b' ').unwrap_or(input.len());
-                &input[trimmed_start..]
+            fn trim_initial_spaces(input: &[u8], dialect: PyDialect) -> Vec<u8> {
+                let mut trimmed = Vec::with_capacity(input.len());
+                let mut scan_state = QuoteScanState::new();
+                let mut index = 0;
+
+                // Delimiters inside quoted fields are data, so only skip spaces
+                // after delimiters encountered outside quotes.
+                while index < input.len() {
+                    let (event, consumed) = scan_state.scan(input, index, dialect, false);
+                    if !matches!(event, QuoteScanEvent::InitialSpace) {
+                        trimmed.extend_from_slice(&input[index..index + consumed]);
+                    }
+                    index += consumed;
+                }
+
+                trimmed
             }
 
             #[inline]
@@ -1162,12 +1188,7 @@ mod _csv {
             }
 
             let input = if *skipinitialspace {
-                let t = input.split(|x| x == delimiter);
-                t.map(|x| {
-                    let trimmed = trim_initial_spaces(x);
-                    String::from_utf8(trimmed.to_vec()).unwrap()
-                })
-                .join(format!("{}", *delimiter as char).as_str())
+                String::from_utf8(trim_initial_spaces(input, zelf.dialect)).unwrap()
             } else {
                 String::from_utf8(input.to_vec()).unwrap()
             };

--- a/extra_tests/snippets/stdlib_csv.py
+++ b/extra_tests/snippets/stdlib_csv.py
@@ -192,3 +192,11 @@ def test_quote_minimal_writer_empty_fields():
 
 
 test_quote_minimal_writer_empty_fields()
+
+
+def test_reader_skipinitialspace_preserves_quoted_spaces():
+    reader = csv.reader(['a, "b, c", d'], skipinitialspace=True)
+    assert list(reader) == [["a", "b, c", "d"]]
+
+
+test_reader_skipinitialspace_preserves_quoted_spaces()


### PR DESCRIPTION
- [ ] Closes #xxxx
- [x] This PR follows our [AI policy](https://github.com/RustPython/.github/blob/main/AI_POLICY.md)

## Summary

`csv.reader(..., skipinitialspace=True)` preprocessed each record by splitting
it on the delimiter and trimming both ends of every piece. This had two
problems:

- a field containing only spaces could produce an invalid Rust slice and panic;
- trailing spaces were removed even though only initial spaces should be ignored;
- delimiters inside quoted fields were treated as field boundaries, so valid quoted spaces could be removed before csv-core parsed the record.

For example, the old preprocessing could change:
```python
'a, "b, c", d'
```

before passing it to csv-core, removing the space inside "b, c".

The raw split-and-join preprocessing is now removed. A small per-item quote scanner classifies field starts, quote boundaries, doubled quotes, escapes, delimiters, and record terminators. The skipinitialspace preprocessing discards only actual initial-space events and copies every other source byte unchanged.

The same scanner is consumed by the custom quote-mode reader, avoiding separate implementations of the quote and escape transitions.

## QUOTE_NOTNULL and QUOTE_STRINGS

The CPython test also covers `QUOTE_NOTNULL` and `QUOTE_STRINGS`. For these
modes, an empty unquoted field must become `None`, while a quoted empty field
must remain an empty string:

```python
',""'  -> [None, '']
```

Both fields have empty decoded byte contents, so the conversion cannot be
decided from the final field buffer alone. The reader must retain whether each
field began with a quote.

The existing custom QUOTE_NONE reader is therefore extended into a shared
reader path for:

- QUOTE_NONE with an escape character;
- QUOTE_NOTNULL;
- QUOTE_STRINGS.

Each parsed field carries its bytes and a was_quoted flag. The flag is used
only when QUOTE_NOTNULL or QUOTE_STRINGS converts an empty unquoted field
to None. This avoids separate, duplicated functions for the two modes while
preserving the existing QUOTE_NONE escape behavior.

Test_Csv.test_read_skipinitialspace is unmarked now that its regular,
QUOTE_NOTNULL, and QUOTE_STRINGS cases pass.

## Scope

This is intentionally a narrow reader fix. It does not introduce a complete
CPython-style CSV state machine and does not change:

- strict parsing;
- records spanning multiple iterator items;
- multiline reader lifecycle;
- complete QUOTE_STRINGS numeric conversion;
- writer quoting or lineterminator handling.

## Testing

temp/workspace/before-commit-csv.sh passed, including:

- cargo fmt --check
- cargo run --release Lib/test/test_csv.py
    - 128 tests passed
    - 6 skipped
    - 21 expected failures

- cargo run -- extra_tests/snippets/stdlib_csv.py
- cargo clippy -p rustpython-stdlib --all-targets
- the configured workspace test suite

## related issue
- #8310 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved CSV reader behavior for quoted fields, including correct handling of escaped quotes, delimiters, and record/line termination.
  * When `skipinitialspace=True`, initial-space trimming is now quote-aware, preserving spaces inside quoted fields.
  * Empty unquoted fields and empty quoted fields are now handled distinctly (null vs empty string, as applicable).
  * Refined parsing behavior when `escapechar` is configured.
* **Tests**
  * Added a regression test for `skipinitialspace=True` ensuring spaces inside quoted fields are preserved.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->