### PR TITLE
sqlite3: fix iterdump import and filter support

### DIFF
--- a/Lib/test/test_sqlite3/test_dump.py
+++ b/Lib/test/test_sqlite3/test_dump.py
@@ -9,7 +9,6 @@ from .util import requires_virtual_table
 
 class DumpTests(MemoryDatabaseMixin, unittest.TestCase):
 
-    @unittest.expectedFailure  # TODO: RUSTPYTHON
     def test_table_dump(self):
         expected_sqls = [
                 "PRAGMA foreign_keys=OFF;",
@@ -57,7 +56,6 @@ class DumpTests(MemoryDatabaseMixin, unittest.TestCase):
         [self.assertEqual(expected_sqls[i], actual_sqls[i])
             for i in range(len(expected_sqls))]
 
-    @unittest.expectedFailure  # TODO: RUSTPYTHON; iterdump filter parameter not implemented
     def test_table_dump_filter(self):
         all_table_sqls = [
             """CREATE TABLE "some_table_2" ("id_1" INTEGER);""",
@@ -128,7 +126,6 @@ class DumpTests(MemoryDatabaseMixin, unittest.TestCase):
             ["BEGIN TRANSACTION;", *all_table_sqls, *all_views_sqls, "COMMIT;"],
         )
 
-    @unittest.expectedFailure  # TODO: RUSTPYTHON; _iterdump not implemented
     def test_dump_autoincrement(self):
         expected = [
             'CREATE TABLE "t1" (id integer primary key autoincrement);',
@@ -149,7 +146,6 @@ class DumpTests(MemoryDatabaseMixin, unittest.TestCase):
         actual = [stmt for stmt in self.cx.iterdump()]
         self.assertEqual(expected, actual)
 
-    @unittest.expectedFailure  # TODO: RUSTPYTHON; _iterdump not implemented
     def test_dump_autoincrement_create_new_db(self):
         self.cu.execute("BEGIN TRANSACTION")
         self.cu.execute("CREATE TABLE t1 (id integer primary key autoincrement)")
@@ -175,7 +171,6 @@ class DumpTests(MemoryDatabaseMixin, unittest.TestCase):
                     rows = res.fetchall()
                     self.assertEqual(rows[0][0], seq)
 
-    @unittest.expectedFailure  # TODO: RUSTPYTHON; _iterdump not implemented
     def test_unorderable_row(self):
         # iterdump() should be able to cope with unorderable row types (issue #15545)
         class UnorderableRow:
@@ -197,7 +192,6 @@ class DumpTests(MemoryDatabaseMixin, unittest.TestCase):
         got = list(self.cx.iterdump())
         self.assertEqual(expected, got)
 
-    @unittest.expectedFailure  # TODO: RUSTPYTHON; _iterdump not implemented
     def test_dump_custom_row_factory(self):
         # gh-118221: iterdump should be able to cope with custom row factories.
         def dict_factory(cu, row):
@@ -213,7 +207,6 @@ class DumpTests(MemoryDatabaseMixin, unittest.TestCase):
         self.assertEqual(expected, actual)
         self.assertEqual(self.cx.row_factory, dict_factory)
 
-    @unittest.expectedFailure  # TODO: RUSTPYTHON; _iterdump not implemented
     @requires_virtual_table("fts4")
     def test_dump_virtual_tables(self):
         # gh-64662

--- a/crates/stdlib/src/_sqlite3.rs
+++ b/crates/stdlib/src/_sqlite3.rs
@@ -62,7 +62,7 @@ mod _sqlite3 {
         },
         convert::IntoObject,
         function::{
-            ArgCallable, ArgIterable, FsPath, FuncArgs, OptionalArg, PyComparisonValue,
+            ArgCallable, ArgIterable, FsPath, FuncArgs, KwArgs, OptionalArg, PyComparisonValue,
             PySetterValue, TimeoutSeconds,
         },
         object::{Traverse, TraverseFn},
@@ -403,6 +403,12 @@ mod _sqlite3 {
             self.progress.traverse(tracer_fn);
             self.name.traverse(tracer_fn);
         }
+    }
+
+    #[derive(FromArgs)]
+    struct IterDumpArgs {
+        #[pyarg(named, optional)]
+        filter: Option<PyStrRef>,
     }
 
     #[derive(FromArgs)]
@@ -1507,10 +1513,15 @@ mod _sqlite3 {
         }
 
         #[pymethod]
-        fn iterdump(zelf: PyRef<Self>, vm: &VirtualMachine) -> PyResult {
-            let module = vm.import("sqlite3.dump", 0)?;
+        fn iterdump(zelf: PyRef<Self>, args: IterDumpArgs, vm: &VirtualMachine) -> PyResult {
+            let from_list = PyTuple::new_ref_typed(vec![vm.ctx.new_str("_iterdump")], &vm.ctx);
+            let module = vm.import_from("sqlite3.dump", &from_list, 0)?;
             let func = module.get_attr("_iterdump", vm)?;
-            func.call((zelf,), vm)
+            let filter: PyObjectRef = args
+                .filter
+                .map_or_else(|| vm.ctx.none(), |filter| filter.into());
+            let kwargs = std::iter::once(("filter", filter)).collect::<KwArgs>();
+            func.call(FuncArgs::new(vec![zelf.into()], kwargs), vm)
         }
 
         #[pymethod]


### PR DESCRIPTION
Assisted-by: GitHub Copilot:GPT-5.6 Luna (high)<!--
Thanks for your contribution!
-->

- [ ] Closes #xxxx <!-- Replace xxxx with the GitHub issue number if exists -->

One of checkbox below must be checked.
- [ ] I did not use AI to write the code of this patch.
- [x] This PR follows our [AI policy](https://github.com/RustPython/.github/blob/main/AI_POLICY.md)

## Summary
<!-- What's the purpose of the change? What does it do, and why? -->
CPython ref: https://github.com/python/cpython/blob/31e1476cc301e320c82677ed5a9b4835515cc298/Modules/_sqlite/connection.c#L2134


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an optional `filter` keyword argument to `Connection.iterdump()`.
  * Database dumps can now be limited to matching objects.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->