### PR TITLE
Add new_payload_exception helper for constructing built-in payload exceptions

### DIFF
--- a/crates/vm/src/exceptions.rs
+++ b/crates/vm/src/exceptions.rs
@@ -2139,7 +2139,7 @@ pub(super) mod types {
                         .and_then(|errno| errno.try_to_primitive::<i32>(vm).ok())
                         .and_then(|errno| super::errno_to_exc_type(errno, vm))
                         .and_then(|typ| {
-                            vm.new_payload_exception::<PyOSError>(typ.to_owned(), args_vec.into())
+                            vm.new_payload_exception::<Self>(typ.to_owned(), args_vec.into())
                                 .ok()
                         })
                     {

--- a/crates/vm/src/exceptions.rs
+++ b/crates/vm/src/exceptions.rs
@@ -2138,7 +2138,9 @@ pub(super) mod types {
                         .downcast_ref::<PyInt>()
                         .and_then(|errno| errno.try_to_primitive::<i32>(vm).ok())
                         .and_then(|errno| super::errno_to_exc_type(errno, vm))
-                        .and_then(|typ| vm.invoke_exception(typ, args_vec).ok())
+                        .and_then(|typ| vm.new_payload_exception::<PyOSError>(
+                            typ.to_owned(), args_vec.into()).ok()
+                        )
                     {
                         return error.to_pyresult(vm);
                     }

--- a/crates/vm/src/exceptions.rs
+++ b/crates/vm/src/exceptions.rs
@@ -2138,9 +2138,10 @@ pub(super) mod types {
                         .downcast_ref::<PyInt>()
                         .and_then(|errno| errno.try_to_primitive::<i32>(vm).ok())
                         .and_then(|errno| super::errno_to_exc_type(errno, vm))
-                        .and_then(|typ| vm.new_payload_exception::<PyOSError>(
-                            typ.to_owned(), args_vec.into()).ok()
-                        )
+                        .and_then(|typ| {
+                            vm.new_payload_exception::<PyOSError>(typ.to_owned(), args_vec.into())
+                                .ok()
+                        })
                     {
                         return error.to_pyresult(vm);
                     }

--- a/crates/vm/src/exceptions.rs
+++ b/crates/vm/src/exceptions.rs
@@ -1385,14 +1385,8 @@ impl OSErrorBuilder {
             vec![strerror.to_pyobject(vm)]
         };
 
-        let payload = PyOSError::py_new(&exc_type, args.clone().into(), vm)
-            .expect("new_os_error usage error");
-        let os_error = payload
-            .into_ref_with_type_lazy_dict(vm, exc_type)
-            .expect("new_os_error usage error");
-        PyOSError::slot_init(os_error.as_object().to_owned(), args.into(), vm)
-            .expect("new_os_error usage error");
-        os_error
+        vm.new_payload_exception::<PyOSError>(exc_type, args.into())
+            .expect("new_os_error usage error")
     }
 }
 

--- a/crates/vm/src/stdlib/_io.rs
+++ b/crates/vm/src/stdlib/_io.rs
@@ -944,14 +944,17 @@ mod _io {
                     Some(n) => n,
                     None => {
                         // BlockingIOError(errno, msg, characters_written=0)
-                        return Err(vm.new_payload_exception::<PyOSError>(
-                            vm.ctx.exceptions.blocking_io_error.to_owned(),
-                            vec![
-                                vm.new_pyobj(EAGAIN),
-                                vm.new_pyobj("write could not complete without blocking"),
-                                vm.new_pyobj(0),
-                            ].into(),
-                        )?.upcast());
+                        return Err(vm
+                            .new_payload_exception::<PyOSError>(
+                                vm.ctx.exceptions.blocking_io_error.to_owned(),
+                                vec![
+                                    vm.new_pyobj(EAGAIN),
+                                    vm.new_pyobj("write could not complete without blocking"),
+                                    vm.new_pyobj(0),
+                                ]
+                                .into(),
+                            )?
+                            .upcast());
                     }
                 };
                 self.write_pos += n as Offset;
@@ -1155,14 +1158,17 @@ mod _io {
                     self.buffer[self.write_end as usize..][..avail].copy_from_slice(&buf[..avail]);
                     self.write_end += avail as Offset;
                     self.pos += avail as Offset;
-                    return Err(vm.new_payload_exception::<PyOSError>(
-                        vm.ctx.exceptions.blocking_io_error.to_owned(),
-                        vec![
-                            vm.new_pyobj(EAGAIN),
-                            vm.new_pyobj("write could not complete without blocking"),
-                            vm.new_pyobj(avail),
-                        ].into(),
-                    )?.upcast());
+                    return Err(vm
+                        .new_payload_exception::<PyOSError>(
+                            vm.ctx.exceptions.blocking_io_error.to_owned(),
+                            vec![
+                                vm.new_pyobj(EAGAIN),
+                                vm.new_pyobj("write could not complete without blocking"),
+                                vm.new_pyobj(avail),
+                            ]
+                            .into(),
+                        )?
+                        .upcast());
                 }
                 Err(e) => return Err(e),
             }
@@ -1201,14 +1207,17 @@ mod _io {
                         self.write_end = buffer_size;
                         // BlockingIOError(errno, msg, characters_written)
                         let chars_written = written + buffer_len;
-                        return Err(vm.new_payload_exception::<PyOSError>(
-                            vm.ctx.exceptions.blocking_io_error.to_owned(),
-                            vec![
-                                vm.new_pyobj(EAGAIN),
-                                vm.new_pyobj("write could not complete without blocking"),
-                                vm.new_pyobj(chars_written),
-                            ].into(),
-                        )?.upcast());
+                        return Err(vm
+                            .new_payload_exception::<PyOSError>(
+                                vm.ctx.exceptions.blocking_io_error.to_owned(),
+                                vec![
+                                    vm.new_pyobj(EAGAIN),
+                                    vm.new_pyobj("write could not complete without blocking"),
+                                    vm.new_pyobj(chars_written),
+                                ]
+                                .into(),
+                            )?
+                            .upcast());
                     }
                     None => break,
                 }

--- a/crates/vm/src/stdlib/_io.rs
+++ b/crates/vm/src/stdlib/_io.rs
@@ -20,7 +20,8 @@ cfg_select! {
 }
 
 use crate::{
-    AsObject, PyObject, PyObjectRef, PyResult, TryFromObject, VirtualMachine, builtins::PyModule,
+    AsObject, PyObject, PyObjectRef, PyResult, TryFromObject, VirtualMachine,
+    builtins::{PyModule, PyOSError},
 };
 pub use _io::{OpenArgs, io_open as open};
 use rustpython_host_env::io as host_io;
@@ -943,14 +944,14 @@ mod _io {
                     Some(n) => n,
                     None => {
                         // BlockingIOError(errno, msg, characters_written=0)
-                        return Err(vm.invoke_exception(
-                            vm.ctx.exceptions.blocking_io_error,
+                        return Err(vm.new_payload_exception::<PyOSError>(
+                            vm.ctx.exceptions.blocking_io_error.to_owned(),
                             vec![
                                 vm.new_pyobj(EAGAIN),
                                 vm.new_pyobj("write could not complete without blocking"),
                                 vm.new_pyobj(0),
-                            ],
-                        )?);
+                            ].into(),
+                        )?.upcast());
                     }
                 };
                 self.write_pos += n as Offset;
@@ -1154,14 +1155,14 @@ mod _io {
                     self.buffer[self.write_end as usize..][..avail].copy_from_slice(&buf[..avail]);
                     self.write_end += avail as Offset;
                     self.pos += avail as Offset;
-                    return Err(vm.invoke_exception(
-                        vm.ctx.exceptions.blocking_io_error,
+                    return Err(vm.new_payload_exception::<PyOSError>(
+                        vm.ctx.exceptions.blocking_io_error.to_owned(),
                         vec![
                             vm.new_pyobj(EAGAIN),
                             vm.new_pyobj("write could not complete without blocking"),
                             vm.new_pyobj(avail),
-                        ],
-                    )?);
+                        ].into(),
+                    )?.upcast());
                 }
                 Err(e) => return Err(e),
             }
@@ -1200,14 +1201,14 @@ mod _io {
                         self.write_end = buffer_size;
                         // BlockingIOError(errno, msg, characters_written)
                         let chars_written = written + buffer_len;
-                        return Err(vm.invoke_exception(
-                            vm.ctx.exceptions.blocking_io_error,
+                        return Err(vm.new_payload_exception::<PyOSError>(
+                            vm.ctx.exceptions.blocking_io_error.to_owned(),
                             vec![
                                 vm.new_pyobj(EAGAIN),
                                 vm.new_pyobj("write could not complete without blocking"),
                                 vm.new_pyobj(chars_written),
-                            ],
-                        )?);
+                            ].into(),
+                        )?.upcast());
                     }
                     None => break,
                 }

--- a/crates/vm/src/stdlib/_thread.rs
+++ b/crates/vm/src/stdlib/_thread.rs
@@ -635,8 +635,12 @@ pub(crate) mod _thread {
 
     #[pyfunction]
     fn exit(vm: &VirtualMachine) -> PyResult {
-        Err(vm.new_payload_exception::<PySystemExit>(
-            vm.ctx.exceptions.system_exit.to_owned(), vec![].into())?.upcast())
+        Err(vm
+            .new_payload_exception::<PySystemExit>(
+                vm.ctx.exceptions.system_exit.to_owned(),
+                vec![].into(),
+            )?
+            .upcast())
     }
 
     thread_local!(static SENTINELS: RefCell<Vec<PyRef<Lock>>> = const { RefCell::new(Vec::new()) });

--- a/crates/vm/src/stdlib/_thread.rs
+++ b/crates/vm/src/stdlib/_thread.rs
@@ -21,8 +21,8 @@ pub(crate) mod _thread {
     use crate::{
         AsObject, Py, PyPayload, PyRef, PyResult, VirtualMachine,
         builtins::{
-            PyBaseExceptionRef, PyDictRef, PyIntRef, PyStr, PyTupleRef, PyType, PyTypeRef,
-            PyUtf8StrRef,
+            PyBaseExceptionRef, PyDictRef, PyIntRef, PyStr, PySystemExit, PyTupleRef, PyType,
+            PyTypeRef, PyUtf8StrRef,
         },
         common::{lock::PyMutex, wtf8::Wtf8Buf},
         frame::FrameRef,
@@ -635,7 +635,8 @@ pub(crate) mod _thread {
 
     #[pyfunction]
     fn exit(vm: &VirtualMachine) -> PyResult {
-        Err(vm.invoke_exception(vm.ctx.exceptions.system_exit, vec![])?)
+        Err(vm.new_payload_exception::<PySystemExit>(
+            vm.ctx.exceptions.system_exit.to_owned(), vec![].into())?.upcast())
     }
 
     thread_local!(static SENTINELS: RefCell<Vec<PyRef<Lock>>> = const { RefCell::new(Vec::new()) });

--- a/crates/vm/src/stdlib/_thread.rs
+++ b/crates/vm/src/stdlib/_thread.rs
@@ -21,8 +21,8 @@ pub(crate) mod _thread {
     use crate::{
         AsObject, Py, PyPayload, PyRef, PyResult, VirtualMachine,
         builtins::{
-            PyBaseExceptionRef, PyDictRef, PyIntRef, PyStr, PySystemExit, PyTupleRef, PyType,
-            PyTypeRef, PyUtf8StrRef,
+            PyBaseExceptionRef, PyDictRef, PyIntRef, PyStr, PyTupleRef, PyType, PyTypeRef,
+            PyUtf8StrRef,
         },
         common::{lock::PyMutex, wtf8::Wtf8Buf},
         frame::FrameRef,
@@ -635,13 +635,7 @@ pub(crate) mod _thread {
 
     #[pyfunction]
     fn exit(vm: &VirtualMachine) -> PyResult {
-        Err(vm
-            .new_payload_exception::<PySystemExit>(
-                vm.ctx.exceptions.system_exit.to_owned(),
-                vec![].into(),
-            )
-            .expect("SystemExit is a BaseException Subclass.")
-            .upcast())
+        Err(vm.new_system_exit(vec![].into()))
     }
 
     thread_local!(static SENTINELS: RefCell<Vec<PyRef<Lock>>> = const { RefCell::new(Vec::new()) });

--- a/crates/vm/src/stdlib/_thread.rs
+++ b/crates/vm/src/stdlib/_thread.rs
@@ -639,7 +639,8 @@ pub(crate) mod _thread {
             .new_payload_exception::<PySystemExit>(
                 vm.ctx.exceptions.system_exit.to_owned(),
                 vec![].into(),
-            )?
+            )
+            .expect("SystemExit is a BaseException Subclass.")
             .upcast())
     }
 

--- a/crates/vm/src/stdlib/builtins.rs
+++ b/crates/vm/src/stdlib/builtins.rs
@@ -10,7 +10,7 @@ mod builtins {
     use crate::{
         AsObject, PyObject, PyObjectRef, PyPayload, PyRef, PyResult, TryFromObject, VirtualMachine,
         builtins::{
-            PyByteArray, PyBytes, PyDictRef, PyStr, PyStrRef, PyTuple, PyTupleRef, PyType,
+            PyByteArray, PyBytes, PyDictRef, PyStr, PyStrRef, PySystemExit, PyTuple, PyTupleRef, PyType,
             PyUtf8StrRef,
             enumerate::PyReverseSequenceIterator,
             function::{PyCell, PyCellRef, PyFunction},
@@ -1041,7 +1041,8 @@ mod builtins {
     #[pyfunction]
     pub(super) fn exit(exit_code_arg: OptionalArg<PyObjectRef>, vm: &VirtualMachine) -> PyResult {
         let code = exit_code_arg.unwrap_or_else(|| vm.ctx.new_int(0).into());
-        Err(vm.invoke_exception(vm.ctx.exceptions.system_exit, vec![code])?)
+        Err(vm.new_payload_exception::<PySystemExit>(
+            vm.ctx.exceptions.system_exit.to_owned(), vec![code].into())?.upcast())
     }
 
     #[derive(Debug, Default, FromArgs)]

--- a/crates/vm/src/stdlib/builtins.rs
+++ b/crates/vm/src/stdlib/builtins.rs
@@ -10,8 +10,8 @@ mod builtins {
     use crate::{
         AsObject, PyObject, PyObjectRef, PyPayload, PyRef, PyResult, TryFromObject, VirtualMachine,
         builtins::{
-            PyByteArray, PyBytes, PyDictRef, PyStr, PyStrRef, PySystemExit, PyTuple, PyTupleRef, PyType,
-            PyUtf8StrRef,
+            PyByteArray, PyBytes, PyDictRef, PyStr, PyStrRef, PySystemExit, PyTuple, PyTupleRef,
+            PyType, PyUtf8StrRef,
             enumerate::PyReverseSequenceIterator,
             function::{PyCell, PyCellRef, PyFunction},
             int::PyIntRef,
@@ -1041,8 +1041,12 @@ mod builtins {
     #[pyfunction]
     pub(super) fn exit(exit_code_arg: OptionalArg<PyObjectRef>, vm: &VirtualMachine) -> PyResult {
         let code = exit_code_arg.unwrap_or_else(|| vm.ctx.new_int(0).into());
-        Err(vm.new_payload_exception::<PySystemExit>(
-            vm.ctx.exceptions.system_exit.to_owned(), vec![code].into())?.upcast())
+        Err(vm
+            .new_payload_exception::<PySystemExit>(
+                vm.ctx.exceptions.system_exit.to_owned(),
+                vec![code].into(),
+            )?
+            .upcast())
     }
 
     #[derive(Debug, Default, FromArgs)]

--- a/crates/vm/src/stdlib/builtins.rs
+++ b/crates/vm/src/stdlib/builtins.rs
@@ -10,8 +10,8 @@ mod builtins {
     use crate::{
         AsObject, PyObject, PyObjectRef, PyPayload, PyRef, PyResult, TryFromObject, VirtualMachine,
         builtins::{
-            PyByteArray, PyBytes, PyDictRef, PyStr, PyStrRef, PySystemExit, PyTuple, PyTupleRef,
-            PyType, PyUtf8StrRef,
+            PyByteArray, PyBytes, PyDictRef, PyStr, PyStrRef, PyTuple, PyTupleRef, PyType,
+            PyUtf8StrRef,
             enumerate::PyReverseSequenceIterator,
             function::{PyCell, PyCellRef, PyFunction},
             int::PyIntRef,
@@ -1041,13 +1041,7 @@ mod builtins {
     #[pyfunction]
     pub(super) fn exit(exit_code_arg: OptionalArg<PyObjectRef>, vm: &VirtualMachine) -> PyResult {
         let code = exit_code_arg.unwrap_or_else(|| vm.ctx.new_int(0).into());
-        Err(vm
-            .new_payload_exception::<PySystemExit>(
-                vm.ctx.exceptions.system_exit.to_owned(),
-                vec![code].into(),
-            )
-            .expect("SystemExit is a BaseException Subclass.")
-            .upcast())
+        Err(vm.new_system_exit(vec![code].into()))
     }
 
     #[derive(Debug, Default, FromArgs)]

--- a/crates/vm/src/stdlib/builtins.rs
+++ b/crates/vm/src/stdlib/builtins.rs
@@ -1045,7 +1045,8 @@ mod builtins {
             .new_payload_exception::<PySystemExit>(
                 vm.ctx.exceptions.system_exit.to_owned(),
                 vec![code].into(),
-            )?
+            )
+            .expect("SystemExit is a BaseException Subclass.")
             .upcast())
     }
 

--- a/crates/vm/src/stdlib/sys.rs
+++ b/crates/vm/src/stdlib/sys.rs
@@ -776,10 +776,12 @@ pub mod sys {
         } else {
             vec![status]
         };
-        let exc = vm.new_payload_exception::<PySystemExit>(
-            vm.ctx.exceptions.system_exit.to_owned(),
-            args.into(),
-        )?;
+        let exc = vm
+            .new_payload_exception::<PySystemExit>(
+                vm.ctx.exceptions.system_exit.to_owned(),
+                args.into(),
+            )
+            .expect("SystemExit is a BaseException Subclass.");
         Err(exc.upcast())
     }
 

--- a/crates/vm/src/stdlib/sys.rs
+++ b/crates/vm/src/stdlib/sys.rs
@@ -36,8 +36,8 @@ pub mod sys {
     use crate::{
         AsObject, PyObject, PyObjectRef, PyPayload, PyRef, PyRefExact, PyResult,
         builtins::{
-            PyBaseExceptionRef, PyDictRef, PyFrozenSet, PyNamespace, PyStr, PyStrRef, PyTuple,
-            PyTupleRef, PyTypeRef, PyUtf8StrRef,
+            PyBaseExceptionRef, PyDictRef, PyFrozenSet, PyNamespace, PyStr, PyStrRef, PySystemExit,
+            PyTuple, PyTupleRef, PyTypeRef, PyUtf8StrRef,
         },
         common::{
             ascii,
@@ -776,8 +776,9 @@ pub mod sys {
         } else {
             vec![status]
         };
-        let exc = vm.invoke_exception(vm.ctx.exceptions.system_exit, args)?;
-        Err(exc)
+        let exc = vm.new_payload_exception::<PySystemExit>(
+            vm.ctx.exceptions.system_exit.to_owned(), args.into())?;
+        Err(exc.upcast())
     }
 
     #[pyfunction]

--- a/crates/vm/src/stdlib/sys.rs
+++ b/crates/vm/src/stdlib/sys.rs
@@ -36,8 +36,8 @@ pub mod sys {
     use crate::{
         AsObject, PyObject, PyObjectRef, PyPayload, PyRef, PyRefExact, PyResult,
         builtins::{
-            PyBaseExceptionRef, PyDictRef, PyFrozenSet, PyNamespace, PyStr, PyStrRef, PySystemExit,
-            PyTuple, PyTupleRef, PyTypeRef, PyUtf8StrRef,
+            PyBaseExceptionRef, PyDictRef, PyFrozenSet, PyNamespace, PyStr, PyStrRef, PyTuple,
+            PyTupleRef, PyTypeRef, PyUtf8StrRef,
         },
         common::{
             ascii,
@@ -776,13 +776,7 @@ pub mod sys {
         } else {
             vec![status]
         };
-        let exc = vm
-            .new_payload_exception::<PySystemExit>(
-                vm.ctx.exceptions.system_exit.to_owned(),
-                args.into(),
-            )
-            .expect("SystemExit is a BaseException Subclass.");
-        Err(exc.upcast())
+        Err(vm.new_system_exit(args.into()))
     }
 
     #[pyfunction]

--- a/crates/vm/src/stdlib/sys.rs
+++ b/crates/vm/src/stdlib/sys.rs
@@ -777,7 +777,9 @@ pub mod sys {
             vec![status]
         };
         let exc = vm.new_payload_exception::<PySystemExit>(
-            vm.ctx.exceptions.system_exit.to_owned(), args.into())?;
+            vm.ctx.exceptions.system_exit.to_owned(),
+            args.into(),
+        )?;
         Err(exc.upcast())
     }
 

--- a/crates/vm/src/vm/mod.rs
+++ b/crates/vm/src/vm/mod.rs
@@ -43,6 +43,8 @@ use crate::{
     stdlib,
     warn::WarningsState,
 };
+#[cfg(feature = "threading")]
+use crate::builtins::PySystemExit;
 use alloc::{borrow::Cow, collections::BTreeMap};
 #[cfg(all(not(unix), feature = "threading"))]
 use core::ptr::NonNull;
@@ -2167,7 +2169,8 @@ impl VirtualMachine {
         if self.state.finalizing.load(Ordering::Acquire) && !self.is_main_thread() {
             // once finalization starts,
             // non-main Python threads should stop running bytecode.
-            return Err(self.invoke_exception(self.ctx.exceptions.system_exit, vec![])?);
+            return Err(self.new_payload_exception::<PySystemExit>(
+                self.ctx.exceptions.system_exit.to_owned(), vec![].into())?.upcast());
         }
 
         // Suspend this thread if stop-the-world is in progress

--- a/crates/vm/src/vm/mod.rs
+++ b/crates/vm/src/vm/mod.rs
@@ -2173,7 +2173,8 @@ impl VirtualMachine {
                 .new_payload_exception::<PySystemExit>(
                     self.ctx.exceptions.system_exit.to_owned(),
                     vec![].into(),
-                )?
+                )
+                .expect("SystemExit is a BaseException Subclass.")
                 .upcast());
         }
 

--- a/crates/vm/src/vm/mod.rs
+++ b/crates/vm/src/vm/mod.rs
@@ -19,6 +19,8 @@ mod vm_new;
 mod vm_object;
 mod vm_ops;
 
+#[cfg(feature = "threading")]
+use crate::builtins::PySystemExit;
 use crate::{
     AsObject, Py, PyObject, PyObjectRef, PyPayload, PyRef, PyResult,
     builtins::{
@@ -43,8 +45,6 @@ use crate::{
     stdlib,
     warn::WarningsState,
 };
-#[cfg(feature = "threading")]
-use crate::builtins::PySystemExit;
 use alloc::{borrow::Cow, collections::BTreeMap};
 #[cfg(all(not(unix), feature = "threading"))]
 use core::ptr::NonNull;
@@ -2169,8 +2169,12 @@ impl VirtualMachine {
         if self.state.finalizing.load(Ordering::Acquire) && !self.is_main_thread() {
             // once finalization starts,
             // non-main Python threads should stop running bytecode.
-            return Err(self.new_payload_exception::<PySystemExit>(
-                self.ctx.exceptions.system_exit.to_owned(), vec![].into())?.upcast());
+            return Err(self
+                .new_payload_exception::<PySystemExit>(
+                    self.ctx.exceptions.system_exit.to_owned(),
+                    vec![].into(),
+                )?
+                .upcast());
         }
 
         // Suspend this thread if stop-the-world is in progress

--- a/crates/vm/src/vm/mod.rs
+++ b/crates/vm/src/vm/mod.rs
@@ -19,8 +19,6 @@ mod vm_new;
 mod vm_object;
 mod vm_ops;
 
-#[cfg(feature = "threading")]
-use crate::builtins::PySystemExit;
 use crate::{
     AsObject, Py, PyObject, PyObjectRef, PyPayload, PyRef, PyResult,
     builtins::{
@@ -2169,13 +2167,7 @@ impl VirtualMachine {
         if self.state.finalizing.load(Ordering::Acquire) && !self.is_main_thread() {
             // once finalization starts,
             // non-main Python threads should stop running bytecode.
-            return Err(self
-                .new_payload_exception::<PySystemExit>(
-                    self.ctx.exceptions.system_exit.to_owned(),
-                    vec![].into(),
-                )
-                .expect("SystemExit is a BaseException Subclass.")
-                .upcast());
+            return Err(self.new_system_exit(vec![].into()));
         }
 
         // Suspend this thread if stop-the-world is in progress

--- a/crates/vm/src/vm/vm_new.rs
+++ b/crates/vm/src/vm/vm_new.rs
@@ -13,7 +13,7 @@ use crate::{
     AsObject, Py, PyObject, PyObjectRef, PyPayload, PyRef, PyResult,
     builtins::{
         PyBaseException, PyBaseExceptionRef, PyBytesRef, PyDictRef, PyModule, PyOSError,
-        PyStopIteration, PyStrRef, PyType, PyTypeRef,
+        PyStopIteration, PyStrRef, PySystemExit, PyType, PyTypeRef,
         builtin_func::PyNativeFunction,
         descriptor::PyMethodDescriptor,
         tuple::{IntoPyTuple, PyTupleRef},
@@ -914,13 +914,19 @@ impl VirtualMachine {
         exc
     }
 
+    pub fn new_system_exit(&self, args: FuncArgs) -> PyBaseExceptionRef {
+        self.new_payload_exception::<PySystemExit>(self.ctx.exceptions.system_exit.to_owned(), args)
+            .expect("SystemExit construction from internal args is infallible")
+            .upcast()
+    }
+
     pub fn new_stop_iteration(&self, value: Option<PyObjectRef>) -> PyBaseExceptionRef {
         let args: FuncArgs = value.map(|v| vec![v]).unwrap_or_default().into();
         self.new_payload_exception::<PyStopIteration>(
             self.ctx.exceptions.stop_iteration.to_owned(),
             args,
         )
-        .expect("StopIteration is a BaseException Subclass.")
+        .expect("StopIteration construction from internal args is infallible")
         // `PyStopIteration` -> `PyBaseException` needs an owned upcast here.
         // `.upcast()` does a runtime downcast; the zero-cost `upcast_ref`/`to_base`
         // only return `&Py<_>`, which doesn't fit the owned `PyBaseExceptionRef`

--- a/crates/vm/src/vm/vm_new.rs
+++ b/crates/vm/src/vm/vm_new.rs
@@ -361,6 +361,13 @@ impl VirtualMachine {
     where
         T: Constructor<Args = FuncArgs> + Initializer,
     {
+        debug_assert_eq!(
+            cls.slots.basicsize,
+            size_of::<T>(),
+            "vm.new_payload_exception::<{}>() called with mismatched type '{}'",
+            core::any::type_name::<T>(),
+            cls.name()
+        );
         let payload = T::py_new(&cls, args.clone(), self)?;
         let exc = payload.into_ref_with_type_lazy_dict(self, cls)?;
         T::slot_init(exc.as_object().to_owned(), args, self)?;

--- a/crates/vm/src/vm/vm_new.rs
+++ b/crates/vm/src/vm/vm_new.rs
@@ -12,17 +12,18 @@ use rustpython_compiler::{CompileError, ParseError};
 use crate::{
     AsObject, Py, PyObject, PyObjectRef, PyPayload, PyRef, PyResult,
     builtins::{
-        PyBaseException, PyBaseExceptionRef, PyBytesRef, PyDictRef, PyModule, PyOSError, PyStrRef,
-        PyType, PyTypeRef,
+        PyBaseException, PyBaseExceptionRef, PyBytesRef, PyDictRef, PyModule, PyOSError,
+        PyStopIteration, PyStrRef, PyType, PyTypeRef,
         builtin_func::PyNativeFunction,
         descriptor::PyMethodDescriptor,
         tuple::{IntoPyTuple, PyTupleRef},
     },
     convert::{ToPyException, ToPyObject},
     exceptions::OSErrorBuilder,
-    function::{IntoPyNativeFn, PyMethodFlags},
+    function::{FuncArgs, IntoPyNativeFn, PyMethodFlags},
     scope::Scope,
     set_attrs,
+    types::{Constructor, Initializer},
     vm::VirtualMachine,
 };
 
@@ -351,6 +352,19 @@ impl VirtualMachine {
         PyBaseException::new(args, self)
             .into_ref_with_type_lazy_dict(self, exc_type)
             .expect("vm.new_exception() called with an invalid exception type")
+    }
+
+    /// Construct a built-in exception type that carries a payload, directly
+    /// (`py_new` + `slot_init`), without routing through `PyType::call`.
+    /// Only valid for a built-in `T` whose exact type is known at compile time.
+    pub fn new_payload_exception<T>(&self, cls: PyTypeRef, args: FuncArgs) -> PyResult<PyRef<T>>
+    where
+        T: Constructor<Args = FuncArgs> + Initializer,
+    {
+        let payload = T::py_new(&cls, args.clone(), self)?;
+        let exc = payload.into_ref_with_type_lazy_dict(self, cls)?;
+        T::slot_init(exc.as_object().to_owned(), args, self)?;
+        Ok(exc)
     }
 
     pub fn new_os_error(&self, msg: impl ToPyObject) -> PyRef<PyBaseException> {
@@ -894,15 +908,17 @@ impl VirtualMachine {
     }
 
     pub fn new_stop_iteration(&self, value: Option<PyObjectRef>) -> PyBaseExceptionRef {
-        let stop_iteration_error = self.ctx.exceptions.stop_iteration;
-        let args = if let Some(value) = value {
-            vec![value]
-        } else {
-            Vec::new()
-        };
-        let exc = self.invoke_exception(stop_iteration_error, args);
-
-        exc.expect("StopIteration is a BaseException Subclass.")
+        let args: FuncArgs = value.map(|v| vec![v]).unwrap_or_default().into();
+        self.new_payload_exception::<PyStopIteration>(
+            self.ctx.exceptions.stop_iteration.to_owned(),
+            args,
+        )
+        .expect("StopIteration is a BaseException Subclass.")
+        // `PyStopIteration` -> `PyBaseException` needs an owned upcast here.
+        // `.upcast()` does a runtime downcast; the zero-cost `upcast_ref`/`to_base`
+        // only return `&Py<_>`, which doesn't fit the owned `PyBaseExceptionRef`
+        // return. Keeping the downcast for now.
+        .upcast()
     }
 
     fn new_downcast_error(

--- a/crates/vm/src/vm/vm_new.rs
+++ b/crates/vm/src/vm/vm_new.rs
@@ -927,10 +927,6 @@ impl VirtualMachine {
             args,
         )
         .expect("StopIteration construction from internal args is infallible")
-        // `PyStopIteration` -> `PyBaseException` needs an owned upcast here.
-        // `.upcast()` does a runtime downcast; the zero-cost `upcast_ref`/`to_base`
-        // only return `&Py<_>`, which doesn't fit the owned `PyBaseExceptionRef`
-        // return. Keeping the downcast for now.
         .upcast()
     }
 


### PR DESCRIPTION
- [x] This PR follows our [AI policy](https://github.com/RustPython/.github/blob/main/AI_POLICY.md)

Follow-up to #8348.

## Summary

Adds `new_payload_exception`, a generic helper for constructing built-in payload exceptions (a `#[repr(C)]` struct with extra fields, e.g. `SystemExit.code`, `StopIteration.value`, the `OSError` fields) whose type is known at compile time. It builds them directly with `py_new` + `slot_init` instead of going through `PyType::call`, and replaces the ad hoc construction in the internal builders.

## Background

Payload exceptions were introduced in #8282 (`SystemExit.code`) and #8301 (`StopIteration.value`), where the value moved from the instance dict into a real struct field. Constructing them currently happens either through `PyType::call` (via `invoke_exception`) or through a bespoke per-type builder like `OSErrorBuilder`. This adds a single direct path for the internal builders that know their exact type at compile time:

```rust
pub fn new_payload_exception<T>(&self, cls: PyTypeRef, args: FuncArgs) -> PyResult<PyRef<T>>
where
    T: Constructor<Args = FuncArgs> + Initializer,
{
    let payload = T::py_new(&cls, args.clone(), self)?;
    // cls not matching T structurally is a caller bug, not a runtime error
    let exc = payload
        .into_ref_with_type_lazy_dict(self, cls)
        .expect("new_payload_exception: cls is not a matching subtype of T");
    T::slot_init(exc.as_object().to_owned(), args, self)?;
    Ok(exc)
}
```

`new_exception` stays as the thin, restricted fast path for payload-free types. `invoke_exception` stays for construction where the concrete type is only known at runtime and a compile-time `T` cannot express it: `raise <expr>`, the C-API entry, and ctypes `COMError`. `BaseExceptionGroup` is left as is too, since it is `repr(transparent)` and carries no extra payload.

## Call sites

This routes the internal builders that know their type at compile time through the helper:

- `new_stop_iteration` and `OSErrorBuilder`, the simplest and most complex payload exceptions respectively
- `SystemExit` raise sites: builtins `exit`, `sys.exit`, `_thread.exit`, and the finalization check in `check_signals`
- `BlockingIOError` raise sites in `_io`
- the errno-based OSError subtype dispatch in `PyOSError::slot_new`. The target subtype is chosen at runtime, but every result of `errno_to_exc_type` is a `repr(transparent)` OSError subtype, so `PyOSError` is a valid payload type for all of them

## What this buys

The main effect is on `invoke_exception`. Once these sites move off it, `invoke_exception` is left holding only construction that is genuinely runtime-typed (`raise <expr>`, C-API, `COMError`), so its role is explicit rather than a catch-all. Going through the helper also skips `PyType::call`, which for each construction avoids two slot lookups, the `__new__` and `__init__` indirect calls, an args clone, and a subclass check. For the hot sites (`StopIteration` on iterator exhaustion, and the errno OSError path) that saving is real per call. For the cold raise sites (`SystemExit`, `BlockingIOError`) it is not measurable.

## Notes

Two things I would welcome feedback on:

- For the cold sites the change is consistency-driven, not a perf win. It makes every internal payload construction go through one helper and narrows `invoke_exception` to the runtime-typed path, but those raise sites are rare. Happy to land only the higher-value sites if the consistency-only ones aren't worth the churn.
- The owned upcast has a cost of its own. Call sites that return `PyBaseExceptionRef` upcast the helper's `PyRef<T>`, and `.upcast()` goes through a runtime downcast (the zero-cost `upcast_ref`/`to_base` only yield `&Py<_>`). So the migration trades `PyType::call`'s slot dispatch for a smaller runtime downcast: a net reduction in steps where it is hot, and a wash where it is cold. If there is a zero-cost owned upcast I missed, I would rather use that.

Assisted-by: claude-fable-5

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved construction and handling of built-in exceptions, including `OSError`, `BlockingIOError`, `SystemExit`, and `StopIteration`.
  * Preserved error details such as messages, errno values, exit arguments, and characters written during I/O operations.
  * Improved exception behavior during thread shutdown and I/O-related operations.
* **Compatibility**
  * Existing exception behavior and public interfaces remain consistent.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->