### PR TITLE
Make SSL Certificate immutable and non-instantiable

### DIFF
--- a/Lib/test/test_ssl.py
+++ b/Lib/test/test_ssl.py
@@ -415,7 +415,6 @@ class BasicSocketTests(unittest.TestCase):
                 value = getattr(ssl, name)
                 self.assertGreaterEqual(value, 0, f"ssl.{name}")
 
-    @unittest.expectedFailure  # TODO: RUSTPYTHON; AssertionError: TypeError not raised by Certificate
     def test_ssl_types(self):
         ssl_types = [
             _ssl._SSLContext,

--- a/crates/stdlib/src/openssl/cert.rs
+++ b/crates/stdlib/src/openssl/cert.rs
@@ -67,7 +67,10 @@ pub(crate) mod ssl_cert {
         }
     }
 
-    #[pyclass(with(Comparable, Hashable, Representable))]
+    #[pyclass(
+        flags(IMMUTABLETYPE, DISALLOW_INSTANTIATION),
+        with(Comparable, Hashable, Representable)
+    )]
     impl PySSLCertificate {
         #[pymethod]
         fn public_bytes(

--- a/crates/stdlib/src/ssl.rs
+++ b/crates/stdlib/src/ssl.rs
@@ -5040,7 +5040,10 @@ mod _ssl {
         }
     }
 
-    #[pyclass(with(Comparable, Hashable, Representable))]
+    #[pyclass(
+        flags(IMMUTABLETYPE, DISALLOW_INSTANTIATION),
+        with(Comparable, Hashable, Representable)
+    )]
     impl PySSLCertificate {
         #[pymethod]
         fn public_bytes(


### PR DESCRIPTION
Assisted-by: Codex:gpt-5.6-sol

<!--
Thanks for your contribution!
-->

- [ ] Closes #xxxx <!-- Replace xxxx with the GitHub issue number -->
- [x] This PR follows our [AI policy](https://github.com/RustPython/.github/blob/main/AI_POLICY.md)

## Summary
<!-- What's the purpose of the change? What does it do, and why? -->
- Apply the `DISALLOW_INSTANTIATION` and `IMMUTABLETYPE` flags to `_ssl.Certificate` in both the Rustls and OpenSSL backends.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * SSL certificate objects are now immutable, preventing accidental modification after creation.
  * Direct instantiation of certificate objects is no longer allowed.
  * Existing comparison, hashing, and representation behavior remains unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->