### PR TITLE
Expose symbol scopes through _symtable

### DIFF
--- a/Lib/test/test_symtable.py
+++ b/Lib/test/test_symtable.py
@@ -247,7 +247,6 @@ class SymtableTest(unittest.TestCase):
         self.assertEqual(self.top.get_lineno(), 0)
         self.assertEqual(self.spam.get_lineno(), 14)
 
-    @unittest.expectedFailure  # TODO: RUSTPYTHON; AssertionError: Lists differ: [] != ['a', 'b', 'internal', 'kw', 'other_internal', 'some_var', 'var', 'x']
     def test_function_info(self):
         func = self.spam
         self.assertEqual(sorted(func.get_parameters()), ["a", "b", "kw", "var"])
@@ -256,7 +255,6 @@ class SymtableTest(unittest.TestCase):
         self.assertEqual(sorted(func.get_globals()), ["bar", "glob", "some_assigned_global_var"])
         self.assertEqual(self.internal.get_frees(), ("x",))
 
-    @unittest.expectedFailure  # TODO: RUSTPYTHON
     def test_globals(self):
         self.assertTrue(self.spam.lookup("glob").is_global())
         self.assertFalse(self.spam.lookup("glob").is_declared_global())
@@ -275,7 +273,6 @@ class SymtableTest(unittest.TestCase):
         expected = ("some_var",)
         self.assertEqual(self.other_internal.get_nonlocals(), expected)
 
-    @unittest.expectedFailure  # TODO: RUSTPYTHON
     def test_local(self):
         self.assertTrue(self.spam.lookup("x").is_local())
         self.assertFalse(self.spam.lookup("bar").is_local())
@@ -283,7 +280,6 @@ class SymtableTest(unittest.TestCase):
         self.assertTrue(self.top.lookup("some_non_assigned_global_var").is_local())
         self.assertTrue(self.top.lookup("some_assigned_global_var").is_local())
 
-    @unittest.expectedFailure  # TODO: RUSTPYTHON
     def test_free(self):
         self.assertTrue(self.internal.lookup("x").is_free())
 
@@ -328,7 +324,6 @@ class SymtableTest(unittest.TestCase):
         self.assertTrue(self.Mine.lookup("a_method").is_assigned())
         self.assertFalse(self.internal.lookup("x").is_assigned())
 
-    @unittest.expectedFailure  # TODO: RUSTPYTHON; IndexError: list index out of range
     def test_annotated(self):
         st1 = symtable.symtable('def f():\n    x: int\n', 'test', 'exec')
         st2 = st1.get_children()[1]
@@ -493,7 +488,6 @@ class SymtableTest(unittest.TestCase):
         self.assertEqual(str(self.top), "<SymbolTable for module ?>")
         self.assertEqual(str(self.spam), "<Function SymbolTable for spam in ?>")
 
-    @unittest.expectedFailure  # TODO: RUSTPYTHON; AssertionError: AssertionError: "<symbol 'glob': 0, DEF_GLOBAL>" != "<symbol 'glob': GLOBAL_IMPLICIT, USE>"
     def test_symbol_repr(self):
         self.assertEqual(repr(self.spam.lookup("glob")),
                          "<symbol 'glob': GLOBAL_IMPLICIT, USE>")

--- a/crates/vm/src/stdlib/_symtable.rs
+++ b/crates/vm/src/stdlib/_symtable.rs
@@ -185,8 +185,9 @@ mod _symtable {
         fn symbols(&self, vm: &VirtualMachine) -> PyDictRef {
             let dict = vm.ctx.new_dict();
             for (name, symbol) in &self.symtable.symbols {
-                dict.set_item(name, vm.new_pyobj(symbol.flags.bits()), vm)
-                    .unwrap();
+                let packed_flags =
+                    i32::from(symbol.flags.bits()) | (symbol.scope.as_i32() << SCOPE_OFFSET);
+                dict.set_item(name, vm.new_pyobj(packed_flags), vm).unwrap();
             }
             dict
         }


### PR DESCRIPTION
- [x] This PR follows our [AI policy](https://github.com/RustPython/.github/blob/main/AI_POLICY.md)

## Summary

`_symtable` omitted symbol scope information, causing `Lib/symtable.py` to report incorrect globals, locals, and free variables.

Expose the missing scope information so the public `symtable` API returns CPython-compatible results.
## Testing

- `cargo run --release -- -m test test_symtable`

## AI assistance

Codex (GPT-5) was used to investigate and implement this change. 
I reviewed and validated all AI-assisted work.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected symbol table results to include both symbol flags and scope information.
  * Improved the accuracy of symbol metadata returned to callers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->