### PR TITLE
`str.format`: reject non-existing `!b` format conversion

### DIFF
--- a/crates/common/src/cformat.rs
+++ b/crates/common/src/cformat.rs
@@ -55,6 +55,12 @@ impl fmt::Display for CFormatError {
 
 pub type CFormatConversion = super::format::FormatConversion;
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum CFormatContext {
+    Str,
+    Bytes,
+}
+
 #[derive(Debug, PartialEq, Eq, Clone, Copy)]
 #[repr(u8)]
 pub enum CNumberType {
@@ -98,6 +104,7 @@ pub enum CFormatType {
     Float(CFloatType),
     Character(CCharacterType),
     String(CFormatConversion),
+    Bytes,
 }
 
 impl CFormatType {
@@ -108,6 +115,7 @@ impl CFormatType {
             Self::Float(x) => x as u8 as char,
             Self::Character(x) => x as u8 as char,
             Self::String(x) => x as u8 as char,
+            Self::Bytes => 'b',
         }
     }
 }
@@ -296,14 +304,14 @@ impl FromStr for CFormatSpecKeyed<String> {
             return Err((CFormatErrorType::MissingModuloSign, 1));
         }
 
-        Self::parse(&mut chars)
+        Self::parse(&mut chars, CFormatContext::Str)
     }
 }
 
 pub type ParseIter<I> = Peekable<Enumerate<I>>;
 
 impl<T: FormatBuf> CFormatSpecKeyed<T> {
-    pub fn parse<I>(iter: &mut ParseIter<I>) -> Result<Self, ParsingError>
+    pub fn parse<I>(iter: &mut ParseIter<I>, context: CFormatContext) -> Result<Self, ParsingError>
     where
         I: Iterator<Item = T::Char>,
     {
@@ -313,7 +321,7 @@ impl<T: FormatBuf> CFormatSpecKeyed<T> {
             parse_quantity(iter, isize::MAX as usize, CFormatErrorType::WidthTooBig)?;
         let precision = parse_precision(iter)?;
         consume_length(iter);
-        let format_type = parse_format_type(iter)?;
+        let format_type = parse_format_type(iter, context)?;
 
         let spec = CFormatSpec {
             flags,
@@ -618,7 +626,10 @@ where
     iter.next_if(|(_, c)| matches!(c.to_char_lossy(), 'h' | 'l' | 'L'));
 }
 
-fn parse_format_type<C, I>(iter: &mut ParseIter<I>) -> Result<CFormatType, ParsingError>
+fn parse_format_type<C, I>(
+    iter: &mut ParseIter<I>,
+    context: CFormatContext,
+) -> Result<CFormatType, ParsingError>
 where
     C: FormatChar,
     I: Iterator<Item = C>,
@@ -646,8 +657,8 @@ where
         'c' => CFormatType::Character(CCharacterType::Character),
         'r' => CFormatType::String(CFormatConversion::Repr),
         's' => CFormatType::String(CFormatConversion::Str),
-        'b' => CFormatType::String(CFormatConversion::Bytes),
         'a' => CFormatType::String(CFormatConversion::Ascii),
+        'b' if context == CFormatContext::Bytes => CFormatType::Bytes,
         _ => return Err((CFormatErrorType::UnsupportedFormatChar(c.into()), index)),
     })
 }
@@ -784,7 +795,7 @@ impl<S> CFormatStrOrBytes<S> {
         self.parts.iter_mut()
     }
 
-    pub fn parse<I>(iter: &mut ParseIter<I>) -> Result<Self, CFormatError>
+    pub fn parse<I>(iter: &mut ParseIter<I>, context: CFormatContext) -> Result<Self, CFormatError>
     where
         S: FormatBuf,
         I: Iterator<Item = S::Char>,
@@ -808,10 +819,11 @@ impl<S> CFormatStrOrBytes<S> {
                         ));
                     }
 
-                    let spec = CFormatSpecKeyed::parse(iter).map_err(|err| CFormatError {
-                        typ: err.0,
-                        index: err.1,
-                    })?;
+                    let spec =
+                        CFormatSpecKeyed::parse(iter, context).map_err(|err| CFormatError {
+                            typ: err.0,
+                            index: err.1,
+                        })?;
 
                     parts.push((index, CFormatPart::Spec(spec)));
                     if let Some(&(index, _)) = iter.peek() {
@@ -848,7 +860,7 @@ pub type CFormatBytes = CFormatStrOrBytes<Vec<u8>>;
 impl CFormatBytes {
     pub fn parse_from_bytes(bytes: &[u8]) -> Result<Self, CFormatError> {
         let mut iter = bytes.iter().copied().enumerate().peekable();
-        Self::parse(&mut iter)
+        Self::parse(&mut iter, CFormatContext::Bytes)
     }
 }
 
@@ -859,7 +871,7 @@ impl FromStr for CFormatString {
 
     fn from_str(text: &str) -> Result<Self, Self::Err> {
         let mut iter = text.chars().enumerate().peekable();
-        Self::parse(&mut iter)
+        Self::parse(&mut iter, CFormatContext::Str)
     }
 }
 
@@ -868,7 +880,7 @@ pub type CFormatWtf8 = CFormatStrOrBytes<Wtf8Buf>;
 impl CFormatWtf8 {
     pub fn parse_from_wtf8(s: &Wtf8) -> Result<Self, CFormatError> {
         let mut iter = s.code_points().enumerate().peekable();
-        Self::parse(&mut iter)
+        Self::parse(&mut iter, CFormatContext::Str)
     }
 }
 

--- a/crates/common/src/format.rs
+++ b/crates/common/src/format.rs
@@ -37,7 +37,6 @@ pub enum FormatConversion {
     Str = b's',
     Repr = b'r',
     Ascii = b'b',
-    Bytes = b'a',
 }
 
 impl FormatParse for FormatConversion {
@@ -59,7 +58,6 @@ impl FormatConversion {
             's' => Some(Self::Str),
             'r' => Some(Self::Repr),
             'a' => Some(Self::Ascii),
-            'b' => Some(Self::Bytes),
             _ => None,
         }
     }

--- a/crates/vm/src/cformat.rs
+++ b/crates/vm/src/cformat.rs
@@ -32,38 +32,37 @@ fn spec_format_bytes(
     obj: PyObjectRef,
 ) -> PyResult<Vec<u8>> {
     match &spec.format_type {
-        CFormatType::String(conversion) => match conversion {
-            // Unlike strings, %r and %a are identical for bytes: the behaviour corresponds to
-            // %a for strings (not %r)
-            CFormatConversion::Repr | CFormatConversion::Ascii => {
-                let b = builtins::ascii(obj, vm)?.as_bytes().to_vec();
-                Ok(b)
+        // Unlike strings, %r and %a are identical for bytes: the behaviour corresponds to
+        // %a for strings (not %r)
+        CFormatType::String(CFormatConversion::Repr | CFormatConversion::Ascii) => {
+            let b = builtins::ascii(obj, vm)?.as_bytes().to_vec();
+            Ok(b)
+        }
+        // %b and %s are equivalent for bytes formatting.
+        // Mirrors CPython's format_obj() in bytesobject.c
+        CFormatType::Bytes | CFormatType::String(CFormatConversion::Str) => {
+            if let Some(bytes) = obj.downcast_ref::<PyBytes>() {
+                return Ok(spec.format_bytes(bytes.as_bytes()));
             }
-            // format_obj
-            CFormatConversion::Str | CFormatConversion::Bytes => {
-                if let Some(bytes) = obj.downcast_ref::<PyBytes>() {
-                    return Ok(spec.format_bytes(bytes.as_bytes()));
-                }
-                if let Some(bytearray) = obj.downcast_ref::<PyByteArray>() {
-                    return Ok(spec.format_bytes(&bytearray.borrow_buf()));
-                }
-                if let Some(method) = vm.get_special_method(&obj, identifier!(vm, __bytes__))? {
-                    let bytes = method.invoke((), vm)?;
-                    let bytes = PyBytes::try_from_borrowed_object(vm, &bytes)?;
-                    return Ok(spec.format_bytes(bytes.as_bytes()));
-                }
-                if obj.check_buffer() {
-                    let buffer = PyBuffer::from_object(vm, &obj, BufferFlags::FULL_RO)?;
-                    return Ok(buffer.contiguous_or_collect(|bytes| spec.format_bytes(bytes)));
-                }
-                let msg = format!(
-                    "%b requires a bytes-like object, or an object that \
-                        implements __bytes__, not '{}'",
-                    obj.class().name()
-                );
-                Err(vm.new_type_error(msg))
+            if let Some(bytearray) = obj.downcast_ref::<PyByteArray>() {
+                return Ok(spec.format_bytes(&bytearray.borrow_buf()));
             }
-        },
+            if let Some(method) = vm.get_special_method(&obj, identifier!(vm, __bytes__))? {
+                let bytes = method.invoke((), vm)?;
+                let bytes = PyBytes::try_from_borrowed_object(vm, &bytes)?;
+                return Ok(spec.format_bytes(bytes.as_bytes()));
+            }
+            if obj.check_buffer() {
+                let buffer = PyBuffer::from_object(vm, &obj, BufferFlags::FULL_RO)?;
+                return Ok(buffer.contiguous_or_collect(|bytes| spec.format_bytes(bytes)));
+            }
+            let msg = format!(
+                "%b requires a bytes-like object, or an object that \
+                    implements __bytes__, not '{}'",
+                obj.class().name()
+            );
+            Err(vm.new_type_error(msg))
+        }
         CFormatType::Number(number_type) => match number_type {
             CNumberType::DecimalD | CNumberType::DecimalI | CNumberType::DecimalU => {
                 match_class!(match &obj {
@@ -166,7 +165,6 @@ fn spec_format_string(
     vm: &VirtualMachine,
     spec: &CFormatSpec,
     obj: PyObjectRef,
-    idx: usize,
 ) -> PyResult<Wtf8Buf> {
     match &spec.format_type {
         CFormatType::String(conversion) => {
@@ -174,15 +172,12 @@ fn spec_format_string(
                 CFormatConversion::Ascii => builtins::ascii(obj, vm)?.as_wtf8().to_owned(),
                 CFormatConversion::Str => obj.str(vm)?.as_wtf8().to_owned(),
                 CFormatConversion::Repr => obj.repr(vm)?.as_wtf8().to_owned(),
-                CFormatConversion::Bytes => {
-                    // idx is the position of the %, we want the position of the b
-                    return Err(vm.new_value_error(format!(
-                        "unsupported format character 'b' (0x62) at index {}",
-                        idx + 1
-                    )));
-                }
             };
             Ok(spec.format_string(result))
+        }
+        CFormatType::Bytes => {
+            // 'b' is rejected at parse time in Str context, see `CFormatContext`.
+            unreachable!("%b cannot be parsed in a str format string")
         }
         CFormatType::Number(number_type) => match number_type {
             CNumberType::DecimalD | CNumberType::DecimalI | CNumberType::DecimalU => {
@@ -487,12 +482,12 @@ pub(crate) fn cformat_string(
         }
 
         // dict
-        for (idx, part) in format {
+        for (_, part) in format {
             match part {
                 CFormatPart::Literal(literal) => result.push_wtf8(&literal),
                 CFormatPart::Spec(CFormatSpecKeyed { mapping_key, spec }) => {
                     let value = values_obj.get_item(&mapping_key.unwrap(), vm)?;
-                    let part_result = spec_format_string(vm, &spec, value, idx)?;
+                    let part_result = spec_format_string(vm, &spec, value)?;
                     result.push_wtf8(&part_result);
                 }
             }
@@ -510,7 +505,7 @@ pub(crate) fn cformat_string(
 
     let mut value_iter = values.iter();
 
-    for (idx, part) in format {
+    for (_, part) in format {
         match part {
             CFormatPart::Literal(literal) => result.push_wtf8(&literal),
             CFormatPart::Spec(CFormatSpecKeyed { mut spec, .. }) => {
@@ -526,7 +521,7 @@ pub(crate) fn cformat_string(
                     return Err(vm.new_type_error("not enough arguments for format string"));
                 };
 
-                let part_result = spec_format_string(vm, &spec, value.clone(), idx)?;
+                let part_result = spec_format_string(vm, &spec, value.clone())?;
                 result.push_wtf8(&part_result);
             }
         }

--- a/crates/vm/src/format.rs
+++ b/crates/vm/src/format.rs
@@ -153,9 +153,6 @@ fn format_internal(
                         Some(FormatConversion::Str) => argument.str(vm)?.into(),
                         Some(FormatConversion::Repr) => argument.repr(vm)?.into(),
                         Some(FormatConversion::Ascii) => builtins::ascii(argument, vm)?.into(),
-                        Some(FormatConversion::Bytes) => {
-                            vm.call_method(&argument, identifier!(vm, decode).as_str(), ())?
-                        }
                         None => {
                             return Err(
                                 vm.new_value_error(format!("Unknown conversion specifier {c}"))

--- a/extra_tests/snippets/builtin_format.py
+++ b/extra_tests/snippets/builtin_format.py
@@ -66,6 +66,15 @@ except ValueError as error:
 else:
     raise AssertionError("expected ValueError for unknown conversion specifier '!x'")
 
+# 'b' is a valid conversion specifier for %-style bytes formatting, but not for str.format().
+try:
+    "{0!b}".format(3)
+except ValueError as error:
+    if str(error) != "Unknown conversion specifier b":
+        raise AssertionError(f"unexpected error message: {error}") from error
+else:
+    raise AssertionError("expected ValueError for unknown conversion specifier '!b'")
+
 assert "{:,}".format(100) == "100"
 assert "{:,}".format(1024) == "1,024"
 assert "{:_}".format(65536) == "65_536"


### PR DESCRIPTION
<!--
Thanks for your contribution!
-->

One of checkbox below must be checked.
- [x] I did not use AI to write the code of this patch.
- [ ] This PR follows our [AI policy](https://github.com/RustPython/.github/blob/main/AI_POLICY.md)

## Summary

The issue - `str.format` is accepting `!b` as a format conversion specifier, though it doesn't exist in Python.

```python
{!b}".format(42)

# CPython, RustPython after this PR
# ValueError: Unknown conversion specifier b

# RustPython before this PR
# AttributeError: 'int' object has no attribute 'decode'
```

So it was trying to decode the value, e.g. `"{!b}".format(b"42")` in RustPython would previously result in `'42'`, not a `ValueError`.

To resolve this I've removed `Bytes` from `FormatConversion` enum in `format.rs` and dropped decoding code for this enum variant.

https://github.com/RustPython/RustPython/blob/cb7acec87d4c3e1e7f43b74f228656127008f523/crates/vm/src/format.rs#L156-L158

But since `cformat.rs` is defining `CFormatConversion` using `FormatConversion`, change needed to be propagated there too and it resulted in a bit of a refactor.

https://github.com/RustPython/RustPython/blob/cb7acec87d4c3e1e7f43b74f228656127008f523/crates/common/src/cformat.rs#L56

So I had to move `Bytes` to it's own variant in `CFormatType`, since it's no longer part of `CFormatConversion`.
Most of the diff in `vm/cformat.rs` is basically just dedent in `spec_format_bytes`, since we can't `match` by `conversion` anymore, since for strings and bytes need to have have the same handling.

But since I was already working on this area, I've also used this as an opportunity to make format parsing more consistent. Previously, `'b'` was parsed as `Bytes`, regardless whether it was parsed from string or bytes. Which is incorrect, since `%b` is only allowed on byte strings in CPython.

```python
# CPython, RustPython
"%b" % 42
# ValueError: unsupported format character 'b' (0x62) at index 
b"%b" % b"42"
# OK
```

And to accommodate this, `spec_format_string` in `vm/cformat.rs` had to hardcode `unsupported format character 'b' (0x62)` error for bytes specifier in the string.

In this PR I added a new enum, `CFormatContext`, so it allows to reject `'b'` during parsing. 
So for strings, parsing it automatically lands to `UnsupportedFormatChar`, 


---


I've added a new test in `extra_tests` to test regression when using `!b` in `str.format`.

`cformat` didn't needed any new tests, since the behavior was preserved and already covered by `test_format` tests.

https://github.com/RustPython/RustPython/blob/cb7acec87d4c3e1e7f43b74f228656127008f523/Lib/test/test_format.py#L300-L301




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved formatting behavior by distinguishing string and byte-string contexts.
  - Byte formatting now handles supported conversions consistently, including bytes-like values and buffers.
  - String formatting rejects the unsupported `!b` conversion with the appropriate error.
  - Removed legacy byte conversion handling from standard string formatting.

- **Tests**
  - Added regression coverage for invalid `!b` conversions in `str.format()`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->