### PR TITLE
Classify continuable unclosed strings as incomplete

### DIFF
--- a/.cspell.dict/cpython.txt
+++ b/.cspell.dict/cpython.txt
@@ -139,6 +139,7 @@ Lshift
 lslpp
 lsprof
 MAXBLOCKS
+MAXFSTRINGLEVEL
 maxdepth
 mbiencoder
 mbstreamreader

--- a/Lib/test/test_codeop.py
+++ b/Lib/test/test_codeop.py
@@ -113,7 +113,6 @@ class CodeopTests(unittest.TestCase):
         av("def f():\n pass\n#foo\n")
         av("@a.b.c\ndef f():\n pass\n")
 
-    @unittest.expectedFailure  # TODO: RUSTPYTHON; AssertionError: <code object <module> at 0xc99532080 file "<input>", line 1> != None
     @subTests('compiler', COMPILERS)
     def test_incomplete(self, compiler):
         ai = functools.partial(self.assertIncomplete, compiler=compiler)

--- a/Lib/test/test_fstring.py
+++ b/Lib/test/test_fstring.py
@@ -1073,7 +1073,6 @@ x = (
         self.assertEqual(rf'''{3+
 4}''', '7')
 
-    @unittest.expectedFailure  # TODO: RUSTPYTHON; AssertionError: "f-string: expecting a valid expression after '{'" does not match "invalid syntax (<string>, line 1)"
     def test_lambda(self):
         x = 5
         self.assertEqual(f'{(lambda y:x*y)("8")!r}', "'88888'")

--- a/Lib/test/test_fstring.py
+++ b/Lib/test/test_fstring.py
@@ -630,7 +630,6 @@ x = (
                             ])
         self.assertRaises(SyntaxError, eval, "f'{" + "("*20 + "}'")
 
-    @unittest.expectedFailure  # TODO: RUSTPYTHON; AssertionError: No exception raised
     @unittest.skipIf(support.is_wasi, "exhausts limited stack on WASI")
     def test_fstring_nested_too_deeply(self):
         def raises_syntax_or_memory_error(txt):
@@ -1004,7 +1003,6 @@ x = (
         self.assertEqual(fr'\N{AMPERSAND}', '\\Nspam')
         self.assertEqual(f'\\\N{AMPERSAND}', '\\&')
 
-    @unittest.expectedFailure  # TODO: RUSTPYTHON
     def test_misformed_unicode_character_name(self):
         # These test are needed because unicode names are parsed
         # differently inside f-strings.
@@ -1283,7 +1281,6 @@ x = (
         self.assertEqual(f'{f"{0}"*3}', '000')
         self.assertEqual(f'{f"{y}"*3}', '555')
 
-    @unittest.expectedFailure  # TODO: RUSTPYTHON
     def test_invalid_string_prefixes(self):
         single_quote_cases = ["fu''",
                              "uf''",
@@ -1728,7 +1725,6 @@ x = (
                                     "f-string: expecting a valid expression after '{'"):
             compile("f'{**a}'", "?", "exec")
 
-    @unittest.expectedFailure  # TODO: RUSTPYTHON; -
     def test_not_closing_quotes(self):
         self.assertAllRaise(SyntaxError, "unterminated f-string literal", ['f"', "f'"])
         self.assertAllRaise(SyntaxError, "unterminated triple-quoted f-string literal",

--- a/crates/compiler/src/lib.rs
+++ b/crates/compiler/src/lib.rs
@@ -35,6 +35,8 @@ pub struct ParseError {
     pub source_path: String,
     /// Set when the error is an unclosed bracket (converted from EOF).
     pub is_unclosed_bracket: bool,
+    /// Set when a string is still open at EOF and more input could close it.
+    pub is_unclosed_string: bool,
 }
 
 impl ::core::fmt::Display for ParseError {
@@ -71,6 +73,7 @@ impl CompileError {
             end_location: diagnostic.end_location,
             source_path: source_file.name().to_owned(),
             is_unclosed_bracket: diagnostic.is_unclosed_bracket,
+            is_unclosed_string: diagnostic.is_unclosed_string,
         })
     }
 
@@ -87,6 +90,7 @@ impl CompileError {
             end_location,
             source_path: source_file.name().to_owned(),
             is_unclosed_bracket: false,
+            is_unclosed_string: diagnostic.is_unclosed_string,
         })
     }
 
@@ -160,6 +164,7 @@ struct NormalizedParseDiagnostic {
     location: SourceLocation,
     end_location: SourceLocation,
     is_unclosed_bracket: bool,
+    is_unclosed_string: bool,
 }
 
 impl NormalizedParseDiagnostic {
@@ -173,6 +178,7 @@ impl NormalizedParseDiagnostic {
             location,
             end_location,
             is_unclosed_bracket: false,
+            is_unclosed_string: false,
         }
     }
 
@@ -182,11 +188,13 @@ impl NormalizedParseDiagnostic {
             diagnostic.range.start(),
             diagnostic.range.end(),
         );
-        Self::new(
+        let mut diagnostic_out = Self::new(
             parser::ParseErrorType::OtherError(diagnostic.message),
             location,
             end_location,
-        )
+        );
+        diagnostic_out.is_unclosed_string = diagnostic.is_unclosed_string;
+        diagnostic_out
     }
 
     const fn with_unclosed_bracket(mut self, is_unclosed_bracket: bool) -> Self {
@@ -202,6 +210,7 @@ impl NormalizedParseDiagnostic {
 struct CpythonDiagnostic {
     message: String,
     range: ruff_text_size::TextRange,
+    is_unclosed_string: bool,
 }
 
 impl CpythonDiagnostic {
@@ -216,7 +225,13 @@ impl CpythonDiagnostic {
                 TextSize::new(start as u32),
                 TextSize::new(end as u32),
             ),
+            is_unclosed_string: false,
         }
+    }
+
+    const fn with_unclosed_string(mut self) -> Self {
+        self.is_unclosed_string = true;
+        self
     }
 }
 
@@ -1578,7 +1593,7 @@ fn invalid_parameter_list_slice_error(
                         name_end,
                     ));
                 }
-                index = name_end;
+                index = param_end;
             }
             b'(' if level == 0 => {
                 let close = matching_delimiter(bytes, index, b')')
@@ -3920,7 +3935,7 @@ fn unterminated_string_error(source: &str) -> Option<CpythonDiagnostic> {
                         return Some(error);
                     }
                     let detected_line = if quote_size == 3 { line } else { start_line };
-                    return Some(CpythonDiagnostic::new(
+                    let diagnostic = CpythonDiagnostic::new(
                         unterminated_string_message(
                             detected_line,
                             quote_size == 3,
@@ -3929,7 +3944,12 @@ fn unterminated_string_error(source: &str) -> Option<CpythonDiagnostic> {
                         ),
                         start,
                         start,
-                    ));
+                    );
+                    return Some(if index >= bytes.len() {
+                        diagnostic.with_unclosed_string()
+                    } else {
+                        diagnostic
+                    });
                 }
             }
             _ => index += 1,
@@ -4446,6 +4466,16 @@ fn replacement_field_error(
         ));
     }
 
+    if let Some(lambda_at) = top_level_lambda(bytes, expr_start, expr_end)
+        && lambda_allowed_at_expression_position(bytes, expr_start, lambda_at)
+    {
+        return Some(CpythonDiagnostic::new(
+            format!("{prefix}: lambda expressions are not allowed without parentheses"),
+            lambda_at,
+            lambda_at + b"lambda".len(),
+        ));
+    }
+
     if bytes[separator] == b':'
         && replacement_expression_has_parse_error(bytes, expr_start, separator)
     {
@@ -4516,6 +4546,65 @@ fn unterminated_string_in_replacement_field(
     None
 }
 
+fn top_level_lambda(bytes: &[u8], mut index: usize, end: usize) -> Option<usize> {
+    let mut level = 0usize;
+    while index < end {
+        match bytes[index] {
+            b'\'' | b'"' => index = skip_quoted_string(bytes, index),
+            b'#' => index = skip_replacement_field_comment(bytes, index, end),
+            b'(' | b'[' | b'{' => {
+                level += 1;
+                index += 1;
+            }
+            b')' | b']' | b'}' if level > 0 => {
+                level -= 1;
+                index += 1;
+            }
+            _ if level == 0 && starts_identifier(bytes, index, b"lambda") => {
+                return Some(index);
+            }
+            _ => index += 1,
+        }
+    }
+    None
+}
+
+/// Unparenthesized `lambda` is allowed in the same places a `lambdef` can appear:
+/// at the start of the field or after a top-level comma.
+fn lambda_allowed_at_expression_position(bytes: &[u8], mut index: usize, lambda_at: usize) -> bool {
+    let mut after_comma = true;
+    let mut level = 0usize;
+    while index < lambda_at {
+        match bytes[index] {
+            b'\'' | b'"' => {
+                after_comma = false;
+                index = skip_quoted_string(bytes, index);
+            }
+            b'#' => index = skip_replacement_field_comment(bytes, index, lambda_at),
+            b'(' | b'[' | b'{' => {
+                level += 1;
+                after_comma = false;
+                index += 1;
+            }
+            b')' | b']' | b'}' if level > 0 => {
+                level -= 1;
+                after_comma = false;
+                index += 1;
+            }
+            b',' if level == 0 => {
+                after_comma = true;
+                index += 1;
+            }
+            b' ' | b'\t' | b'\n' | b'\r' | b'\x0c' => index += 1,
+            _ => {
+                after_comma = false;
+                index += 1;
+            }
+        }
+    }
+    after_comma
+}
+
 fn replacement_expression_has_parse_error(bytes: &[u8], start: usize, end: usize) -> bool {
     let Ok(expression) = ::core::str::from_utf8(&bytes[start..end]) else {
         return false;
@@ -4549,6 +4638,9 @@ fn invalid_replacement_expression_start(bytes: &[u8], index: usize, end: usize) 
 
     if matches!(bytes[index], b'+' | b'-' | b'~') {
         let operand = skip_ascii_whitespace(bytes, index + 1, end);
+        if starts_identifier(bytes, operand, b"lambda") {
+            return true;
+        }
         return !bytes.get(operand).is_some_and(|byte| {
             *byte >= 0x80
                 || *byte == b'_'
@@ -6566,6 +6658,18 @@ mod tests {
             ),
             ("f'{=a}'", "f-string: valid expression required before '='"),
             ("f'{!}'", "f-string: valid expression required before '!'"),
+            (
+                "f'{lambda x:x}'",
+                "f-string: lambda expressions are not allowed without parentheses",
+            ),
+            (
+                "f'{1, lambda:x}'",
+                "f-string: lambda expressions are not allowed without parentheses",
+            ),
+            (
+                "f'{+ lambda:None}'",
+                "f-string: expecting a valid expression after '{'",
+            ),
         ] {
             let err = compile(source, Mode::Eval, "<interp>", CompileOpts::default())
                 .expect_err("should not compile");

--- a/crates/compiler/src/lib.rs
+++ b/crates/compiler/src/lib.rs
@@ -252,6 +252,8 @@ fn cpython_parse_diagnostic_override(
 
     source_error!(invalid_number_literal_error(source_text));
     source_error!(invalid_legacy_statement_error(source_text));
+    source_error!(incompatible_string_prefix_error(source_text));
+    source_error!(malformed_unicode_n_escape_error(source_text));
     source_error!(non_printable_character_error(source_text));
     source_error!(invalid_interpolated_string_error(source_text));
     source_error!(mixed_tstring_literal_error(error, source_text));
@@ -778,6 +780,20 @@ fn number_literal_end(bytes: &[u8], start: usize) -> Option<(&'static str, usize
         return Some(("imaginary", index + 1));
     }
     Some(("decimal", index))
+}
+
+fn quoted_string_is_closed(bytes: &[u8], start: usize) -> bool {
+    let quote = bytes[start];
+    let triple = bytes.get(start + 1) == Some(&quote) && bytes.get(start + 2) == Some(&quote);
+    let end = skip_quoted_string(bytes, start);
+    if triple {
+        end >= start + 6
+            && bytes[end - 3] == quote
+            && bytes[end - 2] == quote
+            && bytes[end - 1] == quote
+    } else {
+        end > start + 1 && bytes[end - 1] == quote
+    }
 }
 
 fn skip_quoted_string(bytes: &[u8], mut index: usize) -> usize {
@@ -4143,6 +4159,98 @@ fn interpolated_string_prefix(bytes: &[u8], quote: usize) -> Option<&'static str
     })
 }
 
+const MAXFSTRINGLEVEL: usize = 150;
+
+fn skip_string_token(bytes: &[u8], quote_index: usize) -> usize {
+    if interpolated_string_prefix(bytes, quote_index).is_some() {
+        interpolated_string_end(bytes, quote_index).unwrap_or(bytes.len())
+    } else {
+        skip_quoted_string(bytes, quote_index)
+    }
+}
+
+fn interpolated_string_end(bytes: &[u8], quote_index: usize) -> Option<usize> {
+    let quote = bytes[quote_index];
+    let triple =
+        bytes.get(quote_index + 1) == Some(&quote) && bytes.get(quote_index + 2) == Some(&quote);
+    let quote_len = if triple { 3 } else { 1 };
+    let mut index = quote_index + quote_len;
+    let mut brace_depth = 0usize;
+    while index < bytes.len() {
+        if brace_depth == 0 {
+            if bytes[index] == b'\\' {
+                index = (index + 2).min(bytes.len());
+                continue;
+            }
+            if triple
+                && bytes.get(index) == Some(&quote)
+                && bytes.get(index + 1) == Some(&quote)
+                && bytes.get(index + 2) == Some(&quote)
+            {
+                return Some(index + 3);
+            }
+            if !triple && bytes[index] == quote {
+                return Some(index + 1);
+            }
+            if bytes[index] == b'{' {
+                if bytes.get(index + 1) == Some(&b'{') {
+                    index += 2;
+                } else {
+                    brace_depth = 1;
+                    index += 1;
+                }
+            } else if bytes[index] == b'}' && bytes.get(index + 1) == Some(&b'}') {
+                index += 2;
+            } else {
+                index += 1;
+            }
+        } else {
+            match bytes[index] {
+                quote_ch @ (b'\'' | b'"') => {
+                    if quoted_string_is_closed(bytes, index) {
+                        index = skip_string_token(bytes, index).max(index + 1);
+                    } else if !triple && quote_ch == quote {
+                        return Some(index + 1);
+                    } else {
+                        index = skip_string_token(bytes, index).max(index + 1);
+                    }
+                }
+                b'#' => {
+                    while index < bytes.len() && bytes[index] != b'\n' {
+                        index += 1;
+                    }
+                }
+                b'{' => {
+                    brace_depth += 1;
+                    index += 1;
+                }
+                b'}' => {
+                    brace_depth -= 1;
+                    index += 1;
+                }
+                b'\\' => index = (index + 2).min(bytes.len()),
+                _ => index += 1,
+            }
+        }
+    }
+    None
+}
+
+fn quote_len_at(bytes: &[u8], quote_index: usize) -> usize {
+    let quote = bytes[quote_index];
+    if bytes.get(quote_index + 1) == Some(&quote) && bytes.get(quote_index + 2) == Some(&quote) {
+        3
+    } else {
+        1
+    }
+}
+
+fn interpolated_string_content_range(bytes: &[u8], quote_index: usize) -> Option<(usize, usize)> {
+    let end = interpolated_string_end(bytes, quote_index)?;
+    let quote_len = quote_len_at(bytes, quote_index);
+    Some((quote_index + quote_len, end - quote_len))
+}
+
 fn quoted_string_content_range(
     bytes: &[u8],
     quote_index: usize,
@@ -5725,6 +5833,268 @@ fn invalid_parenthesized_import_star_error(source: &str) -> Option<CpythonDiagno
     None
 }
 
+fn prefix_letters_before_quote(
+    bytes: &[u8],
+    quote_index: usize,
+) -> Option<(usize, [u8; 3], usize)> {
+    let mut letters = [0u8; 3];
+    let mut count = 0;
+    let mut index = quote_index;
+    while index > 0 && count < 3 {
+        let byte = bytes[index - 1];
+        if !matches!(
+            byte,
+            b'r' | b'R' | b'b' | b'B' | b'u' | b'U' | b'f' | b'F' | b't' | b'T'
+        ) {
+            break;
+        }
+        letters[count] = byte.to_ascii_lowercase();
+        count += 1;
+        index -= 1;
+    }
+    if count == 0 {
+        return None;
+    }
+    if index > 0 && (bytes[index - 1] == b'_' || bytes[index - 1].is_ascii_alphabetic()) {
+        return None;
+    }
+    letters[..count].reverse();
+    Some((index, letters, count))
+}
+
+fn incompatible_string_prefix_error(source: &str) -> Option<CpythonDiagnostic> {
+    let bytes = source.as_bytes();
+    let mut index = 0;
+    while index < bytes.len() {
+        match bytes[index] {
+            b'#' => {
+                while index < bytes.len() && bytes[index] != b'\n' {
+                    index += 1;
+                }
+            }
+            b'\'' | b'"' => {
+                if let Some((start, letters, count)) = prefix_letters_before_quote(bytes, index)
+                    && let Some(message) = incompatible_prefix_message(&letters[..count])
+                {
+                    return Some(CpythonDiagnostic::new(message, start, start + 1));
+                }
+                index = skip_string_token(bytes, index);
+            }
+            _ => index += 1,
+        }
+    }
+    None
+}
+
+fn incompatible_prefix_message(letters: &[u8]) -> Option<String> {
+    if letters.len() < 2 {
+        return None;
+    }
+    let mut seen_r = false;
+    let mut seen_b = false;
+    let mut seen_u = false;
+    let mut seen_f = false;
+    let mut seen_t = false;
+    for &letter in letters {
+        match letter {
+            b'r' if seen_r => return None,
+            b'b' if seen_b => return None,
+            b'u' if seen_u => return None,
+            b'f' if seen_f => return None,
+            b't' if seen_t => return None,
+            b'r' => seen_r = true,
+            b'b' => seen_b = true,
+            b'u' => seen_u = true,
+            b'f' => seen_f = true,
+            b't' => seen_t = true,
+            _ => {}
+        }
+    }
+    let pair = if seen_u && seen_r {
+        ("u", "r")
+    } else if seen_u && seen_b {
+        ("u", "b")
+    } else if seen_u && seen_f {
+        ("u", "f")
+    } else if seen_u && seen_t {
+        ("u", "t")
+    } else if seen_b && seen_f {
+        ("b", "f")
+    } else if seen_b && seen_t {
+        ("b", "t")
+    } else if seen_f && seen_t {
+        ("f", "t")
+    } else {
+        return None;
+    };
+    Some(format!(
+        "'{}' and '{}' prefixes are incompatible",
+        pair.0, pair.1
+    ))
+}
+
+fn malformed_unicode_n_escape_error(source: &str) -> Option<CpythonDiagnostic> {
+    let bytes = source.as_bytes();
+    let mut index = 0;
+    while index < bytes.len() {
+        match bytes[index] {
+            b'#' => {
+                while index < bytes.len() && bytes[index] != b'\n' {
+                    index += 1;
+                }
+            }
+            b'\'' | b'"' => {
+                let quote_index = index;
+                let interpolated = interpolated_string_prefix(bytes, quote_index).is_some();
+                let Some((content_start, content_end)) =
+                    quoted_string_content_range(bytes, quote_index, bytes[quote_index])
+                else {
+                    index = skip_quoted_string(bytes, quote_index);
+                    continue;
+                };
+                if let Some(error) = malformed_unicode_n_in_content(
+                    bytes,
+                    content_start,
+                    content_end,
+                    quote_index,
+                    interpolated,
+                ) {
+                    return Some(error);
+                }
+                index = skip_string_token(bytes, quote_index);
+            }
+            _ => index += 1,
+        }
+    }
+    None
+}
+
+fn malformed_unicode_n_in_content(
+    bytes: &[u8],
+    start: usize,
+    end: usize,
+    quote_index: usize,
+    interpolated: bool,
+) -> Option<CpythonDiagnostic> {
+    let mut index = start;
+    let mut brace_depth = 0usize;
+    while index + 1 < end {
+        if interpolated && brace_depth == 0 && bytes[index] == b'{' {
+            if bytes.get(index + 1) == Some(&b'{') {
+                index += 2;
+                continue;
+            }
+            brace_depth = 1;
+            index += 1;
+            continue;
+        }
+        if interpolated && brace_depth > 0 {
+            match bytes[index] {
+                b'\'' | b'"' => index = skip_string_token(bytes, index).max(index + 1),
+                b'{' => {
+                    brace_depth += 1;
+                    index += 1;
+                }
+                b'}' => {
+                    brace_depth -= 1;
+                    index += 1;
+                }
+                _ => index += 1,
+            }
+            continue;
+        }
+        if bytes[index] == b'\\' && bytes[index + 1] == b'N' {
+            let escape_start = index;
+            if bytes.get(index + 2) == Some(&b'{') {
+                let mut look = index + 3;
+                while look < end && bytes[look] != b'}' {
+                    look += 1;
+                }
+                if look >= end {
+                    return Some(unicode_n_diagnostic(escape_start, end, start, quote_index));
+                }
+                index = look + 1;
+                continue;
+            }
+            return Some(unicode_n_diagnostic(
+                escape_start,
+                escape_start + 2,
+                start,
+                quote_index,
+            ));
+        }
+        if interpolated && bytes[index] == b'}' && bytes.get(index + 1) == Some(&b'}') {
+            index += 2;
+            continue;
+        }
+        index += 1;
+    }
+    None
+}
+
+fn unicode_n_diagnostic(
+    escape_start: usize,
+    escape_end: usize,
+    content_start: usize,
+    quote_index: usize,
+) -> CpythonDiagnostic {
+    let start = escape_start - content_start;
+    let end = escape_end.saturating_sub(content_start).saturating_sub(1);
+    CpythonDiagnostic::new(
+        format!(
+            "(unicode error) 'unicodeescape' codec can't decode bytes in position {start}-{end}: malformed \\N character escape"
+        ),
+        quote_index,
+        quote_index + 1,
+    )
+}
+
+fn too_many_nested_interpolated_strings(source: &str) -> Option<CpythonDiagnostic> {
+    too_many_nested_interpolated_strings_in(source.as_bytes(), 0, source.len(), 0)
+}
+
+fn too_many_nested_interpolated_strings_in(
+    bytes: &[u8],
+    mut index: usize,
+    end: usize,
+    depth: usize,
+) -> Option<CpythonDiagnostic> {
+    while index < end {
+        match bytes[index] {
+            b'#' => {
+                while index < end && bytes[index] != b'\n' {
+                    index += 1;
+                }
+            }
+            b'\'' | b'"' => {
+                if interpolated_string_prefix(bytes, index).is_some() {
+                    if depth + 1 >= MAXFSTRINGLEVEL {
+                        return Some(CpythonDiagnostic::new(
+                            "too many nested f-strings or t-strings".to_owned(),
+                            index,
+                            index + 1,
+                        ));
+                    }
+                    if let Some((content_start, content_end)) =
+                        interpolated_string_content_range(bytes, index)
+                        && let Some(error) = too_many_nested_interpolated_strings_in(
+                            bytes,
+                            content_start,
+                            content_end,
+                            depth + 1,
+                        )
+                    {
+                        return Some(error);
+                    }
+                }
+                index = skip_string_token(bytes, index).max(index + 1);
+            }
+            _ => index += 1,
+        }
+    }
+    None
+}
+
 fn too_many_nested_parentheses_error(source: &str) -> Option<CpythonDiagnostic> {
     const MAXLEVEL: usize = 200;
 
@@ -5819,6 +6189,9 @@ fn post_parse_source_error(
         return Some(error);
     }
     if let Some(error) = too_many_nested_parentheses_error(source_file.source_text()) {
+        return Some(CompileError::from_source_error(source_file, error));
+    }
+    if let Some(error) = too_many_nested_interpolated_strings(source_file.source_text()) {
         return Some(CompileError::from_source_error(source_file, error));
     }
     if let Some(error) =
@@ -6560,6 +6933,26 @@ mod tests {
     }
 
     #[test]
+    fn too_many_nested_fstrings_match_tokenizer_limit() {
+        fn nested(n: usize) -> String {
+            if n == 0 {
+                return "1+1".to_owned();
+            }
+            format!("f\"{{{}}}\"", nested(n - 1))
+        }
+
+        compile(&nested(149), Mode::Eval, "<nest>", CompileOpts::default())
+            .expect("149 nested f-strings should compile");
+        let err = compile(&nested(150), Mode::Eval, "<nest>", CompileOpts::default())
+            .expect_err("150 nested f-strings should fail");
+        assert!(
+            err.to_string()
+                .contains("too many nested f-strings or t-strings"),
+            "got {err}"
+        );
+    }
+
+    #[test]
     fn interpolated_string_diagnostics_match_cpython() {
         for (source, expected) in [
             ("f'{'", "f-string: expecting '}'"),
@@ -6669,6 +7062,17 @@ mod tests {
             (
                 "f'{+ lambda:None}'",
                 "f-string: expecting a valid expression after '{'",
+            ),
+            ("fu''", "'u' and 'f' prefixes are incompatible"),
+            ("fb''", "'b' and 'f' prefixes are incompatible"),
+            ("ufr''", "'u' and 'r' prefixes are incompatible"),
+            (
+                r"'\N'",
+                "(unicode error) 'unicodeescape' codec can't decode bytes in position 0-1: malformed \\N character escape",
+            ),
+            (
+                r"f'\N{'",
+                "(unicode error) 'unicodeescape' codec can't decode bytes in position 0-2: malformed \\N character escape",
             ),
         ] {
             let err = compile(source, Mode::Eval, "<interp>", CompileOpts::default())

--- a/crates/vm/src/stdlib/_ast.rs
+++ b/crates/vm/src/stdlib/_ast.rs
@@ -1027,6 +1027,7 @@ fn type_comment_parse_error(
         end_location: source_range.end.to_source_location(),
         source_path: source_file.name().to_owned(),
         is_unclosed_bracket: false,
+        is_unclosed_string: false,
     }
     .into()
 }
@@ -1756,6 +1757,7 @@ fn ipython_escape_command_syntax_error(
             end_location: source_range.end.to_source_location(),
             source_path: source_file.name().to_owned(),
             is_unclosed_bracket: false,
+            is_unclosed_string: false,
         }
         .into(),
     )
@@ -1831,6 +1833,7 @@ pub(crate) fn parse(
             end_location: range.end.to_source_location(),
             source_path: source_file.name().to_owned(),
             is_unclosed_bracket: false,
+            is_unclosed_string: false,
         }
         .into());
     }
@@ -1860,6 +1863,7 @@ pub(crate) fn parse(
             end_location: range.end.to_source_location(),
             source_path: source_file.name().to_owned(),
             is_unclosed_bracket: false,
+            is_unclosed_string: false,
         }
         .into());
     }
@@ -1969,6 +1973,7 @@ pub(crate) fn parse_func_type(
             end_location: SourceLocation::default(),
             source_path: filename.to_owned(),
             is_unclosed_bracket: false,
+            is_unclosed_string: false,
         }
         .into()
     };
@@ -1997,6 +2002,7 @@ pub(crate) fn parse_func_type(
             end_location: SourceLocation::default(),
             source_path: filename.to_owned(),
             is_unclosed_bracket: false,
+            is_unclosed_string: false,
         }
         .into());
     };
@@ -2017,6 +2023,7 @@ pub(crate) fn parse_func_type(
                 end_location: range.end.to_source_location(),
                 source_path: source_file.name().to_owned(),
                 is_unclosed_bracket: false,
+                is_unclosed_string: false,
             }
         })?;
         let ast::Mod::Expression(expression) = parsed.into_syntax() else {
@@ -2048,6 +2055,7 @@ pub(crate) fn parse_func_type(
                 end_location: range.end.to_source_location(),
                 source_path: source_file.name().to_owned(),
                 is_unclosed_bracket: false,
+                is_unclosed_string: false,
             }
         })?;
         let ast::Mod::Expression(expression) = parsed.into_syntax() else {

--- a/crates/vm/src/vm/vm_new.rs
+++ b/crates/vm/src/vm/vm_new.rs
@@ -921,8 +921,7 @@ impl VirtualMachine {
         }
 
         let SyntaxErrorInfo { msg, narrow_caret } = syntax_error_info;
-        let unterminated_triple_quoted_string =
-            msg.starts_with("unterminated triple-quoted string literal");
+        let unterminated_triple_quoted_string = msg.starts_with("unterminated triple-quoted");
         let unexpected_eof_error = msg == "unexpected EOF while parsing";
         if unterminated_triple_quoted_string
             && let Some(statement) = statement.as_mut()

--- a/crates/vm/src/vm/vm_new.rs
+++ b/crates/vm/src/vm/vm_new.rs
@@ -777,6 +777,11 @@ impl VirtualMachine {
             }) => incomplete_or_syntax(allow_incomplete),
             #[cfg(feature = "parser")]
             crate::compiler::CompileError::Parse(rustpython_compiler::ParseError {
+                is_unclosed_string: true,
+                ..
+            }) => incomplete_or_syntax(allow_incomplete),
+            #[cfg(feature = "parser")]
+            crate::compiler::CompileError::Parse(rustpython_compiler::ParseError {
                 error:
                     ruff_python_parser::ParseErrorType::Lexical(
                         ruff_python_parser::LexicalErrorType::FStringError(
@@ -794,24 +799,10 @@ impl VirtualMachine {
                     ruff_python_parser::ParseErrorType::Lexical(
                         ruff_python_parser::LexicalErrorType::UnclosedStringError,
                     ),
-                raw_location,
                 ..
             }) => {
                 if allow_incomplete {
-                    let mut is_incomplete = false;
-
-                    if let Some(source) = source {
-                        let loc = raw_location.start().to_usize();
-                        let mut iter = source.chars();
-                        if let Some(quote) = iter.nth(loc)
-                            && iter.next() == Some(quote)
-                            && iter.next() == Some(quote)
-                        {
-                            is_incomplete = true;
-                        }
-                    }
-
-                    incomplete_or_syntax(is_incomplete)
+                    incomplete_or_syntax(source.is_some_and(unclosed_string_is_incomplete))
                 } else {
                     self.ctx.exceptions.syntax_error
                 }
@@ -865,6 +856,11 @@ impl VirtualMachine {
                 }
             }
             _ => self.ctx.exceptions.syntax_error,
+        };
+        let syntax_error_type = if allow_incomplete && source.is_some_and(is_blank_python_source) {
+            self.ctx.exceptions.incomplete_input_error
+        } else {
+            syntax_error_type
         }
         .to_owned();
 
@@ -1148,4 +1144,80 @@ impl VirtualMachine {
     define_exception_fn!(fn new_memory_error, memory_error, MemoryError);
     define_exception_fn!(fn new_assertion_error, assertion_error, AssertionError);
     define_exception_fn!(fn new_unbound_local_error, unbound_local_error, UnboundLocalError);
+}
+
+fn is_blank_python_source(source: &str) -> bool {
+    source.lines().all(|line| {
+        let trimmed = line.trim();
+        trimmed.is_empty() || trimmed.starts_with('#')
+    })
+}
+
+#[cfg(feature = "parser")]
+enum QuotedStringScan {
+    Closed(usize),
+    Unclosed {
+        triple: bool,
+        unescaped_newline: bool,
+    },
+}
+
+/// An unclosed string is incomplete when more input could still finish it.
+/// A non-triple string that already hit an unescaped newline is a hard error.
+#[cfg(feature = "parser")]
+fn unclosed_string_is_incomplete(source: &str) -> bool {
+    let bytes = source.as_bytes();
+    let mut index = 0;
+    while index < bytes.len() {
+        match bytes[index] {
+            b'#' => {
+                while index < bytes.len() && bytes[index] != b'\n' {
+                    index += 1;
+                }
+            }
+            b'\'' | b'"' => match scan_quoted_string_for_incomplete(bytes, index) {
+                QuotedStringScan::Closed(end) => index = end,
+                QuotedStringScan::Unclosed {
+                    triple,
+                    unescaped_newline,
+                } => return triple || !unescaped_newline,
+            },
+            _ => index += 1,
+        }
+    }
+    false
+}
+
+#[cfg(feature = "parser")]
+fn scan_quoted_string_for_incomplete(bytes: &[u8], quote_index: usize) -> QuotedStringScan {
+    let quote = bytes[quote_index];
+    let triple =
+        bytes.get(quote_index + 1) == Some(&quote) && bytes.get(quote_index + 2) == Some(&quote);
+    let mut index = quote_index + if triple { 3 } else { 1 };
+    while index < bytes.len() {
+        if bytes[index] == b'\\' {
+            index = (index + 2).min(bytes.len());
+            continue;
+        }
+        if triple {
+            if bytes.get(index) == Some(&quote)
+                && bytes.get(index + 1) == Some(&quote)
+                && bytes.get(index + 2) == Some(&quote)
+            {
+                return QuotedStringScan::Closed(index + 3);
+            }
+        } else if bytes[index] == quote {
+            return QuotedStringScan::Closed(index + 1);
+        } else if bytes[index] == b'\n' {
+            return QuotedStringScan::Unclosed {
+                triple: false,
+                unescaped_newline: true,
+            };
+        }
+        index += 1;
+    }
+    QuotedStringScan::Unclosed {
+        triple,
+        unescaped_newline: false,
+    }
 }


### PR DESCRIPTION
Follow-up after #8686.

- Treat strings that are still open at EOF as incomplete when `PyCF_ALLOW_INCOMPLETE_INPUT` is set. A non-triple string that already hit an unescaped newline stays a `SyntaxError`.
- Treat blank (whitespace/comment-only) `eval` input as incomplete under the same flag.
- Report unparenthesized `lambda` after a comma in an f-string field (`f'{1, lambda:x}'`).
- After a unary `+`/`-`/`~`, a following `lambda` is not a valid expression start (`f'{+ lambda:None}'`).
- Advance parameter-list scans past each parameter's default value so `f'{name_4}'` is not treated as a later parameter.

Removes `@unittest.expectedFailure` from `test_codeop.test_incomplete` and `test_fstring.test_lambda`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved detection and reporting of unterminated strings, including clearer handling of triple-quoted and interpolated strings.
  * Interactive and incomplete-input parsing now better distinguishes recoverable input from syntax errors, including blank or comment-only input.
  * Improved diagnostics for empty default values and invalid lambda defaults.
  * Added validation for f-strings and t-strings used with unparenthesized lambdas.
  * Improved reporting for incompatible prefixes and malformed `\N` escapes.
  * Deeply nested f-strings and t-strings now produce clear syntax errors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->