### PR TITLE
Skip C-API in workspace coverage

### DIFF
--- a/.github/workflows/cron-ci.yaml
+++ b/.github/workflows/cron-ci.yaml
@@ -42,7 +42,7 @@ jobs:
       - run: sudo apt-get update && sudo apt-get -y install lcov
 
       - name: Run cargo-llvm-cov with Rust tests.
-        run: cargo llvm-cov --no-report --workspace --exclude rustpython_wasm --exclude rustpython-compiler-source --exclude rustpython-venvlauncher --verbose --no-default-features --features stdlib,importlib,stdio,encodings,ssl-rustls-aws-lc,jit,host_env
+        run: cargo llvm-cov --no-report --workspace --exclude rustpython_wasm --exclude rustpython-compiler-source --exclude rustpython-venvlauncher --exclude rustpython-capi --verbose --no-default-features --features stdlib,importlib,stdio,encodings,ssl-rustls-aws-lc,jit,host_env
 
       - name: Run cargo-llvm-cov with Python snippets.
         run: python scripts/cargo-llvm-cov.py


### PR DESCRIPTION
- [x] This PR follows our [AI policy](https://github.com/RustPython/.github/blob/main/AI_POLICY.md)

## Summary

The periodic coverage job runs tests from the workspace root, which causes the rustpython-capi test binary to be built without the crate-local PyO3 configuration from crates/capi/.cargo/config.toml. The binary consequently crashes with SIGSEGV as soon as its unit tests start. This failure appeared in the run associated with #8616, but the same failure has also affected scheduled runs on main since C-API tests were enabled.

This change excludes rustpython-capi from the root workspace coverage invocation, matching the existing regular CI workflow. The C-API suite remains covered by its dedicated CI invocation from crates/capi, where all 102 tests pass with the required configuration. I also verified the remaining workspace tests, clippy, formatting, pre-commit hooks, actionlint, and the workflow security scan locally.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Rust test coverage reporting to exclude an additional internal package.
  * No user-facing functionality or behavior changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->