### PR TITLE
Fix map no iterables

### DIFF
--- a/Lib/test/test_itertools.py
+++ b/Lib/test/test_itertools.py
@@ -1136,7 +1136,6 @@ class TestBasicOps(unittest.TestCase):
         self.assertEqual(repr(repeat('a', times=-1)), "repeat('a', 0)")
         self.assertEqual(repr(repeat('a', times=-2)), "repeat('a', 0)")
 
-    @unittest.expectedFailure  # TODO: RUSTPYTHON
     def test_map(self):
         self.assertEqual(list(map(operator.pow, range(3), range(1,7))),
                          [0**1, 1**2, 2**3])

--- a/crates/vm/src/builtins/map.rs
+++ b/crates/vm/src/builtins/map.rs
@@ -37,9 +37,12 @@ impl Constructor for PyMap {
     fn py_new(
         _cls: &Py<PyType>,
         (mapper, iterators, args): Self::Args,
-        _vm: &VirtualMachine,
+        vm: &VirtualMachine,
     ) -> PyResult<Self> {
         let iterators = iterators.into_vec();
+        if iterators.is_empty() {
+            return Err(vm.new_type_error("map() must have at least two arguments."));
+        }
         let strict = Radium::new(args.strict.unwrap_or(false));
         Ok(Self {
             mapper,

--- a/extra_tests/snippets/builtin_map.py
+++ b/extra_tests/snippets/builtin_map.py
@@ -24,13 +24,6 @@ it = map(lambda x: x + 1, Counter())
 assert next(it) == 2
 assert next(it) == 3
 
-# test for no iterables
-try:
-    map(lambda: 1)
-    assert False, "TypeError expected at map construction"
-except TypeError as e:
-    assert str(e) == "map() must have at least two arguments."
-
 
 def mapping(x):
     if x == 0:

--- a/extra_tests/snippets/builtin_map.py
+++ b/extra_tests/snippets/builtin_map.py
@@ -24,6 +24,13 @@ it = map(lambda x: x + 1, Counter())
 assert next(it) == 2
 assert next(it) == 3
 
+# test for no iterables
+try:
+    map(lambda: 1)
+    assert False, "TypeError expected at map construction"
+except TypeError as e:
+    assert str(e) == "map() must have at least two arguments."
+
 
 def mapping(x):
     if x == 0:


### PR DESCRIPTION
<!--
Thanks for your contribution!
-->

- [x] Closes #8462
- [x] This PR follows our [AI policy](https://github.com/RustPython/.github/blob/main/AI_POLICY.md)

## Summary
<!-- What's the purpose of the change? What does it do, and why? -->

This PR is to bring RustPython to CPython parity in the handling of maps constructed without iterables. CPython raises a TypeError if a map is constructed without an iterable. RustPython had no such check, so while constructing something like `map(lambda: 1)` would succeed, iterating it would loop infinitely. Added a no-iterable check and an accompanying test.

## AI Usage

Code, commit messages, and this description are hand-written. Fable 5 was used for review.

## Acknowledgements

Thank you @jseop-lim for raising the issue.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Calling `map` without iterables now correctly raises a `TypeError`.
  - The error message clearly indicates that `map()` requires at least two arguments.

- **Tests**
  - Added coverage to verify the error type and message for invalid `map` construction.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->