### PR TITLE
time: use C altzone when available

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3422,6 +3422,7 @@ name = "rustpython-host_env"
 version = "0.5.0"
 dependencies = [
  "bitflags 2.13.1",
+ "cc",
  "dns-lookup",
  "gethostname",
  "getrandom 0.4.3",

--- a/crates/host_env/Cargo.toml
+++ b/crates/host_env/Cargo.toml
@@ -84,5 +84,8 @@ windows-sys = { workspace = true, features = [
     "Win32_UI_WindowsAndMessaging",
 ] }
 
+[build-dependencies]
+cc = "1"
+
 [lints]
 workspace = true

--- a/crates/host_env/build.rs
+++ b/crates/host_env/build.rs
@@ -1,0 +1,62 @@
+//! Like CPython's `HAVE_ALTZONE`, it detects the presence of `altzone` in `time.h` at build time.
+
+#![allow(
+    clippy::disallowed_methods,
+    reason = "build scripts cannot use rustpython-host_env"
+)]
+
+use std::{env, fs, path::PathBuf};
+
+fn main() {
+    println!("cargo:rerun-if-changed=build.rs");
+    println!("cargo:rustc-check-cfg=cfg(has_altzone)");
+
+    let target_env = env::var("CARGO_CFG_TARGET_ENV").unwrap_or_default();
+    let target_arch = env::var("CARGO_CFG_TARGET_ARCH").unwrap_or_default();
+
+    if target_env == "msvc" || target_arch == "wasm32" {
+        return;
+    }
+
+    let host = env::var("HOST").unwrap_or_default();
+    let target = env::var("TARGET").unwrap_or_default();
+    if host != target && env::var_os("CC").is_none() {
+        return;
+    }
+
+    if probe_altzone() {
+        println!("cargo:rustc-cfg=has_altzone");
+    }
+}
+
+/// Check corresponding to `AC_TRY_COMPILE(... altzone ...)` in CPython's `configure`.
+fn probe_altzone() -> bool {
+    let out_dir = PathBuf::from(env::var_os("OUT_DIR").expect("OUT_DIR"));
+    let src = out_dir.join("probe_altzone.c");
+    let obj = out_dir.join("probe_altzone.o");
+
+    if fs::write(
+        &src,
+        "#include <time.h>\nint main(void) { return (int)altzone; }\n",
+    )
+    .is_err()
+    {
+        return false;
+    }
+
+    let Ok(compiler) = cc::Build::new().try_get_compiler() else {
+        return false;
+    };
+
+    let mut cmd = compiler.to_command();
+    if compiler.is_like_msvc() {
+        cmd.arg("/c").arg(&src).arg(format!("/Fo{}", obj.display()));
+    } else {
+        cmd.arg("-c").arg(&src).arg("-o").arg(&obj);
+    }
+
+    match cmd.output() {
+        Ok(output) => output.status.success(),
+        Err(_) => false,
+    }
+}

--- a/crates/host_env/build.rs
+++ b/crates/host_env/build.rs
@@ -20,13 +20,23 @@ fn main() {
 
     let host = env::var("HOST").unwrap_or_default();
     let target = env::var("TARGET").unwrap_or_default();
-    if host != target && env::var_os("CC").is_none() {
+    // cc::Build resolves CC_<target>, CC_<target_with_underscores>, TARGET_CC, then CC.
+    if host != target && !has_target_c_compiler(&target) {
         return;
     }
 
     if probe_altzone() {
         println!("cargo:rustc-cfg=has_altzone");
     }
+}
+
+/// Whether any compiler env var that `cc::Build` would consult for the target is set.
+fn has_target_c_compiler(target: &str) -> bool {
+    let underscored = target.replace(['-', '.'], "_");
+    env::var_os(format!("CC_{target}")).is_some()
+        || env::var_os(format!("CC_{underscored}")).is_some()
+        || env::var_os("TARGET_CC").is_some()
+        || env::var_os("CC").is_some()
 }
 
 /// Check corresponding to `AC_TRY_COMPILE(... altzone ...)` in CPython's `configure`.

--- a/crates/host_env/src/time.rs
+++ b/crates/host_env/src/time.rs
@@ -15,7 +15,7 @@ pub const SEC_TO_NS: i64 = SEC_TO_MS * MS_TO_NS;
 pub const NS_TO_MS: i64 = 1000 * 1000;
 pub const NS_TO_US: i64 = 1000;
 
-/// Access to the C runtime's `tzset` / `timezone` / `daylight` / `tzname`
+/// Access to the C runtime's `tzset` / `timezone` / `altzone` / `daylight` / `tzname`
 /// globals used by Python's `time` module.
 ///
 /// Not available under MSVC (which exposes these only via the
@@ -28,6 +28,10 @@ pub mod tz {
         static c_daylight: core::ffi::c_int;
         #[link_name = "timezone"]
         static c_timezone: core::ffi::c_long;
+        // Set by `build.rs` when `time.h` exposes `altzone` (CPython `HAVE_ALTZONE`).
+        #[cfg(has_altzone)]
+        #[link_name = "altzone"]
+        static c_altzone: core::ffi::c_long;
         #[link_name = "tzname"]
         static c_tzname: [*const core::ffi::c_char; 2];
         #[link_name = "tzset"]
@@ -41,6 +45,22 @@ pub mod tz {
     #[must_use]
     pub fn timezone() -> core::ffi::c_long {
         unsafe { c_timezone }
+    }
+
+    /// DST offset west of UTC in seconds, matching CPython's `time.altzone`.
+    ///
+    /// Uses the C `altzone` global when available; otherwise falls back to
+    /// `timezone - 3600` (same as CPython without `HAVE_ALTZONE`).
+    #[must_use]
+    pub fn altzone() -> core::ffi::c_long {
+        #[cfg(has_altzone)]
+        {
+            unsafe { c_altzone }
+        }
+        #[cfg(not(has_altzone))]
+        {
+            timezone() - 3600
+        }
     }
 
     #[cfg(not(target_os = "freebsd"))]

--- a/crates/vm/src/stdlib/time.rs
+++ b/crates/vm/src/stdlib/time.rs
@@ -210,8 +210,7 @@ mod decl {
     #[cfg(not(target_arch = "wasm32"))]
     #[pyattr]
     fn altzone(_vm: &VirtualMachine) -> core::ffi::c_long {
-        // TODO: RUSTPYTHON; Add support for using the C altzone
-        crate::host_env::time::tz::timezone() - 3600
+        crate::host_env::time::tz::altzone()
     }
 
     #[cfg(target_env = "msvc")]


### PR DESCRIPTION
- [x] This PR follows our [AI policy](https://github.com/RustPython/.github/blob/main/AI_POLICY.md)

## Summary
Fixed an issue where the existing `altzone` was simply calculated as `timezone - 3600` without checking for the presence of `altzone` in `libc`.

During the build process, the code now checks for the existence of `altzone` and implements logic consistent with CPython.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved `time.altzone` accuracy by using the host-provided native daylight-saving offset when available.
  * Added a CPython-compatible fallback for platforms where the native offset cannot be detected.
  * Enhanced correctness across supported environments, including cases where capability detection is unavailable during builds.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->