### PR TITLE
Stop skipping six tests whose reason no longer reproduces

### DIFF
--- a/Lib/test/test_array.py
+++ b/Lib/test/test_array.py
@@ -1707,7 +1707,6 @@ class LargeArrayTest(unittest.TestCase):
     # when the index conversion mutates the array.
     # See: https://github.com/python/cpython/issues/142555.
 
-    @unittest.skip("TODO: RUSTPYTHON; Hangs")
     @subTests("dtype", ["b", "B", "h", "H", "i", "l", "q", "I", "L", "Q"])
     def test_setitem_use_after_clear_with_int_data(self, dtype):
         victim = array.array(dtype, list(range(64)))
@@ -1720,7 +1719,6 @@ class LargeArrayTest(unittest.TestCase):
         self.assertRaises(IndexError, victim.__setitem__, 1, Index())
         self.assertEqual(len(victim), 0)
 
-    @unittest.skip("TODO: RUSTPYTHON; Hangs")
     def test_setitem_use_after_shrink_with_int_data(self):
         victim = array.array('b', [1, 2, 3])
 
@@ -1732,7 +1730,6 @@ class LargeArrayTest(unittest.TestCase):
 
         self.assertRaises(IndexError, victim.__setitem__, 1, Index())
 
-    @unittest.skip("TODO: RUSTPYTHON; Hangs")
     @subTests("dtype", ["f", "d"])
     def test_setitem_use_after_clear_with_float_data(self, dtype):
         victim = array.array(dtype, [1.0, 2.0, 3.0])

--- a/Lib/test/test_marshal.py
+++ b/Lib/test/test_marshal.py
@@ -704,7 +704,6 @@ class InstancingTestCase(unittest.TestCase, HelperMixin):
         self.helper(code)
         self.helper3(code)
 
-    @unittest.skip("TODO: RUSTPYTHON")
     def testRecursion(self):
         obj = 1.2345
         d = {"hello": obj, "goodbye": obj, obj: "hello"}

--- a/Lib/test/test_thread.py
+++ b/Lib/test/test_thread.py
@@ -323,7 +323,6 @@ class ThreadRunningTests(BasicThreadTest):
         with self.assertRaisesRegex(RuntimeError, "thread not started"):
             handle._set_done()
 
-    @unittest.skipIf(__import__("sys").platform == "linux", "TODO: RUSTPYTHON; panic")
     def test_start_duplicate_handle(self):
         lock = thread.allocate_lock()
         lock.acquire()
@@ -339,7 +338,6 @@ class ThreadRunningTests(BasicThreadTest):
             lock.release()
             handle.join()
 
-    @unittest.skipIf(__import__("sys").platform == "linux", "TODO: RUSTPYTHON; panic")
     def test_start_with_none_handle(self):
         def func():
             pass


### PR DESCRIPTION
- [x] This PR follows our [AI policy](https://github.com/RustPython/.github/blob/main/AI_POLICY.md)

## Summary

Six tests are skipped for something that no longer happens.

| file | tests | reason on the marker |
| --- | --- | --- |
| `Lib/test/test_array.py` | `test_setitem_use_after_clear_with_int_data`, `test_setitem_use_after_shrink_with_int_data`, `test_setitem_use_after_clear_with_float_data` | `TODO: RUSTPYTHON; Hangs` |
| `Lib/test/test_marshal.py` | `testRecursion` | `TODO: RUSTPYTHON` |
| `Lib/test/test_thread.py` | `test_start_duplicate_handle`, `test_start_with_none_handle` | `TODO: RUSTPYTHON; panic`, on Linux only |

## What was measured

The `test_array` three cover `array.__setitem__` when the index conversion mutates the array, from [python/cpython#142555](https://github.com/python/cpython/issues/142555). Before unskipping them I ran their bodies straight against CPython 3.14, one process each with a timeout, plus four shapes the tests do not cover:

| case | CPython | RustPython |
| --- | --- | --- |
| `clear()` in `__index__`, then `victim[1] = idx` | `IndexError`, `len` 0 | `IndexError`, `len` 0 |
| two `pop()` in `__index__` | `IndexError`, `len` 1 | `IndexError`, `len` 1 |
| `clear()` in `__float__` on a `'d'` array | `IndexError`, `len` 0 | `IndexError`, `len` 0 |
| `append()` in `__index__` | `[1, 0, 3, 9]` | `[1, 0, 3, 9]` |
| `clear()` in `__index__` on a read | `IndexError` | `IndexError` |
| `clear()` in `__index__` on a slice assignment | `[7]` | `[7]` |
| `clear()` in `__index__` on `del` | `IndexError` | `IndexError` |

Nothing hangs, and the exception is the one the tests assert on. The exception text differs (`array assignment index out of range` against `assignment index out of range`), which the tests do not look at, and which belongs to #7993 rather than here.

`testRecursion` marshals a self-referential dict and list through `helper3`. It passes.

The two in `test_thread` exercise `thread.start_joinable_thread` with a reused `_ThreadHandle` and with `handle=None`. They already ran on macOS and Windows; only the Linux skip is dropped, and they passed there five times in a row.

I did not track down which change fixed each one, so the claim here is only that the stated reason does not reproduce on current `main`.

## Runs

Each module ran three times end to end after the markers came off, and the two thread tests ran five times:

```
[1] test_array -> Total tests: run=892 skipped=45 Result: SUCCESS
[1] test_marshal -> Total tests: run=75 skipped=15 Result: SUCCESS
[1] test_thread -> Total tests: run=35 skipped=3 Result: SUCCESS
```

`scripts/check_redundant_patches.py` is clean on all three files.

## Left alone

`test_logging` has two markers reading `Flaky` and `flaky EOFError`, and `test_thread.test__count` reads `Flakey on CI`. All three passed here, and that is not evidence about a flake, so they stay as they are.
