### PR TITLE
Stop generating a `__text_signature__` that `inspect` cannot parse

### DIFF
--- a/crates/derive-impl/src/util.rs
+++ b/crates/derive-impl/src/util.rs
@@ -768,8 +768,9 @@ pub(crate) fn infer_native_call_flags(sig: &Signature, drop_first_typed: usize) 
         };
         let ty_tokens = &typed.ty;
         let ty = quote!(#ty_tokens).to_string().replace(' ', "");
-        // `vm: &VirtualMachine` is not a Python-level argument.
-        if ty.starts_with('&') && ty.ends_with("VirtualMachine") {
+        // The interpreter supplies `vm` and `callee`; a Python call never
+        // passes them.
+        if (ty.starts_with('&') && ty.ends_with("VirtualMachine")) || ty.ends_with("Callee") {
             continue;
         }
         typed_args.push(ty);
@@ -853,7 +854,7 @@ fn func_sig(sig: &Signature, mut implicit_self: Option<&str>) -> Option<String> 
             params.push("*args, **kwargs".to_owned());
             continue;
         }
-        if ty.starts_with('&') && ty.ends_with("VirtualMachine") {
+        if (ty.starts_with('&') && ty.ends_with("VirtualMachine")) || ty.ends_with("Callee") {
             continue;
         }
         if let Some(marker) = implicit_self.take() {

--- a/crates/vm/src/builtins/bytearray.rs
+++ b/crates/vm/src/builtins/bytearray.rs
@@ -252,8 +252,8 @@ impl PyByteArray {
     }
 
     #[pystaticmethod]
-    fn maketrans(from: PyBytesInner, to: PyBytesInner, vm: &VirtualMachine) -> PyResult<Vec<u8>> {
-        PyBytesInner::maketrans(from, to, vm)
+    fn maketrans(frm: PyBytesInner, to: PyBytesInner, vm: &VirtualMachine) -> PyResult<Vec<u8>> {
+        PyBytesInner::maketrans(frm, to, vm)
     }
 
     #[pymethod]

--- a/crates/vm/src/builtins/bytes.rs
+++ b/crates/vm/src/builtins/bytes.rs
@@ -250,8 +250,8 @@ impl PyBytes {
     }
 
     #[pystaticmethod]
-    fn maketrans(from: PyBytesInner, to: PyBytesInner, vm: &VirtualMachine) -> PyResult<Vec<u8>> {
-        PyBytesInner::maketrans(from, to, vm)
+    fn maketrans(frm: PyBytesInner, to: PyBytesInner, vm: &VirtualMachine) -> PyResult<Vec<u8>> {
+        PyBytesInner::maketrans(frm, to, vm)
     }
 
     fn __getitem__(&self, needle: PyObjectRef, vm: &VirtualMachine) -> PyResult {


### PR DESCRIPTION
- [x] Related #8383
- [x] This PR follows our [AI policy](https://github.com/RustPython/.github/blob/main/AI_POLICY.md)

## Summary

`inspect.signature()` raises `ValueError: builtin has invalid signature` for 99 method descriptors, because it parses `__text_signature__` as Python source and two generated strings are not valid Python. Two unrelated causes, one commit each.

**`Callee` was reported as a parameter.** The interpreter supplies it the way it supplies `vm`, but only `vm` was filtered:

```
>>> object.__getstate__.__text_signature__
'(*args, **kwargs, callee)'          # a parameter cannot follow **kwargs
```

`object.__getstate__` is the only `#[pymethod]` taking one today, and 95 types inherit it. `infer_native_call_flags` counted it as a fixed positional argument too, which `FuncArgs` happens to short-circuit today, so the call flags were right by accident.

**`maketrans` named its first parameter `from`,** a Python keyword. Argument Clinic spells it `frm` for the same reason, so `bytes.maketrans` and `bytearray.maketrans` now report `(frm, to, /)`, which is what CPython reports. Both parameters are positional-only, so the name is documentation only.

## Notes

- The first is a regression from #8630, which added the `Callee` argument.
- Of the 1409 methods and classmethods on the builtin types, only these 97 descriptors report a different signature. The builtin, module-function and `__doc__` counts are unchanged.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected native call signature and flag handling for functions that receive interpreter-supplied callee arguments.

* **Refactor**
  * Updated internal parameter naming for byte and bytearray translation methods without changing their behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->