### PR TITLE
_sre: drive an all-ASCII str subject over its bytes

### DIFF
--- a/crates/sre_engine/src/engine.rs
+++ b/crates/sre_engine/src/engine.rs
@@ -581,7 +581,11 @@ fn _match<S: StrDrive>(req: &Request<'_, S>, state: &mut State, mut ctx: MatchCo
                                 ..ctx
                             };
 
-                            for _ in group_start..group_end {
+                            // Walk the group itself rather than counting to its
+                            // width: `g_ctx` is already stepping over exactly
+                            // the characters being compared, so its own cursor
+                            // is the loop bound.
+                            while g_ctx.cursor.position < group_end {
                                 #[allow(clippy::redundant_closure_call)]
                                 if ctx.at_end(req)
                                     || $f(ctx.peek_char::<S>()) != $f(g_ctx.peek_char::<S>())

--- a/crates/sre_engine/src/string.rs
+++ b/crates/sre_engine/src/string.rs
@@ -1,5 +1,12 @@
 use rustpython_wtf8::Wtf8;
 
+/// A position in the subject, paired with the byte pointer it resolves to.
+///
+/// `position` is a **character index**, never a byte offset. The engine does
+/// arithmetic on it directly — it subtracts two positions to get a character
+/// count, adds a repeat count to get a bound, and compares one against a
+/// lookbehind width — so the unit is part of the [`StrDrive`] contract rather
+/// than a detail each implementation may pick.
 #[derive(Debug, Clone, Copy)]
 pub struct StringCursor {
     pub(crate) ptr: *const u8,
@@ -15,15 +22,43 @@ impl Default for StringCursor {
     }
 }
 
+/// Random access over the subject being matched.
+///
+/// An implementation chooses how a character is spelled in memory — one byte
+/// for `&[u8]`, one code point for `&str` and `&Wtf8` — but **not** how
+/// positions are counted. Every position this trait produces or consumes is a
+/// character index: `count` is the subject's length in characters, and
+/// `skip(n)` advances a cursor's `position` by exactly `n`.
+///
+/// That is load-bearing, not incidental. The engine reads position arithmetic
+/// as character arithmetic in several places — `_count` bounds a repeat with
+/// `position + max_count` and reports the repeat's length as a difference of
+/// positions, `ASSERT` tests `position < back` against a lookbehind width, and
+/// `search_info` recovers a match start as `position - (len - 1)`. A drive
+/// that stored byte offsets here would leave all of those type-correct and
+/// silently wrong, and would index a lookbehind out of bounds.
+///
+/// So a drive over a variable-width encoding pays for the mapping: `count`
+/// and `create_cursor` have to resolve character indices, and cannot simply
+/// hand back byte lengths and byte offsets.
 pub trait StrDrive: Copy {
+    /// The subject's length, in characters.
     fn count(&self) -> usize;
+    /// A cursor at character index `n`.
     fn create_cursor(&self, n: usize) -> StringCursor;
+    /// Move `cursor` to character index `n`, from wherever it is now.
     fn adjust_cursor(&self, cursor: &mut StringCursor, n: usize);
+    /// Consume one character, returning it; `position` grows by one.
     fn advance(cursor: &mut StringCursor) -> u32;
+    /// The character at `cursor`, without moving it.
     fn peek(cursor: &StringCursor) -> u32;
+    /// Skip `n` characters, so `position` grows by exactly `n`.
     fn skip(cursor: &mut StringCursor, n: usize);
+    /// Step back over one character, returning it; `position` shrinks by one.
     fn back_advance(cursor: &mut StringCursor) -> u32;
+    /// The character before `cursor`, without moving it.
     fn back_peek(cursor: &StringCursor) -> u32;
+    /// Step back `n` characters, so `position` shrinks by exactly `n`.
     fn back_skip(cursor: &mut StringCursor, n: usize);
 }
 

--- a/crates/vm/src/stdlib/_sre.rs
+++ b/crates/vm/src/stdlib/_sre.rs
@@ -22,7 +22,7 @@ mod _sre {
     use itertools::Itertools;
     use num_traits::ToPrimitive;
     use rustpython_sre_engine::{
-        Request, SearchIter, SreFlag, State, StrDrive,
+        Request, SearchIter, SreFlag, State, StrDrive, StringCursor,
         string::{lower_ascii, lower_unicode},
     };
 
@@ -80,6 +80,72 @@ mod _sre {
                         .collect::<Wtf8Buf>(),
                 )
                 .into()
+        }
+    }
+
+    /// An all-ASCII `str` subject, driven over its bytes.
+    ///
+    /// For ASCII a character index *is* a byte index, so `&[u8]`'s cursor
+    /// arithmetic is already the right arithmetic: `count` is the byte length
+    /// and `create_cursor` is a pointer offset. The `&Wtf8` drive has to count
+    /// code points from the start of the subject to answer either, once per
+    /// `Request`, which makes a scan that restarts at successive positions --
+    /// `finditer`, or `re` module functions called in a loop -- walk the
+    /// subject again on every call.
+    ///
+    /// Matching is unaffected: `StrDrive` carries no unicode semantics of its
+    /// own, because the engine keys every unicode decision on the compiled
+    /// pattern's opcode rather than on the subject type. Only `slice` differs
+    /// from the `&[u8]` impl, to hand back `str` instead of `bytes`.
+    #[derive(Clone, Copy)]
+    struct AsciiStr<'a>(&'a [u8]);
+
+    impl StrDrive for AsciiStr<'_> {
+        fn count(&self) -> usize {
+            <&[u8] as StrDrive>::count(&self.0)
+        }
+
+        fn create_cursor(&self, n: usize) -> StringCursor {
+            <&[u8] as StrDrive>::create_cursor(&self.0, n)
+        }
+
+        fn adjust_cursor(&self, cursor: &mut StringCursor, n: usize) {
+            <&[u8] as StrDrive>::adjust_cursor(&self.0, cursor, n)
+        }
+
+        fn advance(cursor: &mut StringCursor) -> u32 {
+            <&[u8] as StrDrive>::advance(cursor)
+        }
+
+        fn peek(cursor: &StringCursor) -> u32 {
+            <&[u8] as StrDrive>::peek(cursor)
+        }
+
+        fn skip(cursor: &mut StringCursor, n: usize) {
+            <&[u8] as StrDrive>::skip(cursor, n)
+        }
+
+        fn back_advance(cursor: &mut StringCursor) -> u32 {
+            <&[u8] as StrDrive>::back_advance(cursor)
+        }
+
+        fn back_peek(cursor: &StringCursor) -> u32 {
+            <&[u8] as StrDrive>::back_peek(cursor)
+        }
+
+        fn back_skip(cursor: &mut StringCursor, n: usize) {
+            <&[u8] as StrDrive>::back_skip(cursor, n)
+        }
+    }
+
+    impl SreStr for AsciiStr<'_> {
+        fn slice(&self, start: usize, end: usize, vm: &VirtualMachine) -> PyObjectRef {
+            let end = end.min(self.0.len());
+            let start = start.min(end);
+            // The subject is ASCII, so any span of it is valid UTF-8 and the
+            // span is a reslice rather than a walk from the subject's start.
+            let s = str::from_utf8(&self.0[start..end]).expect("ascii subject");
+            vm.ctx.new_str(s).into()
         }
     }
 
@@ -200,13 +266,18 @@ mod _sre {
     }
 
     macro_rules! with_sre_str {
-        ($pattern:expr, $string:expr, $vm:expr, $f:expr) => {
+        ($pattern:expr, $string:expr, $vm:expr, $f:expr) => {{
+            // Bind once: the branches only borrow the subject, and callers pass
+            // a temporary (`&x.clone()`) that would otherwise be rebuilt per arm.
+            let subject = $string;
             if $pattern.isbytes {
-                Pattern::with_bytes($string, $vm, $f)
+                Pattern::with_bytes(subject, $vm, $f)
+            } else if Pattern::is_ascii_str(subject) {
+                Pattern::with_ascii_str(subject, $vm, $f)
             } else {
-                Pattern::with_str($string, $vm, $f)
+                Pattern::with_str(subject, $vm, $f)
             }
-        };
+        }};
     }
 
     #[pyclass(with(Hashable, Comparable, Representable), flags(HAS_WEAKREF))]
@@ -219,6 +290,27 @@ mod _sre {
                 vm.new_type_error(format!("expected string got '{}'", string.class()))
             })?;
             f(string.as_wtf8())
+        }
+
+        /// Whether a `str` subject can take the [`AsciiStr`] drive.
+        ///
+        /// `PyStr` already knows: `StrKind` is decided when the string is
+        /// built, so this is a field load rather than a scan. A non-`str`
+        /// argument answers `false` and is reported by [`Self::with_str`].
+        fn is_ascii_str(string: &PyObject) -> bool {
+            string
+                .downcast_ref::<PyStr>()
+                .is_some_and(|s| s.kind().is_ascii())
+        }
+
+        fn with_ascii_str<F, R>(string: &PyObject, vm: &VirtualMachine, f: F) -> PyResult<R>
+        where
+            F: FnOnce(AsciiStr<'_>) -> PyResult<R>,
+        {
+            let string = string.downcast_ref::<PyStr>().ok_or_else(|| {
+                vm.new_type_error(format!("expected string got '{}'", string.class()))
+            })?;
+            f(AsciiStr(string.as_wtf8().as_bytes()))
         }
 
         fn with_bytes<F, R>(string: &PyObject, vm: &VirtualMachine, f: F) -> PyResult<R>


### PR DESCRIPTION
`re.finditer` over an all-ASCII `str` was quadratic in the subject's length.

## Why it was quadratic

`StrDrive` positions are character indices, so the `&Wtf8` drive answers `count()` by counting
code points from the start of the subject, and `create_cursor(n)` by walking to `n`. Both are
O(n). A scan that restarts at successive positions pays that setup once per step, so the subject
is walked again for every match.

For an ASCII subject a character index *is* a byte index, so `&[u8]`'s cursor arithmetic is
already the right arithmetic: `count` is the byte length and `create_cursor` is a pointer offset.
`AsciiStr` is a newtype that takes `&[u8]`'s `StrDrive` and overrides only `slice`, to hand back
`str` instead of `bytes`. `with_sre_str!` selects it on `StrKind::is_ascii()`, which `PyStr`
decided when the string was built, so the choice is a field load and not a scan.

Matching is unaffected by the choice: `StrDrive` carries no unicode semantics of its own, because
the engine keys every unicode decision on the compiled pattern's opcode rather than on the
subject type.

## Measurements

`re.compile(r"\d+")` over `("item%04d " % 7) * n`, best of 3, same machine and base commit for
both columns (`x` is the factor over the previous row, so 4 is quadratic and 2 is linear):

| n | finditer before | finditer after | `m.group(0)` before | `m.group(0)` after |
|---|---|---|---|---|
| 5000 | 36.56 ms | 1.21 ms | 98.07 ms | 1.91 ms |
| 10000 | 147.56 ms (x4.04) | 2.25 ms (x1.87) | 352.25 ms (x3.59) | 3.81 ms (x1.99) |
| 20000 | 592.97 ms (x4.02) | 4.52 ms (x2.01) | 1288.47 ms (x3.66) | 8.03 ms (x2.11) |
| 40000 | 2367.13 ms (x3.99) | 9.41 ms (x2.08) | 4988.72 ms (x3.87) | 15.98 ms (x1.99) |

The two arms this does not touch, as controls in the same runs:

| n=40000 | before | after |
|---|---|---|
| non-ASCII `str` finditer (`&Wtf8` drive) | 5048.97 ms | 4908.55 ms |
| `bytes` finditer (`&[u8]` drive) | 10.75 ms | 9.67 ms |

Non-ASCII `str` is unchanged and still quadratic. Removing that needs a character-index to
byte-offset mapping stored on `PyStr`, which is a separate change.

## Correctness

- `test_re`: run=166, skipped=14, SUCCESS.
- A differential over the ASCII/non-ASCII boundary — 26 patterns × 15 subjects × 7 operations
  (`findall`, `finditer` spans/groups, `sub`, `split`, `match`, `search`, `fullmatch`) — produces
  2731 lines of output that are identical on CPython 3.14.6 and on this branch. The subjects
  include the empty string, pure ASCII, mixed strings where only the first/middle/last character
  is non-ASCII, Korean, emoji, a lone surrogate, and an embedded NUL, so both drives are
  exercised and the split between them is covered from either side.

## The first commit

`sre_engine: document that StrDrive positions are character indices` writes down the unit
`StringCursor::position` is in and which engine sites depend on it: `_count` bounds a repeat with
`position + max_count`, `ASSERT` compares a position against a lookbehind width, and
`search_info` recovers a match start as `position - (len - 1)`. A drive that stored byte offsets
there would leave all of them type-correct and silently wrong; `AsciiStr` is only sound because
ASCII makes the two units coincide.

It also rewrites the `GROUPREF` comparison loop as `while g_ctx.cursor.position < group_end`
instead of `for _ in group_start..group_end`, since `g_ctx` is already stepping over exactly the
characters being compared. Both spellings iterate the same number of times, and the normalized
machine code for the crate's consumers is byte-identical across the change (1,217,188 lines
compared), so it is a readability change only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved group-reference matching to handle character positions correctly.
  * Enhanced regular-expression processing for ASCII and Unicode strings.
  * Improved handling of string subjects across different character encodings.

* **Documentation**
  * Clarified cursor positioning and character-to-byte mapping behavior for string processing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->