### PR TITLE
Fix tuple subclass preservation in type bases

### DIFF
--- a/Lib/test/test_types.py
+++ b/Lib/test/test_types.py
@@ -1881,7 +1881,6 @@ class ClassCreationTests(unittest.TestCase):
         D.__getitem__ = dict.__getitem__
         self.assertIs(d[None], None)
 
-    @unittest.expectedFailure  # TODO: RUSTPYTHON; AssertionError: <class 'tuple'> != <class 'test.test_types.ClassCreationTests.test_tu[41 chars]ass'>
     def test_tuple_subclass_as_bases(self):
         # gh-132176: it used to crash on using
         # tuple subclass for as base classes.

--- a/Lib/test/test_types.py
+++ b/Lib/test/test_types.py
@@ -1882,7 +1882,6 @@ class ClassCreationTests(unittest.TestCase):
         D.__getitem__ = dict.__getitem__
         self.assertIs(d[None], None)
 
-    @unittest.expectedFailure  # TODO: RUSTPYTHON; AssertionError: <class 'tuple'> != <class 'test.test_types.ClassCreationTests.test_tu[41 chars]ass'>
     def test_tuple_subclass_as_bases(self):
         # gh-132176: it used to crash on using
         # tuple subclass for as base classes.

--- a/crates/vm/src/builtins/mod.rs
+++ b/crates/vm/src/builtins/mod.rs
@@ -72,7 +72,7 @@ pub(crate) mod super_;
 pub use super_::PySuper;
 #[path = "type.rs"]
 pub(crate) mod type_;
-pub use type_::{PyType, PyTypeBases, PyTypeRef};
+pub use type_::{PyType, PyTypeRef};
 pub(crate) mod range;
 pub use range::PyRange;
 pub(crate) mod set;

--- a/crates/vm/src/builtins/mod.rs
+++ b/crates/vm/src/builtins/mod.rs
@@ -72,7 +72,7 @@ pub(crate) mod super_;
 pub use super_::PySuper;
 #[path = "type.rs"]
 pub(crate) mod type_;
-pub use type_::{PyType, PyTypeRef};
+pub use type_::{PyType, PyTypeBases, PyTypeRef};
 pub(crate) mod range;
 pub use range::PyRange;
 pub(crate) mod set;

--- a/crates/vm/src/builtins/tuple.rs
+++ b/crates/vm/src/builtins/tuple.rs
@@ -375,6 +375,23 @@ impl PyTuple<PyObjectRef> {
 }
 
 impl<T> PyTuple<PyRef<T>> {
+    pub(crate) fn new_ref_typed_with_type(
+        elements: Vec<PyRef<T>>,
+        tuple_type: PyTypeRef,
+    ) -> PyRef<Self> {
+        // SAFETY: PyRef<T> has the same layout as PyObjectRef.
+        unsafe {
+            let elements: Vec<PyObjectRef> =
+                core::mem::transmute::<Vec<PyRef<T>>, Vec<PyObjectRef>>(elements);
+            let tuple = PyRef::new_ref(
+                PyTuple::new_unchecked(elements.into_boxed_slice()),
+                tuple_type,
+                None,
+            );
+            core::mem::transmute::<PyRef<PyTuple>, PyRef<Self>>(tuple)
+        }
+    }
+
     pub fn new_ref_typed(elements: Vec<PyRef<T>>, ctx: &Context) -> PyRef<Self> {
         // SAFETY: PyRef<T> has the same layout as PyObjectRef
         unsafe {

--- a/crates/vm/src/builtins/tuple.rs
+++ b/crates/vm/src/builtins/tuple.rs
@@ -308,6 +308,23 @@ impl PyTuple<PyObjectRef> {
 }
 
 impl<T> PyTuple<PyRef<T>> {
+    pub(crate) fn new_ref_typed_with_type(
+        elements: Vec<PyRef<T>>,
+        tuple_type: PyTypeRef,
+    ) -> PyRef<Self> {
+        // SAFETY: PyRef<T> has the same layout as PyObjectRef.
+        unsafe {
+            let elements: Vec<PyObjectRef> =
+                core::mem::transmute::<Vec<PyRef<T>>, Vec<PyObjectRef>>(elements);
+            let tuple = PyRef::new_ref(
+                PyTuple::new_unchecked(elements.into_boxed_slice()),
+                tuple_type,
+                None,
+            );
+            core::mem::transmute::<PyRef<PyTuple>, PyRef<Self>>(tuple)
+        }
+    }
+
     pub fn new_ref_typed(elements: Vec<PyRef<T>>, ctx: &Context) -> PyRef<Self> {
         // SAFETY: PyRef<T> has the same layout as PyObjectRef
         unsafe {

--- a/crates/vm/src/builtins/type.rs
+++ b/crates/vm/src/builtins/type.rs
@@ -41,12 +41,54 @@ use num_traits::ToPrimitive;
 use rustpython_common::wtf8::Wtf8;
 use std::collections::HashSet;
 
+type PyTypeTupleRef = PyRef<PyTuple<PyTypeRef>>;
+
+#[derive(Clone, Debug)]
+pub enum PyTypeBases {
+    /// Bases created before a Python tuple can be allocated.
+    Bootstrap(Vec<PyTypeRef>),
+    /// The Python-visible tuple, with every element validated as a type.
+    Tuple(PyTypeTupleRef),
+}
+
+impl Default for PyTypeBases {
+    fn default() -> Self {
+        Self::Bootstrap(Vec::new())
+    }
+}
+
+impl Deref for PyTypeBases {
+    type Target = [PyTypeRef];
+
+    fn deref(&self) -> &Self::Target {
+        match self {
+            Self::Bootstrap(bases) => bases,
+            Self::Tuple(bases) => bases.as_slice(),
+        }
+    }
+}
+
+unsafe impl Traverse for PyTypeBases {
+    fn traverse(&self, tracer_fn: &mut TraverseFn<'_>) {
+        match self {
+            Self::Bootstrap(bases) => bases.traverse(tracer_fn),
+            Self::Tuple(bases) => tracer_fn(bases.as_untyped().as_object()),
+        }
+    }
+
+    fn clear(&mut self, out: &mut Vec<PyObjectRef>) {
+        match core::mem::take(self) {
+            Self::Bootstrap(bases) => out.extend(bases.into_iter().map(Into::into)),
+            Self::Tuple(bases) => out.push(bases.into_untyped().into()),
+        }
+    }
+}
+
 #[pyclass(module = false, name = "type", traverse = "manual")]
 pub struct PyType {
     /// tp_base. Written under the type lock (see `set_bases`); read lock-free.
     pub base: PyAtomicRef<Option<Self>>,
-    pub bases: PyRwLock<Vec<PyTypeRef>>,
-    pub(crate) bases_tuple: PyRwLock<Option<PyTupleRef>>,
+    pub bases: PyRwLock<PyTypeBases>,
     pub mro: PyRwLock<Vec<PyTypeRef>>,
     pub subclasses: PyRwLock<Vec<PyRef<PyWeak>>>,
     pub attributes: TypeNamespace,
@@ -243,7 +285,6 @@ unsafe impl crate::object::Traverse for PyType {
             tracer_fn(base.as_object());
         }
         self.bases.traverse(tracer_fn);
-        self.bases_tuple.traverse(tracer_fn);
         self.mro.traverse(tracer_fn);
         self.subclasses.traverse(tracer_fn);
         self.attributes.traverse(tracer_fn);
@@ -258,15 +299,8 @@ unsafe impl crate::object::Traverse for PyType {
         if let Some(base) = unsafe { self.base.swap(None) } {
             out.push(base.into());
         }
-        if let Some(mut guard) = self.bases.try_write() {
-            for base in guard.drain(..) {
-                out.push(base.into());
-            }
-        }
-        if let Some(mut guard) = self.bases_tuple.try_write()
-            && let Some(bases) = guard.take()
-        {
-            out.push(bases.into());
+        if let Some(mut bases) = self.bases.try_write() {
+            bases.clear(out);
         }
         if let Some(mut guard) = self.mro.try_write() {
             for typ in guard.drain(..) {
@@ -773,6 +807,7 @@ impl PyType {
             specialization_cache: TypeSpecializationCache::new(),
             interpreter_id: HeapTypeExt::creating_interpreter_id(),
         };
+        let bases = PyTuple::new_ref_typed(bases, ctx);
         let base = bases[0].clone();
 
         Self::new_heap_inner(base, bases, attrs, slots, heaptype_ext, metaclass, ctx)
@@ -941,7 +976,7 @@ impl PyType {
     #[allow(clippy::too_many_arguments)]
     fn new_heap_inner(
         base: PyRef<Self>,
-        bases: Vec<PyRef<Self>>,
+        bases: PyTypeTupleRef,
         attrs: PyAttributes,
         mut slots: PyTypeSlots,
         heaptype_ext: HeapTypeExt,
@@ -995,8 +1030,7 @@ impl PyType {
         let new_type = PyRef::new_ref(
             Self {
                 base: Some(base).into(),
-                bases: PyRwLock::new(bases),
-                bases_tuple: PyRwLock::default(),
+                bases: PyRwLock::new(PyTypeBases::Tuple(bases)),
                 mro: PyRwLock::new(mro),
                 subclasses: PyRwLock::default(),
                 attributes: TypeNamespace::new(attrs, ctx),
@@ -1052,14 +1086,13 @@ impl PyType {
         }
 
         let inherited_abc_tpflags = Self::inherited_abc_tpflags(core::slice::from_ref(&base));
-        let bases = PyRwLock::new(vec![base.clone()]);
+        let bases = PyRwLock::new(PyTypeBases::Bootstrap(vec![base.clone()]));
         let mro = base.mro_map_collect(|x| x.to_owned());
 
         let new_type = PyRef::new_ref(
             Self {
                 base: Some(base).into(),
                 bases,
-                bases_tuple: PyRwLock::default(),
                 mro: PyRwLock::new(mro),
                 subclasses: PyRwLock::default(),
                 attributes: attrs.into(),
@@ -1651,26 +1684,21 @@ impl Py<PyType> {
 impl PyType {
     #[pygetset]
     fn __bases__(&self, vm: &VirtualMachine) -> PyTupleRef {
-        enum BasesSnapshot {
-            Tuple(PyTupleRef),
-            Types(Vec<PyTypeRef>),
-        }
+        let bases = Self::with_type_lock(vm, || self.bases.read().clone());
+        let types = match bases {
+            PyTypeBases::Tuple(tuple) => return tuple.into_untyped(),
+            PyTypeBases::Bootstrap(types) => types,
+        };
 
-        let bases = Self::with_type_lock(vm, || {
-            self.bases_tuple.read().clone().map_or_else(
-                || BasesSnapshot::Types(self.bases.read().clone()),
-                BasesSnapshot::Tuple,
-            )
-        });
-        match bases {
-            BasesSnapshot::Tuple(tuple) => tuple,
-            BasesSnapshot::Types(types) => vm.ctx.new_tuple(
-                types
-                    .into_iter()
-                    .map(|typ| typ.as_object().to_owned())
-                    .collect(),
-            ),
-        }
+        let tuple = PyTuple::new_ref_typed(types, &vm.ctx);
+        Self::with_type_lock(vm, || {
+            let mut bases = self.bases.write();
+            if let PyTypeBases::Tuple(current) = &*bases {
+                return current.clone().into_untyped();
+            }
+            *bases = PyTypeBases::Tuple(tuple.clone());
+            tuple.into_untyped()
+        })
     }
     #[pygetset(setter, name = "__bases__")]
     fn set_bases(zelf: &Py<Self>, bases_tuple: PyTupleRef, vm: &VirtualMachine) -> PyResult<()> {
@@ -1688,18 +1716,16 @@ impl PyType {
                 zelf.name()
             )));
         }
-        let bases = bases_tuple
-            .iter()
-            .map(|base| {
-                base.clone().downcast::<Self>().map_err(|base| {
-                    vm.new_type_error(format!(
-                        "{}.__bases__ must be tuple of classes, not '{}'",
-                        zelf.name(),
-                        base.class().name()
-                    ))
-                })
-            })
-            .collect::<PyResult<Vec<_>>>()?;
+        for base in bases_tuple.iter() {
+            if base.downcast_ref::<Self>().is_none() {
+                return Err(vm.new_type_error(format!(
+                    "{}.__bases__ must be tuple of classes, not '{}'",
+                    zelf.name(),
+                    base.class().name()
+                )));
+            }
+        }
+        let bases = bases_tuple.try_into_typed::<Self>(vm)?;
 
         // TODO: check for mro cycles
 
@@ -1769,7 +1795,8 @@ impl PyType {
                 *subclasses = kept;
             }
 
-            let old_bases = core::mem::replace(&mut *zelf.bases.write(), bases);
+            let mut old_bases =
+                core::mem::replace(&mut *zelf.bases.write(), PyTypeBases::Tuple(bases));
             let old_base = unsafe { zelf.base.swap(Some(new_base)) };
 
             // Recursively update the mros of this class and all subclasses,
@@ -1805,12 +1832,12 @@ impl PyType {
                     retired.extend(failed_mro.into_iter().map(Into::into));
                     retired.push(cls.into());
                 }
-                let failed_bases = core::mem::replace(&mut *zelf.bases.write(), old_bases);
+                let mut failed_bases = core::mem::replace(&mut *zelf.bases.write(), old_bases);
                 if let Some(failed_base) = unsafe { zelf.base.swap(old_base) } {
                     keep_alive(failed_base, &mut retired);
                 }
                 register_subclasses(&zelf.bases.read());
-                retired.extend(failed_bases.into_iter().map(Into::into));
+                failed_bases.clear(&mut retired);
                 zelf.modified_inner();
                 return Err(err);
             }
@@ -1820,7 +1847,7 @@ impl PyType {
                 retired.extend(old_mro.into_iter().map(Into::into));
                 retired.push(cls.into());
             }
-            retired.extend(old_bases.into_iter().map(Into::into));
+            old_bases.clear(&mut retired);
             if let Some(old_base) = old_base {
                 keep_alive(old_base, &mut retired);
             }
@@ -1830,13 +1857,6 @@ impl PyType {
             zelf.update_all_slots(&vm.ctx);
 
             register_subclasses(&zelf.bases.read());
-            let old_bases_tuple = {
-                let mut bases = zelf.bases_tuple.write();
-                bases.replace(bases_tuple)
-            };
-            if let Some(bases) = old_bases_tuple {
-                retired.push(bases.into());
-            }
             Ok(())
         });
         drop(retired);
@@ -2326,7 +2346,6 @@ impl Constructor for PyType {
 
         let (name, bases, dict, kwargs): (PyStrRef, PyTupleRef, PyDictRef, KwArgs) =
             args.clone().bind(vm)?;
-        let original_bases = (!bases.is_empty()).then(|| bases.clone());
 
         if name.as_bytes().contains(&0) {
             return Err(vm.new_value_error("type name must not contain null characters"));
@@ -2335,26 +2354,24 @@ impl Constructor for PyType {
 
         let (metatype, base, bases, base_is_type) = if bases.is_empty() {
             let base = vm.ctx.types.object_type.to_owned();
-            (metatype, base.clone(), vec![base], false)
+            let bases = PyTuple::new_ref_typed(vec![base.clone()], &vm.ctx);
+            (metatype, base, bases, false)
         } else {
-            let bases = bases
-                .iter()
-                .map(|obj| {
-                    obj.clone().downcast::<Self>().or_else(|obj| {
-                        if vm
-                            .get_attribute_opt(obj, identifier!(vm, __mro_entries__))?
-                            .is_some()
-                        {
-                            Err(vm.new_type_error(
-                                "type() doesn't support MRO entry resolution; \
-                                 use types.new_class()",
-                            ))
-                        } else {
-                            Err(vm.new_type_error("bases must be types"))
-                        }
-                    })
-                })
-                .collect::<PyResult<Vec<_>>>()?;
+            for obj in bases.iter() {
+                if obj.downcast_ref::<Self>().is_none() {
+                    if vm
+                        .get_attribute_opt(obj.clone(), identifier!(vm, __mro_entries__))?
+                        .is_some()
+                    {
+                        return Err(vm.new_type_error(
+                            "type() doesn't support MRO entry resolution; \
+                             use types.new_class()",
+                        ));
+                    }
+                    return Err(vm.new_type_error("bases must be types"));
+                }
+            }
+            let bases = bases.try_into_typed::<Self>(vm)?;
 
             // Search the bases for the proper metatype to deal with this:
             let winner = calculate_meta_class(metatype.clone(), &bases, vm)?;
@@ -2613,16 +2630,6 @@ impl Constructor for PyType {
             &vm.ctx,
         )
         .map_err(|e| vm.new_type_error(e))?;
-
-        *typ.bases_tuple.write() = Some(original_bases.unwrap_or_else(|| {
-            vm.ctx.new_tuple(
-                typ.bases
-                    .read()
-                    .iter()
-                    .map(|base| base.as_object().to_owned())
-                    .collect(),
-            )
-        }));
 
         if let Some(ref slots) = heaptype_slots {
             let class_name = typ.name().to_string();

--- a/crates/vm/src/builtins/type.rs
+++ b/crates/vm/src/builtins/type.rs
@@ -46,6 +46,7 @@ pub struct PyType {
     /// tp_base. Written under the type lock (see `set_bases`); read lock-free.
     pub base: PyAtomicRef<Option<Self>>,
     pub bases: PyRwLock<Vec<PyTypeRef>>,
+    pub(crate) bases_tuple: PyRwLock<Option<PyTupleRef>>,
     pub mro: PyRwLock<Vec<PyTypeRef>>,
     pub subclasses: PyRwLock<Vec<PyRef<PyWeak>>>,
     pub attributes: TypeNamespace,
@@ -242,6 +243,7 @@ unsafe impl crate::object::Traverse for PyType {
             tracer_fn(base.as_object());
         }
         self.bases.traverse(tracer_fn);
+        self.bases_tuple.traverse(tracer_fn);
         self.mro.traverse(tracer_fn);
         self.subclasses.traverse(tracer_fn);
         self.attributes.traverse(tracer_fn);
@@ -260,6 +262,11 @@ unsafe impl crate::object::Traverse for PyType {
             for base in guard.drain(..) {
                 out.push(base.into());
             }
+        }
+        if let Some(mut guard) = self.bases_tuple.try_write()
+            && let Some(bases) = guard.take()
+        {
+            out.push(bases.into());
         }
         if let Some(mut guard) = self.mro.try_write() {
             for typ in guard.drain(..) {
@@ -989,6 +996,7 @@ impl PyType {
             Self {
                 base: Some(base).into(),
                 bases: PyRwLock::new(bases),
+                bases_tuple: PyRwLock::default(),
                 mro: PyRwLock::new(mro),
                 subclasses: PyRwLock::default(),
                 attributes: TypeNamespace::new(attrs, ctx),
@@ -1051,6 +1059,7 @@ impl PyType {
             Self {
                 base: Some(base).into(),
                 bases,
+                bases_tuple: PyRwLock::default(),
                 mro: PyRwLock::new(mro),
                 subclasses: PyRwLock::default(),
                 attributes: attrs.into(),
@@ -1642,16 +1651,29 @@ impl Py<PyType> {
 impl PyType {
     #[pygetset]
     fn __bases__(&self, vm: &VirtualMachine) -> PyTupleRef {
-        vm.ctx.new_tuple(
-            self.bases
-                .read()
-                .iter()
-                .map(|x| x.as_object().to_owned())
-                .collect(),
-        )
+        enum BasesSnapshot {
+            Tuple(PyTupleRef),
+            Types(Vec<PyTypeRef>),
+        }
+
+        let bases = Self::with_type_lock(vm, || {
+            self.bases_tuple.read().clone().map_or_else(
+                || BasesSnapshot::Types(self.bases.read().clone()),
+                BasesSnapshot::Tuple,
+            )
+        });
+        match bases {
+            BasesSnapshot::Tuple(tuple) => tuple,
+            BasesSnapshot::Types(types) => vm.ctx.new_tuple(
+                types
+                    .into_iter()
+                    .map(|typ| typ.as_object().to_owned())
+                    .collect(),
+            ),
+        }
     }
     #[pygetset(setter, name = "__bases__")]
-    fn set_bases(zelf: &Py<Self>, bases: Vec<PyTypeRef>, vm: &VirtualMachine) -> PyResult<()> {
+    fn set_bases(zelf: &Py<Self>, bases_tuple: PyTupleRef, vm: &VirtualMachine) -> PyResult<()> {
         // TODO: Assigning to __bases__ is only used in typing.NamedTupleMeta.__new__
         // Rather than correctly re-initializing the class, we are skipping a few steps for now
         if zelf.slots.flags.has_feature(PyTypeFlags::IMMUTABLETYPE) {
@@ -1660,12 +1682,24 @@ impl PyType {
                 zelf.name()
             )));
         }
-        if bases.is_empty() {
+        if bases_tuple.is_empty() {
             return Err(vm.new_type_error(format!(
                 "can only assign non-empty tuple to {}.__bases__, not ()",
                 zelf.name()
             )));
         }
+        let bases = bases_tuple
+            .iter()
+            .map(|base| {
+                base.clone().downcast::<Self>().map_err(|base| {
+                    vm.new_type_error(format!(
+                        "{}.__bases__ must be tuple of classes, not '{}'",
+                        zelf.name(),
+                        base.class().name()
+                    ))
+                })
+            })
+            .collect::<PyResult<Vec<_>>>()?;
 
         // TODO: check for mro cycles
 
@@ -1796,6 +1830,13 @@ impl PyType {
             zelf.update_all_slots(&vm.ctx);
 
             register_subclasses(&zelf.bases.read());
+            let old_bases_tuple = {
+                let mut bases = zelf.bases_tuple.write();
+                bases.replace(bases_tuple)
+            };
+            if let Some(bases) = old_bases_tuple {
+                retired.push(bases.into());
+            }
             Ok(())
         });
         drop(retired);
@@ -2285,6 +2326,7 @@ impl Constructor for PyType {
 
         let (name, bases, dict, kwargs): (PyStrRef, PyTupleRef, PyDictRef, KwArgs) =
             args.clone().bind(vm)?;
+        let original_bases = (!bases.is_empty()).then(|| bases.clone());
 
         if name.as_bytes().contains(&0) {
             return Err(vm.new_value_error("type name must not contain null characters"));
@@ -2571,6 +2613,16 @@ impl Constructor for PyType {
             &vm.ctx,
         )
         .map_err(|e| vm.new_type_error(e))?;
+
+        *typ.bases_tuple.write() = Some(original_bases.unwrap_or_else(|| {
+            vm.ctx.new_tuple(
+                typ.bases
+                    .read()
+                    .iter()
+                    .map(|base| base.as_object().to_owned())
+                    .collect(),
+            )
+        }));
 
         if let Some(ref slots) = heaptype_slots {
             let class_name = typ.name().to_string();

--- a/crates/vm/src/builtins/type.rs
+++ b/crates/vm/src/builtins/type.rs
@@ -41,54 +41,13 @@ use num_traits::ToPrimitive;
 use rustpython_common::wtf8::Wtf8;
 use std::collections::HashSet;
 
-type PyTypeTupleRef = PyRef<PyTuple<PyTypeRef>>;
-
-#[derive(Clone, Debug)]
-pub enum PyTypeBases {
-    /// Bases created before a Python tuple can be allocated.
-    Bootstrap(Vec<PyTypeRef>),
-    /// The Python-visible tuple, with every element validated as a type.
-    Tuple(PyTypeTupleRef),
-}
-
-impl Default for PyTypeBases {
-    fn default() -> Self {
-        Self::Bootstrap(Vec::new())
-    }
-}
-
-impl Deref for PyTypeBases {
-    type Target = [PyTypeRef];
-
-    fn deref(&self) -> &Self::Target {
-        match self {
-            Self::Bootstrap(bases) => bases,
-            Self::Tuple(bases) => bases.as_slice(),
-        }
-    }
-}
-
-unsafe impl Traverse for PyTypeBases {
-    fn traverse(&self, tracer_fn: &mut TraverseFn<'_>) {
-        match self {
-            Self::Bootstrap(bases) => bases.traverse(tracer_fn),
-            Self::Tuple(bases) => tracer_fn(bases.as_untyped().as_object()),
-        }
-    }
-
-    fn clear(&mut self, out: &mut Vec<PyObjectRef>) {
-        match core::mem::take(self) {
-            Self::Bootstrap(bases) => out.extend(bases.into_iter().map(Into::into)),
-            Self::Tuple(bases) => out.push(bases.into_untyped().into()),
-        }
-    }
-}
+pub(crate) type PyTypeTupleRef = PyRef<PyTuple<PyTypeRef>>;
 
 #[pyclass(module = false, name = "type", traverse = "manual")]
 pub struct PyType {
     /// tp_base. Written under the type lock (see `set_bases`); read lock-free.
     pub base: PyAtomicRef<Option<Self>>,
-    pub bases: PyRwLock<PyTypeBases>,
+    pub bases: PyRwLock<PyTypeTupleRef>,
     pub mro: PyRwLock<Vec<PyTypeRef>>,
     pub subclasses: PyRwLock<Vec<PyRef<PyWeak>>>,
     pub attributes: TypeNamespace,
@@ -284,7 +243,7 @@ unsafe impl crate::object::Traverse for PyType {
         if let Some(base) = self.base.deref() {
             tracer_fn(base.as_object());
         }
-        self.bases.traverse(tracer_fn);
+        tracer_fn(self.bases.read_recursive().as_untyped().as_object());
         self.mro.traverse(tracer_fn);
         self.subclasses.traverse(tracer_fn);
         self.attributes.traverse(tracer_fn);
@@ -300,7 +259,9 @@ unsafe impl crate::object::Traverse for PyType {
             out.push(base.into());
         }
         if let Some(mut bases) = self.bases.try_write() {
-            bases.clear(out);
+            let empty = object::PyBaseObject::static_type().bases.read().clone();
+            let old_bases = core::mem::replace(&mut *bases, empty);
+            out.push(old_bases.into_untyped().into());
         }
         if let Some(mut guard) = self.mro.try_write() {
             for typ in guard.drain(..) {
@@ -1030,7 +991,7 @@ impl PyType {
         let new_type = PyRef::new_ref(
             Self {
                 base: Some(base).into(),
-                bases: PyRwLock::new(PyTypeBases::Tuple(bases)),
+                bases: PyRwLock::new(bases),
                 mro: PyRwLock::new(mro),
                 subclasses: PyRwLock::default(),
                 attributes: TypeNamespace::new(attrs, ctx),
@@ -1086,13 +1047,14 @@ impl PyType {
         }
 
         let inherited_abc_tpflags = Self::inherited_abc_tpflags(core::slice::from_ref(&base));
-        let bases = PyRwLock::new(PyTypeBases::Bootstrap(vec![base.clone()]));
+        let bases =
+            PyTuple::new_ref_typed_with_type(vec![base.clone()], PyTuple::static_type().to_owned());
         let mro = base.mro_map_collect(|x| x.to_owned());
 
         let new_type = PyRef::new_ref(
             Self {
                 base: Some(base).into(),
-                bases,
+                bases: PyRwLock::new(bases),
                 mro: PyRwLock::new(mro),
                 subclasses: PyRwLock::default(),
                 attributes: attrs.into(),
@@ -1203,6 +1165,11 @@ impl PyType {
                 .alloc
                 .store(base.and_then(|base| base.slots.alloc.load()));
         }
+    }
+
+    pub(crate) fn finalize_bootstrap_static(typ: &Py<Self>) {
+        Self::set_new(&typ.slots, typ.base.deref());
+        Self::set_alloc(&typ.slots, typ.base.deref());
     }
 
     /// Inherit slots from base type. inherit_slots
@@ -1684,21 +1651,7 @@ impl Py<PyType> {
 impl PyType {
     #[pygetset]
     fn __bases__(&self, vm: &VirtualMachine) -> PyTupleRef {
-        let bases = Self::with_type_lock(vm, || self.bases.read().clone());
-        let types = match bases {
-            PyTypeBases::Tuple(tuple) => return tuple.into_untyped(),
-            PyTypeBases::Bootstrap(types) => types,
-        };
-
-        let tuple = PyTuple::new_ref_typed(types, &vm.ctx);
-        Self::with_type_lock(vm, || {
-            let mut bases = self.bases.write();
-            if let PyTypeBases::Tuple(current) = &*bases {
-                return current.clone().into_untyped();
-            }
-            *bases = PyTypeBases::Tuple(tuple.clone());
-            tuple.into_untyped()
-        })
+        Self::with_type_lock(vm, || self.bases.read().clone().into_untyped())
     }
     #[pygetset(setter, name = "__bases__")]
     fn set_bases(zelf: &Py<Self>, bases_tuple: PyTupleRef, vm: &VirtualMachine) -> PyResult<()> {
@@ -1795,8 +1748,7 @@ impl PyType {
                 *subclasses = kept;
             }
 
-            let mut old_bases =
-                core::mem::replace(&mut *zelf.bases.write(), PyTypeBases::Tuple(bases));
+            let old_bases = core::mem::replace(&mut *zelf.bases.write(), bases);
             let old_base = unsafe { zelf.base.swap(Some(new_base)) };
 
             // Recursively update the mros of this class and all subclasses,
@@ -1832,12 +1784,12 @@ impl PyType {
                     retired.extend(failed_mro.into_iter().map(Into::into));
                     retired.push(cls.into());
                 }
-                let mut failed_bases = core::mem::replace(&mut *zelf.bases.write(), old_bases);
+                let failed_bases = core::mem::replace(&mut *zelf.bases.write(), old_bases);
                 if let Some(failed_base) = unsafe { zelf.base.swap(old_base) } {
                     keep_alive(failed_base, &mut retired);
                 }
                 register_subclasses(&zelf.bases.read());
-                failed_bases.clear(&mut retired);
+                retired.push(failed_bases.into_untyped().into());
                 zelf.modified_inner();
                 return Err(err);
             }
@@ -1847,7 +1799,7 @@ impl PyType {
                 retired.extend(old_mro.into_iter().map(Into::into));
                 retired.push(cls.into());
             }
-            old_bases.clear(&mut retired);
+            retired.push(old_bases.into_untyped().into());
             if let Some(old_base) = old_base {
                 keep_alive(old_base, &mut retired);
             }

--- a/crates/vm/src/builtins/type.rs
+++ b/crates/vm/src/builtins/type.rs
@@ -47,6 +47,7 @@ pub struct PyType {
     /// tp_base. Written under the type lock (see `set_bases`); read lock-free.
     pub base: PyAtomicRef<Option<Self>>,
     pub bases: PyRwLock<Vec<PyTypeRef>>,
+    pub(crate) bases_tuple: PyRwLock<Option<PyTupleRef>>,
     pub mro: PyRwLock<Vec<PyTypeRef>>,
     pub subclasses: PyRwLock<Vec<PyRef<PyWeak>>>,
     pub attributes: PyRwLock<PyAttributes>,
@@ -243,6 +244,7 @@ unsafe impl crate::object::Traverse for PyType {
             tracer_fn(base.as_object());
         }
         self.bases.traverse(tracer_fn);
+        self.bases_tuple.traverse(tracer_fn);
         self.mro.traverse(tracer_fn);
         self.subclasses.traverse(tracer_fn);
         self.attributes
@@ -265,6 +267,11 @@ unsafe impl crate::object::Traverse for PyType {
             for base in guard.drain(..) {
                 out.push(base.into());
             }
+        }
+        if let Some(mut guard) = self.bases_tuple.try_write()
+            && let Some(bases) = guard.take()
+        {
+            out.push(bases.into());
         }
         if let Some(mut guard) = self.mro.try_write() {
             for typ in guard.drain(..) {
@@ -815,6 +822,7 @@ impl PyType {
             Self {
                 base: Some(base).into(),
                 bases: PyRwLock::new(bases),
+                bases_tuple: PyRwLock::default(),
                 mro: PyRwLock::new(mro),
                 subclasses: PyRwLock::default(),
                 attributes: PyRwLock::new(attrs),
@@ -879,6 +887,7 @@ impl PyType {
             Self {
                 base: Some(base).into(),
                 bases,
+                bases_tuple: PyRwLock::default(),
                 mro: PyRwLock::new(mro),
                 subclasses: PyRwLock::default(),
                 attributes: PyRwLock::new(attrs),
@@ -1466,16 +1475,29 @@ impl Py<PyType> {
 impl PyType {
     #[pygetset]
     fn __bases__(&self, vm: &VirtualMachine) -> PyTupleRef {
-        vm.ctx.new_tuple(
-            self.bases
-                .read()
-                .iter()
-                .map(|x| x.as_object().to_owned())
-                .collect(),
-        )
+        enum BasesSnapshot {
+            Tuple(PyTupleRef),
+            Types(Vec<PyTypeRef>),
+        }
+
+        let bases = Self::with_type_lock(vm, || {
+            self.bases_tuple.read().clone().map_or_else(
+                || BasesSnapshot::Types(self.bases.read().clone()),
+                BasesSnapshot::Tuple,
+            )
+        });
+        match bases {
+            BasesSnapshot::Tuple(tuple) => tuple,
+            BasesSnapshot::Types(types) => vm.ctx.new_tuple(
+                types
+                    .into_iter()
+                    .map(|typ| typ.as_object().to_owned())
+                    .collect(),
+            ),
+        }
     }
     #[pygetset(setter, name = "__bases__")]
-    fn set_bases(zelf: &Py<Self>, bases: Vec<PyTypeRef>, vm: &VirtualMachine) -> PyResult<()> {
+    fn set_bases(zelf: &Py<Self>, bases_tuple: PyTupleRef, vm: &VirtualMachine) -> PyResult<()> {
         // TODO: Assigning to __bases__ is only used in typing.NamedTupleMeta.__new__
         // Rather than correctly re-initializing the class, we are skipping a few steps for now
         if zelf.slots.flags.has_feature(PyTypeFlags::IMMUTABLETYPE) {
@@ -1484,12 +1506,24 @@ impl PyType {
                 zelf.name()
             )));
         }
-        if bases.is_empty() {
+        if bases_tuple.is_empty() {
             return Err(vm.new_type_error(format!(
                 "can only assign non-empty tuple to {}.__bases__, not ()",
                 zelf.name()
             )));
         }
+        let bases = bases_tuple
+            .iter()
+            .map(|base| {
+                base.clone().downcast::<Self>().map_err(|base| {
+                    vm.new_type_error(format!(
+                        "{}.__bases__ must be tuple of classes, not '{}'",
+                        zelf.name(),
+                        base.class().name()
+                    ))
+                })
+            })
+            .collect::<PyResult<Vec<_>>>()?;
 
         // TODO: check for mro cycles
 
@@ -1615,6 +1649,13 @@ impl PyType {
             zelf.update_all_slots(&vm.ctx);
 
             register_subclasses(&zelf.bases.read());
+            let old_bases_tuple = {
+                let mut bases = zelf.bases_tuple.write();
+                bases.replace(bases_tuple)
+            };
+            if let Some(bases) = old_bases_tuple {
+                retired.push(bases.into());
+            }
             Ok(())
         });
         drop(retired);
@@ -2099,6 +2140,7 @@ impl Constructor for PyType {
 
         let (name, bases, dict, kwargs): (PyStrRef, PyTupleRef, PyDictRef, KwArgs) =
             args.clone().bind(vm)?;
+        let original_bases = (!bases.is_empty()).then(|| bases.clone());
 
         if name.as_bytes().contains(&0) {
             return Err(vm.new_value_error("type name must not contain null characters"));
@@ -2380,6 +2422,16 @@ impl Constructor for PyType {
             &vm.ctx,
         )
         .map_err(|e| vm.new_type_error(e))?;
+
+        *typ.bases_tuple.write() = Some(original_bases.unwrap_or_else(|| {
+            vm.ctx.new_tuple(
+                typ.bases
+                    .read()
+                    .iter()
+                    .map(|base| base.as_object().to_owned())
+                    .collect(),
+            )
+        }));
 
         if let Some(ref slots) = heaptype_slots {
             let class_name = typ.name().to_string();

--- a/crates/vm/src/builtins/type.rs
+++ b/crates/vm/src/builtins/type.rs
@@ -42,54 +42,13 @@ use num_traits::ToPrimitive;
 use rustpython_common::wtf8::Wtf8;
 use std::collections::HashSet;
 
-type PyTypeTupleRef = PyRef<PyTuple<PyTypeRef>>;
-
-#[derive(Clone, Debug)]
-pub enum PyTypeBases {
-    /// Bases created before a Python tuple can be allocated.
-    Bootstrap(Vec<PyTypeRef>),
-    /// The Python-visible tuple, with every element validated as a type.
-    Tuple(PyTypeTupleRef),
-}
-
-impl Default for PyTypeBases {
-    fn default() -> Self {
-        Self::Bootstrap(Vec::new())
-    }
-}
-
-impl Deref for PyTypeBases {
-    type Target = [PyTypeRef];
-
-    fn deref(&self) -> &Self::Target {
-        match self {
-            Self::Bootstrap(bases) => bases,
-            Self::Tuple(bases) => bases.as_slice(),
-        }
-    }
-}
-
-unsafe impl Traverse for PyTypeBases {
-    fn traverse(&self, tracer_fn: &mut TraverseFn<'_>) {
-        match self {
-            Self::Bootstrap(bases) => bases.traverse(tracer_fn),
-            Self::Tuple(bases) => tracer_fn(bases.as_untyped().as_object()),
-        }
-    }
-
-    fn clear(&mut self, out: &mut Vec<PyObjectRef>) {
-        match core::mem::take(self) {
-            Self::Bootstrap(bases) => out.extend(bases.into_iter().map(Into::into)),
-            Self::Tuple(bases) => out.push(bases.into_untyped().into()),
-        }
-    }
-}
+pub(crate) type PyTypeTupleRef = PyRef<PyTuple<PyTypeRef>>;
 
 #[pyclass(module = false, name = "type", traverse = "manual")]
 pub struct PyType {
     /// tp_base. Written under the type lock (see `set_bases`); read lock-free.
     pub base: PyAtomicRef<Option<Self>>,
-    pub bases: PyRwLock<PyTypeBases>,
+    pub bases: PyRwLock<PyTypeTupleRef>,
     pub mro: PyRwLock<Vec<PyTypeRef>>,
     pub subclasses: PyRwLock<Vec<PyRef<PyWeak>>>,
     pub attributes: PyRwLock<PyAttributes>,
@@ -285,7 +244,7 @@ unsafe impl crate::object::Traverse for PyType {
         if let Some(base) = self.base.deref() {
             tracer_fn(base.as_object());
         }
-        self.bases.traverse(tracer_fn);
+        tracer_fn(self.bases.read_recursive().as_untyped().as_object());
         self.mro.traverse(tracer_fn);
         self.subclasses.traverse(tracer_fn);
         self.attributes
@@ -305,7 +264,9 @@ unsafe impl crate::object::Traverse for PyType {
             out.push(base.into());
         }
         if let Some(mut bases) = self.bases.try_write() {
-            bases.clear(out);
+            let empty = object::PyBaseObject::static_type().bases.read().clone();
+            let old_bases = core::mem::replace(&mut *bases, empty);
+            out.push(old_bases.into_untyped().into());
         }
         if let Some(mut guard) = self.mro.try_write() {
             for typ in guard.drain(..) {
@@ -856,7 +817,7 @@ impl PyType {
         let new_type = PyRef::new_ref(
             Self {
                 base: Some(base).into(),
-                bases: PyRwLock::new(PyTypeBases::Tuple(bases)),
+                bases: PyRwLock::new(bases),
                 mro: PyRwLock::new(mro),
                 subclasses: PyRwLock::default(),
                 attributes: PyRwLock::new(attrs),
@@ -914,13 +875,14 @@ impl PyType {
         }
 
         let inherited_abc_tpflags = Self::inherited_abc_tpflags(core::slice::from_ref(&base));
-        let bases = PyRwLock::new(PyTypeBases::Bootstrap(vec![base.clone()]));
+        let bases =
+            PyTuple::new_ref_typed_with_type(vec![base.clone()], PyTuple::static_type().to_owned());
         let mro = base.mro_map_collect(|x| x.to_owned());
 
         let new_type = PyRef::new_ref(
             Self {
                 base: Some(base).into(),
-                bases,
+                bases: PyRwLock::new(bases),
                 mro: PyRwLock::new(mro),
                 subclasses: PyRwLock::default(),
                 attributes: PyRwLock::new(attrs),
@@ -1031,6 +993,11 @@ impl PyType {
                 .alloc
                 .store(base.and_then(|base| base.slots.alloc.load()));
         }
+    }
+
+    pub(crate) fn finalize_bootstrap_static(typ: &Py<Self>) {
+        Self::set_new(&typ.slots, typ.base.deref());
+        Self::set_alloc(&typ.slots, typ.base.deref());
     }
 
     /// Inherit readonly slots from base type at creation time.
@@ -1508,21 +1475,7 @@ impl Py<PyType> {
 impl PyType {
     #[pygetset]
     fn __bases__(&self, vm: &VirtualMachine) -> PyTupleRef {
-        let bases = Self::with_type_lock(vm, || self.bases.read().clone());
-        let types = match bases {
-            PyTypeBases::Tuple(tuple) => return tuple.into_untyped(),
-            PyTypeBases::Bootstrap(types) => types,
-        };
-
-        let tuple = PyTuple::new_ref_typed(types, &vm.ctx);
-        Self::with_type_lock(vm, || {
-            let mut bases = self.bases.write();
-            if let PyTypeBases::Tuple(current) = &*bases {
-                return current.clone().into_untyped();
-            }
-            *bases = PyTypeBases::Tuple(tuple.clone());
-            tuple.into_untyped()
-        })
+        Self::with_type_lock(vm, || self.bases.read().clone().into_untyped())
     }
     #[pygetset(setter, name = "__bases__")]
     fn set_bases(zelf: &Py<Self>, bases_tuple: PyTupleRef, vm: &VirtualMachine) -> PyResult<()> {
@@ -1614,8 +1567,7 @@ impl PyType {
                 *subclasses = kept;
             }
 
-            let mut old_bases =
-                core::mem::replace(&mut *zelf.bases.write(), PyTypeBases::Tuple(bases));
+            let old_bases = core::mem::replace(&mut *zelf.bases.write(), bases);
             let old_base = unsafe { zelf.base.swap(Some(new_base)) };
 
             // Recursively update the mros of this class and all subclasses,
@@ -1651,12 +1603,12 @@ impl PyType {
                     retired.extend(failed_mro.into_iter().map(Into::into));
                     retired.push(cls.into());
                 }
-                let mut failed_bases = core::mem::replace(&mut *zelf.bases.write(), old_bases);
+                let failed_bases = core::mem::replace(&mut *zelf.bases.write(), old_bases);
                 if let Some(failed_base) = unsafe { zelf.base.swap(old_base) } {
                     keep_alive(failed_base, &mut retired);
                 }
                 register_subclasses(&zelf.bases.read());
-                failed_bases.clear(&mut retired);
+                retired.push(failed_bases.into_untyped().into());
                 zelf.modified_inner();
                 return Err(err);
             }
@@ -1666,7 +1618,7 @@ impl PyType {
                 retired.extend(old_mro.into_iter().map(Into::into));
                 retired.push(cls.into());
             }
-            old_bases.clear(&mut retired);
+            retired.push(old_bases.into_untyped().into());
             if let Some(old_base) = old_base {
                 keep_alive(old_base, &mut retired);
             }

--- a/crates/vm/src/builtins/type.rs
+++ b/crates/vm/src/builtins/type.rs
@@ -42,12 +42,54 @@ use num_traits::ToPrimitive;
 use rustpython_common::wtf8::Wtf8;
 use std::collections::HashSet;
 
+type PyTypeTupleRef = PyRef<PyTuple<PyTypeRef>>;
+
+#[derive(Clone, Debug)]
+pub enum PyTypeBases {
+    /// Bases created before a Python tuple can be allocated.
+    Bootstrap(Vec<PyTypeRef>),
+    /// The Python-visible tuple, with every element validated as a type.
+    Tuple(PyTypeTupleRef),
+}
+
+impl Default for PyTypeBases {
+    fn default() -> Self {
+        Self::Bootstrap(Vec::new())
+    }
+}
+
+impl Deref for PyTypeBases {
+    type Target = [PyTypeRef];
+
+    fn deref(&self) -> &Self::Target {
+        match self {
+            Self::Bootstrap(bases) => bases,
+            Self::Tuple(bases) => bases.as_slice(),
+        }
+    }
+}
+
+unsafe impl Traverse for PyTypeBases {
+    fn traverse(&self, tracer_fn: &mut TraverseFn<'_>) {
+        match self {
+            Self::Bootstrap(bases) => bases.traverse(tracer_fn),
+            Self::Tuple(bases) => tracer_fn(bases.as_untyped().as_object()),
+        }
+    }
+
+    fn clear(&mut self, out: &mut Vec<PyObjectRef>) {
+        match core::mem::take(self) {
+            Self::Bootstrap(bases) => out.extend(bases.into_iter().map(Into::into)),
+            Self::Tuple(bases) => out.push(bases.into_untyped().into()),
+        }
+    }
+}
+
 #[pyclass(module = false, name = "type", traverse = "manual")]
 pub struct PyType {
     /// tp_base. Written under the type lock (see `set_bases`); read lock-free.
     pub base: PyAtomicRef<Option<Self>>,
-    pub bases: PyRwLock<Vec<PyTypeRef>>,
-    pub(crate) bases_tuple: PyRwLock<Option<PyTupleRef>>,
+    pub bases: PyRwLock<PyTypeBases>,
     pub mro: PyRwLock<Vec<PyTypeRef>>,
     pub subclasses: PyRwLock<Vec<PyRef<PyWeak>>>,
     pub attributes: PyRwLock<PyAttributes>,
@@ -244,7 +286,6 @@ unsafe impl crate::object::Traverse for PyType {
             tracer_fn(base.as_object());
         }
         self.bases.traverse(tracer_fn);
-        self.bases_tuple.traverse(tracer_fn);
         self.mro.traverse(tracer_fn);
         self.subclasses.traverse(tracer_fn);
         self.attributes
@@ -263,15 +304,8 @@ unsafe impl crate::object::Traverse for PyType {
         if let Some(base) = unsafe { self.base.swap(None) } {
             out.push(base.into());
         }
-        if let Some(mut guard) = self.bases.try_write() {
-            for base in guard.drain(..) {
-                out.push(base.into());
-            }
-        }
-        if let Some(mut guard) = self.bases_tuple.try_write()
-            && let Some(bases) = guard.take()
-        {
-            out.push(bases.into());
+        if let Some(mut bases) = self.bases.try_write() {
+            bases.clear(out);
         }
         if let Some(mut guard) = self.mro.try_write() {
             for typ in guard.drain(..) {
@@ -597,6 +631,7 @@ impl PyType {
             type_data: PyRwLock::new(None),
             specialization_cache: TypeSpecializationCache::new(),
         };
+        let bases = PyTuple::new_ref_typed(bases, ctx);
         let base = bases[0].clone();
 
         Self::new_heap_inner(base, bases, attrs, slots, heaptype_ext, metaclass, ctx)
@@ -765,7 +800,7 @@ impl PyType {
     #[allow(clippy::too_many_arguments)]
     fn new_heap_inner(
         base: PyRef<Self>,
-        bases: Vec<PyRef<Self>>,
+        bases: PyTypeTupleRef,
         attrs: PyAttributes,
         mut slots: PyTypeSlots,
         heaptype_ext: HeapTypeExt,
@@ -821,8 +856,7 @@ impl PyType {
         let new_type = PyRef::new_ref(
             Self {
                 base: Some(base).into(),
-                bases: PyRwLock::new(bases),
-                bases_tuple: PyRwLock::default(),
+                bases: PyRwLock::new(PyTypeBases::Tuple(bases)),
                 mro: PyRwLock::new(mro),
                 subclasses: PyRwLock::default(),
                 attributes: PyRwLock::new(attrs),
@@ -880,14 +914,13 @@ impl PyType {
         }
 
         let inherited_abc_tpflags = Self::inherited_abc_tpflags(core::slice::from_ref(&base));
-        let bases = PyRwLock::new(vec![base.clone()]);
+        let bases = PyRwLock::new(PyTypeBases::Bootstrap(vec![base.clone()]));
         let mro = base.mro_map_collect(|x| x.to_owned());
 
         let new_type = PyRef::new_ref(
             Self {
                 base: Some(base).into(),
                 bases,
-                bases_tuple: PyRwLock::default(),
                 mro: PyRwLock::new(mro),
                 subclasses: PyRwLock::default(),
                 attributes: PyRwLock::new(attrs),
@@ -1475,26 +1508,21 @@ impl Py<PyType> {
 impl PyType {
     #[pygetset]
     fn __bases__(&self, vm: &VirtualMachine) -> PyTupleRef {
-        enum BasesSnapshot {
-            Tuple(PyTupleRef),
-            Types(Vec<PyTypeRef>),
-        }
+        let bases = Self::with_type_lock(vm, || self.bases.read().clone());
+        let types = match bases {
+            PyTypeBases::Tuple(tuple) => return tuple.into_untyped(),
+            PyTypeBases::Bootstrap(types) => types,
+        };
 
-        let bases = Self::with_type_lock(vm, || {
-            self.bases_tuple.read().clone().map_or_else(
-                || BasesSnapshot::Types(self.bases.read().clone()),
-                BasesSnapshot::Tuple,
-            )
-        });
-        match bases {
-            BasesSnapshot::Tuple(tuple) => tuple,
-            BasesSnapshot::Types(types) => vm.ctx.new_tuple(
-                types
-                    .into_iter()
-                    .map(|typ| typ.as_object().to_owned())
-                    .collect(),
-            ),
-        }
+        let tuple = PyTuple::new_ref_typed(types, &vm.ctx);
+        Self::with_type_lock(vm, || {
+            let mut bases = self.bases.write();
+            if let PyTypeBases::Tuple(current) = &*bases {
+                return current.clone().into_untyped();
+            }
+            *bases = PyTypeBases::Tuple(tuple.clone());
+            tuple.into_untyped()
+        })
     }
     #[pygetset(setter, name = "__bases__")]
     fn set_bases(zelf: &Py<Self>, bases_tuple: PyTupleRef, vm: &VirtualMachine) -> PyResult<()> {
@@ -1512,18 +1540,16 @@ impl PyType {
                 zelf.name()
             )));
         }
-        let bases = bases_tuple
-            .iter()
-            .map(|base| {
-                base.clone().downcast::<Self>().map_err(|base| {
-                    vm.new_type_error(format!(
-                        "{}.__bases__ must be tuple of classes, not '{}'",
-                        zelf.name(),
-                        base.class().name()
-                    ))
-                })
-            })
-            .collect::<PyResult<Vec<_>>>()?;
+        for base in bases_tuple.iter() {
+            if base.downcast_ref::<Self>().is_none() {
+                return Err(vm.new_type_error(format!(
+                    "{}.__bases__ must be tuple of classes, not '{}'",
+                    zelf.name(),
+                    base.class().name()
+                )));
+            }
+        }
+        let bases = bases_tuple.try_into_typed::<Self>(vm)?;
 
         // TODO: check for mro cycles
 
@@ -1588,7 +1614,8 @@ impl PyType {
                 *subclasses = kept;
             }
 
-            let old_bases = core::mem::replace(&mut *zelf.bases.write(), bases);
+            let mut old_bases =
+                core::mem::replace(&mut *zelf.bases.write(), PyTypeBases::Tuple(bases));
             let old_base = unsafe { zelf.base.swap(Some(new_base)) };
 
             // Recursively update the mros of this class and all subclasses,
@@ -1624,12 +1651,12 @@ impl PyType {
                     retired.extend(failed_mro.into_iter().map(Into::into));
                     retired.push(cls.into());
                 }
-                let failed_bases = core::mem::replace(&mut *zelf.bases.write(), old_bases);
+                let mut failed_bases = core::mem::replace(&mut *zelf.bases.write(), old_bases);
                 if let Some(failed_base) = unsafe { zelf.base.swap(old_base) } {
                     keep_alive(failed_base, &mut retired);
                 }
                 register_subclasses(&zelf.bases.read());
-                retired.extend(failed_bases.into_iter().map(Into::into));
+                failed_bases.clear(&mut retired);
                 zelf.modified_inner();
                 return Err(err);
             }
@@ -1639,7 +1666,7 @@ impl PyType {
                 retired.extend(old_mro.into_iter().map(Into::into));
                 retired.push(cls.into());
             }
-            retired.extend(old_bases.into_iter().map(Into::into));
+            old_bases.clear(&mut retired);
             if let Some(old_base) = old_base {
                 keep_alive(old_base, &mut retired);
             }
@@ -1649,13 +1676,6 @@ impl PyType {
             zelf.update_all_slots(&vm.ctx);
 
             register_subclasses(&zelf.bases.read());
-            let old_bases_tuple = {
-                let mut bases = zelf.bases_tuple.write();
-                bases.replace(bases_tuple)
-            };
-            if let Some(bases) = old_bases_tuple {
-                retired.push(bases.into());
-            }
             Ok(())
         });
         drop(retired);
@@ -2140,7 +2160,6 @@ impl Constructor for PyType {
 
         let (name, bases, dict, kwargs): (PyStrRef, PyTupleRef, PyDictRef, KwArgs) =
             args.clone().bind(vm)?;
-        let original_bases = (!bases.is_empty()).then(|| bases.clone());
 
         if name.as_bytes().contains(&0) {
             return Err(vm.new_value_error("type name must not contain null characters"));
@@ -2149,26 +2168,24 @@ impl Constructor for PyType {
 
         let (metatype, base, bases, base_is_type) = if bases.is_empty() {
             let base = vm.ctx.types.object_type.to_owned();
-            (metatype, base.clone(), vec![base], false)
+            let bases = PyTuple::new_ref_typed(vec![base.clone()], &vm.ctx);
+            (metatype, base, bases, false)
         } else {
-            let bases = bases
-                .iter()
-                .map(|obj| {
-                    obj.clone().downcast::<Self>().or_else(|obj| {
-                        if vm
-                            .get_attribute_opt(obj, identifier!(vm, __mro_entries__))?
-                            .is_some()
-                        {
-                            Err(vm.new_type_error(
-                                "type() doesn't support MRO entry resolution; \
-                                 use types.new_class()",
-                            ))
-                        } else {
-                            Err(vm.new_type_error("bases must be types"))
-                        }
-                    })
-                })
-                .collect::<PyResult<Vec<_>>>()?;
+            for obj in bases.iter() {
+                if obj.downcast_ref::<Self>().is_none() {
+                    if vm
+                        .get_attribute_opt(obj.clone(), identifier!(vm, __mro_entries__))?
+                        .is_some()
+                    {
+                        return Err(vm.new_type_error(
+                            "type() doesn't support MRO entry resolution; \
+                             use types.new_class()",
+                        ));
+                    }
+                    return Err(vm.new_type_error("bases must be types"));
+                }
+            }
+            let bases = bases.try_into_typed::<Self>(vm)?;
 
             // Search the bases for the proper metatype to deal with this:
             let winner = calculate_meta_class(metatype.clone(), &bases, vm)?;
@@ -2422,16 +2439,6 @@ impl Constructor for PyType {
             &vm.ctx,
         )
         .map_err(|e| vm.new_type_error(e))?;
-
-        *typ.bases_tuple.write() = Some(original_bases.unwrap_or_else(|| {
-            vm.ctx.new_tuple(
-                typ.bases
-                    .read()
-                    .iter()
-                    .map(|base| base.as_object().to_owned())
-                    .collect(),
-            )
-        }));
 
         if let Some(ref slots) = heaptype_slots {
             let class_name = typ.name().to_string();

--- a/crates/vm/src/object/core.rs
+++ b/crates/vm/src/object/core.rs
@@ -17,7 +17,7 @@ use super::{
 };
 use crate::object::traverse_object::PyObjVTable;
 use crate::{
-    builtins::{PyDictRef, PyType, PyTypeBases, PyTypeRef},
+    builtins::{PyDictRef, PyTuple, PyTupleRef, PyType, PyTypeRef, type_::PyTypeTupleRef},
     common::{
         atomic::{Ordering, PyAtomic, Radium},
         linked_list::{Link, Pointers},
@@ -2309,12 +2309,12 @@ impl<T> Clone for PyRef<T> {
 }
 
 impl<T: PyPayload> PyRef<T> {
-    // #[inline(always)]
-    // pub(crate) const fn into_non_null(self) -> NonNull<Py<T>> {
-    //     let ptr = self.ptr;
-    //     std::mem::forget(self);
-    //     ptr
-    // }
+    #[inline(always)]
+    pub(super) const fn into_non_null(self) -> NonNull<Py<T>> {
+        let ptr = self.ptr;
+        core::mem::forget(self);
+        ptr
+    }
 
     #[inline(always)]
     pub(crate) const unsafe fn from_non_null(ptr: NonNull<Py<T>>) -> Self {
@@ -2547,156 +2547,195 @@ impl<T: PyPayload> PyWeakRef<T> {
 
 /// Partially initialize a struct, ensuring that all fields are
 /// either given values or explicitly left uninitialized
-macro_rules! partially_init {
-    (
-        $ty:path {$($init_field:ident: $init_value:expr),*$(,)?},
-        Uninit { $($uninit_field:ident),*$(,)? }$(,)?
-    ) => {{
-        // check all the fields are there but *don't* actually run it
-
-        #[allow(clippy::diverging_sub_expression, reason = "intentional compile-time field check in an unreachable branch")]
-        if false {
-            #[allow(invalid_value, dead_code, unreachable_code)]
-            let _ = {$ty {
-                $($init_field: $init_value,)*
-                $($uninit_field: unreachable!(),)*
-            }};
-        }
-        let mut m = ::core::mem::MaybeUninit::<$ty>::uninit();
-        #[allow(unused_unsafe)]
-        unsafe {
-            $(::core::ptr::write(&mut (*m.as_mut_ptr()).$init_field, $init_value);)*
-        }
-        m
-    }};
+pub(crate) struct BootstrapTypeHierarchy {
+    pub type_type: PyTypeRef,
+    pub object_type: PyTypeRef,
+    pub tuple_type: PyTypeRef,
+    pub weakref_type: PyTypeRef,
+    pub empty_tuple: PyTupleRef,
 }
 
-pub(crate) fn init_type_hierarchy() -> (PyTypeRef, PyTypeRef, PyTypeRef) {
-    use crate::{builtins::object, class::PyClassImpl};
+pub(crate) fn init_type_hierarchy() -> BootstrapTypeHierarchy {
+    use crate::{
+        builtins::{object, tuple},
+        class::PyClassImpl,
+    };
     use core::mem::MaybeUninit;
 
-    // `type` inherits from `object`
-    // and both `type` and `object are instances of `type`.
-    // to produce this circular dependency, we need an unsafe block.
-    // (and yes, this will never get dropped. TODO?)
-    let (type_type, object_type) = {
-        // We cast between these 2 types, so make sure (at compile time) that there's no change in
-        // layout when we wrap PyInner<PyTypeObj> in MaybeUninit<>
-        static_assertions::assert_eq_size!(MaybeUninit<PyInner<PyType>>, PyInner<PyType>);
-        static_assertions::assert_eq_align!(MaybeUninit<PyInner<PyType>>, PyInner<PyType>);
+    static_assertions::assert_eq_size!(MaybeUninit<PyInner<PyType>>, PyInner<PyType>);
+    static_assertions::assert_eq_align!(MaybeUninit<PyInner<PyType>>, PyInner<PyType>);
+    static_assertions::assert_eq_size!(MaybeUninit<PyInner<PyTuple>>, PyInner<PyTuple>);
+    static_assertions::assert_eq_align!(MaybeUninit<PyInner<PyTuple>>, PyInner<PyTuple>);
 
-        let type_payload = PyType {
-            base: None.into(),
-            bases: PyRwLock::default(),
-            mro: PyRwLock::default(),
-            subclasses: PyRwLock::default(),
-            attributes: PyRwLock::new(Default::default()),
-            slots: PyType::make_slots(),
-            heaptype_ext: None,
-            tp_version_tag: core::sync::atomic::AtomicU32::new(0),
-            abc_tpflags: core::sync::atomic::AtomicU64::new(0),
-        };
-        let object_payload = PyType {
-            base: None.into(),
-            bases: PyRwLock::default(),
-            mro: PyRwLock::default(),
-            subclasses: PyRwLock::default(),
-            attributes: PyRwLock::new(Default::default()),
-            slots: object::PyBaseObject::make_slots(),
-            heaptype_ext: None,
-            tp_version_tag: core::sync::atomic::AtomicU32::new(0),
-            abc_tpflags: core::sync::atomic::AtomicU64::new(0),
-        };
-        // Both type_type and object_type are instances of `type`, which has
-        // HAS_DICT and HAS_WEAKREF, so they need both ObjExt and WeakRefList prefixes.
-        // Layout: [ObjExt][WeakRefList][PyInner<PyType>]
-        let alloc_type_with_prefixes = || -> *mut MaybeUninit<PyInner<PyType>> {
-            let inner_layout = core::alloc::Layout::new::<MaybeUninit<PyInner<PyType>>>();
-            let ext_layout = core::alloc::Layout::new::<ObjExt>();
-            let weakref_layout = core::alloc::Layout::new::<WeakRefList>();
+    // All three core type objects are instances of `type`, which has HAS_DICT
+    // and HAS_WEAKREF. Their allocations therefore need both prefixes.
+    let alloc_type_with_prefixes = || -> *mut PyInner<PyType> {
+        let inner_layout = core::alloc::Layout::new::<MaybeUninit<PyInner<PyType>>>();
+        let ext_layout = core::alloc::Layout::new::<ObjExt>();
+        let weakref_layout = core::alloc::Layout::new::<WeakRefList>();
 
-            let (layout, weakref_offset) = ext_layout.extend(weakref_layout).unwrap();
-            let (combined, inner_offset) = layout.extend(inner_layout).unwrap();
-            let combined = combined.pad_to_align();
+        let (layout, weakref_offset) = ext_layout.extend(weakref_layout).unwrap();
+        let (combined, inner_offset) = layout.extend(inner_layout).unwrap();
+        let combined = combined.pad_to_align();
 
-            let alloc_ptr = unsafe { alloc::alloc::alloc(combined) };
-            if alloc_ptr.is_null() {
-                alloc::alloc::handle_alloc_error(combined);
-            }
-            alloc_ptr.expose_provenance();
-
-            unsafe {
-                let ext_ptr = alloc_ptr as *mut ObjExt;
-                ext_ptr.write(ObjExt::new(None, 0, true));
-
-                let weakref_ptr = alloc_ptr.add(weakref_offset) as *mut WeakRefList;
-                weakref_ptr.write(WeakRefList::new());
-
-                alloc_ptr.add(inner_offset) as *mut MaybeUninit<PyInner<PyType>>
-            }
-        };
-
-        let type_type_ptr = alloc_type_with_prefixes();
-        unsafe {
-            type_type_ptr.write(partially_init!(
-                PyInner::<PyType> {
-                    ref_count: RefCount::new(),
-                    vtable: PyObjVTable::of::<PyType>(),
-                    gc_bits: Radium::new(0),
-                    gc_generation: Radium::new(GC_UNTRACKED),
-                    gc_pointers: Pointers::new(),
-                    payload: type_payload,
-                },
-                Uninit { typ }
-            ));
+        let alloc_ptr = unsafe { alloc::alloc::alloc(combined) };
+        if alloc_ptr.is_null() {
+            alloc::alloc::handle_alloc_error(combined);
         }
-
-        let object_type_ptr = alloc_type_with_prefixes();
-        unsafe {
-            object_type_ptr.write(partially_init!(
-                PyInner::<PyType> {
-                    ref_count: RefCount::new(),
-                    vtable: PyObjVTable::of::<PyType>(),
-                    gc_bits: Radium::new(0),
-                    gc_generation: Radium::new(GC_UNTRACKED),
-                    gc_pointers: Pointers::new(),
-                    payload: object_payload,
-                },
-                Uninit { typ },
-            ));
-        }
-
-        let object_type_ptr = object_type_ptr as *mut PyInner<PyType>;
-        let type_type_ptr = type_type_ptr as *mut PyInner<PyType>;
+        alloc_ptr.expose_provenance();
 
         unsafe {
-            (*type_type_ptr).ref_count.inc();
-            let type_type = PyTypeRef::from_raw(type_type_ptr.cast());
-            ptr::write(&mut (*object_type_ptr).typ, PyAtomicRef::from(type_type));
-            (*type_type_ptr).ref_count.inc();
-            let type_type = PyTypeRef::from_raw(type_type_ptr.cast());
-            ptr::write(&mut (*type_type_ptr).typ, PyAtomicRef::from(type_type));
-
-            let object_type = PyTypeRef::from_raw(object_type_ptr.cast());
-            // object's mro is [object]
-            (*object_type_ptr).payload.mro = PyRwLock::new(vec![object_type.clone()]);
-
-            (*type_type_ptr).payload.bases =
-                PyRwLock::new(PyTypeBases::Bootstrap(vec![object_type.clone()]));
-            (*type_type_ptr).payload.base = Some(object_type.clone()).into();
-
-            let type_type = PyTypeRef::from_raw(type_type_ptr.cast());
-            // type's mro is [type, object]
-            (*type_type_ptr).payload.mro =
-                PyRwLock::new(vec![type_type.clone(), object_type.clone()]);
-
-            (type_type, object_type)
+            (alloc_ptr as *mut ObjExt).write(ObjExt::new(None, 0, true));
+            (alloc_ptr.add(weakref_offset) as *mut WeakRefList).write(WeakRefList::new());
+            alloc_ptr.add(inner_offset).cast()
         }
     };
 
-    let weakref_type = PyType {
+    let alloc_tuple = || {
+        Box::into_raw(Box::new(MaybeUninit::<PyInner<PyTuple>>::uninit()))
+            .cast::<PyInner<PyTuple>>()
+    };
+
+    unsafe fn init_ref_count<T>(ptr: *mut PyInner<T>) {
+        unsafe { ptr::addr_of_mut!((*ptr).ref_count).write(RefCount::new()) };
+    }
+
+    unsafe fn initial_ref<T: PyPayload>(ptr: *mut PyInner<T>) -> PyRef<T> {
+        unsafe { PyRef::from_raw(ptr.cast()) }
+    }
+
+    unsafe fn clone_raw_ref<T: PyPayload>(ptr: *mut PyInner<T>) -> PyRef<T> {
+        unsafe { &*ptr::addr_of!((*ptr).ref_count) }.inc();
+        unsafe { PyRef::from_raw(ptr.cast()) }
+    }
+
+    unsafe fn into_type_tuple(tuple: PyTupleRef) -> PyTypeTupleRef {
+        // SAFETY: PyTypeRef and PyObjectRef have the same layout, and the
+        // bootstrap tuples contain only PyType objects.
+        unsafe { core::mem::transmute::<PyTupleRef, PyTypeTupleRef>(tuple) }
+    }
+
+    unsafe fn init_inner<T>(ptr: *mut PyInner<T>, typ: PyTypeRef, payload: T)
+    where
+        T: PyPayload + MaybeTraverse + fmt::Debug,
+    {
+        unsafe {
+            ptr::addr_of_mut!((*ptr).vtable).write(PyObjVTable::of::<T>());
+            ptr::addr_of_mut!((*ptr).gc_bits).write(Radium::new(0));
+            ptr::addr_of_mut!((*ptr).gc_generation).write(Radium::new(GC_UNTRACKED));
+            ptr::addr_of_mut!((*ptr).gc_pointers).write(Pointers::new());
+            ptr::addr_of_mut!((*ptr).typ).write(PyAtomicRef::from_ref_without_retag(typ));
+            ptr::addr_of_mut!((*ptr).payload).write(payload);
+        }
+    }
+
+    let type_type_ptr = alloc_type_with_prefixes();
+    let object_type_ptr = alloc_type_with_prefixes();
+    let tuple_type_ptr = alloc_type_with_prefixes();
+    let empty_tuple_ptr = alloc_tuple();
+    let type_bases_ptr = alloc_tuple();
+    let tuple_bases_ptr = alloc_tuple();
+
+    unsafe {
+        init_ref_count(type_type_ptr);
+        init_ref_count(object_type_ptr);
+        init_ref_count(tuple_type_ptr);
+        init_ref_count(empty_tuple_ptr);
+        init_ref_count(type_bases_ptr);
+        init_ref_count(tuple_bases_ptr);
+    }
+
+    // Each initial reference consumes the allocation's initial strong count.
+    // Further references are created through clone_raw_ref while the graph is
+    // still being assembled and cannot yet be safely dereferenced.
+    let type_type = unsafe { initial_ref(type_type_ptr) };
+    let object_type = unsafe { initial_ref(object_type_ptr) };
+    let tuple_type = unsafe { initial_ref(tuple_type_ptr) };
+    let empty_tuple = unsafe { initial_ref(empty_tuple_ptr) };
+    let type_bases = unsafe { into_type_tuple(initial_ref(type_bases_ptr)) };
+    let tuple_bases = unsafe { into_type_tuple(initial_ref(tuple_bases_ptr)) };
+
+    let type_payload = PyType {
+        base: unsafe {
+            PyAtomicRef::from_optional_ref_without_retag(Some(clone_raw_ref(object_type_ptr)))
+        },
+        bases: PyRwLock::new(type_bases),
+        mro: PyRwLock::new(vec![unsafe { clone_raw_ref(type_type_ptr) }, unsafe {
+            clone_raw_ref(object_type_ptr)
+        }]),
+        subclasses: PyRwLock::default(),
+        attributes: PyRwLock::default(),
+        slots: PyType::make_slots(),
+        heaptype_ext: None,
+        tp_version_tag: core::sync::atomic::AtomicU32::new(0),
+        abc_tpflags: core::sync::atomic::AtomicU64::new(0),
+    };
+    let object_payload = PyType {
+        base: unsafe { PyAtomicRef::from_optional_ref_without_retag(None) },
+        bases: PyRwLock::new(unsafe { into_type_tuple(clone_raw_ref(empty_tuple_ptr)) }),
+        mro: PyRwLock::new(vec![unsafe { clone_raw_ref(object_type_ptr) }]),
+        subclasses: PyRwLock::default(),
+        attributes: PyRwLock::default(),
+        slots: object::PyBaseObject::make_slots(),
+        heaptype_ext: None,
+        tp_version_tag: core::sync::atomic::AtomicU32::new(0),
+        abc_tpflags: core::sync::atomic::AtomicU64::new(0),
+    };
+    let tuple_payload = PyType {
+        base: unsafe {
+            PyAtomicRef::from_optional_ref_without_retag(Some(clone_raw_ref(object_type_ptr)))
+        },
+        bases: PyRwLock::new(tuple_bases),
+        mro: PyRwLock::new(vec![unsafe { clone_raw_ref(tuple_type_ptr) }, unsafe {
+            clone_raw_ref(object_type_ptr)
+        }]),
+        subclasses: PyRwLock::default(),
+        attributes: PyRwLock::default(),
+        slots: tuple::PyTuple::make_slots(),
+        heaptype_ext: None,
+        tp_version_tag: core::sync::atomic::AtomicU32::new(0),
+        abc_tpflags: core::sync::atomic::AtomicU64::new(0),
+    };
+
+    let object_element =
+        || -> PyObjectRef { unsafe { clone_raw_ref::<PyType>(object_type_ptr) }.into() };
+    unsafe {
+        init_inner(type_type_ptr, clone_raw_ref(type_type_ptr), type_payload);
+        init_inner(
+            object_type_ptr,
+            clone_raw_ref(type_type_ptr),
+            object_payload,
+        );
+        init_inner(tuple_type_ptr, clone_raw_ref(type_type_ptr), tuple_payload);
+        init_inner(
+            empty_tuple_ptr,
+            clone_raw_ref(tuple_type_ptr),
+            PyTuple::new_unchecked(Vec::new().into_boxed_slice()),
+        );
+        init_inner(
+            type_bases_ptr,
+            clone_raw_ref(tuple_type_ptr),
+            PyTuple::new_unchecked(vec![object_element()].into_boxed_slice()),
+        );
+        init_inner(
+            tuple_bases_ptr,
+            clone_raw_ref(tuple_type_ptr),
+            PyTuple::new_unchecked(vec![object_element()].into_boxed_slice()),
+        );
+    }
+
+    PyType::finalize_bootstrap_static(&tuple_type);
+
+    let weakref_bases =
+        PyTuple::new_ref_typed_with_type(vec![object_type.clone()], tuple_type.clone());
+    unsafe {
+        crate::gc_state::gc_state()
+            .untrack_object(NonNull::from(weakref_bases.as_untyped().as_object()));
+    }
+    weakref_bases.as_untyped().as_object().clear_gc_tracked();
+    let weakref_payload = PyType {
         base: Some(object_type.clone()).into(),
-        bases: PyRwLock::new(PyTypeBases::Bootstrap(vec![object_type.clone()])),
+        bases: PyRwLock::new(weakref_bases),
         mro: PyRwLock::new(vec![object_type.clone()]),
         subclasses: PyRwLock::default(),
         attributes: PyRwLock::default(),
@@ -2705,7 +2744,7 @@ pub(crate) fn init_type_hierarchy() -> (PyTypeRef, PyTypeRef, PyTypeRef) {
         tp_version_tag: core::sync::atomic::AtomicU32::new(0),
         abc_tpflags: core::sync::atomic::AtomicU64::new(0),
     };
-    let weakref_type = PyRef::new_ref(weakref_type, type_type.clone(), None);
+    let weakref_type = PyRef::new_ref(weakref_payload, type_type.clone(), None);
     // Static type: untrack from GC (was tracked by new_ref because PyType has HAS_TRAVERSE)
     unsafe {
         crate::gc_state::gc_state()
@@ -2723,13 +2762,26 @@ pub(crate) fn init_type_hierarchy() -> (PyTypeRef, PyTypeRef, PyTypeRef) {
     );
 
     object_type.subclasses.write().push(
+        tuple_type
+            .as_object()
+            .downgrade_with_weakref_typ_opt(None, weakref_type.clone())
+            .unwrap(),
+    );
+
+    object_type.subclasses.write().push(
         weakref_type
             .as_object()
             .downgrade_with_weakref_typ_opt(None, weakref_type.clone())
             .unwrap(),
     );
 
-    (type_type, object_type, weakref_type)
+    BootstrapTypeHierarchy {
+        type_type,
+        object_type,
+        tuple_type,
+        weakref_type,
+        empty_tuple,
+    }
 }
 
 #[cfg(test)]
@@ -2738,7 +2790,29 @@ mod tests {
 
     #[test]
     fn miri_test_type_initialization() {
-        let _ = init_type_hierarchy();
+        let hierarchy = init_type_hierarchy();
+
+        assert!(hierarchy.type_type.class().is(&hierarchy.type_type));
+        assert!(hierarchy.object_type.class().is(&hierarchy.type_type));
+        assert!(hierarchy.tuple_type.class().is(&hierarchy.type_type));
+        assert!(hierarchy.weakref_type.class().is(&hierarchy.type_type));
+
+        let object_bases = hierarchy.object_type.bases.read();
+        assert!(object_bases.is_empty());
+        assert!(object_bases.as_untyped().is(&hierarchy.empty_tuple));
+        assert!(object_bases.as_untyped().class().is(&hierarchy.tuple_type));
+        drop(object_bases);
+
+        for typ in [
+            &hierarchy.type_type,
+            &hierarchy.tuple_type,
+            &hierarchy.weakref_type,
+        ] {
+            let bases = typ.bases.read();
+            assert_eq!(bases.len(), 1);
+            assert!(bases[0].is(&hierarchy.object_type));
+            assert!(bases.as_untyped().class().is(&hierarchy.tuple_type));
+        }
     }
 
     #[test]

--- a/crates/vm/src/object/core.rs
+++ b/crates/vm/src/object/core.rs
@@ -17,7 +17,7 @@ use super::{
 };
 use crate::object::traverse_object::PyObjVTable;
 use crate::{
-    builtins::{PyDictRef, PyType, PyTypeRef},
+    builtins::{PyDictRef, PyType, PyTypeBases, PyTypeRef},
     common::{
         atomic::{Ordering, PyAtomic, Radium},
         linked_list::{Link, Pointers},
@@ -2771,7 +2771,6 @@ pub(crate) fn init_type_hierarchy() -> (PyTypeRef, PyTypeRef, PyTypeRef) {
         let type_payload = PyType {
             base: None.into(),
             bases: PyRwLock::default(),
-            bases_tuple: PyRwLock::default(),
             mro: PyRwLock::default(),
             subclasses: PyRwLock::default(),
             attributes: Default::default(),
@@ -2783,7 +2782,6 @@ pub(crate) fn init_type_hierarchy() -> (PyTypeRef, PyTypeRef, PyTypeRef) {
         let object_payload = PyType {
             base: None.into(),
             bases: PyRwLock::default(),
-            bases_tuple: PyRwLock::default(),
             mro: PyRwLock::default(),
             subclasses: PyRwLock::default(),
             attributes: Default::default(),
@@ -2870,7 +2868,8 @@ pub(crate) fn init_type_hierarchy() -> (PyTypeRef, PyTypeRef, PyTypeRef) {
             // object's mro is [object]
             (*object_type_ptr).payload.mro = PyRwLock::new(vec![object_type.clone()]);
 
-            (*type_type_ptr).payload.bases = PyRwLock::new(vec![object_type.clone()]);
+            (*type_type_ptr).payload.bases =
+                PyRwLock::new(PyTypeBases::Bootstrap(vec![object_type.clone()]));
             (*type_type_ptr).payload.base = Some(object_type.clone()).into();
 
             let type_type = PyTypeRef::from_raw(type_type_ptr.cast());
@@ -2884,8 +2883,7 @@ pub(crate) fn init_type_hierarchy() -> (PyTypeRef, PyTypeRef, PyTypeRef) {
 
     let weakref_type = PyType {
         base: Some(object_type.clone()).into(),
-        bases: PyRwLock::new(vec![object_type.clone()]),
-        bases_tuple: PyRwLock::default(),
+        bases: PyRwLock::new(PyTypeBases::Bootstrap(vec![object_type.clone()])),
         mro: PyRwLock::new(vec![object_type.clone()]),
         subclasses: PyRwLock::default(),
         attributes: Default::default(),

--- a/crates/vm/src/object/core.rs
+++ b/crates/vm/src/object/core.rs
@@ -2771,6 +2771,7 @@ pub(crate) fn init_type_hierarchy() -> (PyTypeRef, PyTypeRef, PyTypeRef) {
         let type_payload = PyType {
             base: None.into(),
             bases: PyRwLock::default(),
+            bases_tuple: PyRwLock::default(),
             mro: PyRwLock::default(),
             subclasses: PyRwLock::default(),
             attributes: Default::default(),
@@ -2782,6 +2783,7 @@ pub(crate) fn init_type_hierarchy() -> (PyTypeRef, PyTypeRef, PyTypeRef) {
         let object_payload = PyType {
             base: None.into(),
             bases: PyRwLock::default(),
+            bases_tuple: PyRwLock::default(),
             mro: PyRwLock::default(),
             subclasses: PyRwLock::default(),
             attributes: Default::default(),
@@ -2883,6 +2885,7 @@ pub(crate) fn init_type_hierarchy() -> (PyTypeRef, PyTypeRef, PyTypeRef) {
     let weakref_type = PyType {
         base: Some(object_type.clone()).into(),
         bases: PyRwLock::new(vec![object_type.clone()]),
+        bases_tuple: PyRwLock::default(),
         mro: PyRwLock::new(vec![object_type.clone()]),
         subclasses: PyRwLock::default(),
         attributes: Default::default(),

--- a/crates/vm/src/object/core.rs
+++ b/crates/vm/src/object/core.rs
@@ -17,7 +17,7 @@ use super::{
 };
 use crate::object::traverse_object::PyObjVTable;
 use crate::{
-    builtins::{PyDictRef, PyType, PyTypeRef},
+    builtins::{PyDictRef, PyType, PyTypeBases, PyTypeRef},
     common::{
         atomic::{Ordering, PyAtomic, Radium},
         linked_list::{Link, Pointers},
@@ -2588,7 +2588,6 @@ pub(crate) fn init_type_hierarchy() -> (PyTypeRef, PyTypeRef, PyTypeRef) {
         let type_payload = PyType {
             base: None.into(),
             bases: PyRwLock::default(),
-            bases_tuple: PyRwLock::default(),
             mro: PyRwLock::default(),
             subclasses: PyRwLock::default(),
             attributes: PyRwLock::new(Default::default()),
@@ -2600,7 +2599,6 @@ pub(crate) fn init_type_hierarchy() -> (PyTypeRef, PyTypeRef, PyTypeRef) {
         let object_payload = PyType {
             base: None.into(),
             bases: PyRwLock::default(),
-            bases_tuple: PyRwLock::default(),
             mro: PyRwLock::default(),
             subclasses: PyRwLock::default(),
             attributes: PyRwLock::new(Default::default()),
@@ -2683,7 +2681,8 @@ pub(crate) fn init_type_hierarchy() -> (PyTypeRef, PyTypeRef, PyTypeRef) {
             // object's mro is [object]
             (*object_type_ptr).payload.mro = PyRwLock::new(vec![object_type.clone()]);
 
-            (*type_type_ptr).payload.bases = PyRwLock::new(vec![object_type.clone()]);
+            (*type_type_ptr).payload.bases =
+                PyRwLock::new(PyTypeBases::Bootstrap(vec![object_type.clone()]));
             (*type_type_ptr).payload.base = Some(object_type.clone()).into();
 
             let type_type = PyTypeRef::from_raw(type_type_ptr.cast());
@@ -2697,8 +2696,7 @@ pub(crate) fn init_type_hierarchy() -> (PyTypeRef, PyTypeRef, PyTypeRef) {
 
     let weakref_type = PyType {
         base: Some(object_type.clone()).into(),
-        bases: PyRwLock::new(vec![object_type.clone()]),
-        bases_tuple: PyRwLock::default(),
+        bases: PyRwLock::new(PyTypeBases::Bootstrap(vec![object_type.clone()])),
         mro: PyRwLock::new(vec![object_type.clone()]),
         subclasses: PyRwLock::default(),
         attributes: PyRwLock::default(),

--- a/crates/vm/src/object/core.rs
+++ b/crates/vm/src/object/core.rs
@@ -17,7 +17,7 @@ use super::{
 };
 use crate::object::traverse_object::PyObjVTable;
 use crate::{
-    builtins::{PyDictRef, PyType, PyTypeBases, PyTypeRef},
+    builtins::{PyDictRef, PyTuple, PyTupleRef, PyType, PyTypeRef, type_::PyTypeTupleRef},
     common::{
         atomic::{Ordering, PyAtomic, Radium},
         linked_list::{Link, Pointers},
@@ -2493,12 +2493,12 @@ impl<T> Clone for PyRef<T> {
 }
 
 impl<T: PyPayload> PyRef<T> {
-    // #[inline(always)]
-    // pub(crate) const fn into_non_null(self) -> NonNull<Py<T>> {
-    //     let ptr = self.ptr;
-    //     std::mem::forget(self);
-    //     ptr
-    // }
+    #[inline(always)]
+    pub(super) const fn into_non_null(self) -> NonNull<Py<T>> {
+        let ptr = self.ptr;
+        core::mem::forget(self);
+        ptr
+    }
 
     #[inline(always)]
     pub(crate) const unsafe fn from_non_null(ptr: NonNull<Py<T>>) -> Self {
@@ -2730,160 +2730,197 @@ impl<T: PyPayload> PyWeakRef<T> {
 
 /// Partially initialize a struct, ensuring that all fields are
 /// either given values or explicitly left uninitialized
-macro_rules! partially_init {
-    (
-        $ty:path {$($init_field:ident: $init_value:expr),*$(,)?},
-        Uninit { $($uninit_field:ident),*$(,)? }$(,)?
-    ) => {{
-        // check all the fields are there but *don't* actually run it
-
-        #[allow(clippy::diverging_sub_expression, reason = "intentional compile-time field check in an unreachable branch")]
-        if false {
-            #[allow(invalid_value, dead_code, unreachable_code)]
-            let _ = {$ty {
-                $($init_field: $init_value,)*
-                $($uninit_field: unreachable!(),)*
-            }};
-        }
-        let mut m = ::core::mem::MaybeUninit::<$ty>::uninit();
-        #[allow(unused_unsafe)]
-        unsafe {
-            $(::core::ptr::write(&mut (*m.as_mut_ptr()).$init_field, $init_value);)*
-        }
-        m
-    }};
+pub(crate) struct BootstrapTypeHierarchy {
+    pub type_type: PyTypeRef,
+    pub object_type: PyTypeRef,
+    pub tuple_type: PyTypeRef,
+    pub weakref_type: PyTypeRef,
+    pub empty_tuple: PyTupleRef,
 }
 
-pub(crate) fn init_type_hierarchy() -> (PyTypeRef, PyTypeRef, PyTypeRef) {
-    use crate::{builtins::object, class::PyClassImpl};
+pub(crate) fn init_type_hierarchy() -> BootstrapTypeHierarchy {
+    use crate::{
+        builtins::{object, tuple},
+        class::PyClassImpl,
+    };
     use core::mem::MaybeUninit;
 
-    // `type` inherits from `object`
-    // and both `type` and `object are instances of `type`.
-    // to produce this circular dependency, we need an unsafe block.
-    // (and yes, this will never get dropped. TODO?)
-    let (type_type, object_type) = {
-        // We cast between these 2 types, so make sure (at compile time) that there's no change in
-        // layout when we wrap PyInner<PyTypeObj> in MaybeUninit<>
-        static_assertions::assert_eq_size!(MaybeUninit<PyInner<PyType>>, PyInner<PyType>);
-        static_assertions::assert_eq_align!(MaybeUninit<PyInner<PyType>>, PyInner<PyType>);
+    static_assertions::assert_eq_size!(MaybeUninit<PyInner<PyType>>, PyInner<PyType>);
+    static_assertions::assert_eq_align!(MaybeUninit<PyInner<PyType>>, PyInner<PyType>);
+    static_assertions::assert_eq_size!(MaybeUninit<PyInner<PyTuple>>, PyInner<PyTuple>);
+    static_assertions::assert_eq_align!(MaybeUninit<PyInner<PyTuple>>, PyInner<PyTuple>);
 
-        let type_payload = PyType {
-            base: None.into(),
-            bases: PyRwLock::default(),
-            mro: PyRwLock::default(),
-            subclasses: PyRwLock::default(),
-            attributes: Default::default(),
-            slots: PyType::make_slots(),
-            heaptype_ext: None,
-            tp_version_tag: core::sync::atomic::AtomicU32::new(0),
-            abc_tpflags: core::sync::atomic::AtomicU64::new(0),
-        };
-        let object_payload = PyType {
-            base: None.into(),
-            bases: PyRwLock::default(),
-            mro: PyRwLock::default(),
-            subclasses: PyRwLock::default(),
-            attributes: Default::default(),
-            slots: object::PyBaseObject::make_slots(),
-            heaptype_ext: None,
-            tp_version_tag: core::sync::atomic::AtomicU32::new(0),
-            abc_tpflags: core::sync::atomic::AtomicU64::new(0),
-        };
-        // Both type_type and object_type are instances of `type`, which has
-        // HAS_DICT and HAS_WEAKREF, so they need both ObjExt and WeakRefList prefixes.
-        // Layout: [ObjExt][WeakRefList][PyInner<PyType>]
-        let alloc_type_with_prefixes = || -> *mut MaybeUninit<PyInner<PyType>> {
-            let inner_layout = core::alloc::Layout::new::<MaybeUninit<PyInner<PyType>>>();
-            let ext_layout = core::alloc::Layout::new::<ObjExt>();
-            let weakref_layout = core::alloc::Layout::new::<WeakRefList>();
+    // All three core type objects are instances of `type`, which has HAS_DICT
+    // and HAS_WEAKREF. Their allocations therefore need both prefixes.
+    let alloc_type_with_prefixes = || -> *mut PyInner<PyType> {
+        let inner_layout = core::alloc::Layout::new::<MaybeUninit<PyInner<PyType>>>();
+        let ext_layout = core::alloc::Layout::new::<ObjExt>();
+        let weakref_layout = core::alloc::Layout::new::<WeakRefList>();
 
-            let (layout, weakref_offset) = ext_layout.extend(weakref_layout).unwrap();
-            let (combined, inner_offset) = layout.extend(inner_layout).unwrap();
-            let combined = combined.pad_to_align();
+        let (layout, weakref_offset) = ext_layout.extend(weakref_layout).unwrap();
+        let (combined, inner_offset) = layout.extend(inner_layout).unwrap();
+        let combined = combined.pad_to_align();
 
-            let alloc_ptr = unsafe { alloc::alloc::alloc(combined) };
-            if alloc_ptr.is_null() {
-                alloc::alloc::handle_alloc_error(combined);
-            }
-            alloc_ptr.expose_provenance();
-
-            unsafe {
-                let ext_ptr = alloc_ptr as *mut ObjExt;
-                ext_ptr.write(ObjExt::new(None, 0, true));
-
-                let weakref_ptr = alloc_ptr.add(weakref_offset) as *mut WeakRefList;
-                weakref_ptr.write(WeakRefList::new());
-
-                alloc_ptr.add(inner_offset) as *mut MaybeUninit<PyInner<PyType>>
-            }
-        };
-
-        let type_type_ptr = alloc_type_with_prefixes();
-        unsafe {
-            type_type_ptr.write(partially_init!(
-                PyInner::<PyType> {
-                    ref_count: RefCount::new(),
-                    vtable: PyObjVTable::of::<PyType>(),
-                    gc_bits: Radium::new(0),
-                    gc_generation: Radium::new(GC_UNTRACKED),
-                    gc_owner: Radium::new(GC_NO_OWNER),
-                    gc_refs: Radium::new(0),
-                    gc_pointers: Pointers::new(),
-                    payload: type_payload,
-                },
-                Uninit { typ }
-            ));
+        let alloc_ptr = unsafe { alloc::alloc::alloc(combined) };
+        if alloc_ptr.is_null() {
+            alloc::alloc::handle_alloc_error(combined);
         }
-
-        let object_type_ptr = alloc_type_with_prefixes();
-        unsafe {
-            object_type_ptr.write(partially_init!(
-                PyInner::<PyType> {
-                    ref_count: RefCount::new(),
-                    vtable: PyObjVTable::of::<PyType>(),
-                    gc_bits: Radium::new(0),
-                    gc_generation: Radium::new(GC_UNTRACKED),
-                    gc_owner: Radium::new(GC_NO_OWNER),
-                    gc_refs: Radium::new(0),
-                    gc_pointers: Pointers::new(),
-                    payload: object_payload,
-                },
-                Uninit { typ },
-            ));
-        }
-
-        let object_type_ptr = object_type_ptr as *mut PyInner<PyType>;
-        let type_type_ptr = type_type_ptr as *mut PyInner<PyType>;
+        alloc_ptr.expose_provenance();
 
         unsafe {
-            (*type_type_ptr).ref_count.inc();
-            let type_type = PyTypeRef::from_raw(type_type_ptr.cast());
-            ptr::write(&mut (*object_type_ptr).typ, PyAtomicRef::from(type_type));
-            (*type_type_ptr).ref_count.inc();
-            let type_type = PyTypeRef::from_raw(type_type_ptr.cast());
-            ptr::write(&mut (*type_type_ptr).typ, PyAtomicRef::from(type_type));
-
-            let object_type = PyTypeRef::from_raw(object_type_ptr.cast());
-            // object's mro is [object]
-            (*object_type_ptr).payload.mro = PyRwLock::new(vec![object_type.clone()]);
-
-            (*type_type_ptr).payload.bases =
-                PyRwLock::new(PyTypeBases::Bootstrap(vec![object_type.clone()]));
-            (*type_type_ptr).payload.base = Some(object_type.clone()).into();
-
-            let type_type = PyTypeRef::from_raw(type_type_ptr.cast());
-            // type's mro is [type, object]
-            (*type_type_ptr).payload.mro =
-                PyRwLock::new(vec![type_type.clone(), object_type.clone()]);
-
-            (type_type, object_type)
+            (alloc_ptr as *mut ObjExt).write(ObjExt::new(None, 0, true));
+            (alloc_ptr.add(weakref_offset) as *mut WeakRefList).write(WeakRefList::new());
+            alloc_ptr.add(inner_offset).cast()
         }
     };
 
-    let weakref_type = PyType {
+    let alloc_tuple = || {
+        Box::into_raw(Box::new(MaybeUninit::<PyInner<PyTuple>>::uninit()))
+            .cast::<PyInner<PyTuple>>()
+    };
+
+    unsafe fn init_ref_count<T>(ptr: *mut PyInner<T>) {
+        unsafe { ptr::addr_of_mut!((*ptr).ref_count).write(RefCount::new()) };
+    }
+
+    unsafe fn initial_ref<T: PyPayload>(ptr: *mut PyInner<T>) -> PyRef<T> {
+        unsafe { PyRef::from_raw(ptr.cast()) }
+    }
+
+    unsafe fn clone_raw_ref<T: PyPayload>(ptr: *mut PyInner<T>) -> PyRef<T> {
+        unsafe { &*ptr::addr_of!((*ptr).ref_count) }.inc();
+        unsafe { PyRef::from_raw(ptr.cast()) }
+    }
+
+    unsafe fn into_type_tuple(tuple: PyTupleRef) -> PyTypeTupleRef {
+        // SAFETY: PyTypeRef and PyObjectRef have the same layout, and the
+        // bootstrap tuples contain only PyType objects.
+        unsafe { core::mem::transmute::<PyTupleRef, PyTypeTupleRef>(tuple) }
+    }
+
+    unsafe fn init_inner<T>(ptr: *mut PyInner<T>, typ: PyTypeRef, payload: T)
+    where
+        T: PyPayload + MaybeTraverse + fmt::Debug,
+    {
+        unsafe {
+            ptr::addr_of_mut!((*ptr).vtable).write(PyObjVTable::of::<T>());
+            ptr::addr_of_mut!((*ptr).gc_bits).write(Radium::new(0));
+            ptr::addr_of_mut!((*ptr).gc_generation).write(Radium::new(GC_UNTRACKED));
+            ptr::addr_of_mut!((*ptr).gc_owner).write(Radium::new(GC_NO_OWNER));
+            ptr::addr_of_mut!((*ptr).gc_refs).write(Radium::new(0));
+            ptr::addr_of_mut!((*ptr).gc_pointers).write(Pointers::new());
+            ptr::addr_of_mut!((*ptr).typ).write(PyAtomicRef::from_ref_without_retag(typ));
+            ptr::addr_of_mut!((*ptr).payload).write(payload);
+        }
+    }
+
+    let type_type_ptr = alloc_type_with_prefixes();
+    let object_type_ptr = alloc_type_with_prefixes();
+    let tuple_type_ptr = alloc_type_with_prefixes();
+    let empty_tuple_ptr = alloc_tuple();
+    let type_bases_ptr = alloc_tuple();
+    let tuple_bases_ptr = alloc_tuple();
+
+    unsafe {
+        init_ref_count(type_type_ptr);
+        init_ref_count(object_type_ptr);
+        init_ref_count(tuple_type_ptr);
+        init_ref_count(empty_tuple_ptr);
+        init_ref_count(type_bases_ptr);
+        init_ref_count(tuple_bases_ptr);
+    }
+
+    // Each initial reference consumes the allocation's initial strong count.
+    // Further references are created through clone_raw_ref while the graph is
+    // still being assembled and cannot yet be safely dereferenced.
+    let type_type = unsafe { initial_ref(type_type_ptr) };
+    let object_type = unsafe { initial_ref(object_type_ptr) };
+    let tuple_type = unsafe { initial_ref(tuple_type_ptr) };
+    let empty_tuple = unsafe { initial_ref(empty_tuple_ptr) };
+    let type_bases = unsafe { into_type_tuple(initial_ref(type_bases_ptr)) };
+    let tuple_bases = unsafe { into_type_tuple(initial_ref(tuple_bases_ptr)) };
+
+    let type_payload = PyType {
+        base: unsafe {
+            PyAtomicRef::from_optional_ref_without_retag(Some(clone_raw_ref(object_type_ptr)))
+        },
+        bases: PyRwLock::new(type_bases),
+        mro: PyRwLock::new(vec![unsafe { clone_raw_ref(type_type_ptr) }, unsafe {
+            clone_raw_ref(object_type_ptr)
+        }]),
+        subclasses: PyRwLock::default(),
+        attributes: Default::default(),
+        slots: PyType::make_slots(),
+        heaptype_ext: None,
+        tp_version_tag: core::sync::atomic::AtomicU32::new(0),
+        abc_tpflags: core::sync::atomic::AtomicU64::new(0),
+    };
+    let object_payload = PyType {
+        base: unsafe { PyAtomicRef::from_optional_ref_without_retag(None) },
+        bases: PyRwLock::new(unsafe { into_type_tuple(clone_raw_ref(empty_tuple_ptr)) }),
+        mro: PyRwLock::new(vec![unsafe { clone_raw_ref(object_type_ptr) }]),
+        subclasses: PyRwLock::default(),
+        attributes: Default::default(),
+        slots: object::PyBaseObject::make_slots(),
+        heaptype_ext: None,
+        tp_version_tag: core::sync::atomic::AtomicU32::new(0),
+        abc_tpflags: core::sync::atomic::AtomicU64::new(0),
+    };
+    let tuple_payload = PyType {
+        base: unsafe {
+            PyAtomicRef::from_optional_ref_without_retag(Some(clone_raw_ref(object_type_ptr)))
+        },
+        bases: PyRwLock::new(tuple_bases),
+        mro: PyRwLock::new(vec![unsafe { clone_raw_ref(tuple_type_ptr) }, unsafe {
+            clone_raw_ref(object_type_ptr)
+        }]),
+        subclasses: PyRwLock::default(),
+        attributes: Default::default(),
+        slots: tuple::PyTuple::make_slots(),
+        heaptype_ext: None,
+        tp_version_tag: core::sync::atomic::AtomicU32::new(0),
+        abc_tpflags: core::sync::atomic::AtomicU64::new(0),
+    };
+
+    let object_element =
+        || -> PyObjectRef { unsafe { clone_raw_ref::<PyType>(object_type_ptr) }.into() };
+    unsafe {
+        init_inner(type_type_ptr, clone_raw_ref(type_type_ptr), type_payload);
+        init_inner(
+            object_type_ptr,
+            clone_raw_ref(type_type_ptr),
+            object_payload,
+        );
+        init_inner(tuple_type_ptr, clone_raw_ref(type_type_ptr), tuple_payload);
+        init_inner(
+            empty_tuple_ptr,
+            clone_raw_ref(tuple_type_ptr),
+            PyTuple::new_unchecked(Vec::new().into_boxed_slice()),
+        );
+        init_inner(
+            type_bases_ptr,
+            clone_raw_ref(tuple_type_ptr),
+            PyTuple::new_unchecked(vec![object_element()].into_boxed_slice()),
+        );
+        init_inner(
+            tuple_bases_ptr,
+            clone_raw_ref(tuple_type_ptr),
+            PyTuple::new_unchecked(vec![object_element()].into_boxed_slice()),
+        );
+    }
+
+    PyType::finalize_bootstrap_static(&tuple_type);
+
+    let weakref_bases =
+        PyTuple::new_ref_typed_with_type(vec![object_type.clone()], tuple_type.clone());
+    unsafe {
+        crate::gc_state::gc_state()
+            .untrack_object(NonNull::from(weakref_bases.as_untyped().as_object()));
+    }
+    weakref_bases.as_untyped().as_object().clear_gc_tracked();
+    let weakref_payload = PyType {
         base: Some(object_type.clone()).into(),
-        bases: PyRwLock::new(PyTypeBases::Bootstrap(vec![object_type.clone()])),
+        bases: PyRwLock::new(weakref_bases),
         mro: PyRwLock::new(vec![object_type.clone()]),
         subclasses: PyRwLock::default(),
         attributes: Default::default(),
@@ -2892,7 +2929,7 @@ pub(crate) fn init_type_hierarchy() -> (PyTypeRef, PyTypeRef, PyTypeRef) {
         tp_version_tag: core::sync::atomic::AtomicU32::new(0),
         abc_tpflags: core::sync::atomic::AtomicU64::new(0),
     };
-    let weakref_type = PyRef::new_ref(weakref_type, type_type.clone(), None);
+    let weakref_type = PyRef::new_ref(weakref_payload, type_type.clone(), None);
     // Static type: untrack from GC (was tracked by new_ref because PyType has HAS_TRAVERSE)
     unsafe {
         crate::gc_state::gc_state()
@@ -2910,13 +2947,26 @@ pub(crate) fn init_type_hierarchy() -> (PyTypeRef, PyTypeRef, PyTypeRef) {
     );
 
     object_type.subclasses.write().push(
+        tuple_type
+            .as_object()
+            .downgrade_with_weakref_typ_opt(None, weakref_type.clone())
+            .unwrap(),
+    );
+
+    object_type.subclasses.write().push(
         weakref_type
             .as_object()
             .downgrade_with_weakref_typ_opt(None, weakref_type.clone())
             .unwrap(),
     );
 
-    (type_type, object_type, weakref_type)
+    BootstrapTypeHierarchy {
+        type_type,
+        object_type,
+        tuple_type,
+        weakref_type,
+        empty_tuple,
+    }
 }
 
 #[cfg(test)]
@@ -2925,7 +2975,29 @@ mod tests {
 
     #[test]
     fn miri_test_type_initialization() {
-        let _ = init_type_hierarchy();
+        let hierarchy = init_type_hierarchy();
+
+        assert!(hierarchy.type_type.class().is(&hierarchy.type_type));
+        assert!(hierarchy.object_type.class().is(&hierarchy.type_type));
+        assert!(hierarchy.tuple_type.class().is(&hierarchy.type_type));
+        assert!(hierarchy.weakref_type.class().is(&hierarchy.type_type));
+
+        let object_bases = hierarchy.object_type.bases.read();
+        assert!(object_bases.is_empty());
+        assert!(object_bases.as_untyped().is(&hierarchy.empty_tuple));
+        assert!(object_bases.as_untyped().class().is(&hierarchy.tuple_type));
+        drop(object_bases);
+
+        for typ in [
+            &hierarchy.type_type,
+            &hierarchy.tuple_type,
+            &hierarchy.weakref_type,
+        ] {
+            let bases = typ.bases.read();
+            assert_eq!(bases.len(), 1);
+            assert!(bases[0].is(&hierarchy.object_type));
+            assert!(bases.as_untyped().class().is(&hierarchy.tuple_type));
+        }
     }
 
     #[test]

--- a/crates/vm/src/object/core.rs
+++ b/crates/vm/src/object/core.rs
@@ -2588,6 +2588,7 @@ pub(crate) fn init_type_hierarchy() -> (PyTypeRef, PyTypeRef, PyTypeRef) {
         let type_payload = PyType {
             base: None.into(),
             bases: PyRwLock::default(),
+            bases_tuple: PyRwLock::default(),
             mro: PyRwLock::default(),
             subclasses: PyRwLock::default(),
             attributes: PyRwLock::new(Default::default()),
@@ -2599,6 +2600,7 @@ pub(crate) fn init_type_hierarchy() -> (PyTypeRef, PyTypeRef, PyTypeRef) {
         let object_payload = PyType {
             base: None.into(),
             bases: PyRwLock::default(),
+            bases_tuple: PyRwLock::default(),
             mro: PyRwLock::default(),
             subclasses: PyRwLock::default(),
             attributes: PyRwLock::new(Default::default()),
@@ -2696,6 +2698,7 @@ pub(crate) fn init_type_hierarchy() -> (PyTypeRef, PyTypeRef, PyTypeRef) {
     let weakref_type = PyType {
         base: Some(object_type.clone()).into(),
         bases: PyRwLock::new(vec![object_type.clone()]),
+        bases_tuple: PyRwLock::default(),
         mro: PyRwLock::new(vec![object_type.clone()]),
         subclasses: PyRwLock::default(),
         attributes: PyRwLock::default(),

--- a/crates/vm/src/object/ext.rs
+++ b/crates/vm/src/object/ext.rs
@@ -312,6 +312,22 @@ impl<T: PyPayload> Deref for PyAtomicRef<T> {
 }
 
 impl<T: PyPayload> PyAtomicRef<T> {
+    /// Move a reference into an atomic pointer without creating a Rust
+    /// reference to the pointee. This is only for bootstrap objects whose
+    /// allocation is valid but whose payload is still being initialized.
+    ///
+    /// # Safety
+    /// The pointee must remain allocated, and this atomic reference must not
+    /// be dereferenced until the pointee has been fully initialized.
+    pub(super) unsafe fn from_ref_without_retag(pyref: PyRef<T>) -> Self {
+        let ptr = pyref.into_non_null().as_ptr().cast::<u8>();
+        ptr.expose_provenance();
+        Self {
+            inner: Radium::new(ptr),
+            _phantom: Default::default(),
+        }
+    }
+
     /// Load the raw pointer without creating a reference.
     /// Avoids Stacked Borrows retag, safe for use during bootstrap
     /// when type objects have self-referential pointers being mutated.
@@ -349,6 +365,22 @@ impl<T: PyPayload> From<Option<PyRef<T>>> for PyAtomicRef<Option<T>> {
 }
 
 impl<T: PyPayload> PyAtomicRef<Option<T>> {
+    /// Optional form of PyAtomicRef::from_ref_without_retag.
+    ///
+    /// # Safety
+    /// A non-None pointee must remain allocated, and this atomic reference
+    /// must not be dereferenced until the pointee has been fully initialized.
+    pub(super) unsafe fn from_optional_ref_without_retag(opt_ref: Option<PyRef<T>>) -> Self {
+        let ptr = opt_ref.map_or(null_mut(), |pyref| {
+            pyref.into_non_null().as_ptr().cast::<u8>()
+        });
+        ptr.expose_provenance();
+        Self {
+            inner: Radium::new(ptr),
+            _phantom: Default::default(),
+        }
+    }
+
     pub fn deref(&self) -> Option<&Py<T>> {
         self.deref_ordering(Ordering::Relaxed)
     }

--- a/crates/vm/src/object/ext.rs
+++ b/crates/vm/src/object/ext.rs
@@ -315,6 +315,22 @@ impl<T: PyPayload> Deref for PyAtomicRef<T> {
 }
 
 impl<T: PyPayload> PyAtomicRef<T> {
+    /// Move a reference into an atomic pointer without creating a Rust
+    /// reference to the pointee. This is only for bootstrap objects whose
+    /// allocation is valid but whose payload is still being initialized.
+    ///
+    /// # Safety
+    /// The pointee must remain allocated, and this atomic reference must not
+    /// be dereferenced until the pointee has been fully initialized.
+    pub(super) unsafe fn from_ref_without_retag(pyref: PyRef<T>) -> Self {
+        let ptr = pyref.into_non_null().as_ptr().cast::<u8>();
+        ptr.expose_provenance();
+        Self {
+            inner: Radium::new(ptr),
+            _phantom: Default::default(),
+        }
+    }
+
     /// Load the raw pointer without creating a reference.
     /// Avoids Stacked Borrows retag, safe for use during bootstrap
     /// when type objects have self-referential pointers being mutated.
@@ -352,6 +368,22 @@ impl<T: PyPayload> From<Option<PyRef<T>>> for PyAtomicRef<Option<T>> {
 }
 
 impl<T: PyPayload> PyAtomicRef<Option<T>> {
+    /// Optional form of PyAtomicRef::from_ref_without_retag.
+    ///
+    /// # Safety
+    /// A non-None pointee must remain allocated, and this atomic reference
+    /// must not be dereferenced until the pointee has been fully initialized.
+    pub(super) unsafe fn from_optional_ref_without_retag(opt_ref: Option<PyRef<T>>) -> Self {
+        let ptr = opt_ref.map_or(null_mut(), |pyref| {
+            pyref.into_non_null().as_ptr().cast::<u8>()
+        });
+        ptr.expose_provenance();
+        Self {
+            inner: Radium::new(ptr),
+            _phantom: Default::default(),
+        }
+    }
+
     pub fn deref(&self) -> Option<&Py<T>> {
         self.deref_ordering(Ordering::Relaxed)
     }

--- a/crates/vm/src/types/zoo.rs
+++ b/crates/vm/src/types/zoo.rs
@@ -109,18 +109,19 @@ pub struct TypeZoo {
 
 impl TypeZoo {
     #[cold]
-    pub(crate) fn init() -> Self {
-        let (type_type, object_type, weakref_type) = crate::object::init_type_hierarchy();
-        // the order matters for type, object, weakref, and int - must be initialized first
-        let type_type = type_::PyType::init_manually(type_type);
-        let object_type = object::PyBaseObject::init_manually(object_type);
-        let weakref_type = weakref::PyWeak::init_manually(weakref_type);
+    pub(crate) fn init() -> (Self, crate::builtins::PyTupleRef) {
+        let hierarchy = crate::object::init_type_hierarchy();
+        // These core types must be published before any other static type is created.
+        let type_type = type_::PyType::init_manually(hierarchy.type_type);
+        let object_type = object::PyBaseObject::init_manually(hierarchy.object_type);
+        let tuple_type = tuple::PyTuple::init_manually(hierarchy.tuple_type);
+        let weakref_type = weakref::PyWeak::init_manually(hierarchy.weakref_type);
         let int_type = int::PyInt::init_builtin_type();
 
         // builtin_function_or_method and builtin_method share the same type (CPython behavior)
         let builtin_function_or_method_type = builtin_func::PyNativeFunction::init_builtin_type();
 
-        Self {
+        let types = Self {
             type_type,
             object_type,
             weakref_type,
@@ -147,7 +148,7 @@ impl TypeZoo {
             staticmethod_type: staticmethod::PyStaticMethod::init_builtin_type(),
             str_type: pystr::PyStr::init_builtin_type(),
             super_type: super_::PySuper::init_builtin_type(),
-            tuple_type: tuple::PyTuple::init_builtin_type(),
+            tuple_type,
             zip_type: zip::PyZip::init_builtin_type(),
 
             // hidden internal types. is this really need to be cached here?
@@ -213,7 +214,8 @@ impl TypeZoo {
             method_wrapper_type: descriptor::PyMethodWrapper::init_builtin_type(),
 
             method_def: crate::function::HeapMethodDef::init_builtin_type(),
-        }
+        };
+        (types, hierarchy.empty_tuple)
     }
 
     /// Fill attributes of builtin types.

--- a/crates/vm/src/vm/context.rs
+++ b/crates/vm/src/vm/context.rs
@@ -303,7 +303,7 @@ impl Context {
 
     fn init_genesis() -> Self {
         flame_guard!("init Context");
-        let types = TypeZoo::init();
+        let (types, empty_tuple) = TypeZoo::init();
         let exceptions = exceptions::ExceptionZoo::init();
 
         #[inline]
@@ -348,10 +348,6 @@ impl Context {
         let true_value = create_object(PyBool(PyInt::from(1)), types.bool_type);
         let false_value = create_object(PyBool(PyInt::from(0)), types.bool_type);
 
-        let empty_tuple = create_object(
-            PyTuple::new_unchecked(Vec::new().into_boxed_slice()),
-            types.tuple_type,
-        );
         let empty_frozenset = PyRef::new_ref(
             PyFrozenSet::default(),
             types.frozenset_type.to_owned(),

--- a/crates/vm/src/vm/context.rs
+++ b/crates/vm/src/vm/context.rs
@@ -304,7 +304,7 @@ impl Context {
 
     fn init_genesis() -> Self {
         flame_guard!("init Context");
-        let types = TypeZoo::init();
+        let (types, empty_tuple) = TypeZoo::init();
         let exceptions = exceptions::ExceptionZoo::init();
 
         #[inline]
@@ -340,10 +340,6 @@ impl Context {
         let true_value = create_object(PyBool(PyInt::from(1)), types.bool_type);
         let false_value = create_object(PyBool(PyInt::from(0)), types.bool_type);
 
-        let empty_tuple = create_object(
-            PyTuple::new_unchecked(Vec::new().into_boxed_slice()),
-            types.tuple_type,
-        );
         let empty_frozenset = PyRef::new_ref(
             PyFrozenSet::default(),
             types.frozenset_type.to_owned(),


### PR DESCRIPTION
- [x] This PR follows our [AI policy](https://github.com/RustPython/.github/blob/main/AI_POLICY.md)

## Summary

`type.__bases__` always synthesized a fresh plain `tuple` from an internal `Vec<PyTypeRef>`, so a `tuple` subclass passed as a base class lost its identity (CPython [gh-132176](https://github.com/python/cpython/issues/132176)). `test_tuple_subclass_as_bases` no longer needs `@unittest.expectedFailure`.

- `PyType.bases` is now a typed `PyTuple<PyTypeRef>` instead of a `Vec`, so `__bases__` returns the stored tuple object directly — preserving a tuple subclass passed via `bases=`.
- This required `tuple` to exist as a real type before any other type (including `type`/`object`) is constructed, so bootstrap (`init_type_hierarchy`) now builds `tuple` and the canonical empty tuple alongside `type`/`object`.
- The old `partially_init!` macro bootstrap is replaced with explicit, Miri-safe helpers (`init_ref_count`, `initial_ref`, `clone_raw_ref`, `init_inner`).

---

*Written with Claude Code*


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved runtime handling of class inheritance, method resolution, and type hierarchies.
  * Added validation to ensure type bases are valid classes.
  * Improved tuple and type initialization during startup.
  * Strengthened support for built-in types, including tuples and weak references.
  * Improved cleanup and cycle handling for type hierarchies.
  * Enhanced consistency when accessing or assigning a type’s base classes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->