### PR TITLE
Take a borrow in invoke_exception instead of an owned type

### DIFF
--- a/crates/capi/src/pyerrors.rs
+++ b/crates/capi/src/pyerrors.rs
@@ -147,10 +147,7 @@ pub unsafe extern "C" fn PyErr_SetString(exception: *mut PyObject, message: *con
         let exc_type = unsafe { &*exception }.try_downcast_ref::<PyType>(vm)?;
         let message = unsafe { message.try_as_str(vm) }?;
 
-        let exc = vm.invoke_exception(
-            exc_type.to_owned(),
-            vec![vm.ctx.new_str(message).into_object()],
-        )?;
+        let exc = vm.invoke_exception(exc_type, vec![vm.ctx.new_str(message).into_object()])?;
 
         Err(exc)
     })

--- a/crates/vm/src/exception_group.rs
+++ b/crates/vm/src/exception_group.rs
@@ -71,11 +71,8 @@ pub(super) mod types {
             vm: &VirtualMachine,
         ) -> PyResult {
             let message = zelf.get_arg(0).unwrap_or_else(|| vm.ctx.new_str("").into());
-            vm.invoke_exception(
-                vm.ctx.exceptions.base_exception_group.to_owned(),
-                vec![message, excs],
-            )
-            .map(|e| e.into())
+            vm.invoke_exception(vm.ctx.exceptions.base_exception_group, vec![message, excs])
+                .map(|e| e.into())
         }
 
         #[pymethod]

--- a/crates/vm/src/exceptions.rs
+++ b/crates/vm/src/exceptions.rs
@@ -353,11 +353,11 @@ impl VirtualMachine {
 
     pub fn invoke_exception(
         &self,
-        cls: PyTypeRef,
+        cls: &Py<PyType>,
         args: Vec<PyObjectRef>,
     ) -> PyResult<PyBaseExceptionRef> {
         // TODO: fast-path built-in exceptions by directly instantiating them? Is that really worth it?
-        let res = PyType::call(&cls, args.into_args(self), self)?;
+        let res = PyType::call(cls, args.into_args(self), self)?;
         res.downcast::<PyBaseException>().map_err(|obj| {
             self.new_type_error(format!(
                 "calling {} should have returned an instance of BaseException, not {}",
@@ -444,7 +444,7 @@ impl TryFromObject for ExceptionCtor {
 impl ExceptionCtor {
     pub fn instantiate(self, vm: &VirtualMachine) -> PyResult<PyBaseExceptionRef> {
         match self {
-            Self::Class(cls) => vm.invoke_exception(cls, vec![]),
+            Self::Class(cls) => vm.invoke_exception(&cls, vec![]),
             Self::Instance(exc) => Ok(exc),
         }
     }
@@ -472,7 +472,7 @@ impl ExceptionCtor {
                     exc @ PyBaseException => exc.args().to_vec(),
                     obj => vec![obj],
                 });
-                vm.invoke_exception(cls, args)
+                vm.invoke_exception(&cls, args)
             }
         }
     }
@@ -2101,7 +2101,7 @@ pub(super) mod types {
                         .downcast_ref::<PyInt>()
                         .and_then(|errno| errno.try_to_primitive::<i32>(vm).ok())
                         .and_then(|errno| super::errno_to_exc_type(errno, vm))
-                        .and_then(|typ| vm.invoke_exception(typ.to_owned(), args_vec).ok())
+                        .and_then(|typ| vm.invoke_exception(typ, args_vec).ok())
                     {
                         return error.to_pyresult(vm);
                     }

--- a/crates/vm/src/stdlib/_ctypes/function.rs
+++ b/crates/vm/src/stdlib/_ctypes/function.rs
@@ -1361,7 +1361,7 @@ fn check_hresult(hresult: i32, zelf: &Py<PyCFuncPtr>, vm: &VirtualMachine) -> Py
             .new_str(format!("HRESULT: 0x{:08X}", hresult as u32))
             .into();
         let details: PyObjectRef = vm.ctx.none();
-        let exc = vm.invoke_exception(com_error_type, vec![text.clone(), details.clone()])?;
+        let exc = vm.invoke_exception(&com_error_type, vec![text.clone(), details.clone()])?;
         let _ = exc.as_object().set_attr("hresult", hresult_obj, vm);
         let _ = exc.as_object().set_attr("text", text, vm);
         let _ = exc.as_object().set_attr("details", details, vm);

--- a/crates/vm/src/stdlib/_io.rs
+++ b/crates/vm/src/stdlib/_io.rs
@@ -943,7 +943,7 @@ mod _io {
                     None => {
                         // BlockingIOError(errno, msg, characters_written=0)
                         return Err(vm.invoke_exception(
-                            vm.ctx.exceptions.blocking_io_error.to_owned(),
+                            vm.ctx.exceptions.blocking_io_error,
                             vec![
                                 vm.new_pyobj(EAGAIN),
                                 vm.new_pyobj("write could not complete without blocking"),
@@ -1154,7 +1154,7 @@ mod _io {
                     self.write_end += avail as Offset;
                     self.pos += avail as Offset;
                     return Err(vm.invoke_exception(
-                        vm.ctx.exceptions.blocking_io_error.to_owned(),
+                        vm.ctx.exceptions.blocking_io_error,
                         vec![
                             vm.new_pyobj(EAGAIN),
                             vm.new_pyobj("write could not complete without blocking"),
@@ -1200,7 +1200,7 @@ mod _io {
                         // BlockingIOError(errno, msg, characters_written)
                         let chars_written = written + buffer_len;
                         return Err(vm.invoke_exception(
-                            vm.ctx.exceptions.blocking_io_error.to_owned(),
+                            vm.ctx.exceptions.blocking_io_error,
                             vec![
                                 vm.new_pyobj(EAGAIN),
                                 vm.new_pyobj("write could not complete without blocking"),

--- a/crates/vm/src/stdlib/_thread.rs
+++ b/crates/vm/src/stdlib/_thread.rs
@@ -623,7 +623,7 @@ pub(crate) mod _thread {
 
     #[pyfunction]
     fn exit(vm: &VirtualMachine) -> PyResult {
-        Err(vm.invoke_exception(vm.ctx.exceptions.system_exit.to_owned(), vec![])?)
+        Err(vm.invoke_exception(vm.ctx.exceptions.system_exit, vec![])?)
     }
 
     thread_local!(static SENTINELS: RefCell<Vec<PyRef<Lock>>> = const { RefCell::new(Vec::new()) });

--- a/crates/vm/src/stdlib/builtins.rs
+++ b/crates/vm/src/stdlib/builtins.rs
@@ -1041,7 +1041,7 @@ mod builtins {
     #[pyfunction]
     pub(super) fn exit(exit_code_arg: OptionalArg<PyObjectRef>, vm: &VirtualMachine) -> PyResult {
         let code = exit_code_arg.unwrap_or_else(|| vm.ctx.new_int(0).into());
-        Err(vm.invoke_exception(vm.ctx.exceptions.system_exit.to_owned(), vec![code])?)
+        Err(vm.invoke_exception(vm.ctx.exceptions.system_exit, vec![code])?)
     }
 
     #[derive(Debug, Default, FromArgs)]

--- a/crates/vm/src/stdlib/sys.rs
+++ b/crates/vm/src/stdlib/sys.rs
@@ -776,7 +776,7 @@ pub mod sys {
         } else {
             vec![status]
         };
-        let exc = vm.invoke_exception(vm.ctx.exceptions.system_exit.to_owned(), args)?;
+        let exc = vm.invoke_exception(vm.ctx.exceptions.system_exit, args)?;
         Err(exc)
     }
 

--- a/crates/vm/src/vm/mod.rs
+++ b/crates/vm/src/vm/mod.rs
@@ -2161,7 +2161,7 @@ impl VirtualMachine {
         if self.state.finalizing.load(Ordering::Acquire) && !self.is_main_thread() {
             // once finalization starts,
             // non-main Python threads should stop running bytecode.
-            return Err(self.invoke_exception(self.ctx.exceptions.system_exit.to_owned(), vec![])?);
+            return Err(self.invoke_exception(self.ctx.exceptions.system_exit, vec![])?);
         }
 
         // Suspend this thread if stop-the-world is in progress

--- a/crates/vm/src/vm/vm_new.rs
+++ b/crates/vm/src/vm/vm_new.rs
@@ -894,7 +894,7 @@ impl VirtualMachine {
     }
 
     pub fn new_stop_iteration(&self, value: Option<PyObjectRef>) -> PyBaseExceptionRef {
-        let stop_iteration_error = self.ctx.exceptions.stop_iteration.to_owned();
+        let stop_iteration_error = self.ctx.exceptions.stop_iteration;
         let args = if let Some(value) = value {
             vec![value]
         } else {


### PR DESCRIPTION
- [x] Closes #8320
- [x] This PR follows our [AI policy](https://github.com/RustPython/.github/blob/main/AI_POLICY.md)

## Summary

`VirtualMachine::invoke_exception` took its class argument as an owned `PyTypeRef`, but it never takes ownership — it only borrows `cls` for `PyType::call` (which itself is defined as `fn call(zelf: &Py<Self>, ...)`) and for `Display` in the error message. `cls` is never moved or stored.

Because the signature demanded ownership, callers holding only a borrow had to `.to_owned()` — an atomic refcount bump and later decrement — purely to satisfy the type, even though the reference was dropped immediately after the call. This changes the parameter to `&Py<PyType>`, the exact borrowed form (`PyTypeRef` = `PyRef<PyType>` derefs to `Py<PyType>`), and drops those `.to_owned()` calls.

Call sites updated:

| file | before |
|---|---|
| `stdlib/_io.rs` (3×) | `vm.ctx.exceptions.blocking_io_error.to_owned()` |
| `stdlib/sys.rs` | `vm.ctx.exceptions.system_exit.to_owned()` |
| `stdlib/builtins.rs` | `vm.ctx.exceptions.system_exit.to_owned()` |
| `stdlib/_thread.rs` | `vm.ctx.exceptions.system_exit.to_owned()` |
| `vm/mod.rs` | `vm.ctx.exceptions.system_exit.to_owned()` |
| `vm/vm_new.rs` | `vm.ctx.exceptions.stop_iteration.to_owned()` |
| `exception_group.rs` | `vm.ctx.exceptions.base_exception_group.to_owned()` |
| `exceptions.rs` | `typ.to_owned()` |
| `capi/pyerrors.rs` | `exc_type.to_owned()` |

`ExceptionCtor::instantiate` / `instantiate_value` own their `cls` via the `self` match, so they just pass `&cls` — no clone either way.

No behavior change; this is an API/ergonomics cleanup that removes unnecessary refcount churn and makes the helper consistent with the `PyType::call` it wraps.

## Test plan

- `test_exceptions`, `test_sys`, `test_io` (667 tests, covering the `BlockingIOError` sites), `extra_tests/snippets/builtin_exceptions.py`: no regressions (the single `test_exceptions` failure, `test_badisinstance`, is pre-existing on `main`).
- Exercised each touched path manually: `sys.exit` / `exit()` / `_thread.exit`, `raise ValueError` and `raise ValueError(...)` via `ExceptionCtor`, `ExceptionGroup`, generator `StopIteration`, `OSError` from a failed `open`, and the genuine `Err` path of `invoke_exception` (a `BaseException` subclass whose `__new__` returns a non-exception).
- `cargo fmt --check` / `cargo clippy`: clean.

Assisted-by: Claude Code:claude-fable-5

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Streamlined internal exception creation across the runtime by avoiding unnecessary exception-type copies.
  * Preserved existing behavior for `SystemExit`, `BlockingIOError`, `StopIteration`, COM errors, and other exception paths.
  * Improved exception handling efficiency without changing public functionality or error messages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->