### PR TITLE
socket: accept a filesystem-encoded hostname in sethostname

### DIFF
--- a/crates/host_env/src/socket.rs
+++ b/crates/host_env/src/socket.rs
@@ -44,9 +44,15 @@ pub use libc::{AF_ALG, AF_CAN};
 #[cfg(target_os = "linux")]
 pub use libc::{sockaddr_alg, sockaddr_can};
 
+/// Set the system's hostname from its filesystem-encoded bytes.
+///
+/// `socketmodule.c socket_sethostname` reads the argument as a buffer and
+/// passes `buf.buf`/`buf.len` straight to the syscall, so a name is not
+/// required to be UTF-8; taking `&[u8]` keeps that true here as well.
 #[cfg(all(unix, not(target_os = "redox")))]
-pub fn sethostname(hostname: &str) -> io::Result<()> {
-    nix::unistd::sethostname(hostname).map_err(io::Error::from)
+pub fn sethostname(hostname: &[u8]) -> io::Result<()> {
+    use std::os::unix::ffi::OsStrExt;
+    nix::unistd::sethostname(std::ffi::OsStr::from_bytes(hostname)).map_err(io::Error::from)
 }
 
 #[cfg(unix)]

--- a/crates/stdlib/src/socket.rs
+++ b/crates/stdlib/src/socket.rs
@@ -2325,8 +2325,8 @@ mod _socket {
 
     #[cfg(all(unix, not(any(target_os = "redox", target_os = "android"))))]
     #[pyfunction]
-    fn sethostname(hostname: PyUtf8StrRef) -> std::io::Result<()> {
-        host_socket::sethostname(hostname.as_str())
+    fn sethostname(hostname: FsPath) -> std::io::Result<()> {
+        host_socket::sethostname(hostname.as_bytes())
     }
 
     #[pyfunction]


### PR DESCRIPTION
`socket.sethostname` took `PyUtf8StrRef`, so it rejected `bytes` outright and
refused a `str` carrying a surrogate escape.

`socketmodule.c socket_sethostname` accepts a bytes object directly (`"S"`),
falls back to `PyUnicode_FSConverter` for anything else, and hands the syscall
the resulting buffer together with its length — the name is never required to be
UTF-8.

This takes `FsPath`, the converter `if_nametoindex` in this same module already
uses, and passes its bytes down. `host_env::socket::sethostname` correspondingly
takes `&[u8]` and builds the `OsStr` from them; `nix::unistd::sethostname` accepts
`AsRef<OsStr>` and passes pointer and length to the syscall, so nothing on the path
needs a NUL terminator or valid UTF-8.

`Lib/test/test_socket.py test_sethostname` already covers this — it calls
`socket.sethostname(b'bar')` and asserts the hostname changed. The test is skipped
unless run as root, which is why the gap went unnoticed.

## Verification

Built both ways and called `sethostname` as a non-root user, where every accepted
argument reaches the syscall and comes back `EPERM`. That makes the exception type
the discriminator: `PermissionError` means the argument was converted and reached
the OS, anything else means it was rejected before that.

| argument | before | after | CPython 3.14 |
| --- | --- | --- | --- |
| `'bar'` | `PermissionError` | `PermissionError` | `PermissionError` |
| `b'bar'` | `TypeError: Expected type 'str' but 'bytes' found.` | `PermissionError` | `PermissionError` |
| `'x\udcff'` | `UnicodeEncodeError: 'utf-8' codec can't encode character '\udcff'` | `PermissionError` | `PermissionError` |

The hostname itself is never changed by this check, so it is safe to run anywhere.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved hostname handling to support filesystem-encoded bytes, including valid non-UTF-8 hostnames.
  * Updated the hostname-setting interface to accept filesystem path-style values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->