### PR TITLE
marshal: allow runtime bags to preserve raw code bytes

### DIFF
--- a/crates/compiler-core/src/marshal.rs
+++ b/crates/compiler-core/src/marshal.rs
@@ -586,6 +586,33 @@ pub trait MarshalBag: Copy {
         self.make_code(code)
     }
 
+    /// Decode the public `co_code` byte string into the execution-oriented
+    /// instruction storage.
+    ///
+    /// Runtime code-object implementations may accept byte values that the
+    /// compiler's `Instruction` enum cannot represent, retaining those bytes
+    /// separately and substituting a non-executable placeholder here.  The
+    /// default remains the strict compiler representation.
+    fn code_units_from_bytes(&self, code_bytes: &[u8]) -> Result<CodeUnits> {
+        CodeUnits::try_from(code_bytes)
+    }
+
+    /// Construct a runtime code object while retaining both its exact public
+    /// `co_code` bytes and the exact values read from `co_consts`.
+    ///
+    /// The default ignores the redundant byte spelling because ordinary
+    /// compiler code is represented losslessly by `CodeUnits`.  Runtime bags
+    /// that accepted otherwise unrepresentable opcode bytes in
+    /// [`MarshalBag::code_units_from_bytes`] can preserve them here.
+    fn make_code_with_constants_and_bytes(
+        &self,
+        code: CodeObject<<Self::ConstantBag as ConstantBag>::Constant>,
+        constants: Vec<Self::Value>,
+        _code_bytes: Vec<u8>,
+    ) -> Result<Self::Value> {
+        self.make_code_with_constants(code, constants)
+    }
+
     fn make_stop_iter(&self) -> Result<Self::Value>;
 
     fn make_list(&self, it: impl Iterator<Item = Self::Value>) -> Result<Self::Value>;
@@ -967,7 +994,7 @@ fn deserialize_code_value_inner<R: Read, Bag: MarshalBag>(
         kwonlyarg_count,
         flags,
     )?;
-    let instructions = CodeUnits::try_from(code_bytes.as_slice())?;
+    let instructions = bag.code_units_from_bytes(&code_bytes)?;
     let locations = linetable_to_locations(&linetable, first_line_raw, instructions.len());
     let constant_bag = bag.constant_bag();
     let code = CodeObject {
@@ -1006,7 +1033,7 @@ fn deserialize_code_value_inner<R: Read, Bag: MarshalBag>(
         linetable,
         exceptiontable,
     };
-    bag.make_code_with_constants(code, constant_values)
+    bag.make_code_with_constants_and_bytes(code, constant_values, code_bytes)
 }
 
 fn deserialize_value_typed<R: Read, Bag: MarshalBag>(


### PR DESCRIPTION
## Summary

- add a `MarshalBag::code_units_from_bytes` hook for runtime-specific decoding of marshalled `co_code`
- add a `make_code_with_constants_and_bytes` hook so a runtime can retain the exact public byte string
- preserve the existing strict `CodeUnits` behavior by default

## Motivation

Runtime code objects may accept raw opcode bytes that are not representable by the compiler-core `Instruction` enum. CPython and PyPy allow such code objects to round-trip through `marshal`; execution rejects the unknown opcode later. The current shared deserializer rejects these bytes before a runtime bag can preserve them.

These defaulted hooks keep compiler-core behavior unchanged while allowing runtimes with a raw-byte fallback to implement that behavior without duplicating the marshal parser.

## Validation

- `cargo fmt --all -- --check`
- `cargo test -p rustpython-compiler-core`

This is a draft while the downstream runtime integration is validated.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added customizable handling for converting serialized code bytes into executable code units.
  * Added a construction hook that can access both decoded constants and the original code bytes during deserialization.
  * Preserved existing default behavior for standard runtime code loading.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->