### PR TITLE
Use datastack path for __init__ dispatch in CallAllocAndEnterInit

### DIFF
--- a/crates/vm/src/builtins/function.rs
+++ b/crates/vm/src/builtins/function.rs
@@ -791,7 +791,7 @@ impl Py<PyFunction> {
         frame
     }
 
-    fn invoke_prepared_exact_args(
+    pub(crate) fn invoke_prepared_exact_args(
         &self,
         args: impl ExactSizeIterator<Item = PyObjectRef>,
         vm: &VirtualMachine,

--- a/crates/vm/src/frame.rs
+++ b/crates/vm/src/frame.rs
@@ -2673,10 +2673,7 @@ impl ExecutingFrame<'_> {
             .iter_mut()
             .map(|slot| slot.take().expect("arg slot must be filled"));
 
-        let init_frame = init_func.prepare_exact_args_frame(taken, vm);
-        let init_result = vm.run_frame(init_frame.clone());
-        release_datastack_frame(&init_frame, vm);
-        let init_result = init_result?;
+        let init_result = init_func.invoke_prepared_exact_args(taken, vm)?;
 
         if !vm.is_none(&init_result) {
             return Err(vm.new_type_error(format!(


### PR DESCRIPTION
## Summary

`specialization_run_init` (used by `CallAllocAndEnterInit`) called `prepare_exact_args_frame` which heap-allocates a `FrameObject` with 4-5 atomic refcount bumps per call. This switches to `invoke_prepared_exact_args` which uses `InterpreterFrame::new_on_datastack` + `run_frame_fast` with zero refcount bumps on code/globals/builtins/func_obj.

Part of #40.

## Safety

`CallAllocAndEnterInit` already guards against:
- Tracing (`specialization_eval_frame_active`)
- Recursion limits (`specialization_call_recursion_guard`)
- Datastack space (`specialization_has_datastack_space_for_func`)

These are the same guards used by `CallPyExactArgs` which already uses the datastack path.

## Changes

- `frame.rs`: `specialization_run_init` — replace `prepare_exact_args_frame` + `run_frame` + `release_datastack_frame` with `invoke_prepared_exact_args`
- `function.rs`: `invoke_prepared_exact_args` visibility `fn` → `pub(crate) fn`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Streamlined object initialization by using the standard prepared-call flow.
  * Preserved existing initialization result validation and error handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->