### PR TITLE
Reject a fifth argument to `property()`

### DIFF
--- a/crates/vm/src/builtins/property.rs
+++ b/crates/vm/src/builtins/property.rs
@@ -1,7 +1,7 @@
 /*! Python `property` descriptor class.
 
 */
-use super::{PyStrRef, PyType};
+use super::PyType;
 use crate::common::lock::PyRwLock;
 use crate::function::{IntoFuncArgs, PosArgs};
 use crate::{
@@ -41,8 +41,6 @@ pub struct PropertyArgs {
     fdel: Option<PyObjectRef>,
     #[pyarg(any, default)]
     doc: Option<PyObjectRef>,
-    #[pyarg(any, default)]
-    name: Option<PyStrRef>,
 }
 
 impl GetDescriptor for PyProperty {
@@ -221,7 +219,6 @@ impl PyProperty {
             fset: new_setter.or_else(|| zelf.fset()),
             fdel: new_deleter.or_else(|| zelf.fdel()),
             doc,
-            name: None,
         };
 
         // Create new property using py_new and init
@@ -401,7 +398,6 @@ impl Initializer for PyProperty {
         *zelf.getter.write() = args.fget;
         *zelf.setter.write() = args.fset;
         *zelf.deleter.write() = args.fdel;
-        *zelf.name.write() = args.name.map(|a| a.as_object().to_owned());
         zelf.getter_doc.store(getter_doc, Ordering::Relaxed);
 
         Ok(())

--- a/extra_tests/snippets/builtin_property.py
+++ b/extra_tests/snippets/builtin_property.py
@@ -85,3 +85,10 @@ assert p1.__get__(None, object) is p1
 
 p2 = property("a", doc="pdoc")
 # assert p2.__doc__ == 'pdoc'
+
+
+# property() takes at most four arguments, and `name` is not one of them:
+# the name slot is filled by __set_name__ and the __name__ setter instead.
+assert_raises(TypeError, property, None, None, None, None, None)
+assert_raises(TypeError, property, "a", "b", "c", "d", "e")
+assert_raises(TypeError, property, name="x")


### PR DESCRIPTION
- [x] Closes #8460
- [x] This PR follows our [AI policy](https://github.com/RustPython/.github/blob/main/AI_POLICY.md)

## Summary

`PropertyArgs` declared a fifth positional-or-keyword field, `name`, so the derived arity was `0..=5` and `property(None, None, None, None, None)` built a `property` object with the fifth argument stored in the `__name__` slot. CPython's `property.__init__` is Argument Clinic generated with `maxpos = 4` and the keyword list `{fget, fset, fdel, doc}`, so it rejects both that call and `property(name='x')`.

#### AS-IS
```
>>> type(property(None, None, None, None, None))
<class 'property'>
>>> type(property(name='x'))
<class 'property'>
```

#### TO-BE
```
>>> property(None, None, None, None, None)
TypeError: expected at most 4 arguments, got 5
>>> property(name='x')
TypeError: Unexpected keyword argument name
```
(matching CPython, which raises `TypeError` for both; the message wording still comes from `FuncArgs::bind` rather than CPython's `property() takes at most 4 arguments (5 given)`, which is a separate repo-wide difference)

## Changes

- Remove the `name` field from `PropertyArgs` and the assignment that consumes it in `Initializer::init`, dropping the derived arity back to `0..=4`.
- Drop the now-dead `name: None` initializer in `clone_property_with` and the unused `PyStrRef` import. The `PyProperty` `name` slot is untouched and is still filled by `__set_name__` and the `__name__` setter.
- Add regression tests in `extra_tests/snippets/builtin_property.py` for the five-positional-argument and `name=` keyword forms.

### Test plan

Built and run on macOS aarch64 against upstream/main `525ba8cf0`, using the CI feature set `--no-default-features --features stdlib,importlib,stdio,encodings,sqlite,ssl-rustls-aws-lc,host_env`.

- On an unpatched build of that commit both forms produced a `property` object; with the patch both raise `TypeError`. Four-argument construction, the `getter`/`setter`/`deleter` builders and `__set_name__` still behave as before, and `__set_name__` still fills the name slot.
- `cargo run --release -- -m test test_property test_descr test_builtin`: 331 run, 36 skipped, all pass.
- `cargo test --workspace --exclude rustpython-capi --exclude rustpython_wasm --exclude rustpython-compiler-source --exclude rustpython-venvlauncher --features threading`: 1107 pass, 0 fail. `cargo test` in `crates/capi`: 102 pass.
- `extra_tests` builtin snippets under RustPython: 66 of 67 pass, the new `builtin_property.py` cases among them. The one failure, `builtin_thread.py`, asserts `_thread.TIMEOUT_MAX in [9223372036.0, 4294967.0]` and my build reports `2147483648`, which is an unrelated platform constant.
- `cargo fmt --check` clean, `cargo clippy -p rustpython-vm --all-targets` reports nothing on the changed file, and `pre-commit run --files` passes on both changed files.

I used Claude Code (claude-opus-5) to draft the analysis, the patch and this description; I reviewed the change and ran every command above myself.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected property handling so property names are managed consistently through standard name-assignment behavior.
  * `property()` now correctly rejects more than four positional arguments.
  * Unsupported `name` keyword arguments are now rejected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->