### PR TITLE
Fix building against new libc

### DIFF
--- a/crates/host_env/src/posix.rs
+++ b/crates/host_env/src/posix.rs
@@ -1424,8 +1424,9 @@ fn build_posix_spawn_attrs(
             target_os = "hurd",
         ))]
         {
+            #[allow(clippy::useless_conversion)]
             flags.insert(nix::spawn::PosixSpawnFlags::from_bits_retain(
-                libc::POSIX_SPAWN_SETSID,
+                libc::POSIX_SPAWN_SETSID.into(),
             ));
         }
         #[cfg(not(any(


### PR DESCRIPTION
<!--
Thanks for your contribution!
-->

- [x] Closes #xxxx <!-- Replace xxxx with the GitHub issue number -->
- [x] This PR follows our [AI policy](https://github.com/RustPython/.github/blob/main/AI_POLICY.md)

## Summary
<!-- What's the purpose of the change? What does it do, and why? -->

The Ubuntu build is failing in CI due to a libc change. Check my previous PR to see the build failure.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved compatibility when configuring POSIX process-spawn attributes on supported systems.
  * Ensures the correct session-related behavior is applied during new process creation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->