### PR TITLE
Follow CPython's padding rules in a2b_base64

### DIFF
--- a/Lib/test/test_binascii.py
+++ b/Lib/test/test_binascii.py
@@ -117,7 +117,6 @@ class BinASCIITest(unittest.TestCase):
         # empty strings. TBD: shouldn't it raise an exception instead ?
         self.assertEqual(binascii.a2b_base64(self.type2test(fillers)), b'')
 
-    @unittest.expectedFailure  # TODO: RUSTPYTHON
     def test_base64_strict_mode(self):
         # Test base64 with strict mode on
         def _assertRegexTemplate(assert_regex: str, data: bytes, non_strict_mode_expected_result: bytes):
@@ -175,7 +174,6 @@ class BinASCIITest(unittest.TestCase):
         assertExcessPadding(b'abcd====', b'i\xb7\x1d')
         assertExcessPadding(b'abcd=====', b'i\xb7\x1d')
 
-    @unittest.expectedFailure  # TODO: RUSTPYTHON; AssertionError: b'i' != b'i\xb7'
     def test_base64_excess_data(self):
         # Test excess data exceptions
         def assertExcessData(data, expected):

--- a/crates/stdlib/src/binascii.rs
+++ b/crates/stdlib/src/binascii.rs
@@ -291,31 +291,38 @@ mod decl {
                 return Ok(vec![]);
             }
 
-            if strict_mode && b[0] == PAD {
-                return Err(base64::DecodeError::InvalidByte(0, 61));
-            }
-
             let mut decoded: Vec<u8> = vec![];
 
             let mut quad_pos = 0; // position in the nibble
             let mut pads = 0;
             let mut left_char: u8 = 0;
-            let mut padding_started = false;
             for (i, &el) in b.iter().enumerate() {
                 if el == PAD {
-                    padding_started = true;
-
                     pads += 1;
-                    if quad_pos >= 2 && quad_pos + pads >= 4 {
-                        if strict_mode && i + 1 < b.len() {
-                            // Represents excess data after padding error
-                            return Err(base64::DecodeError::InvalidLastSymbol(i, PAD));
-                        }
-
-                        return Ok(decoded);
+                    // A pad that finishes the quad it belongs to is the expected one.
+                    if quad_pos >= 2 && quad_pos + pads <= 4 {
+                        continue;
                     }
 
-                    continue;
+                    // RFC 4648 section 3.3 allows a decoder to ignore a pad that
+                    // shows up anywhere else, so only strict mode complains.
+                    if !strict_mode {
+                        continue;
+                    }
+
+                    if quad_pos == 1 {
+                        // A single data character cannot be padded into a quad,
+                        // and the check after the loop already reports that.
+                        break;
+                    }
+
+                    return Err(if quad_pos == 0 && i == 0 {
+                        // Represents leading padding error
+                        base64::DecodeError::InvalidByte(0, PAD)
+                    } else {
+                        // Represents excess padding error
+                        base64::DecodeError::InvalidPadding
+                    });
                 }
 
                 let binary_char = BASE64_TABLE[el as usize];
@@ -327,9 +334,14 @@ mod decl {
                     continue;
                 }
 
-                if strict_mode && padding_started {
-                    // Represents discontinuous padding error
-                    return Err(base64::DecodeError::InvalidByte(i, PAD));
+                if pads > 0 && strict_mode {
+                    return Err(if quad_pos + pads == 4 {
+                        // Represents excess data after padding error
+                        base64::DecodeError::InvalidLastSymbol(i, PAD)
+                    } else {
+                        // Represents discontinuous padding error
+                        base64::DecodeError::InvalidByte(i, PAD)
+                    });
                 }
                 pads = 0;
 
@@ -361,14 +373,19 @@ mod decl {
                 }
             }
 
-            match quad_pos {
-                0 => Ok(decoded),
-                1 => Err(base64::DecodeError::InvalidLastSymbol(
+            if quad_pos == 1 {
+                // One data character too many: no input encodes to that length.
+                return Err(base64::DecodeError::InvalidLastSymbol(
                     decoded.len() / 3 * 4 + 1,
                     0,
-                )),
-                _ => Err(base64::DecodeError::InvalidLength(quad_pos)),
+                ));
             }
+
+            if quad_pos != 0 && quad_pos + pads < 4 {
+                return Err(base64::DecodeError::InvalidLength(quad_pos));
+            }
+
+            Ok(decoded)
         })
         .map_err(|err| super::Base64DecodeError(err).to_pyexception(vm))
     }
@@ -864,7 +881,7 @@ impl ToPyException for Base64DecodeError {
             }
             // TODO: clean up errors
             DecodeError::InvalidLength(_) => "Incorrect padding".to_owned(),
-            DecodeError::InvalidPadding => "Incorrect padding".to_owned(),
+            DecodeError::InvalidPadding => "Excess padding not allowed".to_owned(),
         };
         new_binascii_error(format!("error decoding base64: {message}"), vm)
     }


### PR DESCRIPTION
- [x] This PR follows our [AI policy](https://github.com/RustPython/.github/blob/main/AI_POLICY.md)

## Summary

`binascii.a2b_base64` with `strict_mode=True` accepts padding that CPython rejects:

```pycon
>>> binascii.a2b_base64(b'YWJj=', strict_mode=True)
b'abc'                 # CPython: binascii.Error: Excess padding not allowed
>>> binascii.a2b_base64(b'abcd====', strict_mode=True)
b'i\xb7\x1d'           # CPython: binascii.Error: Excess padding not allowed
```

The flag exists to reject malformed input, so accepting it silently defeats it.

The same loop also drops data in the default mode. It returns as soon as a pad completes a quad, so whatever follows is lost:

```pycon
>>> binascii.a2b_base64(b'abc=a')
b'i\xb7'               # CPython: b'i\xb7\x1a'
```

Both come from the same place. CPython counts pads as it goes and decides at the end; this one decides at the first complete pad sequence and never looks at a pad while `quad_pos` is still 0. The loop now follows CPython: a pad that fits the current quad is consumed, any other pad is ignored outside strict mode, and strict mode names it leading, excess or discontinuous. The tail reports the two lengths no valid encoding can produce.

`DecodeError::InvalidPadding` was mapped to `Incorrect padding`, but nothing in the file ever built that variant, so it now carries `Excess padding not allowed`. The other messages are untouched.

## Tests

`Lib/test/test_binascii.py` already had both cases, marked as expected failures. They run now:

- `test_base64_strict_mode`, which covers all five padding errors across the four buffer types
- `test_base64_excess_data`, whose marker had even recorded the symptom (`AssertionError: b'i' != b'i\xb7'`)

What I ran:

- `cargo run --release -- -m test test_binascii`: 93 tests, 17 skipped, SUCCESS
- `cargo run --release -- -m test test_base64`: 41 tests, SUCCESS
- `cargo test --workspace --exclude rustpython_wasm --exclude rustpython-venvlauncher --exclude rustpython-capi`: 41 test binaries, no failures
- `cargo fmt --check`, and clippy with the flags CI uses: both clean

I also ran the inputs above plus the padding cases around them under CPython 3.14 and this build side by side. Every returned value agrees now. Two error strings still differ, both because of the `error decoding base64: ` prefix that #7993 is already working through, so I left them alone.

## AI assistance

Claude Code (claude-opus-5) helped with the comparison against CPython, the loop and this description. I read the final diff and ran the checks above on Linux.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Base64 decoding behavior when padding is misplaced or excessive.
  * Strict decoding now provides distinct errors for leading, excess, discontinuous, and trailing data.
  * Updated final-length validation to correctly account for padding.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->