### PR TITLE
Add seekable() to mmap.mmap

### DIFF
--- a/crates/stdlib/src/mmap.rs
+++ b/crates/stdlib/src/mmap.rs
@@ -1142,7 +1142,7 @@ mod mmap {
         }
 
         #[pymethod]
-        const fn seekable(&self) -> bool {
+        fn seekable(&self) -> bool {
             true
         }
 

--- a/crates/stdlib/src/mmap.rs
+++ b/crates/stdlib/src/mmap.rs
@@ -1142,6 +1142,11 @@ mod mmap {
         }
 
         #[pymethod]
+        const fn seekable(&self) -> bool {
+            true
+        }
+
+        #[pymethod]
         fn write(&self, bytes: ArgBytesLike, vm: &VirtualMachine) -> PyResult<PyIntRef> {
             let pos = self.pos();
             let size = self.__len__();

--- a/extra_tests/snippets/stdlib_mmap.py
+++ b/extra_tests/snippets/stdlib_mmap.py
@@ -1,6 +1,5 @@
 import mmap
 
-
 mapped = mmap.mmap(-1, 1)
 assert mapped.seekable()
 mapped.close()

--- a/extra_tests/snippets/stdlib_mmap.py
+++ b/extra_tests/snippets/stdlib_mmap.py
@@ -1,0 +1,7 @@
+import mmap
+
+
+mapped = mmap.mmap(-1, 1)
+assert mapped.seekable()
+mapped.close()
+assert mapped.seekable()


### PR DESCRIPTION
- [x] Closes #8401
- [x] This PR follows our [AI policy](https://github.com/RustPython/.github/blob/main/AI_POLICY.md)

## Summary

Add `mmap.mmap.seekable()`, matching CPython for open and closed mappings.

## Testing

- `cargo run --release -- -m test test_mmap`
- `cargo run -- extra_tests/snippets/stdlib_mmap.py`
- `cargo clippy -p rustpython-stdlib -- -D warnings`
- `cargo test -p rustpython-stdlib`
- `prek run --all-files`
- `cd extra_tests && pytest -v` (406 passed)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `mmap.mmap.seekable()` to report whether a memory-mapped object is seekable (always returns `true`).

* **Tests**
  * Added coverage for `seekable()` on an in-memory mapping before and after closing it.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->