### PR TITLE
Drop the narrow-build surrogate pairing from unicode_escape

### DIFF
--- a/Lib/_pycodecs.py
+++ b/Lib/_pycodecs.py
@@ -1102,20 +1102,6 @@ def unicodeescape_string(s, size, quotes):
             pos += 1
             continue
         # endif
-        # /* Map UTF-16 surrogate pairs to Unicode \UXXXXXXXX escapes */
-        elif ord(ch) >= 0xD800 and ord(ch) < 0xDC00:
-            pos += 1
-            ch2 = s[pos]
-
-            if ord(ch2) >= 0xDC00 and ord(ch2) <= 0xDFFF:
-                ucs = (((ord(ch) & 0x03FF) << 10) | (ord(ch2) & 0x03FF)) + 0x00010000
-                p.append(b"\\U%08x" % ucs)
-                pos += 1
-                continue
-
-            # /* Fall through: isolated surrogates are copied as-is */
-            pos -= 1
-
         # /* Map 16-bit characters to '\uxxxx' */
         if ord(ch) >= 256:
             p.append(b"\\u%04x" % ord(ch))

--- a/Lib/test/test_codecs.py
+++ b/Lib/test/test_codecs.py
@@ -2776,9 +2776,6 @@ class UnicodeEscapeTest(ReadTest, unittest.TestCase):
             ]
         )
 
-    @unittest.expectedFailure  # TODO: RUSTPYTHON; IndexError: index out of range
-    def test_incremental_surrogatepass(self):
-        return super().test_incremental_surrogatepass()
 
 class RawUnicodeEscapeTest(ReadTest, unittest.TestCase):
     encoding = "raw-unicode-escape"

--- a/extra_tests/snippets/builtin_str_encode.py
+++ b/extra_tests/snippets/builtin_str_encode.py
@@ -32,3 +32,12 @@ assert not b"\x80\x80".islower()
 assert not b"\x80\x80".isupper()
 assert b"\x80cat\x80".islower()
 assert b"\x80CAT\x80".isupper()
+
+# A lone surrogate gets an escape of its own wherever it sits, and a high one
+# followed by a low one stays two escapes rather than being folded into one.
+assert "\ud800".encode("unicode_escape") == b"\\ud800"
+assert "a\ud800".encode("unicode_escape") == b"a\\ud800"
+assert "\ud800b".encode("unicode_escape") == b"\\ud800b"
+assert "\ud800\ud800".encode("unicode_escape") == b"\\ud800\\ud800"
+assert "\ud800\udc00".encode("unicode_escape") == b"\\ud800\\udc00"
+assert "\U00010000".encode("unicode_escape") == b"\\U00010000"


### PR DESCRIPTION
- [x] This PR follows our [AI policy](https://github.com/RustPython/.github/blob/main/AI_POLICY.md)

## Summary

A high surrogate at the end of a string makes `unicode_escape` walk off the end:

```pycon
>>> "\ud800".encode("unicode_escape")
IndexError: index out of range        # CPython: b'\ud800'
>>> "a\ud800".encode("unicode_escape")
IndexError: index out of range        # CPython: b'a\ud800'
```

And a high surrogate followed by a low one gets folded into one escape:

```pycon
>>> "𐀀".encode("unicode_escape")
b'\U00010000'                        # CPython: b'\ud800\udc00'
```

Both come out of the same block in `unicodeescape_string` (`Lib/_pycodecs.py`). That function is a port of CPython 2.7's `PyUnicode_EncodeUnicodeEscape`, where the branch for a character at or above `0x10000` sits under `#ifdef Py_UNICODE_WIDE` and the surrogate pairing sits under the `#else` (`Objects/unicodeobject.c:3117-3158` on the 2.7 branch). The port kept the `# ifdef Py_UNICODE_WIDE` and `# endif` comments around the first branch but dropped the `#else`, so the narrow build branch runs too. It steps forward and reads `s[pos]` without checking `pos < size`, which is the IndexError, and when that read lands it does the pairing that no wide build does.

Dropping the block fixes both. A high surrogate then falls through to the 16-bit case and comes out as `\udXXX`, which is where a low surrogate was already going, and that is why `"\udfff"` encoded fine before this change while `"\ud800"` did not.

`UnicodeEscapeTest.test_incremental_surrogatepass` carried `@unittest.expectedFailure  # TODO: RUSTPYTHON; IndexError: index out of range`. It passes now, so the override goes with it.

## Verification

Run in a `rust:1` container with CPython 3.14.7 as the oracle.

A differential probe over 67 strings (lone surrogates at the start, in the middle and at the end, every combination of high and low, astral characters, control characters, plain ASCII) went from **23 divergences to zero**.

- `extra_tests/snippets/builtin_str_encode.py` gained six assertions. `pytest test_snippets.py -k builtin_str_encode` passes under both interpreters, and putting `Lib/_pycodecs.py` back turns the RustPython half red with the IndexError while the CPython half stays green.
- Whole snippet suite: 429 passed, 1 failed. The failure is `stdlib_sqlite`, because the binary here was built without the `sqlite` feature.
- `cargo run --release -- -m test test_codecs`: 287 run, 23 skipped, no failures. With the patch but before the marker came out, that same run reported the unexpected success.
- `test_codeccallbacks test_str test_bytes test_unicodedata`: 550 run, 33 skipped, all four OK.
- `ruff format --check` and `ruff check --select I` on the snippet, plus `scripts/check_redundant_patches.py` on the test file.

On the AI policy: Claude Code (claude-opus-5) wrote the patch, the snippet and this description. Every command quoted above was run in the environment described and the numbers are its output.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added coverage for `unicode_escape` encoding of lone surrogates, surrogate pairs, embedded and repeated surrogates, and supplementary Unicode characters.
  * Verified that surrogate characters remain represented as individual escape sequences.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->