### PR TITLE
docs: fix AGENTS.md's broken DEVELOPMENT.md references

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -265,11 +265,9 @@ cargo run --features jit
 
 ### Linux Build and Debug on macOS
 
-See the "Testing on Linux from macOS" section in [DEVELOPMENT.md](DEVELOPMENT.md#testing-on-linux-from-macos).
+See the "Testing on Linux from macOS" section in [CONTRIBUTING.md](CONTRIBUTING.md#testing-on-linux-from-macos).
 
 ### Building venvlauncher (Windows)
-
-See DEVELOPMENT.md "CPython Version Upgrade Checklist" section.
 
 **IMPORTANT**: All 4 venvlauncher binaries use the same source code. Do NOT add multiple `[[bin]]` entries to Cargo.toml. Build once and copy with different names.
 
@@ -301,7 +299,7 @@ If you modify any file under `.github/workflows/`, the change must pass a [zizmo
 ## Documentation
 
 - Check the [architecture document](/architecture/architecture.md) for a high-level overview
-- Read the [development guide](/DEVELOPMENT.md) for detailed setup instructions
+- Read the [development guide](/CONTRIBUTING.md) for detailed setup instructions
 - Generate documentation with `cargo doc --no-deps --all`
 - Online documentation is available at [docs.rs/rustpython](https://docs.rs/rustpython/)
 - [How to update test files](https://github.com/RustPython/RustPython/wiki/How-to-update-test-files#checkout-cpython-source-code-initial-setup) — guide for syncing test cases from upstream CPython into the `Lib/` directory


### PR DESCRIPTION
- [x] Closes #8356 <!-- doesn't fully close it; two of three broken links fixed, see Summary -->
- [x] This PR follows our [AI policy](https://github.com/RustPython/.github/blob/main/AI_POLICY.md)

## Summary

Related to #8356. `AGENTS.md` had three references to `DEVELOPMENT.md`, which was renamed to `CONTRIBUTING.md` in #7914:

- Two had a clear target and are repointed here: the "Testing on Linux from macOS" section link, and the development guide link.
- The third, under "Building venvlauncher (Windows)", pointed at a "CPython Version Upgrade Checklist" section that never existed in `DEVELOPMENT.md` — grepping every revision in history only finds that phrase in `AGENTS.md` itself. I removed the dangling line rather than repoint it, since there's nothing to point to.

If real venvlauncher build steps exist somewhere, or should be written, happy to add them in a follow-up.

Assisted-by: Claude Code:claude-sonnet-5


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated documentation links to point to the contributing guide for macOS/Linux testing instructions and development guidance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->