### PR TITLE
Normalize `round()` result to an exact `int`

### DIFF
--- a/crates/vm/src/builtins/int.rs
+++ b/crates/vm/src/builtins/int.rs
@@ -487,7 +487,9 @@ impl PyInt {
                 return vm.ctx.new_int(rounded);
             }
         }
-        zelf
+        // No rounding to do, but an int subclass must still be normalized to an
+        // exact int, the way CPython's long_long() does.
+        zelf.__int__(vm).into_pyref()
     }
 
     #[pymethod]

--- a/extra_tests/snippets/builtin_round.py
+++ b/extra_tests/snippets/builtin_round.py
@@ -93,3 +93,21 @@ assert math.copysign(1.0, round(0.0, 2)) == 1.0
 assert round(1.0, 1000) == 1.0
 assert round(1.0, -1000) == 0.0
 assert round(1.7976931348623157e308, 0) == 1.7976931348623157e308
+
+
+# round() normalizes an int subclass to an exact int, like CPython's long_long().
+assert round(True) == 1
+assert type(round(True)) is int
+assert type(round(True, 0)) is int
+assert type(round(False)) is int
+
+
+class MyInt(int):
+    pass
+
+
+assert round(MyInt(5)) == 5
+assert type(round(MyInt(5))) is int
+assert type(round(MyInt(5), 2)) is int
+# A negative ndigits already produced a fresh exact int.
+assert type(round(MyInt(15), -1)) is int


### PR DESCRIPTION
- [x] Closes #8459
- [x] This PR follows our [AI policy](https://github.com/RustPython/.github/blob/main/AI_POLICY.md)

## Summary

`round()` on an `int` subclass returned the receiver unchanged, so `round(True)` gave back `True` instead of `1`. CPython routes both no-rounding paths through `long_long()`, which reuses the reference only for an exact `int` and otherwise copies the value into a fresh one.

#### AS-IS
```
>>> round(True)
True
>>> type(round(True))
<class 'bool'>
```

#### TO-BE
```
>>> round(True)
1
>>> type(round(True))
<class 'int'>
```
(matching CPython)

## Changes

- Return `zelf.__int__(vm).into_pyref()` from `PyInt::__round__` instead of `zelf`, so an `int` subclass instance is copied into an exact `int` while an exact `int` is still returned as-is. This is the normalization the neighbouring `__trunc__`, `__floor__` and `__ceil__` already perform through `into_exact_or()`.
- Add regression tests in `extra_tests/snippets/builtin_round.py` covering `bool` and a user-defined `int` subclass, with and without `ndigits`.

### Test plan

Built and run on macOS aarch64 against upstream/main `525ba8cf0`, using the CI feature set `--no-default-features --features stdlib,importlib,stdio,encodings,sqlite,ssl-rustls-aws-lc,host_env`.

- On an unpatched build of that commit `round(True)` gave `True` and `round(MyInt(7))` gave a `MyInt`; with the patch both come back as exact `int`, matching CPython on every case I checked including `round(True, -1)`, `round(MyInt(15), -1)` and `round(12345, -2)`, which were already correct.
- `cargo run --release -- -m test test_builtin test_bool test_int test_long`: 268 run, 36 skipped, all pass, with no unexpected successes.
- `cargo test --workspace --exclude rustpython-capi --exclude rustpython_wasm --exclude rustpython-compiler-source --exclude rustpython-venvlauncher --features threading`: 1107 pass, 0 fail. `cargo test` in `crates/capi`: 102 pass.
- `extra_tests` builtin snippets under RustPython: 66 of 67 pass, the new `builtin_round.py` cases among them. The one failure, `builtin_thread.py`, asserts `_thread.TIMEOUT_MAX in [9223372036.0, 4294967.0]` and my build reports `2147483648`, which is an unrelated platform constant.
- `cargo fmt --check` clean, `cargo clippy -p rustpython-vm --all-targets` reports nothing on the changed file, and `pre-commit run --files` passes on both changed files.

I used Claude Code (claude-opus-5) to draft the analysis, the patch and this description; I reviewed the change and ran every command above myself.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Updated `round()` so rounding whole-number values consistently returns an exact integer, including for Boolean and integer subclasses.
  - Preserved correct behavior for both positive and negative decimal-place arguments.

- **Tests**
  - Added coverage for normalization of Boolean and integer subclasses when using `round()`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->