### PR TITLE
tuple: implement fmt::Debug trait for PyTuple

### DIFF
--- a/crates/vm/src/builtins/tuple.rs
+++ b/crates/vm/src/builtins/tuple.rs
@@ -31,10 +31,14 @@ pub struct PyTuple<R = PyObjectRef> {
     elements: Box<[R]>,
 }
 
-impl<R> fmt::Debug for PyTuple<R> {
+impl<R> fmt::Debug for PyTuple<R>
+where
+    R: fmt::Debug,
+{
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        // TODO: implement more informational, non-recursive Debug formatter
-        f.write_str("tuple")
+        f.debug_struct("PyTuple")
+            .field("elements", &self.elements)
+            .finish()
     }
 }
 


### PR DESCRIPTION
<!--
Thanks for your contribution!
-->

- [x] Closes #xxxx <!-- Replace xxxx with the GitHub issue number -->
- [x] This PR follows our [AI policy](https://github.com/RustPython/.github/blob/main/AI_POLICY.md)

## Summary
<!-- What's the purpose of the change? What does it do, and why? -->

This commit includes a change of the implementation of fmt::Debug trait for PyTuple.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved tuple debug output to display the tuple type and its elements instead of a generic placeholder.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->