### PR TITLE
Use non-raising lookup for default optional attribute access

### DIFF
--- a/crates/vm/src/vm/mod.rs
+++ b/crates/vm/src/vm/mod.rs
@@ -23,8 +23,8 @@ mod vm_ops;
 use crate::{
     AsObject, Py, PyObject, PyObjectRef, PyPayload, PyRef, PyResult,
     builtins::{
-        self, PyBaseExceptionRef, PyDict, PyDictRef, PyInt, PyList, PyModule, PyStr, PyStrInterned,
-        PyStrRef, PyTypeRef, PyUtf8Str, PyUtf8StrInterned, PyWeak,
+        self, PyBaseExceptionRef, PyBaseObject, PyDict, PyDictRef, PyInt, PyList, PyModule, PyStr,
+        PyStrInterned, PyStrRef, PyTypeRef, PyUtf8Str, PyUtf8StrInterned, PyWeak,
         code::PyCode,
         dict::{PyDictItems, PyDictKeys, PyDictValues},
         pystr::AsPyStr,
@@ -42,6 +42,7 @@ use crate::{
     scope::Scope,
     signal::{self, SignalHandlers},
     stdlib,
+    types::{GetattroFunc, fn_addr},
     warn::WarningsState,
 };
 use alloc::{borrow::Cow, collections::BTreeMap};
@@ -2854,8 +2855,14 @@ impl VirtualMachine {
         attr_name: impl AsPyStr<'a>,
     ) -> PyResult<Option<PyObjectRef>> {
         let attr_name = attr_name.as_pystr(&self.ctx);
-        match obj.get_attr_inner(attr_name, self) {
-            Ok(attr) => Ok(Some(attr)),
+        let getattro = obj.class().slots.getattro.load().unwrap();
+        let result = if fn_addr(getattro) == fn_addr(PyBaseObject::getattro as GetattroFunc) {
+            obj.generic_getattr_opt(attr_name, None, self)
+        } else {
+            obj.get_attr_inner(attr_name, self).map(Some)
+        };
+        match result {
+            Ok(attr) => Ok(attr),
             Err(e) if e.fast_isinstance(self.ctx.exceptions.attribute_error) => Ok(None),
             Err(e) => Err(e),
         }

--- a/extra_tests/snippets/builtin_optional_attr.py
+++ b/extra_tests/snippets/builtin_optional_attr.py
@@ -1,0 +1,126 @@
+def assert_raises(exc_type, func, *args):
+    try:
+        func(*args)
+    except exc_type:
+        return
+    except BaseException as exc:
+        raise AssertionError(
+            f"expected {exc_type.__name__}, got {type(exc).__name__}"
+        ) from exc
+    raise AssertionError(f"expected {exc_type.__name__}")
+
+
+class Plain:
+    class_attr = "class"
+
+
+plain = Plain()
+plain.instance_attr = "instance"
+sentinel = object()
+
+assert hasattr(plain, "class_attr")
+assert hasattr(plain, "instance_attr")
+assert not hasattr(plain, "missing")
+assert getattr(plain, "class_attr", sentinel) == "class"
+assert getattr(plain, "instance_attr", sentinel) == "instance"
+assert getattr(plain, "missing", sentinel) is sentinel
+assert_raises(AttributeError, getattr, plain, "missing")
+assert_raises(TypeError, hasattr, plain, 1)
+assert_raises(TypeError, getattr, plain, 1, sentinel)
+
+
+getattribute_calls = []
+
+
+class CustomGetattribute:
+    def __getattribute__(self, name):
+        getattribute_calls.append(name)
+        if name == "missing":
+            raise AttributeError("custom miss")
+        if name == "bad":
+            raise ValueError("custom error")
+        return f"value:{name}"
+
+
+custom_getattribute = CustomGetattribute()
+assert not hasattr(custom_getattribute, "missing")
+assert getattr(custom_getattribute, "missing", sentinel) is sentinel
+assert getattribute_calls == ["missing", "missing"]
+assert getattr(custom_getattribute, "present", sentinel) == "value:present"
+assert_raises(ValueError, hasattr, custom_getattribute, "bad")
+
+
+getattr_calls = []
+
+
+class CustomGetattr:
+    def __getattr__(self, name):
+        getattr_calls.append(name)
+        if name == "present":
+            return "fallback value"
+        if name == "bad":
+            raise SystemExit("custom error")
+        raise AttributeError(name)
+
+
+custom_getattr = CustomGetattr()
+assert getattr(custom_getattr, "present", sentinel) == "fallback value"
+assert not hasattr(custom_getattr, "missing")
+assert getattr_calls == ["present", "missing"]
+assert_raises(SystemExit, hasattr, custom_getattr, "bad")
+
+
+class AttributeErrorSubclass(AttributeError):
+    pass
+
+
+class AttributeErrorDescriptor:
+    def __get__(self, obj, owner):
+        raise AttributeError("descriptor miss")
+
+
+class AttributeErrorSubclassDescriptor:
+    def __get__(self, obj, owner):
+        raise AttributeErrorSubclass("descriptor miss")
+
+
+class ValueErrorDescriptor:
+    def __get__(self, obj, owner):
+        raise ValueError("descriptor error")
+
+
+class DescriptorContainer:
+    attribute_error = AttributeErrorDescriptor()
+    attribute_error_subclass = AttributeErrorSubclassDescriptor()
+    value_error = ValueErrorDescriptor()
+
+
+descriptor_container = DescriptorContainer()
+assert not hasattr(descriptor_container, "attribute_error")
+assert getattr(descriptor_container, "attribute_error", sentinel) is sentinel
+assert not hasattr(descriptor_container, "attribute_error_subclass")
+assert getattr(descriptor_container, "attribute_error_subclass", sentinel) is sentinel
+assert_raises(ValueError, hasattr, descriptor_container, "value_error")
+
+
+class Dynamic:
+    pass
+
+
+dynamic = Dynamic()
+assert not hasattr(dynamic, "missing")
+dynamic_calls = []
+
+
+def dynamic_getattribute(self, name):
+    dynamic_calls.append(name)
+    if name == "missing":
+        raise AttributeError(name)
+    return object.__getattribute__(self, name)
+
+
+Dynamic.__getattribute__ = dynamic_getattribute
+assert not hasattr(dynamic, "missing")
+assert dynamic_calls == ["missing"]
+del Dynamic.__getattribute__
+assert not hasattr(dynamic, "missing")

--- a/extra_tests/snippets/builtin_optional_attr.py
+++ b/extra_tests/snippets/builtin_optional_attr.py
@@ -121,6 +121,6 @@ def dynamic_getattribute(self, name):
 
 Dynamic.__getattribute__ = dynamic_getattribute
 assert not hasattr(dynamic, "missing")
-assert dynamic_calls == ["missing"]
 del Dynamic.__getattribute__
 assert not hasattr(dynamic, "missing")
+assert dynamic_calls == ["missing"]


### PR DESCRIPTION
- [x] This PR follows our [AI policy](https://github.com/RustPython/.github/blob/main/AI_POLICY.md)

## Summary

`get_attribute_opt()` backs `hasattr()` and `getattr(obj, name, default)`. On
an ordinary missing attribute it previously called the raising
`get_attr_inner()` path and caught the resulting `AttributeError`. That made
the common optional-miss case allocate and discard an exception.

This PR sends objects using the default `PyBaseObject::getattro` slot through
`generic_getattr_opt()`, which represents an absent attribute as `None`
without constructing `AttributeError`.

Custom `getattro` slots remain on `get_attr_inner()`. This preserves execution
of Python-defined `__getattribute__` and `__getattr__` hooks and preserves
their non-`AttributeError` exceptions. The common final conversion still maps
`AttributeError` to `None` for both routes, including an `AttributeError`
raised by a descriptor, while propagating every other exception.

Refs youknowone#48

## Changes

- In `VirtualMachine::get_attribute_opt`, identify the default
  `PyBaseObject::getattro` slot by function address.
- Use `generic_getattr_opt()` only for that default slot.
- Retain the existing raising lookup for custom slots, then apply the shared
  `AttributeError`-to-`None` conversion.
- Add `extra_tests/snippets/builtin_optional_attr.py`, covering:
  - ordinary `hasattr()` and defaulted `getattr()` hits/misses;
  - non-string names;
  - custom `__getattribute__` and `__getattr__` behavior;
  - `AttributeError` (and its subclass) versus `ValueError`/`SystemExit`;
  - descriptors and runtime changes to `__getattribute__`.

## Performance

On the local WSL measurement harness (100,000 iterations, Hyperfine 1.20.0),
the optional-miss path improved in an interleaved before/after comparison:

| workload | before | after | result |
| --- | ---: | ---: | ---: |
| `hasattr(record, "missing")` | 197.4 ± 7.0 ms | 77.8 ± 2.5 ms | 2.54 ± 0.12x faster |
| `getattr(record, "missing", sentinel)` | 201.3 ± 6.5 ms | 85.1 ± 3.3 ms | 2.36 ± 0.12x faster |

These are local end-to-end wall-clock measurements, not a cross-platform
claim or a CPython comparison. The harness includes interpreter startup and
the WSL environment; its value is the paired before/after direction. The
historical per-call figures in the issue were measured on different hardware
and require a controlled CI or local reproduction for direct comparison.

## Testing

- `cargo fmt --check`
- `cargo clippy -p rustpython-vm -p rustpython-stdlib --all-targets -- -Dwarnings`
- `cargo run --release -- -m test test_builtin` — SUCCESS (138 run, 10 skipped)
- `git diff --check`
- workspace tests



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved optional attribute lookup for objects using standard or custom attribute handling.
  - Correctly returns fallback values for missing attributes while preserving other exceptions.
  - Improved handling of descriptor-raised attribute errors and dynamically added attributes.

- **Tests**
  - Added comprehensive coverage for `hasattr` and `getattr`, including defaults, invalid names, custom lookup methods, descriptors, and exception behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->