### PR TITLE
Store SyntaxError members in struct fields instead of the instance dict

### DIFF
--- a/Lib/test/test_exceptions.py
+++ b/Lib/test/test_exceptions.py
@@ -2527,7 +2527,6 @@ class SyntaxErrorTests(unittest.TestCase):
         args = ("bad.py", 1, 2, "abcdefg", 1)
         self.assertRaises(TypeError, SyntaxError, "bad bad", args)
 
-    @unittest.expectedFailure  # TODO: RUSTPYTHON; AssertionError: 2 is not None
     def test_syntax_error_memory_leak(self):
         # gh-146250: memory leak with re-initialization of SyntaxError
         e = SyntaxError("msg", ("file.py", 1, 2, "txt", 2, 3))

--- a/crates/vm/src/exceptions.rs
+++ b/crates/vm/src/exceptions.rs
@@ -2762,6 +2762,8 @@ pub(super) mod types {
         type Args = FuncArgs;
 
         fn py_new(_cls: &Py<PyType>, args: FuncArgs, vm: &VirtualMachine) -> PyResult<Self> {
+            // msg must also be set here, not only in slot_init: second-level
+            // subclasses such as TabError never reach PySyntaxError::slot_init.
             let msg = args.args.first().cloned();
             let base_exception = PyBaseException::new(args.args, vm);
             Ok(Self {

--- a/crates/vm/src/exceptions.rs
+++ b/crates/vm/src/exceptions.rs
@@ -2783,14 +2783,7 @@ pub(super) mod types {
 
         fn slot_init(zelf: PyObjectRef, args: FuncArgs, vm: &VirtualMachine) -> PyResult<()> {
             let msg = args.args.first().cloned();
-            let location_tuple = if args.args.len() == 2 {
-                args.args[1]
-                    .clone()
-                    .downcast::<crate::builtins::PyTuple>()
-                    .ok()
-            } else {
-                None
-            };
+            let location_arg = (args.args.len() == 2).then(|| args.args[1].clone());
 
             PyBaseException::slot_init(zelf.clone(), args, vm)?;
             let exc: &Py<Self> = zelf.downcast_ref::<Self>().unwrap();
@@ -2800,19 +2793,21 @@ pub(super) mod types {
             }
 
             // SyntaxError(msg, (filename, lineno, offset, text[, end_lineno, end_offset]))
-            if let Some(location_tuple) = location_tuple {
-                let location_tup_len = location_tuple.len();
+            // The location argument is coerced from any sequence like CPython's
+            // PySequence_Tuple; a non-sequence raises TypeError.
+            if let Some(location_arg) = location_arg {
+                let location: Vec<PyObjectRef> = location_arg.try_to_value(vm)?;
 
-                match location_tup_len {
+                match location.len() {
                     4 | 6 => {}
                     5 => {
                         return Err(vm.new_type_error(
                             "end_offset must be provided when end_lineno is provided",
                         ));
                     }
-                    _ => {
+                    len => {
                         return Err(vm.new_type_error(format!(
-                            "function takes exactly 4 or 6 arguments ({location_tup_len} given)"
+                            "function takes exactly 4 or 6 arguments ({len} given)"
                         )));
                     }
                 }
@@ -2821,18 +2816,18 @@ pub(super) mod types {
                 exc.end_offset.swap_to_temporary_refs(None, vm);
 
                 exc.filename
-                    .swap_to_temporary_refs(Some(location_tuple[0].to_owned()), vm);
+                    .swap_to_temporary_refs(Some(location[0].clone()), vm);
                 exc.lineno
-                    .swap_to_temporary_refs(Some(location_tuple[1].to_owned()), vm);
+                    .swap_to_temporary_refs(Some(location[1].clone()), vm);
                 exc.offset
-                    .swap_to_temporary_refs(Some(location_tuple[2].to_owned()), vm);
+                    .swap_to_temporary_refs(Some(location[2].clone()), vm);
                 exc.text
-                    .swap_to_temporary_refs(Some(location_tuple[3].to_owned()), vm);
-                if location_tup_len == 6 {
+                    .swap_to_temporary_refs(Some(location[3].clone()), vm);
+                if location.len() == 6 {
                     exc.end_lineno
-                        .swap_to_temporary_refs(Some(location_tuple[4].to_owned()), vm);
+                        .swap_to_temporary_refs(Some(location[4].clone()), vm);
                     exc.end_offset
-                        .swap_to_temporary_refs(Some(location_tuple[5].to_owned()), vm);
+                        .swap_to_temporary_refs(Some(location[5].clone()), vm);
                 }
             }
 

--- a/crates/vm/src/exceptions.rs
+++ b/crates/vm/src/exceptions.rs
@@ -9,7 +9,7 @@ use crate::{
     },
     class::{PyClassImpl, StaticType},
     convert::{IntoPyException, ToPyException, ToPyObject},
-    function::{ArgIterable, FuncArgs, IntoFuncArgs, PySetterValue},
+    function::{ArgIterable, FuncArgs, IntoFuncArgs},
     py_io::{self, Write},
     stdlib::sys,
     suggestion::offer_suggestions,
@@ -1029,21 +1029,7 @@ impl ExceptionZoo {
             excs.python_finalization_error
         );
 
-        extend_exception!(PySyntaxError, ctx, excs.syntax_error, {
-            "msg" => ctx.new_static_getset(
-                "msg",
-                excs.syntax_error,
-                make_arg_getter(0),
-                syntax_error_set_msg,
-            ),
-            // TODO: members
-            "filename" => ctx.none(),
-            "lineno" => ctx.none(),
-            "end_lineno" => ctx.none(),
-            "offset" => ctx.none(),
-            "end_offset" => ctx.none(),
-            "text" => ctx.none(),
-        });
+        extend_exception!(PySyntaxError, ctx, excs.syntax_error);
         extend_exception!(PyIncompleteInputError, ctx, excs.incomplete_input_error);
         extend_exception!(PyIndentationError, ctx, excs.indentation_error);
         extend_exception!(PyTabError, ctx, excs.tab_error);
@@ -1080,20 +1066,6 @@ impl ExceptionZoo {
 
 fn make_arg_getter(idx: usize) -> impl Fn(PyBaseExceptionRef) -> Option<PyObjectRef> {
     move |exc| exc.get_arg(idx)
-}
-
-fn syntax_error_set_msg(exc: PyBaseExceptionRef, value: PySetterValue, vm: &VirtualMachine) {
-    let mut args = exc.args.write();
-    let mut new_args = args.as_slice().to_vec();
-    // Ensure the message slot at index 0 always exists for SyntaxError.args.
-    if new_args.is_empty() {
-        new_args.push(vm.ctx.none());
-    }
-    match value {
-        PySetterValue::Assign(value) => new_args[0] = value,
-        PySetterValue::Delete => new_args[0] = vm.ctx.none(),
-    }
-    *args = PyTuple::new_ref(new_args, &vm.ctx);
 }
 
 #[cfg(feature = "serde")]
@@ -2551,12 +2523,64 @@ pub(super) mod types {
     #[repr(transparent)]
     pub struct PyPythonFinalizationError(PyRuntimeError);
 
-    #[pyexception(name, base = PyException, ctx = "syntax_error")]
-    #[derive(Debug)]
-    #[repr(transparent)]
-    pub struct PySyntaxError(PyException);
+    #[pyexception(name, base = PyException, ctx = "syntax_error", traverse = "manual")]
+    #[repr(C)]
+    pub struct PySyntaxError {
+        base: PyException,
+        msg: PyAtomicRef<Option<PyObject>>,
+        filename: PyAtomicRef<Option<PyObject>>,
+        lineno: PyAtomicRef<Option<PyObject>>,
+        offset: PyAtomicRef<Option<PyObject>>,
+        text: PyAtomicRef<Option<PyObject>>,
+        end_lineno: PyAtomicRef<Option<PyObject>>,
+        end_offset: PyAtomicRef<Option<PyObject>>,
+        print_file_and_line: PyAtomicRef<Option<PyObject>>,
+    }
 
-    #[pyexception(with(Initializer))]
+    impl crate::class::PySubclass for PySyntaxError {
+        type Base = PyException;
+        fn as_base(&self) -> &Self::Base {
+            &self.base
+        }
+    }
+
+    impl core::fmt::Debug for PySyntaxError {
+        fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+            f.debug_struct("PySyntaxError").finish_non_exhaustive()
+        }
+    }
+
+    unsafe impl Traverse for PySyntaxError {
+        fn traverse(&self, tracer_fn: &mut TraverseFn<'_>) {
+            self.base.0.traverse(tracer_fn);
+            if let Some(obj) = self.msg.deref() {
+                tracer_fn(obj);
+            }
+            if let Some(obj) = self.filename.deref() {
+                tracer_fn(obj);
+            }
+            if let Some(obj) = self.lineno.deref() {
+                tracer_fn(obj);
+            }
+            if let Some(obj) = self.offset.deref() {
+                tracer_fn(obj);
+            }
+            if let Some(obj) = self.text.deref() {
+                tracer_fn(obj);
+            }
+            if let Some(obj) = self.end_lineno.deref() {
+                tracer_fn(obj);
+            }
+            if let Some(obj) = self.end_offset.deref() {
+                tracer_fn(obj);
+            }
+            if let Some(obj) = self.print_file_and_line.deref() {
+                tracer_fn(obj);
+            }
+        }
+    }
+
+    #[pyexception(with(Constructor, Initializer))]
     impl PySyntaxError {
         #[pymethod]
         fn __str__(zelf: &Py<PyBaseException>, vm: &VirtualMachine) -> PyStrRef {
@@ -2620,22 +2644,163 @@ pub(super) mod types {
 
             vm.ctx.new_str(msg_with_location_info)
         }
+
+        #[pygetset]
+        fn msg(&self) -> Option<PyObjectRef> {
+            self.msg.to_owned()
+        }
+
+        #[pygetset(setter)]
+        fn set_msg(&self, value: PySetterValue, vm: &VirtualMachine) {
+            let value = match value {
+                PySetterValue::Assign(v) => Some(v),
+                PySetterValue::Delete => None,
+            };
+            self.msg.swap_to_temporary_refs(value, vm);
+        }
+
+        #[pygetset]
+        fn filename(&self) -> Option<PyObjectRef> {
+            self.filename.to_owned()
+        }
+
+        #[pygetset(setter)]
+        fn set_filename(&self, value: PySetterValue, vm: &VirtualMachine) {
+            let value = match value {
+                PySetterValue::Assign(v) => Some(v),
+                PySetterValue::Delete => None,
+            };
+            self.filename.swap_to_temporary_refs(value, vm);
+        }
+
+        #[pygetset]
+        fn lineno(&self) -> Option<PyObjectRef> {
+            self.lineno.to_owned()
+        }
+
+        #[pygetset(setter)]
+        fn set_lineno(&self, value: PySetterValue, vm: &VirtualMachine) {
+            let value = match value {
+                PySetterValue::Assign(v) => Some(v),
+                PySetterValue::Delete => None,
+            };
+            self.lineno.swap_to_temporary_refs(value, vm);
+        }
+
+        #[pygetset]
+        fn offset(&self) -> Option<PyObjectRef> {
+            self.offset.to_owned()
+        }
+
+        #[pygetset(setter)]
+        fn set_offset(&self, value: PySetterValue, vm: &VirtualMachine) {
+            let value = match value {
+                PySetterValue::Assign(v) => Some(v),
+                PySetterValue::Delete => None,
+            };
+            self.offset.swap_to_temporary_refs(value, vm);
+        }
+
+        #[pygetset]
+        fn text(&self) -> Option<PyObjectRef> {
+            self.text.to_owned()
+        }
+
+        #[pygetset(setter)]
+        fn set_text(&self, value: PySetterValue, vm: &VirtualMachine) {
+            let value = match value {
+                PySetterValue::Assign(v) => Some(v),
+                PySetterValue::Delete => None,
+            };
+            self.text.swap_to_temporary_refs(value, vm);
+        }
+
+        #[pygetset]
+        fn end_lineno(&self) -> Option<PyObjectRef> {
+            self.end_lineno.to_owned()
+        }
+
+        #[pygetset(setter)]
+        fn set_end_lineno(&self, value: PySetterValue, vm: &VirtualMachine) {
+            let value = match value {
+                PySetterValue::Assign(v) => Some(v),
+                PySetterValue::Delete => None,
+            };
+            self.end_lineno.swap_to_temporary_refs(value, vm);
+        }
+
+        #[pygetset]
+        fn end_offset(&self) -> Option<PyObjectRef> {
+            self.end_offset.to_owned()
+        }
+
+        #[pygetset(setter)]
+        fn set_end_offset(&self, value: PySetterValue, vm: &VirtualMachine) {
+            let value = match value {
+                PySetterValue::Assign(v) => Some(v),
+                PySetterValue::Delete => None,
+            };
+            self.end_offset.swap_to_temporary_refs(value, vm);
+        }
+
+        #[pygetset]
+        fn print_file_and_line(&self) -> Option<PyObjectRef> {
+            self.print_file_and_line.to_owned()
+        }
+
+        #[pygetset(setter)]
+        fn set_print_file_and_line(&self, value: PySetterValue, vm: &VirtualMachine) {
+            let value = match value {
+                PySetterValue::Assign(v) => Some(v),
+                PySetterValue::Delete => None,
+            };
+            self.print_file_and_line.swap_to_temporary_refs(value, vm);
+        }
+    }
+
+    impl Constructor for PySyntaxError {
+        type Args = FuncArgs;
+
+        fn py_new(_cls: &Py<PyType>, args: FuncArgs, vm: &VirtualMachine) -> PyResult<Self> {
+            let msg = args.args.first().cloned();
+            let base_exception = PyBaseException::new(args.args, vm);
+            Ok(Self {
+                base: PyException(base_exception),
+                msg: msg.into(),
+                filename: None.into(),
+                lineno: None.into(),
+                offset: None.into(),
+                text: None.into(),
+                end_lineno: None.into(),
+                end_offset: None.into(),
+                print_file_and_line: None.into(),
+            })
+        }
     }
 
     impl Initializer for PySyntaxError {
         type Args = FuncArgs;
 
         fn slot_init(zelf: PyObjectRef, args: FuncArgs, vm: &VirtualMachine) -> PyResult<()> {
-            let len = args.args.len();
-            let new_args = args;
-
-            zelf.set_attr("print_file_and_line", vm.ctx.none(), vm)?;
-
-            if len == 2
-                && let Ok(location_tuple) = new_args.args[1]
+            let msg = args.args.first().cloned();
+            let location_tuple = if args.args.len() == 2 {
+                args.args[1]
                     .clone()
                     .downcast::<crate::builtins::PyTuple>()
-            {
+                    .ok()
+            } else {
+                None
+            };
+
+            PyBaseException::slot_init(zelf.clone(), args, vm)?;
+            let exc: &Py<Self> = zelf.downcast_ref::<Self>().unwrap();
+
+            if let Some(msg) = msg {
+                exc.msg.swap_to_temporary_refs(Some(msg), vm);
+            }
+
+            // SyntaxError(msg, (filename, lineno, offset, text[, end_lineno, end_offset]))
+            if let Some(location_tuple) = location_tuple {
                 let location_tup_len = location_tuple.len();
 
                 match location_tup_len {
@@ -2652,26 +2817,26 @@ pub(super) mod types {
                     }
                 }
 
-                for (i, &attr) in [
-                    "filename",
-                    "lineno",
-                    "offset",
-                    "text",
-                    "end_lineno",
-                    "end_offset",
-                ]
-                .iter()
-                .enumerate()
-                {
-                    if location_tup_len > i {
-                        zelf.set_attr(attr, location_tuple[i].to_owned(), vm)?;
-                    } else {
-                        break;
-                    }
+                exc.end_lineno.swap_to_temporary_refs(None, vm);
+                exc.end_offset.swap_to_temporary_refs(None, vm);
+
+                exc.filename
+                    .swap_to_temporary_refs(Some(location_tuple[0].to_owned()), vm);
+                exc.lineno
+                    .swap_to_temporary_refs(Some(location_tuple[1].to_owned()), vm);
+                exc.offset
+                    .swap_to_temporary_refs(Some(location_tuple[2].to_owned()), vm);
+                exc.text
+                    .swap_to_temporary_refs(Some(location_tuple[3].to_owned()), vm);
+                if location_tup_len == 6 {
+                    exc.end_lineno
+                        .swap_to_temporary_refs(Some(location_tuple[4].to_owned()), vm);
+                    exc.end_offset
+                        .swap_to_temporary_refs(Some(location_tuple[5].to_owned()), vm);
                 }
             }
 
-            PyBaseException::slot_init(zelf, new_args, vm)
+            Ok(())
         }
 
         fn init(_zelf: PyRef<Self>, _args: Self::Args, _vm: &VirtualMachine) -> PyResult<()> {

--- a/crates/vm/src/vm/vm_new.rs
+++ b/crates/vm/src/vm/vm_new.rs
@@ -341,12 +341,11 @@ impl VirtualMachine {
     /// [`vm.invoke_exception()`][Self::invoke_exception] or
     /// [`exceptions::ExceptionCtor`][crate::exceptions::ExceptionCtor] instead.
     pub fn new_exception(&self, exc_type: PyTypeRef, args: Vec<PyObjectRef>) -> PyBaseExceptionRef {
-        debug_assert_eq!(
-            exc_type.slots.basicsize,
-            core::mem::size_of::<PyBaseException>(),
-            "vm.new_exception() is only for exception types without additional payload. The given type '{}' is not allowed. Use vm.new_os_subtype_error() for OSError subtypes.",
-            exc_type.name()
-        );
+        if exc_type.slots.basicsize != core::mem::size_of::<PyBaseException>() {
+            return self
+                .invoke_exception(&exc_type, args)
+                .expect("vm.new_exception() called with an invalid exception type");
+        }
 
         PyBaseException::new(args, self)
             .into_ref_with_type_lazy_dict(self, exc_type)

--- a/crates/vm/src/vm/vm_new.rs
+++ b/crates/vm/src/vm/vm_new.rs
@@ -342,9 +342,9 @@ impl VirtualMachine {
     /// [`exceptions::ExceptionCtor`][crate::exceptions::ExceptionCtor] instead.
     pub fn new_exception(&self, exc_type: PyTypeRef, args: Vec<PyObjectRef>) -> PyBaseExceptionRef {
         if exc_type.slots.basicsize != core::mem::size_of::<PyBaseException>() {
-            return self
-                .invoke_exception(&exc_type, args)
-                .expect("vm.new_exception() called with an invalid exception type");
+            // If constructing the exception raises (e.g. __init__ rejects the
+            // args), surface that exception instead of panicking.
+            return self.invoke_exception(&exc_type, args).unwrap_or_else(|e| e);
         }
 
         PyBaseException::new(args, self)


### PR DESCRIPTION
Part of #8345

- [x] This PR follows our [AI policy](https://github.com/RustPython/.github/blob/main/AI_POLICY.md)

## Summary

`SyntaxError`'s members were stored as `None` class-attribute placeholders plus per-instance `__dict__` entries, so `SyntaxError('m').__dict__` was non-empty (`{'print_file_and_line': None}`, plus `filename`/`lineno`/`offset`/`text` for the `(msg, tuple)` form) unlike CPython, and they weren't backed by descriptors. They're now struct fields on `PySyntaxError` (`#[repr(C)]` + `base` field, the same approach as `SystemExit` in #8282 and `StopIteration` in #8301), exposed via `#[pygetset]` — writable, deletable, independent from `args`, with an empty `__dict__` as in CPython. `IndentationError`, `TabError`, and `_IncompleteInputError` inherit the fields.

Re-initialization now resets `end_lineno`/`end_offset`, so a 4-element location tuple after a 6-element one no longer keeps stale values (matches CPython's gh-146250 fix):

```python
e = SyntaxError("msg", ("file.py", 1, 2, "txt", 2, 3))
e.__init__("new", ("new.py", 4, 5, "t"))
print(e.end_lineno, e.end_offset)
# before: 2 3    after: None None   (matches CPython)
```

`new_exception` is also routed through the real constructor for exception types that carry additional payload (now including `SyntaxError`), instead of building a base-sized `PyBaseException`. Without this, the compile-error path (`new_exception_msg(syntax_error, …)`, ~15 call sites) would allocate a wrong-sized payload — a debug-assert panic, and out-of-bounds reads in release.

## Test plan

Verified against CPython 3.14.6: `msg`/`filename`/`lineno`/`offset`/`text`/`end_lineno`/`end_offset` for `SyntaxError()`, the 4-tuple, and the 6-tuple forms; write/delete; re-init reset; empty `__dict__`; `IndentationError`/`TabError` inheritance; and the compile-error path (`compile("1 +", ...)` renders the caret and sets `lineno`/`msg`).

- `test_exceptions`: no regressions — `test_syntax_error_memory_leak` now passes; the single `test_badisinstance` failure is pre-existing on `main` (an unrelated empty-message `RecursionError`).
- `test_syntax` / `test_compile`: pass.
- `cargo fmt` / `cargo clippy`: clean (no new warnings).
- Unmarks `test_exceptions`'s `test_syntax_error_memory_leak` (removes its `@expectedFailure`) — it now passes.

Notes:
- Like `StopIteration.value` in #8301, the members are `getset_descriptor`s rather than CPython's `member_descriptor`s; both are data descriptors and behave the same for get/set/delete.
- `msg` is initialized in the constructor (not only `__init__`) so `TabError` still renders its message. `TabError`'s `__init__` slot is not reached during construction — a pre-existing limitation for two-level exception subclasses — so its location members (`lineno`/`offset`/…) are not populated from a direct `TabError(msg, tuple)` call; the compile path sets them via attribute assignment, so raised `TabError`s are unaffected. Fixing that inheritance is out of scope here.

Assisted-by: Claude Code:claude-fable-5


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved `SyntaxError` handling for message, filename, line number, offset, source text, and end-position details.
  * Added stricter validation for how location information is provided, including correct handling of supported shapes and end-position constraints.
  * Improved exception creation compatibility when exception types use different internal payload layouts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->