### PR TITLE
docs: match CONTRIBUTING.md's test command to what CI runs

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -89,7 +89,15 @@ $ pytest -v
 Rust unit tests can be run with `cargo`:
 
 ```shell
-$ cargo test --workspace --exclude rustpython_wasm --exclude rustpython-venvlauncher
+$ cargo test --workspace --exclude rustpython_wasm --exclude rustpython-venvlauncher --exclude rustpython-capi
+```
+
+`rustpython-capi` needs to be tested from inside its own directory, since it has a
+separate `cargo` config that only applies there:
+
+```shell
+$ cd crates/capi
+$ cargo test
 ```
 
 Python unit tests can be run by compiling RustPython and running the test module:


### PR DESCRIPTION
- [x] Closes #8415
- [x] This PR follows our [AI policy](https://github.com/RustPython/.github/blob/main/AI_POLICY.md)

## Summary

`CONTRIBUTING.md`'s documented `cargo test --workspace ...` command doesn't match what CI runs, and segfaults on `rustpython-capi` when run from the workspace root. Add `--exclude rustpython-capi` and document the separate `cd crates/capi && cargo test` step, mirroring CI.

Kept this docs-only rather than restructuring `crates/capi` out of the workspace: that would mean hardcoding ~16 `workspace = true` fields, a separate `Cargo.lock`, and new CI steps for build/clippy/doc/shear that currently reach it through the root workspace.

Assisted-by: Claude Code:claude-sonnet-5


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated workspace test instructions to exclude the C API component.
  * Added separate instructions for running C API tests with its local configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->