### PR TITLE
Warn instead of aborting when a class namespace holds a non-string key

### DIFF
--- a/Lib/test/test_descr.py
+++ b/Lib/test/test_descr.py
@@ -4857,7 +4857,6 @@ class ClassPropertiesAndMethods(unittest.TestCase):
         with self.assertRaises(AttributeError):
             del X.__abstractmethods__
 
-    @unittest.skip("TODO: RUSTPYTHON; crash. \"dict has non-string keys: [PyObject PyInt { value: 1 }]\"")
     def test_gh55664(self):
         # gh-55664: issue a warning when the
         # __dict__ of a class contains non-string keys
@@ -5297,7 +5296,7 @@ class AAAPTypesLongInitTest(unittest.TestCase):
 
 
 class MiscTests(unittest.TestCase):
-    @unittest.skip("TODO: RUSTPYTHON; rustpython panicked at 'dict has non-string keys: [PyObject PyBaseObject]'")
+    @unittest.skip("TODO: RUSTPYTHON; a class namespace drops keys that are not strings, so MyKey.__eq__ is never reached and __bases__ stays put")
     def test_type_lookup_mro_reference(self):
         # Issue #14199: _PyType_Lookup() has to keep a strong reference to
         # the type MRO because it may be modified during the lookup, if

--- a/Lib/test/test_descr.py
+++ b/Lib/test/test_descr.py
@@ -5296,7 +5296,7 @@ class AAAPTypesLongInitTest(unittest.TestCase):
 
 
 class MiscTests(unittest.TestCase):
-    @unittest.skip("TODO: RUSTPYTHON; a class namespace drops keys that are not strings, so MyKey.__eq__ is never reached and __bases__ stays put")
+    @unittest.expectedFailure  # TODO: RUSTPYTHON; a class namespace drops keys that are not strings, so MyKey.__eq__ is never reached and __bases__ stays put
     def test_type_lookup_mro_reference(self):
         # Issue #14199: _PyType_Lookup() has to keep a strong reference to
         # the type MRO because it may be modified during the lookup, if

--- a/crates/vm/src/builtins/dict.rs
+++ b/crates/vm/src/builtins/dict.rs
@@ -775,13 +775,38 @@ impl Py<PyDict> {
     }
 
     /// Take a python dictionary and convert it to attributes.
-    pub fn to_attributes(&self, vm: &VirtualMachine) -> PyAttributes {
+    ///
+    /// `PyAttributes` is keyed by interned strings, so a key that is not a
+    /// string has nowhere to go. Those keys are left out, and `on_non_string`
+    /// is called once, the first time one turns up, so the caller can decide
+    /// whether that deserves an error or a warning.
+    pub fn to_attributes(
+        &self,
+        vm: &VirtualMachine,
+        on_non_string: impl FnOnce(&VirtualMachine) -> PyResult<()>,
+    ) -> PyResult<PyAttributes> {
         let mut attrs = PyAttributes::default();
+        let mut on_non_string = Some(on_non_string);
         for (key, value) in self {
-            let key: PyRefExact<PyStr> = key.downcast_exact(vm).expect("dict has non-string keys");
-            attrs.insert(vm.ctx.intern_str(key), value);
+            let key = match key.downcast_exact::<PyStr>(vm) {
+                Ok(key) => vm.ctx.intern_str(key),
+                // `PyStr`, not the exact type: a `str` subclass names an
+                // attribute just as well, the same way it does as a keyword
+                // argument. Interning drops the subclass, which nothing but
+                // the key object itself can observe.
+                Err(key) => match key.downcast_ref::<PyStr>() {
+                    Some(key) => vm.ctx.intern_str(key.as_wtf8()),
+                    None => {
+                        if let Some(on_non_string) = on_non_string.take() {
+                            on_non_string(vm)?;
+                        }
+                        continue;
+                    }
+                },
+            };
+            attrs.insert(key, value);
         }
-        attrs
+        Ok(attrs)
     }
 
     pub fn get_item_opt<K: DictKey + ?Sized>(

--- a/crates/vm/src/builtins/type.rs
+++ b/crates/vm/src/builtins/type.rs
@@ -2179,7 +2179,14 @@ impl Constructor for PyType {
                 name.clone().into_wtf8()
             });
 
-        let mut attributes = dict.to_attributes(vm);
+        let mut attributes = dict.to_attributes(vm, |vm| {
+            crate::stdlib::_warnings::warn(
+                vm.ctx.exceptions.runtime_warning,
+                format!("non-string key in the __dict__ of class {name}"),
+                1,
+                vm,
+            )
+        })?;
         attributes.shift_remove(identifier!(vm, __qualname__));
 
         // Check __doc__ for surrogates - raises UnicodeEncodeError during type creation

--- a/crates/vm/src/stdlib/_thread.rs
+++ b/crates/vm/src/stdlib/_thread.rs
@@ -547,7 +547,12 @@ pub(crate) mod _thread {
         let args = FuncArgs::new(
             args.to_vec(),
             kwargs
-                .map_or_else(Default::default, |k| k.to_attributes(vm))
+                .map_or_else(
+                    || Ok(Default::default()),
+                    |k| {
+                        k.to_attributes(vm, |vm| Err(vm.new_type_error("keywords must be strings")))
+                    },
+                )?
                 .into_iter()
                 .map(|(k, v)| (k.as_str().to_owned(), v))
                 .collect::<KwArgs>(),

--- a/extra_tests/snippets/builtin_type.py
+++ b/extra_tests/snippets/builtin_type.py
@@ -1,4 +1,5 @@
 import types
+import warnings
 
 from testutils import assert_raises
 
@@ -717,3 +718,28 @@ for owner in (NarrowSlots(), NoSlots()):
             owner.borrowed = 1
         with assert_raises(TypeError):
             del owner.borrowed
+
+
+# A str subclass names an attribute the same way a str does, and interning the
+# key is what makes it reachable at all.
+class StrKey(str):
+    pass
+
+
+subclass_key = type("SubclassKey", (), {StrKey("attr"): 7})
+assert subclass_key.attr == 7
+
+# A key that is not a string at all cannot become an attribute. CPython keeps it
+# in the class dict and warns once; the class is built either way.
+with warnings.catch_warnings(record=True) as caught:
+    warnings.simplefilter("always")
+    non_string_key = type("NonStringKey", (), {"kept": 1, 2: 3, 4: 5})
+
+assert non_string_key.kept == 1
+assert [w.category for w in caught] == [RuntimeWarning], [w.category for w in caught]
+assert "NonStringKey" in str(caught[0].message), str(caught[0].message)
+
+with warnings.catch_warnings():
+    warnings.simplefilter("error")
+    with assert_raises(RuntimeWarning):
+        type("NonStringKeyRaises", (), {6: 7})


### PR DESCRIPTION
- [x] This PR follows our [AI policy](https://github.com/RustPython/.github/blob/main/AI_POLICY.md)

## Summary

A class namespace holding a key that is not a string takes the interpreter down:

```pycon
>>> type("MyClass", (), {1: 2})
thread 'main' panicked at crates/vm/src/builtins/dict.rs:781:65:
dict has non-string keys: [PyObject PyInt { value: 1 }]
```

CPython builds the class and warns once:

```pycon
>>> type("MyClass", (), {1: 2})
<stdin>:1: RuntimeWarning: non-string key in the __dict__ of class MyClass
<class '__main__.MyClass'>
```

A metaclass that writes into the namespace it is given reaches the same line, so `class Z(metaclass=M)` aborts too when `M.__new__` does `ns[42] = "x"`.

A `str` subclass hit that panic as well, and it names an attribute as well as a `str` does:

```pycon
>>> class S(str): pass
...
>>> type("Sub", (), {S("z"): 9}).z
9
```

`_thread.start_new_thread` shares the line through its kwargs dict, so it aborted where an ordinary call with the same mapping already raises:

```pycon
>>> (lambda **k: k)(**{1: 2})
TypeError: keywords must be strings
>>> import _thread
>>> _thread.start_new_thread(lambda: None, (), {1: 2})
thread 'main' panicked at crates/vm/src/builtins/dict.rs:781:65:
```

## The change

`Py<PyDict>::to_attributes` called `expect()` on `downcast_exact`. `PyAttributes` is an `IndexMap` keyed by `&'static PyStrInterned`, so the two kinds of key now split there:

- a `str` subclass is interned like any other name, through `downcast_ref::<PyStr>`, which is the test `collect_ex_args` already applies to keyword names;
- a key that is no kind of string is skipped, and the caller passes a closure that decides what the skip means. `type()` warns once per class with CPython's wording, `_thread` raises `TypeError: keywords must be strings`.

## What this does not fix

The key still does not reach the class `__dict__`, and interning gives up the `str` subclass:

| | CPython | here |
| --- | --- | --- |
| `1 in type("K", (), {1: 2}).__dict__` | `True` | `False` |
| type of the key in `{S("z"): 9}` | `S` | `str` |

Either row would mean `PyAttributes` giving up its interned-string key, which reaches a lot further than the crash does. `test_descr.MiscTests.test_type_lookup_mro_reference` rests on the first row, because its lookup only reaches `MyKey.__eq__` if the key sits in the class dict, so it stays skipped and its reason now names that instead of the crash.

## Tests

`Lib/test/test_descr.py::test_gh55664` was skipped on this exact panic, quoting it in the reason, and is now unskipped. Without the change the module takes the runner down with it:

```
0:00:00 load avg: 2.70 [1/1] test_descr

thread 'main' (4629) panicked at crates/vm/src/builtins/dict.rs:781:65:
dict has non-string keys: [PyObject PyInt { value: 1 }]
```

`extra_tests/snippets/builtin_type.py` covers the `str` subclass key, the single warning a class gets however many bad keys it holds, and that warning turning into an exception under `simplefilter("error")`. It passes under CPython 3.14 too.

Also run: `cargo test --workspace --exclude rustpython_wasm --exclude rustpython-venvlauncher --exclude rustpython-capi`, `cargo test` in `crates/capi`, the `extra_tests` snippets, `cargo fmt --check`, the clippy invocation from CI, and `-m test` over test_descr, test_class, test_type_aliases, test_types, test_thread, test_threading, test_metaclass, test_dict, test_dictviews, test_super, test_abc, test_enum, test_dataclasses, test_functools and test_warnings. The one snippet failure is `stdlib_sqlite`, which wants a feature that is not in the default set.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Class creation now supports attribute keys that are `str` subclasses.
  * Non-string class dictionary keys remain available in the class dictionary instead of causing a failure.
  * Non-string keyword arguments passed to thread creation now raise a clear `TypeError`.

* **Warnings**
  * Class creation emits a `RuntimeWarning` when non-string attribute keys are encountered.
  * Applications configured to treat warnings as errors can handle this condition consistently.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->