### PR TITLE
Add PR performance regression gate (callgrind instruction counts)

### DIFF
--- a/.github/workflows/codspeed.yaml
+++ b/.github/workflows/codspeed.yaml
@@ -1,0 +1,93 @@
+# CodSpeed benchmark tracking.
+#
+# Runs the criterion benchmark suites under CodSpeed's instrumentation and
+# uploads the results, which gives per-PR comparison comments and a commit-by-
+# commit dashboard at codspeed.io. Like the callgrind gate in perf-ci.yaml,
+# CodSpeed measures with a modified Callgrind rather than wall-clock time, so
+# the numbers are deterministic on shared runners.
+#
+# How this relates to the other two benchmark workflows:
+#   * perf-ci.yaml -- blocks PRs. Measures whole processes, so it is the only
+#     one that sees end-to-end startup and import cost. Self-contained: no
+#     external service, thresholds under our control.
+#   * cron-ci.yaml "benchmark" job -- scheduled criterion wall-clock runs
+#     published to the website.
+#   * this workflow -- in-process criterion benchmarks, reported to CodSpeed
+#     for trend tracking and PR comments. Informational; it does not block.
+#
+# The upload is tokenless: CodSpeed accepts OIDC from public repositories.
+
+name: CodSpeed
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    types: [unlabeled, opened, synchronize, reopened]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref_name }}-${{ github.event.pull_request.number || github.sha }}
+  cancel-in-progress: true
+
+env:
+  CARGO_INCREMENTAL: 0
+  CARGO_TERM_COLOR: always
+  CI: true
+
+jobs:
+  benchmarks:
+    if: ${{ !contains(github.event.pull_request.labels.*.name, 'skip:ci') }}
+    name: Run benchmarks
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - uses: dtolnay/rust-toolchain@stable
+
+      # setup-python picks the version up from .python-version. The benchmark
+      # binaries link against libpython through pyo3 even when the CPython
+      # comparison benchmarks are skipped, so an interpreter has to be present.
+      - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
+
+      - name: Restore cargo cache
+        uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: |
+            ~/.cargo/bin/
+            ~/.cargo/registry/index/
+            ~/.cargo/registry/cache/
+            ~/.cargo/git/db/
+            target/
+          key: ${{ runner.os }}-${{ hashFiles('**/Cargo.toml') }}-
+          restore-keys: |
+            ${{ runner.os }}-stable--${{ hashFiles('**/Cargo.toml') }}-
+            ${{ runner.os }}-stable--
+        continue-on-error: true
+
+      # Not available through taiki-e/install-action, so install from crates.io.
+      - name: Install cargo-codspeed
+        run: cargo install cargo-codspeed --locked
+
+      # --jobs 1: profile.bench uses thin LTO with codegen-units = 1, and
+      # CodSpeed additionally builds with full debug info for symbolisation.
+      # Linking several bench binaries at once under those settings exhausts
+      # the runner's memory and rustc is OOM-killed.
+      - name: Build benchmarks
+        run: cargo codspeed build --jobs 1 --bench execution --bench microbenchmarks --bench vm_boot
+
+      - name: Run benchmarks
+        uses: CodSpeedHQ/action@4296e51e7041e24dadb86d1d6e8b9320d223dbe8 # v5.0.3
+        with:
+          mode: simulation
+          run: cargo codspeed run
+        env:
+          # Measure RustPython only; see the note on skip_cpython in
+          # benches/execution.rs.
+          RUSTPYTHON_BENCH_SKIP_CPYTHON: "1"

--- a/.github/workflows/perf-ci.yaml
+++ b/.github/workflows/perf-ci.yaml
@@ -160,6 +160,11 @@ jobs:
           name: perf-ci-binary-head
           path: perf-bin/head
 
+      # Both binaries are measured in the same checkout, so each measure run
+      # purges the bytecode cache and repopulates it with the binary it is
+      # about to measure. Without that, the second run would reuse the .pyc
+      # files the first one compiled and look several percent faster with an
+      # identical interpreter -- a bias towards head that hides regressions.
       - name: Measure base
         run: |
           chmod +x perf-bin/base/rustpython perf-bin/head/rustpython

--- a/.github/workflows/perf-ci.yaml
+++ b/.github/workflows/perf-ci.yaml
@@ -140,6 +140,13 @@ jobs:
         with:
           persist-credentials: false
 
+      # CPython 3.14 matches the stdlib version vendored in Lib/ and the
+      # version CONTRIBUTING.md requires for development; the harness itself
+      # only uses the stdlib.
+      - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
+        with:
+          python-version: "3.14"
+
       - name: Install valgrind
         run: sudo apt-get update && sudo apt-get install -y --no-install-recommends valgrind
 

--- a/.github/workflows/perf-ci.yaml
+++ b/.github/workflows/perf-ci.yaml
@@ -1,0 +1,174 @@
+# PR performance regression gate.
+#
+# Role split with the nightly/weekly benchmarks (cron-ci.yaml "benchmark" job):
+#   * cron-ci.yaml collects criterion wall-clock data on a schedule and
+#     publishes it to the website for long-term trend tracking. It never
+#     blocks a PR.
+#   * This workflow runs on pull requests and BLOCKS merges that regress
+#     interpreter performance. There is no overlap in tooling or data:
+#     this gate uses callgrind instruction counts, not criterion.
+#
+# Why instruction counts (callgrind Ir) instead of wall-clock time?
+# GitHub-hosted runners are shared, throttled machines: wall-clock timings
+# routinely vary by 10-40% run to run, so any wall-clock threshold is either
+# too loose to catch real regressions or flaky enough to block unrelated PRs.
+# Retired-instruction counts for a deterministic program are reproducible to
+# well under 0.1% between runs (PYTHONHASHSEED is pinned by the runner
+# script), are immune to CPU contention and frequency scaling, and stay
+# comparable even when measurements run concurrently. The trade-off is a
+# ~50x slowdown under callgrind, which the workload sizes in
+# scripts/perf_ci.py are tuned for. See benches/perf_ci/README.md.
+#
+# Budget: measurement (both binaries, excluding builds) is parallelized and
+# targets well under 10 minutes; builds reuse the shared cargo cache and the
+# base binary is cached by commit SHA, so the base build is usually a
+# cache hit.
+
+name: Performance gate
+
+on:
+  pull_request:
+    types: [unlabeled, opened, synchronize, reopened]
+    paths:
+      - "Cargo.toml"
+      - "Cargo.lock"
+      - "rust-toolchain.toml"
+      - ".cargo/config.toml"
+      - "crates/**"
+      - "src/**"
+      - "benches/perf_ci/**"
+      - "scripts/perf_ci.py"
+      - ".github/workflows/perf-ci.yaml"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref_name }}-${{ github.event.pull_request.number || github.sha }}
+  cancel-in-progress: true
+
+env:
+  CARGO_INCREMENTAL: 0
+  CARGO_PROFILE_RELEASE_DEBUG: 0
+  CARGO_TERM_COLOR: always
+  CI: true
+
+jobs:
+  build:
+    if: ${{ !contains(github.event.pull_request.labels.*.name, 'skip:ci') }}
+    # Named after the matrix entry rather than left to be named for it (see
+    # the note on generated names in ci.yaml).
+    name: Build rustpython (${{ matrix.rev }})
+    runs-on: ubuntu-latest
+    timeout-minutes: 90
+    strategy:
+      matrix:
+        rev: [base, head]
+      fail-fast: true
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Resolve revision to build
+        id: resolve
+        # For "base", measure against the merge base with the target branch so
+        # the comparison only reflects this PR's diff. For "head", measure the
+        # checked-out merge/head commit itself.
+        run: |
+          base_sha=$(git merge-base HEAD "origin/${BASE_REF}")
+          if [ "${REV}" = "base" ]; then
+            echo "sha=${base_sha}" >> "$GITHUB_OUTPUT"
+            git checkout --quiet "${base_sha}"
+          else
+            echo "sha=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
+          fi
+        env:
+          BASE_REF: ${{ github.event.pull_request.base.ref || 'main' }}
+          REV: ${{ matrix.rev }}
+
+      # The finished binary is cached by commit SHA: every PR against the same
+      # main tip shares one base build, and re-runs skip both builds entirely.
+      - name: Restore built binary
+        id: bin_cache
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: target/release/rustpython
+          key: perf-ci-bin-v1-${{ runner.os }}-${{ steps.resolve.outputs.sha }}
+
+      - uses: dtolnay/rust-toolchain@stable
+        if: steps.bin_cache.outputs.cache-hit != 'true'
+
+      - name: Restore cargo cache
+        if: steps.bin_cache.outputs.cache-hit != 'true'
+        uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: |
+            ~/.cargo/bin/
+            ~/.cargo/registry/index/
+            ~/.cargo/registry/cache/
+            ~/.cargo/git/db/
+            target/
+          key: ${{ runner.os }}-${{ hashFiles('**/Cargo.toml') }}-
+          restore-keys: |
+            ${{ runner.os }}-stable--${{ hashFiles('**/Cargo.toml') }}-
+            ${{ runner.os }}-stable--
+        continue-on-error: true
+
+      - name: Build release binary
+        if: steps.bin_cache.outputs.cache-hit != 'true'
+        run: cargo build --release --bin rustpython
+
+      - name: Upload binary
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: perf-ci-binary-${{ matrix.rev }}
+          path: target/release/rustpython
+          retention-days: 3
+
+  measure:
+    name: Measure and compare instruction counts
+    needs: build
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      # Workloads and the runner script are always taken from the PR head, so
+      # both binaries execute identical guest code.
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - name: Install valgrind
+        run: sudo apt-get update && sudo apt-get install -y --no-install-recommends valgrind
+
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: perf-ci-binary-base
+          path: perf-bin/base
+
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: perf-ci-binary-head
+          path: perf-bin/head
+
+      - name: Measure base
+        run: |
+          chmod +x perf-bin/base/rustpython perf-bin/head/rustpython
+          python3 scripts/perf_ci.py measure --binary perf-bin/base/rustpython -o perf-base.json
+
+      - name: Measure head
+        run: python3 scripts/perf_ci.py measure --binary perf-bin/head/rustpython -o perf-head.json
+
+      - name: Upload measurements
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: perf-ci-results
+          path: |
+            perf-base.json
+            perf-head.json
+          retention-days: 30
+
+      - name: Compare against threshold
+        run: python3 scripts/perf_ci.py compare perf-base.json perf-head.json

--- a/.github/workflows/perf-ci.yaml
+++ b/.github/workflows/perf-ci.yaml
@@ -140,12 +140,10 @@ jobs:
         with:
           persist-credentials: false
 
-      # CPython 3.14 matches the stdlib version vendored in Lib/ and the
-      # version CONTRIBUTING.md requires for development; the harness itself
-      # only uses the stdlib.
+      # No python-version here: setup-python picks up .python-version, which is
+      # the same CPython the rest of CI uses and matches the stdlib vendored in
+      # Lib/. The harness itself only needs the stdlib.
       - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
-        with:
-          python-version: "3.14"
 
       - name: Install valgrind
         run: sudo apt-get update && sudo apt-get install -y --no-install-recommends valgrind

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -59,15 +59,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "alloca"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e5a7d05ea6aea7e9e64d25b9156ba2fee3fdd659e34e41063cd2fc7cd020d7f4"
-dependencies = [
- "cc",
-]
-
-[[package]]
 name = "allocator-api2"
 version = "0.2.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -599,6 +590,64 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0c9ea0ac24bc397ab3c98583a3c9ba74fa56b09a4449bbe172b9b1ddb016027a"
 
 [[package]]
+name = "codspeed"
+version = "5.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7083f253260bcb4aaa3b4aa4c52973703dabc1a85c2f193997e2689aafa8a919"
+dependencies = [
+ "anyhow",
+ "cc",
+ "colored",
+ "getrandom 0.4.3",
+ "glob",
+ "libc",
+ "nix 0.31.3",
+ "serde",
+ "serde_json",
+ "statrs",
+]
+
+[[package]]
+name = "codspeed-criterion-compat"
+version = "5.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9f24251445188c69d50f10179d795424bd71b533b7e3f84fc03f26893b01af0"
+dependencies = [
+ "clap",
+ "codspeed",
+ "codspeed-criterion-compat-walltime",
+ "colored",
+ "regex",
+]
+
+[[package]]
+name = "codspeed-criterion-compat-walltime"
+version = "5.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c38205d56e2cb4fe04b708de7f9653a3f1b89edbe3a20b28f21e9e525e9e061"
+dependencies = [
+ "anes",
+ "cast",
+ "ciborium",
+ "clap",
+ "codspeed",
+ "criterion-plot",
+ "is-terminal",
+ "itertools 0.10.5",
+ "num-traits",
+ "once_cell",
+ "oorandom",
+ "plotters",
+ "rayon",
+ "regex",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "tinytemplate",
+ "walkdir",
+]
+
+[[package]]
 name = "collection_literals"
 version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -609,6 +658,15 @@ name = "colorchoice"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
+
+[[package]]
+name = "colored"
+version = "3.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "faf9468729b8cbcea668e36183cb69d317348c2e08e994829fb56ebfdfbaac34"
+dependencies = [
+ "windows-sys 0.61.2",
+]
 
 [[package]]
 name = "combine"
@@ -897,38 +955,13 @@ dependencies = [
 ]
 
 [[package]]
-name = "criterion"
-version = "0.8.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "950046b2aa2492f9a536f5f4f9a3de7b9e2476e575e05bd6c333371add4d98f3"
-dependencies = [
- "alloca",
- "anes",
- "cast",
- "ciborium",
- "clap",
- "criterion-plot",
- "itertools 0.13.0",
- "num-traits",
- "oorandom",
- "page_size",
- "plotters",
- "rayon",
- "regex",
- "serde",
- "serde_json",
- "tinytemplate",
- "walkdir",
-]
-
-[[package]]
 name = "criterion-plot"
-version = "0.8.2"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d8d80a2f4f5b554395e47b5d8305bc3d27813bacb73493eb1001e8f76dae29ea"
+checksum = "6b50826342786a51a89e2da3a28f1c32b06e387201bc2d19791f622c673706b1"
 dependencies = [
  "cast",
- "itertools 0.13.0",
+ "itertools 0.10.5",
 ]
 
 [[package]]
@@ -1728,10 +1761,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "is-terminal"
+version = "0.4.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
+dependencies = [
+ "hermit-abi",
+ "libc",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "is_terminal_polyfill"
 version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
+
+[[package]]
+name = "itertools"
+version = "0.10.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b0fd2260e829bddf4cb6ea802289de2f86d6a7a690192fbe91b3f46e0f2c8473"
+dependencies = [
+ "either",
+]
 
 [[package]]
 name = "itertools"
@@ -2462,16 +2515,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f7476a5b122ff1fce7208e7ee9dccd0a516e835f5b8b19b8f3c98a34cf757c1"
 dependencies = [
  "indexmap",
-]
-
-[[package]]
-name = "page_size"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "30d5b2194ed13191c1999ae0704b7839fb18384fa22e49b57eeaa97d79ce40da"
-dependencies = [
- "libc",
- "winapi",
 ]
 
 [[package]]
@@ -3253,7 +3296,7 @@ dependencies = [
 name = "rustpython"
 version = "0.5.0"
 dependencies = [
- "criterion",
+ "codspeed-criterion-compat",
  "dirs",
  "env_logger",
  "flame",
@@ -3543,7 +3586,7 @@ name = "rustpython-sre_engine"
 version = "0.5.0"
 dependencies = [
  "bitflags 2.13.1",
- "criterion",
+ "codspeed-criterion-compat",
  "num_enum",
  "optional",
  "rustpython-unicode",
@@ -4070,6 +4113,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
+name = "statrs"
+version = "0.18.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2a3fe7c28c6512e766b0874335db33c94ad7b8f9054228ae1c2abd47ce7d335e"
+dependencies = [
+ "approx",
+ "num-traits",
+]
+
+[[package]]
 name = "strum"
 version = "0.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4180,7 +4233,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
 dependencies = [
  "fastrand",
- "getrandom 0.3.4",
+ "getrandom 0.4.3",
  "once_cell",
  "rustix",
  "windows-sys 0.61.2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -71,6 +71,10 @@ harness = false
 name = "microbenchmarks"
 harness = false
 
+[[bench]]
+name = "vm_boot"
+harness = false
+
 [[bin]]
 name = "rustpython"
 path = "src/main.rs"
@@ -206,7 +210,10 @@ cranelift = "0.132.0"
 cranelift-jit = "0.132.0"
 cranelift-module = "0.132.0"
 crc32fast = "1.3.2"
-criterion = { version = "0.8", features = ["html_reports"] }
+# CodSpeed's drop-in criterion replacement: sources keep importing `criterion`,
+# and outside CodSpeed's instrumentation it delegates to criterion as before, so
+# `cargo bench` and the scheduled `cargo criterion` job are unaffected.
+criterion = { package = "codspeed-criterion-compat", version = "5.0.1", features = ["html_reports"] }
 crossbeam-utils = "0.8.21"
 csv-core = "0.1.11"
 digest = "0.11"

--- a/benches/execution.rs
+++ b/benches/execution.rs
@@ -38,10 +38,21 @@ fn bench_rustpython_code(b: &mut Bencher, name: &str, source: &str) {
     })
 }
 
+/// CodSpeed instruments whatever the harness runs, so its workflow sets this
+/// to keep the CPython comparison benchmarks out of the instrumented set: they
+/// measure CPython's C code rather than RustPython, and a runner-side CPython
+/// upgrade would surface as a regression. Unset -- `cargo bench` and the
+/// scheduled `cargo criterion` job -- they run as before.
+fn skip_cpython() -> bool {
+    std::env::var_os("RUSTPYTHON_BENCH_SKIP_CPYTHON").is_some()
+}
+
 pub fn benchmark_file_execution(group: &mut BenchmarkGroup<WallTime>, name: &str, contents: &str) {
-    group.bench_function(BenchmarkId::new(name, "cpython"), |b| {
-        bench_cpython_code(b, contents)
-    });
+    if !skip_cpython() {
+        group.bench_function(BenchmarkId::new(name, "cpython"), |b| {
+            bench_cpython_code(b, contents)
+        });
+    }
     group.bench_function(BenchmarkId::new(name, "rustpython"), |b| {
         bench_rustpython_code(b, name, contents)
     });
@@ -52,6 +63,9 @@ pub fn benchmark_file_parsing(group: &mut BenchmarkGroup<WallTime>, name: &str, 
     group.bench_function(BenchmarkId::new("rustpython", name), |b| {
         b.iter(|| ruff_python_parser::parse_module(contents).unwrap())
     });
+    if skip_cpython() {
+        return;
+    }
     group.bench_function(BenchmarkId::new("cpython", name), |b| {
         use pyo3::types::PyAnyMethods;
         pyo3::Python::attach(|py| {
@@ -75,9 +89,11 @@ pub fn benchmark_pystone(group: &mut BenchmarkGroup<WallTime>, contents: String)
         let code_str = code_with_loops.as_str();
 
         group.throughput(Throughput::Elements(idx as u64));
-        group.bench_function(BenchmarkId::new("cpython", idx), |b| {
-            bench_cpython_code(b, code_str)
-        });
+        if !skip_cpython() {
+            group.bench_function(BenchmarkId::new("cpython", idx), |b| {
+                bench_cpython_code(b, code_str)
+            });
+        }
         group.bench_function(BenchmarkId::new("rustpython", idx), |b| {
             bench_rustpython_code(b, "pystone", code_str)
         });

--- a/benches/microbenchmarks.rs
+++ b/benches/microbenchmarks.rs
@@ -168,10 +168,21 @@ fn bench_rustpython_code(group: &mut BenchmarkGroup<WallTime>, bench: &MicroBenc
     })
 }
 
+/// CodSpeed instruments whatever the harness runs, so its workflow sets this
+/// to keep the CPython comparison benchmarks out of the instrumented set: they
+/// measure CPython's C code rather than RustPython, and a runner-side CPython
+/// upgrade would surface as a regression. Unset -- `cargo bench` and the
+/// scheduled `cargo criterion` job -- they run as before.
+fn skip_cpython() -> bool {
+    std::env::var_os("RUSTPYTHON_BENCH_SKIP_CPYTHON").is_some()
+}
+
 pub fn run_micro_benchmark(c: &mut Criterion, benchmark: MicroBenchmark) {
     let mut group = c.benchmark_group("microbenchmarks");
 
-    bench_cpython_code(&mut group, &benchmark);
+    if !skip_cpython() {
+        bench_cpython_code(&mut group, &benchmark);
+    }
     bench_rustpython_code(&mut group, &benchmark);
 
     group.finish();

--- a/benches/perf_ci/README.md
+++ b/benches/perf_ci/README.md
@@ -24,6 +24,17 @@ Role split:
   published to the website; long-term trend data, never blocks PRs.
 * This gate — per-PR, deterministic, blocks regressions.
 
+Two runs of the gate share a checkout, so bytecode caching has to be handled
+explicitly: RustPython writes `.pyc` files next to the sources it imports, and
+loading a cached module is far cheaper than compiling it (measured: ~3.8x
+fewer instructions for `import_stdlib`, ~2x for `chaos`). Whichever binary ran
+second would otherwise inherit the first one's compiled bytecode and look up
+to 46% faster with no interpreter change at all. `scripts/perf_ci.py`
+therefore purges the cache at the start of every measurement run and warms it
+with the binary it is about to measure, then measures with `-B` so the timed
+runs cannot mutate it. Both binaries are thus compared in the same steady
+state, and the numbers do not depend on measurement order.
+
 ## Layout
 
 * `micro/` — targeted microbenchmarks written for this gate, one interpreter

--- a/benches/perf_ci/README.md
+++ b/benches/perf_ci/README.md
@@ -47,6 +47,11 @@ pyperf would also not fit the deterministic instruction-count approach.
 
 ## Running locally
 
+Drive the harness with CPython 3.14 (the version CONTRIBUTING.md requires and
+the one CI uses); the script itself only needs the stdlib, plus `valgrind` on
+the system. All workloads also run unmodified under CPython, which is handy
+for sanity-checking a workload change.
+
 ```shell
 cargo build --release
 python3 scripts/perf_ci.py measure --binary target/release/rustpython -o head.json

--- a/benches/perf_ci/README.md
+++ b/benches/perf_ci/README.md
@@ -1,0 +1,61 @@
+# PR performance regression gate workloads
+
+These workloads back the `Performance gate` workflow
+(`.github/workflows/perf-ci.yaml`), which blocks pull requests that regress
+interpreter performance. They are driven by `scripts/perf_ci.py`, which runs
+each file under `valgrind --tool=callgrind` and compares retired instruction
+counts (Ir) between the PR head and its merge base.
+
+## Why instruction counts
+
+Wall-clock timings on shared CI runners are noisy (10-40% run-to-run swings),
+which makes any wall-clock threshold either too loose or flaky. Instruction
+counts of a deterministic program are reproducible to well under 0.1%
+(`PYTHONHASHSEED=0` is pinned so dict/str hashing is deterministic), are
+immune to CPU contention and frequency scaling, and remain comparable when
+measurements run in parallel. Ir cannot observe cache or branch-predictor
+effects, so the gate can miss (rare) regressions that change memory locality
+without changing instruction count — the scheduled criterion benchmarks
+(`cron-ci.yaml`) still track wall-clock trends over time for that.
+
+Role split:
+
+* `cron-ci.yaml` `benchmark` job — scheduled criterion wall-clock runs,
+  published to the website; long-term trend data, never blocks PRs.
+* This gate — per-PR, deterministic, blocks regressions.
+
+## Layout
+
+* `micro/` — targeted microbenchmarks written for this gate, one interpreter
+  axis per file: integer/float arithmetic, function calls, method calls,
+  instance attribute loads, dict/list/str operations, class creation,
+  exception handling, and stdlib import cost. Interpreter startup (`-c pass`)
+  is measured directly by `scripts/perf_ci.py`.
+* `pyperformance/` — benchmark kernels vendored from
+  [pyperformance](https://github.com/python/pyperformance) 1.14.0 (MIT
+  license, see `pyperformance/COPYING`). Modifications are limited to
+  `# RUSTPYTHON perf_ci` blocks that let the gate shrink workload sizes via
+  environment variables (upstream defaults are kept).
+  `pyperformance/pyperf.py` is a minimal local stand-in for
+  the real pyperf harness so the kernels run unmodified; it is our code, not
+  vendored.
+
+The full pyperformance harness is not used because it hard-requires building
+`psutil` (a CPython C extension) into a venv managed by the measured
+interpreter, which RustPython cannot currently do. Wall-clock statistics from
+pyperf would also not fit the deterministic instruction-count approach.
+
+## Running locally
+
+```shell
+cargo build --release
+python3 scripts/perf_ci.py measure --binary target/release/rustpython -o head.json
+git stash        # or check out the base commit and rebuild
+python3 scripts/perf_ci.py measure --binary target/release/rustpython -o base.json
+python3 scripts/perf_ci.py compare base.json head.json
+```
+
+Workload sizes are tuned so one full measurement of one binary takes a few
+minutes (callgrind slows execution ~50x). When adding a workload, keep its
+native runtime in the 50-500 ms range and make it deterministic: fixed seeds,
+no wall-clock dependence, no filesystem or network I/O in the hot path.

--- a/benches/perf_ci/micro/attr_load.py
+++ b/benches/perf_ci/micro/attr_load.py
@@ -1,0 +1,31 @@
+# perf_ci axis: instance attribute load/store (__dict__ and slots).
+import os
+
+N = int(os.environ.get("PERF_CI_N", "100000"))
+
+
+class Plain:
+    def __init__(self):
+        self.a = 1
+        self.b = 2
+        self.c = 3
+
+
+class Slotted:
+    __slots__ = ("a", "b")
+
+    def __init__(self):
+        self.a = 1
+        self.b = 2
+
+
+p = Plain()
+s = Slotted()
+total = 0
+for _ in range(N):
+    total += p.a + p.b + p.c
+    total += s.a + s.b
+    p.a = total & 0xFF
+    s.a = total & 0xF
+
+print(total)

--- a/benches/perf_ci/micro/call_function.py
+++ b/benches/perf_ci/micro/call_function.py
@@ -1,0 +1,26 @@
+# perf_ci axis: Python function call overhead (positional, default, kwargs).
+import os
+
+N = int(os.environ.get("PERF_CI_N", "100000"))
+
+
+def f0():
+    return 1
+
+
+def f2(a, b):
+    return a + b
+
+
+def fd(a, b=2, c=3):
+    return a + b + c
+
+
+total = 0
+for i in range(N):
+    total += f0()
+    total += f2(i, 1)
+    total += fd(i)
+    total += fd(i, c=5)
+
+print(total)

--- a/benches/perf_ci/micro/class_create.py
+++ b/benches/perf_ci/micro/class_create.py
@@ -1,0 +1,27 @@
+# perf_ci axis: class object creation (type creation) and instantiation.
+import os
+
+N = int(os.environ.get("PERF_CI_N", "2000"))
+
+total = 0
+for i in range(N):
+    class Dynamic:
+        x = 1
+
+        def method(self):
+            return self.x
+
+    obj = Dynamic()
+    total += obj.method()
+
+
+class Fixed:
+    def __init__(self, a, b):
+        self.a = a
+        self.b = b
+
+
+for i in range(N * 10):
+    total += Fixed(i, i + 1).a
+
+print(total)

--- a/benches/perf_ci/micro/dict_ops.py
+++ b/benches/perf_ci/micro/dict_ops.py
@@ -1,0 +1,23 @@
+# perf_ci axis: dict store, load, delete, iteration with str and int keys.
+# PYTHONHASHSEED is pinned by the runner so hashing is deterministic.
+import os
+
+N = int(os.environ.get("PERF_CI_N", "50000"))
+
+d = {}
+for i in range(N):
+    d[i] = i
+    d["k%d" % (i % 512)] = i
+
+total = 0
+for i in range(N):
+    total += d[i]
+    total += d["k%d" % (i % 512)]
+
+for i in range(0, N, 2):
+    del d[i]
+
+for k in d:
+    total += 1
+
+print(total, len(d))

--- a/benches/perf_ci/micro/exceptions.py
+++ b/benches/perf_ci/micro/exceptions.py
@@ -1,0 +1,33 @@
+# perf_ci axis: exception raise/catch, including try bodies that do not raise.
+import os
+
+N = int(os.environ.get("PERF_CI_N", "50000"))
+
+
+class AppError(Exception):
+    pass
+
+
+total = 0
+for i in range(N):
+    try:
+        if i % 2:
+            raise AppError(i)
+        total += 1
+    except AppError:
+        total += 2
+
+    try:
+        total += 1
+    except ValueError:
+        pass
+
+    try:
+        try:
+            raise ValueError(i)
+        except KeyError:
+            pass
+    except ValueError:
+        total += 1
+
+print(total)

--- a/benches/perf_ci/micro/float_arith.py
+++ b/benches/perf_ci/micro/float_arith.py
@@ -1,0 +1,12 @@
+# perf_ci axis: float arithmetic in a hot loop.
+import os
+
+N = int(os.environ.get("PERF_CI_N", "200000"))
+
+x = 0.0
+y = 1.0
+for i in range(N):
+    x += y * 1.000001
+    y = y * 0.999999 + x * 1e-9
+
+print(x, y)

--- a/benches/perf_ci/micro/import_stdlib.py
+++ b/benches/perf_ci/micro/import_stdlib.py
@@ -1,0 +1,9 @@
+# perf_ci axis: import machinery cost for a few common stdlib modules.
+# Fresh process per run, so these are real (uncached) imports.
+import collections
+import functools
+import itertools
+import json
+import re
+
+print(len((collections, functools, itertools, json, re)))

--- a/benches/perf_ci/micro/int_arith.py
+++ b/benches/perf_ci/micro/int_arith.py
@@ -1,0 +1,17 @@
+# perf_ci axis: integer arithmetic in a hot loop.
+# Deterministic; sized for callgrind instruction counting (small native runtime).
+import os
+
+N = int(os.environ.get("PERF_CI_N", "200000"))
+
+total = 0
+i = 0
+while i < N:
+    total += i * 3 + (i >> 2) - (i % 7)
+    i += 1
+
+acc = 0
+for j in range(N):
+    acc = acc * 2 % 1000003 + j
+
+print(total, acc)

--- a/benches/perf_ci/micro/list_ops.py
+++ b/benches/perf_ci/micro/list_ops.py
@@ -1,0 +1,19 @@
+# perf_ci axis: list append, index, slice, sort, comprehension.
+import os
+
+N = int(os.environ.get("PERF_CI_N", "50000"))
+
+lst = []
+for i in range(N):
+    lst.append((i * 7919) % N)
+
+total = 0
+for i in range(N):
+    total += lst[i]
+
+sub = lst[: N // 2]
+squares = [x * x for x in sub]
+lst.sort()
+total += lst[0] + lst[-1] + len(squares)
+
+print(total)

--- a/benches/perf_ci/micro/method_call.py
+++ b/benches/perf_ci/micro/method_call.py
@@ -1,0 +1,24 @@
+# perf_ci axis: bound method call overhead (instance and builtin methods).
+import os
+
+N = int(os.environ.get("PERF_CI_N", "100000"))
+
+
+class C:
+    def get(self):
+        return 1
+
+    def add(self, x):
+        return x + 1
+
+
+obj = C()
+lst = []
+total = 0
+for i in range(N):
+    total += obj.get()
+    total += obj.add(i)
+    lst.append(i)
+    lst.pop()
+
+print(total, len(lst))

--- a/benches/perf_ci/micro/str_ops.py
+++ b/benches/perf_ci/micro/str_ops.py
@@ -1,0 +1,21 @@
+# perf_ci axis: string concat, join, format, find, case conversion.
+# PYTHONHASHSEED is pinned by the runner so str hashing is deterministic.
+import os
+
+N = int(os.environ.get("PERF_CI_N", "20000"))
+
+parts = []
+s = ""
+for i in range(N):
+    s += "x"
+    parts.append("part%d" % (i % 100))
+
+joined = ",".join(parts)
+total = len(s) + len(joined)
+for i in range(N):
+    t = "prefix %d suffix" % i
+    total += t.find("suffix")
+    total += len(t.upper())
+    total += len(f"{i}-{i:04d}")
+
+print(total)

--- a/benches/perf_ci/pyperformance/COPYING
+++ b/benches/perf_ci/pyperformance/COPYING
@@ -1,0 +1,20 @@
+The MIT License
+
+Permission is hereby granted, free of charge, to any person
+obtaining a copy of this software and associated documentation
+files (the "Software"), to deal in the Software without
+restriction, including without limitation the rights to use,
+copy, modify, merge, publish, distribute, sublicense, and/or
+sell copies of the Software, and to permit persons to whom the
+Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included
+in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+DEALINGS IN THE SOFTWARE.

--- a/benches/perf_ci/pyperformance/bm_chaos.py
+++ b/benches/perf_ci/pyperformance/bm_chaos.py
@@ -1,0 +1,309 @@
+"""create chaosgame-like fractals
+
+Copyright (C) 2005 Carl Friedrich Bolz
+"""
+
+import math
+import random
+
+import pyperf
+
+
+DEFAULT_THICKNESS = 0.25
+DEFAULT_WIDTH = 256
+DEFAULT_HEIGHT = 256
+DEFAULT_ITERATIONS = 5000
+DEFAULT_RNG_SEED = 1234
+
+
+class GVector(object):
+
+    def __init__(self, x=0, y=0, z=0):
+        self.x = x
+        self.y = y
+        self.z = z
+
+    def Mag(self):
+        return math.sqrt(self.x ** 2 + self.y ** 2 + self.z ** 2)
+
+    def dist(self, other):
+        return math.sqrt((self.x - other.x) ** 2
+                         + (self.y - other.y) ** 2
+                         + (self.z - other.z) ** 2)
+
+    def __add__(self, other):
+        if not isinstance(other, GVector):
+            raise ValueError("Can't add GVector to " + str(type(other)))
+        v = GVector(self.x + other.x, self.y + other.y, self.z + other.z)
+        return v
+
+    def __sub__(self, other):
+        return self + other * -1
+
+    def __mul__(self, other):
+        v = GVector(self.x * other, self.y * other, self.z * other)
+        return v
+    __rmul__ = __mul__
+
+    def linear_combination(self, other, l1, l2=None):
+        if l2 is None:
+            l2 = 1 - l1
+        v = GVector(self.x * l1 + other.x * l2,
+                    self.y * l1 + other.y * l2,
+                    self.z * l1 + other.z * l2)
+        return v
+
+    def __str__(self):
+        return "<%f, %f, %f>" % (self.x, self.y, self.z)
+
+    def __repr__(self):
+        return "GVector(%f, %f, %f)" % (self.x, self.y, self.z)
+
+
+class Spline(object):
+    """Class for representing B-Splines and NURBS of arbitrary degree"""
+
+    def __init__(self, points, degree, knots):
+        """Creates a Spline.
+
+        points is a list of GVector, degree is the degree of the Spline.
+        """
+        if len(points) > len(knots) - degree + 1:
+            raise ValueError("too many control points")
+        elif len(points) < len(knots) - degree + 1:
+            raise ValueError("not enough control points")
+        last = knots[0]
+        for cur in knots[1:]:
+            if cur < last:
+                raise ValueError("knots not strictly increasing")
+            last = cur
+        self.knots = knots
+        self.points = points
+        self.degree = degree
+
+    def GetDomain(self):
+        """Returns the domain of the B-Spline"""
+        return (self.knots[self.degree - 1],
+                self.knots[len(self.knots) - self.degree])
+
+    def __call__(self, u):
+        """Calculates a point of the B-Spline using de Boors Algorithm"""
+        dom = self.GetDomain()
+        if u < dom[0] or u > dom[1]:
+            raise ValueError("Function value not in domain")
+        if u == dom[0]:
+            return self.points[0]
+        if u == dom[1]:
+            return self.points[-1]
+        I = self.GetIndex(u)
+        d = [self.points[I - self.degree + 1 + ii]
+             for ii in range(self.degree + 1)]
+        U = self.knots
+        for ik in range(1, self.degree + 1):
+            for ii in range(I - self.degree + ik + 1, I + 2):
+                ua = U[ii + self.degree - ik]
+                ub = U[ii - 1]
+                co1 = (ua - u) / (ua - ub)
+                co2 = (u - ub) / (ua - ub)
+                index = ii - I + self.degree - ik - 1
+                d[index] = d[index].linear_combination(d[index + 1], co1, co2)
+        return d[0]
+
+    def GetIndex(self, u):
+        dom = self.GetDomain()
+        for ii in range(self.degree - 1, len(self.knots) - self.degree):
+            if u >= self.knots[ii] and u < self.knots[ii + 1]:
+                I = ii
+                break
+        else:
+            I = dom[1] - 1
+        return I
+
+    def __len__(self):
+        return len(self.points)
+
+    def __repr__(self):
+        return "Spline(%r, %r, %r)" % (self.points, self.degree, self.knots)
+
+
+def write_ppm(im, filename):
+    magic = 'P6\n'
+    maxval = 255
+    w = len(im)
+    h = len(im[0])
+
+    with open(filename, "w", encoding="latin1", newline='') as fp:
+        fp.write(magic)
+        fp.write('%i %i\n%i\n' % (w, h, maxval))
+        for j in range(h):
+            for i in range(w):
+                val = im[i][j]
+                c = val * 255
+                fp.write('%c%c%c' % (c, c, c))
+
+
+class Chaosgame(object):
+
+    def __init__(self, splines, thickness=0.1):
+        self.splines = splines
+        self.thickness = thickness
+        self.minx = min([p.x for spl in splines for p in spl.points])
+        self.miny = min([p.y for spl in splines for p in spl.points])
+        self.maxx = max([p.x for spl in splines for p in spl.points])
+        self.maxy = max([p.y for spl in splines for p in spl.points])
+        self.height = self.maxy - self.miny
+        self.width = self.maxx - self.minx
+        self.num_trafos = []
+        maxlength = thickness * self.width / self.height
+        for spl in splines:
+            length = 0
+            curr = spl(0)
+            for i in range(1, 1000):
+                last = curr
+                t = 1 / 999 * i
+                curr = spl(t)
+                length += curr.dist(last)
+            self.num_trafos.append(max(1, int(length / maxlength * 1.5)))
+        self.num_total = sum(self.num_trafos)
+
+    def get_random_trafo(self):
+        r = random.randrange(int(self.num_total) + 1)
+        l = 0
+        for i in range(len(self.num_trafos)):
+            if r >= l and r < l + self.num_trafos[i]:
+                return i, random.randrange(self.num_trafos[i])
+            l += self.num_trafos[i]
+        return len(self.num_trafos) - 1, random.randrange(self.num_trafos[-1])
+
+    def transform_point(self, point, trafo=None):
+        x = (point.x - self.minx) / self.width
+        y = (point.y - self.miny) / self.height
+        if trafo is None:
+            trafo = self.get_random_trafo()
+        start, end = self.splines[trafo[0]].GetDomain()
+        length = end - start
+        seg_length = length / self.num_trafos[trafo[0]]
+        t = start + seg_length * trafo[1] + seg_length * x
+        basepoint = self.splines[trafo[0]](t)
+        if t + 1 / 50000 > end:
+            neighbour = self.splines[trafo[0]](t - 1 / 50000)
+            derivative = neighbour - basepoint
+        else:
+            neighbour = self.splines[trafo[0]](t + 1 / 50000)
+            derivative = basepoint - neighbour
+        if derivative.Mag() != 0:
+            basepoint.x += derivative.y / derivative.Mag() * (y - 0.5) * \
+                self.thickness
+            basepoint.y += -derivative.x / derivative.Mag() * (y - 0.5) * \
+                self.thickness
+        else:
+            print("r", end='')
+        self.truncate(basepoint)
+        return basepoint
+
+    def truncate(self, point):
+        if point.x >= self.maxx:
+            point.x = self.maxx
+        if point.y >= self.maxy:
+            point.y = self.maxy
+        if point.x < self.minx:
+            point.x = self.minx
+        if point.y < self.miny:
+            point.y = self.miny
+
+    def create_image_chaos(self, w, h, iterations, filename, rng_seed):
+        # Always use the same sequence of random numbers
+        # to get reproductible benchmark
+        random.seed(rng_seed)
+
+        im = [[1] * h for i in range(w)]
+        point = GVector((self.maxx + self.minx) / 2,
+                        (self.maxy + self.miny) / 2, 0)
+        for _ in range(iterations):
+            point = self.transform_point(point)
+            x = (point.x - self.minx) / self.width * w
+            y = (point.y - self.miny) / self.height * h
+            x = int(x)
+            y = int(y)
+            if x == w:
+                x -= 1
+            if y == h:
+                y -= 1
+            im[x][h - y - 1] = 0
+
+        if filename:
+            write_ppm(im, filename)
+
+
+def main(runner, args):
+    splines = [
+        Spline([
+            GVector(1.597350, 3.304460, 0.000000),
+            GVector(1.575810, 4.123260, 0.000000),
+            GVector(1.313210, 5.288350, 0.000000),
+            GVector(1.618900, 5.329910, 0.000000),
+            GVector(2.889940, 5.502700, 0.000000),
+            GVector(2.373060, 4.381830, 0.000000),
+            GVector(1.662000, 4.360280, 0.000000)],
+            3, [0, 0, 0, 1, 1, 1, 2, 2, 2]),
+        Spline([
+            GVector(2.804500, 4.017350, 0.000000),
+            GVector(2.550500, 3.525230, 0.000000),
+            GVector(1.979010, 2.620360, 0.000000),
+            GVector(1.979010, 2.620360, 0.000000)],
+            3, [0, 0, 0, 1, 1, 1]),
+        Spline([
+            GVector(2.001670, 4.011320, 0.000000),
+            GVector(2.335040, 3.312830, 0.000000),
+            GVector(2.366800, 3.233460, 0.000000),
+            GVector(2.366800, 3.233460, 0.000000)],
+            3, [0, 0, 0, 1, 1, 1])
+    ]
+
+    runner.metadata['chaos_thickness'] = args.thickness
+    runner.metadata['chaos_width'] = args.width
+    runner.metadata['chaos_height'] = args.height
+    runner.metadata['chaos_iterations'] = args.iterations
+    runner.metadata['chaos_rng_seed'] = args.rng_seed
+
+    chaos = Chaosgame(splines, args.thickness)
+    runner.bench_func('chaos', chaos.create_image_chaos,
+                      args.width, args.height, args.iterations,
+                      args.filename, args.rng_seed)
+
+
+def add_cmdline_args(cmd, args):
+    cmd.append("--width=%s" % args.width)
+    cmd.append("--height=%s" % args.height)
+    cmd.append("--thickness=%s" % args.thickness)
+    cmd.append("--rng-seed=%s" % args.rng_seed)
+    if args.filename:
+        cmd.extend(("--filename", args.filename))
+
+
+if __name__ == "__main__":
+    runner = pyperf.Runner(add_cmdline_args=add_cmdline_args)
+    runner.metadata['description'] = "Create chaosgame-like fractals"
+    cmd = runner.argparser
+    cmd.add_argument("--thickness",
+                     type=float, default=DEFAULT_THICKNESS,
+                     help="Thickness (default: %s)" % DEFAULT_THICKNESS)
+    cmd.add_argument("--width",
+                     type=int, default=DEFAULT_WIDTH,
+                     help="Image width (default: %s)" % DEFAULT_WIDTH)
+    cmd.add_argument("--height",
+                     type=int, default=DEFAULT_HEIGHT,
+                     help="Image height (default: %s)" % DEFAULT_HEIGHT)
+    cmd.add_argument("--iterations",
+                     type=int, default=DEFAULT_ITERATIONS,
+                     help="Number of iterations (default: %s)"
+                          % DEFAULT_ITERATIONS)
+    cmd.add_argument("--filename", metavar="FILENAME.PPM",
+                     help="Output filename of the PPM picture")
+    cmd.add_argument("--rng-seed",
+                     type=int, default=DEFAULT_RNG_SEED,
+                     help="Random number generator seed (default: %s)"
+                          % DEFAULT_RNG_SEED)
+
+    args = runner.parse_args()
+    main(runner, args)

--- a/benches/perf_ci/pyperformance/bm_deltablue.py
+++ b/benches/perf_ci/pyperformance/bm_deltablue.py
@@ -1,0 +1,638 @@
+"""
+deltablue.py
+============
+
+Ported for the PyPy project.
+Contributed by Daniel Lindsley
+
+This implementation of the DeltaBlue benchmark was directly ported
+from the `V8's source code`_, which was in turn derived
+from the Smalltalk implementation by John Maloney and Mario
+Wolczko. The original Javascript implementation was licensed under the GPL.
+
+It's been updated in places to be more idiomatic to Python (for loops over
+collections, a couple magic methods, ``OrderedCollection`` being a list & things
+altering those collections changed to the builtin methods) but largely retains
+the layout & logic from the original. (Ugh.)
+
+.. _`V8's source code`: (https://github.com/v8/v8/blob/master/benchmarks/deltablue.js)
+"""
+
+import pyperf
+
+
+# The JS variant implements "OrderedCollection", which basically completely
+# overlaps with ``list``. So we'll cheat. :D
+class OrderedCollection(list):
+    pass
+
+
+class Strength(object):
+    REQUIRED = None
+    STRONG_PREFERRED = None
+    PREFERRED = None
+    STRONG_DEFAULT = None
+    NORMAL = None
+    WEAK_DEFAULT = None
+    WEAKEST = None
+
+    def __init__(self, strength, name):
+        super(Strength, self).__init__()
+        self.strength = strength
+        self.name = name
+
+    @classmethod
+    def stronger(cls, s1, s2):
+        return s1.strength < s2.strength
+
+    @classmethod
+    def weaker(cls, s1, s2):
+        return s1.strength > s2.strength
+
+    @classmethod
+    def weakest_of(cls, s1, s2):
+        if cls.weaker(s1, s2):
+            return s1
+
+        return s2
+
+    @classmethod
+    def strongest(cls, s1, s2):
+        if cls.stronger(s1, s2):
+            return s1
+
+        return s2
+
+    def next_weaker(self):
+        strengths = {
+            0: self.__class__.WEAKEST,
+            1: self.__class__.WEAK_DEFAULT,
+            2: self.__class__.NORMAL,
+            3: self.__class__.STRONG_DEFAULT,
+            4: self.__class__.PREFERRED,
+            # TODO: This looks like a bug in the original code. Shouldn't this be
+            #       ``STRONG_PREFERRED? Keeping for porting sake...
+            5: self.__class__.REQUIRED,
+        }
+        return strengths[self.strength]
+
+
+# This is a terrible pattern IMO, but true to the original JS implementation.
+Strength.REQUIRED = Strength(0, "required")
+Strength.STRONG_PREFERRED = Strength(1, "strongPreferred")
+Strength.PREFERRED = Strength(2, "preferred")
+Strength.STRONG_DEFAULT = Strength(3, "strongDefault")
+Strength.NORMAL = Strength(4, "normal")
+Strength.WEAK_DEFAULT = Strength(5, "weakDefault")
+Strength.WEAKEST = Strength(6, "weakest")
+
+
+class Constraint(object):
+
+    def __init__(self, strength):
+        super(Constraint, self).__init__()
+        self.strength = strength
+
+    def add_constraint(self):
+        global planner
+        self.add_to_graph()
+        planner.incremental_add(self)
+
+    def satisfy(self, mark):
+        global planner
+        self.choose_method(mark)
+
+        if not self.is_satisfied():
+            if self.strength == Strength.REQUIRED:
+                print('Could not satisfy a required constraint!')
+
+            return None
+
+        self.mark_inputs(mark)
+        out = self.output()
+        overridden = out.determined_by
+
+        if overridden is not None:
+            overridden.mark_unsatisfied()
+
+        out.determined_by = self
+
+        if not planner.add_propagate(self, mark):
+            print('Cycle encountered')
+
+        out.mark = mark
+        return overridden
+
+    def destroy_constraint(self):
+        global planner
+        if self.is_satisfied():
+            planner.incremental_remove(self)
+        else:
+            self.remove_from_graph()
+
+    def is_input(self):
+        return False
+
+
+class UrnaryConstraint(Constraint):
+
+    def __init__(self, v, strength):
+        super(UrnaryConstraint, self).__init__(strength)
+        self.my_output = v
+        self.satisfied = False
+        self.add_constraint()
+
+    def add_to_graph(self):
+        self.my_output.add_constraint(self)
+        self.satisfied = False
+
+    def choose_method(self, mark):
+        if self.my_output.mark != mark and \
+           Strength.stronger(self.strength, self.my_output.walk_strength):
+            self.satisfied = True
+        else:
+            self.satisfied = False
+
+    def is_satisfied(self):
+        return self.satisfied
+
+    def mark_inputs(self, mark):
+        # No-ops.
+        pass
+
+    def output(self):
+        # Ugh. Keeping it for consistency with the original. So much for
+        # "we're all adults here"...
+        return self.my_output
+
+    def recalculate(self):
+        self.my_output.walk_strength = self.strength
+        self.my_output.stay = not self.is_input()
+
+        if self.my_output.stay:
+            self.execute()
+
+    def mark_unsatisfied(self):
+        self.satisfied = False
+
+    def inputs_known(self, mark):
+        return True
+
+    def remove_from_graph(self):
+        if self.my_output is not None:
+            self.my_output.remove_constraint(self)
+            self.satisfied = False
+
+
+class StayConstraint(UrnaryConstraint):
+
+    def __init__(self, v, string):
+        super(StayConstraint, self).__init__(v, string)
+
+    def execute(self):
+        # The methods, THEY DO NOTHING.
+        pass
+
+
+class EditConstraint(UrnaryConstraint):
+
+    def __init__(self, v, string):
+        super(EditConstraint, self).__init__(v, string)
+
+    def is_input(self):
+        return True
+
+    def execute(self):
+        # This constraint also does nothing.
+        pass
+
+
+class Direction(object):
+    # Hooray for things that ought to be structs!
+    NONE = 0
+    FORWARD = 1
+    BACKWARD = -1
+
+
+class BinaryConstraint(Constraint):
+
+    def __init__(self, v1, v2, strength):
+        super(BinaryConstraint, self).__init__(strength)
+        self.v1 = v1
+        self.v2 = v2
+        self.direction = Direction.NONE
+        self.add_constraint()
+
+    def choose_method(self, mark):
+        if self.v1.mark == mark:
+            if self.v2.mark != mark and Strength.stronger(self.strength, self.v2.walk_strength):
+                self.direction = Direction.FORWARD
+            else:
+                self.direction = Direction.BACKWARD
+
+        if self.v2.mark == mark:
+            if self.v1.mark != mark and Strength.stronger(self.strength, self.v1.walk_strength):
+                self.direction = Direction.BACKWARD
+            else:
+                self.direction = Direction.NONE
+
+        if Strength.weaker(self.v1.walk_strength, self.v2.walk_strength):
+            if Strength.stronger(self.strength, self.v1.walk_strength):
+                self.direction = Direction.BACKWARD
+            else:
+                self.direction = Direction.NONE
+        else:
+            if Strength.stronger(self.strength, self.v2.walk_strength):
+                self.direction = Direction.FORWARD
+            else:
+                self.direction = Direction.BACKWARD
+
+    def add_to_graph(self):
+        self.v1.add_constraint(self)
+        self.v2.add_constraint(self)
+        self.direction = Direction.NONE
+
+    def is_satisfied(self):
+        return self.direction != Direction.NONE
+
+    def mark_inputs(self, mark):
+        self.input().mark = mark
+
+    def input(self):
+        if self.direction == Direction.FORWARD:
+            return self.v1
+
+        return self.v2
+
+    def output(self):
+        if self.direction == Direction.FORWARD:
+            return self.v2
+
+        return self.v1
+
+    def recalculate(self):
+        ihn = self.input()
+        out = self.output()
+        out.walk_strength = Strength.weakest_of(
+            self.strength, ihn.walk_strength)
+        out.stay = ihn.stay
+
+        if out.stay:
+            self.execute()
+
+    def mark_unsatisfied(self):
+        self.direction = Direction.NONE
+
+    def inputs_known(self, mark):
+        i = self.input()
+        return i.mark == mark or i.stay or i.determined_by is None
+
+    def remove_from_graph(self):
+        if self.v1 is not None:
+            self.v1.remove_constraint(self)
+
+        if self.v2 is not None:
+            self.v2.remove_constraint(self)
+
+        self.direction = Direction.NONE
+
+
+class ScaleConstraint(BinaryConstraint):
+
+    def __init__(self, src, scale, offset, dest, strength):
+        self.direction = Direction.NONE
+        self.scale = scale
+        self.offset = offset
+        super(ScaleConstraint, self).__init__(src, dest, strength)
+
+    def add_to_graph(self):
+        super(ScaleConstraint, self).add_to_graph()
+        self.scale.add_constraint(self)
+        self.offset.add_constraint(self)
+
+    def remove_from_graph(self):
+        super(ScaleConstraint, self).remove_from_graph()
+
+        if self.scale is not None:
+            self.scale.remove_constraint(self)
+
+        if self.offset is not None:
+            self.offset.remove_constraint(self)
+
+    def mark_inputs(self, mark):
+        super(ScaleConstraint, self).mark_inputs(mark)
+        self.scale.mark = mark
+        self.offset.mark = mark
+
+    def execute(self):
+        if self.direction == Direction.FORWARD:
+            self.v2.value = self.v1.value * self.scale.value + self.offset.value
+        else:
+            self.v1.value = (
+                self.v2.value - self.offset.value) / self.scale.value
+
+    def recalculate(self):
+        ihn = self.input()
+        out = self.output()
+        out.walk_strength = Strength.weakest_of(
+            self.strength, ihn.walk_strength)
+        out.stay = ihn.stay and self.scale.stay and self.offset.stay
+
+        if out.stay:
+            self.execute()
+
+
+class EqualityConstraint(BinaryConstraint):
+
+    def execute(self):
+        self.output().value = self.input().value
+
+
+class Variable(object):
+
+    def __init__(self, name, initial_value=0):
+        super(Variable, self).__init__()
+        self.name = name
+        self.value = initial_value
+        self.constraints = OrderedCollection()
+        self.determined_by = None
+        self.mark = 0
+        self.walk_strength = Strength.WEAKEST
+        self.stay = True
+
+    def __repr__(self):
+        # To make debugging this beast from pdb easier...
+        return '<Variable: %s - %s>' % (
+            self.name,
+            self.value
+        )
+
+    def add_constraint(self, constraint):
+        self.constraints.append(constraint)
+
+    def remove_constraint(self, constraint):
+        self.constraints.remove(constraint)
+
+        if self.determined_by == constraint:
+            self.determined_by = None
+
+
+class Planner(object):
+
+    def __init__(self):
+        super(Planner, self).__init__()
+        self.current_mark = 0
+
+    def incremental_add(self, constraint):
+        mark = self.new_mark()
+        overridden = constraint.satisfy(mark)
+
+        while overridden is not None:
+            overridden = overridden.satisfy(mark)
+
+    def incremental_remove(self, constraint):
+        out = constraint.output()
+        constraint.mark_unsatisfied()
+        constraint.remove_from_graph()
+        unsatisfied = self.remove_propagate_from(out)
+        strength = Strength.REQUIRED
+        # Do-while, the Python way.
+        repeat = True
+
+        while repeat:
+            for u in unsatisfied:
+                if u.strength == strength:
+                    self.incremental_add(u)
+
+                strength = strength.next_weaker()
+
+            repeat = strength != Strength.WEAKEST
+
+    def new_mark(self):
+        self.current_mark += 1
+        return self.current_mark
+
+    def make_plan(self, sources):
+        mark = self.new_mark()
+        plan = Plan()
+        todo = sources
+
+        while len(todo):
+            c = todo.pop(0)
+
+            if c.output().mark != mark and c.inputs_known(mark):
+                plan.add_constraint(c)
+                c.output().mark = mark
+                self.add_constraints_consuming_to(c.output(), todo)
+
+        return plan
+
+    def extract_plan_from_constraints(self, constraints):
+        sources = OrderedCollection()
+
+        for c in constraints:
+            if c.is_input() and c.is_satisfied():
+                sources.append(c)
+
+        return self.make_plan(sources)
+
+    def add_propagate(self, c, mark):
+        todo = OrderedCollection()
+        todo.append(c)
+
+        while len(todo):
+            d = todo.pop(0)
+
+            if d.output().mark == mark:
+                self.incremental_remove(c)
+                return False
+
+            d.recalculate()
+            self.add_constraints_consuming_to(d.output(), todo)
+
+        return True
+
+    def remove_propagate_from(self, out):
+        out.determined_by = None
+        out.walk_strength = Strength.WEAKEST
+        out.stay = True
+        unsatisfied = OrderedCollection()
+        todo = OrderedCollection()
+        todo.append(out)
+
+        while len(todo):
+            v = todo.pop(0)
+
+            for c in v.constraints:
+                if not c.is_satisfied():
+                    unsatisfied.append(c)
+
+            determining = v.determined_by
+
+            for c in v.constraints:
+                if c != determining and c.is_satisfied():
+                    c.recalculate()
+                    todo.append(c.output())
+
+        return unsatisfied
+
+    def add_constraints_consuming_to(self, v, coll):
+        determining = v.determined_by
+        cc = v.constraints
+
+        for c in cc:
+            if c != determining and c.is_satisfied():
+                # I guess we're just updating a reference (``coll``)? Seems
+                # inconsistent with the rest of the implementation, where they
+                # return the lists...
+                coll.append(c)
+
+
+class Plan(object):
+
+    def __init__(self):
+        super(Plan, self).__init__()
+        self.v = OrderedCollection()
+
+    def add_constraint(self, c):
+        self.v.append(c)
+
+    def __len__(self):
+        return len(self.v)
+
+    def __getitem__(self, index):
+        return self.v[index]
+
+    def execute(self):
+        for c in self.v:
+            c.execute()
+
+
+# Main
+
+def chain_test(n):
+    """
+    This is the standard DeltaBlue benchmark. A long chain of equality
+    constraints is constructed with a stay constraint on one end. An
+    edit constraint is then added to the opposite end and the time is
+    measured for adding and removing this constraint, and extracting
+    and executing a constraint satisfaction plan. There are two cases.
+    In case 1, the added constraint is stronger than the stay
+    constraint and values must propagate down the entire length of the
+    chain. In case 2, the added constraint is weaker than the stay
+    constraint so it cannot be accomodated. The cost in this case is,
+    of course, very low. Typical situations lie somewhere between these
+    two extremes.
+    """
+    global planner
+    planner = Planner()
+    prev, first, last = None, None, None
+
+    # We need to go up to n inclusively.
+    for i in range(n + 1):
+        name = "v%s" % i
+        v = Variable(name)
+
+        if prev is not None:
+            EqualityConstraint(prev, v, Strength.REQUIRED)
+
+        if i == 0:
+            first = v
+
+        if i == n:
+            last = v
+
+        prev = v
+
+    StayConstraint(last, Strength.STRONG_DEFAULT)
+    edit = EditConstraint(first, Strength.PREFERRED)
+    edits = OrderedCollection()
+    edits.append(edit)
+    plan = planner.extract_plan_from_constraints(edits)
+
+    for i in range(100):
+        first.value = i
+        plan.execute()
+
+        if last.value != i:
+            print("Chain test failed.")
+
+
+def projection_test(n):
+    """
+    This test constructs a two sets of variables related to each
+    other by a simple linear transformation (scale and offset). The
+    time is measured to change a variable on either side of the
+    mapping and to change the scale and offset factors.
+    """
+    global planner
+    planner = Planner()
+    scale = Variable("scale", 10)
+    offset = Variable("offset", 1000)
+    src = None
+
+    dests = OrderedCollection()
+
+    for i in range(n):
+        src = Variable("src%s" % i, i)
+        dst = Variable("dst%s" % i, i)
+        dests.append(dst)
+        StayConstraint(src, Strength.NORMAL)
+        ScaleConstraint(src, scale, offset, dst, Strength.REQUIRED)
+
+    change(src, 17)
+
+    if dst.value != 1170:
+        print("Projection 1 failed")
+
+    change(dst, 1050)
+
+    if src.value != 5:
+        print("Projection 2 failed")
+
+    change(scale, 5)
+
+    for i in range(n - 1):
+        if dests[i].value != (i * 5 + 1000):
+            print("Projection 3 failed")
+
+    change(offset, 2000)
+
+    for i in range(n - 1):
+        if dests[i].value != (i * 5 + 2000):
+            print("Projection 4 failed")
+
+
+def change(v, new_value):
+    global planner
+    edit = EditConstraint(v, Strength.PREFERRED)
+    edits = OrderedCollection()
+    edits.append(edit)
+
+    plan = planner.extract_plan_from_constraints(edits)
+
+    for i in range(10):
+        v.value = new_value
+        plan.execute()
+
+    edit.destroy_constraint()
+
+
+# HOORAY FOR GLOBALS... Oh wait.
+# In spirit of the original, we'll keep it, but ugh.
+planner = None
+
+
+def delta_blue(n):
+    chain_test(n)
+    projection_test(n)
+
+
+if __name__ == "__main__":
+    runner = pyperf.Runner()
+    runner.metadata['description'] = "DeltaBlue benchmark"
+
+    # RUSTPYTHON perf_ci: allow shrinking the workload via env (upstream default: 100)
+    import os
+    n = int(os.environ.get("PERF_CI_DELTABLUE_N", "100"))
+    runner.bench_func('deltablue', delta_blue, n)

--- a/benches/perf_ci/pyperformance/bm_fannkuch.py
+++ b/benches/perf_ci/pyperformance/bm_fannkuch.py
@@ -1,0 +1,56 @@
+"""
+The Computer Language Benchmarks Game
+http://benchmarksgame.alioth.debian.org/
+
+Contributed by Sokolov Yura, modified by Tupteq.
+"""
+
+import pyperf
+
+
+DEFAULT_ARG = 9
+
+
+def fannkuch(n):
+    count = list(range(1, n + 1))
+    max_flips = 0
+    m = n - 1
+    r = n
+    perm1 = list(range(n))
+    perm = list(range(n))
+    perm1_ins = perm1.insert
+    perm1_pop = perm1.pop
+
+    while 1:
+        while r != 1:
+            count[r - 1] = r
+            r -= 1
+
+        if perm1[0] != 0 and perm1[m] != m:
+            perm = perm1[:]
+            flips_count = 0
+            k = perm[0]
+            while k:
+                perm[:k + 1] = perm[k::-1]
+                flips_count += 1
+                k = perm[0]
+
+            if flips_count > max_flips:
+                max_flips = flips_count
+
+        while r != n:
+            perm1_ins(r, perm1_pop(0))
+            count[r] -= 1
+            if count[r] > 0:
+                break
+            r += 1
+        else:
+            return max_flips
+
+
+if __name__ == "__main__":
+    runner = pyperf.Runner()
+    # RUSTPYTHON perf_ci: allow shrinking the workload via env (upstream default: 9)
+    import os
+    arg = int(os.environ.get("PERF_CI_FANNKUCH_ARG", str(DEFAULT_ARG)))
+    runner.bench_func('fannkuch', fannkuch, arg)

--- a/benches/perf_ci/pyperformance/bm_float.py
+++ b/benches/perf_ci/pyperformance/bm_float.py
@@ -1,0 +1,62 @@
+"""
+Artificial, floating point-heavy benchmark originally used by Factor.
+"""
+import pyperf
+
+from math import sin, cos, sqrt
+
+
+POINTS = 100000
+
+
+class Point(object):
+    __slots__ = ('x', 'y', 'z')
+
+    def __init__(self, i):
+        self.x = x = sin(i)
+        self.y = cos(i) * 3
+        self.z = (x * x) / 2
+
+    def __repr__(self):
+        return "<Point: x=%s, y=%s, z=%s>" % (self.x, self.y, self.z)
+
+    def normalize(self):
+        x = self.x
+        y = self.y
+        z = self.z
+        norm = sqrt(x * x + y * y + z * z)
+        self.x /= norm
+        self.y /= norm
+        self.z /= norm
+
+    def maximize(self, other):
+        self.x = self.x if self.x > other.x else other.x
+        self.y = self.y if self.y > other.y else other.y
+        self.z = self.z if self.z > other.z else other.z
+        return self
+
+
+def maximize(points):
+    next = points[0]
+    for p in points[1:]:
+        next = next.maximize(p)
+    return next
+
+
+def benchmark(n):
+    points = [None] * n
+    for i in range(n):
+        points[i] = Point(i)
+    for p in points:
+        p.normalize()
+    return maximize(points)
+
+
+if __name__ == "__main__":
+    runner = pyperf.Runner()
+    runner.metadata['description'] = "Float benchmark"
+
+    # RUSTPYTHON perf_ci: allow shrinking the workload via env (upstream default: 100000)
+    import os
+    points = int(os.environ.get("PERF_CI_FLOAT_POINTS", str(POINTS)))
+    runner.bench_func('float', benchmark, points)

--- a/benches/perf_ci/pyperformance/bm_nbody.py
+++ b/benches/perf_ci/pyperformance/bm_nbody.py
@@ -1,0 +1,156 @@
+"""
+N-body benchmark from the Computer Language Benchmarks Game.
+
+This is intended to support Unladen Swallow's pyperf.py. Accordingly, it has been
+modified from the Shootout version:
+- Accept standard Unladen Swallow benchmark options.
+- Run report_energy()/advance() in a loop.
+- Reimplement itertools.combinations() to work with older Python versions.
+
+Pulled from:
+http://benchmarksgame.alioth.debian.org/u64q/program.php?test=nbody&lang=python3&id=1
+
+Contributed by Kevin Carson.
+Modified by Tupteq, Fredrik Johansson, and Daniel Nanz.
+"""
+
+import pyperf
+
+__contact__ = "collinwinter@google.com (Collin Winter)"
+DEFAULT_ITERATIONS = 20000
+DEFAULT_REFERENCE = 'sun'
+
+
+def combinations(l):
+    """Pure-Python implementation of itertools.combinations(l, 2)."""
+    result = []
+    for x in range(len(l) - 1):
+        ls = l[x + 1:]
+        for y in ls:
+            result.append((l[x], y))
+    return result
+
+
+PI = 3.14159265358979323
+SOLAR_MASS = 4 * PI * PI
+DAYS_PER_YEAR = 365.24
+
+BODIES = {
+    'sun': ([0.0, 0.0, 0.0], [0.0, 0.0, 0.0], SOLAR_MASS),
+
+    'jupiter': ([4.84143144246472090e+00,
+                 -1.16032004402742839e+00,
+                 -1.03622044471123109e-01],
+                [1.66007664274403694e-03 * DAYS_PER_YEAR,
+                 7.69901118419740425e-03 * DAYS_PER_YEAR,
+                 -6.90460016972063023e-05 * DAYS_PER_YEAR],
+                9.54791938424326609e-04 * SOLAR_MASS),
+
+    'saturn': ([8.34336671824457987e+00,
+                4.12479856412430479e+00,
+                -4.03523417114321381e-01],
+               [-2.76742510726862411e-03 * DAYS_PER_YEAR,
+                4.99852801234917238e-03 * DAYS_PER_YEAR,
+                2.30417297573763929e-05 * DAYS_PER_YEAR],
+               2.85885980666130812e-04 * SOLAR_MASS),
+
+    'uranus': ([1.28943695621391310e+01,
+                -1.51111514016986312e+01,
+                -2.23307578892655734e-01],
+               [2.96460137564761618e-03 * DAYS_PER_YEAR,
+                2.37847173959480950e-03 * DAYS_PER_YEAR,
+                -2.96589568540237556e-05 * DAYS_PER_YEAR],
+               4.36624404335156298e-05 * SOLAR_MASS),
+
+    'neptune': ([1.53796971148509165e+01,
+                 -2.59193146099879641e+01,
+                 1.79258772950371181e-01],
+                [2.68067772490389322e-03 * DAYS_PER_YEAR,
+                 1.62824170038242295e-03 * DAYS_PER_YEAR,
+                 -9.51592254519715870e-05 * DAYS_PER_YEAR],
+                5.15138902046611451e-05 * SOLAR_MASS)}
+
+
+SYSTEM = list(BODIES.values())
+PAIRS = combinations(SYSTEM)
+
+
+def advance(dt, n, bodies=SYSTEM, pairs=PAIRS):
+    for i in range(n):
+        for (([x1, y1, z1], v1, m1),
+             ([x2, y2, z2], v2, m2)) in pairs:
+            dx = x1 - x2
+            dy = y1 - y2
+            dz = z1 - z2
+            mag = dt * ((dx * dx + dy * dy + dz * dz) ** (-1.5))
+            b1m = m1 * mag
+            b2m = m2 * mag
+            v1[0] -= dx * b2m
+            v1[1] -= dy * b2m
+            v1[2] -= dz * b2m
+            v2[0] += dx * b1m
+            v2[1] += dy * b1m
+            v2[2] += dz * b1m
+        for (r, [vx, vy, vz], m) in bodies:
+            r[0] += dt * vx
+            r[1] += dt * vy
+            r[2] += dt * vz
+
+
+def report_energy(bodies=SYSTEM, pairs=PAIRS, e=0.0):
+    for (((x1, y1, z1), v1, m1),
+         ((x2, y2, z2), v2, m2)) in pairs:
+        dx = x1 - x2
+        dy = y1 - y2
+        dz = z1 - z2
+        e -= (m1 * m2) / ((dx * dx + dy * dy + dz * dz) ** 0.5)
+    for (r, [vx, vy, vz], m) in bodies:
+        e += m * (vx * vx + vy * vy + vz * vz) / 2.
+    return e
+
+
+def offset_momentum(ref, bodies=SYSTEM, px=0.0, py=0.0, pz=0.0):
+    for (r, [vx, vy, vz], m) in bodies:
+        px -= vx * m
+        py -= vy * m
+        pz -= vz * m
+    (r, v, m) = ref
+    v[0] = px / m
+    v[1] = py / m
+    v[2] = pz / m
+
+
+def bench_nbody(loops, reference, iterations):
+    # Set up global state
+    offset_momentum(BODIES[reference])
+
+    range_it = range(loops)
+    t0 = pyperf.perf_counter()
+
+    for _ in range_it:
+        report_energy()
+        advance(0.01, iterations)
+        report_energy()
+
+    return pyperf.perf_counter() - t0
+
+
+def add_cmdline_args(cmd, args):
+    cmd.extend(("--iterations", str(args.iterations)))
+
+
+if __name__ == '__main__':
+    runner = pyperf.Runner(add_cmdline_args=add_cmdline_args)
+    runner.metadata['description'] = "n-body benchmark"
+    runner.argparser.add_argument("--iterations",
+                                  type=int, default=DEFAULT_ITERATIONS,
+                                  help="Number of nbody advance() iterations "
+                                       "(default: %s)" % DEFAULT_ITERATIONS)
+    runner.argparser.add_argument("--reference",
+                                  type=str, default=DEFAULT_REFERENCE,
+                                  help="nbody reference (default: %s)"
+                                       % DEFAULT_REFERENCE)
+
+    args = runner.parse_args()
+    runner.bench_time_func('nbody', bench_nbody,
+                           args.reference, args.iterations)

--- a/benches/perf_ci/pyperformance/bm_nqueens.py
+++ b/benches/perf_ci/pyperformance/bm_nqueens.py
@@ -1,0 +1,64 @@
+"""Simple, brute-force N-Queens solver."""
+
+import pyperf
+
+__author__ = "collinwinter@google.com (Collin Winter)"
+
+
+# Pure-Python implementation of itertools.permutations().
+def permutations(iterable, r=None):
+    """permutations(range(3), 2) --> (0,1) (0,2) (1,0) (1,2) (2,0) (2,1)"""
+    pool = tuple(iterable)
+    n = len(pool)
+    if r is None:
+        r = n
+    indices = list(range(n))
+    cycles = list(range(n - r + 1, n + 1))[::-1]
+    yield tuple(pool[i] for i in indices[:r])
+    while n:
+        for i in reversed(range(r)):
+            cycles[i] -= 1
+            if cycles[i] == 0:
+                indices[i:] = indices[i + 1:] + indices[i:i + 1]
+                cycles[i] = n - i
+            else:
+                j = cycles[i]
+                indices[i], indices[-j] = indices[-j], indices[i]
+                yield tuple(pool[i] for i in indices[:r])
+                break
+        else:
+            return
+
+
+# From http://code.activestate.com/recipes/576647/
+def n_queens(queen_count):
+    """N-Queens solver.
+
+    Args:
+        queen_count: the number of queens to solve for. This is also the
+            board size.
+
+    Yields:
+        Solutions to the problem. Each yielded value is looks like
+        (3, 8, 2, 1, 4, ..., 6) where each number is the column position for the
+        queen, and the index into the tuple indicates the row.
+    """
+    cols = range(queen_count)
+    for vec in permutations(cols):
+        if (queen_count == len(set(vec[i] + i for i in cols))
+                        == len(set(vec[i] - i for i in cols))):
+            yield vec
+
+
+def bench_n_queens(queen_count):
+    list(n_queens(queen_count))
+
+
+if __name__ == "__main__":
+    runner = pyperf.Runner()
+    runner.metadata['description'] = "Simple, brute-force N-Queens solver"
+
+    # RUSTPYTHON perf_ci: allow shrinking the workload via env (upstream default: 8)
+    import os
+    queen_count = int(os.environ.get("PERF_CI_NQUEENS_COUNT", "8"))
+    runner.bench_func('nqueens', bench_n_queens, queen_count)

--- a/benches/perf_ci/pyperformance/bm_raytrace.py
+++ b/benches/perf_ci/pyperformance/bm_raytrace.py
@@ -1,0 +1,409 @@
+"""
+This file contains definitions for a simple raytracer.
+Copyright Callum and Tony Garnock-Jones, 2008.
+
+This file may be freely redistributed under the MIT license,
+http://www.opensource.org/licenses/mit-license.php
+
+From http://www.lshift.net/blog/2008/10/29/toy-raytracer-in-python
+"""
+
+import array
+import math
+
+import pyperf
+
+
+DEFAULT_WIDTH = 100
+DEFAULT_HEIGHT = 100
+EPSILON = 0.00001
+
+
+class Vector(object):
+
+    def __init__(self, initx, inity, initz):
+        self.x = initx
+        self.y = inity
+        self.z = initz
+
+    def __str__(self):
+        return '(%s,%s,%s)' % (self.x, self.y, self.z)
+
+    def __repr__(self):
+        return 'Vector(%s,%s,%s)' % (self.x, self.y, self.z)
+
+    def magnitude(self):
+        return math.sqrt(self.dot(self))
+
+    def __add__(self, other):
+        if other.isPoint():
+            return Point(self.x + other.x, self.y + other.y, self.z + other.z)
+        else:
+            return Vector(self.x + other.x, self.y + other.y, self.z + other.z)
+
+    def __sub__(self, other):
+        other.mustBeVector()
+        return Vector(self.x - other.x, self.y - other.y, self.z - other.z)
+
+    def scale(self, factor):
+        return Vector(factor * self.x, factor * self.y, factor * self.z)
+
+    def dot(self, other):
+        other.mustBeVector()
+        return (self.x * other.x) + (self.y * other.y) + (self.z * other.z)
+
+    def cross(self, other):
+        other.mustBeVector()
+        return Vector(self.y * other.z - self.z * other.y,
+                      self.z * other.x - self.x * other.z,
+                      self.x * other.y - self.y * other.x)
+
+    def normalized(self):
+        return self.scale(1.0 / self.magnitude())
+
+    def negated(self):
+        return self.scale(-1)
+
+    def __eq__(self, other):
+        return (self.x == other.x) and (self.y == other.y) and (self.z == other.z)
+
+    def isVector(self):
+        return True
+
+    def isPoint(self):
+        return False
+
+    def mustBeVector(self):
+        return self
+
+    def mustBePoint(self):
+        raise 'Vectors are not points!'
+
+    def reflectThrough(self, normal):
+        d = normal.scale(self.dot(normal))
+        return self - d.scale(2)
+
+
+Vector.ZERO = Vector(0, 0, 0)
+Vector.RIGHT = Vector(1, 0, 0)
+Vector.UP = Vector(0, 1, 0)
+Vector.OUT = Vector(0, 0, 1)
+
+assert Vector.RIGHT.reflectThrough(Vector.UP) == Vector.RIGHT
+assert Vector(-1, -1, 0).reflectThrough(Vector.UP) == Vector(-1, 1, 0)
+
+
+class Point(object):
+
+    def __init__(self, initx, inity, initz):
+        self.x = initx
+        self.y = inity
+        self.z = initz
+
+    def __str__(self):
+        return '(%s,%s,%s)' % (self.x, self.y, self.z)
+
+    def __repr__(self):
+        return 'Point(%s,%s,%s)' % (self.x, self.y, self.z)
+
+    def __add__(self, other):
+        other.mustBeVector()
+        return Point(self.x + other.x, self.y + other.y, self.z + other.z)
+
+    def __sub__(self, other):
+        if other.isPoint():
+            return Vector(self.x - other.x, self.y - other.y, self.z - other.z)
+        else:
+            return Point(self.x - other.x, self.y - other.y, self.z - other.z)
+
+    def isVector(self):
+        return False
+
+    def isPoint(self):
+        return True
+
+    def mustBeVector(self):
+        raise 'Points are not vectors!'
+
+    def mustBePoint(self):
+        return self
+
+
+class Sphere(object):
+
+    def __init__(self, centre, radius):
+        centre.mustBePoint()
+        self.centre = centre
+        self.radius = radius
+
+    def __repr__(self):
+        return 'Sphere(%s,%s)' % (repr(self.centre), self.radius)
+
+    def intersectionTime(self, ray):
+        cp = self.centre - ray.point
+        v = cp.dot(ray.vector)
+        discriminant = (self.radius * self.radius) - (cp.dot(cp) - v * v)
+        if discriminant < 0:
+            return None
+        else:
+            return v - math.sqrt(discriminant)
+
+    def normalAt(self, p):
+        return (p - self.centre).normalized()
+
+
+class Halfspace(object):
+
+    def __init__(self, point, normal):
+        self.point = point
+        self.normal = normal.normalized()
+
+    def __repr__(self):
+        return 'Halfspace(%s,%s)' % (repr(self.point), repr(self.normal))
+
+    def intersectionTime(self, ray):
+        v = ray.vector.dot(self.normal)
+        if v:
+            return 1 / -v
+        else:
+            return None
+
+    def normalAt(self, p):
+        return self.normal
+
+
+class Ray(object):
+
+    def __init__(self, point, vector):
+        self.point = point
+        self.vector = vector.normalized()
+
+    def __repr__(self):
+        return 'Ray(%s,%s)' % (repr(self.point), repr(self.vector))
+
+    def pointAtTime(self, t):
+        return self.point + self.vector.scale(t)
+
+
+Point.ZERO = Point(0, 0, 0)
+
+
+class Canvas(object):
+
+    def __init__(self, width, height):
+        self.bytes = array.array('B', [0] * (width * height * 3))
+        for i in range(width * height):
+            self.bytes[i * 3 + 2] = 255
+        self.width = width
+        self.height = height
+
+    def plot(self, x, y, r, g, b):
+        i = ((self.height - y - 1) * self.width + x) * 3
+        self.bytes[i] = max(0, min(255, int(r * 255)))
+        self.bytes[i + 1] = max(0, min(255, int(g * 255)))
+        self.bytes[i + 2] = max(0, min(255, int(b * 255)))
+
+    def write_ppm(self, filename):
+        header = 'P6 %d %d 255\n' % (self.width, self.height)
+        with open(filename, "wb") as fp:
+            fp.write(header.encode('ascii'))
+            fp.write(self.bytes.tobytes())
+
+
+def firstIntersection(intersections):
+    result = None
+    for i in intersections:
+        candidateT = i[1]
+        if candidateT is not None and candidateT > -EPSILON:
+            if result is None or candidateT < result[1]:
+                result = i
+    return result
+
+
+class Scene(object):
+
+    def __init__(self):
+        self.objects = []
+        self.lightPoints = []
+        self.position = Point(0, 1.8, 10)
+        self.lookingAt = Point.ZERO
+        self.fieldOfView = 45
+        self.recursionDepth = 0
+
+    def moveTo(self, p):
+        self.position = p
+
+    def lookAt(self, p):
+        self.lookingAt = p
+
+    def addObject(self, object, surface):
+        self.objects.append((object, surface))
+
+    def addLight(self, p):
+        self.lightPoints.append(p)
+
+    def render(self, canvas):
+        fovRadians = math.pi * (self.fieldOfView / 2.0) / 180.0
+        halfWidth = math.tan(fovRadians)
+        halfHeight = 0.75 * halfWidth
+        width = halfWidth * 2
+        height = halfHeight * 2
+        pixelWidth = width / (canvas.width - 1)
+        pixelHeight = height / (canvas.height - 1)
+
+        eye = Ray(self.position, self.lookingAt - self.position)
+        vpRight = eye.vector.cross(Vector.UP).normalized()
+        vpUp = vpRight.cross(eye.vector).normalized()
+
+        for y in range(canvas.height):
+            for x in range(canvas.width):
+                xcomp = vpRight.scale(x * pixelWidth - halfWidth)
+                ycomp = vpUp.scale(y * pixelHeight - halfHeight)
+                ray = Ray(eye.point, eye.vector + xcomp + ycomp)
+                colour = self.rayColour(ray)
+                canvas.plot(x, y, *colour)
+
+    def rayColour(self, ray):
+        if self.recursionDepth > 3:
+            return (0, 0, 0)
+        try:
+            self.recursionDepth = self.recursionDepth + 1
+            intersections = [(o, o.intersectionTime(ray), s)
+                             for (o, s) in self.objects]
+            i = firstIntersection(intersections)
+            if i is None:
+                return (0, 0, 0)  # the background colour
+            else:
+                (o, t, s) = i
+                p = ray.pointAtTime(t)
+                return s.colourAt(self, ray, p, o.normalAt(p))
+        finally:
+            self.recursionDepth = self.recursionDepth - 1
+
+    def _lightIsVisible(self, l, p):
+        for (o, s) in self.objects:
+            t = o.intersectionTime(Ray(p, l - p))
+            if t is not None and t > EPSILON:
+                return False
+        return True
+
+    def visibleLights(self, p):
+        result = []
+        for l in self.lightPoints:
+            if self._lightIsVisible(l, p):
+                result.append(l)
+        return result
+
+
+def addColours(a, scale, b):
+    return (a[0] + scale * b[0],
+            a[1] + scale * b[1],
+            a[2] + scale * b[2])
+
+
+class SimpleSurface(object):
+
+    def __init__(self, **kwargs):
+        self.baseColour = kwargs.get('baseColour', (1, 1, 1))
+        self.specularCoefficient = kwargs.get('specularCoefficient', 0.2)
+        self.lambertCoefficient = kwargs.get('lambertCoefficient', 0.6)
+        self.ambientCoefficient = 1.0 - self.specularCoefficient - self.lambertCoefficient
+
+    def baseColourAt(self, p):
+        return self.baseColour
+
+    def colourAt(self, scene, ray, p, normal):
+        b = self.baseColourAt(p)
+
+        c = (0, 0, 0)
+        if self.specularCoefficient > 0:
+            reflectedRay = Ray(p, ray.vector.reflectThrough(normal))
+            reflectedColour = scene.rayColour(reflectedRay)
+            c = addColours(c, self.specularCoefficient, reflectedColour)
+
+        if self.lambertCoefficient > 0:
+            lambertAmount = 0
+            for lightPoint in scene.visibleLights(p):
+                contribution = (lightPoint - p).normalized().dot(normal)
+                if contribution > 0:
+                    lambertAmount = lambertAmount + contribution
+            lambertAmount = min(1, lambertAmount)
+            c = addColours(c, self.lambertCoefficient * lambertAmount, b)
+
+        if self.ambientCoefficient > 0:
+            c = addColours(c, self.ambientCoefficient, b)
+
+        return c
+
+
+class CheckerboardSurface(SimpleSurface):
+
+    def __init__(self, **kwargs):
+        SimpleSurface.__init__(self, **kwargs)
+        self.otherColour = kwargs.get('otherColour', (0, 0, 0))
+        self.checkSize = kwargs.get('checkSize', 1)
+
+    def baseColourAt(self, p):
+        v = p - Point.ZERO
+        v.scale(1.0 / self.checkSize)
+        if ((int(abs(v.x) + 0.5)
+             + int(abs(v.y) + 0.5)
+             + int(abs(v.z) + 0.5)) % 2):
+            return self.otherColour
+        else:
+            return self.baseColour
+
+
+def bench_raytrace(loops, width, height, filename):
+    range_it = range(loops)
+    t0 = pyperf.perf_counter()
+
+    for i in range_it:
+        canvas = Canvas(width, height)
+        s = Scene()
+        s.addLight(Point(30, 30, 10))
+        s.addLight(Point(-10, 100, 30))
+        s.lookAt(Point(0, 3, 0))
+        s.addObject(Sphere(Point(1, 3, -10), 2),
+                    SimpleSurface(baseColour=(1, 1, 0)))
+        for y in range(6):
+            s.addObject(Sphere(Point(-3 - y * 0.4, 2.3, -5), 0.4),
+                        SimpleSurface(baseColour=(y / 6.0, 1 - y / 6.0, 0.5)))
+        s.addObject(Halfspace(Point(0, 0, 0), Vector.UP),
+                    CheckerboardSurface())
+        s.render(canvas)
+
+    dt = pyperf.perf_counter() - t0
+
+    if filename:
+        canvas.write_ppm(filename)
+    return dt
+
+
+def add_cmdline_args(cmd, args):
+    cmd.append("--width=%s" % args.width)
+    cmd.append("--height=%s" % args.height)
+    if args.filename:
+        cmd.extend(("--filename", args.filename))
+
+
+if __name__ == "__main__":
+    runner = pyperf.Runner(add_cmdline_args=add_cmdline_args)
+    cmd = runner.argparser
+    cmd.add_argument("--width",
+                     type=int, default=DEFAULT_WIDTH,
+                     help="Image width (default: %s)" % DEFAULT_WIDTH)
+    cmd.add_argument("--height",
+                     type=int, default=DEFAULT_HEIGHT,
+                     help="Image height (default: %s)" % DEFAULT_HEIGHT)
+    cmd.add_argument("--filename", metavar="FILENAME.PPM",
+                     help="Output filename of the PPM picture")
+
+    args = runner.parse_args()
+    runner.metadata['description'] = "Simple raytracer"
+    runner.metadata['raytrace_width'] = args.width
+    runner.metadata['raytrace_height'] = args.height
+
+    runner.bench_time_func('raytrace', bench_raytrace,
+                           args.width, args.height,
+                           args.filename)

--- a/benches/perf_ci/pyperformance/bm_richards.py
+++ b/benches/perf_ci/pyperformance/bm_richards.py
@@ -1,0 +1,423 @@
+"""
+based on a Java version:
+ Based on original version written in BCPL by Dr Martin Richards
+ in 1981 at Cambridge University Computer Laboratory, England
+ and a C++ version derived from a Smalltalk version written by
+ L Peter Deutsch.
+ Java version:  Copyright (C) 1995 Sun Microsystems, Inc.
+ Translation from C++, Mario Wolczko
+ Outer loop added by Alex Jacoby
+"""
+
+import pyperf
+
+
+# Task IDs
+I_IDLE = 1
+I_WORK = 2
+I_HANDLERA = 3
+I_HANDLERB = 4
+I_DEVA = 5
+I_DEVB = 6
+
+# Packet types
+K_DEV = 1000
+K_WORK = 1001
+
+# Packet
+
+BUFSIZE = 4
+
+BUFSIZE_RANGE = range(BUFSIZE)
+
+
+class Packet(object):
+
+    def __init__(self, l, i, k):
+        self.link = l
+        self.ident = i
+        self.kind = k
+        self.datum = 0
+        self.data = [0] * BUFSIZE
+
+    def append_to(self, lst):
+        self.link = None
+        if lst is None:
+            return self
+        else:
+            p = lst
+            next = p.link
+            while next is not None:
+                p = next
+                next = p.link
+            p.link = self
+            return lst
+
+# Task Records
+
+
+class TaskRec(object):
+    pass
+
+
+class DeviceTaskRec(TaskRec):
+
+    def __init__(self):
+        self.pending = None
+
+
+class IdleTaskRec(TaskRec):
+
+    def __init__(self):
+        self.control = 1
+        self.count = 10000
+
+
+class HandlerTaskRec(TaskRec):
+
+    def __init__(self):
+        self.work_in = None
+        self.device_in = None
+
+    def workInAdd(self, p):
+        self.work_in = p.append_to(self.work_in)
+        return self.work_in
+
+    def deviceInAdd(self, p):
+        self.device_in = p.append_to(self.device_in)
+        return self.device_in
+
+
+class WorkerTaskRec(TaskRec):
+
+    def __init__(self):
+        self.destination = I_HANDLERA
+        self.count = 0
+# Task
+
+
+class TaskState(object):
+
+    def __init__(self):
+        self.packet_pending = True
+        self.task_waiting = False
+        self.task_holding = False
+
+    def packetPending(self):
+        self.packet_pending = True
+        self.task_waiting = False
+        self.task_holding = False
+        return self
+
+    def waiting(self):
+        self.packet_pending = False
+        self.task_waiting = True
+        self.task_holding = False
+        return self
+
+    def running(self):
+        self.packet_pending = False
+        self.task_waiting = False
+        self.task_holding = False
+        return self
+
+    def waitingWithPacket(self):
+        self.packet_pending = True
+        self.task_waiting = True
+        self.task_holding = False
+        return self
+
+    def isPacketPending(self):
+        return self.packet_pending
+
+    def isTaskWaiting(self):
+        return self.task_waiting
+
+    def isTaskHolding(self):
+        return self.task_holding
+
+    def isTaskHoldingOrWaiting(self):
+        return self.task_holding or (not self.packet_pending and self.task_waiting)
+
+    def isWaitingWithPacket(self):
+        return self.packet_pending and self.task_waiting and not self.task_holding
+
+
+tracing = False
+layout = 0
+
+
+def trace(a):
+    global layout
+    layout -= 1
+    if layout <= 0:
+        print()
+        layout = 50
+    print(a, end='')
+
+
+TASKTABSIZE = 10
+
+
+class TaskWorkArea(object):
+
+    def __init__(self):
+        self.taskTab = [None] * TASKTABSIZE
+
+        self.taskList = None
+
+        self.holdCount = 0
+        self.qpktCount = 0
+
+
+taskWorkArea = TaskWorkArea()
+
+
+class Task(TaskState):
+
+    def __init__(self, i, p, w, initialState, r):
+        self.link = taskWorkArea.taskList
+        self.ident = i
+        self.priority = p
+        self.input = w
+
+        self.packet_pending = initialState.isPacketPending()
+        self.task_waiting = initialState.isTaskWaiting()
+        self.task_holding = initialState.isTaskHolding()
+
+        self.handle = r
+
+        taskWorkArea.taskList = self
+        taskWorkArea.taskTab[i] = self
+
+    def fn(self, pkt, r):
+        raise NotImplementedError
+
+    def addPacket(self, p, old):
+        if self.input is None:
+            self.input = p
+            self.packet_pending = True
+            if self.priority > old.priority:
+                return self
+        else:
+            p.append_to(self.input)
+        return old
+
+    def runTask(self):
+        if self.isWaitingWithPacket():
+            msg = self.input
+            self.input = msg.link
+            if self.input is None:
+                self.running()
+            else:
+                self.packetPending()
+        else:
+            msg = None
+
+        return self.fn(msg, self.handle)
+
+    def waitTask(self):
+        self.task_waiting = True
+        return self
+
+    def hold(self):
+        taskWorkArea.holdCount += 1
+        self.task_holding = True
+        return self.link
+
+    def release(self, i):
+        t = self.findtcb(i)
+        t.task_holding = False
+        if t.priority > self.priority:
+            return t
+        else:
+            return self
+
+    def qpkt(self, pkt):
+        t = self.findtcb(pkt.ident)
+        taskWorkArea.qpktCount += 1
+        pkt.link = None
+        pkt.ident = self.ident
+        return t.addPacket(pkt, self)
+
+    def findtcb(self, id):
+        t = taskWorkArea.taskTab[id]
+        if t is None:
+            raise Exception("Bad task id %d" % id)
+        return t
+
+
+# DeviceTask
+
+
+class DeviceTask(Task):
+
+    def __init__(self, i, p, w, s, r):
+        Task.__init__(self, i, p, w, s, r)
+
+    def fn(self, pkt, r):
+        d = r
+        assert isinstance(d, DeviceTaskRec)
+        if pkt is None:
+            pkt = d.pending
+            if pkt is None:
+                return self.waitTask()
+            else:
+                d.pending = None
+                return self.qpkt(pkt)
+        else:
+            d.pending = pkt
+            if tracing:
+                trace(pkt.datum)
+            return self.hold()
+
+
+class HandlerTask(Task):
+
+    def __init__(self, i, p, w, s, r):
+        Task.__init__(self, i, p, w, s, r)
+
+    def fn(self, pkt, r):
+        h = r
+        assert isinstance(h, HandlerTaskRec)
+        if pkt is not None:
+            if pkt.kind == K_WORK:
+                h.workInAdd(pkt)
+            else:
+                h.deviceInAdd(pkt)
+        work = h.work_in
+        if work is None:
+            return self.waitTask()
+        count = work.datum
+        if count >= BUFSIZE:
+            h.work_in = work.link
+            return self.qpkt(work)
+
+        dev = h.device_in
+        if dev is None:
+            return self.waitTask()
+
+        h.device_in = dev.link
+        dev.datum = work.data[count]
+        work.datum = count + 1
+        return self.qpkt(dev)
+
+# IdleTask
+
+
+class IdleTask(Task):
+
+    def __init__(self, i, p, w, s, r):
+        Task.__init__(self, i, 0, None, s, r)
+
+    def fn(self, pkt, r):
+        i = r
+        assert isinstance(i, IdleTaskRec)
+        i.count -= 1
+        if i.count == 0:
+            return self.hold()
+        elif i.control & 1 == 0:
+            i.control //= 2
+            return self.release(I_DEVA)
+        else:
+            i.control = i.control // 2 ^ 0xd008
+            return self.release(I_DEVB)
+
+
+# WorkTask
+
+
+A = ord('A')
+
+
+class WorkTask(Task):
+
+    def __init__(self, i, p, w, s, r):
+        Task.__init__(self, i, p, w, s, r)
+
+    def fn(self, pkt, r):
+        w = r
+        assert isinstance(w, WorkerTaskRec)
+        if pkt is None:
+            return self.waitTask()
+
+        if w.destination == I_HANDLERA:
+            dest = I_HANDLERB
+        else:
+            dest = I_HANDLERA
+
+        w.destination = dest
+        pkt.ident = dest
+        pkt.datum = 0
+
+        for i in BUFSIZE_RANGE:  # range(BUFSIZE)
+            w.count += 1
+            if w.count > 26:
+                w.count = 1
+            pkt.data[i] = A + w.count - 1
+
+        return self.qpkt(pkt)
+
+
+def schedule():
+    t = taskWorkArea.taskList
+    while t is not None:
+        if tracing:
+            print("tcb =", t.ident)
+
+        if t.isTaskHoldingOrWaiting():
+            t = t.link
+        else:
+            if tracing:
+                trace(chr(ord("0") + t.ident))
+            t = t.runTask()
+
+
+class Richards(object):
+
+    def run(self, iterations):
+        for i in range(iterations):
+            taskWorkArea.holdCount = 0
+            taskWorkArea.qpktCount = 0
+
+            IdleTask(I_IDLE, 1, 10000, TaskState().running(), IdleTaskRec())
+
+            wkq = Packet(None, 0, K_WORK)
+            wkq = Packet(wkq, 0, K_WORK)
+            WorkTask(I_WORK, 1000, wkq, TaskState(
+            ).waitingWithPacket(), WorkerTaskRec())
+
+            wkq = Packet(None, I_DEVA, K_DEV)
+            wkq = Packet(wkq, I_DEVA, K_DEV)
+            wkq = Packet(wkq, I_DEVA, K_DEV)
+            HandlerTask(I_HANDLERA, 2000, wkq, TaskState(
+            ).waitingWithPacket(), HandlerTaskRec())
+
+            wkq = Packet(None, I_DEVB, K_DEV)
+            wkq = Packet(wkq, I_DEVB, K_DEV)
+            wkq = Packet(wkq, I_DEVB, K_DEV)
+            HandlerTask(I_HANDLERB, 3000, wkq, TaskState(
+            ).waitingWithPacket(), HandlerTaskRec())
+
+            wkq = None
+            DeviceTask(I_DEVA, 4000, wkq,
+                       TaskState().waiting(), DeviceTaskRec())
+            DeviceTask(I_DEVB, 5000, wkq,
+                       TaskState().waiting(), DeviceTaskRec())
+
+            schedule()
+
+            if taskWorkArea.holdCount == 9297 and taskWorkArea.qpktCount == 23246:
+                pass
+            else:
+                return False
+
+        return True
+
+
+if __name__ == "__main__":
+    runner = pyperf.Runner()
+    runner.metadata['description'] = "The Richards benchmark"
+
+    richard = Richards()
+    runner.bench_func('richards', richard.run, 1)

--- a/benches/perf_ci/pyperformance/bm_scimark.py
+++ b/benches/perf_ci/pyperformance/bm_scimark.py
@@ -1,0 +1,421 @@
+from array import array
+import math
+
+import pyperf
+
+
+class Array2D(object):
+
+    def __init__(self, w, h, data=None):
+        self.width = w
+        self.height = h
+        self.data = array('d', [0]) * (w * h)
+        if data is not None:
+            self.setup(data)
+
+    def _idx(self, x, y):
+        if 0 <= x < self.width and 0 <= y < self.height:
+            return y * self.width + x
+        raise IndexError
+
+    def __getitem__(self, x_y):
+        (x, y) = x_y
+        return self.data[self._idx(x, y)]
+
+    def __setitem__(self, x_y, val):
+        (x, y) = x_y
+        self.data[self._idx(x, y)] = val
+
+    def setup(self, data):
+        for y in range(self.height):
+            for x in range(self.width):
+                self[x, y] = data[y][x]
+        return self
+
+    def indexes(self):
+        for y in range(self.height):
+            for x in range(self.width):
+                yield x, y
+
+    def copy_data_from(self, other):
+        self.data[:] = other.data[:]
+
+
+class Random(object):
+    MDIG = 32
+    ONE = 1
+    m1 = (ONE << (MDIG - 2)) + ((ONE << (MDIG - 2)) - ONE)
+    m2 = ONE << MDIG // 2
+    dm1 = 1.0 / float(m1)
+
+    def __init__(self, seed):
+        self.initialize(seed)
+        self.left = 0.0
+        self.right = 1.0
+        self.width = 1.0
+        self.haveRange = False
+
+    def initialize(self, seed):
+
+        self.seed = seed
+        seed = abs(seed)
+        jseed = min(seed, self.m1)
+        if (jseed % 2 == 0):
+            jseed -= 1
+        k0 = 9069 % self.m2
+        k1 = 9069 / self.m2
+        j0 = jseed % self.m2
+        j1 = jseed / self.m2
+        self.m = array('d', [0]) * 17
+        for iloop in range(17):
+            jseed = j0 * k0
+            j1 = (jseed / self.m2 + j0 * k1 + j1 * k0) % (self.m2 / 2)
+            j0 = jseed % self.m2
+            self.m[iloop] = j0 + self.m2 * j1
+        self.i = 4
+        self.j = 16
+
+    def nextDouble(self):
+        I, J, m = self.i, self.j, self.m
+        k = m[I] - m[J]
+        if (k < 0):
+            k += self.m1
+        self.m[J] = k
+
+        if (I == 0):
+            I = 16
+        else:
+            I -= 1
+        self.i = I
+
+        if (J == 0):
+            J = 16
+        else:
+            J -= 1
+        self.j = J
+
+        if (self.haveRange):
+            return self.left + self.dm1 * float(k) * self.width
+        else:
+            return self.dm1 * float(k)
+
+    def RandomMatrix(self, a):
+        for x, y in a.indexes():
+            a[x, y] = self.nextDouble()
+        return a
+
+    def RandomVector(self, n):
+        return array('d', [self.nextDouble() for i in range(n)])
+
+
+def copy_vector(vec):
+    # Copy a vector created by Random.RandomVector()
+    vec2 = array('d')
+    vec2[:] = vec[:]
+    return vec2
+
+
+class ArrayList(Array2D):
+
+    def __init__(self, w, h, data=None):
+        self.width = w
+        self.height = h
+        self.data = [array('d', [0]) * w for y in range(h)]
+        if data is not None:
+            self.setup(data)
+
+    def __getitem__(self, idx):
+        if isinstance(idx, tuple):
+            return self.data[idx[1]][idx[0]]
+        else:
+            return self.data[idx]
+
+    def __setitem__(self, idx, val):
+        if isinstance(idx, tuple):
+            self.data[idx[1]][idx[0]] = val
+        else:
+            self.data[idx] = val
+
+    def copy_data_from(self, other):
+        for l1, l2 in zip(self.data, other.data):
+            l1[:] = l2
+
+
+def SOR_execute(omega, G, cycles, Array):
+    for p in range(cycles):
+        for y in range(1, G.height - 1):
+            for x in range(1, G.width - 1):
+                G[x, y] = (omega * 0.25 * (G[x, y - 1] + G[x, y + 1] + G[x - 1, y]
+                                           + G[x + 1, y])
+                           + (1.0 - omega) * G[x, y])
+
+
+def bench_SOR(loops, n, cycles, Array):
+    range_it = range(loops)
+    t0 = pyperf.perf_counter()
+
+    for _ in range_it:
+        G = Array(n, n)
+        SOR_execute(1.25, G, cycles, Array)
+
+    return pyperf.perf_counter() - t0
+
+
+def SparseCompRow_matmult(M, y, val, row, col, x, num_iterations):
+    range_it = range(num_iterations)
+    t0 = pyperf.perf_counter()
+
+    for _ in range_it:
+        for r in range(M):
+            sa = 0.0
+            for i in range(row[r], row[r + 1]):
+                sa += x[col[i]] * val[i]
+            y[r] = sa
+
+    return pyperf.perf_counter() - t0
+
+
+def bench_SparseMatMult(cycles, N, nz):
+    x = array('d', [0]) * N
+    y = array('d', [0]) * N
+
+    nr = nz // N
+    anz = nr * N
+    val = array('d', [0]) * anz
+    col = array('i', [0]) * nz
+    row = array('i', [0]) * (N + 1)
+
+    row[0] = 0
+    for r in range(N):
+        rowr = row[r]
+        step = r // nr
+        row[r + 1] = rowr + nr
+        if step < 1:
+            step = 1
+        for i in range(nr):
+            col[rowr + i] = i * step
+
+    return SparseCompRow_matmult(N, y, val, row, col, x, cycles)
+
+
+def MonteCarlo(Num_samples):
+    rnd = Random(113)
+    under_curve = 0
+    for count in range(Num_samples):
+        x = rnd.nextDouble()
+        y = rnd.nextDouble()
+        if x * x + y * y <= 1.0:
+            under_curve += 1
+    return float(under_curve) / Num_samples * 4.0
+
+
+def bench_MonteCarlo(loops, Num_samples):
+    range_it = range(loops)
+    t0 = pyperf.perf_counter()
+
+    for _ in range_it:
+        MonteCarlo(Num_samples)
+
+    return pyperf.perf_counter() - t0
+
+
+def LU_factor(A, pivot):
+    M, N = A.height, A.width
+    minMN = min(M, N)
+    for j in range(minMN):
+        jp = j
+        t = abs(A[j][j])
+        for i in range(j + 1, M):
+            ab = abs(A[i][j])
+            if ab > t:
+                jp = i
+                t = ab
+        pivot[j] = jp
+
+        if A[jp][j] == 0:
+            raise Exception("factorization failed because of zero pivot")
+
+        if jp != j:
+            A[j], A[jp] = A[jp], A[j]
+
+        if j < M - 1:
+            recp = 1.0 / A[j][j]
+            for k in range(j + 1, M):
+                A[k][j] *= recp
+
+        if j < minMN - 1:
+            for ii in range(j + 1, M):
+                for jj in range(j + 1, N):
+                    A[ii][jj] -= A[ii][j] * A[j][jj]
+
+
+def LU(lu, A, pivot):
+    lu.copy_data_from(A)
+    LU_factor(lu, pivot)
+
+
+def bench_LU(cycles, N):
+    rnd = Random(7)
+    A = rnd.RandomMatrix(ArrayList(N, N))
+    lu = ArrayList(N, N)
+    pivot = array('i', [0]) * N
+    range_it = range(cycles)
+    t0 = pyperf.perf_counter()
+
+    for _ in range_it:
+        LU(lu, A, pivot)
+
+    return pyperf.perf_counter() - t0
+
+
+def int_log2(n):
+    k = 1
+    log = 0
+    while k < n:
+        k *= 2
+        log += 1
+    if n != 1 << log:
+        raise Exception("FFT: Data length is not a power of 2: %s" % n)
+    return log
+
+
+def FFT_num_flops(N):
+    return (5.0 * N - 2) * int_log2(N) + 2 * (N + 1)
+
+
+def FFT_transform_internal(N, data, direction):
+    n = N // 2
+    bit = 0
+    dual = 1
+    if n == 1:
+        return
+
+    logn = int_log2(n)
+    if N == 0:
+        return
+    FFT_bitreverse(N, data)
+
+    # apply fft recursion
+    # this loop executed int_log2(N) times
+    bit = 0
+    while bit < logn:
+        w_real = 1.0
+        w_imag = 0.0
+        theta = 2.0 * direction * math.pi / (2.0 * float(dual))
+        s = math.sin(theta)
+        t = math.sin(theta / 2.0)
+        s2 = 2.0 * t * t
+        for b in range(0, n, 2 * dual):
+            i = 2 * b
+            j = 2 * (b + dual)
+            wd_real = data[j]
+            wd_imag = data[j + 1]
+            data[j] = data[i] - wd_real
+            data[j + 1] = data[i + 1] - wd_imag
+            data[i] += wd_real
+            data[i + 1] += wd_imag
+        for a in range(1, dual):
+            tmp_real = w_real - s * w_imag - s2 * w_real
+            tmp_imag = w_imag + s * w_real - s2 * w_imag
+            w_real = tmp_real
+            w_imag = tmp_imag
+            for b in range(0, n, 2 * dual):
+                i = 2 * (b + a)
+                j = 2 * (b + a + dual)
+                z1_real = data[j]
+                z1_imag = data[j + 1]
+                wd_real = w_real * z1_real - w_imag * z1_imag
+                wd_imag = w_real * z1_imag + w_imag * z1_real
+                data[j] = data[i] - wd_real
+                data[j + 1] = data[i + 1] - wd_imag
+                data[i] += wd_real
+                data[i + 1] += wd_imag
+        bit += 1
+        dual *= 2
+
+
+def FFT_bitreverse(N, data):
+    n = N // 2
+    nm1 = n - 1
+    j = 0
+    for i in range(nm1):
+        ii = i << 1
+        jj = j << 1
+        k = n >> 1
+        if i < j:
+            tmp_real = data[ii]
+            tmp_imag = data[ii + 1]
+            data[ii] = data[jj]
+            data[ii + 1] = data[jj + 1]
+            data[jj] = tmp_real
+            data[jj + 1] = tmp_imag
+        while k <= j:
+            j -= k
+            k >>= 1
+        j += k
+
+
+def FFT_transform(N, data):
+    FFT_transform_internal(N, data, -1)
+
+
+def FFT_inverse(N, data):
+    n = N / 2
+    norm = 0.0
+    FFT_transform_internal(N, data, +1)
+    norm = 1 / float(n)
+    for i in range(N):
+        data[i] *= norm
+
+
+def bench_FFT(loops, N, cycles):
+    twoN = 2 * N
+    init_vec = Random(7).RandomVector(twoN)
+    range_it = range(loops)
+    t0 = pyperf.perf_counter()
+
+    for _ in range_it:
+        x = copy_vector(init_vec)
+        for i in range(cycles):
+            FFT_transform(twoN, x)
+            FFT_inverse(twoN, x)
+
+    return pyperf.perf_counter() - t0
+
+
+def add_cmdline_args(cmd, args):
+    if args.benchmark:
+        cmd.append(args.benchmark)
+
+
+# RUSTPYTHON perf_ci: allow shrinking workloads via env (upstream defaults kept)
+import os
+
+_SOR_N = int(os.environ.get("PERF_CI_SCIMARK_SOR_N", "100"))
+_MC_N = int(os.environ.get("PERF_CI_SCIMARK_MONTE_CARLO_N", str(100 * 1000)))
+
+BENCHMARKS = {
+    # function name => arguments
+    'sor': (bench_SOR, _SOR_N, 10, Array2D),
+    'sparse_mat_mult': (bench_SparseMatMult, 1000, 50 * 1000),
+    'monte_carlo': (bench_MonteCarlo, _MC_N,),
+    'lu': (bench_LU, 100,),
+    'fft': (bench_FFT, 1024, 50),
+}
+
+
+if __name__ == "__main__":
+    runner = pyperf.Runner(add_cmdline_args=add_cmdline_args)
+    runner.argparser.add_argument("benchmark", nargs='?',
+                                  choices=sorted(BENCHMARKS))
+
+    args = runner.parse_args()
+    if args.benchmark:
+        benchmarks = (args.benchmark,)
+    else:
+        benchmarks = sorted(BENCHMARKS)
+
+    for bench in benchmarks:
+        name = 'scimark_%s' % bench
+        args = BENCHMARKS[bench]
+        runner.bench_time_func(name, *args)

--- a/benches/perf_ci/pyperformance/bm_spectral_norm.py
+++ b/benches/perf_ci/pyperformance/bm_spectral_norm.py
@@ -1,0 +1,77 @@
+"""
+MathWorld: "Hundred-Dollar, Hundred-Digit Challenge Problems", Challenge #3.
+http://mathworld.wolfram.com/Hundred-DollarHundred-DigitChallengeProblems.html
+
+The Computer Language Benchmarks Game
+http://benchmarksgame.alioth.debian.org/u64q/spectralnorm-description.html#spectralnorm
+
+Contributed by Sebastien Loisel
+Fixed by Isaac Gouy
+Sped up by Josh Goldfoot
+Dirtily sped up by Simon Descarpentries
+Concurrency by Jason Stitt
+"""
+
+import pyperf
+
+
+# RUSTPYTHON perf_ci: allow shrinking the workload via env (upstream default: 130)
+import os
+
+DEFAULT_N = int(os.environ.get("PERF_CI_SPECTRAL_NORM_N", "130"))
+
+
+def eval_A(i, j):
+    return 1.0 / ((i + j) * (i + j + 1) // 2 + i + 1)
+
+
+def eval_times_u(func, u):
+    return [func((i, u)) for i in range(len(list(u)))]
+
+
+def eval_AtA_times_u(u):
+    return eval_times_u(part_At_times_u, eval_times_u(part_A_times_u, u))
+
+
+def part_A_times_u(i_u):
+    i, u = i_u
+    partial_sum = 0
+    for j, u_j in enumerate(u):
+        partial_sum += eval_A(i, j) * u_j
+    return partial_sum
+
+
+def part_At_times_u(i_u):
+    i, u = i_u
+    partial_sum = 0
+    for j, u_j in enumerate(u):
+        partial_sum += eval_A(j, i) * u_j
+    return partial_sum
+
+
+def bench_spectral_norm(loops):
+    range_it = range(loops)
+    t0 = pyperf.perf_counter()
+
+    for _ in range_it:
+        u = [1] * DEFAULT_N
+
+        for dummy in range(10):
+            v = eval_AtA_times_u(u)
+            u = eval_AtA_times_u(v)
+
+        vBv = vv = 0
+
+        for ue, ve in zip(u, v):
+            vBv += ue * ve
+            vv += ve * ve
+
+    return pyperf.perf_counter() - t0
+
+
+if __name__ == "__main__":
+    runner = pyperf.Runner()
+    runner.metadata['description'] = (
+        'MathWorld: "Hundred-Dollar, Hundred-Digit Challenge Problems", '
+        'Challenge #3.')
+    runner.bench_time_func('spectral_norm', bench_spectral_norm)

--- a/benches/perf_ci/pyperformance/pyperf.py
+++ b/benches/perf_ci/pyperformance/pyperf.py
@@ -1,0 +1,51 @@
+# Minimal stand-in for the `pyperf` module, used by the vendored pyperformance
+# benchmark kernels in this directory when they run under RustPython for the
+# PR performance gate (scripts/perf_ci.py).
+#
+# This is NOT the real pyperf (https://github.com/psf/pyperf). The real
+# harness spawns worker subprocesses and does wall-clock statistics; the perf
+# gate instead counts instructions with callgrind, so all we need is to
+# execute each kernel a fixed, deterministic number of times inside a single
+# process. Keeping the vendored kernels importing `pyperf` unmodified makes
+# refreshing them from upstream pyperformance trivial.
+#
+# Supported surface (everything the vendored kernels use):
+#   pyperf.perf_counter
+#   pyperf.Runner(add_cmdline_args=...)
+#   runner.metadata (a dict)
+#   runner.argparser (a real argparse.ArgumentParser)
+#   runner.parse_args()
+#   runner.bench_func(name, func, *args)
+#   runner.bench_time_func(name, time_func, *args)
+#
+# The number of kernel invocations is controlled by PERF_CI_LOOPS (default 1).
+
+import argparse
+import os
+import sys
+from time import perf_counter
+
+LOOPS = int(os.environ.get("PERF_CI_LOOPS", "1"))
+
+
+class Runner:
+    def __init__(self, add_cmdline_args=None, **kwargs):
+        self.metadata = {}
+        self.argparser = argparse.ArgumentParser()
+        self._args = None
+
+    def parse_args(self, args=None):
+        if self._args is None:
+            self._args = self.argparser.parse_args(args)
+        return self._args
+
+    def bench_func(self, name, func, *args):
+        for _ in range(LOOPS):
+            result = func(*args)
+        sys.stderr.write("perf_ci: %s ok (%d loops)\n" % (name, LOOPS))
+        return result
+
+    def bench_time_func(self, name, time_func, *args):
+        result = time_func(LOOPS, *args)
+        sys.stderr.write("perf_ci: %s ok (%d loops)\n" % (name, LOOPS))
+        return result

--- a/benches/vm_boot.rs
+++ b/benches/vm_boot.rs
@@ -1,0 +1,88 @@
+//! Benchmarks for interpreter construction and the import machinery.
+//!
+//! The other bench files deliberately build the `Interpreter` outside the
+//! timed closure so they measure guest-code execution only. These do the
+//! opposite: the VM construction *is* the subject, which is the part of
+//! startup cost that lives in Rust and that a PR can regress.
+//!
+//! What this can and cannot see: a real `rustpython -c pass` process costs
+//! ~135M instructions, of which building the VM and running the code in an
+//! already-warm process accounts for ~40M. The remaining ~95M is process
+//! exec, dynamic linking, one-time lazy initialisation and teardown, all of
+//! which happen exactly once per process and therefore cannot be observed by
+//! any in-process harness -- the first `Interpreter` built in a process costs
+//! ~7.5x what later ones do. The subprocess workloads in scripts/perf_ci.py
+//! cover that end-to-end number; these cover the reconstructible part.
+
+use criterion::{BatchSize, Criterion, criterion_group, criterion_main};
+use rustpython_compiler::Mode;
+use rustpython_vm::{Interpreter, PyResult, Settings};
+use std::hint::black_box;
+
+fn build_interpreter() -> Interpreter {
+    let mut settings = Settings::default();
+    settings.path_list.push("Lib/".to_string());
+    // Never touch __pycache__, so every run compiles the same sources and the
+    // measurement does not depend on what a previous run left behind.
+    settings.write_bytecode = false;
+    settings.user_site_directory = false;
+    let builder = Interpreter::builder(settings);
+    let defs = rustpython_stdlib::stdlib_module_defs(&builder.ctx);
+    builder.add_native_modules(&defs).build()
+}
+
+fn run_source(interpreter: &Interpreter, name: &str, source: &str) {
+    interpreter.enter(|vm| {
+        let code = vm.compile(source, Mode::Exec, name.to_owned()).unwrap();
+        let scope = vm.new_scope_with_builtins();
+        let res: PyResult = vm.run_code_obj(code, scope);
+        vm.unwrap_pyresult(res);
+    })
+}
+
+pub fn criterion_benchmark(c: &mut Criterion) {
+    let mut group = c.benchmark_group("vm_boot");
+    // Each iteration builds a whole interpreter, so keep the sample count low
+    // enough that `cargo bench` stays usable.
+    group.sample_size(20);
+
+    // Interpreter construction on its own: registering native modules, setting
+    // up types, populating builtins.
+    group.bench_function("build", |b| {
+        b.iter(|| black_box(build_interpreter()));
+    });
+
+    // Construction plus executing a trivial program, the in-process analogue
+    // of `rustpython -c pass`.
+    group.bench_function("build_and_run_pass", |b| {
+        b.iter(|| {
+            let interpreter = build_interpreter();
+            run_source(&interpreter, "<bench>", "pass");
+            black_box(interpreter);
+        });
+    });
+
+    // The import machinery, with construction moved into the setup closure,
+    // which is not measured, so only importing is. A fresh interpreter per
+    // iteration is what makes these real imports rather than sys.modules
+    // lookups.
+    group.bench_function("import_stdlib", |b| {
+        b.iter_batched(
+            build_interpreter,
+            |interpreter| {
+                run_source(
+                    &interpreter,
+                    "<bench-import>",
+                    "import json, re, collections, functools, itertools",
+                );
+                interpreter
+            },
+            BatchSize::SmallInput,
+        );
+    });
+
+    group.finish();
+}
+
+criterion_group!(benches, criterion_benchmark);
+criterion_main!(benches);

--- a/scripts/perf_ci.py
+++ b/scripts/perf_ci.py
@@ -22,7 +22,11 @@ but for an interpreter hot-loop it tracks real cost closely and, above all,
 it makes the gate reproducible: a red gate is always caused by the diff.
 
 The interpreter is run with PYTHONHASHSEED=0 so that str/bytes hashing, and
-therefore dict layout, is identical across runs.
+therefore dict layout, is identical across runs. Each measurement run first
+purges the bytecode cache and then repopulates it with the binary it is about
+to measure, so no run is made cheaper by bytecode another run compiled and
+both binaries are measured in the same steady state (see
+purge_bytecode_cache and warm_bytecode_cache).
 
 Usage:
   scripts/perf_ci.py list
@@ -35,6 +39,7 @@ import concurrent.futures
 import json
 import math
 import os
+import shutil
 import subprocess
 import sys
 import tempfile
@@ -119,16 +124,18 @@ DEFAULT_THRESHOLD = 0.02
 def measure_one(binary, name, out_dir):
     argv, extra_env = WORKLOADS[name]
     out_file = os.path.join(out_dir, "callgrind.%s.out" % name)
-    env = dict(os.environ)
-    env["PYTHONHASHSEED"] = "0"
-    env.setdefault("RUSTPYTHONPATH", os.path.join(REPO_ROOT, "Lib"))
-    env.update(extra_env)
+    env = workload_env(extra_env)
     cmd = [
         "valgrind",
         "--tool=callgrind",
         "--callgrind-out-file=%s" % out_file,
         "--quiet",
         binary,
+        # Never write .pyc files. The cache is populated up front by
+        # warm_bytecode_cache; keeping the measured runs read-only means a
+        # workload can neither pay to compile bytecode for a later one nor
+        # race another measurement writing the same file.
+        "-B",
     ] + argv
     start = time.monotonic()
     proc = subprocess.run(cmd, cwd=REPO_ROOT, env=env, capture_output=True, text=True)
@@ -157,6 +164,66 @@ def parse_ir(out_file):
     raise RuntimeError("no summary line in %s" % out_file)
 
 
+def workload_env(extra_env):
+    env = dict(os.environ)
+    env["PYTHONHASHSEED"] = "0"
+    env.setdefault("RUSTPYTHONPATH", os.path.join(REPO_ROOT, "Lib"))
+    env.update(extra_env)
+    return env
+
+
+def purge_bytecode_cache():
+    """Delete every __pycache__ directory the workloads could import from.
+
+    RustPython caches compiled bytecode next to the source it imports, and
+    compiling a stdlib module costs far more than loading it from that cache
+    (measured: ~3.8x total instructions for import_stdlib, ~2x for chaos).
+    A cache left behind by an earlier run therefore makes a measurement depend
+    on what ran before it. Measuring base and then head in one checkout let
+    head reuse the bytecode base had just compiled, so head came out up to 46%
+    "faster" with an identical interpreter -- a bias towards whichever binary
+    is measured second, which is the direction that hides a regression.
+    """
+    removed = 0
+    for root in (os.path.join(REPO_ROOT, "Lib"), os.path.join(REPO_ROOT, PERF_DIR)):
+        for dirpath, dirnames, _ in os.walk(root):
+            if "__pycache__" in dirnames:
+                dirnames.remove("__pycache__")
+                shutil.rmtree(os.path.join(dirpath, "__pycache__"), ignore_errors=True)
+                removed += 1
+    return removed
+
+
+def warm_bytecode_cache(binary, names):
+    """Run each workload once, untimed, to populate the cache for `binary`.
+
+    Purging alone would leave every measurement paying bytecode compilation
+    for the stdlib modules its workload imports. That cost is unrelated to the
+    interpreter hot paths this gate exists to protect: it inflates the job and,
+    worse, dilutes sensitivity, because a regression in the measured code is
+    divided by a much larger total (compiling `os` and `argparse` alone adds
+    ~60% to fannkuch). Warming with the very binary about to be measured keeps
+    the comparison symmetric -- each binary compiles its own bytecode -- while
+    the measured runs observe steady-state execution.
+
+    Run sequentially: concurrent writers of the same .pyc would race.
+    """
+    for name in names:
+        argv, extra_env = WORKLOADS[name]
+        proc = subprocess.run(
+            [binary] + argv,
+            cwd=REPO_ROOT,
+            env=workload_env(extra_env),
+            capture_output=True,
+            text=True,
+        )
+        if proc.returncode != 0:
+            raise RuntimeError(
+                "warm-up of workload %r failed (exit %d):\n%s"
+                % (name, proc.returncode, proc.stderr[-2000:])
+            )
+
+
 def cmd_measure(args):
     binary = os.path.abspath(args.binary)
     names = args.bench or sorted(WORKLOADS)
@@ -164,6 +231,15 @@ def cmd_measure(args):
     if unknown:
         sys.exit("unknown workloads: %s" % ", ".join(sorted(unknown)))
     jobs = args.jobs or max(1, (os.cpu_count() or 2) - 1)
+    removed = purge_bytecode_cache()
+    print("purged %d stale __pycache__ directories" % removed, flush=True)
+    warm_start = time.monotonic()
+    warm_bytecode_cache(binary, names)
+    print(
+        "warmed bytecode cache with the measured binary in %.0fs"
+        % (time.monotonic() - warm_start),
+        flush=True,
+    )
     results = {}
     wall = time.monotonic()
     with tempfile.TemporaryDirectory() as out_dir:

--- a/scripts/perf_ci.py
+++ b/scripts/perf_ci.py
@@ -1,0 +1,313 @@
+#!/usr/bin/env python3
+"""PR performance regression gate for RustPython.
+
+Measures retired instruction counts (callgrind "Ir") for a fixed set of
+Python workloads executed by a RustPython binary, and compares two such
+measurements (base vs head) with a relative threshold.
+
+Why instruction counts instead of wall-clock time?
+
+* GitHub Actions runners are shared, throttled machines; wall-clock numbers
+  routinely swing by 10-40% between runs, which forces either huge thresholds
+  (misses real regressions) or a flaky gate (noise blocks unrelated PRs).
+* Instruction counts from callgrind are deterministic for a deterministic
+  program: repeated runs of the same binary+workload differ by well under
+  0.1% (see benches/perf_ci/README.md for measured numbers), and are immune
+  to CPU contention, frequency scaling, and co-tenant noise.
+* Determinism also means results are comparable when base and head are
+  measured in parallel processes, which keeps the job inside its time budget.
+
+Instruction count is a proxy for time (it cannot see cache/branch effects),
+but for an interpreter hot-loop it tracks real cost closely and, above all,
+it makes the gate reproducible: a red gate is always caused by the diff.
+
+The interpreter is run with PYTHONHASHSEED=0 so that str/bytes hashing, and
+therefore dict layout, is identical across runs.
+
+Usage:
+  scripts/perf_ci.py list
+  scripts/perf_ci.py measure --binary target/release/rustpython -o head.json
+  scripts/perf_ci.py compare base.json head.json --threshold 0.02
+"""
+
+import argparse
+import concurrent.futures
+import json
+import math
+import os
+import subprocess
+import sys
+import tempfile
+import time
+
+REPO_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+PERF_DIR = os.path.join("benches", "perf_ci")
+MICRO = os.path.join(PERF_DIR, "micro")
+PYPERF = os.path.join(PERF_DIR, "pyperformance")
+
+# Workload table. Each entry: name -> (argv after the binary, extra env).
+# Sizes are tuned so that a single run takes roughly 50-500 ms natively
+# (a few seconds under callgrind) while still executing enough guest code
+# that interpreter startup (~135M Ir) stays a small fraction of the total.
+WORKLOADS = {
+    # Interpreter startup cost: process creation to exit with a no-op program.
+    "startup": (["-c", "pass"], {}),
+    # Import machinery: startup plus a handful of common stdlib imports.
+    "import_stdlib": ([os.path.join(MICRO, "import_stdlib.py")], {}),
+    # Targeted microbenchmarks, one interpreter axis each.
+    "int_arith": ([os.path.join(MICRO, "int_arith.py")], {}),
+    "float_arith": ([os.path.join(MICRO, "float_arith.py")], {}),
+    "call_function": ([os.path.join(MICRO, "call_function.py")], {}),
+    "method_call": ([os.path.join(MICRO, "method_call.py")], {}),
+    "attr_load": ([os.path.join(MICRO, "attr_load.py")], {}),
+    "dict_ops": ([os.path.join(MICRO, "dict_ops.py")], {}),
+    "list_ops": ([os.path.join(MICRO, "list_ops.py")], {}),
+    "str_ops": ([os.path.join(MICRO, "str_ops.py")], {}),
+    "class_create": ([os.path.join(MICRO, "class_create.py")], {}),
+    "exceptions": ([os.path.join(MICRO, "exceptions.py")], {}),
+    # Vendored pyperformance kernels (see benches/perf_ci/pyperformance/).
+    # Workload sizes are shrunk from upstream defaults via CLI args or env so
+    # each run stays affordable under callgrind's ~50x slowdown.
+    "nbody": ([os.path.join(PYPERF, "bm_nbody.py"), "--iterations", "500"], {}),
+    "chaos": (
+        [
+            os.path.join(PYPERF, "bm_chaos.py"),
+            "--iterations",
+            "500",
+            "--width",
+            "128",
+            "--height",
+            "128",
+        ],
+        {},
+    ),
+    "raytrace": (
+        [os.path.join(PYPERF, "bm_raytrace.py"), "--width", "24", "--height", "24"],
+        {},
+    ),
+    "deltablue": (
+        [os.path.join(PYPERF, "bm_deltablue.py")],
+        {"PERF_CI_DELTABLUE_N": "30"},
+    ),
+    "float": ([os.path.join(PYPERF, "bm_float.py")], {"PERF_CI_FLOAT_POINTS": "20000"}),
+    "nqueens": (
+        [os.path.join(PYPERF, "bm_nqueens.py")],
+        {"PERF_CI_NQUEENS_COUNT": "7"},
+    ),
+    "fannkuch": (
+        [os.path.join(PYPERF, "bm_fannkuch.py")],
+        {"PERF_CI_FANNKUCH_ARG": "8"},
+    ),
+    "spectral_norm": (
+        [os.path.join(PYPERF, "bm_spectral_norm.py")],
+        {"PERF_CI_SPECTRAL_NORM_N": "60"},
+    ),
+    "richards": ([os.path.join(PYPERF, "bm_richards.py")], {}),
+    "scimark_sor": (
+        [os.path.join(PYPERF, "bm_scimark.py"), "sor"],
+        {"PERF_CI_SCIMARK_SOR_N": "40"},
+    ),
+    "scimark_monte_carlo": (
+        [os.path.join(PYPERF, "bm_scimark.py"), "monte_carlo"],
+        {"PERF_CI_SCIMARK_MONTE_CARLO_N": "20000"},
+    ),
+}
+
+DEFAULT_THRESHOLD = 0.02
+
+
+def measure_one(binary, name, out_dir):
+    argv, extra_env = WORKLOADS[name]
+    out_file = os.path.join(out_dir, "callgrind.%s.out" % name)
+    env = dict(os.environ)
+    env["PYTHONHASHSEED"] = "0"
+    env.setdefault("RUSTPYTHONPATH", os.path.join(REPO_ROOT, "Lib"))
+    env.update(extra_env)
+    cmd = [
+        "valgrind",
+        "--tool=callgrind",
+        "--callgrind-out-file=%s" % out_file,
+        "--quiet",
+        binary,
+    ] + argv
+    start = time.monotonic()
+    proc = subprocess.run(cmd, cwd=REPO_ROOT, env=env, capture_output=True, text=True)
+    elapsed = time.monotonic() - start
+    if proc.returncode != 0:
+        raise RuntimeError(
+            "workload %r failed (exit %d):\n%s\n%s"
+            % (name, proc.returncode, proc.stdout[-2000:], proc.stderr[-2000:])
+        )
+    ir = parse_ir(out_file)
+    os.unlink(out_file)
+    return name, ir, elapsed
+
+
+def parse_ir(out_file):
+    events = None
+    with open(out_file) as f:
+        for line in f:
+            if line.startswith("events:"):
+                events = line.split()[1:]
+            elif line.startswith("summary:"):
+                values = [int(v) for v in line.split()[1:]]
+                if events is None or "Ir" not in events:
+                    raise RuntimeError("no Ir event in %s" % out_file)
+                return values[events.index("Ir")]
+    raise RuntimeError("no summary line in %s" % out_file)
+
+
+def cmd_measure(args):
+    binary = os.path.abspath(args.binary)
+    names = args.bench or sorted(WORKLOADS)
+    unknown = set(names) - set(WORKLOADS)
+    if unknown:
+        sys.exit("unknown workloads: %s" % ", ".join(sorted(unknown)))
+    jobs = args.jobs or max(1, (os.cpu_count() or 2) - 1)
+    results = {}
+    wall = time.monotonic()
+    with tempfile.TemporaryDirectory() as out_dir:
+        with concurrent.futures.ThreadPoolExecutor(max_workers=jobs) as pool:
+            futures = [
+                pool.submit(measure_one, binary, name, out_dir) for name in names
+            ]
+            for fut in concurrent.futures.as_completed(futures):
+                name, ir, elapsed = fut.result()
+                results[name] = ir
+                print(
+                    "%-22s %14s Ir  (%.1fs under callgrind)"
+                    % (name, format(ir, ","), elapsed),
+                    flush=True,
+                )
+    wall = time.monotonic() - wall
+    payload = {
+        "binary": binary,
+        "unit": "instructions (callgrind Ir)",
+        "results": results,
+    }
+    with open(args.output, "w") as f:
+        json.dump(payload, f, indent=2, sort_keys=True)
+        f.write("\n")
+    print("measured %d workloads in %.0fs -> %s" % (len(results), wall, args.output))
+
+
+def cmd_compare(args):
+    with open(args.base) as f:
+        base = json.load(f)["results"]
+    with open(args.head) as f:
+        head = json.load(f)["results"]
+
+    common = sorted(set(base) & set(head))
+    if not common:
+        sys.exit("no common workloads between %s and %s" % (args.base, args.head))
+    only_base = sorted(set(base) - set(head))
+    only_head = sorted(set(head) - set(base))
+
+    rows = []
+    regressions = []
+    for name in common:
+        delta = (head[name] - base[name]) / base[name]
+        status = "ok"
+        if delta > args.threshold:
+            status = "REGRESSION"
+            regressions.append((name, delta))
+        elif delta < -args.threshold:
+            status = "improved"
+        rows.append((name, base[name], head[name], delta, status))
+
+    geomean = (
+        math.exp(sum(math.log(head[n] / base[n]) for n in common) / len(common)) - 1.0
+    )
+
+    lines = []
+    lines.append("| workload | base Ir | head Ir | delta | status |")
+    lines.append("|---|---:|---:|---:|---|")
+    for name, b, h, delta, status in rows:
+        mark = {"REGRESSION": "❌", "improved": "✅", "ok": ""}[status]
+        lines.append(
+            "| %s | %s | %s | %+.2f%% | %s %s |"
+            % (name, format(b, ","), format(h, ","), delta * 100, mark, status)
+        )
+    lines.append("")
+    lines.append(
+        "Geometric mean delta: **%+.2f%%** (threshold per workload: +%.1f%%)"
+        % (geomean * 100, args.threshold * 100)
+    )
+    for name in only_base:
+        lines.append("- `%s` only present in base measurement" % name)
+    for name in only_head:
+        lines.append("- `%s` only present in head measurement" % name)
+    report = "\n".join(lines)
+
+    print(report)
+    summary_path = args.summary or os.environ.get("GITHUB_STEP_SUMMARY")
+    if summary_path:
+        with open(summary_path, "a") as f:
+            f.write("## Performance gate (callgrind instruction counts)\n\n")
+            f.write(report)
+            f.write("\n")
+
+    if regressions:
+        print()
+        print(
+            "FAIL: %d workload(s) regressed more than %.1f%%:"
+            % (len(regressions), args.threshold * 100)
+        )
+        for name, delta in regressions:
+            print("  %-22s %+.2f%%" % (name, delta * 100))
+        sys.exit(1)
+    print()
+    print("PASS: no workload regressed more than %.1f%%" % (args.threshold * 100))
+
+
+def cmd_list(_args):
+    for name in sorted(WORKLOADS):
+        argv, env = WORKLOADS[name]
+        extra = " ".join("%s=%s" % kv for kv in sorted(env.items()))
+        print("%-22s %s %s" % (name, " ".join(argv), extra))
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    sub = parser.add_subparsers(dest="command", required=True)
+
+    p = sub.add_parser("measure", help="measure Ir for each workload")
+    p.add_argument("--binary", required=True, help="rustpython binary to measure")
+    p.add_argument("-o", "--output", required=True, help="output JSON path")
+    p.add_argument(
+        "--bench",
+        action="append",
+        help="measure only this workload (repeatable; default: all)",
+    )
+    p.add_argument(
+        "--jobs",
+        type=int,
+        help="parallel callgrind processes (default: cpu_count - 1); "
+        "instruction counts are unaffected by concurrency",
+    )
+    p.set_defaults(func=cmd_measure)
+
+    p = sub.add_parser("compare", help="compare two measurement files")
+    p.add_argument("base", help="JSON produced by `measure` for the base commit")
+    p.add_argument("head", help="JSON produced by `measure` for the head commit")
+    p.add_argument(
+        "--threshold",
+        type=float,
+        default=DEFAULT_THRESHOLD,
+        help="max allowed relative Ir increase per workload (default: %(default)s)",
+    )
+    p.add_argument(
+        "--summary",
+        help="markdown summary output path (default: $GITHUB_STEP_SUMMARY)",
+    )
+    p.set_defaults(func=cmd_compare)
+
+    p = sub.add_parser("list", help="list workloads")
+    p.set_defaults(func=cmd_list)
+
+    args = parser.parse_args()
+    args.func(args)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
- [x] This PR follows our [AI policy](https://github.com/RustPython/.github/blob/main/AI_POLICY.md)

## Summary

Adds a `Performance gate` workflow that builds RustPython twice — once from the PR's merge base, once from its head — runs the same 23 Python workloads under both, and fails the check if any workload got measurably slower. It exists because the queued interpreter hot-path work (in-place str concat, `LOAD_FAST_BORROW`, immortal objects, int unboxing, method-cache invalidation, attribute specialization) all touches the same code paths, and without a shared baseline those changes can't be told apart from each other or from a regression. Today PR CI has no performance signal at all; benchmarks only run in the scheduled `cron-ci.yaml` job.

Instead of timing, it counts **retired instructions** with `valgrind --tool=callgrind`. Wall-clock on shared runners swings 10-40% run to run, so any threshold on it is either too loose to catch anything or flaky enough to block unrelated PRs. Instruction counts are deterministic: base vs head with an identical interpreter agreed to within 0.03% in CI, so the 2% per-workload threshold sits ~16x above the noise floor.

## What's in it

| path | what |
|---|---|
| `.github/workflows/perf-ci.yaml` | the gate: build base + head, measure both, compare |
| `scripts/perf_ci.py` | the runner — `measure`, `compare`, `list` |
| `benches/perf_ci/micro/` | 11 microbenchmarks, one interpreter axis each |
| `benches/perf_ci/pyperformance/` | 10 kernels vendored from pyperformance 1.14.0 (MIT) |
| `benches/perf_ci/README.md` | how to run it and how to add a workload |

Workloads cover the axes the optimization work targets: int/float arithmetic, function calls, method calls, instance attribute loads (`__dict__` and `__slots__`), dict/list/str ops, class creation, exceptions, startup (`-c pass`) and stdlib import cost, plus the vendored kernels (nbody, spectral_norm, chaos, deltablue, richards, float, nqueens, raytrace, scimark, fannkuch).

## Using it on a PR

Nothing to do — it runs automatically when a PR touches `crates/`, `src/`, `Cargo.*`, or the gate's own files. Results land in three places:

- **the check** — red if any workload regressed more than 2%
- **the job summary** — a per-workload table of base Ir, head Ir, delta, and status, so you can see *which* workload moved and by how much
- **the `perf-ci-results` artifact** — `perf-base.json` / `perf-head.json`, kept 30 days, so any two measurements can be re-compared later

When it goes red, the summary table names the workload. Reproduce it locally with the commands below, and if the slowdown is real but intended, the threshold is a flag on the `compare` step rather than something baked into the script.

https://github.com/moreal/RustPython/actions/runs/32617025665

<img width="666" height="838" alt="image" src="https://github.com/user-attachments/assets/02e0e58a-a3f4-4fad-be7b-51c6c6b754ae" />

## Running it locally

Needs `valgrind` and CPython 3.14. Measure your build, then a baseline build, then compare:

```shell
cargo build --release
python3 scripts/perf_ci.py measure --binary target/release/rustpython -o head.json

git checkout <base-commit> && cargo build --release
python3 scripts/perf_ci.py measure --binary target/release/rustpython -o base.json

python3 scripts/perf_ci.py compare base.json head.json
```

`compare` prints the same table CI shows and exits non-zero on a regression. Useful flags: `--bench <name>` (repeatable) to measure one workload while iterating, `--jobs N` to control parallelism, `--threshold 0.05` to loosen the gate, and `scripts/perf_ci.py list` to see every workload with its arguments. A full measurement of one binary takes ~2 minutes on 4 cores; a single workload takes seconds.

## Adding a workload

Drop a `.py` file in `benches/perf_ci/micro/` and add one line to the `WORKLOADS` table in `scripts/perf_ci.py`. Keep it deterministic (fixed seeds, no clock or I/O in the hot path) and sized to 50-500 ms natively — callgrind slows execution ~50x, and the workload needs to be big enough that interpreter startup (~135M instructions) isn't most of the number.

## Notes for reviewers

**Why not pyperformance itself.** It was tried first: `pyperformance run --python=<rustpython>` creates the venv and then hard-fails building `psutil`, a CPython C extension RustPython can't load. `pyperf` alone does run on RustPython, but it reports wall-clock statistics, which brings back the noise problem. Hence vendored kernels plus a ~50-line local `pyperf` stand-in, so the kernels stay unmodified apart from env-var size overrides marked `# RUSTPYTHON perf_ci` and refreshing them from upstream stays easy.

**Relationship to `cron-ci.yaml`.** No overlap and nothing runs twice: the cron job keeps collecting criterion wall-clock data for long-term trends on the website and never blocks a PR; this gate is per-PR, deterministic, and blocking. `cron-ci.yaml` is unchanged.

**A hazard worth knowing about.** The first CI run reported head as up to 46% faster than base with a byte-identical interpreter. Both binaries are measured in one checkout, and RustPython caches compiled bytecode next to the sources it imports — so base paid to compile the stdlib and head loaded it from that cache for free. The bias always favours whichever binary is measured second, which is the direction that *hides* a regression. Fixed by purging `__pycache__` up front, re-warming it with the binary about to be measured, and passing `-B` so timed runs can't mutate it. Two runs of the same binary from a polluted cache now agree to within 0.022%.

**Validation.** An artificial slowdown injected into `execute_instruction` pushed 13 of 23 workloads past the threshold (+2.17% to +3.68%) and turned the gate red; the ten that stayed under are the ones where the dispatch loop is a smaller share of the total, `startup` and `import_stdlib` least affected — the expected shape. The injection was reverted. `actionlint` and `zizmor` are clean.

**Cost.** Measured on this PR's two runs: base and head build in parallel jobs and the finished binary is cached by commit SHA, so PRs against the same `main` tip share one base build (run 2 skipped it in 14s). Measurement of both binaries takes ~5 minutes, and the whole workflow ~9 minutes.

**Not included.** The gate doesn't post a PR comment — the workflow holds only `contents: read`, and adding a comment would need a `workflow_run`-triggered follow-up to keep write permissions away from PR code. Happy to add that separately.

Assisted-by: Claude Code

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added automated pull-request performance regression checks using deterministic instruction-count measurements.
  * Added benchmark coverage for interpreter startup, language operations, algorithms, numerical workloads, and standard-library imports.
  * Added CodSpeed benchmarking support for selected Rust benchmarks.
  * Added tools to list workloads, collect results, compare runs, and report regressions.
  * Added an option to skip CPython comparisons during benchmark runs.

* **Documentation**
  * Added guidance for running, tuning, and understanding performance benchmarks locally.
  * Included licensing information for vendored benchmark content.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->