### PR TITLE
Use `core::ptr::fn_addr_eq` for function pointer comparisons

### DIFF
--- a/crates/vm/src/class.rs
+++ b/crates/vm/src/class.rs
@@ -5,7 +5,7 @@ use crate::{
     builtins::{PyBaseObject, PyType, PyTypeRef, descriptor::PyWrapper},
     function::PyMethodDef,
     object::Py,
-    types::{PyTypeFlags, PyTypeSlots, SLOT_DEFS, hash_not_implemented},
+    types::{HashFunc, PyTypeFlags, PyTypeSlots, SLOT_DEFS, hash_not_implemented},
     vm::Context,
 };
 use rustpython_common::static_cell;
@@ -28,7 +28,7 @@ pub fn add_operators(class: &'static Py<PyType>, ctx: &Context) {
                 .slots
                 .hash
                 .load()
-                .is_some_and(|h| h as usize == hash_not_implemented as *const () as usize)
+                .is_some_and(|h| core::ptr::fn_addr_eq(h, hash_not_implemented as HashFunc))
         {
             class.set_attr(ctx.names.__hash__, ctx.none.clone().into());
             continue;


### PR DESCRIPTION
<!--
Thanks for your contribution!
-->
Assisted-by: Codex-5.6-sol

- [ ] Closes #xxxx <!-- Replace xxxx with the GitHub issue number -->
- [x] This PR follows our [AI policy](https://github.com/RustPython/.github/blob/main/AI_POLICY.md)

## Summary
<!-- What's the purpose of the change? What does it do, and why? -->
- Replaces raw pointer cast comparisons with `core::ptr::fn_addr_eq` to preserve pointer provenance.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability when comparing hash implementations by using a safer function comparison method.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->