### PR TITLE
Bind method descriptor when `__get__` owner is omitted

### DIFF
--- a/Lib/test/test_types.py
+++ b/Lib/test/test_types.py
@@ -660,7 +660,6 @@ class TypesTests(unittest.TestCase):
         self.assertIsInstance(int.from_bytes, types.BuiltinMethodType)
         self.assertIsInstance(int.__new__, types.BuiltinMethodType)
 
-    @unittest.expectedFailure  # TODO: RUSTPYTHON; TypeError: descriptor 'read' needs a type, not 'StringIO', as arg 2
     def test_method_descriptor_crash(self):
         # gh-132747: The default __get__() implementation in C was unable
         # to handle a second argument of None when called from Python

--- a/crates/vm/src/builtins/descriptor.rs
+++ b/crates/vm/src/builtins/descriptor.rs
@@ -79,7 +79,10 @@ impl GetDescriptor for PyMethodDescriptor {
         let bound = match obj {
             Some(obj) => {
                 if descr.method.flags.contains(PyMethodFlags::METHOD) {
-                    if cls.is_some_and(|c| c.fast_isinstance(vm.ctx.types.type_type)) {
+                    if cls
+                        .as_ref()
+                        .is_none_or(|c| c.fast_isinstance(vm.ctx.types.type_type))
+                    {
                         obj
                     } else {
                         return Err(vm.new_type_error(format!(


### PR DESCRIPTION
- [x] Closes #8375
- [x] This PR follows our [AI policy](https://github.com/RustPython/.github/blob/main/AI_POLICY.md)

## Summary

`method_descriptor.__get__(obj)` raised `TypeError: descriptor '...' needs a type, not '...', as arg 2` when the owner (the second argument) was omitted:

```python
import _io, io
_io._TextIOBase.read.__get__(io.StringIO())   # TypeError on RustPython, works on CPython
```

The owner is optional in the descriptor protocol; CPython binds to `obj` when it is not supplied, and only rejects a *non-type* owner.

## Cause

The `METHOD`-flag branch of `PyMethodDescriptor::descr_get` gated binding on `cls.is_some_and(|c| c.fast_isinstance(type))`, so an omitted owner (`cls == None`) fell through to the "needs a type" error.

## Fix

Use `cls.as_ref().is_none_or(...)`: a missing owner binds to `obj`, while a non-type owner still raises "needs a type, not ...".

## Test plan

Verified against CPython 3.14.6 — owner omitted binds, non-type owner raises, type owner binds:

- Unmarks `test_types`'s `test_method_descriptor_crash` (removes its `@expectedFailure`); it now passes.
- `test_types` / `test_descr`: pass, no regressions (the non-type-owner "needs a type" path in `test_descr` still holds).
- `cargo build` / `cargo clippy -p rustpython-vm` / `cargo fmt --check`: clean.
