### PR TITLE
Report which format string mistake was made

### DIFF
--- a/crates/common/src/format.rs
+++ b/crates/common/src/format.rs
@@ -1618,6 +1618,12 @@ impl FormatString {
             let right = &text[pos..];
             let format_part = Self::parse_part_in_brackets(&left)?;
             Ok((format_part, &right[1..]))
+        } else if text.len() == 1 {
+            // Nothing follows the brace, so it is a stray one rather than a field
+            // that was left open: CPython separates "{" and "a{" from "{0" and
+            // "a{b" the same way. `{` is one byte, so a length of one is the brace
+            // on its own.
+            Err(FormatParseError::UnescapedStartBracketInLiteral)
         } else {
             Err(FormatParseError::UnmatchedBracket)
         }
@@ -2336,6 +2342,26 @@ mod tests {
             FormatString::from_str("{s".as_ref()),
             Err(FormatParseError::UnmatchedBracket)
         );
+    }
+
+    #[test]
+    fn format_parse_lone_start_bracket() {
+        // A brace with nothing after it is a stray brace; one holding a field
+        // that was never closed is not. CPython words the two differently.
+        for lone in ["{", "a{"] {
+            assert_eq!(
+                FormatString::from_str(lone.as_ref()),
+                Err(FormatParseError::UnescapedStartBracketInLiteral),
+                "{lone:?}"
+            );
+        }
+        for unclosed in ["{s", "a{b", "{0"] {
+            assert_eq!(
+                FormatString::from_str(unclosed.as_ref()),
+                Err(FormatParseError::UnmatchedBracket),
+                "{unclosed:?}"
+            );
+        }
     }
 
     #[test]

--- a/crates/vm/src/format.rs
+++ b/crates/vm/src/format.rs
@@ -113,10 +113,10 @@ impl ToPyException for FormatParseError {
             Self::MissingStartBracket => {
                 vm.new_value_error("Single '}' encountered in format string")
             }
-            // The variant means a bracket in literal text that was not doubled. A
-            // trailing lone `{` reaches UnmatchedBracket instead, so I could not
-            // construct an input that lands here; the message is what CPython uses
-            // for that condition.
+            // A brace in literal text that was not doubled, i.e. a stray `{` with
+            // nothing after it. `parse_spec` reports this rather than
+            // UnmatchedBracket so that "{" and "a{" are separated from "{0" and
+            // "a{b", which are fields left open.
             Self::UnescapedStartBracketInLiteral => {
                 vm.new_value_error("Single '{' encountered in format string")
             }

--- a/crates/vm/src/format.rs
+++ b/crates/vm/src/format.rs
@@ -103,12 +103,36 @@ impl IntoPyException for FormatSpecError {
 
 impl ToPyException for FormatParseError {
     fn to_pyexception(&self, vm: &VirtualMachine) -> PyBaseExceptionRef {
+        // Matched exhaustively on purpose: a catch-all sent most of these to
+        // "Unexpected error parsing format string", which tells the reader nothing
+        // about the format string they mistyped.
         match self {
-            Self::UnmatchedBracket => vm.new_value_error("expected '}' before end of string"),
+            Self::UnmatchedBracket | Self::MissingRightBracket => {
+                vm.new_value_error("expected '}' before end of string")
+            }
+            Self::MissingStartBracket => {
+                vm.new_value_error("Single '}' encountered in format string")
+            }
+            // The variant means a bracket in literal text that was not doubled. A
+            // trailing lone `{` reaches UnmatchedBracket instead, so I could not
+            // construct an input that lands here; the message is what CPython uses
+            // for that condition.
+            Self::UnescapedStartBracketInLiteral => {
+                vm.new_value_error("Single '{' encountered in format string")
+            }
+            Self::InvalidFormatSpecifier => vm.new_value_error("unmatched '{' in format spec"),
+            // Reached both for a conversion that is not one character (`{0!xy}`,
+            // where CPython says "expected ':' after conversion specifier") and for
+            // an empty one (`{0!}`, "unmatched '{' in format spec"). Telling those
+            // apart needs the parser to say which, so the generic message stays.
+            Self::UnknownConversion => vm.new_value_error("Unexpected error parsing format string"),
+            Self::EmptyAttribute => vm.new_value_error("Empty attribute in format string"),
+            Self::InvalidCharacterAfterRightBracket => {
+                vm.new_value_error("Only '.' or '[' may follow ']' in format field specifier")
+            }
             Self::TooManyDecimalDigits => {
                 vm.new_value_error("Too many decimal digits in format string")
             }
-            _ => vm.new_value_error("Unexpected error parsing format string"),
         }
     }
 }

--- a/extra_tests/snippets/builtin_format.py
+++ b/extra_tests/snippets/builtin_format.py
@@ -369,5 +369,12 @@ def test_format_parse_error_messages():
 
     assert message("{:{{}}", 1) == "unmatched '{' in format spec"
 
+    # A brace with nothing after it is a stray brace; one holding an unclosed
+    # field is not.
+    assert message("{") == "Single '{' encountered in format string"
+    assert message("a{") == "Single '{' encountered in format string"
+    assert message("{s") == "expected '}' before end of string"
+    assert message("a{b") == "expected '}' before end of string"
+
 
 test_format_parse_error_messages()

--- a/extra_tests/snippets/builtin_format.py
+++ b/extra_tests/snippets/builtin_format.py
@@ -336,3 +336,38 @@ assert_raises(ValueError, format, True, ".2")
 assert_raises(ValueError, format, True, "5.2")
 assert_raises(ValueError, format, True, "z")
 assert_raises(ValueError, format, True, "s")
+
+
+def test_format_parse_error_messages():
+    # Most FormatParseError variants used to fall into a catch-all that said
+    # "Unexpected error parsing format string", which does not say what is wrong
+    # with the format string. Messages are CPython 3.14.0's.
+    def message(fmt, *args):
+        try:
+            fmt.format(*args)
+        except ValueError as err:
+            return str(err)
+        raise AssertionError("ValueError was not raised for " + repr(fmt))
+
+    assert message("a}b") == "Single '}' encountered in format string"
+    assert message("{{a}") == "Single '}' encountered in format string"
+
+    assert message("{0.}", 1) == "Empty attribute in format string"
+    assert message("{0[]}", [1]) == "Empty attribute in format string"
+
+    assert message("{0[1}", [1, 2]) == "expected '}' before end of string"
+    assert message("{0", 1) == "expected '}' before end of string"
+
+    assert (
+        message("{0[0]x}", [1])
+        == "Only '.' or '[' may follow ']' in format field specifier"
+    )
+    assert (
+        message("{0[0]]}", [1])
+        == "Only '.' or '[' may follow ']' in format field specifier"
+    )
+
+    assert message("{:{{}}", 1) == "unmatched '{' in format spec"
+
+
+test_format_parse_error_messages()


### PR DESCRIPTION
- [ ] Closes #xxxx <!-- no issue: found by differential testing against CPython 3.14.0 -->

One of checkbox below must be checked.
- [ ] I did not use AI to write the code of this patch.
- [x] This PR follows our [AI policy](https://github.com/RustPython/.github/blob/main/AI_POLICY.md)

## Summary

`ToPyException for FormatParseError` mapped two variants and sent the rest to `"Unexpected error parsing format string"`, so most format-string mistakes did not say what was wrong. The match is now exhaustive, so a variant added later cannot inherit the generic message.

The second commit separates a stray `{` from a field left open, which is what makes `UnescapedStartBracketInLiteral` reachable at all.

> The following was generated by Claude Code (Claude Opus 5), which wrote this patch under @rawsun007's account. Measured against CPython 3.14.0:
>
> | expression | before | CPython |
> | --- | --- | --- |
> | `"a}b".format()` | Unexpected error… | ``Single `}` encountered in format string`` |
> | `"{0.}".format(1)` | Unexpected error… | `Empty attribute in format string` |
> | `"{0[]}".format([1])` | Unexpected error… | `Empty attribute in format string` |
> | `"{0[1}".format([1,2])` | Unexpected error… | ``expected `}` before end of string`` |
> | `"{0[0]x}".format([1])` | Unexpected error… | ``Only `.` or `[` may follow `]` in format field specifier`` |
> | `"{:{{}}".format(1)` | Unexpected error… | ``unmatched `{` in format spec`` |
> | `"{".format()` | ``expected `}`…`` | ``Single `{` encountered in format string`` |
>
> Two cases stay generic on purpose, with the reason in a comment beside each: `UnknownConversion` is raised both for a multi-character conversion (`{0!xy}`, CPython: "expected ':' after conversion specifier") and an empty one (`{0!}`, "unmatched '{' in format spec"), so one message cannot serve both.
>
> Verification: the snippet in `extra_tests/snippets/builtin_format.py` passes under both RustPython and CPython 3.14.0; `format_parse_lone_start_bracket` pins the parser change; `cargo test --workspace --exclude rustpython_wasm --exclude rustpython-venvlauncher --exclude rustpython-capi` — 42 binaries pass; `-m test test_str` SUCCESS; `cargo fmt` and `ruff format` clean. `extra_tests` shows 4 failures that also fail on a clean `main` (memoryview, atexit, struct, sqlite).
>
> On the CodSpeed report: `gc_traversal.py` contains no formatting at all and both changed functions run only after a parse has failed, so the benchmark cannot reach the diff; a local A/B against the same base sha gave 0.20s either side.

@youknowone — sorry about the template, restoring it was mine to fix. The generated text is now marked off above; @rawsun007 will follow up on the review in his own words.
