### PR TITLE
Rebase range iterator `__reduce__` to match CPython

### DIFF
--- a/crates/vm/src/builtins/range.rs
+++ b/crates/vm/src/builtins/range.rs
@@ -716,13 +716,17 @@ fn range_iter_reduce(
     vm: &VirtualMachine,
 ) -> PyTupleRef {
     let iter = builtins_iter(vm);
+    // CPython pickles the remaining range with a None state. next() increments
+    // the index unconditionally, so clamp it to length before rebasing start.
+    let index = BigInt::from(index).min(length.clone());
     let stop = start.clone() + length * step.clone();
+    let start = start + index * step.clone();
     let range = PyRange {
         start: PyInt::from(start).into_ref(&vm.ctx),
         stop: PyInt::from(stop).into_ref(&vm.ctx),
         step: PyInt::from(step).into_ref(&vm.ctx),
     };
-    vm.new_tuple((iter, (range,), index))
+    vm.new_tuple((iter, (range,), vm.ctx.none()))
 }
 
 // Silently clips state (i.e index) in range [0, usize::MAX].

--- a/extra_tests/snippets/builtin_range.py
+++ b/extra_tests/snippets/builtin_range.py
@@ -120,7 +120,9 @@ assert range(10, 1, -2).__reduce__()[1] == (10, 1, -2)
 
 # range iterator __reduce__ (state is None, range rebased to current position)
 it = iter(range(10))
-next(it); next(it); next(it)
+next(it)
+next(it)
+next(it)
 assert it.__reduce__()[0] is iter
 assert it.__reduce__()[1] == (range(3, 10),)
 assert it.__reduce__()[2] is None

--- a/extra_tests/snippets/builtin_range.py
+++ b/extra_tests/snippets/builtin_range.py
@@ -118,6 +118,15 @@ assert range(10).__reduce__()[1] == (0, 10, 1)
 assert range(10, 1, -2).__reduce__()[0] == range
 assert range(10, 1, -2).__reduce__()[1] == (10, 1, -2)
 
+# range iterator __reduce__ (state is None, range rebased to current position)
+it = iter(range(10))
+next(it); next(it); next(it)
+assert it.__reduce__()[0] is iter
+assert it.__reduce__()[1] == (range(3, 10),)
+assert it.__reduce__()[2] is None
+assert iter(range(3)).__reduce__()[1:] == ((range(0, 3),), None)
+assert reversed(range(3)).__reduce__()[1:] == ((range(2, -1, -1),), None)
+
 # range retains the original int refs
 i = 2**64
 assert range(i).stop is i


### PR DESCRIPTION
- [x] Closes #8377
- [x] This PR follows our [AI policy](https://github.com/RustPython/.github/blob/main/AI_POLICY.md)

## Summary

`range_iterator.__reduce__` (and `longrange_iterator.__reduce__`) returned the original range plus the current index as the pickle state, whereas CPython returns the *remaining* range rebased to the current position with a `None` state. The round-trip result was already correct on both (RustPython restored the index via `__setstate__`), so this is a representational / cross-compatibility divergence, not data loss.

```python
it = iter(range(10)); next(it); next(it); next(it)
it.__reduce__()
# before: (<built-in function iter>, (range(0, 10),), 3)
# after:  (<built-in function iter>, (range(3, 10),), None)   # matches CPython
```

## Cause

`range_iter_reduce` embedded the full original range and passed `index` as the third tuple element. Both `PyRangeIterator::__reduce__` and `PyLongRangeIterator::__reduce__` go through it.

## Fix

Rebase the range start by `index * step` and emit `None` for the state. The index is clamped to the length first, because RustPython's iterator increments the index unconditionally, so it can run past the length after exhaustion (unlike CPython, which stops at the length). `__setstate__` is left intact, so pickles that carry an integer state still load.

## Test

Verified against CPython 3.14.6 — `__reduce__` output now matches for mid-iteration, fresh, `reversed`, exhausted (`range(2, 2)`), step > 1, empty, single-element, negative-step, `longrange`, and `__setstate__`-advanced iterators. `pickle.loads(pickle.dumps(it))` round-trips correctly in all cases.

- `test_range`: SUCCESS (29 run, 2 skipped — the two skips are a separate, pre-existing `__setstate__` crash, unrelated to this change).
- `cargo build` / `cargo clippy -p rustpython-vm` / `cargo fmt --check`: clean.

No `@expectedFailure` marker flips here: CPython's own `test_range` has no test asserting the `__reduce__` shape, so this is a representational fix, covered for regressions by the existing pickle round-trip tests.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved range iterator state handling during serialization and reconstruction.
  * Prevented iterator positions from exceeding the range length.
  * Ensured reconstructed iterators resume correctly for forward and reversed ranges.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->