### PR TITLE
host_env: rustix for unlinkat, fix clippy deny

### DIFF
--- a/crates/host_env/src/posix.rs
+++ b/crates/host_env/src/posix.rs
@@ -143,16 +143,6 @@ pub fn chroot(path: &Path) -> std::io::Result<()> {
     nix::unistd::chroot(path).map_err(std::io::Error::from)
 }
 
-#[cfg(not(target_os = "redox"))]
-pub fn unlinkat(dir_fd: i32, path: &CStr) -> std::io::Result<()> {
-    let ret = unsafe { libc::unlinkat(dir_fd, path.as_ptr(), 0) };
-    if ret < 0 {
-        Err(std::io::Error::last_os_error())
-    } else {
-        Ok(())
-    }
-}
-
 #[cfg(any(target_os = "macos", target_os = "freebsd", target_os = "netbsd"))]
 pub fn lchmod(path: &CStr, mode: libc::mode_t) -> std::io::Result<()> {
     unsafe extern "C" {

--- a/crates/host_env/src/posix_unix_like.rs
+++ b/crates/host_env/src/posix_unix_like.rs
@@ -64,3 +64,8 @@ pub fn stat_path(
         .map(Option::Some)
         .map_err(Into::into)
 }
+
+pub fn unlinkat(dir_fd: Option<crt_fd::Borrowed<'_>>, path: impl AsRef<Path>) -> io::Result<()> {
+    let dir_fd = dir_fd.as_ref().map_or(fs::CWD, AsFd::as_fd);
+    fs::unlinkat(dir_fd, path.as_ref(), AtFlags::empty()).map_err(Into::into)
+}

--- a/crates/vm/src/stdlib/os.rs
+++ b/crates/vm/src/stdlib/os.rs
@@ -229,7 +229,7 @@ pub(super) mod _os {
     const STAT_DIR_FD: bool = cfg!(not(any(windows, target_os = "redox")));
     const UTIME_DIR_FD: bool = cfg!(not(any(windows, target_os = "redox")));
     pub(crate) const SYMLINK_DIR_FD: bool = cfg!(not(any(windows, target_os = "redox")));
-    pub(crate) const UNLINK_DIR_FD: bool = cfg!(not(any(windows, target_os = "redox")));
+    pub(crate) const UNLINK_DIR_FD: bool = cfg!(not(windows));
     const RENAME_DIR_FD: bool = cfg!(any(unix, target_os = "wasi"));
     const RMDIR_DIR_FD: bool = cfg!(not(any(windows, target_os = "redox")));
     const SCANDIR_FD: bool = cfg!(all(unix, not(target_os = "redox")));

--- a/crates/vm/src/stdlib/posix.rs
+++ b/crates/vm/src/stdlib/posix.rs
@@ -440,15 +440,7 @@ pub mod module {
         dir_fd: DirFd<'_, { _os::UNLINK_DIR_FD as usize }>,
         vm: &VirtualMachine,
     ) -> PyResult<()> {
-        #[cfg(not(target_os = "redox"))]
-        if let Some(fd) = dir_fd.raw_opt() {
-            let c_path = path.clone().into_cstring(vm)?;
-            return rustpython_host_env::posix::unlinkat(fd, &c_path)
-                .map_err(|err| OSErrorBuilder::with_filename(&err, path, vm));
-        }
-        #[cfg(target_os = "redox")]
-        let [] = dir_fd.0;
-        crate::host_env::fs::remove_file(&path)
+        rustpython_host_env::posix::unlinkat(dir_fd.get_opt(), &path)
             .map_err(|err| OSErrorBuilder::with_filename(&err, path, vm))
     }
 

--- a/crates/vm/src/stdlib/posix_compat.rs
+++ b/crates/vm/src/stdlib/posix_compat.rs
@@ -9,17 +9,34 @@ pub(crate) mod module {
     use crate::{
         Py, PyObjectRef, PyResult, VirtualMachine,
         builtins::PyStrRef,
-        convert::IntoPyException,
         ospath::OsPath,
         stdlib::os::{_os, DirFd, SupportFunc, TargetIsDirectory},
     };
-    use std::fs;
+
+    #[cfg(not(target_os = "wasi"))]
+    use {crate::convert::IntoPyException, std::fs};
+
+    #[cfg(target_os = "wasi")]
+    use crate::exceptions::OSErrorBuilder;
 
     #[pyfunction]
     pub(super) fn access(_path: PyStrRef, _mode: u8, vm: &VirtualMachine) -> PyResult<bool> {
         os_unimpl("os.access", vm)
     }
 
+    #[cfg(target_os = "wasi")]
+    #[pyfunction]
+    #[pyfunction(name = "unlink")]
+    fn remove(
+        path: OsPath,
+        dir_fd: DirFd<'_, { _os::UNLINK_DIR_FD as usize }>,
+        vm: &VirtualMachine,
+    ) -> PyResult<()> {
+        rustpython_host_env::posix::unlinkat(dir_fd.get_opt(), &path)
+            .map_err(|err| OSErrorBuilder::with_filename(&err, path, vm))
+    }
+
+    #[cfg(not(target_os = "wasi"))]
     #[pyfunction]
     #[pyfunction(name = "unlink")]
     fn remove(path: OsPath, dir_fd: DirFd<'_, 0>, vm: &VirtualMachine) -> PyResult<()> {


### PR DESCRIPTION
Like the other patches, this greatly simplifies our unlinkat code and is overall nicer because it uses the syscall directly on Linux.

As an added benefit, this commit adds WASI support and fixes a clippy deny. The old code caused clippy to complain that the WASI branch bypassed host_env for remove/unlink.

<!--
Thanks for your contribution!
-->

- [ ] Closes #xxxx <!-- Replace xxxx with the GitHub issue number if exists -->

One of checkbox below must be checked.
- [x] I did not use AI to write the code of this patch.
- [ ] This PR follows our [AI policy](https://github.com/RustPython/.github/blob/main/AI_POLICY.md)

## Summary
<!-- What's the purpose of the change? What does it do, and why? -->

* Simplify os.remove for Unix-likes
* Fix a clippy deny for WASI

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved consistency when removing files through the POSIX interface across supported platforms.
  * File removal now supports paths relative to an optional directory descriptor, including on Redox and WASI.
  * Preserved clear operating system error reporting, including the affected filename, when removal fails.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->