### PR TITLE
Bound the recursion in exception group split and subgroup

### DIFF
--- a/Lib/test/test_exception_group.py
+++ b/Lib/test/test_exception_group.py
@@ -538,7 +538,6 @@ class DeepRecursionInSplitAndSubgroup(unittest.TestCase):
             e = ExceptionGroup('eg', [e])
         return e
 
-    @unittest.skip("TODO: RUSTPYTHON; Segfault")
     @skip_emscripten_stack_overflow()
     @skip_wasi_stack_overflow()
     def test_deep_split(self):
@@ -546,7 +545,6 @@ class DeepRecursionInSplitAndSubgroup(unittest.TestCase):
         with self.assertRaises(RecursionError):
             e.split(TypeError)
 
-    @unittest.skip("TODO: RUSTPYTHON; Segfault")
     @skip_emscripten_stack_overflow()
     @skip_wasi_stack_overflow()
     def test_deep_subgroup(self):

--- a/crates/vm/src/exception_group.rs
+++ b/crates/vm/src/exception_group.rs
@@ -95,8 +95,13 @@ pub(super) mod types {
 
             for exc in exceptions {
                 if is_base_exception_group(&exc, vm) {
-                    // Recursive call for nested groups
-                    let subgroup_result = vm.call_method(&exc, "subgroup", (condition.clone(),))?;
+                    // Recursive call for nested groups. It pushes no Python
+                    // frame, so a deep enough group runs off the native stack
+                    // unless this guard is here.
+                    let subgroup_result = vm
+                        .with_recursion("in exception group subgroup", || {
+                            vm.call_method(&exc, "subgroup", (condition.clone(),))
+                        })?;
                     if !vm.is_none(&subgroup_result) {
                         matching.push(subgroup_result.clone());
                     }
@@ -142,7 +147,11 @@ pub(super) mod types {
 
             for exc in exceptions {
                 if is_base_exception_group(&exc, vm) {
-                    let result = vm.call_method(&exc, "split", (condition.clone(),))?;
+                    // Same as in subgroup: nothing else bounds this recursion
+                    // against the native stack.
+                    let result = vm.with_recursion("in exception group split", || {
+                        vm.call_method(&exc, "split", (condition.clone(),))
+                    })?;
                     let result_tuple: PyTupleRef = result.try_into_value(vm)?;
                     let match_part = result_tuple
                         .first()


### PR DESCRIPTION
- [x] This PR follows our [AI policy](https://github.com/RustPython/.github/blob/main/AI_POLICY.md)

## Summary

`BaseExceptionGroup.split` and `.subgroup` recurse into nested groups through `vm.call_method`, which pushes no Python frame. `sys.setrecursionlimit` therefore never sees the nesting, and a group nested deeply enough runs the native stack out:

```python
from test.support import exceeds_recursion_limit

e = TypeError(1)
for _ in range(exceeds_recursion_limit()):   # 150000
    e = ExceptionGroup("eg", [e])
e.split(TypeError)
```

CPython answers `RecursionError`. RustPython dumps core, and so does the test module that covers it:

```
0:00:00 load avg: 2.86 [1/1] test_exception_group
timeout: the monitored command dumped core
```

`Lib/test/test_exception_group.py` says as much in two skip reasons, `TODO: RUSTPYTHON; Segfault`, on `test_deep_split` and `test_deep_subgroup`. Both are unskipped here.

## Fix

The two recursive `vm.call_method` calls now sit inside `vm.with_recursion`, which is the `Py_EnterRecursiveCall` counterpart already used for comparison, `repr`, `__length_hint__` and `__subclasscheck__`. It measures the native stack rather than counting frames, which is the right budget for recursion that never reaches the evaluator.

## Measurements

Deep case, one process each:

| | CPython 3.14 | before | after |
| --- | --- | --- | --- |
| `split` at depth 150000 | `RecursionError` | core dumped | `RecursionError` |
| `subgroup` at depth 150000 | `RecursionError` | core dumped | `RecursionError` |

Shallow behaviour is untouched, checked case by case against CPython: `split` and `subgroup` on a flat group, on a nested one, with a predicate instead of a type, with no match at all, and at depth 100 where neither implementation is anywhere near the limit. Every one agrees.

`test_exception_group` ran three times after unskipping, 52 tests, SUCCESS each time, and `test_except_star`, `test_traceback`, `test_asyncio.test_taskgroups`, `test_baseexception` and `test_exceptions` are green too. Also `cargo test --workspace --exclude rustpython_wasm --exclude rustpython-venvlauncher --exclude rustpython-capi` (41 binaries, no failures), `cargo test` in `crates/capi`, `cargo fmt --check`, the clippy invocation from CI, and `scripts/check_redundant_patches.py` on the test file.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Added recursion protection when processing nested exception groups.
  * Prevented excessive recursion from causing native stack overflows while preserving existing subgroup and split behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->