### PR TITLE
Automate OSCCA pull request triage

### DIFF
--- a/.github/workflows/oscca-pr.yml
+++ b/.github/workflows/oscca-pr.yml
@@ -1,0 +1,70 @@
+name: Manage OSCCA pull requests
+
+on:
+  pull_request_target:
+    types: [opened]
+
+permissions: {}
+
+jobs:
+  label-and-assign:
+    name: Label and assign OSCCA pull request
+    runs-on: ubuntu-slim
+    timeout-minutes: 5
+    permissions:
+      issues: write
+    steps:
+      - name: Label and assign pull request
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+        with:
+          script: |
+            const osccaUsers = new Set(
+              [
+                "2jiyong",
+                "chestnut1717",
+                "devyubin",
+                "fregataa",
+                "hyoinandout",
+                "HyoJongPark",
+                "JaceJung-dev",
+                "jinmay",
+                "jiwahn",
+                "kangdora",
+                "kim-jaedeok",
+                "kyokuping",
+                "leehanjeong",
+                "lms0806",
+                "lsahn-gh",
+                "moreal",
+                "name-of-okja",
+                "rlaisqls",
+                "seungje0612",
+                "shAn-kor",
+                "sigmaith",
+                "teddygood",
+                "widehyo1",
+                "YangSiJun528",
+                "zzarbttoo",
+              ].map((login) => login.toLowerCase()),
+            );
+            const pullRequest = context.payload.pull_request;
+            const author = pullRequest.user.login;
+
+            if (!osccaUsers.has(author.toLowerCase())) {
+              core.info(`${author} is not an OSCCA participant; skipping.`);
+              return;
+            }
+
+            const issue = {
+              ...context.repo,
+              issue_number: pullRequest.number,
+            };
+
+            await github.rest.issues.addLabels({
+              ...issue,
+              labels: ["z-ca-2026"],
+            });
+            await github.rest.issues.addAssignees({
+              ...issue,
+              assignees: [author],
+            });

--- a/.github/zizmor.yml
+++ b/.github/zizmor.yml
@@ -1,4 +1,9 @@
 rules:
+  dangerous-triggers:
+    ignore:
+      # pull_request_target is needed to label and assign PRs from forks with issues: write.
+      # The workflow does not check out or execute pull request code.
+      - oscca-pr.yml:3
   excessive-permissions:
     ignore:
       # pull_request_target is needed to post PR comments with pull-requests: write.


### PR DESCRIPTION
## Motivation

OSCCA pull requests currently need their program label and assignee set manually. This automation keeps that metadata consistent for both draft and ready pull requests as soon as they are opened.

The workflow grants only `issues: write`, and it does not check out or execute pull request code.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Newly opened pull requests targeting the repository are automatically reviewed for eligible contributors.
  * Eligible pull requests receive the `z-ca-2026` label and are assigned to their author.
  * Contributor matching is case-insensitive for consistent handling.
* **Bug Fixes**
  * Pull requests from ineligible contributors are skipped without automatic labeling or assignment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->