### PR TITLE
Honor coroutine reuse, origin, and unawaited warnings

### DIFF
--- a/Lib/test/test_asyncgen.py
+++ b/Lib/test/test_asyncgen.py
@@ -1835,7 +1835,6 @@ class AsyncGenAsyncioTest(unittest.TestCase):
         res = self.loop.run_until_complete(run())
         self.assertEqual(res, [i * 2 for i in range(1, 10)])
 
-    @unittest.expectedFailure  # TODO: RUSTPYTHON; AttributeError: __aiter__
     def test_async_gen_expression_incorrect(self):
         async def ag():
             yield 42
@@ -2008,7 +2007,6 @@ class AsyncGenAsyncioTest(unittest.TestCase):
 
 
 class TestUnawaitedWarnings(unittest.TestCase):
-    @unittest.expectedFailure  # TODO: RUSTPYTHON; AssertionError: RuntimeWarning not triggered
     def test_asend(self):
         async def gen():
             yield 1
@@ -2027,7 +2025,6 @@ class TestUnawaitedWarnings(unittest.TestCase):
             g.asend(None)
             gc_collect()
 
-    @unittest.expectedFailure  # TODO: RUSTPYTHON; AssertionError: RuntimeWarning not triggered
     def test_athrow(self):
         async def gen():
             yield 1
@@ -2038,7 +2035,6 @@ class TestUnawaitedWarnings(unittest.TestCase):
             g.athrow(RuntimeError)
             gc_collect()
 
-    @unittest.expectedFailure  # TODO: RUSTPYTHON; AssertionError: RuntimeWarning not triggered
     def test_aclose(self):
         async def gen():
             yield 1

--- a/Lib/test/test_coroutines.py
+++ b/Lib/test/test_coroutines.py
@@ -563,7 +563,6 @@ class CoroutineTest(unittest.TestCase):
         self.assertRegex(repr(coro), '^<coroutine object.* at 0x.*>$')
         coro.close()
 
-    @unittest.expectedFailure  # TODO: RUSTPYTHON; RuntimeError: coroutine raised StopIteration
     def test_func_4(self):
         async def foo():
             raise StopIteration
@@ -593,7 +592,6 @@ class CoroutineTest(unittest.TestCase):
 
         coro.close()
 
-    @unittest.expectedFailure  # TODO: RUSTPYTHON; AssertionError: TypeError not raised
     def test_func_5(self):
         @types.coroutine
         def bar():
@@ -661,7 +659,6 @@ class CoroutineTest(unittest.TestCase):
         self.assertEqual(run_async(bar()), ([], 'spam'))
         coro.close()
 
-    @unittest.expectedFailure  # TODO: RUSTPYTHON; AssertionError: RuntimeWarning not triggered
     def test_func_9(self):
         async def foo():
             pass
@@ -772,7 +769,6 @@ class CoroutineTest(unittest.TestCase):
                                     "coroutine ignored GeneratorExit"):
             c.close()
 
-    @unittest.expectedFailure  # TODO: RUSTPYTHON; StopIteration
     def test_func_15(self):
         # See http://bugs.python.org/issue25887 for details
 
@@ -790,7 +786,6 @@ class CoroutineTest(unittest.TestCase):
                                     'cannot reuse already awaited coroutine'):
             reader(spammer_coro).send(None)
 
-    @unittest.expectedFailure  # TODO: RUSTPYTHON; StopIteration
     def test_func_16(self):
         # See http://bugs.python.org/issue25887 for details
 
@@ -822,7 +817,6 @@ class CoroutineTest(unittest.TestCase):
                                     'cannot reuse already awaited coroutine'):
             reader.throw(Exception('wat'))
 
-    @unittest.expectedFailure  # TODO: RUSTPYTHON; StopIteration
     def test_func_17(self):
         # See http://bugs.python.org/issue25887 for details
 
@@ -931,7 +925,6 @@ class CoroutineTest(unittest.TestCase):
         self.assertIsInstance(result[1], StopIteration)
         self.assertEqual(result[1].value, 10)
 
-    @unittest.expectedFailure  # TODO: RUSTPYTHON; AttributeError: 'coroutine' object has no attribute 'cr_suspended'
     def test_cr_await(self):
         @types.coroutine
         def a():
@@ -962,7 +955,6 @@ class CoroutineTest(unittest.TestCase):
         self.assertEqual(inspect.getcoroutinestate(coro_b), inspect.CORO_CLOSED)
         self.assertIsNone(coro_b.cr_await)
 
-    @unittest.expectedFailure  # TODO: RUSTPYTHON; TypeError: 'NoneType' object is not iterable
     def test_corotype_1(self):
         ct = types.CoroutineType
         if not support.MISSING_C_DOCSTRINGS:
@@ -1604,7 +1596,6 @@ class CoroutineTest(unittest.TestCase):
         self.assertEqual(buffer, [i for i in range(1, 21)] +
                                  ['what?', 'end'])
 
-    @unittest.expectedFailure  # TODO: RUSTPYTHON; AttributeError: __aiter__
     def test_for_2(self):
         tup = (1, 2, 3)
         refs_before = sys.getrefcount(tup)
@@ -1620,7 +1611,6 @@ class CoroutineTest(unittest.TestCase):
 
         self.assertEqual(sys.getrefcount(tup), refs_before)
 
-    @unittest.expectedFailure  # TODO: RUSTPYTHON; AssertionError: "that does not implement __anext__" does not match "'async for' requires an iterator with __anext__ method, got I"
     def test_for_3(self):
         class I:
             def __aiter__(self):
@@ -1641,7 +1631,6 @@ class CoroutineTest(unittest.TestCase):
 
         self.assertEqual(sys.getrefcount(aiter), refs_before)
 
-    @unittest.expectedFailure  # TODO: RUSTPYTHON; AssertionError: "async for' received an invalid object.*__anext__.*tuple" does not match "'tuple' object is not an iterator"
     def test_for_4(self):
         class I:
             def __aiter__(self):
@@ -1789,7 +1778,6 @@ class CoroutineTest(unittest.TestCase):
                 run_async(foo())
         self.assertEqual(CNT, 0)
 
-    @unittest.expectedFailure  # TODO: RUSTPYTHON; AssertionError: "an invalid object from __anext__" does not match "'F' object is not an iterator"
     def test_for_11(self):
         class F:
             def __aiter__(self):
@@ -2147,7 +2135,6 @@ class CoroutineTest(unittest.TestCase):
         finally:
             aw.close()
 
-    @unittest.expectedFailure  # TODO: RUSTPYTHON; AttributeError: 'NoneType' object has no attribute 'err_msg'
     def test_fatal_coro_warning(self):
         # Issue 27811
         async def func(): pass
@@ -2238,7 +2225,6 @@ class CoroutineTest(unittest.TestCase):
             frame = f().cr_frame
         frame.clear()
 
-    @unittest.expectedFailure  # TODO: RUSTPYTHON; This would crash the interpreter in 3.11a2
     def test_bpo_45813_2(self):
         'This would crash the interpreter in 3.11a2'
         async def f():
@@ -2361,7 +2347,6 @@ class OriginTrackingTest(unittest.TestCase):
         info = inspect.getframeinfo(inspect.currentframe().f_back)
         return (info.filename, info.lineno)
 
-    @unittest.expectedFailure  # TODO: RUSTPYTHON; AssertionError: None != (('/home/fanninpm/Documents/GitHub/RustPy[74 chars]g'),)
     def test_origin_tracking(self):
         orig_depth = sys.get_coroutine_origin_tracking_depth()
         try:
@@ -2408,7 +2393,6 @@ class OriginTrackingTest(unittest.TestCase):
         finally:
             sys.set_coroutine_origin_tracking_depth(orig_depth)
 
-    @unittest.expectedFailure  # TODO: RUSTPYTHON; AssertionError: RuntimeWarning not triggered
     def test_origin_tracking_warning(self):
         async def corofn():
             pass
@@ -2451,7 +2435,6 @@ class OriginTrackingTest(unittest.TestCase):
         finally:
             sys.set_coroutine_origin_tracking_depth(orig_depth)
 
-    @unittest.expectedFailure  # TODO: RUSTPYTHON; AttributeError: 'NoneType' object has no attribute 'err_msg'
     def test_unawaited_warning_when_module_broken(self):
         # Make sure we don't blow up too bad if
         # warnings._warn_unawaited_coroutine is broken somehow (e.g. because

--- a/Lib/test/test_inspect/test_inspect.py
+++ b/Lib/test/test_inspect/test_inspect.py
@@ -2860,16 +2860,13 @@ class TestGetCoroutineState(unittest.TestCase):
     def _coroutinestate(self):
         return inspect.getcoroutinestate(self.coroutine)
 
-    @unittest.expectedFailure  # TODO: RUSTPYTHON; AttributeError: 'coroutine' object has no attribute 'cr_suspended'
     def test_created(self):
         self.assertEqual(self._coroutinestate(), inspect.CORO_CREATED)
 
-    @unittest.expectedFailure  # TODO: RUSTPYTHON; AttributeError: 'coroutine' object has no attribute 'cr_suspended'
     def test_suspended(self):
         self.coroutine.send(None)
         self.assertEqual(self._coroutinestate(), inspect.CORO_SUSPENDED)
 
-    @unittest.expectedFailure  # TODO: RUSTPYTHON; AttributeError: 'coroutine' object has no attribute 'cr_suspended'
     def test_closed_after_exhaustion(self):
         while True:
             try:
@@ -2879,13 +2876,11 @@ class TestGetCoroutineState(unittest.TestCase):
 
         self.assertEqual(self._coroutinestate(), inspect.CORO_CLOSED)
 
-    @unittest.expectedFailure  # TODO: RUSTPYTHON; AttributeError: 'coroutine' object has no attribute 'cr_suspended'
     def test_closed_after_immediate_exception(self):
         with self.assertRaises(RuntimeError):
             self.coroutine.throw(RuntimeError)
         self.assertEqual(self._coroutinestate(), inspect.CORO_CLOSED)
 
-    @unittest.expectedFailure  # TODO: RUSTPYTHON; AttributeError: 'coroutine' object has no attribute 'cr_suspended'
     def test_closed_after_close(self):
         self.coroutine.close()
         self.assertEqual(self._coroutinestate(), inspect.CORO_CLOSED)

--- a/Lib/test/test_unittest/testmock/testasync.py
+++ b/Lib/test/test_unittest/testmock/testasync.py
@@ -852,7 +852,6 @@ class AsyncMockAssert(unittest.TestCase):
         mock.async_method.assert_awaited()
         mock.async_method.assert_awaited_once()
 
-    @unittest.expectedFailure  # TODO: RUSTPYTHON
     def test_assert_called_once_and_awaited_twice(self):
         mock = AsyncMock(AsyncClass)
         coroutine = mock.async_method()

--- a/crates/derive-impl/src/pyclass.rs
+++ b/crates/derive-impl/src/pyclass.rs
@@ -1152,9 +1152,14 @@ where
             args.attrs.push(allow_attr);
         }
 
-        args.context
-            .getset_items
-            .add_item(&py_name, args.cfgs.to_vec(), kind, ident.clone())?;
+        let doc = args.attrs.doc();
+        args.context.getset_items.add_item(
+            &py_name,
+            args.cfgs.to_vec(),
+            kind,
+            ident.clone(),
+            doc,
+        )?;
         Ok(())
     }
 }
@@ -1422,9 +1427,15 @@ impl ToTokens for MethodNursery {
 }
 
 #[derive(Default)]
-#[allow(clippy::type_complexity)]
+struct GetSetEntry {
+    getter: Option<Ident>,
+    setter: Option<Ident>,
+    doc: Option<String>,
+}
+
+#[derive(Default)]
 struct GetSetNursery {
-    map: HashMap<(String, Vec<Attribute>), (Option<Ident>, Option<Ident>)>,
+    map: HashMap<(String, Vec<Attribute>), GetSetEntry>,
     validated: bool,
 }
 
@@ -1441,14 +1452,15 @@ impl GetSetNursery {
         cfgs: Vec<Attribute>,
         kind: GetSetItemKind,
         item_ident: Ident,
+        doc: Option<String>,
     ) -> Result<()> {
         assert!(!self.validated, "new item is not allowed after validation");
         // Note: Both getter and setter can have #[cfg], but they must have matching cfgs
         // since the map key is (name, cfgs). This ensures getter and setter are paired correctly.
         let entry = self.map.entry((name.to_string(), cfgs)).or_default();
         let func = match kind {
-            GetSetItemKind::Get => &mut entry.0,
-            GetSetItemKind::Set => &mut entry.1,
+            GetSetItemKind::Get => &mut entry.getter,
+            GetSetItemKind::Set => &mut entry.setter,
         };
         if func.is_some() {
             bail_span!(
@@ -1458,6 +1470,11 @@ impl GetSetNursery {
             );
         }
         *func = Some(item_ident);
+        if matches!(kind, GetSetItemKind::Get)
+            && let Some(doc) = doc
+        {
+            entry.doc = Some(doc);
+        }
         Ok(())
     }
 
@@ -1468,10 +1485,10 @@ impl GetSetNursery {
             clippy::iter_over_hash_type,
             reason = "Iteration order doesn't matter here"
         )]
-        for ((name, _cfgs), (getter, setter)) in &self.map {
-            if getter.is_none() {
+        for ((name, _cfgs), entry) in &self.map {
+            if entry.getter.is_none() {
                 errors.push(err_span!(
-                    setter.as_ref().unwrap(),
+                    entry.setter.as_ref().unwrap(),
                     "GetSet '{}' is missing a getter",
                     name
                 ));
@@ -1487,9 +1504,14 @@ impl GetSetNursery {
 impl ToTokens for GetSetNursery {
     fn to_tokens(&self, tokens: &mut TokenStream) {
         assert!(self.validated, "Call `validate()` before token generation");
-        let properties = self.map.iter().map(|((name, cfgs), (getter, setter))| {
-            let setter = match setter {
+        let properties = self.map.iter().map(|((name, cfgs), entry)| {
+            let getter = entry.getter.as_ref().unwrap();
+            let setter = match &entry.setter {
                 Some(setter) => quote_spanned! { setter.span() => .with_set(Self::#setter)},
+                None => quote! {},
+            };
+            let doc = match &entry.doc {
+                Some(doc) => quote! { .with_doc(#doc) },
                 None => quote! {},
             };
             quote_spanned! { getter.span() =>
@@ -1499,7 +1521,8 @@ impl ToTokens for GetSetNursery {
                     ::rustpython_vm::PyRef::new_ref(
                         ::rustpython_vm::builtins::PyGetSet::new(#name.into(), class)
                             .with_get(Self::#getter)
-                            #setter,
+                            #setter
+                            #doc,
                             ctx.types.getset_type.to_owned(), None),
                     ctx
                 );

--- a/crates/vm/src/builtins/asyncgenerator.rs
+++ b/crates/vm/src/builtins/asyncgenerator.rs
@@ -14,6 +14,14 @@ use crate::{
 
 use crossbeam_utils::atomic::AtomicCell;
 
+fn warn_unawaited_asyncgen_method(ag: &Py<PyAsyncGen>, method: &str, vm: &VirtualMachine) {
+    let name = ag.as_coro().qualname();
+    let msg = format!("coroutine method '{method}' of '{name}' was never awaited");
+    if let Err(e) = crate::stdlib::_warnings::warn(vm.ctx.exceptions.runtime_warning, msg, 1, vm) {
+        vm.run_unraisable(e, None, ag.as_object().to_owned());
+    }
+}
+
 #[pyclass(name = "async_generator", module = false, traverse = "manual")]
 #[derive(Debug)]
 pub struct PyAsyncGen {
@@ -303,7 +311,7 @@ impl PyPayload for PyAsyncGenASend {
     }
 }
 
-#[pyclass(with(IterNext, Iterable))]
+#[pyclass(with(IterNext, Iterable, Destructor))]
 impl PyAsyncGenASend {
     #[pymethod(name = "__await__")]
     const fn r#await(zelf: PyRef<Self>, _vm: &VirtualMachine) -> PyRef<Self> {
@@ -420,6 +428,15 @@ impl IterNext for PyAsyncGenASend {
     }
 }
 
+impl Destructor for PyAsyncGenASend {
+    fn del(zelf: &Py<Self>, vm: &VirtualMachine) -> PyResult<()> {
+        if matches!(zelf.state.load(), AwaitableState::Init) {
+            warn_unawaited_asyncgen_method(&zelf.ag, "asend", vm);
+        }
+        Ok(())
+    }
+}
+
 #[pyclass(module = false, name = "async_generator_athrow", traverse = "manual")]
 #[derive(Debug)]
 pub(crate) struct PyAsyncGenAThrow {
@@ -443,7 +460,7 @@ impl PyPayload for PyAsyncGenAThrow {
     }
 }
 
-#[pyclass(with(IterNext, Iterable))]
+#[pyclass(with(IterNext, Iterable, Destructor))]
 impl PyAsyncGenAThrow {
     #[pymethod(name = "__await__")]
     const fn r#await(zelf: PyRef<Self>, _vm: &VirtualMachine) -> PyRef<Self> {
@@ -618,6 +635,16 @@ impl SelfIter for PyAsyncGenAThrow {}
 impl IterNext for PyAsyncGenAThrow {
     fn next(zelf: &Py<Self>, vm: &VirtualMachine) -> PyResult<PyIterReturn> {
         PyIterReturn::from_pyresult(zelf.send(vm.ctx.none(), vm), vm)
+    }
+}
+
+impl Destructor for PyAsyncGenAThrow {
+    fn del(zelf: &Py<Self>, vm: &VirtualMachine) -> PyResult<()> {
+        if matches!(zelf.state.load(), AwaitableState::Init) {
+            let method = if zelf.aclose { "aclose" } else { "athrow" };
+            warn_unawaited_asyncgen_method(&zelf.ag, method, vm);
+        }
+        Ok(())
     }
 }
 

--- a/crates/vm/src/builtins/coroutine.rs
+++ b/crates/vm/src/builtins/coroutine.rs
@@ -1,4 +1,4 @@
-use super::{PyCode, PyGenericAlias, PyStrRef, PyType, PyTypeRef};
+use super::{PyCode, PyGenericAlias, PyStrRef, PyTupleRef, PyType, PyTypeRef};
 use crate::{
     AsObject, Context, Py, PyObjectRef, PyPayload, PyRef, PyResult, VirtualMachine,
     class::PyClassImpl,
@@ -16,11 +16,15 @@ use crossbeam_utils::atomic::AtomicCell;
 // PyCoro_Type in CPython
 pub struct PyCoroutine {
     inner: Coro,
+    origin: Option<PyTupleRef>,
 }
 
 unsafe impl Traverse for PyCoroutine {
     fn traverse(&self, tracer_fn: &mut TraverseFn<'_>) {
         self.inner.traverse(tracer_fn);
+        if let Some(origin) = &self.origin {
+            origin.traverse(tracer_fn);
+        }
     }
 }
 
@@ -33,7 +37,7 @@ impl PyPayload for PyCoroutine {
 
 #[pyclass(
     flags(DISALLOW_INSTANTIATION, HAS_WEAKREF),
-    with(Py, IterNext, Representable, Destructor)
+    with(Py, Representable, Destructor)
 )]
 impl PyCoroutine {
     pub const fn as_coro(&self) -> &Coro {
@@ -41,13 +45,20 @@ impl PyCoroutine {
     }
 
     #[must_use]
-    pub fn new(frame: FrameObjectRef, name: PyStrRef, qualname: PyStrRef) -> Self {
+    pub fn new(
+        frame: FrameObjectRef,
+        name: PyStrRef,
+        qualname: PyStrRef,
+        origin: Option<PyTupleRef>,
+    ) -> Self {
         Self {
             inner: Coro::new(frame, name, qualname),
+            origin,
         }
     }
 
     #[pygetset]
+    /// name of the coroutine
     fn __name__(&self) -> PyStrRef {
         self.inner.name()
     }
@@ -58,6 +69,7 @@ impl PyCoroutine {
     }
 
     #[pygetset]
+    /// qualified name of the coroutine
     fn __qualname__(&self) -> PyStrRef {
         self.inner.qualname()
     }
@@ -95,11 +107,13 @@ impl PyCoroutine {
     fn cr_code(&self, _vm: &VirtualMachine) -> PyRef<PyCode> {
         self.inner.frame().iframe().code().to_owned()
     }
-    // TODO: coroutine origin tracking:
-    // https://docs.python.org/3/library/sys.html#sys.set_coroutine_origin_tracking_depth
     #[pygetset]
-    const fn cr_origin(&self, _vm: &VirtualMachine) -> Option<(PyStrRef, usize, PyStrRef)> {
-        None
+    fn cr_origin(&self, _vm: &VirtualMachine) -> Option<PyTupleRef> {
+        self.origin.clone()
+    }
+    #[pygetset]
+    fn cr_suspended(&self, _vm: &VirtualMachine) -> bool {
+        self.inner.suspended()
     }
 
     #[pyclassmethod]
@@ -115,11 +129,20 @@ impl PyCoroutine {
 #[pyclass]
 impl Py<PyCoroutine> {
     #[pymethod]
+    /// send(arg) -> send 'arg' into coroutine,
+    /// return next iterated value or raise StopIteration.
     fn send(&self, value: PyObjectRef, vm: &VirtualMachine) -> PyResult<PyIterReturn> {
         self.inner.send(self.as_object(), value, vm)
     }
 
     #[pymethod]
+    /// throw(value)
+    /// throw(type[,value[,traceback]])
+    ///
+    /// Raise exception in coroutine, return next iterated value or raise
+    /// StopIteration.
+    /// the (type, val, tb) signature is deprecated,
+    /// and may be removed in a future version of Python.
     fn throw(
         &self,
         exc_type: PyObjectRef,
@@ -138,6 +161,7 @@ impl Py<PyCoroutine> {
     }
 
     #[pymethod]
+    /// close() -> raise GeneratorExit inside coroutine.
     fn close(&self, vm: &VirtualMachine) -> PyResult<PyObjectRef> {
         self.inner.close(self.as_object(), vm)
     }
@@ -150,26 +174,13 @@ impl Representable for PyCoroutine {
     }
 }
 
-impl SelfIter for PyCoroutine {}
-impl IterNext for PyCoroutine {
-    fn next(zelf: &Py<Self>, vm: &VirtualMachine) -> PyResult<PyIterReturn> {
-        zelf.send(vm.ctx.none(), vm)
-    }
-}
-
 impl Destructor for PyCoroutine {
     fn del(zelf: &Py<Self>, vm: &VirtualMachine) -> PyResult<()> {
         if zelf.inner.closed() || zelf.inner.running() {
             return Ok(());
         }
         if zelf.inner.frame().lasti() == 0 {
-            let name = zelf.inner.qualname();
-            let msg = format!("coroutine '{name}' was never awaited");
-            if let Err(e) =
-                crate::stdlib::_warnings::warn(vm.ctx.exceptions.runtime_warning, msg, 1, vm)
-            {
-                vm.run_unraisable(e, None, zelf.as_object().to_owned());
-            }
+            crate::warn::warn_unawaited_coroutine(zelf.as_object(), &zelf.inner.qualname(), vm);
             zelf.inner.closed.store(true);
             return Ok(());
         }

--- a/crates/vm/src/builtins/frame.rs
+++ b/crates/vm/src/builtins/frame.rs
@@ -2,13 +2,13 @@
 
 */
 
-use super::{PyCode, PyDictRef, PyIntRef, PyStrRef};
+use super::{PyAsyncGen, PyCode, PyCoroutine, PyDictRef, PyIntRef, PyStrRef};
 use crate::{
     Context, Py, PyObjectRef, PyPayload, PyRef, PyResult, VirtualMachine,
     class::PyClassImpl,
     frame::{FrameObject, FrameObjectRef, FrameOwner},
     function::PySetterValue,
-    types::Representable,
+    types::{Destructor, Representable},
 };
 use core::sync::atomic::Ordering::Relaxed;
 use num_traits::Zero;
@@ -780,10 +780,19 @@ impl Py<FrameObject> {
             FrameOwner::Generator => {
                 // Generator frame: check if suspended (lasti > 0 means
                 // FRAME_SUSPENDED). lasti == 0 means FRAME_CREATED and
-                // can be cleared.
+                // can be cleared. Finalize the owner so a never-started
+                // coroutine emits its never-awaited warning.
                 if self.lasti() != 0 {
                     return Err(vm.new_runtime_error("cannot clear a suspended frame"));
                 }
+                if let Some(owner) = self.iframe().generator.to_owned() {
+                    if let Some(coro) = owner.downcast_ref::<PyCoroutine>() {
+                        let _ = PyCoroutine::del(coro, vm);
+                    } else if let Some(async_gen) = owner.downcast_ref::<PyAsyncGen>() {
+                        let _ = PyAsyncGen::del(async_gen, vm);
+                    }
+                }
+                return Ok(());
             }
             FrameOwner::Thread => {
                 // Thread-owned frame: always executing, cannot clear.

--- a/crates/vm/src/builtins/function.rs
+++ b/crates/vm/src/builtins/function.rs
@@ -688,7 +688,9 @@ impl Py<PyFunction> {
         } else if is_gen {
             PyGenerator::new(frame.clone(), self.__name__(), self.__qualname__()).into_pyobject(vm)
         } else {
-            PyCoroutine::new(frame.clone(), self.__name__(), self.__qualname__()).into_pyobject(vm)
+            let origin = crate::coroutine::compute_cr_origin(vm);
+            PyCoroutine::new(frame.clone(), self.__name__(), self.__qualname__(), origin)
+                .into_pyobject(vm)
         };
         debug_assert!(
             !frame.localsplus_is_datastack_backed(),

--- a/crates/vm/src/builtins/getset.rs
+++ b/crates/vm/src/builtins/getset.rs
@@ -17,7 +17,7 @@ pub struct PyGetSet {
     class: PyRef<PyType>,
     getter: Option<PyGetterFunc>,
     setter: Option<PySetterFunc>,
-    // doc: Option<String>,
+    doc: Option<String>,
 }
 
 impl core::fmt::Debug for PyGetSet {
@@ -85,7 +85,14 @@ impl PyGetSet {
             class: class.to_owned(),
             getter: None,
             setter: None,
+            doc: None,
         }
+    }
+
+    #[must_use]
+    pub fn with_doc(mut self, doc: impl Into<String>) -> Self {
+        self.doc = Some(doc.into());
+        self
     }
 
     #[must_use]
@@ -138,6 +145,11 @@ impl PyGetSet {
     #[pygetset]
     fn __qualname__(&self) -> String {
         format!("{}.{}", self.class.slot_name(), self.name.clone())
+    }
+
+    #[pygetset]
+    fn __doc__(&self) -> Option<String> {
+        self.doc.clone()
     }
 
     #[pymember]

--- a/crates/vm/src/coroutine.rs
+++ b/crates/vm/src/coroutine.rs
@@ -1,9 +1,9 @@
 use crate::{
     AsObject, Py, PyObject, PyObjectRef, PyResult, TryFromObject, VirtualMachine,
-    builtins::PyStrRef,
+    builtins::{PyStrRef, PyTupleRef},
     common::lock::PyMutex,
     exceptions::types::PyBaseException,
-    frame::{ExecutionResult, FrameObject, FrameObjectRef, FrameOwner},
+    frame::{ExecutionResult, FrameObject, FrameObjectRef, FrameOwner, InterpreterFrame},
     function::OptionalArg,
     object::{PyAtomicRef, Traverse, TraverseFn},
     protocol::PyIterReturn,
@@ -189,12 +189,12 @@ impl Coro {
 
     pub(crate) fn send_none(&self, jen: &PyObject, vm: &VirtualMachine) -> PyResult<PyIterReturn> {
         if self.closed.load() {
-            return Ok(PyIterReturn::StopIteration(None));
+            return Self::send_when_closed(jen, vm);
         }
         let claim = self.claim(jen, vm)?;
         // The generator can have run to its end in the meantime.
         if self.closed.load() {
-            return Ok(PyIterReturn::StopIteration(None));
+            return Self::send_when_closed(jen, vm);
         }
         let value = if self.frame.lasti() > 0 {
             Some(vm.ctx.none())
@@ -207,6 +207,28 @@ impl Coro {
         self.finalize_send_result(result, jen, vm)
     }
 
+    fn send_when_closed(jen: &PyObject, vm: &VirtualMachine) -> PyResult<PyIterReturn> {
+        if jen.class().is(vm.ctx.types.coroutine_type) {
+            Err(vm.new_runtime_error("cannot reuse already awaited coroutine"))
+        } else {
+            Ok(PyIterReturn::StopIteration(None))
+        }
+    }
+
+    fn throw_when_closed(
+        jen: &PyObject,
+        exc_type: PyObjectRef,
+        exc_val: PyObjectRef,
+        exc_tb: PyObjectRef,
+        vm: &VirtualMachine,
+    ) -> PyResult<PyIterReturn> {
+        if jen.class().is(vm.ctx.types.coroutine_type) {
+            Err(vm.new_runtime_error("cannot reuse already awaited coroutine"))
+        } else {
+            Err(vm.normalize_exception(exc_type, exc_val, exc_tb)?)
+        }
+    }
+
     pub fn send(
         &self,
         jen: &PyObject,
@@ -214,12 +236,12 @@ impl Coro {
         vm: &VirtualMachine,
     ) -> PyResult<PyIterReturn> {
         if self.closed.load() {
-            return Ok(PyIterReturn::StopIteration(None));
+            return Self::send_when_closed(jen, vm);
         }
         let claim = self.claim(jen, vm)?;
         // The generator can have run to its end in the meantime.
         if self.closed.load() {
-            return Ok(PyIterReturn::StopIteration(None));
+            return Self::send_when_closed(jen, vm);
         }
         let value = if self.frame.lasti() > 0 {
             Some(value)
@@ -254,7 +276,7 @@ impl Coro {
             return Err(vm.new_type_error("throw() third argument must be a traceback object"));
         }
         if self.closed.load() {
-            return Err(vm.normalize_exception(exc_type, exc_val, exc_tb)?);
+            return Self::throw_when_closed(jen, exc_type, exc_val, exc_tb, vm);
         }
         // Validate exception type before entering generator context.
         // Invalid types propagate to caller without closing the generator.
@@ -264,7 +286,7 @@ impl Coro {
         // runs the exception's constructor, so let the claim go first.
         if self.closed.load() {
             drop(claim);
-            return Err(vm.normalize_exception(exc_type, exc_val, exc_tb)?);
+            return Self::throw_when_closed(jen, exc_type, exc_val, exc_tb, vm);
         }
         let result = self.run_claimed(&claim, vm, |f| f.gen_throw(vm, exc_type, exc_val, exc_tb));
         self.maybe_close(&result, &claim);
@@ -354,6 +376,51 @@ impl Coro {
 
 pub(crate) fn is_gen_exit(exc: &Py<PyBaseException>, vm: &VirtualMachine) -> bool {
     exc.fast_isinstance(vm.ctx.exceptions.generator_exit)
+}
+
+fn iframe_origin_lineno(frame: &InterpreterFrame) -> usize {
+    if frame.get_lasti() == 0 {
+        return frame.code().first_line_number.map_or(1, |n| n.get());
+    }
+    let prev = frame.prev_line.get();
+    if prev > 0 {
+        prev as usize
+    } else {
+        frame.code().first_line_number.map_or(1, |n| n.get())
+    }
+}
+
+/// Capture the current call stack as a coroutine `cr_origin` tuple.
+///
+/// Each entry is `(filename, lineno, funcname)`, innermost first. Depth 0
+/// disables tracking and returns `None`.
+pub(crate) fn compute_cr_origin(vm: &VirtualMachine) -> Option<PyTupleRef> {
+    let depth = crate::vm::thread::COROUTINE_ORIGIN_TRACKING_DEPTH.get();
+    if depth == 0 {
+        return None;
+    }
+    let mut items = Vec::new();
+    let mut iframe = crate::frame::current_thread_iframe();
+    while !iframe.is_null() && items.len() < depth as usize {
+        // SAFETY: TLS iframe chain entries stay alive while this thread runs.
+        let frame = unsafe { &*iframe };
+        let code = frame.code();
+        items.push(
+            vm.ctx
+                .new_tuple(vec![
+                    code.source_path().to_owned().into(),
+                    vm.ctx.new_int(iframe_origin_lineno(frame)).into(),
+                    code.obj_name.to_owned().into(),
+                ])
+                .into(),
+        );
+        iframe = frame.previous();
+    }
+    if items.is_empty() {
+        None
+    } else {
+        Some(vm.ctx.new_tuple(items))
+    }
 }
 
 /// Get an awaitable iterator from an object.

--- a/crates/vm/src/frame.rs
+++ b/crates/vm/src/frame.rs
@@ -4064,7 +4064,24 @@ impl ExecutingFrame<'_> {
             }
             Instruction::GetAiter => {
                 let aiterable = self.pop_value();
-                let aiter = vm.call_special_method(&aiterable, identifier!(vm, __aiter__), ())?;
+                let aiter = match vm.get_special_method(&aiterable, identifier!(vm, __aiter__))? {
+                    Some(meth) => meth.invoke((), vm)?,
+                    None => {
+                        return Err(vm.new_type_error(format!(
+                            "'async for' requires an object with __aiter__ method, got {}",
+                            aiterable.class().name()
+                        )));
+                    }
+                };
+                if vm
+                    .get_special_method(&aiter, identifier!(vm, __anext__))?
+                    .is_none()
+                {
+                    return Err(vm.new_type_error(format!(
+                        "'async for' received an object from __aiter__ that does not implement __anext__: {}",
+                        aiter.class().name()
+                    )));
+                }
                 self.push_value(aiter);
                 Ok(None)
             }
@@ -4076,8 +4093,10 @@ impl ExecutingFrame<'_> {
                 let awaitable = if aiter.class().is(vm.ctx.types.async_generator) {
                     vm.call_special_method(aiter, identifier!(vm, __anext__), ())?
                 } else {
-                    if !aiter.has_attr("__anext__", vm).unwrap_or(false) {
-                        // TODO: __anext__ must be protocol
+                    if vm
+                        .get_special_method(aiter, identifier!(vm, __anext__))?
+                        .is_none()
+                    {
                         let msg = format!(
                             "'async for' requires an iterator with __anext__ method, got {:.100}",
                             aiter.class().name()
@@ -4086,26 +4105,13 @@ impl ExecutingFrame<'_> {
                     }
                     let next_iter =
                         vm.call_special_method(aiter, identifier!(vm, __anext__), ())?;
-
-                    // _PyCoro_GetAwaitableIter in CPython
-                    fn get_awaitable_iter(next_iter: &PyObject, vm: &VirtualMachine) -> PyResult {
-                        let gen_is_coroutine = |_| {
-                            // TODO: cpython gen_is_coroutine
-                            true
-                        };
-                        if next_iter.class().is(vm.ctx.types.coroutine_type)
-                            || gen_is_coroutine(next_iter)
-                        {
-                            return Ok(next_iter.to_owned());
-                        }
-                        // TODO: error handling
-                        vm.call_special_method(next_iter, identifier!(vm, __await__), ())
-                    }
-                    get_awaitable_iter(&next_iter, vm).map_err(|_| {
-                        vm.new_type_error(format!(
+                    crate::coroutine::get_awaitable_iter(next_iter.clone(), vm).map_err(|e| {
+                        let err = vm.new_type_error(format!(
                             "'async for' received an invalid object from __anext__: {:.200}",
                             next_iter.class().name()
-                        ))
+                        ));
+                        err.set___cause__(Some(e));
+                        err
                     })?
                 };
                 self.push_value(awaitable);

--- a/crates/vm/src/warn.rs
+++ b/crates/vm/src/warn.rs
@@ -305,6 +305,42 @@ pub fn warn(
     warn_with_skip(message, category, stack_level, source, None, vm)
 }
 
+/// Warn that `coro` was never awaited.
+///
+/// Prefer `warnings._warn_unawaited_coroutine` so origin tracking can
+/// format the creation traceback. If that helper is missing, broken, or
+/// not a RuntimeWarning-as-error, fall back to a plain RuntimeWarning.
+/// Never raises; leftover exceptions become unraisable.
+pub fn warn_unawaited_coroutine(coro: &PyObject, qualname: &PyStrRef, vm: &VirtualMachine) {
+    let unraisable_msg = format!(
+        "Exception ignored while finalizing coroutine {}",
+        coro.repr(vm)
+            .map_or_else(|_| String::new(), |s| s.to_string())
+    );
+    let mut warned = false;
+    if let Some(helper) =
+        get_warnings_attr(vm, vm.ctx.intern_str("_warn_unawaited_coroutine"), true)
+    {
+        match helper.call((coro.to_owned(),), vm) {
+            Ok(_) => warned = true,
+            Err(e) => {
+                if e.fast_isinstance(vm.ctx.exceptions.runtime_warning) {
+                    warned = true;
+                }
+                vm.run_unraisable(e, Some(unraisable_msg.clone()), coro.to_owned());
+            }
+        }
+    }
+    if !warned {
+        let msg = format!("coroutine '{qualname}' was never awaited");
+        if let Err(e) =
+            crate::stdlib::_warnings::warn(vm.ctx.exceptions.runtime_warning, msg, 1, vm)
+        {
+            vm.run_unraisable(e, Some(unraisable_msg), coro.to_owned());
+        }
+    }
+}
+
 /// do_warn: resolve context via setup_context, then call warn_explicit.
 pub fn warn_with_skip(
     message: PyObjectRef,


### PR DESCRIPTION
Closed coroutines now raise `RuntimeError: cannot reuse already awaited coroutine` on `send`/`throw`. Coroutine creation records `cr_origin` from `sys.set_coroutine_origin_tracking_depth`, and finalization calls `warnings._warn_unawaited_coroutine` (with a fallback warning and unraisable handling). `cr_suspended` is exposed, and coroutine objects are no longer iterable.

`frame.clear()` on a never-started coroutine frame finalizes the owner so the never-awaited warning is emitted. Unawaited async generator `asend`/`athrow`/`aclose` objects warn. `async for` TypeErrors match the required `__aiter__`/`__anext__` messages. Coroutine `send`/`close`/`throw` and `__name__`/`__qualname__` getset docs are attached.

Removes the corresponding `expectedFailure` markers in `test_coroutines`, `test_asyncgen`, `test_unittest.testmock.testasync`, and `test_inspect`.

Assisted-by: Grok:grok-4.6

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Get/set properties now expose their documentation through `__doc__`.
  * Coroutine objects now provide accurate `cr_origin` and `cr_suspended` information.
  * Coroutine origin tracking captures relevant call-stack details when enabled.

* **Bug Fixes**
  * Improved warnings for coroutines and async-generator awaitables that are never awaited.
  * Corrected behavior when reusing closed coroutines.
  * Strengthened validation and error reporting for asynchronous iterator protocols.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->