### PR TITLE
Fix x86_64-pc-windows-gnu build

### DIFF
--- a/.github/actions/install-linux-deps/action.yml
+++ b/.github/actions/install-linux-deps/action.yml
@@ -29,6 +29,10 @@ inputs:
     description: Install gcc-aarch64-linux-gnu (gcc-aarch64-linux-gnu)
     required: false
     default: "false"
+  gcc-mingw-w64-x86-64:
+    description: Install gcc-mingw-w64-x86-64 (gcc-mingw-w64-x86-64)
+    required: false
+    default: "false"
   clang:
     description: Install clang (clang)
     required: false
@@ -44,6 +48,7 @@ runs:
         MUSL_TOOLS: ${{ inputs.musl-tools }}
         CLANG: ${{ inputs.clang }}
         GCC_AARCH64_LINUX_GNU: ${{ inputs.gcc-aarch64-linux-gnu }}
+        GCC_MINGW_W64_X86_64: ${{ inputs.gcc-mingw-w64-x86-64 }}
       run: |
         if ! sudo apt-get update; then
           echo "::warning::apt-get update failed; disabling nonessential Microsoft apt sources and retrying"
@@ -67,6 +72,9 @@ runs:
         fi
         if [[ "$GCC_AARCH64_LINUX_GNU" == "true" ]]; then
           packages+=(gcc-aarch64-linux-gnu linux-libc-dev-arm64-cross libc6-dev-arm64-cross)
+        fi
+        if [[ "$GCC_MINGW_W64_X86_64" == "true" ]]; then
+          packages+=(gcc-mingw-w64-x86-64)
         fi
 
         if ((${#packages[@]})); then

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -198,6 +198,10 @@ jobs:
           target: aarch64-unknown-linux-gnu
           dependencies:
             gcc-aarch64-linux-gnu: true
+        - os: ubuntu-latest
+          target: x86_64-pc-windows-gnu
+          dependencies:
+            gcc-mingw-w64-x86-64: true
         - os: macos-latest
           target: aarch64-apple-ios
         - os: macos-latest
@@ -216,6 +220,7 @@ jobs:
           gcc-multilib: ${{ matrix.dependencies.gcc-multilib || false }}
           musl-tools: ${{ matrix.dependencies.musl-tools || false }}
           gcc-aarch64-linux-gnu: ${{ matrix.dependencies.gcc-aarch64-linux-gnu || false }}
+          gcc-mingw-w64-x86-64: ${{ matrix.dependencies.gcc-mingw-w64-x86-64 || false }}
 
       - name: Restore cache
         uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0

--- a/crates/host_env/src/time.rs
+++ b/crates/host_env/src/time.rs
@@ -317,7 +317,7 @@ pub fn gethrvtime_duration() -> Duration {
     Duration::from_nanos(unsafe { libc::gethrvtime() })
 }
 
-#[cfg(target_env = "msvc")]
+#[cfg(windows)]
 #[cfg(not(target_arch = "wasm32"))]
 #[derive(Clone, Debug)]
 pub struct WindowsTimeZoneInfo {
@@ -328,7 +328,7 @@ pub struct WindowsTimeZoneInfo {
     pub daylight_name: String,
 }
 
-#[cfg(target_env = "msvc")]
+#[cfg(windows)]
 #[cfg(not(target_arch = "wasm32"))]
 fn decode_tz_name(name: &[u16]) -> String {
     widestring::decode_utf16_lossy(name.iter().copied())
@@ -336,7 +336,7 @@ fn decode_tz_name(name: &[u16]) -> String {
         .collect()
 }
 
-#[cfg(target_env = "msvc")]
+#[cfg(windows)]
 #[cfg(not(target_arch = "wasm32"))]
 #[must_use]
 pub fn get_tz_info() -> WindowsTimeZoneInfo {

--- a/crates/vm/src/stdlib/time.rs
+++ b/crates/vm/src/stdlib/time.rs
@@ -195,7 +195,7 @@ mod decl {
         Ok(get_perf_time(vm)?.as_nanos())
     }
 
-    #[cfg(target_env = "msvc")]
+    #[cfg(windows)]
     #[cfg(not(target_arch = "wasm32"))]
     pub(super) fn get_tz_info() -> host_time::WindowsTimeZoneInfo {
         host_time::get_tz_info()


### PR DESCRIPTION
A few functions were improperly gated to MSVC. Those functions call `windows-sys` so they're not MSVC.

<!--
Thanks for your contribution!
-->

- [ ] Closes #xxxx <!-- Replace xxxx with the GitHub issue number -->
- [x] This PR follows our [AI policy](https://github.com/RustPython/.github/blob/main/AI_POLICY.md)

## Summary
<!-- What's the purpose of the change? What does it do, and why? -->

* Fixes a build error for the `x86_64-pc-windows-gnu` target

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Expanded Windows time zone support beyond MSVC, enabling the time-zone information API on additional Windows targets (excluding WASM).
* **CI**
  * Broadened build verification by adding an `x86_64-pc-windows-gnu` target to the CI `cargo check` matrix.
  * Updated the Linux dependency installer to optionally install the MinGW-w64 toolchain needed for that target.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->