### PR TITLE
str: take search bounds through the character index

### DIFF
--- a/crates/common/src/str.rs
+++ b/crates/common/src/str.rs
@@ -443,7 +443,8 @@ impl StrData {
         self.char_index_to_byte(index)
     }
 
-    /// The byte range spanned by the code points in `range`.
+    /// The byte range spanned by the code points in `range`, whose end must not
+    /// exceed the string's code point count.
     ///
     /// A range that reaches within [`MAX_WALK_TO_INDEX`] of *both* ends is
     /// walked to for the same reason a single index near one end is -- a slice
@@ -474,6 +475,25 @@ impl StrData {
             return start..end;
         }
         self.char_index_to_byte(range.start)..self.char_index_to_byte(range.end)
+    }
+
+    /// The character index of the character starting at byte offset `bytepos`,
+    /// the inverse of [`Self::char_index_to_byte`].
+    ///
+    /// `bytepos` must be a character boundary at or before the end.
+    ///
+    /// Logarithmic rather than constant, because the index is keyed the other
+    /// way -- but a search whose bounds came from `char_index_to_byte` has the
+    /// table already, and this is what turns a byte offset back into the answer
+    /// a caller asked for in characters.
+    pub fn byte_to_char_index(&self, bytepos: usize) -> usize {
+        if self.kind.is_ascii() {
+            return bytepos;
+        }
+        let char_len = self.char_len();
+        self.index
+            .get_or_build(&self.data, char_len)
+            .char_index_at_byte(&self.data, bytepos, char_len)
     }
 
     pub fn nth_char(&self, index: usize) -> CodePoint {

--- a/crates/common/src/wtf8_index.rs
+++ b/crates/common/src/wtf8_index.rs
@@ -104,6 +104,63 @@ impl Wtf8Index {
         }
     }
 
+    /// The index of the code point starting at byte offset `bytepos`, the
+    /// inverse of [`Self::byte_offset`].
+    ///
+    /// `data` must be the buffer the table was built for, `char_len` its code
+    /// point count, and `bytepos` a code point boundary at or before its end.
+    ///
+    /// Logarithmic rather than constant: the table is keyed by code point
+    /// index, so going the other way is a search through it. The bracketing
+    /// below is what keeps that search short -- a code point occupies one to
+    /// four bytes, which pins the answer to a narrow band around `bytepos`
+    /// before the first comparison.
+    #[must_use]
+    pub fn char_index_at_byte(&self, data: &Wtf8, bytepos: usize, char_len: usize) -> usize {
+        let bytes_remaining = data.len() - bytepos;
+        // At least one byte per remaining code point, and at most four, so the
+        // group holding the answer lies between these.
+        let mut group_min =
+            usize::max(bytepos / 4, char_len.saturating_sub(bytes_remaining + 1)) >> 6;
+        let mut group_max = usize::min(bytepos, char_len.saturating_sub(bytes_remaining / 4)) >> 6;
+        while group_min < group_max {
+            let middle = group_min.midpoint(group_max) + 1;
+            if bytepos < self.groups[middle].base {
+                group_max = middle - 1;
+            } else {
+                group_min = middle;
+            }
+        }
+
+        let base = self.groups[group_min].base;
+        if base == bytepos {
+            return group_min << 6;
+        }
+        // Walk the group's entries to the last one at or before `bytepos`,
+        // then step the remaining code points, of which there are at most
+        // three -- an entry covers four.
+        let entries = if group_min == self.groups.len() - 1 {
+            ((char_len - 1) >> 2) & 0x0F
+        } else {
+            16
+        };
+        let mut index = group_min << 6;
+        let mut pos = base;
+        for entry in 0..entries {
+            let at = base + self.groups[group_min].ofs[entry] as usize;
+            if at >= bytepos {
+                break;
+            }
+            pos = at;
+            index = (group_min << 6) + (entry << 2) + 1;
+        }
+        while pos < bytepos {
+            pos = next_pos(data, pos);
+            index += 1;
+        }
+        index
+    }
+
     /// The table's heap footprint, in bytes.
     #[must_use]
     pub fn byte_size(&self) -> usize {
@@ -153,21 +210,34 @@ mod tests {
     use super::*;
     use crate::wtf8::{CodePoint, Wtf8Buf};
 
-    /// Every index of `s`, against the offsets its own iterator reports.
+    /// Every index of `s`, both ways, against the offsets its own iterator
+    /// reports.
     fn check(s: &Wtf8) {
         let expected: Vec<usize> = s
             .code_point_indices()
             .map(|(byte_offset, _)| byte_offset)
             .collect();
-        let index = Wtf8Index::new(s, expected.len());
+        let char_len = expected.len();
+        let index = Wtf8Index::new(s, char_len);
         for (i, &want) in expected.iter().enumerate() {
             assert_eq!(
                 index.byte_offset(s, i),
                 want,
-                "index {i} of {s:?} ({} code points)",
-                expected.len()
+                "index {i} of {s:?} ({char_len} code points)"
+            );
+            assert_eq!(
+                index.char_index_at_byte(s, want, char_len),
+                i,
+                "byte {want} of {s:?} ({char_len} code points)"
             );
         }
+        // One past the last code point is a boundary too, and the searches that
+        // use this ask for it as an end bound.
+        assert_eq!(
+            index.char_index_at_byte(s, s.len(), char_len),
+            char_len,
+            "end of {s:?}"
+        );
     }
 
     fn wtf8(s: &str) -> Wtf8Buf {

--- a/crates/vm/src/anystr.rs
+++ b/crates/vm/src/anystr.rs
@@ -147,7 +147,11 @@ pub(crate) trait AnyStr {
     fn as_bytes(&self) -> &[u8];
     fn elements(&self) -> impl Iterator<Item = Self::Char>;
     fn get_bytes(&self, range: Range<usize>) -> &Self;
-    // FIXME: get_chars is expensive for str
+    /// The characters in `range`, which for a `str` payload means walking to
+    /// both bounds -- the payload does not carry the string's character index.
+    /// `PyStr` therefore converts its own ranges and does not reach the search
+    /// helpers below through this; what remains are the byte strings, where a
+    /// character range is already a byte range.
     fn get_chars(&self, range: Range<usize>) -> &Self;
     fn bytes_len(&self) -> usize;
     // NOTE: str::chars().count() consumes the O(n) time. But pystr::char_len does cache.

--- a/crates/vm/src/builtins/str.rs
+++ b/crates/vm/src/builtins/str.rs
@@ -1275,8 +1275,17 @@ impl PyStr {
     #[pymethod]
     fn count(&self, args: FindArgs) -> usize {
         let (needle, range) = args.get_value(self.len());
-        self.as_wtf8()
-            .py_count(needle.as_wtf8(), range, |h, n| h.find_iter(n).count())
+        self.as_wtf8().py_count(needle.as_wtf8(), range, |h, n| {
+            if n.is_empty() {
+                // An empty needle sits between every pair of characters and at
+                // both ends, so it occurs once more than the haystack holds
+                // characters. Searching for it in the bytes would instead
+                // answer in encoded positions.
+                h.code_points().count() + 1
+            } else {
+                h.find_iter(n).count()
+            }
+        })
     }
 
     #[pymethod]

--- a/crates/vm/src/builtins/str.rs
+++ b/crates/vm/src/builtins/str.rs
@@ -9,7 +9,7 @@ use super::{
 use crate::{
     AsObject, Context, Py, PyExact, PyObject, PyObjectRef, PyPayload, PyRef, PyRefExact, PyResult,
     TryFromBorrowedObject, VirtualMachine,
-    anystr::{self, AnyStr, AnyStrContainer, AnyStrWrapper, adjust_indices},
+    anystr::{self, AnyStr, AnyStrContainer, AnyStrWrapper, StringRange, adjust_indices},
     atomic_func,
     bytes_inner::{swapcase_ascii, title_ascii},
     cformat::cformat_string,
@@ -719,6 +719,13 @@ impl PyStr {
         self.data.char_index_to_byte(index)
     }
 
+    /// The character index of the character starting at byte offset `bytepos`,
+    /// which must be a character boundary at or before the end.
+    #[inline]
+    pub fn byte_to_char_index(&self, bytepos: usize) -> usize {
+        self.data.byte_to_char_index(bytepos)
+    }
+
     #[pymethod]
     #[inline(always)]
     pub const fn isascii(&self) -> bool {
@@ -924,11 +931,12 @@ impl PyStr {
 
     #[pymethod]
     fn endswith(&self, options: anystr::StartsEndsWithArgs, vm: &VirtualMachine) -> PyResult<bool> {
-        let (affix, substr) =
-            match options.prepare(self.as_wtf8(), self.len(), |s, r| s.get_chars(r)) {
-                Some(x) => x,
-                None => return Ok(false),
-            };
+        let (affix, substr) = match options.prepare(self.as_wtf8(), self.len(), |s, r| {
+            &s[self.data.char_range_to_bytes(r)]
+        }) {
+            Some(x) => x,
+            None => return Ok(false),
+        };
         substr.py_starts_ends_with(
             &affix,
             "endswith",
@@ -944,11 +952,12 @@ impl PyStr {
         options: anystr::StartsEndsWithArgs,
         vm: &VirtualMachine,
     ) -> PyResult<bool> {
-        let (affix, substr) =
-            match options.prepare(self.as_wtf8(), self.len(), |s, r| s.get_chars(r)) {
-                Some(x) => x,
-                None => return Ok(false),
-            };
+        let (affix, substr) = match options.prepare(self.as_wtf8(), self.len(), |s, r| {
+            &s[self.data.char_range_to_bytes(r)]
+        }) {
+            Some(x) => x,
+            None => return Ok(false),
+        };
         substr.py_starts_ends_with(
             &affix,
             "startswith",
@@ -1167,42 +1176,52 @@ impl PyStr {
         Ok(vm.ctx.new_str(joined))
     }
 
-    // FIXME: two traversals of str is expensive
+    /// The bytes the character range `range` spans and the byte offset it
+    /// starts at, or `None` if the range is inverted.
+    ///
+    /// The bounds go through the string's character index, so reaching a range
+    /// deep in the subject costs a lookup rather than a walk to it.
     #[inline]
-    fn _to_char_idx(r: &Wtf8, byte_idx: usize) -> usize {
-        r[..byte_idx].code_points().count()
+    fn char_range_bytes(&self, range: Range<usize>) -> Option<(usize, &Wtf8)> {
+        if !range.is_normal() {
+            return None;
+        }
+        let bytes = self.data.char_range_to_bytes(range);
+        Some((bytes.start, &self.as_wtf8()[bytes]))
     }
 
+    /// Searches the character range `range` with `find`, which answers in bytes
+    /// relative to the range, and reports the hit as a character index.
     #[inline]
     fn _find<F>(&self, args: FindArgs, find: F) -> Option<usize>
     where
         F: Fn(&Wtf8, &Wtf8) -> Option<usize>,
     {
         let (sub, range) = args.get_value(self.len());
-        self.as_wtf8().py_find(sub.as_wtf8(), range, find)
+        let (start, haystack) = self.char_range_bytes(range)?;
+        let found = find(haystack, sub.as_wtf8())?;
+        Some(self.byte_to_char_index(start + found))
     }
 
     #[pymethod]
     fn find(&self, args: FindArgs) -> isize {
-        self._find(args, |r, s| Some(Self::_to_char_idx(r, r.find(s)?)))
-            .map_or(-1, |v| v as isize)
+        self._find(args, Wtf8::find).map_or(-1, |v| v as isize)
     }
 
     #[pymethod]
     fn rfind(&self, args: FindArgs) -> isize {
-        self._find(args, |r, s| Some(Self::_to_char_idx(r, r.rfind(s)?)))
-            .map_or(-1, |v| v as isize)
+        self._find(args, Wtf8::rfind).map_or(-1, |v| v as isize)
     }
 
     #[pymethod]
     fn index(&self, args: FindArgs, vm: &VirtualMachine) -> PyResult<usize> {
-        self._find(args, |r, s| Some(Self::_to_char_idx(r, r.find(s)?)))
+        self._find(args, Wtf8::find)
             .ok_or_else(|| vm.new_value_error("substring not found"))
     }
 
     #[pymethod]
     fn rindex(&self, args: FindArgs, vm: &VirtualMachine) -> PyResult<usize> {
-        self._find(args, |r, s| Some(Self::_to_char_idx(r, r.rfind(s)?)))
+        self._find(args, Wtf8::rfind)
             .ok_or_else(|| vm.new_value_error("substring not found"))
     }
 
@@ -1275,15 +1294,16 @@ impl PyStr {
     #[pymethod]
     fn count(&self, args: FindArgs) -> usize {
         let (needle, range) = args.get_value(self.len());
-        self.as_wtf8().py_count(needle.as_wtf8(), range, |h, n| {
-            if n.is_empty() {
+        let chars = range.len();
+        self.char_range_bytes(range).map_or(0, |(_, haystack)| {
+            if needle.is_empty() {
                 // An empty needle sits between every pair of characters and at
-                // both ends, so it occurs once more than the haystack holds
-                // characters. Searching for it in the bytes would instead
-                // answer in encoded positions.
-                h.code_points().count() + 1
+                // both ends, so it occurs once more than the range holds
+                // characters. Counting it in the bytes would answer in encoded
+                // positions instead.
+                chars + 1
             } else {
-                h.find_iter(n).count()
+                haystack.find_iter(needle.as_wtf8()).count()
             }
         })
     }

--- a/extra_tests/snippets/builtin_str.py
+++ b/extra_tests/snippets/builtin_str.py
@@ -170,6 +170,15 @@ assert "aaa".count("a", 1, 2) == 1
 assert "aaa".count("a", 2, 2) == 0
 assert "aaa".count("a", 2, 1) == 0
 
+# An empty needle is counted in characters, not in encoded positions.
+assert "".count("") == 1
+assert "abc".count("") == 4
+assert "가나다".count("") == 4
+assert "가나다".count("", 1) == 3
+assert "가나다".count("", 1, 2) == 2
+assert "가나다".count("", 4, 4) == 0
+assert "a\U0001f600b".count("") == 4
+
 assert "___a__".find("a") == 3
 assert "___a__".find("a", -10) == 3
 assert "___a__".find("a", -3) == 3


### PR DESCRIPTION
Follows #8522 and #8526, which gave `PyStr` a code-point index (`Wtf8Index`) and used it to drive `re` and to resolve subscripts and slices. The same index answers the remaining quadratic in the string type: the search methods.

## What was happening

`find`, `rfind`, `index`, `rindex`, `count`, `startswith` and `endswith` all take character bounds. They resolved them through `AnyStr::get_chars`, which walks the payload to both bounds, and `find` then reported its hit with `_to_char_idx`, which counts the code points in front of it -- the `// FIXME: two traversals of str is expensive` that sat above it.

So a sweep over a subject's own indices walked the subject once per call. `AnyStr` sees only the payload, which does not say whether it is ASCII, so the ASCII path walked too.

## What this does

Resolve the bounds with `StrData::char_range_to_bytes`, the converter #8526 added for slices -- so the search methods inherit its short-walk case too, and `s.startswith(x, 1, -1)` does not build a table over the whole string. Map the hit back with `Wtf8Index::char_index_at_byte`, added here as the table's inverse. The table is keyed by character index, so the inverse is a search rather than a lookup, but a narrow one: a character is one to four bytes, which brackets the answer to a band around the byte offset before the first comparison, and the walk that follows is at most an entry's worth of steps. It is also amortised -- the callers that need it have already built the table resolving their own bounds.

`AnyStr::get_chars` keeps its byte-string callers, where a character range is already a byte range; the `FIXME` is replaced by a note saying so.

## Measurements

n=8000, sweeping the bound over the subject, best of 3, the two binaries interleaved:

| sweep | subject | before | after | |
|---|---|---|---|---|
| `s.find(x, i)` | `'가나다라' * n/4` | 18.00 ms | **0.15 ms** | 120x |
| `s.startswith(x, i)` | `'가나다라' * n/4` | 16.75 ms | **0.12 ms** | 140x |
| `s.count(x, i)` | `'가나다라' * n/4` | 22.78 ms | **4.02 ms** | 5.7x |
| `s.find(x, i)` | `'abcd' * n/4` | 3.48 ms | **0.14 ms** | 25x |

The per-doubling factor is the clearer statement: `find` and `startswith` go from ×4 (quadratic) to ×2 (linear). `count` stays ×3 because counting is linear in the range it is handed -- CPython is the same shape there; what drops is the constant.

## The first commit is an independent fix

`str.count` with an **empty** needle answered in encoded positions rather than characters, because `find_iter` over the range's bytes reports one hit per byte boundary:

```python
>>> '가나다'.count('')
10          # CPython: 4
>>> '가나다'.count('', 1, 2)
4           # CPython: 2
```

This is on main today, independent of the rest of the PR; it is fixed first, in the shape main has, so it can be read on its own. `bytes.count` keeps the byte-position answer, which is correct there. The snippet assertions added with it fail on main and pass after.

## Verification

- A differential of `find`/`rfind`/`index`/`rindex`/`count`/`startswith`/`endswith` against CPython over **356048** shapes -- 16 subjects (empty, ASCII, 2/3/4-byte, lone surrogates, embedded NUL, and lengths on and around the 64-character group boundary) x 11 needles (absent, ASCII, non-ASCII, multi-character, a lone surrogate) x 17 x 17 bounds (`None`, in range, past the end, negative, far negative). main differs from CPython on **1375** of them, all of them the empty-needle `count`; this branch differs on **0**.
- The `re` differential from #8522 (2731 lines) and the subscript/slice differential from #8526 (44331 shapes): 0 diffs.
- `test_str`, `test_bytes`, `test_re`, `test_string`, `test_userstring`: SUCCESS. (`test_unicode` fails identically on main -- it does not reach its tests on either.)
- `cargo clippy --all-targets`, `cargo fmt --check`, `cargo test -p rustpython-common` clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved Unicode handling for string searches, indexing, counting, and prefix/suffix checks.
  - Corrected character-position results when operations use byte ranges or supplementary-plane characters.
  - Fixed empty-string counting across ASCII, Unicode, and bounded ranges.

- **Performance**
  - Optimized string operations by reducing unnecessary character-by-character traversal while preserving character-based results.
  - Improved handling of character positions in Unicode text, including lookups at the end of strings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## What a single call pays

The table costs a pass over the buffer, so the fair question is what happens to a string that is searched once and never again. Measured on a **fresh** subject per call, so nothing is amortised, n=1,000,000:

| one call on a fresh string | main | this branch |
|---|---|---|
| `s.find(miss, len//2)` | 2508 µs | 2314 µs |
| `s.find(miss)` (no bounds) | 2571 µs | **193 µs** |
| `s.count(x, len//2)` | 3172 µs | 2808 µs |
| `s[len//2]` | 2137 µs | 2329 µs |

A bounded search is a wash: building the table costs about what the walk it replaces cost. An **unbounded** search is 13x, and that is the common form -- `s.find(x)` is `0..len`, which `char_range_to_bytes` answers by walking zero steps at each end, so the call becomes a plain byte search with no conversion at all. On main it walked the whole string through `get_chars` before searching it.
