### PR TITLE
wasm: add stderr support

### DIFF
--- a/crates/wasm/Lib/asyncweb.py
+++ b/crates/wasm/Lib/asyncweb.py
@@ -64,8 +64,7 @@ async def _main_wrapper(coro):
         import traceback
         import sys
 
-        # TODO: sys.stderr on wasm
-        traceback.print_exc(file=sys.stdout)
+        traceback.print_exc(file=sys.stderr)
 
 
 def _resolve(prom):

--- a/crates/wasm/README.md
+++ b/crates/wasm/README.md
@@ -34,6 +34,9 @@ pyEval(code, options?);
 - `stdout?`: `"console" | ((out: string) => void) | null`: A function to replace the
   native print function, and it will be `console.log` when giving `undefined`
   or "console", and it will be a dumb function when giving null.
+- `stderr?`: `"console" | ((out: string) => void) | null`: A function to replace
+  `sys.stderr`, and it will be `console.error` when giving `undefined` or
+  "console".
 
 ## License
 

--- a/crates/wasm/src/lib.rs
+++ b/crates/wasm/src/lib.rs
@@ -66,6 +66,7 @@ pub mod eval {
         };
 
         vm.set_stdout(Reflect::get(&options, &"stdout".into())?)?;
+        vm.set_stderr(Reflect::get(&options, &"stderr".into())?)?;
 
         if let Some(js_vars) = js_vars {
             vm.add_to_scope("js_vars".into(), js_vars.into())?;
@@ -93,6 +94,8 @@ pub mod eval {
     /// -   `stdout?`: `"console" | ((out: string) => void) | null`: A function to replace the
     ///     native print native print function, and it will be `console.log` when giving
     ///     `undefined` or "console", and it will be a dumb function when giving null.
+    /// -   `stderr?`: `"console" | ((out: string) => void) | null`: A function to replace
+    ///     `sys.stderr`, and it will be `console.error` when giving `undefined` or "console".
     #[wasm_bindgen(js_name = pyEval)]
     pub fn eval_py(source: &str, options: Option<Object>) -> Result<JsValue, JsValue> {
         run_py(source, options, Mode::Eval)

--- a/crates/wasm/src/vm_class.rs
+++ b/crates/wasm/src/vm_class.rs
@@ -249,31 +249,59 @@ impl WASMVirtualMachine {
 
     #[wasm_bindgen(js_name = setStdout)]
     pub fn set_stdout(&self, stdout: JsValue) -> Result<(), JsValue> {
+        self.set_stdstream(
+            "stdout",
+            "JSStdout",
+            stdout,
+            wasm_builtins::sys_stdout_write_console,
+        )
+    }
+
+    #[wasm_bindgen(js_name = setStderr)]
+    pub fn set_stderr(&self, stderr: JsValue) -> Result<(), JsValue> {
+        self.set_stdstream(
+            "stderr",
+            "JSStderr",
+            stderr,
+            wasm_builtins::sys_stderr_write_console,
+        )
+    }
+
+    fn set_stdstream(
+        &self,
+        attr: &'static str,
+        class_name: &'static str,
+        stream: JsValue,
+        console_write: fn(&str, &VirtualMachine) -> PyResult<()>,
+    ) -> Result<(), JsValue> {
         self.with_vm(|vm, _| {
-            fn error() -> JsValue {
-                TypeError::new("Unknown stdout option, please pass a function or 'console'").into()
+            fn error(attr: &str) -> JsValue {
+                TypeError::new(&format!(
+                    "Unknown {attr} option, please pass a function or 'console'"
+                ))
+                .into()
             }
-            use wasm_builtins::make_stdout_object;
-            let stdout: PyObjectRef = if let Some(s) = stdout.as_string() {
+            use wasm_builtins::make_stdstream_object;
+            let stream: PyObjectRef = if let Some(s) = stream.as_string() {
                 match s.as_str() {
-                    "console" => make_stdout_object(vm, wasm_builtins::sys_stdout_write_console),
-                    _ => return Err(error()),
+                    "console" => make_stdstream_object(vm, class_name, console_write),
+                    _ => return Err(error(attr)),
                 }
-            } else if stdout.is_function() {
-                let func = js_sys::Function::from(stdout);
-                make_stdout_object(vm, move |data, vm| {
+            } else if stream.is_function() {
+                let func = js_sys::Function::from(stream);
+                make_stdstream_object(vm, class_name, move |data, vm| {
                     func.call1(&JsValue::UNDEFINED, &data.into())
                         .map_err(|err| convert::js_py_typeerror(vm, err))?;
                     Ok(())
                 })
-            } else if stdout.is_null() {
-                make_stdout_object(vm, |_, _| Ok(()))
-            } else if stdout.is_undefined() {
-                make_stdout_object(vm, wasm_builtins::sys_stdout_write_console)
+            } else if stream.is_null() {
+                make_stdstream_object(vm, class_name, |_, _| Ok(()))
+            } else if stream.is_undefined() {
+                make_stdstream_object(vm, class_name, console_write)
             } else {
-                return Err(error());
+                return Err(error(attr));
             };
-            vm.sys_module.set_attr("stdout", stdout, vm).unwrap();
+            vm.sys_module.set_attr(attr, stream, vm).unwrap();
             Ok(())
         })?
     }

--- a/crates/wasm/src/wasm_builtins.rs
+++ b/crates/wasm/src/wasm_builtins.rs
@@ -16,19 +16,20 @@ pub fn sys_stdout_write_console(data: &str, _vm: &VirtualMachine) -> PyResult<()
     Ok(())
 }
 
-pub fn make_stdout_object(
+pub fn sys_stderr_write_console(data: &str, _vm: &VirtualMachine) -> PyResult<()> {
+    console::error_1(&data.into());
+    Ok(())
+}
+
+pub fn make_stdstream_object(
     vm: &VirtualMachine,
+    name: &'static str,
     write_f: impl Fn(&str, &VirtualMachine) -> PyResult<()> + 'static,
 ) -> PyObjectRef {
     let ctx = &vm.ctx;
     // there's not really any point to storing this class so that there's a consistent type object,
     // we just want a half-decent repr() output
-    let cls = PyRef::leak(py_class!(
-        ctx,
-        "JSStdout",
-        vm.ctx.types.object_type.to_owned(),
-        {}
-    ));
+    let cls = PyRef::leak(py_class!(ctx, name, vm.ctx.types.object_type.to_owned(), {}));
     let write_method = vm.new_method(
         "write",
         cls,

--- a/wasm/demo/src/index.js
+++ b/wasm/demo/src/index.js
@@ -159,6 +159,7 @@ function onReady() {
 
     terminalVM = rp.vmStore.init('term_vm');
     terminalVM.setStdout((data) => readline.print(data));
+    terminalVM.setStderr((data) => readline.print(data));
     readPrompts().catch((err) => console.error(err));
 
     // so that the test knows that we're ready

--- a/wasm/tests/test_exec_mode.py
+++ b/wasm/tests/test_exec_mode.py
@@ -19,3 +19,17 @@ def test_exec_single_mode(wdriver):
         """
     )
     assert stdout == "2\n4\n"
+
+
+def test_exec_stderr_option(wdriver):
+    stderr = wdriver.execute_script(
+        """
+        let output = "";
+        save_output = function(text) {
+            output += text
+        };
+        window.rp.pyExec('import sys; print("err", file=sys.stderr)', {stderr: save_output});
+        return output;
+        """
+    )
+    assert stderr == "err\n"


### PR DESCRIPTION
Assisted-by: Codex:gpt-5.5

<!--
Thanks for your contribution!
-->

- [ ] Closes #xxxx <!-- Replace xxxx with the GitHub issue number -->
- [x] This PR follows our [AI policy](https://github.com/RustPython/.github/blob/main/AI_POLICY.md)

## Summary by @jiwahn
<!-- What's the purpose of the change? What does it do, and why? -->


- Added stderr support for the WASM module, fixing this TODO [here](https://github.com/RustPython/RustPython/blob/main/crates/wasm/Lib/asyncweb.py#L67)
- Generalized the existing stdout implementation into a shared stdstream helper so stdout and stderr are handled through the same code path.

<img width="499" height="183" alt="Screenshot 2026-07-19 at 11 46 03" src="https://github.com/user-attachments/assets/98e91c39-cce7-43ee-a464-ce7c3503dee4" />




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **New Features**
  * Added support for configuring Python `stderr` in WebAssembly execution (console, custom callback, or disabled).
  * Demo terminal now forwards `stderr` to the on-screen terminal output.
* **Documentation**
  * Updated execution options to document the new `stderr` behavior and how it maps to `sys.stderr`.
* **Bug Fixes**
  * Exception tracebacks now display in the browser error console instead of standard output.
* **Tests**
  * Added a test to verify capturing `stderr` output via the `{stderr: ...}` option.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->