### PR TITLE
Optimize list.remove() lock usage

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -42,7 +42,7 @@ repos:
 
       - id: generate-rs-opcode-metadata
         name: generate rust opcode metadata
-        entry: python tools/opcode_metadata/generate_rs_opcode_metadata.py
+        entry: python3 tools/opcode_metadata/generate_rs_opcode_metadata.py
         files: '^(crates/compiler-core/src/bytecode/instruction\.rs|tools/opcode_metadata/*)$'
         pass_filenames: false
         language: system
@@ -53,7 +53,7 @@ repos:
 
       - id: generate-py-opcode-metadata
         name: generate python opcode metadata
-        entry: python tools/opcode_metadata/generate_py_opcode_metadata.py
+        entry: python3 tools/opcode_metadata/generate_py_opcode_metadata.py
         files: '^(crates/compiler-core/src/bytecode/instruction\.rs|tools/opcode_metadata/*)$'
         pass_filenames: false
         language: system

--- a/crates/vm/src/builtins/list.rs
+++ b/crates/vm/src/builtins/list.rs
@@ -372,12 +372,15 @@ impl PyList {
 
         if let Some(index) = index.into() {
             // defer delete out of borrow
-            let is_inside_range = index < self.borrow_vec().len();
-            Ok(is_inside_range.then(|| self.borrow_vec_mut().remove(index)))
+            let removed = {
+                let mut elements = self.borrow_vec_mut();
+                (index < elements.len()).then(|| elements.remove(index))
+            };
+            drop(removed);
+            Ok(())
         } else {
             Err(vm.new_value_error(format!("'{}' is not in list", needle.str(vm)?)))
         }
-        .map(drop)
     }
 
     fn _delitem(&self, needle: &PyObject, vm: &VirtualMachine) -> PyResult<()> {

--- a/scripts/check_redundant_patches.py
+++ b/scripts/check_redundant_patches.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 import argparse
 import ast
 import glob


### PR DESCRIPTION
- [x] This PR follows our [AI policy](https://github.com/RustPython/.github/blob/main/AI_POLICY.md)

## Summary

- Reduce `list.remove()` from two lock acquisitions to one.
- Update pre-commit Python hooks to use `python3`.
- Update the redundant-test-patches script shebang.

## Performance

`PyList::remove` now checks bounds and removes the item under a single mutable lock, avoiding an extra read-lock acquisition.

## Testing

- `prek run --all-files` passes.
- Full workspace tests compile successfully.
- `rustpython-capi` tests currently fail with an unrelated SIGSEGV in PyO3's CPython-specific `PyList_SET_ITEM`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved list element removal reliability by validating the target index against the current list length before removal.
  * Updated development checks and metadata generation to consistently use Python 3.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->