### PR TITLE
sqlite3: fix closed connection error message to match CPython

### DIFF
--- a/Lib/test/test_sqlite3/test_dbapi.py
+++ b/Lib/test/test_sqlite3/test_dbapi.py
@@ -1775,29 +1775,23 @@ class ClosedConTests(unittest.TestCase):
         self.cur = self.con.cursor()
         self.con.close()
 
-    @unittest.expectedFailure  # TODO: RUSTPYTHON; error message differs for closed connection
     def test_closed_con_cursor(self):
         self.check(self.con.cursor)
 
-    @unittest.expectedFailure  # TODO: RUSTPYTHON; error message differs for closed connection
     def test_closed_con_commit(self):
         self.check(self.con.commit)
 
-    @unittest.expectedFailure  # TODO: RUSTPYTHON; error message differs for closed connection
     def test_closed_con_rollback(self):
         self.check(self.con.rollback)
 
-    @unittest.expectedFailure  # TODO: RUSTPYTHON; error message differs for closed connection
     def test_closed_cur_execute(self):
         self.check(self.cur.execute, "select 4")
 
-    @unittest.expectedFailure  # TODO: RUSTPYTHON; error message differs for closed connection
     def test_closed_create_function(self):
         def f(x):
             return 17
         self.check(self.con.create_function, "foo", 1, f)
 
-    @unittest.expectedFailure  # TODO: RUSTPYTHON; error message differs for closed connection
     def test_closed_create_aggregate(self):
         class Agg:
             def __init__(self):
@@ -1808,19 +1802,16 @@ class ClosedConTests(unittest.TestCase):
                 return 17
         self.check(self.con.create_aggregate, "foo", 1, Agg)
 
-    @unittest.expectedFailure  # TODO: RUSTPYTHON; error message differs for closed connection
     def test_closed_set_authorizer(self):
         def authorizer(*args):
             return sqlite.DENY
         self.check(self.con.set_authorizer, authorizer)
 
-    @unittest.expectedFailure  # TODO: RUSTPYTHON; error message differs for closed connection
     def test_closed_set_progress_callback(self):
         def progress():
             pass
         self.check(self.con.set_progress_handler, progress, 100)
 
-    @unittest.expectedFailure  # TODO: RUSTPYTHON; error message differs for closed connection
     def test_closed_call(self):
         self.check(self.con)
 

--- a/crates/stdlib/src/_sqlite3.rs
+++ b/crates/stdlib/src/_sqlite3.rs
@@ -1026,6 +1026,11 @@ mod _sqlite3 {
                 Ok(PyMutexGuard::map(guard, |x| unsafe {
                     x.as_mut().unwrap_unchecked()
                 }))
+            } else if self.initialized.load(Ordering::Acquire) {
+                Err(new_programming_error(
+                    vm,
+                    "Cannot operate on a closed database.".to_owned(),
+                ))
             } else {
                 Err(new_programming_error(
                     vm,


### PR DESCRIPTION
When a Connection is explicitly closed via con.close(), subsequent operations (cursor(), commit(), rollback(), create_function(), etc.) should raise ProgrammingError with 'Cannot operate on a closed database.' to match CPython behaviour.

Previously, _db_lock() always returned 'Base Connection.__init__ not called.' when self.db was None, without distinguishing between a connection that was never initialised (subclass before __init__) and one that was initialised and then explicitly closed.

Assisted-by: GitHub Copilot:claude-sonnet-4-6

<!--
Thanks for your contribution!
-->

- [x] This PR follows our [AI policy](https://github.com/RustPython/.github/blob/main/AI_POLICY.md)

## Summary
<!-- What's the purpose of the change? What does it do, and why? -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error reporting for operations on closed database connections.
  * Closed connections now display a clear “Cannot operate on a closed database.” message instead of an initialization-related error.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->