### PR TITLE
Fix `binascii.b2a_qp` CRLF boundary check

### DIFF
--- a/crates/stdlib/src/binascii.rs
+++ b/crates/stdlib/src/binascii.rs
@@ -504,7 +504,7 @@ mod decl {
                 }
                 in_idx += 1;
             }
-            if buflen > 0 && in_idx < buflen && buf[in_idx - 1] == b'\r' {
+            if in_idx > 0 && in_idx < buflen && buf[in_idx - 1] == b'\r' {
                 crlf = true;
             }
 


### PR DESCRIPTION
- Related to #8325 ([RUSTPY-0010-binascii-b2a-qp-underflow](https://github.com/devdanzin/rustpython-findings/tree/main/reports/RUSTPY-0010-binascii-b2a-qp-underflow))
- [x] This PR follows our [AI policy](https://github.com/RustPython/.github/blob/main/AI_POLICY.md)

## Summary

- Prevent `binascii.b2a_qp()` from panicking when the input starts with `\n`.
- Match CPython's boundary check when detecting CRLF line endings.

When the first byte is `\n`, `in_idx` remains zero and accessing `buf[in_idx - 1]` causes an integer underflow. 
This change checks `in_idx > 0` before accessing the preceding byte.

## Testing

- `cargo run -- -c 'import binascii; assert binascii.b2a_qp(b"\n") == b"\n"'`
- `cargo run --release -- -m test test_binascii`

Before this change, the RustPython command panicked with:

```text
attempt to subtract with overflow
```

## AI assistance
Codex (GPT‑5.6 Sol) was used to investigate and implement this change. 
I reviewed and validated all AI-assisted work.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved quoted-printable encoding’s carriage-return detection to avoid incorrect line-ending handling near buffer boundaries.
  * Added tighter boundary checks so CR detection only occurs when the previous byte is safely accessible.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->