### PR TITLE
interpolated strings: align f-string and t-string diagnostics with CPython

### DIFF
--- a/.cspell.dict/cpython.txt
+++ b/.cspell.dict/cpython.txt
@@ -189,6 +189,7 @@ parg
 pathconfig
 patma
 peepholer
+pegen
 phcount
 platstdlib
 ploc

--- a/Lib/test/test_fstring.py
+++ b/Lib/test/test_fstring.py
@@ -606,7 +606,6 @@ x = (
                              r"""f'{("x}'""",
                              ])
 
-    @unittest.expectedFailure  # TODO: RUSTPYTHON
     @unittest.skipIf(support.is_wasi, "exhausts limited stack on WASI")
     def test_mismatched_parens(self):
         self.assertAllRaise(SyntaxError, r"closing parenthesis '\}' "
@@ -737,7 +736,6 @@ x = (
                             ['''f'{3' f"}"''',  # can't concat to get a valid f-string
                              ])
 
-    @unittest.expectedFailure  # TODO: RUSTPYTHON
     def test_comments(self):
         # These aren't comments, since they're in strings.
         d = {'#': 'hash'}
@@ -931,7 +929,6 @@ x = (
                              "\xa0",
                              ])
 
-    @unittest.expectedFailure  # TODO: RUSTPYTHON
     def test_parens_in_expressions(self):
         self.assertEqual(f'{3,}', '(3,)')
 
@@ -1342,7 +1339,6 @@ x = (
 
         self.assertEqual(f'{0==1}', 'False')
 
-    @unittest.expectedFailure  # TODO: RUSTPYTHON
     def test_conversions(self):
         self.assertEqual(f'{3.14:10.10}', '      3.14')
         self.assertEqual(f'{1.25!s:10.10}', '1.25      ')
@@ -1413,7 +1409,6 @@ x = (
                              "del '' f''",
                              ])
 
-    @unittest.expectedFailure  # TODO: RUSTPYTHON
     def test_mismatched_braces(self):
         self.assertAllRaise(SyntaxError, "f-string: single '}' is not allowed",
                             ["f'{{}'",
@@ -1701,7 +1696,6 @@ x = (
         self.assertEqual(f'{(x:=10)}', '10')
         self.assertEqual(x, 10)
 
-    @unittest.expectedFailure  # TODO: RUSTPYTHON; AssertionError: "f-string: expecting '=', or '!', or ':', or '}'" does not match "invalid syntax (?, line 1)"
     def test_invalid_syntax_error_message(self):
         with self.assertRaisesRegex(SyntaxError,
                                     "f-string: expecting '=', or '!', or ':', or '}'"):
@@ -1755,7 +1749,7 @@ sdfsdfs{1+
         except SyntaxError as e:
             self.assertEqual(e.text, 'z = f"""')
             self.assertEqual(e.lineno, 3)
-    @unittest.expectedFailure  # TODO: RUSTPYTHON
+
     def test_syntax_error_after_debug(self):
         self.assertAllRaise(SyntaxError, "f-string: expecting a valid expression after '{'",
                             [

--- a/Lib/test/test_tstring.py
+++ b/Lib/test/test_tstring.py
@@ -150,7 +150,6 @@ class TestTString(unittest.TestCase, TStringBaseCase):
         t = tr"{path}\Documents"
         self.assertTStringEqual(t, ("", r"\Documents"), [(path, "path")])
 
-    @unittest.expectedFailure  # TODO: RUSTPYTHON; AssertionError: "can only concatenate string.templatelib.Template \(not "str"\) to string.templatelib.Template" does not match "can only concatenate Template (not 'str') to Template"
     def test_template_concatenation(self):
         # Test template + template
         t1 = t"Hello, "

--- a/Lib/test/test_tstring.py
+++ b/Lib/test/test_tstring.py
@@ -196,7 +196,6 @@ class TestTString(unittest.TestCase, TStringBaseCase):
         self.assertEqual(t_interp.conversion, None)
         self.assertEqual(t_interp.format_spec, "")
 
-    @unittest.expectedFailure  # TODO: RUSTPYTHON multiple instances of AssertionError
     def test_syntax_errors(self):
         for case, err in (
             ("t'", "unterminated t-string literal"),
@@ -231,7 +230,6 @@ class TestTString(unittest.TestCase, TStringBaseCase):
         with self.assertRaises(NameError):
             eval("t'Hello, {name}'")
 
-    @unittest.expectedFailure  # TODO: RUSTPYTHON
     def test_literal_concatenation(self):
         # Test concatenation of t-string literals
         t = t"Hello, " t"world"

--- a/crates/compiler/src/lib.rs
+++ b/crates/compiler/src/lib.rs
@@ -3882,24 +3882,10 @@ fn unterminated_string_error(source: &str) -> Option<CpythonDiagnostic> {
                     let c = bytes[index];
                     if c == b'\n' {
                         if quote_size == 1 {
-                            if let Some(error) = unclosed_replacement_field_error(
-                                bytes,
-                                start,
-                                start + quote_size,
-                                index,
-                            ) {
-                                return Some(error);
-                            }
-                            return Some(CpythonDiagnostic::new(
-                                unterminated_string_message(
-                                    line,
-                                    false,
-                                    has_escaped_quote,
-                                    interpolated_string_prefix(bytes, start),
-                                ),
-                                start,
-                                start,
-                            ));
+                            // A single-quoted literal cannot span a line, so this is the same
+                            // "the literal never ended" case as running out of source; CPython
+                            // spells the two as one condition in lexer.c too.
+                            break;
                         }
                         line += 1;
                         index += 1;

--- a/crates/compiler/src/lib.rs
+++ b/crates/compiler/src/lib.rs
@@ -229,6 +229,7 @@ fn cpython_parse_diagnostic_override(
     source_error!(invalid_legacy_statement_error(source_text));
     source_error!(non_printable_character_error(source_text));
     source_error!(invalid_interpolated_string_error(source_text));
+    source_error!(mixed_tstring_literal_error(error, source_text));
 
     if let Some((message, start, end, unclosed)) = bracket_syntax_error(source_text) {
         return Some(
@@ -3828,8 +3829,21 @@ fn unterminated_string_error(source: &str) -> Option<(String, usize, usize)> {
                     let c = bytes[index];
                     if c == b'\n' {
                         if quote_size == 1 {
+                            if let Some(error) = unclosed_replacement_field_error(
+                                bytes,
+                                start,
+                                start + quote_size,
+                                index,
+                            ) {
+                                return Some(error);
+                            }
                             return Some((
-                                unterminated_string_message(line, false, has_escaped_quote),
+                                unterminated_string_message(
+                                    line,
+                                    false,
+                                    has_escaped_quote,
+                                    interpolated_string_prefix(bytes, start),
+                                ),
                                 start,
                                 start,
                             ));
@@ -3861,12 +3875,18 @@ fn unterminated_string_error(source: &str) -> Option<(String, usize, usize)> {
                     }
                 }
                 if !closed {
+                    if let Some(error) =
+                        unclosed_replacement_field_error(bytes, start, start + quote_size, index)
+                    {
+                        return Some(error);
+                    }
                     let detected_line = if quote_size == 3 { line } else { start_line };
                     return Some((
                         unterminated_string_message(
                             detected_line,
                             quote_size == 3,
                             has_escaped_quote,
+                            interpolated_string_prefix(bytes, start),
                         ),
                         start,
                         start,
@@ -3909,6 +3929,81 @@ fn invalid_interpolated_string_error(source: &str) -> Option<(String, usize, usi
                     invalid_replacement_field_error(bytes, content_start, content_end, prefix)
                 {
                     return Some(error);
+                }
+                index = skip_quoted_string(bytes, index);
+            }
+            _ => index += 1,
+        }
+    }
+    None
+}
+
+/// Whether the literal opened at `quote` carries a `b` in its prefix.
+fn is_bytes_literal(bytes: &[u8], quote: usize) -> bool {
+    let mut start = quote;
+    while quote - start < 2
+        && start > 0
+        && matches!(
+            bytes[start - 1].to_ascii_lowercase(),
+            b'r' | b'b' | b'u' | b'f' | b't'
+        )
+    {
+        start -= 1;
+    }
+    if start > 0 && is_ascii_identifier_char(bytes[start - 1]) {
+        return false;
+    }
+    bytes[start..quote]
+        .iter()
+        .any(|byte| byte.eq_ignore_ascii_case(&b'b'))
+}
+
+/// Which of CPython's two messages a mixed literal concatenation gets. Ruff reports only the
+/// bytes/non-bytes mix, so `t"x" b"y"` arrives here as a bytes error where CPython names the
+/// t-string, and this scanner owns the choice between them.
+///
+/// CPython's `invalid_string_tstring_concat` is an `invalid_` rule, reached only on the error
+/// pass, and the `strings` rule tries `(fstring|string)+` first. That alternative consumes the
+/// concatenation's leading run of non-t-string literals, so a bytes/non-bytes mix among *those*
+/// raises from `_PyPegen_concatenate_strings` on the first pass and the t-string rule never runs.
+/// The bytes message therefore keeps precedence for `"a" b"b" t"c"` but not for `t"x" b"y"`.
+fn mixed_tstring_literal_error(
+    error: &parser::ParseError,
+    source: &str,
+) -> Option<(String, usize, usize)> {
+    let parser::ParseErrorType::OtherError(message) = &error.error else {
+        return None;
+    };
+    if !message.eq_ignore_ascii_case("bytes literal cannot be mixed with non-bytes literals") {
+        return None;
+    }
+
+    let start = error.location.start().to_usize();
+    let end = error.location.end().to_usize();
+    let bytes = source.as_bytes();
+    if end > bytes.len() {
+        return None;
+    }
+
+    let mut index = start;
+    let (mut bytes_seen, mut nonbytes_seen) = (false, false);
+    while index < end {
+        match bytes[index] {
+            b'\'' | b'"' => {
+                if interpolated_string_prefix(bytes, index) == Some("t-string") {
+                    let message = if bytes_seen && nonbytes_seen {
+                        // Reported here rather than left to ruff's error so that the scanners
+                        // further down the chain cannot claim the concatenation instead.
+                        "cannot mix bytes and nonbytes literals"
+                    } else {
+                        "cannot mix t-string literals with string or bytes literals"
+                    };
+                    return Some((message.to_owned(), start, end));
+                }
+                if is_bytes_literal(bytes, index) {
+                    bytes_seen = true;
+                } else {
+                    nonbytes_seen = true;
                 }
                 index = skip_quoted_string(bytes, index);
             }
@@ -4028,10 +4123,12 @@ fn invalid_replacement_field_error(
             b'{' if bytes.get(index + 1) == Some(&b'{') => index += 2,
             b'}' if bytes.get(index + 1) == Some(&b'}') => index += 2,
             b'{' => {
-                if let Some(error) = replacement_field_error(bytes, index, end, prefix) {
+                if let Some(error) = replacement_field_error(bytes, index, end, prefix, 0) {
                     return Some(error);
                 }
-                index += 1;
+                // Resume in the literal text. Inside the field a `#` starts a comment and a `{`
+                // opens no new field, so walking on byte by byte would misread both.
+                index = replacement_field_end(bytes, index, end).unwrap_or(end);
             }
             _ => index += 1,
         }
@@ -4039,44 +4136,219 @@ fn invalid_replacement_field_error(
     None
 }
 
+/// Position just past a replacement field's closing brace. The expression part is code, where a
+/// comment runs to the end of the line; past the separator only nested fields nest.
+fn replacement_field_end(bytes: &[u8], open: usize, end: usize) -> Option<usize> {
+    let expr_start = skip_replacement_field_trivia(bytes, open + 1, end);
+    let separator = replacement_field_separator(bytes, expr_start, end)?;
+    if bytes[separator] == b'}' {
+        return Some(separator + 1);
+    }
+    replacement_field_closing_brace(bytes, separator + 1, end).map(|brace| brace + 1)
+}
+
+/// The one-based line holding `offset`. Counted on demand: these scanners only run once the
+/// source has failed to parse, and tracking a line through the spans they skip would have to
+/// re-scan them anyway.
+fn line_of_offset(bytes: &[u8], offset: usize) -> usize {
+    1 + bytes[..offset]
+        .iter()
+        .filter(|byte| **byte == b'\n')
+        .count()
+}
+
+/// Brackets opened in a replacement field's expression must close before the field does. CPython
+/// words these exactly as it does for brackets anywhere else, except that a closer with nothing
+/// open is attributed to the literal. `start..end` must cover only the expression: a format spec
+/// is plain text, so a bracket there opens nothing.
+fn replacement_field_bracket_error(
+    bytes: &[u8],
+    start: usize,
+    end: usize,
+    prefix: &str,
+) -> Option<(String, usize, usize)> {
+    // Each entry carries where its bracket opened, so a mismatch can name that line.
+    let mut stack: Vec<(u8, usize)> = Vec::new();
+    let mut index = start;
+    while index < end {
+        let byte = bytes[index];
+        match byte {
+            b'\'' | b'"' => {
+                index = skip_quoted_string(bytes, index);
+                continue;
+            }
+            b'#' => {
+                index = skip_replacement_field_comment(bytes, index, end);
+                continue;
+            }
+            b'(' | b'[' | b'{' => stack.push((byte, index)),
+            b')' | b']' | b'}' => {
+                let expected = expected_opening_bracket(byte as char) as u8;
+                match stack.last() {
+                    // The field's own closing brace: everything inside it balanced.
+                    None if byte == b'}' => return None,
+                    None => {
+                        return Some((
+                            format!("{prefix}: unmatched '{}'", byte as char),
+                            index,
+                            index + 1,
+                        ));
+                    }
+                    Some(&(opening, _)) if opening == expected => {
+                        stack.pop();
+                    }
+                    Some(&(opening, opened_at)) => {
+                        // CPython names the opening line only when it is not the closing one,
+                        // comparing `parenlinenostack[level]` against the current `lineno`.
+                        let opening_line = line_of_offset(bytes, opened_at);
+                        let suffix = if opening_line == line_of_offset(bytes, index) {
+                            String::new()
+                        } else {
+                            format!(" on line {opening_line}")
+                        };
+                        return Some((
+                            format!(
+                                "closing parenthesis '{}' does not match opening parenthesis '{}'{suffix}",
+                                byte as char, opening as char
+                            ),
+                            index,
+                            index + 1,
+                        ));
+                    }
+                }
+            }
+            _ => {}
+        }
+        index += 1;
+    }
+    None
+}
+
+/// A `#` in a replacement field's expression starts a comment. When no newline follows it before
+/// the end of the literal, the comment swallows the closing brace and the field can never close.
+/// `start..end` must cover only the expression: `#` is an ordinary character in a format spec,
+/// where it selects the alternate form.
+fn replacement_field_comment_error(
+    bytes: &[u8],
+    open: usize,
+    start: usize,
+    end: usize,
+    literal_end: usize,
+) -> Option<(String, usize, usize)> {
+    let mut index = start;
+    while index < end {
+        match bytes[index] {
+            b'\'' | b'"' => {
+                index = skip_quoted_string(bytes, index);
+                continue;
+            }
+            b'#' => {
+                if !bytes[index..literal_end].contains(&b'\n') {
+                    return Some(("'{' was never closed".to_owned(), open, open + 1));
+                }
+                index = skip_replacement_field_comment(bytes, index, end);
+                continue;
+            }
+            _ => index += 1,
+        }
+    }
+    None
+}
+
+/// Advances past a comment, stopping on the newline that ends it.
+fn skip_replacement_field_comment(bytes: &[u8], mut index: usize, end: usize) -> usize {
+    while index < end && bytes[index] != b'\n' {
+        index += 1;
+    }
+    index
+}
+
+/// Whitespace and comments may both precede a replacement field's expression.
+fn skip_replacement_field_trivia(bytes: &[u8], mut index: usize, end: usize) -> usize {
+    loop {
+        index = skip_ascii_whitespace(bytes, index, end);
+        if index < end && bytes[index] == b'#' {
+            index = skip_replacement_field_comment(bytes, index, end);
+            continue;
+        }
+        return index;
+    }
+}
+
+/// Bounds the mutual recursion between a replacement field and the format spec it contains,
+/// so that pathologically nested input cannot exhaust the stack.
+const MAX_REPLACEMENT_FIELD_DEPTH: usize = 32;
+
 fn replacement_field_error(
     bytes: &[u8],
     open: usize,
     end: usize,
     prefix: &str,
+    depth: usize,
 ) -> Option<(String, usize, usize)> {
-    let expr_start = skip_ascii_whitespace(bytes, open + 1, end);
-    if let Some(backslash) = replacement_field_line_continuation(bytes, expr_start, end) {
+    let expr_start = skip_replacement_field_trivia(bytes, open + 1, end);
+
+    // The expression runs up to the field's first top-level `=`, `!`, `:` or `}`. Everything past
+    // it is a conversion or a format spec, which are text rather than code, so the checks that
+    // treat the field as code have to stop here.
+    let separator = replacement_field_separator(bytes, expr_start, end);
+    let expr_end = separator.unwrap_or(end);
+
+    if let Some(backslash) = replacement_field_line_continuation(bytes, expr_start, expr_end) {
         return Some((
             "unexpected character after line continuation character".to_owned(),
             backslash + 1,
             (backslash + 2).min(end),
         ));
     }
-    if let Some(quote) = unterminated_string_in_replacement_field(bytes, expr_start, end) {
+    if let Some(quote) = unterminated_string_in_replacement_field(bytes, expr_start, expr_end) {
         return Some((
-            unterminated_string_message(1, false, false),
+            unterminated_string_message(1, false, false, None),
             quote,
             quote + 1,
         ));
     }
-    match bytes.get(expr_start).copied() {
-        Some(marker @ (b'=' | b'!' | b':' | b'}')) => {
-            return Some((
-                format!(
-                    "{prefix}: valid expression required before '{}'",
-                    marker as char
-                ),
-                expr_start,
-                expr_start + 1,
-            ));
-        }
-        Some(_) => {}
-        None => {
+    // Brackets are reported ahead of everything else in the field, and a comment that swallows
+    // the closing brace ahead of the expression itself. The comment scan starts at the brace
+    // because a comment may also sit between it and the expression.
+    if let Some(error) = replacement_field_bracket_error(bytes, expr_start, expr_end, prefix) {
+        return Some(error);
+    }
+    if let Some(error) = replacement_field_comment_error(bytes, open, open + 1, expr_end, end) {
+        return Some(error);
+    }
+
+    // Nothing follows `{` at all, so the field simply never closed. CPython asks for the
+    // brace here; an expression that merely fails to start is reported further down.
+    if expr_start >= end {
+        return Some((format!("{prefix}: expecting '}}'"), open, open + 1));
+    }
+
+    if let marker @ (b'=' | b'!' | b':' | b'}') = bytes[expr_start]
+        && is_replacement_field_marker(bytes, expr_start)
+    {
+        return Some((
+            format!(
+                "{prefix}: valid expression required before '{}'",
+                marker as char
+            ),
+            expr_start,
+            expr_start + 1,
+        ));
+    }
+
+    // A `{` display is a valid expression, but only if something can follow it. CPython
+    // reports the inner brace when it cannot, as in `f'{3:{{>10}'`.
+    if bytes[expr_start] == b'{' {
+        let inner = skip_ascii_whitespace(bytes, expr_start + 1, end);
+        if inner < end
+            && bytes[inner] != b'}'
+            && invalid_replacement_expression_start(bytes, inner, end)
+        {
             return Some((
                 format!("{prefix}: expecting a valid expression after '{{'"),
-                open,
-                open + 1,
+                expr_start,
+                expr_start + 1,
             ));
         }
     }
@@ -4097,9 +4369,31 @@ fn replacement_field_error(
         ));
     }
 
-    let Some(separator) = replacement_field_separator(bytes, expr_start, end) else {
+    // The expression started fine but ran into a character that cannot continue it. CPython
+    // points at that character and lists the separators it wanted instead.
+    if let Some(stray) = replacement_expression_stray_character(bytes, expr_start, expr_end) {
+        return Some((
+            format!("{prefix}: expecting '=', or '!', or ':', or '}}'"),
+            stray,
+            stray + 1,
+        ));
+    }
+
+    let Some(separator) = separator else {
         return Some((format!("{prefix}: expecting '}}'"), open, open + 1));
     };
+
+    // Only now that the field is known to close. A stray character above is a finished token
+    // the parser rejects on lookahead, but a dangling operator makes it ask for one more, and
+    // producing that token runs into the literal's closing quote: lexer.c then answers from
+    // `INSIDE_FSTRING(tok)` with "%c-string: expecting '}'" before any `invalid_` rule is tried.
+    if let Some(operator) = dangling_operator(bytes, expr_start, expr_end) {
+        return Some((
+            format!("{prefix}: expecting '=', or '!', or ':', or '}}'"),
+            operator,
+            operator + 1,
+        ));
+    }
 
     if bytes[separator] == b':'
         && replacement_expression_has_parse_error(bytes, expr_start, separator)
@@ -4108,9 +4402,9 @@ fn replacement_field_error(
     }
 
     match bytes[separator] {
-        b'=' => invalid_debug_expression_error(bytes, separator, end, prefix),
-        b'!' => invalid_conversion_error(bytes, separator, end, prefix),
-        b':' => invalid_format_spec_error(bytes, separator, end, prefix),
+        b'=' => invalid_debug_expression_error(bytes, separator, end, prefix, depth),
+        b'!' => invalid_conversion_error(bytes, separator, end, prefix, depth),
+        b':' => invalid_format_spec_error(bytes, separator, end, prefix, depth),
         b'}' => None,
         _ => unreachable!(),
     }
@@ -4125,6 +4419,7 @@ fn replacement_field_line_continuation(
     while index < end {
         match bytes[index] {
             b'\'' | b'"' => index = skip_quoted_string(bytes, index),
+            b'#' => index = skip_replacement_field_comment(bytes, index, end),
             b'\\' => return Some(index),
             b'(' | b'[' | b'{' => {
                 level += 1;
@@ -4134,7 +4429,11 @@ fn replacement_field_line_continuation(
                 level -= 1;
                 index += 1;
             }
-            b'=' | b'!' | b':' | b'}' if level == 0 => return None,
+            b'=' | b'!' | b':' | b'}'
+                if level == 0 && is_replacement_field_marker(bytes, index) =>
+            {
+                return None;
+            }
             _ => index += 1,
         }
     }
@@ -4155,6 +4454,7 @@ fn unterminated_string_in_replacement_field(
                 }
                 index = string_end;
             }
+            b'#' => index = skip_replacement_field_comment(bytes, index, end),
             _ => index += 1,
         }
     }
@@ -4173,10 +4473,22 @@ fn invalid_replacement_expression_start(bytes: &[u8], index: usize, end: usize) 
         return true;
     }
 
+    // A leading `.` is Ellipsis or a float without an integer part, both of which start a
+    // perfectly good expression.
+    if bytes[index] == b'.'
+        && (bytes[index..end].starts_with(b"...")
+            || bytes
+                .get(index + 1)
+                .is_some_and(|byte| byte.is_ascii_digit()))
+    {
+        return false;
+    }
+
     if matches!(
         bytes[index],
-        b'.' | b',' | b'*' | b'/' | b'%' | b'&' | b'|' | b'^' | b'<' | b'>' | b'@'
-    ) {
+        b'.' | b',' | b'*' | b'/' | b'%' | b'&' | b'|' | b'^' | b'<' | b'>' | b'@' | b'=' | b'!'
+    ) || is_stray_in_replacement_expression(bytes[index])
+    {
         return true;
     }
 
@@ -4188,6 +4500,11 @@ fn invalid_replacement_expression_start(bytes: &[u8], index: usize, end: usize) 
                 || byte.is_ascii_alphabetic()
                 || byte.is_ascii_digit()
                 || matches!(*byte, b'\'' | b'"' | b'(' | b'[' | b'{')
+                // `-.5` is a signed float.
+                || (*byte == b'.'
+                    && bytes
+                        .get(operand + 1)
+                        .is_some_and(|next| next.is_ascii_digit()))
         });
     }
 
@@ -4205,11 +4522,48 @@ fn invalid_replacement_expression_start(bytes: &[u8], index: usize, end: usize) 
     .any(|keyword| starts_identifier(bytes, index, keyword))
 }
 
+/// A top-level `=` or `!` marks a debug specifier or a conversion only when it is not part of a
+/// longer operator. CPython's tokenizer consumes `==`, `!=`, `<=`, `+=` and the rest as single
+/// tokens before it ever considers the debug marker, so those must not end the expression here.
+fn is_replacement_field_marker(bytes: &[u8], index: usize) -> bool {
+    match bytes[index] {
+        b'=' => {
+            if bytes.get(index + 1) == Some(&b'=') {
+                return false;
+            }
+            !index
+                .checked_sub(1)
+                .and_then(|previous| bytes.get(previous))
+                .is_some_and(|byte| {
+                    matches!(
+                        byte,
+                        b'=' | b'!'
+                            | b'<'
+                            | b'>'
+                            | b'+'
+                            | b'-'
+                            | b'*'
+                            | b'/'
+                            | b'%'
+                            | b'&'
+                            | b'|'
+                            | b'^'
+                            | b'@'
+                            | b':'
+                    )
+                })
+        }
+        b'!' => bytes.get(index + 1) != Some(&b'='),
+        _ => true,
+    }
+}
+
 fn replacement_field_separator(bytes: &[u8], mut index: usize, end: usize) -> Option<usize> {
     let mut level = 0usize;
     while index < end {
         match bytes[index] {
             b'\'' | b'"' => index = skip_quoted_string(bytes, index),
+            b'#' => index = skip_replacement_field_comment(bytes, index, end),
             b'(' | b'[' | b'{' => {
                 level += 1;
                 index += 1;
@@ -4218,11 +4572,146 @@ fn replacement_field_separator(bytes: &[u8], mut index: usize, end: usize) -> Op
                 level -= 1;
                 index += 1;
             }
-            b'=' | b'!' | b':' | b'}' if level == 0 => return Some(index),
+            b'=' | b'!' | b':' | b'}'
+                if level == 0 && is_replacement_field_marker(bytes, index) =>
+            {
+                return Some(index);
+            }
             _ => index += 1,
         }
     }
     None
+}
+
+/// Characters that can neither start nor continue a replacement field expression. CPython's
+/// interpolated-string tokenizer stops at them and asks for a separator instead.
+const fn is_stray_in_replacement_expression(byte: u8) -> bool {
+    matches!(byte, b';' | b'$' | b'?' | b'`')
+}
+
+fn replacement_expression_stray_character(
+    bytes: &[u8],
+    mut index: usize,
+    end: usize,
+) -> Option<usize> {
+    while index < end {
+        match bytes[index] {
+            b'\'' | b'"' => index = skip_quoted_string(bytes, index),
+            b'#' => index = skip_replacement_field_comment(bytes, index, end),
+            byte if is_stray_in_replacement_expression(byte) => return Some(index),
+            _ => index += 1,
+        }
+    }
+    None
+}
+
+/// Characters that make up an operator which cannot end an expression.
+const fn is_dangling_operator_byte(byte: u8) -> bool {
+    matches!(
+        byte,
+        b'+' | b'-'
+            | b'*'
+            | b'/'
+            | b'%'
+            | b'@'
+            | b'|'
+            | b'&'
+            | b'^'
+            | b'~'
+            | b'<'
+            | b'>'
+            | b'='
+            | b'!'
+            | b'.'
+    )
+}
+
+/// The identifier that ends just before `word`, skipping the whitespace between them.
+fn preceding_keyword(bytes: &[u8], start: usize, word: usize) -> Option<(usize, &[u8])> {
+    let mut cursor = word;
+    while cursor > start && matches!(bytes[cursor - 1], b' ' | b'\t' | b'\r' | b'\n' | 0x0c) {
+        cursor -= 1;
+    }
+    let stop = cursor;
+    while cursor > start && is_ascii_identifier_char(bytes[cursor - 1]) {
+        cursor -= 1;
+    }
+    (cursor < stop).then(|| (cursor, &bytes[cursor..stop]))
+}
+
+/// A replacement field expression cannot end on an operator that still wants an operand.
+/// CPython's tokenizer then reaches the field brace with the expression unfinished and asks for
+/// a separator, pointing at the operator that left it that way. Returns that operator's start.
+fn dangling_operator(bytes: &[u8], start: usize, end: usize) -> Option<usize> {
+    // The region cannot be read backwards: the newline that ends a comment is whitespace, so
+    // trimming from `end` would step into the comment body. Walk forward instead and keep the
+    // position just past the last byte that is really part of the expression.
+    let mut index = start;
+    let mut tail = start;
+    while index < end {
+        match bytes[index] {
+            b'\'' | b'"' => {
+                index = skip_quoted_string(bytes, index).min(end);
+                tail = index;
+            }
+            b'#' => index = skip_replacement_field_comment(bytes, index, end),
+            b' ' | b'\t' | b'\r' | b'\n' | 0x0c => index += 1,
+            _ => {
+                index += 1;
+                tail = index;
+            }
+        }
+    }
+    if tail == start {
+        return None;
+    }
+
+    // A trailing keyword operator reads back as an identifier.
+    if is_ascii_identifier_char(bytes[tail - 1]) {
+        let mut word = tail;
+        while word > start && is_ascii_identifier_char(bytes[word - 1]) {
+            word -= 1;
+        }
+        if ![
+            b"and".as_slice(),
+            b"or".as_slice(),
+            b"not".as_slice(),
+            b"in".as_slice(),
+            b"is".as_slice(),
+            b"if".as_slice(),
+            b"for".as_slice(),
+        ]
+        .iter()
+        .any(|keyword| &bytes[word..tail] == *keyword)
+        {
+            return None;
+        }
+        // `is not` and `not in` are single operators, and CPython points at their first word.
+        let previous = preceding_keyword(bytes, start, word);
+        return Some(match (previous, &bytes[word..tail]) {
+            (Some((at, b"is")), b"not") | (Some((at, b"not")), b"in") => at,
+            _ => word,
+        });
+    }
+
+    if !is_dangling_operator_byte(bytes[tail - 1]) {
+        return None;
+    }
+    let mut token = tail;
+    while token > start && is_dangling_operator_byte(bytes[token - 1]) {
+        token -= 1;
+    }
+
+    // `1.` is a float: that dot finishes the literal rather than dangling.
+    if bytes[token..tail] == *b"." && token > start && bytes[token - 1].is_ascii_digit() {
+        return None;
+    }
+    // `...` is Ellipsis, so consume whole triples: a leftover dot is what dangles.
+    if bytes[token..tail].iter().all(|byte| *byte == b'.') {
+        let leftover = (tail - token) % 3;
+        return (leftover != 0).then(|| tail - leftover);
+    }
+    Some(token)
 }
 
 fn invalid_debug_expression_error(
@@ -4230,10 +4719,19 @@ fn invalid_debug_expression_error(
     equals: usize,
     end: usize,
     prefix: &str,
+    depth: usize,
 ) -> Option<(String, usize, usize)> {
     let next = equals + 1;
-    if next >= end || matches!(bytes[next], b'!' | b':' | b'}') {
+    if next >= end {
         return None;
+    }
+    // A conversion or format spec may follow `=`, and is validated exactly as it would be
+    // when following the expression directly.
+    match bytes[next] {
+        b'!' => return invalid_conversion_error(bytes, next, end, prefix, depth),
+        b':' => return invalid_format_spec_error(bytes, next, end, prefix, depth),
+        b'}' => return None,
+        _ => {}
     }
     Some((
         format!("{prefix}: expecting '!', or ':', or '}}'"),
@@ -4247,6 +4745,7 @@ fn invalid_conversion_error(
     bang: usize,
     end: usize,
     prefix: &str,
+    depth: usize,
 ) -> Option<(String, usize, usize)> {
     let next = bang + 1;
     if next >= end {
@@ -4274,6 +4773,22 @@ fn invalid_conversion_error(
         ));
     }
 
+    // A non-ASCII character is still a conversion character as far as CPython is concerned,
+    // so it gets named in the message like any other invalid one.
+    if bytes[next] >= 0x80
+        && let Some(character) = ::core::str::from_utf8(&bytes[next..end])
+            .ok()
+            .and_then(|text| text.chars().next())
+    {
+        return Some((
+            format!(
+                "{prefix}: invalid conversion character '{character}': expected 's', 'r', or 'a'"
+            ),
+            next,
+            next + character.len_utf8(),
+        ));
+    }
+
     if !bytes[next].is_ascii_alphabetic() && bytes[next] != b'_' {
         return Some((
             format!("{prefix}: invalid conversion character"),
@@ -4295,8 +4810,14 @@ fn invalid_conversion_error(
         ));
     }
 
-    if conversion_end >= end || matches!(bytes[conversion_end], b':' | b'}') {
+    if conversion_end >= end {
         return None;
+    }
+
+    match bytes[conversion_end] {
+        b':' => return invalid_format_spec_error(bytes, conversion_end, end, prefix, depth),
+        b'}' => return None,
+        _ => {}
     }
 
     Some((
@@ -4311,9 +4832,31 @@ fn invalid_format_spec_error(
     colon: usize,
     end: usize,
     prefix: &str,
+    depth: usize,
 ) -> Option<(String, usize, usize)> {
-    if replacement_field_closing_brace(bytes, colon + 1, end).is_some() {
-        return None;
+    // Unlike literal text, a format spec has no `{{` escape: every `{` opens a nested
+    // replacement field, so the outer scanner cannot validate these for us.
+    let mut index = colon + 1;
+    while index < end {
+        match bytes[index] {
+            b'\'' | b'"' => index = skip_quoted_string(bytes, index),
+            b'{' => {
+                if depth < MAX_REPLACEMENT_FIELD_DEPTH
+                    && let Some(error) =
+                        replacement_field_error(bytes, index, end, prefix, depth + 1)
+                {
+                    return Some(error);
+                }
+                // Resume after the nested field. Walking into it again from every enclosing
+                // spec would re-scan the same bytes once per level, which costs O(2^depth).
+                let Some(after) = replacement_field_end(bytes, index, end) else {
+                    break;
+                };
+                index = after;
+            }
+            b'}' => return None,
+            _ => index += 1,
+        }
     }
     Some((
         format!("{prefix}: expecting '}}', or format specs"),
@@ -4565,19 +5108,94 @@ fn adjacent_atom_end(bytes: &[u8], index: usize) -> Option<usize> {
     }
 }
 
+/// An f-string or t-string that runs off the end with a replacement field still open reports
+/// the brace rather than the missing quote, matching CPython — but only while the tokenizer is
+/// still reading the field's *expression*. Past the field's own `:` it is emitting FSTRING_MIDDLE
+/// again, so running out of input there is an unterminated literal like any other, and
+/// `f'{a:>5` gets the quote message where `f'{a` gets the brace.
+fn unclosed_replacement_field_error(
+    bytes: &[u8],
+    quote_start: usize,
+    content_start: usize,
+    content_end: usize,
+) -> Option<(String, usize, usize)> {
+    interpolated_string_prefix(bytes, quote_start)?;
+
+    // One entry per unclosed delimiter: its position, its opening character, and — for a brace —
+    // whether that field has reached its format spec. Brackets and quotes are only delimiters
+    // once a field is open; in the literal's text they are ordinary characters. A brace nested
+    // in an expression is a set or dict display rather than a field, but it nests all the same.
+    let mut open: Vec<(usize, u8, bool)> = Vec::new();
+    let mut index = content_start;
+    while index < content_end {
+        let inside_expression = matches!(open.last(), Some((_, b'{', false)));
+        match bytes[index] {
+            // `{{` and `}}` escape only in literal text, which is where a brace at depth zero is.
+            b'{' if open.is_empty() && bytes.get(index + 1) == Some(&b'{') => index += 2,
+            b'}' if open.is_empty() && bytes.get(index + 1) == Some(&b'}') => index += 2,
+            b'{' => {
+                open.push((index, b'{', false));
+                index += 1;
+            }
+            b'}' => {
+                open.pop();
+                index += 1;
+            }
+            byte @ (b'(' | b'[') if !open.is_empty() => {
+                open.push((index, byte, false));
+                index += 1;
+            }
+            b')' | b']' if !open.is_empty() => {
+                open.pop();
+                index += 1;
+            }
+            // Only the field's own `:` opens a format spec — one in a slice, a display or a
+            // lambda belongs to whatever bracket encloses it.
+            b':' if inside_expression => {
+                open.last_mut().expect("a brace is open").2 = true;
+                index += 1;
+            }
+            b'\'' | b'"' if !open.is_empty() => {
+                index = skip_quoted_string(bytes, index).min(content_end);
+            }
+            b'#' if inside_expression => {
+                index = skip_replacement_field_comment(bytes, index, content_end);
+            }
+            _ => index += 1,
+        }
+    }
+
+    // CPython names the innermost unclosed delimiter, so a bracket opened inside the expression
+    // takes the message from the field that encloses it.
+    let (position, opener, in_format_spec) = *open.last()?;
+    (!in_format_spec).then(|| {
+        (
+            format!("'{}' was never closed", opener as char),
+            position,
+            position + 1,
+        )
+    })
+}
+
 fn unterminated_string_message(
     detected_line: usize,
     triple: bool,
     has_escaped_quote: bool,
+    prefix: Option<&str>,
 ) -> String {
+    // CPython names the literal kind, e.g. "unterminated f-string literal".
+    let kind = prefix.unwrap_or("string");
     if triple {
-        format!("unterminated triple-quoted string literal (detected at line {detected_line})")
-    } else if has_escaped_quote {
+        format!("unterminated triple-quoted {kind} literal (detected at line {detected_line})")
+    // The escaped-quote hint belongs to the plain-string branch of CPython's tokenizer alone.
+    // Its interpolated branch has only the two forms above and below, so pairing the hint with
+    // a prefix would invent a message CPython never emits.
+    } else if has_escaped_quote && prefix.is_none() {
         format!(
-            "unterminated string literal (detected at line {detected_line}); perhaps you escaped the end quote?"
+            "unterminated {kind} literal (detected at line {detected_line}); perhaps you escaped the end quote?"
         )
     } else {
-        format!("unterminated string literal (detected at line {detected_line})")
+        format!("unterminated {kind} literal (detected at line {detected_line})")
     }
 }
 
@@ -5732,6 +6350,269 @@ mod tests {
         let code = "x = 'abc'";
         let compiled = compile(code, Mode::Single, "<>", CompileOpts::default());
         dbg!(compiled.expect("compile error"));
+    }
+
+    #[test]
+    fn interpolated_string_diagnostics_match_cpython() {
+        for (source, expected) in [
+            ("f'{'", "f-string: expecting '}'"),
+            ("t'{'", "t-string: expecting '}'"),
+            (
+                "f'{1=}{;'",
+                "f-string: expecting a valid expression after '{'",
+            ),
+            (
+                "t'{x;y}'",
+                "t-string: expecting '=', or '!', or ':', or '}'",
+            ),
+            ("t'{x!s:'", "t-string: expecting '}', or format specs"),
+            ("t'{x=!}'", "t-string: missing conversion character"),
+            (
+                "t'{x:{;}}'",
+                "t-string: expecting a valid expression after '{'",
+            ),
+            ("f'{1#}'", "'{' was never closed"),
+            ("t'{", "'{' was never closed"),
+            // A field is only "never closed" while the tokenizer is reading its expression.
+            // Past the field's own `:` it emits literal text again, so the quote is what is
+            // missing — and a `:` in a slice, a display or a lambda is not the field's own.
+            ("f'{a", "'{' was never closed"),
+            ("f'{a!r", "'{' was never closed"),
+            ("f'{a=", "'{' was never closed"),
+            ("f'{ {1:2}", "'{' was never closed"),
+            ("f'{d[1:2]", "'{' was never closed"),
+            ("f'{(lambda x: x)", "'{' was never closed"),
+            ("f'{a:{b:{c", "'{' was never closed"),
+            ("f'{a:", "unterminated f-string literal"),
+            ("f'{a:>5", "unterminated f-string literal"),
+            ("f'{a!r:", "unterminated f-string literal"),
+            ("f'{a}{b:", "unterminated f-string literal"),
+            ("f'{a:{b}c", "unterminated f-string literal"),
+            ("t'{a:>5", "unterminated t-string literal"),
+            ("f'''{a:>5", "unterminated triple-quoted f-string literal"),
+            // CPython names the innermost unclosed delimiter, not the field around it.
+            ("f'{a[", "'[' was never closed"),
+            ("f'{(a", "'(' was never closed"),
+            ("f'{)#}'", "f-string: unmatched ')'"),
+            (
+                "f'{a[4)}'",
+                "closing parenthesis ')' does not match opening parenthesis '['",
+            ),
+            ("t'", "unterminated t-string literal (detected at line 1)"),
+            (
+                "t'''",
+                "unterminated triple-quoted t-string literal (detected at line 1)",
+            ),
+            (
+                "t\"x\" b\"y\"",
+                "cannot mix t-string literals with string or bytes literals",
+            ),
+            (
+                "b\"x\" t\"y\"",
+                "cannot mix t-string literals with string or bytes literals",
+            ),
+            // The literals ahead of the first t-string already mix, so CPython's first pass
+            // raises from `_PyPegen_concatenate_strings` before the t-string rule is reached.
+            (
+                "\"a\" b\"b\" t\"c\"",
+                "cannot mix bytes and nonbytes literals",
+            ),
+            // A dangling operator ends the expression before a separator could follow.
+            (
+                "f'{a==}'",
+                "f-string: expecting '=', or '!', or ':', or '}'",
+            ),
+            (
+                "f'{a and}'",
+                "f-string: expecting '=', or '!', or ':', or '}'",
+            ),
+            (
+                "f'{a is not}'",
+                "f-string: expecting '=', or '!', or ':', or '}'",
+            ),
+            (
+                "f'{a.b.}'",
+                "f-string: expecting '=', or '!', or ':', or '}'",
+            ),
+            ("t'{a~}'", "t-string: expecting '=', or '!', or ':', or '}'"),
+            // A doubled `=` or `!` opens no debug specifier and no conversion, so the field has
+            // no expression at all rather than an empty one before a marker.
+            (
+                "f'{==a}'",
+                "f-string: expecting a valid expression after '{'",
+            ),
+            (
+                "f'{!=a}'",
+                "f-string: expecting a valid expression after '{'",
+            ),
+            (
+                "t'{==a}'",
+                "t-string: expecting a valid expression after '{'",
+            ),
+            ("f'{=a}'", "f-string: valid expression required before '='"),
+            ("f'{!}'", "f-string: valid expression required before '!'"),
+        ] {
+            let err = compile(source, Mode::Eval, "<interp>", CompileOpts::default())
+                .expect_err("should not compile");
+            assert!(
+                err.to_string().contains(expected),
+                "{source:?}: expected {expected:?}, got {err}"
+            );
+        }
+    }
+
+    #[test]
+    fn interpolated_literals_do_not_take_the_escaped_quote_hint() {
+        // Parser/lexer/lexer.c offers "perhaps you escaped the end quote?" from its plain-string
+        // branch only; the interpolated branch has just the triple-quoted and plain forms. The
+        // assertion has to be exact: the hint is a suffix, so `contains` would pass either way.
+        for (source, expected) in [
+            (
+                r"f'\'",
+                "unterminated f-string literal (detected at line 1)",
+            ),
+            (
+                r"t'\'",
+                "unterminated t-string literal (detected at line 1)",
+            ),
+        ] {
+            let err = compile(source, Mode::Eval, "<escaped>", CompileOpts::default())
+                .expect_err("should not compile");
+            assert_eq!(err.to_string(), expected, "{source:?}");
+        }
+        // A literal without a prefix still gets it.
+        let err = compile(r"'\'", Mode::Eval, "<escaped>", CompileOpts::default())
+            .expect_err("should not compile");
+        assert_eq!(
+            err.to_string(),
+            "unterminated string literal (detected at line 1); perhaps you escaped the end quote?"
+        );
+    }
+
+    #[test]
+    fn a_field_bracket_mismatch_names_the_opening_line() {
+        // CPython compares `parenlinenostack[level]` against the current `lineno`, so it names
+        // the opening line only when the two brackets are not on the same one.
+        for (source, expected) in [
+            (
+                "x = f\"\"\"{a[\n4)}\"\"\"\n",
+                "closing parenthesis ')' does not match opening parenthesis '[' on line 1",
+            ),
+            (
+                "x = f\"\"\"{a(\n\n4]}\"\"\"\n",
+                "closing parenthesis ']' does not match opening parenthesis '(' on line 1",
+            ),
+            (
+                "x = f\"{a[4)}\"\n",
+                "closing parenthesis ')' does not match opening parenthesis '['",
+            ),
+        ] {
+            let err = compile(source, Mode::Exec, "<paren>", CompileOpts::default())
+                .expect_err("should not compile");
+            assert_eq!(err.to_string(), expected, "{source:?}");
+        }
+    }
+
+    #[test]
+    fn a_dangling_operator_needs_the_field_to_close() {
+        // A stray character is a finished token, so CPython's grammar rejects it on lookahead
+        // and names the separators even when the field never closes. A dangling operator makes
+        // the parser ask for one more token, and producing it hits the closing quote, where
+        // lexer.c answers "expecting '}'" from the tokenizer instead.
+        for (source, expected) in [
+            ("f'{a;'", "f-string: expecting '=', or '!', or ':', or '}'"),
+            ("f'{a$'", "f-string: expecting '=', or '!', or ':', or '}'"),
+            ("f'{a?'", "f-string: expecting '=', or '!', or ':', or '}'"),
+            ("f'{a and'", "f-string: expecting '}'"),
+            ("f'{a+'", "f-string: expecting '}'"),
+            ("f'{a=='", "f-string: expecting '}'"),
+            ("f'{a.b.'", "f-string: expecting '}'"),
+            ("f'{a is not'", "f-string: expecting '}'"),
+            ("t'{a and'", "t-string: expecting '}'"),
+            // With the field closed, the operator is what gets named.
+            (
+                "f'{a and}'",
+                "f-string: expecting '=', or '!', or ':', or '}'",
+            ),
+            (
+                "f'{a==}'",
+                "f-string: expecting '=', or '!', or ':', or '}'",
+            ),
+        ] {
+            let err = compile(source, Mode::Eval, "<dangling>", CompileOpts::default())
+                .expect_err("should not compile");
+            assert!(
+                err.to_string().contains(expected),
+                "{source:?}: expected {expected:?}, got {err}"
+            );
+        }
+    }
+
+    #[test]
+    fn deeply_nested_format_specs_stay_linear() {
+        // Each enclosing spec used to re-scan every field nested inside it, which made this
+        // O(2^depth): a 110-byte source took six seconds. The scan now resumes past a nested
+        // field once it has checked it, so this has to finish immediately.
+        for depth in [32usize, 200] {
+            let source = format!("x = f\"{}{}\"\n$", "{1:".repeat(depth), "}".repeat(depth));
+            compile(&source, Mode::Exec, "<nested>", CompileOpts::default())
+                .expect_err("the trailing `$` is a syntax error");
+        }
+    }
+
+    #[test]
+    #[expect(
+        clippy::literal_string_with_formatting_args,
+        reason = "these are Python format specs, not Rust format args"
+    )]
+    fn valid_interpolated_literals_do_not_shadow_a_later_syntax_error() {
+        // A format spec is text rather than code, and a `#` in a replacement field starts a
+        // comment. Mistaking either for expression syntax would blame a perfectly good literal
+        // for the `$` further down, so the reported line must stay on the `$`.
+        for source in [
+            "x = f\"{1:(}\"\n$",
+            "x = f\"{1:[}\"\n$",
+            "x = f\"{1:#x}\"\n$",
+            "x = f\"{1!r:#>5}\"\n$",
+            "x = t\"{1:(}\"\n$",
+            "x = f\"\"\"{1 # (\n}\"\"\"\n$",
+            "x = f\"\"\"{1 # {\n}\"\"\"\n$",
+            "x = f\"\"\"{1 # ]\n}\"\"\"\n$",
+            "x = f\"\"\"{1 # a\\ b\n}\"\"\"\n$",
+            // A comment tail is not the end of the expression, whatever it looks like.
+            "x = f\"\"\"{a # +\n}\"\"\"\n$",
+            "x = f\"\"\"{a # and\n}\"\"\"\n$",
+            "x = f\"\"\"{a # ==\n}\"\"\"\n$",
+            "x = t\"\"\"{a # .\n}\"\"\"\n$",
+            "x = f\"\"\"{1:{a # +\n}}\"\"\"\n$",
+            "x = f\"\"\"{a # +\n + b}\"\"\"\n$",
+            // A signed leading-dot float is an operand.
+            "x = f\"{-.5}\"\n$",
+            "x = f\"{+.5}\"\n$",
+            // Ellipsis and a leading-dot float start real expressions.
+            "x = f\"{...}\"\n$",
+            "x = f\"{.5}\"\n$",
+            "x = t\"{...}\"\n$",
+            // A dangling operator is reported, but a complete one is not.
+            "x = f\"{a+b}\"\n$",
+            "x = f\"{a.b.c}\"\n$",
+            "x = f\"{1.}\"\n$",
+            // A comparison operator is not a debug or conversion marker.
+            "x = f\"{a==b}\"\n$",
+            "x = f\"{a!=b}\"\n$",
+            "x = f\"{a<=b}\"\n$",
+            "x = f\"{a>=b}\"\n$",
+            "x = t\"{a==b}\"\n$",
+            "x = f\"{a:{b==c}}\"\n$",
+        ] {
+            let err = compile(source, Mode::Exec, "<interp>", CompileOpts::default())
+                .expect_err("the trailing `$` is a syntax error");
+            assert_eq!(
+                err.python_location().0,
+                source.lines().count(),
+                "{source:?} reported the wrong line: {err}"
+            );
+        }
     }
 
     #[test]

--- a/crates/compiler/src/lib.rs
+++ b/crates/compiler/src/lib.rs
@@ -74,18 +74,15 @@ impl CompileError {
         })
     }
 
-    fn from_source_error(
-        source_file: &SourceFile,
-        message: String,
-        start: usize,
-        end: usize,
-    ) -> Self {
-        let start = TextSize::new(start as u32);
-        let end = TextSize::new(end as u32);
-        let (location, end_location) = source_locations(source_file, start, end);
+    fn from_source_error(source_file: &SourceFile, diagnostic: CpythonDiagnostic) -> Self {
+        let (location, end_location) = source_locations(
+            source_file,
+            diagnostic.range.start(),
+            diagnostic.range.end(),
+        );
         Self::Parse(ParseError {
-            error: parser::ParseErrorType::OtherError(message),
-            raw_location: ruff_text_size::TextRange::new(start, end),
+            error: parser::ParseErrorType::OtherError(diagnostic.message),
+            raw_location: diagnostic.range,
             location,
             end_location,
             source_path: source_file.name().to_owned(),
@@ -179,14 +176,14 @@ impl NormalizedParseDiagnostic {
         }
     }
 
-    fn other(source_file: &SourceFile, message: String, start: usize, end: usize) -> Self {
+    fn other(source_file: &SourceFile, diagnostic: CpythonDiagnostic) -> Self {
         let (location, end_location) = source_locations(
             source_file,
-            TextSize::new(start as u32),
-            TextSize::new(end as u32),
+            diagnostic.range.start(),
+            diagnostic.range.end(),
         );
         Self::new(
-            parser::ParseErrorType::OtherError(message),
+            parser::ParseErrorType::OtherError(diagnostic.message),
             location,
             end_location,
         )
@@ -195,6 +192,31 @@ impl NormalizedParseDiagnostic {
     const fn with_unclosed_bracket(mut self, is_unclosed_bracket: bool) -> Self {
         self.is_unclosed_bracket = is_unclosed_bracket;
         self
+    }
+}
+
+/// What CPython would have reported for a piece of source, before it is resolved to a line and
+/// column. These are reconstructed by re-scanning after ruff's parse has already failed, so they
+/// carry CPython's wording rather than a translation of ruff's own error, and they never reach
+/// ruff — `NormalizedParseDiagnostic` and `CompileError` are the only things that consume one.
+struct CpythonDiagnostic {
+    message: String,
+    range: ruff_text_size::TextRange,
+}
+
+impl CpythonDiagnostic {
+    /// The `u32` cast is ruff's invariant rather than one this adds: its `Lexer::new` asserts
+    /// that the source fits in a `u32` ("Lexer only supports files with a size up to 4GB") and
+    /// relies on that for its own offset arithmetic, and nothing here runs until that lexer has
+    /// read the source and the parse built on it has failed.
+    fn new(message: String, start: usize, end: usize) -> Self {
+        Self {
+            message,
+            range: ruff_text_size::TextRange::new(
+                TextSize::new(start as u32),
+                TextSize::new(end as u32),
+            ),
+        }
     }
 }
 
@@ -207,34 +229,22 @@ fn cpython_parse_diagnostic_override(
 
     macro_rules! source_error {
         ($expr:expr) => {
-            if let Some((message, start, end)) = $expr {
-                return Some(NormalizedParseDiagnostic::other(
-                    source_file,
-                    message,
-                    start,
-                    end,
-                ));
+            if let Some(error) = $expr {
+                return Some(NormalizedParseDiagnostic::other(source_file, error));
             }
         };
     }
 
-    if let Some((message, start, end)) = invalid_number_literal_error(source_text) {
-        return Some(NormalizedParseDiagnostic::other(
-            source_file,
-            message,
-            start,
-            end,
-        ));
-    }
+    source_error!(invalid_number_literal_error(source_text));
     source_error!(invalid_legacy_statement_error(source_text));
     source_error!(non_printable_character_error(source_text));
     source_error!(invalid_interpolated_string_error(source_text));
     source_error!(mixed_tstring_literal_error(error, source_text));
 
-    if let Some((message, start, end, unclosed)) = bracket_syntax_error(source_text) {
+    if let Some(bracket) = bracket_syntax_error(source_text) {
         return Some(
-            NormalizedParseDiagnostic::other(source_file, message, start, end)
-                .with_unclosed_bracket(unclosed),
+            NormalizedParseDiagnostic::other(source_file, bracket.diagnostic)
+                .with_unclosed_bracket(bracket.unclosed),
         );
     }
 
@@ -262,14 +272,7 @@ fn cpython_parse_diagnostic_override(
         ));
     }
 
-    if let Some((message, start, end)) = unterminated_string_error(source_text) {
-        return Some(NormalizedParseDiagnostic::other(
-            source_file,
-            message,
-            start,
-            end,
-        ));
-    }
+    source_error!(unterminated_string_error(source_text));
     source_error!(expected_indented_block_error(error, source_text));
 
     if matches!(
@@ -637,10 +640,7 @@ fn invalid_decimal_literal_error(bytes: &[u8], start: usize) -> Option<(String, 
     None
 }
 
-fn leading_zero_decimal_literal_error(
-    bytes: &[u8],
-    start: usize,
-) -> Option<(String, usize, usize)> {
+fn leading_zero_decimal_literal_error(bytes: &[u8], start: usize) -> Option<CpythonDiagnostic> {
     if bytes.get(start) != Some(&b'0') {
         return None;
     }
@@ -664,8 +664,9 @@ fn leading_zero_decimal_literal_error(
             bytes.get(after_digits),
             Some(b'.' | b'e' | b'E' | b'j' | b'J')
         ) {
-            return Some((
-                "leading zeros in decimal integer literals are not permitted; use an 0o prefix for octal integers".to_owned(),
+            return Some(CpythonDiagnostic::new(
+                "leading zeros in decimal integer literals are not permitted; use an 0o prefix for octal integers"
+                    .to_owned(),
                 start,
                 index,
             ));
@@ -674,7 +675,7 @@ fn leading_zero_decimal_literal_error(
     None
 }
 
-fn invalid_numeric_literal_error(bytes: &[u8], start: usize) -> Option<(String, usize, usize)> {
+fn invalid_numeric_literal_error(bytes: &[u8], start: usize) -> Option<CpythonDiagnostic> {
     if bytes.get(start) == Some(&b'0') {
         let radix = match bytes.get(start + 1) {
             Some(b'x' | b'X') => invalid_radix_literal_error(bytes, start, "hexadecimal", |byte| {
@@ -788,11 +789,11 @@ fn skip_quoted_string(bytes: &[u8], mut index: usize) -> usize {
 }
 
 // An error the tokenizer reports at a single position spans nothing.
-fn point_span((message, offset): (String, usize)) -> (String, usize, usize) {
-    (message, offset, offset)
+fn point_span((message, offset): (String, usize)) -> CpythonDiagnostic {
+    CpythonDiagnostic::new(message, offset, offset)
 }
 
-fn invalid_number_literal_error(source: &str) -> Option<(String, usize, usize)> {
+fn invalid_number_literal_error(source: &str) -> Option<CpythonDiagnostic> {
     let bytes = source.as_bytes();
     let mut index = 0;
     while index < bytes.len() {
@@ -823,7 +824,11 @@ fn invalid_number_literal_error(source: &str) -> Option<(String, usize, usize)> 
                 };
                 if end > index {
                     if source[end..].starts_with('⁄') {
-                        return Some(("invalid character '⁄' (U+2044)".to_owned(), end, end));
+                        return Some(CpythonDiagnostic::new(
+                            "invalid character '⁄' (U+2044)".to_owned(),
+                            end,
+                            end,
+                        ));
                     }
                     if bytes
                         .get(end)
@@ -831,7 +836,11 @@ fn invalid_number_literal_error(source: &str) -> Option<(String, usize, usize)> 
                         && !numeric_keyword_suffix(&bytes[end..])
                     {
                         let offset = end.saturating_sub(1);
-                        return Some((format!("invalid {kind} literal"), offset, offset));
+                        return Some(CpythonDiagnostic::new(
+                            format!("invalid {kind} literal"),
+                            offset,
+                            offset,
+                        ));
                     }
                 }
                 index = end.max(index + 1);
@@ -898,7 +907,7 @@ fn previous_non_empty_line_number(source: &str, offset: usize) -> Option<usize> 
 fn expected_indented_block_error(
     error: &parser::ParseError,
     source: &str,
-) -> Option<(String, usize, usize)> {
+) -> Option<CpythonDiagnostic> {
     let parser::ParseErrorType::OtherError(message) = &error.error else {
         return None;
     };
@@ -915,7 +924,7 @@ fn expected_indented_block_error(
     {
         clause = "'except*' statement";
     }
-    Some((
+    Some(CpythonDiagnostic::new(
         format!("expected an indented block after {clause} on line {line}"),
         start,
         end,
@@ -1174,7 +1183,7 @@ fn invalid_type_param_item_error(
     source: &str,
     start: usize,
     end: usize,
-) -> Option<(String, usize, usize)> {
+) -> Option<CpythonDiagnostic> {
     let bytes = source.as_bytes();
     let (start, end) = trim_target_range(bytes, start, end);
     if start >= end || bytes.get(start) != Some(&b'*') {
@@ -1197,14 +1206,14 @@ fn invalid_type_param_item_error(
         (true, false) => "cannot use bound with ParamSpec",
         (true, true) => "cannot use constraints with ParamSpec",
     };
-    Some((message.to_owned(), colon, colon + 1))
+    Some(CpythonDiagnostic::new(message.to_owned(), colon, colon + 1))
 }
 
 fn invalid_type_param_list_error(
     source: &str,
     open: usize,
     close: usize,
-) -> Option<(String, usize, usize)> {
+) -> Option<CpythonDiagnostic> {
     let bytes = source.as_bytes();
     let mut item_start = open + 1;
     let mut index = item_start;
@@ -1234,7 +1243,7 @@ fn invalid_type_param_list_error(
     None
 }
 
-fn invalid_type_param_error(source: &str) -> Option<(String, usize, usize)> {
+fn invalid_type_param_error(source: &str) -> Option<CpythonDiagnostic> {
     let bytes = source.as_bytes();
     let mut index = 0usize;
     while index < bytes.len() {
@@ -1265,24 +1274,28 @@ fn invalid_comprehension_in_slice(
     bytes: &[u8],
     open: usize,
     close: usize,
-) -> Option<(String, usize, usize)> {
+) -> Option<CpythonDiagnostic> {
     let for_index = find_keyword_at_level(bytes, open + 1, close, b"for")?;
     let item_start = next_non_horizontal_whitespace(bytes, open + 1);
     if item_start >= for_index {
         return None;
     }
     if bytes.get(item_start..item_start + 2) == Some(b"**") && bytes.get(open) == Some(&b'{') {
-        return Some((
+        return Some(CpythonDiagnostic::new(
             "dict unpacking cannot be used in dict comprehension".to_owned(),
             item_start,
             item_start + 2,
         ));
     }
     if bytes.get(item_start..item_start + 2) == Some(b"**") && bytes.get(open) == Some(&b'(') {
-        return Some(("invalid syntax".to_owned(), for_index, for_index + 3));
+        return Some(CpythonDiagnostic::new(
+            "invalid syntax".to_owned(),
+            for_index,
+            for_index + 3,
+        ));
     }
     if bytes.get(item_start) == Some(&b'*') {
-        return Some((
+        return Some(CpythonDiagnostic::new(
             "iterable unpacking cannot be used in comprehension".to_owned(),
             item_start,
             item_start + 1,
@@ -1295,7 +1308,7 @@ fn invalid_comprehension_in_slice(
         && let Some(comma) = top_level_byte(bytes, open + 1, for_index, b',')
     {
         let (start, _) = trim_target_range(bytes, open + 1, comma);
-        return Some((
+        return Some(CpythonDiagnostic::new(
             "did you forget parentheses around the comprehension target?".to_owned(),
             start,
             comma + 1,
@@ -1304,7 +1317,7 @@ fn invalid_comprehension_in_slice(
     None
 }
 
-fn invalid_comprehension_error(source: &str) -> Option<(String, usize, usize)> {
+fn invalid_comprehension_error(source: &str) -> Option<CpythonDiagnostic> {
     let bytes = source.as_bytes();
     let mut index = 0usize;
     while index < bytes.len() {
@@ -1336,11 +1349,7 @@ fn invalid_comprehension_error(source: &str) -> Option<(String, usize, usize)> {
     None
 }
 
-fn invalid_group_in_slice(
-    bytes: &[u8],
-    open: usize,
-    close: usize,
-) -> Option<(String, usize, usize)> {
+fn invalid_group_in_slice(bytes: &[u8], open: usize, close: usize) -> Option<CpythonDiagnostic> {
     let (item_start, item_end) = trim_target_range(bytes, open + 1, close);
     if item_start >= item_end
         || top_level_byte(bytes, item_start, item_end, b',').is_some()
@@ -1350,14 +1359,14 @@ fn invalid_group_in_slice(
         return None;
     }
     if bytes.get(item_start..item_start + 2) == Some(b"**") {
-        return Some((
+        return Some(CpythonDiagnostic::new(
             "cannot use double starred expression here".to_owned(),
             item_start,
             item_start + 2,
         ));
     }
     if bytes.get(item_start) == Some(&b'*') {
-        return Some((
+        return Some(CpythonDiagnostic::new(
             "cannot use starred expression here".to_owned(),
             item_start,
             item_start + 1,
@@ -1366,7 +1375,7 @@ fn invalid_group_in_slice(
     None
 }
 
-fn invalid_group_error(source: &str) -> Option<(String, usize, usize)> {
+fn invalid_group_error(source: &str) -> Option<CpythonDiagnostic> {
     let bytes = source.as_bytes();
     let mut index = 0usize;
     while index < bytes.len() {
@@ -1393,7 +1402,7 @@ fn invalid_group_error(source: &str) -> Option<(String, usize, usize)> {
     None
 }
 
-fn invalid_parameter_star_annotation_error(source: &str) -> Option<(String, usize, usize)> {
+fn invalid_parameter_star_annotation_error(source: &str) -> Option<CpythonDiagnostic> {
     let bytes = source.as_bytes();
     let mut index = 0usize;
     while index < bytes.len() {
@@ -1416,7 +1425,7 @@ fn invalid_parameter_star_annotation_error(source: &str) -> Option<(String, usiz
                     if let Some(colon) = top_level_colon(bytes, param_start, param_end) {
                         let value_start = next_non_horizontal_whitespace(bytes, colon + 1);
                         if bytes.get(value_start) == Some(&b'*') {
-                            return Some((
+                            return Some(CpythonDiagnostic::new(
                                 "invalid syntax".to_owned(),
                                 value_start,
                                 value_start + 1,
@@ -1433,7 +1442,7 @@ fn invalid_parameter_star_annotation_error(source: &str) -> Option<(String, usiz
     None
 }
 
-fn invalid_def_type_params_error(source: &str) -> Option<(String, usize, usize)> {
+fn invalid_def_type_params_error(source: &str) -> Option<CpythonDiagnostic> {
     let bytes = source.as_bytes();
     let mut index = 0;
     while index < bytes.len() {
@@ -1457,7 +1466,11 @@ fn invalid_def_type_params_error(source: &str) -> Option<(String, usize, usize)>
                     if bytes.get(after_close) == Some(&b'(')
                         && type_param_list_is_malformed(bytes, bracket + 1, close)
                     {
-                        return Some(("expected '('".to_owned(), bracket, bracket + 1));
+                        return Some(CpythonDiagnostic::new(
+                            "expected '('".to_owned(),
+                            bracket,
+                            bracket + 1,
+                        ));
                     }
                 }
                 index = name_end.max(index + 3);
@@ -1517,7 +1530,7 @@ fn invalid_parameter_list_slice_error(
     start: usize,
     end: usize,
     kind: ParameterListKind,
-) -> Option<(String, usize, usize)> {
+) -> Option<CpythonDiagnostic> {
     let bytes = source.as_bytes();
     let mut index = start;
     let mut level = 0usize;
@@ -1535,7 +1548,7 @@ fn invalid_parameter_list_slice_error(
                 }) =>
             {
                 let name_end = identifier_end(bytes, index, end);
-                return Some((
+                return Some(CpythonDiagnostic::new(
                     "arguments cannot follow var-keyword argument".to_owned(),
                     index,
                     name_end,
@@ -1559,7 +1572,7 @@ fn invalid_parameter_list_slice_error(
                 if top_level_byte(bytes, index, param_end, b'=').is_some() {
                     default_seen = true;
                 } else if default_seen {
-                    return Some((
+                    return Some(CpythonDiagnostic::new(
                         "parameter without a default follows parameter with a default".to_owned(),
                         index,
                         name_end,
@@ -1577,7 +1590,7 @@ fn invalid_parameter_list_slice_error(
                         "Lambda expression parameters cannot be parenthesized"
                     }
                 };
-                return Some((message.to_owned(), index, close + 1));
+                return Some(CpythonDiagnostic::new(message.to_owned(), index, close + 1));
             }
             b'(' | b'[' | b'{' => {
                 level += 1;
@@ -1589,25 +1602,33 @@ fn invalid_parameter_list_slice_error(
             }
             b'/' if level == 0 => {
                 if var_keyword_seen {
-                    return Some((
+                    return Some(CpythonDiagnostic::new(
                         "arguments cannot follow var-keyword argument".to_owned(),
                         index,
                         index + 1,
                     ));
                 }
                 if slash_seen {
-                    return Some(("/ may appear only once".to_owned(), index, index + 1));
+                    return Some(CpythonDiagnostic::new(
+                        "/ may appear only once".to_owned(),
+                        index,
+                        index + 1,
+                    ));
                 }
                 slash_seen = true;
                 let next = next_non_horizontal_whitespace(bytes, index + 1);
                 if bytes.get(next) == Some(&b'*') {
-                    return Some(("expected comma between / and *".to_owned(), next, next + 1));
+                    return Some(CpythonDiagnostic::new(
+                        "expected comma between / and *".to_owned(),
+                        next,
+                        next + 1,
+                    ));
                 }
                 index += 1;
             }
             b'*' if level == 0 => {
                 if var_keyword_seen {
-                    return Some((
+                    return Some(CpythonDiagnostic::new(
                         "arguments cannot follow var-keyword argument".to_owned(),
                         index,
                         index + 1,
@@ -1618,7 +1639,7 @@ fn invalid_parameter_list_slice_error(
                 let name_start = next_non_horizontal_whitespace(bytes, index + stars);
                 for keyword in [b"True".as_slice(), b"False".as_slice(), b"None".as_slice()] {
                     if starts_identifier(bytes, name_start, keyword) {
-                        return Some((
+                        return Some(CpythonDiagnostic::new(
                             "invalid syntax".to_owned(),
                             name_start,
                             name_start + keyword.len(),
@@ -1634,21 +1655,21 @@ fn invalid_parameter_list_slice_error(
                     })
                     .unwrap_or(end);
                 if stars == 1 && matches!(bytes.get(name_start), Some(b')' | b',' | b':')) {
-                    return Some((
+                    return Some(CpythonDiagnostic::new(
                         "named arguments must follow bare *".to_owned(),
                         index,
                         index + 1,
                     ));
                 }
                 if stars == 1 && top_level_byte(bytes, name_start, param_end, b'=').is_some() {
-                    return Some((
+                    return Some(CpythonDiagnostic::new(
                         "var-positional argument cannot have default value".to_owned(),
                         index,
                         index + 1,
                     ));
                 }
                 if stars == 2 && top_level_byte(bytes, name_start, param_end, b'=').is_some() {
-                    return Some((
+                    return Some(CpythonDiagnostic::new(
                         "var-keyword argument cannot have default value".to_owned(),
                         index,
                         index + 2,
@@ -1668,9 +1689,13 @@ fn invalid_parameter_list_slice_error(
                     if matches!(kind, ParameterListKind::Lambda)
                         && matches!(bytes.get(value_start), Some(b':'))
                     {
-                        return Some(("invalid syntax".to_owned(), index, index + 1));
+                        return Some(CpythonDiagnostic::new(
+                            "invalid syntax".to_owned(),
+                            index,
+                            index + 1,
+                        ));
                     }
-                    return Some((
+                    return Some(CpythonDiagnostic::new(
                         "expected default value expression".to_owned(),
                         index,
                         index + 1,
@@ -1684,7 +1709,7 @@ fn invalid_parameter_list_slice_error(
     None
 }
 
-fn invalid_parameter_list_error(source: &str) -> Option<(String, usize, usize)> {
+fn invalid_parameter_list_error(source: &str) -> Option<CpythonDiagnostic> {
     let bytes = source.as_bytes();
     let mut index = 0usize;
     while index < bytes.len() {
@@ -1754,7 +1779,7 @@ fn invalid_call_argument_assignment_error(
     source: &str,
     arg_start: usize,
     equal: usize,
-) -> Option<(String, usize, usize)> {
+) -> Option<CpythonDiagnostic> {
     let bytes = source.as_bytes();
     let start = bytes[arg_start..equal]
         .iter()
@@ -1766,21 +1791,21 @@ fn invalid_call_argument_assignment_error(
     }
     let value_start = next_non_horizontal_whitespace(bytes, equal + 1);
     if matches!(bytes.get(value_start), None | Some(b',' | b')')) {
-        return Some((
+        return Some(CpythonDiagnostic::new(
             "expected argument value expression".to_owned(),
             target_start,
             equal + 1,
         ));
     }
     if bytes.get(target_start..target_start + 2) == Some(b"**") {
-        return Some((
+        return Some(CpythonDiagnostic::new(
             "cannot assign to keyword argument unpacking".to_owned(),
             target_start,
             value_start,
         ));
     }
     if bytes.get(target_start) == Some(&b'*') {
-        return Some((
+        return Some(CpythonDiagnostic::new(
             "cannot assign to iterable argument unpacking".to_owned(),
             target_start,
             value_start,
@@ -1789,7 +1814,7 @@ fn invalid_call_argument_assignment_error(
     for keyword in [b"True".as_slice(), b"False".as_slice(), b"None".as_slice()] {
         if bytes.get(target_start..target_end) == Some(keyword) {
             let keyword = ::core::str::from_utf8(keyword).ok()?;
-            return Some((
+            return Some(CpythonDiagnostic::new(
                 format!("cannot assign to {keyword}"),
                 target_start,
                 target_end,
@@ -1799,7 +1824,7 @@ fn invalid_call_argument_assignment_error(
     if is_simple_keyword_name(bytes, target_start, target_end) {
         return None;
     }
-    Some((
+    Some(CpythonDiagnostic::new(
         "expression cannot contain assignment, perhaps you meant \"==\"?".to_owned(),
         target_start,
         equal,
@@ -1810,14 +1835,14 @@ fn invalid_call_star_expression_error(
     bytes: &[u8],
     arg_start: usize,
     index: usize,
-) -> Option<(String, usize, usize)> {
+) -> Option<CpythonDiagnostic> {
     let start = next_non_horizontal_whitespace(bytes, arg_start);
     if start != index || bytes.get(index) != Some(&b'*') {
         return None;
     }
     let after_star = next_non_horizontal_whitespace(bytes, index + 1);
     if matches!(bytes.get(after_star), None | Some(b',' | b')' | b':')) {
-        return Some((
+        return Some(CpythonDiagnostic::new(
             "Invalid star expression".to_owned(),
             index,
             (index + 1).min(bytes.len()),
@@ -1826,7 +1851,7 @@ fn invalid_call_star_expression_error(
     None
 }
 
-fn invalid_call_argument_error(source: &str) -> Option<(String, usize, usize)> {
+fn invalid_call_argument_error(source: &str) -> Option<CpythonDiagnostic> {
     let bytes = source.as_bytes();
     let mut index = 0usize;
     let mut level = 0usize;
@@ -1950,7 +1975,7 @@ fn invalid_dict_entry_error(
     item_end: usize,
     colon: Option<usize>,
     saw_dict_item: bool,
-) -> Option<(String, usize, usize)> {
+) -> Option<CpythonDiagnostic> {
     let bytes = source.as_bytes();
     let (item_start, item_end) = trim_target_range(bytes, item_start, item_end);
     if item_start >= item_end {
@@ -1959,24 +1984,28 @@ fn invalid_dict_entry_error(
     if let Some(colon) = colon {
         let value_start = next_non_horizontal_whitespace(bytes, colon + 1);
         if value_start >= item_end {
-            return Some((
+            return Some(CpythonDiagnostic::new(
                 "expression expected after dictionary key and ':'".to_owned(),
                 colon,
                 colon + 1,
             ));
         }
         if bytes.get(value_start) == Some(&b'*') {
-            return Some((
+            return Some(CpythonDiagnostic::new(
                 "cannot use a starred expression in a dictionary value".to_owned(),
                 value_start,
                 value_start + 1,
             ));
         }
         if !expression_slice_is_valid(source, value_start, item_end) {
-            return Some(("invalid syntax".to_owned(), value_start, value_start));
+            return Some(CpythonDiagnostic::new(
+                "invalid syntax".to_owned(),
+                value_start,
+                value_start,
+            ));
         }
     } else if saw_dict_item {
-        return Some((
+        return Some(CpythonDiagnostic::new(
             "':' expected after dictionary key".to_owned(),
             item_end.saturating_sub(1),
             item_end,
@@ -1989,7 +2018,7 @@ fn invalid_dict_literal_error(
     source: &str,
     open: usize,
     close: usize,
-) -> Option<(String, usize, usize)> {
+) -> Option<CpythonDiagnostic> {
     let bytes = source.as_bytes();
     let mut item_start = open + 1;
     let mut index = item_start;
@@ -2030,7 +2059,7 @@ fn invalid_dict_literal_error(
     None
 }
 
-fn invalid_dict_error(source: &str) -> Option<(String, usize, usize)> {
+fn invalid_dict_error(source: &str) -> Option<CpythonDiagnostic> {
     let bytes = source.as_bytes();
     let mut index = 0usize;
     while index < bytes.len() {
@@ -2078,7 +2107,7 @@ fn invalid_collection_assignment_in_slice(
     bytes: &[u8],
     start: usize,
     end: usize,
-) -> Option<(String, usize, usize)> {
+) -> Option<CpythonDiagnostic> {
     let mut item_start = start;
     let mut index = start;
     let mut level = 0usize;
@@ -2109,7 +2138,7 @@ fn invalid_collection_assignment_in_slice(
                             return None;
                         }
                         if matches!(expr_name, "expression" | "attribute" | "subscript") {
-                            return Some((
+                            return Some(CpythonDiagnostic::new(
                                 format!(
                                     "cannot assign to {expr_name} here. Maybe you meant '==' instead of '='?"
                                 ),
@@ -2118,7 +2147,7 @@ fn invalid_collection_assignment_in_slice(
                             ));
                         }
                     }
-                    return Some((
+                    return Some(CpythonDiagnostic::new(
                         "invalid syntax. Maybe you meant '==' or ':=' instead of '='?".to_owned(),
                         start,
                         index + 1,
@@ -2132,7 +2161,7 @@ fn invalid_collection_assignment_in_slice(
     None
 }
 
-fn invalid_collection_assignment_error(source: &str) -> Option<(String, usize, usize)> {
+fn invalid_collection_assignment_error(source: &str) -> Option<CpythonDiagnostic> {
     let bytes = source.as_bytes();
     let mut index = 0usize;
     while index < bytes.len() {
@@ -2167,7 +2196,7 @@ fn invalid_collection_assignment_error(source: &str) -> Option<(String, usize, u
     None
 }
 
-fn expression_assignment_error(source: &str) -> Option<(String, usize, usize)> {
+fn expression_assignment_error(source: &str) -> Option<CpythonDiagnostic> {
     let bytes = source.as_bytes();
     let mut index = 0;
     let mut paren_arg_starts: Vec<(Option<usize>, bool)> = Vec::new();
@@ -2218,7 +2247,7 @@ fn expression_assignment_error(source: &str) -> Option<(String, usize, usize)> {
                     while matches!(bytes.get(expr_start), Some(b' ' | b'\t' | b'\x0c')) {
                         expr_start += 1;
                     }
-                    return Some((
+                    return Some(CpythonDiagnostic::new(
                         "expression cannot contain assignment, perhaps you meant \"==\"?"
                             .to_owned(),
                         expr_start,
@@ -2233,7 +2262,7 @@ fn expression_assignment_error(source: &str) -> Option<(String, usize, usize)> {
     None
 }
 
-fn invalid_named_expression_error(source: &str) -> Option<(String, usize, usize)> {
+fn invalid_named_expression_error(source: &str) -> Option<CpythonDiagnostic> {
     let bytes = source.as_bytes();
     let mut index = 0;
     while index + 1 < bytes.len() {
@@ -2252,7 +2281,7 @@ fn invalid_named_expression_error(source: &str) -> Option<(String, usize, usize)
                         expression_name_and_range(&source[target_start..target_end])
                     && !is_name
                 {
-                    return Some((
+                    return Some(CpythonDiagnostic::new(
                         format!("cannot use assignment expressions with {expr_name}"),
                         target_start + start,
                         target_start + end,
@@ -2272,7 +2301,7 @@ struct AssignmentContext {
     call: bool,
 }
 
-fn invalid_plain_assignment_error(source: &str) -> Option<(String, usize, usize)> {
+fn invalid_plain_assignment_error(source: &str) -> Option<CpythonDiagnostic> {
     let bytes = source.as_bytes();
     let mut stack: Vec<AssignmentContext> = Vec::new();
     let mut index = 0;
@@ -2314,7 +2343,7 @@ fn invalid_plain_assignment_error(source: &str) -> Option<(String, usize, usize)
                             expression_name_and_range(&source[target_start..target_end])
                         && matches!(expr_name, "expression" | "attribute" | "subscript")
                     {
-                        return Some((
+                        return Some(CpythonDiagnostic::new(
                             format!(
                                 "cannot assign to {expr_name} here. Maybe you meant '==' instead of '='?"
                             ),
@@ -2369,7 +2398,7 @@ fn annotation_target_error_for_slice(
     source: &str,
     start: usize,
     colon: usize,
-) -> Option<(String, usize, usize)> {
+) -> Option<CpythonDiagnostic> {
     let bytes = source.as_bytes();
     let (target_start, target_end) = trim_target_range(bytes, start, colon);
     if target_start >= target_end {
@@ -2384,17 +2413,17 @@ fn annotation_target_error_for_slice(
     };
     match expression.body.as_ref() {
         ast::Expr::Name(_) | ast::Expr::Attribute(_) | ast::Expr::Subscript(_) => None,
-        ast::Expr::List(_) => Some((
+        ast::Expr::List(_) => Some(CpythonDiagnostic::new(
             "only single target (not list) can be annotated".to_owned(),
             target_start,
             target_end,
         )),
-        ast::Expr::Tuple(_) => Some((
+        ast::Expr::Tuple(_) => Some(CpythonDiagnostic::new(
             "only single target (not tuple) can be annotated".to_owned(),
             target_start,
             target_end,
         )),
-        _ => Some((
+        _ => Some(CpythonDiagnostic::new(
             "illegal target for annotation".to_owned(),
             target_start,
             target_end,
@@ -2427,7 +2456,7 @@ fn invalid_annotation_line_start(bytes: &[u8], line_start: usize) -> bool {
     true
 }
 
-fn invalid_annotation_target_error(source: &str) -> Option<(String, usize, usize)> {
+fn invalid_annotation_target_error(source: &str) -> Option<CpythonDiagnostic> {
     let bytes = source.as_bytes();
     let mut line_start = 0usize;
     for line in source.split_inclusive('\n') {
@@ -2643,14 +2672,14 @@ fn assignment_target_error_for_slice(
     source: &str,
     start: usize,
     end: usize,
-) -> Option<(String, usize, usize)> {
+) -> Option<CpythonDiagnostic> {
     let bytes = source.as_bytes();
     let (target_start, target_end) = trim_target_range(bytes, start, end);
     if target_start >= target_end {
         return None;
     }
     if starts_identifier(bytes, target_start, b"yield") {
-        return Some((
+        return Some(CpythonDiagnostic::new(
             "assignment to yield expression not possible".to_owned(),
             target_start,
             target_start + 5,
@@ -2667,7 +2696,11 @@ fn assignment_target_error_for_slice(
     let invalid_start = target_start + invalid_target.range().start().to_usize();
     let invalid_end = target_start + invalid_target.range().end().to_usize();
     if matches!(invalid_target, ast::Expr::FString(_)) {
-        return Some(("invalid syntax".to_owned(), invalid_start, invalid_end));
+        return Some(CpythonDiagnostic::new(
+            "invalid syntax".to_owned(),
+            invalid_start,
+            invalid_end,
+        ));
     }
     let name = delete_target_expr_name(invalid_target);
     let top_level = invalid_target.range() == expression.body.range();
@@ -2682,7 +2715,7 @@ fn assignment_target_error_for_slice(
             | ast::Expr::BytesLiteral(_)
             | ast::Expr::EllipsisLiteral(_)
     );
-    Some((
+    Some(CpythonDiagnostic::new(
         invalid_assignment_message(name, top_level && bitwise_like),
         invalid_start,
         invalid_end,
@@ -2693,15 +2726,11 @@ fn star_target_error_for_slice(
     source: &str,
     start: usize,
     end: usize,
-) -> Option<(String, usize, usize)> {
+) -> Option<CpythonDiagnostic> {
     invalid_target_error_for_slice(source, start, end, invalid_assignment_target)
 }
 
-fn for_target_error_for_slice(
-    source: &str,
-    start: usize,
-    end: usize,
-) -> Option<(String, usize, usize)> {
+fn for_target_error_for_slice(source: &str, start: usize, end: usize) -> Option<CpythonDiagnostic> {
     invalid_target_error_for_slice(source, start, end, invalid_for_target)
 }
 
@@ -2710,7 +2739,7 @@ fn invalid_target_error_for_slice(
     start: usize,
     end: usize,
     invalid_target: for<'a> fn(&'a ast::Expr) -> Option<&'a ast::Expr>,
-) -> Option<(String, usize, usize)> {
+) -> Option<CpythonDiagnostic> {
     let bytes = source.as_bytes();
     let (target_start, target_end) = trim_target_range(bytes, start, end);
     if target_start >= target_end {
@@ -2727,7 +2756,7 @@ fn invalid_target_error_for_slice(
     let name = delete_target_expr_name(invalid_target);
     let invalid_start = target_start + invalid_target.range().start().to_usize();
     let invalid_end = target_start + invalid_target.range().end().to_usize();
-    Some((
+    Some(CpythonDiagnostic::new(
         format!("cannot assign to {name}"),
         invalid_start,
         invalid_end,
@@ -2762,7 +2791,7 @@ fn non_in_compare_for_target_error(
     source: &str,
     start: usize,
     end: usize,
-) -> Option<(String, usize, usize)> {
+) -> Option<CpythonDiagnostic> {
     let bytes = source.as_bytes();
     let (target_start, target_end) = trim_target_range(bytes, start, end);
     if target_start >= target_end {
@@ -2782,7 +2811,7 @@ fn non_in_compare_for_target_error(
         return None;
     }
     let operator = first_compare_operator_at_level(bytes, target_start, target_end)?;
-    Some((
+    Some(CpythonDiagnostic::new(
         "invalid syntax".to_owned(),
         operator,
         (operator + 1).min(target_end),
@@ -2819,7 +2848,7 @@ fn top_level_plain_assignment_offsets(bytes: &[u8]) -> Vec<usize> {
     offsets
 }
 
-fn invalid_assignment_target_error(source: &str) -> Option<(String, usize, usize)> {
+fn invalid_assignment_target_error(source: &str) -> Option<CpythonDiagnostic> {
     let bytes = source.as_bytes();
     let offsets = top_level_plain_assignment_offsets(bytes);
     if offsets.is_empty() {
@@ -2884,7 +2913,7 @@ fn top_level_augassign_offset(bytes: &[u8]) -> Option<(usize, usize)> {
     None
 }
 
-fn invalid_augassign_target_error(source: &str) -> Option<(String, usize, usize)> {
+fn invalid_augassign_target_error(source: &str) -> Option<CpythonDiagnostic> {
     let bytes = source.as_bytes();
     let (operator, _) = top_level_augassign_offset(bytes)?;
     let (target_start, target_end) = trim_target_range(bytes, 0, operator);
@@ -2899,7 +2928,7 @@ fn invalid_augassign_target_error(source: &str) -> Option<(String, usize, usize)
         return None;
     };
     let name = delete_target_expr_name(&expression.body);
-    Some((
+    Some(CpythonDiagnostic::new(
         format!("'{name}' is an illegal expression for augmented assignment"),
         target_start,
         target_end,
@@ -2928,7 +2957,7 @@ fn find_for_target_delimiter(bytes: &[u8], mut index: usize, end: usize) -> Opti
     None
 }
 
-fn invalid_for_target_error(source: &str) -> Option<(String, usize, usize)> {
+fn invalid_for_target_error(source: &str) -> Option<CpythonDiagnostic> {
     let bytes = source.as_bytes();
     let mut index = 0usize;
     while index < bytes.len() {
@@ -2986,7 +3015,7 @@ fn find_with_target_delimiter(bytes: &[u8], mut index: usize, end: usize) -> Opt
     None
 }
 
-fn invalid_with_target_error(source: &str) -> Option<(String, usize, usize)> {
+fn invalid_with_target_error(source: &str) -> Option<CpythonDiagnostic> {
     let bytes = source.as_bytes();
     let mut line_start = 0usize;
     for line in source.split_inclusive('\n') {
@@ -3039,7 +3068,7 @@ fn find_missing_in_if_keyword(bytes: &[u8], mut index: usize, end: usize) -> Opt
     None
 }
 
-fn invalid_for_if_clause_error(source: &str) -> Option<(String, usize, usize)> {
+fn invalid_for_if_clause_error(source: &str) -> Option<CpythonDiagnostic> {
     let bytes = source.as_bytes();
     let mut index = 0usize;
     let mut level = 0usize;
@@ -3065,7 +3094,7 @@ fn invalid_for_if_clause_error(source: &str) -> Option<(String, usize, usize)> {
                     .find('\n')
                     .map_or(bytes.len(), |newline| index + newline);
                 if let Some(if_index) = find_missing_in_if_keyword(bytes, target_start, line_end) {
-                    return Some((
+                    return Some(CpythonDiagnostic::new(
                         "'in' expected after for-loop variables".to_owned(),
                         if_index,
                         (if_index + 2).min(line_end),
@@ -3079,7 +3108,7 @@ fn invalid_for_if_clause_error(source: &str) -> Option<(String, usize, usize)> {
     None
 }
 
-fn invalid_delete_target_error(source: &str) -> Option<(String, usize, usize)> {
+fn invalid_delete_target_error(source: &str) -> Option<CpythonDiagnostic> {
     let bytes = source.as_bytes();
     let mut index = 0;
     while index < bytes.len() {
@@ -3112,14 +3141,14 @@ fn invalid_delete_target_error(source: &str) -> Option<(String, usize, usize)> {
                     continue;
                 }
                 if parenthesized_single_starred_delete_target(bytes, target_start, target_end) {
-                    return Some((
+                    return Some(CpythonDiagnostic::new(
                         "cannot use starred expression here".to_owned(),
                         target_start,
                         target_end,
                     ));
                 }
                 if bytes.get(target_start) == Some(&b'*') {
-                    return Some((
+                    return Some(CpythonDiagnostic::new(
                         "cannot delete starred".to_owned(),
                         target_start,
                         (target_start + 1).min(target_end),
@@ -3141,10 +3170,18 @@ fn invalid_delete_target_error(source: &str) -> Option<(String, usize, usize)> {
                 let start = target_start + invalid_target.range().start().to_usize();
                 let end = target_start + invalid_target.range().end().to_usize();
                 if matches!(invalid_target, ast::Expr::FString(_)) {
-                    return Some(("invalid syntax".to_owned(), start, end));
+                    return Some(CpythonDiagnostic::new(
+                        "invalid syntax".to_owned(),
+                        start,
+                        end,
+                    ));
                 }
                 let name = delete_target_expr_name(invalid_target);
-                return Some((format!("cannot delete {name}"), start, end));
+                return Some(CpythonDiagnostic::new(
+                    format!("cannot delete {name}"),
+                    start,
+                    end,
+                ));
             }
             _ => index += 1,
         }
@@ -3224,7 +3261,7 @@ fn expression_name_and_range(source: &str) -> Option<(&'static str, usize, usize
     ))
 }
 
-fn invalid_standalone_except_error(source: &str) -> Option<(String, usize, usize)> {
+fn invalid_standalone_except_error(source: &str) -> Option<CpythonDiagnostic> {
     let bytes = source.as_bytes();
     let mut line_start = 0usize;
     let mut seen_try = false;
@@ -3246,14 +3283,18 @@ fn invalid_standalone_except_error(source: &str) -> Option<(String, usize, usize
             } else {
                 column + 6
             };
-            return Some(("invalid syntax".to_owned(), column, end));
+            return Some(CpythonDiagnostic::new(
+                "invalid syntax".to_owned(),
+                column,
+                end,
+            ));
         }
         line_start = line_end;
     }
     None
 }
 
-fn invalid_import_statement_error(source: &str) -> Option<(String, usize, usize)> {
+fn invalid_import_statement_error(source: &str) -> Option<CpythonDiagnostic> {
     let bytes = source.as_bytes();
     let mut line_start = 0usize;
     for line in source.split_inclusive('\n') {
@@ -3263,7 +3304,7 @@ fn invalid_import_statement_error(source: &str) -> Option<(String, usize, usize)
             && starts_identifier(bytes, column, b"import")
             && find_keyword_at_level(bytes, column + 6, line_end, b"from").is_some()
         {
-            return Some((
+            return Some(CpythonDiagnostic::new(
                 "Did you mean to use 'from ... import ...' instead?".to_owned(),
                 column,
                 column + 6,
@@ -3323,7 +3364,7 @@ fn import_target_error_for_slice(
     source: &str,
     start: usize,
     end: usize,
-) -> Option<(String, usize, usize)> {
+) -> Option<CpythonDiagnostic> {
     let bytes = source.as_bytes();
     let (target_start, target_end) = trim_target_range(bytes, start, end);
     if target_start >= target_end || valid_import_alias_name(bytes, target_start, target_end) {
@@ -3340,7 +3381,11 @@ fn import_target_error_for_slice(
     let name = delete_target_expr_name(&expression.body);
     let start = target_start + expression.body.range().start().to_usize();
     let end = target_start + expression.body.range().end().to_usize();
-    Some((format!("cannot use {name} as import target"), start, end))
+    Some(CpythonDiagnostic::new(
+        format!("cannot use {name} as import target"),
+        start,
+        end,
+    ))
 }
 
 fn statement_starts_import(bytes: &[u8], line_start: usize, line_end: usize) -> bool {
@@ -3352,7 +3397,7 @@ fn statement_starts_import(bytes: &[u8], line_start: usize, line_end: usize) -> 
         && find_keyword_at_level(bytes, column + 4, line_end, b"import").is_some()
 }
 
-fn invalid_import_target_error(source: &str) -> Option<(String, usize, usize)> {
+fn invalid_import_target_error(source: &str) -> Option<CpythonDiagnostic> {
     let bytes = source.as_bytes();
     let mut line_start = 0usize;
     let mut in_parenthesized_from_import = false;
@@ -3387,7 +3432,7 @@ fn invalid_import_target_error(source: &str) -> Option<(String, usize, usize)> {
     None
 }
 
-fn invalid_except_as_target_error(source: &str) -> Option<(String, usize, usize)> {
+fn invalid_except_as_target_error(source: &str) -> Option<CpythonDiagnostic> {
     let bytes = source.as_bytes();
     let mut line_start = 0usize;
     let mut seen_try = false;
@@ -3443,7 +3488,7 @@ fn invalid_except_as_target_error(source: &str) -> Option<(String, usize, usize)
         };
         if !is_name {
             let statement = if starred { "except*" } else { "except" };
-            return Some((
+            return Some(CpythonDiagnostic::new(
                 format!("cannot use {statement} statement with {expr_name}"),
                 target_start + start,
                 target_start + end,
@@ -3454,7 +3499,7 @@ fn invalid_except_as_target_error(source: &str) -> Option<(String, usize, usize)
     None
 }
 
-fn invalid_match_as_target_error(source: &str) -> Option<(String, usize, usize)> {
+fn invalid_match_as_target_error(source: &str) -> Option<CpythonDiagnostic> {
     let bytes = source.as_bytes();
     let quoted_ranges = quoted_string_ranges(bytes);
     let mut quoted_range = 0usize;
@@ -3490,7 +3535,7 @@ fn invalid_match_as_target_error(source: &str) -> Option<(String, usize, usize)>
             target_end -= 1;
         }
         if source[target_start..target_end].trim() == "_" {
-            return Some((
+            return Some(CpythonDiagnostic::new(
                 "cannot use '_' as a target".to_owned(),
                 target_start,
                 target_end,
@@ -3507,7 +3552,7 @@ fn invalid_match_as_target_error(source: &str) -> Option<(String, usize, usize)>
                 line_start = line_end;
                 continue;
             }
-            return Some((
+            return Some(CpythonDiagnostic::new(
                 format!("cannot use {expr_name} as pattern target"),
                 target_start + start,
                 target_start + end,
@@ -3551,7 +3596,7 @@ fn offset_in_ranges(ranges: &[(usize, usize)], range_index: &mut usize, offset: 
         .is_some_and(|(start, end)| *start <= offset && offset < *end)
 }
 
-fn invalid_match_mapping_rest_wildcard_error(source: &str) -> Option<(String, usize, usize)> {
+fn invalid_match_mapping_rest_wildcard_error(source: &str) -> Option<CpythonDiagnostic> {
     let bytes = source.as_bytes();
     let next_line_end = |line_start: usize| {
         line_start
@@ -3596,7 +3641,7 @@ fn invalid_match_mapping_rest_wildcard_error(source: &str) -> Option<(String, us
                                 let name_start = next_non_horizontal_whitespace(bytes, rest + 2);
                                 let name_end = identifier_end(bytes, name_start, line_end);
                                 if source.get(name_start..name_end) == Some("_") {
-                                    return Some((
+                                    return Some(CpythonDiagnostic::new(
                                         "invalid syntax".to_owned(),
                                         name_start,
                                         name_end,
@@ -3615,7 +3660,7 @@ fn invalid_match_mapping_rest_wildcard_error(source: &str) -> Option<(String, us
     None
 }
 
-fn invalid_if_expression_statement_error(source: &str) -> Option<(String, usize, usize)> {
+fn invalid_if_expression_statement_error(source: &str) -> Option<CpythonDiagnostic> {
     let bytes = source.as_bytes();
     let mut line_start = 0usize;
     for line in source.split_inclusive('\n') {
@@ -3624,7 +3669,7 @@ fn invalid_if_expression_statement_error(source: &str) -> Option<(String, usize,
             && let Some((start, end)) = statement_before_if_expression(bytes, line_start, if_index)
             && find_keyword_at_level(bytes, if_index + 2, line_end, b"else").is_some()
         {
-            return Some((
+            return Some(CpythonDiagnostic::new(
                 "expected expression before 'if', but statement is given".to_owned(),
                 start,
                 end,
@@ -3635,7 +3680,7 @@ fn invalid_if_expression_statement_error(source: &str) -> Option<(String, usize,
             && let Some((start, end)) =
                 statement_after_else_expression(bytes, else_index + 4, line_end)
         {
-            return Some((
+            return Some(CpythonDiagnostic::new(
                 "expected expression after 'else', but statement is given".to_owned(),
                 start,
                 end,
@@ -3698,7 +3743,7 @@ fn statement_after_else_expression(
     None
 }
 
-fn invalid_else_elif_error(source: &str) -> Option<(String, usize, usize)> {
+fn invalid_else_elif_error(source: &str) -> Option<CpythonDiagnostic> {
     let bytes = source.as_bytes();
     let mut line_start = 0usize;
     let mut else_indents: Vec<usize> = Vec::new();
@@ -3721,7 +3766,7 @@ fn invalid_else_elif_error(source: &str) -> Option<(String, usize, usize)> {
         {
             else_indents.push(line_column);
         } else if starts_identifier(bytes, column, b"elif") && else_indents.contains(&line_column) {
-            return Some((
+            return Some(CpythonDiagnostic::new(
                 "'elif' block follows an 'else' block".to_owned(),
                 column,
                 column + 4,
@@ -3732,7 +3777,7 @@ fn invalid_else_elif_error(source: &str) -> Option<(String, usize, usize)> {
     None
 }
 
-fn mixed_except_handlers_error(source: &str) -> Option<(String, usize, usize)> {
+fn mixed_except_handlers_error(source: &str) -> Option<CpythonDiagnostic> {
     let message = "cannot have both 'except' and 'except*' on the same 'try'".to_owned();
     let mut seen_except = false;
     let mut seen_except_star = false;
@@ -3746,12 +3791,20 @@ fn mixed_except_handlers_error(source: &str) -> Option<(String, usize, usize)> {
         let token_start = line_start + column;
         if bytes.get(column..column + 7) == Some(b"except*") {
             if seen_except {
-                return Some((message, token_start, token_start + 7));
+                return Some(CpythonDiagnostic::new(
+                    message,
+                    token_start,
+                    token_start + 7,
+                ));
             }
             seen_except_star = true;
         } else if starts_identifier(bytes, column, b"except") {
             if seen_except_star {
-                return Some((message, token_start, token_start + 6));
+                return Some(CpythonDiagnostic::new(
+                    message,
+                    token_start,
+                    token_start + 6,
+                ));
             }
             seen_except = true;
         }
@@ -3760,7 +3813,7 @@ fn mixed_except_handlers_error(source: &str) -> Option<(String, usize, usize)> {
     None
 }
 
-fn non_printable_character_error(source: &str) -> Option<(String, usize, usize)> {
+fn non_printable_character_error(source: &str) -> Option<CpythonDiagnostic> {
     let bytes = source.as_bytes();
     let mut index = 0;
     while index < bytes.len() {
@@ -3774,7 +3827,7 @@ fn non_printable_character_error(source: &str) -> Option<(String, usize, usize)>
                 index = skip_quoted_string(bytes, index);
             }
             byte if byte.is_ascii_control() && !matches!(byte, b'\t' | b'\n' | b'\r' | b'\x0c') => {
-                return Some((
+                return Some(CpythonDiagnostic::new(
                     format!("invalid non-printable character U+{byte:04X}"),
                     index,
                     index + 1,
@@ -3783,7 +3836,7 @@ fn non_printable_character_error(source: &str) -> Option<(String, usize, usize)>
             byte if byte >= 0x80 => {
                 let ch = source[index..].chars().next()?;
                 if ch.is_control() {
-                    return Some((
+                    return Some(CpythonDiagnostic::new(
                         format!("invalid non-printable character U+{:04X}", ch as u32),
                         index,
                         index + ch.len_utf8(),
@@ -3797,7 +3850,7 @@ fn non_printable_character_error(source: &str) -> Option<(String, usize, usize)>
     None
 }
 
-fn unterminated_string_error(source: &str) -> Option<(String, usize, usize)> {
+fn unterminated_string_error(source: &str) -> Option<CpythonDiagnostic> {
     let bytes = source.as_bytes();
     let mut index = 0;
     let mut line = 1usize;
@@ -3837,7 +3890,7 @@ fn unterminated_string_error(source: &str) -> Option<(String, usize, usize)> {
                             ) {
                                 return Some(error);
                             }
-                            return Some((
+                            return Some(CpythonDiagnostic::new(
                                 unterminated_string_message(
                                     line,
                                     false,
@@ -3881,7 +3934,7 @@ fn unterminated_string_error(source: &str) -> Option<(String, usize, usize)> {
                         return Some(error);
                     }
                     let detected_line = if quote_size == 3 { line } else { start_line };
-                    return Some((
+                    return Some(CpythonDiagnostic::new(
                         unterminated_string_message(
                             detected_line,
                             quote_size == 3,
@@ -3899,7 +3952,7 @@ fn unterminated_string_error(source: &str) -> Option<(String, usize, usize)> {
     None
 }
 
-fn invalid_interpolated_string_error(source: &str) -> Option<(String, usize, usize)> {
+fn invalid_interpolated_string_error(source: &str) -> Option<CpythonDiagnostic> {
     let bytes = source.as_bytes();
     let mut index = 0;
     while index < bytes.len() {
@@ -3970,7 +4023,7 @@ fn is_bytes_literal(bytes: &[u8], quote: usize) -> bool {
 fn mixed_tstring_literal_error(
     error: &parser::ParseError,
     source: &str,
-) -> Option<(String, usize, usize)> {
+) -> Option<CpythonDiagnostic> {
     let parser::ParseErrorType::OtherError(message) = &error.error else {
         return None;
     };
@@ -3998,7 +4051,7 @@ fn mixed_tstring_literal_error(
                     } else {
                         "cannot mix t-string literals with string or bytes literals"
                     };
-                    return Some((message.to_owned(), start, end));
+                    return Some(CpythonDiagnostic::new(message.to_owned(), start, end));
                 }
                 if is_bytes_literal(bytes, index) {
                     bytes_seen = true;
@@ -4018,7 +4071,7 @@ fn single_quoted_format_spec_newline_error(
     quote_index: usize,
     quote: u8,
     prefix: &str,
-) -> Option<(String, usize, usize)> {
+) -> Option<CpythonDiagnostic> {
     if bytes.get(quote_index + 1) == Some(&quote) && bytes.get(quote_index + 2) == Some(&quote) {
         return None;
     }
@@ -4038,7 +4091,7 @@ fn single_quoted_format_spec_newline_error(
                         replacement_field_closing_brace(bytes, separator + 1, content_end)
                             .unwrap_or(content_end);
                     if bytes[separator + 1..format_end].contains(&b'\n') {
-                        return Some((
+                        return Some(CpythonDiagnostic::new(
                             format!(
                                 "{prefix}: newlines are not allowed in format specifiers for single quoted {prefix}s"
                             ),
@@ -4116,7 +4169,7 @@ fn invalid_replacement_field_error(
     start: usize,
     end: usize,
     prefix: &str,
-) -> Option<(String, usize, usize)> {
+) -> Option<CpythonDiagnostic> {
     let mut index = start;
     while index < end {
         match bytes[index] {
@@ -4166,7 +4219,7 @@ fn replacement_field_bracket_error(
     start: usize,
     end: usize,
     prefix: &str,
-) -> Option<(String, usize, usize)> {
+) -> Option<CpythonDiagnostic> {
     // Each entry carries where its bracket opened, so a mismatch can name that line.
     let mut stack: Vec<(u8, usize)> = Vec::new();
     let mut index = start;
@@ -4188,7 +4241,7 @@ fn replacement_field_bracket_error(
                     // The field's own closing brace: everything inside it balanced.
                     None if byte == b'}' => return None,
                     None => {
-                        return Some((
+                        return Some(CpythonDiagnostic::new(
                             format!("{prefix}: unmatched '{}'", byte as char),
                             index,
                             index + 1,
@@ -4206,7 +4259,7 @@ fn replacement_field_bracket_error(
                         } else {
                             format!(" on line {opening_line}")
                         };
-                        return Some((
+                        return Some(CpythonDiagnostic::new(
                             format!(
                                 "closing parenthesis '{}' does not match opening parenthesis '{}'{suffix}",
                                 byte as char, opening as char
@@ -4234,7 +4287,7 @@ fn replacement_field_comment_error(
     start: usize,
     end: usize,
     literal_end: usize,
-) -> Option<(String, usize, usize)> {
+) -> Option<CpythonDiagnostic> {
     let mut index = start;
     while index < end {
         match bytes[index] {
@@ -4244,7 +4297,11 @@ fn replacement_field_comment_error(
             }
             b'#' => {
                 if !bytes[index..literal_end].contains(&b'\n') {
-                    return Some(("'{' was never closed".to_owned(), open, open + 1));
+                    return Some(CpythonDiagnostic::new(
+                        "'{' was never closed".to_owned(),
+                        open,
+                        open + 1,
+                    ));
                 }
                 index = skip_replacement_field_comment(bytes, index, end);
                 continue;
@@ -4285,7 +4342,7 @@ fn replacement_field_error(
     end: usize,
     prefix: &str,
     depth: usize,
-) -> Option<(String, usize, usize)> {
+) -> Option<CpythonDiagnostic> {
     let expr_start = skip_replacement_field_trivia(bytes, open + 1, end);
 
     // The expression runs up to the field's first top-level `=`, `!`, `:` or `}`. Everything past
@@ -4295,14 +4352,14 @@ fn replacement_field_error(
     let expr_end = separator.unwrap_or(end);
 
     if let Some(backslash) = replacement_field_line_continuation(bytes, expr_start, expr_end) {
-        return Some((
+        return Some(CpythonDiagnostic::new(
             "unexpected character after line continuation character".to_owned(),
             backslash + 1,
             (backslash + 2).min(end),
         ));
     }
     if let Some(quote) = unterminated_string_in_replacement_field(bytes, expr_start, expr_end) {
-        return Some((
+        return Some(CpythonDiagnostic::new(
             unterminated_string_message(1, false, false, None),
             quote,
             quote + 1,
@@ -4321,13 +4378,17 @@ fn replacement_field_error(
     // Nothing follows `{` at all, so the field simply never closed. CPython asks for the
     // brace here; an expression that merely fails to start is reported further down.
     if expr_start >= end {
-        return Some((format!("{prefix}: expecting '}}'"), open, open + 1));
+        return Some(CpythonDiagnostic::new(
+            format!("{prefix}: expecting '}}'"),
+            open,
+            open + 1,
+        ));
     }
 
     if let marker @ (b'=' | b'!' | b':' | b'}') = bytes[expr_start]
         && is_replacement_field_marker(bytes, expr_start)
     {
-        return Some((
+        return Some(CpythonDiagnostic::new(
             format!(
                 "{prefix}: valid expression required before '{}'",
                 marker as char
@@ -4345,7 +4406,7 @@ fn replacement_field_error(
             && bytes[inner] != b'}'
             && invalid_replacement_expression_start(bytes, inner, end)
         {
-            return Some((
+            return Some(CpythonDiagnostic::new(
                 format!("{prefix}: expecting a valid expression after '{{'"),
                 expr_start,
                 expr_start + 1,
@@ -4354,7 +4415,7 @@ fn replacement_field_error(
     }
 
     if starts_identifier(bytes, expr_start, b"lambda") {
-        return Some((
+        return Some(CpythonDiagnostic::new(
             format!("{prefix}: lambda expressions are not allowed without parentheses"),
             expr_start,
             expr_start + b"lambda".len(),
@@ -4362,7 +4423,7 @@ fn replacement_field_error(
     }
 
     if invalid_replacement_expression_start(bytes, expr_start, end) {
-        return Some((
+        return Some(CpythonDiagnostic::new(
             format!("{prefix}: expecting a valid expression after '{{'"),
             open,
             open + 1,
@@ -4372,7 +4433,7 @@ fn replacement_field_error(
     // The expression started fine but ran into a character that cannot continue it. CPython
     // points at that character and lists the separators it wanted instead.
     if let Some(stray) = replacement_expression_stray_character(bytes, expr_start, expr_end) {
-        return Some((
+        return Some(CpythonDiagnostic::new(
             format!("{prefix}: expecting '=', or '!', or ':', or '}}'"),
             stray,
             stray + 1,
@@ -4380,7 +4441,11 @@ fn replacement_field_error(
     }
 
     let Some(separator) = separator else {
-        return Some((format!("{prefix}: expecting '}}'"), open, open + 1));
+        return Some(CpythonDiagnostic::new(
+            format!("{prefix}: expecting '}}'"),
+            open,
+            open + 1,
+        ));
     };
 
     // Only now that the field is known to close. A stray character above is a finished token
@@ -4388,7 +4453,7 @@ fn replacement_field_error(
     // producing that token runs into the literal's closing quote: lexer.c then answers from
     // `INSIDE_FSTRING(tok)` with "%c-string: expecting '}'" before any `invalid_` rule is tried.
     if let Some(operator) = dangling_operator(bytes, expr_start, expr_end) {
-        return Some((
+        return Some(CpythonDiagnostic::new(
             format!("{prefix}: expecting '=', or '!', or ':', or '}}'"),
             operator,
             operator + 1,
@@ -4398,7 +4463,11 @@ fn replacement_field_error(
     if bytes[separator] == b':'
         && replacement_expression_has_parse_error(bytes, expr_start, separator)
     {
-        return Some(("invalid syntax".to_owned(), expr_start, separator));
+        return Some(CpythonDiagnostic::new(
+            "invalid syntax".to_owned(),
+            expr_start,
+            separator,
+        ));
     }
 
     match bytes[separator] {
@@ -4720,7 +4789,7 @@ fn invalid_debug_expression_error(
     end: usize,
     prefix: &str,
     depth: usize,
-) -> Option<(String, usize, usize)> {
+) -> Option<CpythonDiagnostic> {
     let next = equals + 1;
     if next >= end {
         return None;
@@ -4733,7 +4802,7 @@ fn invalid_debug_expression_error(
         b'}' => return None,
         _ => {}
     }
-    Some((
+    Some(CpythonDiagnostic::new(
         format!("{prefix}: expecting '!', or ':', or '}}'"),
         next,
         next.saturating_add(1).min(end),
@@ -4746,10 +4815,14 @@ fn invalid_conversion_error(
     end: usize,
     prefix: &str,
     depth: usize,
-) -> Option<(String, usize, usize)> {
+) -> Option<CpythonDiagnostic> {
     let next = bang + 1;
     if next >= end {
-        return Some((format!("{prefix}: expecting '}}'"), bang, bang + 1));
+        return Some(CpythonDiagnostic::new(
+            format!("{prefix}: expecting '}}'"),
+            bang,
+            bang + 1,
+        ));
     }
 
     if bytes[next].is_ascii_whitespace() {
@@ -4762,11 +4835,15 @@ fn invalid_conversion_error(
         } else {
             "missing conversion character"
         };
-        return Some((format!("{prefix}: {message}"), next, next + 1));
+        return Some(CpythonDiagnostic::new(
+            format!("{prefix}: {message}"),
+            next,
+            next + 1,
+        ));
     }
 
     if matches!(bytes[next], b':' | b'}') {
-        return Some((
+        return Some(CpythonDiagnostic::new(
             format!("{prefix}: missing conversion character"),
             next,
             next + 1,
@@ -4780,7 +4857,7 @@ fn invalid_conversion_error(
             .ok()
             .and_then(|text| text.chars().next())
     {
-        return Some((
+        return Some(CpythonDiagnostic::new(
             format!(
                 "{prefix}: invalid conversion character '{character}': expected 's', 'r', or 'a'"
             ),
@@ -4790,7 +4867,7 @@ fn invalid_conversion_error(
     }
 
     if !bytes[next].is_ascii_alphabetic() && bytes[next] != b'_' {
-        return Some((
+        return Some(CpythonDiagnostic::new(
             format!("{prefix}: invalid conversion character"),
             next,
             next + 1,
@@ -4801,7 +4878,7 @@ fn invalid_conversion_error(
     let conversion = &bytes[next..conversion_end];
     if !matches!(conversion, b"s" | b"r" | b"a") {
         let conversion = ::core::str::from_utf8(conversion).unwrap_or("");
-        return Some((
+        return Some(CpythonDiagnostic::new(
             format!(
                 "{prefix}: invalid conversion character '{conversion}': expected 's', 'r', or 'a'"
             ),
@@ -4820,7 +4897,7 @@ fn invalid_conversion_error(
         _ => {}
     }
 
-    Some((
+    Some(CpythonDiagnostic::new(
         format!("{prefix}: expecting ':' or '}}'"),
         conversion_end,
         conversion_end + 1,
@@ -4833,7 +4910,7 @@ fn invalid_format_spec_error(
     end: usize,
     prefix: &str,
     depth: usize,
-) -> Option<(String, usize, usize)> {
+) -> Option<CpythonDiagnostic> {
     // Unlike literal text, a format spec has no `{{` escape: every `{` opens a nested
     // replacement field, so the outer scanner cannot validate these for us.
     let mut index = colon + 1;
@@ -4858,7 +4935,7 @@ fn invalid_format_spec_error(
             _ => index += 1,
         }
     }
-    Some((
+    Some(CpythonDiagnostic::new(
         format!("{prefix}: expecting '}}', or format specs"),
         colon,
         colon + 1,
@@ -4951,11 +5028,11 @@ fn string_literal_prefix(bytes: &[u8], start: usize, quote: usize) -> bool {
     valid && (start == 0 || !is_ascii_identifier_char(bytes[start - 1]))
 }
 
-fn invalid_expression_error(source: &str) -> Option<(String, usize, usize)> {
+fn invalid_expression_error(source: &str) -> Option<CpythonDiagnostic> {
     invalid_string_expression_error(source).or_else(|| missing_comma_expression_error(source))
 }
 
-fn invalid_string_expression_error(source: &str) -> Option<(String, usize, usize)> {
+fn invalid_string_expression_error(source: &str) -> Option<CpythonDiagnostic> {
     let bytes = source.as_bytes();
     let mut index = 0;
     while index < bytes.len() {
@@ -4966,7 +5043,7 @@ fn invalid_string_expression_error(source: &str) -> Option<(String, usize, usize
             {
                 let next = skip_ascii_whitespace(bytes, expr_end, bytes.len());
                 if string_literal_end_at(bytes, next).is_some() {
-                    return Some((
+                    return Some(CpythonDiagnostic::new(
                         "invalid syntax. Is this intended to be part of the string?".to_owned(),
                         expr_start,
                         expr_end,
@@ -4981,7 +5058,7 @@ fn invalid_string_expression_error(source: &str) -> Option<(String, usize, usize
     None
 }
 
-fn missing_comma_expression_error(source: &str) -> Option<(String, usize, usize)> {
+fn missing_comma_expression_error(source: &str) -> Option<CpythonDiagnostic> {
     let bytes = source.as_bytes();
     let mut stack: Vec<u8> = Vec::new();
     let mut index = 0;
@@ -5025,7 +5102,7 @@ fn missing_comma_expression_error(source: &str) -> Option<(String, usize, usize)
                         // first byte instead, which is only the same thing
                         // when that atom is one ASCII character.
                         let second_end = adjacent_atom_end(bytes, next).unwrap_or(next + 1);
-                        return Some((
+                        return Some(CpythonDiagnostic::new(
                             "invalid syntax. Perhaps you forgot a comma?".to_owned(),
                             index,
                             second_end,
@@ -5108,6 +5185,12 @@ fn adjacent_atom_end(bytes: &[u8], index: usize) -> Option<usize> {
     }
 }
 
+struct OpenDelimiter {
+    position: usize,
+    opener: u8,
+    in_format_spec: bool,
+}
+
 /// An f-string or t-string that runs off the end with a replacement field still open reports
 /// the brace rather than the missing quote, matching CPython — but only while the tokenizer is
 /// still reading the field's *expression*. Past the field's own `:` it is emitting FSTRING_MIDDLE
@@ -5118,23 +5201,33 @@ fn unclosed_replacement_field_error(
     quote_start: usize,
     content_start: usize,
     content_end: usize,
-) -> Option<(String, usize, usize)> {
+) -> Option<CpythonDiagnostic> {
     interpolated_string_prefix(bytes, quote_start)?;
 
-    // One entry per unclosed delimiter: its position, its opening character, and — for a brace —
-    // whether that field has reached its format spec. Brackets and quotes are only delimiters
-    // once a field is open; in the literal's text they are ordinary characters. A brace nested
-    // in an expression is a set or dict display rather than a field, but it nests all the same.
-    let mut open: Vec<(usize, u8, bool)> = Vec::new();
+    // Brackets and quotes are delimiters only once a field is open; in the literal's text they
+    // are ordinary characters. And past a field's own format spec the tokenizer emits literal
+    // text again, so a field still open at end of input is an unclosed brace only before that.
+    let mut open: Vec<OpenDelimiter> = Vec::new();
     let mut index = content_start;
     while index < content_end {
-        let inside_expression = matches!(open.last(), Some((_, b'{', false)));
+        let inside_expression = matches!(
+            open.last(),
+            Some(OpenDelimiter {
+                opener: b'{',
+                in_format_spec: false,
+                ..
+            })
+        );
         match bytes[index] {
             // `{{` and `}}` escape only in literal text, which is where a brace at depth zero is.
             b'{' if open.is_empty() && bytes.get(index + 1) == Some(&b'{') => index += 2,
             b'}' if open.is_empty() && bytes.get(index + 1) == Some(&b'}') => index += 2,
             b'{' => {
-                open.push((index, b'{', false));
+                open.push(OpenDelimiter {
+                    position: index,
+                    opener: b'{',
+                    in_format_spec: false,
+                });
                 index += 1;
             }
             b'}' => {
@@ -5142,7 +5235,11 @@ fn unclosed_replacement_field_error(
                 index += 1;
             }
             byte @ (b'(' | b'[') if !open.is_empty() => {
-                open.push((index, byte, false));
+                open.push(OpenDelimiter {
+                    position: index,
+                    opener: byte,
+                    in_format_spec: false,
+                });
                 index += 1;
             }
             b')' | b']' if !open.is_empty() => {
@@ -5152,7 +5249,7 @@ fn unclosed_replacement_field_error(
             // Only the field's own `:` opens a format spec — one in a slice, a display or a
             // lambda belongs to whatever bracket encloses it.
             b':' if inside_expression => {
-                open.last_mut().expect("a brace is open").2 = true;
+                open.last_mut().expect("a brace is open").in_format_spec = true;
                 index += 1;
             }
             b'\'' | b'"' if !open.is_empty() => {
@@ -5167,9 +5264,13 @@ fn unclosed_replacement_field_error(
 
     // CPython names the innermost unclosed delimiter, so a bracket opened inside the expression
     // takes the message from the field that encloses it.
-    let (position, opener, in_format_spec) = *open.last()?;
+    let &OpenDelimiter {
+        position,
+        opener,
+        in_format_spec,
+    } = open.last()?;
     (!in_format_spec).then(|| {
-        (
+        CpythonDiagnostic::new(
             format!("'{}' was never closed", opener as char),
             position,
             position + 1,
@@ -5208,7 +5309,14 @@ fn expected_opening_bracket(closing: char) -> char {
     }
 }
 
-fn bracket_syntax_error(source: &str) -> Option<(String, usize, usize, bool)> {
+/// A bracket diagnostic, and whether it is an opener that was never closed. The caller needs
+/// that apart from the message because ruff reports the unclosed case as an EOF error.
+struct BracketError {
+    diagnostic: CpythonDiagnostic,
+    unclosed: bool,
+}
+
+fn bracket_syntax_error(source: &str) -> Option<BracketError> {
     let mut stack: Vec<(char, usize, usize)> = Vec::new();
     let mut in_string = false;
     let mut string_quote = '\0';
@@ -5289,7 +5397,14 @@ fn bracket_syntax_error(source: &str) -> Option<(String, usize, usize, bool)> {
             ')' | ']' | '}' => {
                 let expected = expected_opening_bracket(ch);
                 let Some(&(opening, _, opening_line)) = stack.last() else {
-                    return Some((format!("unmatched '{ch}'"), byte_offset, byte_offset, false));
+                    return Some(BracketError {
+                        diagnostic: CpythonDiagnostic::new(
+                            format!("unmatched '{ch}'"),
+                            byte_offset,
+                            byte_offset,
+                        ),
+                        unclosed: false,
+                    });
                 };
                 if opening == expected {
                     stack.pop();
@@ -5299,14 +5414,16 @@ fn bracket_syntax_error(source: &str) -> Option<(String, usize, usize, bool)> {
                     } else {
                         String::new()
                     };
-                    return Some((
-                        format!(
-                            "closing parenthesis '{ch}' does not match opening parenthesis '{opening}'{suffix}"
+                    return Some(BracketError {
+                        diagnostic: CpythonDiagnostic::new(
+                            format!(
+                                "closing parenthesis '{ch}' does not match opening parenthesis '{opening}'{suffix}"
+                            ),
+                            byte_offset,
+                            byte_offset,
                         ),
-                        byte_offset,
-                        byte_offset,
-                        false,
-                    ));
+                        unclosed: false,
+                    });
                 }
             }
             _ => {}
@@ -5315,13 +5432,13 @@ fn bracket_syntax_error(source: &str) -> Option<(String, usize, usize, bool)> {
         index += 1;
     }
 
-    stack.last().map(|(opening, byte_offset, _)| {
-        (
+    stack.last().map(|(opening, byte_offset, _)| BracketError {
+        diagnostic: CpythonDiagnostic::new(
             format!("'{opening}' was never closed"),
             *byte_offset,
             *byte_offset,
-            true,
-        )
+        ),
+        unclosed: true,
     })
 }
 
@@ -5381,7 +5498,7 @@ fn legacy_statement_container_has_invalid_attribute(bytes: &[u8], start: usize) 
     false
 }
 
-fn invalid_legacy_statement_error(source: &str) -> Option<(String, usize, usize)> {
+fn invalid_legacy_statement_error(source: &str) -> Option<CpythonDiagnostic> {
     let bytes = source.as_bytes();
     let mut index = 0;
     while index < bytes.len() {
@@ -5422,7 +5539,7 @@ fn invalid_legacy_statement_error(source: &str) -> Option<(String, usize, usize)
                 if bytes.get(cursor).is_some_and(|byte| {
                     *byte != b'(' && is_legacy_statement_expression_start(*byte)
                 }) {
-                    return Some((
+                    return Some(CpythonDiagnostic::new(
                         format!(
                             "Missing parentheses in call to '{keyword}'. Did you mean {keyword}(...)?"
                         ),
@@ -5467,19 +5584,14 @@ pub fn long_decimal_integer_literal_error(
         let digits = literal.bytes().filter(u8::is_ascii_digit).count();
         (digits > max_str_digits).then(|| {
             let start = token.range().start().to_usize();
-            CompileError::from_source_error(
-                source_file,
-                format!(
+            CompileError::from_source_error(source_file, CpythonDiagnostic::new(format!(
                     "Exceeds the limit ({max_str_digits} digits) for integer string conversion: value has {digits} digits; use sys.set_int_max_str_digits() to increase the limit - Consider hexadecimal for huge integer literals to avoid decimal conversion limits."
-                ),
-                start,
-                start,
-            )
+                ), start, start))
         })
     })
 }
 
-fn invalid_parenthesized_import_star_error(source: &str) -> Option<(String, usize, usize)> {
+fn invalid_parenthesized_import_star_error(source: &str) -> Option<CpythonDiagnostic> {
     let bytes = source.as_bytes();
     let mut index = 0;
     while index < bytes.len() {
@@ -5506,7 +5618,11 @@ fn invalid_parenthesized_import_star_error(source: &str) -> Option<(String, usiz
                                 && !matches!(bytes[cursor], b')' | b'\n' | b';')
                             {
                                 if bytes[cursor] == b'*' {
-                                    return Some(("invalid syntax".to_owned(), cursor, cursor + 1));
+                                    return Some(CpythonDiagnostic::new(
+                                        "invalid syntax".to_owned(),
+                                        cursor,
+                                        cursor + 1,
+                                    ));
                                 }
                                 cursor += 1;
                             }
@@ -5523,7 +5639,7 @@ fn invalid_parenthesized_import_star_error(source: &str) -> Option<(String, usiz
     None
 }
 
-fn too_many_nested_parentheses_error(source: &str) -> Option<(String, usize, usize)> {
+fn too_many_nested_parentheses_error(source: &str) -> Option<CpythonDiagnostic> {
     const MAXLEVEL: usize = 200;
 
     let bytes = source.as_bytes();
@@ -5541,7 +5657,11 @@ fn too_many_nested_parentheses_error(source: &str) -> Option<(String, usize, usi
             }
             b'(' | b'[' | b'{' => {
                 if level >= MAXLEVEL {
-                    return Some(("too many nested parentheses".to_owned(), index, index + 1));
+                    return Some(CpythonDiagnostic::new(
+                        "too many nested parentheses".to_owned(),
+                        index,
+                        index + 1,
+                    ));
                 }
                 level += 1;
                 index += 1;
@@ -5556,7 +5676,7 @@ fn too_many_nested_parentheses_error(source: &str) -> Option<(String, usize, usi
     None
 }
 
-fn invalid_unparenthesized_yield_after_comma_error(source: &str) -> Option<(String, usize, usize)> {
+fn invalid_unparenthesized_yield_after_comma_error(source: &str) -> Option<CpythonDiagnostic> {
     let bytes = source.as_bytes();
     let mut index = 0;
     while index < bytes.len() {
@@ -5575,7 +5695,11 @@ fn invalid_unparenthesized_yield_after_comma_error(source: &str) -> Option<(Stri
                     cursor += 1;
                 }
                 if starts_identifier(bytes, cursor, b"yield") {
-                    return Some(("invalid syntax".to_owned(), cursor, cursor + 5));
+                    return Some(CpythonDiagnostic::new(
+                        "invalid syntax".to_owned(),
+                        cursor,
+                        cursor + 5,
+                    ));
                 }
                 index += 1;
             }
@@ -5595,9 +5719,7 @@ pub fn leading_byte_order_mark_error(source_file: &SourceFile) -> Option<Compile
     source_file.source_text().starts_with('\u{feff}').then(|| {
         CompileError::from_source_error(
             source_file,
-            "invalid non-printable character U+FEFF".to_owned(),
-            0,
-            0,
+            CpythonDiagnostic::new("invalid non-printable character U+FEFF".to_owned(), 0, 0),
         )
     })
 }
@@ -5610,15 +5732,8 @@ fn post_parse_source_error(
     if let Some(error) = leading_byte_order_mark_error(source_file) {
         return Some(error);
     }
-    if let Some((message, start, end)) =
-        too_many_nested_parentheses_error(source_file.source_text())
-    {
-        return Some(CompileError::from_source_error(
-            source_file,
-            message,
-            start,
-            end,
-        ));
+    if let Some(error) = too_many_nested_parentheses_error(source_file.source_text()) {
+        return Some(CompileError::from_source_error(source_file, error));
     }
     if let Some(error) =
         long_decimal_integer_literal_error(source_file, tokens, opts.int_max_str_digits)
@@ -5630,9 +5745,7 @@ fn post_parse_source_error(
         .or_else(|| invalid_match_as_target_error(source_file.source_text()))
         .or_else(|| invalid_unparenthesized_yield_after_comma_error(source_file.source_text()))
         .or_else(|| invalid_parenthesized_import_star_error(source_file.source_text()))
-        .map(|(message, start, end)| {
-            CompileError::from_source_error(source_file, message, start, end)
-        })
+        .map(|error| CompileError::from_source_error(source_file, error))
 }
 
 fn is_compound_stmt(stmt: &ast::Stmt) -> bool {
@@ -5672,9 +5785,11 @@ pub fn unsupported_grammar_error(ast: &ast::Mod, source_file: &SourceFile) -> Op
         fn fail(&mut self, message: &str, range: ruff_text_size::TextRange) {
             self.error = Some(CompileError::from_source_error(
                 self.source_file,
-                message.to_owned(),
-                range.start().to_usize(),
-                range.end().to_usize(),
+                CpythonDiagnostic::new(
+                    message.to_owned(),
+                    range.start().to_usize(),
+                    range.end().to_usize(),
+                ),
             ));
         }
 
@@ -5776,9 +5891,11 @@ fn single_mode_body_error(body: &[ast::Stmt], source_file: &SourceFile) -> Optio
     }) {
         return Some(CompileError::from_source_error(
             source_file,
-            "multiple statements found while compiling a single statement".to_owned(),
-            first.range().end().to_usize(),
-            first.range().end().to_usize(),
+            CpythonDiagnostic::new(
+                "multiple statements found while compiling a single statement".to_owned(),
+                first.range().end().to_usize(),
+                first.range().end().to_usize(),
+            ),
         ));
     }
 
@@ -5788,9 +5905,11 @@ fn single_mode_body_error(body: &[ast::Stmt], source_file: &SourceFile) -> Optio
     {
         return Some(CompileError::from_source_error(
             source_file,
-            "invalid syntax".to_owned(),
-            first.range().start().to_usize(),
-            first.range().start().to_usize(),
+            CpythonDiagnostic::new(
+                "invalid syntax".to_owned(),
+                first.range().start().to_usize(),
+                first.range().start().to_usize(),
+            ),
         ));
     }
     None
@@ -5833,9 +5952,7 @@ pub fn dont_imply_dedent_source_error(source_file: &SourceFile) -> Option<Compil
     let eof = source.len();
     Some(CompileError::from_source_error(
         source_file,
-        "incomplete input".to_owned(),
-        eof,
-        eof,
+        CpythonDiagnostic::new("incomplete input".to_owned(), eof, eof),
     ))
 }
 
@@ -6125,9 +6242,11 @@ pub fn barry_as_flufl_not_equal_error(
 ) -> CompileError {
     CompileError::from_source_error(
         source_file,
-        "with Barry as BDFL, use '<>' instead of '!='".to_owned(),
-        range.start().to_usize(),
-        range.end().to_usize(),
+        CpythonDiagnostic::new(
+            "with Barry as BDFL, use '<>' instead of '!='".to_owned(),
+            range.start().to_usize(),
+            range.end().to_usize(),
+        ),
     )
 }
 
@@ -6139,9 +6258,11 @@ pub fn barry_as_flufl_invalid_legacy_operator_error(
 ) -> CompileError {
     CompileError::from_source_error(
         source_file,
-        "invalid syntax".to_owned(),
-        range.start().to_usize(),
-        range.end().to_usize(),
+        CpythonDiagnostic::new(
+            "invalid syntax".to_owned(),
+            range.start().to_usize(),
+            range.end().to_usize(),
+        ),
     )
 }
 

--- a/crates/compiler/src/lib.rs
+++ b/crates/compiler/src/lib.rs
@@ -4602,25 +4602,8 @@ fn is_replacement_field_marker(bytes: &[u8], index: usize) -> bool {
             }
             !index
                 .checked_sub(1)
-                .and_then(|previous| bytes.get(previous))
-                .is_some_and(|byte| {
-                    matches!(
-                        byte,
-                        b'=' | b'!'
-                            | b'<'
-                            | b'>'
-                            | b'+'
-                            | b'-'
-                            | b'*'
-                            | b'/'
-                            | b'%'
-                            | b'&'
-                            | b'|'
-                            | b'^'
-                            | b'@'
-                            | b':'
-                    )
-                })
+                .and_then(|previous| bytes.get(previous).copied())
+                .is_some_and(precedes_equals_in_one_operator)
         }
         b'!' => bytes.get(index + 1) != Some(&b'='),
         _ => true,
@@ -4674,24 +4657,49 @@ fn replacement_expression_stray_character(
     None
 }
 
-/// Characters that make up an operator which cannot end an expression.
+/// A byte that pairs with a following `=` to make one operator token, so that the `=` belongs
+/// to it rather than opening a debug specifier: `==`, `!=`, `<=`, `>=`, the augmented
+/// assignments, and the `:=` walrus. Against `is_dangling_operator_byte` below, this has `:`
+/// and lacks `.` and `~`, because neither `.=` nor `~=` is a Python operator.
+const fn precedes_equals_in_one_operator(byte: u8) -> bool {
+    matches!(
+        byte,
+        b'!' | b'%'
+            | b'&'
+            | b'*'
+            | b'+'
+            | b'-'
+            | b'/'
+            | b':'
+            | b'<'
+            | b'='
+            | b'>'
+            | b'@'
+            | b'^'
+            | b'|'
+    )
+}
+
+/// Characters that make up an operator which cannot end an expression. Against
+/// `precedes_equals_in_one_operator` above, this has `.` and `~` for `a.b.` and `~a`, and lacks
+/// `:`, which separates a replacement field's parts rather than operating on anything.
 const fn is_dangling_operator_byte(byte: u8) -> bool {
     matches!(
         byte,
-        b'+' | b'-'
-            | b'*'
-            | b'/'
-            | b'%'
-            | b'@'
-            | b'|'
+        b'!' | b'%'
             | b'&'
-            | b'^'
-            | b'~'
-            | b'<'
-            | b'>'
-            | b'='
-            | b'!'
+            | b'*'
+            | b'+'
+            | b'-'
             | b'.'
+            | b'/'
+            | b'<'
+            | b'='
+            | b'>'
+            | b'@'
+            | b'^'
+            | b'|'
+            | b'~'
     )
 }
 

--- a/crates/vm/src/builtins/str.rs
+++ b/crates/vm/src/builtins/str.rs
@@ -661,7 +661,7 @@ impl PyStr {
         } else {
             Err(vm.new_type_error(format!(
                 r#"can only concatenate str (not "{}") to str"#,
-                other.class().name()
+                other.class().slot_name()
             )))
         }
     }

--- a/crates/vm/src/builtins/template.rs
+++ b/crates/vm/src/builtins/template.rs
@@ -5,7 +5,7 @@ use super::{
 use crate::{
     AsObject, Context, Py, PyObject, PyObjectRef, PyPayload, PyRef, PyResult, VirtualMachine,
     atomic_func,
-    class::PyClassImpl,
+    class::{PyClassDef, PyClassImpl},
     common::lock::LazyLock,
     function::{FuncArgs, PyComparisonValue},
     protocol::{PyIterReturn, PySequenceMethods},
@@ -125,8 +125,9 @@ impl PyTemplate {
     fn concat(&self, other: &PyObject, vm: &VirtualMachine) -> PyResult<PyRef<Self>> {
         let other = other.downcast_ref::<Self>().ok_or_else(|| {
             vm.new_type_error(format!(
-                "can only concatenate Template (not '{}') to Template",
-                other.class().name()
+                r#"can only concatenate {name} (not "{}") to {name}"#,
+                other.class().slot_name(),
+                name = Self::TP_NAME,
             ))
         })?;
 

--- a/crates/vm/src/vm/vm_new.rs
+++ b/crates/vm/src/vm/vm_new.rs
@@ -734,6 +734,9 @@ impl VirtualMachine {
                     ruff_python_parser::ParseErrorType::Lexical(
                         ruff_python_parser::LexicalErrorType::FStringError(
                             ruff_python_parser::InterpolatedStringErrorType::UnterminatedTripleQuotedString,
+                        )
+                        | ruff_python_parser::LexicalErrorType::TStringError(
+                            ruff_python_parser::InterpolatedStringErrorType::UnterminatedTripleQuotedString,
                         ),
                     ),
                 ..

--- a/crates/vm/src/vm/vm_new.rs
+++ b/crates/vm/src/vm/vm_new.rs
@@ -86,6 +86,11 @@ impl SyntaxErrorInfo {
                 InterpolatedStringErrorType::UnterminatedString,
             )) => "unterminated f-string literal".into(),
 
+            ParseErrorType::TStringError(InterpolatedStringErrorType::UnterminatedString)
+            | ParseErrorType::Lexical(LexicalErrorType::TStringError(
+                InterpolatedStringErrorType::UnterminatedString,
+            )) => "unterminated t-string literal".into(),
+
             ParseErrorType::FStringError(
                 InterpolatedStringErrorType::UnterminatedTripleQuotedString,
             )
@@ -93,11 +98,20 @@ impl SyntaxErrorInfo {
                 InterpolatedStringErrorType::UnterminatedTripleQuotedString,
             )) => "unterminated triple-quoted f-string literal".into(),
 
+            ParseErrorType::TStringError(
+                InterpolatedStringErrorType::UnterminatedTripleQuotedString,
+            )
+            | ParseErrorType::Lexical(LexicalErrorType::TStringError(
+                InterpolatedStringErrorType::UnterminatedTripleQuotedString,
+            )) => "unterminated triple-quoted t-string literal".into(),
+
+            // ruff already prefixes these with `f-string: ` / `t-string: `, matching CPython.
+            // It quotes braces with backticks where CPython uses single quotes.
             ParseErrorType::FStringError(_)
-            | ParseErrorType::Lexical(LexicalErrorType::FStringError(_)) => {
-                // Replace backticks with single quotes to match CPython's error messages
-                format!("invalid syntax: {}", self.msg.replace('`', "'"))
-            }
+            | ParseErrorType::TStringError(_)
+            | ParseErrorType::Lexical(
+                LexicalErrorType::FStringError(_) | LexicalErrorType::TStringError(_),
+            ) => self.msg.replace('`', "'"),
 
             ParseErrorType::UnexpectedExpressionToken => "invalid syntax".into(),
 


### PR DESCRIPTION
- [x] Closes #8495

One of checkbox below must be checked.
- [ ] I did not use AI to write the code of this patch.
- [x] This PR follows our [AI policy](https://github.com/RustPython/.github/blob/main/AI_POLICY.md)

## Summary

RustPython synthesizes CPython's syntax-error messages by re-scanning the source in
`cpython_parse_diagnostic_override` once ruff's parse has already failed. The scanner
shared by f-strings and t-strings misread several replacement-field states, which is
what #8495 reports.

Fixing that surfaced a second and larger problem. Because these scanners run *only*
after a parse failure, a scanner that misreads a **valid** literal makes that literal
take the blame for an error elsewhere in the file. Several of the field checks treated
the whole field as code, so a format spec containing `(` or a comment containing `+`
was enough to move the reported error onto a perfectly good line.

Both are addressed against the rules CPython spells out in `Grammar/python.gram`,
`Parser/lexer/lexer.c` and `Parser/pegen*`. All CPython links below are permalinks to
`197fdd7`.

### 1. Replacement field states

[`invalid_fstring_replacement_field`](https://github.com/python/cpython/blob/197fdd787a117686fa78a4e7ceefedf2f06038d6/Grammar/python.gram#L1510-L1526)
gives four distinct answers, and the order of the alternatives is the priority. The
[t-string twin](https://github.com/python/cpython/blob/197fdd787a117686fa78a4e7ceefedf2f06038d6/Grammar/python.gram#L1532-L1552)
is the same rule with the prefix swapped. "the field has no content" and "the expression
failed to start" were collapsed into one branch here; they are now separate, and
[`lexer.c:1181-1192`](https://github.com/python/cpython/blob/197fdd787a117686fa78a4e7ceefedf2f06038d6/Parser/lexer/lexer.c#L1181-L1192)
is explicit that a field still open at end of input becomes `expecting '}'`.

| input | before | after (= CPython 3.14) |
| --- | --- | --- |
| `f'{'` | `expecting a valid expression after '{'` | `expecting '}'` |
| `f'{1=}{;'` | `expecting '}'` | `expecting a valid expression after '{'` |
| `f'{1=}{1;'` | `expecting '}'` | `expecting '=', or '!', or ':', or '}'` |
| `t'{x=!}'` | `invalid conversion character` | `missing conversion character` |
| `t'{x!s:'` | ``expecting `}` `` | `expecting '}', or format specs` |

A conversion or format spec following `=` was never validated, and a format spec
following a valid conversion was skipped entirely; both now run the same checks they
would have run directly after the expression, as
[`invalid_fstring_conversion_character`](https://github.com/python/cpython/blob/197fdd787a117686fa78a4e7ceefedf2f06038d6/Grammar/python.gram#L1528-L1530)
being referenced after `'='?` implies.

### 2. Only the expression is code

[`fstring_format_spec`](https://github.com/python/cpython/blob/197fdd787a117686fa78a4e7ceefedf2f06038d6/Grammar/python.gram#L959-L961)
is a separate grammar rule from `annotated_rhs`. So inside a format spec a `(` opens
nothing and a `#` selects the alternate form, while inside the expression a `#` starts a
comment that runs to end of line. Scanning the whole field for either produced
diagnostics against valid literals:

```python
x = f"{1:#x}"     # was reported as: '{' was never closed
x = f"""{a # +
}"""              # was reported as an expression ending on `+`
```

The expression-level checks now stop at the field's top-level separator and skip
comments, and the literal is walked field by field rather than byte by byte so a `{`
inside a comment no longer opens one. A pre-existing instance of the same bug in the
line-continuation check is fixed with them.

The spec also has no `{{` escape at that level, so nested fields inside a spec were
never checked at all. They are now, resuming past each nested field once checked —
recursing per `{` without resuming was `O(2^depth)` (a 110-byte source took 6.1s;
there is a regression test at depth 200).

### 3. Brackets and comments inside a field

[`lexer.c:1342`](https://github.com/python/cpython/blob/197fdd787a117686fa78a4e7ceefedf2f06038d6/Parser/lexer/lexer.c#L1342)
attributes a closer with nothing open to the literal (so it carries the prefix) while a
kind mismatch keeps the generic bracket wording (so it does not). Brackets opened in a
field were not matched at all before.

| input | before | after |
| --- | --- | --- |
| `f'{a[4)}'` | `invalid syntax` | `closing parenthesis ')' does not match opening parenthesis '['` |
| `f'{3)+(4}'` | `f-string: expecting '}'` | `f-string: unmatched ')'` |
| `f'{1#}'` | `unterminated string literal (detected at line 1)` | `'{' was never closed` |

### 4. The literal's kind belongs in the message

[`lexer.c:1500-1514`](https://github.com/python/cpython/blob/197fdd787a117686fa78a4e7ceefedf2f06038d6/Parser/lexer/lexer.c#L1500-L1514)
parameterises the prefix with `%c` rather than duplicating the messages, and this
scanner shares the same structure — which is why the f-string cases move together with
the t-string ones here. Separating them would need an artificial branch.

| input | before | after |
| --- | --- | --- |
| `t'` | `unterminated string literal (detected at line 1)` | `unterminated t-string literal (detected at line 1)` |
| `t'''` | `unterminated triple-quoted string literal …` | `unterminated triple-quoted t-string literal …` |

An interpolated literal that runs out of input with a field still open reports the brace
instead, per [`pegen_errors.c:18`](https://github.com/python/cpython/blob/197fdd787a117686fa78a4e7ceefedf2f06038d6/Parser/pegen_errors.c#L18)
— but only while the tokenizer is reading that field's *expression*. Past the field's own
`:` it is emitting FSTRING_MIDDLE again, so running out of input there is an ordinary
unterminated literal. And the field's own `:` is not the one in a slice, a display or a
lambda, nor is the field the innermost unclosed delimiter when a bracket is open inside
its expression. So this walk carries the whole delimiter stack:

`main` answers every row below with `unterminated string literal`. The third column is an
earlier revision of *this* branch, kept because the last four rows are what it got wrong
and what the delimiter stack is there to fix.

| input | CPython 3.14, and now | earlier revision of this branch |
| --- | --- | --- |
| `t'{`, `f'{a`, `f'{a!r`, `f'{a=` | `'{' was never closed` | `unterminated string literal …` |
| `f'{ {1:2}`, `f'{d[1:2]`, `f'{(lambda x: x)` | `'{' was never closed` | `unterminated f-string literal …` |
| `f'{a:`, `f'{a:>5`, `f'{a!r:`, `f'{a}{b:` | `unterminated f-string literal …` | `'{' was never closed` |
| `f'''{a:>5` | `unterminated triple-quoted f-string literal …` | `'{' was never closed` |
| `f'{a[` | `'[' was never closed` | `'{' was never closed` |
| `f'{(a` | `'(' was never closed` | `'{' was never closed` |

### 5. Mixed literal concatenation

Ruff reports a mixed concatenation only as a bytes/non-bytes mix, so `t"x" b"y"` arrived
as a bytes error where CPython names the t-string.

[`invalid_string_tstring_concat`](https://github.com/python/cpython/blob/197fdd787a117686fa78a4e7ceefedf2f06038d6/Grammar/python.gram#L1554-L1558)
is an `invalid_` rule, reached only on the error pass
([`pegen.c:964-974`](https://github.com/python/cpython/blob/197fdd787a117686fa78a4e7ceefedf2f06038d6/Parser/pegen.c#L964-L974)),
and [`strings`](https://github.com/python/cpython/blob/197fdd787a117686fa78a4e7ceefedf2f06038d6/Grammar/python.gram#L988-L994)
tries `(fstring|string)+` ahead of it. That alternative consumes the concatenation's
leading run of non-t-string literals, so a mix among *those* raises from
[`_PyPegen_concatenate_strings`](https://github.com/python/cpython/blob/197fdd787a117686fa78a4e7ceefedf2f06038d6/Parser/action_helpers.c#L1919-L1933)
on the first pass and
[suppresses](https://github.com/python/cpython/blob/197fdd787a117686fa78a4e7ceefedf2f06038d6/Parser/pegen_errors.c#L275-L283)
the t-string rule. So the precedence splits:

| input | CPython 3.14 | before |
| --- | --- | --- |
| `t"x" b"y"` | `cannot mix t-string literals with string or bytes literals` | `cannot mix bytes and nonbytes literals` |
| `b"x" t"y"` | `cannot mix t-string literals with …` | `cannot mix bytes and nonbytes literals` |
| `"a" b"b" t"c"` | `cannot mix bytes and nonbytes literals` | `invalid syntax. Is this intended to be part of the string?` |
| `f"x" b"y"` | `cannot mix bytes and nonbytes literals` | unchanged |

Both messages are now decided in one place. The third row has to be *emitted* rather
than deferred to ruff's own error, because otherwise `invalid_string_expression_error`
further down the chain claims the concatenation with an unrelated message.

All 14 cases from `test_tstring.test_literal_concatenation` and both from
`test_fstring.test_compile_time_concat_errors` match.

### 6. Type names in the operand message

CPython uses `tp_name` for
[`str`](https://github.com/python/cpython/blob/197fdd787a117686fa78a4e7ceefedf2f06038d6/Objects/unicodeobject.c#L11643-L11647),
i.e. the module-qualified name; `PyType::name()` strips the module, `slot_name()` does
not. Builtin types have no dot in `TP_NAME`, so this only changes types that declare a
module.

| input | before | after |
| --- | --- | --- |
| `t"a" + "b"` | `can only concatenate Template (not 'str') to Template` | `can only concatenate string.templatelib.Template (not "str") to string.templatelib.Template` |
| `"a" + t"b"` | `… (not "Template") to str` | `… (not "string.templatelib.Template") to str` |

### 7. Operators the scanner had no tokenizer for

CPython consumes `==`, `!=`, `<=` and the rest as single tokens at
[`lexer.c:1280-1298`](https://github.com/python/cpython/blob/197fdd787a117686fa78a4e7ceefedf2f06038d6/Parser/lexer/lexer.c#L1280-L1298),
before the `=` ever reaches the
[debug-marker check](https://github.com/python/cpython/blob/197fdd787a117686fa78a4e7ceefedf2f06038d6/Parser/lexer/lexer.c#L1382-L1384).
The scanner has no such stage, so `f"{a==b}"` — valid code — was read as a field ending
early. Token boundaries are now inferred from the surrounding characters; the character
set is exactly the operators that end in `=`.

An expression also cannot end on an operator that still wants an operand, and CPython
points at that operator rather than at the brace. `is not` / `not in` are single
operators so the first word is pointed at, and `...` is consumed in whole triples.

| input | before | after |
| --- | --- | --- |
| `f"{a==b}"` (valid) | `f-string: expecting '!', or ':', or '}'` | no error |
| `f'{==a}'` | `valid expression required before '='` | `expecting a valid expression after '{'` |
| `f'{a==}'` | `invalid syntax` (col 7) | `expecting '=', or '!', or ':', or '}'` (col 5) |
| `f'{a is not}'` | `invalid syntax` (col 9) | same message, col 6 |
| `f"{...}"`, `f"{.5}"`, `f"{-.5}"` (valid) | reported as broken | no error |

This region has to be walked forwards: a comment's terminating newline is whitespace, so
trimming backwards from the end steps into the comment body.

### 8. Three refactor commits on top

Answering the review here needed changes that carry no behavior, so they are separate
commits and every one was checked by building its parent and diffing the two outputs.

- `f7c9f31` — the scanners returned `Option<(String, usize, usize)>` at 69 signatures and
  114 construction sites, which the consumer reassembled into a message and a range one
  call later. They return a `CpythonDiagnostic` now. `bracket_syntax_error`'s fourth
  element and `unclosed_replacement_field_error`'s `Vec<(usize, u8, bool)>` become
  `BracketError` and `OpenDelimiter`. One thing does change beyond packaging, and the
  commit message says so: `TextRange::new` asserts start ≤ end unconditionally, and
  building the range at the scanner puts that assert in front of scanners that never
  built one before.
- `cd39b1e8` — the operator-character list inside `is_replacement_field_marker` was
  inline and looked like `is_dangling_operator_byte`. It is named, moved next to it, and
  both are sorted the same way; they differ by three characters and neither contains the
  other.
- `35beed5d` — `unterminated_string_error` had two exits, so the guard added in §4 had to
  be written twice. CPython's lexer spells the two conditions as one
  ([`lexer.c:1170`](https://github.com/python/cpython/blob/197fdd787a117686fa78a4e7ceefedf2f06038d6/Parser/lexer/lexer.c#L1170));
  this now does too.

## Verification

Ran on x86-64 Linux (WSL2, Ubuntu). `t`-string reference behavior is taken from the
vendored `Lib/test/*.py` and the pinned CPython source — note that a locally installed
`python3.14` may be a beta that predates `invalid_string_tstring_concat` entirely.

Re-run at `35beed5d`. The three refactor commits add one further check each: their output
is diffed against a build of their own parent, over a malformed-source corpus and over
every `Lib/**/*.py` that parses clean, each recompiled with a trailing `$` so that a
scanner misreading valid code shows up as a moved line. All three are byte-identical.

| check | result |
| --- | --- |
| `Lib/test/test_tstring.py` | 12/12, all 3 `expectedFailure` markers removed |
| `Lib/test/test_fstring.py` | 90 OK, 7 markers removed (6 remain) |
| CPython message comparison, 27 diagnostics | 27/27 match |
| mixed-concatenation precedence, 18 cases | 18/18 match |
| unclosed field / bracket boundary, 29 cases | 29/29 messages match |
| dangling-operator caret columns, 7 cases | 7/7 match CPython |
| valid literals not blamed for a later error | 24 shadow + 67 comment-tail cases, 0 false positives |
| valid expressions, 45 cases | 1 false positive — starred tuple, pre-existing |
| whole stdlib parses (`Lib/`, 1728 files) | 4 failures, all intentional bad-syntax fixtures |
| `cargo test -p rustpython-compiler` | 27 passed |
| `cargo clippy --workspace --all-targets`, `cargo fmt --all --check` | no new warnings, clean |
| adjacent suites | `test_syntax`, `test_compile`, `test_exceptions`, `test_grammar`, `test_str`, `test_ast`, `test_tokenize`, `test_codeop`, `test_traceback`, `test_str`, `test_bytes`, `test_types` all pass |

## Known gaps

All pre-existing, none covered by either test file:

- a starred tuple (`f"{*a,}"`) and a dict-unpacking display are still read as unable to
  start an expression;
- `f"{a===b}"`, `f"{a b}"` and `f"{a,,}"` need the longest valid expression prefix, which
  a character scanner cannot compute — `f"{a b}"` is CPython's "forgot a comma" rule;
- the caret column still differs from CPython's, while the messages match. Over a
  49-case sweep of interpolated-string errors the messages agree 49/49 and the
  `offset`/`end_offset` pair differs on 42. It splits into four independent anchors:
  `unterminated … literal` (CPython points at column 1, the prefix letter; we point at the
  quote), `expecting '}'` (CPython points past the last token, we point at the `{`),
  `expecting a valid expression after '{'` (CPython spans the offending token, we point at
  the `{`), and the operator messages (CPython spans the whole operator, our `end_offset`
  is one past the start). `assertRaisesRegex` only inspects the message, which is why
  neither test file covers this. Left out to keep this reviewable;
- `Template.__add__` names the other operand with `tp_name` where CPython uses
  [`%T`](https://github.com/python/cpython/blob/197fdd787a117686fa78a4e7ceefedf2f06038d6/Objects/templateobject.c#L301-L311)
  (identical for static types, divergent for heap types) — RustPython has no `%T`
  equivalent outside the C-API shim, so this is left for a follow-up;
- a quote inside a format spec is still treated as a string delimiter.

## AI assistance disclosure

Per the AI policy: this patch was written with **Claude Code (`claude-opus-5`)**, also
recorded as an `Assisted-by` trailer on each commit.

Extent: Claude wrote the scanner changes, the added tests and the commit message, working
from the CPython sources linked above. I set the scope, reviewed the diff, and ran every
check in the Verification table locally on the platform above.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved syntax-error messages for interpolated strings, including clearer diagnostics for unterminated literals, invalid replacement fields, conversions, and mixed string types.
  * Added more precise handling for nested expressions, brackets, comments, operators, and unexpected characters.
  * Improved string indexing, whitespace splitting, tab expansion, and joining behavior across varied inputs.
  * Updated string and template errors to report accurate type names and offending values.
  * Improved compiler error output with clearer t-string diagnostics and CPython-compatible wording.
* **Tests**
  * Added coverage for nested format specifications and complex syntax-error cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
