### PR TITLE
builtins: generate accurate __text_signature__

### DIFF
--- a/Lib/test/test_pydoc/test_pydoc.py
+++ b/Lib/test/test_pydoc/test_pydoc.py
@@ -1582,7 +1582,6 @@ class TestDescriptions(unittest.TestCase):
         self.assertEqual(self._get_summary_line(os.stat),
             "stat(path, *, dir_fd=None, follow_symlinks=True)")
 
-    @unittest.expectedFailure  # TODO: RUSTPYTHON
     def test_module_level_callable_noargs(self):
         self.assertEqual(self._get_summary_line(time.time),
             "time()")

--- a/crates/derive-impl/src/pyclass.rs
+++ b/crates/derive-impl/src/pyclass.rs
@@ -1096,7 +1096,10 @@ where
             args.attrs.push(allow_attr);
         }
 
-        let doc = args.attrs.doc().map(|doc| format_doc(&sig_doc, &doc));
+        let doc = args.attrs.doc().map(|doc| match &sig_doc {
+            Some(sig_doc) => format_doc(sig_doc, &doc),
+            None => doc,
+        });
         args.context.method_items.add_item(MethodNurseryItem {
             py_name,
             cfgs: args.cfgs.to_vec(),

--- a/crates/derive-impl/src/pymodule.rs
+++ b/crates/derive-impl/src/pymodule.rs
@@ -524,7 +524,7 @@ struct FunctionNurseryItem {
     py_names: Vec<String>,
     cfgs: Vec<Attribute>,
     ident: Ident,
-    doc: String,
+    doc: Option<String>,
     call_flags: TokenStream,
 }
 
@@ -556,8 +556,10 @@ impl ToTokens for ValidatedFunctionNursery {
             let cfgs = &item.cfgs;
             let cfgs = quote!(#(#cfgs)*);
             let py_names = &item.py_names;
-            let doc = &item.doc;
-            let doc = quote!(Some(#doc));
+            let doc = match &item.doc {
+                Some(doc) => quote!(Some(#doc)),
+                None => quote!(None),
+            };
             let flags = &item.call_flags;
 
             inner_tokens.extend(quote![
@@ -671,10 +673,10 @@ impl ModuleItem for FunctionItem {
                 .copied()
                 .map(str::to_owned)
         });
-        let doc = if let Some(doc) = doc {
-            format_doc(&sig_doc, &doc)
-        } else {
-            sig_doc
+        let doc = match (sig_doc, doc) {
+            (Some(sig_doc), Some(doc)) => Some(format_doc(&sig_doc, &doc)),
+            (Some(sig_doc), None) => Some(sig_doc),
+            (None, doc) => doc,
         };
 
         let py_names = {

--- a/crates/derive-impl/src/util.rs
+++ b/crates/derive-impl/src/util.rs
@@ -735,16 +735,17 @@ where
 //
 // Unlike CPython, a `#[pyfunction]` doesn't take the module as an argument,
 // so there's no module to mark with `$module`.
-pub(crate) fn text_signature(sig: &Signature, name: &str) -> String {
-    let signature = func_sig(sig);
+pub(crate) fn text_signature(sig: &Signature, name: &str) -> Option<String> {
+    let signature = func_sig(sig)?;
     // Arguments bind through `FuncArgs::take_positional`, which never consults
     // the keyword map, so they are positional-only. `*args`/`**kwargs` cannot be
     // followed by `/`, and an empty parameter list has nothing to mark.
-    if signature.is_empty() || signature.contains('*') {
+    let signature = if signature.is_empty() || signature.contains('*') {
         format!("{name}({signature})")
     } else {
         format!("{name}({signature}, /)")
-    }
+    };
+    Some(signature)
 }
 
 pub(crate) fn infer_native_call_flags(sig: &Signature, drop_first_typed: usize) -> TokenStream {
@@ -818,37 +819,45 @@ pub(crate) fn infer_native_call_flags(sig: &Signature, drop_first_typed: usize) 
     }
 }
 
-fn func_sig(sig: &Signature) -> String {
-    sig.inputs
-        .iter()
-        .filter_map(|arg| {
-            let arg = match arg {
-                FnArg::Typed(typed) => typed,
-                FnArg::Receiver(_) => return Some("$self".to_owned()),
-            };
-            let ty = arg.ty.as_ref();
-            let ty = quote!(#ty).to_string();
-            if ty == "FuncArgs" {
-                return Some("*args, **kwargs".to_owned());
+/// Returns None when an argument has no name to report, in which case no
+/// signature can be generated for the function.
+fn func_sig(sig: &Signature) -> Option<String> {
+    let mut params = Vec::new();
+    for arg in &sig.inputs {
+        let arg = match arg {
+            FnArg::Typed(typed) => typed,
+            FnArg::Receiver(_) => {
+                params.push("$self".to_owned());
+                continue;
             }
-            if ty.starts_with('&') && ty.ends_with("VirtualMachine") {
-                return None;
-            }
-            let ident = match arg.pat.as_ref() {
-                syn::Pat::Ident(p) => p.ident.to_string(),
-                // FIXME: other => unreachable!("function arg pattern must be ident but found `{}`", quote!(fn #ident(.. #other ..))),
-                other => quote!(#other).to_string(),
-            };
-            if ident == "zelf" {
-                return Some("$self".to_owned());
-            }
-            if ident == "vm" {
-                unreachable!("type &VirtualMachine(`{ty}`) must be filtered already");
-            }
-            Some(ident)
-        })
-        .collect::<Vec<_>>()
-        .join(", ")
+        };
+        let ty = arg.ty.as_ref();
+        let ty = quote!(#ty).to_string();
+        if ty == "FuncArgs" {
+            params.push("*args, **kwargs".to_owned());
+            continue;
+        }
+        if ty.starts_with('&') && ty.ends_with("VirtualMachine") {
+            continue;
+        }
+        // An argument bound by a destructuring pattern, e.g.
+        // `fn round(RoundArgs { number, ndigits }: RoundArgs, ..)`, has no name
+        // to report. Stringifying the pattern would emit Rust syntax, which
+        // makes inspect.signature() raise "invalid signature".
+        let syn::Pat::Ident(pat) = arg.pat.as_ref() else {
+            return None;
+        };
+        let ident = pat.ident.to_string();
+        if ident == "zelf" {
+            params.push("$self".to_owned());
+            continue;
+        }
+        if ident == "vm" {
+            unreachable!("type &VirtualMachine(`{ty}`) must be filtered already");
+        }
+        params.push(ident);
+    }
+    Some(params.join(", "))
 }
 
 pub(crate) fn format_doc(sig: &str, doc: &str) -> String {

--- a/crates/derive-impl/src/util.rs
+++ b/crates/derive-impl/src/util.rs
@@ -733,7 +733,7 @@ where
 // Best effort attempt to generate a template from which a
 // __text_signature__ can be created.
 //
-// Unlike CPython, a `#[pyfunction]` doesn't take the module as an argument,
+// Unlike CPython, a `#[pyfunction]` doesn't take the module as an argument yet,
 // so there's no module to mark with `$module`.
 pub(crate) fn text_signature(sig: &Signature, name: &str) -> Option<String> {
     let signature = func_sig(sig)?;

--- a/crates/derive-impl/src/util.rs
+++ b/crates/derive-impl/src/util.rs
@@ -732,13 +732,12 @@ where
 
 // Best effort attempt to generate a template from which a
 // __text_signature__ can be created.
+//
+// Unlike CPython, a `#[pyfunction]` doesn't take the module as an argument,
+// so there's no module to mark with `$module`.
 pub(crate) fn text_signature(sig: &Signature, name: &str) -> String {
     let signature = func_sig(sig);
-    if signature.starts_with("$self") {
-        format!("{name}({signature})")
-    } else {
-        format!("{}({}, {})", name, "$module", signature)
-    }
+    format!("{name}({signature})")
 }
 
 pub(crate) fn infer_native_call_flags(sig: &Signature, drop_first_typed: usize) -> TokenStream {

--- a/crates/derive-impl/src/util.rs
+++ b/crates/derive-impl/src/util.rs
@@ -737,7 +737,14 @@ where
 // so there's no module to mark with `$module`.
 pub(crate) fn text_signature(sig: &Signature, name: &str) -> String {
     let signature = func_sig(sig);
-    format!("{name}({signature})")
+    // Arguments bind through `FuncArgs::take_positional`, which never consults
+    // the keyword map, so they are positional-only. `*args`/`**kwargs` cannot be
+    // followed by `/`, and an empty parameter list has nothing to mark.
+    if signature.is_empty() || signature.contains('*') {
+        format!("{name}({signature})")
+    } else {
+        format!("{name}({signature}, /)")
+    }
 }
 
 pub(crate) fn infer_native_call_flags(sig: &Signature, drop_first_typed: usize) -> TokenStream {

--- a/crates/vm/src/stdlib/builtins.rs
+++ b/crates/vm/src/stdlib/builtins.rs
@@ -1007,7 +1007,7 @@ mod builtins {
     #[pyfunction]
     // builtin_ord
     fn ord(character: PyObjectRef, vm: &VirtualMachine) -> PyResult<u32> {
-        let bytes = if let Some(string) = c.downcast_ref::<PyStr>() {
+        let bytes = if let Some(string) = character.downcast_ref::<PyStr>() {
             return match string.as_wtf8().code_points().exactly_one() {
                 Ok(character) => Ok(character.to_u32()),
                 Err(_) => {
@@ -1017,14 +1017,14 @@ mod builtins {
                     )))
                 }
             };
-        } else if let Some(bytes) = c.downcast_ref::<PyBytes>() {
+        } else if let Some(bytes) = character.downcast_ref::<PyBytes>() {
             bytes.as_bytes().to_vec()
-        } else if let Some(bytearray) = c.downcast_ref::<PyByteArray>() {
+        } else if let Some(bytearray) = character.downcast_ref::<PyByteArray>() {
             bytearray.borrow_buf().to_vec()
         } else {
             return Err(vm.new_type_error(format!(
                 "ord() expected string of length 1, but {} found",
-                c.class().name()
+                character.class().name()
             )));
         };
         let bytes_len = bytes.len();

--- a/crates/vm/src/stdlib/builtins.rs
+++ b/crates/vm/src/stdlib/builtins.rs
@@ -74,8 +74,8 @@ mod builtins {
     }
 
     #[pyfunction]
-    fn bin(x: PyIntRef) -> String {
-        let x = x.as_bigint();
+    fn bin(number: PyIntRef) -> String {
+        let x = number.as_bigint();
         if x.is_negative() {
             format!("-0b{:b}", x.abs())
         } else {
@@ -391,11 +391,11 @@ mod builtins {
     }
 
     #[pyfunction]
-    fn delattr(obj: PyObjectRef, attr: PyObjectRef, vm: &VirtualMachine) -> PyResult<()> {
-        let attr = attr.try_to_ref::<PyStr>(vm).map_err(|_e| {
+    fn delattr(obj: PyObjectRef, name: PyObjectRef, vm: &VirtualMachine) -> PyResult<()> {
+        let attr = name.try_to_ref::<PyStr>(vm).map_err(|_e| {
             vm.new_type_error(format!(
                 "attribute name must be string, not '{}'",
-                attr.class().name()
+                name.class().name()
             ))
         })?;
         obj.del_attr(attr, vm)
@@ -407,8 +407,8 @@ mod builtins {
     }
 
     #[pyfunction]
-    fn divmod(a: PyObjectRef, b: PyObjectRef, vm: &VirtualMachine) -> PyResult {
-        vm._divmod(&a, &b)
+    fn divmod(x: PyObjectRef, y: PyObjectRef, vm: &VirtualMachine) -> PyResult {
+        vm._divmod(&x, &y)
     }
 
     #[derive(FromArgs)]
@@ -712,11 +712,11 @@ mod builtins {
     }
 
     #[pyfunction]
-    fn hasattr(obj: PyObjectRef, attr: PyObjectRef, vm: &VirtualMachine) -> PyResult<bool> {
-        let attr = attr.try_to_ref::<PyStr>(vm).map_err(|_e| {
+    fn hasattr(obj: PyObjectRef, name: PyObjectRef, vm: &VirtualMachine) -> PyResult<bool> {
+        let attr = name.try_to_ref::<PyStr>(vm).map_err(|_e| {
             vm.new_type_error(format!(
                 "attribute name must be string, not '{}'",
-                attr.class().name()
+                name.class().name()
             ))
         })?;
         Ok(vm.get_attribute_opt(obj, attr)?.is_some())
@@ -818,13 +818,21 @@ mod builtins {
     }
 
     #[pyfunction]
-    fn isinstance(obj: PyObjectRef, typ: PyObjectRef, vm: &VirtualMachine) -> PyResult<bool> {
-        obj.is_instance(&typ, vm)
+    fn isinstance(
+        obj: PyObjectRef,
+        class_or_tuple: PyObjectRef,
+        vm: &VirtualMachine,
+    ) -> PyResult<bool> {
+        obj.is_instance(&class_or_tuple, vm)
     }
 
     #[pyfunction]
-    fn issubclass(subclass: PyObjectRef, typ: PyObjectRef, vm: &VirtualMachine) -> PyResult<bool> {
-        subclass.is_subclass(&typ, vm)
+    fn issubclass(
+        cls: PyObjectRef,
+        class_or_tuple: PyObjectRef,
+        vm: &VirtualMachine,
+    ) -> PyResult<bool> {
+        cls.is_subclass(&class_or_tuple, vm)
     }
 
     #[pyfunction]
@@ -845,8 +853,8 @@ mod builtins {
     }
 
     #[pyfunction]
-    fn aiter(iter_target: PyObjectRef, vm: &VirtualMachine) -> PyResult {
-        iter_target.get_aiter(vm)
+    fn aiter(async_iterable: PyObjectRef, vm: &VirtualMachine) -> PyResult {
+        async_iterable.get_aiter(vm)
     }
 
     #[pyfunction]
@@ -994,8 +1002,8 @@ mod builtins {
     }
 
     #[pyfunction]
-    fn ord(string: Either<ArgBytesLike, PyStrRef>, vm: &VirtualMachine) -> PyResult<u32> {
-        match string {
+    fn ord(character: Either<ArgBytesLike, PyStrRef>, vm: &VirtualMachine) -> PyResult<u32> {
+        match character {
             Either::A(bytes) => bytes.with_ref(|bytes| {
                 let bytes_len = bytes.len();
                 if bytes_len != 1 {
@@ -1138,14 +1146,14 @@ mod builtins {
     #[pyfunction]
     fn setattr(
         obj: PyObjectRef,
-        attr: PyObjectRef,
+        name: PyObjectRef,
         value: PyObjectRef,
         vm: &VirtualMachine,
     ) -> PyResult<()> {
-        let attr = attr.try_to_ref::<PyStr>(vm).map_err(|_e| {
+        let attr = name.try_to_ref::<PyStr>(vm).map_err(|_e| {
             vm.new_type_error(format!(
                 "attribute name must be string, not '{}'",
-                attr.class().name()
+                name.class().name()
             ))
         })?;
         obj.set_attr(attr, value, vm)?;

--- a/extra_tests/snippets/builtin_signature.py
+++ b/extra_tests/snippets/builtin_signature.py
@@ -1,0 +1,64 @@
+import inspect
+
+# __text_signature__ is generated from the Rust parameter list, so it must not
+# describe parameters the function does not actually take, and must mark the
+# ones it does take as positional-only.
+
+# No phantom `module` parameter. RustPython's #[pyfunction]s take no module
+# argument, so `__self__` is None and inspect has nothing to strip.
+for f in (len, abs, hash, id, repr, bin, ord, divmod, hex, oct, chr, callable):
+    assert "module" not in inspect.signature(f).parameters, f.__name__
+
+# Plain arguments bind through take_positional(), so they are positional-only.
+try:
+    len(obj=[1, 2])
+except TypeError:
+    pass
+else:
+    raise AssertionError("len() should not accept keyword arguments")
+
+assert str(inspect.signature(len)) == "(obj, /)"
+assert str(inspect.signature(abs)) == "(x, /)"
+assert str(inspect.signature(hash)) == "(obj, /)"
+assert str(inspect.signature(chr)) == "(i, /)"
+assert str(inspect.signature(callable)) == "(obj, /)"
+
+assert (
+    inspect.signature(len).parameters["obj"].kind == inspect.Parameter.POSITIONAL_ONLY
+)
+
+# *args/**kwargs cannot be followed by `/`. The parameter names themselves still
+# differ from CPython here, which is out of scope.
+breakpoint_kinds = [p.kind for p in inspect.signature(breakpoint).parameters.values()]
+assert breakpoint_kinds == [
+    inspect.Parameter.VAR_POSITIONAL,
+    inspect.Parameter.VAR_KEYWORD,
+], breakpoint_kinds
+
+# Parameter names follow CPython, so signatures are directly comparable.
+assert str(inspect.signature(bin)) == "(number, /)"
+assert str(inspect.signature(ord)) == "(character, /)"
+assert str(inspect.signature(divmod)) == "(x, y, /)"
+assert str(inspect.signature(hasattr)) == "(obj, name, /)"
+assert str(inspect.signature(setattr)) == "(obj, name, value, /)"
+assert str(inspect.signature(delattr)) == "(obj, name, /)"
+assert str(inspect.signature(isinstance)) == "(obj, class_or_tuple, /)"
+assert str(inspect.signature(issubclass)) == "(cls, class_or_tuple, /)"
+assert str(inspect.signature(aiter)) == "(async_iterable, /)"
+
+# Functions whose Rust arguments are destructuring patterns rather than plain
+# names get no signature at all, instead of emitting text that is not valid
+# Python and makes inspect.signature() raise "invalid signature".
+#
+# CPython does have signatures for these, hand-written via Argument Clinic. We
+# cannot derive them until FromArgs reports its own parameters, so until then we
+# report no signature, which is at least how CPython behaves for the builtins it
+# has no signature for.
+for f in (round, sum):
+    assert f.__text_signature__ is None, f.__name__
+    try:
+        inspect.signature(f)
+    except ValueError as e:
+        assert "no signature found" in str(e), str(e)
+    else:
+        raise AssertionError(f"{f.__name__} should have no signature")

--- a/extra_tests/snippets/builtin_signature.py
+++ b/extra_tests/snippets/builtin_signature.py
@@ -1,4 +1,5 @@
 import inspect
+import sys
 
 # __text_signature__ is generated from the Rust parameter list, so it must not
 # describe parameters the function does not actually take, and must mark the
@@ -46,19 +47,20 @@ assert str(inspect.signature(isinstance)) == "(obj, class_or_tuple, /)"
 assert str(inspect.signature(issubclass)) == "(cls, class_or_tuple, /)"
 assert str(inspect.signature(aiter)) == "(async_iterable, /)"
 
-# Functions whose Rust arguments are destructuring patterns rather than plain
-# names get no signature at all, instead of emitting text that is not valid
-# Python and makes inspect.signature() raise "invalid signature".
-#
-# CPython does have signatures for these, hand-written via Argument Clinic. We
-# cannot derive them until FromArgs reports its own parameters, so until then we
-# report no signature, which is at least how CPython behaves for the builtins it
-# has no signature for.
-for f in (round, sum):
-    assert f.__text_signature__ is None, f.__name__
-    try:
-        inspect.signature(f)
-    except ValueError as e:
-        assert "no signature found" in str(e), str(e)
-    else:
-        raise AssertionError(f"{f.__name__} should have no signature")
+if sys.implementation.name == "rustpython":
+    # Functions whose Rust arguments are destructuring patterns rather than
+    # plain names get no signature at all, instead of emitting text that is not
+    # valid Python and makes inspect.signature() raise "invalid signature".
+    #
+    # CPython does have signatures for these, hand-written via Argument Clinic.
+    # We cannot derive them until FromArgs reports the parameters of its own
+    # structs, so until then we report no signature, which is at least how
+    # CPython behaves for the builtins it has no signature for.
+    for f in (round, sum):
+        assert f.__text_signature__ is None, f.__name__
+        try:
+            inspect.signature(f)
+        except ValueError as e:
+            assert "no signature found" in str(e), str(e)
+        else:
+            raise AssertionError(f"{f.__name__} should have no signature")


### PR DESCRIPTION
- [x] Related #8383
- [x] This PR follows our [AI policy](https://github.com/RustPython/.github/blob/main/AI_POLICY.md)

## Problem

RustPython's `#[pyfunction]`s generate a `__text_signature__` that isn't comparable to CPython's. Of the 45 builtin functions RustPython shares with CPython 3.14, none reported an identical `inspect.signature()` before this PR:

- 43 carried a phantom `module` parameter that doesn't exist.
- None marked their true positional-only parameters as such.
- 2 (`round`, `sum`) emitted a signature string that isn't valid Python, so `inspect.signature()` raised `ValueError: builtin has invalid signature`. The same applies to `os.pathconf`, `binascii.b2a_base64` and `binascii.b2a_uu` in the wider stdlib.

Tools that rely on `inspect.signature()` (`unittest.mock.autospec`, `pydoc`, IDE completion) act on this bad metadata.

## Scope

This PR fixes everything reachable by changing `crates/derive-impl/src/util.rs`'s signature generator alone, without touching `FromArgs` or adding new types. The `#[derive(FromArgs)]` struct case is deliberately left out, so #8383 stays open after this merges.

## What changed

- **Drop the `$module` marker.** CPython's C functions receive the module as `__self__`, so `inspect` strips a leading `$module`. RustPython's `#[pyfunction]`s take no module argument, so `__self__` is always `None` and there was nothing to strip. The marker surfaced as a parameter that doesn't exist (`len(module, /, obj)` instead of `len(obj)`).
- **Mark parameters positional-only.** Plain arguments bind through `FuncArgs::take_positional`, which never consults the keyword map: `len(obj=[1, 2])` already raised `TypeError`, but `inspect` reported `obj` as `POSITIONAL_OR_KEYWORD`. Generated signatures now carry the `/` marker, except for `*args`/`**kwargs` and empty parameter lists, which cannot have one.
- **Give up cleanly on unnamed parameters.** Some functions bind through a destructuring pattern (e.g. `fn round(RoundArgs { number, ndigits }: RoundArgs, ..)`). The generator used to stringify the Rust pattern verbatim, producing text that isn't valid Python. `inspect.signature()` still raises `ValueError` for these, but now with `no signature found for builtin`, matching how CPython reports a builtin it has no signature for, rather than `builtin has invalid signature`.
- **Rename 9 parameters to match CPython** (`bin`, `ord`, `divmod`, `setattr`, `delattr`, `hasattr`, `isinstance`, `issubclass`, `aiter`). All positional-only, so the name is documentation only and renaming doesn't change behavior.
- **Supporting changes.** `test_module_level_callable_noargs` in `Lib/test/test_pydoc/test_pydoc.py` now passes for real (the phantom `module` parameter was the cause), so its `expectedFailure` marker is dropped. The new snippet's "no signature" assertions are guarded to RustPython, since CPython has real Argument Clinic signatures for `round`/`sum`.

## Before / after

Measured across the 45 builtin functions RustPython and CPython 3.14 share:

| | exact match | `ValueError` | phantom `module` |
|---|---|---|---|
| before | 0 / 45 | 2 (`invalid signature`) | 43 |
| after | 23 / 45 | 2 (`no signature found`) | 0 |

The 22 that still differ fall into two groups that need different work.

**CPython documents a signature we could match (13).** Twelve of these hold their arguments in a type the signature generator can't see into: a `#[derive(FromArgs)]` struct (`__import__`, `compile`, `eval`, `exec`, `open`, `pow`, `print`, `sorted`, and `round`/`sum`, which now report no signature at all) or an `OptionalArg` whose default lives in the function body (`format`, `input`). The thirteenth, `breakpoint`, differs only because CPython names its keyword catch-all `**kws` and the generator hardcodes `**kwargs` for every `FuncArgs` function.

**CPython has no signature at all, and RustPython reports one (9).** `__build_class__`, `anext`, `dir`, `getattr`, `iter`, `max`, `min`, `next` and `vars`. Teaching `FromArgs` to report its parameters would not close this gap, since the generated signature is not what's wrong: matching CPython here means deciding to suppress a signature we are able to produce. `test_autospec_on_bound_builtin_function` stays `expectedFailure` for exactly this reason, via `time.ctime`.

## Not in this PR

Two follow-ups would close most of the first group above:

- **`FromArgs` reporting its own parameters.** Implementors would report the parameters they consume, mirroring how `arity()` already self-reports parameter count. The information is already there in each field's `#[pyarg(...)]` attribute; it just isn't reachable from the signature generator today.
- **`OptionalArg`'s hidden defaults**, which the same mechanism would have to carry.

The second group needs a separate decision about whether RustPython should suppress signatures CPython doesn't publish, which seems worth settling before either follow-up.

Two unrelated problems turned up while investigating, both out of scope here:

- **`__doc__` carries the raw signature prefix.** `len.__doc__` is `'len(obj, /)\n--\n\nReturn the number of items in a container.'`. `get_doc_from_internal_doc` (`type.rs`) strips this, but is only wired to `PyType.__doc__`, not to `builtin_func.rs` or `descriptor.rs`.
- **Methods have almost no signatures.** `pyclass.rs` only attaches a generated signature when the method already has a doc comment, so `list.append`, `str.split` and `dict.get` all report `__text_signature__` of `None`. This PR touches the `#[pymethod]` path only enough to keep it compiling.

## Test plan

- New `extra_tests/snippets/builtin_signature.py`, run under both CPython and RustPython.
- `cargo run --release -- -m test test_inspect test_pydoc test_unittest`
- `cargo test -p rustpython-derive-impl`
- `prek run --all-files`

Developed with assistance from Claude Code (claude-opus-5)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved builtin function signatures for clearer, more accurate display.
  * Removed phantom `module` parameters from displayed signatures.
  * Added correct positional-only and variadic parameter formatting.
  * Omitted signatures when they cannot be generated reliably.
  * Preserved documentation accurately when signatures are unavailable or incomplete.

* **Tests**
  * Added coverage for builtin signature formatting, parameter names, and edge cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->