### PR TITLE
Allow automated commits and fix C-API test instructions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -17,6 +17,11 @@ See the "Code organization" section in [CONTRIBUTING.md](CONTRIBUTING.md#code-or
 
 ## AI Agent Rules
 
+**CRITICAL: AI Policy**
+
+- Follow RustPython's [AI Policy](https://github.com/RustPython/.github/blob/main/AI_POLICY.md) for every AI-assisted contribution.
+- Disclose AI assistance in commit messages with an `Assisted-by: AGENT_NAME:MODEL_VERSION` trailer. Use one trailer per AI tool, and never use `Co-authored-by` for an AI assistant.
+
 **CRITICAL: Git Operations**
 - NEVER create pull requests directly without explicit user permission
 - NEVER push commits to remote without explicit user permission
@@ -27,7 +32,7 @@ See the "Code organization" section in [CONTRIBUTING.md](CONTRIBUTING.md#code-or
 - Install the repository's pre-commit hook with `prek install` (or `pre-commit install`) after cloning the repository.
 - Every commit must run the configured pre-commit hook. NEVER bypass it with `--no-verify`. Automated workflows that use a normal `git commit`, such as `scripts/update_lib quick`, should be allowed to create local commits through the hook.
 - If a hook auto-fixes files (e.g. `ruff-format`, `rustfmt`), re-stage the fixes and retry the commit. Do not amend or force a failing commit through.
-- Before completing a task, run the tests appropriate for the change. Test commands are documented in the [Testing](#testing) section below. At minimum run `cargo test --workspace --exclude rustpython_wasm --exclude rustpython-venvlauncher`; if the change touches `extra_tests/snippets/` run `pytest -v` there too, and if it touches `Lib/` or interpreter behavior, run the relevant `cargo run --release -- -m test <module>` modules.
+- Before completing a task, run the tests appropriate for the change. Test commands are documented in the [Testing](#testing) section below. At minimum run `cargo test --workspace --exclude rustpython_wasm --exclude rustpython-venvlauncher --exclude rustpython-capi`, then run `cargo test` from `crates/capi`; if the change touches `extra_tests/snippets/` run `pytest -v` there too, and if it touches `Lib/` or interpreter behavior, run the relevant `cargo run --release -- -m test <module>` modules.
 
 ## Important Development Notes
 
@@ -113,7 +118,10 @@ rm -r target/debug/build/rustpython-* && find . | grep -E "\.pyc$" | xargs rm -r
 
 ```bash
 # Run Rust unit tests
-cargo test --workspace --exclude rustpython_wasm --exclude rustpython-venvlauncher
+cargo test --workspace --exclude rustpython_wasm --exclude rustpython-venvlauncher --exclude rustpython-capi
+
+# Run C-API tests from their directory so their separate Cargo config applies
+(cd crates/capi && cargo test)
 
 # Run Python snippets tests (debug mode recommended for faster compilation)
 cargo run -- extra_tests/snippets/builtin_bytes.py

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -23,11 +23,11 @@ See the "Code organization" section in [CONTRIBUTING.md](CONTRIBUTING.md#code-or
 - Always ask the user before performing any git operations that affect the remote repository
 - Commits can be created locally when requested, but pushing and PR creation require explicit approval
 
-**CRITICAL: Pre-commit Checks**
-- Before creating ANY commit, you MUST run `prek run --all-files` (or `pre-commit run --all-files`) AND the full test suite. Both must pass — do not commit if either fails.
-- Test commands are documented in the [Testing](#testing) section below. At minimum run `cargo test --workspace --exclude rustpython_wasm --exclude rustpython-venvlauncher`; if the change touches `extra_tests/snippets/` run `pytest -v` there too, and if it touches `Lib/` or interpreter behavior, run the relevant `cargo run --release -- -m test <module>` modules.
-- If a hook auto-fixes files (e.g. `ruff-format`, `rustfmt`), re-stage the fixes, re-run `prek` until it reports a clean pass, then re-run the tests, then commit.
-- NEVER bypass these checks with `--no-verify`, `--no-gpg-sign`, or by skipping tests "because the change is small". If a hook or test fails, fix the underlying issue and create a new commit — do not amend or force the failing commit through.
+**CRITICAL: Commit Hooks and Validation**
+- Install the repository's pre-commit hook with `prek install` (or `pre-commit install`) after cloning the repository.
+- Every commit must run the configured pre-commit hook. NEVER bypass it with `--no-verify`. Automated workflows that use a normal `git commit`, such as `scripts/update_lib quick`, should be allowed to create local commits through the hook.
+- If a hook auto-fixes files (e.g. `ruff-format`, `rustfmt`), re-stage the fixes and retry the commit. Do not amend or force a failing commit through.
+- Before completing a task, run the tests appropriate for the change. Test commands are documented in the [Testing](#testing) section below. At minimum run `cargo test --workspace --exclude rustpython_wasm --exclude rustpython-venvlauncher`; if the change touches `extra_tests/snippets/` run `pytest -v` there too, and if it touches `Lib/` or interpreter behavior, run the relevant `cargo run --release -- -m test <module>` modules.
 
 ## Important Development Notes
 


### PR DESCRIPTION
## Summary

I've cleaned up the commit instructions in `AGENTS.md` so that automated tasks using standard `git commit`—like `scripts/update_lib quick`—can generate local commits without bypassing pre-commit hooks.

`CONTRIBUTING.md` already specifies that `rustpython-capi` should be excluded from workspace tests and tested within the `crates/capi` directory to ensure separate Cargo settings are applied. However, the test commands in `AGENTS.md` were missing the `rustpython-capi` exclusion, causing an inconsistency between the two documents.

Running C-API tests from the repository root prevents crate-specific PyO3 settings from being applied, leading to a mix of CPython ABI and RustPython object layouts, which can cause SIGSEGV in C-API tests. Therefore, I've updated `AGENTS.md` to align with `CONTRIBUTING.md` and run C-API tests separately.

Finally, I've specified relevant links and formats to ensure that AI-assisted contributions and commits follow RustPython's AI Policy, including the use of the `Assisted-by` trailer in commit messages.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Documentation

* Updated contributor guidance for AI policy compliance and disclosure.
* Clarified commit-hook installation, execution, automatic fixes, restaging, and retry behavior.
* Expanded validation guidance to cover workspace, C-API, and change-specific tests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->