### PR TITLE
Raise the shared argument-binding errors from the slots that count for themselves

### DIFF
--- a/crates/stdlib/src/contextvars.rs
+++ b/crates/stdlib/src/contextvars.rs
@@ -14,13 +14,14 @@ mod _contextvars {
     use crate::vm::{
         AsObject, Py, PyObjectRef, PyPayload, PyRef, PyResult, VirtualMachine, atomic_func,
         builtins::{PyGenericAlias, PyList, PyStrRef, PyType, PyTypeRef},
+        class::PyClassDef,
         class::StaticType,
         common::{
             hash::PyHash,
             lock::{LazyLock, PyMutex},
             wtf8::Wtf8Buf,
         },
-        function::{ArgCallable, Callee, FuncArgs, OptionalArg},
+        function::{ArgCallable, FuncArgs, OptionalArg},
         protocol::{PyMappingMethods, PySequenceMethods},
         types::{AsMapping, AsSequence, Constructor, Hashable, Iterable, Representable},
     };
@@ -484,7 +485,7 @@ mod _contextvars {
         type Args = ContextVarOptions;
 
         fn slot_new(cls: PyTypeRef, args: FuncArgs, vm: &VirtualMachine) -> PyResult {
-            let args: Self::Args = args.bind_for(vm, Callee::of::<Self>(vm))?;
+            let args: Self::Args = args.bind_for(vm, Self::NAME)?;
             let var = Self {
                 name: args.name.to_string(),
                 default: args.default.into_option(),

--- a/crates/stdlib/src/csv.rs
+++ b/crates/stdlib/src/csv.rs
@@ -7,7 +7,7 @@ mod _csv {
         AsObject, Py, PyObject, PyObjectRef, PyPayload, PyRef, PyResult, TryFromObject,
         VirtualMachine,
         builtins::{PyBaseExceptionRef, PyInt, PyNone, PyStr, PyType, PyTypeRef, PyUtf8StrRef},
-        function::{ArgIterable, ArgumentError, Callee, FromArgs, FuncArgs, OptionalArg},
+        function::{ArgIterable, ArgumentError, FromArgs, FuncArgs, OptionalArg},
         protocol::{PyIter, PyIterReturn},
         types::{Callable, Constructor, IterNext, Iterable, SelfIter},
     };
@@ -734,7 +734,7 @@ mod _csv {
                 // The dialect is parsed by a parser of its own, which has no
                 // name to give the message.
                 return Err(ArgumentError::Exception(
-                    Callee::default().unexpected_keyword(&last_arg.0.to_string(), vm),
+                    vm.new_unexpected_keyword_type_error(None, &last_arg.0.to_string()),
                 ));
             }
 

--- a/crates/stdlib/src/csv.rs
+++ b/crates/stdlib/src/csv.rs
@@ -7,7 +7,7 @@ mod _csv {
         AsObject, Py, PyObject, PyObjectRef, PyPayload, PyRef, PyResult, TryFromObject,
         VirtualMachine,
         builtins::{PyBaseExceptionRef, PyInt, PyNone, PyStr, PyType, PyTypeRef, PyUtf8StrRef},
-        function::{ArgIterable, ArgumentError, FromArgs, FuncArgs, OptionalArg},
+        function::{ArgIterable, ArgumentError, Callee, FromArgs, FuncArgs, OptionalArg},
         protocol::{PyIter, PyIterReturn},
         types::{Callable, Constructor, IterNext, Iterable, SelfIter},
     };
@@ -731,12 +731,11 @@ mod _csv {
             };
 
             if let Some(last_arg) = args.kwargs.pop() {
-                return Err(
-                    rustpython_vm::function::ArgumentError::InvalidKeywordArgument(format!(
-                        "'{}' is an invalid keyword argument for this function",
-                        last_arg.0
-                    )),
-                );
+                // The dialect is parsed by a parser of its own, which has no
+                // name to give the message.
+                return Err(ArgumentError::Exception(
+                    Callee::default().unexpected_keyword(&last_arg.0.to_string(), vm),
+                ));
             }
 
             Ok(res)

--- a/crates/vm/src/builtins/bool.rs
+++ b/crates/vm/src/builtins/bool.rs
@@ -2,9 +2,9 @@ use super::{PyInt, PyStrRef, PyType, PyTypeRef, PyUtf8StrRef};
 use crate::common::format::FormatSpec;
 use crate::{
     AsObject, Context, Py, PyObject, PyObjectRef, PyResult, TryFromBorrowedObject, VirtualMachine,
-    class::PyClassImpl,
+    class::{PyClassDef, PyClassImpl},
     convert::{IntoPyException, ToPyObject, ToPyResult},
-    function::{Callee, FuncArgs, OptionalArg},
+    function::{FuncArgs, OptionalArg},
     protocol::PyNumberMethods,
     types::{AsNumber, Constructor, Representable},
 };
@@ -87,7 +87,7 @@ impl Constructor for PyBool {
     type Args = OptionalArg<PyObjectRef>;
 
     fn slot_new(zelf: PyTypeRef, args: FuncArgs, vm: &VirtualMachine) -> PyResult {
-        let x: Self::Args = args.bind_for(vm, Callee::of::<Self>(vm))?;
+        let x: Self::Args = args.bind_for(vm, Self::NAME)?;
         if !zelf.fast_isinstance(vm.ctx.types.type_type) {
             return Err(vm.new_type_error(format!(
                 "requires a 'type' object but received a '{}'",

--- a/crates/vm/src/builtins/bytes.rs
+++ b/crates/vm/src/builtins/bytes.rs
@@ -14,12 +14,10 @@ use crate::{
         ByteInnerSplitOptions, ByteInnerSub, ByteInnerTranslateOptions, DecodeArgs, PyBytesInner,
         bytes_decode,
     },
-    class::PyClassImpl,
+    class::{PyClassDef, PyClassImpl},
     common::{hash::PyHash, lock::PyMutex},
     convert::{ToPyObject, ToPyResult},
-    function::{
-        ArgBytesLike, ArgIndex, Callee, FuncArgs, OptionalArg, OptionalOption, PyComparisonValue,
-    },
+    function::{ArgBytesLike, ArgIndex, FuncArgs, OptionalArg, OptionalOption, PyComparisonValue},
     protocol::{
         BufferDescriptor, BufferFlags, BufferMethods, PyBuffer, PyIterReturn, PyMappingMethods,
         PyNumberMethods, PySequenceMethods,
@@ -97,7 +95,7 @@ impl Constructor for PyBytes {
     type Args = Vec<u8>;
 
     fn slot_new(cls: PyTypeRef, args: FuncArgs, vm: &VirtualMachine) -> PyResult {
-        let options: ByteInnerNewOptions = args.bind_for(vm, Callee::of::<Self>(vm))?;
+        let options: ByteInnerNewOptions = args.bind_for(vm, Self::NAME)?;
 
         // Optimizations for exact bytes type
         if cls.is(vm.ctx.types.bytes_type) {

--- a/crates/vm/src/builtins/classmethod.rs
+++ b/crates/vm/src/builtins/classmethod.rs
@@ -1,9 +1,9 @@
 use super::{PyBoundMethod, PyGenericAlias, PyStr, PyType, PyTypeRef};
 use crate::{
     AsObject, Context, Py, PyObjectRef, PyPayload, PyRef, PyResult, VirtualMachine,
-    class::PyClassImpl,
+    class::{PyClassDef, PyClassImpl},
     common::lock::PyMutex,
-    function::{Callee, FuncArgs, PySetterValue},
+    function::{FuncArgs, PySetterValue},
     types::{Constructor, GetDescriptor, Initializer, Representable},
 };
 
@@ -70,7 +70,7 @@ impl Constructor for PyClassMethod {
         // copying its attributes to `__init__` so that subclasses overriding
         // `__init__` without calling `super().__init__()` see `__func__` as
         // `None`, matching CPython.
-        let _: Self::Args = args.bind_for(vm, Callee::of::<Self>(vm))?;
+        let _: Self::Args = args.bind_for(vm, Self::NAME)?;
         let classmethod = Self {
             callable: PyMutex::new(vm.ctx.none()),
         };

--- a/crates/vm/src/builtins/complex.rs
+++ b/crates/vm/src/builtins/complex.rs
@@ -2,10 +2,10 @@ use super::{PyStr, PyType, PyTypeRef, float};
 use crate::{
     AsObject, Context, Py, PyObject, PyObjectRef, PyPayload, PyRef, PyResult, VirtualMachine,
     builtins::PyUtf8StrRef,
-    class::PyClassImpl,
+    class::{PyClassDef, PyClassImpl},
     common::{format::FormatSpec, wtf8::Wtf8Buf},
     convert::{IntoPyException, ToPyObject, ToPyResult},
-    function::{Callee, FuncArgs, OptionalArg, PyComparisonValue},
+    function::{FuncArgs, OptionalArg, PyComparisonValue},
     protocol::PyNumberMethods,
     stdlib::_warnings,
     types::{AsNumber, Callable, Comparable, Constructor, Hashable, PyComparisonOp, Representable},
@@ -395,7 +395,7 @@ impl Constructor for PyComplex {
             return Ok(func_args.args[0].clone());
         }
 
-        let args: Self::Args = func_args.bind_for(vm, Callee::of::<Self>(vm))?;
+        let args: Self::Args = func_args.bind_for(vm, Self::NAME)?;
         let payload = Self::py_new(&cls, args, vm)?;
         payload.into_ref_with_type(vm, cls).map(Into::into)
     }

--- a/crates/vm/src/builtins/float.rs
+++ b/crates/vm/src/builtins/float.rs
@@ -5,12 +5,11 @@ use super::{
 use crate::{
     AsObject, Context, Py, PyObject, PyObjectRef, PyPayload, PyRef, PyResult,
     TryFromBorrowedObject, TryFromObject, VirtualMachine,
-    class::PyClassImpl,
+    class::{PyClassDef, PyClassImpl},
     common::{float_ops, format::FormatSpec, hash, wtf8::Wtf8Buf},
     convert::{IntoPyException, ToPyObject, ToPyResult},
     function::{
-        ArgBytesLike, Callee, FuncArgs, OptionalArg, OptionalOption, PyArithmeticValue,
-        PyComparisonValue,
+        ArgBytesLike, FuncArgs, OptionalArg, OptionalOption, PyArithmeticValue, PyComparisonValue,
     },
     protocol::PyNumberMethods,
     types::{AsNumber, Callable, Comparable, Constructor, Hashable, PyComparisonOp, Representable},
@@ -179,7 +178,7 @@ impl Constructor for PyFloat {
     fn slot_new(cls: PyTypeRef, args: FuncArgs, vm: &VirtualMachine) -> PyResult {
         // Bind before the fast path so FromArgs::arity decides how many arguments
         // are acceptable, rather than a count repeated here.
-        let arg: Self::Args = args.bind_for(vm, Callee::of::<Self>(vm))?;
+        let arg: Self::Args = args.bind_for(vm, Self::NAME)?;
 
         // Optimization: return exact float as-is
         if cls.is(vm.ctx.types.float_type)

--- a/crates/vm/src/builtins/frame_locals_proxy.rs
+++ b/crates/vm/src/builtins/frame_locals_proxy.rs
@@ -7,9 +7,9 @@ use super::{PyDict, PyDictRef, PyType};
 use crate::{
     AsObject, Context, Py, PyObject, PyObjectRef, PyPayload, PyRef, PyResult, VirtualMachine,
     atomic_func,
-    class::PyClassImpl,
+    class::{PyClassDef, PyClassImpl},
     frame::FrameObjectRef,
-    function::{Callee, FuncArgs, OptionalArg, PyArithmeticValue, PyComparisonValue},
+    function::{FuncArgs, OptionalArg, PyArithmeticValue, PyComparisonValue},
     object::{Traverse, TraverseFn},
     protocol::{PyIterReturn, PyMappingMethods, PyNumberMethods, PySequenceMethods},
     recursion::ReprGuard,
@@ -72,7 +72,7 @@ impl Constructor for FrameLocalsProxy {
 
     fn py_new(_cls: &Py<PyType>, args: Self::Args, vm: &VirtualMachine) -> PyResult<Self> {
         if args.args.len() != 1 {
-            return Err(Callee::of::<Self>(vm).arity_error(1..=1, args.args.len(), vm));
+            return Err(vm.new_arity_type_error(Self::NAME, 1..=1, args.args.len()));
         }
         if !args.kwargs.is_empty() {
             return Err(vm.new_type_error("FrameLocalsProxy() takes no keyword arguments"));

--- a/crates/vm/src/builtins/frame_locals_proxy.rs
+++ b/crates/vm/src/builtins/frame_locals_proxy.rs
@@ -9,7 +9,7 @@ use crate::{
     atomic_func,
     class::PyClassImpl,
     frame::FrameObjectRef,
-    function::{FuncArgs, OptionalArg, PyArithmeticValue, PyComparisonValue},
+    function::{Callee, FuncArgs, OptionalArg, PyArithmeticValue, PyComparisonValue},
     object::{Traverse, TraverseFn},
     protocol::{PyIterReturn, PyMappingMethods, PyNumberMethods, PySequenceMethods},
     recursion::ReprGuard,
@@ -71,16 +71,13 @@ impl Constructor for FrameLocalsProxy {
     type Args = FuncArgs;
 
     fn py_new(_cls: &Py<PyType>, args: Self::Args, vm: &VirtualMachine) -> PyResult<Self> {
+        if args.args.len() != 1 {
+            return Err(Callee::of::<Self>(vm).arity_error(1..=1, args.args.len(), vm));
+        }
         if !args.kwargs.is_empty() {
             return Err(vm.new_type_error("FrameLocalsProxy() takes no keyword arguments"));
         }
         let mut args = args.args;
-        if args.len() != 1 {
-            return Err(vm.new_type_error(format!(
-                "FrameLocalsProxy expected 1 argument, got {}",
-                args.len()
-            )));
-        }
         let frame: FrameObjectRef = args
             .pop()
             .unwrap()

--- a/crates/vm/src/builtins/genericalias.rs
+++ b/crates/vm/src/builtins/genericalias.rs
@@ -6,10 +6,10 @@ use crate::{
     AsObject, Context, Py, PyObject, PyObjectRef, PyPayload, PyRef, PyResult, TryFromObject,
     VirtualMachine, atomic_func,
     builtins::{PyList, PyStr, PyTuple, PyTupleRef, PyType},
-    class::PyClassImpl,
+    class::{PyClassDef, PyClassImpl},
     common::hash,
     convert::ToPyObject,
-    function::{Callee, FuncArgs, PyComparisonValue},
+    function::{FuncArgs, PyComparisonValue},
     protocol::{PyMappingMethods, PyNumberMethods},
     types::{
         AsMapping, AsNumber, Callable, Comparable, Constructor, GetAttr, Hashable, IterNext,
@@ -62,8 +62,7 @@ impl Constructor for PyGenericAlias {
         if !args.kwargs.is_empty() {
             return Err(vm.new_type_error("GenericAlias() takes no keyword arguments"));
         }
-        let (origin, arguments): (PyObjectRef, PyObjectRef) =
-            args.bind_for(vm, Callee::of::<Self>(vm))?;
+        let (origin, arguments): (PyObjectRef, PyObjectRef) = args.bind_for(vm, Self::NAME)?;
         let args = if let Ok(tuple) = arguments.try_to_ref::<PyTuple>(vm) {
             tuple.to_owned()
         } else {

--- a/crates/vm/src/builtins/genericalias.rs
+++ b/crates/vm/src/builtins/genericalias.rs
@@ -9,7 +9,7 @@ use crate::{
     class::PyClassImpl,
     common::hash,
     convert::ToPyObject,
-    function::{FuncArgs, PyComparisonValue},
+    function::{Callee, FuncArgs, PyComparisonValue},
     protocol::{PyMappingMethods, PyNumberMethods},
     types::{
         AsMapping, AsNumber, Callable, Comparable, Constructor, GetAttr, Hashable, IterNext,
@@ -62,7 +62,8 @@ impl Constructor for PyGenericAlias {
         if !args.kwargs.is_empty() {
             return Err(vm.new_type_error("GenericAlias() takes no keyword arguments"));
         }
-        let (origin, arguments): (PyObjectRef, PyObjectRef) = args.bind(vm)?;
+        let (origin, arguments): (PyObjectRef, PyObjectRef) =
+            args.bind_for(vm, Callee::of::<Self>(vm))?;
         let args = if let Ok(tuple) = arguments.try_to_ref::<PyTuple>(vm) {
             tuple.to_owned()
         } else {

--- a/crates/vm/src/builtins/int.rs
+++ b/crates/vm/src/builtins/int.rs
@@ -4,7 +4,7 @@ use crate::{
     TryFromBorrowedObject, VirtualMachine,
     builtins::PyUtf8StrRef,
     byte::bytes_from_object,
-    class::PyClassImpl,
+    class::{PyClassDef, PyClassImpl},
     common::{
         format::FormatSpec,
         hash,
@@ -13,8 +13,8 @@ use crate::{
     },
     convert::{IntoPyException, ToPyObject, ToPyResult},
     function::{
-        ArgByteOrder, ArgIntoBool, Callee, FuncArgs, OptionalArg, OptionalOption,
-        PyArithmeticValue, PyComparisonValue,
+        ArgByteOrder, ArgIntoBool, FuncArgs, OptionalArg, OptionalOption, PyArithmeticValue,
+        PyComparisonValue,
     },
     protocol::{PyNumberMethods, handle_bytes_to_int_err, numeric_literal_from_str},
     types::{AsNumber, Comparable, Constructor, Hashable, PyComparisonOp, Representable},
@@ -259,7 +259,7 @@ impl Constructor for PyInt {
             return Ok(args.args[0].clone());
         }
 
-        let options: IntOptions = args.bind_for(vm, Callee::of::<Self>(vm))?;
+        let options: IntOptions = args.bind_for(vm, Self::NAME)?;
         let value = if let OptionalArg::Present(val) = options.val_options {
             if let OptionalArg::Present(base) = options.base {
                 let base = base

--- a/crates/vm/src/builtins/range.rs
+++ b/crates/vm/src/builtins/range.rs
@@ -6,9 +6,9 @@ use crate::common::lock::LazyLock;
 use crate::{
     AsObject, Context, Py, PyObject, PyObjectRef, PyPayload, PyRef, PyResult, TryFromObject,
     VirtualMachine, atomic_func,
-    class::PyClassImpl,
+    class::{PyClassDef, PyClassImpl},
     common::hash::PyHash,
-    function::{ArgIndex, Callee, FuncArgs, OptionalArg, PyComparisonValue},
+    function::{ArgIndex, FuncArgs, OptionalArg, PyComparisonValue},
     protocol::{PyIterReturn, PyMappingMethods, PyNumberMethods, PySequenceMethods},
     types::{
         AsMapping, AsNumber, AsSequence, Comparable, Hashable, IterNext, Iterable, PyComparisonOp,
@@ -352,12 +352,12 @@ impl PyRange {
     #[pyslot]
     fn slot_new(cls: PyTypeRef, args: FuncArgs, vm: &VirtualMachine) -> PyResult {
         let range = if args.args.is_empty() {
-            return Err(Callee::of::<Self>(vm).arity_error(1..=3, 0, vm));
+            return Err(vm.new_arity_type_error(Self::NAME, 1..=3, 0));
         } else if args.args.len() == 1 {
-            let stop = args.bind_for(vm, Callee::of::<Self>(vm))?;
+            let stop = args.bind_for(vm, Self::NAME)?;
             Self::new(cls, stop, vm)
         } else {
-            let (start, stop, step) = args.bind_for(vm, Callee::of::<Self>(vm))?;
+            let (start, stop, step) = args.bind_for(vm, Self::NAME)?;
             Self::new_from(cls, start, stop, step, vm)
         }?;
 

--- a/crates/vm/src/builtins/set.rs
+++ b/crates/vm/src/builtins/set.rs
@@ -1095,10 +1095,7 @@ impl Constructor for PyFrozenSet {
                 [] => OptionalArg::Missing,
                 [iterable] => OptionalArg::Present(iterable.clone()),
                 slice => {
-                    return Err(vm.new_type_error(format!(
-                        "frozenset expected at most 1 argument, got {}",
-                        slice.len()
-                    )));
+                    return Err(Callee::of::<Self>(vm).arity_error(0..=1, slice.len(), vm));
                 }
             }
         };

--- a/crates/vm/src/builtins/set.rs
+++ b/crates/vm/src/builtins/set.rs
@@ -8,7 +8,7 @@ use super::{
 use crate::{
     AsObject, Context, Py, PyObject, PyObjectRef, PyPayload, PyRef, PyResult, TryFromObject,
     atomic_func,
-    class::PyClassImpl,
+    class::{PyClassDef, PyClassImpl},
     common::{
         ascii,
         hash::PyHash,
@@ -18,9 +18,7 @@ use crate::{
     },
     convert::ToPyResult,
     dict_inner::{self, DictSize},
-    function::{
-        ArgIterable, Callee, FuncArgs, OptionalArg, PosArgs, PyArithmeticValue, PyComparisonValue,
-    },
+    function::{ArgIterable, FuncArgs, OptionalArg, PosArgs, PyArithmeticValue, PyComparisonValue},
     protocol::{PyIterReturn, PyNumberMethods, PySequenceMethods},
     recursion::ReprGuard,
     types::AsNumber,
@@ -1079,7 +1077,7 @@ impl Constructor for PyFrozenSet {
 
         // Optimizations for exact frozenset type
         let iterable_opt = if is_exact_frozenset || is_frozenset_init {
-            let iterable: OptionalArg<PyObjectRef> = args.bind_for(vm, Callee::of::<Self>(vm))?;
+            let iterable: OptionalArg<PyObjectRef> = args.bind_for(vm, Self::NAME)?;
 
             // Return exact frozenset as-is
             if is_exact_frozenset
@@ -1095,7 +1093,7 @@ impl Constructor for PyFrozenSet {
                 [] => OptionalArg::Missing,
                 [iterable] => OptionalArg::Present(iterable.clone()),
                 slice => {
-                    return Err(Callee::of::<Self>(vm).arity_error(0..=1, slice.len(), vm));
+                    return Err(vm.new_arity_type_error(Self::NAME, 0..=1, slice.len()));
                 }
             }
         };

--- a/crates/vm/src/builtins/singletons.rs
+++ b/crates/vm/src/builtins/singletons.rs
@@ -1,10 +1,10 @@
 use super::{PyStrRef, PyType, PyTypeRef};
 use crate::{
     Context, Py, PyObjectRef, PyPayload, PyResult, VirtualMachine,
-    class::PyClassImpl,
+    class::{PyClassDef, PyClassImpl},
     common::hash::PyHash,
     convert::ToPyObject,
-    function::{Callee, FuncArgs, PyComparisonValue},
+    function::{FuncArgs, PyComparisonValue},
     protocol::PyNumberMethods,
     types::{AsNumber, Comparable, Constructor, Hashable, PyComparisonOp, Representable},
 };
@@ -41,7 +41,7 @@ impl Constructor for PyNone {
     type Args = ();
 
     fn slot_new(_cls: PyTypeRef, args: FuncArgs, vm: &VirtualMachine) -> PyResult {
-        let _: () = args.bind_for(vm, Callee::of::<Self>(vm))?;
+        let _: () = args.bind_for(vm, Self::NAME)?;
         Ok(vm.ctx.none.clone().into())
     }
 
@@ -110,7 +110,7 @@ impl Constructor for PyNotImplemented {
     type Args = ();
 
     fn slot_new(_cls: PyTypeRef, args: FuncArgs, vm: &VirtualMachine) -> PyResult {
-        let _: () = args.bind_for(vm, Callee::of::<Self>(vm))?;
+        let _: () = args.bind_for(vm, Self::NAME)?;
         Ok(vm.ctx.not_implemented.clone().into())
     }
 

--- a/crates/vm/src/builtins/slice.rs
+++ b/crates/vm/src/builtins/slice.rs
@@ -7,10 +7,10 @@ use rustpython_common::wtf8::{Wtf8Buf, wtf8_concat};
 use super::{PyGenericAlias, PyStrRef, PyTupleRef, PyType, PyTypeRef};
 use crate::{
     AsObject, Context, Py, PyObject, PyObjectRef, PyPayload, PyRef, PyResult, VirtualMachine,
-    class::PyClassImpl,
+    class::{PyClassDef, PyClassImpl},
     common::hash::{PyHash, PyUHash},
     convert::ToPyObject,
-    function::{ArgIndex, Callee, FuncArgs, OptionalArg, PyComparisonValue},
+    function::{ArgIndex, FuncArgs, OptionalArg, PyComparisonValue},
     sliceable::SaturatedSlice,
     types::{Comparable, Constructor, Hashable, PyComparisonOp, Representable},
 };
@@ -128,10 +128,10 @@ impl PySlice {
     fn slot_new(cls: PyTypeRef, args: FuncArgs, vm: &VirtualMachine) -> PyResult {
         let slice: Self = match args.args.len() {
             0 => {
-                return Err(Callee::of::<Self>(vm).arity_error(1..=3, 0, vm));
+                return Err(vm.new_arity_type_error(Self::NAME, 1..=3, 0));
             }
             1 => {
-                let stop = args.bind_for(vm, Callee::of::<Self>(vm))?;
+                let stop = args.bind_for(vm, Self::NAME)?;
                 Self {
                     start: None,
                     stop,
@@ -140,7 +140,7 @@ impl PySlice {
             }
             _ => {
                 let (start, stop, step): (PyObjectRef, PyObjectRef, OptionalArg<PyObjectRef>) =
-                    args.bind_for(vm, Callee::of::<Self>(vm))?;
+                    args.bind_for(vm, Self::NAME)?;
                 Self {
                     start: Some(start),
                     stop,
@@ -388,7 +388,7 @@ impl Constructor for PyEllipsis {
     type Args = ();
 
     fn slot_new(_cls: PyTypeRef, args: FuncArgs, vm: &VirtualMachine) -> PyResult {
-        let _: () = args.bind_for(vm, Callee::of::<Self>(vm))?;
+        let _: () = args.bind_for(vm, Self::NAME)?;
         Ok(vm.ctx.ellipsis.clone().into())
     }
 

--- a/crates/vm/src/builtins/staticmethod.rs
+++ b/crates/vm/src/builtins/staticmethod.rs
@@ -1,9 +1,9 @@
 use super::{PyGenericAlias, PyStr, PyType, PyTypeRef};
 use crate::{
     AsObject, Context, Py, PyObjectRef, PyPayload, PyRef, PyResult, VirtualMachine,
-    class::PyClassImpl,
+    class::{PyClassDef, PyClassImpl},
     common::lock::PyMutex,
-    function::{Callee, FuncArgs, PySetterValue},
+    function::{FuncArgs, PySetterValue},
     types::{Callable, Constructor, GetDescriptor, Initializer, Representable},
 };
 
@@ -48,7 +48,7 @@ impl Constructor for PyStaticMethod {
         // copying its attributes to `__init__` so that subclasses overriding
         // `__init__` without calling `super().__init__()` see `__func__` as
         // `None`, matching CPython.
-        let _: Self::Args = args.bind_for(vm, Callee::of::<Self>(vm))?;
+        let _: Self::Args = args.bind_for(vm, Self::NAME)?;
         let result = Self {
             callable: PyMutex::new(vm.ctx.none()),
         }

--- a/crates/vm/src/builtins/str.rs
+++ b/crates/vm/src/builtins/str.rs
@@ -10,16 +10,14 @@ use crate::{
     atomic_func,
     bytes_inner::{swapcase_ascii, title_ascii},
     cformat::cformat_string,
-    class::PyClassImpl,
+    class::{PyClassDef, PyClassImpl},
     common::{
         lock::LazyLock,
         str::{PyKindStr, StrData, StrKind},
     },
     convert::{IntoPyException, ToPyException, ToPyObject, ToPyResult},
     format::{format, format_map},
-    function::{
-        ArgIterable, ArgSize, Callee, FuncArgs, OptionalArg, OptionalOption, PyComparisonValue,
-    },
+    function::{ArgIterable, ArgSize, FuncArgs, OptionalArg, OptionalOption, PyComparisonValue},
     intern::PyInterned,
     object::{MaybeTraverse, Traverse, TraverseFn},
     protocol::{
@@ -411,7 +409,7 @@ impl Constructor for PyStr {
             return Ok(func_args.args[0].clone());
         }
 
-        let args: Self::Args = func_args.bind_for(vm, Callee::of::<Self>(vm))?;
+        let args: Self::Args = func_args.bind_for(vm, Self::NAME)?;
 
         // CPython parity: when cls is exactly str, return the __str__ / __repr__
         // result as-is so any str subclass type the user returned is preserved

--- a/crates/vm/src/builtins/tuple.rs
+++ b/crates/vm/src/builtins/tuple.rs
@@ -8,9 +8,9 @@ use crate::object::{Traverse, TraverseFn};
 use crate::{
     AsObject, Context, Py, PyObject, PyObjectRef, PyPayload, PyRef, PyResult, TryFromObject,
     atomic_func,
-    class::PyClassImpl,
+    class::{PyClassDef, PyClassImpl},
     convert::{ToPyObject, TransmuteFromObject},
-    function::{ArgSize, Callee, FuncArgs, OptionalArg, PyArithmeticValue, PyComparisonValue},
+    function::{ArgSize, FuncArgs, OptionalArg, PyArithmeticValue, PyComparisonValue},
     iter::PyExactSizeIterator,
     protocol::{PyIterReturn, PyMappingMethods, PyNumberMethods, PySequenceMethods},
     recursion::ReprGuard,
@@ -221,7 +221,7 @@ impl Constructor for PyTuple {
     type Args = Vec<PyObjectRef>;
 
     fn slot_new(cls: PyTypeRef, args: FuncArgs, vm: &VirtualMachine) -> PyResult {
-        let iterable: OptionalArg<PyObjectRef> = args.bind_for(vm, Callee::of::<Self>(vm))?;
+        let iterable: OptionalArg<PyObjectRef> = args.bind_for(vm, Self::NAME)?;
 
         // Optimizations for exact tuple type
         if cls.is(vm.ctx.types.tuple_type) {

--- a/crates/vm/src/builtins/type.rs
+++ b/crates/vm/src/builtins/type.rs
@@ -14,13 +14,13 @@ use crate::{
         function::{PyCellRef, PyFunction},
         tuple::{IntoPyTuple, PyTuple},
     },
-    class::{PyClassImpl, StaticType},
+    class::{PyClassDef, PyClassImpl, StaticType},
     common::{
         ascii,
         borrow::BorrowedValue,
         lock::{PyRwLock, PyRwLockReadGuard},
     },
-    function::{Callee, FuncArgs, KwArgs, OptionalArg, PyMethodDef, PySetterValue},
+    function::{FuncArgs, KwArgs, OptionalArg, PyMethodDef, PySetterValue},
     object::{Traverse, TraverseFn},
     protocol::{PyIterReturn, PyNumberMethods},
     types::{
@@ -2297,7 +2297,7 @@ impl Constructor for PyType {
         }
 
         let (name, bases, dict, kwargs): (PyStrRef, PyTupleRef, PyDictRef, KwArgs) =
-            args.clone().bind_for(vm, Callee::of::<Self>(vm))?;
+            args.clone().bind_for(vm, Self::NAME)?;
 
         if name.as_bytes().contains(&0) {
             return Err(vm.new_value_error("type name must not contain null characters"));

--- a/crates/vm/src/builtins/type.rs
+++ b/crates/vm/src/builtins/type.rs
@@ -20,7 +20,7 @@ use crate::{
         borrow::BorrowedValue,
         lock::{PyRwLock, PyRwLockReadGuard},
     },
-    function::{FuncArgs, KwArgs, OptionalArg, PyMethodDef, PySetterValue},
+    function::{Callee, FuncArgs, KwArgs, OptionalArg, PyMethodDef, PySetterValue},
     object::{Traverse, TraverseFn},
     protocol::{PyIterReturn, PyNumberMethods},
     types::{
@@ -2297,7 +2297,7 @@ impl Constructor for PyType {
         }
 
         let (name, bases, dict, kwargs): (PyStrRef, PyTupleRef, PyDictRef, KwArgs) =
-            args.clone().bind(vm)?;
+            args.clone().bind_for(vm, Callee::of::<Self>(vm))?;
 
         if name.as_bytes().contains(&0) {
             return Err(vm.new_value_error("type name must not contain null characters"));

--- a/crates/vm/src/builtins/weakproxy.rs
+++ b/crates/vm/src/builtins/weakproxy.rs
@@ -2,11 +2,9 @@ use super::{PyStr, PyStrRef, PyType, PyTypeRef, PyWeak};
 use crate::common::lock::LazyLock;
 use crate::{
     Context, Py, PyObject, PyObjectRef, PyPayload, PyRef, PyResult, VirtualMachine, atomic_func,
-    class::PyClassImpl,
+    class::{PyClassDef, PyClassImpl},
     common::hash::PyHash,
-    function::{
-        Callee, FuncArgs, OptionalArg, PyArithmeticValue, PyComparisonValue, PySetterValue,
-    },
+    function::{FuncArgs, OptionalArg, PyArithmeticValue, PyComparisonValue, PySetterValue},
     protocol::{PyIter, PyIterReturn, PyMappingMethods, PyNumberMethods, PySequenceMethods},
     stdlib::builtins::reversed,
     types::{
@@ -50,7 +48,7 @@ impl Constructor for PyWeakProxy {
 
     fn slot_new(cls: PyTypeRef, args: FuncArgs, vm: &VirtualMachine) -> PyResult {
         let _ = cls;
-        let Self::Args { referent, callback } = args.bind_for(vm, Callee::of::<Self>(vm))?;
+        let Self::Args { referent, callback } = args.bind_for(vm, Self::NAME)?;
         let callback = callback
             .into_option()
             .filter(|callback| !vm.is_none(callback));

--- a/crates/vm/src/builtins/weakref.rs
+++ b/crates/vm/src/builtins/weakref.rs
@@ -6,7 +6,7 @@ use crate::common::{
 use crate::{
     AsObject, Context, Py, PyObject, PyObjectRef, PyPayload, PyRef, PyResult, VirtualMachine,
     class::PyClassImpl,
-    function::{FuncArgs, OptionalArg, PyArithmeticValue, PyComparisonValue},
+    function::{Callee, FuncArgs, OptionalArg, PyArithmeticValue, PyComparisonValue},
     types::{
         Callable, Comparable, Constructor, Hashable, Initializer, PyComparisonOp, Representable,
     },
@@ -45,16 +45,15 @@ impl Constructor for PyWeak {
     fn slot_new(cls: PyTypeRef, args: FuncArgs, vm: &VirtualMachine) -> PyResult {
         // PyArg_UnpackTuple: only process positional args, ignore kwargs.
         // Subclass __init__ will handle extra kwargs.
+        let callee = Callee::named("__new__");
         let mut positional = args.args.into_iter();
         let referent = positional
             .next()
-            .ok_or_else(|| vm.new_type_error("__new__ expected at least 1 argument, got 0"))?;
+            .ok_or_else(|| callee.arity_error(1..=2, 0, vm))?;
         let callback = positional.next().filter(|callback| !vm.is_none(callback));
         if let Some(_extra) = positional.next() {
             let got = positional.count() + 3;
-            return Err(
-                vm.new_type_error(format!("__new__ expected at most 2 arguments, got {got}"))
-            );
+            return Err(callee.arity_error(1..=2, got, vm));
         }
         let weak = referent.downgrade_with_typ(callback, cls, vm)?;
         Ok(weak.into())

--- a/crates/vm/src/builtins/weakref.rs
+++ b/crates/vm/src/builtins/weakref.rs
@@ -6,7 +6,7 @@ use crate::common::{
 use crate::{
     AsObject, Context, Py, PyObject, PyObjectRef, PyPayload, PyRef, PyResult, VirtualMachine,
     class::PyClassImpl,
-    function::{Callee, FuncArgs, OptionalArg, PyArithmeticValue, PyComparisonValue},
+    function::{FuncArgs, OptionalArg, PyArithmeticValue, PyComparisonValue},
     types::{
         Callable, Comparable, Constructor, Hashable, Initializer, PyComparisonOp, Representable,
     },
@@ -45,15 +45,14 @@ impl Constructor for PyWeak {
     fn slot_new(cls: PyTypeRef, args: FuncArgs, vm: &VirtualMachine) -> PyResult {
         // PyArg_UnpackTuple: only process positional args, ignore kwargs.
         // Subclass __init__ will handle extra kwargs.
-        let callee = Callee::named("__new__");
         let mut positional = args.args.into_iter();
         let referent = positional
             .next()
-            .ok_or_else(|| callee.arity_error(1..=2, 0, vm))?;
+            .ok_or_else(|| vm.new_arity_type_error("__new__", 1..=2, 0))?;
         let callback = positional.next().filter(|callback| !vm.is_none(callback));
         if let Some(_extra) = positional.next() {
             let got = positional.count() + 3;
-            return Err(callee.arity_error(1..=2, got, vm));
+            return Err(vm.new_arity_type_error("__new__", 1..=2, got));
         }
         let weak = referent.downgrade_with_typ(callback, cls, vm)?;
         Ok(weak.into())

--- a/crates/vm/src/exception_group.rs
+++ b/crates/vm/src/exception_group.rs
@@ -7,6 +7,7 @@ use crate::function::{ArgIterable, FuncArgs};
 use crate::types::{PyTypeFlags, PyTypeSlots};
 use crate::{
     AsObject, Context, Py, PyObject, PyObjectRef, PyRef, PyResult, TryFromObject, VirtualMachine,
+    class::PyClassDef,
 };
 use core::fmt::Write;
 use rustpython_common::wtf8::{Wtf8, Wtf8Buf};
@@ -245,7 +246,7 @@ pub(super) mod types {
         type Args = crate::function::PosArgs;
 
         fn slot_new(cls: PyTypeRef, args: FuncArgs, vm: &VirtualMachine) -> PyResult {
-            let args: Self::Args = args.bind_for(vm, crate::function::Callee::of::<Self>(vm))?;
+            let args: Self::Args = args.bind_for(vm, Self::NAME)?;
             let args = args.into_vec();
             // Validate exactly 2 positional arguments
             if args.len() != 2 {

--- a/crates/vm/src/exceptions.rs
+++ b/crates/vm/src/exceptions.rs
@@ -1616,6 +1616,7 @@ impl ToPyException for rustpython_host_env::multiprocessing::SemError {
 }
 
 pub(super) mod types {
+    use crate::class::PyClassDef;
     use crate::common::lock::PyRwLock;
     use crate::object::{Traverse, TraverseFn};
     #[cfg_attr(target_arch = "wasm32", allow(unused_imports))]
@@ -1627,7 +1628,7 @@ pub(super) mod types {
             tuple::IntoPyTuple,
         },
         convert::ToPyResult,
-        function::{ArgBytesLike, Callee, FuncArgs, KwArgs, PySetterValue},
+        function::{ArgBytesLike, FuncArgs, KwArgs, PySetterValue},
         set_attrs,
         types::{Constructor, Initializer},
     };
@@ -1876,7 +1877,10 @@ pub(super) mod types {
 
             // Reject unknown kwargs
             if let Some(invalid_key) = kwargs.keys().next() {
-                return Err(Callee::of::<Self>(vm).unexpected_keyword(&invalid_key.to_string(), vm));
+                return Err(vm.new_unexpected_keyword_type_error(
+                    Some(Self::NAME),
+                    &invalid_key.to_string(),
+                ));
             }
 
             // Pass args without kwargs to BaseException_init
@@ -2029,7 +2033,10 @@ pub(super) mod types {
 
             // Reject unknown kwargs
             if let Some(invalid_key) = kwargs.keys().next() {
-                return Err(Callee::of::<Self>(vm).unexpected_keyword(&invalid_key.to_string(), vm));
+                return Err(vm.new_unexpected_keyword_type_error(
+                    Some(Self::NAME),
+                    &invalid_key.to_string(),
+                ));
             }
 
             // Pass args without kwargs to BaseException_init

--- a/crates/vm/src/exceptions.rs
+++ b/crates/vm/src/exceptions.rs
@@ -1627,7 +1627,7 @@ pub(super) mod types {
             tuple::IntoPyTuple,
         },
         convert::ToPyResult,
-        function::{ArgBytesLike, FuncArgs, KwArgs, PySetterValue},
+        function::{ArgBytesLike, Callee, FuncArgs, KwArgs, PySetterValue},
         set_attrs,
         types::{Constructor, Initializer},
     };
@@ -1876,9 +1876,7 @@ pub(super) mod types {
 
             // Reject unknown kwargs
             if let Some(invalid_key) = kwargs.keys().next() {
-                return Err(vm.new_type_error(format!(
-                    "AttributeError() got an unexpected keyword argument '{invalid_key}'"
-                )));
+                return Err(Callee::of::<Self>(vm).unexpected_keyword(&invalid_key.to_string(), vm));
             }
 
             // Pass args without kwargs to BaseException_init
@@ -2031,9 +2029,7 @@ pub(super) mod types {
 
             // Reject unknown kwargs
             if let Some(invalid_key) = kwargs.keys().next() {
-                return Err(vm.new_type_error(format!(
-                    "NameError() got an unexpected keyword argument '{invalid_key}'"
-                )));
+                return Err(Callee::of::<Self>(vm).unexpected_keyword(&invalid_key.to_string(), vm));
             }
 
             // Pass args without kwargs to BaseException_init

--- a/crates/vm/src/function/argument.rs
+++ b/crates/vm/src/function/argument.rs
@@ -433,7 +433,8 @@ impl Callee {
     }
 
     /// The branch of _PyArg_UnpackKeywords that names a keyword it didn't expect.
-    fn unexpected_keyword(self, keyword: &str, vm: &VirtualMachine) -> PyBaseExceptionRef {
+    #[must_use]
+    pub fn unexpected_keyword(self, keyword: &str, vm: &VirtualMachine) -> PyBaseExceptionRef {
         let (name, parens) = self.call_form("this function");
         vm.new_type_error(format!(
             "{name}{parens} got an unexpected keyword argument '{keyword}'"

--- a/crates/vm/src/function/argument.rs
+++ b/crates/vm/src/function/argument.rs
@@ -290,7 +290,12 @@ impl FuncArgs {
 
     /// Binds these arguments the way [`bind`](Self::bind) does, for a call whose
     /// function a failure can describe.
-    pub fn bind_for<T: FromArgs>(mut self, vm: &VirtualMachine, callee: Callee) -> PyResult<T> {
+    pub fn bind_for<T: FromArgs>(
+        mut self,
+        vm: &VirtualMachine,
+        callee: impl Into<Callee>,
+    ) -> PyResult<T> {
+        let callee = callee.into();
         // A message describes the parameters the function declares, and the
         // instance a method is called on is not one of them.
         let instance = callee.instance_args();
@@ -319,8 +324,9 @@ impl FuncArgs {
     pub fn check_kwargs_empty_for(
         &self,
         vm: &VirtualMachine,
-        callee: Callee,
+        callee: impl Into<Callee>,
     ) -> Option<PyBaseExceptionRef> {
+        let callee = callee.into();
         self.kwargs
             .keys()
             .next()
@@ -339,6 +345,12 @@ impl FuncArgs {
 pub struct Callee {
     name: Option<&'static str>,
     instance_arg: bool,
+}
+
+impl From<&'static str> for Callee {
+    fn from(name: &'static str) -> Self {
+        Self::named(name)
+    }
 }
 
 impl Callee {
@@ -376,35 +388,6 @@ impl Callee {
         self.instance_arg as usize
     }
 
-    /// The name a message uses. `tp_name` carries the module along with the
-    /// type, and a message names only the type itself.
-    fn short_name(self) -> Option<&'static str> {
-        self.name
-            .map(|name| name.rsplit_once('.').map_or(name, |(_, name)| name))
-    }
-
-    /// The name a message opens with and the parentheses that follow it, given
-    /// what to call a function whose name isn't known.
-    fn call_form(self, unnamed: &'static str) -> (&'static str, &'static str) {
-        match self.short_name() {
-            Some(name) => (name, "()"),
-            None => (unnamed, ""),
-        }
-    }
-
-    /// The error a call that passed the wrong number of arguments gets, for a
-    /// slot that counts them itself.
-    #[must_use]
-    pub fn arity_error(
-        self,
-        arity: RangeInclusive<usize>,
-        num_given: usize,
-        vm: &VirtualMachine,
-    ) -> PyBaseExceptionRef {
-        let too_few = num_given < *arity.start();
-        self.wrong_arity(&arity, too_few, num_given, vm)
-    }
-
     /// _PyArg_CheckPositional
     fn wrong_arity(
         self,
@@ -413,32 +396,12 @@ impl Callee {
         num_given: usize,
         vm: &VirtualMachine,
     ) -> PyBaseExceptionRef {
-        let (limit, bound) = if too_few {
-            (*arity.start(), "at least ")
-        } else {
-            (*arity.end(), "at most ")
-        };
-        let bound = if arity.start() == arity.end() {
-            ""
-        } else {
-            bound
-        };
-        let plural = if limit == 1 { "" } else { "s" };
-        let name = self
-            .short_name()
-            .map_or_else(String::new, |name| format!("{name} "));
-        vm.new_type_error(format!(
-            "{name}expected {bound}{limit} argument{plural}, got {num_given}"
-        ))
+        vm.new_type_error(arity_message(self.name, arity, too_few, num_given))
     }
 
     /// The branch of _PyArg_UnpackKeywords that names a keyword it didn't expect.
-    #[must_use]
-    pub fn unexpected_keyword(self, keyword: &str, vm: &VirtualMachine) -> PyBaseExceptionRef {
-        let (name, parens) = self.call_form("this function");
-        vm.new_type_error(format!(
-            "{name}{parens} got an unexpected keyword argument '{keyword}'"
-        ))
+    fn unexpected_keyword(self, keyword: &str, vm: &VirtualMachine) -> PyBaseExceptionRef {
+        vm.new_type_error(unexpected_keyword_message(self.name, keyword))
     }
 
     /// The branch of _PyArg_UnpackKeywords that names a parameter it didn't get.
@@ -448,11 +411,59 @@ impl Callee {
         pos: usize,
         vm: &VirtualMachine,
     ) -> PyBaseExceptionRef {
-        let (name, parens) = self.call_form("function");
-        vm.new_type_error(format!(
-            "{name}{parens} missing required argument '{keyword}' (pos {pos})"
-        ))
+        vm.new_type_error(missing_argument_message(self.name, keyword, pos))
     }
+}
+
+/// The name a message uses. `tp_name` carries the module along with the type,
+/// and a message names only the type itself.
+fn short_name(name: &str) -> &str {
+    name.rsplit_once('.').map_or(name, |(_, name)| name)
+}
+
+/// The name a message opens with and the parentheses that follow it, given what
+/// to call a function whose name isn't known.
+fn call_form<'a>(name: Option<&'a str>, unnamed: &'a str) -> (&'a str, &'static str) {
+    match name.map(short_name) {
+        Some(name) => (name, "()"),
+        None => (unnamed, ""),
+    }
+}
+
+/// _PyArg_CheckPositional
+pub(crate) fn arity_message(
+    name: Option<&str>,
+    arity: &RangeInclusive<usize>,
+    too_few: bool,
+    num_given: usize,
+) -> String {
+    let (limit, bound) = if too_few {
+        (*arity.start(), "at least ")
+    } else {
+        (*arity.end(), "at most ")
+    };
+    let bound = if arity.start() == arity.end() {
+        ""
+    } else {
+        bound
+    };
+    let plural = if limit == 1 { "" } else { "s" };
+    let name = name
+        .map(short_name)
+        .map_or_else(String::new, |name| format!("{name} "));
+    format!("{name}expected {bound}{limit} argument{plural}, got {num_given}")
+}
+
+/// The branch of _PyArg_UnpackKeywords that names a keyword it didn't expect.
+pub(crate) fn unexpected_keyword_message(name: Option<&str>, keyword: &str) -> String {
+    let (name, parens) = call_form(name, "this function");
+    format!("{name}{parens} got an unexpected keyword argument '{keyword}'")
+}
+
+/// The branch of _PyArg_UnpackKeywords that names a parameter it didn't get.
+pub(crate) fn missing_argument_message(name: Option<&str>, keyword: &str, pos: usize) -> String {
+    let (name, parens) = call_form(name, "function");
+    format!("{name}{parens} missing required argument '{keyword}' (pos {pos})")
 }
 
 /// An error encountered while binding arguments to the parameters of a Python

--- a/crates/vm/src/function/mod.rs
+++ b/crates/vm/src/function/mod.rs
@@ -15,6 +15,7 @@ pub use argument::{
     ArgumentError, Callee, FromArgOptional, FromArgs, FuncArgs, IntoFuncArgs, KwArgs, KwArgsMap,
     OptionalArg, OptionalOption, PosArgs,
 };
+pub(crate) use argument::{arity_message, unexpected_keyword_message};
 pub use arithmetic::{PyArithmeticValue, PyComparisonValue};
 pub use buffer::{
     ArgAsciiBuffer, ArgBytesLike, ArgContiguousBytesLike, ArgMemoryBuffer, ArgStrOrBytesLike,

--- a/crates/vm/src/stdlib/_ctypes/simple.rs
+++ b/crates/vm/src/stdlib/_ctypes/simple.rs
@@ -11,7 +11,8 @@ use crate::function::{Either, FuncArgs, OptionalArg};
 use crate::protocol::{BufferDescriptor, PyBuffer, PyNumberMethods};
 use crate::types::{AsBuffer, AsNumber, Constructor, Initializer, Representable};
 use crate::{
-    AsObject, Py, PyObject, PyObjectRef, PyPayload, PyRef, PyResult, VirtualMachine, set_attrs,
+    AsObject, Py, PyObject, PyObjectRef, PyPayload, PyRef, PyResult, VirtualMachine,
+    class::PyClassDef, set_attrs,
 };
 use alloc::borrow::Cow;
 use core::fmt::Debug;
@@ -984,7 +985,7 @@ impl Constructor for PyCSimple {
     type Args = (OptionalArg,);
 
     fn slot_new(cls: PyTypeRef, args: FuncArgs, vm: &VirtualMachine) -> PyResult {
-        let args: Self::Args = args.bind_for(vm, crate::function::Callee::of::<Self>(vm))?;
+        let args: Self::Args = args.bind_for(vm, Self::NAME)?;
         let _type_ = cls
             .type_code(vm)
             .ok_or_else(|| vm.new_type_error("abstract class"))?;

--- a/crates/vm/src/stdlib/_io.rs
+++ b/crates/vm/src/stdlib/_io.rs
@@ -131,8 +131,8 @@ mod _io {
         convert::ToPyObject,
         exceptions::nul_char_error,
         function::{
-            ArgBytesLike, ArgContiguousBytesLike, ArgIterable, ArgMemoryBuffer, ArgSize, Either,
-            FsPath, FuncArgs, IntoFuncArgs, OptionalArg, OptionalOption, PySetterValue,
+            ArgBytesLike, ArgContiguousBytesLike, ArgIterable, ArgMemoryBuffer, ArgSize, Callee,
+            Either, FsPath, FuncArgs, IntoFuncArgs, OptionalArg, OptionalOption, PySetterValue,
         },
         protocol::{
             BufferDescriptor, BufferMethods, BufferResizeGuard, PyBuffer, PyIterReturn, VecBuffer,
@@ -2838,7 +2838,8 @@ mod _io {
                 let mut data = zelf_ref.lock_opt(vm)?;
                 *data = None;
             }
-            let (buffer, text_args): (PyObjectRef, TextIOWrapperArgs) = args.bind(vm)?;
+            let (buffer, text_args): (PyObjectRef, TextIOWrapperArgs) =
+                args.bind_for(vm, Callee::of::<Self>(vm))?;
             Self::init(zelf_ref, (buffer, text_args), vm)
         }
     }

--- a/crates/vm/src/stdlib/_io.rs
+++ b/crates/vm/src/stdlib/_io.rs
@@ -122,7 +122,7 @@ mod _io {
             PyBaseExceptionRef, PyBool, PyByteArray, PyBytes, PyBytesRef, PyDict, PyMemoryView,
             PyStr, PyStrRef, PyTuple, PyTupleRef, PyType, PyTypeRef, PyUtf8Str, PyUtf8StrRef,
         },
-        class::StaticType,
+        class::{PyClassDef, StaticType},
         common::lock::{
             PyMappedThreadMutexGuard, PyRwLock, PyRwLockReadGuard, PyRwLockWriteGuard,
             PyThreadMutex, PyThreadMutexGuard,
@@ -131,8 +131,8 @@ mod _io {
         convert::ToPyObject,
         exceptions::nul_char_error,
         function::{
-            ArgBytesLike, ArgContiguousBytesLike, ArgIterable, ArgMemoryBuffer, ArgSize, Callee,
-            Either, FsPath, FuncArgs, IntoFuncArgs, OptionalArg, OptionalOption, PySetterValue,
+            ArgBytesLike, ArgContiguousBytesLike, ArgIterable, ArgMemoryBuffer, ArgSize, Either,
+            FsPath, FuncArgs, IntoFuncArgs, OptionalArg, OptionalOption, PySetterValue,
         },
         protocol::{
             BufferDescriptor, BufferMethods, BufferResizeGuard, PyBuffer, PyIterReturn, VecBuffer,
@@ -2839,7 +2839,7 @@ mod _io {
                 *data = None;
             }
             let (buffer, text_args): (PyObjectRef, TextIOWrapperArgs) =
-                args.bind_for(vm, Callee::of::<Self>(vm))?;
+                args.bind_for(vm, Self::NAME)?;
             Self::init(zelf_ref, (buffer, text_args), vm)
         }
     }

--- a/crates/vm/src/stdlib/_operator.rs
+++ b/crates/vm/src/stdlib/_operator.rs
@@ -6,7 +6,7 @@ mod _operator {
         AsObject, Py, PyObjectRef, PyPayload, PyRef, PyResult, VirtualMachine,
         builtins::{PyInt, PyIntRef, PyStr, PyStrRef, PyTupleRef, PyType, PyTypeRef, PyUtf8StrRef},
         common::wtf8::{Wtf8, Wtf8Buf},
-        function::{ArgBytesLike, Either, FuncArgs, OptionalArg},
+        function::{ArgBytesLike, Callee, Either, FuncArgs, OptionalArg},
         protocol::PyIter,
         recursion::ReprGuard,
         types::{Callable, Constructor, PyComparisonOp, Representable},
@@ -400,7 +400,7 @@ mod _operator {
                 return Err(vm.new_type_error("attrgetter() takes no keyword arguments"));
             }
             if n_attr == 0 {
-                return Err(vm.new_type_error("attrgetter expected 1 argument, got 0."));
+                return Err(Callee::of::<Self>(vm).arity_error(1..=1, 0, vm));
             }
             let mut attrs = Vec::with_capacity(n_attr);
             for o in args.args {
@@ -486,7 +486,7 @@ mod _operator {
                 return Err(vm.new_type_error("itemgetter() takes no keyword arguments"));
             }
             if args.args.is_empty() {
-                return Err(vm.new_type_error("itemgetter expected 1 argument, got 0."));
+                return Err(Callee::of::<Self>(vm).arity_error(1..=1, 0, vm));
             }
             Ok(Self { items: args.args })
         }

--- a/crates/vm/src/stdlib/_operator.rs
+++ b/crates/vm/src/stdlib/_operator.rs
@@ -5,8 +5,9 @@ mod _operator {
     use crate::{
         AsObject, Py, PyObjectRef, PyPayload, PyRef, PyResult, VirtualMachine,
         builtins::{PyInt, PyIntRef, PyStr, PyStrRef, PyTupleRef, PyType, PyTypeRef, PyUtf8StrRef},
+        class::PyClassDef,
         common::wtf8::{Wtf8, Wtf8Buf},
-        function::{ArgBytesLike, Callee, Either, FuncArgs, OptionalArg},
+        function::{ArgBytesLike, Either, FuncArgs, OptionalArg},
         protocol::PyIter,
         recursion::ReprGuard,
         types::{Callable, Constructor, PyComparisonOp, Representable},
@@ -400,7 +401,7 @@ mod _operator {
                 return Err(vm.new_type_error("attrgetter() takes no keyword arguments"));
             }
             if n_attr == 0 {
-                return Err(Callee::of::<Self>(vm).arity_error(1..=1, 0, vm));
+                return Err(vm.new_arity_type_error(Self::NAME, 1..=1, 0));
             }
             let mut attrs = Vec::with_capacity(n_attr);
             for o in args.args {
@@ -486,7 +487,7 @@ mod _operator {
                 return Err(vm.new_type_error("itemgetter() takes no keyword arguments"));
             }
             if args.args.is_empty() {
-                return Err(Callee::of::<Self>(vm).arity_error(1..=1, 0, vm));
+                return Err(vm.new_arity_type_error(Self::NAME, 1..=1, 0));
             }
             Ok(Self { items: args.args })
         }

--- a/crates/vm/src/stdlib/_thread.rs
+++ b/crates/vm/src/stdlib/_thread.rs
@@ -26,9 +26,7 @@ pub(crate) mod _thread {
         },
         common::{lock::PyMutex, wtf8::Wtf8Buf},
         frame::FrameObjectRef,
-        function::{
-            ArgCallable, Callee, FuncArgs, KwArgs, OptionalArg, PySetterValue, TimeoutSeconds,
-        },
+        function::{ArgCallable, FuncArgs, KwArgs, OptionalArg, PySetterValue, TimeoutSeconds},
         object::{Traverse, TraverseFn},
         types::{Constructor, GetAttr, Representable, SetAttr},
     };
@@ -487,7 +485,7 @@ pub(crate) mod _thread {
 
         let given = f_args.args.len();
         if !(2..=3).contains(&given) {
-            return Err(Callee::named("start_new_thread").arity_error(2..=3, given, vm));
+            return Err(vm.new_arity_type_error("start_new_thread", 2..=3, given));
         }
 
         let func_obj = f_args.take_positional().unwrap();

--- a/crates/vm/src/stdlib/_thread.rs
+++ b/crates/vm/src/stdlib/_thread.rs
@@ -26,7 +26,9 @@ pub(crate) mod _thread {
         },
         common::{lock::PyMutex, wtf8::Wtf8Buf},
         frame::FrameObjectRef,
-        function::{ArgCallable, FuncArgs, KwArgs, OptionalArg, PySetterValue, TimeoutSeconds},
+        function::{
+            ArgCallable, Callee, FuncArgs, KwArgs, OptionalArg, PySetterValue, TimeoutSeconds,
+        },
         object::{Traverse, TraverseFn},
         types::{Constructor, GetAttr, Representable, SetAttr},
     };
@@ -484,16 +486,8 @@ pub(crate) mod _thread {
         }
 
         let given = f_args.args.len();
-        if given < 2 {
-            return Err(vm.new_type_error(format!(
-                "start_new_thread expected at least 2 arguments, got {given}"
-            )));
-        }
-
-        if given > 3 {
-            return Err(vm.new_type_error(format!(
-                "start_new_thread expected at most 3 arguments, got {given}"
-            )));
+        if !(2..=3).contains(&given) {
+            return Err(Callee::named("start_new_thread").arity_error(2..=3, given, vm));
         }
 
         let func_obj = f_args.take_positional().unwrap();

--- a/crates/vm/src/stdlib/_typing.rs
+++ b/crates/vm/src/stdlib/_typing.rs
@@ -28,12 +28,13 @@ pub fn call_typing_func_object<'a>(
 
 #[pymodule(name = "_typing", with(super::typevar::typevar))]
 pub(crate) mod decl {
+    use crate::class::PyClassDef;
     use crate::common::lock::LazyLock;
     use crate::{
         AsObject, Py, PyObjectRef, PyPayload, PyRef, PyResult, VirtualMachine, atomic_func,
         builtins::{PyGenericAlias, PyStrRef, PyTuple, PyTupleRef, PyType, PyTypeRef, type_},
         common::wtf8::Wtf8Buf,
-        function::{Callee, FuncArgs},
+        function::FuncArgs,
         protocol::{PyMappingMethods, PyNumberMethods},
         types::{AsMapping, AsNumber, Callable, Constructor, Iterable, Representable},
     };
@@ -78,7 +79,7 @@ pub(crate) mod decl {
         type Args = ();
 
         fn slot_new(_cls: PyTypeRef, args: FuncArgs, vm: &VirtualMachine) -> PyResult {
-            let _: () = args.bind_for(vm, crate::function::Callee::of::<Self>(vm))?;
+            let _: () = args.bind_for(vm, Self::NAME)?;
             Ok(vm.ctx.typing_no_default.clone().into())
         }
 
@@ -365,7 +366,9 @@ pub(crate) mod decl {
             // Reject unexpected keyword arguments.
             for key in args.kwargs.keys() {
                 if !matches!(key.as_str(), Ok("name" | "value" | "type_params")) {
-                    return Err(Callee::named("typealias").unexpected_keyword(&key.to_string(), vm));
+                    return Err(
+                        vm.new_unexpected_keyword_type_error(Some("typealias"), &key.to_string())
+                    );
                 }
             }
 

--- a/crates/vm/src/stdlib/_typing.rs
+++ b/crates/vm/src/stdlib/_typing.rs
@@ -33,7 +33,7 @@ pub(crate) mod decl {
         AsObject, Py, PyObjectRef, PyPayload, PyRef, PyResult, VirtualMachine, atomic_func,
         builtins::{PyGenericAlias, PyStrRef, PyTuple, PyTupleRef, PyType, PyTypeRef, type_},
         common::wtf8::Wtf8Buf,
-        function::FuncArgs,
+        function::{Callee, FuncArgs},
         protocol::{PyMappingMethods, PyNumberMethods},
         types::{AsMapping, AsNumber, Callable, Constructor, Iterable, Representable},
     };
@@ -365,9 +365,7 @@ pub(crate) mod decl {
             // Reject unexpected keyword arguments.
             for key in args.kwargs.keys() {
                 if !matches!(key.as_str(), Ok("name" | "value" | "type_params")) {
-                    return Err(vm.new_type_error(format!(
-                        "typealias() got an unexpected keyword argument '{key}'"
-                    )));
+                    return Err(Callee::named("typealias").unexpected_keyword(&key.to_string(), vm));
                 }
             }
 

--- a/crates/vm/src/stdlib/builtins.rs
+++ b/crates/vm/src/stdlib/builtins.rs
@@ -22,8 +22,8 @@ mod builtins {
         common::hash::PyHash,
         function::{
             ArgCallable, ArgIndex, ArgIntoBool, ArgIterable, ArgMapping, ArgPrimitiveIndex,
-            ArgStrOrBytesLike, Callee, Either, FsPath, FuncArgs, KwArgs, OptionalArg,
-            OptionalOption, PosArgs,
+            ArgStrOrBytesLike, Either, FsPath, FuncArgs, KwArgs, OptionalArg, OptionalOption,
+            PosArgs,
         },
         protocol::{PyIter, PyIterReturn},
         py_io,
@@ -899,16 +899,15 @@ mod builtins {
         func_name: &'static str,
         op: PyComparisonOp,
     ) -> PyResult {
-        let callee = Callee::named(func_name);
         // A call with nothing to compare is refused before the keywords are read.
         if args.args.is_empty() {
-            return Err(callee.arity_error(1..=usize::MAX, 0, vm));
+            return Err(vm.new_arity_type_error(func_name, 1..=usize::MAX, 0));
         }
 
         let default = args.take_keyword("default");
         let key_func = args.take_keyword("key");
 
-        if let Some(err) = args.check_kwargs_empty_for(vm, callee) {
+        if let Some(err) = args.check_kwargs_empty_for(vm, func_name) {
             return Err(err);
         }
 

--- a/crates/vm/src/stdlib/builtins.rs
+++ b/crates/vm/src/stdlib/builtins.rs
@@ -22,8 +22,8 @@ mod builtins {
         common::hash::PyHash,
         function::{
             ArgCallable, ArgIndex, ArgIntoBool, ArgIterable, ArgMapping, ArgPrimitiveIndex,
-            ArgStrOrBytesLike, Either, FsPath, FuncArgs, KwArgs, OptionalArg, OptionalOption,
-            PosArgs,
+            ArgStrOrBytesLike, Callee, Either, FsPath, FuncArgs, KwArgs, OptionalArg,
+            OptionalOption, PosArgs,
         },
         protocol::{PyIter, PyIterReturn},
         py_io,
@@ -896,32 +896,31 @@ mod builtins {
     fn min_or_max(
         mut args: FuncArgs,
         vm: &VirtualMachine,
-        func_name: &str,
+        func_name: &'static str,
         op: PyComparisonOp,
     ) -> PyResult {
+        let callee = Callee::named(func_name);
+        // A call with nothing to compare is refused before the keywords are read.
+        if args.args.is_empty() {
+            return Err(callee.arity_error(1..=usize::MAX, 0, vm));
+        }
+
         let default = args.take_keyword("default");
         let key_func = args.take_keyword("key");
 
-        if let Some(err) = args.check_kwargs_empty(vm) {
+        if let Some(err) = args.check_kwargs_empty_for(vm, callee) {
             return Err(err);
         }
 
-        let candidates = match args.args.len().cmp(&1) {
-            core::cmp::Ordering::Greater => {
-                if default.is_some() {
-                    return Err(vm.new_type_error(format!(
-                        "Cannot specify a default for {func_name}() with multiple positional arguments"
-                    )));
-                }
-                args.args
+        let candidates = if args.args.len() > 1 {
+            if default.is_some() {
+                return Err(vm.new_type_error(format!(
+                    "Cannot specify a default for {func_name}() with multiple positional arguments"
+                )));
             }
-            core::cmp::Ordering::Equal => args.args[0].try_to_value(vm)?,
-            core::cmp::Ordering::Less => {
-                // zero arguments means type error:
-                return Err(
-                    vm.new_type_error(format!("{func_name} expected at least 1 argument, got 0"))
-                );
-            }
+            args.args
+        } else {
+            args.args[0].try_to_value(vm)?
         };
 
         let mut candidates_iter = candidates.into_iter();

--- a/crates/vm/src/stdlib/itertools.rs
+++ b/crates/vm/src/stdlib/itertools.rs
@@ -7,9 +7,10 @@ mod decl {
         builtins::{
             PyGenericAlias, PyInt, PyIntRef, PyList, PyTuple, PyTupleRef, PyType, PyTypeRef, int,
         },
+        class::PyClassDef,
         common::lock::{PyMutex, PyRwLock, PyRwLockWriteGuard},
         convert::ToPyObject,
-        function::{Callee, FuncArgs, OptionalArg, OptionalOption, PosArgs},
+        function::{FuncArgs, OptionalArg, OptionalOption, PosArgs},
         protocol::{PyIter, PyIterReturn, PyNumber},
         raise_if_stop,
         stdlib::sys,
@@ -755,17 +756,16 @@ mod decl {
         fn slot_new(cls: PyTypeRef, args: FuncArgs, vm: &VirtualMachine) -> PyResult {
             let (iter, start, stop, step) = match args.args.len() {
                 0 | 1 => {
-                    return Err(Callee::of::<Self>(vm).arity_error(2..=4, args.args.len(), vm));
+                    return Err(vm.new_arity_type_error(Self::NAME, 2..=4, args.args.len()));
                 }
                 2 => {
-                    let (iter, stop): (PyObjectRef, PyObjectRef) =
-                        args.bind_for(vm, Callee::of::<Self>(vm))?;
+                    let (iter, stop): (PyObjectRef, PyObjectRef) = args.bind_for(vm, Self::NAME)?;
                     (iter, 0usize, stop, 1usize)
                 }
                 _ => {
                     let (iter, start, stop, step) = if args.args.len() == 3 {
                         let (iter, start, stop): (PyObjectRef, PyObjectRef, PyObjectRef) =
-                            args.bind_for(vm, Callee::of::<Self>(vm))?;
+                            args.bind_for(vm, Self::NAME)?;
                         (iter, start, stop, 1usize)
                     } else {
                         let (iter, start, stop, step): (
@@ -773,7 +773,7 @@ mod decl {
                             PyObjectRef,
                             PyObjectRef,
                             PyObjectRef,
-                        ) = args.bind_for(vm, Callee::of::<Self>(vm))?;
+                        ) = args.bind_for(vm, Self::NAME)?;
 
                         let step = if !vm.is_none(&step) {
                             pyobject_to_opt_usize(step, "Step", vm)?

--- a/crates/vm/src/stdlib/itertools.rs
+++ b/crates/vm/src/stdlib/itertools.rs
@@ -755,10 +755,7 @@ mod decl {
         fn slot_new(cls: PyTypeRef, args: FuncArgs, vm: &VirtualMachine) -> PyResult {
             let (iter, start, stop, step) = match args.args.len() {
                 0 | 1 => {
-                    return Err(vm.new_type_error(format!(
-                        "islice expected at least 2 arguments, got {}",
-                        args.args.len()
-                    )));
+                    return Err(Callee::of::<Self>(vm).arity_error(2..=4, args.args.len(), vm));
                 }
                 2 => {
                     let (iter, stop): (PyObjectRef, PyObjectRef) =

--- a/crates/vm/src/stdlib/os.rs
+++ b/crates/vm/src/stdlib/os.rs
@@ -198,6 +198,7 @@ pub(super) mod _os {
         builtins::{
             PyBytesRef, PyGenericAlias, PyIntRef, PyStrRef, PyTuple, PyTupleRef, PyTypeRef,
         },
+        class::PyClassDef,
         common::lock::{OnceCell, PyRwLock},
         convert::{IntoPyException, ToPyObject},
         exceptions::{OSErrorBuilder, ToOSErrorBuilder},
@@ -1345,7 +1346,7 @@ pub(super) mod _os {
         fn slot_new(cls: PyTypeRef, args: FuncArgs, vm: &VirtualMachine) -> PyResult {
             let result = crate::types::struct_sequence_new(
                 cls.clone(),
-                args.bind_for(vm, crate::function::Callee::of::<Self>(vm))?,
+                args.bind_for(vm, Self::NAME)?,
                 StatResultData::OPTIONAL_FIELD_NAMES,
                 vm,
             )?;
@@ -2002,7 +2003,7 @@ pub(super) mod _os {
         fn slot_new(cls: PyTypeRef, args: FuncArgs, vm: &VirtualMachine) -> PyResult {
             crate::types::struct_sequence_new(
                 cls,
-                args.bind_for(vm, crate::function::Callee::of::<Self>(vm))?,
+                args.bind_for(vm, Self::NAME)?,
                 StatvfsResultData::OPTIONAL_FIELD_NAMES,
                 vm,
             )

--- a/crates/vm/src/stdlib/posix.rs
+++ b/crates/vm/src/stdlib/posix.rs
@@ -2427,6 +2427,7 @@ mod posix_sched {
     use crate::{
         AsObject, Py, PyObjectRef, PyResult, VirtualMachine,
         builtins::PyTupleRef,
+        class::PyClassDef,
         convert::{IntoPyException, ToPyObject},
         function::FuncArgs,
         types::PyStructSequence,
@@ -2456,8 +2457,7 @@ mod posix_sched {
             vm: &VirtualMachine,
         ) -> PyResult {
             use crate::PyPayload;
-            let SchedParamArgs { sched_priority } =
-                args.bind_for(vm, crate::function::Callee::of::<Self>(vm))?;
+            let SchedParamArgs { sched_priority } = args.bind_for(vm, Self::NAME)?;
             let items = vec![sched_priority];
             crate::builtins::PyTuple::new_unchecked(items.into_boxed_slice())
                 .into_ref_with_type(vm, cls)

--- a/crates/vm/src/stdlib/time.rs
+++ b/crates/vm/src/stdlib/time.rs
@@ -17,7 +17,8 @@ mod decl {
     use crate::{
         AsObject, Py, PyObjectRef, PyResult, VirtualMachine,
         builtins::{PyStrRef, PyTypeRef},
-        function::{Callee, Either, FuncArgs, OptionalArg},
+        class::PyClassDef,
+        function::{Either, FuncArgs, OptionalArg},
         types::{PyStructSequence, PyStructSequenceData, struct_sequence_new},
     };
     #[cfg(any(unix, windows))]
@@ -813,7 +814,7 @@ mod decl {
         fn slot_new(cls: PyTypeRef, args: FuncArgs, vm: &VirtualMachine) -> PyResult {
             struct_sequence_new(
                 cls,
-                args.bind_for(vm, Callee::of::<Self>(vm))?,
+                args.bind_for(vm, Self::NAME)?,
                 StructTimeData::OPTIONAL_FIELD_NAMES,
                 vm,
             )

--- a/crates/vm/src/stdlib/typevar.rs
+++ b/crates/vm/src/stdlib/typevar.rs
@@ -8,7 +8,7 @@ pub(crate) mod typevar {
         AsObject, Context, Py, PyObject, PyObjectRef, PyPayload, PyRef, PyResult, VirtualMachine,
         builtins::{PyTuple, PyTupleRef, PyType, PyTypeRef, make_union},
         common::lock::PyMutex,
-        function::{Callee, FuncArgs, PyComparisonValue},
+        function::{FuncArgs, PyComparisonValue},
         protocol::PyNumberMethods,
         stdlib::_typing::{call_typing_func_object, decl::const_evaluator_alloc},
         types::{AsNumber, Comparable, Constructor, Iterable, PyComparisonOp, Representable},
@@ -365,7 +365,7 @@ pub(crate) mod typevar {
             // Check for unexpected keyword arguments
             if let Some(invalid_key) = kwargs.keys().next() {
                 return Err(
-                    Callee::named("typevar").unexpected_keyword(&invalid_key.to_string(), vm)
+                    vm.new_unexpected_keyword_type_error(Some("typevar"), &invalid_key.to_string())
                 );
             }
 
@@ -645,9 +645,10 @@ pub(crate) mod typevar {
 
             // Check for unexpected keyword arguments
             if let Some(invalid_key) = kwargs.keys().next() {
-                return Err(
-                    Callee::named("paramspec").unexpected_keyword(&invalid_key.to_string(), vm)
-                );
+                return Err(vm.new_unexpected_keyword_type_error(
+                    Some("paramspec"),
+                    &invalid_key.to_string(),
+                ));
             }
 
             // Check for invalid combinations
@@ -837,9 +838,10 @@ pub(crate) mod typevar {
 
             // Check for unexpected keyword arguments
             if let Some(invalid_key) = kwargs.keys().next() {
-                return Err(
-                    Callee::named("typevartuple").unexpected_keyword(&invalid_key.to_string(), vm)
-                );
+                return Err(vm.new_unexpected_keyword_type_error(
+                    Some("typevartuple"),
+                    &invalid_key.to_string(),
+                ));
             }
 
             // Handle default value

--- a/crates/vm/src/stdlib/typevar.rs
+++ b/crates/vm/src/stdlib/typevar.rs
@@ -8,7 +8,7 @@ pub(crate) mod typevar {
         AsObject, Context, Py, PyObject, PyObjectRef, PyPayload, PyRef, PyResult, VirtualMachine,
         builtins::{PyTuple, PyTupleRef, PyType, PyTypeRef, make_union},
         common::lock::PyMutex,
-        function::{FuncArgs, PyComparisonValue},
+        function::{Callee, FuncArgs, PyComparisonValue},
         protocol::PyNumberMethods,
         stdlib::_typing::{call_typing_func_object, decl::const_evaluator_alloc},
         types::{AsNumber, Comparable, Constructor, Iterable, PyComparisonOp, Representable},
@@ -363,12 +363,10 @@ pub(crate) mod typevar {
             let default = kwargs.swap_remove("default");
 
             // Check for unexpected keyword arguments
-            if !kwargs.is_empty() {
-                let unexpected_keys = kwargs.keys().map(|s| s.to_string()).collect::<Vec<_>>();
-                return Err(vm.new_type_error(format!(
-                    "TypeVar() got unexpected keyword argument(s): {}",
-                    unexpected_keys.join(", ")
-                )));
+            if let Some(invalid_key) = kwargs.keys().next() {
+                return Err(
+                    Callee::named("typevar").unexpected_keyword(&invalid_key.to_string(), vm)
+                );
             }
 
             // Check for invalid combinations
@@ -646,12 +644,10 @@ pub(crate) mod typevar {
             let default = kwargs.swap_remove("default");
 
             // Check for unexpected keyword arguments
-            if !kwargs.is_empty() {
-                let unexpected_keys = kwargs.keys().map(|s| s.to_string()).collect::<Vec<_>>();
-                return Err(vm.new_type_error(format!(
-                    "ParamSpec() got unexpected keyword argument(s): {}",
-                    unexpected_keys.join(", ")
-                )));
+            if let Some(invalid_key) = kwargs.keys().next() {
+                return Err(
+                    Callee::named("paramspec").unexpected_keyword(&invalid_key.to_string(), vm)
+                );
             }
 
             // Check for invalid combinations
@@ -840,12 +836,10 @@ pub(crate) mod typevar {
             let default = kwargs.swap_remove("default");
 
             // Check for unexpected keyword arguments
-            if !kwargs.is_empty() {
-                let unexpected_keys = kwargs.keys().map(|s| s.to_string()).collect::<Vec<_>>();
-                return Err(vm.new_type_error(format!(
-                    "TypeVarTuple() got unexpected keyword argument(s): {}",
-                    unexpected_keys.join(", ")
-                )));
+            if let Some(invalid_key) = kwargs.keys().next() {
+                return Err(
+                    Callee::named("typevartuple").unexpected_keyword(&invalid_key.to_string(), vm)
+                );
             }
 
             // Handle default value

--- a/crates/vm/src/types/slot.rs
+++ b/crates/vm/src/types/slot.rs
@@ -1843,7 +1843,7 @@ pub trait Callable: PyPayload {
             msg.push_wtf8(&help);
             vm.new_type_error(msg)
         })?;
-        let args = args.bind(vm)?;
+        let args = args.bind_for(vm, Callee::of::<Self>(vm))?;
         Self::call(zelf, args, vm)
     }
 

--- a/crates/vm/src/types/structseq.rs
+++ b/crates/vm/src/types/structseq.rs
@@ -6,9 +6,7 @@ use crate::{
         PyBaseExceptionRef, PyDict, PyStr, PyStrRef, PyTuple, PyTupleRef, PyType, PyTypeRef,
     },
     class::{PyClassImpl, StaticType},
-    function::{
-        Callee, Either, FuncArgs, OptionalArg, PyComparisonValue, PyMethodDef, PyMethodFlags,
-    },
+    function::{Either, FuncArgs, OptionalArg, PyComparisonValue, PyMethodDef, PyMethodFlags},
     iter::PyExactSizeIterator,
     protocol::{PyMappingMethods, PySequenceMethods},
     sliceable::{SequenceIndex, SliceableSequenceOp},
@@ -254,7 +252,7 @@ pub trait PyStructSequence: StaticType + PyClassImpl + Sized + 'static {
     fn slot_new(cls: PyTypeRef, args: FuncArgs, vm: &VirtualMachine) -> PyResult {
         struct_sequence_new(
             cls,
-            args.bind_for(vm, Callee::for_type(Self::static_type()))?,
+            args.bind_for(vm, Self::NAME)?,
             Self::Data::OPTIONAL_FIELD_NAMES,
             vm,
         )

--- a/crates/vm/src/vm/vm_new.rs
+++ b/crates/vm/src/vm/vm_new.rs
@@ -6,6 +6,8 @@ use ruff_python_parser::{InterpolatedStringErrorType, LexicalErrorType, ParseErr
 use rustpython_common::wtf8::Wtf8Buf;
 use rustpython_compiler_core::SourceLocation;
 
+use core::ops::RangeInclusive;
+
 #[cfg(feature = "parser")]
 use rustpython_compiler::{CompileError, ParseError};
 
@@ -20,7 +22,9 @@ use crate::{
     },
     convert::{ToPyException, ToPyObject},
     exceptions::OSErrorBuilder,
-    function::{FuncArgs, IntoPyNativeFn, PyMethodFlags},
+    function::{
+        FuncArgs, IntoPyNativeFn, PyMethodFlags, arity_message, unexpected_keyword_message,
+    },
     scope::Scope,
     set_attrs,
     types::{Constructor, Initializer},
@@ -493,6 +497,30 @@ impl VirtualMachine {
         );
 
         name_error
+    }
+
+    /// The error a call that passed the wrong number of arguments gets. The
+    /// name is the function the call was for; `Self::NAME` is the one a slot
+    /// wants. `_PyArg_CheckPositional`
+    pub fn new_arity_type_error(
+        &self,
+        func_name: &str,
+        arity: RangeInclusive<usize>,
+        num_given: usize,
+    ) -> PyBaseExceptionRef {
+        let too_few = num_given < *arity.start();
+        self.new_type_error(arity_message(Some(func_name), &arity, too_few, num_given))
+    }
+
+    /// The error a call that passed a keyword the function doesn't take gets.
+    /// The name is left off where the parser has none of its own, the way
+    /// `_PyArg_Parser.fname` is NULL. `_PyArg_UnpackKeywords`
+    pub fn new_unexpected_keyword_type_error(
+        &self,
+        func_name: Option<&str>,
+        keyword: &str,
+    ) -> PyBaseExceptionRef {
+        self.new_type_error(unexpected_keyword_message(func_name, keyword))
     }
 
     pub fn new_unsupported_unary_error(&self, a: &PyObject, op: &str) -> PyBaseExceptionRef {

--- a/extra_tests/snippets/vm_argument_errors.py
+++ b/extra_tests/snippets/vm_argument_errors.py
@@ -4,6 +4,11 @@
 # against both.
 import array
 import collections
+import csv
+import itertools
+import operator
+import typing
+import weakref
 
 from testutils import assert_raises
 
@@ -89,9 +94,67 @@ def test_a_type_is_named_by_the_type_it_builds():
         array.array()
 
 
+def test_a_slot_that_counts_its_own_arguments_says_the_same_thing():
+    # Sites that check the count themselves raise what binding would have.
+    class Obj:
+        pass
+
+    check(TypeError, "__new__ expected at least 1 argument, got 0", weakref.ref)
+    check(
+        TypeError,
+        "__new__ expected at most 2 arguments, got 3",
+        weakref.ref,
+        Obj(),
+        1,
+        2,
+    )
+    check(TypeError, "GenericAlias expected 2 arguments, got 0", type(list[int]))
+    check(TypeError, "frozenset expected at most 1 argument, got 2", frozenset, 1, 2)
+    check(TypeError, "attrgetter expected 1 argument, got 0", operator.attrgetter)
+    check(TypeError, "itemgetter expected 1 argument, got 0", operator.itemgetter)
+    check(
+        TypeError, "islice expected at least 2 arguments, got 1", itertools.islice, []
+    )
+    # The count is read before the keywords are.
+    check(TypeError, "min expected at least 1 argument, got 0", min, bogus=1)
+    check(TypeError, "max expected at least 1 argument, got 0", max, bogus=1)
+
+
+def test_a_keyword_check_of_its_own_says_the_same_thing():
+    check(
+        TypeError,
+        "AttributeError() got an unexpected keyword argument 'bogus'",
+        AttributeError,
+        bogus=1,
+    )
+    check(
+        TypeError,
+        "NameError() got an unexpected keyword argument 'bogus'",
+        NameError,
+        bogus=1,
+    )
+    check(
+        TypeError,
+        "typevar() got an unexpected keyword argument 'bogus'",
+        typing.TypeVar,
+        "T",
+        bogus=1,
+    )
+    # The dialect is parsed by a parser of its own, which has no name to give.
+    check(
+        TypeError,
+        "this function got an unexpected keyword argument 'bogus'",
+        csv.reader,
+        [],
+        bogus=1,
+    )
+
+
 test_the_message_names_the_function()
 test_a_method_does_not_count_its_instance()
 test_one_argument_is_singular()
 test_a_keyword_it_did_not_expect_is_quoted()
 test_a_parameter_a_call_may_name_is_named_back()
 test_a_type_is_named_by_the_type_it_builds()
+test_a_slot_that_counts_its_own_arguments_says_the_same_thing()
+test_a_keyword_check_of_its_own_says_the_same_thing()


### PR DESCRIPTION
Follow-up to #8630, which taught the argument binder to name the function it was binding for. Two commits.

### Raise the shared errors from the slots that count for themselves

Sites all over the tree checked their own argument counts and keywords and wrote the message by hand, so they had drifted apart:

| | before | after / CPython 3.14.6 |
|---|---|---|
| `operator.attrgetter()` | `attrgetter expected 1 argument, got 0.` | `attrgetter expected 1 argument, got 0` |
| `typing.TypeVar('T', bogus=1)` | `TypeVar() got unexpected keyword argument(s): bogus` | `typevar() got an unexpected keyword argument 'bogus'` |
| `csv.reader([], bogus=1)` | `reader() got an unexpected keyword argument ''bogus' is an invalid keyword argument for this function'` | `this function got an unexpected keyword argument 'bogus'` |
| `GenericAlias()` | `expected 2 arguments, got 0` | `GenericAlias expected 2 arguments, got 0` |

`weakref.ref`, `frozenset`, `itemgetter`, `islice`, `start_new_thread`, `TextIOWrapper`, `AttributeError`, `NameError`, `ParamSpec`, `TypeVarTuple` and `TypeAliasType` all follow. `FrameLocalsProxy` and `min`/`max` also now count arguments before reading keywords, which is the order `framelocalsproxy_new` and `min_max` check in.

### Give those errors the constructors the rest of them have

Raising one meant writing `Callee::of::<Self>(vm).arity_error(1..=3, 0, vm)` — the vm twice, and a type to know about before you could say what you meant. Every other error in the tree is a `vm.new_*_error`, so these are too:

```rust
return Err(vm.new_arity_type_error(Self::NAME, 1..=3, 0));
return Err(vm.new_unexpected_keyword_type_error(Some("typevar"), &key));
```

The keyword one takes an `Option` because a parser sometimes has no name of its own — `_PyArg_Parser.fname` being NULL, which is what `_csv`'s dialect parser wants. `bind_for` and `check_kwargs_empty_for` take anything a `Callee` converts from, so the slots pass `Self::NAME` there too, and `Callee` stays with the binding machinery that actually needs to carry a name around.

### Measured

Against `python3.14` 3.14.6, side by side:

- 22 of the 26 calls these commits touch produce the identical string (21 after the first commit; the second changed no message).
- The broader 43-call set stands at 23 exact matches.
- Three `@unittest.expectedFailure` decorators removed (`test_bytes`, `string_tests`, `test_range`).
- `extra_tests/snippets/vm_argument_errors.py` passes under both interpreters.
- 133 suites / 25,316 tests SUCCESS; clippy (CI flags) clean; `cargo fmt --check` clean.

Four divergences are left and need more than a name: `weakref.proxy` is a function of its own there rather than a type, `frozenset` names the subclass being constructed, and `TextIOWrapper` names its first parameter (`missing required argument 'buffer' (pos 1)`) and counts before converting.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Standardized `TypeError` messages for incorrect argument counts across built-in constructors and standard-library functions.
  * Improved reporting of unexpected keyword arguments, including the relevant callable or class name.
  * Made validation order more consistent, producing clearer errors for invalid calls.

* **Tests**
  * Added coverage confirming consistent argument-count and unexpected-keyword error messages across callable and constructor implementations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->