### PR TITLE
ast: match CPython argument validation order

### DIFF
--- a/Lib/test/test_ast/test_ast.py
+++ b/Lib/test/test_ast/test_ast.py
@@ -2055,7 +2055,6 @@ class ASTValidatorTests(unittest.TestCase):
                           kw_defaults=[None, ast.Name("x", ast.Store())]),
                           "must have Load context")
 
-    @unittest.expectedFailure  # TODO: RUSTPYTHON; ValueError not raised
     def test_funcdef(self):
         a = ast.arguments([], [], None, [], [], None, [])
         f = ast.FunctionDef("x", a, [], [], None, None, [])
@@ -2267,7 +2266,6 @@ class ASTValidatorTests(unittest.TestCase):
         u = ast.UnaryOp(ast.Not(), ast.Name("x", ast.Store()))
         self.expr(u, "must have Load context")
 
-    @unittest.expectedFailure  # TODO: RUSTPYTHON; ValueError not raised
     def test_lambda(self):
         a = ast.arguments([], [], None, [], [], None, [])
         self.expr(ast.Lambda(a, ast.Name("x", ast.Store())),

--- a/crates/vm/src/stdlib/_ast/parameter.rs
+++ b/crates/vm/src/stdlib/_ast/parameter.rs
@@ -88,14 +88,23 @@ impl Node for ast::Parameters {
             "arguments",
         )?;
 
+        validate_parameter_annotations(
+            vm,
+            &posonlyargs,
+            &args,
+            vararg.as_deref(),
+            &kwonlyargs,
+            kwarg.as_deref(),
+        )?;
+
         let ParameterDefaults {
             runtime_defaults,
             defaults,
             _range: _,
         } = defaults;
-        let kwonlyargs = merge_keyword_parameter_defaults(vm, kwonlyargs, kw_defaults)?;
         let (posonlyargs, args) =
             merge_positional_parameter_defaults(vm, posonlyargs, args, defaults)?;
+        let kwonlyargs = merge_keyword_parameter_defaults(vm, kwonlyargs, kw_defaults)?;
 
         Ok(Self {
             node_index: Default::default(),
@@ -112,6 +121,29 @@ impl Node for ast::Parameters {
     fn is_none(&self) -> bool {
         self.is_empty()
     }
+}
+
+fn validate_parameter_annotations(
+    vm: &VirtualMachine,
+    posonlyargs: &PositionalParameters,
+    args: &PositionalParameters,
+    vararg: Option<&ast::Parameter>,
+    kwonlyargs: &KeywordParameters,
+    kwarg: Option<&ast::Parameter>,
+) -> PyResult<()> {
+    for parameter in posonlyargs.args.iter().chain(&args.args) {
+        super::validate::validate_parameter_annotation(vm, parameter)?;
+    }
+    if let Some(parameter) = vararg {
+        super::validate::validate_parameter_annotation(vm, parameter)?;
+    }
+    for parameter in &kwonlyargs.keywords {
+        super::validate::validate_parameter_annotation(vm, parameter)?;
+    }
+    if let Some(parameter) = kwarg {
+        super::validate::validate_parameter_annotation(vm, parameter)?;
+    }
+    Ok(())
 }
 
 // product

--- a/crates/vm/src/stdlib/_ast/validate.rs
+++ b/crates/vm/src/stdlib/_ast/validate.rs
@@ -56,7 +56,10 @@ fn validate_keywords(vm: &VirtualMachine, keywords: &[ast::Keyword]) -> PyResult
     Ok(())
 }
 
-fn validate_parameter_annotation(vm: &VirtualMachine, parameter: &ast::Parameter) -> PyResult<()> {
+pub(super) fn validate_parameter_annotation(
+    vm: &VirtualMachine,
+    parameter: &ast::Parameter,
+) -> PyResult<()> {
     if let Some(annotation) = &parameter.annotation {
         validate_expr(vm, annotation, ast::ExprContext::Load)?;
     }


### PR DESCRIPTION
- [ ] Closes #xxxx <!-- Replace xxxx with the GitHub issue number -->
- [x] This PR follows our [AI policy](https://github.com/RustPython/.github/blob/main/AI_POLICY.md)

## Summary

Match CPython's `ast.arguments` validation order when compiling a Python AST
object.

RustPython previously merged keyword-only defaults before validating parameter
annotations. Consequently, an invalid `Store` context in an annotation could
be hidden by a `kw_defaults` length error. It also reported that keyword-only
length error before an excess positional-default error.

Validate parameter annotations before either default-list merge, then merge
positional defaults before keyword-only defaults. This preserves the existing
validation rule while giving errors the same precedence as CPython.

Remove the `expectedFailure` markers from the FunctionDef and Lambda AST
validator tests, which now pass without changing their assertions or data.

## Testing

- `uv tool run prek run --all-files`
- `cargo fmt --check`
- `cargo run --release Lib/test/test_ast/test_ast.py`
  - 227 tests run
  - 7 skipped
  - 19 expected failures
- `cargo run --release -- -m test test_ast`
- `cargo run -- extra_tests/snippets/stdlib_ast.py`
- `cargo clippy -p rustpython-stdlib --all-targets`
- the configured workspace test suite

<details>
<summary>Workspace test command</summary>

`rustpython-capi` is tested separately in CI; its test binary previously could
not load `libpython3.14.so.1.0` in this local environment.
`rustpython-compiler-source` is deprecated and is excluded from CI workspace
builds as well.

```bash
cargo test --workspace \
    --exclude rustpython-capi \
    --exclude rustpython_wasm \
    --exclude rustpython-compiler-source \
    --exclude rustpython-venvlauncher \
    --features threading \
    -- --quiet
```

</details>

AI assistance: Codex:gpt-5.6-sol

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved validation of annotations across positional, variadic, keyword-only, and keyword parameters.
  * Validation errors are now reported before parameter defaults are merged, improving consistency for invalid function definitions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->