### PR TITLE
csv: quote embedded CR/LF under QUOTE_MINIMAL

### DIFF
--- a/Lib/test/test_csv.py
+++ b/Lib/test/test_csv.py
@@ -276,7 +276,6 @@ class Test_Csv(unittest.TestCase):
                                      f'1,2{lineterminator}'
                                      f'"\r","\n"{lineterminator}')
 
-    @unittest.expectedFailure  # TODO: RUSTPYTHON
     def test_write_iterable(self):
         self._write_test(iter(['a', 1, 'p,q']), 'a,1,"p,q"')
         self._write_test(iter(['a', 1, None]), 'a,1,')
@@ -319,7 +318,6 @@ class Test_Csv(unittest.TestCase):
             self.assertEqual(fileobj.read(), 'a\r\n""\r\n')
 
 
-    @unittest.expectedFailure  # TODO: RUSTPYTHON
     def test_write_empty_fields(self):
         self._write_test((), '')
         self._write_test([''], '""')

--- a/crates/stdlib/src/csv.rs
+++ b/crates/stdlib/src/csv.rs
@@ -1380,6 +1380,55 @@ mod _csv {
             self.write.call((s,), vm)
         }
 
+        fn writerow_minimal(&self, row: PyObjectRef, vm: &VirtualMachine) -> PyResult {
+            let _state = self.state.lock();
+
+            let row: ArgIterable = ArgIterable::try_from_object(vm, row.clone()).map_err(|_e| {
+                new_csv_error(
+                    vm,
+                    format!("'{}' object is not iterable", row.class().name()),
+                )
+            })?;
+
+            let fields = row.iter(vm)?.collect::<PyResult<Vec<_>>>()?;
+            let single_field = fields.len() == 1;
+            let mut output = Vec::new();
+
+            for (index, field) in fields.into_iter().enumerate() {
+                if index > 0 {
+                    output.push(self.dialect.delimiter);
+                }
+
+                let stringified;
+                let data: &[u8] = match_class!(match field {
+                    ref s @ PyStr => s.as_bytes(),
+                    crate::builtins::PyNone => b"",
+                    ref obj => {
+                        stringified = obj.str(vm)?;
+                        stringified.as_bytes()
+                    }
+                });
+
+                // CPython quotes a QUOTE_MINIMAL field if it contains the
+                // delimiter, the quote character, '\r', '\n', or the line
+                // terminator, regardless of which line terminator is
+                // configured. A row with a single empty field is also quoted
+                // so that it is not read back as an empty line.
+                if field_needs_quotes(data, self.dialect) || (single_field && data.is_empty()) {
+                    write_quoted_field(&mut output, data, self.dialect, vm)?;
+                } else {
+                    output.extend_from_slice(data);
+                }
+            }
+
+            write_lineterminator(&mut output, self.dialect.lineterminator);
+
+            let s = core::str::from_utf8(&output)
+                .map_err(|_| vm.new_unicode_decode_error("csv not utf8"))?;
+
+            self.write.call((s,), vm)
+        }
+
         #[pymethod]
         fn writerow(&self, row: PyObjectRef, vm: &VirtualMachine) -> PyResult {
             match self.dialect.quoting {
@@ -1387,6 +1436,7 @@ mod _csv {
                 QuoteStyle::Strings | QuoteStyle::Notnull => {
                     return self.writerow_quoted_strings(row, vm);
                 }
+                QuoteStyle::Minimal => return self.writerow_minimal(row, vm),
                 _ => {}
             }
 

--- a/extra_tests/snippets/stdlib_csv.py
+++ b/extra_tests/snippets/stdlib_csv.py
@@ -147,3 +147,48 @@ def test_quote_none_reader_skipinitialspace_escapechar():
 
 
 test_quote_none_reader_skipinitialspace_escapechar()
+
+
+def test_quote_minimal_writer_lineterminator():
+    # https://github.com/RustPython/RustPython/issues/8302
+    # QUOTE_MINIMAL must quote '\r' and '\n' regardless of the line terminator.
+    buf = io.StringIO()
+    writer = csv.writer(buf, lineterminator="!")
+    writer.writerow(["a", "b"])
+    writer.writerow([1, 2])
+    writer.writerow(["\r", "\n"])
+    assert buf.getvalue() == 'a,b!1,2!"\r","\n"!'
+
+    nul = io.StringIO()
+    csv.writer(nul, lineterminator="\0").writerow(["\r", "\n"])
+    assert nul.getvalue() == '"\r","\n"\0'
+
+    crlf = io.StringIO()
+    csv.writer(crlf, lineterminator="!").writerow(["\r\n"])
+    assert crlf.getvalue() == '"\r\n"!'
+
+    # the terminator character itself still triggers quoting
+    term = io.StringIO()
+    csv.writer(term, lineterminator="!").writerow(["a!b", "c"])
+    assert term.getvalue() == '"a!b",c!'
+
+    # default terminator behavior is unchanged
+    default = io.StringIO()
+    csv.writer(default).writerow(["\r", "\n"])
+    assert default.getvalue() == '"\r","\n"\r\n'
+
+
+test_quote_minimal_writer_lineterminator()
+
+
+def test_quote_minimal_writer_empty_fields():
+    buf = io.StringIO()
+    writer = csv.writer(buf)
+    writer.writerow([""])
+    writer.writerow([None])
+    writer.writerow([])
+    writer.writerow(["", ""])
+    assert buf.getvalue() == '""\r\n""\r\n\r\n,\r\n'
+
+
+test_quote_minimal_writer_empty_fields()


### PR DESCRIPTION
- [x] Closes #8317 (re-created; #8302 was closed by accident)
- [x] This PR follows our [AI policy](https://github.com/RustPython/.github/blob/main/AI_POLICY.md)

## Summary

Under `QUOTE_MINIMAL`, a field containing `\r` or `\n` must be quoted regardless of the `lineterminator` — CPython quotes them unconditionally. RustPython serialized `QUOTE_MINIMAL` rows with `csv_core`, which decides quoting from the bytes it registered for the terminator, so with a terminator other than CR/LF (e.g. `'!'` or `'\0'`) embedded `\r`/`\n` were left unquoted.

`QUOTE_MINIMAL` now uses a hand-written path (like `QUOTE_NONE` / `QUOTE_STRINGS`) that decides quoting via the existing `field_needs_quotes`, which always treats `\r`/`\n` as needing quotes. `QUOTE_ALL` and `QUOTE_NONNUMERIC` still use `csv_core`.

This also fixes an empty row (`writerow([])`) emitting `""` instead of only the terminator.

```python
import csv, io
sio = io.StringIO()
csv.writer(sio, lineterminator="!").writerow(["\r", "\n"])
# before: '\r,\n!'
# after:  '"\r","\n"!'   (matches CPython)
```

Multi-character `lineterminator` (the `!@#` case in `test_write_lineterminator`) is still unsupported and left for a follow-up, so that test stays marked.

## Test plan

- Unmarks `test_write_iterable` and `test_write_empty_fields` (both `@unittest.expectedFailure` before). `cargo run --release -- -m test test_csv`: 128 run, 7 skipped, SUCCESS.
- `extra_tests/snippets/stdlib_csv.py`: passes (added writer cases for custom terminators and empty fields).
- `cargo fmt --check` / `cargo clippy`: clean (no new warnings).
- Compared against CPython 3.14.6 on the same machine; the `QUOTE_MINIMAL` writer outputs match.

Assisted-by: Claude Code:claude-opus-4-8

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed CSV writing with minimal quoting so fields are quoted only when required by delimiters, quotes, line breaks, or line terminators.
  * Correctly handles empty fields and single empty values when producing CSV output.
  * Ensured custom line terminators are serialized correctly.

* **Tests**
  * Added coverage for minimal-quoting behavior, line terminators, and empty fields.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->