### PR TITLE
Fix `staticmethod` and `classmethod` repr error propagation

### DIFF
--- a/crates/vm/src/builtins/classmethod.rs
+++ b/crates/vm/src/builtins/classmethod.rs
@@ -195,7 +195,7 @@ impl PyClassMethod {
 impl Representable for PyClassMethod {
     #[inline]
     fn repr_str(zelf: &Py<Self>, vm: &VirtualMachine) -> PyResult<String> {
-        let callable = zelf.callable.lock().repr(vm).unwrap();
+        let callable = zelf.callable.lock().repr(vm)?;
         let class = Self::class(&vm.ctx);
 
         let repr = match (

--- a/crates/vm/src/builtins/staticmethod.rs
+++ b/crates/vm/src/builtins/staticmethod.rs
@@ -179,7 +179,7 @@ impl Callable for PyStaticMethod {
 
 impl Representable for PyStaticMethod {
     fn repr_str(zelf: &Py<Self>, vm: &VirtualMachine) -> PyResult<String> {
-        let callable = zelf.callable.lock().repr(vm).unwrap();
+        let callable = zelf.callable.lock().repr(vm)?;
         let class = Self::class(&vm.ctx);
 
         match (

--- a/extra_tests/snippets/syntax_class.py
+++ b/extra_tests/snippets/syntax_class.py
@@ -163,6 +163,29 @@ assert T4.t1.__doc__ == "t1"
 cm = classmethod(lambda cls: cls)
 assert cm.__func__(int) is int
 
+
+class Callback:
+    def __init__(self, error):
+        self.error = error
+
+    def __call__(self, *args, **kwargs):
+        pass
+
+    def __repr__(self):
+        raise self.error
+
+
+callback = Callback(RuntimeError("callback is unavailable"))
+
+with assert_raises(RuntimeError) as caught:
+    repr(staticmethod(callback))
+assert caught.exception is callback.error
+
+with assert_raises(RuntimeError) as caught:
+    repr(classmethod(callback))
+assert caught.exception is callback.error
+
+
 assert str(super(int, 5)) == "<super: <class 'int'>, <int object>>"
 
 class T5(int):


### PR DESCRIPTION
- Related to #8325 ([RUSTPY-0009](https://github.com/devdanzin/rustpython-findings/tree/main/reports/RUSTPY-0009-staticmethod-repr-unwrap), [RUSTPY-0011](https://github.com/devdanzin/rustpython-findings/tree/main/reports/RUSTPY-0011-classmethod-repr-unwrap))
- [x] This PR follows our [AI policy](https://github.com/RustPython/.github/blob/main/AI_POLICY.md)

## Summary

- Propagate exceptions from the `repr()` implementations of `staticmethod` and `classmethod`.
- Add regression tests for both descriptor types.

`staticmethod` and `classmethod` used `repr(vm).unwrap()` in their `repr_str()` implementations, which turned exceptions raised by the wrapped object's `__repr__()` into Rust panics.

Since `repr_str()` already returns `PyResult<String>`, this change uses `?` to propagate the original Python exception unchanged, matching CPython's behavior.

## Testing

- `cargo run -- extra_tests/snippets/syntax_class.py`

Regression tests were added for both descriptor types. 
Before this change, both test cases triggered a Rust panic when the wrapped object's `__repr__()` raised an exception.

## AI assistance

Codex (GPT-5.6 Sol) was used to investigate and implement this change.
I reviewed and validated all AI-assisted work.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling when displaying `staticmethod` and `classmethod` objects.
  * Representation errors now propagate correctly instead of causing an unexpected application failure.

* **Tests**
  * Added coverage confirming that errors raised while representing wrapped callbacks are reported correctly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->