### PR TITLE
str: fix the character count of a stepped slice, which reversed() read past

### DIFF
--- a/crates/vm/src/builtins/str.rs
+++ b/crates/vm/src/builtins/str.rs
@@ -1870,14 +1870,14 @@ impl SliceableSequenceOp for PyStr {
                 .collect::<AsciiString>()
                 .into(),
             PyKindStr::Utf8(s) => {
-                let char_len = (range.len() / step) + 1;
+                let char_len = range.len().div_ceil(step);
                 let mut out = String::with_capacity(2 * char_len);
                 out.extend(s.chars().skip(range.start).take(range.len()).step_by(step));
                 // SAFETY: char_len is accurate
                 unsafe { Self::new_with_char_len(out, char_len) }
             }
             PyKindStr::Wtf8(w) => {
-                let char_len = (range.len() / step) + 1;
+                let char_len = range.len().div_ceil(step);
                 let mut out = Wtf8Buf::with_capacity(2 * char_len);
                 out.extend(
                     w.code_points()
@@ -1900,7 +1900,7 @@ impl SliceableSequenceOp for PyStr {
                 .collect::<AsciiString>()
                 .into(),
             PyKindStr::Utf8(s) => {
-                let char_len = (range.len() / step) + 1;
+                let char_len = range.len().div_ceil(step);
                 // not ascii, so the codepoints have to be at least 2 bytes each
                 let mut out = String::with_capacity(2 * char_len);
                 out.extend(
@@ -1914,7 +1914,7 @@ impl SliceableSequenceOp for PyStr {
                 unsafe { Self::new_with_char_len(out, char_len) }
             }
             PyKindStr::Wtf8(w) => {
-                let char_len = (range.len() / step) + 1;
+                let char_len = range.len().div_ceil(step);
                 // not ascii, so the codepoints have to be at least 2 bytes each
                 let mut out = Wtf8Buf::with_capacity(2 * char_len);
                 out.extend(

--- a/extra_tests/snippets/builtin_str_unicode_slice.py
+++ b/extra_tests/snippets/builtin_str_unicode_slice.py
@@ -59,3 +59,32 @@ assert hebrew_text[30:10:-3] == "אםהֱאּ "
 assert len(hebrew_text[30:10:-3]) == 7
 assert hebrew_text[30:10:-1] == "א ,םיִהֹלֱא אָרָּב ,"
 assert len(hebrew_text[30:10:-1]) == 20
+
+
+# A stepped slice whose span is an exact multiple of the step ends on the last
+# character it collects rather than one past it, so the character count is the
+# span divided by the step and not one more. The subject goes through a
+# variable because a constant subscript is folded at compile time and would
+# never reach the runtime slice at all.
+def stepped(s, step):
+    return s[::step]
+
+
+for subject, step, expected in [
+    ("a\u00e9c", 3, "a"),
+    ("가나다라", 2, "가다"),
+    ("가나다라마바", 3, "가라"),
+    ("가나다라", -2, "라나"),
+    ("가나다라마바", -3, "바다"),
+    ("\U0001f600\U0001f601\U0001f602\U0001f603", 2, "\U0001f600\U0001f602"),
+]:
+    sliced = stepped(subject, step)
+    assert sliced == expected, (subject, step, sliced)
+    assert len(sliced) == len(expected), (subject, step, len(sliced))
+    # An overstated count makes the string claim characters its buffer does not
+    # hold, which reversed() then reads past.
+    assert list(reversed(sliced)) == list(expected)[::-1]
+
+assert len(stepped(hebrew_text, 2)) == 30
+assert len(stepped(hebrew_text, 4)) == 15
+assert len(stepped(hebrew_text, -2)) == 30


### PR DESCRIPTION
A stepped slice of a non-ASCII string reports a character count one too high whenever the
span is an exact multiple of the step, and the overstated count makes `reversed()` on the
result read past the end of the buffer and panic:

```python
s = "".join(["a", "é", "c"])
list(reversed(s[::3]))
# thread 'main' panicked at crates/common/src/str.rs:327:37:
# index out of bounds: the len is 1 but the index is 1
```

The subject goes through a variable because a constant subscript is folded at compile time,
and the folded path is correct -- only a slice evaluated at runtime reaches the bug.

## Cause

`do_stepped_slice` and `do_stepped_slice_reverse` compute the result's character count as
`(range.len() / step) + 1`. That is the number of steps *taken* plus one, which is right
only when the last step lands short of the end; when the span divides evenly it counts a
character the slice never collected.

| | characters | reported |
|---|---|---|
| `"aéc"[::3]` | 1 | 2 |
| `"가나다라"[::2]` | 2 | 3 |
| `"가나다라마바"[::3]` | 2 | 3 |

ASCII subjects are unaffected: that arm collects into an `AsciiString`, whose length comes
from the data rather than from the formula.

The count is passed to `new_with_char_len`, whose contract is that it is accurate, and is
stored as the string's character length. So the result is a string that claims a character
its buffer does not hold -- `len()` lies, and any consumer that walks to the last index
walks off the end. `reversed()` is the one that panics, because it indexes from
`char_len - 1`.

## Fix

Use `range.len().div_ceil(step)`, which is the number of elements the underlying range
yields.

## Verification

- New assertions in `extra_tests/snippets/builtin_str_unicode_slice.py`, covering both step
  directions over 2-, 3- and 4-byte characters, and `reversed()` on each result. They fail
  on `main` at the first case (`AssertionError: ('aéc', 3, 2)`) and pass here, so they are
  not vacuous -- the subject goes through a function to keep the compiler from folding the
  subscript.
- A differential over **44331** subscript and slice shapes -- every combination of start,
  stop and step from `{None, 0..6, -1..-6, ±100}` over strings straddling the ASCII split,
  the WTF-8 surrogate range, the astral plane and the 64-code-point index-group boundary --
  matches CPython 3.14.6 exactly. On `main` the same run differs on **3100** lines, all of
  them stepped slices, all of them a wrong length beside correct content.
- `test_str test_string test_re test_bytes test_json`: 893 run, 44 skipped, SUCCESS.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected character counts for stepped Unicode string slices when the step does not evenly divide the selected range.
  * Improved slicing reliability for accented, Korean, Hebrew, and emoji text.
  * Fixed reverse stepped slices to report accurate lengths and avoid incorrect results.

* **Tests**
  * Added regression coverage for positive and negative steps, including slice content, counts, and reverse iteration safety.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->