### PR TITLE
compiler-core: implement DerefMut and IndexMut for Constants

### DIFF
--- a/crates/compiler-core/src/bytecode.rs
+++ b/crates/compiler-core/src/bytecode.rs
@@ -11,7 +11,7 @@ use bitflags::bitflags;
 use core::{
     cell::UnsafeCell,
     hash, mem,
-    ops::{Deref, Index, IndexMut},
+    ops::{Deref, DerefMut, Index, IndexMut},
     sync::atomic::{AtomicU8, AtomicU16, AtomicUsize, Ordering},
 };
 use itertools::Itertools;
@@ -383,11 +383,23 @@ impl<C: Constant> Deref for Constants<C> {
     }
 }
 
+impl<C: Constant> DerefMut for Constants<C> {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.0
+    }
+}
+
 impl<C: Constant> Index<oparg::ConstIdx> for Constants<C> {
     type Output = C;
 
     fn index(&self, consti: oparg::ConstIdx) -> &Self::Output {
         &self.0[consti.as_usize()]
+    }
+}
+
+impl<C: Constant> IndexMut<oparg::ConstIdx> for Constants<C> {
+    fn index_mut(&mut self, consti: oparg::ConstIdx) -> &mut Self::Output {
+        &mut self.0[consti.as_usize()]
     }
 }
 


### PR DESCRIPTION
`Constants<C>` is a newtype over `Box<[C]>` that exposes `Deref` and
`Index<oparg::ConstIdx>` but neither mutable counterpart. An owner of a
`CodeObject` can therefore read a constant but cannot replace one in place —
the field is public, but `Constants`' own `.0` is not, so the only way to
change a single entry is to map the whole slice and rebuild it with
`FromIterator`.

This adds the two missing halves. The file already carries both sides of the
same pair for `VarNum` (`impl<T> Index<oparg::VarNum> for [T]` and its
`IndexMut`), so this makes `ConstIdx` symmetric with it.

No behaviour change: both impls are new trait implementations over the
existing private field, and nothing in the tree currently mutates a
`Constants` value.

Motivation: an out-of-tree consumer of `rustpython-compiler-core` that owns
its `CodeObject`s rewrites nested code constants (the `_imp._fix_co_filename`
path) and today has to rebuild the constants array to do it, which also moves
every entry and invalidates pointers into it. RustPython itself does not need
this — `update_code_filenames` reaches its nested code objects as already
wrapped `PyRef<PyCode>` and mutates them through interior mutability — so this
is an API-completeness change rather than a fix for in-tree code.

— *commented by Claude*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for modifying values through mutable dereferencing.
  * Added support for updating constant entries by index.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->