### PR TITLE
bytes: support keyword arguments in hex()

### DIFF
--- a/Lib/test/test_bytes.py
+++ b/Lib/test/test_bytes.py
@@ -518,7 +518,6 @@ class BaseBytesTest:
         self.assertEqual(self.type2test(b"\x1a\x2b\x30").hex(), '1a2b30')
         self.assertEqual(memoryview(b"\x1a\x2b\x30").hex(), '1a2b30')
 
-    @unittest.expectedFailure  # TODO: RUSTPYTHON; TypeError: Unexpected keyword argument sep
     def test_hex_separator_basics(self):
         three_bytes = self.type2test(b'\xb9\x01\xef')
         self.assertEqual(three_bytes.hex(), 'b901ef')

--- a/Lib/test/test_memoryview.py
+++ b/Lib/test/test_memoryview.py
@@ -664,7 +664,6 @@ class OtherTest(unittest.TestCase):
         m2 = m1[::-1]
         self.assertEqual(m2.hex(), '30' * 200000)
 
-    @unittest.expectedFailure  # TODO: RUSTPYTHON; TypeError: Unexpected keyword argument sep
     def test_memoryview_hex_separator(self):
         x = bytes(range(97, 102))
         m1 = memoryview(x)

--- a/crates/vm/src/builtins/bytearray.rs
+++ b/crates/vm/src/builtins/bytearray.rs
@@ -1,7 +1,7 @@
 //! Implementation of the python bytearray object.
 use super::{
-    PositionIterInternal, PyBytes, PyBytesRef, PyDictRef, PyGenericAlias, PyIntRef, PyStrRef,
-    PyTuple, PyTupleRef, PyType, PyTypeRef, iter::builtins_iter,
+    PositionIterInternal, PyBytes, PyDictRef, PyGenericAlias, PyIntRef, PyStrRef, PyTuple,
+    PyTupleRef, PyType, PyTypeRef, iter::builtins_iter,
 };
 use crate::{
     AsObject, Context, Py, PyObject, PyObjectRef, PyPayload, PyRef, PyResult, TryFromObject,
@@ -10,8 +10,8 @@ use crate::{
     atomic_func,
     byte::{bytes_from_object, value_from_object},
     bytes_inner::{
-        ByteInnerFindOptions, ByteInnerNewOptions, ByteInnerPaddingOptions, ByteInnerSplitOptions,
-        ByteInnerTranslateOptions, DecodeArgs, PyBytesInner, bytes_decode,
+        ByteInnerFindOptions, ByteInnerHexOptions, ByteInnerNewOptions, ByteInnerPaddingOptions,
+        ByteInnerSplitOptions, ByteInnerTranslateOptions, DecodeArgs, PyBytesInner, bytes_decode,
     },
     class::PyClassImpl,
     common::{
@@ -321,12 +321,8 @@ impl PyByteArray {
     }
 
     #[pymethod]
-    fn hex(
-        &self,
-        sep: OptionalArg<Either<PyStrRef, PyBytesRef>>,
-        bytes_per_sep: OptionalArg<isize>,
-        vm: &VirtualMachine,
-    ) -> PyResult<String> {
+    fn hex(&self, options: ByteInnerHexOptions, vm: &VirtualMachine) -> PyResult<String> {
+        let ByteInnerHexOptions { sep, bytes_per_sep } = options;
         self.inner().hex(sep, bytes_per_sep, vm)
     }
 

--- a/crates/vm/src/builtins/bytes.rs
+++ b/crates/vm/src/builtins/bytes.rs
@@ -9,8 +9,8 @@ use crate::{
     anystr::{self, AnyStr},
     atomic_func,
     bytes_inner::{
-        ByteInnerFindOptions, ByteInnerNewOptions, ByteInnerPaddingOptions, ByteInnerSplitOptions,
-        ByteInnerTranslateOptions, DecodeArgs, PyBytesInner, bytes_decode,
+        ByteInnerFindOptions, ByteInnerHexOptions, ByteInnerNewOptions, ByteInnerPaddingOptions,
+        ByteInnerSplitOptions, ByteInnerTranslateOptions, DecodeArgs, PyBytesInner, bytes_decode,
     },
     class::PyClassImpl,
     common::{hash::PyHash, lock::PyMutex},
@@ -318,10 +318,10 @@ impl PyBytes {
     #[pymethod]
     pub(crate) fn hex(
         &self,
-        sep: OptionalArg<Either<PyStrRef, PyBytesRef>>,
-        bytes_per_sep: OptionalArg<isize>,
+        options: ByteInnerHexOptions,
         vm: &VirtualMachine,
     ) -> PyResult<String> {
+        let ByteInnerHexOptions { sep, bytes_per_sep } = options;
         self.inner.hex(sep, bytes_per_sep, vm)
     }
 

--- a/crates/vm/src/builtins/memory.rs
+++ b/crates/vm/src/builtins/memory.rs
@@ -1,13 +1,13 @@
 use super::{
     PositionIterInternal, PyBytes, PyBytesRef, PyGenericAlias, PyInt, PyListRef, PySlice, PyStr,
-    PyStrRef, PyTuple, PyTupleRef, PyType, PyTypeRef, PyUtf8StrRef, iter::builtins_iter,
+    PyTuple, PyTupleRef, PyType, PyTypeRef, PyUtf8StrRef, iter::builtins_iter,
 };
 use crate::common::lock::LazyLock;
 use crate::{
     AsObject, Context, Py, PyObject, PyObjectRef, PyPayload, PyRef, PyResult,
     TryFromBorrowedObject, TryFromObject, VirtualMachine, atomic_func,
     buffer::FormatSpec,
-    bytes_inner::bytes_to_hex,
+    bytes_inner::{ByteInnerHexOptions, bytes_to_hex},
     class::PyClassImpl,
     common::{
         borrow::{BorrowedValue, BorrowedValueMut},
@@ -739,12 +739,8 @@ impl PyMemoryView {
     }
 
     #[pymethod]
-    fn hex(
-        &self,
-        sep: OptionalArg<Either<PyStrRef, PyBytesRef>>,
-        bytes_per_sep: OptionalArg<isize>,
-        vm: &VirtualMachine,
-    ) -> PyResult<String> {
+    fn hex(&self, options: ByteInnerHexOptions, vm: &VirtualMachine) -> PyResult<String> {
+        let ByteInnerHexOptions { sep, bytes_per_sep } = options;
         self.try_not_released(vm)?;
         self.contiguous_or_collect(|x| bytes_to_hex(x, sep, bytes_per_sep, vm))
     }

--- a/crates/vm/src/bytes_inner.rs
+++ b/crates/vm/src/bytes_inner.rs
@@ -1113,6 +1113,14 @@ pub(crate) fn bytes_decode(
         .decode_text(zelf, encoding, errors, vm)
 }
 
+#[derive(FromArgs)]
+pub(crate) struct ByteInnerHexOptions {
+    #[pyarg(any, optional)]
+    pub sep: OptionalArg<Either<PyStrRef, PyBytesRef>>,
+    #[pyarg(any, optional)]
+    pub bytes_per_sep: OptionalArg<isize>,
+}
+
 fn hex_impl_no_sep(bytes: &[u8]) -> String {
     let mut buf: Vec<u8> = vec![0; bytes.len() * 2];
     hex::encode_to_slice(bytes, buf.as_mut_slice()).unwrap();


### PR DESCRIPTION
- [x] This PR follows our [AI policy](https://github.com/RustPython/.github/blob/main/AI_POLICY.md)

## Summary

`bytes`/`bytearray`/`memoryview`'s `hex()` rejected its `sep` and `bytes_per_sep`
arguments when passed by keyword, even though CPython accepts them either
positionally or by keyword.

```python
b'\xb9\x01\xef'.hex(sep=':', bytes_per_sep=2)
# before: TypeError: Unexpected keyword argument sep
# after:  'b9:01ef'   # matches CPython
```

## Cause

`hex()` took its arguments as bare `OptionalArg<T>` method parameters, whose
`FromArgs` only consumes positionals (`take_positional()`) and never keywords.
The argument names were never registered, so `sep=` / `bytes_per_sep=` stayed in
`kwargs` and tripped `check_kwargs_empty`.

## Fix

Move the arguments into a `#[derive(FromArgs)]` struct (`ByteInnerHexOptions`)
with `#[pyarg(any, optional)]` fields, which generates `take_positional_keyword`
so both positional and keyword forms are accepted — matching CPython's
positional-or-keyword signature (no `/` or `*` in its Argument Clinic definition).
Applied consistently to `bytes`, `bytearray`, and `memoryview`; the computation
still delegates to the existing `inner.hex(...)`, so the error cases are preserved
(`None` → `TypeError`, separator `len != 1` → `ValueError`). Re-enables
`test_hex_separator_basics` by removing its `expectedFailure` marker.

## Test

Verified locally:

- `cargo run -- -m test test_bytes -v` → **`Tests result: SUCCESS`** (Ran 317 tests, `OK (skipped=15, expected failures=18)`)
  - `test_hex_separator_basics` (`BytesTest` / `ByteArrayTest`) ... **ok**
  - `test_hex_separator_five_bytes` / `test_hex_separator_six_bytes` / `test_hex` ... **ok**

Assisted-by: Claude Code:claude-opus-4-8


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Standardized hexadecimal formatting options across `bytes`, `bytearray`, and `memoryview`.
  * Consistent support for custom separators and configurable bytes-per-group formatting.
  * Existing `.hex()` behavior remains unchanged while argument handling is more consistent across these types.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->