### PR TITLE
Drop the lint expectations clippy 1.98 no longer fulfils

### DIFF
--- a/crates/host_env/src/fileutils.rs
+++ b/crates/host_env/src/fileutils.rs
@@ -445,10 +445,6 @@ pub unsafe fn fclose(fp: *mut CFile) -> core::ffi::c_int {
 // _Py_fopen_obj in cpython (Python/fileutils.c:1757-1835)
 // Open a file using std::fs::File and convert to FILE*
 // Automatically handles path encoding and EINTR retries
-#[expect(
-    clippy::std_instead_of_core,
-    reason = "false positive: core::io::ErrorKind is unstable (core_io)"
-)]
 pub fn fopen(path: &std::path::Path, mode: &str) -> std::io::Result<*mut CFile> {
     use std::fs::File;
 

--- a/crates/stdlib/src/pyexpat.rs
+++ b/crates/stdlib/src/pyexpat.rs
@@ -1,8 +1,5 @@
 //! Pyexpat builtin module
 
-// false positive: core::io::Cursor is unstable (core_io), unusable on stable
-#![expect(clippy::std_instead_of_core)]
-
 // spell-checker: ignore libexpat
 
 pub(crate) use _pyexpat::module_def;

--- a/crates/stdlib/src/ssl.rs
+++ b/crates/stdlib/src/ssl.rs
@@ -13,9 +13,6 @@
 //!
 //! Warning: This library contains AI-generated code and comments. Do not trust any code or comment without verification. Please have a qualified expert review the code and remove this notice after review.
 
-// false positive: core::io::{Cursor, ErrorKind} are unstable (core_io), unusable on stable
-#![expect(clippy::std_instead_of_core)]
-
 // OID (Object Identifier) management module
 mod oid;
 

--- a/crates/vm/src/stdlib/_io.rs
+++ b/crates/vm/src/stdlib/_io.rs
@@ -113,10 +113,6 @@ impl std::os::fd::AsRawFd for Fildes {
 }
 
 #[pymodule]
-#[expect(
-    clippy::std_instead_of_core,
-    reason = "false positive: core::io items (Cursor, etc.) are unstable (core_io)"
-)]
 mod _io {
     use super::*;
     use crate::{


### PR DESCRIPTION
- [x] This PR follows our [AI policy](https://github.com/RustPython/.github/blob/main/AI_POLICY.md)

## Summary

The three clippy jobs and the WASM check fail on current stable for any pull request, whatever it touches:

```
error: this lint expectation is unfulfilled
   --> crates/host_env/src/fileutils.rs:449:5
    |
449 |     clippy::std_instead_of_core,
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = note: false positive: core::io::ErrorKind is unstable (core_io)
    = note: `-D unfulfilled-lint-expectations` implied by `-D warnings`
```

`clippy::std_instead_of_core` no longer fires at four of the places that carry an `#[expect]` for it, all four written for the same false positive on items whose `core` counterpart is still unstable. Once the lint stops firing, `unfulfilled_lint_expectations` turns each of those attributes into an error under `-D warnings`, and the crate fails to check.

Removing the four is enough. The other two `#[expect(clippy::std_instead_of_core)]` in the tree, in `crates/host_env/src/posix.rs` and `crates/vm/src/stdlib/_signal.rs`, still fire, so they stay.

## Test Plan

rustc 1.98.0 (88d9e12ae 2026-08-18) in a Debian container.

The command CI runs, with the same flags:

```
cargo clippy --keep-going --no-default-features \
  --features stdlib,importlib,stdio,encodings,sqlite,ssl-rustls-aws-lc,host_env \
  --workspace --all-targets \
  --exclude rustpython_wasm --exclude rustpython-compiler-source --exclude rustpython-venvlauncher \
  -- -Dwarnings
```

finishes clean here. Without the change it stops at `crates/host_env/src/fileutils.rs:449`, then at `crates/vm/src/stdlib/_io.rs:117`, then at `crates/stdlib/src/pyexpat.rs:4` and `crates/stdlib/src/ssl.rs:17`. The same four jobs are red on #8561, #8562 and #8563 for the first of those.

Also run: `cargo fmt --check`, clean, and `cargo test --workspace --exclude rustpython_wasm --exclude rustpython-venvlauncher --exclude rustpython-capi`, 41 test binaries and no failures.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Removed obsolete internal lint configuration.
  * No user-facing behavior, functionality, or public API changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->