### PR TITLE
jit: fix recursive call return value type tagging

### DIFF
--- a/crates/jit/src/instructions.rs
+++ b/crates/jit/src/instructions.rs
@@ -548,8 +548,22 @@ impl<'a, 'b> FunctionCompiler<'a, 'b> {
                 match self.stack.pop().ok_or(JitCompileError::BadBytecode)? {
                     JitValue::FuncRef(reference) => {
                         let call = self.builder.ins().call(reference, &args);
-                        let returns = self.builder.inst_results(call);
-                        self.stack.push(JitValue::Int(returns[0]));
+                        // The only callable reachable here is this function itself,
+                        // so the result carries the declared return type - it is not
+                        // always an Int. A function whose return type is still
+                        // unknown has no return slot in the signature it was
+                        // declared with, and there is nothing to type the result as.
+                        let ret = match *self.builder.inst_results(call) {
+                            [] => None,
+                            [val] => Some(val),
+                            _ => return Err(JitCompileError::NotSupported),
+                        };
+                        let val = match (self.sig.ret.clone(), ret) {
+                            (Some(JitType::None), None) => JitValue::None,
+                            (Some(ty), Some(val)) => JitValue::from_type_and_value(ty, val),
+                            _ => return Err(JitCompileError::NotSupported),
+                        };
+                        self.stack.push(val);
 
                         Ok(())
                     }

--- a/crates/jit/tests/bool_tests.rs
+++ b/crates/jit/tests/bool_tests.rs
@@ -202,4 +202,18 @@ mod tests {
         assert_eq!(lte(false, 1), Ok(1));
         assert_eq!(lte(true, 0), Ok(0));
     }
+
+    #[test]
+    fn recursive_bool() {
+        let recursive_bool = jit_function! { recursive_bool(n: i64) -> bool => r##"
+        def recursive_bool(n: int) -> bool:
+            if n == 0:
+                return True
+            return not recursive_bool(n - 1)
+    "## };
+
+        assert_eq!(recursive_bool(0), Ok(true));
+        assert_eq!(recursive_bool(1), Ok(false));
+        assert_eq!(recursive_bool(4), Ok(true));
+    }
 }

--- a/crates/jit/tests/float_tests.rs
+++ b/crates/jit/tests/float_tests.rs
@@ -379,4 +379,18 @@ mod tests {
         assert_eq!(float_lte(f64::NAN, f64::NAN), Ok(false));
         assert_eq!(float_lte(f64::INFINITY, f64::NEG_INFINITY), Ok(false));
     }
+
+    #[test]
+    fn recursive_float() {
+        let recursive_float = jit_function! { recursive_float(n: i64) -> f64 => r##"
+        def recursive_float(n: int) -> float:
+            if n == 0:
+                return 1.0
+            return recursive_float(n - 1) / 2.0
+    "## };
+
+        assert_eq!(recursive_float(0), Ok(1.0));
+        assert_eq!(recursive_float(1), Ok(0.5));
+        assert_eq!(recursive_float(4), Ok(0.0625));
+    }
 }


### PR DESCRIPTION
Assisted-by: Codex:5.6-sol
<!--
Thanks for your contribution!
-->

- [ ] Closes #xxxx <!-- Replace xxxx with the GitHub issue number -->
- [x] This PR follows our [AI policy](https://github.com/RustPython/.github/blob/main/AI_POLICY.md)

## Summary
<!-- What's the purpose of the change? What does it do, and why? -->
Recursive call results were previously hardcoded as `JitValue::Int(...)`. Even when Cranelift gave back a value with the right machine type, the JIT still wrote it down as an integer at compile time.

As a result, recursive functions returning `bool` or `float` were incorrectly typed. Functions with no return value could also try to read a return slot that was not there.

- Use slice pattern matching on return slots so we don't index into a nonexistent result
- Match the declared return type (`self.sig.ret`) with the actual return slot to preserve `bool`, `float`, and `None` return types
- Return `NotSupported` when the declared return type and actual return slot do not match
- Add regression tests for recursive functions returning `bool` and `float`
  - `recursive_float`: verifies that a recursive call result remains tagged as `Float`, allowing the following `/ 2.0` operation to consume the underlying `F64` value correctly
  - `recursive_bool`: verifies that a recursive call result remains tagged as `Bool` (`I8`), allowing the following `not` operation to compile and execute correctly

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Recursive JIT calls now correctly handle functions returning no value, integers, booleans, and floating-point values.
  - Unsupported return shapes are reported clearly instead of being interpreted incorrectly.

- **Tests**
  - Added coverage for recursive boolean evaluation, including negation and base cases.
  - Added coverage for recursive floating-point calculations across multiple recursion levels.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->