### PR TITLE
Fix sqlite autocommit cursor transaction control

### DIFF
--- a/Lib/test/test_sqlite3/test_transactions.py
+++ b/Lib/test/test_sqlite3/test_transactions.py
@@ -488,7 +488,6 @@ class AutocommitAttribute(unittest.TestCase):
                     self.assertTrue(cx.in_transaction)
                 self.assertFalse(cx.in_transaction)
 
-    @unittest.expectedFailure  # TODO: RUSTPYTHON; autocommit behavior differs
     def test_autocommit_enabled_executescript(self):
         expected = ["BEGIN", "SELECT 1"]
         with memory_database(autocommit=True) as cx:
@@ -498,7 +497,6 @@ class AutocommitAttribute(unittest.TestCase):
                 cx.executescript("SELECT 1")
                 self.assertTrue(cx.in_transaction)
 
-    @unittest.expectedFailure  # TODO: RUSTPYTHON; autocommit behavior differs
     def test_autocommit_disabled_executescript(self):
         expected = ["SELECT 1"]
         with memory_database(autocommit=False) as cx:

--- a/crates/stdlib/src/_sqlite3.rs
+++ b/crates/stdlib/src/_sqlite3.rs
@@ -1761,11 +1761,11 @@ mod _sqlite3 {
 
             let db = zelf.connection.db_lock(vm)?;
 
-            // Start implicit transaction for DML statements unless in autocommit mode
+            // Only legacy transaction control starts implicit DML transactions.
             if stmt.is_dml
                 && db.is_autocommit()
                 && zelf.connection.isolation_level.deref().is_some()
-                && *zelf.connection.autocommit.lock() != AutocommitMode::Enabled
+                && *zelf.connection.autocommit.lock() == AutocommitMode::Legacy
             {
                 db.begin_transaction(
                     zelf.connection
@@ -1855,11 +1855,11 @@ mod _sqlite3 {
 
             let db = zelf.connection.db_lock(vm)?;
 
-            // Start implicit transaction for DML statements unless in autocommit mode
+            // Only legacy transaction control starts implicit DML transactions.
             if stmt.is_dml
                 && db.is_autocommit()
                 && zelf.connection.isolation_level.deref().is_some()
-                && *zelf.connection.autocommit.lock() != AutocommitMode::Enabled
+                && *zelf.connection.autocommit.lock() == AutocommitMode::Legacy
             {
                 db.begin_transaction(
                     zelf.connection
@@ -1909,7 +1909,9 @@ mod _sqlite3 {
 
             db.sql_limit(script.byte_len(), vm)?;
 
-            db.implicit_commit(vm)?;
+            if *zelf.connection.autocommit.lock() == AutocommitMode::Legacy {
+                db.implicit_commit(vm)?;
+            }
 
             let script = script.to_cstring(vm)?;
             let mut ptr = script.as_ptr();


### PR DESCRIPTION
<!--
Thanks for your contribution!
-->

- [x] Closes #8258
- Follow-up to #8387
- [x] This PR follows our [AI policy](https://github.com/RustPython/.github/blob/main/AI_POLICY.md)

## Summary
<!-- What's the purpose of the change? What does it do, and why? -->

Align sqlite cursor transaction control across the three `Connection.autocommit` modes with CPython.

Previously, `execute()` and `executemany()` started an implicit transaction before DML statements whenever autocommit was not enabled. This also affected `autocommit=False`, even though that mode already manages its transaction through the connection lifecycle.

`executescript()` also committed a pending transaction regardless of the selected autocommit mode. This could close a transaction opened explicitly under `autocommit=True` or the transaction maintained under `autocommit=False`.

Implicit DML `BEGIN` handling in `execute()` and `executemany()` is now limited to `sqlite3.LEGACY_TRANSACTION_CONTROL`. The implicit pre-script `COMMIT` in `executescript()` is limited to the same mode, matching CPython.

As a result:

- `autocommit=False` transaction management remains the responsibility of the connection lifecycle implemented in #8387.
- `autocommit=True` leaves explicit SQL transaction control untouched.
- `sqlite3.LEGACY_TRANSACTION_CONTROL` preserves the existing implicit transaction behavior.

Two CPython tests now pass without `expectedFailure`:

- `test_autocommit_enabled_executescript`
- `test_autocommit_disabled_executescript`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Refined transaction handling for database modification statements and scripts.
  * Prevented unintended implicit transactions and commits when using non-legacy autocommit modes.
  * Preserved expected legacy autocommit behavior for configured connections.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->