### PR TITLE
Replace malformed unicode error helper calls with the _real variants

### DIFF
--- a/crates/stdlib/src/csv.rs
+++ b/crates/stdlib/src/csv.rs
@@ -60,6 +60,20 @@ mod _csv {
         vm.new_exception_msg(super::_csv::error(vm), msg.into())
     }
 
+    fn new_not_utf8_error(
+        vm: &VirtualMachine,
+        bytes: &[u8],
+        err: core::str::Utf8Error,
+    ) -> PyBaseExceptionRef {
+        vm.new_unicode_decode_error_real(
+            vm.ctx.new_str("utf-8"),
+            vm.ctx.new_bytes(bytes.to_vec()),
+            err.valid_up_to(),
+            err.valid_up_to() + 1,
+            vm.ctx.new_str("csv not utf8"),
+        )
+    }
+
     #[pyattr]
     #[pyclass(module = "csv", name = "Dialect")]
     #[derive(Debug, PyPayload, Clone, Copy)]
@@ -1111,8 +1125,8 @@ mod _csv {
                 {
                     return Ok(vm.ctx.none());
                 }
-                let field = core::str::from_utf8(&field)
-                    .map_err(|_| vm.new_unicode_decode_error("csv not utf8"))?;
+                let field =
+                    core::str::from_utf8(&field).map_err(|e| new_not_utf8_error(vm, &field, e))?;
                 Ok(vm.ctx.new_str(field).into())
             })
             .collect()
@@ -1248,7 +1262,7 @@ mod _csv {
                     prev_end = end;
                     let s = core::str::from_utf8(&buffer[range.clone()])
                         // not sure if this is possible - the input was all strings
-                        .map_err(|_e| vm.new_unicode_decode_error("csv not utf8"))?;
+                        .map_err(|e| new_not_utf8_error(vm, &buffer[range.clone()], e))?;
 
                     // TODO: RUSTPYTHON; Incomplete implementation
                     if let QuoteStyle::Nonnumeric = zelf.dialect.quoting {
@@ -1423,8 +1437,8 @@ mod _csv {
             }
 
             write_lineterminator(&mut output, self.dialect.lineterminator);
-            let s = core::str::from_utf8(&output)
-                .map_err(|_| vm.new_unicode_decode_error("csv not utf8"))?;
+            let s =
+                core::str::from_utf8(&output).map_err(|e| new_not_utf8_error(vm, &output, e))?;
             self.write.call((s,), vm)
         }
 
@@ -1469,8 +1483,8 @@ mod _csv {
 
             write_lineterminator(&mut output, self.dialect.lineterminator);
 
-            let s = core::str::from_utf8(&output)
-                .map_err(|_| vm.new_unicode_decode_error("csv not utf8"))?;
+            let s =
+                core::str::from_utf8(&output).map_err(|e| new_not_utf8_error(vm, &output, e))?;
 
             self.write.call((s,), vm)
         }
@@ -1518,8 +1532,8 @@ mod _csv {
 
             write_lineterminator(&mut output, self.dialect.lineterminator);
 
-            let s = core::str::from_utf8(&output)
-                .map_err(|_| vm.new_unicode_decode_error("csv not utf8"))?;
+            let s =
+                core::str::from_utf8(&output).map_err(|e| new_not_utf8_error(vm, &output, e))?;
 
             self.write.call((s,), vm)
         }
@@ -1593,7 +1607,7 @@ mod _csv {
             }
 
             let s = core::str::from_utf8(&buffer[..buffer_offset])
-                .map_err(|_| vm.new_unicode_decode_error("csv not utf8"))?;
+                .map_err(|e| new_not_utf8_error(vm, &buffer[..buffer_offset], e))?;
 
             self.write.call((s,), vm)
         }

--- a/crates/stdlib/src/csv.rs
+++ b/crates/stdlib/src/csv.rs
@@ -69,7 +69,8 @@ mod _csv {
             vm.ctx.new_str("utf-8"),
             vm.ctx.new_bytes(bytes.to_vec()),
             err.valid_up_to(),
-            err.valid_up_to() + 1,
+            err.error_len()
+                .map_or(bytes.len(), |n| err.valid_up_to() + n),
             vm.ctx.new_str("csv not utf8"),
         )
     }

--- a/crates/stdlib/src/socket.rs
+++ b/crates/stdlib/src/socket.rs
@@ -2612,8 +2612,15 @@ mod _socket {
             }
             Some(ArgStrOrBytesLike::Buf(b)) => {
                 let bytes = b.borrow_buf();
-                let host_str = core::str::from_utf8(&bytes)
-                    .map_err(|_| vm.new_unicode_decode_error("host bytes is not utf8"))?;
+                let host_str = core::str::from_utf8(&bytes).map_err(|e| {
+                    vm.new_unicode_decode_error_real(
+                        vm.ctx.new_str("utf-8"),
+                        vm.ctx.new_bytes(bytes.to_vec()),
+                        e.valid_up_to(),
+                        e.valid_up_to() + 1,
+                        vm.ctx.new_str("host bytes is not utf8"),
+                    )
+                })?;
                 Some(host_str.to_owned())
             }
             None => None,
@@ -2627,14 +2634,35 @@ mod _socket {
                     ArgStrOrBytesLike::Str(s) => {
                         // For str, check for surrogates and raise UnicodeEncodeError if found
                         s.to_str()
-                            .ok_or_else(|| vm.new_unicode_encode_error("surrogates not allowed"))?
+                            .ok_or_else(|| {
+                                let start = s
+                                    .as_wtf8()
+                                    .code_points()
+                                    .position(|c| c.to_char().is_none())
+                                    .unwrap();
+                                vm.new_unicode_encode_error_real(
+                                    vm.ctx.new_str("utf-8"),
+                                    (*s).clone(),
+                                    start,
+                                    start + 1,
+                                    vm.ctx.new_str("surrogates not allowed"),
+                                )
+                            })?
                             .to_owned()
                     }
                     ArgStrOrBytesLike::Buf(b) => {
                         // For bytes, check if it's valid UTF-8
                         let bytes = b.borrow_buf();
                         core::str::from_utf8(&bytes)
-                            .map_err(|_| vm.new_unicode_decode_error("port is not utf8"))?
+                            .map_err(|e| {
+                                vm.new_unicode_decode_error_real(
+                                    vm.ctx.new_str("utf-8"),
+                                    vm.ctx.new_bytes(bytes.to_vec()),
+                                    e.valid_up_to(),
+                                    e.valid_up_to() + 1,
+                                    vm.ctx.new_str("port is not utf8"),
+                                )
+                            })?
                             .to_owned()
                     }
                 };

--- a/crates/stdlib/src/socket.rs
+++ b/crates/stdlib/src/socket.rs
@@ -2617,7 +2617,7 @@ mod _socket {
                         vm.ctx.new_str("utf-8"),
                         vm.ctx.new_bytes(bytes.to_vec()),
                         e.valid_up_to(),
-                        e.valid_up_to() + 1,
+                        e.error_len().map_or(bytes.len(), |n| e.valid_up_to() + n),
                         vm.ctx.new_str("host bytes is not utf8"),
                     )
                 })?;
@@ -2659,7 +2659,7 @@ mod _socket {
                                     vm.ctx.new_str("utf-8"),
                                     vm.ctx.new_bytes(bytes.to_vec()),
                                     e.valid_up_to(),
-                                    e.valid_up_to() + 1,
+                                    e.error_len().map_or(bytes.len(), |n| e.valid_up_to() + n),
                                     vm.ctx.new_str("port is not utf8"),
                                 )
                             })?

--- a/crates/vm/src/function/fspath.rs
+++ b/crates/vm/src/function/fspath.rs
@@ -125,8 +125,15 @@ impl FsPath {
     }
 
     pub fn bytes_as_os_str<'a>(b: &'a [u8], vm: &VirtualMachine) -> PyResult<&'a std::ffi::OsStr> {
-        rustpython_host_env::os::bytes_as_os_str(b)
-            .map_err(|_| vm.new_unicode_decode_error("can't decode path for utf-8"))
+        rustpython_host_env::os::bytes_as_os_str(b).map_err(|e| {
+            vm.new_unicode_decode_error_real(
+                vm.ctx.new_str("utf-8"),
+                vm.ctx.new_bytes(b.to_vec()),
+                e.valid_up_to(),
+                e.valid_up_to() + 1,
+                vm.ctx.new_str("can't decode path for utf-8"),
+            )
+        })
     }
 }
 

--- a/crates/vm/src/function/fspath.rs
+++ b/crates/vm/src/function/fspath.rs
@@ -130,7 +130,7 @@ impl FsPath {
                 vm.ctx.new_str("utf-8"),
                 vm.ctx.new_bytes(b.to_vec()),
                 e.valid_up_to(),
-                e.valid_up_to() + 1,
+                e.error_len().map_or(b.len(), |n| e.valid_up_to() + n),
                 vm.ctx.new_str("can't decode path for utf-8"),
             )
         })

--- a/crates/vm/src/stdlib/os.rs
+++ b/crates/vm/src/stdlib/os.rs
@@ -130,8 +130,15 @@ pub(super) struct FollowSymlinks(
 
 #[cfg(not(windows))]
 fn bytes_as_os_str<'a>(b: &'a [u8], vm: &VirtualMachine) -> PyResult<&'a std::ffi::OsStr> {
-    rustpython_host_env::os::bytes_as_os_str(b)
-        .map_err(|_| vm.new_unicode_decode_error("can't decode path for utf-8"))
+    rustpython_host_env::os::bytes_as_os_str(b).map_err(|e| {
+        vm.new_unicode_decode_error_real(
+            vm.ctx.new_str("utf-8"),
+            vm.ctx.new_bytes(b.to_vec()),
+            e.valid_up_to(),
+            e.valid_up_to() + 1,
+            vm.ctx.new_str("can't decode path for utf-8"),
+        )
+    })
 }
 
 pub(crate) fn warn_if_bool_fd(obj: &PyObjectRef, vm: &VirtualMachine) -> PyResult<()> {

--- a/crates/vm/src/stdlib/os.rs
+++ b/crates/vm/src/stdlib/os.rs
@@ -135,7 +135,7 @@ fn bytes_as_os_str<'a>(b: &'a [u8], vm: &VirtualMachine) -> PyResult<&'a std::ff
             vm.ctx.new_str("utf-8"),
             vm.ctx.new_bytes(b.to_vec()),
             e.valid_up_to(),
-            e.valid_up_to() + 1,
+            e.error_len().map_or(b.len(), |n| e.valid_up_to() + n),
             vm.ctx.new_str("can't decode path for utf-8"),
         )
     })

--- a/crates/vm/src/stdlib/posix.rs
+++ b/crates/vm/src/stdlib/posix.rs
@@ -1731,10 +1731,15 @@ pub mod module {
         let Some(login) = rustpython_host_env::posix::getlogin() else {
             return Err(vm.new_os_error("unable to determine login name"));
         };
-        login
-            .to_str()
-            .map(|s| s.to_owned())
-            .map_err(|e| vm.new_unicode_decode_error(format!("unable to decode login name: {e}")))
+        login.to_str().map(|s| s.to_owned()).map_err(|e| {
+            vm.new_unicode_decode_error_real(
+                vm.ctx.new_str("utf-8"),
+                vm.ctx.new_bytes(login.as_bytes().to_vec()),
+                e.valid_up_to(),
+                e.valid_up_to() + 1,
+                vm.ctx.new_str("unable to decode login name"),
+            )
+        })
     }
 
     // cfg from nix

--- a/crates/vm/src/stdlib/posix.rs
+++ b/crates/vm/src/stdlib/posix.rs
@@ -1736,7 +1736,8 @@ pub mod module {
                 vm.ctx.new_str("utf-8"),
                 vm.ctx.new_bytes(login.as_bytes().to_vec()),
                 e.valid_up_to(),
-                e.valid_up_to() + 1,
+                e.error_len()
+                    .map_or(login.as_bytes().len(), |n| e.valid_up_to() + n),
                 vm.ctx.new_str("unable to decode login name"),
             )
         })


### PR DESCRIPTION
Part of #8352

- [x] This PR follows our [AI policy](https://github.com/RustPython/.github/blob/main/AI_POLICY.md)

## Summary

`new_unicode_decode_error` / `new_unicode_encode_error` construct a structurally invalid exception: it has none of the five attributes a unicode error must carry (`encoding`, `object`, `start`, `end`, `reason`), its `args` is a 1-tuple message, and `str()` renders as an empty string. This converts the non-Windows call sites to the `_real` constructors:

```python
import csv
next(csv.reader(['\udcff'], quoting=csv.QUOTE_STRINGS))
# before: str(e) = ''            args = ('csv not utf8',)   e.encoding -> AttributeError
# after:  str(e) = "'utf-8' codec can't decode byte 0xed in position 0: csv not utf8"
#         args = ('utf-8', b'\xed\xb3\xbf', 0, 1, 'csv not utf8')   all five attributes set
```

## Cause

The broken helpers are generated by `define_exception_fn!`, which goes through `new_exception_msg` → `PyBaseException::new(args)`. That only stores `args` and never runs the type's initializer, so the unicode-error attributes are never set. The `_real` constructors pass the full `(encoding, object, start, end, reason)` and set every attribute.

## Fix

Converted call sites, supplying the source bytes/str and the failing offset from the previously discarded `Utf8Error` (`valid_up_to()`, span `start..start + 1` matching the existing `_real` usages):

- `csv`: all 6 sites, via a `new_not_utf8_error` helper next to the existing `new_csv_error`
- `socket`: host/port bytes decode; the port surrogate check now reports the first surrogate position (same scan as `PyStr::ensure_valid_utf8`)
- `posix.getlogin`, `FsPath::bytes_as_os_str`, `os::bytes_as_os_str`

Left for follow-ups, per the issue plan:
- the Windows-gated sites (`nt.rs`, mbcs/oem codecs) — I can't test Windows locally
- sites whose source object is not reachable at the error site (`uname`, `array`) — these need a small refactor or an error-type decision rather than a mechanical conversion

## Test

- Repro above now produces a well-formed `UnicodeDecodeError`; also verified `socket.getaddrinfo(b"\xff\xfe", 80)` → `('utf-8', b'\xff\xfe', 0, 1, ...)` and `socket.getaddrinfo("localhost", "ab\udcffcd")` → `UnicodeEncodeError ('utf-8', 'ab\udcffcd', 2, 3, 'surrogates not allowed')` (surrogate position reported precisely).
- `cargo run -- -m test test_csv` / `test_os` / `test_posix` → **`Tests result: SUCCESS`** (no unexpected successes).
- `cargo clippy` / `cargo fmt`: clean (no new warnings).

Assisted-by: Claude Code:claude-fable-5


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Unicode decoding errors in CSV operations with clearer failure details.
  * Enhanced socket address handling to report accurate errors for invalid host and port text.
  * Improved error reporting when filesystem paths contain invalid UTF-8 bytes.
  * Updated login-name decoding failures to provide standard, detailed Unicode errors.
  * Preserved the original invalid data and error location wherever possible for easier diagnosis.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->