### PR TITLE
Drop what a deque with maxlen of zero is handed

### DIFF
--- a/crates/vm/src/stdlib/_collections.rs
+++ b/crates/vm/src/stdlib/_collections.rs
@@ -77,6 +77,10 @@ mod _collections {
         fn borrow_deque_mut(&self) -> PyRwLockWriteGuard<'_, VecDeque<PyObjectRef>> {
             self.deque.write()
         }
+
+        fn is_over_maxlen(&self, deque: &VecDeque<PyObjectRef>) -> bool {
+            self.maxlen.is_some_and(|maxlen| deque.len() > maxlen)
+        }
     }
 
     #[pyclass(
@@ -96,20 +100,22 @@ mod _collections {
         fn append(&self, obj: PyObjectRef) {
             self.state.fetch_add(1);
             let mut deque = self.borrow_deque_mut();
-            if self.maxlen == Some(deque.len()) {
+            deque.push_back(obj);
+            // Trim after pushing, so that a `maxlen` of zero drops what just
+            // arrived instead of popping from an empty deque and keeping it.
+            if self.is_over_maxlen(&deque) {
                 deque.pop_front();
             }
-            deque.push_back(obj);
         }
 
         #[pymethod]
         fn appendleft(&self, obj: PyObjectRef) {
             self.state.fetch_add(1);
             let mut deque = self.borrow_deque_mut();
-            if self.maxlen == Some(deque.len()) {
+            deque.push_front(obj);
+            if self.is_over_maxlen(&deque) {
                 deque.pop_back();
             }
-            deque.push_front(obj);
         }
 
         #[pymethod]

--- a/extra_tests/snippets/stdlib_collections_deque.py
+++ b/extra_tests/snippets/stdlib_collections_deque.py
@@ -108,3 +108,46 @@ if sys.implementation.name == "rustpython":
     # until the allocator gives up, so it is left out of this check.
     with assert_raises(MemoryError):
         deque([0]) * sys.maxsize
+
+
+# maxlen=0 keeps nothing, whichever end the item arrives at.
+d = deque(maxlen=0)
+d.append(1)
+d.appendleft(2)
+assert list(d) == []
+assert len(d) == 0
+assert d.maxlen == 0
+
+d = deque(maxlen=0)
+d.extend("abc")
+d.extendleft("abc")
+d += "abc"
+assert list(d) == []
+
+assert list(deque("abc", maxlen=0)) == []
+assert list(deque("ab", maxlen=0) * 3) == []
+assert list(deque("ab", maxlen=0) + deque("cd")) == []
+
+d = deque("abc", maxlen=0)
+d.rotate(1)
+assert list(d) == []
+
+assert_raises(IndexError, deque(maxlen=0).insert, 0, 1)
+
+
+# A bounded deque still drops from the far end, and only once it is full.
+d = deque(maxlen=1)
+d.append(1)
+assert list(d) == [1]
+d.append(2)
+assert list(d) == [2]
+d.appendleft(3)
+assert list(d) == [3]
+
+d = deque("ab", maxlen=3)
+d.append("c")
+assert list(d) == ["a", "b", "c"]
+d.append("d")
+assert list(d) == ["b", "c", "d"]
+d.appendleft("z")
+assert list(d) == ["z", "b", "c"]


### PR DESCRIPTION
- [x] This PR follows our [AI policy](https://github.com/RustPython/.github/blob/main/AI_POLICY.md)

## Summary

`deque(maxlen=0)` keeps everything that is appended to it:

```pycon
>>> d = deque(maxlen=0)
>>> d.append(1)
>>> d.append(2)
>>> list(d)
[1, 2]                    # CPython: []
>>> d.maxlen
0
```

A container that reports a bound of zero grows without one, so the idiom of using a zero length deque as a sink holds on to every object handed to it.

`append` and `appendleft` in `crates/vm/src/stdlib/_collections.rs` trim before pushing, on `self.maxlen == Some(deque.len())`. For an empty deque with `maxlen` zero that comparison is true, `pop_front` on an empty deque does nothing, and the push goes through anyway. CPython appends and then trims while the deque is longer than its bound, so the same two lines are enough here.

The rest of the deque already handles the case. I ran every mutating entry point with `maxlen=0` against CPython 3.14 and only these two disagreed:

| | before | CPython |
|---|---|---|
| `append`, `appendleft` | keeps the item | empty |
| `extend`, `extendleft`, `+=` | empty | empty |
| `insert` | `IndexError: deque already at its maximum size` | same |
| `*`, `*=`, `+`, `rotate`, `copy`, constructor | empty | empty |

## Why the suite is green

`Lib/test/test_deque.py` has `test_maxlen_zero`, and it exercises the constructor, `extend` and `extendleft`, which are the three paths that were already correct. It never calls `append` on a deque built with `maxlen=0`.

## Test Plan

Built in a Debian container on rustc 1.98.0.

- `extra_tests/snippets/stdlib_collections_deque.py` gains the zero bound cases, plus the neighbouring behaviour it would be easy to break: a bounded deque still drops from the far end and only once it is full. On a build without the change the file stops at `assert list(d) == []` right after the first append.
- `pytest test_snippets.py -k collections_deque`, both legs green, so the file holds under CPython 3.14.7 as well.
- `cargo run --release -- -m test test_deque`: 81 tests, 3 skipped, SUCCESS.
- `cargo clippy` with the flags CI uses, clean, and `cargo fmt --check` clean. `ruff format --check` and `ruff check --select I` clean on the snippet.
- `cargo test --workspace --exclude rustpython_wasm --exclude rustpython-venvlauncher --exclude rustpython-capi`: no failures.

The three clippy jobs and the WASM check are red for the reason in #8564, unrelated to this change.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected bounded deque behavior when adding items at capacity.
  * Ensured zero-capacity deques remain empty across append, extension, concatenation, rotation, and construction operations.
  * Fixed item eviction and insertion handling for bounded deques.

* **Tests**
  * Added coverage for zero-capacity and full-capacity deque scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->