### PR TITLE
ci: fix OSCCA pull request permissions

### DIFF
--- a/.github/workflows/oscca-pr.yml
+++ b/.github/workflows/oscca-pr.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-slim
     timeout-minutes: 5
     permissions:
-      issues: write
+      pull-requests: write
     steps:
       - name: Label and assign pull request
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0


### PR DESCRIPTION
## Summary

- grant the OSCCA triage job `pull-requests: write` instead of `issues: write`
- allow the job to apply the existing `z-ca-2026` label and assign matching PR authors

## Root cause

The workflow mutates pull request metadata but only requested the `issues: write` token scope. The label request therefore failed with `403 Resource not accessible by integration`, and the subsequent assignment request was never reached.

Example failure: https://github.com/RustPython/RustPython/actions/runs/31683869400

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated pull request automation permissions to support labeling and assignment operations correctly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->