### PR TITLE
Implement TclObject support in tkinter varname_converter

### DIFF
--- a/crates/stdlib/src/tkinter.rs
+++ b/crates/stdlib/src/tkinter.rs
@@ -160,10 +160,13 @@ mod _tkinter {
             return Ok(varname);
         }
 
-        if let Some(_tcl_obj) = obj.downcast_ref::<TclObject>() {
-            // Assume that the Tcl object has a method to retrieve a string.
-            // return tcl_obj.
-            todo!();
+        if let Some(tcl_obj) = obj.downcast_ref::<TclObject>() {
+            let c_str = unsafe { tk_sys::Tcl_GetString(tcl_obj.value) };
+            let varname = unsafe { ffi::CStr::from_ptr(c_str as _) }
+                .to_str()
+                .map_err(|e| vm.new_unicode_decode_error(e.to_string()))?
+                .to_owned();
+            return Ok(varname);
         }
 
         // Construct an error message using the type name (truncated to 50 characters).


### PR DESCRIPTION
- [ ] Closes #xxxx <!-- Replace xxxx with the GitHub issue number -->
- [V] This PR follows our [AI policy](https://github.com/RustPython/.github/blob/main/AI_POLICY.md)

## Summary
I have addressed one of the current "Todo" items by modifying the `PyTclObject` checker in `tkinter`.

I implemented the logic found in [CPython](https://github.com/python/cpython/blob/8ed1479619a3487af72a7c44bf61c9711370d4da/Modules/_tkinter.c#L1927) within RustPython.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of Tcl values converted to text.
  * Invalid text data now produces a clear Unicode decoding error instead of causing an incomplete-operation failure.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->