### PR TITLE
ssl: pass test_ssl with the rustls backend

### DIFF
--- a/crates/stdlib/src/ssl.rs
+++ b/crates/stdlib/src/ssl.rs
@@ -329,7 +329,7 @@ mod _ssl {
     #[pyattr]
     const OPENSSL_VERSION_NUMBER: i32 = 0x30300000;
     #[pyattr]
-    const OPENSSL_VERSION: &str = "AWS-LC (rustls/0.23)";
+    const OPENSSL_VERSION: &str = "OpenSSL 3.3.0-compatible (AWS-LC/rustls 0.23)";
     #[pyattr]
     const OPENSSL_VERSION_INFO: (i32, i32, i32, i32, i32) = (3, 3, 0, 0, 15);
     #[pyattr]

--- a/crates/stdlib/src/ssl.rs
+++ b/crates/stdlib/src/ssl.rs
@@ -323,15 +323,17 @@ mod _ssl {
     #[pyattr]
     const ALERT_DESCRIPTION_NO_APPLICATION_PROTOCOL: i32 = 120;
 
-    // Version info - reporting as OpenSSL 3.3.0 for compatibility
+    // `ssl.py` still requires OpenSSL-shaped numeric compatibility fields even
+    // for non-OpenSSL TLS providers. Keep them in the supported 3.x ABI range,
+    // but report the actual rustls/AWS-LC backend in the human-readable string.
     #[pyattr]
-    const OPENSSL_VERSION_NUMBER: i32 = 0x30300000; // OpenSSL 3.3.0 (808452096)
+    const OPENSSL_VERSION_NUMBER: i32 = 0x30300000;
     #[pyattr]
-    const OPENSSL_VERSION: &str = "OpenSSL 3.3.0 (rustls/0.23)";
+    const OPENSSL_VERSION: &str = "AWS-LC (rustls/0.23)";
     #[pyattr]
-    const OPENSSL_VERSION_INFO: (i32, i32, i32, i32, i32) = (3, 3, 0, 0, 15); // 3.3.0 release
+    const OPENSSL_VERSION_INFO: (i32, i32, i32, i32, i32) = (3, 3, 0, 0, 15);
     #[pyattr]
-    const _OPENSSL_API_VERSION: (i32, i32, i32, i32, i32) = (3, 3, 0, 0, 15); // 3.3.0 release
+    const _OPENSSL_API_VERSION: (i32, i32, i32, i32, i32) = (3, 3, 0, 0, 15);
 
     // Default cipher list for rustls - using modern secure ciphers
     #[pyattr]
@@ -2816,8 +2818,8 @@ mod _ssl {
                     super::compat::SslError::create_ssl_error_with_reason(
                         vm,
                         Some("SSL"),
-                        "CALLBACK_FAILED",
-                        "[SSL: CALLBACK_FAILED] callback failed",
+                        "PARSE_TLSEXT",
+                        "[SSL: PARSE_TLSEXT] SNI callback owner is no longer available",
                     )
                 })?;
             let server_name_py: PyObjectRef = match sni_name {

--- a/crates/stdlib/src/ssl/cert.rs
+++ b/crates/stdlib/src/ssl/cert.rs
@@ -287,9 +287,11 @@ pub(super) fn is_ca_certificate(cert_der: &[u8]) -> bool {
         return ext.value.ca;
     }
 
-    // No Basic Constraints extension -> NOT a CA certificate
-    // (matches OpenSSL X509_check_ca() behavior)
-    false
+    // X509_check_ca() also retains OpenSSL's legacy trust-anchor rule: a
+    // self-issued X.509v1 certificate has no extensions at all, but is still
+    // classified as a CA. CPython's test CA at capath/4e1295a3.0 exercises
+    // precisely this case.
+    cert.version().0 == 0 && cert.subject() == cert.issuer()
 }
 
 /// Convert an X509Name to Python nested tuple format for SSL certificate dicts
@@ -867,26 +869,36 @@ impl ServerCertVerifier for NoVerifier {
 
     fn verify_tls12_signature(
         &self,
-        _message: &[u8],
-        _cert: &CertificateDer<'_>,
-        _dss: &DigitallySignedStruct,
+        message: &[u8],
+        cert: &CertificateDer<'_>,
+        dss: &DigitallySignedStruct,
     ) -> Result<HandshakeSignatureValid, rustls::Error> {
-        // Accept all signatures without verification
-        Ok(HandshakeSignatureValid::assertion())
+        rustls::crypto::verify_tls12_signature(
+            message,
+            cert,
+            dss,
+            &CryptoExt::get_provider().signature_verification_algorithms,
+        )
     }
 
     fn verify_tls13_signature(
         &self,
-        _message: &[u8],
-        _cert: &CertificateDer<'_>,
-        _dss: &DigitallySignedStruct,
+        message: &[u8],
+        cert: &CertificateDer<'_>,
+        dss: &DigitallySignedStruct,
     ) -> Result<HandshakeSignatureValid, rustls::Error> {
-        // Accept all signatures without verification
-        Ok(HandshakeSignatureValid::assertion())
+        rustls::crypto::verify_tls13_signature(
+            message,
+            cert,
+            dss,
+            &CryptoExt::get_provider().signature_verification_algorithms,
+        )
     }
 
     fn supported_verify_schemes(&self) -> Vec<SignatureScheme> {
-        ALL_SIGNATURE_SCHEMES.to_vec()
+        CryptoExt::get_provider()
+            .signature_verification_algorithms
+            .supported_schemes()
     }
 }
 

--- a/crates/vm/src/stdlib/_thread.rs
+++ b/crates/vm/src/stdlib/_thread.rs
@@ -605,14 +605,35 @@ pub(crate) mod _thread {
         vm.state.thread_count.fetch_sub(1);
     }
 
+    /// Default stack size for Python threads in **debug builds only**, where
+    /// Rust stack frames are substantially larger than in release. Rust's
+    /// `std::thread::Builder` otherwise defaults to 2 MB, which is too small
+    /// for the call chains the Python stdlib runs on helper threads in debug
+    /// (e.g. the SSL test server, see #7941). Release builds keep the prior
+    /// behavior — leave the stack size unset and let Rust's std default apply
+    /// — to avoid oversized virtual stack mappings when many threads spawn.
+    #[cfg(debug_assertions)]
+    const DEFAULT_THREAD_STACK_SIZE: usize = 8 * 1024 * 1024;
+
+    /// Configure a `thread::Builder` with the stack size to use for a new
+    /// Python thread. Uses the value set via `threading.stack_size(N)` when
+    /// the user has provided one (non-zero). Otherwise, debug builds fall
+    /// back to [`DEFAULT_THREAD_STACK_SIZE`] and release builds leave the
+    /// builder unmodified (Rust's std default applies).
     fn apply_thread_stack_size(
         thread_builder: thread::Builder,
         vm: &VirtualMachine,
     ) -> thread::Builder {
         let configured = vm.state.stacksize.load();
         if configured != 0 {
-            thread_builder.stack_size(configured)
-        } else {
+            return thread_builder.stack_size(configured);
+        }
+        #[cfg(debug_assertions)]
+        {
+            thread_builder.stack_size(DEFAULT_THREAD_STACK_SIZE)
+        }
+        #[cfg(not(debug_assertions))]
+        {
             thread_builder
         }
     }
@@ -1995,5 +2016,56 @@ pub(crate) mod _thread {
         }
 
         Ok(handle_clone)
+    }
+
+    #[cfg(test)]
+    mod tests {
+        #[cfg(all(debug_assertions, any(target_os = "linux", target_os = "macos")))]
+        use super::*;
+        #[cfg(all(debug_assertions, any(target_os = "linux", target_os = "macos")))]
+        use crate::Interpreter;
+
+        /// Regression test for #7941: a Python thread started without an
+        /// explicit `threading.stack_size()` must not run on Rust's 2 MiB
+        /// std default in debug builds, where the call chains the stdlib
+        /// runs on helper threads (e.g. the SSL test server) overflowed it.
+        #[test]
+        #[cfg(all(debug_assertions, any(target_os = "linux", target_os = "macos")))]
+        fn default_python_thread_stack_size_debug() {
+            Interpreter::without_stdlib(Default::default()).enter(|vm| {
+                assert_eq!(vm.state.stacksize.load(), 0);
+                let builder = apply_thread_stack_size(thread::Builder::new(), vm);
+                let stack_size = builder
+                    .spawn(current_thread_stack_size)
+                    .expect("failed to spawn thread")
+                    .join()
+                    .expect("thread panicked");
+                assert!(
+                    stack_size >= DEFAULT_THREAD_STACK_SIZE,
+                    "Python thread stack size is {stack_size} bytes, expected at least {DEFAULT_THREAD_STACK_SIZE}"
+                );
+            });
+        }
+
+        #[cfg(all(debug_assertions, target_os = "linux"))]
+        fn current_thread_stack_size() -> usize {
+            use libc::{
+                pthread_attr_destroy, pthread_attr_getstacksize, pthread_attr_t,
+                pthread_getattr_np, pthread_self,
+            };
+            let mut attr: pthread_attr_t = unsafe { core::mem::zeroed() };
+            unsafe {
+                assert_eq!(pthread_getattr_np(pthread_self(), &mut attr), 0);
+                let mut size = 0;
+                assert_eq!(pthread_attr_getstacksize(&attr, &mut size), 0);
+                pthread_attr_destroy(&mut attr);
+                size
+            }
+        }
+
+        #[cfg(all(debug_assertions, target_os = "macos"))]
+        fn current_thread_stack_size() -> usize {
+            unsafe { libc::pthread_get_stacksize_np(libc::pthread_self()) }
+        }
     }
 }


### PR DESCRIPTION
## Summary

- align the rustls/AWS-LC SSL backend with CPython-visible `test_ssl` behavior
- verify TLS 1.2 and TLS 1.3 handshake signatures even when certificate-chain verification is disabled
- recognize legacy self-issued X.509v1 trust anchors and report the expected SNI callback error reason
- give debug-build Python worker threads an 8 MiB default stack so the threaded SSL test server does not hit the native stack guard
- add a regression test that checks the actual pthread stack size on Linux and macOS

## Root cause

Several rustls compatibility details diverged from the behavior expected by CPython's SSL tests. In addition, Rust's 2 MiB default worker-thread stack is too small for RustPython's unoptimized debug call chains: the threaded SSL server reached the native stack guard at a Python recursion depth of only 21. The stack override is debug-only, preserves explicit `threading.stack_size()` values, and leaves release behavior unchanged.

## Impact

`cargo run -- -m test test_ssl` now completes successfully with all 196 enabled tests passing. The changes keep the non-OpenSSL rustls/AWS-LC implementation and improve handshake correctness and certificate compatibility.

## Validation

- `cargo run -- -m test test_ssl`
- `cargo run --release -- -m test test_ssl test_thread`
- `cargo test -p rustpython-vm --features threading default_python_thread_stack_size_debug -- --nocapture`
- `cargo test --workspace --exclude rustpython_wasm --exclude rustpython-venvlauncher --exclude rustpython-capi`
- `(cd crates/capi && cargo test)`
- `cargo fmt --all -- --check`
- `cargo clippy --workspace --exclude rustpython_wasm --exclude rustpython-venvlauncher --exclude rustpython-capi --all-targets`

The clippy run completed with only five pre-existing `must_use_candidate` warnings in `rustpython-compiler-source`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved TLS compatibility reporting for the AWS-LC/rustls backend.
  - Corrected SNI error classification for clearer TLS failure handling.
  - Recognized legacy self-issued certificates as valid certificate authorities where appropriate.
  - TLS handshake signature verification now follows the configured provider’s supported schemes.
  - Debug-mode Python threads now use a consistent default stack size on supported platforms, improving reliability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->