### PR TITLE
Add StringIO newline tracking

### DIFF
--- a/Lib/test/test_memoryio.py
+++ b/Lib/test/test_memoryio.py
@@ -1004,10 +1004,6 @@ class CStringIOTest(PyStringIOTest):
     def test_flags(self):
         return super().test_flags()
 
-    @unittest.expectedFailure  # TODO: RUSTPYTHON; AttributeError: 'StringIO' object has no attribute 'newlines'. Did you mean: 'readlines'?
-    def test_newlines_property(self):
-        return super().test_newlines_property()
-
 class CStringIOPickleTest(PyStringIOPickleTest):
     UnsupportedOperation = io.UnsupportedOperation
 
@@ -1016,10 +1012,6 @@ class CStringIOPickleTest(PyStringIOPickleTest):
             return pickle.loads(pickle.dumps(io.StringIO(*args, **kwargs)))
         def __init__(self, *args, **kwargs):
             pass
-
-    @unittest.expectedFailure  # TODO: RUSTPYTHON; AttributeError: 'StringIO' object has no attribute 'newlines'. Did you mean: 'readlines'?
-    def test_newlines_property(self):
-        return super().test_newlines_property()
 
 if __name__ == '__main__':
     unittest.main()

--- a/crates/vm/src/stdlib/_io.rs
+++ b/crates/vm/src/stdlib/_io.rs
@@ -4445,6 +4445,7 @@ mod _io {
             });
             *zelf.buffer.write() = BufferedIO::new(Cursor::new(raw_bytes));
             zelf.newline.store(newline);
+            zelf.seennl.store(SeenNewline::empty());
             if let Some(object) = object {
                 zelf.observe_newlines(object.as_wtf8(), newline);
             }
@@ -4533,8 +4534,12 @@ mod _io {
         }
 
         #[pygetset]
-        fn newlines(&self, vm: &VirtualMachine) -> PyObjectRef {
-            self.seennl.load().to_pyobject(vm)
+        fn newlines(&self, vm: &VirtualMachine) -> PyResult {
+            if self.closed.load() {
+                Err(io_closed_error(vm))
+            } else {
+                Ok(self.seennl.load().to_pyobject(vm))
+            }
         }
 
         #[pymethod]

--- a/crates/vm/src/stdlib/_io.rs
+++ b/crates/vm/src/stdlib/_io.rs
@@ -4187,6 +4187,37 @@ mod _io {
         }
     }
 
+    impl SeenNewline {
+        fn observe(&mut self, text: &Wtf8) {
+            let bytes = text.as_bytes();
+            let mut matches = memchr::memchr2_iter(b'\r', b'\n', bytes);
+            while !self.is_all() {
+                let Some(i) = matches.next() else { break };
+                match bytes[i] {
+                    b'\n' => self.insert(Self::LF),
+                    _ if bytes.get(i + 1) == Some(&b'\n') => {
+                        matches.next();
+                        self.insert(Self::CRLF);
+                    }
+                    _ => self.insert(Self::CR),
+                }
+            }
+        }
+
+        fn to_pyobject(self, vm: &VirtualMachine) -> PyObjectRef {
+            match self.bits() {
+                1 => "\n".to_pyobject(vm),
+                2 => "\r".to_pyobject(vm),
+                3 => ("\r", "\n").to_pyobject(vm),
+                4 => "\r\n".to_pyobject(vm),
+                5 => ("\n", "\r\n").to_pyobject(vm),
+                6 => ("\r", "\r\n").to_pyobject(vm),
+                7 => ("\r", "\n", "\r\n").to_pyobject(vm),
+                _ => vm.ctx.none(),
+            }
+        }
+    }
+
     impl DefaultConstructor for IncrementalNewlineDecoder {}
 
     #[derive(FromArgs)]
@@ -4278,16 +4309,7 @@ mod _io {
         #[pygetset]
         fn newlines(&self, vm: &VirtualMachine) -> PyResult {
             let data = self.lock(vm)?;
-            Ok(match data.seennl.bits() {
-                1 => "\n".to_pyobject(vm),
-                2 => "\r".to_pyobject(vm),
-                3 => ("\r", "\n").to_pyobject(vm),
-                4 => "\r\n".to_pyobject(vm),
-                5 => ("\n", "\r\n").to_pyobject(vm),
-                6 => ("\r", "\r\n").to_pyobject(vm),
-                7 => ("\r", "\n", "\r\n").to_pyobject(vm),
-                _ => vm.ctx.none(),
-            })
+            Ok(data.seennl.to_pyobject(vm))
         }
     }
 
@@ -4334,20 +4356,7 @@ mod _io {
                     self.seennl.insert(SeenNewline::LF);
                 }
             } else if !self.translate {
-                let output = output.as_bytes();
-                let mut matches = memchr::memchr2_iter(b'\r', b'\n', output);
-                while !self.seennl.is_all() {
-                    let Some(i) = matches.next() else { break };
-                    match output[i] {
-                        b'\n' => self.seennl.insert(SeenNewline::LF),
-                        // if c isn't \n, it can only be \r
-                        _ if output.get(i + 1) == Some(&b'\n') => {
-                            matches.next();
-                            self.seennl.insert(SeenNewline::CRLF);
-                        }
-                        _ => self.seennl.insert(SeenNewline::CR),
-                    }
-                }
+                self.seennl.observe(&output);
             } else {
                 let bytes = output.as_bytes();
                 let mut matches = memchr::memchr2_iter(b'\r', b'\n', bytes);
@@ -4390,6 +4399,7 @@ mod _io {
         _base: _TextIOBase,
         buffer: PyRwLock<BufferedIO>,
         newline: AtomicCell<Newlines>,
+        seennl: AtomicCell<SeenNewline>,
         closed: AtomicCell<bool>,
     }
 
@@ -4410,6 +4420,7 @@ mod _io {
                 _base: Default::default(),
                 buffer: PyRwLock::new(BufferedIO::new(Cursor::new(Vec::new()))),
                 newline: AtomicCell::new(Newlines::Lf),
+                seennl: AtomicCell::new(SeenNewline::empty()),
                 closed: AtomicCell::new(false),
             })
         }
@@ -4428,11 +4439,15 @@ mod _io {
                 OptionalArg::Present(None) => Newlines::Universal,
                 OptionalArg::Present(Some(newline)) => newline,
             };
-            let raw_bytes = object.flatten().map_or_else(Vec::new, |v| {
+            let object = object.flatten();
+            let raw_bytes = object.as_ref().map_or_else(Vec::new, |v| {
                 Self::translate_newlines(v.as_wtf8(), newline).into_bytes()
             });
             *zelf.buffer.write() = BufferedIO::new(Cursor::new(raw_bytes));
             zelf.newline.store(newline);
+            if let Some(object) = object {
+                zelf.observe_newlines(object.as_wtf8(), newline);
+            }
             Ok(())
         }
     }
@@ -4454,6 +4469,14 @@ mod _io {
                 Newlines::Cr => data.replace("\n".as_ref(), "\r".as_ref()),
                 Newlines::Crlf => data.replace("\n".as_ref(), "\r\n".as_ref()),
                 Newlines::Passthrough | Newlines::Lf => data.to_owned(),
+            }
+        }
+
+        fn observe_newlines(&self, data: &Wtf8, newline: Newlines) {
+            if matches!(newline, Newlines::Universal | Newlines::Passthrough) {
+                let mut seennl = self.seennl.load();
+                seennl.observe(data);
+                self.seennl.store(seennl);
             }
         }
 
@@ -4509,6 +4532,11 @@ mod _io {
             self.closed.load()
         }
 
+        #[pygetset]
+        fn newlines(&self, vm: &VirtualMachine) -> PyObjectRef {
+            self.seennl.load().to_pyobject(vm)
+        }
+
         #[pymethod]
         fn close(&self) {
             self.closed.store(true);
@@ -4517,8 +4545,11 @@ mod _io {
         // write string to underlying vector
         #[pymethod]
         fn write(&self, data: PyStrRef, vm: &VirtualMachine) -> PyResult<u64> {
-            let bytes = Self::translate_newlines(data.as_wtf8(), self.newline.load()).into_bytes();
-            self.buffer(vm)?
+            let newline = self.newline.load();
+            let bytes = Self::translate_newlines(data.as_wtf8(), newline).into_bytes();
+            let mut buffer = self.buffer(vm)?;
+            self.observe_newlines(data.as_wtf8(), newline);
+            buffer
                 .write(&bytes)
                 .ok_or_else(|| vm.new_type_error("Error Writing String"))?;
             Ok(data.char_len() as u64)
@@ -4678,6 +4709,11 @@ mod _io {
                 .map_err(|err| os_err(vm, err))?;
             drop(buffer);
             zelf.newline.store(newline);
+            let mut seennl = SeenNewline::empty();
+            if matches!(newline, Newlines::Universal | Newlines::Passthrough) {
+                seennl.observe(content.as_wtf8());
+            }
+            zelf.seennl.store(seennl);
 
             // Set __dict__ if provided
             if !vm.is_none(dict) {

--- a/extra_tests/snippets/stdlib_io_stringio.py
+++ b/extra_tests/snippets/stdlib_io_stringio.py
@@ -69,9 +69,25 @@ def test_05():
     assert f.readline() == ""
 
 
+def test_06():
+    f = StringIO(newline=None)
+    f.write("\r")
+    f.__init__("x\n", newline=None)
+    assert f.newlines == "\n"
+
+    f.close()
+    try:
+        f.newlines
+    except ValueError:
+        pass
+    else:
+        assert False
+
+
 if __name__ == "__main__":
     test_01()
     test_02()
     test_03()
     test_04()
     test_05()
+    test_06()


### PR DESCRIPTION
- [x] Closes #8513
- [x] This PR follows our [AI policy](https://github.com/RustPython/.github/blob/main/AI_POLICY.md)

AI assistance: Codex:gpt-5.6-sol

## Summary

Add `StringIO.newlines` and record newline forms observed from initial content,
`write()`, and state restoration. `StringIO` now matches CPython for
`newline=None` and `newline=""` while preserving its configured newline mode.

This also removes the two now-redundant RustPython expected-failure wrappers
from `test_memoryio`.

## Testing

- Compared `StringIO` newline modes with CPython
- `cargo run --release -- -m test test_memoryio`
- `prek run --all-files`
- `cargo clippy -p rustpython-vm --lib -- -D warnings`
- `cargo test --workspace --exclude rustpython_wasm --exclude rustpython-venvlauncher --exclude rustpython-capi`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved newline detection and reporting for incremental text decoding.
  * `StringIO` now reports newline styles encountered during initialization and writing.
  * Newline tracking is preserved when restoring `StringIO` state.
  * Accessing newline information after closing a `StringIO` now correctly raises a closed-file error.
  * Reinitializing `StringIO` with automatic newline handling resets and tracks newline information appropriately.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->