### PR TITLE
Fix future annotation block alignment

### DIFF
--- a/crates/codegen/src/compile.rs
+++ b/crates/codegen/src/compile.rs
@@ -5083,6 +5083,14 @@ impl<'warnings> Compiler<'warnings> {
         func_range: TextRange,
     ) -> CompileResult<bool> {
         if !self.next_function_annotation_symbol_table_uses_annotations() {
+            // CPython creates a hidden AnnotationBlock for every function
+            // signature under `from __future__ import annotations`, including
+            // an unannotated one.  It still belongs to this function: consume
+            // it so the next function sees its own block rather than remaining
+            // pinned to this unused entry.
+            if self.push_annotation_symbol_table() {
+                self.pop_annotation_symbol_table();
+            }
             return Ok(false);
         }
 
@@ -31244,6 +31252,25 @@ def f(x: T): pass
         assert!(
             find_code(&code, "f").is_some(),
             "function body symbol-table cursor must skip the hidden AnnotationBlock"
+        );
+    }
+
+    #[test]
+    fn future_unannotated_function_does_not_hide_next_annotation_block() {
+        let code = compile_exec(
+            "\
+from __future__ import annotations
+def plain(x): pass
+def annotated(x: int): pass
+",
+        );
+        let annotate = find_direct_child_code(&code, "__annotate__")
+            .expect("second function must retain its annotation closure");
+        assert!(
+            annotate.constants.iter().any(
+                |constant| matches!(constant, ConstantData::Str { value } if value.as_str() == Ok("int"))
+            ),
+            "annotation closure must belong to the annotated function"
         );
     }
 


### PR DESCRIPTION
## Summary

- consume unused hidden function-signature annotation blocks under `from __future__ import annotations`
- keep the hidden annotation cursor aligned for the next function
- add a regression test for an unannotated function followed by an annotated one

## Root cause

The symbol table creates a hidden `AnnotationBlock` for every function signature while future annotations are active, including signatures with no annotations. Code generation returned early for an unused block without advancing the cursor, so the following function inspected the previous block and could lose its `__annotate__` closure.

This is observable through `functools.singledispatch`: a later annotated registration function can have an empty `__annotations__` mapping.

## Validation

- `cargo fmt --check -- crates/codegen/src/compile.rs`
- `cargo test -p rustpython-codegen` (784 passed)
- CPython/PyPy oracle: an unannotated function followed by `def annotated(x: int)` retains `{'x': 'int'}`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed annotation handling when unannotated and annotated functions appear together.
  * Ensured later annotated functions retain their annotation metadata correctly.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->