### PR TITLE
Reject the string format flags CPython refuses

### DIFF
--- a/crates/common/src/format.rs
+++ b/crates/common/src/format.rs
@@ -1083,8 +1083,18 @@ impl FormatSpec {
         self.validate_format(FormatType::String)?;
         match self.format_type {
             Some(FormatType::String) | None => {
+                // CPython rejects these four in this order: sign, z, #, then '='.
+                if let Some(sign) = self.sign {
+                    return Err(FormatSpecError::StringSpecNotAllowed(match sign {
+                        FormatSign::MinusOrSpace => "Space",
+                        FormatSign::Plus | FormatSign::Minus => "Sign",
+                    }));
+                }
                 if self.no_neg_0 {
                     return Err(FormatSpecError::NegativeZeroCoercionNotAllowed("string"));
+                }
+                if self.alternate_form {
+                    return Err(FormatSpecError::StringSpecNotAllowed("Alternate form (#)"));
                 }
                 if self.align == Some(FormatAlign::AfterSign) && self.align_specified {
                     return Err(FormatSpecError::StringAlignmentFlag);
@@ -1334,6 +1344,7 @@ pub enum FormatSpecError {
     AlignmentFlag,
     NegativeZeroCoercionNotAllowed(&'static str),
     StringAlignmentFlag,
+    StringSpecNotAllowed(&'static str),
     NotImplemented(char, &'static str),
 }
 
@@ -1786,6 +1797,52 @@ mod tests {
             spec.format_string(&value),
             Err(FormatSpecError::StringAlignmentFlag)
         );
+    }
+
+    #[test]
+    fn format_string_rejects_sign_space_and_alternate_form() {
+        let value = "result".to_owned();
+        let cases = [
+            ("+", "Sign"),
+            ("-", "Sign"),
+            ("+8s", "Sign"),
+            (" ", "Space"),
+            (" 8s", "Space"),
+            ("#", "Alternate form (#)"),
+            ("#8s", "Alternate form (#)"),
+        ];
+
+        for (text, flag) in cases {
+            let spec = FormatSpec::parse(text).unwrap();
+            assert_eq!(
+                spec.format_string(&value),
+                Err(FormatSpecError::StringSpecNotAllowed(flag)),
+                "{text}"
+            );
+        }
+    }
+
+    #[test]
+    fn format_string_reports_the_flag_cpython_reports_first() {
+        let value = "result".to_owned();
+        // Sign beats z, z beats the alternate form, and the alternate form
+        // beats an explicit '=' alignment.
+        let cases = [
+            ("+z#5", FormatSpecError::StringSpecNotAllowed("Sign")),
+            (
+                "x=z#5",
+                FormatSpecError::NegativeZeroCoercionNotAllowed("string"),
+            ),
+            (
+                "x=#5",
+                FormatSpecError::StringSpecNotAllowed("Alternate form (#)"),
+            ),
+        ];
+
+        for (text, expected) in cases {
+            let spec = FormatSpec::parse(text).unwrap();
+            assert_eq!(spec.format_string(&value), Err(expected), "{text}");
+        }
     }
 
     #[test]

--- a/crates/vm/src/format.rs
+++ b/crates/vm/src/format.rs
@@ -86,6 +86,10 @@ impl IntoPyException for FormatSpecError {
             Self::StringAlignmentFlag => {
                 vm.new_value_error("'=' alignment not allowed in string format specifier")
             }
+            Self::StringSpecNotAllowed(s) => {
+                let msg = format!("{s} not allowed in string format specifier");
+                vm.new_value_error(msg)
+            }
             Self::NotImplemented(c, s) => {
                 let msg = format!("Format code '{c}' for object of type '{s}' not implemented yet");
                 vm.new_value_error(msg)

--- a/extra_tests/snippets/builtin_format.py
+++ b/extra_tests/snippets/builtin_format.py
@@ -32,6 +32,30 @@ except ValueError as error:
 else:
     raise AssertionError("expected ValueError for '=8s' string format specifier")
 
+# regression: a sign, a space or an alternate form used to be accepted and dropped.
+for spec, flag in [
+    ("+", "Sign"),
+    ("-", "Sign"),
+    ("+5", "Sign"),
+    (" ", "Space"),
+    (" 5", "Space"),
+    ("#", "Alternate form (#)"),
+    ("#5", "Alternate form (#)"),
+    ("+.2", "Sign"),
+]:
+    try:
+        format("result", spec)
+    except ValueError as error:
+        expected = f"{flag} not allowed in string format specifier"
+        if str(error) != expected:
+            raise AssertionError(
+                f"{spec!r}: unexpected error message: {error}"
+            ) from error
+    else:
+        raise AssertionError(
+            f"expected ValueError for {spec!r} string format specifier"
+        )
+
 # regression: unknown conversion specifiers used to be silently ignored instead of raising.
 # The ValueError case itself is covered by test_str, but here we're testing the error message.
 try:


### PR DESCRIPTION
- [x] This PR follows our [AI policy](https://github.com/RustPython/.github/blob/main/AI_POLICY.md)

## Summary

A sign, a space or an alternate form in a string format spec is accepted and then dropped:

```pycon
>>> format('ab', '+')
'ab'           # CPython: ValueError: Sign not allowed in string format specifier
>>> f"{'ab':+5}"
'ab   '        # CPython: ValueError: Sign not allowed in string format specifier
>>> format('ab', '#')
'ab'           # CPython: ValueError: Alternate form (#) not allowed in string format specifier
```

`format_string` in `crates/common/src/format.rs` already turns down `z` and an explicit `=` alignment for strings, with the wording CPython uses. These three were never checked, so the spec parses, the flag means nothing to a string, and the caller gets plain padding where CPython refuses the spec outright.

The three checks sit next to the two that were already there. Their order is the one CPython reports in, which I read off these, under CPython 3.14:

| spec | first error | what it settles |
|---|---|---|
| `+z#5` | Sign | sign comes before `z` and `#` |
| `x=z#5` | Negative zero coercion (z) | `z` comes before `#` |
| `x=#5` | Alternate form (#) | `#` comes before the `=` alignment |

`FormatSpecError` gains one variant that carries the flag name, so the three share a message built the same way as `StringAlignmentFlag`.

## Tests

I ran the string spec shapes side by side under CPython 3.14 and this build: the four flags, fill and align pairs, width, precision, grouping, the format codes, and specs where two errors compete. Two differences are left afterwards, neither on this path. `Invalid format specifier` is still missing the spec and the type, which #8477 covers. And `format('ab', '+,5')` reports the unknown format code here while CPython reports the grouping.

- `extra_tests/snippets/builtin_format.py`: eight specs checked by message, next to the `=8s` case that was already there. It passes under CPython 3.14 too.
- two unit tests in `crates/common/src/format.rs`, one per flag and one for the order in the table
- `cargo run --release -- -m test test_str test_format test_fstring`: SUCCESS, 138, 18 and 90 tests
- `cargo test --workspace --exclude rustpython_wasm --exclude rustpython-venvlauncher --exclude rustpython-capi`: no failures
- `cargo fmt --check`, `ruff format --check`, `ruff check --select I`, and clippy with the flags CI uses: clean

`test_str.test_format` asserts all three, but its marker records an unrelated reason to stay an expected failure (`'{0.}'.format()` raises ValueError instead of IndexError), so the snippet carries the coverage instead.

## AI assistance

Claude Code (claude-opus-5) helped with the comparison against CPython, the change and this description. I read the final diff and ran the checks above on Linux.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved string formatting validation to match CPython behavior.
  * String format specifications now correctly reject unsupported sign, space, and alternate-form (`#`) flags.
  * Errors now report the specific unsupported formatting option and follow the expected validation precedence.

* **Tests**
  * Added regression coverage for rejected string format specifications and corresponding `ValueError` messages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->