### PR TITLE
ssl: cap rustls unsent output at 4 KiB

### DIFF
--- a/Lib/test/test_asyncio/test_sendfile.py
+++ b/Lib/test/test_asyncio/test_sendfile.py
@@ -625,10 +625,6 @@ else:
             def create_event_loop(self):
                 return asyncio.SelectorEventLoop(selectors.EpollSelector())
 
-            @unittest.skipIf(sys.platform != "win32", "TODO: RUSTPYTHON; Flaky on CI")
-            def test_sendfile_ssl_pre_and_post_data(self):
-                return super().test_sendfile_ssl_pre_and_post_data()
-
     if hasattr(selectors, 'PollSelector'):
         class PollEventLoopTests(SendfileTestsBase,
                                  test_utils.TestCase):
@@ -636,20 +632,12 @@ else:
             def create_event_loop(self):
                 return asyncio.SelectorEventLoop(selectors.PollSelector())
 
-            @unittest.skipIf(sys.platform != "win32", "TODO: RUSTPYTHON; Flaky on CI")
-            def test_sendfile_ssl_pre_and_post_data(self):
-                return super().test_sendfile_ssl_pre_and_post_data()
-
     # Should always exist.
     class SelectEventLoopTests(SendfileTestsBase,
                                test_utils.TestCase):
 
         def create_event_loop(self):
             return asyncio.SelectorEventLoop(selectors.SelectSelector())
-
-        @unittest.skipIf(sys.platform != "win32", "TODO: RUSTPYTHON; Flaky on CI")
-        def test_sendfile_ssl_pre_and_post_data(self):
-            return super().test_sendfile_ssl_pre_and_post_data()
 
 
 if __name__ == '__main__':

--- a/crates/stdlib/src/ssl.rs
+++ b/crates/stdlib/src/ssl.rs
@@ -99,6 +99,10 @@ mod _ssl {
     };
     use sha2::{Digest, Sha256};
 
+    /// Caps unsent TLS so BIO writes stay inside asyncio's 64 KiB
+    /// socket-transport high-water mark when SO_SNDBUF is small.
+    const TLS_IO_BUFFER_LIMIT: Option<usize> = Some(4 * 1024);
+
     // Import certificate operations module
     use super::cert;
     use super::chain::{self, VerifiedChainBuilder};
@@ -3238,7 +3242,8 @@ mod _ssl {
             // particular connection's mutable keylog routing.
             Arc::make_mut(&mut config_arc).key_log = self.key_log.clone();
             match accepted.into_connection(config_arc) {
-                Ok(conn) => {
+                Ok(mut conn) => {
+                    conn.set_buffer_limit(TLS_IO_BUFFER_LIMIT);
                     *conn_guard = Some(Connection::Server(conn));
                     *self.state.lock() = TlsState::Handshaking;
                 }
@@ -3381,9 +3386,10 @@ mod _ssl {
                     *self.client_config.write() = Some(config.clone());
                     *self.client_session_store.write() = Some(session_store);
 
-                    let conn = ClientConnection::new(config, server_name).map_err(|e| {
+                    let mut conn = ClientConnection::new(config, server_name).map_err(|e| {
                         vm.new_value_error(format!("Failed to create client connection: {e}"))
                     })?;
+                    conn.set_buffer_limit(TLS_IO_BUFFER_LIMIT);
 
                     *conn_guard = Some(Connection::Client(conn));
                 }


### PR DESCRIPTION
- [ ] Closes #xxxx

One of checkbox below must be checked.
- [ ] I did not use AI to write the code of this patch.
- [x] This PR follows our [AI policy](https://github.com/RustPython/.github/blob/main/AI_POLICY.md)

## Summary

Cap rustls unsent output at 4 KiB on both client and server connections.

Without a buffer limit, rustls can queue more TLS records than asyncio's socket transport will accept when `SO_SNDBUF` is small. Those BIO writes then push the transport past its 64 KiB high-water mark and flake `test_sendfile_ssl_pre_and_post_data` on Unix selectors.

This uses rustls `set_buffer_limit` so writes stay inside that window, and drops the Unix skips on the Epoll, Poll, and Select sendfile cases.

Assisted-by: Claude

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * Limited buffered unsent TLS output to 4 KiB for both client and server connections.
  * TLS connections now write pending data more regularly, helping control memory usage and output buffering.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->