### PR TITLE
posixsubprocess: call libc setgroups directly in the child

### DIFF
--- a/crates/host_env/src/posix.rs
+++ b/crates/host_env/src/posix.rs
@@ -797,11 +797,15 @@ pub fn setpgid_if_needed(pgid_to_set: libc::pid_t) -> nix::Result<()> {
     Ok(())
 }
 
-pub fn setgroups_if_needed(_groups: Option<&[u32]>) -> nix::Result<()> {
-    #[cfg(not(any(target_os = "ios", target_os = "macos", target_os = "redox")))]
-    if let Some(groups) = _groups {
-        let groups = groups.iter().copied().map(gid_from_raw).collect::<Vec<_>>();
-        nix::unistd::setgroups(&groups)?;
+pub fn setgroups_if_needed(groups: Option<&[u32]>) -> nix::Result<()> {
+    #[cfg(not(any(target_os = "ios", target_os = "redox")))]
+    if let Some(groups) = groups {
+        // The caller prepares this array before fork.  Call libc directly so
+        // macOS performs the requested operation too, and so the child does
+        // not allocate a second array between fork and exec.
+        let ret =
+            unsafe { libc::setgroups(groups.len() as _, groups.as_ptr().cast::<libc::gid_t>()) };
+        nix::Error::result(ret)?;
     }
     Ok(())
 }


### PR DESCRIPTION
`setgroups_if_needed` carried `target_os = "macos"` in its `cfg(not(any(...)))`, so on macOS the `extra_groups` argument was accepted by `_posixsubprocess.fork_exec` and then silently dropped — the child ran with the parent's group list.

nix gates `unistd::setgroups` off `apple_targets`, `redox` and `haiku`, which is where that exclusion came from. `libc` declares `setgroups` on every one of those except redox, so this calls it directly and checks the return with `nix::Error::result` — the same shape the adjacent `setregid_if_needed` and `setreuid_if_needed` already use. `ngroups` is `c_int` on the BSDs and `size_t` on linux, hence `as _`.

Passing the caller's `&[u32]` straight through also drops an allocation: `u32` and `libc::gid_t` have the same layout, so no `Vec<Gid>` needs to be built. That code runs in the child between `fork` and `exec`, where `malloc` is not async-signal-safe.

Draft: not yet exercised against `test_subprocess`'s `extra_groups` cases on macOS, and iOS is still excluded.

— *commented by Claude*


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved process group handling on macOS.
  * Reduced the risk of failures when configuring group IDs after process creation.
  * Preserved existing behavior on supported platforms while continuing to disable the operation on iOS and Redox.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->