### PR TITLE
Reject extra positional arguments to `float()`

### DIFF
--- a/crates/vm/src/builtins/float.rs
+++ b/crates/vm/src/builtins/float.rs
@@ -178,6 +178,7 @@ impl Constructor for PyFloat {
     fn slot_new(cls: PyTypeRef, args: FuncArgs, vm: &VirtualMachine) -> PyResult {
         // Optimization: return exact float as-is
         if cls.is(vm.ctx.types.float_type)
+            && args.args.len() == 1
             && args.kwargs.is_empty()
             && let Some(first) = args.args.first()
             && first.class().is(vm.ctx.types.float_type)

--- a/crates/vm/src/builtins/float.rs
+++ b/crates/vm/src/builtins/float.rs
@@ -176,17 +176,18 @@ impl Constructor for PyFloat {
     type Args = OptionalArg<PyObjectRef>;
 
     fn slot_new(cls: PyTypeRef, args: FuncArgs, vm: &VirtualMachine) -> PyResult {
+        // Bind before the fast path so FromArgs::arity decides how many arguments
+        // are acceptable, rather than a count repeated here.
+        let arg: Self::Args = args.bind(vm)?;
+
         // Optimization: return exact float as-is
         if cls.is(vm.ctx.types.float_type)
-            && args.args.len() == 1
-            && args.kwargs.is_empty()
-            && let Some(first) = args.args.first()
+            && let OptionalArg::Present(first) = &arg
             && first.class().is(vm.ctx.types.float_type)
         {
             return Ok(first.clone());
         }
 
-        let arg: Self::Args = args.bind(vm)?;
         let payload = Self::py_new(&cls, arg, vm)?;
         payload.into_ref_with_type(vm, cls).map(Into::into)
     }

--- a/extra_tests/snippets/builtin_float.py
+++ b/extra_tests/snippets/builtin_float.py
@@ -561,3 +561,12 @@ assert str(161852602146008.12) == "161852602146008.12"
 assert repr(1.5) == "1.5"
 assert repr(0.1) == "0.1"
 assert repr(100.0) == "100.0"
+
+
+# float() takes at most one positional argument; the exact-float fast path
+# must not let extra ones through.
+assert_raises(TypeError, float, 1.5, True)
+assert_raises(TypeError, float, 1.5, 2, 3)
+assert_raises(TypeError, float, "1.5", 2)
+assert float(1.5) == 1.5
+assert float() == 0.0


### PR DESCRIPTION
- [x] Closes #8461
- [x] This PR follows our [AI policy](https://github.com/RustPython/.github/blob/main/AI_POLICY.md)

## Summary

`PyFloat::slot_new`'s exact-float fast path tested `args.args.first()`, which succeeds for any number of positional arguments, so `float(1.5, True)` returned the first one and never reached `args.bind(vm)`. CPython's clinic-generated `float_new` runs `_PyArg_CheckPositional("float", nargs, 0, 1)` before it fetches the first argument.

#### AS-IS
```
>>> float(1.5, True)
1.5
```

#### TO-BE
```
>>> float(1.5, True)
TypeError: expected at most 1 arguments, got 2
```
(matching CPython, which raises `TypeError: float expected at most 1 argument, got 2`; the wording comes from `FuncArgs::bind` and is a separate repo-wide difference)

## Changes

- Add `args.args.len() == 1` to the fast path condition in `PyFloat::slot_new`, so an extra positional argument falls through to `args.bind(vm)`. `PyInt::slot_new`, `PyStr::slot_new` and `PyComplex::slot_new` already guard the same optimization this way; `float` was the one that did not.
- Add regression tests in `extra_tests/snippets/builtin_float.py` for two and three positional arguments, plus the unchanged `float(1.5)` and `float()` forms.

### Test plan

Built and run on macOS aarch64 against upstream/main `525ba8cf0`, using the CI feature set `--no-default-features --features stdlib,importlib,stdio,encodings,sqlite,ssl-rustls-aws-lc,host_env`.

- On an unpatched build of that commit `float(1.5, True)` returned `1.5`; with the patch it raises `TypeError`. `float(1.5)`, `float()`, `float("1.5")` and `float` subclass construction are unchanged.
- `cargo run --release -- -m test test_float test_builtin test_complex`: 229 run, 18 skipped, all pass.
- `cargo test --workspace --exclude rustpython-capi --exclude rustpython_wasm --exclude rustpython-compiler-source --exclude rustpython-venvlauncher --features threading`: 1107 pass, 0 fail. `cargo test` in `crates/capi`: 102 pass.
- `extra_tests` builtin snippets under RustPython: 66 of 67 pass, the new `builtin_float.py` cases among them. The one failure, `builtin_thread.py`, asserts `_thread.TIMEOUT_MAX in [9223372036.0, 4294967.0]` and my build reports `2147483648`, which is an unrelated platform constant.
- `cargo fmt --check` clean, `cargo clippy -p rustpython-vm --all-targets` reports nothing on the changed file, and `pre-commit run --files` passes on both changed files.

I used Claude Code (claude-opus-5) to draft the analysis, the patch and this description; I reviewed the change and ran every command above myself.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected `float()` so it rejects calls with multiple positional arguments.
  * Preserved existing behavior for valid single-argument calls, no-argument calls, and exact float values.

* **Tests**
  * Added coverage for invalid multi-argument calls involving floats and strings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->