### PR TITLE
cli: avoid panic when -X int_max_str_digits has no value

### DIFF
--- a/extra_tests/snippets/cli_int_max_str_digits.py
+++ b/extra_tests/snippets/cli_int_max_str_digits.py
@@ -1,0 +1,35 @@
+import subprocess
+import sys
+
+for option in (
+    "int_max_str_digits",
+    "int_max_str_digits=639",
+    "int_max_str_digits=invalid",
+):
+    result = subprocess.run(
+        [sys.executable, "-E", "-X", option, "-c", "pass"],
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+    )
+    assert result.returncode == 1, (option, result.returncode, result.stderr)
+    assert b"-X int_max_str_digits: invalid limit" in result.stderr, (
+        option,
+        result.stderr,
+    )
+    assert b"panicked" not in result.stderr, (option, result.stderr)
+
+for digits in (640, 0):
+    result = subprocess.run(
+        [
+            sys.executable,
+            "-E",
+            "-X",
+            f"int_max_str_digits={digits}",
+            "-c",
+            "import sys; print(sys.get_int_max_str_digits())",
+        ],
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+    )
+    assert result.returncode == 0, (digits, result.returncode, result.stderr)
+    assert result.stdout.strip() == str(digits).encode(), (digits, result.stdout)

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -339,8 +339,8 @@ pub fn parse_opts() -> Result<(Settings, RunMode), lexopt::Error> {
                 };
             }
             "int_max_str_digits" => {
-                settings.int_max_str_digits = match value.unwrap().parse() {
-                    Ok(digits) if digits == 0 || digits >= 640 => digits,
+                settings.int_max_str_digits = match value.and_then(|value| value.parse().ok()) {
+                    Some(digits) if digits == 0 || digits >= 640 => digits,
                     _ => {
                         error!(
                             "Fatal Python error: config_init_int_max_str_digits: \


### PR DESCRIPTION
- [ ] I did not use AI to write the code of this patch.
- [x] This PR follows our [AI policy](https://github.com/RustPython/.github/blob/main/AI_POLICY.md)

## Summary

Passing `-X int_max_str_digits` without a value unwraps `None` and causes a Rust panic before reaching the existing configuration error handler.

Handle the optional value before parsing so missing values report the existing `invalid limit` diagnostic and exit with status 1.



AI assistance: Codex (GPT-6) assisted with the regression test, validation, and I have reviewed and understand the code.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Invalid or missing `-X int_max_str_digits` values now produce a clear error instead of causing an interpreter panic.
  * Valid limits, including `640` and `0`, continue to be accepted and reported correctly.

* **Tests**
  * Added coverage for valid, invalid, and missing command-line option values.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->