### PR TITLE
Apply the format spec to a bool instead of dropping it

### DIFF
--- a/crates/common/src/format.rs
+++ b/crates/common/src/format.rs
@@ -829,6 +829,37 @@ impl FormatSpec {
         Ok(self.format_sign_and_align(&AsciiStr::new(&magnitude_str), "", FormatAlign::Right))
     }
 
+    /// Whether the spec carries nothing at all, which is what `format(value, "")`
+    /// parses to. Written as a destructure so a new field cannot be forgotten here.
+    fn is_empty(&self) -> bool {
+        let Self {
+            conversion,
+            fill,
+            align,
+            align_specified,
+            sign,
+            no_neg_0,
+            alternate_form,
+            width,
+            grouping_option,
+            precision,
+            frac_grouping_option,
+            format_type,
+        } = self;
+        conversion.is_none()
+            && fill.is_none()
+            && align.is_none()
+            && !align_specified
+            && sign.is_none()
+            && !no_neg_0
+            && !alternate_form
+            && width.is_none()
+            && grouping_option.is_none()
+            && precision.is_none()
+            && frac_grouping_option.is_none()
+            && format_type.is_none()
+    }
+
     pub fn format_bool(&self, input: bool) -> Result<String, FormatSpecError> {
         let x = u8::from(input);
         match &self.format_type {
@@ -844,13 +875,11 @@ impl FormatSpec {
             Some(FormatType::Exponent(_) | FormatType::FixedPoint(_) | FormatType::Percentage) => {
                 self.format_float(x as f64)
             }
-            None => {
-                if self.no_neg_0 {
-                    return Err(FormatSpecError::NegativeZeroCoercionNotAllowed("integer"));
-                }
-                let first_letter = (input.to_string().as_bytes()[0] as char).to_uppercase();
-                Ok(first_letter.collect::<String>() + &input.to_string()[1..])
-            }
+            // Only the empty spec spells the value out. Everything else without a
+            // presentation type, a width or an alignment included, formats `bool`
+            // the way it formats the `int` it is.
+            None if self.is_empty() => Ok(if input { "True" } else { "False" }.to_owned()),
+            None => self.format_int(&BigInt::from_u8(x).unwrap()),
             Some(format_type) => {
                 let ch = char::from(format_type);
                 Err(FormatSpecError::UnknownFormatCode(ch, "bool"))
@@ -1767,6 +1796,34 @@ mod tests {
         assert_eq!(format_bool("F", false), Ok("0.000000".to_owned()));
         assert_eq!(format_bool("%", true), Ok("100.000000%".to_owned()));
         assert_eq!(format_bool("%", false), Ok("0.000000%".to_owned()));
+    }
+
+    #[test]
+    fn format_bool_without_a_presentation_type() {
+        // The bare spec is the only one that spells the value out.
+        assert_eq!(format_bool("", true), Ok("True".to_owned()));
+        assert_eq!(format_bool("", false), Ok("False".to_owned()));
+
+        // Anything else formats the integer, the way `int.__format__` would.
+        assert_eq!(format_bool("5", true), Ok("    1".to_owned()));
+        assert_eq!(format_bool("<5", true), Ok("1    ".to_owned()));
+        assert_eq!(format_bool(">5", false), Ok("    0".to_owned()));
+        assert_eq!(format_bool("^5", true), Ok("  1  ".to_owned()));
+        assert_eq!(format_bool("05", true), Ok("00001".to_owned()));
+        assert_eq!(format_bool("+", true), Ok("+1".to_owned()));
+        assert_eq!(format_bool(" ", false), Ok(" 0".to_owned()));
+        assert_eq!(format_bool(",", true), Ok("1".to_owned()));
+        assert_eq!(format_bool("<", true), Ok("1".to_owned()));
+
+        // And it inherits the integer rules, precision included.
+        assert_eq!(
+            format_bool(".2", true),
+            Err(FormatSpecError::PrecisionNotAllowed)
+        );
+        assert_eq!(
+            format_bool("z", true),
+            Err(FormatSpecError::NegativeZeroCoercionNotAllowed("integer"))
+        );
     }
 
     #[test]

--- a/extra_tests/snippets/builtin_format.py
+++ b/extra_tests/snippets/builtin_format.py
@@ -269,3 +269,37 @@ assert "{:.4e}".format(1234.5) == "1.2345e+03"
 assert "{:.3g}".format(1234.5) == "1.23e+03"
 assert f"{float('nan'):.10f}" == "nan"
 assert f"{float('inf'):.10f}" == "inf"
+
+# bool has no __format__ of its own, so the int rules apply. Only the bare
+# spec spells the value out.
+assert format(True, "") == "True"
+assert format(False, "") == "False"
+assert f"{True}" == "True"
+assert f"{True:}" == "True"
+
+assert format(True, "5") == "    1"
+assert format(True, "<5") == "1    "
+assert format(False, ">5") == "    0"
+assert format(True, "^5") == "  1  "
+assert format(True, "=5") == "    1"
+assert format(True, "05") == "00001"
+assert format(False, "05") == "00000"
+assert format(True, "+") == "+1"
+assert format(False, " ") == " 0"
+assert format(True, ",") == "1"
+assert format(True, "<") == "1"
+assert "{:>6}|{:^6}".format(True, False) == "     1|  0   "
+
+# The presentation types were already right, and stay right.
+assert format(True, "d") == "1"
+assert format(True, "#b") == "0b1"
+assert format(False, "x") == "0"
+assert format(True, "c") == "\x01"
+assert format(True, "e") == "1.000000e+00"
+assert format(True, "%") == "100.000000%"
+
+# Precision belongs to no integer spec, bool included.
+assert_raises(ValueError, format, True, ".2")
+assert_raises(ValueError, format, True, "5.2")
+assert_raises(ValueError, format, True, "z")
+assert_raises(ValueError, format, True, "s")


### PR DESCRIPTION
- [x] This PR follows our [AI policy](https://github.com/RustPython/.github/blob/main/AI_POLICY.md)

## Summary

A `bool` ignores every format spec that does not name a presentation type:

```pycon
>>> f"{True:>5}"
'True'                            # CPython: '    1'
>>> "{:>6}|{:^6}".format(True, False)
'True|False'                      # CPython: '     1|  0   '
>>> format(True, "05")
'True'                            # CPython: '00001'
>>> format(True, ".2")
'True'                            # CPython: ValueError: Precision not allowed in integer format specifier
```

Width, fill, alignment, sign and the thousands separator are all dropped, and a spec that an integer would reject is accepted quietly. Lining a boolean column up in a table is the case that runs into this, since that spec has no type letter in it.

`format(True, "d")` and the rest of the presentation types were already right, which is why this only shows up on the specs that leave the letter out.

`FormatSpec::format_bool` has a `None` arm for "no presentation type" that returns the spelled out name whatever else the spec holds. CPython does not give `bool` a `__format__` at all:

```pycon
>>> "__format__" in vars(bool)
False
```

It inherits `int.__format__`, and the rule there is the one already written in `PyInt::__format__` in this tree: an empty spec on a subclass gives `str(self)`, anything else formats the integer. So the empty spec keeps the old answer and every other spec goes to `format_int`, which is also what restores `Precision not allowed in integer format specifier` and the `z` rejection.

`is_empty` is written as a destructure of `Self` rather than a chain of `self.field`, so that adding a field to `FormatSpec` later fails to compile here instead of silently making an empty spec look non-empty.

The literal `"True"` / `"False"` replaces a round trip through `to_string()` plus `to_uppercase()` on the first byte, in the arm that was being rewritten anyway.

## Test Plan

Built in a Debian container on rustc 1.98.0.

- `crates/common/src/format.rs` gains `format_bool_without_a_presentation_type`, next to the existing `format_bool_basic`. Without the change it fails with `left: Ok("True")` against `right: Ok("    1")`.
- `extra_tests/snippets/builtin_format.py` gains the same ground at the Python level, including the four specs that have to raise. Without the change it stops at `assert format(True, "5") == "    1"`.
- `pytest test_snippets.py -k builtin_format`, both legs green, so the file also holds under CPython 3.14.7.
- `-m test test_format`, `-m test test_bool` and `-m test test_types` on the release build: 18, 31 and 129 tests, all SUCCESS.
- `cargo clippy` with the flags CI uses, clean, and `cargo fmt --check` clean. `ruff format --check` and `ruff check --select I` clean on the snippet.
- `cargo test --workspace --exclude rustpython_wasm --exclude rustpython-venvlauncher --exclude rustpython-capi`: no failures.

The three clippy jobs and the WASM check are red for the reason in #8564, unrelated to this change.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved boolean formatting with integer-style alignment, width, zero-padding, signs, and grouping.
  * Added clear `True`/`False` output for empty formatting specifications.

* **Bug Fixes**
  * Boolean formatting now reports errors for unsupported precision and string-style specifications.
  * Missing presentation types correctly follow integer formatting behavior.
  * Unknown conversion specifiers now produce a clear `ValueError` message.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->