### PR TITLE
Fix re.findall reporting a group that did not match

### DIFF
--- a/crates/vm/src/stdlib/_sre.rs
+++ b/crates/vm/src/stdlib/_sre.rs
@@ -452,15 +452,25 @@ mod _sre {
                 let mut match_list: Vec<PyObjectRef> = Vec::new();
                 let mut iter = SearchIter { req, state };
 
+                // What a group that took no part in the match is reported as.
+                // `findall` hands back the matched text rather than a match
+                // object, so the stand-in has to be an empty value of the type
+                // the pattern works on. `Match.groups` still reports `None` and
+                // is not affected by this.
+                let empty: PyObjectRef = if zelf.isbytes {
+                    vm.ctx.new_bytes(vec![]).into()
+                } else {
+                    vm.ctx.new_str(ascii!("")).into()
+                };
+
                 while iter.next().is_some() {
                     let m = Match::new(&mut iter.state, zelf.clone(), string_args.string.clone());
 
                     let item = if zelf.groups == 0 || zelf.groups == 1 {
                         m.get_slice(zelf.groups, s, vm)
-                            .unwrap_or_else(|| vm.ctx.none())
+                            .unwrap_or_else(|| empty.clone())
                     } else {
-                        m.groups(OptionalArg::Present(vm.ctx.new_str(ascii!("")).into()), vm)?
-                            .into()
+                        m.groups(OptionalArg::Present(empty.clone()), vm)?.into()
                     };
 
                     match_list.push(item);

--- a/extra_tests/snippets/stdlib_re.py
+++ b/extra_tests/snippets/stdlib_re.py
@@ -82,3 +82,47 @@ assert re.fullmatch(r"([0-9]++(?:\.[0-9]+)*+)", "1.25.38").group(0) == "1.25.38"
 
 # Combining characters; issue #7518
 assert not re.match(r"\w", "\u0345"), r"\w should not match U+0345 (category Mn)"
+
+
+def test_findall_group_that_did_not_participate():
+    # findall returns the matched text, not a match object, so a group that
+    # took no part in the match stands in as an empty value of the type the
+    # pattern works on. One group used to come back as None, and a bytes
+    # pattern used to mix str into its results.
+    assert re.findall(r"(a)?b", "b ab") == ["", "a"]
+    assert re.findall(r"(x)?", "a") == ["", ""]
+    assert re.findall(r"(a|b)?c", "c ac bc") == ["", "a", "b"]
+    assert re.findall(r"(?P<g>a)?b", "b ab") == ["", "a"]
+    assert re.compile(r"(a)?b").findall("b ab") == ["", "a"]
+
+    assert re.findall(rb"(a)?b", b"b ab") == [b"", b"a"]
+    assert re.findall(rb"(x)?", b"a") == [b"", b""]
+
+    # Two or more groups give a tuple per match, with the same stand-in.
+    assert re.findall(r"(a)|(b)", "ab") == [("a", ""), ("", "b")]
+    assert re.findall(rb"(a)|(b)", b"ab") == [(b"a", b""), (b"", b"b")]
+    assert re.findall(rb"(a)(b)?", b"a ab") == [(b"a", b""), (b"a", b"b")]
+
+    # The type is the pattern's, never the other one.
+    assert [type(x) for x in re.findall(r"(a)?b", "b ab")] == [str, str]
+    assert [type(x) for x in re.findall(rb"(a)?b", b"b ab")] == [bytes, bytes]
+    assert [type(y) for x in re.findall(rb"(a)|(b)", b"ab") for y in x] == [
+        bytes,
+        bytes,
+        bytes,
+        bytes,
+    ]
+
+    # A group that does participate, and no group at all, are unchanged.
+    assert re.findall(r"(a)", "aa") == ["a", "a"]
+    assert re.findall(r"a", "aa") == ["a", "a"]
+    assert re.findall(rb"a", b"aa") == [b"a", b"a"]
+
+    # A match object still reports None, which is where the difference lies.
+    assert re.match(r"(a)?b", "b").groups() == (None,)
+    assert re.match(r"(a)?b", "b").group(1) is None
+    assert [m.groups() for m in re.finditer(r"(a)?b", "b ab")] == [(None,), ("a",)]
+    assert re.split(r"(a)|(b)", "xaybz") == ["x", "a", None, "y", None, "b", "z"]
+
+
+test_findall_group_that_did_not_participate()


### PR DESCRIPTION
`re.findall` hands back the matched text rather than a match object, so a group that took no part in the match is reported as an empty string. With one group it was reported as `None`:

```pycon
>>> re.findall(r"(a)?b", "b ab")
[None, 'a']          # CPython: ['', 'a']
>>> re.findall(r"(x)?", "a")
[None, None]         # CPython: ['', '']
```

Anything reading the result as a list of strings gets a `TypeError` from `"".join(...)`, from `max(..., key=len)`, from a `.strip()` in a loop. With two groups it was already right, because that branch passes `""` to `Match.groups` as the default while the one-group branch fell through to `None`. The two halves of the same function disagreed.

While pinning that down, the same line turned up a second one. The default is built as a `str` whatever the pattern is, so a `bytes` pattern comes back with `str` mixed into it:

```pycon
>>> re.findall(rb"(a)|(b)", b"ab")
[(b'a', ''), ('', b'b')]        # CPython: [(b'a', b''), (b'', b'b')]
>>> [type(y).__name__ for x in re.findall(rb"(a)|(b)", b"ab") for y in x]
['bytes', 'str', 'str', 'bytes']
```

That one is on the two-group branch, so it is there on `main` today and is not a consequence of the first fix. Both come from the same decision, so the empty value is now built once from `zelf.isbytes`, using the idiom `sub_impl` already uses a few lines up, and both branches take it.

`Match.groups()` keeps reporting `None`, which is what CPython does and is the reason the two are easy to confuse. `re.split` keeps `None` as well. Both are covered by the tests so a later change cannot quietly pull them along.

Checked against CPython 3.14.7 over 41 cases: one group participating and not, named groups, zero groups, two and three groups, `str` and `bytes`, the compiled-pattern form, and the neighbours that share the match machinery (`finditer`, `group`, `groups`, `groupdict`, `split`, `sub`, `expand`). All 41 agree now. Without the change 20 of them differ.

`Lib/test/test_re.py::test_re_findall` only uses groups that participate, or two groups, so the suite passes either way. It still passes here, 166 tests. The new cases are in `extra_tests/snippets/stdlib_re.py`, and they also assert the result types, since that is where the `bytes` half went wrong.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed `re.findall` so unmatched capturing groups consistently return an empty value matching the pattern type: `""` for text patterns and `b""` for byte patterns.
  - Preserved existing behavior for participating groups, patterns without groups, and other matching APIs.

- **Tests**
  - Added coverage for unmatched groups across text and byte patterns, including single- and multi-group results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->