### PR TITLE
Reuse stored hashes when building a set from a set/frozenset/dict

### DIFF
--- a/crates/vm/src/builtins/set.rs
+++ b/crates/vm/src/builtins/set.rs
@@ -195,6 +195,29 @@ impl PySetInner {
         Ok(set)
     }
 
+    /// Build a set from an arbitrary object, reusing the source's stored
+    /// hashes when it is a set/frozenset/dict.
+    pub(super) fn from_object(iterable: PyObjectRef, vm: &VirtualMachine) -> PyResult<Self> {
+        let set = Self::default();
+        set.update_internal(iterable, vm)?;
+        Ok(set)
+    }
+
+    /// Elements of `obj` paired with the hash already stored alongside them,
+    /// or `None` if `obj` keeps no such hashes and has to be iterated
+    /// generically (which calls `__hash__` on every element again).
+    ///
+    /// Mirrors the `PyAnySet_Check` / `PyDict_CheckExact` fast paths in
+    /// CPython's `set_update_internal`.
+    fn cached_hashes(obj: &PyObject, vm: &VirtualMachine) -> Option<Vec<(PyObjectRef, PyHash)>> {
+        if let Some(set) = extract_set(obj) {
+            Some(set.content.keys_with_hashes())
+        } else {
+            obj.downcast_ref_if_exact::<PyDict>(vm)
+                .map(|dict| dict._as_dict_inner().keys_with_hashes())
+        }
+    }
+
     fn fold_op<O>(
         &self,
         others: impl core::iter::Iterator<Item = O>,
@@ -228,6 +251,18 @@ impl PySetInner {
         Self::wrap_unhashable_error(result, needle, vm)
     }
 
+    /// [`Self::contains`] for a needle whose hash was read from another
+    /// set/dict. Such a needle is hashable by construction, so there is no
+    /// set-to-frozenset retry to do.
+    fn contains_with_hash(
+        &self,
+        needle: &PyObject,
+        hash: PyHash,
+        vm: &VirtualMachine,
+    ) -> PyResult<bool> {
+        self.content.contains_with_hash(vm, needle, hash)
+    }
+
     fn compare(&self, other: &Self, op: PyComparisonOp, vm: &VirtualMachine) -> PyResult<bool> {
         if op == PyComparisonOp::Ne {
             return self.compare(other, PyComparisonOp::Eq, vm).map(|eq| !eq);
@@ -251,6 +286,12 @@ impl PySetInner {
 
     pub(super) fn union(&self, other: ArgIterable, vm: &VirtualMachine) -> PyResult<Self> {
         let set = self.clone();
+        if let Some(elements) = Self::cached_hashes(other.as_object(), vm) {
+            for (item, hash) in elements {
+                set.add_with_hash(item, hash, vm)?;
+            }
+            return Ok(set);
+        }
         for item in other.iter(vm)? {
             set.add(item?, vm)?;
         }
@@ -260,6 +301,14 @@ impl PySetInner {
 
     pub(super) fn intersection(&self, other: ArgIterable, vm: &VirtualMachine) -> PyResult<Self> {
         let set = Self::default();
+        if let Some(elements) = Self::cached_hashes(other.as_object(), vm) {
+            for (obj, hash) in elements {
+                if self.contains_with_hash(&obj, hash, vm)? {
+                    set.add_with_hash(obj, hash, vm)?;
+                }
+            }
+            return Ok(set);
+        }
         for item in other.iter(vm)? {
             let obj = item?;
             if self.contains(&obj, vm)? {
@@ -271,6 +320,12 @@ impl PySetInner {
 
     pub(super) fn difference(&self, other: ArgIterable, vm: &VirtualMachine) -> PyResult<Self> {
         let set = self.copy();
+        if let Some(elements) = Self::cached_hashes(other.as_object(), vm) {
+            for (item, hash) in elements {
+                set.content.delete_if_exists_with_hash(vm, &*item, hash)?;
+            }
+            return Ok(set);
+        }
         for item in other.iter(vm)? {
             set.content.delete_if_exists(vm, &*item?)?;
         }
@@ -283,6 +338,16 @@ impl PySetInner {
         vm: &VirtualMachine,
     ) -> PyResult<Self> {
         let new_inner = self.clone();
+
+        if let Some(elements) = Self::cached_hashes(other.as_object(), vm) {
+            // the source is already duplicate-free
+            for (item, hash) in elements {
+                new_inner
+                    .content
+                    .delete_or_insert_with_hash(vm, &item, hash, ())?;
+            }
+            return Ok(new_inner);
+        }
 
         // We want to remove duplicates in other
         let other_set = Self::from_iter(other.iter(vm)?, vm)?;
@@ -330,6 +395,12 @@ impl PySetInner {
 
     fn add(&self, item: PyObjectRef, vm: &VirtualMachine) -> PyResult<()> {
         let result = self.content.insert(vm, &*item, ());
+        Self::wrap_unhashable_error(result, &item, vm)
+    }
+
+    /// [`Self::add`] for an item whose hash was read from another set/dict.
+    fn add_with_hash(&self, item: PyObjectRef, hash: PyHash, vm: &VirtualMachine) -> PyResult<()> {
+        let result = self.content.insert_with_hash(vm, &*item, hash, ());
         Self::wrap_unhashable_error(result, &item, vm)
     }
 
@@ -393,15 +464,15 @@ impl PySetInner {
     }
 
     fn merge_set(&self, any_set: AnySet, vm: &VirtualMachine) -> PyResult<()> {
-        for item in any_set.as_inner().elements() {
-            self.add(item, vm)?;
+        for (item, hash) in any_set.as_inner().content.keys_with_hashes() {
+            self.add_with_hash(item, hash, vm)?;
         }
         Ok(())
     }
 
     fn merge_dict(&self, dict: PyDictRef, vm: &VirtualMachine) -> PyResult<()> {
-        for (key, _value) in dict {
-            self.add(key, vm)?;
+        for (key, hash) in dict._as_dict_inner().keys_with_hashes() {
+            self.add_with_hash(key, hash, vm)?;
         }
         Ok(())
     }
@@ -413,8 +484,8 @@ impl PySetInner {
     ) -> PyResult<()> {
         let temp_inner = self.fold_op(others, Self::intersection, vm)?;
         self.clear();
-        for obj in temp_inner.elements() {
-            self.add(obj, vm)?;
+        for (obj, hash) in temp_inner.content.keys_with_hashes() {
+            self.add_with_hash(obj, hash, vm)?;
         }
         Ok(())
     }
@@ -425,6 +496,12 @@ impl PySetInner {
         vm: &VirtualMachine,
     ) -> PyResult<()> {
         for iterable in others {
+            if let Some(elements) = Self::cached_hashes(iterable.as_object(), vm) {
+                for (item, hash) in elements {
+                    self.content.delete_if_exists_with_hash(vm, &*item, hash)?;
+                }
+                continue;
+            }
             let items = iterable.iter(vm)?.collect::<Result<Vec<_>, _>>()?;
             for item in items {
                 self.content.delete_if_exists(vm, &*item)?;
@@ -439,6 +516,14 @@ impl PySetInner {
         vm: &VirtualMachine,
     ) -> PyResult<()> {
         for iterable in others {
+            if let Some(elements) = Self::cached_hashes(iterable.as_object(), vm) {
+                // the source is already duplicate-free
+                for (item, hash) in elements {
+                    self.content
+                        .delete_or_insert_with_hash(vm, &item, hash, ())?;
+                }
+                continue;
+            }
             // We want to remove duplicates in iterable
             let iterable_set = Self::from_iter(iterable.iter(vm)?, vm)?;
             for item in iterable_set.elements() {
@@ -955,7 +1040,7 @@ impl Representable for PySet {
 }
 
 impl Constructor for PyFrozenSet {
-    type Args = Vec<PyObjectRef>;
+    type Args = OptionalArg<PyObjectRef>;
 
     fn slot_new(cls: PyTypeRef, args: FuncArgs, vm: &VirtualMachine) -> PyResult {
         let is_exact_frozenset = cls.is(vm.ctx.types.frozenset_type);
@@ -988,11 +1073,11 @@ impl Constructor for PyFrozenSet {
                 return Ok(input.clone());
             }
 
-            iterable.into_option()
+            iterable
         } else {
             match &args.args[..] {
-                [] => None,
-                [iterable] => Some(iterable.clone()),
+                [] => OptionalArg::Missing,
+                [iterable] => OptionalArg::Present(iterable.clone()),
                 slice => {
                     return Err(vm.new_type_error(format!(
                         "frozenset expected at most 1 argument, got {}",
@@ -1002,23 +1087,27 @@ impl Constructor for PyFrozenSet {
             }
         };
 
-        let elements = if let Some(iterable) = iterable_opt {
-            iterable.try_to_value(vm)?
-        } else {
-            vec![]
-        };
+        let payload = Self::py_new(&cls, iterable_opt, vm)?;
 
         // Return empty frozenset singleton
-        if is_exact_frozenset && elements.is_empty() {
+        if is_exact_frozenset && payload.inner.len() == 0 {
             return Ok(vm.ctx.empty_frozenset.clone().into());
         }
 
-        let payload = Self::py_new(&cls, elements, vm)?;
         payload.into_ref_with_type(vm, cls).map(Into::into)
     }
 
-    fn py_new(_cls: &Py<PyType>, elements: Self::Args, vm: &VirtualMachine) -> PyResult<Self> {
-        Self::from_iter(vm, elements)
+    fn py_new(_cls: &Py<PyType>, iterable: Self::Args, vm: &VirtualMachine) -> PyResult<Self> {
+        // built from the object itself, so a set/frozenset/dict source can
+        // hand over its stored hashes instead of being re-hashed
+        let inner = match iterable {
+            OptionalArg::Present(iterable) => PySetInner::from_object(iterable, vm)?,
+            OptionalArg::Missing => PySetInner::default(),
+        };
+        Ok(Self {
+            inner,
+            ..Default::default()
+        })
     }
 }
 

--- a/crates/vm/src/builtins/set.rs
+++ b/crates/vm/src/builtins/set.rs
@@ -254,13 +254,13 @@ impl PySetInner {
     /// [`Self::contains`] for a needle whose hash was read from another
     /// set/dict. Such a needle is hashable by construction, so there is no
     /// set-to-frozenset retry to do.
-    fn contains_with_hash(
+    fn contains_known_hash(
         &self,
         needle: &PyObject,
         hash: PyHash,
         vm: &VirtualMachine,
     ) -> PyResult<bool> {
-        self.content.contains_with_hash(vm, needle, hash)
+        self.content.contains_known_hash(vm, needle, hash)
     }
 
     fn compare(&self, other: &Self, op: PyComparisonOp, vm: &VirtualMachine) -> PyResult<bool> {
@@ -288,7 +288,7 @@ impl PySetInner {
         let set = self.clone();
         if let Some(elements) = Self::cached_hashes(other.as_object(), vm) {
             for (item, hash) in elements {
-                set.add_with_hash(item, hash, vm)?;
+                set.add_known_hash(item, hash, vm)?;
             }
             return Ok(set);
         }
@@ -303,8 +303,8 @@ impl PySetInner {
         let set = Self::default();
         if let Some(elements) = Self::cached_hashes(other.as_object(), vm) {
             for (obj, hash) in elements {
-                if self.contains_with_hash(&obj, hash, vm)? {
-                    set.add_with_hash(obj, hash, vm)?;
+                if self.contains_known_hash(&obj, hash, vm)? {
+                    set.add_known_hash(obj, hash, vm)?;
                 }
             }
             return Ok(set);
@@ -322,7 +322,7 @@ impl PySetInner {
         let set = self.copy();
         if let Some(elements) = Self::cached_hashes(other.as_object(), vm) {
             for (item, hash) in elements {
-                set.content.delete_if_exists_with_hash(vm, &*item, hash)?;
+                set.content.delete_if_exists_known_hash(vm, &*item, hash)?;
             }
             return Ok(set);
         }
@@ -344,7 +344,7 @@ impl PySetInner {
             for (item, hash) in elements {
                 new_inner
                     .content
-                    .delete_or_insert_with_hash(vm, &item, hash, ())?;
+                    .delete_or_insert_known_hash(vm, &item, hash, ())?;
             }
             return Ok(new_inner);
         }
@@ -399,8 +399,8 @@ impl PySetInner {
     }
 
     /// [`Self::add`] for an item whose hash was read from another set/dict.
-    fn add_with_hash(&self, item: PyObjectRef, hash: PyHash, vm: &VirtualMachine) -> PyResult<()> {
-        let result = self.content.insert_with_hash(vm, &*item, hash, ());
+    fn add_known_hash(&self, item: PyObjectRef, hash: PyHash, vm: &VirtualMachine) -> PyResult<()> {
+        let result = self.content.insert_known_hash(vm, &*item, hash, ());
         Self::wrap_unhashable_error(result, &item, vm)
     }
 
@@ -465,14 +465,14 @@ impl PySetInner {
 
     fn merge_set(&self, any_set: AnySet, vm: &VirtualMachine) -> PyResult<()> {
         for (item, hash) in any_set.as_inner().content.keys_with_hashes() {
-            self.add_with_hash(item, hash, vm)?;
+            self.add_known_hash(item, hash, vm)?;
         }
         Ok(())
     }
 
     fn merge_dict(&self, dict: PyDictRef, vm: &VirtualMachine) -> PyResult<()> {
         for (key, hash) in dict._as_dict_inner().keys_with_hashes() {
-            self.add_with_hash(key, hash, vm)?;
+            self.add_known_hash(key, hash, vm)?;
         }
         Ok(())
     }
@@ -485,7 +485,7 @@ impl PySetInner {
         let temp_inner = self.fold_op(others, Self::intersection, vm)?;
         self.clear();
         for (obj, hash) in temp_inner.content.keys_with_hashes() {
-            self.add_with_hash(obj, hash, vm)?;
+            self.add_known_hash(obj, hash, vm)?;
         }
         Ok(())
     }
@@ -498,7 +498,7 @@ impl PySetInner {
         for iterable in others {
             if let Some(elements) = Self::cached_hashes(iterable.as_object(), vm) {
                 for (item, hash) in elements {
-                    self.content.delete_if_exists_with_hash(vm, &*item, hash)?;
+                    self.content.delete_if_exists_known_hash(vm, &*item, hash)?;
                 }
                 continue;
             }
@@ -520,7 +520,7 @@ impl PySetInner {
                 // the source is already duplicate-free
                 for (item, hash) in elements {
                     self.content
-                        .delete_or_insert_with_hash(vm, &item, hash, ())?;
+                        .delete_or_insert_known_hash(vm, &item, hash, ())?;
                 }
                 continue;
             }

--- a/crates/vm/src/builtins/set.rs
+++ b/crates/vm/src/builtins/set.rs
@@ -195,20 +195,17 @@ impl PySetInner {
         Ok(set)
     }
 
-    /// Build a set from an arbitrary object, reusing the source's stored
-    /// hashes when it is a set/frozenset/dict.
-    pub(super) fn from_object(iterable: PyObjectRef, vm: &VirtualMachine) -> PyResult<Self> {
+    /// Build a set from an arbitrary object, reusing stored hashes when the
+    /// source is a set/frozenset/dict.
+    fn from_object(iterable: PyObjectRef, vm: &VirtualMachine) -> PyResult<Self> {
         let set = Self::default();
         set.update_internal(iterable, vm)?;
         Ok(set)
     }
 
-    /// Elements of `obj` paired with the hash already stored alongside them,
-    /// or `None` if `obj` keeps no such hashes and has to be iterated
-    /// generically (which calls `__hash__` on every element again).
-    ///
-    /// Mirrors the `PyAnySet_Check` / `PyDict_CheckExact` fast paths in
-    /// CPython's `set_update_internal`.
+    /// Elements of `obj` with their stored hashes, or `None` if `obj` keeps
+    /// none and must be iterated generically. Mirrors the `PyAnySet_Check` /
+    /// `PyDict_CheckExact` fast paths in CPython's `set_update_internal`.
     fn cached_hashes(obj: &PyObject, vm: &VirtualMachine) -> Option<Vec<(PyObjectRef, PyHash)>> {
         if let Some(set) = extract_set(obj) {
             Some(set.content.keys_with_hashes())
@@ -251,9 +248,8 @@ impl PySetInner {
         Self::wrap_unhashable_error(result, needle, vm)
     }
 
-    /// [`Self::contains`] for a needle whose hash was read from another
-    /// set/dict. Such a needle is hashable by construction, so there is no
-    /// set-to-frozenset retry to do.
+    /// [`Self::contains`] with a known hash. Such a needle came out of a
+    /// set/dict, so it is hashable and needs no frozenset retry.
     fn contains_known_hash(
         &self,
         needle: &PyObject,
@@ -398,7 +394,7 @@ impl PySetInner {
         Self::wrap_unhashable_error(result, &item, vm)
     }
 
-    /// [`Self::add`] for an item whose hash was read from another set/dict.
+    /// [`Self::add`] with a known hash.
     fn add_known_hash(&self, item: PyObjectRef, hash: PyHash, vm: &VirtualMachine) -> PyResult<()> {
         let result = self.content.insert_known_hash(vm, &*item, hash, ());
         Self::wrap_unhashable_error(result, &item, vm)
@@ -1098,8 +1094,6 @@ impl Constructor for PyFrozenSet {
     }
 
     fn py_new(_cls: &Py<PyType>, iterable: Self::Args, vm: &VirtualMachine) -> PyResult<Self> {
-        // built from the object itself, so a set/frozenset/dict source can
-        // hand over its stored hashes instead of being re-hashed
         let inner = match iterable {
             OptionalArg::Present(iterable) => PySetInner::from_object(iterable, vm)?,
             OptionalArg::Missing => PySetInner::default(),

--- a/crates/vm/src/dict_inner.rs
+++ b/crates/vm/src/dict_inner.rs
@@ -463,6 +463,26 @@ impl<T: Clone> Dict<T> {
         K: DictKey + ?Sized,
     {
         let hash = key.key_hash(vm)?;
+        self.insert_with_hash(vm, key, hash, value)
+    }
+
+    /// Store a key whose hash the caller already knows.
+    ///
+    /// `hash` MUST be the value `key.key_hash(vm)` would return. Passing a
+    /// different hash corrupts the table: the entry is stored in a bucket no
+    /// lookup will probe, so the key silently goes missing. Only pass a hash
+    /// read out of another dict/set entry holding this very key object, e.g.
+    /// via [`Self::keys_with_hashes`].
+    pub(crate) fn insert_with_hash<K>(
+        &self,
+        vm: &VirtualMachine,
+        key: &K,
+        hash: HashValue,
+        value: T,
+    ) -> PyResult<()>
+    where
+        K: DictKey + ?Sized,
+    {
         let _removed = loop {
             let (entry_index, index_index) = self.lookup(vm, key, hash, None)?;
             let mut inner = self.write();
@@ -512,7 +532,20 @@ impl<T: Clone> Dict<T> {
         key: &K,
     ) -> PyResult<bool> {
         let key_hash = key.key_hash(vm)?;
-        let (entry, _) = self.lookup(vm, key, key_hash, None)?;
+        self.contains_with_hash(vm, key, key_hash)
+    }
+
+    /// [`Self::contains`] with a caller-supplied hash.
+    ///
+    /// Same contract as [`Self::insert_with_hash`]: a wrong `hash` makes the
+    /// lookup probe the wrong bucket and report a present key as missing.
+    pub(crate) fn contains_with_hash<K: DictKey + ?Sized>(
+        &self,
+        vm: &VirtualMachine,
+        key: &K,
+        hash: HashValue,
+    ) -> PyResult<bool> {
+        let (entry, _) = self.lookup(vm, key, hash, None)?;
         Ok(entry.index().is_some())
     }
 
@@ -697,6 +730,22 @@ impl<T: Clone> Dict<T> {
         self.remove_if_exists(vm, key).map(|opt| opt.is_some())
     }
 
+    /// [`Self::delete_if_exists`] with a caller-supplied hash.
+    ///
+    /// Same contract as [`Self::insert_with_hash`].
+    pub(crate) fn delete_if_exists_with_hash<K>(
+        &self,
+        vm: &VirtualMachine,
+        key: &K,
+        hash: HashValue,
+    ) -> PyResult<bool>
+    where
+        K: DictKey + ?Sized,
+    {
+        self.remove_if_with_hash(vm, key, hash, |_| Ok(true))
+            .map(|opt| opt.is_some())
+    }
+
     pub(crate) fn delete_if<K, F>(&self, vm: &VirtualMachine, key: &K, pred: F) -> PyResult<bool>
     where
         K: DictKey + ?Sized,
@@ -725,6 +774,23 @@ impl<T: Clone> Dict<T> {
         F: Fn(&T) -> PyResult<bool>,
     {
         let hash = key.key_hash(vm)?;
+        self.remove_if_with_hash(vm, key, hash, pred)
+    }
+
+    /// [`Self::remove_if`] with a caller-supplied hash.
+    ///
+    /// Same contract as [`Self::insert_with_hash`].
+    fn remove_if_with_hash<K, F>(
+        &self,
+        vm: &VirtualMachine,
+        key: &K,
+        hash: HashValue,
+        pred: F,
+    ) -> PyResult<Option<T>>
+    where
+        K: DictKey + ?Sized,
+        F: Fn(&T) -> PyResult<bool>,
+    {
         let removed = loop {
             let lookup = self.lookup(vm, key, hash, None)?;
             match self.pop_inner_if(lookup, &pred)? {
@@ -742,6 +808,19 @@ impl<T: Clone> Dict<T> {
         value: T,
     ) -> PyResult<()> {
         let hash = key.key_hash(vm)?;
+        self.delete_or_insert_with_hash(vm, key, hash, value)
+    }
+
+    /// [`Self::delete_or_insert`] with a caller-supplied hash.
+    ///
+    /// Same contract as [`Self::insert_with_hash`].
+    pub(crate) fn delete_or_insert_with_hash(
+        &self,
+        vm: &VirtualMachine,
+        key: &PyObject,
+        hash: HashValue,
+        value: T,
+    ) -> PyResult<()> {
         let _removed = loop {
             let lookup = self.lookup(vm, key, hash, None)?;
             let (entry, index_index) = lookup;
@@ -885,6 +964,18 @@ impl<T: Clone> Dict<T> {
             .entries
             .iter()
             .filter_map(|v| v.as_ref().map(|v| v.key.clone()))
+            .collect()
+    }
+
+    /// All keys paired with the hash already stored in their entry.
+    ///
+    /// Lets a caller move keys into another dict/set without calling
+    /// `__hash__` again; see [`Self::insert_with_hash`].
+    pub(crate) fn keys_with_hashes(&self) -> Vec<(PyObjectRef, HashValue)> {
+        self.read()
+            .entries
+            .iter()
+            .filter_map(|v| v.as_ref().map(|v| (v.key.clone(), v.hash)))
             .collect()
     }
 

--- a/crates/vm/src/dict_inner.rs
+++ b/crates/vm/src/dict_inner.rs
@@ -463,7 +463,7 @@ impl<T: Clone> Dict<T> {
         K: DictKey + ?Sized,
     {
         let hash = key.key_hash(vm)?;
-        self.insert_with_hash(vm, key, hash, value)
+        self.insert_known_hash(vm, key, hash, value)
     }
 
     /// Store a key whose hash the caller already knows.
@@ -473,7 +473,7 @@ impl<T: Clone> Dict<T> {
     /// lookup will probe, so the key silently goes missing. Only pass a hash
     /// read out of another dict/set entry holding this very key object, e.g.
     /// via [`Self::keys_with_hashes`].
-    pub(crate) fn insert_with_hash<K>(
+    pub(crate) fn insert_known_hash<K>(
         &self,
         vm: &VirtualMachine,
         key: &K,
@@ -532,14 +532,14 @@ impl<T: Clone> Dict<T> {
         key: &K,
     ) -> PyResult<bool> {
         let key_hash = key.key_hash(vm)?;
-        self.contains_with_hash(vm, key, key_hash)
+        self.contains_known_hash(vm, key, key_hash)
     }
 
     /// [`Self::contains`] with a caller-supplied hash.
     ///
-    /// Same contract as [`Self::insert_with_hash`]: a wrong `hash` makes the
+    /// Same contract as [`Self::insert_known_hash`]: a wrong `hash` makes the
     /// lookup probe the wrong bucket and report a present key as missing.
-    pub(crate) fn contains_with_hash<K: DictKey + ?Sized>(
+    pub(crate) fn contains_known_hash<K: DictKey + ?Sized>(
         &self,
         vm: &VirtualMachine,
         key: &K,
@@ -732,8 +732,8 @@ impl<T: Clone> Dict<T> {
 
     /// [`Self::delete_if_exists`] with a caller-supplied hash.
     ///
-    /// Same contract as [`Self::insert_with_hash`].
-    pub(crate) fn delete_if_exists_with_hash<K>(
+    /// Same contract as [`Self::insert_known_hash`].
+    pub(crate) fn delete_if_exists_known_hash<K>(
         &self,
         vm: &VirtualMachine,
         key: &K,
@@ -742,7 +742,7 @@ impl<T: Clone> Dict<T> {
     where
         K: DictKey + ?Sized,
     {
-        self.remove_if_with_hash(vm, key, hash, |_| Ok(true))
+        self.remove_if_known_hash(vm, key, hash, |_| Ok(true))
             .map(|opt| opt.is_some())
     }
 
@@ -774,13 +774,13 @@ impl<T: Clone> Dict<T> {
         F: Fn(&T) -> PyResult<bool>,
     {
         let hash = key.key_hash(vm)?;
-        self.remove_if_with_hash(vm, key, hash, pred)
+        self.remove_if_known_hash(vm, key, hash, pred)
     }
 
     /// [`Self::remove_if`] with a caller-supplied hash.
     ///
-    /// Same contract as [`Self::insert_with_hash`].
-    fn remove_if_with_hash<K, F>(
+    /// Same contract as [`Self::insert_known_hash`].
+    fn remove_if_known_hash<K, F>(
         &self,
         vm: &VirtualMachine,
         key: &K,
@@ -808,13 +808,13 @@ impl<T: Clone> Dict<T> {
         value: T,
     ) -> PyResult<()> {
         let hash = key.key_hash(vm)?;
-        self.delete_or_insert_with_hash(vm, key, hash, value)
+        self.delete_or_insert_known_hash(vm, key, hash, value)
     }
 
     /// [`Self::delete_or_insert`] with a caller-supplied hash.
     ///
-    /// Same contract as [`Self::insert_with_hash`].
-    pub(crate) fn delete_or_insert_with_hash(
+    /// Same contract as [`Self::insert_known_hash`].
+    pub(crate) fn delete_or_insert_known_hash(
         &self,
         vm: &VirtualMachine,
         key: &PyObject,
@@ -970,7 +970,7 @@ impl<T: Clone> Dict<T> {
     /// All keys paired with the hash already stored in their entry.
     ///
     /// Lets a caller move keys into another dict/set without calling
-    /// `__hash__` again; see [`Self::insert_with_hash`].
+    /// `__hash__` again; see [`Self::insert_known_hash`].
     pub(crate) fn keys_with_hashes(&self) -> Vec<(PyObjectRef, HashValue)> {
         self.read()
             .entries

--- a/crates/vm/src/dict_inner.rs
+++ b/crates/vm/src/dict_inner.rs
@@ -468,11 +468,9 @@ impl<T: Clone> Dict<T> {
 
     /// Store a key whose hash the caller already knows.
     ///
-    /// `hash` MUST be the value `key.key_hash(vm)` would return. Passing a
-    /// different hash corrupts the table: the entry is stored in a bucket no
-    /// lookup will probe, so the key silently goes missing. Only pass a hash
-    /// read out of another dict/set entry holding this very key object, e.g.
-    /// via [`Self::keys_with_hashes`].
+    /// `hash` must equal `key.key_hash(vm)`; a wrong one lands the entry in a
+    /// bucket no lookup probes, silently losing the key. Only pass a hash from
+    /// [`Self::keys_with_hashes`] on a container holding this same key.
     pub(crate) fn insert_known_hash<K>(
         &self,
         vm: &VirtualMachine,
@@ -535,10 +533,8 @@ impl<T: Clone> Dict<T> {
         self.contains_known_hash(vm, key, key_hash)
     }
 
-    /// [`Self::contains`] with a caller-supplied hash.
-    ///
-    /// Same contract as [`Self::insert_known_hash`]: a wrong `hash` makes the
-    /// lookup probe the wrong bucket and report a present key as missing.
+    /// [`Self::contains`] with a known hash. Same contract as
+    /// [`Self::insert_known_hash`].
     pub(crate) fn contains_known_hash<K: DictKey + ?Sized>(
         &self,
         vm: &VirtualMachine,
@@ -730,9 +726,8 @@ impl<T: Clone> Dict<T> {
         self.remove_if_exists(vm, key).map(|opt| opt.is_some())
     }
 
-    /// [`Self::delete_if_exists`] with a caller-supplied hash.
-    ///
-    /// Same contract as [`Self::insert_known_hash`].
+    /// [`Self::delete_if_exists`] with a known hash. Same contract as
+    /// [`Self::insert_known_hash`].
     pub(crate) fn delete_if_exists_known_hash<K>(
         &self,
         vm: &VirtualMachine,
@@ -777,9 +772,8 @@ impl<T: Clone> Dict<T> {
         self.remove_if_known_hash(vm, key, hash, pred)
     }
 
-    /// [`Self::remove_if`] with a caller-supplied hash.
-    ///
-    /// Same contract as [`Self::insert_known_hash`].
+    /// [`Self::remove_if`] with a known hash. Same contract as
+    /// [`Self::insert_known_hash`].
     fn remove_if_known_hash<K, F>(
         &self,
         vm: &VirtualMachine,
@@ -811,9 +805,8 @@ impl<T: Clone> Dict<T> {
         self.delete_or_insert_known_hash(vm, key, hash, value)
     }
 
-    /// [`Self::delete_or_insert`] with a caller-supplied hash.
-    ///
-    /// Same contract as [`Self::insert_known_hash`].
+    /// [`Self::delete_or_insert`] with a known hash. Same contract as
+    /// [`Self::insert_known_hash`].
     pub(crate) fn delete_or_insert_known_hash(
         &self,
         vm: &VirtualMachine,
@@ -967,10 +960,8 @@ impl<T: Clone> Dict<T> {
             .collect()
     }
 
-    /// All keys paired with the hash already stored in their entry.
-    ///
-    /// Lets a caller move keys into another dict/set without calling
-    /// `__hash__` again; see [`Self::insert_known_hash`].
+    /// All keys paired with the hash stored in their entry, for feeding
+    /// [`Self::insert_known_hash`] without re-calling `__hash__`.
     pub(crate) fn keys_with_hashes(&self) -> Vec<(PyObjectRef, HashValue)> {
         self.read()
             .entries

--- a/crates/vm/src/function/protocol.rs
+++ b/crates/vm/src/function/protocol.rs
@@ -86,6 +86,11 @@ unsafe impl<T: Traverse> Traverse for ArgIterable<T> {
 }
 
 impl<T> ArgIterable<T> {
+    #[must_use]
+    pub fn as_object(&self) -> &PyObject {
+        &self.iterable
+    }
+
     /// Returns an iterator over this sequence of objects.
     ///
     /// This operation may fail if an exception is raised while invoking the

--- a/crates/vm/src/function/protocol.rs
+++ b/crates/vm/src/function/protocol.rs
@@ -87,7 +87,7 @@ unsafe impl<T: Traverse> Traverse for ArgIterable<T> {
 
 impl<T> ArgIterable<T> {
     #[must_use]
-    pub fn as_object(&self) -> &PyObject {
+    pub(crate) fn as_object(&self) -> &PyObject {
         &self.iterable
     }
 


### PR DESCRIPTION
Closes #8489.

## Changes

**`dict_inner.rs`** — each entry point computed the hash on its first line and passed only the `hash` variable downward, so the split is mechanical: the body moves to a `*_known_hash` variant and the original becomes a wrapper. No logic is duplicated.

- `insert_known_hash`, `contains_known_hash`, `remove_if_known_hash`, `delete_if_exists_known_hash`, `delete_or_insert_known_hash`
- `keys_with_hashes()` — yields `(key, hash)` from the entries, next to the existing `keys()`/`values()`/`items()`

The `_known_hash` suffix follows CPython's "KnownHash" variants (`_PyDict_SetItem_KnownHash`, `_PyDict_Contains_KnownHash`, `_PyDict_DelItem_KnownHash`), which mark the same split as `set_add_key`/`set_add_entry` on the set side. `keys_with_hashes()` keeps `with` because it really does return the hashes.

**`function/protocol.rs`** — `ArgIterable::as_object()`, a `pub(crate)` accessor for the object before any `__iter__` call. The set operations take `ArgIterable`, which already held the original `PyObjectRef` in a private field; reaching it lets them dispatch on the source type without changing a single signature (they are passed around as `fn(&PySetInner, ArgIterable, &VirtualMachine) -> ...` function pointers, so changing them would have rippled widely).

**`builtins/set.rs`**

- `PySetInner::cached_hashes()` — `Some(Vec<(key, hash)>)` for a set/frozenset (subclasses included, via the existing `extract_set`) or an exact dict, `None` otherwise. Same predicates as CPython.
- `add_known_hash` / `contains_known_hash`
- `merge_set` / `merge_dict` now forward the stored hashes
- Fast path added to `union`, `intersection`, `difference`, `symmetric_difference`, `difference_update`, `symmetric_difference_update`, `intersection_update` — **the existing generic loop stays as the fallback in each**
- `PyFrozenSet`'s `Constructor::Args` becomes `OptionalArg<PyObjectRef>` so `py_new` receives the source object and can hand its stored hashes over via `PySetInner::from_object`, instead of flattening to `Vec<PyObjectRef>` first; `slot_new` keeps only argument parsing and the empty-singleton check

## Result

```
after dict.fromkeys(map):  10
after frozenset(d):        10
after set(d):              10
after s.difference(d):     10
after s.symmetric_difference_update(d): 10
```

## Testing

- `test_set` — `Ran 630 tests ... OK (expected failures=10)`, no new failures
- `test_dict`, `test_dictviews`, `test_dictcomps`, `test_ordered_dict`, `test_defaultdict`, `test_userdict`, `test_setcomps`, `test_weakset`, `test_collections`, `test_copy` — all pass
- `test_types`, `test_builtin`, `test_iter`, `test_pickle`, `test_marshal`, `test_descr`, `test_class`, `test_functools`, `test_typing` — all pass
- `extra_tests/snippets/`: `builtin_set.py`, `builtin_dict.py`, `builtin_dict_union.py`, `frozen.py`
- Ad-hoc: empty-frozenset singleton, `frozenset(f) is f`, distinct ids for empty subclass instances, dict **subclasses** correctly excluded from the exact-dict path, self-referential ops (`s.update(s)`, `s.symmetric_difference_update(s)`), results not aliasing their operands, error messages unchanged vs CPython 3.14.6
- `cargo fmt --check` clean, `cargo clippy -p rustpython-vm --all-targets` no new warnings

## Review note

`insert_known_hash` depends on a contract the callee cannot verify: pass a hash that isn't `key.key_hash(vm)` and the entry lands in a bucket no lookup will probe, so the key silently disappears. This is documented on the function, and every call site forwards a hash that came from `keys_with_hashes()` on a container holding that same key object. Worth a careful look.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Frozensets can now be created directly from an optional iterable.
  - Exact frozenset inputs are preserved where applicable.
  - Empty frozenset creation continues to reuse the shared empty instance.

- **Performance**
  - Set operations and updates are more efficient by reusing cached element hashes.
  - Improved hashing efficiency for set, frozenset, and dictionary insertion, lookup, deletion, merging, and membership operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->