### PR TITLE
lzma: build the xz-core engine on wasm32

### DIFF
--- a/crates/common/Cargo.toml
+++ b/crates/common/Cargo.toml
@@ -66,10 +66,6 @@ zlib-rs = { workspace = true, optional = true }
 lock_api = { workspace = true }
 siphasher = { workspace = true }
 num-complex = { workspace = true }
-
-[target.'cfg(not(any(target_os = "android", target_arch = "wasm32")))'.dependencies]
-# RustPython does not expose `_lzma` on these targets; keep the native engine's
-# dependency boundary with its common-module owner rather than in stdlib.
 xz = { workspace = true, optional = true }
 xz-sys = { workspace = true, optional = true }
 

--- a/crates/common/src/compression/lzma.rs
+++ b/crates/common/src/compression/lzma.rs
@@ -2,9 +2,8 @@
 
 //! VM-independent liblzma stream engine.
 //!
-//! `_lzma` is not built on Android or WebAssembly in RustPython, so the xz
-//! dependency and this module have the same target boundary.  Python object
-//! conversion and exception construction remain in `rustpython-stdlib`.
+//! Python object conversion and exception construction remain in
+//! `rustpython-stdlib`.
 
 use xz::stream::{
     Action, Check, Error as XzError, Filters, LzmaOptions, MatchFinder, Mode, Status, Stream,

--- a/crates/common/src/compression/mod.rs
+++ b/crates/common/src/compression/mod.rs
@@ -71,10 +71,7 @@ impl<'a> Chunker<'a> {
 
 #[cfg(feature = "bz2")]
 pub mod bz2;
-#[cfg(all(
-    feature = "lzma",
-    not(any(target_os = "android", target_arch = "wasm32"))
-))]
+#[cfg(feature = "lzma")]
 pub mod lzma;
 #[cfg(feature = "zlib")]
 pub mod zlib;

--- a/crates/stdlib/src/lib.rs
+++ b/crates/stdlib/src/lib.rs
@@ -23,7 +23,6 @@ mod compression; // internal module
 mod contextvars;
 mod csv;
 
-#[cfg(not(any(target_os = "android", target_arch = "wasm32")))]
 mod lzma;
 
 mod zlib;
@@ -206,7 +205,6 @@ pub fn stdlib_module_defs(ctx: &Context) -> Vec<&'static builtins::PyModuleDef> 
             not(any(target_os = "ios", target_arch = "wasm32"))
         ))]
         locale::module_def(ctx),
-        #[cfg(not(any(target_os = "android", target_arch = "wasm32")))]
         lzma::module_def(ctx),
         math::module_def(ctx),
         md5::module_def(ctx),


### PR DESCRIPTION
Expose `_lzma` on wasm32 and Android by compiling the xz-core engine on those targets instead of gating it out.

Assisted-by: Claude

<!--
Thanks for your contribution!
-->

- [ ] Closes #xxxx <!-- Replace xxxx with the GitHub issue number if exists -->

One of checkbox below must be checked.
- [ ] I did not use AI to write the code of this patch.
- [ ] This PR follows our [AI policy](https://github.com/RustPython/.github/blob/main/AI_POLICY.md)

## Summary
<!-- What's the purpose of the change? What does it do, and why? -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - LZMA compression support is now available on Android and WebAssembly platforms.
  - Applications targeting these platforms can use LZMA compression and decompression wherever the LZMA feature is enabled.

- **Documentation**
  - Updated compression documentation to reflect broader platform availability and current exception-handling behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->