### PR TITLE
Fix subinterpreter lifecycle edge cases

### DIFF
--- a/crates/vm/src/builtins/memory.rs
+++ b/crates/vm/src/builtins/memory.rs
@@ -128,7 +128,9 @@ impl PyMemoryView {
     /// `send_buffer` so the destination memoryview sees the same memory.
     #[must_use]
     pub fn clone_buffer(&self) -> PyBuffer {
-        self.buffer.clone()
+        let mut buffer = self.buffer.clone();
+        buffer.desc = self.desc.clone();
+        buffer
     }
 
     // PyMemoryView_FromObjectAndFlags

--- a/crates/vm/src/stdlib/_interpchannels.rs
+++ b/crates/vm/src/stdlib/_interpchannels.rs
@@ -230,6 +230,9 @@ pub(crate) mod _interpchannels {
         }
 
         fn release_end(&mut self, index: usize, send: bool) {
+            if !self.list(send)[index].1 {
+                return;
+            }
             self.list(send)[index].1 = false;
             if send {
                 self.numsendopen -= 1;
@@ -1294,5 +1297,29 @@ pub(crate) mod _interpchannels {
             }
         }
         Ok(())
+    }
+
+    #[cfg(test)]
+    mod tests {
+        use super::ChannelEnds;
+
+        #[test]
+        fn releasing_an_end_twice_is_a_noop() {
+            let mut ends = ChannelEnds::default();
+            ends.add(1, true);
+            ends.add(1, false);
+
+            let send = ends.find(1, true).unwrap();
+            ends.release_end(send, true);
+            ends.release_end(send, true);
+            assert_eq!(ends.numsendopen, 0);
+            assert_eq!(ends.numrecvopen, 1);
+            assert!(ends.is_open());
+
+            let recv = ends.find(1, false).unwrap();
+            ends.release_end(recv, false);
+            assert_eq!(ends.numrecvopen, 0);
+            assert!(!ends.is_open());
+        }
     }
 }

--- a/crates/vm/src/vm/interpreter.rs
+++ b/crates/vm/src/vm/interpreter.rs
@@ -148,6 +148,7 @@ where
     let warnings = WarningsState::init_state(&ctx);
 
     let interpreter_id = runtime::alloc_interpreter_id();
+    let runtime_root_id = parent_state.map_or(interpreter_id, |parent| parent.runtime_root_id);
 
     // Process main OS thread identity is process-global; subinterpreters inherit
     // it from the parent so `is_main_thread()` stays correct when running on the
@@ -162,6 +163,7 @@ where
     let global_state = PyRc::new(PyGlobalState {
         gc: crate::gc_state::GcInterpreterState::new(&ctx),
         interpreter_id,
+        runtime_root_id,
         whence,
         is_main,
         config,
@@ -735,9 +737,9 @@ fn finalize_subinterpreters(vm: &VirtualMachine) {
     if !vm.state.is_main {
         return;
     }
-    let ids = runtime::owned_interpreter_ids();
+    let root_id = vm.state.runtime_root_id;
     // Bail out if there are no subinterpreters left.
-    if ids.is_empty() {
+    if runtime::owned_interpreter_ids_for(root_id).is_empty() {
         return;
     }
     // Warn the user if they forgot to clean up subinterpreters.
@@ -751,7 +753,12 @@ fn finalize_subinterpreters(vm: &VirtualMachine) {
         None,
         vm,
     );
-    for id in ids {
+    // A subinterpreter's finalizers may create another subinterpreter, so
+    // re-read the owner table after each destruction like CPython does.
+    while let Some(id) = runtime::owned_interpreter_ids_for(root_id)
+        .into_iter()
+        .next()
+    {
         let _ = runtime::destroy_owned_interpreter(id);
     }
 }
@@ -1555,6 +1562,25 @@ mod tests {
         let sub = runtime::take_owned_interpreter(id).expect("owned by runtime");
         assert_eq!(sub.id(), id);
         assert!(!sub.is_main());
+    }
+
+    /// Finalizing one embedded runtime must leave another runtime's owned
+    /// subinterpreters alone.
+    #[cfg(feature = "threading")]
+    #[test]
+    fn owned_subinterpreter_cleanup_is_scoped_to_its_runtime() {
+        let main1 = Interpreter::without_stdlib(Default::default());
+        let main2 = Interpreter::without_stdlib(Default::default());
+        let sub1 = main1.create_owned_subinterpreter();
+        let sub2 = main2.create_owned_subinterpreter();
+
+        main1.enter(finalize_subinterpreters);
+
+        assert!(!runtime::is_owned_interpreter(sub1));
+        assert!(runtime::is_owned_interpreter(sub2));
+
+        let sub2 = runtime::take_owned_interpreter(sub2).expect("owned by second runtime");
+        let _ = sub2.finalize(None);
     }
 
     /// A collection must stop every interpreter, not just the collecting one:

--- a/crates/vm/src/vm/mod.rs
+++ b/crates/vm/src/vm/mod.rs
@@ -759,6 +759,8 @@ pub(crate) struct CallableCache {
 pub struct PyGlobalState {
     /// Unique process-global interpreter id (main is [`MAIN_INTERPRETER_ID`]).
     pub interpreter_id: i64,
+    /// Top-level interpreter whose runtime owns this interpreter.
+    pub runtime_root_id: i64,
     /// How this interpreter was created.
     pub whence: runtime::InterpreterWhence,
     /// True for every top-level (non-sub) interpreter, each of which keeps its

--- a/crates/vm/src/vm/runtime.rs
+++ b/crates/vm/src/vm/runtime.rs
@@ -452,9 +452,15 @@ pub fn live_interpreter_states() -> Vec<PyRc<PyGlobalState>> {
 /// via [`owned_new_thread`], which only clones the shared interpreter fields
 /// (`sys`, builtins, `PyGlobalState`).
 #[cfg(feature = "threading")]
-fn owned_interpreters() -> &'static Mutex<HashMap<i64, crate::Interpreter>> {
+struct OwnedInterpreter {
+    root_id: i64,
+    interpreter: crate::Interpreter,
+}
+
+#[cfg(feature = "threading")]
+fn owned_interpreters() -> &'static Mutex<HashMap<i64, OwnedInterpreter>> {
     use std::sync::OnceLock;
-    static OWNED: OnceLock<Mutex<HashMap<i64, crate::Interpreter>>> = OnceLock::new();
+    static OWNED: OnceLock<Mutex<HashMap<i64, OwnedInterpreter>>> = OnceLock::new();
     OWNED.get_or_init(|| Mutex::new(HashMap::new()))
 }
 
@@ -462,9 +468,16 @@ fn owned_interpreters() -> &'static Mutex<HashMap<i64, crate::Interpreter>> {
 #[cfg(feature = "threading")]
 pub fn store_owned_interpreter(interp: crate::Interpreter) -> i64 {
     let id = interp.id();
+    let root_id = interp.global_state.runtime_root_id;
     // Ids are strictly monotonic, so this never displaces (and drops) an
     // existing entry under the lock.
-    owned_interpreters().lock().insert(id, interp);
+    owned_interpreters().lock().insert(
+        id,
+        OwnedInterpreter {
+            root_id,
+            interpreter: interp,
+        },
+    );
     id
 }
 
@@ -475,7 +488,10 @@ pub fn store_owned_interpreter(interp: crate::Interpreter) -> i64 {
 #[cfg(feature = "threading")]
 #[must_use]
 pub fn take_owned_interpreter(id: i64) -> Option<crate::Interpreter> {
-    owned_interpreters().lock().remove(&id)
+    owned_interpreters()
+        .lock()
+        .remove(&id)
+        .map(|owned| owned.interpreter)
 }
 
 /// Create a thread-state VM for a runtime-owned interpreter.
@@ -487,7 +503,7 @@ pub fn owned_new_thread(id: i64) -> Option<crate::vm::thread::ThreadedVirtualMac
     owned_interpreters()
         .lock()
         .get(&id)
-        .map(|interp| interp.new_thread())
+        .map(|owned| owned.interpreter.new_thread())
 }
 
 /// Whether `id` refers to a runtime-owned interpreter.
@@ -509,6 +525,19 @@ pub fn owned_interpreter_count() -> usize {
 #[must_use]
 pub fn owned_interpreter_ids() -> Vec<i64> {
     let mut ids: Vec<i64> = owned_interpreters().lock().keys().copied().collect();
+    ids.sort_unstable();
+    ids
+}
+
+/// Ids of runtime-owned interpreters belonging to `root_id`, oldest first.
+#[cfg(feature = "threading")]
+#[must_use]
+pub fn owned_interpreter_ids_for(root_id: i64) -> Vec<i64> {
+    let mut ids: Vec<i64> = owned_interpreters()
+        .lock()
+        .iter()
+        .filter_map(|(&id, owned)| (owned.root_id == root_id).then_some(id))
+        .collect();
     ids.sort_unstable();
     ids
 }

--- a/extra_tests/snippets/stdlib_subinterpreters.py
+++ b/extra_tests/snippets/stdlib_subinterpreters.py
@@ -1,0 +1,23 @@
+import _interpchannels
+import _interpreters
+
+
+def roundtrip_buffer(view):
+    cid = _interpchannels.create(3)
+    try:
+        _interpchannels.send_buffer(cid, view, blocking=False)
+        received, unbound = _interpchannels.recv(cid)
+        assert unbound is None
+        return received
+    finally:
+        _interpchannels.destroy(cid)
+
+
+data = bytearray(range(12))
+for view in (memoryview(data)[2:10:2], memoryview(data).cast("I")):
+    received = roundtrip_buffer(view)
+    assert received.tolist() == view.tolist()
+    assert received.shape == view.shape
+    assert received.strides == view.strides
+    assert received.format == view.format
+    assert received.itemsize == view.itemsize


### PR DESCRIPTION
- [ ] Closes #xxxx

One of checkbox below must be checked.
- [ ] I did not use AI to write the code of this patch.
- [x] This PR follows our [AI policy](https://github.com/RustPython/.github/blob/main/AI_POLICY.md)

## Summary

Follow-up to #8605 addressing valid findings from post-merge review:

- Preserve the logical descriptor of sliced and cast memoryviews during cross-interpreter transfer.
- Make repeated channel-end release idempotent.
- Scope runtime-owned subinterpreter cleanup to the creating top-level runtime.
- Re-read the owned-interpreter table during shutdown so finalizers cannot leave newly created children behind.
- Add regressions for memoryview metadata, repeated release, and multiple embedded runtimes.

The behavior was compared against CPython 3.14.7. Two other review suggestions were intentionally not included: CPython has the same `EXTENDED_ARG` limitation in `_PyCode_ReturnsOnlyNone()`, and its absolute-path construction also produces the observed double separator for a root working directory.

## Testing

- `cargo clippy`
- `INSTA_WORKSPACE_ROOT=/Users/youknowone/Projects/RustPython-11 cargo test --workspace --exclude rustpython_wasm --exclude rustpython-venvlauncher --exclude rustpython-capi`
- `(cd crates/capi && cargo test)` (103 passed)
- `prek run --from-ref upstream/main --to-ref HEAD`
- `cargo test -p rustpython-vm releasing_an_end_twice_is_a_noop`
- `cargo test -p rustpython-vm --features threading owned_subinterpreter_cleanup_is_scoped_to_its_runtime`
- `cargo run -- extra_tests/snippets/stdlib_subinterpreters.py`
- Direct comparison of the new snippet with CPython 3.14.6

## AI assistance

OpenAI Codex (GPT-5) assisted extensively with CPython source comparison, implementation, regression-test design, independent review coordination, validation, commit preparation, and this pull request description. The contributor reviewed the findings and directed which valid issues to address.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Preserved memoryview layout metadata when buffers are cloned or transferred.
  * Prevented repeated channel-end releases from corrupting open-end tracking.
  * Ensured subinterpreter cleanup is isolated to the correct runtime.
* **Tests**
  * Added coverage for buffer round-tripping, including strided and cast memoryviews.
  * Added tests for repeated channel-end release and isolated runtime finalization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->