### PR TITLE
Fix resource index conversion and REPL warning

### DIFF
--- a/crates/stdlib/src/resource.rs
+++ b/crates/stdlib/src/resource.rs
@@ -175,7 +175,7 @@ mod resource {
     }
 
     fn py2rlim_limit(obj: &PyObject, vm: &VirtualMachine) -> PyResult<host_resource::rlim_t> {
-        let int = obj.try_to_ref::<crate::vm::builtins::PyInt>(vm)?;
+        let int = obj.try_index(vm)?;
         if int.as_bigint().is_negative() {
             return Err(vm.new_value_error("Cannot convert negative int"));
         }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -361,7 +361,9 @@ fn run_rustpython(vm: &VirtualMachine, run_mode: RunMode) -> PyResult<()> {
         RunMode::Repl => Ok(()),
     };
     let result = if is_repl || vm.state.config.settings.inspect {
-        warn_if_pyrepl_unavailable(vm);
+        if std::io::stdin().is_terminal() {
+            warn_if_pyrepl_unavailable(vm);
+        }
         shell::run_shell(vm, scope)
     } else {
         res


### PR DESCRIPTION
## Summary

- accept objects implementing `__index__` when converting `resource.setrlimit()` limits
- only emit the PyREPL fallback warning when standard input is a terminal, keeping piped stdin clean

## Testing

- `cargo fmt --all -- --check`
- `cargo test --workspace --exclude rustpython_wasm --exclude rustpython-venvlauncher --exclude rustpython-capi`
- `(cd crates/capi && cargo test)`
- `cargo clippy --workspace --all-targets --exclude rustpython_wasm --exclude rustpython-venvlauncher --exclude rustpython-capi`
- `(cd crates/capi && cargo clippy --all-targets)`
- `target/release/rustpython -m test test_resource`
- `target/release/rustpython -m test -m "*test_dumb_terminal_exits_cleanly*" test_pyrepl.test_pyrepl`
- manual `__index__`, negative limit, overflow, and piped-stdin checks

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Resource limit values can now be provided by any object that supports integer conversion through `__index__`, rather than only by integer objects.
  - The unavailable interactive REPL warning is now shown only when standard input is connected to a terminal, preventing unnecessary warnings in non-interactive environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->