### PR TITLE
Fix binascii.a2b_uu empty input

### DIFF
--- a/Lib/test/test_binascii.py
+++ b/Lib/test/test_binascii.py
@@ -222,7 +222,6 @@ class BinASCIITest(unittest.TestCase):
         assertInvalidLength(b'a' * (4 * 87 + 1))
         assertInvalidLength(b'A\tB\nC ??DE')  # only 5 valid characters
 
-    @unittest.expectedFailure  # TODO: RUSTPYTHON; AssertionError: Error not raised by a2b_uu
     def test_uu(self):
         MAX_UU = 45
         for backtick in (True, False):
@@ -445,7 +444,6 @@ class BinASCIITest(unittest.TestCase):
         self.assertConversion(binary, converted, restored,
                               quotetabs=quotetabs, istext=istext, header=header)
 
-    @unittest.expectedFailure  # TODO: RUSTPYTHON; AssertionError: Error not raised by a2b_uu
     def test_empty_string(self):
         # A test for SF bug #1022953.  Make sure SystemError is not raised.
         empty = self.type2test(b'')

--- a/crates/stdlib/src/binascii.rs
+++ b/crates/stdlib/src/binascii.rs
@@ -746,12 +746,12 @@ mod decl {
     #[pyfunction]
     fn a2b_uu(s: ArgAsciiBuffer, vm: &VirtualMachine) -> PyResult<Vec<u8>> {
         s.with_ref(|b| {
+            if b.is_empty() {
+                return Err(super::new_binascii_error("Missing length byte", vm));
+            }
+
             // First byte: binary data length (in bytes)
-            let length = if b.is_empty() {
-                ((-0x20i32) & 0x3fi32) as usize
-            } else {
-                ((b[0] - b' ') & 0x3f) as usize
-            };
+            let length = ((b[0] - b' ') & 0x3f) as usize;
 
             // Allocate the buffer
             let mut res = Vec::<u8>::with_capacity(length);


### PR DESCRIPTION
- [x] Closes #8388
- [x] This PR follows our [AI policy](https://github.com/RustPython/.github/blob/main/AI_POLICY.md)

## Summary

Make `binascii.a2b_uu(b\"\")` raise `binascii.Error`, matching CPython.

Previously, empty input was treated as a UU length byte and returned 32 NUL
bytes. It is now rejected before decoding with `binascii.Error: Missing length byte`.

## Testing

- `cargo run --release -- -m test test_binascii`
- `prek run --all-files`
- `cargo fmt --check`
- `cargo clippy -p rustpython-stdlib -- -D warnings`
- `cargo test -p rustpython-stdlib`
- Manual workspace test verification

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved UU-encoded data handling when the input is empty.
  * Empty input now returns a clear “Missing length byte” error instead of being processed incorrectly.
  * Valid inputs continue to be decoded as expected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->