### PR TITLE
Cache cargo-codspeed installation metadata

### DIFF
--- a/.github/workflows/codspeed.yaml
+++ b/.github/workflows/codspeed.yaml
@@ -33,6 +33,9 @@ jobs:
       id-token: write # for OpenID Connect authentication with CodSpeed
     env:
       CACHE_PATHS: |
+        # https://doc.rust-lang.org/cargo/guide/cargo-home.html#caching-the-cargo-home-in-ci
+        ~/.cargo/.crates2.json
+        ~/.cargo/.crates.toml
         ~/.cargo/bin/
         ~/.cargo/registry/index/
         ~/.cargo/registry/cache/
@@ -52,8 +55,8 @@ jobs:
         uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: ${{ env.CACHE_PATHS }}
-          key: codspeed-${{ hashFiles('**/Cargo.lock') }}
-          restore-keys: codspeed-
+          key: codspeed-v2-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: codspeed-v2-
         continue-on-error: true
 
       - name: Install cargo-codspeed
@@ -67,7 +70,7 @@ jobs:
         uses: actions/cache/save@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: ${{ env.CACHE_PATHS }}
-          key: codspeed-${{ hashFiles('**/Cargo.lock') }}
+          key: codspeed-v2-${{ hashFiles('**/Cargo.lock') }}
         continue-on-error: true
 
       - name: Run the benchmarks


### PR DESCRIPTION
<!--
Thanks for your contribution!
-->

One of checkbox below must be checked.
- [ ] I did not use AI to write the code of this patch.
- [x] This PR follows our [AI policy](https://github.com/RustPython/.github/blob/main/AI_POLICY.md)

## Summary
<!-- What's the purpose of the change? What does it do, and why? -->

The CodSpeed workflow caches the cargo-codspeed executable under `~/.cargo/bin` but omits `~/.cargo/.crates.toml` and `~/.cargo/.crates2.json`, which record the packages installed by Cargo. After the main-branch workflow saves that incomplete cache, subsequent jobs restore the executable without its installation records. Cargo then treats the executable as an untracked destination conflict, causing cargo install cargo-codspeed to fail with exit code 101 instead of recognizing the existing installation.

This change adds both Cargo installation metadata files to the cached paths and links the relevant Cargo documentation next to the entries. It also changes the cache namespace from codspeed- to codspeed-v2- because GitHub Actions caches are immutable; without a new namespace, jobs would continue restoring the already-saved incomplete cache.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved benchmark workflow caching for faster, more consistent performance testing.
  * Updated the benchmark cache version to ensure refreshed cache data is used.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->