### PR TITLE
Fix locals()/vars() cell-variable sync for module/class scope

### DIFF
--- a/crates/vm/src/frame.rs
+++ b/crates/vm/src/frame.rs
@@ -1794,9 +1794,10 @@ impl FrameObject {
                 }
             }
 
-            // Free variables only included for optimized (function-like) scopes.
-            // Class/module scopes should not expose free vars in locals().
-            if kind == CO_FAST_FREE && !is_optimized {
+            // CPython only syncs fastlocals/cells into locals() for function
+            // scope; class/module scope just returns the namespace dict as-is
+            // (_PyFrame_GetLocals, Objects/frameobject.c).
+            if !is_optimized && kind & (CO_FAST_CELL | CO_FAST_FREE) != 0 {
                 continue;
             }
 

--- a/extra_tests/snippets/syntax_annotations_locals.py
+++ b/extra_tests/snippets/syntax_annotations_locals.py
@@ -1,0 +1,50 @@
+"""Module/class-scope locals() must not corrupt or leak __conditional_annotations__.
+
+CPython's _PyFrame_GetLocals never syncs cell variables into a module/class
+scope's namespace dict, it just returns the dict directly (verified against
+CPython 3.14.6). __conditional_annotations__ is a cell in both scopes, but
+only module codegen also writes it into the dict (StoreName); class codegen
+only ever uses the cell (StoreDeref). So it's visible via locals()/dir() at
+module scope and absent at class scope.
+
+RustPython's fast-locals-to-mapping sync used to read every cellvar's value
+straight from the cell regardless of scope. At module scope the cell is
+always empty, so this overwrote the dict's real value with None -- deleting
+it, and the next annotated statement raised NameError. At class scope it
+leaked __conditional_annotations__ into locals()/dir(), which CPython never
+does.
+"""
+
+count: int = 1
+_ = locals()
+maybe: int = None  # used to raise NameError before the fix
+assert maybe is None
+
+assert "__conditional_annotations__" in dir(), (
+    "module-level annotation should expose __conditional_annotations__, matching CPython"
+)
+
+exec("a: int = 1\nlocals()\nb: int = 2")
+
+if True:
+    x: int = 1
+vars()
+if True:
+    y: int = 2
+assert (x, y) == (1, 2)
+
+
+class C:
+    if True:
+        cx: int = 1
+    locals()
+    if True:
+        cy: int = 2
+    assert "__conditional_annotations__" not in dir(), (
+        "class-level locals() should not leak __conditional_annotations__, matching CPython"
+    )
+
+
+assert (C.cx, C.cy) == (1, 2)
+
+print("ok")


### PR DESCRIPTION
- [x] Closes #8379
- [x] This PR follows our [AI policy](https://github.com/RustPython/.github/blob/main/AI_POLICY.md)

## Summary

- CPython's  [`_PyFrame_GetLocals`](https://github.com/python/cpython/blob/b35c37910a4595f22458cf0291a9b0252b3c6c70/Objects/frameobject.c#L2272-L2299)  only syncs fastlocals/cells into `locals()` for function scope; for module/class scope it just returns the namespace dict as-is, since ordinary names there are already stored via `StoreName`, not fastlocals.
- `sync_visible_locals_to_mapping` did the fastlocals/cell sync for every scope, so the implicit `__conditional_annotations__` cell (added for PEP 649/749 deferred annotations) broke two ways: 

&nbsp;&nbsp;1. At module scope its cell is always empty (real writes go through `StoreName`), so syncing overwrote the dict's real value with `None`, deleting it and causing `NameError` on the next annotated statement. 

&nbsp;&nbsp;2. At class scope the cell is the only place the value lives (`StoreDeref`-only, never in the dict), so syncing instead leaked `__conditional_annotations__` into `locals()`/`dir()`, which CPython never does.

## Fix

Skip `CO_FAST_CELL`/`CO_FAST_FREE` slots for non-optimized (module/class) scope in `sync_visible_locals_to_mapping`, matching CPython's behavior.

## Details

- Verified against CPython 3.14.6 (both a running interpreter and the C source at the `v3.14.6` tag): module codegen writes `__conditional_annotations__` with `StoreName` into the dict; class codegen writes it with `StoreDeref` into the cell only. [`_PyFrame_GetLocals`](https://github.com/python/cpython/blob/b35c37910a4595f22458cf0291a9b0252b3c6c70/Objects/frameobject.c#L2272-L2299) never reads cells for either scope — it returns the namespace dict directly for non-optimized scope.
- The skip only targets `CO_FAST_CELL`/`CO_FAST_FREE`, not `CO_FAST_HIDDEN` — a hidden slot (PEP 709 inlined comprehensions) can also be a cell, and the existing hidden-variable check just above already decides per-slot whether a live hidden value should still appear in `locals()`. Gating on scope alone would have overridden that.

## Testing

- Added `extra_tests/snippets/syntax_annotations_locals.py`, covering both the module-scope corruption and the class-scope leak. Confirmed it fails with the pre-fix `NameError` on unfixed code and passes after the fix.
- `cargo test -p rustpython-codegen` (783 tests), `cargo test -p rustpython-vm --lib` (55 tests): all pass.
- CPython test suite: `test_annotationlib` (117/117), `test_builtin` (138/138), `test_class` (37/37) all pass.
- `cargo clippy` / `cargo fmt --check`: clean.

## AI assistance

Investigated, implemented, and tested with Claude Code assistance, including direct comparison against a local CPython 3.14.6 source checkout and binary; all findings and the fix were manually verified before submission.

Assisted-by: Claude Code:claude-sonnet-5


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected `locals()` behavior in module and class scopes to match Python semantics.
  * Preserved annotated local values when using conditional annotations and `exec`.
  * Prevented internal annotation details from appearing in class `locals()` or `dir()` results.

* **Tests**
  * Added regression coverage for module and class annotation behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->