### PR TITLE
str, bytes: answer equality with equality rather than with an ordering

### DIFF
--- a/crates/vm/src/builtins/str.rs
+++ b/crates/vm/src/builtins/str.rs
@@ -1563,6 +1563,11 @@ impl Comparable for PyStr {
             return Ok(res.into());
         }
         let other = class_or_notimplemented!(Self, other);
+        // Equality does not need the ordering, and answers two strings of
+        // different length without reading either.
+        if let Some(res) = op.eval_eq(|| zelf.as_wtf8() == other.as_wtf8()) {
+            return Ok(res.into());
+        }
         Ok(op.eval_ord(zelf.as_wtf8().cmp(other.as_wtf8())).into())
     }
 }

--- a/crates/vm/src/bytes_inner.rs
+++ b/crates/vm/src/bytes_inner.rs
@@ -345,7 +345,12 @@ impl PyBytesInner {
         // but not memoryview, and not equal if compare with unicode str(PyStr)
         PyComparisonValue::from_option(
             other
-                .try_bytes_like(vm, |other| op.eval_ord(self.elements.as_slice().cmp(other)))
+                .try_bytes_like(vm, |other| {
+                    // Equality does not need the ordering, and answers two
+                    // buffers of different length without reading either.
+                    op.eval_eq(|| self.elements.as_slice() == other)
+                        .unwrap_or_else(|| op.eval_ord(self.elements.as_slice().cmp(other)))
+                })
                 .ok(),
         )
     }

--- a/crates/vm/src/frame.rs
+++ b/crates/vm/src/frame.rs
@@ -6894,10 +6894,13 @@ impl ExecutingFrame<'_> {
                     b.downcast_ref_if_exact::<PyStr>(vm),
                 ) {
                     let op = self.compare_op_from_arg(arg);
-                    if op != PyComparisonOp::Eq && op != PyComparisonOp::Ne {
+                    // The same two shortcuts the unspecialized comparison takes:
+                    // one object is equal to itself, and equality answers two
+                    // strings of different length without reading either.
+                    let Some(result) = op.eval_eq(|| a.is(b) || a_str.as_wtf8() == b_str.as_wtf8())
+                    else {
                         return self.execute_compare(vm, arg);
-                    }
-                    let result = op.eval_ord(a_str.as_wtf8().cmp(b_str.as_wtf8()));
+                    };
                     self.pop_value();
                     self.pop_value();
                     self.push_value(vm.ctx.new_bool(result).into());

--- a/crates/vm/src/types/slot.rs
+++ b/crates/vm/src/types/slot.rs
@@ -1995,6 +1995,29 @@ impl PyComparisonOp {
         self.map_eq(|| a.borrow().is(b.borrow()))
     }
 
+    /// The answer to this comparison for two operands that `equal` reports as
+    /// equal or not, or `None` for an ordering operator, which equality alone
+    /// cannot settle -- `equal` is not called in that case.
+    ///
+    /// This is what lets a type answer `==` and `!=` with an equality test
+    /// rather than with an ordering: the two agree on the answer, but equality
+    /// can settle a length mismatch without looking at the contents at all.
+    ///
+    /// The two neighbouring helpers answer different questions: [`Self::map_eq`]
+    /// answers only where its predicate holds, so a caller still handles the
+    /// other side, and [`Self::eq_only`] declares the comparison
+    /// `NotImplemented` for an ordering operator. This one leaves the ordering
+    /// operators to the caller, which is what a type with a real ordering
+    /// needs.
+    #[inline]
+    pub fn eval_eq(self, equal: impl FnOnce() -> bool) -> Option<bool> {
+        match self {
+            Self::Eq => Some(equal()),
+            Self::Ne => Some(!equal()),
+            _ => None,
+        }
+    }
+
     /// Returns `Some(true)` when self is `Eq` and `f()` returns true. Returns `Some(false)` when self
     /// is `Ne` and `f()` returns true. Otherwise returns `None`.
     #[inline]

--- a/extra_tests/snippets/operator_comparison.py
+++ b/extra_tests/snippets/operator_comparison.py
@@ -87,3 +87,50 @@ assert not math.nan > 123
 assert not math.nan < 123
 assert not math.nan >= 123
 assert not math.nan <= 123
+
+
+# str and bytes comparisons, through a function so that the operands are not
+# constants the compiler can fold, and in a loop so the specialized comparison
+# is reached.
+def cmp_all(a, b):
+    return (a == b, a != b, a < b, a <= b, a > b, a >= b)
+
+
+def check(a, b, expected):
+    for _ in range(200):
+        assert cmp_all(a, b) == expected, (a, b, cmp_all(a, b), expected)
+
+
+EQ = (True, False, False, True, False, True)
+LT = (False, True, True, True, False, False)
+GT = (False, True, False, False, True, True)
+
+same = "abc" * 3
+check(same, same, EQ)  # the very same object
+check(same, "abcabcabc", EQ)  # equal, distinct objects
+check("abc", "abd", LT)  # same length, differing content
+check("abc", "abcd", LT)  # a prefix is less than what extends it
+check("abcd", "abc", GT)
+check("", "a", LT)
+check("", "", EQ)
+check("\ud800", "\ud800", EQ)  # lone surrogates are compared as themselves
+check("\ud800", "\udfff", LT)
+check("a\U0001f600", "a\U0001f600", EQ)
+check("가나다", "가나다", EQ)
+check("가나", "가나다", LT)
+
+# Comparing with a non-string is never an error for == and !=.
+assert not "abc" == 3
+assert "abc" != 3
+
+bsame = b"abc" * 3
+check(bsame, bsame, EQ)
+check(bsame, b"abcabcabc", EQ)
+check(b"abc", b"abd", LT)
+check(b"abc", b"abcd", LT)
+check(b"abcd", b"abc", GT)
+check(bytearray(b"abc"), bytearray(b"abcd"), LT)
+check(bytearray(b"abc"), b"abc", EQ)  # bytearray and bytes compare by content
+check(b"abc", bytearray(b"abd"), LT)
+assert not b"abc" == "abc"
+assert b"abc" != "abc"


### PR DESCRIPTION
Found while checking whether anything else in `str` still scales worse than CPython. These are not asymptotic -- they are two O(1) answers that were being computed in O(n).

## What was happening

Three places answered `==` and `!=` by taking `Ord::cmp` of the two buffers and asking whether the result was `Equal`:

- `impl Comparable for PyStr` (`builtins/str.rs`)
- `PyBytesInner::cmp` (`bytes_inner.rs`), which serves `bytes` and `bytearray`
- `Instruction::CompareOpStr` (`frame.rs`), the specialization the interpreter installs after it sees two exact `str` operands

An ordering has to read the bytes. `[u8]: Ord` memcmps the common prefix and only then compares the lengths, so `"a" * 1_000_000 == "a" * 999_999` -- an answer the lengths give away -- memcmped a megabyte. And `CompareOpStr` bypasses the `Comparable` slot, so it had also lost the identity shortcut the slot takes with `identical_optimization`: a string compared with **itself** was read end to end.

CPython answers both with `_PyUnicode_Equal`, which starts `if (str1 == str2) return 1;` and then compares kinds and lengths before any content; `unicode_richcompare` and `bytes_richcompare` special-case `Py_EQ`/`Py_NE` the same way.

## What this does

Adds `PyComparisonOp::eval_eq`, which settles `Eq` and `Ne` from an equality test and returns `None` for an ordering operator (without evaluating the test), and answers through it in the three places. Slice equality checks the length first, and `CompareOpStr` answers an object compared with itself the way the slot it specializes does.

## Measurements

n=1,000,000, per comparison, best of 7:

| | before | after | |
|---|---|---|---|
| `s == s` (the very same object) | 23.21 µs | **0.16 µs** | 145x |
| `s == ` a string one character shorter | 24.63 µs | **0.17 µs** | 145x |
| `b == ` bytes one byte shorter | 25.28 µs | **0.20 µs** | 126x |
| `ba == ` a bytearray one byte shorter | 27.68 µs | **0.23 µs** | 120x |
| `s == ` an equal, distinct string | 23.78 µs | 24.50 µs | unchanged |
| `s < ` an equal string | 29.87 µs | 25.07 µs | unchanged |

CPython answers the first four in 0.02 µs. The remaining 0.16 µs here is the interpreter loop -- an empty lambda call measures 0.12 µs on the same machine.

## Verification

Behaviour is unchanged, so the tests added to `operator_comparison.py` are a guard on the two new shortcuts rather than a regression test -- they pass on main as well. They go through a function and a loop so the operands are not constants the compiler folds and the specialized instruction is actually reached, and they cover: the same object, equal distinct objects, same-length differences, prefixes (`"abc" < "abcd"`), the empty string, lone surrogates, astral characters, `bytes`/`bytearray` in both directions, and comparison against a non-string.

`test_str`, `test_bytes`, `test_string`, `test_dict`, `test_set`, `test_operator`, `test_compare`, `test_richcmp`, `test_sort`, `test_userstring`, `test_collections`, `test_json`: SUCCESS. (`test_bytearray` and `test_unicode` fail identically on main -- neither reaches its tests on either.) `cargo clippy --all-targets` and `cargo fmt --check` clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved equality and inequality comparisons for strings, bytes, and bytearrays, including values with different lengths.
  * Preserved correct ordering behavior for less-than and greater-than comparisons.
  * Improved handling of Unicode text, mixed byte types, and comparisons with nonmatching types.

* **Tests**
  * Added comprehensive coverage for equality, ordering, prefixes, Unicode edge cases, and repeated comparisons.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Are there others?

Every `eval_ord` call site in the tree (15 outside `slot.rs`), checked for the same shape -- an ordering used to answer equality where the ordering costs more:

- `set.rs`, `dict.rs`, `iter.rs`, `array.rs:1286` compare **lengths**; `frame.rs`'s int/float specializations, `int.rs`, `float.rs` compare **scalars**; `cert.rs` compares a **bool**, `function.rs` an **`Option::is_none`**. An ordering is O(1) on all of those, so there is nothing to save.
- `array.rs:1255` already routes `Eq`/`Ne` through `eq_only` before it reaches the ordering path -- the same shape as this change, arrived at independently.
- `BigInt: Ord` compares sign and limb count before digits, so `int` equality already short-circuits on magnitude.

The three fixed here are the ones whose operands are **buffers**, where the ordering reads O(min(len)) bytes to answer a question the lengths settle.

`eval_eq` sits beside two existing helpers and is not a duplicate of either: `map_eq` answers only where its predicate holds (its caller handles the other side), and `eq_only` declares the comparison `NotImplemented` for an ordering operator -- correct for a type with no ordering, wrong for `str`, which has one. The doc comment says so.
