### PR TITLE
compiler: end the missing-comma diagnostic past the whole second atom

### DIFF
--- a/crates/compiler/src/lib.rs
+++ b/crates/compiler/src/lib.rs
@@ -4477,10 +4477,15 @@ fn missing_comma_expression_error(source: &str) -> Option<(String, usize, usize)
                         && expression_atom_start(bytes, next)
                         && !expression_continuation_keyword(bytes, next)
                     {
+                        // The diagnostic covers both atoms, so it ends past
+                        // the whole second one.  `next + 1` ended past its
+                        // first byte instead, which is only the same thing
+                        // when that atom is one ASCII character.
+                        let second_end = adjacent_atom_end(bytes, next).unwrap_or(next + 1);
                         return Some((
                             "invalid syntax. Perhaps you forgot a comma?".to_owned(),
                             index,
-                            next + 1,
+                            second_end,
                         ));
                     }
                     index = atom_end;
@@ -5783,6 +5788,40 @@ mod tests {
             "with Barry as BDFL, use '<>' instead of '!='"
         );
         assert_eq!(err.python_location(), (2, 3));
+    }
+
+    #[test]
+    fn missing_comma_diagnostic_spans_the_whole_second_atom() {
+        // `(start, end)` reported as one-based character columns, matching
+        // `SyntaxError.offset` / `.end_offset`.
+        let span = |source: &str| {
+            let err = compile(source, Mode::Eval, "<comma>", CompileOpts::default())
+                .expect_err("two adjacent atoms are a syntax error");
+            assert_eq!(
+                err.to_string(),
+                "invalid syntax. Perhaps you forgot a comma?"
+            );
+            (
+                err.python_location().1,
+                err.python_end_location().unwrap().1,
+            )
+        };
+
+        // A one-character second atom is the case that already worked.
+        assert_eq!(span("(a b)"), (2, 5));
+        // A longer one ends where it ends, not one byte in.
+        assert_eq!(span("(a bb)"), (2, 6));
+        assert_eq!(span("(a bbb)"), (2, 7));
+        assert_eq!(span("(1 22)"), (2, 6));
+        // A non-ASCII atom is one character but several bytes, so counting
+        // bytes here used to stop inside it and round back off the boundary.
+        assert_eq!(span("(a \u{3b2})"), (2, 5));
+        assert_eq!(span("(a \u{3b2}\u{3b2})"), (2, 6));
+        assert_eq!(span("(\u{3b1}\u{3b1} \u{3b2})"), (2, 6));
+        // The first atom's width was never the problem; pin it anyway.
+        assert_eq!(span("(\u{3b1} b)"), (2, 5));
+        // Other bracket kinds take the same path.
+        assert_eq!(span("[\u{3b1} \u{3b2}]"), (2, 5));
     }
 
     #[test]


### PR DESCRIPTION
`missing_comma_expression_error` returns its span as `(index, next + 1)`,
where `next` is the **byte** index at which the second atom starts. The `+ 1`
is a fixed one-byte width, so `SyntaxError.end_offset` matched CPython only
when that atom happened to be a single ASCII character.

Measured against CPython 3.14.6, `compile(src, '<t>', 'eval')`:

| source | CPython `end_offset` | before | after |
|---|---|---|---|
| `(a b)` | 5 | 5 | 5 |
| `(a bb)` | 6 | **5** | 6 |
| `(a bbb)` | 7 | **5** | 7 |
| `(1 22)` | 6 | **5** | 6 |
| `(a β)` | 5 | **4** | 5 |
| `(a ββ)` | 6 | **4** | 6 |
| `(a βb)` | 6 | **4** | 6 |
| `(αα β)` | 6 | **5** | 6 |
| `[α β]` | 5 | **4** | 5 |

Pure ASCII is wrong too, so this is not a UTF-8 conversion problem — `(a bb)`
is the case that rules that reading out. A non-ASCII second atom loses an
extra column on top, because the short end lands inside the character and
`source_location` then walks back to where it starts.

`adjacent_atom_end` already measures an atom — identifiers including
non-ASCII ones, string literals, and numbers — and is what the **first** atom
is measured with three lines above. Using it for the second one makes both
ends of the span agree about what an atom is.

## Verification

- New unit test `missing_comma_diagnostic_spans_the_whole_second_atom`, nine
  cases, values taken from CPython 3.14.6.
- Negative control: with the one-line change reverted and the test kept, it
  fails on `(a bb)` with `left: (2, 5)` / `right: (2, 6)`.
- `cargo test -p rustpython-compiler` — 21 passed, 0 failed.
- End-to-end against the built interpreter: all nine plain-expression cases
  now match CPython, and the f-string forms (`f'{a bb}'` and friends) pick up
  the corrected end as well.
- The four `Lib/test/test_syntax.py` doctests for this message check only the
  message text, so none of their expectations move.

## Out of scope

Two pre-existing divergences turned up in the same probe and are deliberately
left alone:

- `(a 'xy')` — CPython reports `invalid syntax` at offset 4, we report the
  missing-comma message at offset 2. A message mismatch, not a span one.
  (Its `end_offset` does become 8, which is CPython's value.)
- `f'{a b}'` — CPython reports `offset` 4, we report 6. The **start** of the
  f-string form is computed elsewhere; only the end is touched here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DqhjV61wmP78FZoJwvkazF


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved missing-comma diagnostics to highlight the complete adjacent expression, including multi-character and non-ASCII values.
  * Corrected highlighting across different bracket types for clearer error messages.

* **Tests**
  * Added regression coverage for identifiers, numbers, Unicode values, and bracketed expressions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->