### PR TITLE
memoryview: traverse the view for the collector, and name types as `tp_name` does

### DIFF
--- a/Lib/test/test_memoryview.py
+++ b/Lib/test/test_memoryview.py
@@ -564,10 +564,6 @@ class BytesMemoryviewTest(unittest.TestCase,
             self.assertRaises(TypeError, memoryview, argument=ob)
             self.assertRaises(TypeError, memoryview, ob, argument=True)
 
-    @unittest.expectedFailure  # TODO: RUSTPYTHON; AssertionError: False is not true : <test.test_memoryview.MyObject object at 0x84ecb1920>
-    def test_gc(self):
-        return super().test_gc()
-
 class ArrayMemoryviewTest(unittest.TestCase,
     BaseMemoryviewTests, BaseArrayMemoryTests):
 
@@ -606,10 +602,6 @@ class BytesMemorySliceTest(unittest.TestCase,
     BaseMemorySliceTests, BaseBytesMemoryTests):
     pass
 
-    @unittest.expectedFailure  # TODO: RUSTPYTHON; AssertionError: False is not true : <test.test_memoryview.MyObject object at 0x84ecb13e0>
-    def test_gc(self):
-        return super().test_gc()
-
 class ArrayMemorySliceTest(unittest.TestCase,
     BaseMemorySliceTests, BaseArrayMemoryTests):
     pass
@@ -617,10 +609,6 @@ class ArrayMemorySliceTest(unittest.TestCase,
 class BytesMemorySliceSliceTest(unittest.TestCase,
     BaseMemorySliceSliceTests, BaseBytesMemoryTests):
     pass
-
-    @unittest.expectedFailure  # TODO: RUSTPYTHON; AssertionError: False is not true : <test.test_memoryview.MyObject object at 0x84ddca1c0>
-    def test_gc(self):
-        return super().test_gc()
 
 class ArrayMemorySliceSliceTest(unittest.TestCase,
     BaseMemorySliceSliceTests, BaseArrayMemoryTests):

--- a/crates/vm/src/builtins/memory.rs
+++ b/crates/vm/src/builtins/memory.rs
@@ -47,7 +47,7 @@ struct PyMemoryViewFromFlagsArgs {
     flags: ArgIndex,
 }
 
-#[pyclass(module = false, name = "memoryview")]
+#[pyclass(module = false, name = "memoryview", traverse)]
 #[derive(Debug)]
 pub struct PyMemoryView {
     /// One share of the acquisition this view is looking at, given up when the
@@ -55,17 +55,23 @@ pub struct PyMemoryView {
     buffer: PyBuffer,
     // the released memoryview does not mean the buffer is destroyed
     // because the possible another memoryview is viewing from it
+    #[pytraverse(skip)]
     released: AtomicCell<bool>,
     /// Forbids handing out anything that outlives this view, for the window
     /// passed to `__release_buffer__`.
+    #[pytraverse(skip)]
     restricted: AtomicCell<bool>,
+    #[pytraverse(skip)]
     format_spec: FormatSpec,
     // memoryview's options could be different from buffer's options
+    #[pytraverse(skip)]
     desc: BufferDescriptor,
+    #[pytraverse(skip)]
     hash: OnceCell<PyHash>,
     /// Buffers handed out of this view that have not been given back yet. The
     /// view cannot be released while any of them is outstanding, so that what
     /// reads them keeps reading memory that is still there. self->exports
+    #[pytraverse(skip)]
     exports: AtomicCell<usize>,
 }
 
@@ -1409,7 +1415,7 @@ pub(crate) fn init(ctx: &'static Context) {
     PyBufferWindow::extend_class(ctx, PyBufferWindow::init_builtin_type());
 }
 
-#[pyclass(module = false, name = "_buffer_wrapper")]
+#[pyclass(module = false, name = "_buffer_wrapper", traverse)]
 #[derive(Debug)]
 struct PyBufferWrapper {
     // bw->obj: the object whose `__buffer__` produced the view
@@ -1420,6 +1426,7 @@ struct PyBufferWrapper {
     /// forwards shares of it rather than owning one.
     view: PyBuffer,
     /// Exports handed out for this wrapper; the wrapper is spent at zero.
+    #[pytraverse(skip)]
     exports: AtomicCell<usize>,
 }
 
@@ -1465,7 +1472,7 @@ static BUFFER_WRAPPER_METHODS: BufferMethods = BufferMethods {
 // Read-only window over an exporter, handed to `__release_buffer__`. It owns no
 // export, like a `Py_buffer` whose `obj` is NULL, so releasing it is inert and
 // cannot recurse back into the hook.
-#[pyclass(module = false, name = "_buffer_window")]
+#[pyclass(module = false, name = "_buffer_window", traverse)]
 #[derive(Debug)]
 struct PyBufferWindow {
     source: PyBuffer,

--- a/crates/vm/src/protocol/object.rs
+++ b/crates/vm/src/protocol/object.rs
@@ -698,7 +698,7 @@ impl PyObject {
             return vm.with_recursion("while hashing", || hash(self, vm));
         }
 
-        Err(vm.new_type_error(format!("unhashable type: '{}'", self.class().name())))
+        Err(vm.new_type_error(format!("unhashable type: '{}'", self.class().slot_name())))
     }
 
     // type protocol

--- a/crates/vm/src/types/slot.rs
+++ b/crates/vm/src/types/slot.rs
@@ -523,7 +523,7 @@ fn hash_wrapper(zelf: &PyObject, vm: &VirtualMachine) -> PyResult<PyHash> {
 
 /// Marks a type as unhashable. Similar to PyObject_HashNotImplemented in CPython
 pub fn hash_not_implemented(zelf: &PyObject, vm: &VirtualMachine) -> PyResult<PyHash> {
-    Err(vm.new_type_error(format!("unhashable type: '{}'", zelf.class().name())))
+    Err(vm.new_type_error(format!("unhashable type: '{}'", zelf.class().slot_name())))
 }
 
 fn call_wrapper(zelf: &PyObject, args: FuncArgs, vm: &VirtualMachine) -> PyResult {

--- a/extra_tests/snippets/builtin_hash.py
+++ b/extra_tests/snippets/builtin_hash.py
@@ -47,3 +47,30 @@ if sys.implementation.name == "rustpython":
         {deep_tuple: 1}
     with assert_raises(RecursionError):
         {deep_tuple}
+
+
+def test_unhashable_names_the_type_as_written():
+    # The message names the type the way `tp_name` does, so a type defined in a
+    # module carries the module with it.
+    import array
+    import collections
+
+    for value, name in [
+        (array.array("B", b"a"), "array.array"),
+        (collections.deque(), "collections.deque"),
+        ([], "list"),
+        (bytearray(), "bytearray"),
+        (Unhashable(), "Unhashable"),
+    ]:
+        try:
+            hash(value)
+            raise AssertionError(f"hashed {name}")
+        except TypeError as e:
+            assert str(e) == f"unhashable type: '{name}'", e
+
+
+class Unhashable:
+    __hash__ = None
+
+
+test_unhashable_names_the_type_as_written()

--- a/extra_tests/snippets/stdlib_gc.py
+++ b/extra_tests/snippets/stdlib_gc.py
@@ -65,4 +65,54 @@ assert collects(lambda c: itertools.combinations(c, 1))
 # tee holds its buffer through a second object, which has to be walked too
 assert collects(lambda c: itertools.tee(c)[0])
 
+
+# A view keeps the object it looks at in a field of its own, and the wrapper a
+# `__buffer__` produces keeps the exporter the same way.
+class Buf(bytearray):
+    pass
+
+
+def collects_view(wrap):
+    """Report whether the collector breaks a cycle that runs through a view."""
+
+    def build():
+        container = Buf(b"abc")
+        node = Node()
+        container.node = node
+        node.held = wrap(container)
+        return weakref.ref(node)
+
+    gc.collect()
+    ref = build()
+    gc.collect()
+    return ref() is None
+
+
+assert collects_view(memoryview)
+assert collects_view(lambda c: memoryview(c)[1:])
+assert collects_view(lambda c: memoryview(c).cast("B"))
+assert collects_view(lambda c: memoryview(memoryview(c)))
+
+
+class Exporter:
+    def __buffer__(self, flags):
+        return memoryview(b"abcdef")
+
+
+def collects_exporter():
+    def build():
+        exporter = Exporter()
+        node = Node()
+        exporter.node = node
+        node.held = memoryview(exporter)
+        return weakref.ref(node)
+
+    gc.collect()
+    ref = build()
+    gc.collect()
+    return ref() is None
+
+
+assert collects_exporter()
+
 print("ok")


### PR DESCRIPTION
Two defects, both found while working through what was left after #8553. Comparisons are against CPython 3.14.6.

## A cycle running through a view was never collected

Neither `memoryview` nor the `_buffer_wrapper` a `__buffer__` produces reported what it held while being traversed, so the object a view looks at was invisible to the collector and the cycle was classified as reachable:

```python
class Src:
    def __buffer__(self, flags):
        return memoryview(b'abcdef')

o = Src()
o.keep = memoryview(o)      # o -> memoryview -> wrapper -> o
del o
gc.collect()                # CPython: freed. before: never freed
```

The same held for a plain view over an exporter that refers back to it. Both types now report what they hold, as `memory_traverse` and `mbuf_traverse` do.

This is what `test_gc` in `test_memoryview` was covering; the three `expectedFailure` decorators are removed, and with them the overrides that only existed to carry the decorator.

## An unhashable-type message dropped the module from the name

The message took the short name where CPython uses `tp_name`:

| | CPython | before |
|---|---|---|
| `hash(array.array('B', b'a'))` | `unhashable type: 'array.array'` | `unhashable type: 'array'` |
| `hash(collections.deque())` | `unhashable type: 'collections.deque'` | `unhashable type: 'deque'` |
| `hash(Foo())` where `Foo.__hash__ = None` | `unhashable type: 'Foo'` | same |

`slot_name()` already holds what `tp_name` holds — `name()` strips everything before the last dot — so this is that accessor at the two sites that build the message. A class defined in Python is still reported by its own name.

Only this message is changed. `name()` is read in 321 places, and which of them CPython builds from `tp_name` rather than `__name__` is a separate audit.

## Tests

`extra_tests/snippets/stdlib_gc.py` gains five cycle shapes through a view, and `builtin_hash.py` five type-name cases. Both files pass under CPython 3.14.6 as well.

16 suites run clean locally — memoryview, buffer, gc, weakref, array, bytes, dict, set, collections, io, re, types, descr, exceptions, pickle, struct.

## Left out

- **`pickle.PickleBuffer`** is still missing. It is reachable only through `_pickle`, and `test_pickle.py` reads a successful `import _pickle` as "the C accelerator is present", then binds `dump`, `dumps`, `load`, `loads`, `Pickler` and `Unpickler` from it in a class body. A `_pickle` carrying only `PickleBuffer` therefore breaks that file at import, so the accelerator has to come first.
- **Argument errors carry no function name** — `readinto() argument must be read-write bytes-like object` is reported as `buffer is not a read-write bytes-like object`. `ArgumentError::into_exception` never receives the name, which is why the arity messages read `expected at least 1 arguments, got 0` too. Threading it through is a change to the argument-binding path rather than to any one converter.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01P9HewXGX8qcGSccUxGdSPV


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved garbage collection for `memoryview` objects and custom buffer exporters, helping cyclic references be collected reliably.
  * Corrected unhashable-type error messages so they display the type name accurately.

* **Tests**
  * Added coverage for garbage collection across sliced, cast, nested, and custom-exported memory views.
  * Added tests verifying unhashable-type message formatting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->