### PR TITLE
Implement cell comparison and repr

### DIFF
--- a/Lib/test/test_funcattrs.py
+++ b/Lib/test/test_funcattrs.py
@@ -432,7 +432,6 @@ def empty_cell(empty=True):
 
 
 class CellTest(unittest.TestCase):
-    @unittest.expectedFailure  # TODO: RUSTPYTHON
     def test_comparison(self):
         # These tests are here simply to exercise the comparison code;
         # their presence should not be interpreted as providing any

--- a/Lib/test/test_reprlib.py
+++ b/Lib/test/test_reprlib.py
@@ -237,7 +237,6 @@ class ReprTests(unittest.TestCase):
         eq(r([[[[[[{}]]]]]]), "[[[[[[{}]]]]]]")
         eq(r([[[[[[[{}]]]]]]]), "[[[[[[[...]]]]]]]")
 
-    @unittest.expectedFailure  # TODO: RUSTPYTHON
     def test_cell(self):
         def get_cell():
             x = 42

--- a/crates/vm/src/builtins/function.rs
+++ b/crates/vm/src/builtins/function.rs
@@ -15,7 +15,7 @@ use crate::{
     class::PyClassImpl,
     common::wtf8::{Wtf8Buf, wtf8_concat},
     frame::{FrameObject, FrameObjectRef},
-    function::{FuncArgs, OptionalArg, PyComparisonValue, PySetterValue},
+    function::{Either, FuncArgs, OptionalArg, PyComparisonValue, PySetterValue},
     scope::Scope,
     types::{
         Callable, Comparable, Constructor, GetAttr, GetDescriptor, Hashable, PyComparisonOp,
@@ -1507,7 +1507,7 @@ impl Representable for PyBoundMethod {
     }
 }
 
-#[pyclass(module = false, name = "cell", traverse)]
+#[pyclass(module = false, name = "cell", unhashable = true, traverse)]
 #[derive(Debug, Default)]
 pub(crate) struct PyCell {
     contents: PyMutex<Option<PyObjectRef>>,
@@ -1530,8 +1530,26 @@ impl Constructor for PyCell {
     }
 }
 
-#[pyclass(with(Constructor))]
+#[pyclass(with(Constructor, Representable))]
 impl PyCell {
+    #[pyslot]
+    fn slot_richcompare(
+        zelf: &PyObject,
+        other: &PyObject,
+        op: PyComparisonOp,
+        vm: &VirtualMachine,
+    ) -> PyResult<Either<PyObjectRef, PyComparisonValue>> {
+        let (Some(zelf), Some(other)) = (zelf.downcast_ref::<Self>(), other.downcast_ref::<Self>())
+        else {
+            return Ok(Either::B(PyComparisonValue::NotImplemented));
+        };
+        // compare cells by contents; empty cells come before anything else
+        match (zelf.get(), other.get()) {
+            (Some(a), Some(b)) => a.rich_compare(b, op, vm).map(Either::A),
+            (a, b) => Ok(Either::B(op.eval_ord(b.is_none().cmp(&a.is_none())).into())),
+        }
+    }
+
     pub(crate) const fn new(contents: Option<PyObjectRef>) -> Self {
         Self {
             contents: PyMutex::new(contents),
@@ -1558,6 +1576,30 @@ impl PyCell {
             PySetterValue::Assign(value) => self.set(Some(value)),
             PySetterValue::Delete => self.set(None),
         }
+    }
+}
+
+impl Representable for PyCell {
+    #[inline]
+    fn repr_str(zelf: &Py<Self>, _vm: &VirtualMachine) -> PyResult<String> {
+        let id = zelf.get_id();
+        Ok(match zelf.get() {
+            Some(value) => {
+                let type_name = value.class().slot_name();
+                // CPython renders the type name with "%.80s", which reads at
+                // most 80 bytes and drops a character left incomplete by the cut.
+                let mut end = type_name.len().min(80);
+                while !type_name.is_char_boundary(end) {
+                    end -= 1;
+                }
+                format!(
+                    "<cell at {id:#x}: {} object at {:#x}>",
+                    &type_name[..end],
+                    value.get_id()
+                )
+            }
+            None => format!("<cell at {id:#x}: empty>"),
+        })
     }
 }
 


### PR DESCRIPTION
- [ ] Closes #xxxx <!-- Replace xxxx with the GitHub issue number -->
- [x] This PR follows our [AI policy](https://github.com/RustPython/.github/blob/main/AI_POLICY.md)

## Summary

`PyCell` filled neither the richcompare nor the repr slot, so `object`'s
address-based defaults showed through. Cells were compared as boxes rather than
by what they hold:

```pycon
>>> cell(1) == cell(1)
False                       # CPython: True
>>> cell(-36) == cell(-36.0)
False                       # CPython: True
>>> cell(2) < cell(3)
TypeError: '<' not supported between instances of 'cell' and 'cell'
>>> repr(cell(1))
'<cell object at 0x7f...>'  # CPython: '<cell at 0x7f...: int object at 0x1b...>'
```

The box is an implementation detail, so CPython compares the contents instead
and renders both addresses in the repr. This ports the two missing slots.

**Comparison** follows `cell_richcompare`, which delegates to
`cell_compare_impl`:

https://github.com/python/cpython/blob/v3.14.0/Objects/cellobject.c#L85-L115

Contents are compared when both cells are full; otherwise the emptiness flags
are compared, which is how CPython gets "empty cells come before anything
else".

Two details of that delegation are load-bearing:

- The slot is filled directly rather than through `Comparable`, whose `cmp`
  can only answer with a bool. CPython returns whatever `PyObject_RichCompare`
  produced, so a contained `__eq__` yielding a non-bool has to pass through
  untouched — and coercing it would additionally call `__bool__`, raising
  exceptions CPython never raises. The empty-cell branch still answers with a
  bool, so the slot returns `Either`.
- `PyObject_RichCompare` is used rather than `PyObject_RichCompareBool`,
  matching CPython. The latter short-circuits `Eq` on identity, which is
  observable:

  ```pycon
  >>> c = cell(float('nan'))
  >>> c == c
  False                     # contents are actually compared
  ```

**Repr** follows `cell_repr`, including the empty case and the `%.80s` bound on
the contained type name — at most 80 bytes, dropping a character the cut would
leave incomplete:

https://github.com/python/cpython/blob/v3.14.0/Objects/cellobject.c#L117-L128

**The type also becomes unhashable.** This is not cosmetic: content-based
equality combined with the inherited identity hash would break the invariant
that objects comparing equal hash equally, so `{cell(1): v}[cell(1)]` would
raise `KeyError`. Hashing the contents is not an option either, because
`cell_contents` is writable and a key's hash has to stay put:

https://github.com/python/cpython/blob/v3.14.0/Objects/cellobject.c#L158-L170

CPython arrives at the same place implicitly — `cell` leaves `tp_hash` empty
while filling `tp_richcompare`, and the two slots are inherited as a pair:

https://github.com/python/cpython/blob/v3.14.0/Objects/typeobject.c#L8261-L8276

`list` reaches it explicitly with `PyObject_HashNotImplemented`, which is the
shape `unhashable = true` already has in RustPython.

## Test Plan

- Removed `@unittest.expectedFailure` from the two tests that now pass:
  `test_funcattrs.CellTest.test_comparison` and `test_reprlib.test_cell`.
- Differentially compared against CPython 3.14.0 over every documented cell
  behaviour — repr (filled, empty, constructed directly), all six comparison
  operators, empty-vs-filled ordering in both directions, non-cell operands,
  the `nan` identity case, hashing, and mutation through `cell_contents`.
  Output is identical once addresses are normalised.
- Separately compared the two cases raised in review: contained `__eq__`/`__lt__`
  returning a non-bool or an object whose `__bool__` raises, and type names of
  79/80/81 ASCII bytes plus 100 each of 2-, 3- and 4-byte characters. The 3-byte
  case is the one that pins the bound to bytes rather than characters — CPython
  renders 26 characters (78 bytes) there, since a 27th would reach 81.
- `test_funcattrs` and `test_reprlib` pass with no unexpected successes.
- 27 modules that exercise closures, cells and comparison pass (3,872 tests):
  serialization (`test_pickle`, `test_copy`, `test_marshal`), frame
  reconstruction (`test_inspect`, `test_pdb`, `test_annotationlib`), cycle
  collection (`test_gc`, `test_weakref`), plus `test_richcmp`, `test_sys`,
  `test_code`, `test_scope`, `test_types`, `test_descr`, `test_class`,
  `test_super`, `test_builtin`, `test_functools`, `test_typing`,
  `test_dataclasses`, `test_generators`, `test_doctest` and others.
- `cargo test -p rustpython-vm -p rustpython-common`, `cargo fmt --check` and
  `cargo clippy --all-targets` are clean.

One gap worth naming: no test in the CPython suite covers `cell` being
unhashable, so that part rests on the reasoning above rather than on coverage.
Nothing in `crates/` or `Lib/` hashes a cell or depends on the old repr.
