### PR TITLE
itertools: defer dropwhile predicate validation

### DIFF
--- a/Lib/test/test_itertools.py
+++ b/Lib/test/test_itertools.py
@@ -1260,7 +1260,6 @@ class TestBasicOps(unittest.TestCase):
         self.assertEqual(list(t), [1, 1, 1])
         self.assertRaises(StopIteration, next, t)
 
-    @unittest.expectedFailure  # TODO: RUSTPYTHON
     def test_dropwhile(self):
         data = [1, 3, 5, 20, 2, 4, 6, 8]
         self.assertEqual(list(dropwhile(underten, data)), [20, 2, 4, 6, 8])

--- a/crates/vm/src/stdlib/itertools.rs
+++ b/crates/vm/src/stdlib/itertools.rs
@@ -10,7 +10,7 @@ mod decl {
             rc::PyRc,
         },
         convert::ToPyObject,
-        function::{ArgCallable, FuncArgs, OptionalArg, OptionalOption, PosArgs},
+        function::{FuncArgs, OptionalArg, OptionalOption, PosArgs},
         protocol::{PyIter, PyIterReturn, PyNumber},
         raise_if_stop,
         stdlib::sys,
@@ -477,7 +477,7 @@ mod decl {
     #[pyclass(name = "dropwhile")]
     #[derive(Debug, PyPayload)]
     struct PyItertoolsDropwhile {
-        predicate: ArgCallable,
+        predicate: PyObjectRef,
         iterable: PyIter,
         start_flag: AtomicCell<bool>,
     }
@@ -485,7 +485,7 @@ mod decl {
     #[derive(FromArgs)]
     struct DropwhileNewArgs {
         #[pyarg(positional)]
-        predicate: ArgCallable,
+        predicate: PyObjectRef,
         #[pyarg(positional)]
         iterable: PyIter,
     }
@@ -522,8 +522,7 @@ mod decl {
             if !zelf.start_flag.load() {
                 loop {
                     let obj = raise_if_stop!(iterable.next(vm)?);
-                    let pred = predicate.clone();
-                    let pred_value = pred.invoke((obj.clone(),), vm)?;
+                    let pred_value = predicate.call((obj.clone(),), vm)?;
                     if !pred_value.try_to_bool(vm)? {
                         zelf.start_flag.store(true);
                         return Ok(PyIterReturn::Return(obj));


### PR DESCRIPTION
- [ ] Closes #xxxx
- [x] This PR follows our [AI policy](https://github.com/RustPython/.github/blob/main/AI_POLICY.md)

## Summary

Defer `itertools.dropwhile()` predicate validation until iteration, matching
CPython's lazy behavior.

## Details

`dropwhile` stored its predicate as `ArgCallable`, which rejected a
non-callable predicate during construction. CPython permits construction and
only calls (and therefore validates) the predicate when it consumes an item.
This matters for an empty iterable and for the timing of exceptions.

Store the predicate as `PyObjectRef` and invoke it from `next()`. The change
keeps the existing first-false-item behavior and exception propagation while
aligning validation timing with CPython.

`TestBasicOps.test_dropwhile` now passes with its existing CPython test body,
so remove its `expectedFailure` marker.

## Testing

- `uv tool run prek run --all-files`
- `cargo fmt --check`
- `cargo run --release Lib/test/test_itertools.py`
  - 137 tests run
  - 21 skipped
  - 5 expected failures
- `cargo run --release -- -m test test_itertools`
- `cargo run -- extra_tests/snippets/stdlib_itertools.py`
- `cargo clippy -p rustpython-vm --all-targets -- -Dwarnings`
- `cargo test --workspace --exclude rustpython_wasm --exclude rustpython-venvlauncher --exclude rustpython-capi`
- `git diff --check`

AI assistance: Codex:gpt-5.6-sol

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved `dropwhile` predicate handling for more reliable iterator behavior.
  * Removed unnecessary callable wrapping during predicate evaluation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->