### PR TITLE
Insert the item rather than its key in bisect.insort

### DIFF
--- a/crates/stdlib/src/bisect.rs
+++ b/crates/stdlib/src/bisect.rs
@@ -106,15 +106,15 @@ mod _bisect {
 
     #[pyfunction]
     fn insort_left(BisectArgs { a, x, lo, hi, key }: BisectArgs, vm: &VirtualMachine) -> PyResult {
-        let x = if let Some(ref key) = key {
-            key.call((x,), vm)?
-        } else {
-            x
+        // The search runs on the key, the insert has to put back the item itself.
+        let needle = match key {
+            Some(ref key) => key.call((x.clone(),), vm)?,
+            None => x.clone(),
         };
         let index = bisect_left(
             BisectArgs {
                 a: a.clone(),
-                x: x.clone(),
+                x: needle,
                 lo,
                 hi,
                 key,
@@ -126,15 +126,15 @@ mod _bisect {
 
     #[pyfunction]
     fn insort_right(BisectArgs { a, x, lo, hi, key }: BisectArgs, vm: &VirtualMachine) -> PyResult {
-        let x = if let Some(ref key) = key {
-            key.call((x,), vm)?
-        } else {
-            x
+        // The search runs on the key, the insert has to put back the item itself.
+        let needle = match key {
+            Some(ref key) => key.call((x.clone(),), vm)?,
+            None => x.clone(),
         };
         let index = bisect_right(
             BisectArgs {
                 a: a.clone(),
-                x: x.clone(),
+                x: needle,
                 lo,
                 hi,
                 key,

--- a/extra_tests/snippets/stdlib_bisect.py
+++ b/extra_tests/snippets/stdlib_bisect.py
@@ -1,0 +1,73 @@
+from bisect import bisect_left, bisect_right, insort, insort_left, insort_right
+
+# A key decides where the item goes, but the item is what gets stored.
+for insort_fn in (insort, insort_left, insort_right):
+    words = ["a", "ccc"]
+    insort_fn(words, "bb", key=len)
+    assert words == ["a", "bb", "ccc"], (insort_fn.__name__, words)
+
+    numbers = [1, 3]
+    insort_fn(numbers, -2, key=abs)
+    assert numbers == [1, -2, 3], (insort_fn.__name__, numbers)
+
+    pairs = [(1, "a"), (3, "b")]
+    insort_fn(pairs, (2, "x"), key=lambda pair: pair[0])
+    assert pairs == [(1, "a"), (2, "x"), (3, "b")], (insort_fn.__name__, pairs)
+
+
+descending = [3, 1]
+insort(descending, 2, key=lambda value: -value)
+assert descending == [3, 2, 1], descending
+
+
+class Tagged:
+    def __init__(self, size, tag):
+        self.size = size
+        self.tag = tag
+
+
+def sizes_and_tags(items):
+    return [(item.size, item.tag) for item in items]
+
+
+by_size = [Tagged(1, "old"), Tagged(2, "old")]
+
+# On a tie, left goes before the equal element and right goes after it.
+left = list(by_size)
+insort_left(left, Tagged(2, "new"), key=lambda item: item.size)
+assert sizes_and_tags(left) == [(1, "old"), (2, "new"), (2, "old")]
+
+right = list(by_size)
+insort_right(right, Tagged(2, "new"), key=lambda item: item.size)
+assert sizes_and_tags(right) == [(1, "old"), (2, "old"), (2, "new")]
+
+
+# The key runs once on the new item, whatever the search does afterwards.
+seen = []
+
+
+def counting_key(value):
+    seen.append(value)
+    return value
+
+
+data = [1, 3, 5, 7]
+insort(data, 4, key=counting_key)
+assert data == [1, 3, 4, 5, 7], data
+assert seen.count(4) == 1, seen
+
+
+# lo and hi bound the search and leave the inserted item alone.
+bounded = [3, 1]
+insort(bounded, 2, 0, 1, key=lambda value: -value)
+assert bounded == [3, 2, 1], bounded
+
+
+plain = [1, 3]
+insort(plain, 2)
+assert plain == [1, 2, 3], plain
+
+# The search takes the key value itself, so these two stay where they were.
+sizes = ["a", "bb", "ccc"]
+assert bisect_left(sizes, 2, key=len) == 1
+assert bisect_right(sizes, 2, key=len) == 2


### PR DESCRIPTION
- [x] This PR follows our [AI policy](https://github.com/RustPython/.github/blob/main/AI_POLICY.md)

## Summary

`bisect.insort` with a `key` stores what the key returned instead of the object it was given:

```pycon
>>> words = ["a", "ccc"]
>>> bisect.insort(words, "bb", key=len)
>>> words
['a', 2, 'ccc']                 # CPython: ['a', 'bb', 'ccc']

>>> pairs = [(1, "a"), (3, "b")]
>>> bisect.insort(pairs, (2, "x"), key=lambda pair: pair[0])
>>> pairs
[(1, 'a'), 2, (3, 'b')]         # CPython: [(1, 'a'), (2, 'x'), (3, 'b')]
```

The item is not misplaced, it is gone. A list of strings comes back holding an int, a list of tuples comes back holding the field the key read, and `key=abs` quietly turns `-2` into `2`.

`insort_left` and `insort_right` in `crates/stdlib/src/bisect.rs` rebind `x` to `key(x)` and then pass that same value to the search and to `a.insert`. CPython computes the key for the search and inserts the original object. `insort` is `insort_right`, so all three names carry it.

The key is still called once on the new item, which is what CPython does too.

## Why the suite is green

`Lib/test/test_bisect.py` passes on `main`. `test_insort` uses `abs` as its key function and asserts only that the target list stays sorted by that key. Since `abs(abs(x)) == abs(x)`, inserting the key instead of the item preserves the property the test measures, and nothing there ever compares the elements against what was passed in.

## Test Plan

Built in a Debian container on rustc 1.98.0.

- New snippet `extra_tests/snippets/stdlib_bisect.py`. It fails on `main` at the first assertion, with `AssertionError: ('insort_right', ['a', 2, 'ccc'])`, and passes with this change. Verified both ways by stashing only the Rust file and rebuilding.
- `pytest test_snippets.py -k stdlib_bisect` in `extra_tests`, both legs green: the snippet runs under CPython 3.14.7 and under this build.
- `cargo run --release -- -m test test_bisect`: 46 tests, SUCCESS.
- `cargo clippy` with the flags from CI, clean, and `cargo fmt --check` clean. `ruff format --check` and `ruff check --select I` clean on the snippet.
- `cargo test --workspace --exclude rustpython_wasm --exclude rustpython-venvlauncher --exclude rustpython-capi`: no failures.

The clippy and WASM jobs are red here for the reason in #8564, which is unrelated to this change.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved keyed insertion so objects are searched using their key while preserving the original object during insertion.
  * Ensured insertion keys are evaluated only once.
  * Preserved stable left/right placement for equal values and correct behavior for bounded or descending searches.

* **Tests**
  * Added coverage for keyed and plain insertion, bisect operations, ordering, and key evaluation behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->