### PR TITLE
Allow and document clippy::drain_collect

### DIFF
--- a/crates/vm/src/stdlib/_codecs.rs
+++ b/crates/vm/src/stdlib/_codecs.rs
@@ -791,19 +791,18 @@ mod _codecs_windows {
 
             // Convert code point to UTF-16
             let mut wchars = [0u16; 2];
-            let wchar_len;
             let is_surrogate = (0xD800..=0xDFFF).contains(&ch);
 
-            if is_surrogate {
-                wchar_len = 0; // Can't encode surrogates normally
+            let wchar_len = if is_surrogate {
+                0 // Can't encode surrogates normally
             } else if ch < 0x10000 {
                 wchars[0] = ch as u16;
-                wchar_len = 1;
+                1
             } else {
                 wchars[0] = ((ch - 0x10000) >> 10) as u16 + 0xD800;
                 wchars[1] = ((ch - 0x10000) & 0x3FF) as u16 + 0xDC00;
-                wchar_len = 2;
-            }
+                2
+            };
 
             if !is_surrogate {
                 let mut buf = [0u8; 8];

--- a/crates/vm/src/vm/mod.rs
+++ b/crates/vm/src/vm/mod.rs
@@ -1467,6 +1467,10 @@ impl VirtualMachine {
 
         let initial_ptr = self.take_pending_tailcall();
         // Drain the refs that keep the initial callee's raw pointers alive.
+        #[allow(
+            clippy::drain_collect,
+            reason = "`pending_tailcall_refs`'s allocation is intentionally reused"
+        )]
         let initial_refs = unsafe { &mut *self.pending_tailcall_refs.get() }
             .drain(..)
             .collect();
@@ -1498,6 +1502,10 @@ impl VirtualMachine {
                     let result = crate::frame::run_iframe(callee, self);
                     match result {
                         Ok(ExecutionResult::TailCall) => {
+                            #[allow(
+                                clippy::drain_collect,
+                                reason = "`pending_tailcall_refs`'s allocation is intentionally reused"
+                            )]
                             let refs = unsafe { &mut *self.pending_tailcall_refs.get() }
                                 .drain(..)
                                 .collect();
@@ -1548,6 +1556,10 @@ impl VirtualMachine {
                     let result = crate::frame::run_iframe(caller_iframe, self);
                     match result {
                         Ok(ExecutionResult::TailCall) => {
+                            #[allow(
+                                clippy::drain_collect,
+                                reason = "`pending_tailcall_refs`'s allocation is intentionally reused"
+                            )]
                             let refs = unsafe { &mut *self.pending_tailcall_refs.get() }
                                 .drain(..)
                                 .collect();
@@ -1609,6 +1621,10 @@ impl VirtualMachine {
                             let result = crate::frame::run_iframe(caller_iframe, self);
                             match result {
                                 Ok(ExecutionResult::TailCall) => {
+                                    #[allow(
+                                        clippy::drain_collect,
+                                        reason = "`pending_tailcall_refs`'s allocation is intentionally reused"
+                                    )]
                                     let refs = unsafe { &mut *self.pending_tailcall_refs.get() }
                                         .drain(..)
                                         .collect();


### PR DESCRIPTION
RustPython's tail call machinery pre-allocates and reuses a vector. The code drains the vector into a new vector which is stored elsewhere.

Clippy warns that this pattern causes a spurious location. Clippy is usually right that this pattern is suspect, but in this case the initial vector is reused so we want to keep the initial location.


<!--
Thanks for your contribution!
-->

- [ ] Closes #xxxx <!-- Replace xxxx with the GitHub issue number -->
- [x] This PR follows our [AI policy](https://github.com/RustPython/.github/blob/main/AI_POLICY.md)

## Summary
<!-- What's the purpose of the change? What does it do, and why? -->

* Silences a clippy lint about collecting a drain iterator
* Documents why this behavior is expected

---

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Simplified character encoding logic while preserving existing encoding behavior.
  * Improved runtime handling of pending references during optimized call execution.
* **Performance**
  * Reduced unnecessary memory allocation in internal execution paths, supporting more efficient runtime performance.
* **Reliability**
  * Maintained consistent behavior across initial, nested, and resumed calls.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->