### PR TITLE
csv: reject reentrant reader advancement

### DIFF
--- a/Lib/test/test_csv.py
+++ b/Lib/test/test_csv.py
@@ -568,7 +568,6 @@ class Test_Csv(unittest.TestCase):
                         self.assertEqual(row, rows[i])
 
 
-    @unittest.expectedFailure  # TODO: RUSTPYTHON; AssertionError: Error not raised
     def test_reader_reentrant_iterator(self):
         # gh-145105: re-entering the reader from the iterator must not crash.
         class ReentrantIter:

--- a/crates/stdlib/src/csv.rs
+++ b/crates/stdlib/src/csv.rs
@@ -962,7 +962,7 @@ mod _csv {
         skipinitialspace: bool,
         delimiter: u8,
         line_num: u64,
-        generation: usize,
+        generation: u64,
     }
 
     #[pyclass(no_attr, module = "_csv", name = "reader", traverse)]

--- a/crates/stdlib/src/csv.rs
+++ b/crates/stdlib/src/csv.rs
@@ -1060,8 +1060,17 @@ mod _csv {
     impl IterNext for Reader {
         fn next(zelf: &Py<Self>, vm: &VirtualMachine) -> PyResult<PyIterReturn> {
             let generation = zelf.state.lock().generation;
-            let string = raise_if_stop!(zelf.iter.next(vm)?);
-            let string = string.downcast::<PyStr>().map_err(|obj| {
+            let string_obj = raise_if_stop!(zelf.iter.next(vm)?);
+            let mut state = zelf.state.lock();
+            if state.generation != generation {
+                return Err(new_csv_error(
+                    vm,
+                    "iterator has already advanced the reader",
+                ));
+            }
+            state.generation += 1;
+
+            let string = string_obj.downcast::<PyStr>().map_err(|obj| {
                 new_csv_error(
                     vm,
                     format!(
@@ -1071,15 +1080,7 @@ mod _csv {
                 )
             })?;
             let input = string.as_bytes();
-            let mut state = zelf.state.lock();
-            if state.generation != generation {
-                return Err(new_csv_error(
-                    vm,
-                    "iterator has already advanced the reader",
-                ));
-            }
             if input.is_empty() || input.starts_with(b"\n") {
-                state.generation += 1;
                 return Ok(PyIterReturn::Return(vm.ctx.new_list(vec![]).into()));
             }
             let ReadState {
@@ -1089,7 +1090,7 @@ mod _csv {
                 skipinitialspace,
                 delimiter,
                 line_num,
-                generation,
+                generation: _,
             } = &mut *state;
 
             let mut input_offset = 0;
@@ -1100,7 +1101,6 @@ mod _csv {
             if zelf.dialect.quoting == QuoteStyle::None && zelf.dialect.escapechar.is_some() {
                 let out = read_quote_none_record(input, zelf.dialect, field_limit, vm)?;
                 *line_num += 1;
-                *generation += 1;
                 return Ok(PyIterReturn::Return(vm.ctx.new_list(out).into()));
             }
 
@@ -1188,7 +1188,6 @@ mod _csv {
             //     out.pop();
             // }
             *line_num += 1;
-            *generation += 1;
             Ok(PyIterReturn::Return(vm.ctx.new_list(out).into()))
         }
     }

--- a/crates/stdlib/src/csv.rs
+++ b/crates/stdlib/src/csv.rs
@@ -411,6 +411,7 @@ mod _csv {
                 skipinitialspace: options.get_skipinitialspace(),
                 delimiter: options.get_delimiter(),
                 line_num: 0,
+                generation: 0,
             }),
             dialect: options.result(vm)?,
         })
@@ -961,6 +962,7 @@ mod _csv {
         skipinitialspace: bool,
         delimiter: u8,
         line_num: u64,
+        generation: usize,
     }
 
     #[pyclass(no_attr, module = "_csv", name = "reader", traverse)]
@@ -1057,6 +1059,7 @@ mod _csv {
 
     impl IterNext for Reader {
         fn next(zelf: &Py<Self>, vm: &VirtualMachine) -> PyResult<PyIterReturn> {
+            let generation = zelf.state.lock().generation;
             let string = raise_if_stop!(zelf.iter.next(vm)?);
             let string = string.downcast::<PyStr>().map_err(|obj| {
                 new_csv_error(
@@ -1068,10 +1071,17 @@ mod _csv {
                 )
             })?;
             let input = string.as_bytes();
+            let mut state = zelf.state.lock();
+            if state.generation != generation {
+                return Err(new_csv_error(
+                    vm,
+                    "iterator has already advanced the reader",
+                ));
+            }
             if input.is_empty() || input.starts_with(b"\n") {
+                state.generation += 1;
                 return Ok(PyIterReturn::Return(vm.ctx.new_list(vec![]).into()));
             }
-            let mut state = zelf.state.lock();
             let ReadState {
                 buffer,
                 output_ends,
@@ -1079,6 +1089,7 @@ mod _csv {
                 skipinitialspace,
                 delimiter,
                 line_num,
+                generation,
             } = &mut *state;
 
             let mut input_offset = 0;
@@ -1089,6 +1100,7 @@ mod _csv {
             if zelf.dialect.quoting == QuoteStyle::None && zelf.dialect.escapechar.is_some() {
                 let out = read_quote_none_record(input, zelf.dialect, field_limit, vm)?;
                 *line_num += 1;
+                *generation += 1;
                 return Ok(PyIterReturn::Return(vm.ctx.new_list(out).into()));
             }
 
@@ -1176,6 +1188,7 @@ mod _csv {
             //     out.pop();
             // }
             *line_num += 1;
+            *generation += 1;
             Ok(PyIterReturn::Return(vm.ctx.new_list(out).into()))
         }
     }


### PR DESCRIPTION
- [x] Closes #8323
- [x] This PR follows our [AI policy](https://github.com/RustPython/.github/blob/main/AI_POLICY.md)

## Summary

RustPython's CSV reader allowed an outer `next()` call to continue parsing after
its input iterator re-entered and advanced the same reader. CPython raises
`csv.Error` in this situation to avoid continuing with stale reader state (see
[CPython gh-145105](https://github.com/python/cpython/issues/145105)).

Track the reader generation and compare the generation before and after
calling the input iterator. If a reentrant call advanced the reader, raise
`csv.Error("iterator has already advanced the reader")`, matching CPython's
handling of this regression.

```python
import csv


class ReentrantIterator:
    def __init__(self):
        self.reader = None
        self.index = 0

    def __iter__(self):
        return self

    def __next__(self):
        self.index += 1
        if self.index == 1:
            next(self.reader)
            return "a,b"
        if self.index == 2:
            return "x"
        raise StopIteration


iterator = ReentrantIterator()
reader = csv.reader(iterator)
iterator.reader = reader
print(next(reader))

# before: ['a', 'b']
# after:  csv.Error: iterator has already advanced the reader
```

The existing CPython regression test now passes without its
`expectedFailure` marker.

## Test plan

The following validation was completed by the author:

- Unmarks `Test_Csv.test_reader_reentrant_iterator`.
- `cargo run --release Lib/test/test_csv.py`: 128 tests run, 7 skipped,
  18 expected failures, SUCCESS.
- `cargo run -- extra_tests/snippets/stdlib_csv.py`: passed.
- `cargo fmt --check`: passed.
- `cargo clippy -p rustpython-stdlib --all-targets`: passed with unrelated
  `unfulfilled_lint_expectations` warnings.
- The configured workspace test suite passed.
- Compared the reproducer against CPython 3.14.6.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved CSV reader reliability by detecting attempts to reuse an already-advanced iterator, preventing incorrect reads.
  * Added a clear error when the CSV reader is advanced unexpectedly during iteration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->