### PR TITLE
codegen: preserve symbol tables across copied finally bodies

### DIFF
--- a/crates/codegen/src/compile.rs
+++ b/crates/codegen/src/compile.rs
@@ -2406,7 +2406,13 @@ impl<'warnings> Compiler<'warnings> {
                 }
 
                 if let FBlockDatum::FinallyBody(ref body) = info.fb_datum {
+                    // This is an extra copy of the finally body, emitted for the
+                    // path that leaves the try block early. The try statement
+                    // emits its own copies afterwards, so rewind the symbol table
+                    // cursors and leave the nested scopes for those copies.
+                    let symbol_table_cursors = self.current_symbol_table_cursors();
                     self.compile_statements(body)?;
+                    self.set_symbol_table_cursors(symbol_table_cursors);
                 }
 
                 if preserve_tos {

--- a/extra_tests/snippets/syntax_try.py
+++ b/extra_tests/snippets/syntax_try.py
@@ -285,3 +285,85 @@ with assert_raises(SyntaxError):
 try:
     pass
 """)
+
+
+# leaving the try block early emits an extra copy of the finally body, which
+# must not consume the symbol tables of the nested scopes it contains
+def return_from_try():
+    log = []
+    try:
+        return "returned"
+    finally:
+        log.append((lambda x: x * 2)(3))
+        log.append({t for t in [1, 2]})
+        log.append([t for t in [3]])
+        log.append({k: k for k in [4]})
+
+        def nested():
+            return 5
+
+        class Nested:
+            value = 6
+
+        assert log == [6, {1, 2}, [3], {4: 4}], log
+        assert nested() == 5
+        assert Nested.value == 6
+
+
+assert return_from_try() == "returned"
+
+
+def break_and_continue_from_try():
+    seen = []
+    for i in range(4):
+        try:
+            if i == 1:
+                continue
+            if i == 3:
+                break
+            seen.append(i)
+        finally:
+            seen.append({t for t in [i]})
+    return seen
+
+
+assert break_and_continue_from_try() == [0, {0}, {1}, 2, {2}, {3}]
+
+
+def return_from_try_runs_finally_once():
+    log = []
+
+    def inner():
+        try:
+            return "value"
+        finally:
+            log.append(sorted({t for t in "ab"}))
+
+    assert inner() == "value"
+    return log
+
+
+assert return_from_try_runs_finally_once() == [["a", "b"]]
+
+
+def generator_return_from_try():
+    log = []
+
+    def gen():
+        try:
+            return (yield "yielded")
+        finally:
+            log.append([t for t in "z"])
+
+    g = gen()
+    assert g.send(None) == "yielded"
+    try:
+        g.send("sent")
+    except StopIteration as stop:
+        assert stop.value == "sent", stop.value
+    else:
+        assert False, "generator did not stop"
+    return log
+
+
+assert generator_return_from_try() == [["z"]]


### PR DESCRIPTION
## Summary

- preserve the current symbol-table cursors while codegen emits the extra copy of a `finally` body used by an early `return`, `break`, or `continue`
- add coverage for lambdas, comprehensions, nested functions, and nested classes in copied `finally` bodies

## Root cause

Leaving a `try` block early compiles its `finally` body once for the early-exit path and again for the statement's normal cleanup paths. The first copy consumed the nested-scope symbol-table cursors. When the later copy reached a comprehension or another nested scope, codegen reported `SyntaxError: no symbol table available`.

Saving and restoring all three cursor components around the early-exit copy makes that speculative emission cursor-neutral, matching the existing treatment of duplicated codegen paths.

This surfaced while importing pytest: `_pytest/pytester.py` has a generator hook that returns from a `try` and uses comprehensions in `finally`.

## Validation

- `cargo fmt --all -- --check`
- `cargo clippy --workspace --exclude rustpython_wasm --exclude rustpython-venvlauncher --exclude rustpython-capi --all-targets`
- `cargo test --workspace --exclude rustpython_wasm --exclude rustpython-venvlauncher --exclude rustpython-capi`
- `(cd crates/capi && cargo test)` — 102 passed
- CI-equivalent release build with `threading,jit` and the explicit stdlib/sqlite/rustls feature set
- `extra_tests`: 410 passed
- byte-compiled pytest 9.1.1's `_pytest/pytester.py`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed `try`/`finally` handling to preserve correct behavior after returns, breaks, and continues.
  * Ensured `finally` blocks execute exactly once during returns.
  * Corrected generator behavior when returning from `try` blocks, including proper `StopIteration` values.
  * Preserved nested comprehension and scope behavior in duplicated `finally` code.

* **Tests**
  * Added regression coverage for control flow, generators, nested scopes, and `try`/`finally` execution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->