### PR TITLE
Document separate C-API Clippy checks

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -123,6 +123,10 @@ cargo test --workspace --exclude rustpython_wasm --exclude rustpython-venvlaunch
 # Run C-API tests from their directory so their separate Cargo config applies
 (cd crates/capi && cargo test)
 
+# Run Clippy with the same C-API separation
+cargo clippy --workspace --all-targets --exclude rustpython_wasm --exclude rustpython-venvlauncher --exclude rustpython-capi
+(cd crates/capi && cargo clippy --all-targets)
+
 # Run Python snippets tests (debug mode recommended for faster compilation)
 cargo run -- extra_tests/snippets/builtin_bytes.py
 


### PR DESCRIPTION
- [x] This PR follows our [AI policy](https://github.com/RustPython/.github/blob/main/AI_POLICY.md)

## Summary

Document that `rustpython-capi` must be excluded from workspace-wide Clippy and linted separately from `crates/capi` so its Cargo config applies.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added Clippy linting commands to the testing guidance.
  * Documented separate linting steps for the C API and excluded components.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->