### PR TITLE
Drop the handler-table borrow before running a signal handler

### DIFF
--- a/Lib/test/test_io.py
+++ b/Lib/test/test_io.py
@@ -5053,13 +5053,11 @@ class SignalsTest(unittest.TestCase):
                 if e.errno != errno.EBADF:
                     raise
 
-    @unittest.skip("TODO: RUSTPYTHON; thread 'main' (103833) panicked at crates/vm/src/stdlib/signal.rs:233:43: RefCell already borrowed")
     @requires_alarm
     @support.requires_resource('walltime')
     def test_interrupted_write_retry_buffered(self):
         self.check_interrupted_write_retry(b"x", mode="wb")
 
-    @unittest.skip("TODO: RUSTPYTHON; thread 'main' (103833) panicked at crates/vm/src/stdlib/signal.rs:233:43: RefCell already borrowed")
     @requires_alarm
     @support.requires_resource('walltime')
     def test_interrupted_write_retry_text(self):
@@ -5068,10 +5066,6 @@ class SignalsTest(unittest.TestCase):
 
 class CSignalsTest(SignalsTest):
     io = io
-
-    @unittest.skip("TODO: RUSTPYTHON; thread 'main' (103833) panicked at crates/vm/src/stdlib/signal.rs:233:43: RefCell already borrowed")
-    def test_interrupted_read_retry_buffered(self):
-        return super().test_interrupted_read_retry_buffered()
 
 class PySignalsTest(SignalsTest):
     io = pyio

--- a/crates/vm/src/signal.rs
+++ b/crates/vm/src/signal.rs
@@ -88,17 +88,23 @@ fn trigger_signals(vm: &VirtualMachine) -> PyResult<()> {
     let signal_handlers = vm
         .signal_handlers
         .get()
-        .expect("should never fail since we check above")
-        .borrow();
+        .expect("should never fail since we check above");
 
     for (signum, trigger) in TRIGGERS.iter().enumerate().skip(1) {
         let triggered = trigger.swap(false, Ordering::Relaxed);
+        if !triggered {
+            continue;
+        }
 
         // SAFETY: TRIGGERS has the same length as the signal_handlers
         let signum = unsafe { SignalNum::new_unchecked(signum as i32) };
 
-        if triggered
-            && let Some(handler) = &signal_handlers[signum]
+        // Read the handler out and drop the borrow before running it. A
+        // handler is free to call signal.signal(), which takes the same cell
+        // mutably, and a live read borrow turns that into a panic.
+        let handler = signal_handlers.borrow()[signum].clone();
+
+        if let Some(handler) = handler
             && let Some(callable) = handler.to_callable()
         {
             callable.invoke((signum.as_i32(), vm.ctx.none()), vm)?;

--- a/extra_tests/snippets/stdlib_signal.py
+++ b/extra_tests/snippets/stdlib_signal.py
@@ -41,3 +41,39 @@ if "win" not in sys.platform:
     time.sleep(2.0)
 
     assert signals == [signal.SIGALRM, signal.SIGALRM]
+
+    # A handler may call signal.signal(), and the usual reason is to disarm
+    # itself. Reading the handler table while the handler runs used to be a
+    # crash rather than a rearm.
+    rearmed = []
+
+    def rearm(signum, frame):
+        rearmed.append(signum)
+        signal.signal(signal.SIGALRM, signal.SIG_IGN)
+
+    signal.signal(signal.SIGALRM, rearm)
+    signal.raise_signal(signal.SIGALRM)
+    assert rearmed == [signal.SIGALRM], rearmed
+    assert signal.getsignal(signal.SIGALRM) is signal.SIG_IGN
+
+    # The same goes for arming a different signal from inside a handler.
+    armed = []
+
+    def target(signum, frame):
+        armed.append("target")
+
+    def arm_other(signum, frame):
+        armed.append("arm_other")
+        signal.signal(signal.SIGUSR2, target)
+
+    signal.signal(signal.SIGUSR1, arm_other)
+    signal.raise_signal(signal.SIGUSR1)
+    assert armed == ["arm_other"], armed
+    assert signal.getsignal(signal.SIGUSR2) is target
+
+    signal.raise_signal(signal.SIGUSR2)
+    assert armed == ["arm_other", "target"], armed
+
+    signal.signal(signal.SIGALRM, signal.SIG_DFL)
+    signal.signal(signal.SIGUSR1, signal.SIG_DFL)
+    signal.signal(signal.SIGUSR2, signal.SIG_DFL)


### PR DESCRIPTION
- [x] This PR follows our [AI policy](https://github.com/RustPython/.github/blob/main/AI_POLICY.md)

## Summary

A signal handler that calls `signal.signal()` takes the interpreter down:

```pycon
>>> import signal
>>> def h(signum, frame): signal.signal(signal.SIGUSR1, signal.SIG_IGN)
...
>>> signal.signal(signal.SIGUSR1, h)
>>> signal.raise_signal(signal.SIGUSR1)
thread 'main' panicked at crates/vm/src/stdlib/_signal.rs:255:43:
RefCell already borrowed
```

CPython runs the handler and keeps the new disposition:

```pycon
>>> signal.raise_signal(signal.SIGUSR1)
>>> signal.getsignal(signal.SIGUSR1)
1
```

A handler that disarms itself is the ordinary shape for one, so this is not an exotic input. `Lib/test/test_io.py` already carries the panic in three skip reasons, quoted from an earlier run:

```
@unittest.skip("TODO: RUSTPYTHON; thread 'main' (103833) panicked at crates/vm/src/stdlib/signal.rs:233:43: RefCell already borrowed")
```

## The change

`trigger_signals` in `crates/vm/src/signal.rs` took `.borrow()` before the dispatch loop and kept it across `callable.invoke(...)`, so `signal.signal()` from inside the handler hit `_signal.rs:255`, which needs the same cell mutably.

The handler is now cloned out under a borrow that ends on the same line, before any Python code runs. Reading it inside the loop instead of once up front is deliberate: a handler that arms or disarms another signal is then seen by the rest of the pass, which is what CPython does by rereading `Handlers[i].func` each iteration.

## Tests

Eleven cases run against CPython 3.14, one process each since a panic ends the run. All eleven now agree: a handler that rearms itself, one that arms a different signal, one that calls `getsignal`, one that installs `SIG_DFL` on itself, one that restores the previous handler, one that raises (same traceback, line for line), two levels of nesting, and a handler calling `alarm`.

`Lib/test/test_io.py` had three tests skipped on this panic. They are now unskipped and pass, and they stayed green over three consecutive runs:

```
test_interrupted_read_retry_buffered (test.test_io.CSignalsTest...) ... ok
test_interrupted_write_retry_buffered (test.test_io.CSignalsTest...) ... ok
test_interrupted_write_retry_text (test.test_io.CSignalsTest...) ... ok
```

Without the change the module does not report a failure, it takes the runner down:

```
0:00:00 load avg: 2.69 [1/1] test_io

thread 'main' (25422) panicked at crates/vm/src/stdlib/_signal.rs:255:43:
RefCell already borrowed
```

`extra_tests/snippets/stdlib_signal.py` grows two cases inside its existing non-Windows block, rearming from inside a handler and arming a different signal from inside one. It passes under CPython 3.14 too.

Also run: `cargo test --workspace --exclude rustpython_wasm --exclude rustpython-venvlauncher --exclude rustpython-capi` with no failures, `cargo test` in `crates/capi`, `cargo fmt --check`, the clippy invocation from CI, and `-m test -u all` over test_io, test_signal, test_threading, test_subprocess, test_socket, test_asyncio.test_events and test_selectors, all SUCCESS.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Unix signal handling so signal callbacks can safely change signal registrations while running.
  * Ensured signal handlers are dispatched correctly without affecting unrelated or inactive signals.

* **Tests**
  * Added regression coverage for rearming, disabling, and switching signals during callback execution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->