### PR TITLE
docs: drop stale crate paths from AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,6 +1,6 @@
-# GitHub Copilot Instructions for RustPython
+# AI Agent Instructions for RustPython
 
-This document provides guidelines for working with GitHub Copilot when contributing to the RustPython project.
+This document provides guidelines for AI coding agents (GitHub Copilot, Claude Code, Gemini, etc.) contributing to the RustPython project.
 
 ## Project Overview
 
@@ -13,22 +13,7 @@ RustPython is a Python 3 interpreter written in Rust, implementing Python 3.14.0
 
 ## Repository Structure
 
-- `src/` - Top-level code for the RustPython binary
-- `vm/` - The Python virtual machine implementation
-  - `builtins/` - Python built-in types and functions
-  - `stdlib/` - Essential standard library modules implemented in Rust, required to run the Python core
-- `compiler/` - Python compiler components
-  - `parser/` - Parser for converting Python source to AST
-  - `core/` - Bytecode representation in Rust structures
-  - `codegen/` - AST to bytecode compiler
-- `Lib/` - CPython's standard library in Python (copied from CPython). **IMPORTANT**: Do not edit this directory directly; The only allowed operation is copying files from CPython.
-- `derive/` - Rust macros for RustPython
-- `common/` - Common utilities
-- `extra_tests/` - Integration tests and snippets
-- `stdlib/` - Non-essential Python standard library modules implemented in Rust (useful but not required for core functionality)
-- `wasm/` - WebAssembly support
-- `jit/` - Experimental JIT compiler implementation
-- `pylib/` - Python standard library packaging (do not modify this directory directly - its contents are generated automatically)
+See the "Code organization" section in [CONTRIBUTING.md](CONTRIBUTING.md#code-organization) for the current directory layout.
 
 ## AI Agent Rules
 


### PR DESCRIPTION
- [x] Closes #8416
- [x] This PR follows our [AI policy](https://github.com/RustPython/.github/blob/main/AI_POLICY.md)

## Summary

`AGENTS.md`'s "Repository Structure" section described the pre-`crates/` layout (`vm/`, `compiler/`, `derive/`, etc.), none of which exist anymore. `CONTRIBUTING.md` already documents the current layout under "Code organization", so this replaces the stale list with a link there instead of maintaining two copies that can drift apart again.

Also generalized the file's title/intro from "GitHub Copilot Instructions" to "AI Agent Instructions". The file was already renamed from `.github/copilot-instructions.md` to `AGENTS.md` in #6813 to follow the cross-vendor [AGENTS.md standard](https://agents.md/), but the title text was never updated to match. Happy to revert this part if the intent was Copilot-specific.

Assisted-by: Claude Code:claude-sonnet-5


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated contributor guidance to support a broader range of AI coding agents.
  * Replaced outdated repository structure details with a link to the current code organization documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->