### PR TITLE
Raise OverflowError for float overflow in struct packing

### DIFF
--- a/Lib/test/test_struct.py
+++ b/Lib/test/test_struct.py
@@ -365,7 +365,6 @@ class StructTest(ComplexesAreIdenticalMixin, unittest.TestCase):
             (got,) = struct.unpack(code, got)
             self.assertEqual(got, expectedback)
 
-    @unittest.expectedFailure  # TODO: RUSTPYTHON
     def test_705836(self):
         # SF bug 705836.  "<f" and ">f" had a severe rounding bug, where a carry
         # from the low-order discarded bits could propagate into the exponent

--- a/crates/vm/src/buffer.rs
+++ b/crates/vm/src/buffer.rs
@@ -615,14 +615,22 @@ make_pack_prim_int!(usize);
 make_pack_prim_int!(isize);
 
 macro_rules! make_pack_float {
-    ($T:ty) => {
+    ($T:ty, $fmt:literal) => {
         impl Packable for $T {
             fn pack<E: ByteOrder>(
                 vm: &VirtualMachine,
                 arg: PyObjectRef,
                 data: &mut [u8],
             ) -> PyResult<()> {
-                let f = ArgIntoFloat::try_from_object(vm, arg)?.into_float() as $T;
+                let f_64 = ArgIntoFloat::try_from_object(vm, arg)?.into_float();
+                let f = f_64 as $T;
+                if f.is_infinite() != f_64.is_infinite() {
+                    return Err(vm.new_overflow_error(concat!(
+                        "float too large to pack with ",
+                        $fmt,
+                        " format"
+                    )));
+                }
                 f.to_bits().pack_int::<E>(data);
                 Ok(())
             }
@@ -635,8 +643,8 @@ macro_rules! make_pack_float {
     };
 }
 
-make_pack_float!(f32);
-make_pack_float!(f64);
+make_pack_float!(f32, "f");
+make_pack_float!(f64, "d");
 
 impl Packable for f16 {
     fn pack<E: ByteOrder>(vm: &VirtualMachine, arg: PyObjectRef, data: &mut [u8]) -> PyResult<()> {


### PR DESCRIPTION
- [x] This PR follows our [AI policy](https://github.com/RustPython/.github/blob/main/AI_POLICY.md)

## Summary

- Detect when a finite Python float overflows to infinity while being converted for the `struct` `f` format.
- Raise `OverflowError` with the CPython-compatible message instead of silently packing an IEEE 754 infinity.

## Behavior changes

Before:

```python
$ cargo run -- -c 'import math, struct; x = math.ldexp((1 << 25) - 1, 127 - 24); print(struct.pack(">f", x))'
b'\x7f\x80\x00\x00'
```

After:

```python
$ cargo run -- -c 'import math, struct; x = math.ldexp((1 << 25) - 1, 127 - 24); print(struct.pack(">f", x))'
OverflowError: float too large to pack with f format
```

## References

- `PyFloat_Pack4`: https://github.com/python/cpython/blob/v3.14.6/Objects/floatobject.c#L2180-L2185

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved detection of floating-point values that exceed the selected packing format’s representational limits.
  - Updated overflow messages to identify the affected float format, making errors clearer when packing values fails.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->