### PR TITLE
Fix int unicode decimal digits

### DIFF
--- a/Lib/test/test_decimal.py
+++ b/Lib/test/test_decimal.py
@@ -854,7 +854,6 @@ class CExplicitConstructionTest(ExplicitConstructionTest, unittest.TestCase):
 class PyExplicitConstructionTest(ExplicitConstructionTest, unittest.TestCase):
     decimal = P
 
-    @unittest.expectedFailure  # TODO: RUSTPYTHON
     def test_unicode_digits(self):
         return super().test_unicode_digits()
 

--- a/Lib/test/test_decimal.py
+++ b/Lib/test/test_decimal.py
@@ -854,9 +854,6 @@ class CExplicitConstructionTest(ExplicitConstructionTest, unittest.TestCase):
 class PyExplicitConstructionTest(ExplicitConstructionTest, unittest.TestCase):
     decimal = P
 
-    def test_unicode_digits(self):
-        return super().test_unicode_digits()
-
 class ImplicitConstructionTest:
     '''Unit tests for Implicit Construction cases of Decimal.'''
 

--- a/Lib/test/test_int.py
+++ b/Lib/test/test_int.py
@@ -247,7 +247,6 @@ class IntTestCases(unittest.TestCase):
         with self.assertRaises(ValueError):
             int(' + 1 ')
 
-    @unittest.expectedFailure  # TODO: RUSTPYTHON
     def test_unicode(self):
         self.assertEqual(int("१२३४५६७८९०1234567890"), 12345678901234567890)
         self.assertEqual(int('١٢٣٤٥٦٧٨٩٠'), 1234567890)

--- a/crates/common/src/str.rs
+++ b/crates/common/src/str.rs
@@ -2,6 +2,7 @@
 use crate::atomic::{PyAtomic, Radium};
 use crate::format::CharLen;
 use crate::wtf8::{CodePoint, Wtf8, Wtf8Buf};
+use alloc::borrow::Cow;
 use ascii::{AsciiChar, AsciiStr, AsciiString};
 use core::fmt;
 use core::ops::{Bound, RangeBounds};
@@ -658,9 +659,62 @@ pub fn char_to_decimal(ch: char) -> Option<u8> {
         .map(|i| (i % 10) as u8)
 }
 
+/// Replace Unicode decimal digits with their ASCII equivalents and any Unicode
+/// whitespace with a plain space, so the byte-oriented numeric parsers can read
+/// them. Mirrors CPython's `_PyUnicode_TransformDecimalAndSpaceToASCII`.
+///
+/// The result is always ASCII. Any other non-ASCII character cannot appear in a
+/// numeric literal, so it becomes a `?` and the rest of the string is dropped:
+/// `?` is rejected by every parser at every base, which leaves the caller — the
+/// one that knows the base and owns the original string — to raise the error.
+#[must_use]
+pub fn transform_decimal_and_space_to_ascii(s: &str) -> Cow<'_, str> {
+    if s.is_ascii() {
+        return Cow::Borrowed(s);
+    }
+    let mut out = String::with_capacity(s.len());
+    for c in s.chars() {
+        if (c as u32) < 127 {
+            out.push(c);
+        } else if c.is_whitespace() {
+            out.push(' ');
+        } else if let Some(n) = char_to_decimal(c) {
+            out.push(char::from_digit(n.into(), 10).unwrap());
+        } else {
+            out.push('?');
+            break;
+        }
+    }
+    debug_assert!(out.is_ascii());
+    Cow::Owned(out)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn transform_decimal_and_space() {
+        // ASCII input is passed through untouched, without allocating.
+        assert!(matches!(
+            transform_decimal_and_space_to_ascii("123"),
+            Cow::Borrowed("123")
+        ));
+        // Decimal digits from any script fold to ASCII.
+        assert_eq!(transform_decimal_and_space_to_ascii("١٢٣"), "123");
+        assert_eq!(transform_decimal_and_space_to_ascii("１２३"), "123");
+        assert_eq!(transform_decimal_and_space_to_ascii("1٢3"), "123");
+        // Unicode whitespace folds to a plain space.
+        assert_eq!(transform_decimal_and_space_to_ascii("\u{3000}٣"), " 3");
+        // ASCII characters ride through untouched, whatever they are.
+        assert_eq!(transform_decimal_and_space_to_ascii("0x١f"), "0x1f");
+        assert_eq!(transform_decimal_and_space_to_ascii("-١_٢"), "-1_2");
+        // Anything else poisons the literal and truncates it, so the result stays
+        // ASCII and the caller's parser is guaranteed to reject it.
+        assert_eq!(transform_decimal_and_space_to_ascii("½가"), "?");
+        assert_eq!(transform_decimal_and_space_to_ascii("١٢가٣"), "12?");
+        assert_eq!(transform_decimal_and_space_to_ascii("١\u{7f}"), "1?");
+    }
 
     #[test]
     fn get_chars_basic() {

--- a/crates/vm/src/builtins/complex.rs
+++ b/crates/vm/src/builtins/complex.rs
@@ -220,11 +220,10 @@ impl Constructor for PyComplex {
                             "complex() can't take second arg if first is a string",
                         ));
                     }
-                    let (re, im) = s
-                        .to_str()
-                        .map(crate::common::str::transform_decimal_and_space_to_ascii)
-                        .and_then(|s| rustpython_literal::complex::parse_str(&s))
-                        .ok_or_else(|| vm.new_value_error("complex() arg is a malformed string"))?;
+                    let (re, im) = rustpython_literal::complex::parse_str(
+                        &crate::protocol::numeric_literal_from_str(s),
+                    )
+                    .ok_or_else(|| vm.new_value_error("complex() arg is a malformed string"))?;
                     return Ok(Self::from(Complex64 { re, im }));
                 } else {
                     return Err(vm.new_type_error(format!(

--- a/crates/vm/src/builtins/complex.rs
+++ b/crates/vm/src/builtins/complex.rs
@@ -222,7 +222,8 @@ impl Constructor for PyComplex {
                     }
                     let (re, im) = s
                         .to_str()
-                        .and_then(rustpython_literal::complex::parse_str)
+                        .map(crate::common::str::transform_decimal_and_space_to_ascii)
+                        .and_then(|s| rustpython_literal::complex::parse_str(&s))
                         .ok_or_else(|| vm.new_value_error("complex() arg is a malformed string"))?;
                     return Ok(Self::from(Complex64 { re, im }));
                 } else {

--- a/crates/vm/src/builtins/float.rs
+++ b/crates/vm/src/builtins/float.rs
@@ -212,19 +212,8 @@ pub fn float_from_string(val: PyObjectRef, vm: &VirtualMachine) -> PyResult<f64>
         match s.as_str_kind() {
             PyKindStr::Ascii(s) => s.trim().as_bytes(),
             PyKindStr::Utf8(s) => {
-                mapped_string = s
-                    .trim()
-                    .chars()
-                    .map(|c| {
-                        if let Some(n) = rustpython_common::str::char_to_decimal(c) {
-                            char::from_digit(n.into(), 10).unwrap()
-                        } else if c.is_whitespace() {
-                            ' '
-                        } else {
-                            c
-                        }
-                    })
-                    .collect::<String>();
+                mapped_string =
+                    rustpython_common::str::transform_decimal_and_space_to_ascii(s.trim());
                 mapped_string.as_bytes()
             }
             // if there are surrogates, it's not gonna parse anyway,

--- a/crates/vm/src/builtins/float.rs
+++ b/crates/vm/src/builtins/float.rs
@@ -208,18 +208,8 @@ impl Constructor for PyFloat {
 pub fn float_from_string(val: PyObjectRef, vm: &VirtualMachine) -> PyResult<f64> {
     let (bytearray, buffer, buffer_lock, mapped_string);
     let b = if let Some(s) = val.downcast_ref::<PyStr>() {
-        use crate::common::str::PyKindStr;
-        match s.as_str_kind() {
-            PyKindStr::Ascii(s) => s.trim().as_bytes(),
-            PyKindStr::Utf8(s) => {
-                mapped_string =
-                    rustpython_common::str::transform_decimal_and_space_to_ascii(s.trim());
-                mapped_string.as_bytes()
-            }
-            // if there are surrogates, it's not gonna parse anyway,
-            // so we can just choose a known bad value
-            PyKindStr::Wtf8(_) => b"",
-        }
+        mapped_string = crate::protocol::numeric_literal_from_str(s);
+        mapped_string.as_bytes()
     } else if let Some(bytes) = val.downcast_ref::<PyBytes>() {
         bytes.as_bytes()
     } else if let Some(buf) = val.downcast_ref::<PyByteArray>() {

--- a/crates/vm/src/builtins/int.rs
+++ b/crates/vm/src/builtins/int.rs
@@ -9,6 +9,7 @@ use crate::{
         format::FormatSpec,
         hash,
         int::{bigint_to_finite_float, bytes_to_int, true_div},
+        str::{PyKindStr, transform_decimal_and_space_to_ascii},
         wtf8::Wtf8Buf,
     },
     convert::{IntoPyException, ToPyObject, ToPyResult},
@@ -19,6 +20,7 @@ use crate::{
     protocol::{PyNumberMethods, handle_bytes_to_int_err},
     types::{AsNumber, Comparable, Constructor, Hashable, PyComparisonOp, Representable},
 };
+use alloc::borrow::Cow;
 use alloc::fmt;
 use core::cell::Cell;
 use core::ops::{Neg, Not};
@@ -801,10 +803,22 @@ struct IntToByteArgs {
     signed: OptionalArg<ArgIntoBool>,
 }
 
+/// Normalize a `str` for the byte-oriented int parser: Unicode decimal digits and
+/// whitespace fold to their ASCII equivalents, the way CPython's
+/// `PyLong_FromUnicodeObject` does. A string holding surrogates can never be a
+/// valid literal, so it folds to an empty — and therefore invalid — one.
+pub(crate) fn int_literal_from_str(s: &PyStr) -> Cow<'_, str> {
+    match s.as_str_kind() {
+        PyKindStr::Ascii(s) => Cow::Borrowed(s.trim().as_str()),
+        PyKindStr::Utf8(s) => transform_decimal_and_space_to_ascii(s.trim()),
+        PyKindStr::Wtf8(_) => Cow::Borrowed(""),
+    }
+}
+
 fn try_int_radix(obj: &PyObject, base: u32, vm: &VirtualMachine) -> PyResult<BigInt> {
     match_class!(match obj.to_owned() {
         string @ PyStr => {
-            let s = string.as_wtf8().trim();
+            let s = int_literal_from_str(&string);
             bytes_to_int(s.as_bytes(), base, vm.state.int_max_str_digits.load())
                 .map_err(|e| handle_bytes_to_int_err(e, obj, vm))
         }

--- a/crates/vm/src/builtins/int.rs
+++ b/crates/vm/src/builtins/int.rs
@@ -9,7 +9,6 @@ use crate::{
         format::FormatSpec,
         hash,
         int::{bigint_to_finite_float, bytes_to_int, true_div},
-        str::{PyKindStr, transform_decimal_and_space_to_ascii},
         wtf8::Wtf8Buf,
     },
     convert::{IntoPyException, ToPyObject, ToPyResult},
@@ -17,10 +16,9 @@ use crate::{
         ArgByteOrder, ArgIntoBool, FuncArgs, OptionalArg, OptionalOption, PyArithmeticValue,
         PyComparisonValue,
     },
-    protocol::{PyNumberMethods, handle_bytes_to_int_err},
+    protocol::{PyNumberMethods, handle_bytes_to_int_err, numeric_literal_from_str},
     types::{AsNumber, Comparable, Constructor, Hashable, PyComparisonOp, Representable},
 };
-use alloc::borrow::Cow;
 use alloc::fmt;
 use core::cell::Cell;
 use core::ops::{Neg, Not};
@@ -803,22 +801,10 @@ struct IntToByteArgs {
     signed: OptionalArg<ArgIntoBool>,
 }
 
-/// Normalize a `str` for the byte-oriented int parser: Unicode decimal digits and
-/// whitespace fold to their ASCII equivalents, the way CPython's
-/// `PyLong_FromUnicodeObject` does. A string holding surrogates can never be a
-/// valid literal, so it folds to an empty — and therefore invalid — one.
-pub(crate) fn int_literal_from_str(s: &PyStr) -> Cow<'_, str> {
-    match s.as_str_kind() {
-        PyKindStr::Ascii(s) => Cow::Borrowed(s.trim().as_str()),
-        PyKindStr::Utf8(s) => transform_decimal_and_space_to_ascii(s.trim()),
-        PyKindStr::Wtf8(_) => Cow::Borrowed(""),
-    }
-}
-
 fn try_int_radix(obj: &PyObject, base: u32, vm: &VirtualMachine) -> PyResult<BigInt> {
     match_class!(match obj.to_owned() {
         string @ PyStr => {
-            let s = int_literal_from_str(&string);
+            let s = numeric_literal_from_str(&string);
             bytes_to_int(s.as_bytes(), base, vm.state.int_max_str_digits.load())
                 .map_err(|e| handle_bytes_to_int_err(e, obj, vm))
         }

--- a/crates/vm/src/protocol/mod.rs
+++ b/crates/vm/src/protocol/mod.rs
@@ -14,5 +14,6 @@ pub use mapping::{PyMapping, PyMappingMethods, PyMappingSlots};
 pub use number::{
     PyNumber, PyNumberBinaryFunc, PyNumberBinaryOp, PyNumberMethods, PyNumberSlots,
     PyNumberTernaryFunc, PyNumberTernaryOp, PyNumberUnaryFunc, handle_bytes_to_int_err,
+    numeric_literal_from_str,
 };
 pub use sequence::{PySequence, PySequenceMethods, PySequenceSlots};

--- a/crates/vm/src/protocol/number.rs
+++ b/crates/vm/src/protocol/number.rs
@@ -59,7 +59,7 @@ impl PyObject {
         } else if let Some(i) = self.number().int(vm).or_else(|| self.try_index_opt(vm)) {
             i
         } else if let Some(s) = self.downcast_ref::<PyStr>() {
-            try_convert(self, s.as_wtf8().trim().as_bytes(), vm)
+            try_convert(self, int::int_literal_from_str(s).as_bytes(), vm)
         } else if let Some(bytes) = self.downcast_ref::<PyBytes>() {
             try_convert(self, bytes, vm)
         } else if let Some(bytearray) = self.downcast_ref::<PyByteArray>() {

--- a/crates/vm/src/protocol/number.rs
+++ b/crates/vm/src/protocol/number.rs
@@ -8,11 +8,34 @@ use crate::{
     builtins::{
         PyBaseExceptionRef, PyByteArray, PyBytes, PyComplex, PyFloat, PyInt, PyIntRef, PyStr, int,
     },
-    common::int::{BytesToIntError, bytes_to_int},
+    common::{
+        int::{BytesToIntError, bytes_to_int},
+        str::{PyKindStr, transform_decimal_and_space_to_ascii},
+    },
     function::ArgBytesLike,
     object::{Traverse, TraverseFn},
     stdlib::_warnings,
 };
+use alloc::borrow::Cow;
+
+/// Normalize a `str` for the byte-oriented numeric parsers: Unicode decimal digits
+/// and whitespace fold to their ASCII equivalents, the way CPython runs every
+/// numeric constructor's string argument through
+/// `_PyUnicode_TransformDecimalAndSpaceToASCII` first.
+///
+/// `int`, `float` and `complex` share this step and nothing else — only `int` takes
+/// a base, and only `int` and `float` accept bytes-like input, so each keeps its own
+/// entry point around this one.
+///
+/// A string holding surrogates can never be a valid literal, so it folds to an
+/// empty — and therefore invalid — one.
+pub fn numeric_literal_from_str(s: &PyStr) -> Cow<'_, str> {
+    match s.as_str_kind() {
+        PyKindStr::Ascii(s) => Cow::Borrowed(s.trim().as_str()),
+        PyKindStr::Utf8(s) => transform_decimal_and_space_to_ascii(s.trim()),
+        PyKindStr::Wtf8(_) => Cow::Borrowed(""),
+    }
+}
 
 pub type PyNumberUnaryFunc<R = PyObjectRef> = fn(PyNumber<'_>, &VirtualMachine) -> PyResult<R>;
 pub type PyNumberBinaryFunc = fn(&PyObject, &PyObject, &VirtualMachine) -> PyResult;
@@ -59,7 +82,7 @@ impl PyObject {
         } else if let Some(i) = self.number().int(vm).or_else(|| self.try_index_opt(vm)) {
             i
         } else if let Some(s) = self.downcast_ref::<PyStr>() {
-            try_convert(self, int::int_literal_from_str(s).as_bytes(), vm)
+            try_convert(self, numeric_literal_from_str(s).as_bytes(), vm)
         } else if let Some(bytes) = self.downcast_ref::<PyBytes>() {
             try_convert(self, bytes, vm)
         } else if let Some(bytearray) = self.downcast_ref::<PyByteArray>() {


### PR DESCRIPTION
- [ ] Closes #xxxx <!-- Replace xxxx with the GitHub issue number -->
- [X] This PR follows our [AI policy](https://github.com/RustPython/.github/blob/main/AI_POLICY.md)

## Summary
CPython runs the string argument of every numeric constructor through
`_PyUnicode_TransformDecimalAndSpaceToASCII` before parsing, so digits from any
script — and any Unicode whitespace — are accepted:

```python
>>> int("١٢٣٤٥٦٧٨٩٠")
1234567890
>>> int("१२३४५६७८९०1234567890")
12345678901234567890
```

## Changes
- Add `rustpython_common::str::transform_decimal_and_space_to_ascii`, a port of CPython's transform. Unicode decimal digits fold to ASCII, Unicode whitespace folds to a plain space, and ASCII input is returned borrowed without allocating. Any other non-ASCII character can never appear in a numeric literal, so it is replaced with `?` and the rest of the string is dropped — `?` is rejected by every parser at every base, which leaves the error message to the caller that knows the base and owns the original string.
- Add `protocol::numeric_literal_from_str`, the shared trim + transform step, and route `int()` (both `try_int_radix` and `try_int`), `float()` and `complex()` through it. This is the only step the three constructors share — only `int` takes a base, and only `int` and `float` accept bytes-like input — so each keeps its own entry point around it. Strings holding surrogates fold to an empty (and therefore invalid) literal, as before.
- `float()`'s inline mapping is replaced by the shared helper; its previous version left non-digit non-ASCII characters in place, which the new one rejects up front.
- `Decimal()` inherits the fix through its `int()` call in `_pydecimal`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Numeric string parsing now recognizes Unicode decimal digits and whitespace, converting them to standard ASCII equivalents.
  * Integer, floating-point, and complex-number conversions consistently apply these normalization rules.

* **Bug Fixes**
  * Improved handling of unsupported characters and surrogate-containing strings, treating them as invalid numeric input.
  * Preserved efficient processing for already-ASCII numeric strings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->