### PR TITLE
ast: fix identifier interning

### DIFF
--- a/Lib/test/test_ast/test_ast.py
+++ b/Lib/test/test_ast/test_ast.py
@@ -1331,7 +1331,6 @@ class CopyTests(unittest.TestCase):
         self.assertEqual(repl.x, 0)
         self.assertEqual(repl.y, y)
 
-    @unittest.expectedFailure  # TODO: RUSTPYTHON; AssertionError: 'x' is not 'x'
     def test_replace_ignore_known_custom_instance_fields(self):
         node = ast.parse('x').body[0].value
         node.extra = extra = object()  # add instance 'extra' field
@@ -1401,7 +1400,6 @@ class CopyTests(unittest.TestCase):
         self.assertIs(node2.returns, None)
         self.assertEqual(node2.decorator_list, [])
 
-    @unittest.expectedFailure  # TODO: RUSTPYTHON; AssertionError: "Name\.__replace__\ got\ an\ unexpected\ keyword\ argument\ 'extra'\." does not match "replace() does not support Name objects"
     def test_replace_reject_known_custom_instance_fields_commits(self):
         node = ast.parse('x').body[0].value
         node.extra = extra = object()  # add instance 'extra' field
@@ -1417,7 +1415,6 @@ class CopyTests(unittest.TestCase):
         self.assertIs(node.ctx, context)
         self.assertIs(node.extra, extra)
 
-    @unittest.expectedFailure  # TODO: RUSTPYTHON; AssertionError: "Name\.__replace__\ got\ an\ unexpected\ keyword\ argument\ 'unknown'\." does not match "replace() does not support Name objects"
     def test_replace_reject_unknown_instance_fields(self):
         node = ast.parse('x').body[0].value
         context = node.ctx

--- a/crates/vm/src/stdlib/_ast/expression.rs
+++ b/crates/vm/src/stdlib/_ast/expression.rs
@@ -1376,7 +1376,8 @@ impl Node for ast::ExprName {
             .into_ref_with_type(vm, pyast::NodeExprName::static_type().to_owned())
             .unwrap();
         let dict = node.as_object().dict().unwrap();
-        dict.set_item("id", id.to_pyobject(vm), vm).unwrap();
+        dict.set_item("id", id.ast_to_object(vm, source_file), vm)
+            .unwrap();
         dict.set_item("ctx", ctx.ast_to_object(vm, source_file), vm)
             .unwrap();
         node_add_location(&dict, range, vm, source_file);

--- a/crates/vm/src/stdlib/_ast/statement.rs
+++ b/crates/vm/src/stdlib/_ast/statement.rs
@@ -409,7 +409,7 @@ impl Node for ast::StmtFunctionDef {
 
         let node = NodeAst.into_ref_with_type(vm, cls).unwrap();
         let dict = node.as_object().dict().unwrap();
-        dict.set_item("name", vm.ctx.new_str(name.as_str()).to_pyobject(vm), vm)
+        dict.set_item("name", name.ast_to_object(vm, source_file), vm)
             .unwrap();
         dict.set_item("args", parameters.ast_to_object(vm, source_file), vm)
             .unwrap();

--- a/extra_tests/snippets/stdlib_ast.py
+++ b/extra_tests/snippets/stdlib_ast.py
@@ -39,6 +39,27 @@ assert i.names[0].name == "a"
 assert i.names[0].asname is None
 
 
+# Regression: parsed AST identifier fields are interned, matching CPython.
+import copy
+
+name_literal = "x"
+name = ast.parse("x").body[0].value
+assert name.id is name_literal
+
+name.extra = object()
+replacement = copy.replace(name)
+assert replacement.id is name.id
+assert replacement.ctx is name.ctx
+assert not hasattr(replacement, "extra")
+
+function_name = "f"
+function = ast.parse("def f(): pass").body[0]
+assert function.name is function_name
+
+async_function = ast.parse("async def f(): pass").body[0]
+assert async_function.name is function_name
+
+
 # Regression test for issue #4862:
 # A cyclic AST fed to compile() used to overflow the Rust stack and SIGSEGV.
 # After the fix, the recursion guard in ast_from_object raises RecursionError,

--- a/extra_tests/snippets/stdlib_ast.py
+++ b/extra_tests/snippets/stdlib_ast.py
@@ -1,4 +1,5 @@
 import ast
+import copy
 
 print(ast)
 
@@ -40,8 +41,6 @@ assert i.names[0].asname is None
 
 
 # Regression: parsed AST identifier fields are interned, matching CPython.
-import copy
-
 name_literal = "x"
 name = ast.parse("x").body[0].value
 assert name.id is name_literal


### PR DESCRIPTION
- [x] This PR follows our [AI policy](https://github.com/RustPython/.github/blob/main/AI_POLICY.md)


## Summary

Ensure that identifier fields produced while converting parsed AST nodes use
interned Python strings, matching CPython behavior. In particular, this fixes
`Name.id` and function definition `name` fields.

This restores identity-sensitive behavior used by `copy.replace()` and removes
the three `test_ast` expected-failure markers that now pass. Add regression
coverage for expression, synchronous-function, and async-function identifiers.

## Testing

- uv tool run prek run --all-files
- cargo fmt --check
- cargo run --release Lib/test/test_ast/test_ast.py
  - 199 tests passed
  - 7 skipped
  - 21 expected failures
- cargo run -- extra_tests/snippets/stdlib_ast.py
- cargo clippy -p rustpython-stdlib --all-targets
- the configured workspace test suite

AI assistance: Codex:gpt-5.6-sol


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed AST identifier and function name conversion so `id`/`name` values match the expected representation and preserve correct identity semantics.
  * Improved AST node `copy`/`replace` behavior to retain the original identifier and context while dropping unrelated dynamically added attributes.

* **Tests**
  * Added regression coverage for identifier interning, function and async function name handling, and AST copy/replace semantics to align with CPython behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->