### PR TITLE
Specialize list.sort() comparisons for homogeneous lists

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3716,7 +3716,6 @@ dependencies = [
  "strum_macros",
  "thin-vec",
  "thiserror",
- "timsort",
  "wasm-bindgen",
  "widestring",
 ]
@@ -4284,12 +4283,6 @@ dependencies = [
  "num-conv",
  "time-core",
 ]
-
-[[package]]
-name = "timsort"
-version = "0.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "639ce8ef6d2ba56be0383a94dd13b92138d58de44c62618303bb798fa92bdc00"
 
 [[package]]
 name = "tinystr"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -305,7 +305,6 @@ textwrap = { version = "0.16.2", default-features = false }
 termios = "0.3.3"
 thiserror = "2.0"
 thin-vec = "0.2.14"
-timsort = "0.1.2"
 tk-sys = { git = "https://github.com/arihant2math/tkinter.git", tag = "v0.2.0" }
 icu_casemap = "2"
 icu_locale = "2"

--- a/crates/vm/Cargo.toml
+++ b/crates/vm/Cargo.toml
@@ -80,7 +80,6 @@ half = { workspace = true }
 psm = { workspace = true }
 optional = { workspace = true }
 result-like = { workspace = true }
-timsort = { workspace = true }
 
 [target.'cfg(unix)'.dependencies]
 exitcode = { workspace = true }

--- a/crates/vm/src/builtins/list.rs
+++ b/crates/vm/src/builtins/list.rs
@@ -18,6 +18,7 @@ use crate::{
     recursion::ReprGuard,
     sequence::{MutObjectSequenceOp, OptionalRangeArgs, SequenceExt, SequenceMutExt},
     sliceable::{SequenceIndex, SliceableSequenceMutOp, SliceableSequenceOp},
+    sorting::timsort,
     types::{
         AsMapping, AsSequence, Comparable, Constructor, Initializer, IterNext, Iterable,
         PyComparisonOp, Representable, SelfIter,
@@ -642,13 +643,11 @@ fn do_sort(
 ) -> PyResult<()> {
     // CPython uses __lt__ for all comparisons in sort.
     // try_sort_by_gt expects is_gt(a, b) = true when a should come AFTER b.
-    let cmp = |a: &PyObjectRef, b: &PyObjectRef| {
+    let mut is_lt = |a: &PyObjectRef, b: &PyObjectRef| {
         if reverse {
-            // Descending: a comes after b when a < b
-            a.rich_compare_bool(b, PyComparisonOp::Lt, vm)
-        } else {
-            // Ascending: a comes after b when b < a
             b.rich_compare_bool(a, PyComparisonOp::Lt, vm)
+        } else {
+            a.rich_compare_bool(b, PyComparisonOp::Lt, vm)
         }
     };
 
@@ -657,10 +656,10 @@ fn do_sort(
             .iter()
             .map(|x| Ok((x.clone(), key_func.call((x.clone(),), vm)?)))
             .collect::<Result<Vec<_>, _>>()?;
-        timsort::try_sort_by_gt(&mut items, |a, b| cmp(&a.1, &b.1))?;
+        timsort(&mut items, &mut |a, b| is_lt(&a.1, &b.1))?;
         *values = items.into_iter().map(|(val, _)| val).collect();
     } else {
-        timsort::try_sort_by_gt(values, cmp)?;
+        timsort(values, &mut is_lt)?;
     }
 
     Ok(())

--- a/crates/vm/src/builtins/list.rs
+++ b/crates/vm/src/builtins/list.rs
@@ -642,7 +642,10 @@ fn do_sort(
     reverse: bool,
 ) -> PyResult<()> {
     // CPython uses __lt__ for all comparisons in sort.
-    // try_sort_by_gt expects is_gt(a, b) = true when a should come AFTER b.
+    // `timsort` expects is_lt(a, b) = true when a must be placed BEFORE b.
+    // For reverse=True, swapping the operands yields a descending order that is
+    // still stable in the original relative order, matching CPython's
+    // reverse-sort-reverse approach.
     let mut is_lt = |a: &PyObjectRef, b: &PyObjectRef| {
         if reverse {
             b.rich_compare_bool(a, PyComparisonOp::Lt, vm)

--- a/crates/vm/src/builtins/list.rs
+++ b/crates/vm/src/builtins/list.rs
@@ -12,7 +12,7 @@ use crate::{
     builtins::{PyFloat, PyInt, PyStr},
     class::PyClassImpl,
     convert::ToPyObject,
-    function::{ArgSize, FuncArgs, OptionalArg, PyComparisonValue},
+    function::{ArgSize, Either, FuncArgs, OptionalArg, PyComparisonValue},
     iter::PyExactSizeIterator,
     protocol::{PyIterReturn, PyMappingMethods, PySequenceMethods},
     recursion::ReprGuard,
@@ -21,7 +21,7 @@ use crate::{
     sorting::timsort,
     types::{
         AsMapping, AsSequence, Comparable, Constructor, Initializer, IterNext, Iterable,
-        PyComparisonOp, Representable, SelfIter,
+        PyComparisonOp, Representable, RichCompareFunc, SelfIter,
     },
     vm::VirtualMachine,
 };
@@ -639,6 +639,7 @@ enum PreSort {
     Str,
     Int,
     Float,
+    Object(RichCompareFunc),
     Generic,
 }
 
@@ -659,6 +660,8 @@ fn pre_sort_check<'a>(
         PreSort::Int
     } else if class.is(vm.ctx.types.float_type) {
         PreSort::Float
+    } else if let Some(f) = class.slots.richcompare.load() {
+        PreSort::Object(f)
     } else {
         PreSort::Generic
     }
@@ -674,6 +677,31 @@ fn int_lt(a: &PyObjectRef, b: &PyObjectRef) -> bool {
 
 fn float_lt(a: &PyObjectRef, b: &PyObjectRef) -> bool {
     a.downcast_ref::<PyFloat>().unwrap().to_f64() < b.downcast_ref::<PyFloat>().unwrap().to_f64()
+}
+
+fn object_lt(
+    cmp: RichCompareFunc,
+    a: &PyObjectRef,
+    b: &PyObjectRef,
+    vm: &VirtualMachine,
+) -> PyResult<bool> {
+    #[allow(unpredictable_function_pointer_comparisons)]
+    if a.class().slots.richcompare.load() != Some(cmp) {
+        return a.rich_compare_bool(b, PyComparisonOp::Lt, vm);
+    }
+    match cmp(a, b, PyComparisonOp::Lt, vm)? {
+        Either::B(PyComparisonValue::Implemented(v)) => Ok(v),
+        Either::B(PyComparisonValue::NotImplemented) => {
+            a.rich_compare_bool(b, PyComparisonOp::Lt, vm)
+        }
+        Either::A(obj) => {
+            if obj.is(&vm.ctx.not_implemented) {
+                a.rich_compare_bool(b, PyComparisonOp::Lt, vm)
+            } else {
+                obj.try_to_bool(vm)
+            }
+        }
+    }
 }
 
 fn timsort_specialized<T, K>(
@@ -710,6 +738,14 @@ where
                 (key(a), key(b))
             };
             Ok(float_lt(a, b))
+        }),
+        PreSort::Object(cmp) => timsort(items, &mut |a, b| {
+            let (a, b) = if reverse {
+                (key(b), key(a))
+            } else {
+                (key(a), key(b))
+            };
+            object_lt(cmp, a, b, vm)
         }),
         PreSort::Generic => timsort(items, &mut |a, b| {
             let (a, b) = if reverse {

--- a/crates/vm/src/builtins/list.rs
+++ b/crates/vm/src/builtins/list.rs
@@ -9,7 +9,7 @@ use crate::common::lock::{
 use crate::object::{Traverse, TraverseFn};
 use crate::{
     AsObject, Context, Py, PyObject, PyObjectRef, PyPayload, PyRef, PyResult,
-    builtins::PyStr,
+    builtins::{PyFloat, PyInt, PyStr},
     class::PyClassImpl,
     convert::ToPyObject,
     function::{ArgSize, FuncArgs, OptionalArg, PyComparisonValue},
@@ -635,34 +635,113 @@ impl Representable for PyList {
     }
 }
 
+enum PreSort {
+    Str,
+    Int,
+    Float,
+    Generic,
+}
+
+fn pre_sort_check<'a>(
+    mut keys: impl Iterator<Item = &'a PyObjectRef>,
+    vm: &VirtualMachine,
+) -> PreSort {
+    let Some(first) = keys.next() else {
+        return PreSort::Generic;
+    };
+    let class = first.class();
+    if !keys.all(|o| o.class().is(class)) {
+        return PreSort::Generic;
+    }
+    if class.is(vm.ctx.types.str_type) {
+        PreSort::Str
+    } else if class.is(vm.ctx.types.int_type) {
+        PreSort::Int
+    } else if class.is(vm.ctx.types.float_type) {
+        PreSort::Float
+    } else {
+        PreSort::Generic
+    }
+}
+
+fn str_lt(a: &PyObjectRef, b: &PyObjectRef) -> bool {
+    a.downcast_ref::<PyStr>().unwrap().as_bytes() < b.downcast_ref::<PyStr>().unwrap().as_bytes()
+}
+
+fn int_lt(a: &PyObjectRef, b: &PyObjectRef) -> bool {
+    a.downcast_ref::<PyInt>().unwrap().as_bigint() < b.downcast_ref::<PyInt>().unwrap().as_bigint()
+}
+
+fn float_lt(a: &PyObjectRef, b: &PyObjectRef) -> bool {
+    a.downcast_ref::<PyFloat>().unwrap().to_f64() < b.downcast_ref::<PyFloat>().unwrap().to_f64()
+}
+
+fn timsort_specialized<T, K>(
+    vm: &VirtualMachine,
+    items: &mut [T],
+    reverse: bool,
+    key: K,
+) -> PyResult<()>
+where
+    T: Clone,
+    K: Fn(&T) -> &PyObjectRef,
+{
+    match pre_sort_check(items.iter().map(&key), vm) {
+        PreSort::Str => timsort(items, &mut |a, b| {
+            let (a, b) = if reverse {
+                (key(b), key(a))
+            } else {
+                (key(a), key(b))
+            };
+            Ok(str_lt(a, b))
+        }),
+        PreSort::Int => timsort(items, &mut |a, b| {
+            let (a, b) = if reverse {
+                (key(b), key(a))
+            } else {
+                (key(a), key(b))
+            };
+            Ok(int_lt(a, b))
+        }),
+        PreSort::Float => timsort(items, &mut |a, b| {
+            let (a, b) = if reverse {
+                (key(b), key(a))
+            } else {
+                (key(a), key(b))
+            };
+            Ok(float_lt(a, b))
+        }),
+        PreSort::Generic => timsort(items, &mut |a, b| {
+            let (a, b) = if reverse {
+                (key(b), key(a))
+            } else {
+                (key(a), key(b))
+            };
+            a.rich_compare_bool(b, PyComparisonOp::Lt, vm)
+        }),
+    }
+}
+
 fn do_sort(
     vm: &VirtualMachine,
     values: &mut Vec<PyObjectRef>,
     key_func: Option<PyObjectRef>,
     reverse: bool,
 ) -> PyResult<()> {
-    // CPython uses __lt__ for all comparisons in sort.
-    // `timsort` expects is_lt(a, b) = true when a must be placed BEFORE b.
-    // For reverse=True, swapping the operands yields a descending order that is
-    // still stable in the original relative order, matching CPython's
-    // reverse-sort-reverse approach.
-    let mut is_lt = |a: &PyObjectRef, b: &PyObjectRef| {
-        if reverse {
-            b.rich_compare_bool(a, PyComparisonOp::Lt, vm)
-        } else {
-            a.rich_compare_bool(b, PyComparisonOp::Lt, vm)
-        }
-    };
-
     if let Some(ref key_func) = key_func {
         let mut items = values
             .iter()
             .map(|x| Ok((x.clone(), key_func.call((x.clone(),), vm)?)))
             .collect::<Result<Vec<_>, _>>()?;
-        timsort(&mut items, &mut |a, b| is_lt(&a.1, &b.1))?;
+        timsort_specialized(
+            vm,
+            &mut items,
+            reverse,
+            |item: &(PyObjectRef, PyObjectRef)| &item.1,
+        )?;
         *values = items.into_iter().map(|(val, _)| val).collect();
     } else {
-        timsort(values, &mut is_lt)?;
+        timsort_specialized(vm, values, reverse, |x: &PyObjectRef| x)?
     }
 
     Ok(())

--- a/crates/vm/src/builtins/list.rs
+++ b/crates/vm/src/builtins/list.rs
@@ -9,7 +9,7 @@ use crate::common::lock::{
 use crate::object::{Traverse, TraverseFn};
 use crate::{
     AsObject, Context, Py, PyObject, PyObjectRef, PyPayload, PyRef, PyResult,
-    builtins::{PyFloat, PyInt, PyStr},
+    builtins::{PyFloat, PyInt, PyStr, PyTuple},
     class::PyClassImpl,
     convert::ToPyObject,
     function::{ArgSize, Either, FuncArgs, OptionalArg, PyComparisonValue},
@@ -635,12 +635,47 @@ impl Representable for PyList {
     }
 }
 
-enum PreSort {
+enum Elem {
     Str,
     Int,
     Float,
     Object(RichCompareFunc),
     Generic,
+}
+
+enum PreSort {
+    Str,
+    Int,
+    Float,
+    Object(RichCompareFunc),
+    Tuple(Elem),
+    Generic,
+}
+
+impl From<Elem> for PreSort {
+    fn from(e: Elem) -> Self {
+        match e {
+            Elem::Str => Self::Str,
+            Elem::Int => Self::Int,
+            Elem::Float => Self::Float,
+            Elem::Object(f) => Self::Object(f),
+            Elem::Generic => Self::Generic,
+        }
+    }
+}
+
+fn classify(class: &Py<PyType>, vm: &VirtualMachine) -> Elem {
+    if class.is(vm.ctx.types.str_type) {
+        Elem::Str
+    } else if class.is(vm.ctx.types.int_type) {
+        Elem::Int
+    } else if class.is(vm.ctx.types.float_type) {
+        Elem::Float
+    } else if let Some(f) = class.slots.richcompare.load() {
+        Elem::Object(f)
+    } else {
+        Elem::Generic
+    }
 }
 
 fn pre_sort_check<'a>(
@@ -650,21 +685,48 @@ fn pre_sort_check<'a>(
     let Some(first) = keys.next() else {
         return PreSort::Generic;
     };
-    let class = first.class();
-    if !keys.all(|o| o.class().is(class)) {
-        return PreSort::Generic;
-    }
-    if class.is(vm.ctx.types.str_type) {
-        PreSort::Str
-    } else if class.is(vm.ctx.types.int_type) {
-        PreSort::Int
-    } else if class.is(vm.ctx.types.float_type) {
-        PreSort::Float
-    } else if let Some(f) = class.slots.richcompare.load() {
-        PreSort::Object(f)
+
+    if let Some(t) = first
+        .downcast_ref_if_exact::<PyTuple>(vm)
+        .filter(|t| !t.as_slice().is_empty())
+    {
+        pre_sort_check_tuples(&t.as_slice()[0], keys, vm)
     } else {
-        PreSort::Generic
+        let class = first.class();
+        if keys.all(|k| k.class().is(class)) {
+            classify(class, vm).into()
+        } else {
+            PreSort::Generic
+        }
     }
+}
+
+fn pre_sort_check_tuples<'a>(
+    first_elem: &PyObjectRef,
+    keys: impl Iterator<Item = &'a PyObjectRef>,
+    vm: &VirtualMachine,
+) -> PreSort {
+    let class = first_elem.class();
+    let mut all_same_type = true;
+
+    for k in keys {
+        let Some(t) = k
+            .downcast_ref_if_exact::<PyTuple>(vm)
+            .filter(|t| !t.as_slice().is_empty())
+        else {
+            return PreSort::Generic;
+        };
+        if all_same_type && !t.as_slice()[0].class().is(class) {
+            all_same_type = false;
+        }
+    }
+
+    let elem = if !all_same_type || class.is(vm.ctx.types.tuple_type) {
+        Elem::Generic
+    } else {
+        classify(class, vm)
+    };
+    PreSort::Tuple(elem)
 }
 
 fn str_lt(a: &PyObjectRef, b: &PyObjectRef) -> bool {
@@ -701,6 +763,37 @@ fn object_lt(
                 obj.try_to_bool(vm)
             }
         }
+    }
+}
+
+fn elem_lt(elem: &Elem, a: &PyObjectRef, b: &PyObjectRef, vm: &VirtualMachine) -> PyResult<bool> {
+    match elem {
+        Elem::Str => Ok(str_lt(a, b)),
+        Elem::Int => Ok(int_lt(a, b)),
+        Elem::Float => Ok(float_lt(a, b)),
+        Elem::Object(f) => object_lt(*f, a, b, vm),
+        Elem::Generic => a.rich_compare_bool(b, PyComparisonOp::Lt, vm),
+    }
+}
+
+fn tuple_lt(elem: &Elem, a: &PyObjectRef, b: &PyObjectRef, vm: &VirtualMachine) -> PyResult<bool> {
+    let a = a.downcast_ref::<PyTuple>().unwrap().as_slice();
+    let b = b.downcast_ref::<PyTuple>().unwrap().as_slice();
+
+    let mut i = 0;
+    while i < a.len() && i < b.len() {
+        if !a[i].rich_compare_bool(&b[i], PyComparisonOp::Eq, vm)? {
+            break;
+        }
+        i += 1;
+    }
+    if i >= a.len() || i >= b.len() {
+        return Ok(a.len() < b.len());
+    }
+    if i == 0 {
+        elem_lt(elem, &a[0], &b[0], vm)
+    } else {
+        a[i].rich_compare_bool(&b[i], PyComparisonOp::Lt, vm)
     }
 }
 
@@ -746,6 +839,14 @@ where
                 (key(a), key(b))
             };
             object_lt(cmp, a, b, vm)
+        }),
+        PreSort::Tuple(elem) => timsort(items, &mut |a, b| {
+            let (a, b) = if reverse {
+                (key(b), key(a))
+            } else {
+                (key(a), key(b))
+            };
+            tuple_lt(&elem, a, b, vm)
         }),
         PreSort::Generic => timsort(items, &mut |a, b| {
             let (a, b) = if reverse {

--- a/crates/vm/src/lib.rs
+++ b/crates/vm/src/lib.rs
@@ -92,6 +92,7 @@ pub mod scope;
 pub mod sequence;
 pub mod signal;
 pub mod sliceable;
+pub mod sorting;
 pub mod stdlib;
 pub mod suggestion;
 pub mod types;

--- a/crates/vm/src/sorting.rs
+++ b/crates/vm/src/sorting.rs
@@ -706,7 +706,7 @@ mod tests {
     }
 
     #[test]
-    fn test_basic() {
+    fn basic_examples() {
         assert_eq!(sort(vec![3, 1, 2]), vec![1, 2, 3]);
         assert_eq!(sort(Vec::<i32>::new()), Vec::<i32>::new());
         assert_eq!(sort(vec![1]), vec![1]);
@@ -714,25 +714,25 @@ mod tests {
     }
 
     #[test]
-    fn test_ordered() {
+    fn five_elements_forwards_and_backwards() {
         assert_eq!(sort(vec![1, 2, 3, 4, 5]), vec![1, 2, 3, 4, 5]);
         assert_eq!(sort(vec![5, 4, 3, 2, 1]), vec![1, 2, 3, 4, 5]);
     }
 
     #[test]
-    fn test_duplicates() {
+    fn six_elements_with_duplicates() {
         assert_eq!(sort(vec![3, 1, 3, 1, 2, 2]), vec![1, 1, 2, 2, 3, 3]);
     }
 
     #[test]
-    fn test_large() {
+    fn one_thousand_elements() {
         let v: Vec<i32> = (0..1000).rev().collect(); // 999..0
         let sorted: Vec<i32> = (0..1000).collect();
         assert_eq!(sort(v), sorted);
     }
 
     #[test]
-    fn test_random_ish() {
+    fn pseudorandom_collection() {
         let v: Vec<i32> = (0..500).map(|i| (i * 7919) % 500).collect();
         let mut expected = v.clone();
         expected.sort();

--- a/crates/vm/src/sorting.rs
+++ b/crates/vm/src/sorting.rs
@@ -344,7 +344,7 @@ impl<T: Clone> MergeState<T> {
         match breakout {
             Some(Breakout::Succeed) => {
                 if len_b > 0 {
-                    values[dest - len_b + 1..dest + 1].clone_from_slice(&self.buf[0..len_b]);
+                    values[(dest + 1) - len_b..dest + 1].clone_from_slice(&self.buf[0..len_b]);
                 }
                 Ok(())
             }

--- a/crates/vm/src/sorting.rs
+++ b/crates/vm/src/sorting.rs
@@ -134,7 +134,7 @@ impl<T: Clone> MergeState<T> {
                     breakout = Some(Breakout::Succeed);
                     break;
                 }
-                k = gallop_left(&values, is_lt, &self.buf[cursor_a], cursor_b, len_b, 0)?;
+                k = gallop_left(values, is_lt, &self.buf[cursor_a], cursor_b, len_b, 0)?;
                 b_count = k;
                 if k > 0 {
                     copy_within_clone(values, cursor_b, dest, k);
@@ -208,7 +208,7 @@ impl<T: Clone> MergeState<T> {
         len_a -= 1;
 
         if len_a == 0 {
-            values[dest - len_b + 1..dest + 1].clone_from_slice(&self.buf[0..len_b]);
+            values[(dest - len_b + 1)..=dest].clone_from_slice(&self.buf[0..len_b]);
             return Ok(());
         }
         if len_b == 1 {
@@ -272,7 +272,7 @@ impl<T: Clone> MergeState<T> {
                 }
                 self.min_gallop = min_gallop;
                 let mut k = gallop_right(
-                    &values,
+                    values,
                     is_lt,
                     &self.buf[cursor_b],
                     start_a,
@@ -303,8 +303,8 @@ impl<T: Clone> MergeState<T> {
                 k = len_b - k;
                 b_count = k;
                 if k > 0 {
-                    values[dest + 1 - k..dest + 1]
-                        .clone_from_slice(&self.buf[cursor_b + 1 - k..cursor_b + 1]);
+                    values[dest + 1 - k..=dest]
+                        .clone_from_slice(&self.buf[cursor_b + 1 - k..=cursor_b]);
                     dest -= k;
                     len_b -= k;
 
@@ -344,7 +344,7 @@ impl<T: Clone> MergeState<T> {
         match breakout {
             Some(Breakout::Succeed) => {
                 if len_b > 0 {
-                    values[(dest + 1) - len_b..dest + 1].clone_from_slice(&self.buf[0..len_b]);
+                    values[(dest + 1) - len_b..=dest].clone_from_slice(&self.buf[0..len_b]);
                 }
                 Ok(())
             }
@@ -407,7 +407,12 @@ impl<T: Clone> MergeState<T> {
         Ok(())
     }
 
-    fn found_new_run<E, F>(&mut self, new_run_len: usize, values: &mut [T], is_lt: &mut F) -> Result<(), E>
+    fn found_new_run<E, F>(
+        &mut self,
+        new_run_len: usize,
+        values: &mut [T],
+        is_lt: &mut F,
+    ) -> Result<(), E>
     where
         F: FnMut(&T, &T) -> Result<bool, E>,
     {
@@ -661,7 +666,7 @@ where
     }
 
     if n < MAX_MINRUN {
-        let (l, desc) = count_run(&values, is_lt)?;
+        let (l, desc) = count_run(values, is_lt)?;
         if desc {
             values[0..l].reverse();
         }
@@ -721,14 +726,14 @@ mod tests {
 
     #[test]
     fn test_large() {
-        let mut v: Vec<i32> = (0..1000).rev().collect(); // 999..0
+        let v: Vec<i32> = (0..1000).rev().collect(); // 999..0
         let sorted: Vec<i32> = (0..1000).collect();
         assert_eq!(sort(v), sorted);
     }
 
     #[test]
     fn test_random_ish() {
-        let mut v: Vec<i32> = (0..500).map(|i| (i * 7919) % 500).collect();
+        let v: Vec<i32> = (0..500).map(|i| (i * 7919) % 500).collect();
         let mut expected = v.clone();
         expected.sort();
         assert_eq!(sort(v), expected);

--- a/crates/vm/src/sorting.rs
+++ b/crates/vm/src/sorting.rs
@@ -2,10 +2,14 @@
 const MIN_GALLOP: usize = 7;
 const MAX_MINRUN: usize = 64;
 
-enum Breakout {
+enum LoBreakout {
+    Succeed,
+    CopyB,
+}
+
+enum HiBreakout {
     Succeed,
     CopyA,
-    CopyB,
 }
 
 #[derive(Clone, Copy)]
@@ -62,14 +66,17 @@ impl<T: Clone> MergeState<T> {
         }
 
         let mut min_gallop = self.min_gallop;
-        let mut breakout: Option<Breakout> = None;
 
-        loop {
+        let breakout: Result<LoBreakout, E> = 'merging: loop {
             let mut a_count = 0;
             let mut b_count = 0;
 
             loop {
-                if is_lt(&values[cursor_b], &self.buf[cursor_a])? {
+                let b_wins = match is_lt(&values[cursor_b], &self.buf[cursor_a]) {
+                    Ok(v) => v,
+                    Err(e) => break 'merging Err(e),
+                };
+                if b_wins {
                     values[dest] = values[cursor_b].clone();
                     dest += 1;
                     cursor_b += 1;
@@ -77,8 +84,7 @@ impl<T: Clone> MergeState<T> {
                     b_count += 1;
                     a_count = 0;
                     if len_b == 0 {
-                        breakout = Some(Breakout::Succeed);
-                        break;
+                        break 'merging Ok(LoBreakout::Succeed);
                     }
                     if b_count >= min_gallop {
                         break;
@@ -91,17 +97,12 @@ impl<T: Clone> MergeState<T> {
                     a_count += 1;
                     b_count = 0;
                     if len_a == 1 {
-                        breakout = Some(Breakout::CopyB);
-                        break;
+                        break 'merging Ok(LoBreakout::CopyB);
                     }
                     if a_count >= min_gallop {
                         break;
                     }
                 }
-            }
-
-            if breakout.is_some() {
-                break;
             }
 
             min_gallop += 1;
@@ -110,7 +111,11 @@ impl<T: Clone> MergeState<T> {
                     min_gallop -= 1;
                 }
                 self.min_gallop = min_gallop;
-                let mut k = gallop_right(&self.buf, is_lt, &values[cursor_b], cursor_a, len_a, 0)?;
+                let mut k =
+                    match gallop_right(&self.buf, is_lt, &values[cursor_b], cursor_a, len_a, 0) {
+                        Ok(k) => k,
+                        Err(e) => break 'merging Err(e),
+                    };
                 a_count = k;
                 if k > 0 {
                     values[dest..dest + k].clone_from_slice(&self.buf[cursor_a..cursor_a + k]);
@@ -118,12 +123,10 @@ impl<T: Clone> MergeState<T> {
                     cursor_a += k;
                     len_a -= k;
                     if len_a == 1 {
-                        breakout = Some(Breakout::CopyB);
-                        break;
+                        break 'merging Ok(LoBreakout::CopyB);
                     }
                     if len_a == 0 {
-                        breakout = Some(Breakout::Succeed);
-                        break;
+                        break 'merging Ok(LoBreakout::Succeed);
                     }
                 }
                 values[dest] = values[cursor_b].clone();
@@ -131,10 +134,12 @@ impl<T: Clone> MergeState<T> {
                 cursor_b += 1;
                 len_b -= 1;
                 if len_b == 0 {
-                    breakout = Some(Breakout::Succeed);
-                    break;
+                    break 'merging Ok(LoBreakout::Succeed);
                 }
-                k = gallop_left(values, is_lt, &self.buf[cursor_a], cursor_b, len_b, 0)?;
+                k = match gallop_left(values, is_lt, &self.buf[cursor_a], cursor_b, len_b, 0) {
+                    Ok(k) => k,
+                    Err(e) => break 'merging Err(e),
+                };
                 b_count = k;
                 if k > 0 {
                     copy_within_clone(values, cursor_b, dest, k);
@@ -142,39 +147,34 @@ impl<T: Clone> MergeState<T> {
                     cursor_b += k;
                     len_b -= k;
                     if len_b == 0 {
-                        breakout = Some(Breakout::Succeed);
-                        break;
+                        break 'merging Ok(LoBreakout::Succeed);
                     }
                 }
                 if len_a == 1 {
-                    breakout = Some(Breakout::CopyB);
-                    break;
+                    break 'merging Ok(LoBreakout::CopyB);
                 }
                 if a_count < MIN_GALLOP && b_count < MIN_GALLOP {
                     break;
                 }
             }
-            if breakout.is_some() {
-                break;
-            }
+
             min_gallop += 1;
             self.min_gallop = min_gallop;
-        }
+        };
 
         match breakout {
-            Some(Breakout::Succeed) => {
-                if len_a > 0 {
-                    values[dest..dest + len_a]
-                        .clone_from_slice(&self.buf[cursor_a..cursor_a + len_a]);
-                }
-                Ok(())
-            }
-            Some(Breakout::CopyB) => {
+            Ok(LoBreakout::CopyB) => {
                 copy_within_clone(values, cursor_b, dest, len_b);
                 values[dest + len_b] = self.buf[cursor_a].clone();
                 Ok(())
             }
-            _ => unreachable!(),
+            other => {
+                if len_a > 0 {
+                    values[dest..dest + len_a]
+                        .clone_from_slice(&self.buf[cursor_a..cursor_a + len_a]);
+                }
+                other.map(|_| ())
+            }
         }
     }
 
@@ -220,21 +220,22 @@ impl<T: Clone> MergeState<T> {
         }
 
         let mut min_gallop = self.min_gallop;
-        let mut breakout: Option<Breakout> = None;
-
-        loop {
+        let breakout: Result<HiBreakout, E> = 'merging: loop {
             let mut a_count = 0;
             let mut b_count = 0;
 
             loop {
-                if is_lt(&self.buf[cursor_b], &values[cursor_a])? {
+                let b_wins = match is_lt(&self.buf[cursor_b], &values[cursor_a]) {
+                    Ok(v) => v,
+                    Err(e) => break 'merging Err(e),
+                };
+                if b_wins {
                     values[dest] = values[cursor_a].clone();
                     dest -= 1;
                     len_a -= 1;
 
                     if len_a == 0 {
-                        breakout = Some(Breakout::Succeed);
-                        break;
+                        break 'merging Ok(HiBreakout::Succeed);
                     }
 
                     cursor_a -= 1;
@@ -252,17 +253,12 @@ impl<T: Clone> MergeState<T> {
                     b_count += 1;
                     a_count = 0;
                     if len_b == 1 {
-                        breakout = Some(Breakout::CopyA);
-                        break;
+                        break 'merging Ok(HiBreakout::CopyA);
                     }
                     if b_count >= min_gallop {
                         break;
                     }
                 }
-            }
-
-            if breakout.is_some() {
-                break;
             }
 
             min_gallop += 1;
@@ -271,14 +267,17 @@ impl<T: Clone> MergeState<T> {
                     min_gallop -= 1;
                 }
                 self.min_gallop = min_gallop;
-                let mut k = gallop_right(
+                let mut k = match gallop_right(
                     values,
                     is_lt,
                     &self.buf[cursor_b],
                     start_a,
                     len_a,
                     len_a - 1,
-                )?;
+                ) {
+                    Ok(k) => k,
+                    Err(e) => break 'merging Err(e),
+                };
                 k = len_a - k;
                 a_count = k;
                 if k > 0 {
@@ -286,8 +285,7 @@ impl<T: Clone> MergeState<T> {
                     dest -= k;
                     len_a -= k;
                     if len_a == 0 {
-                        breakout = Some(Breakout::Succeed);
-                        break;
+                        break 'merging Ok(HiBreakout::Succeed);
                     }
                     cursor_a -= k;
                 }
@@ -296,10 +294,12 @@ impl<T: Clone> MergeState<T> {
                 cursor_b -= 1;
                 len_b -= 1;
                 if len_b == 1 {
-                    breakout = Some(Breakout::CopyA);
-                    break;
+                    break 'merging Ok(HiBreakout::CopyA);
                 }
-                k = gallop_left(&self.buf, is_lt, &values[cursor_a], 0, len_b, len_b - 1)?;
+                k = match gallop_left(&self.buf, is_lt, &values[cursor_a], 0, len_b, len_b - 1) {
+                    Ok(k) => k,
+                    Err(e) => break 'merging Err(e),
+                };
                 k = len_b - k;
                 b_count = k;
                 if k > 0 {
@@ -309,14 +309,12 @@ impl<T: Clone> MergeState<T> {
                     len_b -= k;
 
                     if len_b == 0 {
-                        breakout = Some(Breakout::Succeed);
-                        break;
+                        break 'merging Ok(HiBreakout::Succeed);
                     }
                     cursor_b -= k;
 
                     if len_b == 1 {
-                        breakout = Some(Breakout::CopyA);
-                        break;
+                        break 'merging Ok(HiBreakout::CopyA);
                     }
                 }
                 values[dest] = values[cursor_a].clone();
@@ -324,8 +322,7 @@ impl<T: Clone> MergeState<T> {
                 len_a -= 1;
 
                 if len_a == 0 {
-                    breakout = Some(Breakout::Succeed);
-                    break;
+                    break 'merging Ok(HiBreakout::Succeed);
                 }
 
                 cursor_a -= 1;
@@ -334,28 +331,24 @@ impl<T: Clone> MergeState<T> {
                     break;
                 }
             }
-            if breakout.is_some() {
-                break;
-            }
             min_gallop += 1;
             self.min_gallop = min_gallop;
-        }
+        };
 
         match breakout {
-            Some(Breakout::Succeed) => {
-                if len_b > 0 {
-                    values[(dest + 1) - len_b..=dest].clone_from_slice(&self.buf[0..len_b]);
-                }
-                Ok(())
-            }
-            Some(Breakout::CopyA) => {
+            Ok(HiBreakout::CopyA) => {
                 let src = cursor_a + 1 - len_a;
                 let dst = dest + 1 - len_a;
                 copy_within_clone(values, src, dst, len_a);
                 values[dst - 1] = self.buf[cursor_b].clone();
                 Ok(())
             }
-            _ => unreachable!(),
+            other => {
+                if len_b > 0 {
+                    values[(dest + 1) - len_b..=dest].clone_from_slice(&self.buf[0..len_b]);
+                }
+                other.map(|_| ())
+            }
         }
     }
 

--- a/crates/vm/src/sorting.rs
+++ b/crates/vm/src/sorting.rs
@@ -1,0 +1,736 @@
+// TODO: MERGESTATE_TEMP_SIZE unused — buf is a dynamic Vec, not a fixed stack array.
+const MIN_GALLOP: usize = 7;
+const MAX_MINRUN: usize = 64;
+
+enum Breakout {
+    Succeed,
+    CopyA,
+    CopyB,
+}
+
+#[derive(Clone, Copy)]
+struct Run {
+    base: usize,
+    len: usize,
+    power: u32,
+}
+
+struct MergeState<T> {
+    buf: Vec<T>,
+    min_gallop: usize,
+    pending: Vec<Run>,
+}
+
+impl<T: Clone> MergeState<T> {
+    fn merge_lo<E, F>(
+        &mut self,
+        values: &mut [T],
+        is_lt: &mut F,
+        start_a: usize,
+        mut len_a: usize,
+        start_b: usize,
+        mut len_b: usize,
+    ) -> Result<(), E>
+    where
+        F: FnMut(&T, &T) -> Result<bool, E>,
+    {
+        debug_assert!(len_a > 0);
+        debug_assert!(len_b > 0);
+        debug_assert!(start_a + len_a == start_b);
+
+        self.buf.clear();
+        self.buf
+            .extend_from_slice(&values[start_a..start_a + len_a]);
+
+        let mut cursor_a = 0;
+        let mut cursor_b = start_b;
+        let mut dest = start_a;
+
+        values[dest] = values[cursor_b].clone();
+        dest += 1;
+        cursor_b += 1;
+        len_b -= 1;
+
+        if len_b == 0 {
+            values[dest..dest + len_a].clone_from_slice(&self.buf[cursor_a..cursor_a + len_a]);
+            return Ok(());
+        }
+        if len_a == 1 {
+            copy_within_clone(values, cursor_b, dest, len_b);
+            values[dest + len_b] = self.buf[cursor_a].clone();
+            return Ok(());
+        }
+
+        let mut min_gallop = self.min_gallop;
+        let mut breakout: Option<Breakout> = None;
+
+        loop {
+            let mut a_count = 0;
+            let mut b_count = 0;
+
+            loop {
+                if is_lt(&values[cursor_b], &self.buf[cursor_a])? {
+                    values[dest] = values[cursor_b].clone();
+                    dest += 1;
+                    cursor_b += 1;
+                    len_b -= 1;
+                    b_count += 1;
+                    a_count = 0;
+                    if len_b == 0 {
+                        breakout = Some(Breakout::Succeed);
+                        break;
+                    }
+                    if b_count >= min_gallop {
+                        break;
+                    }
+                } else {
+                    values[dest] = self.buf[cursor_a].clone();
+                    dest += 1;
+                    cursor_a += 1;
+                    len_a -= 1;
+                    a_count += 1;
+                    b_count = 0;
+                    if len_a == 1 {
+                        breakout = Some(Breakout::CopyB);
+                        break;
+                    }
+                    if a_count >= min_gallop {
+                        break;
+                    }
+                }
+            }
+
+            if breakout.is_some() {
+                break;
+            }
+
+            min_gallop += 1;
+            loop {
+                if min_gallop > 1 {
+                    min_gallop -= 1;
+                }
+                self.min_gallop = min_gallop;
+                let mut k = gallop_right(&self.buf, is_lt, &values[cursor_b], cursor_a, len_a, 0)?;
+                a_count = k;
+                if k > 0 {
+                    values[dest..dest + k].clone_from_slice(&self.buf[cursor_a..cursor_a + k]);
+                    dest += k;
+                    cursor_a += k;
+                    len_a -= k;
+                    if len_a == 1 {
+                        breakout = Some(Breakout::CopyB);
+                        break;
+                    }
+                    if len_a == 0 {
+                        breakout = Some(Breakout::Succeed);
+                        break;
+                    }
+                }
+                values[dest] = values[cursor_b].clone();
+                dest += 1;
+                cursor_b += 1;
+                len_b -= 1;
+                if len_b == 0 {
+                    breakout = Some(Breakout::Succeed);
+                    break;
+                }
+                k = gallop_left(&values, is_lt, &self.buf[cursor_a], cursor_b, len_b, 0)?;
+                b_count = k;
+                if k > 0 {
+                    copy_within_clone(values, cursor_b, dest, k);
+                    dest += k;
+                    cursor_b += k;
+                    len_b -= k;
+                    if len_b == 0 {
+                        breakout = Some(Breakout::Succeed);
+                        break;
+                    }
+                }
+                if len_a == 1 {
+                    breakout = Some(Breakout::CopyB);
+                    break;
+                }
+                if a_count < MIN_GALLOP && b_count < MIN_GALLOP {
+                    break;
+                }
+            }
+            if breakout.is_some() {
+                break;
+            }
+            min_gallop += 1;
+            self.min_gallop = min_gallop;
+        }
+
+        match breakout {
+            Some(Breakout::Succeed) => {
+                if len_a > 0 {
+                    values[dest..dest + len_a]
+                        .clone_from_slice(&self.buf[cursor_a..cursor_a + len_a]);
+                }
+                Ok(())
+            }
+            Some(Breakout::CopyB) => {
+                copy_within_clone(values, cursor_b, dest, len_b);
+                values[dest + len_b] = self.buf[cursor_a].clone();
+                Ok(())
+            }
+            _ => unreachable!(),
+        }
+    }
+
+    fn merge_hi<E, F>(
+        &mut self,
+        values: &mut [T],
+        is_lt: &mut F,
+        start_a: usize,
+        mut len_a: usize,
+        start_b: usize,
+        mut len_b: usize,
+    ) -> Result<(), E>
+    where
+        F: FnMut(&T, &T) -> Result<bool, E>,
+    {
+        debug_assert!(len_a > 0);
+        debug_assert!(len_b > 0);
+        debug_assert!(start_a + len_a == start_b);
+
+        self.buf.clear();
+        self.buf
+            .extend_from_slice(&values[start_b..start_b + len_b]);
+
+        let mut dest = start_b + len_b - 1;
+        let mut cursor_a = start_a + len_a - 1;
+        let mut cursor_b = len_b - 1;
+
+        values[dest] = values[cursor_a].clone();
+        dest -= 1;
+        cursor_a -= 1;
+        len_a -= 1;
+
+        if len_a == 0 {
+            values[dest - len_b + 1..dest + 1].clone_from_slice(&self.buf[0..len_b]);
+            return Ok(());
+        }
+        if len_b == 1 {
+            let src = cursor_a + 1 - len_a;
+            let dst = dest + 1 - len_a;
+            copy_within_clone(values, src, dst, len_a);
+            values[dst - 1] = self.buf[cursor_b].clone();
+            return Ok(());
+        }
+
+        let mut min_gallop = self.min_gallop;
+        let mut breakout: Option<Breakout> = None;
+
+        loop {
+            let mut a_count = 0;
+            let mut b_count = 0;
+
+            loop {
+                if is_lt(&self.buf[cursor_b], &values[cursor_a])? {
+                    values[dest] = values[cursor_a].clone();
+                    dest -= 1;
+                    len_a -= 1;
+
+                    if len_a == 0 {
+                        breakout = Some(Breakout::Succeed);
+                        break;
+                    }
+
+                    cursor_a -= 1;
+                    a_count += 1;
+                    b_count = 0;
+
+                    if a_count >= min_gallop {
+                        break;
+                    }
+                } else {
+                    values[dest] = self.buf[cursor_b].clone();
+                    dest -= 1;
+                    cursor_b -= 1;
+                    len_b -= 1;
+                    b_count += 1;
+                    a_count = 0;
+                    if len_b == 1 {
+                        breakout = Some(Breakout::CopyA);
+                        break;
+                    }
+                    if b_count >= min_gallop {
+                        break;
+                    }
+                }
+            }
+
+            if breakout.is_some() {
+                break;
+            }
+
+            min_gallop += 1;
+            loop {
+                if min_gallop > 1 {
+                    min_gallop -= 1;
+                }
+                self.min_gallop = min_gallop;
+                let mut k = gallop_right(
+                    &values,
+                    is_lt,
+                    &self.buf[cursor_b],
+                    start_a,
+                    len_a,
+                    len_a - 1,
+                )?;
+                k = len_a - k;
+                a_count = k;
+                if k > 0 {
+                    copy_within_clone(values, cursor_a + 1 - k, dest + 1 - k, k);
+                    dest -= k;
+                    len_a -= k;
+                    if len_a == 0 {
+                        breakout = Some(Breakout::Succeed);
+                        break;
+                    }
+                    cursor_a -= k;
+                }
+                values[dest] = self.buf[cursor_b].clone();
+                dest -= 1;
+                cursor_b -= 1;
+                len_b -= 1;
+                if len_b == 1 {
+                    breakout = Some(Breakout::CopyA);
+                    break;
+                }
+                k = gallop_left(&self.buf, is_lt, &values[cursor_a], 0, len_b, len_b - 1)?;
+                k = len_b - k;
+                b_count = k;
+                if k > 0 {
+                    values[dest + 1 - k..dest + 1]
+                        .clone_from_slice(&self.buf[cursor_b + 1 - k..cursor_b + 1]);
+                    dest -= k;
+                    len_b -= k;
+
+                    if len_b == 0 {
+                        breakout = Some(Breakout::Succeed);
+                        break;
+                    }
+                    cursor_b -= k;
+
+                    if len_b == 1 {
+                        breakout = Some(Breakout::CopyA);
+                        break;
+                    }
+                }
+                values[dest] = values[cursor_a].clone();
+                dest -= 1;
+                len_a -= 1;
+
+                if len_a == 0 {
+                    breakout = Some(Breakout::Succeed);
+                    break;
+                }
+
+                cursor_a -= 1;
+
+                if a_count < MIN_GALLOP && b_count < MIN_GALLOP {
+                    break;
+                }
+            }
+            if breakout.is_some() {
+                break;
+            }
+            min_gallop += 1;
+            self.min_gallop = min_gallop;
+        }
+
+        match breakout {
+            Some(Breakout::Succeed) => {
+                if len_b > 0 {
+                    values[dest - len_b + 1..dest + 1].clone_from_slice(&self.buf[0..len_b]);
+                }
+                Ok(())
+            }
+            Some(Breakout::CopyA) => {
+                let src = cursor_a + 1 - len_a;
+                let dst = dest + 1 - len_a;
+                copy_within_clone(values, src, dst, len_a);
+                values[dst - 1] = self.buf[cursor_b].clone();
+                Ok(())
+            }
+            _ => unreachable!(),
+        }
+    }
+
+    fn merge_at<E, F>(&mut self, values: &mut [T], is_lt: &mut F, i: usize) -> Result<(), E>
+    where
+        F: FnMut(&T, &T) -> Result<bool, E>,
+    {
+        debug_assert!(self.pending.len() >= 2);
+        debug_assert!(i == self.pending.len() - 2 || i == self.pending.len() - 3);
+
+        let mut start_a = self.pending[i].base;
+        let mut len_a = self.pending[i].len;
+        let start_b = self.pending[i + 1].base;
+        let mut len_b = self.pending[i + 1].len;
+
+        debug_assert!(len_a > 0);
+        debug_assert!(len_b > 0);
+        debug_assert!(start_a + len_a == start_b);
+
+        self.pending[i].len = len_a + len_b;
+        self.pending.remove(i + 1);
+
+        let k = gallop_right(values, is_lt, &values[start_b], start_a, len_a, 0)?;
+        start_a += k;
+        len_a -= k;
+
+        if len_a == 0 {
+            return Ok(());
+        }
+
+        len_b = gallop_left(
+            values,
+            is_lt,
+            &values[start_a + len_a - 1],
+            start_b,
+            len_b,
+            len_b - 1,
+        )?;
+
+        if len_b == 0 {
+            return Ok(());
+        }
+
+        if len_a <= len_b {
+            self.merge_lo(values, is_lt, start_a, len_a, start_b, len_b)?;
+        } else {
+            self.merge_hi(values, is_lt, start_a, len_a, start_b, len_b)?;
+        }
+        Ok(())
+    }
+
+    fn found_new_run<E, F>(&mut self, new_run_len: usize, values: &mut [T], is_lt: &mut F) -> Result<(), E>
+    where
+        F: FnMut(&T, &T) -> Result<bool, E>,
+    {
+        if !self.pending.is_empty() {
+            let last = self.pending.len() - 1;
+            let s1 = self.pending[last].base;
+            let n1 = self.pending[last].len;
+            let power = powerloop(s1, n1, new_run_len, values.len());
+
+            while self.pending.len() > 1 && self.pending[self.pending.len() - 2].power > power {
+                self.merge_at(values, is_lt, self.pending.len() - 2)?;
+            }
+
+            debug_assert!(
+                self.pending.len() < 2 || self.pending[self.pending.len() - 2].power < power
+            );
+            let last = self.pending.len() - 1;
+            self.pending[last].power = power;
+        }
+        Ok(())
+    }
+
+    fn push_run(&mut self, base: usize, len: usize) {
+        self.pending.push(Run {
+            base,
+            len,
+            power: 0,
+        })
+    }
+
+    fn merge_force_collapse<E, F>(&mut self, values: &mut [T], is_lt: &mut F) -> Result<(), E>
+    where
+        F: FnMut(&T, &T) -> Result<bool, E>,
+    {
+        while self.pending.len() > 1 {
+            let mut n = self.pending.len() - 2;
+            if n > 0 && self.pending[n - 1].len < self.pending[n + 1].len {
+                n -= 1;
+            }
+            self.merge_at(values, is_lt, n)?;
+        }
+        Ok(())
+    }
+}
+
+fn binary_insertion_sort<T, E, F>(values: &mut [T], is_lt: &mut F, start: usize) -> Result<(), E>
+where
+    F: FnMut(&T, &T) -> Result<bool, E>,
+{
+    for i in start..values.len() {
+        let mut l = 0;
+        let mut r = i;
+
+        while l < r {
+            let m = (l + r) / 2;
+            if is_lt(&values[i], &values[m])? {
+                r = m;
+            } else {
+                l = m + 1;
+            }
+        }
+        values[l..=i].rotate_right(1);
+    }
+    Ok(())
+}
+
+fn copy_within_clone<T: Clone>(values: &mut [T], src: usize, dest: usize, n: usize) {
+    if dest <= src {
+        for k in 0..n {
+            values[dest + k] = values[src + k].clone();
+        }
+    } else {
+        for k in (0..n).rev() {
+            values[dest + k] = values[src + k].clone();
+        }
+    }
+}
+
+fn count_run<T, E, F>(values: &[T], is_lt: &mut F) -> Result<(usize, bool), E>
+where
+    F: FnMut(&T, &T) -> Result<bool, E>,
+{
+    let n = values.len();
+    if n == 1 {
+        return Ok((1, false));
+    }
+    let mut i = 2;
+    let descending = is_lt(&values[1], &values[0])?;
+    if descending {
+        while i < n && is_lt(&values[i], &values[i - 1])? {
+            i += 1;
+        }
+    } else {
+        while i < n && !is_lt(&values[i], &values[i - 1])? {
+            i += 1;
+        }
+    }
+    Ok((i, descending))
+}
+
+fn gallop_left<T, E, F>(
+    values: &[T],
+    is_lt: &mut F,
+    key: &T,
+    base: usize,
+    len: usize,
+    hint: usize,
+) -> Result<usize, E>
+where
+    F: FnMut(&T, &T) -> Result<bool, E>,
+{
+    debug_assert!(hint < len);
+    let mut lastofs: isize = 0;
+    let mut ofs: isize = 1;
+    let hint_i = hint as isize;
+    let len_i = len as isize;
+
+    if is_lt(&values[base + hint], key)? {
+        let maxofs = len_i - hint_i;
+        while ofs < maxofs && is_lt(&values[base + hint + ofs as usize], key)? {
+            lastofs = ofs;
+            ofs = (ofs * 2) + 1;
+        }
+        if ofs > maxofs {
+            ofs = maxofs;
+        }
+        lastofs += hint_i;
+        ofs += hint_i;
+    } else {
+        let maxofs = hint_i + 1;
+        while ofs < maxofs && !is_lt(&values[base + (hint_i - ofs) as usize], key)? {
+            lastofs = ofs;
+            ofs = (ofs * 2) + 1;
+        }
+        if ofs > maxofs {
+            ofs = maxofs;
+        }
+        (lastofs, ofs) = (hint_i - ofs, hint_i - lastofs);
+    }
+    lastofs += 1;
+    while lastofs < ofs {
+        let m = lastofs + ((ofs - lastofs) / 2);
+        if is_lt(&values[base + m as usize], key)? {
+            lastofs = m + 1;
+        } else {
+            ofs = m;
+        }
+    }
+    Ok(ofs as usize)
+}
+
+fn gallop_right<T, E, F>(
+    values: &[T],
+    is_lt: &mut F,
+    key: &T,
+    base: usize,
+    len: usize,
+    hint: usize,
+) -> Result<usize, E>
+where
+    F: FnMut(&T, &T) -> Result<bool, E>,
+{
+    debug_assert!(hint < len);
+    let mut lastofs: isize = 0;
+    let mut ofs: isize = 1;
+    let hint_i = hint as isize;
+    let len_i = len as isize;
+
+    if is_lt(key, &values[base + hint])? {
+        let maxofs = hint_i + 1;
+        while ofs < maxofs && is_lt(key, &values[base + (hint_i - ofs) as usize])? {
+            lastofs = ofs;
+            ofs = (ofs * 2) + 1;
+        }
+        if ofs > maxofs {
+            ofs = maxofs;
+        }
+        (lastofs, ofs) = (hint_i - ofs, hint_i - lastofs);
+    } else {
+        let maxofs = len_i - hint_i;
+        while ofs < maxofs && !is_lt(key, &values[base + hint + ofs as usize])? {
+            lastofs = ofs;
+            ofs = (ofs * 2) + 1;
+        }
+        if ofs > maxofs {
+            ofs = maxofs;
+        }
+        lastofs += hint_i;
+        ofs += hint_i;
+    }
+    lastofs += 1;
+    while lastofs < ofs {
+        let m = lastofs + ((ofs - lastofs) / 2);
+        if is_lt(key, &values[base + m as usize])? {
+            ofs = m;
+        } else {
+            lastofs = m + 1;
+        }
+    }
+    Ok(ofs as usize)
+}
+
+// TODO: consider CPython 3.12+'s incremental minrun (mr_current/mr_e/mr_mask)
+//       for a more precise minrun; current bit-shift version is the classic one.
+fn merge_compute_minrun(mut n: usize) -> usize {
+    let mut r = 0;
+    while n >= MAX_MINRUN {
+        r |= n & 1;
+        n >>= 1;
+    }
+    n + r
+}
+
+fn powerloop(s1: usize, n1: usize, n2: usize, n: usize) -> u32 {
+    let mut result: u32 = 0;
+    let mut a = 2 * s1 + n1;
+    let mut b = a + n1 + n2;
+
+    loop {
+        result += 1;
+        if a >= n {
+            debug_assert!(b >= a);
+            a -= n;
+            b -= n;
+        } else if b >= n {
+            break;
+        }
+        debug_assert!(a < b && b < n);
+        a <<= 1;
+        b <<= 1;
+    }
+    result
+}
+
+/// Stable adaptive mergesort (Tim Peters' timsort with powersort's
+/// merge-ordering policy, matching CPython 3.11+). `is_lt` provides comparison.
+pub(crate) fn timsort<T, E, F>(values: &mut [T], is_lt: &mut F) -> Result<(), E>
+where
+    T: Clone,
+    F: FnMut(&T, &T) -> Result<bool, E>,
+{
+    let n = values.len();
+    let mut ms = MergeState {
+        buf: Vec::new(),
+        min_gallop: MIN_GALLOP,
+        pending: Vec::new(),
+    };
+
+    if n < 2 {
+        return Ok(());
+    }
+
+    if n < MAX_MINRUN {
+        let (l, desc) = count_run(&values, is_lt)?;
+        if desc {
+            values[0..l].reverse();
+        }
+        binary_insertion_sort(values, is_lt, l)?;
+        return Ok(());
+    }
+
+    let minrun = merge_compute_minrun(n);
+    let mut lo = 0;
+
+    while lo < n {
+        let (mut l, desc) = count_run(&values[lo..n], is_lt)?;
+        if desc {
+            values[lo..lo + l].reverse();
+        }
+        if l < minrun {
+            let force = minrun.min(n - lo);
+            binary_insertion_sort(&mut values[lo..lo + force], is_lt, l)?;
+            l = force;
+        }
+        ms.found_new_run(l, values, is_lt)?;
+        ms.push_run(lo, l);
+        lo += l;
+    }
+    ms.merge_force_collapse(values, is_lt)?;
+    debug_assert!(ms.pending.len() == 1 && ms.pending[0].len == n);
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn sort(mut v: Vec<i32>) -> Vec<i32> {
+        timsort(&mut v, &mut |a: &i32, b: &i32| Ok::<bool, ()>(a < b)).unwrap();
+        v
+    }
+
+    #[test]
+    fn test_basic() {
+        assert_eq!(sort(vec![3, 1, 2]), vec![1, 2, 3]);
+        assert_eq!(sort(Vec::<i32>::new()), Vec::<i32>::new());
+        assert_eq!(sort(vec![1]), vec![1]);
+        assert_eq!(sort(vec![2, 1]), vec![1, 2]);
+    }
+
+    #[test]
+    fn test_ordered() {
+        assert_eq!(sort(vec![1, 2, 3, 4, 5]), vec![1, 2, 3, 4, 5]);
+        assert_eq!(sort(vec![5, 4, 3, 2, 1]), vec![1, 2, 3, 4, 5]);
+    }
+
+    #[test]
+    fn test_duplicates() {
+        assert_eq!(sort(vec![3, 1, 3, 1, 2, 2]), vec![1, 1, 2, 2, 3, 3]);
+    }
+
+    #[test]
+    fn test_large() {
+        let mut v: Vec<i32> = (0..1000).rev().collect(); // 999..0
+        let sorted: Vec<i32> = (0..1000).collect();
+        assert_eq!(sort(v), sorted);
+    }
+
+    #[test]
+    fn test_random_ish() {
+        let mut v: Vec<i32> = (0..500).map(|i| (i * 7919) % 500).collect();
+        let mut expected = v.clone();
+        expected.sort();
+        assert_eq!(sort(v), expected);
+    }
+}

--- a/crates/vm/src/sorting.rs
+++ b/crates/vm/src/sorting.rs
@@ -150,6 +150,10 @@ impl<T: Clone> MergeState<T> {
                         break 'merging Ok(LoBreakout::Succeed);
                     }
                 }
+                values[dest] = self.buf[cursor_a].clone();
+                dest += 1;
+                cursor_a += 1;
+                len_a -= 1;
                 if len_a == 1 {
                     break 'merging Ok(LoBreakout::CopyB);
                 }

--- a/extra_tests/snippets/builtin_list.py
+++ b/extra_tests/snippets/builtin_list.py
@@ -257,6 +257,11 @@ assert_raises(TypeError, sorted, [1, "a"])
 nan = float("nan")
 assert repr(sorted([nan, 1.0, 2.0])) == "[nan, 1.0, 2.0]"
 assert sorted([b"b", b"a", b"c"]) == [b"a", b"b", b"c"]
+assert sorted([(2, 9), (1, 5), (2, 1)]) == [(1, 5), (2, 1), (2, 9)]
+assert sorted([(1, "b"), (1, "a")]) == [(1, "a"), (1, "b")]
+assert sorted([(1,), (1, 2), ()]) == [(), (1,), (1, 2)]
+assert sorted([((2,), "x"), ((1,), "y")]) == [((1,), "y"), ((2,), "x")]
+assert sorted([(1, "a"), (2.5, "b"), (0, "c")]) == [(0, "c"), (1, "a"), (2.5, "b")]
 
 lst = [3, 1, 5, 2, 4]
 

--- a/extra_tests/snippets/builtin_list.py
+++ b/extra_tests/snippets/builtin_list.py
@@ -242,6 +242,21 @@ assert sorted([(1, 2, 3), (0, 3, 6)], key=lambda x: x[0]) == [(0, 3, 6), (1, 2, 
 assert sorted([(1, 2, 3), (0, 3, 6)], key=lambda x: x[1]) == [(1, 2, 3), (0, 3, 6)]
 assert sorted([(1, 2), (), (5,)], key=len) == [(), (5,), (1, 2)]
 
+assert sorted(["b", "a", "é", "z\U0001F600", "z"]) == ["a", "b", "z", "z\U0001F600", "é"]
+assert sorted([10**30, -(10**30), 5, 0]) == [-(10**30), 0, 5, 10**30]
+assert sorted([True, False, True]) == [False, True, True]
+
+
+class IntSub(int):
+    pass
+
+
+assert sorted([IntSub(2), 3, IntSub(1)]) == [1, 2, 3]
+assert sorted([2.5, 1, 3.0, 2]) == [1, 2, 2.5, 3.0]
+assert_raises(TypeError, sorted, [1, "a"])
+nan = float("nan")
+assert repr(sorted([nan, 1.0, 2.0])) == "[nan, 1.0, 2.0]"
+
 lst = [3, 1, 5, 2, 4]
 
 

--- a/extra_tests/snippets/builtin_list.py
+++ b/extra_tests/snippets/builtin_list.py
@@ -256,6 +256,7 @@ assert sorted([2.5, 1, 3.0, 2]) == [1, 2, 2.5, 3.0]
 assert_raises(TypeError, sorted, [1, "a"])
 nan = float("nan")
 assert repr(sorted([nan, 1.0, 2.0])) == "[nan, 1.0, 2.0]"
+assert sorted([b"b", b"a", b"c"]) == [b"a", b"b", b"c"]
 
 lst = [3, 1, 5, 2, 4]
 


### PR DESCRIPTION
- [x] Closes #8450 (follow-up to #8421, relates to #6093)
- [x] This PR follows our [AI policy](https://github.com/RustPython/.github/blob/main/AI_POLICY.md) (assisted by Claude Code Fable-5)

## Summary

Implements CPython's pre-sort check for `list.sort()`, as promised in the follow-ups of #8421.

Before sorting, the keys are scanned once (O(n)); when they are homogeneous in exact type, the O(n log n) comparisons skip `rich_compare_bool`'s dispatch (recursion guard, subclass/reflected-op resolution, slot lookup, NotImplemented retry) and use a comparator specialized for that type. This mirrors the `unsafe_latin_compare` / `unsafe_long_compare` / `unsafe_float_compare` / `unsafe_object_compare` / `unsafe_tuple_compare` family in CPython's `Objects/listobject.c`.

### What changed

- `crates/vm/src/builtins/list.rs`: `pre_sort_check` scans the keys (the key function results when `key=` is given, matching CPython's `lo.keys` scan) and picks a tier: `Str`, `Int`, `Float`, `Object` (cached richcompare slot), `Tuple` (with a nested tier for first elements), or `Generic`. `sorting.rs` is untouched — specialization only decides which `is_lt` closure the existing powersort receives.
- Each tier dispatches through its own `timsort` call, so the comparator monomorphizes into the merge loop — no per-comparison indirect call, unlike CPython's function-pointer approach.
- The `Object` tier guards each comparison with a pointer check against the cached slot and falls back to `rich_compare_bool` on mismatch or `NotImplemented`, so a stale cache can only cost speed, never correctness.
- The `Tuple` tier follows CPython exactly: elements are walked with `==` (identity shortcut included), only index 0 may use the specialized comparator (the scan verified nothing about later elements), later differences fall back to generic `<`, and nested tuples are not recursed into. The element-tier enum has no tuple variant, so that rule is enforced by the type system.
- Tests in `extra_tests/snippets/builtin_list.py`: non-ASCII code point order, huge ints, `bool`/subclass rejection, mixed-type `TypeError`, NaN ordering, bytes, and five tuple cases (empty, nested, mixed first elements, ties at and past index 0).

### Differences from CPython, and why they hold

- **No latin-1 restriction for str.** CPython stores strings as UCS-1/2/4, so memcmp only matches code point order for 1-byte strings. RustPython stores WTF-8, and generalized UTF-8 byte order equals code point order across the whole range (lone surrogates included), so every homogeneous str list qualifies.
- **No machine-word restriction for int.** CPython needs single-digit longs to shortcut its digit-array walk; comparing `BigInt`s through `Ord` is already dispatch-free, so all-int lists qualify regardless of magnitude.
- `bool` is excluded by the exact-type check (as in CPython), and subclasses never qualify since they may override `__lt__`.

### Results

Release build, best of 5, seed 42, vs CPython 3.14. "generic" is the same build with the scan defeated by one subclass element, i.e. the previous behavior on otherwise identical data.

1M elements:

| workload | generic | specialized | CPython 3.14 |
|---|---|---|---|
| 1M random ints | 0.72s | 0.53s (×1.35) | 0.30s |
| 1M random floats | 0.69s | 0.45s (×1.54) | 0.18s |
| 1M random strs | 1.07s | 0.83s (×1.29) | 0.35s |
| 1M sorted ints | — | 0.044s | 0.035s |

300k elements, and the speedup CPython itself gets from the same trick on the same data as a cross-check that the port is faithful:

| workload | speedup here | speedup in CPython |
|---|---|---|
| random bytes (object tier) | ×1.05 | ×1.06 |
| random (int, int) tuples | ×1.23 | ×1.17 |

(For str/int/float the CPython-side ratios are ×1.33/×1.07/×1.53 — same pattern.) The gap vs CPython on random ints narrows from 2.4× to 1.7×.

### Follow-ups

The remaining gap is dominated by two things outside this PR's scope: merges are clone-based (`T: Clone` in `sorting.rs`), so every element move pays an atomic refcount operation where CPython memmoves bare pointers — I plan to address this with move-based merges as a follow-up; and `PyStr` keeps its bytes in a separate allocation (CPython inlines them since PEP 393), which is an object-representation question to be filed separately.

### Notes

Despite mirroring CPython's `unsafe_*` comparator family, the port is entirely safe Rust: the invariants those comparators trust are still re-checked by cheap typed downcasts, so a violated invariant degrades to a panic or a fallback, never to undefined behavior.

The `Object` tier compares function pointers, which rustc flags (`unpredictable_function_pointer_comparisons`). Both failure modes are harmless here: a duplicated function makes the guard fail into the fallback path (slower, still correct), and merged functions have identical bodies.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved list sorting with stable ordering and optimized handling for strings, numbers, tuples, and custom comparisons.
  * Added broader support for sorting mixed and Unicode values, large integers, booleans, bytes, NaN, and incomparable types.

* **Bug Fixes**
  * Improved sorting behavior for descending runs, duplicate values, and lexicographic tuple ordering.
  * Preserved appropriate fallback behavior when custom comparisons cannot determine an order.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->