### PR TITLE
`str.format`: fix not raising for unknown conversions

### DIFF
--- a/crates/vm/src/format.rs
+++ b/crates/vm/src/format.rs
@@ -143,14 +143,21 @@ fn format_internal(
                     FormatString::from_str(format_spec).map_err(|e| e.to_pyexception(vm))?;
                 let format_spec = format_internal(vm, &nested_format, field_func)?;
 
-                let argument = match conversion_spec.and_then(FormatConversion::from_char) {
-                    Some(FormatConversion::Str) => argument.str(vm)?.into(),
-                    Some(FormatConversion::Repr) => argument.repr(vm)?.into(),
-                    Some(FormatConversion::Ascii) => builtins::ascii(argument, vm)?.into(),
-                    Some(FormatConversion::Bytes) => {
-                        vm.call_method(&argument, identifier!(vm, decode).as_str(), ())?
-                    }
+                let argument = match conversion_spec {
                     None => argument,
+                    Some(c) => match FormatConversion::from_char(*c) {
+                        Some(FormatConversion::Str) => argument.str(vm)?.into(),
+                        Some(FormatConversion::Repr) => argument.repr(vm)?.into(),
+                        Some(FormatConversion::Ascii) => builtins::ascii(argument, vm)?.into(),
+                        Some(FormatConversion::Bytes) => {
+                            vm.call_method(&argument, identifier!(vm, decode).as_str(), ())?
+                        }
+                        None => {
+                            return Err(
+                                vm.new_value_error(format!("Unknown conversion specifier {c}"))
+                            );
+                        }
+                    },
                 };
 
                 // FIXME: compiler can intern specs using parser tree. Then this call can be interned_str
@@ -218,4 +225,22 @@ pub(crate) fn format_map(
         }
         FieldType::Keyword(keyword) => dict.get_item(&keyword, vm),
     })
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::Interpreter;
+    use crate::object::AsObject;
+
+    // Regression test; remove once expectedFailure is removed from test_format in test_str.py.
+    #[test]
+    fn format_rejects_unknown_conversion_specifier() {
+        Interpreter::without_stdlib(Default::default()).enter(|vm| {
+            let source = String::from("'{0!x}'.format(3)");
+            let scope = vm.new_scope_with_builtins();
+            let err = crate::eval::eval(vm, &source, scope, "<unittest>")
+                .expect_err("unknown conversion specifier should raise");
+            assert!(err.fast_isinstance(vm.ctx.exceptions.value_error));
+        })
+    }
 }

--- a/crates/vm/src/format.rs
+++ b/crates/vm/src/format.rs
@@ -226,21 +226,3 @@ pub(crate) fn format_map(
         FieldType::Keyword(keyword) => dict.get_item(&keyword, vm),
     })
 }
-
-#[cfg(test)]
-mod tests {
-    use crate::Interpreter;
-    use crate::object::AsObject;
-
-    // Regression test; remove once expectedFailure is removed from test_format in test_str.py.
-    #[test]
-    fn format_rejects_unknown_conversion_specifier() {
-        Interpreter::without_stdlib(Default::default()).enter(|vm| {
-            let source = String::from("'{0!x}'.format(3)");
-            let scope = vm.new_scope_with_builtins();
-            let err = crate::eval::eval(vm, &source, scope, "<unittest>")
-                .expect_err("unknown conversion specifier should raise");
-            assert!(err.fast_isinstance(vm.ctx.exceptions.value_error));
-        })
-    }
-}

--- a/extra_tests/snippets/builtin_format.py
+++ b/extra_tests/snippets/builtin_format.py
@@ -32,6 +32,16 @@ except ValueError as error:
 else:
     raise AssertionError("expected ValueError for '=8s' string format specifier")
 
+# regression: unknown conversion specifiers used to be silently ignored instead of raising.
+# The ValueError case itself is covered by test_str, but here we're testing the error message.
+try:
+    "{0!x}".format(3)
+except ValueError as error:
+    if str(error) != "Unknown conversion specifier x":
+        raise AssertionError(f"unexpected error message: {error}") from error
+else:
+    raise AssertionError("expected ValueError for unknown conversion specifier '!x'")
+
 assert "{:,}".format(100) == "100"
 assert "{:,}".format(1024) == "1,024"
 assert "{:_}".format(65536) == "65_536"


### PR DESCRIPTION
<!--
Thanks for your contribution!
-->

- [x] This PR follows our [AI policy](https://github.com/RustPython/.github/blob/main/AI_POLICY.md)

## Summary

Hi! Fixing an issue with `str.format` not raising `ValueError` on unknown format specifiers.

```python
"{!z}".format(42)

# CPython, RustPython now:
# ValueError: Unknown conversion specifier z

# RustPython before this commit:
'42'
```

It was caused by code in `vm/format.rs` - `conversion_spec` is passed there as `&Option<CodePoint>` and then processed using `.and_then`. 
`FormatConversion::from_char` is capable of returning `None` for unknown specifiers.
But in this code `None` from `from_char` (unknown specifier)  and from `conversion_spec` (just missing specifier) got mixed up and end up both being interpreted as "missing specifier".

https://github.com/RustPython/RustPython/blob/dd2cc4d77a625661e5ca189f1cf9be199ecaa434/crates/vm/src/format.rs#L145-L147

It could have been caught by test from CPython, but it's currently marked with `expectedFailure` due to other issues, so I've added a regression test to `vm/format.rs` directly.

https://github.com/RustPython/RustPython/blob/dd2cc4d77a625661e5ca189f1cf9be199ecaa434/Lib/test/test_str.py#L1323

---

A side note - I've actually got investigating this, because noticed `FormatConversion::Bytes`, which doesn't really exist in Python - there's just str, repr and ascii, so it might be the next thing I'll try to figure out. Actually found in ruff downstream and then learned that its formatter's code was pulled from RustPython awhile ago.
I also might be able to look into other failing test in `test_format` to eventually drop `expectedFailure`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Invalid format conversion specifiers now raise a `ValueError` instead of being silently ignored.
  * Added coverage to verify the corrected formatting behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->