### PR TITLE
Dedupe Unix & WASI stdlib

### DIFF
--- a/crates/vm/src/stdlib/mod.rs
+++ b/crates/vm/src/stdlib/mod.rs
@@ -37,6 +37,8 @@ pub mod posix;
 #[cfg(all(feature = "host_env", not(any(unix, windows))))]
 #[path = "posix_compat.rs"]
 pub mod posix;
+#[cfg(all(feature = "host_env", any(unix, target_os = "wasi")))]
+pub mod posix_unix_like;
 
 #[cfg(all(
     feature = "host_env",

--- a/crates/vm/src/stdlib/nt.rs
+++ b/crates/vm/src/stdlib/nt.rs
@@ -13,7 +13,7 @@ pub(crate) mod module {
         function::{ArgMapping, Either, OptionalArg},
         host_env::crt_fd,
         ospath::{OsPath, OsPathOrFd},
-        stdlib::os::{_os, DirFd, SupportFunc, TargetIsDirectory},
+        stdlib::os::{_os, DirFd, SupportFunc, SymlinkArgs},
     };
     use core::hint::cold_path;
     use libc::intptr_t;
@@ -99,16 +99,6 @@ pub(crate) mod module {
     #[pyfunction]
     pub(super) fn _supports_virtual_terminal() -> bool {
         host_nt::supports_virtual_terminal()
-    }
-
-    #[derive(FromArgs)]
-    pub(super) struct SymlinkArgs<'fd> {
-        src: OsPath,
-        dst: OsPath,
-        #[pyarg(flatten)]
-        target_is_directory: TargetIsDirectory,
-        #[pyarg(flatten)]
-        _dir_fd: DirFd<'fd, { _os::SYMLINK_DIR_FD as usize }>,
     }
 
     #[pyfunction]

--- a/crates/vm/src/stdlib/os.rs
+++ b/crates/vm/src/stdlib/os.rs
@@ -7,6 +7,7 @@ use crate::{
     convert::{IntoPyException, ToPyException, ToPyObject},
     function::{ArgumentError, FromArgs, FuncArgs},
     host_env::{crt_fd, posix::RawMode},
+    ospath::OsPath,
 };
 use core::marker::PhantomData;
 use std::{io, path::Path};
@@ -121,6 +122,18 @@ impl<const AVAILABLE: usize, KW: DirFdKeyword> FromArgs for DirFd<'_, AVAILABLE,
         let fd = fd.map_err(|e| e.to_pyexception(vm))?;
         Ok(Self([fd; AVAILABLE], PhantomData))
     }
+}
+
+#[derive(FromArgs)]
+pub(crate) struct SymlinkArgs<'fd> {
+    pub src: OsPath,
+    pub dst: OsPath,
+    #[cfg_attr(any(unix, target_os = "wasi"), expect(unused))]
+    #[pyarg(flatten)]
+    pub target_is_directory: TargetIsDirectory,
+    #[cfg_attr(not(unix), expect(unused))]
+    #[pyarg(flatten)]
+    pub dir_fd: DirFd<'fd, { _os::SYMLINK_DIR_FD as usize }>,
 }
 
 #[derive(FromArgs)]

--- a/crates/vm/src/stdlib/posix.rs
+++ b/crates/vm/src/stdlib/posix.rs
@@ -6,6 +6,7 @@ pub use rustpython_host_env::posix::set_inheritable;
 
 #[pymodule(name = "posix", with(
     super::os::_os,
+    super::posix_unix_like::_posix_unix_like,
     #[cfg(any(
         target_os = "linux",
         target_os = "netbsd",
@@ -23,8 +24,7 @@ pub mod module {
         function::{ArgMapping, Either, KwArgs, OptionalArg},
         ospath::{OsPath, OsPathOrFd},
         stdlib::os::{
-            _os, DirFd, FollowSymlinks, SupportFunc, TargetIsDirectory, fs_metadata,
-            warn_if_bool_fd,
+            _os, DirFd, FollowSymlinks, SupportFunc, SymlinkArgs, fs_metadata, warn_if_bool_fd,
         },
     };
     #[cfg(any(
@@ -384,18 +384,6 @@ pub mod module {
             .map_err(|err| err.to_pyexception(vm))
     }
 
-    #[pyattr]
-    fn environ(vm: &VirtualMachine) -> PyDictRef {
-        let environ = vm.ctx.new_dict();
-        for (key, value) in crate::host_env::os::vars_os() {
-            let key: PyObjectRef = vm.ctx.new_bytes(key.into_vec()).into();
-            let value: PyObjectRef = vm.ctx.new_bytes(value.into_vec()).into();
-            environ.set_item(&*key, value, vm).unwrap();
-        }
-
-        environ
-    }
-
     #[pyfunction]
     fn _create_environ(vm: &VirtualMachine) -> PyDictRef {
         let environ = vm.ctx.new_dict();
@@ -405,16 +393,6 @@ pub mod module {
             environ.set_item(&*key, value, vm).unwrap();
         }
         environ
-    }
-
-    #[derive(FromArgs)]
-    pub(super) struct SymlinkArgs<'fd> {
-        src: OsPath,
-        dst: OsPath,
-        #[pyarg(flatten)]
-        _target_is_directory: TargetIsDirectory,
-        #[pyarg(flatten)]
-        dir_fd: DirFd<'fd, { _os::SYMLINK_DIR_FD as usize }>,
     }
 
     #[pyfunction]
@@ -431,17 +409,6 @@ pub mod module {
             let [] = args.dir_fd.0;
             rustpython_host_env::posix::symlink(&src, &dst).map_err(|err| err.into_pyexception(vm))
         }
-    }
-
-    #[pyfunction]
-    #[pyfunction(name = "unlink")]
-    fn remove(
-        path: OsPath,
-        dir_fd: DirFd<'_, { _os::UNLINK_DIR_FD as usize }>,
-        vm: &VirtualMachine,
-    ) -> PyResult<()> {
-        rustpython_host_env::posix::unlinkat(dir_fd.get_opt(), &path)
-            .map_err(|err| OSErrorBuilder::with_filename(&err, path, vm))
     }
 
     #[cfg(not(target_os = "redox"))]

--- a/crates/vm/src/stdlib/posix_compat.rs
+++ b/crates/vm/src/stdlib/posix_compat.rs
@@ -4,36 +4,22 @@
 
 pub(crate) use module::module_def;
 
-#[pymodule(name = "posix", with(super::os::_os))]
+#[pymodule(name = "posix", with(
+    super::os::_os,
+    #[cfg(any(unix, target_os = "wasi"))]
+    super::posix_unix_like::_posix_unix_like,
+))]
 pub(crate) mod module {
     use crate::{
         Py, PyObjectRef, PyResult, VirtualMachine,
         builtins::PyStrRef,
         ospath::OsPath,
-        stdlib::os::{_os, DirFd, SupportFunc, TargetIsDirectory},
+        stdlib::os::{_os, DirFd, SupportFunc, SymlinkArgs, TargetIsDirectory},
     };
-
-    #[cfg(not(target_os = "wasi"))]
-    use {crate::convert::IntoPyException, std::fs};
-
-    #[cfg(target_os = "wasi")]
-    use crate::exceptions::OSErrorBuilder;
 
     #[pyfunction]
     pub(super) fn access(_path: PyStrRef, _mode: u8, vm: &VirtualMachine) -> PyResult<bool> {
         os_unimpl("os.access", vm)
-    }
-
-    #[cfg(target_os = "wasi")]
-    #[pyfunction]
-    #[pyfunction(name = "unlink")]
-    fn remove(
-        path: OsPath,
-        dir_fd: DirFd<'_, { _os::UNLINK_DIR_FD as usize }>,
-        vm: &VirtualMachine,
-    ) -> PyResult<()> {
-        rustpython_host_env::posix::unlinkat(dir_fd.get_opt(), &path)
-            .map_err(|err| OSErrorBuilder::with_filename(&err, path, vm))
     }
 
     #[cfg(not(target_os = "wasi"))]
@@ -44,35 +30,9 @@ pub(crate) mod module {
         fs::remove_file(&path).map_err(|err| err.into_pyexception(vm))
     }
 
-    #[derive(FromArgs)]
-    #[allow(unused)]
-    pub(super) struct SymlinkArgs<'a> {
-        src: OsPath,
-        dst: OsPath,
-        #[pyarg(flatten)]
-        _target_is_directory: TargetIsDirectory,
-        #[pyarg(flatten)]
-        _dir_fd: DirFd<'a, { _os::SYMLINK_DIR_FD as usize }>,
-    }
-
     #[pyfunction]
     pub(super) fn symlink(_args: SymlinkArgs<'_>, vm: &VirtualMachine) -> PyResult<()> {
         os_unimpl("os.symlink", vm)
-    }
-
-    #[cfg(target_os = "wasi")]
-    #[pyattr]
-    fn environ(vm: &VirtualMachine) -> crate::builtins::PyDictRef {
-        use rustpython_host_env::os::ffi::OsStringExt;
-
-        let environ = vm.ctx.new_dict();
-        for (key, value) in crate::host_env::os::vars_os() {
-            let key: PyObjectRef = vm.ctx.new_bytes(key.into_vec()).into();
-            let value: PyObjectRef = vm.ctx.new_bytes(value.into_vec()).into();
-            environ.set_item(&*key, value, vm).unwrap();
-        }
-
-        environ
     }
 
     #[allow(dead_code)]

--- a/crates/vm/src/stdlib/posix_unix_like.rs
+++ b/crates/vm/src/stdlib/posix_unix_like.rs
@@ -1,0 +1,35 @@
+#[pymodule(sub)]
+pub(crate) mod _posix_unix_like {
+    use rustpython_host_env::os::ffi::OsStringExt;
+
+    use crate::{
+        PyObjectRef, PyResult, VirtualMachine,
+        builtins::PyDictRef,
+        exceptions::OSErrorBuilder,
+        ospath::OsPath,
+        stdlib::os::{_os, DirFd},
+    };
+
+    #[pyattr]
+    fn environ(vm: &VirtualMachine) -> PyDictRef {
+        let environ = vm.ctx.new_dict();
+        for (key, value) in crate::host_env::os::vars_os() {
+            let key: PyObjectRef = vm.ctx.new_bytes(key.into_vec()).into();
+            let value: PyObjectRef = vm.ctx.new_bytes(value.into_vec()).into();
+            environ.set_item(&*key, value, vm).unwrap();
+        }
+
+        environ
+    }
+
+    #[pyfunction]
+    #[pyfunction(name = "unlink")]
+    fn remove(
+        path: OsPath,
+        dir_fd: DirFd<'_, { _os::UNLINK_DIR_FD as usize }>,
+        vm: &VirtualMachine,
+    ) -> PyResult<()> {
+        rustpython_host_env::posix::unlinkat(dir_fd.get_opt(), &path)
+            .map_err(|err| OSErrorBuilder::with_filename(&err, path, vm))
+    }
+}


### PR DESCRIPTION
Follow up to #8591 because I figured out how to deduplicate the code. This is nicer for future patches that improve WASI support because Unix-likes and WASI can often share the same dispatch functions.

<!--
Thanks for your contribution!
-->

- [ ] Closes #xxxx <!-- Replace xxxx with the GitHub issue number if exists -->

One of checkbox below must be checked.
- [x] I did not use AI to write the code of this patch.
- [ ] This PR follows our [AI policy](https://github.com/RustPython/.github/blob/main/AI_POLICY.md)

## Summary
<!-- What's the purpose of the change? What does it do, and why? -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved POSIX compatibility across Unix-like and WASI environments.
  * Added consistent support for reading environment variables and removing files through both `remove` and `unlink`.
  * Standardized symlink operations, including directory and file-descriptor options.

* **Bug Fixes**
  * Reduced platform-specific differences in POSIX behavior.
  * Improved consistency for file removal and symlink operations across supported environments.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->