### PR TITLE
Drop the last two lint expectations clippy 1.98 no longer fulfils

### DIFF
--- a/crates/host_env/src/posix.rs
+++ b/crates/host_env/src/posix.rs
@@ -1406,10 +1406,6 @@ fn build_posix_spawn_attrs(
             target_os = "illumos",
             target_os = "hurd",
         )))]
-        #[expect(
-            clippy::std_instead_of_core,
-            reason = "false positive: core::io::ErrorKind is unstable (core_io); expect is co-gated with the usage so it is not left unfulfilled on platforms where this block is compiled out"
-        )]
         {
             return Err(std::io::Error::new(
                 std::io::ErrorKind::Unsupported,

--- a/crates/vm/src/stdlib/_signal.rs
+++ b/crates/vm/src/stdlib/_signal.rs
@@ -337,10 +337,6 @@ pub(crate) mod _signal {
         }
 
         #[cfg(windows)]
-        #[expect(
-            clippy::std_instead_of_core,
-            reason = "false positive: core::io::ErrorKind is unstable (core_io)"
-        )]
         let is_socket = if fd != INVALID_WAKEUP {
             host_signal::wakeup_fd_is_socket(fd).map_err(|err| {
                 if err.kind() == std::io::ErrorKind::InvalidInput {


### PR DESCRIPTION
- [ ] I did not use AI to write the code of this patch.
- [x] This PR follows our [AI policy](https://github.com/RustPython/.github/blob/main/AI_POLICY.md)

## Summary

#8564 removed four `#[expect(clippy::std_instead_of_core)]` that clippy 1.98 stopped
fulfilling. Two more were left behind, and each hid behind a `cfg` that the job which
would have reported it did not compile.

`crates/vm/src/stdlib/_signal.rs` is gated on `#[cfg(windows)]`, so only the Windows job
sees it. It showed up on #8564's own last run, once the other four were gone:

```
error: this lint expectation is unfulfilled
   --> crates\vm\src\stdlib\_signal.rs:341:13
    = note: false positive: core::io::ErrorKind is unstable (core_io)
```

`crates/host_env/src/posix.rs` is gated on `not(any(linux, haiku, solaris, illumos, hurd))`,
so among the CI runners only macOS compiles it. It stayed quiet until #8564 landed because
clippy reports one error per crate, and the `fopen` expectation in the same crate came
first. It surfaced on main right after the merge:

```
error: this lint expectation is unfulfilled
   --> crates/host_env/src/posix.rs:1410:13
```

Only the attributes go; the `cfg` on each statement stays.

## Testing

`cargo fmt --check` and the workspace clippy with the flags from the CI job both pass on
Linux, so the side that was already green is undisturbed. I do not have a Rust toolchain on
Windows or macOS, so I did not reproduce either of those two jobs myself. The quoted errors
are from your CI rather than from my machine, and your CI is what will confirm the fix.

## AI assistance

Claude Code (claude-opus-5) was used throughout: reading the CI logs to locate the two
expectations, making the deletions, and running fmt and clippy on Linux. I reviewed the
diff and the policy before opening this.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Removed unnecessary code-quality suppressions from Windows-specific and POSIX platform implementations.
  * No user-visible behavior or functionality changed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->