### PR TITLE
ssl: honor hostname_checks_common_name and tls-unique

### DIFF
--- a/crates/host_env/src/ssl/config.rs
+++ b/crates/host_env/src/ssl/config.rs
@@ -68,6 +68,8 @@ pub struct ClientConfigOptions {
     pub verify_server_cert: bool,
     /// Whether to check hostname against certificate (check_hostname)
     pub check_hostname: bool,
+    /// When true, a certificate with no SAN may still match via Common Name.
+    pub check_common_name: bool,
     /// SSL verification flags (e.g., VERIFY_X509_STRICT)
     pub verify_flags: i32,
     /// Session store for client-side session resumption
@@ -244,6 +246,7 @@ fn apply_verifier_wrappers(
     verify_flags: i32,
     has_crls: bool,
     ca_certs_der: Vec<Vec<u8>>,
+    check_common_name: bool,
 ) -> Arc<dyn rustls::client::danger::ServerCertVerifier> {
     let crl_check_requested = verify_flags & X509_V_FLAG_CRL_CHECK != 0;
 
@@ -268,6 +271,7 @@ fn apply_verifier_wrappers(
             verifier,
             ca_certs_der,
             verify_flags,
+            check_common_name,
         ))
     } else {
         verifier
@@ -356,12 +360,19 @@ pub fn create_client_config(options: ClientConfigOptions) -> Result<chain::Clien
                 )?;
 
                 // Apply CRL and Strict verifier wrappers using helper function
-                apply_verifier_wrappers(
+                let verifier = apply_verifier_wrappers(
                     base_verifier,
                     options.verify_flags,
                     has_crls,
                     options.ca_certs_der.clone(),
-                )
+                    options.check_common_name,
+                );
+                if options.check_common_name {
+                    use super::verify::CommonNameFallbackVerifier;
+                    Arc::new(CommonNameFallbackVerifier::new(verifier))
+                } else {
+                    verifier
+                }
             } else {
                 // check_hostname=False: verify certificate chain but ignore hostname
                 use super::verify::HostnameIgnoringVerifier;
@@ -393,6 +404,7 @@ pub fn create_client_config(options: ClientConfigOptions) -> Result<chain::Clien
                         verifier,
                         options.ca_certs_der.clone(),
                         options.verify_flags,
+                        options.check_common_name,
                     )) as Arc<dyn rustls::client::danger::ServerCertVerifier>
                 } else {
                     verifier

--- a/crates/host_env/src/ssl/constants.rs
+++ b/crates/host_env/src/ssl/constants.rs
@@ -20,6 +20,10 @@ pub const VERIFY_ALLOW_PROXY_CERTS: i32 = 64;
 pub const VERIFY_X509_TRUSTED_FIRST: i32 = 32768;
 pub const VERIFY_X509_PARTIAL_CHAIN: i32 = 0x80000;
 
+/// `X509_CHECK_FLAG_NEVER_CHECK_SUBJECT`. When set, hostname checks
+/// use SAN only and never fall back to the certificate Common Name.
+pub const HOSTFLAG_NEVER_CHECK_SUBJECT: i32 = 0x20;
+
 pub const PROTO_TLSV1_2: i32 = 0x0303;
 pub const PROTO_TLSV1_3: i32 = 0x0304;
 pub const OP_NO_TLSV1_2: i32 = 0x0800_0000;

--- a/crates/host_env/src/ssl/verify.rs
+++ b/crates/host_env/src/ssl/verify.rs
@@ -1173,6 +1173,7 @@ pub struct PartialChainVerifier {
     inner: Arc<dyn ServerCertVerifier>,
     ca_certs_der: Vec<Vec<u8>>,
     verify_flags: i32,
+    check_common_name: bool,
 }
 
 impl PartialChainVerifier {
@@ -1180,11 +1181,13 @@ impl PartialChainVerifier {
         inner: Arc<dyn ServerCertVerifier>,
         ca_certs_der: Vec<Vec<u8>>,
         verify_flags: i32,
+        check_common_name: bool,
     ) -> Self {
         Self {
             inner,
             ca_certs_der,
             verify_flags,
+            check_common_name,
         }
     }
 }
@@ -1227,7 +1230,7 @@ impl ServerCertVerifier for PartialChainVerifier {
                     // Non-self-signed: require VERIFY_X509_PARTIAL_CHAIN flag
                     if is_self_signed_cert || (self.verify_flags & VERIFY_X509_PARTIAL_CHAIN != 0) {
                         // Certificate is trusted, but still perform hostname verification
-                        verify_hostname(end_entity, server_name)?;
+                        verify_hostname(end_entity, server_name, self.check_common_name)?;
                         return Ok(ServerCertVerified::assertion());
                     }
                 }
@@ -1278,11 +1281,93 @@ fn is_self_signed(cert_der: &CertificateDer<'_>) -> bool {
     cert.issuer() == cert.subject()
 }
 
+/// True when the certificate advertises at least one dNSName SAN.
+fn cert_has_dns_san(cert: &X509Certificate<'_>) -> bool {
+    use x509_parser::extensions::GeneralName;
+    cert.subject_alternative_name()
+        .ok()
+        .flatten()
+        .is_some_and(|san| {
+            san.value
+                .general_names
+                .iter()
+                .any(|name| matches!(name, GeneralName::DNSName(_)))
+        })
+}
+
+/// rustls checks SAN only. When no dNSName SAN is present and CN matching
+/// is enabled, accept a Common Name that matches the requested hostname.
+#[derive(Debug)]
+pub struct CommonNameFallbackVerifier {
+    inner: Arc<dyn ServerCertVerifier>,
+}
+
+impl CommonNameFallbackVerifier {
+    pub fn new(inner: Arc<dyn ServerCertVerifier>) -> Self {
+        Self { inner }
+    }
+}
+
+impl ServerCertVerifier for CommonNameFallbackVerifier {
+    fn verify_server_cert(
+        &self,
+        end_entity: &CertificateDer<'_>,
+        intermediates: &[CertificateDer<'_>],
+        server_name: &ServerName<'_>,
+        ocsp_response: &[u8],
+        now: UnixTime,
+    ) -> Result<ServerCertVerified, rustls::Error> {
+        match self.inner.verify_server_cert(
+            end_entity,
+            intermediates,
+            server_name,
+            ocsp_response,
+            now,
+        ) {
+            Ok(verified) => Ok(verified),
+            Err(
+                e @ rustls::Error::InvalidCertificate(
+                    rustls::CertificateError::NotValidForName
+                    | rustls::CertificateError::NotValidForNameContext { .. },
+                ),
+            ) => {
+                verify_hostname(end_entity, server_name, true).map_err(|_| e)?;
+                Ok(ServerCertVerified::assertion())
+            }
+            Err(error) => Err(error),
+        }
+    }
+
+    fn verify_tls12_signature(
+        &self,
+        message: &[u8],
+        cert: &CertificateDer<'_>,
+        dss: &DigitallySignedStruct,
+    ) -> Result<HandshakeSignatureValid, rustls::Error> {
+        self.inner.verify_tls12_signature(message, cert, dss)
+    }
+
+    fn verify_tls13_signature(
+        &self,
+        message: &[u8],
+        cert: &CertificateDer<'_>,
+        dss: &DigitallySignedStruct,
+    ) -> Result<HandshakeSignatureValid, rustls::Error> {
+        self.inner.verify_tls13_signature(message, cert, dss)
+    }
+
+    fn supported_verify_schemes(&self) -> Vec<SignatureScheme> {
+        self.inner.supported_verify_schemes()
+    }
+}
+
 /// Verify that a certificate is valid for the given hostname/IP address.
-/// This function checks Subject Alternative Names (SAN) and Common Name (CN).
+/// SAN dNSName entries take precedence. Common Name is used only when
+/// `check_common_name` is set and the certificate has no dNSName SAN.
 fn verify_hostname(
     cert_der: &CertificateDer<'_>,
     server_name: &ServerName<'_>,
+    check_common_name: bool,
 ) -> Result<(), rustls::Error> {
     use x509_parser::extensions::GeneralName;
     use x509_parser::prelude::*;
@@ -1297,31 +1382,31 @@ fn verify_hostname(
     match server_name {
         ServerName::DnsName(dns) => {
             let expected_name = dns.as_ref();
+            let has_dns_san = cert_has_dns_san(&cert);
 
-            // 1. Check Subject Alternative Names (SAN) - preferred method
-            if let Ok(Some(san_ext)) = cert.subject_alternative_name() {
-                for name in &san_ext.value.general_names {
-                    if let GeneralName::DNSName(dns_name) = name
-                        && hostname_matches(expected_name, dns_name)
-                    {
-                        return Ok(());
+            if has_dns_san {
+                if let Ok(Some(san_ext)) = cert.subject_alternative_name() {
+                    for name in &san_ext.value.general_names {
+                        if let GeneralName::DNSName(dns_name) = name
+                            && hostname_matches(expected_name, dns_name)
+                        {
+                            return Ok(());
+                        }
+                    }
+                }
+            } else if check_common_name {
+                for rdn in cert.subject().iter() {
+                    for attr in rdn.iter() {
+                        if attr.attr_type() == &x509_parser::oid_registry::OID_X509_COMMON_NAME
+                            && let Ok(cn) = attr.attr_value().as_str()
+                            && hostname_matches(expected_name, cn)
+                        {
+                            return Ok(());
+                        }
                     }
                 }
             }
 
-            // 2. Fallback to Common Name (CN) - deprecated but still checked for compatibility
-            for rdn in cert.subject().iter() {
-                for attr in rdn.iter() {
-                    if attr.attr_type() == &x509_parser::oid_registry::OID_X509_COMMON_NAME
-                        && let Ok(cn) = attr.attr_value().as_str()
-                        && hostname_matches(expected_name, cn)
-                    {
-                        return Ok(());
-                    }
-                }
-            }
-
-            // No match found - return error
             Err(cert_error::to_rustls_invalid_cert(format!(
                 "Hostname mismatch: certificate is not valid for '{expected_name}'",
             )))

--- a/crates/stdlib/src/ssl.rs
+++ b/crates/stdlib/src/ssl.rs
@@ -206,6 +206,9 @@ mod _ssl {
     #[pyattr]
     pub(crate) const VERIFY_X509_PARTIAL_CHAIN: i32 =
         rustpython_host_env::ssl::VERIFY_X509_PARTIAL_CHAIN;
+    #[pyattr]
+    const HOSTFLAG_NEVER_CHECK_SUBJECT: i32 =
+        rustpython_host_env::ssl::HOSTFLAG_NEVER_CHECK_SUBJECT;
 
     // Options (OpenSSL-compatible flags, mostly no-op in rustls)
     #[pyattr]
@@ -332,7 +335,7 @@ mod _ssl {
     #[pyattr]
     const HAS_SNI: bool = true;
     #[pyattr]
-    const HAS_TLS_UNIQUE: bool = false; // Not supported
+    const HAS_TLS_UNIQUE: bool = true;
     #[pyattr]
     const HAS_ECDH: bool = true;
     #[pyattr]
@@ -394,6 +397,8 @@ mod _ssl {
         protocol: i32,
         #[pytraverse(skip)]
         check_hostname: PyRwLock<bool>,
+        #[pytraverse(skip)]
+        host_flags: PyRwLock<i32>,
         #[pytraverse(skip)]
         verify_mode: PyRwLock<i32>,
         #[pytraverse(skip)]
@@ -630,6 +635,16 @@ mod _ssl {
                     *self.verify_mode.write() = CERT_REQUIRED;
                 }
             }
+        }
+
+        #[pygetset]
+        fn _host_flags(&self) -> i32 {
+            *self.host_flags.read()
+        }
+
+        #[pygetset(setter)]
+        fn set__host_flags(&self, value: i32) {
+            *self.host_flags.write() = value;
         }
 
         #[pygetset]
@@ -2017,6 +2032,7 @@ mod _ssl {
                 context_identity: Arc::new(()),
                 protocol,
                 check_hostname: PyRwLock::new(protocol == PROTOCOL_TLS_CLIENT),
+                host_flags: PyRwLock::new(0),
                 verify_mode: PyRwLock::new(default_verify_mode),
                 verify_flags: PyRwLock::new(default_verify_flags),
                 server_config: PyRwLock::new(None),
@@ -3037,6 +3053,8 @@ mod _ssl {
                     drop(cert_keys_guard);
 
                     let check_hostname = *ctx.check_hostname.read();
+                    let check_common_name =
+                        *ctx.host_flags.read() & HOSTFLAG_NEVER_CHECK_SUBJECT == 0;
                     let verify_flags = *ctx.verify_flags.read();
                     let context_identity = ctx.context_identity.clone();
 
@@ -3101,6 +3119,7 @@ mod _ssl {
                             private_key: private_key_opt,
                             verify_server_cert: verify_mode != CERT_NONE,
                             check_hostname,
+                            check_common_name,
                             verify_flags,
                             session_store: Some(session_store.clone()),
                             crls: crls_clone,


### PR DESCRIPTION
Expose `HOSTFLAG_NEVER_CHECK_SUBJECT` and `_host_flags` so `ssl.py` can
turn off Common Name fallback (`hostname_checks_common_name = False`).
SAN names still win when present. `HAS_TLS_UNIQUE` is now true to match
the TLS 1.2 channel binding we already implement.

### Verified

- `cargo clippy -p rustpython-host_env --features ssl --all-targets -- -D warnings`
- `cargo clippy -p rustpython-stdlib -- -D warnings`
- `cargo test -p rustpython-host_env --features ssl --lib -- ssl` (38 passed)
- `cargo run --release -- -m test test_ssl` — 196 run, 37 skip, SUCCESS

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added TLS certificate hostname verification controls, allowing connections to use the certificate Common Name when no DNS Subject Alternative Name is present.
  * Added a host flag to explicitly require hostname checks to use Subject Alternative Names only.
  * Added support for retrieving `tls-unique` channel binding data from secure connections.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->