### PR TITLE
wasi: fix os.environb byte handling

### DIFF
--- a/crates/host_env/src/os.rs
+++ b/crates/host_env/src/os.rs
@@ -519,13 +519,14 @@ pub fn set_errno(value: i32) {
 #[cfg(not(any(unix, windows, target_os = "wasi")))]
 pub fn set_errno(_value: i32) {}
 
-#[cfg(unix)]
+// WASIp1, like Unix, provides byte-preserving OsStr conversions.
+#[cfg(any(unix, all(target_os = "wasi", not(target_env = "p2"))))]
 pub fn bytes_as_os_str(b: &[u8]) -> Result<&std::ffi::OsStr, Utf8Error> {
-    use std::os::unix::ffi::OsStrExt;
+    use self::ffi::OsStrExt;
     Ok(std::ffi::OsStr::from_bytes(b))
 }
 
-#[cfg(not(unix))]
+#[cfg(not(any(unix, all(target_os = "wasi", not(target_env = "p2")))))]
 pub fn bytes_as_os_str(b: &[u8]) -> Result<&std::ffi::OsStr, Utf8Error> {
     Ok(core::str::from_utf8(b)?.as_ref())
 }


### PR DESCRIPTION
Part of: #4583


<!--
Thanks for your contribution!
-->

- [ ] Closes #xxxx <!-- Replace xxxx with the GitHub issue number -->
- [x] This PR follows our [AI policy](https://github.com/RustPython/.github/blob/main/AI_POLICY.md)

## Summary
<!-- What's the purpose of the change? What does it do, and why? -->

RustPython WASIp1 did not preserve raw bytes in os.environb, causing python -m test to fail during setup.

This will enable -m test for wasi preview 1

Below is the example of running test_support on wasmer
```shell
╰─$ wasmer run \                                                                                                                                                                          
  --volume "$(pwd):$(pwd)" \
  --volume "/tmp:/tmp" \
  target/wasm32-wasip1/wasm-release/rustpython.wasm \
  -- -m test test_support
Using random seed: 1848393816
0:00:00 Run 1 test sequentially in a single process
0:00:00 [1/1] test_support
test test_support crashed -- Traceback (most recent call last):
  File "test.libregrtest.single", line 210, in _runtest_env_changed_exc
  File "test.libregrtest.single", line 155, in _load_run_test
  File "importlib", line 88, in import_module
  File "_frozen_importlib", line 1406, in _gcd_import
  File "_frozen_importlib", line 1371, in _find_and_load
  File "_frozen_importlib", line 1342, in _find_and_load_unlocked
  File "_frozen_importlib", line 938, in _load_unlocked
  File "_frozen_importlib", line 1179, in exec_module
  File "test.test_support", line 9, in <module>
  File "socket", line 52, in <module>
ModuleNotFoundError: No module named '_socket'

0:00:00 [1/1/1] test_support failed (uncaught exception)

== Tests result: FAILURE ==

1 test failed:
    test_support

Total duration: 75 ms
Total tests: run=0
Total test files: run=1/1 failed=1
Result: FAILURE
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of operating-system strings on WASI Preview 1.
  * Preserved UTF-8 conversion behavior for WASI Preview 2 and other supported targets.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->