### PR TITLE
sqlite3: fix row_factory deletion error

### DIFF
--- a/Lib/test/test_sqlite3/test_factory.py
+++ b/Lib/test/test_sqlite3/test_factory.py
@@ -159,7 +159,6 @@ class RowFactoryTests(MemoryDatabaseMixin, unittest.TestCase):
         with self.assertRaises(IndexError):
             row[complex()]  # index must be int or string
 
-    @unittest.expectedFailure  # TODO: RUSTPYTHON; TypeError: can't delete attribute
     def test_delete_connection_row_factory(self):
         # gh-149738: deleting row_factory should raise an exception
         with self.assertRaises(AttributeError):

--- a/crates/stdlib/src/_sqlite3.rs
+++ b/crates/stdlib/src/_sqlite3.rs
@@ -1661,8 +1661,20 @@ mod _sqlite3 {
             self.row_factory.to_owned()
         }
         #[pygetset(setter)]
-        fn set_row_factory(&self, val: Option<PyObjectRef>) {
-            let _ = unsafe { self.row_factory.swap(val) };
+        fn set_row_factory(
+            &self,
+            val: PySetterValue<Option<PyObjectRef>>,
+            vm: &VirtualMachine,
+        ) -> PyResult<()> {
+            match val {
+                PySetterValue::Assign(val) => {
+                    let _ = unsafe { self.row_factory.swap(val) };
+                    Ok(())
+                }
+                PySetterValue::Delete => {
+                    Err(vm.new_attribute_error("cannot delete row_factory attribute"))
+                }
+            }
         }
 
         fn check_thread(&self, vm: &VirtualMachine) -> PyResult<()> {


### PR DESCRIPTION
Match CPython 3.14 by distinguishing row_factory assignment from deletion and raising AttributeError with the compatible message. Unmark the passing row_factory deletion test.

Assisted-by: GitHub Copilot:GPT-5.6 Luna (high)

<!--
Thanks for your contribution!
-->

- [ ] Closes #xxxx <!-- Replace xxxx with the GitHub issue number if exists -->

One of checkbox below must be checked.
- [ ] I did not use AI to write the code of this patch.
- [x] This PR follows our [AI policy](https://github.com/RustPython/.github/blob/main/AI_POLICY.md)

## Summary
<!-- What's the purpose of the change? What does it do, and why? -->
CPython ref: https://github.com/python/cpython/blob/31e1476cc301e320c82677ed5a9b4835515cc298/Modules/_sqlite/connection.c#L591-L602


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved `Connection.row_factory` attribute handling.
  - Assigning a value or `None` continues to work as expected.
  - Attempting to delete the attribute now raises an `AttributeError` instead of silently resetting it.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->