### PR TITLE
Fix some pyo3 testcase against the c-api

### DIFF
--- a/crates/capi/src/import.rs
+++ b/crates/capi/src/import.rs
@@ -8,7 +8,18 @@ use rustpython_vm::import::import_code_obj;
 pub unsafe extern "C" fn PyImport_Import(name: *mut PyObject) -> *mut PyObject {
     with_vm(|vm| {
         let name = unsafe { (&*name).try_downcast_ref::<PyStr>(vm)? };
-        vm.import(name, 0)
+        vm.import(name, 0)?;
+
+        let sys_modules = vm
+            .sys_module
+            .get_attr(rustpython_vm::identifier!(vm, modules), vm)?;
+        let sys_modules = sys_modules.try_downcast_ref::<PyDict>(vm)?;
+
+        if let Some(module) = sys_modules.get_item_opt(name, vm)? {
+            Ok(module)
+        } else {
+            vm.import(name, 0)
+        }
     })
 }
 
@@ -72,6 +83,14 @@ mod tests {
     fn import_stdlib() {
         Python::attach(|py| {
             let _module = py.import("types").unwrap();
+        })
+    }
+
+    #[test]
+    fn import_sub_module() {
+        Python::attach(|py| {
+            let module = py.import("collections.abc").unwrap();
+            module.getattr("Sequence").unwrap();
         })
     }
 }

--- a/crates/capi/src/import.rs
+++ b/crates/capi/src/import.rs
@@ -1,25 +1,15 @@
 use crate::util::CStrExt;
 use crate::{PyObject, pystate::with_vm};
 use core::ffi::c_char;
-use rustpython_vm::builtins::{PyCode, PyDict, PyModule, PyStr};
+use rustpython_vm::builtins::{PyCode, PyDict, PyModule, PyStr, PyTuple};
 use rustpython_vm::import::import_code_obj;
 
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn PyImport_Import(name: *mut PyObject) -> *mut PyObject {
     with_vm(|vm| {
         let name = unsafe { (&*name).try_downcast_ref::<PyStr>(vm)? };
-        vm.import(name, 0)?;
-
-        let sys_modules = vm
-            .sys_module
-            .get_attr(rustpython_vm::identifier!(vm, modules), vm)?;
-        let sys_modules = sys_modules.try_downcast_ref::<PyDict>(vm)?;
-
-        if let Some(module) = sys_modules.get_item_opt(name, vm)? {
-            Ok(module)
-        } else {
-            vm.import(name, 0)
-        }
+        let from_list = PyTuple::new_ref_typed(vec![vm.ctx.new_str("*")], &vm.ctx);
+        vm.import_from(name, &from_list, 0)
     })
 }
 

--- a/crates/capi/src/import.rs
+++ b/crates/capi/src/import.rs
@@ -1,15 +1,18 @@
 use crate::util::CStrExt;
 use crate::{PyObject, pystate::with_vm};
 use core::ffi::c_char;
-use rustpython_vm::builtins::{PyCode, PyDict, PyModule, PyStr, PyTuple};
+use rustpython_vm::builtins::{PyCode, PyDict, PyModule, PyStr};
 use rustpython_vm::import::import_code_obj;
 
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn PyImport_Import(name: *mut PyObject) -> *mut PyObject {
     with_vm(|vm| {
         let name = unsafe { (&*name).try_downcast_ref::<PyStr>(vm)? };
-        let from_list = PyTuple::new_ref_typed(vec![vm.ctx.new_str("*")], &vm.ctx);
-        vm.import_from(name, &from_list, 0)
+        let _ = vm.import(name, 0)?;
+
+        vm.sys_module
+            .get_attr(rustpython_vm::identifier!(vm, modules), vm)?
+            .get_item(name, vm)
     })
 }
 

--- a/crates/capi/src/methodobject.rs
+++ b/crates/capi/src/methodobject.rs
@@ -53,6 +53,7 @@ pub(crate) fn build_method_def(
 
     let flags = PyMethodFlags::from_bits(ml.ml_flags as u32)
         .ok_or_else(|| vm.new_system_error("PyMethodDef contains unknown flags"))?;
+    let has_self = has_self && !flags.contains(PyMethodFlags::STATIC);
 
     let method = ml.ml_meth;
 
@@ -358,5 +359,18 @@ mod tests {
                 "Exception('Something went wrong')"
             );
         })
+    }
+
+    #[test]
+    fn wrap_static_no_args_function() {
+        #[pyfunction()]
+        fn f() {}
+
+        Python::attach(|py| {
+            let module = PyModule::new(py, "test_wrap_pyfunction_forms").unwrap();
+
+            let func = wrap_pyfunction!(f, &module).unwrap();
+            func.call0().unwrap();
+        });
     }
 }

--- a/crates/capi/src/object.rs
+++ b/crates/capi/src/object.rs
@@ -598,6 +598,7 @@ mod tests {
             let x = 5i32.into_pyobject(py).unwrap();
             assert!(x.is_instance_of::<PyInt>());
 
+            // spell-checker:ignore bbbbbbytes
             assert!(x.hasattr("to_bytes").unwrap());
             assert!(!x.hasattr("bbbbbbytes").unwrap());
         })

--- a/crates/capi/src/object.rs
+++ b/crates/capi/src/object.rs
@@ -217,7 +217,7 @@ pub unsafe extern "C" fn PyObject_HasAttrWithError(
     with_vm(|vm| {
         let obj = unsafe { &*obj };
         let name = unsafe { &*attr_name }.try_downcast_ref::<PyStr>(vm)?;
-        obj.has_attr(name, vm)
+        Ok(vm.get_attribute_opt(obj.to_owned(), name)?.is_some())
     })
 }
 
@@ -272,7 +272,7 @@ pub unsafe extern "C" fn PyObject_HasAttrStringWithError(
     with_vm(|vm| {
         let obj = unsafe { &*obj };
         let name = unsafe { attr_name.try_as_str(vm) }?;
-        obj.has_attr(name, vm)
+        Ok(vm.get_attribute_opt(obj.to_owned(), name)?.is_some())
     })
 }
 
@@ -589,6 +589,17 @@ mod tests {
             }
             .unwrap();
             assert!(dict.get_item("foo").is_ok());
+        })
+    }
+
+    #[test]
+    fn hasattr() {
+        Python::attach(|py| {
+            let x = 5i32.into_pyobject(py).unwrap();
+            assert!(x.is_instance_of::<PyInt>());
+
+            assert!(x.hasattr("to_bytes").unwrap());
+            assert!(!x.hasattr("bbbbbbytes").unwrap());
         })
     }
 }

--- a/crates/capi/src/pycapsule.rs
+++ b/crates/capi/src/pycapsule.rs
@@ -48,6 +48,11 @@ pub unsafe extern "C" fn PyCapsule_GetContext(capsule: *mut PyObject) -> *mut c_
         let capsule = unsafe { &*capsule }
             .downcast_ref_if_exact::<PyCapsule>(vm)
             .ok_or_else(|| vm.new_value_error("Invalid capsule"))?;
+
+        if capsule.pointer().is_null() {
+            return Err(vm.new_value_error("Capsule has null pointer"));
+        }
+
         Ok(capsule.context())
     })
 }
@@ -143,6 +148,7 @@ fn checked_capsule<'a>(
 
 #[cfg(test)]
 mod tests {
+    use pyo3::ffi;
     use pyo3::prelude::*;
     use pyo3::types::PyCapsule;
 
@@ -155,5 +161,22 @@ mod tests {
             let ptr = capsule.pointer_checked(Some(c"my_capsule")).unwrap();
             assert_eq!(unsafe { ptr.cast::<String>().as_ref() }, "Some data");
         })
+    }
+
+    #[test]
+    fn capsule_context_on_invalid_capsule() {
+        Python::attach(|py| {
+            let cap = PyCapsule::new_with_value(py, 123u32, c"name").unwrap();
+
+            // Invalidate the capsule
+            // SAFETY: intentionally breaking the capsule for testing
+            unsafe {
+                ffi::PyCapsule_SetPointer(cap.as_ptr(), core::ptr::null_mut());
+            }
+
+            // context() on invalid capsule should fail
+            let result = cap.context();
+            assert!(result.is_err());
+        });
     }
 }

--- a/crates/vm/src/builtins/capsule.rs
+++ b/crates/vm/src/builtins/capsule.rs
@@ -76,9 +76,10 @@ impl Representable for PyCapsule {
 
 impl Destructor for PyCapsule {
     fn del(zelf: &Py<Self>, _vm: &VirtualMachine) -> PyResult<()> {
-        if !zelf.pointer().is_null()
-            && let Some(destructor) = zelf.destructor()
-        {
+        if zelf.pointer().is_null() {
+            return Ok(());
+        }
+        if let Some(destructor) = zelf.destructor() {
             unsafe { destructor(zelf.as_object().as_raw().cast_mut()) };
         }
         Ok(())

--- a/crates/vm/src/builtins/capsule.rs
+++ b/crates/vm/src/builtins/capsule.rs
@@ -76,7 +76,9 @@ impl Representable for PyCapsule {
 
 impl Destructor for PyCapsule {
     fn del(zelf: &Py<Self>, _vm: &VirtualMachine) -> PyResult<()> {
-        if let Some(destructor) = zelf.destructor() {
+        if !zelf.pointer().is_null()
+            && let Some(destructor) = zelf.destructor()
+        {
             unsafe { destructor(zelf.as_object().as_raw().cast_mut()) };
         }
         Ok(())


### PR DESCRIPTION
Found some bugs while running pyo3 test-suite against our implementation. Copied relevant testcases and fixed them.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved import behavior to return the imported module object from the runtime module registry (so submodule attributes are accessible).
  * Fixed wrapping of static Rust functions so no-argument functions are handled correctly.
  * Corrected attribute-existence checks to match Python `hasattr` results.
  * Added a clearer error when requesting capsule context from a capsule with a null pointer.
  * Prevented capsule destructor callbacks from running when the capsule pointer is null.
* **Tests**
  * Added coverage for submodule importing, static no-arg wrapping, `hasattr` behavior, and invalid capsule context/destructor cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->