### PR TITLE
Fix panic in code.replace() with non-interned strings

### DIFF
--- a/Lib/test/test_modulefinder.py
+++ b/Lib/test/test_modulefinder.py
@@ -390,8 +390,6 @@ class ModuleFinderTest(unittest.TestCase):
         os.remove(source_path)
         self._do_test(bytecode_test)
 
-    # TODO: RUSTPYTHON; panics at code.rs with 'called Option::unwrap() on a None value'
-    @unittest.skip("TODO: RUSTPYTHON; panics in co_filename replacement")
     def test_replace_paths(self):
         old_path = os.path.join(self.test_dir, 'a', 'module.py')
         new_path = os.path.join(self.test_dir, 'a', 'spam.py')

--- a/crates/vm/src/builtins/code.rs
+++ b/crates/vm/src/builtins/code.rs
@@ -1366,19 +1366,25 @@ impl PyCode {
             OptionalArg::Missing => self.code.instructions.clone(),
         };
 
+        let intern_all = |objs: Vec<PyObjectRef>, field: &str| -> PyResult<Box<[_]>> {
+            objs.into_iter()
+                .map(|o| {
+                    let s = o.downcast_ref::<super::pystr::PyStr>().ok_or_else(|| {
+                        vm.new_type_error(format!("{field} must be a tuple of strings"))
+                    })?;
+                    Ok(vm.ctx.intern_str(s.as_wtf8()))
+                })
+                .collect::<PyResult<Vec<_>>>()
+                .map(Vec::into_boxed_slice)
+        };
+
         let cellvars = match co_cellvars {
-            OptionalArg::Present(cellvars) => cellvars
-                .into_iter()
-                .map(|o| o.as_interned_str(vm).unwrap())
-                .collect(),
+            OptionalArg::Present(cellvars) => intern_all(cellvars, "co_cellvars")?,
             OptionalArg::Missing => self.code.cellvars.clone(),
         };
 
         let freevars = match co_freevars {
-            OptionalArg::Present(freevars) => freevars
-                .into_iter()
-                .map(|o| o.as_interned_str(vm).unwrap())
-                .collect(),
+            OptionalArg::Present(freevars) => intern_all(freevars, "co_freevars")?,
             OptionalArg::Missing => self.code.freevars.clone(),
         };
 
@@ -1411,10 +1417,10 @@ impl PyCode {
             posonlyarg_count,
             arg_count,
             kwonlyarg_count,
-            source_path: source_path.as_object().as_interned_str(vm).unwrap(),
+            source_path: vm.ctx.intern_str(source_path.as_wtf8()),
             first_line_number,
-            obj_name: obj_name.as_object().as_interned_str(vm).unwrap(),
-            qualname: qualname.as_object().as_interned_str(vm).unwrap(),
+            obj_name: vm.ctx.intern_str(obj_name.as_wtf8()),
+            qualname: vm.ctx.intern_str(qualname.as_wtf8()),
 
             max_stackdepth,
             instructions,
@@ -1422,14 +1428,8 @@ impl PyCode {
             // It can be removed once we move every other code to use linetable only.
             locations: self.code.locations.clone(),
             constants: constants.into_iter().map(Literal).collect(),
-            names: names
-                .into_iter()
-                .map(|o| o.as_interned_str(vm).unwrap())
-                .collect(),
-            varnames: varnames
-                .into_iter()
-                .map(|o| o.as_interned_str(vm).unwrap())
-                .collect(),
+            names: intern_all(names, "co_names")?,
+            varnames: intern_all(varnames, "co_varnames")?,
             cellvars,
             freevars,
             localspluskinds: self.code.localspluskinds.clone(),


### PR DESCRIPTION
`code.replace()` called `as_interned_str().unwrap()` on its string arguments, which panics when the caller passes a string that has not been interned.

`modulefinder.ModuleFinder(replace_paths=...)` hits this: `replace_paths_in_code()` builds a fresh `co_filename` and passes it to `co.replace()`, aborting the interpreter. This was the last remaining skip in `test_modulefinder`, part of #3846.

This interns the incoming strings instead, and raises `TypeError` instead of panicking when a non-string appears in `co_names`/`co_varnames`/`co_cellvars`/`co_freevars`.

```python
def f(): pass
f.__code__.replace(co_filename='/new/path.py')  # panicked before, works now
```

`test_modulefinder.test_replace_paths` is unskipped. `test_modulefinder`, `test_code`, `test_dis`, `test_funcattrs`, `test_sys_settrace` all pass.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved validation when replacing code-object metadata.
  * Invalid non-string entries now produce a clear `TypeError` instead of causing failures during conversion.
  * String metadata is handled consistently for more reliable runtime behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->