### PR TITLE
Specialize list.sort() comparisons for homogeneous lists

### DIFF
--- a/crates/vm/src/builtins/list.rs
+++ b/crates/vm/src/builtins/list.rs
@@ -800,6 +800,22 @@ fn tuple_lt(elem: &Elem, a: &PyObjectRef, b: &PyObjectRef, vm: &VirtualMachine) 
     }
 }
 
+fn timsort_by<T, K, L>(items: &mut [T], reverse: bool, key: &K, mut lt: L) -> PyResult<()>
+where
+    T: Clone,
+    K: Fn(&T) -> &PyObjectRef,
+    L: FnMut(&PyObjectRef, &PyObjectRef) -> PyResult<bool>,
+{
+    timsort(items, &mut |a, b| {
+        let (a, b) = if reverse {
+            (key(b), key(a))
+        } else {
+            (key(a), key(b))
+        };
+        lt(a, b)
+    })
+}
+
 fn timsort_specialized<T, K>(
     vm: &VirtualMachine,
     items: &mut [T],
@@ -811,52 +827,12 @@ where
     K: Fn(&T) -> &PyObjectRef,
 {
     match pre_sort_check(items.iter().map(&key), vm) {
-        PreSort::Str => timsort(items, &mut |a, b| {
-            let (a, b) = if reverse {
-                (key(b), key(a))
-            } else {
-                (key(a), key(b))
-            };
-            Ok(str_lt(a, b))
-        }),
-        PreSort::Int => timsort(items, &mut |a, b| {
-            let (a, b) = if reverse {
-                (key(b), key(a))
-            } else {
-                (key(a), key(b))
-            };
-            Ok(int_lt(a, b))
-        }),
-        PreSort::Float => timsort(items, &mut |a, b| {
-            let (a, b) = if reverse {
-                (key(b), key(a))
-            } else {
-                (key(a), key(b))
-            };
-            Ok(float_lt(a, b))
-        }),
-        PreSort::Object(cmp) => timsort(items, &mut |a, b| {
-            let (a, b) = if reverse {
-                (key(b), key(a))
-            } else {
-                (key(a), key(b))
-            };
-            object_lt(cmp, a, b, vm)
-        }),
-        PreSort::Tuple(elem) => timsort(items, &mut |a, b| {
-            let (a, b) = if reverse {
-                (key(b), key(a))
-            } else {
-                (key(a), key(b))
-            };
-            tuple_lt(&elem, a, b, vm)
-        }),
-        PreSort::Generic => timsort(items, &mut |a, b| {
-            let (a, b) = if reverse {
-                (key(b), key(a))
-            } else {
-                (key(a), key(b))
-            };
+        PreSort::Str => timsort_by(items, reverse, &key, |a, b| Ok(str_lt(a, b))),
+        PreSort::Int => timsort_by(items, reverse, &key, |a, b| Ok(int_lt(a, b))),
+        PreSort::Float => timsort_by(items, reverse, &key, |a, b| Ok(float_lt(a, b))),
+        PreSort::Object(cmp) => timsort_by(items, reverse, &key, |a, b| object_lt(cmp, a, b, vm)),
+        PreSort::Tuple(elem) => timsort_by(items, reverse, &key, |a, b| tuple_lt(&elem, a, b, vm)),
+        PreSort::Generic => timsort_by(items, reverse, &key, |a, b| {
             a.rich_compare_bool(b, PyComparisonOp::Lt, vm)
         }),
     }

--- a/crates/vm/src/builtins/list.rs
+++ b/crates/vm/src/builtins/list.rs
@@ -9,7 +9,7 @@ use crate::common::lock::{
 use crate::object::{Traverse, TraverseFn};
 use crate::{
     AsObject, Context, Py, PyObject, PyObjectRef, PyPayload, PyRef, PyResult,
-    builtins::PyStr,
+    builtins::{PyFloat, PyInt, PyStr},
     class::PyClassImpl,
     convert::ToPyObject,
     function::{ArgSize, FuncArgs, OptionalArg, PyComparisonValue},
@@ -638,34 +638,113 @@ impl Representable for PyList {
     }
 }
 
+enum PreSort {
+    Str,
+    Int,
+    Float,
+    Generic,
+}
+
+fn pre_sort_check<'a>(
+    mut keys: impl Iterator<Item = &'a PyObjectRef>,
+    vm: &VirtualMachine,
+) -> PreSort {
+    let Some(first) = keys.next() else {
+        return PreSort::Generic;
+    };
+    let class = first.class();
+    if !keys.all(|o| o.class().is(class)) {
+        return PreSort::Generic;
+    }
+    if class.is(vm.ctx.types.str_type) {
+        PreSort::Str
+    } else if class.is(vm.ctx.types.int_type) {
+        PreSort::Int
+    } else if class.is(vm.ctx.types.float_type) {
+        PreSort::Float
+    } else {
+        PreSort::Generic
+    }
+}
+
+fn str_lt(a: &PyObjectRef, b: &PyObjectRef) -> bool {
+    a.downcast_ref::<PyStr>().unwrap().as_bytes() < b.downcast_ref::<PyStr>().unwrap().as_bytes()
+}
+
+fn int_lt(a: &PyObjectRef, b: &PyObjectRef) -> bool {
+    a.downcast_ref::<PyInt>().unwrap().as_bigint() < b.downcast_ref::<PyInt>().unwrap().as_bigint()
+}
+
+fn float_lt(a: &PyObjectRef, b: &PyObjectRef) -> bool {
+    a.downcast_ref::<PyFloat>().unwrap().to_f64() < b.downcast_ref::<PyFloat>().unwrap().to_f64()
+}
+
+fn timsort_specialized<T, K>(
+    vm: &VirtualMachine,
+    items: &mut [T],
+    reverse: bool,
+    key: K,
+) -> PyResult<()>
+where
+    T: Clone,
+    K: Fn(&T) -> &PyObjectRef,
+{
+    match pre_sort_check(items.iter().map(&key), vm) {
+        PreSort::Str => timsort(items, &mut |a, b| {
+            let (a, b) = if reverse {
+                (key(b), key(a))
+            } else {
+                (key(a), key(b))
+            };
+            Ok(str_lt(a, b))
+        }),
+        PreSort::Int => timsort(items, &mut |a, b| {
+            let (a, b) = if reverse {
+                (key(b), key(a))
+            } else {
+                (key(a), key(b))
+            };
+            Ok(int_lt(a, b))
+        }),
+        PreSort::Float => timsort(items, &mut |a, b| {
+            let (a, b) = if reverse {
+                (key(b), key(a))
+            } else {
+                (key(a), key(b))
+            };
+            Ok(float_lt(a, b))
+        }),
+        PreSort::Generic => timsort(items, &mut |a, b| {
+            let (a, b) = if reverse {
+                (key(b), key(a))
+            } else {
+                (key(a), key(b))
+            };
+            a.rich_compare_bool(b, PyComparisonOp::Lt, vm)
+        }),
+    }
+}
+
 fn do_sort(
     vm: &VirtualMachine,
     values: &mut Vec<PyObjectRef>,
     key_func: Option<PyObjectRef>,
     reverse: bool,
 ) -> PyResult<()> {
-    // CPython uses __lt__ for all comparisons in sort.
-    // `timsort` expects is_lt(a, b) = true when a must be placed BEFORE b.
-    // For reverse=True, swapping the operands yields a descending order that is
-    // still stable in the original relative order, matching CPython's
-    // reverse-sort-reverse approach.
-    let mut is_lt = |a: &PyObjectRef, b: &PyObjectRef| {
-        if reverse {
-            b.rich_compare_bool(a, PyComparisonOp::Lt, vm)
-        } else {
-            a.rich_compare_bool(b, PyComparisonOp::Lt, vm)
-        }
-    };
-
     if let Some(ref key_func) = key_func {
         let mut items = values
             .iter()
             .map(|x| Ok((x.clone(), key_func.call((x.clone(),), vm)?)))
             .collect::<Result<Vec<_>, _>>()?;
-        timsort(&mut items, &mut |a, b| is_lt(&a.1, &b.1))?;
+        timsort_specialized(
+            vm,
+            &mut items,
+            reverse,
+            |item: &(PyObjectRef, PyObjectRef)| &item.1,
+        )?;
         *values = items.into_iter().map(|(val, _)| val).collect();
     } else {
-        timsort(values, &mut is_lt)?;
+        timsort_specialized(vm, values, reverse, |x: &PyObjectRef| x)?
     }
 
     Ok(())

--- a/crates/vm/src/builtins/list.rs
+++ b/crates/vm/src/builtins/list.rs
@@ -9,7 +9,7 @@ use crate::common::lock::{
 use crate::object::{Traverse, TraverseFn};
 use crate::{
     AsObject, Context, Py, PyObject, PyObjectRef, PyPayload, PyRef, PyResult,
-    builtins::{PyFloat, PyInt, PyStr},
+    builtins::{PyFloat, PyInt, PyStr, PyTuple},
     class::PyClassImpl,
     convert::ToPyObject,
     function::{ArgSize, Either, FuncArgs, OptionalArg, PyComparisonValue},
@@ -638,12 +638,47 @@ impl Representable for PyList {
     }
 }
 
-enum PreSort {
+enum Elem {
     Str,
     Int,
     Float,
     Object(RichCompareFunc),
     Generic,
+}
+
+enum PreSort {
+    Str,
+    Int,
+    Float,
+    Object(RichCompareFunc),
+    Tuple(Elem),
+    Generic,
+}
+
+impl From<Elem> for PreSort {
+    fn from(e: Elem) -> Self {
+        match e {
+            Elem::Str => Self::Str,
+            Elem::Int => Self::Int,
+            Elem::Float => Self::Float,
+            Elem::Object(f) => Self::Object(f),
+            Elem::Generic => Self::Generic,
+        }
+    }
+}
+
+fn classify(class: &Py<PyType>, vm: &VirtualMachine) -> Elem {
+    if class.is(vm.ctx.types.str_type) {
+        Elem::Str
+    } else if class.is(vm.ctx.types.int_type) {
+        Elem::Int
+    } else if class.is(vm.ctx.types.float_type) {
+        Elem::Float
+    } else if let Some(f) = class.slots.richcompare.load() {
+        Elem::Object(f)
+    } else {
+        Elem::Generic
+    }
 }
 
 fn pre_sort_check<'a>(
@@ -653,21 +688,48 @@ fn pre_sort_check<'a>(
     let Some(first) = keys.next() else {
         return PreSort::Generic;
     };
-    let class = first.class();
-    if !keys.all(|o| o.class().is(class)) {
-        return PreSort::Generic;
-    }
-    if class.is(vm.ctx.types.str_type) {
-        PreSort::Str
-    } else if class.is(vm.ctx.types.int_type) {
-        PreSort::Int
-    } else if class.is(vm.ctx.types.float_type) {
-        PreSort::Float
-    } else if let Some(f) = class.slots.richcompare.load() {
-        PreSort::Object(f)
+
+    if let Some(t) = first
+        .downcast_ref_if_exact::<PyTuple>(vm)
+        .filter(|t| !t.as_slice().is_empty())
+    {
+        pre_sort_check_tuples(&t.as_slice()[0], keys, vm)
     } else {
-        PreSort::Generic
+        let class = first.class();
+        if keys.all(|k| k.class().is(class)) {
+            classify(class, vm).into()
+        } else {
+            PreSort::Generic
+        }
     }
+}
+
+fn pre_sort_check_tuples<'a>(
+    first_elem: &PyObjectRef,
+    keys: impl Iterator<Item = &'a PyObjectRef>,
+    vm: &VirtualMachine,
+) -> PreSort {
+    let class = first_elem.class();
+    let mut all_same_type = true;
+
+    for k in keys {
+        let Some(t) = k
+            .downcast_ref_if_exact::<PyTuple>(vm)
+            .filter(|t| !t.as_slice().is_empty())
+        else {
+            return PreSort::Generic;
+        };
+        if all_same_type && !t.as_slice()[0].class().is(class) {
+            all_same_type = false;
+        }
+    }
+
+    let elem = if !all_same_type || class.is(vm.ctx.types.tuple_type) {
+        Elem::Generic
+    } else {
+        classify(class, vm)
+    };
+    PreSort::Tuple(elem)
 }
 
 fn str_lt(a: &PyObjectRef, b: &PyObjectRef) -> bool {
@@ -704,6 +766,37 @@ fn object_lt(
                 obj.try_to_bool(vm)
             }
         }
+    }
+}
+
+fn elem_lt(elem: &Elem, a: &PyObjectRef, b: &PyObjectRef, vm: &VirtualMachine) -> PyResult<bool> {
+    match elem {
+        Elem::Str => Ok(str_lt(a, b)),
+        Elem::Int => Ok(int_lt(a, b)),
+        Elem::Float => Ok(float_lt(a, b)),
+        Elem::Object(f) => object_lt(*f, a, b, vm),
+        Elem::Generic => a.rich_compare_bool(b, PyComparisonOp::Lt, vm),
+    }
+}
+
+fn tuple_lt(elem: &Elem, a: &PyObjectRef, b: &PyObjectRef, vm: &VirtualMachine) -> PyResult<bool> {
+    let a = a.downcast_ref::<PyTuple>().unwrap().as_slice();
+    let b = b.downcast_ref::<PyTuple>().unwrap().as_slice();
+
+    let mut i = 0;
+    while i < a.len() && i < b.len() {
+        if !a[i].rich_compare_bool(&b[i], PyComparisonOp::Eq, vm)? {
+            break;
+        }
+        i += 1;
+    }
+    if i >= a.len() || i >= b.len() {
+        return Ok(a.len() < b.len());
+    }
+    if i == 0 {
+        elem_lt(elem, &a[0], &b[0], vm)
+    } else {
+        a[i].rich_compare_bool(&b[i], PyComparisonOp::Lt, vm)
     }
 }
 
@@ -749,6 +842,14 @@ where
                 (key(a), key(b))
             };
             object_lt(cmp, a, b, vm)
+        }),
+        PreSort::Tuple(elem) => timsort(items, &mut |a, b| {
+            let (a, b) = if reverse {
+                (key(b), key(a))
+            } else {
+                (key(a), key(b))
+            };
+            tuple_lt(&elem, a, b, vm)
         }),
         PreSort::Generic => timsort(items, &mut |a, b| {
             let (a, b) = if reverse {

--- a/crates/vm/src/builtins/list.rs
+++ b/crates/vm/src/builtins/list.rs
@@ -12,7 +12,7 @@ use crate::{
     builtins::{PyFloat, PyInt, PyStr},
     class::PyClassImpl,
     convert::ToPyObject,
-    function::{ArgSize, FuncArgs, OptionalArg, PyComparisonValue},
+    function::{ArgSize, Either, FuncArgs, OptionalArg, PyComparisonValue},
     iter::PyExactSizeIterator,
     protocol::{PyIterReturn, PyMappingMethods, PySequenceMethods},
     recursion::ReprGuard,
@@ -21,7 +21,7 @@ use crate::{
     sorting::timsort,
     types::{
         AsMapping, AsSequence, Comparable, Constructor, Initializer, IterNext, Iterable,
-        PyComparisonOp, Representable, SelfIter,
+        PyComparisonOp, Representable, RichCompareFunc, SelfIter,
     },
     vm::VirtualMachine,
 };
@@ -642,6 +642,7 @@ enum PreSort {
     Str,
     Int,
     Float,
+    Object(RichCompareFunc),
     Generic,
 }
 
@@ -662,6 +663,8 @@ fn pre_sort_check<'a>(
         PreSort::Int
     } else if class.is(vm.ctx.types.float_type) {
         PreSort::Float
+    } else if let Some(f) = class.slots.richcompare.load() {
+        PreSort::Object(f)
     } else {
         PreSort::Generic
     }
@@ -677,6 +680,31 @@ fn int_lt(a: &PyObjectRef, b: &PyObjectRef) -> bool {
 
 fn float_lt(a: &PyObjectRef, b: &PyObjectRef) -> bool {
     a.downcast_ref::<PyFloat>().unwrap().to_f64() < b.downcast_ref::<PyFloat>().unwrap().to_f64()
+}
+
+fn object_lt(
+    cmp: RichCompareFunc,
+    a: &PyObjectRef,
+    b: &PyObjectRef,
+    vm: &VirtualMachine,
+) -> PyResult<bool> {
+    #[allow(unpredictable_function_pointer_comparisons)]
+    if a.class().slots.richcompare.load() != Some(cmp) {
+        return a.rich_compare_bool(b, PyComparisonOp::Lt, vm);
+    }
+    match cmp(a, b, PyComparisonOp::Lt, vm)? {
+        Either::B(PyComparisonValue::Implemented(v)) => Ok(v),
+        Either::B(PyComparisonValue::NotImplemented) => {
+            a.rich_compare_bool(b, PyComparisonOp::Lt, vm)
+        }
+        Either::A(obj) => {
+            if obj.is(&vm.ctx.not_implemented) {
+                a.rich_compare_bool(b, PyComparisonOp::Lt, vm)
+            } else {
+                obj.try_to_bool(vm)
+            }
+        }
+    }
 }
 
 fn timsort_specialized<T, K>(
@@ -713,6 +741,14 @@ where
                 (key(a), key(b))
             };
             Ok(float_lt(a, b))
+        }),
+        PreSort::Object(cmp) => timsort(items, &mut |a, b| {
+            let (a, b) = if reverse {
+                (key(b), key(a))
+            } else {
+                (key(a), key(b))
+            };
+            object_lt(cmp, a, b, vm)
         }),
         PreSort::Generic => timsort(items, &mut |a, b| {
             let (a, b) = if reverse {

--- a/extra_tests/snippets/builtin_list.py
+++ b/extra_tests/snippets/builtin_list.py
@@ -242,7 +242,13 @@ assert sorted([(1, 2, 3), (0, 3, 6)], key=lambda x: x[0]) == [(0, 3, 6), (1, 2, 
 assert sorted([(1, 2, 3), (0, 3, 6)], key=lambda x: x[1]) == [(1, 2, 3), (0, 3, 6)]
 assert sorted([(1, 2), (), (5,)], key=len) == [(), (5,), (1, 2)]
 
-assert sorted(["b", "a", "é", "z\U0001F600", "z"]) == ["a", "b", "z", "z\U0001F600", "é"]
+assert sorted(["b", "a", "é", "z\U0001f600", "z"]) == [
+    "a",
+    "b",
+    "z",
+    "z\U0001f600",
+    "é",
+]
 assert sorted([10**30, -(10**30), 5, 0]) == [-(10**30), 0, 5, 10**30]
 assert sorted([True, False, True]) == [False, True, True]
 

--- a/extra_tests/snippets/builtin_list.py
+++ b/extra_tests/snippets/builtin_list.py
@@ -257,6 +257,11 @@ assert_raises(TypeError, sorted, [1, "a"])
 nan = float("nan")
 assert repr(sorted([nan, 1.0, 2.0])) == "[nan, 1.0, 2.0]"
 assert sorted([b"b", b"a", b"c"]) == [b"a", b"b", b"c"]
+assert sorted([(2, 9), (1, 5), (2, 1)]) == [(1, 5), (2, 1), (2, 9)]
+assert sorted([(1, "b"), (1, "a")]) == [(1, "a"), (1, "b")]
+assert sorted([(1,), (1, 2), ()]) == [(), (1,), (1, 2)]
+assert sorted([((2,), "x"), ((1,), "y")]) == [((1,), "y"), ((2,), "x")]
+assert sorted([(1, "a"), (2.5, "b"), (0, "c")]) == [(0, "c"), (1, "a"), (2.5, "b")]
 
 lst = [3, 1, 5, 2, 4]
 

--- a/extra_tests/snippets/builtin_list.py
+++ b/extra_tests/snippets/builtin_list.py
@@ -242,6 +242,21 @@ assert sorted([(1, 2, 3), (0, 3, 6)], key=lambda x: x[0]) == [(0, 3, 6), (1, 2, 
 assert sorted([(1, 2, 3), (0, 3, 6)], key=lambda x: x[1]) == [(1, 2, 3), (0, 3, 6)]
 assert sorted([(1, 2), (), (5,)], key=len) == [(), (5,), (1, 2)]
 
+assert sorted(["b", "a", "é", "z\U0001F600", "z"]) == ["a", "b", "z", "z\U0001F600", "é"]
+assert sorted([10**30, -(10**30), 5, 0]) == [-(10**30), 0, 5, 10**30]
+assert sorted([True, False, True]) == [False, True, True]
+
+
+class IntSub(int):
+    pass
+
+
+assert sorted([IntSub(2), 3, IntSub(1)]) == [1, 2, 3]
+assert sorted([2.5, 1, 3.0, 2]) == [1, 2, 2.5, 3.0]
+assert_raises(TypeError, sorted, [1, "a"])
+nan = float("nan")
+assert repr(sorted([nan, 1.0, 2.0])) == "[nan, 1.0, 2.0]"
+
 lst = [3, 1, 5, 2, 4]
 
 

--- a/extra_tests/snippets/builtin_list.py
+++ b/extra_tests/snippets/builtin_list.py
@@ -256,6 +256,7 @@ assert sorted([2.5, 1, 3.0, 2]) == [1, 2, 2.5, 3.0]
 assert_raises(TypeError, sorted, [1, "a"])
 nan = float("nan")
 assert repr(sorted([nan, 1.0, 2.0])) == "[nan, 1.0, 2.0]"
+assert sorted([b"b", b"a", b"c"]) == [b"a", b"b", b"c"]
 
 lst = [3, 1, 5, 2, 4]
 


### PR DESCRIPTION
- [x] Closes #8450 (follow-up to #8421, relates to #6093)
- [x] This PR follows our [AI policy](https://github.com/RustPython/.github/blob/main/AI_POLICY.md) (assisted by Claude Code Fable-5)

## Summary

Implements CPython's pre-sort check for `list.sort()`, as promised in the follow-ups of #8421.

Before sorting, the keys are scanned once (O(n)); when they are homogeneous in exact type, the O(n log n) comparisons skip `rich_compare_bool`'s dispatch (recursion guard, subclass/reflected-op resolution, slot lookup, NotImplemented retry) and use a comparator specialized for that type. This mirrors the `unsafe_latin_compare` / `unsafe_long_compare` / `unsafe_float_compare` / `unsafe_object_compare` / `unsafe_tuple_compare` family in CPython's `Objects/listobject.c`.

### What changed

- `crates/vm/src/builtins/list.rs`: `pre_sort_check` scans the keys (the key function results when `key=` is given, matching CPython's `lo.keys` scan) and picks a tier: `Str`, `Int`, `Float`, `Object` (cached richcompare slot), `Tuple` (with a nested tier for first elements), or `Generic`. `sorting.rs` is untouched — specialization only decides which `is_lt` closure the existing powersort receives.
- Each tier dispatches through its own `timsort` call, so the comparator monomorphizes into the merge loop — no per-comparison indirect call, unlike CPython's function-pointer approach.
- The `Object` tier guards each comparison with a pointer check against the cached slot and falls back to `rich_compare_bool` on mismatch or `NotImplemented`, so a stale cache can only cost speed, never correctness.
- The `Tuple` tier follows CPython exactly: elements are walked with `==` (identity shortcut included), only index 0 may use the specialized comparator (the scan verified nothing about later elements), later differences fall back to generic `<`, and nested tuples are not recursed into. The element-tier enum has no tuple variant, so that rule is enforced by the type system.
- Tests in `extra_tests/snippets/builtin_list.py`: non-ASCII code point order, huge ints, `bool`/subclass rejection, mixed-type `TypeError`, NaN ordering, bytes, and five tuple cases (empty, nested, mixed first elements, ties at and past index 0).

### Differences from CPython, and why they hold

- **No latin-1 restriction for str.** CPython stores strings as UCS-1/2/4, so memcmp only matches code point order for 1-byte strings. RustPython stores WTF-8, and generalized UTF-8 byte order equals code point order across the whole range (lone surrogates included), so every homogeneous str list qualifies.
- **No machine-word restriction for int.** CPython needs single-digit longs to shortcut its digit-array walk; comparing `BigInt`s through `Ord` is already dispatch-free, so all-int lists qualify regardless of magnitude.
- `bool` is excluded by the exact-type check (as in CPython), and subclasses never qualify since they may override `__lt__`.

### Results

Release build, best of 5, seed 42, vs CPython 3.14. "generic" is the same build with the scan defeated by one subclass element, i.e. the previous behavior on otherwise identical data.

1M elements:

| workload | generic | specialized | CPython 3.14 |
|---|---|---|---|
| 1M random ints | 0.72s | 0.53s (×1.35) | 0.30s |
| 1M random floats | 0.69s | 0.45s (×1.54) | 0.18s |
| 1M random strs | 1.07s | 0.83s (×1.29) | 0.35s |
| 1M sorted ints | — | 0.044s | 0.035s |

300k elements, and the speedup CPython itself gets from the same trick on the same data as a cross-check that the port is faithful:

| workload | speedup here | speedup in CPython |
|---|---|---|
| random bytes (object tier) | ×1.05 | ×1.06 |
| random (int, int) tuples | ×1.23 | ×1.17 |

(For str/int/float the CPython-side ratios are ×1.33/×1.07/×1.53 — same pattern.) The gap vs CPython on random ints narrows from 2.4× to 1.7×.

### Follow-ups

The remaining gap is dominated by two things outside this PR's scope: merges are clone-based (`T: Clone` in `sorting.rs`), so every element move pays an atomic refcount operation where CPython memmoves bare pointers — I plan to address this with move-based merges as a follow-up; and `PyStr` keeps its bytes in a separate allocation (CPython inlines them since PEP 393), which is an object-representation question to be filed separately.

### Notes

Despite mirroring CPython's `unsafe_*` comparator family, the port is entirely safe Rust: the invariants those comparators trust are still re-checked by cheap typed downcasts, so a violated invariant degrades to a panic or a fallback, never to undefined behavior.

The `Object` tier compares function pointers, which rustc flags (`unpredictable_function_pointer_comparisons`). Both failure modes are harmless here: a duplicated function makes the guard fail into the fallback path (slower, still correct), and merged functions have identical bodies.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Improved `list.sort()` and `sorted()` handling for strings, numbers, tuples, custom objects, and other key types.
  - Sorting preserves reverse-order behavior while using optimized comparisons where possible.
  - Enhanced fallback behavior for custom comparisons and unsupported comparison results.

- **Bug Fixes**
  - Improved consistency for mixed numeric values, integer subclasses, booleans, NaN values, bytes, and invalid mixed-type comparisons.
  - Expanded support for Unicode strings and lexicographic tuple sorting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->