### PR TITLE
Keep `str`'s concat error when `__radd__` declines

### DIFF
--- a/crates/vm/src/builtins/str.rs
+++ b/crates/vm/src/builtins/str.rs
@@ -653,10 +653,17 @@ impl PyStr {
                 Self::new_str_unchecked(bytes.into(), kind)
             }
             .to_pyobject(vm))
-        } else if let Some(radd) = vm.get_method(other.clone(), identifier!(vm, __radd__)) {
-            // hack to get around not distinguishing number add from seq concat
-            radd?.call((zelf,), vm)
         } else {
+            // hack to get around not distinguishing number add from seq concat
+            if let Some(radd) = vm.get_method(other.clone(), identifier!(vm, __radd__)) {
+                let result = radd?.call((zelf,), vm)?;
+                // CPython reaches `str`'s sq_concat once the reflected call declines, so a
+                // `__radd__` returning NotImplemented must still report the concat error
+                // rather than the generic binary-op one.
+                if !result.is(&vm.ctx.not_implemented) {
+                    return Ok(result);
+                }
+            }
             Err(vm.new_type_error(format!(
                 r#"can only concatenate str (not "{}") to str"#,
                 other.class().slot_name()

--- a/extra_tests/snippets/builtin_str.py
+++ b/extra_tests/snippets/builtin_str.py
@@ -979,3 +979,39 @@ def test_expandtabs_zero_tabsize():
 
 
 test_expandtabs_zero_tabsize()
+
+
+def test_concat_error_message():
+    # CPython falls back to str's sequence concatenation once a reflected
+    # __radd__ declines, so the message names the concatenation, not the
+    # generic binary operation. Types that define __radd__ (every number)
+    # used to take the generic path here.
+    def message(other):
+        try:
+            "a" + other
+        except TypeError as err:
+            return str(err)
+        raise AssertionError("TypeError was not raised")
+
+    assert message(1) == 'can only concatenate str (not "int") to str'
+    assert message(1.5) == 'can only concatenate str (not "float") to str'
+    assert message(True) == 'can only concatenate str (not "bool") to str'
+    assert message([]) == 'can only concatenate str (not "list") to str'
+    assert message(None) == 'can only concatenate str (not "NoneType") to str'
+    assert message(b"b") == 'can only concatenate str (not "bytes") to str'
+
+    class Declines:
+        def __radd__(self, other):
+            return NotImplemented
+
+    assert message(Declines()) == 'can only concatenate str (not "Declines") to str'
+
+    # A __radd__ that returns a value still wins.
+    class Accepts:
+        def __radd__(self, other):
+            return "from-radd"
+
+    assert "a" + Accepts() == "from-radd"
+
+
+test_concat_error_message()


### PR DESCRIPTION
`"a" + 1` reports the generic binary-op error instead of CPython's concatenation error:

```
RustPython: TypeError: unsupported operand type(s) for +: 'str' and 'int'
CPython:    TypeError: can only concatenate str (not "int") to str
```

`PyStr::__add__` delegates to the right operand's `__radd__` whenever it has one and returns whatever comes back. Every numeric type has `__radd__`, and it returns `NotImplemented` for a `str` left operand, so the result reached the generic handler. CPython instead falls back to `str`'s `sq_concat` once the reflected call declines, which is where its message comes from.

The correct message was already in the `else` branch, reachable only for operands with **no** `__radd__` at all — so `list`, `object`, `bytes` and `None` were already right, while `int`, `float`, `bool` and any class whose `__radd__` returns `NotImplemented` were not. The fix keeps the reflected call, and only falls through to the concat error when it declines. A `__radd__` that returns a value still wins, unchanged.

| `"a" + x` | before | after |
| --- | --- | --- |
| `1`, `1.5`, `True` | generic | `can only concatenate str (not "int"/"float"/"bool") to str` |
| declining `__radd__` | generic | `can only concatenate str (not "Declines") to str` |
| `[]`, `None`, `b"b"`, `object()` | already correct | unchanged |
| `__radd__` returning a value | works | unchanged |

Verification:

- The new snippet in `extra_tests/snippets/builtin_str.py` passes under **both** RustPython and CPython 3.14.0, so its expectations are CPython's behaviour rather than my reading of it.
- Reverting only the `str.rs` change fails its first assertion.
- `cargo test --workspace --exclude rustpython_wasm --exclude rustpython-venvlauncher --exclude rustpython-capi` — all 42 test binaries pass.
- `cargo run --release -- -m test test_str test_operator test_descr test_exceptions` — SUCCESS for each.
- `cargo fmt --check` and `ruff format --check` clean.

Found by diffing ~70 expressions across both interpreters. Three other divergences turned up and are deliberately not in this PR, since they are unrelated one-line message fixes in different files: `'{'.format()` and `'{0.}'.format(1)` produce different `ValueError` text, and `bytes([256])` says `byte must be in range(0, 256)` where CPython says `bytes`. Happy to send those separately if wanted.

AI disclosure per the AI policy: found, written and verified with Claude Code (Claude Opus 5), which is also recorded in the commit's `Assisted-by:` trailer. @rawsun007 reviewed the change and authorised the push.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved string concatenation errors to report the specific incompatible operand type.
  - Correctly falls back to the standard string error when a reflected operation declines handling.
  - Preserved reflected-operation results when they provide a valid value.

- **Tests**
  - Added coverage for concatenation with incompatible types and reflected operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->