### PR TITLE
perf: reduce compile-time allocations and quadratic constant lookup

### DIFF
--- a/crates/codegen/src/compile.rs
+++ b/crates/codegen/src/compile.rs
@@ -178,6 +178,10 @@ struct Compiler<'a> {
     source_file: SourceFile,
     // current_source_location: SourceLocation,
     current_source_range: TextRange,
+    /// Memoized `(range, location, end_location)` conversion of
+    /// `current_source_range`, since it changes far less often than
+    /// instructions get emitted. See `current_locations`.
+    current_source_locations: Option<(TextRange, SourceLocation, SourceLocation)>,
     future_features: bytecode::CodeFlags,
     future_annotations: bool,
     ctx: CompileContext,
@@ -1109,6 +1113,7 @@ impl<'warnings> Compiler<'warnings> {
             source_file,
             // current_source_location: SourceLocation::default(),
             current_source_range: TextRange::default(),
+            current_source_locations: None,
             future_features: opts.future_features,
             future_annotations: false,
             ctx: CompileContext {
@@ -3145,6 +3150,17 @@ impl<'warnings> Compiler<'warnings> {
         })
     }
 
+    /// Whether `name`, referenced at module scope, is declared `global` in
+    /// some nested (function/class) scope. Only meaningful - and only
+    /// worth the recursive scan - when the current scope is actually the
+    /// module scope, so callers should only reach for this from the
+    /// `Local`/`Unknown` scope arms where the result is actually used.
+    fn module_global_from_nested_scope(&self, name: &Name) -> bool {
+        let current_table = self.current_symbol_table();
+        current_table.typ == CompilerScope::Module
+            && Self::module_name_declared_global_in_nested_scope(current_table, name)
+    }
+
     // = compiler_nameop
     fn compile_name(&mut self, name: &Name, usage: NameUsage) -> CompileResult<()> {
         enum NameOp {
@@ -3265,18 +3281,12 @@ impl<'warnings> Compiler<'warnings> {
             }
         };
 
-        let module_global_from_nested_scope = {
-            let current_table = self.current_symbol_table();
-            current_table.typ == CompilerScope::Module
-                && Self::module_name_declared_global_in_nested_scope(current_table, name.as_ref())
-        };
-
         // Determine operation type based on scope
         let op_type = match actual_scope {
             SymbolScope::Free => NameOp::Deref,
             SymbolScope::Cell => NameOp::Deref,
             SymbolScope::Local => {
-                if module_global_from_nested_scope {
+                if self.module_global_from_nested_scope(name.as_ref()) {
                     NameOp::Global
                 } else if is_function_like
                     || self
@@ -3315,7 +3325,7 @@ impl<'warnings> Compiler<'warnings> {
                 }
             }
             SymbolScope::Unknown => {
-                if module_global_from_nested_scope {
+                if self.module_global_from_nested_scope(name.as_ref()) {
                     NameOp::Global
                 } else {
                     NameOp::Name
@@ -11289,10 +11299,7 @@ impl<'warnings> Compiler<'warnings> {
             target == BlockIdx::NULL || instr.has_target(),
             "CPython codegen_addop_j only accepts HAS_TARGET opcodes"
         );
-        let range = self.current_source_range;
-        let source = self.source_file.to_source_code();
-        let location = source.source_location(range.start(), PositionEncoding::Utf8);
-        let end_location = source.source_location(range.end(), PositionEncoding::Utf8);
+        let (location, end_location) = self.current_locations();
         let except_handler = None;
         self.cpython_cfg_builder_addop(ir::InstructionInfo {
             instr,
@@ -11324,10 +11331,7 @@ impl<'warnings> Compiler<'warnings> {
             !instr.is_assembler(),
             "CPython codegen_addop_j must not emit assembler-only opcodes"
         );
-        let range = self.current_source_range;
-        let source = self.source_file.to_source_code();
-        let location = source.source_location(range.start(), PositionEncoding::Utf8);
-        let end_location = source.source_location(range.end(), PositionEncoding::Utf8);
+        let (location, end_location) = self.current_locations();
         let target = self
             .current_code_info()
             .block_for_instr_sequence_label(target_label);
@@ -12325,6 +12329,25 @@ impl<'warnings> Compiler<'warnings> {
 
     const fn set_source_range(&mut self, range: TextRange) {
         self.current_source_range = range;
+    }
+
+    /// Converts `self.current_source_range` to `(location, end_location)`,
+    /// reusing the last conversion when the range hasn't changed since.
+    /// `current_source_range` is set far less often than instructions are
+    /// emitted, so this avoids two binary searches per emitted instruction
+    /// in the common case.
+    fn current_locations(&mut self) -> (SourceLocation, SourceLocation) {
+        let range = self.current_source_range;
+        if let Some((cached_range, location, end_location)) = self.current_source_locations
+            && cached_range == range
+        {
+            return (location, end_location);
+        }
+        let source = self.source_file.to_source_code();
+        let location = source.source_location(range.start(), PositionEncoding::Utf8);
+        let end_location = source.source_location(range.end(), PositionEncoding::Utf8);
+        self.current_source_locations = Some((range, location, end_location));
+        (location, end_location)
     }
 
     fn update_start_location_to_match_attr(

--- a/crates/codegen/src/ir.rs
+++ b/crates/codegen/src/ir.rs
@@ -63,6 +63,42 @@ fn is_within_opcode_range(opcode: AnyOpcode) -> bool {
 #[derive(Clone, Debug, Default)]
 pub struct ConstantPool {
     constants: Vec<ConstantData>,
+    /// De-dup index: digest of a canonicalized constant -> positions in
+    /// `constants` sharing that digest. Kept separate from `constants` so
+    /// `constants` stays a plain, order-preserving `Vec` for every other
+    /// consumer (indexing, iteration, in-place compaction in
+    /// `remove_unused_consts`). NaN-bearing constants are intentionally
+    /// never registered here, since they must never be deduplicated (see
+    /// `find_existing`).
+    index: crate::IndexMap<u64, Vec<u32>>,
+}
+
+/// A tiny, fully self-contained FNV-1a accumulator used only to build the
+/// `ConstantPool` de-dup digest. It does not need to match any external
+/// hash quality/seed contract, only to be deterministic within a single
+/// compilation.
+struct ConstantDigestHasher(u64);
+
+impl ConstantDigestHasher {
+    const OFFSET_BASIS: u64 = 0xcbf2_9ce4_8422_2325;
+    const PRIME: u64 = 0x0000_0100_0000_01b3;
+
+    fn new() -> Self {
+        Self(Self::OFFSET_BASIS)
+    }
+}
+
+impl core::hash::Hasher for ConstantDigestHasher {
+    fn finish(&self) -> u64 {
+        self.0
+    }
+
+    fn write(&mut self, bytes: &[u8]) {
+        for &byte in bytes {
+            self.0 ^= u64::from(byte);
+            self.0 = self.0.wrapping_mul(Self::PRIME);
+        }
+    }
 }
 
 impl ConstantPool {
@@ -165,6 +201,73 @@ impl ConstantPool {
             .expect("constant key canonicalization only fails on allocation error")
     }
 
+    /// Digest used for the de-dup `index`. Mirrors `constant_key_eq`: it
+    /// must treat frozensets as order-independent so two frozensets built
+    /// from the same (already-deduplicated) elements in different orders
+    /// still land in the same bucket. Every other variant recurses in the
+    /// same order `constant_key_eq` compares them. A hash collision only
+    /// costs an extra `constant_key_eq` check in `find_existing`'s bucket
+    /// scan; it can never cause an incorrect match.
+    fn constant_key_digest(constant: &ConstantData) -> u64 {
+        use core::hash::{Hash, Hasher};
+        match constant {
+            ConstantData::Tuple { elements } => {
+                let mut hasher = ConstantDigestHasher::new();
+                elements.len().hash(&mut hasher);
+                for element in elements {
+                    Self::constant_key_digest(element).hash(&mut hasher);
+                }
+                hasher.finish()
+            }
+            ConstantData::Slice { elements } => {
+                let mut hasher = ConstantDigestHasher::new();
+                for element in elements.iter() {
+                    Self::constant_key_digest(element).hash(&mut hasher);
+                }
+                hasher.finish()
+            }
+            ConstantData::Frozenset { elements } => {
+                // Order-independent: XOR the per-element digests together so
+                // permutations of the same elements land in the same bucket.
+                let combined = elements.iter().fold(0u64, |acc, element| {
+                    acc ^ Self::constant_key_digest(element)
+                });
+                let mut hasher = ConstantDigestHasher::new();
+                elements.len().hash(&mut hasher);
+                combined.hash(&mut hasher);
+                hasher.finish()
+            }
+            other => {
+                let mut hasher = ConstantDigestHasher::new();
+                other.hash(&mut hasher);
+                hasher.finish()
+            }
+        }
+    }
+
+    /// Registers `constant` (already stored at `idx` in `self.constants`)
+    /// in the de-dup index, unless it contains NaN.
+    fn index_insert(&mut self, constant: &ConstantData, idx: usize) {
+        if Self::constant_contains_nan(constant) {
+            return;
+        }
+        let digest = Self::constant_key_digest(constant);
+        self.index.entry(digest).or_default().push(idx as u32);
+    }
+
+    /// Rebuilds the de-dup index from scratch to match the current contents
+    /// of `self.constants`. Used after `remove_unused_consts` reorders and
+    /// truncates the constant list in place.
+    fn rebuild_index(&mut self) {
+        self.index.clear();
+        for (idx, constant) in self.constants.iter().enumerate() {
+            if !Self::constant_contains_nan(constant) {
+                let digest = Self::constant_key_digest(constant);
+                self.index.entry(digest).or_default().push(idx as u32);
+            }
+        }
+    }
+
     /// Index of an already-stored constant equal to `constant`, if any.
     /// _PyCode_ConstantKey() keeps NaN-bearing constants distinct because
     /// Python-level NaN keys do not compare equal.
@@ -172,9 +275,13 @@ impl ConstantPool {
         if Self::constant_contains_nan(constant) {
             return None;
         }
-        self.constants
+        let digest = Self::constant_key_digest(constant);
+        let bucket = self.index.get(&digest)?;
+        bucket
             .iter()
-            .position(|existing| Self::constant_key_eq(existing, constant))
+            .copied()
+            .map(|idx| idx as usize)
+            .find(|&idx| Self::constant_key_eq(&self.constants[idx], constant))
     }
 
     pub fn insert_full(&mut self, constant: ConstantData) -> (usize, bool) {
@@ -183,6 +290,7 @@ impl ConstantPool {
             return (idx, false);
         }
         let idx = self.constants.len();
+        self.index_insert(&constant, idx);
         self.constants.push(constant);
         (idx, true)
     }
@@ -196,6 +304,7 @@ impl ConstantPool {
             .try_reserve_exact(1)
             .map_err(|_| InternalError::MalformedControlFlowGraph)?;
         let idx = self.constants.len();
+        self.index_insert(&constant, idx);
         self.constants.push(constant);
         Ok((idx, true))
     }
@@ -225,6 +334,7 @@ impl ConstantPool {
 
     pub fn clear(&mut self) {
         self.constants.clear();
+        self.index.clear();
     }
 }
 
@@ -2622,18 +2732,26 @@ impl Blocks {
         }
 
         // Move all used consts to the beginning of the consts list.
+        // Each `old_index` is visited exactly once (index_map's used-const
+        // entries are the strictly-increasing original indices of the used
+        // consts), so moving the value out with `mem::replace` instead of
+        // cloning is safe: a source slot is never read again after its
+        // designated iteration, and any position that later becomes a
+        // destination gets unconditionally overwritten anyway.
         debug_assert!(n_used_consts < nconsts);
         for (i, item) in index_map.iter().enumerate().take(n_used_consts) {
             let old_index = *item as usize;
             debug_assert!(i <= old_index && old_index < nconsts);
             if i != old_index {
-                let value = consts.constants[old_index].clone();
+                let value =
+                    core::mem::replace(&mut consts.constants[old_index], ConstantData::None);
                 consts.constants[i] = value;
             }
         }
 
         // Truncate the consts list at its new size.
         consts.constants.truncate(n_used_consts);
+        consts.rebuild_index();
 
         // Adjust const indices in the bytecode.
         let mut reverse_index_map = Vec::new();


### PR DESCRIPTION
## What changed

Four compile-time-only optimizations in the bytecode compiler (`crates/codegen`), from audit section 3.13 ("compile-time hot spots"):

1. **O(n²) constant pool (`crates/codegen/src/ir.rs`, `ConstantPool`)**
   `ConstantPool::find_existing` used to linearly scan `self.constants` and compare every existing entry structurally against the new one, making constant-pool insertion O(n²) per code object. It now maintains an auxiliary de-dup index (`digest -> Vec<index>`) alongside the existing `Vec<ConstantData>`, giving O(1)-average lookup. The digest is a small, fully self-contained FNV-1a accumulator (`ConstantDigestHasher`) that mirrors the existing `constant_key_eq`/`constant_contains_nan` semantics exactly:
   - Frozensets hash order-independently (XOR of per-element digests), matching `frozenset_key_eq`'s order-independent set comparison, so two frozensets built from the same elements in a different order still land in the same bucket and get deduplicated.
   - Constants containing NaN (anywhere, including nested inside a tuple/frozenset/slice) are never registered in the index, so they are never deduplicated — matching the existing `_PyCode_ConstantKey`-style behavior.
   - A digest collision only costs an extra `constant_key_eq` comparison inside the (typically single-entry) bucket; it can never produce an incorrect match, since the final equality check is unchanged.
   `self.constants: Vec<ConstantData>` is untouched as the ordered backing store, so every other consumer (`Index`, `iter()`, `IntoIterator`, `get_index`) is unaffected.

2. **Per-instruction source-location conversion (`crates/codegen/src/compile.rs`, `Compiler::_emit`/`emit_jump_label`)**
   Both emit a location for every single instruction by calling `SourceCode::source_location` twice (start/end), even though `current_source_range` changes far less often than instructions are emitted. Added `Compiler::current_locations`, which memoizes the last `(range, location, end_location)` triple and reuses it when `current_source_range` is unchanged, added a new `current_source_locations: Option<(TextRange, SourceLocation, SourceLocation)>` field to `Compiler`.

3. **Eager DFS per module-scope name reference (`crates/codegen/src/compile.rs`, `Compiler::compile_name`)**
   `module_name_declared_global_in_nested_scope` (a recursive walk of the current scope's sub-scopes) used to run unconditionally for every name reference at module scope, even though its result (`module_global_from_nested_scope`) is only read in the `SymbolScope::Local` and `SymbolScope::Unknown` match arms. Extracted a `Compiler::module_global_from_nested_scope` method and moved the check into those two arms so the scan is skipped entirely for `Free`/`Cell`/`GlobalImplicit`/`GlobalExplicit` names.

4. **`remove_unused_consts` clones (`crates/codegen/src/ir.rs`)**
   The constant-pool compaction pass used `.clone()` to move a surviving constant from its old index to its new (lower) index, deep-copying nested `CodeObject`s/tuples/frozensets. Replaced with `core::mem::replace(..., ConstantData::None)`, which is safe because each source slot (`index_map`'s used-const entries are the strictly-increasing original indices of the used consts) is read exactly once at its own iteration and never read again afterward — any position that later becomes a destination is unconditionally overwritten regardless of what placeholder sits there. Also added `ConstantPool::rebuild_index`, called once after the in-place compaction to keep the de-dup index (from #1) consistent with the reordered/truncated `constants` Vec.

I evaluated items 3 (`push_symbol_table`'s `sub_tables[idx].clone()`) and 6 (lower priority, `arg_constant`'s code-object dedup scan / `mangle` per name-op) from the audit and did **not** implement them:

- **Item 3 is unsafe as literally suggested.** `Compiler::module_name_declared_global_in_nested_scope` (used by item 3's own fix target, item 4) reads `current_table.sub_tables` — the exact same `Vec<SymbolTable>` that `push_symbol_table`/`push_symbol_table_matching` pull children out of via `.clone()` — *after* those children have already been visited and popped back off `symbol_table_stack`. A module like:
  ```python
  def f():
      global x
      x = 1

  x
  ```
  needs `sub_tables[0]` (the already-compiled-and-popped `f`) to still hold real data when the module-level reference to `x` is compiled. Replacing the `.clone()` with `mem::take` (per the audit's suggestion) would leave a `SymbolTable::default()`-shaped hole there, silently breaking `global` detection for names referenced after an earlier nested function/class in the same module. I did not find a way to make it safe without changing the audit's premise, so I left it as `.clone()`.
- Item 6 was left for a follow-up since the assigned scope was items 1/2/4/5 ("start with items 1, 3 and 5 ... then evaluate 2 and 4"); given item 3 turned out to be unsafe, I substituted the already-measured item 2 to keep three landed changes plus item 5.

## Why it's faster

Items 1 and 5 remove an O(n²) pattern and redundant deep clones from constant-pool bookkeeping, which every compiled code object goes through. Item 2 removes two binary-search-based `source_location` calls per emitted bytecode instruction in the (very common) case where the source range hasn't moved since the previous instruction. Item 4 skips a recursive scope-tree walk for every module-scope name reference whose resolved scope doesn't actually need the result.

None of these touch what bytecode gets generated — they only change how it's assembled internally.

## Benchmark script

`/tmp/choco-pi/perf/perf-compile-time/` (interleaved A/B driver `run_bench.py`, benchmarks `bench_compile_loop.py`, `bench_control_runtime.py`, `bench_startup.py`, `bench_import_cold.py`):

- `compile_loop`: in-process `compile(source, path, "exec")` called 15x per file for `Lib/_pydecimal.py`, `Lib/typing.py`, `Lib/test/test_descr.py`, timed with `time.perf_counter()` inside the interpreter (excludes process startup).
- `control_runtime`: a 2,000,000-iteration arithmetic loop, run-time dominated, expected to be neutral — a control for the "did this touch the interpreter loop" question.
- `startup`: whole-process wall clock for `rustpython bench_startup.py` (a `pass` script), i.e. interpreter startup including the stdlib bootstrap it compiles from source.
- `import_cold`: whole-process wall clock for `rustpython bench_import_cold.py`, importing `_pydecimal`, `typing`, `argparse` fresh (no in-process module cache reuse — every subprocess is a cold import).

Method: interleaved A/B, alternating baseline/patched, min and median reported, release builds both sides. Ran twice: once at reps=9 under heavy shared-machine load (several sibling perf agents building concurrently), once more at reps=11 after that load eased, per the "prefer low background load" guidance. Both runs agree; the second (lower-noise) run is reported below.

## Results (11 reps, interleaved A/B, low background load)

| Benchmark | Metric | Baseline min | Patched min | Δ min | Baseline median | Patched median | Δ median |
|---|---|---|---|---|---|---|---|
| compile_loop _pydecimal.py | s / 15 compiles | 0.26855 | 0.26200 | **-2.4%** | 0.27057 | 0.26566 | **-1.8%** |
| compile_loop typing.py | s / 15 compiles | 0.22656 | 0.21646 | **-4.5%** | 0.22793 | 0.21810 | **-4.3%** |
| compile_loop test_descr.py | s / 15 compiles | 0.49171 | 0.47730 | **-2.9%** | 0.49615 | 0.48290 | **-2.7%** |
| control_runtime (neutral) | s | 0.37949 | 0.37886 | -0.2% (noise) | 0.39907 | 0.38189 | -4.3% (noise) |
| startup (`-c pass`) | s / process | 0.02554 | 0.02547 | -0.3% (noise) | 0.02602 | 0.02591 | -0.4% (noise) |
| import_cold | s / process | 0.04972 | 0.04976 | +0.1% (noise) | 0.05074 | 0.05058 | -0.3% (noise) |

`compile_loop` — the workload these changes directly target — is consistently 2-5% faster on both min and median across all three real-world files, with the effect strongest on `typing.py` (largest constant pool / annotation-heavy). This reproduces the same direction and similar magnitude seen in the earlier, noisier 9-rep run (-1.6% to -5.9%). `control_runtime`'s min values are within 0.2% of each other (its median moved more, but that's consistent with general system jitter, not a real effect, since it never touches the changed code paths). `startup` and `import_cold` are both tens-of-milliseconds, process-dominated measurements where compiler-only savings of a few percent of `compile_loop`'s cost are below the noise floor of process spawn/exec overhead; they show no consistent direction and no regression in either run.

## Bytecode-identity verification

Compared `marshal.dumps(compile(source, path, "exec"))` between the baseline and patched binaries (byte-for-byte, including nested code objects) for:
- 328 real files from `Lib/*.py`, `Lib/test/test_*.py` (first 60), and `Lib/email`, `Lib/urllib`, `Lib/importlib`, `Lib/unittest`, `Lib/asyncio`, `Lib/collections`, `Lib/json`, `Lib/xml`, `Lib/multiprocessing` — all 328 compiled successfully on both binaries, and `diff -rq` over all 328 marshaled outputs reported **zero differences**.
- A dedicated edge-case file (`edge_cases.py`) exercising: frozenset constants built from the same elements in different insertion orders (`{1,2,3}` vs `{3,2,1}` vs `{2,1,3}`), repeated `float("nan")` constants (top-level and nested in a tuple, expected to stay distinct), a frozenset nested inside a tuple with reordered elements, repeated/reordered tuple constants, a `match` statement, and a `global` declared in a nested class method referenced at module scope after the class body runs. Marshaled output was identical (3105 bytes, byte-for-byte) between baseline and patched, and printed output matched.

## Test results

- `cargo clippy --workspace --all-targets --exclude rustpython_wasm --exclude rustpython-venvlauncher --exclude rustpython-capi`: clean (only pre-existing, unrelated `must_use_candidate` warnings in `crates/compiler-source`, a file this change does not touch).
- `cargo test --workspace --exclude rustpython_wasm --exclude rustpython-venvlauncher --exclude rustpython-capi`: PASS (42/42 test-result groups green, zero failures) on a clean rerun. Note: on a heavily loaded shared build machine, this command intermittently reported 8 `rustpython-stdlib::_opcode::tests::*` insta-snapshot failures with an empty "old" side of the diff (i.e. `+new results` only, no `-old`) and a spurious untracked `crates/stdlib/crates/stdlib/src/snapshots/...` directory created alongside the real one. I reproduced this identically on the *unmodified* base commit (`git stash` + rerun), and all 8 tests pass reliably in isolation (`cargo test -p rustpython-stdlib --lib`, twice). This is a pre-existing `cargo test --workspace` / insta snapshot-path flake in this environment, unrelated to this change; it did not reproduce on the clean, lower-load final run.
- `(cd crates/capi && cargo test)`: PASS, 103 passed, 0 failed.
- `-m test test_compile test_dis test_symtable test_syntax test_ast test_peepholer`: all six `Result: SUCCESS`.
- `extra_tests` (`uv run --with pytest --with bytecode pytest -q`): 443 passed, 1 failed (`test_rustpython_stdlib_sqlite`, pre-existing: `ModuleNotFoundError: No module named '_sqlite3'` because the release binary wasn't built with the `sqlite` cargo feature — unrelated to this change).

## Caveats

- Item 3 from the audit (symbol-table sub-table `.clone()` -> `mem::take`) was investigated and found unsafe; not implemented (see above).
- Item 6 (lower priority per the task) was not attempted in this pass.
- Benchmarks ran on a shared machine with several other perf-focused sibling agents building concurrently; `compile_loop` numbers are consistent and directionally clear, but `startup`/`import_cold` are noisy at this scale and are reported as neutral/inconclusive rather than as a proven win.
