### PR TITLE
Collapse bare ExpectedExpression to 'invalid syntax'; fix '<>' diagnostic offset

### DIFF
--- a/Lib/test/test_flufl.py
+++ b/Lib/test/test_flufl.py
@@ -22,7 +22,6 @@ class FLUFLTests(unittest.TestCase):
         # parser reports the start of the token
         self.assertEqual(cm.exception.offset, 3)
 
-    @unittest.expectedFailure  # TODO: RUSTPYTHON
     def test_guido_as_bdfl(self):
         code = '2 {0} 3'
         compile(code.format('!='), '<BDFL test>', 'exec')
@@ -50,7 +49,6 @@ class FLUFLTests(unittest.TestCase):
         self.assertEqual(cm.exception.lineno, 1)
         self.assertEqual(cm.exception.offset, len(code) - 4)
 
-    @unittest.expectedFailure  # TODO: RUSTPYTHON
     def test_barry_as_bdfl_relative_import(self):
         code = "from .__future__ import barry_as_FLUFL;2 {0} 3"
         compile(code.format('!='), '<FLUFL test>', 'exec')

--- a/crates/compiler/src/lib.rs
+++ b/crates/compiler/src/lib.rs
@@ -362,7 +362,40 @@ fn cpython_parse_diagnostic_override(
         ));
     }
 
+    // `2 <> 3` outside Barry mode: ruff lexes `<` then an unexpected `>` and
+    // reports `ExpectedExpression` starting at the `>`. CPython's tokenizer
+    // treats `<>` as a single obsolete token and points at its start (the
+    // `<`) instead, so shift the reported location back over it.
+    source_error!(barry_flufl_obsolete_operator_error(error, source_text));
+
+    // CPython's PEG parser collapses a bare "expected an expression" failure
+    // into the generic "invalid syntax" message. rustpython-vm's `vm_new.rs`
+    // does this same collapse for its own callers; rustpython-compiler has no
+    // vm dependency, so mirror it here.
+    if matches!(&error.error, parser::ParseErrorType::ExpectedExpression) {
+        let (loc, end_loc) = adjusted_error_locations(source_file, error.location);
+        return Some(NormalizedParseDiagnostic::new(
+            parser::ParseErrorType::OtherError("invalid syntax".into()),
+            loc,
+            end_loc,
+        ));
+    }
+
     None
+}
+
+fn barry_flufl_obsolete_operator_error(
+    error: &parser::ParseError,
+    source: &str,
+) -> Option<(String, usize, usize)> {
+    if !matches!(&error.error, parser::ParseErrorType::ExpectedExpression) {
+        return None;
+    }
+    let start = error.location.start().to_usize();
+    if start == 0 || source.as_bytes().get(start - 1) != Some(&b'<') {
+        return None;
+    }
+    Some(("invalid syntax".to_string(), start - 1, start + 1))
 }
 
 fn eof_parse_diagnostic(

--- a/crates/compiler/src/lib.rs
+++ b/crates/compiler/src/lib.rs
@@ -395,6 +395,9 @@ fn barry_flufl_obsolete_operator_error(
     if start == 0 || source.as_bytes().get(start - 1) != Some(&b'<') {
         return None;
     }
+    if source.as_bytes().get(start) != Some(&b'>') {
+        return None;
+    }
     Some(("invalid syntax".to_string(), start - 1, start + 1))
 }
 


### PR DESCRIPTION
- [ ] Closes #xxxx
- [x] This PR follows our [AI policy](https://github.com/RustPython/.github/blob/main/AI_POLICY.md)

## AI disclosure

This PR was implemented by Claude Code (Anthropic, Claude Sonnet 5), driven
interactively by a human maintainer of a downstream RustPython consumer
(Pyre) across a full session: the human directed the investigation, reviewed
and steered each step, and made the call to open this PR. The commit carries
an `Assisted-by: Claude Code:claude-sonnet-5` trailer per policy. The change
itself is small and self-contained (~30 lines in one function), and has been
exercised against CPython's `test_flufl.py` via the downstream consumer
mentioned below, plus a spot-check regression pass over `test_grammar`,
`test_syntax`, `test_tokenize`, and `test_compile` showing no behavior change
outside the two fixed cases.

## Summary
- `ParseErrorType::ExpectedExpression` currently surfaces as the raw ruff
  parser message (e.g. "Expected an expression") to callers that only depend
  on `rustpython-compiler` (no `rustpython-vm`). `rustpython-vm`'s
  `vm_new.rs` already collapses this to CPython's generic `"invalid syntax"`
  for its own callers; this mirrors that same collapse inside
  `cpython_parse_diagnostic_override` so non-vm consumers get the same
  CPython-compatible message.
- A bare `<>` outside Barry-as-BDFL mode (`2 <> 3`) lexes as `Less` then an
  unexpected `Greater`, so the resulting `ExpectedExpression` location points
  at the `>` — one character past where CPython's tokenizer (which treats
  `<>` as a single obsolete token) reports the error. Detect the `<`
  immediately preceding the location and shift the reported range back over
  it.

This is a companion to a `RustPython/ruff` PR implementing real
Barry-as-BDFL tokenizer support, which needs the offset fix here to make
CPython's `test_flufl.py` pass end to end. It's independently useful for any
caller hitting these two message/offset mismatches outside Barry mode too.

## Test plan
- Reproduced against CPython's `Lib/test/test_flufl.py` (via a downstream
  consumer, Pyre) — `test_guido_as_bdfl` and
  `test_barry_as_bdfl_relative_import` now pass with correct message text
  and offset.
- `cargo check -p rustpython-compiler` passes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved syntax error messages for obsolete `<>` usage.
  * Standardized certain parser errors as “invalid syntax.”
  * Adjusted error locations so diagnostics highlight the correct source text.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->